### PR TITLE
fix(security): contain credential and computer-use privacy leaks

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -152,14 +152,28 @@ _PREFIX_PATTERNS = [
 _SECRET_ENV_NAMES = r"(?:API_?KEY|KEY|TOKEN|SECRET|PASSWORD|PASSWD|PASS|PW|CREDENTIAL|AUTH)"
 # Uppercase keys keep the legacy embedded match (``MYTOKEN=…``, ``FOO_SECRET``)
 # — an all-caps key is almost never prose.
+_ENV_ASSIGN_SINGLE_QUOTED_RE = re.compile(
+    rf"([A-Z0-9_]{{0,50}}{_SECRET_ENV_NAMES}[A-Z0-9_]{{0,50}})\s*=\s*(')([^'\r\n]*)'",
+)
+_ENV_ASSIGN_DOUBLE_QUOTED_RE = re.compile(
+    rf'([A-Z0-9_]{{0,50}}{_SECRET_ENV_NAMES}[A-Z0-9_]{{0,50}})\s*=\s*(")([^"\r\n]*)"',
+)
 _ENV_ASSIGN_RE = re.compile(
-    rf"([A-Z0-9_]{{0,50}}{_SECRET_ENV_NAMES}[A-Z0-9_]{{0,50}})\s*=\s*(['\"]?)(\S+)\2",
+    rf"([A-Z0-9_]{{0,50}}{_SECRET_ENV_NAMES}[A-Z0-9_]{{0,50}})\s*=\s*()([^\s'\"]+)",
 )
 # Lowercase env names: only underscore-boundary forms (``openai_key=…``,
 # ``FAL_KEY=…``, ``db_pw=…``) — NOT bare ``password=``/``token=``/``secret=``,
 # which appear in prose, URLs, and form bodies (issue #77484).
+_ENV_ASSIGN_LOWER_SINGLE_QUOTED_RE = re.compile(
+    rf"([a-z0-9_]+(?:_|^)(?:key|pass|pw|token|secret|password|passwd|credential|auth)(?=[^a-z0-9_]|$))\s*=\s*(')([^'\r\n]*)'",
+    re.IGNORECASE,
+)
+_ENV_ASSIGN_LOWER_DOUBLE_QUOTED_RE = re.compile(
+    rf'([a-z0-9_]+(?:_|^)(?:key|pass|pw|token|secret|password|passwd|credential|auth)(?=[^a-z0-9_]|$))\s*=\s*(")([^"\r\n]*)"',
+    re.IGNORECASE,
+)
 _ENV_ASSIGN_LOWER_RE = re.compile(
-    rf"([a-z0-9_]+(?:_|^)(?:key|pass|pw|token|secret|password|passwd|credential|auth)(?=[^a-z0-9_]|$))\s*=\s*(['\"]?)(\S+)\2",
+    rf"([a-z0-9_]+(?:_|^)(?:key|pass|pw|token|secret|password|passwd|credential|auth)(?=[^a-z0-9_]|$))\s*=\s*()([^\s'\"]+)",
     re.IGNORECASE,
 )
 
@@ -171,9 +185,9 @@ _ENV_ASSIGN_LOWER_RE = re.compile(
 # These run only in a config-file context, NOT in prose, code, or URLs — three
 # carve-outs preserved from the original design (#4367 + the documented
 # web-URL passthrough below):
-#   1. The value is bounded by ``[^\s&]`` (stops at whitespace AND ``&``) so
-#      form-urlencoded bodies are handled pair-by-pair (by _redact_form_body),
-#      not greedily swallowed.
+#   1. Quoted values bind the opening quote possessively, so the regex cannot
+#      backtrack to an unquoted match and swallow trailing shell/HTML markup.
+#      Unquoted values stop at whitespace, ``&``, ``;``, or markup start.
 #   2. _CFG_DOTTED_RE only matches when the key is NAMESPACED (contains a dot),
 #      which is unambiguously a config key — never a prose word.
 #   3. _CFG_ANCHORED_RE matches a bare secret-word key only at line start
@@ -181,7 +195,7 @@ _ENV_ASSIGN_LOWER_RE = re.compile(
 #      mid-sentence is left alone.
 # The colon-form URL guard (skip when ``://`` present) lives at the call site.
 _SECRET_CFG_NAMES = r"(?:api[ _.\-]?key|token|secret|passwd|password|credential|auth)"
-_CFG_VALUE = r"(['\"]?)([^\s&]+?)\2(?=[\s&]|$)"
+_CFG_VALUE = r"(['\"]?+)([^\s&]+?)\2(?=[\s&;<]|$)"
 # Linear pre-gate for the _CFG_*_RE subs below: a text with no secret keyword
 # can never match either pattern, so the (potentially backtrack-heavy) subs
 # are skipped entirely for such text. See the call site in
@@ -319,6 +333,19 @@ def _key_has_secret_keyword(key: str) -> bool:
 _JSON_KEY_NAMES = r"(?:api_?[Kk]ey|token|secret|password|access_token|refresh_token|auth_token|bearer|secret_value|raw_secret|secret_input|key_material)"
 _JSON_FIELD_RE = re.compile(
     rf'("{_JSON_KEY_NAMES}")\s*:\s*"([^"]+)"',
+    re.IGNORECASE,
+)
+
+# Exact credential carriers remain sensitive even when their surrounding text
+# is source code or file content. Keep this list narrow so code_file=True still
+# preserves illustrative generic fields such as ``{"token": "example"}``.
+_ALWAYS_REDACT_JSON_FIELD_RE = re.compile(
+    r'("(?:access_token|refresh_token|session_token)")\s*:\s*"([^"]+)"',
+    re.IGNORECASE,
+)
+
+_JS_SESSION_TOKEN_ASSIGN_RE = re.compile(
+    r"((?:window\s*\.\s*)?__HERMES_SESSION_TOKEN__\s*=\s*)(['\"])([^'\"\r\n]*)(\2)",
     re.IGNORECASE,
 )
 
@@ -791,10 +818,11 @@ def redact_sensitive_text(
     URL userinfo. The default remains False because actionable OAuth callback,
     magic-link, and pre-signed URLs must survive ordinary tool flows unchanged.
 
-    Set code_file=True to skip the ENV-assignment and JSON-field regex
+    Set code_file=True to skip the broad ENV-assignment and generic JSON-field
     patterns when the text is known to be source code (e.g. MAX_TOKENS=***
-    constants, "apiKey": "test" fixtures). Prefix patterns, auth headers,
-    private keys, DB connstrings, JWTs, and URL secrets are still redacted.
+    constants, "apiKey": "test" fixtures). Exact access/refresh/session token
+    JSON carriers, prefix patterns, auth headers, private keys, DB connstrings,
+    JWTs, and URL secrets are still redacted.
 
     Set file_read=True for file *content* returned to the agent (read_file /
     search_files / cat). Secrets are STILL redacted — they are never exposed —
@@ -830,6 +858,35 @@ def redact_sensitive_text(
     if file_read:
         code_file = True
 
+    # Dashboard bootstrap HTML carries the session credential in a JavaScript
+    # assignment. Match only the quoted value so trailing ``;</script>`` and
+    # later markup cannot be swallowed by the generic ENV-assignment pass.
+    if "HERMES_SESSION_TOKEN" in text:
+        _js_session_assignment = _JS_SESSION_TOKEN_ASSIGN_RE.search(text)
+        if _js_session_assignment is not None:
+            _js_mask = _mask_token_nonreusable if file_read else _mask_token
+            text = _JS_SESSION_TOKEN_ASSIGN_RE.sub(
+                lambda m: (
+                    f"{m.group(1)}{m.group(2)}{_js_mask(m.group(3))}{m.group(4)}"
+                ),
+                text,
+            )
+            # The carrier proves this block is JavaScript/HTML, not an env or
+            # dotted-config dump. Keep the broad assignment passes off so they
+            # cannot reinterpret markup after the now-masked value.
+            code_file = True
+
+    # Exact JSON credential fields are high-confidence carriers, not generic
+    # secret-keyword guesses. Redact them in every output mode, including
+    # source/file/ordinary-terminal paths where the broad JSON pass below is
+    # intentionally disabled to avoid corrupting examples and prose.
+    if ":" in text and '"' in text:
+        _exact_json_mask = _mask_token_nonreusable if file_read else _mask_token
+        text = _ALWAYS_REDACT_JSON_FIELD_RE.sub(
+            lambda m: f'{m.group(1)}: "{_exact_json_mask(m.group(2))}"',
+            text,
+        )
+
     # Known prefixes (sk-, ghp_, etc.) — gate on substring presence
     if _has_known_prefix_substring(text):
         _prefix_sub = _mask_token_nonreusable if file_read else _mask_token
@@ -860,6 +917,8 @@ def redact_sensitive_text(
                 if not _key_has_secret_keyword(name):
                     return m.group(0)
                 return f"{name}={quote}{_mask_token(value)}{quote}"
+            text = _ENV_ASSIGN_SINGLE_QUOTED_RE.sub(_redact_env, text)
+            text = _ENV_ASSIGN_DOUBLE_QUOTED_RE.sub(_redact_env, text)
             text = _ENV_ASSIGN_RE.sub(_redact_env, text)
             # Lowercase env names (``openai_key=…``). Skip URLs — the query
             # string may contain ``token=``/``key=`` params that are
@@ -868,6 +927,8 @@ def redact_sensitive_text(
             # case). The uppercase regex above is all-caps-only, so it never
             # matches URL params; the lowercase one would (issue #77484).
             if "://" not in text:
+                text = _ENV_ASSIGN_LOWER_SINGLE_QUOTED_RE.sub(_redact_env, text)
+                text = _ENV_ASSIGN_LOWER_DOUBLE_QUOTED_RE.sub(_redact_env, text)
                 text = _ENV_ASSIGN_LOWER_RE.sub(_redact_env, text)
             # Lowercase/dotted config keys (issue #16413). Skip URLs entirely —
             # web-URL query params are intentionally passed through (see note

--- a/agent/tool_dispatch_helpers.py
+++ b/agent/tool_dispatch_helpers.py
@@ -33,7 +33,10 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from agent.message_metadata import stamp_message_timestamp
-from agent.redact import redact_sensitive_text
+from agent.tool_result_egress import (
+    is_multimodal_tool_result as _is_multimodal_tool_result,
+    redact_tool_result_for_egress as _redact_tool_result_for_egress,
+)
 from agent.tool_result_classification import (
     FILE_MUTATING_TOOL_NAMES as _FILE_MUTATING_TOOLS,
 )
@@ -392,20 +395,6 @@ def _paths_overlap(left: Path, right: Path) -> bool:
     return left_parts[:common_len] == right_parts[:common_len]
 
 
-def _is_multimodal_tool_result(value: Any) -> bool:
-    """True if the value is a multimodal tool result envelope.
-
-    Multimodal handlers (e.g. tools/computer_use) return a dict with
-    `_multimodal=True`, a `content` key holding OpenAI-style content
-    parts, and an optional `text_summary` for string-only fallbacks.
-    """
-    return (
-        isinstance(value, dict)
-        and value.get("_multimodal") is True
-        and isinstance(value.get("content"), list)
-    )
-
-
 def _multimodal_text_summary(value: Any) -> str:
     """Extract a plain text view of a multimodal tool result.
 
@@ -450,56 +439,6 @@ def _append_subdir_hint_to_multimodal(value: Dict[str, Any], hint: str) -> None:
         value["content"] = parts
     if isinstance(value.get("text_summary"), str):
         value["text_summary"] = value["text_summary"] + hint
-
-
-def _redact_tool_result_for_egress(value: Any) -> Any:
-    """Redact model-visible tool-result text at the universal egress boundary.
-
-    Plain strings receive the normal configured redaction policy plus strict
-    URL query/userinfo masking. Multimodal envelopes and content lists are
-    rebuilt only where text-bearing parts change; image/base64 parts are kept
-    by identity so screenshot bytes cannot be altered accidentally.
-
-    ``redact_sensitive_text`` deliberately owns the global opt-out. This helper
-    does not pass ``force=True`` and therefore preserves the documented
-    ``security.redact_secrets: false`` behavior.
-    """
-
-    def _redact_text(text: str) -> str:
-        return redact_sensitive_text(text, redact_url_credentials=True)
-
-    def _redact_parts(parts: list[Any]) -> list[Any]:
-        redacted_parts: list[Any] = []
-        for part in parts:
-            if isinstance(part, str):
-                redacted_parts.append(_redact_text(part))
-                continue
-            if not isinstance(part, dict) or part.get("type") not in {
-                "text",
-                "input_text",
-                "output_text",
-            }:
-                redacted_parts.append(part)
-                continue
-            redacted_part = dict(part)
-            for field in ("text", "content"):
-                field_value = redacted_part.get(field)
-                if isinstance(field_value, str):
-                    redacted_part[field] = _redact_text(field_value)
-            redacted_parts.append(redacted_part)
-        return redacted_parts
-
-    if isinstance(value, str):
-        return _redact_text(value)
-    if isinstance(value, list):
-        return _redact_parts(value)
-    if _is_multimodal_tool_result(value):
-        redacted_value = dict(value)
-        redacted_value["content"] = _redact_parts(value.get("content") or [])
-        if isinstance(value.get("text_summary"), str):
-            redacted_value["text_summary"] = _redact_text(value["text_summary"])
-        return redacted_value
-    return value
 
 
 def _extract_file_mutation_targets(tool_name: str, args: Dict[str, Any]) -> List[str]:

--- a/agent/tool_dispatch_helpers.py
+++ b/agent/tool_dispatch_helpers.py
@@ -33,6 +33,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from agent.message_metadata import stamp_message_timestamp
+from agent.redact import redact_sensitive_text
 from agent.tool_result_classification import (
     FILE_MUTATING_TOOL_NAMES as _FILE_MUTATING_TOOLS,
 )
@@ -451,6 +452,56 @@ def _append_subdir_hint_to_multimodal(value: Dict[str, Any], hint: str) -> None:
         value["text_summary"] = value["text_summary"] + hint
 
 
+def _redact_tool_result_for_egress(value: Any) -> Any:
+    """Redact model-visible tool-result text at the universal egress boundary.
+
+    Plain strings receive the normal configured redaction policy plus strict
+    URL query/userinfo masking. Multimodal envelopes and content lists are
+    rebuilt only where text-bearing parts change; image/base64 parts are kept
+    by identity so screenshot bytes cannot be altered accidentally.
+
+    ``redact_sensitive_text`` deliberately owns the global opt-out. This helper
+    does not pass ``force=True`` and therefore preserves the documented
+    ``security.redact_secrets: false`` behavior.
+    """
+
+    def _redact_text(text: str) -> str:
+        return redact_sensitive_text(text, redact_url_credentials=True)
+
+    def _redact_parts(parts: list[Any]) -> list[Any]:
+        redacted_parts: list[Any] = []
+        for part in parts:
+            if isinstance(part, str):
+                redacted_parts.append(_redact_text(part))
+                continue
+            if not isinstance(part, dict) or part.get("type") not in {
+                "text",
+                "input_text",
+                "output_text",
+            }:
+                redacted_parts.append(part)
+                continue
+            redacted_part = dict(part)
+            for field in ("text", "content"):
+                field_value = redacted_part.get(field)
+                if isinstance(field_value, str):
+                    redacted_part[field] = _redact_text(field_value)
+            redacted_parts.append(redacted_part)
+        return redacted_parts
+
+    if isinstance(value, str):
+        return _redact_text(value)
+    if isinstance(value, list):
+        return _redact_parts(value)
+    if _is_multimodal_tool_result(value):
+        redacted_value = dict(value)
+        redacted_value["content"] = _redact_parts(value.get("content") or [])
+        if isinstance(value.get("text_summary"), str):
+            redacted_value["text_summary"] = _redact_text(value["text_summary"])
+        return redacted_value
+    return value
+
+
 def _extract_file_mutation_targets(tool_name: str, args: Dict[str, Any]) -> List[str]:
     """Return the file paths a ``write_file`` or ``patch`` call is targeting.
 
@@ -613,11 +664,13 @@ def make_tool_result_message(
     # paths that do not go through the live executor's canonical-id helper.
     tool_call_id = _normalize_tool_call_id(tool_call_id)
 
-    # Order matters: detect provider-side elision on the RAW content and
-    # append the notice first, THEN wrap — so the notice lives inside the
-    # untrusted block next to the data it describes, appended exactly once
-    # at construction time (cache-safe).
-    wrapped = _maybe_wrap_untrusted(name, _maybe_append_elision_notice(name, content))
+    # Detect provider-side elision on the raw content, then redact every
+    # model-visible text carrier before wrapping it as untrusted data. Keep
+    # ``content`` unchanged for the risk scan below so redaction cannot hide
+    # evidence from classification.
+    content_with_notice = _maybe_append_elision_notice(name, content)
+    redacted_content = _redact_tool_result_for_egress(content_with_notice)
+    wrapped = _maybe_wrap_untrusted(name, redacted_content)
     message = stamp_message_timestamp({
         "role": "tool",
         "name": name,

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -33,14 +33,16 @@ from agent.display import (
     _detect_tool_failure,
 )
 from agent.message_sanitization import coalesce_tool_call_id
+from agent.tool_result_egress import (
+    is_multimodal_tool_result as _is_multimodal_tool_result,
+    redact_tool_result_for_egress as _redact_tool_result_for_egress,
+)
 from agent.tool_dispatch_helpers import (
     _NEVER_PARALLEL_TOOLS,
     _is_destructive_command,
-    _is_multimodal_tool_result,
     _multimodal_text_summary,
     _append_subdir_hint_to_multimodal,
     _plan_tool_batch_segments,
-    _redact_tool_result_for_egress,
     make_tool_result_message,
 )
 from tools.terminal_tool import (

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -40,6 +40,7 @@ from agent.tool_dispatch_helpers import (
     _multimodal_text_summary,
     _append_subdir_hint_to_multimodal,
     _plan_tool_batch_segments,
+    _redact_tool_result_for_egress,
     make_tool_result_message,
 )
 from tools.terminal_tool import (
@@ -311,6 +312,9 @@ def _emit_terminal_post_tool_call(
     error_message: str | None = None,
     middleware_trace: Optional[list[dict[str, Any]]] = None,
 ) -> None:
+    result = _redact_tool_result_for_egress(result)
+    if isinstance(error_message, str):
+        error_message = _redact_tool_result_for_egress(error_message)
     try:
         from model_tools import _emit_post_tool_call_hook
         _emit_post_tool_call_hook(
@@ -692,6 +696,7 @@ def _run_agent_tool_execution_middleware(
                     getattr(guardrail_decision, "message", None)
                     or "Tool blocked by guardrail policy"
                 )
+            result = _redact_tool_result_for_egress(result)
             _emit_terminal_post_tool_call(
                 agent,
                 function_name=function_name,
@@ -729,7 +734,7 @@ def _run_agent_tool_execution_middleware(
         )
         _hb_thread.start()
         try:
-            return execute(final_args)
+            return _redact_tool_result_for_egress(execute(final_args))
         finally:
             _hb_stop.set()
             _hb_thread.join(timeout=2.0)
@@ -779,7 +784,7 @@ def _run_agent_tool_execution_middleware(
         },
     )
     return _ManagedToolResult(
-        result=result,
+        result=_redact_tool_result_for_egress(result),
         args=state["args"],
         middleware_trace=state["middleware_trace"],
         blocked=bool(state["blocked"]),
@@ -1441,8 +1446,9 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                 )
                 return
             except Exception as tool_error:
-                result = f"Error executing tool '{function_name}': {tool_error}"
-                logger.error("_invoke_tool raised for %s: %s", function_name, tool_error, exc_info=True)
+                safe_error = _redact_tool_result_for_egress(str(tool_error))
+                result = f"Error executing tool '{function_name}': {safe_error}"
+                logger.error("_invoke_tool raised for %s: %s", function_name, safe_error)
             duration = time.time() - start
             if not blocked and not dispatched:
                 _emit_terminal_post_tool_call(
@@ -1789,6 +1795,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                     failed=is_error,
                     tool_call_id=tool_call_id,
                 )
+                function_result = _redact_tool_result_for_egress(function_result)
 
             if is_error:
                 _err_text = _multimodal_text_summary(function_result)
@@ -2451,8 +2458,9 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 ))
                 _ce_result = function_result
             except Exception as tool_error:
-                function_result = json.dumps({"error": f"Context engine tool '{function_name}' failed: {tool_error}"})
-                logger.error("context_engine.handle_tool_call raised for %s: %s", function_name, tool_error, exc_info=True)
+                safe_error = _redact_tool_result_for_egress(str(tool_error))
+                function_result = json.dumps({"error": f"Context engine tool '{function_name}' failed: {safe_error}"})
+                logger.error("context_engine.handle_tool_call raised for %s: %s", function_name, safe_error)
             finally:
                 tool_duration = time.time() - tool_start_time
                 cute_msg = _get_cute_tool_message_impl(function_name, function_args, tool_duration, result=_ce_result)
@@ -2487,8 +2495,9 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 ))
                 _mem_result = function_result
             except Exception as tool_error:
-                function_result = json.dumps({"error": f"Memory tool '{function_name}' failed: {tool_error}"})
-                logger.error("memory_manager.handle_tool_call raised for %s: %s", function_name, tool_error, exc_info=True)
+                safe_error = _redact_tool_result_for_egress(str(tool_error))
+                function_result = json.dumps({"error": f"Memory tool '{function_name}' failed: {safe_error}"})
+                logger.error("memory_manager.handle_tool_call raised for %s: %s", function_name, safe_error)
             finally:
                 tool_duration = time.time() - tool_start_time
                 cute_msg = _get_cute_tool_message_impl(function_name, function_args, tool_duration, result=_mem_result)
@@ -2578,8 +2587,9 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 )
                 raise
             except Exception as tool_error:
-                function_result = f"Error executing tool '{function_name}': {tool_error}"
-                logger.error("handle_function_call raised for %s: %s", function_name, tool_error, exc_info=True)
+                safe_error = _redact_tool_result_for_egress(str(tool_error))
+                function_result = f"Error executing tool '{function_name}': {safe_error}"
+                logger.error("handle_function_call raised for %s: %s", function_name, safe_error)
             finally:
                 tool_duration = time.time() - tool_start_time
                 cute_msg = _get_cute_tool_message_impl(function_name, function_args, tool_duration, result=_spinner_result)
@@ -2657,13 +2667,15 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 )
                 raise
             except Exception as tool_error:
-                function_result = f"Error executing tool '{function_name}': {tool_error}"
-                logger.error("handle_function_call raised for %s: %s", function_name, tool_error, exc_info=True)
+                safe_error = _redact_tool_result_for_egress(str(tool_error))
+                function_result = f"Error executing tool '{function_name}': {safe_error}"
+                logger.error("handle_function_call raised for %s: %s", function_name, safe_error)
             tool_duration = time.time() - tool_start_time
 
         _execution_timed_out = isinstance(
             function_result, (_ToolTimeoutResult, _ToolCancelledResult)
         )
+        function_result = _redact_tool_result_for_egress(function_result)
         if isinstance(function_result, str):
             result_preview = function_result if agent.verbose_logging else (
                 function_result[:200] if len(function_result) > 200 else function_result
@@ -2707,6 +2719,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 failed=_is_error_result,
                 tool_call_id=tool_call_id,
             )
+            function_result = _redact_tool_result_for_egress(function_result)
             result_preview = function_result if agent.verbose_logging else (
                 function_result[:200] if len(function_result) > 200 else function_result
             )

--- a/agent/tool_result_egress.py
+++ b/agent/tool_result_egress.py
@@ -1,0 +1,67 @@
+"""Canonical model-visible tool-result egress sanitation.
+
+The executor and message-construction paths share this bounded owner while
+``agent.tool_executor`` is fractured under #79975. Legacy private imports remain
+available through compatibility aliases in ``agent.tool_dispatch_helpers``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agent.redact import redact_sensitive_text
+
+
+def is_multimodal_tool_result(value: Any) -> bool:
+    """Return whether ``value`` is a supported multimodal result envelope."""
+    return (
+        isinstance(value, dict)
+        and value.get("_multimodal") is True
+        and isinstance(value.get("content"), list)
+    )
+
+
+def redact_tool_result_for_egress(value: Any) -> Any:
+    """Redact every model-visible text carrier without altering media bytes.
+
+    Plain strings receive the configured redaction policy plus strict URL
+    userinfo/query masking. Text parts are copied before mutation; non-text
+    image/base64 parts are retained by identity. ``redact_sensitive_text`` owns
+    the global opt-out, so this function deliberately does not force redaction.
+    """
+
+    def redact_text(text: str) -> str:
+        return redact_sensitive_text(text, redact_url_credentials=True)
+
+    def redact_parts(parts: list[Any]) -> list[Any]:
+        redacted_parts: list[Any] = []
+        for part in parts:
+            if isinstance(part, str):
+                redacted_parts.append(redact_text(part))
+                continue
+            if not isinstance(part, dict) or part.get("type") not in {
+                "text",
+                "input_text",
+                "output_text",
+            }:
+                redacted_parts.append(part)
+                continue
+            redacted_part = dict(part)
+            for field in ("text", "content"):
+                field_value = redacted_part.get(field)
+                if isinstance(field_value, str):
+                    redacted_part[field] = redact_text(field_value)
+            redacted_parts.append(redacted_part)
+        return redacted_parts
+
+    if isinstance(value, str):
+        return redact_text(value)
+    if isinstance(value, list):
+        return redact_parts(value)
+    if is_multimodal_tool_result(value):
+        redacted_value = dict(value)
+        redacted_value["content"] = redact_parts(value.get("content") or [])
+        if isinstance(value.get("text_summary"), str):
+            redacted_value["text_summary"] = redact_text(value["text_summary"])
+        return redacted_value
+    return value

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1696,16 +1696,12 @@ def is_runtime_provider_routable(provider_id: str) -> bool:
 def _suppressed_sources_for_provider(
     auth_store: Dict[str, Any], provider_id: str
 ) -> set[str]:
-    """Return profile-local credential source suppressions without mutating them."""
-    suppressed = auth_store.get("suppressed_sources")
-    if not isinstance(suppressed, dict):
-        return set()
-    raw_sources = suppressed.get(provider_id)
-    if isinstance(raw_sources, list):
-        return {str(source) for source in raw_sources if source}
-    if isinstance(raw_sources, dict):
-        return {str(source) for source in raw_sources if source}
-    return set()
+    """Return the union of profile and root suppressions for global fallback."""
+    local_sources = set(_suppressed_sources_for(auth_store, provider_id))
+    global_sources = set(
+        _suppressed_sources_for(_load_global_auth_store(), provider_id)
+    )
+    return local_sources | global_sources
 
 
 def _filter_suppressed_global_entries(

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -87,6 +87,12 @@ from hermes_cli.config import (
     read_raw_config,
     require_readable_config_before_write,
 )
+from hermes_cli.auth_suppression import (
+    filter_suppressed_entries as _filter_suppressed_global_entries,
+    source_is_suppressed as _source_is_suppressed,
+    suppressed_sources_for as _suppressed_sources_for,
+    suppression_union as _suppression_union,
+)
 from hermes_constants import OPENROUTER_BASE_URL, secure_parent_dir
 from agent.credential_persistence import sanitize_borrowed_credential_payload
 from utils import atomic_replace, atomic_yaml_write, env_float, is_truthy_value
@@ -1696,28 +1702,12 @@ def is_runtime_provider_routable(provider_id: str) -> bool:
 def _suppressed_sources_for_provider(
     auth_store: Dict[str, Any], provider_id: str
 ) -> set[str]:
-    """Return the union of profile and root suppressions for global fallback."""
-    local_sources = set(_suppressed_sources_for(auth_store, provider_id))
-    global_sources = set(
-        _suppressed_sources_for(_load_global_auth_store(), provider_id)
+    """Compatibility delegate to the canonical profile/root suppression owner."""
+    return _suppression_union(
+        auth_store,
+        _load_global_auth_store(),
+        provider_id,
     )
-    return local_sources | global_sources
-
-
-def _filter_suppressed_global_entries(
-    entries: List[Any], suppressed_sources: set[str]
-) -> List[Any]:
-    """Remove only global fallback entries explicitly suppressed by source."""
-    if not suppressed_sources:
-        return list(entries)
-    return [
-        entry
-        for entry in entries
-        if not (
-            isinstance(entry, dict)
-            and entry.get("source") in suppressed_sources
-        )
-    ]
 
 
 def read_credential_pool(
@@ -1942,24 +1932,6 @@ def suppress_credential_source(provider_id: str, source: str) -> None:
         _save_auth_store(auth_store)
 
 
-def _suppressed_sources_for(store: Dict[str, Any], provider_id: str) -> List[str]:
-    """The source names suppressed for ``provider_id`` in one auth store.
-
-    Both shapes of the per-provider entry are accepted: the writers above store a
-    list, but an older store may hold a mapping whose keys are the source names
-    (both migrate it in place the next time they touch it).
-    """
-    suppressed = store.get("suppressed_sources")
-    if not isinstance(suppressed, dict):
-        return []
-    entries = suppressed.get(provider_id)
-    if isinstance(entries, dict):
-        return [str(name) for name in entries]
-    if isinstance(entries, (list, tuple, set)):
-        return [str(name) for name in entries]
-    return []
-
-
 def is_source_suppressed(provider_id: str, source: str) -> bool:
     """Check if a credential source has been suppressed by the user.
 
@@ -1981,11 +1953,12 @@ def is_source_suppressed(provider_id: str, source: str) -> bool:
 
     """
     try:
-        if source in _suppressed_sources_for(_load_auth_store(), provider_id):
-            return True
-        # Returns {} in classic mode and never raises, so this is a no-op when
-        # there is no global root distinct from the profile.
-        return source in _suppressed_sources_for(_load_global_auth_store(), provider_id)
+        return _source_is_suppressed(
+            _load_auth_store(),
+            _load_global_auth_store(),
+            provider_id,
+            source,
+        )
     except Exception:
         return False
 

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -78,7 +78,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
-from typing import Any, Callable, Dict, FrozenSet, Iterable, List, Optional, Tuple
+from typing import Any, Callable, Dict, FrozenSet, Iterable, List, Optional, Tuple, Union
 from urllib.parse import parse_qs, urlencode, urlparse
 
 from hermes_cli.config import (
@@ -1469,6 +1469,23 @@ def _save_auth_store(auth_store: Dict[str, Any], target_path: Optional[Path] = N
     return auth_file
 
 
+_GLOBAL_PROVIDER_STATE_SOURCES = {
+    "nous": "device_code",
+    "openai-codex": "device_code",
+    "xai-oauth": "device_code",
+}
+
+
+def _global_provider_state_source(
+    provider_id: str, state: Dict[str, Any]
+) -> Optional[str]:
+    """Resolve the source whose suppression governs a global singleton state."""
+    explicit_source = state.get("source")
+    if isinstance(explicit_source, str) and explicit_source.strip():
+        return explicit_source.strip()
+    return _GLOBAL_PROVIDER_STATE_SOURCES.get(provider_id)
+
+
 def _load_provider_state_with_source(
     auth_store: Dict[str, Any],
     provider_id: str,
@@ -1495,6 +1512,15 @@ def _load_provider_state_with_source(
         if isinstance(global_providers, dict):
             global_state = global_providers.get(provider_id)
             if isinstance(global_state, dict):
+                fallback_source = _global_provider_state_source(
+                    provider_id, global_state
+                )
+                if (
+                    fallback_source
+                    and fallback_source
+                    in _suppressed_sources_for_provider(auth_store, provider_id)
+                ):
+                    return None, None
                 return dict(global_state), global_path
     return None, None
 
@@ -1667,7 +1693,40 @@ def is_runtime_provider_routable(provider_id: str) -> bool:
     return True
 
 
-def read_credential_pool(provider_id: Optional[str] = None) -> Dict[str, Any]:
+def _suppressed_sources_for_provider(
+    auth_store: Dict[str, Any], provider_id: str
+) -> set[str]:
+    """Return profile-local credential source suppressions without mutating them."""
+    suppressed = auth_store.get("suppressed_sources")
+    if not isinstance(suppressed, dict):
+        return set()
+    raw_sources = suppressed.get(provider_id)
+    if isinstance(raw_sources, list):
+        return {str(source) for source in raw_sources if source}
+    if isinstance(raw_sources, dict):
+        return {str(source) for source in raw_sources if source}
+    return set()
+
+
+def _filter_suppressed_global_entries(
+    entries: List[Any], suppressed_sources: set[str]
+) -> List[Any]:
+    """Remove only global fallback entries explicitly suppressed by source."""
+    if not suppressed_sources:
+        return list(entries)
+    return [
+        entry
+        for entry in entries
+        if not (
+            isinstance(entry, dict)
+            and entry.get("source") in suppressed_sources
+        )
+    ]
+
+
+def read_credential_pool(
+    provider_id: Optional[str] = None,
+) -> Union[Dict[str, Any], List[Any]]:
     """Return the persisted credential pool, or one provider slice.
 
     In profile mode, the profile's credential pool is authoritative. If a
@@ -1703,7 +1762,12 @@ def read_credential_pool(provider_id: Optional[str] = None) -> Dict[str, Any]:
             existing = merged.get(gp_key)
             if isinstance(existing, list) and existing:
                 continue
-            merged[gp_key] = list(gp_entries)
+            filtered_entries = _filter_suppressed_global_entries(
+                gp_entries,
+                _suppressed_sources_for_provider(auth_store, gp_key),
+            )
+            if filtered_entries:
+                merged[gp_key] = filtered_entries
         return merged
 
     provider_entries = pool.get(provider_id)
@@ -1711,7 +1775,12 @@ def read_credential_pool(provider_id: Optional[str] = None) -> Dict[str, Any]:
         return list(provider_entries)
     # Profile has no entries for this provider — fall back to global.
     global_entries = global_pool.get(provider_id)
-    return list(global_entries) if isinstance(global_entries, list) else []
+    if not isinstance(global_entries, list):
+        return []
+    return _filter_suppressed_global_entries(
+        global_entries,
+        _suppressed_sources_for_provider(auth_store, provider_id),
+    )
 
 
 _POOL_STATUS_FIELDS = (

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1946,12 +1946,50 @@ def suppress_credential_source(provider_id: str, source: str) -> None:
         _save_auth_store(auth_store)
 
 
+def _suppressed_sources_for(store: Dict[str, Any], provider_id: str) -> List[str]:
+    """The source names suppressed for ``provider_id`` in one auth store.
+
+    Both shapes of the per-provider entry are accepted: the writers above store a
+    list, but an older store may hold a mapping whose keys are the source names
+    (both migrate it in place the next time they touch it).
+    """
+    suppressed = store.get("suppressed_sources")
+    if not isinstance(suppressed, dict):
+        return []
+    entries = suppressed.get(provider_id)
+    if isinstance(entries, dict):
+        return [str(name) for name in entries]
+    if isinstance(entries, (list, tuple, set)):
+        return [str(name) for name in entries]
+    return []
+
+
 def is_source_suppressed(provider_id: str, source: str) -> bool:
-    """Check if a credential source has been suppressed by the user."""
+    """Check if a credential source has been suppressed by the user.
+
+    Consults the profile store AND the global root, and answers their UNION.
+
+    ``read_credential_pool`` and ``_load_provider_state_with_source`` already fall
+    back to the global root so a provider authed there is visible to a profile
+    process that has not configured it locally. This one did not, which left the
+    deny-list as the one piece of auth state a profile escaped by simply not
+    repeating it: ``hermes auth remove`` at the root writes a suppression marker
+    meaning "stop seeding this source", and every profile then re-seeded it anyway.
+
+    Union rather than shadow, deliberately. For a credential pool, a profile's own
+    answer should win when it has one — that is what shadowing is for. A deny-list
+    is the opposite: it must not be escapable by omission, or it is not a list. The
+    cost is that a global suppression can no longer be overridden in one profile;
+    expressing that now means unsuppressing globally and suppressing in the others,
+    which states the intent explicitly instead of relying on an absent key.
+
+    """
     try:
-        auth_store = _load_auth_store()
-        suppressed = auth_store.get("suppressed_sources", {})
-        return source in suppressed.get(provider_id, [])
+        if source in _suppressed_sources_for(_load_auth_store(), provider_id):
+            return True
+        # Returns {} in classic mode and never raises, so this is a no-op when
+        # there is no global root distinct from the profile.
+        return source in _suppressed_sources_for(_load_global_auth_store(), provider_id)
     except Exception:
         return False
 
@@ -1983,6 +2021,42 @@ def unsuppress_credential_source(provider_id: str, source: str) -> bool:
             auth_store.pop("suppressed_sources", None)
         _save_auth_store(auth_store)
         return True
+
+
+def lift_provider_suppressions(provider_id: str) -> List[str]:
+    """Lift every suppression marker this scope can write for ``provider_id``.
+
+    Re-adding a credential is an explicit re-engagement signal, so ``hermes auth
+    add`` and the dashboard's pool-add both clear the provider's whole deny-list
+    rather than only the source being re-added.
+
+    Writes stay scoped to this process's store — a profile must not rewrite the
+    global root on the other profiles' behalf — so in profile mode a marker set at
+    the root survives, and because ``is_source_suppressed`` answers the union of
+    both scopes it stays in force. Those names are RETURNED rather than dropped so
+    the caller can say so, instead of reporting a clean re-engagement and leaving
+    the user to wonder why a provider they just re-added still will not seed from
+    that source. Always empty in classic mode, where there is no global scope
+    distinct from this one.
+    """
+    try:
+        local = _suppressed_sources_for(_load_auth_store(), provider_id)
+    except Exception:
+        logger.debug(
+            "auth: could not read suppression markers for %s", provider_id, exc_info=True
+        )
+        return []
+    for source in local:
+        try:
+            unsuppress_credential_source(provider_id, source)
+        except Exception:
+            logger.debug(
+                "auth: could not lift suppression %s/%s", provider_id, source, exc_info=True
+            )
+    try:
+        return _suppressed_sources_for(_load_global_auth_store(), provider_id)
+    except Exception:
+        return []
 
 
 def get_provider_auth_state(provider_id: str) -> Optional[Dict[str, Any]]:

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -264,20 +264,23 @@ def auth_add_command(args) -> None:
 
     pool = load_pool(provider)
 
-    # Clear ALL suppressions for this provider — re-adding a credential is
-    # a strong signal the user wants auth re-enabled.  This covers env:*
-    # (shell-exported vars), gh_cli (copilot), claude_code, qwen-cli,
+    # Clear every suppression this scope can write for the provider — re-adding a
+    # credential is a strong signal the user wants auth re-enabled.  This covers
+    # env:* (shell-exported vars), gh_cli (copilot), claude_code, qwen-cli,
     # device_code (codex), etc.  One consistent re-engagement pattern.
     # Matches the Codex device_code re-link pattern that predates this.
     if not provider.startswith(CUSTOM_POOL_PREFIX):
         try:
-            from hermes_cli.auth import (
-                _load_auth_store,
-                unsuppress_credential_source,
-            )
-            suppressed = _load_auth_store().get("suppressed_sources", {})
-            for src in list(suppressed.get(provider, []) or []):
-                unsuppress_credential_source(provider, src)
+            from hermes_cli.auth import lift_provider_suppressions
+
+            still_suppressed = lift_provider_suppressions(provider)
+            if still_suppressed:
+                print(
+                    f"Note: {provider} stays suppressed at the global root for "
+                    f"{', '.join(sorted(still_suppressed))} — a profile cannot lift a "
+                    f"marker it does not own.  Re-run outside the profile to seed "
+                    f"from those sources."
+                )
         except Exception:
             pass
 

--- a/hermes_cli/auth_suppression.py
+++ b/hermes_cli/auth_suppression.py
@@ -1,0 +1,65 @@
+"""Canonical credential-source suppression policy.
+
+This bounded owner keeps deny-list parsing and profile/root composition out of
+``hermes_cli.auth`` while that legacy module is fractured under #78637.  The
+legacy module retains thin compatibility delegates for existing imports.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+
+def suppressed_sources_for(store: Mapping[str, Any], provider_id: str) -> list[str]:
+    """Return source names suppressed for one provider in one auth store.
+
+    Writers use a list today, while older stores may contain a mapping keyed by
+    source name. Reading is shape-tolerant and never mutates the supplied store.
+    """
+    suppressed = store.get("suppressed_sources")
+    if not isinstance(suppressed, dict):
+        return []
+    entries = suppressed.get(provider_id)
+    if isinstance(entries, dict):
+        return [str(name) for name in entries]
+    if isinstance(entries, (list, tuple, set)):
+        return [str(name) for name in entries]
+    return []
+
+
+def suppression_union(
+    local_store: Mapping[str, Any],
+    global_store: Mapping[str, Any],
+    provider_id: str,
+) -> set[str]:
+    """Return the union of local and root deny-lists for ``provider_id``."""
+    return set(suppressed_sources_for(local_store, provider_id)) | set(
+        suppressed_sources_for(global_store, provider_id)
+    )
+
+
+def source_is_suppressed(
+    local_store: Mapping[str, Any],
+    global_store: Mapping[str, Any],
+    provider_id: str,
+    source: str,
+) -> bool:
+    """Return whether either scope denies ``source`` for ``provider_id``."""
+    return source in suppression_union(local_store, global_store, provider_id)
+
+
+def filter_suppressed_entries(
+    entries: list[Any], suppressed_sources: set[str]
+) -> list[Any]:
+    """Remove global fallback entries whose explicit source is denied."""
+    if not suppressed_sources:
+        return list(entries)
+    return [
+        entry
+        for entry in entries
+        if not (
+            isinstance(entry, dict)
+            and entry.get("source") in suppressed_sources
+        )
+    ]

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -14313,13 +14313,19 @@ async def add_credential_pool_entry(body: CredentialPoolAdd):
         # Mirrors the `hermes auth add` behaviour in auth_commands.py.
         if not provider.startswith(CUSTOM_POOL_PREFIX):
             try:
-                from hermes_cli.auth import (
-                    _load_auth_store,
-                    unsuppress_credential_source,
-                )
-                suppressed = _load_auth_store().get("suppressed_sources", {})
-                for src in list(suppressed.get(provider, []) or []):
-                    unsuppress_credential_source(provider, src)
+                from hermes_cli.auth import lift_provider_suppressions
+
+                still_suppressed = lift_provider_suppressions(provider)
+                if still_suppressed:
+                    # A profile cannot rewrite the global root and
+                    # is_source_suppressed answers the union of both scopes, so
+                    # name the sources that stay denied instead of logging a
+                    # re-engagement that only partly happened.
+                    _log.warning(
+                        "pool add: %s stays suppressed at the global root for %s",
+                        provider,
+                        ", ".join(sorted(still_suppressed)),
+                    )
             except Exception:
                 _log.exception("unsuppress after pool add failed (non-fatal)")
     except HTTPException:

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -1,5 +1,6 @@
 """Tests for agent.redact -- secret masking in logs and output."""
 
+import json
 import logging
 
 import pytest
@@ -112,6 +113,28 @@ class TestEnvAssignments:
         assert result.startswith("export ")
         assert "SECRET_TOKEN=" in result
         assert "mypassword" not in result
+
+    @pytest.mark.parametrize(
+        ("key", "delimiter", "opposite_quote"),
+        [
+            ("API_KEY", "'", '"'),
+            ("API_KEY", '"', "'"),
+            ("openai_key", "'", '"'),
+            ("openai_key", '"', "'"),
+        ],
+    )
+    def test_quoted_env_value_with_opposite_quote_redacts_without_swallowing_markup(
+        self, key, delimiter, opposite_quote
+    ):
+        value = "opaque-value-" + opposite_quote + "-still-secret-123456"
+        markup = "<span>public-tail</span>"
+        text = f"{key}={delimiter}{value}{delimiter};{markup}"
+
+        result = redact_sensitive_text(text, force=True)
+
+        assert value not in result
+        assert result.startswith(f"{key}={delimiter}")
+        assert result.endswith(f"{delimiter};{markup}")
 
 
 class TestBareSecretEnvSuffixes:
@@ -250,6 +273,76 @@ class TestJsonFields:
         text = '{"name": "John", "model": "gpt-4"}'
         result = redact_sensitive_text(text)
         assert result == text
+
+    @pytest.mark.parametrize(
+        "mode",
+        ["default", "code_file", "file_read", "terminal"],
+    )
+    def test_exact_credential_fields_redact_in_every_output_mode(self, mode):
+        access_value = "access-" + "opaque-carrier-value"
+        refresh_value = "refresh-" + "opaque-carrier-value"
+        session_value = "session-" + "opaque-carrier-value"
+        digest = "7f" * 32
+        text = json.dumps({
+            "access_token": access_value,
+            "refresh_token": refresh_value,
+            "session_token": session_value,
+            "sha256": digest,
+            "message": "token_count remains public prose",
+        })
+
+        if mode == "terminal":
+            from agent.redact import redact_terminal_output
+
+            result = redact_terminal_output(text, "printf result", force=True)
+        else:
+            result = redact_sensitive_text(
+                text,
+                force=True,
+                code_file=mode == "code_file",
+                file_read=mode == "file_read",
+            )
+
+        assert access_value not in result
+        assert refresh_value not in result
+        assert session_value not in result
+        assert digest in result
+        assert "token_count remains public prose" in result
+
+    @pytest.mark.parametrize(
+        "mode",
+        ["default", "code_file", "file_read", "terminal"],
+    )
+    def test_dashboard_session_assignment_redacts_without_consuming_markup(
+        self, mode
+    ):
+        session_value = "dashboard-" + "opaque-carrier-value"
+        digest = "ab" * 32
+        text = (
+            '<script>window.__HERMES_SESSION_TOKEN__ = "'
+            + session_value
+            + '";</script><main data-sha="'
+            + digest
+            + '">ready</main>'
+        )
+
+        if mode == "terminal":
+            from agent.redact import redact_terminal_output
+
+            result = redact_terminal_output(text, "printf result", force=True)
+        else:
+            result = redact_sensitive_text(
+                text,
+                force=True,
+                code_file=mode == "code_file",
+                file_read=mode == "file_read",
+            )
+
+        assert session_value not in result
+        assert "window.__HERMES_SESSION_TOKEN__" in result
+        assert result.endswith(
+            '";</script><main data-sha="' + digest + '">ready</main>'
+        )
 
 
 class TestAuthHeaders:

--- a/tests/agent/test_tool_dispatch_helpers.py
+++ b/tests/agent/test_tool_dispatch_helpers.py
@@ -8,6 +8,8 @@ NOT a regex scan — it's an unconditional architectural mark on every result
 from a known-untrusted source.
 """
 
+import json
+
 import pytest
 
 from agent.tool_dispatch_helpers import (
@@ -134,6 +136,78 @@ class TestUntrustedWrapping:
 
 
 class TestMakeToolResultMessage:
+
+    def test_plain_tool_result_redacts_exact_carriers_and_strict_urls(self):
+        refresh_value = "refresh-" + "opaque-egress-value"
+        session_value = "dashboard-" + "opaque-egress-value"
+        query_value = "query-" + "opaque-egress-value"
+        password_value = "password-" + "opaque-egress-value"
+        raw = (
+            json.dumps({"refresh_token": refresh_value})
+            + '\n<script>window.__HERMES_SESSION_TOKEN__ = "'
+            + session_value
+            + '";</script>\nhttps://user:'
+            + password_value
+            + "@example.test/path?token="
+            + query_value
+            + "&view=public"
+        )
+
+        msg = make_tool_result_message("terminal", raw, "call_egress_plain")
+
+        assert refresh_value not in msg["content"]
+        assert session_value not in msg["content"]
+        assert query_value not in msg["content"]
+        assert password_value not in msg["content"]
+        assert "view=public" in msg["content"]
+        assert "</script>" in msg["content"]
+
+    def test_multimodal_tool_result_redacts_text_only(self):
+        refresh_value = "refresh-" + "opaque-multimodal-value"
+        query_value = "query-" + "opaque-multimodal-value"
+        raw_text = (
+            json.dumps({"refresh_token": refresh_value})
+            + " https://example.test/cb?token="
+            + query_value
+        )
+        image_part = {
+            "type": "image_url",
+            "image_url": {
+                "url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUg==",
+            },
+        }
+        envelope = {
+            "_multimodal": True,
+            "content": [
+                {"type": "text", "text": raw_text},
+                {"type": "text", "content": raw_text},
+                image_part,
+            ],
+            "text_summary": raw_text,
+        }
+
+        msg = make_tool_result_message("terminal", envelope, "call_egress_multi")
+        result = msg["content"]
+
+        assert refresh_value not in result["content"][0]["text"]
+        assert query_value not in result["content"][0]["text"]
+        assert refresh_value not in result["content"][1]["content"]
+        assert query_value not in result["content"][1]["content"]
+        assert refresh_value not in result["text_summary"]
+        assert query_value not in result["text_summary"]
+        assert result["content"][2] is image_part
+        assert result["content"][2]["image_url"]["url"] == (
+            "data:image/png;base64,iVBORw0KGgoAAAANSUhEUg=="
+        )
+
+    def test_tool_result_egress_preserves_global_redaction_opt_out(self, monkeypatch):
+        query_value = "query-" + "opaque-opt-out-value"
+        raw = "https://example.test/cb?token=" + query_value
+        monkeypatch.setattr("agent.redact._REDACT_ENABLED", False)
+
+        msg = make_tool_result_message("terminal", raw, "call_egress_opt_out")
+
+        assert query_value in msg["content"]
 
     def test_message_is_timestamped_when_result_is_created(self, monkeypatch):
         monkeypatch.setattr("agent.message_metadata.wall_time", lambda: 123.5)

--- a/tests/agent/test_tool_result_egress.py
+++ b/tests/agent/test_tool_result_egress.py
@@ -1,0 +1,42 @@
+"""Tool-result callbacks must receive the same redacted egress payload as the model."""
+
+from types import SimpleNamespace
+
+
+def test_terminal_post_hook_receives_redacted_result_and_error(monkeypatch):
+    from agent.tool_executor import _emit_terminal_post_tool_call
+
+    captured = {}
+
+    def capture_hook(**kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr("model_tools._emit_post_tool_call_hook", capture_hook)
+    query_value = "query-" + "opaque-callback-value"
+    refresh_value = "refresh-" + "opaque-callback-value"
+    raw = (
+        '{"refresh_token": "'
+        + refresh_value
+        + '"} https://example.test/cb?token='
+        + query_value
+    )
+    agent = SimpleNamespace(
+        session_id="synthetic-session",
+        _current_turn_id="synthetic-turn",
+        _current_api_request_id="synthetic-request",
+    )
+
+    _emit_terminal_post_tool_call(
+        agent,
+        function_name="synthetic_tool",
+        function_args={},
+        result=raw,
+        effective_task_id="synthetic-task",
+        tool_call_id="synthetic-call",
+        error_message=raw,
+    )
+
+    assert refresh_value not in captured["result"]
+    assert query_value not in captured["result"]
+    assert refresh_value not in captured["error_message"]
+    assert query_value not in captured["error_message"]

--- a/tests/hermes_cli/test_auth_profile_fallback.py
+++ b/tests/hermes_cli/test_auth_profile_fallback.py
@@ -19,12 +19,18 @@ from pathlib import Path
 import pytest
 
 
-def _make_auth_store(pool: dict | None = None, providers: dict | None = None) -> dict:
+def _make_auth_store(
+    pool: dict | None = None,
+    providers: dict | None = None,
+    suppressed_sources: dict | None = None,
+) -> dict:
     store: dict = {"version": 1}
     if pool is not None:
         store["credential_pool"] = pool
     if providers is not None:
         store["providers"] = providers
+    if suppressed_sources is not None:
+        store["suppressed_sources"] = suppressed_sources
     return store
 
 
@@ -55,6 +61,53 @@ def _write(path: Path, payload: dict) -> None:
 # ---------------------------------------------------------------------------
 # read_credential_pool — provider-slice reads
 # ---------------------------------------------------------------------------
+
+
+def _fallback_entry(entry_id: str, source: str) -> dict:
+    return {
+        "id": entry_id,
+        "label": entry_id,
+        "auth_type": "oauth",
+        "priority": 0,
+        "source": source,
+        "access_token": "opaque-" + entry_id + "-value",
+    }
+
+
+def test_provider_slice_filters_suppressed_global_sources(profile_env):
+    from hermes_cli.auth import read_credential_pool
+
+    suppressed_source = "device_code"
+    _write(profile_env["global"] / "auth.json", _make_auth_store(pool={
+        "xai-oauth": [
+            _fallback_entry("global-device", suppressed_source),
+            _fallback_entry("global-manual", "manual"),
+        ],
+    }))
+    _write(
+        profile_env["profile"] / "auth.json",
+        _make_auth_store(
+            pool={},
+            suppressed_sources={"xai-oauth": [suppressed_source]},
+        ),
+    )
+
+    assert [entry["id"] for entry in read_credential_pool("xai-oauth")] == [
+        "global-manual"
+    ]
+
+    # A non-empty local slice remains authoritative even when global fallback
+    # has unsuppressed entries available.
+    _write(
+        profile_env["profile"] / "auth.json",
+        _make_auth_store(
+            pool={"xai-oauth": [_fallback_entry("profile-local", "manual")]},
+            suppressed_sources={"xai-oauth": [suppressed_source]},
+        ),
+    )
+    assert [entry["id"] for entry in read_credential_pool("xai-oauth")] == [
+        "profile-local"
+    ]
 
 
 
@@ -109,9 +162,65 @@ def test_malformed_global_auth_file_does_not_break_profile_read(profile_env):
 # ---------------------------------------------------------------------------
 
 
+def test_whole_pool_merge_filters_suppressed_global_sources(profile_env):
+    from hermes_cli.auth import read_credential_pool
+
+    suppressed_source = "device_code"
+    _write(profile_env["global"] / "auth.json", _make_auth_store(pool={
+        "xai-oauth": [
+            _fallback_entry("global-device", suppressed_source),
+            _fallback_entry("global-manual", "manual"),
+        ],
+        "openrouter": [_fallback_entry("global-router", "manual")],
+    }))
+    _write(
+        profile_env["profile"] / "auth.json",
+        _make_auth_store(
+            pool={},
+            suppressed_sources={"xai-oauth": [suppressed_source]},
+        ),
+    )
+
+    merged = read_credential_pool()
+    assert isinstance(merged, dict)
+    assert [entry["id"] for entry in merged["xai-oauth"]] == ["global-manual"]
+    assert [entry["id"] for entry in merged["openrouter"]] == ["global-router"]
+
+
+
 # ---------------------------------------------------------------------------
 # get_provider_auth_state — singleton fallback
 # ---------------------------------------------------------------------------
+
+
+def test_provider_state_fallback_respects_profile_source_suppression(profile_env):
+    from hermes_cli.auth import get_provider_auth_state
+
+    suppressed_source = "device_code"
+    access_value = "xai-access-" + "opaque-value"
+    refresh_value = "xai-refresh-" + "opaque-value"
+    _write(
+        profile_env["global"] / "auth.json",
+        _make_auth_store(providers={
+            "xai-oauth": {
+                "tokens": {
+                    "access_token": access_value,
+                    "refresh_token": refresh_value,
+                },
+                "auth_mode": "oauth_device_code",
+            },
+        }),
+    )
+    _write(
+        profile_env["profile"] / "auth.json",
+        _make_auth_store(
+            providers={},
+            suppressed_sources={"xai-oauth": [suppressed_source]},
+        ),
+    )
+
+    assert get_provider_auth_state("xai-oauth") is None
+
 
 
 def test_provider_auth_state_falls_back_to_global_when_profile_has_none(profile_env):

--- a/tests/hermes_cli/test_auth_profile_fallback.py
+++ b/tests/hermes_cli/test_auth_profile_fallback.py
@@ -441,3 +441,166 @@ def test_write_pool_never_merges_cooldown_onto_reauthed_entry(classic_env):
     assert persisted["access_token"] == "sk-new"
     assert persisted.get("last_status") != "exhausted"
     assert persisted.get("last_error_code") is None
+# ---------------------------------------------------------------------------
+# is_source_suppressed — a deny-list must not be escapable by omission
+# ---------------------------------------------------------------------------
+
+
+def _suppressed_store(mapping: dict) -> dict:
+    # ``providers`` is not decoration: _load_auth_store() discards the whole
+    # store and returns an empty default unless it finds a dict-valued
+    # "providers" or "credential_pool" key, so a fixture carrying only
+    # suppressed_sources would read back as {} and pass for the wrong reason.
+    return {"version": 1, "providers": {}, "suppressed_sources": mapping}
+
+
+def test_a_global_suppression_is_honoured_inside_a_profile(profile_env):
+    """`hermes auth remove` at the root must not silently reverse per profile.
+
+    read_credential_pool and get_provider_auth_state already fall back to the
+    global root so a provider authed there is visible in profile mode.
+    is_source_suppressed did not, which left the deny-list as the one piece of
+    auth state a profile escaped by simply not repeating it: the root said "stop
+    seeding this source" and every profile re-seeded it on the next load.
+    """
+    from hermes_cli.auth import is_source_suppressed
+
+    _write(profile_env["global"] / "auth.json",
+           _suppressed_store({"copilot": ["env:GITHUB_TOKEN", "gh_cli"]}))
+    _write(profile_env["profile"] / "auth.json", _make_auth_store(pool={}))
+
+    assert is_source_suppressed("copilot", "gh_cli") is True
+    assert is_source_suppressed("copilot", "env:GITHUB_TOKEN") is True
+    assert is_source_suppressed("copilot", "manual") is False
+    assert is_source_suppressed("openrouter", "gh_cli") is False
+
+
+def test_a_profile_suppression_still_works_on_its_own(profile_env):
+    """The pre-existing behaviour: a marker written in the profile is honoured
+    there even when the global root knows nothing about it."""
+    from hermes_cli.auth import is_source_suppressed
+
+    _write(profile_env["global"] / "auth.json", _make_auth_store(pool={}))
+    _write(profile_env["profile"] / "auth.json",
+           _suppressed_store({"zai": ["env:GLM_API_KEY"]}))
+
+    assert is_source_suppressed("zai", "env:GLM_API_KEY") is True
+
+
+def test_the_two_scopes_are_unioned_not_shadowed(profile_env):
+    """A profile that suppresses ONE source does not un-suppress the others.
+
+    This is the difference between union and shadow, and it is the whole point:
+    with shadowing, a profile listing any marker at all would hide every global
+    marker for that provider.
+    """
+    from hermes_cli.auth import is_source_suppressed
+
+    _write(profile_env["global"] / "auth.json",
+           _suppressed_store({"copilot": ["gh_cli"]}))
+    _write(profile_env["profile"] / "auth.json",
+           _suppressed_store({"copilot": ["env:GH_TOKEN"]}))
+
+    assert is_source_suppressed("copilot", "gh_cli") is True
+    assert is_source_suppressed("copilot", "env:GH_TOKEN") is True
+
+
+def test_a_dict_shaped_entry_is_accepted(profile_env):
+    """unsuppress_credential_source already handles a dict as well as a list, so
+    the reader has to accept both or the two disagree about the same file."""
+    from hermes_cli.auth import is_source_suppressed
+
+    _write(profile_env["global"] / "auth.json",
+           _suppressed_store({"copilot": {"gh_cli": "2026-08-19T00:00:00Z"}}))
+    _write(profile_env["profile"] / "auth.json", _make_auth_store(pool={}))
+
+    assert is_source_suppressed("copilot", "gh_cli") is True
+
+
+def test_a_malformed_global_store_does_not_break_the_check(profile_env):
+    """Same robustness the neighbouring fallback paths already have: an unreadable
+    global file must not make a profile process raise on an auth question."""
+    from hermes_cli.auth import is_source_suppressed
+
+    (profile_env["global"] / "auth.json").write_text("{not valid json")
+    _write(profile_env["profile"] / "auth.json",
+           _suppressed_store({"copilot": ["gh_cli"]}))
+
+    assert is_source_suppressed("copilot", "gh_cli") is True
+    assert is_source_suppressed("copilot", "manual") is False
+# ---------------------------------------------------------------------------
+# lift_provider_suppressions — re-engagement across the two scopes
+# ---------------------------------------------------------------------------
+
+
+def test_lifting_suppressions_reports_what_the_root_still_denies(profile_env):
+    """`hermes auth add` lifts what it owns and names what it cannot.
+
+    The re-engagement gesture clears the provider's whole deny-list, but a profile
+    must not rewrite the global root on the other profiles' behalf. Since
+    is_source_suppressed now answers the union, a root marker stays in force — so
+    it is returned, not dropped, and the caller says so rather than reporting a
+    clean re-engagement that only partly happened.
+    """
+    from hermes_cli.auth import is_source_suppressed, lift_provider_suppressions
+
+    _write(profile_env["global"] / "auth.json",
+           _suppressed_store({"copilot": ["gh_cli"]}))
+    _write(profile_env["profile"] / "auth.json",
+           _suppressed_store({"copilot": ["env:GH_TOKEN", "claude_code"]}))
+
+    assert lift_provider_suppressions("copilot") == ["gh_cli"]
+
+    # What the profile owned is gone for good...
+    assert is_source_suppressed("copilot", "env:GH_TOKEN") is False
+    assert is_source_suppressed("copilot", "claude_code") is False
+    # ...and the name that came back is not advisory: it is still denied.
+    assert is_source_suppressed("copilot", "gh_cli") is True
+
+
+def test_lifting_suppressions_leaves_other_providers_alone(profile_env):
+    """The gesture is per-provider: re-adding copilot must not re-enable zai."""
+    from hermes_cli.auth import is_source_suppressed, lift_provider_suppressions
+
+    _write(profile_env["global"] / "auth.json", _make_auth_store(pool={}))
+    _write(profile_env["profile"] / "auth.json",
+           _suppressed_store({"copilot": ["gh_cli"], "zai": ["env:GLM_API_KEY"]}))
+
+    assert lift_provider_suppressions("copilot") == []
+
+    assert is_source_suppressed("copilot", "gh_cli") is False
+    assert is_source_suppressed("zai", "env:GLM_API_KEY") is True
+
+
+def test_lifting_suppressions_reports_nothing_without_a_distinct_global(profile_env,
+                                                                       monkeypatch):
+    """Classic mode: one scope, so there is never a residual to report.
+
+    Pointing the default root at the active home is what "no global scope distinct
+    from mine" means to _global_auth_file_path(), and is how the vast majority of
+    installs run.  Behaviour there must be exactly what it was before the union.
+    """
+    import hermes_constants
+    from hermes_cli.auth import is_source_suppressed, lift_provider_suppressions
+
+    monkeypatch.setattr(hermes_constants, "get_default_hermes_root",
+                        lambda: profile_env["profile"])
+    _write(profile_env["profile"] / "auth.json",
+           _suppressed_store({"copilot": ["gh_cli", "env:GH_TOKEN"]}))
+
+    assert lift_provider_suppressions("copilot") == []
+    assert is_source_suppressed("copilot", "gh_cli") is False
+    assert is_source_suppressed("copilot", "env:GH_TOKEN") is False
+
+
+def test_lifting_suppressions_accepts_a_dict_shaped_entry(profile_env):
+    """An older store holds a mapping keyed by source name; the write side already
+    migrated it in place, so the read side must not be the one to trip over it."""
+    from hermes_cli.auth import is_source_suppressed, lift_provider_suppressions
+
+    _write(profile_env["global"] / "auth.json", _make_auth_store(pool={}))
+    _write(profile_env["profile"] / "auth.json",
+           _suppressed_store({"copilot": {"gh_cli": "2026-08-19T00:00:00Z"}}))
+
+    assert lift_provider_suppressions("copilot") == []
+    assert is_source_suppressed("copilot", "gh_cli") is False

--- a/tests/hermes_cli/test_auth_profile_fallback.py
+++ b/tests/hermes_cli/test_auth_profile_fallback.py
@@ -222,6 +222,50 @@ def test_provider_state_fallback_respects_profile_source_suppression(profile_env
     assert get_provider_auth_state("xai-oauth") is None
 
 
+def test_root_only_suppression_blocks_all_profile_global_fallbacks(profile_env):
+    """A root deny-list cannot disappear when a named profile omits it."""
+    from hermes_cli.auth import get_provider_auth_state, read_credential_pool
+
+    _write(
+        profile_env["global"] / "auth.json",
+        _make_auth_store(
+            pool={
+                "xai-oauth": [
+                    _fallback_entry("global-device", "device_code"),
+                    _fallback_entry("global-manual", "manual"),
+                ],
+            },
+            providers={
+                "xai-oauth": {
+                    "tokens": {
+                        "access_token": "synthetic-access-value",
+                        "refresh_token": "synthetic-refresh-value",
+                    },
+                    "auth_mode": "oauth_device_code",
+                },
+            },
+            suppressed_sources={"xai-oauth": ["device_code"]},
+        ),
+    )
+    _write(
+        profile_env["profile"] / "auth.json",
+        _make_auth_store(pool={}, providers={}),
+    )
+
+    # Provider-slice fallback keeps the unsuppressed positive control only.
+    assert [entry["id"] for entry in read_credential_pool("xai-oauth")] == [
+        "global-manual"
+    ]
+
+    # Whole-pool merge applies the same union-of-denials policy.
+    merged = read_credential_pool()
+    assert isinstance(merged, dict)
+    assert [entry["id"] for entry in merged["xai-oauth"]] == ["global-manual"]
+
+    # Singleton/provider-state fallback cannot resurrect the root device login.
+    assert get_provider_auth_state("xai-oauth") is None
+
+
 
 def test_provider_auth_state_falls_back_to_global_when_profile_has_none(profile_env):
     from hermes_cli.auth import get_provider_auth_state

--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -1493,6 +1493,74 @@ class TestCaptureAppFilterNoMatch:
     (e.g. a menu-bar utility), giving the agent wrong UI elements.
     """
 
+    def test_exact_metadata_pid_absence_blocks_nameless_title_fallback(self):
+        windows = [
+            {
+                "app_name": "",
+                "pid": 222,
+                "window_id": 22,
+                "is_on_screen": True,
+                "title": "Hermes Agent - Dashboard — Mozilla Firefox",
+                "z_index": 1,
+            },
+        ]
+        apps = [
+            {
+                "name": "Hermes",
+                "bundle_id": "com.nous.hermes",
+                "pid": 111,
+                "running": True,
+            },
+        ]
+        backend = _make_cua_backend_with_windows_and_apps(windows, apps)
+
+        matched = backend._match_windows_for_app(windows, "Hermes")
+
+        assert matched == []
+
+        capture = backend.capture(mode="som", app="Hermes")
+        call_tool = cast(Any, backend._session.call_tool)
+        called_tools = [call.args[0] for call in call_tool.call_args_list]
+        assert "get_window_state" not in called_tools
+        assert "screenshot" not in called_tools
+        assert backend._active_pid is None
+        assert backend._active_window_id is None
+        assert capture.elements == []
+        assert capture.png_b64 is None
+
+    def test_exact_metadata_pid_returns_only_its_windows(self):
+        expected = {
+            "app_name": "",
+            "pid": 111,
+            "window_id": 11,
+            "is_on_screen": True,
+            "title": "Hermes",
+            "z_index": 0,
+        }
+        wrong_title = {
+            "app_name": "",
+            "pid": 222,
+            "window_id": 22,
+            "is_on_screen": True,
+            "title": "Hermes Agent - Dashboard — Mozilla Firefox",
+            "z_index": 1,
+        }
+        apps = [
+            {
+                "name": "Hermes",
+                "bundle_id": "com.nous.hermes",
+                "pid": 111,
+                "running": True,
+            },
+        ]
+        backend = _make_cua_backend_with_windows_and_apps(
+            [wrong_title, expected], apps
+        )
+
+        assert backend._match_windows_for_app(
+            [wrong_title, expected], "Hermes"
+        ) == [expected]
+
     def test_app_filter_no_match_returns_empty_capture_with_diagnostic(self):
         # Simulates a localized macOS where Calculator's app_name is "計算機".
         windows = [

--- a/tests/tools/test_computer_use_capture_target_guard.py
+++ b/tests/tools/test_computer_use_capture_target_guard.py
@@ -1,0 +1,146 @@
+"""Explicit capture app requests must fail closed before response materialization."""
+
+import json
+from unittest.mock import Mock, patch
+
+import pytest
+
+from tools.computer_use.backend import CaptureResult, UIElement
+from tools.computer_use.tool import _dispatch
+
+
+def _capture(app: str) -> CaptureResult:
+    return CaptureResult(
+        mode="som",
+        width=32,
+        height=32,
+        png_b64="iVBORw0KGgoAAAANSUhEUg==",
+        elements=[UIElement(index=0, role="button", label="Private", bounds=(0, 0, 1, 1))],
+        app=app,
+        window_title="Synthetic window",
+        png_bytes_len=16,
+    )
+
+
+def _backend(returned_app: str):
+    backend = Mock()
+    backend.capture.return_value = _capture(returned_app)
+    return backend
+
+
+def test_capture_mismatch_fails_before_response_spill_or_vision():
+    from tools.computer_use import tool as cu_tool
+
+    backend = _backend("Hermes Agent - Dashboard — Mozilla Firefox")
+    with patch.object(cu_tool, "_capture_response", return_value={"unexpected": True}) as response, \
+         patch.object(cu_tool, "_spill_elements_to_file") as spill, \
+         patch.object(cu_tool, "_route_capture_through_aux_vision") as vision:
+        result = _dispatch(backend, "capture", {"mode": "som", "app": "Hermes"})
+
+    assert isinstance(result, str)
+    payload = json.loads(result)
+    assert payload["ok"] is False
+    assert payload["code"] == "capture_target_mismatch"
+    assert "elements" not in payload
+    assert "screenshot" not in payload
+    response.assert_not_called()
+    spill.assert_not_called()
+    vision.assert_not_called()
+
+
+def test_capture_empty_returned_app_fails_closed():
+    from tools.computer_use import tool as cu_tool
+
+    with patch.object(cu_tool, "_capture_response", return_value={"unexpected": True}) as response:
+        result = _dispatch(
+            _backend(""), "capture", {"mode": "som", "app": "Hermes"}
+        )
+
+    payload = json.loads(result)
+    assert payload["code"] == "capture_target_mismatch"
+    response.assert_not_called()
+
+
+def test_capture_canonical_chrome_alias_passes():
+    from tools.computer_use import tool as cu_tool
+
+    expected = {"matched": True}
+    with patch.object(cu_tool, "_capture_response", return_value=expected) as response:
+        result = _dispatch(
+            _backend("google-chrome"),
+            "capture",
+            {"mode": "som", "app": "chrome"},
+        )
+
+    assert result is expected
+    response.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    ("requested_app", "returned_app"),
+    [
+        ("Terminal", "GNOME Terminal"),
+        ("Code", "Visual Studio Code"),
+        ("calc", "Calculator"),
+    ],
+)
+def test_capture_legitimate_substring_app_resolution_passes(
+    requested_app, returned_app
+):
+    from tools.computer_use import tool as cu_tool
+
+    expected = {"matched": returned_app}
+    with patch.object(cu_tool, "_capture_response", return_value=expected) as response:
+        result = _dispatch(
+            _backend(returned_app),
+            "capture",
+            {"mode": "som", "app": requested_app},
+        )
+
+    assert result is expected
+    response.assert_called_once()
+
+
+@pytest.mark.parametrize("requested_app", ["screen", "desktop", "all"])
+@pytest.mark.parametrize(
+    "returned_app", ["Progman", "WorkerW", "Finder", "plasmashell"]
+)
+def test_capture_desktop_sentinel_passes_resolved_shell_app(
+    requested_app, returned_app
+):
+    from tools.computer_use import tool as cu_tool
+
+    expected = {"desktop": returned_app}
+    with patch.object(cu_tool, "_capture_response", return_value=expected) as response:
+        result = _dispatch(
+            _backend(returned_app),
+            "capture",
+            {"mode": "som", "app": requested_app},
+        )
+
+    assert result is expected
+    response.assert_called_once()
+
+
+def test_exact_pid_window_binding_is_exempt_from_app_response_guard():
+    from tools.computer_use import tool as cu_tool
+
+    expected = {"bound": True}
+    backend = _backend("different-app")
+    with patch.object(cu_tool, "_capture_response", return_value=expected) as response:
+        result = _dispatch(
+            backend,
+            "capture",
+            {
+                "mode": "som",
+                "app": "Hermes",
+                "pid": 123,
+                "window_id": 456,
+            },
+        )
+
+    assert result is expected
+    response.assert_called_once()
+    backend.capture.assert_called_once_with(
+        mode="som", app="Hermes", pid=123, window_id=456
+    )

--- a/tools/computer_use/capture_targeting.py
+++ b/tools/computer_use/capture_targeting.py
@@ -1,0 +1,160 @@
+"""Computer Use capture-target identity and resolution policy.
+
+This bounded owner serves both the tool response guard and cua-driver window
+resolution while ``cua_backend.py`` is fractured under #79937. Legacy functions
+and methods remain as compatibility delegates at their original surfaces.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from collections.abc import Callable
+from typing import Any
+
+_CAPTURE_SCREEN_SENTINELS = frozenset({
+    "screen", "desktop", "fullscreen", "full-screen", "all",
+})
+
+_CAPTURE_BROWSER_IDENTITY_TOKENS = frozenset({
+    "brave", "chrome", "chromium", "edge", "firefox", "msedge",
+    "opera", "safari", "vivaldi",
+})
+
+_CAPTURE_APP_ALIASES = {
+    "chrome": "chrome",
+    "google-chrome": "chrome",
+    "google-chrome-stable": "chrome",
+    "chrome-browser": "chrome",
+    "com-google-chrome": "chrome",
+    "firefox": "firefox",
+    "mozilla-firefox": "firefox",
+    "org-mozilla-firefox": "firefox",
+    "edge": "edge",
+    "msedge": "edge",
+    "microsoft-edge": "edge",
+    "com-microsoft-edgemac": "edge",
+    "chromium": "chromium",
+    "chromium-browser": "chromium",
+}
+
+
+def canonical_capture_app_name(value: Any) -> str:
+    """Canonicalize exact app identities without accepting title substrings."""
+    if not isinstance(value, str):
+        return ""
+    normalized = re.sub(r"[\s_]+", "-", value.strip().casefold()).strip("-")
+    if normalized.endswith(".app"):
+        normalized = normalized[:-4]
+    return _CAPTURE_APP_ALIASES.get(normalized, normalized)
+
+
+def capture_app_matches(requested_app: Any, returned_app: Any) -> bool:
+    """Accept app-name variants without trusting unrelated browser titles."""
+    requested = canonical_capture_app_name(requested_app)
+    if requested in _CAPTURE_SCREEN_SENTINELS:
+        return True
+
+    returned = canonical_capture_app_name(returned_app)
+    if not requested or not returned:
+        return False
+    if requested == returned:
+        return True
+
+    requested_tokens = tuple(re.findall(r"[a-z0-9]+", requested))
+    returned_tokens = tuple(re.findall(r"[a-z0-9]+", returned))
+    requested_browsers = set(requested_tokens) & _CAPTURE_BROWSER_IDENTITY_TOKENS
+    returned_browsers = set(returned_tokens) & _CAPTURE_BROWSER_IDENTITY_TOKENS
+    if returned_browsers - requested_browsers:
+        return False
+
+    if not requested_tokens or len(requested_tokens) > len(returned_tokens):
+        return False
+    width = len(requested_tokens)
+    return any(
+        all(
+            returned_token.startswith(requested_token)
+            for requested_token, returned_token in zip(
+                requested_tokens, returned_tokens[start:start + width]
+            )
+        )
+        for start in range(len(returned_tokens) - width + 1)
+    )
+
+
+def match_windows_for_app(
+    windows: list[dict[str, Any]],
+    app: str,
+    *,
+    list_apps: Callable[[], list[dict[str, Any]]],
+    logger: logging.Logger | None = None,
+) -> list[dict[str, Any]]:
+    """Resolve ``app=`` through exact names before convenience substrings."""
+    app_lower = app.strip().lower()
+    if not app_lower:
+        return []
+
+    direct_exact = [
+        window
+        for window in windows
+        if app_lower == str(window.get("app_name", "")).strip().lower()
+    ]
+    if direct_exact:
+        return direct_exact
+
+    log = logger or logging.getLogger(__name__)
+    try:
+        running_apps = list_apps()
+    except Exception as exc:
+        log.debug("computer_use list_apps fallback failed for %r: %s", app, exc)
+        running_apps = []
+
+    exact_pids: set[int] = set()
+    partial_pids: set[int] = set()
+    for raw_app in running_apps:
+        if not isinstance(raw_app, dict) or raw_app.get("running") is False:
+            continue
+        raw_pid = raw_app.get("pid")
+        if isinstance(raw_pid, bool) or not isinstance(raw_pid, (int, str)):
+            continue
+        try:
+            pid = int(raw_pid)
+        except ValueError:
+            continue
+        if pid <= 0:
+            continue
+
+        aliases = {
+            value.strip().lower()
+            for key in ("bundle_id", "bundleId", "name", "app_name", "display_name")
+            if isinstance((value := raw_app.get(key)), str) and value.strip()
+        }
+        if app_lower in aliases:
+            exact_pids.add(pid)
+        elif any(app_lower in alias for alias in aliases):
+            partial_pids.add(pid)
+
+    metadata_exact = [window for window in windows if window.get("pid") in exact_pids]
+    if exact_pids:
+        return metadata_exact
+
+    direct_partial = [
+        window
+        for window in windows
+        if app_lower in str(window.get("app_name", "")).lower()
+    ]
+    if direct_partial:
+        return direct_partial
+
+    metadata_partial = [
+        window for window in windows if window.get("pid") in partial_pids
+    ]
+    if metadata_partial:
+        return metadata_partial
+
+    return [
+        window
+        for window in windows
+        if not str(window.get("app_name", "")).strip()
+        and app_lower in str(window.get("title", "")).lower()
+    ]

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -3037,7 +3037,12 @@ class CuaDriverBackend(ComputerUseBackend):
                 partial_pids.add(pid)
 
         metadata_exact = [w for w in windows if w.get("pid") in exact_pids]
-        if metadata_exact:
+        if exact_pids:
+            # Exact app metadata is authoritative even when its PID has no
+            # corresponding visible window. Falling through here would let a
+            # nameless browser/title substring impersonate the requested app
+            # and cause the wrong window to be captured before any response
+            # guard can intervene.
             return metadata_exact
 
         direct_partial = [

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -61,6 +61,9 @@ from tools.computer_use.backend import (
     ComputerUseBackend,
     UIElement,
 )
+from tools.computer_use.capture_targeting import (
+    match_windows_for_app as _resolve_windows_for_app,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -2984,86 +2987,13 @@ class CuaDriverBackend(ComputerUseBackend):
     def _match_windows_for_app(
         self, windows: List[Dict[str, Any]], app: str
     ) -> List[Dict[str, Any]]:
-        """Resolve ``app=`` through exact names before convenience substrings.
-
-        Linux ``list_windows`` can omit an app name while ``list_apps`` retains
-        name/bundle-ID metadata. Exact direct names and exact metadata aliases
-        must win over substring matches: querying ``Code`` must not silently
-        select ``Visual Studio Code`` merely because it is frontmost.
-        """
-        app_lower = app.strip().lower()
-        if not app_lower:
-            return []
-
-        direct_exact = [
-            w for w in windows
-            if app_lower == str(w.get("app_name", "")).strip().lower()
-        ]
-        if direct_exact:
-            return direct_exact
-
-        try:
-            running_apps = self.list_apps()
-        except Exception as exc:
-            # A title can still be the only usable identity on X11 when app
-            # enumeration is unavailable, so retain the constrained title
-            # fallback below instead of treating this as a hard no-match.
-            logger.debug("computer_use list_apps fallback failed for %r: %s", app, exc)
-            running_apps = []
-
-        exact_pids: set[int] = set()
-        partial_pids: set[int] = set()
-        for raw_app in running_apps:
-            if not isinstance(raw_app, dict) or raw_app.get("running") is False:
-                continue
-            raw_pid = raw_app.get("pid")
-            if isinstance(raw_pid, bool) or not isinstance(raw_pid, (int, str)):
-                continue
-            try:
-                pid = int(raw_pid)
-            except ValueError:
-                continue
-            if pid <= 0:
-                continue
-
-            aliases = {
-                value.strip().lower()
-                for key in ("bundle_id", "bundleId", "name", "app_name", "display_name")
-                if isinstance((value := raw_app.get(key)), str) and value.strip()
-            }
-            if app_lower in aliases:
-                exact_pids.add(pid)
-            elif any(app_lower in alias for alias in aliases):
-                partial_pids.add(pid)
-
-        metadata_exact = [w for w in windows if w.get("pid") in exact_pids]
-        if exact_pids:
-            # Exact app metadata is authoritative even when its PID has no
-            # corresponding visible window. Falling through here would let a
-            # nameless browser/title substring impersonate the requested app
-            # and cause the wrong window to be captured before any response
-            # guard can intervene.
-            return metadata_exact
-
-        direct_partial = [
-            w for w in windows
-            if app_lower in str(w.get("app_name", "")).lower()
-        ]
-        if direct_partial:
-            return direct_partial
-
-        metadata_partial = [w for w in windows if w.get("pid") in partial_pids]
-        if metadata_partial:
-            return metadata_partial
-
-        # Some X11 backends expose a title but no app name. Restrict this final
-        # fallback to nameless rows so a localized app name is not overridden
-        # merely because its title happens to be in the caller's language.
-        return [
-            w for w in windows
-            if not str(w.get("app_name", "")).strip()
-            and app_lower in str(w.get("title", "")).lower()
-        ]
+        """Compatibility delegate to the bounded capture-target resolver."""
+        return _resolve_windows_for_app(
+            windows,
+            app,
+            list_apps=self.list_apps,
+            logger=logger,
+        )
 
     def _capture_full_screen(self, mode: str) -> CaptureResult:
         """Capture the whole displayed screen via cua-driver's desktop lane.

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -55,6 +55,9 @@ from tools.computer_use.backend import (
     ComputerUseBackend,
     UIElement,
 )
+from tools.computer_use.capture_targeting import (
+    capture_app_matches as _capture_app_matches,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -128,85 +131,6 @@ _INPUT_ACTIONS = frozenset({
     "click", "double_click", "right_click", "middle_click",
     "drag", "scroll", "type", "key", "set_value",
 })
-
-
-_CAPTURE_SCREEN_SENTINELS = frozenset({
-    "screen", "desktop", "fullscreen", "full-screen", "all",
-})
-
-_CAPTURE_BROWSER_IDENTITY_TOKENS = frozenset({
-    "brave", "chrome", "chromium", "edge", "firefox", "msedge",
-    "opera", "safari", "vivaldi",
-})
-
-
-_CAPTURE_APP_ALIASES = {
-    "chrome": "chrome",
-    "google-chrome": "chrome",
-    "google-chrome-stable": "chrome",
-    "chrome-browser": "chrome",
-    "com-google-chrome": "chrome",
-    "firefox": "firefox",
-    "mozilla-firefox": "firefox",
-    "org-mozilla-firefox": "firefox",
-    "edge": "edge",
-    "msedge": "edge",
-    "microsoft-edge": "edge",
-    "com-microsoft-edgemac": "edge",
-    "chromium": "chromium",
-    "chromium-browser": "chromium",
-}
-
-
-def _canonical_capture_app_name(value: Any) -> str:
-    """Canonicalize exact app identities without accepting title substrings."""
-    if not isinstance(value, str):
-        return ""
-    normalized = re.sub(r"[\s_]+", "-", value.strip().casefold()).strip("-")
-    if normalized.endswith(".app"):
-        normalized = normalized[:-4]
-    return _CAPTURE_APP_ALIASES.get(normalized, normalized)
-
-
-def _capture_app_name_tokens(value: str) -> Tuple[str, ...]:
-    return tuple(re.findall(r"[a-z0-9]+", value))
-
-
-def _capture_app_matches(requested_app: Any, returned_app: Any) -> bool:
-    """Accept backend app-name variants without trusting browser window titles."""
-    requested = _canonical_capture_app_name(requested_app)
-    if requested in _CAPTURE_SCREEN_SENTINELS:
-        # The backend resolves these aliases to an OS desktop/shell window, so
-        # CaptureResult.app is intentionally the shell identity, not the alias.
-        return True
-
-    returned = _canonical_capture_app_name(returned_app)
-    if not requested or not returned:
-        return False
-    if requested == returned:
-        return True
-
-    requested_tokens = _capture_app_name_tokens(requested)
-    returned_tokens = _capture_app_name_tokens(returned)
-    requested_browsers = set(requested_tokens) & _CAPTURE_BROWSER_IDENTITY_TOKENS
-    returned_browsers = set(returned_tokens) & _CAPTURE_BROWSER_IDENTITY_TOKENS
-    if returned_browsers - requested_browsers:
-        # A non-browser request such as "Hermes" must not accept a browser
-        # window title merely because that title contains the requested word.
-        return False
-
-    if not requested_tokens or len(requested_tokens) > len(returned_tokens):
-        return False
-    width = len(requested_tokens)
-    return any(
-        all(
-            returned_token.startswith(requested_token)
-            for requested_token, returned_token in zip(
-                requested_tokens, returned_tokens[start:start + width]
-            )
-        )
-        for start in range(len(returned_tokens) - width + 1)
-    )
 
 
 def _input_target_mismatch(backend, requested_app: str) -> Optional[str]:

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -130,6 +130,85 @@ _INPUT_ACTIONS = frozenset({
 })
 
 
+_CAPTURE_SCREEN_SENTINELS = frozenset({
+    "screen", "desktop", "fullscreen", "full-screen", "all",
+})
+
+_CAPTURE_BROWSER_IDENTITY_TOKENS = frozenset({
+    "brave", "chrome", "chromium", "edge", "firefox", "msedge",
+    "opera", "safari", "vivaldi",
+})
+
+
+_CAPTURE_APP_ALIASES = {
+    "chrome": "chrome",
+    "google-chrome": "chrome",
+    "google-chrome-stable": "chrome",
+    "chrome-browser": "chrome",
+    "com-google-chrome": "chrome",
+    "firefox": "firefox",
+    "mozilla-firefox": "firefox",
+    "org-mozilla-firefox": "firefox",
+    "edge": "edge",
+    "msedge": "edge",
+    "microsoft-edge": "edge",
+    "com-microsoft-edgemac": "edge",
+    "chromium": "chromium",
+    "chromium-browser": "chromium",
+}
+
+
+def _canonical_capture_app_name(value: Any) -> str:
+    """Canonicalize exact app identities without accepting title substrings."""
+    if not isinstance(value, str):
+        return ""
+    normalized = re.sub(r"[\s_]+", "-", value.strip().casefold()).strip("-")
+    if normalized.endswith(".app"):
+        normalized = normalized[:-4]
+    return _CAPTURE_APP_ALIASES.get(normalized, normalized)
+
+
+def _capture_app_name_tokens(value: str) -> Tuple[str, ...]:
+    return tuple(re.findall(r"[a-z0-9]+", value))
+
+
+def _capture_app_matches(requested_app: Any, returned_app: Any) -> bool:
+    """Accept backend app-name variants without trusting browser window titles."""
+    requested = _canonical_capture_app_name(requested_app)
+    if requested in _CAPTURE_SCREEN_SENTINELS:
+        # The backend resolves these aliases to an OS desktop/shell window, so
+        # CaptureResult.app is intentionally the shell identity, not the alias.
+        return True
+
+    returned = _canonical_capture_app_name(returned_app)
+    if not requested or not returned:
+        return False
+    if requested == returned:
+        return True
+
+    requested_tokens = _capture_app_name_tokens(requested)
+    returned_tokens = _capture_app_name_tokens(returned)
+    requested_browsers = set(requested_tokens) & _CAPTURE_BROWSER_IDENTITY_TOKENS
+    returned_browsers = set(returned_tokens) & _CAPTURE_BROWSER_IDENTITY_TOKENS
+    if returned_browsers - requested_browsers:
+        # A non-browser request such as "Hermes" must not accept a browser
+        # window title merely because that title contains the requested word.
+        return False
+
+    if not requested_tokens or len(requested_tokens) > len(returned_tokens):
+        return False
+    width = len(requested_tokens)
+    return any(
+        all(
+            returned_token.startswith(requested_token)
+            for requested_token, returned_token in zip(
+                requested_tokens, returned_tokens[start:start + width]
+            )
+        )
+        for start in range(len(returned_tokens) - width + 1)
+    )
+
+
 def _input_target_mismatch(backend, requested_app: str) -> Optional[str]:
     """Current sticky-target app when it clearly differs from *requested_app*.
 
@@ -678,6 +757,29 @@ def _dispatch(backend: ComputerUseBackend, action: str, args: Dict[str, Any]) ->
                 "window_id": args.get("window_id"),
             })
         cap = backend.capture(**capture_kwargs)
+        requested_app = args.get("app")
+        exact_binding = (
+            args.get("pid") is not None and args.get("window_id") is not None
+        )
+        if (
+            isinstance(requested_app, str)
+            and requested_app.strip()
+            and not exact_binding
+            and not _capture_app_matches(requested_app, cap.app)
+        ):
+            returned_app = cap.app.strip() if isinstance(cap.app, str) else ""
+            return json.dumps({
+                "ok": False,
+                "action": "capture",
+                "code": "capture_target_mismatch",
+                "error": (
+                    f"capture requested app {requested_app.strip()!r}, but the "
+                    f"backend returned {returned_app or '<unverifiable>'!r}. "
+                    "Screenshot and element data were withheld before response "
+                    "materialization. Use list_apps/list_windows or an exact "
+                    "pid+window_id binding."
+                ),
+            })
         return _capture_response(cap)
 
     if action == "wait":


### PR DESCRIPTION
## Summary

This fixes three privacy-boundary failures while preserving existing behavior:

- Prevent named profiles from borrowing suppressed root credentials through provider-pool, merged-pool, singleton-state, or credential-seeding fallback paths.
- Redact credential-shaped values at the universal model-visible tool-result boundary, including strict URL userinfo/query masking, while preserving the configured opt-out and leaving image/base64 parts byte-identical.
- Make Computer Use capture fail closed before response materialization when a named app resolves to an unrelated application, while preserving whole-screen sentinels and legitimate documented substring matches.

## Review follow-up

### Root/profile suppression union

The root-only omission case from the review is now a witnessed RED→GREEN regression covering all additional consumers owned by this PR:

1. provider-slice fallback;
2. whole-pool merge;
3. singleton/provider-state fallback;
4. an unsuppressed `manual` source as the positive control.

PR #90585's exact implementation commit was cherry-picked with Rodrigo Gomes's authorship preserved. Its shape-tolerant parser and union-of-denials contract now feed this PR's additional pool and singleton consumers through one bounded owner: `hermes_cli/auth_suppression.py`. Existing `hermes_cli.auth` names remain compatibility delegates/re-exports.

### Bounded landing owners

The three security boundaries no longer establish their canonical policy inside fracture targets:

- `hermes_cli/auth_suppression.py` owns suppression parsing, profile/root union, source decisions, and fallback filtering. `hermes_cli/auth.py` delegates. Part of #78637 and #78647.
- `agent/tool_result_egress.py` owns multimodal result identification and model-visible sanitation. `agent/tool_executor.py` consumes it directly; `agent/tool_dispatch_helpers.py` keeps compatibility aliases. Part of #79975 and #78647.
- `tools/computer_use/capture_targeting.py` owns app identity matching and window resolution. `tools/computer_use/tool.py` and `cua_backend.py` delegate. Part of #79937 and #78647.

## Problem

The previous boundaries allowed three classes of privacy failure:

1. A source denied at the root could reappear inside a profile that omitted the marker.
2. Some tool-result paths reached model context without universal secret-redaction coverage.
3. A named Computer Use capture could fall through from native process discovery to an unrelated browser window whose title contained the requested name.

All fixtures are synthetic and temporary. No live credentials, authentication stores, services, or user data are included.

## Implementation

- Compose all suppression reads as the union of profile and root deny-lists while keeping writes profile-scoped.
- Filter suppressed global pool entries and singleton states through the same canonical policy.
- Redact plain and multimodal text at message construction, terminal callbacks, middleware, and exception paths; retain raw content for risk classification and media objects by identity.
- Treat exact app-metadata PID sets as authoritative even when their visible-window intersection is empty.
- Reject unverifiable response app identities before screenshot/element materialization, except exact `pid + window_id` bindings.
- Preserve `screen` / `desktop` / `all` sentinels and legitimate variants such as `Terminal` → `GNOME Terminal`.

## Verification

Fresh verification on exact rebased bytes:

- Base: `4cbbe11ffcf25732f0b387a7c0bd8620d8310729`
- Head: `73e1506faa2a2be4699ebb93e75fb753ebabf3a6`
- Tree: `c5adb4092a4cd6acb662e8621eab5ab9c67c665b`
- Repository wrapper: **347 passed, 0 failed** across 11 focused files.
- Ruff on all 17 changed Python files: passed.
- `git diff --check`: passed.
- Final worktree: clean.

Focused files:

- `tests/hermes_cli/test_auth_profile_fallback.py`
- `tests/hermes_cli/test_auth_commands.py`
- `tests/hermes_cli/test_web_oauth_dispatch.py`
- `tests/agent/test_redact.py`
- `tests/agent/test_tool_dispatch_helpers.py`
- `tests/agent/test_tool_result_egress.py`
- `tests/agent/test_tool_executor_checkpoint_paths.py`
- `tests/tools/test_computer_use.py`
- `tests/tools/test_computer_use_capture_target_guard.py`
- `tests/tools/test_computer_use_capture_routing.py`
- `tests/tools/test_computer_use_input_target_guard.py`

## Interlocks

- #90585 retains credit for the root/profile suppression discovery, shape-tolerant reader, union contract, and scoped re-engagement behavior. This PR owns the additional pool/singleton consumers and bounded owner extraction.
- #70093 remains complementary for external gateway streaming/delivery redaction.
- #95493 remains complementary for qualified auth-store ownership.

## Safety notes

- No runtime, service, configuration, credential, or authentication state is changed by this PR.
- Existing untrusted-tool wrapping, tool-call ID normalization, provider-side elision detection, and raw-content risk classification remain intact.
- The fix does not disable Computer Use capture or documented screen/substring targeting behavior.

Part of #78637
Part of #79975
Part of #79937
Part of #78647
