### PR TITLE
fix(feishu): release adapter resources even when disconnect is cancelled mid-wait

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1829,77 +1829,96 @@ class FeishuAdapter(BasePlatformAdapter):
     async def disconnect(self) -> None:
         """Disconnect from Feishu/Lark."""
         self._running = False
-        await self._cancel_pending_tasks(self._pending_text_batch_tasks)
-        await self._cancel_pending_tasks(self._pending_media_batch_tasks)
-        self._reset_batch_buffers()
+        try:
+            await self._cancel_pending_tasks(self._pending_text_batch_tasks)
+            await self._cancel_pending_tasks(self._pending_media_batch_tasks)
+            self._reset_batch_buffers()
 
-        # Send a WebSocket CLOSE frame to Feishu BEFORE tearing down the
-        # thread loop. Without this, Feishu's server never learns the
-        # connection is dead and continues routing messages to the stale
-        # endpoint — the channel goes silent until the server-side
-        # CLOSE-WAIT expires (minutes to hours). See issue #10202.
-        #
-        # ``_disable_websocket_auto_reconnect()`` nils ``self._ws_client``,
-        # so capture the client reference first.
-        ws_client = self._ws_client
-        ws_thread_loop = self._ws_thread_loop
-        self._disable_websocket_auto_reconnect()
-        await self._stop_webhook_server()
+            # Send a WebSocket CLOSE frame to Feishu BEFORE tearing down the
+            # thread loop. Without this, Feishu's server never learns the
+            # connection is dead and continues routing messages to the stale
+            # endpoint — the channel goes silent until the server-side
+            # CLOSE-WAIT expires (minutes to hours). See issue #10202.
+            #
+            # ``_disable_websocket_auto_reconnect()`` nils ``self._ws_client``,
+            # so capture the client reference first.
+            ws_client = self._ws_client
+            ws_thread_loop = self._ws_thread_loop
+            self._disable_websocket_auto_reconnect()
+            await self._stop_webhook_server()
 
-        if (
-            ws_client is not None
-            and ws_thread_loop is not None
-            and not ws_thread_loop.is_closed()
-            and hasattr(ws_client, "_disconnect")
-        ):
-            try:
-                future = asyncio.run_coroutine_threadsafe(
-                    ws_client._disconnect(), ws_thread_loop
-                )
-                # 5s is generous — the CLOSE frame is a single WebSocket
-                # control frame. If it takes longer than that the
-                # connection is already wedged and we gain nothing by
-                # waiting further.
-                await asyncio.wait_for(asyncio.wrap_future(future), timeout=5.0)
-                logger.debug("[Feishu] Sent WebSocket CLOSE frame to Feishu")
-            except asyncio.TimeoutError:
-                logger.warning(
-                    "[Feishu] CLOSE frame not acknowledged within 5s — "
-                    "Feishu may briefly route messages to the stale "
-                    "connection until server-side timeout"
-                )
-            except Exception as exc:
-                logger.debug(
-                    "[Feishu] Could not send WebSocket CLOSE frame: %s",
-                    exc,
-                    exc_info=True,
-                )
+            if (
+                ws_client is not None
+                and ws_thread_loop is not None
+                and not ws_thread_loop.is_closed()
+                and hasattr(ws_client, "_disconnect")
+            ):
+                try:
+                    future = asyncio.run_coroutine_threadsafe(
+                        ws_client._disconnect(), ws_thread_loop
+                    )
+                    # 5s is generous — the CLOSE frame is a single WebSocket
+                    # control frame. If it takes longer than that the
+                    # connection is already wedged and we gain nothing by
+                    # waiting further.
+                    await asyncio.wait_for(asyncio.wrap_future(future), timeout=5.0)
+                    logger.debug("[Feishu] Sent WebSocket CLOSE frame to Feishu")
+                except asyncio.TimeoutError:
+                    logger.warning(
+                        "[Feishu] CLOSE frame not acknowledged within 5s — "
+                        "Feishu may briefly route messages to the stale "
+                        "connection until server-side timeout"
+                    )
+                except Exception as exc:
+                    logger.debug(
+                        "[Feishu] Could not send WebSocket CLOSE frame: %s",
+                        exc,
+                        exc_info=True,
+                    )
 
-        if ws_thread_loop is not None and not ws_thread_loop.is_closed():
-            logger.debug("[Feishu] Cancelling websocket thread tasks and stopping loop")
+            if ws_thread_loop is not None and not ws_thread_loop.is_closed():
+                logger.debug("[Feishu] Cancelling websocket thread tasks and stopping loop")
 
-            def cancel_all_tasks() -> None:
-                tasks = [t for t in asyncio.all_tasks(ws_thread_loop) if not t.done()]
-                logger.debug("[Feishu] Found %d pending tasks in websocket thread", len(tasks))
-                for task in tasks:
-                    task.cancel()
-                ws_thread_loop.call_later(0.1, ws_thread_loop.stop)
+                def cancel_all_tasks() -> None:
+                    tasks = [t for t in asyncio.all_tasks(ws_thread_loop) if not t.done()]
+                    logger.debug("[Feishu] Found %d pending tasks in websocket thread", len(tasks))
+                    for task in tasks:
+                        task.cancel()
+                    ws_thread_loop.call_later(0.1, ws_thread_loop.stop)
 
-            ws_thread_loop.call_soon_threadsafe(cancel_all_tasks)
+                ws_thread_loop.call_soon_threadsafe(cancel_all_tasks)
 
-        ws_future = self._ws_future
-        if ws_future is not None:
-            try:
-                logger.debug("[Feishu] Waiting for websocket thread to exit (timeout=10s)")
-                await asyncio.wait_for(asyncio.shield(ws_future), timeout=10.0)
-                logger.debug("[Feishu] Websocket thread exited cleanly")
-            except asyncio.TimeoutError:
-                logger.warning("[Feishu] Websocket thread did not exit within 10s - may be stuck")
-            except asyncio.CancelledError:
-                logger.debug("[Feishu] Websocket thread cancelled during disconnect")
-            except Exception as exc:
-                logger.debug("[Feishu] Websocket thread exited with error: %s", exc, exc_info=True)
+            ws_future = self._ws_future
+            if ws_future is not None:
+                try:
+                    logger.debug("[Feishu] Waiting for websocket thread to exit (timeout=10s)")
+                    await asyncio.wait_for(asyncio.shield(ws_future), timeout=10.0)
+                    logger.debug("[Feishu] Websocket thread exited cleanly")
+                except asyncio.TimeoutError:
+                    logger.warning("[Feishu] Websocket thread did not exit within 10s - may be stuck")
+                except asyncio.CancelledError:
+                    logger.debug("[Feishu] Websocket thread cancelled during disconnect")
+                except Exception as exc:
+                    logger.debug("[Feishu] Websocket thread exited with error: %s", exc, exc_info=True)
 
+            logger.info("[Feishu] Disconnected")
+        finally:
+            await self._local_teardown()
+
+    async def _local_teardown(self) -> None:
+        """Release every adapter-owned resource the replacement process needs.
+
+        Runs from ``disconnect()``'s ``finally`` so a gateway-level
+        cancellation cannot skip it: the planned-restart path cancels
+        ``disconnect()`` after 5 s while the waits above can legitimately
+        spend 15 s (CLOSE ack + thread exit). When cancellation landed on a
+        wait, the old cleanup block was skipped entirely — the SDK executor,
+        seen-id persistence, and the Feishu app-scoped lock stayed alive in
+        the old process, so the replacement repeatedly failed to claim the
+        Feishu app and the planned restart stalled (#96801). Everything in
+        here is synchronous and fast, so a single cancellation cannot
+        interrupt it mid-way.
+        """
         self._ws_future = None
         self._ws_thread_loop = None
         self._loop = None
@@ -1907,9 +1926,7 @@ class FeishuAdapter(BasePlatformAdapter):
         self._shutdown_sdk_executor()
         self._persist_seen_message_ids()
         await self._release_app_lock()
-
         self._mark_disconnected()
-        logger.info("[Feishu] Disconnected")
 
     async def _cancel_pending_tasks(self, tasks: Dict[str, asyncio.Task]) -> None:
         pending = [task for task in tasks.values() if task and not task.done()]

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -181,6 +181,92 @@ class TestFeishuAdapterMessaging(unittest.TestCase):
         # _disable_websocket_auto_reconnect() must still run.
         self.assertIsNone(adapter._ws_client)
 
+    def test_disconnect_local_teardown_survives_cancellation(self):
+        """A gateway-level cancel landing on a wait inside disconnect() must
+        still release every adapter-owned resource (#96801).
+
+        The planned-restart path cancels disconnect() after 5s while the
+        CLOSE-ack (5s) and thread-exit (10s) waits can legitimately spend
+        15s. Before the fix, the cancellation skipped the local cleanup
+        block entirely — SDK executor, seen-id persistence, and the
+        Feishu app-scoped lock stayed owned by the old process, so the
+        replacement could not claim the app.
+        """
+        import threading
+        from types import SimpleNamespace
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+
+        ws_thread_loop = asyncio.new_event_loop()
+        ready = threading.Event()
+
+        def _run_loop() -> None:
+            asyncio.set_event_loop(ws_thread_loop)
+            ready.set()
+            ws_thread_loop.run_forever()
+
+        thread = threading.Thread(target=_run_loop, daemon=True)
+        thread.start()
+        ready.wait()
+
+        # A CLOSE that never completes: the coroutine hangs forever, so
+        # disconnect() sits on the 5s wait_for when the cancel arrives.
+        started = threading.Event()
+
+        async def _hanging_disconnect() -> None:
+            started.set()
+            await asyncio.Event().wait()
+
+        ws_client = SimpleNamespace(_disconnect=_hanging_disconnect, _auto_reconnect=True)
+        adapter._ws_client = ws_client
+        adapter._ws_thread_loop = ws_thread_loop
+        adapter._ws_future = None
+        # Local-teardown observables: an app-lock identity the release path
+        # must clear, and the disconnected marker (base-class method writes
+        # runtime status — replace it to observe the call without IO).
+        adapter._app_lock_identity = "test-lock-identity"
+        mark_disconnected_calls = []
+        adapter._mark_disconnected = lambda: mark_disconnected_calls.append(1)
+
+        async def _cancel_mid_disconnect() -> None:
+            task = asyncio.create_task(adapter.disconnect())
+            # Let disconnect() reach the CLOSE wait (it needs the thread
+            # loop to schedule the coroutine first).
+            for _ in range(100):
+                if started.is_set():
+                    break
+                await asyncio.sleep(0.01)
+            await asyncio.sleep(0.05)
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        try:
+            asyncio.run(_cancel_mid_disconnect())
+        finally:
+            if not ws_thread_loop.is_closed():
+                ws_thread_loop.call_soon_threadsafe(ws_thread_loop.stop)
+            thread.join(timeout=2.0)
+            if not ws_thread_loop.is_closed():
+                ws_thread_loop.close()
+
+        self.assertIsNone(
+            adapter._app_lock_identity,
+            "cancellation must not skip the app-lock release",
+        )
+        self.assertTrue(
+            mark_disconnected_calls,
+            "cancellation must not skip the disconnected marker",
+        )
+        self.assertIsNone(
+            adapter._sdk_executor,
+            "cancellation must not skip the SDK executor shutdown",
+        )
+
 
     @patch.dict(os.environ, {
         "FEISHU_APP_ID": "cli_app",


### PR DESCRIPTION
## What does this PR do?

Guarantees Feishu adapter resources are released even when `disconnect()` is cancelled mid-wait, which is what a planned gateway restart does.

The gateway-level teardown cancels `FeishuAdapter.disconnect()` after 5s, but the waits inside can legitimately spend 15s (5s WebSocket CLOSE acknowledgement + 10s thread exit). When the cancellation landed on one of those waits, the local cleanup block at the end of `disconnect()` — SDK executor shutdown, seen-id persistence, and the **Feishu app-scoped lock release** — was skipped entirely. The old gateway process stayed alive owning the app-scoped lock, the replacement process repeatedly failed to claim the Feishu app, and the planned restart stalled for minutes (#96801).

The fix extracts the local cleanup into `_local_teardown()` and runs it from `disconnect()`'s `finally`. Everything in it is synchronous and fast, so a single cancellation cannot interrupt it mid-way. The CLOSE/thread-exit waits keep their existing timeouts and warnings; the normal (uncancelled) path is byte-equivalent apart from the refactor.

## Related Issue

Fixes #96801

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/feishu/adapter.py` — wrapped `disconnect()`'s wait sequence in `try`, moved the trailing local cleanup (ws refs, event handler, SDK executor, seen-id persistence, app-lock release, disconnected marker) into a new `_local_teardown()` invoked from `finally`.
- `tests/gateway/test_feishu.py` — regression `test_disconnect_local_teardown_survives_cancellation`: a hanging CLOSE coroutine parks `disconnect()` on the 5s wait, the test cancels the task mid-wait, and asserts the app-lock identity is cleared, the disconnected marker ran, and the SDK executor was shut down.

## How to Test

1. `python -m pytest tests/gateway/test_feishu.py -q` — should pass apart from `test_download_remote_document_blocks_connect_time_rebind`, which fails identically on clean `upstream/main` (pre-existing, SSRF-assertion domain, no overlap with this diff).
2. Red/green verified locally: with the pre-fix `disconnect()` restored, the new regression fails (cancellation skips the app-lock release); with this change it passes, and the existing `test_disconnect_sends_websocket_close_frame` still passes.
3. Manual equivalent: start a gateway with the Feishu adapter, trigger a planned restart (`/restart`) while the Feishu WebSocket stalls its CLOSE — the old process must release the app-scoped lock so the replacement claims the Feishu app instead of retrying.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (targeted: `tests/gateway/test_feishu.py` — 58 passed / 18 skipped / 1 pre-existing failure unrelated to this diff, identical on clean main)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.5 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (docstring added on the new helper)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (pure-asyncio teardown ordering)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
