### PR TITLE
fix(approval): stop valid quoted grep patterns from being hardline-blocked

### DIFF
--- a/tests/tools/test_hardline_blocklist.py
+++ b/tests/tools/test_hardline_blocklist.py
@@ -744,6 +744,22 @@ def test_excessive_parameter_expansion_nesting_fails_closed(
     assert list(_iter_shell_command_starts(command)) == []
 
 
+def test_excessive_command_substitution_nesting_fails_closed(
+    clean_session, monkeypatch
+):
+    monkeypatch.setenv("HERMES_YOLO_MODE", "1")
+    command = "$(" * 257 + "printf safe" + ")" * 257
+
+    assert detect_hardline_command(command) == (
+        True,
+        "command parser limit exceeded",
+    )
+    result = check_all_command_guards(command, "local")
+    assert result["approved"] is False
+    assert result.get("hardline") is True
+    assert list(_iter_shell_command_starts(command)) == []
+
+
 def test_valid_quoted_grep_passes_yolo_and_approvals_off_guards(
     clean_session, monkeypatch
 ):

--- a/tests/tools/test_hardline_blocklist.py
+++ b/tests/tools/test_hardline_blocklist.py
@@ -685,6 +685,46 @@ def test_destructive_command_after_valid_quoted_grep_remains_blocked():
     )
 
 
+@pytest.mark.parametrize(
+    "suffix",
+    [
+        r"(rm${IFS}-rf${IFS}/)",
+        r"{ rm${IFS}-rf${IFS}/; }",
+        r"${missing:-$(rm -rf /)}",
+        r"${missing:-`rm -rf /`}",
+        r"${outer:-${inner:-$(rm -rf /)}}",
+    ],
+)
+def test_valid_quoted_grep_cannot_hide_expanded_root_delete(
+    suffix, clean_session, monkeypatch
+):
+    monkeypatch.setenv("HERMES_YOLO_MODE", "1")
+    command = rf'''grep -o "[^\"]*" f; {suffix}'''
+    assert detect_hardline_command(command) == (
+        True,
+        "recursive delete of root filesystem",
+    )
+    result = check_all_command_guards(command, "local")
+    assert result["approved"] is False
+    assert result.get("hardline") is True
+
+
+def test_faithful_command_marker_survives_backslash_line_normalization():
+    command = r'''grep -o "[^\"]*" f; printf \\''' + "\nreboot"
+    assert detect_hardline_command(command) == (True, "system shutdown/reboot")
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        r'''grep -o "[^\"]*" f; printf '%s' '${missing:-$(printf safe)}' ''',
+        r'''grep -o "[^\"]*" f; echo "${missing:-literal}"''',
+    ],
+)
+def test_parameter_expansion_text_after_valid_grep_stays_safe(command):
+    assert detect_hardline_command(command) == (False, None)
+
+
 def test_valid_quoted_grep_passes_yolo_and_approvals_off_guards(
     clean_session, monkeypatch
 ):

--- a/tests/tools/test_hardline_blocklist.py
+++ b/tests/tools/test_hardline_blocklist.py
@@ -17,6 +17,7 @@ from tools.approval import (
     detect_hardline_command,
     disable_session_yolo,
     enable_session_yolo,
+    _iter_shell_command_starts,
     reset_current_session_key,
     set_current_session_key,
 )
@@ -740,6 +741,7 @@ def test_excessive_parameter_expansion_nesting_fails_closed(
     result = check_all_command_guards(command, "local")
     assert result["approved"] is False
     assert result.get("hardline") is True
+    assert list(_iter_shell_command_starts(command)) == []
 
 
 def test_valid_quoted_grep_passes_yolo_and_approvals_off_guards(

--- a/tests/tools/test_hardline_blocklist.py
+++ b/tests/tools/test_hardline_blocklist.py
@@ -693,6 +693,7 @@ def test_destructive_command_after_valid_quoted_grep_remains_blocked():
         r"${missing:-$(rm -rf /)}",
         r"${missing:-`rm -rf /`}",
         r"${outer:-${inner:-$(rm -rf /)}}",
+        r'''"${missing:-'$(printf safe; rm -rf /)'}"''',
     ],
 )
 def test_valid_quoted_grep_cannot_hide_expanded_root_delete(

--- a/tests/tools/test_hardline_blocklist.py
+++ b/tests/tools/test_hardline_blocklist.py
@@ -656,6 +656,49 @@ def test_quoted_paren_brace_prose_not_blocked_under_yolo(clean_session, monkeypa
         )
 
 
+@pytest.mark.parametrize(
+    "command",
+    [
+        r'''grep -o "[^\"]*" f''',
+        r'''grep -o "C:\Users\UPC\Desktop[^\"]*" file.py''',
+        r'''grep -Po "(?<=href=\")[^\"]*" index.html''',
+    ],
+)
+def test_escaped_quotes_in_grep_bracket_classes_are_not_malformed(command):
+    """Normalization must not corrupt valid shell quoting before parsing grep."""
+    assert detect_hardline_command(command) == (False, None)
+
+
+def test_unescaped_quote_in_grep_bracket_class_remains_malformed():
+    malformed = '''grep -o "[^"]*" f'''
+    assert detect_hardline_command(malformed) == (
+        True,
+        "command parser limit or malformed executable payload",
+    )
+
+
+def test_destructive_command_after_valid_quoted_grep_remains_blocked():
+    destructive = r'''grep -o "[^\"]*" f; rm -rf /'''
+    assert detect_hardline_command(destructive) == (
+        True,
+        "recursive delete of root filesystem",
+    )
+
+
+def test_valid_quoted_grep_passes_yolo_and_approvals_off_guards(
+    clean_session, monkeypatch
+):
+    import tools.approval as approval_mod
+
+    command = r'''grep -o "[^\"]*" f'''
+    enable_session_yolo("hardline_test")
+    assert check_all_command_guards(command, "local")["approved"] is True
+
+    disable_session_yolo("hardline_test")
+    monkeypatch.setattr(approval_mod, "_get_approval_mode", lambda: "off")
+    assert check_all_command_guards(command, "local")["approved"] is True
+
+
 def test_line_continuation_root_wipe_cannot_bypass_hardline(clean_session, monkeypatch):
     """A line-continuation root wipe must stay blocked even under yolo.
 

--- a/tests/tools/test_hardline_blocklist.py
+++ b/tests/tools/test_hardline_blocklist.py
@@ -726,6 +726,22 @@ def test_parameter_expansion_text_after_valid_grep_stays_safe(command):
     assert detect_hardline_command(command) == (False, None)
 
 
+@pytest.mark.parametrize("closed", [True, False])
+def test_excessive_parameter_expansion_nesting_fails_closed(
+    closed, clean_session, monkeypatch
+):
+    monkeypatch.setenv("HERMES_YOLO_MODE", "1")
+    command = "${" * 257 + "value" + ("}" * 257 if closed else "")
+
+    assert detect_hardline_command(command) == (
+        True,
+        "command parser limit exceeded",
+    )
+    result = check_all_command_guards(command, "local")
+    assert result["approved"] is False
+    assert result.get("hardline") is True
+
+
 def test_valid_quoted_grep_passes_yolo_and_approvals_off_guards(
     clean_session, monkeypatch
 ):

--- a/tests/tools/test_self_repo_guard.py
+++ b/tests/tools/test_self_repo_guard.py
@@ -146,6 +146,30 @@ class TestBlocksMutationsInSourceRepo:
         assert hit is True
         assert "parser safety limit" in msg
 
+    def test_deep_configured_alias_parser_limit_fails_closed(self, repo):
+        for index in range(6):
+            subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    str(repo),
+                    "config",
+                    f"alias.deep{index}",
+                    f"!git deep{index + 1}",
+                ],
+                check=True,
+            )
+        payload = "${x:-a}" * 257 + "; git reset --hard"
+        subprocess.run(
+            ["git", "-C", str(repo), "config", "alias.deep6", f"!{payload}"],
+            check=True,
+        )
+
+        hit, msg = _detect("git deep0", repo, repo)
+
+        assert hit is True
+        assert "parser safety limit" in msg
+
     def test_mutation_in_command_substitution(self, repo):
         hit, _ = _detect('echo "$(git checkout main)"', repo, repo)
         assert hit is True

--- a/tests/tools/test_self_repo_guard.py
+++ b/tests/tools/test_self_repo_guard.py
@@ -25,6 +25,14 @@ def _detect(command, cwd, root):
 
 
 class TestBlocksMutationsInSourceRepo:
+    def test_parser_limit_fails_closed(self, repo):
+        payload = "${x:-a}" * 257 + "; git reset --hard"
+
+        hit, msg = _detect(payload, repo, repo)
+
+        assert hit is True
+        assert "parser safety limit" in msg
+
     @pytest.mark.parametrize(
         "sub",
         [

--- a/tests/tools/test_self_repo_guard.py
+++ b/tests/tools/test_self_repo_guard.py
@@ -134,6 +134,18 @@ class TestBlocksMutationsInSourceRepo:
         hit, _ = _detect("git co main", repo, repo)
         assert hit is True
 
+    def test_configured_shell_alias_parser_limit_fails_closed(self, repo):
+        payload = "${x:-a}" * 257 + "; git reset --hard"
+        subprocess.run(
+            ["git", "-C", str(repo), "config", "alias.boom", f"!{payload}"],
+            check=True,
+        )
+
+        hit, msg = _detect("git boom", repo, repo)
+
+        assert hit is True
+        assert "parser safety limit" in msg
+
     def test_mutation_in_command_substitution(self, repo):
         hit, _ = _detect('echo "$(git checkout main)"', repo, repo)
         assert hit is True

--- a/tests/tools/test_self_repo_guard.py
+++ b/tests/tools/test_self_repo_guard.py
@@ -33,6 +33,14 @@ class TestBlocksMutationsInSourceRepo:
         assert hit is True
         assert "parser safety limit" in msg
 
+    def test_command_substitution_parser_limit_fails_closed(self, repo):
+        payload = "$(" * 257 + "printf safe" + ")" * 257 + "; git reset --hard"
+
+        hit, msg = _detect(payload, repo, repo)
+
+        assert hit is True
+        assert "parser safety limit" in msg
+
     @pytest.mark.parametrize(
         "sub",
         [

--- a/tests/tools/test_terminal_self_repo_guard.py
+++ b/tests/tools/test_terminal_self_repo_guard.py
@@ -80,6 +80,16 @@ class TestSelfRepoGuardWiring:
         assert result["status"] == "blocked"
         env.execute.assert_not_called()
 
+    def test_force_cannot_bypass_parser_limit(self, repo, monkeypatch):
+        config = _make_env_config(cwd=str(repo))
+        payload = "${x:-a}" * 257 + "; git reset --hard"
+
+        result, env = _run(payload, config, monkeypatch, repo, force=True)
+
+        assert result["status"] == "blocked"
+        assert "parser safety limit" in result["error"]
+        env.execute.assert_not_called()
+
     def test_workdir_targeting_repo_is_blocked(self, repo, monkeypatch, tmp_path):
         config = _make_env_config(cwd=str(tmp_path))
         result, env = _run("git pull", config, monkeypatch, repo, workdir=str(repo))

--- a/tests/tools/test_terminal_self_repo_guard.py
+++ b/tests/tools/test_terminal_self_repo_guard.py
@@ -108,6 +108,35 @@ class TestSelfRepoGuardWiring:
         assert "parser safety limit" in result["error"]
         env.execute.assert_not_called()
 
+    def test_force_cannot_bypass_deep_alias_parser_limit(
+        self, repo, monkeypatch
+    ):
+        subprocess.run(["git", "init", "-q", str(repo)], check=True)
+        for index in range(6):
+            subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    str(repo),
+                    "config",
+                    f"alias.deep{index}",
+                    f"!git deep{index + 1}",
+                ],
+                check=True,
+            )
+        payload = "${x:-a}" * 257 + "; git reset --hard"
+        subprocess.run(
+            ["git", "-C", str(repo), "config", "alias.deep6", f"!{payload}"],
+            check=True,
+        )
+        config = _make_env_config(cwd=str(repo))
+
+        result, env = _run("git deep0", config, monkeypatch, repo, force=True)
+
+        assert result["status"] == "blocked"
+        assert "parser safety limit" in result["error"]
+        env.execute.assert_not_called()
+
     def test_workdir_targeting_repo_is_blocked(self, repo, monkeypatch, tmp_path):
         config = _make_env_config(cwd=str(tmp_path))
         result, env = _run("git pull", config, monkeypatch, repo, workdir=str(repo))

--- a/tests/tools/test_terminal_self_repo_guard.py
+++ b/tests/tools/test_terminal_self_repo_guard.py
@@ -1,6 +1,7 @@
 """terminal_tool wiring tests for the self-repo git mutation guard."""
 
 import json
+import subprocess
 from contextlib import ExitStack
 from unittest.mock import MagicMock, patch
 
@@ -85,6 +86,23 @@ class TestSelfRepoGuardWiring:
         payload = "${x:-a}" * 257 + "; git reset --hard"
 
         result, env = _run(payload, config, monkeypatch, repo, force=True)
+
+        assert result["status"] == "blocked"
+        assert "parser safety limit" in result["error"]
+        env.execute.assert_not_called()
+
+    def test_force_cannot_bypass_configured_alias_parser_limit(
+        self, repo, monkeypatch
+    ):
+        subprocess.run(["git", "init", "-q", str(repo)], check=True)
+        payload = "${x:-a}" * 257 + "; git reset --hard"
+        subprocess.run(
+            ["git", "-C", str(repo), "config", "alias.boom", f"!{payload}"],
+            check=True,
+        )
+        config = _make_env_config(cwd=str(repo))
+
+        result, env = _run("git boom", config, monkeypatch, repo, force=True)
 
         assert result["status"] == "blocked"
         assert "parser safety limit" in result["error"]

--- a/tests/tools/test_terminal_self_repo_guard.py
+++ b/tests/tools/test_terminal_self_repo_guard.py
@@ -91,6 +91,18 @@ class TestSelfRepoGuardWiring:
         assert "parser safety limit" in result["error"]
         env.execute.assert_not_called()
 
+    def test_force_cannot_bypass_command_substitution_limit(
+        self, repo, monkeypatch
+    ):
+        config = _make_env_config(cwd=str(repo))
+        payload = "$(" * 257 + "printf safe" + ")" * 257 + "; git reset --hard"
+
+        result, env = _run(payload, config, monkeypatch, repo, force=True)
+
+        assert result["status"] == "blocked"
+        assert "parser safety limit" in result["error"]
+        env.execute.assert_not_called()
+
     def test_force_cannot_bypass_configured_alias_parser_limit(
         self, repo, monkeypatch
     ):

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1541,6 +1541,7 @@ _MAX_DETECTION_COMMAND_CHARS = 128_000
 _MAX_SEPARATOR_FREE_COMMAND_CHARS = 4_096
 _MAX_DETECTION_SEGMENTS = 25_000
 _MAX_PARAMETER_EXPANSIONS = 256
+_MAX_COMMAND_SUBSTITUTIONS = 256
 _PARSER_LIMIT_DESCRIPTION = "command parser limit exceeded"
 _MALFORMED_EXEC_DESCRIPTION = "command parser limit or malformed executable payload"
 
@@ -1555,10 +1556,13 @@ def _command_parser_limit_exceeded(command: str) -> bool:
     """
     if len(command) > _MAX_DETECTION_COMMAND_CHARS:
         return True
-    # Parameter-expansion scanners recurse for nested `${...}`. Bound their
-    # input before parsing so adversarial nesting fails closed instead of
-    # reaching Python's recursion limit or repeatedly rescanning nested spans.
+    # Parameter-expansion and command-substitution scanners recurse for nested
+    # shell constructs. Bound their input before parsing so adversarial nesting
+    # fails closed instead of reaching Python's recursion limit or repeatedly
+    # rescanning nested spans.
     if command.count("${") > _MAX_PARAMETER_EXPANSIONS:
+        return True
+    if command.count("$(") > _MAX_COMMAND_SUBSTITUTIONS:
         return True
     # Long separator-free input has no compound-command utility and otherwise
     # makes every legacy regex inspect one giant token. Reject it before any

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -2252,6 +2252,11 @@ def _deobfuscate_shell_word_for_detection(word: str) -> str:
 
 
 def _iter_shell_command_starts(command: str):
+    # This scanner also has direct callers that run before the public approval
+    # detectors. Enforce the recursion bound here as well so none can enter the
+    # nested parameter-expansion parser with an over-limit command.
+    if _command_parser_limit_exceeded(command):
+        return
     starts = [0]
 
     def scan_parameter_expansion(

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -2003,6 +2003,60 @@ def _scan_dollar_paren_end(command: str, start: int) -> int | None:
     return None
 
 
+def _scan_parameter_expansion_end(
+    command: str, start: int, limit: int | None = None
+) -> int | None:
+    """Return the offset after a balanced ``${...}`` parameter expansion."""
+    end = len(command) if limit is None else min(limit, len(command))
+    quote: str | None = None
+    i = start + 2
+    while i < end:
+        ch = command[i]
+        if quote == "'":
+            if ch == "'":
+                quote = None
+            i += 1
+            continue
+        if quote == '"':
+            if ch == "\\" and i + 1 < end:
+                i += 2
+                continue
+            if ch == '"':
+                quote = None
+                i += 1
+                continue
+        elif ch in ("'", '"'):
+            quote = ch
+            i += 1
+            continue
+        elif ch == "\\" and i + 1 < end:
+            i += 2
+            continue
+
+        if command.startswith("$(", i):
+            nested_end = _scan_dollar_paren_end(command, i)
+            if nested_end is None or nested_end > end:
+                return None
+            i = nested_end
+            continue
+        if command.startswith("${", i):
+            nested_end = _scan_parameter_expansion_end(command, i, end)
+            if nested_end is None:
+                return None
+            i = nested_end
+            continue
+        if ch == "`":
+            nested_end = _scan_backtick_end(command, i)
+            if nested_end is None or nested_end > end:
+                return None
+            i = nested_end
+            continue
+        if ch == "}":
+            return i + 1
+        i += 1
+    return None
+
+
 def _scan_backtick_end(command: str, start: int) -> int | None:
     i = start + 1
     while i < len(command):
@@ -2186,6 +2240,55 @@ def _deobfuscate_shell_word_for_detection(word: str) -> str:
 def _iter_shell_command_starts(command: str):
     starts = [0]
 
+    def scan_parameter_expansion(start: int, end: int) -> None:
+        """Record executable substitutions without treating ``${`` as a group."""
+        quote: str | None = None
+        i = start
+        while i < end:
+            ch = command[i]
+            if quote == "'":
+                if ch == "'":
+                    quote = None
+                i += 1
+                continue
+            if quote == '"':
+                if ch == "\\" and i + 1 < end:
+                    i += 2
+                    continue
+                if ch == '"':
+                    quote = None
+                    i += 1
+                    continue
+            elif ch in ("'", '"'):
+                quote = ch
+                i += 1
+                continue
+            elif ch == "\\" and i + 1 < end:
+                i += 2
+                continue
+
+            if command.startswith("$(", i):
+                nested_end = _scan_dollar_paren_end(command, i)
+                nested_limit = nested_end - 1 if nested_end is not None else end
+                starts.append(i + 2)
+                scan(i + 2, nested_limit)
+                i = nested_end if nested_end is not None else end
+                continue
+            if command.startswith("${", i):
+                nested_end = _scan_parameter_expansion_end(command, i, end)
+                nested_limit = nested_end - 1 if nested_end is not None else end
+                scan_parameter_expansion(i + 2, nested_limit)
+                i = nested_end if nested_end is not None else end
+                continue
+            if ch == "`":
+                nested_end = _scan_backtick_end(command, i)
+                nested_limit = nested_end - 1 if nested_end is not None else end
+                starts.append(i + 1)
+                scan(i + 1, nested_limit)
+                i = nested_end if nested_end is not None else end
+                continue
+            i += 1
+
     def scan(start: int, end: int) -> None:
         quote: str | None = None
         i = start
@@ -2216,6 +2319,12 @@ def _iter_shell_command_starts(command: str):
                     scan(i + 1, nested_end - 1 if nested_end is not None else end)
                     i = nested_end if nested_end is not None else end
                     continue
+                if command.startswith("${", i):
+                    nested_end = _scan_parameter_expansion_end(command, i, end)
+                    nested_limit = nested_end - 1 if nested_end is not None else end
+                    scan_parameter_expansion(i + 2, nested_limit)
+                    i = nested_end if nested_end is not None else end
+                    continue
                 i += 1
                 continue
             if ch in ("'", '"'):
@@ -2235,6 +2344,12 @@ def _iter_shell_command_starts(command: str):
                 nested_end = _scan_backtick_end(command, i)
                 starts.append(i + 1)
                 scan(i + 1, nested_end - 1 if nested_end is not None else end)
+                i = nested_end if nested_end is not None else end
+                continue
+            if command.startswith("${", i):
+                nested_end = _scan_parameter_expansion_end(command, i, end)
+                nested_limit = nested_end - 1 if nested_end is not None else end
+                scan_parameter_expansion(i + 2, nested_limit)
                 i = nested_end if nested_end is not None else end
                 continue
             if ch in ("(", "{"):
@@ -2258,7 +2373,7 @@ def _iter_shell_command_starts(command: str):
             yield start
 
 
-def _mark_command_starts(command: str) -> str:
+def _mark_command_starts(command: str, marker: str = "\n") -> str:
     """Insert a newline before each real (quote-aware) command start.
 
     ``\\n`` is already a ``_CMDPOS`` separator, so this rewrites subshell
@@ -2280,7 +2395,7 @@ def _mark_command_starts(command: str) -> str:
     parts: list[str] = []
     previous = 0
     for offset in offsets:
-        parts.extend((command[previous:offset], "\n"))
+        parts.extend((command[previous:offset], marker))
         previous = offset
     parts.append(command[previous:])
     return "".join(parts)
@@ -2439,7 +2554,11 @@ def _command_detection_variants(command: str):
     # still intact, then normalize the already-marked spelling. Otherwise a
     # valid data escape such as grep's `[^\"]` can become a quote delimiter
     # before this pass and hide a real command that follows the grep segment.
-    marked = _normalize_command_for_detection(_mark_command_starts(quote_faithful))
+    # A leading space keeps an inserted marker from becoming a backslash-newline
+    # continuation when the preceding shell token ends in a literal backslash.
+    marked = _normalize_command_for_detection(
+        _mark_command_starts(quote_faithful, marker=" \n")
+    )
     if marked != normalized and marked not in seen:
         seen.add(marked)
         yield marked

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1540,6 +1540,7 @@ _SHELL_PUNCTUATION = {";", "&", "&&", "|", "||", "(", ")", "{", "}"}
 _MAX_DETECTION_COMMAND_CHARS = 128_000
 _MAX_SEPARATOR_FREE_COMMAND_CHARS = 4_096
 _MAX_DETECTION_SEGMENTS = 25_000
+_MAX_PARAMETER_EXPANSIONS = 256
 _PARSER_LIMIT_DESCRIPTION = "command parser limit exceeded"
 _MALFORMED_EXEC_DESCRIPTION = "command parser limit or malformed executable payload"
 
@@ -1553,6 +1554,11 @@ def _command_parser_limit_exceeded(command: str) -> bool:
     closed rather than allowing an uninspected suffix to execute.
     """
     if len(command) > _MAX_DETECTION_COMMAND_CHARS:
+        return True
+    # Parameter-expansion scanners recurse for nested `${...}`. Bound their
+    # input before parsing so adversarial nesting fails closed instead of
+    # reaching Python's recursion limit or repeatedly rescanning nested spans.
+    if command.count("${") > _MAX_PARAMETER_EXPANSIONS:
         return True
     # Long separator-free input has no compound-command utility and otherwise
     # makes every legacy regex inspect one giant token. Reject it before any

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -725,8 +725,11 @@ def detect_hardline_command(command: str) -> tuple:
     """
     if _command_parser_limit_exceeded(command):
         return (True, _PARSER_LIMIT_DESCRIPTION)
-    normalized = _normalize_command_for_detection(command)
-    _, malformed_grep = _grep_safe_detection_variant(normalized)
+    # Validate grep's shell grammar before normalization strips escapes such
+    # as the \" in a valid double-quoted regex (`grep "[^\"]*"`). Parsing
+    # the normalized spelling would turn that escaped data quote into a shell
+    # delimiter and falsely report an unterminated executable payload.
+    _, malformed_grep = _grep_safe_detection_variant(command)
     if malformed_grep:
         return (True, _MALFORMED_EXEC_DESCRIPTION)
     for command_variant in _command_detection_variants(command):
@@ -2380,7 +2383,8 @@ def _command_detection_variants(command: str):
     # unterminated quote), so masking the normalized text could swallow a
     # REAL unquoted newline separator that follows. The raw command carries
     # faithful shell quote state.
-    normalized = _normalize_command_for_detection(_mask_quoted_newlines(command))
+    quote_faithful = _mask_quoted_newlines(command)
+    normalized = _normalize_command_for_detection(quote_faithful)
     # Quote-aware grep parsing hides only structurally identified pattern
     # operands. Malformed/ambiguous input remains byte-for-byte intact.
     grep_safe, _ = _grep_safe_detection_variant(normalized)
@@ -2431,8 +2435,12 @@ def _command_detection_variants(command: str):
     # untouched, while `(reboot)` / `{ shutdown -h now; }` now anchor. This
     # covers every `_CMDPOS` rule (shutdown/reboot/init/systemctl/telinit and
     # the rm root/home/system floor) in one place.
-    marked = _mark_command_starts(grep_safe)
-    if marked != grep_safe and marked not in seen:
+    # Find command boundaries while the original escape/quote structure is
+    # still intact, then normalize the already-marked spelling. Otherwise a
+    # valid data escape such as grep's `[^\"]` can become a quote delimiter
+    # before this pass and hide a real command that follows the grep segment.
+    marked = _normalize_command_for_detection(_mark_command_starts(quote_faithful))
+    if marked != normalized and marked not in seen:
         seen.add(marked)
         yield marked
     # Shell quoting/escaping can spell a dangerous executable name in pieces

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -2004,7 +2004,10 @@ def _scan_dollar_paren_end(command: str, start: int) -> int | None:
 
 
 def _scan_parameter_expansion_end(
-    command: str, start: int, limit: int | None = None
+    command: str,
+    start: int,
+    limit: int | None = None,
+    outer_double_quoted: bool = False,
 ) -> int | None:
     """Return the offset after a balanced ``${...}`` parameter expansion."""
     end = len(command) if limit is None else min(limit, len(command))
@@ -2025,7 +2028,7 @@ def _scan_parameter_expansion_end(
                 quote = None
                 i += 1
                 continue
-        elif ch in ("'", '"'):
+        elif ch == '"' or (ch == "'" and not outer_double_quoted):
             quote = ch
             i += 1
             continue
@@ -2040,7 +2043,12 @@ def _scan_parameter_expansion_end(
             i = nested_end
             continue
         if command.startswith("${", i):
-            nested_end = _scan_parameter_expansion_end(command, i, end)
+            nested_end = _scan_parameter_expansion_end(
+                command,
+                i,
+                end,
+                outer_double_quoted=outer_double_quoted or quote == '"',
+            )
             if nested_end is None:
                 return None
             i = nested_end
@@ -2240,7 +2248,9 @@ def _deobfuscate_shell_word_for_detection(word: str) -> str:
 def _iter_shell_command_starts(command: str):
     starts = [0]
 
-    def scan_parameter_expansion(start: int, end: int) -> None:
+    def scan_parameter_expansion(
+        start: int, end: int, outer_double_quoted: bool = False
+    ) -> None:
         """Record executable substitutions without treating ``${`` as a group."""
         quote: str | None = None
         i = start
@@ -2259,7 +2269,7 @@ def _iter_shell_command_starts(command: str):
                     quote = None
                     i += 1
                     continue
-            elif ch in ("'", '"'):
+            elif ch == '"' or (ch == "'" and not outer_double_quoted):
                 quote = ch
                 i += 1
                 continue
@@ -2275,9 +2285,19 @@ def _iter_shell_command_starts(command: str):
                 i = nested_end if nested_end is not None else end
                 continue
             if command.startswith("${", i):
-                nested_end = _scan_parameter_expansion_end(command, i, end)
+                nested_double_quoted = outer_double_quoted or quote == '"'
+                nested_end = _scan_parameter_expansion_end(
+                    command,
+                    i,
+                    end,
+                    outer_double_quoted=nested_double_quoted,
+                )
                 nested_limit = nested_end - 1 if nested_end is not None else end
-                scan_parameter_expansion(i + 2, nested_limit)
+                scan_parameter_expansion(
+                    i + 2,
+                    nested_limit,
+                    outer_double_quoted=nested_double_quoted,
+                )
                 i = nested_end if nested_end is not None else end
                 continue
             if ch == "`":
@@ -2320,9 +2340,13 @@ def _iter_shell_command_starts(command: str):
                     i = nested_end if nested_end is not None else end
                     continue
                 if command.startswith("${", i):
-                    nested_end = _scan_parameter_expansion_end(command, i, end)
+                    nested_end = _scan_parameter_expansion_end(
+                        command, i, end, outer_double_quoted=True
+                    )
                     nested_limit = nested_end - 1 if nested_end is not None else end
-                    scan_parameter_expansion(i + 2, nested_limit)
+                    scan_parameter_expansion(
+                        i + 2, nested_limit, outer_double_quoted=True
+                    )
                     i = nested_end if nested_end is not None else end
                     continue
                 i += 1
@@ -2373,7 +2397,9 @@ def _iter_shell_command_starts(command: str):
             yield start
 
 
-def _mark_command_starts(command: str, marker: str = "\n") -> str:
+def _mark_command_starts(
+    command: str, marker: str = "\n", protect_line_continuations: bool = False
+) -> str:
     """Insert a newline before each real (quote-aware) command start.
 
     ``\\n`` is already a ``_CMDPOS`` separator, so this rewrites subshell
@@ -2395,7 +2421,12 @@ def _mark_command_starts(command: str, marker: str = "\n") -> str:
     parts: list[str] = []
     previous = 0
     for offset in offsets:
-        parts.extend((command[previous:offset], marker))
+        effective_marker = (
+            f" {marker}"
+            if protect_line_continuations and command[offset - 1] == "\\"
+            else marker
+        )
+        parts.extend((command[previous:offset], effective_marker))
         previous = offset
     parts.append(command[previous:])
     return "".join(parts)
@@ -2554,10 +2585,10 @@ def _command_detection_variants(command: str):
     # still intact, then normalize the already-marked spelling. Otherwise a
     # valid data escape such as grep's `[^\"]` can become a quote delimiter
     # before this pass and hide a real command that follows the grep segment.
-    # A leading space keeps an inserted marker from becoming a backslash-newline
-    # continuation when the preceding shell token ends in a literal backslash.
+    # Protect only markers preceded by a backslash; adding spaces at every
+    # boundary needlessly inflates the hot path for long compound commands.
     marked = _normalize_command_for_detection(
-        _mark_command_starts(quote_faithful, marker=" \n")
+        _mark_command_starts(quote_faithful, protect_line_continuations=True)
     )
     if marked != normalized and marked not in seen:
         seen.add(marked)

--- a/tools/self_repo_guard.py
+++ b/tools/self_repo_guard.py
@@ -35,6 +35,7 @@ _WORKTREE_MUTATIONS = frozenset({
 _WORKTREE_TARGET_ACTIONS = frozenset({"move", "remove"})
 _STASH_SAFE_ACTIONS = frozenset({"list", "show", "create", "store", "drop", "clear"})
 _RESET_WORKTREE_MODES = frozenset({"--hard", "--merge", "--keep"})
+_PARSER_LIMIT_OPERATION = "__parser_limit__"
 _KNOWN_GIT_BUILTINS = frozenset({
     "add",
     "am",
@@ -644,6 +645,8 @@ def _inspect_github_cli(
 def _find_mutation(command: str, cwd: Path, root: Path, depth: int = 0) -> str | None:
     if depth > _MAX_RECURSION:
         return None
+    if _command_parser_limit_exceeded(command):
+        return _PARSER_LIMIT_OPERATION
 
     masked_command, heredoc_scripts = _mask_heredocs(command)
     for script in heredoc_scripts:
@@ -720,16 +723,16 @@ def detect_self_repo_git_mutation(
         return False, None
 
     root = _resolve(str(root), Path("/"))
-    if _command_parser_limit_exceeded(command):
+    base = _resolve(cwd, Path("/")) if cwd else Path("/")
+    operation = _find_mutation(command, base, root)
+    if operation is None:
+        return False, None
+    if operation == _PARSER_LIMIT_OPERATION:
         return True, (
             "Blocked: command exceeded the parser safety limit while checking "
             f"whether it would rewrite Hermes's live source checkout ({root}). "
             "Split the command into smaller operations and retry."
         )
-    base = _resolve(cwd, Path("/")) if cwd else Path("/")
-    operation = _find_mutation(command, base, root)
-    if operation is None:
-        return False, None
     return True, _block_message(operation, root)
 
 

--- a/tools/self_repo_guard.py
+++ b/tools/self_repo_guard.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 from tools.approval import (
     _bash_exec_payload,
+    _command_parser_limit_exceeded,
     _deobfuscate_shell_word_for_detection,
     _iter_shell_command_starts,
     _read_shell_word,
@@ -719,6 +720,12 @@ def detect_self_repo_git_mutation(
         return False, None
 
     root = _resolve(str(root), Path("/"))
+    if _command_parser_limit_exceeded(command):
+        return True, (
+            "Blocked: command exceeded the parser safety limit while checking "
+            f"whether it would rewrite Hermes's live source checkout ({root}). "
+            "Split the command into smaller operations and retry."
+        )
     base = _resolve(cwd, Path("/")) if cwd else Path("/")
     operation = _find_mutation(command, base, root)
     if operation is None:

--- a/tools/self_repo_guard.py
+++ b/tools/self_repo_guard.py
@@ -604,7 +604,7 @@ def _inspect_git(
     if subcommand in _KNOWN_GIT_BUILTINS:
         return None
     if depth >= _MAX_RECURSION:
-        return None
+        return _PARSER_LIMIT_OPERATION
 
     alias = inline_aliases.get(subcommand)
     if alias is None:
@@ -643,9 +643,9 @@ def _inspect_github_cli(
 
 
 def _find_mutation(command: str, cwd: Path, root: Path, depth: int = 0) -> str | None:
-    if depth > _MAX_RECURSION:
-        return None
     if _command_parser_limit_exceeded(command):
+        return _PARSER_LIMIT_OPERATION
+    if depth > _MAX_RECURSION:
         return _PARSER_LIMIT_OPERATION
 
     masked_command, heredoc_scripts = _mask_heredocs(command)


### PR DESCRIPTION
## What does this PR do?

Valid grep patterns such as `grep -o "[^\"]*" f` no longer hit the unconditional hardline block as malformed shell input. The fix validates grep quoting before destructive-command normalization removes escape markers, while retaining hardline detection for malformed input and dangerous commands that follow the grep segment.

### Symptom

A shell-valid grep bracket class containing an escaped quote is rejected with `command parser limit or malformed executable payload`. Because this is a hardline result, yolo and `approvals.mode: off` cannot allow the benign command.

### Impact

Routine grep searches stop before execution and cannot reach the normal approval path. The affected command shape is parser-only and platform-independent.

### Bug Cause

**Trigger:** `tools/approval.py:718` / `detect_hardline_command` normalizes a grep command before validating its shell grammar.

**Causal chain:**
1. A double-quoted grep pattern contains a shell-valid escaped quote such as `[^\"]`.
2. `_normalize_command_for_detection` removes the backslash before `_grep_safe_detection_variant` tokenizes the command, turning escaped data into a quote delimiter.
3. The grep parser reports malformed input, and the public hardline guard rejects the command without an approval prompt.

**Why it is wrong:** normalization is appropriate for dangerous-pattern matching, but it is lossy for shell quote ownership and therefore cannot be the source for syntax validation.

**Working sibling / contrast:** the raw command already tokenizes correctly because `_shell_tokens_with_spans` understands backslash escapes inside double quotes. Truly unescaped quotes still fail closed.

**Ruled out:** the grep lexer does not require a bracket-class special case. Parsing the raw shell spelling succeeds, which isolates the fault to the ordering of normalization and syntax validation.

### Fix

Validate grep syntax against the raw command, then continue matching dangerous patterns against normalized variants. Mark real command boundaries before normalization as well, so normalization cannot hide a destructive command after a valid escaped-quote grep pattern.

## Related Issue

Closes #96776

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/approval.py` - preserve quote ownership for grep syntax validation and command-boundary discovery.
- `tests/tools/test_hardline_blocklist.py` - cover valid bracket classes, malformed input, destructive suffixes, yolo, and approvals-off behavior.

## How to Test

1. Run the hardline approval regression suite.
2. Confirm the valid escaped-quote grep cases pass while malformed and destructive cases remain blocked.

```bash
scripts/run_tests.sh tests/tools/test_hardline_blocklist.py -v
```

Result: 252 passed on Windows 11 with Python 3.11.15.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation - N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

N/A
