### PR TITLE
fix(gateway): honor tool_preview_length=0 as unlimited in progress previews

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4481,17 +4481,24 @@ class TurnRunner:
                 "" if ctx.last_was_terminal_block[0] else f"{emoji} {tool_name}\n"
             )
             _code_block_full = f"{_block_header}```\n{_cmd_full}\n```"
-            # Single-line, capped preview for non-verbose modes.
+            # Single-line capped preview for non-verbose modes when a length is
+            # explicitly configured.  ``tool_preview_length: 0`` means unlimited
+            # (the same semantics as agent/display.py and the verbose-mode
+            # branch), so the full multi-line command block is shown instead of
+            # an arbitrary 40-char fallback.
             _pl = get_tool_preview_max_len()
-            _cap = _pl if _pl > 0 else 40
-            _lines = _cmd_full.splitlines()
-            _cmd_short = _lines[0] if _lines else _cmd_full
-            _multiline = len(_lines) > 1
-            if len(_cmd_short) > _cap:
-                _cmd_short = _cmd_short[:_cap - 3] + "..."
-            elif _multiline:
-                _cmd_short = _cmd_short + " ..."
-            _code_block_short = f"{_block_header}```\n{_cmd_short}\n```"
+            if _pl > 0:
+                _cap = _pl
+                _lines = _cmd_full.splitlines()
+                _cmd_short = _lines[0] if _lines else _cmd_full
+                _multiline = len(_lines) > 1
+                if len(_cmd_short) > _cap:
+                    _cmd_short = _cmd_short[:_cap - 3] + "..."
+                elif _multiline:
+                    _cmd_short = _cmd_short + " ..."
+                _code_block_short = f"{_block_header}```\n{_cmd_short}\n```"
+            else:
+                _code_block_short = _code_block_full
 
         # Verbose mode: show detailed arguments, respects tool_preview_length
         if ctx.progress_mode == "verbose":
@@ -4534,7 +4541,11 @@ class TurnRunner:
                 verb_drops_preview,
             )
             _pl = get_tool_preview_max_len()
-            _cap = _pl if _pl > 0 else 40
+            # tool_preview_length: 0 means unlimited (same semantics as
+            # agent/display.py) — pass it through so prepare_tool_preview's
+            # internal truncation skips capping instead of falling back to an
+            # arbitrary 40 chars.
+            _cap = _pl
             _prepared_preview = prepare_tool_preview(
                 tool_name,
                 args,

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -742,6 +742,80 @@ def test_all_mode_respects_custom_preview_length(monkeypatch, tmp_path):
     assert len(preview_text) <= 120, f"Preview too long ({len(preview_text)}): {preview_text}"
 
 
+def test_all_mode_zero_preview_length_means_unlimited(monkeypatch, tmp_path):
+    """``display.tool_preview_length: 0`` means unlimited, not the 40-char fallback.
+
+    agent/display.py documents 0 as "no limit" (set_tool_preview_max_len) and the
+    verbose-mode branch already honors it, but the all/new preview path used to
+    coerce 0 into a hardcoded 40-char cap, silently truncating gateway tool
+    previews for every deployment running the default config.
+    """
+    adapter, result = _run_long_preview_helper(monkeypatch, tmp_path, preview_length=0)
+    assert result["final_response"] == "done"
+    assert adapter.sent
+    content = adapter.sent[0]["content"]
+    preview_text = _extract_progress_preview(content)
+    assert preview_text is not None, f"No preview found in: {content}"
+    # The full command survives — no arbitrary 40-char cap.
+    assert LongPreviewAgent.LONG_CMD in content, (
+        f"Full command missing from progress content ({len(preview_text)} chars): {preview_text}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_zero_preview_length_terminal_block_shows_full_command(monkeypatch, tmp_path):
+    """On markdown-capable gateways, ``tool_preview_length: 0`` keeps the full
+    multi-line terminal command block in non-verbose modes (parity with the
+    verbose-mode behavior)."""
+    monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "all")
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = TerminalCommandAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+    import tools.terminal_tool  # noqa: F401 - register terminal emoji
+
+    import yaml
+    (tmp_path / "config.yaml").write_text(
+        yaml.dump({"display": {"tool_preview_length": 0}}),
+        encoding="utf-8",
+    )
+
+    adapter = CodeBlockProgressAdapter(platform=Platform.TELEGRAM)
+    runner = _make_runner(adapter)
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+        thread_id=None,
+    )
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-terminal-zero-preview",
+        session_key="agent:main:telegram:dm:12345",
+    )
+
+    assert result["final_response"] == "done"
+    all_content = " ".join(call["content"] for call in adapter.sent)
+    all_content += " ".join(call["content"] for call in adapter.edits)
+    # Every command line survives — the block was not collapsed to one line.
+    assert "set -euo pipefail" in all_content
+    assert "node --version" in all_content
+    assert "npm install -g hyperframes@latest" in all_content
+    # No truncation marker injected into the block.
+    assert "..." not in all_content
+
+
 def test_discord_truncated_tool_url_links_to_full_destination(monkeypatch, tmp_path):
     """The real gateway path must retain the URL beyond its visible cap."""
     import yaml
@@ -756,8 +830,11 @@ def test_discord_truncated_tool_url_links_to_full_destination(monkeypatch, tmp_p
     fake_run_agent.AIAgent = UrlPreviewAgent
     monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
 
+    # Explicit cap so the visible text truncates while the full URL must
+    # survive behind the link target (0 would mean unlimited now, and the
+    # URL would render in full without exercising the link-metadata path).
     (tmp_path / "config.yaml").write_text(
-        yaml.dump({"display": {"tool_preview_length": 0}}),
+        yaml.dump({"display": {"tool_preview_length": 40}}),
         encoding="utf-8",
     )
 


### PR DESCRIPTION
## Problem

`display.tool_preview_length` is documented as `0 = no limit` everywhere:

- `agent/display.py` — `set_tool_preview_max_len(n)`: "0 = no limit" (default)
- `hermes_cli/config.py` — `"tool_preview_length": 0  # Max chars for tool call previews (0 = no limit, show full paths/commands)`
- the **verbose** progress branch: "When tool_preview_length is 0 (default), don't truncate"

But in the gateway's non-verbose (`all`/`new`) progress path, both preview
construction sites coerce 0 into a hardcoded fallback:

```python
_cap = _pl if _pl > 0 else 40
```

So every deployment running the default config gets gateway tool previews and
terminal command blocks silently truncated to 40 chars with no way to turn it
off — the documented "no limit" setting does nothing on that path.

## Fix

- **Terminal fenced-block path**: when `_pl > 0`, behave exactly as before
  (single line, capped, `" ..."` marker for multi-line). When `_pl == 0`, use
  the full multi-line command block — parity with what verbose mode already
  does.
- **Friendly-verb preview path**: pass `_pl` through unchanged.
  `prepare_tool_preview` → `_truncate_preview` already treats `max_len <= 0`
  as a no-op, so no behavior change is needed downstream.

Explicit lengths are unaffected; only the 0 semantics changed.

## Tests

- `test_all_mode_zero_preview_length_means_unlimited` — with
  `tool_preview_length: 0`, the full (165-char, previously
  hardcoded-capped) command survives in the progress message.
- `test_zero_preview_length_terminal_block_shows_full_command` — on a
  markdown-capable adapter, 0 keeps the full multi-line fenced command block
  in `all` mode (no first-line collapse, no `...`).
- `test_all_mode_respects_custom_preview_length` (existing) still passes —
  explicit 120 cap unchanged.
- `test_discord_truncated_tool_url_links_to_full_destination` (existing) was
  written against the old coercion: it configured `0` while asserting
  *truncated* text with link retention. Its actual subject is URL metadata
  retention behind a visible cap, so it now uses an explicit `40` cap; the
  zero-length behavior is covered by the two new tests.

`pytest tests/gateway/test_run_progress_topics.py` → 29 passed.