### PR TITLE
fix(desktop): bridge the Windows updater marker handoff

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -3852,6 +3852,15 @@ async function applyUpdates(opts: { stopSafeBlockers?: boolean } = {}) {
         process.execPath
       ])
 
+      // Write the bridge BEFORE spawning the short-lived cmd.exe wrapper.
+      // PowerShell claims the marker as step 0, so no parent write may follow
+      // spawn and overwrite that live claim. The bounded tag also self-heals
+      // after a failed spawn even though this Desktop process remains alive.
+      writeUpdateMarker(HERMES_HOME, process.pid, {
+        startedAt: updateStartedAt,
+        handoffBridge: true
+      })
+
       child = spawnUpdaterProcess(wrapped.command, wrapped.args, {
         cwd: HERMES_HOME,
         env: {
@@ -3863,17 +3872,6 @@ async function applyUpdates(opts: { stopSafeBlockers?: boolean } = {}) {
         detached: true,
         stdio: 'ignore'
       })
-
-      // Bridge marker: child.pid is the short-lived cmd.exe WRAPPER, not the
-      // script (see wrapHandoffForDetachedConsole). Write it anyway to cover
-      // the first moments of the hand-off — the script's step 0 overwrites it
-      // with its own live $PID, and if the script never starts the wrapper's
-      // dead pid makes the marker read as stale and self-delete (no wedge).
-      // The `hermes update` child adopts the SCRIPT's claim via
-      // update_lock.py's process-ancestry rule; no mtime heuristics needed.
-      if (Number.isInteger(child.pid)) {
-        writeUpdateMarker(HERMES_HOME, child.pid, { startedAt: updateStartedAt })
-      }
 
       rememberLog(
         `[updates] launched repo hand-off script: ${scriptHandoff.scriptPath} (branch ${branch}); exiting desktop to release venv shim`
@@ -3928,8 +3926,8 @@ async function applyUpdates(opts: { stopSafeBlockers?: boolean } = {}) {
     // detached child for an async spawn `error` (ENOENT/EACCES) or an early
     // non-zero/signal exit. On failure, DON'T quit — the user would be left
     // with no app, no updater, and no evidence. Restart our backend and
-    // surface the error instead. The pre-written marker names the dead child
-    // pid, so readLiveUpdateMarker self-heals it; no cleanup needed.
+    // surface the error instead. A staged-updater marker self-heals with its
+    // dead child PID; a script bridge expires after its bounded claim grace.
     const dwellStartedAt = Date.now()
     const handoffOutcome = await observeUpdaterHandoff(child, UPDATE_HANDOFF_DWELL_MS)
 

--- a/apps/desktop/electron/update-marker.test.ts
+++ b/apps/desktop/electron/update-marker.test.ts
@@ -23,6 +23,7 @@ import {
   isPidAlive,
   markerPath,
   readLiveUpdateMarker,
+  UPDATE_HANDOFF_BRIDGE_GRACE_MS,
   UPDATE_MARKER_MAX_AGE_MS,
   updateHandoffConflict,
   writeUpdateMarker
@@ -34,8 +35,10 @@ function tmpHome(tag) {
   return dir
 }
 
-function writeMarker(home, pid, startedAtSec) {
-  fs.writeFileSync(markerPath(home), `${pid}\n${startedAtSec}`)
+function writeMarker(home, pid, startedAtSec, kind = '') {
+  const kindLine = kind ? `\n${kind}\n` : ''
+
+  fs.writeFileSync(markerPath(home), `${pid}\n${startedAtSec}${kindLine}`)
 }
 
 const ALIVE: typeof process.kill = () => true // injected kill that "succeeds" => pid alive
@@ -152,6 +155,59 @@ test('writeUpdateMarker + dead pid => self-heals on read', () => {
   const res = readLiveUpdateMarker(home, { kill: DEAD })
   assert.equal(res, null, 'a dead-pid marker from writeUpdateMarker self-heals')
   assert.ok(!fs.existsSync(markerPath(home)), 'marker file is pruned')
+})
+
+test('dead tagged hand-off bridge covers the wrapper-to-script claim gap', () => {
+  const home = tmpHome('dead-handoff-bridge')
+  const now = 1_000_000_000_000
+
+  writeMarker(home, 999999, Math.floor(now / 1000) - 8, 'handoff-bridge')
+
+  const res = readLiveUpdateMarker(home, { kill: DEAD, now: () => now })
+  assert.ok(res, 'the bridge must keep the backend gate closed until PowerShell claims the marker')
+  assert.ok(fs.existsSync(markerPath(home)), 'the bridge remains during the bounded claim gap')
+})
+
+test('tagged hand-off bridge expires after the claim gap even while its pid is alive', () => {
+  const home = tmpHome('expired-handoff-bridge')
+  const now = 1_000_000_000_000
+
+  writeMarker(
+    home,
+    4242,
+    Math.floor((now - UPDATE_HANDOFF_BRIDGE_GRACE_MS - 1000) / 1000),
+    'handoff-bridge'
+  )
+
+  assert.equal(readLiveUpdateMarker(home, { kill: ALIVE, now: () => now }), null)
+  assert.ok(!fs.existsSync(markerPath(home)), 'an unclaimed bridge cannot wedge later update attempts')
+})
+
+test('live updater claim replaces the pre-spawn Desktop bridge', () => {
+  const home = tmpHome('handoff-claim-order')
+  const now = 1_000_000_000_000
+  const startedAt = Math.floor(now / 1000) - 8
+
+  writeUpdateMarker(home, 1010, { now: () => now, startedAt, handoffBridge: true })
+
+  const [bridgePidLine, bridgeStartedLine, bridgeKindLine] = fs
+    .readFileSync(markerPath(home), 'utf8')
+    .split('\n')
+
+  assert.equal(Number.parseInt(bridgePidLine, 10), 1010, 'the Desktop owns the bridge')
+  assert.equal(Number.parseInt(bridgeStartedLine, 10), startedAt)
+  assert.equal(bridgeKindLine, 'handoff-bridge', 'the pre-spawn marker is explicitly bounded')
+  assert.ok(
+    readLiveUpdateMarker(home, { kill: DEAD, now: () => now }),
+    'the tagged bridge remains live inside the claim grace even after its owner exits'
+  )
+
+  writeUpdateMarker(home, 2020, { now: () => now, startedAt })
+
+  const [pidLine, startedLine, kindLine] = fs.readFileSync(markerPath(home), 'utf8').split('\n')
+  assert.equal(Number.parseInt(pidLine, 10), 2020, 'the updater becomes the live marker owner')
+  assert.equal(Number.parseInt(startedLine, 10), startedAt, 'the original acquisition time is preserved')
+  assert.equal(kindLine, '', 'the updater claim is no longer a bounded bridge')
 })
 
 // ---------------------------------------------------------------------------

--- a/apps/desktop/electron/update-marker.ts
+++ b/apps/desktop/electron/update-marker.ts
@@ -3,8 +3,9 @@
  *
  * The Tauri updater writes HERMES_HOME/.hermes-update-in-progress for the whole
  * duration of an `--update` run (see apps/bootstrap-installer/src-tauri/src/
- * update.rs `UpdateMarkerGuard`). The marker body is two lines: the updater's
- * pid and the unix-seconds it started.
+ * update.rs `UpdateMarkerGuard`). The marker body starts with the updater's
+ * pid and the unix-seconds it started. A Desktop-owned Windows bridge adds a
+ * third `handoff-bridge` line until windows.ps1 claims the marker itself.
  *
  * Why: if the user relaunches the desktop mid-update — the window vanished with
  * no progress and looks crashed — a fresh instance must NOT spawn its own local
@@ -28,6 +29,12 @@ import path from 'path'
 // of minutes; past this the marker is almost certainly stale (e.g. the OS
 // recycled the pid onto an unrelated process), so the gate self-heals.
 export const UPDATE_MARKER_MAX_AGE_MS = 20 * 60 * 1000
+
+// The Windows script starts through a short-lived cmd.exe wrapper. Hold the
+// backend gate closed across that bounded wrapper-to-script claim gap, even
+// after the bridge owner exits. The bound applies regardless of PID liveness
+// so a failed hand-off cannot wedge retries behind the still-running Desktop.
+export const UPDATE_HANDOFF_BRIDGE_GRACE_MS = 30 * 1000
 
 export function markerPath(hermesHome) {
   return path.join(hermesHome, '.hermes-update-in-progress')
@@ -54,11 +61,10 @@ export function isPidAlive(pid, kill: typeof process.kill = process.kill.bind(pr
 /**
  * Read + interpret the marker.
  *
- * Returns `{ pid, ageMs }` only when an update is GENUINELY still running
- * (parseable pid that is alive, within the age ceiling). Returns `null` for
- * every "no live update" case — absent, unreadable, malformed, dead pid, or
- * past the ceiling — and, when a stale marker file exists, deletes it so it
- * cannot strand future launches.
+ * Returns `{ pid, ageMs }` when an update is still running: either a parseable
+ * live pid within the age ceiling, or an explicitly tagged Windows hand-off
+ * bridge inside its short claim grace. Returns `null` for every other case and
+ * deletes stale markers so they cannot strand future launches.
  *
  * Pure-ish: file I/O against the given path, plus an injectable pid probe and
  * clock for tests.
@@ -84,13 +90,18 @@ export function readLiveUpdateMarker(
     return null // absent or unreadable => no live update
   }
 
-  const [pidLine, startedLine] = String(raw).split('\n')
+  const [pidLine, startedLine, kindLine] = String(raw).split('\n')
   const pid = Number.parseInt((pidLine || '').trim(), 10)
   const startedAt = Number.parseInt((startedLine || '').trim(), 10)
   const ageMs = Number.isFinite(startedAt) ? now() - startedAt * 1000 : Infinity
-  const alive = Number.isInteger(pid) && isPidAlive(pid, kill)
+  const validPid = Number.isInteger(pid) && pid > 0
+  const handoffBridge = (kindLine || '').trim() === 'handoff-bridge'
 
-  if (!alive || ageMs > maxAgeMs) {
+  const active = handoffBridge
+    ? validPid && ageMs >= -1000 && ageMs <= UPDATE_HANDOFF_BRIDGE_GRACE_MS
+    : validPid && isPidAlive(pid, kill) && ageMs <= maxAgeMs
+
+  if (!active) {
     try {
       fs.unlinkSync(file)
     } catch {
@@ -107,24 +118,15 @@ export function readLiveUpdateMarker(
  * Write the update-in-progress marker *from the desktop* before handing off
  * to the detached updater.
  *
- * The Tauri-based hermes-setup.exe takes several seconds to initialise its
- * window and reach the Rust `run_update` entry point where it writes the
- * marker itself. During that gap the desktop's `app.quit()` teardown kills
- * the backend child, the renderer's WebSocket drops, and the renderer
- * immediately calls `ensureBackend()` → `waitForUpdateToFinish()`. Because
- * the updater hasn't written the marker yet, the gate sees no live update
- * and spawns a *new* backend — which re-locks `.pyd` files in the venv.
- * When the updater finally reaches the venv-rebuild stage it finds those
- * files locked and the update bricks.
+ * During updater startup the Desktop's backend exits and its renderer may
+ * reconnect. Without a marker, that reconnect can spawn a new backend which
+ * re-locks the venv before the updater reaches its rebuild stage.
  *
- * Fix: the desktop writes the marker itself, using the spawned updater's
- * PID, immediately after `spawn()`. The updater's `UpdateMarkerGuard` will
- * later adopt it or another hand-off stage may replace the PID. A live
- * holder's original timestamp is preserved across those transfers so retries
- * cannot keep resetting the 20-minute stale ceiling. When the updater finishes
- * it deletes the marker as before.
- * If the updater never starts (spawn failure) the marker still contains a
- * real PID, so `readLiveUpdateMarker` will self-heal once that PID exits.
+ * Staged updaters receive a marker with their spawned PID. The repo-owned
+ * Windows script instead receives a tagged marker with the Desktop PID before
+ * `cmd start`; the tag keeps the gate closed for the bounded claim gap, then
+ * windows.ps1 replaces it with its own PID. Transfers preserve the original
+ * timestamp so retries cannot reset the 20-minute stale ceiling.
  */
 export function writeUpdateMarker(
   hermesHome,
@@ -133,12 +135,14 @@ export function writeUpdateMarker(
     kill,
     now = Date.now,
     maxAgeMs = UPDATE_MARKER_MAX_AGE_MS,
-    startedAt
+    startedAt,
+    handoffBridge = false
   }: {
     now?: () => number
     maxAgeMs?: number
     kill?: typeof process.kill
     startedAt?: number
+    handoffBridge?: boolean
   } = {}
 ) {
   const file = markerPath(hermesHome)
@@ -153,7 +157,8 @@ export function writeUpdateMarker(
         : Math.floor(nowMs / 1000)
 
   try {
-    fs.writeFileSync(file, `${pid}\n${acquiredAt}\n`, 'utf8')
+    const kindLine = handoffBridge ? 'handoff-bridge\n' : ''
+    fs.writeFileSync(file, `${pid}\n${acquiredAt}\n${kindLine}`, 'utf8')
   } catch {
     // Best-effort: if we can't write the marker, proceed anyway. The
     // updater will write its own when it reaches run_update.


### PR DESCRIPTION
## Summary  On Windows, the Desktop now keeps its backend gate closed across the gap between the short-lived detached `cmd.exe` wrapper and `windows.ps1` claiming the update marker. This prevents a relaunched Desktop from starting a backend that re-locks the managed environment while the updater is preparing it.  The Desktop writes a tagged 30-second bridge before it spawns the wrapper. `windows.ps1` replaces that bridge with its normal live PID claim at step 0. If the script never claims it, the bridge expires even while the Desktop PID remains alive. Ordinary two-line marker behavior and holder termination are unchanged.  This is an upstream Windows Desktop race. It does not depend on fork-specific configuration.  Related: #77277  ## How to test  - On Windows, start an update from the packaged Desktop and verify the backend does not respawn during the wrapper-to-PowerShell handoff. - Verify the marker changes from the tagged Desktop bridge to the PowerShell-owned two-line claim before the bridge grace expires. - Verify a bridge from a failed handoff expires and does not block a later update attempt.  Validation performed on Windows 11 build `10.0.26200.8973`:  - The two new regression cases failed on unpatched upstream and pass with this change. - Focused Electron marker, gate, and updater-process tests: 54 passed. - Electron TypeScript check: passed. - Targeted ESLint check: passed. - Hidden `windows.ps1 -NoUi -NoMarkerCleanup -SelfTestMarker`: passed; PowerShell replaced the tagged bridge with its normal two-line claim and preserved `startedAt`.  ---  [![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)  
## Live packaged Desktop proof

A full visible Windows Desktop update succeeded on Windows 11 build 10.0.26200.8973 on 2026-08-27 PDT.

- The initiating packaged Desktop ran the patched bridge logic while its managed checkout was still at 24b3ba6ae0 on fork-integration.
- The marker was claimed immediately by windows.ps1 as its ordinary two-line live-PID marker before the Desktop exited.
- The existing force/kill-all updater path ran unchanged; no holder-inventory fallback or manual process kill was used.
- The managed checkout advanced cleanly to 2938f39bf33ea0c33d54bb4dd42046dfdc90d087, which contains this PR cherry-picked onto current upstream plus the fork commits.
- The result reported ok=true and exit_code=0, the owned marker was removed, and the Desktop relaunched visibly as v0.20.6 at 2938f39.
- The relaunched install stamp, managed checkout HEAD, and origin/fork-integration all matched 2938f39bf33ea0c33d54bb4dd42046dfdc90d087.

This exercises the real wrapper-to-PowerShell handoff, managed checkout update, Desktop rebuild, marker cleanup, and relaunch rather than a fixture-only path.