### PR TITLE
docs: honest Nous fork notice for hermes-agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+> [!NOTE]
+> jediswimmer fork of [NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agent). This clone is behind upstream. Not a Titans Rift product. Install, models, and gateway docs: follow upstream.
+
+`hermes-agent · fork of NousResearch/hermes-agent · jediswimmer`
+
 <p align="center">
   <img src="assets/banner.png" alt="Hermes Agent" width="100%">
 </p>


### PR DESCRIPTION
## Summary

Fork-class README pass for `jediswimmer/hermes-agent`. Honest upstream. No Titans Rift product claim. No banner seam.

Base: `main`. Draft only. House card t_42c6dd2c. No merge.
