### PR TITLE
fix(desktop): stop bot prewarm startup stampede

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -9009,6 +9009,7 @@ function BotRow({ bot, onDelete, onEdit, onGroup, showHandle }) {
   const rowTooltip = [displayName(bot, meta), `@${handle}`, gatewayLabel, sourceStatus.label]
     .filter(Boolean)
     .join(' · ')
+  const warmedForPointerVisit = useRef(false)
 
   const warm = () => {
     // Multi-source row: pre-dial the agent's OWN source (feature-detected).
@@ -9033,13 +9034,32 @@ function BotRow({ bot, onDelete, onEdit, onGroup, showHandle }) {
     }
   }
 
+  // `pointerenter` can fire without physical pointer movement when live bot
+  // rows reorder underneath a stationary cursor. Warming on that event alone
+  // cascades through the roster: each backend emits activity, the next row
+  // moves under the cursor, and Desktop wakes every profile. Require one real
+  // pointer move per visit so layout churn cannot start the cascade.
+  const armWarm = () => {
+    warmedForPointerVisit.current = false
+  }
+  const warmOnPointerMove = () => {
+    if (warmedForPointerVisit.current) {
+      return
+    }
+
+    warmedForPointerVisit.current = true
+    warm()
+  }
+
   // Rows and Active Now share the exact-owner open path; only that path may
   // activate a source and resolve the canonical Bot Chat.
   const open = () => void openRosterBot(bot)
 
   const row = jsxs('button', {
     type: 'button',
-    onPointerEnter: warm,
+    onPointerEnter: armWarm,
+    onPointerLeave: armWarm,
+    onPointerMove: warmOnPointerMove,
     onClick: open,
     className: cn(
       'flex w-full min-w-0 max-w-full items-center gap-2.5 overflow-hidden rounded-md px-2 py-2 text-left transition-colors',

--- a/apps/desktop/src/plugins/hermes-bots/tests/profile-prewarm.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/profile-prewarm.test.mjs
@@ -107,6 +107,7 @@ function renderBotRow(input = 'alpha') {
     ACTIVE_WINDOW_S: 90,
     A2A_PREFIX_RE: /^$/,
     useEffect: () => undefined,
+    useRef: initial => ({ current: initial }),
     useState: initial => [typeof initial === 'function' ? initial() : initial, () => undefined],
     host: {
       state: { gateway: atom('open'), profile: atom('default') },
@@ -169,12 +170,17 @@ test('regression: source transitions keep BotRow hook order stable', () => {
   assert.doesNotMatch(botRowSource, /remoteSource && Boolean\(useValue/)
 })
 
-test('behavior: pointer entry prewarms only the hovered bot', () => {
+test('regression: layout-only pointer entry does not prewarm a bot until the pointer moves', () => {
   const { row, warmed } = renderBotRow('alpha')
 
   assert.deepEqual(warmed, [])
   assert.equal(typeof row.props.onPointerEnter, 'function')
   row.props.onPointerEnter()
+  assert.deepEqual(warmed, [])
+
+  assert.equal(typeof row.props.onPointerMove, 'function')
+  row.props.onPointerMove()
+  row.props.onPointerMove()
   assert.deepEqual(warmed, ['alpha'])
 })
 
@@ -212,6 +218,7 @@ test('behavior: a remote Connections row opens through its captured route withou
   })
 
   row.props.onPointerEnter()
+  row.props.onPointerMove()
   assert.deepEqual(warmed, [['work', 'research']])
 
   await row.props.onClick()
@@ -297,6 +304,7 @@ test('behavior: remote default never opens the same-name local chat', async () =
     ACTIVE_WINDOW_S: 90,
     A2A_PREFIX_RE: /^$/,
     useEffect: () => undefined,
+    useRef: initial => ({ current: initial }),
     useState: initial => [typeof initial === 'function' ? initial() : initial, () => undefined],
     host: {
       state: { gateway: atom('open'), profile: atom('default') },

--- a/apps/desktop/src/plugins/hermes-bots/tests/roster-preview.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/roster-preview.test.mjs
@@ -14,6 +14,7 @@ function runtime() {
     jsxs: jsx,
     useQuery: () => ({}),
     useValue: value => (value?.get ? value.get() : value),
+    useRef: initial => ({ current: initial }),
     useState: value => [value, () => undefined],
     document: { getElementById: () => null, createElement: () => ({}), head: { appendChild: () => undefined } },
     host: { state: { profile: { get: () => 'ops', listen: () => undefined } }, request: () => undefined }
@@ -122,6 +123,7 @@ function renderRuntime() {
     relativeTime: () => 'now',
     useQuery: () => ({}),
     useValue: value => (value?.get ? value.get() : value),
+    useRef: initial => ({ current: initial }),
     useState: value => [value, () => undefined],
     useEffect: () => undefined,
     document: { getElementById: () => null, createElement: () => ({}), head: { appendChild: () => undefined } }


### PR DESCRIPTION
Bot Mode warmed a profile on raw pointerenter. Live roster reordering beneath a stationary cursor generated pointerenter events without user movement, cascading through every profile backend and causing 90-second startup timeouts under load.

This gates each row warm on the first real pointer move per visit. Layout-only pointer entry is inert; intentional hover still prewarms one backend.

Verification:
- Red/green regression test for layout-only pointer entry
- Hermes Bots suite: 625/625 passing
- Desktop TypeScript typecheck passing
- Packaged Desktop build passing
- Live cold launch: 2m17s, zero backend timeout/restart/renderer errors; only primary + default backend started
- HTTP health and authenticated WebSocket gateway.ping passed on both backends