### PR TITLE
fix(desktop): hydrate pending clarify args on re-arm

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/clarify-hydration.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/clarify-hydration.test.tsx
@@ -176,6 +176,40 @@ describe('clarify.request stream hydration', () => {
     expect(stream.state().streamId).toBe('assistant-codex')
   })
 
+  it('hydrates an already-pending sparse clarify row from the live request', () => {
+    mountStream()
+
+    seedHydratedMessages([
+      { id: 'user-1', role: 'user', parts: [{ type: 'text', text: 'help me choose' }] },
+      {
+        id: 'assistant-pending',
+        role: 'assistant',
+        pending: true,
+        parts: [
+          {
+            type: 'tool-call',
+            toolCallId: 'call-provider',
+            toolName: 'clarify',
+            args: {},
+            argsText: '{}'
+          }
+        ]
+      }
+    ])
+
+    clarifyRequest({ choices: ['Approve', 'Reject'], question: 'Continue?', request_id: 'req-pending' })
+
+    const messages = stream.state().messages
+    const part = clarifyParts()[0]
+    expect(messages).toHaveLength(2)
+    expect(messages[1]).toMatchObject({ id: 'assistant-pending', pending: true })
+    expect(part).toMatchObject({
+      toolCallId: 'call-provider',
+      args: { choices: ['Approve', 'Reject'], question: 'Continue?' }
+    })
+    expect(stream.state().streamId).toBe('assistant-pending')
+  })
+
   it('keeps a hydrated DeepSeek text-plus-clarify row in its original position', () => {
     mountStream()
 

--- a/apps/desktop/src/lib/chat-messages/tool-parts.ts
+++ b/apps/desktop/src/lib/chat-messages/tool-parts.ts
@@ -505,13 +505,26 @@ export function restorePendingClarifyToolCall(
 
   if (location) {
     const message = messages[location.messageIndex]
+    const part = message.parts[location.partIndex]
 
-    if (message.pending) {
+    if (part.type !== 'tool-call') {
       return { messages, streamId: message.id }
     }
 
+    // A sparse hydrated projection may already be marked pending while still
+    // lacking the authoritative clarify.request args. Re-arm in place and
+    // merge the live payload into that provider-authored part, preserving its
+    // tool-call id and transcript position.
+    const args = toolArgs(clarifyPayload, part.args)
+    const parts = [...message.parts]
+    parts[location.partIndex] = {
+      ...part,
+      args: args as never,
+      argsText: JSON.stringify(args)
+    }
+
     const next = [...messages]
-    next[location.messageIndex] = { ...message, pending: true }
+    next[location.messageIndex] = { ...message, parts, pending: true }
 
     return { messages: next, streamId: message.id }
   }
@@ -697,7 +710,6 @@ export function applyStoredToolResult(messages: ChatMessage[], toolMessage: Sess
       isError: false
     } as ChatMessagePart
     messages[i] = { ...message, parts }
-
     return true
   }
 


### PR DESCRIPTION
Fixes #96718.

## Problem

A hydrated transcript can already contain a pending `clarify` tool-call row whose args are sparse (`{}`). When the authoritative `clarify.request` arrives, `restorePendingClarifyToolCall()` finds that row but previously returned immediately if the containing message was already pending. The live question/choices were therefore discarded and Desktop could render a spinner-only clarify card.

## Fix

- re-arm the matched clarify part in place even when its message is already pending;
- merge the authoritative live request args into the existing part using the shared `toolArgs()` normalization path;
- preserve the provider-authored tool-call id, timestamp, and transcript position;
- keep the existing no-duplicate behavior for hydrated Codex/DeepSeek shapes.

## Regression coverage

Adds a focused stream-hydration test that starts with an already-pending clarify row with empty args, delivers `clarify.request`, and verifies that:

- question/choices are hydrated;
- the original provider tool-call id is preserved;
- no second message/card is appended;
- the original row remains the active stream row.

## Validation

- refreshed onto upstream `main` (`64cc87e6681a3db4e158ed8b999ff77ba0b9d28a`);
- branch is exactly one focused commit ahead and zero commits behind;
- neither touched file changed upstream since the previous base, so the refresh preserves current `main` plus this PR's existing patch only;
- final duplicate search still finds no other open PR covering #96718 / the pending+sparse-args case;
- fresh hosted CI is the execution gate for head `b053eda514baee0d34a7db781ce9f5f00a8cb15c`; the same focused patch was green on the previous head.