### PR TITLE
fix(whatsapp): recover adopted bridge after refusal

### DIFF
--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -844,6 +844,15 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 pass
             self._bridge_log_fh = None
 
+    async def _report_bridge_failure(self, message: str) -> str:
+        """Surface a retryable bridge failure through the adapter lifecycle."""
+        if not self.has_fatal_error:
+            logger.error("[%s] %s", self.name, message)
+            self._set_fatal_error("whatsapp_bridge_exited", message, retryable=True)
+            self._close_bridge_log()
+            await self._notify_fatal_error()
+        return self.fatal_error_message or message
+
     async def _check_managed_bridge_exit(self) -> Optional[str]:
         """Return a fatal error message if the managed bridge child exited."""
         if self._bridge_process is None:
@@ -869,12 +878,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             return None
 
         message = f"WhatsApp bridge process exited unexpectedly (code {returncode})."
-        if not self.has_fatal_error:
-            logger.error("[%s] %s", self.name, message)
-            self._set_fatal_error("whatsapp_bridge_exited", message, retryable=True)
-            self._close_bridge_log()
-            await self._notify_fatal_error()
-        return self.fatal_error_message or message
+        return await self._report_bridge_failure(message)
 
     async def disconnect(self) -> None:
         """Stop the WhatsApp bridge and clean up any orphaned processes."""
@@ -1362,6 +1366,23 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 bridge_exit = await self._check_managed_bridge_exit()
                 if bridge_exit:
                     print(f"[{self.name}] {bridge_exit}")
+                    break
+                connector_error = getattr(e, "os_error", None)
+                adopted_bridge_refused = (
+                    self._bridge_process is None
+                    and not getattr(self, "_shutting_down", False)
+                    and (
+                        isinstance(e, ConnectionRefusedError)
+                        or (
+                            isinstance(e, aiohttp.ClientConnectorError)
+                            and isinstance(connector_error, ConnectionRefusedError)
+                        )
+                    )
+                )
+                if adopted_bridge_refused:
+                    message = "WhatsApp bridge became unreachable while polling."
+                    print(f"[{self.name}] {message}")
+                    await self._report_bridge_failure(message)
                     break
                 print(f"[{self.name}] Poll error: {e}")
                 await asyncio.sleep(5)

--- a/tests/gateway/test_whatsapp_connect.py
+++ b/tests/gateway/test_whatsapp_connect.py
@@ -251,6 +251,63 @@ class TestBridgeRuntimeFailure:
         assert adapter._bridge_log_fh is None
 
     @pytest.mark.asyncio
+    async def test_poll_marks_retryable_fatal_when_adopted_bridge_refuses_connection(self):
+        import aiohttp
+
+        adapter = _make_adapter()
+        fatal_handler = AsyncMock()
+        adapter.set_fatal_error_handler(fatal_handler)
+        adapter._running = True
+        adapter._bridge_process = None
+        adapter._http_session = MagicMock()
+        connection_key = MagicMock(host="127.0.0.1", port=19876, ssl=False)
+        connector_error = aiohttp.ClientConnectorError(
+            connection_key,
+            ConnectionRefusedError("bridge stopped listening"),
+        )
+        adapter._http_session.get = MagicMock(
+            side_effect=[
+                connector_error,
+                asyncio.CancelledError(),
+            ]
+        )
+
+        with patch(
+            "plugins.platforms.whatsapp.adapter.asyncio.sleep",
+            new_callable=AsyncMock,
+        ):
+            await adapter._poll_messages()
+
+        assert adapter.fatal_error_code == "whatsapp_bridge_exited"
+        assert adapter.fatal_error_retryable is True
+        assert "unreachable" in (adapter.fatal_error_message or "")
+        fatal_handler.assert_awaited_once_with(adapter)
+        assert adapter._http_session.get.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_poll_keeps_retrying_non_terminal_http_responses(self):
+        adapter = _make_adapter()
+        fatal_handler = AsyncMock()
+        adapter.set_fatal_error_handler(fatal_handler)
+        adapter._running = True
+        adapter._bridge_process = None
+        response = MagicMock(status=503)
+        adapter._http_session = MagicMock()
+        adapter._http_session.get = MagicMock(
+            side_effect=[_AsyncCM(response), asyncio.CancelledError()]
+        )
+
+        with patch(
+            "plugins.platforms.whatsapp.adapter.asyncio.sleep",
+            new_callable=AsyncMock,
+        ):
+            await adapter._poll_messages()
+
+        assert adapter.fatal_error_code is None
+        fatal_handler.assert_not_awaited()
+        assert adapter._http_session.get.call_count == 2
+
+    @pytest.mark.asyncio
     async def test_send_normalizes_bare_phone_numbers_to_jid(self):
         """A bare phone target (with or without +) becomes a full JID.
 


### PR DESCRIPTION
## What does this PR do?

When Hermes adopts an already-running WhatsApp bridge, the adapter has no managed child process. If that bridge later exits, connection refusals from the message poller were treated like transient HTTP errors forever, so the adapter stayed connected without inbound delivery or a reconnect attempt.

This change routes adopted-bridge connection refusals through the adapter's existing retryable fatal-error lifecycle. The gateway is notified, tears down the stale adapter, and queues the platform for reconnection. Managed bridge exits reuse the same reporting helper, while non-terminal HTTP responses such as 503 continue to retry without forcing a reconnect.

### Existing work reviewed

#87382 supervises a poll task after that task terminates. It does not cover this failure mode because the adopted-bridge connection refusal is caught inside `_poll_messages` and the task keeps running. The changes are complementary: this PR identifies the terminal in-loop liveness failure and reuses the existing reconnect path.

## Related Issue

Fixes #96758

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/whatsapp/adapter.py` — report managed exits and adopted-bridge connection refusals through one retryable fatal-error path.
- `tests/gateway/test_whatsapp_connect.py` — cover adopted bridge refusal and verify that HTTP 503 remains non-terminal.

## How to Test

```bash
scripts/run_tests.sh tests/gateway/test_whatsapp_connect.py tests/gateway/test_whatsapp_stale_bridge.py tests/gateway/test_whatsapp_bridge_pidfile.py -q
```

Result on macOS: 19 passed, 3 platform-specific skips.

Additional checks:

```bash
python3 -m ruff check plugins/platforms/whatsapp/adapter.py tests/gateway/test_whatsapp_connect.py
python3 -m py_compile plugins/platforms/whatsapp/adapter.py tests/gateway/test_whatsapp_connect.py
git diff --check origin/main...HEAD
```

All completed successfully.

## Checklist

### Code

- [x] I've read the contributing guide.
- [x] My commit follows Conventional Commits.
- [x] I searched open and closed PRs by issue number and failure mechanism.
- [x] The PR contains only changes related to this fix.
- [x] Regression tests cover the fix and its non-terminal control case.
- [x] Tested on macOS.

### Documentation & Housekeeping

- [x] Documentation changes are not required for this lifecycle fix.
- [x] No configuration keys were added or changed.
- [x] No architecture or contributor workflow changed.
- [x] Cross-platform impact was considered; the change uses existing Python and aiohttp lifecycle paths.
- [x] No tool schemas or descriptions changed.

## Screenshots / Logs

Not applicable.
