### PR TITLE
fix(auth): rotate credential pool on 403 quota walls

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -1231,7 +1231,9 @@ def _classify_by_status(
 
     if status_code == 403:
         # OpenRouter 403 "key limit exceeded" is actually billing. Other
-        # providers also use 403 for account-plan or credit exhaustion.
+        # providers also use 403 for account-plan, credit, or hard usage-quota
+        # exhaustion. Reuse the same semantic quota-wall predicate as the 429
+        # path so a provider-specific status code cannot bypass pool rotation.
         if (
             (
                 provider == "xai-oauth"
@@ -1239,7 +1241,12 @@ def _classify_by_status(
             )
             or "key limit exceeded" in error_msg
             or "spending limit" in error_msg
-            or any(p in error_msg for p in _BILLING_PATTERNS)
+            or _is_hard_usage_or_billing_limit(
+                error_msg,
+                error_code,
+                body,
+                response_headers,
+            )
         ):
             return result_fn(
                 FailoverReason.billing,
@@ -1359,28 +1366,11 @@ def _classify_by_status(
         # not itself an explicit rate-limit phrase. Without that guard,
         # "Rate limit exceeded" ("limit exceeded" substring) would wrongly
         # promote to non-retryable billing. (broadening + guard credit #39441)
-        has_usage_limit = (
-            error_code.lower() == "usage_limit_reached"
-            or "usage_limit_reached" in error_msg
-            or any(p in error_msg for p in _USAGE_LIMIT_PATTERNS)
-        )
-        # Explicit billing phrases in a 429 body are a hard wall regardless of
-        # usage-limit wording — a provider that wraps "insufficient credits" in
-        # a 429 (rather than 402) was previously retried as a rate limit and
-        # burned the pool. (credit #39441)
-        has_billing = any(p in error_msg for p in _BILLING_PATTERNS)
-        has_explicit_rate_limit = any(
-            p in error_msg for p in _RATE_LIMIT_PATTERNS
-        )
-        has_transient_signal = _has_usage_limit_transient_signal(
+        if _is_hard_usage_or_billing_limit(
             error_msg,
+            error_code,
             body,
             response_headers,
-        )
-        if (
-            (has_billing or has_usage_limit)
-            and not has_explicit_rate_limit
-            and not has_transient_signal
         ):
             return result_fn(
                 FailoverReason.billing,
@@ -1528,6 +1518,34 @@ def _has_usage_limit_transient_signal(
             if value is not None and value != "":
                 return True
     return False
+
+
+def _is_hard_usage_or_billing_limit(
+    error_msg: str,
+    error_code: str,
+    body: dict,
+    response_headers,
+) -> bool:
+    """Return whether an account-scoped quota wall should rotate credentials."""
+    has_usage_limit = (
+        error_code.lower() == "usage_limit_reached"
+        or "usage_limit_reached" in error_msg
+        or any(pattern in error_msg for pattern in _USAGE_LIMIT_PATTERNS)
+    )
+    has_billing = any(pattern in error_msg for pattern in _BILLING_PATTERNS)
+    has_explicit_rate_limit = any(
+        pattern in error_msg for pattern in _RATE_LIMIT_PATTERNS
+    )
+    has_transient_signal = _has_usage_limit_transient_signal(
+        error_msg,
+        body,
+        response_headers,
+    )
+    return (
+        (has_billing or has_usage_limit)
+        and not has_explicit_rate_limit
+        and not has_transient_signal
+    )
 
 
 def _classify_402(error_msg: str, result_fn) -> ClassifiedError:

--- a/tests/agent/test_credential_pool_routing.py
+++ b/tests/agent/test_credential_pool_routing.py
@@ -534,7 +534,7 @@ class TestFailureAttribution:
 
         from agent.agent_runtime_helpers import recover_with_credential_pool
 
-        recover_with_credential_pool(
+        recovered, _ = recover_with_credential_pool(
             agent,
             status_code=403,
             has_retried_429=False,
@@ -542,8 +542,11 @@ class TestFailureAttribution:
         )
 
         failed = {e.id: e for e in pool.entries()}["cred-1"]
+        assert recovered is True
         assert failed.last_status == "exhausted"
         assert failed.failure_reason == "billing"
+        swapped = agent._swap_credential.call_args[0][0]
+        assert swapped.id == "cred-0"
 
     def test_unclassified_403_records_no_billing_reason(self, tmp_path, monkeypatch):
         """An unclassified 403 stays transient — no billing verdict is invented."""

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -203,6 +203,29 @@ class TestClassifyApiError:
         assert result.reason == FailoverReason.auth
         assert result.should_fallback is True
 
+    def test_403_weekly_usage_limit_rotates_credential(self):
+        e = MockAPIError(
+            "You've reached your weekly (7-day) usage limit.",
+            status_code=403,
+        )
+
+        result = classify_api_error(e, provider="kimi-coding")
+
+        assert result.reason == FailoverReason.billing
+        assert result.retryable is False
+        assert result.should_rotate_credential is True
+        assert result.should_fallback is True
+
+    def test_403_transient_usage_limit_is_not_billing(self):
+        e = MockAPIError(
+            "Usage limit reached; retry after 60 seconds.",
+            status_code=403,
+        )
+
+        result = classify_api_error(e, provider="kimi-coding")
+
+        assert result.reason != FailoverReason.billing
+
 
 
 


### PR DESCRIPTION
## What does this PR do?

Rotates a same-provider credential pool when an account-scoped hard quota arrives as HTTP 403.

Kimi Coding currently returns `HTTP 403: You've reached your weekly (7-day) usage limit.` The 403 classifier treated that as generic auth, skipped credential rotation, and aborted even when a sibling pool entry was available. The 429 path already had the correct semantic quota-wall predicate; this PR shares it with 403 while preserving ordinary forbidden and explicit transient rate-limit responses.

## Related Issue

https://github.com/anombyte93/troubleshooting/issues/84

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [x] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/error_classifier.py`
  - extracts the 429 hard usage/billing quota predicate into a shared helper;
  - applies that predicate to HTTP 403 so a hard account quota requests pool rotation;
  - keeps ordinary `403 Forbidden` on the auth path and keeps retry/reset-shaped quota messages out of billing.
- `tests/agent/test_error_classifier.py`
  - pins the verbatim Kimi weekly quota response;
  - covers a transient 403 usage-limit response.
- `tests/agent/test_credential_pool_routing.py`
  - strengthens the billing-403 recovery test to prove only the failing entry is exhausted and the sibling entry is selected.

## How to Test

1. Run:
   `scripts/run_tests.sh tests/agent/test_error_classifier.py tests/agent/test_credential_pool_routing.py`
2. Confirm 141 tests pass.
3. Run:
   `python scripts/check-windows-footguns.py --diff upstream/main`
4. Confirm no Windows footguns are reported.

TDD evidence: before the classifier change, the verbatim Kimi regression test failed with `FailoverReason.auth`; after the change it passes with `FailoverReason.billing` and `should_rotate_credential=True`.

Full-suite note: `scripts/run_tests.sh` was also attempted in the scratch clone. It completed with 2,743 failures across 457 files plus 2 collection/import failures, largely from unavailable optional async/platform dependencies and live-system guards. Neither changed test file was in the failure set, and both focused files pass in the canonical hermetic runner. This PR does not claim the repository-wide suite is green in that local environment.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux 6.18.22-1-lts

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, internal recovery behaviour is covered by code comments and tests
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure classifier logic; Windows footgun scan clean
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Focused verification:

```text
141 tests passed, 0 failed
✓ No Windows footguns found (3 file(s) scanned).
```

No credential value was read, logged, or used during reproduction or testing. Whether the second live Kimi credential currently has headroom remains UNKNOWN; the regression test proves Hermes attempts the sibling pool entry, not that any particular subscription has remaining quota.
