### PR TITLE
feat(session): safely audit and bulk-reset stored model routes

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -120,6 +120,24 @@ def _hermes_database_paths(hermes_home: Path) -> list[tuple[str, Path]]:
     return entries
 
 
+def _session_model_route_diagnostics(db_path: Path) -> dict:
+    """Read-only summary of internally inconsistent session model routes."""
+    from hermes_state import SessionDB
+
+    db = SessionDB(db_path, read_only=True)
+    try:
+        rows = db.audit_session_model_routes(inconsistent_only=True)
+    finally:
+        db.close()
+    return {
+        "count": len(rows),
+        "session_ids": [str(row["id"]) for row in rows[:10]],
+        "issues": sorted(
+            {issue for row in rows for issue in row.get("route_issues", [])}
+        ),
+    }
+
+
 _SQLITE_HEADER_MAGIC = b"SQLite format 3\x00"
 
 
@@ -2070,6 +2088,24 @@ def run_doctor(args):
             count = cursor.fetchone()[0]
             conn.close()
             check_ok(f"{_DHH}/state.db exists ({count} sessions)")
+
+            route_report = _session_model_route_diagnostics(state_db_path)
+            if route_report["count"]:
+                shown_ids = ", ".join(route_report["session_ids"])
+                suffix = (
+                    f", +{route_report['count'] - len(route_report['session_ids'])} more"
+                    if route_report["count"] > len(route_report["session_ids"])
+                    else ""
+                )
+                check_warn(
+                    f"{route_report['count']} session model route(s) are inconsistent",
+                    f"({shown_ids}{suffix}; audit with `hermes sessions list --model '*'`)",
+                )
+                issues.append(
+                    "Session model/provider metadata is inconsistent — audit with "
+                    "`hermes sessions list --model '*'` and repair with "
+                    "`hermes sessions reset-model --dry-run --all`"
+                )
 
             # FTS write-health probe (#50502): `SELECT COUNT(*)` above succeeds
             # even when the FTS index is corrupt and every message write fails

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -14042,7 +14042,7 @@ def main():
     # =========================================================================
     sessions_parser = subparsers.add_parser(
         "sessions",
-        help="Manage session history (list, rename, export, prune, delete)",
+        help="Manage session history and stored model routes",
         description="View and manage the SQLite session store",
     )
     sessions_subparsers = sessions_parser.add_subparsers(dest="sessions_action")
@@ -14059,6 +14059,45 @@ def main():
         metavar="NEEDLE",
         help="Only sessions in one workspace: a git repo root or project dir "
         "(matched by path substring or basename).",
+    )
+    sessions_list.add_argument(
+        "--model",
+        metavar="GLOB",
+        help="Audit sessions whose stored model matches a glob (for example 'gpt-*')",
+    )
+    sessions_list.add_argument(
+        "--provider",
+        metavar="NAME",
+        help="Audit sessions whose stored provider matches NAME",
+    )
+
+    sessions_reset_model = sessions_subparsers.add_parser(
+        "reset-model",
+        help="Safely bulk-reset session model/provider overrides",
+        description=(
+            "Reset every non-target session route in the active profile. The "
+            "profile's model.default/model.provider are used unless overridden. "
+            "A full SQLite backup is mandatory before writes, and the result is "
+            "read back for verification."
+        ),
+    )
+    sessions_reset_model.add_argument(
+        "--to", metavar="MODEL", help="Target model (default: profile model.default)"
+    )
+    sessions_reset_model.add_argument(
+        "--provider",
+        metavar="NAME",
+        help="Target provider (default: profile model.provider)",
+    )
+    sessions_reset_model.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print exact session IDs without writing or creating a backup",
+    )
+    sessions_reset_model.add_argument(
+        "--all",
+        action="store_true",
+        help="Acknowledge that all non-target sessions in this profile are in scope",
     )
 
     def _add_session_filter_args(p, default_older_help):

--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -121,6 +121,106 @@ def _prune_never_active_keyed(db, args):
     )
 
 
+def _resolve_session_model_target(args):
+    """Resolve reset-model's explicit target over the active profile defaults."""
+    from hermes_cli.runtime_provider import _get_model_config
+
+    config = _get_model_config()
+    configured_model = str(config.get("default") or "").strip()
+    configured_provider = str(config.get("provider") or "").strip()
+    model = str(getattr(args, "to", None) or configured_model).strip()
+    provider = str(
+        getattr(args, "provider", None) or configured_provider
+    ).strip()
+    if not model:
+        raise ValueError(
+            "no target model was supplied and model.default is not configured"
+        )
+    if not provider:
+        raise ValueError(
+            "no target provider was supplied and model.provider is not configured"
+        )
+
+    # Endpoint/mode belong to the configured default route. An explicit provider
+    # change must not carry that old route's endpoint into the new provider.
+    same_provider = not getattr(args, "provider", None) or (
+        provider.lower() == configured_provider.lower()
+    )
+    return {
+        "model": model,
+        "provider": provider,
+        "base_url": str(config.get("base_url") or "").strip() if same_provider else "",
+        "api_mode": str(config.get("api_mode") or "").strip() if same_provider else "",
+    }
+
+
+def _print_session_model_audit(rows):
+    home = get_hermes_home()
+    profile = (
+        home.name
+        if home.parent.name == "profiles"
+        else os.environ.get("HERMES_PROFILE", "default")
+    )
+    print(f"Profile: {profile}")
+    if not rows:
+        print("No sessions match the model/provider audit filters.")
+        return
+    print(
+        f"{'Model':<30} {'Provider':<18} {'Status':<9} "
+        f"{'Last Active':<13} {'Src':<10} {'ID'}"
+    )
+    print("─" * 120)
+    for row in rows:
+        status = "DESYNC" if row.get("route_issues") else "ok"
+        print(
+            f"{str(row.get('stored_model') or '-')[:28]:<30} "
+            f"{str(row.get('stored_provider') or '-')[:16]:<18} "
+            f"{status:<9} {_relative_time(row.get('last_active')):<13} "
+            f"{str(row.get('source') or '-')[:8]:<10} {row['id']}"
+        )
+        if row.get("route_issues"):
+            print(f"  route issues: {'; '.join(row['route_issues'])}")
+
+
+def _reset_session_models(db, args):
+    if not getattr(args, "all", False):
+        print(
+            "Error: reset-model requires --all to acknowledge that every "
+            "non-target session in this profile is in scope."
+        )
+        return 2
+    try:
+        target = _resolve_session_model_target(args)
+        report = db.reset_session_model_routes(
+            target_model=target["model"],
+            target_provider=target["provider"],
+            target_base_url=target.get("base_url"),
+            target_api_mode=target.get("api_mode"),
+            dry_run=bool(getattr(args, "dry_run", False)),
+        )
+    except (OSError, ValueError) as exc:
+        print(f"Error: session model reset failed: {exc}")
+        return 1
+
+    print(
+        f"Target route: {target['provider']} / {target['model']} "
+        f"({report['rows_affected']} session(s))"
+    )
+    for session_id in report["row_ids"]:
+        print(f"  {session_id}")
+    if report["dry_run"]:
+        print("Dry run — no rows changed and no backup was created.")
+        return 0
+    if report["backup_path"]:
+        print(f"  backup: {report['backup_path']}")
+    print(f"✓ Updated {report['rows_affected']} session(s).")
+    print(
+        "Read-back verification — remaining non-target sessions: "
+        f"{report['remaining_non_target']}"
+    )
+    return 0 if report["remaining_non_target"] == 0 else 1
+
+
 def cmd_sessions(args, sessions_parser=None):
     import json as _json
 
@@ -329,6 +429,20 @@ def cmd_sessions(args, sessions_parser=None):
     if action == "list":
         from hermes_state import workspace_key as _ws_key
 
+        model_filter = getattr(args, "model", None)
+        provider_filter = getattr(args, "provider", None)
+        if model_filter or provider_filter:
+            rows = db.audit_session_model_routes(
+                model_glob=model_filter,
+                provider=provider_filter,
+                source=_source,
+                exclude_sources=_exclude,
+                limit=args.limit,
+            )
+            _print_session_model_audit(rows)
+            db.close()
+            return
+
         sessions = db.list_sessions_rich(
             source=args.source, exclude_sources=_exclude, limit=args.limit
         )
@@ -399,6 +513,12 @@ def cmd_sessions(args, sessions_parser=None):
             else:
                 sid = s["id"]
                 print(f"{preview:<50} {last_active:<13} {s['source']:<6} {sid}")
+
+    elif action == "reset-model":
+        try:
+            return _reset_session_models(db, args)
+        finally:
+            db.close()
 
     elif action == "export":
         from hermes_cli.session_filters import (

--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -20,6 +20,7 @@ time — no import cycle).
 """
 
 import os
+import sqlite3
 import sys
 from pathlib import Path
 
@@ -198,7 +199,7 @@ def _reset_session_models(db, args):
             target_api_mode=target.get("api_mode"),
             dry_run=bool(getattr(args, "dry_run", False)),
         )
-    except (OSError, ValueError) as exc:
+    except (OSError, ValueError, sqlite3.Error) as exc:
         print(f"Error: session model reset failed: {exc}")
         return 1
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -8513,6 +8513,13 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         with self._read_ctx() as conn:
             candidates = _candidates(conn)
         candidate_ids = [str(row["id"]) for row in candidates]
+        route_fields = (
+            "model",
+            "billing_provider",
+            "billing_base_url",
+            "billing_mode",
+            "model_config",
+        )
         if dry_run or not candidates:
             return {
                 "dry_run": bool(dry_run),
@@ -8536,6 +8543,17 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             suffix += 1
         with self._lock:
             self._conn.execute("VACUUM INTO ?", (str(backup),))
+        backed_up_routes: Dict[str, Any] = {}
+        candidate_id_set = set(candidate_ids)
+        with sqlite3.connect(str(backup)) as backup_conn:
+            backup_conn.row_factory = sqlite3.Row
+            for backup_row in backup_conn.execute("SELECT * FROM sessions"):
+                backup_data = dict(backup_row)
+                backup_id = str(backup_data["id"])
+                if backup_id in candidate_id_set:
+                    backed_up_routes[backup_id] = tuple(
+                        backup_data.get(field) for field in route_fields
+                    )
 
         def _do(conn):
             changed: List[str] = []
@@ -8550,6 +8568,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 if current is None:
                     continue
                 row = dict(current)
+                if candidate_id not in backed_up_routes or tuple(
+                    row.get(field) for field in route_fields
+                ) != backed_up_routes[candidate_id]:
+                    continue
                 if not _needs_reset(row):
                     continue
                 config = self._session_model_route(row)["_parsed_model_config"]
@@ -8558,7 +8580,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 )
                 conn.execute(
                     "UPDATE sessions SET model = ?, billing_provider = ?, "
-                    "billing_base_url = ?, billing_mode = ?, model_config = ? "
+                    "billing_base_url = ?, billing_mode = ?, model_config = ?, "
+                    "system_prompt = NULL, system_prompt_hash = NULL "
                     "WHERE id = ?",
                     (
                         target_model,
@@ -8570,6 +8593,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     ),
                 )
                 changed.append(str(row["id"]))
+            if changed:
+                self._delete_unreferenced_system_prompts(conn)
             return changed
 
         changed_ids = self._execute_write(_do)

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -8324,6 +8324,265 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             self._delete_unreferenced_system_prompts(conn)
         self._execute_write(_do)
 
+    @staticmethod
+    def _session_model_route(row: Any) -> Dict[str, Any]:
+        """Normalize the three persisted session route shapes for diagnostics."""
+        data = dict(row) if isinstance(row, sqlite3.Row) else dict(row or {})
+        raw_config = data.get("model_config")
+        config: Dict[str, Any] = {}
+        malformed = False
+        if isinstance(raw_config, str) and raw_config.strip():
+            try:
+                parsed = json.loads(raw_config)
+                if isinstance(parsed, dict):
+                    config = parsed
+                else:
+                    malformed = True
+            except (json.JSONDecodeError, TypeError):
+                malformed = True
+        elif isinstance(raw_config, dict):
+            config = dict(raw_config)
+
+        runtime = config.get("gateway_runtime")
+        if not isinstance(runtime, dict):
+            runtime = {}
+        column_model = str(data.get("model") or "").strip()
+        billing_provider = str(data.get("billing_provider") or "").strip()
+        config_model = str(runtime.get("model") or config.get("model") or "").strip()
+        config_provider = str(
+            runtime.get("provider") or config.get("provider") or ""
+        ).strip()
+        issues: List[str] = []
+        if malformed:
+            issues.append("model_config is malformed")
+        if config_model and column_model and config_model != column_model:
+            issues.append("model_config.model != sessions.model")
+        if (
+            config_provider
+            and billing_provider
+            and billing_provider.lower() not in _BARE_BILLING_PROVIDERS
+            and config_provider.lower() != billing_provider.lower()
+        ):
+            issues.append("model_config.provider != sessions.billing_provider")
+        top_model = str(config.get("model") or "").strip()
+        runtime_model = str(runtime.get("model") or "").strip()
+        if top_model and runtime_model and top_model != runtime_model:
+            issues.append("gateway_runtime.model != model_config.model")
+        top_provider = str(config.get("provider") or "").strip()
+        runtime_provider = str(runtime.get("provider") or "").strip()
+        if (
+            top_provider
+            and runtime_provider
+            and top_provider.lower() != runtime_provider.lower()
+        ):
+            issues.append("gateway_runtime.provider != model_config.provider")
+        for key in ("base_url", "api_mode"):
+            top_value = str(config.get(key) or "").strip()
+            runtime_value = str(runtime.get(key) or "").strip()
+            if top_value and runtime_value and top_value != runtime_value:
+                issues.append(f"gateway_runtime.{key} != model_config.{key}")
+
+        return {
+            **data,
+            "stored_model": column_model or config_model,
+            "stored_provider": config_provider or billing_provider,
+            "route_issues": issues,
+            "_parsed_model_config": config,
+        }
+
+    def audit_session_model_routes(
+        self,
+        *,
+        model_glob: Optional[str] = None,
+        provider: Optional[str] = None,
+        source: Optional[str] = None,
+        exclude_sources: Optional[List[str]] = None,
+        inconsistent_only: bool = False,
+        limit: Optional[int] = None,
+    ) -> List[Dict[str, Any]]:
+        """Return profile-local session model routes with optional audit filters."""
+        import fnmatch
+
+        self.flush_token_counts()
+        with self._read_ctx() as conn:
+            rows = conn.execute(
+                "SELECT s.*, "
+                "COALESCE(s.last_activity_at, s.ended_at, s.started_at) AS last_active "
+                "FROM sessions s "
+                "ORDER BY last_active DESC, s.started_at DESC, s.id DESC"
+            ).fetchall()
+
+        model_pattern = (model_glob or "").strip().lower()
+        provider_needle = (provider or "").strip().lower()
+        source_needle = (source or "").strip().lower()
+        excluded = {str(value).strip().lower() for value in (exclude_sources or [])}
+        result: List[Dict[str, Any]] = []
+        if limit is not None and int(limit) <= 0:
+            return result
+        for raw_row in rows:
+            row = self._session_model_route(raw_row)
+            if model_pattern and not fnmatch.fnmatchcase(
+                str(row["stored_model"]).lower(), model_pattern
+            ):
+                continue
+            if provider_needle and str(row["stored_provider"]).lower() != provider_needle:
+                continue
+            row_source = str(row.get("source") or "").lower()
+            if source_needle and row_source != source_needle:
+                continue
+            if excluded and row_source in excluded:
+                continue
+            if inconsistent_only and not row["route_issues"]:
+                continue
+            row.pop("_parsed_model_config", None)
+            result.append(row)
+            if limit is not None and len(result) >= int(limit):
+                break
+        return result
+
+    def reset_session_model_routes(
+        self,
+        *,
+        target_model: str,
+        target_provider: str,
+        target_base_url: Optional[str] = None,
+        target_api_mode: Optional[str] = None,
+        dry_run: bool = False,
+    ) -> Dict[str, Any]:
+        """Atomically align every non-target session route after a safe backup."""
+        target_model = str(target_model or "").strip()
+        target_provider = str(target_provider or "").strip()
+        if not target_model or not target_provider:
+            raise ValueError("target model and provider are required")
+        base_url = str(target_base_url or "").strip() or None
+        api_mode = str(target_api_mode or "").strip() or None
+        self.flush_token_counts()
+
+        def _target_config(raw: Dict[str, Any]) -> Dict[str, Any]:
+            config = dict(raw)
+            runtime = config.get("gateway_runtime")
+            runtime = dict(runtime) if isinstance(runtime, dict) else {}
+            config["model"] = target_model
+            config["provider"] = target_provider
+            runtime["model"] = target_model
+            runtime["provider"] = target_provider
+            for key, value in (("base_url", base_url), ("api_mode", api_mode)):
+                if value is None:
+                    config.pop(key, None)
+                    runtime.pop(key, None)
+                else:
+                    config[key] = value
+                    runtime[key] = value
+            config["gateway_runtime"] = runtime
+            config.pop("browser_model_lock", None)
+            return config
+
+        def _needs_reset(row: Dict[str, Any]) -> bool:
+            route = self._session_model_route(row)
+            config = route["_parsed_model_config"]
+            runtime = config.get("gateway_runtime")
+            runtime = runtime if isinstance(runtime, dict) else {}
+            return any(
+                (
+                    str(row.get("model") or "").strip() != target_model,
+                    str(row.get("billing_provider") or "").strip().lower()
+                    != target_provider.lower(),
+                    str(config.get("model") or "").strip() != target_model,
+                    str(config.get("provider") or "").strip().lower()
+                    != target_provider.lower(),
+                    str(runtime.get("model") or "").strip() != target_model,
+                    str(runtime.get("provider") or "").strip().lower()
+                    != target_provider.lower(),
+                    (str(config.get("base_url") or "").strip() or None) != base_url,
+                    (str(runtime.get("base_url") or "").strip() or None) != base_url,
+                    (str(config.get("api_mode") or "").strip() or None) != api_mode,
+                    (str(runtime.get("api_mode") or "").strip() or None) != api_mode,
+                    "browser_model_lock" in config,
+                )
+            )
+
+        def _candidates(conn) -> List[Dict[str, Any]]:
+            return [
+                dict(row)
+                for row in conn.execute(
+                    "SELECT * FROM sessions ORDER BY started_at DESC, id DESC"
+                ).fetchall()
+                if _needs_reset(dict(row))
+            ]
+
+        with self._read_ctx() as conn:
+            candidates = _candidates(conn)
+        candidate_ids = [str(row["id"]) for row in candidates]
+        if dry_run or not candidates:
+            return {
+                "dry_run": bool(dry_run),
+                "rows_affected": len(candidates),
+                "row_ids": candidate_ids,
+                "backup_path": None,
+                "remaining_non_target": len(candidates),
+            }
+
+        import datetime
+
+        stamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+        backup = self.db_path.with_name(
+            f"{self.db_path.name}.pre-model-reset-backup-{stamp}"
+        )
+        suffix = 1
+        while backup.exists():
+            backup = self.db_path.with_name(
+                f"{self.db_path.name}.pre-model-reset-backup-{stamp}_{suffix}"
+            )
+            suffix += 1
+        with self._lock:
+            self._conn.execute("VACUUM INTO ?", (str(backup),))
+
+        def _do(conn):
+            changed: List[str] = []
+            # Bind the write set to the rows audited before the backup. A row
+            # created between VACUUM INTO and BEGIN IMMEDIATE is intentionally
+            # left alone (and makes read-back verification non-zero) because it
+            # does not exist in the safety snapshot.
+            for candidate_id in candidate_ids:
+                current = conn.execute(
+                    "SELECT * FROM sessions WHERE id = ?", (candidate_id,)
+                ).fetchone()
+                if current is None:
+                    continue
+                row = dict(current)
+                if not _needs_reset(row):
+                    continue
+                config = self._session_model_route(row)["_parsed_model_config"]
+                serialized = json.dumps(
+                    _target_config(config), separators=(",", ":"), sort_keys=True
+                )
+                conn.execute(
+                    "UPDATE sessions SET model = ?, billing_provider = ?, "
+                    "billing_base_url = ?, billing_mode = ?, model_config = ? "
+                    "WHERE id = ?",
+                    (
+                        target_model,
+                        target_provider,
+                        base_url,
+                        api_mode,
+                        serialized,
+                        row["id"],
+                    ),
+                )
+                changed.append(str(row["id"]))
+            return changed
+
+        changed_ids = self._execute_write(_do)
+        with self._read_ctx() as conn:
+            remaining = len(_candidates(conn))
+        return {
+            "dry_run": False,
+            "rows_affected": len(changed_ids),
+            "row_ids": changed_ids,
+            "backup_path": str(backup),
+            "remaining_non_target": remaining,
+        }
+
     def _merge_model_config_json(
         self,
         conn,

--- a/tests/hermes_cli/test_session_model_admin.py
+++ b/tests/hermes_cli/test_session_model_admin.py
@@ -1,6 +1,7 @@
 """Behavior tests for safe session model-route audit and reset."""
 
 import json
+import sqlite3
 from argparse import Namespace
 from pathlib import Path
 
@@ -421,6 +422,47 @@ def test_sessions_reset_model_uses_profile_default_and_prints_verification(
     assert rc in (None, 0)
     assert "backup:" in output
     assert "remaining non-target sessions: 0" in output
+
+
+def test_sessions_reset_model_reports_sqlite_failure(tmp_path, monkeypatch, capsys):
+    import hermes_state
+    import hermes_cli.sessions_cmd as sessions_cmd
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", tmp_path / "state.db")
+    monkeypatch.setattr(
+        sessions_cmd,
+        "_resolve_session_model_target",
+        lambda _args: {
+            "model": "new/model",
+            "provider": "openrouter",
+            "base_url": "",
+            "api_mode": "",
+        },
+    )
+    monkeypatch.setattr(
+        SessionDB,
+        "reset_session_model_routes",
+        lambda self, **kwargs: (_ for _ in ()).throw(
+            sqlite3.OperationalError("database or disk is full")
+        ),
+    )
+
+    rc = sessions_cmd.cmd_sessions(
+        Namespace(
+            sessions_action="reset-model",
+            all=True,
+            dry_run=False,
+            to=None,
+            provider=None,
+        )
+    )
+
+    assert rc == 1
+    assert (
+        "Error: session model reset failed: database or disk is full"
+        in capsys.readouterr().out
+    )
 
 
 def test_doctor_route_diagnostics_are_read_only(tmp_path):

--- a/tests/hermes_cli/test_session_model_admin.py
+++ b/tests/hermes_cli/test_session_model_admin.py
@@ -1,0 +1,369 @@
+"""Behavior tests for safe session model-route audit and reset."""
+
+import json
+from argparse import Namespace
+from pathlib import Path
+
+from hermes_state import SessionDB
+
+
+def _seed_session(
+    db: SessionDB,
+    session_id: str,
+    *,
+    model: str,
+    billing_provider: str,
+    model_config: dict,
+    source: str = "cli",
+) -> None:
+    db.create_session(
+        session_id,
+        source=source,
+        model=model,
+        model_config=model_config,
+    )
+    db._conn.execute(
+        "UPDATE sessions SET billing_provider = ?, title = ? WHERE id = ?",
+        (billing_provider, f"Title {session_id}", session_id),
+    )
+    db._conn.commit()
+
+
+def test_audit_filters_glob_and_reports_route_desync(tmp_path):
+    db = SessionDB(tmp_path / "state.db")
+    try:
+        _seed_session(
+            db,
+            "stale",
+            model="new/model",
+            billing_provider="openrouter",
+            model_config={
+                "model": "old/model",
+                "provider": "legacy",
+                "gateway_runtime": {
+                    "model": "old/model",
+                    "provider": "legacy",
+                    "base_url": "https://legacy.invalid/v1",
+                },
+                "_branched_from": "parent",
+            },
+            source="discord",
+        )
+        _seed_session(
+            db,
+            "healthy",
+            model="new/model",
+            billing_provider="openrouter",
+            model_config={
+                "model": "new/model",
+                "provider": "openrouter",
+                "gateway_runtime": {
+                    "model": "new/model",
+                    "provider": "openrouter",
+                },
+            },
+        )
+
+        rows = db.audit_session_model_routes(model_glob="new/*", provider="legacy")
+
+        assert [row["id"] for row in rows] == ["stale"]
+        assert rows[0]["source"] == "discord"
+        assert rows[0]["stored_provider"] == "legacy"
+        assert "model_config.model != sessions.model" in rows[0]["route_issues"]
+        assert "model_config.provider != sessions.billing_provider" in rows[0]["route_issues"]
+    finally:
+        db.close()
+
+
+def test_audit_does_not_treat_bare_billing_bucket_as_provider_desync(tmp_path):
+    db = SessionDB(tmp_path / "state.db")
+    try:
+        _seed_session(
+            db,
+            "custom",
+            model="vendor/model",
+            billing_provider="custom",
+            model_config={
+                "model": "vendor/model",
+                "provider": "custom:team-endpoint",
+            },
+        )
+
+        assert db.audit_session_model_routes(inconsistent_only=True) == []
+    finally:
+        db.close()
+
+
+def test_reset_dry_run_is_read_only_and_creates_no_backup(tmp_path):
+    db_path = tmp_path / "state.db"
+    db = SessionDB(db_path)
+    try:
+        _seed_session(
+            db,
+            "stale",
+            model="old/model",
+            billing_provider="legacy",
+            model_config={"model": "old/model", "provider": "legacy"},
+        )
+
+        report = db.reset_session_model_routes(
+            target_model="new/model",
+            target_provider="openrouter",
+            dry_run=True,
+        )
+
+        assert report["dry_run"] is True
+        assert report["rows_affected"] == 1
+        assert report["row_ids"] == ["stale"]
+        assert report["backup_path"] is None
+        assert db.get_session("stale")["model"] == "old/model"
+        assert list(tmp_path.glob("state.db.pre-model-reset-backup-*")) == []
+    finally:
+        db.close()
+
+
+def test_reset_backs_up_then_updates_only_session_route_fields_and_verifies(tmp_path):
+    db_path = tmp_path / "state.db"
+    db = SessionDB(db_path)
+    try:
+        original_config = {
+            "model": "old/model",
+            "provider": "legacy",
+            "base_url": "https://legacy.invalid/v1",
+            "api_mode": "anthropic_messages",
+            "gateway_runtime": {
+                "model": "old/model",
+                "provider": "legacy",
+                "base_url": "https://legacy.invalid/v1",
+                "api_mode": "anthropic_messages",
+            },
+            "browser_model_lock": {"model": "old/model", "confirmed": True},
+            "_branched_from": "parent",
+            "future_key": {"keep": True},
+        }
+        _seed_session(
+            db,
+            "stale",
+            model="old/model",
+            billing_provider="legacy",
+            model_config=original_config,
+        )
+        db._conn.execute(
+            "UPDATE sessions SET billing_base_url = ?, billing_mode = ?, message_count = 7 WHERE id = ?",
+            ("https://legacy.invalid/v1", "anthropic_messages", "stale"),
+        )
+        db._conn.execute("CREATE TABLE reset_sentinel (value TEXT)")
+        db._conn.execute("INSERT INTO reset_sentinel VALUES ('untouched')")
+        db._conn.commit()
+
+        report = db.reset_session_model_routes(
+            target_model="new/model",
+            target_provider="openrouter",
+            target_base_url="https://openrouter.ai/api/v1",
+            target_api_mode="chat_completions",
+        )
+
+        assert report["rows_affected"] == 1
+        assert report["remaining_non_target"] == 0
+        backup = Path(report["backup_path"])
+        assert backup.is_file()
+        row = db.get_session("stale")
+        config = json.loads(row["model_config"])
+        assert row["model"] == "new/model"
+        assert row["billing_provider"] == "openrouter"
+        assert row["billing_base_url"] == "https://openrouter.ai/api/v1"
+        assert row["billing_mode"] == "chat_completions"
+        assert row["message_count"] == 7
+        assert config["model"] == "new/model"
+        assert config["provider"] == "openrouter"
+        assert config["gateway_runtime"] == {
+            "model": "new/model",
+            "provider": "openrouter",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_mode": "chat_completions",
+        }
+        assert "browser_model_lock" not in config
+        assert config["_branched_from"] == "parent"
+        assert config["future_key"] == {"keep": True}
+        assert db._conn.execute("SELECT value FROM reset_sentinel").fetchone()[0] == "untouched"
+
+        backup_db = SessionDB(backup)
+        try:
+            assert backup_db.get_session("stale")["model"] == "old/model"
+        finally:
+            backup_db.close()
+    finally:
+        db.close()
+
+
+def test_reset_clears_stale_endpoint_keys_when_target_has_none(tmp_path):
+    db = SessionDB(tmp_path / "state.db")
+    try:
+        _seed_session(
+            db,
+            "stale",
+            model="old/model",
+            billing_provider="legacy",
+            model_config={
+                "model": "old/model",
+                "provider": "legacy",
+                "base_url": "https://legacy.invalid/v1",
+                "api_mode": "anthropic_messages",
+                "gateway_runtime": {
+                    "model": "old/model",
+                    "provider": "legacy",
+                    "base_url": "https://legacy.invalid/v1",
+                    "api_mode": "anthropic_messages",
+                },
+            },
+        )
+
+        db.reset_session_model_routes(
+            target_model="new/model",
+            target_provider="openrouter",
+        )
+
+        row = db.get_session("stale")
+        config = json.loads(row["model_config"])
+        assert row["billing_base_url"] is None
+        assert row["billing_mode"] is None
+        assert "base_url" not in config
+        assert "api_mode" not in config
+        assert "base_url" not in config["gateway_runtime"]
+        assert "api_mode" not in config["gateway_runtime"]
+    finally:
+        db.close()
+
+
+def test_sessions_list_model_filter_renders_audit_columns(
+    tmp_path, monkeypatch, capsys
+):
+    import hermes_state
+    from hermes_cli.sessions_cmd import cmd_sessions
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", tmp_path / "state.db")
+    db = SessionDB(tmp_path / "state.db")
+    try:
+        _seed_session(
+            db,
+            "stale",
+            model="old/model",
+            billing_provider="legacy",
+            model_config={"model": "old/model", "provider": "legacy"},
+            source="telegram",
+        )
+    finally:
+        db.close()
+
+    rc = cmd_sessions(
+        Namespace(
+            sessions_action="list",
+            source=None,
+            limit=20,
+            workspace=None,
+            model="old/*",
+            provider="legacy",
+        )
+    )
+
+    output = capsys.readouterr().out
+    assert rc in (None, 0)
+    assert "Model" in output and "Provider" in output and "Status" in output
+    assert "old/model" in output
+    assert "legacy" in output
+    assert "telegram" in output
+    assert "stale" in output
+
+
+def test_sessions_reset_model_requires_explicit_all_scope(tmp_path, monkeypatch, capsys):
+    import hermes_state
+    from hermes_cli.sessions_cmd import cmd_sessions
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", tmp_path / "state.db")
+    db = SessionDB(tmp_path / "state.db")
+    db.close()
+
+    rc = cmd_sessions(
+        Namespace(
+            sessions_action="reset-model",
+            all=False,
+            dry_run=True,
+            to="new/model",
+            provider="openrouter",
+        )
+    )
+
+    assert rc == 2
+    assert "--all" in capsys.readouterr().out
+
+
+def test_sessions_reset_model_uses_profile_default_and_prints_verification(
+    tmp_path, monkeypatch, capsys
+):
+    import hermes_state
+    import hermes_cli.sessions_cmd as sessions_cmd
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", tmp_path / "state.db")
+    monkeypatch.setattr(
+        sessions_cmd,
+        "_resolve_session_model_target",
+        lambda _args: {
+            "model": "new/model",
+            "provider": "openrouter",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_mode": "chat_completions",
+        },
+    )
+    db = SessionDB(tmp_path / "state.db")
+    try:
+        _seed_session(
+            db,
+            "stale",
+            model="old/model",
+            billing_provider="legacy",
+            model_config={"model": "old/model", "provider": "legacy"},
+        )
+    finally:
+        db.close()
+
+    rc = sessions_cmd.cmd_sessions(
+        Namespace(
+            sessions_action="reset-model",
+            all=True,
+            dry_run=False,
+            to=None,
+            provider=None,
+        )
+    )
+
+    output = capsys.readouterr().out
+    assert rc in (None, 0)
+    assert "backup:" in output
+    assert "remaining non-target sessions: 0" in output
+
+
+def test_doctor_route_diagnostics_are_read_only(tmp_path):
+    from hermes_cli.doctor import _session_model_route_diagnostics
+
+    db_path = tmp_path / "state.db"
+    db = SessionDB(db_path)
+    try:
+        _seed_session(
+            db,
+            "stale",
+            model="new/model",
+            billing_provider="openrouter",
+            model_config={"model": "old/model", "provider": "legacy"},
+        )
+    finally:
+        db.close()
+    before = db_path.stat().st_mtime_ns
+
+    report = _session_model_route_diagnostics(db_path)
+
+    assert report["count"] == 1
+    assert report["session_ids"] == ["stale"]
+    assert db_path.stat().st_mtime_ns == before

--- a/tests/hermes_cli/test_session_model_admin.py
+++ b/tests/hermes_cli/test_session_model_admin.py
@@ -196,6 +196,84 @@ def test_reset_backs_up_then_updates_only_session_route_fields_and_verifies(tmp_
         db.close()
 
 
+def test_reset_skips_route_changed_after_backup(tmp_path, monkeypatch):
+    db = SessionDB(tmp_path / "state.db")
+    try:
+        _seed_session(
+            db,
+            "stale",
+            model="old/model",
+            billing_provider="legacy",
+            model_config={"model": "old/model", "provider": "legacy"},
+        )
+        execute_write = db._execute_write
+
+        def interpose_route_change(callback):
+            db._conn.execute(
+                "UPDATE sessions SET model = ?, billing_provider = ?, model_config = ? "
+                "WHERE id = ?",
+                (
+                    "concurrent/model",
+                    "concurrent",
+                    json.dumps(
+                        {"model": "concurrent/model", "provider": "concurrent"}
+                    ),
+                    "stale",
+                ),
+            )
+            db._conn.commit()
+            return execute_write(callback)
+
+        monkeypatch.setattr(db, "_execute_write", interpose_route_change)
+
+        report = db.reset_session_model_routes(
+            target_model="new/model",
+            target_provider="openrouter",
+        )
+
+        assert report["rows_affected"] == 0
+        assert report["remaining_non_target"] == 1
+        assert db.get_session("stale")["model"] == "concurrent/model"
+        backup_db = SessionDB(Path(report["backup_path"]))
+        try:
+            assert backup_db.get_session("stale")["model"] == "old/model"
+        finally:
+            backup_db.close()
+    finally:
+        db.close()
+
+
+def test_reset_clears_cached_system_prompt_for_rewritten_route(tmp_path):
+    db = SessionDB(tmp_path / "state.db")
+    try:
+        _seed_session(
+            db,
+            "stale",
+            model="old/model",
+            billing_provider="legacy",
+            model_config={"model": "old/model", "provider": "legacy"},
+        )
+        db.update_system_prompt(
+            "stale", "Model: old/model\nProvider: legacy\nCached instructions"
+        )
+        before = db.get_session("stale")
+        assert before["system_prompt"] is not None
+        assert before["system_prompt_hash"] is not None
+
+        report = db.reset_session_model_routes(
+            target_model="new/model",
+            target_provider="openrouter",
+        )
+
+        assert report["rows_affected"] == 1
+        after = db.get_session("stale")
+        assert after["system_prompt"] is None
+        assert after["system_prompt_hash"] is None
+        assert db._conn.execute("SELECT COUNT(*) FROM system_prompts").fetchone()[0] == 0
+    finally:
+        db.close()
+
+
 def test_reset_clears_stale_endpoint_keys_when_target_has_none(tmp_path):
     db = SessionDB(tmp_path / "state.db")
     try:


### PR DESCRIPTION
## What does this PR do?

Adds a supported, profile-local way to audit and safely bulk-reset model/provider routing stored on existing sessions. Users can now find sessions pinned to old routes, preview the exact reset scope, take a mandatory SQLite snapshot before any write, and verify the rewritten rows instead of editing state.db with raw SQL.

### Motivation

Changing a profile's configured default does not alter deliberate per-session route persistence. Provider rotations can therefore leave many resumed chats pinned to old models or endpoints, while the only existing remediation is direct database manipulation.

### Behavior

- `hermes sessions list --model <glob> [--provider <name>]` renders model, provider, consistency status, activity, source, profile, and session ID.
- `hermes sessions reset-model --dry-run --all` previews every non-target session in the active profile.
- `hermes sessions reset-model --all` uses the profile defaults unless `--to` and/or `--provider` are supplied, snapshots state.db before writing, updates only session route columns/JSON, preserves unrelated model_config keys, and reports a read-back count.
- `hermes doctor` reports internally inconsistent session model route shapes.
- Cron job configuration and run records are not modified. Named profiles remain isolated and are selected through the existing `hermes -p <profile>` surface.

### Implementation

`SessionDB` now owns route normalization, audit filtering, transactional rewrite, backup creation, and post-write verification. The write set is bound to rows captured before the backup so a concurrently created session that is absent from the snapshot is never modified. CLI wiring resolves targets from the active profile and requires an explicit `--all` scope acknowledgement.

## Related Issue

Closes #96745

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `hermes_state.py` - add route audit, consistency diagnostics, mandatory backup, atomic reset, and read-back verification.
- `hermes_cli/sessions_cmd.py` - add audit rendering, target resolution, dry-run output, and reset execution.
- `hermes_cli/main.py` - register list filters and the `reset-model` command surface.
- `hermes_cli/doctor.py` - report inconsistent persisted session routes through a read-only probe.
- `tests/hermes_cli/test_session_model_admin.py` - cover filters, desync detection, dry-run immutability, backup contents, scope isolation, route-key preservation, endpoint cleanup, CLI output, and doctor reads.

## How to Test

1. Run `hermes sessions list --model '*'` and confirm stored routes are displayed without writes.
2. Run `hermes sessions reset-model --dry-run --all`, then `hermes sessions reset-model --all`, and confirm the backup path plus `remaining non-target sessions: 0`.
3. Run the automated coverage:

```bash
scripts/run_tests.sh tests/hermes_cli/test_session_model_admin.py tests/hermes_cli/test_doctor.py tests/hermes_cli/test_sessions_error_exit_codes.py tests/cli/test_resume_model_restore.py tests/test_stale_tool_call_marker_session_repair.py -q
uv run ruff check hermes_state.py hermes_cli/sessions_cmd.py hermes_cli/doctor.py hermes_cli/main.py tests/hermes_cli/test_session_model_admin.py
```

The targeted batch passed 116 tests on Windows 11. A broader `tests/state/` batch passed 194 tests with 6 skips and exposed 2 failures in untouched Linux `/proc` holder-detection tests that fake Linux from a Windows interpreter; no changed route-audit/reset test failed.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits.
- [x] I searched for existing PRs to make sure this is not a duplicate.
- [x] My PR contains only changes related to this feature.
- [x] I've run the relevant test entry points and reported their exact results above.
- [x] I've added tests for my changes.
- [x] I've tested on Windows 11.

### Documentation & Housekeeping

- [x] The CLI help and docstrings document the new behavior; no separate guide is required.
- [x] No config keys changed, so `cli-config.yaml.example` is N/A.
- [x] No contributor workflow changed, so `CONTRIBUTING.md` and `AGENTS.md` are N/A.
- [x] Cross-platform impact was considered; the implementation uses pathlib, sqlite3, and standard CLI paths.
- [x] No model tool behavior changed, so tool descriptions/schemas are N/A.

## Screenshots / Logs

N/A - this is a CLI and SQLite behavior change covered by command output and automated tests above.
