### PR TITLE
fix(tools): stop reporting a failed PTY reap as a clean exit

### DIFF
--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -415,6 +415,104 @@ def test_pty_reader_loop_reassembles_multibyte_char_split_across_chunks(registry
 
 
 # =========================================================================
+# PTY reap accounting (issue #96362)
+# =========================================================================
+
+
+class _ReapPty:
+    """Minimal PTY double: one chunk, then EOF, with a scriptable wait()."""
+
+    def __init__(self, exitstatus=0, wait_error=None):
+        self.exitstatus = exitstatus
+        self._wait_error = wait_error
+        self._chunks = [b"done\n"]
+
+    def isalive(self):
+        return bool(self._chunks)
+
+    def read(self, _n):
+        if self._chunks:
+            return self._chunks.pop(0)
+        raise EOFError
+
+    def wait(self):
+        if self._wait_error is not None:
+            raise self._wait_error
+        return self.exitstatus
+
+
+def _run_pty_loop(registry, monkeypatch, pty, sid):
+    session = _make_session(sid=sid)
+    session._pty = pty
+    monkeypatch.setattr(registry, "_check_watch_patterns", lambda _s, _c: None)
+    monkeypatch.setattr(registry, "_emit_output", lambda _s, _c: None)
+    monkeypatch.setattr(registry, "_move_to_finished", lambda _s: None)
+    registry._pty_reader_loop(session)
+    return session
+
+
+def test_pty_reader_loop_reports_a_real_exit_status(registry, monkeypatch):
+    session = _run_pty_loop(registry, monkeypatch, _ReapPty(exitstatus=3), "proc_pty_ok")
+
+    assert session.exited is True
+    assert session.exit_code == 3
+    assert session.completion_reason == "exited"
+
+
+def test_pty_reader_loop_does_not_call_a_failed_reap_a_clean_exit(registry, monkeypatch):
+    """A failed wait() left exit_code None while claiming completion_reason
+    'exited', so the agent saw a finished command with a null exit code."""
+    pty = _ReapPty(exitstatus=None, wait_error=OSError("no child processes"))
+    session = _run_pty_loop(registry, monkeypatch, pty, "proc_pty_wait_fail")
+
+    assert session.exited is True
+    assert session.exit_code == -1
+    assert session.completion_reason == "lost"
+    assert session.termination_source == "pty_wait_failed"
+
+
+def test_pty_reader_loop_never_reports_a_null_exit_code(registry, monkeypatch):
+    """wait() succeeded but the backend exposes no status (pywinpty)."""
+    session = _run_pty_loop(registry, monkeypatch, _ReapPty(exitstatus=None), "proc_pty_no_status")
+
+    assert session.exit_code == -1
+    assert session.completion_reason == "exited"
+
+
+def test_pty_reader_loop_keeps_an_explicit_kill_labelled_killed(registry, monkeypatch):
+    session = _make_session(sid="proc_pty_killed")
+    session._pty = _ReapPty(exitstatus=None, wait_error=OSError("no child processes"))
+    session.completion_reason = "killed"
+    session.exit_code = -9
+    monkeypatch.setattr(registry, "_check_watch_patterns", lambda _s, _c: None)
+    monkeypatch.setattr(registry, "_emit_output", lambda _s, _c: None)
+    monkeypatch.setattr(registry, "_move_to_finished", lambda _s: None)
+
+    registry._pty_reader_loop(session)
+
+    assert session.completion_reason == "killed"
+    assert session.exit_code == -9
+
+
+def test_lost_pty_completion_names_the_pty_not_a_vanished_backend():
+    from tools.process_registry import format_process_notification
+
+    text = format_process_notification(
+        {
+            "type": "completion",
+            "session_id": "proc_pty_wait_fail",
+            "exit_code": -1,
+            "completion_reason": "lost",
+            "termination_source": "pty_wait_failed",
+            "output": "",
+        }
+    )
+
+    assert "PTY could not be reaped" in text
+    assert "process backend disappeared" not in text
+
+
+# =========================================================================
 # Orphaned-pipe reconciliation (issue #17327)
 # =========================================================================
 

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -1606,14 +1606,31 @@ class ProcessRegistry:
             pass
 
         # Process exited
+        reaped = True
         try:
             pty.wait()
         except Exception as e:
-            logger.debug("PTY wait timed out or failed: %s", e)
+            reaped = False
+            logger.warning("PTY wait for session %s failed: %s", session.id, e)
+
+        status = getattr(pty, "exitstatus", None)
         session.exited = True
         if session.completion_reason != "killed":
-            session.exit_code = pty.exitstatus if hasattr(pty, 'exitstatus') else -1
-            session.completion_reason = "exited"
+            if reaped:
+                # wait() returned, so the child really is gone. A backend
+                # without exitstatus (pywinpty) still reports -1 rather than
+                # a null exit code.
+                session.exit_code = status if status is not None else -1
+                session.completion_reason = "exited"
+            else:
+                # _move_to_finished drops the last handle on this child, so
+                # nothing can determine its status afterwards. Report the
+                # outcome as unknown instead of a clean exit carrying a null
+                # code — same shape the env poller uses when it loses a
+                # backend.
+                session.exit_code = -1
+                session.completion_reason = "lost"
+                session.termination_source = "pty_wait_failed"
         self._move_to_finished(session)
 
     def _move_to_finished(self, session: ProcessSession):
@@ -3207,7 +3224,11 @@ def format_process_notification(evt: dict) -> "str | None":
     if _reason == "killed":
         _status = f"terminated by {_source or 'Hermes'}"
     elif _reason == "lost":
-        _status = "marked lost because the process backend disappeared"
+        _status = (
+            "marked lost because the PTY could not be reaped"
+            if _source == "pty_wait_failed"
+            else "marked lost because the process backend disappeared"
+        )
     elif _reason == "failed_start":
         _status = "failed to start"
     elif _exit == 0:


### PR DESCRIPTION
## What does this PR do?

`_pty_reader_loop` swallowed a `pty.wait()` failure at debug level and then set
`completion_reason = "exited"` with `exit_code = pty.exitstatus` unconditionally. When
`wait()` raises, `exitstatus` is `None`, so the agent was handed a background command
described as cleanly finished while carrying a null exit code, and the failure left no
trace at the default log level.

This tracks whether the reap actually succeeded:

- reap succeeded: report the real status, falling back to `-1` rather than `None`. That
  fallback fires in ordinary use, not just in theory: ptyprocess leaves `exitstatus` at
  `None` whenever the child dies on a signal and records `signalstatus` instead, and a
  backend such as pywinpty may not expose the attribute at all
- reap failed: report the outcome as unknown using the shape the env poller in the same
  file already uses for an indeterminate result, `exit_code = -1`,
  `completion_reason = "lost"`, `termination_source = "pty_wait_failed"`

The wait failure now logs at warning with the session id instead of debug.

Two notes on why the approach is shaped this way:

`_move_to_finished` still runs on both branches. Returning early instead would strand
the session in `_running` forever, because `_reconcile_local_exit` is a documented no-op
for sessions without a local `Popen`, which includes every PTY session. That is why this
does not mirror the early-return used for the pipe path.

The `"lost"` notification text said "the process backend disappeared", which is accurate
for the env poller but wrong for a PTY that failed to reap, so the message now names the
real cause when `termination_source` is `pty_wait_failed`.

## Related Issue

Part of #96362

Scope note: #96362 covers two call paths. The sibling pipe path in `_reader_loop` is
already being addressed in #86511, so this PR deliberately leaves it alone rather than
opening a competing change. #96362 also suggests escalating to SIGKILL after a failed
wait. I left that out: `pty.wait()` blocks until the child exits, so a raise almost
always means the child is already gone or unwaitable, and force killing on that signal
risks acting on a recycled pid. This PR fixes the dishonest reporting, which is provable.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/process_registry.py`, `_pty_reader_loop`: distinguish a failed reap from a
  successful one, never publish a null `exit_code`, log the failure at warning
- `tools/process_registry.py`, `format_process_notification`: name the PTY as the cause
  for a `"lost"` completion that came from `pty_wait_failed`
- `tests/tools/test_process_registry.py`: five tests covering a real exit status, a
  failed reap, a missing `exitstatus`, an explicit kill staying labelled `killed`, and
  the notification wording

## How to Test

1. `scripts/run_tests.sh tests/tools/test_process_registry.py`
2. Against unfixed `tools/process_registry.py`, three of the five new tests fail. The
   central one fails with `AssertionError: assert None == -1`, which is the reported
   defect: a session marked `completion_reason "exited"` while `exit_code` is `None`.
3. The other two pass before and after by design. They are regression guards that a real
   exit status is still reported and an explicit kill stays labelled `killed`.
4. Manual exercise, spawning real PTY sessions through
   `ProcessRegistry.spawn_local(..., use_pty=True)` and reading back the finished session.
   Linux, Python 3.12, ptyprocess backend:

| command | `main` | this branch |
|---|---|---|
| `exit 0` | `exit_code=0`, `exited` | `exit_code=0`, `exited` |
| `sh -c 'exit 7'` | `exit_code=7`, `exited` | `exit_code=7`, `exited` |
| `sh -c 'kill -TERM $$'` | `exit_code=None`, `exited` | `exit_code=-1`, `exited` |

The third row is the null exit code reaching a caller with no fault injection at all,
just a process that died on a signal. The first two rows confirm normal exits are
unchanged.

Test counts on `tests/tools/test_process_registry.py`, same environment both ways:

| | failed | passed | skipped |
|---|---|---|---|
| `main` | 17 | 69 | 4 |
| this branch | 17 | 74 | 4 |

The 17 failures are identical in both runs and pre-existing in my environment, which has
no systemd or dbus available. The delta is the five added tests.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 22.04, Python 3.12

On the unchecked box: I ran `scripts/run_tests.sh` per AGENTS.md rather than bare
`pytest`, and I ran the affected file rather than the whole suite. My local environment
cannot run the full suite cleanly, so I am reporting what I actually ran instead of
claiming a green full run. CI is the real check here.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

The cross-platform box is the load-bearing one. The `exitstatus` fallback covers both a
signal-terminated child on POSIX and a Windows backend such as pywinpty that may not
expose the attribute, and in both cases the session now reports `-1` with `"exited"`
rather than a null code.
