### PR TITLE
fix(desktop): drive slash commands from the registry

### DIFF
--- a/apps/desktop/src/app/chat/composer/composer-utils.test.ts
+++ b/apps/desktop/src/app/chat/composer/composer-utils.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 
 import {
   acceptsTriggerCompletion,
+  implicitSlashAcceptIndex,
   isPendingDraftPersistCurrent,
   type PendingDraftPersist,
   pickPlaceholder,
@@ -85,6 +86,34 @@ describe('acceptsTriggerCompletion', () => {
 
   it('keeps Tab as the explicit accept even over free text', () => {
     expect(press('Tab', { freeTextArgStage: true, query: 'goal stat' })).toBe(true)
+  })
+})
+
+describe('implicitSlashAcceptIndex', () => {
+  const rows = ['/compress', '/review', '/resume']
+
+  it('completes a prefix of the highlighted row', () => {
+    expect(implicitSlashAcceptIndex('com', rows, 0, false)).toBe(0)
+  })
+
+  it('keeps a fully typed command even when another row is highlighted', () => {
+    expect(implicitSlashAcceptIndex('review', rows, 0, false)).toBe(1)
+  })
+
+  it('does not steal when the typed token is not a prefix of any row', () => {
+    expect(implicitSlashAcceptIndex('review', ['/compress', '/resume'], 0, false)).toBeNull()
+  })
+
+  it('takes the only prefix match when the highlight is a leftover', () => {
+    expect(implicitSlashAcceptIndex('rev', ['/compress', '/review', '/resume'], 0, false)).toBe(1)
+  })
+
+  it('honours an arrowed pick even when it is not a prefix', () => {
+    expect(implicitSlashAcceptIndex('review', rows, 0, true)).toBe(0)
+  })
+
+  it('matches an arg-stage prefix against the full completion text', () => {
+    expect(implicitSlashAcceptIndex('personality alic', ['/personality alice', '/personality none'], 0, false)).toBe(0)
   })
 })
 

--- a/apps/desktop/src/app/chat/composer/composer-utils.ts
+++ b/apps/desktop/src/app/chat/composer/composer-utils.ts
@@ -87,6 +87,50 @@ export const slashArgStage = (query: string) => query.includes(' ')
 /** The `/command` token of a slash query (`personality x` → `/personality`). */
 export const slashCommandToken = (query: string) => `/${query.split(/\s+/, 1)[0]?.toLowerCase() ?? ''}`
 
+/** Typed `/` query or completion text without the leading slash. */
+export const slashCompletionToken = (value: string) => value.replace(/^\//, '').trimEnd().toLowerCase()
+
+/**
+ * Which row Space/Enter should take. Tab always uses the highlight; this is
+ * the "still suggesting, don't steal what I typed" pick.
+ *
+ * `/com` + a highlighted `/compress` still completes. `/review` while
+ * `/compress` is the leftover highlight does not. An exact list match wins
+ * so a fully typed command isn't replaced by a longer/fuzzier neighbour.
+ */
+export function implicitSlashAcceptIndex(
+  query: string,
+  itemTexts: readonly string[],
+  activeIndex: number,
+  activeExplicit: boolean
+): number | null {
+  const typed = slashCompletionToken(query)
+
+  if (!typed) {
+    return null
+  }
+
+  if (activeExplicit && itemTexts[activeIndex] != null) {
+    return activeIndex
+  }
+
+  const exact = itemTexts.findIndex(text => slashCompletionToken(text) === typed)
+
+  if (exact >= 0) {
+    return exact
+  }
+
+  const active = itemTexts[activeIndex]
+
+  if (active != null && slashCompletionToken(active).startsWith(typed)) {
+    return activeIndex
+  }
+
+  const prefixHits = itemTexts.flatMap((text, index) => (slashCompletionToken(text).startsWith(typed) ? [index] : []))
+
+  return prefixHits.length === 1 ? prefixHits[0] : null
+}
+
 export interface TriggerAcceptInput {
   /** The user moved the highlight themselves (arrow keys) rather than
    *  inheriting the list's default first row. */

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-trigger.test.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-trigger.test.ts
@@ -1,11 +1,26 @@
 import type { Unstable_TriggerAdapter, Unstable_TriggerItem } from '@assistant-ui/core'
 import { act, renderHook } from '@testing-library/react'
 import { createRef } from 'react'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { rememberDesktopCommandsCatalog } from '@/lib/desktop-slash-commands'
 
 import { composerPlainText, renderComposerContents, RICH_INPUT_SLOT } from '../rich-editor'
 
 import { useComposerTrigger } from './use-composer-trigger'
+
+beforeEach(() => {
+  rememberDesktopCommandsCatalog({
+    commands: {
+      '/goal': { argument_mode: 'mixed', desktop: null },
+      '/personality': { argument_mode: 'options', desktop: null }
+    }
+  })
+})
+
+afterEach(() => {
+  rememberDesktopCommandsCatalog(undefined)
+})
 
 /** A live contentEditable seeded with `text`, caret parked at the end. */
 function mountEditor(text: string) {

--- a/apps/desktop/src/app/chat/composer/hooks/use-live-completion-adapter.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-live-completion-adapter.ts
@@ -5,6 +5,9 @@ export interface CompletionEntry {
   text: string
   display?: unknown
   meta?: unknown
+  /** From `complete.slash`: registry command vs skill. The popover groups on
+   *  this instead of re-deriving kind from the desktop command table. */
+  kind?: string
   /** Optional section label (e.g. "Commands", "Skills"). The popover renders a
    *  header whenever this changes between consecutive items, so the fetcher must
    *  emit entries already grouped contiguously. */

--- a/apps/desktop/src/app/chat/composer/hooks/use-slash-completions.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-slash-completions.test.tsx
@@ -130,17 +130,23 @@ describe('useSlashCompletions', () => {
     expect(skills).toEqual(['/work', '/research', '/docx'])
   })
 
-  // Typing is a search, and a search that hides a match is broken — the
-  // never-used built-in still shows, just below the one she actually uses.
-  it('ranks a typed query by use without hiding anything', async () => {
+  // Typing is a search, and a search that hides a match is broken. Order
+  // stays the backend's (fuzzy score, then usage) — a second client usage
+  // sort is what buried `/review` under skills.
+  it('keeps backend order on a typed query and does not hide matches', async () => {
     const request = vi.fn().mockImplementation((method: string) =>
       Promise.resolve(
         method === 'commands.catalog'
           ? RANKED_CATALOG
           : {
               items: [
-                { text: '/research-paper-writing', display: '/research-paper-writing', meta: 'Write a paper' },
-                { text: '/research', display: '/research', meta: 'Look it up' }
+                {
+                  text: '/research-paper-writing',
+                  display: '/research-paper-writing',
+                  kind: 'skill',
+                  meta: 'Write a paper'
+                },
+                { text: '/research', display: '/research', kind: 'skill', meta: 'Look it up' }
               ]
             }
       )
@@ -148,10 +154,33 @@ describe('useSlashCompletions', () => {
 
     const api = harness({ request } as unknown as HermesGateway)
 
-    // Warm the catalog first: the popover always opens on a bare `/` before a
-    // query is typed, which is where the usage map comes from.
-    await completions(api, '')
+    expect(commandsOf(await completions(api, 'research'))).toEqual(['/research-paper-writing', '/research'])
+  })
 
-    expect(commandsOf(await completions(api, 'research'))).toEqual(['/research', '/research-paper-writing'])
+  it('keeps a registry command in Commands even when the desktop table has no row', async () => {
+    const request = vi.fn().mockImplementation((method: string) =>
+      Promise.resolve(
+        method === 'commands.catalog'
+          ? CATALOG
+          : {
+              items: [
+                { text: '/refine', display: '/refine', kind: 'command', meta: 'Review this conversation' },
+                { text: '/docx', display: '/docx', kind: 'skill', meta: 'Edit Word documents' },
+                { text: '/compress', display: '/compress', kind: 'command', meta: 'Compress context' }
+              ]
+            }
+      )
+    )
+
+    const api = harness({ request } as unknown as HermesGateway)
+    const items = await completions(api, 're')
+    const groupOf = (command: string) =>
+      (items.find(item => (item.metadata as { command?: string })?.command === command)?.metadata as { group?: string })
+        ?.group
+
+    expect(commandsOf(items)).toEqual(['/refine', '/compress', '/docx'])
+    expect(groupOf('/refine')).toBe('Commands')
+    expect(groupOf('/compress')).toBe('Commands')
+    expect(groupOf('/docx')).toBe('Skills')
   })
 })

--- a/apps/desktop/src/app/chat/composer/hooks/use-slash-completions.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-slash-completions.ts
@@ -1,6 +1,6 @@
 import type { Unstable_TriggerAdapter, Unstable_TriggerItem } from '@assistant-ui/core'
 import { useStore } from '@nanostores/react'
-import { useCallback } from 'react'
+import { useCallback, useEffect } from 'react'
 
 import type { HermesGateway } from '@/hermes'
 import { sessionTitle } from '@/lib/chat-runtime'
@@ -12,13 +12,13 @@ import {
   filterDesktopCommandsCatalog,
   isDesktopSlashExtensionCommand,
   isDesktopSlashSuggestion,
-  rankSkillCommands
+  rankSkillCommands,
+  slashCompletionGroup
 } from '@/lib/desktop-slash-commands'
 import {
   $slashCompletionsEpoch,
   cachedSlashCompletion,
-  hasCachedSlashCompletion,
-  peekCachedSlashCompletion
+  hasCachedSlashCompletion
 } from '@/lib/slash-completion-cache'
 import { normalize } from '@/lib/text'
 import { $sessions } from '@/store/session'
@@ -72,6 +72,21 @@ export function useSlashCompletions(options: {
   const { gateway, skinThemes, activeSkin } = options
   const enabled = Boolean(gateway)
   const epoch = useStore($slashCompletionsEpoch)
+
+  // Warm argument_mode before the first `/` so Space treats /review as text.
+  useEffect(() => {
+    if (!gateway) {
+      return
+    }
+
+    void cachedSlashCompletion('catalog', () => gateway.request<CommandsCatalogLike>('commands.catalog'))
+      .then(catalog => {
+        filterDesktopCommandsCatalog(catalog)
+      })
+      .catch(() => {
+        // Next keystroke retries; don't block the composer on a warm-up miss.
+      })
+  }, [gateway, epoch])
 
   const fetcher = useCallback(
     async (query: string): Promise<CompletionPayload> => {
@@ -210,7 +225,9 @@ export function useSlashCompletions(options: {
             ...item,
             // Arg suggestions (e.g. `/handoff <platform>`) live under one
             // header; otherwise split skills out from built-in commands.
-            group: isArgCompletion ? 'Options' : isDesktopSlashExtensionCommand(item.text) ? 'Skills' : 'Commands',
+            // Kind comes from the backend — the desktop table is a visibility
+            // gate (`isDesktopSlashSuggestion`), not a classifier.
+            group: isArgCompletion ? 'Options' : slashCompletionGroup(item.text, item.kind),
             // Arg items carry their own meta (the personality/toolset/platform
             // blurb). Only command rows get the registry description — looking
             // one up for `/personality none` would clobber it with the parent
@@ -220,29 +237,18 @@ export function useSlashCompletions(options: {
 
         // Keep each group contiguous so headers render once: Commands before
         // Skills (stable within a group, preserving backend relevance order).
+        // Do not re-sort skills by usage here — complete.slash already ranked
+        // by fuzzy score, then usage. A second usage pass buried exact name
+        // matches that the table had mis-filed as skills.
         const groupOrder = ['Commands', 'Skills', 'Options']
 
         if (isArgCompletion) {
           return { items: decorated, query }
         }
 
-        // Rank the matched skills by use — `/re` should lead with the /research
-        // the user lives in, not the /research-paper-writing they've never
-        // opened. Nothing is pruned here: a typed query is a search, and a
-        // search that hides a match is broken. Usage rides along on the catalog
-        // response, which the popover has already fetched by the time anyone
-        // types; if it somehow hasn't, order falls back to the backend's.
-        const catalogSkills = peekCachedSlashCompletion<CommandsCatalogLike>('catalog')?.skills
-
-        const ranked = [
-          ...decorated.filter(item => item.group !== 'Skills'),
-          ...rankSkillCommands(
-            decorated.filter(item => item.group === 'Skills'),
-            catalogSkills
-          )
-        ]
-
-        const items = [...ranked].sort((a, b) => groupOrder.indexOf(a.group) - groupOrder.indexOf(b.group))
+        const items = [...decorated].sort(
+          (a, b) => groupOrder.indexOf(a.group ?? '') - groupOrder.indexOf(b.group ?? '')
+        )
 
         return { items, query }
       } catch {

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -30,6 +30,7 @@ import { AttachmentList } from './attachments'
 import {
   acceptsTriggerCompletion,
   COMPOSER_FADE_BACKGROUND,
+  implicitSlashAcceptIndex,
   type QueueEditState,
   slashArgStage
 } from './composer-utils'
@@ -691,9 +692,11 @@ export function ChatBar({
         return
       }
 
-      // Accepting the highlighted item: a no-arg command commits its directive
-      // chip, an arg-taking command expands to its options step, and an arg
-      // option commits the full `/cmd arg` chip.
+      // Accepting a completion: a no-arg command commits its directive chip,
+      // an arg-taking command expands to its options step, and an arg option
+      // commits the full `/cmd arg` chip. Space/Enter resolve the pick so a
+      // leftover highlight does not replace a typed command; Tab still takes
+      // the highlight.
       const accept = acceptsTriggerCompletion({
         activeExplicit: triggerActiveExplicit,
         freeTextArgStage: slashFreeTextArgStage,
@@ -703,17 +706,34 @@ export function ChatBar({
       })
 
       if (accept) {
-        event.preventDefault()
-        triggerKeyConsumedRef.current = true
-        const item = triggerItems[triggerActive]
+        const itemTexts = triggerItems.map(item => {
+          const meta = item.metadata as { command?: string; rawText?: string } | undefined
+
+          return meta?.command || meta?.rawText || item.label
+        })
+
+        const item =
+          trigger.kind === '/' && event.key !== 'Tab'
+            ? triggerItems[
+                implicitSlashAcceptIndex(trigger.query, itemTexts, triggerActive, triggerActiveExplicit) ?? -1
+              ]
+            : triggerItems[triggerActive]
 
         if (item) {
+          event.preventDefault()
+          triggerKeyConsumedRef.current = true
           // Tab means "go deeper" on a folder; Enter means "I want this one".
-          // Everything else treats them alike.
           replaceTriggerWithChip(item, { descend: event.key === 'Tab' })
+
+          return
         }
 
-        return
+        if (event.key === 'Tab') {
+          event.preventDefault()
+          triggerKeyConsumedRef.current = true
+
+          return
+        }
       }
 
       // Backspace climbs out of an `@` path one segment at a time, mirroring

--- a/apps/desktop/src/app/chat/composer/rich-editor.test.ts
+++ b/apps/desktop/src/app/chat/composer/rich-editor.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { rememberDesktopCommandsCatalog } from '@/lib/desktop-slash-commands'
 
 import { insertInlineRefsIntoEditor } from './inline-refs'
 import {
@@ -12,6 +14,16 @@ import {
   RICH_INPUT_SLOT
 } from './rich-editor'
 import { placeCaretAtEnd } from './test-utils'
+
+beforeEach(() => {
+  rememberDesktopCommandsCatalog({
+    commands: { '/goal': { argument_mode: 'mixed', desktop: null } }
+  })
+})
+
+afterEach(() => {
+  rememberDesktopCommandsCatalog(undefined)
+})
 
 describe('renderComposerContents', () => {
   it('renders refs and raw text without interpreting user text as HTML', () => {

--- a/apps/desktop/src/app/chat/composer/slash-refs.test.ts
+++ b/apps/desktop/src/app/chat/composer/slash-refs.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { rememberDesktopCommandsCatalog } from '@/lib/desktop-slash-commands'
 
 import { slashCommandMatches } from './slash-refs'
 
@@ -6,6 +8,16 @@ const commands = (text: string, options?: Parameters<typeof slashCommandMatches>
   slashCommandMatches(text, options).map(match => `${match.kind}:${match.command}`)
 
 describe('slashCommandMatches', () => {
+  beforeEach(() => {
+    rememberDesktopCommandsCatalog({
+      commands: { '/goal': { argument_mode: 'mixed', desktop: null } }
+    })
+  })
+
+  afterEach(() => {
+    rememberDesktopCommandsCatalog(undefined)
+  })
+
   it('recognizes a leading command and a skill named mid-prose', () => {
     expect(commands('/some-skill clean this with /other-skill please')).toEqual([
       'skill:/some-skill',

--- a/apps/desktop/src/lib/desktop-slash-commands.test.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.test.ts
@@ -3,8 +3,8 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import {
   type CommandCatalogMeta,
   type CommandsCatalogLike,
-  type DesktopSlashArgumentMode,
   desktopSkinSlashCompletions,
+  type DesktopSlashArgumentMode,
   desktopSlashCommandArgumentMode,
   desktopSlashDescription,
   desktopSlashUnavailableMessage,

--- a/apps/desktop/src/lib/desktop-slash-commands.test.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.test.ts
@@ -1,6 +1,9 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import {
+  type CommandCatalogMeta,
+  type CommandsCatalogLike,
+  type DesktopSlashArgumentMode,
   desktopSkinSlashCompletions,
   desktopSlashCommandArgumentMode,
   desktopSlashDescription,
@@ -11,10 +14,65 @@ import {
   isModelPickerCommand,
   isPickerCommand,
   rankSkillCommands,
-  resolveDesktopCommand
+  rememberDesktopCommandsCatalog,
+  resolveDesktopCommand,
+  slashCompletionGroup
 } from './desktop-slash-commands'
 
+function registryCatalog(
+  modes: Record<string, DesktopSlashArgumentMode | null>,
+  aliases: Record<string, string> = {}
+): CommandsCatalogLike {
+  const commands: Record<string, CommandCatalogMeta> = {}
+  const canon: Record<string, string> = {}
+
+  for (const [name, argument_mode] of Object.entries(modes)) {
+    commands[name] = { argument_mode, desktop: null }
+    canon[name] = name
+  }
+
+  for (const [alias, target] of Object.entries(aliases)) {
+    commands[alias] = commands[target]
+    canon[alias] = target
+  }
+
+  return { commands, canon }
+}
+
+const REGISTRY_CATALOG = registryCatalog(
+  {
+    '/approvals': 'options',
+    '/review': 'text',
+    '/refine': 'text',
+    '/usage': null,
+    '/version': null,
+    '/agents': null,
+    '/steer': 'text',
+    '/stop': null,
+    '/background': 'text',
+    '/debug': null,
+    '/goal': 'mixed',
+    '/personality': 'options',
+    '/queue': 'text',
+    '/retry': null,
+    '/rollback': null,
+    '/tools': 'options',
+    '/undo': null,
+    '/loop': 'mixed',
+    '/lcm': 'text'
+  },
+  { '/tasks': '/agents', '/bg': '/background', '/q': '/queue', '/proactive': '/loop' }
+)
+
 describe('desktop slash command curation', () => {
+  beforeEach(() => {
+    rememberDesktopCommandsCatalog(REGISTRY_CATALOG)
+  })
+
+  afterEach(() => {
+    rememberDesktopCommandsCatalog(undefined)
+  })
+
   it('keeps core desktop chat commands in suggestions', () => {
     expect(isDesktopSlashSuggestion('/new')).toBe(true)
     expect(isDesktopSlashSuggestion('/branch')).toBe(true)
@@ -26,6 +84,29 @@ describe('desktop slash command curation', () => {
     expect(isDesktopSlashSuggestion('/approvals')).toBe(true)
     expect(isDesktopSlashCommand('/approvals')).toBe(true)
     expect(resolveDesktopCommand('/approvals')?.surface).toEqual({ kind: 'exec' })
+    expect(isDesktopSlashSuggestion('/review')).toBe(true)
+    expect(isDesktopSlashCommand('/review')).toBe(true)
+    expect(resolveDesktopCommand('/review')?.surface).toEqual({ kind: 'exec' })
+    expect(resolveDesktopCommand('/review')?.argumentMode).toBe('text')
+  })
+
+  it('treats registry and plugin commands as exec when the catalog says so', () => {
+    expect(resolveDesktopCommand('/refine')?.argumentMode).toBe('text')
+    expect(isDesktopSlashSuggestion('/refine')).toBe(true)
+    expect(isDesktopSlashSuggestion('/bg')).toBe(false)
+    expect(isDesktopSlashCommand('/background')).toBe(true)
+    expect(desktopSlashCommandArgumentMode('/background')).toBe('text')
+    expect(resolveDesktopCommand('/lcm')?.surface).toEqual({ kind: 'exec' })
+    expect(desktopSlashCommandArgumentMode('/lcm')).toBe('text')
+  })
+
+  it('groups complete.slash rows by backend kind, not the desktop table', () => {
+    // A registry command the table has never heard of is still a command.
+    expect(slashCompletionGroup('/refine', 'command')).toBe('Commands')
+    expect(slashCompletionGroup('/docx', 'skill')).toBe('Skills')
+    // Older backends omit kind — fall back to the table.
+    expect(slashCompletionGroup('/new')).toBe('Commands')
+    expect(slashCompletionGroup('/docx')).toBe('Skills')
   })
 
   it('surfaces skill and quick commands (extensions) in suggestions and lets them run', () => {

--- a/apps/desktop/src/lib/desktop-slash-commands.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.ts
@@ -1,10 +1,19 @@
+import { peekCachedSlashCompletion } from '@/lib/slash-completion-cache'
+
 export interface CommandsCatalogSection {
   name: string
   pairs: [string, string][]
 }
 
+export interface CommandCatalogMeta {
+  argument_mode?: 'mixed' | 'options' | 'text' | null
+  desktop?: string | null
+}
+
 export interface CommandsCatalogLike {
+  canon?: Record<string, string>
   categories?: CommandsCatalogSection[]
+  commands?: Record<string, CommandCatalogMeta>
   pairs?: [string, string][]
   skill_count?: number
   skills?: SkillCatalogMap
@@ -155,9 +164,10 @@ const rpc = (
 ): DesktopCommandSurface => ({ kind: 'rpc', rpc: rpcName, timeoutMs, buildParams })
 
 /**
- * THE source of truth for desktop slash commands. Everything below — execution
- * gating, popover suggestions, catalog filtering, pill grouping, and the
- * dispatcher's behavior — derives from this one table.
+ * Local desktop overlay — actions, pickers, and dedicated RPCs the Electron
+ * client owns. Registry commands without a row here are `exec` unless the
+ * catalog marks them unavailable/hidden. New commands and plugins declare
+ * `argument_mode` / `desktop` on the Python registry instead of adding a row.
  */
 const DESKTOP_COMMAND_SPECS: readonly DesktopCommandSpec[] = [
   // Local client actions
@@ -219,35 +229,6 @@ const DESKTOP_COMMAND_SPECS: readonly DesktopCommandSpec[] = [
     argumentMode: 'mixed'
   },
 
-  // Backend-executed commands that render useful inline output.
-  // Commands with a dedicated gateway RPC (@method in tui_gateway/server.py)
-  // route to it directly via `rpc(...)` — bypassing slash.exec avoids the
-  // slash-worker pipe timeout and the "not a quick/plugin/skill command"
-  // fallback noise for commands the dispatcher doesn't handle inline.
-  // These commands have gateway RPCs, but their established desktop behavior
-  // carries richer CLI semantics: /agents includes delegations, /stop cancels
-  // them, /steer falls back to a next-turn prompt, and /usage is a formatted
-  // live report. Keep them on slash.exec until their RPC contracts are fully
-  // equivalent.
-  {
-    name: '/approvals',
-    description: 'Show or set approval mode [manual|smart|off]',
-    surface: exec(),
-    argumentMode: 'options'
-  },
-  {
-    name: '/agents',
-    description: 'Show active desktop sessions and running tasks',
-    aliases: ['/tasks'],
-    surface: exec()
-  },
-  {
-    name: '/background',
-    description: 'Run a prompt in the background',
-    aliases: ['/bg', '/btw'],
-    surface: exec(),
-    argumentMode: 'text'
-  },
   // /compress must be an action (session.compress RPC), not exec: the slash
   // worker route times out on large sessions (30s WS / 45s pipe) before the
   // LLM summarise call finishes, then command.dispatch surfaces a bogus
@@ -258,26 +239,6 @@ const DESKTOP_COMMAND_SPECS: readonly DesktopCommandSpec[] = [
     aliases: ['/compact'],
     surface: action('compress'),
     argumentMode: 'text'
-  },
-  { name: '/debug', description: 'Create a debug report', surface: exec() },
-  {
-    name: '/goal',
-    description: 'Manage the standing goal for this session',
-    surface: exec(),
-    argumentMode: 'mixed'
-  },
-  {
-    name: '/loop',
-    description: 'Re-run a prompt on a recurring interval in this session',
-    aliases: ['/proactive'],
-    surface: exec(),
-    argumentMode: 'mixed'
-  },
-  {
-    name: '/personality',
-    description: 'Switch personality for this session',
-    surface: exec(),
-    argumentMode: 'options'
   },
   {
     name: '/pet',
@@ -292,15 +253,6 @@ const DESKTOP_COMMAND_SPECS: readonly DesktopCommandSpec[] = [
     surface: action('hatch')
   },
   {
-    name: '/queue',
-    description: 'Queue a prompt for the next turn',
-    aliases: ['/q'],
-    surface: exec(),
-    argumentMode: 'text'
-  },
-  { name: '/retry', description: 'Retry the last user message', surface: exec() },
-  { name: '/rollback', description: 'List or restore filesystem checkpoints', surface: exec() },
-  {
     name: '/save',
     description: 'Save the current transcript to JSON',
     surface: rpc('session.save', ctx => ({ session_id: ctx.sessionId }))
@@ -309,27 +261,7 @@ const DESKTOP_COMMAND_SPECS: readonly DesktopCommandSpec[] = [
     name: '/status',
     description: 'Show current session status',
     surface: rpc('session.status', ctx => ({ session_id: ctx.sessionId }))
-  },
-  {
-    name: '/steer',
-    description: 'Steer the current run after the next tool call',
-    surface: exec(),
-    argumentMode: 'text'
-  },
-  { name: '/stop', description: 'Stop running background processes', surface: exec() },
-  {
-    name: '/tools',
-    description: 'List or toggle tools available to the agent',
-    surface: exec(),
-    argumentMode: 'options'
-  },
-  { name: '/undo', description: 'Remove the last user/assistant exchange', surface: exec() },
-  { name: '/usage', description: 'Show token usage for this session', surface: exec() },
-  { name: '/version', description: 'Show Hermes Agent version', surface: exec() },
-
-  // No desktop surface, but carry an alias (underscore spelling variants).
-  { name: '/reload-mcp', aliases: ['/reload_mcp'], surface: unavailable('advanced') },
-  { name: '/reload-skills', aliases: ['/reload_skills'], surface: unavailable('advanced') }
+  }
 ]
 
 // Known commands with no desktop surface (and no alias) — a flat name list
@@ -370,7 +302,17 @@ const NO_DESKTOP_SURFACE: Record<DesktopUnavailableReason, readonly string[]> = 
   ],
   messaging: ['/approve', '/deny'],
   settings: ['/skills', '/pets'],
-  advanced: ['/curator', '/fast', '/insights', '/kanban', '/reasoning'],
+  advanced: [
+    '/curator',
+    '/fast',
+    '/insights',
+    '/kanban',
+    '/reasoning',
+    '/reload-mcp',
+    '/reload_mcp',
+    '/reload-skills',
+    '/reload_skills'
+  ],
   // /voice arms SERVER-side capture (voice.record → PortAudio on the backend
   // host) — meaningless on desktop, which has its own composer-native voice
   // conversation (mic menu / Ctrl+B) with client-side capture and playback.
@@ -390,6 +332,94 @@ const SPEC_BY_NAME = new Map<string, DesktopCommandSpec>(ALL_SPECS.map(spec => [
 const ALIAS_TO_CANONICAL = new Map<string, string>(
   ALL_SPECS.flatMap(spec => (spec.aliases ?? []).map(alias => [alias, spec.name] as const))
 )
+
+let rememberedCatalog: CommandsCatalogLike | undefined
+
+/** Last catalog the composer saw — used so Space/Enter know argument mode
+ *  without waiting for another `/` keystroke. */
+export function rememberDesktopCommandsCatalog(catalog: CommandsCatalogLike | undefined): void {
+  rememberedCatalog = catalog
+}
+
+function liveCatalog(): CommandsCatalogLike | undefined {
+  return rememberedCatalog ?? peekCachedSlashCompletion<CommandsCatalogLike>('catalog')
+}
+
+function catalogMeta(command: string): CommandCatalogMeta | undefined {
+  const commands = liveCatalog()?.commands
+  if (!commands) {
+    return undefined
+  }
+
+  const normalized = normalizeCommand(command)
+  const canonical = ALIAS_TO_CANONICAL.get(normalized) || catalogCanonical(normalized) || normalized
+
+  return commands[canonical] ?? commands[normalized]
+}
+
+function catalogCanonical(normalized: string): string | undefined {
+  const canon = liveCatalog()?.canon
+  if (!canon) {
+    return undefined
+  }
+
+  return canon[normalized] ?? canon[normalized.toLowerCase()]
+}
+
+function asUnavailableReason(value: string | null | undefined): DesktopUnavailableReason | null {
+  if (
+    value === 'advanced' ||
+    value === 'composer-voice' ||
+    value === 'messaging' ||
+    value === 'settings' ||
+    value === 'terminal'
+  ) {
+    return value
+  }
+
+  return null
+}
+
+function asArgumentMode(value: string | null | undefined): DesktopSlashArgumentMode | undefined {
+  if (value === 'options' || value === 'text' || value === 'mixed') {
+    return value
+  }
+
+  return undefined
+}
+
+function specFromCatalog(command: string): DesktopCommandSpec | null {
+  const entry = catalogMeta(command)
+  if (!entry) {
+    return null
+  }
+
+  const name = canonicalDesktopSlashCommand(command)
+  const reason = asUnavailableReason(entry.desktop)
+
+  if (reason) {
+    return { name, surface: unavailable(reason) }
+  }
+
+  return {
+    name,
+    surface: exec(),
+    hidden: entry.desktop === 'hidden',
+    argumentMode: asArgumentMode(entry.argument_mode)
+  }
+}
+
+function isAliasCommand(command: string): boolean {
+  const normalized = normalizeCommand(command)
+
+  if (ALIAS_TO_CANONICAL.has(normalized)) {
+    return true
+  }
+
+  const resolved = catalogCanonical(normalized)
+
+  return Boolean(resolved && resolved.toLowerCase() !== normalized)
+}
 
 const UNAVAILABLE_MESSAGE: Record<DesktopUnavailableReason, (command: string) => string> = {
   advanced: command =>
@@ -416,18 +446,22 @@ function normalizeCommand(command: string): string {
 export function canonicalDesktopSlashCommand(command: string): string {
   const normalized = normalizeCommand(command)
 
-  return ALIAS_TO_CANONICAL.get(normalized) || normalized
+  return ALIAS_TO_CANONICAL.get(normalized) || catalogCanonical(normalized) || normalized
 }
 
 /** Resolve a command (or alias) to its desktop spec, or null for unknown/extension commands. */
 export function resolveDesktopCommand(command: string): DesktopCommandSpec | null {
-  return SPEC_BY_NAME.get(canonicalDesktopSlashCommand(command)) ?? null
+  return SPEC_BY_NAME.get(canonicalDesktopSlashCommand(command)) ?? specFromCatalog(command)
 }
 
 function isKnownHermesSlashCommand(command: string): boolean {
   const normalized = normalizeCommand(command)
 
-  return SPEC_BY_NAME.has(normalized) || ALIAS_TO_CANONICAL.has(normalized)
+  if (SPEC_BY_NAME.has(normalized) || ALIAS_TO_CANONICAL.has(normalized)) {
+    return true
+  }
+
+  return catalogMeta(normalized) !== undefined
 }
 
 /**
@@ -446,6 +480,24 @@ export function isDesktopSlashExtensionCommand(command: string): boolean {
   return !isKnownHermesSlashCommand(normalized)
 }
 
+/**
+ * Popover group for a `complete.slash` row. The backend already tags each
+ * item `skill` | `command`; trust that so a new registry command isn't
+ * dumped into Skills just because this table has no row yet. Older backends
+ * omit `kind` — then the table is the fallback.
+ */
+export function slashCompletionGroup(command: string, kind?: string | null): 'Commands' | 'Skills' {
+  if (kind === 'skill') {
+    return 'Skills'
+  }
+
+  if (kind === 'command') {
+    return 'Commands'
+  }
+
+  return isDesktopSlashExtensionCommand(command) ? 'Skills' : 'Commands'
+}
+
 /** Gates execution: true unless the command is a known no-desktop-surface command. */
 export function isDesktopSlashCommand(command: string): boolean {
   const spec = resolveDesktopCommand(command)
@@ -462,11 +514,11 @@ export function isDesktopSlashSuggestion(command: string): boolean {
   const normalized = normalizeCommand(command)
 
   // Aliases stay hidden so the popover isn't cluttered with duplicates.
-  if (ALIAS_TO_CANONICAL.has(normalized)) {
+  if (isAliasCommand(normalized)) {
     return false
   }
 
-  const spec = SPEC_BY_NAME.get(normalized)
+  const spec = resolveDesktopCommand(normalized)
 
   if (spec) {
     return spec.surface.kind !== 'unavailable' && !spec.hidden
@@ -497,7 +549,7 @@ export function isModelPickerCommand(command: string): boolean {
 
 export function desktopSlashUnavailableMessage(command: string): string | null {
   const canonical = canonicalDesktopSlashCommand(command)
-  const surface = SPEC_BY_NAME.get(canonical)?.surface
+  const surface = resolveDesktopCommand(canonical)?.surface
 
   if (!surface) {
     return null
@@ -519,7 +571,7 @@ export function desktopSlashDescription(command: string, fallback = ''): string 
 }
 
 export function desktopSlashCommandArgumentMode(command: string): DesktopSlashArgumentMode | null {
-  return resolveDesktopCommand(command)?.argumentMode ?? null
+  return resolveDesktopCommand(command)?.argumentMode ?? asArgumentMode(catalogMeta(command)?.argument_mode) ?? null
 }
 
 export function desktopSkinSlashCompletions(
@@ -592,6 +644,8 @@ export function rankSkillCommands<T extends { text: string }>(
 }
 
 export function filterDesktopCommandsCatalog(catalog: CommandsCatalogLike): CommandsCatalogLike {
+  rememberDesktopCommandsCatalog(catalog)
+
   const categories = catalog.categories
     ?.map(section => ({
       ...section,

--- a/apps/desktop/src/lib/desktop-slash-commands.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.ts
@@ -347,6 +347,7 @@ function liveCatalog(): CommandsCatalogLike | undefined {
 
 function catalogMeta(command: string): CommandCatalogMeta | undefined {
   const commands = liveCatalog()?.commands
+
   if (!commands) {
     return undefined
   }
@@ -359,6 +360,7 @@ function catalogMeta(command: string): CommandCatalogMeta | undefined {
 
 function catalogCanonical(normalized: string): string | undefined {
   const canon = liveCatalog()?.canon
+
   if (!canon) {
     return undefined
   }
@@ -390,6 +392,7 @@ function asArgumentMode(value: string | null | undefined): DesktopSlashArgumentM
 
 function specFromCatalog(command: string): DesktopCommandSpec | null {
   const entry = catalogMeta(command)
+
   if (!entry) {
     return null
   }

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -17,7 +17,7 @@ import shutil
 import subprocess
 import time
 from collections.abc import Callable, Mapping
-from dataclasses import dataclass, field, replace
+from dataclasses import dataclass, field
 from typing import Any, Dict, Optional, Tuple
 
 from utils import is_truthy_value
@@ -154,11 +154,11 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("topic", "Enable or inspect Telegram DM topic sessions", "Session",
                gateway_only=True, args_hint="[off|help|session-id]"),
     CommandDef("clear", "Clear screen and start a new session", "Session",
-               cli_only=True),
+               cli_only=True, desktop="terminal"),
     CommandDef("redraw", "Force a full UI repaint (recovers from terminal drift)", "Session",
-               cli_only=True),
+               cli_only=True, desktop="terminal"),
     CommandDef("history", "Show conversation history", "Session",
-               cli_only=True),
+               cli_only=True, desktop="terminal"),
     CommandDef("save", "Export the current conversation (bare /save shows usage)", "Session",
                args_hint="<json|md|html> [filename] [redact]"),
     CommandDef("retry", "Retry the last message (resend to agent)", "Session"),
@@ -169,7 +169,7 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("title", "Set a title for the current session", "Session",
                args_hint="[name]"),
     CommandDef("handoff", "Hand off this session to a messaging platform (Telegram, Discord, etc.)", "Session",
-               args_hint="<platform>", cli_only=True),
+               args_hint="<platform>", cli_only=True, argument_mode="options"),
     CommandDef("branch", "Branch the current session (explore a different path)", "Session",
                aliases=("fork",), args_hint="[name]"),
     CommandDef("worktree", "Show, list, create, or prune isolated git worktrees", "Session",
@@ -180,7 +180,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("rollback", "List or restore filesystem checkpoints (restores keep your hand-edits; --all overrides)", "Session",
                args_hint="[number] [--all]"),
     CommandDef("snapshot", "Create or restore state snapshots of Hermes config/state", "Session",
-               cli_only=True, aliases=("snap",), args_hint="[create|restore <id>|prune]"),
+               cli_only=True, aliases=("snap",), args_hint="[create|restore <id>|prune]",
+               desktop="terminal"),
     CommandDef("export", "Export a profile (config, skills, theme) to a shareable archive", "Configuration",
                cli_only=True, args_hint="[profile] [-o output.tar.gz]"),
     CommandDef("import", "Import a shared profile archive as a new profile", "Configuration",
@@ -191,9 +192,11 @@ COMMAND_REGISTRY: list[CommandDef] = [
                gateway_only=True, args_hint="[reason | off]",
                busy_policy="dispatch"),
     CommandDef("approve", "Approve a pending dangerous command", "Session",
-               gateway_only=True, args_hint="[session|always]", busy_policy="dispatch"),
+               gateway_only=True, args_hint="[session|always]", busy_policy="dispatch",
+               desktop="messaging"),
     CommandDef("deny", "Deny a pending dangerous command (optionally with a reason)", "Session",
-               gateway_only=True, args_hint="[all] [reason]", busy_policy="dispatch"),
+               gateway_only=True, args_hint="[all] [reason]", busy_policy="dispatch",
+               desktop="messaging"),
     CommandDef("background", "Run a prompt in the background", "Session",
                aliases=("bg", "btw"), args_hint="<prompt>", busy_policy="dispatch"),
     CommandDef("agents", "Show active agents and running tasks", "Session",
@@ -209,7 +212,7 @@ COMMAND_REGISTRY: list[CommandDef] = [
                args_hint="<prompt>", busy_policy="dispatch", busy_handler="steer"),
     CommandDef("goal", "Set a standing goal Hermes works on across turns until achieved", "Session",
                args_hint="[text | draft <text> | show | gate add <cmd> | pause | resume | clear | status | wait <pid> | unwait]",
-               busy_policy="dispatch", busy_handler="goal"),
+               argument_mode="mixed", busy_policy="dispatch", busy_handler="goal"),
     CommandDef("heartbeat", "Set a recurring prompt that re-enters this session when idle", "Session",
                aliases=("hb",), args_hint="[every <interval> <prompt> | status | pause | resume | clear]",
                subcommands=("status", "pause", "resume", "clear"),
@@ -221,7 +224,7 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("loop", "Re-run a prompt on a recurring interval in this session", "Session",
                aliases=("proactive",),
                args_hint="[interval] <prompt> [--times N] [--until <condition>] | status | pause | resume | stop",
-               busy_policy="dispatch", busy_handler="loop"),
+               argument_mode="mixed", busy_policy="dispatch", busy_handler="loop"),
     CommandDef("moa", "Run one prompt through the default Mixture of Agents preset, then restore your model", "Session",
                args_hint="<prompt>", busy_policy="reject", busy_handler="moa"),
     CommandDef("subgoal", "Add or manage extra criteria on the active goal", "Session",
@@ -239,28 +242,28 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("profile", "Show active profile name and home directory", "Info",
                busy_policy="dispatch", execute="profile"),
     CommandDef("sethome", "Set this chat as the home channel", "Session",
-               gateway_only=True, aliases=("set-home",)),
+               gateway_only=True, aliases=("set-home",), desktop="terminal"),
     CommandDef("resume", "Resume a previously-named session", "Session",
-               args_hint="[name]"),
+               args_hint="[name]", argument_mode="mixed"),
 
     # Configuration
     CommandDef("sessions", "Browse and resume previous sessions", "Session"),
 
     # Configuration
     CommandDef("config", "Show current configuration", "Configuration",
-               cli_only=True),
+               cli_only=True, desktop="terminal"),
     CommandDef("model", "Switch model (session-scoped; --global to persist)", "Configuration",
                args_hint="[model] [--provider name] [--global|--session] [--refresh]",
-               busy_policy="reject", busy_handler="model"),
+               busy_policy="reject", busy_handler="model", desktop="hidden"),
     CommandDef("codex-runtime", "Toggle codex app-server runtime for OpenAI/Codex models",
                "Configuration", aliases=("codex_runtime",),
                args_hint="[auto|codex_app_server]",
                busy_policy="reject", busy_handler="codex-runtime"),
 
     CommandDef("personality", "Set a predefined personality", "Configuration",
-               args_hint="[name]"),
+               args_hint="[name]", argument_mode="options"),
     CommandDef("statusbar", "Toggle the context/model status bar", "Configuration",
-               cli_only=True, aliases=("sb",)),
+               cli_only=True, aliases=("sb",), desktop="terminal"),
     CommandDef("battery", "Toggle a color-coded battery indicator in the status bar",
                "Configuration", cli_only=True, args_hint="[on|off|status]",
                subcommands=("on", "off", "status")),
@@ -273,13 +276,14 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("verbose", "Cycle tool progress display: off -> new -> all -> verbose",
                "Configuration", cli_only=True,
                gateway_config_gate="display.tool_progress_command",
-               busy_policy="dispatch"),
+               busy_policy="dispatch", desktop="terminal"),
     CommandDef("focus", "Toggle focus view — show only your prompt and the final response",
                "Configuration", cli_only=True, args_hint="[on|off|status]",
                subcommands=("on", "off", "status")),
     CommandDef("footer", "Toggle gateway runtime-metadata footer on final replies",
                "Configuration", args_hint="[on|off|status]",
-               subcommands=("on", "off", "status"), busy_policy="dispatch"),
+               subcommands=("on", "off", "status"), busy_policy="dispatch",
+               desktop="terminal"),
     CommandDef("yolo", "Toggle YOLO mode (skip all dangerous command approvals)",
                "Configuration", busy_policy="dispatch"),
     CommandDef("approvals", "Show or set the persistent dangerous-command approval mode",
@@ -287,34 +291,40 @@ COMMAND_REGISTRY: list[CommandDef] = [
                subcommands=("manual", "smart", "off")),
     CommandDef("reasoning", "Manage reasoning effort and display", "Configuration",
                args_hint="[level|show|hide|full|clamp] [--global]",
-               subcommands=("none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra", "show", "hide", "on", "off", "full", "clamp", "--global")),
+               subcommands=("none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra", "show", "hide", "on", "off", "full", "clamp", "--global"),
+               desktop="advanced"),
     CommandDef("fast", "Toggle fast mode — OpenAI Priority Processing / Anthropic Fast Mode (Normal/Fast)", "Configuration",
                args_hint="[normal|fast|status] [--global]",
-               subcommands=("normal", "fast", "status", "on", "off", "--global")),
+               subcommands=("normal", "fast", "status", "on", "off", "--global"),
+               desktop="advanced"),
     CommandDef("skin", "Show or change the display skin/theme", "Configuration",
-               cli_only=True, args_hint="[name]"),
+               cli_only=True, args_hint="[name]", argument_mode="options"),
     CommandDef("indicator", "Pick the TUI busy-indicator style", "Configuration",
                cli_only=True, args_hint=f"[{'|'.join(INDICATOR_STYLES)}]",
-               subcommands=INDICATOR_STYLES),
+               subcommands=INDICATOR_STYLES, desktop="terminal"),
     CommandDef("voice", "Toggle voice mode", "Configuration",
-               args_hint="[on|off|tts|status]", subcommands=("on", "off", "tts", "status")),
+               args_hint="[on|off|tts|status]", subcommands=("on", "off", "tts", "status"),
+               desktop="composer-voice"),
     CommandDef("wake", "Toggle the 'Hey Hermes' wake word listener", "Configuration",
                cli_only=True, args_hint="[on|off|status]",
                subcommands=("on", "off", "status")),
     CommandDef("busy", "Control what Enter does while Hermes is working", "Configuration",
                cli_only=True, args_hint="[queue|steer|interrupt|status]",
-               subcommands=("queue", "steer", "interrupt", "status")),
+               subcommands=("queue", "steer", "interrupt", "status"),
+               desktop="terminal"),
 
     # Tools & Skills
     CommandDef("tools", "Manage tools: /tools [list|disable|enable] [name...]", "Tools & Skills",
-               args_hint="[list|disable|enable] [name...]", cli_only=True),
+               args_hint="[list|disable|enable] [name...]", cli_only=True,
+               argument_mode="options"),
     CommandDef("toolsets", "List available toolsets", "Tools & Skills",
-               cli_only=True),
+               cli_only=True, desktop="terminal"),
     CommandDef("skills", "Search, install, inspect, or manage skills",
                "Tools & Skills", cli_only=True,
                gateway_config_gate="skills.write_approval",
                subcommands=("search", "browse", "inspect", "install", "audit",
-                            "pending", "approve", "reject", "diff", "approval")),
+                            "pending", "approve", "reject", "diff", "approval"),
+               desktop="settings"),
     CommandDef("memory", "Review pending memory writes / toggle the approval gate",
                "Tools & Skills",
                args_hint="[pending|approve|reject|approval] [id|on|off]",
@@ -331,7 +341,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                "Tools & Skills", args_hint="[notes]"),
     CommandDef("cron", "Manage scheduled tasks", "Tools & Skills",
                cli_only=True, args_hint="[subcommand]",
-               subcommands=("list", "add", "create", "edit", "pause", "resume", "run", "remove")),
+               subcommands=("list", "add", "create", "edit", "pause", "resume", "run", "remove"),
+               desktop="terminal"),
     CommandDef("suggestions", "Review suggested automations (accept/dismiss)",
                "Tools & Skills", aliases=("suggest",), args_hint="[accept|dismiss N | catalog]",
                subcommands=("accept", "dismiss", "catalog", "clear")),
@@ -339,7 +350,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                "Tools & Skills", aliases=("bp",), args_hint="[name] [slot=value ...]"),
     CommandDef("curator", "Background skill maintenance (status, run, pin, archive, list-archived)",
                "Tools & Skills", args_hint="[subcommand]",
-               subcommands=("status", "run", "pause", "resume", "pin", "unpin", "restore", "list-archived")),
+               subcommands=("status", "run", "pause", "resume", "pin", "unpin", "restore", "list-archived"),
+               desktop="advanced"),
     CommandDef("kanban", "Multi-profile collaboration board (tasks, links, comments)",
                "Tools & Skills", args_hint="[subcommand]",
                subcommands=("init", "boards", "create", "list", "ls", "show", "assign",
@@ -348,18 +360,18 @@ COMMAND_REGISTRY: list[CommandDef] = [
                             "archive", "tail", "dispatch", "stats", "notify-subscribe",
                             "notify-list", "notify-unsubscribe", "log", "runs",
                             "heartbeat", "assignees", "context", "specify", "gc"),
-               busy_policy="dispatch"),
+               busy_policy="dispatch", desktop="advanced"),
     CommandDef("reload", "Reload .env variables into the running session", "Tools & Skills",
-               cli_only=True),
+               cli_only=True, desktop="terminal"),
     CommandDef("reload-mcp", "Reload MCP servers from config", "Tools & Skills",
-               aliases=("reload_mcp",)),
+               aliases=("reload_mcp",), desktop="advanced"),
     CommandDef("reload-skills", "Re-scan ~/.hermes/skills/ for newly installed or removed skills",
-               "Tools & Skills", aliases=("reload_skills",)),
+               "Tools & Skills", aliases=("reload_skills",), desktop="advanced"),
     CommandDef("browser", "Connect browser tools to your live Chromium-family browser via CDP, or switch to Browser Use mode", "Tools & Skills",
                cli_only=True, args_hint="[connect|disconnect|status|use]",
                subcommands=("connect", "disconnect", "status", "use")),
     CommandDef("plugins", "List installed plugins and their status",
-               "Tools & Skills", cli_only=True),
+               "Tools & Skills", cli_only=True, desktop="terminal"),
 
     # Info
     CommandDef("commands", "Browse all commands and skills (paginated)", "Info",
@@ -370,26 +382,26 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("palette", "Open the fuzzy command palette (also Ctrl+P)", "Info",
                cli_only=True, busy_policy="dispatch"),
     CommandDef("restart", "Gracefully restart the gateway after draining active runs", "Session",
-               gateway_only=True, busy_policy="dispatch"),
+               gateway_only=True, busy_policy="dispatch", desktop="terminal"),
     CommandDef("usage", "Show token usage and rate limits; `reset` redeems a banked Codex limit reset", "Info",
                args_hint="[reset [--force]]"),
     CommandDef("subscription", "View your Nous plan and change it in the browser", "Info",
                cli_only=True, aliases=("upgrade",)),
     CommandDef("topup", "Show your Nous balance and manage billing on the portal", "Info"),
     CommandDef("insights", "Show usage insights and analytics", "Info",
-               args_hint="[days]"),
+               args_hint="[days]", desktop="advanced"),
     CommandDef("platforms", "Show gateway/messaging platform status", "Info",
-               cli_only=True, aliases=("gateway",)),
+               cli_only=True, aliases=("gateway",), desktop="terminal"),
     CommandDef("platform", "Pause, resume, or list a failing gateway platform", "Info",
                gateway_only=True, args_hint="<pause|resume|list> [name]"),
     CommandDef("copy", "Copy the last assistant response to clipboard", "Info",
-               cli_only=True, args_hint="[number]"),
+               cli_only=True, args_hint="[number]", desktop="terminal"),
     CommandDef("paste", "Attach clipboard image from your clipboard", "Info",
-               cli_only=True),
+               cli_only=True, desktop="terminal"),
     CommandDef("image", "Attach a local image file for your next prompt", "Info",
-               cli_only=True, args_hint="<path>"),
+               cli_only=True, args_hint="<path>", desktop="terminal"),
     CommandDef("update", "Update Hermes Agent to the latest version", "Info",
-               busy_policy="dispatch"),
+               busy_policy="dispatch", desktop="terminal"),
     CommandDef("version", "Show Hermes Agent version", "Info", aliases=("v",),
                busy_policy="dispatch", execute="version"),
     CommandDef("debug", "Upload debug report (system info + logs) and get shareable links", "Info",
@@ -397,80 +409,23 @@ COMMAND_REGISTRY: list[CommandDef] = [
 
     # Exit
     CommandDef("quit", "Exit the CLI (use --delete to also remove session history)", "Exit",
-               cli_only=True, aliases=("exit",), args_hint="[--delete]"),
+               cli_only=True, aliases=("exit",), args_hint="[--delete]",
+               desktop="terminal"),
 ]
 
 
-# Desktop composer / popover metadata. Lives next to the registry so a new
-# CommandDef can declare how desktop should treat it — the TS table is only
-# the local-action overlay (pickers, Electron actions, dedicated RPCs).
-_DESKTOP_UNAVAILABLE: dict[str, str] = {
-    "busy": "terminal",
-    "clear": "terminal",
-    "config": "terminal",
-    "copy": "terminal",
-    "cron": "terminal",
-    "density": "terminal",
-    "details": "terminal",
-    "footer": "terminal",
-    "gateway": "terminal",
-    "history": "terminal",
-    "image": "terminal",
-    "indicator": "terminal",
-    "logs": "terminal",
-    "mouse": "terminal",
-    "paste": "terminal",
-    "platforms": "terminal",
-    "plugins": "terminal",
-    "quit": "terminal",
-    "redraw": "terminal",
-    "reload": "terminal",
-    "restart": "terminal",
-    "sethome": "terminal",
-    "snapshot": "terminal",
-    "statusbar": "terminal",
-    "toolsets": "terminal",
-    "update": "terminal",
-    "verbose": "terminal",
-    "approve": "messaging",
-    "deny": "messaging",
-    "skills": "settings",
-    "pets": "settings",
-    "curator": "advanced",
-    "fast": "advanced",
-    "insights": "advanced",
-    "kanban": "advanced",
-    "reasoning": "advanced",
-    "reload-mcp": "advanced",
-    "reload-skills": "advanced",
-    "voice": "composer-voice",
-}
-
-_DESKTOP_HIDDEN: frozenset[str] = frozenset({"model"})
-
-# Only the cases ``args_hint`` / ``subcommands`` would get wrong.
-_ARGUMENT_MODE_OVERRIDES: dict[str, str] = {
-    "goal": "mixed",
-    "handoff": "options",
-    "loop": "mixed",
-    "personality": "options",
-    "resume": "mixed",
-    "skin": "options",
-    "tools": "options",
-}
-
-_TEXT_HINTS = ("<prompt>", "[text", "instructions", "[interval]", "<what", "[focus", "[review")
+# Used only to distinguish ``mixed`` (subcommands plus free-text) from
+# ``options`` (subcommand list only). A bare ``args_hint`` with no
+# subcommands is always ``text`` — do not add tokens here for that path.
+_PROSE_HINTS = ("<prompt>", "[text", "instructions", "[interval]", "<what")
 
 
 def infer_argument_mode(cmd: CommandDef) -> str | None:
-    """Composer mode for a command: explicit, override, or inferred from args."""
+    """Composer mode: explicit on the CommandDef, else inferred from its args."""
     if cmd.argument_mode in {"options", "text", "mixed"}:
         return cmd.argument_mode
-    override = _ARGUMENT_MODE_OVERRIDES.get(cmd.name)
-    if override:
-        return override
-    hint = (cmd.args_hint or "").lower()
-    if cmd.subcommands and hint and any(token in hint for token in _TEXT_HINTS):
+    hint = (cmd.args_hint or "").strip()
+    if cmd.subcommands and hint and any(token in hint.lower() for token in _PROSE_HINTS):
         return "mixed"
     if cmd.subcommands:
         return "options"
@@ -480,26 +435,8 @@ def infer_argument_mode(cmd: CommandDef) -> str | None:
 
 
 def command_desktop_meta(cmd: CommandDef) -> dict[str, str | None]:
-    """Wire shape for ``commands.catalog`` — argument mode + desktop availability."""
-    desktop = cmd.desktop
-    if desktop is None and cmd.name in _DESKTOP_HIDDEN:
-        desktop = "hidden"
-    if desktop is None:
-        desktop = _DESKTOP_UNAVAILABLE.get(cmd.name)
-    return {"argument_mode": infer_argument_mode(cmd), "desktop": desktop}
-
-
-def _apply_desktop_fields(cmds: list[CommandDef]) -> list[CommandDef]:
-    applied: list[CommandDef] = []
-    for cmd in cmds:
-        meta = command_desktop_meta(cmd)
-        if meta["argument_mode"] != cmd.argument_mode or meta["desktop"] != cmd.desktop:
-            cmd = replace(cmd, argument_mode=meta["argument_mode"], desktop=meta["desktop"])
-        applied.append(cmd)
-    return applied
-
-
-COMMAND_REGISTRY = _apply_desktop_fields(COMMAND_REGISTRY)
+    """Wire shape for ``commands.catalog`` — reads the CommandDef, nothing else."""
+    return {"argument_mode": infer_argument_mode(cmd), "desktop": cmd.desktop}
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -17,7 +17,7 @@ import shutil
 import subprocess
 import time
 from collections.abc import Callable, Mapping
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import Any, Dict, Optional, Tuple
 
 from utils import is_truthy_value
@@ -127,6 +127,11 @@ class CommandDef:
     # gateway can import commands.py without prompt_toolkit and without
     # pulling in executor dependencies.
     execute: str | None = None
+    # Desktop composer: ``options`` | ``text`` | ``mixed``. ``None`` is inferred.
+    argument_mode: str | None = None
+    # Desktop availability. ``None`` = offered; ``hidden`` = runs but stays out
+    # of the popover; otherwise a reason (terminal / messaging / settings / …).
+    desktop: str | None = None
 
 
 # Valid values for CommandDef.busy_policy (see field docs above).
@@ -394,6 +399,107 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("quit", "Exit the CLI (use --delete to also remove session history)", "Exit",
                cli_only=True, aliases=("exit",), args_hint="[--delete]"),
 ]
+
+
+# Desktop composer / popover metadata. Lives next to the registry so a new
+# CommandDef can declare how desktop should treat it — the TS table is only
+# the local-action overlay (pickers, Electron actions, dedicated RPCs).
+_DESKTOP_UNAVAILABLE: dict[str, str] = {
+    "busy": "terminal",
+    "clear": "terminal",
+    "config": "terminal",
+    "copy": "terminal",
+    "cron": "terminal",
+    "density": "terminal",
+    "details": "terminal",
+    "footer": "terminal",
+    "gateway": "terminal",
+    "history": "terminal",
+    "image": "terminal",
+    "indicator": "terminal",
+    "logs": "terminal",
+    "mouse": "terminal",
+    "paste": "terminal",
+    "platforms": "terminal",
+    "plugins": "terminal",
+    "quit": "terminal",
+    "redraw": "terminal",
+    "reload": "terminal",
+    "restart": "terminal",
+    "sethome": "terminal",
+    "snapshot": "terminal",
+    "statusbar": "terminal",
+    "toolsets": "terminal",
+    "update": "terminal",
+    "verbose": "terminal",
+    "approve": "messaging",
+    "deny": "messaging",
+    "skills": "settings",
+    "pets": "settings",
+    "curator": "advanced",
+    "fast": "advanced",
+    "insights": "advanced",
+    "kanban": "advanced",
+    "reasoning": "advanced",
+    "reload-mcp": "advanced",
+    "reload-skills": "advanced",
+    "voice": "composer-voice",
+}
+
+_DESKTOP_HIDDEN: frozenset[str] = frozenset({"model"})
+
+# Only the cases ``args_hint`` / ``subcommands`` would get wrong.
+_ARGUMENT_MODE_OVERRIDES: dict[str, str] = {
+    "goal": "mixed",
+    "handoff": "options",
+    "loop": "mixed",
+    "personality": "options",
+    "resume": "mixed",
+    "skin": "options",
+    "tools": "options",
+}
+
+_TEXT_HINTS = ("<prompt>", "[text", "instructions", "[interval]", "<what", "[focus", "[review")
+
+
+def infer_argument_mode(cmd: CommandDef) -> str | None:
+    """Composer mode for a command: explicit, override, or inferred from args."""
+    if cmd.argument_mode in {"options", "text", "mixed"}:
+        return cmd.argument_mode
+    override = _ARGUMENT_MODE_OVERRIDES.get(cmd.name)
+    if override:
+        return override
+    hint = (cmd.args_hint or "").lower()
+    if cmd.subcommands and hint and any(token in hint for token in _TEXT_HINTS):
+        return "mixed"
+    if cmd.subcommands:
+        return "options"
+    if hint:
+        return "text"
+    return None
+
+
+def command_desktop_meta(cmd: CommandDef) -> dict[str, str | None]:
+    """Wire shape for ``commands.catalog`` — argument mode + desktop availability."""
+    desktop = cmd.desktop
+    if desktop is None and cmd.name in _DESKTOP_HIDDEN:
+        desktop = "hidden"
+    if desktop is None:
+        desktop = _DESKTOP_UNAVAILABLE.get(cmd.name)
+    return {"argument_mode": infer_argument_mode(cmd), "desktop": desktop}
+
+
+def _apply_desktop_fields(cmds: list[CommandDef]) -> list[CommandDef]:
+    applied: list[CommandDef] = []
+    for cmd in cmds:
+        meta = command_desktop_meta(cmd)
+        if meta["argument_mode"] != cmd.argument_mode or meta["desktop"] != cmd.desktop:
+            cmd = replace(cmd, argument_mode=meta["argument_mode"], desktop=meta["desktop"])
+        applied.append(cmd)
+    return applied
+
+
+COMMAND_REGISTRY = _apply_desktop_fields(COMMAND_REGISTRY)
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -2182,6 +2182,7 @@ class PluginContext:
         handler: Callable,
         description: str = "",
         args_hint: str = "",
+        argument_mode: str | None = None,
     ) -> Optional[PluginRegistration]:
         """Register a slash command (e.g. ``/lcm``) available in CLI and gateway sessions.
 
@@ -2198,6 +2199,10 @@ class PluginContext:
         command picker. Plugin commands without ``args_hint`` register as
         parameterless in Discord and still accept trailing text when invoked
         as free-form chat.
+
+        ``argument_mode`` tells the desktop composer how text after the command
+        name behaves (``options``, ``text``, or ``mixed``). Omit it to infer
+        ``text`` whenever ``args_hint`` is set, so ``/myplugin `` stays typeable.
 
         Names conflicting with built-in commands are rejected with a warning.
         """
@@ -2223,12 +2228,17 @@ class PluginContext:
             pass  # If commands module isn't available, skip the check
 
         previous = self._manager._plugin_commands.get(clean)
+        hint = (args_hint or "").strip()
+        mode = argument_mode if argument_mode in {"options", "text", "mixed"} else (
+            "text" if hint else None
+        )
         entry = {
             "handler": handler,
             "description": description or "Plugin command",
             "plugin": self.manifest.name,
             "plugin_key": self.manifest.key or self.manifest.name,
-            "args_hint": (args_hint or "").strip(),
+            "args_hint": hint,
+            "argument_mode": mode,
         }
         self._manager._plugin_commands[clean] = entry
         handle = self._track_replacement(

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -74,11 +74,11 @@ class TestCommandRegistry:
                     assert resolve_command(alias).name == cmd.name or alias == cmd.name, \
                         f"Alias '{alias}' of '{cmd.name}' shadows canonical '{target.name}'"
 
-    def test_desktop_meta_marks_review_typeable_and_terminal_hidden(self):
+    def test_desktop_meta_lives_on_the_command_def(self):
         review = resolve_command("review")
         assert review is not None
-        assert review.argument_mode == "text"
-        assert review.desktop is None
+        assert review.argument_mode is None
+        assert infer_argument_mode(review) == "text"
         assert command_desktop_meta(review) == {"argument_mode": "text", "desktop": None}
 
         clear = resolve_command("clear")
@@ -89,9 +89,14 @@ class TestCommandRegistry:
         assert model is not None
         assert model.desktop == "hidden"
 
-    def test_argument_mode_infers_text_from_args_hint(self):
-        cmd = CommandDef("demo", "Demo", "Session", args_hint="<prompt>")
-        assert infer_argument_mode(cmd) == "text"
+        goal = resolve_command("goal")
+        assert goal is not None
+        assert goal.argument_mode == "mixed"
+
+    def test_argument_mode_infers_text_from_any_args_hint(self):
+        assert infer_argument_mode(CommandDef("demo", "Demo", "Session", args_hint="<prompt>")) == "text"
+        assert infer_argument_mode(CommandDef("ask", "Ask", "Session", args_hint="<query>")) == "text"
+        assert infer_argument_mode(CommandDef("note", "Note", "Session", args_hint="[message]")) == "text"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -19,8 +19,10 @@ from hermes_cli.commands import (
     _clamp_command_names,
     _clamp_telegram_names,
     _sanitize_telegram_name,
+    command_desktop_meta,
     discord_skill_commands,
     gateway_help_lines,
+    infer_argument_mode,
     resolve_command,
     slack_app_manifest,
     slack_native_slashes,
@@ -72,8 +74,24 @@ class TestCommandRegistry:
                     assert resolve_command(alias).name == cmd.name or alias == cmd.name, \
                         f"Alias '{alias}' of '{cmd.name}' shadows canonical '{target.name}'"
 
+    def test_desktop_meta_marks_review_typeable_and_terminal_hidden(self):
+        review = resolve_command("review")
+        assert review is not None
+        assert review.argument_mode == "text"
+        assert review.desktop is None
+        assert command_desktop_meta(review) == {"argument_mode": "text", "desktop": None}
 
+        clear = resolve_command("clear")
+        assert clear is not None
+        assert clear.desktop == "terminal"
 
+        model = resolve_command("model")
+        assert model is not None
+        assert model.desktop == "hidden"
+
+    def test_argument_mode_infers_text_from_args_hint(self):
+        cmd = CommandDef("demo", "Demo", "Session", args_hint="<prompt>")
+        assert infer_argument_mode(cmd) == "text"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -1946,6 +1946,17 @@ class TestPluginCommands:
         assert len(mgr._plugin_commands) == 0
         assert "empty name" in caplog.text
 
+    def test_register_command_infers_text_argument_mode_from_args_hint(self):
+        mgr = PluginManager()
+        manifest = PluginManifest(name="test-plugin", source="user")
+        ctx = PluginContext(manifest, mgr)
+
+        ctx.register_command("lcm", lambda a: a, description="LCM", args_hint="<prompt>")
+        ctx.register_command("ping", lambda a: a, description="Ping")
+
+        assert mgr._plugin_commands["lcm"]["argument_mode"] == "text"
+        assert mgr._plugin_commands["ping"]["argument_mode"] is None
+
 
 
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -10718,6 +10718,49 @@ def test_commands_catalog_filters_gateway_only_commands_and_keeps_status_visible
     assert "/set-home" not in canon
 
 
+def test_commands_catalog_includes_desktop_meta_without_skills():
+    resp = server.handle_request(
+        {"id": "1", "method": "commands.catalog", "params": {}}
+    )
+
+    commands = resp["result"]["commands"]
+    assert commands["/review"] == {"argument_mode": "text", "desktop": None}
+    assert commands["/clear"]["desktop"] == "terminal"
+    assert commands["/model"]["desktop"] == "hidden"
+    assert commands["/compact"]["argument_mode"] == commands["/compress"]["argument_mode"]
+
+    for skill in resp["result"]["skills"]:
+        assert skill not in commands
+
+
+def test_commands_catalog_includes_plugin_commands(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.plugins.get_plugin_commands",
+        lambda: {
+            "lcm": {
+                "description": "Latent consistency",
+                "args_hint": "<prompt>",
+                "argument_mode": "text",
+            }
+        },
+    )
+
+    resp = server.handle_request(
+        {"id": "1", "method": "commands.catalog", "params": {}}
+    )
+
+    assert resp["result"]["commands"]["/lcm"] == {
+        "argument_mode": "text",
+        "desktop": None,
+    }
+    pairs = dict(resp["result"]["pairs"])
+    assert "/lcm" in pairs
+    plugin_cat = next(
+        c for c in resp["result"]["categories"] if c["name"] == "Plugin commands"
+    )
+    assert "/lcm" in dict(plugin_cat["pairs"])
+
+
 def test_session_status_reads_live_gateway_agent(monkeypatch):
     agent = types.SimpleNamespace(
         model="live-model",

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -260,15 +260,22 @@ def _(rid, params: dict) -> dict:
             COMMAND_REGISTRY,
             SUBCOMMANDS,
             _build_description,
+            command_desktop_meta,
         )
 
         all_pairs: list[list[str]] = []
         canon: dict[str, str] = {}
+        commands: dict[str, dict[str, str | None]] = {}
         categories: list[dict] = []
         cat_map: dict[str, list[list[str]]] = {}
         cat_order: list[str] = []
 
         for cmd in COMMAND_REGISTRY:
+            meta = command_desktop_meta(cmd)
+            commands[f"/{cmd.name}"] = meta
+            for alias in cmd.aliases:
+                commands[f"/{alias}"] = meta
+
             if cmd.name in _TUI_HIDDEN or cmd.gateway_only:
                 continue
 
@@ -328,6 +335,35 @@ def _(rid, params: dict) -> dict:
             if not warning:
                 warning = f"quick_commands discovery unavailable: {e}"
 
+        try:
+            from hermes_cli.plugins import get_plugin_commands
+
+            plugin_cmds = get_plugin_commands() or {}
+            if plugin_cmds:
+                bucket = "Plugin commands"
+                if bucket not in cat_map:
+                    cat_map[bucket] = []
+                    cat_order.append(bucket)
+                for pname, info in sorted(plugin_cmds.items()):
+                    if not isinstance(info, dict):
+                        continue
+                    key = f"/{pname}"
+                    if key.lower() in canon:
+                        continue
+                    canon[key.lower()] = key
+                    pdesc = str(info.get("description") or "Plugin command")
+                    pdesc = pdesc[:120] + ("…" if len(pdesc) > 120 else "")
+                    all_pairs.append([key, pdesc])
+                    cat_map[bucket].append([key, pdesc])
+                    hint = str(info.get("args_hint") or "").strip()
+                    mode = info.get("argument_mode")
+                    if mode not in {"options", "text", "mixed"}:
+                        mode = "text" if hint else None
+                    commands[key] = {"argument_mode": mode, "desktop": None}
+        except Exception as e:
+            if not warning:
+                warning = f"plugin command discovery unavailable: {e}"
+
         skill_count = 0
         skills: dict[str, dict] = {}
         try:
@@ -358,6 +394,7 @@ def _(rid, params: dict) -> dict:
                 "pairs": all_pairs,
                 "sub": sub,
                 "canon": canon,
+                "commands": commands,
                 "categories": categories,
                 "skills": skills,
                 "skill_count": skill_count,

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -272,9 +272,9 @@ def _(rid, params: dict) -> dict:
 
         for cmd in COMMAND_REGISTRY:
             meta = command_desktop_meta(cmd)
-            commands[f"/{cmd.name}"] = meta
+            commands[f"/{cmd.name}"] = dict(meta)
             for alias in cmd.aliases:
-                commands[f"/{alias}"] = meta
+                commands[f"/{alias}"] = dict(meta)
 
             if cmd.name in _TUI_HIDDEN or cmd.gateway_only:
                 continue


### PR DESCRIPTION
## What does this PR do?

The desktop slash popover kept a second copy of every command. Typing `/review` and pressing space swapped it for leftover `/compress`: Space accepted whatever row was highlighted, and registry names the table had never heard of (`/review`, `/refine`, `/memory`, plugin commands) were labeled skills and usage-sorted under the real ones.

`COMMAND_REGISTRY` now owns `argument_mode` and `desktop`. `commands.catalog` sends that map for built-ins and plugin commands (skills stay out of it). The desktop table is only local actions, pickers, and RPCs. A new command or plugin declares composer behavior on the registry instead of a TypeScript row.

Space and Enter still complete a prefix (`/com` → `/compress`) and keep an exactly typed name. Completions group by the backend `kind`. The catalog warms when the composer mounts so the first `/review` already knows it takes text.

## Related Issue

Subsumes [#94073](https://github.com/NousResearch/hermes-agent/pull/94073) (curated `/review` row on the desktop table). This PR is the class fix for that symptom.


## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/commands.py` — `argument_mode` / `desktop` on `CommandDef`, inferred from args when unset
- `hermes_cli/plugins.py` — `register_command(..., argument_mode=)` (inferred `text` from `args_hint`)
- `tui_gateway/methods_tools.py` — `commands.catalog` includes a `commands` map and plugin commands
- `apps/desktop` — overlay table shrinks; resolve + Space/Enter + grouping read catalog `kind` / `argument_mode`

## How to Test

1. Type `/com` and press space — should complete `/compress`.
2. Type `/review` (do not arrow) and press space — should keep `/review `, not swap to `/compress`.
3. Type `/review` — first Commands row, not buried under Skills. Extra instructions stay typeable.
4. Type `/refine` or `/memory` — Commands, even with no desktop table row.
5. Type `/` — `/review` in the palette. Plugin commands with args stay typeable after space.
6. Arrow to a different row, then space — takes that row. Tab still takes the highlight.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

