### PR TITLE
feat(bot-mode): share files through Group Chats

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/desktop-room-command-client.js
+++ b/apps/desktop/src/plugins/hermes-bots/desktop-room-command-client.js
@@ -115,7 +115,10 @@ export async function runDesktopRoomCommandCycle({
           }
           try {
             result = await execute(command, descriptors, {
-              signal: abortController?.signal || null
+              signal: abortController?.signal || null,
+              route,
+              consumerId,
+              request: (method, params) => request(route, method, params)
             })
             if (leaseLost) {
               outcomes.push({

--- a/apps/desktop/src/plugins/hermes-bots/desktop-room-command-client.js
+++ b/apps/desktop/src/plugins/hermes-bots/desktop-room-command-client.js
@@ -1,0 +1,146 @@
+const MAX_COMMANDS_PER_CLAIM = 8
+const MAX_COMMANDS_PER_WAKE = 64
+const MAX_ROOM_IDS_PER_CLAIM = 128
+const LEASE_RENEW_INTERVAL_MS = 15_000
+
+/** Stable identity shared by the bounded gateway projection and command queue. */
+export function desktopRoomIdentity(name, room) {
+  const roomId = String(room?.roomId || '').trim()
+  return roomId || `name:${String(name || '').trim()}`
+}
+
+/** Classic rooms this Desktop can coordinate. Hosted rooms run on a gateway. */
+export function desktopRoomDescriptors(rooms) {
+  return Object.entries(rooms || {})
+    .filter(([, room]) => {
+      const hosted = typeof room?.hosted === 'string' ? room.hosted.trim() : ''
+      return !hosted && !room?.tombstone && Array.isArray(room?.log)
+    })
+    .map(([name, room]) => ({
+      name,
+      roomId: desktopRoomIdentity(name, room)
+    }))
+    .filter(room => room.roomId && room.name)
+}
+
+export function createDesktopRoomConsumerId() {
+  if (globalThis.crypto && typeof globalThis.crypto.randomUUID === 'function') {
+    return `desktop:${globalThis.crypto.randomUUID()}`
+  }
+  return `desktop:${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
+}
+
+function boundedError(error) {
+  const text = String(error?.message || 'Desktop could not apply the room command')
+    .replace(/\s+/g, ' ')
+    .trim()
+  return text.slice(0, 240)
+}
+
+/**
+ * Claim and apply classic-room commands from every reachable default gateway.
+ * Missing methods identify an older backend and simply disable this fallback.
+ */
+export async function runDesktopRoomCommandCycle({
+  routes,
+  consumerId,
+  rooms,
+  request,
+  execute,
+  shouldContinue = () => true
+}) {
+  const descriptors = desktopRoomDescriptors(rooms)
+  if (!descriptors.length) return []
+
+  const roomBatches = []
+  for (let index = 0; index < descriptors.length; index += MAX_ROOM_IDS_PER_CLAIM) {
+    roomBatches.push(descriptors.slice(index, index + MAX_ROOM_IDS_PER_CLAIM))
+  }
+  const seenConnections = new Set()
+  const outcomes = []
+
+  for (const route of Array.isArray(routes) ? routes : []) {
+    const connectionId = String(route?.connectionId || '')
+    const routeKey = connectionId || '__active__'
+    if (seenConnections.has(routeKey)) continue
+    seenConnections.add(routeKey)
+
+    let remaining = MAX_COMMANDS_PER_WAKE
+    for (const batch of roomBatches) {
+      if (remaining <= 0) return outcomes
+
+      while (remaining > 0) {
+        const claimLimit = Math.min(MAX_COMMANDS_PER_CLAIM, remaining)
+        let claimed
+        try {
+          claimed = await request(route, 'groups.desktop.claim', {
+            consumer_id: consumerId,
+            room_ids: batch.map(room => room.roomId),
+            limit: claimLimit
+          })
+        } catch {
+          break
+        }
+
+        const commands = Array.isArray(claimed?.commands) ? claimed.commands : []
+        remaining -= commands.length
+        for (const command of commands) {
+          if (!shouldContinue()) return outcomes
+          let success = false
+          let result
+          let renewTimer = null
+          const leaseToken = String(command?.lease_token || '')
+          if (leaseToken && typeof setInterval === 'function') {
+            renewTimer = setInterval(() => {
+              if (!shouldContinue()) return
+              void request(route, 'groups.desktop.renew', {
+                consumer_id: consumerId,
+                command_id: command.command_id,
+                lease_token: leaseToken
+              }).catch(() => undefined)
+            }, LEASE_RENEW_INTERVAL_MS)
+          }
+          try {
+            result = await execute(command, descriptors)
+            success = true
+          } catch (error) {
+            if (error?.retryable === true) {
+              // Keep the lease unacknowledged. It expires back to pending so a
+              // temporary member outage never turns into a terminal failure.
+              outcomes.push({
+                commandId: command.command_id,
+                connectionId: routeKey,
+                success: false,
+                retryable: true
+              })
+              continue
+            }
+            result = { message: boundedError(error) }
+          } finally {
+            if (renewTimer !== null && typeof clearInterval === 'function') {
+              clearInterval(renewTimer)
+            }
+          }
+
+          try {
+            await request(route, 'groups.desktop.complete', {
+              consumer_id: consumerId,
+              command_id: command.command_id,
+              lease_token: leaseToken,
+              success,
+              result
+            })
+          } catch {
+            // The lease expires and a later cycle retries. Send effects use the
+            // command id as their room-log id, so a lost ACK cannot duplicate text.
+          }
+          outcomes.push({ commandId: command.command_id, connectionId: routeKey, success })
+        }
+
+        if (commands.length < claimLimit) break
+      }
+    }
+  }
+
+  return outcomes
+}

--- a/apps/desktop/src/plugins/hermes-bots/desktop-room-command-client.js
+++ b/apps/desktop/src/plugins/hermes-bots/desktop-room-command-client.js
@@ -18,9 +18,10 @@ export function desktopRoomDescriptors(rooms) {
     })
     .map(([name, room]) => ({
       name,
-      roomId: desktopRoomIdentity(name, room)
+      roomId: desktopRoomIdentity(name, room),
+      authorityToken: String(room?.desktopAuthorityToken || '').trim()
     }))
-    .filter(room => room.roomId && room.name)
+    .filter(room => room.roomId && room.name && room.authorityToken)
 }
 
 export function createDesktopRoomConsumerId() {
@@ -47,6 +48,7 @@ export async function runDesktopRoomCommandCycle({
   rooms,
   request,
   execute,
+  actions = null,
   shouldContinue = () => true
 }) {
   const descriptors = desktopRoomDescriptors(rooms)
@@ -68,6 +70,10 @@ export async function runDesktopRoomCommandCycle({
     let remaining = MAX_COMMANDS_PER_WAKE
     for (const batch of roomBatches) {
       if (remaining <= 0) return outcomes
+      const roomAuthorities = batch.map(room => ({
+        room_id: room.roomId,
+        authority_token: room.authorityToken
+      }))
 
       while (remaining > 0) {
         const claimLimit = Math.min(MAX_COMMANDS_PER_CLAIM, remaining)
@@ -75,7 +81,8 @@ export async function runDesktopRoomCommandCycle({
         try {
           claimed = await request(route, 'groups.desktop.claim', {
             consumer_id: consumerId,
-            room_ids: batch.map(room => room.roomId),
+            room_authorities: roomAuthorities,
+            ...(Array.isArray(actions) && actions.length ? { actions } : {}),
             limit: claimLimit
           })
         } catch {
@@ -89,6 +96,9 @@ export async function runDesktopRoomCommandCycle({
           let success = false
           let result
           let renewTimer = null
+          let leaseLost = false
+          const abortController =
+            typeof AbortController === 'function' ? new AbortController() : null
           const leaseToken = String(command?.lease_token || '')
           if (leaseToken && typeof setInterval === 'function') {
             renewTimer = setInterval(() => {
@@ -97,21 +107,37 @@ export async function runDesktopRoomCommandCycle({
                 consumer_id: consumerId,
                 command_id: command.command_id,
                 lease_token: leaseToken
-              }).catch(() => undefined)
+              }).catch(() => {
+                leaseLost = true
+                abortController?.abort('lease-lost')
+              })
             }, LEASE_RENEW_INTERVAL_MS)
           }
           try {
-            result = await execute(command, descriptors)
+            result = await execute(command, descriptors, {
+              signal: abortController?.signal || null
+            })
+            if (leaseLost) {
+              outcomes.push({
+                commandId: command.command_id,
+                connectionId: routeKey,
+                success: false,
+                retryable: true,
+                leaseLost: true
+              })
+              continue
+            }
             success = true
           } catch (error) {
-            if (error?.retryable === true) {
+            if (leaseLost || error?.retryable === true) {
               // Keep the lease unacknowledged. It expires back to pending so a
               // temporary member outage never turns into a terminal failure.
               outcomes.push({
                 commandId: command.command_id,
                 connectionId: routeKey,
                 success: false,
-                retryable: true
+                retryable: true,
+                ...(leaseLost ? { leaseLost: true } : {})
               })
               continue
             }

--- a/apps/desktop/src/plugins/hermes-bots/hosted-room-client.js
+++ b/apps/desktop/src/plugins/hermes-bots/hosted-room-client.js
@@ -1,0 +1,977 @@
+const MIN_ROOM_MEMBERS = 2
+const MAX_ROOM_MEMBERS = 6
+const MAX_REPLAY_PAGE_SIZE = 500
+const MAX_REPLAY_PAGES = 100
+const MAX_ATTACHMENT_COUNT = 8
+const MAX_ATTACHMENT_NAME_CHARS = 255
+const MAX_ATTACHMENT_NAME_BYTES = 512
+const MAX_ATTACHMENT_FILE_BYTES = 15_000_000
+const MAX_ATTACHMENT_MANIFEST_BYTES = 32 * 1024
+const MAX_ATTACHMENT_MIME_CHARS = 127
+const MAX_ATTACHMENT_REFS = 6
+const MAX_MEMBER_ID_CHARS = 128
+const MAX_STAGED_REF_CHARS = 256
+
+export const HOSTED_ROOM_CLIENT_LIMITATIONS = Object.freeze({
+  attachments: false,
+  automaticFailover: false,
+  crossGatewayMembers: false,
+  stagedAttachmentManifest: true
+})
+
+const ATTACHMENT_FIELDS = new Set(['kind', 'name', 'size', 'mime', 'refs'])
+const ATTACHMENT_KINDS = new Set(['image', 'pdf', 'file'])
+const ATTACHMENT_PAYLOAD_ALIASES = new Set(['attachment', 'attachment_manifest', 'files', 'images'])
+const COMMAND_KINDS = new Set(['create', 'send', 'stop', 'disband'])
+const DISALLOWED_STAGED_REF_SCHEMES = new Set(['blob', 'data', 'file', 'http', 'https', 'path'])
+const FORBIDDEN_TRANSPORT_FIELD_TOKENS = new Set(['base64', 'byte', 'bytes', 'data', 'path', 'paths'])
+const MEMBER_ID_RE = /^[A-Za-z0-9][A-Za-z0-9._:-]*$/
+const MIME_RE = /^[a-z0-9][a-z0-9!#$&^_.+-]*\/[a-z0-9][a-z0-9!#$&^_.+-]*$/i
+const STAGED_REF_RE = /^[a-z][a-z0-9+.-]*:[A-Za-z0-9][A-Za-z0-9._:-]*$/i
+const STATUS_EVENT_KINDS = new Set([
+  'authority.lost',
+  'member.unavailable',
+  'room.activity',
+  'turn.cancelled',
+  'turn.deferred',
+  'turn.failed',
+  'turn.reassigned',
+  'turn.settled',
+  'turn.started'
+])
+const KNOWN_EVENT_KINDS = new Set([
+  'authority.claimed',
+  'authority.lost',
+  'member.unavailable',
+  'message.member',
+  'message.user',
+  'room.activity',
+  'room.created',
+  'room.disbanded',
+  'room.members_changed',
+  'room.renamed',
+  'turn.cancelled',
+  'turn.deferred',
+  'turn.failed',
+  'turn.reassigned',
+  'turn.settled',
+  'turn.started'
+])
+
+function text(value) {
+  return typeof value === 'string' && value.trim() ? value.trim() : null
+}
+
+function nonNegativeInteger(value, fallback = 0) {
+  const number = Number(value)
+
+  return Number.isSafeInteger(number) && number >= 0 ? number : fallback
+}
+
+function positiveInteger(value, fallback = null) {
+  const number = Number(value)
+
+  return Number.isSafeInteger(number) && number > 0 ? number : fallback
+}
+
+function errorCode(error) {
+  return error?.code ?? error?.error?.code ?? null
+}
+
+function errorMessage(error) {
+  return String(error?.message || error?.error?.message || error || '')
+}
+
+function isMissingCapabilityMethod(error) {
+  return (
+    errorCode(error) === -32601 ||
+    /method not found|-32601|unknown method|no such method|no handler for|unsupported rpc/i.test(errorMessage(error))
+  )
+}
+
+function capabilityResult(probe) {
+  if (!probe || typeof probe !== 'object') {
+    return null
+  }
+
+  if (probe.ok === true && probe.result && typeof probe.result === 'object') {
+    return probe.result
+  }
+
+  if (!Object.prototype.hasOwnProperty.call(probe, 'ok') && !Object.prototype.hasOwnProperty.call(probe, 'error')) {
+    return probe
+  }
+
+  return null
+}
+
+/** Classify a groups.capabilities probe without turning connectivity failures
+ * into a compatibility verdict. */
+export function classifyHostedRoomCapability(probe, { connectionId = null } = {}) {
+  const localConnectionId = text(connectionId)
+  const error = probe instanceof Error ? probe : probe?.ok === false ? probe.error || probe : probe?.error
+
+  if (error) {
+    return {
+      kind: isMissingCapabilityMethod(error) ? 'unsupported' : 'transient-failure',
+      reason: isMissingCapabilityMethod(error) ? 'old-gateway' : 'probe-failed',
+      connectionId: localConnectionId,
+      authorityId: null,
+      persistentProcess: null,
+      limits: HOSTED_ROOM_CLIENT_LIMITATIONS
+    }
+  }
+
+  const capabilities = capabilityResult(probe)
+
+  if (!capabilities) {
+    return {
+      kind: 'transient-failure',
+      reason: 'invalid-response',
+      connectionId: localConnectionId,
+      authorityId: null,
+      persistentProcess: null,
+      limits: HOSTED_ROOM_CLIENT_LIMITATIONS
+    }
+  }
+
+  if (capabilities.driver !== true) {
+    return {
+      kind: 'unsupported',
+      reason: capabilities.driver === false ? 'driver-disabled' : 'incomplete-contract',
+      connectionId: localConnectionId,
+      authorityId: null,
+      persistentProcess: capabilities.persistent_process === true,
+      limits: HOSTED_ROOM_CLIENT_LIMITATIONS
+    }
+  }
+
+  const authorityId = text(capabilities.authority_gateway_id)
+
+  if (!authorityId) {
+    return {
+      kind: 'unsupported',
+      reason: 'incomplete-contract',
+      connectionId: localConnectionId,
+      authorityId: null,
+      persistentProcess: capabilities.persistent_process === true,
+      limits: HOSTED_ROOM_CLIENT_LIMITATIONS
+    }
+  }
+
+  return {
+    kind: 'driver-capable',
+    reason: null,
+    connectionId: localConnectionId,
+    authorityId,
+    persistentProcess: capabilities.persistent_process === true,
+    maxLogLimit: positiveInteger(capabilities.max_log_limit, 100),
+    limits: HOSTED_ROOM_CLIENT_LIMITATIONS
+  }
+}
+
+/** A running driver hosted inside an app-managed child process cannot outlive
+ * Desktop. Accept either a raw capability response or its classified form. */
+export function isHostedRoomContinuityEligible(capability) {
+  if (!capability || typeof capability !== 'object') {
+    return false
+  }
+
+  if (Object.prototype.hasOwnProperty.call(capability, 'kind')) {
+    return capability.kind === 'driver-capable' && capability.persistentProcess === true
+  }
+
+  return capability.driver === true && capability.persistent_process === true
+}
+
+function memberConnectionId(member, activeConnectionId) {
+  if (!member || member.sourceMissing) {
+    return null
+  }
+
+  const explicit = text(member.route?.connectionId) || text(member.connectionId)
+
+  if (explicit) {
+    return explicit
+  }
+
+  if (member.sourceScoped || member.remoteSource) {
+    return null
+  }
+
+  return text(activeConnectionId)
+}
+
+/** Resolve a same-gateway home candidate. This deliberately does not select a
+ * different gateway or attach a stable authority identity. */
+export function resolveSingleGatewayRoute(members, { activeConnectionId = null } = {}) {
+  const roster = Array.isArray(members) ? members : []
+
+  if (roster.length < MIN_ROOM_MEMBERS || roster.length > MAX_ROOM_MEMBERS) {
+    return {
+      kind: 'unsupported',
+      reason: 'member-count',
+      connectionId: null,
+      memberConnectionIds: [],
+      limits: HOSTED_ROOM_CLIENT_LIMITATIONS
+    }
+  }
+
+  const memberConnectionIds = roster.map(member => memberConnectionId(member, activeConnectionId))
+
+  if (memberConnectionIds.some(connectionId => !connectionId)) {
+    return {
+      kind: 'unsupported',
+      reason: 'unresolved-member-route',
+      connectionId: null,
+      memberConnectionIds,
+      limits: HOSTED_ROOM_CLIENT_LIMITATIONS
+    }
+  }
+
+  const connectionIds = [...new Set(memberConnectionIds)]
+
+  if (connectionIds.length !== 1) {
+    return {
+      kind: 'unsupported',
+      reason: 'cross-gateway',
+      connectionId: null,
+      memberConnectionIds,
+      limits: HOSTED_ROOM_CLIENT_LIMITATIONS
+    }
+  }
+
+  return {
+    kind: 'single-gateway',
+    reason: null,
+    connectionId: connectionIds[0],
+    memberConnectionIds,
+    limits: HOSTED_ROOM_CLIENT_LIMITATIONS
+  }
+}
+
+function cloneList(value) {
+  return Array.isArray(value) ? value.map(item => (item && typeof item === 'object' ? { ...item } : item)) : []
+}
+
+/** Serializable replay state. Stable gateway authority and local routing are
+ * intentionally separate fields. */
+export function createHostedRoomReplayState({
+  roomId,
+  name = '',
+  members = [],
+  authorityId = null,
+  authorityEpoch = null,
+  connectionId = null,
+  cursor = 0,
+  latestSeq = null,
+  messages = [],
+  activity = [],
+  timeline = [],
+  pendingEvents = [],
+  lastStatusEvent = null,
+  deleted = false,
+  conflicts = []
+} = {}) {
+  const normalizedCursor = nonNegativeInteger(cursor)
+
+  return {
+    roomId: text(roomId),
+    name: typeof name === 'string' ? name : '',
+    members: cloneList(members),
+    authorityId: text(authorityId),
+    authorityEpoch: positiveInteger(authorityEpoch),
+    connectionId: text(connectionId),
+    cursor: normalizedCursor,
+    latestSeq: Math.max(normalizedCursor, nonNegativeInteger(latestSeq, normalizedCursor)),
+    messages: cloneList(messages),
+    activity: cloneList(activity),
+    timeline: cloneList(timeline),
+    pendingEvents: cloneList(pendingEvents),
+    lastStatusEvent: lastStatusEvent && typeof lastStatusEvent === 'object' ? { ...lastStatusEvent } : null,
+    deleted: Boolean(deleted),
+    conflicts: cloneList(conflicts)
+  }
+}
+
+function normalizeEvent(raw) {
+  if (!raw || typeof raw !== 'object') {
+    return null
+  }
+
+  const seq = positiveInteger(raw.seq)
+  const eventId = text(raw.event_id) || text(raw.eventId)
+  const kind = text(raw.kind)
+
+  if (!seq || !eventId || !kind) {
+    return null
+  }
+
+  return {
+    roomId: text(raw.room_id) || text(raw.roomId),
+    seq,
+    eventId,
+    kind,
+    actor: raw.actor && typeof raw.actor === 'object' ? { ...raw.actor } : {},
+    payload: raw.payload && typeof raw.payload === 'object' && !Array.isArray(raw.payload) ? { ...raw.payload } : {},
+    createdAt: Number.isFinite(Number(raw.created_at ?? raw.createdAt)) ? Number(raw.created_at ?? raw.createdAt) : 0
+  }
+}
+
+function memberLabel(roomEvent) {
+  const payload = roomEvent?.payload || {}
+  const actor = roomEvent?.actor || {}
+
+  return (
+    text(payload.member_display_name) ||
+    text(payload.member_name) ||
+    text(payload.display_name) ||
+    text(actor.display_name) ||
+    text(actor.profile) ||
+    'A bot'
+  )
+}
+
+function messageFromEvent(roomEvent) {
+  const isUser = roomEvent.kind === 'message.user'
+  const payload = roomEvent.payload || {}
+  const actor = roomEvent.actor || {}
+  const attachments = safeAttachmentMetadata(payload.attachments)
+
+  return {
+    seq: roomEvent.seq,
+    eventId: roomEvent.eventId,
+    from: {
+      kind: isUser ? 'user' : 'member',
+      name: isUser ? 'You' : memberLabel(roomEvent),
+      ...(text(actor.connection_id) ? { source: text(actor.connection_id) } : {})
+    },
+    text: typeof payload.text === 'string' ? payload.text : '',
+    thread: text(payload.thread_id) || text(payload.thread) || 'legacy',
+    at: roomEvent.createdAt,
+    ...(attachments.length ? { attachments } : {})
+  }
+}
+
+function activityFromEvent(roomEvent) {
+  return {
+    seq: roomEvent.seq,
+    eventId: roomEvent.eventId,
+    kind: roomEvent.kind,
+    member: memberLabel(roomEvent),
+    reasonCode: text(roomEvent.payload?.reason_code),
+    at: roomEvent.createdAt
+  }
+}
+
+function applyReplayEvent(state, roomEvent) {
+  const next = state
+
+  if (KNOWN_EVENT_KINDS.has(roomEvent.kind)) {
+    next.timeline.push({ seq: roomEvent.seq, eventId: roomEvent.eventId, kind: roomEvent.kind })
+  }
+
+  if (roomEvent.kind === 'message.user' || roomEvent.kind === 'message.member') {
+    next.messages.push(messageFromEvent(roomEvent))
+  } else if (roomEvent.kind === 'room.created') {
+    next.name = text(roomEvent.payload.name) || next.name
+    if (Array.isArray(roomEvent.payload.members)) {
+      next.members = cloneList(roomEvent.payload.members)
+    }
+  } else if (roomEvent.kind === 'room.renamed') {
+    next.name = text(roomEvent.payload.name) || next.name
+  } else if (roomEvent.kind === 'room.members_changed' && Array.isArray(roomEvent.payload.members)) {
+    next.members = cloneList(roomEvent.payload.members)
+  } else if (roomEvent.kind === 'room.disbanded') {
+    next.deleted = true
+  } else if (roomEvent.kind === 'authority.claimed') {
+    const claimedAuthorityId = text(roomEvent.payload.authority_gateway_id)
+
+    if (claimedAuthorityId) {
+      if (next.authorityId && next.authorityId !== claimedAuthorityId) {
+        next.connectionId = null
+      }
+      next.authorityId = claimedAuthorityId
+    }
+    next.authorityEpoch = positiveInteger(roomEvent.payload.authority_epoch, next.authorityEpoch)
+  } else if (roomEvent.kind === 'authority.lost') {
+    next.connectionId = null
+  }
+
+  if (STATUS_EVENT_KINDS.has(roomEvent.kind)) {
+    next.activity.push(activityFromEvent(roomEvent))
+    next.lastStatusEvent = roomEvent
+  }
+
+  return next
+}
+
+function mergePendingEvents(state, incomingEvents) {
+  const bySeq = new Map()
+  const byId = new Map()
+  const conflicts = [...state.conflicts]
+
+  for (const candidate of [...state.pendingEvents, ...(Array.isArray(incomingEvents) ? incomingEvents : [])]) {
+    const roomEvent = normalizeEvent(candidate)
+
+    if (!roomEvent || roomEvent.seq <= state.cursor) {
+      continue
+    }
+    if (state.roomId && roomEvent.roomId && state.roomId !== roomEvent.roomId) {
+      continue
+    }
+
+    const sequenceTwin = bySeq.get(roomEvent.seq)
+    const idTwin = byId.get(roomEvent.eventId)
+
+    if (sequenceTwin || idTwin) {
+      const prior = sequenceTwin || idTwin
+
+      if (prior.seq !== roomEvent.seq || prior.eventId !== roomEvent.eventId) {
+        conflicts.push({ seq: roomEvent.seq, eventId: roomEvent.eventId })
+      }
+      continue
+    }
+
+    bySeq.set(roomEvent.seq, roomEvent)
+    byId.set(roomEvent.eventId, roomEvent)
+  }
+
+  return {
+    conflicts,
+    events: [...bySeq.values()].sort((left, right) => left.seq - right.seq || left.eventId.localeCompare(right.eventId))
+  }
+}
+
+/** Apply only contiguous gateway events. Reordered pages are buffered; unknown
+ * kinds advance the cursor but cannot erase known room state. */
+export function reduceHostedRoomEvents(state, incomingEvents) {
+  const next = createHostedRoomReplayState(state)
+  const merged = mergePendingEvents(next, incomingEvents)
+  const pending = [...merged.events]
+
+  next.conflicts = merged.conflicts
+  next.latestSeq = Math.max(next.latestSeq, ...pending.map(roomEvent => roomEvent.seq), next.cursor)
+
+  while (pending.length && pending[0].seq === next.cursor + 1) {
+    const roomEvent = pending.shift()
+
+    applyReplayEvent(next, roomEvent)
+    next.cursor = roomEvent.seq
+  }
+
+  next.pendingEvents = pending
+
+  return next
+}
+
+function friendlyStatus(kind, textValue, { member = null, canRetry = false, canStop = false } = {}) {
+  return { kind, text: textValue, member, canRetry, canStop }
+}
+
+function failedTurnStatus(roomEvent) {
+  const member = memberLabel(roomEvent)
+  const reasonCode = text(roomEvent.payload?.reason_code)
+
+  if (reasonCode === 'provider_auth_or_access') {
+    return friendlyStatus('needs-attention', `${member} needs you to sign in again.`, { member })
+  }
+  if (reasonCode === 'provider_quota_limit') {
+    return friendlyStatus('needs-attention', `${member} is out of quota or balance.`, { member })
+  }
+  if (reasonCode === 'missing_config') {
+    return friendlyStatus('needs-attention', `${member} needs a model provider.`, { member })
+  }
+  if (reasonCode === 'agent_blocked') {
+    return friendlyStatus('needs-attention', `${member} needs your help.`, { member })
+  }
+
+  return friendlyStatus('failed', `${member} couldn't respond.`, { member, canRetry: true })
+}
+
+function roomActivityStatus(roomEvent) {
+  const activity = text(roomEvent.payload?.status)?.toLowerCase()
+  const member = memberLabel(roomEvent)
+
+  if (activity === 'working') {
+    return friendlyStatus('working', `${member} is working.`, { member, canStop: true })
+  }
+  if (activity === 'needs_user' || activity === 'waiting_for_user') {
+    return friendlyStatus('needs-you', 'Waiting for your answer.')
+  }
+  if (activity === 'waiting') {
+    return friendlyStatus('waiting', 'The room is waiting.')
+  }
+  if (activity === 'paused') {
+    return friendlyStatus('paused', 'Paused.')
+  }
+  if (activity === 'offline') {
+    return friendlyStatus('offline', 'This room is offline.', { canRetry: true })
+  }
+
+  return friendlyStatus('ready', 'Ready.')
+}
+
+/** Convert durable typed events into short, user-facing status copy. Raw
+ * coordinator and provider errors are never reflected. */
+export function deriveFriendlyHostedRoomStatus(state) {
+  if (state?.deleted) {
+    return friendlyStatus('deleted', 'This group was deleted.')
+  }
+  if (state?.authorityId && !state?.connectionId) {
+    return friendlyStatus('offline', 'This room is offline.', { canRetry: true })
+  }
+
+  const roomEvent = normalizeEvent(state?.lastStatusEvent)
+
+  if (!roomEvent) {
+    return friendlyStatus('ready', 'Ready.')
+  }
+
+  const member = memberLabel(roomEvent)
+
+  if (roomEvent.kind === 'turn.started' || roomEvent.kind === 'turn.reassigned') {
+    return friendlyStatus('working', `${member} is working.`, { member, canStop: true })
+  }
+  if (roomEvent.kind === 'member.unavailable') {
+    return friendlyStatus('member-unavailable', `${member} is unavailable.`, { member, canRetry: true })
+  }
+  if (roomEvent.kind === 'turn.failed') {
+    return failedTurnStatus(roomEvent)
+  }
+  if (roomEvent.kind === 'turn.cancelled') {
+    return friendlyStatus('stopped', 'Stopped.')
+  }
+  if (roomEvent.kind === 'turn.settled') {
+    return friendlyStatus('ready', 'Ready.')
+  }
+  if (roomEvent.kind === 'turn.deferred') {
+    return friendlyStatus('waiting', `${member} is waiting to continue.`, { member, canRetry: true })
+  }
+  if (roomEvent.kind === 'authority.lost') {
+    return friendlyStatus('offline', 'This room is offline.', { canRetry: true })
+  }
+  if (roomEvent.kind === 'room.activity') {
+    return roomActivityStatus(roomEvent)
+  }
+
+  return friendlyStatus('ready', 'Ready.')
+}
+
+/** Fetch monotonic groups.log pages from the persisted replay cursor. The
+ * helper stops on gaps, no-progress responses, transient errors, or a hard
+ * page bound instead of spinning. */
+export async function replayHostedRoomPages({ state, fetchPage, pageSize = 100, maxPages = 20 } = {}) {
+  if (typeof fetchPage !== 'function') {
+    throw new TypeError('fetchPage must be a function')
+  }
+
+  const limit = Math.min(MAX_REPLAY_PAGE_SIZE, Math.max(1, positiveInteger(pageSize, 100)))
+  const pageBound = Math.min(MAX_REPLAY_PAGES, Math.max(1, positiveInteger(maxPages, 20)))
+  let next = createHostedRoomReplayState(state)
+  let pages = 0
+  let fetchedEvents = 0
+
+  while (pages < pageBound) {
+    const beforeCursor = next.cursor
+    let page
+
+    try {
+      page = await fetchPage({ sinceSeq: beforeCursor, limit })
+    } catch (error) {
+      return { state: next, complete: false, reason: 'transient-failure', pages, fetchedEvents, error }
+    }
+
+    if (!page || typeof page !== 'object') {
+      return { state: next, complete: false, reason: 'invalid-response', pages, fetchedEvents }
+    }
+
+    const events = Array.isArray(page.events) ? page.events : []
+    const latestSeq = nonNegativeInteger(page.latest_seq ?? page.latestSeq, next.latestSeq)
+
+    if (events.length > limit) {
+      return { state: next, complete: false, reason: 'oversized-page', pages, fetchedEvents }
+    }
+
+    pages += 1
+    fetchedEvents += events.length
+    next = reduceHostedRoomEvents(next, events)
+    next.latestSeq = Math.max(next.latestSeq, latestSeq)
+
+    const hasMore = page.has_more === true || next.cursor < latestSeq
+
+    if (!hasMore) {
+      if (next.pendingEvents.length) {
+        return { state: next, complete: false, reason: 'gap', pages, fetchedEvents }
+      }
+      return { state: next, complete: true, reason: null, pages, fetchedEvents }
+    }
+
+    if (next.cursor <= beforeCursor) {
+      return { state: next, complete: false, reason: 'stalled', pages, fetchedEvents }
+    }
+  }
+
+  return { state: next, complete: false, reason: 'limit', pages, fetchedEvents }
+}
+
+function cloneJson(value, label) {
+  try {
+    return JSON.parse(JSON.stringify(value))
+  } catch (error) {
+    throw new TypeError(`${label} must be JSON-serializable`, { cause: error })
+  }
+}
+
+function utf8Size(value) {
+  return new TextEncoder().encode(value).length
+}
+
+function fieldTokens(field) {
+  return String(field)
+    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean)
+}
+
+function forbiddenTransportField(field) {
+  return fieldTokens(field).find(token => FORBIDDEN_TRANSPORT_FIELD_TOKENS.has(token)) || null
+}
+
+function assertNoRawTransportFields(value, location = 'payload') {
+  if (!value || typeof value !== 'object') {
+    return
+  }
+  if (Array.isArray(value)) {
+    value.forEach((entry, index) => assertNoRawTransportFields(entry, `${location}[${index}]`))
+    return
+  }
+
+  for (const [key, nested] of Object.entries(value)) {
+    const forbidden = forbiddenTransportField(key)
+
+    if (forbidden) {
+      throw new TypeError(`${location}.${key} contains a forbidden ${forbidden} field`)
+    }
+    if (key !== 'refs') {
+      assertNoRawTransportFields(nested, `${location}.${key}`)
+    }
+  }
+}
+
+function normalizeAttachmentName(value) {
+  const name = text(value)
+
+  if (
+    !name ||
+    name.length > MAX_ATTACHMENT_NAME_CHARS ||
+    utf8Size(name) > MAX_ATTACHMENT_NAME_BYTES ||
+    name.includes('\0') ||
+    name.includes('/') ||
+    name.includes('\\')
+  ) {
+    throw new TypeError('attachment name must be a bounded base filename')
+  }
+
+  return name
+}
+
+function normalizeAttachmentMime(value, kind) {
+  const mime = text(value)?.toLowerCase()
+
+  if (!mime || mime.length > MAX_ATTACHMENT_MIME_CHARS || !MIME_RE.test(mime)) {
+    throw new TypeError('attachment mime must be a bounded MIME type')
+  }
+  if (kind === 'image' && !mime.startsWith('image/')) {
+    throw new TypeError('image attachments require an image MIME type')
+  }
+  if (kind === 'pdf' && mime !== 'application/pdf') {
+    throw new TypeError('pdf attachments require application/pdf')
+  }
+
+  return mime
+}
+
+function normalizeAttachmentRefs(value, { required }) {
+  if (value === undefined && !required) {
+    return null
+  }
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError('attachment member refs must be an object')
+  }
+
+  const entries = Object.entries(value)
+
+  if (!entries.length || entries.length > MAX_ATTACHMENT_REFS) {
+    throw new TypeError(`attachment member refs must contain 1-${MAX_ATTACHMENT_REFS} entries`)
+  }
+
+  const refs = {}
+
+  for (const [rawMemberId, rawRef] of entries) {
+    const memberId = text(rawMemberId)
+    const ref = text(rawRef)
+    const refScheme = ref?.split(':', 1)[0]?.toLowerCase()
+
+    if (!memberId || memberId.length > MAX_MEMBER_ID_CHARS || !MEMBER_ID_RE.test(memberId)) {
+      throw new TypeError('attachment member refs require valid member_id keys')
+    }
+    if (
+      !ref ||
+      ref.length > MAX_STAGED_REF_CHARS ||
+      !STAGED_REF_RE.test(ref) ||
+      DISALLOWED_STAGED_REF_SCHEMES.has(refScheme)
+    ) {
+      throw new TypeError('attachment member refs require opaque staged reference ids')
+    }
+
+    refs[memberId] = ref
+  }
+
+  return refs
+}
+
+function normalizeAttachmentEntry(raw, { requireRefs }) {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new TypeError('each attachment must be an object')
+  }
+
+  for (const key of Object.keys(raw)) {
+    if (!ATTACHMENT_FIELDS.has(key)) {
+      const forbidden = forbiddenTransportField(key)
+
+      throw new TypeError(
+        forbidden
+          ? `attachment ${key} contains a forbidden ${forbidden} field`
+          : `attachment contains unsupported field: ${key}`
+      )
+    }
+  }
+
+  const kind = text(raw.kind)?.toLowerCase()
+
+  if (!kind || !ATTACHMENT_KINDS.has(kind)) {
+    throw new TypeError('attachment kind must be image, pdf, or file')
+  }
+  if (
+    typeof raw.size !== 'number' ||
+    !Number.isSafeInteger(raw.size) ||
+    raw.size < 0 ||
+    raw.size > MAX_ATTACHMENT_FILE_BYTES
+  ) {
+    throw new TypeError(`attachment size must be between 0 and ${MAX_ATTACHMENT_FILE_BYTES} bytes`)
+  }
+
+  const normalized = {
+    kind,
+    name: normalizeAttachmentName(raw.name),
+    size: raw.size,
+    mime: normalizeAttachmentMime(raw.mime, kind)
+  }
+  const refs = normalizeAttachmentRefs(raw.refs, { required: requireRefs })
+
+  return refs ? { ...normalized, refs } : normalized
+}
+
+function normalizeAttachmentManifest(value, { requireRefs }) {
+  if (!Array.isArray(value)) {
+    throw new TypeError('attachments must be a manifest array')
+  }
+  if (value.length > MAX_ATTACHMENT_COUNT) {
+    throw new TypeError(`attachment manifest supports at most ${MAX_ATTACHMENT_COUNT} entries`)
+  }
+
+  const manifest = value.map(entry => normalizeAttachmentEntry(entry, { requireRefs }))
+
+  if (utf8Size(JSON.stringify(manifest)) > MAX_ATTACHMENT_MANIFEST_BYTES) {
+    throw new TypeError('attachment manifest metadata is too large')
+  }
+
+  return manifest
+}
+
+function safeAttachmentMetadata(value) {
+  if (!Array.isArray(value) || value.length > MAX_ATTACHMENT_COUNT) {
+    return []
+  }
+
+  const metadata = []
+
+  for (const entry of value) {
+    try {
+      const normalized = normalizeAttachmentEntry(entry, { requireRefs: false })
+
+      metadata.push({ kind: normalized.kind, name: normalized.name, size: normalized.size, mime: normalized.mime })
+    } catch {
+      // A malformed internal manifest must not expose refs or block replay.
+    }
+  }
+
+  return metadata
+}
+
+function normalizeCommand(raw) {
+  if (!raw || typeof raw !== 'object') {
+    throw new TypeError('command must be an object')
+  }
+
+  const commandId = text(raw.commandId) || text(raw.id)
+  const kind = text(raw.kind)
+  const roomId = text(raw.roomId) || text(raw.room_id)
+  const authorityId = text(raw.authorityId) || text(raw.authority_gateway_id)
+  const connectionId = text(raw.connectionId) || text(raw.connection_id)
+
+  if (!commandId || !kind || !roomId || !authorityId || !connectionId) {
+    throw new TypeError('command requires commandId, kind, roomId, authorityId, and connectionId')
+  }
+  if (!COMMAND_KINDS.has(kind)) {
+    throw new TypeError(`unsupported hosted room command: ${kind}`)
+  }
+
+  const rawPayload = raw.payload && typeof raw.payload === 'object' ? raw.payload : {}
+
+  if (kind === 'send') {
+    assertNoRawTransportFields(rawPayload)
+    for (const alias of ATTACHMENT_PAYLOAD_ALIASES) {
+      if (Object.prototype.hasOwnProperty.call(rawPayload, alias)) {
+        throw new TypeError(`send attachments must use the attachments manifest, not ${alias}`)
+      }
+    }
+  }
+
+  const payload = cloneJson(rawPayload, 'command payload')
+
+  if (kind === 'send' && Object.prototype.hasOwnProperty.call(payload, 'attachments')) {
+    payload.attachments = normalizeAttachmentManifest(payload.attachments, { requireRefs: true })
+  }
+
+  return {
+    commandId,
+    kind,
+    roomId,
+    authorityId,
+    connectionId,
+    payload,
+    status: raw.status === 'failed' ? 'failed' : raw.status === 'in-flight' ? 'in-flight' : 'pending',
+    attempts: nonNegativeInteger(raw.attempts),
+    failureCode: text(raw.failureCode)
+  }
+}
+
+function stableJson(value) {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableJson).join(',')}]`
+  }
+  if (value && typeof value === 'object') {
+    return `{${Object.keys(value)
+      .sort()
+      .map(key => `${JSON.stringify(key)}:${stableJson(value[key])}`)
+      .join(',')}}`
+  }
+
+  return JSON.stringify(value)
+}
+
+function commandSignature(command) {
+  return stableJson({
+    commandId: command.commandId,
+    kind: command.kind,
+    roomId: command.roomId,
+    authorityId: command.authorityId,
+    connectionId: command.connectionId,
+    payload: command.payload
+  })
+}
+
+/** Rehydrate a persisted outbox. An in-flight command has an unknown outcome
+ * after relaunch, so it returns to pending with the same idempotency key. */
+export function createHostedRoomOutbox(persisted = null) {
+  const commands = []
+
+  for (const raw of Array.isArray(persisted?.commands) ? persisted.commands : []) {
+    const command = normalizeCommand(raw)
+    const existing = commands.find(candidate => candidate.commandId === command.commandId)
+
+    command.status = command.status === 'in-flight' ? 'pending' : command.status
+
+    if (!existing) {
+      commands.push(command)
+    } else if (commandSignature(existing) !== commandSignature(command)) {
+      throw new TypeError(`commandId ${command.commandId} has conflicting persisted content`)
+    }
+  }
+
+  return { version: 1, commands }
+}
+
+function updateCommand(state, commandId, mutate) {
+  const index = state.commands.findIndex(command => command.commandId === commandId)
+
+  if (index < 0) {
+    return state
+  }
+
+  const commands = [...state.commands]
+  commands[index] = mutate({ ...commands[index] })
+
+  return { ...state, commands }
+}
+
+/** Pure state transitions for persisted create/send/stop/disband commands. */
+export function reduceHostedRoomOutbox(state, action) {
+  const current = state && Array.isArray(state.commands) ? state : createHostedRoomOutbox()
+
+  if (!action || typeof action !== 'object') {
+    throw new TypeError('outbox action must be an object')
+  }
+
+  if (action.type === 'enqueue') {
+    const command = normalizeCommand(action.command)
+    const existing = current.commands.find(candidate => candidate.commandId === command.commandId)
+
+    command.status = 'pending'
+
+    if (existing) {
+      if (commandSignature(existing) !== commandSignature(command)) {
+        throw new TypeError(`commandId ${command.commandId} is already bound to different content`)
+      }
+      return current
+    }
+
+    return { ...current, commands: [...current.commands, command] }
+  }
+
+  const commandId = text(action.commandId)
+
+  if (!commandId) {
+    throw new TypeError('outbox action requires commandId')
+  }
+
+  if (action.type === 'dispatch') {
+    return updateCommand(current, commandId, command => ({
+      ...command,
+      status: 'in-flight',
+      attempts: command.attempts + 1,
+      failureCode: null
+    }))
+  }
+  if (action.type === 'retry' || action.type === 'transient-failure') {
+    return updateCommand(current, commandId, command => ({ ...command, status: 'pending' }))
+  }
+  if (action.type === 'terminal-failure') {
+    return updateCommand(current, commandId, command => ({
+      ...command,
+      status: 'failed',
+      failureCode: text(action.failureCode) || 'command-failed'
+    }))
+  }
+  if (action.type === 'acknowledge') {
+    if (!current.commands.some(command => command.commandId === commandId)) {
+      return current
+    }
+    return { ...current, commands: current.commands.filter(command => command.commandId !== commandId) }
+  }
+
+  throw new TypeError(`unsupported outbox action: ${action.type}`)
+}

--- a/apps/desktop/src/plugins/hermes-bots/hosted-room-client.js
+++ b/apps/desktop/src/plugins/hermes-bots/hosted-room-client.js
@@ -8,26 +8,23 @@ const MAX_ATTACHMENT_NAME_BYTES = 512
 const MAX_ATTACHMENT_FILE_BYTES = 15_000_000
 const MAX_ATTACHMENT_MANIFEST_BYTES = 32 * 1024
 const MAX_ATTACHMENT_MIME_CHARS = 127
-const MAX_ATTACHMENT_REFS = 6
 const MAX_MEMBER_ID_CHARS = 128
-const MAX_STAGED_REF_CHARS = 256
+const ATTACHMENT_ID_RE = /^att_[0-9a-f]{32}$/
 
 export const HOSTED_ROOM_CLIENT_LIMITATIONS = Object.freeze({
-  attachments: false,
+  attachments: true,
   automaticFailover: false,
   crossGatewayMembers: false,
   stagedAttachmentManifest: true
 })
 
-const ATTACHMENT_FIELDS = new Set(['kind', 'name', 'size', 'mime', 'refs'])
+const ATTACHMENT_FIELDS = new Set(['attachment_id', 'kind', 'name', 'size', 'mime'])
 const ATTACHMENT_KINDS = new Set(['image', 'pdf', 'file'])
 const ATTACHMENT_PAYLOAD_ALIASES = new Set(['attachment', 'attachment_manifest', 'files', 'images'])
 const COMMAND_KINDS = new Set(['create', 'send', 'stop', 'disband'])
-const DISALLOWED_STAGED_REF_SCHEMES = new Set(['blob', 'data', 'file', 'http', 'https', 'path'])
 const FORBIDDEN_TRANSPORT_FIELD_TOKENS = new Set(['base64', 'byte', 'bytes', 'data', 'path', 'paths'])
 const MEMBER_ID_RE = /^[A-Za-z0-9][A-Za-z0-9._:-]*$/
 const MIME_RE = /^[a-z0-9][a-z0-9!#$&^_.+-]*\/[a-z0-9][a-z0-9!#$&^_.+-]*$/i
-const STAGED_REF_RE = /^[a-z][a-z0-9+.-]*:[A-Za-z0-9][A-Za-z0-9._:-]*$/i
 const STATUS_EVENT_KINDS = new Set([
   'authority.lost',
   'member.unavailable',
@@ -349,7 +346,7 @@ function messageFromEvent(roomEvent) {
     text: typeof payload.text === 'string' ? payload.text : '',
     thread: text(payload.thread_id) || text(payload.thread) || 'legacy',
     at: roomEvent.createdAt,
-    ...(attachments.length ? { attachments } : {})
+    ...(attachments.length ? { images: attachments } : {})
   }
 }
 
@@ -654,9 +651,7 @@ function assertNoRawTransportFields(value, location = 'payload') {
     if (forbidden) {
       throw new TypeError(`${location}.${key} contains a forbidden ${forbidden} field`)
     }
-    if (key !== 'refs') {
-      assertNoRawTransportFields(nested, `${location}.${key}`)
-    }
+    assertNoRawTransportFields(nested, `${location}.${key}`)
   }
 }
 
@@ -693,46 +688,7 @@ function normalizeAttachmentMime(value, kind) {
   return mime
 }
 
-function normalizeAttachmentRefs(value, { required }) {
-  if (value === undefined && !required) {
-    return null
-  }
-  if (!value || typeof value !== 'object' || Array.isArray(value)) {
-    throw new TypeError('attachment member refs must be an object')
-  }
-
-  const entries = Object.entries(value)
-
-  if (!entries.length || entries.length > MAX_ATTACHMENT_REFS) {
-    throw new TypeError(`attachment member refs must contain 1-${MAX_ATTACHMENT_REFS} entries`)
-  }
-
-  const refs = {}
-
-  for (const [rawMemberId, rawRef] of entries) {
-    const memberId = text(rawMemberId)
-    const ref = text(rawRef)
-    const refScheme = ref?.split(':', 1)[0]?.toLowerCase()
-
-    if (!memberId || memberId.length > MAX_MEMBER_ID_CHARS || !MEMBER_ID_RE.test(memberId)) {
-      throw new TypeError('attachment member refs require valid member_id keys')
-    }
-    if (
-      !ref ||
-      ref.length > MAX_STAGED_REF_CHARS ||
-      !STAGED_REF_RE.test(ref) ||
-      DISALLOWED_STAGED_REF_SCHEMES.has(refScheme)
-    ) {
-      throw new TypeError('attachment member refs require opaque staged reference ids')
-    }
-
-    refs[memberId] = ref
-  }
-
-  return refs
-}
-
-function normalizeAttachmentEntry(raw, { requireRefs }) {
+function normalizeAttachmentEntry(raw) {
   if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
     throw new TypeError('each attachment must be an object')
   }
@@ -750,7 +706,11 @@ function normalizeAttachmentEntry(raw, { requireRefs }) {
   }
 
   const kind = text(raw.kind)?.toLowerCase()
+  const attachmentId = text(raw.attachment_id)
 
+  if (!attachmentId || !ATTACHMENT_ID_RE.test(attachmentId)) {
+    throw new TypeError('attachment_id must be an opaque server-minted id')
+  }
   if (!kind || !ATTACHMENT_KINDS.has(kind)) {
     throw new TypeError('attachment kind must be image, pdf, or file')
   }
@@ -764,17 +724,16 @@ function normalizeAttachmentEntry(raw, { requireRefs }) {
   }
 
   const normalized = {
+    attachment_id: attachmentId,
     kind,
     name: normalizeAttachmentName(raw.name),
     size: raw.size,
     mime: normalizeAttachmentMime(raw.mime, kind)
   }
-  const refs = normalizeAttachmentRefs(raw.refs, { required: requireRefs })
-
-  return refs ? { ...normalized, refs } : normalized
+  return normalized
 }
 
-function normalizeAttachmentManifest(value, { requireRefs }) {
+function normalizeAttachmentManifest(value) {
   if (!Array.isArray(value)) {
     throw new TypeError('attachments must be a manifest array')
   }
@@ -782,7 +741,13 @@ function normalizeAttachmentManifest(value, { requireRefs }) {
     throw new TypeError(`attachment manifest supports at most ${MAX_ATTACHMENT_COUNT} entries`)
   }
 
-  const manifest = value.map(entry => normalizeAttachmentEntry(entry, { requireRefs }))
+  const manifest = value.map(entry => normalizeAttachmentEntry(entry))
+  if (new Set(manifest.map(entry => entry.attachment_id)).size !== manifest.length) {
+    throw new TypeError('attachment ids must be unique within one message')
+  }
+  if (manifest.reduce((sum, entry) => sum + entry.size, 0) > 25_000_000) {
+    throw new TypeError('attachment manifest exceeds the 25MB message limit')
+  }
 
   if (utf8Size(JSON.stringify(manifest)) > MAX_ATTACHMENT_MANIFEST_BYTES) {
     throw new TypeError('attachment manifest metadata is too large')
@@ -800,9 +765,15 @@ function safeAttachmentMetadata(value) {
 
   for (const entry of value) {
     try {
-      const normalized = normalizeAttachmentEntry(entry, { requireRefs: false })
+      const normalized = normalizeAttachmentEntry(entry)
 
-      metadata.push({ kind: normalized.kind, name: normalized.name, size: normalized.size, mime: normalized.mime })
+      metadata.push({
+        attachment_id: normalized.attachment_id,
+        kind: normalized.kind,
+        name: normalized.name,
+        size: normalized.size,
+        mime: normalized.mime
+      })
     } catch {
       // A malformed internal manifest must not expose refs or block replay.
     }
@@ -843,7 +814,7 @@ function normalizeCommand(raw) {
   const payload = cloneJson(rawPayload, 'command payload')
 
   if (kind === 'send' && Object.prototype.hasOwnProperty.call(payload, 'attachments')) {
-    payload.attachments = normalizeAttachmentManifest(payload.attachments, { requireRefs: true })
+    payload.attachments = normalizeAttachmentManifest(payload.attachments)
   }
 
   return {

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -599,6 +599,69 @@ function groupChatRoomKey(name, room) {
     : `name:${String(name)}`
 }
 
+/** Gateway id/label for a backend-hosted room. The field is additive in the
+ *  v3 projection; older clients ignore it, while hosted-aware clients must
+ *  never start a second local round driver for the same room. */
+function groupChatHostedGateway(room) {
+  return typeof room?.hosted === 'string' ? room.hosted.trim().slice(0, 128) : ''
+}
+
+/** Monotonic fencing epoch for the hosted room authority. Draft rooms that
+ *  predate the field are epoch 1; local rooms have no hosted epoch. */
+function groupChatHostedEpoch(room) {
+  const epoch = Number(room?.hostedEpoch || 0)
+  if (Number.isSafeInteger(epoch) && epoch >= 1) {
+    return epoch
+  }
+  return groupChatHostedGateway(room) ? 1 : 0
+}
+
+/** Apply an authority coordinate read directly from ``groups.state``.
+ *  Display projections are client-writable caches and must never call this
+ *  helper. Only a higher server-issued epoch may replace an existing owner. */
+function applyHostedRoomAuthority(room, serverRoom) {
+  const authorityGateway = groupChatHostedGateway({ hosted: serverRoom?.authority_gateway_id })
+  const authorityEpoch = Number(serverRoom?.authority_epoch || 0)
+  const roomId = typeof room?.roomId === 'string' ? room.roomId : ''
+  const serverRoomId = typeof serverRoom?.room_id === 'string' ? serverRoom.room_id : ''
+
+  if (
+    !authorityGateway ||
+    !Number.isSafeInteger(authorityEpoch) ||
+    authorityEpoch < 1 ||
+    (roomId && serverRoomId && roomId !== serverRoomId)
+  ) {
+    return room
+  }
+
+  const currentGateway = groupChatHostedGateway(room)
+  const currentEpoch = groupChatHostedEpoch(room)
+  const claim = serverRoom?.authority_claim
+  const claimPayload = claim?.payload
+  const transferProven = Boolean(
+    claim?.kind === 'authority.claimed' &&
+      claim?.actor?.kind === 'system' &&
+      claim?.actor?.id === 'authority-control' &&
+      Number(claim?.authority_epoch || 0) === authorityEpoch &&
+      claimPayload?.previous_gateway_id === currentGateway &&
+      claimPayload?.authority_gateway_id === authorityGateway &&
+      Number(claimPayload?.authority_epoch || 0) === authorityEpoch
+  )
+  if (
+    currentEpoch > authorityEpoch ||
+    (currentGateway && currentGateway !== authorityGateway && !transferProven) ||
+    (currentEpoch === authorityEpoch && currentGateway && currentGateway !== authorityGateway)
+  ) {
+    return room
+  }
+
+  return {
+    ...room,
+    hosted: authorityGateway,
+    hostedEpoch: authorityEpoch
+  }
+}
+
 /** Lift any historical projection shape (v1 wall-clock, v2 name-keyed) to
  *  the v3 room-key shape so one merge path serves mixed-version fleets. */
 function normalizeGroupChatSyncSnapshot(snapshot) {
@@ -660,6 +723,7 @@ function groupChatSyncSnapshot(all = $groupChats.get(), deleted = {}) {
   for (const [name, room] of ranked) {
     const log = room.log.slice(-GROUP_CHAT_SYNC_MESSAGES).map(entry => ({
       ...(entry?.id ? { id: String(entry.id).slice(0, 160) } : {}),
+      ...(groupChatSyncSequence(entry) !== null ? { seq: groupChatSyncSequence(entry) } : {}),
       from: {
         kind: entry?.from?.kind === 'member' ? 'member' : 'user',
         name: String(entry?.from?.name || (entry?.from?.kind === 'member' ? 'Bot' : 'You')).slice(0, 128),
@@ -672,6 +736,11 @@ function groupChatSyncSnapshot(all = $groupChats.get(), deleted = {}) {
     const compact = {
       name: String(name).slice(0, 64),
       ...(typeof room?.roomId === 'string' && room.roomId ? { roomId: String(room.roomId).slice(0, 128) } : {}),
+      // Presence is the compatibility contract: current clients always emit
+      // a value or null. Older clients omit the unknown field, which must not
+      // be interpreted as moving a hosted room back to local execution.
+      hosted: groupChatHostedGateway(room) || null,
+      hostedEpoch: groupChatHostedEpoch(room) || null,
       log,
       revision: Math.max(0, Number(room?.syncRevision ?? room?.revision ?? 0)),
       members: (Array.isArray(room.members) ? room.members : []).slice(0, GROUP_CHAT_MAX_MEMBERS).map(member => ({
@@ -704,6 +773,12 @@ function groupChatSyncSnapshot(all = $groupChats.get(), deleted = {}) {
 }
 
 function groupChatSyncEntryKey(entry) {
+  const seq = groupChatSyncSequence(entry)
+
+  if (seq !== null) {
+    return `seq:${seq}`
+  }
+
   if (entry?.id) {
     return `id:${String(entry.id)}`
   }
@@ -722,6 +797,85 @@ function groupChatSyncEntryKey(entry) {
     String(entry?.thread || 'legacy').replace(/^legacy-\d+$/, 'legacy'),
     String(entry?.text || '')
   ])
+}
+
+function groupChatSyncSequence(entry) {
+  const seq = Number(entry?.seq)
+
+  return Number.isSafeInteger(seq) && seq > 0 ? seq : null
+}
+
+/** Hosted gateway logs carry a monotonic per-room sequence. Prefer it when
+ *  both entries have one; legacy/local entries keep their existing time/key
+ *  order until migration assigns them a sequence. */
+function compareGroupChatSyncEntries(left, right) {
+  const leftSeq = groupChatSyncSequence(left)
+  const rightSeq = groupChatSyncSequence(right)
+
+  if (leftSeq !== null && rightSeq !== null) {
+    return leftSeq - rightSeq || groupChatSyncEntryKey(left).localeCompare(groupChatSyncEntryKey(right))
+  }
+
+  const byTime = Number(left?.at || 0) - Number(right?.at || 0)
+
+  return byTime || groupChatSyncEntryKey(left).localeCompare(groupChatSyncEntryKey(right))
+}
+
+/** Union gateway replay with a legacy/local mirror without duplicating the
+ *  same event across its two identities. A hosted replay may add ``seq`` to
+ *  an entry the local room already knows by ``id``; repeated replay may also
+ *  carry different transport ids for the same authoritative sequence. Keep
+ *  both indexes while preferring the gateway sequence for ordering. */
+function mergeGroupChatSyncEntries(...logs) {
+  const entries = []
+  const byId = new Map()
+  const bySeq = new Map()
+
+  const remember = (entry, index) => {
+    const id = entry?.id ? String(entry.id) : ''
+    const seq = groupChatSyncSequence(entry)
+
+    if (id) {
+      byId.set(id, index)
+    }
+
+    if (seq !== null) {
+      bySeq.set(seq, index)
+    }
+  }
+
+  for (const entry of logs.flat()) {
+    const id = entry?.id ? String(entry.id) : ''
+    const seq = groupChatSyncSequence(entry)
+    let index = id ? byId.get(id) : undefined
+
+    if (index === undefined && seq !== null) {
+      index = bySeq.get(seq)
+    }
+
+    if (index === undefined) {
+      index = entries.length
+      entries.push(entry)
+      remember(entry, index)
+      continue
+    }
+
+    const prior = entries[index]
+    const authoritativeSeq = groupChatSyncSequence(prior) ?? seq
+    const merged = {
+      ...prior,
+      ...entry,
+      ...(prior?.images && !entry?.images ? { images: prior.images } : {}),
+      ...(prior?.id && !entry?.id ? { id: prior.id } : {}),
+      ...(authoritativeSeq !== null ? { seq: authoritativeSeq } : {})
+    }
+    entries[index] = merged
+    remember(prior, index)
+    remember(entry, index)
+    remember(merged, index)
+  }
+
+  return entries.sort(compareGroupChatSyncEntries)
 }
 
 function groupChatSyncMemberKey(member) {
@@ -804,24 +958,48 @@ function mergeGroupChatSyncSnapshots(
     const localRevision = changed.has(key)
       ? Math.max(0, Number(writeRevision || 0))
       : Math.max(0, Number(localRoom?.revision || 0))
-    const entries = new Map()
-    for (const entry of [...(remoteRoom?.log || []), ...(localRoom?.log || [])]) {
-      entries.set(groupChatSyncEntryKey(entry), entry)
-    }
+    const entries = mergeGroupChatSyncEntries(remoteRoom?.log || [], localRoom?.log || [])
 
     // Identity fields (display name, membership, picture) follow the higher
     // revision; a tie unions members and prefers the local writer's fields.
     let identity
     let members
     let image
+    let hosted
+    let hostedEpoch = 0
+    let hostedPresent = false
+    const remoteHostedPresent = Object.prototype.hasOwnProperty.call(remoteRoom || {}, 'hosted')
+    const localHostedPresent = Object.prototype.hasOwnProperty.call(localRoom || {}, 'hosted')
+    const remoteHostedEpoch = groupChatHostedEpoch(remoteRoom)
+    const localHostedEpoch = groupChatHostedEpoch(localRoom)
     if (localRevision > remoteRevision) {
       identity = localRoom
       members = [...(localRoom?.members || [])]
       image = localRoom?.image
+      if (localHostedPresent) {
+        hostedPresent = true
+        hosted = groupChatHostedGateway(localRoom)
+        hostedEpoch = groupChatHostedEpoch(localRoom)
+      } else if (remoteHostedPresent) {
+        // A newer legacy writer omitted a field it cannot understand. Keep
+        // the last explicit hosted/local statement from the other side.
+        hostedPresent = true
+        hosted = groupChatHostedGateway(remoteRoom)
+        hostedEpoch = groupChatHostedEpoch(remoteRoom)
+      }
     } else if (remoteRevision > localRevision) {
       identity = remoteRoom
       members = [...(remoteRoom?.members || [])]
       image = remoteRoom?.image
+      if (remoteHostedPresent) {
+        hostedPresent = true
+        hosted = groupChatHostedGateway(remoteRoom)
+        hostedEpoch = groupChatHostedEpoch(remoteRoom)
+      } else if (localHostedPresent) {
+        hostedPresent = true
+        hosted = groupChatHostedGateway(localRoom)
+        hostedEpoch = groupChatHostedEpoch(localRoom)
+      }
     } else {
       identity = localRoom || remoteRoom
       const byId = new Map()
@@ -830,18 +1008,34 @@ function mergeGroupChatSyncSnapshots(
       }
       members = [...byId.values()]
       image = Object.prototype.hasOwnProperty.call(localRoom || {}, 'image') ? localRoom.image : remoteRoom?.image
+      hostedPresent = localHostedPresent || remoteHostedPresent
+      hosted = localHostedPresent ? groupChatHostedGateway(localRoom) : groupChatHostedGateway(remoteRoom)
+      hostedEpoch = localHostedPresent ? groupChatHostedEpoch(localRoom) : groupChatHostedEpoch(remoteRoom)
+    }
+    // Both snapshots are client-writable display projections, not authority
+    // receipts. Keep an existing non-empty owner as a conservative execution
+    // fence; a larger client-authored epoch cannot replace or clear it.
+    const remoteHosted = groupChatHostedGateway(remoteRoom)
+    const localHosted = groupChatHostedGateway(localRoom)
+    if (remoteHosted) {
+      hostedPresent = true
+      hosted = remoteHosted
+      hostedEpoch = remoteHostedEpoch
+    } else if (localHosted) {
+      hostedPresent = true
+      hosted = localHosted
+      hostedEpoch = localHostedEpoch
     }
     rooms[key] = {
       ...(identity?.name ? { name: identity.name } : {}),
       ...(identity?.roomId || (key.startsWith('id:') ? key.slice(3) : '')
         ? { roomId: identity?.roomId || key.slice(3) }
         : {}),
-      log: [...entries.values()].sort((left, right) => {
-        const byTime = Number(left?.at || 0) - Number(right?.at || 0)
-        return byTime || groupChatSyncEntryKey(left).localeCompare(groupChatSyncEntryKey(right))
-      }),
+      log: entries,
       members,
       revision: Math.max(remoteRevision, localRevision),
+      ...(hostedPresent ? { hosted: hosted || null } : {}),
+      ...(hostedPresent ? { hostedEpoch: hostedEpoch || null } : {}),
       ...(typeof image === 'string' && image ? { image } : {})
     }
   }
@@ -963,6 +1157,14 @@ function mergeRemoteGroupChatSnapshotIntoRooms(
       }
     }
     const isPreserved = preserved.has(displayName) || (localName && preserved.has(localName))
+    const projectedAuthorityEpoch = groupChatHostedEpoch(projected)
+    const existingAuthorityEpoch = groupChatHostedEpoch(existing)
+    const projectedHosted = groupChatHostedGateway(projected)
+    const existingHosted = groupChatHostedGateway(existing)
+    // ``ui_meta`` is only a cache. It may initialize a fail-safe hosted fence,
+    // but it cannot replace or clear one already held by this runtime.
+    const cachedHosted = existingHosted || projectedHosted
+    const cachedHostedEpoch = existingHosted ? existingAuthorityEpoch : projectedAuthorityEpoch
     if (!isPreserved) {
       if (remoteRevision > localRevision) {
         members.clear()
@@ -972,12 +1174,7 @@ function mergeRemoteGroupChatSnapshotIntoRooms(
       }
     }
 
-    const log = assignLegacyThreads(
-      [...entries.values()].sort((left, right) => {
-        const byTime = Number(left?.at || 0) - Number(right?.at || 0)
-        return byTime || groupChatSyncEntryKey(left).localeCompare(groupChatSyncEntryKey(right))
-      })
-    )
+    const log = assignLegacyThreads([...entries.values()].sort(compareGroupChatSyncEntries))
     const bounded = trimGroupChatLog(log, existing.watermarks || {})
 
     // A remote rename with a higher revision moves the local record to the
@@ -1001,6 +1198,8 @@ function mergeRemoteGroupChatSnapshotIntoRooms(
         : remoteRevision >= localRevision && Object.prototype.hasOwnProperty.call(projected, 'image')
           ? projected.image || null
           : existing.image || null,
+      hosted: cachedHosted || null,
+      hostedEpoch: cachedHostedEpoch || null,
       syncRevision: isPreserved ? localRevision : Math.max(remoteRevision, localRevision),
       epoch: Number(existing.epoch || 0),
       running: Boolean(existing.running)
@@ -1051,7 +1250,9 @@ function durableGroupChatRooms(all = $groupChats.get()) {
       log: room.log,
       watermarks: room.watermarks || {},
       sessions: room.sessions || {},
+      sessionOwners: room.sessionOwners || {},
       stranded: room.stranded || {},
+      holds: room.holds || {},
       members: Array.isArray(room.members) ? room.members : [],
       // Immutable room identity: without this, a room merged in via the
       // remote-sync path (the only caller of this function) loses its
@@ -1059,12 +1260,51 @@ function durableGroupChatRooms(all = $groupChats.get()) {
       // name-keyed identity — same field updateGroupChat's inline map
       // already carries.
       roomId: typeof room.roomId === 'string' && room.roomId ? room.roomId : null,
+      hosted: groupChatHostedGateway(room) || null,
+      hostedEpoch: groupChatHostedEpoch(room) || null,
       image: room.image || null,
       syncRevision: Math.max(0, Number(room.syncRevision || 0))
     }
   }
 
   return durable
+}
+
+/** Rehydrate the durable room cache without weakening execution authority.
+ *  Runtime-only loop state always resets, but a hosted marker is a safety
+ *  fence: dropping it while its gateway is offline would let the renderer
+ *  start the legacy local driver after a relaunch. */
+function hydratePersistedGroupChatRooms(value) {
+  const rooms = {}
+
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return rooms
+  }
+
+  for (const [name, room] of Object.entries(value)) {
+    if (!room || !Array.isArray(room.log)) {
+      continue
+    }
+
+    rooms[name] = {
+      log: assignLegacyThreads(room.log),
+      watermarks: room.watermarks && typeof room.watermarks === 'object' ? room.watermarks : {},
+      sessions: room.sessions && typeof room.sessions === 'object' ? room.sessions : {},
+      sessionOwners: room.sessionOwners && typeof room.sessionOwners === 'object' ? room.sessionOwners : {},
+      stranded: room.stranded && typeof room.stranded === 'object' ? room.stranded : {},
+      holds: room.holds && typeof room.holds === 'object' ? room.holds : {},
+      members: Array.isArray(room.members) ? room.members : [],
+      roomId: typeof room.roomId === 'string' && room.roomId ? room.roomId : null,
+      hosted: groupChatHostedGateway(room) || null,
+      hostedEpoch: groupChatHostedEpoch(room) || null,
+      image: typeof room.image === 'string' && room.image ? room.image : null,
+      syncRevision: Math.max(0, Number(room.syncRevision || 0)),
+      epoch: 0,
+      running: false
+    }
+  }
+
+  return rooms
 }
 
 function persistGroupChatRooms(all = $groupChats.get()) {
@@ -7018,6 +7258,8 @@ function updateGroupChat(group, mutate, { sync = true } = {}) {
         members: Array.isArray(room.members) ? room.members : [],
         // Immutable room identity: the member-session title for new rooms.
         roomId: typeof room.roomId === 'string' && room.roomId ? room.roomId : null,
+        hosted: groupChatHostedGateway(room) || null,
+        hostedEpoch: groupChatHostedEpoch(room) || null,
         // Room picture (small data URL, same normalization as bot avatars).
         image: room.image || null,
         syncRevision: Math.max(0, Number(room.syncRevision || 0))
@@ -7106,6 +7348,8 @@ async function disbandGroupChat(group, members) {
           sessionOwners: room.sessionOwners || {},
           members: Array.isArray(room.members) ? room.members : [],
           roomId: typeof room.roomId === 'string' && room.roomId ? room.roomId : null,
+          hosted: groupChatHostedGateway(room) || null,
+          hostedEpoch: groupChatHostedEpoch(room) || null,
           image: room.image || null,
           syncRevision: Math.max(0, Number(room.syncRevision || 0))
         }
@@ -7271,6 +7515,13 @@ function normalizeGroupChatText(text) {
 }
 
 function appendGroupChatEntry(group, from, text, thread, images) {
+  // Once a gateway owns the room, its monotonic log is authoritative. Late
+  // renderer harvest/clarify callbacks from the pre-hosted epoch must not
+  // mutate the read mirror after ownership moves.
+  if (groupChatHostedGateway($groupChats.get()[group])) {
+    return null
+  }
+
   const entry = {
     id: groupChatEntryId(),
     at: Date.now(),
@@ -8553,8 +8804,17 @@ async function harvestStrandedUntilSettled(group, members, thread) {
 function sendToGroupChat(group, members, text, thread, images) {
   const trimmed = String(text || '').trim()
   const attached = Array.isArray(images) ? images.filter(img => img && img.data) : []
+  const hosted = groupChatHostedGateway($groupChats.get()[group])
 
   if ((!trimmed && !attached.length) || !members.length) {
+    return null
+  }
+
+  if (hosted) {
+    host.notify?.({
+      kind: 'info',
+      message: `“${group}” runs on ${hosted}. Sending to hosted rooms isn't available in this build yet.`
+    })
     return null
   }
 
@@ -15735,31 +15995,7 @@ export default {
       Promise.resolve(ctx.storage?.get?.('group-chats'))
         .then(async value => {
           if (value && typeof value === 'object' && !Array.isArray(value)) {
-            const rooms = {}
-
-            for (const [name, room] of Object.entries(value)) {
-              if (room && Array.isArray(room.log)) {
-                rooms[name] = {
-                  // Pre-thread entries get synthetic thread ids on hydrate so
-                  // every UI/engine path can assume entry.thread exists.
-                  log: assignLegacyThreads(room.log),
-                  watermarks: room.watermarks && typeof room.watermarks === 'object' ? room.watermarks : {},
-                  sessions: room.sessions && typeof room.sessions === 'object' ? room.sessions : {},
-                  sessionOwners: room.sessionOwners && typeof room.sessionOwners === 'object' ? room.sessionOwners : {},
-                  stranded: room.stranded && typeof room.stranded === 'object' ? room.stranded : {},
-                  // #93129: rehydrate sticky stop holds with the same shape
-                  // guard as the other maps — a held bot stays held across
-                  // window restarts until explicitly released.
-                  holds: room.holds && typeof room.holds === 'object' ? room.holds : {},
-                  members: Array.isArray(room.members) ? room.members : [],
-                  roomId: typeof room.roomId === 'string' && room.roomId ? room.roomId : null,
-                  image: typeof room.image === 'string' && room.image ? room.image : null,
-                  syncRevision: Math.max(0, Number(room.syncRevision || 0)),
-                  epoch: 0,
-                  running: false
-                }
-              }
-            }
+            const rooms = hydratePersistedGroupChatRooms(value)
 
             $groupChats.set({ ...rooms, ...$groupChats.get() })
 

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -42,6 +42,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
   EmptyState,
+  ErrorState,
   GlyphSpinner,
   haptic,
   host,
@@ -563,6 +564,15 @@ const groupChatSyncInFlightConnections = new Set()
 const groupChatSyncRetryTimers = new Map()
 const groupChatSyncRetryCounts = new Map()
 let groupChatSyncDisposed = false
+
+const HOSTED_ROOM_OUTBOX_KEY = 'hosted-room-outbox-v1'
+const HOSTED_ROOM_SYNC_INTERVAL_MS = 5000
+const $hostedRoomCapabilities = atom({})
+const $hostedRoomOutbox = atom({ version: 1, commands: [] })
+let hostedRoomSyncTimer = null
+let hostedRoomSyncRunning = false
+let hostedRoomSyncDisposed = false
+const hostedAuthorityRoutes = new Map()
 
 /** Conservative byte count for the gateway's ensure_ascii JSON encoding.
  *  Python also inserts separator spaces, so reserve one extra byte per JS
@@ -1262,6 +1272,11 @@ function durableGroupChatRooms(all = $groupChats.get()) {
       roomId: typeof room.roomId === 'string' && room.roomId ? room.roomId : null,
       hosted: groupChatHostedGateway(room) || null,
       hostedEpoch: groupChatHostedEpoch(room) || null,
+      hostedConnectionId:
+        typeof room.hostedConnectionId === 'string' && room.hostedConnectionId
+          ? room.hostedConnectionId
+          : null,
+      hostedSeq: Math.max(0, Number(room.hostedSeq || 0)),
       image: room.image || null,
       syncRevision: Math.max(0, Number(room.syncRevision || 0))
     }
@@ -1297,6 +1312,11 @@ function hydratePersistedGroupChatRooms(value) {
       roomId: typeof room.roomId === 'string' && room.roomId ? room.roomId : null,
       hosted: groupChatHostedGateway(room) || null,
       hostedEpoch: groupChatHostedEpoch(room) || null,
+      hostedConnectionId:
+        typeof room.hostedConnectionId === 'string' && room.hostedConnectionId
+          ? room.hostedConnectionId
+          : null,
+      hostedSeq: Math.max(0, Number(room.hostedSeq || 0)),
       image: typeof room.image === 'string' && room.image ? room.image : null,
       syncRevision: Math.max(0, Number(room.syncRevision || 0)),
       epoch: 0,
@@ -1459,6 +1479,323 @@ async function groupChatSyncRequest(job, method, params) {
     throw new Error('Group chat gateway changed before sync')
   }
   return host.request(method, params)
+}
+
+async function hostedDefaultRoutes() {
+  if (typeof host.profileRoutes !== 'function') {
+    return []
+  }
+  const routes = await host.profileRoutes()
+  const byConnection = new Map()
+
+  for (const route of Array.isArray(routes) ? routes : []) {
+    const profile = String(route?.targetProfile || route?.profile || '')
+    const connectionId = String(route?.connectionId || '')
+
+    if (!connectionId || profile !== 'default' || byConnection.has(connectionId)) {
+      continue
+    }
+    byConnection.set(connectionId, route)
+  }
+
+  return [...byConnection.values()]
+}
+
+async function requestHostedConnection(route, method, params = {}) {
+  if (!route?.connectionId || typeof host.requestProfile !== 'function') {
+    throw new Error('Hermes gateway is unavailable')
+  }
+  return host.requestProfile(route, method, params)
+}
+
+function hostedMemberDescriptors(room, connectionId, connectionLabel) {
+  return (Array.isArray(room?.members) ? room.members : []).map(member => ({
+    name: String(member?.profile || member?.member_id || 'default'),
+    handle: String(member?.handle || member?.profile || 'hermes'),
+    title: String(member?.display_name || ''),
+    connectionId,
+    connectionLabel,
+    remoteSource: true,
+    sourceScoped: true,
+    targetProfile: String(member?.profile || 'default')
+  }))
+}
+
+async function refreshHostedRooms() {
+  if (hostedRoomSyncDisposed || hostedRoomSyncRunning) {
+    return
+  }
+  hostedRoomSyncRunning = true
+
+  try {
+    const client = await import('./hosted-room-client.js')
+    const routes = await hostedDefaultRoutes()
+    const sources = new Map(
+      ($lastSources.get() || []).map(source => [String(source?.connectionId || ''), source])
+    )
+    const capabilities = { ...$hostedRoomCapabilities.get() }
+
+    for (const route of routes) {
+      const connectionId = String(route.connectionId)
+      let capability
+
+      try {
+        const result = await requestHostedConnection(route, 'groups.capabilities', {})
+        capability = client.classifyHostedRoomCapability(result, { connectionId })
+      } catch (error) {
+        capability = client.classifyHostedRoomCapability({ ok: false, error }, { connectionId })
+      }
+
+      capabilities[connectionId] = capability
+      if (
+        capability.kind !== 'driver-capable' ||
+        capability.persistentProcess !== true ||
+        !capability.authorityId
+      ) {
+        continue
+      }
+
+      hostedAuthorityRoutes.set(capability.authorityId, route)
+      let listed
+      try {
+        listed = await requestHostedConnection(route, 'groups.list', {})
+      } catch {
+        continue
+      }
+
+      for (const listedRoom of Array.isArray(listed?.rooms) ? listed.rooms : []) {
+        const roomId = String(listedRoom?.room_id || '')
+        const roomName = String(listedRoom?.name || '').trim()
+
+        if (!roomId || !roomName) continue
+        let serverState
+        try {
+          serverState = await requestHostedConnection(route, 'groups.state', { room_id: roomId })
+        } catch {
+          continue
+        }
+        const roomState = serverState?.room || listedRoom
+        const existingEntry = Object.entries($groupChats.get()).find(
+          ([, room]) => String(room?.roomId || '') === roomId
+        )
+        const existingName = existingEntry?.[0] || roomName
+        const existing = existingEntry?.[1] || {}
+        const replay = await client.replayHostedRoomPages({
+          state: client.createHostedRoomReplayState({
+            roomId,
+            name: roomName,
+            members: roomState.members,
+            authorityId: roomState.authority_gateway_id,
+            authorityEpoch: roomState.authority_epoch,
+            connectionId,
+            cursor: Number(existing.hostedSeq || 0),
+            messages: existing.log || []
+          }),
+          fetchPage: ({ sinceSeq, limit }) =>
+            requestHostedConnection(route, 'groups.log', {
+              room_id: roomId,
+              since_seq: sinceSeq,
+              limit
+            })
+        })
+        const source = sources.get(connectionId)
+        const label = source?.label || source?.connectionLabel || connectionId
+        const replayState = replay.state
+
+        updateGroupChat(existingName, room => {
+          const authoritative = applyHostedRoomAuthority(room, roomState)
+
+          return {
+            ...authoritative,
+            roomId,
+            members: hostedMemberDescriptors(roomState, connectionId, label),
+            log: mergeGroupChatSyncEntries(room.log || [], replayState.messages || []),
+            hostedConnectionId: connectionId,
+            hostedSeq: replayState.cursor,
+            hostedStatus: client.deriveFriendlyHostedRoomStatus(replayState),
+            running: replayState.lastStatusEvent?.kind === 'turn.started'
+          }
+        }, { sync: false })
+      }
+    }
+
+    $hostedRoomCapabilities.set(capabilities)
+  } finally {
+    hostedRoomSyncRunning = false
+  }
+}
+
+function scheduleHostedRoomSync(delay = HOSTED_ROOM_SYNC_INTERVAL_MS) {
+  if (hostedRoomSyncDisposed || typeof window === 'undefined') return
+  if (hostedRoomSyncTimer) window.clearTimeout(hostedRoomSyncTimer)
+  hostedRoomSyncTimer = window.setTimeout(async () => {
+    hostedRoomSyncTimer = null
+    await refreshHostedRooms().catch(() => undefined)
+    scheduleHostedRoomSync()
+  }, delay)
+}
+
+function stopHostedRoomSync() {
+  hostedRoomSyncDisposed = true
+  if (hostedRoomSyncTimer && typeof window !== 'undefined') {
+    window.clearTimeout(hostedRoomSyncTimer)
+  }
+  hostedRoomSyncTimer = null
+}
+
+async function hostedRouteForRoom(room) {
+  const cachedId = String(room?.hostedConnectionId || '')
+  if (cachedId) {
+    const route = (await hostedDefaultRoutes()).find(candidate => String(candidate?.connectionId || '') === cachedId)
+    if (route) return route
+  }
+  return hostedAuthorityRoutes.get(groupChatHostedGateway(room)) || null
+}
+
+async function persistHostedRoomOutbox() {
+  try {
+    await pluginCtx?.storage?.set?.(HOSTED_ROOM_OUTBOX_KEY, $hostedRoomOutbox.get())
+  } catch {
+    /* a later mutation retries persistence */
+  }
+}
+
+let hostedOutboxDispatching = false
+
+async function dispatchHostedRoomOutbox() {
+  if (hostedOutboxDispatching || hostedRoomSyncDisposed) return
+  hostedOutboxDispatching = true
+
+  try {
+    const client = await import('./hosted-room-client.js')
+    let state = $hostedRoomOutbox.get()
+
+    for (const command of state.commands.filter(entry => entry.status === 'pending')) {
+      const routes = await hostedDefaultRoutes()
+      const route = routes.find(candidate => String(candidate?.connectionId || '') === command.connectionId)
+
+      if (!route) continue
+      state = client.reduceHostedRoomOutbox(state, { type: 'dispatch', commandId: command.commandId })
+      $hostedRoomOutbox.set(state)
+      await persistHostedRoomOutbox()
+
+      const method = {
+        create: 'groups.create',
+        send: 'groups.send',
+        stop: 'groups.stop',
+        disband: 'groups.disband'
+      }[command.kind]
+      const params =
+        command.kind === 'send'
+          ? { room_id: command.roomId, event_id: command.commandId, payload: command.payload }
+          : command.kind === 'stop'
+            ? { room_id: command.roomId, cancel_id: command.commandId }
+            : command.kind === 'disband'
+              ? { room_id: command.roomId, cancel_id: command.commandId }
+              : command.payload
+
+      try {
+        await requestHostedConnection(route, method, params)
+        state = client.reduceHostedRoomOutbox(state, { type: 'acknowledge', commandId: command.commandId })
+        $hostedRoomOutbox.set(state)
+        await persistHostedRoomOutbox()
+        scheduleHostedRoomSync(0)
+      } catch {
+        state = client.reduceHostedRoomOutbox(state, { type: 'transient-failure', commandId: command.commandId })
+        $hostedRoomOutbox.set(state)
+        await persistHostedRoomOutbox()
+      }
+    }
+  } finally {
+    hostedOutboxDispatching = false
+  }
+}
+
+async function enqueueHostedRoomCommand(command) {
+  const client = await import('./hosted-room-client.js')
+  const next = client.reduceHostedRoomOutbox($hostedRoomOutbox.get(), {
+    type: 'enqueue',
+    command
+  })
+  $hostedRoomOutbox.set(next)
+  await persistHostedRoomOutbox()
+  await dispatchHostedRoomOutbox()
+}
+
+function hostedAttachmentRef(eventId, index, memberId) {
+  const seed = `${eventId}-${index}-${memberId}`.replace(/[^A-Za-z0-9._:-]/g, '-').slice(0, 220)
+  return `staged:${seed || `attachment-${index}`}`
+}
+
+function attachmentMime(attachment) {
+  if (attachment?.mime) return String(attachment.mime)
+  const match = /^data:([^;,]+)/i.exec(String(attachment?.data || ''))
+  return match?.[1] || (attachment?.kind === 'pdf' ? 'application/pdf' : attachment?.kind === 'image' ? 'image/png' : 'application/octet-stream')
+}
+
+async function stageHostedAttachments(group, members, eventId, attachments) {
+  const picked = (Array.isArray(attachments) ? attachments : []).slice(0, 8)
+  if (!picked.length) return []
+  const manifests = picked.map(attachment => ({
+    kind: attachment.kind,
+    name: attachment.name || 'attachment',
+    size: Math.max(0, Number(attachment.size || 0)),
+    mime: attachmentMime(attachment),
+    refs: {}
+  }))
+
+  for (const member of members) {
+    const { runtime } = await ensureGroupChatSession(group, member)
+    if (!runtime) throw new Error(`${displayName(member, botRosterMeta(member, $botMeta.get()))} is unavailable.`)
+    const memberId = member.name === 'default' ? 'default' : member.name
+
+    for (let index = 0; index < picked.length; index++) {
+      const attachment = picked[index]
+      if (attachment.kind === 'pdf') {
+        await requestForBot(member, 'pdf.attach', {
+          session_id: runtime,
+          content_base64: attachment.data,
+          filename: attachment.name || 'attachment.pdf'
+        })
+      } else if (attachment.kind === 'file') {
+        await requestForBot(member, 'file.attach', {
+          session_id: runtime,
+          data_url: attachment.data,
+          name: attachment.name || 'attachment'
+        })
+      } else {
+        await requestForBot(member, 'image.attach_bytes', {
+          session_id: runtime,
+          content_base64: attachment.data,
+          filename: attachment.name || 'attachment.png'
+        })
+      }
+      manifests[index].refs[memberId] = hostedAttachmentRef(eventId, index, memberId)
+    }
+  }
+
+  return manifests
+}
+
+async function sendHostedGroupChat(group, members, sent, thread, attachments) {
+  const room = $groupChats.get()[group]
+  const route = await hostedRouteForRoom(room)
+  if (!route) {
+    throw new Error('This group is offline. Try again when its gateway reconnects.')
+  }
+  const manifests = await stageHostedAttachments(group, members, sent.id, attachments)
+  await enqueueHostedRoomCommand({
+    commandId: sent.id,
+    kind: 'send',
+    roomId: room.roomId,
+    authorityId: groupChatHostedGateway(room),
+    connectionId: String(route.connectionId),
+    payload: {
+      text: sent.text || '',
+      thread_id: thread,
+      ...(manifests.length ? { attachments: manifests } : {})
+    }
+  })
 }
 
 async function groupChatRemoteSnapshot(job) {
@@ -4292,7 +4629,11 @@ async function filesToGroupAttachments(files) {
     picked.push({
       name: file.name || (kind === 'image' ? 'pasted image' : 'attachment'),
       data: kind === 'image' ? await normalizeGroupAttachment(data) : data,
-      kind
+      kind,
+      size: Number(file.size || 0),
+      mime:
+        file.type ||
+        (kind === 'image' ? 'image/png' : kind === 'pdf' ? 'application/pdf' : 'application/octet-stream')
     })
   }
 
@@ -7260,6 +7601,11 @@ function updateGroupChat(group, mutate, { sync = true } = {}) {
         roomId: typeof room.roomId === 'string' && room.roomId ? room.roomId : null,
         hosted: groupChatHostedGateway(room) || null,
         hostedEpoch: groupChatHostedEpoch(room) || null,
+        hostedConnectionId:
+          typeof room.hostedConnectionId === 'string' && room.hostedConnectionId
+            ? room.hostedConnectionId
+            : null,
+        hostedSeq: Math.max(0, Number(room.hostedSeq || 0)),
         // Room picture (small data URL, same normalization as bot avatars).
         image: room.image || null,
         syncRevision: Math.max(0, Number(room.syncRevision || 0))
@@ -12794,6 +13140,12 @@ function CreateGroupChatDialog({ open, roster, onClose, onCreated }) {
   const [checked, setChecked] = useState({})
   const [name, setName] = useState('')
   const [image, setImage] = useState(null)
+  const [keepRunning, setKeepRunning] = useState(false)
+  const [hostCapability, setHostCapability] = useState(null)
+  const [hostRoute, setHostRoute] = useState(null)
+  const [hostProbePending, setHostProbePending] = useState(false)
+  const [createPending, setCreatePending] = useState(false)
+  const [createError, setCreateError] = useState('')
 
   // Reset per open so a cancelled draft doesn't leak into the next one.
   useEffect(() => {
@@ -12802,6 +13154,12 @@ function CreateGroupChatDialog({ open, roster, onClose, onCreated }) {
       setChecked({})
       setName('')
       setImage(null)
+      setKeepRunning(false)
+      setHostCapability(null)
+      setHostRoute(null)
+      setHostProbePending(false)
+      setCreatePending(false)
+      setCreateError('')
     }
   }, [open])
 
@@ -12816,7 +13174,66 @@ function CreateGroupChatDialog({ open, roster, onClose, onCreated }) {
     : 'Group name'
   const canCreate = selected.length >= 2 && Boolean(name.trim() || selected.length)
 
-  const create = () => {
+  const selectedRouteKey = selected.map(botRosterKey).sort().join('|')
+
+  useEffect(() => {
+    let cancelled = false
+
+    if (!open || selected.length < 2) {
+      setHostCapability(null)
+      setHostRoute(null)
+      setKeepRunning(false)
+      return () => {
+        cancelled = true
+      }
+    }
+
+    setHostProbePending(true)
+    void import('./hosted-room-client.js')
+      .then(async client => {
+        if (cancelled) return
+        const route = client.resolveSingleGatewayRoute(selected, {
+          activeConnectionId: String(host.state.connectionId?.get?.() || host.activeConnectionId?.() || 'local')
+        })
+        setHostRoute(route)
+        if (route.kind !== 'single-gateway') {
+          setHostCapability(null)
+          setKeepRunning(false)
+          return
+        }
+        const result = await requestForBot(selected[0], 'groups.capabilities', {})
+        if (cancelled) return
+        const capability = client.classifyHostedRoomCapability(result, {
+          connectionId: route.connectionId
+        })
+        setHostCapability(capability)
+        if (capability.kind !== 'driver-capable' || capability.persistentProcess !== true) {
+          setKeepRunning(false)
+        }
+      })
+      .catch(error => {
+        if (cancelled) return
+        setHostCapability({ kind: 'transient-failure', reason: 'probe-failed', error })
+        setHostRoute(null)
+        setKeepRunning(false)
+      })
+      .finally(() => {
+        if (!cancelled) setHostProbePending(false)
+      })
+
+    return () => {
+      cancelled = true
+    }
+    // The key is stable across harmless roster object refreshes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, selectedRouteKey])
+
+  const hostedEligible =
+    hostRoute?.kind === 'single-gateway' &&
+    hostCapability?.kind === 'driver-capable' &&
+    hostCapability?.persistentProcess === true
+
+  const create = async () => {
     const base = (name.trim() || placeholder).slice(0, 64)
 
     if (selected.length < 2 || !base) {
@@ -12842,29 +13259,67 @@ function CreateGroupChatDialog({ open, roster, onClose, onCreated }) {
     const groupName = uniqueGroupChatName(base, taken)
     const roomId = mintGroupRoomId()
 
-    for (const bot of selected) {
-      void saveBotMeta(bot, groupMembershipPatch(botRosterMeta(bot, allMeta), groupName, true))
-    }
-
     // Persist every machine identity, including today's active source. That
     // member becomes remote after a source switch and cannot rely on the new
     // gateway's name-keyed bot metadata to remain seated in this room.
     const roomMembers = durableGroupChatMembers(selected)
 
-    updateGroupChat(groupName, room => {
-      room.members = roomMembers
-      room.roomId = roomId
+    setCreatePending(true)
+    setCreateError('')
+    let hostedRoom = null
 
-      if (image) {
-        room.image = image
+    try {
+      if (keepRunning) {
+        if (!hostedEligible) {
+          throw new Error('This gateway cannot keep group work running yet.')
+        }
+        const created = await requestForBot(selected[0], 'groups.create', {
+          room_id: roomId,
+          name: groupName,
+          members: selected.map(bot => ({
+            member_id: bot.name === 'default' ? 'default' : bot.name,
+            profile: bot.name,
+            handle: botMentionTag(bot),
+            ...(displayName(bot, botRosterMeta(bot, allMeta))
+              ? { display_name: displayName(bot, botRosterMeta(bot, allMeta)) }
+              : {})
+          }))
+        })
+        hostedRoom = created?.room
+        if (!hostedRoom?.authority_gateway_id) {
+          throw new Error('The gateway did not create the group.')
+        }
       }
 
-      return room
-    })
+      for (const bot of selected) {
+        await saveBotMeta(bot, groupMembershipPatch(botRosterMeta(bot, allMeta), groupName, true))
+      }
 
-    host.notify({ kind: 'info', message: `“${groupName}” created with ${selected.length} bots` })
-    onClose()
-    onCreated?.(groupName)
+      updateGroupChat(groupName, room => {
+        room.members = roomMembers
+        room.roomId = roomId
+
+        if (hostedRoom) {
+          room.hosted = hostedRoom.authority_gateway_id
+          room.hostedEpoch = hostedRoom.authority_epoch || 1
+          room.hostedConnectionId = hostRoute.connectionId
+        }
+
+        if (image) {
+          room.image = image
+        }
+
+        return room
+      })
+
+      host.notify({ kind: 'info', message: `“${groupName}” created with ${selected.length} bots` })
+      onClose()
+      onCreated?.(groupName)
+    } catch (error) {
+      setCreateError(error instanceof Error ? error.message : 'Could not create the group.')
+    } finally {
+      setCreatePending(false)
+    }
   }
 
   return jsx(Dialog, {
@@ -12987,14 +13442,48 @@ function CreateGroupChatDialog({ open, roster, onClose, onCreated }) {
             })
           ]
         }),
+        hostedEligible || hostProbePending
+          ? jsxs('div', {
+              className: 'flex items-start justify-between gap-4 py-1',
+              children: [
+                jsxs('div', {
+                  className: 'min-w-0',
+                  children: [
+                    jsx('div', {
+                      className: 'text-xs font-medium text-foreground',
+                      children: 'Keep working when this app is closed'
+                    }),
+                    jsx('div', {
+                      className: 'mt-0.5 text-[0.6875rem] leading-relaxed text-(--ui-text-tertiary)',
+                      children: hostProbePending
+                        ? 'Checking this gateway…'
+                        : `Runs on ${selected[0]?.connectionLabel || 'this Hermes gateway'}.`
+                    })
+                  ]
+                }),
+                jsx(Switch, {
+                  'aria-label': 'Keep group work running when this app is closed',
+                  checked: keepRunning,
+                  disabled: hostProbePending || !hostedEligible,
+                  onCheckedChange: setKeepRunning,
+                  size: 'xs'
+                })
+              ]
+            })
+          : null,
+        createError
+          ? jsx(ErrorState, { title: 'Could not create the group', description: createError })
+          : null,
         jsxs(DialogFooter, {
           children: [
             jsx(Button, { variant: 'secondary', onClick: onClose, children: 'Cancel' }),
             jsx(Button, {
-              disabled: !canCreate,
+              disabled: !canCreate || createPending,
               title: selected.length < 2 ? 'Pick at least 2 bots' : undefined,
-              onClick: create,
-              children: `Create Group${selected.length ? ` (${selected.length})` : ''}`
+              onClick: () => void create(),
+              children: createPending
+                ? 'Creating…'
+                : `Create Group${selected.length ? ` (${selected.length})` : ''}`
             })
           ]
         })
@@ -15481,7 +15970,7 @@ function BotsPane() {
                         children: [jsx(Codicon, { name: 'hubot', className: 'mr-1.5' }), 'New Bot']
                       }),
                       jsxs(DropdownMenuItem, {
-                        disabled: activeSourceRoster.length < 2,
+                        disabled: roster.length < 2,
                         onSelect: () => setGroupCreateOpen(true),
                         children: [jsx(Codicon, { name: 'organization', className: 'mr-1.5' }), 'New Group Chat']
                       })

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -564,6 +564,19 @@ const groupChatSyncInFlightConnections = new Set()
 const groupChatSyncRetryTimers = new Map()
 const groupChatSyncRetryCounts = new Map()
 let groupChatSyncDisposed = false
+const DESKTOP_ROOM_COMMAND_CONSUMER_KEY = 'desktop-room-command-consumer-v1'
+const DESKTOP_ROOM_COMMAND_INTERVAL_MS = 60_000
+const DESKTOP_ROOM_COMMAND_PUSH_DEBOUNCE_MS = 250
+let desktopRoomCommandConsumerId = ''
+let desktopRoomCommandConsumerPromise = null
+let desktopRoomCommandTimer = null
+let desktopRoomCommandRunning = false
+let desktopRoomCommandDisposed = false
+let desktopRoomCommandPushUnsub = null
+let desktopRoomCommandPushTimer = null
+let desktopRoomCommandRerun = false
+const desktopRoomCommandPendingConnections = new Set()
+const desktopRoomCommandRetentions = new Map()
 
 const HOSTED_ROOM_OUTBOX_KEY = 'hosted-room-outbox-v1'
 const HOSTED_ROOM_SYNC_INTERVAL_MS = 5000
@@ -1242,6 +1255,68 @@ function mergeRemoteGroupChatSnapshotIntoRooms(
   return rooms
 }
 
+function currentDesktopRoomCoordinatorId() {
+  if (!desktopRoomCommandConsumerId) {
+    desktopRoomCommandConsumerId = `desktop:${groupChatEntryId()}`
+    try {
+      Promise.resolve(
+        pluginCtx?.storage?.set?.(DESKTOP_ROOM_COMMAND_CONSUMER_KEY, desktopRoomCommandConsumerId)
+      ).catch(() => undefined)
+    } catch {
+      /* storage unavailable: this window still owns rooms it creates */
+    }
+  }
+  return desktopRoomCommandConsumerId
+}
+
+async function ensureDesktopRoomCommandConsumerId() {
+  if (desktopRoomCommandConsumerId) return desktopRoomCommandConsumerId
+  if (desktopRoomCommandConsumerPromise) return desktopRoomCommandConsumerPromise
+
+  desktopRoomCommandConsumerPromise = (async () => {
+    let stored = ''
+    try {
+      stored = String((await pluginCtx?.storage?.get?.(DESKTOP_ROOM_COMMAND_CONSUMER_KEY)) || '').trim()
+    } catch {
+      stored = ''
+    }
+    if (stored) {
+      desktopRoomCommandConsumerId = stored
+      return stored
+    }
+    return currentDesktopRoomCoordinatorId()
+  })().finally(() => {
+    desktopRoomCommandConsumerPromise = null
+  })
+
+  return desktopRoomCommandConsumerPromise
+}
+
+function hasDesktopRoomExecutionEvidence(room) {
+  return (
+    Object.keys(room?.sessions || {}).length > 0 ||
+    Object.keys(room?.sessionOwners || {}).length > 0
+  )
+}
+
+function desktopRoomCoordinatorId(room, { migrate = false } = {}) {
+  const stored = String(room?.desktopCoordinatorId || '').trim()
+  if (stored) return stored
+  return migrate && hasDesktopRoomExecutionEvidence(room)
+    ? currentDesktopRoomCoordinatorId()
+    : null
+}
+
+function boundedDesktopCommandSettled(value, limit = 128) {
+  return Object.fromEntries(
+    Object.entries(value && typeof value === 'object' ? value : {})
+      .map(([id, at]) => [String(id), Math.max(0, Number(at || 0))])
+      .filter(([id]) => id)
+      .sort(([, left], [, right]) => right - left)
+      .slice(0, limit)
+  )
+}
+
 function durableGroupChatRooms(all = $groupChats.get()) {
   const durable = {}
 
@@ -1270,6 +1345,11 @@ function durableGroupChatRooms(all = $groupChats.get()) {
       // name-keyed identity — same field updateGroupChat's inline map
       // already carries.
       roomId: typeof room.roomId === 'string' && room.roomId ? room.roomId : null,
+      desktopCoordinatorId:
+        typeof room.desktopCoordinatorId === 'string' && room.desktopCoordinatorId
+          ? room.desktopCoordinatorId
+          : null,
+      desktopCommandSettled: boundedDesktopCommandSettled(room.desktopCommandSettled),
       hosted: groupChatHostedGateway(room) || null,
       hostedEpoch: groupChatHostedEpoch(room) || null,
       hostedConnectionId:
@@ -1310,6 +1390,8 @@ function hydratePersistedGroupChatRooms(value) {
       holds: room.holds && typeof room.holds === 'object' ? room.holds : {},
       members: Array.isArray(room.members) ? room.members : [],
       roomId: typeof room.roomId === 'string' && room.roomId ? room.roomId : null,
+      desktopCoordinatorId: desktopRoomCoordinatorId(room, { migrate: true }),
+      desktopCommandSettled: boundedDesktopCommandSettled(room.desktopCommandSettled),
       hosted: groupChatHostedGateway(room) || null,
       hostedEpoch: groupChatHostedEpoch(room) || null,
       hostedConnectionId:
@@ -1876,6 +1958,276 @@ async function groupChatSyncTargetConnections() {
     }
   }
   return [...targets]
+}
+
+function desktopRoomEntry(roomId, descriptors) {
+  const descriptor = (descriptors || []).find(room => room.roomId === roomId)
+  if (!descriptor) return null
+  const room = $groupChats.get()[descriptor.name]
+  return room && !groupChatHostedGateway(room) ? [descriptor.name, room] : null
+}
+
+function desktopCommandEligibleRooms(connectionIds) {
+  const known = new Set((connectionIds || []).map(value => String(value || '')))
+  const coordinator = String(desktopRoomCommandConsumerId || '')
+  return Object.fromEntries(
+    Object.entries($groupChats.get()).filter(([, room]) => {
+      if (groupChatHostedGateway(room) || room?.tombstone) return false
+      if (!coordinator || String(room?.desktopCoordinatorId || '') !== coordinator) return false
+      const members = Array.isArray(room?.members) ? room.members : []
+      if (!members.length) return false
+      return members.every(member => {
+        if (member?.sourceMissing) return false
+        const connectionId = String(member?.route?.connectionId || member?.connectionId || '')
+        return !connectionId || known.has(connectionId)
+      })
+    })
+  )
+}
+
+function retryableDesktopRoomCommand(message) {
+  const error = new Error(message)
+  error.retryable = true
+  return error
+}
+
+async function waitForDesktopRoomCommandSettlement(group, commandId) {
+  while (!desktopRoomCommandDisposed) {
+    const room = $groupChats.get()[group]
+    if (!room) throw new Error('This group chat is no longer available.')
+    if (room?.desktopCommandSettled?.[commandId]) return true
+    if (!room.running) return false
+    await new Promise(resolve => setTimeout(resolve, 250))
+  }
+  throw retryableDesktopRoomCommand('Hermes Desktop closed before the group chat settled.')
+}
+
+async function executeDesktopRoomCommand(command, descriptors) {
+  const roomId = String(command?.room_id || '')
+  const entry = desktopRoomEntry(roomId, descriptors)
+  if (!entry) throw new Error('This room is no longer available on this Desktop.')
+
+  const [group, room] = entry
+  const cached = cachedUnionRoster()
+  const roster = Array.isArray(cached?.profiles) ? cached.profiles : $lastRoster.get()
+  const members = groupChatMemberBots(group, roster, $botMeta.get())
+
+  if (command.action === 'send') {
+    const liveRoster = (Array.isArray(roster) ? roster : []).filter(bot => !bot?.ghost)
+    const durableMembers = Array.isArray(room?.members) ? room.members : []
+    const completeRoster = durableMembers.every(descriptor => {
+      const resolved = resolveLegacyMemberDescriptor(descriptor, liveRoster)
+      return liveRoster.some(bot => botRosterKey(bot) === botRosterKey(resolved))
+    })
+    if (
+      !members.length ||
+      !completeRoster ||
+      members.some(member => !botSourceStatus(member).available)
+    ) {
+      throw retryableDesktopRoomCommand('Waiting for every Bot in this room to reconnect.')
+    }
+    try {
+      await Promise.all(
+        members.map(member => requestForBot(member, 'profiles.describe', { name: member.name }))
+      )
+    } catch {
+      // Cached roster reachability can lag a socket failure by a few seconds.
+      // Probe only when a real messaging command arrives; never ACK a partial
+      // room based on stale green rows.
+      throw retryableDesktopRoomCommand('Waiting for every Bot in this room to reconnect.')
+    }
+    const message = String(command?.payload?.message || '').trim()
+    if (!message) throw new Error('The room message is empty.')
+    let thread = null
+    while (!desktopRoomCommandDisposed) {
+      thread = sendToGroupChat(group, members, message, null, [], {
+        entryId: String(command.command_id || ''),
+        userName: String(command?.payload?.actor_display_name || 'Messaging')
+      })
+      if (!thread) throw new Error('The group chat could not accept the message.')
+      if (await waitForDesktopRoomCommandSettlement(group, String(command.command_id || ''))) {
+        return { room_name: group, thread_id: thread }
+      }
+      // A newer local turn may have superseded this thread. Once that drive
+      // settles, re-enter through the same command id so no user row is added.
+    }
+    throw retryableDesktopRoomCommand('Hermes Desktop closed before the group chat settled.')
+  }
+
+  if (command.action === 'stop') {
+    if (room?.desktopCommandSettled?.[String(command.command_id || '')]) {
+      return { room_name: group, stopped: true }
+    }
+    const latestThread = [...(Array.isArray(room?.log) ? room.log : [])]
+      .reverse()
+      .find(item => item?.thread)?.thread || null
+    await stopGroupThread(group, latestThread, members)
+    updateGroupChat(group, current => {
+      current.desktopCommandSettled = boundedDesktopCommandSettled({
+        ...(current.desktopCommandSettled || {}),
+        [String(command.command_id || '')]: Date.now()
+      })
+      return current
+    })
+    return { room_name: group, stopped: true }
+  }
+
+  throw new Error('Unsupported room command.')
+}
+
+async function desktopRoomCommandConnections() {
+  const byConnection = new Map()
+  if (typeof host.profileRoutes === 'function') {
+    try {
+      const routes = await host.profileRoutes()
+      for (const route of Array.isArray(routes) ? routes : []) {
+        const profile = String(route?.targetProfile || route?.profile || '')
+        const connectionId = String(route?.connectionId || '')
+        if (profile === 'default' && !byConnection.has(connectionId)) {
+          byConnection.set(connectionId, route)
+        }
+      }
+    } catch {
+      /* active route below remains a safe compatibility fallback */
+    }
+  }
+
+  const active = String(groupChatSyncConnectionId() || '')
+  if (!byConnection.has(active)) {
+    byConnection.set(active, { connectionId: active, targetProfile: 'default' })
+  }
+  return [...byConnection.entries()].map(([id, route]) => ({ id, route }))
+}
+
+function syncDesktopRoomCommandRetention(connections) {
+  if (typeof host.retainProfileSocket !== 'function') return
+  const live = new Set(connections.map(connection => connection.id))
+  for (const [id, release] of [...desktopRoomCommandRetentions]) {
+    if (!live.has(id)) {
+      desktopRoomCommandRetentions.delete(id)
+      try { release() } catch { /* teardown stays best-effort */ }
+    }
+  }
+  if (desktopRoomCommandDisposed) return
+  for (const connection of connections) {
+    if (!desktopRoomCommandRetentions.has(connection.id)) {
+      desktopRoomCommandRetentions.set(
+        connection.id,
+        host.retainProfileSocket(connection.route)
+      )
+    }
+  }
+}
+
+function releaseDesktopRoomCommandRetention() {
+  for (const release of desktopRoomCommandRetentions.values()) {
+    try { release() } catch { /* teardown stays best-effort */ }
+  }
+  desktopRoomCommandRetentions.clear()
+}
+
+function scheduleDesktopRoomCommandPump(connectionId = null) {
+  if (desktopRoomCommandDisposed || typeof setTimeout !== 'function') return
+  desktopRoomCommandPendingConnections.add(connectionId === null ? '*' : String(connectionId))
+  if (desktopRoomCommandPushTimer !== null) return
+  desktopRoomCommandPushTimer = setTimeout(() => {
+    desktopRoomCommandPushTimer = null
+    const pending = new Set(desktopRoomCommandPendingConnections)
+    desktopRoomCommandPendingConnections.clear()
+    void runDesktopRoomCommandPump(pending.has('*') ? null : pending)
+  }, DESKTOP_ROOM_COMMAND_PUSH_DEBOUNCE_MS)
+}
+
+async function runDesktopRoomCommandPump(targetConnectionIds = null) {
+  if (desktopRoomCommandDisposed) return
+  if (desktopRoomCommandRunning) {
+    desktopRoomCommandRerun = true
+    if (targetConnectionIds === null) {
+      desktopRoomCommandPendingConnections.add('*')
+    } else {
+      for (const id of targetConnectionIds) desktopRoomCommandPendingConnections.add(String(id))
+    }
+    return
+  }
+  desktopRoomCommandRunning = true
+  try {
+    const client = await import('./desktop-room-command-client.js')
+    await ensureDesktopRoomCommandConsumerId()
+    const connections = await desktopRoomCommandConnections()
+    const connectionIds = connections.map(connection => connection.id)
+    const rooms = desktopCommandEligibleRooms(connectionIds)
+    if (!Object.keys(rooms).length) {
+      syncDesktopRoomCommandRetention([])
+      return
+    }
+    syncDesktopRoomCommandRetention(connections)
+    const selected = targetConnectionIds === null
+      ? connections
+      : connections.filter(connection => targetConnectionIds.has(connection.id))
+    await client.runDesktopRoomCommandCycle({
+      routes: selected.map(connection => connection.route),
+      consumerId: desktopRoomCommandConsumerId,
+      rooms,
+      request: (route, method, params) =>
+        typeof host.requestProfile === 'function'
+          ? host.requestProfile(route, method, params)
+          : groupChatSyncRequest({ connectionId: route.connectionId }, method, params),
+      execute: executeDesktopRoomCommand,
+      shouldContinue: () => !desktopRoomCommandDisposed
+    })
+  } catch {
+    // A reconnect or older backend simply leaves durable commands pending.
+  } finally {
+    desktopRoomCommandRunning = false
+    if (desktopRoomCommandRerun && !desktopRoomCommandDisposed) {
+      desktopRoomCommandRerun = false
+      const pending = [...desktopRoomCommandPendingConnections]
+      desktopRoomCommandPendingConnections.clear()
+      if (!pending.length || pending.includes('*')) {
+        scheduleDesktopRoomCommandPump()
+      } else {
+        for (const connectionId of pending) scheduleDesktopRoomCommandPump(connectionId)
+      }
+    }
+  }
+}
+
+function startDesktopRoomCommandPump() {
+  desktopRoomCommandDisposed = false
+  if (typeof setInterval !== 'function' || desktopRoomCommandTimer !== null) return
+  void ensureDesktopRoomCommandConsumerId().then(() => {
+    if (desktopRoomCommandDisposed || desktopRoomCommandTimer !== null) return
+    void runDesktopRoomCommandPump()
+    desktopRoomCommandTimer = setInterval(
+      () => void runDesktopRoomCommandPump(),
+      DESKTOP_ROOM_COMMAND_INTERVAL_MS
+    )
+    if (desktopRoomCommandPushUnsub === null && typeof host.onEvent === 'function') {
+      desktopRoomCommandPushUnsub = host.onEvent(
+        'desktop_rooms.commands.pending',
+        event => scheduleDesktopRoomCommandPump(event?.connectionId ?? null)
+      )
+    }
+  })
+}
+
+function stopDesktopRoomCommandPump() {
+  desktopRoomCommandDisposed = true
+  desktopRoomCommandRerun = false
+  desktopRoomCommandPendingConnections.clear()
+  releaseDesktopRoomCommandRetention()
+  if (desktopRoomCommandTimer !== null && typeof clearInterval === 'function') {
+    clearInterval(desktopRoomCommandTimer)
+    desktopRoomCommandTimer = null
+  }
+  if (desktopRoomCommandPushTimer !== null && typeof clearTimeout === 'function') {
+    clearTimeout(desktopRoomCommandPushTimer)
+    desktopRoomCommandPushTimer = null
+  }
+  if (desktopRoomCommandPushUnsub !== null) {
+    try { desktopRoomCommandPushUnsub() } catch { /* older host disposer */ }
+    desktopRoomCommandPushUnsub = null
+  }
 }
 
 async function flushGroupChatServerSync(connectionId) {
@@ -7599,6 +7951,14 @@ function updateGroupChat(group, mutate, { sync = true } = {}) {
         members: Array.isArray(room.members) ? room.members : [],
         // Immutable room identity: the member-session title for new rooms.
         roomId: typeof room.roomId === 'string' && room.roomId ? room.roomId : null,
+        // Local execution authority. This deliberately never enters the
+        // gateway projection, so a second Desktop cannot claim the room just
+        // because it can read the shared transcript.
+        desktopCoordinatorId:
+          typeof room.desktopCoordinatorId === 'string' && room.desktopCoordinatorId
+            ? room.desktopCoordinatorId
+            : null,
+        desktopCommandSettled: boundedDesktopCommandSettled(room.desktopCommandSettled),
         hosted: groupChatHostedGateway(room) || null,
         hostedEpoch: groupChatHostedEpoch(room) || null,
         hostedConnectionId:
@@ -7694,6 +8054,11 @@ async function disbandGroupChat(group, members) {
           sessionOwners: room.sessionOwners || {},
           members: Array.isArray(room.members) ? room.members : [],
           roomId: typeof room.roomId === 'string' && room.roomId ? room.roomId : null,
+          desktopCoordinatorId:
+            typeof room.desktopCoordinatorId === 'string' && room.desktopCoordinatorId
+              ? room.desktopCoordinatorId
+              : null,
+          desktopCommandSettled: boundedDesktopCommandSettled(room.desktopCommandSettled),
           hosted: groupChatHostedGateway(room) || null,
           hostedEpoch: groupChatHostedEpoch(room) || null,
           image: room.image || null,
@@ -7860,7 +8225,7 @@ function normalizeGroupChatText(text) {
   return trimmed === GROUP_EMPTY_SENTINEL ? GROUP_EMPTY_FRIENDLY : trimmed
 }
 
-function appendGroupChatEntry(group, from, text, thread, images) {
+function appendGroupChatEntry(group, from, text, thread, images, { entryId = '' } = {}) {
   // Once a gateway owns the room, its monotonic log is authoritative. Late
   // renderer harvest/clarify callbacks from the pre-hosted epoch must not
   // mutate the read mirror after ownership moves.
@@ -7868,12 +8233,20 @@ function appendGroupChatEntry(group, from, text, thread, images) {
     return null
   }
 
+  const priorLog = ($groupChats.get()[group] || {}).log || []
+  const externalId = String(entryId || '').trim()
+  if (externalId) {
+    const existing = priorLog.find(candidate => candidate?.id === externalId)
+    if (existing) return existing
+  }
+
   const entry = {
-    id: groupChatEntryId(),
+    id: externalId || groupChatEntryId(),
     at: Date.now(),
     from,
     text: normalizeGroupChatText(text),
-    thread: thread || 'legacy'
+    thread: thread || 'legacy',
+    ...(externalId ? { external: true } : {})
   }
 
   if (Array.isArray(images) && images.length) {
@@ -7886,7 +8259,6 @@ function appendGroupChatEntry(group, from, text, thread, images) {
   // loop both committing the same member reply) lands back-to-back and
   // byte-identical. Drop the echo instead of flooding the room. User
   // entries and non-adjacent repeats are never touched.
-  const priorLog = ($groupChats.get()[group] || {}).log || []
   const lastEntry = priorLog[priorLog.length - 1]
 
   if (isDuplicateGroupAppend(lastEntry, from, entry.text, entry.thread)) {
@@ -9083,14 +9455,32 @@ async function runGroupChatRounds(group, members, thread) {
     // the round cap ended the drive, not consensus. (#94478)
     exitKind = 'capped'
   } finally {
-    if (isCurrent()) {
+    const current = isCurrent()
+    const externalIds = (Array.isArray(($groupChats.get()[group] || {}).log)
+      ? $groupChats.get()[group].log
+      : [])
+      .filter(entry => entry?.external && groupThreadOf(entry) === thread && entry?.id)
+      .map(entry => String(entry.id))
+
+    if (current) {
       recordGroupActivity(group, { kind: exitKind, member: null, thread })
+    }
+    if (current || externalIds.length) {
       updateGroupChat(group, r => {
-        r.running = false
-        r.turn = null
+        if (current) {
+          r.running = false
+          r.turn = null
+        }
+        const settled = { ...(r.desktopCommandSettled || {}) }
+        for (const id of externalIds) {
+          settled[id] = Date.now()
+        }
+        r.desktopCommandSettled = boundedDesktopCommandSettled(settled)
         return r
       })
+    }
 
+    if (current) {
       // #89545: the loop's harvest pass only ran at the top of each round of
       // an ACTIVE loop — a member whose turn timed out after the final round
       // stayed stranded until the user's NEXT send. Poll for the late reply
@@ -9147,13 +9537,52 @@ async function harvestStrandedUntilSettled(group, members, thread) {
  *  Appends, bumps the room epoch (supersedes any running loop at its next
  *  member boundary), and starts the turn drive for the target thread.
  *  Returns the thread id the message landed in. */
-function sendToGroupChat(group, members, text, thread, images) {
+function sendToGroupChat(group, members, text, thread, images, options = {}) {
   const trimmed = String(text || '').trim()
   const attached = Array.isArray(images) ? images.filter(img => img && img.data) : []
-  const hosted = groupChatHostedGateway($groupChats.get()[group])
+  let room = $groupChats.get()[group]
+  const hosted = groupChatHostedGateway(room)
+  const externalId = String(options?.entryId || '').trim()
+  const userName = String(options?.userName || 'You').trim().slice(0, 128) || 'You'
 
   if ((!trimmed && !attached.length) || !members.length) {
     return null
+  }
+
+  if (!hosted && !room?.desktopCoordinatorId) {
+    room = updateGroupChat(group, current => {
+      current.desktopCoordinatorId = currentDesktopRoomCoordinatorId()
+      return current
+    })
+  }
+
+  if (externalId) {
+    const existing = (Array.isArray(room?.log) ? room.log : []).find(entry => entry?.id === externalId)
+    if (existing) {
+      const existingThread = existing.thread || 'legacy'
+      if (room?.desktopCommandSettled?.[externalId] || room?.running) {
+        return existingThread
+      }
+
+      // The visible entry survived but its ACK did not. Re-drive the SAME
+      // thread without appending a second user message. A settled marker is
+      // written only when the drive finishes, so a crash between append and
+      // launch remains recoverable while a completed turn stays idempotent.
+      updateGroupChat(group, current => {
+        current.members = durableGroupChatMembers(members)
+        current.epoch = (current.epoch || 0) + 1
+        current.running = true
+        return current
+      })
+      recordGroupActivity(group, { kind: 'queued', member: userName, thread: existingThread })
+      void runGroupChatRounds(group, members, existingThread).catch(() => {
+        updateGroupChat(group, current => {
+          current.running = false
+          return current
+        })
+      })
+      return existingThread
+    }
   }
 
   if (hosted) {
@@ -9174,7 +9603,14 @@ function sendToGroupChat(group, members, text, thread, images) {
     room.members = durableGroupChatMembers(members)
     return room
   })
-  const sent = appendGroupChatEntry(group, { kind: 'user', name: 'You' }, trimmed, target, attached)
+  const sent = appendGroupChatEntry(
+    group,
+    { kind: 'user', name: userName },
+    trimmed,
+    target,
+    attached,
+    { entryId: externalId }
+  )
 
   const wasRunning = ($groupChats.get()[group] || {}).running === true
 
@@ -13295,9 +13731,14 @@ function CreateGroupChatDialog({ open, roster, onClose, onCreated }) {
         await saveBotMeta(bot, groupMembershipPatch(botRosterMeta(bot, allMeta), groupName, true))
       }
 
+      const desktopCoordinator = hostedRoom
+        ? null
+        : await ensureDesktopRoomCommandConsumerId()
+
       updateGroupChat(groupName, room => {
         room.members = roomMembers
         room.roomId = roomId
+        room.desktopCoordinatorId = desktopCoordinator
 
         if (hostedRoom) {
           room.hosted = hostedRoom.authority_gateway_id
@@ -16361,11 +16802,13 @@ export default {
     // The cross-connection relay rides every gateway socket this Desktop
     // holds: roster sync + envelope drain/deliver/reply loops.
     startBotRelay()
+    startDesktopRoomCommandPump()
     // Disabling the plugin (or a hot reload) must actually stop the clock —
     // before this, the rAF loop + 1Hz document scan ran until app restart.
     if (typeof ctx.onDispose === 'function') {
       ctx.onDispose(stopFaceClock)
       ctx.onDispose(stopBotRelay)
+      ctx.onDispose(stopDesktopRoomCommandPump)
     }
 
     // @-mention autocomplete: typing "@rese…" in ANY composer offers the
@@ -16483,10 +16926,15 @@ export default {
     try {
       Promise.resolve(ctx.storage?.get?.('group-chats'))
         .then(async value => {
+          await ensureDesktopRoomCommandConsumerId()
           if (value && typeof value === 'object' && !Array.isArray(value)) {
             const rooms = hydratePersistedGroupChatRooms(value)
 
             $groupChats.set({ ...rooms, ...$groupChats.get() })
+            // Persist one-time authority migration for legacy rooms that
+            // already own member sessions. Without this write the same room
+            // would mint a fresh coordinator after every relaunch.
+            await persistGroupChatRooms($groupChats.get())
 
             // #93492: annotate rows orphaned before this build (their
             // connection was deleted while an older Desktop ran, so no

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -586,6 +586,10 @@ const HOSTED_ROOM_OUTBOX_KEY = 'hosted-room-outbox-v1'
 const HOSTED_ROOM_SYNC_INTERVAL_MS = 5000
 const $hostedRoomCapabilities = atom({})
 const $hostedRoomOutbox = atom({ version: 1, commands: [] })
+const groupTransientAttachments = new Map()
+const groupAttachmentDataCache = new Map()
+let groupAttachmentDataCacheChars = 0
+const GROUP_ATTACHMENT_CACHE_CHARS = 50_000_000
 let hostedRoomSyncTimer = null
 let hostedRoomSyncRunning = false
 let hostedRoomSyncDisposed = false
@@ -758,7 +762,26 @@ function groupChatSyncSnapshot(all = $groupChats.get(), deleted = {}) {
       },
       text: String(entry?.text || '').slice(0, GROUP_CHAT_SYNC_TEXT_CHARS),
       at: Number(entry?.at || 0),
-      ...(entry?.thread ? { thread: String(entry.thread).slice(0, 128) } : {})
+      ...(entry?.thread ? { thread: String(entry.thread).slice(0, 128) } : {}),
+      ...(Array.isArray(entry?.images)
+        ? {
+            images: entry.images
+              .filter(attachment =>
+                /^att_[0-9a-f]{32}$/.test(String(attachment?.attachment_id || ''))
+              )
+              .slice(0, 8)
+              .map(attachment => ({
+                attachment_id: String(attachment.attachment_id),
+                kind: ['image', 'pdf', 'file'].includes(attachment.kind) ? attachment.kind : 'file',
+                name: String(attachment.name || 'attachment').slice(0, 255),
+                size: Math.max(0, Number(attachment.size || 0)),
+                mime: String(attachment.mime || 'application/octet-stream').slice(0, 127),
+                ...(attachment.connectionId
+                  ? { connectionId: String(attachment.connectionId).slice(0, 128) }
+                  : {})
+              }))
+          }
+        : {})
     }))
     const compact = {
       name: String(name).slice(0, 64),
@@ -1749,6 +1772,17 @@ async function refreshHostedRooms() {
         const source = sources.get(connectionId)
         const label = source?.label || source?.connectionLabel || connectionId
         const replayState = replay.state
+        const replayMessages = (replayState.messages || []).map(message => ({
+          ...message,
+          ...(Array.isArray(message.images) && message.images.length
+            ? {
+                images: message.images.map(attachment => ({
+                  ...attachment,
+                  connectionId
+                }))
+              }
+            : {})
+        }))
 
         updateGroupChat(existingName, room => {
           const authoritative = applyHostedRoomAuthority(room, roomState)
@@ -1757,7 +1791,7 @@ async function refreshHostedRooms() {
             ...authoritative,
             roomId,
             members: hostedMemberDescriptors(roomState, connectionId, label),
-            log: mergeGroupChatSyncEntries(room.log || [], replayState.messages || []),
+            log: mergeGroupChatSyncEntries(room.log || [], replayMessages),
             hostedConnectionId: connectionId,
             hostedSeq: replayState.cursor,
             hostedStatus: client.deriveFriendlyHostedRoomStatus(replayState),
@@ -1870,68 +1904,193 @@ async function enqueueHostedRoomCommand(command) {
   await dispatchHostedRoomOutbox()
 }
 
-function hostedAttachmentRef(eventId, index, memberId) {
-  const seed = `${eventId}-${index}-${memberId}`.replace(/[^A-Za-z0-9._:-]/g, '-').slice(0, 220)
-  return `staged:${seed || `attachment-${index}`}`
-}
-
 function attachmentMime(attachment) {
-  if (attachment?.mime) return String(attachment.mime)
   const match = /^data:([^;,]+)/i.exec(String(attachment?.data || ''))
-  return match?.[1] || (attachment?.kind === 'pdf' ? 'application/pdf' : attachment?.kind === 'image' ? 'image/png' : 'application/octet-stream')
+  return match?.[1] || String(attachment?.mime || '') || (attachment?.kind === 'pdf' ? 'application/pdf' : attachment?.kind === 'image' ? 'image/png' : 'application/octet-stream')
 }
 
-async function stageHostedAttachments(group, members, eventId, attachments) {
-  const picked = (Array.isArray(attachments) ? attachments : []).slice(0, 8)
-  if (!picked.length) return []
-  const manifests = picked.map(attachment => ({
-    kind: attachment.kind,
-    name: attachment.name || 'attachment',
-    size: Math.max(0, Number(attachment.size || 0)),
-    mime: attachmentMime(attachment),
-    refs: {}
-  }))
+function cacheGroupAttachmentData(key, dataUrl) {
+  const data = String(dataUrl || '')
+  if (!key || !data || data.length > GROUP_ATTACHMENT_CACHE_CHARS) return
+  const prior = groupAttachmentDataCache.get(key)
+  if (prior) groupAttachmentDataCacheChars -= prior.length
+  groupAttachmentDataCache.delete(key)
+  groupAttachmentDataCache.set(key, data)
+  groupAttachmentDataCacheChars += data.length
+  while (groupAttachmentDataCacheChars > GROUP_ATTACHMENT_CACHE_CHARS && groupAttachmentDataCache.size > 1) {
+    const oldest = groupAttachmentDataCache.keys().next().value
+    const removed = groupAttachmentDataCache.get(oldest) || ''
+    groupAttachmentDataCache.delete(oldest)
+    groupAttachmentDataCacheChars -= removed.length
+  }
+}
 
-  for (const member of members) {
-    const { runtime } = await ensureGroupChatSession(group, member)
-    if (!runtime) throw new Error(`${displayName(member, botRosterMeta(member, $botMeta.get()))} is unavailable.`)
-    const memberId = member.name === 'default' ? 'default' : member.name
+async function loadGroupAttachmentData(room, entry, attachment) {
+  if (attachment?.data) return String(attachment.data)
+  const attachmentId = String(attachment?.attachment_id || '')
+  const connectionId = String(attachment?.connectionId || room?.hostedConnectionId || '')
+  const roomId = String(room?.roomId || '')
+  const eventId = String(entry?.id || entry?.eventId || '')
+  if (!/^att_[0-9a-f]{32}$/.test(attachmentId) || !roomId || !eventId) {
+    throw new Error('This attachment is not available from its source.')
+  }
+  const cacheKey = `${connectionId}:${roomId}:${eventId}:${attachmentId}`
+  const cached = groupAttachmentDataCache.get(cacheKey)
+  if (cached) return cached
+  const result = await groupChatSyncRequest(
+    { connectionId },
+    'groups.attachment.read',
+    {
+      purpose: 'viewer',
+      room_id: roomId,
+      event_id: eventId,
+      attachment_id: attachmentId
+    }
+  )
+  const stored = result?.attachment
+  if (
+    stored?.attachment_id !== attachmentId ||
+    stored?.kind !== attachment.kind ||
+    stored?.name !== attachment.name ||
+    stored?.size !== attachment.size ||
+    stored?.mime !== attachment.mime ||
+    typeof result?.content_base64 !== 'string'
+  ) {
+    throw new Error('This attachment failed its integrity check.')
+  }
+  const dataUrl = `data:${attachment.mime};base64,${result.content_base64}`
+  cacheGroupAttachmentData(cacheKey, dataUrl)
+  return dataUrl
+}
 
-    for (let index = 0; index < picked.length; index++) {
-      const attachment = picked[index]
-      if (attachment.kind === 'pdf') {
-        await requestForBot(member, 'pdf.attach', {
-          session_id: runtime,
-          content_base64: attachment.data,
-          filename: attachment.name || 'attachment.pdf'
-        })
-      } else if (attachment.kind === 'file') {
-        await requestForBot(member, 'file.attach', {
-          session_id: runtime,
-          data_url: attachment.data,
-          name: attachment.name || 'attachment'
-        })
-      } else {
-        await requestForBot(member, 'image.attach_bytes', {
-          session_id: runtime,
-          content_base64: attachment.data,
-          filename: attachment.name || 'attachment.png'
-        })
+function downloadGroupAttachment(dataUrl, name) {
+  if (typeof document === 'undefined') return false
+  const link = document.createElement('a')
+  link.href = dataUrl
+  link.download = String(name || 'attachment')
+  link.style.display = 'none'
+  document.body.appendChild(link)
+  link.click()
+  link.remove()
+  return true
+}
+
+function GroupAttachmentDisplay({ room, entry, attachment, entryKey, index }) {
+  const [busy, setBusy] = useState(false)
+  const [data, setData] = useState(() => String(attachment?.data || ''))
+  const isImage = attachment?.kind === 'image'
+  const label = String(attachment?.name || (isImage ? 'attached image' : 'attached file'))
+  const canLoad = Boolean(attachment?.attachment_id && (attachment?.connectionId || room?.hostedConnectionId))
+
+  const open = async () => {
+    if (busy || (!data && !canLoad)) return
+    setBusy(true)
+    try {
+      const loaded = data || await loadGroupAttachmentData(room, entry, attachment)
+      if (isImage && !data) {
+        setData(loaded)
+      } else if (!downloadGroupAttachment(loaded, label)) {
+        throw new Error('Download is unavailable in this build.')
       }
-      manifests[index].refs[memberId] = hostedAttachmentRef(eventId, index, memberId)
+    } catch (error) {
+      host.notify?.({
+        kind: 'error',
+        message: String(error?.message || 'This attachment could not be opened.')
+      })
+    } finally {
+      setBusy(false)
     }
   }
 
+  if (isImage && data) {
+    return jsx('button', {
+      type: 'button',
+      className: 'cursor-pointer rounded-md border border-(--ui-stroke-secondary) p-0',
+      title: `Download ${label}`,
+      'aria-label': `Download ${label}`,
+      onClick: () => void open(),
+      children: jsx('img', {
+        src: data,
+        alt: label,
+        className: 'max-h-40 max-w-60 rounded-md object-contain'
+      })
+    }, `${entryKey}:img:${index}`)
+  }
+
+  return jsxs('button', {
+    type: 'button',
+    className:
+      'flex items-center gap-1 rounded-md border border-(--ui-stroke-secondary) px-1.5 py-1 text-[0.65rem] text-(--ui-text-tertiary)',
+    title: canLoad || data ? `${isImage ? 'Load preview for' : 'Download'} ${label}` : label,
+    'aria-label': canLoad || data ? `${isImage ? 'Load preview for' : 'Download'} ${label}` : label,
+    'aria-busy': busy || undefined,
+    disabled: busy || (!data && !canLoad),
+    onClick: () => void open(),
+    children: [
+      jsx(Codicon, {
+        name: attachment?.kind === 'pdf' ? 'file-pdf' : isImage ? 'file-media' : 'file',
+        className: 'text-[0.8rem]'
+      }),
+      jsx('span', { className: 'max-w-48 truncate', children: label }),
+      canLoad || data
+        ? jsx('span', {
+            className: 'text-(--ui-text-quaternary)',
+            children: busy ? 'Loading…' : isImage ? 'Preview' : 'Download'
+          })
+        : null
+    ]
+  }, `${entryKey}:img:${index}`)
+}
+
+function attachmentBase64(attachment) {
+  const value = String(attachment?.data || '')
+  const match = /^data:([^;,]+);base64,([A-Za-z0-9+/=]+)$/i.exec(value)
+  if (!match) throw new Error(`${attachment?.name || 'Attachment'} could not be encoded for upload.`)
+  return { mime: match[1].toLowerCase(), contentBase64: match[2] }
+}
+
+async function stageHostedAttachments(route, roomId, eventId, attachments) {
+  const picked = Array.isArray(attachments) ? attachments : []
+  if (picked.length > 8) throw new Error('A Group Chat message supports at most 8 attachments.')
+  if (!picked.length) return []
+
+  let total = 0
+  const manifests = []
+  for (let index = 0; index < picked.length; index++) {
+    const attachment = picked[index]
+    const encoded = attachmentBase64(attachment)
+    const mime = attachmentMime(attachment).toLowerCase()
+    if (encoded.mime !== mime) throw new Error(`${attachment.name || 'Attachment'} has conflicting MIME metadata.`)
+    total += Math.max(0, Number(attachment.size || 0))
+    if (total > 25_000_000) throw new Error('Attachments exceed the 25MB message limit.')
+    const result = await requestHostedConnection(route, 'groups.attachment.put', {
+      room_id: roomId,
+      upload_id: `${eventId}:upload:${index}`,
+      kind: attachment.kind,
+      name: attachment.name || 'attachment',
+      mime,
+      content_base64: encoded.contentBase64
+    })
+    const stored = result?.attachment
+    if (!stored?.attachment_id) throw new Error(`${attachment.name || 'Attachment'} was not accepted by the room gateway.`)
+    manifests.push({
+      attachment_id: stored.attachment_id,
+      kind: stored.kind,
+      name: stored.name,
+      size: stored.size,
+      mime: stored.mime
+    })
+  }
   return manifests
 }
 
-async function sendHostedGroupChat(group, members, sent, thread, attachments) {
+async function sendHostedGroupChat(group, sent, thread, attachments) {
   const room = $groupChats.get()[group]
   const route = await hostedRouteForRoom(room)
   if (!route) {
     throw new Error('This group is offline. Try again when its gateway reconnects.')
   }
-  const manifests = await stageHostedAttachments(group, members, sent.id, attachments)
+  const manifests = await stageHostedAttachments(route, room.roomId, sent.id, attachments)
   await enqueueHostedRoomCommand({
     commandId: sent.id,
     kind: 'send',
@@ -2094,7 +2253,11 @@ async function waitForDesktopRoomCommandSettlement(group, commandId, signal = nu
   throw retryableDesktopRoomCommand('Hermes Desktop closed before the group chat settled.')
 }
 
-async function executeDesktopRoomCommand(command, descriptors, { signal = null } = {}) {
+async function executeDesktopRoomCommand(
+  command,
+  descriptors,
+  { signal = null, request: commandRequest = null, consumerId = null, route = null } = {}
+) {
   const assertLiveLease = () => {
     if (signal?.aborted) {
       throw retryableDesktopRoomCommand('The command lease moved to another Desktop.')
@@ -2108,12 +2271,15 @@ async function executeDesktopRoomCommand(command, descriptors, { signal = null }
   const [group, room] = entry
   const cached = cachedUnionRoster()
   const roster = Array.isArray(cached?.profiles) ? cached.profiles : $lastRoster.get()
-  const members = groupChatMemberBots(group, roster, $botMeta.get())
+  let members = groupChatMemberBots(group, roster, $botMeta.get())
 
   if (command.action === 'send') {
+    const frozenRecipients = Array.isArray(command?.payload?.recipients) && command.payload.recipients.length
+      ? command.payload.recipients
+      : room?.members
+    members = groupChatBotsFromDescriptors(frozenRecipients, roster)
     const liveRoster = (Array.isArray(roster) ? roster : []).filter(bot => !bot?.ghost)
-    const durableMembers = Array.isArray(room?.members) ? room.members : []
-    const completeRoster = durableMembers.every(descriptor => {
+    const completeRoster = (Array.isArray(frozenRecipients) ? frozenRecipients : []).every(descriptor => {
       const resolved = resolveLegacyMemberDescriptor(descriptor, liveRoster)
       return liveRoster.some(bot => botRosterKey(bot) === botRosterKey(resolved))
     })
@@ -2136,30 +2302,69 @@ async function executeDesktopRoomCommand(command, descriptors, { signal = null }
     }
     assertLiveLease()
     const message = String(command?.payload?.message || '').trim()
-    if (!message) throw new Error('The room message is empty.')
+    const manifest = Array.isArray(command?.payload?.attachments) ? command.payload.attachments : []
+    if (!message && !manifest.length) throw new Error('The room message is empty.')
+    const commandId = String(command.command_id || '')
     const localAbort = new AbortController()
     const onLeaseAbort = () => localAbort.abort('lease-lost')
     signal?.addEventListener?.('abort', onLeaseAbort, { once: true })
     if (signal?.aborted) localAbort.abort('lease-lost')
     activeDesktopRoomCommands.set(roomId, {
-      commandId: String(command.command_id || ''),
+      commandId,
       controller: localAbort
     })
+    const transientAttachments = []
     let thread = null
     try {
+      for (const attachment of manifest) {
+        if (localAbort.signal.aborted) {
+          throw retryableDesktopRoomCommand('The command lease moved to another Desktop.')
+        }
+        const readAttachment = typeof commandRequest === 'function' ? commandRequest : host.request
+        const result = await readAttachment('groups.attachment.read', {
+          room_id: roomId,
+          attachment_id: attachment.attachment_id,
+          purpose: 'desktop-command',
+          event_id: commandId,
+          consumer_id: String(consumerId || desktopRoomCommandConsumerId || ''),
+          lease_token: String(command?.lease_token || ''),
+          authority_token: String(room?.desktopAuthorityToken || '')
+        })
+        if (localAbort.signal.aborted) {
+          throw retryableDesktopRoomCommand('The command lease moved to another Desktop.')
+        }
+        const stored = result?.attachment
+        if (
+          !stored ||
+          stored.attachment_id !== attachment.attachment_id ||
+          stored.kind !== attachment.kind ||
+          stored.name !== attachment.name ||
+          stored.size !== attachment.size ||
+          stored.mime !== attachment.mime ||
+          typeof result?.content_base64 !== 'string'
+        ) {
+          throw new Error('A messaging attachment failed its gateway integrity check.')
+        }
+        transientAttachments.push({
+          ...attachment,
+          connectionId: String(route?.connectionId || ''),
+          data: `data:${attachment.mime};base64,${result.content_base64}`
+        })
+      }
       while (!desktopRoomCommandDisposed) {
         if (localAbort.signal.aborted) {
           throw retryableDesktopRoomCommand('The command lease moved to another Desktop.')
         }
-        thread = sendToGroupChat(group, members, message, null, [], {
-          entryId: String(command.command_id || ''),
-          userName: String(command?.payload?.actor_display_name || 'Messaging')
+        thread = sendToGroupChat(group, members, message, null, transientAttachments, {
+          entryId: commandId,
+          userName: String(command?.payload?.actor_display_name || 'Messaging'),
+          omitAttachmentDataFromLog: true
         })
         if (!thread) throw new Error('The group chat could not accept the message.')
         if (
           await waitForDesktopRoomCommandSettlement(
             group,
-            String(command.command_id || ''),
+            commandId,
             localAbort.signal
           )
         ) {
@@ -2178,6 +2383,7 @@ async function executeDesktopRoomCommand(command, descriptors, { signal = null }
       }
       throw error
     } finally {
+      groupTransientAttachments.delete(commandId)
       signal?.removeEventListener?.('abort', onLeaseAbort)
       if (activeDesktopRoomCommands.get(roomId)?.controller === localAbort) {
         activeDesktopRoomCommands.delete(roomId)
@@ -7736,6 +7942,21 @@ function groupChatMemberBots(group, roster, metaByName) {
   return [...local, ...remote]
 }
 
+function groupChatBotsFromDescriptors(descriptors, roster) {
+  const members = []
+  const seen = new Set()
+  for (const descriptor of Array.isArray(descriptors) ? descriptors : []) {
+    const resolved = resolveLegacyMemberDescriptor(descriptor, roster)
+    const key = botRosterKey(resolved)
+    if (!key || seen.has(key)) continue
+    seen.add(key)
+    members.push(
+      (roster || []).find(bot => !bot?.ghost && botRosterKey(bot) === key) || resolved
+    )
+  }
+  return members
+}
+
 /** A stored member descriptor, resolved against the live roster when its
  *  `name` is not a real slug (#92794). Exact key matches pass through
  *  untouched; only a descriptor whose key matches NO roster row is re-tried
@@ -9484,7 +9705,10 @@ async function runGroupChatRounds(group, members, thread) {
         // carry images today, but flatMap keeps this future-proof) get staged
         // into the member's session so the model sees the pixels, not just
         // the transcript's [attached image: …] marker.
-        const deltaImages = delta.flatMap(e => (Array.isArray(e.images) ? e.images : []))
+        const deltaImages = delta.flatMap(e => {
+          const transient = e?.id ? groupTransientAttachments.get(String(e.id)) : null
+          return Array.isArray(transient) ? transient : Array.isArray(e.images) ? e.images : []
+        })
 
         // Surface WHO is on turn (runtime-only, like running/epoch) so the
         // room shows "Radar is thinking…" instead of a generic working line —
@@ -9807,6 +10031,10 @@ function sendToGroupChat(group, members, text, thread, images, options = {}) {
         return existingThread
       }
 
+      if (options?.omitAttachmentDataFromLog && attached.length) {
+        groupTransientAttachments.set(externalId, attached)
+      }
+
       // The visible entry survived but its ACK did not. Re-drive the SAME
       // thread without appending a second user message. A settled marker is
       // written only when the drive finishes, so a crash between append and
@@ -9828,15 +10056,13 @@ function sendToGroupChat(group, members, text, thread, images, options = {}) {
     }
   }
 
-  if (hosted) {
-    host.notify?.({
-      kind: 'info',
-      message: `“${group}” runs on ${hosted}. Sending to hosted rooms isn't available in this build yet.`
-    })
-    return null
-  }
-
   const target = thread || mintGroupThreadId()
+
+  if (hosted) {
+    const sent = { id: externalId || groupChatEntryId(), text: trimmed }
+    recordGroupActivity(group, { kind: 'queued', member: userName, thread: target })
+    return sendHostedGroupChat(group, sent, target, attached).then(() => target)
+  }
 
   $groupNeedsYou.set({ ...$groupNeedsYou.get(), [group]: false })
   // Refresh the durable room roster on every send. This backfills rooms made
@@ -9846,14 +10072,20 @@ function sendToGroupChat(group, members, text, thread, images, options = {}) {
     room.members = durableGroupChatMembers(members)
     return room
   })
+  const loggedAttachments = options?.omitAttachmentDataFromLog
+    ? attached.map(({ data: _data, ...metadata }) => metadata)
+    : attached
   const sent = appendGroupChatEntry(
     group,
     { kind: 'user', name: userName },
     trimmed,
     target,
-    attached,
+    loggedAttachments,
     { entryId: externalId }
   )
+  if (sent?.id && options?.omitAttachmentDataFromLog && attached.length) {
+    groupTransientAttachments.set(String(sent.id), attached)
+  }
 
   const wasRunning = ($groupChats.get()[group] || {}).running === true
 
@@ -14623,28 +14855,30 @@ function updateGroupComposerDraft(key, mutate) {
   return next
 }
 
-function restoreGroupComposerDraft(key, expectedRevision, snapshot) {
-  const current = groupComposerDraftSnapshot(key)
-
-  if (current.revision !== expectedRevision) {
-    return null
-  }
-
-  const restored = {
-    ...snapshot,
-    pendingAttachments: Object.fromEntries(
-      Object.entries(snapshot.pendingAttachments || {}).map(([thread, attachments]) => [
-        thread,
-        [...(attachments || [])]
-      ])
-    ),
-    replies: { ...(snapshot.replies || {}) },
-    revision: current.revision + 1
-  }
-
-  groupComposerDrafts.set(key, restored)
-
-  return restored
+function completeGroupComposerSend(key, before, attachments, thread = null) {
+  const submitted = new Set(Array.isArray(attachments) ? attachments : [])
+  return updateGroupComposerDraft(key, current => {
+    const pending = { ...(current.pendingAttachments || {}) }
+    const slot = thread || 'main'
+    pending[slot] = (pending[slot] || []).filter(item => !submitted.has(item))
+    if (thread) {
+      return {
+        ...current,
+        pendingAttachments: pending,
+        replies: {
+          ...(current.replies || {}),
+          [thread]: current.replies?.[thread] === before.replies?.[thread]
+            ? ''
+            : current.replies?.[thread] || ''
+        }
+      }
+    }
+    return {
+      ...current,
+      main: current.main === before.main ? '' : current.main,
+      pendingAttachments: pending
+    }
+  })
 }
 
 function clearGroupComposerDraft(key) {
@@ -14711,6 +14945,7 @@ function GroupChatWorkspace({ group, members, onBack, visible = true }) {
     }))
   const [confirmDisband, setConfirmDisband] = useState(false)
   const [settingsOpen, setSettingsOpen] = useState(false)
+  const [sendingComposer, setSendingComposer] = useState(null)
   // Click-to-disambiguate: which log entry is showing its speaker's full
   // @handle (the roster's name-device form when names collide across
   // connections). Naturally every speaker just shows its display name.
@@ -15010,58 +15245,66 @@ function GroupChatWorkspace({ group, members, onBack, visible = true }) {
     const text = draft.trim()
     const images = imagesFor(null)
 
-    if (!text && !images.length) {
+    if ((!text && !images.length) || sendingComposer !== null) {
       return
     }
 
     const before = groupComposerDraftSnapshot(composerKeyRef.current)
-    const cleared = updateComposerDraft(current => ({
-      ...current,
-      main: '',
-      pendingAttachments: { ...(current.pendingAttachments || {}), main: [] }
-    }))
-    // Main composer = START A NEW THREAD with the whole group (Slack shape).
-    // Full descriptors ride into the turn loop: remote members keep their
-    // connection fields so their turns route to their own machines.
-    const minted = sendToGroupChat(group, memberDescriptors(), text, null, images)
-
-    if (minted) {
-      setOpenThreads(prev => ({ ...prev, [minted]: true }))
-    } else {
-      const restored = restoreGroupComposerDraft(composerKeyRef.current, cleared.revision, before)
-
-      if (restored) {
-        setComposerDraft(restored)
+    setSendingComposer('main')
+    void (async () => {
+      try {
+        // Main composer = START A NEW THREAD with the whole group (Slack shape).
+        // Hosted uploads and the outbox must both be durable before the draft
+        // clears; local rooms still resolve immediately through the same path.
+        const minted = await Promise.resolve(
+          sendToGroupChat(group, memberDescriptors(), text, null, images)
+        )
+        if (minted) {
+          setComposerDraft(
+            completeGroupComposerSend(composerKeyRef.current, before, images)
+          )
+          setOpenThreads(prev => ({ ...prev, [minted]: true }))
+        }
+      } catch (error) {
+        host.notify?.({
+          kind: 'error',
+          message: String(error?.message || 'The Group Chat could not accept this message.')
+        })
+      } finally {
+        setSendingComposer(null)
       }
-    }
+    })()
   }
 
-  const submitReply = thread => {
+  const submitReply = async thread => {
     const text = (replyDrafts[thread] || '').trim()
     const images = imagesFor(thread)
 
-    if (!text && !images.length) {
+    if ((!text && !images.length) || sendingComposer !== null) {
       return
     }
 
     const before = groupComposerDraftSnapshot(composerKeyRef.current)
-    const cleared = updateComposerDraft(current => ({
-      ...current,
-      pendingAttachments: { ...(current.pendingAttachments || {}), [thread]: [] },
-      replies: { ...(current.replies || {}), [thread]: '' }
-    }))
-    // Reply box = CONTINUE this thread; the member turns it triggers are
-    // scoped to it.
-    const sent = sendToGroupChat(group, memberDescriptors(), text, thread, images)
-
-    if (sent) {
-      setOpenThreads(prev => ({ ...prev, [thread]: true }))
-    } else {
-      const restored = restoreGroupComposerDraft(composerKeyRef.current, cleared.revision, before)
-
-      if (restored) {
-        setComposerDraft(restored)
+    setSendingComposer(thread)
+    try {
+      // Reply box = CONTINUE this thread. Preserve the exact draft until the
+      // hosted upload and durable command enqueue both succeed.
+      const sent = await Promise.resolve(
+        sendToGroupChat(group, memberDescriptors(), text, thread, images)
+      )
+      if (sent) {
+        setComposerDraft(
+          completeGroupComposerSend(composerKeyRef.current, before, images, thread)
+        )
+        setOpenThreads(prev => ({ ...prev, [thread]: true }))
       }
+    } catch (error) {
+      host.notify?.({
+        kind: 'error',
+        message: String(error?.message || 'The Group Chat could not accept this reply.')
+      })
+    } finally {
+      setSendingComposer(null)
     }
   }
 
@@ -15112,6 +15355,7 @@ function GroupChatWorkspace({ group, members, onBack, visible = true }) {
       size: 'sm',
       className: 'shrink-0 text-(--ui-text-tertiary) hover:text-foreground',
       title: 'Attach files — every responding bot sees them',
+      disabled: sendingComposer !== null,
       onClick: () => void pickGroupAttachments().then(picked => addImages(thread, picked)),
       children: jsx(Codicon, { name: 'attach' })
     })
@@ -15221,23 +15465,13 @@ function GroupChatWorkspace({ group, members, onBack, visible = true }) {
                             ? jsx('div', {
                                 className: 'mt-1 flex flex-wrap items-center gap-1.5',
                                 children: entry.images.map((img, imgIndex) =>
-                                  img.kind === 'pdf' || img.kind === 'file'
-                                    ? jsxs('div', {
-                                        className:
-                                          'flex items-center gap-1 rounded-md border border-(--ui-stroke-secondary) px-1.5 py-1 text-[0.65rem] text-(--ui-text-tertiary)',
-                                        title: img.name || 'attached file',
-                                        children: [
-                                          jsx(Codicon, { name: img.kind === 'pdf' ? 'file-pdf' : 'file', className: 'text-[0.8rem]' }),
-                                          jsx('span', { className: 'max-w-48 truncate', children: img.name || 'attached file' })
-                                        ]
-                                      }, `${entryKey}:img:${imgIndex}`)
-                                    : jsx('img', {
-                                        src: img.data,
-                                        alt: img.name || 'attached image',
-                                        title: img.name || 'attached image',
-                                        className:
-                                          'max-h-40 max-w-60 rounded-md border border-(--ui-stroke-secondary) object-contain'
-                                      }, `${entryKey}:img:${imgIndex}`)
+                                  jsx(GroupAttachmentDisplay, {
+                                    room,
+                                    entry,
+                                    attachment: img,
+                                    entryKey,
+                                    index: imgIndex
+                                  }, `${entryKey}:img:${imgIndex}`)
                                 )
                               })
                             : null
@@ -15334,7 +15568,7 @@ function GroupChatWorkspace({ group, members, onBack, visible = true }) {
             className: 'grid gap-0 px-2 pb-1',
             onSubmit: event => {
               event.preventDefault()
-              submitReply(id)
+              void submitReply(id)
             },
             children: [
               attachmentRow(id),
@@ -15355,8 +15589,10 @@ function GroupChatWorkspace({ group, members, onBack, visible = true }) {
                   jsx(Button, {
                     type: 'submit',
                     size: 'sm',
-                    disabled: !(replyDrafts[id] || '').trim() && !imagesFor(id).length,
-                    children: 'Reply'
+                    disabled:
+                      sendingComposer !== null ||
+                      (!(replyDrafts[id] || '').trim() && !imagesFor(id).length),
+                    children: sendingComposer === id ? 'Sending…' : 'Reply'
                   })
                 ]
               })
@@ -15444,7 +15680,7 @@ function GroupChatWorkspace({ group, members, onBack, visible = true }) {
           className: 'grid gap-0',
           onSubmit: event => {
             event.preventDefault()
-            submit()
+            void submit()
           },
           children: [
             attachmentRow(null),
@@ -15464,8 +15700,10 @@ function GroupChatWorkspace({ group, members, onBack, visible = true }) {
                 jsx(Button, {
                   type: 'submit',
                   size: 'sm',
-                  disabled: !draft.trim() && !imagesFor(null).length,
-                  children: 'New Thread'
+                  disabled:
+                    sendingComposer !== null ||
+                    (!draft.trim() && !imagesFor(null).length),
+                  children: sendingComposer === 'main' ? 'Sending…' : 'New Thread'
                 })
               ]
             })

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -571,12 +571,16 @@ let desktopRoomCommandConsumerId = ''
 let desktopRoomCommandConsumerPromise = null
 let desktopRoomCommandTimer = null
 let desktopRoomCommandRunning = false
+let desktopRoomStopRunning = false
 let desktopRoomCommandDisposed = false
 let desktopRoomCommandPushUnsub = null
 let desktopRoomCommandPushTimer = null
 let desktopRoomCommandRerun = false
+let desktopRoomStopRerun = false
 const desktopRoomCommandPendingConnections = new Set()
+const desktopRoomStopPendingConnections = new Set()
 const desktopRoomCommandRetentions = new Map()
+const activeDesktopRoomCommands = new Map()
 
 const HOSTED_ROOM_OUTBOX_KEY = 'hosted-room-outbox-v1'
 const HOSTED_ROOM_SYNC_INTERVAL_MS = 5000
@@ -764,6 +768,9 @@ function groupChatSyncSnapshot(all = $groupChats.get(), deleted = {}) {
       // be interpreted as moving a hosted room back to local execution.
       hosted: groupChatHostedGateway(room) || null,
       hostedEpoch: groupChatHostedEpoch(room) || null,
+      ...(typeof room?.desktopAuthorityHash === 'string' && /^[a-f0-9]{64}$/.test(room.desktopAuthorityHash)
+        ? { desktopAuthorityHash: room.desktopAuthorityHash }
+        : {}),
       log,
       revision: Math.max(0, Number(room?.syncRevision ?? room?.revision ?? 0)),
       members: (Array.isArray(room.members) ? room.members : []).slice(0, GROUP_CHAT_MAX_MEMBERS).map(member => ({
@@ -1040,6 +1047,12 @@ function mergeGroupChatSyncSnapshots(
     // fence; a larger client-authored epoch cannot replace or clear it.
     const remoteHosted = groupChatHostedGateway(remoteRoom)
     const localHosted = groupChatHostedGateway(localRoom)
+    const remoteAuthorityHash = typeof remoteRoom?.desktopAuthorityHash === 'string' && /^[a-f0-9]{64}$/.test(remoteRoom.desktopAuthorityHash)
+      ? remoteRoom.desktopAuthorityHash
+      : ''
+    const localAuthorityHash = typeof localRoom?.desktopAuthorityHash === 'string' && /^[a-f0-9]{64}$/.test(localRoom.desktopAuthorityHash)
+      ? localRoom.desktopAuthorityHash
+      : ''
     if (remoteHosted) {
       hostedPresent = true
       hosted = remoteHosted
@@ -1059,6 +1072,9 @@ function mergeGroupChatSyncSnapshots(
       revision: Math.max(remoteRevision, localRevision),
       ...(hostedPresent ? { hosted: hosted || null } : {}),
       ...(hostedPresent ? { hostedEpoch: hostedEpoch || null } : {}),
+      ...(remoteAuthorityHash || localAuthorityHash
+        ? { desktopAuthorityHash: remoteAuthorityHash || localAuthorityHash }
+        : {}),
       ...(typeof image === 'string' && image ? { image } : {})
     }
   }
@@ -1223,6 +1239,13 @@ function mergeRemoteGroupChatSnapshotIntoRooms(
           : existing.image || null,
       hosted: cachedHosted || null,
       hostedEpoch: cachedHostedEpoch || null,
+      desktopAuthorityHash:
+        (typeof existing.desktopAuthorityHash === 'string' && /^[a-f0-9]{64}$/.test(existing.desktopAuthorityHash)
+          ? existing.desktopAuthorityHash
+          : null) ||
+        (typeof projected.desktopAuthorityHash === 'string' && /^[a-f0-9]{64}$/.test(projected.desktopAuthorityHash)
+          ? projected.desktopAuthorityHash
+          : null),
       syncRevision: isPreserved ? localRevision : Math.max(remoteRevision, localRevision),
       epoch: Number(existing.epoch || 0),
       running: Boolean(existing.running)
@@ -1269,6 +1292,38 @@ function currentDesktopRoomCoordinatorId() {
   return desktopRoomCommandConsumerId
 }
 
+function mintDesktopRoomAuthorityToken() {
+  if (globalThis.crypto && typeof globalThis.crypto.randomUUID === 'function') {
+    return `authority:${globalThis.crypto.randomUUID()}`
+  }
+  return `authority:${groupChatEntryId()}:${Math.random().toString(36).slice(2)}`
+}
+
+async function attachDesktopRoomAuthorityCommitments(snapshot, all = $groupChats.get()) {
+  const subtle = globalThis.crypto?.subtle
+  const Encoder = globalThis.TextEncoder
+  if (!subtle || typeof subtle.digest !== 'function' || typeof Encoder !== 'function') {
+    return snapshot
+  }
+  const encoder = new Encoder()
+  for (const [name, room] of Object.entries(all || {})) {
+    if (groupChatHostedGateway(room)) continue
+    const token = String(room?.desktopAuthorityToken || '').trim()
+    const key = groupChatRoomKey(name, room)
+    const projected = snapshot?.rooms?.[key]
+    if (!token || !projected) continue
+    try {
+      const digest = await subtle.digest('SHA-256', encoder.encode(token))
+      projected.desktopAuthorityHash = [...new Uint8Array(digest)]
+        .map(value => value.toString(16).padStart(2, '0'))
+        .join('')
+    } catch {
+      delete projected.desktopAuthorityHash
+    }
+  }
+  return groupChatSyncEnvelope(snapshot.rooms || {}, snapshot.deleted || {})
+}
+
 async function ensureDesktopRoomCommandConsumerId() {
   if (desktopRoomCommandConsumerId) return desktopRoomCommandConsumerId
   if (desktopRoomCommandConsumerPromise) return desktopRoomCommandConsumerPromise
@@ -1279,6 +1334,9 @@ async function ensureDesktopRoomCommandConsumerId() {
       stored = String((await pluginCtx?.storage?.get?.(DESKTOP_ROOM_COMMAND_CONSUMER_KEY)) || '').trim()
     } catch {
       stored = ''
+    }
+    if (desktopRoomCommandConsumerId) {
+      return desktopRoomCommandConsumerId
     }
     if (stored) {
       desktopRoomCommandConsumerId = stored
@@ -1349,6 +1407,10 @@ function durableGroupChatRooms(all = $groupChats.get()) {
         typeof room.desktopCoordinatorId === 'string' && room.desktopCoordinatorId
           ? room.desktopCoordinatorId
           : null,
+      desktopAuthorityToken:
+        typeof room.desktopAuthorityToken === 'string' && room.desktopAuthorityToken
+          ? room.desktopAuthorityToken
+          : null,
       desktopCommandSettled: boundedDesktopCommandSettled(room.desktopCommandSettled),
       hosted: groupChatHostedGateway(room) || null,
       hostedEpoch: groupChatHostedEpoch(room) || null,
@@ -1391,6 +1453,10 @@ function hydratePersistedGroupChatRooms(value) {
       members: Array.isArray(room.members) ? room.members : [],
       roomId: typeof room.roomId === 'string' && room.roomId ? room.roomId : null,
       desktopCoordinatorId: desktopRoomCoordinatorId(room, { migrate: true }),
+      desktopAuthorityToken:
+        typeof room.desktopAuthorityToken === 'string' && room.desktopAuthorityToken
+          ? room.desktopAuthorityToken
+          : null,
       desktopCommandSettled: boundedDesktopCommandSettled(room.desktopCommandSettled),
       hosted: groupChatHostedGateway(room) || null,
       hostedEpoch: groupChatHostedEpoch(room) || null,
@@ -1985,14 +2051,40 @@ function desktopCommandEligibleRooms(connectionIds) {
   )
 }
 
+function ensureDesktopRoomAuthorityTokens() {
+  const coordinator = String(desktopRoomCommandConsumerId || '')
+  if (!coordinator) return
+  for (const [name, room] of Object.entries($groupChats.get())) {
+    if (
+      groupChatHostedGateway(room) ||
+      room?.tombstone ||
+      String(room?.desktopCoordinatorId || '') !== coordinator ||
+      String(room?.desktopAuthorityToken || '').trim()
+    ) {
+      continue
+    }
+    updateGroupChat(
+      name,
+      current => {
+        current.desktopAuthorityToken = mintDesktopRoomAuthorityToken()
+        return current
+      },
+      { sync: false }
+    )
+  }
+}
+
 function retryableDesktopRoomCommand(message) {
   const error = new Error(message)
   error.retryable = true
   return error
 }
 
-async function waitForDesktopRoomCommandSettlement(group, commandId) {
+async function waitForDesktopRoomCommandSettlement(group, commandId, signal = null) {
   while (!desktopRoomCommandDisposed) {
+    if (signal?.aborted) {
+      throw retryableDesktopRoomCommand('The command lease moved to another Desktop.')
+    }
     const room = $groupChats.get()[group]
     if (!room) throw new Error('This group chat is no longer available.')
     if (room?.desktopCommandSettled?.[commandId]) return true
@@ -2002,7 +2094,13 @@ async function waitForDesktopRoomCommandSettlement(group, commandId) {
   throw retryableDesktopRoomCommand('Hermes Desktop closed before the group chat settled.')
 }
 
-async function executeDesktopRoomCommand(command, descriptors) {
+async function executeDesktopRoomCommand(command, descriptors, { signal = null } = {}) {
+  const assertLiveLease = () => {
+    if (signal?.aborted) {
+      throw retryableDesktopRoomCommand('The command lease moved to another Desktop.')
+    }
+  }
+  assertLiveLease()
   const roomId = String(command?.room_id || '')
   const entry = desktopRoomEntry(roomId, descriptors)
   if (!entry) throw new Error('This room is no longer available on this Desktop.')
@@ -2036,20 +2134,54 @@ async function executeDesktopRoomCommand(command, descriptors) {
       // room based on stale green rows.
       throw retryableDesktopRoomCommand('Waiting for every Bot in this room to reconnect.')
     }
+    assertLiveLease()
     const message = String(command?.payload?.message || '').trim()
     if (!message) throw new Error('The room message is empty.')
+    const localAbort = new AbortController()
+    const onLeaseAbort = () => localAbort.abort('lease-lost')
+    signal?.addEventListener?.('abort', onLeaseAbort, { once: true })
+    if (signal?.aborted) localAbort.abort('lease-lost')
+    activeDesktopRoomCommands.set(roomId, {
+      commandId: String(command.command_id || ''),
+      controller: localAbort
+    })
     let thread = null
-    while (!desktopRoomCommandDisposed) {
-      thread = sendToGroupChat(group, members, message, null, [], {
-        entryId: String(command.command_id || ''),
-        userName: String(command?.payload?.actor_display_name || 'Messaging')
-      })
-      if (!thread) throw new Error('The group chat could not accept the message.')
-      if (await waitForDesktopRoomCommandSettlement(group, String(command.command_id || ''))) {
-        return { room_name: group, thread_id: thread }
+    try {
+      while (!desktopRoomCommandDisposed) {
+        if (localAbort.signal.aborted) {
+          throw retryableDesktopRoomCommand('The command lease moved to another Desktop.')
+        }
+        thread = sendToGroupChat(group, members, message, null, [], {
+          entryId: String(command.command_id || ''),
+          userName: String(command?.payload?.actor_display_name || 'Messaging')
+        })
+        if (!thread) throw new Error('The group chat could not accept the message.')
+        if (
+          await waitForDesktopRoomCommandSettlement(
+            group,
+            String(command.command_id || ''),
+            localAbort.signal
+          )
+        ) {
+          return { room_name: group, thread_id: thread }
+        }
+        // A newer local turn may have superseded this thread. Once that drive
+        // settles, re-enter through the same command id so no user row is added.
       }
-      // A newer local turn may have superseded this thread. Once that drive
-      // settles, re-enter through the same command id so no user row is added.
+    } catch (error) {
+      if (localAbort.signal.aborted) {
+        if (localAbort.signal.reason === 'room-stop') {
+          return { room_name: group, stopped: true }
+        }
+        await cancelGroupThreadForLeaseLoss(group, members)
+        throw retryableDesktopRoomCommand('The command lease moved to another Desktop.')
+      }
+      throw error
+    } finally {
+      signal?.removeEventListener?.('abort', onLeaseAbort)
+      if (activeDesktopRoomCommands.get(roomId)?.controller === localAbort) {
+        activeDesktopRoomCommands.delete(roomId)
+      }
     }
     throw retryableDesktopRoomCommand('Hermes Desktop closed before the group chat settled.')
   }
@@ -2061,10 +2193,13 @@ async function executeDesktopRoomCommand(command, descriptors) {
     const latestThread = [...(Array.isArray(room?.log) ? room.log : [])]
       .reverse()
       .find(item => item?.thread)?.thread || null
+    const active = activeDesktopRoomCommands.get(roomId)
+    active?.controller?.abort('room-stop')
     await stopGroupThread(group, latestThread, members)
     updateGroupChat(group, current => {
       current.desktopCommandSettled = boundedDesktopCommandSettled({
         ...(current.desktopCommandSettled || {}),
+        ...(active?.commandId ? { [active.commandId]: Date.now() } : {}),
         [String(command.command_id || '')]: Date.now()
       })
       return current
@@ -2128,13 +2263,18 @@ function releaseDesktopRoomCommandRetention() {
 
 function scheduleDesktopRoomCommandPump(connectionId = null) {
   if (desktopRoomCommandDisposed || typeof setTimeout !== 'function') return
-  desktopRoomCommandPendingConnections.add(connectionId === null ? '*' : String(connectionId))
+  const key = connectionId === null ? '*' : String(connectionId)
+  desktopRoomCommandPendingConnections.add(key)
+  desktopRoomStopPendingConnections.add(key)
   if (desktopRoomCommandPushTimer !== null) return
   desktopRoomCommandPushTimer = setTimeout(() => {
     desktopRoomCommandPushTimer = null
     const pending = new Set(desktopRoomCommandPendingConnections)
+    const stopPending = new Set(desktopRoomStopPendingConnections)
     desktopRoomCommandPendingConnections.clear()
+    desktopRoomStopPendingConnections.clear()
     void runDesktopRoomCommandPump(pending.has('*') ? null : pending)
+    void runDesktopRoomStopPump(stopPending.has('*') ? null : stopPending)
   }, DESKTOP_ROOM_COMMAND_PUSH_DEBOUNCE_MS)
 }
 
@@ -2153,6 +2293,7 @@ async function runDesktopRoomCommandPump(targetConnectionIds = null) {
   try {
     const client = await import('./desktop-room-command-client.js')
     await ensureDesktopRoomCommandConsumerId()
+    ensureDesktopRoomAuthorityTokens()
     const connections = await desktopRoomCommandConnections()
     const connectionIds = connections.map(connection => connection.id)
     const rooms = desktopCommandEligibleRooms(connectionIds)
@@ -2173,6 +2314,7 @@ async function runDesktopRoomCommandPump(targetConnectionIds = null) {
           ? host.requestProfile(route, method, params)
           : groupChatSyncRequest({ connectionId: route.connectionId }, method, params),
       execute: executeDesktopRoomCommand,
+      actions: ['send'],
       shouldContinue: () => !desktopRoomCommandDisposed
     })
   } catch {
@@ -2192,14 +2334,73 @@ async function runDesktopRoomCommandPump(targetConnectionIds = null) {
   }
 }
 
+async function runDesktopRoomStopPump(targetConnectionIds = null) {
+  if (desktopRoomCommandDisposed) return
+  if (desktopRoomStopRunning) {
+    desktopRoomStopRerun = true
+    if (targetConnectionIds === null) {
+      desktopRoomStopPendingConnections.add('*')
+    } else {
+      for (const id of targetConnectionIds) {
+        desktopRoomStopPendingConnections.add(String(id))
+      }
+    }
+    return
+  }
+  desktopRoomStopRunning = true
+  try {
+    const client = await import('./desktop-room-command-client.js')
+    await ensureDesktopRoomCommandConsumerId()
+    ensureDesktopRoomAuthorityTokens()
+    const connections = await desktopRoomCommandConnections()
+    const connectionIds = connections.map(connection => connection.id)
+    const rooms = desktopCommandEligibleRooms(connectionIds)
+    if (!Object.keys(rooms).length) return
+    const selected = targetConnectionIds === null
+      ? connections
+      : connections.filter(connection => targetConnectionIds.has(connection.id))
+    await client.runDesktopRoomCommandCycle({
+      routes: selected.map(connection => connection.route),
+      consumerId: desktopRoomCommandConsumerId,
+      rooms,
+      request: (route, method, params) =>
+        typeof host.requestProfile === 'function'
+          ? host.requestProfile(route, method, params)
+          : groupChatSyncRequest({ connectionId: route.connectionId }, method, params),
+      execute: executeDesktopRoomCommand,
+      actions: ['stop'],
+      shouldContinue: () => !desktopRoomCommandDisposed
+    })
+  } catch {
+    // A reconnect or older backend simply leaves durable Stops pending.
+  } finally {
+    desktopRoomStopRunning = false
+    if (desktopRoomStopRerun && !desktopRoomCommandDisposed) {
+      desktopRoomStopRerun = false
+      const pending = [...desktopRoomStopPendingConnections]
+      desktopRoomStopPendingConnections.clear()
+      if (!pending.length || pending.includes('*')) {
+        void runDesktopRoomStopPump()
+      } else {
+        const targets = new Set(pending)
+        void runDesktopRoomStopPump(targets)
+      }
+    }
+  }
+}
+
 function startDesktopRoomCommandPump() {
   desktopRoomCommandDisposed = false
   if (typeof setInterval !== 'function' || desktopRoomCommandTimer !== null) return
   void ensureDesktopRoomCommandConsumerId().then(() => {
     if (desktopRoomCommandDisposed || desktopRoomCommandTimer !== null) return
     void runDesktopRoomCommandPump()
+    void runDesktopRoomStopPump()
     desktopRoomCommandTimer = setInterval(
-      () => void runDesktopRoomCommandPump(),
+      () => {
+        void runDesktopRoomCommandPump()
+        void runDesktopRoomStopPump()
+      },
       DESKTOP_ROOM_COMMAND_INTERVAL_MS
     )
     if (desktopRoomCommandPushUnsub === null && typeof host.onEvent === 'function') {
@@ -2214,7 +2415,9 @@ function startDesktopRoomCommandPump() {
 function stopDesktopRoomCommandPump() {
   desktopRoomCommandDisposed = true
   desktopRoomCommandRerun = false
+  desktopRoomStopRerun = false
   desktopRoomCommandPendingConnections.clear()
+  desktopRoomStopPendingConnections.clear()
   releaseDesktopRoomCommandRetention()
   if (desktopRoomCommandTimer !== null && typeof clearInterval === 'function') {
     clearInterval(desktopRoomCommandTimer)
@@ -2248,7 +2451,10 @@ async function flushGroupChatServerSync(connectionId) {
 
   try {
     const remoteState = await groupChatRemoteSnapshot(job)
-    const local = groupChatSyncSnapshot($groupChats.get())
+    const local = await attachDesktopRoomAuthorityCommitments(
+      groupChatSyncSnapshot($groupChats.get()),
+      $groupChats.get()
+    )
     const writeRevision = remoteState.revision + 1
     const snapshot = mergeGroupChatSyncSnapshots(remoteState.snapshot, local, {
       changedRooms: job.changedRooms,
@@ -7958,6 +8164,10 @@ function updateGroupChat(group, mutate, { sync = true } = {}) {
           typeof room.desktopCoordinatorId === 'string' && room.desktopCoordinatorId
             ? room.desktopCoordinatorId
             : null,
+        desktopAuthorityToken:
+          typeof room.desktopAuthorityToken === 'string' && room.desktopAuthorityToken
+            ? room.desktopAuthorityToken
+            : null,
         desktopCommandSettled: boundedDesktopCommandSettled(room.desktopCommandSettled),
         hosted: groupChatHostedGateway(room) || null,
         hostedEpoch: groupChatHostedEpoch(room) || null,
@@ -8057,6 +8267,10 @@ async function disbandGroupChat(group, members) {
           desktopCoordinatorId:
             typeof room.desktopCoordinatorId === 'string' && room.desktopCoordinatorId
               ? room.desktopCoordinatorId
+              : null,
+          desktopAuthorityToken:
+            typeof room.desktopAuthorityToken === 'string' && room.desktopAuthorityToken
+              ? room.desktopAuthorityToken
               : null,
           desktopCommandSettled: boundedDesktopCommandSettled(room.desktopCommandSettled),
           hosted: groupChatHostedGateway(room) || null,
@@ -9134,6 +9348,33 @@ async function stopGroupThread(group, thread, members = null) {
   }
 }
 
+/** Fence work after this Desktop loses its gateway command lease. Unlike a
+ *  user Stop, this does not place durable holds or settle the command: the
+ *  gateway must be able to lease the same idempotent turn to the current
+ *  owner and continue it safely. */
+async function cancelGroupThreadForLeaseLoss(group, members = null) {
+  const room = $groupChats.get()[group] || {}
+  const roster = Array.isArray(members) && members.length ? members : room.members || []
+  const turnName = room.turn || null
+
+  updateGroupChat(group, current => {
+    current.epoch = (current.epoch || 0) + 1
+    current.running = false
+    current.turn = null
+    return current
+  })
+
+  const onTurn = turnName ? roster.find(member => member?.name === turnName) : null
+  const sessionId = onTurn ? (room.sessions || {})[groupMemberKey(onTurn)] : null
+  if (onTurn && sessionId) {
+    try {
+      await requestForBot(onTurn, 'session.interrupt', { session_id: sessionId })
+    } catch {
+      /* best-effort: the epoch fence prevents stale room commits */
+    }
+  }
+}
+
 /** Drive one bounded round-robin turn for ONE THREAD. Serial — one member at
  *  a time. A newer user send bumps the room epoch; this loop notices at the
  *  next member boundary, bails, and the newest send's own loop takes over.
@@ -9465,12 +9706,10 @@ async function runGroupChatRounds(group, members, thread) {
     if (current) {
       recordGroupActivity(group, { kind: exitKind, member: null, thread })
     }
-    if (current || externalIds.length) {
+    if (current) {
       updateGroupChat(group, r => {
-        if (current) {
-          r.running = false
-          r.turn = null
-        }
+        r.running = false
+        r.turn = null
         const settled = { ...(r.desktopCommandSettled || {}) }
         for (const id of externalIds) {
           settled[id] = Date.now()
@@ -9549,9 +9788,13 @@ function sendToGroupChat(group, members, text, thread, images, options = {}) {
     return null
   }
 
-  if (!hosted && !room?.desktopCoordinatorId) {
+  if (
+    !hosted &&
+    (!room?.desktopCoordinatorId || !room?.desktopAuthorityToken)
+  ) {
     room = updateGroupChat(group, current => {
-      current.desktopCoordinatorId = currentDesktopRoomCoordinatorId()
+      current.desktopCoordinatorId ||= currentDesktopRoomCoordinatorId()
+      current.desktopAuthorityToken ||= mintDesktopRoomAuthorityToken()
       return current
     })
   }
@@ -13739,6 +13982,7 @@ function CreateGroupChatDialog({ open, roster, onClose, onCreated }) {
         room.members = roomMembers
         room.roomId = roomId
         room.desktopCoordinatorId = desktopCoordinator
+        room.desktopAuthorityToken = hostedRoom ? null : mintDesktopRoomAuthorityToken()
 
         if (hostedRoom) {
           room.hosted = hostedRoom.authority_gateway_id

--- a/apps/desktop/src/plugins/hermes-bots/tests/desktop-room-command-client.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/desktop-room-command-client.test.mjs
@@ -1,0 +1,236 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  desktopRoomDescriptors,
+  desktopRoomIdentity,
+  runDesktopRoomCommandCycle
+} from '../desktop-room-command-client.js'
+
+
+test('descriptors expose classic rooms only with stable identities', () => {
+  const rooms = {
+    Classic: { roomId: 'room-1', log: [] },
+    Legacy: { log: [{ text: 'hi' }] },
+    Hosted: { roomId: 'room-2', hosted: 'gateway-a', log: [] },
+    Deleted: { roomId: 'room-3', tombstone: true, log: [] }
+  }
+
+  assert.equal(desktopRoomIdentity('Legacy', rooms.Legacy), 'name:Legacy')
+  assert.deepEqual(desktopRoomDescriptors(rooms), [
+    { name: 'Classic', roomId: 'room-1' },
+    { name: 'Legacy', roomId: 'name:Legacy' }
+  ])
+})
+
+
+test('one cycle claims, executes and completes commands per gateway', async () => {
+  const calls = []
+  const request = async (route, method, params) => {
+    calls.push({ connectionId: route.connectionId, method, params })
+    if (route.connectionId === 'old') throw new Error('method not found')
+    if (method === 'groups.desktop.claim') {
+      return {
+        commands: [{
+          command_id: 'messaging:1',
+          room_id: 'room-1',
+          action: 'send',
+          payload: { message: 'hello' }
+        }]
+      }
+    }
+    return { command: { state: 'completed' } }
+  }
+
+  const outcomes = await runDesktopRoomCommandCycle({
+    routes: [
+      { connectionId: 'old' },
+      { connectionId: 'current' },
+      { connectionId: 'current' }
+    ],
+    consumerId: 'desktop:test',
+    rooms: { Classic: { roomId: 'room-1', log: [] } },
+    request,
+    execute: async command => ({ thread_id: `thread:${command.command_id}` })
+  })
+
+  assert.deepEqual(outcomes, [
+    { commandId: 'messaging:1', connectionId: 'current', success: true }
+  ])
+  const complete = calls.find(call => call.method === 'groups.desktop.complete')
+  assert.equal(complete.params.success, true)
+  assert.deepEqual(complete.params.result, { thread_id: 'thread:messaging:1' })
+  assert.deepEqual(
+    calls.filter(call => call.method === 'groups.desktop.claim').map(call => call.connectionId),
+    ['old', 'current']
+  )
+})
+
+
+test('execution failures are acknowledged without breaking later cycles', async () => {
+  const completions = []
+  const outcomes = await runDesktopRoomCommandCycle({
+    routes: [{ connectionId: 'current' }],
+    consumerId: 'desktop:test',
+    rooms: { Classic: { roomId: 'room-1', log: [] } },
+    request: async (_route, method, params) => {
+      if (method === 'groups.desktop.claim') {
+        return {
+          commands: [{
+            command_id: 'messaging:failed',
+            room_id: 'room-1',
+            action: 'send',
+            payload: { message: 'hello' }
+          }]
+        }
+      }
+      completions.push(params)
+      return {}
+    },
+    execute: async () => {
+      throw new Error('room disappeared')
+    }
+  })
+
+  assert.equal(outcomes[0].success, false)
+  assert.equal(completions[0].success, false)
+  assert.equal(completions[0].result.message, 'room disappeared')
+})
+
+
+test('an unscoped local gateway still receives compatibility commands', async () => {
+  const calls = []
+  await runDesktopRoomCommandCycle({
+    routes: [{ connectionId: '' }],
+    consumerId: 'desktop:test',
+    rooms: { Local: { roomId: 'room-local', log: [] } },
+    request: async (_route, method, params) => {
+      calls.push({ method, params })
+      return method === 'groups.desktop.claim' ? { commands: [] } : {}
+    },
+    execute: async () => ({})
+  })
+
+  assert.equal(calls[0].method, 'groups.desktop.claim')
+  assert.deepEqual(calls[0].params.room_ids, ['room-local'])
+})
+
+
+test('no advertised rooms performs no gateway request', async () => {
+  let calls = 0
+  const outcomes = await runDesktopRoomCommandCycle({
+    routes: [{ connectionId: 'current' }],
+    consumerId: 'desktop:test',
+    rooms: {},
+    request: async () => {
+      calls += 1
+      return {}
+    },
+    execute: async () => ({})
+  })
+
+  assert.deepEqual(outcomes, [])
+  assert.equal(calls, 0)
+})
+
+
+test('large room rosters are claimed in bounded pages', async () => {
+  const claimSizes = []
+  const rooms = Object.fromEntries(
+    Array.from({ length: 260 }, (_, index) => [
+      `Room ${index}`,
+      { roomId: `room-${index}`, log: [] }
+    ])
+  )
+  await runDesktopRoomCommandCycle({
+    routes: [{ connectionId: 'current' }],
+    consumerId: 'desktop:test',
+    rooms,
+    request: async (_route, method, params) => {
+      if (method === 'groups.desktop.claim') claimSizes.push(params.room_ids.length)
+      return { commands: [] }
+    },
+    execute: async () => ({})
+  })
+
+  assert.deepEqual(claimSizes, [128, 128, 4])
+})
+
+
+test('one push drains more than one eight-command claim page', async () => {
+  const pending = Array.from({ length: 9 }, (_, index) => ({
+    command_id: `messaging:${index}`,
+    room_id: 'room-1',
+    lease_token: `token:${index}`
+  }))
+  const completed = []
+  const outcomes = await runDesktopRoomCommandCycle({
+    routes: [{ connectionId: 'current' }],
+    consumerId: 'desktop:test',
+    rooms: { Classic: { roomId: 'room-1', log: [] } },
+    request: async (_route, method, params) => {
+      if (method === 'groups.desktop.claim') {
+        return { commands: pending.splice(0, params.limit) }
+      }
+      if (method === 'groups.desktop.complete') completed.push(params.command_id)
+      return {}
+    },
+    execute: async () => ({ settled: true })
+  })
+
+  assert.equal(outcomes.length, 9)
+  assert.equal(completed.length, 9)
+  assert.equal(pending.length, 0)
+})
+
+
+test('retryable execution leaves a claimed command unacknowledged', async () => {
+  const methods = []
+  const outcomes = await runDesktopRoomCommandCycle({
+    routes: [{ connectionId: 'current' }],
+    consumerId: 'desktop:test',
+    rooms: { Classic: { roomId: 'room-1', log: [] } },
+    request: async (_route, method) => {
+      methods.push(method)
+      return method === 'groups.desktop.claim'
+        ? { commands: [{ command_id: 'messaging:later', room_id: 'room-1' }] }
+        : {}
+    },
+    execute: async () => {
+      const error = new Error('member offline')
+      error.retryable = true
+      throw error
+    }
+  })
+
+  assert.deepEqual(methods, ['groups.desktop.claim'])
+  assert.deepEqual(outcomes, [{
+    commandId: 'messaging:later',
+    connectionId: 'current',
+    success: false,
+    retryable: true
+  }])
+})
+
+
+test('disposing after claim leaves the command leased for safe retry', async () => {
+  const methods = []
+  const outcomes = await runDesktopRoomCommandCycle({
+    routes: [{ connectionId: 'current' }],
+    consumerId: 'desktop:test',
+    rooms: { Classic: { roomId: 'room-1', log: [] } },
+    request: async (_route, method) => {
+      methods.push(method)
+      return method === 'groups.desktop.claim'
+        ? { commands: [{ command_id: 'messaging:one', room_id: 'room-1' }] }
+        : {}
+    },
+    execute: async () => {
+      throw new Error('must not execute')
+    },
+    shouldContinue: () => false
+  })
+
+  assert.deepEqual(outcomes, [])
+  assert.deepEqual(methods, ['groups.desktop.claim'])
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/desktop-room-command-client.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/desktop-room-command-client.test.mjs
@@ -67,6 +67,48 @@ test('one cycle claims, executes and completes commands per gateway', async () =
 })
 
 
+test('execution context reads command data from the gateway that issued the claim', async () => {
+  const calls = []
+  let executionContext
+  await runDesktopRoomCommandCycle({
+    routes: [{ connectionId: 'gateway-b' }],
+    consumerId: 'desktop:test',
+    rooms: {
+      Classic: {
+        roomId: 'room-1',
+        desktopAuthorityToken: 'authority:test',
+        log: []
+      }
+    },
+    request: async (route, method, params) => {
+      calls.push({ connectionId: route.connectionId, method, params })
+      if (method === 'groups.desktop.claim') {
+        return {
+          commands: [{
+            command_id: 'messaging:attachment',
+            room_id: 'room-1',
+            action: 'send',
+            lease_token: 'lease:one',
+            payload: { message: 'inspect' }
+          }]
+        }
+      }
+      return {}
+    },
+    execute: async (_command, _rooms, context) => {
+      executionContext = context
+      await context.request('groups.attachment.read', { attachment_id: 'att_1' })
+      return { settled: true }
+    }
+  })
+
+  assert.equal(executionContext.consumerId, 'desktop:test')
+  assert.equal(executionContext.route.connectionId, 'gateway-b')
+  const read = calls.find(call => call.method === 'groups.attachment.read')
+  assert.equal(read.connectionId, 'gateway-b')
+})
+
+
 test('execution failures are acknowledged without breaking later cycles', async () => {
   const completions = []
   const outcomes = await runDesktopRoomCommandCycle({

--- a/apps/desktop/src/plugins/hermes-bots/tests/desktop-room-command-client.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/desktop-room-command-client.test.mjs
@@ -10,16 +10,16 @@ import {
 
 test('descriptors expose classic rooms only with stable identities', () => {
   const rooms = {
-    Classic: { roomId: 'room-1', log: [] },
-    Legacy: { log: [{ text: 'hi' }] },
+    Classic: { roomId: 'room-1', desktopAuthorityToken: 'authority:classic', log: [] },
+    Legacy: { desktopAuthorityToken: 'authority:legacy', log: [{ text: 'hi' }] },
     Hosted: { roomId: 'room-2', hosted: 'gateway-a', log: [] },
     Deleted: { roomId: 'room-3', tombstone: true, log: [] }
   }
 
   assert.equal(desktopRoomIdentity('Legacy', rooms.Legacy), 'name:Legacy')
   assert.deepEqual(desktopRoomDescriptors(rooms), [
-    { name: 'Classic', roomId: 'room-1' },
-    { name: 'Legacy', roomId: 'name:Legacy' }
+    { name: 'Classic', roomId: 'room-1', authorityToken: 'authority:classic' },
+    { name: 'Legacy', roomId: 'name:Legacy', authorityToken: 'authority:legacy' }
   ])
 })
 
@@ -49,7 +49,7 @@ test('one cycle claims, executes and completes commands per gateway', async () =
       { connectionId: 'current' }
     ],
     consumerId: 'desktop:test',
-    rooms: { Classic: { roomId: 'room-1', log: [] } },
+    rooms: { Classic: { roomId: 'room-1', desktopAuthorityToken: 'authority:test', log: [] } },
     request,
     execute: async command => ({ thread_id: `thread:${command.command_id}` })
   })
@@ -72,7 +72,7 @@ test('execution failures are acknowledged without breaking later cycles', async 
   const outcomes = await runDesktopRoomCommandCycle({
     routes: [{ connectionId: 'current' }],
     consumerId: 'desktop:test',
-    rooms: { Classic: { roomId: 'room-1', log: [] } },
+    rooms: { Classic: { roomId: 'room-1', desktopAuthorityToken: 'authority:test', log: [] } },
     request: async (_route, method, params) => {
       if (method === 'groups.desktop.claim') {
         return {
@@ -84,7 +84,7 @@ test('execution failures are acknowledged without breaking later cycles', async 
           }]
         }
       }
-      completions.push(params)
+      if (method === 'groups.desktop.complete') completions.push(params)
       return {}
     },
     execute: async () => {
@@ -103,7 +103,7 @@ test('an unscoped local gateway still receives compatibility commands', async ()
   await runDesktopRoomCommandCycle({
     routes: [{ connectionId: '' }],
     consumerId: 'desktop:test',
-    rooms: { Local: { roomId: 'room-local', log: [] } },
+    rooms: { Local: { roomId: 'room-local', desktopAuthorityToken: 'authority:local', log: [] } },
     request: async (_route, method, params) => {
       calls.push({ method, params })
       return method === 'groups.desktop.claim' ? { commands: [] } : {}
@@ -112,7 +112,9 @@ test('an unscoped local gateway still receives compatibility commands', async ()
   })
 
   assert.equal(calls[0].method, 'groups.desktop.claim')
-  assert.deepEqual(calls[0].params.room_ids, ['room-local'])
+  assert.deepEqual(calls[0].params.room_authorities, [
+    { room_id: 'room-local', authority_token: 'authority:local' }
+  ])
 })
 
 
@@ -139,7 +141,7 @@ test('large room rosters are claimed in bounded pages', async () => {
   const rooms = Object.fromEntries(
     Array.from({ length: 260 }, (_, index) => [
       `Room ${index}`,
-      { roomId: `room-${index}`, log: [] }
+      { roomId: `room-${index}`, desktopAuthorityToken: `authority:${index}`, log: [] }
     ])
   )
   await runDesktopRoomCommandCycle({
@@ -147,7 +149,7 @@ test('large room rosters are claimed in bounded pages', async () => {
     consumerId: 'desktop:test',
     rooms,
     request: async (_route, method, params) => {
-      if (method === 'groups.desktop.claim') claimSizes.push(params.room_ids.length)
+      if (method === 'groups.desktop.claim') claimSizes.push(params.room_authorities.length)
       return { commands: [] }
     },
     execute: async () => ({})
@@ -167,7 +169,7 @@ test('one push drains more than one eight-command claim page', async () => {
   const outcomes = await runDesktopRoomCommandCycle({
     routes: [{ connectionId: 'current' }],
     consumerId: 'desktop:test',
-    rooms: { Classic: { roomId: 'room-1', log: [] } },
+    rooms: { Classic: { roomId: 'room-1', desktopAuthorityToken: 'authority:test', log: [] } },
     request: async (_route, method, params) => {
       if (method === 'groups.desktop.claim') {
         return { commands: pending.splice(0, params.limit) }
@@ -189,7 +191,7 @@ test('retryable execution leaves a claimed command unacknowledged', async () => 
   const outcomes = await runDesktopRoomCommandCycle({
     routes: [{ connectionId: 'current' }],
     consumerId: 'desktop:test',
-    rooms: { Classic: { roomId: 'room-1', log: [] } },
+    rooms: { Classic: { roomId: 'room-1', desktopAuthorityToken: 'authority:test', log: [] } },
     request: async (_route, method) => {
       methods.push(method)
       return method === 'groups.desktop.claim'
@@ -218,7 +220,7 @@ test('disposing after claim leaves the command leased for safe retry', async () 
   const outcomes = await runDesktopRoomCommandCycle({
     routes: [{ connectionId: 'current' }],
     consumerId: 'desktop:test',
-    rooms: { Classic: { roomId: 'room-1', log: [] } },
+    rooms: { Classic: { roomId: 'room-1', desktopAuthorityToken: 'authority:test', log: [] } },
     request: async (_route, method) => {
       methods.push(method)
       return method === 'groups.desktop.claim'
@@ -233,4 +235,75 @@ test('disposing after claim leaves the command leased for safe retry', async () 
 
   assert.deepEqual(outcomes, [])
   assert.deepEqual(methods, ['groups.desktop.claim'])
+})
+
+
+test('a Stop-only lane claims only Stop commands', async () => {
+  const claims = []
+  await runDesktopRoomCommandCycle({
+    routes: [{ connectionId: 'current' }],
+    consumerId: 'desktop:test',
+    rooms: { Classic: { roomId: 'room-1', desktopAuthorityToken: 'authority:test', log: [] } },
+    actions: ['stop'],
+    request: async (_route, method, params) => {
+      if (method === 'groups.desktop.claim') claims.push(params)
+      return { commands: [] }
+    },
+    execute: async () => ({})
+  })
+
+  assert.deepEqual(claims[0].actions, ['stop'])
+  assert.deepEqual(claims[0].room_authorities, [
+    { room_id: 'room-1', authority_token: 'authority:test' }
+  ])
+})
+
+
+test('lease renewal failure aborts execution and never acknowledges stale effects', async () => {
+  const originalSetInterval = globalThis.setInterval
+  const originalClearInterval = globalThis.clearInterval
+  let renewTick = null
+  let completed = 0
+  globalThis.setInterval = callback => {
+    renewTick = callback
+    return 1
+  }
+  globalThis.clearInterval = () => undefined
+  try {
+    const cycle = runDesktopRoomCommandCycle({
+      routes: [{ connectionId: 'current' }],
+      consumerId: 'desktop:test',
+      rooms: { Classic: { roomId: 'room-1', desktopAuthorityToken: 'authority:test', log: [] } },
+      request: async (_route, method) => {
+        if (method === 'groups.desktop.claim') {
+          return {
+            commands: [{
+              command_id: 'messaging:lease-lost',
+              room_id: 'room-1',
+              action: 'send',
+              lease_token: 'lease:one',
+              payload: { message: 'hello' }
+            }]
+          }
+        }
+        if (method === 'groups.desktop.renew') throw new Error('lease moved')
+        if (method === 'groups.desktop.complete') completed += 1
+        return {}
+      },
+      execute: async (_command, _rooms, { signal }) =>
+        new Promise((resolve, reject) => {
+          signal.addEventListener('abort', () => reject(new Error('aborted')), { once: true })
+        })
+    })
+    while (renewTick === null) await Promise.resolve()
+    renewTick()
+    const outcomes = await cycle
+
+    assert.equal(completed, 0)
+    assert.equal(outcomes[0].leaseLost, true)
+    assert.equal(outcomes[0].retryable, true)
+  } finally {
+    globalThis.setInterval = originalSetInterval
+    globalThis.clearInterval = originalClearInterval
+  }
 })

--- a/apps/desktop/src/plugins/hermes-bots/tests/desktop-room-command-lifecycle.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/desktop-room-command-lifecycle.test.mjs
@@ -1,0 +1,95 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+const pluginSource = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+function loadRetention() {
+  const start = pluginSource.indexOf('function syncDesktopRoomCommandRetention(')
+  const end = pluginSource.indexOf('function scheduleDesktopRoomCommandPump(', start)
+  assert.ok(start > 0)
+  assert.ok(end > start)
+
+  const releases = []
+  const context = {
+    desktopRoomCommandDisposed: false,
+    desktopRoomCommandRetentions: new Map(),
+    retainCalls: [],
+    releases,
+    host: {
+      retainProfileSocket: route => {
+        context.retainCalls.push(route)
+        return () => releases.push(route)
+      }
+    }
+  }
+  vm.createContext(context)
+  vm.runInContext(
+    `${pluginSource.slice(start, end)}
+globalThis.syncRetention = syncDesktopRoomCommandRetention
+globalThis.releaseRetention = releaseDesktopRoomCommandRetention`,
+    context
+  )
+  return context
+}
+
+const connection = id => ({ id, route: { connectionId: id, targetProfile: 'default' } })
+
+test('classic room command routes keep one reusable socket per gateway', () => {
+  const context = loadRetention()
+  const connections = [connection('a'), connection('b')]
+
+  context.syncRetention(connections)
+  context.syncRetention(connections)
+
+  assert.equal(context.retainCalls.length, 2)
+  assert.equal(context.desktopRoomCommandRetentions.size, 2)
+})
+
+test('classic room command retention releases removed routes and all routes on stop', () => {
+  const context = loadRetention()
+  context.syncRetention([connection('a'), connection('b')])
+  context.syncRetention([connection('a')])
+
+  assert.deepEqual(context.releases.map(route => route.connectionId), ['b'])
+  context.releaseRetention()
+  assert.deepEqual(context.releases.map(route => route.connectionId), ['b', 'a'])
+})
+
+test('push is feature-detected, disposed, and the minute poll is only a backstop', () => {
+  const start = pluginSource.indexOf('function startDesktopRoomCommandPump(')
+  const stop = pluginSource.indexOf('function stopDesktopRoomCommandPump(', start)
+  const end = pluginSource.indexOf('async function flushGroupChatServerSync', stop)
+  const lifecycle = pluginSource.slice(start, end)
+
+  assert.match(lifecycle, /desktop_rooms\.commands\.pending/)
+  assert.match(lifecycle, /typeof host\.onEvent === 'function'/)
+  assert.match(lifecycle, /desktopRoomCommandPushUnsub\(\)/)
+  assert.match(pluginSource, /DESKTOP_ROOM_COMMAND_INTERVAL_MS = 60_000/)
+  assert.match(lifecycle, /setInterval\(/)
+  assert.match(lifecycle, /releaseDesktopRoomCommandRetention\(\)/)
+})
+
+test('a signal racing an active command cycle schedules a follow-up pass', () => {
+  const start = pluginSource.indexOf('async function runDesktopRoomCommandPump(')
+  const end = pluginSource.indexOf('function startDesktopRoomCommandPump(', start)
+  const pump = pluginSource.slice(start, end)
+
+  assert.match(pump, /if \(desktopRoomCommandRunning\)/)
+  assert.match(pump, /desktopRoomCommandRerun = true/)
+  assert.match(pump, /if \(desktopRoomCommandRerun && !desktopRoomCommandDisposed\)/)
+  assert.match(pump, /scheduleDesktopRoomCommandPump\(/)
+})
+
+test('long room turns renew their generation-fenced command lease', () => {
+  const clientSource = readFileSync(
+    new URL('../desktop-room-command-client.js', import.meta.url),
+    'utf8'
+  )
+
+  assert.match(clientSource, /groups\.desktop\.renew/)
+  assert.match(clientSource, /lease_token: leaseToken/)
+  assert.match(clientSource, /LEASE_RENEW_INTERVAL_MS = 15_000/)
+  assert.match(clientSource, /clearInterval\(renewTimer\)/)
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/desktop-room-command-lifecycle.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/desktop-room-command-lifecycle.test.mjs
@@ -93,3 +93,14 @@ test('long room turns renew their generation-fenced command lease', () => {
   assert.match(clientSource, /LEASE_RENEW_INTERVAL_MS = 15_000/)
   assert.match(clientSource, /clearInterval\(renewTimer\)/)
 })
+
+test('Stop commands use an independent priority lane', () => {
+  const start = pluginSource.indexOf('function scheduleDesktopRoomCommandPump(')
+  const end = pluginSource.indexOf('function stopDesktopRoomCommandPump(', start)
+  const lifecycle = pluginSource.slice(start, end)
+
+  assert.match(lifecycle, /runDesktopRoomStopPump/)
+  assert.match(lifecycle, /actions: \['send'\]/)
+  assert.match(lifecycle, /actions: \['stop'\]/)
+  assert.match(lifecycle, /desktopRoomStopRunning/)
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
@@ -22,6 +22,7 @@ function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall, approva
   }
   const calls = []
   const clarifyResponds = []
+  const notifications = []
   const approvalResponds = []
   const requests = []
   const sessions = new Map()
@@ -192,7 +193,7 @@ function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall, approva
         return {}
       },
       state: { profile: { get: () => 'default', listen: () => undefined }, gateway: { listen: () => undefined } },
-      notify: () => undefined,
+      notify: notification => notifications.push(notification),
       notifyError: () => undefined
     }
   }
@@ -204,7 +205,7 @@ function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall, approva
     .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
     .replace('export default {', 'globalThis.plugin = {')
     .concat(
-      '\nglobalThis.__gc = { sendToGroupChat, runGroupChatRounds, harvestStrandedGroupReply, resolveGroupResponders, parseGroupChatMentions, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, groupSpeakerLabel, buildGroupChatTurnPrompt, trimGroupChatLog, groupChatSyncSnapshot, groupChatGatewayJsonSize, mergeGroupChatSyncSnapshots, mergeRemoteGroupChatSnapshotIntoRooms, scheduleGroupChatServerSync, disbandGroupChat, renameGroupChat, updateGroupChat, durableGroupChatRooms, persistGroupChatRooms, ensureGroupChatSession, uniqueGroupChatName, liveGroupChatNames, groupChatNames, openGroupChat, closeGroupChatMainTab, shouldRenderGroupChatInPane, syncGroupClarify, clearGroupClarify, answerGroupClarify, $groupClarify, $groupChats, $groupNeedsYou, $groupChatWorkspace, $groupMainTabsRev, $botMeta, $lastRoster, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
+      '\nglobalThis.__gc = { sendToGroupChat, appendGroupChatEntry, runGroupChatRounds, harvestStrandedGroupReply, resolveGroupResponders, parseGroupChatMentions, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, groupSpeakerLabel, buildGroupChatTurnPrompt, trimGroupChatLog, groupChatHostedGateway, applyHostedRoomAuthority, groupChatSyncSequence, compareGroupChatSyncEntries, mergeGroupChatSyncEntries, groupChatSyncSnapshot, groupChatGatewayJsonSize, mergeGroupChatSyncSnapshots, mergeRemoteGroupChatSnapshotIntoRooms, scheduleGroupChatServerSync, disbandGroupChat, renameGroupChat, updateGroupChat, durableGroupChatRooms, hydratePersistedGroupChatRooms, persistGroupChatRooms, ensureGroupChatSession, uniqueGroupChatName, liveGroupChatNames, groupChatNames, openGroupChat, closeGroupChatMainTab, shouldRenderGroupChatInPane, syncGroupClarify, clearGroupClarify, answerGroupClarify, $groupClarify, $groupChats, $groupNeedsYou, $groupChatWorkspace, $groupMainTabsRev, $botMeta, $lastRoster, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
     )
   vm.runInNewContext(source, context, { filename: 'plugin.js' })
   const storageWrites = new Map()
@@ -212,7 +213,7 @@ function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall, approva
     storage: { get: () => null, set: (key, value) => storageWrites.set(key, value) },
     register: () => undefined
   })
-  return { ...context.__gc, approvalResponds, calls, clarifyResponds, host: context.host, requests, sessions, storageWrites, sharedUiMeta, uiMetaRevisions }
+  return { ...context.__gc, approvalResponds, calls, clarifyResponds, host: context.host, notifications, requests, sessions, storageWrites, sharedUiMeta, uiMetaRevisions }
 }
 
 const MEMBERS = [{ name: 'research', title: '' }, { name: 'builder', title: '' }, { name: 'ops', title: 'The Ops' }]
@@ -319,6 +320,7 @@ test('failed member turn is a pass, not a room error', async () => {
 
   const log = roomLog(gc, 'Flaky')
   assert.equal(log.length, 1) // just the user message; no error entries
+  assert.equal(gc.calls.length, MEMBERS.length, 'remaining members still receive their turns')
 })
 
 test('delta injection: a second user send only feeds members the NEW messages', async () => {
@@ -648,6 +650,458 @@ test('group gateway mirror preserves threads and budgets escaped Unicode', () =>
 
   assert.ok(gc.groupChatGatewayJsonSize(snapshot) <= 48000)
   assert.equal(snapshot.rooms['name:Unicode'].log.at(-1).thread, 'thread-15')
+  assert.equal(snapshot.rooms['name:Unicode'].hosted, null, 'current clients state local execution explicitly')
+})
+
+test('hosted-room marker survives projection, cold hydrate, and plugin persistence', () => {
+  const gc = load(() => '(pass)')
+  const snapshot = gc.groupChatSyncSnapshot({
+    Hosted: {
+      roomId: 'room-hosted',
+      hosted: '  gateway-a  ',
+      syncRevision: 4,
+      log: [{ id: 'm1', from: { kind: 'user', name: 'You' }, text: 'hello', at: 1 }],
+      members: [{ name: 'research' }]
+    }
+  })
+
+  assert.equal(snapshot.rooms['id:room-hosted'].hosted, 'gateway-a')
+  assert.equal(snapshot.rooms['id:room-hosted'].hostedEpoch, 1)
+
+  const hydrated = gc.mergeRemoteGroupChatSnapshotIntoRooms(snapshot, {})
+  assert.equal(hydrated.Hosted.hosted, 'gateway-a')
+  assert.equal(hydrated.Hosted.hostedEpoch, 1)
+
+  const durable = gc.durableGroupChatRooms(hydrated)
+  assert.equal(durable.Hosted.hosted, 'gateway-a')
+  assert.equal(durable.Hosted.hostedEpoch, 1)
+
+  const reloaded = gc.hydratePersistedGroupChatRooms(durable)
+  assert.equal(reloaded.Hosted.hosted, 'gateway-a')
+  assert.equal(reloaded.Hosted.hostedEpoch, 1)
+  assert.equal(reloaded.Hosted.epoch, 0)
+  assert.equal(reloaded.Hosted.running, false)
+})
+
+test('persisted hosted fence blocks the local driver after relaunch', () => {
+  const gc = load(() => 'must not run')
+  const reloaded = gc.hydratePersistedGroupChatRooms({
+    Hosted: {
+      roomId: 'room-hosted',
+      hosted: 'gateway-a',
+      hostedEpoch: 3,
+      log: [{ id: 'm1', from: { kind: 'user', name: 'You' }, text: 'before restart', at: 1 }],
+      members: [{ name: 'research' }]
+    }
+  })
+
+  gc.$groupChats.set(reloaded)
+  const thread = gc.sendToGroupChat('Hosted', [{ name: 'research' }], 'after restart')
+
+  assert.equal(thread, null)
+  assert.equal(gc.calls.length, 0)
+  assert.match(gc.notifications.at(-1).message, /gateway-a/)
+})
+
+test('remote-merge persistence preserves session ownership and sticky holds', () => {
+  const gc = load(() => '(pass)')
+  const durable = gc.durableGroupChatRooms({
+    Team: {
+      log: [{ id: 'm1', from: { kind: 'user', name: 'You' }, text: 'pause', at: 1 }],
+      watermarks: {},
+      sessions: { research: 'session-1' },
+      sessionOwners: { research: 'gateway-a' },
+      holds: { research: { at: 1, byMessageId: 'm1' } },
+      members: [{ name: 'research' }]
+    }
+  })
+  const reloaded = gc.hydratePersistedGroupChatRooms(durable)
+
+  assert.equal(reloaded.Team.sessionOwners.research, 'gateway-a')
+  assert.equal(reloaded.Team.holds.research.byMessageId, 'm1')
+})
+
+test('a newer legacy revision cannot clear a hosted-room marker by omission', () => {
+  const gc = load(() => '(pass)')
+  const merged = gc.mergeGroupChatSyncSnapshots(
+    {
+      version: 3,
+      rooms: {
+        'id:room-1': {
+          name: 'Team',
+          roomId: 'room-1',
+          hosted: 'gateway-a',
+          hostedEpoch: 1,
+          revision: 3,
+          log: [{ id: 'old', from: { kind: 'user', name: 'You' }, text: 'old', at: 1 }]
+        }
+      }
+    },
+    {
+      version: 3,
+      rooms: {
+        'id:room-1': {
+          name: 'Team',
+          roomId: 'room-1',
+          revision: 4,
+          log: [{ id: 'new', from: { kind: 'user', name: 'You' }, text: 'new', at: 2 }]
+        }
+      }
+    }
+  )
+
+  assert.equal(merged.rooms['id:room-1'].hosted, 'gateway-a')
+  assert.equal(merged.rooms['id:room-1'].hostedEpoch, 1)
+})
+
+test('a fabricated higher client epoch cannot move a hosted room back to local', () => {
+  const gc = load(() => '(pass)')
+  const merged = gc.mergeGroupChatSyncSnapshots(
+    {
+      version: 3,
+      rooms: {
+        'id:room-1': {
+          name: 'Team',
+          roomId: 'room-1',
+          hosted: 'gateway-a',
+          revision: 3,
+          log: [{ id: 'old', from: { kind: 'user', name: 'You' }, text: 'old', at: 1 }]
+        }
+      }
+    },
+    {
+      version: 3,
+      rooms: {
+        'id:room-1': {
+          name: 'Team',
+          roomId: 'room-1',
+          hosted: null,
+          hostedEpoch: 2,
+          revision: 4,
+          log: [{ id: 'new', from: { kind: 'user', name: 'You' }, text: 'new', at: 2 }]
+        }
+      }
+    }
+  )
+
+  assert.equal(merged.rooms['id:room-1'].hosted, 'gateway-a')
+  assert.equal(merged.rooms['id:room-1'].hostedEpoch, 1)
+})
+
+test('a fabricated higher client epoch cannot replace a cached hosted owner', () => {
+  const gc = load(() => '(pass)')
+  const merged = gc.mergeGroupChatSyncSnapshots(
+    {
+      version: 3,
+      rooms: {
+        'id:room-1': {
+          name: 'Team',
+          roomId: 'room-1',
+          hosted: 'gateway-a',
+          hostedEpoch: 1,
+          revision: 4,
+          log: [{ id: 'new-owner', from: { kind: 'user', name: 'You' }, text: 'new', at: 2 }]
+        }
+      }
+    },
+    {
+      version: 3,
+      rooms: {
+        'id:room-1': {
+          name: 'Team',
+          roomId: 'room-1',
+          hosted: 'gateway-b',
+          hostedEpoch: 99,
+          revision: 99,
+          log: [{ id: 'stale-owner', from: { kind: 'user', name: 'You' }, text: 'stale', at: 3 }]
+        }
+      }
+    }
+  )
+
+  assert.equal(merged.rooms['id:room-1'].hosted, 'gateway-a')
+  assert.equal(merged.rooms['id:room-1'].hostedEpoch, 1)
+})
+
+test('a client-authored local projection cannot clear a cached hosted owner', () => {
+  const gc = load(() => '(pass)')
+  const hydrated = gc.mergeRemoteGroupChatSnapshotIntoRooms(
+    {
+      version: 3,
+      rooms: {
+        'id:room-1': {
+          name: 'Team',
+          roomId: 'room-1',
+          hosted: 'gateway-b',
+          hostedEpoch: 2,
+          revision: 4,
+          log: [{ id: 'stale', from: { kind: 'user', name: 'You' }, text: 'stale', at: 1 }]
+        }
+      }
+    },
+    {
+      Team: {
+        roomId: 'room-1',
+        hosted: null,
+        hostedEpoch: 3,
+        syncRevision: 5,
+        log: [{ id: 'local', from: { kind: 'user', name: 'You' }, text: 'local', at: 2 }]
+      }
+    },
+    { preserveRooms: ['Team'] }
+  )
+
+  assert.equal(hydrated.Team.hosted, 'gateway-b')
+  assert.equal(hydrated.Team.hostedEpoch, 2)
+})
+
+test('ordinary hydration cannot replace an existing owner from client projection', () => {
+  const gc = load(() => '(pass)')
+  const hydrated = gc.mergeRemoteGroupChatSnapshotIntoRooms(
+    {
+      version: 3,
+      rooms: {
+        'id:room-1': {
+          name: 'Team',
+          roomId: 'room-1',
+          hosted: 'gateway-b',
+          hostedEpoch: 2,
+          revision: 4,
+          log: [{ id: 'new-owner', from: { kind: 'user', name: 'You' }, text: 'new', at: 1 }]
+        }
+      }
+    },
+    {
+      Team: {
+        roomId: 'room-1',
+        hosted: 'gateway-a',
+        hostedEpoch: 1,
+        syncRevision: 99,
+        log: [{ id: 'stale-owner', from: { kind: 'user', name: 'You' }, text: 'stale', at: 2 }]
+      }
+    }
+  )
+
+  assert.equal(hydrated.Team.hosted, 'gateway-a')
+  assert.equal(hydrated.Team.hostedEpoch, 1)
+})
+
+test('a higher server epoch without transfer lineage cannot replace the cached owner', () => {
+  const gc = load(() => '(pass)')
+  const room = {
+    roomId: 'room-1',
+    hosted: 'gateway-a',
+    hostedEpoch: 1,
+    log: []
+  }
+
+  const updated = gc.applyHostedRoomAuthority(room, {
+    room_id: 'room-1',
+    authority_gateway_id: 'gateway-b',
+    authority_epoch: 2
+  })
+
+  assert.equal(updated.hosted, 'gateway-a')
+  assert.equal(updated.hostedEpoch, 1)
+})
+
+test('a server-issued transfer receipt replaces the cached owner', () => {
+  const gc = load(() => '(pass)')
+  const room = {
+    roomId: 'room-1',
+    hosted: 'gateway-a',
+    hostedEpoch: 1,
+    log: []
+  }
+
+  const updated = gc.applyHostedRoomAuthority(room, {
+    room_id: 'room-1',
+    authority_gateway_id: 'gateway-b',
+    authority_epoch: 2,
+    authority_claim: {
+      kind: 'authority.claimed',
+      actor: { kind: 'system', id: 'authority-control' },
+      authority_epoch: 2,
+      payload: {
+        previous_gateway_id: 'gateway-a',
+        authority_gateway_id: 'gateway-b',
+        authority_epoch: 2
+      }
+    }
+  })
+
+  assert.equal(updated.hosted, 'gateway-b')
+  assert.equal(updated.hostedEpoch, 2)
+})
+
+test('a receipted legacy adoption converges on the install authority once', () => {
+  const gc = load(() => '(pass)')
+  const room = {
+    roomId: 'room-1',
+    hosted: 'legacy',
+    hostedEpoch: 1,
+    log: []
+  }
+  const serverRoom = {
+    room_id: 'room-1',
+    authority_gateway_id: 'install:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    authority_epoch: 2,
+    authority_claim: {
+      kind: 'authority.claimed',
+      actor: { kind: 'system', id: 'authority-control' },
+      authority_epoch: 2,
+      payload: {
+        previous_gateway_id: 'legacy',
+        authority_gateway_id: 'install:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        authority_epoch: 2
+      }
+    }
+  }
+
+  const adopted = gc.applyHostedRoomAuthority(room, serverRoom)
+  const repeated = gc.applyHostedRoomAuthority(adopted, serverRoom)
+
+  assert.equal(adopted.hosted, 'install:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
+  assert.equal(adopted.hostedEpoch, 2)
+  assert.deepEqual(repeated, adopted)
+})
+
+test('a hosted-room marker prevents a second local round driver', () => {
+  const gc = load(() => 'must not run')
+  gc.$groupChats.set({
+    Hosted: {
+      roomId: 'room-hosted',
+      hosted: 'gateway-a',
+      log: [],
+      watermarks: {},
+      sessions: {},
+      members: [{ name: 'research' }]
+    }
+  })
+
+  const sent = gc.sendToGroupChat('Hosted', [{ name: 'research', title: '' }], 'do the work')
+
+  assert.equal(sent, null)
+  assert.equal(gc.calls.length, 0, 'no member turn starts locally')
+  assert.equal(gc.$groupChats.get().Hosted.log.length, 0, 'the local mirror stays read-only')
+  assert.equal(gc.notifications.length, 1)
+  assert.equal(gc.notifications[0].kind, 'info')
+  assert.match(gc.notifications[0].message, /gateway-a/)
+  assert.match(gc.notifications[0].message, /isn't available in this build yet/)
+})
+
+test('late renderer callbacks cannot mutate a hosted room mirror', () => {
+  const gc = load(() => '(pass)')
+  gc.$groupChats.set({
+    Hosted: {
+      hosted: 'gateway-a',
+      log: [{ id: 'm1', seq: 1, from: { kind: 'user', name: 'You' }, text: 'hello', at: 1 }]
+    }
+  })
+
+  const appended = gc.appendGroupChatEntry(
+    'Hosted',
+    { kind: 'member', name: 'research' },
+    'late reply',
+    'legacy'
+  )
+
+  assert.equal(appended, null)
+  assert.equal(gc.$groupChats.get().Hosted.log.length, 1)
+})
+
+test('hosted projection preserves only valid monotonic sequence ids', () => {
+  const gc = load(() => '(pass)')
+  const snapshot = gc.groupChatSyncSnapshot({
+    Hosted: {
+      hosted: 'gateway-a',
+      log: [
+        { seq: 1, from: { kind: 'user', name: 'You' }, text: 'one', at: 30 },
+        { seq: '2', from: { kind: 'member', name: 'research' }, text: 'two', at: 20 },
+        { seq: 0, from: { kind: 'member', name: 'research' }, text: 'legacy', at: 10 }
+      ]
+    }
+  })
+
+  assert.equal(snapshot.rooms['name:Hosted'].log[0].seq, 1)
+  assert.equal(snapshot.rooms['name:Hosted'].log[1].seq, 2)
+  assert.equal(Object.prototype.hasOwnProperty.call(snapshot.rooms['name:Hosted'].log[2], 'seq'), false)
+})
+
+test('since-seq replay deduplicates repeated events and orders clock-skewed deltas by sequence', () => {
+  const gc = load(() => '(pass)')
+  const merged = gc.mergeGroupChatSyncSnapshots(
+    {
+      version: 3,
+      rooms: {
+        'id:room-1': {
+          name: 'Hosted',
+          roomId: 'room-1',
+          hosted: 'gateway-a',
+          revision: 5,
+          log: [
+            { seq: 2, id: 'remote-2', from: { kind: 'member', name: 'research' }, text: 'two', at: 1 }
+          ]
+        }
+      }
+    },
+    {
+      version: 3,
+      rooms: {
+        'id:room-1': {
+          name: 'Hosted',
+          roomId: 'room-1',
+          hosted: 'gateway-a',
+          revision: 5,
+          log: [
+            { seq: 1, id: 'local-1', from: { kind: 'user', name: 'You' }, text: 'one', at: 999 },
+            { seq: 2, id: 'local-copy-2', from: { kind: 'member', name: 'research' }, text: 'two', at: 998 }
+          ]
+        }
+      }
+    }
+  )
+
+  assert.equal(merged.rooms['id:room-1'].log.length, 2)
+  assert.equal(JSON.stringify(merged.rooms['id:room-1'].log.map(entry => entry.seq)), JSON.stringify([1, 2]))
+})
+
+test('hosted replay adds sequence to a same-id legacy entry without duplicating it', () => {
+  const gc = load(() => '(pass)')
+  const merged = gc.mergeGroupChatSyncSnapshots(
+    {
+      version: 3,
+      rooms: {
+        'id:room-1': {
+          name: 'Hosted',
+          roomId: 'room-1',
+          hosted: 'gateway-a',
+          revision: 5,
+          log: [
+            { seq: 4, id: 'stable-id', from: { kind: 'user', name: 'You' }, text: 'hello', at: 20 }
+          ]
+        }
+      }
+    },
+    {
+      version: 3,
+      rooms: {
+        'id:room-1': {
+          name: 'Hosted',
+          roomId: 'room-1',
+          hosted: 'gateway-a',
+          revision: 5,
+          log: [
+            { id: 'stable-id', from: { kind: 'user', name: 'You' }, text: 'hello', at: 10 }
+          ]
+        }
+      }
+    }
+  )
+
+  assert.equal(merged.rooms['id:room-1'].log.length, 1)
+  assert.equal(merged.rooms['id:room-1'].log[0].id, 'stable-id')
+  assert.equal(merged.rooms['id:room-1'].log[0].seq, 4)
 })
 
 test('empty runtime rooms are omitted from the gateway mirror', () => {

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
@@ -208,7 +208,7 @@ function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall, approva
     .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
     .replace('export default {', 'globalThis.plugin = {')
     .concat(
-      '\nglobalThis.__gc = { sendToGroupChat, appendGroupChatEntry, runGroupChatRounds, harvestStrandedGroupReply, resolveGroupResponders, parseGroupChatMentions, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, groupSpeakerLabel, buildGroupChatTurnPrompt, trimGroupChatLog, groupChatHostedGateway, applyHostedRoomAuthority, groupChatSyncSequence, compareGroupChatSyncEntries, mergeGroupChatSyncEntries, mergeGroupChatSyncSnapshots, groupChatSyncSnapshot, attachDesktopRoomAuthorityCommitments, groupChatGatewayJsonSize, mergeRemoteGroupChatSnapshotIntoRooms, scheduleGroupChatServerSync, desktopCommandEligibleRooms, currentDesktopRoomCoordinatorId, ensureDesktopRoomCommandConsumerId, executeDesktopRoomCommand, disbandGroupChat, renameGroupChat, updateGroupChat, durableGroupChatRooms, hydratePersistedGroupChatRooms, persistGroupChatRooms, ensureGroupChatSession, uniqueGroupChatName, liveGroupChatNames, groupChatNames, openGroupChat, closeGroupChatMainTab, shouldRenderGroupChatInPane, syncGroupClarify, clearGroupClarify, answerGroupClarify, $groupClarify, $groupChats, $groupNeedsYou, $groupChatWorkspace, $groupMainTabsRev, $botMeta, $lastRoster, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
+      '\nglobalThis.__gc = { sendToGroupChat, stageHostedAttachments, appendGroupChatEntry, runGroupChatRounds, harvestStrandedGroupReply, resolveGroupResponders, parseGroupChatMentions, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, groupSpeakerLabel, buildGroupChatTurnPrompt, trimGroupChatLog, groupChatHostedGateway, applyHostedRoomAuthority, groupChatSyncSequence, compareGroupChatSyncEntries, mergeGroupChatSyncEntries, mergeGroupChatSyncSnapshots, groupChatSyncSnapshot, attachDesktopRoomAuthorityCommitments, groupChatGatewayJsonSize, mergeRemoteGroupChatSnapshotIntoRooms, scheduleGroupChatServerSync, desktopCommandEligibleRooms, currentDesktopRoomCoordinatorId, ensureDesktopRoomCommandConsumerId, executeDesktopRoomCommand, disbandGroupChat, renameGroupChat, updateGroupChat, durableGroupChatRooms, hydratePersistedGroupChatRooms, persistGroupChatRooms, ensureGroupChatSession, uniqueGroupChatName, liveGroupChatNames, groupChatNames, openGroupChat, closeGroupChatMainTab, shouldRenderGroupChatInPane, syncGroupClarify, clearGroupClarify, answerGroupClarify, $groupClarify, $groupChats, $groupNeedsYou, $groupChatWorkspace, $groupMainTabsRev, $botMeta, $lastRoster, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
     )
   vm.runInNewContext(source, context, { filename: 'plugin.js' })
   const storageWrites = new Map()
@@ -332,6 +332,37 @@ test('classic room projection carries only a one-way authority commitment', asyn
   assert.equal(JSON.stringify(snapshot).includes('private-token'), false)
 })
 
+test('shared room projection keeps attachment ids and metadata but never bytes', () => {
+  const gc = load(() => '(pass)')
+  const snapshot = gc.groupChatSyncSnapshot({
+    Classic: {
+      roomId: 'room-1',
+      log: [{
+        id: 'message-1',
+        at: 1,
+        from: { kind: 'user', name: 'You' },
+        text: 'Review this',
+        images: [{
+          attachment_id: 'att_11111111111111111111111111111111',
+          kind: 'image',
+          name: 'diagram.png',
+          size: 12,
+          mime: 'image/png',
+          connectionId: 'gateway-a',
+          data: 'data:image/png;base64,iVBORw0KGgoAAAAA'
+        }]
+      }],
+      members: [{ name: 'research' }]
+    }
+  })
+  const projected = snapshot.rooms['id:room-1'].log[0].images[0]
+
+  assert.equal(projected.attachment_id, 'att_11111111111111111111111111111111')
+  assert.equal(projected.connectionId, 'gateway-a')
+  assert.equal(Object.hasOwn(projected, 'data'), false)
+  assert.doesNotMatch(JSON.stringify(snapshot), /iVBOR|data:image/)
+})
+
 test('classic messaging send waits for a complete live roster', async () => {
   const gc = load(() => '(pass)')
   gc.$lastRoster.set([{ name: 'research' }])
@@ -422,6 +453,235 @@ test('lease loss during the reachability probe prevents every room effect', asyn
   assert.equal(gc.$groupChats.get().Classic.log.length, 0)
 })
 
+test('classic attachment read carries authority and live command lease proof', async () => {
+  const gc = load(() => '(pass)')
+  const members = [{ name: 'research' }]
+  const coordinator = gc.currentDesktopRoomCoordinatorId()
+  gc.$lastRoster.set(members)
+  gc.$groupChats.set({
+    Classic: {
+      roomId: 'room-1',
+      log: [],
+      members,
+      desktopCoordinatorId: coordinator,
+      desktopAuthorityToken: 'authority:test'
+    }
+  })
+  const request = gc.host.request
+  let attachmentRead
+  gc.host.request = async (method, params) => {
+    if (method === 'groups.attachment.read') {
+      attachmentRead = params
+      return {
+        attachment: {
+          attachment_id: 'att_11111111111111111111111111111111',
+          kind: 'image',
+          name: 'diagram.png',
+          size: 12,
+          mime: 'image/png'
+        },
+        content_base64: 'iVBORw0KGgoAAAAA'
+      }
+    }
+    return request(method, params)
+  }
+
+  const result = await gc.executeDesktopRoomCommand({
+    command_id: 'messaging:attachment-proof',
+    room_id: 'room-1',
+    action: 'send',
+    lease_token: 'lease:one',
+    payload: {
+      message: '',
+      attachments: [{
+        attachment_id: 'att_11111111111111111111111111111111',
+        kind: 'image',
+        name: 'diagram.png',
+        size: 12,
+        mime: 'image/png'
+      }]
+    }
+  }, [{ name: 'Classic', roomId: 'room-1' }])
+
+  assert.equal(result.room_name, 'Classic')
+  assert.equal(attachmentRead.consumer_id, coordinator)
+  assert.equal(attachmentRead.lease_token, 'lease:one')
+  assert.equal(attachmentRead.authority_token, 'authority:test')
+  assert.equal(attachmentRead.event_id, 'messaging:attachment-proof')
+  assert.equal(attachmentRead.purpose, 'desktop-command')
+  assert.doesNotMatch(JSON.stringify(gc.$groupChats.get().Classic.log), /iVBOR|data:image/)
+  assert.ok(gc.requests.some(call => call.method === 'image.attach_bytes'))
+})
+
+test('classic messaging executes against the send-time Bot roster only', async () => {
+  const gc = load(() => '(pass)')
+  const roster = [{ name: 'research' }, { name: 'late-bot' }]
+  gc.$lastRoster.set(roster)
+  gc.$groupChats.set({
+    Classic: {
+      roomId: 'room-1',
+      log: [],
+      members: roster,
+      desktopCoordinatorId: gc.currentDesktopRoomCoordinatorId(),
+      desktopAuthorityToken: 'authority:test'
+    }
+  })
+
+  await gc.executeDesktopRoomCommand({
+    command_id: 'messaging:frozen-roster',
+    room_id: 'room-1',
+    action: 'send',
+    payload: {
+      message: 'Review this',
+      recipients: [{ name: 'research' }]
+    }
+  }, [{ name: 'Classic', roomId: 'room-1' }])
+
+  assert.deepEqual(gc.calls.map(call => call.profile), ['research'])
+})
+
+test('classic messaging waits for an unavailable send-time recipient instead of using a later Bot', async () => {
+  const gc = load(() => '(pass)')
+  gc.$lastRoster.set([{ name: 'late-bot' }])
+  gc.$groupChats.set({
+    Classic: {
+      roomId: 'room-1',
+      log: [],
+      members: [{ name: 'research' }, { name: 'late-bot' }],
+      desktopCoordinatorId: gc.currentDesktopRoomCoordinatorId(),
+      desktopAuthorityToken: 'authority:test'
+    }
+  })
+
+  await assert.rejects(
+    gc.executeDesktopRoomCommand({
+      command_id: 'messaging:frozen-offline',
+      room_id: 'room-1',
+      action: 'send',
+      payload: {
+        message: 'Review this',
+        recipients: [{ name: 'research' }]
+      }
+    }, [{ name: 'Classic', roomId: 'room-1' }]),
+    error => error.retryable === true
+  )
+  assert.equal(gc.calls.length, 0)
+})
+
+test('lease loss during attachment read prevents the room turn from starting', async () => {
+  let releaseRead
+  const pendingRead = new Promise(resolve => { releaseRead = resolve })
+  const gc = load(() => '(pass)')
+  const members = [{ name: 'research' }]
+  gc.$lastRoster.set(members)
+  gc.$groupChats.set({
+    Classic: {
+      roomId: 'room-1',
+      log: [],
+      members,
+      desktopCoordinatorId: gc.currentDesktopRoomCoordinatorId(),
+      desktopAuthorityToken: 'authority:test'
+    }
+  })
+  const request = gc.host.request
+  gc.host.request = async (method, params) =>
+    method === 'groups.attachment.read' ? pendingRead : request(method, params)
+  const lease = new AbortController()
+  const execution = gc.executeDesktopRoomCommand({
+    command_id: 'messaging:attachment-lease-loss',
+    room_id: 'room-1',
+    action: 'send',
+    lease_token: 'lease:one',
+    payload: {
+      message: '',
+      attachments: [{
+        attachment_id: 'att_11111111111111111111111111111111',
+        kind: 'image',
+        name: 'diagram.png',
+        size: 12,
+        mime: 'image/png'
+      }]
+    }
+  }, [{ name: 'Classic', roomId: 'room-1' }], { signal: lease.signal })
+
+  await new Promise(resolve => setImmediate(resolve))
+  lease.abort('lease-lost')
+  releaseRead({
+    attachment: {
+      attachment_id: 'att_11111111111111111111111111111111',
+      kind: 'image',
+      name: 'diagram.png',
+      size: 12,
+      mime: 'image/png'
+    },
+    content_base64: 'iVBORw0KGgoAAAAA'
+  })
+
+  await assert.rejects(execution, error => error.retryable === true && /lease/.test(error.message))
+  assert.equal(gc.calls.length, 0)
+  assert.equal(gc.$groupChats.get().Classic.log.length, 0)
+})
+
+test('priority Stop overtakes an attachment read before the room turn starts', async () => {
+  let releaseRead
+  const pendingRead = new Promise(resolve => { releaseRead = resolve })
+  const gc = load(() => '(pass)')
+  const members = [{ name: 'research' }]
+  gc.$lastRoster.set(members)
+  gc.$groupChats.set({
+    Classic: {
+      roomId: 'room-1',
+      log: [],
+      members,
+      desktopCoordinatorId: gc.currentDesktopRoomCoordinatorId(),
+      desktopAuthorityToken: 'authority:test'
+    }
+  })
+  const request = gc.host.request
+  gc.host.request = async (method, params) =>
+    method === 'groups.attachment.read' ? pendingRead : request(method, params)
+  const send = gc.executeDesktopRoomCommand({
+    command_id: 'messaging:attachment-send',
+    room_id: 'room-1',
+    action: 'send',
+    lease_token: 'lease:send',
+    payload: {
+      message: '',
+      attachments: [{
+        attachment_id: 'att_11111111111111111111111111111111',
+        kind: 'image',
+        name: 'diagram.png',
+        size: 12,
+        mime: 'image/png'
+      }]
+    }
+  }, [{ name: 'Classic', roomId: 'room-1' }])
+
+  await new Promise(resolve => setImmediate(resolve))
+  const stopped = await gc.executeDesktopRoomCommand({
+    command_id: 'stop:attachment-send',
+    room_id: 'room-1',
+    action: 'stop',
+    payload: {}
+  }, [{ name: 'Classic', roomId: 'room-1' }])
+  releaseRead({
+    attachment: {
+      attachment_id: 'att_11111111111111111111111111111111',
+      kind: 'image',
+      name: 'diagram.png',
+      size: 12,
+      mime: 'image/png'
+    },
+    content_base64: 'iVBORw0KGgoAAAAA'
+  })
+  const sendResult = await send
+
+  assert.equal(stopped.stopped, true)
+  assert.equal(sendResult.stopped, true)
+  assert.equal(gc.calls.length, 0)
+  assert.equal(gc.$groupChats.get().Classic.log.length, 0)
+})
+
 test('lease loss cancels without holds or settlement and the command can replay', async () => {
   let releaseFirst
   let turn = 0
@@ -490,7 +750,14 @@ test('a visible unacknowledged messaging entry re-drives once then stays settled
         at: 1,
         from: { kind: 'user', name: 'Signal' },
         text: 'Resume this',
-        thread: 'thread-recover'
+        thread: 'thread-recover',
+        images: [{
+          attachment_id: 'att_11111111111111111111111111111111',
+          kind: 'image',
+          name: 'diagram.png',
+          size: 12,
+          mime: 'image/png'
+        }]
       }],
       members,
       desktopCoordinatorId: gc.currentDesktopRoomCoordinatorId(),
@@ -499,24 +766,36 @@ test('a visible unacknowledged messaging entry re-drives once then stays settled
     }
   })
 
-  gc.sendToGroupChat('Classic', members, 'Resume this', null, [], {
+  const attachments = [{
+    attachment_id: 'att_11111111111111111111111111111111',
+    kind: 'image',
+    name: 'diagram.png',
+    size: 12,
+    mime: 'image/png',
+    data: 'data:image/png;base64,iVBORw0KGgoAAAAA'
+  }]
+  gc.sendToGroupChat('Classic', members, 'Resume this', null, attachments, {
     entryId: 'messaging:recover',
-    userName: 'Signal'
+    userName: 'Signal',
+    omitAttachmentDataFromLog: true
   })
   for (let index = 0; index < 100 && gc.$groupChats.get().Classic.running; index++) {
     await new Promise(resolve => setImmediate(resolve))
   }
 
   assert.equal(gc.calls.length, 1)
+  assert.equal(gc.requests.filter(call => call.method === 'image.attach_bytes').length, 1)
   assert.equal(roomLog(gc, 'Classic').filter(entry => entry.id === 'messaging:recover').length, 1)
   assert.ok(gc.$groupChats.get().Classic.desktopCommandSettled['messaging:recover'])
 
-  gc.sendToGroupChat('Classic', members, 'Resume this', null, [], {
+  gc.sendToGroupChat('Classic', members, 'Resume this', null, attachments, {
     entryId: 'messaging:recover',
-    userName: 'Signal'
+    userName: 'Signal',
+    omitAttachmentDataFromLog: true
   })
   await new Promise(resolve => setImmediate(resolve))
   assert.equal(gc.calls.length, 1)
+  assert.equal(gc.requests.filter(call => call.method === 'image.attach_bytes').length, 1)
 })
 
 test('classic command execution resolves only after the room drive settles', async () => {
@@ -1091,7 +1370,7 @@ test('hosted-room marker survives projection, cold hydrate, and plugin persisten
   assert.equal(reloaded.Hosted.running, false)
 })
 
-test('persisted hosted fence blocks the local driver after relaunch', () => {
+test('persisted hosted fence routes the send to its home without a local driver', async () => {
   const gc = load(() => 'must not run')
   const reloaded = gc.hydratePersistedGroupChatRooms({
     Hosted: {
@@ -1104,11 +1383,11 @@ test('persisted hosted fence blocks the local driver after relaunch', () => {
   })
 
   gc.$groupChats.set(reloaded)
-  const thread = gc.sendToGroupChat('Hosted', [{ name: 'research' }], 'after restart')
-
-  assert.equal(thread, null)
+  await assert.rejects(
+    gc.sendToGroupChat('Hosted', [{ name: 'research' }], 'after restart'),
+    /offline/i
+  )
   assert.equal(gc.calls.length, 0)
-  assert.match(gc.notifications.at(-1).message, /gateway-a/)
 })
 
 test('remote-merge persistence preserves session ownership and sticky holds', () => {
@@ -1374,7 +1653,7 @@ test('a receipted legacy adoption converges on the install authority once', () =
   assert.deepEqual(repeated, adopted)
 })
 
-test('a hosted-room marker prevents a second local round driver', () => {
+test('a hosted-room marker prevents a second local round driver', async () => {
   const gc = load(() => 'must not run')
   gc.$groupChats.set({
     Hosted: {
@@ -1387,15 +1666,105 @@ test('a hosted-room marker prevents a second local round driver', () => {
     }
   })
 
-  const sent = gc.sendToGroupChat('Hosted', [{ name: 'research', title: '' }], 'do the work')
-
-  assert.equal(sent, null)
+  await assert.rejects(
+    gc.sendToGroupChat('Hosted', [{ name: 'research', title: '' }], 'do the work'),
+    /offline/i
+  )
   assert.equal(gc.calls.length, 0, 'no member turn starts locally')
   assert.equal(gc.$groupChats.get().Hosted.log.length, 0, 'the local mirror stays read-only')
-  assert.equal(gc.notifications.length, 1)
-  assert.equal(gc.notifications[0].kind, 'info')
-  assert.match(gc.notifications[0].message, /gateway-a/)
-  assert.match(gc.notifications[0].message, /isn't available in this build yet/)
+})
+
+test('hosted attachments upload once to the room home and return metadata-only manifests', async () => {
+  const gc = load(() => 'must not run')
+  const calls = []
+  gc.host.requestProfile = async (route, method, params) => {
+    calls.push({ route, method, params })
+    return {
+      attachment: {
+        attachment_id: 'att_11111111111111111111111111111111',
+        kind: params.kind,
+        name: params.name,
+        size: 12,
+        mime: params.mime
+      }
+    }
+  }
+  const manifest = await gc.stageHostedAttachments(
+    { connectionId: 'gateway-a' },
+    'room-hosted',
+    'event-1',
+    [
+      {
+        kind: 'image',
+        name: 'diagram.png',
+        size: 12,
+        mime: 'image/png',
+        data: 'data:image/png;base64,iVBORw0KGgoAAAAA'
+      }
+    ]
+  )
+
+  assert.equal(calls.length, 1)
+  assert.equal(calls[0].method, 'groups.attachment.put')
+  assert.equal(calls[0].params.room_id, 'room-hosted')
+  assert.equal(calls[0].params.upload_id, 'event-1:upload:0')
+  assert.equal(calls[0].params.content_base64, 'iVBORw0KGgoAAAAA')
+  assert.deepEqual(JSON.parse(JSON.stringify(manifest)), [
+    {
+      attachment_id: 'att_11111111111111111111111111111111',
+      kind: 'image',
+      name: 'diagram.png',
+      size: 12,
+      mime: 'image/png'
+    }
+  ])
+  assert.doesNotMatch(JSON.stringify(manifest), /base64|data:|iVBOR/)
+})
+
+test('classic messaging image, PDF, and file bytes reuse the existing attach RPCs', async () => {
+  const gc = load(() => '(pass)')
+  const members = [{ name: 'research', title: '' }]
+  gc.$groupChats.set({ Classic: { log: [], members } })
+
+  gc.sendToGroupChat(
+    'Classic',
+    members,
+    '',
+    null,
+    [
+      {
+        attachment_id: 'att_11111111111111111111111111111111',
+        kind: 'image',
+        name: 'diagram.png',
+        size: 12,
+        mime: 'image/png',
+        data: 'data:image/png;base64,iVBORw0KGgoAAAAA'
+      },
+      {
+        attachment_id: 'att_22222222222222222222222222222222',
+        kind: 'pdf',
+        name: 'brief.pdf',
+        size: 8,
+        mime: 'application/pdf',
+        data: 'data:application/pdf;base64,JVBERi0xLjc='
+      },
+      {
+        attachment_id: 'att_33333333333333333333333333333333',
+        kind: 'file',
+        name: 'notes.txt',
+        size: 5,
+        mime: 'text/plain',
+        data: 'data:text/plain;base64,aGVsbG8='
+      }
+    ],
+    { entryId: 'messaging:attachment-1', omitAttachmentDataFromLog: true }
+  )
+  await new Promise(resolve => setImmediate(resolve))
+
+  assert.doesNotMatch(JSON.stringify(roomLog(gc, 'Classic')), /base64,|iVBOR|JVBER|aGVsbG8/)
+  assert.ok(gc.requests.some(call => call.method === 'image.attach_bytes'))
+  assert.ok(gc.requests.some(call => call.method === 'pdf.attach'))
+  assert.ok(gc.requests.some(call => call.method === 'file.attach'))
 })
 
 test('late renderer callbacks cannot mutate a hosted room mirror', () => {
@@ -2629,7 +2998,7 @@ test('source contract: thread UI — folded rows, per-thread reply box, new-thre
   assert.match(pluginSource, /Open this thread/)
   assert.match(pluginSource, /Collapse thread/)
   assert.match(pluginSource, /Reply in thread…/)
-  assert.match(pluginSource, /children: 'New Thread'/)
+  assert.match(pluginSource, /sendingComposer === 'main' \? 'Sending…' : 'New Thread'/)
   assert.match(pluginSource, /const markKey = `\$\{thread\}::\$\{memberKey\}`/)
 })
 
@@ -2654,6 +3023,17 @@ test('source contract: group chat log lines expose CopyButton on the entry body'
   assert.doesNotMatch(src, /RefreshCw/)
   assert.doesNotMatch(src, /readAloud/)
   assert.doesNotMatch(src, /ActionBarPrimitive\.Reload/)
+})
+
+test('source contract: metadata-only attachments load on demand without a broken image source', () => {
+  const src = groupChatWorkspaceSource()
+  const render = src.slice(src.indexOf('const renderEntry'), src.indexOf('// Threads:'))
+
+  assert.match(pluginSource, /function GroupAttachmentDisplay\(/)
+  assert.match(pluginSource, /'groups\.attachment\.read'/)
+  assert.match(pluginSource, /purpose: 'viewer'/)
+  assert.match(render, /jsx\(GroupAttachmentDisplay/)
+  assert.doesNotMatch(render, /src: img\.data/)
 })
 
 test('source contract: group chat message bodies opt back into selectable text', () => {

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
@@ -8,7 +8,7 @@ const pluginSource = readFileSync(new URL('../plugin.js', import.meta.url), 'utf
 /** Load the plugin in a vm with a scripted cli.exec so member turns are
  *  deterministic. `turnScript(profile, prompt)` returns the member's reply
  *  text (or throws to simulate a failed turn). */
-function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall, approvalUntilResumeCall, conflictOnce = false, deferredTimers = false } = {}) {
+function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall, approvalUntilResumeCall, conflictOnce = false, deferredTimers = false, storageGet = () => null } = {}) {
   const values = new Map()
   const atom = initial => {
     const slot = { get: () => values.get(slot), set: value => {
@@ -45,6 +45,9 @@ function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall, approva
   }
   const context = {
     atom,
+    AbortController,
+    crypto: globalThis.crypto,
+    TextEncoder,
     setTimeout: fn => {
       if (deferredTimers) {
         setImmediate(fn)
@@ -178,7 +181,7 @@ function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall, approva
             stored: session.stored,
             title: session.title
           })
-          const reply = turnScript(session.profile, params.text, calls.length, session)
+          const reply = await turnScript(session.profile, params.text, calls.length, session)
           session.messages.push({ role: 'assistant', content: reply })
           return {}
         }
@@ -205,12 +208,12 @@ function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall, approva
     .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
     .replace('export default {', 'globalThis.plugin = {')
     .concat(
-      '\nglobalThis.__gc = { sendToGroupChat, appendGroupChatEntry, runGroupChatRounds, harvestStrandedGroupReply, resolveGroupResponders, parseGroupChatMentions, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, groupSpeakerLabel, buildGroupChatTurnPrompt, trimGroupChatLog, groupChatHostedGateway, applyHostedRoomAuthority, groupChatSyncSequence, compareGroupChatSyncEntries, mergeGroupChatSyncEntries, groupChatSyncSnapshot, groupChatGatewayJsonSize, mergeGroupChatSyncSnapshots, mergeRemoteGroupChatSnapshotIntoRooms, scheduleGroupChatServerSync, desktopCommandEligibleRooms, currentDesktopRoomCoordinatorId, executeDesktopRoomCommand, disbandGroupChat, renameGroupChat, updateGroupChat, durableGroupChatRooms, hydratePersistedGroupChatRooms, persistGroupChatRooms, ensureGroupChatSession, uniqueGroupChatName, liveGroupChatNames, groupChatNames, openGroupChat, closeGroupChatMainTab, shouldRenderGroupChatInPane, syncGroupClarify, clearGroupClarify, answerGroupClarify, $groupClarify, $groupChats, $groupNeedsYou, $groupChatWorkspace, $groupMainTabsRev, $botMeta, $lastRoster, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
+      '\nglobalThis.__gc = { sendToGroupChat, appendGroupChatEntry, runGroupChatRounds, harvestStrandedGroupReply, resolveGroupResponders, parseGroupChatMentions, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, groupSpeakerLabel, buildGroupChatTurnPrompt, trimGroupChatLog, groupChatHostedGateway, applyHostedRoomAuthority, groupChatSyncSequence, compareGroupChatSyncEntries, mergeGroupChatSyncEntries, mergeGroupChatSyncSnapshots, groupChatSyncSnapshot, attachDesktopRoomAuthorityCommitments, groupChatGatewayJsonSize, mergeRemoteGroupChatSnapshotIntoRooms, scheduleGroupChatServerSync, desktopCommandEligibleRooms, currentDesktopRoomCoordinatorId, ensureDesktopRoomCommandConsumerId, executeDesktopRoomCommand, disbandGroupChat, renameGroupChat, updateGroupChat, durableGroupChatRooms, hydratePersistedGroupChatRooms, persistGroupChatRooms, ensureGroupChatSession, uniqueGroupChatName, liveGroupChatNames, groupChatNames, openGroupChat, closeGroupChatMainTab, shouldRenderGroupChatInPane, syncGroupClarify, clearGroupClarify, answerGroupClarify, $groupClarify, $groupChats, $groupNeedsYou, $groupChatWorkspace, $groupMainTabsRev, $botMeta, $lastRoster, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
     )
   vm.runInNewContext(source, context, { filename: 'plugin.js' })
   const storageWrites = new Map()
   context.plugin.register({
-    storage: { get: () => null, set: (key, value) => storageWrites.set(key, value) },
+    storage: { get: storageGet, set: (key, value) => storageWrites.set(key, value) },
     register: () => undefined
   })
   return { ...context.__gc, approvalResponds, calls, clarifyResponds, host: context.host, notifications, requests, sessions, storageWrites, sharedUiMeta, uiMetaRevisions }
@@ -221,6 +224,19 @@ const MEMBERS = [{ name: 'research', title: '' }, { name: 'builder', title: '' }
 function roomLog(gc, group) {
   return (gc.$groupChats.get()[group] || { log: [] }).log
 }
+
+test('a delayed coordinator hydrate cannot replace an identity minted meanwhile', async () => {
+  let resolveStored
+  const stored = new Promise(resolve => { resolveStored = resolve })
+  const gc = load(undefined, { storageGet: () => stored })
+  const pending = gc.ensureDesktopRoomCommandConsumerId()
+  const minted = gc.currentDesktopRoomCoordinatorId()
+
+  resolveStored('desktop:stale')
+
+  assert.equal(await pending, minted)
+  assert.equal(gc.currentDesktopRoomCoordinatorId(), minted)
+})
 
 test('classic command pump advertises only rooms this Desktop can coordinate', () => {
   const gc = load(() => '(pass)')
@@ -286,6 +302,7 @@ test('classic room execution authority persists locally but never projects', () 
       roomId: 'room-1',
       log: [{ id: 'u1', at: 1, from: { kind: 'user', name: 'You' }, text: 'hi' }],
       desktopCoordinatorId: coordinator,
+      desktopAuthorityToken: 'authority:private-token',
       members: [{ name: 'research' }]
     }
   }
@@ -293,6 +310,26 @@ test('classic room execution authority persists locally but never projects', () 
   assert.equal(gc.durableGroupChatRooms(rooms).Classic.desktopCoordinatorId, coordinator)
   const snapshot = gc.groupChatSyncSnapshot(rooms)
   assert.equal(Object.hasOwn(snapshot.rooms['id:room-1'], 'desktopCoordinatorId'), false)
+  assert.equal(Object.hasOwn(snapshot.rooms['id:room-1'], 'desktopAuthorityToken'), false)
+})
+
+test('classic room projection carries only a one-way authority commitment', async () => {
+  const gc = load(() => '(pass)')
+  const rooms = {
+    Classic: {
+      roomId: 'room-1',
+      log: [{ id: 'u1', at: 1, from: { kind: 'user', name: 'You' }, text: 'hi' }],
+      desktopAuthorityToken: 'authority:private-token',
+      members: [{ name: 'research' }]
+    }
+  }
+  const snapshot = await gc.attachDesktopRoomAuthorityCommitments(
+    gc.groupChatSyncSnapshot(rooms),
+    rooms
+  )
+
+  assert.match(snapshot.rooms['id:room-1'].desktopAuthorityHash, /^[a-f0-9]{64}$/)
+  assert.equal(JSON.stringify(snapshot).includes('private-token'), false)
 })
 
 test('classic messaging send waits for a complete live roster', async () => {
@@ -346,6 +383,89 @@ test('classic messaging send treats a live-roster probe failure as retryable', a
     }, [{ name: 'Classic', roomId: 'room-1' }]),
     error => error.retryable === true
   )
+})
+
+test('lease loss during the reachability probe prevents every room effect', async () => {
+  let releaseProbe
+  const probe = new Promise(resolve => { releaseProbe = resolve })
+  const gc = load(() => '(pass)')
+  const members = [{ name: 'research' }]
+  gc.$lastRoster.set(members)
+  gc.$groupChats.set({
+    Classic: {
+      roomId: 'room-1',
+      log: [],
+      members,
+      desktopCoordinatorId: gc.currentDesktopRoomCoordinatorId(),
+      desktopAuthorityToken: 'authority:test'
+    }
+  })
+  const request = gc.host.request
+  gc.host.request = async (method, params) => {
+    if (method === 'profiles.describe') return probe
+    return request(method, params)
+  }
+  const lease = new AbortController()
+  const execution = gc.executeDesktopRoomCommand({
+    command_id: 'messaging:preflight-fence',
+    room_id: 'room-1',
+    action: 'send',
+    payload: { message: 'Do not start this' }
+  }, [{ name: 'Classic', roomId: 'room-1' }], { signal: lease.signal })
+
+  await new Promise(resolve => setImmediate(resolve))
+  lease.abort('lease-lost')
+  releaseProbe({})
+
+  await assert.rejects(execution, error => error.retryable === true && /lease/.test(error.message))
+  assert.equal(gc.calls.length, 0)
+  assert.equal(gc.$groupChats.get().Classic.log.length, 0)
+})
+
+test('lease loss cancels without holds or settlement and the command can replay', async () => {
+  let releaseFirst
+  let turn = 0
+  const firstTurn = new Promise(resolve => { releaseFirst = resolve })
+  const gc = load(() => (++turn === 1 ? firstTurn : '(pass)'), { deferredTimers: true })
+  const members = [{ name: 'research', title: '' }]
+  const descriptors = [{ name: 'Classic', roomId: 'room-1', authorityToken: 'authority:test' }]
+  gc.$lastRoster.set(members)
+  gc.$groupChats.set({
+    Classic: {
+      roomId: 'room-1',
+      log: [],
+      members,
+      epoch: 1,
+      running: false,
+      desktopCoordinatorId: gc.currentDesktopRoomCoordinatorId(),
+      desktopAuthorityToken: 'authority:test'
+    }
+  })
+  const command = {
+    command_id: 'messaging:lease-replay',
+    room_id: 'room-1',
+    action: 'send',
+    payload: { message: 'Complete this once' }
+  }
+  const lease = new AbortController()
+  const first = gc.executeDesktopRoomCommand(command, descriptors, { signal: lease.signal })
+  for (let i = 0; i < 50 && !gc.$groupChats.get().Classic?.running; i++) {
+    await new Promise(resolve => setImmediate(resolve))
+  }
+
+  lease.abort('lease-lost')
+  await assert.rejects(first, error => error.retryable === true)
+  assert.equal(gc.$groupChats.get().Classic.running, false)
+  assert.equal(Object.keys(gc.$groupChats.get().Classic.holds || {}).length, 0)
+  assert.equal(Boolean(gc.$groupChats.get().Classic.desktopCommandSettled?.[command.command_id]), false)
+
+  releaseFirst('(pass)')
+  await new Promise(resolve => setImmediate(resolve))
+  const replay = await gc.executeDesktopRoomCommand(command, descriptors)
+
+  assert.equal(replay.room_name, 'Classic')
+  assert.equal(gc.calls.length, 2)
+  assert.equal(Boolean(gc.$groupChats.get().Classic.desktopCommandSettled?.[command.command_id]), true)
 })
 
 test('legacy local execution evidence migrates authority but a cold projection does not', () => {
@@ -450,6 +570,64 @@ test('lost stop acknowledgement cannot stop newer work twice', async () => {
   await gc.executeDesktopRoomCommand(command, [{ name: 'Classic', roomId: 'room-1' }])
 
   assert.equal(gc.$groupChats.get().Classic.epoch, stoppedEpoch)
+})
+
+test('a priority Stop interrupts an active messaging-driven room turn', async () => {
+  let releaseTurn
+  const blockedTurn = new Promise(resolve => { releaseTurn = resolve })
+  const gc = load(() => blockedTurn, { deferredTimers: true })
+  const members = [{ name: 'research', title: '' }]
+  const descriptors = [{ name: 'Classic', roomId: 'room-1', authorityToken: 'authority:test' }]
+  gc.$lastRoster.set(members)
+  gc.$groupChats.set({
+    Classic: {
+      roomId: 'room-1',
+      log: [],
+      members,
+      epoch: 1,
+      running: false,
+      desktopCoordinatorId: gc.currentDesktopRoomCoordinatorId(),
+      desktopAuthorityToken: 'authority:test'
+    }
+  })
+
+  const send = gc.executeDesktopRoomCommand({
+    command_id: 'send:long',
+    room_id: 'room-1',
+    action: 'send',
+    payload: { message: 'Start the long task' }
+  }, descriptors)
+
+  for (let i = 0; i < 50 && !gc.$groupChats.get().Classic?.running; i++) {
+    await new Promise(resolve => setImmediate(resolve))
+  }
+  assert.equal(gc.$groupChats.get().Classic?.running, true)
+
+  const stopped = await gc.executeDesktopRoomCommand({
+    command_id: 'stop:priority',
+    room_id: 'room-1',
+    action: 'stop',
+    payload: {}
+  }, descriptors)
+  const sendResult = await send
+
+  assert.equal(stopped.room_name, 'Classic')
+  assert.equal(stopped.stopped, true)
+  assert.equal(sendResult.room_name, 'Classic')
+  assert.equal(sendResult.stopped, true)
+  assert.equal(gc.$groupChats.get().Classic.running, false)
+  assert.ok(gc.$groupChats.get().Classic.holds.research)
+
+  gc.updateGroupChat('Classic', current => {
+    current.epoch += 1
+    current.running = true
+    current.holds = {}
+    return current
+  })
+  releaseTurn('(pass)')
+  await new Promise(resolve => setImmediate(resolve))
+  assert.equal(gc.$groupChats.get().Classic.running, true)
+  assert.deepEqual(gc.$groupChats.get().Classic.holds, {})
 })
 
 test('pass detection: (pass), pass, pass., empty are silence; real text is not', () => {

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
@@ -205,7 +205,7 @@ function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall, approva
     .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
     .replace('export default {', 'globalThis.plugin = {')
     .concat(
-      '\nglobalThis.__gc = { sendToGroupChat, appendGroupChatEntry, runGroupChatRounds, harvestStrandedGroupReply, resolveGroupResponders, parseGroupChatMentions, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, groupSpeakerLabel, buildGroupChatTurnPrompt, trimGroupChatLog, groupChatHostedGateway, applyHostedRoomAuthority, groupChatSyncSequence, compareGroupChatSyncEntries, mergeGroupChatSyncEntries, groupChatSyncSnapshot, groupChatGatewayJsonSize, mergeGroupChatSyncSnapshots, mergeRemoteGroupChatSnapshotIntoRooms, scheduleGroupChatServerSync, disbandGroupChat, renameGroupChat, updateGroupChat, durableGroupChatRooms, hydratePersistedGroupChatRooms, persistGroupChatRooms, ensureGroupChatSession, uniqueGroupChatName, liveGroupChatNames, groupChatNames, openGroupChat, closeGroupChatMainTab, shouldRenderGroupChatInPane, syncGroupClarify, clearGroupClarify, answerGroupClarify, $groupClarify, $groupChats, $groupNeedsYou, $groupChatWorkspace, $groupMainTabsRev, $botMeta, $lastRoster, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
+      '\nglobalThis.__gc = { sendToGroupChat, appendGroupChatEntry, runGroupChatRounds, harvestStrandedGroupReply, resolveGroupResponders, parseGroupChatMentions, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, groupSpeakerLabel, buildGroupChatTurnPrompt, trimGroupChatLog, groupChatHostedGateway, applyHostedRoomAuthority, groupChatSyncSequence, compareGroupChatSyncEntries, mergeGroupChatSyncEntries, groupChatSyncSnapshot, groupChatGatewayJsonSize, mergeGroupChatSyncSnapshots, mergeRemoteGroupChatSnapshotIntoRooms, scheduleGroupChatServerSync, desktopCommandEligibleRooms, currentDesktopRoomCoordinatorId, executeDesktopRoomCommand, disbandGroupChat, renameGroupChat, updateGroupChat, durableGroupChatRooms, hydratePersistedGroupChatRooms, persistGroupChatRooms, ensureGroupChatSession, uniqueGroupChatName, liveGroupChatNames, groupChatNames, openGroupChat, closeGroupChatMainTab, shouldRenderGroupChatInPane, syncGroupClarify, clearGroupClarify, answerGroupClarify, $groupClarify, $groupChats, $groupNeedsYou, $groupChatWorkspace, $groupMainTabsRev, $botMeta, $lastRoster, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
     )
   vm.runInNewContext(source, context, { filename: 'plugin.js' })
   const storageWrites = new Map()
@@ -221,6 +221,236 @@ const MEMBERS = [{ name: 'research', title: '' }, { name: 'builder', title: '' }
 function roomLog(gc, group) {
   return (gc.$groupChats.get()[group] || { log: [] }).log
 }
+
+test('classic command pump advertises only rooms this Desktop can coordinate', () => {
+  const gc = load(() => '(pass)')
+  const coordinator = gc.currentDesktopRoomCoordinatorId()
+  gc.$groupChats.set({
+    Local: { log: [], desktopCoordinatorId: coordinator, members: [{ name: 'default' }] },
+    Remote: {
+      log: [],
+      desktopCoordinatorId: coordinator,
+      members: [{ name: 'reviewer', connectionId: 'gateway-a', sourceScoped: true }]
+    },
+    Missing: {
+      log: [],
+      desktopCoordinatorId: coordinator,
+      members: [{ name: 'builder', connectionId: 'gateway-b', sourceMissing: true }]
+    },
+    ColdProjection: { log: [], members: [{ name: 'default' }] },
+    OtherDesktop: { log: [], desktopCoordinatorId: 'desktop:other', members: [{ name: 'default' }] },
+    Hosted: { log: [], hosted: 'gateway-a', desktopCoordinatorId: coordinator, members: [{ name: 'ops' }] }
+  })
+
+  assert.deepEqual(
+    Object.keys(gc.desktopCommandEligibleRooms(['', 'gateway-a'])),
+    ['Local', 'Remote']
+  )
+})
+
+test('messaging redelivery keeps one visible classic-room user entry', () => {
+  const gc = load(() => '(pass)')
+  const members = [{ name: 'research', title: '' }]
+  gc.$groupChats.set({ Classic: { log: [], members } })
+
+  const first = gc.sendToGroupChat(
+    'Classic',
+    members,
+    'Review the plan',
+    null,
+    [],
+    { entryId: 'messaging:one', userName: 'Signal' }
+  )
+  const second = gc.sendToGroupChat(
+    'Classic',
+    members,
+    'Review the plan',
+    null,
+    [],
+    { entryId: 'messaging:one', userName: 'Signal' }
+  )
+
+  assert.equal(first, second)
+  assert.equal(
+    roomLog(gc, 'Classic').filter(entry => entry.id === 'messaging:one').length,
+    1
+  )
+  assert.equal(roomLog(gc, 'Classic')[0].from.name, 'Signal')
+})
+
+test('classic room execution authority persists locally but never projects', () => {
+  const gc = load(() => '(pass)')
+  const coordinator = gc.currentDesktopRoomCoordinatorId()
+  const rooms = {
+    Classic: {
+      roomId: 'room-1',
+      log: [{ id: 'u1', at: 1, from: { kind: 'user', name: 'You' }, text: 'hi' }],
+      desktopCoordinatorId: coordinator,
+      members: [{ name: 'research' }]
+    }
+  }
+
+  assert.equal(gc.durableGroupChatRooms(rooms).Classic.desktopCoordinatorId, coordinator)
+  const snapshot = gc.groupChatSyncSnapshot(rooms)
+  assert.equal(Object.hasOwn(snapshot.rooms['id:room-1'], 'desktopCoordinatorId'), false)
+})
+
+test('classic messaging send waits for a complete live roster', async () => {
+  const gc = load(() => '(pass)')
+  gc.$lastRoster.set([{ name: 'research' }])
+  gc.$groupChats.set({
+    Classic: {
+      roomId: 'room-1',
+      log: [],
+      members: [{ name: 'research' }, { name: 'builder' }],
+      desktopCoordinatorId: gc.currentDesktopRoomCoordinatorId()
+    }
+  })
+
+  await assert.rejects(
+    gc.executeDesktopRoomCommand({
+      command_id: 'messaging:wait',
+      room_id: 'room-1',
+      action: 'send',
+      payload: { message: 'Ship it' }
+    }, [{ name: 'Classic', roomId: 'room-1' }]),
+    error => error.retryable === true && /every Bot/.test(error.message)
+  )
+})
+
+test('classic messaging send treats a live-roster probe failure as retryable', async () => {
+  const gc = load(() => '(pass)')
+  gc.$lastRoster.set([{ name: 'research' }, { name: 'builder' }])
+  gc.$groupChats.set({
+    Classic: {
+      roomId: 'room-1',
+      log: [],
+      members: [{ name: 'research' }, { name: 'builder' }],
+      desktopCoordinatorId: gc.currentDesktopRoomCoordinatorId()
+    }
+  })
+  const request = gc.host.request
+  gc.host.request = async (method, params) => {
+    if (method === 'profiles.describe' && params.name === 'builder') {
+      throw new Error('connection lost')
+    }
+    return request(method, params)
+  }
+
+  await assert.rejects(
+    gc.executeDesktopRoomCommand({
+      command_id: 'messaging:probe',
+      room_id: 'room-1',
+      action: 'send',
+      payload: { message: 'Ship it' }
+    }, [{ name: 'Classic', roomId: 'room-1' }]),
+    error => error.retryable === true
+  )
+})
+
+test('legacy local execution evidence migrates authority but a cold projection does not', () => {
+  const gc = load(() => '(pass)')
+  const hydrated = gc.hydratePersistedGroupChatRooms({
+    Local: { log: [], sessions: { research: 'sid-1' }, members: [{ name: 'research' }] },
+    Projection: { log: [], members: [{ name: 'research' }] }
+  })
+
+  assert.equal(hydrated.Local.desktopCoordinatorId, gc.currentDesktopRoomCoordinatorId())
+  assert.equal(hydrated.Projection.desktopCoordinatorId, null)
+})
+
+test('a visible unacknowledged messaging entry re-drives once then stays settled', async () => {
+  const gc = load(() => '(pass)')
+  const members = [{ name: 'research', title: '' }]
+  gc.$groupChats.set({
+    Classic: {
+      log: [{
+        id: 'messaging:recover',
+        external: true,
+        at: 1,
+        from: { kind: 'user', name: 'Signal' },
+        text: 'Resume this',
+        thread: 'thread-recover'
+      }],
+      members,
+      desktopCoordinatorId: gc.currentDesktopRoomCoordinatorId(),
+      epoch: 0,
+      running: false
+    }
+  })
+
+  gc.sendToGroupChat('Classic', members, 'Resume this', null, [], {
+    entryId: 'messaging:recover',
+    userName: 'Signal'
+  })
+  for (let index = 0; index < 100 && gc.$groupChats.get().Classic.running; index++) {
+    await new Promise(resolve => setImmediate(resolve))
+  }
+
+  assert.equal(gc.calls.length, 1)
+  assert.equal(roomLog(gc, 'Classic').filter(entry => entry.id === 'messaging:recover').length, 1)
+  assert.ok(gc.$groupChats.get().Classic.desktopCommandSettled['messaging:recover'])
+
+  gc.sendToGroupChat('Classic', members, 'Resume this', null, [], {
+    entryId: 'messaging:recover',
+    userName: 'Signal'
+  })
+  await new Promise(resolve => setImmediate(resolve))
+  assert.equal(gc.calls.length, 1)
+})
+
+test('classic command execution resolves only after the room drive settles', async () => {
+  const gc = load(() => '(pass)')
+  const members = [{ name: 'research', title: '' }]
+  gc.$lastRoster.set(members)
+  gc.$groupChats.set({
+    Classic: {
+      roomId: 'room-1',
+      log: [],
+      members,
+      desktopCoordinatorId: gc.currentDesktopRoomCoordinatorId()
+    }
+  })
+
+  const result = await gc.executeDesktopRoomCommand({
+    command_id: 'messaging:settle',
+    room_id: 'room-1',
+    action: 'send',
+    payload: { message: 'Review this' }
+  }, [{ name: 'Classic', roomId: 'room-1' }])
+
+  assert.equal(result.thread_id.startsWith('t'), true)
+  assert.ok(gc.$groupChats.get().Classic.desktopCommandSettled['messaging:settle'])
+  assert.equal(gc.$groupChats.get().Classic.running, false)
+})
+
+test('lost stop acknowledgement cannot stop newer work twice', async () => {
+  const gc = load(() => '(pass)')
+  const members = [{ name: 'research', title: '' }]
+  gc.$lastRoster.set(members)
+  gc.$groupChats.set({
+    Classic: {
+      roomId: 'room-1',
+      log: [{ id: 'u1', from: { kind: 'user', name: 'You' }, text: 'work', thread: 't1' }],
+      members,
+      epoch: 3,
+      running: false,
+      desktopCoordinatorId: gc.currentDesktopRoomCoordinatorId()
+    }
+  })
+  const command = {
+    command_id: 'stop:one',
+    room_id: 'room-1',
+    action: 'stop',
+    payload: {}
+  }
+
+  await gc.executeDesktopRoomCommand(command, [{ name: 'Classic', roomId: 'room-1' }])
+  const stoppedEpoch = gc.$groupChats.get().Classic.epoch
+  await gc.executeDesktopRoomCommand(command, [{ name: 'Classic', roomId: 'room-1' }])
+
+  assert.equal(gc.$groupChats.get().Classic.epoch, stoppedEpoch)
+})
 
 test('pass detection: (pass), pass, pass., empty are silence; real text is not', () => {
   const gc = load(() => '(pass)')

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-composer-drafts.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-composer-drafts.test.mjs
@@ -23,10 +23,10 @@ function load() {
   vm.runInNewContext(
     `${roomKey}\n${drafts}\nglobalThis.drafts = {
       clearGroupComposerDraft,
+      completeGroupComposerSend,
       groupComposerDraftKey,
       groupComposerDraftSnapshot,
       migrateGroupComposerDraft,
-      restoreGroupComposerDraft,
       updateGroupComposerDraft
     }`,
     context
@@ -70,18 +70,39 @@ test('legacy name-keyed drafts migrate when an immutable room id appears', () =>
   assert.equal(drafts.groupComposerDraftSnapshot(legacy).main, '')
 })
 
-test('a failed send cannot overwrite text entered after the optimistic clear', () => {
+test('a send can detect newer typing without clearing the original draft first', () => {
   const drafts = load()
   const key = 'id:room-1'
 
   drafts.updateGroupComposerDraft(key, state => ({ ...state, main: 'send this' }))
   const before = drafts.groupComposerDraftSnapshot(key)
-  const cleared = drafts.updateGroupComposerDraft(key, state => ({ ...state, main: '' }))
-
   drafts.updateGroupComposerDraft(key, state => ({ ...state, main: 'newer typing' }))
 
-  assert.equal(drafts.restoreGroupComposerDraft(key, cleared.revision, before), null)
+  assert.notEqual(drafts.groupComposerDraftSnapshot(key).revision, before.revision)
   assert.equal(drafts.groupComposerDraftSnapshot(key).main, 'newer typing')
+})
+
+test('successful upload clears only submitted files while preserving newer typing and files', () => {
+  const drafts = load()
+  const key = 'id:room-1'
+  const submitted = { name: 'plan.pdf' }
+  const newer = { name: 'notes.txt' }
+  drafts.updateGroupComposerDraft(key, state => ({
+    ...state,
+    main: 'send this',
+    pendingAttachments: { main: [submitted] }
+  }))
+  const before = drafts.groupComposerDraftSnapshot(key)
+  drafts.updateGroupComposerDraft(key, state => ({
+    ...state,
+    main: 'send this and keep my newer edit',
+    pendingAttachments: { main: [submitted, newer] }
+  }))
+
+  const completed = drafts.completeGroupComposerSend(key, before, [submitted])
+
+  assert.equal(completed.main, 'send this and keep my newer edit')
+  assert.equal(completed.pendingAttachments.main.map(item => item.name).join(','), 'notes.txt')
 })
 
 test('disband removes only that room draft', () => {
@@ -99,7 +120,9 @@ test('GroupChatWorkspace owns composer state through the room draft store', () =
   const workspace = between('function GroupChatWorkspace(', '/** Live closers for group-chat MAIN-window tabs')
 
   assert.match(workspace, /groupComposerDraftKey\(group, room\)/)
-  assert.match(workspace, /restoreGroupComposerDraft\(composerKeyRef\.current, cleared\.revision, before\)/)
+  assert.match(workspace, /await Promise\.resolve\(/)
+  assert.match(workspace, /completeGroupComposerSend\(composerKeyRef\.current, before, images/)
+  assert.match(workspace, /sendingComposer === 'main' \? 'Sending…' : 'New Thread'/)
   assert.match(workspace, /clearGroupComposerDraft\(composerKeyRef\.current\)/)
   assert.doesNotMatch(workspace, /useState\(''\).*?draft/)
   assert.doesNotMatch(workspace, /useState\(\{\}\).*?replyDrafts/)

--- a/apps/desktop/src/plugins/hermes-bots/tests/hosted-room-client.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/hosted-room-client.test.mjs
@@ -1,0 +1,509 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  HOSTED_ROOM_CLIENT_LIMITATIONS,
+  classifyHostedRoomCapability,
+  createHostedRoomOutbox,
+  createHostedRoomReplayState,
+  deriveFriendlyHostedRoomStatus,
+  isHostedRoomContinuityEligible,
+  reduceHostedRoomEvents,
+  reduceHostedRoomOutbox,
+  replayHostedRoomPages,
+  resolveSingleGatewayRoute
+} from '../hosted-room-client.js'
+
+function attachmentManifest() {
+  return [
+    {
+      kind: 'image',
+      name: 'diagram.png',
+      size: 2048,
+      mime: 'image/png',
+      refs: {
+        research: 'stage:research:image-1',
+        builder: 'stage:builder:image-1'
+      }
+    },
+    {
+      kind: 'pdf',
+      name: 'brief.pdf',
+      size: 4096,
+      mime: 'application/pdf',
+      refs: {
+        research: 'stage:research:pdf-1',
+        builder: 'stage:builder:pdf-1'
+      }
+    },
+    {
+      kind: 'file',
+      name: 'notes.txt',
+      size: 128,
+      mime: 'text/plain',
+      refs: {
+        research: 'stage:research:file-1',
+        builder: 'stage:builder:file-1'
+      }
+    }
+  ]
+}
+
+function event(seq, eventId, kind, payload = {}, actor = { kind: 'gateway', id: 'install:home' }) {
+  return {
+    room_id: 'room-1',
+    seq,
+    event_id: eventId,
+    kind,
+    actor,
+    payload,
+    created_at: seq
+  }
+}
+
+test('capability classification distinguishes old, disabled, transient, and driver-capable gateways', () => {
+  const missing = Object.assign(new Error('JSON-RPC -32601: method not found'), { code: -32601 })
+
+  assert.deepEqual(classifyHostedRoomCapability({ ok: false, error: missing }, { connectionId: 'local-a' }), {
+    kind: 'unsupported',
+    reason: 'old-gateway',
+    connectionId: 'local-a',
+    authorityId: null,
+    persistentProcess: null,
+    limits: HOSTED_ROOM_CLIENT_LIMITATIONS
+  })
+
+  assert.equal(
+    classifyHostedRoomCapability({ ok: true, result: { driver: false } }, { connectionId: 'local-a' }).reason,
+    'driver-disabled'
+  )
+  assert.equal(
+    classifyHostedRoomCapability({ ok: false, error: new Error('socket closed during reconnect') }).kind,
+    'transient-failure'
+  )
+  assert.equal(classifyHostedRoomCapability(new Error('socket closed during reconnect')).kind, 'transient-failure')
+
+  const capable = classifyHostedRoomCapability(
+    {
+      ok: true,
+      result: {
+        driver: true,
+        persistent_process: true,
+        authority_gateway_id: 'install:stable-home',
+        max_log_limit: 250,
+        features: ['typed_events', 'attachments', 'automatic_failover']
+      }
+    },
+    { connectionId: 'machine-local-7' }
+  )
+
+  assert.equal(capable.kind, 'driver-capable')
+  assert.equal(capable.authorityId, 'install:stable-home')
+  assert.equal(capable.connectionId, 'machine-local-7')
+  assert.equal(capable.persistentProcess, true)
+  assert.equal(capable.maxLogLimit, 250)
+  assert.deepEqual(capable.limits, {
+    attachments: false,
+    automaticFailover: false,
+    crossGatewayMembers: false,
+    stagedAttachmentManifest: true
+  })
+
+  const appManaged = classifyHostedRoomCapability({
+    driver: true,
+    persistent_process: false,
+    authority_gateway_id: 'install:desktop-child'
+  })
+  assert.equal(appManaged.kind, 'driver-capable')
+  assert.equal(appManaged.persistentProcess, false)
+  assert.equal(isHostedRoomContinuityEligible(capable), true)
+  assert.equal(isHostedRoomContinuityEligible(appManaged), false)
+  assert.equal(isHostedRoomContinuityEligible({ driver: true, persistent_process: true }), true)
+  assert.equal(isHostedRoomContinuityEligible({ driver: false, persistent_process: true }), false)
+})
+
+test('single-gateway route resolution accepts 2-6 co-located bots and rejects mixed or incomplete routes', () => {
+  const same = resolveSingleGatewayRoute(
+    [
+      { name: 'research', connectionId: 'connection-a', sourceScoped: true },
+      { name: 'builder', route: { connectionId: 'connection-a' }, remoteSource: true }
+    ],
+    { activeConnectionId: 'active-local' }
+  )
+
+  assert.deepEqual(same, {
+    kind: 'single-gateway',
+    reason: null,
+    connectionId: 'connection-a',
+    memberConnectionIds: ['connection-a', 'connection-a'],
+    limits: HOSTED_ROOM_CLIENT_LIMITATIONS
+  })
+
+  const local = resolveSingleGatewayRoute([{ name: 'one' }, { name: 'two' }], {
+    activeConnectionId: 'active-local'
+  })
+  assert.equal(local.connectionId, 'active-local')
+
+  const mixed = resolveSingleGatewayRoute([
+    { name: 'one', connectionId: 'connection-a', sourceScoped: true },
+    { name: 'two', connectionId: 'connection-b', sourceScoped: true }
+  ])
+  assert.equal(mixed.kind, 'unsupported')
+  assert.equal(mixed.reason, 'cross-gateway')
+
+  assert.equal(
+    resolveSingleGatewayRoute([{ name: 'alone' }], { activeConnectionId: 'active-local' }).reason,
+    'member-count'
+  )
+  assert.equal(
+    resolveSingleGatewayRoute(
+      [
+        { name: 'one', connectionId: 'connection-a', sourceScoped: true },
+        { name: 'lost', sourceScoped: true }
+      ],
+      { activeConnectionId: 'active-local' }
+    ).reason,
+    'unresolved-member-route'
+  )
+})
+
+test('authoritative replay orders and deduplicates by sequence and event id while ignoring unknown events safely', () => {
+  const initial = createHostedRoomReplayState({
+    roomId: 'room-1',
+    name: 'Release room',
+    members: [{ profile: 'research' }],
+    authorityId: 'install:stable-home',
+    connectionId: 'machine-local-7'
+  })
+  const user = event(
+    1,
+    'event-user-1',
+    'message.user',
+    { text: 'Start the review', thread_id: 'thread-1' },
+    { kind: 'user', id: 'desktop' }
+  )
+  const unknown = event(2, 'event-future-1', 'future.room.signal', { destructive: true })
+  const member = event(
+    3,
+    'event-member-1',
+    'message.member',
+    { text: 'Review complete', thread_id: 'thread-1' },
+    { kind: 'member', id: 'research', display_name: 'Research', profile: 'research' }
+  )
+
+  const replayed = reduceHostedRoomEvents(initial, [member, unknown, user, { ...user }])
+
+  assert.equal(replayed.cursor, 3)
+  assert.equal(replayed.name, 'Release room')
+  assert.deepEqual(replayed.members, [{ profile: 'research' }])
+  assert.deepEqual(
+    replayed.messages.map(message => [message.seq, message.eventId, message.text]),
+    [
+      [1, 'event-user-1', 'Start the review'],
+      [3, 'event-member-1', 'Review complete']
+    ]
+  )
+  assert.deepEqual(replayed.pendingEvents, [])
+
+  const repeated = reduceHostedRoomEvents(replayed, [member, unknown, user])
+  assert.equal(repeated.cursor, 3)
+  assert.equal(repeated.messages.length, 2)
+})
+
+test('replay buffers sequence gaps and a tombstone preserves history while closing the room', () => {
+  const initial = createHostedRoomReplayState({ roomId: 'room-1', name: 'Core' })
+  const later = event(
+    2,
+    'event-member-1',
+    'message.member',
+    { text: 'Done' },
+    { kind: 'member', id: 'builder', display_name: 'Builder' }
+  )
+
+  const buffered = reduceHostedRoomEvents(initial, [later])
+  assert.equal(buffered.cursor, 0)
+  assert.equal(buffered.pendingEvents.length, 1)
+
+  const caughtUp = reduceHostedRoomEvents(buffered, [
+    event(1, 'event-user-1', 'message.user', { text: 'Build it' }, { kind: 'user', id: 'desktop' })
+  ])
+  const deleted = reduceHostedRoomEvents(caughtUp, [event(3, 'system:room-disbanded', 'room.disbanded')])
+
+  assert.equal(deleted.cursor, 3)
+  assert.equal(deleted.deleted, true)
+  assert.deepEqual(
+    deleted.messages.map(message => message.text),
+    ['Build it', 'Done']
+  )
+  assert.deepEqual(deriveFriendlyHostedRoomStatus(deleted), {
+    kind: 'deleted',
+    text: 'This group was deleted.',
+    member: null,
+    canRetry: false,
+    canStop: false
+  })
+})
+
+test('replay preserves safe attachment metadata without exposing staged member refs', () => {
+  const replayed = reduceHostedRoomEvents(createHostedRoomReplayState({ roomId: 'room-1' }), [
+    event(
+      1,
+      'event-user-with-attachments',
+      'message.user',
+      { text: 'Review these', thread_id: 'thread-1', attachments: attachmentManifest() },
+      { kind: 'user', id: 'desktop' }
+    )
+  ])
+
+  assert.deepEqual(replayed.messages[0].attachments, [
+    { kind: 'image', name: 'diagram.png', size: 2048, mime: 'image/png' },
+    { kind: 'pdf', name: 'brief.pdf', size: 4096, mime: 'application/pdf' },
+    { kind: 'file', name: 'notes.txt', size: 128, mime: 'text/plain' }
+  ])
+  assert.doesNotMatch(JSON.stringify(replayed.messages[0]), /stage:|refs/)
+})
+
+test('friendly status output uses typed reason codes without exposing coordination jargon', () => {
+  const cases = [
+    [
+      event(1, 'turn-started-1', 'turn.started', { member_display_name: 'Research', task_id: 'task-secret' }),
+      'Research is working.',
+      'working'
+    ],
+    [
+      event(1, 'member-unavailable-1', 'member.unavailable', { member_display_name: 'Builder', lease: 'lease-secret' }),
+      'Builder is unavailable.',
+      'member-unavailable'
+    ],
+    [
+      event(1, 'turn-failed-1', 'turn.failed', {
+        member_display_name: 'Research',
+        reason_code: 'provider_auth_or_access',
+        error: 'stale lease at epoch 9 for task 12'
+      }),
+      'Research needs you to sign in again.',
+      'needs-attention'
+    ],
+    [event(1, 'turn-cancelled-1', 'turn.cancelled', { task_id: 'task-secret' }), 'Stopped.', 'stopped'],
+    [event(1, 'authority-lost-1', 'authority.lost', { authority_epoch: 9 }), 'This room is offline.', 'offline']
+  ]
+
+  for (const [roomEvent, text, kind] of cases) {
+    const state = reduceHostedRoomEvents(createHostedRoomReplayState({ roomId: 'room-1' }), [roomEvent])
+    const status = deriveFriendlyHostedRoomStatus(state)
+
+    assert.equal(status.text, text)
+    assert.equal(status.kind, kind)
+    assert.doesNotMatch(JSON.stringify(status), /lease|epoch|task/i)
+  }
+})
+
+test('bounded paged replay resumes from the persisted cursor and catches up through reordered pages', async () => {
+  const calls = []
+  const pages = [
+    {
+      events: [
+        event(4, 'event-member-2', 'message.member', { text: 'Four' }, { kind: 'member', id: 'builder' }),
+        event(3, 'event-user-2', 'message.user', { text: 'Three' }, { kind: 'user', id: 'desktop' })
+      ],
+      cursor: 4,
+      latest_seq: 5,
+      has_more: true
+    },
+    {
+      events: [event(5, 'turn-settled-1', 'turn.settled')],
+      cursor: 5,
+      latest_seq: 5,
+      has_more: false
+    }
+  ]
+
+  const result = await replayHostedRoomPages({
+    state: createHostedRoomReplayState({ roomId: 'room-1', cursor: 2 }),
+    pageSize: 2,
+    maxPages: 4,
+    fetchPage: async params => {
+      calls.push(params)
+      return pages.shift()
+    }
+  })
+
+  assert.equal(result.complete, true)
+  assert.equal(result.reason, null)
+  assert.equal(result.pages, 2)
+  assert.equal(result.state.cursor, 5)
+  assert.deepEqual(calls, [
+    { sinceSeq: 2, limit: 2 },
+    { sinceSeq: 4, limit: 2 }
+  ])
+  assert.deepEqual(
+    result.state.messages.map(message => message.text),
+    ['Three', 'Four']
+  )
+})
+
+test('paged replay stops at its configured bound instead of spinning', async () => {
+  const result = await replayHostedRoomPages({
+    state: createHostedRoomReplayState({ roomId: 'room-1' }),
+    pageSize: 1,
+    maxPages: 1,
+    fetchPage: async () => ({
+      events: [event(1, 'event-user-1', 'message.user', { text: 'One' }, { kind: 'user', id: 'desktop' })],
+      cursor: 1,
+      latest_seq: 2,
+      has_more: true
+    })
+  })
+
+  assert.equal(result.complete, false)
+  assert.equal(result.reason, 'limit')
+  assert.equal(result.state.cursor, 1)
+})
+
+test('paged replay refuses a gateway response larger than the requested bound', async () => {
+  const result = await replayHostedRoomPages({
+    state: createHostedRoomReplayState({ roomId: 'room-1' }),
+    pageSize: 1,
+    fetchPage: async () => ({
+      events: [
+        event(1, 'event-user-1', 'message.user', { text: 'One' }, { kind: 'user', id: 'desktop' }),
+        event(2, 'event-user-2', 'message.user', { text: 'Two' }, { kind: 'user', id: 'desktop' })
+      ],
+      cursor: 2,
+      latest_seq: 2,
+      has_more: false
+    })
+  })
+
+  assert.equal(result.complete, false)
+  assert.equal(result.reason, 'oversized-page')
+  assert.equal(result.state.cursor, 0)
+})
+
+test('persisted command outbox accepts each supported command and enqueue is idempotent', () => {
+  let outbox = createHostedRoomOutbox()
+
+  for (const kind of ['create', 'send', 'stop', 'disband']) {
+    outbox = reduceHostedRoomOutbox(outbox, {
+      type: 'enqueue',
+      command: {
+        commandId: `${kind}-1`,
+        kind,
+        roomId: 'room-1',
+        authorityId: 'install:stable-home',
+        connectionId: 'machine-local-7',
+        payload: kind === 'send' ? { text: 'Hello', thread_id: 'thread-1', attachments: attachmentManifest() } : {}
+      }
+    })
+  }
+
+  const unchanged = reduceHostedRoomOutbox(outbox, { type: 'enqueue', command: outbox.commands[0] })
+  assert.equal(unchanged, outbox)
+  assert.deepEqual(
+    outbox.commands.map(command => command.kind),
+    ['create', 'send', 'stop', 'disband']
+  )
+  assert.equal(outbox.commands[0].authorityId, 'install:stable-home')
+  assert.equal(outbox.commands[0].connectionId, 'machine-local-7')
+  assert.deepEqual(outbox.commands[1].payload.attachments, attachmentManifest())
+})
+
+test('send attachment manifests reject raw transport data, local paths, malformed refs, and oversized metadata', () => {
+  const enqueue = attachments =>
+    reduceHostedRoomOutbox(createHostedRoomOutbox(), {
+      type: 'enqueue',
+      command: {
+        commandId: 'send-with-files',
+        kind: 'send',
+        roomId: 'room-1',
+        authorityId: 'install:stable-home',
+        connectionId: 'machine-local-7',
+        payload: { text: 'See files', attachments }
+      }
+    })
+
+  assert.throws(() => enqueue(Array.from({ length: 9 }, () => attachmentManifest()[0])), /at most 8/i)
+
+  const oversizedName = attachmentManifest()
+  oversizedName[0].name = `${'x'.repeat(256)}.png`
+  assert.throws(() => enqueue(oversizedName), /attachment name/i)
+
+  const rawData = attachmentManifest()
+  rawData[0].data = 'data:image/png;base64,AAAA'
+  assert.throws(() => enqueue(rawData), /data/i)
+
+  const rawBase64 = attachmentManifest()
+  rawBase64[0].content_base64 = 'AAAA'
+  assert.throws(() => enqueue(rawBase64), /base64/i)
+
+  const localPath = attachmentManifest()
+  localPath[0].path = '/Users/david/Desktop/diagram.png'
+  assert.throws(() => enqueue(localPath), /path/i)
+
+  const pathRef = attachmentManifest()
+  pathRef[0].refs.research = '/tmp/diagram.png'
+  assert.throws(() => enqueue(pathRef), /staged reference/i)
+
+  const fileRef = attachmentManifest()
+  fileRef[0].refs.research = 'file:diagram.png'
+  assert.throws(() => enqueue(fileRef), /staged reference/i)
+
+  assert.throws(
+    () =>
+      reduceHostedRoomOutbox(createHostedRoomOutbox(), {
+        type: 'enqueue',
+        command: {
+          commandId: 'send-with-image-alias',
+          kind: 'send',
+          roomId: 'room-1',
+          authorityId: 'install:stable-home',
+          connectionId: 'machine-local-7',
+          payload: { text: 'See image', images: attachmentManifest() }
+        }
+      }),
+    /attachments manifest/i
+  )
+
+  assert.throws(
+    () =>
+      enqueue([
+        {
+          kind: 'pdf',
+          name: 'report.pdf',
+          size: 10,
+          mime: 'application/pdf',
+          refs: {}
+        }
+      ]),
+    /member refs/i
+  )
+})
+
+test('response-lost commands retry with the same idempotency key after persisted rehydration', () => {
+  const command = {
+    commandId: 'send-stable-1',
+    kind: 'send',
+    roomId: 'room-1',
+    authorityId: 'install:stable-home',
+    connectionId: 'machine-local-7',
+    payload: { text: 'Ship it', thread_id: 'thread-1', attachments: attachmentManifest() }
+  }
+  let outbox = reduceHostedRoomOutbox(createHostedRoomOutbox(), { type: 'enqueue', command })
+  outbox = reduceHostedRoomOutbox(outbox, { type: 'dispatch', commandId: command.commandId })
+
+  const rehydrated = createHostedRoomOutbox(JSON.parse(JSON.stringify(outbox)))
+  assert.equal(rehydrated.commands[0].status, 'pending')
+  assert.equal(rehydrated.commands[0].attempts, 1)
+  assert.equal(rehydrated.commands[0].commandId, command.commandId)
+  assert.deepEqual(rehydrated.commands[0].payload.attachments, attachmentManifest())
+
+  const deduped = reduceHostedRoomOutbox(rehydrated, { type: 'enqueue', command })
+  assert.equal(deduped, rehydrated)
+
+  const retried = reduceHostedRoomOutbox(rehydrated, { type: 'dispatch', commandId: command.commandId })
+  assert.equal(retried.commands[0].attempts, 2)
+  assert.equal(retried.commands[0].commandId, command.commandId)
+
+  const acknowledged = reduceHostedRoomOutbox(retried, { type: 'acknowledge', commandId: command.commandId })
+  assert.deepEqual(acknowledged.commands, [])
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/hosted-room-client.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/hosted-room-client.test.mjs
@@ -17,34 +17,25 @@ import {
 function attachmentManifest() {
   return [
     {
+      attachment_id: 'att_11111111111111111111111111111111',
       kind: 'image',
       name: 'diagram.png',
       size: 2048,
-      mime: 'image/png',
-      refs: {
-        research: 'stage:research:image-1',
-        builder: 'stage:builder:image-1'
-      }
+      mime: 'image/png'
     },
     {
+      attachment_id: 'att_22222222222222222222222222222222',
       kind: 'pdf',
       name: 'brief.pdf',
       size: 4096,
-      mime: 'application/pdf',
-      refs: {
-        research: 'stage:research:pdf-1',
-        builder: 'stage:builder:pdf-1'
-      }
+      mime: 'application/pdf'
     },
     {
+      attachment_id: 'att_33333333333333333333333333333333',
       kind: 'file',
       name: 'notes.txt',
       size: 128,
-      mime: 'text/plain',
-      refs: {
-        research: 'stage:research:file-1',
-        builder: 'stage:builder:file-1'
-      }
+      mime: 'text/plain'
     }
   ]
 }
@@ -103,7 +94,7 @@ test('capability classification distinguishes old, disabled, transient, and driv
   assert.equal(capable.persistentProcess, true)
   assert.equal(capable.maxLogLimit, 250)
   assert.deepEqual(capable.limits, {
-    attachments: false,
+    attachments: true,
     automaticFailover: false,
     crossGatewayMembers: false,
     stagedAttachmentManifest: true
@@ -244,7 +235,7 @@ test('replay buffers sequence gaps and a tombstone preserves history while closi
   })
 })
 
-test('replay preserves safe attachment metadata without exposing staged member refs', () => {
+test('replay preserves opaque attachment ids in the renderer attachment shape', () => {
   const replayed = reduceHostedRoomEvents(createHostedRoomReplayState({ roomId: 'room-1' }), [
     event(
       1,
@@ -255,11 +246,7 @@ test('replay preserves safe attachment metadata without exposing staged member r
     )
   ])
 
-  assert.deepEqual(replayed.messages[0].attachments, [
-    { kind: 'image', name: 'diagram.png', size: 2048, mime: 'image/png' },
-    { kind: 'pdf', name: 'brief.pdf', size: 4096, mime: 'application/pdf' },
-    { kind: 'file', name: 'notes.txt', size: 128, mime: 'text/plain' }
-  ])
+  assert.deepEqual(replayed.messages[0].images, attachmentManifest())
   assert.doesNotMatch(JSON.stringify(replayed.messages[0]), /stage:|refs/)
 })
 
@@ -408,7 +395,7 @@ test('persisted command outbox accepts each supported command and enqueue is ide
   assert.deepEqual(outbox.commands[1].payload.attachments, attachmentManifest())
 })
 
-test('send attachment manifests reject raw transport data, local paths, malformed refs, and oversized metadata', () => {
+test('send attachment manifests reject raw transport data, local paths, malformed ids, and oversized metadata', () => {
   const enqueue = attachments =>
     reduceHostedRoomOutbox(createHostedRoomOutbox(), {
       type: 'enqueue',
@@ -440,13 +427,20 @@ test('send attachment manifests reject raw transport data, local paths, malforme
   localPath[0].path = '/Users/david/Desktop/diagram.png'
   assert.throws(() => enqueue(localPath), /path/i)
 
-  const pathRef = attachmentManifest()
-  pathRef[0].refs.research = '/tmp/diagram.png'
-  assert.throws(() => enqueue(pathRef), /staged reference/i)
+  const badId = attachmentManifest()
+  badId[0].attachment_id = 'file:diagram.png'
+  assert.throws(() => enqueue(badId), /server-minted id/i)
 
-  const fileRef = attachmentManifest()
-  fileRef[0].refs.research = 'file:diagram.png'
-  assert.throws(() => enqueue(fileRef), /staged reference/i)
+  const duplicateIds = attachmentManifest()
+  duplicateIds[1].attachment_id = duplicateIds[0].attachment_id
+  assert.throws(() => enqueue(duplicateIds), /unique/i)
+
+  const oversizedTotal = attachmentManifest().map((attachment, index) => ({
+    ...attachment,
+    attachment_id: `att_${String(index).padStart(32, '0')}`,
+    size: 9_000_000
+  }))
+  assert.throws(() => enqueue(oversizedTotal), /25MB/i)
 
   assert.throws(
     () =>
@@ -468,14 +462,15 @@ test('send attachment manifests reject raw transport data, local paths, malforme
     () =>
       enqueue([
         {
+          attachment_id: 'att_44444444444444444444444444444444',
           kind: 'pdf',
           name: 'report.pdf',
           size: 10,
           mime: 'application/pdf',
-          refs: {}
+          content_base64: 'AAAA'
         }
       ]),
-    /member refs/i
+    /base64/i
   )
 })
 

--- a/docs/relay-connector-contract.md
+++ b/docs/relay-connector-contract.md
@@ -182,11 +182,11 @@ present (may be `null`); the rest are included only when set.
 | `guild_id` | string | no | **Legacy alias, no longer read by the connector.** As of D-Q2.5c the connector reads and writes only `scope_id`; the gateway's agent-wide `SessionSource.to_dict()` still emits `guild_id` (mirrored to `scope_id`) for non-relay session persistence, so it may still appear on the wire but the connector ignores it. Do not depend on it. |
 | `parent_chat_id` | string | no | Parent channel when `chat_id` refers to a thread. |
 | `message_id` | string | no | Id of the triggering message (for pin/reply/react). |
+| `is_bot` | boolean | yes | Whether the author is a bot or webhook. Room controls fail closed when an older connector omits this classification. |
 
-> `is_bot` (author-is-a-bot/webhook classification) exists on the gateway-side
-> dataclass but is **intentionally NOT on the wire** in v1 — it is not part of
-> `to_dict()`. Do not add it to the connector's `SessionSource` until it is
-> first added here and to `to_dict()` (additive bump).
+`is_bot` is an additive author-provenance bump. Updated connectors must send an
+explicit `false` for people rather than omitting the field; omission remains
+accepted by older gateway features but room controls reject it.
 
 ### SessionSource discriminators per platform
 

--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -84,6 +84,67 @@ def _coerce_allow_set(raw) -> set[str]:
     return {part.strip() for part in str(raw).split(",") if part.strip()}
 
 
+_PLATFORM_ALLOWED_USERS_ENV = {
+    Platform.TELEGRAM: "TELEGRAM_ALLOWED_USERS",
+    Platform.DISCORD: "DISCORD_ALLOWED_USERS",
+    Platform.WHATSAPP: "WHATSAPP_ALLOWED_USERS",
+    Platform.WHATSAPP_CLOUD: "WHATSAPP_CLOUD_ALLOWED_USERS",
+    Platform.SLACK: "SLACK_ALLOWED_USERS",
+    Platform.SIGNAL: "SIGNAL_ALLOWED_USERS",
+    Platform.EMAIL: "EMAIL_ALLOWED_USERS",
+    Platform.SMS: "SMS_ALLOWED_USERS",
+    Platform.MATTERMOST: "MATTERMOST_ALLOWED_USERS",
+    Platform.MATRIX: "MATRIX_ALLOWED_USERS",
+    Platform.DINGTALK: "DINGTALK_ALLOWED_USERS",
+    Platform.FEISHU: "FEISHU_ALLOWED_USERS",
+    Platform.WECOM: "WECOM_ALLOWED_USERS",
+    Platform.WECOM_CALLBACK: "WECOM_CALLBACK_ALLOWED_USERS",
+    Platform.WEIXIN: "WEIXIN_ALLOWED_USERS",
+    Platform.BLUEBUBBLES: "BLUEBUBBLES_ALLOWED_USERS",
+    Platform.QQBOT: "QQ_ALLOWED_USERS",
+    Platform.YUANBAO: "YUANBAO_ALLOWED_USERS",
+}
+
+_PLATFORM_ALLOW_ALL_ENV = {
+    Platform.TELEGRAM: "TELEGRAM_ALLOW_ALL_USERS",
+    Platform.DISCORD: "DISCORD_ALLOW_ALL_USERS",
+    Platform.WHATSAPP: "WHATSAPP_ALLOW_ALL_USERS",
+    Platform.WHATSAPP_CLOUD: "WHATSAPP_CLOUD_ALLOW_ALL_USERS",
+    Platform.SLACK: "SLACK_ALLOW_ALL_USERS",
+    Platform.SIGNAL: "SIGNAL_ALLOW_ALL_USERS",
+    Platform.EMAIL: "EMAIL_ALLOW_ALL_USERS",
+    Platform.SMS: "SMS_ALLOW_ALL_USERS",
+    Platform.MATTERMOST: "MATTERMOST_ALLOW_ALL_USERS",
+    Platform.MATRIX: "MATRIX_ALLOW_ALL_USERS",
+    Platform.DINGTALK: "DINGTALK_ALLOW_ALL_USERS",
+    Platform.FEISHU: "FEISHU_ALLOW_ALL_USERS",
+    Platform.WECOM: "WECOM_ALLOW_ALL_USERS",
+    Platform.WECOM_CALLBACK: "WECOM_CALLBACK_ALLOW_ALL_USERS",
+    Platform.WEIXIN: "WEIXIN_ALLOW_ALL_USERS",
+    Platform.BLUEBUBBLES: "BLUEBUBBLES_ALLOW_ALL_USERS",
+    Platform.QQBOT: "QQ_ALLOW_ALL_USERS",
+    Platform.YUANBAO: "YUANBAO_ALLOW_ALL_USERS",
+}
+
+
+def _platform_authorization_env_names(platform: Platform) -> tuple[str, str]:
+    """Return the authoritative allowed-users and allow-all env names."""
+    allowed_users = _PLATFORM_ALLOWED_USERS_ENV.get(platform, "")
+    allow_all = _PLATFORM_ALLOW_ALL_ENV.get(platform, "")
+    if allowed_users and allow_all:
+        return allowed_users, allow_all
+    try:
+        from gateway.platform_registry import platform_registry
+
+        entry = platform_registry.get(platform.value)
+        if entry is not None:
+            allowed_users = allowed_users or entry.allowed_users_env
+            allow_all = allow_all or entry.allow_all_env
+    except Exception:
+        pass
+    return allowed_users, allow_all
+
+
 class GatewayAuthorizationMixin:
     """User/chat authorization methods for ``GatewayRunner``."""
 
@@ -509,26 +570,9 @@ class GatewayAuthorizationMixin:
         if not user_id:
             return False
 
-        platform_env_map = {
-            Platform.TELEGRAM: "TELEGRAM_ALLOWED_USERS",
-            Platform.DISCORD: "DISCORD_ALLOWED_USERS",
-            Platform.WHATSAPP: "WHATSAPP_ALLOWED_USERS",
-            Platform.WHATSAPP_CLOUD: "WHATSAPP_CLOUD_ALLOWED_USERS",
-            Platform.SLACK: "SLACK_ALLOWED_USERS",
-            Platform.SIGNAL: "SIGNAL_ALLOWED_USERS",
-            Platform.EMAIL: "EMAIL_ALLOWED_USERS",
-            Platform.SMS: "SMS_ALLOWED_USERS",
-            Platform.MATTERMOST: "MATTERMOST_ALLOWED_USERS",
-            Platform.MATRIX: "MATRIX_ALLOWED_USERS",
-            Platform.DINGTALK: "DINGTALK_ALLOWED_USERS",
-            Platform.FEISHU: "FEISHU_ALLOWED_USERS",
-            Platform.WECOM: "WECOM_ALLOWED_USERS",
-            Platform.WECOM_CALLBACK: "WECOM_CALLBACK_ALLOWED_USERS",
-            Platform.WEIXIN: "WEIXIN_ALLOWED_USERS",
-            Platform.BLUEBUBBLES: "BLUEBUBBLES_ALLOWED_USERS",
-            Platform.QQBOT: "QQ_ALLOWED_USERS",
-            Platform.YUANBAO: "YUANBAO_ALLOWED_USERS",
-        }
+        platform_allowed_users_var, platform_allow_all_var = (
+            _platform_authorization_env_names(source.platform)
+        )
         platform_group_user_env_map = {
             Platform.TELEGRAM: "TELEGRAM_GROUP_ALLOWED_USERS",
         }
@@ -536,43 +580,7 @@ class GatewayAuthorizationMixin:
             Platform.TELEGRAM: "TELEGRAM_GROUP_ALLOWED_CHATS",
             Platform.QQBOT: "QQ_GROUP_ALLOWED_USERS",
         }
-        platform_allow_all_map = {
-            Platform.TELEGRAM: "TELEGRAM_ALLOW_ALL_USERS",
-            Platform.DISCORD: "DISCORD_ALLOW_ALL_USERS",
-            Platform.WHATSAPP: "WHATSAPP_ALLOW_ALL_USERS",
-            Platform.WHATSAPP_CLOUD: "WHATSAPP_CLOUD_ALLOW_ALL_USERS",
-            Platform.SLACK: "SLACK_ALLOW_ALL_USERS",
-            Platform.SIGNAL: "SIGNAL_ALLOW_ALL_USERS",
-            Platform.EMAIL: "EMAIL_ALLOW_ALL_USERS",
-            Platform.SMS: "SMS_ALLOW_ALL_USERS",
-            Platform.MATTERMOST: "MATTERMOST_ALLOW_ALL_USERS",
-            Platform.MATRIX: "MATRIX_ALLOW_ALL_USERS",
-            Platform.DINGTALK: "DINGTALK_ALLOW_ALL_USERS",
-            Platform.FEISHU: "FEISHU_ALLOW_ALL_USERS",
-            Platform.WECOM: "WECOM_ALLOW_ALL_USERS",
-            Platform.WECOM_CALLBACK: "WECOM_CALLBACK_ALLOW_ALL_USERS",
-            Platform.WEIXIN: "WEIXIN_ALLOW_ALL_USERS",
-            Platform.BLUEBUBBLES: "BLUEBUBBLES_ALLOW_ALL_USERS",
-            Platform.QQBOT: "QQ_ALLOW_ALL_USERS",
-            Platform.YUANBAO: "YUANBAO_ALLOW_ALL_USERS",
-        }
-
-        # Plugin platforms: check the registry for auth env var names
-        if source.platform not in platform_env_map:
-            try:
-                from gateway.platform_registry import platform_registry
-
-                entry = platform_registry.get(source.platform.value)
-                if entry:
-                    if entry.allowed_users_env:
-                        platform_env_map[source.platform] = entry.allowed_users_env
-                    if entry.allow_all_env:
-                        platform_allow_all_map[source.platform] = entry.allow_all_env
-            except Exception:
-                pass
-
         # Per-platform allow-all flag (e.g., DISCORD_ALLOW_ALL_USERS=true)
-        platform_allow_all_var = platform_allow_all_map.get(source.platform, "")
         if platform_allow_all_var and _auth_env(platform_allow_all_var).lower() in {"true", "1", "yes"}:
             return True
 
@@ -607,7 +615,7 @@ class GatewayAuthorizationMixin:
             return True
 
         # Check platform-specific and global allowlists
-        platform_allowlist = _auth_env(platform_env_map.get(source.platform, ""))
+        platform_allowlist = _auth_env(platform_allowed_users_var)
         group_user_allowlist = ""
         group_chat_allowlist = ""
         if source.chat_type in {"group", "forum"}:

--- a/gateway/desktop_room_mailbox.py
+++ b/gateway/desktop_room_mailbox.py
@@ -115,7 +115,7 @@ def authorize_attachment_read(
     authority_token: Any,
     clock: Any = time.time,
 ) -> None:
-    """Require the live command lease and room authority before byte access."""
+    """Require the live command lease and bound room authority before byte access."""
 
     room_id = _room_identifier(room_id)
     command_id = _identifier(command_id, label="command_id")

--- a/gateway/desktop_room_mailbox.py
+++ b/gateway/desktop_room_mailbox.py
@@ -7,6 +7,7 @@ idempotent and recoverable without making the gateway a second room runner.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import re
@@ -30,6 +31,7 @@ CLAIM_TTL_SECONDS = 45.0
 TERMINAL_RETENTION_SECONDS = 7 * 24 * 60 * 60
 
 _IDENTIFIER_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]*$")
+_AUTHORITY_HASH_RE = re.compile(r"^[a-f0-9]{64}$")
 _ACTIONS = frozenset({"send", "stop"})
 _TERMINAL_STATES = frozenset({"completed", "failed"})
 
@@ -76,6 +78,48 @@ def _room_ids(value: Any) -> list[str]:
     if len(value) > MAX_ROOM_IDS:
         raise DesktopRoomMailboxError("too many room_ids")
     return list(dict.fromkeys(_room_identifier(item) for item in value))
+
+
+def _room_authorities(value: Any) -> list[tuple[str, str]]:
+    if not isinstance(value, (list, tuple)):
+        raise DesktopRoomMailboxError("room_authorities must be a list")
+    if len(value) > MAX_ROOM_IDS:
+        raise DesktopRoomMailboxError("too many room authorities")
+    authorities: dict[str, str] = {}
+    for item in value:
+        if not isinstance(item, dict):
+            raise DesktopRoomMailboxError("invalid room authority")
+        room_id = _room_identifier(item.get("room_id"))
+        token = _identifier(item.get("authority_token"), label="authority_token")
+        digest = hashlib.sha256(token.encode("utf-8")).hexdigest()
+        prior = authorities.setdefault(room_id, digest)
+        if prior != digest:
+            raise DesktopRoomMailboxError("conflicting room authority")
+    return list(authorities.items())
+
+
+def _authority_hash(value: Any) -> str:
+    authority_hash = str(value or "").strip().casefold()
+    if not _AUTHORITY_HASH_RE.fullmatch(authority_hash):
+        raise DesktopRoomMailboxError("invalid room authority commitment")
+    return authority_hash
+
+
+def _room_commitments(value: Any) -> list[tuple[str, str]]:
+    if not isinstance(value, (list, tuple)):
+        raise DesktopRoomMailboxError("room commitments must be a list")
+    if len(value) > MAX_ROOM_IDS:
+        raise DesktopRoomMailboxError("too many room commitments")
+    commitments: dict[str, str] = {}
+    for item in value:
+        if not isinstance(item, dict):
+            raise DesktopRoomMailboxError("invalid room commitment")
+        room_id = _room_identifier(item.get("room_id"))
+        authority_hash = _authority_hash(item.get("authority_hash"))
+        prior = commitments.setdefault(room_id, authority_hash)
+        if prior != authority_hash:
+            raise DesktopRoomMailboxError("conflicting room commitment")
+    return list(commitments.items())
 
 
 def _query_room_ids(value: Any) -> list[str]:
@@ -150,6 +194,21 @@ def _initialize(conn: sqlite3.Connection) -> None:
         """CREATE INDEX IF NOT EXISTS idx_desktop_room_owners_expiry
            ON desktop_room_owners(expires_at)"""
     )
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS desktop_room_authorities (
+            room_id TEXT PRIMARY KEY,
+            consumer_id TEXT,
+            authority_hash TEXT NOT NULL,
+            created_at REAL NOT NULL
+        )"""
+    )
+    authority_columns = {
+        row[1] for row in conn.execute("PRAGMA table_info(desktop_room_authorities)")
+    }
+    if "consumer_id" not in authority_columns:
+        conn.execute(
+            "ALTER TABLE desktop_room_authorities ADD COLUMN consumer_id TEXT"
+        )
 
 
 def _schema_is_current(conn: sqlite3.Connection) -> bool:
@@ -161,6 +220,9 @@ def _schema_is_current(conn: sqlite3.Connection) -> bool:
     }
     owners = {
         row[1] for row in conn.execute("PRAGMA table_info(desktop_room_owners)")
+    }
+    authorities = {
+        row[1] for row in conn.execute("PRAGMA table_info(desktop_room_authorities)")
     }
     return (
         {
@@ -179,6 +241,9 @@ def _schema_is_current(conn: sqlite3.Connection) -> bool:
         }.issubset(commands)
         and {"consumer_id", "room_id", "expires_at"}.issubset(presence)
         and {"room_id", "consumer_id", "expires_at"}.issubset(owners)
+        and {"room_id", "consumer_id", "authority_hash", "created_at"}.issubset(
+            authorities
+        )
     )
 
 
@@ -252,11 +317,47 @@ def _command(row: sqlite3.Row, *, idempotent: bool = False) -> dict[str, Any]:
     return result
 
 
+def register_projected_authorities(
+    db_path: Path | str,
+    commitments: Any,
+    *,
+    clock: Any = time.time,
+) -> list[str]:
+    """Record one-way owner proofs read from the trusted room projection.
+
+    Conflicts are isolated per room: an old or corrupted projection cannot
+    prevent healthy rooms in the same snapshot from advertising presence.
+    """
+
+    parsed = _room_commitments(commitments)
+    now = float(clock())
+    registered: list[str] = []
+    with _transaction(db_path, immediate=True) as conn:
+        for room_id, authority_hash in parsed:
+            existing = conn.execute(
+                """SELECT authority_hash FROM desktop_room_authorities
+                   WHERE room_id = ?""",
+                (room_id,),
+            ).fetchone()
+            if existing is None:
+                conn.execute(
+                    """INSERT INTO desktop_room_authorities (
+                           room_id, consumer_id, authority_hash, created_at
+                       ) VALUES (?, NULL, ?, ?)""",
+                    (room_id, authority_hash, now),
+                )
+                registered.append(room_id)
+            elif str(existing["authority_hash"] or "") == authority_hash:
+                registered.append(room_id)
+    return registered
+
+
 def enqueue_command(
     db_path: Path | str,
     *,
     command_id: str,
     room_id: str,
+    authority_hash: str,
     action: str,
     payload: Any,
     clock: Any = time.time,
@@ -265,12 +366,29 @@ def enqueue_command(
 
     command_id = _identifier(command_id, label="command_id")
     room_id = _room_identifier(room_id)
+    authority_hash = _authority_hash(authority_hash)
     action = str(action or "").strip().casefold()
     if action not in _ACTIONS:
         raise DesktopRoomMailboxError("invalid action")
     encoded = _payload_json(payload)
     now = float(clock())
     with _transaction(db_path, immediate=True) as conn:
+        existing_authority = conn.execute(
+            """SELECT authority_hash FROM desktop_room_authorities
+               WHERE room_id = ?""",
+            (room_id,),
+        ).fetchone()
+        if existing_authority is None:
+            conn.execute(
+                """INSERT INTO desktop_room_authorities (
+                       room_id, consumer_id, authority_hash, created_at
+                   ) VALUES (?, NULL, ?, ?)""",
+                (room_id, authority_hash, now),
+            )
+        elif str(existing_authority["authority_hash"] or "") != authority_hash:
+            raise DesktopRoomMailboxError(
+                "room authority commitment does not match its existing owner"
+            )
         existing = conn.execute(
             "SELECT * FROM desktop_room_commands WHERE command_id = ?",
             (command_id,),
@@ -306,7 +424,8 @@ def claim_commands(
     db_path: Path | str,
     *,
     consumer_id: str,
-    room_ids: Any,
+    room_authorities: Any,
+    actions: Any = None,
     limit: int = MAX_COMMANDS_PER_CLAIM,
     presence_ttl: float = PRESENCE_TTL_SECONDS,
     claim_ttl: float = CLAIM_TTL_SECONDS,
@@ -315,12 +434,39 @@ def claim_commands(
     """Refresh room presence and lease pending commands to one Desktop."""
 
     consumer_id = _identifier(consumer_id, label="consumer_id")
-    rooms = _room_ids(room_ids)
+    authorities = _room_authorities(room_authorities)
+    requested_actions = (
+        {str(action or "").strip().casefold() for action in actions}
+        if isinstance(actions, (list, tuple, set, frozenset))
+        else set()
+    )
+    if requested_actions and not requested_actions.issubset(_ACTIONS):
+        raise DesktopRoomMailboxError("invalid action filter")
     limit = max(1, min(MAX_COMMANDS_PER_CLAIM, int(limit)))
     now = float(clock())
     with _transaction(db_path, immediate=True) as conn:
         conn.execute("DELETE FROM desktop_room_presence WHERE expires_at <= ?", (now,))
         conn.execute("DELETE FROM desktop_room_owners WHERE expires_at <= ?", (now,))
+        for room_id, authority_hash in authorities:
+            # The commitment was written by the messaging enqueue path from
+            # the Desktop's shared room projection. Only a caller that knows
+            # the unpublished token can bind the first consumer.
+            conn.execute(
+                """UPDATE desktop_room_authorities SET consumer_id = ?
+                   WHERE room_id = ? AND consumer_id IS NULL
+                     AND authority_hash = ?""",
+                (consumer_id, room_id, authority_hash),
+            )
+        rooms = [
+            room_id
+            for room_id, authority_hash in authorities
+            if conn.execute(
+                """SELECT 1 FROM desktop_room_authorities
+                   WHERE room_id = ? AND consumer_id = ? AND authority_hash = ?""",
+                (room_id, consumer_id, authority_hash),
+            ).fetchone()
+            is not None
+        ]
         if rooms:
             conn.executemany(
                 """INSERT INTO desktop_room_owners (
@@ -365,16 +511,23 @@ def claim_commands(
         if not owned:
             return []
         placeholders = ",".join("?" for _ in owned)
+        action_sql = ""
+        action_params: tuple[str, ...] = ()
+        if requested_actions:
+            action_placeholders = ",".join("?" for _ in requested_actions)
+            action_sql = f" AND action IN ({action_placeholders})"
+            action_params = tuple(sorted(requested_actions))
         rows = conn.execute(
             f"""SELECT * FROM desktop_room_commands
                 WHERE room_id IN ({placeholders})
+                  {action_sql}
                   AND (
                     state = 'pending'
                     OR (state = 'claimed' AND COALESCE(lease_expires_at, 0) <= ?)
                   )
                 ORDER BY created_at, command_id
                 LIMIT ?""",
-            (*owned, now, limit),
+            (*owned, *action_params, now, limit),
         ).fetchall()
         claimed: list[dict[str, Any]] = []
         for row in rows:
@@ -470,6 +623,7 @@ def renew_command(
     command_id: str,
     lease_token: str,
     claim_ttl: float = CLAIM_TTL_SECONDS,
+    presence_ttl: float = PRESENCE_TTL_SECONDS,
     clock: Any = time.time,
 ) -> dict[str, Any]:
     """Extend one live claim without allowing an expired attempt to revive."""
@@ -479,6 +633,28 @@ def renew_command(
     lease_token = _identifier(lease_token, label="lease_token")
     now = float(clock())
     with _transaction(db_path, immediate=True) as conn:
+        row = conn.execute(
+            """SELECT room_id FROM desktop_room_commands
+               WHERE command_id = ? AND state = 'claimed'
+                 AND lease_owner = ? AND lease_token = ?
+                 AND lease_expires_at > ?""",
+            (command_id, consumer_id, lease_token, now),
+        ).fetchone()
+        if row is None:
+            raise DesktopRoomMailboxError(
+                "command lease is no longer owned by this Desktop"
+            )
+        room_id = str(row["room_id"])
+        owner = conn.execute(
+            """UPDATE desktop_room_owners
+               SET expires_at = ?
+               WHERE room_id = ? AND consumer_id = ? AND expires_at > ?""",
+            (now + float(presence_ttl), room_id, consumer_id, now),
+        )
+        if owner.rowcount != 1:
+            raise DesktopRoomMailboxError(
+                "room authority is no longer owned by this Desktop"
+            )
         updated = conn.execute(
             """UPDATE desktop_room_commands
                SET lease_expires_at = ?, updated_at = ?
@@ -498,6 +674,14 @@ def renew_command(
             raise DesktopRoomMailboxError(
                 "command lease is no longer owned by this Desktop"
             )
+        conn.execute(
+            """INSERT INTO desktop_room_presence (
+                   consumer_id, room_id, expires_at
+               ) VALUES (?, ?, ?)
+               ON CONFLICT(consumer_id, room_id) DO UPDATE
+               SET expires_at = excluded.expires_at""",
+            (consumer_id, room_id, now + float(presence_ttl)),
+        )
         current = conn.execute(
             "SELECT * FROM desktop_room_commands WHERE command_id = ?",
             (command_id,),

--- a/gateway/desktop_room_mailbox.py
+++ b/gateway/desktop_room_mailbox.py
@@ -1,0 +1,580 @@
+"""Durable command handoff for Desktop-driven Bot rooms.
+
+Messaging adapters run on the gateway while classic room orchestration lives
+in a connected Desktop renderer. This mailbox keeps that compatibility path
+idempotent and recoverable without making the gateway a second room runner.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import secrets
+import sqlite3
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Iterator
+
+
+MAX_ROOM_IDS = 128
+MAX_QUERY_ROOM_IDS = 4096
+MAX_COMMANDS_PER_CLAIM = 8
+MAX_PAYLOAD_BYTES = 64 * 1024
+# Desktop refreshes classic-room presence on a 60s retained-socket backstop;
+# push events handle command latency. Keep enough overlap for scheduler jitter
+# without turning a closed Desktop into a long-lived false-positive.
+PRESENCE_TTL_SECONDS = 90.0
+CLAIM_TTL_SECONDS = 45.0
+TERMINAL_RETENTION_SECONDS = 7 * 24 * 60 * 60
+
+_IDENTIFIER_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]*$")
+_ACTIONS = frozenset({"send", "stop"})
+_TERMINAL_STATES = frozenset({"completed", "failed"})
+
+
+class DesktopRoomMailboxError(ValueError):
+    """Raised when a mailbox command is invalid or stale."""
+
+
+def default_db_path() -> Path:
+    """Keep compatibility heartbeats out of the session state database."""
+
+    from gateway.hosted_rooms import default_db_path as hosted_db_path
+
+    return hosted_db_path().with_name("desktop_room_mailbox.db")
+
+
+def pending_signal_path(db_path: Path | str | None = None) -> Path:
+    """Cross-process change signal watched by the gateway WebSocket server."""
+
+    return Path(db_path or default_db_path()).with_name("desktop_room_mailbox.pending")
+
+
+def _identifier(value: Any, *, label: str) -> str:
+    text = str(value or "").strip()
+    if not text or len(text) > 160 or not _IDENTIFIER_RE.fullmatch(text):
+        raise DesktopRoomMailboxError(f"invalid {label}")
+    return text
+
+
+def _room_identifier(value: Any) -> str:
+    text = str(value or "").strip()
+    if (
+        not text
+        or len(text) > 200
+        or any(char in text for char in ("\x00", "\r", "\n"))
+    ):
+        raise DesktopRoomMailboxError("invalid room_id")
+    return text
+
+
+def _room_ids(value: Any) -> list[str]:
+    if not isinstance(value, (list, tuple)):
+        raise DesktopRoomMailboxError("room_ids must be a list")
+    if len(value) > MAX_ROOM_IDS:
+        raise DesktopRoomMailboxError("too many room_ids")
+    return list(dict.fromkeys(_room_identifier(item) for item in value))
+
+
+def _query_room_ids(value: Any) -> list[str]:
+    if not isinstance(value, (list, tuple)):
+        raise DesktopRoomMailboxError("room_ids must be a list")
+    if len(value) > MAX_QUERY_ROOM_IDS:
+        raise DesktopRoomMailboxError("too many room_ids")
+    return list(dict.fromkeys(_room_identifier(item) for item in value))
+
+
+def _payload_json(value: Any) -> str:
+    try:
+        encoded = json.dumps(
+            value,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+    except (TypeError, ValueError, RecursionError) as exc:
+        raise DesktopRoomMailboxError("payload must be JSON-serializable") from exc
+    if len(encoded.encode("utf-8")) > MAX_PAYLOAD_BYTES:
+        raise DesktopRoomMailboxError("payload is too large")
+    return encoded
+
+
+def _initialize(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS desktop_room_commands (
+            command_id TEXT PRIMARY KEY,
+            room_id TEXT NOT NULL,
+            action TEXT NOT NULL,
+            payload_json TEXT NOT NULL,
+            state TEXT NOT NULL DEFAULT 'pending',
+            lease_owner TEXT,
+            lease_token TEXT,
+            lease_expires_at REAL,
+            attempts INTEGER NOT NULL DEFAULT 0,
+            result_json TEXT,
+            created_at REAL NOT NULL,
+            updated_at REAL NOT NULL
+        )"""
+    )
+    command_columns = {
+        row[1] for row in conn.execute("PRAGMA table_info(desktop_room_commands)")
+    }
+    if "lease_token" not in command_columns:
+        conn.execute("ALTER TABLE desktop_room_commands ADD COLUMN lease_token TEXT")
+    conn.execute(
+        """CREATE INDEX IF NOT EXISTS idx_desktop_room_commands_claim
+           ON desktop_room_commands(state, room_id, created_at)"""
+    )
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS desktop_room_presence (
+            consumer_id TEXT NOT NULL,
+            room_id TEXT NOT NULL,
+            expires_at REAL NOT NULL,
+            PRIMARY KEY (consumer_id, room_id)
+        )"""
+    )
+    conn.execute(
+        """CREATE INDEX IF NOT EXISTS idx_desktop_room_presence_room
+           ON desktop_room_presence(room_id, expires_at)"""
+    )
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS desktop_room_owners (
+            room_id TEXT PRIMARY KEY,
+            consumer_id TEXT NOT NULL,
+            expires_at REAL NOT NULL
+        )"""
+    )
+    conn.execute(
+        """CREATE INDEX IF NOT EXISTS idx_desktop_room_owners_expiry
+           ON desktop_room_owners(expires_at)"""
+    )
+
+
+def _schema_is_current(conn: sqlite3.Connection) -> bool:
+    commands = {
+        row[1] for row in conn.execute("PRAGMA table_info(desktop_room_commands)")
+    }
+    presence = {
+        row[1] for row in conn.execute("PRAGMA table_info(desktop_room_presence)")
+    }
+    owners = {
+        row[1] for row in conn.execute("PRAGMA table_info(desktop_room_owners)")
+    }
+    return (
+        {
+            "command_id",
+            "room_id",
+            "action",
+            "payload_json",
+            "state",
+            "lease_owner",
+            "lease_token",
+            "lease_expires_at",
+            "attempts",
+            "result_json",
+            "created_at",
+            "updated_at",
+        }.issubset(commands)
+        and {"consumer_id", "room_id", "expires_at"}.issubset(presence)
+        and {"room_id", "consumer_id", "expires_at"}.issubset(owners)
+    )
+
+
+def _connect(db_path: Path | str) -> sqlite3.Connection:
+    from hermes_state import apply_wal_with_fallback
+
+    path = Path(db_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path, timeout=10)
+    conn.row_factory = sqlite3.Row
+    try:
+        apply_wal_with_fallback(conn, db_label="state.db (desktop room mailbox)")
+        if _schema_is_current(conn):
+            return conn
+        conn.execute("BEGIN IMMEDIATE")
+        _initialize(conn)
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        conn.close()
+        raise
+    return conn
+
+
+def _notify_pending(db_path: Path | str) -> None:
+    path = pending_signal_path(db_path)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(str(time.time_ns()), encoding="ascii")
+        os.chmod(path, 0o600)
+    except OSError:
+        # The command is already durable. A failed best-effort wake signal
+        # must never turn success into an error or invite a duplicate send;
+        # the retained-socket poll remains the backstop.
+        pass
+
+
+@contextmanager
+def _transaction(
+    db_path: Path | str, *, immediate: bool = False
+) -> Iterator[sqlite3.Connection]:
+    conn = _connect(db_path)
+    try:
+        if immediate:
+            conn.execute("BEGIN IMMEDIATE")
+        yield conn
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+
+def _command(row: sqlite3.Row, *, idempotent: bool = False) -> dict[str, Any]:
+    result = {
+        "command_id": str(row["command_id"]),
+        "room_id": str(row["room_id"]),
+        "action": str(row["action"]),
+        "payload": json.loads(row["payload_json"]),
+        "state": str(row["state"]),
+        "attempts": int(row["attempts"]),
+        "created_at": float(row["created_at"]),
+        "updated_at": float(row["updated_at"]),
+        "idempotent": idempotent,
+    }
+    if row["result_json"]:
+        result["result"] = json.loads(row["result_json"])
+    if row["lease_token"]:
+        result["lease_token"] = str(row["lease_token"])
+    return result
+
+
+def enqueue_command(
+    db_path: Path | str,
+    *,
+    command_id: str,
+    room_id: str,
+    action: str,
+    payload: Any,
+    clock: Any = time.time,
+) -> dict[str, Any]:
+    """Persist one idempotent command for a compatible Desktop."""
+
+    command_id = _identifier(command_id, label="command_id")
+    room_id = _room_identifier(room_id)
+    action = str(action or "").strip().casefold()
+    if action not in _ACTIONS:
+        raise DesktopRoomMailboxError("invalid action")
+    encoded = _payload_json(payload)
+    now = float(clock())
+    with _transaction(db_path, immediate=True) as conn:
+        existing = conn.execute(
+            "SELECT * FROM desktop_room_commands WHERE command_id = ?",
+            (command_id,),
+        ).fetchone()
+        if existing is not None:
+            if (
+                str(existing["room_id"]) != room_id
+                or str(existing["action"]) != action
+                or str(existing["payload_json"]) != encoded
+            ):
+                raise DesktopRoomMailboxError(
+                    "command_id was already used for different room work"
+                )
+            result = _command(existing, idempotent=True)
+        else:
+            conn.execute(
+                """INSERT INTO desktop_room_commands (
+                       command_id, room_id, action, payload_json, state,
+                       created_at, updated_at
+                   ) VALUES (?, ?, ?, ?, 'pending', ?, ?)""",
+                (command_id, room_id, action, encoded, now, now),
+            )
+            row = conn.execute(
+                "SELECT * FROM desktop_room_commands WHERE command_id = ?",
+                (command_id,),
+            ).fetchone()
+            result = _command(row)
+    _notify_pending(db_path)
+    return result
+
+
+def claim_commands(
+    db_path: Path | str,
+    *,
+    consumer_id: str,
+    room_ids: Any,
+    limit: int = MAX_COMMANDS_PER_CLAIM,
+    presence_ttl: float = PRESENCE_TTL_SECONDS,
+    claim_ttl: float = CLAIM_TTL_SECONDS,
+    clock: Any = time.time,
+) -> list[dict[str, Any]]:
+    """Refresh room presence and lease pending commands to one Desktop."""
+
+    consumer_id = _identifier(consumer_id, label="consumer_id")
+    rooms = _room_ids(room_ids)
+    limit = max(1, min(MAX_COMMANDS_PER_CLAIM, int(limit)))
+    now = float(clock())
+    with _transaction(db_path, immediate=True) as conn:
+        conn.execute("DELETE FROM desktop_room_presence WHERE expires_at <= ?", (now,))
+        conn.execute("DELETE FROM desktop_room_owners WHERE expires_at <= ?", (now,))
+        if rooms:
+            conn.executemany(
+                """INSERT INTO desktop_room_owners (
+                       room_id, consumer_id, expires_at
+                   ) VALUES (?, ?, ?)
+                   ON CONFLICT(room_id) DO UPDATE SET expires_at = excluded.expires_at
+                   WHERE desktop_room_owners.consumer_id = excluded.consumer_id""",
+                (
+                    (room_id, consumer_id, now + float(presence_ttl))
+                    for room_id in rooms
+                ),
+            )
+        owned = []
+        if rooms:
+            placeholders = ",".join("?" for _ in rooms)
+            owned = [
+                str(row["room_id"])
+                for row in conn.execute(
+                    f"""SELECT room_id FROM desktop_room_owners
+                        WHERE room_id IN ({placeholders}) AND consumer_id = ?
+                          AND expires_at > ?""",
+                    (*rooms, consumer_id, now),
+                )
+            ]
+        if owned:
+            conn.executemany(
+                """INSERT INTO desktop_room_presence (
+                       consumer_id, room_id, expires_at
+                   ) VALUES (?, ?, ?)
+                   ON CONFLICT(consumer_id, room_id) DO UPDATE
+                   SET expires_at = excluded.expires_at""",
+                (
+                    (consumer_id, room_id, now + float(presence_ttl))
+                    for room_id in owned
+                ),
+            )
+        conn.execute(
+            """DELETE FROM desktop_room_commands
+               WHERE state IN ('completed', 'failed') AND updated_at <= ?""",
+            (now - TERMINAL_RETENTION_SECONDS,),
+        )
+        if not owned:
+            return []
+        placeholders = ",".join("?" for _ in owned)
+        rows = conn.execute(
+            f"""SELECT * FROM desktop_room_commands
+                WHERE room_id IN ({placeholders})
+                  AND (
+                    state = 'pending'
+                    OR (state = 'claimed' AND COALESCE(lease_expires_at, 0) <= ?)
+                  )
+                ORDER BY created_at, command_id
+                LIMIT ?""",
+            (*owned, now, limit),
+        ).fetchall()
+        claimed: list[dict[str, Any]] = []
+        for row in rows:
+            lease_token = secrets.token_hex(16)
+            updated = conn.execute(
+                """UPDATE desktop_room_commands
+                   SET state = 'claimed', lease_owner = ?, lease_token = ?,
+                       lease_expires_at = ?, attempts = attempts + 1,
+                       updated_at = ?
+                   WHERE command_id = ?
+                     AND (
+                       state = 'pending'
+                       OR (state = 'claimed' AND COALESCE(lease_expires_at, 0) <= ?)
+                     )""",
+                (
+                    consumer_id,
+                    lease_token,
+                    now + float(claim_ttl),
+                    now,
+                    str(row["command_id"]),
+                    now,
+                ),
+            )
+            if updated.rowcount != 1:
+                continue
+            current = conn.execute(
+                "SELECT * FROM desktop_room_commands WHERE command_id = ?",
+                (str(row["command_id"]),),
+            ).fetchone()
+            claimed.append(_command(current))
+        return claimed
+
+
+def complete_command(
+    db_path: Path | str,
+    *,
+    consumer_id: str,
+    command_id: str,
+    lease_token: str,
+    success: bool,
+    result: Any,
+    clock: Any = time.time,
+) -> dict[str, Any]:
+    """Commit one claimed command result, tolerating an ACK retry."""
+
+    consumer_id = _identifier(consumer_id, label="consumer_id")
+    command_id = _identifier(command_id, label="command_id")
+    lease_token = _identifier(lease_token, label="lease_token")
+    encoded = _payload_json(result)
+    state = "completed" if success else "failed"
+    now = float(clock())
+    with _transaction(db_path, immediate=True) as conn:
+        row = conn.execute(
+            "SELECT * FROM desktop_room_commands WHERE command_id = ?",
+            (command_id,),
+        ).fetchone()
+        if row is None:
+            raise DesktopRoomMailboxError("command not found")
+        if str(row["state"]) in _TERMINAL_STATES:
+            if str(row["state"]) == state and str(row["result_json"] or "") == encoded:
+                return _command(row, idempotent=True)
+            raise DesktopRoomMailboxError("command already has a different result")
+        if (
+            str(row["state"]) != "claimed"
+            or str(row["lease_owner"] or "") != consumer_id
+            or str(row["lease_token"] or "") != lease_token
+            or float(row["lease_expires_at"] or 0) <= now
+        ):
+            raise DesktopRoomMailboxError(
+                "command lease is no longer owned by this Desktop"
+            )
+        updated = conn.execute(
+            """UPDATE desktop_room_commands
+               SET state = ?, result_json = ?, lease_owner = NULL,
+                   lease_token = NULL, lease_expires_at = NULL, updated_at = ?
+               WHERE command_id = ? AND state = 'claimed' AND lease_owner = ?
+                 AND lease_token = ? AND lease_expires_at > ?""",
+            (state, encoded, now, command_id, consumer_id, lease_token, now),
+        )
+        if updated.rowcount != 1:
+            raise DesktopRoomMailboxError("command completion raced another consumer")
+        current = conn.execute(
+            "SELECT * FROM desktop_room_commands WHERE command_id = ?",
+            (command_id,),
+        ).fetchone()
+        return _command(current)
+
+
+def renew_command(
+    db_path: Path | str,
+    *,
+    consumer_id: str,
+    command_id: str,
+    lease_token: str,
+    claim_ttl: float = CLAIM_TTL_SECONDS,
+    clock: Any = time.time,
+) -> dict[str, Any]:
+    """Extend one live claim without allowing an expired attempt to revive."""
+
+    consumer_id = _identifier(consumer_id, label="consumer_id")
+    command_id = _identifier(command_id, label="command_id")
+    lease_token = _identifier(lease_token, label="lease_token")
+    now = float(clock())
+    with _transaction(db_path, immediate=True) as conn:
+        updated = conn.execute(
+            """UPDATE desktop_room_commands
+               SET lease_expires_at = ?, updated_at = ?
+               WHERE command_id = ? AND state = 'claimed'
+                 AND lease_owner = ? AND lease_token = ?
+                 AND lease_expires_at > ?""",
+            (
+                now + float(claim_ttl),
+                now,
+                command_id,
+                consumer_id,
+                lease_token,
+                now,
+            ),
+        )
+        if updated.rowcount != 1:
+            raise DesktopRoomMailboxError(
+                "command lease is no longer owned by this Desktop"
+            )
+        current = conn.execute(
+            "SELECT * FROM desktop_room_commands WHERE command_id = ?",
+            (command_id,),
+        ).fetchone()
+        return _command(current)
+
+
+def room_available(
+    db_path: Path | str,
+    room_id: str,
+    *,
+    clock: Any = time.time,
+) -> bool:
+    """Return whether a connected Desktop currently advertises this room."""
+
+    room_id = _room_identifier(room_id)
+    now = float(clock())
+    with _transaction(db_path) as conn:
+        row = conn.execute(
+            """SELECT 1 FROM desktop_room_presence
+               WHERE room_id = ? AND expires_at > ? LIMIT 1""",
+            (room_id, now),
+        ).fetchone()
+        return row is not None
+
+
+def available_room_ids(
+    db_path: Path | str,
+    room_ids: Any,
+    *,
+    clock: Any = time.time,
+) -> set[str]:
+    """Return all advertised room ids using one bounded database read."""
+
+    rooms = _query_room_ids(room_ids)
+    if not rooms:
+        return set()
+    now = float(clock())
+    available: set[str] = set()
+    with _transaction(db_path) as conn:
+        for index in range(0, len(rooms), MAX_ROOM_IDS):
+            batch = rooms[index : index + MAX_ROOM_IDS]
+            placeholders = ",".join("?" for _ in batch)
+            rows = conn.execute(
+                f"""SELECT DISTINCT room_id FROM desktop_room_presence
+                    WHERE room_id IN ({placeholders}) AND expires_at > ?""",
+                (*batch, now),
+            ).fetchall()
+            available.update(str(row["room_id"]) for row in rows)
+    return available
+
+
+def latest_command_states(
+    db_path: Path | str,
+    room_ids: Any,
+) -> dict[str, dict[str, Any]]:
+    """Return the newest command state for each requested room."""
+
+    rooms = _query_room_ids(room_ids)
+    if not rooms:
+        return {}
+    states: dict[str, dict[str, Any]] = {}
+    with _transaction(db_path) as conn:
+        for index in range(0, len(rooms), MAX_ROOM_IDS):
+            batch = rooms[index : index + MAX_ROOM_IDS]
+            placeholders = ",".join("?" for _ in batch)
+            rows = conn.execute(
+                f"""SELECT c.* FROM desktop_room_commands AS c
+                    WHERE c.room_id IN ({placeholders})
+                      AND c.command_id = (
+                        SELECT newer.command_id
+                        FROM desktop_room_commands AS newer
+                        WHERE newer.room_id = c.room_id
+                        ORDER BY newer.created_at DESC, newer.command_id DESC
+                        LIMIT 1
+                      )""",
+                tuple(batch),
+            ).fetchall()
+            states.update({str(row["room_id"]): _command(row) for row in rows})
+    return states

--- a/gateway/desktop_room_mailbox.py
+++ b/gateway/desktop_room_mailbox.py
@@ -105,6 +105,63 @@ def _authority_hash(value: Any) -> str:
     return authority_hash
 
 
+def authorize_attachment_read(
+    db_path: Path | str,
+    *,
+    room_id: Any,
+    command_id: Any,
+    consumer_id: Any,
+    lease_token: Any,
+    authority_token: Any,
+    clock: Any = time.time,
+) -> None:
+    """Require the live command lease and room authority before byte access."""
+
+    room_id = _room_identifier(room_id)
+    command_id = _identifier(command_id, label="command_id")
+    consumer_id = _identifier(consumer_id, label="consumer_id")
+    lease_token = _identifier(lease_token, label="lease_token")
+    authority_token = _identifier(authority_token, label="authority_token")
+    authority_hash = hashlib.sha256(authority_token.encode("utf-8")).hexdigest()
+    now = float(clock())
+    with _transaction(db_path) as conn:
+        authorized = conn.execute(
+            """SELECT 1
+                 FROM desktop_room_commands AS command
+                 JOIN desktop_room_authorities AS authority
+                   ON authority.room_id = command.room_id
+                 JOIN desktop_room_owners AS owner
+                   ON owner.room_id = command.room_id
+                WHERE command.command_id = ?
+                  AND command.room_id = ?
+                  AND command.action = 'send'
+                  AND command.state = 'claimed'
+                  AND command.lease_owner = ?
+                  AND command.lease_token = ?
+                  AND command.lease_expires_at > ?
+                  AND authority.consumer_id = ?
+                  AND authority.authority_hash = ?
+                  AND owner.consumer_id = ?
+                  AND owner.expires_at > ?
+                LIMIT 1""",
+            (
+                command_id,
+                room_id,
+                consumer_id,
+                lease_token,
+                now,
+                consumer_id,
+                authority_hash,
+                consumer_id,
+                now,
+            ),
+        ).fetchone()
+    if authorized is None:
+        raise DesktopRoomMailboxError(
+            "attachment read is not authorized by the live Desktop command lease"
+        )
+
+
 def _room_commitments(value: Any) -> list[tuple[str, str]]:
     if not isinstance(value, (list, tuple)):
         raise DesktopRoomMailboxError("room commitments must be a list")

--- a/gateway/hosted_room_attachments.py
+++ b/gateway/hosted_room_attachments.py
@@ -1,0 +1,892 @@
+"""Durable, private attachment storage for gateway-owned Group Chats.
+
+The room log carries only server-minted attachment ids and bounded metadata.
+Canonical bytes live in a private directory beside ``state.db`` and are shared
+by SHA-256 through an internal blob table.  Upload ids make client retries
+idempotent; send-time commitment binds each upload to one room event and the
+room's frozen recipient roster.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import json
+import os
+import re
+import secrets
+import sqlite3
+import stat
+import threading
+import time
+from collections import Counter
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Iterator, Mapping, Sequence
+
+
+MAX_ATTACHMENTS_PER_MESSAGE = 8
+MAX_ATTACHMENT_BYTES = 15_000_000
+MAX_MESSAGE_ATTACHMENT_BYTES = 25_000_000
+MAX_ROOM_ATTACHMENT_BYTES = 512 * 1024 * 1024
+MAX_GATEWAY_BLOB_BYTES = 2 * 1024 * 1024 * 1024
+MAX_ROOM_UNCOMMITTED_BYTES = 100 * 1024 * 1024
+MAX_ROOM_UNCOMMITTED_COUNT = 64
+MAX_TASK_ATTACHMENTS = 16
+MAX_TASK_ATTACHMENT_BYTES = 50_000_000
+UNCOMMITTED_TTL_SECONDS = 60 * 60
+DISBANDED_GRACE_SECONDS = 15 * 60
+CLASSIC_ATTACHMENT_TTL_SECONDS = 7 * 24 * 60 * 60
+
+MAX_ATTACHMENT_NAME_CHARS = 255
+MAX_ATTACHMENT_MIME_CHARS = 127
+MAX_IDENTIFIER_CHARS = 128
+
+_ATTACHMENT_FIELDS = frozenset({"attachment_id", "kind", "name", "size", "mime"})
+_ATTACHMENT_KINDS = frozenset({"image", "pdf", "file"})
+_ATTACHMENT_ID_RE = re.compile(r"^att_[0-9a-f]{32}$")
+_BLOB_ID_RE = re.compile(r"^blob_[0-9a-f]{32}$")
+_IDENTIFIER_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]*$")
+_MIME_RE = re.compile(
+    r"^[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]*/[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]*$"
+)
+
+
+class AttachmentError(ValueError):
+    """Base class for hosted-room attachment contract failures."""
+
+
+class AttachmentNotFoundError(AttachmentError):
+    """The attachment id is unknown, expired, or unavailable to this caller."""
+
+
+class AttachmentConflictError(AttachmentError):
+    """An idempotency or ownership key was reused with different content."""
+
+
+class AttachmentQuotaError(AttachmentError):
+    """A bounded room or gateway quota would be exceeded."""
+
+
+class AttachmentIntegrityError(AttachmentError):
+    """Canonical blob bytes no longer match their durable metadata."""
+
+
+@dataclass(frozen=True)
+class AttachmentData:
+    """Verified canonical bytes plus safe attachment metadata."""
+
+    attachment: dict[str, Any]
+    data: bytes
+
+
+def default_attachment_root(db_path: Path | str) -> Path:
+    """Return the private byte-store root beside the room state database."""
+
+    return Path(db_path).parent / "hosted-room-attachments"
+
+
+def _identifier(value: Any, *, label: str) -> str:
+    if not isinstance(value, str):
+        raise AttachmentError(f"{label} must be a string")
+    normalized = value.strip()
+    if (
+        not normalized
+        or len(normalized) > MAX_IDENTIFIER_CHARS
+        or _IDENTIFIER_RE.fullmatch(normalized) is None
+    ):
+        raise AttachmentError(f"invalid {label}")
+    return normalized
+
+
+def _attachment_id(value: Any) -> str:
+    if not isinstance(value, str) or _ATTACHMENT_ID_RE.fullmatch(value) is None:
+        raise AttachmentError("invalid attachment_id")
+    return value
+
+
+def _name(value: Any) -> str:
+    if not isinstance(value, str):
+        raise AttachmentError("attachment name must be a string")
+    normalized = value.strip()
+    if (
+        not normalized
+        or len(normalized) > MAX_ATTACHMENT_NAME_CHARS
+        or normalized in {".", ".."}
+        or any(token in normalized for token in ("/", "\\", "\x00", "\n", "\r"))
+    ):
+        raise AttachmentError("attachment name must be a bounded basename")
+    return normalized
+
+
+def _mime(value: Any) -> str:
+    if not isinstance(value, str):
+        raise AttachmentError("attachment mime must be a string")
+    normalized = value.strip().lower()
+    if (
+        not normalized
+        or len(normalized) > MAX_ATTACHMENT_MIME_CHARS
+        or _MIME_RE.fullmatch(normalized) is None
+    ):
+        raise AttachmentError("attachment mime is invalid")
+    return normalized
+
+
+def _kind(value: Any) -> str:
+    if not isinstance(value, str) or value not in _ATTACHMENT_KINDS:
+        raise AttachmentError("attachment kind must be image, pdf, or file")
+    return value
+
+
+def _sniff_known_mime(data: bytes) -> str:
+    if data.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "image/png"
+    if data.startswith(b"\xff\xd8\xff"):
+        return "image/jpeg"
+    if data.startswith((b"GIF87a", b"GIF89a")):
+        return "image/gif"
+    if data.startswith(b"BM"):
+        return "image/bmp"
+    if len(data) >= 12 and data.startswith(b"RIFF") and data[8:12] == b"WEBP":
+        return "image/webp"
+    if data.startswith(b"%PDF-"):
+        return "application/pdf"
+    if data.startswith(b"PK\x03\x04"):
+        return "application/zip"
+    if data.startswith(b"\x1f\x8b"):
+        return "application/gzip"
+    if b"\x00" not in data:
+        try:
+            data.decode("utf-8")
+        except UnicodeDecodeError:
+            pass
+        else:
+            return "text/plain"
+    return "application/octet-stream"
+
+
+def _validate_mime_and_kind(data: bytes, *, kind: str, mime: str) -> None:
+    sniffed = _sniff_known_mime(data)
+    if kind == "image":
+        if not mime.startswith("image/") or sniffed != mime:
+            raise AttachmentError("image bytes do not match the declared MIME type")
+        return
+    if kind == "pdf":
+        if mime != "application/pdf" or sniffed != "application/pdf":
+            raise AttachmentError("PDF bytes do not match application/pdf")
+        return
+    if mime.startswith("image/") or mime == "application/pdf":
+        raise AttachmentError("image and PDF MIME types require their matching kind")
+    if mime.startswith("text/") and sniffed != "text/plain":
+        raise AttachmentError("text bytes do not match the declared MIME type")
+    # Generic files are opaque bytes. ZIP and gzip are container formats used
+    # by many non-archive MIME types (DOCX, XLSX, PPTX, EPUB, JAR, APK, etc.).
+    # Only image and PDF payloads are security-sensitive enough to require an
+    # exact magic/MIME match here; text remains strict to avoid binary prompts.
+
+
+def decode_content_base64(value: Any) -> bytes:
+    """Strictly decode one bounded RPC upload body without accepting data URLs."""
+
+    if not isinstance(value, str) or not value:
+        raise AttachmentError("content_base64 is required")
+    if value.lstrip().lower().startswith("data:"):
+        raise AttachmentError("data URLs are not accepted")
+    maximum_encoded = ((MAX_ATTACHMENT_BYTES + 2) // 3) * 4
+    if len(value) > maximum_encoded + 4:
+        raise AttachmentError("attachment exceeds the per-file size limit")
+    try:
+        data = base64.b64decode(value, validate=True)
+    except (binascii.Error, ValueError) as exc:
+        raise AttachmentError("content_base64 is not valid base64") from exc
+    if not data:
+        raise AttachmentError("attachment must not be empty")
+    if len(data) > MAX_ATTACHMENT_BYTES:
+        raise AttachmentError("attachment exceeds the per-file size limit")
+    return data
+
+
+def encode_content_base64(data: bytes) -> str:
+    """Encode verified bytes for the bounded attachment read RPC."""
+
+    return base64.b64encode(data).decode("ascii")
+
+
+def _safe_manifest_entry(value: Any) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise AttachmentError("each attachment manifest entry must be an object")
+    fields = frozenset(value)
+    if fields != _ATTACHMENT_FIELDS:
+        unknown = fields - _ATTACHMENT_FIELDS
+        missing = _ATTACHMENT_FIELDS - fields
+        if unknown:
+            raise AttachmentError(
+                f"attachment manifest has unknown fields: {', '.join(sorted(unknown))}"
+            )
+        raise AttachmentError(
+            f"attachment manifest is missing fields: {', '.join(sorted(missing))}"
+        )
+    size = value["size"]
+    if isinstance(size, bool) or not isinstance(size, int) or not 0 < size <= MAX_ATTACHMENT_BYTES:
+        raise AttachmentError("attachment size is outside the per-file limit")
+    kind = _kind(value["kind"])
+    mime = _mime(value["mime"])
+    if kind == "image" and not mime.startswith("image/"):
+        raise AttachmentError("image attachments require an image MIME type")
+    if kind == "pdf" and mime != "application/pdf":
+        raise AttachmentError("PDF attachments require application/pdf")
+    return {
+        "attachment_id": _attachment_id(value["attachment_id"]),
+        "kind": kind,
+        "name": _name(value["name"]),
+        "size": size,
+        "mime": mime,
+    }
+
+
+def validate_manifest(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        raise AttachmentError("attachments must be a list")
+    if len(value) > MAX_ATTACHMENTS_PER_MESSAGE:
+        raise AttachmentError(
+            f"attachments must contain at most {MAX_ATTACHMENTS_PER_MESSAGE} entries"
+        )
+    normalized = [_safe_manifest_entry(entry) for entry in value]
+    if len({entry["attachment_id"] for entry in normalized}) != len(normalized):
+        raise AttachmentError("attachment ids must be unique within one message")
+    if sum(entry["size"] for entry in normalized) > MAX_MESSAGE_ATTACHMENT_BYTES:
+        raise AttachmentError("attachments exceed the per-message total size limit")
+    return normalized
+
+
+def validate_task_manifest(value: Any) -> list[dict[str, Any]]:
+    """Validate a bounded aggregate of several already-valid message manifests."""
+
+    if not isinstance(value, list):
+        raise AttachmentError("task attachments must be a list")
+    if len(value) > MAX_TASK_ATTACHMENTS:
+        raise AttachmentError(
+            f"task attachments must contain at most {MAX_TASK_ATTACHMENTS} entries"
+        )
+    normalized = [_safe_manifest_entry(entry) for entry in value]
+    if len({entry["attachment_id"] for entry in normalized}) != len(normalized):
+        raise AttachmentError("task attachment ids must be unique")
+    if sum(entry["size"] for entry in normalized) > MAX_TASK_ATTACHMENT_BYTES:
+        raise AttachmentError("task attachments exceed the aggregate byte limit")
+    return normalized
+
+
+class HostedRoomAttachmentStore:
+    """SQLite-owned metadata and private, content-deduplicated blob bytes."""
+
+    def __init__(
+        self,
+        db_path: Path | str,
+        *,
+        root: Path | str | None = None,
+        clock: Callable[[], float] = time.time,
+        room_quota_bytes: int = MAX_ROOM_ATTACHMENT_BYTES,
+        gateway_quota_bytes: int = MAX_GATEWAY_BLOB_BYTES,
+    ) -> None:
+        self.db_path = Path(db_path)
+        self.root = Path(root or default_attachment_root(self.db_path))
+        self.blob_root = self.root / "blobs"
+        self.clock = clock
+        self.room_quota_bytes = max(1, int(room_quota_bytes))
+        self.gateway_quota_bytes = max(1, int(gateway_quota_bytes))
+        self._lock = threading.RLock()
+        self._prepare_private_root()
+        conn = self._connect()
+        conn.close()
+        self.prune()
+
+    def _prepare_private_root(self) -> None:
+        self.root.mkdir(parents=True, exist_ok=True, mode=0o700)
+        self.blob_root.mkdir(parents=True, exist_ok=True, mode=0o700)
+        for path in (self.root, self.blob_root):
+            try:
+                os.chmod(path, 0o700)
+            except OSError:
+                pass
+
+    def _initialize(self, conn: sqlite3.Connection) -> None:
+        conn.execute(
+            """CREATE TABLE IF NOT EXISTS hosted_room_attachment_blobs (
+                blob_id TEXT PRIMARY KEY,
+                sha256 TEXT NOT NULL UNIQUE,
+                size INTEGER NOT NULL CHECK (size > 0),
+                ref_count INTEGER NOT NULL CHECK (ref_count > 0),
+                created_at REAL NOT NULL
+            )"""
+        )
+        conn.execute(
+            """CREATE TABLE IF NOT EXISTS hosted_room_attachments (
+                attachment_id TEXT PRIMARY KEY,
+                upload_id TEXT NOT NULL,
+                room_id TEXT NOT NULL,
+                event_id TEXT,
+                kind TEXT NOT NULL,
+                name TEXT NOT NULL,
+                size INTEGER NOT NULL CHECK (size > 0),
+                mime TEXT NOT NULL,
+                sha256 TEXT NOT NULL,
+                blob_id TEXT NOT NULL,
+                recipient_member_ids_json TEXT NOT NULL DEFAULT '[]',
+                state TEXT NOT NULL CHECK (state IN ('uploaded', 'committed', 'disbanded')),
+                created_at REAL NOT NULL,
+                updated_at REAL NOT NULL,
+                expires_at REAL,
+                UNIQUE (room_id, upload_id),
+                FOREIGN KEY (blob_id) REFERENCES hosted_room_attachment_blobs(blob_id)
+            )"""
+        )
+        conn.execute(
+            """CREATE INDEX IF NOT EXISTS idx_hosted_room_attachments_room_state
+               ON hosted_room_attachments(room_id, state, created_at)"""
+        )
+        conn.execute(
+            """CREATE INDEX IF NOT EXISTS idx_hosted_room_attachments_expiry
+               ON hosted_room_attachments(expires_at)"""
+        )
+
+    def _connect(self) -> sqlite3.Connection:
+        from hermes_state import apply_wal_with_fallback
+
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(self.db_path, timeout=10)
+        conn.row_factory = sqlite3.Row
+        try:
+            apply_wal_with_fallback(conn, db_label="state.db (hosted room attachments)")
+            conn.execute("PRAGMA foreign_keys=ON")
+            conn.execute("BEGIN IMMEDIATE")
+            self._initialize(conn)
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            conn.close()
+            raise
+        return conn
+
+    @contextmanager
+    def _transaction(self, *, immediate: bool = False) -> Iterator[sqlite3.Connection]:
+        conn = self._connect()
+        try:
+            if immediate:
+                conn.execute("BEGIN IMMEDIATE")
+            yield conn
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+    def _blob_path(self, blob_id: str) -> Path:
+        if _BLOB_ID_RE.fullmatch(blob_id) is None:
+            raise AttachmentIntegrityError("stored blob id is invalid")
+        return self.blob_root / blob_id
+
+    def _write_blob(self, target: Path, data: bytes) -> None:
+        temp = self.blob_root / f".tmp-{secrets.token_hex(16)}"
+        descriptor = None
+        try:
+            descriptor = os.open(temp, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+            with os.fdopen(descriptor, "wb") as handle:
+                descriptor = None
+                handle.write(data)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temp, target)
+            os.chmod(target, 0o600)
+            try:
+                directory = os.open(self.blob_root, os.O_RDONLY)
+                try:
+                    os.fsync(directory)
+                finally:
+                    os.close(directory)
+            except OSError:
+                pass
+        finally:
+            if descriptor is not None:
+                os.close(descriptor)
+            temp.unlink(missing_ok=True)
+
+    def _read_blob(self, *, blob_id: str, size: int, sha256: str) -> bytes:
+        path = self._blob_path(blob_id)
+        flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+        try:
+            descriptor = os.open(path, flags)
+        except OSError as exc:
+            raise AttachmentIntegrityError("canonical attachment blob is unavailable") from exc
+        try:
+            info = os.fstat(descriptor)
+            if not stat.S_ISREG(info.st_mode) or info.st_size != size:
+                raise AttachmentIntegrityError("canonical attachment blob size changed")
+            with os.fdopen(descriptor, "rb", closefd=False) as handle:
+                data = handle.read(MAX_ATTACHMENT_BYTES + 1)
+        finally:
+            os.close(descriptor)
+        if len(data) != size or hashlib.sha256(data).hexdigest() != sha256:
+            raise AttachmentIntegrityError("canonical attachment blob failed SHA-256 validation")
+        return data
+
+    @staticmethod
+    def _metadata(row: sqlite3.Row, *, idempotent: bool = False) -> dict[str, Any]:
+        result = {
+            "attachment_id": str(row["attachment_id"]),
+            "kind": str(row["kind"]),
+            "name": str(row["name"]),
+            "size": int(row["size"]),
+            "mime": str(row["mime"]),
+            "sha256": str(row["sha256"]),
+            "state": str(row["state"]),
+            "created_at": float(row["created_at"]),
+            "idempotent": idempotent,
+        }
+        if row["event_id"] is not None:
+            result["event_id"] = str(row["event_id"])
+        return result
+
+    def put(
+        self,
+        *,
+        room_id: Any,
+        upload_id: Any,
+        kind: Any,
+        name: Any,
+        mime: Any,
+        data: bytes,
+    ) -> dict[str, Any]:
+        room_id = _identifier(room_id, label="room_id")
+        upload_id = _identifier(upload_id, label="upload_id")
+        kind = _kind(kind)
+        name = _name(name)
+        mime = _mime(mime)
+        if not isinstance(data, bytes) or not data:
+            raise AttachmentError("attachment bytes must not be empty")
+        if len(data) > MAX_ATTACHMENT_BYTES:
+            raise AttachmentError("attachment exceeds the per-file size limit")
+        _validate_mime_and_kind(data, kind=kind, mime=mime)
+        digest = hashlib.sha256(data).hexdigest()
+        now = float(self.clock())
+        # Long-lived gateways keep one store instance. Reclaim abandoned
+        # uploads before applying quotas so an expired failed send cannot
+        # permanently exhaust the room without a process restart.
+        self.prune(now=now)
+
+        with self._lock, self._transaction(immediate=True) as conn:
+            existing = conn.execute(
+                "SELECT * FROM hosted_room_attachments WHERE room_id=? AND upload_id=?",
+                (room_id, upload_id),
+            ).fetchone()
+            if existing is not None:
+                if (
+                    str(existing["kind"]) != kind
+                    or str(existing["name"]) != name
+                    or str(existing["mime"]) != mime
+                    or int(existing["size"]) != len(data)
+                    or str(existing["sha256"]) != digest
+                ):
+                    raise AttachmentConflictError(
+                        "upload_id was already used for different attachment content"
+                    )
+                self._read_blob(
+                    blob_id=str(existing["blob_id"]),
+                    size=int(existing["size"]),
+                    sha256=str(existing["sha256"]),
+                )
+                return self._metadata(existing, idempotent=True)
+
+            room_totals = conn.execute(
+                """SELECT COALESCE(SUM(size), 0) AS bytes, COUNT(*) AS count
+                     FROM hosted_room_attachments
+                    WHERE room_id=? AND state!='disbanded'""",
+                (room_id,),
+            ).fetchone()
+            uncommitted = conn.execute(
+                """SELECT COALESCE(SUM(size), 0) AS bytes, COUNT(*) AS count
+                     FROM hosted_room_attachments
+                    WHERE room_id=? AND state='uploaded'""",
+                (room_id,),
+            ).fetchone()
+            if int(room_totals["bytes"]) + len(data) > self.room_quota_bytes:
+                raise AttachmentQuotaError("room attachment quota exceeded")
+            if (
+                int(uncommitted["bytes"]) + len(data) > MAX_ROOM_UNCOMMITTED_BYTES
+                or int(uncommitted["count"]) + 1 > MAX_ROOM_UNCOMMITTED_COUNT
+            ):
+                raise AttachmentQuotaError("room uncommitted upload quota exceeded")
+
+            blob = conn.execute(
+                "SELECT * FROM hosted_room_attachment_blobs WHERE sha256=?",
+                (digest,),
+            ).fetchone()
+            if blob is None:
+                physical = int(
+                    conn.execute(
+                        "SELECT COALESCE(SUM(size), 0) FROM hosted_room_attachment_blobs"
+                    ).fetchone()[0]
+                )
+                if physical + len(data) > self.gateway_quota_bytes:
+                    raise AttachmentQuotaError("gateway attachment quota exceeded")
+                blob_id = f"blob_{secrets.token_hex(16)}"
+                target = self._blob_path(blob_id)
+                self._write_blob(target, data)
+                conn.execute(
+                    """INSERT INTO hosted_room_attachment_blobs
+                       (blob_id, sha256, size, ref_count, created_at)
+                       VALUES (?, ?, ?, 1, ?)""",
+                    (blob_id, digest, len(data), now),
+                )
+            else:
+                blob_id = str(blob["blob_id"])
+                self._read_blob(blob_id=blob_id, size=int(blob["size"]), sha256=digest)
+                conn.execute(
+                    "UPDATE hosted_room_attachment_blobs SET ref_count=ref_count+1 WHERE blob_id=?",
+                    (blob_id,),
+                )
+
+            attachment_id = f"att_{secrets.token_hex(16)}"
+            conn.execute(
+                """INSERT INTO hosted_room_attachments
+                   (attachment_id, upload_id, room_id, event_id, kind, name, size,
+                    mime, sha256, blob_id, recipient_member_ids_json, state,
+                    created_at, updated_at, expires_at)
+                   VALUES (?, ?, ?, NULL, ?, ?, ?, ?, ?, ?, '[]', 'uploaded', ?, ?, ?)""",
+                (
+                    attachment_id,
+                    upload_id,
+                    room_id,
+                    kind,
+                    name,
+                    len(data),
+                    mime,
+                    digest,
+                    blob_id,
+                    now,
+                    now,
+                    now + UNCOMMITTED_TTL_SECONDS,
+                ),
+            )
+            row = conn.execute(
+                "SELECT * FROM hosted_room_attachments WHERE attachment_id=?",
+                (attachment_id,),
+            ).fetchone()
+            if row is None:  # pragma: no cover - guarded by insert
+                raise RuntimeError("stored attachment could not be reloaded")
+            return self._metadata(row)
+
+    def find_upload(self, *, room_id: Any, upload_id: Any) -> dict[str, Any] | None:
+        """Return verified metadata for an idempotent upload retry, if it exists."""
+
+        room_id = _identifier(room_id, label="room_id")
+        upload_id = _identifier(upload_id, label="upload_id")
+        now = float(self.clock())
+        with self._transaction() as conn:
+            row = conn.execute(
+                """SELECT * FROM hosted_room_attachments
+                    WHERE room_id=? AND upload_id=?""",
+                (room_id, upload_id),
+            ).fetchone()
+            if row is None or str(row["state"]) == "disbanded":
+                return None
+            if row["expires_at"] is not None and float(row["expires_at"]) <= now:
+                return None
+            self._read_blob(
+                blob_id=str(row["blob_id"]),
+                size=int(row["size"]),
+                sha256=str(row["sha256"]),
+            )
+            return self._metadata(row, idempotent=True)
+
+    def commit_message(
+        self,
+        *,
+        room_id: Any,
+        event_id: Any,
+        manifest: Any,
+        recipient_member_ids: Sequence[str],
+        retention_seconds: float | None = None,
+        hold_until_event: bool = False,
+    ) -> list[dict[str, Any]]:
+        room_id = _identifier(room_id, label="room_id")
+        event_id = _identifier(event_id, label="event_id")
+        normalized = validate_manifest(manifest)
+        recipients = tuple(
+            _identifier(member_id, label="recipient_member_id")
+            for member_id in recipient_member_ids
+        )
+        if not recipients:
+            raise AttachmentError("attachment commitment requires recipient ids")
+        if len(set(recipients)) != len(recipients):
+            raise AttachmentError("recipient ids must be unique")
+        recipients_json = json.dumps(sorted(recipients), separators=(",", ":"))
+        now = float(self.clock())
+        expires_at = (
+            now + UNCOMMITTED_TTL_SECONDS
+            if hold_until_event
+            else None
+            if retention_seconds is None
+            else now + float(retention_seconds)
+        )
+
+        with self._lock, self._transaction(immediate=True) as conn:
+            for entry in normalized:
+                row = conn.execute(
+                    "SELECT * FROM hosted_room_attachments WHERE attachment_id=?",
+                    (entry["attachment_id"],),
+                ).fetchone()
+                if row is None or str(row["room_id"]) != room_id:
+                    raise AttachmentNotFoundError("attachment is not uploaded for this room")
+                durable = {
+                    "attachment_id": str(row["attachment_id"]),
+                    "kind": str(row["kind"]),
+                    "name": str(row["name"]),
+                    "size": int(row["size"]),
+                    "mime": str(row["mime"]),
+                }
+                if durable != entry:
+                    raise AttachmentConflictError(
+                        "attachment manifest metadata does not match the uploaded bytes"
+                    )
+                state = str(row["state"])
+                if state == "disbanded":
+                    raise AttachmentNotFoundError("attachment belongs to a disbanded room")
+                if state == "committed" and (
+                    str(row["event_id"] or "") != event_id
+                    or str(row["recipient_member_ids_json"]) != recipients_json
+                ):
+                    raise AttachmentConflictError(
+                        "attachment is already owned by a different room event"
+                    )
+                self._read_blob(
+                    blob_id=str(row["blob_id"]),
+                    size=int(row["size"]),
+                    sha256=str(row["sha256"]),
+                )
+            for entry in normalized:
+                conn.execute(
+                    """UPDATE hosted_room_attachments
+                          SET event_id=?, recipient_member_ids_json=?, state='committed',
+                              updated_at=?, expires_at=?
+                        WHERE attachment_id=?""",
+                    (event_id, recipients_json, now, expires_at, entry["attachment_id"]),
+                )
+        return normalized
+
+    def retain_event(self, *, room_id: Any, event_id: Any) -> int:
+        """Retain committed blobs after their immutable room event is durable."""
+
+        room_id = _identifier(room_id, label="room_id")
+        event_id = _identifier(event_id, label="event_id")
+        now = float(self.clock())
+        with self._transaction(immediate=True) as conn:
+            event = conn.execute(
+                """SELECT 1 FROM hosted_room_events
+                    WHERE room_id=? AND event_id=? LIMIT 1""",
+                (room_id, event_id),
+            ).fetchone()
+            if event is None:
+                raise AttachmentConflictError(
+                    "attachment owner event is not durable in the room log"
+                )
+            changed = conn.execute(
+                """UPDATE hosted_room_attachments
+                      SET expires_at=NULL, updated_at=?
+                    WHERE room_id=? AND event_id=? AND state='committed'""",
+                (now, room_id, event_id),
+            )
+            return int(changed.rowcount)
+
+    def read(
+        self,
+        *,
+        room_id: Any,
+        attachment_id: Any,
+        recipient_member_id: Any,
+        event_id: Any | None = None,
+    ) -> AttachmentData:
+        room_id = _identifier(room_id, label="room_id")
+        attachment_id = _attachment_id(attachment_id)
+        recipient_member_id = _identifier(
+            recipient_member_id, label="recipient_member_id"
+        )
+        normalized_event = _identifier(event_id, label="event_id") if event_id is not None else None
+        now = float(self.clock())
+        with self._transaction() as conn:
+            row = conn.execute(
+                "SELECT * FROM hosted_room_attachments WHERE attachment_id=? AND room_id=?",
+                (attachment_id, room_id),
+            ).fetchone()
+            if row is None or str(row["state"]) != "committed":
+                raise AttachmentNotFoundError("attachment is not committed for this room")
+            if row["expires_at"] is not None and float(row["expires_at"]) <= now:
+                raise AttachmentNotFoundError("attachment has expired")
+            if normalized_event is not None and str(row["event_id"] or "") != normalized_event:
+                raise AttachmentNotFoundError("attachment is not owned by this room event")
+            recipients = json.loads(str(row["recipient_member_ids_json"]))
+            if recipient_member_id not in recipients:
+                raise AttachmentNotFoundError("attachment is unavailable to this recipient")
+            data = self._read_blob(
+                blob_id=str(row["blob_id"]),
+                size=int(row["size"]),
+                sha256=str(row["sha256"]),
+            )
+            return AttachmentData(self._metadata(row), data)
+
+    def mark_room_disbanded(self, room_id: Any) -> int:
+        room_id = _identifier(room_id, label="room_id")
+        now = float(self.clock())
+        with self._transaction(immediate=True) as conn:
+            changed = conn.execute(
+                """UPDATE hosted_room_attachments
+                      SET state='disbanded', updated_at=?, expires_at=?
+                    WHERE room_id=? AND state!='disbanded'""",
+                (now, now + DISBANDED_GRACE_SECONDS, room_id),
+            )
+            return int(changed.rowcount)
+
+    def prune(self, *, now: float | None = None) -> int:
+        now = float(self.clock()) if now is None else float(now)
+        removed_blob_ids: list[str] = []
+        removed = 0
+        with self._lock, self._transaction(immediate=True) as conn:
+            has_rooms = conn.execute(
+                """SELECT 1 FROM sqlite_master
+                    WHERE type='table' AND name='hosted_rooms'"""
+            ).fetchone()
+            if has_rooms is not None:
+                conn.execute(
+                    """UPDATE hosted_room_attachments
+                          SET state='disbanded',
+                              expires_at=(
+                                SELECT room.disbanded_at + ? FROM hosted_rooms AS room
+                                 WHERE room.room_id=hosted_room_attachments.room_id
+                              ),
+                              updated_at=?
+                        WHERE state='committed' AND EXISTS (
+                            SELECT 1 FROM hosted_rooms AS room
+                             WHERE room.room_id=hosted_room_attachments.room_id
+                               AND room.disbanded_at IS NOT NULL
+                        )""",
+                    (DISBANDED_GRACE_SECONDS, now),
+                )
+            has_events = conn.execute(
+                """SELECT 1 FROM sqlite_master
+                    WHERE type='table' AND name='hosted_room_events'"""
+            ).fetchone()
+            if has_events is not None:
+                conn.execute(
+                    """UPDATE hosted_room_attachments
+                          SET expires_at=NULL, updated_at=?
+                        WHERE state='committed' AND expires_at IS NOT NULL
+                          AND EXISTS (
+                            SELECT 1 FROM hosted_room_events AS event
+                             WHERE event.room_id=hosted_room_attachments.room_id
+                               AND event.event_id=hosted_room_attachments.event_id
+                          )""",
+                    (now,),
+                )
+            rows = conn.execute(
+                """SELECT attachment_id, blob_id FROM hosted_room_attachments
+                    WHERE expires_at IS NOT NULL AND expires_at <= ?""",
+                (now,),
+            ).fetchall()
+            released = Counter(str(row["blob_id"]) for row in rows)
+            for row in rows:
+                conn.execute(
+                    "DELETE FROM hosted_room_attachments WHERE attachment_id=?",
+                    (str(row["attachment_id"]),),
+                )
+                removed += 1
+            for blob_id, count in released.items():
+                blob = conn.execute(
+                    "SELECT ref_count FROM hosted_room_attachment_blobs WHERE blob_id=?",
+                    (blob_id,),
+                ).fetchone()
+                if blob is None:
+                    continue
+                if int(blob["ref_count"]) <= count:
+                    removed_blob_ids.append(blob_id)
+                else:
+                    conn.execute(
+                        """UPDATE hosted_room_attachment_blobs
+                              SET ref_count=ref_count-?
+                            WHERE blob_id=?""",
+                        (count, blob_id),
+                    )
+            if removed_blob_ids:
+                conn.executemany(
+                    "DELETE FROM hosted_room_attachment_blobs WHERE blob_id=?",
+                    ((blob_id,) for blob_id in removed_blob_ids),
+                )
+        for blob_id in removed_blob_ids:
+            self._blob_path(blob_id).unlink(missing_ok=True)
+        self._sweep_orphans()
+        return removed
+
+    def _sweep_orphans(self) -> None:
+        with self._transaction() as conn:
+            live = {
+                str(row["blob_id"])
+                for row in conn.execute("SELECT blob_id FROM hosted_room_attachment_blobs")
+            }
+        try:
+            candidates = tuple(self.blob_root.iterdir())
+        except OSError:
+            return
+        for path in candidates:
+            if path.name.startswith(".tmp-") or (
+                _BLOB_ID_RE.fullmatch(path.name) is not None and path.name not in live
+            ):
+                try:
+                    if path.is_file() or path.is_symlink():
+                        path.unlink(missing_ok=True)
+                except OSError:
+                    continue
+
+    def stats(self, *, room_id: str | None = None) -> dict[str, int]:
+        with self._transaction() as conn:
+            where = " WHERE room_id=?" if room_id is not None else ""
+            params = (room_id,) if room_id is not None else ()
+            row = conn.execute(
+                f"SELECT COUNT(*) AS count, COALESCE(SUM(size), 0) AS bytes "
+                f"FROM hosted_room_attachments{where}",
+                params,
+            ).fetchone()
+            blob = conn.execute(
+                "SELECT COUNT(*) AS count, COALESCE(SUM(size), 0) AS bytes "
+                "FROM hosted_room_attachment_blobs"
+            ).fetchone()
+        return {
+            "attachments": int(row["count"]),
+            "logical_bytes": int(row["bytes"]),
+            "blobs": int(blob["count"]),
+            "physical_bytes": int(blob["bytes"]),
+        }
+
+
+__all__ = [
+    "AttachmentConflictError",
+    "AttachmentData",
+    "AttachmentError",
+    "AttachmentIntegrityError",
+    "AttachmentNotFoundError",
+    "AttachmentQuotaError",
+    "CLASSIC_ATTACHMENT_TTL_SECONDS",
+    "DISBANDED_GRACE_SECONDS",
+    "HostedRoomAttachmentStore",
+    "MAX_ATTACHMENT_BYTES",
+    "MAX_ATTACHMENTS_PER_MESSAGE",
+    "MAX_MESSAGE_ATTACHMENT_BYTES",
+    "MAX_TASK_ATTACHMENT_BYTES",
+    "MAX_TASK_ATTACHMENTS",
+    "UNCOMMITTED_TTL_SECONDS",
+    "decode_content_base64",
+    "default_attachment_root",
+    "encode_content_base64",
+    "validate_manifest",
+    "validate_task_manifest",
+]

--- a/gateway/hosted_room_discussion.py
+++ b/gateway/hosted_room_discussion.py
@@ -1,0 +1,1352 @@
+"""Deterministic policy for same-gateway hosted-room Discussions.
+
+This module translates a frozen local member roster and the complete typed room
+log into one next driver task.  It performs no I/O, starts no workers, and knows
+nothing about transports or model runtimes.  Callers persist the returned task
+with :mod:`gateway.hosted_room_driver` and append publication plans with
+:mod:`gateway.hosted_rooms`.
+
+The unpublished driver payload intentionally remains unchanged.  Discussion
+coordinates live in deterministic ``TaskIdentity`` values and typed terminal
+events; a restart can therefore reconstruct a task without widening the driver
+schema.  Callers must reconcile terminal driver rows into publication plans
+before asking for the next task.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from gateway import hosted_room_driver as driver
+from gateway import hosted_rooms
+
+
+MAX_DISCUSSION_MEMBERS = 6
+MIN_DISCUSSION_MEMBERS = 2
+MAX_DISCUSSION_ROUNDS = 3
+MAX_DISCUSSION_MESSAGES = 10
+MAX_DISCUSSION_DELTA_LINES = 24
+MAX_USER_TEXT_BYTES = 64 * 1024
+MAX_ATTACHMENTS = 8
+MAX_ATTACHMENT_NAME_CHARS = 255
+MAX_ATTACHMENT_MIME_CHARS = 127
+MAX_ATTACHMENT_REF_CHARS = 256
+MAX_ATTACHMENT_SIZE_BYTES = 100 * 1024 * 1024
+MAX_ATTACHMENT_MANIFEST_BYTES = 32 * 1024
+
+DecisionStatus = Literal["idle", "task", "settled", "bounded"]
+TerminalKind = Literal["settled", "failed", "cancelled"]
+
+_IDENTIFIER_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]*$")
+_MENTION_RE = re.compile(r"@([A-Za-z0-9][A-Za-z0-9._:-]*)", re.IGNORECASE)
+_MIME_RE = re.compile(
+    r"^[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]*/[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]*$"
+)
+_SAFE_REF_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:@-]*$")
+_TURN_ID_RE = re.compile(
+    r"^d(?P<source>[1-9][0-9]*)\.r(?P<round>[0-2])\."
+    r"p(?P<position>[0-5])\.s(?P<seen>[1-9][0-9]*)\."
+    r"m(?P<member>[0-9a-f]{24})$"
+)
+
+_MEMBER_FIELDS = frozenset({"member_id", "profile", "handle", "display_name"})
+_REMOTE_MEMBER_FIELDS = frozenset({
+    "connectionId",
+    "connectionKind",
+    "connectionLabel",
+    "connection_id",
+    "connection_kind",
+    "connection_label",
+    "remoteSource",
+    "route",
+    "sourceMissing",
+    "sourceReachable",
+    "sourceScoped",
+    "targetProfile",
+    "target_profile",
+})
+_USER_PAYLOAD_FIELDS = frozenset({"text", "thread_id"})
+_USER_PAYLOAD_OPTIONAL_FIELDS = frozenset({"attachments"})
+_ATTACHMENT_FIELDS = frozenset({"kind", "name", "size", "mime", "refs"})
+_ATTACHMENT_KINDS = frozenset({"image", "pdf", "file"})
+_MEMBER_MESSAGE_FIELDS = frozenset({
+    "discussion_event_id",
+    "member_id",
+    "member_index",
+    "round_index",
+    "task_id",
+    "text",
+    "thread_id",
+    "turn_id",
+})
+_TERMINAL_COMMON_FIELDS = frozenset({
+    "discussion_event_id",
+    "member_id",
+    "member_index",
+    "round_index",
+    "seen_through_seq",
+    "task_id",
+    "thread_id",
+    "turn_id",
+})
+_TERMINAL_EXTRA_FIELDS = {
+    "turn.settled": frozenset({"message_event_id", "passed"}),
+    "turn.failed": frozenset({"error"}),
+    "turn.cancelled": frozenset({"reason"}),
+}
+_TERMINAL_EVENT_KINDS = frozenset(_TERMINAL_EXTRA_FIELDS)
+
+
+class DiscussionPolicyError(ValueError):
+    """Base class for invalid policy input or unreconstructable state."""
+
+
+class DiscussionValidationError(DiscussionPolicyError):
+    """Raised when a room, roster, payload, or typed event is malformed."""
+
+
+class DiscussionReconstructionError(DiscussionPolicyError):
+    """Raised when a persisted task cannot be reproduced from durable state."""
+
+
+@dataclass(frozen=True)
+class DiscussionMember:
+    """One immutable member local to the room's authority gateway."""
+
+    member_id: str
+    profile: str
+    handle: str
+    display_name: str = ""
+
+
+@dataclass(frozen=True)
+class DiscussionRoom:
+    """Validated policy projection of one active hosted room."""
+
+    room_id: str
+    name: str
+    members: tuple[DiscussionMember, ...]
+    gateway_id: str
+    authority_epoch: int
+
+
+@dataclass(frozen=True)
+class DiscussionTaskPlan:
+    """One deterministic member turn compatible with the driver schema."""
+
+    identity: driver.TaskIdentity
+    payload: Mapping[str, Any]
+    discussion_event_id: str
+    member: DiscussionMember
+    member_index: int
+    round_index: int
+    seen_through_seq: int
+
+
+@dataclass(frozen=True)
+class DiscussionDecision:
+    """Current result of replaying one room's Discussion policy."""
+
+    status: DecisionStatus
+    reason: str
+    discussion_event_id: str | None = None
+    source_event_seq: int | None = None
+    thread_id: str | None = None
+    task: DiscussionTaskPlan | None = None
+
+
+@dataclass(frozen=True)
+class EventPlan:
+    """One idempotent append for :func:`gateway.hosted_rooms.append_event`."""
+
+    event_id: str
+    kind: str
+    actor: Mapping[str, str]
+    payload: Mapping[str, Any]
+    authority_gateway_id: str
+    authority_epoch: int
+
+    def append_kwargs(self, room_id: str) -> dict[str, Any]:
+        """Return keyword arguments accepted by ``append_event``."""
+
+        return {
+            "room_id": room_id,
+            "event_id": self.event_id,
+            "kind": self.kind,
+            "actor": dict(self.actor),
+            "payload": dict(self.payload),
+            "authority_gateway_id": self.authority_gateway_id,
+            "authority_epoch": self.authority_epoch,
+        }
+
+
+@dataclass(frozen=True)
+class PublicationPlan:
+    """Ordered visible and terminal effects for one driver task."""
+
+    task_id: str
+    terminal_kind: str
+    events: tuple[EventPlan, ...]
+
+
+@dataclass(frozen=True)
+class _ValidatedEvent:
+    raw: Mapping[str, Any]
+    seq: int
+    event_id: str
+    kind: str
+    actor: Mapping[str, Any]
+    payload: Mapping[str, Any]
+
+
+def _identifier(value: Any, *, label: str) -> str:
+    if not isinstance(value, str):
+        raise DiscussionValidationError(f"{label} must be a string")
+    normalized = value.strip()
+    if (
+        not normalized
+        or len(normalized) > driver.MAX_IDENTIFIER_CHARS
+        or not _IDENTIFIER_RE.fullmatch(normalized)
+    ):
+        raise DiscussionValidationError(f"invalid {label}")
+    return normalized
+
+
+def _positive_int(value: Any, *, label: str, maximum: int | None = None) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise DiscussionValidationError(f"{label} must be a positive integer")
+    if maximum is not None and value > maximum:
+        raise DiscussionValidationError(f"{label} must be at most {maximum}")
+    return value
+
+
+def _zero_based_int(value: Any, *, label: str, maximum: int) -> int:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or not 0 <= value <= maximum
+    ):
+        raise DiscussionValidationError(
+            f"{label} must be an integer between 0 and {maximum}"
+        )
+    return value
+
+
+def _exact_fields(
+    value: Any,
+    *,
+    label: str,
+    required: frozenset[str],
+    optional: frozenset[str] = frozenset(),
+) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise DiscussionValidationError(f"{label} must be an object")
+    keys = frozenset(value)
+    missing = required - keys
+    unknown = keys - required - optional
+    if missing:
+        raise DiscussionValidationError(
+            f"{label} is missing fields: {', '.join(sorted(missing))}"
+        )
+    if unknown:
+        raise DiscussionValidationError(
+            f"{label} has unknown fields: {', '.join(sorted(unknown))}"
+        )
+    return value
+
+
+def _attachment_name(value: Any, *, index: int) -> str:
+    if not isinstance(value, str):
+        raise DiscussionValidationError(f"attachment {index} name must be a string")
+    name = value.strip()
+    if (
+        not name
+        or len(name) > MAX_ATTACHMENT_NAME_CHARS
+        or name in {".", ".."}
+        or "/" in name
+        or "\\" in name
+        or "\x00" in name
+        or "\n" in name
+        or "\r" in name
+    ):
+        raise DiscussionValidationError(
+            f"attachment {index} name must be a bounded basename"
+        )
+    return name
+
+
+def _attachment_mime(value: Any, *, index: int, kind: str) -> str:
+    if not isinstance(value, str):
+        raise DiscussionValidationError(f"attachment {index} mime must be a string")
+    mime = value.strip().lower()
+    if (
+        not mime
+        or len(mime) > MAX_ATTACHMENT_MIME_CHARS
+        or _MIME_RE.fullmatch(mime) is None
+    ):
+        raise DiscussionValidationError(f"attachment {index} has invalid mime metadata")
+    if kind == "image" and not mime.startswith("image/"):
+        raise DiscussionValidationError(
+            f"attachment {index} image kind requires image mime"
+        )
+    if kind == "pdf" and mime != "application/pdf":
+        raise DiscussionValidationError(
+            f"attachment {index} pdf kind requires application/pdf"
+        )
+    return mime
+
+
+def _safe_attachment_ref(value: Any, *, index: int, member_id: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise DiscussionValidationError(
+            f"attachment {index} ref for '{member_id}' must be a string or null"
+        )
+    ref = value.strip()
+    lowered = ref.casefold()
+    if (
+        not ref
+        or len(ref) > MAX_ATTACHMENT_REF_CHARS
+        or _SAFE_REF_RE.fullmatch(ref) is None
+        or lowered.startswith(("data:", "base64:", "file:", "path:"))
+        or ref.startswith((".", "~"))
+    ):
+        raise DiscussionValidationError(
+            f"attachment {index} ref for '{member_id}' is not a safe opaque ref"
+        )
+    return ref
+
+
+def _validate_attachments(
+    value: Any,
+    *,
+    member_ids: Iterable[str] | None,
+) -> list[dict[str, Any]]:
+    if member_ids is None:
+        raise DiscussionValidationError(
+            "attachment validation requires the frozen room member ids"
+        )
+    if not isinstance(value, list):
+        raise DiscussionValidationError("attachments must be a list")
+    if len(value) > MAX_ATTACHMENTS:
+        raise DiscussionValidationError(
+            f"attachments must contain at most {MAX_ATTACHMENTS} entries"
+        )
+    expected_member_ids = tuple(
+        _identifier(member_id, label="attachment member_id") for member_id in member_ids
+    )
+    expected_keys = frozenset(expected_member_ids)
+    normalized: list[dict[str, Any]] = []
+    for index, raw in enumerate(value):
+        attachment = _exact_fields(
+            raw,
+            label=f"attachment {index}",
+            required=_ATTACHMENT_FIELDS,
+        )
+        kind = attachment["kind"]
+        if not isinstance(kind, str) or kind not in _ATTACHMENT_KINDS:
+            raise DiscussionValidationError(
+                f"attachment {index} kind must be image, pdf, or file"
+            )
+        name = _attachment_name(attachment["name"], index=index)
+        size = attachment["size"]
+        if (
+            isinstance(size, bool)
+            or not isinstance(size, int)
+            or not 0 <= size <= MAX_ATTACHMENT_SIZE_BYTES
+        ):
+            raise DiscussionValidationError(
+                f"attachment {index} size must be between 0 and "
+                f"{MAX_ATTACHMENT_SIZE_BYTES} bytes"
+            )
+        mime = _attachment_mime(attachment["mime"], index=index, kind=kind)
+        refs = attachment["refs"]
+        if not isinstance(refs, Mapping):
+            raise DiscussionValidationError(
+                f"attachment {index} refs must be an object"
+            )
+        ref_keys = frozenset(refs)
+        missing = expected_keys - ref_keys
+        unknown = ref_keys - expected_keys
+        if missing:
+            raise DiscussionValidationError(
+                f"attachment {index} refs are missing member ids: "
+                f"{', '.join(sorted(missing))}"
+            )
+        if unknown:
+            raise DiscussionValidationError(
+                f"attachment {index} refs contain unknown member ids: "
+                f"{', '.join(sorted(str(key) for key in unknown))}"
+            )
+        normalized.append({
+            "kind": kind,
+            "name": name,
+            "size": size,
+            "mime": mime,
+            "refs": {
+                member_id: _safe_attachment_ref(
+                    refs[member_id],
+                    index=index,
+                    member_id=member_id,
+                )
+                for member_id in expected_member_ids
+            },
+        })
+    encoded = json.dumps(
+        normalized,
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    if len(encoded.encode("utf-8")) > MAX_ATTACHMENT_MANIFEST_BYTES:
+        raise DiscussionValidationError("attachment manifest is too large")
+    return normalized
+
+
+def validate_user_payload(
+    value: Any,
+    *,
+    member_ids: Iterable[str] | None = None,
+) -> dict[str, Any]:
+    """Validate and normalize the exact ``message.user`` Discussion payload."""
+
+    payload = _exact_fields(
+        value,
+        label="user payload",
+        required=_USER_PAYLOAD_FIELDS,
+        optional=_USER_PAYLOAD_OPTIONAL_FIELDS,
+    )
+    text = payload["text"]
+    if not isinstance(text, str):
+        raise DiscussionValidationError("user payload text must be a string")
+    text = text.strip()
+    if not text:
+        raise DiscussionValidationError("user payload text must not be empty")
+    if len(text.encode("utf-8")) > MAX_USER_TEXT_BYTES:
+        raise DiscussionValidationError("user payload text is too large")
+    thread_id = _identifier(payload["thread_id"], label="thread_id")
+    normalized: dict[str, Any] = {"text": text, "thread_id": thread_id}
+    if "attachments" in payload:
+        normalized["attachments"] = _validate_attachments(
+            payload["attachments"],
+            member_ids=member_ids,
+        )
+    return normalized
+
+
+def validate_roster(
+    value: Any,
+    *,
+    local_profiles: Iterable[str],
+) -> tuple[DiscussionMember, ...]:
+    """Validate a frozen 2-6 member roster of profiles on this gateway."""
+
+    if not isinstance(value, list):
+        raise DiscussionValidationError("members must be a list")
+    if not MIN_DISCUSSION_MEMBERS <= len(value) <= MAX_DISCUSSION_MEMBERS:
+        raise DiscussionValidationError(
+            f"members must contain between {MIN_DISCUSSION_MEMBERS} and "
+            f"{MAX_DISCUSSION_MEMBERS} entries"
+        )
+
+    known_profiles = {
+        _identifier(profile, label="local profile") for profile in local_profiles
+    }
+    members: list[DiscussionMember] = []
+    profiles: set[str] = set()
+    handles: set[str] = set()
+    member_ids: set[str] = set()
+
+    for index, raw in enumerate(value):
+        if not isinstance(raw, Mapping):
+            raise DiscussionValidationError(f"member {index} must be an object")
+        remote_fields = frozenset(raw) & _REMOTE_MEMBER_FIELDS
+        if remote_fields:
+            raise DiscussionValidationError(
+                f"member {index} contains cross-gateway fields: "
+                f"{', '.join(sorted(remote_fields))}"
+            )
+        member = _exact_fields(
+            raw,
+            label=f"member {index}",
+            required=frozenset({"member_id", "profile", "handle"}),
+            optional=frozenset({"display_name"}),
+        )
+        member_id = _identifier(member["member_id"], label=f"member {index} id")
+        profile = _identifier(member["profile"], label=f"member {index} profile")
+        handle = _identifier(member["handle"], label=f"member {index} handle")
+        if profile not in known_profiles:
+            raise DiscussionValidationError(
+                f"member {index} profile '{profile}' is not local to this gateway"
+            )
+        display_name = member.get("display_name", "")
+        if not isinstance(display_name, str):
+            raise DiscussionValidationError(
+                f"member {index} display_name must be a string"
+            )
+        display_name = display_name.strip()
+        if len(display_name) > hosted_rooms.MAX_ACTOR_LABEL_CHARS:
+            raise DiscussionValidationError(f"member {index} display_name is too long")
+
+        profile_key = profile.casefold()
+        handle_key = handle.casefold()
+        member_key = member_id.casefold()
+        if profile_key in profiles:
+            raise DiscussionValidationError("member profiles must be unique")
+        if handle_key in handles or handle_key in {"all", "everyone"}:
+            raise DiscussionValidationError(
+                "member handles must be unique and cannot reserve @all or @everyone"
+            )
+        if member_key in member_ids:
+            raise DiscussionValidationError("member ids must be unique")
+        profiles.add(profile_key)
+        handles.add(handle_key)
+        member_ids.add(member_key)
+        members.append(
+            DiscussionMember(
+                member_id=member_id,
+                profile=profile,
+                handle=handle,
+                display_name=display_name,
+            )
+        )
+    return tuple(members)
+
+
+def validate_room(
+    value: Any,
+    *,
+    local_profiles: Iterable[str],
+) -> DiscussionRoom:
+    """Project a hosted-room row into the strict same-gateway policy shape."""
+
+    if not isinstance(value, Mapping):
+        raise DiscussionValidationError("room must be an object")
+    if value.get("disbanded_at") is not None:
+        raise DiscussionValidationError("room is disbanded")
+    room_id = _identifier(value.get("room_id"), label="room_id")
+    name = value.get("name")
+    if not isinstance(name, str) or not name.strip():
+        raise DiscussionValidationError("room name must be a non-empty string")
+    name = name.strip()
+    if len(name) > hosted_rooms.MAX_ROOM_NAME_CHARS:
+        raise DiscussionValidationError("room name is too long")
+    gateway_id = _identifier(
+        value.get("authority_gateway_id"),
+        label="authority_gateway_id",
+    )
+    authority_epoch = _positive_int(
+        value.get("authority_epoch"),
+        label="authority_epoch",
+    )
+    members = validate_roster(value.get("members"), local_profiles=local_profiles)
+    return DiscussionRoom(
+        room_id=room_id,
+        name=name,
+        members=members,
+        gateway_id=gateway_id,
+        authority_epoch=authority_epoch,
+    )
+
+
+def is_pass_text(value: Any) -> bool:
+    """Return whether a settled member result is Discussion silence."""
+
+    text = str(value or "").strip()
+    return (
+        not text
+        or re.fullmatch(r"\(?\s*pass\s*\)?\.?", text, re.IGNORECASE) is not None
+    )
+
+
+def resolve_mentions(
+    texts: Iterable[str],
+    members: Sequence[DiscussionMember],
+) -> tuple[DiscussionMember, ...]:
+    """Resolve member handles deterministically; no known mention means all."""
+
+    by_handle = {member.handle.casefold(): member for member in members}
+    mentioned: set[str] = set()
+    everyone = False
+    for text in texts:
+        for match in _MENTION_RE.finditer(str(text or "")):
+            handle = match.group(1).casefold()
+            if handle in {"all", "everyone"}:
+                everyone = True
+            elif handle in by_handle:
+                mentioned.add(handle)
+    if everyone or not mentioned:
+        return tuple(members)
+    return tuple(member for member in members if member.handle.casefold() in mentioned)
+
+
+def _validate_event(
+    raw: Any,
+    *,
+    room: DiscussionRoom,
+    previous_seq: int,
+) -> _ValidatedEvent:
+    if not isinstance(raw, Mapping):
+        raise DiscussionValidationError("room event must be an object")
+    if raw.get("room_id") != room.room_id:
+        raise DiscussionValidationError("room event belongs to a different room")
+    seq = _positive_int(raw.get("seq"), label="event seq")
+    if seq <= previous_seq:
+        raise DiscussionValidationError("room events must be in strict sequence order")
+    event_id = _identifier(raw.get("event_id"), label="event_id")
+    kind = raw.get("kind")
+    if not isinstance(kind, str):
+        raise DiscussionValidationError("event kind must be a string")
+    actor = raw.get("actor")
+    if not isinstance(actor, Mapping):
+        raise DiscussionValidationError("event actor must be an object")
+    payload = raw.get("payload")
+    if not isinstance(payload, Mapping):
+        raise DiscussionValidationError("event payload must be an object")
+
+    if kind == "message.user":
+        payload = validate_user_payload(
+            payload,
+            member_ids=(member.member_id for member in room.members),
+        )
+        if actor.get("kind") != "user":
+            raise DiscussionValidationError("message.user requires a user actor")
+    elif kind == "message.member":
+        if raw.get("authority_epoch") != room.authority_epoch:
+            raise DiscussionValidationError(
+                "message.member authority epoch does not match the room"
+            )
+        _validate_member_message(payload, actor=actor, room=room)
+    elif kind in _TERMINAL_EVENT_KINDS:
+        if raw.get("authority_epoch") != room.authority_epoch:
+            raise DiscussionValidationError(
+                f"{kind} authority epoch does not match the room"
+            )
+        _validate_terminal_event(kind, payload, actor=actor, room=room)
+
+    return _ValidatedEvent(
+        raw=raw,
+        seq=seq,
+        event_id=event_id,
+        kind=kind,
+        actor=actor,
+        payload=payload,
+    )
+
+
+def _member_by_id(room: DiscussionRoom, member_id: Any) -> DiscussionMember:
+    normalized = _identifier(member_id, label="member_id")
+    for member in room.members:
+        if member.member_id == normalized:
+            return member
+    raise DiscussionValidationError(f"unknown Discussion member '{normalized}'")
+
+
+def _validate_turn_coordinates(
+    payload: Mapping[str, Any], room: DiscussionRoom
+) -> None:
+    _member_by_id(room, payload.get("member_id"))
+    member_index = _zero_based_int(
+        payload.get("member_index"),
+        label="member_index",
+        maximum=MAX_DISCUSSION_MEMBERS - 1,
+    )
+    round_index = _zero_based_int(
+        payload.get("round_index"),
+        label="round_index",
+        maximum=MAX_DISCUSSION_ROUNDS - 1,
+    )
+    thread_id = _identifier(payload.get("thread_id"), label="thread_id")
+    task_id = _identifier(payload.get("task_id"), label="task_id")
+    turn_id = _identifier(payload.get("turn_id"), label="turn_id")
+    discussion_event_id = _identifier(
+        payload.get("discussion_event_id"),
+        label="discussion_event_id",
+    )
+    del member_index, round_index, thread_id, task_id, turn_id, discussion_event_id
+
+
+def _validate_member_message(
+    payload: Mapping[str, Any],
+    *,
+    actor: Mapping[str, Any],
+    room: DiscussionRoom,
+) -> None:
+    _exact_fields(
+        payload,
+        label="message.member payload",
+        required=_MEMBER_MESSAGE_FIELDS,
+    )
+    _validate_turn_coordinates(payload, room)
+    text = payload.get("text")
+    if not isinstance(text, str) or not text.strip() or is_pass_text(text):
+        raise DiscussionValidationError("message.member text must be a non-pass string")
+    member = _member_by_id(room, payload.get("member_id"))
+    if (
+        actor.get("kind") != "member"
+        or actor.get("id") != member.member_id
+        or actor.get("profile") != member.profile
+        or actor.get("connection_id") is not None
+    ):
+        raise DiscussionValidationError("message.member actor does not match roster")
+
+
+def _validate_terminal_event(
+    kind: str,
+    payload: Mapping[str, Any],
+    *,
+    actor: Mapping[str, Any],
+    room: DiscussionRoom,
+) -> None:
+    required = _TERMINAL_COMMON_FIELDS | _TERMINAL_EXTRA_FIELDS[kind]
+    _exact_fields(payload, label=f"{kind} payload", required=required)
+    _validate_turn_coordinates(payload, room)
+    _positive_int(payload.get("seen_through_seq"), label="seen_through_seq")
+    if (
+        actor.get("kind") != "gateway"
+        or actor.get("id") != room.gateway_id
+        or actor.get("connection_id") is not None
+    ):
+        raise DiscussionValidationError(f"{kind} requires a gateway actor")
+    if kind == "turn.settled":
+        if not isinstance(payload.get("passed"), bool):
+            raise DiscussionValidationError("turn.settled passed must be a boolean")
+        message_event_id = payload.get("message_event_id")
+        if payload["passed"]:
+            if message_event_id is not None:
+                raise DiscussionValidationError(
+                    "a passed turn cannot reference a member message"
+                )
+        else:
+            _identifier(message_event_id, label="message_event_id")
+    else:
+        field = "error" if kind == "turn.failed" else "reason"
+        if not isinstance(payload.get(field), str) or not payload[field].strip():
+            raise DiscussionValidationError(f"{kind} {field} must be non-empty")
+
+
+def _validated_events(
+    events: Sequence[Mapping[str, Any]],
+    *,
+    room: DiscussionRoom,
+) -> tuple[_ValidatedEvent, ...]:
+    validated: list[_ValidatedEvent] = []
+    previous_seq = 0
+    event_ids: set[str] = set()
+    for raw in events:
+        event = _validate_event(raw, room=room, previous_seq=previous_seq)
+        if event.event_id in event_ids:
+            raise DiscussionValidationError("room event ids must be unique")
+        validated.append(event)
+        previous_seq = event.seq
+        event_ids.add(event.event_id)
+    return tuple(validated)
+
+
+def _discussion_user_events(
+    events: Sequence[_ValidatedEvent],
+) -> tuple[_ValidatedEvent, ...]:
+    return tuple(event for event in events if event.kind == "message.user")
+
+
+def _message_events(
+    events: Sequence[_ValidatedEvent],
+    *,
+    thread_id: str | None = None,
+    maximum_seq: int | None = None,
+) -> tuple[_ValidatedEvent, ...]:
+    result = []
+    for event in events:
+        if event.kind not in {"message.user", "message.member"}:
+            continue
+        if thread_id is not None and event.payload.get("thread_id") != thread_id:
+            continue
+        if maximum_seq is not None and event.seq > maximum_seq:
+            continue
+        result.append(event)
+    return tuple(result)
+
+
+def derive_member_watermarks(
+    room_value: Any,
+    events: Sequence[Mapping[str, Any]],
+    *,
+    local_profiles: Iterable[str],
+) -> dict[tuple[str, str], int]:
+    """Derive ``(thread_id, member_id)`` watermarks from terminal events."""
+
+    room = validate_room(room_value, local_profiles=local_profiles)
+    validated = _validated_events(events, room=room)
+    return _derive_member_watermarks(validated)
+
+
+def _derive_member_watermarks(
+    events: Sequence[_ValidatedEvent],
+) -> dict[tuple[str, str], int]:
+    messages_by_id = {
+        event.event_id: event for event in events if event.kind == "message.member"
+    }
+    terminal_by_task: dict[str, _ValidatedEvent] = {}
+    watermarks: dict[tuple[str, str], int] = {}
+    for event in events:
+        if event.kind not in _TERMINAL_EVENT_KINDS:
+            continue
+        task_id = str(event.payload["task_id"])
+        if task_id in terminal_by_task:
+            raise DiscussionValidationError(
+                f"task '{task_id}' has more than one terminal room event"
+            )
+        terminal_by_task[task_id] = event
+        key = (str(event.payload["thread_id"]), str(event.payload["member_id"]))
+        watermark = int(event.payload["seen_through_seq"])
+        if event.kind == "turn.settled" and not event.payload["passed"]:
+            message_id = str(event.payload["message_event_id"])
+            message = messages_by_id.get(message_id)
+            if (
+                message is None
+                or message.payload.get("task_id") != task_id
+                or message.payload.get("member_id") != event.payload.get("member_id")
+                or message.payload.get("thread_id") != event.payload.get("thread_id")
+            ):
+                raise DiscussionValidationError(
+                    "turn.settled references no matching member message"
+                )
+            watermark = max(watermark, message.seq)
+        watermarks[key] = max(watermarks.get(key, 0), watermark)
+    return watermarks
+
+
+def _member_digest(member: DiscussionMember) -> str:
+    seed = f"{member.member_id}\0{member.profile}\0{member.handle}"
+    return hashlib.sha256(seed.encode("utf-8")).hexdigest()[:24]
+
+
+def _rotate(
+    members: Sequence[DiscussionMember], round_index: int
+) -> tuple[DiscussionMember, ...]:
+    if len(members) < 2:
+        return tuple(members)
+    shift = round_index % len(members)
+    return tuple((*members[shift:], *members[:shift]))
+
+
+def _format_message(event: _ValidatedEvent, room: DiscussionRoom) -> str:
+    text = str(event.payload["text"])
+    if event.kind == "message.user":
+        return f"User (user): {text}"
+    member = _member_by_id(room, event.payload["member_id"])
+    return f"@{member.handle}: {text}"
+
+
+def _attachment_prompt_lines(
+    messages: Sequence[_ValidatedEvent],
+    member: DiscussionMember,
+) -> list[str]:
+    entries: list[str] = []
+    queued_media = False
+    for event in messages:
+        if event.kind != "message.user":
+            continue
+        for attachment in event.payload.get("attachments", []):
+            ref = attachment["refs"][member.member_id]
+            name = json.dumps(attachment["name"], ensure_ascii=True)
+            metadata = f"{attachment['mime']}, {attachment['size']} bytes"
+            if attachment["kind"] == "file":
+                if ref is not None:
+                    entries.append(f"- Staged file {name} ({metadata}): {ref}")
+                continue
+            queued_media = True
+            label = "image" if attachment["kind"] == "image" else "PDF"
+            ref_note = f" Staged ref: {ref}." if ref is not None else ""
+            entries.append(
+                f"- Queued {label} {name} ({metadata}) for this turn.{ref_note}"
+            )
+    if not entries:
+        return []
+    lines = ["", "Attachments available to you for this turn:", *entries]
+    if queued_media:
+        lines.append(
+            "Queued image/PDF attachments are staged separately for this turn; "
+            "inspect the supplied media rather than treating its filename as content."
+        )
+    return lines
+
+
+def _build_prompt(
+    *,
+    room: DiscussionRoom,
+    member: DiscussionMember,
+    messages: Sequence[_ValidatedEvent],
+    watermark: int,
+    seen_through_seq: int,
+) -> str:
+    delta = [event for event in messages if watermark < event.seq <= seen_through_seq][
+        -MAX_DISCUSSION_DELTA_LINES:
+    ]
+    peers = ", ".join(
+        f"@{candidate.handle}"
+        for candidate in room.members
+        if candidate.member_id != member.member_id
+    )
+    lines = [
+        f'[Discussion: "{room.name}"] You are @{member.handle}, one participant '
+        f"with {peers or 'no other members'} and the user.",
+        "",
+        "New messages in this thread since your last turn (oldest first):",
+        *[f"  {_format_message(event, room)}" for event in delta],
+        *_attachment_prompt_lines(delta, member),
+        "",
+        "Rules for this Discussion:",
+        "- Reply with one conversational message only when you have something new worth adding.",
+        '- If you have nothing new to add, reply with exactly "(pass)".',
+        "- Mention a teammate by handle to pull them into the next round; do not repeat points already made.",
+        "- Never reveal content from private conversations. Your reply is published verbatim.",
+    ]
+    prompt = "\n".join(lines)
+    if len(prompt.encode("utf-8")) > driver.MAX_PROMPT_BYTES:
+        raise DiscussionValidationError("Discussion prompt exceeds the driver limit")
+    return prompt
+
+
+def _turn_id(
+    *,
+    source_event_seq: int,
+    round_index: int,
+    member_index: int,
+    seen_through_seq: int,
+    member: DiscussionMember,
+) -> str:
+    return (
+        f"d{source_event_seq}.r{round_index}.p{member_index}."
+        f"s{seen_through_seq}.m{_member_digest(member)}"
+    )
+
+
+def _task_id(
+    *,
+    room: DiscussionRoom,
+    discussion_event: _ValidatedEvent,
+    member: DiscussionMember,
+    member_index: int,
+    round_index: int,
+    seen_through_seq: int,
+    prompt: str,
+) -> str:
+    seed = json.dumps(
+        {
+            "discussion_event_id": discussion_event.event_id,
+            "member_id": member.member_id,
+            "member_index": member_index,
+            "prompt_sha256": hashlib.sha256(prompt.encode("utf-8")).hexdigest(),
+            "room_id": room.room_id,
+            "round_index": round_index,
+            "seen_through_seq": seen_through_seq,
+            "source_event_seq": discussion_event.seq,
+            "thread_id": discussion_event.payload["thread_id"],
+        },
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return f"dtask:{hashlib.sha256(seed.encode('utf-8')).hexdigest()[:48]}"
+
+
+def _make_task_plan(
+    *,
+    room: DiscussionRoom,
+    discussion_event: _ValidatedEvent,
+    member: DiscussionMember,
+    member_index: int,
+    round_index: int,
+    seen_through_seq: int,
+    prompt: str,
+) -> DiscussionTaskPlan:
+    turn_id = _turn_id(
+        source_event_seq=discussion_event.seq,
+        round_index=round_index,
+        member_index=member_index,
+        seen_through_seq=seen_through_seq,
+        member=member,
+    )
+    task_id = _task_id(
+        room=room,
+        discussion_event=discussion_event,
+        member=member,
+        member_index=member_index,
+        round_index=round_index,
+        seen_through_seq=seen_through_seq,
+        prompt=prompt,
+    )
+    identity = driver.TaskIdentity(
+        room_id=room.room_id,
+        task_id=task_id,
+        thread_id=str(discussion_event.payload["thread_id"]),
+        turn_id=turn_id,
+    )
+    payload = {
+        "target_profile": member.profile,
+        "prompt": prompt,
+        "source_event_seq": discussion_event.seq,
+    }
+    return DiscussionTaskPlan(
+        identity=identity,
+        payload=payload,
+        discussion_event_id=discussion_event.event_id,
+        member=member,
+        member_index=member_index,
+        round_index=round_index,
+        seen_through_seq=seen_through_seq,
+    )
+
+
+def plan_next_task(
+    room_value: Any,
+    events: Sequence[Mapping[str, Any]],
+    *,
+    local_profiles: Iterable[str],
+) -> DiscussionDecision:
+    """Replay the complete room log and return at most one next member task."""
+
+    room = validate_room(room_value, local_profiles=local_profiles)
+    validated = _validated_events(events, room=room)
+    user_events = _discussion_user_events(validated)
+    if not user_events:
+        return DiscussionDecision(status="idle", reason="no_user_event")
+
+    discussion = user_events[-1]
+    thread_id = str(discussion.payload["thread_id"])
+    committed_member_message_ids = {
+        str(event.payload["message_event_id"])
+        for event in validated
+        if event.kind == "turn.settled"
+        and event.payload.get("message_event_id") is not None
+    }
+    # Publication writes the visible member message before the terminal event.
+    # A crash in that gap leaves the message in the log, but it is not committed
+    # policy input yet: ignoring it reproduces the original task coordinates so
+    # the caller can inspect the terminal driver row and finish publication.
+    thread_messages = tuple(
+        event
+        for event in _message_events(validated, thread_id=thread_id)
+        if event.kind == "message.user"
+        or event.event_id in committed_member_message_ids
+    )
+    discussion_messages = tuple(
+        event for event in thread_messages if event.seq >= discussion.seq
+    )
+    member_messages = tuple(
+        event
+        for event in thread_messages
+        if event.kind == "message.member"
+        and event.payload.get("discussion_event_id") == discussion.event_id
+    )
+    if len(member_messages) >= MAX_DISCUSSION_MESSAGES:
+        return DiscussionDecision(
+            status="bounded",
+            reason="max_messages",
+            discussion_event_id=discussion.event_id,
+            source_event_seq=discussion.seq,
+            thread_id=thread_id,
+        )
+
+    terminals = {
+        (int(event.payload["round_index"]), str(event.payload["member_id"])): event
+        for event in validated
+        if event.kind in _TERMINAL_EVENT_KINDS
+        and event.payload.get("discussion_event_id") == discussion.event_id
+    }
+    watermarks = _derive_member_watermarks(validated)
+    seen_through_seq = max(event.seq for event in thread_messages)
+
+    for round_index in range(MAX_DISCUSSION_ROUNDS):
+        # Mentions emitted during a round recruit members for the next round,
+        # never retroactively into the one already in progress.
+        mention_texts = [
+            str(event.payload["text"])
+            for event in discussion_messages
+            if event.kind == "message.user"
+            or int(event.payload["round_index"]) < round_index
+        ]
+        responders = resolve_mentions(mention_texts, room.members)
+        ordered = _rotate(responders, round_index)
+        for member_index, member in enumerate(ordered):
+            if (round_index, member.member_id) in terminals:
+                continue
+            watermark = watermarks.get((thread_id, member.member_id), 0)
+            delta = [
+                event
+                for event in thread_messages
+                if watermark < event.seq <= seen_through_seq
+            ]
+            if not delta:
+                continue
+            prompt = _build_prompt(
+                room=room,
+                member=member,
+                messages=thread_messages,
+                watermark=watermark,
+                seen_through_seq=seen_through_seq,
+            )
+            task = _make_task_plan(
+                room=room,
+                discussion_event=discussion,
+                member=member,
+                member_index=member_index,
+                round_index=round_index,
+                seen_through_seq=seen_through_seq,
+                prompt=prompt,
+            )
+            return DiscussionDecision(
+                status="task",
+                reason="member_turn",
+                discussion_event_id=discussion.event_id,
+                source_event_seq=discussion.seq,
+                thread_id=thread_id,
+                task=task,
+            )
+
+        spoke = any(
+            int(event.payload["round_index"]) == round_index
+            for event in member_messages
+        )
+        if not spoke:
+            return DiscussionDecision(
+                status="settled",
+                reason="silent_round",
+                discussion_event_id=discussion.event_id,
+                source_event_seq=discussion.seq,
+                thread_id=thread_id,
+            )
+        if round_index == MAX_DISCUSSION_ROUNDS - 1:
+            return DiscussionDecision(
+                status="bounded",
+                reason="max_rounds",
+                discussion_event_id=discussion.event_id,
+                source_event_seq=discussion.seq,
+                thread_id=thread_id,
+            )
+
+    raise AssertionError("bounded Discussion loop exhausted unexpectedly")
+
+
+def reconstruct_task_plan(
+    room_value: Any,
+    events: Sequence[Mapping[str, Any]],
+    task: Mapping[str, Any],
+    *,
+    local_profiles: Iterable[str],
+) -> DiscussionTaskPlan:
+    """Reconstruct and verify one persisted driver task after a restart."""
+
+    room = validate_room(room_value, local_profiles=local_profiles)
+    validated = _validated_events(events, room=room)
+    identity = task.get("identity")
+    payload = task.get("payload")
+    if not isinstance(identity, driver.TaskIdentity) or not isinstance(
+        payload, Mapping
+    ):
+        raise DiscussionReconstructionError(
+            "driver task has no valid identity or payload"
+        )
+    if frozenset(payload) != frozenset({
+        "target_profile",
+        "prompt",
+        "source_event_seq",
+    }):
+        raise DiscussionReconstructionError("driver task payload shape changed")
+    match = _TURN_ID_RE.fullmatch(identity.turn_id)
+    if match is None:
+        raise DiscussionReconstructionError("turn_id is not a Discussion coordinate")
+    source_event_seq = int(match.group("source"))
+    round_index = int(match.group("round"))
+    member_index = int(match.group("position"))
+    seen_through_seq = int(match.group("seen"))
+    if payload.get("source_event_seq") != source_event_seq:
+        raise DiscussionReconstructionError("task source event does not match turn_id")
+    discussion = next(
+        (
+            event
+            for event in validated
+            if event.seq == source_event_seq and event.kind == "message.user"
+        ),
+        None,
+    )
+    if discussion is None:
+        raise DiscussionReconstructionError("task source user event is missing")
+    if (
+        identity.room_id != room.room_id
+        or identity.thread_id != discussion.payload["thread_id"]
+    ):
+        raise DiscussionReconstructionError(
+            "task identity does not match its room thread"
+        )
+    profile = payload.get("target_profile")
+    member = next(
+        (candidate for candidate in room.members if candidate.profile == profile), None
+    )
+    if member is None or _member_digest(member) != match.group("member"):
+        raise DiscussionReconstructionError("task target member does not match turn_id")
+    prompt = payload.get("prompt")
+    if not isinstance(prompt, str) or not prompt.strip():
+        raise DiscussionReconstructionError("task prompt is missing")
+    if len(prompt.encode("utf-8")) > driver.MAX_PROMPT_BYTES:
+        raise DiscussionReconstructionError("task prompt exceeds the driver limit")
+    reconstructed = _make_task_plan(
+        room=room,
+        discussion_event=discussion,
+        member=member,
+        member_index=member_index,
+        round_index=round_index,
+        seen_through_seq=seen_through_seq,
+        prompt=prompt,
+    )
+    if reconstructed.identity != identity or dict(reconstructed.payload) != dict(
+        payload
+    ):
+        raise DiscussionReconstructionError(
+            "driver task failed deterministic reconstruction"
+        )
+    return reconstructed
+
+
+def _terminal_text(result: Any, *, field: str, fallback: str) -> str:
+    if isinstance(result, Mapping):
+        value = result.get(field)
+        if value is None and field == "error":
+            value = result.get("text")
+    else:
+        value = result
+    text = str(value or "").strip()
+    return text or fallback
+
+
+def plan_publication(
+    room_value: Any,
+    events: Sequence[Mapping[str, Any]],
+    task: DiscussionTaskPlan,
+    *,
+    status: TerminalKind,
+    result: Any = None,
+    local_profiles: Iterable[str],
+) -> PublicationPlan:
+    """Plan idempotent room effects for one terminal driver task.
+
+    A newer user event in the same thread supersedes a late result.  The task
+    remains terminal in driver state, but only a deterministic cancellation is
+    published, preventing stale prose and its watermark from hiding the newer
+    user message.
+    """
+
+    room = validate_room(room_value, local_profiles=local_profiles)
+    validated = _validated_events(events, room=room)
+    if task.identity.room_id != room.room_id:
+        raise DiscussionValidationError("task belongs to a different room")
+    if task.member not in room.members:
+        raise DiscussionValidationError("task member is not in the frozen roster")
+    if status not in {"settled", "failed", "cancelled"}:
+        raise DiscussionValidationError("invalid terminal publication status")
+
+    newer_same_thread = any(
+        event.kind == "message.user"
+        and event.seq > task.seen_through_seq
+        and event.payload.get("thread_id") == task.identity.thread_id
+        for event in validated
+    )
+    effective_status: TerminalKind = "cancelled" if newer_same_thread else status
+    digest = task.identity.task_id.removeprefix("dtask:")
+    message_event_id = f"dmessage:{digest}"
+    terminal_event_id = f"dterminal:{digest}"
+    common = {
+        "discussion_event_id": task.discussion_event_id,
+        "member_id": task.member.member_id,
+        "member_index": task.member_index,
+        "round_index": task.round_index,
+        "seen_through_seq": task.seen_through_seq,
+        "task_id": task.identity.task_id,
+        "thread_id": task.identity.thread_id,
+        "turn_id": task.identity.turn_id,
+    }
+    effects: list[EventPlan] = []
+
+    if effective_status == "settled":
+        text = _terminal_text(result, field="text", fallback="")
+        passed = is_pass_text(text)
+        if not passed:
+            member_actor = {
+                "kind": "member",
+                "id": task.member.member_id,
+                "profile": task.member.profile,
+            }
+            if task.member.display_name:
+                member_actor["display_name"] = task.member.display_name
+            effects.append(
+                EventPlan(
+                    event_id=message_event_id,
+                    kind="message.member",
+                    actor=member_actor,
+                    payload={
+                        "discussion_event_id": task.discussion_event_id,
+                        "member_id": task.member.member_id,
+                        "member_index": task.member_index,
+                        "round_index": task.round_index,
+                        "task_id": task.identity.task_id,
+                        "text": text,
+                        "thread_id": task.identity.thread_id,
+                        "turn_id": task.identity.turn_id,
+                    },
+                    authority_gateway_id=room.gateway_id,
+                    authority_epoch=room.authority_epoch,
+                )
+            )
+        terminal_payload = {
+            **common,
+            "message_event_id": None if passed else message_event_id,
+            "passed": passed,
+        }
+        terminal_kind = "turn.settled"
+    elif effective_status == "failed":
+        terminal_payload = {
+            **common,
+            "error": _terminal_text(
+                result,
+                field="error",
+                fallback="member turn failed",
+            ),
+        }
+        terminal_kind = "turn.failed"
+    else:
+        terminal_payload = {
+            **common,
+            "reason": (
+                "superseded_by_newer_user_event"
+                if newer_same_thread
+                else _terminal_text(
+                    result,
+                    field="reason",
+                    fallback="member turn cancelled",
+                )
+            ),
+        }
+        terminal_kind = "turn.cancelled"
+
+    effects.append(
+        EventPlan(
+            event_id=terminal_event_id,
+            kind=terminal_kind,
+            actor={"kind": "gateway", "id": room.gateway_id},
+            payload=terminal_payload,
+            authority_gateway_id=room.gateway_id,
+            authority_epoch=room.authority_epoch,
+        )
+    )
+    return PublicationPlan(
+        task_id=task.identity.task_id,
+        terminal_kind=terminal_kind,
+        events=tuple(effects),
+    )

--- a/gateway/hosted_room_discussion.py
+++ b/gateway/hosted_room_discussion.py
@@ -100,6 +100,13 @@ _TERMINAL_EXTRA_FIELDS = {
     "turn.cancelled": frozenset({"reason"}),
 }
 _TERMINAL_EVENT_KINDS = frozenset(_TERMINAL_EXTRA_FIELDS)
+_ROOM_ACTIVITY_FIELDS = frozenset({
+    "status",
+    "reason_code",
+    "thread_id",
+    "discussion_event_id",
+})
+_ROOM_STOP_FIELDS = frozenset({"cancel_id"})
 
 
 class DiscussionPolicyError(ValueError):
@@ -629,6 +636,38 @@ def _validate_event(
                 f"{kind} authority epoch does not match the room"
             )
         _validate_terminal_event(kind, payload, actor=actor, room=room)
+    elif kind == "room.activity":
+        if raw.get("authority_epoch") != room.authority_epoch:
+            raise DiscussionValidationError(
+                "room.activity authority epoch does not match the room"
+            )
+        _exact_fields(
+            payload,
+            label="room.activity payload",
+            required=_ROOM_ACTIVITY_FIELDS,
+        )
+        if payload.get("status") not in {"settled", "bounded"}:
+            raise DiscussionValidationError("invalid room.activity status")
+        _identifier(payload.get("reason_code"), label="reason_code")
+        _identifier(payload.get("thread_id"), label="thread_id")
+        _identifier(payload.get("discussion_event_id"), label="discussion_event_id")
+        if actor.get("kind") != "gateway" or actor.get("id") != room.gateway_id:
+            raise DiscussionValidationError("room.activity requires the room gateway")
+    elif kind == "room.stop_requested":
+        if raw.get("authority_epoch") != room.authority_epoch:
+            raise DiscussionValidationError(
+                "room.stop_requested authority epoch does not match the room"
+            )
+        _exact_fields(
+            payload,
+            label="room.stop_requested payload",
+            required=_ROOM_STOP_FIELDS,
+        )
+        _identifier(payload.get("cancel_id"), label="cancel_id")
+        if actor.get("kind") != "gateway" or actor.get("id") != room.gateway_id:
+            raise DiscussionValidationError(
+                "room.stop_requested requires the room gateway"
+            )
 
     return _ValidatedEvent(
         raw=raw,
@@ -1016,10 +1055,33 @@ def plan_next_task(
     room = validate_room(room_value, local_profiles=local_profiles)
     validated = _validated_events(events, room=room)
     user_events = _discussion_user_events(validated)
-    if not user_events:
-        return DiscussionDecision(status="idle", reason="no_user_event")
+    stopped_through_seq = max(
+        (
+            event.seq
+            for event in validated
+            if event.kind == "room.stop_requested"
+        ),
+        default=0,
+    )
+    completed_discussion_ids = {
+        str(event.payload["discussion_event_id"])
+        for event in validated
+        if event.kind == "room.activity"
+        and event.payload.get("status") in {"settled", "bounded"}
+    }
+    latest_by_thread: dict[str, _ValidatedEvent] = {}
+    for event in user_events:
+        latest_by_thread[str(event.payload["thread_id"])] = event
+    pending_user_events = tuple(
+        event
+        for event in sorted(latest_by_thread.values(), key=lambda item: item.seq)
+        if event.seq > stopped_through_seq
+        and event.event_id not in completed_discussion_ids
+    )
+    if not pending_user_events:
+        return DiscussionDecision(status="idle", reason="no_pending_user_event")
 
-    discussion = user_events[-1]
+    discussion = pending_user_events[0]
     thread_id = str(discussion.payload["thread_id"])
     committed_member_message_ids = {
         str(event.payload["message_event_id"])

--- a/gateway/hosted_room_discussion.py
+++ b/gateway/hosted_room_discussion.py
@@ -24,6 +24,10 @@ from typing import Any, Literal
 
 from gateway import hosted_room_driver as driver
 from gateway import hosted_rooms
+from gateway.hosted_room_attachments import (
+    MAX_TASK_ATTACHMENT_BYTES,
+    MAX_TASK_ATTACHMENTS,
+)
 
 
 MAX_DISCUSSION_MEMBERS = 6
@@ -35,8 +39,9 @@ MAX_USER_TEXT_BYTES = 64 * 1024
 MAX_ATTACHMENTS = 8
 MAX_ATTACHMENT_NAME_CHARS = 255
 MAX_ATTACHMENT_MIME_CHARS = 127
-MAX_ATTACHMENT_REF_CHARS = 256
-MAX_ATTACHMENT_SIZE_BYTES = 100 * 1024 * 1024
+MAX_ATTACHMENT_ID_CHARS = 128
+MAX_ATTACHMENT_SIZE_BYTES = 15_000_000
+MAX_ATTACHMENT_TOTAL_BYTES = 25_000_000
 MAX_ATTACHMENT_MANIFEST_BYTES = 32 * 1024
 
 DecisionStatus = Literal["idle", "task", "settled", "bounded"]
@@ -47,7 +52,7 @@ _MENTION_RE = re.compile(r"@([A-Za-z0-9][A-Za-z0-9._:-]*)", re.IGNORECASE)
 _MIME_RE = re.compile(
     r"^[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]*/[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]*$"
 )
-_SAFE_REF_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:@-]*$")
+_ATTACHMENT_ID_RE = re.compile(r"^att_[0-9a-f]{32}$")
 _TURN_ID_RE = re.compile(
     r"^d(?P<source>[1-9][0-9]*)\.r(?P<round>[0-2])\."
     r"p(?P<position>[0-5])\.s(?P<seen>[1-9][0-9]*)\."
@@ -72,7 +77,7 @@ _REMOTE_MEMBER_FIELDS = frozenset({
 })
 _USER_PAYLOAD_FIELDS = frozenset({"text", "thread_id"})
 _USER_PAYLOAD_OPTIONAL_FIELDS = frozenset({"attachments"})
-_ATTACHMENT_FIELDS = frozenset({"kind", "name", "size", "mime", "refs"})
+_ATTACHMENT_FIELDS = frozenset({"attachment_id", "kind", "name", "size", "mime"})
 _ATTACHMENT_KINDS = frozenset({"image", "pdf", "file"})
 _MEMBER_MESSAGE_FIELDS = frozenset({
     "discussion_event_id",
@@ -308,28 +313,6 @@ def _attachment_mime(value: Any, *, index: int, kind: str) -> str:
     return mime
 
 
-def _safe_attachment_ref(value: Any, *, index: int, member_id: str) -> str | None:
-    if value is None:
-        return None
-    if not isinstance(value, str):
-        raise DiscussionValidationError(
-            f"attachment {index} ref for '{member_id}' must be a string or null"
-        )
-    ref = value.strip()
-    lowered = ref.casefold()
-    if (
-        not ref
-        or len(ref) > MAX_ATTACHMENT_REF_CHARS
-        or _SAFE_REF_RE.fullmatch(ref) is None
-        or lowered.startswith(("data:", "base64:", "file:", "path:"))
-        or ref.startswith((".", "~"))
-    ):
-        raise DiscussionValidationError(
-            f"attachment {index} ref for '{member_id}' is not a safe opaque ref"
-        )
-    return ref
-
-
 def _validate_attachments(
     value: Any,
     *,
@@ -348,7 +331,12 @@ def _validate_attachments(
     expected_member_ids = tuple(
         _identifier(member_id, label="attachment member_id") for member_id in member_ids
     )
-    expected_keys = frozenset(expected_member_ids)
+    if not expected_member_ids or len(set(expected_member_ids)) != len(
+        expected_member_ids
+    ):
+        raise DiscussionValidationError(
+            "attachment member ids must be a non-empty frozen set"
+        )
     normalized: list[dict[str, Any]] = []
     for index, raw in enumerate(value):
         attachment = _exact_fields(
@@ -356,6 +344,15 @@ def _validate_attachments(
             label=f"attachment {index}",
             required=_ATTACHMENT_FIELDS,
         )
+        attachment_id = attachment["attachment_id"]
+        if (
+            not isinstance(attachment_id, str)
+            or len(attachment_id) > MAX_ATTACHMENT_ID_CHARS
+            or _ATTACHMENT_ID_RE.fullmatch(attachment_id) is None
+        ):
+            raise DiscussionValidationError(
+                f"attachment {index} has an invalid opaque attachment_id"
+            )
         kind = attachment["kind"]
         if not isinstance(kind, str) or kind not in _ATTACHMENT_KINDS:
             raise DiscussionValidationError(
@@ -366,45 +363,26 @@ def _validate_attachments(
         if (
             isinstance(size, bool)
             or not isinstance(size, int)
-            or not 0 <= size <= MAX_ATTACHMENT_SIZE_BYTES
+            or not 0 < size <= MAX_ATTACHMENT_SIZE_BYTES
         ):
             raise DiscussionValidationError(
-                f"attachment {index} size must be between 0 and "
+                f"attachment {index} size must be between 1 and "
                 f"{MAX_ATTACHMENT_SIZE_BYTES} bytes"
             )
         mime = _attachment_mime(attachment["mime"], index=index, kind=kind)
-        refs = attachment["refs"]
-        if not isinstance(refs, Mapping):
-            raise DiscussionValidationError(
-                f"attachment {index} refs must be an object"
-            )
-        ref_keys = frozenset(refs)
-        missing = expected_keys - ref_keys
-        unknown = ref_keys - expected_keys
-        if missing:
-            raise DiscussionValidationError(
-                f"attachment {index} refs are missing member ids: "
-                f"{', '.join(sorted(missing))}"
-            )
-        if unknown:
-            raise DiscussionValidationError(
-                f"attachment {index} refs contain unknown member ids: "
-                f"{', '.join(sorted(str(key) for key in unknown))}"
-            )
         normalized.append({
+            "attachment_id": attachment_id,
             "kind": kind,
             "name": name,
             "size": size,
             "mime": mime,
-            "refs": {
-                member_id: _safe_attachment_ref(
-                    refs[member_id],
-                    index=index,
-                    member_id=member_id,
-                )
-                for member_id in expected_member_ids
-            },
         })
+    if len({item["attachment_id"] for item in normalized}) != len(normalized):
+        raise DiscussionValidationError("attachment ids must be unique")
+    if sum(item["size"] for item in normalized) > MAX_ATTACHMENT_TOTAL_BYTES:
+        raise DiscussionValidationError(
+            "attachment manifest exceeds the message byte limit"
+        )
     encoded = json.dumps(
         normalized,
         ensure_ascii=True,
@@ -433,8 +411,10 @@ def validate_user_payload(
     if not isinstance(text, str):
         raise DiscussionValidationError("user payload text must be a string")
     text = text.strip()
-    if not text:
-        raise DiscussionValidationError("user payload text must not be empty")
+    if not text and not payload.get("attachments"):
+        raise DiscussionValidationError(
+            "user payload must contain text or attachments"
+        )
     if len(text.encode("utf-8")) > MAX_USER_TEXT_BYTES:
         raise DiscussionValidationError("user payload text is too large")
     thread_id = _identifier(payload["thread_id"], label="thread_id")
@@ -831,6 +811,9 @@ def _derive_member_watermarks(
     messages_by_id = {
         event.event_id: event for event in events if event.kind == "message.member"
     }
+    user_seq_by_id = {
+        event.event_id: event.seq for event in events if event.kind == "message.user"
+    }
     terminal_by_task: dict[str, _ValidatedEvent] = {}
     watermarks: dict[tuple[str, str], int] = {}
     for event in events:
@@ -856,7 +839,18 @@ def _derive_member_watermarks(
                 raise DiscussionValidationError(
                     "turn.settled references no matching member message"
                 )
-            watermark = max(watermark, message.seq)
+            discussion_seq = user_seq_by_id.get(
+                str(event.payload["discussion_event_id"])
+            )
+            if discussion_seq is None:
+                raise DiscussionValidationError(
+                    "turn.settled references no matching user discussion"
+                )
+            # A partial attachment batch deliberately stops before the latest
+            # user event. Do not let this Bot's later visible reply skip the
+            # older attachment events that still need a bounded follow-up task.
+            if watermark >= discussion_seq:
+                watermark = max(watermark, message.seq)
         watermarks[key] = max(watermarks.get(key, 0), watermark)
     return watermarks
 
@@ -885,7 +879,6 @@ def _format_message(event: _ValidatedEvent, room: DiscussionRoom) -> str:
 
 def _attachment_prompt_lines(
     messages: Sequence[_ValidatedEvent],
-    member: DiscussionMember,
 ) -> list[str]:
     entries: list[str] = []
     queued_media = False
@@ -893,18 +886,15 @@ def _attachment_prompt_lines(
         if event.kind != "message.user":
             continue
         for attachment in event.payload.get("attachments", []):
-            ref = attachment["refs"][member.member_id]
             name = json.dumps(attachment["name"], ensure_ascii=True)
             metadata = f"{attachment['mime']}, {attachment['size']} bytes"
             if attachment["kind"] == "file":
-                if ref is not None:
-                    entries.append(f"- Staged file {name} ({metadata}): {ref}")
+                entries.append(f"- Staged file {name} ({metadata})")
                 continue
             queued_media = True
             label = "image" if attachment["kind"] == "image" else "PDF"
-            ref_note = f" Staged ref: {ref}." if ref is not None else ""
             entries.append(
-                f"- Queued {label} {name} ({metadata}) for this turn.{ref_note}"
+                f"- Queued {label} {name} ({metadata}) for this turn."
             )
     if not entries:
         return []
@@ -925,9 +915,15 @@ def _build_prompt(
     watermark: int,
     seen_through_seq: int,
 ) -> str:
-    delta = [event for event in messages if watermark < event.seq <= seen_through_seq][
-        -MAX_DISCUSSION_DELTA_LINES:
-    ]
+    delta = [
+        event
+        for event in messages
+        if watermark < event.seq <= seen_through_seq
+        and not (
+            event.kind == "message.member"
+            and event.payload.get("member_id") == member.member_id
+        )
+    ][-MAX_DISCUSSION_DELTA_LINES:]
     peers = ", ".join(
         f"@{candidate.handle}"
         for candidate in room.members
@@ -939,7 +935,7 @@ def _build_prompt(
         "",
         "New messages in this thread since your last turn (oldest first):",
         *[f"  {_format_message(event, room)}" for event in delta],
-        *_attachment_prompt_lines(delta, member),
+        *_attachment_prompt_lines(delta),
         "",
         "Rules for this Discussion:",
         "- Reply with one conversational message only when you have something new worth adding.",
@@ -1005,6 +1001,7 @@ def _make_task_plan(
     round_index: int,
     seen_through_seq: int,
     prompt: str,
+    attachments: Sequence[Mapping[str, Any]] = (),
 ) -> DiscussionTaskPlan:
     turn_id = _turn_id(
         source_event_seq=discussion_event.seq,
@@ -1033,6 +1030,8 @@ def _make_task_plan(
         "prompt": prompt,
         "source_event_seq": discussion_event.seq,
     }
+    if attachments:
+        payload["attachments"] = [dict(attachment) for attachment in attachments]
     return DiscussionTaskPlan(
         identity=identity,
         payload=payload,
@@ -1042,6 +1041,52 @@ def _make_task_plan(
         round_index=round_index,
         seen_through_seq=seen_through_seq,
     )
+
+
+def _bounded_task_delta(
+    messages: Sequence[_ValidatedEvent],
+    *,
+    watermark: int,
+    maximum_seq: int,
+) -> tuple[int, list[_ValidatedEvent], list[dict[str, Any]]]:
+    """Return the oldest complete input prefix that fits one model turn.
+
+    Every accepted user message already fits the per-message attachment limits,
+    so the first event can always make progress. Stopping only between events
+    preserves each message and lets the terminal watermark resume at the next
+    unconsumed event instead of poisoning the room backlog.
+    """
+
+    selected: list[_ValidatedEvent] = []
+    attachments: list[dict[str, Any]] = []
+    attachment_bytes = 0
+    seen_through_seq = watermark
+    for event in messages:
+        if not watermark < event.seq <= maximum_seq:
+            continue
+        event_attachments = (
+            list(event.payload.get("attachments", []))
+            if event.kind == "message.user"
+            else []
+        )
+        next_count = len(attachments) + len(event_attachments)
+        next_bytes = attachment_bytes + sum(
+            int(attachment["size"]) for attachment in event_attachments
+        )
+        if event_attachments and (
+            next_count > MAX_TASK_ATTACHMENTS
+            or next_bytes > MAX_TASK_ATTACHMENT_BYTES
+        ):
+            if selected:
+                break
+            raise DiscussionValidationError(
+                "one user message exceeds the per-task attachment budget"
+            )
+        selected.append(event)
+        attachments.extend(dict(attachment) for attachment in event_attachments)
+        attachment_bytes = next_bytes
+        seen_through_seq = event.seq
+    return seen_through_seq, selected, attachments
 
 
 def plan_next_task(
@@ -1124,7 +1169,7 @@ def plan_next_task(
         and event.payload.get("discussion_event_id") == discussion.event_id
     }
     watermarks = _derive_member_watermarks(validated)
-    seen_through_seq = max(event.seq for event in thread_messages)
+    maximum_seen_seq = max(event.seq for event in thread_messages)
 
     for round_index in range(MAX_DISCUSSION_ROUNDS):
         # Mentions emitted during a round recruit members for the next round,
@@ -1138,14 +1183,21 @@ def plan_next_task(
         responders = resolve_mentions(mention_texts, room.members)
         ordered = _rotate(responders, round_index)
         for member_index, member in enumerate(ordered):
-            if (round_index, member.member_id) in terminals:
-                continue
             watermark = watermarks.get((thread_id, member.member_id), 0)
-            delta = [
-                event
+            terminal = terminals.get((round_index, member.member_id))
+            pending_attachments = any(
+                event.kind == "message.user"
+                and watermark < event.seq <= maximum_seen_seq
+                and event.payload.get("attachments")
                 for event in thread_messages
-                if watermark < event.seq <= seen_through_seq
-            ]
+            )
+            if terminal is not None and not pending_attachments:
+                continue
+            seen_through_seq, delta, attachments = _bounded_task_delta(
+                thread_messages,
+                watermark=watermark,
+                maximum_seq=maximum_seen_seq,
+            )
             if not delta:
                 continue
             prompt = _build_prompt(
@@ -1163,6 +1215,7 @@ def plan_next_task(
                 round_index=round_index,
                 seen_through_seq=seen_through_seq,
                 prompt=prompt,
+                attachments=attachments,
             )
             return DiscussionDecision(
                 status="task",
@@ -1216,11 +1269,10 @@ def reconstruct_task_plan(
         raise DiscussionReconstructionError(
             "driver task has no valid identity or payload"
         )
-    if frozenset(payload) != frozenset({
-        "target_profile",
-        "prompt",
-        "source_event_seq",
-    }):
+    if frozenset(payload) not in {
+        frozenset({"target_profile", "prompt", "source_event_seq"}),
+        frozenset({"target_profile", "prompt", "source_event_seq", "attachments"}),
+    }:
         raise DiscussionReconstructionError("driver task payload shape changed")
     match = _TURN_ID_RE.fullmatch(identity.turn_id)
     if match is None:
@@ -1259,6 +1311,19 @@ def reconstruct_task_plan(
         raise DiscussionReconstructionError("task prompt is missing")
     if len(prompt.encode("utf-8")) > driver.MAX_PROMPT_BYTES:
         raise DiscussionReconstructionError("task prompt exceeds the driver limit")
+    watermarks = _derive_member_watermarks(validated)
+    watermark = watermarks.get((identity.thread_id, member.member_id), 0)
+    task_messages = _message_events(
+        validated,
+        thread_id=identity.thread_id,
+        maximum_seq=seen_through_seq,
+    )
+    attachments = [
+        dict(attachment)
+        for event in task_messages
+        if watermark < event.seq <= seen_through_seq and event.kind == "message.user"
+        for attachment in event.payload.get("attachments", [])
+    ]
     reconstructed = _make_task_plan(
         room=room,
         discussion_event=discussion,
@@ -1267,6 +1332,7 @@ def reconstruct_task_plan(
         round_index=round_index,
         seen_through_seq=seen_through_seq,
         prompt=prompt,
+        attachments=attachments,
     )
     if reconstructed.identity != identity or dict(reconstructed.payload) != dict(
         payload
@@ -1314,9 +1380,10 @@ def plan_publication(
     if status not in {"settled", "failed", "cancelled"}:
         raise DiscussionValidationError("invalid terminal publication status")
 
+    source_event_seq = int(task.payload["source_event_seq"])
     newer_same_thread = any(
         event.kind == "message.user"
-        and event.seq > task.seen_through_seq
+        and event.seq > source_event_seq
         and event.payload.get("thread_id") == task.identity.thread_id
         for event in validated
     )

--- a/gateway/hosted_room_driver.py
+++ b/gateway/hosted_room_driver.py
@@ -1,0 +1,1465 @@
+"""Durable execution state for a same-gateway hosted room driver.
+
+This module owns only the driver lease and task state machine. It does not
+invoke models, touch sessions, or depend on the hosted-room event log. Callers
+provide both the database path and clock so recovery and fencing behavior can
+be tested without process-global state.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import re
+import sqlite3
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Iterator, Literal
+
+
+Clock = Callable[[], float]
+TaskStatus = Literal[
+    "queued",
+    "running",
+    "settled",
+    "failed",
+    "cancelled",
+    "indeterminate",
+    "stopping",
+]
+TerminalStatus = Literal["settled", "failed"]
+
+MAX_IDENTIFIER_CHARS = 128
+MAX_PROMPT_BYTES = 128 * 1024
+MAX_RESULT_JSON_BYTES = 256 * 1024
+TASK_STATUSES = frozenset({
+    "queued",
+    "running",
+    "settled",
+    "failed",
+    "cancelled",
+    "indeterminate",
+    "stopping",
+})
+TERMINAL_STATUSES = frozenset({"settled", "failed", "cancelled"})
+
+_IDENTIFIER_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]*$")
+_TASK_PAYLOAD_FIELDS = frozenset({"target_profile", "prompt", "source_event_seq"})
+_LEASE_COLUMNS = frozenset({
+    "room_id",
+    "gateway_id",
+    "authority_epoch",
+    "process_generation",
+    "lease_generation",
+    "expires_at",
+    "acquired_at",
+    "updated_at",
+    "released_at",
+})
+_TASK_COLUMNS = frozenset({
+    "room_id",
+    "task_id",
+    "thread_id",
+    "turn_id",
+    "source_event_seq",
+    "payload_json",
+    "payload_digest",
+    "status",
+    "execution_generation",
+    "cancel_generation",
+    "run_gateway_id",
+    "run_process_generation",
+    "run_lease_generation",
+    "cancel_id",
+    "settlement_id",
+    "settlement_status",
+    "result_json",
+    "created_at",
+    "updated_at",
+    "started_at",
+    "terminal_at",
+    "indeterminate_at",
+})
+_TASK_COLUMN_ORDER = (
+    "room_id",
+    "task_id",
+    "thread_id",
+    "turn_id",
+    "source_event_seq",
+    "payload_json",
+    "payload_digest",
+    "status",
+    "execution_generation",
+    "cancel_generation",
+    "run_gateway_id",
+    "run_process_generation",
+    "run_lease_generation",
+    "cancel_id",
+    "settlement_id",
+    "settlement_status",
+    "result_json",
+    "created_at",
+    "updated_at",
+    "started_at",
+    "terminal_at",
+    "indeterminate_at",
+)
+
+
+class DriverStateError(ValueError):
+    """Base class for invalid or conflicting driver-state operations."""
+
+
+class DriverValidationError(DriverStateError):
+    """Raised when an identifier, clock, TTL, or payload is invalid."""
+
+
+class RoomUnavailableError(DriverStateError):
+    """Raised when the hosted room does not exist or was disbanded."""
+
+
+class LeaseHeldError(DriverStateError):
+    """Raised when another unexpired driver generation owns the room."""
+
+
+class StaleLeaseError(DriverStateError):
+    """Raised when a lease generation can no longer mutate room state."""
+
+
+class TaskConflictError(DriverStateError):
+    """Raised when an idempotency key is reused for different task state."""
+
+
+class StaleTaskError(DriverStateError):
+    """Raised when an obsolete task attempt or cancellation tries to commit."""
+
+
+class InvalidTaskTransitionError(DriverStateError):
+    """Raised when a requested task transition is not allowed."""
+
+
+def _identifier(value: Any, *, label: str) -> str:
+    if not isinstance(value, str):
+        raise DriverValidationError(f"{label} must be a string")
+    value = value.strip()
+    if (
+        not value
+        or len(value) > MAX_IDENTIFIER_CHARS
+        or not _IDENTIFIER_RE.fullmatch(value)
+    ):
+        raise DriverValidationError(f"invalid {label}")
+    return value
+
+
+def _timestamp(clock: Clock) -> float:
+    if not callable(clock):
+        raise DriverValidationError("clock must be callable")
+    try:
+        value = float(clock())
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise DriverValidationError("clock must return a finite number") from exc
+    if not math.isfinite(value):
+        raise DriverValidationError("clock must return a finite number")
+    return value
+
+
+def _ttl(value: Any) -> float:
+    try:
+        ttl = float(value)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise DriverValidationError(
+            "ttl_seconds must be a finite positive number"
+        ) from exc
+    if not math.isfinite(ttl) or ttl <= 0:
+        raise DriverValidationError("ttl_seconds must be a finite positive number")
+    return ttl
+
+
+def _expiry(now: float, ttl: float) -> float:
+    expires_at = now + ttl
+    if not math.isfinite(expires_at):
+        raise DriverValidationError("lease expiry must be finite")
+    return expires_at
+
+
+def _canonical_json(value: Any) -> str:
+    try:
+        encoded = json.dumps(
+            value,
+            ensure_ascii=True,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+    except (TypeError, ValueError, RecursionError) as exc:
+        raise DriverValidationError("result must be JSON-serializable") from exc
+    if len(encoded.encode("utf-8")) > MAX_RESULT_JSON_BYTES:
+        raise DriverValidationError("result is too large")
+    return encoded
+
+
+def _authority_epoch(value: Any) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise DriverValidationError("authority_epoch must be a positive integer")
+    return value
+
+
+def _task_payload(value: Any) -> tuple[dict[str, Any], str, str]:
+    if not isinstance(value, dict):
+        raise DriverValidationError("payload must be an object")
+    unknown = set(value) - _TASK_PAYLOAD_FIELDS
+    missing = _TASK_PAYLOAD_FIELDS - set(value)
+    if unknown:
+        raise DriverValidationError(
+            f"unknown payload fields: {', '.join(sorted(unknown))}"
+        )
+    if missing:
+        raise DriverValidationError(
+            f"missing payload fields: {', '.join(sorted(missing))}"
+        )
+
+    target_profile = _identifier(value["target_profile"], label="target_profile")
+    prompt = value["prompt"]
+    if not isinstance(prompt, str):
+        raise DriverValidationError("prompt must be a string")
+    if not prompt.strip():
+        raise DriverValidationError("prompt must not be empty")
+    if len(prompt.encode("utf-8")) > MAX_PROMPT_BYTES:
+        raise DriverValidationError("prompt is too large")
+    source_event_seq = value["source_event_seq"]
+    if (
+        isinstance(source_event_seq, bool)
+        or not isinstance(source_event_seq, int)
+        or source_event_seq < 1
+    ):
+        raise DriverValidationError("source_event_seq must be a positive integer")
+
+    normalized = {
+        "target_profile": target_profile,
+        "prompt": prompt,
+        "source_event_seq": source_event_seq,
+    }
+    encoded = json.dumps(
+        normalized,
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    digest = hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+    return normalized, encoded, digest
+
+
+@dataclass(frozen=True)
+class TaskIdentity:
+    """Stable identity for one admitted room turn."""
+
+    room_id: str
+    task_id: str
+    thread_id: str
+    turn_id: str
+
+    def __post_init__(self) -> None:
+        for field in ("room_id", "task_id", "thread_id", "turn_id"):
+            object.__setattr__(
+                self,
+                field,
+                _identifier(getattr(self, field), label=field),
+            )
+
+
+@dataclass(frozen=True)
+class DriverLease:
+    """A fenced lease held by one gateway process incarnation."""
+
+    room_id: str
+    gateway_id: str
+    authority_epoch: int
+    process_generation: str
+    lease_generation: int
+    expires_at: float
+    reclaimed: bool = False
+
+
+@dataclass(frozen=True)
+class TaskAttempt:
+    """The exact running generation authorized to settle one task."""
+
+    identity: TaskIdentity
+    lease: DriverLease
+    execution_generation: int
+    cancel_generation: int
+
+
+def _create_task_table(
+    conn: sqlite3.Connection, table: str = "hosted_room_driver_tasks"
+) -> None:
+    if table not in {"hosted_room_driver_tasks", "hosted_room_driver_tasks_next"}:
+        raise DriverStateError("invalid hosted-room task table name")
+    conn.execute(
+        f"""CREATE TABLE IF NOT EXISTS {table} (
+            room_id TEXT NOT NULL,
+            task_id TEXT NOT NULL,
+            thread_id TEXT NOT NULL,
+            turn_id TEXT NOT NULL,
+            source_event_seq INTEGER NOT NULL CHECK (source_event_seq >= 1),
+            payload_json TEXT NOT NULL,
+            payload_digest TEXT NOT NULL,
+            status TEXT NOT NULL CHECK (
+                status IN (
+                    'queued', 'running', 'settled', 'failed',
+                    'cancelled', 'indeterminate', 'stopping'
+                )
+            ),
+            execution_generation INTEGER NOT NULL DEFAULT 0
+                CHECK (execution_generation >= 0),
+            cancel_generation INTEGER NOT NULL DEFAULT 0
+                CHECK (cancel_generation >= 0),
+            run_gateway_id TEXT,
+            run_process_generation TEXT,
+            run_lease_generation INTEGER,
+            cancel_id TEXT,
+            settlement_id TEXT,
+            settlement_status TEXT,
+            result_json TEXT,
+            created_at REAL NOT NULL,
+            updated_at REAL NOT NULL,
+            started_at REAL,
+            terminal_at REAL,
+            indeterminate_at REAL,
+            PRIMARY KEY (room_id, task_id),
+            UNIQUE (room_id, thread_id, turn_id),
+            FOREIGN KEY (room_id) REFERENCES hosted_rooms(room_id)
+        )"""
+    )
+
+
+def _initialize_schema(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS hosted_room_driver_leases (
+            room_id TEXT PRIMARY KEY,
+            gateway_id TEXT NOT NULL,
+            authority_epoch INTEGER NOT NULL CHECK (authority_epoch >= 1),
+            process_generation TEXT NOT NULL,
+            lease_generation INTEGER NOT NULL CHECK (lease_generation >= 1),
+            expires_at REAL NOT NULL,
+            acquired_at REAL NOT NULL,
+            updated_at REAL NOT NULL,
+            released_at REAL,
+            FOREIGN KEY (room_id) REFERENCES hosted_rooms(room_id)
+        )"""
+    )
+    _create_task_table(conn)
+    _validate_schema(conn)
+    conn.execute(
+        """CREATE INDEX IF NOT EXISTS idx_hosted_room_driver_tasks_status
+           ON hosted_room_driver_tasks(
+               room_id, status, source_event_seq, created_at, task_id
+           )"""
+    )
+
+
+def _validate_schema(conn: sqlite3.Connection) -> None:
+    lease_columns = frozenset(
+        row[1] for row in conn.execute("PRAGMA table_info(hosted_room_driver_leases)")
+    )
+    task_columns = frozenset(
+        row[1] for row in conn.execute("PRAGMA table_info(hosted_room_driver_tasks)")
+    )
+    if lease_columns != _LEASE_COLUMNS or task_columns != _TASK_COLUMNS:
+        raise DriverStateError(
+            "unsupported unpublished hosted-room driver schema; "
+            "recreate the driver tables before starting the driver"
+        )
+
+    for table in ("hosted_room_driver_leases", "hosted_room_driver_tasks"):
+        foreign_keys = conn.execute(f"PRAGMA foreign_key_list({table})").fetchall()
+        if not any(
+            row[2] == "hosted_rooms" and row[3] == "room_id" and row[4] == "room_id"
+            for row in foreign_keys
+        ):
+            raise DriverStateError(f"{table} is missing its hosted_rooms foreign key")
+
+
+def _schema_objects_exist(conn: sqlite3.Connection) -> bool:
+    rows = conn.execute(
+        """SELECT name FROM sqlite_master
+           WHERE type='table' AND name IN (
+               'hosted_room_driver_leases', 'hosted_room_driver_tasks'
+           )"""
+    ).fetchall()
+    tables = {row[0] for row in rows}
+    if tables != {"hosted_room_driver_leases", "hosted_room_driver_tasks"}:
+        return False
+    index = conn.execute(
+        """SELECT 1 FROM sqlite_master
+           WHERE type='index' AND name='idx_hosted_room_driver_tasks_status'"""
+    ).fetchone()
+    return index is not None
+
+
+def _task_schema_supports_stopping(conn: sqlite3.Connection) -> bool:
+    row = conn.execute(
+        """SELECT sql FROM sqlite_master
+           WHERE type='table' AND name='hosted_room_driver_tasks'"""
+    ).fetchone()
+    return bool(row and "'stopping'" in str(row[0] or "").lower())
+
+
+def _migrate_task_status_constraint(conn: sqlite3.Connection) -> None:
+    """Expand the unpublished task-state CHECK without losing durable work."""
+    conn.execute("DROP INDEX IF EXISTS idx_hosted_room_driver_tasks_status")
+    _create_task_table(conn, "hosted_room_driver_tasks_next")
+    columns = ", ".join(_TASK_COLUMN_ORDER)
+    conn.execute(
+        f"""INSERT INTO hosted_room_driver_tasks_next ({columns})
+             SELECT {columns} FROM hosted_room_driver_tasks"""
+    )
+    conn.execute("DROP TABLE hosted_room_driver_tasks")
+    conn.execute(
+        "ALTER TABLE hosted_room_driver_tasks_next RENAME TO hosted_room_driver_tasks"
+    )
+    conn.execute(
+        """CREATE INDEX idx_hosted_room_driver_tasks_status
+           ON hosted_room_driver_tasks(
+               room_id, status, source_event_seq, created_at, task_id
+           )"""
+    )
+
+
+def _connect(db_path: Path | str) -> sqlite3.Connection:
+    from hermes_state import apply_wal_with_fallback
+
+    path = Path(db_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path, timeout=10)
+    conn.row_factory = sqlite3.Row
+    try:
+        apply_wal_with_fallback(conn, db_label="state.db (hosted_room_driver)")
+        conn.execute("PRAGMA foreign_keys=ON")
+        if _schema_objects_exist(conn):
+            if not _task_schema_supports_stopping(conn):
+                conn.execute("BEGIN IMMEDIATE")
+                _migrate_task_status_constraint(conn)
+                conn.commit()
+            _validate_schema(conn)
+            return conn
+        # Schema creation is one database-wide transaction. The driver schema
+        # has never shipped, so an incompatible draft schema fails closed
+        # instead of attempting a partial in-place migration.
+        conn.execute("BEGIN IMMEDIATE")
+        _initialize_schema(conn)
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        conn.close()
+        raise
+    return conn
+
+
+@contextmanager
+def _transaction(db_path: Path | str) -> Iterator[sqlite3.Connection]:
+    conn = _connect(db_path)
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        yield conn
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+
+def _lease_from_row(
+    row: sqlite3.Row | dict[str, Any], *, reclaimed: bool = False
+) -> DriverLease:
+    return DriverLease(
+        room_id=row["room_id"],
+        gateway_id=row["gateway_id"],
+        authority_epoch=int(row["authority_epoch"]),
+        process_generation=row["process_generation"],
+        lease_generation=int(row["lease_generation"]),
+        expires_at=float(row["expires_at"]),
+        reclaimed=reclaimed,
+    )
+
+
+def _task_identity_from_row(row: sqlite3.Row) -> TaskIdentity:
+    return TaskIdentity(
+        room_id=row["room_id"],
+        task_id=row["task_id"],
+        thread_id=row["thread_id"],
+        turn_id=row["turn_id"],
+    )
+
+
+def _task_from_row(row: sqlite3.Row, *, idempotent: bool = False) -> dict[str, Any]:
+    try:
+        raw_payload = json.loads(row["payload_json"])
+        payload, encoded_payload, payload_digest = _task_payload(raw_payload)
+    except (TypeError, json.JSONDecodeError, DriverValidationError) as exc:
+        raise TaskConflictError("stored task payload is invalid") from exc
+    if (
+        encoded_payload != row["payload_json"]
+        or payload_digest != row["payload_digest"]
+        or payload["source_event_seq"] != int(row["source_event_seq"])
+    ):
+        raise TaskConflictError("stored task payload failed its integrity check")
+    result = json.loads(row["result_json"]) if row["result_json"] is not None else None
+    return {
+        "identity": _task_identity_from_row(row),
+        "payload": payload,
+        "payload_digest": row["payload_digest"],
+        "status": row["status"],
+        "execution_generation": int(row["execution_generation"]),
+        "cancel_generation": int(row["cancel_generation"]),
+        "run_gateway_id": row["run_gateway_id"],
+        "run_process_generation": row["run_process_generation"],
+        "run_lease_generation": (
+            int(row["run_lease_generation"])
+            if row["run_lease_generation"] is not None
+            else None
+        ),
+        "cancel_id": row["cancel_id"],
+        "settlement_id": row["settlement_id"],
+        "settlement_status": row["settlement_status"],
+        "result": result,
+        "created_at": float(row["created_at"]),
+        "updated_at": float(row["updated_at"]),
+        "started_at": (
+            float(row["started_at"]) if row["started_at"] is not None else None
+        ),
+        "terminal_at": (
+            float(row["terminal_at"]) if row["terminal_at"] is not None else None
+        ),
+        "indeterminate_at": (
+            float(row["indeterminate_at"])
+            if row["indeterminate_at"] is not None
+            else None
+        ),
+        "idempotent": idempotent,
+    }
+
+
+def _load_task(conn: sqlite3.Connection, identity: TaskIdentity) -> sqlite3.Row:
+    row = conn.execute(
+        """SELECT * FROM hosted_room_driver_tasks
+           WHERE room_id=? AND task_id=?""",
+        (identity.room_id, identity.task_id),
+    ).fetchone()
+    if row is None:
+        raise TaskConflictError("task does not exist")
+    if _task_identity_from_row(row) != identity:
+        raise TaskConflictError("task_id is already bound to a different turn")
+    return row
+
+
+def _load_active_room(conn: sqlite3.Connection, room_id: str) -> sqlite3.Row:
+    try:
+        row = conn.execute(
+            """SELECT room_id, authority_gateway_id, authority_epoch, disbanded_at
+               FROM hosted_rooms WHERE room_id=?""",
+            (room_id,),
+        ).fetchone()
+    except sqlite3.OperationalError as exc:
+        if "no such table" in str(exc).lower():
+            raise RoomUnavailableError("hosted room does not exist") from exc
+        raise
+    if row is None:
+        raise RoomUnavailableError("hosted room does not exist")
+    if row["disbanded_at"] is not None:
+        raise RoomUnavailableError("hosted room is disbanded")
+    return row
+
+
+def _require_room_authority(
+    conn: sqlite3.Connection,
+    *,
+    room_id: str,
+    gateway_id: str,
+    authority_epoch: int,
+) -> sqlite3.Row:
+    room = _load_active_room(conn, room_id)
+    if (
+        room["authority_gateway_id"] != gateway_id
+        or int(room["authority_epoch"]) != authority_epoch
+    ):
+        raise StaleLeaseError("hosted room authority changed")
+    return room
+
+
+def _require_active_lease(
+    conn: sqlite3.Connection,
+    lease: DriverLease,
+    *,
+    now: float,
+) -> sqlite3.Row:
+    _require_room_authority(
+        conn,
+        room_id=lease.room_id,
+        gateway_id=lease.gateway_id,
+        authority_epoch=lease.authority_epoch,
+    )
+    row = conn.execute(
+        "SELECT * FROM hosted_room_driver_leases WHERE room_id=?",
+        (lease.room_id,),
+    ).fetchone()
+    if (
+        row is None
+        or row["gateway_id"] != lease.gateway_id
+        or int(row["authority_epoch"]) != lease.authority_epoch
+        or row["process_generation"] != lease.process_generation
+        or int(row["lease_generation"]) != lease.lease_generation
+        or row["released_at"] is not None
+        or float(row["expires_at"]) <= now
+    ):
+        raise StaleLeaseError("driver lease is stale or expired")
+    return row
+
+
+def acquire_lease(
+    db_path: Path | str,
+    *,
+    room_id: Any,
+    gateway_id: Any,
+    authority_epoch: Any,
+    process_generation: Any,
+    ttl_seconds: Any,
+    clock: Clock,
+) -> DriverLease:
+    """Acquire an empty or expired room lease with a monotonic generation."""
+    room_id = _identifier(room_id, label="room_id")
+    gateway_id = _identifier(gateway_id, label="gateway_id")
+    authority_epoch = _authority_epoch(authority_epoch)
+    process_generation = _identifier(
+        process_generation,
+        label="process_generation",
+    )
+    ttl_seconds = _ttl(ttl_seconds)
+    now = _timestamp(clock)
+    expires_at = _expiry(now, ttl_seconds)
+
+    with _transaction(db_path) as conn:
+        _require_room_authority(
+            conn,
+            room_id=room_id,
+            gateway_id=gateway_id,
+            authority_epoch=authority_epoch,
+        )
+        row = conn.execute(
+            "SELECT * FROM hosted_room_driver_leases WHERE room_id=?",
+            (room_id,),
+        ).fetchone()
+        if row is None:
+            conn.execute(
+                """INSERT INTO hosted_room_driver_leases (
+                       room_id, gateway_id, authority_epoch, process_generation,
+                       lease_generation, expires_at, acquired_at,
+                       updated_at, released_at
+                   ) VALUES (?, ?, ?, ?, 1, ?, ?, ?, NULL)""",
+                (
+                    room_id,
+                    gateway_id,
+                    authority_epoch,
+                    process_generation,
+                    expires_at,
+                    now,
+                    now,
+                ),
+            )
+            row = conn.execute(
+                "SELECT * FROM hosted_room_driver_leases WHERE room_id=?",
+                (room_id,),
+            ).fetchone()
+            return _lease_from_row(row)
+
+        if (
+            row["gateway_id"] == gateway_id
+            and int(row["authority_epoch"]) == authority_epoch
+            and row["process_generation"] == process_generation
+            and row["released_at"] is None
+            and float(row["expires_at"]) > now
+        ):
+            renewed_expiry = max(float(row["expires_at"]), expires_at)
+            conn.execute(
+                """UPDATE hosted_room_driver_leases
+                   SET expires_at=?, updated_at=?
+                   WHERE room_id=? AND lease_generation=?""",
+                (renewed_expiry, now, room_id, int(row["lease_generation"])),
+            )
+            current = dict(row)
+            current["expires_at"] = renewed_expiry
+            return _lease_from_row(current)
+
+        same_authority = (
+            row["gateway_id"] == gateway_id
+            and int(row["authority_epoch"]) == authority_epoch
+        )
+        if (
+            same_authority
+            and row["released_at"] is None
+            and float(row["expires_at"]) > now
+        ):
+            raise LeaseHeldError("room driver lease is held by another generation")
+
+        previous_generation = int(row["lease_generation"])
+        updated = conn.execute(
+            """UPDATE hosted_room_driver_leases
+               SET gateway_id=?, authority_epoch=?, process_generation=?,
+                   lease_generation=lease_generation + 1,
+                   expires_at=?, acquired_at=?, updated_at=?, released_at=NULL
+               WHERE room_id=? AND lease_generation=?
+                 AND (
+                     gateway_id != ? OR authority_epoch != ?
+                     OR released_at IS NOT NULL OR expires_at <= ?
+                 )""",
+            (
+                gateway_id,
+                authority_epoch,
+                process_generation,
+                expires_at,
+                now,
+                now,
+                room_id,
+                previous_generation,
+                gateway_id,
+                authority_epoch,
+                now,
+            ),
+        )
+        if updated.rowcount != 1:
+            raise LeaseHeldError("room driver lease changed during acquisition")
+        current = conn.execute(
+            "SELECT * FROM hosted_room_driver_leases WHERE room_id=?",
+            (room_id,),
+        ).fetchone()
+        return _lease_from_row(current, reclaimed=True)
+
+
+def renew_lease(
+    db_path: Path | str,
+    lease: DriverLease,
+    *,
+    ttl_seconds: Any,
+    clock: Clock,
+) -> DriverLease:
+    """Renew the exact active lease generation or fail closed."""
+    ttl_seconds = _ttl(ttl_seconds)
+    now = _timestamp(clock)
+    requested_expiry = _expiry(now, ttl_seconds)
+    with _transaction(db_path) as conn:
+        current = _require_active_lease(conn, lease, now=now)
+        expires_at = max(float(current["expires_at"]), requested_expiry)
+        updated = conn.execute(
+            """UPDATE hosted_room_driver_leases
+               SET expires_at=?, updated_at=?
+               WHERE room_id=? AND gateway_id=? AND process_generation=?
+                 AND lease_generation=? AND released_at IS NULL AND expires_at > ?""",
+            (
+                expires_at,
+                now,
+                lease.room_id,
+                lease.gateway_id,
+                lease.process_generation,
+                lease.lease_generation,
+                now,
+            ),
+        )
+        if updated.rowcount != 1:
+            raise StaleLeaseError("driver lease changed during renewal")
+        return DriverLease(
+            room_id=lease.room_id,
+            gateway_id=lease.gateway_id,
+            authority_epoch=lease.authority_epoch,
+            process_generation=lease.process_generation,
+            lease_generation=lease.lease_generation,
+            expires_at=expires_at,
+        )
+
+
+def release_lease(
+    db_path: Path | str,
+    lease: DriverLease,
+    *,
+    clock: Clock,
+) -> dict[str, Any]:
+    """Release the exact active lease generation idempotently."""
+    now = _timestamp(clock)
+    with _transaction(db_path) as conn:
+        _require_room_authority(
+            conn,
+            room_id=lease.room_id,
+            gateway_id=lease.gateway_id,
+            authority_epoch=lease.authority_epoch,
+        )
+        row = conn.execute(
+            "SELECT * FROM hosted_room_driver_leases WHERE room_id=?",
+            (lease.room_id,),
+        ).fetchone()
+        if (
+            row is None
+            or row["gateway_id"] != lease.gateway_id
+            or int(row["authority_epoch"]) != lease.authority_epoch
+            or row["process_generation"] != lease.process_generation
+            or int(row["lease_generation"]) != lease.lease_generation
+        ):
+            raise StaleLeaseError("driver lease is stale")
+        if row["released_at"] is not None:
+            return {"lease": _lease_from_row(row), "idempotent": True}
+        if float(row["expires_at"]) <= now:
+            raise StaleLeaseError("driver lease expired before release")
+        running = conn.execute(
+            """SELECT 1 FROM hosted_room_driver_tasks
+               WHERE room_id=? AND status='running' LIMIT 1""",
+            (lease.room_id,),
+        ).fetchone()
+        if running is not None:
+            raise InvalidTaskTransitionError(
+                "cannot release a room lease while tasks are running"
+            )
+        conn.execute(
+            """UPDATE hosted_room_driver_leases
+               SET expires_at=?, updated_at=?, released_at=?
+               WHERE room_id=? AND lease_generation=?""",
+            (now, now, now, lease.room_id, lease.lease_generation),
+        )
+        current = dict(row)
+        current["expires_at"] = now
+        current["updated_at"] = now
+        current["released_at"] = now
+        return {"lease": _lease_from_row(current), "idempotent": False}
+
+
+def admit_task(
+    db_path: Path | str,
+    identity: TaskIdentity,
+    *,
+    payload: Any,
+    clock: Clock,
+) -> dict[str, Any]:
+    """Persist a queued task, or return the identical admission."""
+    normalized_payload, payload_json, payload_digest = _task_payload(payload)
+    now = _timestamp(clock)
+    with _transaction(db_path) as conn:
+        _load_active_room(conn, identity.room_id)
+        existing = conn.execute(
+            """SELECT * FROM hosted_room_driver_tasks
+               WHERE room_id=? AND task_id=?""",
+            (identity.room_id, identity.task_id),
+        ).fetchone()
+        if existing is not None:
+            if _task_identity_from_row(existing) != identity:
+                raise TaskConflictError("task_id is already bound to a different turn")
+            if (
+                existing["payload_digest"] != payload_digest
+                or existing["payload_json"] != payload_json
+            ):
+                raise TaskConflictError(
+                    "task_id is already bound to a different payload"
+                )
+            return _task_from_row(existing, idempotent=True)
+
+        turn = conn.execute(
+            """SELECT * FROM hosted_room_driver_tasks
+               WHERE room_id=? AND thread_id=? AND turn_id=?""",
+            (identity.room_id, identity.thread_id, identity.turn_id),
+        ).fetchone()
+        if turn is not None:
+            raise TaskConflictError("thread_id and turn_id are already bound to a task")
+
+        conn.execute(
+            """INSERT INTO hosted_room_driver_tasks (
+                   room_id, task_id, thread_id, turn_id,
+                   source_event_seq, payload_json, payload_digest, status,
+                   execution_generation, cancel_generation,
+                   created_at, updated_at
+               ) VALUES (?, ?, ?, ?, ?, ?, ?, 'queued', 0, 0, ?, ?)""",
+            (
+                identity.room_id,
+                identity.task_id,
+                identity.thread_id,
+                identity.turn_id,
+                normalized_payload["source_event_seq"],
+                payload_json,
+                payload_digest,
+                now,
+                now,
+            ),
+        )
+        row = _load_task(conn, identity)
+        return _task_from_row(row)
+
+
+def start_task(
+    db_path: Path | str,
+    identity: TaskIdentity,
+    lease: DriverLease,
+    *,
+    expected_cancel_generation: int,
+    clock: Clock,
+) -> TaskAttempt:
+    """Move one queued task to running under the current driver lease."""
+    if lease.room_id != identity.room_id:
+        raise DriverValidationError("lease and task belong to different rooms")
+    if (
+        not isinstance(expected_cancel_generation, int)
+        or expected_cancel_generation < 0
+    ):
+        raise DriverValidationError("expected_cancel_generation must be non-negative")
+    now = _timestamp(clock)
+    with _transaction(db_path) as conn:
+        _require_active_lease(conn, lease, now=now)
+        row = _load_task(conn, identity)
+        if int(row["cancel_generation"]) != expected_cancel_generation:
+            raise StaleTaskError("task cancellation generation changed")
+        if row["status"] != "queued":
+            raise InvalidTaskTransitionError(
+                f"cannot start task in state '{row['status']}'"
+            )
+        unresolved = conn.execute(
+            """SELECT task_id, status FROM hosted_room_driver_tasks
+               WHERE room_id=? AND status IN ('running', 'indeterminate', 'stopping')
+               ORDER BY source_event_seq, created_at, task_id LIMIT 1""",
+            (identity.room_id,),
+        ).fetchone()
+        if unresolved is not None:
+            raise InvalidTaskTransitionError(
+                "room recovery must resolve the prior task before starting new work"
+            )
+        next_queued = conn.execute(
+            """SELECT task_id FROM hosted_room_driver_tasks
+               WHERE room_id=? AND status='queued'
+               ORDER BY source_event_seq, created_at, task_id LIMIT 1""",
+            (identity.room_id,),
+        ).fetchone()
+        if next_queued is None or next_queued["task_id"] != identity.task_id:
+            raise InvalidTaskTransitionError(
+                "task is not next in the hosted room event order"
+            )
+        execution_generation = int(row["execution_generation"]) + 1
+        updated = conn.execute(
+            """UPDATE hosted_room_driver_tasks
+               SET status='running', execution_generation=?,
+                   run_gateway_id=?, run_process_generation=?,
+                   run_lease_generation=?, started_at=?, updated_at=?
+               WHERE room_id=? AND task_id=? AND status='queued'
+                 AND cancel_generation=?""",
+            (
+                execution_generation,
+                lease.gateway_id,
+                lease.process_generation,
+                lease.lease_generation,
+                now,
+                now,
+                identity.room_id,
+                identity.task_id,
+                expected_cancel_generation,
+            ),
+        )
+        if updated.rowcount != 1:
+            raise StaleTaskError("task changed during start")
+        return TaskAttempt(
+            identity=identity,
+            lease=lease,
+            execution_generation=execution_generation,
+            cancel_generation=expected_cancel_generation,
+        )
+
+
+def settle_task(
+    db_path: Path | str,
+    attempt: TaskAttempt,
+    *,
+    settlement_id: Any,
+    status: TerminalStatus,
+    result: Any,
+    clock: Clock,
+) -> dict[str, Any]:
+    """Commit one terminal result if every lease and task fence still matches."""
+    settlement_id = _identifier(settlement_id, label="settlement_id")
+    if status not in {"settled", "failed"}:
+        raise DriverValidationError("status must be 'settled' or 'failed'")
+    result_json = _canonical_json(result)
+    now = _timestamp(clock)
+
+    with _transaction(db_path) as conn:
+        row = _load_task(conn, attempt.identity)
+        if row["settlement_id"] is not None:
+            if (
+                row["settlement_id"] == settlement_id
+                and row["settlement_status"] == status
+                and row["result_json"] == result_json
+            ):
+                return _task_from_row(row, idempotent=True)
+            raise TaskConflictError("task already has a different terminal settlement")
+
+        _require_active_lease(conn, attempt.lease, now=now)
+        expected = (
+            row["status"] == "running"
+            and int(row["execution_generation"]) == attempt.execution_generation
+            and int(row["cancel_generation"]) == attempt.cancel_generation
+            and row["run_gateway_id"] == attempt.lease.gateway_id
+            and row["run_process_generation"] == attempt.lease.process_generation
+            and int(row["run_lease_generation"]) == attempt.lease.lease_generation
+        )
+        if not expected:
+            raise StaleTaskError("task attempt is stale or cancelled")
+
+        updated = conn.execute(
+            """UPDATE hosted_room_driver_tasks
+               SET status=?, settlement_id=?, settlement_status=?,
+                   result_json=?, terminal_at=?, updated_at=?
+               WHERE room_id=? AND task_id=? AND status='running'
+                 AND execution_generation=? AND cancel_generation=?
+                 AND run_gateway_id=? AND run_process_generation=?
+                 AND run_lease_generation=?""",
+            (
+                status,
+                settlement_id,
+                status,
+                result_json,
+                now,
+                now,
+                attempt.identity.room_id,
+                attempt.identity.task_id,
+                attempt.execution_generation,
+                attempt.cancel_generation,
+                attempt.lease.gateway_id,
+                attempt.lease.process_generation,
+                attempt.lease.lease_generation,
+            ),
+        )
+        if updated.rowcount != 1:
+            raise StaleTaskError("task changed during settlement")
+        return _task_from_row(_load_task(conn, attempt.identity))
+
+
+def settle_stopping_task(
+    db_path: Path | str,
+    identity: TaskIdentity,
+    lease: DriverLease,
+    *,
+    expected_execution_generation: int,
+    expected_cancel_generation: int,
+    settlement_id: Any,
+    status: TerminalStatus,
+    result: Any,
+    clock: Clock,
+) -> dict[str, Any]:
+    """Commit a completion that won the race with an unacknowledged Stop."""
+    settlement_id = _identifier(settlement_id, label="settlement_id")
+    if status not in {"settled", "failed"}:
+        raise DriverValidationError("status must be 'settled' or 'failed'")
+    if expected_execution_generation < 1 or expected_cancel_generation < 1:
+        raise DriverValidationError("stopping settlement generations are invalid")
+    result_json = _canonical_json(result)
+    now = _timestamp(clock)
+    with _transaction(db_path) as conn:
+        row = _load_task(conn, identity)
+        if row["settlement_id"] is not None:
+            if (
+                row["settlement_id"] == settlement_id
+                and row["settlement_status"] == status
+                and row["result_json"] == result_json
+            ):
+                return _task_from_row(row, idempotent=True)
+            raise TaskConflictError("task already has a different terminal settlement")
+        _require_active_lease(conn, lease, now=now)
+        updated = conn.execute(
+            """UPDATE hosted_room_driver_tasks
+               SET status=?, settlement_id=?, settlement_status=?,
+                   result_json=?, terminal_at=?, updated_at=?
+               WHERE room_id=? AND task_id=? AND status='stopping'
+                 AND execution_generation=? AND cancel_generation=?""",
+            (
+                status,
+                settlement_id,
+                status,
+                result_json,
+                now,
+                now,
+                identity.room_id,
+                identity.task_id,
+                expected_execution_generation,
+                expected_cancel_generation,
+            ),
+        )
+        if updated.rowcount != 1:
+            raise StaleTaskError("task completion lost the stop race")
+        return _task_from_row(_load_task(conn, identity))
+
+
+def resolve_indeterminate_task(
+    db_path: Path | str,
+    identity: TaskIdentity,
+    lease: DriverLease,
+    *,
+    expected_execution_generation: int,
+    expected_cancel_generation: int,
+    settlement_id: Any,
+    status: TerminalStatus,
+    result: Any,
+    clock: Clock,
+) -> dict[str, Any]:
+    """Commit a verified historical receipt under the current room lease."""
+    if lease.room_id != identity.room_id:
+        raise DriverValidationError("lease and task belong to different rooms")
+    if (
+        not isinstance(expected_execution_generation, int)
+        or expected_execution_generation < 1
+    ):
+        raise DriverValidationError(
+            "expected_execution_generation must be a positive integer"
+        )
+    if (
+        not isinstance(expected_cancel_generation, int)
+        or expected_cancel_generation < 0
+    ):
+        raise DriverValidationError("expected_cancel_generation must be non-negative")
+    settlement_id = _identifier(settlement_id, label="settlement_id")
+    if status not in {"settled", "failed"}:
+        raise DriverValidationError("status must be 'settled' or 'failed'")
+    result_json = _canonical_json(result)
+    now = _timestamp(clock)
+
+    with _transaction(db_path) as conn:
+        _require_active_lease(conn, lease, now=now)
+        row = _load_task(conn, identity)
+        if row["settlement_id"] is not None:
+            if (
+                row["settlement_id"] == settlement_id
+                and row["settlement_status"] == status
+                and row["result_json"] == result_json
+            ):
+                return _task_from_row(row, idempotent=True)
+            raise TaskConflictError("task already has a different terminal settlement")
+        if (
+            row["status"] != "indeterminate"
+            or int(row["execution_generation"]) != expected_execution_generation
+            or int(row["cancel_generation"]) != expected_cancel_generation
+        ):
+            raise StaleTaskError("indeterminate task generation changed")
+        updated = conn.execute(
+            """UPDATE hosted_room_driver_tasks
+               SET status=?, settlement_id=?, settlement_status=?,
+                   result_json=?, terminal_at=?, updated_at=?
+               WHERE room_id=? AND task_id=? AND status='indeterminate'
+                 AND execution_generation=? AND cancel_generation=?""",
+            (
+                status,
+                settlement_id,
+                status,
+                result_json,
+                now,
+                now,
+                identity.room_id,
+                identity.task_id,
+                expected_execution_generation,
+                expected_cancel_generation,
+            ),
+        )
+        if updated.rowcount != 1:
+            raise StaleTaskError("indeterminate task changed during reconciliation")
+        return _task_from_row(_load_task(conn, identity))
+
+
+def requeue_indeterminate_task(
+    db_path: Path | str,
+    identity: TaskIdentity,
+    lease: DriverLease,
+    *,
+    expected_execution_generation: int,
+    expected_cancel_generation: int,
+    clock: Clock,
+) -> dict[str, Any]:
+    """Explicitly retry uncertain work after an operator accepts at-least-once risk."""
+    if lease.room_id != identity.room_id:
+        raise DriverValidationError("lease and task belong to different rooms")
+    if (
+        not isinstance(expected_execution_generation, int)
+        or expected_execution_generation < 1
+    ):
+        raise DriverValidationError(
+            "expected_execution_generation must be a positive integer"
+        )
+    if (
+        not isinstance(expected_cancel_generation, int)
+        or expected_cancel_generation < 0
+    ):
+        raise DriverValidationError("expected_cancel_generation must be non-negative")
+    now = _timestamp(clock)
+    with _transaction(db_path) as conn:
+        _require_active_lease(conn, lease, now=now)
+        row = _load_task(conn, identity)
+        if (
+            row["status"] != "indeterminate"
+            or int(row["execution_generation"]) != expected_execution_generation
+            or int(row["cancel_generation"]) != expected_cancel_generation
+        ):
+            raise StaleTaskError("indeterminate task generation changed")
+        updated = conn.execute(
+            """UPDATE hosted_room_driver_tasks
+               SET status='queued', run_gateway_id=NULL,
+                   run_process_generation=NULL, run_lease_generation=NULL,
+                   started_at=NULL, indeterminate_at=NULL, updated_at=?
+               WHERE room_id=? AND task_id=? AND status='indeterminate'
+                 AND execution_generation=? AND cancel_generation=?""",
+            (
+                now,
+                identity.room_id,
+                identity.task_id,
+                expected_execution_generation,
+                expected_cancel_generation,
+            ),
+        )
+        if updated.rowcount != 1:
+            raise StaleTaskError("indeterminate task changed during requeue")
+        return _task_from_row(_load_task(conn, identity))
+
+
+def cancel_task(
+    db_path: Path | str,
+    identity: TaskIdentity,
+    *,
+    cancel_id: Any,
+    expected_cancel_generation: int,
+    clock: Clock,
+) -> dict[str, Any]:
+    """Cancel a queued task before any external work was admitted."""
+    cancel_id = _identifier(cancel_id, label="cancel_id")
+    if (
+        not isinstance(expected_cancel_generation, int)
+        or expected_cancel_generation < 0
+    ):
+        raise DriverValidationError("expected_cancel_generation must be non-negative")
+    now = _timestamp(clock)
+    with _transaction(db_path) as conn:
+        row = _load_task(conn, identity)
+        if row["status"] == "cancelled" and row["cancel_id"] == cancel_id:
+            return _task_from_row(row, idempotent=True)
+        if row["status"] in TERMINAL_STATUSES:
+            raise InvalidTaskTransitionError(
+                f"cannot cancel task in state '{row['status']}'"
+            )
+        if row["status"] != "queued":
+            raise InvalidTaskTransitionError(
+                "running work requires acknowledged two-phase cancellation"
+            )
+        if int(row["cancel_generation"]) != expected_cancel_generation:
+            raise StaleTaskError("task cancellation generation changed")
+
+        next_generation = expected_cancel_generation + 1
+        updated = conn.execute(
+            """UPDATE hosted_room_driver_tasks
+               SET status='cancelled', cancel_generation=?, cancel_id=?,
+                   terminal_at=?, updated_at=?
+               WHERE room_id=? AND task_id=?
+                 AND status='queued'
+                 AND cancel_generation=?""",
+            (
+                next_generation,
+                cancel_id,
+                now,
+                now,
+                identity.room_id,
+                identity.task_id,
+                expected_cancel_generation,
+            ),
+        )
+        if updated.rowcount != 1:
+            raise StaleTaskError("task changed during cancellation")
+        return _task_from_row(_load_task(conn, identity))
+
+
+def begin_task_cancel(
+    db_path: Path | str,
+    identity: TaskIdentity,
+    *,
+    cancel_id: Any,
+    expected_cancel_generation: int,
+    clock: Clock,
+) -> dict[str, Any]:
+    """Persist a stop intent without claiming the remote run has stopped."""
+    cancel_id = _identifier(cancel_id, label="cancel_id")
+    if (
+        not isinstance(expected_cancel_generation, int)
+        or expected_cancel_generation < 0
+    ):
+        raise DriverValidationError("expected_cancel_generation must be non-negative")
+    now = _timestamp(clock)
+    with _transaction(db_path) as conn:
+        row = _load_task(conn, identity)
+        if row["status"] == "stopping" and row["cancel_id"] == cancel_id:
+            return _task_from_row(row, idempotent=True)
+        if row["status"] in TERMINAL_STATUSES or row["status"] == "queued":
+            raise InvalidTaskTransitionError(
+                f"cannot request remote stop in state '{row['status']}'"
+            )
+        if int(row["cancel_generation"]) != expected_cancel_generation:
+            raise StaleTaskError("task cancellation generation changed")
+        updated = conn.execute(
+            """UPDATE hosted_room_driver_tasks
+               SET status='stopping', cancel_generation=?, cancel_id=?,
+                   updated_at=?
+               WHERE room_id=? AND task_id=?
+                 AND status IN ('running', 'indeterminate')
+                 AND cancel_generation=?""",
+            (
+                expected_cancel_generation + 1,
+                cancel_id,
+                now,
+                identity.room_id,
+                identity.task_id,
+                expected_cancel_generation,
+            ),
+        )
+        if updated.rowcount != 1:
+            raise StaleTaskError("task changed during stop request")
+        return _task_from_row(_load_task(conn, identity))
+
+
+def complete_task_cancel(
+    db_path: Path | str,
+    identity: TaskIdentity,
+    *,
+    cancel_id: Any,
+    expected_cancel_generation: int,
+    clock: Clock,
+) -> dict[str, Any]:
+    """Commit cancellation only after the transport acknowledges exact Stop."""
+    cancel_id = _identifier(cancel_id, label="cancel_id")
+    now = _timestamp(clock)
+    with _transaction(db_path) as conn:
+        row = _load_task(conn, identity)
+        if row["status"] == "cancelled" and row["cancel_id"] == cancel_id:
+            return _task_from_row(row, idempotent=True)
+        if (
+            row["status"] != "stopping"
+            or row["cancel_id"] != cancel_id
+            or int(row["cancel_generation"]) != expected_cancel_generation
+        ):
+            raise StaleTaskError("task stop acknowledgement is stale")
+        updated = conn.execute(
+            """UPDATE hosted_room_driver_tasks
+               SET status='cancelled', terminal_at=?, updated_at=?
+               WHERE room_id=? AND task_id=? AND status='stopping'
+                 AND cancel_id=? AND cancel_generation=?""",
+            (
+                now,
+                now,
+                identity.room_id,
+                identity.task_id,
+                cancel_id,
+                expected_cancel_generation,
+            ),
+        )
+        if updated.rowcount != 1:
+            raise StaleTaskError("task changed during stop acknowledgement")
+        return _task_from_row(_load_task(conn, identity))
+
+
+def recover_room(
+    db_path: Path | str,
+    lease: DriverLease,
+    *,
+    clock: Clock,
+) -> dict[str, list[TaskIdentity]]:
+    """Fence abandoned running attempts without requeueing uncertain work."""
+    now = _timestamp(clock)
+    with _transaction(db_path) as conn:
+        _require_active_lease(conn, lease, now=now)
+        stale_rows = conn.execute(
+            """SELECT * FROM hosted_room_driver_tasks
+               WHERE room_id=? AND status='running'
+                 AND NOT (
+                     run_gateway_id=? AND run_process_generation=?
+                     AND run_lease_generation=?
+                 )
+               ORDER BY source_event_seq, created_at, task_id""",
+            (
+                lease.room_id,
+                lease.gateway_id,
+                lease.process_generation,
+                lease.lease_generation,
+            ),
+        ).fetchall()
+        if stale_rows:
+            conn.execute(
+                """UPDATE hosted_room_driver_tasks
+                   SET status='indeterminate', indeterminate_at=?, updated_at=?
+                   WHERE room_id=? AND status='running'
+                     AND NOT (
+                         run_gateway_id=? AND run_process_generation=?
+                         AND run_lease_generation=?
+                     )""",
+                (
+                    now,
+                    now,
+                    lease.room_id,
+                    lease.gateway_id,
+                    lease.process_generation,
+                    lease.lease_generation,
+                ),
+            )
+        queued_rows = conn.execute(
+            """SELECT * FROM hosted_room_driver_tasks
+               WHERE room_id=? AND status='queued'
+               ORDER BY source_event_seq, created_at, task_id""",
+            (lease.room_id,),
+        ).fetchall()
+        indeterminate_rows = conn.execute(
+            """SELECT * FROM hosted_room_driver_tasks
+               WHERE room_id=? AND status='indeterminate'
+               ORDER BY source_event_seq, created_at, task_id""",
+            (lease.room_id,),
+        ).fetchall()
+        return {
+            "queued": [_task_identity_from_row(row) for row in queued_rows],
+            "indeterminate": [
+                _task_identity_from_row(row) for row in indeterminate_rows
+            ],
+        }
+
+
+def get_task(
+    db_path: Path | str,
+    identity: TaskIdentity,
+) -> dict[str, Any]:
+    """Read one task without mutating its state."""
+    conn = _connect(db_path)
+    try:
+        return _task_from_row(_load_task(conn, identity))
+    finally:
+        conn.close()
+
+
+def list_tasks(
+    db_path: Path | str,
+    *,
+    room_id: Any,
+    status: TaskStatus | None = None,
+) -> list[dict[str, Any]]:
+    """Return room tasks in deterministic admission order."""
+    room_id = _identifier(room_id, label="room_id")
+    if status is not None and status not in TASK_STATUSES:
+        raise DriverValidationError("invalid task status")
+    conn = _connect(db_path)
+    try:
+        if status is None:
+            rows = conn.execute(
+                """SELECT * FROM hosted_room_driver_tasks
+                   WHERE room_id=?
+                   ORDER BY source_event_seq, created_at, task_id""",
+                (room_id,),
+            ).fetchall()
+        else:
+            rows = conn.execute(
+                """SELECT * FROM hosted_room_driver_tasks
+                   WHERE room_id=? AND status=?
+                   ORDER BY source_event_seq, created_at, task_id""",
+                (room_id, status),
+            ).fetchall()
+        return [_task_from_row(row) for row in rows]
+    finally:
+        conn.close()

--- a/gateway/hosted_room_driver.py
+++ b/gateway/hosted_room_driver.py
@@ -46,7 +46,12 @@ TASK_STATUSES = frozenset({
 TERMINAL_STATUSES = frozenset({"settled", "failed", "cancelled"})
 
 _IDENTIFIER_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]*$")
-_TASK_PAYLOAD_FIELDS = frozenset({"target_profile", "prompt", "source_event_seq"})
+_TASK_PAYLOAD_REQUIRED_FIELDS = frozenset({
+    "target_profile",
+    "prompt",
+    "source_event_seq",
+})
+_TASK_PAYLOAD_OPTIONAL_FIELDS = frozenset({"attachments"})
 _LEASE_COLUMNS = frozenset({
     "room_id",
     "gateway_id",
@@ -208,8 +213,8 @@ def _authority_epoch(value: Any) -> int:
 def _task_payload(value: Any) -> tuple[dict[str, Any], str, str]:
     if not isinstance(value, dict):
         raise DriverValidationError("payload must be an object")
-    unknown = set(value) - _TASK_PAYLOAD_FIELDS
-    missing = _TASK_PAYLOAD_FIELDS - set(value)
+    unknown = set(value) - _TASK_PAYLOAD_REQUIRED_FIELDS - _TASK_PAYLOAD_OPTIONAL_FIELDS
+    missing = _TASK_PAYLOAD_REQUIRED_FIELDS - set(value)
     if unknown:
         raise DriverValidationError(
             f"unknown payload fields: {', '.join(sorted(unknown))}"
@@ -240,6 +245,13 @@ def _task_payload(value: Any) -> tuple[dict[str, Any], str, str]:
         "prompt": prompt,
         "source_event_seq": source_event_seq,
     }
+    if "attachments" in value:
+        from gateway.hosted_room_attachments import validate_task_manifest
+
+        attachments = validate_task_manifest(value["attachments"])
+        if not attachments:
+            raise DriverValidationError("attachments must not be empty when present")
+        normalized["attachments"] = attachments
     encoded = json.dumps(
         normalized,
         ensure_ascii=True,

--- a/gateway/hosted_room_messaging.py
+++ b/gateway/hosted_room_messaging.py
@@ -8,9 +8,13 @@ one behavior contract.
 
 from __future__ import annotations
 
+import errno
 import hashlib
+import os
 import re
 import sqlite3
+import stat
+import tempfile
 import time
 from collections.abc import Mapping
 from dataclasses import dataclass
@@ -20,11 +24,20 @@ from typing import Any
 from gateway import hosted_room_discussion as discussion
 from gateway import hosted_room_driver as driver
 from gateway import hosted_rooms
+from gateway.hosted_room_attachments import (
+    AttachmentError,
+    CLASSIC_ATTACHMENT_TTL_SECONDS,
+    HostedRoomAttachmentStore,
+    MAX_ATTACHMENT_BYTES,
+    MAX_ATTACHMENTS_PER_MESSAGE,
+    MAX_MESSAGE_ATTACHMENT_BYTES,
+)
 
 
 MAX_ROOM_CHOICES = 8
 MAX_RECENT_MESSAGES = 5
 MAX_PREVIEW_CHARS = 180
+MAX_GROUP_MEMBERS = 6
 GROUP_CHAT_SYNC_META_KEY = "hermes-bots-groups"
 
 
@@ -229,6 +242,10 @@ class RoomControlError(ValueError):
     """A user-actionable hosted-room command error."""
 
 
+class _LocalizedMediaUnavailable(RoomControlError):
+    """A trusted localized media reference disappeared before durable ingest."""
+
+
 @dataclass(frozen=True)
 class RoomCommand:
     """Parsed mutating ``/group`` subcommand."""
@@ -244,6 +261,11 @@ class MessagingRoomBackend:
     def __init__(self, *, db_path: Any, service: Any = None) -> None:
         self.db_path = db_path
         self.service = service
+        self.attachments = (
+            service.attachments
+            if service is not None and hasattr(service, "attachments")
+            else HostedRoomAttachmentStore(db_path)
+        )
 
     def status(self, room_id: str) -> dict[str, Any]:
         if self.service is not None:
@@ -274,14 +296,61 @@ class MessagingRoomBackend:
                 payload=payload,
                 actor=actor,
             )
-        normalized = discussion.validate_user_payload(payload)
-        return hosted_rooms.append_event(
+        room = hosted_rooms.room_state(self.db_path, room_id=room_id)
+        member_ids = tuple(
+            str(member.get("member_id") or "") for member in room["members"]
+        )
+        normalized = discussion.validate_user_payload(
+            payload,
+            member_ids=member_ids,
+        )
+        if normalized.get("attachments"):
+            normalized["attachments"] = self.attachments.commit_message(
+                room_id=room_id,
+                event_id=event_id,
+                manifest=normalized["attachments"],
+                recipient_member_ids=(*member_ids, "viewer"),
+                hold_until_event=True,
+            )
+        event = hosted_rooms.append_event(
             self.db_path,
             room_id=room_id,
             event_id=event_id,
             kind="message.user",
             actor=dict(actor),
             payload=normalized,
+        )
+        if normalized.get("attachments"):
+            self.attachments.retain_event(room_id=room_id, event_id=event_id)
+        return event
+
+    def put_attachment(
+        self,
+        *,
+        room_id: str,
+        upload_id: str,
+        kind: str,
+        name: str,
+        mime: str,
+        data: bytes,
+    ) -> dict[str, Any]:
+        if self.service is not None:
+            return self.service.put_attachment(
+                room_id=room_id,
+                upload_id=upload_id,
+                kind=kind,
+                name=name,
+                mime=mime,
+                data=data,
+            )
+        hosted_rooms.room_state(self.db_path, room_id=room_id)
+        return self.attachments.put(
+            room_id=room_id,
+            upload_id=upload_id,
+            kind=kind,
+            name=name,
+            mime=mime,
+            data=data,
         )
 
     def stop_room(self, room_id: str, *, cancel_id: str) -> int:
@@ -385,10 +454,6 @@ def parse_room_command(args: str, *, command_root: str = "/group") -> RoomComman
         message = remainder.removeprefix("--").strip()
         if len(message) >= 2 and message[0] == message[-1] and message[0] in {'"', "'"}:
             message = message[1:-1].strip()
-        if not message:
-            raise RoomControlError(
-                f"Use `{command_root} <number> send <message>`."
-            )
         return RoomCommand("send", room_query, message)
     if action == "stop":
         if remainder:
@@ -553,6 +618,22 @@ def _event_label(event: Mapping[str, Any], member_names: Mapping[str, str]) -> s
     return "You"
 
 
+def _activity_text(text: Any, attachments: Any) -> str:
+    message = _clean_line(text)
+    names = [
+        _clean_line(item.get("name"), limit=48)
+        for item in attachments
+        if isinstance(item, Mapping) and _clean_line(item.get("name"), limit=48)
+    ] if isinstance(attachments, list) else []
+    if not names:
+        return message
+    visible = names[:3]
+    files = ", ".join(visible)
+    if len(names) > len(visible):
+        files += f", and {len(names) - len(visible)} more"
+    return f"{message} [Files: {files}]" if message else f"Shared {files}"
+
+
 def format_room_detail(
     service: Any,
     room: Mapping[str, Any],
@@ -613,14 +694,12 @@ def format_room_detail(
             if desktop_mode:
                 source = event.get("from") if isinstance(event.get("from"), Mapping) else {}
                 label = _clean_line(source.get("name") or "You", limit=48)
-                text = event.get("text")
+                text = _activity_text(event.get("text"), event.get("images"))
             else:
                 payload = event.get("payload") if isinstance(event.get("payload"), Mapping) else {}
                 label = _event_label(event, member_names)
-                text = payload.get("text")
-            lines.append(
-                f"• {label}: {_clean_line(text)}"
-            )
+                text = _activity_text(payload.get("text"), payload.get("attachments"))
+            lines.append(f"• {label}: {text}")
     else:
         lines.append("No messages yet.")
     command = room.get("desktop_command")
@@ -757,13 +836,185 @@ def messaging_event_id(event: Any) -> str:
     return f"messaging:{hashlib.sha256(material.encode()).hexdigest()}"
 
 
-def ensure_text_only(event: Any) -> None:
-    """Reject media explicitly until hosted-room attachment transport exists."""
+def _localized_media_roots(service: Any) -> tuple[Path, ...]:
+    """Return the bounded cache roots authorized inbound adapters localize into."""
 
-    if getattr(event, "media_urls", None) or getattr(event, "media_types", None):
+    db_root = Path(service.db_path).parent
+    roots = [Path(tempfile.gettempdir()), db_root / "cache"]
+    profiles = db_root / "profiles"
+    if profiles.is_dir():
+        roots.extend(path / "cache" for path in profiles.iterdir() if path.is_dir())
+    for key in (
+        "IMAGE_CACHE_DIR",
+        "VIDEO_CACHE_DIR",
+        "AUDIO_CACHE_DIR",
+        "DOCUMENT_CACHE_DIR",
+    ):
+        value = os.getenv(key, "").strip()
+        if value:
+            roots.append(Path(value).expanduser())
+    return tuple(roots)
+
+
+def _read_localized_media(service: Any, raw_path: Any) -> tuple[str, bytes]:
+    """Read one regular, non-symlinked adapter-localized file under a cache root."""
+
+    if not isinstance(raw_path, str) or not raw_path.strip():
+        raise RoomControlError("Attachment media path is missing.")
+    raw_path = raw_path.strip()
+    if "://" in raw_path or raw_path.lower().startswith(("data:", "file:")):
+        raise RoomControlError("Remote or encoded attachment URLs are not trusted.")
+    path = Path(raw_path)
+    if not path.is_absolute() or ".." in path.parts:
+        raise RoomControlError("Attachment media path is not a safe localized path.")
+
+    selected: tuple[Path, tuple[str, ...]] | None = None
+    for root in _localized_media_roots(service):
+        try:
+            relative = path.relative_to(root)
+        except ValueError:
+            continue
+        selected = (root, relative.parts)
+        break
+    if selected is None:
+        raise RoomControlError("Attachment is outside the authenticated media cache.")
+
+    current = selected[0]
+    try:
+        for part in selected[1]:
+            current = current / part
+            if stat.S_ISLNK(current.lstat().st_mode):
+                raise RoomControlError("Symlinked attachments are not trusted.")
+    except FileNotFoundError as exc:
+        raise _LocalizedMediaUnavailable(
+            "Localized attachment is no longer available."
+        ) from exc
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(path, flags)
+    except OSError as exc:
+        if exc.errno == errno.ELOOP:
+            raise RoomControlError("Symlinked attachments are not trusted.") from exc
+        raise _LocalizedMediaUnavailable(
+            "Localized attachment could not be opened safely."
+        ) from exc
+    try:
+        info = os.fstat(descriptor)
+        if not stat.S_ISREG(info.st_mode):
+            raise RoomControlError("Localized attachment is not a regular file.")
+        if info.st_size <= 0 or info.st_size > MAX_ATTACHMENT_BYTES:
+            raise RoomControlError("Attachment exceeds the 15MB per-file limit.")
+        with os.fdopen(descriptor, "rb", closefd=False) as handle:
+            data = handle.read(MAX_ATTACHMENT_BYTES + 1)
+    finally:
+        os.close(descriptor)
+    if len(data) != info.st_size or len(data) > MAX_ATTACHMENT_BYTES:
+        raise RoomControlError("Attachment changed while it was being ingested.")
+    return path.name, data
+
+
+def _ingest_event_attachments(
+    service: Any,
+    room: Mapping[str, Any],
+    event: Any,
+    *,
+    event_id: str,
+) -> list[dict[str, Any]]:
+    """Persist authenticated local media once and return a metadata-only manifest."""
+
+    urls = list(getattr(event, "media_urls", None) or [])
+    media_types = list(getattr(event, "media_types", None) or [])
+    if not urls and not media_types:
+        return []
+    if len(urls) != len(media_types):
+        raise RoomControlError("Attachment MIME metadata is incomplete or misaligned.")
+    if len(urls) > MAX_ATTACHMENTS_PER_MESSAGE:
         raise RoomControlError(
-            "Attachments from messaging chats aren’t supported yet. Send text only."
+            f"A Group Chat message supports at most {MAX_ATTACHMENTS_PER_MESSAGE} attachments."
         )
+
+    room_id = str(room["room_id"])
+    classic = room.get("_room_mode") == "desktop"
+    store = HostedRoomAttachmentStore(hosted_rooms.default_db_path()) if classic else None
+    canonical_store = store or getattr(service, "attachments", None)
+    manifest = []
+    total = 0
+    for index, (raw_path, raw_mime) in enumerate(zip(urls, media_types)):
+        upload_id = f"{event_id}:media:{index}"
+        mime = str(raw_mime or "").strip().lower()
+        kind = "image" if mime.startswith("image/") else "pdf" if mime == "application/pdf" else "file"
+        try:
+            existing = (
+                canonical_store.find_upload(room_id=room_id, upload_id=upload_id)
+                if canonical_store is not None
+                else None
+            )
+        except AttachmentError as exc:
+            raise RoomControlError(str(exc)) from exc
+        try:
+            name, data = _read_localized_media(service, raw_path)
+        except _LocalizedMediaUnavailable:
+            if existing is None:
+                raise
+            attachment = existing
+        else:
+            if existing is not None:
+                if (
+                    existing["kind"] != kind
+                    or existing["mime"] != mime
+                    or existing["size"] != len(data)
+                    or existing["sha256"] != hashlib.sha256(data).hexdigest()
+                ):
+                    raise RoomControlError(
+                        "Message redelivery changed previously ingested attachment content."
+                    )
+                attachment = existing
+            else:
+                try:
+                    attachment = (
+                        store.put(
+                            room_id=room_id,
+                            upload_id=upload_id,
+                            kind=kind,
+                            name=name,
+                            mime=mime,
+                            data=data,
+                        )
+                        if store is not None
+                        else service.put_attachment(
+                            room_id=room_id,
+                            upload_id=upload_id,
+                            kind=kind,
+                            name=name,
+                            mime=mime,
+                            data=data,
+                        )
+                    )
+                except AttachmentError as exc:
+                    raise RoomControlError(str(exc)) from exc
+        if attachment["kind"] != kind or attachment["mime"] != mime:
+            raise RoomControlError(
+                "Message redelivery changed previously ingested attachment metadata."
+            )
+        total += int(attachment["size"])
+        if total > MAX_MESSAGE_ATTACHMENT_BYTES:
+            raise RoomControlError("Attachments exceed the 25MB per-message total limit.")
+        manifest.append({
+            "attachment_id": attachment["attachment_id"],
+            "kind": attachment["kind"],
+            "name": attachment["name"],
+            "size": attachment["size"],
+            "mime": attachment["mime"],
+        })
+    if store is not None:
+        manifest = store.commit_message(
+            room_id=room_id,
+            event_id=event_id,
+            manifest=manifest,
+            recipient_member_ids=("desktop", "viewer"),
+            retention_seconds=CLASSIC_ATTACHMENT_TTL_SECONDS,
+        )
+    return manifest
 
 
 def is_machine_authored(event: Any) -> bool:
@@ -813,11 +1064,54 @@ def _desktop_authority_hash(room: Mapping[str, Any]) -> str:
     return authority_hash
 
 
+def _desktop_recipients(room: Mapping[str, Any]) -> list[dict[str, Any]]:
+    """Freeze the projected Bot owners when a messaging command is admitted."""
+
+    recipients: list[dict[str, Any]] = []
+    for raw in list(room.get("members") or [])[:MAX_GROUP_MEMBERS]:
+        if not isinstance(raw, Mapping):
+            continue
+        name = _clean_line(raw.get("name"), limit=128)
+        if not name:
+            continue
+        recipient: dict[str, Any] = {"name": name}
+        for key, limit in (
+            ("handle", 128),
+            ("connectionId", 128),
+            ("connectionKind", 64),
+            ("connectionLabel", 128),
+        ):
+            value = _clean_line(raw.get(key), limit=limit)
+            if value:
+                recipient[key] = value
+        if raw.get("sourceScoped") is True:
+            recipient["sourceScoped"] = True
+        recipients.append(recipient)
+    if not recipients:
+        raise RoomControlError(
+            "This Group Chat has no reachable Bot roster yet. Open it in Hermes Desktop and retry."
+        )
+    return recipients
+
+
 def send_to_room(service: Any, room: Mapping[str, Any], event: Any, text: str) -> str:
     """Append or hand off one idempotent room turn."""
 
-    ensure_text_only(event)
     event_id = messaging_event_id(event)
+    desktop_authority_hash = (
+        _desktop_authority_hash(room)
+        if room.get("_room_mode") == "desktop"
+        else None
+    )
+    attachments = _ingest_event_attachments(
+        service,
+        room,
+        event,
+        event_id=event_id,
+    )
+    text = str(text or "").strip()
+    if not text and not attachments:
+        raise RoomControlError("Send a message, an attachment, or both.")
     name = _clean_line(room.get("name") or room.get("room_id"), limit=72)
     if room.get("_room_mode") == "desktop":
         from gateway.desktop_room_mailbox import enqueue_command, default_db_path
@@ -830,11 +1124,13 @@ def send_to_room(service: Any, room: Mapping[str, Any], event: Any, text: str) -
             default_db_path(),
             command_id=event_id,
             room_id=str(room["room_id"]),
-            authority_hash=_desktop_authority_hash(room),
+            authority_hash=desktop_authority_hash,
             action="send",
             payload={
                 "message": text,
                 "actor_display_name": actor.get("display_name") or "Messaging",
+                "recipients": _desktop_recipients(room),
+                **({"attachments": attachments} if attachments else {}),
             },
         )
         if room.get("desktop_available"):
@@ -843,7 +1139,11 @@ def send_to_room(service: Any, room: Mapping[str, Any], event: Any, text: str) -
     service.send(
         room_id=str(room["room_id"]),
         event_id=event_id,
-        payload={"text": text, "thread_id": event_id},
+        payload={
+            "text": text,
+            "thread_id": event_id,
+            **({"attachments": attachments} if attachments else {}),
+        },
         actor=messaging_actor(
             event,
             gateway_id=str(room["authority_gateway_id"]),

--- a/gateway/hosted_room_messaging.py
+++ b/gateway/hosted_room_messaging.py
@@ -68,8 +68,16 @@ def _projected_desktop_rooms() -> list[dict[str, Any]]:
             explicit_room_id
             or (str(key).strip() if snapshot_version >= 3 else f"name:{name}")
         )
-        if not name or not room_id:
+        if (
+            not name
+            or not room_id
+            or len(room_id) > 200
+            or any(char in room_id for char in ("\x00", "\r", "\n"))
+        ):
             continue
+        authority_hash = str(raw_room.get("desktopAuthorityHash") or "").strip().lower()
+        if not re.fullmatch(r"[a-f0-9]{64}", authority_hash):
+            authority_hash = ""
         raw_log = raw_room.get("log")
         log = [dict(item) for item in raw_log if isinstance(item, Mapping)] if isinstance(raw_log, list) else []
         raw_members = raw_room.get("members")
@@ -93,6 +101,7 @@ def _projected_desktop_rooms() -> list[dict[str, Any]]:
                     default=updated_at,
                 ),
                 "updated_at": updated_at,
+                "desktop_authority_hash": authority_hash,
                 "_room_mode": "desktop",
             }
         )
@@ -117,13 +126,28 @@ def list_messaging_rooms(service: Any) -> list[dict[str, Any]]:
         return []
 
     from gateway.desktop_room_mailbox import (
+        MAX_ROOM_IDS,
         available_room_ids,
         default_db_path,
         latest_command_states,
+        register_projected_authorities,
     )
 
     mailbox_db = default_db_path()
     desktop_ids = [room["room_id"] for room in desktop]
+    commitments = [
+        {
+            "room_id": room["room_id"],
+            "authority_hash": room["desktop_authority_hash"],
+        }
+        for room in desktop
+        if room.get("desktop_authority_hash")
+    ]
+    for index in range(0, len(commitments), MAX_ROOM_IDS):
+        register_projected_authorities(
+            mailbox_db,
+            commitments[index : index + MAX_ROOM_IDS],
+        )
     available = available_room_ids(mailbox_db, desktop_ids)
     command_states = latest_command_states(mailbox_db, desktop_ids)
     rooms = [
@@ -780,6 +804,15 @@ def relay_provenance_is_unknown(event: Any) -> bool:
     )
 
 
+def _desktop_authority_hash(room: Mapping[str, Any]) -> str:
+    authority_hash = str(room.get("desktop_authority_hash") or "").strip().lower()
+    if not re.fullmatch(r"[a-f0-9]{64}", authority_hash):
+        raise RoomControlError(
+            "Open this Group Chat once in the latest Hermes Desktop, then try again."
+        )
+    return authority_hash
+
+
 def send_to_room(service: Any, room: Mapping[str, Any], event: Any, text: str) -> str:
     """Append or hand off one idempotent room turn."""
 
@@ -797,6 +830,7 @@ def send_to_room(service: Any, room: Mapping[str, Any], event: Any, text: str) -
             default_db_path(),
             command_id=event_id,
             room_id=str(room["room_id"]),
+            authority_hash=_desktop_authority_hash(room),
             action="send",
             payload={
                 "message": text,
@@ -830,6 +864,7 @@ def stop_room(service: Any, room: Mapping[str, Any], event: Any) -> str:
             default_db_path(),
             command_id=cancel_id,
             room_id=str(room["room_id"]),
+            authority_hash=_desktop_authority_hash(room),
             action="stop",
             payload={},
         )

--- a/gateway/hosted_room_messaging.py
+++ b/gateway/hosted_room_messaging.py
@@ -97,7 +97,7 @@ class RoomControlError(ValueError):
 
 @dataclass(frozen=True)
 class RoomCommand:
-    """Parsed mutating ``/rooms`` subcommand."""
+    """Parsed mutating ``/group`` subcommand."""
 
     action: str
     room_query: str
@@ -228,33 +228,41 @@ def command_form(event: Any) -> str:
     source = getattr(event, "source", None)
     platform = getattr(getattr(source, "platform", None), "value", "")
     if platform == "slack":
-        return "/hermes rooms"
+        return "/hermes group"
     if platform == "matrix":
-        return "!rooms"
-    return "/rooms"
+        return "!group"
+    return "/group"
 
 
-def parse_room_command(args: str, *, command_root: str = "/rooms") -> RoomCommand:
-    """Parse ``send`` and ``stop`` without making room names quote-only."""
+def parse_room_command(args: str, *, command_root: str = "/group") -> RoomCommand:
+    """Parse the number-first send/stop grammar used by messaging clients."""
 
     raw = str(args or "").strip()
-    action, _, remainder = raw.partition(" ")
-    action = action.casefold()
-    remainder = remainder.strip()
+    entity_first = raw.split(maxsplit=2)
+    if len(entity_first) < 2 or not entity_first[0].isdecimal():
+        raise RoomControlError(
+            f"Use `{command_root} <number> send <message>` or "
+            f"`{command_root} <number> stop`."
+        )
+    room_query = entity_first[0]
+    action = entity_first[1].casefold()
+    remainder = entity_first[2].strip() if len(entity_first) == 3 else ""
     if action == "send":
-        room_query, delimiter, message = remainder.partition(" -- ")
-        if not delimiter or not room_query.strip() or not message.strip():
+        message = remainder.removeprefix("--").strip()
+        if len(message) >= 2 and message[0] == message[-1] and message[0] in {'"', "'"}:
+            message = message[1:-1].strip()
+        if not message:
             raise RoomControlError(
-                f"Use `{command_root} send <room number> -- <message>`."
+                f"Use `{command_root} <number> send <message>`."
             )
-        return RoomCommand("send", room_query.strip(), message.strip())
+        return RoomCommand("send", room_query, message)
     if action == "stop":
-        if not remainder:
-            raise RoomControlError(f"Use `{command_root} stop <room number>`.")
-        return RoomCommand("stop", remainder)
+        if remainder:
+            raise RoomControlError(f"Use `{command_root} <number> stop`.")
+        return RoomCommand("stop", room_query)
     raise RoomControlError(
-        f"Use `{command_root} send <room number> -- <message>` or "
-        f"`{command_root} stop <room number>`."
+        f"Use `{command_root} <number> send <message>` or "
+        f"`{command_root} <number> stop`."
     )
 
 
@@ -272,7 +280,7 @@ def resolve_room(rooms: list[dict[str, Any]], query: str) -> dict[str, Any]:
         ]
         if len(matches) == 1:
             return matches[0]
-        raise RoomControlError(f"No hosted Bot room is numbered {numeric_ref}.")
+        raise RoomControlError(f"No Group Chat is numbered {numeric_ref}.")
 
     if needle.startswith("id:"):
         internal_id = needle.removeprefix("id:")
@@ -283,7 +291,7 @@ def resolve_room(rooms: list[dict[str, Any]], query: str) -> dict[str, Any]:
         ]
         if len(matches) == 1:
             return matches[0]
-        raise RoomControlError("No hosted Bot room matches that internal ID.")
+        raise RoomControlError("No Group Chat matches that internal ID.")
 
     def _keys(room: Mapping[str, Any]) -> tuple[str, str]:
         return (
@@ -315,9 +323,9 @@ def resolve_room(rooms: list[dict[str, Any]], query: str) -> dict[str, Any]:
             )
             suffix = "…" if len(matches) > MAX_ROOM_CHOICES else ""
             raise RoomControlError(
-                f"That matches several rooms: {names}{suffix}. Enter more of the name."
+                f"That matches several group chats: {names}{suffix}. Enter more of the name."
             )
-    raise RoomControlError(f"No hosted Bot room matches “{_clean_line(query)}”.")
+    raise RoomControlError(f"No Group Chat matches “{_clean_line(query)}”.")
 
 
 def _room_status(service: Any, room_id: str) -> str:
@@ -353,13 +361,16 @@ def _room_status(service: Any, room_id: str) -> str:
     return "idle"
 
 
-def format_room_list(service: Any, *, rooms_command: str = "/rooms") -> str:
+def format_room_list(service: Any, *, rooms_command: str = "/group") -> str:
     """Render a bounded, scan-friendly hosted-room list."""
 
     rooms = list_messaging_rooms(service)
     if not rooms:
-        return "No hosted Bot rooms yet. Create one in Hermes Desktop first."
-    lines = ["Hosted Bot rooms"]
+        return (
+            "No Group Chats yet. Create one in Hermes Desktop first.\n\n"
+            f"Send: `{rooms_command} <number> send <message>`"
+        )
+    lines = ["Group Chats"]
     for room in rooms[:MAX_ROOM_CHOICES]:
         name = _clean_line(room.get("name") or room.get("room_id"), limit=72)
         raw_members = room.get("members")
@@ -370,7 +381,15 @@ def format_room_list(service: Any, *, rooms_command: str = "/rooms") -> str:
         )
     if len(rooms) > MAX_ROOM_CHOICES:
         lines.append(f"…and {len(rooms) - MAX_ROOM_CHOICES} more")
-    lines.append(f"Use `{rooms_command} <number>` to see recent activity.")
+    lines.extend(
+        [
+            "",
+            "Commands",
+            f"Check: `{rooms_command} <number>`",
+            f"Send: `{rooms_command} <number> send <message>`",
+            f"Stop: `{rooms_command} <number> stop`",
+        ]
+    )
     return "\n".join(lines)
 
 
@@ -395,7 +414,7 @@ def format_room_detail(
     service: Any,
     room: Mapping[str, Any],
     *,
-    room_command: str = "/rooms",
+    room_command: str = "/group",
 ) -> str:
     """Render status plus the latest visible room messages."""
 
@@ -449,9 +468,9 @@ def format_room_detail(
     else:
         lines.append("No messages yet.")
     lines.append(
-        f"Send: `{room_command} send {room_reference(room)} -- <message>`"
+        f"Send: `{room_command} {room_reference(room)} send <message>`"
     )
-    lines.append(f"Stop: `{room_command} stop {room_reference(room)}`")
+    lines.append(f"Stop: `{room_command} {room_reference(room)} stop`")
     return "\n".join(lines)
 
 

--- a/gateway/hosted_room_messaging.py
+++ b/gateway/hosted_room_messaging.py
@@ -25,15 +25,125 @@ from gateway import hosted_rooms
 MAX_ROOM_CHOICES = 8
 MAX_RECENT_MESSAGES = 5
 MAX_PREVIEW_CHARS = 180
+GROUP_CHAT_SYNC_META_KEY = "hermes-bots-groups"
+
+
+def _projected_desktop_rooms() -> list[dict[str, Any]]:
+    """Read the bounded classic-room projection shared by Desktop clients."""
+
+    try:
+        import yaml
+        from hermes_cli.profiles import get_profile_dir
+
+        profile_meta = Path(get_profile_dir("default")) / "profile.yaml"
+        if not profile_meta.is_file():
+            return []
+        raw = yaml.safe_load(profile_meta.read_text(encoding="utf-8")) or {}
+        ui_meta = raw.get("ui_meta") if isinstance(raw, Mapping) else None
+        snapshot = (
+            ui_meta.get(GROUP_CHAT_SYNC_META_KEY)
+            if isinstance(ui_meta, Mapping)
+            else None
+        )
+        raw_rooms = snapshot.get("rooms") if isinstance(snapshot, Mapping) else None
+    except Exception:
+        return []
+    if not isinstance(raw_rooms, Mapping):
+        return []
+    try:
+        snapshot_version = int(snapshot.get("version") or 0)
+    except (TypeError, ValueError):
+        snapshot_version = 0
+
+    rooms: list[dict[str, Any]] = []
+    for key, raw_room in raw_rooms.items():
+        if not isinstance(raw_room, Mapping):
+            continue
+        hosted = raw_room.get("hosted")
+        if isinstance(hosted, str) and hosted.strip():
+            continue
+        name = _clean_line(raw_room.get("name") or key, limit=200)
+        explicit_room_id = str(raw_room.get("roomId") or "").strip()
+        room_id = (
+            explicit_room_id
+            or (str(key).strip() if snapshot_version >= 3 else f"name:{name}")
+        )
+        if not name or not room_id:
+            continue
+        raw_log = raw_room.get("log")
+        log = [dict(item) for item in raw_log if isinstance(item, Mapping)] if isinstance(raw_log, list) else []
+        raw_members = raw_room.get("members")
+        members = (
+            [dict(item) for item in raw_members if isinstance(item, Mapping)]
+            if isinstance(raw_members, list)
+            else []
+        )
+        updated_at = max(
+            (float(item.get("at") or 0) for item in log),
+            default=float(snapshot.get("updatedAt") or 0) / 1000,
+        )
+        rooms.append(
+            {
+                "room_id": room_id,
+                "name": name,
+                "members": members,
+                "log": log,
+                "created_at": min(
+                    (float(item.get("at") or 0) for item in log),
+                    default=updated_at,
+                ),
+                "updated_at": updated_at,
+                "_room_mode": "desktop",
+            }
+        )
+    return rooms
 
 
 def list_messaging_rooms(service: Any) -> list[dict[str, Any]]:
-    """Return active rooms with gateway-stable numeric messaging references."""
+    """Return hosted and reachable classic rooms with stable short numbers."""
 
-    rooms = hosted_rooms.list_rooms(service.db_path)
+    hosted = [
+        {**room, "_room_mode": "hosted"}
+        for room in hosted_rooms.list_rooms(service.db_path)
+    ]
+    hosted_ids = {str(room["room_id"]) for room in hosted}
+    desktop = [
+        room
+        for room in _projected_desktop_rooms()
+        if str(room["room_id"]) not in hosted_ids
+    ]
+    rooms = hosted + desktop
     if not rooms:
         return []
 
+    from gateway.desktop_room_mailbox import (
+        available_room_ids,
+        default_db_path,
+        latest_command_states,
+    )
+
+    mailbox_db = default_db_path()
+    desktop_ids = [room["room_id"] for room in desktop]
+    available = available_room_ids(mailbox_db, desktop_ids)
+    command_states = latest_command_states(mailbox_db, desktop_ids)
+    rooms = [
+        {
+            **room,
+            **(
+                {
+                    "desktop_available": str(room["room_id"]) in available,
+                    "desktop_command": command_states.get(str(room["room_id"])),
+                }
+                if room.get("_room_mode") == "desktop"
+                else {}
+            ),
+        }
+        for room in rooms
+    ]
+
+    # Keep the numeric reference ledger where #96274 first created it. Moving
+    # it to the compatibility mailbox would silently renumber existing group
+    # chats after upgrade, making `/group 2 send ...` target the wrong chat.
     db_path = Path(service.db_path)
     db_path.parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(db_path, timeout=10)
@@ -280,7 +390,7 @@ def resolve_room(rooms: list[dict[str, Any]], query: str) -> dict[str, Any]:
         ]
         if len(matches) == 1:
             return matches[0]
-        raise RoomControlError(f"No Group Chat is numbered {numeric_ref}.")
+        raise RoomControlError(f"No hosted Bot room is numbered {numeric_ref}.")
 
     if needle.startswith("id:"):
         internal_id = needle.removeprefix("id:")
@@ -291,7 +401,7 @@ def resolve_room(rooms: list[dict[str, Any]], query: str) -> dict[str, Any]:
         ]
         if len(matches) == 1:
             return matches[0]
-        raise RoomControlError("No Group Chat matches that internal ID.")
+        raise RoomControlError("No hosted Bot room matches that internal ID.")
 
     def _keys(room: Mapping[str, Any]) -> tuple[str, str]:
         return (
@@ -325,10 +435,19 @@ def resolve_room(rooms: list[dict[str, Any]], query: str) -> dict[str, Any]:
             raise RoomControlError(
                 f"That matches several group chats: {names}{suffix}. Enter more of the name."
             )
-    raise RoomControlError(f"No Group Chat matches “{_clean_line(query)}”.")
+    raise RoomControlError(f"No group chat matches “{_clean_line(query)}”.")
 
 
-def _room_status(service: Any, room_id: str) -> str:
+def _room_status(service: Any, room: Mapping[str, Any]) -> str:
+    if room.get("_room_mode") == "desktop":
+        command = room.get("desktop_command")
+        state = str(command.get("state") or "") if isinstance(command, Mapping) else ""
+        if state == "failed":
+            return "needs attention"
+        if state in {"pending", "claimed"} and room.get("desktop_available"):
+            return "applying command"
+        return "ready" if room.get("desktop_available") else "waiting for Desktop"
+    room_id = str(room["room_id"])
     status = service.status(room_id)
     if status.get("blocked"):
         return "needs attention"
@@ -362,7 +481,7 @@ def _room_status(service: Any, room_id: str) -> str:
 
 
 def format_room_list(service: Any, *, rooms_command: str = "/group") -> str:
-    """Render a bounded, scan-friendly hosted-room list."""
+    """Render a bounded, scan-friendly Group Chat list."""
 
     rooms = list_messaging_rooms(service)
     if not rooms:
@@ -376,7 +495,7 @@ def format_room_list(service: Any, *, rooms_command: str = "/group") -> str:
         raw_members = room.get("members")
         members: list[Any] = raw_members if isinstance(raw_members, list) else []
         lines.append(
-            f"{room_reference(room)}. {name} — {_room_status(service, str(room['room_id']))}, "
+            f"{room_reference(room)}. {name} — {_room_status(service, room)}, "
             f"{len(members)} bot{'s' if len(members) != 1 else ''}"
         )
     if len(rooms) > MAX_ROOM_CHOICES:
@@ -428,45 +547,68 @@ def format_room_detail(
             ),
             dict(room),
         )
-    state = hosted_rooms.room_state(service.db_path, room_id=room_id)
-    since = max(0, int(state.get("latest_seq") or 0) - 80)
-    delta = hosted_rooms.read_events(
-        service.db_path,
-        room_id=room_id,
-        since_seq=since,
-        limit=80,
-    )
     raw_members = room.get("members")
     members: list[Any] = raw_members if isinstance(raw_members, list) else []
-    member_names = {
-        str(member.get("member_id") or ""): _clean_line(
-            member.get("display_name") or member.get("handle") or "Bot",
-            limit=48,
+    desktop_mode = room.get("_room_mode") == "desktop"
+    if desktop_mode:
+        visible = [
+            event for event in room.get("log", []) if isinstance(event, Mapping)
+        ][-MAX_RECENT_MESSAGES:]
+        member_names: dict[str, str] = {}
+    else:
+        state = hosted_rooms.room_state(service.db_path, room_id=room_id)
+        since = max(0, int(state.get("latest_seq") or 0) - 80)
+        delta = hosted_rooms.read_events(
+            service.db_path,
+            room_id=room_id,
+            since_seq=since,
+            limit=80,
         )
-        for member in members
-        if isinstance(member, Mapping)
-    }
-    visible = [
-        event
-        for event in delta.get("events", [])
-        if isinstance(event, Mapping)
-        and event.get("kind") in {"message.user", "message.member"}
-    ][-MAX_RECENT_MESSAGES:]
+        member_names = {
+            str(member.get("member_id") or ""): _clean_line(
+                member.get("display_name") or member.get("handle") or "Bot",
+                limit=48,
+            )
+            for member in members
+            if isinstance(member, Mapping)
+        }
+        visible = [
+            event
+            for event in delta.get("events", [])
+            if isinstance(event, Mapping)
+            and event.get("kind") in {"message.user", "message.member"}
+        ][-MAX_RECENT_MESSAGES:]
     name = _clean_line(room.get("name") or room_id, limit=72)
     lines = [
-        f"{name} — {_room_status(service, room_id)}",
+        f"{name} — {_room_status(service, room)}",
         f"{len(members)} bot{'s' if len(members) != 1 else ''}",
     ]
     if visible:
         lines.append("Recent activity")
         for event in visible:
-            payload = event.get("payload") if isinstance(event.get("payload"), Mapping) else {}
+            if desktop_mode:
+                source = event.get("from") if isinstance(event.get("from"), Mapping) else {}
+                label = _clean_line(source.get("name") or "You", limit=48)
+                text = event.get("text")
+            else:
+                payload = event.get("payload") if isinstance(event.get("payload"), Mapping) else {}
+                label = _event_label(event, member_names)
+                text = payload.get("text")
             lines.append(
-                f"• {_event_label(event, member_names)}: "
-                f"{_clean_line(payload.get('text'))}"
+                f"• {label}: {_clean_line(text)}"
             )
     else:
         lines.append("No messages yet.")
+    command = room.get("desktop_command")
+    if (
+        desktop_mode
+        and isinstance(command, Mapping)
+        and command.get("state") == "failed"
+    ):
+        lines.append(
+            "The latest command could not be applied. Open this room in "
+            "Hermes Desktop, then try again."
+        )
     lines.append(
         f"Send: `{room_command} {room_reference(room)} send <message>`"
     )
@@ -639,10 +781,31 @@ def relay_provenance_is_unknown(event: Any) -> bool:
 
 
 def send_to_room(service: Any, room: Mapping[str, Any], event: Any, text: str) -> str:
-    """Append one idempotent user turn and wake the hosted driver."""
+    """Append or hand off one idempotent room turn."""
 
     ensure_text_only(event)
     event_id = messaging_event_id(event)
+    name = _clean_line(room.get("name") or room.get("room_id"), limit=72)
+    if room.get("_room_mode") == "desktop":
+        from gateway.desktop_room_mailbox import enqueue_command, default_db_path
+
+        actor = messaging_actor(
+            event,
+            gateway_id=hosted_rooms.local_authority_gateway_id(),
+        )
+        enqueue_command(
+            default_db_path(),
+            command_id=event_id,
+            room_id=str(room["room_id"]),
+            action="send",
+            payload={
+                "message": text,
+                "actor_display_name": actor.get("display_name") or "Messaging",
+            },
+        )
+        if room.get("desktop_available"):
+            return f"Queued in {name}."
+        return f"Saved for {name}. Open or update Hermes Desktop to continue."
     service.send(
         room_id=str(room["room_id"]),
         event_id=event_id,
@@ -652,7 +815,6 @@ def send_to_room(service: Any, room: Mapping[str, Any], event: Any, text: str) -
             gateway_id=str(room["authority_gateway_id"]),
         ),
     )
-    name = _clean_line(room.get("name") or room.get("room_id"), limit=72)
     return f"Queued in {name}."
 
 
@@ -660,6 +822,19 @@ def stop_room(service: Any, room: Mapping[str, Any], event: Any) -> str:
     """Cancel active room tasks using a transport-derived idempotency key."""
 
     cancel_id = f"stop:{messaging_event_id(event)}"
-    service.stop_room(str(room["room_id"]), cancel_id=cancel_id)
     name = _clean_line(room.get("name") or room.get("room_id"), limit=72)
+    if room.get("_room_mode") == "desktop":
+        from gateway.desktop_room_mailbox import enqueue_command, default_db_path
+
+        enqueue_command(
+            default_db_path(),
+            command_id=cancel_id,
+            room_id=str(room["room_id"]),
+            action="stop",
+            payload={},
+        )
+        if room.get("desktop_available"):
+            return f"Stop requested for {name}."
+        return f"Stop saved for {name}. Open or update Hermes Desktop to apply it."
+    service.stop_room(str(room["room_id"]), cancel_id=cancel_id)
     return f"Stop requested for {name}. Active work will stop safely."

--- a/gateway/hosted_room_messaging.py
+++ b/gateway/hosted_room_messaging.py
@@ -1,0 +1,646 @@
+"""Messaging-facing controls for gateway-hosted Bot rooms.
+
+The handlers in :mod:`gateway.slash_commands` deliberately stay thin.  This
+module owns parsing, room lookup, bounded presentation, and server-owned actor
+identity so Telegram, Signal, WhatsApp, and the other gateway transports share
+one behavior contract.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import sqlite3
+import time
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from gateway import hosted_room_discussion as discussion
+from gateway import hosted_room_driver as driver
+from gateway import hosted_rooms
+
+
+MAX_ROOM_CHOICES = 8
+MAX_RECENT_MESSAGES = 5
+MAX_PREVIEW_CHARS = 180
+
+
+def list_messaging_rooms(service: Any) -> list[dict[str, Any]]:
+    """Return active rooms with gateway-stable numeric messaging references."""
+
+    rooms = hosted_rooms.list_rooms(service.db_path)
+    if not rooms:
+        return []
+
+    db_path = Path(service.db_path)
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db_path, timeout=10)
+    conn.row_factory = sqlite3.Row
+    try:
+        from hermes_state import apply_wal_with_fallback
+
+        apply_wal_with_fallback(conn, db_label="state.db (room messaging refs)")
+        conn.execute("BEGIN IMMEDIATE")
+        conn.execute(
+            """CREATE TABLE IF NOT EXISTS hosted_room_messaging_refs (
+                room_ref INTEGER PRIMARY KEY AUTOINCREMENT,
+                room_id TEXT NOT NULL UNIQUE
+            )"""
+        )
+        # Existing rooms receive deterministic first-use numbers. AUTOINCREMENT
+        # keeps those numbers stable and prevents a disbanded room's reference
+        # from being reassigned to unrelated work later.
+        for room in sorted(
+            rooms,
+            key=lambda item: (
+                float(item.get("created_at") or 0),
+                str(item.get("room_id") or ""),
+            ),
+        ):
+            conn.execute(
+                "INSERT OR IGNORE INTO hosted_room_messaging_refs (room_id) VALUES (?)",
+                (str(room["room_id"]),),
+            )
+        refs = {
+            str(row["room_id"]): int(row["room_ref"])
+            for row in conn.execute(
+                "SELECT room_id, room_ref FROM hosted_room_messaging_refs"
+            )
+        }
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+    return [
+        {**room, "messaging_ref": refs[str(room["room_id"])]}
+        for room in rooms
+    ]
+
+
+def room_reference(room: Mapping[str, Any]) -> str:
+    """Return the short messaging reference, with an internal-id fallback."""
+
+    reference = room.get("messaging_ref")
+    if isinstance(reference, int) and reference > 0:
+        return str(reference)
+    return str(room.get("room_id") or "")
+
+
+class RoomControlError(ValueError):
+    """A user-actionable hosted-room command error."""
+
+
+@dataclass(frozen=True)
+class RoomCommand:
+    """Parsed mutating ``/rooms`` subcommand."""
+
+    action: str
+    room_query: str
+    message: str = ""
+
+
+class MessagingRoomBackend:
+    """Cross-process hosted-room access through the shared durable stores."""
+
+    def __init__(self, *, db_path: Any, service: Any = None) -> None:
+        self.db_path = db_path
+        self.service = service
+
+    def status(self, room_id: str) -> dict[str, Any]:
+        if self.service is not None:
+            return self.service.status(room_id)
+        tasks = driver.list_tasks(self.db_path, room_id=room_id)
+        counts: dict[str, int] = {}
+        for task in tasks:
+            status = str(task.get("status") or "")
+            counts[status] = counts.get(status, 0) + 1
+        return {
+            "working": any(counts.get(status) for status in ("queued", "running", "stopping")),
+            "blocked": bool(counts.get("indeterminate")),
+            "counts": counts,
+        }
+
+    def send(
+        self,
+        *,
+        room_id: str,
+        event_id: str,
+        payload: Any,
+        actor: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        if self.service is not None:
+            return self.service.send(
+                room_id=room_id,
+                event_id=event_id,
+                payload=payload,
+                actor=actor,
+            )
+        normalized = discussion.validate_user_payload(payload)
+        return hosted_rooms.append_event(
+            self.db_path,
+            room_id=room_id,
+            event_id=event_id,
+            kind="message.user",
+            actor=dict(actor),
+            payload=normalized,
+        )
+
+    def stop_room(self, room_id: str, *, cancel_id: str) -> int:
+        if self.service is not None:
+            return self.service.stop_room(room_id, cancel_id=cancel_id)
+        hosted_rooms.request_room_stop(
+            self.db_path,
+            room_id=room_id,
+            cancel_id=cancel_id,
+        )
+        requested = 0
+        for task in driver.list_tasks(self.db_path, room_id=room_id):
+            for _attempt in range(3):
+                current = driver.get_task(self.db_path, task["identity"])
+                status = str(current.get("status") or "")
+                try:
+                    if status == "queued":
+                        driver.cancel_task(
+                            self.db_path,
+                            current["identity"],
+                            cancel_id=cancel_id,
+                            expected_cancel_generation=int(
+                                current["cancel_generation"]
+                            ),
+                            clock=time.time,
+                        )
+                        requested += 1
+                    elif status in {"running", "indeterminate"}:
+                        driver.begin_task_cancel(
+                            self.db_path,
+                            current["identity"],
+                            cancel_id=cancel_id,
+                            expected_cancel_generation=int(
+                                current["cancel_generation"]
+                            ),
+                            clock=time.time,
+                        )
+                        requested += 1
+                    elif status == "stopping":
+                        requested += 1
+                    elif (
+                        status == "cancelled"
+                        and current.get("cancel_id") == cancel_id
+                    ):
+                        requested += 1
+                    break
+                except (driver.InvalidTaskTransitionError, driver.StaleTaskError):
+                    # Queued work can become running between the list and the
+                    # write. Reload and retry under the new generation.
+                    continue
+        return requested
+
+
+def current_room_backend() -> MessagingRoomBackend:
+    """Resolve in-process service access or the shared cross-process store."""
+
+    from tui_gateway.methods_groups import get_hosted_room_service
+
+    service = get_hosted_room_service()
+    return MessagingRoomBackend(
+        db_path=service.db_path if service is not None else hosted_rooms.default_db_path(),
+        service=service,
+    )
+
+
+def _clean_line(value: Any, *, limit: int = MAX_PREVIEW_CHARS) -> str:
+    """Collapse untrusted text to one bounded display line."""
+
+    text = re.sub(r"\s+", " ", str(value or "")).strip()
+    if len(text) <= limit:
+        return text
+    return text[: max(1, limit - 1)].rstrip() + "…"
+
+
+def command_form(event: Any) -> str:
+    """Return the channel-valid hosted-room command prefix."""
+
+    source = getattr(event, "source", None)
+    platform = getattr(getattr(source, "platform", None), "value", "")
+    if platform == "slack":
+        return "/hermes rooms"
+    if platform == "matrix":
+        return "!rooms"
+    return "/rooms"
+
+
+def parse_room_command(args: str, *, command_root: str = "/rooms") -> RoomCommand:
+    """Parse ``send`` and ``stop`` without making room names quote-only."""
+
+    raw = str(args or "").strip()
+    action, _, remainder = raw.partition(" ")
+    action = action.casefold()
+    remainder = remainder.strip()
+    if action == "send":
+        room_query, delimiter, message = remainder.partition(" -- ")
+        if not delimiter or not room_query.strip() or not message.strip():
+            raise RoomControlError(
+                f"Use `{command_root} send <room number> -- <message>`."
+            )
+        return RoomCommand("send", room_query.strip(), message.strip())
+    if action == "stop":
+        if not remainder:
+            raise RoomControlError(f"Use `{command_root} stop <room number>`.")
+        return RoomCommand("stop", remainder)
+    raise RoomControlError(
+        f"Use `{command_root} send <room number> -- <message>` or "
+        f"`{command_root} stop <room number>`."
+    )
+
+
+def resolve_room(rooms: list[dict[str, Any]], query: str) -> dict[str, Any]:
+    """Resolve by stable messaging number, then id/name convenience matches."""
+
+    needle = _clean_line(query, limit=hosted_rooms.MAX_ROOM_NAME_CHARS).casefold()
+    if not needle:
+        raise RoomControlError("Enter a room number or name.")
+
+    if needle.isdecimal():
+        numeric_ref = int(needle)
+        matches = [
+            room for room in rooms if room.get("messaging_ref") == numeric_ref
+        ]
+        if len(matches) == 1:
+            return matches[0]
+        raise RoomControlError(f"No hosted Bot room is numbered {numeric_ref}.")
+
+    if needle.startswith("id:"):
+        internal_id = needle.removeprefix("id:")
+        matches = [
+            room
+            for room in rooms
+            if str(room.get("room_id") or "").casefold() == internal_id
+        ]
+        if len(matches) == 1:
+            return matches[0]
+        raise RoomControlError("No hosted Bot room matches that internal ID.")
+
+    def _keys(room: Mapping[str, Any]) -> tuple[str, str]:
+        return (
+            str(room.get("room_id") or "").casefold(),
+            str(room.get("name") or "").casefold(),
+        )
+
+    for match_kind in ("exact", "prefix", "contains"):
+        matches: list[dict[str, Any]] = []
+        for room in rooms:
+            room_id, name = _keys(room)
+            if match_kind == "exact" and needle in {room_id, name}:
+                matches.append(room)
+            elif match_kind == "prefix" and (
+                room_id.startswith(needle) or name.startswith(needle)
+            ):
+                matches.append(room)
+            elif match_kind == "contains" and (needle in room_id or needle in name):
+                matches.append(room)
+        if len(matches) == 1:
+            return matches[0]
+        if len(matches) > 1:
+            names = ", ".join(
+                (
+                    f"{_clean_line(room.get('name') or room.get('room_id'), limit=48)} "
+                    f"[{room_reference(room)}]"
+                )
+                for room in matches[:MAX_ROOM_CHOICES]
+            )
+            suffix = "…" if len(matches) > MAX_ROOM_CHOICES else ""
+            raise RoomControlError(
+                f"That matches several rooms: {names}{suffix}. Enter more of the name."
+            )
+    raise RoomControlError(f"No hosted Bot room matches “{_clean_line(query)}”.")
+
+
+def _room_status(service: Any, room_id: str) -> str:
+    status = service.status(room_id)
+    if status.get("blocked"):
+        return "needs attention"
+    if status.get("counts", {}).get("stopping"):
+        return "stopping"
+    if status.get("working"):
+        return "work queued or running"
+    state = hosted_rooms.room_state(service.db_path, room_id=room_id)
+    since = max(0, int(state.get("latest_seq") or 0) - 80)
+    recent = hosted_rooms.read_events(
+        service.db_path,
+        room_id=room_id,
+        since_seq=since,
+        limit=80,
+    ).get("events", [])
+    latest_user = max(
+        (int(event["seq"]) for event in recent if event.get("kind") == "message.user"),
+        default=0,
+    )
+    latest_boundary = max(
+        (
+            int(event["seq"])
+            for event in recent
+            if event.get("kind") in {"room.activity", "room.stop_requested"}
+        ),
+        default=0,
+    )
+    if latest_user > latest_boundary:
+        return "waiting for the room host"
+    return "idle"
+
+
+def format_room_list(service: Any, *, rooms_command: str = "/rooms") -> str:
+    """Render a bounded, scan-friendly hosted-room list."""
+
+    rooms = list_messaging_rooms(service)
+    if not rooms:
+        return "No hosted Bot rooms yet. Create one in Hermes Desktop first."
+    lines = ["Hosted Bot rooms"]
+    for room in rooms[:MAX_ROOM_CHOICES]:
+        name = _clean_line(room.get("name") or room.get("room_id"), limit=72)
+        raw_members = room.get("members")
+        members: list[Any] = raw_members if isinstance(raw_members, list) else []
+        lines.append(
+            f"{room_reference(room)}. {name} — {_room_status(service, str(room['room_id']))}, "
+            f"{len(members)} bot{'s' if len(members) != 1 else ''}"
+        )
+    if len(rooms) > MAX_ROOM_CHOICES:
+        lines.append(f"…and {len(rooms) - MAX_ROOM_CHOICES} more")
+    lines.append(f"Use `{rooms_command} <number>` to see recent activity.")
+    return "\n".join(lines)
+
+
+def _event_label(event: Mapping[str, Any], member_names: Mapping[str, str]) -> str:
+    raw_actor = event.get("actor")
+    actor: Mapping[str, Any] = raw_actor if isinstance(raw_actor, Mapping) else {}
+    actor_id = str(actor.get("id") or "")
+    display_name = _clean_line(actor.get("display_name"), limit=48)
+    if display_name:
+        return display_name
+    if event.get("kind") == "message.member":
+        raw_payload = event.get("payload")
+        payload: Mapping[str, Any] = (
+            raw_payload if isinstance(raw_payload, Mapping) else {}
+        )
+        member_id = str(payload.get("member_id") or actor_id)
+        return member_names.get(member_id, "Bot")
+    return "You"
+
+
+def format_room_detail(
+    service: Any,
+    room: Mapping[str, Any],
+    *,
+    room_command: str = "/rooms",
+) -> str:
+    """Render status plus the latest visible room messages."""
+
+    room_id = str(room["room_id"])
+    if not isinstance(room.get("messaging_ref"), int):
+        room = next(
+            (
+                candidate
+                for candidate in list_messaging_rooms(service)
+                if str(candidate["room_id"]) == room_id
+            ),
+            dict(room),
+        )
+    state = hosted_rooms.room_state(service.db_path, room_id=room_id)
+    since = max(0, int(state.get("latest_seq") or 0) - 80)
+    delta = hosted_rooms.read_events(
+        service.db_path,
+        room_id=room_id,
+        since_seq=since,
+        limit=80,
+    )
+    raw_members = room.get("members")
+    members: list[Any] = raw_members if isinstance(raw_members, list) else []
+    member_names = {
+        str(member.get("member_id") or ""): _clean_line(
+            member.get("display_name") or member.get("handle") or "Bot",
+            limit=48,
+        )
+        for member in members
+        if isinstance(member, Mapping)
+    }
+    visible = [
+        event
+        for event in delta.get("events", [])
+        if isinstance(event, Mapping)
+        and event.get("kind") in {"message.user", "message.member"}
+    ][-MAX_RECENT_MESSAGES:]
+    name = _clean_line(room.get("name") or room_id, limit=72)
+    lines = [
+        f"{name} — {_room_status(service, room_id)}",
+        f"{len(members)} bot{'s' if len(members) != 1 else ''}",
+    ]
+    if visible:
+        lines.append("Recent activity")
+        for event in visible:
+            payload = event.get("payload") if isinstance(event.get("payload"), Mapping) else {}
+            lines.append(
+                f"• {_event_label(event, member_names)}: "
+                f"{_clean_line(payload.get('text'))}"
+            )
+    else:
+        lines.append("No messages yet.")
+    lines.append(
+        f"Send: `{room_command} send {room_reference(room)} -- <message>`"
+    )
+    lines.append(f"Stop: `{room_command} stop {room_reference(room)}`")
+    return "\n".join(lines)
+
+
+def messaging_actor(event: Any, *, gateway_id: str) -> dict[str, str]:
+    """Build a stable actor without persisting raw platform user IDs."""
+
+    source = getattr(event, "source", None)
+    platform_value = getattr(getattr(source, "platform", None), "value", None)
+    platform = _clean_line(platform_value or "messaging", limit=32).casefold()
+    raw_user_id = (
+        getattr(source, "user_id_alt", None)
+        or getattr(event, "user_id", None)
+        or getattr(source, "user_id", None)
+        or "unknown"
+    )
+    scope = getattr(source, "scope_id", None) or getattr(source, "guild_id", None)
+    chat_id = getattr(source, "chat_id", None)
+    digest = hashlib.sha256(
+        f"{gateway_id}:{platform}:{scope or ''}:{chat_id or ''}:{raw_user_id}".encode()
+    ).hexdigest()[:20]
+    raw_name = _clean_line(
+        getattr(event, "user_name", None) or getattr(source, "user_name", None),
+        limit=48,
+    )
+    platform_label = platform.replace("_", " ").title()
+    display_name = (
+        f"{raw_name} via {platform_label}"
+        if raw_name and raw_name != str(raw_user_id)
+        else platform_label
+    )
+    return {
+        "kind": "user",
+        "id": f"messaging:{platform}:{digest}",
+        "display_name": display_name,
+    }
+
+
+def _raw_transport_id(event: Any) -> Any:
+    """Extract one adapter-owned redelivery key without guessing from text."""
+
+    metadata = getattr(event, "metadata", None)
+    candidates: list[Any] = []
+    if isinstance(metadata, Mapping):
+        candidates.extend(
+            metadata.get(key)
+            for key in (
+                "delivery_id",
+                "event_id",
+                "message_id",
+                "request_id",
+                "update_id",
+            )
+        )
+    raw = getattr(event, "raw_message", None)
+    payloads = [raw]
+    if isinstance(raw, Mapping):
+        payloads.extend(
+            raw.get(key) for key in ("event", "message", "data", "container")
+        )
+    for payload in payloads:
+        if isinstance(payload, Mapping):
+            candidates.extend(
+                payload.get(key)
+                for key in (
+                    "client_msg_id",
+                    "trigger_id",
+                    "event_id",
+                    "message_id",
+                    "id",
+                    "ts",
+                    "event_ts",
+                    "timestamp_ms",
+                    "timestamp",
+                )
+            )
+    if raw is not None and not isinstance(raw, Mapping):
+        candidates.extend(
+            getattr(raw, key, None) for key in ("id", "interaction_id")
+        )
+    return next(
+        (
+            value
+            for value in candidates
+            if value is not None and str(value).strip()
+        ),
+        None,
+    )
+
+
+def messaging_event_id(event: Any) -> str:
+    """Return a deterministic idempotency key when the transport provides one."""
+
+    source = getattr(event, "source", None)
+    platform = getattr(getattr(source, "platform", None), "value", "messaging")
+    stable_message_id = (
+        getattr(event, "platform_update_id", None)
+        or getattr(event, "message_id", None)
+        or getattr(source, "message_id", None)
+        or _raw_transport_id(event)
+    )
+    if stable_message_id is None:
+        raise RoomControlError(
+            "This channel didn’t provide a stable message ID, so Hermes can’t "
+            "safely repeat this room command. Try another connected channel."
+        )
+    material = "|".join(
+        str(value or "")
+        for value in (
+            platform,
+            getattr(source, "chat_id", None),
+            getattr(source, "thread_id", None),
+            getattr(source, "user_id_alt", None)
+            or getattr(event, "user_id", None)
+            or getattr(source, "user_id", None),
+            stable_message_id,
+        )
+    )
+    return f"messaging:{hashlib.sha256(material.encode()).hexdigest()}"
+
+
+def ensure_text_only(event: Any) -> None:
+    """Reject media explicitly until hosted-room attachment transport exists."""
+
+    if getattr(event, "media_urls", None) or getattr(event, "media_types", None):
+        raise RoomControlError(
+            "Attachments from messaging chats aren’t supported yet. Send text only."
+        )
+
+
+def is_machine_authored(event: Any) -> bool:
+    """Recognize native and relayed bot/webhook provenance defensively."""
+
+    source = getattr(event, "source", None)
+    if getattr(source, "is_bot", False):
+        return True
+    metadata = getattr(event, "metadata", None)
+    if isinstance(metadata, Mapping) and any(
+        metadata.get(key) is True
+        for key in ("is_bot", "sender_is_bot", "webhook_sender")
+    ):
+        return True
+    raw = getattr(event, "raw_message", None)
+    if isinstance(raw, Mapping):
+        if raw.get("bot_id") or raw.get("bot_profile"):
+            return True
+        if raw.get("subtype") in {"bot_message", "webhook_message"}:
+            return True
+    for owner_field in ("author", "user"):
+        owner = getattr(raw, owner_field, None)
+        if getattr(owner, "bot", False) or getattr(owner, "is_bot", False):
+            return True
+    return False
+
+
+def relay_provenance_is_unknown(event: Any) -> bool:
+    """Fail closed until a relay producer classifies the inbound author."""
+
+    source = getattr(event, "source", None)
+    if not getattr(source, "delivered_via_upstream_relay", False):
+        return False
+    metadata = getattr(event, "metadata", None)
+    return not (
+        isinstance(metadata, Mapping)
+        and metadata.get("relay_author_classified") is True
+    )
+
+
+def send_to_room(service: Any, room: Mapping[str, Any], event: Any, text: str) -> str:
+    """Append one idempotent user turn and wake the hosted driver."""
+
+    ensure_text_only(event)
+    event_id = messaging_event_id(event)
+    service.send(
+        room_id=str(room["room_id"]),
+        event_id=event_id,
+        payload={"text": text, "thread_id": event_id},
+        actor=messaging_actor(
+            event,
+            gateway_id=str(room["authority_gateway_id"]),
+        ),
+    )
+    name = _clean_line(room.get("name") or room.get("room_id"), limit=72)
+    return f"Queued in {name}."
+
+
+def stop_room(service: Any, room: Mapping[str, Any], event: Any) -> str:
+    """Cancel active room tasks using a transport-derived idempotency key."""
+
+    cancel_id = f"stop:{messaging_event_id(event)}"
+    service.stop_room(str(room["room_id"]), cancel_id=cancel_id)
+    name = _clean_line(room.get("name") or room.get("room_id"), limit=72)
+    return f"Stop requested for {name}. Active work will stop safely."

--- a/gateway/hosted_rooms.py
+++ b/gateway/hosted_rooms.py
@@ -12,6 +12,7 @@ can isolate state. Production handlers use the gateway's root ``state.db``.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import re
 import sqlite3
@@ -64,6 +65,7 @@ _EVENT_KINDS_BY_ACTOR = {
     "gateway": frozenset({
         "member.unavailable",
         "room.activity",
+        "room.stop_requested",
         "turn.deferred",
         "turn.reassigned",
         "turn.cancelled",
@@ -736,6 +738,33 @@ def room_state(
     if claim_row is not None:
         state["authority_claim"] = _event_from_row(claim_row)
     return state
+
+
+def request_room_stop(
+    db_path: Path | str,
+    *,
+    room_id: Any,
+    cancel_id: Any,
+) -> dict[str, Any]:
+    """Append an idempotent fence that supersedes earlier user turns."""
+
+    cancel_id = _validate_identifier(
+        cancel_id,
+        label="cancel_id",
+        max_chars=MAX_EVENT_ID_CHARS,
+    )
+    room = room_state(db_path, room_id=room_id)
+    digest = hashlib.sha256(cancel_id.encode()).hexdigest()[:32]
+    return append_event(
+        db_path,
+        room_id=room["room_id"],
+        event_id=f"room-stop:{digest}",
+        kind="room.stop_requested",
+        actor={"kind": "gateway", "id": room["authority_gateway_id"]},
+        payload={"cancel_id": cancel_id},
+        authority_gateway_id=room["authority_gateway_id"],
+        authority_epoch=room["authority_epoch"],
+    )
 
 
 def claim_authority(

--- a/gateway/hosted_rooms.py
+++ b/gateway/hosted_rooms.py
@@ -1,0 +1,1035 @@
+"""Durable state for gateway-hosted Bot Mode rooms.
+
+This module owns only hosted-room identity and its append-only event log. It
+does not deliver events, lease relay work, or run agent turns; those concerns
+belong to the relay and the future hosted-room driver. Keeping that boundary
+explicit lets the room log compose with a durable relay without creating a
+second transport queue.
+
+The caller supplies the database path so tests and alternate gateway layouts
+can isolate state. Production handlers use the gateway's root ``state.db``.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sqlite3
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Iterator
+
+
+PROTOCOL_VERSION = 2
+MAX_ROOM_ID_CHARS = 128
+MAX_EVENT_ID_CHARS = 128
+MAX_ROOM_NAME_CHARS = 200
+MAX_EVENT_KIND_CHARS = 64
+MAX_ACTOR_ID_CHARS = 128
+MAX_ACTOR_LABEL_CHARS = 200
+MAX_MEMBERS = 128
+MAX_MEMBERS_JSON_BYTES = 128 * 1024
+MAX_EVENT_JSON_BYTES = 256 * 1024
+MAX_LOG_LIMIT = 500
+
+_IDENTIFIER_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]*$")
+_EVENT_KIND_RE = re.compile(r"^[a-z][a-z0-9_.-]*$")
+_ROOM_SCHEMA_COLUMNS = frozenset({
+    "room_id",
+    "name",
+    "members_json",
+    "authority_gateway_id",
+    "authority_epoch",
+    "next_seq",
+    "revision",
+    "created_at",
+    "updated_at",
+    "disbanded_at",
+})
+_EVENT_SCHEMA_COLUMNS = frozenset({
+    "room_id",
+    "seq",
+    "event_id",
+    "kind",
+    "actor_json",
+    "authority_epoch",
+    "payload_json",
+    "created_at",
+})
+
+_EVENT_KINDS_BY_ACTOR = {
+    "user": frozenset({"message.user"}),
+    "member": frozenset({"message.member"}),
+    "gateway": frozenset({
+        "member.unavailable",
+        "room.activity",
+        "turn.deferred",
+        "turn.reassigned",
+        "turn.cancelled",
+        "turn.failed",
+        "turn.settled",
+        "turn.started",
+    }),
+    "system": frozenset({
+        "authority.claimed",
+        "authority.lost",
+        "room.created",
+        "room.disbanded",
+        "room.members_changed",
+        "room.renamed",
+    }),
+}
+_ACTOR_FIELDS = frozenset({"kind", "id", "display_name", "profile", "connection_id"})
+
+
+class HostedRoomError(ValueError):
+    """Base class for invalid or conflicting hosted-room operations."""
+
+
+class RoomNotFoundError(HostedRoomError):
+    """Raised when a room does not exist or has been disbanded."""
+
+
+class RoomConflictError(HostedRoomError):
+    """Raised when an idempotency key is reused for different room state."""
+
+
+class EventConflictError(HostedRoomError):
+    """Raised when an event id is reused with different immutable content."""
+
+
+class AuthorityConflictError(HostedRoomError):
+    """Raised when a stale room authority attempts to mutate hosted state."""
+
+
+class AuthoritySupersededError(AuthorityConflictError):
+    """Raised when a successful authority claim was later superseded."""
+
+
+def default_db_path() -> Path:
+    """Return the gateway-wide state database for the active install."""
+    from hermes_constants import get_hermes_home
+
+    home = get_hermes_home()
+    root = home.parent.parent if home.parent.name == "profiles" else home
+    return root / "state.db"
+
+
+def local_authority_gateway_id() -> str:
+    """Return the stable server-owned identity for hosted-room authority."""
+    from hermes_cli.install_identity import get_install_id
+
+    install_id = get_install_id()
+    if not install_id:
+        raise HostedRoomError("stable gateway install identity is unavailable")
+    return _validate_identifier(
+        f"install:{install_id}",
+        label="authority_gateway_id",
+        max_chars=MAX_ACTOR_ID_CHARS,
+    )
+
+
+def _canonical_json(value: Any, *, label: str, max_bytes: int) -> str:
+    try:
+        encoded = json.dumps(
+            value,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+    except (TypeError, ValueError, RecursionError) as exc:
+        raise HostedRoomError(f"{label} must be JSON-serializable") from exc
+    if len(encoded.encode("utf-8")) > max_bytes:
+        raise HostedRoomError(f"{label} is too large")
+    return encoded
+
+
+def _validate_identifier(value: Any, *, label: str, max_chars: int) -> str:
+    if not isinstance(value, str):
+        raise HostedRoomError(f"{label} must be a string")
+    value = value.strip()
+    if not value or len(value) > max_chars or not _IDENTIFIER_RE.fullmatch(value):
+        raise HostedRoomError(f"invalid {label}")
+    return value
+
+
+def _validate_room_name(value: Any) -> str:
+    if not isinstance(value, str):
+        raise HostedRoomError("name must be a string")
+    value = value.strip()
+    if not value or len(value) > MAX_ROOM_NAME_CHARS:
+        raise HostedRoomError("invalid room name")
+    return value
+
+
+def _validate_members(value: Any) -> tuple[list[dict[str, Any]], str]:
+    if not isinstance(value, list):
+        raise HostedRoomError("members must be a list")
+    if len(value) > MAX_MEMBERS:
+        raise HostedRoomError("too many room members")
+    members: list[dict[str, Any]] = []
+    for member in value:
+        if not isinstance(member, dict):
+            raise HostedRoomError("each room member must be an object")
+        members.append(dict(member))
+    encoded = _canonical_json(
+        members,
+        label="members",
+        max_bytes=MAX_MEMBERS_JSON_BYTES,
+    )
+    return members, encoded
+
+
+def _validate_event_kind(value: Any) -> str:
+    if not isinstance(value, str):
+        raise HostedRoomError("kind must be a string")
+    value = value.strip()
+    if (
+        not value
+        or len(value) > MAX_EVENT_KIND_CHARS
+        or not _EVENT_KIND_RE.fullmatch(value)
+    ):
+        raise HostedRoomError("invalid event kind")
+    return value
+
+
+def _optional_actor_field(actor: dict[str, Any], field: str, max_chars: int) -> str:
+    value = actor.get(field)
+    if value is None:
+        return ""
+    if not isinstance(value, str):
+        raise HostedRoomError(f"actor.{field} must be a string")
+    value = value.strip()
+    if len(value) > max_chars:
+        raise HostedRoomError(f"actor.{field} is too long")
+    return value
+
+
+def _validate_actor(value: Any, *, kind: str) -> tuple[dict[str, str], str]:
+    if not isinstance(value, dict):
+        raise HostedRoomError("actor must be an object")
+    unknown = set(value) - _ACTOR_FIELDS
+    if unknown:
+        raise HostedRoomError(f"unknown actor fields: {', '.join(sorted(unknown))}")
+
+    actor_kind = value.get("kind")
+    if not isinstance(actor_kind, str) or actor_kind not in _EVENT_KINDS_BY_ACTOR:
+        raise HostedRoomError("invalid actor.kind")
+    if kind not in _EVENT_KINDS_BY_ACTOR[actor_kind]:
+        raise HostedRoomError(f"actor kind '{actor_kind}' cannot append '{kind}'")
+
+    actor_id = _validate_identifier(
+        value.get("id"),
+        label="actor.id",
+        max_chars=MAX_ACTOR_ID_CHARS,
+    )
+    actor = {"kind": actor_kind, "id": actor_id}
+    for field, max_chars in (
+        ("display_name", MAX_ACTOR_LABEL_CHARS),
+        ("profile", MAX_ACTOR_ID_CHARS),
+        ("connection_id", MAX_ACTOR_ID_CHARS),
+    ):
+        field_value = _optional_actor_field(value, field, max_chars)
+        if field_value:
+            actor[field] = field_value
+    encoded = _canonical_json(
+        actor,
+        label="actor",
+        max_bytes=4 * 1024,
+    )
+    return actor, encoded
+
+
+def _initialize_schema(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS hosted_rooms (
+            room_id TEXT PRIMARY KEY,
+            name TEXT NOT NULL,
+            members_json TEXT NOT NULL,
+            authority_gateway_id TEXT NOT NULL,
+            authority_epoch INTEGER NOT NULL DEFAULT 1 CHECK (authority_epoch >= 1),
+            next_seq INTEGER NOT NULL DEFAULT 1 CHECK (next_seq >= 1),
+            revision INTEGER NOT NULL DEFAULT 1 CHECK (revision >= 1),
+            created_at REAL NOT NULL,
+            updated_at REAL NOT NULL,
+            disbanded_at REAL
+        )"""
+    )
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS hosted_room_events (
+            room_id TEXT NOT NULL,
+            seq INTEGER NOT NULL CHECK (seq >= 1),
+            event_id TEXT NOT NULL,
+            kind TEXT NOT NULL,
+            actor_json TEXT NOT NULL,
+            authority_epoch INTEGER CHECK (authority_epoch IS NULL OR authority_epoch >= 1),
+            payload_json TEXT NOT NULL,
+            created_at REAL NOT NULL,
+            PRIMARY KEY (room_id, seq),
+            UNIQUE (room_id, event_id),
+            FOREIGN KEY (room_id) REFERENCES hosted_rooms(room_id)
+        )"""
+    )
+    room_columns = {row[1] for row in conn.execute("PRAGMA table_info(hosted_rooms)")}
+    if "authority_gateway_id" not in room_columns:
+        conn.execute(
+            "ALTER TABLE hosted_rooms "
+            "ADD COLUMN authority_gateway_id TEXT NOT NULL DEFAULT 'legacy'"
+        )
+    if "authority_epoch" not in room_columns:
+        conn.execute(
+            "ALTER TABLE hosted_rooms "
+            "ADD COLUMN authority_epoch INTEGER NOT NULL DEFAULT 1"
+        )
+
+    event_columns = {
+        row[1] for row in conn.execute("PRAGMA table_info(hosted_room_events)")
+    }
+    if "actor_json" not in event_columns:
+        # Draft builds before the actor contract carried no identity. Preserve
+        # their inert replay rows explicitly as legacy system events rather
+        # than guessing a user or Bot author.
+        legacy_actor = _canonical_json(
+            {"kind": "system", "id": "legacy"},
+            label="actor",
+            max_bytes=4 * 1024,
+        )
+        escaped_actor = legacy_actor.replace("'", "''")
+        conn.execute(
+            "ALTER TABLE hosted_room_events "
+            f"ADD COLUMN actor_json TEXT NOT NULL DEFAULT '{escaped_actor}'"
+        )
+    if "authority_epoch" not in event_columns:
+        conn.execute(
+            "ALTER TABLE hosted_room_events ADD COLUMN authority_epoch INTEGER"
+        )
+    conn.execute(
+        """CREATE INDEX IF NOT EXISTS idx_hosted_room_events_cursor
+           ON hosted_room_events(room_id, seq)"""
+    )
+    if not _schema_is_current(conn):
+        raise HostedRoomError("hosted room schema migration did not complete")
+
+
+def _schema_is_current(conn: sqlite3.Connection) -> bool:
+    room_columns = frozenset(
+        row[1] for row in conn.execute("PRAGMA table_info(hosted_rooms)")
+    )
+    event_columns = frozenset(
+        row[1] for row in conn.execute("PRAGMA table_info(hosted_room_events)")
+    )
+    if not _ROOM_SCHEMA_COLUMNS.issubset(room_columns):
+        return False
+    if not _EVENT_SCHEMA_COLUMNS.issubset(event_columns):
+        return False
+    index = conn.execute(
+        """SELECT 1 FROM sqlite_master
+           WHERE type='index' AND name='idx_hosted_room_events_cursor'"""
+    ).fetchone()
+    return index is not None
+
+
+def _connect(db_path: Path | str) -> sqlite3.Connection:
+    from hermes_state import apply_wal_with_fallback
+
+    path = Path(db_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path, timeout=10)
+    conn.row_factory = sqlite3.Row
+    try:
+        apply_wal_with_fallback(conn, db_label="state.db (hosted_rooms)")
+        conn.execute("PRAGMA foreign_keys=ON")
+        if _schema_is_current(conn):
+            return conn
+        # Multiple profile gateways share this root database. Serialize every
+        # draft-schema transition in SQLite itself so a crash rolls back the
+        # whole DDL/data migration and another process can safely retry it.
+        conn.execute("BEGIN IMMEDIATE")
+        _initialize_schema(conn)
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        conn.close()
+        raise
+    return conn
+
+
+@contextmanager
+def _transaction(
+    db_path: Path | str, *, immediate: bool = False
+) -> Iterator[sqlite3.Connection]:
+    conn = _connect(db_path)
+    try:
+        if immediate:
+            conn.execute("BEGIN IMMEDIATE")
+        yield conn
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+
+def _room_from_row(row: sqlite3.Row, *, idempotent: bool = False) -> dict[str, Any]:
+    room = {
+        "room_id": row["room_id"],
+        "name": row["name"],
+        "members": json.loads(row["members_json"]),
+        "authority_gateway_id": row["authority_gateway_id"],
+        "authority_epoch": int(row["authority_epoch"]),
+        "revision": int(row["revision"]),
+        "created_at": float(row["created_at"]),
+        "updated_at": float(row["updated_at"]),
+        "idempotent": idempotent,
+    }
+    if "disbanded_at" in row.keys() and row["disbanded_at"] is not None:
+        room["disbanded_at"] = float(row["disbanded_at"])
+    if "next_seq" in row.keys():
+        room["latest_seq"] = int(row["next_seq"]) - 1
+    return room
+
+
+def _event_from_row(row: sqlite3.Row, *, idempotent: bool = False) -> dict[str, Any]:
+    return {
+        "room_id": row["room_id"],
+        "seq": int(row["seq"]),
+        "event_id": row["event_id"],
+        "kind": row["kind"],
+        "actor": json.loads(row["actor_json"]),
+        "authority_epoch": (
+            int(row["authority_epoch"]) if row["authority_epoch"] is not None else None
+        ),
+        "payload": json.loads(row["payload_json"]),
+        "created_at": float(row["created_at"]),
+        "idempotent": idempotent,
+    }
+
+
+def create_room(
+    db_path: Path | str,
+    *,
+    room_id: Any,
+    name: Any,
+    members: Any,
+    authority_gateway_id: Any,
+    now: float | None = None,
+) -> dict[str, Any]:
+    """Create a room, or return the identical existing room idempotently."""
+    room_id = _validate_identifier(
+        room_id,
+        label="room_id",
+        max_chars=MAX_ROOM_ID_CHARS,
+    )
+    name = _validate_room_name(name)
+    normalized_members, members_json = _validate_members(members)
+    authority_gateway_id = _validate_identifier(
+        authority_gateway_id,
+        label="authority_gateway_id",
+        max_chars=MAX_ACTOR_ID_CHARS,
+    )
+    now = time.time() if now is None else float(now)
+
+    with _transaction(db_path, immediate=True) as conn:
+        existing = conn.execute(
+            """SELECT room_id, name, members_json, authority_gateway_id,
+                      authority_epoch, next_seq, revision, created_at, updated_at,
+                      disbanded_at
+               FROM hosted_rooms WHERE room_id=?""",
+            (room_id,),
+        ).fetchone()
+        if existing is not None:
+            if existing["disbanded_at"] is not None:
+                raise RoomConflictError("room_id belongs to a disbanded room")
+            if existing["name"] != name or existing["members_json"] != members_json:
+                raise RoomConflictError("room_id already exists with different state")
+            if (
+                existing["authority_gateway_id"] == "legacy"
+                and authority_gateway_id != "legacy"
+            ):
+                target_epoch = int(existing["authority_epoch"]) + 1
+                seq = int(existing["next_seq"])
+                claim_actor_json = _canonical_json(
+                    {"kind": "system", "id": "authority-control"},
+                    label="actor",
+                    max_bytes=4 * 1024,
+                )
+                claim_payload_json = _canonical_json(
+                    {
+                        "previous_gateway_id": "legacy",
+                        "authority_gateway_id": authority_gateway_id,
+                        "authority_epoch": target_epoch,
+                    },
+                    label="payload",
+                    max_bytes=MAX_EVENT_JSON_BYTES,
+                )
+                conn.execute(
+                    """INSERT INTO hosted_room_events
+                       (room_id, seq, event_id, kind, actor_json,
+                        authority_epoch, payload_json, created_at)
+                       VALUES (?, ?, 'system:authority-adopted',
+                               'authority.claimed', ?, ?, ?, ?)""",
+                    (
+                        room_id,
+                        seq,
+                        claim_actor_json,
+                        target_epoch,
+                        claim_payload_json,
+                        now,
+                    ),
+                )
+                adopted = conn.execute(
+                    """UPDATE hosted_rooms
+                          SET authority_gateway_id=?, authority_epoch=?,
+                              next_seq=next_seq+1, revision=revision+1,
+                              updated_at=?
+                        WHERE room_id=? AND authority_gateway_id='legacy'
+                          AND authority_epoch=? AND next_seq=?
+                          AND disbanded_at IS NULL""",
+                    (
+                        authority_gateway_id,
+                        target_epoch,
+                        now,
+                        room_id,
+                        int(existing["authority_epoch"]),
+                        seq,
+                    ),
+                )
+                if adopted.rowcount != 1:
+                    raise AuthorityConflictError("legacy room adoption lost its fence")
+                existing = conn.execute(
+                    """SELECT room_id, name, members_json, authority_gateway_id,
+                              authority_epoch, next_seq, revision, created_at,
+                              updated_at, disbanded_at
+                         FROM hosted_rooms WHERE room_id=?""",
+                    (room_id,),
+                ).fetchone()
+                if existing is None:  # pragma: no cover - row updated above
+                    raise RuntimeError("adopted room could not be reloaded")
+                result = _room_from_row(existing, idempotent=True)
+                result["adopted"] = True
+                claim_event = conn.execute(
+                    """SELECT room_id, seq, event_id, kind, actor_json,
+                              authority_epoch, payload_json, created_at
+                         FROM hosted_room_events
+                        WHERE room_id=? AND event_id='system:authority-adopted'""",
+                    (room_id,),
+                ).fetchone()
+                if claim_event is None:  # pragma: no cover - inserted above
+                    raise RuntimeError("legacy adoption event could not be reloaded")
+                result["claim_event"] = _event_from_row(claim_event)
+                return result
+            if existing["authority_gateway_id"] != authority_gateway_id:
+                raise RoomConflictError(
+                    "room_id already belongs to a different authority"
+                )
+            return _room_from_row(existing, idempotent=True)
+
+        conn.execute(
+            """INSERT INTO hosted_rooms
+               (room_id, name, members_json, authority_gateway_id,
+                authority_epoch, next_seq, revision,
+                created_at, updated_at, disbanded_at)
+               VALUES (?, ?, ?, ?, 1, 1, 1, ?, ?, NULL)""",
+            (room_id, name, members_json, authority_gateway_id, now, now),
+        )
+        row = conn.execute(
+            """SELECT room_id, name, members_json, authority_gateway_id,
+                      authority_epoch, revision, created_at, updated_at
+               FROM hosted_rooms WHERE room_id=?""",
+            (room_id,),
+        ).fetchone()
+        if row is None:  # pragma: no cover - guarded by the insert above
+            raise RuntimeError("created room could not be reloaded")
+    result = _room_from_row(row)
+    result["members"] = normalized_members
+    return result
+
+
+def list_rooms(
+    db_path: Path | str,
+    *,
+    include_disbanded: bool = False,
+) -> list[dict[str, Any]]:
+    """Return hosted rooms ordered by most recent change."""
+    with _transaction(db_path) as conn:
+        rows = conn.execute(
+            """SELECT room_id, name, members_json, authority_gateway_id,
+                      authority_epoch, next_seq, revision, created_at, updated_at,
+                      disbanded_at
+               FROM hosted_rooms
+               WHERE disbanded_at IS NULL OR ?
+               ORDER BY updated_at DESC, room_id ASC""",
+            (int(include_disbanded),),
+        ).fetchall()
+    return [_room_from_row(row) for row in rows]
+
+
+def append_event(
+    db_path: Path | str,
+    *,
+    room_id: Any,
+    event_id: Any,
+    kind: Any,
+    actor: Any,
+    payload: Any,
+    authority_gateway_id: Any = None,
+    authority_epoch: Any = None,
+    now: float | None = None,
+) -> dict[str, Any]:
+    """Append one immutable event and allocate its per-room sequence atomically.
+
+    Repeating the same ``event_id`` and immutable content returns the original
+    event. Reusing the id for different content fails closed.
+    """
+    room_id = _validate_identifier(
+        room_id,
+        label="room_id",
+        max_chars=MAX_ROOM_ID_CHARS,
+    )
+    event_id = _validate_identifier(
+        event_id,
+        label="event_id",
+        max_chars=MAX_EVENT_ID_CHARS,
+    )
+    kind = _validate_event_kind(kind)
+    normalized_actor, actor_json = _validate_actor(actor, kind=kind)
+    authority_scoped = normalized_actor["kind"] in {"member", "gateway", "system"}
+    normalized_authority_gateway_id: str | None = None
+    normalized_authority_epoch: int | None = None
+    if authority_scoped:
+        normalized_authority_gateway_id = _validate_identifier(
+            authority_gateway_id,
+            label="authority_gateway_id",
+            max_chars=MAX_ACTOR_ID_CHARS,
+        )
+        if (
+            normalized_actor["kind"] == "gateway"
+            and normalized_actor["id"] != normalized_authority_gateway_id
+        ):
+            raise HostedRoomError("gateway actor.id must match authority_gateway_id")
+        if (
+            isinstance(authority_epoch, bool)
+            or not isinstance(authority_epoch, int)
+            or authority_epoch < 1
+        ):
+            raise HostedRoomError("authority_epoch must be a positive integer")
+        normalized_authority_epoch = authority_epoch
+    elif authority_gateway_id is not None or authority_epoch is not None:
+        raise HostedRoomError(
+            "authority fields are only valid for member, gateway, or system events"
+        )
+    if not isinstance(payload, dict):
+        raise HostedRoomError("payload must be an object")
+    payload_json = _canonical_json(
+        payload,
+        label="payload",
+        max_bytes=MAX_EVENT_JSON_BYTES,
+    )
+    now = time.time() if now is None else float(now)
+
+    with _transaction(db_path, immediate=True) as conn:
+        existing = conn.execute(
+            """SELECT room_id, seq, event_id, kind, actor_json, authority_epoch,
+                      payload_json, created_at
+               FROM hosted_room_events WHERE room_id=? AND event_id=?""",
+            (room_id, event_id),
+        ).fetchone()
+        if existing is not None:
+            if (
+                existing["kind"] != kind
+                or existing["actor_json"] != actor_json
+                or existing["authority_epoch"] != normalized_authority_epoch
+                or existing["payload_json"] != payload_json
+            ):
+                raise EventConflictError(
+                    "event_id already exists with different content"
+                )
+            return _event_from_row(existing, idempotent=True)
+
+        room = conn.execute(
+            """SELECT next_seq, authority_gateway_id, authority_epoch
+                  FROM hosted_rooms
+               WHERE room_id=? AND disbanded_at IS NULL""",
+            (room_id,),
+        ).fetchone()
+        if room is None:
+            raise RoomNotFoundError("hosted room not found")
+        if authority_scoped and (
+            room["authority_gateway_id"] != normalized_authority_gateway_id
+            or int(room["authority_epoch"]) != normalized_authority_epoch
+        ):
+            raise AuthorityConflictError("stale hosted room authority")
+        seq = int(room["next_seq"])
+        conn.execute(
+            """INSERT INTO hosted_room_events
+               (room_id, seq, event_id, kind, actor_json, authority_epoch,
+                payload_json, created_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                room_id,
+                seq,
+                event_id,
+                kind,
+                actor_json,
+                normalized_authority_epoch,
+                payload_json,
+                now,
+            ),
+        )
+        advanced = conn.execute(
+            """UPDATE hosted_rooms
+               SET next_seq=?, updated_at=?
+               WHERE room_id=? AND next_seq=?""",
+            (seq + 1, now, room_id, seq),
+        )
+        if advanced.rowcount != 1:
+            raise RuntimeError("hosted room sequence advance lost its write fence")
+        row = conn.execute(
+            """SELECT room_id, seq, event_id, kind, actor_json, authority_epoch,
+                      payload_json, created_at
+               FROM hosted_room_events WHERE room_id=? AND seq=?""",
+            (room_id, seq),
+        ).fetchone()
+        if row is None:  # pragma: no cover - guarded by the insert above
+            raise RuntimeError("appended event could not be reloaded")
+    result = _event_from_row(row)
+    result["actor"] = normalized_actor
+    return result
+
+
+def room_state(
+    db_path: Path | str,
+    *,
+    room_id: Any,
+    include_disbanded: bool = False,
+) -> dict[str, Any]:
+    """Return durable replay and authority state for one room."""
+    room_id = _validate_identifier(
+        room_id,
+        label="room_id",
+        max_chars=MAX_ROOM_ID_CHARS,
+    )
+    with _transaction(db_path) as conn:
+        row = conn.execute(
+            """SELECT room_id, name, members_json, authority_gateway_id,
+                      authority_epoch, next_seq, revision, created_at, updated_at,
+                      disbanded_at
+                 FROM hosted_rooms
+                WHERE room_id=? AND (disbanded_at IS NULL OR ?)""",
+            (room_id, int(include_disbanded)),
+        ).fetchone()
+        if row is None:
+            raise RoomNotFoundError("hosted room not found")
+        claim_row = conn.execute(
+            """SELECT room_id, seq, event_id, kind, actor_json, authority_epoch,
+                      payload_json, created_at
+                 FROM hosted_room_events
+                WHERE room_id=? AND kind='authority.claimed'
+                  AND authority_epoch=?
+                ORDER BY seq DESC LIMIT 1""",
+            (room_id, int(row["authority_epoch"])),
+        ).fetchone()
+    state = _room_from_row(row)
+    state["latest_seq"] = int(row["next_seq"]) - 1
+    if claim_row is not None:
+        state["authority_claim"] = _event_from_row(claim_row)
+    return state
+
+
+def claim_authority(
+    db_path: Path | str,
+    *,
+    room_id: Any,
+    expected_gateway_id: Any,
+    expected_epoch: Any,
+    new_gateway_id: Any,
+    event_id: Any,
+    now: float | None = None,
+) -> dict[str, Any]:
+    """Fence a verified authority transfer with a compare-and-swap epoch.
+
+    This storage primitive does not decide *when* takeover is safe. A future
+    replicated driver must call it only after its lease/quorum policy has
+    established that the previous owner can no longer commit.
+    """
+    room_id = _validate_identifier(
+        room_id,
+        label="room_id",
+        max_chars=MAX_ROOM_ID_CHARS,
+    )
+    expected_gateway_id = _validate_identifier(
+        expected_gateway_id,
+        label="expected_gateway_id",
+        max_chars=MAX_ACTOR_ID_CHARS,
+    )
+    new_gateway_id = _validate_identifier(
+        new_gateway_id,
+        label="new_gateway_id",
+        max_chars=MAX_ACTOR_ID_CHARS,
+    )
+    event_id = _validate_identifier(
+        event_id,
+        label="event_id",
+        max_chars=MAX_EVENT_ID_CHARS,
+    )
+    if (
+        isinstance(expected_epoch, bool)
+        or not isinstance(expected_epoch, int)
+        or expected_epoch < 1
+    ):
+        raise HostedRoomError("expected_epoch must be a positive integer")
+    now = time.time() if now is None else float(now)
+    target_epoch = expected_epoch + 1
+    claim_actor = {"kind": "system", "id": "authority-control"}
+    claim_actor_json = _canonical_json(
+        claim_actor,
+        label="actor",
+        max_bytes=4 * 1024,
+    )
+    claim_payload = {
+        "previous_gateway_id": expected_gateway_id,
+        "authority_gateway_id": new_gateway_id,
+        "authority_epoch": target_epoch,
+    }
+    claim_payload_json = _canonical_json(
+        claim_payload,
+        label="payload",
+        max_bytes=MAX_EVENT_JSON_BYTES,
+    )
+
+    with _transaction(db_path, immediate=True) as conn:
+        row = conn.execute(
+            """SELECT authority_gateway_id, authority_epoch, next_seq
+                 FROM hosted_rooms
+                WHERE room_id=? AND disbanded_at IS NULL""",
+            (room_id,),
+        ).fetchone()
+        if row is None:
+            raise RoomNotFoundError("hosted room not found")
+        current_gateway = str(row["authority_gateway_id"])
+        current_epoch = int(row["authority_epoch"])
+        existing_event = conn.execute(
+            """SELECT room_id, seq, event_id, kind, actor_json, authority_epoch,
+                      payload_json, created_at
+                 FROM hosted_room_events WHERE room_id=? AND event_id=?""",
+            (room_id, event_id),
+        ).fetchone()
+        if existing_event is not None:
+            if (
+                existing_event["kind"] != "authority.claimed"
+                or existing_event["actor_json"] != claim_actor_json
+                or existing_event["authority_epoch"] != target_epoch
+                or existing_event["payload_json"] != claim_payload_json
+            ):
+                raise EventConflictError(
+                    "event_id already exists with different content"
+                )
+            if current_gateway != new_gateway_id or current_epoch != target_epoch:
+                raise AuthoritySupersededError(
+                    "authority claim succeeded but was later superseded"
+                )
+            idempotent = True
+        elif current_gateway != expected_gateway_id or current_epoch != expected_epoch:
+            raise AuthorityConflictError("hosted room authority changed")
+        else:
+            seq = int(row["next_seq"])
+            conn.execute(
+                """INSERT INTO hosted_room_events
+                   (room_id, seq, event_id, kind, actor_json, authority_epoch,
+                    payload_json, created_at)
+                   VALUES (?, ?, ?, 'authority.claimed', ?, ?, ?, ?)""",
+                (
+                    room_id,
+                    seq,
+                    event_id,
+                    claim_actor_json,
+                    target_epoch,
+                    claim_payload_json,
+                    now,
+                ),
+            )
+            updated = conn.execute(
+                """UPDATE hosted_rooms
+                      SET authority_gateway_id=?, authority_epoch=authority_epoch+1,
+                          next_seq=next_seq+1, revision=revision+1, updated_at=?
+                    WHERE room_id=? AND disbanded_at IS NULL
+                      AND authority_gateway_id=? AND authority_epoch=?""",
+                (
+                    new_gateway_id,
+                    now,
+                    room_id,
+                    expected_gateway_id,
+                    expected_epoch,
+                ),
+            )
+            if updated.rowcount != 1:
+                raise AuthorityConflictError("hosted room authority changed")
+            idempotent = False
+            existing_event = conn.execute(
+                """SELECT room_id, seq, event_id, kind, actor_json,
+                          authority_epoch, payload_json, created_at
+                     FROM hosted_room_events WHERE room_id=? AND event_id=?""",
+                (room_id, event_id),
+            ).fetchone()
+        state_row = conn.execute(
+            """SELECT room_id, name, members_json, authority_gateway_id,
+                      authority_epoch, next_seq, revision, created_at, updated_at
+                 FROM hosted_rooms WHERE room_id=?""",
+            (room_id,),
+        ).fetchone()
+        if state_row is None:  # pragma: no cover - room exists in this transaction
+            raise RuntimeError("claimed room could not be reloaded")
+    state = _room_from_row(state_row, idempotent=idempotent)
+    state["latest_seq"] = int(state_row["next_seq"]) - 1
+    if existing_event is None:  # pragma: no cover - both claim paths set it
+        raise RuntimeError("authority claim event could not be reloaded")
+    state["claim_event"] = _event_from_row(
+        existing_event,
+        idempotent=idempotent,
+    )
+    return state
+
+
+def disband_room(
+    db_path: Path | str,
+    *,
+    room_id: Any,
+    now: float | None = None,
+) -> dict[str, Any]:
+    """Tombstone a room id permanently and idempotently."""
+    room_id = _validate_identifier(
+        room_id,
+        label="room_id",
+        max_chars=MAX_ROOM_ID_CHARS,
+    )
+    now = time.time() if now is None else float(now)
+
+    with _transaction(db_path, immediate=True) as conn:
+        room = conn.execute(
+            """SELECT authority_epoch, next_seq, disbanded_at
+                 FROM hosted_rooms WHERE room_id=?""",
+            (room_id,),
+        ).fetchone()
+        if room is None:
+            raise RoomNotFoundError("hosted room not found")
+        if room["disbanded_at"] is not None:
+            event = conn.execute(
+                """SELECT room_id, seq, event_id, kind, actor_json,
+                          authority_epoch, payload_json, created_at
+                     FROM hosted_room_events
+                    WHERE room_id=? AND event_id='system:room-disbanded'""",
+                (room_id,),
+            ).fetchone()
+            return {
+                "room_id": room_id,
+                "disbanded_at": float(room["disbanded_at"]),
+                "idempotent": True,
+                **(
+                    {"event": _event_from_row(event, idempotent=True)}
+                    if event is not None
+                    else {}
+                ),
+            }
+        seq = int(room["next_seq"])
+        actor_json = _canonical_json(
+            {"kind": "system", "id": "room-control"},
+            label="actor",
+            max_bytes=4 * 1024,
+        )
+        payload_json = _canonical_json(
+            {"room_id": room_id},
+            label="payload",
+            max_bytes=MAX_EVENT_JSON_BYTES,
+        )
+        conn.execute(
+            """INSERT INTO hosted_room_events
+               (room_id, seq, event_id, kind, actor_json, authority_epoch,
+                payload_json, created_at)
+               VALUES (?, ?, 'system:room-disbanded', 'room.disbanded', ?, ?, ?, ?)""",
+            (
+                room_id,
+                seq,
+                actor_json,
+                int(room["authority_epoch"]),
+                payload_json,
+                now,
+            ),
+        )
+        updated = conn.execute(
+            """UPDATE hosted_rooms
+               SET disbanded_at=?, updated_at=?, revision=revision+1,
+                   next_seq=next_seq+1
+               WHERE room_id=? AND disbanded_at IS NULL""",
+            (now, now, room_id),
+        )
+        if updated.rowcount != 1:
+            raise RoomConflictError("hosted room disband lost its fence")
+        event = conn.execute(
+            """SELECT room_id, seq, event_id, kind, actor_json,
+                      authority_epoch, payload_json, created_at
+                 FROM hosted_room_events
+                WHERE room_id=? AND event_id='system:room-disbanded'""",
+            (room_id,),
+        ).fetchone()
+        if event is None:  # pragma: no cover - inserted in this transaction
+            raise RuntimeError("room disband event could not be reloaded")
+    return {
+        "room_id": room_id,
+        "disbanded_at": now,
+        "idempotent": False,
+        "event": _event_from_row(event),
+    }
+
+
+def read_events(
+    db_path: Path | str,
+    *,
+    room_id: Any,
+    since_seq: Any = 0,
+    limit: Any = 100,
+    include_disbanded: bool = False,
+) -> dict[str, Any]:
+    """Read a monotonic room-log delta after ``since_seq``."""
+    room_id = _validate_identifier(
+        room_id,
+        label="room_id",
+        max_chars=MAX_ROOM_ID_CHARS,
+    )
+    if isinstance(since_seq, bool) or not isinstance(since_seq, int) or since_seq < 0:
+        raise HostedRoomError("since_seq must be a non-negative integer")
+    if (
+        isinstance(limit, bool)
+        or not isinstance(limit, int)
+        or not 1 <= limit <= MAX_LOG_LIMIT
+    ):
+        raise HostedRoomError(f"limit must be between 1 and {MAX_LOG_LIMIT}")
+
+    with _transaction(db_path) as conn:
+        room = conn.execute(
+            """SELECT next_seq FROM hosted_rooms
+               WHERE room_id=? AND (disbanded_at IS NULL OR ?)""",
+            (room_id, int(include_disbanded)),
+        ).fetchone()
+        if room is None:
+            raise RoomNotFoundError("hosted room not found")
+        latest_seq = int(room["next_seq"]) - 1
+        if since_seq > latest_seq:
+            raise HostedRoomError("since_seq is ahead of the hosted room log")
+        rows = conn.execute(
+            """SELECT room_id, seq, event_id, kind, actor_json, authority_epoch,
+                      payload_json, created_at
+               FROM hosted_room_events
+               WHERE room_id=? AND seq>?
+               ORDER BY seq ASC LIMIT ?""",
+            (room_id, since_seq, limit),
+        ).fetchall()
+    events = [_event_from_row(row) for row in rows]
+    cursor = events[-1]["seq"] if events else since_seq
+    return {
+        "events": events,
+        "cursor": cursor,
+        "latest_seq": latest_seq,
+        "has_more": cursor < latest_seq,
+    }

--- a/gateway/relay/ws_transport.py
+++ b/gateway/relay/ws_transport.py
@@ -289,6 +289,7 @@ def _event_from_wire(raw: Dict[str, Any]) -> MessageEvent:
         scope_id=src.get("scope_id"),
         parent_chat_id=src.get("parent_chat_id"),
         message_id=src.get("message_id"),
+        is_bot=bool(src.get("is_bot", False)),
         # The HERMES profile this event is routed to (multiplex mode). The
         # connector stamps it on the wire source when NAS resolves the target
         # profile for a Team-Gateway message; absent for a single-profile
@@ -336,6 +337,7 @@ def _event_from_wire(raw: Dict[str, Any]) -> MessageEvent:
         text=text,
         message_type=msg_type,
         source=source,
+        metadata={"relay_author_classified": "is_bot" in src},
         message_id=raw.get("message_id"),
         reply_to_message_id=raw.get("reply_to_message_id"),
         # Richer quoted-reply context (Phase 4): what the user replied TO,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16926,7 +16926,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "agents": self._handle_agents_command,
                 "background": self._handle_background_command,
                 "kanban": self._handle_kanban_command,
-                "rooms": self._handle_rooms_command,
+                "group": self._handle_rooms_command,
                 "subgoal": self._handle_subgoal_command,
                 "heartbeat": self._handle_heartbeat_command,
                 "yolo": self._handle_yolo_command,
@@ -18093,7 +18093,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if canonical == "agents":
             return await self._handle_agents_command(event)
 
-        if canonical == "rooms":
+        if canonical == "group":
             return await self._handle_rooms_command(event)
 
         if canonical == "platform":

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16926,6 +16926,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "agents": self._handle_agents_command,
                 "background": self._handle_background_command,
                 "kanban": self._handle_kanban_command,
+                "rooms": self._handle_rooms_command,
                 "subgoal": self._handle_subgoal_command,
                 "heartbeat": self._handle_heartbeat_command,
                 "yolo": self._handle_yolo_command,
@@ -18091,6 +18092,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         if canonical == "agents":
             return await self._handle_agents_command(event)
+
+        if canonical == "rooms":
+            return await self._handle_rooms_command(event)
 
         if canonical == "platform":
             return await self._handle_platform_command(event)

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -251,7 +251,7 @@ class SessionSource:
         return ", ".join(parts)
     
     def to_dict(self) -> Dict[str, Any]:
-        d = {
+        d: Dict[str, Any] = {
             "platform": self.platform.value,
             "chat_id": self.chat_id,
             "chat_name": self.chat_name,
@@ -260,6 +260,7 @@ class SessionSource:
             "user_name": self.user_name,
             "thread_id": self.thread_id,
             "chat_topic": self.chat_topic,
+            "is_bot": self.is_bot,
         }
         if self.user_id_alt:
             d["user_id_alt"] = self.user_id_alt
@@ -305,6 +306,7 @@ class SessionSource:
             scope_id=data.get("scope_id", data.get("guild_id")),
             parent_chat_id=data.get("parent_chat_id"),
             message_id=data.get("message_id"),
+            is_bot=bool(data.get("is_bot", False)),
             profile=data.get("profile"),
             auto_thread_created=bool(data.get("auto_thread_created", False)),
             auto_thread_initial_name=data.get("auto_thread_initial_name"),

--- a/gateway/slash_access.py
+++ b/gateway/slash_access.py
@@ -222,8 +222,47 @@ def policy_for_source(gateway_config: Any, source: Any) -> SlashAccessPolicy:
     return policy_from_extra(extra, scope)
 
 
+def is_home_dm_source(gateway_config: Any, source: Any) -> bool:
+    """Return whether *source* is the gateway's configured home DM.
+
+    The home chat is the operator-selected control surface (``/sethome``).
+    Matching it here avoids making that same operator maintain a second
+    slash-admin allowlist for owner-only controls.  Groups never inherit this
+    authority, and stored relay provenance must still match when present.
+    """
+    if gateway_config is None or source is None:
+        return False
+    if _scope_for_chat_type(getattr(source, "chat_type", None)) != "dm":
+        return False
+    if getattr(source, "is_bot", False) is True:
+        return False
+
+    platform = getattr(source, "platform", None)
+    user_id = getattr(source, "user_id", None)
+    chat_id = getattr(source, "chat_id", None)
+    if platform is None or not user_id or not chat_id:
+        return False
+
+    try:
+        home = gateway_config.get_home_channel(platform)
+    except Exception:
+        return False
+    if home is None or str(home.chat_id) != str(chat_id):
+        return False
+
+    home_user_id = getattr(home, "user_id", None)
+    if home_user_id and str(home_user_id) != str(user_id):
+        return False
+    home_scope_id = getattr(home, "scope_id", None)
+    source_scope_id = getattr(source, "scope_id", None)
+    if home_scope_id and str(home_scope_id) != str(source_scope_id or ""):
+        return False
+    return True
+
+
 __all__ = [
     "SlashAccessPolicy",
     "policy_from_extra",
     "policy_for_source",
+    "is_home_dm_source",
 ]

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -573,8 +573,117 @@ class GatewaySlashCommandsMixin:
             output = output[:3800] + "\n" + t("gateway.kanban.truncated_suffix")
         return output or t("gateway.kanban.no_output")
 
+    def _home_dm_is_single_operator(self, event: MessageEvent) -> bool:
+        """Recognize the sole authorized operator's configured home DM."""
+        from gateway.authz_mixin import (
+            _auth_env,
+            _coerce_allow_set,
+            _platform_authorization_env_names,
+        )
+        from gateway.slash_access import is_home_dm_source
+
+        source = event.source
+        if getattr(source, "delivered_via_upstream_relay", False) is True:
+            return False
+        if not is_home_dm_source(self.config, source):
+            return False
+
+        is_authorized = getattr(self, "_is_user_authorized_for_source", None)
+        if not callable(is_authorized):
+            return False
+        try:
+            if not is_authorized(source):
+                return False
+        except Exception:
+            return False
+
+        def _census() -> bool:
+            platform_name = source.platform.value
+            allowed_users_env, allow_all_env = _platform_authorization_env_names(
+                source.platform
+            )
+            candidates: set[str] = set()
+            adapter_for_source = getattr(self, "_adapter_for_source", None)
+            transport_adapter = (
+                adapter_for_source(source) if callable(adapter_for_source) else None
+            )
+            adapter_config = getattr(transport_adapter, "config", None)
+            adapter_extra = getattr(adapter_config, "extra", None)
+            if transport_adapter is not None:
+                extra = adapter_extra if isinstance(adapter_extra, dict) else {}
+            else:
+                platform_config = self.config.platforms.get(source.platform)
+                extra = getattr(platform_config, "extra", None) or {}
+            candidates.update(_coerce_allow_set(extra.get("allow_from")))
+            candidates.update(_coerce_allow_set(_auth_env(allowed_users_env)))
+            candidates.update(_coerce_allow_set(_auth_env("GATEWAY_ALLOWED_USERS")))
+            if _auth_env("GATEWAY_ALLOW_ALL_USERS").lower() in {
+                "true",
+                "1",
+                "yes",
+            }:
+                return False
+            if allow_all_env and _auth_env(allow_all_env).lower() in {
+                "true",
+                "1",
+                "yes",
+            }:
+                return False
+
+            authorization_home = getattr(
+                source,
+                "_authorization_profile_home",
+                None,
+            )
+            if authorization_home is not None:
+                pairing_store = getattr(self, "pairing_store", None)
+            else:
+                pairing_store_for = getattr(self, "_pairing_store_for", None)
+                pairing_store = (
+                    pairing_store_for(source)
+                    if callable(pairing_store_for)
+                    else None
+                )
+            if pairing_store is not None:
+                try:
+                    candidates.update(
+                        str(row.get("user_id") or "").strip()
+                        for row in pairing_store.list_approved(platform_name)
+                        if str(row.get("user_id") or "").strip()
+                    )
+                except Exception:
+                    return False
+            if not candidates or "*" in candidates:
+                return False
+
+            user_id = str(source.user_id)
+            matcher = getattr(pairing_store, "_user_ids_match", None)
+            if callable(matcher):
+                return all(
+                    matcher(platform_name, candidate, user_id)
+                    for candidate in candidates
+                )
+            return candidates == {user_id}
+
+        authorization_home = getattr(source, "_authorization_profile_home", None)
+        if authorization_home is None:
+            return _census()
+        from gateway.run import _profile_runtime_scope
+
+        with _profile_runtime_scope(Path(authorization_home)):
+            return _census()
+
+    def _can_control_group_chats(self, event: MessageEvent) -> bool:
+        """Authorize explicit admins or the sole operator's home DM."""
+        from gateway.slash_access import policy_for_source
+
+        policy = policy_for_source(self.config, event.source)
+        return (
+            policy.enabled and policy.is_admin(event.source.user_id)
+        ) or self._home_dm_is_single_operator(event)
+
     async def _handle_rooms_command(self, event: MessageEvent) -> str:
-        """List hosted Bot rooms or show one room's recent activity."""
+        """List Bot Group Chats or show one chat's recent activity."""
 
         from gateway import hosted_rooms
         from gateway.hosted_room_messaging import (
@@ -590,19 +699,16 @@ class GatewaySlashCommandsMixin:
         )
 
         if is_machine_authored(event):
-            return "Hosted Bot room controls are only available to people."
+            return "Group Chat controls are only available to people."
         if relay_provenance_is_unknown(event):
             return (
-                "Room controls need a relay connector that reports whether the "
+                "Group Chat controls need a relay connector that reports whether the "
                 "sender is a person or a bot. Update the connector and try again."
             )
-        from gateway.slash_access import policy_for_source
-
-        policy = policy_for_source(self.config, event.source)
-        if not policy.enabled or not policy.is_admin(event.source.user_id):
+        if not self._can_control_group_chats(event):
             return (
-                "Room controls are off for this chat. Add your user ID to this "
-                "channel’s admin list, then try again."
+                "This chat can’t control Group Chats. Use the gateway’s home DM or "
+                "add your user ID to this chat’s admin list."
             )
         service = current_room_backend()
         rooms_command = command_form(event)
@@ -624,9 +730,15 @@ class GatewaySlashCommandsMixin:
                     exact_name,
                     room_command=rooms_command,
                 )
-            if query.partition(" ")[0].casefold() in {"send", "stop"}:
+            words = query.split()
+            if (
+                words
+                and words[0].isdecimal()
+                and len(words) > 1
+                and words[1].casefold() in {"send", "stop"}
+            ):
                 return await self._handle_room_command(event)
-            if not query:
+            if not query or query.casefold() == "list":
                 return await asyncio.to_thread(
                     format_room_list,
                     service,
@@ -645,11 +757,11 @@ class GatewaySlashCommandsMixin:
         except (RoomControlError, hosted_rooms.HostedRoomError) as exc:
             return str(exc)
         except Exception:
-            logger.exception("Failed to read hosted Bot rooms from messaging")
-            return "Couldn’t load hosted Bot rooms. Try again in a moment."
+            logger.exception("Failed to read Bot Group Chats from messaging")
+            return "Couldn’t load Group Chats. Try again in a moment."
 
     async def _handle_room_command(self, event: MessageEvent) -> str:
-        """Send to or stop work in a hosted Bot room."""
+        """Send to or stop work in a Bot Group Chat."""
 
         from gateway import hosted_rooms
         from gateway.hosted_room_messaging import (
@@ -665,20 +777,17 @@ class GatewaySlashCommandsMixin:
             list_messaging_rooms,
             relay_provenance_is_unknown,
         )
-        from gateway.slash_access import policy_for_source
-
         if is_machine_authored(event):
-            return "Hosted Bot room controls are only available to people."
+            return "Group Chat controls are only available to people."
         if relay_provenance_is_unknown(event):
             return (
-                "Room controls need a relay connector that reports whether the "
+                "Group Chat controls need a relay connector that reports whether the "
                 "sender is a person or a bot. Update the connector and try again."
             )
-        policy = policy_for_source(self.config, event.source)
-        if not policy.enabled or not policy.is_admin(event.source.user_id):
+        if not self._can_control_group_chats(event):
             return (
-                "Room controls are off for this chat. Add your user ID to this "
-                "channel’s admin list, then try again."
+                "This chat can’t control Group Chats. Use the gateway’s home DM or "
+                "add your user ID to this chat’s admin list."
             )
         service = current_room_backend()
         rooms_command = command_form(event)
@@ -690,10 +799,10 @@ class GatewaySlashCommandsMixin:
             if not command.room_query.isdecimal():
                 if command.action == "send":
                     raise RoomControlError(
-                        f"Use `{rooms_command} send <room number> -- <message>`."
+                        f"Use `{rooms_command} <room number> send <message>`."
                     )
                 raise RoomControlError(
-                    f"Use `{rooms_command} stop <room number>`."
+                    f"Use `{rooms_command} <room number> stop`."
                 )
 
             def _mutate() -> str:

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -573,6 +573,147 @@ class GatewaySlashCommandsMixin:
             output = output[:3800] + "\n" + t("gateway.kanban.truncated_suffix")
         return output or t("gateway.kanban.no_output")
 
+    async def _handle_rooms_command(self, event: MessageEvent) -> str:
+        """List hosted Bot rooms or show one room's recent activity."""
+
+        from gateway import hosted_rooms
+        from gateway.hosted_room_messaging import (
+            RoomControlError,
+            command_form,
+            current_room_backend,
+            format_room_detail,
+            format_room_list,
+            is_machine_authored,
+            list_messaging_rooms,
+            relay_provenance_is_unknown,
+            resolve_room,
+        )
+
+        if is_machine_authored(event):
+            return "Hosted Bot room controls are only available to people."
+        if relay_provenance_is_unknown(event):
+            return (
+                "Room controls need a relay connector that reports whether the "
+                "sender is a person or a bot. Update the connector and try again."
+            )
+        from gateway.slash_access import policy_for_source
+
+        policy = policy_for_source(self.config, event.source)
+        if not policy.enabled or not policy.is_admin(event.source.user_id):
+            return (
+                "Room controls are off for this chat. Add your user ID to this "
+                "channel’s admin list, then try again."
+            )
+        service = current_room_backend()
+        rooms_command = command_form(event)
+        query = event.get_command_args().strip()
+        try:
+            rooms = list_messaging_rooms(service)
+            exact_name = next(
+                (
+                    room
+                    for room in rooms
+                    if str(room.get("name") or "").casefold() == query.casefold()
+                ),
+                None,
+            )
+            if exact_name is not None:
+                return await asyncio.to_thread(
+                    format_room_detail,
+                    service,
+                    exact_name,
+                    room_command=rooms_command,
+                )
+            if query.partition(" ")[0].casefold() in {"send", "stop"}:
+                return await self._handle_room_command(event)
+            if not query:
+                return await asyncio.to_thread(
+                    format_room_list,
+                    service,
+                    rooms_command=rooms_command,
+                )
+
+            def _detail() -> str:
+                room = resolve_room(rooms, query)
+                return format_room_detail(
+                    service,
+                    room,
+                    room_command=rooms_command,
+                )
+
+            return await asyncio.to_thread(_detail)
+        except (RoomControlError, hosted_rooms.HostedRoomError) as exc:
+            return str(exc)
+        except Exception:
+            logger.exception("Failed to read hosted Bot rooms from messaging")
+            return "Couldn’t load hosted Bot rooms. Try again in a moment."
+
+    async def _handle_room_command(self, event: MessageEvent) -> str:
+        """Send to or stop work in a hosted Bot room."""
+
+        from gateway import hosted_rooms
+        from gateway.hosted_room_messaging import (
+            RoomControlError,
+            command_form,
+            current_room_backend,
+            parse_room_command,
+            resolve_room,
+            room_reference,
+            send_to_room,
+            stop_room,
+            is_machine_authored,
+            list_messaging_rooms,
+            relay_provenance_is_unknown,
+        )
+        from gateway.slash_access import policy_for_source
+
+        if is_machine_authored(event):
+            return "Hosted Bot room controls are only available to people."
+        if relay_provenance_is_unknown(event):
+            return (
+                "Room controls need a relay connector that reports whether the "
+                "sender is a person or a bot. Update the connector and try again."
+            )
+        policy = policy_for_source(self.config, event.source)
+        if not policy.enabled or not policy.is_admin(event.source.user_id):
+            return (
+                "Room controls are off for this chat. Add your user ID to this "
+                "channel’s admin list, then try again."
+            )
+        service = current_room_backend()
+        rooms_command = command_form(event)
+        try:
+            command = parse_room_command(
+                event.get_command_args(),
+                command_root=rooms_command,
+            )
+            if not command.room_query.isdecimal():
+                if command.action == "send":
+                    raise RoomControlError(
+                        f"Use `{rooms_command} send <room number> -- <message>`."
+                    )
+                raise RoomControlError(
+                    f"Use `{rooms_command} stop <room number>`."
+                )
+
+            def _mutate() -> str:
+                room = resolve_room(
+                    list_messaging_rooms(service),
+                    command.room_query,
+                )
+                if command.action == "send":
+                    result = send_to_room(service, room, event, command.message)
+                    return f"{result} Check: `{rooms_command} {room_reference(room)}`."
+                result = stop_room(service, room, event)
+                return f"{result} Check: `{rooms_command} {room_reference(room)}`."
+
+            return await asyncio.to_thread(_mutate)
+        except (RoomControlError, hosted_rooms.HostedRoomError) as exc:
+            return str(exc)
+        except Exception:
+            logger.exception("Failed to control hosted Bot room from messaging")
+            return "Couldn’t update that Bot room. Try again in a moment."
+
     async def _handle_status_command(self, event: MessageEvent) -> str:
         """Handle /status command."""
         from gateway.run import _AGENT_PENDING_SENTINEL, _load_gateway_config, _resolve_gateway_model

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -193,6 +193,10 @@ COMMAND_REGISTRY: list[CommandDef] = [
                aliases=("bg", "btw"), args_hint="<prompt>", busy_policy="dispatch"),
     CommandDef("agents", "Show active agents and running tasks", "Session",
                aliases=("tasks",), busy_policy="dispatch"),
+    CommandDef("rooms", "List, inspect, or control hosted Bot rooms", "Bots",
+               gateway_only=True,
+               args_hint="[room name | send room -- message | stop room]",
+               subcommands=("send", "stop"), busy_policy="dispatch"),
     CommandDef("journey", "Open the learning journey timeline",
                "Session", aliases=("learning", "memory-graph"), cli_only=True,
                args_hint="[list|delete <id>|edit <id>]",
@@ -1368,7 +1372,7 @@ _SLACK_PRIORITY_ALIASES = ("btw", "bg")
 #     (session export is an interactive surface; platform is a rare
 #     informational lookup) — without this entry /save tips the registry
 #     past the 50-cap and silently clamps /platform, breaking parity.
-_SLACK_VIA_HERMES_ONLY = frozenset({"topup", "moa", "debug", "egress", "init", "version", "diff", "update", "heartbeat", "refine", "review", "pause", "whoami", "platform"})
+_SLACK_VIA_HERMES_ONLY = frozenset({"topup", "moa", "debug", "egress", "init", "version", "diff", "update", "heartbeat", "refine", "review", "pause", "whoami", "platform", "rooms"})
 
 
 def _sanitize_slack_name(raw: str) -> str:

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -193,10 +193,10 @@ COMMAND_REGISTRY: list[CommandDef] = [
                aliases=("bg", "btw"), args_hint="<prompt>", busy_policy="dispatch"),
     CommandDef("agents", "Show active agents and running tasks", "Session",
                aliases=("tasks",), busy_policy="dispatch"),
-    CommandDef("rooms", "List, inspect, or control hosted Bot rooms", "Bots",
+    CommandDef("group", "List, inspect, or control Bot Group Chats", "Bots",
                gateway_only=True,
-               args_hint="[room name | send room -- message | stop room]",
-               subcommands=("send", "stop"), busy_policy="dispatch"),
+               args_hint="[list | number | number send message | number stop]",
+               busy_policy="dispatch"),
     CommandDef("journey", "Open the learning journey timeline",
                "Session", aliases=("learning", "memory-graph"), cli_only=True,
                args_hint="[list|delete <id>|edit <id>]",
@@ -1372,7 +1372,7 @@ _SLACK_PRIORITY_ALIASES = ("btw", "bg")
 #     (session export is an interactive surface; platform is a rare
 #     informational lookup) — without this entry /save tips the registry
 #     past the 50-cap and silently clamps /platform, breaking parity.
-_SLACK_VIA_HERMES_ONLY = frozenset({"topup", "moa", "debug", "egress", "init", "version", "diff", "update", "heartbeat", "refine", "review", "pause", "whoami", "platform", "rooms"})
+_SLACK_VIA_HERMES_ONLY = frozenset({"topup", "moa", "debug", "egress", "init", "version", "diff", "update", "heartbeat", "refine", "review", "pause", "whoami", "platform", "group"})
 
 
 def _sanitize_slack_name(raw: str) -> str:

--- a/hermes_cli/install_identity.py
+++ b/hermes_cli/install_identity.py
@@ -1,0 +1,149 @@
+"""Stable opaque identity shared by every profile in one Hermes install."""
+
+from __future__ import annotations
+
+import contextlib
+import os
+from pathlib import Path
+import re
+import tempfile
+import threading
+from typing import Optional
+import uuid
+
+from hermes_constants import get_default_hermes_root
+
+_INSTALL_ID_FILENAME = "install_id"
+_INSTALL_ID_RE = re.compile(r"^[0-9a-f]{32}$")
+_INSTALL_ID_CACHE: dict[str, Optional[str]] = {"root": None, "value": None}
+_INSTALL_ID_LOCK = threading.Lock()
+
+
+@contextlib.contextmanager
+def _install_id_file_lock(root: Path):
+    """Serialize identity publication across processes on POSIX and Windows."""
+    lock_path = root / ".install_id.lock"
+    fd = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o600)
+    windows = os.name == "nt"
+    try:
+        if windows:
+            import msvcrt
+
+            if os.fstat(fd).st_size == 0:
+                os.write(fd, b"\0")
+                os.fsync(fd)
+            os.lseek(fd, 0, os.SEEK_SET)
+            msvcrt.locking(fd, msvcrt.LK_LOCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(fd, fcntl.LOCK_EX)
+        yield
+    finally:
+        try:
+            if windows:
+                import msvcrt
+
+                os.lseek(fd, 0, os.SEEK_SET)
+                msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+            else:
+                import fcntl
+
+                fcntl.flock(fd, fcntl.LOCK_UN)
+        finally:
+            os.close(fd)
+
+
+def _fsync_directory(path: Path) -> None:
+    """Best-effort durability for the directory entry after replace."""
+    if os.name == "nt":
+        return
+    try:
+        fd = os.open(path, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+    except OSError:
+        return
+    try:
+        os.fsync(fd)
+    except OSError:
+        pass
+    finally:
+        os.close(fd)
+
+
+def read_or_create_install_id(root: Path | None = None) -> Optional[str]:
+    """Read or atomically mint the opaque id for the physical install.
+
+    ``None`` means the id could neither be read nor persisted. Returning an
+    ephemeral id would violate the authority and connection-registry contract.
+    """
+    root = get_default_hermes_root() if root is None else root
+    path = root / _INSTALL_ID_FILENAME
+    try:
+        existing = path.read_text(encoding="utf-8").strip().lower()
+        if _INSTALL_ID_RE.fullmatch(existing):
+            return existing
+    except FileNotFoundError:
+        pass
+    except (OSError, UnicodeDecodeError):
+        return None
+
+    try:
+        root.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        return None
+
+    try:
+        with _install_id_file_lock(root):
+            try:
+                existing = path.read_text(encoding="utf-8").strip().lower()
+                if _INSTALL_ID_RE.fullmatch(existing):
+                    return existing
+            except FileNotFoundError:
+                pass
+            except (OSError, UnicodeDecodeError):
+                return None
+
+            minted = uuid.uuid4().hex
+            fd, tmp_name = tempfile.mkstemp(dir=str(root), prefix=".install_id-")
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                    handle.write(minted + "\n")
+                    handle.flush()
+                    os.fsync(handle.fileno())
+                os.replace(tmp_name, path)
+                _fsync_directory(root)
+            except BaseException:
+                with contextlib.suppress(OSError):
+                    os.unlink(tmp_name)
+                raise
+
+            committed = path.read_text(encoding="utf-8").strip().lower()
+            return committed if _INSTALL_ID_RE.fullmatch(committed) else None
+    except OSError:
+        return None
+
+
+def get_install_id(
+    *,
+    cache: dict[str, Optional[str]] | None = None,
+) -> Optional[str]:
+    """Return the process-cached stable id for the active Hermes root."""
+    root = get_default_hermes_root()
+    root_key = str(root)
+    target_cache = _INSTALL_ID_CACHE if cache is None else cache
+    cached = target_cache.get("value")
+    if cached and target_cache.get("root") in (None, root_key):
+        return cached
+
+    with _INSTALL_ID_LOCK:
+        cached = target_cache.get("value")
+        if cached and target_cache.get("root") in (None, root_key):
+            return cached
+        value = read_or_create_install_id(root)
+        if value:
+            target_cache["root"] = root_key
+            target_cache["value"] = value
+        return value
+
+
+__all__ = ["get_install_id", "read_or_create_install_id"]

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -48,6 +48,7 @@ import urllib.parse
 import zipfile
 
 from hermes_cli._subprocess_compat import windows_detach_flags, windows_hide_flags
+from hermes_cli.install_identity import get_install_id as _shared_get_install_id
 import urllib.request
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, Tuple
@@ -3523,66 +3524,12 @@ _TOPOLOGY_CACHE_TTL = 10.0
 # fact it reveals is "these addresses are the same box", which is the feature.
 # It must never change across restarts/updates, so reads are cached for the
 # process lifetime and the file is written once, atomically.
-_INSTALL_ID_FILENAME = "install_id"
-_INSTALL_ID_RE = re.compile(r"^[0-9a-f]{32}$")
-_INSTALL_ID_CACHE: Dict[str, Optional[str]] = {"value": None}
-_INSTALL_ID_LOCK = threading.Lock()
-
-
-def _read_or_create_install_id() -> Optional[str]:
-    """Read (or mint + persist) the install id under the root Hermes home.
-
-    Returns ``None`` only when the id can neither be read nor persisted (e.g.
-    a read-only filesystem) — an unpersisted id would violate the stability
-    contract, so callers omit the field rather than emit a churning value.
-    """
-    import uuid
-
-    from hermes_constants import get_default_hermes_root
-
-    root = get_default_hermes_root()
-    path = root / _INSTALL_ID_FILENAME
-    try:
-        existing = path.read_text(encoding="utf-8").strip().lower()
-        if _INSTALL_ID_RE.match(existing):
-            return existing
-    except FileNotFoundError:
-        pass
-    except (OSError, UnicodeDecodeError):
-        return None
-
-    minted = uuid.uuid4().hex
-    try:
-        root.mkdir(parents=True, exist_ok=True)
-        # Atomic replace so a crash mid-write can't leave a truncated id that
-        # would be regenerated (i.e. changed) on the next boot.
-        fd, tmp_name = tempfile.mkstemp(dir=str(root), prefix=".install_id-")
-        try:
-            with os.fdopen(fd, "w", encoding="utf-8") as handle:
-                handle.write(minted + "\n")
-            os.replace(tmp_name, path)
-        except BaseException:
-            with contextlib.suppress(OSError):
-                os.unlink(tmp_name)
-            raise
-    except OSError:
-        return None
-    return minted
+_INSTALL_ID_CACHE: Dict[str, Optional[str]] = {"root": None, "value": None}
 
 
 def get_install_id() -> Optional[str]:
-    """Process-lifetime-cached stable install id (see _read_or_create_install_id)."""
-    cached = _INSTALL_ID_CACHE["value"]
-    if cached:
-        return cached
-    with _INSTALL_ID_LOCK:
-        cached = _INSTALL_ID_CACHE["value"]
-        if cached:
-            return cached
-        value = _read_or_create_install_id()
-        if value:
-            _INSTALL_ID_CACHE["value"] = value
-        return value
+    """Process-lifetime-cached stable install id."""
+    return _shared_get_install_id(cache=_INSTALL_ID_CACHE)
 
 
 # Serializes read-modify-write cycles over config.yaml for handlers that run

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -431,6 +431,14 @@ async def _lifespan(app: "FastAPI"):
 
     record_boot_fingerprint()
 
+    # Hosted Bot rooms belong to the backend process, not to any connected
+    # Desktop socket. Start their coordinator before accepting clients so a
+    # restart can reconcile durable work even when no viewer reconnects.
+    from tui_gateway import methods_groups as _hosted_groups
+    import tui_gateway.server  # noqa: F401
+
+    _hosted_groups.start_hosted_room_service()
+
     # Desktop-spawned backends (HERMES_DESKTOP=1) fire cron jobs themselves,
     # since the app has no gateway running the scheduler. Server `hermes
     # dashboard` is unaffected — it relies on its own gateway.
@@ -473,6 +481,7 @@ async def _lifespan(app: "FastAPI"):
     try:
         yield
     finally:
+        _hosted_groups.stop_hosted_room_service(timeout=5.0)
         if cron_stop is not None:
             cron_stop.set()
         pty_reaper_task.cancel()

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -7049,7 +7049,7 @@ class SlackAdapter(BasePlatformAdapter):
             # subtype=bot_message with user=None; flag them so the
             # gateway SLACK_ALLOW_BOTS bypass can authorize them
             # (they carry no user_id to match against the allowlist).
-            is_bot=bool(event.get("bot_id")) or event.get("subtype") == "bot_message",
+            is_bot=sender_is_bot,
         )
 
         # Per-channel ephemeral prompt

--- a/tests/gateway/test_desktop_room_mailbox.py
+++ b/tests/gateway/test_desktop_room_mailbox.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import hashlib
+
 import pytest
 
 from gateway import desktop_room_mailbox as mailbox
@@ -13,12 +15,24 @@ class Clock:
         return self.value
 
 
+def authorities(*room_ids: str, token: str = "authority:one") -> list[dict]:
+    return [
+        {"room_id": room_id, "authority_token": token}
+        for room_id in room_ids
+    ]
+
+
+def authority_commitment(token: str = "authority:one") -> str:
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
 def test_enqueue_is_idempotent_and_rejects_key_reuse(tmp_path):
     db = tmp_path / "state.db"
     first = mailbox.enqueue_command(
         db,
         command_id="messaging:abc",
         room_id="room-1",
+        authority_hash=authority_commitment(),
         action="send",
         payload={"message": "hello"},
     )
@@ -26,6 +40,7 @@ def test_enqueue_is_idempotent_and_rejects_key_reuse(tmp_path):
         db,
         command_id="messaging:abc",
         room_id="room-1",
+        authority_hash=authority_commitment(),
         action="send",
         payload={"message": "hello"},
     )
@@ -37,6 +52,7 @@ def test_enqueue_is_idempotent_and_rejects_key_reuse(tmp_path):
             db,
             command_id="messaging:abc",
             room_id="room-1",
+            authority_hash=authority_commitment(),
             action="send",
             payload={"message": "changed"},
         )
@@ -50,6 +66,7 @@ def test_enqueue_moves_the_cross_process_pending_signal(tmp_path):
         db,
         command_id="messaging:first",
         room_id="room-1",
+        authority_hash=authority_commitment(),
         action="send",
         payload={"message": "hello"},
     )
@@ -58,6 +75,7 @@ def test_enqueue_moves_the_cross_process_pending_signal(tmp_path):
         db,
         command_id="messaging:second",
         room_id="room-1",
+        authority_hash=authority_commitment(),
         action="send",
         payload={"message": "again"},
     )
@@ -72,6 +90,7 @@ def test_signal_failure_does_not_change_a_durable_enqueue(tmp_path, monkeypatch)
         db,
         command_id="messaging:seed",
         room_id="room-1",
+        authority_hash=authority_commitment(),
         action="send",
         payload={"message": "seed"},
     )
@@ -85,6 +104,7 @@ def test_signal_failure_does_not_change_a_durable_enqueue(tmp_path, monkeypatch)
         db,
         command_id="messaging:still-durable",
         room_id="room-1",
+        authority_hash=authority_commitment(),
         action="send",
         payload={"message": "hello"},
     )
@@ -99,6 +119,7 @@ def test_one_desktop_claims_and_presence_is_room_scoped(tmp_path):
         db,
         command_id="messaging:one",
         room_id="name:Classic room",
+        authority_hash=authority_commitment(),
         action="send",
         payload={"message": "hello"},
         clock=clock,
@@ -107,13 +128,13 @@ def test_one_desktop_claims_and_presence_is_room_scoped(tmp_path):
     claimed = mailbox.claim_commands(
         db,
         consumer_id="desktop:first",
-        room_ids=["name:Classic room"],
+        room_authorities=authorities("name:Classic room"),
         clock=clock,
     )
     duplicate = mailbox.claim_commands(
         db,
         consumer_id="desktop:second",
-        room_ids=["name:Classic room"],
+        room_authorities=authorities("name:Classic room", token="authority:two"),
         clock=clock,
     )
 
@@ -123,13 +144,14 @@ def test_one_desktop_claims_and_presence_is_room_scoped(tmp_path):
     assert mailbox.room_available(db, "another-room", clock=clock) is False
 
 
-def test_expired_claim_moves_to_another_desktop(tmp_path):
+def test_expired_claim_is_recovered_by_the_registered_desktop(tmp_path):
     db = tmp_path / "state.db"
     clock = Clock()
     mailbox.enqueue_command(
         db,
         command_id="messaging:retry",
         room_id="room-1",
+        authority_hash=authority_commitment(),
         action="send",
         payload={"message": "hello"},
         clock=clock,
@@ -137,7 +159,7 @@ def test_expired_claim_moves_to_another_desktop(tmp_path):
     first = mailbox.claim_commands(
         db,
         consumer_id="desktop:first",
-        room_ids=["room-1"],
+        room_authorities=authorities("room-1"),
         claim_ttl=10,
         presence_ttl=10,
         clock=clock,
@@ -145,8 +167,8 @@ def test_expired_claim_moves_to_another_desktop(tmp_path):
     clock.value += 11
     second = mailbox.claim_commands(
         db,
-        consumer_id="desktop:second",
-        room_ids=["room-1"],
+        consumer_id="desktop:first",
+        room_authorities=authorities("room-1"),
         clock=clock,
     )
 
@@ -170,13 +192,14 @@ def test_completion_ack_retry_is_idempotent(tmp_path):
         db,
         command_id="messaging:complete",
         room_id="room-1",
+        authority_hash=authority_commitment(),
         action="stop",
         payload={},
     )
     claimed = mailbox.claim_commands(
         db,
         consumer_id="desktop:first",
-        room_ids=["room-1"],
+        room_authorities=authorities("room-1"),
     )
     first = mailbox.complete_command(
         db,
@@ -206,6 +229,7 @@ def test_reclaim_rotates_token_and_fences_a_stale_attempt(tmp_path):
         db,
         command_id="messaging:fenced",
         room_id="room-1",
+        authority_hash=authority_commitment(),
         action="send",
         payload={"message": "hello"},
         clock=clock,
@@ -213,7 +237,7 @@ def test_reclaim_rotates_token_and_fences_a_stale_attempt(tmp_path):
     first = mailbox.claim_commands(
         db,
         consumer_id="desktop:same-install",
-        room_ids=["room-1"],
+        room_authorities=authorities("room-1"),
         claim_ttl=5,
         clock=clock,
     )[0]
@@ -221,7 +245,7 @@ def test_reclaim_rotates_token_and_fences_a_stale_attempt(tmp_path):
     second = mailbox.claim_commands(
         db,
         consumer_id="desktop:same-install",
-        room_ids=["room-1"],
+        room_authorities=authorities("room-1"),
         claim_ttl=5,
         clock=clock,
     )[0]
@@ -246,6 +270,7 @@ def test_live_claim_can_be_renewed(tmp_path):
         db,
         command_id="messaging:renew",
         room_id="room-1",
+        authority_hash=authority_commitment(),
         action="send",
         payload={"message": "hello"},
         clock=clock,
@@ -253,7 +278,7 @@ def test_live_claim_can_be_renewed(tmp_path):
     claimed = mailbox.claim_commands(
         db,
         consumer_id="desktop:first",
-        room_ids=["room-1"],
+        room_authorities=authorities("room-1"),
         claim_ttl=10,
         clock=clock,
     )[0]
@@ -287,6 +312,7 @@ def test_presence_expires_without_deleting_pending_work(tmp_path):
         db,
         command_id="messaging:later",
         room_id="room-1",
+        authority_hash=authority_commitment(),
         action="send",
         payload={"message": "later"},
         clock=clock,
@@ -294,7 +320,7 @@ def test_presence_expires_without_deleting_pending_work(tmp_path):
     mailbox.claim_commands(
         db,
         consumer_id="desktop:first",
-        room_ids=["room-1"],
+        room_authorities=authorities("room-1"),
         presence_ttl=5,
         claim_ttl=5,
         clock=clock,
@@ -304,20 +330,204 @@ def test_presence_expires_without_deleting_pending_work(tmp_path):
     assert mailbox.room_available(db, "room-1", clock=clock) is False
     reclaimed = mailbox.claim_commands(
         db,
-        consumer_id="desktop:second",
-        room_ids=["room-1"],
+        consumer_id="desktop:first",
+        room_authorities=authorities("room-1"),
         clock=clock,
     )
     assert reclaimed[0]["command_id"] == "messaging:later"
 
 
+def test_authority_token_fences_a_cold_desktop_after_owner_expiry(tmp_path):
+    db = tmp_path / "state.db"
+    clock = Clock()
+    mailbox.enqueue_command(
+        db,
+        command_id="messaging:fenced-room",
+        room_id="room-1",
+        authority_hash=authority_commitment(),
+        action="send",
+        payload={"message": "hello"},
+        clock=clock,
+    )
+    mailbox.claim_commands(
+        db,
+        consumer_id="desktop:owner",
+        room_authorities=authorities("room-1"),
+        claim_ttl=5,
+        presence_ttl=5,
+        clock=clock,
+    )
+    clock.value += 6
+
+    assert mailbox.claim_commands(
+        db,
+        consumer_id="desktop:cold",
+        room_authorities=authorities("room-1", token="authority:wrong"),
+        clock=clock,
+    ) == []
+    reclaimed = mailbox.claim_commands(
+        db,
+        consumer_id="desktop:owner",
+        room_authorities=authorities("room-1"),
+        clock=clock,
+    )
+    assert reclaimed[0]["command_id"] == "messaging:fenced-room"
+
+
+def test_claim_cannot_establish_room_authority(tmp_path):
+    db = tmp_path / "state.db"
+    mailbox.enqueue_command(
+        db,
+        command_id="messaging:unregistered",
+        room_id="room-1",
+        authority_hash=authority_commitment(),
+        action="send",
+        payload={"message": "hello"},
+    )
+
+    assert mailbox.claim_commands(
+        db,
+        consumer_id="desktop:untrusted",
+        room_authorities=authorities("room-1", token="authority:guessed"),
+    ) == []
+
+    claimed = mailbox.claim_commands(
+        db,
+        consumer_id="desktop:owner",
+        room_authorities=authorities("room-1"),
+    )
+    assert [item["command_id"] for item in claimed] == ["messaging:unregistered"]
+
+
+def test_projected_authority_commitment_is_idempotent_and_fenced(tmp_path):
+    db = tmp_path / "state.db"
+    assert mailbox.register_projected_authorities(
+        db,
+        [{"room_id": "room-1", "authority_hash": authority_commitment()}],
+    ) == ["room-1"]
+    assert mailbox.register_projected_authorities(
+        db,
+        [{"room_id": "room-1", "authority_hash": authority_commitment()}],
+    ) == ["room-1"]
+
+    assert mailbox.register_projected_authorities(
+        db,
+        [{
+            "room_id": "room-1",
+            "authority_hash": authority_commitment("authority:other"),
+        }],
+    ) == []
+
+    assert mailbox.register_projected_authorities(
+        db,
+        [
+            {
+                "room_id": "room-1",
+                "authority_hash": authority_commitment("authority:other"),
+            },
+            {"room_id": "room-2", "authority_hash": authority_commitment()},
+        ],
+    ) == ["room-2"]
+
+    with pytest.raises(mailbox.DesktopRoomMailboxError, match="commitment"):
+        mailbox.enqueue_command(
+            db,
+            command_id="messaging:conflict",
+            room_id="room-1",
+            authority_hash=authority_commitment("authority:other"),
+            action="send",
+            payload={"message": "must not replace owner"},
+        )
+
+
+def test_action_filter_allows_stop_to_bypass_pending_send(tmp_path):
+    db = tmp_path / "state.db"
+    clock = Clock()
+    for action in ("send", "stop"):
+        mailbox.enqueue_command(
+            db,
+            command_id=f"messaging:{action}",
+            room_id="room-1",
+            authority_hash=authority_commitment(),
+            action=action,
+            payload={"message": "hello"} if action == "send" else {},
+            clock=clock,
+        )
+
+    stopped = mailbox.claim_commands(
+        db,
+        consumer_id="desktop:owner",
+        room_authorities=authorities("room-1"),
+        actions=["stop"],
+        clock=clock,
+    )
+    sends = mailbox.claim_commands(
+        db,
+        consumer_id="desktop:owner",
+        room_authorities=authorities("room-1"),
+        actions=["send"],
+        clock=clock,
+    )
+
+    assert [item["action"] for item in stopped] == ["stop"]
+    assert [item["action"] for item in sends] == ["send"]
+
+
+def test_renew_keeps_room_ownership_alive_for_long_turn(tmp_path):
+    db = tmp_path / "state.db"
+    clock = Clock()
+    mailbox.enqueue_command(
+        db,
+        command_id="messaging:long",
+        room_id="room-1",
+        authority_hash=authority_commitment(),
+        action="send",
+        payload={"message": "hello"},
+        clock=clock,
+    )
+    command = mailbox.claim_commands(
+        db,
+        consumer_id="desktop:owner",
+        room_authorities=authorities("room-1"),
+        claim_ttl=45,
+        presence_ttl=90,
+        clock=clock,
+    )[0]
+
+    for _ in range(8):
+        clock.value += 30
+        mailbox.renew_command(
+            db,
+            consumer_id="desktop:owner",
+            command_id=command["command_id"],
+            lease_token=command["lease_token"],
+            claim_ttl=45,
+            presence_ttl=90,
+            clock=clock,
+        )
+
+    assert mailbox.room_available(db, "room-1", clock=clock) is True
+    assert mailbox.claim_commands(
+        db,
+        consumer_id="desktop:other",
+        room_authorities=authorities("room-1"),
+        actions=["stop"],
+        clock=clock,
+    ) == []
+
+
 def test_default_presence_overlaps_the_minute_desktop_backstop(tmp_path):
     db = tmp_path / "state.db"
     clock = Clock()
+    mailbox.register_projected_authorities(
+        db,
+        [{"room_id": "room-1", "authority_hash": authority_commitment()}],
+        clock=clock,
+    )
     mailbox.claim_commands(
         db,
         consumer_id="desktop:first",
-        room_ids=["room-1"],
+        room_authorities=authorities("room-1"),
         clock=clock,
     )
 
@@ -334,6 +544,7 @@ def test_latest_command_state_is_scoped_per_room(tmp_path):
         db,
         command_id="messaging:first",
         room_id="room-1",
+        authority_hash=authority_commitment(),
         action="send",
         payload={"message": "first"},
         clock=clock,
@@ -343,6 +554,7 @@ def test_latest_command_state_is_scoped_per_room(tmp_path):
         db,
         command_id="messaging:second",
         room_id="room-1",
+        authority_hash=authority_commitment(),
         action="send",
         payload={"message": "second"},
         clock=clock,
@@ -351,6 +563,7 @@ def test_latest_command_state_is_scoped_per_room(tmp_path):
         db,
         command_id="messaging:other",
         room_id="room-2",
+        authority_hash=authority_commitment(),
         action="stop",
         payload={},
         clock=clock,
@@ -368,10 +581,19 @@ def test_paged_claims_preserve_presence_for_every_owned_room(tmp_path):
     rooms = [f"room-{index}" for index in range(260)]
 
     for index in range(0, len(rooms), mailbox.MAX_ROOM_IDS):
+        batch = rooms[index : index + mailbox.MAX_ROOM_IDS]
+        mailbox.register_projected_authorities(
+            db,
+            [
+                {"room_id": room_id, "authority_hash": authority_commitment()}
+                for room_id in batch
+            ],
+            clock=clock,
+        )
         mailbox.claim_commands(
             db,
             consumer_id="desktop:first",
-            room_ids=rooms[index : index + mailbox.MAX_ROOM_IDS],
+            room_authorities=authorities(*batch),
             clock=clock,
         )
 

--- a/tests/gateway/test_desktop_room_mailbox.py
+++ b/tests/gateway/test_desktop_room_mailbox.py
@@ -1,0 +1,378 @@
+from __future__ import annotations
+
+import pytest
+
+from gateway import desktop_room_mailbox as mailbox
+
+
+class Clock:
+    def __init__(self, value: float = 1000.0) -> None:
+        self.value = value
+
+    def __call__(self) -> float:
+        return self.value
+
+
+def test_enqueue_is_idempotent_and_rejects_key_reuse(tmp_path):
+    db = tmp_path / "state.db"
+    first = mailbox.enqueue_command(
+        db,
+        command_id="messaging:abc",
+        room_id="room-1",
+        action="send",
+        payload={"message": "hello"},
+    )
+    replay = mailbox.enqueue_command(
+        db,
+        command_id="messaging:abc",
+        room_id="room-1",
+        action="send",
+        payload={"message": "hello"},
+    )
+
+    assert first["state"] == "pending"
+    assert replay["idempotent"] is True
+    with pytest.raises(mailbox.DesktopRoomMailboxError, match="different room work"):
+        mailbox.enqueue_command(
+            db,
+            command_id="messaging:abc",
+            room_id="room-1",
+            action="send",
+            payload={"message": "changed"},
+        )
+
+
+def test_enqueue_moves_the_cross_process_pending_signal(tmp_path):
+    db = tmp_path / "desktop_room_mailbox.db"
+    signal = mailbox.pending_signal_path(db)
+
+    mailbox.enqueue_command(
+        db,
+        command_id="messaging:first",
+        room_id="room-1",
+        action="send",
+        payload={"message": "hello"},
+    )
+    first = signal.read_text(encoding="ascii")
+    mailbox.enqueue_command(
+        db,
+        command_id="messaging:second",
+        room_id="room-1",
+        action="send",
+        payload={"message": "again"},
+    )
+
+    assert signal.read_text(encoding="ascii") != first
+    assert signal.stat().st_mode & 0o777 == 0o600
+
+
+def test_signal_failure_does_not_change_a_durable_enqueue(tmp_path, monkeypatch):
+    db = tmp_path / "desktop_room_mailbox.db"
+    mailbox.enqueue_command(
+        db,
+        command_id="messaging:seed",
+        room_id="room-1",
+        action="send",
+        payload={"message": "seed"},
+    )
+    monkeypatch.setattr(
+        type(mailbox.pending_signal_path(db)),
+        "write_text",
+        lambda *args, **kwargs: (_ for _ in ()).throw(OSError("read only")),
+    )
+
+    queued = mailbox.enqueue_command(
+        db,
+        command_id="messaging:still-durable",
+        room_id="room-1",
+        action="send",
+        payload={"message": "hello"},
+    )
+
+    assert queued["state"] == "pending"
+
+
+def test_one_desktop_claims_and_presence_is_room_scoped(tmp_path):
+    db = tmp_path / "state.db"
+    clock = Clock()
+    mailbox.enqueue_command(
+        db,
+        command_id="messaging:one",
+        room_id="name:Classic room",
+        action="send",
+        payload={"message": "hello"},
+        clock=clock,
+    )
+
+    claimed = mailbox.claim_commands(
+        db,
+        consumer_id="desktop:first",
+        room_ids=["name:Classic room"],
+        clock=clock,
+    )
+    duplicate = mailbox.claim_commands(
+        db,
+        consumer_id="desktop:second",
+        room_ids=["name:Classic room"],
+        clock=clock,
+    )
+
+    assert [item["command_id"] for item in claimed] == ["messaging:one"]
+    assert duplicate == []
+    assert mailbox.room_available(db, "name:Classic room", clock=clock) is True
+    assert mailbox.room_available(db, "another-room", clock=clock) is False
+
+
+def test_expired_claim_moves_to_another_desktop(tmp_path):
+    db = tmp_path / "state.db"
+    clock = Clock()
+    mailbox.enqueue_command(
+        db,
+        command_id="messaging:retry",
+        room_id="room-1",
+        action="send",
+        payload={"message": "hello"},
+        clock=clock,
+    )
+    first = mailbox.claim_commands(
+        db,
+        consumer_id="desktop:first",
+        room_ids=["room-1"],
+        claim_ttl=10,
+        presence_ttl=10,
+        clock=clock,
+    )
+    clock.value += 11
+    second = mailbox.claim_commands(
+        db,
+        consumer_id="desktop:second",
+        room_ids=["room-1"],
+        clock=clock,
+    )
+
+    assert first[0]["attempts"] == 1
+    assert second[0]["attempts"] == 2
+    with pytest.raises(mailbox.DesktopRoomMailboxError, match="no longer owned"):
+        mailbox.complete_command(
+            db,
+            consumer_id="desktop:first",
+            command_id="messaging:retry",
+            lease_token=first[0]["lease_token"],
+            success=True,
+            result={"thread_id": "old"},
+            clock=clock,
+        )
+
+
+def test_completion_ack_retry_is_idempotent(tmp_path):
+    db = tmp_path / "state.db"
+    mailbox.enqueue_command(
+        db,
+        command_id="messaging:complete",
+        room_id="room-1",
+        action="stop",
+        payload={},
+    )
+    claimed = mailbox.claim_commands(
+        db,
+        consumer_id="desktop:first",
+        room_ids=["room-1"],
+    )
+    first = mailbox.complete_command(
+        db,
+        consumer_id="desktop:first",
+        command_id="messaging:complete",
+        lease_token=claimed[0]["lease_token"],
+        success=True,
+        result={"stopped": True},
+    )
+    replay = mailbox.complete_command(
+        db,
+        consumer_id="desktop:first",
+        command_id="messaging:complete",
+        lease_token=claimed[0]["lease_token"],
+        success=True,
+        result={"stopped": True},
+    )
+
+    assert first["state"] == "completed"
+    assert replay["idempotent"] is True
+
+
+def test_reclaim_rotates_token_and_fences_a_stale_attempt(tmp_path):
+    db = tmp_path / "state.db"
+    clock = Clock()
+    mailbox.enqueue_command(
+        db,
+        command_id="messaging:fenced",
+        room_id="room-1",
+        action="send",
+        payload={"message": "hello"},
+        clock=clock,
+    )
+    first = mailbox.claim_commands(
+        db,
+        consumer_id="desktop:same-install",
+        room_ids=["room-1"],
+        claim_ttl=5,
+        clock=clock,
+    )[0]
+    clock.value += 6
+    second = mailbox.claim_commands(
+        db,
+        consumer_id="desktop:same-install",
+        room_ids=["room-1"],
+        claim_ttl=5,
+        clock=clock,
+    )[0]
+
+    assert first["lease_token"] != second["lease_token"]
+    with pytest.raises(mailbox.DesktopRoomMailboxError, match="no longer owned"):
+        mailbox.complete_command(
+            db,
+            consumer_id="desktop:same-install",
+            command_id="messaging:fenced",
+            lease_token=first["lease_token"],
+            success=True,
+            result={"thread_id": "old"},
+            clock=clock,
+        )
+
+
+def test_live_claim_can_be_renewed(tmp_path):
+    db = tmp_path / "state.db"
+    clock = Clock()
+    mailbox.enqueue_command(
+        db,
+        command_id="messaging:renew",
+        room_id="room-1",
+        action="send",
+        payload={"message": "hello"},
+        clock=clock,
+    )
+    claimed = mailbox.claim_commands(
+        db,
+        consumer_id="desktop:first",
+        room_ids=["room-1"],
+        claim_ttl=10,
+        clock=clock,
+    )[0]
+    clock.value += 8
+    renewed = mailbox.renew_command(
+        db,
+        consumer_id="desktop:first",
+        command_id="messaging:renew",
+        lease_token=claimed["lease_token"],
+        claim_ttl=10,
+        clock=clock,
+    )
+    clock.value += 5
+
+    assert renewed["lease_token"] == claimed["lease_token"]
+    assert mailbox.complete_command(
+        db,
+        consumer_id="desktop:first",
+        command_id="messaging:renew",
+        lease_token=claimed["lease_token"],
+        success=True,
+        result={"thread_id": "thread-1"},
+        clock=clock,
+    )["state"] == "completed"
+
+
+def test_presence_expires_without_deleting_pending_work(tmp_path):
+    db = tmp_path / "state.db"
+    clock = Clock()
+    mailbox.enqueue_command(
+        db,
+        command_id="messaging:later",
+        room_id="room-1",
+        action="send",
+        payload={"message": "later"},
+        clock=clock,
+    )
+    mailbox.claim_commands(
+        db,
+        consumer_id="desktop:first",
+        room_ids=["room-1"],
+        presence_ttl=5,
+        claim_ttl=5,
+        clock=clock,
+    )
+    clock.value += 6
+
+    assert mailbox.room_available(db, "room-1", clock=clock) is False
+    reclaimed = mailbox.claim_commands(
+        db,
+        consumer_id="desktop:second",
+        room_ids=["room-1"],
+        clock=clock,
+    )
+    assert reclaimed[0]["command_id"] == "messaging:later"
+
+
+def test_default_presence_overlaps_the_minute_desktop_backstop(tmp_path):
+    db = tmp_path / "state.db"
+    clock = Clock()
+    mailbox.claim_commands(
+        db,
+        consumer_id="desktop:first",
+        room_ids=["room-1"],
+        clock=clock,
+    )
+
+    clock.value += 61
+    assert mailbox.room_available(db, "room-1", clock=clock) is True
+    clock.value += 30
+    assert mailbox.room_available(db, "room-1", clock=clock) is False
+
+
+def test_latest_command_state_is_scoped_per_room(tmp_path):
+    db = tmp_path / "state.db"
+    clock = Clock()
+    mailbox.enqueue_command(
+        db,
+        command_id="messaging:first",
+        room_id="room-1",
+        action="send",
+        payload={"message": "first"},
+        clock=clock,
+    )
+    clock.value += 1
+    mailbox.enqueue_command(
+        db,
+        command_id="messaging:second",
+        room_id="room-1",
+        action="send",
+        payload={"message": "second"},
+        clock=clock,
+    )
+    mailbox.enqueue_command(
+        db,
+        command_id="messaging:other",
+        room_id="room-2",
+        action="stop",
+        payload={},
+        clock=clock,
+    )
+
+    states = mailbox.latest_command_states(db, ["room-1", "room-2"])
+
+    assert states["room-1"]["command_id"] == "messaging:second"
+    assert states["room-2"]["command_id"] == "messaging:other"
+
+
+def test_paged_claims_preserve_presence_for_every_owned_room(tmp_path):
+    db = tmp_path / "state.db"
+    clock = Clock()
+    rooms = [f"room-{index}" for index in range(260)]
+
+    for index in range(0, len(rooms), mailbox.MAX_ROOM_IDS):
+        mailbox.claim_commands(
+            db,
+            consumer_id="desktop:first",
+            room_ids=rooms[index : index + mailbox.MAX_ROOM_IDS],
+            clock=clock,
+        )
+
+    assert mailbox.available_room_ids(db, rooms, clock=clock) == set(rooms)

--- a/tests/gateway/test_desktop_room_mailbox.py
+++ b/tests/gateway/test_desktop_room_mailbox.py
@@ -374,6 +374,60 @@ def test_authority_token_fences_a_cold_desktop_after_owner_expiry(tmp_path):
     assert reclaimed[0]["command_id"] == "messaging:fenced-room"
 
 
+def test_attachment_read_requires_bound_authority_and_live_command_lease(tmp_path):
+    db = tmp_path / "state.db"
+    clock = Clock()
+    mailbox.enqueue_command(
+        db,
+        command_id="messaging:attachment",
+        room_id="room-1",
+        authority_hash=authority_commitment(),
+        action="send",
+        payload={"message": "inspect"},
+        clock=clock,
+    )
+    command = mailbox.claim_commands(
+        db,
+        consumer_id="desktop:owner",
+        room_authorities=authorities("room-1"),
+        claim_ttl=5,
+        presence_ttl=5,
+        clock=clock,
+    )[0]
+
+    mailbox.authorize_attachment_read(
+        db,
+        room_id="room-1",
+        command_id="messaging:attachment",
+        consumer_id="desktop:owner",
+        lease_token=command["lease_token"],
+        authority_token="authority:one",
+        clock=clock,
+    )
+    with pytest.raises(mailbox.DesktopRoomMailboxError, match="not authorized"):
+        mailbox.authorize_attachment_read(
+            db,
+            room_id="room-1",
+            command_id="messaging:attachment",
+            consumer_id="desktop:owner",
+            lease_token=command["lease_token"],
+            authority_token="authority:wrong",
+            clock=clock,
+        )
+
+    clock.value += 6
+    with pytest.raises(mailbox.DesktopRoomMailboxError, match="not authorized"):
+        mailbox.authorize_attachment_read(
+            db,
+            room_id="room-1",
+            command_id="messaging:attachment",
+            consumer_id="desktop:owner",
+            lease_token=command["lease_token"],
+            authority_token="authority:one",
+            clock=clock,
+        )
+
+
 def test_claim_cannot_establish_room_authority(tmp_path):
     db = tmp_path / "state.db"
     mailbox.enqueue_command(

--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -493,6 +493,23 @@ class _FakeThreadChannel(_discord_mod.Thread):
         return _empty()
 
 
+def test_discord_slash_interaction_supplies_room_control_idempotency(adapter):
+    from gateway.hosted_room_messaging import messaging_event_id
+
+    channel = _FakeTextChannel(channel_id=123)
+    interaction = SimpleNamespace(
+        id=987654321,
+        channel=channel,
+        channel_id=channel.id,
+        user=SimpleNamespace(id=42, display_name="Jezza"),
+    )
+    event = adapter._build_slash_event(
+        interaction,
+        "/rooms send release-room -- hello",
+    )
+    assert messaging_event_id(event) == messaging_event_id(event)
+
+
 def _fake_message(channel, *, content="Hello", author_id=42, display_name="Jezza"):
     return SimpleNamespace(
         author=SimpleNamespace(id=author_id, display_name=display_name, bot=False),
@@ -600,5 +617,4 @@ def test_register_skill_command_payload_fits_discord_8kb_limit(adapter):
         f"Flat /skill command payload is ~{len(payload)} bytes — the whole "
         f"point of this design is that it stays small regardless of skill count"
     )
-
 

--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -505,7 +505,7 @@ def test_discord_slash_interaction_supplies_room_control_idempotency(adapter):
     )
     event = adapter._build_slash_event(
         interaction,
-        "/rooms send release-room -- hello",
+        "/group 1 send hello",
     )
     assert messaging_event_id(event) == messaging_event_id(event)
 
@@ -617,4 +617,3 @@ def test_register_skill_command_payload_fits_discord_8kb_limit(adapter):
         f"Flat /skill command payload is ~{len(payload)} bytes — the whole "
         f"point of this design is that it stays small regardless of skill count"
     )
-

--- a/tests/gateway/test_hosted_room_attachments.py
+++ b/tests/gateway/test_hosted_room_attachments.py
@@ -1,0 +1,417 @@
+import os
+import sqlite3
+
+import pytest
+
+from gateway import hosted_rooms
+from gateway.hosted_room_attachments import (
+    AttachmentConflictError,
+    AttachmentError,
+    AttachmentIntegrityError,
+    AttachmentNotFoundError,
+    AttachmentQuotaError,
+    HostedRoomAttachmentStore,
+    MAX_TASK_ATTACHMENT_BYTES,
+    MAX_TASK_ATTACHMENTS,
+    UNCOMMITTED_TTL_SECONDS,
+    decode_content_base64,
+    validate_task_manifest,
+)
+
+
+PNG = b"\x89PNG\r\n\x1a\n" + b"image-payload"
+PDF = b"%PDF-1.7\nattachment\n%%EOF\n"
+
+
+def _put(store, *, upload_id="upload-1", data=PNG, **overrides):
+    params = {
+        "room_id": "room-1",
+        "upload_id": upload_id,
+        "kind": "image",
+        "name": "diagram.png",
+        "mime": "image/png",
+        "data": data,
+    }
+    params.update(overrides)
+    return store.put(**params)
+
+
+def _manifest(*attachments):
+    return [
+        {
+            "attachment_id": item["attachment_id"],
+            "kind": item["kind"],
+            "name": item["name"],
+            "size": item["size"],
+            "mime": item["mime"],
+        }
+        for item in attachments
+    ]
+
+
+def test_store_is_private_atomic_deduplicated_and_upload_idempotent(tmp_path):
+    store = HostedRoomAttachmentStore(tmp_path / "state.db")
+
+    first = _put(store)
+    repeated = _put(store)
+    second = _put(store, upload_id="upload-2")
+
+    assert repeated["attachment_id"] == first["attachment_id"]
+    assert repeated["idempotent"] is True
+    assert second["attachment_id"] != first["attachment_id"]
+    assert store.stats() == {
+        "attachments": 2,
+        "logical_bytes": len(PNG) * 2,
+        "blobs": 1,
+        "physical_bytes": len(PNG),
+    }
+    if os.name != "nt":
+        assert store.root.stat().st_mode & 0o777 == 0o700
+        assert store.blob_root.stat().st_mode & 0o777 == 0o700
+        blob = next(path for path in store.blob_root.iterdir() if path.name.startswith("blob_"))
+        assert blob.stat().st_mode & 0o777 == 0o600
+    assert not list(store.blob_root.glob(".tmp-*"))
+
+
+def test_upload_id_conflict_and_manifest_metadata_conflict_fail_closed(tmp_path):
+    store = HostedRoomAttachmentStore(tmp_path / "state.db")
+    attachment = _put(store)
+
+    with pytest.raises(AttachmentConflictError):
+        _put(store, data=PNG + b"different")
+
+    manifest = _manifest(attachment)
+    manifest[0]["name"] = "renamed.png"
+    with pytest.raises(AttachmentConflictError):
+        store.commit_message(
+            room_id="room-1",
+            event_id="event-1",
+            manifest=manifest,
+            recipient_member_ids=("research", "builder"),
+        )
+
+
+def test_image_pdf_text_and_binary_round_trip_with_frozen_recipients(tmp_path):
+    store = HostedRoomAttachmentStore(tmp_path / "state.db")
+    image = _put(store)
+    pdf = _put(
+        store,
+        upload_id="upload-pdf",
+        data=PDF,
+        kind="pdf",
+        name="brief.pdf",
+        mime="application/pdf",
+    )
+    text = _put(
+        store,
+        upload_id="upload-text",
+        data=b"release notes\n",
+        kind="file",
+        name="notes.txt",
+        mime="text/plain",
+    )
+    binary = _put(
+        store,
+        upload_id="upload-bin",
+        data=b"\x00\x01\x02\xff",
+        kind="file",
+        name="payload.bin",
+        mime="application/octet-stream",
+    )
+    manifest = _manifest(image, pdf, text, binary)
+
+    committed = store.commit_message(
+        room_id="room-1",
+        event_id="event-1",
+        manifest=manifest,
+        recipient_member_ids=("research", "builder"),
+    )
+    repeated = store.commit_message(
+        room_id="room-1",
+        event_id="event-1",
+        manifest=manifest,
+        recipient_member_ids=("research", "builder"),
+    )
+
+    assert committed == repeated == manifest
+    assert store.read(
+        room_id="room-1",
+        attachment_id=image["attachment_id"],
+        recipient_member_id="research",
+        event_id="event-1",
+    ).data == PNG
+    assert store.read(
+        room_id="room-1",
+        attachment_id=pdf["attachment_id"],
+        recipient_member_id="builder",
+    ).data == PDF
+    with pytest.raises(AttachmentNotFoundError):
+        store.read(
+            room_id="room-1",
+            attachment_id=image["attachment_id"],
+            recipient_member_id="late-member",
+        )
+
+
+@pytest.mark.parametrize(
+    ("kind", "mime", "data"),
+    [
+        ("image", "image/png", b"not an image"),
+        ("pdf", "application/pdf", b"not a pdf"),
+        ("file", "text/plain", b"text\x00binary"),
+        ("file", "image/png", PNG),
+    ],
+)
+def test_mime_mismatches_are_rejected(tmp_path, kind, mime, data):
+    store = HostedRoomAttachmentStore(tmp_path / "state.db")
+
+    with pytest.raises(AttachmentError, match="MIME|mime|kind|bytes"):
+        _put(store, data=data, kind=kind, mime=mime, name="claimed.dat")
+
+
+@pytest.mark.parametrize(
+    ("name", "mime"),
+    [
+        (
+            "brief.docx",
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        ),
+        (
+            "budget.xlsx",
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        ),
+        (
+            "deck.pptx",
+            "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        ),
+        ("book.epub", "application/epub+zip"),
+        ("library.jar", "application/java-archive"),
+        ("mobile.apk", "application/vnd.android.package-archive"),
+    ],
+)
+def test_generic_zip_container_formats_are_accepted_as_opaque_files(
+    tmp_path, name, mime
+):
+    store = HostedRoomAttachmentStore(tmp_path / "state.db")
+    container = b"PK\x03\x04" + b"opaque-container-payload"
+
+    attachment = _put(
+        store,
+        data=container,
+        kind="file",
+        name=name,
+        mime=mime,
+    )
+
+    assert attachment["name"] == name
+    assert attachment["mime"] == mime
+
+
+def test_task_manifest_has_independent_count_and_byte_budgets():
+    entry = {
+        "attachment_id": "att_00000000000000000000000000000000",
+        "kind": "file",
+        "name": "part.bin",
+        "size": 1,
+        "mime": "application/octet-stream",
+    }
+    too_many = [
+        {
+            **entry,
+            "attachment_id": f"att_{index:032x}",
+            "name": f"part-{index}.bin",
+        }
+        for index in range(MAX_TASK_ATTACHMENTS + 1)
+    ]
+    with pytest.raises(AttachmentError, match="at most"):
+        validate_task_manifest(too_many)
+
+    too_large = [
+        {
+            **entry,
+            "attachment_id": f"att_{index + 1:032x}",
+            "name": f"chunk-{index}.bin",
+            "size": 13_000_000,
+        }
+        for index in range(4)
+    ]
+    with pytest.raises(AttachmentError, match="aggregate byte limit"):
+        validate_task_manifest(too_large)
+
+
+def test_uncommitted_expiry_and_disband_grace_release_deduplicated_blob(tmp_path):
+    now = [100.0]
+    store = HostedRoomAttachmentStore(tmp_path / "state.db", clock=lambda: now[0])
+    first = _put(store)
+    second = _put(store, upload_id="upload-2")
+    store.commit_message(
+        room_id="room-1",
+        event_id="event-1",
+        manifest=_manifest(first),
+        recipient_member_ids=("research",),
+    )
+
+    now[0] += UNCOMMITTED_TTL_SECONDS + 1
+    assert store.prune() == 1
+    assert store.stats()["blobs"] == 1
+    assert store.stats()["attachments"] == 1
+
+    assert store.mark_room_disbanded("room-1") == 1
+    now[0] += 15 * 60 + 1
+    assert store.prune() == 1
+    assert store.stats()["blobs"] == 0
+    assert not any(store.blob_root.iterdir())
+    with pytest.raises(AttachmentNotFoundError):
+        store.read(
+            room_id="room-1",
+            attachment_id=second["attachment_id"],
+            recipient_member_id="research",
+        )
+
+
+def test_new_upload_reclaims_expired_uncommitted_quota_without_restart(tmp_path):
+    now = [100.0]
+    store = HostedRoomAttachmentStore(
+        tmp_path / "state.db",
+        clock=lambda: now[0],
+        room_quota_bytes=len(PNG),
+    )
+    _put(store, upload_id="expired")
+    now[0] += UNCOMMITTED_TTL_SECONDS + 1
+
+    current = _put(store, upload_id="current")
+
+    assert current["attachment_id"].startswith("att_")
+    assert store.stats()["attachments"] == 1
+
+
+def test_integrity_check_rejects_tampering_and_symlink_replacement(tmp_path):
+    store = HostedRoomAttachmentStore(tmp_path / "state.db")
+    attachment = _put(store)
+    store.commit_message(
+        room_id="room-1",
+        event_id="event-1",
+        manifest=_manifest(attachment),
+        recipient_member_ids=("research",),
+    )
+    blob = next(path for path in store.blob_root.iterdir() if path.name.startswith("blob_"))
+    blob.write_bytes(PNG + b"tampered")
+    with pytest.raises(AttachmentIntegrityError):
+        store.read(
+            room_id="room-1",
+            attachment_id=attachment["attachment_id"],
+            recipient_member_id="research",
+        )
+
+    blob.unlink()
+    target = tmp_path / "outside"
+    target.write_bytes(PNG)
+    try:
+        blob.symlink_to(target)
+    except OSError:
+        pytest.skip("symlink creation is unavailable")
+    with pytest.raises(AttachmentIntegrityError):
+        store.read(
+            room_id="room-1",
+            attachment_id=attachment["attachment_id"],
+            recipient_member_id="research",
+        )
+
+
+def test_room_and_gateway_quotas_are_bounded(tmp_path):
+    room_limited = HostedRoomAttachmentStore(
+        tmp_path / "room.db", room_quota_bytes=len(PNG)
+    )
+    _put(room_limited)
+    with pytest.raises(AttachmentQuotaError, match="room"):
+        _put(room_limited, upload_id="upload-2")
+
+    gateway_limited = HostedRoomAttachmentStore(
+        tmp_path / "gateway.db", gateway_quota_bytes=len(PNG)
+    )
+    _put(gateway_limited)
+    with pytest.raises(AttachmentQuotaError, match="gateway"):
+        _put(gateway_limited, upload_id="upload-2", data=PNG + b"other")
+
+
+def test_base64_decoder_is_bounded_and_rejects_data_urls():
+    with pytest.raises(AttachmentError, match="data URL"):
+        decode_content_base64("data:image/png;base64,AAAA")
+    with pytest.raises(AttachmentError, match="valid base64"):
+        decode_content_base64("not-base64")
+
+
+def test_metadata_database_never_contains_blob_bytes_or_paths(tmp_path):
+    db = tmp_path / "state.db"
+    store = HostedRoomAttachmentStore(db)
+    attachment = _put(store)
+    store.commit_message(
+        room_id="room-1",
+        event_id="event-1",
+        manifest=_manifest(attachment),
+        recipient_member_ids=("research",),
+    )
+
+    conn = sqlite3.connect(db)
+    row = conn.execute(
+        "SELECT * FROM hosted_room_attachments WHERE attachment_id=?",
+        (attachment["attachment_id"],),
+    ).fetchone()
+    conn.close()
+    encoded = repr(row)
+    assert repr(PNG) not in encoded
+    assert str(store.root) not in encoded
+
+
+def test_restart_reconciles_event_commit_and_expires_abandoned_commit(tmp_path):
+    now = [100.0]
+    db = tmp_path / "state.db"
+    hosted_rooms.create_room(
+        db,
+        room_id="room-1",
+        name="Release",
+        members=[{"member_id": "research"}],
+        authority_gateway_id="gateway-a",
+        now=now[0],
+    )
+    store = HostedRoomAttachmentStore(db, clock=lambda: now[0])
+    retained = _put(store, upload_id="retained")
+    abandoned = _put(store, upload_id="abandoned", data=PNG + b"other")
+    store.commit_message(
+        room_id="room-1",
+        event_id="event-retained",
+        manifest=_manifest(retained),
+        recipient_member_ids=("research",),
+        hold_until_event=True,
+    )
+    store.commit_message(
+        room_id="room-1",
+        event_id="event-abandoned",
+        manifest=_manifest(abandoned),
+        recipient_member_ids=("research",),
+        hold_until_event=True,
+    )
+    hosted_rooms.append_event(
+        db,
+        room_id="room-1",
+        event_id="event-retained",
+        kind="message.user",
+        actor={"kind": "user", "id": "desktop"},
+        payload={"text": "inspect", "thread_id": "thread-1"},
+        now=now[0],
+    )
+
+    now[0] += UNCOMMITTED_TTL_SECONDS + 1
+    restarted = HostedRoomAttachmentStore(db, clock=lambda: now[0])
+
+    assert restarted.read(
+        room_id="room-1",
+        attachment_id=retained["attachment_id"],
+        recipient_member_id="research",
+    ).data == PNG
+    with pytest.raises(AttachmentNotFoundError):
+        restarted.read(
+            room_id="room-1",
+            attachment_id=abandoned["attachment_id"],
+            recipient_member_id="research",
+        )

--- a/tests/gateway/test_hosted_room_discussion.py
+++ b/tests/gateway/test_hosted_room_discussion.py
@@ -148,6 +148,30 @@ def _append_publication(
     ]
 
 
+def _append_activity(
+    db: Path,
+    *,
+    event_id: str,
+    discussion_event_id: str,
+    thread_id: str,
+) -> dict:
+    return hosted_rooms.append_event(
+        db,
+        room_id=ROOM_ID,
+        event_id=event_id,
+        kind="room.activity",
+        actor={"kind": "gateway", "id": GATEWAY_ID},
+        payload={
+            "status": "settled",
+            "reason_code": "silent_round",
+            "thread_id": thread_id,
+            "discussion_event_id": discussion_event_id,
+        },
+        authority_gateway_id=GATEWAY_ID,
+        authority_epoch=1,
+    )
+
+
 def _next_task(room: dict, db: Path) -> discussion.DiscussionTaskPlan:
     decision = discussion.plan_next_task(
         room,
@@ -176,6 +200,44 @@ def _settle_next(
     )
     _append_publication(db, publication)
     return task
+
+
+def test_distinct_threads_are_planned_fifo_without_skipping(room_db):
+    db, room = room_db
+    _append_user(db, event_id="user-1", text="First", thread_id="thread-1")
+    _append_user(db, event_id="user-2", text="Second", thread_id="thread-2")
+
+    first = _next_task(room, db)
+    assert first.discussion_event_id == "user-1"
+    _append_activity(
+        db,
+        event_id="activity-1",
+        discussion_event_id="user-1",
+        thread_id="thread-1",
+    )
+    second = _next_task(room, db)
+    assert second.discussion_event_id == "user-2"
+
+
+def test_room_stop_fences_old_work_but_allows_a_later_message(room_db):
+    db, room = room_db
+    _append_user(db, event_id="user-1", text="First", thread_id="thread-1")
+    stop = hosted_rooms.request_room_stop(
+        db,
+        room_id=ROOM_ID,
+        cancel_id="user-stop-1",
+    )
+    decision = discussion.plan_next_task(
+        room,
+        _events(db),
+        local_profiles=LOCAL_PROFILES,
+    )
+    assert decision.status == "idle"
+    assert stop["kind"] == "room.stop_requested"
+
+    _append_user(db, event_id="user-2", text="Continue", thread_id="thread-2")
+    resumed = _next_task(room, db)
+    assert resumed.discussion_event_id == "user-2"
 
 
 def test_deterministic_task_fits_existing_driver_and_reconstructs_after_restart(

--- a/tests/gateway/test_hosted_room_discussion.py
+++ b/tests/gateway/test_hosted_room_discussion.py
@@ -1,0 +1,920 @@
+"""Behavior tests for deterministic same-gateway Discussion policy."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+from gateway import hosted_room_discussion as discussion
+from gateway import hosted_room_driver as driver
+from gateway import hosted_rooms
+
+
+ROOM_ID = "room-1"
+GATEWAY_ID = "gateway-a"
+LOCAL_PROFILES = ("research", "build", "review", "ops", "qa", "docs")
+MEMBERS = [
+    {
+        "member_id": f"member-{profile}",
+        "profile": profile,
+        "handle": profile,
+        "display_name": profile.title(),
+    }
+    for profile in LOCAL_PROFILES[:3]
+]
+MEMBER_IDS = tuple(member["member_id"] for member in MEMBERS)
+
+
+def _refs(
+    overrides: dict[str, str | None] | None = None,
+) -> dict[str, str | None]:
+    refs: dict[str, str | None] = {member_id: None for member_id in MEMBER_IDS}
+    if overrides:
+        refs.update(overrides)
+    return refs
+
+
+def _attachment(
+    kind: str,
+    name: str,
+    mime: str,
+    *,
+    size: int = 128,
+    refs: dict[str, str | None] | None = None,
+) -> dict:
+    return {
+        "kind": kind,
+        "name": name,
+        "size": size,
+        "mime": mime,
+        "refs": refs if refs is not None else _refs(),
+    }
+
+
+def _attachment_manifest() -> list[dict]:
+    return [
+        _attachment(
+            "image",
+            "diagram.png",
+            "image/png",
+            size=2048,
+            refs=_refs({
+                "member-research": "stage:image:research",
+                "member-build": "stage:image:build",
+            }),
+        ),
+        _attachment(
+            "pdf",
+            "release.pdf",
+            "application/pdf",
+            size=4096,
+            refs=_refs({
+                "member-research": "stage:pdf:research",
+                "member-build": "stage:pdf:build",
+            }),
+        ),
+        _attachment(
+            "file",
+            "notes.txt",
+            "text/plain",
+            size=512,
+            refs=_refs({
+                "member-research": "stage:file:research",
+                "member-build": "stage:file:build",
+                "member-review": "stage:file:review",
+            }),
+        ),
+    ]
+
+
+@pytest.fixture
+def room_db(tmp_path: Path) -> tuple[Path, dict]:
+    db = tmp_path / "state.db"
+    room = hosted_rooms.create_room(
+        db,
+        room_id=ROOM_ID,
+        name="Release",
+        members=MEMBERS,
+        authority_gateway_id=GATEWAY_ID,
+        now=1,
+    )
+    return db, room
+
+
+def _events(db: Path) -> list[dict]:
+    return hosted_rooms.read_events(
+        db,
+        room_id=ROOM_ID,
+        since_seq=0,
+        limit=hosted_rooms.MAX_LOG_LIMIT,
+    )["events"]
+
+
+def _append_user(
+    db: Path,
+    *,
+    event_id: str,
+    text: str,
+    thread_id: str = "thread-1",
+    attachments: list[dict] | None = None,
+) -> dict:
+    payload: dict[str, object] = {"text": text, "thread_id": thread_id}
+    if attachments is not None:
+        payload["attachments"] = attachments
+    return hosted_rooms.append_event(
+        db,
+        room_id=ROOM_ID,
+        event_id=event_id,
+        kind="message.user",
+        actor={"kind": "user", "id": "local-user"},
+        payload=payload,
+        now=time.time(),
+    )
+
+
+def _append_publication(
+    db: Path,
+    plan: discussion.PublicationPlan,
+) -> list[dict]:
+    return [
+        hosted_rooms.append_event(
+            db,
+            **event.append_kwargs(ROOM_ID),
+            now=time.time(),
+        )
+        for event in plan.events
+    ]
+
+
+def _next_task(room: dict, db: Path) -> discussion.DiscussionTaskPlan:
+    decision = discussion.plan_next_task(
+        room,
+        _events(db),
+        local_profiles=LOCAL_PROFILES,
+    )
+    assert decision.status == "task", decision
+    assert decision.task is not None
+    return decision.task
+
+
+def _settle_next(
+    room: dict,
+    db: Path,
+    *,
+    text: str,
+) -> discussion.DiscussionTaskPlan:
+    task = _next_task(room, db)
+    publication = discussion.plan_publication(
+        room,
+        _events(db),
+        task,
+        status="settled",
+        result={"text": text},
+        local_profiles=LOCAL_PROFILES,
+    )
+    _append_publication(db, publication)
+    return task
+
+
+def test_deterministic_task_fits_existing_driver_and_reconstructs_after_restart(
+    room_db: tuple[Path, dict],
+):
+    db, room = room_db
+    user = _append_user(db, event_id="user-1", text="Check the release.")
+
+    first = _next_task(room, db)
+    repeated = _next_task(room, db)
+    assert first == repeated
+    assert first.identity.thread_id == "thread-1"
+    assert first.payload == {
+        "target_profile": "research",
+        "prompt": first.payload["prompt"],
+        "source_event_seq": user["seq"],
+    }
+    assert set(first.payload) == {"target_profile", "prompt", "source_event_seq"}
+
+    admitted = driver.admit_task(
+        db,
+        first.identity,
+        payload=first.payload,
+        clock=time.time,
+    )
+    stored = driver.get_task(db, first.identity)
+    reconstructed = discussion.reconstruct_task_plan(
+        room,
+        _events(db),
+        stored,
+        local_profiles=LOCAL_PROFILES,
+    )
+    assert admitted["status"] == "queued"
+    assert reconstructed == first
+
+    reopened_events = _events(db)
+    assert (
+        discussion.reconstruct_task_plan(
+            room,
+            reopened_events,
+            driver.get_task(db, first.identity),
+            local_profiles=LOCAL_PROFILES,
+        )
+        == first
+    )
+
+
+@pytest.mark.parametrize(
+    ("text", "expected_profile"),
+    [
+        ("@build please inspect this", "build"),
+        ("@all inspect this", "research"),
+        ("@everyone inspect this", "research"),
+        ("inspect this", "research"),
+        ("@unknown inspect this", "research"),
+    ],
+)
+def test_mentions_select_handles_or_everyone(
+    room_db: tuple[Path, dict],
+    text: str,
+    expected_profile: str,
+):
+    db, room = room_db
+    _append_user(db, event_id="user-1", text=text)
+
+    assert _next_task(room, db).member.profile == expected_profile
+
+
+def test_member_mention_joins_the_next_round_not_the_current_round(
+    room_db: tuple[Path, dict],
+):
+    db, room = room_db
+    _append_user(db, event_id="user-1", text="@research lead this")
+
+    first = _settle_next(room, db, text="@build can add the implementation detail.")
+    second = _next_task(room, db)
+
+    assert first.member.profile == "research"
+    assert first.round_index == 0
+    assert second.member.profile == "build"
+    assert second.round_index == 1
+
+
+@pytest.mark.parametrize("value", ["", "pass", "pass.", "(pass)", " ( PASS ). "])
+def test_pass_detection(value: str):
+    assert discussion.is_pass_text(value)
+
+
+def test_real_text_is_not_a_pass():
+    assert not discussion.is_pass_text("I found the issue.")
+
+
+def test_full_pass_round_settles_without_member_messages(
+    room_db: tuple[Path, dict],
+):
+    db, room = room_db
+    _append_user(db, event_id="user-1", text="Any concerns?")
+
+    for _member in MEMBERS:
+        _settle_next(room, db, text="(pass)")
+
+    decision = discussion.plan_next_task(
+        room,
+        _events(db),
+        local_profiles=LOCAL_PROFILES,
+    )
+    assert decision.status == "settled"
+    assert decision.reason == "silent_round"
+    assert [event["kind"] for event in _events(db)].count("message.member") == 0
+
+
+def test_failed_members_advance_the_round_as_silence(
+    room_db: tuple[Path, dict],
+):
+    db, room = room_db
+    _append_user(db, event_id="user-1", text="Any concerns?")
+
+    for expected in ("research", "build", "review"):
+        task = _next_task(room, db)
+        assert task.member.profile == expected
+        publication = discussion.plan_publication(
+            room,
+            _events(db),
+            task,
+            status="failed",
+            result={"error": f"{expected} unavailable"},
+            local_profiles=LOCAL_PROFILES,
+        )
+        assert publication.terminal_kind == "turn.failed"
+        assert len(publication.events) == 1
+        _append_publication(db, publication)
+
+    decision = discussion.plan_next_task(
+        room,
+        _events(db),
+        local_profiles=LOCAL_PROFILES,
+    )
+    assert decision.status == "settled"
+    assert decision.reason == "silent_round"
+
+
+def test_publication_is_idempotent_and_changed_result_conflicts(
+    room_db: tuple[Path, dict],
+):
+    db, room = room_db
+    _append_user(db, event_id="user-1", text="Report.")
+    task = _next_task(room, db)
+    publication = discussion.plan_publication(
+        room,
+        _events(db),
+        task,
+        status="settled",
+        result={"text": "Ready."},
+        local_profiles=LOCAL_PROFILES,
+    )
+
+    first = _append_publication(db, publication)
+    repeated = _append_publication(db, publication)
+    assert [event["seq"] for event in first] == [event["seq"] for event in repeated]
+    assert all(event["idempotent"] for event in repeated)
+
+    changed = discussion.plan_publication(
+        room,
+        _events(db),
+        task,
+        status="settled",
+        result={"text": "Different."},
+        local_profiles=LOCAL_PROFILES,
+    )
+    with pytest.raises(hosted_rooms.EventConflictError):
+        _append_publication(db, changed)
+
+
+def test_partial_publication_replays_same_effects_before_policy_advances(
+    room_db: tuple[Path, dict],
+):
+    db, room = room_db
+    _append_user(db, event_id="user-1", text="Report.")
+    task = _next_task(room, db)
+    publication = discussion.plan_publication(
+        room,
+        _events(db),
+        task,
+        status="settled",
+        result={"text": "Ready."},
+        local_profiles=LOCAL_PROFILES,
+    )
+
+    message_effect = publication.events[0]
+    hosted_rooms.append_event(
+        db,
+        **message_effect.append_kwargs(ROOM_ID),
+        now=time.time(),
+    )
+    assert _next_task(room, db).identity == task.identity
+
+    replayed = discussion.plan_publication(
+        room,
+        _events(db),
+        task,
+        status="settled",
+        result={"text": "Ready."},
+        local_profiles=LOCAL_PROFILES,
+    )
+    _append_publication(db, replayed)
+    assert _next_task(room, db).member.profile == "build"
+
+
+def test_watermark_excludes_a_members_old_input_and_own_reply(
+    room_db: tuple[Path, dict],
+):
+    db, room = room_db
+    _append_user(db, event_id="user-1", text="Old request.")
+    first = _settle_next(room, db, text="Old answer.")
+    watermark = discussion.derive_member_watermarks(
+        room,
+        _events(db),
+        local_profiles=LOCAL_PROFILES,
+    )[("thread-1", first.member.member_id)]
+    assert watermark == max(
+        event["seq"]
+        for event in _events(db)
+        if event["kind"] == "message.member"
+        and event["payload"]["task_id"] == first.identity.task_id
+    )
+
+    latest = _append_user(db, event_id="user-2", text="New request.")
+    next_task = _next_task(room, db)
+    assert next_task.member.profile == "research"
+    assert next_task.payload["source_event_seq"] == latest["seq"]
+    assert "New request." in next_task.payload["prompt"]
+    assert "Old request." not in next_task.payload["prompt"]
+    assert "Old answer." not in next_task.payload["prompt"]
+
+
+def test_newer_same_thread_user_event_cancels_a_late_result(
+    room_db: tuple[Path, dict],
+):
+    db, room = room_db
+    _append_user(db, event_id="user-1", text="First request.")
+    stale = _next_task(room, db)
+    latest = _append_user(db, event_id="user-2", text="Second request.")
+
+    publication = discussion.plan_publication(
+        room,
+        _events(db),
+        stale,
+        status="settled",
+        result={"text": "Late stale answer."},
+        local_profiles=LOCAL_PROFILES,
+    )
+    assert publication.terminal_kind == "turn.cancelled"
+    assert [event.kind for event in publication.events] == ["turn.cancelled"]
+    assert publication.events[0].payload["reason"] == "superseded_by_newer_user_event"
+    _append_publication(db, publication)
+
+    current = _next_task(room, db)
+    assert current.payload["source_event_seq"] == latest["seq"]
+    assert "Second request." in current.payload["prompt"]
+
+
+def test_cross_thread_newer_user_does_not_discard_completed_old_reply(
+    room_db: tuple[Path, dict],
+):
+    db, room = room_db
+    _append_user(db, event_id="user-1", text="First request.", thread_id="thread-1")
+    old = _next_task(room, db)
+    _append_user(db, event_id="user-2", text="Other topic.", thread_id="thread-2")
+
+    publication = discussion.plan_publication(
+        room,
+        _events(db),
+        old,
+        status="settled",
+        result={"text": "Completed first topic."},
+        local_profiles=LOCAL_PROFILES,
+    )
+    assert [event.kind for event in publication.events] == [
+        "message.member",
+        "turn.settled",
+    ]
+
+
+def test_three_round_bound(room_db: tuple[Path, dict]):
+    db, room = room_db
+    room["members"] = MEMBERS[:2]
+    _append_user(db, event_id="user-1", text="Discuss.")
+
+    for index in range(6):
+        _settle_next(room, db, text=f"Reply {index}.")
+
+    decision = discussion.plan_next_task(
+        room,
+        _events(db),
+        local_profiles=LOCAL_PROFILES,
+    )
+    assert decision.status == "bounded"
+    assert decision.reason == "max_rounds"
+
+
+def test_ten_message_bound(tmp_path: Path):
+    db = tmp_path / "state.db"
+    members = [
+        {
+            "member_id": f"member-{profile}",
+            "profile": profile,
+            "handle": profile,
+        }
+        for profile in LOCAL_PROFILES
+    ]
+    room = hosted_rooms.create_room(
+        db,
+        room_id=ROOM_ID,
+        name="Large",
+        members=members,
+        authority_gateway_id=GATEWAY_ID,
+        now=1,
+    )
+    _append_user(db, event_id="user-1", text="Discuss.")
+
+    for index in range(discussion.MAX_DISCUSSION_MESSAGES):
+        _settle_next(room, db, text=f"Reply {index}.")
+
+    decision = discussion.plan_next_task(
+        room,
+        _events(db),
+        local_profiles=LOCAL_PROFILES,
+    )
+    assert decision.status == "bounded"
+    assert decision.reason == "max_messages"
+
+
+def test_prompt_delta_is_bounded_to_24_message_lines(
+    room_db: tuple[Path, dict],
+):
+    db, room = room_db
+    for index in range(30):
+        _append_user(
+            db,
+            event_id=f"user-{index}",
+            text=f"Message {index}.",
+        )
+
+    task = _next_task(room, db)
+    assert task.payload["prompt"].count("User (user):") == 24
+    assert "Message 5." not in task.payload["prompt"]
+    assert "Message 6." in task.payload["prompt"]
+    assert "Message 29." in task.payload["prompt"]
+
+
+def test_valid_image_pdf_and_file_manifest_is_normalized():
+    payload = discussion.validate_user_payload(
+        {
+            "text": "Review the attached material.",
+            "thread_id": "thread-1",
+            "attachments": _attachment_manifest(),
+        },
+        member_ids=MEMBER_IDS,
+    )
+
+    assert [attachment["kind"] for attachment in payload["attachments"]] == [
+        "image",
+        "pdf",
+        "file",
+    ]
+    assert payload["attachments"][0] == {
+        "kind": "image",
+        "name": "diagram.png",
+        "size": 2048,
+        "mime": "image/png",
+        "refs": _refs({
+            "member-research": "stage:image:research",
+            "member-build": "stage:image:build",
+        }),
+    }
+
+
+def test_prompts_include_only_the_current_members_refs_and_queued_media_note(
+    room_db: tuple[Path, dict],
+):
+    db, room = room_db
+    _append_user(
+        db,
+        event_id="user-attachments",
+        text="Review the upload.",
+        attachments=_attachment_manifest(),
+    )
+
+    research = _next_task(room, db)
+    research_prompt = research.payload["prompt"]
+    assert research.member.member_id == "member-research"
+    assert "User (user): Review the upload." in research_prompt
+    assert "User (user): Review the upload. diagram.png" not in research_prompt
+    assert "stage:image:research" in research_prompt
+    assert "stage:pdf:research" in research_prompt
+    assert "stage:file:research" in research_prompt
+    assert "stage:image:build" not in research_prompt
+    assert "Queued image/PDF attachments are staged separately" in research_prompt
+    assert 'Queued image "diagram.png"' in research_prompt
+    assert 'Queued PDF "release.pdf"' in research_prompt
+    assert 'Staged file "notes.txt"' in research_prompt
+
+    publication = discussion.plan_publication(
+        room,
+        _events(db),
+        research,
+        status="settled",
+        result={"text": "(pass)"},
+        local_profiles=LOCAL_PROFILES,
+    )
+    _append_publication(db, publication)
+    build = _next_task(room, db)
+    build_prompt = build.payload["prompt"]
+    assert build.member.member_id == "member-build"
+    assert "stage:image:build" in build_prompt
+    assert "stage:pdf:build" in build_prompt
+    assert "stage:file:build" in build_prompt
+    assert "stage:image:research" not in build_prompt
+    assert build.identity.task_id != research.identity.task_id
+
+
+def test_attachment_manifest_changes_the_deterministic_task_id(
+    room_db: tuple[Path, dict],
+):
+    db, room = room_db
+    _append_user(
+        db,
+        event_id="user-attachments",
+        text="Review the upload.",
+        attachments=_attachment_manifest(),
+    )
+    with_attachments = _next_task(room, db)
+    without_events = [
+        {
+            **event,
+            "payload": {
+                "text": event["payload"]["text"],
+                "thread_id": event["payload"]["thread_id"],
+            },
+        }
+        if event["kind"] == "message.user"
+        else event
+        for event in _events(db)
+    ]
+    without_attachments = discussion.plan_next_task(
+        room,
+        without_events,
+        local_profiles=LOCAL_PROFILES,
+    ).task
+
+    assert without_attachments is not None
+    assert with_attachments.identity.turn_id == without_attachments.identity.turn_id
+    assert with_attachments.identity.task_id != without_attachments.identity.task_id
+    assert with_attachments.payload["prompt"] != without_attachments.payload["prompt"]
+
+
+def test_attachment_task_reconstructs_after_driver_reopen(
+    room_db: tuple[Path, dict],
+):
+    db, room = room_db
+    _append_user(
+        db,
+        event_id="user-attachments",
+        text="Review the upload.",
+        attachments=_attachment_manifest(),
+    )
+    task = _next_task(room, db)
+    driver.admit_task(db, task.identity, payload=task.payload, clock=time.time)
+
+    reconstructed = discussion.reconstruct_task_plan(
+        room,
+        _events(db),
+        driver.get_task(db, task.identity),
+        local_profiles=LOCAL_PROFILES,
+    )
+    assert reconstructed == task
+    assert "stage:image:research" in reconstructed.payload["prompt"]
+
+
+def test_attachment_refs_require_every_member_and_reject_unknown_members():
+    missing = _refs()
+    missing.pop("member-review")
+    unknown = _refs()
+    unknown["member-remote"] = "stage:file:remote"
+
+    with pytest.raises(
+        discussion.DiscussionValidationError, match="missing member ids"
+    ):
+        discussion.validate_user_payload(
+            {
+                "text": "Review.",
+                "thread_id": "thread-1",
+                "attachments": [
+                    _attachment("file", "notes.txt", "text/plain", refs=missing)
+                ],
+            },
+            member_ids=MEMBER_IDS,
+        )
+    with pytest.raises(
+        discussion.DiscussionValidationError, match="unknown member ids"
+    ):
+        discussion.validate_user_payload(
+            {
+                "text": "Review.",
+                "thread_id": "thread-1",
+                "attachments": [
+                    _attachment("file", "notes.txt", "text/plain", refs=unknown)
+                ],
+            },
+            member_ids=MEMBER_IDS,
+        )
+
+
+@pytest.mark.parametrize("field", ["data", "data_url", "base64", "path"])
+def test_attachment_manifest_rejects_raw_data_and_path_fields(field: str):
+    attachment = _attachment("file", "notes.txt", "text/plain")
+    attachment[field] = "/tmp/raw" if field == "path" else "AAAA"
+
+    with pytest.raises(discussion.DiscussionValidationError, match="unknown fields"):
+        discussion.validate_user_payload(
+            {
+                "text": "Review.",
+                "thread_id": "thread-1",
+                "attachments": [attachment],
+            },
+            member_ids=MEMBER_IDS,
+        )
+
+
+def test_attachment_manifest_requires_every_exact_metadata_field():
+    attachment = _attachment("file", "notes.txt", "text/plain")
+    attachment.pop("mime")
+
+    with pytest.raises(discussion.DiscussionValidationError, match="missing fields"):
+        discussion.validate_user_payload(
+            {
+                "text": "Review.",
+                "thread_id": "thread-1",
+                "attachments": [attachment],
+            },
+            member_ids=MEMBER_IDS,
+        )
+
+
+@pytest.mark.parametrize(
+    "unsafe_ref",
+    [
+        "data:image/png;base64,AAAA",
+        "base64:AAAA",
+        "file:secret",
+        "path:secret",
+        "/tmp/secret",
+        "../secret",
+        "folder/secret",
+        "C:\\secret",
+    ],
+)
+def test_attachment_manifest_rejects_unsafe_refs(unsafe_ref: str):
+    refs = _refs({"member-research": unsafe_ref})
+
+    with pytest.raises(discussion.DiscussionValidationError, match="safe opaque ref"):
+        discussion.validate_user_payload(
+            {
+                "text": "Review.",
+                "thread_id": "thread-1",
+                "attachments": [
+                    _attachment("file", "notes.txt", "text/plain", refs=refs)
+                ],
+            },
+            member_ids=MEMBER_IDS,
+        )
+
+
+@pytest.mark.parametrize(
+    ("attachment", "match"),
+    [
+        (
+            _attachment("file", "x" * 256, "text/plain"),
+            "bounded basename",
+        ),
+        (
+            _attachment("file", "../secret", "text/plain"),
+            "bounded basename",
+        ),
+        (
+            _attachment(
+                "file",
+                "notes.txt",
+                "text/plain",
+                size=discussion.MAX_ATTACHMENT_SIZE_BYTES + 1,
+            ),
+            "size must be between",
+        ),
+        (
+            _attachment("image", "image.bin", "application/octet-stream"),
+            "image kind requires image mime",
+        ),
+        (
+            _attachment("pdf", "release.pdf", "application/octet-stream"),
+            "pdf kind requires application/pdf",
+        ),
+        (
+            _attachment(
+                "file",
+                "notes.txt",
+                "text/plain",
+                refs=_refs({"member-research": "r" * 257}),
+            ),
+            "safe opaque ref",
+        ),
+    ],
+)
+def test_attachment_metadata_is_bounded(attachment: dict, match: str):
+    with pytest.raises(discussion.DiscussionValidationError, match=match):
+        discussion.validate_user_payload(
+            {
+                "text": "Review.",
+                "thread_id": "thread-1",
+                "attachments": [attachment],
+            },
+            member_ids=MEMBER_IDS,
+        )
+
+
+def test_attachment_count_is_bounded():
+    attachments = [
+        _attachment("file", f"notes-{index}.txt", "text/plain")
+        for index in range(discussion.MAX_ATTACHMENTS + 1)
+    ]
+
+    with pytest.raises(discussion.DiscussionValidationError, match="at most 8"):
+        discussion.validate_user_payload(
+            {
+                "text": "Review.",
+                "thread_id": "thread-1",
+                "attachments": attachments,
+            },
+            member_ids=MEMBER_IDS,
+        )
+
+
+def test_attachment_manifest_total_metadata_is_bounded():
+    maximum_ref = "r" * discussion.MAX_ATTACHMENT_REF_CHARS
+    member_ids = tuple(f"member-{profile}" for profile in LOCAL_PROFILES)
+    refs: dict[str, str | None] = {member_id: maximum_ref for member_id in member_ids}
+    attachments = [
+        _attachment(
+            "file",
+            "\U0001f9ea" * discussion.MAX_ATTACHMENT_NAME_CHARS,
+            "application/octet-stream",
+            refs=refs,
+        )
+        for _index in range(discussion.MAX_ATTACHMENTS)
+    ]
+
+    with pytest.raises(
+        discussion.DiscussionValidationError, match="manifest is too large"
+    ):
+        discussion.validate_user_payload(
+            {
+                "text": "Review.",
+                "thread_id": "thread-1",
+                "attachments": attachments,
+            },
+            member_ids=member_ids,
+        )
+
+
+@pytest.mark.parametrize(
+    ("members", "match"),
+    [
+        (MEMBERS[:1], "between 2 and 6"),
+        (MEMBERS + MEMBERS + MEMBERS[:1], "between 2 and 6"),
+        (
+            [MEMBERS[0], {**MEMBERS[1], "profile": "research"}],
+            "profiles must be unique",
+        ),
+        ([MEMBERS[0], {**MEMBERS[1], "handle": "RESEARCH"}], "handles must be unique"),
+        (
+            [MEMBERS[0], {**MEMBERS[1], "member_id": "MEMBER-RESEARCH"}],
+            "ids must be unique",
+        ),
+        ([MEMBERS[0], {**MEMBERS[1], "route": {"mode": "ssh"}}], "cross-gateway"),
+        ([MEMBERS[0], {**MEMBERS[1], "connectionId": "remote"}], "cross-gateway"),
+        ([MEMBERS[0], {**MEMBERS[1], "profile": "missing"}], "not local"),
+    ],
+)
+def test_malformed_or_remote_roster_is_rejected(members: list[dict], match: str):
+    with pytest.raises(discussion.DiscussionValidationError, match=match):
+        discussion.validate_roster(members, local_profiles=LOCAL_PROFILES)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"text": "hello"},
+        {"text": "hello", "thread_id": "thread-1", "images": []},
+        {"text": "", "thread_id": "thread-1"},
+        {"text": "hello", "thread_id": "../escape"},
+        {"text": ["hello"], "thread_id": "thread-1"},
+    ],
+)
+def test_user_payload_is_exact_and_text_only(payload: dict):
+    with pytest.raises(discussion.DiscussionValidationError):
+        discussion.validate_user_payload(payload)
+
+
+def test_malformed_log_and_task_reconstruction_fail_closed(
+    room_db: tuple[Path, dict],
+):
+    db, room = room_db
+    _append_user(db, event_id="user-1", text="Report.")
+    _append_user(db, event_id="user-2", text="Report again.")
+    task = _next_task(room, db)
+    events = _events(db)
+
+    with pytest.raises(discussion.DiscussionValidationError, match="sequence order"):
+        discussion.plan_next_task(
+            room,
+            list(reversed(events)),
+            local_profiles=LOCAL_PROFILES,
+        )
+
+    malformed = {
+        "identity": driver.TaskIdentity(
+            room_id=task.identity.room_id,
+            task_id="dtask:wrong",
+            thread_id=task.identity.thread_id,
+            turn_id=task.identity.turn_id,
+        ),
+        "payload": dict(task.payload),
+    }
+    with pytest.raises(
+        discussion.DiscussionReconstructionError,
+        match="deterministic reconstruction",
+    ):
+        discussion.reconstruct_task_plan(
+            room,
+            events,
+            malformed,
+            local_profiles=LOCAL_PROFILES,
+        )

--- a/tests/gateway/test_hosted_room_discussion.py
+++ b/tests/gateway/test_hosted_room_discussion.py
@@ -27,29 +27,20 @@ MEMBERS = [
 MEMBER_IDS = tuple(member["member_id"] for member in MEMBERS)
 
 
-def _refs(
-    overrides: dict[str, str | None] | None = None,
-) -> dict[str, str | None]:
-    refs: dict[str, str | None] = {member_id: None for member_id in MEMBER_IDS}
-    if overrides:
-        refs.update(overrides)
-    return refs
-
-
 def _attachment(
     kind: str,
     name: str,
     mime: str,
     *,
     size: int = 128,
-    refs: dict[str, str | None] | None = None,
+    attachment_id: str = "att_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 ) -> dict:
     return {
+        "attachment_id": attachment_id,
         "kind": kind,
         "name": name,
         "size": size,
         "mime": mime,
-        "refs": refs if refs is not None else _refs(),
     }
 
 
@@ -60,31 +51,21 @@ def _attachment_manifest() -> list[dict]:
             "diagram.png",
             "image/png",
             size=2048,
-            refs=_refs({
-                "member-research": "stage:image:research",
-                "member-build": "stage:image:build",
-            }),
+            attachment_id="att_11111111111111111111111111111111",
         ),
         _attachment(
             "pdf",
             "release.pdf",
             "application/pdf",
             size=4096,
-            refs=_refs({
-                "member-research": "stage:pdf:research",
-                "member-build": "stage:pdf:build",
-            }),
+            attachment_id="att_22222222222222222222222222222222",
         ),
         _attachment(
             "file",
             "notes.txt",
             "text/plain",
             size=512,
-            refs=_refs({
-                "member-research": "stage:file:research",
-                "member-build": "stage:file:build",
-                "member-review": "stage:file:review",
-            }),
+            attachment_id="att_33333333333333333333333333333333",
         ),
     ]
 
@@ -604,18 +585,15 @@ def test_valid_image_pdf_and_file_manifest_is_normalized():
         "file",
     ]
     assert payload["attachments"][0] == {
+        "attachment_id": "att_11111111111111111111111111111111",
         "kind": "image",
         "name": "diagram.png",
         "size": 2048,
         "mime": "image/png",
-        "refs": _refs({
-            "member-research": "stage:image:research",
-            "member-build": "stage:image:build",
-        }),
     }
 
 
-def test_prompts_include_only_the_current_members_refs_and_queued_media_note(
+def test_prompts_include_safe_metadata_and_tasks_carry_attachment_ids(
     room_db: tuple[Path, dict],
 ):
     db, room = room_db
@@ -631,10 +609,8 @@ def test_prompts_include_only_the_current_members_refs_and_queued_media_note(
     assert research.member.member_id == "member-research"
     assert "User (user): Review the upload." in research_prompt
     assert "User (user): Review the upload. diagram.png" not in research_prompt
-    assert "stage:image:research" in research_prompt
-    assert "stage:pdf:research" in research_prompt
-    assert "stage:file:research" in research_prompt
-    assert "stage:image:build" not in research_prompt
+    assert "att_11111111111111111111111111111111" not in research_prompt
+    assert research.payload["attachments"] == _attachment_manifest()
     assert "Queued image/PDF attachments are staged separately" in research_prompt
     assert 'Queued image "diagram.png"' in research_prompt
     assert 'Queued PDF "release.pdf"' in research_prompt
@@ -652,11 +628,104 @@ def test_prompts_include_only_the_current_members_refs_and_queued_media_note(
     build = _next_task(room, db)
     build_prompt = build.payload["prompt"]
     assert build.member.member_id == "member-build"
-    assert "stage:image:build" in build_prompt
-    assert "stage:pdf:build" in build_prompt
-    assert "stage:file:build" in build_prompt
-    assert "stage:image:research" not in build_prompt
+    assert "att_11111111111111111111111111111111" not in build_prompt
+    assert build.payload["attachments"] == _attachment_manifest()
     assert build.identity.task_id != research.identity.task_id
+
+
+def test_large_attachment_backlog_advances_in_bounded_lossless_batches(
+    room_db: tuple[Path, dict],
+):
+    db, room = room_db
+    expected_ids: list[str] = []
+    for message_index in range(25):
+        manifest = [
+            _attachment(
+                "file",
+                f"part-{message_index}-{file_index}.bin",
+                "application/octet-stream",
+                size=1,
+                attachment_id=f"att_{message_index * 8 + file_index:032x}",
+            )
+            for file_index in range(8)
+        ]
+        expected_ids.extend(item["attachment_id"] for item in manifest)
+        _append_user(
+            db,
+            event_id=f"user-batch-{message_index}",
+            text=f"Batch {message_index}",
+            attachments=manifest,
+        )
+
+    observed_ids: list[str] = []
+    tasks: list[discussion.DiscussionTaskPlan] = []
+    while len(observed_ids) < len(expected_ids):
+        task = _next_task(room, db)
+        assert task.member.profile == "research"
+        attachments = task.payload["attachments"]
+        assert len(attachments) <= 16
+        assert sum(item["size"] for item in attachments) <= 50_000_000
+        observed_ids.extend(item["attachment_id"] for item in attachments)
+        tasks.append(task)
+        publication = discussion.plan_publication(
+            room,
+            _events(db),
+            task,
+            status="settled",
+            result={"text": "First batch reviewed." if len(tasks) == 1 else "(pass)"},
+            local_profiles=LOCAL_PROFILES,
+        )
+        assert publication.terminal_kind == "turn.settled"
+        _append_publication(db, publication)
+
+    assert observed_ids == expected_ids
+    assert len(tasks) == 13
+    assert len({task.identity.task_id for task in tasks}) == len(tasks)
+    assert tasks[0].seen_through_seq < tasks[-1].seen_through_seq
+    assert "First batch reviewed." not in tasks[1].payload["prompt"]
+
+    next_member = _next_task(room, db)
+    assert next_member.member.profile == "build"
+    assert len(next_member.payload["attachments"]) == 16
+
+
+def test_attachment_backlog_is_also_chunked_by_task_bytes(
+    room_db: tuple[Path, dict],
+):
+    db, room = room_db
+    for message_index in range(3):
+        manifest = [
+            _attachment(
+                "file",
+                f"chunk-{message_index}-{file_index}.bin",
+                "application/octet-stream",
+                size=10_000_000,
+                attachment_id=f"att_{message_index * 2 + file_index:032x}",
+            )
+            for file_index in range(2)
+        ]
+        _append_user(
+            db,
+            event_id=f"user-bytes-{message_index}",
+            text=f"Byte batch {message_index}",
+            attachments=manifest,
+        )
+
+    first = _next_task(room, db)
+    assert sum(item["size"] for item in first.payload["attachments"]) == 40_000_000
+    publication = discussion.plan_publication(
+        room,
+        _events(db),
+        first,
+        status="settled",
+        result={"text": "(pass)"},
+        local_profiles=LOCAL_PROFILES,
+    )
+    _append_publication(db, publication)
+
+    second = _next_task(room, db)
+    assert second.member.profile == "research"
+    assert sum(item["size"] for item in second.payload["attachments"]) == 20_000_000
 
 
 def test_attachment_manifest_changes_the_deterministic_task_id(
@@ -714,40 +783,18 @@ def test_attachment_task_reconstructs_after_driver_reopen(
         local_profiles=LOCAL_PROFILES,
     )
     assert reconstructed == task
-    assert "stage:image:research" in reconstructed.payload["prompt"]
+    assert reconstructed.payload["attachments"] == _attachment_manifest()
+    assert "att_11111111111111111111111111111111" not in reconstructed.payload["prompt"]
 
 
-def test_attachment_refs_require_every_member_and_reject_unknown_members():
-    missing = _refs()
-    missing.pop("member-review")
-    unknown = _refs()
-    unknown["member-remote"] = "stage:file:remote"
-
-    with pytest.raises(
-        discussion.DiscussionValidationError, match="missing member ids"
-    ):
+def test_attachment_manifest_requires_frozen_member_ids():
+    with pytest.raises(discussion.DiscussionValidationError, match="frozen room member"):
         discussion.validate_user_payload(
             {
                 "text": "Review.",
                 "thread_id": "thread-1",
-                "attachments": [
-                    _attachment("file", "notes.txt", "text/plain", refs=missing)
-                ],
+                "attachments": [_attachment("file", "notes.txt", "text/plain")],
             },
-            member_ids=MEMBER_IDS,
-        )
-    with pytest.raises(
-        discussion.DiscussionValidationError, match="unknown member ids"
-    ):
-        discussion.validate_user_payload(
-            {
-                "text": "Review.",
-                "thread_id": "thread-1",
-                "attachments": [
-                    _attachment("file", "notes.txt", "text/plain", refs=unknown)
-                ],
-            },
-            member_ids=MEMBER_IDS,
         )
 
 
@@ -782,29 +829,20 @@ def test_attachment_manifest_requires_every_exact_metadata_field():
         )
 
 
-@pytest.mark.parametrize(
-    "unsafe_ref",
-    [
-        "data:image/png;base64,AAAA",
-        "base64:AAAA",
-        "file:secret",
-        "path:secret",
-        "/tmp/secret",
-        "../secret",
-        "folder/secret",
-        "C:\\secret",
-    ],
-)
-def test_attachment_manifest_rejects_unsafe_refs(unsafe_ref: str):
-    refs = _refs({"member-research": unsafe_ref})
-
-    with pytest.raises(discussion.DiscussionValidationError, match="safe opaque ref"):
+@pytest.mark.parametrize("attachment_id", ["", "att_short", "file:secret", "../secret"])
+def test_attachment_manifest_rejects_non_opaque_ids(attachment_id: str):
+    with pytest.raises(discussion.DiscussionValidationError, match="attachment_id"):
         discussion.validate_user_payload(
             {
                 "text": "Review.",
                 "thread_id": "thread-1",
                 "attachments": [
-                    _attachment("file", "notes.txt", "text/plain", refs=refs)
+                    _attachment(
+                        "file",
+                        "notes.txt",
+                        "text/plain",
+                        attachment_id=attachment_id,
+                    )
                 ],
             },
             member_ids=MEMBER_IDS,
@@ -839,15 +877,6 @@ def test_attachment_manifest_rejects_unsafe_refs(unsafe_ref: str):
             _attachment("pdf", "release.pdf", "application/octet-stream"),
             "pdf kind requires application/pdf",
         ),
-        (
-            _attachment(
-                "file",
-                "notes.txt",
-                "text/plain",
-                refs=_refs({"member-research": "r" * 257}),
-            ),
-            "safe opaque ref",
-        ),
     ],
 )
 def test_attachment_metadata_is_bounded(attachment: dict, match: str):
@@ -864,7 +893,12 @@ def test_attachment_metadata_is_bounded(attachment: dict, match: str):
 
 def test_attachment_count_is_bounded():
     attachments = [
-        _attachment("file", f"notes-{index}.txt", "text/plain")
+        _attachment(
+            "file",
+            f"notes-{index}.txt",
+            "text/plain",
+            attachment_id=f"att_{index:032x}",
+        )
         for index in range(discussion.MAX_ATTACHMENTS + 1)
     ]
 
@@ -879,22 +913,20 @@ def test_attachment_count_is_bounded():
         )
 
 
-def test_attachment_manifest_total_metadata_is_bounded():
-    maximum_ref = "r" * discussion.MAX_ATTACHMENT_REF_CHARS
-    member_ids = tuple(f"member-{profile}" for profile in LOCAL_PROFILES)
-    refs: dict[str, str | None] = {member_id: maximum_ref for member_id in member_ids}
+def test_attachment_manifest_total_bytes_are_bounded():
     attachments = [
         _attachment(
             "file",
-            "\U0001f9ea" * discussion.MAX_ATTACHMENT_NAME_CHARS,
+            f"attachment-{index}.bin",
             "application/octet-stream",
-            refs=refs,
+            size=4_000_000,
+            attachment_id=f"att_{index:032x}",
         )
-        for _index in range(discussion.MAX_ATTACHMENTS)
+        for index in range(discussion.MAX_ATTACHMENTS)
     ]
 
     with pytest.raises(
-        discussion.DiscussionValidationError, match="manifest is too large"
+        discussion.DiscussionValidationError, match="message byte limit"
     ):
         discussion.validate_user_payload(
             {
@@ -902,8 +934,22 @@ def test_attachment_manifest_total_metadata_is_bounded():
                 "thread_id": "thread-1",
                 "attachments": attachments,
             },
-            member_ids=member_ids,
+            member_ids=MEMBER_IDS,
         )
+
+
+def test_attachment_only_user_payload_is_accepted():
+    payload = discussion.validate_user_payload(
+        {
+            "text": "",
+            "thread_id": "thread-1",
+            "attachments": [_attachment("file", "notes.txt", "text/plain")],
+        },
+        member_ids=MEMBER_IDS,
+    )
+
+    assert payload["text"] == ""
+    assert len(payload["attachments"]) == 1
 
 
 @pytest.mark.parametrize(

--- a/tests/gateway/test_hosted_room_driver.py
+++ b/tests/gateway/test_hosted_room_driver.py
@@ -1,0 +1,928 @@
+"""Behavior tests for the hosted-room driver state machine."""
+
+from __future__ import annotations
+
+import sqlite3
+from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
+
+import pytest
+
+from gateway import hosted_rooms as rooms
+from gateway import hosted_room_driver as driver
+
+
+class FakeClock:
+    def __init__(self, value: float = 100.0):
+        self.value = value
+
+    def __call__(self) -> float:
+        return self.value
+
+    def advance(self, seconds: float) -> None:
+        self.value += seconds
+
+
+def _identity(task_id: str = "task-1", *, turn_id: str = "turn-1"):
+    return driver.TaskIdentity(
+        room_id="room-1",
+        task_id=task_id,
+        thread_id="thread-1",
+        turn_id=turn_id,
+    )
+
+
+def _payload(
+    *,
+    target_profile: str = "ops",
+    prompt: str = "Inspect the release candidate.",
+    source_event_seq: int = 1,
+):
+    return {
+        "target_profile": target_profile,
+        "prompt": prompt,
+        "source_event_seq": source_event_seq,
+    }
+
+
+@pytest.fixture
+def db(tmp_path):
+    path = tmp_path / "state.db"
+    rooms.create_room(
+        path,
+        room_id="room-1",
+        name="Release room",
+        members=[{"profile": "ops", "handle": "ops"}],
+        authority_gateway_id="gateway-a",
+        now=90,
+    )
+    return path
+
+
+def _lease(
+    db,
+    clock,
+    *,
+    gateway="gateway-a",
+    authority_epoch=1,
+    process="process-a",
+    ttl=30,
+):
+    return driver.acquire_lease(
+        db,
+        room_id="room-1",
+        gateway_id=gateway,
+        authority_epoch=authority_epoch,
+        process_generation=process,
+        ttl_seconds=ttl,
+        clock=clock,
+    )
+
+
+def _admit(db, identity, clock, *, payload=None):
+    return driver.admit_task(
+        db,
+        identity,
+        payload=_payload() if payload is None else payload,
+        clock=clock,
+    )
+
+
+def _open_driver_schema(path: str) -> int:
+    return len(driver.list_tasks(path, room_id="room-1"))
+
+
+def test_two_contenders_have_one_winner(db):
+    clock = FakeClock()
+
+    def contend(process):
+        try:
+            return _lease(db, clock, process=process)
+        except driver.LeaseHeldError:
+            return None
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(contend, ["process-a", "process-b"]))
+
+    winners = [result for result in results if result is not None]
+    assert len(winners) == 1
+    assert winners[0].lease_generation == 1
+
+
+def test_expiry_allows_reclaim_and_fences_stale_renew_and_release(db):
+    clock = FakeClock()
+    first = _lease(db, clock, ttl=5)
+
+    clock.advance(5)
+    second = _lease(db, clock, process="process-b")
+
+    assert second.reclaimed is True
+    assert second.lease_generation == first.lease_generation + 1
+    with pytest.raises(driver.StaleLeaseError):
+        driver.renew_lease(db, first, ttl_seconds=30, clock=clock)
+    with pytest.raises(driver.StaleLeaseError):
+        driver.release_lease(db, first, clock=clock)
+
+
+def test_nonexistent_and_disbanded_rooms_cannot_lease_or_admit(db):
+    clock = FakeClock()
+    missing = driver.TaskIdentity("missing-room", "task", "thread", "turn")
+
+    with pytest.raises(driver.RoomUnavailableError, match="does not exist"):
+        driver.acquire_lease(
+            db,
+            room_id="missing-room",
+            gateway_id="gateway-a",
+            authority_epoch=1,
+            process_generation="process-a",
+            ttl_seconds=30,
+            clock=clock,
+        )
+    with pytest.raises(driver.RoomUnavailableError, match="does not exist"):
+        _admit(db, missing, clock)
+
+    rooms.disband_room(db, room_id="room-1", now=clock())
+    with pytest.raises(driver.RoomUnavailableError, match="disbanded"):
+        _lease(db, clock)
+    with pytest.raises(driver.RoomUnavailableError, match="disbanded"):
+        _admit(db, _identity(), clock)
+
+
+@pytest.mark.parametrize(
+    ("gateway", "authority_epoch"),
+    [("gateway-b", 1), ("gateway-a", 2)],
+)
+def test_acquire_requires_current_room_authority(db, gateway, authority_epoch):
+    with pytest.raises(driver.StaleLeaseError, match="authority changed"):
+        _lease(
+            db,
+            FakeClock(),
+            gateway=gateway,
+            authority_epoch=authority_epoch,
+        )
+
+
+def test_same_process_acquire_and_release_are_idempotent(db):
+    clock = FakeClock()
+    first = _lease(db, clock)
+    repeated = _lease(db, clock)
+
+    assert repeated.lease_generation == first.lease_generation
+    released = driver.release_lease(db, repeated, clock=clock)
+    released_again = driver.release_lease(db, repeated, clock=clock)
+
+    assert released["idempotent"] is False
+    assert released_again["idempotent"] is True
+
+
+def test_renew_extends_only_the_current_lease_generation(db):
+    clock = FakeClock()
+    lease = _lease(db, clock, ttl=5)
+
+    clock.advance(2)
+    renewed = driver.renew_lease(db, lease, ttl_seconds=20, clock=clock)
+
+    assert renewed.lease_generation == lease.lease_generation
+    assert renewed.expires_at == 122
+
+
+def test_authority_transfer_fences_lease_and_late_settlement(db):
+    clock = FakeClock()
+    identity = _identity()
+    queued = _identity("task-2", turn_id="turn-2")
+    old_lease = _lease(db, clock)
+    _admit(db, identity, clock)
+    _admit(db, queued, clock)
+    old_attempt = driver.start_task(
+        db,
+        identity,
+        old_lease,
+        expected_cancel_generation=0,
+        clock=clock,
+    )
+
+    rooms.claim_authority(
+        db,
+        room_id="room-1",
+        expected_gateway_id="gateway-a",
+        expected_epoch=1,
+        new_gateway_id="gateway-b",
+        event_id="claim-gateway-b",
+        now=clock(),
+    )
+
+    with pytest.raises(driver.StaleLeaseError, match="authority changed"):
+        driver.renew_lease(db, old_lease, ttl_seconds=30, clock=clock)
+    with pytest.raises(driver.StaleLeaseError, match="authority changed"):
+        driver.start_task(
+            db,
+            queued,
+            old_lease,
+            expected_cancel_generation=0,
+            clock=clock,
+        )
+    with pytest.raises(driver.StaleLeaseError, match="authority changed"):
+        driver.recover_room(db, old_lease, clock=clock)
+    with pytest.raises(driver.StaleLeaseError, match="authority changed"):
+        driver.settle_task(
+            db,
+            old_attempt,
+            settlement_id="late-settlement",
+            status="settled",
+            result={"text": "late"},
+            clock=clock,
+        )
+
+    new_lease = _lease(
+        db,
+        clock,
+        gateway="gateway-b",
+        authority_epoch=2,
+        process="process-b",
+    )
+    recovery = driver.recover_room(db, new_lease, clock=clock)
+    assert new_lease.lease_generation == old_lease.lease_generation + 1
+    assert recovery["indeterminate"] == [identity]
+    assert recovery["queued"] == [queued]
+
+
+def test_room_disband_fences_active_lease_operations(db):
+    clock = FakeClock()
+    identity = _identity()
+    lease = _lease(db, clock)
+    _admit(db, identity, clock)
+    rooms.disband_room(db, room_id="room-1", now=clock())
+
+    with pytest.raises(driver.RoomUnavailableError, match="disbanded"):
+        driver.renew_lease(db, lease, ttl_seconds=30, clock=clock)
+    with pytest.raises(driver.RoomUnavailableError, match="disbanded"):
+        driver.start_task(
+            db,
+            identity,
+            lease,
+            expected_cancel_generation=0,
+            clock=clock,
+        )
+    with pytest.raises(driver.RoomUnavailableError, match="disbanded"):
+        driver.recover_room(db, lease, clock=clock)
+    with pytest.raises(driver.RoomUnavailableError, match="disbanded"):
+        driver.release_lease(db, lease, clock=clock)
+
+
+def test_task_admission_is_idempotent_and_identity_conflicts_fail(db):
+    clock = FakeClock()
+    identity = _identity()
+
+    first = _admit(db, identity, clock)
+    repeated = _admit(db, identity, clock)
+
+    assert first["status"] == "queued"
+    assert repeated["idempotent"] is True
+
+    with pytest.raises(driver.TaskConflictError):
+        driver.admit_task(
+            db,
+            driver.TaskIdentity(
+                room_id="room-1",
+                task_id="task-1",
+                thread_id="thread-other",
+                turn_id="turn-other",
+            ),
+            payload=_payload(),
+            clock=clock,
+        )
+
+    with pytest.raises(driver.TaskConflictError, match="different payload"):
+        _admit(
+            db,
+            identity,
+            clock,
+            payload=_payload(prompt="A different immutable prompt."),
+        )
+    with pytest.raises(driver.TaskConflictError):
+        driver.admit_task(
+            db,
+            driver.TaskIdentity(
+                room_id="room-1",
+                task_id="task-other",
+                thread_id="thread-1",
+                turn_id="turn-1",
+            ),
+            payload=_payload(),
+            clock=clock,
+        )
+
+
+def test_concurrent_task_start_has_one_winner(db):
+    clock = FakeClock()
+    identity = _identity()
+    lease = _lease(db, clock)
+    _admit(db, identity, clock)
+
+    def start(_):
+        try:
+            return driver.start_task(
+                db,
+                identity,
+                lease,
+                expected_cancel_generation=0,
+                clock=clock,
+            )
+        except driver.InvalidTaskTransitionError:
+            return None
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(start, range(2)))
+
+    winners = [result for result in results if result is not None]
+    assert len(winners) == 1
+    assert winners[0].execution_generation == 1
+
+
+def test_stale_lease_cannot_start_or_commit_task(db):
+    clock = FakeClock()
+    identity = _identity()
+    first = _lease(db, clock, ttl=5)
+    _admit(db, identity, clock)
+    attempt = driver.start_task(
+        db,
+        identity,
+        first,
+        expected_cancel_generation=0,
+        clock=clock,
+    )
+
+    clock.advance(5)
+    second = _lease(db, clock, process="process-b")
+    driver.recover_room(db, second, clock=clock)
+
+    with pytest.raises(driver.StaleLeaseError):
+        driver.settle_task(
+            db,
+            attempt,
+            settlement_id="settlement-old",
+            status="settled",
+            result={"text": "late"},
+            clock=clock,
+        )
+    assert driver.get_task(db, identity)["status"] == "indeterminate"
+
+
+@pytest.mark.parametrize("status", ["settled", "failed"])
+def test_terminal_settlement_is_idempotent(db, status):
+    clock = FakeClock()
+    identity = _identity()
+    lease = _lease(db, clock)
+    _admit(db, identity, clock)
+    attempt = driver.start_task(
+        db,
+        identity,
+        lease,
+        expected_cancel_generation=0,
+        clock=clock,
+    )
+
+    first = driver.settle_task(
+        db,
+        attempt,
+        settlement_id="settlement-1",
+        status=status,
+        result={"text": "done"},
+        clock=clock,
+    )
+    repeated = driver.settle_task(
+        db,
+        attempt,
+        settlement_id="settlement-1",
+        status=status,
+        result={"text": "done"},
+        clock=clock,
+    )
+
+    assert first["status"] == status
+    assert repeated["idempotent"] is True
+    with pytest.raises(driver.TaskConflictError):
+        driver.settle_task(
+            db,
+            attempt,
+            settlement_id="settlement-2",
+            status=status,
+            result={"text": "changed"},
+            clock=clock,
+        )
+
+
+def test_cancellation_fences_late_success(db):
+    clock = FakeClock()
+    identity = _identity()
+    lease = _lease(db, clock)
+    _admit(db, identity, clock)
+    attempt = driver.start_task(
+        db,
+        identity,
+        lease,
+        expected_cancel_generation=0,
+        clock=clock,
+    )
+
+    stopping = driver.begin_task_cancel(
+        db,
+        identity,
+        cancel_id="cancel-1",
+        expected_cancel_generation=0,
+        clock=clock,
+    )
+    cancelled = driver.complete_task_cancel(
+        db,
+        identity,
+        cancel_id="cancel-1",
+        expected_cancel_generation=1,
+        clock=clock,
+    )
+    repeated = driver.complete_task_cancel(
+        db,
+        identity,
+        cancel_id="cancel-1",
+        expected_cancel_generation=1,
+        clock=clock,
+    )
+
+    assert stopping["status"] == "stopping"
+    assert cancelled["status"] == "cancelled"
+    assert cancelled["cancel_generation"] == 1
+    assert repeated["idempotent"] is True
+    with pytest.raises(driver.StaleTaskError):
+        driver.settle_task(
+            db,
+            attempt,
+            settlement_id="late-success",
+            status="settled",
+            result={"text": "too late"},
+            clock=clock,
+        )
+
+
+def test_release_fails_closed_while_its_task_is_running(db):
+    clock = FakeClock()
+    identity = _identity()
+    lease = _lease(db, clock)
+    _admit(db, identity, clock)
+    driver.start_task(
+        db,
+        identity,
+        lease,
+        expected_cancel_generation=0,
+        clock=clock,
+    )
+
+    with pytest.raises(
+        driver.InvalidTaskTransitionError,
+        match="tasks are running",
+    ):
+        driver.release_lease(db, lease, clock=clock)
+    assert driver.get_task(db, identity)["status"] == "running"
+
+    driver.begin_task_cancel(
+        db,
+        identity,
+        cancel_id="cancel-before-release",
+        expected_cancel_generation=0,
+        clock=clock,
+    )
+    driver.complete_task_cancel(
+        db,
+        identity,
+        cancel_id="cancel-before-release",
+        expected_cancel_generation=1,
+        clock=clock,
+    )
+    assert driver.release_lease(db, lease, clock=clock)["idempotent"] is False
+
+
+def test_restart_recovery_never_requeues_indeterminate_work(db):
+    clock = FakeClock()
+    running = _identity()
+    queued = _identity("task-2", turn_id="turn-2")
+    first = _lease(db, clock, ttl=5)
+    _admit(db, running, clock)
+    _admit(db, queued, clock)
+    driver.start_task(
+        db,
+        running,
+        first,
+        expected_cancel_generation=0,
+        clock=clock,
+    )
+
+    with pytest.raises(driver.LeaseHeldError):
+        _lease(db, clock, gateway="gateway-a", process="new-process")
+
+    clock.advance(5)
+    recovered_lease = _lease(
+        db,
+        clock,
+        gateway="gateway-a",
+        process="new-process",
+    )
+    recovery = driver.recover_room(db, recovered_lease, clock=clock)
+    repeated = driver.recover_room(db, recovered_lease, clock=clock)
+
+    assert recovery == {"queued": [queued], "indeterminate": [running]}
+    assert repeated == recovery
+    with pytest.raises(driver.InvalidTaskTransitionError):
+        driver.start_task(
+            db,
+            running,
+            recovered_lease,
+            expected_cancel_generation=0,
+            clock=clock,
+        )
+    assert [task["status"] for task in driver.list_tasks(db, room_id="room-1")] == [
+        "indeterminate",
+        "queued",
+    ]
+
+
+def test_recovery_is_required_before_starting_later_work(db):
+    clock = FakeClock()
+    running = _identity()
+    queued = _identity("task-2", turn_id="turn-2")
+    first = _lease(db, clock, ttl=5)
+    _admit(db, running, clock, payload=_payload(source_event_seq=1))
+    _admit(db, queued, clock, payload=_payload(source_event_seq=2))
+    driver.start_task(
+        db,
+        running,
+        first,
+        expected_cancel_generation=0,
+        clock=clock,
+    )
+    clock.advance(5)
+    recovered = _lease(db, clock, process="new-process")
+
+    with pytest.raises(
+        driver.InvalidTaskTransitionError,
+        match="recovery must resolve",
+    ):
+        driver.start_task(
+            db,
+            queued,
+            recovered,
+            expected_cancel_generation=0,
+            clock=clock,
+        )
+
+
+def test_current_lease_can_commit_verified_indeterminate_receipt(db):
+    clock = FakeClock()
+    running = _identity()
+    queued = _identity("task-2", turn_id="turn-2")
+    first = _lease(db, clock, ttl=5)
+    _admit(db, running, clock, payload=_payload(source_event_seq=1))
+    _admit(db, queued, clock, payload=_payload(source_event_seq=2))
+    attempt = driver.start_task(
+        db,
+        running,
+        first,
+        expected_cancel_generation=0,
+        clock=clock,
+    )
+    clock.advance(5)
+    recovered = _lease(db, clock, process="new-process")
+    driver.recover_room(db, recovered, clock=clock)
+
+    settled = driver.resolve_indeterminate_task(
+        db,
+        running,
+        recovered,
+        expected_execution_generation=attempt.execution_generation,
+        expected_cancel_generation=attempt.cancel_generation,
+        settlement_id="recovered-receipt",
+        status="settled",
+        result={"text": "recovered"},
+        clock=clock,
+    )
+    next_attempt = driver.start_task(
+        db,
+        queued,
+        recovered,
+        expected_cancel_generation=0,
+        clock=clock,
+    )
+
+    assert settled["status"] == "settled"
+    assert next_attempt.execution_generation == 1
+
+
+def test_indeterminate_retry_is_explicit_and_advances_execution_generation(db):
+    clock = FakeClock()
+    identity = _identity()
+    first = _lease(db, clock, ttl=5)
+    _admit(db, identity, clock)
+    original = driver.start_task(
+        db,
+        identity,
+        first,
+        expected_cancel_generation=0,
+        clock=clock,
+    )
+    clock.advance(5)
+    recovered = _lease(db, clock, process="new-process")
+    driver.recover_room(db, recovered, clock=clock)
+
+    requeued = driver.requeue_indeterminate_task(
+        db,
+        identity,
+        recovered,
+        expected_execution_generation=original.execution_generation,
+        expected_cancel_generation=original.cancel_generation,
+        clock=clock,
+    )
+    retried = driver.start_task(
+        db,
+        identity,
+        recovered,
+        expected_cancel_generation=0,
+        clock=clock,
+    )
+
+    assert requeued["status"] == "queued"
+    assert retried.execution_generation == original.execution_generation + 1
+
+
+def test_state_survives_sqlite_reopen_and_concurrent_duplicate_admission(db):
+    clock = FakeClock()
+    identity = _identity()
+
+    def admit(_):
+        return _admit(db, identity, clock)
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        results = list(pool.map(admit, range(8)))
+
+    assert sum(not result["idempotent"] for result in results) == 1
+    with sqlite3.connect(db) as conn:
+        count = conn.execute(
+            "SELECT COUNT(*) FROM hosted_room_driver_tasks"
+        ).fetchone()[0]
+    assert count == 1
+    reopened = driver.get_task(db, identity)
+    listed = driver.list_tasks(db, room_id="room-1")
+    assert reopened["identity"] == identity
+    assert reopened["payload"] == _payload()
+    assert listed[0]["payload"] == _payload()
+
+
+def test_unpublished_legacy_driver_schema_fails_closed(db):
+    conn = sqlite3.connect(db)
+    try:
+        conn.execute("DROP TABLE IF EXISTS hosted_room_driver_tasks")
+        conn.execute("DROP TABLE IF EXISTS hosted_room_driver_leases")
+        conn.execute(
+            """CREATE TABLE hosted_room_driver_leases (
+                room_id TEXT PRIMARY KEY,
+                gateway_id TEXT NOT NULL,
+                process_generation TEXT NOT NULL,
+                lease_generation INTEGER NOT NULL,
+                expires_at REAL NOT NULL,
+                acquired_at REAL NOT NULL,
+                updated_at REAL NOT NULL,
+                released_at REAL
+            )"""
+        )
+        conn.execute(
+            """CREATE TABLE hosted_room_driver_tasks (
+                room_id TEXT NOT NULL,
+                task_id TEXT NOT NULL,
+                thread_id TEXT NOT NULL,
+                turn_id TEXT NOT NULL,
+                status TEXT NOT NULL,
+                execution_generation INTEGER NOT NULL,
+                cancel_generation INTEGER NOT NULL,
+                run_gateway_id TEXT,
+                run_process_generation TEXT,
+                run_lease_generation INTEGER,
+                cancel_id TEXT,
+                settlement_id TEXT,
+                settlement_status TEXT,
+                result_json TEXT,
+                created_at REAL NOT NULL,
+                updated_at REAL NOT NULL,
+                started_at REAL,
+                terminal_at REAL,
+                indeterminate_at REAL,
+                PRIMARY KEY (room_id, task_id),
+                UNIQUE (room_id, thread_id, turn_id)
+            )"""
+        )
+        conn.execute(
+            """INSERT INTO hosted_room_driver_leases
+               VALUES ('room-1', 'gateway-a', 'old-process', 1,
+                       200, 100, 100, NULL)"""
+        )
+        conn.execute(
+            """INSERT INTO hosted_room_driver_tasks
+               (room_id, task_id, thread_id, turn_id, status,
+                execution_generation, cancel_generation,
+                run_gateway_id, run_process_generation, run_lease_generation,
+                created_at, updated_at, started_at)
+               VALUES ('room-1', 'task-1', 'thread-1', 'turn-1', 'running',
+                       1, 0, 'gateway-a', 'old-process', 1, 100, 100, 100)"""
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    with pytest.raises(driver.DriverStateError, match="unsupported unpublished"):
+        driver.get_task(db, _identity())
+
+
+def test_pre_stopping_schema_is_migrated_without_losing_tasks(db):
+    clock = FakeClock()
+    identity = _identity()
+    _admit(db, identity, clock)
+
+    with sqlite3.connect(db) as conn:
+        current_sql = conn.execute(
+            "SELECT sql FROM sqlite_master WHERE name='hosted_room_driver_tasks'"
+        ).fetchone()[0]
+        old_sql = current_sql.replace(", 'stopping'", "")
+        conn.execute("DROP INDEX idx_hosted_room_driver_tasks_status")
+        conn.execute(
+            "ALTER TABLE hosted_room_driver_tasks RENAME TO hosted_room_driver_tasks_current"
+        )
+        conn.execute(old_sql)
+        columns = ", ".join(driver._TASK_COLUMN_ORDER)
+        conn.execute(
+            f"""INSERT INTO hosted_room_driver_tasks ({columns})
+                 SELECT {columns} FROM hosted_room_driver_tasks_current"""
+        )
+        conn.execute("DROP TABLE hosted_room_driver_tasks_current")
+        conn.execute(
+            """CREATE INDEX idx_hosted_room_driver_tasks_status
+               ON hosted_room_driver_tasks(
+                   room_id, status, source_event_seq, created_at, task_id
+               )"""
+        )
+
+    assert driver.get_task(db, identity)["status"] == "queued"
+    lease = _lease(db, clock)
+    attempt = driver.start_task(
+        db,
+        identity,
+        lease,
+        expected_cancel_generation=0,
+        clock=clock,
+    )
+    stopping = driver.begin_task_cancel(
+        db,
+        identity,
+        cancel_id="cancel-after-upgrade",
+        expected_cancel_generation=attempt.cancel_generation,
+        clock=clock,
+    )
+
+    assert stopping["status"] == "stopping"
+    with sqlite3.connect(db) as conn:
+        table_sql = conn.execute(
+            "SELECT sql FROM sqlite_master WHERE name='hosted_room_driver_tasks'"
+        ).fetchone()[0]
+    assert "'stopping'" in table_sql
+
+
+def test_first_schema_creation_is_safe_across_processes(db):
+    with sqlite3.connect(db) as conn:
+        conn.execute("DROP TABLE IF EXISTS hosted_room_driver_tasks")
+        conn.execute("DROP TABLE IF EXISTS hosted_room_driver_leases")
+        conn.commit()
+
+    with ProcessPoolExecutor(max_workers=4) as pool:
+        results = list(pool.map(_open_driver_schema, [str(db)] * 4))
+
+    assert results == [0, 0, 0, 0]
+
+
+def test_tasks_follow_source_event_order_not_admission_time(db):
+    clock = FakeClock()
+    later = _identity("task-2", turn_id="turn-2")
+    earlier = _identity("task-1", turn_id="turn-1")
+    _admit(db, later, clock, payload=_payload(source_event_seq=2))
+    _admit(db, earlier, clock, payload=_payload(source_event_seq=1))
+    lease = _lease(db, clock)
+
+    assert [task["identity"] for task in driver.list_tasks(db, room_id="room-1")] == [
+        earlier,
+        later,
+    ]
+    with pytest.raises(driver.InvalidTaskTransitionError, match="event order"):
+        driver.start_task(
+            db,
+            later,
+            lease,
+            expected_cancel_generation=0,
+            clock=clock,
+        )
+    assert (
+        driver.start_task(
+            db,
+            earlier,
+            lease,
+            expected_cancel_generation=0,
+            clock=clock,
+        ).identity
+        == earlier
+    )
+
+
+def test_payload_digest_is_verified_on_read(db):
+    identity = _identity()
+    _admit(db, identity, FakeClock())
+    with sqlite3.connect(db) as conn:
+        conn.execute(
+            """UPDATE hosted_room_driver_tasks
+               SET payload_json=REPLACE(payload_json, 'Inspect', 'Replace')
+               WHERE room_id=? AND task_id=?""",
+            (identity.room_id, identity.task_id),
+        )
+        conn.commit()
+
+    with pytest.raises(driver.TaskConflictError, match="integrity"):
+        driver.get_task(db, identity)
+
+
+@pytest.mark.parametrize(
+    ("payload", "match"),
+    [
+        ({"target_profile": "ops", "prompt": "hello"}, "missing payload fields"),
+        (
+            {**_payload(), "unexpected": True},
+            "unknown payload fields",
+        ),
+        (_payload(target_profile="bad profile"), "invalid target_profile"),
+        (_payload(prompt="   "), "prompt must not be empty"),
+        (_payload(prompt="x" * (driver.MAX_PROMPT_BYTES + 1)), "prompt is too large"),
+        (_payload(source_event_seq=0), "source_event_seq"),
+        (_payload(source_event_seq=True), "source_event_seq"),
+    ],
+)
+def test_invalid_task_payload_is_rejected(db, payload, match):
+    with pytest.raises(driver.DriverValidationError, match=match):
+        _admit(db, _identity(), FakeClock(), payload=payload)
+
+
+@pytest.mark.parametrize(
+    ("factory", "match"),
+    [
+        (
+            lambda: driver.TaskIdentity("bad room", "task", "thread", "turn"),
+            "invalid room_id",
+        ),
+        (
+            lambda: driver.TaskIdentity("room", "", "thread", "turn"),
+            "invalid task_id",
+        ),
+    ],
+)
+def test_invalid_task_identity_is_rejected(factory, match):
+    with pytest.raises(driver.DriverValidationError, match=match):
+        factory()
+
+
+def test_invalid_lease_clock_ttl_and_settlement_schema_are_rejected(db):
+    clock = FakeClock()
+
+    with pytest.raises(driver.DriverValidationError, match="ttl_seconds"):
+        _lease(db, clock, ttl=0)
+    with pytest.raises(driver.DriverValidationError, match="clock"):
+        _lease(db, lambda: float("nan"))
+    with pytest.raises(driver.DriverValidationError, match="expiry"):
+        _lease(db, FakeClock(1e308), ttl=1e308)
+
+    identity = _identity()
+    lease = _lease(db, clock)
+    _admit(db, identity, clock)
+    attempt = driver.start_task(
+        db,
+        identity,
+        lease,
+        expected_cancel_generation=0,
+        clock=clock,
+    )
+    with pytest.raises(driver.DriverValidationError, match="JSON-serializable"):
+        driver.settle_task(
+            db,
+            attempt,
+            settlement_id="settlement-1",
+            status="settled",
+            result={"bad": object()},
+            clock=clock,
+        )
+
+
+def test_renewal_never_shortens_an_active_lease(db):
+    clock = FakeClock()
+    lease = _lease(db, clock, ttl=30)
+    clock.advance(1)
+
+    renewed = driver.renew_lease(db, lease, ttl_seconds=2, clock=clock)
+
+    assert renewed.expires_at == lease.expires_at

--- a/tests/gateway/test_hosted_room_messaging.py
+++ b/tests/gateway/test_hosted_room_messaging.py
@@ -1,0 +1,844 @@
+"""Messaging controls for gateway-hosted Bot rooms."""
+
+from __future__ import annotations
+
+import time
+from concurrent.futures import ThreadPoolExecutor
+from types import ModuleType, SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway import hosted_room_driver, hosted_rooms
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.hosted_room_messaging import (
+    MessagingRoomBackend,
+    RoomControlError,
+    command_form,
+    format_room_detail,
+    format_room_list,
+    list_messaging_rooms,
+    messaging_actor,
+    messaging_event_id,
+    parse_room_command,
+    relay_provenance_is_unknown,
+    resolve_room,
+)
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.session import SessionSource
+from hermes_cli.commands import resolve_command
+from tui_gateway.hosted_room_service import HostedRoomService
+
+
+class _FakeService:
+    def __init__(self, db_path):
+        self.db_path = db_path
+        self.sent = []
+        self.stopped = []
+        self.room_status = {"running": True, "working": False, "blocked": False}
+
+    def status(self, _room_id):
+        return dict(self.room_status)
+
+    def send(self, **kwargs):
+        self.sent.append(kwargs)
+        return {"seq": 1}
+
+    def stop_room(self, room_id, *, cancel_id):
+        self.stopped.append((room_id, cancel_id))
+        return 2
+
+
+class _TestHostedRoomService(HostedRoomService):
+    """Hosted service with a fixed two-profile test roster."""
+
+    def __init__(self, db_path):
+        super().__init__(ModuleType("test_hosted_room_server"), db_path=db_path)
+
+    def local_profiles(self) -> tuple[str, ...]:
+        return ("default", "ops")
+
+
+class _ImmediateRPC:
+    """In-process room worker transport that settles without a model call."""
+
+    def __init__(self):
+        self.sessions = {}
+
+    def resolve_exact(self, *, profile, title, source):
+        return self.sessions.get((profile, title))
+
+    def create(self, *, profile, title, source):
+        session = {"session_id": f"{profile}-session", "title": title}
+        self.sessions[(profile, title)] = session
+        return session
+
+    def resume(self, *, profile, session_id, source):
+        return {"session_id": session_id}
+
+    def submit(
+        self,
+        *,
+        profile,
+        session_id,
+        prompt,
+        source,
+        task,
+        execution_generation,
+        on_terminal,
+    ):
+        on_terminal({"status": "settled", "text": f"reply from {profile}"})
+        return {"accepted": True}
+
+    def history(self, *, profile, session_id, source):
+        return []
+
+    def info(self, *, profile, session_id, source):
+        return {"active": False, "task_id": None}
+
+    def interrupt(self, *, profile, session_id, source, expected_task_id):
+        return {"interrupted": True}
+
+
+class _HoldingRPC(_ImmediateRPC):
+    """Keep a turn active until the owner observes a durable stop intent."""
+
+    def __init__(self):
+        super().__init__()
+        self.active = {}
+        self.interrupts = []
+
+    def create(self, *, profile, title, source):
+        session = super().create(profile=profile, title=title, source=source)
+        self.active[session["session_id"]] = {"active": False, "task_id": None}
+        return session
+
+    def submit(
+        self,
+        *,
+        profile,
+        session_id,
+        prompt,
+        source,
+        task,
+        execution_generation,
+        on_terminal,
+    ):
+        self.active[session_id] = {"active": True, "task_id": task.task_id}
+        return {"accepted": True}
+
+    def info(self, *, profile, session_id, source):
+        return dict(self.active[session_id])
+
+    def interrupt(self, *, profile, session_id, source, expected_task_id):
+        state = self.active[session_id]
+        if state["task_id"] != expected_task_id:
+            return {"interrupted": False}
+        state["active"] = False
+        self.interrupts.append(expected_task_id)
+        return {"interrupted": True}
+
+
+def _wait_for(predicate, timeout=2.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(0.01)
+    raise AssertionError("condition was not reached")
+
+
+def _seed_rooms(tmp_path):
+    db = tmp_path / "state.db"
+    authority = "install:test-gateway"
+    first = hosted_rooms.create_room(
+        db,
+        room_id="release-room",
+        name="Release room",
+        members=[
+            {"member_id": "default", "handle": "hermes"},
+            {"member_id": "ops", "handle": "ops", "display_name": "Operations"},
+        ],
+        authority_gateway_id=authority,
+    )
+    second = hosted_rooms.create_room(
+        db,
+        room_id="research-room",
+        name="Research room",
+        members=[
+            {"member_id": "default", "handle": "hermes"},
+            {"member_id": "research", "handle": "research"},
+        ],
+        authority_gateway_id=authority,
+    )
+    return db, first, second
+
+
+def _event(
+    text: str,
+    *,
+    platform: Platform = Platform.SIGNAL,
+    user_id: str = "user-1",
+    message_id: str = "message-1",
+    media: bool = False,
+    is_bot: bool = False,
+) -> MessageEvent:
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.COMMAND,
+        user_id=user_id,
+        user_name="Display Name",
+        message_id=message_id,
+        media_urls=["/tmp/image.png"] if media else [],
+        media_types=["image/png"] if media else [],
+        source=SessionSource(
+            platform=platform,
+            chat_id=f"chat-{platform.value}",
+            chat_type="dm",
+            user_id=user_id,
+            user_name="Display Name",
+            is_bot=is_bot,
+        ),
+    )
+
+
+def _runner(*, platform: Platform = Platform.SIGNAL, extra=None):
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    effective_extra = (
+        {"allow_admin_from": ["user-1"]} if extra is None else extra
+    )
+    runner.config = GatewayConfig(
+        platforms={
+            platform: PlatformConfig(
+                enabled=True,
+                token="***",
+                extra=effective_extra,
+            )
+        }
+    )
+    return runner
+
+
+def test_room_commands_are_gateway_dispatchable_without_interrupting_agent():
+    rooms = resolve_command("rooms")
+    assert rooms is not None and rooms.gateway_only and rooms.busy_policy == "dispatch"
+    assert rooms.subcommands == ("send", "stop")
+    assert resolve_command("room") is None
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (
+            "send Release room -- check the build -- then report",
+            ("send", "Release room", "check the build -- then report"),
+        ),
+        ("stop Release room", ("stop", "Release room", "")),
+    ],
+)
+def test_parse_room_command_keeps_names_and_message_content(raw, expected):
+    parsed = parse_room_command(raw)
+    assert (parsed.action, parsed.room_query, parsed.message) == expected
+
+
+@pytest.mark.parametrize("raw", ["", "send room", "send -- hello", "stop"])
+def test_parse_room_command_returns_actionable_usage(raw):
+    with pytest.raises(RoomControlError, match="Use `/rooms"):
+        parse_room_command(raw)
+
+
+def test_room_resolution_is_exact_then_unique_prefix_then_substring(tmp_path):
+    db, _, _ = _seed_rooms(tmp_path)
+    rooms = hosted_rooms.list_rooms(db)
+    assert resolve_room(rooms, "release-room")["name"] == "Release room"
+    assert resolve_room(rooms, "Research")["room_id"] == "research-room"
+    assert resolve_room(rooms, "lease")["room_id"] == "release-room"
+
+
+def test_room_numbers_stay_stable_and_are_not_reused_after_disband(tmp_path):
+    db, first, second = _seed_rooms(tmp_path)
+    service = _FakeService(db)
+    initial = {
+        room["room_id"]: room["messaging_ref"]
+        for room in list_messaging_rooms(service)
+    }
+
+    hosted_rooms.disband_room(db, room_id=first["room_id"])
+    third = hosted_rooms.create_room(
+        db,
+        room_id="stop-signals",
+        name="Stop signals",
+        members=[],
+        authority_gateway_id="install:test-gateway",
+    )
+    current = list_messaging_rooms(service)
+    refs = {room["room_id"]: room["messaging_ref"] for room in current}
+
+    assert refs[second["room_id"]] == initial[second["room_id"]]
+    assert refs[third["room_id"]] > max(initial.values())
+    assert resolve_room(current, str(refs[third["room_id"]]))["name"] == "Stop signals"
+
+
+def test_missing_room_number_fails_closed_without_matching_a_numeric_name(tmp_path):
+    db, _, _ = _seed_rooms(tmp_path)
+    hosted_rooms.create_room(
+        db,
+        room_id="roadmap-2026",
+        name="2026 roadmap",
+        members=[],
+        authority_gateway_id="install:test-gateway",
+    )
+    rooms = list_messaging_rooms(_FakeService(db))
+
+    with pytest.raises(RoomControlError, match="numbered 2026"):
+        resolve_room(rooms, "2026")
+
+
+def test_numeric_internal_id_requires_an_explicit_advanced_escape(tmp_path):
+    db, _, _ = _seed_rooms(tmp_path)
+    numeric_id = hosted_rooms.create_room(
+        db,
+        room_id="1",
+        name="Legacy numeric ID",
+        members=[],
+        authority_gateway_id="install:test-gateway",
+    )
+    rooms = list_messaging_rooms(_FakeService(db))
+
+    assert resolve_room(rooms, "1")["room_id"] != numeric_id["room_id"]
+    assert resolve_room(rooms, "id:1")["room_id"] == numeric_id["room_id"]
+
+
+def test_room_numbers_allocate_once_across_concurrent_gateway_processes(tmp_path):
+    db, _, _ = _seed_rooms(tmp_path)
+
+    def load_refs(_index):
+        service = _FakeService(db)
+        return {
+            room["room_id"]: room["messaging_ref"]
+            for room in list_messaging_rooms(service)
+        }
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        results = list(pool.map(load_refs, range(24)))
+
+    assert all(result == results[0] for result in results)
+    assert len(set(results[0].values())) == 2
+
+
+def test_room_resolution_explains_ambiguity_and_missing_names(tmp_path):
+    db, _, _ = _seed_rooms(tmp_path)
+    hosted_rooms.create_room(
+        db,
+        room_id="release-notes",
+        name="Release notes",
+        members=[],
+        authority_gateway_id="install:test-gateway",
+    )
+    rooms = hosted_rooms.list_rooms(db)
+    with pytest.raises(RoomControlError, match="matches several rooms"):
+        resolve_room(rooms, "release")
+    with pytest.raises(RoomControlError, match="No hosted Bot room"):
+        resolve_room(rooms, "missing")
+
+
+@pytest.mark.asyncio
+async def test_reserved_word_room_name_opens_detail_without_triggering_stop(
+    tmp_path, monkeypatch
+):
+    db, _, _ = _seed_rooms(tmp_path)
+    hosted_rooms.create_room(
+        db,
+        room_id="stop-signals",
+        name="Stop signals",
+        members=[],
+        authority_gateway_id="install:test-gateway",
+    )
+    service = _FakeService(db)
+    monkeypatch.setattr(
+        "gateway.hosted_room_messaging.current_room_backend", lambda: service
+    )
+
+    result = await _runner()._handle_rooms_command(_event("/rooms Stop signals"))
+
+    assert result.startswith("Stop signals —")
+    assert service.stopped == []
+
+
+@pytest.mark.asyncio
+async def test_mutating_room_commands_require_the_stable_number(tmp_path, monkeypatch):
+    db, _, _ = _seed_rooms(tmp_path)
+    service = _FakeService(db)
+    monkeypatch.setattr(
+        "gateway.hosted_room_messaging.current_room_backend", lambda: service
+    )
+
+    result = await _runner()._handle_room_command(
+        _event("/rooms stop Release room")
+    )
+
+    assert result == "Use `/rooms stop <room number>`."
+    assert service.stopped == []
+
+
+def test_room_list_and_detail_are_bounded_and_user_facing(tmp_path):
+    db, release, _ = _seed_rooms(tmp_path)
+    service = _FakeService(db)
+    hosted_rooms.append_event(
+        db,
+        room_id=release["room_id"],
+        event_id="user-1",
+        kind="message.user",
+        actor={"kind": "user", "id": "messaging:signal:abc", "display_name": "Signal"},
+        payload={"text": "Please inspect the release", "thread_id": "thread-1"},
+    )
+    hosted_rooms.append_event(
+        db,
+        room_id=release["room_id"],
+        event_id="member-1",
+        kind="message.member",
+        actor={"kind": "member", "id": "ops"},
+        payload={
+            "member_id": "ops",
+            "text": "The release is ready",
+            "thread_id": "thread-1",
+            "task_id": "task-1",
+            "turn_id": "turn-1",
+            "round_index": 0,
+        },
+        authority_gateway_id="install:test-gateway",
+        authority_epoch=1,
+    )
+
+    listing = format_room_list(service)
+    assert "Hosted Bot rooms" in listing
+    assert "1. Release room — waiting for the room host, 2 bots" in listing
+    detail = format_room_detail(service, release)
+    assert "Signal: Please inspect the release" in detail
+    assert "Operations: The release is ready" in detail
+    assert "Send: `/rooms send 1 -- <message>`" in detail
+    assert "Stop: `/rooms stop 1`" in detail
+
+
+def test_messaging_identity_is_stable_private_and_edit_safe():
+    first = _event("/rooms send 1 -- hello", platform=Platform.TELEGRAM)
+    first.platform_update_id = 123
+    second = _event("/rooms send 1 -- edited", platform=Platform.TELEGRAM)
+    second.platform_update_id = 124
+    actor = messaging_actor(first, gateway_id="install:test-gateway")
+    assert actor["display_name"] == "Display Name via Telegram"
+    assert "user-1" not in actor["id"]
+    assert messaging_event_id(first) != messaging_event_id(second)
+    assert messaging_event_id(first) == messaging_event_id(first)
+
+
+def test_transport_specific_command_forms_are_actionable():
+    assert command_form(_event("/rooms", platform=Platform.SIGNAL)) == "/rooms"
+    assert command_form(_event("/rooms", platform=Platform.SLACK)) == "/hermes rooms"
+    assert command_form(_event("/rooms", platform=Platform.MATRIX)) == "!rooms"
+
+
+@pytest.mark.parametrize(
+    "raw_message",
+    [
+        {"timestamp_ms": 1770000000000},
+        {"trigger_id": "slack-trigger-1"},
+        SimpleNamespace(id="discord-interaction-1"),
+    ],
+)
+def test_real_channel_raw_ids_are_stable_without_normalized_message_id(raw_message):
+    event = _event("/rooms send 1 -- hello")
+    event.message_id = None
+    event.source.message_id = None
+    event.raw_message = raw_message
+    assert messaging_event_id(event) == messaging_event_id(event)
+
+
+def test_mutation_fails_closed_without_a_transport_redelivery_id():
+    event = _event("/rooms send 1 -- hello")
+    event.message_id = None
+    event.source.message_id = None
+    with pytest.raises(RoomControlError, match="stable message ID"):
+        messaging_event_id(event)
+
+
+def test_signal_group_idempotency_includes_sender_identity():
+    first = _event("/rooms send 1 -- hello", user_id="sender-a")
+    second = _event("/rooms send 1 -- hello", user_id="sender-b")
+    for event in (first, second):
+        event.message_id = None
+        event.source.message_id = None
+        event.raw_message = {"timestamp_ms": 1770000000000}
+    assert messaging_event_id(first) != messaging_event_id(second)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("platform", [p for p in Platform if p is not Platform.LOCAL])
+async def test_send_handler_is_shared_by_every_gateway_channel(
+    tmp_path, monkeypatch, platform
+):
+    db, _, _ = _seed_rooms(tmp_path)
+    service = _FakeService(db)
+    monkeypatch.setattr(
+        "gateway.hosted_room_messaging.current_room_backend", lambda: service
+    )
+    event = _event(
+        "/rooms send 1 -- hello from messaging",
+        platform=platform,
+        message_id=f"message-{platform.value}",
+    )
+    result = await _runner(platform=platform)._handle_room_command(event)
+    rooms_command = command_form(event)
+    assert result == f"Queued in Release room. Check: `{rooms_command} 1`."
+    assert service.sent[-1]["payload"]["text"] == "hello from messaging"
+    platform_label = platform.value.replace("_", " ").title()
+    assert service.sent[-1]["actor"]["display_name"] == (
+        f"Display Name via {platform_label}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_send_rejects_attachments_instead_of_silently_dropping_them(
+    tmp_path, monkeypatch
+):
+    db, _, _ = _seed_rooms(tmp_path)
+    service = _FakeService(db)
+    monkeypatch.setattr(
+        "gateway.hosted_room_messaging.current_room_backend", lambda: service
+    )
+    result = await _runner()._handle_room_command(
+        _event("/rooms send 1 -- inspect this", media=True)
+    )
+    assert "Attachments from messaging chats aren’t supported yet" in result
+    assert service.sent == []
+
+
+@pytest.mark.asyncio
+async def test_bot_authored_controls_are_rejected_to_prevent_bridge_loops(
+    tmp_path, monkeypatch
+):
+    db, _, _ = _seed_rooms(tmp_path)
+    service = _FakeService(db)
+    monkeypatch.setattr(
+        "gateway.hosted_room_messaging.current_room_backend", lambda: service
+    )
+    result = await _runner(platform=Platform.DISCORD)._handle_room_command(
+        _event(
+            "/rooms send 1 -- repeat this",
+            platform=Platform.DISCORD,
+            is_bot=True,
+        )
+    )
+    assert result == "Hosted Bot room controls are only available to people."
+    assert service.sent == []
+
+
+@pytest.mark.asyncio
+async def test_raw_webhook_bot_marker_is_rejected_even_without_source_flag(
+    tmp_path, monkeypatch
+):
+    db, _, _ = _seed_rooms(tmp_path)
+    service = _FakeService(db)
+    monkeypatch.setattr(
+        "gateway.hosted_room_messaging.current_room_backend", lambda: service
+    )
+    event = _event("/rooms send 1 -- repeat this")
+    event.raw_message = {"subtype": "bot_message", "bot_id": "B123"}
+    result = await _runner()._handle_rooms_command(event)
+    assert result == "Hosted Bot room controls are only available to people."
+    assert service.sent == []
+
+
+def test_relay_and_session_roundtrip_preserve_bot_provenance():
+    from gateway.relay.ws_transport import _event_from_wire
+
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="chat-1",
+        user_id="bot-1",
+        is_bot=True,
+    )
+    assert SessionSource.from_dict(source.to_dict()).is_bot is True
+    relayed = _event_from_wire(
+        {
+            "text": "/rooms",
+            "message_type": "command",
+            "source": source.to_dict(),
+        }
+    )
+    assert relayed.source.is_bot is True
+    assert relay_provenance_is_unknown(relayed) is False
+
+
+def test_legacy_relay_without_author_classification_fails_closed():
+    from gateway.relay.ws_transport import _event_from_wire
+
+    relayed = _event_from_wire(
+        {
+            "text": "/rooms",
+            "message_type": "command",
+            "source": {
+                "platform": "discord",
+                "chat_id": "chat-1",
+                "chat_type": "dm",
+                "user_id": "user-1",
+            },
+        }
+    )
+    assert relay_provenance_is_unknown(relayed) is True
+
+
+@pytest.mark.asyncio
+async def test_stop_requires_admin_when_operator_enabled_slash_gating(
+    tmp_path, monkeypatch
+):
+    db, _, _ = _seed_rooms(tmp_path)
+    service = _FakeService(db)
+    monkeypatch.setattr(
+        "gateway.hosted_room_messaging.current_room_backend", lambda: service
+    )
+    extra = {
+        "allow_admin_from": ["admin"],
+        "user_allowed_commands": ["rooms"],
+    }
+    result = await _runner(extra=extra)._handle_room_command(
+        _event("/rooms stop 1", user_id="member")
+    )
+    assert result.startswith("Room controls are off for this chat")
+    assert service.stopped == []
+
+    result = await _runner(extra=extra)._handle_room_command(
+        _event("/rooms stop 1", user_id="admin", message_id="stop-1")
+    )
+    assert result == (
+        "Stop requested for Release room. Active work will stop safely. "
+        "Check: `/rooms 1`."
+    )
+    assert service.stopped[0][0] == "release-room"
+
+
+@pytest.mark.asyncio
+async def test_room_history_and_mutation_require_an_explicit_admin(
+    tmp_path, monkeypatch
+):
+    db, _, _ = _seed_rooms(tmp_path)
+    service = _FakeService(db)
+    monkeypatch.setattr(
+        "gateway.hosted_room_messaging.current_room_backend", lambda: service
+    )
+    runner = _runner(extra={})
+    denial = "Room controls are off for this chat"
+    assert denial in await runner._handle_rooms_command(_event("/rooms"))
+    assert denial in await runner._handle_room_command(
+        _event("/rooms send 1 -- hello")
+    )
+    assert service.sent == []
+
+
+@pytest.mark.asyncio
+async def test_busy_dispatch_runs_room_control_without_touching_main_agent():
+    runner = _runner()
+    runner._handle_rooms_command = AsyncMock(return_value="room-dispatched")
+    event = _event("/rooms send 1 -- hello")
+    result = await runner._dispatch_busy_slash_command(
+        event,
+        resolve_command("rooms"),
+        "session-key",
+        event.source,
+    )
+    assert result == "room-dispatched"
+    runner._handle_rooms_command.assert_awaited_once_with(event)
+
+
+@pytest.mark.asyncio
+async def test_real_service_persists_server_owned_messaging_actor(tmp_path, monkeypatch):
+    service = _TestHostedRoomService(tmp_path / "state.db")
+    service.create_room(
+        room_id="release-room",
+        name="Release room",
+        members=[
+            {"member_id": "default", "profile": "default", "handle": "hermes"},
+            {"member_id": "ops", "profile": "ops", "handle": "ops"},
+        ],
+    )
+    monkeypatch.setattr(
+        "gateway.hosted_room_messaging.current_room_backend",
+        lambda: MessagingRoomBackend(db_path=service.db_path, service=service),
+    )
+    event = _event(
+        "/rooms send 1 -- @ops inspect the release",
+        platform=Platform.SIGNAL,
+    )
+    result = await _runner()._handle_room_command(event)
+    assert result == "Queued in Release room. Check: `/rooms 1`."
+    delta = hosted_rooms.read_events(
+        service.db_path,
+        room_id="release-room",
+        since_seq=0,
+        limit=20,
+    )
+    user_event = next(row for row in delta["events"] if row["kind"] == "message.user")
+    assert user_event["actor"]["display_name"] == "Display Name via Signal"
+    assert user_event["actor"]["id"].startswith("messaging:signal:")
+    assert "user-1" not in user_event["actor"]["id"]
+
+
+def test_cross_process_store_wakes_owner_without_desktop_transport(tmp_path):
+    service = _TestHostedRoomService(tmp_path / "state.db")
+    service.rpc = _ImmediateRPC()
+    service.runtime.rpc = service.rpc
+    service.create_room(
+        room_id="release-room",
+        name="Release room",
+        members=[
+            {"member_id": "default", "profile": "default", "handle": "hermes"},
+            {"member_id": "ops", "profile": "ops", "handle": "ops"},
+        ],
+    )
+    messaging_process = MessagingRoomBackend(db_path=service.db_path)
+    first_event = _event(
+        "/rooms send 1 -- @ops inspect the release",
+        platform=Platform.WHATSAPP,
+        message_id="message-1",
+    )
+    second_event = _event(
+        "/rooms send 1 -- @ops check the notes",
+        platform=Platform.WHATSAPP,
+        message_id="message-2",
+    )
+    for event, text in (
+        (first_event, "@ops inspect the release"),
+        (second_event, "@ops check the notes"),
+    ):
+        event_id = messaging_event_id(event)
+        messaging_process.send(
+            room_id="release-room",
+            event_id=event_id,
+            payload={"text": text, "thread_id": event_id},
+            actor=messaging_actor(event, gateway_id="install:test-gateway"),
+        )
+    service.start()
+    try:
+        _wait_for(
+            lambda: sum(
+                row["kind"] == "message.member"
+                for row in hosted_rooms.read_events(
+                    service.db_path,
+                    room_id="release-room",
+                    since_seq=0,
+                    limit=40,
+                )["events"]
+            )
+            == 2
+        )
+    finally:
+        assert service.stop(timeout=1.0)
+
+    events = hosted_rooms.read_events(
+        service.db_path,
+        room_id="release-room",
+        since_seq=0,
+        limit=40,
+    )["events"]
+    assert [row["kind"] for row in events[:2]] == ["message.user", "message.user"]
+    assert sum(row["kind"] == "message.member" for row in events) == 2
+    assert events[0]["actor"]["display_name"] == "Display Name via Whatsapp"
+
+
+def test_cross_process_stop_cancels_durable_queued_work(tmp_path):
+    service = _TestHostedRoomService(tmp_path / "state.db")
+    service.create_room(
+        room_id="release-room",
+        name="Release room",
+        members=[
+            {"member_id": "default", "profile": "default", "handle": "hermes"},
+            {"member_id": "ops", "profile": "ops", "handle": "ops"},
+        ],
+    )
+    service.send(
+        room_id="release-room",
+        event_id="user-1",
+        payload={"text": "@ops inspect", "thread_id": "thread-1"},
+    )
+    messaging_process = MessagingRoomBackend(db_path=service.db_path)
+    assert messaging_process.stop_room("release-room", cancel_id="stop-1") == 1
+    assert messaging_process.stop_room("release-room", cancel_id="stop-1") == 1
+    service.prepare_room(service.bindings()[0])
+    assert messaging_process.status("release-room")["working"] is False
+    tasks = hosted_room_driver.list_tasks(service.db_path, room_id="release-room")
+    assert [task["status"] for task in tasks] == ["cancelled"]
+
+
+def test_cross_process_send_is_idempotent_on_transport_redelivery(tmp_path):
+    db, room, _ = _seed_rooms(tmp_path)
+    messaging_process = MessagingRoomBackend(db_path=db)
+    event = _event("/rooms send 1 -- hello", platform=Platform.TELEGRAM)
+    event_id = messaging_event_id(event)
+    payload = {"text": "hello", "thread_id": event_id}
+    actor = messaging_actor(event, gateway_id="install:test-gateway")
+    first = messaging_process.send(
+        room_id=room["room_id"],
+        event_id=event_id,
+        payload=payload,
+        actor=actor,
+    )
+    second = messaging_process.send(
+        room_id=room["room_id"],
+        event_id=event_id,
+        payload=payload,
+        actor=actor,
+    )
+    assert first["seq"] == second["seq"] == 1
+    assert second["idempotent"] is True
+    delta = hosted_rooms.read_events(
+        db, room_id=room["room_id"], since_seq=0, limit=20
+    )
+    assert len(delta["events"]) == 1
+
+
+def test_cross_process_stop_is_acknowledged_by_owner_for_running_work(tmp_path):
+    service = _TestHostedRoomService(tmp_path / "state.db")
+    service.rpc = _HoldingRPC()
+    service.runtime.rpc = service.rpc
+    service.create_room(
+        room_id="release-room",
+        name="Release room",
+        members=[
+            {"member_id": "default", "profile": "default", "handle": "hermes"},
+            {"member_id": "ops", "profile": "ops", "handle": "ops"},
+        ],
+    )
+    messaging_process = MessagingRoomBackend(db_path=service.db_path)
+    event = _event("/rooms send 1 -- inspect")
+    messaging_process.send(
+        room_id="release-room",
+        event_id=messaging_event_id(event),
+        payload={"text": "inspect", "thread_id": messaging_event_id(event)},
+        actor=messaging_actor(event, gateway_id="install:test-gateway"),
+    )
+    service.start()
+    try:
+        _wait_for(
+            lambda: any(
+                task["status"] == "running"
+                for task in hosted_room_driver.list_tasks(
+                    service.db_path, room_id="release-room"
+                )
+            )
+        )
+        assert messaging_process.stop_room("release-room", cancel_id="stop-1") == 1
+        _wait_for(
+            lambda: hosted_room_driver.list_tasks(
+                service.db_path, room_id="release-room"
+            )[0]["status"]
+            == "cancelled"
+        )
+    finally:
+        assert service.stop(timeout=1.0)
+
+    assert len(service.rpc.interrupts) == 1
+    tasks = hosted_room_driver.list_tasks(service.db_path, room_id="release-room")
+    assert len(tasks) == 1
+    assert tasks[0]["status"] == "cancelled"

--- a/tests/gateway/test_hosted_room_messaging.py
+++ b/tests/gateway/test_hosted_room_messaging.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import time
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
@@ -13,6 +14,7 @@ import pytest
 
 from gateway import hosted_room_driver, hosted_rooms
 from gateway.config import GatewayConfig, HomeChannel, Platform, PlatformConfig
+from gateway.hosted_room_attachments import HostedRoomAttachmentStore
 from gateway.hosted_room_messaging import (
     MessagingRoomBackend,
     RoomControlError,
@@ -39,14 +41,29 @@ class _FakeService:
         self.db_path = db_path
         self.sent = []
         self.stopped = []
+        self.attachments = HostedRoomAttachmentStore(db_path)
         self.room_status = {"running": True, "working": False, "blocked": False}
 
     def status(self, _room_id):
         return dict(self.room_status)
 
     def send(self, **kwargs):
+        manifest = kwargs.get("payload", {}).get("attachments") or []
+        if manifest:
+            room = hosted_rooms.room_state(self.db_path, room_id=kwargs["room_id"])
+            self.attachments.commit_message(
+                room_id=kwargs["room_id"],
+                event_id=kwargs["event_id"],
+                manifest=manifest,
+                recipient_member_ids=tuple(
+                    member["member_id"] for member in room["members"]
+                ),
+            )
         self.sent.append(kwargs)
         return {"seq": 1}
+
+    def put_attachment(self, **kwargs):
+        return self.attachments.put(**kwargs)
 
     def stop_room(self, room_id, *, cancel_id):
         self.stopped.append((room_id, cancel_id))
@@ -185,6 +202,8 @@ def _event(
     user_id: str = "user-1",
     message_id: str = "message-1",
     media: bool = False,
+    media_urls: list[str] | None = None,
+    media_types: list[str] | None = None,
     is_bot: bool = False,
 ) -> MessageEvent:
     return MessageEvent(
@@ -193,8 +212,8 @@ def _event(
         user_id=user_id,
         user_name="Display Name",
         message_id=message_id,
-        media_urls=["/tmp/image.png"] if media else [],
-        media_types=["image/png"] if media else [],
+        media_urls=media_urls if media_urls is not None else ["/tmp/image.png"] if media else [],
+        media_types=media_types if media_types is not None else ["image/png"] if media else [],
         source=SessionSource(
             platform=platform,
             chat_id=f"chat-{platform.value}",
@@ -429,7 +448,14 @@ def test_classic_room_send_and_stop_wait_for_desktop(tmp_path, monkeypatch):
     assert [(item["action"], item["payload"]) for item in commands] == [
         (
             "send",
-            {"actor_display_name": "Display Name via Signal", "message": "hello"},
+            {
+                "actor_display_name": "Display Name via Signal",
+                "message": "hello",
+                "recipients": [
+                    {"name": "default", "handle": "hermes"},
+                    {"name": "reviewer", "handle": "reviewer"},
+                ],
+            },
         ),
         ("stop", {}),
     ]
@@ -456,6 +482,57 @@ def test_legacy_desktop_room_control_requests_one_current_desktop_open(tmp_path,
             _event("/group 1 send hello", message_id="legacy-send"),
             "hello",
         )
+
+
+def test_classic_mailbox_carries_attachment_ids_and_desktop_can_read_bytes(
+    tmp_path, monkeypatch
+):
+    from gateway import desktop_room_mailbox
+
+    home = tmp_path / "hermes"
+    _seed_classic_projection(home)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(
+        hosted_rooms,
+        "local_authority_gateway_id",
+        lambda: "install:test-gateway",
+    )
+    db = desktop_room_mailbox.default_db_path()
+    service = _FakeService(db)
+    room = list_messaging_rooms(service)[0]
+    cache = db.parent / "cache"
+    cache.mkdir(exist_ok=True)
+    notes = cache / "notes.txt"
+    notes.write_text("release notes", encoding="utf-8")
+    event = _event(
+        "/group 1 send",
+        message_id="send-attachment-1",
+        media_urls=[str(notes)],
+        media_types=["text/plain"],
+    )
+
+    send_to_room(service, room, event, "")
+    command = desktop_room_mailbox.claim_commands(
+        db,
+        consumer_id="desktop:test",
+        room_authorities=[{
+            "room_id": "classic-room",
+            "authority_token": "authority:test",
+        }],
+    )[0]
+
+    attachment = command["payload"]["attachments"][0]
+    assert attachment["attachment_id"].startswith("att_")
+    serialized = json.dumps(command["payload"])
+    assert "release notes" not in serialized
+    assert str(notes) not in serialized
+    stored = HostedRoomAttachmentStore(hosted_rooms.default_db_path()).read(
+        room_id="classic-room",
+        attachment_id=attachment["attachment_id"],
+        recipient_member_id="desktop",
+        event_id=command["command_id"],
+    )
+    assert stored.data == b"release notes"
 
 
 def test_classic_room_detail_surfaces_failed_command_recovery(tmp_path, monkeypatch):
@@ -496,6 +573,26 @@ def test_classic_room_detail_surfaces_failed_command_recovery(tmp_path, monkeypa
 
     assert "Desktop planning — needs attention" in detail
     assert "The latest command could not be applied." in detail
+
+
+def test_room_detail_names_attachment_only_activity(tmp_path):
+    room = {
+        "room_id": "classic-room",
+        "name": "Design review",
+        "members": [{"name": "default"}],
+        "messaging_ref": 1,
+        "_room_mode": "desktop",
+        "desktop_available": True,
+        "log": [{
+            "from": {"kind": "user", "name": "You"},
+            "text": "",
+            "images": [{"name": "brief.pdf", "kind": "pdf"}],
+        }],
+    }
+
+    detail = format_room_detail(_FakeService(tmp_path / "state.db"), room)
+
+    assert "• You: Shared brief.pdf" in detail
 
 
 @pytest.mark.parametrize(
@@ -810,7 +907,7 @@ async def test_entity_first_group_send_is_dispatched(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_send_rejects_attachments_instead_of_silently_dropping_them(
+async def test_send_ingests_localized_attachment_and_accepts_attachment_only_command(
     tmp_path, monkeypatch
 ):
     db, _, _ = _seed_rooms(tmp_path)
@@ -818,10 +915,116 @@ async def test_send_rejects_attachments_instead_of_silently_dropping_them(
     monkeypatch.setattr(
         "gateway.hosted_room_messaging.current_room_backend", lambda: service
     )
+    cache = tmp_path / "cache"
+    cache.mkdir()
+    image = cache / "image.png"
+    image.write_bytes(b"\x89PNG\r\n\x1a\nimage")
+
     result = await _runner()._handle_room_command(
-        _event("/group 1 send inspect this", media=True)
+        _event(
+            "/group 1 send",
+            media_urls=[str(image)],
+            media_types=["image/png"],
+        )
     )
-    assert "Attachments from messaging chats aren’t supported yet" in result
+
+    assert result == "Queued in Release room. Check: `/group 1`."
+    assert service.sent[-1]["payload"]["text"] == ""
+    manifest = service.sent[-1]["payload"]["attachments"]
+    assert manifest[0]["attachment_id"].startswith("att_")
+    assert manifest[0]["name"] == "image.png"
+    serialized = json.dumps(service.sent[-1])
+    assert str(image) not in serialized
+    assert "base64" not in serialized
+    assert "PNG" not in serialized
+
+
+def test_attachment_redelivery_reuses_upload_after_local_temp_file_is_removed(tmp_path):
+    db, room, _ = _seed_rooms(tmp_path)
+    service = _FakeService(db)
+    cache = tmp_path / "cache"
+    cache.mkdir()
+    image = cache / "image.png"
+    image.write_bytes(b"\x89PNG\r\n\x1a\nimage")
+    event = _event(
+        "/group 1 send inspect",
+        media_urls=[str(image)],
+        media_types=["image/png"],
+    )
+
+    send_to_room(service, {**room, "_room_mode": "hosted"}, event, "inspect")
+    first_id = service.sent[-1]["payload"]["attachments"][0]["attachment_id"]
+    image.unlink()
+    send_to_room(service, {**room, "_room_mode": "hosted"}, event, "inspect")
+
+    assert service.sent[-1]["payload"]["attachments"][0]["attachment_id"] == first_id
+    assert service.attachments.stats()["attachments"] == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("media_url", "message"),
+    [
+        ("https://example.com/private.png", "Remote or encoded"),
+        ("../image.png", "safe localized path"),
+    ],
+)
+async def test_send_rejects_remote_and_traversal_media(
+    tmp_path, monkeypatch, media_url, message
+):
+    db, _, _ = _seed_rooms(tmp_path)
+    service = _FakeService(db)
+    monkeypatch.setattr(
+        "gateway.hosted_room_messaging.current_room_backend", lambda: service
+    )
+
+    result = await _runner()._handle_room_command(
+        _event(
+            "/group 1 send inspect",
+            media_urls=[media_url],
+            media_types=["image/png"],
+        )
+    )
+
+    assert message in result
+    assert service.sent == []
+
+
+@pytest.mark.asyncio
+async def test_send_rejects_symlink_and_mime_mismatch(tmp_path, monkeypatch):
+    db, _, _ = _seed_rooms(tmp_path)
+    service = _FakeService(db)
+    monkeypatch.setattr(
+        "gateway.hosted_room_messaging.current_room_backend", lambda: service
+    )
+    cache = tmp_path / "cache"
+    cache.mkdir()
+    real = cache / "real.png"
+    real.write_bytes(b"\x89PNG\r\n\x1a\nimage")
+    link = cache / "link.png"
+    try:
+        link.symlink_to(real)
+    except OSError:
+        pytest.skip("symlink creation is unavailable")
+
+    symlink_result = await _runner()._handle_room_command(
+        _event(
+            "/group 1 send inspect",
+            media_urls=[str(link)],
+            media_types=["image/png"],
+        )
+    )
+    mismatch_result = await _runner()._handle_room_command(
+        _event(
+            "/group 1 send inspect",
+            message_id="message-2",
+            media_urls=[str(real)],
+            media_types=["application/pdf"],
+        )
+    )
+
+    assert "Symlinked attachments" in symlink_result
+    assert "PDF bytes" in mismatch_result
     assert service.sent == []
 
 

--- a/tests/gateway/test_hosted_room_messaging.py
+++ b/tests/gateway/test_hosted_room_messaging.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import time
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
@@ -240,6 +241,9 @@ def _seed_classic_projection(home, *, room_id="classic-room"):
                                 "name": "Desktop planning",
                                 "roomId": room_id,
                                 "hosted": None,
+                                "desktopAuthorityHash": hashlib.sha256(
+                                    b"authority:test"
+                                ).hexdigest(),
                                 "members": [
                                     {"name": "default", "handle": "hermes"},
                                     {"name": "reviewer", "handle": "reviewer"},
@@ -362,6 +366,28 @@ def test_more_than_128_classic_rooms_list_without_disabling_controls(tmp_path, m
     assert len({room["messaging_ref"] for room in listed}) == 260
 
 
+def test_malformed_projected_room_does_not_hide_healthy_group_chats(tmp_path, monkeypatch):
+    import yaml
+
+    home = tmp_path / "hermes"
+    _seed_classic_projection(home)
+    profile = home / "profile.yaml"
+    raw = yaml.safe_load(profile.read_text(encoding="utf-8"))
+    raw["ui_meta"]["hermes-bots-groups"]["rooms"]["id:broken"] = {
+        "name": "Broken",
+        "roomId": "x" * 201,
+        "desktopAuthorityHash": hashlib.sha256(b"authority:broken").hexdigest(),
+        "members": [{"name": "default"}],
+        "log": [],
+    }
+    profile.write_text(yaml.safe_dump(raw), encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    rooms = list_messaging_rooms(_FakeService(tmp_path / "state.db"))
+
+    assert [room["room_id"] for room in rooms] == ["classic-room"]
+
+
 def test_classic_room_send_and_stop_wait_for_desktop(tmp_path, monkeypatch):
     from gateway import desktop_room_mailbox
 
@@ -395,7 +421,10 @@ def test_classic_room_send_and_stop_wait_for_desktop(tmp_path, monkeypatch):
     commands = desktop_room_mailbox.claim_commands(
         desktop_room_mailbox.default_db_path(),
         consumer_id="desktop:test",
-        room_ids=["classic-room"],
+        room_authorities=[{
+            "room_id": "classic-room",
+            "authority_token": "authority:test",
+        }],
     )
     assert [(item["action"], item["payload"]) for item in commands] == [
         (
@@ -404,6 +433,29 @@ def test_classic_room_send_and_stop_wait_for_desktop(tmp_path, monkeypatch):
         ),
         ("stop", {}),
     ]
+
+
+def test_legacy_desktop_room_control_requests_one_current_desktop_open(tmp_path, monkeypatch):
+    import yaml
+
+    home = tmp_path / "hermes"
+    _seed_classic_projection(home)
+    profile = home / "profile.yaml"
+    raw = yaml.safe_load(profile.read_text(encoding="utf-8"))
+    del raw["ui_meta"]["hermes-bots-groups"]["rooms"]["id:classic-room"][
+        "desktopAuthorityHash"
+    ]
+    profile.write_text(yaml.safe_dump(raw), encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    room = list_messaging_rooms(_FakeService(tmp_path / "state.db"))[0]
+
+    with pytest.raises(RoomControlError, match="Open this Group Chat once"):
+        send_to_room(
+            _FakeService(tmp_path / "state.db"),
+            room,
+            _event("/group 1 send hello", message_id="legacy-send"),
+            "hello",
+        )
 
 
 def test_classic_room_detail_surfaces_failed_command_recovery(tmp_path, monkeypatch):
@@ -417,13 +469,17 @@ def test_classic_room_detail_surfaces_failed_command_recovery(tmp_path, monkeypa
         db,
         command_id="messaging:failed",
         room_id="classic-room",
+        authority_hash=hashlib.sha256(b"authority:test").hexdigest(),
         action="send",
         payload={"message": "hello"},
     )
     claimed = desktop_room_mailbox.claim_commands(
         db,
         consumer_id="desktop:test",
-        room_ids=["classic-room"],
+        room_authorities=[{
+            "room_id": "classic-room",
+            "authority_token": "authority:test",
+        }],
     )[0]
     desktop_room_mailbox.complete_command(
         db,

--- a/tests/gateway/test_hosted_room_messaging.py
+++ b/tests/gateway/test_hosted_room_messaging.py
@@ -1,16 +1,17 @@
-"""Messaging controls for gateway-hosted Bot rooms."""
+"""Messaging controls for gateway-hosted Group Chats."""
 
 from __future__ import annotations
 
 import time
 from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
 from types import ModuleType, SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
 
 from gateway import hosted_room_driver, hosted_rooms
-from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.config import GatewayConfig, HomeChannel, Platform, PlatformConfig
 from gateway.hosted_room_messaging import (
     MessagingRoomBackend,
     RoomControlError,
@@ -222,20 +223,19 @@ def _runner(*, platform: Platform = Platform.SIGNAL, extra=None):
 
 
 def test_room_commands_are_gateway_dispatchable_without_interrupting_agent():
-    rooms = resolve_command("rooms")
-    assert rooms is not None and rooms.gateway_only and rooms.busy_policy == "dispatch"
-    assert rooms.subcommands == ("send", "stop")
-    assert resolve_command("room") is None
+    group = resolve_command("group")
+    assert group is not None and group.gateway_only and group.busy_policy == "dispatch"
+    assert group.subcommands == ()
+    assert resolve_command("groups") is None
+    assert resolve_command("rooms") is None
 
 
 @pytest.mark.parametrize(
     ("raw", "expected"),
     [
-        (
-            "send Release room -- check the build -- then report",
-            ("send", "Release room", "check the build -- then report"),
-        ),
-        ("stop Release room", ("stop", "Release room", "")),
+        ('1 send "hi there"', ("send", "1", "hi there")),
+        ("1 send -- quoted style", ("send", "1", "quoted style")),
+        ("1 stop", ("stop", "1", "")),
     ],
 )
 def test_parse_room_command_keeps_names_and_message_content(raw, expected):
@@ -245,7 +245,7 @@ def test_parse_room_command_keeps_names_and_message_content(raw, expected):
 
 @pytest.mark.parametrize("raw", ["", "send room", "send -- hello", "stop"])
 def test_parse_room_command_returns_actionable_usage(raw):
-    with pytest.raises(RoomControlError, match="Use `/rooms"):
+    with pytest.raises(RoomControlError, match="Use `/group"):
         parse_room_command(raw)
 
 
@@ -338,9 +338,9 @@ def test_room_resolution_explains_ambiguity_and_missing_names(tmp_path):
         authority_gateway_id="install:test-gateway",
     )
     rooms = hosted_rooms.list_rooms(db)
-    with pytest.raises(RoomControlError, match="matches several rooms"):
+    with pytest.raises(RoomControlError, match="matches several group chats"):
         resolve_room(rooms, "release")
-    with pytest.raises(RoomControlError, match="No hosted Bot room"):
+    with pytest.raises(RoomControlError, match="No Group Chat"):
         resolve_room(rooms, "missing")
 
 
@@ -361,10 +361,24 @@ async def test_reserved_word_room_name_opens_detail_without_triggering_stop(
         "gateway.hosted_room_messaging.current_room_backend", lambda: service
     )
 
-    result = await _runner()._handle_rooms_command(_event("/rooms Stop signals"))
+    result = await _runner()._handle_rooms_command(_event("/group Stop signals"))
 
     assert result.startswith("Stop signals —")
     assert service.stopped == []
+
+
+@pytest.mark.asyncio
+async def test_group_list_keyword_uses_the_same_helpful_listing(tmp_path, monkeypatch):
+    db, _, _ = _seed_rooms(tmp_path)
+    monkeypatch.setattr(
+        "gateway.hosted_room_messaging.current_room_backend",
+        lambda: _FakeService(db),
+    )
+
+    result = await _runner()._handle_rooms_command(_event("/group list"))
+
+    assert result.startswith("Group Chats\n")
+    assert "Commands\nCheck: `/group <number>`" in result
 
 
 @pytest.mark.asyncio
@@ -376,10 +390,12 @@ async def test_mutating_room_commands_require_the_stable_number(tmp_path, monkey
     )
 
     result = await _runner()._handle_room_command(
-        _event("/rooms stop Release room")
+        _event("/group stop Release room")
     )
 
-    assert result == "Use `/rooms stop <room number>`."
+    assert result == (
+        "Use `/group <number> send <message>` or `/group <number> stop`."
+    )
     assert service.stopped == []
 
 
@@ -413,19 +429,29 @@ def test_room_list_and_detail_are_bounded_and_user_facing(tmp_path):
     )
 
     listing = format_room_list(service)
-    assert "Hosted Bot rooms" in listing
+    assert "Group Chats" in listing
     assert "1. Release room — waiting for the room host, 2 bots" in listing
+    assert "Commands\nCheck: `/group <number>`" in listing
+    assert "Send: `/group <number> send <message>`" in listing
+    assert "Stop: `/group <number> stop`" in listing
     detail = format_room_detail(service, release)
     assert "Signal: Please inspect the release" in detail
     assert "Operations: The release is ready" in detail
-    assert "Send: `/rooms send 1 -- <message>`" in detail
-    assert "Stop: `/rooms stop 1`" in detail
+    assert "Send: `/group 1 send <message>`" in detail
+    assert "Stop: `/group 1 stop`" in detail
+
+
+def test_empty_group_list_still_explains_the_primary_command(tmp_path):
+    listing = format_room_list(_FakeService(tmp_path / "state.db"))
+
+    assert listing.startswith("No Group Chats yet.")
+    assert "`/group <number> send <message>`" in listing
 
 
 def test_messaging_identity_is_stable_private_and_edit_safe():
-    first = _event("/rooms send 1 -- hello", platform=Platform.TELEGRAM)
+    first = _event("/group 1 send hello", platform=Platform.TELEGRAM)
     first.platform_update_id = 123
-    second = _event("/rooms send 1 -- edited", platform=Platform.TELEGRAM)
+    second = _event("/group 1 send edited", platform=Platform.TELEGRAM)
     second.platform_update_id = 124
     actor = messaging_actor(first, gateway_id="install:test-gateway")
     assert actor["display_name"] == "Display Name via Telegram"
@@ -435,9 +461,9 @@ def test_messaging_identity_is_stable_private_and_edit_safe():
 
 
 def test_transport_specific_command_forms_are_actionable():
-    assert command_form(_event("/rooms", platform=Platform.SIGNAL)) == "/rooms"
-    assert command_form(_event("/rooms", platform=Platform.SLACK)) == "/hermes rooms"
-    assert command_form(_event("/rooms", platform=Platform.MATRIX)) == "!rooms"
+    assert command_form(_event("/group", platform=Platform.SIGNAL)) == "/group"
+    assert command_form(_event("/group", platform=Platform.SLACK)) == "/hermes group"
+    assert command_form(_event("/group", platform=Platform.MATRIX)) == "!group"
 
 
 @pytest.mark.parametrize(
@@ -449,7 +475,7 @@ def test_transport_specific_command_forms_are_actionable():
     ],
 )
 def test_real_channel_raw_ids_are_stable_without_normalized_message_id(raw_message):
-    event = _event("/rooms send 1 -- hello")
+    event = _event("/group 1 send hello")
     event.message_id = None
     event.source.message_id = None
     event.raw_message = raw_message
@@ -457,7 +483,7 @@ def test_real_channel_raw_ids_are_stable_without_normalized_message_id(raw_messa
 
 
 def test_mutation_fails_closed_without_a_transport_redelivery_id():
-    event = _event("/rooms send 1 -- hello")
+    event = _event("/group 1 send hello")
     event.message_id = None
     event.source.message_id = None
     with pytest.raises(RoomControlError, match="stable message ID"):
@@ -465,8 +491,8 @@ def test_mutation_fails_closed_without_a_transport_redelivery_id():
 
 
 def test_signal_group_idempotency_includes_sender_identity():
-    first = _event("/rooms send 1 -- hello", user_id="sender-a")
-    second = _event("/rooms send 1 -- hello", user_id="sender-b")
+    first = _event("/group 1 send hello", user_id="sender-a")
+    second = _event("/group 1 send hello", user_id="sender-b")
     for event in (first, second):
         event.message_id = None
         event.source.message_id = None
@@ -485,7 +511,7 @@ async def test_send_handler_is_shared_by_every_gateway_channel(
         "gateway.hosted_room_messaging.current_room_backend", lambda: service
     )
     event = _event(
-        "/rooms send 1 -- hello from messaging",
+        "/group 1 send hello from messaging",
         platform=platform,
         message_id=f"message-{platform.value}",
     )
@@ -500,6 +526,22 @@ async def test_send_handler_is_shared_by_every_gateway_channel(
 
 
 @pytest.mark.asyncio
+async def test_entity_first_group_send_is_dispatched(tmp_path, monkeypatch):
+    db, _, _ = _seed_rooms(tmp_path)
+    service = _FakeService(db)
+    monkeypatch.setattr(
+        "gateway.hosted_room_messaging.current_room_backend", lambda: service
+    )
+
+    result = await _runner()._handle_rooms_command(
+        _event("/group 1 send hello from Signal", message_id="entity-first-1")
+    )
+
+    assert result == "Queued in Release room. Check: `/group 1`."
+    assert service.sent[-1]["payload"]["text"] == "hello from Signal"
+
+
+@pytest.mark.asyncio
 async def test_send_rejects_attachments_instead_of_silently_dropping_them(
     tmp_path, monkeypatch
 ):
@@ -509,7 +551,7 @@ async def test_send_rejects_attachments_instead_of_silently_dropping_them(
         "gateway.hosted_room_messaging.current_room_backend", lambda: service
     )
     result = await _runner()._handle_room_command(
-        _event("/rooms send 1 -- inspect this", media=True)
+        _event("/group 1 send inspect this", media=True)
     )
     assert "Attachments from messaging chats aren’t supported yet" in result
     assert service.sent == []
@@ -526,12 +568,12 @@ async def test_bot_authored_controls_are_rejected_to_prevent_bridge_loops(
     )
     result = await _runner(platform=Platform.DISCORD)._handle_room_command(
         _event(
-            "/rooms send 1 -- repeat this",
+            "/group 1 send repeat this",
             platform=Platform.DISCORD,
             is_bot=True,
         )
     )
-    assert result == "Hosted Bot room controls are only available to people."
+    assert result == "Group Chat controls are only available to people."
     assert service.sent == []
 
 
@@ -544,10 +586,10 @@ async def test_raw_webhook_bot_marker_is_rejected_even_without_source_flag(
     monkeypatch.setattr(
         "gateway.hosted_room_messaging.current_room_backend", lambda: service
     )
-    event = _event("/rooms send 1 -- repeat this")
+    event = _event("/group 1 send repeat this")
     event.raw_message = {"subtype": "bot_message", "bot_id": "B123"}
     result = await _runner()._handle_rooms_command(event)
-    assert result == "Hosted Bot room controls are only available to people."
+    assert result == "Group Chat controls are only available to people."
     assert service.sent == []
 
 
@@ -563,7 +605,7 @@ def test_relay_and_session_roundtrip_preserve_bot_provenance():
     assert SessionSource.from_dict(source.to_dict()).is_bot is True
     relayed = _event_from_wire(
         {
-            "text": "/rooms",
+            "text": "/group",
             "message_type": "command",
             "source": source.to_dict(),
         }
@@ -577,7 +619,7 @@ def test_legacy_relay_without_author_classification_fails_closed():
 
     relayed = _event_from_wire(
         {
-            "text": "/rooms",
+            "text": "/group",
             "message_type": "command",
             "source": {
                 "platform": "discord",
@@ -601,20 +643,20 @@ async def test_stop_requires_admin_when_operator_enabled_slash_gating(
     )
     extra = {
         "allow_admin_from": ["admin"],
-        "user_allowed_commands": ["rooms"],
+        "user_allowed_commands": ["groups"],
     }
     result = await _runner(extra=extra)._handle_room_command(
-        _event("/rooms stop 1", user_id="member")
+        _event("/group 1 stop", user_id="member")
     )
-    assert result.startswith("Room controls are off for this chat")
+    assert result.startswith("This chat can’t control Group Chats")
     assert service.stopped == []
 
     result = await _runner(extra=extra)._handle_room_command(
-        _event("/rooms stop 1", user_id="admin", message_id="stop-1")
+        _event("/group 1 stop", user_id="admin", message_id="stop-1")
     )
     assert result == (
         "Stop requested for Release room. Active work will stop safely. "
-        "Check: `/rooms 1`."
+        "Check: `/group 1`."
     )
     assert service.stopped[0][0] == "release-room"
 
@@ -628,12 +670,253 @@ async def test_room_history_and_mutation_require_an_explicit_admin(
     monkeypatch.setattr(
         "gateway.hosted_room_messaging.current_room_backend", lambda: service
     )
-    runner = _runner(extra={})
-    denial = "Room controls are off for this chat"
-    assert denial in await runner._handle_rooms_command(_event("/rooms"))
+    runner = _runner(extra={"allow_from": ["user-1"]})
+    runner._is_user_authorized_for_source = lambda _source: True
+    denial = "This chat can’t control Group Chats"
+    assert denial in await runner._handle_rooms_command(_event("/group"))
     assert denial in await runner._handle_room_command(
-        _event("/rooms send 1 -- hello")
+        _event("/group 1 send hello")
     )
+    assert service.sent == []
+
+
+@pytest.mark.asyncio
+async def test_home_dm_controls_rooms_without_duplicate_admin_list(
+    tmp_path, monkeypatch
+):
+    db, _, _ = _seed_rooms(tmp_path)
+    service = _FakeService(db)
+    monkeypatch.setattr(
+        "gateway.hosted_room_messaging.current_room_backend", lambda: service
+    )
+    monkeypatch.setenv("SIGNAL_ALLOWED_USERS", "user-1")
+    runner = _runner(extra={})
+    runner._is_user_authorized_for_source = lambda _source: True
+    runner.config.platforms[Platform.SIGNAL].home_channel = HomeChannel(
+        platform=Platform.SIGNAL,
+        chat_id="chat-signal",
+        name="Home",
+    )
+
+    listing = await runner._handle_rooms_command(_event("/group list"))
+    assert listing.startswith("Group Chats")
+    result = await runner._handle_room_command(
+        _event("/group 1 send hello", message_id="home-send-1")
+    )
+    assert result.startswith("Queued in Release room")
+    assert service.sent[0]["payload"]["text"] == "hello"
+
+
+@pytest.mark.asyncio
+async def test_non_home_dm_still_requires_explicit_admin(tmp_path, monkeypatch):
+    db, _, _ = _seed_rooms(tmp_path)
+    service = _FakeService(db)
+    monkeypatch.setattr(
+        "gateway.hosted_room_messaging.current_room_backend", lambda: service
+    )
+    runner = _runner(extra={})
+    runner.config.platforms[Platform.SIGNAL].home_channel = HomeChannel(
+        platform=Platform.SIGNAL,
+        chat_id="different-chat",
+        name="Home",
+    )
+
+    result = await runner._handle_room_command(
+        _event("/group 1 send hello", message_id="other-send-1")
+    )
+    assert result.startswith("This chat can’t control Group Chats")
+    assert service.sent == []
+
+
+@pytest.mark.asyncio
+async def test_shared_home_dm_does_not_auto_promote_an_allowed_user(
+    tmp_path, monkeypatch
+):
+    db, _, _ = _seed_rooms(tmp_path)
+    service = _FakeService(db)
+    monkeypatch.setattr(
+        "gateway.hosted_room_messaging.current_room_backend", lambda: service
+    )
+    runner = _runner(extra={"allow_from": ["user-1", "user-2"]})
+    runner._is_user_authorized_for_source = lambda _source: True
+    runner.config.platforms[Platform.SIGNAL].home_channel = HomeChannel(
+        platform=Platform.SIGNAL,
+        chat_id="chat-signal",
+        name="Home",
+    )
+
+    result = await runner._handle_room_command(
+        _event("/group 1 send hello", message_id="shared-send-1")
+    )
+    assert result.startswith("This chat can’t control Group Chats")
+    assert service.sent == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("allowed_users", "allow_all"),
+    [
+        ("user-1,user-2", ""),
+        ("user-1", "true"),
+    ],
+)
+async def test_builtin_platform_grants_fail_closed_without_registry(
+    tmp_path,
+    monkeypatch,
+    allowed_users,
+    allow_all,
+):
+    db, _, _ = _seed_rooms(tmp_path)
+    service = _FakeService(db)
+    monkeypatch.setattr(
+        "gateway.hosted_room_messaging.current_room_backend", lambda: service
+    )
+    monkeypatch.setenv("SIGNAL_ALLOWED_USERS", allowed_users)
+    monkeypatch.setenv("SIGNAL_ALLOW_ALL_USERS", allow_all)
+    runner = _runner(extra={})
+    runner._is_user_authorized_for_source = lambda _source: True
+    runner.config.platforms[Platform.SIGNAL].home_channel = HomeChannel(
+        platform=Platform.SIGNAL,
+        chat_id="chat-signal",
+        name="Home",
+    )
+
+    result = await runner._handle_room_command(
+        _event("/group 1 send hello", message_id="grant-send-1")
+    )
+    assert result.startswith("This chat can’t control Group Chats")
+    assert service.sent == []
+
+
+@pytest.mark.asyncio
+async def test_routed_profile_uses_transport_principals_for_owner_census(
+    tmp_path, monkeypatch
+):
+    from contextlib import contextmanager
+
+    from gateway import authz_mixin, run as gateway_run
+
+    db, _, _ = _seed_rooms(tmp_path)
+    service = _FakeService(db)
+    monkeypatch.setattr(
+        "gateway.hosted_room_messaging.current_room_backend", lambda: service
+    )
+    active_scope = {"name": "routed"}
+
+    @contextmanager
+    def fake_profile_scope(path):
+        previous = active_scope["name"]
+        active_scope["name"] = Path(path).name
+        try:
+            yield
+        finally:
+            active_scope["name"] = previous
+
+    def fake_auth_env(name, default=""):
+        if name == "SIGNAL_ALLOWED_USERS":
+            return (
+                "user-1,user-2"
+                if active_scope["name"] == "transport"
+                else "user-1"
+            )
+        return default
+
+    monkeypatch.setattr(gateway_run, "_profile_runtime_scope", fake_profile_scope)
+    monkeypatch.setattr(authz_mixin, "_auth_env", fake_auth_env)
+    runner = _runner(extra={})
+    runner._is_user_authorized_for_source = lambda _source: True
+    runner.config.platforms[Platform.SIGNAL].home_channel = HomeChannel(
+        platform=Platform.SIGNAL,
+        chat_id="chat-signal",
+        name="Home",
+    )
+    event = _event("/group 1 send hello", message_id="routed-send-1")
+    event.source.profile = "worker"
+    event.source._authorization_profile_home = Path("/transport")
+
+    result = await runner._handle_room_command(event)
+    assert result.startswith("This chat can’t control Group Chats")
+    assert service.sent == []
+
+
+@pytest.mark.asyncio
+async def test_secondary_adapter_allowlist_owns_the_owner_census(
+    tmp_path, monkeypatch
+):
+    db, _, _ = _seed_rooms(tmp_path)
+    service = _FakeService(db)
+    monkeypatch.setattr(
+        "gateway.hosted_room_messaging.current_room_backend", lambda: service
+    )
+    runner = _runner(extra={"allow_from": ["user-1"]})
+    runner._is_user_authorized_for_source = lambda _source: True
+    runner.config.platforms[Platform.SIGNAL].home_channel = HomeChannel(
+        platform=Platform.SIGNAL,
+        chat_id="chat-signal",
+        name="Home",
+    )
+    adapter = SimpleNamespace(
+        config=PlatformConfig(extra={"allow_from": ["user-1", "user-2"]})
+    )
+    runner._profile_adapters = {"worker": {Platform.SIGNAL: adapter}}
+    runner.adapters = {}
+    event = _event("/group 1 send hello", message_id="secondary-send-1")
+    event.source.profile = "worker"
+    event.source._transport_adapter_ref = lambda: adapter
+
+    result = await runner._handle_room_command(event)
+    assert result.startswith("This chat can’t control Group Chats")
+    assert service.sent == []
+
+
+@pytest.mark.asyncio
+async def test_registered_adapter_without_visible_allowlist_fails_closed(
+    tmp_path, monkeypatch
+):
+    db, _, _ = _seed_rooms(tmp_path)
+    service = _FakeService(db)
+    monkeypatch.setattr(
+        "gateway.hosted_room_messaging.current_room_backend", lambda: service
+    )
+    runner = _runner(extra={"allow_from": ["user-1"]})
+    runner._is_user_authorized_for_source = lambda _source: True
+    runner.config.platforms[Platform.SIGNAL].home_channel = HomeChannel(
+        platform=Platform.SIGNAL,
+        chat_id="chat-signal",
+        name="Home",
+    )
+    adapter = SimpleNamespace(config=PlatformConfig(extra={}))
+    runner._profile_adapters = {"worker": {Platform.SIGNAL: adapter}}
+    runner.adapters = {}
+    event = _event("/group 1 send hello", message_id="opaque-send-1")
+    event.source.profile = "worker"
+    event.source._transport_adapter_ref = lambda: adapter
+
+    result = await runner._handle_room_command(event)
+    assert result.startswith("This chat can’t control Group Chats")
+    assert service.sent == []
+
+
+@pytest.mark.asyncio
+async def test_relayed_home_dm_requires_explicit_admin(tmp_path, monkeypatch):
+    db, _, _ = _seed_rooms(tmp_path)
+    service = _FakeService(db)
+    monkeypatch.setattr(
+        "gateway.hosted_room_messaging.current_room_backend", lambda: service
+    )
+    runner = _runner(extra={"allow_from": ["user-1"]})
+    runner._is_user_authorized_for_source = lambda _source: True
+    runner.config.platforms[Platform.SIGNAL].home_channel = HomeChannel(
+        platform=Platform.SIGNAL,
+        chat_id="chat-signal",
+        name="Home",
+    )
+    event = _event("/group 1 send hello", message_id="relay-send-1")
+    event.source.delivered_via_upstream_relay = True
+    event.metadata = {"relay_author_classified": True}
+
+    result = await runner._handle_room_command(event)
+    assert result.startswith("This chat can’t control Group Chats")
     assert service.sent == []
 
 
@@ -641,10 +924,10 @@ async def test_room_history_and_mutation_require_an_explicit_admin(
 async def test_busy_dispatch_runs_room_control_without_touching_main_agent():
     runner = _runner()
     runner._handle_rooms_command = AsyncMock(return_value="room-dispatched")
-    event = _event("/rooms send 1 -- hello")
+    event = _event("/group 1 send hello")
     result = await runner._dispatch_busy_slash_command(
         event,
-        resolve_command("rooms"),
+        resolve_command("group"),
         "session-key",
         event.source,
     )
@@ -668,11 +951,11 @@ async def test_real_service_persists_server_owned_messaging_actor(tmp_path, monk
         lambda: MessagingRoomBackend(db_path=service.db_path, service=service),
     )
     event = _event(
-        "/rooms send 1 -- @ops inspect the release",
+        "/group 1 send @ops inspect the release",
         platform=Platform.SIGNAL,
     )
     result = await _runner()._handle_room_command(event)
-    assert result == "Queued in Release room. Check: `/rooms 1`."
+    assert result == "Queued in Release room. Check: `/group 1`."
     delta = hosted_rooms.read_events(
         service.db_path,
         room_id="release-room",
@@ -699,12 +982,12 @@ def test_cross_process_store_wakes_owner_without_desktop_transport(tmp_path):
     )
     messaging_process = MessagingRoomBackend(db_path=service.db_path)
     first_event = _event(
-        "/rooms send 1 -- @ops inspect the release",
+        "/group 1 send @ops inspect the release",
         platform=Platform.WHATSAPP,
         message_id="message-1",
     )
     second_event = _event(
-        "/rooms send 1 -- @ops check the notes",
+        "/group 1 send @ops check the notes",
         platform=Platform.WHATSAPP,
         message_id="message-2",
     )
@@ -774,7 +1057,7 @@ def test_cross_process_stop_cancels_durable_queued_work(tmp_path):
 def test_cross_process_send_is_idempotent_on_transport_redelivery(tmp_path):
     db, room, _ = _seed_rooms(tmp_path)
     messaging_process = MessagingRoomBackend(db_path=db)
-    event = _event("/rooms send 1 -- hello", platform=Platform.TELEGRAM)
+    event = _event("/group 1 send hello", platform=Platform.TELEGRAM)
     event_id = messaging_event_id(event)
     payload = {"text": "hello", "thread_id": event_id}
     actor = messaging_actor(event, gateway_id="install:test-gateway")
@@ -811,7 +1094,7 @@ def test_cross_process_stop_is_acknowledged_by_owner_for_running_work(tmp_path):
         ],
     )
     messaging_process = MessagingRoomBackend(db_path=service.db_path)
-    event = _event("/rooms send 1 -- inspect")
+    event = _event("/group 1 send inspect")
     messaging_process.send(
         room_id="release-room",
         event_id=messaging_event_id(event),

--- a/tests/gateway/test_hosted_room_messaging.py
+++ b/tests/gateway/test_hosted_room_messaging.py
@@ -24,6 +24,8 @@ from gateway.hosted_room_messaging import (
     parse_room_command,
     relay_provenance_is_unknown,
     resolve_room,
+    send_to_room,
+    stop_room,
 )
 from gateway.platforms.base import MessageEvent, MessageType
 from gateway.session import SessionSource
@@ -222,12 +224,222 @@ def _runner(*, platform: Platform = Platform.SIGNAL, extra=None):
     return runner
 
 
+def _seed_classic_projection(home, *, room_id="classic-room"):
+    import yaml
+
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "profile.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "ui_meta": {
+                    "hermes-bots-groups": {
+                        "version": 3,
+                        "updatedAt": 2000,
+                        "rooms": {
+                            f"id:{room_id}": {
+                                "name": "Desktop planning",
+                                "roomId": room_id,
+                                "hosted": None,
+                                "members": [
+                                    {"name": "default", "handle": "hermes"},
+                                    {"name": "reviewer", "handle": "reviewer"},
+                                ],
+                                "log": [
+                                    {
+                                        "id": "message-1",
+                                        "from": {"kind": "user", "name": "You"},
+                                        "text": "Review the plan",
+                                        "at": 1000,
+                                        "thread": "thread-1",
+                                    },
+                                    {
+                                        "id": "message-2",
+                                        "from": {"kind": "member", "name": "Reviewer"},
+                                        "text": "The rollout needs a rollback step.",
+                                        "at": 2000,
+                                        "thread": "thread-1",
+                                    },
+                                ],
+                            }
+                        },
+                    }
+                }
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+
 def test_room_commands_are_gateway_dispatchable_without_interrupting_agent():
     group = resolve_command("group")
     assert group is not None and group.gateway_only and group.busy_policy == "dispatch"
     assert group.subcommands == ()
     assert resolve_command("groups") is None
     assert resolve_command("rooms") is None
+
+
+def test_classic_room_projection_is_listed_with_recent_activity(tmp_path, monkeypatch):
+    home = tmp_path / "hermes"
+    _seed_classic_projection(home)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    service = _FakeService(tmp_path / "state.db")
+
+    rooms = list_messaging_rooms(service)
+
+    assert len(rooms) == 1
+    assert rooms[0]["_room_mode"] == "desktop"
+    assert rooms[0]["desktop_available"] is False
+    assert "Desktop planning — waiting for Desktop" in format_room_detail(
+        service, rooms[0]
+    )
+    assert "• Reviewer: The rollout needs a rollback step." in format_room_detail(
+        service, rooms[0]
+    )
+    listing = format_room_list(service)
+    assert listing.startswith("Group Chats\n")
+    assert "Commands\nCheck: `/group <number>`" in listing
+    assert "Send: `/group <number> send <message>`" in listing
+    assert "Stop: `/group <number> stop`" in listing
+
+
+def test_legacy_projection_uses_the_same_name_identity_as_new_desktop(tmp_path, monkeypatch):
+    import yaml
+
+    home = tmp_path / "hermes"
+    home.mkdir(parents=True)
+    (home / "profile.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "ui_meta": {
+                    "hermes-bots-groups": {
+                        "version": 2,
+                        "rooms": {
+                            "Legacy planning": {
+                                "name": "Legacy planning",
+                                "members": [{"name": "default"}],
+                                "log": [],
+                            }
+                        },
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    room = list_messaging_rooms(_FakeService(tmp_path / "state.db"))[0]
+
+    assert room["room_id"] == "name:Legacy planning"
+
+
+def test_more_than_128_classic_rooms_list_without_disabling_controls(tmp_path, monkeypatch):
+    import yaml
+
+    home = tmp_path / "hermes"
+    home.mkdir(parents=True)
+    rooms = {
+        f"id:room-{index}": {
+            "name": f"Group chat {index}",
+            "roomId": f"room-{index}",
+            "members": [{"name": "default"}],
+            "log": [],
+        }
+        for index in range(260)
+    }
+    (home / "profile.yaml").write_text(
+        yaml.safe_dump(
+            {"ui_meta": {"hermes-bots-groups": {"version": 3, "rooms": rooms}}}
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    listed = list_messaging_rooms(_FakeService(tmp_path / "state.db"))
+
+    assert len(listed) == 260
+    assert len({room["messaging_ref"] for room in listed}) == 260
+
+
+def test_classic_room_send_and_stop_wait_for_desktop(tmp_path, monkeypatch):
+    from gateway import desktop_room_mailbox
+
+    home = tmp_path / "hermes"
+    _seed_classic_projection(home)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(
+        hosted_rooms,
+        "local_authority_gateway_id",
+        lambda: "install:test-gateway",
+    )
+    service = _FakeService(tmp_path / "state.db")
+    room = list_messaging_rooms(service)[0]
+
+    sent = send_to_room(
+        service,
+        room,
+        _event("/group 1 send hello", message_id="send-1"),
+        "hello",
+    )
+    stopped = stop_room(
+        service,
+        room,
+        _event("/group 1 stop", message_id="stop-1"),
+    )
+
+    assert sent == "Saved for Desktop planning. Open or update Hermes Desktop to continue."
+    assert stopped == (
+        "Stop saved for Desktop planning. Open or update Hermes Desktop to apply it."
+    )
+    commands = desktop_room_mailbox.claim_commands(
+        desktop_room_mailbox.default_db_path(),
+        consumer_id="desktop:test",
+        room_ids=["classic-room"],
+    )
+    assert [(item["action"], item["payload"]) for item in commands] == [
+        (
+            "send",
+            {"actor_display_name": "Display Name via Signal", "message": "hello"},
+        ),
+        ("stop", {}),
+    ]
+
+
+def test_classic_room_detail_surfaces_failed_command_recovery(tmp_path, monkeypatch):
+    from gateway import desktop_room_mailbox
+
+    home = tmp_path / "hermes"
+    _seed_classic_projection(home)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    db = desktop_room_mailbox.default_db_path()
+    desktop_room_mailbox.enqueue_command(
+        db,
+        command_id="messaging:failed",
+        room_id="classic-room",
+        action="send",
+        payload={"message": "hello"},
+    )
+    claimed = desktop_room_mailbox.claim_commands(
+        db,
+        consumer_id="desktop:test",
+        room_ids=["classic-room"],
+    )[0]
+    desktop_room_mailbox.complete_command(
+        db,
+        consumer_id="desktop:test",
+        command_id="messaging:failed",
+        lease_token=claimed["lease_token"],
+        success=False,
+        result={"message": "route missing"},
+    )
+    service = _FakeService(tmp_path / "state.db")
+    room = list_messaging_rooms(service)[0]
+
+    detail = format_room_detail(service, room)
+
+    assert "Desktop planning — needs attention" in detail
+    assert "The latest command could not be applied." in detail
 
 
 @pytest.mark.parametrize(
@@ -340,7 +552,7 @@ def test_room_resolution_explains_ambiguity_and_missing_names(tmp_path):
     rooms = hosted_rooms.list_rooms(db)
     with pytest.raises(RoomControlError, match="matches several group chats"):
         resolve_room(rooms, "release")
-    with pytest.raises(RoomControlError, match="No Group Chat"):
+    with pytest.raises(RoomControlError, match="No group chat"):
         resolve_room(rooms, "missing")
 
 

--- a/tests/gateway/test_hosted_rooms.py
+++ b/tests/gateway/test_hosted_rooms.py
@@ -1,0 +1,640 @@
+"""Behavior tests for the gateway-hosted room event log."""
+
+from __future__ import annotations
+
+import sqlite3
+from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
+
+import pytest
+
+from gateway import hosted_rooms as rooms
+from hermes_state import SessionDB
+
+USER = {"kind": "user", "id": "desktop-user", "display_name": "User"}
+GATEWAY_A = {"kind": "gateway", "id": "gateway-a"}
+GATEWAY_B = {"kind": "gateway", "id": "gateway-b"}
+
+
+def _create_pre_actor_database(path) -> None:
+    conn = sqlite3.connect(path)
+    try:
+        conn.execute(
+            """CREATE TABLE hosted_rooms (
+                room_id TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                members_json TEXT NOT NULL,
+                next_seq INTEGER NOT NULL,
+                revision INTEGER NOT NULL,
+                created_at REAL NOT NULL,
+                updated_at REAL NOT NULL,
+                disbanded_at REAL
+            )"""
+        )
+        conn.execute(
+            """CREATE TABLE hosted_room_events (
+                room_id TEXT NOT NULL,
+                seq INTEGER NOT NULL,
+                event_id TEXT NOT NULL,
+                kind TEXT NOT NULL,
+                payload_json TEXT NOT NULL,
+                created_at REAL NOT NULL,
+                PRIMARY KEY (room_id, seq),
+                UNIQUE (room_id, event_id)
+            )"""
+        )
+        conn.execute(
+            """INSERT INTO hosted_rooms
+               VALUES ('room-1', 'Legacy', '[]', 2, 1, 1, 1, NULL)"""
+        )
+        conn.execute(
+            """INSERT INTO hosted_room_events
+               VALUES ('room-1', 1, 'legacy-event', 'message.created', '{}', 1)"""
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _read_legacy_state(path: str) -> tuple[str, int]:
+    state = rooms.room_state(path, room_id="room-1")
+    return state["authority_gateway_id"], state["latest_seq"]
+
+
+def _create(db, room_id="room-1"):
+    return rooms.create_room(
+        db,
+        room_id=room_id,
+        name="Release room",
+        members=[{"profile": "ops", "handle": "ops"}],
+        authority_gateway_id="gateway-a",
+        now=10,
+    )
+
+
+def test_create_room_is_idempotent_but_conflicts_fail_closed(tmp_path):
+    db = tmp_path / "state.db"
+    first = _create(db)
+    second = _create(db)
+
+    assert first["idempotent"] is False
+    assert second["idempotent"] is True
+    assert first["room_id"] == second["room_id"] == "room-1"
+
+    with pytest.raises(rooms.RoomConflictError):
+        rooms.create_room(
+            db,
+            room_id="room-1",
+            name="A different room",
+            members=[],
+            authority_gateway_id="gateway-a",
+        )
+
+
+def test_room_state_exposes_authority_and_replay_cursor(tmp_path):
+    db = tmp_path / "state.db"
+    room = _create(db)
+
+    assert room["authority_gateway_id"] == "gateway-a"
+    assert room["authority_epoch"] == 1
+    assert rooms.room_state(db, room_id="room-1") == {
+        **room,
+        "latest_seq": 0,
+    }
+
+
+def test_authority_claim_fences_stale_gateway_events(tmp_path):
+    db = tmp_path / "state.db"
+    _create(db)
+
+    first = rooms.append_event(
+        db,
+        room_id="room-1",
+        event_id="turn-1",
+        kind="turn.started",
+        actor=GATEWAY_A,
+        authority_gateway_id="gateway-a",
+        authority_epoch=1,
+        payload={"member": "ops"},
+    )
+    claimed = rooms.claim_authority(
+        db,
+        room_id="room-1",
+        expected_gateway_id="gateway-a",
+        expected_epoch=1,
+        new_gateway_id="gateway-b",
+        event_id="claim-gateway-b",
+        now=30,
+    )
+    retried = rooms.claim_authority(
+        db,
+        room_id="room-1",
+        expected_gateway_id="gateway-a",
+        expected_epoch=1,
+        new_gateway_id="gateway-b",
+        event_id="claim-gateway-b",
+        now=40,
+    )
+
+    assert claimed["authority_gateway_id"] == "gateway-b"
+    assert claimed["authority_epoch"] == 2
+    assert claimed["idempotent"] is False
+    assert claimed["claim_event"]["kind"] == "authority.claimed"
+    assert claimed["claim_event"]["authority_epoch"] == 2
+    assert claimed["claim_event"]["payload"] == {
+        "previous_gateway_id": "gateway-a",
+        "authority_gateway_id": "gateway-b",
+        "authority_epoch": 2,
+    }
+    assert retried["authority_epoch"] == 2
+    assert retried["idempotent"] is True
+    assert retried["claim_event"]["seq"] == claimed["claim_event"]["seq"]
+    assert retried["claim_event"]["idempotent"] is True
+    state = rooms.room_state(db, room_id="room-1")
+    assert state["authority_claim"]["event_id"] == "claim-gateway-b"
+    assert state["authority_claim"]["payload"]["previous_gateway_id"] == "gateway-a"
+
+    # An exact retry admitted before takeover stays idempotent and cannot
+    # produce a second side effect, even though its epoch is now stale.
+    repeated = rooms.append_event(
+        db,
+        room_id="room-1",
+        event_id="turn-1",
+        kind="turn.started",
+        actor=GATEWAY_A,
+        authority_gateway_id="gateway-a",
+        authority_epoch=1,
+        payload={"member": "ops"},
+    )
+    assert repeated["seq"] == first["seq"]
+    assert repeated["idempotent"] is True
+
+    with pytest.raises(rooms.AuthorityConflictError, match="stale"):
+        rooms.append_event(
+            db,
+            room_id="room-1",
+            event_id="turn-2-stale",
+            kind="turn.started",
+            actor=GATEWAY_A,
+            authority_gateway_id="gateway-a",
+            authority_epoch=1,
+            payload={"member": "ops"},
+        )
+
+    with pytest.raises(rooms.AuthorityConflictError, match="stale"):
+        rooms.append_event(
+            db,
+            room_id="room-1",
+            event_id="member-2-stale",
+            kind="message.member",
+            actor={"kind": "member", "id": "ops"},
+            authority_gateway_id="gateway-a",
+            authority_epoch=1,
+            payload={"text": "stale result"},
+        )
+
+    current = rooms.append_event(
+        db,
+        room_id="room-1",
+        event_id="turn-2-current",
+        kind="turn.started",
+        actor=GATEWAY_B,
+        authority_gateway_id="gateway-b",
+        authority_epoch=2,
+        payload={"member": "ops"},
+    )
+    assert current["authority_epoch"] == 2
+    current_member = rooms.append_event(
+        db,
+        room_id="room-1",
+        event_id="member-2-current",
+        kind="message.member",
+        actor={"kind": "member", "id": "ops"},
+        authority_gateway_id="gateway-b",
+        authority_epoch=2,
+        payload={"text": "current result"},
+    )
+    assert current_member["authority_epoch"] == 2
+
+
+def test_concurrent_authority_claim_has_one_winner(tmp_path):
+    db = tmp_path / "state.db"
+    _create(db)
+
+    def claim(gateway_id):
+        try:
+            return rooms.claim_authority(
+                db,
+                room_id="room-1",
+                expected_gateway_id="gateway-a",
+                expected_epoch=1,
+                new_gateway_id=gateway_id,
+                event_id=f"claim-{gateway_id}",
+            )
+        except rooms.AuthorityConflictError:
+            return None
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(claim, ["gateway-b", "gateway-c"]))
+
+    winners = [result for result in results if result is not None]
+    assert len(winners) == 1
+    assert winners[0]["authority_epoch"] == 2
+    assert rooms.room_state(db, room_id="room-1")["authority_gateway_id"] in {
+        "gateway-b",
+        "gateway-c",
+    }
+
+
+def test_retry_of_successful_but_superseded_claim_is_distinct(tmp_path):
+    db = tmp_path / "state.db"
+    _create(db)
+    rooms.claim_authority(
+        db,
+        room_id="room-1",
+        expected_gateway_id="gateway-a",
+        expected_epoch=1,
+        new_gateway_id="gateway-b",
+        event_id="claim-b",
+    )
+    rooms.claim_authority(
+        db,
+        room_id="room-1",
+        expected_gateway_id="gateway-b",
+        expected_epoch=2,
+        new_gateway_id="gateway-c",
+        event_id="claim-c",
+    )
+
+    with pytest.raises(rooms.AuthoritySupersededError, match="later superseded"):
+        rooms.claim_authority(
+            db,
+            room_id="room-1",
+            expected_gateway_id="gateway-a",
+            expected_epoch=1,
+            new_gateway_id="gateway-b",
+            event_id="claim-b",
+        )
+
+
+def test_authority_scoped_events_require_gateway_and_epoch(tmp_path):
+    db = tmp_path / "state.db"
+    _create(db)
+
+    with pytest.raises(rooms.HostedRoomError, match="authority_gateway_id"):
+        rooms.append_event(
+            db,
+            room_id="room-1",
+            event_id="turn-1",
+            kind="member.unavailable",
+            actor=GATEWAY_A,
+            payload={"member": "ops"},
+        )
+
+    with pytest.raises(rooms.HostedRoomError, match="actor.id"):
+        rooms.append_event(
+            db,
+            room_id="room-1",
+            event_id="turn-2",
+            kind="turn.started",
+            actor=GATEWAY_B,
+            authority_gateway_id="gateway-a",
+            authority_epoch=1,
+            payload={"member": "ops"},
+        )
+
+    with pytest.raises(rooms.HostedRoomError, match="only valid"):
+        rooms.append_event(
+            db,
+            room_id="room-1",
+            event_id="message-1",
+            kind="message.user",
+            actor=USER,
+            authority_gateway_id="gateway-a",
+            authority_epoch=1,
+            payload={"text": "hello"},
+        )
+
+
+def test_append_is_idempotent_and_conflicting_event_id_is_rejected(tmp_path):
+    db = tmp_path / "state.db"
+    _create(db)
+
+    first = rooms.append_event(
+        db,
+        room_id="room-1",
+        event_id="event-1",
+        kind="message.user",
+        actor=USER,
+        payload={"text": "hello"},
+        now=20,
+    )
+    repeated = rooms.append_event(
+        db,
+        room_id="room-1",
+        event_id="event-1",
+        kind="message.user",
+        actor=USER,
+        payload={"text": "hello"},
+        now=30,
+    )
+
+    assert first["seq"] == repeated["seq"] == 1
+    assert repeated["idempotent"] is True
+    assert rooms.read_events(db, room_id="room-1")["latest_seq"] == 1
+
+    with pytest.raises(rooms.EventConflictError):
+        rooms.append_event(
+            db,
+            room_id="room-1",
+            event_id="event-1",
+            kind="message.user",
+            actor=USER,
+            payload={"text": "changed"},
+        )
+
+
+def test_since_seq_returns_ordered_deltas_and_stable_cursor(tmp_path):
+    db = tmp_path / "state.db"
+    _create(db)
+    for index in range(1, 5):
+        rooms.append_event(
+            db,
+            room_id="room-1",
+            event_id=f"event-{index}",
+            kind="message.user",
+            actor=USER,
+            payload={"index": index},
+            now=20 + index,
+        )
+
+    first = rooms.read_events(db, room_id="room-1", since_seq=0, limit=2)
+    assert [event["seq"] for event in first["events"]] == [1, 2]
+    assert first == {
+        "events": first["events"],
+        "cursor": 2,
+        "latest_seq": 4,
+        "has_more": True,
+    }
+
+    second = rooms.read_events(
+        db,
+        room_id="room-1",
+        since_seq=first["cursor"],
+        limit=2,
+    )
+    assert [event["seq"] for event in second["events"]] == [3, 4]
+    assert second["cursor"] == 4
+    assert second["has_more"] is False
+
+    settled = rooms.read_events(db, room_id="room-1", since_seq=4)
+    assert settled["events"] == []
+    assert settled["cursor"] == settled["latest_seq"] == 4
+
+
+def test_room_log_survives_store_reopen(tmp_path):
+    db = tmp_path / "state.db"
+    _create(db)
+    rooms.append_event(
+        db,
+        room_id="room-1",
+        event_id="event-1",
+        kind="message.user",
+        actor=USER,
+        payload={"text": "persist me"},
+    )
+
+    assert rooms.list_rooms(db)[0]["name"] == "Release room"
+    replay = rooms.read_events(db, room_id="room-1")
+    assert replay["events"][0]["payload"] == {"text": "persist me"}
+
+
+@pytest.mark.parametrize("session_first", [True, False])
+def test_room_tables_coexist_with_session_db_schema(tmp_path, session_first):
+    db = tmp_path / "state.db"
+    if session_first:
+        SessionDB(db_path=db).close()
+
+    _create(db)
+    rooms.append_event(
+        db,
+        room_id="room-1",
+        event_id="event-1",
+        kind="message.user",
+        actor=USER,
+        payload={"text": "shared database"},
+    )
+
+    SessionDB(db_path=db).close()
+    replay = rooms.read_events(db, room_id="room-1")
+    assert replay["latest_seq"] == 1
+    assert replay["events"][0]["payload"]["text"] == "shared database"
+
+
+def test_concurrent_appends_allocate_one_monotonic_sequence(tmp_path):
+    db = tmp_path / "state.db"
+    _create(db)
+
+    def append(index):
+        return rooms.append_event(
+            db,
+            room_id="room-1",
+            event_id=f"event-{index}",
+            kind="message.user",
+            actor=USER,
+            payload={"index": index},
+        )
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        results = list(pool.map(append, range(24)))
+
+    assert sorted(result["seq"] for result in results) == list(range(1, 25))
+    replay = rooms.read_events(db, room_id="room-1", limit=100)
+    assert [event["seq"] for event in replay["events"]] == list(range(1, 25))
+
+
+def test_rolled_back_append_does_not_consume_sequence(tmp_path):
+    db = tmp_path / "state.db"
+    _create(db)
+
+    conn = sqlite3.connect(db)
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        conn.execute(
+            """INSERT INTO hosted_room_events
+               (room_id, seq, event_id, kind, actor_json, payload_json, created_at)
+               VALUES ('room-1', 1, 'crash-event', 'message.user',
+                       '{"id":"desktop-user","kind":"user"}', '{}', 20)"""
+        )
+        conn.execute("UPDATE hosted_rooms SET next_seq=2 WHERE room_id='room-1'")
+        conn.rollback()
+    finally:
+        conn.close()
+
+    event = rooms.append_event(
+        db,
+        room_id="room-1",
+        event_id="after-restart",
+        kind="message.user",
+        actor=USER,
+        payload={"text": "safe"},
+    )
+    assert event["seq"] == 1
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"room_id": "../escape"}, "invalid room_id"),
+        ({"event_id": "event id"}, "invalid event_id"),
+        ({"kind": "Message Created"}, "invalid event kind"),
+        ({"kind": "directive.run"}, "cannot append"),
+        ({"actor": {"kind": "member", "id": "ops"}}, "cannot append"),
+        ({"payload": []}, "payload must be an object"),
+    ],
+)
+def test_invalid_event_contract_is_rejected(tmp_path, kwargs, message):
+    db = tmp_path / "state.db"
+    _create(db)
+    params = {
+        "room_id": "room-1",
+        "event_id": "event-1",
+        "kind": "message.user",
+        "actor": USER,
+        "payload": {},
+    }
+    params.update(kwargs)
+
+    with pytest.raises(rooms.HostedRoomError, match=message):
+        rooms.append_event(db, **params)
+
+
+def test_unknown_room_and_invalid_cursor_fail_closed(tmp_path):
+    db = tmp_path / "state.db"
+    _create(db)
+
+    with pytest.raises(rooms.RoomNotFoundError):
+        rooms.read_events(db, room_id="missing")
+    with pytest.raises(rooms.HostedRoomError, match="since_seq"):
+        rooms.read_events(db, room_id="room-1", since_seq=-1)
+    with pytest.raises(rooms.HostedRoomError, match="ahead"):
+        rooms.read_events(db, room_id="room-1", since_seq=1)
+    with pytest.raises(rooms.HostedRoomError, match="limit"):
+        rooms.read_events(db, room_id="room-1", limit=0)
+
+
+def test_actor_is_part_of_event_idempotency_and_replay(tmp_path):
+    db = tmp_path / "state.db"
+    _create(db)
+    event = rooms.append_event(
+        db,
+        room_id="room-1",
+        event_id="event-1",
+        kind="message.user",
+        actor=USER,
+        payload={"text": "hello"},
+    )
+
+    assert event["actor"] == USER
+    assert rooms.read_events(db, room_id="room-1")["events"][0]["actor"] == USER
+
+    with pytest.raises(rooms.EventConflictError):
+        rooms.append_event(
+            db,
+            room_id="room-1",
+            event_id="event-1",
+            kind="message.user",
+            actor={"kind": "user", "id": "another-user"},
+            payload={"text": "hello"},
+        )
+
+
+def test_disband_is_idempotent_and_room_id_cannot_be_reused(tmp_path):
+    db = tmp_path / "state.db"
+    _create(db)
+
+    first = rooms.disband_room(db, room_id="room-1", now=50)
+    repeated = rooms.disband_room(db, room_id="room-1", now=60)
+
+    assert first["room_id"] == "room-1"
+    assert first["disbanded_at"] == 50.0
+    assert first["idempotent"] is False
+    assert first["event"]["kind"] == "room.disbanded"
+    assert first["event"]["seq"] == 1
+    assert first["event"]["payload"] == {"room_id": "room-1"}
+    assert repeated["idempotent"] is True
+    assert repeated["event"]["seq"] == first["event"]["seq"]
+    assert rooms.list_rooms(db) == []
+    deleted = rooms.list_rooms(db, include_disbanded=True)
+    assert deleted[0]["disbanded_at"] == 50.0
+    assert deleted[0]["latest_seq"] == 1
+    state = rooms.room_state(db, room_id="room-1", include_disbanded=True)
+    assert state["disbanded_at"] == 50.0
+    assert state["latest_seq"] == 1
+    replay = rooms.read_events(db, room_id="room-1", include_disbanded=True)
+    assert [event["kind"] for event in replay["events"]] == ["room.disbanded"]
+    with pytest.raises(rooms.RoomConflictError):
+        _create(db)
+    with pytest.raises(rooms.RoomNotFoundError):
+        rooms.read_events(db, room_id="room-1")
+
+
+def test_pre_actor_draft_database_migrates_with_explicit_legacy_identity(tmp_path):
+    db = tmp_path / "state.db"
+    _create_pre_actor_database(db)
+
+    replay = rooms.read_events(db, room_id="room-1")
+    assert replay["events"][0]["actor"] == {"kind": "system", "id": "legacy"}
+    state = rooms.room_state(db, room_id="room-1")
+    assert state["authority_gateway_id"] == "legacy"
+    assert state["authority_epoch"] == 1
+    adopted = rooms.create_room(
+        db,
+        room_id="room-1",
+        name="Legacy",
+        members=[],
+        authority_gateway_id="gateway-a",
+        now=2,
+    )
+    assert adopted["authority_gateway_id"] == "gateway-a"
+    assert adopted["authority_epoch"] == 2
+    assert adopted["adopted"] is True
+    assert adopted["claim_event"]["seq"] == 2
+    assert adopted["claim_event"]["payload"]["previous_gateway_id"] == "legacy"
+
+
+def test_draft_schema_migration_is_safe_across_processes(tmp_path):
+    db = tmp_path / "state.db"
+    _create_pre_actor_database(db)
+
+    with ProcessPoolExecutor(max_workers=4) as pool:
+        results = list(pool.map(_read_legacy_state, [str(db)] * 4))
+
+    assert results == [("legacy", 1)] * 4
+    replay = rooms.read_events(db, room_id="room-1")
+    assert replay["events"][0]["actor"] == {"kind": "system", "id": "legacy"}
+
+
+def test_interrupted_draft_schema_migration_rolls_back_atomically(
+    tmp_path,
+    monkeypatch,
+):
+    db = tmp_path / "state.db"
+    _create_pre_actor_database(db)
+    original = rooms._initialize_schema
+
+    def interrupt_after_first_alter(conn):
+        conn.execute(
+            "ALTER TABLE hosted_rooms "
+            "ADD COLUMN authority_gateway_id TEXT NOT NULL DEFAULT 'legacy'"
+        )
+        raise RuntimeError("simulated migration interruption")
+
+    monkeypatch.setattr(rooms, "_initialize_schema", interrupt_after_first_alter)
+    with pytest.raises(RuntimeError, match="simulated migration interruption"):
+        rooms.list_rooms(db)
+    with sqlite3.connect(db) as conn:
+        columns = {row[1] for row in conn.execute("PRAGMA table_info(hosted_rooms)")}
+    assert "authority_gateway_id" not in columns
+
+    monkeypatch.setattr(rooms, "_initialize_schema", original)
+    assert rooms.room_state(db, room_id="room-1")["authority_gateway_id"] == "legacy"

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -535,10 +535,10 @@ class TestMatrixBangCommandAlias:
         from gateway.hosted_room_messaging import messaging_event_id
 
         captured_event = await self._dispatch_text(
-            "!rooms send release-room -- hello"
+            "!group 1 send hello"
         )
         assert captured_event is not None
-        assert captured_event.text == "/rooms send release-room -- hello"
+        assert captured_event.text == "/group 1 send hello"
         assert messaging_event_id(captured_event) == messaging_event_id(captured_event)
 
 

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -530,6 +530,17 @@ class TestMatrixBangCommandAlias:
         )
         assert _normalize_matrix_bang_command("!tasks") == "/tasks"
 
+    @pytest.mark.asyncio
+    async def test_room_control_normalizes_and_keeps_matrix_event_id(self):
+        from gateway.hosted_room_messaging import messaging_event_id
+
+        captured_event = await self._dispatch_text(
+            "!rooms send release-room -- hello"
+        )
+        assert captured_event is not None
+        assert captured_event.text == "/rooms send release-room -- hello"
+        assert messaging_event_id(captured_event) == messaging_event_id(captured_event)
+
 
     @pytest.mark.asyncio
     async def test_unknown_bang_text_stays_normal_text(self):

--- a/tests/gateway/test_signal.py
+++ b/tests/gateway/test_signal.py
@@ -994,6 +994,9 @@ class TestSignalQuoteExtraction:
         assert event.reply_to_text == "want to grab lunch?"
         assert event.reply_to_author_id == "other-author"
         assert event.reply_to_is_own_message is False
+        from gateway.hosted_room_messaging import messaging_event_id
+
+        assert messaging_event_id(event) == messaging_event_id(event)
 
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -242,6 +242,30 @@ class TestBotEventDiagnostics:
             for line in debug_lines
         ), debug_lines
 
+    @pytest.mark.asyncio
+    async def test_users_info_bot_classification_reaches_session_source(self, adapter):
+        adapter.config.extra["allow_bots"] = "all"
+        adapter._app.client.users_info = AsyncMock(
+            return_value={
+                "user": {
+                    "is_bot": True,
+                    "profile": {"display_name": "Peer Bot"},
+                    "real_name": "Peer Bot",
+                }
+            }
+        )
+        event = {
+            "type": "message",
+            "user": "U_PEER_BOT",
+            "channel": "D_SHARED",
+            "channel_type": "im",
+            "text": "hello from a peer bot",
+            "ts": "1770000000.000001",
+        }
+        await adapter._handle_slack_message(event)
+        delivered = adapter.handle_message.await_args.args[0]
+        assert delivered.source.is_bot is True
+
 
 # ---------------------------------------------------------------------------
 # TestSlashCommandSessionIsolation
@@ -3475,6 +3499,23 @@ class TestSlashCommands:
         await adapter._handle_slash_command(command)
         msg = adapter.handle_message.call_args[0][0]
         assert msg.text == "/btw run the tests"
+
+    @pytest.mark.asyncio
+    async def test_room_control_keeps_slack_trigger_for_idempotency(self, adapter):
+        from gateway.hosted_room_messaging import messaging_event_id
+
+        command = {
+            "command": "/hermes",
+            "text": "rooms send release-room -- hello",
+            "trigger_id": "trigger-room-1",
+            "user_id": "U1",
+            "channel_id": "C1",
+            "team_id": "T1",
+        }
+        await adapter._handle_slash_command(command)
+        event = adapter.handle_message.call_args[0][0]
+        assert event.text == "/rooms send release-room -- hello"
+        assert messaging_event_id(event) == messaging_event_id(event)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -3506,7 +3506,7 @@ class TestSlashCommands:
 
         command = {
             "command": "/hermes",
-            "text": "rooms send release-room -- hello",
+            "text": "group 1 send hello",
             "trigger_id": "trigger-room-1",
             "user_id": "U1",
             "channel_id": "C1",
@@ -3514,7 +3514,7 @@ class TestSlashCommands:
         }
         await adapter._handle_slash_command(command)
         event = adapter.handle_message.call_args[0][0]
-        assert event.text == "/rooms send release-room -- hello"
+        assert event.text == "/group 1 send hello"
         assert messaging_event_id(event) == messaging_event_id(event)
 
 

--- a/tests/gateway/test_slash_access.py
+++ b/tests/gateway/test_slash_access.py
@@ -5,9 +5,10 @@ exercise the dispatch site live in test_slash_access_dispatch.py.
 """
 from __future__ import annotations
 
-from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.config import GatewayConfig, HomeChannel, Platform, PlatformConfig
 from gateway.session import SessionSource
 from gateway.slash_access import (
+    is_home_dm_source,
     policy_for_source,
     policy_from_extra,
 )
@@ -126,3 +127,75 @@ class TestPolicyForSource:
         assert grp_p.enabled is True
         assert grp_p.can_run("999", "stop") is False  # gated
 
+
+class TestHomeDmSource:
+    def _config(self, *, user_id=None, scope_id=None):
+        return GatewayConfig(
+            platforms={
+                Platform.TELEGRAM: PlatformConfig(
+                    enabled=True,
+                    home_channel=HomeChannel(
+                        platform=Platform.TELEGRAM,
+                        chat_id="home-chat",
+                        name="Home",
+                        user_id=user_id,
+                        scope_id=scope_id,
+                    ),
+                )
+            }
+        )
+
+    def test_legacy_home_dm_matches_authenticated_sender(self):
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="home-chat",
+            chat_type="dm",
+            user_id="owner",
+        )
+        assert is_home_dm_source(self._config(), source) is True
+
+    def test_home_group_never_inherits_owner_controls(self):
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="home-chat",
+            chat_type="group",
+            user_id="owner",
+        )
+        assert is_home_dm_source(self._config(), source) is False
+
+    def test_stored_identity_and_scope_must_match(self):
+        config = self._config(user_id="owner", scope_id="tenant-a")
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="home-chat",
+            chat_type="dm",
+            user_id="other",
+            scope_id="tenant-a",
+        )
+        assert is_home_dm_source(config, source) is False
+        wrong_scope = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="home-chat",
+            chat_type="dm",
+            user_id="owner",
+            scope_id="tenant-b",
+        )
+        assert is_home_dm_source(config, wrong_scope) is False
+
+    def test_bot_and_other_dm_do_not_match(self):
+        config = self._config()
+        bot = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="home-chat",
+            chat_type="dm",
+            user_id="owner",
+            is_bot=True,
+        )
+        other = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="other-chat",
+            chat_type="dm",
+            user_id="owner",
+        )
+        assert is_home_dm_source(config, bot) is False
+        assert is_home_dm_source(config, other) is False

--- a/tests/hermes_cli/test_install_identity.py
+++ b/tests/hermes_cli/test_install_identity.py
@@ -1,0 +1,112 @@
+from concurrent.futures import ThreadPoolExecutor
+import multiprocessing
+from pathlib import Path
+import time
+
+from gateway.hosted_rooms import local_authority_gateway_id
+import hermes_cli.install_identity as install_identity
+from hermes_cli.install_identity import read_or_create_install_id
+
+
+def _race_first_install_id(
+    root_value,
+    minted,
+    results,
+    start_barrier=None,
+    writer_entered=None,
+    release_writer=None,
+):
+    root = Path(root_value)
+    install_identity.uuid.uuid4 = lambda: type("FixedUuid", (), {"hex": minted})()
+    if start_barrier is not None:
+        start_barrier.wait(timeout=10)
+    if writer_entered is not None:
+        original_mkstemp = install_identity.tempfile.mkstemp
+
+        def held_mkstemp(*args, **kwargs):
+            writer_entered.set()
+            assert release_writer.wait(timeout=10)
+            return original_mkstemp(*args, **kwargs)
+
+        install_identity.tempfile.mkstemp = held_mkstemp
+    results.put(read_or_create_install_id(root))
+
+
+def test_concurrent_first_use_returns_one_persisted_identity(tmp_path):
+    with ThreadPoolExecutor(max_workers=16) as executor:
+        values = list(executor.map(lambda _: read_or_create_install_id(tmp_path), range(64)))
+
+    assert len(set(values)) == 1
+    assert values[0]
+    assert (tmp_path / "install_id").read_text(encoding="utf-8").strip() == values[0]
+
+
+def test_independent_first_callers_return_the_single_committed_identity(tmp_path, monkeypatch):
+    context = multiprocessing.get_context("spawn")
+    results = context.Queue()
+    writer_entered = context.Event()
+    release_writer = context.Event()
+    winner = context.Process(
+        target=_race_first_install_id,
+        args=(
+            str(tmp_path),
+            "a" * 32,
+            results,
+            None,
+            writer_entered,
+            release_writer,
+        ),
+    )
+    loser = context.Process(
+        target=_race_first_install_id,
+        args=(str(tmp_path), "b" * 32, results),
+    )
+
+    winner.start()
+    assert writer_entered.wait(timeout=10)
+    loser.start()
+    time.sleep(0.25)
+    assert loser.is_alive()
+    release_writer.set()
+    processes = [winner, loser]
+    for process in processes:
+        process.join(timeout=15)
+        assert process.exitcode == 0
+
+    returned = [results.get(timeout=2) for _ in processes]
+    persisted = (tmp_path / "install_id").read_text(encoding="utf-8").strip()
+
+    assert returned == [persisted, persisted]
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        install_identity,
+        "_INSTALL_ID_CACHE",
+        {"root": None, "value": None},
+    )
+    assert local_authority_gateway_id() == f"install:{persisted}"
+
+
+def test_concurrent_corrupt_file_repair_returns_one_committed_identity(tmp_path):
+    (tmp_path / "install_id").write_text("corrupt\n", encoding="utf-8")
+    context = multiprocessing.get_context("spawn")
+    barrier = context.Barrier(2)
+    results = context.Queue()
+    processes = [
+        context.Process(
+            target=_race_first_install_id,
+            args=(str(tmp_path), value, results, barrier),
+        )
+        for value in ("a" * 32, "b" * 32)
+    ]
+
+    for process in processes:
+        process.start()
+    for process in processes:
+        process.join(timeout=15)
+        assert process.exitcode == 0
+
+    returned = [results.get(timeout=2) for _ in processes]
+    persisted = (tmp_path / "install_id").read_text(encoding="utf-8").strip()
+
+    assert returned == [persisted, persisted]

--- a/tests/tui_gateway/test_auto_continue.py
+++ b/tests/tui_gateway/test_auto_continue.py
@@ -169,6 +169,60 @@ def test_handled_failure_still_clears_marker(emits, turn_env, marker_home):
     assert read_turn_marker(marker_home, "session-key") is None
 
 
+def test_hosted_terminal_receipt_commits_before_marker_retire(
+    emits, turn_env, marker_home
+):
+    observed = []
+
+    def _run(message, **kwargs):
+        return {"final_response": "done"}
+
+    def _terminal(receipt):
+        observed.append((receipt, read_turn_marker(marker_home, "session-key")))
+
+    agent = types.SimpleNamespace(
+        session_id="session-key", run_conversation=_run, clear_interrupt=lambda: None
+    )
+    session = _session(agent=agent, running=True, source="bot_room")
+
+    server._run_prompt_submit(
+        "rid",
+        "sid",
+        session,
+        "do the thing",
+        terminal_callback=_terminal,
+    )
+
+    assert observed[0][0]["status"] == "settled"
+    assert observed[0][1] is not None
+    assert read_turn_marker(marker_home, "session-key") is None
+
+
+def test_hosted_terminal_receipt_failure_keeps_crash_marker(
+    emits, turn_env, marker_home
+):
+    def _run(message, **kwargs):
+        return {"final_response": "done"}
+
+    def _terminal(_receipt):
+        raise RuntimeError("state store unavailable")
+
+    agent = types.SimpleNamespace(
+        session_id="session-key", run_conversation=_run, clear_interrupt=lambda: None
+    )
+    session = _session(agent=agent, running=True, source="bot_room")
+
+    server._run_prompt_submit(
+        "rid",
+        "sid",
+        session,
+        "do the thing",
+        terminal_callback=_terminal,
+    )
+
+    assert read_turn_marker(marker_home, "session-key") is not None
+
+
 def test_continuation_turn_records_attempt_and_original_prompt(
     emits, turn_env, marker_home
 ):
@@ -261,6 +315,20 @@ def test_fresh_marker_schedules_continuation(emits, schedule_env, marker_home):
     assert "fix the flaky test" in text
     assert kwargs["display_kind"] == "auto_continue"
     assert ("message.start", "sid", None) in [(e, s, p) for e, s, p in emits]
+
+
+def test_hosted_room_marker_is_left_to_the_driver(schedule_env, marker_home):
+    record_turn_start(marker_home, "session-key", "hosted prompt")
+
+    result = server._maybe_schedule_auto_continue(
+        "sid",
+        _session(source="bot_room"),
+        "session-key",
+    )
+
+    assert result is None
+    assert not schedule_env
+    assert read_turn_marker(marker_home, "session-key") is not None
 
 
 def test_stale_marker_is_cleared_not_continued(schedule_env, marker_home, monkeypatch):
@@ -372,5 +440,4 @@ def test_failed_agent_build_leaves_marker_for_retry(
 
 
 # ── End to end: continuation runs a real turn and clears the marker ────
-
 

--- a/tests/tui_gateway/test_change_watcher.py
+++ b/tests/tui_gateway/test_change_watcher.py
@@ -240,6 +240,17 @@ def test_new_envelope_after_drain_fires_pending_again(watcher_home):
     ]
 
 
+def test_desktop_room_command_signal_broadcasts_pending(watcher_home):
+    home, events = watcher_home
+    signal = home / "desktop_room_mailbox.pending"
+    server._broadcast_watched_changes(now=0.0)
+
+    signal.write_text("1")
+    server._broadcast_watched_changes(now=10.0)
+
+    assert ("desktop_rooms.commands.pending", {}) in events
+
+
 def test_no_outbox_dir_never_fires_pending(watcher_home):
     home, events = watcher_home
     server._broadcast_watched_changes(now=0.0)

--- a/tests/tui_gateway/test_groups_methods.py
+++ b/tests/tui_gateway/test_groups_methods.py
@@ -1,0 +1,238 @@
+"""Tests for the gateway-hosted ``groups.*`` JSON-RPC contract."""
+
+from __future__ import annotations
+
+import pytest
+
+import tui_gateway.server as srv
+
+
+@pytest.fixture
+def home(tmp_path, monkeypatch):
+    path = tmp_path / ".hermes"
+    path.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(path))
+    return path
+
+
+def _result(envelope):
+    assert "error" not in envelope, envelope
+    return envelope["result"]
+
+
+def _server_authority():
+    from gateway.hosted_rooms import local_authority_gateway_id
+
+    return local_authority_gateway_id()
+
+
+def _create_room():
+    return _result(
+        srv._methods["groups.create"](
+            1,
+            {
+                "room_id": "room-1",
+                "name": "Release room",
+                "members": [{"profile": "ops", "handle": "ops"}],
+                "authority_gateway_id": "gateway-a",
+            },
+        )
+    )["room"]
+
+
+def test_capabilities_are_honest_about_the_driver_boundary(home):
+    result = _result(srv._methods["groups.capabilities"](1, {}))
+
+    assert result["protocol_version"] == 2
+    assert result["driver"] is False
+    assert result["authority_gateway_id"] == _server_authority()
+    assert "authority_epoch" in result["features"]
+    assert "coordinator_fencing" in result["features"]
+    assert "monotonic_log" in result["features"]
+    assert "groups.state" in result["methods"]
+    assert "groups.send" in result["methods"]
+
+
+def test_create_list_send_and_log_roundtrip(home):
+    room = _create_room()
+    assert room["idempotent"] is False
+
+    listed = _result(srv._methods["groups.list"](2, {}))
+    assert [item["room_id"] for item in listed["rooms"]] == ["room-1"]
+    state = _result(srv._methods["groups.state"](3, {"room_id": "room-1"}))
+    assert state["room"]["authority_gateway_id"] == _server_authority()
+    assert state["room"]["authority_epoch"] == 1
+    assert state["room"]["latest_seq"] == 0
+
+    sent = _result(
+        srv._methods["groups.send"](
+            4,
+            {
+                "room_id": "room-1",
+                "event_id": "event-1",
+                "actor": {"kind": "user", "id": "desktop-user"},
+                "payload": {"text": "hello"},
+            },
+        )
+    )
+    assert sent["accepted"] is True
+    assert sent["driver_started"] is False
+    assert sent["event"]["seq"] == 1
+    assert sent["event"]["kind"] == "message.user"
+    assert sent["event"]["actor"] == {"kind": "user", "id": "desktop"}
+
+    replay = _result(
+        srv._methods["groups.log"](
+            5,
+            {"room_id": "room-1", "since_seq": 0},
+        )
+    )
+    assert replay["latest_seq"] == replay["cursor"] == 1
+    assert replay["events"][0]["payload"] == {"text": "hello"}
+
+
+def test_rpc_retry_is_idempotent_and_conflict_is_visible(home):
+    _create_room()
+    params = {
+        "room_id": "room-1",
+        "event_id": "event-1",
+        "actor": {"kind": "user", "id": "desktop-user"},
+        "payload": {"text": "hello"},
+    }
+    first = _result(srv._methods["groups.send"](2, params))
+    repeated = _result(srv._methods["groups.send"](3, params))
+
+    assert first["event"]["seq"] == repeated["event"]["seq"] == 1
+    assert repeated["event"]["idempotent"] is True
+
+    conflict = srv._methods["groups.send"](
+        4,
+        {**params, "payload": {"text": "different"}},
+    )
+    assert conflict["error"]["code"] == 4111
+    assert "different content" in conflict["error"]["message"]
+
+
+def test_send_does_not_trust_client_supplied_actor_identity(home):
+    _create_room()
+    sent = _result(
+        srv._methods["groups.send"](
+            2,
+            {
+                "room_id": "room-1",
+                "event_id": "event-1",
+                "actor": {"kind": "user", "id": "spoofed-user"},
+                "payload": {"text": "hello"},
+            },
+        )
+    )
+
+    assert sent["event"]["actor"] == {"kind": "user", "id": "desktop"}
+
+
+def test_create_ignores_client_supplied_authority_identity(home):
+    created = _result(
+        srv._methods["groups.create"](
+            1,
+            {"room_id": "legacy-room", "name": "Legacy", "members": []},
+        )
+    )["room"]
+    retried = _result(
+        srv._methods["groups.create"](
+            2,
+            {
+                "room_id": "legacy-room",
+                "name": "Legacy",
+                "members": [],
+                "authority_gateway_id": "spoofed-gateway",
+            },
+        )
+    )["room"]
+
+    assert created["authority_gateway_id"] == _server_authority()
+    assert retried["authority_gateway_id"] == _server_authority()
+    assert retried["idempotent"] is True
+
+
+def test_legacy_room_adoption_emits_one_lineage_receipt(home):
+    from gateway.hosted_rooms import create_room, default_db_path
+
+    members = [{"profile": "ops", "handle": "ops"}]
+    create_room(
+        default_db_path(),
+        room_id="legacy-room",
+        name="Legacy",
+        members=members,
+        authority_gateway_id="legacy",
+        now=1,
+    )
+
+    adopted = _result(
+        srv._methods["groups.create"](
+            2,
+            {"room_id": "legacy-room", "name": "Legacy", "members": members},
+        )
+    )["room"]
+    state = _result(
+        srv._methods["groups.state"](3, {"room_id": "legacy-room"})
+    )["room"]
+
+    assert adopted["adopted"] is True
+    assert adopted["authority_gateway_id"] == _server_authority()
+    assert adopted["authority_epoch"] == 2
+    assert adopted["claim_event"]["payload"] == {
+        "previous_gateway_id": "legacy",
+        "authority_gateway_id": _server_authority(),
+        "authority_epoch": 2,
+    }
+    assert state["authority_claim"]["event_id"] == "system:authority-adopted"
+    assert state["latest_seq"] == 1
+
+
+@pytest.mark.parametrize(
+    ("method_name", "params"),
+    [
+        (
+            "groups.create",
+            {
+                "room_id": "",
+                "name": "x",
+                "members": [],
+                "authority_gateway_id": "gateway-a",
+            },
+        ),
+        (
+            "groups.send",
+            {
+                "room_id": "missing",
+                "event_id": "event-1",
+                "actor": {"kind": "user", "id": "desktop-user"},
+                "payload": {},
+            },
+        ),
+        ("groups.log", {"room_id": "missing", "since_seq": 0}),
+    ],
+)
+def test_invalid_or_unknown_room_returns_contract_error(home, method_name, params):
+    result = srv._methods[method_name](1, params)
+    assert result["error"]["code"] in {4110, 4111, 4112}
+
+
+def test_disband_tombstones_room(home):
+    _create_room()
+    first = _result(srv._methods["groups.disband"](3, {"room_id": "room-1"}))
+    repeated = _result(srv._methods["groups.disband"](4, {"room_id": "room-1"}))
+    assert first["tombstone"]["idempotent"] is False
+    assert repeated["tombstone"]["idempotent"] is True
+    assert _result(srv._methods["groups.list"](5, {}))["rooms"] == []
+    deleted = _result(
+        srv._methods["groups.list"](6, {"include_disbanded": True})
+    )["rooms"]
+    assert deleted[0]["disbanded_at"] == first["tombstone"]["disbanded_at"]
+    replay = _result(
+        srv._methods["groups.log"](
+            7,
+            {"room_id": "room-1", "include_disbanded": True},
+        )
+    )
+    assert [event["kind"] for event in replay["events"]] == ["room.disbanded"]

--- a/tests/tui_gateway/test_groups_methods.py
+++ b/tests/tui_gateway/test_groups_methods.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import base64
 
 import pytest
 
@@ -54,6 +55,9 @@ def test_capabilities_are_honest_about_the_driver_boundary(home):
     assert "monotonic_log" in result["features"]
     assert "groups.state" in result["methods"]
     assert "groups.send" in result["methods"]
+    assert "groups.attachment.put" in result["methods"]
+    assert "groups.attachment.read" in result["methods"]
+    assert "attachment_same_gateway_delivery" in result["features"]
     assert "groups.desktop.claim" in result["methods"]
     assert "groups.desktop.renew" in result["methods"]
     assert "groups.desktop.complete" in result["methods"]
@@ -149,7 +153,10 @@ def test_create_list_send_and_log_roundtrip(home):
         )
     )
     assert replay["latest_seq"] == replay["cursor"] == 1
-    assert replay["events"][0]["payload"] == {"text": "hello"}
+    assert replay["events"][0]["payload"] == {
+        "text": "hello",
+        "thread_id": "event-1",
+    }
 
 
 def test_rpc_retry_is_idempotent_and_conflict_is_visible(home):
@@ -172,6 +179,146 @@ def test_rpc_retry_is_idempotent_and_conflict_is_visible(home):
     )
     assert conflict["error"]["code"] == 4111
     assert "different content" in conflict["error"]["message"]
+
+
+def test_attachment_put_send_read_roundtrip_is_bounded_and_recipient_scoped(home):
+    _create_room()
+    encoded = base64.b64encode(b"\x89PNG\r\n\x1a\nimage").decode("ascii")
+    put_params = {
+        "room_id": "room-1",
+        "upload_id": "upload-1",
+        "kind": "image",
+        "name": "diagram.png",
+        "mime": "image/png",
+        "content_base64": encoded,
+    }
+    first = _result(srv._methods["groups.attachment.put"](1, put_params))["attachment"]
+    repeated = _result(srv._methods["groups.attachment.put"](2, put_params))["attachment"]
+    assert repeated["attachment_id"] == first["attachment_id"]
+    assert repeated["idempotent"] is True
+
+    before_send = srv._methods["groups.attachment.read"](
+        3,
+        {
+            "room_id": "room-1",
+            "attachment_id": first["attachment_id"],
+            "purpose": "viewer",
+        },
+    )
+    assert before_send["error"]["code"] == 4141
+
+    manifest = {
+        key: first[key]
+        for key in ("attachment_id", "kind", "name", "size", "mime")
+    }
+    sent = _result(
+        srv._methods["groups.send"](
+            4,
+            {
+                "room_id": "room-1",
+                "event_id": "event-attachment-1",
+                "payload": {
+                    "text": "",
+                    "thread_id": "thread-1",
+                    "attachments": [manifest],
+                },
+            },
+        )
+    )
+    assert sent["event"]["payload"]["attachments"] == [manifest]
+    assert "content_base64" not in sent["event"]["payload"]
+
+    hosted_read = srv._methods["groups.attachment.read"](
+        5,
+        {
+            "room_id": "room-1",
+            "attachment_id": first["attachment_id"],
+            "purpose": "viewer",
+            "event_id": "event-attachment-1",
+        },
+    )
+    assert base64.b64decode(_result(hosted_read)["content_base64"]) == b"\x89PNG\r\n\x1a\nimage"
+    denied = srv._methods["groups.attachment.read"](
+        6,
+        {
+            "room_id": "room-1",
+            "attachment_id": first["attachment_id"],
+            "purpose": "desktop-command",
+        },
+    )
+    assert denied["error"]["code"] == 4141
+
+
+def test_classic_attachment_read_requires_room_authority_and_live_command_lease(home):
+    from gateway import desktop_room_mailbox
+    from gateway.hosted_room_attachments import HostedRoomAttachmentStore
+    from gateway.hosted_rooms import default_db_path as hosted_db_path
+
+    db = desktop_room_mailbox.default_db_path()
+    store = HostedRoomAttachmentStore(hosted_db_path())
+    stored = store.put(
+        room_id="classic-room",
+        upload_id="upload-classic-1",
+        kind="file",
+        name="notes.txt",
+        mime="text/plain",
+        data=b"release notes",
+    )
+    manifest = {
+        key: stored[key]
+        for key in ("attachment_id", "kind", "name", "size", "mime")
+    }
+    store.commit_message(
+        room_id="classic-room",
+        event_id="messaging:classic-attachment",
+        manifest=[manifest],
+        recipient_member_ids=("desktop", "viewer"),
+    )
+    desktop_room_mailbox.enqueue_command(
+        db,
+        command_id="messaging:classic-attachment",
+        room_id="classic-room",
+        authority_hash=hashlib.sha256(b"authority:test").hexdigest(),
+        action="send",
+        payload={"message": "", "attachments": [manifest]},
+    )
+    command = desktop_room_mailbox.claim_commands(
+        db,
+        consumer_id="desktop:test",
+        room_authorities=[{
+            "room_id": "classic-room",
+            "authority_token": "authority:test",
+        }],
+    )[0]
+    params = {
+        "room_id": "classic-room",
+        "attachment_id": stored["attachment_id"],
+        "purpose": "desktop-command",
+        "event_id": "messaging:classic-attachment",
+        "consumer_id": "desktop:test",
+        "lease_token": command["lease_token"],
+        "authority_token": "authority:test",
+    }
+
+    denied = srv._methods["groups.attachment.read"](
+        1,
+        {**params, "authority_token": "authority:wrong"},
+    )
+    assert denied["error"]["code"] == 4141
+    read = _result(srv._methods["groups.attachment.read"](2, params))
+    assert base64.b64decode(read["content_base64"]) == b"release notes"
+    viewer = _result(
+        srv._methods["groups.attachment.read"](
+            3,
+            {
+                "room_id": "classic-room",
+                "attachment_id": stored["attachment_id"],
+                "event_id": "messaging:classic-attachment",
+                "purpose": "viewer",
+            },
+        )
+    )
+    assert base64.b64decode(viewer["content_base64"]) == b"release notes"
 
 
 def test_send_does_not_trust_client_supplied_actor_identity(home):

--- a/tests/tui_gateway/test_groups_methods.py
+++ b/tests/tui_gateway/test_groups_methods.py
@@ -48,9 +48,62 @@ def test_capabilities_are_honest_about_the_driver_boundary(home):
     assert result["authority_gateway_id"] == _server_authority()
     assert "authority_epoch" in result["features"]
     assert "coordinator_fencing" in result["features"]
+    assert "desktop_compatibility_mailbox" in result["features"]
     assert "monotonic_log" in result["features"]
     assert "groups.state" in result["methods"]
     assert "groups.send" in result["methods"]
+    assert "groups.desktop.claim" in result["methods"]
+    assert "groups.desktop.renew" in result["methods"]
+    assert "groups.desktop.complete" in result["methods"]
+
+
+def test_desktop_mailbox_rpc_claim_and_complete(home):
+    from gateway.desktop_room_mailbox import default_db_path, enqueue_command
+
+    enqueue_command(
+        default_db_path(),
+        command_id="messaging:one",
+        room_id="classic-room",
+        action="send",
+        payload={"message": "hello"},
+    )
+
+    claimed = _result(
+        srv._methods["groups.desktop.claim"](
+            1,
+            {
+                "consumer_id": "desktop:test",
+                "room_ids": ["classic-room"],
+            },
+        )
+    )["commands"]
+    assert [item["command_id"] for item in claimed] == ["messaging:one"]
+
+    renewed = _result(
+        srv._methods["groups.desktop.renew"](
+            2,
+            {
+                "consumer_id": "desktop:test",
+                "command_id": "messaging:one",
+                "lease_token": claimed[0]["lease_token"],
+            },
+        )
+    )["command"]
+    assert renewed["lease_token"] == claimed[0]["lease_token"]
+
+    completed = _result(
+        srv._methods["groups.desktop.complete"](
+            3,
+            {
+                "consumer_id": "desktop:test",
+                "command_id": "messaging:one",
+                "lease_token": claimed[0]["lease_token"],
+                "success": True,
+                "result": {"thread_id": "thread-1"},
+            },
+        )
+    )["command"]
+    assert completed["state"] == "completed"
 
 
 def test_create_list_send_and_log_roundtrip(home):

--- a/tests/tui_gateway/test_groups_methods.py
+++ b/tests/tui_gateway/test_groups_methods.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import hashlib
+
 import pytest
 
 import tui_gateway.server as srv
@@ -64,6 +66,7 @@ def test_desktop_mailbox_rpc_claim_and_complete(home):
         default_db_path(),
         command_id="messaging:one",
         room_id="classic-room",
+        authority_hash=hashlib.sha256(b"authority:test").hexdigest(),
         action="send",
         payload={"message": "hello"},
     )
@@ -73,7 +76,12 @@ def test_desktop_mailbox_rpc_claim_and_complete(home):
             1,
             {
                 "consumer_id": "desktop:test",
-                "room_ids": ["classic-room"],
+                "room_authorities": [
+                    {
+                        "room_id": "classic-room",
+                        "authority_token": "authority:test",
+                    }
+                ],
             },
         )
     )["commands"]

--- a/tests/tui_gateway/test_hosted_room_driver_runtime.py
+++ b/tests/tui_gateway/test_hosted_room_driver_runtime.py
@@ -491,6 +491,10 @@ def test_crash_recovery_harvests_existing_terminal_receipt(db: Path):
 
 def test_expired_attempt_receipt_is_reconciled_under_current_lease(db: Path):
     identity = _identity()
+    now = [100.0]
+
+    def clock():
+        return now[0]
     old_lease = state.acquire_lease(
         db,
         room_id=ROOM_ID,
@@ -498,7 +502,7 @@ def test_expired_attempt_receipt_is_reconciled_under_current_lease(db: Path):
         authority_epoch=BINDING.authority_epoch,
         process_generation="old-process",
         ttl_seconds=0.2,
-        clock=time.time,
+        clock=clock,
     )
     _admit(db, identity)
     state.start_task(
@@ -506,7 +510,7 @@ def test_expired_attempt_receipt_is_reconciled_under_current_lease(db: Path):
         identity,
         old_lease,
         expected_cancel_generation=0,
-        clock=time.time,
+        clock=clock,
     )
     rpc = FakeSessionRPC(auto_complete=False)
     rpc.add_session(
@@ -522,8 +526,8 @@ def test_expired_attempt_receipt_is_reconciled_under_current_lease(db: Path):
             }
         ],
     )
-    time.sleep(0.22)
-    runtime = _runtime(db, rpc)
+    now[0] = 101.0
+    runtime = _runtime(db, rpc, clock=clock)
 
     runtime.start()
     _wait_for(lambda: state.get_task(db, identity)["status"] == "settled")
@@ -537,6 +541,10 @@ def test_expired_attempt_receipt_is_reconciled_under_current_lease(db: Path):
 
 def test_retry_ignores_late_receipt_from_prior_execution_generation(db: Path):
     identity = _identity()
+    now = [100.0]
+
+    def clock():
+        return now[0]
     old_lease = state.acquire_lease(
         db,
         room_id=ROOM_ID,
@@ -544,7 +552,7 @@ def test_retry_ignores_late_receipt_from_prior_execution_generation(db: Path):
         authority_epoch=BINDING.authority_epoch,
         process_generation="old-process",
         ttl_seconds=0.2,
-        clock=time.time,
+        clock=clock,
     )
     _admit(db, identity)
     old_attempt = state.start_task(
@@ -552,9 +560,9 @@ def test_retry_ignores_late_receipt_from_prior_execution_generation(db: Path):
         identity,
         old_lease,
         expected_cancel_generation=0,
-        clock=time.time,
+        clock=clock,
     )
-    time.sleep(0.22)
+    now[0] = 101.0
     current_lease = state.acquire_lease(
         db,
         room_id=ROOM_ID,
@@ -562,18 +570,18 @@ def test_retry_ignores_late_receipt_from_prior_execution_generation(db: Path):
         authority_epoch=BINDING.authority_epoch,
         process_generation="manual-recovery",
         ttl_seconds=30,
-        clock=time.time,
+        clock=clock,
     )
-    state.recover_room(db, current_lease, clock=time.time)
+    state.recover_room(db, current_lease, clock=clock)
     state.requeue_indeterminate_task(
         db,
         identity,
         current_lease,
         expected_execution_generation=old_attempt.execution_generation,
         expected_cancel_generation=old_attempt.cancel_generation,
-        clock=time.time,
+        clock=clock,
     )
-    state.release_lease(db, current_lease, clock=time.time)
+    state.release_lease(db, current_lease, clock=clock)
     rpc = FakeSessionRPC(auto_complete=False)
     rpc.add_session(
         task_id=identity.task_id,
@@ -588,7 +596,7 @@ def test_retry_ignores_late_receipt_from_prior_execution_generation(db: Path):
             }
         ],
     )
-    runtime = _runtime(db, rpc)
+    runtime = _runtime(db, rpc, clock=clock)
 
     runtime.start()
     assert rpc.submitted.wait(1.0)
@@ -634,6 +642,10 @@ def test_active_recovered_turn_is_never_resubmitted(db: Path):
 
 def test_ambiguous_recovery_remains_indeterminate(db: Path):
     identity = _identity()
+    now = [100.0]
+
+    def clock():
+        return now[0]
     old_lease = state.acquire_lease(
         db,
         room_id=ROOM_ID,
@@ -641,7 +653,7 @@ def test_ambiguous_recovery_remains_indeterminate(db: Path):
         authority_epoch=BINDING.authority_epoch,
         process_generation="old-process",
         ttl_seconds=0.2,
-        clock=time.time,
+        clock=clock,
     )
     _admit(db, identity)
     state.start_task(
@@ -649,12 +661,12 @@ def test_ambiguous_recovery_remains_indeterminate(db: Path):
         identity,
         old_lease,
         expected_cancel_generation=0,
-        clock=time.time,
+        clock=clock,
     )
     rpc = FakeSessionRPC(auto_complete=False)
     rpc.add_session(active=False, task_id=identity.task_id)
-    time.sleep(0.22)
-    runtime = _runtime(db, rpc)
+    now[0] = 101.0
+    runtime = _runtime(db, rpc, clock=clock)
 
     runtime.start()
     _wait_for(lambda: state.get_task(db, identity)["status"] == "indeterminate")

--- a/tests/tui_gateway/test_hosted_room_driver_runtime.py
+++ b/tests/tui_gateway/test_hosted_room_driver_runtime.py
@@ -1,0 +1,1001 @@
+"""Runtime tests for the hosted-room session adapter."""
+
+from __future__ import annotations
+
+import threading
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from gateway import hosted_room_driver as state
+from gateway import hosted_rooms
+from tui_gateway.hosted_room_driver import (
+    ROOM_SESSION_SOURCE,
+    HostedRoomBinding,
+    HostedRoomRuntime,
+    room_session_title,
+)
+
+
+ROOM_ID = "room-1"
+PROFILE = "ops"
+BINDING = HostedRoomBinding(
+    room_id=ROOM_ID,
+    gateway_id="gateway-a",
+    authority_epoch=1,
+)
+
+
+class RecordingTurnLocks:
+    """Record the profile lock and expose ownership to the fake RPC."""
+
+    def __init__(self) -> None:
+        self.events: list[tuple[str, str]] = []
+        self.local = threading.local()
+
+    @contextmanager
+    def __call__(self, profile: str):
+        self.events.append(("lock-enter", profile))
+        self.local.profile = profile
+        try:
+            yield
+        finally:
+            self.events.append(("lock-exit", profile))
+            self.local.profile = None
+
+    def held_for(self, profile: str) -> bool:
+        return getattr(self.local, "profile", None) == profile
+
+
+class FakeSessionRPC:
+    """Normalized in-memory session adapter with no model or network."""
+
+    def __init__(
+        self,
+        *,
+        auto_complete: bool = True,
+        required_lock: RecordingTurnLocks | None = None,
+    ) -> None:
+        self.auto_complete = auto_complete
+        self.required_lock = required_lock
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+        self.sessions: dict[tuple[str, str], dict[str, Any]] = {}
+        self.states: dict[str, dict[str, Any]] = {}
+        self.submitted = threading.Event()
+        self.on_interrupt = None
+        self.on_info = None
+        self.history_failures = 0
+        self._next_id = 1
+        self._lock = threading.Lock()
+
+    def _assert_lock(self, profile: str) -> None:
+        if self.required_lock is not None:
+            assert self.required_lock.held_for(profile)
+
+    def add_session(
+        self,
+        *,
+        profile: str = PROFILE,
+        title: str = room_session_title(ROOM_ID),
+        active: bool = False,
+        task_id: str | None = None,
+        history: list[dict[str, Any]] | None = None,
+    ) -> str:
+        with self._lock:
+            session_id = f"session-{self._next_id}"
+            self._next_id += 1
+            session = {"session_id": session_id, "title": title}
+            self.sessions[(profile, title)] = session
+            self.states[session_id] = {
+                "active": active,
+                "task_id": task_id,
+                "execution_generation": None,
+                "history": list(history or []),
+                "on_terminal": None,
+                "pending_approval": None,
+            }
+            return session_id
+
+    def complete(
+        self,
+        task_id: str,
+        *,
+        content: str = "Finished once.",
+        status: str = "settled",
+    ) -> None:
+        callback = None
+        receipt = None
+        with self._lock:
+            for session_id, session_state in self.states.items():
+                if session_state["task_id"] != task_id:
+                    continue
+                receipt = {
+                    "role": "assistant",
+                    "task_id": task_id,
+                    "execution_generation": session_state["execution_generation"],
+                    "status": status,
+                    "message_id": f"reply:{task_id}",
+                    "content": content,
+                }
+                session_state["history"].append(receipt)
+                session_state["active"] = False
+                callback = session_state.get("on_terminal")
+                self.calls.append(("complete", {"session_id": session_id}))
+                break
+        if receipt is None:
+            raise AssertionError(f"no active session for {task_id}")
+        if callback is not None:
+            callback({
+                "status": status,
+                "settlement_id": receipt["message_id"],
+                "message_id": receipt["message_id"],
+                "text": content,
+            })
+
+    def resolve_exact(self, *, profile: str, title: str, source: str):
+        self._assert_lock(profile)
+        params = {"profile": profile, "title": title, "source": source}
+        self.calls.append(("resolve_exact", params))
+        with self._lock:
+            session = self.sessions.get((profile, title))
+            return dict(session) if session is not None else None
+
+    def create(self, *, profile: str, title: str, source: str):
+        self._assert_lock(profile)
+        params = {"profile": profile, "title": title, "source": source}
+        self.calls.append(("create", params))
+        session_id = self.add_session(profile=profile, title=title)
+        return {"session_id": session_id, "title": title}
+
+    def resume(self, *, profile: str, session_id: str, source: str):
+        self._assert_lock(profile)
+        params = {
+            "profile": profile,
+            "session_id": session_id,
+            "source": source,
+        }
+        self.calls.append(("resume", params))
+        return {"session_id": session_id}
+
+    def submit(
+        self,
+        *,
+        profile: str,
+        session_id: str,
+        prompt: str,
+        source: str,
+        task: state.TaskIdentity,
+        execution_generation: int,
+        on_terminal,
+    ):
+        self._assert_lock(profile)
+        params = {
+            "profile": profile,
+            "session_id": session_id,
+            "prompt": prompt,
+            "source": source,
+            "task": task,
+            "execution_generation": execution_generation,
+            "on_terminal": on_terminal,
+        }
+        self.calls.append(("submit", params))
+        with self._lock:
+            self.states[session_id]["active"] = True
+            self.states[session_id]["task_id"] = task.task_id
+            self.states[session_id]["execution_generation"] = execution_generation
+            self.states[session_id]["on_terminal"] = on_terminal
+        self.submitted.set()
+        if self.auto_complete:
+            self.complete(task.task_id)
+        return {"accepted": True}
+
+    def history(self, *, profile: str, session_id: str, source: str):
+        self._assert_lock(profile)
+        params = {
+            "profile": profile,
+            "session_id": session_id,
+            "source": source,
+        }
+        self.calls.append(("history", params))
+        if self.history_failures > 0:
+            self.history_failures -= 1
+            raise RuntimeError("transient history read failed")
+        with self._lock:
+            return [dict(message) for message in self.states[session_id]["history"]]
+
+    def info(self, *, profile: str, session_id: str, source: str):
+        self._assert_lock(profile)
+        params = {
+            "profile": profile,
+            "session_id": session_id,
+            "source": source,
+        }
+        self.calls.append(("info", params))
+        with self._lock:
+            session_state = self.states[session_id]
+            result = {
+                "active": session_state["active"],
+                "task_id": session_state["task_id"],
+            }
+            if session_state.get("pending_approval"):
+                result["status"] = "waiting_for_approval"
+                result["pending_approval"] = dict(
+                    session_state["pending_approval"]
+                )
+        if self.on_info is not None:
+            self.on_info()
+        return result
+
+    def interrupt(
+        self,
+        *,
+        profile: str,
+        session_id: str,
+        source: str,
+        expected_task_id: str,
+    ):
+        params = {
+            "profile": profile,
+            "session_id": session_id,
+            "source": source,
+            "expected_task_id": expected_task_id,
+        }
+        with self._lock:
+            current = self.states[session_id]
+            if not current["active"] or current["task_id"] != expected_task_id:
+                self.calls.append(("interrupt_skipped", params))
+                return {"interrupted": False}
+            current["active"] = False
+        self.calls.append(("interrupt", params))
+        if self.on_interrupt is not None:
+            self.on_interrupt()
+        return {"interrupted": True}
+
+
+@pytest.fixture
+def db(tmp_path: Path) -> Path:
+    path = tmp_path / "state.db"
+    hosted_rooms.create_room(
+        path,
+        room_id=ROOM_ID,
+        name="Release room",
+        members=[{"profile": PROFILE, "handle": PROFILE}],
+        authority_gateway_id=BINDING.gateway_id,
+        now=time.time(),
+    )
+    return path
+
+
+def _identity(task_id: str = "task-1") -> state.TaskIdentity:
+    return state.TaskIdentity(
+        room_id=ROOM_ID,
+        task_id=task_id,
+        thread_id="thread-1",
+        turn_id=f"turn-{task_id}",
+    )
+
+
+def _admit(
+    db: Path,
+    identity: state.TaskIdentity,
+    *,
+    prompt: str = "Inspect the release candidate.",
+) -> None:
+    state.admit_task(
+        db,
+        identity,
+        payload={
+            "target_profile": PROFILE,
+            "prompt": prompt,
+            "source_event_seq": 1,
+        },
+        clock=time.time,
+    )
+
+
+def _runtime(
+    db: Path,
+    rpc: FakeSessionRPC,
+    locks: RecordingTurnLocks | None = None,
+    **kwargs,
+) -> HostedRoomRuntime:
+    return HostedRoomRuntime(
+        db_path=db,
+        rooms=[BINDING],
+        rpc=rpc,
+        turn_lock=locks or RecordingTurnLocks(),
+        lease_ttl_seconds=kwargs.pop("lease_ttl_seconds", 0.4),
+        poll_interval_seconds=kwargs.pop("poll_interval_seconds", 0.01),
+        **kwargs,
+    )
+
+
+def _wait_for(predicate, *, timeout: float = 2.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(0.01)
+    raise AssertionError("condition was not reached before timeout")
+
+
+def test_runtime_uses_unique_process_generation(db: Path):
+    first = _runtime(db, FakeSessionRPC())
+    second = _runtime(db, FakeSessionRPC())
+
+    assert first.process_generation != second.process_generation
+    assert len(first.process_generation) == 32
+
+
+def test_queued_task_routes_profile_and_credentials_without_overrides(db: Path):
+    identity = _identity()
+    _admit(db, identity, prompt="Use the configured profile credentials.")
+    rpc = FakeSessionRPC()
+    runtime = _runtime(db, rpc)
+
+    runtime.start()
+    _wait_for(lambda: state.get_task(db, identity)["status"] == "settled")
+    assert runtime.stop(timeout=1.0)
+
+    create = next(params for method, params in rpc.calls if method == "create")
+    submit = next(params for method, params in rpc.calls if method == "submit")
+    assert create == {
+        "profile": PROFILE,
+        "title": f"Group: {ROOM_ID}",
+        "source": ROOM_SESSION_SOURCE,
+    }
+    assert submit["profile"] == PROFILE
+    assert submit["source"] == ROOM_SESSION_SOURCE
+    assert submit["prompt"] == "Use the configured profile credentials."
+    assert "model" not in create | submit
+    assert "provider" not in create | submit
+    assert state.get_task(db, identity)["result"]["text"] == "Finished once."
+
+
+def test_worker_settles_without_any_client_transport(db: Path):
+    identity = _identity()
+    _admit(db, identity)
+    runtime = _runtime(db, FakeSessionRPC())
+
+    runtime.start()
+    _wait_for(lambda: state.get_task(db, identity)["status"] == "settled")
+
+    assert runtime.status()["running"] is True
+    assert runtime.status()["cycles"] >= 1
+    assert runtime.stop(timeout=1.0)
+
+
+def test_policy_hooks_prepare_and_publish_terminal_idempotently(db: Path):
+    identity = _identity()
+    _admit(db, identity)
+    prepared = []
+    published = []
+    runtime = _runtime(
+        db,
+        FakeSessionRPC(),
+        prepare_room=lambda binding: prepared.append(binding.room_id),
+        publish_terminal=lambda binding, task: published.append(
+            (binding.room_id, task["identity"].task_id, task["status"])
+        ),
+    )
+
+    runtime.start()
+    _wait_for(lambda: state.get_task(db, identity)["status"] == "settled")
+    assert runtime.stop(timeout=1.0)
+
+    assert prepared
+    assert published == [(ROOM_ID, identity.task_id, "settled")]
+
+
+def test_transport_resolver_selects_member_transport_without_forking_state(
+    db: Path,
+):
+    identity = _identity()
+    _admit(db, identity)
+    selected = FakeSessionRPC()
+    resolutions = []
+
+    def resolve_transport(binding, task):
+        resolutions.append((binding, task["identity"], task["payload"]))
+        return selected
+
+    runtime = HostedRoomRuntime(
+        db_path=db,
+        rooms=[BINDING],
+        transport_resolver=resolve_transport,
+        turn_lock=RecordingTurnLocks(),
+        lease_ttl_seconds=0.4,
+        poll_interval_seconds=0.01,
+    )
+
+    runtime.start()
+    _wait_for(lambda: state.get_task(db, identity)["status"] == "settled")
+    assert runtime.stop(timeout=1.0)
+
+    assert resolutions
+    assert all(binding == BINDING for binding, _, _ in resolutions)
+    assert all(task_identity == identity for _, task_identity, _ in resolutions)
+    assert any(method == "submit" for method, _ in selected.calls)
+
+
+def test_existing_canonical_session_is_resumed_not_duplicated(db: Path):
+    identity = _identity()
+    _admit(db, identity)
+    rpc = FakeSessionRPC()
+    session_id = rpc.add_session()
+    runtime = _runtime(db, rpc)
+
+    runtime.start()
+    _wait_for(lambda: state.get_task(db, identity)["status"] == "settled")
+    assert runtime.stop(timeout=1.0)
+
+    assert not [call for call in rpc.calls if call[0] == "create"]
+    resume = next(params for method, params in rpc.calls if method == "resume")
+    assert resume == {
+        "profile": PROFILE,
+        "session_id": session_id,
+        "source": ROOM_SESSION_SOURCE,
+    }
+
+
+def test_crash_recovery_harvests_existing_terminal_receipt(db: Path):
+    identity = _identity()
+    old_lease = state.acquire_lease(
+        db,
+        room_id=ROOM_ID,
+        gateway_id=BINDING.gateway_id,
+        authority_epoch=BINDING.authority_epoch,
+        process_generation="old-process",
+        ttl_seconds=10,
+        clock=time.time,
+    )
+    _admit(db, identity)
+    state.start_task(
+        db,
+        identity,
+        old_lease,
+        expected_cancel_generation=0,
+        clock=time.time,
+    )
+    rpc = FakeSessionRPC(auto_complete=False)
+    rpc.add_session(
+        task_id=identity.task_id,
+        history=[
+            {
+                "role": "assistant",
+                "task_id": identity.task_id,
+                "execution_generation": 1,
+                "status": "settled",
+                "message_id": "reply:recovered",
+                "content": "Recovered durable answer.",
+            }
+        ],
+    )
+    runtime = _runtime(db, rpc)
+
+    runtime.start()
+    _wait_for(lambda: state.get_task(db, identity)["status"] == "settled")
+    assert runtime.stop(timeout=1.0)
+
+    assert state.get_task(db, identity)["result"]["text"] == (
+        "Recovered durable answer."
+    )
+    assert not [call for call in rpc.calls if call[0] == "submit"]
+
+
+def test_expired_attempt_receipt_is_reconciled_under_current_lease(db: Path):
+    identity = _identity()
+    old_lease = state.acquire_lease(
+        db,
+        room_id=ROOM_ID,
+        gateway_id=BINDING.gateway_id,
+        authority_epoch=BINDING.authority_epoch,
+        process_generation="old-process",
+        ttl_seconds=0.2,
+        clock=time.time,
+    )
+    _admit(db, identity)
+    state.start_task(
+        db,
+        identity,
+        old_lease,
+        expected_cancel_generation=0,
+        clock=time.time,
+    )
+    rpc = FakeSessionRPC(auto_complete=False)
+    rpc.add_session(
+        task_id=identity.task_id,
+        history=[
+            {
+                "role": "assistant",
+                "task_id": identity.task_id,
+                "execution_generation": 1,
+                "status": "settled",
+                "message_id": "reply:expired-recovered",
+                "content": "Recovered after lease expiry.",
+            }
+        ],
+    )
+    time.sleep(0.22)
+    runtime = _runtime(db, rpc)
+
+    runtime.start()
+    _wait_for(lambda: state.get_task(db, identity)["status"] == "settled")
+    assert runtime.stop(timeout=1.0)
+
+    assert state.get_task(db, identity)["result"]["text"] == (
+        "Recovered after lease expiry."
+    )
+    assert not [call for call in rpc.calls if call[0] == "submit"]
+
+
+def test_retry_ignores_late_receipt_from_prior_execution_generation(db: Path):
+    identity = _identity()
+    old_lease = state.acquire_lease(
+        db,
+        room_id=ROOM_ID,
+        gateway_id=BINDING.gateway_id,
+        authority_epoch=BINDING.authority_epoch,
+        process_generation="old-process",
+        ttl_seconds=0.2,
+        clock=time.time,
+    )
+    _admit(db, identity)
+    old_attempt = state.start_task(
+        db,
+        identity,
+        old_lease,
+        expected_cancel_generation=0,
+        clock=time.time,
+    )
+    time.sleep(0.22)
+    current_lease = state.acquire_lease(
+        db,
+        room_id=ROOM_ID,
+        gateway_id=BINDING.gateway_id,
+        authority_epoch=BINDING.authority_epoch,
+        process_generation="manual-recovery",
+        ttl_seconds=30,
+        clock=time.time,
+    )
+    state.recover_room(db, current_lease, clock=time.time)
+    state.requeue_indeterminate_task(
+        db,
+        identity,
+        current_lease,
+        expected_execution_generation=old_attempt.execution_generation,
+        expected_cancel_generation=old_attempt.cancel_generation,
+        clock=time.time,
+    )
+    state.release_lease(db, current_lease, clock=time.time)
+    rpc = FakeSessionRPC(auto_complete=False)
+    rpc.add_session(
+        task_id=identity.task_id,
+        history=[
+            {
+                "role": "assistant",
+                "task_id": identity.task_id,
+                "execution_generation": old_attempt.execution_generation,
+                "status": "settled",
+                "message_id": "reply:late-old-attempt",
+                "content": "Late old result.",
+            }
+        ],
+    )
+    runtime = _runtime(db, rpc)
+
+    runtime.start()
+    assert rpc.submitted.wait(1.0)
+    time.sleep(0.04)
+    assert runtime.stop(timeout=1.0)
+
+    task = state.get_task(db, identity)
+    assert task["status"] == "running"
+    assert task["execution_generation"] == old_attempt.execution_generation + 1
+
+
+def test_active_recovered_turn_is_never_resubmitted(db: Path):
+    identity = _identity()
+    old_lease = state.acquire_lease(
+        db,
+        room_id=ROOM_ID,
+        gateway_id=BINDING.gateway_id,
+        authority_epoch=BINDING.authority_epoch,
+        process_generation="old-process",
+        ttl_seconds=10,
+        clock=time.time,
+    )
+    _admit(db, identity)
+    state.start_task(
+        db,
+        identity,
+        old_lease,
+        expected_cancel_generation=0,
+        clock=time.time,
+    )
+    rpc = FakeSessionRPC(auto_complete=False)
+    rpc.add_session(active=True, task_id=identity.task_id)
+    runtime = _runtime(db, rpc)
+
+    runtime.start()
+    time.sleep(0.08)
+    assert runtime.stop(timeout=1.0)
+
+    assert state.get_task(db, identity)["status"] == "running"
+    assert not [call for call in rpc.calls if call[0] == "submit"]
+
+
+
+def test_ambiguous_recovery_remains_indeterminate(db: Path):
+    identity = _identity()
+    old_lease = state.acquire_lease(
+        db,
+        room_id=ROOM_ID,
+        gateway_id=BINDING.gateway_id,
+        authority_epoch=BINDING.authority_epoch,
+        process_generation="old-process",
+        ttl_seconds=0.2,
+        clock=time.time,
+    )
+    _admit(db, identity)
+    state.start_task(
+        db,
+        identity,
+        old_lease,
+        expected_cancel_generation=0,
+        clock=time.time,
+    )
+    rpc = FakeSessionRPC(auto_complete=False)
+    rpc.add_session(active=False, task_id=identity.task_id)
+    time.sleep(0.22)
+    runtime = _runtime(db, rpc)
+
+    runtime.start()
+    _wait_for(lambda: state.get_task(db, identity)["status"] == "indeterminate")
+    assert runtime.stop(timeout=1.0)
+
+    assert not [call for call in rpc.calls if call[0] == "submit"]
+
+
+def test_post_submit_observation_failure_preserves_recoverable_outcome(db: Path):
+    identity = _identity()
+    _admit(db, identity)
+    rpc = FakeSessionRPC(auto_complete=False)
+    rpc.history_failures = 1
+    runtime = _runtime(db, rpc)
+
+    runtime.start()
+    assert rpc.submitted.wait(1.0)
+    _wait_for(
+        lambda: (
+            "observation failed after submit"
+            in str(runtime.status()["last_error"] or "")
+        )
+    )
+    assert state.get_task(db, identity)["status"] == "running"
+    rpc.complete(identity.task_id, content="Recovered after a transient read.")
+    runtime.wakeup()
+    _wait_for(lambda: state.get_task(db, identity)["status"] == "settled")
+    assert runtime.stop(timeout=1.0)
+
+    task = state.get_task(db, identity)
+    assert task["result"]["text"] == "Recovered after a transient read."
+    assert not [call for call in rpc.calls if call[0] == "submit"][1:]
+
+
+def test_cancellation_is_persisted_before_interrupt_and_fences_late_result(
+    db: Path,
+):
+    identity = _identity()
+    _admit(db, identity)
+    rpc = FakeSessionRPC(auto_complete=False)
+    runtime = _runtime(db, rpc)
+    observed_status: list[str] = []
+    rpc.on_interrupt = lambda: observed_status.append(
+        state.get_task(db, identity)["status"]
+    )
+
+    runtime.start()
+    assert rpc.submitted.wait(1.0)
+    cancelled = runtime.cancel(identity, cancel_id="cancel-user")
+    rpc.complete(identity.task_id, content="Too late.")
+    runtime.wakeup()
+    time.sleep(0.05)
+    assert runtime.stop(timeout=1.0)
+
+    assert cancelled["status"] == "cancelled"
+    assert observed_status == ["stopping"]
+
+
+def test_transient_remote_stop_failure_stays_pending_and_retries(db: Path):
+    identity = _identity()
+    _admit(db, identity)
+    rpc = FakeSessionRPC(auto_complete=False)
+    runtime = _runtime(db, rpc)
+    original_interrupt = rpc.interrupt
+    attempts = 0
+
+    def flaky_interrupt(**kwargs):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise RuntimeError("temporary stop transport failure")
+        return original_interrupt(**kwargs)
+
+    rpc.interrupt = flaky_interrupt
+    runtime.start()
+    assert rpc.submitted.wait(1.0)
+    stopping = runtime.cancel(identity, cancel_id="cancel-retry")
+    assert stopping["status"] == "stopping"
+    assert state.get_task(db, identity)["status"] == "stopping"
+    runtime.wakeup()
+    _wait_for(lambda: state.get_task(db, identity)["status"] == "cancelled")
+    assert attempts >= 2
+    assert runtime.stop(timeout=1.0)
+    assert state.get_task(db, identity)["status"] == "cancelled"
+
+
+def test_completion_wins_a_race_with_unacknowledged_stop(db: Path):
+    identity = _identity()
+    _admit(db, identity)
+    rpc = FakeSessionRPC(auto_complete=False)
+    runtime = _runtime(db, rpc)
+
+    runtime.start()
+    assert rpc.submitted.wait(1.0)
+    def finish_only_after_stop_intent():
+        if state.get_task(db, identity)["status"] == "stopping":
+            rpc.complete(identity.task_id, content="Already done.")
+
+    rpc.on_info = finish_only_after_stop_intent
+    result = runtime.cancel(identity, cancel_id="cancel-raced")
+
+    assert result["status"] == "settled"
+    assert result["result"]["text"] == "Already done."
+    assert runtime.stop(timeout=1.0)
+
+
+def test_restart_harvests_completion_before_retrying_durable_stop(db: Path):
+    identity = _identity()
+    _admit(db, identity)
+    old_lease = state.acquire_lease(
+        db,
+        room_id=ROOM_ID,
+        gateway_id=BINDING.gateway_id,
+        authority_epoch=BINDING.authority_epoch,
+        process_generation="old-process",
+        ttl_seconds=0.05,
+        clock=time.time,
+    )
+    attempt = state.start_task(
+        db,
+        identity,
+        old_lease,
+        expected_cancel_generation=0,
+        clock=time.time,
+    )
+    stopping = state.begin_task_cancel(
+        db,
+        identity,
+        cancel_id="cancel-before-restart",
+        expected_cancel_generation=attempt.cancel_generation,
+        clock=time.time,
+    )
+    rpc = FakeSessionRPC(auto_complete=False)
+    rpc.add_session(
+        active=False,
+        task_id=identity.task_id,
+        history=[
+            {
+                "role": "assistant",
+                "task_id": identity.task_id,
+                "execution_generation": attempt.execution_generation,
+                "status": "settled",
+                "message_id": "reply-after-stop",
+                "content": "Finished before Stop reached the session.",
+            }
+        ],
+    )
+    time.sleep(0.06)
+    runtime = _runtime(db, rpc, process_generation="new-process")
+
+    runtime.start()
+    _wait_for(lambda: state.get_task(db, identity)["status"] == "settled")
+    assert runtime.stop(timeout=1.0)
+
+    settled = state.get_task(db, identity)
+    assert stopping["status"] == "stopping"
+    assert settled["result"]["text"] == "Finished before Stop reached the session."
+    assert not [call for call in rpc.calls if call[0] == "interrupt"]
+
+
+def test_restart_acknowledges_inactive_local_stop_without_memory_marker(db: Path):
+    identity = _identity()
+    _admit(db, identity)
+    old_lease = state.acquire_lease(
+        db,
+        room_id=ROOM_ID,
+        gateway_id=BINDING.gateway_id,
+        authority_epoch=BINDING.authority_epoch,
+        process_generation="old-process",
+        ttl_seconds=0.05,
+        clock=time.time,
+    )
+    attempt = state.start_task(
+        db,
+        identity,
+        old_lease,
+        expected_cancel_generation=0,
+        clock=time.time,
+    )
+    state.begin_task_cancel(
+        db,
+        identity,
+        cancel_id="cancel-before-restart",
+        expected_cancel_generation=attempt.cancel_generation,
+        clock=time.time,
+    )
+    rpc = FakeSessionRPC(auto_complete=False)
+    time.sleep(0.06)
+    runtime = _runtime(db, rpc, process_generation="new-process")
+
+    cancelled = runtime.cancel(identity, cancel_id="cancel-before-restart")
+
+    assert cancelled["status"] == "cancelled"
+    assert not [call for call in rpc.calls if call[0] == "interrupt"]
+
+
+
+def test_pending_local_approval_is_reported_with_safe_choices(db: Path):
+    identity = _identity()
+    _admit(db, identity)
+    rpc = FakeSessionRPC(auto_complete=False)
+    actions = []
+    runtime = _runtime(
+        db,
+        rpc,
+        pending_action=lambda room_id, member_id, action: actions.append(
+            (room_id, member_id, action)
+        ),
+    )
+
+    runtime.start()
+    assert rpc.submitted.wait(1.0)
+    session_id = next(iter(rpc.states))
+    with rpc._lock:
+        rpc.states[session_id]["pending_approval"] = {
+            "request_id": "approval-1",
+            "command": "pytest -q tests/focused",
+            "choices": ["once", "session", "always", "deny"],
+        }
+    runtime.wakeup()
+    _wait_for(lambda: any(action for _room, _member, action in actions))
+
+    _room, member, action = next(
+        item for item in actions if item[2] is not None
+    )
+    assert member == PROFILE
+    assert action["request_id"] == "approval-1"
+    assert action["approval"]["choices"] == ["once", "deny"]
+    assert runtime.stop(timeout=1.0)
+
+
+def test_cancel_never_interrupts_a_newer_task_in_the_same_session(db: Path):
+    identity = _identity()
+    _admit(db, identity)
+    rpc = FakeSessionRPC(auto_complete=False)
+    runtime = _runtime(db, rpc)
+
+    runtime.start()
+    assert rpc.submitted.wait(1.0)
+    session_id = next(iter(rpc.states))
+
+    def switch_to_newer_task() -> None:
+        with rpc._lock:
+            rpc.states[session_id]["active"] = True
+            rpc.states[session_id]["task_id"] = "task-2"
+
+    rpc.on_info = switch_to_newer_task
+    cancelled = runtime.cancel(identity, cancel_id="cancel-old-task")
+
+    assert cancelled["status"] == "stopping"
+    assert not [call for call in rpc.calls if call[0] == "interrupt"]
+    assert not [call for call in rpc.calls if call[0] == "interrupt_skipped"]
+    assert rpc.states[session_id]["active"] is True
+    assert rpc.states[session_id]["task_id"] == "task-2"
+    assert runtime.stop(timeout=1.0)
+
+
+def test_status_reports_room_blocked_on_unresolved_indeterminate_task(db: Path):
+    identity = _identity()
+    old_lease = state.acquire_lease(
+        db,
+        room_id=ROOM_ID,
+        gateway_id=BINDING.gateway_id,
+        authority_epoch=BINDING.authority_epoch,
+        process_generation="old-process",
+        ttl_seconds=0.2,
+        clock=time.time,
+    )
+    _admit(db, identity)
+    state.start_task(
+        db,
+        identity,
+        old_lease,
+        expected_cancel_generation=0,
+        clock=time.time,
+    )
+    rpc = FakeSessionRPC(auto_complete=False)
+    rpc.add_session(active=False, task_id=identity.task_id)
+    time.sleep(0.22)
+    runtime = _runtime(db, rpc)
+
+    runtime.start()
+    _wait_for(lambda: ROOM_ID in runtime.status()["blocked_rooms"])
+    assert runtime.stop(timeout=1.0)
+
+    assert state.get_task(db, identity)["status"] == "indeterminate"
+
+
+def test_authority_loss_stops_terminal_commit(db: Path):
+    identity = _identity()
+    _admit(db, identity)
+    rpc = FakeSessionRPC(auto_complete=False)
+    runtime = _runtime(db, rpc, lease_ttl_seconds=0.1)
+
+    runtime.start()
+    assert rpc.submitted.wait(1.0)
+    hosted_rooms.claim_authority(
+        db,
+        room_id=ROOM_ID,
+        expected_gateway_id="gateway-a",
+        expected_epoch=1,
+        new_gateway_id="gateway-b",
+        event_id="claim-gateway-b",
+        now=time.time(),
+    )
+    rpc.complete(identity.task_id)
+    runtime.wakeup()
+    _wait_for(lambda: runtime.status()["last_error"] is not None)
+    assert runtime.stop(timeout=1.0)
+
+    assert state.get_task(db, identity)["status"] == "running"
+    assert "authority changed" in runtime.status()["last_error"]
+
+
+def test_profile_turn_lock_covers_resolve_submit_and_terminal_observation(db: Path):
+    identity = _identity()
+    _admit(db, identity)
+    locks = RecordingTurnLocks()
+    rpc = FakeSessionRPC(required_lock=locks)
+    runtime = _runtime(db, rpc, locks)
+
+    runtime.start()
+    _wait_for(lambda: state.get_task(db, identity)["status"] == "settled")
+    assert runtime.stop(timeout=1.0)
+
+    assert locks.events == [("lock-enter", PROFILE), ("lock-exit", PROFILE)]
+    methods = [method for method, _params in rpc.calls]
+    assert methods.index("resolve_exact") < methods.index("submit")
+    assert methods.index("submit") < methods.index("complete")
+    assert "history" not in methods
+
+
+def test_stop_is_bounded_and_does_not_interrupt_active_turn(db: Path):
+    identity = _identity()
+    _admit(db, identity)
+    rpc = FakeSessionRPC(auto_complete=False)
+    runtime = _runtime(db, rpc, poll_interval_seconds=0.01)
+
+    runtime.start()
+    assert rpc.submitted.wait(1.0)
+    started = time.monotonic()
+    stopped = runtime.stop(timeout=0.5)
+
+    assert stopped is True
+    assert time.monotonic() - started < 0.5
+    assert state.get_task(db, identity)["status"] == "running"
+    assert not [call for call in rpc.calls if call[0] == "interrupt"]

--- a/tests/tui_gateway/test_hosted_room_driver_runtime.py
+++ b/tests/tui_gateway/test_hosted_room_driver_runtime.py
@@ -361,7 +361,10 @@ def test_worker_settles_without_any_client_transport(db: Path):
     runtime = _runtime(db, FakeSessionRPC())
 
     runtime.start()
-    _wait_for(lambda: state.get_task(db, identity)["status"] == "settled")
+    _wait_for(
+        lambda: state.get_task(db, identity)["status"] == "settled"
+        and runtime.status()["cycles"] >= 1
+    )
 
     assert runtime.status()["running"] is True
     assert runtime.status()["cycles"] >= 1

--- a/tests/tui_gateway/test_hosted_room_driver_runtime.py
+++ b/tests/tui_gateway/test_hosted_room_driver_runtime.py
@@ -58,9 +58,13 @@ class FakeSessionRPC:
         *,
         auto_complete: bool = True,
         required_lock: RecordingTurnLocks | None = None,
+        fail_stage: bool = False,
+        fail_stage_at: int | None = None,
     ) -> None:
         self.auto_complete = auto_complete
         self.required_lock = required_lock
+        self.fail_stage = fail_stage
+        self.fail_stage_at = fail_stage_at
         self.calls: list[tuple[str, dict[str, Any]]] = []
         self.sessions: dict[tuple[str, str], dict[str, Any]] = {}
         self.states: dict[str, dict[str, Any]] = {}
@@ -69,6 +73,9 @@ class FakeSessionRPC:
         self.on_info = None
         self.history_failures = 0
         self._next_id = 1
+        self._stage_count = 0
+        self._pending_attachments: dict[str, list[str]] = {}
+        self._attachment_snapshots: dict[tuple[str, int], list[str]] = {}
         self._lock = threading.Lock()
 
     def _assert_lock(self, profile: str) -> None:
@@ -180,6 +187,9 @@ class FakeSessionRPC:
             "task": task,
             "execution_generation": execution_generation,
             "on_terminal": on_terminal,
+            "staged_attachment_ids": list(
+                self._pending_attachments.get(session_id, [])
+            ),
         }
         self.calls.append(("submit", params))
         with self._lock:
@@ -191,6 +201,102 @@ class FakeSessionRPC:
         if self.auto_complete:
             self.complete(task.task_id)
         return {"accepted": True}
+
+    def stage_attachment(
+        self,
+        *,
+        profile: str,
+        session_id: str,
+        source: str,
+        attachment,
+        data: bytes,
+        execution_generation: int,
+    ):
+        self._assert_lock(profile)
+        params = {
+            "profile": profile,
+            "session_id": session_id,
+            "source": source,
+            "attachment": dict(attachment),
+            "data": data,
+            "execution_generation": execution_generation,
+        }
+        self.calls.append(("stage_attachment", params))
+        self._stage_count += 1
+        if self.fail_stage or self._stage_count == self.fail_stage_at:
+            raise RuntimeError("attachment staging failed")
+        self._pending_attachments.setdefault(session_id, []).append(
+            str(attachment.get("attachment_id") or "")
+        )
+        return {
+            "attached": True,
+            **(
+                {"ref_text": f"@file:attachments/{attachment['name']}"}
+                if attachment.get("kind") == "file"
+                else {}
+            ),
+        }
+
+    def begin_attachment_staging(
+        self,
+        *,
+        profile: str,
+        session_id: str,
+        source: str,
+        execution_generation: int,
+    ) -> None:
+        self._assert_lock(profile)
+        params = {
+            "profile": profile,
+            "session_id": session_id,
+            "source": source,
+            "execution_generation": execution_generation,
+        }
+        self.calls.append(("begin_attachment_staging", params))
+        self._attachment_snapshots.setdefault(
+            (session_id, execution_generation),
+            list(self._pending_attachments.get(session_id, [])),
+        )
+
+    def commit_attachment_staging(
+        self,
+        *,
+        profile: str,
+        session_id: str,
+        source: str,
+        execution_generation: int,
+    ) -> None:
+        self._assert_lock(profile)
+        params = {
+            "profile": profile,
+            "session_id": session_id,
+            "source": source,
+            "execution_generation": execution_generation,
+        }
+        self.calls.append(("commit_attachment_staging", params))
+        self._attachment_snapshots.pop((session_id, execution_generation), None)
+
+    def rollback_attachment_staging(
+        self,
+        *,
+        profile: str,
+        session_id: str,
+        source: str,
+        execution_generation: int,
+    ) -> None:
+        self._assert_lock(profile)
+        params = {
+            "profile": profile,
+            "session_id": session_id,
+            "source": source,
+            "execution_generation": execution_generation,
+        }
+        self.calls.append(("rollback_attachment_staging", params))
+        snapshot = self._attachment_snapshots.pop(
+            (session_id, execution_generation), None
+        )
+        if snapshot is not None:
+            self._pending_attachments[session_id] = snapshot
 
     def history(self, *, profile: str, session_id: str, source: str):
         self._assert_lock(profile)
@@ -283,15 +389,19 @@ def _admit(
     identity: state.TaskIdentity,
     *,
     prompt: str = "Inspect the release candidate.",
+    attachments: list[dict[str, Any]] | None = None,
 ) -> None:
+    payload = {
+        "target_profile": PROFILE,
+        "prompt": prompt,
+        "source_event_seq": 1,
+    }
+    if attachments:
+        payload["attachments"] = attachments
     state.admit_task(
         db,
         identity,
-        payload={
-            "target_profile": PROFILE,
-            "prompt": prompt,
-            "source_event_seq": 1,
-        },
+        payload=payload,
         clock=time.time,
     )
 
@@ -1014,3 +1124,176 @@ def test_stop_is_bounded_and_does_not_interrupt_active_turn(db: Path):
     assert time.monotonic() - started < 0.5
     assert state.get_task(db, identity)["status"] == "running"
     assert not [call for call in rpc.calls if call[0] == "interrupt"]
+
+
+def test_attachments_stage_before_submit_and_file_ref_is_runtime_only(db: Path):
+    identity = _identity()
+    manifests = [
+        {
+            "attachment_id": "att_11111111111111111111111111111111",
+            "kind": "image",
+            "name": "diagram.png",
+            "size": 12,
+            "mime": "image/png",
+        },
+        {
+            "attachment_id": "att_22222222222222222222222222222222",
+            "kind": "file",
+            "name": "notes.txt",
+            "size": 5,
+            "mime": "text/plain",
+        },
+    ]
+    _admit(db, identity, attachments=manifests)
+    rpc = FakeSessionRPC()
+    runtime = _runtime(
+        db,
+        rpc,
+        attachment_loader=lambda _binding, _task: (
+            (manifests[0], b"image-bytes"),
+            (manifests[1], b"notes"),
+        ),
+    )
+
+    runtime.start()
+    _wait_for(lambda: state.get_task(db, identity)["status"] == "settled")
+    assert runtime.stop(timeout=1.0)
+
+    methods = [method for method, _params in rpc.calls]
+    assert methods.index("stage_attachment") < methods.index("submit")
+    assert methods.count("stage_attachment") == 2
+    submit = next(params for method, params in rpc.calls if method == "submit")
+    assert "@file:attachments/notes.txt" in submit["prompt"]
+    durable = state.get_task(db, identity)
+    assert "@file:" not in durable["payload"]["prompt"]
+    assert "image-bytes" not in repr(durable)
+
+
+def test_attachment_stage_failure_marks_turn_failed_without_text_only_submit(db: Path):
+    identity = _identity()
+    manifest = {
+        "attachment_id": "att_11111111111111111111111111111111",
+        "kind": "image",
+        "name": "diagram.png",
+        "size": 12,
+        "mime": "image/png",
+    }
+    _admit(db, identity, attachments=[manifest])
+    rpc = FakeSessionRPC(fail_stage=True)
+    runtime = _runtime(
+        db,
+        rpc,
+        attachment_loader=lambda _binding, _task: ((manifest, b"image-bytes"),),
+    )
+
+    runtime.start()
+    _wait_for(lambda: state.get_task(db, identity)["status"] == "failed")
+    assert runtime.stop(timeout=1.0)
+
+    assert any(method == "stage_attachment" for method, _params in rpc.calls)
+    assert not any(method == "submit" for method, _params in rpc.calls)
+    assert "attachment staging failed" in state.get_task(db, identity)["result"]["error"]
+
+
+def test_second_attachment_failure_rolls_back_before_later_text_only_turn(db: Path):
+    first = {
+        "attachment_id": "att_11111111111111111111111111111111",
+        "kind": "image",
+        "name": "diagram.png",
+        "size": 12,
+        "mime": "image/png",
+    }
+    second = {
+        "attachment_id": "att_22222222222222222222222222222222",
+        "kind": "pdf",
+        "name": "brief.pdf",
+        "size": 12,
+        "mime": "application/pdf",
+    }
+    failed_identity = _identity("task-with-files")
+    _admit(db, failed_identity, attachments=[first, second])
+    rpc = FakeSessionRPC(fail_stage_at=2)
+    runtime = _runtime(
+        db,
+        rpc,
+        attachment_loader=lambda _binding, _task: (
+            (first, b"image-bytes"),
+            (second, b"pdf-bytes"),
+        ),
+    )
+
+    runtime.start()
+    _wait_for(lambda: state.get_task(db, failed_identity)["status"] == "failed")
+
+    session_id = next(iter(rpc.states))
+    assert rpc._pending_attachments[session_id] == []
+    assert any(method == "rollback_attachment_staging" for method, _ in rpc.calls)
+
+    text_identity = _identity("task-text-only")
+    _admit(db, text_identity, prompt="Continue without any attachment.")
+    runtime.wakeup()
+    _wait_for(lambda: state.get_task(db, text_identity)["status"] == "settled")
+    assert runtime.stop(timeout=1.0)
+
+    text_submit = next(
+        params
+        for method, params in rpc.calls
+        if method == "submit" and params["task"] == text_identity
+    )
+    assert text_submit["staged_attachment_ids"] == []
+
+
+def test_attachment_task_never_uses_peer_transport_binary_path(db: Path):
+    identity = _identity()
+    manifest = {
+        "attachment_id": "att_11111111111111111111111111111111",
+        "kind": "image",
+        "name": "diagram.png",
+        "size": 12,
+        "mime": "image/png",
+    }
+    _admit(db, identity, attachments=[manifest])
+    peer = FakeSessionRPC()
+    runtime = HostedRoomRuntime(
+        db_path=db,
+        rooms=[BINDING],
+        transport_resolver=lambda _binding, _task: peer,
+        turn_lock=RecordingTurnLocks(),
+        attachment_loader=lambda _binding, _task: ((manifest, b"image-bytes"),),
+        lease_ttl_seconds=0.4,
+        poll_interval_seconds=0.01,
+    )
+
+    runtime.start()
+    _wait_for(lambda: state.get_task(db, identity)["status"] == "failed")
+    assert runtime.stop(timeout=1.0)
+
+    assert not any(method == "stage_attachment" for method, _params in peer.calls)
+    assert not any(method == "submit" for method, _params in peer.calls)
+
+
+def test_task_can_stage_a_bounded_aggregate_from_multiple_messages(db: Path):
+    identity = _identity()
+    manifests = [
+        {
+            "attachment_id": f"att_{index:032x}",
+            "kind": "file",
+            "name": f"notes-{index}.txt",
+            "size": 1,
+            "mime": "text/plain",
+        }
+        for index in range(9)
+    ]
+    _admit(db, identity, attachments=manifests)
+    rpc = FakeSessionRPC()
+
+    def load_one_at_a_time(_binding, _task):
+        for manifest in manifests:
+            yield manifest, b"x"
+
+    runtime = _runtime(db, rpc, attachment_loader=load_one_at_a_time)
+    runtime.start()
+    _wait_for(lambda: state.get_task(db, identity)["status"] == "settled")
+    assert runtime.stop(timeout=1.0)
+
+    assert sum(method == "stage_attachment" for method, _params in rpc.calls) == 9

--- a/tests/tui_gateway/test_hosted_room_prompt_fence.py
+++ b/tests/tui_gateway/test_hosted_room_prompt_fence.py
@@ -1,0 +1,84 @@
+"""Older Desktop clients cannot start a second driver for hosted rooms."""
+
+from __future__ import annotations
+
+from gateway import hosted_rooms
+import tui_gateway.server as server
+
+
+def _stub_session(monkeypatch, *, title):
+    monkeypatch.setattr(
+        server,
+        "_sess_nowait",
+        lambda _params, _rid: (
+            {"id": "session-1", "title": title, "source": "bot_room"},
+            None,
+        ),
+    )
+
+
+def test_direct_prompt_to_hosted_group_session_is_rejected(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    hosted_rooms.create_room(
+        hosted_rooms.default_db_path(),
+        room_id="room-hosted",
+        name="Hosted room",
+        members=[
+            {"member_id": "one", "profile": "one", "handle": "one"},
+            {"member_id": "two", "profile": "two", "handle": "two"},
+        ],
+        authority_gateway_id=hosted_rooms.local_authority_gateway_id(),
+    )
+    _stub_session(monkeypatch, title="Group: room-hosted")
+
+    result = server._methods["prompt.submit"](
+        "request-1", {"session_id": "session-1", "text": "continue"}
+    )
+
+    assert result["error"]["code"] == 4122
+    assert "managed by its gateway" in result["error"]["message"]
+
+
+def test_direct_prompt_to_non_hosted_group_reaches_normal_admission(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    _stub_session(monkeypatch, title="Group: local-only")
+    monkeypatch.setattr(
+        server,
+        "_ensure_active_session_slot",
+        lambda _sid, _session: "normal admission reached",
+    )
+
+    result = server._methods["prompt.submit"](
+        "request-2", {"session_id": "session-1", "text": "continue"}
+    )
+
+    assert result["error"] == {"code": 4090, "message": "normal admission reached"}
+
+
+def test_direct_prompt_is_refused_when_room_authority_cannot_be_verified(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    _stub_session(monkeypatch, title="Group: room-unknown")
+    monkeypatch.setattr(
+        hosted_rooms,
+        "room_state",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("disk busy")),
+    )
+
+    result = server._methods["prompt.submit"](
+        "request-3", {"session_id": "session-1", "text": "continue"}
+    )
+
+    assert result["error"]["code"] == 5122
+    assert result["error"]["message"] == (
+        "Could not verify this group. Try again after the gateway recovers."
+    )

--- a/tests/tui_gateway/test_hosted_room_server_rpc.py
+++ b/tests/tui_gateway/test_hosted_room_server_rpc.py
@@ -1,0 +1,148 @@
+"""Tests for the in-process hosted room session adapter."""
+
+from __future__ import annotations
+
+import threading
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.hosted_room_driver import TaskIdentity
+from tui_gateway.hosted_room_server_rpc import (
+    HostedRoomServerRPC,
+    HostedRoomSessionError,
+)
+
+
+def _server():
+    sessions = {}
+    calls = []
+
+    def method(name, result):
+        def handler(rid, params):
+            calls.append((name, params))
+            value = result(params) if callable(result) else result
+            return {"id": rid, **value}
+
+        return handler
+
+    methods = {
+        "session.list": method(
+            "session.list",
+            {"result": {"sessions": [{"id": "stored", "resolved_id": "tip", "title": "Group: room"}]}},
+        ),
+        "session.create": method("session.create", {"result": {"session_id": "runtime"}}),
+        "session.resume": method("session.resume", {"result": {"session_id": "runtime"}}),
+        "session.history": method("session.history", {"result": {"messages": [{"role": "assistant"}]}}),
+        "session.interrupt": method("session.interrupt", {"result": {"interrupted": True}}),
+        "approval.respond": method("approval.respond", {"result": {"resolved": 1}}),
+        "prompt.submit": method("prompt.submit", {"result": {"status": "streaming"}}),
+    }
+    server = SimpleNamespace(
+        _methods=methods,
+        _sessions=sessions,
+        _sessions_lock=threading.Lock(),
+        _pending_approval_request_payload=lambda _session_key: None,
+    )
+    return server, calls
+
+
+def test_routes_exact_hidden_session_and_internal_task_proof():
+    server, calls = _server()
+    rpc = HostedRoomServerRPC(server)
+    task = TaskIdentity("room", "task", "thread", "turn")
+    callback = lambda _receipt: None
+
+    assert rpc.resolve_exact(profile="ops", title="Group: room", source="bot_room")["session_id"] == "tip"
+    assert rpc.create(profile="ops", title="Group: room", source="bot_room")["session_id"] == "runtime"
+    rpc.submit(
+        profile="ops",
+        session_id="runtime",
+        prompt="Do the work",
+        source="bot_room",
+        task=task,
+        execution_generation=2,
+        on_terminal=callback,
+    )
+
+    create = next(params for method, params in calls if method == "session.create")
+    submit = next(params for method, params in calls if method == "prompt.submit")
+    assert create["hidden"] is True
+    assert create["close_on_disconnect"] is False
+    assert submit["_hosted_task"] == {
+        "room_id": "room",
+        "task_id": "task",
+        "thread_id": "thread",
+        "turn_id": "turn",
+        "execution_generation": 2,
+    }
+    assert submit["_hosted_terminal_callback"] is callback
+
+
+def test_info_and_interrupt_are_exact_task_scoped():
+    server, calls = _server()
+    lock = threading.Lock()
+    server._sessions["runtime"] = {
+        "history_lock": lock,
+        "running": True,
+        "_hosted_room_task": {"task_id": "task-a"},
+    }
+    rpc = HostedRoomServerRPC(server)
+
+    assert rpc.info(profile="ops", session_id="runtime", source="bot_room") == {
+        "active": True,
+        "task_id": "task-a",
+    }
+    rpc.interrupt(
+        profile="ops",
+        session_id="runtime",
+        source="bot_room",
+        expected_task_id="task-a",
+    )
+    params = next(params for method, params in calls if method == "session.interrupt")
+    assert params["expected_hosted_task_id"] == "task-a"
+
+
+def test_local_approval_snapshot_and_response_use_exact_request():
+    server, calls = _server()
+    server._pending_approval_request_payload = lambda session_key: {
+        "request_id": "approval-1",
+        "command": "pytest -q tests/focused",
+        "choices": ["once", "deny"],
+    } if session_key == "stored-session" else None
+    server._sessions["runtime"] = {
+        "history_lock": threading.Lock(),
+        "running": True,
+        "session_key": "stored-session",
+        "_hosted_room_task": {"task_id": "task-a"},
+    }
+    rpc = HostedRoomServerRPC(server)
+
+    info = rpc.info(profile="ops", session_id="runtime", source="bot_room")
+    assert info["status"] == "waiting_for_approval"
+    assert info["pending_approval"]["request_id"] == "approval-1"
+    assert rpc.approve(
+        session_id="runtime",
+        request_id="approval-1",
+        choice="once",
+    ) == {"resolved": 1}
+    params = next(params for method, params in calls if method == "approval.respond")
+    assert params == {
+        "session_id": "runtime",
+        "request_id": "approval-1",
+        "choice": "once",
+        "all": False,
+    }
+
+
+def test_rpc_errors_are_typed():
+    server, _calls = _server()
+    server._methods["session.list"] = lambda rid, _params: {
+        "id": rid,
+        "error": {"code": 4007, "message": "not found"},
+    }
+    rpc = HostedRoomServerRPC(server)
+
+    with pytest.raises(HostedRoomSessionError) as exc:
+        rpc.resolve_exact(profile="ops", title="Group: room", source="bot_room")
+    assert exc.value.code == 4007

--- a/tests/tui_gateway/test_hosted_room_server_rpc.py
+++ b/tests/tui_gateway/test_hosted_room_server_rpc.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import base64
 import threading
 from types import SimpleNamespace
 
@@ -15,7 +16,12 @@ from tui_gateway.hosted_room_server_rpc import (
 
 
 def _server():
-    sessions = {}
+    sessions = {
+        "runtime": {
+            "history_lock": threading.Lock(),
+            "attached_images": [],
+        }
+    }
     calls = []
 
     def method(name, result):
@@ -37,6 +43,14 @@ def _server():
         "session.interrupt": method("session.interrupt", {"result": {"interrupted": True}}),
         "approval.respond": method("approval.respond", {"result": {"resolved": 1}}),
         "prompt.submit": method("prompt.submit", {"result": {"status": "streaming"}}),
+        "image.attach_bytes": method(
+            "image.attach_bytes", {"result": {"attached": True}}
+        ),
+        "pdf.attach": method("pdf.attach", {"result": {"attached": True}}),
+        "file.attach": method(
+            "file.attach",
+            {"result": {"attached": True, "ref_text": "@file:attachments/notes.txt"}},
+        ),
     }
     server = SimpleNamespace(
         _methods=methods,
@@ -146,3 +160,188 @@ def test_rpc_errors_are_typed():
     with pytest.raises(HostedRoomSessionError) as exc:
         rpc.resolve_exact(profile="ops", title="Group: room", source="bot_room")
     assert exc.value.code == 4007
+
+
+@pytest.mark.parametrize(
+    ("kind", "name", "mime", "method"),
+    [
+        ("image", "diagram.png", "image/png", "image.attach_bytes"),
+        ("pdf", "brief.pdf", "application/pdf", "pdf.attach"),
+        ("file", "notes.txt", "text/plain", "file.attach"),
+    ],
+)
+def test_attachment_staging_uses_existing_attach_rpcs_and_deduplicates_attempt(
+    kind, name, mime, method
+):
+    server, calls = _server()
+    rpc = HostedRoomServerRPC(server)
+    attachment = {
+        "attachment_id": f"att_{'1' * 32}",
+        "kind": kind,
+        "name": name,
+        "size": 5,
+        "mime": mime,
+    }
+
+    first = rpc.stage_attachment(
+        profile="ops",
+        session_id="runtime",
+        source="bot_room",
+        attachment=attachment,
+        data=b"bytes",
+        execution_generation=1,
+    )
+    repeated = rpc.stage_attachment(
+        profile="ops",
+        session_id="runtime",
+        source="bot_room",
+        attachment=attachment,
+        data=b"bytes",
+        execution_generation=1,
+    )
+    rpc.stage_attachment(
+        profile="ops",
+        session_id="runtime",
+        source="bot_room",
+        attachment=attachment,
+        data=b"bytes",
+        execution_generation=2,
+    )
+
+    assert first == repeated
+    matching = [params for called, params in calls if called == method]
+    assert len(matching) == 2
+    if kind == "file":
+        assert matching[0]["data_url"] == (
+            f"data:{mime};base64,{base64.b64encode(b'bytes').decode('ascii')}"
+        )
+    else:
+        assert matching[0]["content_base64"] == base64.b64encode(b"bytes").decode(
+            "ascii"
+        )
+
+
+def test_attachment_staging_rollback_restores_pending_images_and_clears_cache():
+    server, calls = _server()
+    session = server._sessions["runtime"]
+
+    def attach_image(rid, params):
+        calls.append(("image.attach_bytes", params))
+        session["attached_images"].append("/images/diagram.png")
+        return {
+            "id": rid,
+            "result": {
+                "attached": True,
+                "path": "/images/diagram.png",
+            },
+        }
+
+    def fail_pdf_after_partial_mutation(rid, params):
+        calls.append(("pdf.attach", params))
+        session["attached_images"].append("/images/brief-page-1.png")
+        return {
+            "id": rid,
+            "error": {"code": 5028, "message": "second attachment failed"},
+        }
+
+    server._methods["image.attach_bytes"] = attach_image
+    server._methods["pdf.attach"] = fail_pdf_after_partial_mutation
+    rpc = HostedRoomServerRPC(server)
+    image = {
+        "attachment_id": f"att_{'1' * 32}",
+        "kind": "image",
+        "name": "diagram.png",
+        "mime": "image/png",
+    }
+    pdf = {
+        "attachment_id": f"att_{'2' * 32}",
+        "kind": "pdf",
+        "name": "brief.pdf",
+        "mime": "application/pdf",
+    }
+
+    rpc.stage_attachment(
+        profile="ops",
+        session_id="runtime",
+        source="bot_room",
+        attachment=image,
+        data=b"image",
+        execution_generation=7,
+    )
+    with pytest.raises(HostedRoomSessionError, match="second attachment failed"):
+        rpc.stage_attachment(
+            profile="ops",
+            session_id="runtime",
+            source="bot_room",
+            attachment=pdf,
+            data=b"pdf",
+            execution_generation=7,
+        )
+
+    assert session["attached_images"] == [
+        "/images/diagram.png",
+        "/images/brief-page-1.png",
+    ]
+    rpc.rollback_attachment_staging(
+        profile="ops",
+        session_id="runtime",
+        source="bot_room",
+        execution_generation=7,
+    )
+    assert session["attached_images"] == []
+
+    rpc.stage_attachment(
+        profile="ops",
+        session_id="runtime",
+        source="bot_room",
+        attachment=image,
+        data=b"image",
+        execution_generation=7,
+    )
+    assert len([called for called, _params in calls if called == "image.attach_bytes"]) == 2
+
+
+def test_attachment_staging_rollback_deletes_only_attempt_uploaded_files(tmp_path):
+    server, calls = _server()
+    attachment_dir = tmp_path / "attachments"
+    attachment_dir.mkdir()
+    uploaded = attachment_dir / "notes.txt"
+    uploaded.write_text("release notes", encoding="utf-8")
+    preserved = attachment_dir / "existing.txt"
+    preserved.write_text("keep", encoding="utf-8")
+    server._desktop_attachment_dir = lambda _session: attachment_dir
+    server._methods["file.attach"] = lambda rid, params: {
+        "id": rid,
+        "result": {
+            "attached": True,
+            "path": str(uploaded),
+            "ref_text": "@file:attachments/notes.txt",
+            "uploaded": True,
+        },
+    }
+    rpc = HostedRoomServerRPC(server)
+    attachment = {
+        "attachment_id": f"att_{'3' * 32}",
+        "kind": "file",
+        "name": "notes.txt",
+        "mime": "text/plain",
+    }
+
+    rpc.stage_attachment(
+        profile="ops",
+        session_id="runtime",
+        source="bot_room",
+        attachment=attachment,
+        data=b"release notes",
+        execution_generation=9,
+    )
+    rpc.rollback_attachment_staging(
+        profile="ops",
+        session_id="runtime",
+        source="bot_room",
+        execution_generation=9,
+    )
+
+    assert not uploaded.exists()
+    assert preserved.read_text(encoding="utf-8") == "keep"
+    assert any(method == "file.attach" for method, _params in calls) is False

--- a/tests/tui_gateway/test_hosted_room_service.py
+++ b/tests/tui_gateway/test_hosted_room_service.py
@@ -161,3 +161,35 @@ def test_restart_republishes_terminal_task_before_admitting_more(tmp_path: Path)
     replayed = service._events("room-1")
     assert replayed == events
 
+
+def test_stop_fence_prevents_the_next_room_member_from_starting(
+    tmp_path: Path, monkeypatch
+):
+    db = tmp_path / "state.db"
+    service = HostedRoomService(_server(), db_path=db)
+    monkeypatch.setattr(service, "local_profiles", lambda: ("default", "ops"))
+    service.create_room(
+        room_id="room-1",
+        name="Release room",
+        members=[
+            {"member_id": "default", "profile": "default", "handle": "hermes"},
+            {"member_id": "ops", "profile": "ops", "handle": "ops"},
+        ],
+    )
+    service.send(
+        room_id="room-1",
+        event_id="user-1",
+        payload={"text": "Inspect the release", "thread_id": "thread-1"},
+    )
+    assert len(driver.list_tasks(db, room_id="room-1")) == 1
+
+    assert service.stop_room("room-1", cancel_id="stop-1") == 1
+    service.prepare_room(service.bindings()[0])
+
+    tasks = driver.list_tasks(db, room_id="room-1")
+    assert len(tasks) == 1
+    assert tasks[0]["status"] == "cancelled"
+    assert any(
+        event["kind"] == "room.stop_requested"
+        for event in service._events("room-1")
+    )

--- a/tests/tui_gateway/test_hosted_room_service.py
+++ b/tests/tui_gateway/test_hosted_room_service.py
@@ -1,0 +1,163 @@
+"""Integration tests for the hosted Discussion coordinator."""
+
+from __future__ import annotations
+
+import threading
+import time
+from pathlib import Path
+from types import SimpleNamespace
+
+from gateway import hosted_room_driver as driver
+from gateway import hosted_rooms
+from tui_gateway.hosted_room_service import HostedRoomService
+
+
+class _FakeRPC:
+    def __init__(self) -> None:
+        self.sessions = {}
+
+    def resolve_exact(self, *, profile, title, source):
+        return self.sessions.get((profile, title))
+
+    def create(self, *, profile, title, source):
+        session = {"session_id": f"{profile}-session", "title": title}
+        self.sessions[(profile, title)] = session
+        return session
+
+    def resume(self, *, profile, session_id, source):
+        return {"session_id": session_id}
+
+    def submit(
+        self,
+        *,
+        profile,
+        session_id,
+        prompt,
+        source,
+        task,
+        execution_generation,
+        on_terminal,
+    ):
+        on_terminal({"status": "settled", "text": f"reply from {profile}"})
+        return {"accepted": True}
+
+    def history(self, *, profile, session_id, source):
+        return []
+
+    def info(self, *, profile, session_id, source):
+        return {"active": False, "task_id": None}
+
+    def interrupt(self, *, profile, session_id, source, expected_task_id):
+        return {"interrupted": True}
+
+
+def _server():
+    return SimpleNamespace(_methods={}, _sessions={}, _sessions_lock=threading.Lock())
+
+
+def _wait_for(predicate, timeout=2.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(0.01)
+    raise AssertionError("condition was not reached")
+
+
+def test_create_send_drive_publish_and_replay_without_client_transport(tmp_path: Path):
+    db = tmp_path / "state.db"
+    service = HostedRoomService(_server(), db_path=db)
+    service.rpc = _FakeRPC()
+    service.runtime.rpc = service.rpc
+    service.local_profiles = lambda: ("default", "ops")
+    room = service.create_room(
+        room_id="room-1",
+        name="Release room",
+        members=[
+            {"member_id": "default", "profile": "default", "handle": "hermes"},
+            {"member_id": "ops", "profile": "ops", "handle": "ops"},
+        ],
+    )
+    assert room["room_id"] == "room-1"
+
+    service.start()
+    service.send(
+        room_id="room-1",
+        event_id="user-1",
+        payload={"text": "@ops inspect the release", "thread_id": "thread-1"},
+    )
+    _wait_for(
+        lambda: any(
+            event["kind"] == "message.member"
+            for event in service._events("room-1")
+        )
+    )
+    assert service.stop(timeout=1.0)
+
+    events = service._events("room-1")
+    assert [event["kind"] for event in events][:3] == [
+        "message.user",
+        "message.member",
+        "turn.settled",
+    ]
+    assert events[1]["payload"]["text"] == "reply from ops"
+    assert service.status("room-1")["working"] is False
+
+
+def test_restart_republishes_terminal_task_before_admitting_more(tmp_path: Path):
+    db = tmp_path / "state.db"
+    service = HostedRoomService(_server(), db_path=db)
+    service.local_profiles = lambda: ("default", "ops")
+    service.create_room(
+        room_id="room-1",
+        name="Release room",
+        members=[
+            {"member_id": "default", "profile": "default", "handle": "hermes"},
+            {"member_id": "ops", "profile": "ops", "handle": "ops"},
+        ],
+    )
+    event = hosted_rooms.append_event(
+        db,
+        room_id="room-1",
+        event_id="user-1",
+        kind="message.user",
+        actor={"kind": "user", "id": "desktop"},
+        payload={"text": "@ops inspect", "thread_id": "thread-1"},
+    )
+    binding = service.bindings()[0]
+    service.prepare_room(binding)
+    task = driver.list_tasks(db, room_id="room-1", status="queued")[0]
+    lease = driver.acquire_lease(
+        db,
+        room_id="room-1",
+        gateway_id=binding.gateway_id,
+        authority_epoch=binding.authority_epoch,
+        process_generation="crashed",
+        ttl_seconds=30,
+        clock=time.time,
+    )
+    attempt = driver.start_task(
+        db,
+        task["identity"],
+        lease,
+        expected_cancel_generation=0,
+        clock=time.time,
+    )
+    driver.settle_task(
+        db,
+        attempt,
+        settlement_id="reply-1",
+        status="settled",
+        result={"text": "done"},
+        clock=time.time,
+    )
+
+    service.prepare_room(binding)
+    events = service._events("room-1")
+    assert event["seq"] == 1
+    assert sum(row["kind"] == "message.member" for row in events) == 1
+    assert sum(row["kind"] == "turn.settled" for row in events) == 1
+    service.prepare_room(binding)
+    replayed = service._events("room-1")
+    assert replayed == events
+

--- a/tests/tui_gateway/test_hosted_room_service.py
+++ b/tests/tui_gateway/test_hosted_room_service.py
@@ -15,6 +15,8 @@ from tui_gateway.hosted_room_service import HostedRoomService
 class _FakeRPC:
     def __init__(self) -> None:
         self.sessions = {}
+        self.calls = []
+        self.fail_attachment_profiles = set()
 
     def resolve_exact(self, *, profile, title, source):
         return self.sessions.get((profile, title))
@@ -38,8 +40,63 @@ class _FakeRPC:
         execution_generation,
         on_terminal,
     ):
+        self.calls.append(("submit", {"profile": profile, "prompt": prompt}))
         on_terminal({"status": "settled", "text": f"reply from {profile}"})
         return {"accepted": True}
+
+    def stage_attachment(
+        self,
+        *,
+        profile,
+        session_id,
+        source,
+        attachment,
+        data,
+        execution_generation,
+    ):
+        self.calls.append((
+            "stage_attachment",
+            {
+                "profile": profile,
+                "attachment": dict(attachment),
+                "data": data,
+                "execution_generation": execution_generation,
+            },
+        ))
+        if profile in self.fail_attachment_profiles:
+            raise RuntimeError("attachment staging unavailable")
+        return {
+            "attached": True,
+            **(
+                {"ref_text": f"@file:attachments/{attachment['name']}"}
+                if attachment["kind"] == "file"
+                else {}
+            ),
+        }
+
+    def begin_attachment_staging(
+        self, *, profile, session_id, source, execution_generation
+    ):
+        self.calls.append((
+            "begin_attachment_staging",
+            {"profile": profile, "execution_generation": execution_generation},
+        ))
+
+    def commit_attachment_staging(
+        self, *, profile, session_id, source, execution_generation
+    ):
+        self.calls.append((
+            "commit_attachment_staging",
+            {"profile": profile, "execution_generation": execution_generation},
+        ))
+
+    def rollback_attachment_staging(
+        self, *, profile, session_id, source, execution_generation
+    ):
+        self.calls.append((
+            "rollback_attachment_staging",
+            {"profile": profile, "execution_generation": execution_generation},
+        ))
 
     def history(self, *, profile, session_id, source):
         return []
@@ -102,6 +159,135 @@ def test_create_send_drive_publish_and_replay_without_client_transport(tmp_path:
     ]
     assert events[1]["payload"]["text"] == "reply from ops"
     assert service.status("room-1")["working"] is False
+
+
+def test_attachment_send_freezes_roster_stages_bytes_and_logs_metadata_only(
+    tmp_path: Path,
+):
+    db = tmp_path / "state.db"
+    service = HostedRoomService(_server(), db_path=db)
+    rpc = _FakeRPC()
+    service.rpc = rpc
+    service.runtime.rpc = rpc
+    service.local_profiles = lambda: ("default", "ops")
+    service.create_room(
+        room_id="room-1",
+        name="Release room",
+        members=[
+            {"member_id": "default", "profile": "default", "handle": "hermes"},
+            {"member_id": "ops", "profile": "ops", "handle": "ops"},
+        ],
+    )
+    stored = service.put_attachment(
+        room_id="room-1",
+        upload_id="upload-1",
+        kind="image",
+        name="diagram.png",
+        mime="image/png",
+        data=b"\x89PNG\r\n\x1a\nimage",
+    )
+    manifest = {
+        key: stored[key]
+        for key in ("attachment_id", "kind", "name", "size", "mime")
+    }
+
+    service.start()
+    service.send(
+        room_id="room-1",
+        event_id="user-attachment-1",
+        payload={
+            "text": "@ops inspect",
+            "thread_id": "thread-1",
+            "attachments": [manifest],
+        },
+    )
+    _wait_for(lambda: any(method == "stage_attachment" for method, _ in rpc.calls))
+    _wait_for(
+        lambda: any(
+            event["kind"] == "message.member" for event in service._events("room-1")
+        )
+    )
+    assert service.stop(timeout=1.0)
+
+    stage_index = next(index for index, call in enumerate(rpc.calls) if call[0] == "stage_attachment")
+    submit_index = next(index for index, call in enumerate(rpc.calls) if call[0] == "submit")
+    assert stage_index < submit_index
+    assert rpc.calls[stage_index][1]["data"] == b"\x89PNG\r\n\x1a\nimage"
+    user_event = service._events("room-1")[0]
+    assert user_event["payload"]["attachments"] == [manifest]
+    assert "PNG" not in repr(user_event)
+    assert "base64" not in repr(user_event)
+    try:
+        service.read_attachment(
+            room_id="room-1",
+            attachment_id=stored["attachment_id"],
+            recipient_member_id="late-member",
+        )
+    except ValueError:
+        pass
+    else:  # pragma: no cover - ownership must fail closed
+        raise AssertionError("late member unexpectedly received historic attachment")
+
+
+def test_partial_attachment_failure_never_submits_text_only_and_other_member_continues(
+    tmp_path: Path,
+):
+    db = tmp_path / "state.db"
+    service = HostedRoomService(_server(), db_path=db)
+    rpc = _FakeRPC()
+    rpc.fail_attachment_profiles.add("default")
+    service.rpc = rpc
+    service.runtime.rpc = rpc
+    service.local_profiles = lambda: ("default", "ops")
+    service.create_room(
+        room_id="room-1",
+        name="Release room",
+        members=[
+            {"member_id": "default", "profile": "default", "handle": "hermes"},
+            {"member_id": "ops", "profile": "ops", "handle": "ops"},
+        ],
+    )
+    stored = service.put_attachment(
+        room_id="room-1",
+        upload_id="upload-1",
+        kind="file",
+        name="notes.txt",
+        mime="text/plain",
+        data=b"release notes",
+    )
+    manifest = {
+        key: stored[key]
+        for key in ("attachment_id", "kind", "name", "size", "mime")
+    }
+
+    service.start()
+    service.send(
+        room_id="room-1",
+        event_id="user-attachment-1",
+        payload={
+            "text": "Inspect this",
+            "thread_id": "thread-1",
+            "attachments": [manifest],
+        },
+    )
+    _wait_for(
+        lambda: any(
+            event["kind"] == "message.member" for event in service._events("room-1")
+        )
+    )
+    assert service.stop(timeout=1.0)
+
+    events = service._events("room-1")
+    failed = next(event for event in events if event["kind"] == "turn.failed")
+    assert failed["payload"]["member_id"] == "default"
+    assert any(
+        event["kind"] == "message.member" and event["payload"]["member_id"] == "ops"
+        for event in events
+    )
+    assert not any(
+        method == "submit" and params["profile"] == "default"
+        for method, params in rpc.calls
+    )
 
 
 def test_restart_republishes_terminal_task_before_admitting_more(tmp_path: Path):

--- a/tui_gateway/hosted_room_driver.py
+++ b/tui_gateway/hosted_room_driver.py
@@ -1,0 +1,1033 @@
+"""Runtime adapter for gateway-owned hosted room turns.
+
+The durable state machine lives in :mod:`gateway.hosted_room_driver`.  This
+module owns the process-local worker and a deliberately small, injected session
+adapter.  It does not import the gateway server, construct agents, or depend on
+any client transport.
+
+The adapter normalizes existing internal session RPCs into seven methods. A
+future server integration can implement those methods with the in-process
+handlers while tests use deterministic fakes and no models or network.
+
+One worker serializes rooms deliberately in this first slice. That keeps lease
+and recovery behavior auditable; per-room workers are a later scalability
+change, not an implicit guarantee here. Hosted member sessions intentionally
+reuse ``Group: <room_id>`` so a local-to-hosted migration preserves the same
+canonical transcript instead of forking a second conversation.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import threading
+import time
+import uuid
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, ContextManager, Protocol, cast
+
+from gateway import hosted_room_driver as state
+
+
+ROOM_SESSION_SOURCE = "bot_room"
+
+
+class InternalSessionRPC(Protocol):
+    """Normalized in-process session operations required by the room driver."""
+
+    def resolve_exact(
+        self, *, profile: str, title: str, source: str
+    ) -> Mapping[str, Any] | None:
+        """Return the exact titled session under ``profile``, if it exists."""
+
+    def create(self, *, profile: str, title: str, source: str) -> Mapping[str, Any]:
+        """Create a session without model or provider overrides."""
+
+    def resume(
+        self, *, profile: str, session_id: str, source: str
+    ) -> Mapping[str, Any]:
+        """Resume the canonical room session."""
+
+    def submit(
+        self,
+        *,
+        profile: str,
+        session_id: str,
+        prompt: str,
+        source: str,
+        task: state.TaskIdentity,
+        execution_generation: int,
+        on_terminal: Callable[[Mapping[str, Any]], None],
+    ) -> Mapping[str, Any]:
+        """Submit one fenced room turn and durably report its terminal result."""
+
+    def history(
+        self, *, profile: str, session_id: str, source: str
+    ) -> Sequence[Mapping[str, Any]]:
+        """Return normalized session messages in durable order."""
+
+    def info(self, *, profile: str, session_id: str, source: str) -> Mapping[str, Any]:
+        """Return normalized live status for a session."""
+
+    def interrupt(
+        self,
+        *,
+        profile: str,
+        session_id: str,
+        source: str,
+        expected_task_id: str,
+    ) -> Mapping[str, Any] | None:
+        """Interrupt only when the current turn still matches the expected task."""
+
+
+class MemberTransportResolver(Protocol):
+    """Resolve the session transport for one durable room task."""
+
+    def __call__(
+        self,
+        binding: "HostedRoomBinding",
+        task: Mapping[str, Any],
+    ) -> InternalSessionRPC:
+        """Return a local or peer transport without changing task identity."""
+
+
+@dataclass(frozen=True)
+class HostedRoomBinding:
+    """Current server-issued authority coordinate for one hosted room."""
+
+    room_id: str
+    gateway_id: str
+    authority_epoch: int
+
+
+@dataclass(frozen=True)
+class _TerminalReceipt:
+    status: state.TerminalStatus
+    settlement_id: str
+    result: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class _RecoveryInspection:
+    terminal: _TerminalReceipt | None
+    active: bool
+
+
+class HostedRoomRuntime:
+    """Run queued hosted-room tasks independently of Desktop connections."""
+
+    def __init__(
+        self,
+        *,
+        db_path: Path | str,
+        rooms: Iterable[HostedRoomBinding] | Callable[[], Iterable[HostedRoomBinding]],
+        turn_lock: Callable[[str], ContextManager[Any]],
+        rpc: InternalSessionRPC | None = None,
+        transport_resolver: MemberTransportResolver | None = None,
+        prepare_room: Callable[[HostedRoomBinding], None] | None = None,
+        publish_terminal: Callable[[HostedRoomBinding, Mapping[str, Any]], None]
+        | None = None,
+        pending_action: Callable[
+            [str, str, Mapping[str, Any] | None], None
+        ]
+        | None = None,
+        clock: Callable[[], float] = time.time,
+        lease_ttl_seconds: float = 30.0,
+        poll_interval_seconds: float = 0.1,
+        process_generation: str | None = None,
+    ) -> None:
+        if lease_ttl_seconds <= 0:
+            raise ValueError("lease_ttl_seconds must be positive")
+        if poll_interval_seconds <= 0:
+            raise ValueError("poll_interval_seconds must be positive")
+        if rpc is None and transport_resolver is None:
+            raise ValueError("rpc or transport_resolver is required")
+
+        self.db_path = Path(db_path)
+        self.rpc = rpc
+        self.transport_resolver = transport_resolver
+        self.turn_lock = turn_lock
+        self.prepare_room = prepare_room
+        self.publish_terminal = publish_terminal
+        self.pending_action = pending_action
+        self.clock = clock
+        self.lease_ttl_seconds = float(lease_ttl_seconds)
+        self.poll_interval_seconds = float(poll_interval_seconds)
+        self.process_generation = process_generation or uuid.uuid4().hex
+        self._rooms_provider: Callable[[], Iterable[HostedRoomBinding]]
+        if callable(rooms):
+            self._rooms_provider = cast(
+                Callable[[], Iterable[HostedRoomBinding]], rooms
+            )
+        else:
+            room_bindings = tuple(rooms)
+            self._rooms_provider = lambda: room_bindings
+
+        self._stop = threading.Event()
+        self._wake = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._leases: dict[str, state.DriverLease] = {}
+        self._recovered_leases: set[tuple[str, int]] = set()
+        self._ambiguous_rooms: dict[str, float] = {}
+        self._blocked_rooms: set[str] = set()
+        self._status_lock = threading.Lock()
+        self._current_task: state.TaskIdentity | None = None
+        self._last_error: str | None = None
+        self._cycles = 0
+
+    def start(self) -> None:
+        """Start the single dedicated worker thread idempotently."""
+        with self._status_lock:
+            if self._thread is not None and self._thread.is_alive():
+                return
+            self._stop.clear()
+            self._wake.set()
+            self._thread = threading.Thread(
+                target=self._worker_loop,
+                name="hosted-room-driver",
+                daemon=True,
+            )
+            self._thread.start()
+
+    def stop(self, *, timeout: float = 5.0) -> bool:
+        """Request a bounded clean stop without interrupting accepted turns."""
+        self._stop.set()
+        self._wake.set()
+        with self._status_lock:
+            thread = self._thread
+        if thread is None:
+            return True
+        thread.join(max(0.0, timeout))
+        return not thread.is_alive()
+
+    def wakeup(self) -> None:
+        """Wake the worker after task admission or a room-state change."""
+        self._wake.set()
+
+    def status(self) -> dict[str, Any]:
+        """Return a transport-neutral snapshot of runtime health."""
+        with self._status_lock:
+            thread = self._thread
+            current = self._current_task
+            return {
+                "running": bool(thread and thread.is_alive()),
+                "stopping": self._stop.is_set(),
+                "process_generation": self.process_generation,
+                "current_task": current,
+                "leased_rooms": tuple(sorted(self._leases)),
+                "blocked_rooms": tuple(sorted(self._blocked_rooms)),
+                "last_error": self._last_error,
+                "cycles": self._cycles,
+            }
+
+    def cancel(
+        self,
+        identity: state.TaskIdentity,
+        *,
+        cancel_id: str,
+    ) -> dict[str, Any]:
+        """Persist a stop intent, then commit cancellation after acknowledgement."""
+        before = state.get_task(self.db_path, identity)
+        if before["status"] == "queued":
+            cancelled = state.cancel_task(
+                self.db_path,
+                identity,
+                cancel_id=cancel_id,
+                expected_cancel_generation=before["cancel_generation"],
+                clock=self.clock,
+            )
+            self.wakeup()
+            return cancelled
+
+        stopping = state.begin_task_cancel(
+            self.db_path,
+            identity,
+            cancel_id=cancel_id,
+            expected_cancel_generation=before["cancel_generation"],
+            clock=self.clock,
+        )
+        binding = self._binding_for_room(identity.room_id)
+        try:
+            if binding is not None and self._interrupt_stopping_task(binding, stopping):
+                stopping = state.complete_task_cancel(
+                    self.db_path,
+                    identity,
+                    cancel_id=cancel_id,
+                    expected_cancel_generation=stopping["cancel_generation"],
+                    clock=self.clock,
+                )
+        except Exception as exc:
+            self._record_error(f"stop remains pending: {exc}")
+        stopping = state.get_task(self.db_path, identity)
+        self.wakeup()
+        return stopping
+
+    def retry_indeterminate(self, identity: state.TaskIdentity) -> dict[str, Any]:
+        """Explicitly retry one uncertain attempt under the current room lease."""
+        task = state.get_task(self.db_path, identity)
+        if task["status"] != "indeterminate":
+            raise state.InvalidTaskTransitionError(
+                f"cannot retry task in state '{task['status']}'"
+            )
+        binding = self._binding_for_room(identity.room_id)
+        if binding is None:
+            raise state.RoomUnavailableError("hosted room is unavailable")
+        lease = self._ensure_lease(binding)
+        retried = state.requeue_indeterminate_task(
+            self.db_path,
+            identity,
+            lease,
+            expected_execution_generation=task["execution_generation"],
+            expected_cancel_generation=task["cancel_generation"],
+            clock=self.clock,
+        )
+        with self._status_lock:
+            self._blocked_rooms.discard(identity.room_id)
+        self.wakeup()
+        return retried
+
+    def _interrupt_stopping_task(
+        self,
+        binding: HostedRoomBinding,
+        task: Mapping[str, Any],
+    ) -> bool:
+        transport = self._transport_for(binding, task)
+        if transport is None:
+            return False
+        profile = task["payload"]["target_profile"]
+        session = transport.resolve_exact(
+            profile=profile,
+            title=room_session_title(binding.room_id),
+            source=ROOM_SESSION_SOURCE,
+        )
+        if session is None:
+            # A local accepted turn cannot survive without its canonical
+            # session. Resolution errors raise; an authoritative absence is a
+            # safe Stop acknowledgement. A peer remains uncertain instead.
+            return transport is self.rpc
+        resumed = transport.resume(
+            profile=profile,
+            session_id=_session_id(session),
+            source=ROOM_SESSION_SOURCE,
+        )
+        session_id = _session_id(resumed)
+        info = transport.info(
+            profile=profile,
+            session_id=session_id,
+            source=ROOM_SESSION_SOURCE,
+        )
+        active = bool(info.get("active", info.get("running", False)))
+        if not active:
+            # History was checked immediately before this probe. An exact
+            # local session that is no longer active cannot keep executing, and
+            # after a restart its process-local task marker is expected to be
+            # absent. A peer transport never gets this shortcut: an unreachable
+            # remote run stays uncertain until its own durable status acks Stop.
+            if transport is self.rpc:
+                return True
+            return False
+        if not _info_is_active_for(info, task["identity"], require_exact=True):
+            return False
+        result = transport.interrupt(
+            profile=profile,
+            session_id=session_id,
+            source=ROOM_SESSION_SOURCE,
+            expected_task_id=task["identity"].task_id,
+        )
+        if result is None:
+            return False
+        return result.get("interrupted") is True or str(result.get("status") or "") in {
+            "cancelled",
+            "interrupted",
+            "stopping",
+        }
+
+    def _settle_stopping_completion(
+        self,
+        binding: HostedRoomBinding,
+        task: Mapping[str, Any],
+        lease: state.DriverLease,
+    ) -> bool:
+        """Publish a terminal receipt that arrived before Stop was acknowledged."""
+        transport = self._transport_for(binding, task)
+        if transport is None:
+            return False
+        profile = task["payload"]["target_profile"]
+        session = transport.resolve_exact(
+            profile=profile,
+            title=room_session_title(binding.room_id),
+            source=ROOM_SESSION_SOURCE,
+        )
+        if session is None:
+            return False
+        resumed = transport.resume(
+            profile=profile,
+            session_id=_session_id(session),
+            source=ROOM_SESSION_SOURCE,
+        )
+        receipt = _find_terminal_receipt(
+            transport.history(
+                profile=profile,
+                session_id=_session_id(resumed),
+                source=ROOM_SESSION_SOURCE,
+            ),
+            task["identity"],
+            int(task["execution_generation"]),
+        )
+        if receipt is None:
+            return False
+        settled = state.settle_stopping_task(
+            self.db_path,
+            task["identity"],
+            lease,
+            expected_execution_generation=int(task["execution_generation"]),
+            expected_cancel_generation=int(task["cancel_generation"]),
+            settlement_id=receipt.settlement_id,
+            status=receipt.status,
+            result=receipt.result,
+            clock=self.clock,
+        )
+        if self.publish_terminal is not None:
+            self.publish_terminal(binding, settled)
+        return True
+
+    def _report_pending_action(
+        self,
+        task: Mapping[str, Any],
+        *,
+        session_id: str,
+        info: Mapping[str, Any],
+    ) -> None:
+        if self.pending_action is None:
+            return
+        payload = task.get("payload") or {}
+        member_id = str(
+            payload.get("target_member_id") or payload.get("target_profile") or ""
+        )
+        approval = info.get("pending_approval") or info.get("approval")
+        action = None
+        if isinstance(approval, Mapping):
+            safe_approval = dict(approval)
+            choices = [
+                choice
+                for choice in safe_approval.get("choices") or ()
+                if choice in {"once", "deny"}
+            ]
+            safe_approval["choices"] = choices or ["once", "deny"]
+            action = {
+                "kind": "approval",
+                "task_id": task["identity"].task_id,
+                "execution_generation": int(task["execution_generation"]),
+                "run_id": info.get("run_id"),
+                "session_id": session_id,
+                "request_id": safe_approval.get("request_id"),
+                "approval": safe_approval,
+            }
+        self.pending_action(task["identity"].room_id, member_id, action)
+
+    def _retry_stopping_tasks(
+        self, binding: HostedRoomBinding, lease: state.DriverLease
+    ) -> bool:
+        pending = state.list_tasks(
+            self.db_path,
+            room_id=binding.room_id,
+            status="stopping",
+        )
+        for task in pending:
+            try:
+                lease = self._renew_lease_if_needed(binding, lease)
+                if self._settle_stopping_completion(binding, task, lease):
+                    continue
+                if not self._interrupt_stopping_task(binding, task):
+                    return True
+                state.complete_task_cancel(
+                    self.db_path,
+                    task["identity"],
+                    cancel_id=task["cancel_id"],
+                    expected_cancel_generation=task["cancel_generation"],
+                    clock=self.clock,
+                )
+            except Exception as exc:
+                self._record_error(f"stop retry remains pending: {exc}")
+                return True
+        return False
+
+    def _worker_loop(self) -> None:
+        try:
+            while not self._stop.is_set():
+                try:
+                    self._run_cycle()
+                except Exception as exc:  # keep independent rooms serviceable
+                    self._record_error(f"worker cycle failed: {exc}")
+                with self._status_lock:
+                    self._cycles += 1
+                self._wake.wait(self.poll_interval_seconds)
+                self._wake.clear()
+        finally:
+            self._release_idle_leases()
+
+    def _run_cycle(self) -> None:
+        for binding in tuple(self._rooms_provider()):
+            if self._stop.is_set():
+                return
+            try:
+                self._process_room(binding)
+            except state.LeaseHeldError:
+                continue
+            except (state.RoomUnavailableError, state.StaleLeaseError) as exc:
+                self._drop_lease(binding.room_id)
+                with self._status_lock:
+                    self._blocked_rooms.discard(binding.room_id)
+                self._record_error(f"room {binding.room_id}: {exc}")
+            except Exception as exc:
+                self._record_error(f"room {binding.room_id}: {exc}")
+
+    def _process_room(self, binding: HostedRoomBinding) -> None:
+        if self.prepare_room is not None:
+            self.prepare_room(binding)
+        self._inspect_abandoned_attempts(binding)
+        deferred_until = self._ambiguous_rooms.get(binding.room_id)
+        if deferred_until is not None:
+            running = state.list_tasks(
+                self.db_path,
+                room_id=binding.room_id,
+                status="running",
+            )
+            if not running:
+                self._ambiguous_rooms.pop(binding.room_id, None)
+            elif self.clock() < deferred_until:
+                return
+            else:
+                self._ambiguous_rooms.pop(binding.room_id, None)
+        lease = self._ensure_lease(binding)
+        recovery_key = (lease.room_id, lease.lease_generation)
+        if recovery_key not in self._recovered_leases:
+            state.recover_room(self.db_path, lease, clock=self.clock)
+            self._recovered_leases.add(recovery_key)
+        if self._retry_stopping_tasks(binding, lease):
+            with self._status_lock:
+                self._blocked_rooms.add(binding.room_id)
+            return
+        if self._reconcile_indeterminate(binding, lease):
+            return
+
+        queued = state.list_tasks(
+            self.db_path,
+            room_id=binding.room_id,
+            status="queued",
+        )
+        for task in queued:
+            if self._stop.is_set():
+                return
+            lease = self._renew_lease_if_needed(binding, lease)
+            attempt = state.start_task(
+                self.db_path,
+                task["identity"],
+                lease,
+                expected_cancel_generation=task["cancel_generation"],
+                clock=self.clock,
+            )
+            self._execute_attempt(binding, task, attempt)
+
+    def _ensure_lease(self, binding: HostedRoomBinding) -> state.DriverLease:
+        with self._status_lock:
+            current = self._leases.get(binding.room_id)
+        if current is not None:
+            try:
+                renewed = self._renew_lease_if_needed(binding, current)
+            except state.StaleLeaseError:
+                self._drop_lease(binding.room_id)
+            else:
+                return renewed
+
+        lease = state.acquire_lease(
+            self.db_path,
+            room_id=binding.room_id,
+            gateway_id=binding.gateway_id,
+            authority_epoch=binding.authority_epoch,
+            process_generation=self.process_generation,
+            ttl_seconds=self.lease_ttl_seconds,
+            clock=self.clock,
+        )
+        with self._status_lock:
+            self._leases[binding.room_id] = lease
+            self._recovered_leases = {
+                key for key in self._recovered_leases if key[0] != binding.room_id
+            }
+        return lease
+
+    def _renew_lease_if_needed(
+        self,
+        binding: HostedRoomBinding,
+        lease: state.DriverLease,
+        *,
+        force: bool = False,
+    ) -> state.DriverLease:
+        del binding
+        renew_at = lease.expires_at - (self.lease_ttl_seconds / 2)
+        if not force and self.clock() < renew_at:
+            return lease
+        renewed = state.renew_lease(
+            self.db_path,
+            lease,
+            ttl_seconds=self.lease_ttl_seconds,
+            clock=self.clock,
+        )
+        with self._status_lock:
+            self._leases[lease.room_id] = renewed
+        return renewed
+
+    def _execute_attempt(
+        self,
+        binding: HostedRoomBinding,
+        task: Mapping[str, Any],
+        attempt: state.TaskAttempt,
+    ) -> None:
+        profile = task["payload"]["target_profile"]
+        transport = self._transport_for(binding, task)
+        submit_attempted = False
+        with self._status_lock:
+            self._current_task = attempt.identity
+        try:
+            with self.turn_lock(profile):
+                session = self._resolve_or_create(
+                    transport, profile, binding.room_id
+                )
+                # An in-process submit should fail before admission or return
+                # after it, but an unexpected exception at that boundary is
+                # still ambiguous. Never terminalize it as a proven failure.
+                submit_attempted = True
+                def on_terminal(receipt: Mapping[str, Any]) -> None:
+                    status = receipt.get("status")
+                    if status == "cancelled":
+                        self.wakeup()
+                        return
+                    terminal_status: state.TerminalStatus = (
+                        "settled" if status == "settled" else "failed"
+                    )
+                    try:
+                        settled = state.settle_task(
+                            self.db_path,
+                            attempt,
+                            settlement_id=(
+                                receipt.get("settlement_id")
+                                or f"reply:{attempt.identity.task_id}:{attempt.execution_generation}"
+                            ),
+                            status=terminal_status,
+                            result={
+                                "message_id": receipt.get("message_id"),
+                                "text": receipt.get("text", ""),
+                                **(
+                                    {"error": receipt.get("error")}
+                                    if receipt.get("error")
+                                    else {}
+                                ),
+                            },
+                            clock=self.clock,
+                        )
+                        if self.publish_terminal is not None:
+                            self.publish_terminal(binding, settled)
+                    except state.StaleTaskError:
+                        try:
+                            current = state.get_task(self.db_path, attempt.identity)
+                            if current["status"] == "stopping":
+                                settled = state.settle_stopping_task(
+                                    self.db_path,
+                                    attempt.identity,
+                                    attempt.lease,
+                                    expected_execution_generation=attempt.execution_generation,
+                                    expected_cancel_generation=int(current["cancel_generation"]),
+                                    settlement_id=(
+                                        receipt.get("settlement_id")
+                                        or f"reply:{attempt.identity.task_id}:{attempt.execution_generation}"
+                                    ),
+                                    status=terminal_status,
+                                    result={
+                                        "message_id": receipt.get("message_id"),
+                                        "text": receipt.get("text", ""),
+                                        **(
+                                            {"error": receipt.get("error")}
+                                            if receipt.get("error")
+                                            else {}
+                                        ),
+                                    },
+                                    clock=self.clock,
+                                )
+                                if self.publish_terminal is not None:
+                                    self.publish_terminal(binding, settled)
+                        except (state.StaleLeaseError, state.StaleTaskError):
+                            pass
+                    except state.StaleLeaseError:
+                        # Cancellation, disband, or authority transfer won the
+                        # durable race. The model result is intentionally
+                        # discarded; never turn a correct fence into a worker
+                        # thread exception.
+                        pass
+                    self.wakeup()
+
+                transport.submit(
+                    profile=profile,
+                    session_id=_session_id(session),
+                    prompt=task["payload"]["prompt"],
+                    source=ROOM_SESSION_SOURCE,
+                    task=attempt.identity,
+                    execution_generation=attempt.execution_generation,
+                    on_terminal=on_terminal,
+                )
+                receipt = self._wait_for_terminal(
+                    binding,
+                    task=task,
+                    profile=profile,
+                    session_id=_session_id(session),
+                    attempt=attempt,
+                    transport=transport,
+                )
+                if receipt is None:
+                    return
+                state.settle_task(
+                    self.db_path,
+                    attempt,
+                    settlement_id=receipt.settlement_id,
+                    status=receipt.status,
+                    result=receipt.result,
+                    clock=self.clock,
+                )
+        except (state.StaleLeaseError, state.StaleTaskError) as exc:
+            self._drop_lease(binding.room_id)
+            self._record_error(f"task {attempt.identity.task_id} fenced: {exc}")
+        except Exception as exc:
+            if submit_attempted:
+                self._drop_lease(binding.room_id)
+                self._ambiguous_rooms[binding.room_id] = attempt.lease.expires_at
+                self._record_error(
+                    f"task {attempt.identity.task_id} observation failed after submit: {exc}"
+                )
+            else:
+                self._settle_failure_if_current(attempt, exc)
+        finally:
+            with self._status_lock:
+                self._current_task = None
+
+    def _wait_for_terminal(
+        self,
+        binding: HostedRoomBinding,
+        *,
+        task: Mapping[str, Any],
+        profile: str,
+        session_id: str,
+        attempt: state.TaskAttempt,
+        transport: InternalSessionRPC,
+    ) -> _TerminalReceipt | None:
+        lease = attempt.lease
+        while not self._stop.is_set():
+            task = state.get_task(self.db_path, attempt.identity)
+            if task["status"] in state.TERMINAL_STATUSES:
+                return None
+            if task["status"] == "stopping":
+                try:
+                    lease = self._renew_lease_if_needed(binding, lease)
+                    if self._settle_stopping_completion(binding, task, lease):
+                        return None
+                    if self._interrupt_stopping_task(binding, task):
+                        state.complete_task_cancel(
+                            self.db_path,
+                            attempt.identity,
+                            cancel_id=task["cancel_id"],
+                            expected_cancel_generation=task["cancel_generation"],
+                            clock=self.clock,
+                        )
+                        return None
+                except Exception as exc:
+                    self._record_error(f"stop retry remains pending: {exc}")
+                self._wake.wait(self.poll_interval_seconds)
+                self._wake.clear()
+                continue
+
+            lease = self._renew_lease_if_needed(binding, lease)
+            receipt = _find_terminal_receipt(
+                transport.history(
+                    profile=profile,
+                    session_id=session_id,
+                    source=ROOM_SESSION_SOURCE,
+                ),
+                attempt.identity,
+                attempt.execution_generation,
+            )
+            if receipt is not None:
+                return receipt
+
+            info = transport.info(
+                profile=profile,
+                session_id=session_id,
+                source=ROOM_SESSION_SOURCE,
+            )
+            self._report_pending_action(task, session_id=session_id, info=info)
+            self._wake.wait(self.poll_interval_seconds)
+            self._wake.clear()
+        return None
+
+    def _inspect_abandoned_attempts(self, binding: HostedRoomBinding) -> None:
+        running = state.list_tasks(
+            self.db_path,
+            room_id=binding.room_id,
+            status="running",
+        )
+        for task in running:
+            if task["run_process_generation"] == self.process_generation:
+                continue
+            inspection = self._inspect_recovery_session(binding, task)
+            if inspection.terminal is not None:
+                self._harvest_previous_attempt(binding, task, inspection.terminal)
+            elif inspection.active:
+                # The prior session still owns the turn. Do not contend for its
+                # lease or submit a duplicate prompt.
+                raise state.LeaseHeldError("recovered session turn is still active")
+
+    def _inspect_recovery_session(
+        self,
+        binding: HostedRoomBinding,
+        task: Mapping[str, Any],
+    ) -> _RecoveryInspection:
+        profile = task["payload"]["target_profile"]
+        transport = self._transport_for(binding, task)
+        with self.turn_lock(profile):
+            session = transport.resolve_exact(
+                profile=profile,
+                title=room_session_title(task["identity"].room_id),
+                source=ROOM_SESSION_SOURCE,
+            )
+            if session is None:
+                return _RecoveryInspection(terminal=None, active=False)
+            session_id = _session_id(session)
+            resumed = transport.resume(
+                profile=profile,
+                session_id=session_id,
+                source=ROOM_SESSION_SOURCE,
+            )
+            session_id = _session_id(resumed)
+            receipt = _find_terminal_receipt(
+                transport.history(
+                    profile=profile,
+                    session_id=session_id,
+                    source=ROOM_SESSION_SOURCE,
+                ),
+                task["identity"],
+                task["execution_generation"],
+            )
+            info = transport.info(
+                profile=profile,
+                session_id=session_id,
+                source=ROOM_SESSION_SOURCE,
+            )
+            self._report_pending_action(task, session_id=session_id, info=info)
+            return _RecoveryInspection(
+                terminal=receipt,
+                active=_info_is_active_for(info, task["identity"]),
+            )
+
+    def _reconcile_indeterminate(
+        self,
+        binding: HostedRoomBinding,
+        lease: state.DriverLease,
+    ) -> bool:
+        unresolved = state.list_tasks(
+            self.db_path,
+            room_id=binding.room_id,
+            status="indeterminate",
+        )
+        for task in unresolved:
+            inspection = self._inspect_recovery_session(binding, task)
+            if inspection.terminal is None:
+                with self._status_lock:
+                    self._blocked_rooms.add(binding.room_id)
+                return True
+            state.resolve_indeterminate_task(
+                self.db_path,
+                task["identity"],
+                lease,
+                expected_execution_generation=task["execution_generation"],
+                expected_cancel_generation=task["cancel_generation"],
+                settlement_id=inspection.terminal.settlement_id,
+                status=inspection.terminal.status,
+                result=inspection.terminal.result,
+                clock=self.clock,
+            )
+        with self._status_lock:
+            self._blocked_rooms.discard(binding.room_id)
+        return False
+
+    def _harvest_previous_attempt(
+        self,
+        binding: HostedRoomBinding,
+        task: Mapping[str, Any],
+        receipt: _TerminalReceipt,
+    ) -> None:
+        previous_lease = state.DriverLease(
+            room_id=binding.room_id,
+            gateway_id=task["run_gateway_id"],
+            authority_epoch=binding.authority_epoch,
+            process_generation=task["run_process_generation"],
+            lease_generation=task["run_lease_generation"],
+            expires_at=0.0,
+        )
+        previous_attempt = state.TaskAttempt(
+            identity=task["identity"],
+            lease=previous_lease,
+            execution_generation=task["execution_generation"],
+            cancel_generation=task["cancel_generation"],
+        )
+        try:
+            state.settle_task(
+                self.db_path,
+                previous_attempt,
+                settlement_id=receipt.settlement_id,
+                status=receipt.status,
+                result=receipt.result,
+                clock=self.clock,
+            )
+        except (state.StaleLeaseError, state.StaleTaskError):
+            # Once the previous proof has expired, the current state contract
+            # deliberately offers no unsafe "trust this historical output"
+            # escape hatch. The subsequent fenced recovery leaves it
+            # indeterminate for explicit user action.
+            return
+
+    def _binding_for_room(self, room_id: str) -> HostedRoomBinding | None:
+        return next(
+            (
+                binding
+                for binding in self._rooms_provider()
+                if binding.room_id == room_id
+            ),
+            None,
+        )
+
+    def _transport_for(
+        self,
+        binding: HostedRoomBinding,
+        task: Mapping[str, Any],
+    ) -> InternalSessionRPC:
+        if self.transport_resolver is not None:
+            return self.transport_resolver(binding, task)
+        if self.rpc is None:  # guarded by __init__
+            raise RuntimeError("hosted room transport is unavailable")
+        return self.rpc
+
+    def _resolve_or_create(
+        self,
+        transport: InternalSessionRPC,
+        profile: str,
+        room_id: str,
+    ) -> Mapping[str, Any]:
+        title = room_session_title(room_id)
+        session = transport.resolve_exact(
+            profile=profile,
+            title=title,
+            source=ROOM_SESSION_SOURCE,
+        )
+        if session is None:
+            return transport.create(
+                profile=profile,
+                title=title,
+                source=ROOM_SESSION_SOURCE,
+            )
+        return transport.resume(
+            profile=profile,
+            session_id=_session_id(session),
+            source=ROOM_SESSION_SOURCE,
+        )
+
+    def _settle_failure_if_current(
+        self, attempt: state.TaskAttempt, exc: Exception
+    ) -> None:
+        try:
+            state.settle_task(
+                self.db_path,
+                attempt,
+                settlement_id=f"failure:{attempt.identity.task_id}:{attempt.execution_generation}",
+                status="failed",
+                result={"error": str(exc)},
+                clock=self.clock,
+            )
+        except (state.DriverStateError, state.RoomUnavailableError):
+            pass
+        self._record_error(f"task {attempt.identity.task_id} failed: {exc}")
+
+    def _record_error(self, message: str) -> None:
+        with self._status_lock:
+            self._last_error = message
+
+    def _drop_lease(self, room_id: str) -> None:
+        with self._status_lock:
+            self._leases.pop(room_id, None)
+
+    def _release_idle_leases(self) -> None:
+        for room_id, lease in tuple(self._leases.items()):
+            try:
+                state.release_lease(self.db_path, lease, clock=self.clock)
+            except state.DriverStateError:
+                continue
+            self._drop_lease(room_id)
+
+
+def room_session_title(room_id: str) -> str:
+    """Return the canonical hidden session title for one hosted room."""
+    return f"Group: {room_id}"
+
+
+def _session_id(session: Mapping[str, Any]) -> str:
+    value = session.get("session_id", session.get("id"))
+    if not isinstance(value, str) or not value:
+        raise ValueError("session adapter returned no session_id")
+    return value
+
+
+def _find_terminal_receipt(
+    history: Sequence[Mapping[str, Any]],
+    identity: state.TaskIdentity,
+    execution_generation: int,
+) -> _TerminalReceipt | None:
+    for message in reversed(history):
+        if message.get("task_id") != identity.task_id:
+            continue
+        if message.get("execution_generation") != execution_generation:
+            continue
+        if message.get("role") != "assistant":
+            continue
+        status = message.get("status")
+        if status not in {"settled", "failed"}:
+            continue
+        terminal_status = cast(state.TerminalStatus, status)
+        receipt_id = message.get("message_id")
+        if not isinstance(receipt_id, str) or not receipt_id:
+            receipt_id = f"reply:{identity.task_id}:{execution_generation}"
+        return _TerminalReceipt(
+            status=terminal_status,
+            settlement_id=receipt_id,
+            result={
+                "message_id": receipt_id,
+                "text": message.get("content", ""),
+            },
+        )
+    return None
+
+
+def _info_is_active_for(
+    info: Mapping[str, Any],
+    identity: state.TaskIdentity,
+    *,
+    require_exact: bool = False,
+) -> bool:
+    if not bool(info.get("active", info.get("running", False))):
+        return False
+    active_task_id = info.get("task_id")
+    if require_exact:
+        return active_task_id == identity.task_id
+    return active_task_id in {None, identity.task_id}
+
+
+@contextlib.contextmanager
+def null_turn_lock(_profile: str) -> Any:
+    """Provide an explicit no-op lock for narrow embedding tests."""
+    yield

--- a/tui_gateway/hosted_room_driver.py
+++ b/tui_gateway/hosted_room_driver.py
@@ -49,6 +49,48 @@ class InternalSessionRPC(Protocol):
     ) -> Mapping[str, Any]:
         """Resume the canonical room session."""
 
+    def stage_attachment(
+        self,
+        *,
+        profile: str,
+        session_id: str,
+        source: str,
+        attachment: Mapping[str, Any],
+        data: bytes,
+        execution_generation: int,
+    ) -> Mapping[str, Any]:
+        """Stage one verified canonical blob into the local member session."""
+
+    def begin_attachment_staging(
+        self,
+        *,
+        profile: str,
+        session_id: str,
+        source: str,
+        execution_generation: int,
+    ) -> None:
+        """Snapshot pending session attachments for one fenced attempt."""
+
+    def commit_attachment_staging(
+        self,
+        *,
+        profile: str,
+        session_id: str,
+        source: str,
+        execution_generation: int,
+    ) -> None:
+        """Accept staged attachments after crossing the submit boundary."""
+
+    def rollback_attachment_staging(
+        self,
+        *,
+        profile: str,
+        session_id: str,
+        source: str,
+        execution_generation: int,
+    ) -> None:
+        """Restore pending session attachments after a pre-submit failure."""
+
     def submit(
         self,
         *,
@@ -92,6 +134,12 @@ class MemberTransportResolver(Protocol):
         """Return a local or peer transport without changing task identity."""
 
 
+AttachmentLoader = Callable[
+    ["HostedRoomBinding", Mapping[str, Any]],
+    Iterable[tuple[Mapping[str, Any], bytes]],
+]
+
+
 @dataclass(frozen=True)
 class HostedRoomBinding:
     """Current server-issued authority coordinate for one hosted room."""
@@ -132,6 +180,7 @@ class HostedRoomRuntime:
             [str, str, Mapping[str, Any] | None], None
         ]
         | None = None,
+        attachment_loader: AttachmentLoader | None = None,
         clock: Callable[[], float] = time.time,
         lease_ttl_seconds: float = 30.0,
         poll_interval_seconds: float = 0.1,
@@ -151,6 +200,7 @@ class HostedRoomRuntime:
         self.prepare_room = prepare_room
         self.publish_terminal = publish_terminal
         self.pending_action = pending_action
+        self.attachment_loader = attachment_loader
         self.clock = clock
         self.lease_ttl_seconds = float(lease_ttl_seconds)
         self.poll_interval_seconds = float(poll_interval_seconds)
@@ -587,6 +637,8 @@ class HostedRoomRuntime:
         profile = task["payload"]["target_profile"]
         transport = self._transport_for(binding, task)
         submit_attempted = False
+        attachment_staging_active = False
+        attachment_session_id: str | None = None
         with self._status_lock:
             self._current_task = attempt.identity
         try:
@@ -594,10 +646,69 @@ class HostedRoomRuntime:
                 session = self._resolve_or_create(
                     transport, profile, binding.room_id
                 )
+                session_id = _session_id(session)
+                prompt = str(task["payload"]["prompt"])
+                manifests = task["payload"].get("attachments") or []
+                if manifests:
+                    if self.attachment_loader is None or transport is not self.rpc:
+                        raise RuntimeError(
+                            "hosted attachments are unavailable for this member transport"
+                        )
+                    transport.begin_attachment_staging(
+                        profile=profile,
+                        session_id=session_id,
+                        source=ROOM_SESSION_SOURCE,
+                        execution_generation=attempt.execution_generation,
+                    )
+                    attachment_staging_active = True
+                    attachment_session_id = session_id
+                    expected_ids = [
+                        str(attachment.get("attachment_id") or "")
+                        for attachment in manifests
+                    ]
+                    file_refs = []
+                    loaded_count = 0
+                    for loaded_count, (attachment, data) in enumerate(
+                        self.attachment_loader(binding, task),
+                        start=1,
+                    ):
+                        if (
+                            loaded_count > len(expected_ids)
+                            or str(attachment.get("attachment_id") or "")
+                            != expected_ids[loaded_count - 1]
+                        ):
+                            raise RuntimeError(
+                                "hosted attachment ownership did not match the task manifest"
+                            )
+                        staged = transport.stage_attachment(
+                            profile=profile,
+                            session_id=session_id,
+                            source=ROOM_SESSION_SOURCE,
+                            attachment=attachment,
+                            data=data,
+                            execution_generation=attempt.execution_generation,
+                        )
+                        if attachment.get("kind") == "file":
+                            ref = str(staged.get("ref_text") or "").strip()
+                            if not ref:
+                                raise RuntimeError(
+                                    "hosted file attachment returned no staged reference"
+                                )
+                            file_refs.append(f"{attachment['name']}: {ref}")
+                    if loaded_count != len(expected_ids):
+                        raise RuntimeError(
+                            "hosted attachment ownership did not match the task manifest"
+                        )
+                    if file_refs:
+                        prompt = (
+                            f"{prompt}\n\nAttached files staged in your session workspace:\n"
+                            + "\n".join(file_refs)
+                        )
                 # An in-process submit should fail before admission or return
                 # after it, but an unexpected exception at that boundary is
                 # still ambiguous. Never terminalize it as a proven failure.
                 submit_attempted = True
+
                 def on_terminal(receipt: Mapping[str, Any]) -> None:
                     status = receipt.get("status")
                     if status == "cancelled":
@@ -668,18 +779,26 @@ class HostedRoomRuntime:
 
                 transport.submit(
                     profile=profile,
-                    session_id=_session_id(session),
-                    prompt=task["payload"]["prompt"],
+                    session_id=session_id,
+                    prompt=prompt,
                     source=ROOM_SESSION_SOURCE,
                     task=attempt.identity,
                     execution_generation=attempt.execution_generation,
                     on_terminal=on_terminal,
                 )
+                if attachment_staging_active:
+                    transport.commit_attachment_staging(
+                        profile=profile,
+                        session_id=session_id,
+                        source=ROOM_SESSION_SOURCE,
+                        execution_generation=attempt.execution_generation,
+                    )
+                    attachment_staging_active = False
                 receipt = self._wait_for_terminal(
                     binding,
                     task=task,
                     profile=profile,
-                    session_id=_session_id(session),
+                    session_id=session_id,
                     attempt=attempt,
                     transport=transport,
                 )
@@ -694,9 +813,25 @@ class HostedRoomRuntime:
                     clock=self.clock,
                 )
         except (state.StaleLeaseError, state.StaleTaskError) as exc:
+            if attachment_staging_active and attachment_session_id is not None:
+                self._finish_attachment_staging_after_error(
+                    transport=transport,
+                    profile=profile,
+                    session_id=attachment_session_id,
+                    execution_generation=attempt.execution_generation,
+                    submit_attempted=submit_attempted,
+                )
             self._drop_lease(binding.room_id)
             self._record_error(f"task {attempt.identity.task_id} fenced: {exc}")
         except Exception as exc:
+            if attachment_staging_active and attachment_session_id is not None:
+                self._finish_attachment_staging_after_error(
+                    transport=transport,
+                    profile=profile,
+                    session_id=attachment_session_id,
+                    execution_generation=attempt.execution_generation,
+                    submit_attempted=submit_attempted,
+                )
             if submit_attempted:
                 self._drop_lease(binding.room_id)
                 self._ambiguous_rooms[binding.room_id] = attempt.lease.expires_at
@@ -708,6 +843,42 @@ class HostedRoomRuntime:
         finally:
             with self._status_lock:
                 self._current_task = None
+
+    def _finish_attachment_staging_after_error(
+        self,
+        *,
+        transport: InternalSessionRPC,
+        profile: str,
+        session_id: str,
+        execution_generation: int,
+        submit_attempted: bool,
+    ) -> None:
+        """Close staging without masking the task's original failure.
+
+        Once submit has been attempted, admission is deliberately treated as
+        ambiguous and staged images must remain available to a turn that may
+        already have been accepted. Before that boundary, restoring the
+        snapshot prevents a partially staged attachment from leaking into the
+        next prompt on the canonical session.
+        """
+
+        try:
+            finalizer = (
+                transport.commit_attachment_staging
+                if submit_attempted
+                else transport.rollback_attachment_staging
+            )
+            finalizer(
+                profile=profile,
+                session_id=session_id,
+                source=ROOM_SESSION_SOURCE,
+                execution_generation=execution_generation,
+            )
+        except Exception as cleanup_error:
+            self._record_error(
+                "attachment staging cleanup failed for "
+                f"session {session_id}: {cleanup_error}"
+            )
 
     def _wait_for_terminal(
         self,

--- a/tui_gateway/hosted_room_server_rpc.py
+++ b/tui_gateway/hosted_room_server_rpc.py
@@ -1,0 +1,204 @@
+"""In-process session adapter for the hosted room driver.
+
+The room worker must not depend on a Desktop/WebSocket transport, but it should
+still use the same session handlers as every other TUI/Desktop turn. This
+adapter calls the installed handler registry directly and keeps the extra
+task proof as an in-process-only Python object that JSON clients cannot forge.
+"""
+
+from __future__ import annotations
+
+import itertools
+import threading
+from collections.abc import Mapping, Sequence
+from types import ModuleType
+from typing import Any, Callable
+
+from gateway import hosted_room_driver as state
+
+
+class HostedRoomSessionError(RuntimeError):
+    """Raised when an in-process session operation is rejected."""
+
+    def __init__(self, method: str, code: int, message: str) -> None:
+        super().__init__(f"{method} failed: {message}")
+        self.method = method
+        self.code = code
+
+
+class HostedRoomServerRPC:
+    """Normalize the installed server handlers for :class:`HostedRoomRuntime`."""
+
+    def __init__(self, server: ModuleType) -> None:
+        self.server = server
+        self._ids = itertools.count(1)
+
+    def _call(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
+        handler = self.server._methods[method]
+        envelope = handler(f"hosted-room-{next(self._ids)}", params)
+        error = envelope.get("error") if isinstance(envelope, dict) else None
+        if isinstance(error, dict):
+            raise HostedRoomSessionError(
+                method,
+                int(error.get("code") or 5000),
+                str(error.get("message") or "gateway rejected the request"),
+            )
+        result = envelope.get("result") if isinstance(envelope, dict) else None
+        if not isinstance(result, dict):
+            raise HostedRoomSessionError(method, 5000, "gateway returned no result")
+        return result
+
+    def resolve_exact(
+        self, *, profile: str, title: str, source: str
+    ) -> Mapping[str, Any] | None:
+        del source
+        result = self._call(
+            "session.list",
+            {"profile": profile, "title": title, "include_hidden": True},
+        )
+        rows = result.get("sessions")
+        if not isinstance(rows, list) or not rows:
+            return None
+        row = rows[0]
+        if not isinstance(row, dict):
+            return None
+        session_id = row.get("resolved_id") or row.get("id")
+        return {"session_id": session_id, "title": row.get("title") or title}
+
+    def create(self, *, profile: str, title: str, source: str) -> Mapping[str, Any]:
+        return self._call(
+            "session.create",
+            {
+                "profile": profile,
+                "title": title,
+                "source": source,
+                "hidden": True,
+                "close_on_disconnect": False,
+            },
+        )
+
+    def resume(
+        self, *, profile: str, session_id: str, source: str
+    ) -> Mapping[str, Any]:
+        del source
+        return self._call(
+            "session.resume",
+            {
+                "profile": profile,
+                "session_id": session_id,
+                "omit_messages": True,
+            },
+        )
+
+    def submit(
+        self,
+        *,
+        profile: str,
+        session_id: str,
+        prompt: str,
+        source: str,
+        task: state.TaskIdentity,
+        execution_generation: int,
+        on_terminal: Callable[[Mapping[str, Any]], None],
+    ) -> Mapping[str, Any]:
+        return self._call(
+            "prompt.submit",
+            {
+                "profile": profile,
+                "session_id": session_id,
+                "text": prompt,
+                "source": source,
+                "_hosted_task": {
+                    "room_id": task.room_id,
+                    "task_id": task.task_id,
+                    "thread_id": task.thread_id,
+                    "turn_id": task.turn_id,
+                    "execution_generation": execution_generation,
+                },
+                "_hosted_terminal_callback": on_terminal,
+            },
+        )
+
+    def history(
+        self, *, profile: str, session_id: str, source: str
+    ) -> Sequence[Mapping[str, Any]]:
+        del source
+        result = self._call(
+            "session.history",
+            {"profile": profile, "session_id": session_id},
+        )
+        rows = result.get("messages")
+        return tuple(row for row in rows if isinstance(row, dict)) if isinstance(rows, list) else ()
+
+    def _session_record(self, session_id: str) -> dict[str, Any] | None:
+        with self.server._sessions_lock:
+            record = self.server._sessions.get(session_id)
+            if record is not None:
+                return record
+            for candidate in self.server._sessions.values():
+                if str(candidate.get("session_key") or "") == session_id:
+                    return candidate
+        return None
+
+    def info(self, *, profile: str, session_id: str, source: str) -> Mapping[str, Any]:
+        del profile, source
+        record = self._session_record(session_id)
+        if record is None:
+            return {"active": False, "task_id": None}
+        lock = record.get("history_lock")
+        if not isinstance(lock, type(threading.Lock())):
+            return {"active": bool(record.get("running")), "task_id": None}
+        with lock:
+            task = record.get("_hosted_room_task")
+            result = {
+                "active": bool(record.get("running")),
+                "task_id": task.get("task_id") if isinstance(task, dict) else None,
+            }
+            pending_reader = getattr(
+                self.server, "_pending_approval_request_payload", None
+            )
+            pending = (
+                pending_reader(str(record.get("session_key") or ""))
+                if callable(pending_reader)
+                else None
+            )
+            if pending:
+                result["status"] = "waiting_for_approval"
+                result["pending_approval"] = pending
+            return result
+
+    def approve(
+        self,
+        *,
+        session_id: str,
+        request_id: str,
+        choice: str,
+    ) -> Mapping[str, Any]:
+        """Resolve one exact local room approval without broad policy changes."""
+        return self._call(
+            "approval.respond",
+            {
+                "session_id": session_id,
+                "request_id": request_id,
+                "choice": choice,
+                "all": False,
+            },
+        )
+
+    def interrupt(
+        self,
+        *,
+        profile: str,
+        session_id: str,
+        source: str,
+        expected_task_id: str,
+    ) -> Mapping[str, Any] | None:
+        del source
+        return self._call(
+            "session.interrupt",
+            {
+                "profile": profile,
+                "session_id": session_id,
+                "expected_hosted_task_id": expected_task_id,
+            },
+        )

--- a/tui_gateway/hosted_room_server_rpc.py
+++ b/tui_gateway/hosted_room_server_rpc.py
@@ -8,9 +8,12 @@ task proof as an in-process-only Python object that JSON clients cannot forge.
 
 from __future__ import annotations
 
+import base64
 import itertools
+import stat
 import threading
 from collections.abc import Mapping, Sequence
+from pathlib import Path
 from types import ModuleType
 from typing import Any, Callable
 
@@ -32,6 +35,9 @@ class HostedRoomServerRPC:
     def __init__(self, server: ModuleType) -> None:
         self.server = server
         self._ids = itertools.count(1)
+        self._attachment_lock = threading.Lock()
+        self._staged_attachments: dict[tuple[str, str, int], dict[str, Any]] = {}
+        self._attachment_attempts: dict[tuple[str, int], tuple[str, ...]] = {}
 
     def _call(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
         handler = self.server._methods[method]
@@ -118,6 +124,192 @@ class HostedRoomServerRPC:
                 "_hosted_terminal_callback": on_terminal,
             },
         )
+
+    def stage_attachment(
+        self,
+        *,
+        profile: str,
+        session_id: str,
+        source: str,
+        attachment: Mapping[str, Any],
+        data: bytes,
+        execution_generation: int,
+    ) -> Mapping[str, Any]:
+        """Stage canonical bytes through the existing session attachment RPCs."""
+
+        self.begin_attachment_staging(
+            profile=profile,
+            session_id=session_id,
+            source=source,
+            execution_generation=execution_generation,
+        )
+        attachment_id = str(attachment.get("attachment_id") or "")
+        key = (session_id, attachment_id, int(execution_generation))
+        with self._attachment_lock:
+            cached = self._staged_attachments.get(key)
+            if cached is not None:
+                return dict(cached)
+
+        encoded = base64.b64encode(data).decode("ascii")
+        kind = str(attachment.get("kind") or "")
+        name = str(attachment.get("name") or "attachment")
+        mime = str(attachment.get("mime") or "application/octet-stream")
+        if kind == "image":
+            result = self._call(
+                "image.attach_bytes",
+                {
+                    "session_id": session_id,
+                    "content_base64": encoded,
+                    "filename": name,
+                },
+            )
+        elif kind == "pdf":
+            result = self._call(
+                "pdf.attach",
+                {
+                    "session_id": session_id,
+                    "content_base64": encoded,
+                    "filename": name,
+                },
+            )
+        elif kind == "file":
+            result = self._call(
+                "file.attach",
+                {
+                    "session_id": session_id,
+                    "data_url": f"data:{mime};base64,{encoded}",
+                    "name": name,
+                },
+            )
+        else:
+            raise HostedRoomSessionError(
+                "attachment.stage", 4016, "unsupported hosted attachment kind"
+            )
+        if result.get("attached") is not True:
+            raise HostedRoomSessionError(
+                f"{kind}.attach", 5028, "attachment staging was not acknowledged"
+            )
+        with self._attachment_lock:
+            self._staged_attachments[key] = dict(result)
+        return result
+
+    def begin_attachment_staging(
+        self,
+        *,
+        profile: str,
+        session_id: str,
+        source: str,
+        execution_generation: int,
+    ) -> None:
+        """Capture the canonical session's pending-image queue once."""
+
+        del profile, source
+        attempt_key = (session_id, int(execution_generation))
+        with self._attachment_lock:
+            if attempt_key in self._attachment_attempts:
+                return
+        record = self._session_record(session_id)
+        if record is None:
+            raise HostedRoomSessionError(
+                "attachment.stage", 4007, "session not found"
+            )
+        lock = record.get("history_lock")
+        if lock is None:
+            raise HostedRoomSessionError(
+                "attachment.stage", 5000, "session has no history lock"
+            )
+        with lock:
+            snapshot = tuple(str(path) for path in record.get("attached_images", []))
+        with self._attachment_lock:
+            self._attachment_attempts.setdefault(attempt_key, snapshot)
+
+    def commit_attachment_staging(
+        self,
+        *,
+        profile: str,
+        session_id: str,
+        source: str,
+        execution_generation: int,
+    ) -> None:
+        """Drop attempt bookkeeping after prompt admission becomes ambiguous."""
+
+        del profile, source
+        self._forget_attachment_attempt(session_id, execution_generation)
+
+    def rollback_attachment_staging(
+        self,
+        *,
+        profile: str,
+        session_id: str,
+        source: str,
+        execution_generation: int,
+    ) -> None:
+        """Restore the pending-image queue after a pre-submit failure."""
+
+        del profile, source
+        attempt_key = (session_id, int(execution_generation))
+        with self._attachment_lock:
+            snapshot = self._attachment_attempts.pop(attempt_key, None)
+            stale_keys = [
+                key
+                for key in self._staged_attachments
+                if key[0] == session_id and key[2] == int(execution_generation)
+            ]
+            staged_results = [
+                dict(self._staged_attachments.get(key) or {}) for key in stale_keys
+            ]
+            for key in stale_keys:
+                self._staged_attachments.pop(key, None)
+        for result in staged_results:
+            self._remove_attempt_uploaded_file(session_id, result)
+        if snapshot is None:
+            return
+        record = self._session_record(session_id)
+        if record is None:
+            return
+        lock = record.get("history_lock")
+        if lock is None:
+            return
+        with lock:
+            record["attached_images"] = list(snapshot)
+
+    def _remove_attempt_uploaded_file(
+        self, session_id: str, result: Mapping[str, Any]
+    ) -> None:
+        """Delete only files materialized by this failed staging attempt."""
+
+        if result.get("uploaded") is not True:
+            return
+        raw_path = str(result.get("path") or "")
+        if not raw_path:
+            return
+        record = self._session_record(session_id)
+        attachment_dir = getattr(self.server, "_desktop_attachment_dir", None)
+        if record is None or not callable(attachment_dir):
+            return
+        try:
+            root = Path(attachment_dir(record)).resolve()
+            candidate = Path(raw_path).resolve()
+            candidate.relative_to(root)
+            info = candidate.lstat()
+            if stat.S_ISREG(info.st_mode) and not stat.S_ISLNK(info.st_mode):
+                candidate.unlink(missing_ok=True)
+        except (FileNotFoundError, OSError, ValueError):
+            return
+
+    def _forget_attachment_attempt(
+        self, session_id: str, execution_generation: int
+    ) -> None:
+        attempt_key = (session_id, int(execution_generation))
+        with self._attachment_lock:
+            self._attachment_attempts.pop(attempt_key, None)
+            stale_keys = [
+                key
+                for key in self._staged_attachments
+                if key[0] == session_id and key[2] == int(execution_generation)
+            ]
+            for key in stale_keys:
+                self._staged_attachments.pop(key, None)
 
     def history(
         self, *, profile: str, session_id: str, source: str

--- a/tui_gateway/hosted_room_service.py
+++ b/tui_gateway/hosted_room_service.py
@@ -1,0 +1,266 @@
+"""Production coordinator for same-gateway hosted Discussion rooms."""
+
+from __future__ import annotations
+
+import contextlib
+import threading
+import time
+from collections import Counter
+from collections.abc import Iterator, Mapping
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+from gateway import hosted_room_discussion as discussion
+from gateway import hosted_room_driver as driver
+from gateway import hosted_rooms
+from tui_gateway.hosted_room_driver import HostedRoomBinding, HostedRoomRuntime
+from tui_gateway.hosted_room_server_rpc import HostedRoomServerRPC
+
+
+class HostedRoomService:
+    """Own the hosted Discussion policy and its transport-free worker."""
+
+    def __init__(self, server: ModuleType, *, db_path: Path | str | None = None) -> None:
+        self.server = server
+        self.db_path = Path(db_path or hosted_rooms.default_db_path())
+        self._policy_lock = threading.RLock()
+        self.rpc = HostedRoomServerRPC(server)
+        self.runtime = HostedRoomRuntime(
+            db_path=self.db_path,
+            rooms=self.bindings,
+            rpc=self.rpc,
+            turn_lock=self._turn_lock,
+            prepare_room=self.prepare_room,
+            publish_terminal=self.publish_terminal,
+        )
+
+    @property
+    def root(self) -> Path:
+        return self.db_path.parent
+
+    def local_profiles(self) -> tuple[str, ...]:
+        profiles = {"default"}
+        profiles_dir = self.root / "profiles"
+        if profiles_dir.is_dir():
+            profiles.update(path.name for path in profiles_dir.iterdir() if path.is_dir())
+        return tuple(sorted(profiles))
+
+    def bindings(self) -> tuple[HostedRoomBinding, ...]:
+        return tuple(
+            HostedRoomBinding(
+                room_id=str(room["room_id"]),
+                gateway_id=str(room["authority_gateway_id"]),
+                authority_epoch=int(room["authority_epoch"]),
+            )
+            for room in hosted_rooms.list_rooms(self.db_path)
+        )
+
+    @contextlib.contextmanager
+    def _turn_lock(self, profile: str) -> Iterator[None]:
+        from tools.bot_relay import acquire_turn_lock
+
+        with acquire_turn_lock(self.root, profile):
+            yield
+
+    def start(self) -> None:
+        self.runtime.start()
+
+    def stop(self, *, timeout: float = 5.0) -> bool:
+        return self.runtime.stop(timeout=timeout)
+
+    def wakeup(self) -> None:
+        self.runtime.wakeup()
+
+    def _events(self, room_id: str) -> list[dict[str, Any]]:
+        events: list[dict[str, Any]] = []
+        cursor = 0
+        while True:
+            page = hosted_rooms.read_events(
+                self.db_path,
+                room_id=room_id,
+                since_seq=cursor,
+                limit=hosted_rooms.MAX_LOG_LIMIT,
+            )
+            rows = page.get("events")
+            if isinstance(rows, list):
+                events.extend(row for row in rows if isinstance(row, dict))
+            next_cursor = int(page.get("cursor") or cursor)
+            if not page.get("has_more"):
+                return events
+            if next_cursor <= cursor:
+                raise RuntimeError("hosted room replay cursor did not advance")
+            cursor = next_cursor
+
+    def _append_plan(self, room_id: str, plan: discussion.PublicationPlan) -> None:
+        for event in plan.events:
+            hosted_rooms.append_event(
+                self.db_path,
+                **event.append_kwargs(room_id),
+            )
+
+    def _publish_terminal_tasks(
+        self,
+        room: Mapping[str, Any],
+        events: list[dict[str, Any]],
+    ) -> bool:
+        changed = False
+        local_profiles = self.local_profiles()
+        for status in ("settled", "failed", "cancelled"):
+            for task in driver.list_tasks(
+                self.db_path,
+                room_id=str(room["room_id"]),
+                status=status,
+            ):
+                plan = discussion.reconstruct_task_plan(
+                    room,
+                    events,
+                    task,
+                    local_profiles=local_profiles,
+                )
+                publication = discussion.plan_publication(
+                    room,
+                    events,
+                    plan,
+                    status=status,
+                    result=task.get("result"),
+                    local_profiles=local_profiles,
+                )
+                before = len(events)
+                self._append_plan(str(room["room_id"]), publication)
+                events = self._events(str(room["room_id"]))
+                changed = changed or len(events) > before
+        return changed
+
+    def _append_room_status(
+        self,
+        room: Mapping[str, Any],
+        decision: discussion.DiscussionDecision,
+    ) -> None:
+        if decision.discussion_event_id is None:
+            return
+        hosted_rooms.append_event(
+            self.db_path,
+            room_id=str(room["room_id"]),
+            event_id=f"dactivity:{decision.discussion_event_id}:{decision.reason}",
+            kind="room.activity",
+            actor={"kind": "gateway", "id": str(room["authority_gateway_id"])},
+            payload={
+                "status": decision.status,
+                "reason_code": decision.reason,
+                "thread_id": decision.thread_id,
+                "discussion_event_id": decision.discussion_event_id,
+            },
+            authority_gateway_id=str(room["authority_gateway_id"]),
+            authority_epoch=int(room["authority_epoch"]),
+        )
+
+    def prepare_room(self, binding: HostedRoomBinding) -> None:
+        with self._policy_lock:
+            room = hosted_rooms.room_state(self.db_path, room_id=binding.room_id)
+            events = self._events(binding.room_id)
+            if self._publish_terminal_tasks(room, events):
+                events = self._events(binding.room_id)
+            decision = discussion.plan_next_task(
+                room,
+                events,
+                local_profiles=self.local_profiles(),
+            )
+            if decision.status == "task" and decision.task is not None:
+                driver.admit_task(
+                    self.db_path,
+                    decision.task.identity,
+                    payload=decision.task.payload,
+                    clock=time.time,
+                )
+            elif decision.status in {"settled", "bounded"}:
+                self._append_room_status(room, decision)
+
+    def publish_terminal(
+        self,
+        binding: HostedRoomBinding,
+        _task: Mapping[str, Any],
+    ) -> None:
+        self.prepare_room(binding)
+        self.runtime.wakeup()
+
+    def create_room(self, *, room_id: str, name: str, members: Any) -> dict[str, Any]:
+        normalized = discussion.validate_roster(
+            members,
+            local_profiles=self.local_profiles(),
+        )
+        room = hosted_rooms.create_room(
+            self.db_path,
+            room_id=room_id,
+            name=name,
+            members=[
+                {
+                    "member_id": member.member_id,
+                    "profile": member.profile,
+                    "handle": member.handle,
+                    **(
+                        {"display_name": member.display_name}
+                        if member.display_name
+                        else {}
+                    ),
+                }
+                for member in normalized
+            ],
+            authority_gateway_id=hosted_rooms.local_authority_gateway_id(),
+        )
+        self.runtime.wakeup()
+        return room
+
+    def send(
+        self,
+        *,
+        room_id: str,
+        event_id: str,
+        payload: Any,
+    ) -> dict[str, Any]:
+        normalized = discussion.validate_user_payload(payload)
+        event = hosted_rooms.append_event(
+            self.db_path,
+            room_id=room_id,
+            event_id=event_id,
+            kind="message.user",
+            actor={"kind": "user", "id": "desktop"},
+            payload=normalized,
+        )
+        binding = next(
+            (candidate for candidate in self.bindings() if candidate.room_id == room_id),
+            None,
+        )
+        if binding is None:
+            raise hosted_rooms.RoomNotFoundError("hosted room not found")
+        self.prepare_room(binding)
+        self.runtime.wakeup()
+        return event
+
+    def stop_room(self, room_id: str, *, cancel_id: str) -> int:
+        cancelled = 0
+        with self._policy_lock:
+            for status in ("queued", "running", "indeterminate"):
+                for task in driver.list_tasks(
+                    self.db_path,
+                    room_id=room_id,
+                    status=status,
+                ):
+                    self.runtime.cancel(task["identity"], cancel_id=cancel_id)
+                    cancelled += 1
+        self.runtime.wakeup()
+        return cancelled
+
+    def status(self, room_id: str | None = None) -> dict[str, Any]:
+        runtime = self.runtime.status()
+        if room_id is None:
+            return runtime
+        tasks = driver.list_tasks(self.db_path, room_id=room_id)
+        counts = Counter(str(task["status"]) for task in tasks)
+        return {
+            "running": runtime["running"],
+            "working": bool(counts.get("running") or counts.get("queued")),
+            "blocked": room_id in runtime["blocked_rooms"] or bool(counts.get("indeterminate")),
+            "counts": dict(counts),
+        }
+

--- a/tui_gateway/hosted_room_service.py
+++ b/tui_gateway/hosted_room_service.py
@@ -173,6 +173,26 @@ class HostedRoomService:
                     payload=decision.task.payload,
                     clock=time.time,
                 )
+                # A stop can race the policy read from another process. Re-read
+                # after admission and cancel before the runtime can execute a
+                # task whose source event is now behind the room stop fence.
+                fresh_events = self._events(binding.room_id)
+                stopped_through_seq = max(
+                    (
+                        int(event["seq"])
+                        for event in fresh_events
+                        if event.get("kind") == "room.stop_requested"
+                    ),
+                    default=0,
+                )
+                if (
+                    decision.source_event_seq is not None
+                    and decision.source_event_seq < stopped_through_seq
+                ):
+                    self.runtime.cancel(
+                        decision.task.identity,
+                        cancel_id=f"stop-fence:{stopped_through_seq}",
+                    )
             elif decision.status in {"settled", "bounded"}:
                 self._append_room_status(room, decision)
 
@@ -238,6 +258,11 @@ class HostedRoomService:
         return event
 
     def stop_room(self, room_id: str, *, cancel_id: str) -> int:
+        hosted_rooms.request_room_stop(
+            self.db_path,
+            room_id=room_id,
+            cancel_id=cancel_id,
+        )
         cancelled = 0
         with self._policy_lock:
             for status in ("queued", "running", "indeterminate"):
@@ -259,8 +284,11 @@ class HostedRoomService:
         counts = Counter(str(task["status"]) for task in tasks)
         return {
             "running": runtime["running"],
-            "working": bool(counts.get("running") or counts.get("queued")),
+            "working": bool(
+                counts.get("running")
+                or counts.get("queued")
+                or counts.get("stopping")
+            ),
             "blocked": room_id in runtime["blocked_rooms"] or bool(counts.get("indeterminate")),
             "counts": dict(counts),
         }
-

--- a/tui_gateway/hosted_room_service.py
+++ b/tui_gateway/hosted_room_service.py
@@ -237,6 +237,7 @@ class HostedRoomService:
         room_id: str,
         event_id: str,
         payload: Any,
+        actor: Mapping[str, Any] | None = None,
     ) -> dict[str, Any]:
         normalized = discussion.validate_user_payload(payload)
         event = hosted_rooms.append_event(
@@ -244,7 +245,7 @@ class HostedRoomService:
             room_id=room_id,
             event_id=event_id,
             kind="message.user",
-            actor={"kind": "user", "id": "desktop"},
+            actor=actor or {"kind": "user", "id": "desktop"},
             payload=normalized,
         )
         binding = next(

--- a/tui_gateway/hosted_room_service.py
+++ b/tui_gateway/hosted_room_service.py
@@ -13,6 +13,10 @@ from typing import Any
 
 from gateway import hosted_room_discussion as discussion
 from gateway import hosted_room_driver as driver
+from gateway.hosted_room_attachments import (
+    AttachmentData,
+    HostedRoomAttachmentStore,
+)
 from gateway import hosted_rooms
 from tui_gateway.hosted_room_driver import HostedRoomBinding, HostedRoomRuntime
 from tui_gateway.hosted_room_server_rpc import HostedRoomServerRPC
@@ -25,6 +29,7 @@ class HostedRoomService:
         self.server = server
         self.db_path = Path(db_path or hosted_rooms.default_db_path())
         self._policy_lock = threading.RLock()
+        self.attachments = HostedRoomAttachmentStore(self.db_path)
         self.rpc = HostedRoomServerRPC(server)
         self.runtime = HostedRoomRuntime(
             db_path=self.db_path,
@@ -33,6 +38,7 @@ class HostedRoomService:
             turn_lock=self._turn_lock,
             prepare_room=self.prepare_room,
             publish_terminal=self.publish_terminal,
+            attachment_loader=self._load_task_attachments,
         )
 
     @property
@@ -64,6 +70,7 @@ class HostedRoomService:
             yield
 
     def start(self) -> None:
+        self.attachments.prune()
         self.runtime.start()
 
     def stop(self, *, timeout: float = 5.0) -> bool:
@@ -98,6 +105,48 @@ class HostedRoomService:
                 self.db_path,
                 **event.append_kwargs(room_id),
             )
+
+    def _load_task_attachments(
+        self,
+        binding: HostedRoomBinding,
+        task: Mapping[str, Any],
+    ) -> Iterator[tuple[Mapping[str, Any], bytes]]:
+        """Resolve task manifests to verified bytes for one frozen room member."""
+
+        manifests = task.get("payload", {}).get("attachments") or []
+        if not manifests:
+            return
+        room = hosted_rooms.room_state(self.db_path, room_id=binding.room_id)
+        profile = str(task.get("payload", {}).get("target_profile") or "")
+        member = next(
+            (
+                candidate
+                for candidate in room["members"]
+                if str(candidate.get("profile") or "") == profile
+            ),
+            None,
+        )
+        if member is None:
+            raise RuntimeError("hosted attachment target is not in the frozen roster")
+        member_id = str(member.get("member_id") or "")
+        for manifest in manifests:
+            stored = self.attachments.read(
+                room_id=binding.room_id,
+                attachment_id=manifest.get("attachment_id"),
+                recipient_member_id=member_id,
+            )
+            safe = {
+                "attachment_id": stored.attachment["attachment_id"],
+                "kind": stored.attachment["kind"],
+                "name": stored.attachment["name"],
+                "size": stored.attachment["size"],
+                "mime": stored.attachment["mime"],
+            }
+            if safe != dict(manifest):
+                raise RuntimeError(
+                    "hosted attachment metadata changed after task admission"
+                )
+            yield safe, stored.data
 
     def _publish_terminal_tasks(
         self,
@@ -231,6 +280,45 @@ class HostedRoomService:
         self.runtime.wakeup()
         return room
 
+    def put_attachment(
+        self,
+        *,
+        room_id: str,
+        upload_id: str,
+        kind: str,
+        name: str,
+        mime: str,
+        data: bytes,
+    ) -> dict[str, Any]:
+        """Store one bounded upload for a live room without exposing its path."""
+
+        hosted_rooms.room_state(self.db_path, room_id=room_id)
+        return self.attachments.put(
+            room_id=room_id,
+            upload_id=upload_id,
+            kind=kind,
+            name=name,
+            mime=mime,
+            data=data,
+        )
+
+    def read_attachment(
+        self,
+        *,
+        room_id: str,
+        attachment_id: str,
+        recipient_member_id: str,
+        event_id: str | None = None,
+    ) -> AttachmentData:
+        """Return verified bytes only when send-time recipient ownership permits it."""
+
+        return self.attachments.read(
+            room_id=room_id,
+            attachment_id=attachment_id,
+            recipient_member_id=recipient_member_id,
+            event_id=event_id,
+        )
+
     def send(
         self,
         *,
@@ -239,7 +327,25 @@ class HostedRoomService:
         payload: Any,
         actor: Mapping[str, Any] | None = None,
     ) -> dict[str, Any]:
-        normalized = discussion.validate_user_payload(payload)
+        room = hosted_rooms.room_state(self.db_path, room_id=room_id)
+        member_ids = tuple(
+            str(member.get("member_id") or member.get("profile") or "")
+            for member in room["members"]
+        )
+        if isinstance(payload, Mapping) and "thread_id" not in payload:
+            payload = {**payload, "thread_id": event_id}
+        normalized = discussion.validate_user_payload(
+            payload,
+            member_ids=member_ids,
+        )
+        if normalized.get("attachments"):
+            normalized["attachments"] = self.attachments.commit_message(
+                room_id=room_id,
+                event_id=event_id,
+                manifest=normalized["attachments"],
+                recipient_member_ids=(*member_ids, "viewer"),
+                hold_until_event=True,
+            )
         event = hosted_rooms.append_event(
             self.db_path,
             room_id=room_id,
@@ -248,6 +354,8 @@ class HostedRoomService:
             actor=actor or {"kind": "user", "id": "desktop"},
             payload=normalized,
         )
+        if normalized.get("attachments"):
+            self.attachments.retain_event(room_id=room_id, event_id=event_id)
         binding = next(
             (candidate for candidate in self.bindings() if candidate.room_id == room_id),
             None,

--- a/tui_gateway/methods_groups.py
+++ b/tui_gateway/methods_groups.py
@@ -1,15 +1,64 @@
 """Hosted-room JSON-RPC contract.
 
-These methods expose durable room identity and an append-only, monotonic room
-log. They deliberately do not drive Bot turns yet. ``groups.capabilities``
-makes that boundary machine-readable so a hosted-aware Desktop cannot mistake
-the log prototype for a complete gateway-side orchestrator.
+These methods expose durable room identity, replay, and the process-owned
+same-gateway Discussion driver. ``groups.capabilities`` keeps that boundary
+machine-readable so older clients stay on the renderer-owned room path.
 """
 
 from .method_ctx import HandlerRegistry
 
+import os
+import threading
+
 _registry = HandlerRegistry()
 method = _registry.method
+
+_service_lock = threading.Lock()
+_bound_server = None
+_service = None
+
+
+def bind_server(server) -> None:
+    """Bind the fully initialized server module without starting a worker."""
+
+    global _bound_server
+    _bound_server = server
+
+
+def start_hosted_room_service():
+    """Start one process-owned hosted room service idempotently."""
+
+    global _service
+    if _bound_server is None:
+        return None
+    from gateway.hosted_rooms import default_db_path
+    from tui_gateway.hosted_room_service import HostedRoomService
+
+    db_path = default_db_path()
+    with _service_lock:
+        if _service is not None and _service.db_path != db_path:
+            _service.stop(timeout=1.0)
+            _service = None
+        if _service is None:
+            _service = HostedRoomService(_bound_server, db_path=db_path)
+        _service.start()
+        return _service
+
+
+def stop_hosted_room_service(*, timeout: float = 5.0) -> bool:
+    """Stop the process-owned worker without interrupting accepted turns."""
+
+    global _service
+    with _service_lock:
+        service = _service
+        _service = None
+    return True if service is None else service.stop(timeout=timeout)
+
+
+def get_hosted_room_service():
+    """Return the active service, if its lifecycle owner started it."""
+
+    return _service
 
 
 @method("groups.capabilities")
@@ -21,11 +70,14 @@ def _(rid, params: dict) -> dict:
         local_authority_gateway_id,
     )
 
+    service = get_hosted_room_service()
+    driver_ready = bool(service and service.runtime.status()["running"])
     return _ok(
         rid,
         {
             "protocol_version": PROTOCOL_VERSION,
-            "driver": False,
+            "driver": driver_ready,
+            "persistent_process": os.getenv("HERMES_DESKTOP") != "1",
             "authority_gateway_id": local_authority_gateway_id(),
             "features": [
                 "authority_epoch",
@@ -45,6 +97,7 @@ def _(rid, params: dict) -> dict:
                 "groups.send",
                 "groups.log",
                 "groups.disband",
+                "groups.stop",
             ],
             "max_log_limit": MAX_LOG_LIMIT,
         },
@@ -85,12 +138,21 @@ def _(rid, params: dict) -> dict:
     )
 
     try:
-        room = create_room(
-            default_db_path(),
-            room_id=params.get("room_id"),
-            name=params.get("name"),
-            members=params.get("members"),
-            authority_gateway_id=local_authority_gateway_id(),
+        service = get_hosted_room_service()
+        room = (
+            service.create_room(
+                room_id=params.get("room_id"),
+                name=params.get("name"),
+                members=params.get("members"),
+            )
+            if service is not None
+            else create_room(
+                default_db_path(),
+                room_id=params.get("room_id"),
+                name=params.get("name"),
+                members=params.get("members"),
+                authority_gateway_id=local_authority_gateway_id(),
+            )
         )
         return _ok(rid, {"room": room})
     except HostedRoomError as exc:
@@ -105,14 +167,21 @@ def _(rid, params: dict) -> dict:
     from gateway.hosted_rooms import HostedRoomError, default_db_path, room_state
 
     try:
+        room = room_state(
+            default_db_path(),
+            room_id=params.get("room_id"),
+            include_disbanded=params.get("include_disbanded") is True,
+        )
+        service = get_hosted_room_service()
         return _ok(
             rid,
             {
-                "room": room_state(
-                    default_db_path(),
-                    room_id=params.get("room_id"),
-                    include_disbanded=params.get("include_disbanded") is True,
-                )
+                "room": room,
+                **(
+                    {"driver_status": service.status(str(room["room_id"]))}
+                    if service is not None and room.get("disbanded_at") is None
+                    else {}
+                ),
             },
         )
     except HostedRoomError as exc:
@@ -133,20 +202,29 @@ def _(rid, params: dict) -> dict:
     from gateway.hosted_rooms import HostedRoomError, append_event, default_db_path
 
     try:
-        event = append_event(
-            default_db_path(),
-            room_id=params.get("room_id"),
-            event_id=params.get("event_id"),
-            kind="message.user",
-            actor={"kind": "user", "id": "desktop"},
-            payload=params.get("payload"),
+        service = get_hosted_room_service()
+        event = (
+            service.send(
+                room_id=params.get("room_id"),
+                event_id=params.get("event_id"),
+                payload=params.get("payload"),
+            )
+            if service is not None
+            else append_event(
+                default_db_path(),
+                room_id=params.get("room_id"),
+                event_id=params.get("event_id"),
+                kind="message.user",
+                actor={"kind": "user", "id": "desktop"},
+                payload=params.get("payload"),
+            )
         )
         return _ok(
             rid,
             {
                 "event": event,
                 "accepted": True,
-                "driver_started": False,
+                "driver_started": service is not None,
             },
         )
     except HostedRoomError as exc:
@@ -161,6 +239,12 @@ def _(rid, params: dict) -> dict:
     from gateway.hosted_rooms import HostedRoomError, default_db_path, disband_room
 
     try:
+        service = get_hosted_room_service()
+        if service is not None:
+            service.stop_room(
+                str(params.get("room_id") or ""),
+                cancel_id=str(params.get("cancel_id") or "room-disbanded"),
+            )
         tombstone = disband_room(
             default_db_path(),
             room_id=params.get("room_id"),
@@ -170,6 +254,23 @@ def _(rid, params: dict) -> dict:
         return _err(rid, 4113, str(exc))
     except Exception as exc:
         return _err(rid, 5114, str(exc))
+
+
+@method("groups.stop")
+def _(rid, params: dict) -> dict:
+    """Durably cancel queued or running work for one hosted room."""
+
+    service = get_hosted_room_service()
+    if service is None:
+        return _err(rid, 4115, "hosted room driver is unavailable")
+    try:
+        count = service.stop_room(
+            str(params.get("room_id") or ""),
+            cancel_id=str(params.get("cancel_id") or "desktop-stop"),
+        )
+        return _ok(rid, {"cancelled": count})
+    except Exception as exc:
+        return _err(rid, 5116, str(exc))
 
 
 @method("groups.log")

--- a/tui_gateway/methods_groups.py
+++ b/tui_gateway/methods_groups.py
@@ -1,0 +1,196 @@
+"""Hosted-room JSON-RPC contract.
+
+These methods expose durable room identity and an append-only, monotonic room
+log. They deliberately do not drive Bot turns yet. ``groups.capabilities``
+makes that boundary machine-readable so a hosted-aware Desktop cannot mistake
+the log prototype for a complete gateway-side orchestrator.
+"""
+
+from .method_ctx import HandlerRegistry
+
+_registry = HandlerRegistry()
+method = _registry.method
+
+
+@method("groups.capabilities")
+def _(rid, params: dict) -> dict:
+    """Describe the hosted-room protocol implemented by this gateway."""
+    from gateway.hosted_rooms import (
+        MAX_LOG_LIMIT,
+        PROTOCOL_VERSION,
+        local_authority_gateway_id,
+    )
+
+    return _ok(
+        rid,
+        {
+            "protocol_version": PROTOCOL_VERSION,
+            "driver": False,
+            "authority_gateway_id": local_authority_gateway_id(),
+            "features": [
+                "authority_epoch",
+                "coordinator_fencing",
+                "room_identity",
+                "monotonic_log",
+                "idempotent_send",
+                "replayable_disband",
+                "typed_events",
+                "actor_identity",
+            ],
+            "methods": [
+                "groups.capabilities",
+                "groups.list",
+                "groups.create",
+                "groups.state",
+                "groups.send",
+                "groups.log",
+                "groups.disband",
+            ],
+            "max_log_limit": MAX_LOG_LIMIT,
+        },
+    )
+
+
+@method("groups.list")
+def _(rid, params: dict) -> dict:
+    """List rooms hosted by this gateway."""
+    try:
+        from gateway.hosted_rooms import default_db_path, list_rooms
+
+        return _ok(
+            rid,
+            {
+                "rooms": list_rooms(
+                    default_db_path(),
+                    include_disbanded=params.get("include_disbanded") is True,
+                )
+            },
+        )
+    except Exception as exc:
+        return _err(rid, 5110, str(exc))
+
+
+@method("groups.create")
+def _(rid, params: dict) -> dict:
+    """Create a hosted room idempotently.
+
+    Required params: ``room_id``, ``name``, and ``members``. Authority is
+    derived from this gateway's stable install identity, never from the client.
+    """
+    from gateway.hosted_rooms import (
+        HostedRoomError,
+        create_room,
+        default_db_path,
+        local_authority_gateway_id,
+    )
+
+    try:
+        room = create_room(
+            default_db_path(),
+            room_id=params.get("room_id"),
+            name=params.get("name"),
+            members=params.get("members"),
+            authority_gateway_id=local_authority_gateway_id(),
+        )
+        return _ok(rid, {"room": room})
+    except HostedRoomError as exc:
+        return _err(rid, 4110, str(exc))
+    except Exception as exc:
+        return _err(rid, 5111, str(exc))
+
+
+@method("groups.state")
+def _(rid, params: dict) -> dict:
+    """Return one hosted room's replay cursor and fenced authority state."""
+    from gateway.hosted_rooms import HostedRoomError, default_db_path, room_state
+
+    try:
+        return _ok(
+            rid,
+            {
+                "room": room_state(
+                    default_db_path(),
+                    room_id=params.get("room_id"),
+                    include_disbanded=params.get("include_disbanded") is True,
+                )
+            },
+        )
+    except HostedRoomError as exc:
+        return _err(rid, 4114, str(exc))
+    except Exception as exc:
+        return _err(rid, 5115, str(exc))
+
+
+@method("groups.send")
+def _(rid, params: dict) -> dict:
+    """Append one typed event to a hosted room idempotently.
+
+    Required params: ``room_id``, ``event_id``, and object ``payload``. Only
+    inert ``message.user`` events are accepted through this client-facing
+    method. The actor is server-owned rather than trusted from params.
+    Admission is durable; no Bot turn is started by this slice.
+    """
+    from gateway.hosted_rooms import HostedRoomError, append_event, default_db_path
+
+    try:
+        event = append_event(
+            default_db_path(),
+            room_id=params.get("room_id"),
+            event_id=params.get("event_id"),
+            kind="message.user",
+            actor={"kind": "user", "id": "desktop"},
+            payload=params.get("payload"),
+        )
+        return _ok(
+            rid,
+            {
+                "event": event,
+                "accepted": True,
+                "driver_started": False,
+            },
+        )
+    except HostedRoomError as exc:
+        return _err(rid, 4111, str(exc))
+    except Exception as exc:
+        return _err(rid, 5112, str(exc))
+
+
+@method("groups.disband")
+def _(rid, params: dict) -> dict:
+    """Permanently tombstone a hosted room id."""
+    from gateway.hosted_rooms import HostedRoomError, default_db_path, disband_room
+
+    try:
+        tombstone = disband_room(
+            default_db_path(),
+            room_id=params.get("room_id"),
+        )
+        return _ok(rid, {"tombstone": tombstone})
+    except HostedRoomError as exc:
+        return _err(rid, 4113, str(exc))
+    except Exception as exc:
+        return _err(rid, 5114, str(exc))
+
+
+@method("groups.log")
+def _(rid, params: dict) -> dict:
+    """Return a monotonic room-log delta after ``since_seq``."""
+    from gateway.hosted_rooms import HostedRoomError, default_db_path, read_events
+
+    try:
+        delta = read_events(
+            default_db_path(),
+            room_id=params.get("room_id"),
+            since_seq=params.get("since_seq", 0),
+            limit=params.get("limit", 100),
+            include_disbanded=params.get("include_disbanded") is True,
+        )
+        return _ok(rid, delta)
+    except HostedRoomError as exc:
+        return _err(rid, 4112, str(exc))
+    except Exception as exc:
+        return _err(rid, 5113, str(exc))
+
+
+def register(server) -> None:
+    _registry.install(server)

--- a/tui_gateway/methods_groups.py
+++ b/tui_gateway/methods_groups.py
@@ -82,6 +82,7 @@ def _(rid, params: dict) -> dict:
             "features": [
                 "authority_epoch",
                 "coordinator_fencing",
+                "desktop_compatibility_mailbox",
                 "room_identity",
                 "monotonic_log",
                 "idempotent_send",
@@ -98,10 +99,69 @@ def _(rid, params: dict) -> dict:
                 "groups.log",
                 "groups.disband",
                 "groups.stop",
+                "groups.desktop.claim",
+                "groups.desktop.renew",
+                "groups.desktop.complete",
             ],
             "max_log_limit": MAX_LOG_LIMIT,
         },
     )
+
+
+@method("groups.desktop.claim")
+def _(rid, params: dict) -> dict:
+    """Advertise classic rooms and lease pending messaging commands."""
+
+    try:
+        from gateway.desktop_room_mailbox import claim_commands, default_db_path
+
+        commands = claim_commands(
+            default_db_path(),
+            consumer_id=params.get("consumer_id"),
+            room_ids=params.get("room_ids", []),
+            limit=params.get("limit", 8),
+        )
+        return _ok(rid, {"commands": commands})
+    except Exception as exc:
+        return _err(rid, 4130, str(exc))
+
+
+@method("groups.desktop.complete")
+def _(rid, params: dict) -> dict:
+    """Commit the outcome of one classic-room compatibility command."""
+
+    try:
+        from gateway.desktop_room_mailbox import complete_command, default_db_path
+
+        command = complete_command(
+            default_db_path(),
+            consumer_id=params.get("consumer_id"),
+            command_id=params.get("command_id"),
+            lease_token=params.get("lease_token"),
+            success=params.get("success") is True,
+            result=params.get("result", {}),
+        )
+        return _ok(rid, {"command": command})
+    except Exception as exc:
+        return _err(rid, 4131, str(exc))
+
+
+@method("groups.desktop.renew")
+def _(rid, params: dict) -> dict:
+    """Renew one live classic-room command lease while its turn settles."""
+
+    try:
+        from gateway.desktop_room_mailbox import default_db_path, renew_command
+
+        command = renew_command(
+            default_db_path(),
+            consumer_id=params.get("consumer_id"),
+            command_id=params.get("command_id"),
+            lease_token=params.get("lease_token"),
+        )
+        return _ok(rid, {"command": command})
+    except Exception as exc:
+        return _err(rid, 4132, str(exc))
 
 
 @method("groups.list")

--- a/tui_gateway/methods_groups.py
+++ b/tui_gateway/methods_groups.py
@@ -118,7 +118,8 @@ def _(rid, params: dict) -> dict:
         commands = claim_commands(
             default_db_path(),
             consumer_id=params.get("consumer_id"),
-            room_ids=params.get("room_ids", []),
+            room_authorities=params.get("room_authorities", []),
+            actions=params.get("actions"),
             limit=params.get("limit", 8),
         )
         return _ok(rid, {"commands": commands})

--- a/tui_gateway/methods_groups.py
+++ b/tui_gateway/methods_groups.py
@@ -80,6 +80,8 @@ def _(rid, params: dict) -> dict:
             "persistent_process": os.getenv("HERMES_DESKTOP") != "1",
             "authority_gateway_id": local_authority_gateway_id(),
             "features": [
+                "attachment_ids",
+                "attachment_same_gateway_delivery",
                 "authority_epoch",
                 "coordinator_fencing",
                 "desktop_compatibility_mailbox",
@@ -96,6 +98,8 @@ def _(rid, params: dict) -> dict:
                 "groups.create",
                 "groups.state",
                 "groups.send",
+                "groups.attachment.put",
+                "groups.attachment.read",
                 "groups.log",
                 "groups.disband",
                 "groups.stop",
@@ -106,6 +110,100 @@ def _(rid, params: dict) -> dict:
             "max_log_limit": MAX_LOG_LIMIT,
         },
     )
+
+
+@method("groups.attachment.put")
+def _(rid, params: dict) -> dict:
+    """Store one bounded attachment on the room's authority gateway."""
+
+    try:
+        from gateway.hosted_room_attachments import (
+            HostedRoomAttachmentStore,
+            decode_content_base64,
+        )
+        from gateway.hosted_rooms import default_db_path, room_state
+
+        data = decode_content_base64(params.get("content_base64"))
+        service = get_hosted_room_service()
+        if service is not None:
+            attachment = service.put_attachment(
+                room_id=params.get("room_id"),
+                upload_id=params.get("upload_id"),
+                kind=params.get("kind"),
+                name=params.get("name"),
+                mime=params.get("mime"),
+                data=data,
+            )
+        else:
+            db_path = default_db_path()
+            room_state(db_path, room_id=params.get("room_id"))
+            attachment = HostedRoomAttachmentStore(db_path).put(
+                room_id=params.get("room_id"),
+                upload_id=params.get("upload_id"),
+                kind=params.get("kind"),
+                name=params.get("name"),
+                mime=params.get("mime"),
+                data=data,
+            )
+        return _ok(rid, {"attachment": attachment})
+    except Exception as exc:
+        return _err(rid, 4140, str(exc))
+
+
+@method("groups.attachment.read")
+def _(rid, params: dict) -> dict:
+    """Read one committed attachment through its room/recipient ownership."""
+
+    try:
+        from gateway.hosted_room_attachments import (
+            HostedRoomAttachmentStore,
+            encode_content_base64,
+        )
+        from gateway.hosted_rooms import RoomNotFoundError, default_db_path, room_state
+
+        hosted_db_path = default_db_path()
+        purpose = str(params.get("purpose") or "").strip().casefold()
+        try:
+            room_state(hosted_db_path, room_id=params.get("room_id"))
+        except RoomNotFoundError:
+            if purpose == "viewer":
+                recipient = "viewer"
+            elif purpose == "desktop-command":
+                from gateway.desktop_room_mailbox import (
+                    authorize_attachment_read,
+                    default_db_path as mailbox_db_path,
+                )
+
+                authorize_attachment_read(
+                    mailbox_db_path(),
+                    room_id=params.get("room_id"),
+                    command_id=params.get("event_id"),
+                    consumer_id=params.get("consumer_id"),
+                    lease_token=params.get("lease_token"),
+                    authority_token=params.get("authority_token"),
+                )
+                recipient = "desktop"
+            else:
+                raise ValueError("attachment read purpose is required")
+        else:
+            if purpose != "viewer":
+                raise ValueError("hosted attachment reads are viewer-only over RPC")
+            recipient = "viewer"
+        stored = HostedRoomAttachmentStore(hosted_db_path).read(
+            room_id=params.get("room_id"),
+            attachment_id=params.get("attachment_id"),
+            recipient_member_id=recipient,
+            event_id=params.get("event_id"),
+        )
+        return _ok(
+            rid,
+            {
+                "attachment": stored.attachment,
+                "content_base64": encode_content_base64(stored.data),
+            },
+        )
+    except Exception as exc:
+        return _err(rid, 4141, str(exc))
 
 
 @method("groups.desktop.claim")
@@ -260,26 +358,63 @@ def _(rid, params: dict) -> dict:
     method. The actor is server-owned rather than trusted from params.
     Admission is durable; no Bot turn is started by this slice.
     """
-    from gateway.hosted_rooms import HostedRoomError, append_event, default_db_path
+    from gateway.hosted_rooms import (
+        HostedRoomError,
+        append_event,
+        default_db_path,
+        room_state,
+    )
 
     try:
         service = get_hosted_room_service()
-        event = (
-            service.send(
+        if service is not None:
+            event = service.send(
                 room_id=params.get("room_id"),
                 event_id=params.get("event_id"),
                 payload=params.get("payload"),
             )
-            if service is not None
-            else append_event(
-                default_db_path(),
+        else:
+            from gateway import hosted_room_discussion as discussion
+            from gateway.hosted_room_attachments import HostedRoomAttachmentStore
+
+            db_path = default_db_path()
+            room = room_state(db_path, room_id=params.get("room_id"))
+            member_ids = tuple(
+                str(member.get("member_id") or member.get("profile") or "")
+                for member in room["members"]
+            )
+            raw_payload = params.get("payload")
+            if isinstance(raw_payload, dict) and "thread_id" not in raw_payload:
+                raw_payload = {
+                    **raw_payload,
+                    "thread_id": params.get("event_id"),
+                }
+            payload = discussion.validate_user_payload(
+                raw_payload,
+                member_ids=member_ids,
+            )
+            attachment_store = HostedRoomAttachmentStore(db_path)
+            if payload.get("attachments"):
+                payload["attachments"] = attachment_store.commit_message(
+                    room_id=room["room_id"],
+                    event_id=params.get("event_id"),
+                    manifest=payload["attachments"],
+                    recipient_member_ids=(*member_ids, "viewer"),
+                    hold_until_event=True,
+                )
+            event = append_event(
+                db_path,
                 room_id=params.get("room_id"),
                 event_id=params.get("event_id"),
                 kind="message.user",
                 actor={"kind": "user", "id": "desktop"},
-                payload=params.get("payload"),
+                payload=payload,
             )
-        )
+            if payload.get("attachments"):
+                attachment_store.retain_event(
+                    room_id=room["room_id"],
+                    event_id=params.get("event_id"),
+                )
         return _ok(
             rid,
             {
@@ -310,6 +445,14 @@ def _(rid, params: dict) -> dict:
             default_db_path(),
             room_id=params.get("room_id"),
         )
+        if service is not None:
+            service.attachments.mark_room_disbanded(tombstone["room_id"])
+        else:
+            from gateway.hosted_room_attachments import HostedRoomAttachmentStore
+
+            HostedRoomAttachmentStore(default_db_path()).mark_room_disbanded(
+                tombstone["room_id"]
+            )
         return _ok(rid, {"tombstone": tombstone})
     except HostedRoomError as exc:
         return _err(rid, 4113, str(exc))

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -335,6 +335,57 @@ def _(rid, params: dict) -> dict:
     session, err = _sess_nowait(params, rid)
     if err:
         return err
+    hosted_task = params.get("_hosted_task")
+    hosted_terminal_callback = params.get("_hosted_terminal_callback")
+    internal_hosted_submit = hosted_task is not None or hosted_terminal_callback is not None
+    if internal_hosted_submit:
+        if session.get("source") != "bot_room":
+            return _err(rid, 4120, "hosted room turns require a bot_room session")
+        if not isinstance(hosted_task, dict) or not callable(hosted_terminal_callback):
+            return _err(rid, 4120, "invalid hosted room turn proof")
+        required_hosted_fields = {
+            "room_id",
+            "task_id",
+            "thread_id",
+            "turn_id",
+            "execution_generation",
+        }
+        if set(hosted_task) != required_hosted_fields or not all(
+            isinstance(hosted_task.get(field), str) and hosted_task[field]
+            for field in required_hosted_fields - {"execution_generation"}
+        ) or not isinstance(hosted_task.get("execution_generation"), int):
+            return _err(rid, 4120, "invalid hosted room turn proof")
+    else:
+        # Older Desktop builds know the `Group: <room-id>` session title but
+        # not the hosted authority marker. Once a gateway owns that room, a
+        # direct prompt into its member session would start a second renderer
+        # driver. Fence it server-side instead of trusting client awareness.
+        title = str(session.get("title") or "")
+        if title.startswith("Group: "):
+            room_id = title.removeprefix("Group: ").strip()
+            if room_id:
+                try:
+                    from gateway.hosted_rooms import (
+                        RoomNotFoundError,
+                        default_db_path,
+                        room_state,
+                    )
+
+                    room_state(default_db_path(), room_id=room_id)
+                except RoomNotFoundError:
+                    pass
+                except Exception:
+                    return _err(
+                        rid,
+                        5122,
+                        "Could not verify this group. Try again after the gateway recovers.",
+                    )
+                else:
+                    return _err(
+                        rid,
+                        4122,
+                        "This room is managed by its gateway. Update Hermes Desktop to continue it.",
+                    )
     if (limit_message := _ensure_active_session_slot(sid, session)) is not None:
         return _err(rid, 4090, limit_message)
     # Which desktop window this message was typed into. Rewritten on every
@@ -357,6 +408,12 @@ def _(rid, params: dict) -> dict:
         )
     isolation_cfg = _load_dashboard_process_isolation_config()
     turn_isolation = _session_uses_compute_host(session, isolation_cfg)
+    if internal_hosted_submit and turn_isolation:
+        return _err(
+            rid,
+            4121,
+            "hosted room turns do not support isolated compute workers yet",
+        )
     # Re-bind to the current client transport for this request. This keeps
     # streaming events on the active websocket even if an earlier disconnect
     # or fallback moved the session transport to stdio.
@@ -366,6 +423,8 @@ def _(rid, params: dict) -> dict:
         busy_transport = None
         with session["history_lock"]:
             if session.get("running"):
+                if internal_hosted_submit:
+                    return _err(rid, 4091, "hosted room member session is busy")
                 # Don't reject a mid-turn prompt — queue it (and, by default,
                 # interrupt the live turn) so it runs as the next turn. The
                 # provider interrupt itself must happen after this lock is
@@ -812,6 +871,8 @@ def _(rid, params: dict) -> dict:
         session["running"] = True
         session["_turn_cancel_requested"] = False
         session["last_active"] = time.time()
+        if internal_hosted_submit:
+            session["_hosted_room_task"] = dict(hosted_task)
         _start_inflight_turn(session, text)
 
     if turn_isolation:
@@ -908,7 +969,14 @@ def _(rid, params: dict) -> dict:
                     },
                 )
                 return
-        _run_prompt_submit(rid, sid, session, text, display_kind=display_kind)
+        _run_prompt_submit(
+            rid,
+            sid,
+            session,
+            text,
+            display_kind=display_kind,
+            terminal_callback=hosted_terminal_callback,
+        )
 
     run_thread = threading.Thread(target=run_after_agent_ready, daemon=True)
     # Keep a handle so session.interrupt can tell a live turn from a stuck

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -3332,6 +3332,18 @@ def _(rid, params: dict) -> dict:
     session, err = _sess_nowait(params, rid)
     if err:
         return err
+    expected_hosted_task_id = str(
+        params.get("expected_hosted_task_id") or ""
+    ).strip()
+    if expected_hosted_task_id:
+        with session["history_lock"]:
+            active_task = session.get("_hosted_room_task")
+            if (
+                not session.get("running")
+                or not isinstance(active_task, dict)
+                or active_task.get("task_id") != expected_hosted_task_id
+            ):
+                return _ok(rid, {"status": "not_interrupted", "interrupted": False})
     if _session_uses_compute_host(session):
         sid = str(params.get("session_id") or "")
         try:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4985,6 +4985,17 @@ def _bot_relay_outbox_sig():
     return _bot_relay_outbox_seen or None
 
 
+def _desktop_room_mailbox_sig():
+    """mtime of commands written by a messaging process for Desktop rooms."""
+
+    home = _watcher_home()
+    root = home.parent.parent if home.parent.name == "profiles" else home
+    try:
+        return (root / "desktop_room_mailbox.pending").stat().st_mtime_ns
+    except OSError:
+        return None
+
+
 # Watched change signals: event → (check interval, signature fn, payload fn).
 # Signatures are stat/dict-lookup cheap, same bar as the skin watcher; the
 # check interval keeps the pricier probes (pet resolves the active sheet off
@@ -4998,6 +5009,11 @@ _CHANGE_WATCHES: dict[str, tuple[float, Any, Any]] = {
     # Cross-connection DM latency: 1s check so a queued envelope reaches the
     # Desktop's push-triggered drain fast; the Desktop's poll stays backstop.
     "bot_relay.outbox.pending": (1.0, _bot_relay_outbox_sig, lambda: {}),
+    "desktop_rooms.commands.pending": (
+        1.0,
+        _desktop_room_mailbox_sig,
+        lambda: {},
+    ),
 }
 
 # state.db moves on every message append during a streaming turn, and the

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -309,6 +309,15 @@ _LONG_HANDLERS = frozenset(
         "bot_relay.outbox.drain",
         "bot_relay.deliver",
         "bot_relay.reply",
+        # Hosted-room log calls open the shared state database and may wait on
+        # a concurrent room writer. Keep that bounded wait off the WS reader.
+        "groups.list",
+        "groups.capabilities",
+        "groups.create",
+        "groups.state",
+        "groups.send",
+        "groups.log",
+        "groups.disband",
         # image.generate is a multi-second remote API round-trip.
         "image.generate",
         "projects.discover_repos",
@@ -17284,6 +17293,7 @@ from . import (  # noqa: E402
     methods_bot_relay as _methods_bot_relay,
     methods_complete as _methods_complete,
     methods_config as _methods_config,
+    methods_groups as _methods_groups,
     methods_images as _methods_images,
     methods_profiles as _methods_profiles,
     methods_prompt as _methods_prompt,
@@ -17301,6 +17311,7 @@ for _m in (
     _methods_profiles,
     _methods_images,
     _methods_bot_relay,
+    _methods_groups,
 ):
     _m.register(sys.modules[__name__])
 del _m

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -318,6 +318,7 @@ _LONG_HANDLERS = frozenset(
         "groups.send",
         "groups.log",
         "groups.disband",
+        "groups.stop",
         # image.generate is a multi-second remote API round-trip.
         "image.generate",
         "projects.discover_repos",
@@ -9446,6 +9447,12 @@ def _maybe_schedule_auto_continue(sid: str, session: dict, session_key: str) -> 
     same _run_prompt_submit machinery as every other synthesized turn — so
     the client that just resumed streams it live.
     """
+    # Hosted room turns are recovered by their durable task/lease state
+    # machine. Generic session auto-continue would bypass its execution
+    # generation and can duplicate work after a process restart.
+    if session.get("source") == "bot_room":
+        return None
+
     home = _session_home(session)
     marker = read_turn_marker(home, session_key)
     if marker is None:
@@ -9925,7 +9932,12 @@ def _inflight_snapshot(session: dict) -> dict | None:
 
 
 def _emit_terminal_turn_error(
-    sid: str, session: dict, error: Any, error_surface: Optional[dict] = None
+    sid: str,
+    session: dict,
+    error: Any,
+    error_surface: Optional[dict] = None,
+    *,
+    retire_marker: bool = True,
 ) -> None:
     """Close a failed turn with a terminal ``message.complete`` frame.
 
@@ -9978,7 +9990,8 @@ def _emit_terminal_turn_error(
         rendered = ""
     if rendered:
         payload["rendered"] = rendered
-    _retire_turn_marker(session)
+    if retire_marker:
+        _retire_turn_marker(session)
     _emit("message.complete", sid, payload)
 
 
@@ -12217,6 +12230,7 @@ def _run_prompt_submit(
     display_metadata: dict | None = None,
     image_paths: list[str] | None = None,
     queued_prompt_generation: int | None = None,
+    terminal_callback: Callable[[dict[str, Any]], None] | None = None,
 ) -> bool:
     with session["history_lock"]:
         if session.get("_closing"):
@@ -12266,6 +12280,8 @@ def _run_prompt_submit(
     _emit("message.start", sid)
 
     def run():
+        terminal_receipt_attempted = False
+        terminal_receipt_committed = terminal_callback is None
         # The conversation runs on a fresh thread, so ContextVars from the RPC
         # dispatcher do not follow automatically. Rebind the exact transport
         # stored on this session generation before any tool can commission a
@@ -12806,7 +12822,26 @@ def _run_prompt_submit(
                 payload["recoverable"] = True
                 if _error_surface:
                     payload["error_surface"] = _error_surface
-            _retire_turn_marker(session, marker_key)
+            if terminal_callback is not None:
+                terminal_receipt_attempted = True
+                terminal_callback(
+                    {
+                        "status": (
+                            "cancelled"
+                            if status == "interrupted"
+                            else "failed" if status == "error" else "settled"
+                        ),
+                        "text": raw if isinstance(raw, str) else str(raw),
+                        **(
+                            {"error": str(result.get("error") or raw)}
+                            if status == "error" and isinstance(result, dict)
+                            else {}
+                        ),
+                    }
+                )
+                terminal_receipt_committed = True
+            if terminal_receipt_committed:
+                _retire_turn_marker(session, marker_key)
             _emit("message.complete", sid, payload)
 
             # ── /goal continuation (Ralph-style loop) ─────────────────
@@ -12986,11 +13021,25 @@ def _run_prompt_submit(
             # Keep the partial turn available to the next prompt; the durable
             # inflight record still carries the recoverable error state.
             _restore_agent_history_after_turn_error(session, agent)
+            if terminal_callback is not None and not terminal_receipt_attempted:
+                terminal_receipt_attempted = True
+                try:
+                    terminal_callback(
+                        {"status": "failed", "text": "", "error": str(e)}
+                    )
+                    terminal_receipt_committed = True
+                except Exception:
+                    logger.exception("hosted room terminal receipt commit failed")
             try:
                 # Close the turn with the same terminal error frame shape as
                 # the returned-error path (uniform client handling), retaining
                 # the failed turn for resume replay.
-                _emit_terminal_turn_error(sid, session, e)
+                _emit_terminal_turn_error(
+                    sid,
+                    session,
+                    e,
+                    retire_marker=terminal_receipt_committed,
+                )
                 turn_error_retained = True
             except Exception as emit_exc:
                 print(
@@ -13085,7 +13134,10 @@ def _run_prompt_submit(
             )
             # Backstop for turns that never reached a terminal frame (the
             # frame paths retire the marker as they emit).
-            _retire_turn_marker(session, marker_key)
+            if terminal_receipt_committed:
+                _retire_turn_marker(session, marker_key)
+                with session["history_lock"]:
+                    session.pop("_hosted_room_task", None)
             session.pop("_auto_continue_scheduled", None)
             _emit_settled_session_info(sid, session, agent)
 
@@ -17301,6 +17353,11 @@ from . import (  # noqa: E402
     methods_tools as _methods_tools,
 )
 
+# HandlerRegistry rebinds handler globals onto this module. Publish the hosted
+# service accessor here so methods_groups handlers resolve the lifecycle-owned
+# singleton rather than starting one from an RPC call.
+get_hosted_room_service = _methods_groups.get_hosted_room_service
+
 for _m in (
     _methods_browser_control,
     _methods_session,
@@ -17315,3 +17372,4 @@ for _m in (
 ):
     _m.register(sys.modules[__name__])
 del _m
+_methods_groups.bind_server(sys.modules[__name__])


### PR DESCRIPTION
## The user problem

Sharing a file with a Bot Group Chat should feel like sharing one in any normal
chat. It should not matter whether the chat is hosted by a gateway, still run by
Desktop, or reached from Signal, Telegram, WhatsApp, Slack, or another Hermes
messaging adapter.

Today those paths do not share one complete lifecycle. This draft connects the
existing Desktop attachment UX to the durable gateway layer from the parent PR.

> [!IMPORTANT]
> This draft is stacked on the attachment runtime PR. Review
> `57962642d7..a7eddf11a3`.

## What users can do

### From Desktop

Use the existing picker, paste, or drag and drop in a Group Chat. Images, PDFs,
Office files, archives, and other files are uploaded before the durable room
command is accepted.

### From a messaging app

Attach a file to the normal Group Chat command:

```text
/group list
/group 2
/group 2 send
```

The attachment may be sent with text or by itself. Hermes localizes it through
the adapter's authenticated media cache, stores it once, and reports the same
Group Chat status and recent activity as a text message.

### In history

History keeps the file name, type, size, opaque ID, and source gateway, never
the raw bytes or a machine path. Images can load a preview on demand; files can
be downloaded on demand. The local cache is bounded.

## What users can rely on

- The draft stays in the composer until every upload and the durable command
  enqueue succeed.
- Typing during an upload preserves the newer text and newly added files while
  removing only the files that were actually sent.
- Transport redelivery reuses the same upload and room entry, even after the
  adapter's temporary file has disappeared.
- A Desktop command reads files only while it holds the live room claim.
- The Bot roster is frozen at send time. A Bot added later cannot receive an
  older file, and an unavailable original Bot keeps the command safely pending.
- A Stop request can overtake a long upload/read and no partial file reaches a
  Bot turn.
- One bad or expired file produces an actionable error without exposing paths,
  URLs, bytes, or provider details.

## Compatibility

This reuses the attachment controls and per-session image/PDF/file RPCs merged
in #89486 and #89540. It preserves opaque IDs so the open chip interaction in
#89758 can compose with gateway-backed history; if #89758 lands first, this
draft should rebase onto its final chip implementation rather than duplicate it.

## Boundaries

- This stack completes same-gateway, Desktop-driven, and messaging-client file
  flows.
- Cross-gateway RoomLink byte transfer remains the next stacked increment.
- Messaging adapters must provide authenticated, already-localized cache paths,
  which is the existing `MessageEvent.media_urls` contract. Remote URLs and
  symlinks fail closed.
- Unsolicited notifications and public file URLs are not added.

## Validation at `a7eddf11a3`

| Check | Result |
|---|---:|
| Focused Python suite | 242 passed |
| Focused Desktop/hosted-client suite | 165 passed |
| Desktop TypeScript check | passed |
| Ruff | passed |
| `git diff --check` | passed |

Coverage includes image-only and attachment-only sends, PDF and generic files,
adapter redelivery, upload interruption, lease loss, priority Stop, send-time
recipient freeze, restart/replay, lazy history reads, tampering, MIME mismatch,
path traversal, symlinks, quotas, abandoned-upload cleanup, and composer edits
during upload.

Exact-head live UAT and screenshots will be added before this stack leaves
draft.

## Related work

- #89486: merged image attachment pipeline for Desktop Group Chats
- #89540: merged PDF/file and drag/drop parity
- #89758: open attachment-chip interaction follow-up
- #88983: original Group Chat attachment parity request
- #96274 / #96654: messaging control across hosted and Desktop-driven chats

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Security fix
- [x] Tests
- [ ] Refactor
