### PR TITLE
fix(codex): drop assistant images from Responses replay

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -165,6 +165,13 @@ def _chat_content_to_responses_parts(content: Any, *, role: str = "user") -> Lis
     ``output_text`` inside user messages, so callers MUST pass the correct
     role for the message being converted.
 
+    Image parts are likewise role-restricted: the API only accepts
+    ``input_image`` on user-role messages. An assistant message carrying
+    ``input_image`` is rejected with HTTP 400 on every history replay, which
+    permanently bricks the session (#96816), so image parts are dropped for
+    the assistant role here (the API cannot carry them in any form, so the
+    drop is lossless w.r.t. what would survive the wire).
+
     Returns an empty list when ``content`` is not a list or contains no
     recognized parts — callers fall back to the string path.
     """
@@ -186,6 +193,10 @@ def _chat_content_to_responses_parts(content: Any, *, role: str = "user") -> Lis
                 converted.append({"type": text_type, "text": text})
             continue
         if ptype in {"image_url", "input_image"}:
+            if role == "assistant":
+                # Responses API rejects input_image on assistant messages
+                # (HTTP 400 on every replay) — drop, see docstring (#96816).
+                continue
             image_ref = part.get("image_url")
             detail = part.get("detail")
             if isinstance(image_ref, dict):

--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -194,8 +194,13 @@ def _chat_content_to_responses_parts(content: Any, *, role: str = "user") -> Lis
             continue
         if ptype in {"image_url", "input_image"}:
             if role == "assistant":
-                # Responses API rejects input_image on assistant messages
-                # (HTTP 400 on every replay) — drop, see docstring (#96816).
+                # Responses output messages cannot carry input_image. Keep a
+                # text marker so image-only assistant turns still survive in
+                # replay and later references retain their conversational slot.
+                converted.append({
+                    "type": "output_text",
+                    "text": "[Assistant image omitted during replay]",
+                })
                 continue
             image_ref = part.get("image_url")
             detail = part.get("detail")
@@ -1167,6 +1172,14 @@ def _preflight_codex_input_items(
                             text = str(text or "")
                         validated.append({"type": text_type, "text": sanitize_text(text)})
                     elif ptype in {"input_image", "image_url"}:
+                        if role == "assistant":
+                            # Enforce the same output-message invariant for
+                            # raw request overrides as for normal history.
+                            validated.append({
+                                "type": "output_text",
+                                "text": "[Assistant image omitted during replay]",
+                            })
+                            continue
                         image_ref = part.get("image_url", "")
                         detail = part.get("detail")
                         if isinstance(image_ref, dict):

--- a/tests/agent/test_codex_responses_adapter.py
+++ b/tests/agent/test_codex_responses_adapter.py
@@ -30,6 +30,8 @@ def test_chat_content_drops_images_from_assistant_role():
 
     assert _chat_content_to_responses_parts(content, role="assistant") == [
         {"type": "output_text", "text": "generated image"},
+        {"type": "output_text", "text": "[Assistant image omitted during replay]"},
+        {"type": "output_text", "text": "[Assistant image omitted during replay]"},
     ]
 
 
@@ -43,6 +45,24 @@ def test_chat_content_keeps_images_on_user_role():
         "type": "input_image",
         "image_url": "https://example.invalid/p.png",
         "detail": "high",
+    }]
+
+
+def test_preflight_rewrites_raw_assistant_images_to_text_markers():
+    raw = [{
+        "role": "assistant",
+        "content": [{
+            "type": "input_image",
+            "image_url": "https://example.invalid/p.png",
+        }],
+    }]
+
+    assert _preflight_codex_input_items(raw) == [{
+        "role": "assistant",
+        "content": [{
+            "type": "output_text",
+            "text": "[Assistant image omitted during replay]",
+        }],
     }]
 
 

--- a/tests/agent/test_codex_responses_adapter.py
+++ b/tests/agent/test_codex_responses_adapter.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 import pytest
 
 from agent.codex_responses_adapter import (
+    _chat_content_to_responses_parts,
     _chat_messages_to_responses_input,
     _sanitize_replayed_fn_name,
     _format_responses_error,
@@ -18,6 +19,31 @@ _HARMONY_SOURCE_SNIPPET = (
     "Need to generate one image according to the description."
     "<|end|><|start|>assistant<|channel|>final<|message|>"
 )
+
+
+def test_chat_content_drops_images_from_assistant_role():
+    content = [
+        {"type": "text", "text": "generated image"},
+        {"type": "image_url", "image_url": {"url": "https://example.invalid/p.png"}},
+        {"type": "input_image", "image_url": "data:image/png;base64,AAAA"},
+    ]
+
+    assert _chat_content_to_responses_parts(content, role="assistant") == [
+        {"type": "output_text", "text": "generated image"},
+    ]
+
+
+def test_chat_content_keeps_images_on_user_role():
+    content = [{
+        "type": "image_url",
+        "image_url": {"url": "https://example.invalid/p.png", "detail": "high"},
+    }]
+
+    assert _chat_content_to_responses_parts(content, role="user") == [{
+        "type": "input_image",
+        "image_url": "https://example.invalid/p.png",
+        "detail": "high",
+    }]
 
 
 def _harmony_token(name: str) -> str:


### PR DESCRIPTION
## Summary

OpenAI Responses rejects `input_image` parts on assistant-role messages. Hermes replayed assistant images as `input_image`, so affected history produced HTTP 400 on every subsequent turn.

This rewrites assistant image parts to an `output_text` replay marker, preserving the assistant turn without sending the rejected shape. User-role and multimodal tool-result images remain unchanged. The final preflight applies the same rewrite to raw request overrides.

Fixes #96816

## Tests

- `python -m pytest tests/agent/test_codex_responses_adapter.py -q`
  - branch tip: `26 passed in 4.26s`
  - baseline `origin/main` on the same file: `23 passed in 4.35s`
- Adversarial blast-radius rerun: `python -m pytest tests/agent/test_codex_responses_adapter.py tests/agent/transports/test_codex_transport.py tests/run_agent/test_codex_multimodal_tool_result.py -q` → `132 passed in 6.57s`

## Scope

- `agent/codex_responses_adapter.py`: rewrite assistant `image_url`/`input_image` to a text marker during history conversion and final preflight.
- `tests/agent/test_codex_responses_adapter.py`: regression coverage for assistant markers, raw override preflight, and retaining user images.

## Draft status

Left draft pending maintainer guidance on provider scope: the observed 400 is OpenAI Codex-specific, while this shared Responses adapter also serves compatible xAI/GitHub routes. The generated OpenAI schema is permissive enough that a provider-specific gate may be preferable.
