### PR TITLE
fix(compression): persist stall-interrupted backoff on pre-commit cancel (#96775)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -2871,9 +2871,16 @@ class ContextCompressor(ContextEngine):
         cooldown_seconds: float,
         error: Optional[str],
     ) -> None:
-        cooldown_until = time.time() + cooldown_seconds
-        self._summary_failure_cooldown_until = time.monotonic() + cooldown_seconds
+        now_mono = time.monotonic()
+        new_mono = now_mono + float(cooldown_seconds)
+        # Never shorten a longer live deadline (#96775). A later stall or
+        # timeout records the latest error text but keeps the later of the
+        # two clocks.
+        if new_mono > self._summary_failure_cooldown_until:
+            self._summary_failure_cooldown_until = new_mono
         self._last_summary_error = error
+        remaining = max(0.0, self._summary_failure_cooldown_until - time.monotonic())
+        cooldown_until = time.time() + remaining
 
         session_db = getattr(self, "_session_db", None)
         session_id = getattr(self, "_session_id", "")
@@ -2895,12 +2902,11 @@ class ContextCompressor(ContextEngine):
             logger.debug("compression failure cooldown persist failed (non-sqlite): %s", exc)
 
     def record_timeout_failure(self, error: str) -> None:
-        """Record a consecutive timeout failure using the shared cooldown ladder.
+        """Record a consecutive timeout/stall failure using the shared ladder.
 
-        Used by both the summary-LLM exception handler (inline at line ~3714)
-        and the host-level ``compress_context`` timeout wrapper in
-        ``run_compress_context_with_progress_timeout``. Avoids re-implementing
-        the ladder at each call site (#62452).
+        Used by the summary-LLM exception handler, the host-level
+        ``compress_context`` timeout wrapper, and stall-interrupted
+        pre-commit cancellation (#62452, #96775).
         """
         _TIMEOUT_COOLDOWN_LADDER = (60, 300, 900)
         self._consecutive_timeout_failures = (

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -722,6 +722,12 @@ class CompressionCommitFence:
 DEFAULT_CONTEXT_TIMEOUT_SECONDS = 120.0
 DEFAULT_CONTEXT_TOTAL_CEILING_SECONDS = 600.0
 
+# Distinct from ``explicit_interrupt``: a /stop that arrived after the summary
+# stream had already crossed the no-progress stall window (#96775). Ordinary
+# early /stop stays cooldown-neutral; this class arms the durable backoff so
+# the next automatic turn does not re-enter the same stalled strategy.
+STALL_INTERRUPTED_FAILURE_CLASS = "stall_interrupted"
+
 # Shared daemon pool for sync compress_context timeout wraps — analogous to
 # asyncio's default executor used by gateway session hygiene's
 # ``loop.run_in_executor(None, ...)``, but daemon so a fence-cancelled hung
@@ -841,6 +847,101 @@ def resolve_context_compression_timeouts(
     if idle > 0:
         ceiling = max(ceiling, idle)
     return idle, ceiling
+
+
+def compression_attempt_stalled(
+    *,
+    commit_fence: Optional[CompressionCommitFence],
+    started_at: float,
+    idle_timeout_seconds: Optional[float] = None,
+) -> bool:
+    """Return whether a pre-commit cancel landed after the stall window.
+
+    An ordinary early ``/stop`` must stay cooldown-neutral. When the fence
+    (or, without a fence, the attempt clock) has already sat idle for the
+    configured compression inactivity budget, the interrupt is a stalled
+    attempt — the same condition the host timeout uses — and the next
+    automatic turn must not blindly retry that strategy (#96775).
+    """
+    idle = idle_timeout_seconds
+    if idle is None:
+        idle, _ceiling = resolve_context_compression_timeouts()
+    try:
+        idle = float(idle)
+    except (TypeError, ValueError):
+        return False
+    if idle <= 0:
+        return False
+    if commit_fence is not None:
+        try:
+            return float(commit_fence.seconds_since_progress()) >= idle
+        except Exception:
+            return False
+    try:
+        return (time.monotonic() - float(started_at)) >= idle
+    except (TypeError, ValueError):
+        return False
+
+
+def _stall_source_fingerprint(
+    agent: Any,
+    messages: Any,
+    approx_tokens: Optional[int],
+) -> str:
+    """Identity of the stalled source context + summary strategy."""
+    compressor = getattr(agent, "context_compressor", None)
+    model = (
+        getattr(compressor, "summary_model", None)
+        or getattr(agent, "model", None)
+        or ""
+    )
+    n_messages = len(messages) if isinstance(messages, list) else 0
+    try:
+        tokens = int(approx_tokens or 0)
+    except (TypeError, ValueError):
+        tokens = 0
+    return f"msgs={n_messages}:tokens={tokens}:model={model}"
+
+
+def _record_stall_interrupted_backoff(
+    agent: Any,
+    *,
+    commit_fence: Optional[CompressionCommitFence],
+    started_at: float,
+    messages: Any,
+    approx_tokens: Optional[int],
+) -> bool:
+    """Persist a stall-interrupted cooldown after snapshot restore.
+
+    Must run *after* ``_restore_compressor_attempt_state`` so rollback cannot
+    wipe the new row. Returns True when the stall backoff was recorded.
+    """
+    if not compression_attempt_stalled(
+        commit_fence=commit_fence, started_at=started_at
+    ):
+        return False
+    compressor = getattr(agent, "context_compressor", None)
+    record = getattr(compressor, "record_timeout_failure", None)
+    if not callable(record):
+        return False
+    error = (
+        f"{STALL_INTERRUPTED_FAILURE_CLASS}:"
+        f"{_stall_source_fingerprint(agent, messages, approx_tokens)}"
+    )
+    try:
+        record(error)
+    except Exception:
+        logger.debug(
+            "stall-interrupted compression cooldown persist failed",
+            exc_info=True,
+        )
+        return False
+    logger.info(
+        "Recorded stall-interrupted compression backoff (session=%s, %s)",
+        getattr(agent, "session_id", None) or "none",
+        error,
+    )
+    return True
 
 
 def resolve_compression_fallback_route() -> Optional[dict]:
@@ -3448,6 +3549,15 @@ def compress_context(
             and messages != messages_before_compression
         ):
             messages[:] = copy.deepcopy(messages_before_compression)
+        # Record after restore so rollback cannot wipe a stall backoff, and
+        # while the lease is still held so the next turn cannot race it.
+        _stall_backoff = _record_stall_interrupted_backoff(
+            agent,
+            commit_fence=commit_fence,
+            started_at=_attempt_started_at,
+            messages=messages,
+            approx_tokens=approx_tokens,
+        )
         if _activity_heartbeat is not None:
             _activity_heartbeat.stop("context compression cancelled")
             _activity_heartbeat = None
@@ -3457,7 +3567,11 @@ def compress_context(
             started_at=_attempt_started_at,
             commit_status="aborted",
             split_status="aborted",
-            failure_class="explicit_interrupt",
+            failure_class=(
+                STALL_INTERRUPTED_FAILURE_CLASS
+                if _stall_backoff
+                else "explicit_interrupt"
+            ),
         )
         _existing_sp = getattr(agent, "_cached_system_prompt", None)
         if not _existing_sp:
@@ -3601,6 +3715,13 @@ def compress_context(
                     agent.session_id or "none",
                 )
                 agent._last_compaction_in_place = False
+                _stall_backoff = _record_stall_interrupted_backoff(
+                    agent,
+                    commit_fence=commit_fence,
+                    started_at=_attempt_started_at,
+                    messages=messages,
+                    approx_tokens=approx_tokens,
+                )
                 _existing_sp = getattr(agent, "_cached_system_prompt", None)
                 if not _existing_sp:
                     _existing_sp = agent._build_system_prompt(system_message)
@@ -3609,7 +3730,11 @@ def compress_context(
                     started_at=_attempt_started_at,
                     commit_status="aborted",
                     split_status="aborted",
-                    failure_class="commit_fence_cancelled",
+                    failure_class=(
+                        STALL_INTERRUPTED_FAILURE_CLASS
+                        if _stall_backoff
+                        else "commit_fence_cancelled"
+                    ),
                 )
                 _release_lock()
                 return messages, _existing_sp

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -7438,10 +7438,16 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             return
 
         def _do(conn):
+            # Merge-max with any longer live deadline so a later shorter
+            # write cannot reopen the thrash window (#96775). The error
+            # column always takes the latest diagnostic.
             conn.execute(
-                "UPDATE sessions SET compression_failure_cooldown_until = ?, "
+                "UPDATE sessions SET compression_failure_cooldown_until = CASE "
+                "WHEN compression_failure_cooldown_until IS NOT NULL "
+                " AND compression_failure_cooldown_until > ? "
+                "THEN compression_failure_cooldown_until ELSE ? END, "
                 "compression_failure_error = ? WHERE id = ?",
-                (cooldown_until, error, session_id),
+                (cooldown_until, cooldown_until, error, session_id),
             )
 
         try:

--- a/tests/agent/test_compression_stall_interrupt_96775.py
+++ b/tests/agent/test_compression_stall_interrupt_96775.py
@@ -1,0 +1,359 @@
+"""Stall-interrupted preflight compression must persist a durable backoff.
+
+#96775: an explicit /stop after the summary stream has already crossed the
+no-progress stall window restores the original transcript but must record a
+stall-specific cooldown so the next automatic turn does not re-enter the
+same strategy. An ordinary early /stop stays cooldown-neutral.
+
+Native Codex app-server compaction is a sibling path (#75364) and is not
+covered here. Stall classification reads the commit fence's progress clock,
+not Chat Completions vs Responses frame shapes.
+"""
+
+from __future__ import annotations
+
+import copy
+import os
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+from agent.auxiliary_client import AuxiliaryExplicitCancellation
+from agent.conversation_compression import (
+    STALL_INTERRUPTED_FAILURE_CLASS,
+    CompressionCommitFence,
+    compress_context,
+    compression_attempt_stalled,
+)
+from hermes_state import SessionDB
+
+
+def _build_agent(tmp_path: Path, session_id: str = "STALL_INTERRUPT_96775"):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session(session_id, source="cli")
+    with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            session_db=db,
+            session_id=session_id,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent._compression_feasibility_checked = True
+    agent.compression_in_place = True
+    agent._cached_system_prompt = "sys"
+    agent.context_compressor.threshold_tokens = 1_000
+    return db, agent
+
+
+def _messages():
+    return [{"role": "user", "content": f"m{i}"} for i in range(20)]
+
+
+def _age_fence(fence: CompressionCommitFence, idle_seconds: float) -> None:
+    fence._last_progress = time.monotonic() - float(idle_seconds)
+
+
+class TestStallClassificationIsFenceIdle:
+    def test_fresh_fence_is_not_stalled(self):
+        fence = CompressionCommitFence()
+        assert compression_attempt_stalled(
+            commit_fence=fence,
+            started_at=time.monotonic(),
+            idle_timeout_seconds=1.0,
+        ) is False
+
+    def test_idle_fence_is_stalled(self):
+        fence = CompressionCommitFence()
+        _age_fence(fence, 2.0)
+        assert compression_attempt_stalled(
+            commit_fence=fence,
+            started_at=time.monotonic(),
+            idle_timeout_seconds=1.0,
+        ) is True
+
+    def test_recent_progress_is_not_stalled(self):
+        fence = CompressionCommitFence()
+        _age_fence(fence, 2.0)
+        fence.touch_progress()
+        assert compression_attempt_stalled(
+            commit_fence=fence,
+            started_at=time.monotonic() - 5.0,
+            idle_timeout_seconds=1.0,
+        ) is False
+
+    def test_chat_and_responses_share_the_fence_clock(self):
+        """Transport-agnostic: both APIs tick the same fence or they don't."""
+        chat_fence = CompressionCommitFence()
+        responses_fence = CompressionCommitFence()
+        _age_fence(chat_fence, 2.0)
+        responses_fence.touch_progress()
+        assert compression_attempt_stalled(
+            commit_fence=chat_fence,
+            started_at=time.monotonic(),
+            idle_timeout_seconds=1.0,
+        ) is True
+        assert compression_attempt_stalled(
+            commit_fence=responses_fence,
+            started_at=time.monotonic(),
+            idle_timeout_seconds=1.0,
+        ) is False
+
+
+class TestEarlyStopStaysNeutral:
+    def test_explicit_interrupt_before_stall_does_not_arm_cooldown(
+        self, tmp_path: Path
+    ):
+        db, agent = _build_agent(tmp_path, "EARLY_STOP_96775")
+        original = _messages()
+        live = copy.deepcopy(original)
+        fence = CompressionCommitFence()
+
+        def _early_stop(messages, **_kwargs):
+            messages[0]["content"] = "must be rolled back"
+            raise AuxiliaryExplicitCancellation()
+
+        agent.context_compressor.compress = _early_stop
+
+        compressed, _prompt = compress_context(
+            agent,
+            live,
+            "sys",
+            approx_tokens=50_000,
+            commit_fence=fence,
+        )
+
+        assert compressed == original
+        assert live == original
+        assert db.get_compression_lock_holder("EARLY_STOP_96775") is None
+        assert db.get_compression_failure_cooldown("EARLY_STOP_96775") is None
+        assert agent.context_compressor.should_compress(50_000) is True
+        db.append_message("EARLY_STOP_96775", "assistant", "still writable")
+
+
+class TestStallInterruptedBackoff:
+    def test_aux_explicit_cancel_after_stall_persists_backoff(
+        self, tmp_path: Path, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "agent.conversation_compression.resolve_context_compression_timeouts",
+            lambda compression_cfg=None: (1.0, 10.0),
+        )
+        db, agent = _build_agent(tmp_path, "STALL_AUX_CANCEL")
+        original = _messages()
+        live = copy.deepcopy(original)
+        fence = CompressionCommitFence()
+        compress_calls = {"n": 0}
+
+        def _stalled_then_stop(messages, **_kwargs):
+            compress_calls["n"] += 1
+            _age_fence(fence, 2.0)
+            messages[0]["content"] = "must be rolled back"
+            raise AuxiliaryExplicitCancellation()
+
+        agent.context_compressor.compress = _stalled_then_stop
+
+        compressed, _prompt = compress_context(
+            agent,
+            live,
+            "sys",
+            approx_tokens=50_000,
+            commit_fence=fence,
+        )
+
+        assert compressed == original
+        assert live == original
+        assert db.get_compression_lock_holder("STALL_AUX_CANCEL") is None
+        state = db.get_compression_failure_cooldown("STALL_AUX_CANCEL")
+        assert state is not None
+        assert str(state["error"]).startswith(STALL_INTERRUPTED_FAILURE_CLASS)
+        assert "msgs=20" in str(state["error"])
+        assert agent.context_compressor.should_compress(50_000) is False
+
+        compress_calls["n"] = 0
+        again, _ = compress_context(
+            agent,
+            copy.deepcopy(original),
+            "sys",
+            approx_tokens=50_000,
+            commit_fence=CompressionCommitFence(),
+        )
+        assert again == original
+        assert compress_calls["n"] == 0
+
+        db.append_message("STALL_AUX_CANCEL", "assistant", "still writable")
+
+    def test_commit_fence_cancel_after_stall_persists_backoff(
+        self, tmp_path: Path, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "agent.conversation_compression.resolve_context_compression_timeouts",
+            lambda compression_cfg=None: (1.0, 10.0),
+        )
+        db, agent = _build_agent(tmp_path, "STALL_FENCE_CANCEL")
+        original = _messages()
+        live = copy.deepcopy(original)
+        fence = CompressionCommitFence()
+
+        def _summary_then_cancel(messages, **_kwargs):
+            _age_fence(fence, 2.0)
+            fence.cancel_before_commit()
+            return [
+                {"role": "user", "content": "[CONTEXT COMPACTION] summary"},
+                {"role": "assistant", "content": "tail"},
+            ]
+
+        agent.context_compressor.compress = _summary_then_cancel
+
+        compressed, _prompt = compress_context(
+            agent,
+            live,
+            "sys",
+            approx_tokens=50_000,
+            commit_fence=fence,
+        )
+
+        assert compressed == original
+        assert live == original
+        state = db.get_compression_failure_cooldown("STALL_FENCE_CANCEL")
+        assert state is not None
+        assert str(state["error"]).startswith(STALL_INTERRUPTED_FAILURE_CLASS)
+        assert agent.context_compressor.should_compress(50_000) is False
+        db.append_message("STALL_FENCE_CANCEL", "user", "next turn")
+
+    def test_commit_fence_cancel_with_fresh_progress_stays_neutral(
+        self, tmp_path: Path, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "agent.conversation_compression.resolve_context_compression_timeouts",
+            lambda compression_cfg=None: (1.0, 10.0),
+        )
+        db, agent = _build_agent(tmp_path, "FRESH_FENCE_CANCEL")
+        original = _messages()
+        live = copy.deepcopy(original)
+        fence = CompressionCommitFence()
+
+        def _healthy_then_cancel(messages, **_kwargs):
+            fence.touch_progress()
+            fence.cancel_before_commit()
+            return [
+                {"role": "user", "content": "[CONTEXT COMPACTION] summary"},
+                {"role": "assistant", "content": "tail"},
+            ]
+
+        agent.context_compressor.compress = _healthy_then_cancel
+
+        compressed, _prompt = compress_context(
+            agent,
+            live,
+            "sys",
+            approx_tokens=50_000,
+            commit_fence=fence,
+        )
+
+        assert compressed == original
+        assert db.get_compression_failure_cooldown("FRESH_FENCE_CANCEL") is None
+        assert agent.context_compressor.should_compress(50_000) is True
+
+    def test_manual_force_bypasses_stall_backoff(
+        self, tmp_path: Path, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "agent.conversation_compression.resolve_context_compression_timeouts",
+            lambda compression_cfg=None: (1.0, 10.0),
+        )
+        db, agent = _build_agent(tmp_path, "FORCE_BYPASS_STALL")
+        original = _messages()
+        fence = CompressionCommitFence()
+
+        def _stalled_then_stop(messages, **_kwargs):
+            _age_fence(fence, 2.0)
+            raise AuxiliaryExplicitCancellation()
+
+        agent.context_compressor.compress = _stalled_then_stop
+        compress_context(
+            agent,
+            copy.deepcopy(original),
+            "sys",
+            approx_tokens=50_000,
+            commit_fence=fence,
+        )
+        assert agent.context_compressor.should_compress(50_000) is False
+
+        forced_calls = {"n": 0}
+
+        def _forced(messages, **kwargs):
+            forced_calls["n"] += 1
+            assert kwargs.get("force") is True
+            return messages
+
+        agent.context_compressor.compress = _forced
+        compress_context(
+            agent,
+            copy.deepcopy(original),
+            "sys",
+            approx_tokens=50_000,
+            force=True,
+            commit_fence=CompressionCommitFence(),
+        )
+        assert forced_calls["n"] == 1
+
+    def test_stall_backoff_merges_with_longer_active_deadline(
+        self, tmp_path: Path, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "agent.conversation_compression.resolve_context_compression_timeouts",
+            lambda compression_cfg=None: (1.0, 10.0),
+        )
+        db, agent = _build_agent(tmp_path, "MERGE_MAX_STALL")
+        agent.context_compressor._record_compression_failure_cooldown(
+            900.0, "prior timeout"
+        )
+        before = db.get_compression_failure_cooldown("MERGE_MAX_STALL")
+        assert before is not None
+        prior_until = float(before["cooldown_until"])
+
+        fence = CompressionCommitFence()
+
+        def _stalled_then_stop(messages, **_kwargs):
+            _age_fence(fence, 2.0)
+            raise AuxiliaryExplicitCancellation()
+
+        agent.context_compressor.compress = _stalled_then_stop
+        # force=True so the pre-existing cooldown does not skip the attempt
+        # before the stall-interrupt restore/merge path can run.
+        compress_context(
+            agent,
+            _messages(),
+            "sys",
+            approx_tokens=50_000,
+            force=True,
+            commit_fence=fence,
+        )
+
+        after = db.get_compression_failure_cooldown("MERGE_MAX_STALL")
+        assert after is not None
+        assert float(after["cooldown_until"]) >= prior_until - 1.0
+        assert str(after["error"]).startswith(STALL_INTERRUPTED_FAILURE_CLASS)
+
+
+def test_session_db_cooldown_write_does_not_shorten_longer_deadline(
+    tmp_path: Path,
+):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("merge-max", source="cli")
+    later = time.time() + 900.0
+    sooner = time.time() + 60.0
+    db.record_compression_failure_cooldown("merge-max", later, "timeout")
+    db.record_compression_failure_cooldown(
+        "merge-max", sooner, STALL_INTERRUPTED_FAILURE_CLASS
+    )
+    row = db.get_compression_failure_cooldown("merge-max")
+    assert row is not None
+    assert float(row["cooldown_until"]) >= later - 1.0
+    assert row["error"] == STALL_INTERRUPTED_FAILURE_CLASS


### PR DESCRIPTION
## Summary
- When preflight compression is already stalled and the user interrupts before commit, Hermes now records a stall-specific durable cooldown instead of leaving the same oversized context eligible for the identical summary strategy on the next automatic turn.
- An ordinary early `/stop` stays cooldown-neutral. Manual `/compress` (`force=True`) still bypasses the automatic brake, the original transcript remains authoritative, and a longer live cooldown deadline is never shortened.

Fixes #96775

## Test plan
- [x] `scripts/run_tests.sh tests/agent/test_compression_stall_interrupt_96775.py -q`
- [x] `scripts/run_tests.sh tests/agent/test_compression_interrupt_protection.py tests/agent/test_compression_concurrent_fork.py tests/agent/test_compression_rotation_state.py tests/agent/test_context_compressor.py tests/agent/test_hygiene_timeout_cooldown_isolation.py tests/agent/test_compression_stall_fallback_78981.py tests/agent/test_compress_context_progress_timeout.py -q`
- [ ] Confirm a stalled summary + `/stop` writes `failure_class=stall_interrupted` and the next ordinary turn skips automatic compression with the existing cooldown warning
- [ ] Confirm an early `/stop` before the idle window does not arm a cooldown and the session stays writable