### PR TITLE
fix(desktop): allow Bot chats to start fresh sessions

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/bot-session-rollover.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/bot-session-rollover.mjs
@@ -1,0 +1,74 @@
+const ROLLOVER_PATTERN = /^\/(new|reset)\s*$/i
+
+/** Return the Bot-rollover command name, or null for every ordinary command. */
+export function botRolloverCommand(text) {
+  const match = ROLLOVER_PATTERN.exec(String(text || '').trim())
+  return match ? match[1].toLowerCase() : null
+}
+
+/** Resolve the exact selected Bot owner only while its canonical stored row
+ * (root or compression tip) owns the focused transcript. */
+export function focusedCanonicalBot({ roster, selectedKey, focusedStoredSessionId, botsMode = true, keyForBot }) {
+  const key = String(selectedKey || '')
+  const focused = String(focusedStoredSessionId || '')
+
+  if (!botsMode || !key || !focused || !Array.isArray(roster) || typeof keyForBot !== 'function') {
+    return null
+  }
+
+  const bot = roster.find(row => keyForBot(row) === key)
+  const canonical = bot?.canonical_session || null
+  const ids = [canonical?.id, canonical?.resolved_id].filter(Boolean).map(String)
+
+  if (!bot || !canonical || !ids.includes(focused)) {
+    return null
+  }
+
+  return {
+    bot,
+    canonical,
+    expectedCurrentSessionId: focused
+  }
+}
+
+/** Execute the routed RPC, then reconcile roster truth and open exactly the
+ * returned stored row. A probe requiring confirmation has no UI side effects. */
+export async function executeBotRollover({ target, force = false, request, profileForBot, refresh, open }) {
+  if (!target?.bot || !target.expectedCurrentSessionId) {
+    throw new Error('No focused canonical Bot Chat to roll over')
+  }
+
+  const profile = String(
+    profileForBot?.(target.bot) || target.bot?.targetProfile || target.bot?.profile || target.bot?.name || ''
+  ).trim()
+  if (!profile) {
+    throw new Error('Bot session rollover has no owning profile')
+  }
+
+  const result = await request(target.bot, 'session.bot_rollover', {
+    expected_current_session_id: target.expectedCurrentSessionId,
+    force: Boolean(force),
+    profile
+  })
+
+  if (result?.confirmation_required) {
+    return result
+  }
+
+  const currentId = String(result?.current_session_id || result?.current_session?.id || '')
+  if (!currentId) {
+    throw new Error('Bot session rollover returned no current session')
+  }
+
+  try {
+    await refresh?.()
+    await open(target.bot, currentId, result.current_session || { id: currentId, title: 'Bot Chat', message_count: 0 })
+  } catch (cause) {
+    const detail = cause instanceof Error && cause.message ? `: ${cause.message}` : ''
+    const error = new Error(`The fresh Bot session was created but could not be opened${detail}`, { cause })
+    error.rolloverCommitted = true
+    error.currentSessionId = currentId
+    throw error
+  }
+  return result
+}

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -311,6 +311,9 @@ const $botsPaneVisible = atom(false)
 /** An explicit open landed: {key, openedRegistryId}. This transient view
  *  observation is empty only for the legacy newChat draft fallback. */
 const $openBotChat = atom(null)
+// Shared between the visible Bots header action and the composer middleware:
+// a slash-triggered probe can ask the mounted pane for the existing confirm UI.
+const $pendingBotRollover = atom(null)
 /** A session owns the main workspace. The roster highlight and the home /
  *  Cronjobs lifecycles all key off this rather than reading host.state
  *  conditionally from render. */
@@ -5652,6 +5655,47 @@ let botOpenGeneration = 0
 /** The one canonical title. (profile, CANONICAL_CHAT_TITLE) IS the bot's
  *  forever-chat identity — see the header above. */
 const CANONICAL_CHAT_TITLE = 'Bot Chat'
+
+async function performBotSessionRollover(target, { force = false, refresh = null } = {}) {
+  const { executeBotRollover } = await import('./bot-session-rollover.mjs')
+  const result = await executeBotRollover({
+    target,
+    force,
+    request: requestForBot,
+    profileForBot: bot => backendTargetProfile(botConnectionRoute(bot), bot.name),
+    refresh: refresh || (() => queryClient.invalidateQueries({ queryKey: ROSTER_KEY })),
+    open: async (bot, storedId, summary) => {
+      await openStoredBotChat(bot, storedId, summary)
+      $openBotChat.set({
+        key: botRosterKey(bot),
+        openedRegistryId: String(storedId),
+        openedSessionId: String(storedId)
+      })
+    }
+  })
+
+  if (result?.confirmation_required) {
+    $pendingBotRollover.set(target)
+  }
+
+  return result
+}
+
+function botHistoryContentText(content) {
+  if (typeof content === 'string') return content
+  if (Array.isArray(content)) {
+    return content
+      .map(part => (typeof part === 'string' ? part : typeof part?.text === 'string' ? part.text : ''))
+      .filter(Boolean)
+      .join('\n')
+  }
+  if (content == null) return ''
+  try {
+    return JSON.stringify(content, null, 2)
+  } catch {
+    return String(content)
+  }
+}
 
 async function openStoredBotChat(owner, storedId, summary) {
   if (!storedId || typeof host.openSession !== 'function') {
@@ -14835,6 +14879,12 @@ function BotsPane() {
   const [activityFilter, setActivityFilter] = useState('all')
   const [gatewayFilter, setGatewayFilter] = useState('all')
   const [collapsedRosterSections, setCollapsedRosterSections] = useState(() => new Set())
+  const [historyBot, setHistoryBot] = useState(null)
+  const [historyRows, setHistoryRows] = useState([])
+  const [historyMessages, setHistoryMessages] = useState([])
+  const [historySelected, setHistorySelected] = useState(null)
+  const [historyLoading, setHistoryLoading] = useState(false)
+  const [historyError, setHistoryError] = useState('')
   const hiddenSectionRef = useRef(null)
   const activityToasts = useValue($activityToasts)
   const groupChatName = useValue($groupChatWorkspace)
@@ -14849,6 +14899,7 @@ function BotsPane() {
   const rosterHydrated = useValue($rosterHydrated)
   const selectionHydrated = useValue($selectedRosterHydrated)
   const selectedRosterKey = useValue($selectedRosterKey)
+  const pendingRollover = useValue($pendingBotRollover)
 
   // The socket opening (boot, SSH reconnect, sleep/wake) is the signal to
   // retry immediately instead of waiting out the poll interval.
@@ -14890,6 +14941,79 @@ function BotsPane() {
 
     return activityOf(b) - activityOf(a)
   })
+  const selectedActionBot = selectedRosterBot(roster, selectedRosterKey)
+  const selectedCanonical = selectedActionBot?.canonical_session || null
+  const selectedActionTarget = selectedCanonical
+    ? {
+        bot: selectedActionBot,
+        canonical: selectedCanonical,
+        expectedCurrentSessionId: String(selectedCanonical.resolved_id || selectedCanonical.id || '')
+      }
+    : null
+
+  const runBotRollover = async (target, force = false) => {
+    if (!target) return
+    try {
+      const result = await performBotSessionRollover(target, {
+        force,
+        refresh: async () => {
+          await refetch()
+        }
+      })
+      if (!result?.confirmation_required) {
+        $pendingBotRollover.set(null)
+        host.notify?.({ kind: 'success', message: 'Started a fresh Bot session. Previous history is preserved.' })
+      }
+    } catch (rolloverError) {
+      host.notifyError?.(
+        rolloverError,
+        rolloverError?.rolloverCommitted
+          ? 'The fresh Bot session was created but could not be opened. Click the Bot again to retry opening it.'
+          : 'Could not start a fresh Bot session. Nothing was changed; try again.'
+      )
+      throw rolloverError
+    }
+  }
+
+  const loadBotHistory = async bot => {
+    if (!bot) return
+    setHistoryBot(bot)
+    setHistoryRows([])
+    setHistoryMessages([])
+    setHistorySelected(null)
+    setHistoryError('')
+    setHistoryLoading(true)
+    try {
+      const result = await requestForBot(bot, 'session.bot_history', {
+        profile: backendTargetProfile(botConnectionRoute(bot), bot.name),
+        limit: 50
+      })
+      setHistoryRows(Array.isArray(result?.sessions) ? result.sessions : [])
+    } catch (historyLoadError) {
+      setHistoryError(historyLoadError?.message || 'Could not load previous Bot sessions.')
+    } finally {
+      setHistoryLoading(false)
+    }
+  }
+
+  const loadBotHistoryTranscript = async row => {
+    if (!historyBot || !row?.id) return
+    setHistorySelected(row)
+    setHistoryMessages([])
+    setHistoryError('')
+    setHistoryLoading(true)
+    try {
+      const result = await requestForBot(historyBot, 'session.bot_history', {
+        profile: backendTargetProfile(botConnectionRoute(historyBot), historyBot.name),
+        session_id: row.id
+      })
+      setHistoryMessages(Array.isArray(result?.messages) ? result.messages : [])
+    } catch (historyLoadError) {
+      setHistoryError(historyLoadError?.message || 'Could not read that Bot session.')
+    } finally {
+      setHistoryLoading(false)
+    }
+  }
   // React Query can briefly report neither loading nor data while the plugin
   // and the persisted connection registry hydrate. Keep that transition in a
   // neutral loading state instead of flashing the first-run "No bots" copy.
@@ -15196,6 +15320,30 @@ function BotsPane() {
                     'flex size-6 items-center justify-center rounded-md text-(--ui-text-tertiary) transition-colors hover:bg-(--chrome-action-hover) hover:text-foreground',
                   onClick: () => setActivityToasts(!activityToasts),
                   children: jsx(Codicon, { name: activityToasts ? 'bell' : 'bell-slash' })
+                })
+              }),
+              jsx(Tip, {
+                label: selectedActionTarget ? 'New Bot Session' : 'Select a Bot to start a new session',
+                children: jsx('button', {
+                  type: 'button',
+                  'aria-label': 'New Bot Session',
+                  disabled: !selectedActionTarget,
+                  className:
+                    'flex size-6 items-center justify-center rounded-md text-(--ui-text-tertiary) transition-colors hover:bg-(--chrome-action-hover) hover:text-foreground disabled:cursor-not-allowed disabled:opacity-35',
+                  onClick: () => void runBotRollover(selectedActionTarget).catch(() => undefined),
+                  children: jsx(Codicon, { name: 'new-file' })
+                })
+              }),
+              jsx(Tip, {
+                label: selectedActionBot ? 'Previous Bot Sessions' : 'Select a Bot to view previous sessions',
+                children: jsx('button', {
+                  type: 'button',
+                  'aria-label': 'Previous Bot Sessions',
+                  disabled: !selectedActionBot,
+                  className:
+                    'flex size-6 items-center justify-center rounded-md text-(--ui-text-tertiary) transition-colors hover:bg-(--chrome-action-hover) hover:text-foreground disabled:cursor-not-allowed disabled:opacity-35',
+                  onClick: () => void loadBotHistory(selectedActionBot),
+                  children: jsx(Codicon, { name: 'history' })
                 })
               }),
               jsxs(DropdownMenu, {
@@ -15523,6 +15671,152 @@ function BotsPane() {
                       ]
                     })
                   }),
+      jsx(Dialog, {
+        open: Boolean(historyBot),
+        onOpenChange: value => {
+          if (!value) {
+            setHistoryBot(null)
+            setHistoryRows([])
+            setHistoryMessages([])
+            setHistorySelected(null)
+            setHistoryError('')
+          }
+        },
+        children: jsxs(DialogContent, {
+          className: 'max-w-3xl',
+          children: [
+            jsxs(DialogHeader, {
+              children: [
+                jsx(DialogTitle, { children: 'Previous Bot Sessions' }),
+                jsx(DialogDescription, {
+                  children: historyBot
+                    ? `Read-only history for ${displayName(historyBot, botRosterMeta(historyBot, allMeta))}. Starting a fresh session never deletes these transcripts.`
+                    : 'Read-only Bot history.'
+                })
+              ]
+            }),
+            historyError
+              ? jsxs('div', {
+                  className: 'grid gap-2 rounded-md bg-(--chrome-action-hover) p-2 text-xs text-(--ui-text-secondary)',
+                  children: [
+                    jsx('div', { children: historyError }),
+                    jsx(Button, {
+                      variant: 'secondary',
+                      size: 'sm',
+                      className: 'justify-self-start',
+                      onClick: () =>
+                        historySelected
+                          ? void loadBotHistoryTranscript(historySelected)
+                          : void loadBotHistory(historyBot),
+                      children: 'Retry'
+                    })
+                  ]
+                })
+              : null,
+            historyLoading
+              ? jsx('div', {
+                  className: 'flex min-h-40 items-center justify-center',
+                  children: jsx(GlyphSpinner, { spinner: 'breathe', className: 'text-(--ui-text-tertiary)' })
+                })
+              : historySelected
+                ? jsxs('div', {
+                    className: 'grid min-h-0 gap-2',
+                    children: [
+                      jsx(Button, {
+                        variant: 'ghost',
+                        size: 'sm',
+                        className: 'justify-self-start',
+                        onClick: () => {
+                          setHistorySelected(null)
+                          setHistoryMessages([])
+                          setHistoryError('')
+                        },
+                        children: '← All previous sessions'
+                      }),
+                      jsx(ScrollArea, {
+                        className: 'h-[55vh] rounded-md border border-(--ui-stroke-tertiary)',
+                        children: jsx('div', {
+                          className: 'grid gap-3 p-3',
+                          children: historyMessages.length
+                            ? historyMessages.map((message, index) =>
+                                jsxs(
+                                  'div',
+                                  {
+                                    className: 'grid gap-1',
+                                    children: [
+                                      jsx('div', {
+                                        className: 'text-[0.6875rem] font-semibold uppercase tracking-wide text-(--ui-text-quaternary)',
+                                        children: message.role || 'message'
+                                      }),
+                                      jsx('pre', {
+                                        className: 'whitespace-pre-wrap break-words font-sans text-xs leading-5 text-(--ui-text-secondary)',
+                                        children: botHistoryContentText(message.content)
+                                      })
+                                    ]
+                                  },
+                                  message.id || `${message.role || 'message'}:${index}`
+                                )
+                              )
+                            : jsx(EmptyState, {
+                                icon: 'history',
+                                title: 'No stored messages',
+                                description: 'This retired session has no transcript rows.'
+                              })
+                        })
+                      })
+                    ]
+                  })
+                : historyRows.length
+                  ? jsx(ScrollArea, {
+                      className: 'max-h-[55vh]',
+                      children: jsx('div', {
+                        className: 'grid gap-1',
+                        children: historyRows.map(row =>
+                          jsxs(
+                            'button',
+                            {
+                              type: 'button',
+                              className:
+                                'grid w-full gap-0.5 rounded-md px-2.5 py-2 text-left transition-colors hover:bg-(--chrome-action-hover)',
+                              onClick: () => void loadBotHistoryTranscript(row),
+                              children: [
+                                jsx('span', {
+                                  className: 'text-xs font-medium text-(--ui-text-secondary)',
+                                  children: new Date((row.started_at || 0) * 1000).toLocaleString()
+                                }),
+                                jsx('span', {
+                                  className: 'truncate text-[0.6875rem] text-(--ui-text-quaternary)',
+                                  children: `${row.message_count || 0} messages${row.preview ? ` · ${row.preview}` : ''}`
+                                })
+                              ]
+                            },
+                            row.id
+                          )
+                        )
+                      })
+                    })
+                  : jsx(EmptyState, {
+                      icon: 'history',
+                      title: 'No previous Bot sessions',
+                      description: 'When you start a fresh Bot session, the retired transcript will remain available here.'
+                    })
+          ]
+        })
+      }),
+      jsx(ConfirmDialog, {
+        open: Boolean(pendingRollover),
+        title: 'Stop active work and start fresh?',
+        description:
+          'This Bot is currently working or compressing. Hermes will stop that work, preserve this transcript as history, and open a genuinely empty Bot session.',
+        confirmLabel: 'Stop and Start Fresh',
+        busyLabel: 'Starting…',
+        doneLabel: 'Started',
+        onClose: () => $pendingBotRollover.set(null),
+        onConfirm: async () => {
+          if (!pendingRollover) return
+          await runBotRollover(pendingRollover, true)
+        }
+      }),
       jsx(CreateAgentDialog, {
         open: createOpen,
         onClose: () => {
@@ -16114,36 +16408,52 @@ export default {
         handler: async draft => {
           const text = draft.text || ''
 
-          // /new inside a bot's canonical forever-chat would fork the
-          // relationship into a scratch session — the one thing Bots mode
-          // promises never happens. Reroute to /compact (same felt effect:
-          // fresh working context, SAME conversation) and say so. Only
-          // guards the canonical chat: Sessions-mode scratchpads on the
-          // same profile keep full /new freedom.
-          const slashNew = /^\/(new|reset)\s*$/.exec(text.trim())
+          // Bot Mode /new and /reset are real canonical-session rollovers.
+          // Match the exact selected roster owner (connection + profile) and
+          // the focused STORED id (registry root or compression tip). A same-
+          // named bot elsewhere and every Sessions-mode chat pass through.
+          if (/^\/(?:new|reset)\s*$/i.test(text.trim())) {
+            const { botRolloverCommand, focusedCanonicalBot } = await import('./bot-session-rollover.mjs')
+            const rolloverCommand = botRolloverCommand(text)
+            const target = focusedCanonicalBot({
+              roster: $lastRoster.get(),
+              selectedKey: $selectedRosterKey.get(),
+              focusedStoredSessionId:
+                host.state.focusedStoredSessionId?.get?.() ??
+                host.state.activeSessionId?.get?.() ??
+                host.activeSessionId?.get?.() ??
+                null,
+              botsMode: $botsPaneVisible.get(),
+              keyForBot: botRosterKey
+            })
 
-          if (slashNew) {
-            const activeBot = $selectedBot.get()
-            // Canonical identity is the profile's "Bot Chat" registry row —
-            // read it from the roster cache (canonical_session, resolved
-            // server-side by name), matching either the durable row id or
-            // the compression-lineage tip currently on screen.
-            const roster = $lastRoster.get()
-            const row = Array.isArray(roster) ? roster.find(bot => bot?.name === activeBot) : null
-            const canonical = row?.canonical_session || null
-            const currentId = host.activeSessionId?.get?.() ?? null
-            const canonicalIds = [canonical?.id, canonical?.resolved_id].filter(Boolean).map(String)
+            if (target) {
+              try {
+                const result = await performBotSessionRollover(target)
+                if (result?.confirmation_required) {
+                  host.notify?.({
+                    kind: 'info',
+                    title: 'Active work needs confirmation',
+                    message: 'Use the Bots pane confirmation to stop the current work and start fresh.'
+                  })
+                } else {
+                  host.notify?.({
+                    kind: 'success',
+                    message: `/${rolloverCommand} started a fresh Bot session. Previous history is preserved.`
+                  })
+                }
+              } catch (rolloverError) {
+                host.notifyError?.(
+                  rolloverError,
+                  rolloverError?.rolloverCommitted
+                    ? `/${rolloverCommand} created the fresh Bot session, but it could not be opened. Click the Bot again to retry.`
+                    : `/${rolloverCommand} could not start a fresh Bot session. Nothing was changed; try again.`
+                )
+              }
 
-            if (activeBot && currentId && canonicalIds.includes(String(currentId))) {
-              host.notify({
-                kind: 'info',
-                title: 'This chat never resets',
-                message:
-                  'Bot chats are one continuous conversation — compacting instead. ' +
-                  'For a throwaway session with this agent, use Sessions mode.'
-              })
-
-              return { ...draft, text: '/compact' }
+              // Consume the slash text. It is never submitted to the model and
+              // never rewritten to /compact.
+              return null
             }
           }
 

--- a/apps/desktop/src/plugins/hermes-bots/tests/new-compact-guard.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/new-compact-guard.test.mjs
@@ -1,28 +1,190 @@
 import assert from 'node:assert/strict'
-import { readFileSync } from 'node:fs'
 import test from 'node:test'
 
-// The /new -> /compact guard protects a bot's canonical forever-chat from being
-// forked by /new. Canonical identity is the NAME — the profile's session titled
-// "Bot Chat" — reported by the gateway as canonical_session on every roster row.
-// The guard compares the on-screen session id against that registry row (durable
-// id OR compression-lineage tip). No stored meta.chat pointer is consulted:
-// pointers dangle; the registry row cannot.
+import {
+  botRolloverCommand,
+  executeBotRollover,
+  focusedCanonicalBot
+} from '../bot-session-rollover.mjs'
 
-const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
 
-// Locate the /new reroute guard block.
-const guardStart = source.indexOf('const slashNew =')
-assert.notEqual(guardStart, -1, '/new guard block is missing')
-const guardBlock = source.slice(guardStart, guardStart + 900)
+const keyForBot = bot => `${bot.connectionId || 'local'}::${bot.name}`
 
-test('the /new guard reads the canonical registry row, never a stored pointer', () => {
-  assert.match(guardBlock, /canonical_session/)
-  assert.doesNotMatch(guardBlock, /meta\?\.chat/)
-  assert.doesNotMatch(guardBlock, /chat_pin/)
+
+test('/new and /reset are rollover commands while /compact is unchanged', () => {
+  assert.equal(botRolloverCommand('/new'), 'new')
+  assert.equal(botRolloverCommand('  /RESET  '), 'reset')
+  assert.equal(botRolloverCommand('/new please'), null)
+  assert.equal(botRolloverCommand('/compact'), null)
 })
 
-test('the guard matches both the durable registry id and the lineage tip', () => {
-  assert.match(guardBlock, /canonical\?\.id/)
-  assert.match(guardBlock, /canonical\?\.resolved_id/)
+test('only the focused exact canonical owner resolves; Sessions mode passes through', () => {
+  const local = {
+    name: 'optimus',
+    connectionId: 'local',
+    canonical_session: { id: 'local-root', resolved_id: 'local-tip', title: 'Bot Chat' }
+  }
+  const remote = {
+    name: 'optimus',
+    connectionId: 'spark',
+    remoteSource: true,
+    canonical_session: { id: 'remote-root', resolved_id: 'remote-tip', title: 'Bot Chat' }
+  }
+  const roster = [local, remote]
+
+  const target = focusedCanonicalBot({
+    roster,
+    selectedKey: 'spark::optimus',
+    focusedStoredSessionId: 'remote-tip',
+    keyForBot
+  })
+  assert.equal(target.bot, remote)
+  assert.equal(target.expectedCurrentSessionId, 'remote-tip')
+
+  assert.equal(
+    focusedCanonicalBot({
+      roster,
+      selectedKey: 'spark::optimus',
+      focusedStoredSessionId: 'local-tip',
+      keyForBot
+    }),
+    null,
+    'same-name bot on another connection must not collide'
+  )
+  assert.equal(
+    focusedCanonicalBot({ roster, selectedKey: '', focusedStoredSessionId: 'remote-tip', keyForBot }),
+    null,
+    'Sessions mode has no exact Bot owner and remains untouched'
+  )
+  assert.equal(
+    focusedCanonicalBot({
+      roster,
+      selectedKey: 'spark::optimus',
+      focusedStoredSessionId: 'remote-tip',
+      botsMode: false,
+      keyForBot
+    }),
+    null,
+    'leaving Bots mode disables the interception even if its tab remains focused'
+  )
+})
+
+
+test('compressed canonical root and resolved tip both count as the focused chat', () => {
+  const bot = {
+    name: 'ops',
+    canonical_session: { id: 'root', resolved_id: 'tip', title: 'Bot Chat' }
+  }
+
+  for (const focusedStoredSessionId of ['root', 'tip']) {
+    const target = focusedCanonicalBot({
+      roster: [bot],
+      selectedKey: 'local::ops',
+      focusedStoredSessionId,
+      keyForBot
+    })
+    assert.equal(target.expectedCurrentSessionId, focusedStoredSessionId)
+  }
+})
+
+
+test('rollover refreshes the roster and opens the returned fresh stored session', async () => {
+  const calls = []
+  const opened = []
+  let refreshed = 0
+  const target = {
+    bot: { name: 'ops', connectionId: 'spark', remoteSource: true },
+    canonical: { id: 'old-root', resolved_id: 'old-tip' },
+    expectedCurrentSessionId: 'old-tip'
+  }
+
+  const result = await executeBotRollover({
+    target,
+    force: false,
+    request: async (bot, method, params) => {
+      calls.push({ bot, method, params })
+      return {
+        created: true,
+        confirmation_required: false,
+        current_session_id: 'fresh-session',
+        current_session: { id: 'fresh-session', title: 'Bot Chat', message_count: 0 }
+      }
+    },
+    profileForBot: () => 'ops',
+    refresh: async () => {
+      refreshed += 1
+    },
+    open: async (bot, id, summary) => {
+      opened.push({ bot, id, summary })
+    }
+  })
+
+  assert.equal(result.current_session_id, 'fresh-session')
+  assert.equal(calls[0].method, 'session.bot_rollover')
+  assert.deepEqual(calls[0].params, {
+    expected_current_session_id: 'old-tip',
+    force: false,
+    profile: 'ops'
+  })
+  assert.equal(calls[0].bot, target.bot)
+  assert.equal(refreshed, 1)
+  assert.equal(opened[0].id, 'fresh-session')
+  assert.equal(opened[0].summary.message_count, 0)
+})
+
+
+test('active work returns a confirmation result without refresh or navigation', async () => {
+  let refreshed = false
+  let opened = false
+  const result = await executeBotRollover({
+    target: {
+      bot: { name: 'ops' },
+      canonical: { id: 'old' },
+      expectedCurrentSessionId: 'old'
+    },
+    request: async () => ({
+      created: false,
+      confirmation_required: true,
+      active_reasons: ['turn']
+    }),
+    refresh: async () => {
+      refreshed = true
+    },
+    open: async () => {
+      opened = true
+    }
+  })
+
+  assert.equal(result.confirmation_required, true)
+  assert.equal(refreshed, false)
+  assert.equal(opened, false)
+})
+
+
+test('a post-commit open failure is tagged recoverably instead of claiming rollback', async () => {
+  await assert.rejects(
+    () =>
+      executeBotRollover({
+        target: {
+          bot: { name: 'ops' },
+          canonical: { id: 'old' },
+          expectedCurrentSessionId: 'old'
+        },
+        request: async () => ({
+          created: true,
+          current_session_id: 'fresh',
+          current_session: { id: 'fresh', title: 'Bot Chat', message_count: 0 }
+        }),
+        refresh: async () => undefined,
+        open: async () => {
+          throw new Error('renderer temporarily unavailable')
+        }
+      }),
+    error => {
+      assert.equal(error.rolloverCommitted, true)
+      assert.equal(error.currentSessionId, 'fresh')
+      assert.match(error.message, /created.*could not be opened/i)
+      return true
+    }
+  )
 })

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -6112,6 +6112,267 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         self._insert_session_row(session_id, source, **kwargs)
         return session_id
 
+    def rollover_bot_session(
+        self,
+        *,
+        new_session_id: str,
+        expected_current_session_id: str,
+        force: bool = False,
+        canonical_title: str = "Bot Chat",
+    ) -> Dict[str, Any]:
+        """Atomically replace one profile's canonical Bot Chat with a fresh row.
+
+        The exact *canonical_title* is the registry; no separately persisted
+        client pointer participates.  The old compression lineage remains in
+        the database as visible history, while the new row is unrelated and
+        carries only the bot/session configuration required to rebuild the
+        same profile identity.
+
+        Live compression and turn leases are checked inside the same
+        ``BEGIN IMMEDIATE`` transaction as the title transfer.  A non-forced
+        call is therefore a race-safe probe.  Expired/dead leases are reclaimed
+        without confirmation; a forced call deletes live leases to fence late
+        writes/publication before committing the boundary.
+        """
+        new_id = str(new_session_id or "").strip()
+        expected = str(expected_current_session_id or "").strip()
+        title = str(canonical_title or "").strip()
+        if not new_id:
+            raise ValueError("new_session_id required")
+        if not expected:
+            raise ValueError("expected_current_session_id required")
+        if not title:
+            raise ValueError("canonical_title required")
+
+        def _config(row: sqlite3.Row) -> Dict[str, Any]:
+            raw = row["model_config"]
+            if not raw:
+                return {}
+            try:
+                parsed = json.loads(raw) if isinstance(raw, str) else raw
+            except (TypeError, json.JSONDecodeError):
+                return {}
+            return parsed if isinstance(parsed, dict) else {}
+
+        def _is_continuation(
+            child: sqlite3.Row, parent_id: str, parent_end_reason: Optional[str]
+        ) -> bool:
+            if parent_end_reason != "compression" or child["source"] == "tool":
+                return False
+            cfg = _config(child)
+            return (
+                cfg.get("_branched_from") != parent_id
+                and cfg.get("_delegate_from") != parent_id
+                and cfg.get("_reset_from") != parent_id
+            )
+
+        def _lineage(conn, registry_row: sqlite3.Row) -> List[sqlite3.Row]:
+            root = registry_row
+            seen = {str(root["id"])}
+            for _ in range(100):
+                parent_id = str(root["parent_session_id"] or "")
+                if not parent_id:
+                    break
+                parent = conn.execute(
+                    "SELECT * FROM sessions WHERE id = ?", (parent_id,)
+                ).fetchone()
+                if (
+                    parent is None
+                    or str(parent["id"]) in seen
+                    or not _is_continuation(root, parent_id, parent["end_reason"])
+                ):
+                    break
+                root = parent
+                seen.add(str(root["id"]))
+
+            rows = [root]
+            current = root
+            for _ in range(100):
+                candidates = conn.execute(
+                    "SELECT child.* FROM sessions AS child "
+                    "WHERE child.parent_session_id = ? "
+                    "ORDER BY "
+                    "CASE "
+                    "  WHEN child.end_reason = 'compression' THEN 0 "
+                    "  WHEN child.ended_at IS NULL THEN 1 "
+                    "  ELSE 2 "
+                    "END, "
+                    f"{_sql_session_last_active('child')} DESC, "
+                    "child.started_at DESC, child.id DESC",
+                    (current["id"],),
+                ).fetchall()
+                child = next(
+                    (
+                        row
+                        for row in candidates
+                        if str(row["id"]) not in seen
+                        and _is_continuation(
+                            row, str(current["id"]), current["end_reason"]
+                        )
+                    ),
+                    None,
+                )
+                if child is None:
+                    break
+                rows.append(child)
+                seen.add(str(child["id"]))
+                current = child
+            return rows
+
+        def _holder_is_stale(holder: str, expires_at: Any, now: float) -> bool:
+            try:
+                expired = float(expires_at) <= now
+            except (TypeError, ValueError):
+                expired = True
+            return expired or _compression_lock_holder_process_is_dead(holder)
+
+        def _do(conn):
+            registry = conn.execute(
+                "SELECT * FROM sessions WHERE title = ? LIMIT 1", (title,)
+            ).fetchone()
+            if registry is None:
+                raise RuntimeError(f"canonical Bot Chat not found: {title}")
+
+            lineage = _lineage(conn, registry)
+            lineage_ids = [str(row["id"]) for row in lineage]
+            root = lineage[0]
+            tip = lineage[-1]
+
+            # Idempotent concurrent follower: once another BEGIN IMMEDIATE
+            # writer has transferred the title, the new canonical row is the
+            # answer.  It must not mint a second row or retire the winner.
+            if expected not in lineage_ids:
+                return {
+                    "created": False,
+                    "confirmation_required": False,
+                    "active_reasons": [],
+                    "previous_session_id": None,
+                    "previous_resolved_id": None,
+                    "current_session_id": str(registry["id"]),
+                }
+
+            now = time.time()
+            active_reasons: set[str] = set()
+            placeholders = ",".join("?" for _ in lineage_ids)
+
+            for lock in conn.execute(
+                f"SELECT session_id, holder, expires_at FROM compression_locks "
+                f"WHERE session_id IN ({placeholders})",
+                lineage_ids,
+            ).fetchall():
+                if _holder_is_stale(lock["holder"], lock["expires_at"], now):
+                    conn.execute(
+                        "DELETE FROM compression_locks "
+                        "WHERE session_id = ? AND holder = ?",
+                        (lock["session_id"], lock["holder"]),
+                    )
+                else:
+                    active_reasons.add("compression")
+
+            lease_keys = list(dict.fromkeys((str(root["id"]), *lineage_ids)))
+            lease_ph = ",".join("?" for _ in lease_keys)
+            for lease in conn.execute(
+                f"SELECT conversation_id, holder, expires_at "
+                f"FROM session_turn_leases WHERE conversation_id IN ({lease_ph})",
+                lease_keys,
+            ).fetchall():
+                if _holder_is_stale(lease["holder"], lease["expires_at"], now):
+                    conn.execute(
+                        "DELETE FROM session_turn_leases "
+                        "WHERE conversation_id = ? AND holder = ?",
+                        (lease["conversation_id"], lease["holder"]),
+                    )
+                else:
+                    active_reasons.add("turn")
+
+            if active_reasons and not force:
+                return {
+                    "created": False,
+                    "confirmation_required": True,
+                    "active_reasons": sorted(active_reasons),
+                    "previous_session_id": str(root["id"]),
+                    "previous_resolved_id": str(tip["id"]),
+                    "current_session_id": str(root["id"]),
+                }
+
+            if conn.execute(
+                "SELECT 1 FROM sessions WHERE id = ? LIMIT 1", (new_id,)
+            ).fetchone():
+                raise RuntimeError(f"new Bot Chat session id already exists: {new_id}")
+
+            if force:
+                conn.execute(
+                    f"DELETE FROM compression_locks WHERE session_id IN ({placeholders})",
+                    lineage_ids,
+                )
+                conn.execute(
+                    f"DELETE FROM session_turn_leases "
+                    f"WHERE conversation_id IN ({lease_ph})",
+                    lease_keys,
+                )
+
+            retired_title = (
+                f"{title} (retired {time.strftime('%Y-%m-%d %H:%M:%S', time.gmtime(now))} "
+                f"{str(root['id'])[:12]})"
+            )
+            renamed = conn.execute(
+                "UPDATE sessions SET title = ?, title_source = 'bot_rollover' "
+                "WHERE id = ? AND title = ?",
+                (retired_title, root["id"], title),
+            )
+            if renamed.rowcount != 1:
+                raise RuntimeError("canonical Bot Chat title changed during rollover")
+
+            conn.execute(
+                f"UPDATE sessions SET hidden = 0 WHERE id IN ({placeholders})",
+                lineage_ids,
+            )
+            retired = conn.execute(
+                "UPDATE sessions SET ended_at = ?, end_reason = 'bot_rollover' "
+                "WHERE id = ?",
+                (now, tip["id"]),
+            )
+            if retired.rowcount != 1:
+                raise RuntimeError("canonical Bot Chat tip disappeared during rollover")
+
+            # No gateway peer/routing columns, parent, counters, activity,
+            # cooldowns, or messages are copied.  The row is immediately
+            # durable so title-registry lookups and relaunches cannot observe
+            # an empty window between retiring the old chat and first prompt.
+            conn.execute(
+                """INSERT INTO sessions (
+                       id, source, model, model_config, system_prompt,
+                       system_prompt_hash, started_at, cwd, git_branch,
+                       git_repo_root, profile_name, title, title_source, hidden
+                   ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1)""",
+                (
+                    new_id,
+                    tip["source"],
+                    tip["model"],
+                    tip["model_config"],
+                    tip["system_prompt"],
+                    tip["system_prompt_hash"],
+                    now,
+                    tip["cwd"],
+                    tip["git_branch"],
+                    tip["git_repo_root"],
+                    tip["profile_name"],
+                    title,
+                    self.TITLE_SOURCE_USER,
+                ),
+            )
+
+            return {
+                "created": True,
+                "confirmation_required": False,
+                "active_reasons": sorted(active_reasons),
+                "previous_session_id": str(root["id"]),
+                "previous_resolved_id": str(tip["id"]),
+                "current_session_id": new_id,
+            }
+
+        return self._execute_write(_do, patience_s=self._TRANSCRIPT_WRITE_PATIENCE_S)
+
     def record_gateway_session_peer(
         self,
         session_id: str,

--- a/tests/tui_gateway/test_bot_session_rollover.py
+++ b/tests/tui_gateway/test_bot_session_rollover.py
@@ -1,0 +1,664 @@
+"""Bot Mode canonical-session rollover invariants.
+
+The exact title ``Bot Chat`` is the canonical registry inside one profile's
+state.db.  Rollover transfers that title to a fresh, unrelated row in one
+transaction and preserves the retired lineage as readable history.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from hermes_state import SessionDB, SessionTurnLeaseLostError
+import tui_gateway.server as srv
+from tui_gateway.turn_marker import read_turn_marker, record_turn_start
+
+
+BOT_TITLE = "Bot Chat"
+
+
+def _seed_bot_session(
+    db: SessionDB,
+    sid: str,
+    *,
+    title: str = BOT_TITLE,
+    parent_session_id: str | None = None,
+    source: str = "desktop",
+    model: str = "openai:test-model",
+    cwd: str = "/tmp/bot-workspace",
+    profile_name: str = "ops",
+    with_messages: bool = True,
+) -> None:
+    db.create_session(
+        sid,
+        source=source,
+        model=model,
+        model_config={
+            "model": model,
+            "provider": "openai",
+            "enabled_toolsets": ["web", "memory"],
+            "reasoning_config": {"effort": "high"},
+            "service_tier": "priority",
+            "durable_memory": {"enabled": True},
+        },
+        system_prompt="You are the same durable bot.",
+        cwd=cwd,
+        profile_name=profile_name,
+        git_repo_root="/tmp/bot-workspace",
+        parent_session_id=parent_session_id,
+    )
+    if with_messages:
+        db.append_message(sid, "user", f"old question in {sid}")
+        db.append_message(sid, "assistant", f"old answer in {sid}")
+    assert db.set_session_title(sid, title)
+    db.set_session_hidden(sid, True)
+
+
+def _row(db: SessionDB, sid: str) -> dict:
+    row = db.get_session(sid)
+    assert row is not None
+    return row
+
+
+def _messages(db: SessionDB, sid: str) -> list[dict]:
+    return db.get_messages_as_conversation(sid)
+
+
+def _turn_lease_rows(db: SessionDB) -> list[dict]:
+    with db._lock:
+        return [dict(row) for row in db._conn.execute("SELECT * FROM session_turn_leases")]
+
+
+def test_rollover_creates_unrelated_empty_canonical_row_and_preserves_bot_identity(tmp_path):
+    db = SessionDB(tmp_path / "state.db")
+    _seed_bot_session(db, "old-chat")
+    with db._lock:
+        db._conn.execute(
+            "UPDATE sessions SET git_branch = 'main', last_activity_at = ?, "
+            "last_activity_description = 'compressing', last_activity_provenance = 'tool', "
+            "compression_failure_cooldown_until = ?, compression_failure_error = 'old', "
+            "compression_fallback_streak = 3, compression_ineffective_count = 2 "
+            "WHERE id = 'old-chat'",
+            (time.time(), time.time() + 100),
+        )
+
+    result = db.rollover_bot_session(
+        new_session_id="new-chat",
+        expected_current_session_id="old-chat",
+    )
+
+    assert result["created"] is True
+    assert result["previous_session_id"] == "old-chat"
+    assert result["previous_resolved_id"] == "old-chat"
+    assert result["current_session_id"] == "new-chat"
+
+    old = _row(db, "old-chat")
+    new = _row(db, "new-chat")
+    assert old["end_reason"] == "bot_rollover"
+    assert old["ended_at"] is not None
+    assert old["title"].startswith("Bot Chat (retired ")
+    assert old["hidden"] == 0, "retired history is visible/readable"
+    assert len(_messages(db, "old-chat")) == 2
+
+    assert new["title"] == BOT_TITLE
+    assert new["hidden"] == 1, "only the current Bot Chat stays plugin-owned"
+    assert new["title_source"] == SessionDB.TITLE_SOURCE_USER
+    assert db.set_auto_title(
+        "new-chat", "First-turn generated title", source=SessionDB.TITLE_SOURCE_LLM
+    ) is False
+    assert _row(db, "new-chat")["title"] == BOT_TITLE
+    assert new["parent_session_id"] is None
+    assert _messages(db, "new-chat") == []
+    assert new["message_count"] == 0
+    assert new["source"] == old["source"]
+    assert new["model"] == old["model"]
+    model_config = json.loads(new["model_config"])
+    assert model_config["enabled_toolsets"] == ["web", "memory"]
+    assert model_config["durable_memory"] == {"enabled": True}
+    assert new["system_prompt"] == "You are the same durable bot."
+    assert new["cwd"] == old["cwd"]
+    assert new["profile_name"] == old["profile_name"]
+    assert new["git_repo_root"] == old["git_repo_root"]
+    assert new["git_branch"] == old["git_branch"]
+
+    for field in (
+        "user_id",
+        "session_key",
+        "chat_id",
+        "chat_type",
+        "thread_id",
+        "display_name",
+        "origin_json",
+        "last_activity_at",
+        "last_activity_description",
+        "last_activity_provenance",
+        "compression_failure_cooldown_until",
+        "compression_failure_error",
+    ):
+        assert new[field] is None
+    assert new["compression_fallback_streak"] == 0
+    assert new["compression_ineffective_count"] == 0
+
+
+@pytest.mark.parametrize("expected", ["root-chat", "tip-chat"])
+def test_rollover_accepts_compressed_root_or_tip_and_retires_logical_lineage(tmp_path, expected):
+    db = SessionDB(tmp_path / "state.db")
+    _seed_bot_session(db, "root-chat")
+    db.end_session("root-chat", "compression")
+    _seed_bot_session(
+        db,
+        "tip-chat",
+        title="Bot Chat (continued)",
+        parent_session_id="root-chat",
+    )
+
+    result = db.rollover_bot_session(
+        new_session_id="new-chat",
+        expected_current_session_id=expected,
+    )
+
+    assert result["previous_session_id"] == "root-chat"
+    assert result["previous_resolved_id"] == "tip-chat"
+    assert _row(db, "root-chat")["end_reason"] == "compression"
+    assert _row(db, "tip-chat")["end_reason"] == "bot_rollover"
+    assert _row(db, "root-chat")["hidden"] == 0
+    assert _row(db, "tip-chat")["hidden"] == 0
+    assert _row(db, "new-chat")["parent_session_id"] is None
+    assert _row(db, "new-chat")["title"] == BOT_TITLE
+    assert db.resolve_resume_session_id("root-chat") == "tip-chat"
+
+
+@pytest.mark.parametrize("expected", ["root-chat", "live-child"])
+def test_rollover_uses_canonical_tip_when_stale_closed_sibling_exists(tmp_path, monkeypatch, expected):
+    db = SessionDB(tmp_path / "state.db")
+    monkeypatch.setattr(srv, "_get_db", lambda: db)
+    _seed_bot_session(db, "root-chat")
+    db.end_session("root-chat", "compression")
+    _seed_bot_session(
+        db,
+        "stale-child",
+        title="Bot Chat (stale continuation)",
+        parent_session_id="root-chat",
+    )
+    db.end_session("stale-child", "ws_orphan_reap")
+    _seed_bot_session(
+        db,
+        "live-child",
+        title="Bot Chat (live continuation)",
+        parent_session_id="root-chat",
+    )
+
+    with db._lock:
+        db._conn.execute(
+            "UPDATE sessions SET started_at = ? WHERE id = 'stale-child'",
+            (time.time() - 100,),
+        )
+        db._conn.execute(
+            "UPDATE sessions SET started_at = ? WHERE id = 'live-child'",
+            (time.time(),),
+        )
+        db._conn.commit()
+
+    assert db.resolve_resume_session_id("root-chat") == "live-child"
+
+    result = db.rollover_bot_session(
+        new_session_id="new-chat",
+        expected_current_session_id=expected,
+    )
+
+    assert result["created"] is True
+    assert result["previous_session_id"] == "root-chat"
+    assert result["previous_resolved_id"] == "live-child"
+    assert _row(db, "live-child")["end_reason"] == "bot_rollover"
+    assert _row(db, "stale-child")["end_reason"] == "ws_orphan_reap"
+    assert _row(db, "new-chat")["title"] == BOT_TITLE
+
+    listed = srv._methods["session.bot_history"]("list", {})
+    assert [row["id"] for row in listed["result"]["sessions"]] == ["root-chat"]
+    assert listed["result"]["sessions"][0]["resolved_id"] == "live-child"
+    opened = srv._methods["session.bot_history"](
+        "open", {"session_id": "root-chat"}
+    )
+    assert "error" not in opened, opened
+    assert opened["result"]["session"]["resolved_id"] == "live-child"
+
+
+def test_active_lock_or_turn_lease_probes_without_mutation_then_force_fences_both(tmp_path):
+    db = SessionDB(tmp_path / "state.db")
+    _seed_bot_session(db, "old-chat")
+    compression_holder = f"pid={os.getpid()}:compress"
+    turn_holder = f"pid={os.getpid()}:turn"
+    assert db.try_acquire_compression_lock("old-chat", compression_holder, ttl_seconds=60)
+    assert db.try_acquire_session_turn_lease("old-chat", turn_holder, ttl_seconds=60)
+
+    probe = db.rollover_bot_session(
+        new_session_id="new-chat",
+        expected_current_session_id="old-chat",
+        force=False,
+    )
+    assert probe["confirmation_required"] is True
+    assert set(probe["active_reasons"]) == {"compression", "turn"}
+    assert _row(db, "old-chat")["title"] == BOT_TITLE
+    assert db.get_session("new-chat") is None
+
+    result = db.rollover_bot_session(
+        new_session_id="new-chat",
+        expected_current_session_id="old-chat",
+        force=True,
+    )
+    assert result["created"] is True
+    assert db.get_compression_lock_holder("old-chat") is None
+    assert _turn_lease_rows(db) == []
+    assert not db.refresh_session_turn_lease("old-chat", turn_holder, ttl_seconds=60)
+    with pytest.raises(SessionTurnLeaseLostError):
+        db.append_message(
+            "old-chat",
+            "assistant",
+            "late result from the interrupted turn",
+            turn_lease_holder=turn_holder,
+        )
+    assert _messages(db, "new-chat") == []
+
+
+def test_stale_compression_lock_and_turn_lease_clear_without_confirmation(tmp_path):
+    db = SessionDB(tmp_path / "state.db")
+    _seed_bot_session(db, "old-chat")
+    now = time.time()
+    with db._lock:
+        db._conn.execute(
+            "INSERT INTO compression_locks(session_id, holder, acquired_at, expires_at) "
+            "VALUES ('old-chat', 'pid=999999999:dead', ?, ?)",
+            (now - 10, now - 1),
+        )
+        db._conn.execute(
+            "INSERT INTO session_turn_leases(conversation_id, holder, acquired_at, expires_at) "
+            "VALUES ('old-chat', 'pid=999999999:dead', ?, ?)",
+            (now - 10, now - 1),
+        )
+
+    result = db.rollover_bot_session(
+        new_session_id="new-chat",
+        expected_current_session_id="old-chat",
+    )
+    assert result["created"] is True
+    assert result["confirmation_required"] is False
+    assert db.get_compression_lock_holder("old-chat") is None
+    assert _turn_lease_rows(db) == []
+
+
+def test_concurrent_rollovers_have_one_winner_and_one_canonical_row(tmp_path):
+    path = tmp_path / "state.db"
+    db = SessionDB(path)
+    _seed_bot_session(db, "old-chat")
+    db.close()
+    barrier = threading.Barrier(2)
+
+    def rollover(sid: str) -> dict:
+        local = SessionDB(path)
+        try:
+            barrier.wait()
+            return local.rollover_bot_session(
+                new_session_id=sid,
+                expected_current_session_id="old-chat",
+            )
+        finally:
+            local.close()
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(rollover, ["new-a", "new-b"]))
+
+    winners = [row for row in results if row["created"]]
+    followers = [row for row in results if not row["created"]]
+    assert len(winners) == 1
+    assert len(followers) == 1
+    assert followers[0]["current_session_id"] == winners[0]["current_session_id"]
+
+    check = SessionDB(path)
+    try:
+        canonical = check.get_session_by_title(BOT_TITLE)
+        assert canonical["id"] == winners[0]["current_session_id"]
+        assert sum(bool(check.get_session(sid)) for sid in ("new-a", "new-b")) == 1
+    finally:
+        check.close()
+
+
+def test_insert_failure_rolls_back_title_retirement_locks_and_new_row(tmp_path):
+    db = SessionDB(tmp_path / "state.db")
+    _seed_bot_session(db, "old-chat")
+    holder = f"pid={os.getpid()}:compress"
+    assert db.try_acquire_compression_lock("old-chat", holder, ttl_seconds=60)
+    with db._lock:
+        db._conn.execute(
+            "CREATE TRIGGER fail_rollover BEFORE INSERT ON sessions "
+            "WHEN NEW.id = 'new-chat' BEGIN SELECT RAISE(ABORT, 'synthetic rollover failure'); END"
+        )
+
+    with pytest.raises(sqlite3.DatabaseError, match="synthetic rollover failure"):
+        db.rollover_bot_session(
+            new_session_id="new-chat",
+            expected_current_session_id="old-chat",
+            force=True,
+        )
+
+    assert _row(db, "old-chat")["title"] == BOT_TITLE
+    assert _row(db, "old-chat")["end_reason"] is None
+    assert _row(db, "old-chat")["hidden"] == 1
+    assert db.get_session("new-chat") is None
+    assert db.get_compression_lock_holder("old-chat") == holder
+
+
+def test_rpc_probe_interrupts_only_exact_live_owner_on_force_and_returns_history(tmp_path, monkeypatch):
+    db = SessionDB(tmp_path / "state.db")
+    _seed_bot_session(db, "old-chat")
+    monkeypatch.setattr(srv, "_get_db", lambda: db)
+    old_agent = type("Agent", (), {"session_id": "old-chat"})()
+    other_agent = type("Agent", (), {"session_id": "other-chat"})()
+    old_live = {
+        "agent": old_agent,
+        "history": [{"role": "user", "content": "working"}],
+        "history_lock": threading.Lock(),
+        "running": True,
+        "session_key": "old-chat",
+        "profile_home": str(tmp_path),
+    }
+    other_live = {
+        "agent": other_agent,
+        "history": [],
+        "history_lock": threading.Lock(),
+        "running": True,
+        "session_key": "other-chat",
+    }
+    monkeypatch.setattr(srv, "_sessions", {"ui-old": old_live, "ui-other": other_live})
+    interrupted: list[str] = []
+    monkeypatch.setattr(
+        srv,
+        "_interrupt_session_turn",
+        lambda sid, session, **_kwargs: interrupted.append(sid) or False,
+    )
+
+    probe = srv._methods["session.bot_rollover"](
+        "probe",
+        {"expected_current_session_id": "old-chat", "new_session_id": "new-chat"},
+    )
+    assert probe["result"]["confirmation_required"] is True
+    assert interrupted == []
+    assert db.get_session("new-chat") is None
+
+    forced = srv._methods["session.bot_rollover"](
+        "force",
+        {
+            "expected_current_session_id": "old-chat",
+            "new_session_id": "new-chat",
+            "force": True,
+        },
+    )
+    assert "error" not in forced, forced
+    result = forced["result"]
+    assert interrupted == ["ui-old"]
+    assert other_live.get("_bot_rollover") is None
+    assert old_live["_bot_rollover"] is True
+    assert result["current_session"]["id"] == "new-chat"
+    assert result["current_session"]["title"] == BOT_TITLE
+    assert result["current_session"]["message_count"] == 0
+    assert result["previous_session"]["id"] == "old-chat"
+    assert result["previous_session"]["message_count"] == 2
+
+
+def test_rpc_concurrent_follower_does_not_close_the_winning_new_runtime(tmp_path, monkeypatch):
+    db = SessionDB(tmp_path / "state.db")
+    _seed_bot_session(db, "old-chat")
+    db.rollover_bot_session(
+        new_session_id="winner-chat",
+        expected_current_session_id="old-chat",
+    )
+    monkeypatch.setattr(srv, "_get_db", lambda: db)
+    winner_live = {
+        "agent": type("Agent", (), {"session_id": "winner-chat"})(),
+        "history": [],
+        "history_lock": threading.Lock(),
+        "running": False,
+        "session_key": "winner-chat",
+    }
+    monkeypatch.setattr(srv, "_sessions", {"ui-winner": winner_live})
+
+    follower = srv._methods["session.bot_rollover"](
+        "follower",
+        {
+            "expected_current_session_id": "old-chat",
+            "new_session_id": "loser-chat",
+        },
+    )
+
+    assert "error" not in follower, follower
+    assert follower["result"]["created"] is False
+    assert follower["result"]["current_session_id"] == "winner-chat"
+    assert winner_live.get("_closing") is None
+    assert winner_live.get("_bot_rollover") is None
+    assert db.get_session("loser-chat") is None
+
+
+def test_rpc_force_db_failure_leaves_live_runtime_and_canonical_row_untouched(tmp_path, monkeypatch):
+    db = SessionDB(tmp_path / "state.db")
+    _seed_bot_session(db, "old-chat")
+    with db._lock:
+        db._conn.execute(
+            "CREATE TRIGGER fail_rpc_rollover BEFORE INSERT ON sessions "
+            "WHEN NEW.id = 'new-chat' BEGIN SELECT RAISE(ABORT, 'rpc insert failure'); END"
+        )
+    monkeypatch.setattr(srv, "_get_db", lambda: db)
+    live = {
+        "agent": type("Agent", (), {"session_id": "old-chat"})(),
+        "history": [],
+        "history_lock": threading.Lock(),
+        "running": True,
+        "session_key": "old-chat",
+    }
+    monkeypatch.setattr(srv, "_sessions", {"ui-old": live})
+    interrupted: list[str] = []
+    monkeypatch.setattr(
+        srv,
+        "_interrupt_session_turn",
+        lambda sid, _session, **_kwargs: interrupted.append(sid) or False,
+    )
+
+    failed = srv._methods["session.bot_rollover"](
+        "force-failure",
+        {
+            "expected_current_session_id": "old-chat",
+            "new_session_id": "new-chat",
+            "force": True,
+        },
+    )
+
+    assert failed["error"]["code"] == 5006
+    assert interrupted == []
+    assert live["running"] is True
+    assert live.get("_closing") is None
+    assert live.get("_bot_rollover") is None
+    assert _row(db, "old-chat")["title"] == BOT_TITLE
+    assert _row(db, "old-chat")["end_reason"] is None
+    assert db.get_session("new-chat") is None
+
+
+def test_retired_history_lists_normally_while_relaunch_registry_resolves_only_new(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    db = SessionDB(tmp_path / "state.db")
+    _seed_bot_session(db, "old-chat")
+    monkeypatch.setattr(srv, "_get_db", lambda: db)
+
+    response = srv._methods["session.bot_rollover"](
+        "roll",
+        {"expected_current_session_id": "old-chat", "new_session_id": "new-chat"},
+    )
+    assert "error" not in response, response
+
+    canonical = srv._methods["session.list"](
+        "canonical", {"title": BOT_TITLE, "include_hidden": True}
+    )["result"]["sessions"]
+    assert [row["id"] for row in canonical] == ["new-chat"]
+
+    visible = srv._methods["session.list"]("history", {})["result"]["sessions"]
+    assert any(row["id"] == "old-chat" for row in visible)
+    assert all(row["id"] != "new-chat" for row in visible)
+
+    roster = srv._methods["profiles.list"]("roster", {})["result"]["profiles"]
+    default = next(row for row in roster if row["name"] == "default")
+    assert default["canonical_session"]["id"] == "new-chat"
+    assert default["canonical_session"]["resolved_id"] == "new-chat"
+
+
+def test_retired_turn_marker_cannot_auto_continue_after_relaunch(tmp_path, monkeypatch):
+    db = SessionDB(tmp_path / "state.db")
+    _seed_bot_session(db, "old-chat")
+    db.rollover_bot_session(
+        new_session_id="new-chat",
+        expected_current_session_id="old-chat",
+    )
+    record_turn_start(tmp_path, "old-chat", "work that must stay retired")
+    assert read_turn_marker(tmp_path, "old-chat") is not None
+
+    session = {
+        "agent": None,
+        "history": [],
+        "history_lock": threading.Lock(),
+        "profile_home": str(tmp_path),
+        "running": False,
+        "session_key": "old-chat",
+    }
+    result = srv._maybe_schedule_auto_continue("ui-old", session, "old-chat")
+
+    assert result is None
+    assert read_turn_marker(tmp_path, "old-chat") is None
+    assert read_turn_marker(tmp_path, "new-chat") is None
+
+
+def test_compressed_retired_root_marker_cannot_schedule_auto_continue(tmp_path, monkeypatch):
+    db = SessionDB(tmp_path / "state.db")
+    _seed_bot_session(db, "root-chat")
+    db.end_session("root-chat", "compression")
+    _seed_bot_session(
+        db,
+        "tip-chat",
+        title="Bot Chat (continued)",
+        parent_session_id="root-chat",
+    )
+    db.rollover_bot_session(
+        new_session_id="new-chat",
+        expected_current_session_id="tip-chat",
+    )
+    record_turn_start(tmp_path, "root-chat", "work that must stay retired")
+
+    scheduled = []
+
+    class InertThread:
+        def __init__(self, *, target, daemon):
+            self.target = target
+            self.daemon = daemon
+
+        def start(self):
+            scheduled.append(True)
+
+    monkeypatch.setattr(srv.threading, "Thread", InertThread)
+    session = {
+        "agent": None,
+        "history": [],
+        "history_lock": threading.Lock(),
+        "profile_home": str(tmp_path),
+        "running": False,
+        "session_key": "root-chat",
+    }
+
+    result = srv._maybe_schedule_auto_continue("ui-old", session, "root-chat")
+
+    assert result is None
+    assert scheduled == []
+    assert read_turn_marker(tmp_path, "root-chat") is None
+
+
+def test_bot_history_rpc_lists_and_reads_only_retired_bot_lineages(tmp_path, monkeypatch):
+    db = SessionDB(tmp_path / "state.db")
+    _seed_bot_session(db, "old-chat")
+    _seed_bot_session(db, "ordinary", title="Ordinary session")
+    monkeypatch.setattr(srv, "_get_db", lambda: db)
+    db.rollover_bot_session(
+        new_session_id="new-chat",
+        expected_current_session_id="old-chat",
+    )
+
+    listed = srv._methods["session.bot_history"]("list", {})
+    assert "error" not in listed, listed
+    assert [row["id"] for row in listed["result"]["sessions"]] == ["old-chat"]
+
+    opened = srv._methods["session.bot_history"](
+        "open", {"session_id": "old-chat"}
+    )
+    assert "error" not in opened, opened
+    assert opened["result"]["session"]["id"] == "old-chat"
+    assert [message["role"] for message in opened["result"]["messages"]] == [
+        "user",
+        "assistant",
+    ]
+
+    current = srv._methods["session.bot_history"](
+        "current", {"session_id": "new-chat"}
+    )
+    assert current["error"]["code"] == 4007
+
+
+def test_bot_history_lists_and_opens_compressed_retired_root(tmp_path, monkeypatch):
+    db = SessionDB(tmp_path / "state.db")
+    _seed_bot_session(db, "root-chat")
+    db.end_session("root-chat", "compression")
+    _seed_bot_session(
+        db,
+        "tip-chat",
+        title="Bot Chat (continued)",
+        parent_session_id="root-chat",
+    )
+    monkeypatch.setattr(srv, "_get_db", lambda: db)
+    db.rollover_bot_session(
+        new_session_id="new-chat",
+        expected_current_session_id="tip-chat",
+    )
+
+    listed = srv._methods["session.bot_history"]("list", {})
+
+    assert "error" not in listed, listed
+    assert [row["id"] for row in listed["result"]["sessions"]] == ["root-chat"]
+    assert listed["result"]["sessions"][0]["resolved_id"] == "tip-chat"
+
+    opened = srv._methods["session.bot_history"](
+        "open", {"session_id": listed["result"]["sessions"][0]["id"]}
+    )
+    assert "error" not in opened, opened
+    assert opened["result"]["session"]["id"] == "root-chat"
+    assert opened["result"]["session"]["resolved_id"] == "tip-chat"
+    assert [message["role"] for message in opened["result"]["messages"]] == [
+        "user",
+        "assistant",
+        "user",
+        "assistant",
+    ]
+
+
+def test_rollover_does_not_touch_other_profile_database(tmp_path):
+    default = SessionDB(tmp_path / "default.db")
+    other = SessionDB(tmp_path / "other.db")
+    _seed_bot_session(default, "default-old", profile_name="default")
+    _seed_bot_session(other, "other-old", profile_name="other")
+
+    default.rollover_bot_session(
+        new_session_id="default-new",
+        expected_current_session_id="default-old",
+    )
+
+    assert _row(other, "other-old")["title"] == BOT_TITLE
+    assert _row(other, "other-old")["end_reason"] is None
+    assert other.get_session("default-new") is None

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -277,6 +277,282 @@ def _(rid, params: dict) -> dict:
             return _err(rid, 5006, str(e))
 
 
+@method("session.bot_rollover")
+def _(rid, params: dict) -> dict:
+    """Replace the owning profile's canonical Bot Chat with a fresh DB row.
+
+    ``force=false`` is a race-safe probe: meaningful live work returns
+    ``confirmation_required`` without moving the title.  ``force=true`` asks
+    the live runtime to stop and lets SessionDB fence compression/turn leases
+    in the same transaction as the title transfer.
+    """
+    expected = str(params.get("expected_current_session_id") or "").strip()
+    new_id = str(params.get("new_session_id") or "").strip() or uuid.uuid4().hex[:8]
+    force = is_truthy_value(params.get("force", False))
+    if not expected:
+        return _err(rid, 4002, "expected_current_session_id required")
+
+    from tools.bot_mode_probe import BOT_CHAT_TITLE
+
+    with _profile_db(params) as db:
+        if db is None:
+            return _db_unavailable_error(rid, code=5006)
+        try:
+            canonical = db.get_session_by_title(BOT_CHAT_TITLE)
+            if canonical is None:
+                return _err(rid, 4007, "canonical Bot Chat not found")
+            lineage = db.get_compression_lineage(canonical["id"]) or [canonical["id"]]
+            lineage_ids = {str(value) for value in lineage if value}
+            try:
+                resolved = db.resolve_resume_session_id(canonical["id"]) or canonical["id"]
+            except Exception:
+                resolved = canonical["id"]
+            lineage_ids.add(str(resolved))
+
+            matches = []
+            # A concurrent winner may already have transferred the title.
+            # In that follower case, the current canonical lineage is the NEW
+            # session and must not be marked closing merely because this RPC
+            # still presents the retired expected id.
+            if expected in lineage_ids:
+                with _sessions_lock:
+                    candidates = list(_sessions.items())
+            else:
+                candidates = []
+            for ui_sid, session in candidates:
+                agent = session.get("agent")
+                owned = {
+                    str(session.get("session_key") or ""),
+                    str(getattr(agent, "session_id", "") or ""),
+                }
+                if owned & lineage_ids:
+                    matches.append((ui_sid, session))
+
+            running = []
+            marked = []
+            for ui_sid, session in matches:
+                with session["history_lock"]:
+                    if session.get("running"):
+                        running.append((ui_sid, session))
+                    else:
+                        marked.append(
+                            (
+                                session,
+                                session.get("_closing"),
+                                session.get("_bot_rollover"),
+                            )
+                        )
+                        session["_closing"] = True
+
+            if running and not force:
+                for session, old_closing, old_rollover in marked:
+                    with session["history_lock"]:
+                        if old_closing is None:
+                            session.pop("_closing", None)
+                        else:
+                            session["_closing"] = old_closing
+                        if old_rollover is None:
+                            session.pop("_bot_rollover", None)
+                        else:
+                            session["_bot_rollover"] = old_rollover
+                return _ok(
+                    rid,
+                    {
+                        "created": False,
+                        "confirmation_required": True,
+                        "active_reasons": ["turn"],
+                        "previous_session_id": canonical["id"],
+                        "previous_resolved_id": resolved,
+                        "current_session_id": canonical["id"],
+                    },
+                )
+
+            if force:
+                for ui_sid, session in running:
+                    with session["history_lock"]:
+                        marked.append(
+                            (
+                                session,
+                                session.get("_closing"),
+                                session.get("_bot_rollover"),
+                            )
+                        )
+                        session["_closing"] = True
+
+            try:
+                result = db.rollover_bot_session(
+                    new_session_id=new_id,
+                    expected_current_session_id=expected,
+                    force=force,
+                    canonical_title=BOT_CHAT_TITLE,
+                )
+            except Exception:
+                for session, old_closing, old_rollover in marked:
+                    with session["history_lock"]:
+                        if old_closing is None:
+                            session.pop("_closing", None)
+                        else:
+                            session["_closing"] = old_closing
+                        if old_rollover is None:
+                            session.pop("_bot_rollover", None)
+                        else:
+                            session["_bot_rollover"] = old_rollover
+                raise
+
+            if result.get("confirmation_required"):
+                for session, old_closing, old_rollover in marked:
+                    with session["history_lock"]:
+                        if old_closing is None:
+                            session.pop("_closing", None)
+                        else:
+                            session["_closing"] = old_closing
+                        if old_rollover is None:
+                            session.pop("_bot_rollover", None)
+                        else:
+                            session["_bot_rollover"] = old_rollover
+                return _ok(rid, result)
+
+            if result.get("created"):
+                for ui_sid, session in matches:
+                    with session["history_lock"]:
+                        session["_closing"] = True
+                        session["_bot_rollover"] = True
+                        session["_turn_cancel_requested"] = True
+                        session["queued_prompt"] = None
+                        session.pop("queued_prompts", None)
+                        session.pop("_auto_continue_scheduled", None)
+                    _retire_turn_marker(session, *lineage_ids)
+                if force:
+                    # Commit the DB boundary first. Clearing the turn lease and
+                    # compression lock is the durable publication fence; only
+                    # then interrupt the old runtime. A failed DB transaction
+                    # therefore leaves the live turn and its queue untouched.
+                    for ui_sid, session in running:
+                        try:
+                            _interrupt_session_turn(
+                                ui_sid, session, request_id=f"bot-rollover-{rid}"
+                            )
+                        except Exception:
+                            logger.warning(
+                                "Bot rollover live-turn interrupt failed for %s",
+                                ui_sid,
+                                exc_info=True,
+                            )
+                    # Manual compression does not set session.running. Ask
+                    # every matching agent to abort; its now-deleted DB lease
+                    # makes any late publication fail closed without waiting.
+                    try:
+                        from agent.interrupt_compat import request_hard_interrupt
+
+                        for _ui_sid, session in matches:
+                            request_hard_interrupt(session.get("agent"))
+                    except Exception:
+                        pass
+
+            current = db.get_session(result["current_session_id"])
+            previous_id = result.get("previous_session_id")
+            previous = db.get_session(previous_id) if previous_id else None
+            previous_tip_id = result.get("previous_resolved_id") or previous_id
+            previous_tip = db.get_session(previous_tip_id) if previous_tip_id else None
+
+            def summary(row, *, count_row=None):
+                if row is None:
+                    return None
+                counter = count_row or row
+                return {
+                    "id": row["id"],
+                    "resolved_id": counter["id"],
+                    "title": row.get("title") or "",
+                    "started_at": row.get("started_at") or 0,
+                    "message_count": counter.get("message_count") or 0,
+                    "source": row.get("source") or "",
+                }
+
+            return _ok(
+                rid,
+                {
+                    **result,
+                    "current_session": summary(current),
+                    "previous_session": summary(previous, count_row=previous_tip),
+                },
+            )
+        except Exception as exc:
+            return _err(rid, 5006, f"Bot session rollover failed: {exc}")
+
+
+@method("session.bot_history")
+def _(rid, params: dict) -> dict:
+    """List or read retired Bot Chat lineages without reopening them.
+
+    This is deliberately read-only: ordinary ``session.resume`` clears an
+    explicit end boundary so the conversation can run again, which is the
+    wrong contract for a previous Bot session. Bots mode uses this focused
+    browser to keep ``bot_rollover`` durable while still exposing every old
+    message.
+    """
+    retired_prefix = "Bot Chat (retired "
+
+    with _profile_db(params) as db:
+        if db is None:
+            return _db_unavailable_error(rid, code=5006)
+        try:
+            def retired_summary(root):
+                if not root or not str(root.get("title") or "").startswith(retired_prefix):
+                    return None
+                tip_id = db.get_compression_tip(root["id"]) or root["id"]
+                tip = db.get_session(tip_id) or root
+                if tip.get("end_reason") != "bot_rollover":
+                    return None
+                return {
+                    "id": root["id"],
+                    "resolved_id": tip["id"],
+                    "title": root.get("title") or "",
+                    "started_at": root.get("started_at") or 0,
+                    "last_active": tip.get("last_activity_at") or tip.get("started_at") or 0,
+                    "message_count": tip.get("message_count") or 0,
+                    "source": root.get("source") or "",
+                    "preview": tip.get("preview") or "",
+                }
+
+            requested = str(params.get("session_id") or "").strip()
+            if requested:
+                root = db.get_session(requested)
+                summary = retired_summary(root)
+                if summary is None:
+                    return _err(rid, 4007, "retired Bot session not found")
+                messages = db.get_messages_as_conversation(
+                    summary["resolved_id"],
+                    include_ancestors=True,
+                    include_row_ids=True,
+                )
+                return _ok(
+                    rid,
+                    {
+                        "session": summary,
+                        "messages": _history_to_messages(messages),
+                    },
+                )
+
+            limit = max(1, min(200, int(params.get("limit", 50) or 50)))
+            rows = db.list_sessions_rich(
+                limit=max(limit * 2, 100),
+                order_by_last_active=True,
+                include_hidden=True,
+                compact_rows=True,
+                project_compression_tips=False,
+            )
+            sessions = []
+            for row in rows:
+                summary = retired_summary(db.get_session(row["id"]))
+                if summary is not None:
+                    sessions.append(summary)
+                    if len(sessions) >= limit:
+                        break
+            return _ok(rid, {"sessions": sessions})
+        except Exception as exc:
+            return _err(rid, 5006, f"Bot history failed: {exc}")
+
+
 @method("session.most_recent")
 def _(rid, params: dict) -> dict:
     """Return the most recent human-facing session id, or ``None``.

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -353,6 +353,8 @@ _LONG_HANDLERS = frozenset(
         # so a delayed status rehydrate cannot block runtime readiness, prompt
         # submission, or interrupts queued behind it on the same socket.
         "session.active_list",
+        "session.bot_history",
+        "session.bot_rollover",
         "session.branch",
         "session.compress",
         "session.list",
@@ -9441,6 +9443,25 @@ def _maybe_schedule_auto_continue(sid: str, session: dict, session_key: str) -> 
     marker = read_turn_marker(home, session_key)
     if marker is None:
         return None
+    if session.get("_bot_rollover"):
+        clear_turn_marker(home, session_key)
+        return None
+    try:
+        with _session_db(session) as db:
+            row = db.get_session(session_key) if db is not None else None
+            if row and db is not None:
+                tip_id = db.get_compression_tip(session_key) or session_key
+                if tip_id != session_key:
+                    row = db.get_session(tip_id) or row
+        if row and row.get("end_reason") == "bot_rollover":
+            clear_turn_marker(home, session_key)
+            return None
+    except Exception:
+        logger.debug(
+            "could not verify bot-rollover auto-continue boundary for %s",
+            session_key,
+            exc_info=True,
+        )
     enabled, freshness_secs, max_attempts = _auto_continue_config()
     age = time.time() - marker["started_at"]
     if not enabled or age > freshness_secs or marker["attempts"] >= max_attempts:
@@ -13094,6 +13115,13 @@ def _run_prompt_submit(
             with session["history_lock"]:
                 _enqueue_prompt(session, _leftover_steer, session.get("transport"))
         if _drain_queued_prompt(rid, sid, session):
+            return
+
+        # An explicit Bot-session rollover is a terminal conversation boundary.
+        # The old thread may finish its current Python stack, but it must never
+        # schedule goal/restart/notification follow-ups after the new unrelated
+        # canonical row exists.
+        if session.get("_bot_rollover"):
             return
 
         # Chain a goal-continuation turn if the judge said so. We do


### PR DESCRIPTION
## Problem

Canonical Bot chats currently treat `/new` and `/reset` as `/compact`. That keeps each Bot in one forever-growing transcript, so an oversized Bot chat can become trapped in repeated preflight compression instead of starting cleanly.

Bot identity and conversation history need separate lifecycles: the Bot/profile should remain stable while its current conversation can roll over to a new durable session.

## Solution

- Add `session.bot_rollover` and `session.bot_history` gateway RPCs.
- Make `/new` and `/reset` roll over only the exact focused canonical Bot chat; keep `/compact` and Sessions-mode behavior unchanged.
- Transfer the canonical `Bot Chat` title inside one `BEGIN IMMEDIATE` transaction.
- Create a fresh unrelated session with no copied messages, compressed summary, parent lineage, routing state, activity counters, locks, leases, or background-work ownership.
- Preserve Bot/profile identity, model configuration, toolsets, system prompt, workspace, Git metadata, and durable-memory configuration.
- Retire the previous compression lineage with `end_reason = bot_rollover`, preserve it as read-only Bot history, and suppress restart/auto-continue recovery.
- Fence active compression locks and turn leases atomically; require confirmation for meaningful live work and interrupt only after the durable boundary commits.
- Make concurrent rollovers converge on one canonical winner and roll back cleanly on creation/title-transfer failure.
- Add visible **New Bot Session** and **Previous Bot Sessions** actions in Bots mode.
- Route local, remote, and alias Bots through their exact owning profile/backend.

## Verification

Current `origin/main` transplant:

- `tests/tui_gateway/test_bot_session_rollover.py`: **18 passed**
- Focused Desktop rollover helpers: **6 passed**
- Complete Bot plugin suite: **629 passed**
- Desktop TypeScript typecheck: **passed**
- Python compilation for changed backend modules: **passed**
- `git diff --check`: **passed**

Original packaged-build verification before transplanting the unchanged patch onto current main:

- Desktop UI suite: **6,087 passed**
- Electron platform suite: **1,934 passed, 6 skipped**
- Desktop artifact/package verification: **passed**
- Signed macOS package: **passed**
- Independent read-only review: **PASS — no blocking/high-severity findings**

Live packaged-app validation confirmed:

- a different canonical session ID was created;
- the new transcript was empty before its first message;
- a canary completed without preflight compression;
- canonical/resolved routing survived restart;
- the retired conversation remained readable in Bot history.
