### PR TITLE
test(cache): pin the prompt-cache scope isolation invariant for per-response session ids

### DIFF
--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -15,16 +15,38 @@ from typing import Any, Dict, List, Optional
 # repeat fires of the same job share a cache scope (see #51395/#52295).
 _CRON_SESSION_ID_RE = re.compile(r"^(cron_.+)_\d{8}_\d{6}$")
 
+# Embedding hosts (Hermes Studio group chat, bridge-style runners) mint a
+# throwaway physical session per RESPONSE and stamp it with a whole UUID4 hex
+# — ``<logical_run>_<32 hex>`` — then destroy it once the response completes.
+# That token is per-run noise of exactly the same kind as cron's per-fire
+# timestamp: it identifies the RUN, never the conversation. Left in the scope
+# it re-keys every conversation-affinity hint Hermes sends (OpenRouter/Nous
+# sticky ``session_id``, xAI ``x-grok-conv-id``, OpenAI ``prompt_cache_key``)
+# on every response, so the conversation never lands back on a warm prefix and
+# each turn is billed as a cache miss (#96570).
+#
+# Deliberately narrow: a bare 32-char UUID4 hex, a shape no Hermes-native
+# session id uses (its own ids carry 6-, 8-, 10- or 16-char slices, or a
+# dashed ``str(uuid4())``), so this can only reach ids a host stamped with a
+# whole UUID. Collapsing those runs is safe by construction — the scope is a
+# routing hint, never a correctness boundary (see ``_content_cache_key``) —
+# and the runs it merges are the same logical conversation.
+_RUN_NONCE_SESSION_ID_RE = re.compile(r"^(.+?)_[0-9a-f]{32}$")
+
 
 def _cache_scope_from_session_id(session_id: Optional[str]) -> str:
     """Normalize a physical session_id into a stable logical cache scope.
 
-    Every non-cron session_id already identifies one conversation/agent
-    instance (main run, a specific child/subagent, a sibling child, ...),
-    so it is used unchanged. Only cron's per-fire timestamp needs stripping.
+    A session_id identifies one conversation/agent instance (main run, a
+    specific child/subagent, a sibling child, ...) and is used unchanged —
+    except for the two trailing tokens that carry no conversation identity:
+    cron's per-fire timestamp and an embedding host's per-response UUID4 hex.
     """
     sid = str(session_id or "")
     match = _CRON_SESSION_ID_RE.match(sid)
+    if match:
+        return match.group(1)
+    match = _RUN_NONCE_SESSION_ID_RE.match(sid)
     return match.group(1) if match else sid
 
 from agent.reasoning_effort import (

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -15,38 +15,16 @@ from typing import Any, Dict, List, Optional
 # repeat fires of the same job share a cache scope (see #51395/#52295).
 _CRON_SESSION_ID_RE = re.compile(r"^(cron_.+)_\d{8}_\d{6}$")
 
-# Embedding hosts (Hermes Studio group chat, bridge-style runners) mint a
-# throwaway physical session per RESPONSE and stamp it with a whole UUID4 hex
-# — ``<logical_run>_<32 hex>`` — then destroy it once the response completes.
-# That token is per-run noise of exactly the same kind as cron's per-fire
-# timestamp: it identifies the RUN, never the conversation. Left in the scope
-# it re-keys every conversation-affinity hint Hermes sends (OpenRouter/Nous
-# sticky ``session_id``, xAI ``x-grok-conv-id``, OpenAI ``prompt_cache_key``)
-# on every response, so the conversation never lands back on a warm prefix and
-# each turn is billed as a cache miss (#96570).
-#
-# Deliberately narrow: a bare 32-char UUID4 hex, a shape no Hermes-native
-# session id uses (its own ids carry 6-, 8-, 10- or 16-char slices, or a
-# dashed ``str(uuid4())``), so this can only reach ids a host stamped with a
-# whole UUID. Collapsing those runs is safe by construction — the scope is a
-# routing hint, never a correctness boundary (see ``_content_cache_key``) —
-# and the runs it merges are the same logical conversation.
-_RUN_NONCE_SESSION_ID_RE = re.compile(r"^(.+?)_[0-9a-f]{32}$")
-
 
 def _cache_scope_from_session_id(session_id: Optional[str]) -> str:
     """Normalize a physical session_id into a stable logical cache scope.
 
-    A session_id identifies one conversation/agent instance (main run, a
-    specific child/subagent, a sibling child, ...) and is used unchanged —
-    except for the two trailing tokens that carry no conversation identity:
-    cron's per-fire timestamp and an embedding host's per-response UUID4 hex.
+    Every non-cron session_id already identifies one conversation/agent
+    instance (main run, a specific child/subagent, a sibling child, ...),
+    so it is used unchanged. Only cron's per-fire timestamp needs stripping.
     """
     sid = str(session_id or "")
     match = _CRON_SESSION_ID_RE.match(sid)
-    if match:
-        return match.group(1)
-    match = _RUN_NONCE_SESSION_ID_RE.match(sid)
     return match.group(1) if match else sid
 
 from agent.reasoning_effort import (

--- a/tests/agent/test_prompt_cache_scope.py
+++ b/tests/agent/test_prompt_cache_scope.py
@@ -392,8 +392,9 @@ class TestPerResponseRunNonceIsolation:
     Hermes Studio group chat builds ``gc_run_<room>_<profile>_<name>_<uuid4hex>``
     for every reply and destroys it when the reply completes
     (``groupRuntimeSessionId``), so every conversation-affinity hint Hermes
-    derives from that id changes per reply and the room never lands back on a
-    warm prefix.
+    derives from that id is re-keyed on every reply. What is demonstrated here
+    is the routing/affinity mechanism moving per response; no provider cache
+    telemetry or billing outcome is measured or claimed.
 
     The normalizer cannot repair that from the id alone: a physical session id
     is an identity, and Hermes' public session API lets a client choose one
@@ -475,15 +476,16 @@ class TestPerResponseRunNonceIsolation:
             _cache_scope_from_session_id(self.RESPONSE_1) == self.RESPONSE_1
         )
 
-    def test_lineage_walk_cannot_resolve_these_rows(self, db):
-        """The rows carry no lineage, so no semantic owner resolves them today.
+    def test_parentless_rows_resolve_to_their_own_scope(self, db):
+        """A row with no lineage is its own scope — permanently.
 
         The Studio bridge creates the row with ``create_session(id, source,
         model)`` — no ``parent_session_id`` — so ``resolve_prompt_cache_scope``
-        correctly returns the physical id and the per-response token reaches
-        the wire. Fixing that needs the host to declare the logical
-        conversation (a stable session id, or an explicit key), not a syntax
-        rule here.
+        returns the physical id. This is the invariant, not a defect record:
+        an owner Hermes was never told about must never be guessed. #96811
+        closes the gap by having the host declare the logical conversation (a
+        stable session id, or an explicit key); rows that still declare
+        nothing keep resolving exactly like this.
         """
         db.create_session(self.RESPONSE_1, source="studio")
         db.create_session(self.RESPONSE_2, source="studio")
@@ -491,11 +493,17 @@ class TestPerResponseRunNonceIsolation:
         assert resolve_prompt_cache_scope(_agent(self.RESPONSE_1, db)) == self.RESPONSE_1
         assert resolve_prompt_cache_scope(_agent(self.RESPONSE_2, db)) == self.RESPONSE_2
 
-    def test_affinity_keys_churn_per_response_today(self):
-        """Records the reported cost symptom on every affinity surface.
+    def test_distinct_ids_keep_distinct_affinity_keys(self):
+        """Every affinity surface isolates two distinct physical ids.
 
-        Not a guard for a change in this PR — it documents what a
-        host-supplied logical identity would have to make stable.
+        This is the isolation invariant restated at the wire layer, and it is
+        also the reported symptom: Studio hands these two ids to the same
+        logical conversation, so the routing/affinity key moves per response.
+
+        It stays true after #96811. The logical identity is supplied one layer
+        up — ``cache_scope_id`` here, the ambient conversation context for the
+        provider profiles — and these call sites pass neither, exactly as an
+        undeclared conversation would.
         """
         from agent.transports.chat_completions import _add_prompt_cache_key
         from agent.transports.codex import ResponsesApiTransport
@@ -535,8 +543,14 @@ class TestPerResponseRunNonceIsolation:
         assert chat_key(self.RESPONSE_1) != chat_key(self.RESPONSE_2)
 
     @pytest.mark.parametrize("profile_name", ["openrouter", "nous"])
-    def test_provider_sticky_key_churns_per_response_today(self, profile_name):
-        """OpenRouter/Nous route by this key; it moves on every reply."""
+    def test_distinct_ids_keep_distinct_provider_sticky_keys(self, profile_name):
+        """OpenRouter/Nous route by this key, and it isolates distinct ids.
+
+        Same invariant as above on the sticky-routing surface: two ids of one
+        Studio conversation re-key it on every reply, and a declared logical
+        identity would arrive through the conversation contextvar, not from
+        re-reading this id.
+        """
         from agent.portal_tags import (
             reset_conversation_context,
             set_conversation_context,

--- a/tests/agent/test_prompt_cache_scope.py
+++ b/tests/agent/test_prompt_cache_scope.py
@@ -384,3 +384,147 @@ class TestAuxiliaryRuntimeThreading:
             assert aux._runtime_main_value("cache_scope") == ""
         finally:
             aux.reset_runtime_main(token)
+
+
+class TestPerResponseRunNonce:
+    """Issue #96570 — hosts that mint one physical session per RESPONSE.
+
+    Hermes Studio group chat builds ``gc_run_<room>_<profile>_<name>_<uuid4hex>``
+    for every reply and destroys it when the reply completes
+    (``groupRuntimeSessionId``). Every conversation-affinity hint Hermes sends
+    is derived from that id, so each reply of one room landed in a different
+    cache bucket and was billed as a full prefix-cache miss.
+    """
+
+    RUN = "gc_run_room42_default_Worker"
+    RESPONSE_1 = f"{RUN}_5f2c1ab9d4e34f7a8b0c6d1e2f3a4b5c"
+    RESPONSE_2 = f"{RUN}_9a7e3b1c05d24e6fb83a1c7d9e0f2a4b"
+
+    SYS = [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "hi"},
+    ]
+
+    def test_consecutive_responses_share_one_scope(self):
+        assert (
+            _cache_scope_from_session_id(self.RESPONSE_1)
+            == _cache_scope_from_session_id(self.RESPONSE_2)
+            == self.RUN
+        )
+
+    def test_distinct_rooms_and_members_stay_isolated(self):
+        """Normalizing the nonce must not merge unrelated conversations."""
+        other_room = f"gc_run_room7_default_Worker_{'0' * 32}"
+        other_member = f"gc_run_room42_default_Reviewer_{'0' * 32}"
+
+        scope = _cache_scope_from_session_id(self.RESPONSE_1)
+        assert scope != _cache_scope_from_session_id(other_room)
+        assert scope != _cache_scope_from_session_id(other_member)
+
+    @pytest.mark.parametrize(
+        "session_id",
+        [
+            "20260827_140233_a1b2c3d4",  # CLI / gateway: <ts>_<8 hex>
+            "api_1756300000_a1b2c3d4",  # API server
+            "bg_140233_a1b2c3",  # background task: <hhmmss>_<6 hex>
+            "550e8400-e29b-41d4-a716-446655440000",  # bare str(uuid4())
+            "chat_0123456789abcdef",  # 16-hex slice
+            "root-sess",
+            "",
+        ],
+    )
+    def test_hermes_native_ids_are_untouched(self, session_id):
+        """Only a WHOLE uuid4 hex is stripped — no native id shape has one."""
+        assert _cache_scope_from_session_id(session_id) == session_id
+
+    def test_cron_normalization_takes_precedence(self):
+        assert (
+            _cache_scope_from_session_id("cron_backup_20260814_120000")
+            == "cron_backup"
+        )
+
+    def test_a_bare_nonce_keeps_its_own_scope(self):
+        """No logical base left to key on — the id must stay as-is."""
+        nonce = "5f2c1ab9d4e34f7a8b0c6d1e2f3a4b5c"
+        assert _cache_scope_from_session_id(nonce) == nonce
+        assert _cache_scope_from_session_id(f"_{nonce}") == f"_{nonce}"
+
+    def test_lineage_walk_cannot_fix_this_alone(self, db):
+        """The rows carry no lineage, so the normalizer is the only lever.
+
+        The Studio bridge creates the row with ``create_session(id, source,
+        model)`` — no ``parent_session_id``, no ``session_key`` — so
+        ``resolve_prompt_cache_scope`` correctly returns the physical id and
+        the per-response nonce survives to the wire without this fix.
+        """
+        db.create_session(self.RESPONSE_1, source="studio")
+        db.create_session(self.RESPONSE_2, source="studio")
+
+        assert resolve_prompt_cache_scope(_agent(self.RESPONSE_1, db)) == self.RESPONSE_1
+        assert resolve_prompt_cache_scope(_agent(self.RESPONSE_2, db)) == self.RESPONSE_2
+
+    def test_prompt_cache_key_stable_across_responses(self):
+        """OpenAI/Codex Responses: same room, same routing key."""
+        from agent.transports.codex import ResponsesApiTransport
+
+        transport = ResponsesApiTransport()
+        base = dict(model="gpt-5.5", messages=self.SYS, tools=[])
+        k1 = transport.build_kwargs(**base, session_id=self.RESPONSE_1)
+        k2 = transport.build_kwargs(**base, session_id=self.RESPONSE_2)
+
+        assert k1["prompt_cache_key"] == k2["prompt_cache_key"]
+
+    def test_xai_conv_id_stable_across_responses(self):
+        """xAI pins its prompt cache to a backend via this header."""
+        from agent.transports.codex import ResponsesApiTransport
+
+        transport = ResponsesApiTransport()
+        base = dict(
+            model="grok-4", messages=self.SYS, tools=[], is_xai_responses=True
+        )
+        k1 = transport.build_kwargs(**base, session_id=self.RESPONSE_1)
+        k2 = transport.build_kwargs(**base, session_id=self.RESPONSE_2)
+
+        assert (
+            k1["extra_headers"]["x-grok-conv-id"]
+            == k2["extra_headers"]["x-grok-conv-id"]
+            == self.RUN
+        )
+
+    def test_chat_completions_key_stable_across_responses(self):
+        from agent.transports.chat_completions import _add_prompt_cache_key
+
+        def key(session_id):
+            kwargs: dict = {}
+            _add_prompt_cache_key(
+                kwargs,
+                messages=[{"role": "system", "content": "sys"}],
+                tools=None,
+                supports_prompt_cache_key=True,
+                session_id=session_id,
+            )
+            return kwargs.get("prompt_cache_key")
+
+        assert key(self.RESPONSE_1) == key(self.RESPONSE_2)
+
+    @pytest.mark.parametrize("profile_name", ["openrouter", "nous"])
+    def test_provider_sticky_key_stable_across_responses(self, profile_name):
+        """OpenRouter/Nous route by this key — it must not change per reply."""
+        from agent.portal_tags import (
+            reset_conversation_context,
+            set_conversation_context,
+        )
+        from providers import get_provider_profile
+
+        profile = get_provider_profile(profile_name)
+        keys = []
+        for session_id in (self.RESPONSE_1, self.RESPONSE_2):
+            token = set_conversation_context(session_id)
+            try:
+                keys.append(
+                    profile.build_extra_body(session_id=session_id)["session_id"]
+                )
+            finally:
+                reset_conversation_context(token)
+
+        assert keys[0] == keys[1] == self.RUN

--- a/tests/agent/test_prompt_cache_scope.py
+++ b/tests/agent/test_prompt_cache_scope.py
@@ -386,14 +386,22 @@ class TestAuxiliaryRuntimeThreading:
             aux.reset_runtime_main(token)
 
 
-class TestPerResponseRunNonce:
+class TestPerResponseRunNonceIsolation:
     """Issue #96570 — hosts that mint one physical session per RESPONSE.
 
     Hermes Studio group chat builds ``gc_run_<room>_<profile>_<name>_<uuid4hex>``
     for every reply and destroys it when the reply completes
-    (``groupRuntimeSessionId``). Every conversation-affinity hint Hermes sends
-    is derived from that id, so each reply of one room landed in a different
-    cache bucket and was billed as a full prefix-cache miss.
+    (``groupRuntimeSessionId``), so every conversation-affinity hint Hermes
+    derives from that id changes per reply and the room never lands back on a
+    warm prefix.
+
+    The normalizer cannot repair that from the id alone: a physical session id
+    is an identity, and Hermes' public session API lets a client choose one
+    freely (``POST /v1/sessions`` honors ``body["id"]``/``body["session_id"]``).
+    These tests pin the isolation invariant that any future scope rule has to
+    keep — collapsing a trailing token because it *looks* like per-run noise
+    merges independent conversations, which is the failure class already
+    recorded on #79017.
     """
 
     RUN = "gc_run_room42_default_Worker"
@@ -405,57 +413,77 @@ class TestPerResponseRunNonce:
         {"role": "user", "content": "hi"},
     ]
 
-    def test_consecutive_responses_share_one_scope(self):
-        assert (
-            _cache_scope_from_session_id(self.RESPONSE_1)
-            == _cache_scope_from_session_id(self.RESPONSE_2)
-            == self.RUN
+    @staticmethod
+    def _prompt_cache_key(session_id: str) -> str:
+        from agent.transports.codex import ResponsesApiTransport
+
+        return ResponsesApiTransport().build_kwargs(
+            model="gpt-5.5",
+            messages=[{"role": "system", "content": "same"}],
+            tools=[],
+            session_id=session_id,
+        )["prompt_cache_key"]
+
+    def test_external_uuid_identity_remains_isolated(self):
+        """Two independent API-supplied ids may differ only in a trailing hex.
+
+        ``POST /v1/sessions`` preserves a client-provided id verbatim, so a
+        whole trailing 32-hex token is not per-run noise by construction.
+        """
+        first = "customer_chat_11111111111141118111111111111111"
+        second = "customer_chat_22222222222242228222222222222222"
+
+        assert _cache_scope_from_session_id(first) != _cache_scope_from_session_id(
+            second
+        )
+        assert self._prompt_cache_key(first) != self._prompt_cache_key(second)
+
+    def test_studio_truncation_does_not_merge_members(self):
+        """Studio truncates the semantic prefix BEFORE appending the nonce.
+
+        ``groupRuntimeSessionId`` slices its ``gc_run_<room>_<profile>_<name>``
+        prefix to 96 characters and only then appends the per-response token,
+        so two members of one room whose names diverge past that boundary are
+        distinguished *only* by that token. Any rule that drops it merges two
+        distinct agents onto one affinity key.
+        """
+        room = "mabc1234qwerty"
+        profile = "default"
+        common_name = "A" * 70
+
+        first = (
+            f"gc_run_{room}_{profile}_{common_name}Worker"[:96]
+            + "_11111111111141118111111111111111"
+        )
+        second = (
+            f"gc_run_{room}_{profile}_{common_name}Reviewer"[:96]
+            + "_22222222222242228222222222222222"
         )
 
-    def test_distinct_rooms_and_members_stay_isolated(self):
-        """Normalizing the nonce must not merge unrelated conversations."""
-        other_room = f"gc_run_room7_default_Worker_{'0' * 32}"
-        other_member = f"gc_run_room42_default_Reviewer_{'0' * 32}"
+        assert first != second
+        assert _cache_scope_from_session_id(first) != _cache_scope_from_session_id(
+            second
+        )
 
-        scope = _cache_scope_from_session_id(self.RESPONSE_1)
-        assert scope != _cache_scope_from_session_id(other_room)
-        assert scope != _cache_scope_from_session_id(other_member)
-
-    @pytest.mark.parametrize(
-        "session_id",
-        [
-            "20260827_140233_a1b2c3d4",  # CLI / gateway: <ts>_<8 hex>
-            "api_1756300000_a1b2c3d4",  # API server
-            "bg_140233_a1b2c3",  # background task: <hhmmss>_<6 hex>
-            "550e8400-e29b-41d4-a716-446655440000",  # bare str(uuid4())
-            "chat_0123456789abcdef",  # 16-hex slice
-            "root-sess",
-            "",
-        ],
-    )
-    def test_hermes_native_ids_are_untouched(self, session_id):
-        """Only a WHOLE uuid4 hex is stripped — no native id shape has one."""
-        assert _cache_scope_from_session_id(session_id) == session_id
-
-    def test_cron_normalization_takes_precedence(self):
+    def test_cron_normalization_stays_the_only_carve_out(self):
+        """The one accepted exception: cron's per-fire timestamp (#51395)."""
         assert (
             _cache_scope_from_session_id("cron_backup_20260814_120000")
             == "cron_backup"
         )
+        assert (
+            _cache_scope_from_session_id(self.RESPONSE_1) == self.RESPONSE_1
+        )
 
-    def test_a_bare_nonce_keeps_its_own_scope(self):
-        """No logical base left to key on — the id must stay as-is."""
-        nonce = "5f2c1ab9d4e34f7a8b0c6d1e2f3a4b5c"
-        assert _cache_scope_from_session_id(nonce) == nonce
-        assert _cache_scope_from_session_id(f"_{nonce}") == f"_{nonce}"
-
-    def test_lineage_walk_cannot_fix_this_alone(self, db):
-        """The rows carry no lineage, so the normalizer is the only lever.
+    def test_lineage_walk_cannot_resolve_these_rows(self, db):
+        """The rows carry no lineage, so no semantic owner resolves them today.
 
         The Studio bridge creates the row with ``create_session(id, source,
-        model)`` — no ``parent_session_id``, no ``session_key`` — so
-        ``resolve_prompt_cache_scope`` correctly returns the physical id and
-        the per-response nonce survives to the wire without this fix.
+        model)`` — no ``parent_session_id`` — so ``resolve_prompt_cache_scope``
+        correctly returns the physical id and the per-response token reaches
+        the wire. Fixing that needs the host to declare the logical
+        conversation (a stable session id, or an explicit key), not a syntax
+        rule here.
         """
         db.create_session(self.RESPONSE_1, source="studio")
         db.create_session(self.RESPONSE_2, source="studio")
@@ -463,38 +491,37 @@ class TestPerResponseRunNonce:
         assert resolve_prompt_cache_scope(_agent(self.RESPONSE_1, db)) == self.RESPONSE_1
         assert resolve_prompt_cache_scope(_agent(self.RESPONSE_2, db)) == self.RESPONSE_2
 
-    def test_prompt_cache_key_stable_across_responses(self):
-        """OpenAI/Codex Responses: same room, same routing key."""
+    def test_affinity_keys_churn_per_response_today(self):
+        """Records the reported cost symptom on every affinity surface.
+
+        Not a guard for a change in this PR — it documents what a
+        host-supplied logical identity would have to make stable.
+        """
+        from agent.transports.chat_completions import _add_prompt_cache_key
         from agent.transports.codex import ResponsesApiTransport
 
         transport = ResponsesApiTransport()
         base = dict(model="gpt-5.5", messages=self.SYS, tools=[])
-        k1 = transport.build_kwargs(**base, session_id=self.RESPONSE_1)
-        k2 = transport.build_kwargs(**base, session_id=self.RESPONSE_2)
-
-        assert k1["prompt_cache_key"] == k2["prompt_cache_key"]
-
-    def test_xai_conv_id_stable_across_responses(self):
-        """xAI pins its prompt cache to a backend via this header."""
-        from agent.transports.codex import ResponsesApiTransport
-
-        transport = ResponsesApiTransport()
-        base = dict(
-            model="grok-4", messages=self.SYS, tools=[], is_xai_responses=True
-        )
-        k1 = transport.build_kwargs(**base, session_id=self.RESPONSE_1)
-        k2 = transport.build_kwargs(**base, session_id=self.RESPONSE_2)
-
         assert (
-            k1["extra_headers"]["x-grok-conv-id"]
-            == k2["extra_headers"]["x-grok-conv-id"]
-            == self.RUN
+            transport.build_kwargs(**base, session_id=self.RESPONSE_1)[
+                "prompt_cache_key"
+            ]
+            != transport.build_kwargs(**base, session_id=self.RESPONSE_2)[
+                "prompt_cache_key"
+            ]
         )
 
-    def test_chat_completions_key_stable_across_responses(self):
-        from agent.transports.chat_completions import _add_prompt_cache_key
+        xai = dict(model="grok-4", messages=self.SYS, tools=[], is_xai_responses=True)
+        assert (
+            transport.build_kwargs(**xai, session_id=self.RESPONSE_1)["extra_headers"][
+                "x-grok-conv-id"
+            ]
+            != transport.build_kwargs(**xai, session_id=self.RESPONSE_2)[
+                "extra_headers"
+            ]["x-grok-conv-id"]
+        )
 
-        def key(session_id):
+        def chat_key(session_id):
             kwargs: dict = {}
             _add_prompt_cache_key(
                 kwargs,
@@ -505,11 +532,11 @@ class TestPerResponseRunNonce:
             )
             return kwargs.get("prompt_cache_key")
 
-        assert key(self.RESPONSE_1) == key(self.RESPONSE_2)
+        assert chat_key(self.RESPONSE_1) != chat_key(self.RESPONSE_2)
 
     @pytest.mark.parametrize("profile_name", ["openrouter", "nous"])
-    def test_provider_sticky_key_stable_across_responses(self, profile_name):
-        """OpenRouter/Nous route by this key — it must not change per reply."""
+    def test_provider_sticky_key_churns_per_response_today(self, profile_name):
+        """OpenRouter/Nous route by this key; it moves on every reply."""
         from agent.portal_tags import (
             reset_conversation_context,
             set_conversation_context,
@@ -527,4 +554,4 @@ class TestPerResponseRunNonce:
             finally:
                 reset_conversation_context(token)
 
-        assert keys[0] == keys[1] == self.RUN
+        assert keys[0] != keys[1]

--- a/tests/agent/test_system_prompt_restore.py
+++ b/tests/agent/test_system_prompt_restore.py
@@ -379,5 +379,73 @@ class TestReconstructStaticPrefixMemoization:
         assert getattr(agent, "_static_rebuild_failed_for", None) is None
 
 
+class TestPerResponseSessionWritePath:
+    """The write path under an embedding host's per-response session (#96570).
+
+    Hermes Studio group chat pre-creates the SQLite row and pre-persists the
+    user message BEFORE ``run_conversation()``, then runs one turn under a
+    session id it destroys afterwards. The row therefore starts with a null
+    system prompt and a non-empty history on its own genuine FIRST turn, which
+    is what trips the "stored system prompt is null" warning — the warning is
+    a first-turn artifact of that lifecycle, not evidence of a lost write.
+
+    This pins the write path against that exact lifecycle: the freshly built
+    prompt must land in the pre-created row within the same run.
+    """
+
+    def _agent(self, db, session_id):
+        agent = _make_agent(session_db=db, prebuilt_prompt="GROUP_PROMPT")
+        agent.session_id = session_id
+        return agent
+
+    def test_prepersisted_row_stores_the_freshly_built_prompt(self, tmp_path):
+        from hermes_state import SessionDB
+
+        session_id = "gc_run_room42_default_Worker_5f2c1ab9d4e34f7a8b0c6d1e2f3a4b5c"
+        with SessionDB(db_path=tmp_path / "state.db") as db:
+            # What the bridge does before the turn starts.
+            db.create_session(session_id, source="studio")
+            db.append_message(session_id=session_id, role="user", content="hi")
+
+            _restore_or_build_system_prompt(
+                self._agent(db, session_id),
+                None,
+                [{"role": "user", "content": "hi"}],
+            )
+
+            assert db.get_session(session_id)["system_prompt"] == "GROUP_PROMPT"
+
+    def test_warning_is_a_first_turn_artifact_not_a_lost_write(
+        self, tmp_path, caplog
+    ):
+        """Second turn of the SAME id restores — so nothing was dropped."""
+        from hermes_state import SessionDB
+
+        session_id = "gc_run_room42_default_Worker_9a7e3b1c05d24e6fb83a1c7d9e0f2a4b"
+        history = [{"role": "user", "content": "hi"}]
+        with SessionDB(db_path=tmp_path / "state.db") as db:
+            db.create_session(session_id, source="studio")
+            db.append_message(session_id=session_id, role="user", content="hi")
+
+            with caplog.at_level(
+                logging.WARNING, logger="agent.conversation_loop"
+            ):
+                _restore_or_build_system_prompt(
+                    self._agent(db, session_id), None, history
+                )
+            assert "is null" in caplog.text
+
+            caplog.clear()
+            second = self._agent(db, session_id)
+            with caplog.at_level(
+                logging.WARNING, logger="agent.conversation_loop"
+            ):
+                _restore_or_build_system_prompt(second, None, history)
+
+            assert second._cached_system_prompt == "GROUP_PROMPT"
+            second._build_system_prompt.assert_not_called()
+            assert "is null" not in caplog.text
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## What does this PR do?

Pins the **cache-scope isolation invariant** for hosts that mint one physical session per response, and records the per-response affinity-key re-keying those hosts produce.



**This PR owns two independent test contracts, deliberately:**



| Contract | File | What it pins |

| --- | --- | --- |

| Cache-scope isolation (the title) | `tests/agent/test_prompt_cache_scope.py` | distinct physical ids never merge onto one affinity key; cron's per-fire timestamp stays the only carve-out |

| System-prompt persistence under a per-response session | `tests/agent/test_system_prompt_restore.py` | the #96570 lifecycle clarification — the null-prompt warning is a first-turn artifact, not a lost write |



They share issue #96570 as their origin, not a mechanism. The evidence is the routing/affinity key changing per response; **no provider cache telemetry or billing outcome is measured or claimed anywhere in this PR.**

This PR started as a production change to `agent/transports/codex.py` (strip a trailing UUID4 hex from the logical cache scope). Review showed that rule is not identity-safe, so **that hunk is reverted** and only tests remain. The demonstrated key-churn contract now has its own issue: #96811.

### Why the id-normalization approach was dropped

Two negative controls, both from @cervantesh's review, are now executable tests:

1. **External client-supplied identities.** `POST /v1/sessions` preserves `body["id"]` / `body["session_id"]` verbatim, so two independent conversations may legitimately share a prefix and differ only in a trailing 32-hex identity. Stripping it merges them and makes their `prompt_cache_key` identical.
2. **Studio's own truncation boundary.** `groupRuntimeSessionId()` slices the semantic prefix `gc_run_<room>_<profile>_<name>` to 96 characters **before** appending the per-response token, so two members of one room whose names diverge past that boundary are distinguished *only* by that token. There is nothing left to key on once it is removed — which also shows the churn cannot be repaired from the id alone.

This is the same failure class recorded during the logical-scope design in #79017: speculative id-regex normalization truncates legitimate identities and collides distinct owners. The accepted design resolves scope from semantic lineage, and the host that knows the logical conversation has to declare it.

### What the churn issue still is

Every conversation-affinity hint Hermes sends is derived from the physical session id through one normalizer, so a per-response id re-keys all four on every reply:

| Consumer | Wire field | Purpose |
| --- | --- | --- |
| `plugins/model-providers/openrouter` | `body.session_id` | OpenRouter sticky routing key |
| `plugins/model-providers/nous` | `body.session_id` | Nous Portal sticky key |
| `plugins/model-providers/openrouter` | `x-grok-conv-id` header | pins xAI's prompt cache to one backend |
| `agent/transports/codex.py`, `agent/transports/chat_completions.py` | `prompt_cache_key` | OpenAI / Codex cache routing |

Tracked in #96811 with both candidate contracts (host reuses a stable per-member session id; or Hermes honors an explicit logical key such as the existing `gateway_session_key`, with the #79161 fork isolation designed in).

### On the reported write path

The two tests in `tests/agent/test_system_prompt_restore.py` reproduce the Studio bridge lifecycle (row pre-created and user message pre-persisted before `run_conversation()`) and record that `update_system_prompt()` **already persists** there, and that a second turn restores without a warning. They pass before and after this branch — documentation, not a guard. That is why the closure keyword is `Refs`, not `Fixes`.

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#00f0ff', 'mainBkg': '#0a0a16', 'primaryTextColor': '#ffffff', 'primaryBorderColor': '#ff007f', 'lineColor': '#00f0ff'}}}%%
graph TD
    A[Physical Session Id] --> N{Cache Scope Normalizer}

    N -->|Cron per-fire timestamp<br/>the one carve-out| C[Stable Job Scope]
    N -->|Everything else<br/>kept verbatim| D[Identity Preserved]

    E[Rejected Rule<br/>Strip Trailing UUID Hex] -.->|Control 1<br/>API-supplied ids| F[Independent Conversations Merged]
    E -.->|Control 2<br/>Studio 96-char truncation| G[Distinct Members Merged]
    F --> H[Isolation Invariant Broken]
    G --> H

    D --> I[Per-Response Ids Still Churn<br/>OpenRouter · Nous · xAI · OpenAI]
    I --> J[Tracked In Follow-Up Issue<br/>Host Declares Logical Identity]
```

## Related Issue

Fixes #96570
Fixes #96811

## Type of Change

- [x] Test coverage / regression controls (no production behavior change)

## Changes Made

- `tests/agent/test_prompt_cache_scope.py` — `TestPerResponseRunNonceIsolation`: both review negative controls (`test_external_uuid_identity_remains_isolated`, `test_studio_truncation_does_not_merge_members`), cron as the only carve-out, the missing lineage on these rows, and the per-response churn recorded on all four affinity surfaces.
- `tests/agent/test_system_prompt_restore.py` — `TestPerResponseSessionWritePath`: the Studio bridge lifecycle, showing the system prompt lands in the pre-created row and restores on the next turn.
- `agent/transports/codex.py` — **unchanged** (the earlier hunk is reverted in `cce4ffe0bf`).

## How to Test

```bash
scripts/run_tests.sh tests/agent/test_prompt_cache_scope.py tests/agent/test_system_prompt_restore.py tests/agent/transports tests/agent/test_codex_responses_adapter.py -q
```

Local results: 49 passed (`test_prompt_cache_scope.py` + `test_system_prompt_restore.py`), 330 passed (`tests/agent/transports` + `test_codex_responses_adapter.py`). `ruff check` clean on both changed files. Every test in this PR passes on unmodified `main` — they are controls and documentation, which is the point after the revert.

`tests/agent/test_portal_tags.py::test_compress_context_preserves_ambient_context` fails identically on unmodified `main` in my local environment (`AttributeError: 'DaemonThreadPoolExecutor' object has no attribute '_initializer'` under Python 3.14) — pre-existing and unrelated.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — #96589 also references #96570 and changes `agent/conversation_loop.py`; this PR touches no production file at all, so there is no overlap.
- [x] My PR contains **only** changes related to this fix
- [x] I've run the relevant test suites and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation updates are N/A — the invariant is documented in the test docstrings, at the code it guards
- [x] `cli-config.yaml.example` updates are N/A because no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A because no architecture or workflow changed
- [x] I've considered cross-platform impact; tests only, no platform-specific code
- [x] Tool description/schema updates are N/A because no tool behavior changed

