### PR TITLE
feat(desktop): sort Nous Portal first in the model menu, and offer it when absent

### DIFF
--- a/apps/desktop/src/app/shell/model-catalog-menu.test.tsx
+++ b/apps/desktop/src/app/shell/model-catalog-menu.test.tsx
@@ -21,10 +21,15 @@ beforeAll(() => {
 })
 
 const getGlobalModelOptions = vi.fn()
+const startManualProviderOAuth = vi.fn()
 
 vi.mock('@/hermes', () => ({
   getGlobalModelOptions: (...args: unknown[]) => getGlobalModelOptions(...args),
   setApiRequestProfile: vi.fn()
+}))
+
+vi.mock('@/store/onboarding', () => ({
+  startManualProviderOAuth: (...args: unknown[]) => startManualProviderOAuth(...args)
 }))
 
 beforeEach(() => {
@@ -104,5 +109,92 @@ describe('the catalog owns model curation', () => {
     fireEvent.click(screen.getByText('Edit Models…'))
 
     expect($modelVisibilityOpen.get()).toBe(true)
+  })
+})
+
+// Portal is Hermes' own inference product and the path onboarding already
+// steers new users down (`PROVIDER_DISPLAY` gives it order 0, and it renders
+// through `FeaturedProviderRow`). This menu was the one model surface that
+// ignored that and sorted it wherever the alphabet put it. Deliberate product
+// placement rather than a neutral ranking, so it is pinned by a test.
+describe('Nous Portal sorts above the other providers', () => {
+  const headings = () =>
+    screen
+      .getAllByRole('menuitem')
+      .map(row => row.textContent ?? '')
+      .filter(text => /^(Anthropic|Google|Nous Portal|Zebra Labs)/.test(text))
+
+  it('puts Portal first even when its name sorts last', async () => {
+    getGlobalModelOptions.mockResolvedValue({
+      providers: [
+        { models: ['claude-sonnet-5'], name: 'Anthropic', slug: 'anthropic' },
+        { models: ['portal-model'], name: 'Nous Portal', slug: 'nous' }
+      ]
+    })
+
+    renderMenu()
+    await screen.findByText(/Portal Model/i)
+
+    expect(headings()[0]).toMatch(/^Nous Portal/)
+  })
+
+  // Everything below Portal keeps the previous stable alphabetical order, so
+  // no other provider's position moves relative to its peers.
+  it('leaves the remaining providers alphabetical', async () => {
+    getGlobalModelOptions.mockResolvedValue({
+      providers: [
+        { models: ['zebra-1'], name: 'Zebra Labs', slug: 'zebra' },
+        { models: ['gemini-3.1-pro'], name: 'Google', slug: 'google' },
+        { models: ['portal-model'], name: 'Nous Portal', slug: 'nous' },
+        { models: ['claude-sonnet-5'], name: 'Anthropic', slug: 'anthropic' }
+      ]
+    })
+
+    renderMenu()
+    await screen.findByText(/Portal Model/i)
+
+    expect(headings().map(h => h.replace(/\s.*/, ''))).toEqual(['Nous', 'Anthropic', 'Google', 'Zebra'])
+  })
+})
+
+// An unconfigured provider produces NO row at all (the payload is
+// `explicit_only`), so a user who has never connected Portal would otherwise
+// see every other provider they can reach and no mention of Hermes' own.
+describe('the Portal sign-in offer', () => {
+  it('appears when Portal is absent from the catalog', async () => {
+    renderMenu()
+
+    expect(await screen.findByText('Connect Nous Portal')).toBeTruthy()
+  })
+
+  it('starts the Portal OAuth flow when chosen', async () => {
+    renderMenu()
+
+    fireEvent.click(await screen.findByText('Connect Nous Portal'))
+
+    expect(startManualProviderOAuth).toHaveBeenCalledWith('nous', null)
+  })
+
+  it('stays hidden once Portal is connected', async () => {
+    getGlobalModelOptions.mockResolvedValue({
+      providers: [{ models: ['portal-model'], name: 'Nous Portal', slug: 'nous' }]
+    })
+
+    renderMenu()
+    await screen.findByText(/Portal Model/i)
+
+    expect(screen.queryByText('Connect Nous Portal')).toBeNull()
+  })
+
+  // A query means "find me a model", not "sell me one".
+  it('gets out of the way while searching', async () => {
+    renderMenu()
+    await screen.findByText('Connect Nous Portal')
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Search models' }), { target: { value: 'gemini' } })
+
+    await vi.waitFor(() => {
+      expect(screen.queryByText('Connect Nous Portal')).toBeNull()
+    })
   })
 })

--- a/apps/desktop/src/app/shell/model-catalog-menu.tsx
+++ b/apps/desktop/src/app/shell/model-catalog-menu.tsx
@@ -34,6 +34,7 @@ import {
   modelVisibilityKey,
   setModelVisibilityOpen
 } from '@/store/model-visibility'
+import { startManualProviderOAuth } from '@/store/onboarding'
 import { $collapsedProviders, toggleCollapsedProvider } from '@/store/provider-collapse'
 import { $defaultReasoningEffort } from '@/store/session'
 import type { ModelOptionProvider, ModelOptionsResponse } from '@/types/hermes'
@@ -112,6 +113,30 @@ interface ProviderGroup {
   provider: ModelOptionProvider
 }
 
+/** The Nous Portal provider slug. Portal is Hermes' own inference product and
+ *  the path the app already steers new users down: onboarding gives it
+ *  `order: 0` in `PROVIDER_DISPLAY` and renders it through
+ *  `FeaturedProviderRow`. This menu was the one model surface that ignored
+ *  that and sorted it under whatever fell earlier in the alphabet. */
+const PORTAL_SLUG = 'nous'
+
+/** Provider order: Portal first, then alphabetical by name.
+ *
+ *  Deliberate product placement, not a neutral ranking — worth naming plainly
+ *  rather than burying. Everything below Portal keeps the stable alphabetical
+ *  order the previous sort established, so no other provider's position moves
+ *  relative to its peers and the list still cannot reshuffle on a switch. */
+function compareProviderGroups(a: ProviderGroup, b: ProviderGroup): number {
+  const aPortal = a.provider.slug.toLowerCase() === PORTAL_SLUG
+  const bPortal = b.provider.slug.toLowerCase() === PORTAL_SLUG
+
+  if (aPortal !== bPortal) {
+    return aPortal ? -1 : 1
+  }
+
+  return a.provider.name.localeCompare(b.provider.name)
+}
+
 /**
  * THE model catalog menu: searchable, provider-grouped, `-fast` families
  * collapsed to one row, per-row hover submenu for thinking/effort/fast, full
@@ -186,6 +211,16 @@ export function ModelCatalogMenu({
   )
 
   const q = normalize(search)
+
+  // Portal missing from the catalog means the user has not connected it: the
+  // payload is `explicit_only`, so an unconfigured provider produces no row at
+  // all rather than an empty one. Offer the sign-in instead of silently
+  // leaving Hermes' own inference off a list of everywhere else they can go.
+  // Hidden while searching — a query means "find me a model", not "sell me
+  // one" — and hidden on load/error, where a half-known catalog would make the
+  // row a lie.
+  const showPortalCta =
+    !q && !loading && !error && pickerProviders.every(provider => provider.slug.toLowerCase() !== PORTAL_SLUG)
 
   // Presets are searchable rows like everything else — an unfiltered preset
   // sitting under zero model matches would otherwise become the "first match"
@@ -369,6 +404,15 @@ export function ModelCatalogMenu({
         </DropdownMenuItem>
       ) : (
         <div className={cn('max-h-[max(150px,30dvh)] overflow-y-auto py-0.5', quietRows)} ref={listRef}>
+          {showPortalCta ? (
+            <DropdownMenuItem
+              className={cn(dropdownMenuRow, 'gap-2')}
+              onSelect={() => startManualProviderOAuth(PORTAL_SLUG, null)}
+            >
+              <Codicon className="text-(--ui-accent)" name="sparkle" size="0.75rem" />
+              <span className="min-w-0 flex-1 truncate">{copy.portalCta}</span>
+            </DropdownMenuItem>
+          ) : null}
           {groups.map(group => {
             const slug = group.provider.slug
 
@@ -589,9 +633,9 @@ function groupModels(
     }
   }
 
-  // Stable, logical group order: alphabetical by provider name. (The backend
-  // floats the current provider first, which would reshuffle on every switch.)
-  groups.sort((a, b) => a.provider.name.localeCompare(b.provider.name))
+  // Portal first, then alphabetical by provider name. (The backend floats the
+  // current provider first, which would reshuffle on every switch.)
+  groups.sort(compareProviderGroups)
 
   return groups
 }

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -2211,6 +2211,7 @@ export const ar = defineLocale({
       noModels: 'لا توجد نماذج',
       editModels: 'تحرير النماذج',
       refreshModels: 'تحديث النماذج',
+      portalCta: 'ربط Nous Portal',
       fast: 'سريع'
     },
     modelOptions: {

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2823,6 +2823,7 @@ export const en: Translations = {
       noModels: 'No models found',
       editModels: 'Edit Models…',
       refreshModels: 'Refresh Models',
+      portalCta: 'Connect Nous Portal',
       fast: 'Fast'
     },
     modelOptions: {

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2465,6 +2465,7 @@ export const ja = defineLocale({
       noModels: 'モデルが見つかりません',
       editModels: 'モデルを編集…',
       refreshModels: 'モデルを更新',
+      portalCta: 'Nous Portal に接続',
       fast: '高速'
     },
     modelOptions: {

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2387,6 +2387,7 @@ export interface Translations {
       noModels: string
       editModels: string
       refreshModels: string
+      portalCta: string
       fast: string
     }
     modelOptions: {

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2376,6 +2376,7 @@ export const zhHant = defineLocale({
       noModels: '找不到模型',
       editModels: '編輯模型…',
       refreshModels: '重新整理模型',
+      portalCta: '連接 Nous Portal',
       fast: '快速'
     },
     modelOptions: {

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2987,6 +2987,7 @@ export const zh: Translations = {
       noModels: '未找到模型',
       editModels: '编辑模型…',
       refreshModels: '刷新模型',
+      portalCta: '连接 Nous Portal',
       fast: '快速'
     },
     modelOptions: {


### PR DESCRIPTION
## What does this PR do?

Two changes to the composer's model menu, both about Nous Portal.

**Portal sorts first.** Every other model surface already treats it as the featured path: onboarding gives it `order: 0` in `PROVIDER_DISPLAY` and renders it through `FeaturedProviderRow`. This menu was the one surface that ignored that and sorted providers purely by name, so on a typical install Hermes' own inference sits below whichever third parties happen to start with an earlier letter.

Everything below Portal keeps the stable alphabetical order the previous sort established, so no other provider moves relative to its peers, and the list still cannot reshuffle when the active model changes (the reason that sort exists, per its original comment).

Worth stating plainly rather than burying: this is deliberate product placement, not a neutral ranking. The code comment says so and a test pins it, so a future reader finds the intent instead of guessing at an accident.

**A user who has never connected Portal saw no trace of it.** The catalog payload is `explicit_only`, so an unconfigured provider produces no row at all rather than an empty one. The menu therefore listed every provider that user could reach and made no mention of ours. It now shows a single sign-in row in that case, wired to the existing `startManualProviderOAuth('nous')` deep link so it lands in the same OAuth flow onboarding uses rather than duplicating provider UI.

The row is withheld whenever showing it would be noise or a lie: while a search is active (a query means find me a model, not sell me one), while the catalog is loading or errored, and once Portal is connected.

### Scope note

This touches only the composer catalog menu. The standalone picker dialog (`components/model-picker.tsx`) deliberately preserves backend order verbatim and is left alone here; if provider order should change there too, that is a separate call about the backend's ordering rather than a renderer sort.

### Overlapping PRs

`model-catalog-menu.tsx` is busy right now. #96448, #84831, and #93375 all add per-model pricing to these rows, and #95090 (mine) adds pinning. This PR touches the group sort and adds one row above the list, so it should rebase cleanly behind any of them, and I am happy to be the one that goes last.

## Related Issue

Refs #84986

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/shell/model-catalog-menu.tsx`: `compareProviderGroups` replaces the inline `localeCompare` in `groupModels`, putting the `nous` slug first and leaving the rest alphabetical. Adds the Portal sign-in row above the provider groups, gated on `showPortalCta`.
- `apps/desktop/src/i18n/`: `shell.modelMenu.portalCta` in types plus all five locales.
- `apps/desktop/src/app/shell/model-catalog-menu.test.tsx`: Portal-first ordering (including when its name sorts last), the remaining providers staying alphabetical, and the four states of the sign-in row (absent, connected, searching, and the OAuth hand-off).

## How to Test

1. With Portal connected, open the composer model menu. Nous Portal is the first provider group; the rest are alphabetical below it.
2. Disconnect Portal (or use a profile that has never connected it) and reopen. A "Connect Nous Portal" row sits at the top of the list.
3. Click it. The onboarding overlay opens directly on the Portal OAuth flow rather than the provider picker.
4. Type in the search box. The sign-in row disappears while a query is active.

```
cd apps/desktop
npx tsc -p . --noEmit
TMPDIR=/tmp npx vitest run --project ui     # 617 files, 6091 tests passing
npx eslint src/app/shell/model-catalog-menu.tsx src/i18n
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the renderer gate (`tsc --noEmit`, `vitest run --project ui`, `eslint`) and all of it passes. This PR touches no Python, so `pytest tests/ -q` is not the relevant gate.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.1, Apple silicon

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — renderer-only, no platform-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
