### PR TITLE
fix(tools): keep free-form object params fillable in schema sanitizer

### DIFF
--- a/tests/tools/test_schema_sanitizer.py
+++ b/tests/tools/test_schema_sanitizer.py
@@ -20,10 +20,14 @@ def _tool(name: str, parameters: dict) -> dict:
     return {"type": "function", "function": {"name": name, "parameters": parameters}}
 
 
-def test_object_without_properties_gets_empty_properties():
+def test_freeform_object_gets_empty_properties_and_marker():
     tools = [_tool("t", {"type": "object"})]
     out = sanitize_tool_schemas(tools)
-    assert out[0]["function"]["parameters"] == {"type": "object", "properties": {}}
+    assert out[0]["function"]["parameters"] == {
+        "type": "object",
+        "properties": {},
+        "additionalProperties": True,
+    }
 
 
 def test_nested_object_without_properties_gets_empty_properties():
@@ -56,6 +60,7 @@ def test_bare_string_object_value_replaced_with_schema_dict():
     assert isinstance(payload, dict)
     assert payload["type"] == "object"
     assert payload["properties"] == {}
+    assert payload["additionalProperties"] is True
 
 
 def test_nullable_type_array_collapsed_to_single_string():
@@ -130,7 +135,7 @@ def test_anyof_nested_objects_sanitized():
     })]
     out = sanitize_tool_schemas(tools)
     variants = out[0]["function"]["parameters"]["properties"]["opt"]["anyOf"]
-    assert variants[0] == {"type": "object", "properties": {}}
+    assert variants[0] == {"type": "object", "properties": {}, "additionalProperties": True}
     assert variants[1] == {"type": "string"}
 
 
@@ -182,7 +187,11 @@ def test_additional_properties_schema_sanitized():
     })]
     out = sanitize_tool_schemas(tools)
     field = out[0]["function"]["parameters"]["properties"]["dict_field"]
-    assert field["additionalProperties"] == {"type": "object", "properties": {}}
+    assert field["additionalProperties"] == {
+        "type": "object",
+        "properties": {},
+        "additionalProperties": True,
+    }
 
 
 def test_items_sanitized_in_array_schema():
@@ -197,7 +206,75 @@ def test_items_sanitized_in_array_schema():
     })]
     out = sanitize_tool_schemas(tools)
     items = out[0]["function"]["parameters"]["properties"]["bag"]["items"]
-    assert items == {"type": "object", "properties": {}}
+    assert items == {"type": "object", "properties": {}, "additionalProperties": True}
+
+
+def test_freeform_object_param_not_flattened_for_schema_literal_models():
+    """Issue #96734 regression: a free-form object param (delegate_task's
+    per-task output_schema shape) must keep ``additionalProperties: true``
+    after sanitizing, so a schema-literal model still reads it as
+    "any keys allowed" instead of "object with zero properties" and emits
+    {} for the payload."""
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {
+            "output_schema": {
+                "type": "object",
+                "description": "Optional JSON Schema the child's answer must validate against.",
+            },
+        },
+    })]
+    out = sanitize_tool_schemas(tools)
+    prop = out[0]["function"]["parameters"]["properties"]["output_schema"]
+    assert prop["type"] == "object"
+    assert prop["description"].startswith("Optional JSON Schema")
+    assert prop["properties"] == {}
+    assert prop["additionalProperties"] is True
+
+
+def test_top_level_freeform_declaration_gets_additional_properties():
+    tools = [_tool("t", {"type": "object", "description": "free-form args"})]
+    out_params = sanitize_tool_schemas(tools)[0]["function"]["parameters"]
+    assert out_params["type"] == "object"
+    assert out_params["properties"] == {}
+    assert out_params["additionalProperties"] is True
+    assert out_params["description"] == "free-form args"
+
+
+def test_missing_parameters_fallback_stays_conservative():
+    """A tool that declared NO parameters keeps the plain empty-object
+    fallback — the free-form marker is only for declared schemas."""
+    tools = [{"type": "function", "function": {"name": "t"}}]
+    out = sanitize_tool_schemas(tools)
+    assert out[0]["function"]["parameters"] == {"type": "object", "properties": {}}
+
+
+def test_explicit_additional_properties_schema_not_overwritten():
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {
+            "tags": {"type": "object", "additionalProperties": {"type": "string"}},
+        },
+    })]
+    out = sanitize_tool_schemas(tools)
+    prop = out[0]["function"]["parameters"]["properties"]["tags"]
+    # properties dict present -> node is not free-form; explicit
+    # additionalProperties value schema must survive untouched.
+    assert prop["additionalProperties"] == {"type": "string"}
+    assert "additionalProperties" not in out[0]["function"]["parameters"] or \
+        out[0]["function"]["parameters"]["properties"] != {}
+
+
+def test_closed_empty_object_not_reopened():
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {
+            "sealed": {"type": "object", "additionalProperties": False},
+        },
+    })]
+    out = sanitize_tool_schemas(tools)
+    prop = out[0]["function"]["parameters"]["properties"]["sealed"]
+    assert prop["additionalProperties"] is False
 
 
 # ─────────────────────────────────────────────────────────────────────────
@@ -343,7 +420,11 @@ def test_dependent_schemas_still_recursively_sanitized():
     tools = [_tool("t", copy.deepcopy(schema))]
     out = sanitize_tool_schemas(tools)
     dep_schemas = out[0]["function"]["parameters"]["dependentSchemas"]
-    assert dep_schemas["owner"] == {"type": "object", "properties": {}}, (
+    assert dep_schemas["owner"] == {
+        "type": "object",
+        "properties": {},
+        "additionalProperties": True,
+    }, (
         f"dependentSchemas['owner'] was not fully sanitized: {dep_schemas['owner']!r}"
     )
 

--- a/tools/schema_sanitizer.py
+++ b/tools/schema_sanitizer.py
@@ -158,6 +158,10 @@ def _sanitize_single_tool(tool: dict) -> dict:
             top["type"] = "object"
         if "properties" not in top or not isinstance(top.get("properties"), dict):
             top["properties"] = {}
+            # Free-form top-level declaration (see _sanitize_node): keep
+            # "any keys allowed" semantics for schema-literal models.
+            if "additionalProperties" not in top:
+                top["additionalProperties"] = True
     # Final pass: collapse nullable anyOf/oneOf unions that the recursive
     # sanitizer above leaves intact (it only handles the array-form
     # ``type: [X, "null"]``). Keep the ``nullable: true`` hint so runtime
@@ -403,7 +407,8 @@ def _sanitize_node(node: Any, path: str) -> Any:
 
     - Replaces bare-string schema values ("object", "string", ...) with
       ``{"type": <value>}`` so downstream consumers see a dict.
-    - Injects ``properties: {}`` into object-typed nodes missing it.
+    - Injects ``properties: {}`` into object-typed nodes missing it, stamping
+      ``additionalProperties: True`` on those free-form object nodes.
     - Normalizes ``type: [X, "null"]`` arrays to single ``type: X`` (keeping
       ``nullable: true`` as a hint), and multi-type arrays like
       ``["number", "string"]`` to an ``anyOf`` of single-type schemas so no
@@ -422,6 +427,7 @@ def _sanitize_node(node: Any, path: str) -> Any:
             return {"type": node} if node != "object" else {
                 "type": "object",
                 "properties": {},
+                "additionalProperties": True,
             }
         # Any other stray string is not a schema — drop it by replacing with
         # a permissive object schema rather than propagate something the
@@ -430,7 +436,7 @@ def _sanitize_node(node: Any, path: str) -> Any:
             "schema_sanitizer[%s]: replacing non-schema string %r "
             "with empty object schema", path, node,
         )
-        return {"type": "object", "properties": {}}
+        return {"type": "object", "properties": {}, "additionalProperties": True}
 
     if isinstance(node, list):
         return [_sanitize_node(item, f"{path}[{i}]") for i, item in enumerate(node)]
@@ -525,6 +531,16 @@ def _sanitize_node(node: Any, path: str) -> Any:
     # llama.cpp's grammar generator can't constrain a free-form object.
     if out.get("type") == "object" and not isinstance(out.get("properties"), dict):
         out["properties"] = {}
+        # The empty-properties shape reads as "object with zero properties"
+        # to schema-literal models, which then emit {} for intentionally
+        # free-form params (e.g. delegate_task's per-task output_schema) and
+        # silently defeat them. ``additionalProperties: true`` keeps the
+        # llama.cpp-safe closed shape while restoring "any keys allowed"
+        # semantics for models that follow the schema literally. Nodes that
+        # explicitly declare ``additionalProperties`` (bool false, or a value
+        # schema) already constrain themselves — don't overwrite them.
+        if "additionalProperties" not in out:
+            out["additionalProperties"] = True
 
     # Prune ``required`` entries that don't exist in properties (defense
     # against malformed MCP schemas; also caught upstream for MCP tools, but


### PR DESCRIPTION
## Summary

`tools/schema_sanitizer.py` injects `properties: {}` into object-typed nodes that lack a
`properties` dict — a shim for llama.cpp's `json-schema-to-grammar` converter — but the
sanitizer runs unconditionally on **every** backend (`model_tools.py`). Any intentionally
free-form `object` parameter therefore reaches the model as
`{"type": "object", "properties": {}}` — "an object with zero properties".

The built-in casualty is `delegate_task`'s per-task `output_schema`
(`tools/delegate_tool.py` declares it as a bare `{"type": "object", "description": ...}`
with deliberately no `properties`). A schema-literal model obeys the flattened spec and
emits `output_schema: {}` — while `coerce_output_schema({})` accepts the empty payload and
the result reports `schema_valid: true`. The structured-output contract silently enforces
nothing (#96734, reproduced on `gpt-5.6-sol` and cross-checked with `glm-5.2` over an
OpenAI-compatible replay with the unsanitized spec — model and transport were fine; only
the sanitized spec lost the payload).

### Fix

Stamp `additionalProperties: true` on object nodes whose `properties` are absent after
sanitizing (and on free-form top-level parameter declarations), instead of leaving the
bare empty-properties shape:

- schema-literal models read `additionalProperties: true` as "any keys allowed" and keep
  filling the object — the bug is fixed at the spec level, not by hoping the model ignores
  the schema;
- llama.cpp stays parseable: with the empty `properties` dict present, the converter builds
  an object rule whose bool-true `additionalProperties` expands to a value-wildcard for
  extra keys — valid grammar, no HTTP 400 (verified against both the C++ and Python
  converters on llama.cpp master; the identical output shape already ships on `main` today
  in `tools/mcp_tool.py` and `tools/browser_cdp_tool.py`);
- Gemini's transport strips `additionalProperties` via its allowlist filter — zero change
  for Gemini users; Moonshot's schema repair already leaves bool `additionalProperties`
  alone;
- nodes with an explicit `additionalProperties` (bool `false` or a value schema) are never
  overwritten, and the conservative fallbacks for missing/non-dict `parameters` are left
  byte-identical (a tool that declared no parameters does not get an invitation to invent
  them).

## Changes

- `tools/schema_sanitizer.py` (+20/−2): stamp `additionalProperties: true` in
  `_sanitize_node`'s free-form injection block and in `_sanitize_single_tool`'s top-level
  declared-object guarantee (both guarded by `if "additionalProperties" not in out`), add
  it to the two bare-string repair returns, update the module docstring bullet.
- `tests/tools/test_schema_sanitizer.py` (+93/−6): 5 new regression tests
  (free-form param keeps the marker, top-level declaration, explicit-schema not
  overwritten, closed object not reopened, missing-params fallback stays conservative),
  1 renamed test, 5 updated to pin the new sanitized shape.

## Tests

- `pytest tests/tools/test_schema_sanitizer.py` → **37 passed** (32 baseline → 37).
- `pytest tests/tools/test_delegate_output_schema.py tests/tools/test_delegate.py` →
  **94 passed** (no collateral damage to the delegation contract surface).
- Revert-proof: with the fix stashed (`git stash push -- tools/schema_sanitizer.py`),
  8 shape-pinning tests fail — including the primary regression test
  `test_freeform_object_param_not_flattened_for_schema_literal_models`, which mirrors the
  issue's exact `delegate_task output_schema` shape — and all 37 pass again after
  `git stash pop`.
- End-to-end: the sanitized `delegate_task tasks[].output_schema` node is
  `{"type": "object", "description": "...", "properties": {}, "additionalProperties": true}`
  — fillable again.

Closes #96734