### PR TITLE
fix(gateway): materialize session row on resume for minted-but-never-…

### DIFF
--- a/tests/tui_gateway/test_session_resume_materializes_minted_key.py
+++ b/tests/tui_gateway/test_session_resume_materializes_minted_key.py
@@ -1,0 +1,157 @@
+"""``session.resume`` materializes a row for a minted-but-never-persisted key.
+
+Bug class: the backend dies between ``session.create`` (which intentionally
+writes no state.db row until the first prompt — no "Untitled" litter) and that
+first ``prompt.submit``. The stored key exists client-side (pinned tile,
+sidebar) but has no row anywhere, and after a restart the in-memory live-lazy
+lookup can't find it either — so resume used to 4007 forever and the desktop
+surfaced "no route to the backend holding this session".
+
+The fix: when the resume target is a well-formed server-minted key
+(``%Y%m%d_%H%M%S_`` + 6 hex, the exact shape ``_new_session_key()`` produces),
+materialize the row and continue the normal empty resume instead of failing.
+Abandoned drafts still leave no row — nothing is written until a client
+explicitly resumes the exact key. Fail-closed: garbage, 8-hex runtime ids,
+and titles still 4007, and lazy subagent watch windows are excluded.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hermes_state import SessionDB
+from tui_gateway import server
+
+MINTED_KEY = "20260828_053121_3427a9"  # the morning's lost session shape
+EXISTING_KEY = "20260827_224618_956bf8"
+
+
+@pytest.fixture()
+def real_db(monkeypatch, tmp_path):
+    """Real SessionDB behind ``_get_db``, with the heavy resume machinery off."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    monkeypatch.setattr(server, "_get_db", lambda: db)
+    monkeypatch.setattr(server, "_resolve_model", lambda: "test-model")
+    monkeypatch.setattr(server, "_enable_gateway_prompts", lambda: None)
+    monkeypatch.setattr(server, "_find_live_session_by_key", lambda _key, _home: None)
+    monkeypatch.setattr(server, "_schedule_agent_build", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_schedule_session_cap_enforcement", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_maybe_schedule_auto_continue", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_default_session_cwd", lambda *a, **k: str(tmp_path))
+    monkeypatch.setattr(server, "_profile_configured_cwd", lambda _home: str(tmp_path))
+    monkeypatch.setattr(server, "_child_run_active", lambda _key: False)
+    known = set(server._sessions)
+    yield db
+    with server._sessions_lock:
+        for sid in [s for s in server._sessions if s not in known]:
+            server._sessions.pop(sid, None)
+    db.close()
+
+
+def _resume(**params):
+    return server.handle_request({"id": "1", "method": "session.resume", "params": params})
+
+
+def _assert_resumed_ok(resp, target):
+    assert "error" not in resp, resp
+    assert resp["result"]["resumed"] == target
+    assert resp["result"]["session_id"], "a live runtime must be registered"
+
+
+def test_resume_materializes_row_for_minted_key(real_db):
+    """The core fix: a minted-but-never-persisted key resumes, row now exists."""
+    resp = _resume(session_id=MINTED_KEY)
+
+    _assert_resumed_ok(resp, MINTED_KEY)
+    row = real_db.get_session(MINTED_KEY)
+    assert row is not None, "resume must materialize the DB row"
+    # Launch/default profile row; source uses the same env resolution the rest of
+    # the tree applies (literals drift between dev hosts — compare against the
+    # resolver itself).
+    assert row["source"] == server._resolve_session_source(None)
+    assert row["model"] == "test-model"
+    assert row.get("profile_name") is None  # launch/default profile
+
+
+def test_resume_existing_row_unaffected(real_db):
+    """A persisted session resumes normally and its row is not duplicated."""
+    real_db.create_session(EXISTING_KEY, source="tui", model="test-model")
+    real_db.append_message(EXISTING_KEY, "user", "hello")
+
+    resp = _resume(session_id=EXISTING_KEY)
+
+    _assert_resumed_ok(resp, EXISTING_KEY)
+    # message_count stays 1 — a second create would have been an INSERT-OR-IGNORE
+    # no-op, but the row must remain the same single conversation.
+    assert real_db.get_session(EXISTING_KEY)["message_count"] == 1
+
+
+def test_resume_garbage_id_still_4007(real_db):
+    """Non-key garbage stays fail-closed: same error, no write."""
+    resp = _resume(session_id="not-a-session")
+
+    assert resp["error"]["code"] == 4007
+    # nothing materialized for arbitrary strings
+    assert len(real_db.list_sessions_rich(source="tui")) == 0
+
+
+def test_resume_8hex_runtime_id_still_4007(real_db):
+    """8-hex runtime session ids (``uuid4().hex[:8]``) are NOT stored keys."""
+    resp = _resume(session_id="5a81f231")
+
+    assert resp["error"]["code"] == 4007
+    assert len(real_db.list_sessions_rich(source="tui")) == 0
+
+
+def test_resume_lazy_watch_missing_key_still_4007(real_db):
+    """Lazy subagent watch windows must not mint phantom rows for dead children."""
+    resp = _resume(session_id=MINTED_KEY, lazy=True)
+
+    assert resp["error"]["code"] == 4007
+    assert real_db.get_session(MINTED_KEY) is None
+
+
+def test_resume_minted_key_claimed_by_other_profile_fails_closed(real_db):
+    """A key claimed by a live session under ANOTHER profile must not mint here.
+
+    Mirrors test_resume_live_lazy_session's unscoped-resume fail-closed rule
+    (#93296): the materialize gate must not turn a cross-profile leak into a
+    phantom launch-store row. The key looks server-minted, but a live record
+    owns it — routing guesses are forbidden.
+    """
+    record = {
+        "history": [],
+        "last_active": 0.0,
+        "pending_title": "Bot Chat",
+        "pending_hidden": True,
+        "profile_home": "/tmp/other-profile",
+        "running": False,
+        "session_key": MINTED_KEY,
+        "source": "desktop",
+    }
+    server._sessions["live-other-profile"] = record
+    try:
+        resp = _resume(session_id=MINTED_KEY)
+        assert resp["error"]["code"] == 4007
+        assert real_db.get_session(MINTED_KEY) is None
+    finally:
+        with server._sessions_lock:
+            server._sessions.pop("live-other-profile", None)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("20260828_053121_3427a9", True),
+        ("20260827_224618_956bf8", True),
+        ("5a81f231", False),  # 8-hex runtime sid
+        ("fcd97d0c", False),  # 8-hex runtime sid
+        ("not-a-session", False),
+        ("", False),
+        ("20260828_053121_3427", False),  # too-short hex tail
+        ("20260828_053121_3427a9ZZ", False),  # trailing garbage
+        ("Bot Chat", False),  # titles are not keys
+    ],
+)
+def test_is_server_minted_key_shape(value, expected):
+    assert server._is_server_minted_key(value) is expected

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -588,6 +588,48 @@ def _resume_locate(ctx: _Resume) -> dict | None:
         return _resume_live_unpersisted(ctx, live_sid, live)
     if ctx.owns_db:
         _resume_adopt_stranded(ctx)
+    if (
+        not ctx.found
+        and not ctx.lazy
+        and _is_server_minted_key(ctx.target)
+        and not _any_live_session_claims_key(ctx.target)
+    ):
+        # Minted-but-never-persisted key rescue. session.create mints the stored
+        # key but intentionally writes no DB row until the first prompt (no
+        # "Untitled" litter). If the backend dies between create and that first
+        # prompt, the key exists client-side (pinned tile, stored id) but has no
+        # row anywhere — and after a restart the in-memory live-lazy lookup
+        # above can't find it either, so this resume used to 4007 forever
+        # ("no route to the backend holding this session"). When the target is a
+        # well-formed server-minted key, materialize the row and let the normal
+        # resume path continue with empty history. Abandoned drafts still leave
+        # no row: nothing is written until a client explicitly resumes the exact
+        # key. Fail-closed: anything not matching the minted shape (garbage,
+        # 8-hex runtime ids, titles) still 4007s, and a key claimed by ANY live
+        # session (even under a different profile) is owned — an unscoped resume
+        # must never mint a phantom row in the launch store (#93296 cross-profile
+        # rule: routing guesses are forbidden). Lazy watch windows (subagent
+        # viewers) are excluded: they attach to live children by design, and a
+        # dead child should honestly 4007 rather than mint a phantom row.
+        try:
+            ctx.db.create_session(
+                ctx.target,
+                source=_resolve_session_source(
+                    _str_param(ctx.params, "source") or None
+                ),
+                model=_resolve_model(),
+                profile_name=Path(ctx.profile_home).name if ctx.profile_home else None,
+            )
+            ctx.found = ctx.db.get_session(ctx.target)
+            logger.info(
+                "materialized session row for minted-but-unpersisted "
+                "key %s (resume no longer 4007s)",
+                ctx.target,
+            )
+        except Exception:
+            logger.warning(
+                "failed to materialize session row for %s", ctx.target, exc_info=True
+            )
     return None if ctx.found else _err(ctx.rid, 4007, "session not found")
 
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -10,6 +10,7 @@ import json
 import logging
 import os
 import queue
+import re
 import subprocess
 import sys
 import threading
@@ -2367,6 +2368,34 @@ def _init_session(
 
 def _new_session_key() -> str:
     return f"{datetime.now().strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:6]}"
+
+
+# Server-minted session keys are ``%Y%m%d_%H%M%S_`` + 6 hex chars (see
+# ``_new_session_key``). session.resume uses this shape as the fail-closed gate
+# for materializing a row for a minted-but-never-persisted key: only keys the
+# server itself could have produced qualify — arbitrary strings and 8-hex
+# runtime session ids (``uuid4().hex[:8]``) are rejected.
+_MINTED_SESSION_KEY_RE = re.compile(r"^\d{8}_\d{6}_[0-9a-f]{6}$")
+
+
+def _is_server_minted_key(value: str | None) -> bool:
+    return bool(value and _MINTED_SESSION_KEY_RE.fullmatch(value))
+
+
+def _any_live_session_claims_key(target: str) -> bool:
+    """True if any live registry record claims this stored key (any profile).
+
+    Fail-closed gate for minted-key materialization: a key claimed by a live
+    session — even one scoped to a different profile — is owned, so an
+    unscoped resume must not mint a phantom row in the launch store (#93296
+    cross-profile rule: routing guesses are forbidden).
+    """
+    for record in list(_sessions.values()):
+        if not isinstance(record, dict):
+            continue
+        if str(record.get("session_key") or "") == target:
+            return True
+    return False
 
 
 def _with_checkpoints(session, fn):


### PR DESCRIPTION
## What does this PR do?

Makes a server-minted session key **resumable even when its DB row was never persisted**, because the backend died between `session.create` and the session's first prompt.

`session.create` in `tui_gateway/methods_session.py` deliberately writes no session row until the first prompt arrives (`_ensure_session_db_row`), which avoids "Untitled" rows for sessions that never receive input. But if the backend process dies in that window, e.g. at the end of `hermes update`, which restarts `hermes-gateway.service` and `hermes-dashboard.service`, the minted key (e.g. `20260828_053121_3427a9`) survives **only** client-side: no row, no owner. After restart, `session.resume` returned **4007 permanently** and the desktop tile showed "Couldn't open this session" / "no route to the backend holding this session".

**Why this approach:** the fix is deliberately narrow, at the one seam where a minted key can legitimately exist without a row. It materializes the row **only** when (a) the key matches the server-minted shape (`^\d{8}_\d{6}_[0-9a-f]{6}$`), (b) there is no persisted row, and (c) no currently-live session claims the key. Everything else (garbage ids, runtime ids, titles, lazy sessions, live-claimed keys) still fails closed with 4007. The reaper paths were exonerated during investigation, they only UPDATE `end_reason`, never delete, so this touches none of that machinery.

## Related Issue

Fixes [#96793](https://github.com/NousResearch/hermes-agent/issues/96793)

## Type of Change

- [x] Bug fix

## Changes Made

- `tui_gateway/server.py`: helpers to recognize server-minted keys and detect live claims (`_is_server_minted_key()`, `_any_live_session_claims_key()`).
- `tui_gateway/methods_session.py`: in `session.resume`, before the not-found 4007 path: materialize a row for an eligible minted-but-unpersisted key, then re-resolve.
- `tests/tui_gateway/test_session_resume_materializes_minted_key.py`: 15 tests (fresh run): materialize-success, existing-row untouched, garbage/8-hex/runtime/lazy still 4007, cross-profile live-claim fails closed, replay-safe (idempotent), helper shape matrix.

## How to Test

**Reproduction (before fix):**

1. From Hermes Desktop, create a new session; note the minted key. Send no message.
2. Restart the backend (or reproduce the update-path restart of `hermes-dashboard.service`).
3. Resume that session from the client → 4007 "session not found", permanently.
4. Any text typed into the stranded session is lost.

**After fix:**

5. The same resume now materializes the row from the minted key and opens an empty session; the pinned tile resolves; retyped text lands in a durable row.

**Unit tests** (all green; drive via the repo's test runner):

```bash
scripts/run_tests.sh tests/tui_gateway/test_session_resume_materializes_minted_key.py
scripts/run_tests.sh tests/tui_gateway/ -q
```

- New test file: **15 tests, all pass** (run multiple times this session).
- Full `tests/tui_gateway/` slice: **86 files, 682 passed, 0 failed, 1 skipped** (63s, 4 workers, exit 0).
- The one test that initially failed (`test_hud_surface_note`) did so only because `snowballstemmer==3.1.1`, declared in `pyproject.toml`, was missing from the local dev venv. With the declared pin installed, the whole slice is green; the failing test and `tools/tool_search.py` are untouched by this diff.

## Checklist

### Code

- [x] I read and followed the [CONTRIBUTING.md](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md) guidelines
- [x] I used Conventional Commits: `fix(gateway): ...` (lowercase, imperative)
- [x] I checked existing issues/PRs for this bug class and referenced them as related, not duplicates (#96522, #94724, #95407)
- [x] I kept the change scoped to the files above, no drive-by refactors
- [x] Tests were written first (RED) and pass on the fix (GREEN); sibling suites regression-tested

### Documentation & Housekeeping

- [x] No docs surface changed (behavior-only fix)
- [x] No new dependencies; no `.env`/config changes

## Screenshots / Logs

**Before, permanent resume failure after restart:**

```
session-scoped RPC rejected: method=session.resume session_id='20260828_053121_3427a9' not in memory (detached/reaped runtime; client should resume the stored session), rid=...
```

**After,resume materializes the row and resolves (green suites above).**