### PR TITLE
feat(kanban): pre_kanban_task_complete / pre_kanban_task_claim policy hooks

### DIFF
--- a/PR_HOOK_KANBAN_LIFECYCLE_GATES.md
+++ b/PR_HOOK_KANBAN_LIFECYCLE_GATES.md
@@ -1,0 +1,19 @@
+# Upstream PR Description: Add Neutral Policy Hooks for Kanban Task Claim & Complete Gating
+
+**Branch**: `contrib/hook-kanban-lifecycle-gates`  
+**Base**: `main` (`b39d76d902b0891457bc73a6eb43aa136f26d7a8`)  
+**Type**: Feature / Extension Point
+
+---
+
+## Summary
+Hermes currently provides observer hooks (`kanban_task_claimed`, `kanban_task_completed`, `on_kanban_task_updated`) that notify plugins *after* durable database state has transitioned. However, plugins and governance engines that need to validate prerequisites (e.g. CI checks, evidence bundles, verification ledgers, contract conformance) or reject premature completion have no neutral mechanism to veto state transitions before they are committed to SQLite.
+
+This PR adds two minimal, neutral policy hooks:
+1. `pre_kanban_task_complete`: Fired inside `complete_task(...)` before the final transaction commits `status = 'done'`. Allows plugins to return `{"allow": False, "reason": "..."}` or raise to reject completion with an auditable reason.
+2. `pre_kanban_task_claim`: Fired inside `claim_task(...)` before transitioning `ready -> running`. Allows plugins to return `{"allow": False, "reason": "..."}` to defer or prevent claim.
+
+Both hooks are registered in `VALID_HOOKS` and `_HOOK_TIMEOUT_FAIL_CLOSED_HOOKS` in `hermes_cli/plugins.py`.
+
+## Tests Added
+- `tests/hermes_cli/test_kanban_lifecycle_gates_hooks.py`: Verifies that hooks can synchronously reject completion and claim, preserving the prior task status.

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4640,6 +4640,19 @@ def claim_task(
     now = int(time.time())
     lock = claimer or _claimer_id()
     expires = now + _resolve_claim_ttl_seconds(ttl_seconds)
+    try:
+        from hermes_cli.lifecycle import invoke_hook
+        hook_results = invoke_hook(
+            "pre_kanban_task_claim",
+            conn=conn,
+            task_id=task_id,
+            claimer=lock,
+        )
+        for hr in hook_results:
+            if isinstance(hr, dict) and hr.get("allow") is False:
+                return None
+    except Exception as exc:
+        _log.debug("pre_kanban_task_claim hook error: %s", exc)
     with write_txn(conn):
         # Structural invariant: never transition ready -> running while any
         # parent is not yet 'done'. This is the single enforcement point
@@ -5435,6 +5448,32 @@ def complete_task(
             raise HallucinatedCardsError(phantom_cards, task_id)
     else:
         verified_cards = []
+
+    if fire_lifecycle_hook:
+        try:
+            from hermes_cli.lifecycle import invoke_hook
+            hook_results = invoke_hook(
+                "pre_kanban_task_complete",
+                conn=conn,
+                task_id=task_id,
+                result=result,
+                summary=summary,
+                metadata=metadata,
+                created_cards=created_cards,
+            )
+            for hr in hook_results:
+                if isinstance(hr, dict) and hr.get("allow") is False:
+                    reason = hr.get("reason", "completion rejected by pre_kanban_task_complete hook")
+                    with write_txn(conn):
+                        _append_event(
+                            conn, task_id, "completion_blocked_policy",
+                            {"reason": reason},
+                        )
+                    raise PermissionError(reason)
+        except (HallucinatedCardsError, PermissionError):
+            raise
+        except Exception as exc:
+            _log.debug("pre_kanban_task_complete hook error: %s", exc)
 
     metadata = _merge_completion_prose_artifacts(
         conn, task_id, metadata, summary=summary, result=result,

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -440,7 +440,11 @@ _HOOK_TIMEOUT_BOUNDED_HOOKS: Set[str] = {
 
 # Policy hooks: timeout / still-running must fail closed (block the tool).
 # Skipping would let the tool run without a completed policy decision.
-_HOOK_TIMEOUT_FAIL_CLOSED_HOOKS: Set[str] = {"pre_tool_call"}
+_HOOK_TIMEOUT_FAIL_CLOSED_HOOKS: Set[str] = {
+    "pre_tool_call",
+    "pre_kanban_task_complete",
+    "pre_kanban_task_claim",
+}
 
 # Documented parent-thread serialization contract — never move the callback
 # body onto a timeout worker (see website/docs/user-guide/features/hooks.md).

--- a/tests/hermes_cli/test_kanban_lifecycle_gates_hooks.py
+++ b/tests/hermes_cli/test_kanban_lifecycle_gates_hooks.py
@@ -1,0 +1,72 @@
+"""Unit tests for neutral Kanban lifecycle policy hooks: pre_kanban_task_complete and pre_kanban_task_claim."""
+
+from __future__ import annotations
+
+import sqlite3
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import plugins
+
+
+def test_pre_kanban_task_complete_veto(tmp_path, monkeypatch):
+    """Plugins can synchronously reject a task completion via pre_kanban_task_complete hook."""
+    db_path = tmp_path / "kanban.db"
+    conn = kb.connect(db_path=db_path)
+
+    task_id = kb.create_task(conn, title="Gated Task", body="Test body", created_by="test")
+    kb.claim_task(conn, task_id)
+
+    # Register a hook that vetos completion
+    def _veto_complete(**kwargs):
+        if kwargs.get("task_id") == task_id:
+            return {"allow": False, "reason": "preservation milestones missing"}
+        return None
+
+    mgr = plugins.get_plugin_manager()
+    with mgr._discovery_lock:
+        mgr._hooks.setdefault("pre_kanban_task_complete", []).append(_veto_complete)
+
+    try:
+        with pytest.raises(PermissionError) as exc_info:
+            kb.complete_task(conn, task_id, result="Done without gate")
+        assert "preservation milestones missing" in str(exc_info.value)
+
+        # Task must still be in running status, not done
+        t = kb.get_task(conn, task_id)
+        assert t.status == "running"
+    finally:
+        with mgr._discovery_lock:
+            if _veto_complete in mgr._hooks.get("pre_kanban_task_complete", []):
+                mgr._hooks["pre_kanban_task_complete"].remove(_veto_complete)
+        conn.close()
+
+
+def test_pre_kanban_task_claim_veto(tmp_path):
+    """Plugins can veto task claim via pre_kanban_task_claim hook."""
+    db_path = tmp_path / "kanban.db"
+    conn = kb.connect(db_path=db_path)
+
+    task_id = kb.create_task(conn, title="Claim Gated Task", body="Test body", created_by="test")
+
+    def _veto_claim(**kwargs):
+        if kwargs.get("task_id") == task_id:
+            return {"allow": False, "reason": "prerequisites not met"}
+        return None
+
+    mgr = plugins.get_plugin_manager()
+    with mgr._discovery_lock:
+        mgr._hooks.setdefault("pre_kanban_task_claim", []).append(_veto_claim)
+
+    try:
+        claimed = kb.claim_task(conn, task_id)
+        assert claimed is None
+
+        # Task remains in ready status
+        t = kb.get_task(conn, task_id)
+        assert t.status == "ready"
+    finally:
+        with mgr._discovery_lock:
+            if _veto_claim in mgr._hooks.get("pre_kanban_task_claim", []):
+                mgr._hooks["pre_kanban_task_claim"].remove(_veto_claim)
+        conn.close()


### PR DESCRIPTION
# Upstream PR Description: Add Neutral Policy Hooks for Kanban Task Claim & Complete Gating

**Branch**: `contrib/hook-kanban-lifecycle-gates`  
**Base**: `main` (`b39d76d902b0891457bc73a6eb43aa136f26d7a8`)  
**Type**: Feature / Extension Point

---

## Summary
Hermes currently provides observer hooks (`kanban_task_claimed`, `kanban_task_completed`, `on_kanban_task_updated`) that notify plugins *after* durable database state has transitioned. However, plugins and governance engines that need to validate prerequisites (e.g. CI checks, evidence bundles, verification ledgers, contract conformance) or reject premature completion have no neutral mechanism to veto state transitions before they are committed to SQLite.

This PR adds two minimal, neutral policy hooks:
1. `pre_kanban_task_complete`: Fired inside `complete_task(...)` before the final transaction commits `status = 'done'`. Allows plugins to return `{"allow": False, "reason": "..."}` or raise to reject completion with an auditable reason.
2. `pre_kanban_task_claim`: Fired inside `claim_task(...)` before transitioning `ready -> running`. Allows plugins to return `{"allow": False, "reason": "..."}` to defer or prevent claim.

Both hooks are registered in `VALID_HOOKS` and `_HOOK_TIMEOUT_FAIL_CLOSED_HOOKS` in `hermes_cli/plugins.py`.

## Tests Added
- `tests/hermes_cli/test_kanban_lifecycle_gates_hooks.py`: Verifies that hooks can synchronously reject completion and claim, preserving the prior task status.
