### PR TITLE
fix(desktop): a group member on turn now lights Active Now and its roster row

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/group-membership.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-membership.test.ts
@@ -54,8 +54,9 @@ async function load(): Promise<Modules> {
 let modules: Modules
 
 /** Room records as the store holds them, built from the handful of fields a
- *  case actually cares about. */
-function rooms(map: Record<string, Partial<GroupChat>>): Record<string, GroupChat> {
+ *  case actually cares about. Runtime `turn` included — presence tests key
+ *  off it. */
+function rooms(map: Record<string, Partial<groupChat.GroupChatRoom>>): Record<string, groupChat.GroupChatRoom> {
   return Object.fromEntries(Object.entries(map).map(([name, room]) => [name, { log: [], watermarks: {}, ...room }]))
 }
 
@@ -368,5 +369,50 @@ describe('legacy display-name descriptors', () => {
     modules.chat.$groupChats.set(rooms({ room: { log: [], members: [descriptor] } }))
 
     expect(modules.membership.groupChatMemberBots('room', [TAIYI], {})[0]).toBe(TAIYI)
+  })
+})
+
+// Presence: a member mid group turn lights its roster row (and, through the
+// member keys, the group row). The room's runtime `turn` is the same identity
+// the thread's thinking line uses, so the roster cannot disagree with the room.
+describe('activeGroupMemberKeys', () => {
+  const RESEARCHER: RosterRow = { connectionId: 'local', name: 'researcher', remoteSource: false }
+  const SCRIBE: RosterRow = { connectionId: 'local', name: 'scribe', remoteSource: false }
+
+  it('maps the room turn to the live source-qualified roster key', () => {
+    modules.chat.$groupChats.set(rooms({ room: { log: [], running: true, turn: 'researcher' } }))
+    modules.data.$botMeta.set({ researcher: { groups: ['room'] } })
+
+    const keys = modules.membership.activeGroupMemberKeys(
+      modules.chat.$groupChats.get(),
+      [RESEARCHER, SCRIBE],
+      { researcher: { groups: ['room'] } }
+    )
+
+    expect(keys).toEqual(['local::researcher'])
+  })
+
+  it('seats a remote member through its stored descriptor and qualifies the key', () => {
+    const dixie: RosterRow = { connectionId: 'mini', name: 'dixie', remoteSource: true }
+
+    modules.chat.$groupChats.set(
+      rooms({ room: { log: [], members: [{ connectionId: 'mini', name: 'dixie' }], running: true, turn: 'dixie' } })
+    )
+
+    expect(modules.membership.activeGroupMemberKeys(modules.chat.$groupChats.get(), [dixie], {})).toEqual(['mini::dixie'])
+  })
+
+  it('stays empty when the room is idle, nobody is on turn, or the member is unseated', () => {
+    modules.chat.$groupChats.set(rooms({ room: { log: [], running: true } }))
+
+    expect(modules.membership.activeGroupMemberKeys(modules.chat.$groupChats.get(), [RESEARCHER], {})).toEqual([])
+
+    modules.chat.$groupChats.set(rooms({ room: { log: [], running: true, turn: 'ghost' } }))
+
+    expect(modules.membership.activeGroupMemberKeys(modules.chat.$groupChats.get(), [RESEARCHER], {})).toEqual([])
+
+    modules.chat.$groupChats.set(rooms({ room: { log: [], running: false, turn: 'researcher' } }))
+
+    expect(modules.membership.activeGroupMemberKeys(modules.chat.$groupChats.get(), [RESEARCHER], {})).toEqual([])
   })
 })

--- a/apps/desktop/src/plugins/hermes-bots/group-membership.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-membership.ts
@@ -6,6 +6,7 @@
 
 import { $botMeta, botFriendlyNames, botMetaKey, botRosterKey } from './data'
 import { $groupChats, groupChatRoomKey } from './group-chat'
+import type { GroupChatRoom } from './group-chat'
 import { botConnectionRoute, botRosterMeta, resolveBotConnectionRoute } from './routing'
 import type { BotMeta, GroupChat, GroupMember, RosterRow } from './types'
 
@@ -240,6 +241,25 @@ export function groupChatMemberBots(
   }
 
   return [...local, ...remote]
+}
+
+/** Source-qualified roster keys for members whose group turn is currently
+ *  running. The room's runtime `turn` is the same identity the thread's
+ *  "is thinking" line uses, so the roster and the room cannot drift apart. */
+export function activeGroupMemberKeys(
+  rooms: Record<string, GroupChatRoom>,
+  roster: RosterRow[],
+  metaByName: Record<string, BotMeta>
+): string[] {
+  return Object.entries(rooms || {}).flatMap(([group, room]) => {
+    if (!room?.running || !room.turn) {
+      return []
+    }
+
+    const member = groupChatMemberBots(group, roster, metaByName).find(bot => bot.name === room.turn)
+
+    return member ? [botRosterKey(member)] : []
+  })
 }
 
 /** A stored member descriptor, resolved against the live roster when its

--- a/apps/desktop/src/plugins/hermes-bots/roster-pane.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/roster-pane.tsx
@@ -58,7 +58,7 @@ import {
 import { EditProfileDialog } from './edit-profile-dialog'
 import { $groupChats, $groupChatWorkspace, $groupNeedsYou } from './group-chat'
 import { disbandGroupChat, GroupChatWorkspace, openGroupChat } from './group-chat-view'
-import { groupChatMemberBots, groupChatNames, groupLastActivity } from './group-membership'
+import { activeGroupMemberKeys, groupChatMemberBots, groupChatNames, groupLastActivity } from './group-membership'
 import { $groupMainTabsRev, shouldRenderGroupChatInPane } from './group-panes'
 import { $showHiddenBots, isBotHidden, isBotPinned } from './hidden-bots'
 import { useBots } from './i18n'
@@ -343,7 +343,10 @@ export function BotsPane() {
   // and the persisted connection registry hydrate. Keep that transition in a
   // neutral loading state instead of flashing the first-run "No bots" copy.
   const initialRosterLoading = !data && !error && roster.length === 0
-  const activeRosterKeys = new Set(activeBots(roster, activeProfile, gatewayState).map(botRosterKey))
+  const groupActiveKeys = activeGroupMemberKeys(groupRooms, roster, allMeta)
+  const activeRosterKeys = new Set(
+    activeBots(roster, activeProfile, gatewayState, Date.now(), groupActiveKeys).map(botRosterKey)
+  )
   const gatewayOptions = rosterGatewayOptions(sourceSnapshot, roster)
   const selectedGateway = gatewayOptions.find(option => option.connectionId === gatewayFilter)
   const gatewayFilterExists = gatewayFilter === 'all' || Boolean(selectedGateway)

--- a/apps/desktop/src/plugins/hermes-bots/row-helpers.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/row-helpers.test.ts
@@ -155,6 +155,14 @@ describe('which bots are working right now', () => {
     expect(workerActiveAt(finished, NOW)).toBe(false)
     expect(ACTIVE_WINDOW_S).toBeGreaterThan(0)
   })
+
+  it('includes a member whose group turn is running, keyed by source', () => {
+    const coder = row({ connectionId: 'local', name: 'coder' })
+
+    expect(activeBots([coder], 'other', 'open', NOW, ['local::coder']).map(bot => bot.name)).toContain('coder')
+    // Another connection's same-named member must not light this row.
+    expect(activeBots([coder], 'other', 'open', NOW, ['remote::coder'])).toEqual([])
+  })
 })
 
 describe('the roster activity filter', () => {

--- a/apps/desktop/src/plugins/hermes-bots/row-helpers.ts
+++ b/apps/desktop/src/plugins/hermes-bots/row-helpers.ts
@@ -86,21 +86,25 @@ export function workerActiveAt(bot: null | RosterRow | undefined, now = Date.now
 
 /** Bots that are working right now: the profile the gateway is running a
  *  turn for (busy), any bot whose last message landed inside the liveness
- *  window, plus any bot with a live kanban/tool worker. Pure — output
- *  follows the input roster's order, so presence never reorders or hides
- *  the normal list. */
+ *  window, any live kanban/tool worker, plus members on a group turn (keys
+ *  from `activeGroupMemberKeys`). Pure — output follows the input roster's
+ *  order, so presence never reorders or hides the normal list. */
 export function activeBots(
   roster: null | RosterRow[] | undefined,
   activeProfile: string,
   gatewayState: string,
-  now = Date.now()
+  now = Date.now(),
+  groupKeys: string[] = []
 ): RosterRow[] {
+  const groupTurnKeys = new Set(groupKeys)
+
   return (roster || []).filter(bot => {
     const busyTurn = !bot.remoteSource && bot.name === activeProfile && gatewayState === 'busy'
     const last = botActivitySession(bot)?.last_active || 0
     const inWindow = Boolean(last && now / 1000 - last < ACTIVE_WINDOW_S)
+    const groupTurn = groupTurnKeys.has(botRosterKey(bot))
 
-    return busyTurn || inWindow || workerActiveAt(bot, now)
+    return busyTurn || inWindow || workerActiveAt(bot, now) || groupTurn
   })
 }
 


### PR DESCRIPTION
## Summary

A group chat member turn currently drives the room's "is thinking…" line only — the roster row and the activity filters stay dark for the member actually doing the work. Root cause: the presence pipeline (`activeBots`) only considers (a) the gateway-busy selected profile, (b) bots whose last message landed inside the liveness window, and (c) live kanban/tool workers. Group-room runtime state (`room.running` / `room.turn`) is never consulted, so a 3-member group can show "research is thinking…" in the thread while the roster reports nobody active.

This extends the same signal class merged in #90359 (a running kanban/tool worker lights its bot's roster row) to group-chat member turns: while a member is on turn, its source-qualified roster key is folded into the single `activeRosterKeys` set that feeds bot rows, group rows, and the activity filter — so all surfaces agree by construction instead of by coincidence.

## Changes

- `apps/desktop/src/plugins/hermes-bots/group-membership.ts` (+20): new pure `activeGroupMemberKeys(rooms, roster, metaByName)` — maps each running room's `turn` to the member's source-qualified `botRosterKey`. The room's `turn` is the same identity the thread's thinking line uses, so roster and room cannot drift apart.
- `apps/desktop/src/plugins/hermes-bots/row-helpers.ts` (+5/−3): `activeBots()` gains an optional `groupKeys` argument folded into the same filter (pure; output order unchanged).
- `apps/desktop/src/plugins/hermes-bots/roster-pane.tsx` (+4/−1): computes `groupActiveKeys` once and folds it into the shared `activeRosterKeys` set — a member-on-turn lights its own row AND its group's row (the group row already ORs member keys).
- Tests: `row-helpers.test.ts` (+8) pins group-turn inclusion and cross-connection key isolation; `group-membership.test.ts` (+45) pins turn→key mapping, remote-descriptor seating, and the idle/no-turn/unseated cases.

## Port note

Re-targeted after #96726 split the Bot Mode plugin into TSX/TS modules — the original diff targeted `plugin.js`, which no longer exists on `main`. #96726 also folded the Active Now strip into row presence; this PR now feeds group-turn keys into the shared `activeRosterKeys` set, preserving the original PR's guarantee (strip/rows/filters could never disagree) in the new architecture.

## Validation

| Check | Result |
|---|---|
| `vitest run` row-helpers + group-membership suites | 37/37 pass |
| Full hermes-bots plugin suite (`vitest run --project ui src/plugins/hermes-bots`) | 57 files / 560 tests pass |
| Desktop typecheck (`tsc -p . --noEmit`) | clean |
| E2E (packaged Windows desktop) | pending — behavior verified live in the pre-port PR; ported wiring feeds the same shared `activeRosterKeys` set |

Related: #87886 (Bot Mode bundled as the default-on desktop plugin — the group rooms this PR touches live there), #90359 (same signal class for workers), #90326 (roster activity signals canonical Bot Chat).

Non-overlap note: open #96558 disambiguates member labels *inside the group Activity feed*; this PR instead extends *presence* to group turns. Different surfaces; both compose.

Scope note: presence plumbing only. No gateway protocol, session persistence, group routing, or room-level event semantics changed.
