### PR TITLE
fix(desktop): keep venv interpreter unresolved in Linux .desktop Exec (#92095)

### DIFF
--- a/hermes_cli/linux_desktop_entry.py
+++ b/hermes_cli/linux_desktop_entry.py
@@ -78,12 +78,29 @@ def resolve_exec_command() -> str:
             # third-party import (#90292) — silently, since Terminal=false.
             # sys.executable is the interpreter actually running Hermes (the
             # venv one), so prefix it explicitly.
-            argv = [str(Path(sys.executable).resolve()), str(resolved), "desktop"]
+            argv = [_launcher_python(), str(resolved), "desktop"]
         else:
             argv = [str(resolved), "desktop"]
     else:
-        argv = [str(Path(sys.executable).resolve()), "-m", "hermes_cli.main", "desktop"]
+        argv = [_launcher_python(), "-m", "hermes_cli.main", "desktop"]
     return " ".join(_quote_exec_arg(a) for a in argv)
+
+
+def _launcher_python() -> str:
+    """The interpreter to write into ``Exec=`` — absolute, but NOT resolved.
+
+    ``sys.executable`` is already absolute, so ``.resolve()`` buys nothing,
+    and in a venv whose python is a symlink into a versioned runtime tree
+    (uv-managed CPython, Hermes' own generation-stamped runtime python) it
+    is actively wrong: the resolved target is the BASE interpreter, which
+    has no access to the venv's site-packages (the launch dies on the first
+    third-party import, invisibly under ``Terminal=false``) and is pinned
+    to a version/generation directory that the next update deletes, leaving
+    a dead ``Exec=`` behind (#92095). Writing the venv path keeps the entry
+    stable across updates and preserves PEP 405 venv detection, which keys
+    off the path the interpreter is invoked with.
+    """
+    return os.path.abspath(sys.executable)
 
 
 def _needs_interpreter(bin_path: Path) -> bool:
@@ -103,11 +120,17 @@ def _needs_interpreter(bin_path: Path) -> bool:
         # A shell wrapper (e.g. the installer's bash launcher) execs the venv
         # python itself — leave it alone.
         return False
-    # A python shebang pointing INSIDE the running interpreter's environment
-    # already resolves correctly; anything else (``/usr/bin/env python3``,
-    # a system path) would escape the venv when spawned by the DE.
-    exe_dir = str(Path(sys.executable).resolve().parent)
-    return exe_dir not in shebang
+    # A venv console script's shebang typically names the venv bin dir
+    # (``#!/…/venv/bin/python3``), while ``sys.executable`` may RESOLVE to a
+    # different base-interpreter tree (uv / generation-stamped runtimes).
+    # Match against BOTH the unresolved and the resolved interpreter dirs:
+    # either match means the script is self-sufficient; anything else would
+    # escape the venv when spawned by the DE.
+    candidates = (
+        str(Path(sys.executable).parent).lower(),
+        str(Path(sys.executable).resolve().parent).lower(),
+    )
+    return not any(c in shebang for c in candidates)
 
 
 def _quote_exec_arg(arg: str) -> str:

--- a/tests/hermes_cli/test_linux_desktop_entry.py
+++ b/tests/hermes_cli/test_linux_desktop_entry.py
@@ -107,7 +107,10 @@ def test_exec_prefixes_interpreter_for_env_shebang_python_script(tmp_path, xdg_h
     entry = lde.install_desktop_entry(root)
     exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
 
-    interpreter = str(Path(sys.executable).resolve())
+    # sys.executable verbatim — never symlink-resolved. On uv-created venvs
+    # resolving would write the base interpreter, which cannot import
+    # hermes_cli (#92095), and pins a version dir that updates delete.
+    interpreter = str(Path(sys.executable))
     assert exec_line.split(" ")[0].strip('"') == interpreter
     assert str(hermes_bin) in exec_line
     assert exec_line.endswith("desktop")
@@ -147,6 +150,100 @@ def test_exec_leaves_venv_shebang_scripts_alone(tmp_path, xdg_home, monkeypatch)
     # Console-script with the venv's own interpreter in the shebang: correct
     # as-is, prefixing would only add noise.
     assert exec_line == f"{hermes_bin} desktop"
+
+
+# #92095: on uv-created venvs and Hermes' own generation-stamped runtime
+# python, ``venv/bin/python`` is a SYMLINK into a versioned base-interpreter
+# tree. Resolving it wrote the BASE interpreter into Exec=: no access to the
+# venv's site-packages (dies on the first import, silently under
+# Terminal=false) and pinned to a version dir the next update deletes — so
+# the launcher icon stops launching after every update. Exec must keep the
+# unresolved venv path.
+def test_exec_keeps_symlinked_venv_interpreter_unresolved(tmp_path, xdg_home, monkeypatch):
+    root = _make_project(tmp_path)
+
+    # Mimic the runtime layout: a versioned base-interpreter tree + a venv
+    # whose python is a symlink into it.
+    base_python = tmp_path / "runtime" / "generation-1786171873" / "bin" / "python3.11"
+    base_python.parent.mkdir(parents=True)
+    base_python.write_text("", encoding="utf-8")
+    base_python.chmod(0o755)
+
+    venv_python = tmp_path / "venv" / "bin" / "python"
+    venv_python.parent.mkdir(parents=True)
+    try:
+        venv_python.symlink_to(base_python)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks unavailable on this platform")
+    assert venv_python.resolve() == base_python
+
+    monkeypatch.setattr(lde.sys, "executable", str(venv_python))
+
+    # An /usr/bin/env-shebang launcher forces the interpreter-prefix branch.
+    hermes_bin = tmp_path / "bin" / "hermes"
+    hermes_bin.parent.mkdir()
+    hermes_bin.write_text("#!/usr/bin/env python3\nimport hermes_cli\n", encoding="utf-8")
+    hermes_bin.chmod(0o755)
+    monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: str(hermes_bin))
+    monkeypatch.setattr(lde, "refresh_desktop_databases", lambda _dir: [])
+
+    entry = lde.install_desktop_entry(root)
+    written = _parse(entry.read_text(encoding="utf-8"))["Exec"].split(" ")[0].strip('"')
+
+    assert written == str(venv_python)
+    assert str(base_python) not in entry.read_text(encoding="utf-8")
+
+
+# The module-fallback branch (-m hermes_cli.main) has the same trap: it must
+# write the venv interpreter, not its symlink target.
+def test_exec_module_fallback_keeps_symlinked_venv_interpreter_unresolved(tmp_path, xdg_home, monkeypatch):
+    root = _make_project(tmp_path)
+
+    base_python = tmp_path / "runtime" / "generation-1786171874" / "bin" / "python3.11"
+    base_python.parent.mkdir(parents=True)
+    base_python.write_text("", encoding="utf-8")
+    base_python.chmod(0o755)
+
+    venv_python = tmp_path / "venv" / "bin" / "python"
+    venv_python.parent.mkdir(parents=True)
+    try:
+        venv_python.symlink_to(base_python)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks unavailable on this platform")
+
+    monkeypatch.setattr(lde.sys, "executable", str(venv_python))
+    monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: None)
+    monkeypatch.setattr(lde, "refresh_desktop_databases", lambda _dir: [])
+
+    entry = lde.install_desktop_entry(root)
+    exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
+
+    assert exec_line.split(" ")[0].strip('"') == str(venv_python)
+    assert str(base_python) not in exec_line
+    assert exec_line.endswith("-m hermes_cli.main desktop")
+
+
+# A venv console script whose shebang names the venv (unresolved) is
+# self-sufficient: _needs_interpreter must not demand a prefix just because
+# sys.executable resolves to a different base-interpreter tree.
+def test_venv_shebang_matches_unresolved_executable(tmp_path, monkeypatch):
+    base_python = tmp_path / "runtime" / "generation-1786171875" / "bin" / "python3.11"
+    base_python.parent.mkdir(parents=True)
+    base_python.write_text("", encoding="utf-8")
+
+    venv_python = tmp_path / "venv" / "bin" / "python"
+    venv_python.parent.mkdir(parents=True)
+    try:
+        venv_python.symlink_to(base_python)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks unavailable on this platform")
+
+    script = venv_python.parent / "hermes"
+    script.write_text(f"#!{venv_python.parent / 'python3'}\nimport hermes_cli\n", encoding="utf-8")
+    script.chmod(0o755)
+
+    monkeypatch.setattr(lde.sys, "executable", str(venv_python))
+    assert lde._needs_interpreter(script) is False
 
 
 def test_install_is_idempotent_and_skips_cache_refresh(tmp_path, xdg_home, monkeypatch):


### PR DESCRIPTION
## What & why

`hermes desktop` installs the XDG launcher entry (`~/.local/share/applications/hermes.desktop`) with an `Exec=` built from `Path(sys.executable).resolve()`. In venvs whose `bin/python` is a **symlink into a versioned runtime tree** (uv-managed CPython, and Hermes' own generation-stamped runtime python under `.hermes-runtime/python/generation-<n>/…`), `.resolve()` dereferences the symlink and writes the **base interpreter** into `Exec=`.

Two consequences — both silent (`Terminal=false` hides the traceback):
1. The base interpreter has no access to the venv's site-packages, so the launch dies on the first third-party import (`ModuleNotFoundError: No module named 'yaml'`).
2. The written path is pinned to a generation directory that the **next `hermes update` deletes**, so the launcher icon stops launching after every update.

The terminal works because `~/.local/bin/hermes` is a wrapper that execs the venv python.

**Fix:** keep `sys.executable` **unresolved** (it is already absolute) in both branches of `resolve_exec_command()` — the interpreter-prefix branch and the `-m hermes_cli.main` module fallback — via a small `_launcher_python()` helper, and make `_needs_interpreter()` recognise venv console-script shebangs by matching against **both** the unresolved and the resolved interpreter dirs. The venv symlink path is stable across updates, and PEP 405 venv detection keys off the path the interpreter is invoked with.

## Verification

- **Regression tests: 4 failed on unpatched `main`** (`test_exec_prefixes_interpreter_for_env_shebang_python_script`, `test_exec_keeps_symlinked_venv_interpreter_unresolved`, `test_exec_module_fallback_keeps_symlinked_venv_interpreter_unresolved`, `test_venv_shebang_matches_unresolved_executable`); **18 passed, 2 skipped** (macOS/Windows no-op marks) with this patch. Python 3.11, pytest 9.1.1.
- **Live machine, generation-stamped runtime**: with the venv python symlinked into `.hermes-runtime/python/generation-…/`, the module fallback previously rendered `Exec=…/.hermes-runtime/python/generation-1786171873-183838-d6f08a56/cpython-3.11.15-linux-x86_64-gnu/bin/python3.11 -m hermes_cli.main desktop` (dies after the next update). With this patch: `Exec=…/venv/bin/python -m hermes_cli.main desktop` / `Exec=…/venv/bin/python <launcher> desktop`. No generation path anywhere in the entry.
- Platforms tested: Linux (Debian-based, XDG application launcher). Change is confined to the Linux desktop-entry path; the Windows/macOS no-op guards are untouched.

## Consolidation of existing duplicate PRs

Five open PRs already target this same defect. Per the maintainer triage note ("maintainers should consolidate the launcher approaches"), this PR is that consolidation — please close all of these when it merges:

| PR | Author | Coverage | Notes |
|---|---|---|---|
| #92090 | jackulau | both branches + tests | original fix PR; widest discussion |
| #95190 | thehamsti | both branches + symlink test | `_needs_interpreter` not adjusted |
| #95256 | brian-isadia | interpreter branch only | `-m` fallback still resolves |
| #95810 | uncommonkid | both branches + PATH/home preference | broader Exec-resolution rework |
| #96396 | cosminfuica | both branches + 2 regression tests | closest approach; fix logic credited here |
| **this PR** | i-am-LC | both branches + **module-fallback symlink regression test** + venv-shebang test | supersedes the above; verified on a live generation-stamped install |

Credits: fix approach follows #96396 (cosminfuica); root-cause write-up from #92095 (jackulau) / #92086.

Closes #92095.
