### PR TITLE
fix(desktop): route messaging session model switches to gateway

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
@@ -83,6 +83,7 @@ function Harness({
 
 describe('useModelControls', () => {
   beforeEach(() => {
+    notifyError.mockClear()
     $activeGatewayProfile.set('default')
     $activeSessionId.set(null)
     setCurrentModel('')
@@ -317,6 +318,46 @@ describe('useModelControls', () => {
       key: 'model',
       value: 'gpt-5.6-sol --provider openai-codex --session'
     })
+  })
+
+  it('rolls back a Telegram-origin pick when its gateway owner is offline', async () => {
+    $activeSessionId.set('telegram-runtime')
+    setSelectedStoredSessionId('telegram-stored')
+    setCurrentModel('z-ai/glm-5.2')
+    setCurrentProvider('nous')
+    setCurrentModelSource('default')
+    setMessagingSessions([
+      {
+        ended_at: null,
+        id: 'telegram-stored',
+        input_tokens: 0,
+        is_active: true,
+        last_active: 1,
+        message_count: 1,
+        model: 'z-ai/glm-5.2',
+        output_tokens: 0,
+        preview: 'hello',
+        source: 'telegram',
+        started_at: 1,
+        title: 'Telegram chat',
+        tool_call_count: 0
+      }
+    ])
+
+    const requestGateway = vi.fn(async () => {
+      throw new Error("The telegram gateway is unavailable, so this conversation's model was not changed.")
+    })
+
+    let controls!: Controls
+
+    render(<Harness onReady={value => (controls = value)} requestGateway={requestGateway} />)
+
+    await expect(controls.selectModel({ model: 'gpt-5.6-sol', provider: 'openai-codex' })).resolves.toBe(false)
+
+    expect($currentModel.get()).toBe('z-ai/glm-5.2')
+    expect($currentProvider.get()).toBe('nous')
+    expect(getCurrentModelSource()).toBe('default')
+    expect(notifyError).toHaveBeenCalledWith(expect.any(Error), 'Model switch failed')
   })
 
   it('keeps a completed messaging handoff scoped to that conversation in the primary pane', async () => {

--- a/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
@@ -12,7 +12,10 @@ import {
   getCurrentModelSource,
   setCurrentModel,
   setCurrentModelSource,
-  setCurrentProvider
+  setCurrentProvider,
+  setMessagingSessions,
+  setSelectedStoredSessionId,
+  setSessions
 } from '@/store/session'
 import type * as SessionStates from '@/store/session-states'
 
@@ -85,6 +88,9 @@ describe('useModelControls', () => {
     setCurrentModel('')
     setCurrentModelSource('')
     setCurrentProvider('')
+    setMessagingSessions([])
+    setSelectedStoredSessionId(null)
+    setSessions([])
   })
 
   afterEach(() => {
@@ -95,6 +101,9 @@ describe('useModelControls', () => {
     setCurrentModel('')
     setCurrentModelSource('')
     setCurrentProvider('')
+    setMessagingSessions([])
+    setSelectedStoredSessionId(null)
+    setSessions([])
   })
 
   it('applies the global model when there is no active runtime session', async () => {
@@ -274,6 +283,76 @@ describe('useModelControls', () => {
       value: 'claude-sonnet-4.6 --provider anthropic --global'
     })
     expect(requestGateway).not.toHaveBeenCalledWith('slash.exec', expect.anything())
+  })
+
+  it('keeps a Telegram-origin primary-pane model change scoped to that conversation', async () => {
+    $activeSessionId.set('telegram-runtime')
+    setSelectedStoredSessionId('telegram-stored')
+    setMessagingSessions([
+      {
+        ended_at: null,
+        id: 'telegram-stored',
+        input_tokens: 0,
+        is_active: true,
+        last_active: 1,
+        message_count: 1,
+        model: 'z-ai/glm-5.2',
+        output_tokens: 0,
+        preview: 'hello',
+        source: 'telegram',
+        started_at: 1,
+        title: 'Telegram chat',
+        tool_call_count: 0
+      }
+    ])
+    const requestGateway = vi.fn(async () => ({ key: 'model', value: 'gpt-5.6-sol' }) as never)
+    let controls!: Controls
+
+    render(<Harness onReady={value => (controls = value)} requestGateway={requestGateway} />)
+
+    await expect(controls.selectModel({ model: 'gpt-5.6-sol', provider: 'openai-codex' })).resolves.toBe(true)
+
+    expect(requestGateway).toHaveBeenCalledWith('config.set', {
+      session_id: 'telegram-runtime',
+      key: 'model',
+      value: 'gpt-5.6-sol --provider openai-codex --session'
+    })
+  })
+
+  it('keeps a completed messaging handoff scoped to that conversation in the primary pane', async () => {
+    $activeSessionId.set('handoff-runtime')
+    setSelectedStoredSessionId('handoff-stored')
+    setSessions([
+      {
+        ended_at: null,
+        handoff_platform: 'telegram',
+        handoff_state: 'completed',
+        id: 'handoff-stored',
+        input_tokens: 0,
+        is_active: true,
+        last_active: 1,
+        message_count: 1,
+        model: 'z-ai/glm-5.2',
+        output_tokens: 0,
+        preview: 'hello',
+        source: 'desktop',
+        started_at: 1,
+        title: 'Handed off Telegram chat',
+        tool_call_count: 0
+      }
+    ])
+    const requestGateway = vi.fn(async () => ({ key: 'model', value: 'gpt-5.6-sol' }) as never)
+    let controls!: Controls
+
+    render(<Harness onReady={value => (controls = value)} requestGateway={requestGateway} />)
+
+    await controls.selectModel({ model: 'gpt-5.6-sol', provider: 'openai-codex' })
+
+    expect(requestGateway).toHaveBeenCalledWith('config.set', {
+      session_id: 'handoff-runtime',
+      key: 'model',
+      value: 'gpt-5.6-sol --provider openai-codex --session'
+    })
   })
 
   it('keeps a mid-turn pick painted and skips the refetch that would repaint the old model', async () => {

--- a/apps/desktop/src/app/session/hooks/use-model-controls.ts
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.ts
@@ -7,20 +7,23 @@ import { useI18n } from '@/i18n'
 import { isBusySessionModelSwitch } from '@/lib/gateway-rpc'
 import { surfaceModelSwitchConfirm } from '@/lib/guarded-model-switch'
 import { manualPickRemoved, modelOptionsQueryKey } from '@/lib/model-options'
+import { handoffOriginSource, isMessagingSource } from '@/lib/session-source'
 import { notifyError } from '@/store/notifications'
 import { $activeGatewayProfile } from '@/store/profile'
 import {
   $activeSessionId,
   $currentModel,
   $currentProvider,
+  $selectedStoredSessionId,
   getComposerSelectionGeneration,
   getCurrentModelSource,
   markComposerSelectionManual,
+  ownerLookupSessionRows,
   setCurrentModel,
   setCurrentModelSource,
   setCurrentProvider
 } from '@/store/session'
-import { $sessionStates, sessionTileDelegate } from '@/store/session-states'
+import { $sessionStates, sessionTileDelegate, storedSessionIdForRuntimeId } from '@/store/session-states'
 import type { ModelOptionsResponse } from '@/types/hermes'
 
 interface ModelControlsOptions {
@@ -32,6 +35,31 @@ interface ModelSwitchResponse {
   confirm_message?: string
   confirm_required?: boolean
   deferred?: boolean
+}
+
+/**
+ * Model scope follows the conversation's durable origin, not the pane that is
+ * currently rendering it. A Telegram/Discord/etc. conversation opened in the
+ * primary pane is still an external messaging session: changing its model must
+ * not rewrite the profile default used by unrelated local chats.
+ */
+export function liveSessionHasMessagingOrigin(liveSessionId: string, touchesPrimary: boolean): boolean {
+  const storedId =
+    storedSessionIdForRuntimeId(liveSessionId) ?? (touchesPrimary ? $selectedStoredSessionId.get() : null)
+
+  if (!storedId) {
+    return false
+  }
+
+  const row = ownerLookupSessionRows().find(candidate => {
+    const lineageRoot = candidate._lineage_root_id?.trim()
+
+    return candidate.id === storedId || lineageRoot === storedId
+  })
+
+  return Boolean(
+    row && (isMessagingSource(row.source) || Boolean(handoffOriginSource(row.handoff_state, row.handoff_platform)))
+  )
 }
 
 export function useModelControls({ queryClient, requestGateway }: ModelControlsOptions) {
@@ -247,21 +275,21 @@ export function useModelControls({ queryClient, requestGateway }: ModelControlsO
         return true
       }
 
-      // The PRIMARY profile's main agent is the profile's default — its
-      // model/provider choice IS the default, so persist it to config.yaml
-      // (model.default + model.provider) via --global. This is what makes
-      // the selection "stick": a set model.provider outranks a leftover
-      // OPENAI_API_KEY env var in resolve_provider(), so the main agent
-      // keeps the chosen (e.g. subscription) provider across restarts
-      // instead of silently falling back to an env key.
+      // The PRIMARY *local* profile session owns the profile default, so its
+      // pick persists to config.yaml. Pane placement is not authority though:
+      // a Telegram/Discord/etc. conversation remains session-scoped even when
+      // it is opened in the primary pane.
       //
       // Two things stay --session, deliberately:
       //  - a SECONDARY chat tile: picking a model there must not rewrite the
       //    profile default (the cross-session-contamination guard).
+      //  - an EXTERNAL messaging conversation in any pane: its durable routing
+      //    peer owns the choice, not the profile default.
       //  - MoA (mixture-of-agents) presets: a transient orchestration choice
       //    that must never become the persisted global gateway default.
       const isSessionOnlyPreset = (selection.provider || '').toLowerCase() === 'moa'
-      const persistsAsDefault = touchesPrimary && !isSessionOnlyPreset
+      const messagingOrigin = liveSessionHasMessagingOrigin(liveSessionId, touchesPrimary)
+      const persistsAsDefault = touchesPrimary && !messagingOrigin && !isSessionOnlyPreset
       const scope = persistsAsDefault ? '--global' : '--session'
 
       const requestSwitch = (confirmExpensiveModel = false) =>

--- a/apps/desktop/src/app/shell/model-catalog-menu.test.tsx
+++ b/apps/desktop/src/app/shell/model-catalog-menu.test.tsx
@@ -105,4 +105,18 @@ describe('the catalog owns model curation', () => {
 
     expect($modelVisibilityOpen.get()).toBe(true)
   })
+
+  it('shows a retry control when the model owner cannot load', async () => {
+    getGlobalModelOptions.mockRejectedValueOnce(new Error('Model owner unavailable')).mockResolvedValueOnce({
+      providers: [{ models: ['gemini-3.1-pro'], name: 'Google', slug: 'google' }]
+    })
+
+    renderMenu()
+
+    await screen.findByText('Model owner unavailable')
+    fireEvent.click(screen.getByText('Retry'))
+
+    await screen.findByText(/Gemini 3\.1 Pro/i)
+    expect(getGlobalModelOptions).toHaveBeenCalledTimes(2)
+  })
 })

--- a/apps/desktop/src/app/shell/model-catalog-menu.tsx
+++ b/apps/desktop/src/app/shell/model-catalog-menu.tsx
@@ -145,10 +145,11 @@ export function ModelCatalogMenu({
     // Gateway-first even with no session: a connected (possibly remote)
     // gateway owns the model catalog, including virtual providers the local
     // REST fallback can't know about (#53817).
-    queryFn: (): Promise<ModelOptionsResponse> => requestModelOptions({ gateway, profile, request, sessionId })
+    queryFn: (): Promise<ModelOptionsResponse> => requestModelOptions({ gateway, profile, request, sessionId }),
+    retry: false
   })
 
-  const loading = modelOptions.isPending && !modelOptions.data
+  const loading = modelOptions.isFetching && !modelOptions.data
 
   const error = modelOptions.error
     ? modelOptions.error instanceof Error
@@ -360,9 +361,20 @@ export function ModelCatalogMenu({
           ))}
         </DropdownMenuGroup>
       ) : error ? (
-        <DropdownMenuItem className={dropdownMenuRow} disabled>
-          {error}
-        </DropdownMenuItem>
+        <DropdownMenuGroup className="py-1">
+          <DropdownMenuItem className={dropdownMenuRow} disabled>
+            {error}
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            className={dropdownMenuRow}
+            onSelect={event => {
+              event.preventDefault()
+              void modelOptions.refetch()
+            }}
+          >
+            {t.common.retry}
+          </DropdownMenuItem>
+        </DropdownMenuGroup>
       ) : groups.length === 0 && moaPresets.length === 0 ? (
         <DropdownMenuItem className={dropdownMenuRow} disabled>
           {copy.noModels}

--- a/apps/desktop/src/app/shell/model-menu-panel.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.tsx
@@ -74,7 +74,8 @@ export function ModelMenuPanel({ gateway, onSelectModel, profile = 'default', re
   const modelOptions = useQuery({
     queryKey: modelOptionsQueryKey(profile, activeSessionId),
     queryFn: (): Promise<ModelOptionsResponse> =>
-      requestModelOptions({ gateway, profile, request: requestGateway, sessionId: activeSessionId })
+      requestModelOptions({ gateway, profile, request: requestGateway, sessionId: activeSessionId }),
+    retry: false
   })
 
   const { model: optionsModel, provider: optionsProvider } = currentPickerSelection(

--- a/apps/desktop/src/components/model-picker.tsx
+++ b/apps/desktop/src/components/model-picker.tsx
@@ -60,7 +60,11 @@ export function ModelPickerDialog({
   const modelOptions = useQuery({
     queryKey: modelOptionsQueryKey(profile, sessionId),
     queryFn: () => requestModelOptions({ gateway: gw, sessionId }),
-    enabled: open
+    enabled: open,
+    // The request itself is bounded. Leave retries under the user's control so
+    // an unreachable session owner does not turn one timeout into a long,
+    // unexplained spinner.
+    retry: false
   })
 
   const providers = modelOptions.data?.providers ?? []
@@ -70,7 +74,7 @@ export function ModelPickerDialog({
     modelOptions.data
   )
 
-  const loading = modelOptions.isPending && !modelOptions.data
+  const loading = modelOptions.isFetching && !modelOptions.data
 
   const error = modelOptions.error
     ? modelOptions.error instanceof Error
@@ -115,6 +119,7 @@ export function ModelPickerDialog({
               currentProvider={optionsProvider || currentProvider}
               error={error}
               loading={loading}
+              onRetry={() => void modelOptions.refetch()}
               onSelectModel={selectModel}
               providers={providers}
               search={search}
@@ -142,6 +147,7 @@ function ModelResults({
   currentModel,
   currentProvider,
   onSelectModel,
+  onRetry,
   search
 }: {
   loading: boolean
@@ -150,6 +156,7 @@ function ModelResults({
   currentModel: string
   currentProvider: string
   onSelectModel: (provider: ModelOptionProvider, model: string) => void
+  onRetry: () => void
   search: string
 }) {
   const { t } = useI18n()
@@ -161,10 +168,13 @@ function ModelResults({
 
   if (error) {
     return (
-      <div className="px-3 py-3">
+      <div className="space-y-2 px-3 py-3">
         <InlineNotice kind="error" title={copy.loadFailed}>
           {error}
         </InlineNotice>
+        <Button className="w-full" onClick={onRetry} size="sm" variant="outline">
+          {t.common.retry}
+        </Button>
       </div>
     )
   }

--- a/apps/desktop/src/lib/model-options.test.ts
+++ b/apps/desktop/src/lib/model-options.test.ts
@@ -5,6 +5,7 @@ import { getGlobalModelOptions } from '@/hermes'
 import {
   firstSelectableCatalogModel,
   manualPickRemoved,
+  MODEL_OPTIONS_REQUEST_TIMEOUT_MS,
   modelOptionsQueryKey,
   reconcileSelectionAfterCatalogRefresh,
   requestModelOptions,
@@ -35,7 +36,11 @@ describe('requestModelOptions', () => {
 
     await expect(requestModelOptions({ gateway: gateway as never, sessionId: null })).resolves.toBe(gatewayPayload)
 
-    expect(gateway.request).toHaveBeenCalledWith('model.options', { explicit_only: true })
+    expect(gateway.request).toHaveBeenCalledWith(
+      'model.options',
+      { explicit_only: true },
+      MODEL_OPTIONS_REQUEST_TIMEOUT_MS
+    )
     expect(getGlobalModelOptions).not.toHaveBeenCalled()
   })
 
@@ -111,11 +116,15 @@ describe('requestModelOptions', () => {
 
     await requestModelOptions({ gateway: gateway as never, refresh: true, sessionId: 'session-1' })
 
-    expect(gateway.request).toHaveBeenCalledWith('model.options', {
-      explicit_only: true,
-      refresh: true,
-      session_id: 'session-1'
-    })
+    expect(gateway.request).toHaveBeenCalledWith(
+      'model.options',
+      {
+        explicit_only: true,
+        refresh: true,
+        session_id: 'session-1'
+      },
+      MODEL_OPTIONS_REQUEST_TIMEOUT_MS
+    )
     expect(getGlobalModelOptions).toHaveBeenCalledWith({ explicitOnly: true, refresh: true })
   })
 
@@ -151,7 +160,11 @@ describe('requestModelOptions', () => {
       routedPayload
     )
 
-    expect(request).toHaveBeenCalledWith('model.options', { explicit_only: true, session_id: 'tile-1' })
+    expect(request).toHaveBeenCalledWith(
+      'model.options',
+      { explicit_only: true, session_id: 'tile-1' },
+      MODEL_OPTIONS_REQUEST_TIMEOUT_MS
+    )
     expect(gateway.request).not.toHaveBeenCalled()
   })
 

--- a/apps/desktop/src/lib/model-options.ts
+++ b/apps/desktop/src/lib/model-options.ts
@@ -101,13 +101,25 @@ interface ModelOptionsRequest {
   /** Owner-routed RPC. When set, catalog reads hit this dispatcher instead of
    *  `gateway.request` — a tile's model menu must not query the ambient
    *  chrome socket (#93892). */
-  request?: <T>(method: string, params?: Record<string, unknown>) => Promise<T>
+  request?: <T>(
+    method: string,
+    params?: Record<string, unknown>,
+    timeoutMs?: number,
+    signal?: AbortSignal
+  ) => Promise<T>
   /** Profile for the REST recovery path. Must match the catalog owner so a
    *  secondary tile does not fall back to the launch profile's models. */
   profile?: null | string
   refresh?: boolean
   sessionId?: null | string
 }
+
+/**
+ * A model menu is an interactive control, not an open-ended background load.
+ * Bound the owner-routed RPC so a stale/disconnected messaging-session owner
+ * becomes a recoverable error instead of an infinite loading spinner.
+ */
+export const MODEL_OPTIONS_REQUEST_TIMEOUT_MS = 15_000
 
 export function modelOptionsQueryKey(profile: null | string | undefined, sessionId?: null | string) {
   const profileKey = (profile ?? '').trim() || 'default'
@@ -159,7 +171,7 @@ export async function requestModelOptions({
     let gatewayOptions: ModelOptionsResponse | undefined
 
     try {
-      gatewayOptions = await dispatch<ModelOptionsResponse>('model.options', params)
+      gatewayOptions = await dispatch<ModelOptionsResponse>('model.options', params, MODEL_OPTIONS_REQUEST_TIMEOUT_MS)
     } catch (error) {
       gatewayError = error
     }

--- a/gateway/control_socket.py
+++ b/gateway/control_socket.py
@@ -10,13 +10,16 @@ gateway process creates at startup and removes on clean shutdown, answering
 versioned JSON verbs. A connectable socket with a well-formed ``identify``
 answer IS liveness — no PID-reuse heuristics.
 
-v1 verbs (observation only — no behavior change for the gateway):
+v2 verbs:
 
 - ``identify`` → pid, profile label, hermes_home, code_sha/code_version
   (the #91283 stamps, now queryable live), supervisor kind, served profiles,
   start_time, protocol version.
 - ``status``   → the live runtime-status payload (what ``gateway_state.json``
   holds today, but answered by the process itself, race-free).
+- ``pause-for-update`` → drain and stop this exact gateway for an update.
+- ``set-session-model`` → replace one gateway-owned conversation's model
+  override and evict only that conversation's cached agent.
 
 Transport:
 
@@ -31,7 +34,11 @@ Transport:
 Never a TCP port. Filesystem/pipe ACLs are the auth boundary — the same
 trust model as ``gateway_state.json`` today.
 
-v1 wire contract: ONE request per connection — a single JSON line in, a
+This is an internal Hermes coordination protocol, not a public extension API.
+Protocol v2 adds object-valued ``params`` for mutating verbs; the original
+zero-argument observer verbs remain accepted for mixed-version local fleets.
+
+v2 wire contract: ONE request per connection — a single JSON line in, a
 single JSON line out, then the server closes. Clients must not rely on
 keep-alive or pipelining. Verb handlers may touch disk (they run in an
 executor server-side) but must stay fast; the client budget is small.
@@ -48,6 +55,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import hashlib
+import inspect
 import json
 import logging
 import os
@@ -60,7 +68,7 @@ from typing import Any, Callable, Optional
 
 logger = logging.getLogger(__name__)
 
-CONTROL_PROTOCOL_VERSION = 1
+CONTROL_PROTOCOL_VERSION = 2
 
 _SOCKET_FILENAME = "gateway.sock"
 _POINTER_FILENAME = "gateway.sock.path"
@@ -76,11 +84,17 @@ _MAX_REQUEST_BYTES = 64 * 1024
 _MAX_RESPONSE_BYTES = 512 * 1024
 
 _DEFAULT_CLIENT_TIMEOUT = 2.0
+_SESSION_MODEL_CLIENT_TIMEOUT = 5.0
+
+
+class GatewayControlTimeoutError(TimeoutError):
+    """A control request whose final mutation outcome cannot be confirmed."""
 
 
 # ---------------------------------------------------------------------------
 # Path resolution (shared by server and client)
 # ---------------------------------------------------------------------------
+
 
 def _home_hash(home: Path) -> str:
     canonical = os.path.normcase(str(Path(home).expanduser().resolve(strict=False)))
@@ -153,6 +167,7 @@ def resolve_client_socket_path(home: Path) -> Optional[Path]:
 # Default payload builders (import-light; overridable at wiring time)
 # ---------------------------------------------------------------------------
 
+
 def _detect_supervisor() -> str:
     """Best-effort supervisor kind for THIS process, from its own environment.
 
@@ -223,8 +238,9 @@ def build_status_payload() -> dict[str, Any]:
 # Server
 # ---------------------------------------------------------------------------
 
+
 class GatewayControlServer:
-    """Gateway-owned control socket server (identify/status, v1).
+    """Gateway-owned control socket server (versioned observation + mutation).
 
     Lifecycle is owned by the gateway process: ``start()`` after the PID-file
     claim (the point where this process becomes the authoritative gateway for
@@ -237,7 +253,7 @@ class GatewayControlServer:
         self,
         home: Optional[Path] = None,
         *,
-        verb_handlers: Optional[dict[str, Callable[[], dict[str, Any]]]] = None,
+        verb_handlers: Optional[dict[str, Callable[..., dict[str, Any]]]] = None,
     ) -> None:
         if home is None:
             from gateway.status import _get_process_hermes_home
@@ -248,12 +264,33 @@ class GatewayControlServer:
         self._pipe_server: Any = None  # Windows proactor pipe server
         self._bind_path: Optional[Path] = None
         self._pointer_file: Optional[Path] = None
-        self._handlers: dict[str, Callable[[], dict[str, Any]]] = {
-            "identify": build_identify_payload,
-            "status": build_status_payload,
+        self._handlers: dict[str, Callable[[dict[str, Any]], dict[str, Any]]] = {
+            "identify": lambda _params: build_identify_payload(),
+            "status": lambda _params: build_status_payload(),
         }
         if verb_handlers:
-            self._handlers.update(verb_handlers)
+            for verb, handler in verb_handlers.items():
+                self._handlers[verb] = self._normalize_handler(handler)
+
+    @staticmethod
+    def _normalize_handler(
+        handler: Callable[..., dict[str, Any]],
+    ) -> Callable[[dict[str, Any]], dict[str, Any]]:
+        """Accept old zero-argument observers and new parameterized handlers.
+
+        Normalizing once at registration keeps failures raised *inside* a
+        handler distinguishable from an arity mismatch; the request path never
+        retries a mutating handler after catching a broad ``TypeError``.
+        """
+        try:
+            accepts_params = bool(inspect.signature(handler).parameters)
+        except (TypeError, ValueError):
+            accepts_params = False
+
+        if accepts_params:
+            return handler
+
+        return lambda _params: handler()
 
     # -- lifecycle ---------------------------------------------------------
 
@@ -264,7 +301,9 @@ class GatewayControlServer:
                 return await self._start_windows()
             return await self._start_posix()
         except Exception as exc:
-            logger.warning("Gateway control socket failed to start (non-fatal): %s", exc)
+            logger.warning(
+                "Gateway control socket failed to start (non-fatal): %s", exc
+            )
             return False
 
     async def _start_posix(self) -> bool:
@@ -352,6 +391,10 @@ class GatewayControlServer:
                 raise ValueError("request must be a JSON object")
             request_id = request.get("id")
             verb = request.get("verb")
+            raw_params = request.get("params", {})
+            params = {} if raw_params is None else raw_params
+            if not isinstance(params, dict):
+                raise ValueError("params must be a JSON object")
             handler = self._handlers.get(verb) if isinstance(verb, str) else None
             if handler is None:
                 response: dict[str, Any] = {
@@ -364,7 +407,7 @@ class GatewayControlServer:
                 response = {
                     "ok": True,
                     "protocol": CONTROL_PROTOCOL_VERSION,
-                    "result": handler(),
+                    "result": handler(params),
                 }
         except Exception as exc:
             response = {
@@ -437,29 +480,42 @@ class _PipeControlProtocol(asyncio.Protocol):
 # Client (synchronous — used by CLI/updater consumers)
 # ---------------------------------------------------------------------------
 
+
 def query_gateway_control(
     home: Path,
     verb: str,
     *,
+    params: Optional[dict[str, Any]] = None,
     timeout: float = _DEFAULT_CLIENT_TIMEOUT,
+    propagate_timeout: bool = False,
 ) -> Optional[dict[str, Any]]:
     """Ask the gateway serving ``home`` a control verb; None when unanswered.
 
-    Returns the verb's ``result`` payload on success. Any failure — no
-    socket, stale socket nobody accepts on, timeout, malformed answer,
-    ``ok: false`` — returns None so callers fall back to the scan layer.
-    Never raises.
+    Returns the verb's ``result`` payload on success. Observer callers keep
+    the historical never-raises behavior: no socket, a stale socket, timeout,
+    malformed response, and ``ok: false`` all collapse to None so they can
+    fall back to the scan layer. Mutating callers may set
+    ``propagate_timeout`` so a response timeout is not misreported as an
+    unavailable socket: the gateway may have accepted the mutation and the
+    caller must treat its outcome as unknown.
     """
-    request = (
-        json.dumps({"verb": verb, "id": 1, "protocol": CONTROL_PROTOCOL_VERSION})
-        .encode("utf-8")
-        + b"\n"
-    )
+    request_payload: dict[str, Any] = {
+        "verb": verb,
+        "id": 1,
+        "protocol": CONTROL_PROTOCOL_VERSION,
+    }
+    if params:
+        request_payload["params"] = params
+    request = json.dumps(request_payload).encode("utf-8") + b"\n"
     try:
         if _IS_WINDOWS:
             raw = _query_windows_pipe(Path(home), request, timeout)
         else:
             raw = _query_unix_socket(Path(home), request, timeout)
+    except GatewayControlTimeoutError:
+        if propagate_timeout:
+            raise
+        return None
     except Exception:
         return None
     if not raw:
@@ -482,6 +538,10 @@ def _query_unix_socket(home: Path, request: bytes, timeout: float) -> Optional[b
         sock.settimeout(timeout)
         try:
             sock.connect(str(path))
+        except socket.timeout as exc:
+            raise GatewayControlTimeoutError(
+                "gateway control request timed out while connecting"
+            ) from exc
         except (ConnectionRefusedError, FileNotFoundError, OSError):
             return None
         sock.sendall(request)
@@ -490,8 +550,10 @@ def _query_unix_socket(home: Path, request: bytes, timeout: float) -> Optional[b
         while time.monotonic() < deadline:
             try:
                 chunk = sock.recv(65536)
-            except socket.timeout:
-                return None
+            except socket.timeout as exc:
+                raise GatewayControlTimeoutError(
+                    "gateway control request timed out awaiting a response"
+                ) from exc
             if not chunk:
                 break
             chunks.append(chunk)
@@ -540,7 +602,9 @@ def _query_windows_pipe(
             handle.close()
 
 
-def identify_gateway(home: Path, *, timeout: float = _DEFAULT_CLIENT_TIMEOUT) -> Optional[dict[str, Any]]:
+def identify_gateway(
+    home: Path, *, timeout: float = _DEFAULT_CLIENT_TIMEOUT
+) -> Optional[dict[str, Any]]:
     """Convenience wrapper: ``identify`` the gateway serving ``home``."""
     return query_gateway_control(home, "identify", timeout=timeout)
 
@@ -558,3 +622,33 @@ def pause_gateway_for_update(
     exactly as before this verb existed.
     """
     return query_gateway_control(home, "pause-for-update", timeout=timeout)
+
+
+def set_gateway_session_model_override(
+    home: Path,
+    *,
+    session_key: str,
+    model: str,
+    provider: str = "",
+    base_url: str = "",
+    timeout: float = _SESSION_MODEL_CLIENT_TIMEOUT,
+) -> Optional[dict[str, Any]]:
+    """Set one live gateway conversation's model through its owned socket.
+
+    This is the local bridge used when Desktop opens a Telegram/Discord/etc.
+    session and changes its model. The filesystem-owned socket is the authority
+    boundary; callers never edit ``sessions.json`` or another process's SQLite
+    state behind its back.
+    """
+    return query_gateway_control(
+        home,
+        "set-session-model",
+        params={
+            "session_key": session_key,
+            "model": model,
+            "provider": provider,
+            "base_url": base_url,
+        },
+        timeout=timeout,
+        propagate_timeout=True,
+    )

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6952,6 +6952,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         state = self._peek_session_state(session_key)
         return state is not None and state.turn.agent is not None
 
+    def _defer_or_evict_session_model_cache(self, session_key: str) -> bool:
+        """Evict an idle session now, or defer until its active turn ends.
+
+        A running agent has captured its model client for the current turn.
+        Removing it from the cache mid-turn would let cleanup race the worker,
+        so a control-socket model switch records one conversation-scoped bit
+        that the authoritative turn-release funnel consumes.
+
+        Returns True when eviction was deferred.
+        """
+        state = self._session_state(session_key)
+        if self._is_session_running(session_key):
+            state.conversation.model_cache_evict_pending = True
+            return True
+        state.conversation.model_cache_evict_pending = False
+        self._evict_cached_agent(session_key)
+        return False
+
     def _running_agent_items(self) -> List[tuple]:
         """(session_key, agent) pairs for sessions with a running turn
         (including pending sentinels), matching the old ``_running_agents``
@@ -27136,6 +27154,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # are deliberately NOT cleared here — _release_turn_lease owns
             # them (#64934).
             state.turn.clear()
+            if state.conversation.model_cache_evict_pending:
+                state.conversation.model_cache_evict_pending = False
+                self._evict_cached_agent(session_key)
         # Turn boundary: a running-agent slot was just released.  Persist the
         # new (lower) in-flight count so the dashboard readout stays current
         # between lifecycle transitions.  Preserves gateway_state (see
@@ -31172,7 +31193,107 @@ def _looks_like_profile_conflict_from_cmdline(command: str, our_home) -> bool:
     if home_value is not None and os.path.normcase(os.path.normpath(home_value)) != os.path.normcase(os.path.normpath(str(our_home))):
         return True
     return False
+_SESSION_MODEL_APPLY_TIMEOUT = 4.0
+_SESSION_MODEL_DB_WRITE_TIMEOUT = 1.5
 
+
+def _build_set_session_model_handler(runner, main_loop):
+    """Build the control-thread bridge for one gateway-owned conversation.
+
+    The coroutine owns the only mutation deadline. A request that sits on a
+    stalled loop until that deadline expires is rejected before touching
+    session state; once mutation starts, the only awaited step (SQLite) is
+    bounded by the remaining budget and degrades to a visible durability
+    warning rather than contradicting the already-applied live override.
+    """
+
+    def _set_session_model_handler(params: dict) -> dict:
+        session_key = str(params.get("session_key") or "").strip()
+        model = str(params.get("model") or "").strip()
+        provider = str(params.get("provider") or "").strip()
+        requested_base_url = str(params.get("base_url") or "").strip()
+        if not session_key or not model:
+            raise ValueError("session_key and model are required")
+        if not runner.session_store.has_session(session_key):
+            raise ValueError("session not found")
+
+        runtime: dict = {}
+        if provider:
+            runtime = _resolve_runtime_agent_kwargs_for_provider(provider)
+        resolved_provider = str(runtime.get("provider") or provider or "").strip()
+        full_override: Dict[str, Any] = {
+            "model": model,
+            "provider": resolved_provider,
+            "base_url": requested_base_url or runtime.get("base_url"),
+            "api_key": runtime.get("api_key"),
+            "api_mode": runtime.get("api_mode"),
+            "credential_pool": runtime.get("credential_pool"),
+        }
+        apply_deadline = time.monotonic() + _SESSION_MODEL_APPLY_TIMEOUT
+
+        async def _apply() -> tuple[str, bool]:
+            if time.monotonic() >= apply_deadline:
+                raise TimeoutError(
+                    "gateway did not begin the session model change in time"
+                )
+            # Recheck on the gateway loop so a session removed after the
+            # control request was accepted cannot be resurrected.
+            if not runner.session_store.has_session(session_key):
+                raise ValueError("session not found")
+            session_id = runner.session_store.get_session_id(session_key)
+            if not runner.session_store.set_model_override(
+                session_key, full_override
+            ):
+                raise ValueError("session not found")
+            runner._session_state(
+                session_key
+            ).conversation.model_override = full_override
+            eviction_deferred = runner._defer_or_evict_session_model_cache(
+                session_key
+            )
+
+            durability_warning = ""
+            session_db = getattr(runner, "_session_db", None)
+            if session_db is not None and session_id:
+                remaining = apply_deadline - time.monotonic()
+                if remaining <= 0:
+                    durability_warning = (
+                        "The live model changed, but its transcript record could "
+                        "not be confirmed before the gateway deadline. Refresh "
+                        "before retrying."
+                    )
+                else:
+                    try:
+                        await asyncio.wait_for(
+                            session_db.update_session_model(
+                                session_id, model, provider=resolved_provider
+                            ),
+                            timeout=min(_SESSION_MODEL_DB_WRITE_TIMEOUT, remaining),
+                        )
+                    except Exception:
+                        logger.warning(
+                            "Live session model changed but the transcript row "
+                            "could not be updated",
+                            exc_info=True,
+                        )
+                        durability_warning = (
+                            "The live model changed, but the saved transcript "
+                            "record could not be confirmed. Refresh before retrying."
+                        )
+            return durability_warning, eviction_deferred
+
+        future = asyncio.run_coroutine_threadsafe(_apply(), main_loop)
+        durability_warning, eviction_deferred = future.result()
+        return {
+            "applied": True,
+            "session_key": session_key,
+            "model": model,
+            "provider": resolved_provider,
+            "eviction_deferred": eviction_deferred,
+            "durability_warning": durability_warning,
+        }
+
+    return _set_session_model_handler
 
 
 async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = False, verbosity: Optional[int] = 0) -> bool:
@@ -31642,7 +31763,7 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         # drain budget so the caller knows how long to wait for exit.
         _main_loop = asyncio.get_running_loop()
 
-        def _pause_for_update_handler() -> dict:
+        def _pause_for_update_handler(_params: Optional[dict] = None) -> dict:
             try:
                 from hermes_cli.gateway import _get_restart_drain_timeout
 
@@ -31670,8 +31791,15 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
                 "drain_timeout": _drain,
             }
 
+        _set_session_model_handler = _build_set_session_model_handler(
+            runner, _main_loop
+        )
+
         _control_server = GatewayControlServer(
-            verb_handlers={"pause-for-update": _pause_for_update_handler}
+            verb_handlers={
+                "pause-for-update": _pause_for_update_handler,
+                "set-session-model": _set_session_model_handler,
+            }
         )
         if not await _control_server.start():
             _control_server = None

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -3072,6 +3072,19 @@ class SessionStore:
                 return default
             return entry.metadata.get(key, default)
 
+    def has_session(self, session_key: str) -> bool:
+        """Whether this store currently owns a live routing entry."""
+        with self._lock:
+            self._ensure_loaded_locked()
+            return session_key in self._entries
+
+    def get_session_id(self, session_key: str) -> Optional[str]:
+        """Return the transcript ID currently owned by a routing key."""
+        with self._lock:
+            self._ensure_loaded_locked()
+            entry = self._entries.get(session_key)
+            return entry.session_id if entry is not None else None
+
     def set_session_metadata(
         self,
         session_key: str,
@@ -3101,7 +3114,7 @@ class SessionStore:
 
     def set_model_override(
         self, session_key: str, override: Optional[Dict[str, Any]]
-    ) -> None:
+    ) -> bool:
         """Persist (or clear) the session-scoped /model override.
 
         Only non-secret keys (model/provider/base_url — see
@@ -3109,17 +3122,21 @@ class SessionStore:
         are re-resolved at rehydration time via the normal runtime provider
         resolution.  Pass ``None`` (or a dict with no persistable values)
         to clear the persisted override, e.g. on /new.
+
+        Returns ``False`` when the routing key is no longer owned; callers
+        that bridge another process can then fail without recreating it.
         """
         with self._lock:
             self._ensure_loaded_locked()
             entry = self._entries.get(session_key)
             if entry is None:
-                return
+                return False
             cleaned = sanitize_model_override(override)
             if entry.model_override == cleaned:
-                return
+                return True
             entry.model_override = cleaned
             self._save()
+            return True
 
     def get_model_override(self, session_key: str) -> Optional[Dict[str, str]]:
         """Return the persisted /model override for *session_key*, if any."""

--- a/gateway/session_state.py
+++ b/gateway/session_state.py
@@ -93,6 +93,10 @@ class ConversationState:
 
     # /model per-session override (model/provider/api_key/base_url/api_mode).
     model_override: Optional[Dict[str, Any]] = None
+    # A model switch accepted while this conversation is mid-turn. The live
+    # turn keeps its captured client; its cached agent is rebuilt only after
+    # the running slot is released.
+    model_cache_evict_pending: bool = False
     # /model --once restore snapshot.
     one_turn_restore: Optional[Dict[str, Any]] = None
     # /reasoning per-session override.
@@ -118,6 +122,7 @@ class ConversationState:
         automatically.
         """
         self.model_override = None
+        self.model_cache_evict_pending = False
         self.one_turn_restore = None
         self.reasoning_override = None
         self.service_tier_override = _UNSET_TIER

--- a/tests/gateway/test_control_socket.py
+++ b/tests/gateway/test_control_socket.py
@@ -4,17 +4,20 @@ import asyncio
 import json
 import socket
 import sys
+import time
 from pathlib import Path
 
 import pytest
 
 from gateway.control_socket import (
     CONTROL_PROTOCOL_VERSION,
+    GatewayControlTimeoutError,
     GatewayControlServer,
     identify_gateway,
     query_gateway_control,
     resolve_client_socket_path,
     resolve_server_socket_path,
+    set_gateway_session_model_override,
     windows_pipe_name,
 )
 
@@ -161,6 +164,56 @@ def test_unknown_verb_and_malformed_request(home: Path):
     assert payload["protocol"] == CONTROL_PROTOCOL_VERSION
 
 
+def test_parameterized_handler_receives_bounded_json_payload(home: Path):
+    seen = []
+
+    def handler(params):
+        seen.append(params)
+        return {"applied": True, "session_key": params["session_key"]}
+
+    server = GatewayControlServer(home, verb_handlers={"set-session-model": handler})
+    response = json.loads(
+        server.handle_request_line(
+            json.dumps(
+                {
+                    "verb": "set-session-model",
+                    "params": {
+                        "session_key": "agent:main:telegram:dm:42",
+                        "model": "gpt-5.6-sol",
+                    },
+                }
+            ).encode()
+        ).decode()
+    )
+
+    assert response["ok"] is True
+    assert response["result"] == {
+        "applied": True,
+        "session_key": "agent:main:telegram:dm:42",
+    }
+    assert seen == [
+        {
+            "session_key": "agent:main:telegram:dm:42",
+            "model": "gpt-5.6-sol",
+        }
+    ]
+
+
+@pytest.mark.parametrize("params", [[], "", 0, False])
+def test_control_socket_rejects_non_object_params(home: Path, params):
+    server = GatewayControlServer(
+        home, verb_handlers={"set-session-model": lambda received: received}
+    )
+    response = json.loads(
+        server.handle_request_line(
+            json.dumps({"verb": "set-session-model", "params": params}).encode()
+        ).decode()
+    )
+
+    assert response["ok"] is False
+    assert "params must be a JSON object" in response["error"]
+
+
 def test_stop_removes_socket_and_pointer(home: Path):
     async def scenario():
         server = GatewayControlServer(
@@ -223,6 +276,42 @@ def test_long_home_end_to_end_via_pointer(tmp_path: Path):
 def test_no_socket_returns_none_fast(home: Path):
     assert identify_gateway(home) is None
     assert query_gateway_control(home, "status") is None
+
+
+def test_mutating_timeout_is_not_reported_as_an_unavailable_socket(home: Path):
+    def slow_handler(_params):
+        time.sleep(0.1)
+        return {"applied": True}
+
+    async def scenario():
+        server = GatewayControlServer(
+            home, verb_handlers={"set-session-model": slow_handler}
+        )
+        assert await server.start()
+        try:
+            loop = asyncio.get_running_loop()
+            observer_result = await loop.run_in_executor(
+                None,
+                lambda: query_gateway_control(
+                    home, "set-session-model", params={"probe": True}, timeout=0.01
+                ),
+            )
+
+            def mutate():
+                return set_gateway_session_model_override(
+                    home,
+                    session_key="agent:main:telegram:dm:42",
+                    model="gpt-5.6-sol",
+                    timeout=0.01,
+                )
+
+            with pytest.raises(GatewayControlTimeoutError):
+                await loop.run_in_executor(None, mutate)
+            return observer_result
+        finally:
+            await server.stop()
+
+    assert _run(scenario()) is None
 
 
 def test_default_identify_payload_shape(home: Path, monkeypatch):

--- a/tests/gateway/test_control_socket_windows_live.py
+++ b/tests/gateway/test_control_socket_windows_live.py
@@ -88,14 +88,18 @@ def _kill_tree(proc: subprocess.Popen) -> None:
 
 def test_named_pipe_identify_status_and_fleet_consumer(live_server, monkeypatch):
     proc, home, server_pid = live_server
-    from gateway.control_socket import identify_gateway, query_gateway_control
+    from gateway.control_socket import (
+        CONTROL_PROTOCOL_VERSION,
+        identify_gateway,
+        query_gateway_control,
+    )
 
     ident = identify_gateway(home, timeout=5.0)
     assert ident is not None, "identify returned None against a live pipe server"
     # Compare against the server's SELF-reported pid, not Popen.pid — uv's
     # Windows trampoline makes the spawner's view wrong (see _CHILD_CODE).
     assert ident["pid"] == server_pid
-    assert ident["protocol"] == 1
+    assert ident["protocol"] == CONTROL_PROTOCOL_VERSION
     assert ident["kind"] == "hermes-gateway"
     assert ident["supervisor"] in {"systemd", "launchd", "desktop", "external", "manual"}
 

--- a/tests/gateway/test_session_model_control.py
+++ b/tests/gateway/test_session_model_control.py
@@ -1,0 +1,149 @@
+"""Live gateway model mutation through the internal control socket."""
+
+import asyncio
+import threading
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.run import (
+    GatewayRunner,
+    _AGENT_PENDING_SENTINEL,
+    _build_set_session_model_handler,
+)
+from gateway.session_state import SessionState
+
+
+class _LoopThread:
+    def __enter__(self):
+        self.loop = asyncio.new_event_loop()
+        self.thread = threading.Thread(target=self.loop.run_forever, daemon=True)
+        self.thread.start()
+        return self.loop
+
+    def __exit__(self, *_exc):
+        self.loop.call_soon_threadsafe(self.loop.stop)
+        self.thread.join(timeout=2)
+        self.loop.close()
+
+
+def _runner(*, db_error: Exception | None = None):
+    state = SessionState()
+    store = MagicMock()
+    store.has_session.return_value = True
+    store.get_session_id.return_value = "transcript-42"
+    store.set_model_override.return_value = True
+    update = AsyncMock()
+    if db_error is not None:
+        update.side_effect = db_error
+    runner = SimpleNamespace(
+        session_store=store,
+        _session_db=SimpleNamespace(update_session_model=update),
+        _session_state=lambda _key: state,
+        _defer_or_evict_session_model_cache=MagicMock(return_value=True),
+    )
+    return runner, state, store, update
+
+
+def test_handler_updates_store_state_db_and_defers_running_eviction(monkeypatch):
+    runner, state, store, update = _runner()
+    monkeypatch.setattr(
+        "gateway.run._resolve_runtime_agent_kwargs_for_provider",
+        lambda _provider: {
+            "provider": "openai-codex",
+            "api_key": "resolved-secret",
+            "api_mode": "responses",
+        },
+    )
+
+    with _LoopThread() as loop:
+        result = _build_set_session_model_handler(runner, loop)({
+            "session_key": "agent:main:telegram:dm:42",
+            "model": "gpt-5.6-sol",
+            "provider": "openai-codex",
+        })
+
+    override = store.set_model_override.call_args.args[1]
+    assert override["model"] == "gpt-5.6-sol"
+    assert override["provider"] == "openai-codex"
+    assert override["api_key"] == "resolved-secret"
+    assert state.conversation.model_override == override
+    update.assert_awaited_once_with(
+        "transcript-42", "gpt-5.6-sol", provider="openai-codex"
+    )
+    runner._defer_or_evict_session_model_cache.assert_called_once_with(
+        "agent:main:telegram:dm:42"
+    )
+    assert result["applied"] is True
+    assert result["eviction_deferred"] is True
+    assert result["durability_warning"] == ""
+
+
+def test_handler_surfaces_durable_write_failure_without_reverting_live_state(
+    monkeypatch,
+):
+    runner, state, store, _update = _runner(db_error=OSError("database busy"))
+    monkeypatch.setattr(
+        "gateway.run._resolve_runtime_agent_kwargs_for_provider",
+        lambda _provider: {"provider": "openai-codex"},
+    )
+
+    with _LoopThread() as loop:
+        result = _build_set_session_model_handler(runner, loop)({
+            "session_key": "agent:main:telegram:dm:42",
+            "model": "gpt-5.6-sol",
+            "provider": "openai-codex",
+        })
+
+    assert store.set_model_override.called
+    assert state.conversation.model_override["model"] == "gpt-5.6-sol"
+    assert result["applied"] is True
+    assert "saved transcript record could not be confirmed" in result[
+        "durability_warning"
+    ]
+
+
+def test_handler_deadline_expires_before_any_mutation(monkeypatch):
+    runner, _state, store, update = _runner()
+    monkeypatch.setattr("gateway.run._SESSION_MODEL_APPLY_TIMEOUT", 0.0)
+    monkeypatch.setattr(
+        "gateway.run._resolve_runtime_agent_kwargs_for_provider",
+        lambda _provider: {"provider": "openai-codex"},
+    )
+
+    with _LoopThread() as loop:
+        handler = _build_set_session_model_handler(runner, loop)
+        with pytest.raises(TimeoutError, match="did not begin"):
+            handler({
+                "session_key": "agent:main:telegram:dm:42",
+                "model": "gpt-5.6-sol",
+                "provider": "openai-codex",
+            })
+
+    store.set_model_override.assert_not_called()
+    update.assert_not_awaited()
+
+
+def test_running_session_cache_eviction_waits_for_turn_release():
+    runner = object.__new__(GatewayRunner)
+    runner.__dict__["_sessions"] = {}
+    runner._agent_cache = {
+        "agent:main:telegram:dm:42": (_AGENT_PENDING_SENTINEL, 0.0)
+    }
+    runner._agent_cache_lock = threading.RLock()
+    runner._persist_active_agents = MagicMock()
+    state = runner._session_state("agent:main:telegram:dm:42")
+    state.turn.agent = _AGENT_PENDING_SENTINEL
+
+    assert runner._defer_or_evict_session_model_cache(
+        "agent:main:telegram:dm:42"
+    ) is True
+    assert "agent:main:telegram:dm:42" in runner._agent_cache
+    assert state.conversation.model_cache_evict_pending is True
+
+    assert runner._release_running_agent_state(
+        "agent:main:telegram:dm:42"
+    ) is True
+    assert "agent:main:telegram:dm:42" not in runner._agent_cache
+    assert state.conversation.model_cache_evict_pending is False

--- a/tests/gateway/test_session_model_override_persistence.py
+++ b/tests/gateway/test_session_model_override_persistence.py
@@ -74,7 +74,7 @@ def test_override_persists_and_survives_restart(store_factory, tmp_path):
     entry = store.get_or_create_session(_make_source())
     session_key = entry.session_key
 
-    store.set_model_override(session_key, OVERRIDE)
+    assert store.set_model_override(session_key, OVERRIDE) is True
 
     # Simulated restart: a brand-new store instance reads the same dir.
     store2 = store_factory()
@@ -84,6 +84,12 @@ def test_override_persists_and_survives_restart(store_factory, tmp_path):
         "provider": "openai",
         "base_url": "https://api.openai.example/v1",
     }
+
+
+def test_override_refuses_a_routing_key_the_store_no_longer_owns(store_factory):
+    store = store_factory()
+
+    assert store.set_model_override("missing-routing-key", OVERRIDE) is False
 
 
 def _make_runner(store):

--- a/tests/tui_gateway/test_external_session_model_scope.py
+++ b/tests/tui_gateway/test_external_session_model_scope.py
@@ -209,6 +209,41 @@ def test_completed_desktop_handoff_updates_the_gateway_owned_peer(
     ]
 
 
+def test_desktop_replay_uses_the_stored_messaging_origin(monkeypatch, tmp_path):
+    calls = []
+    db = _DB({
+        "id": "stored-telegram-session",
+        "session_key": "agent:main:telegram:dm:7616809568",
+        "source": "telegram",
+    })
+    session = {
+        "agent": SimpleNamespace(_session_db=db),
+        "profile_home": str(tmp_path),
+        "session_key": "stored-telegram-session",
+        # Resuming a messaging transcript in Desktop creates a local replay
+        # runtime.  The persisted row above remains the origin authority.
+        "source": "desktop",
+    }
+    monkeypatch.setattr(
+        "gateway.control_socket.set_gateway_session_model_override",
+        lambda home, **kwargs: calls.append((home, kwargs)) or {"applied": True},
+    )
+
+    server._sync_gateway_owned_model_override(session, _result())
+
+    assert calls == [
+        (
+            tmp_path,
+            {
+                "session_key": "agent:main:telegram:dm:7616809568",
+                "model": "gpt-5.6-sol",
+                "provider": "openai-codex",
+                "base_url": "https://api.openai.com/v1",
+            },
+        )
+    ]
+
+
 def test_incomplete_desktop_handoff_remains_locally_owned(monkeypatch, tmp_path):
     db = _DB({
         "id": "desktop-session",
@@ -334,6 +369,98 @@ def test_confirmed_telegram_pick_updates_gateway_without_mutating_replay_agent(
     assert response["warning"] == "saved transcript record could not be updated"
     assert calls == [(session, "gpt-5.6-sol")]
     assert agent.model == "z-ai/glm-5.2"
+
+
+def test_offline_gateway_cannot_commit_a_desktop_replay_only_switch(
+    monkeypatch, tmp_path
+):
+    switch_calls = []
+    db = _DB({
+        "id": "stored-telegram-session",
+        "session_key": "agent:main:telegram:dm:7616809568",
+        "source": "telegram",
+    })
+
+    def apply_to_replay(**kwargs):
+        switch_calls.append(kwargs)
+        agent.model = kwargs["new_model"]
+        agent.provider = kwargs["new_provider"]
+
+    agent = SimpleNamespace(
+        _session_db=db,
+        model="z-ai/glm-5.2",
+        provider="nous",
+        base_url="https://inference-api.nousresearch.com/v1",
+        api_key="old-token",
+        switch_model=apply_to_replay,
+    )
+    session = {
+        "agent": agent,
+        "history": [],
+        "profile_home": str(tmp_path),
+        "session_key": "stored-telegram-session",
+        "source": "desktop",
+    }
+    parsed = SimpleNamespace(
+        model_input="gpt-5.6-sol",
+        explicit_provider="openai-codex",
+        is_global=False,
+        is_session=True,
+        is_once=False,
+    )
+    gateway_available = False
+
+    def set_gateway_model(*_args, **_kwargs):
+        return {"applied": True} if gateway_available else None
+
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.switch_model", lambda **_kw: _switch_result()
+    )
+    monkeypatch.setattr(
+        "hermes_cli.model_selection_guards.combined_selection_warning",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "gateway.control_socket.set_gateway_session_model_override", set_gateway_model
+    )
+    monkeypatch.setattr(server, "_restart_slash_worker", lambda *_args: None)
+    monkeypatch.setattr(server, "_persist_live_session_runtime", lambda *_args: None)
+    monkeypatch.setattr(
+        server, "_persist_live_session_system_prompt", lambda *_args: None
+    )
+    monkeypatch.setattr(
+        server, "_append_model_switch_marker", lambda *_args, **_kwargs: None
+    )
+    monkeypatch.setattr(server, "_emit", lambda *_args, **_kwargs: None)
+
+    with pytest.raises(RuntimeError, match="telegram gateway is unavailable"):
+        server._apply_model_switch(
+            "desktop-replay",
+            session,
+            "gpt-5.6-sol --provider openai-codex --session",
+            parsed_flags=parsed,
+        )
+
+    assert switch_calls == []
+    assert agent.model == "z-ai/glm-5.2"
+    assert agent.provider == "nous"
+    assert "model_override" not in session
+
+    # Starting the gateway later does not silently apply a choice that was
+    # reported as failed.  An explicit retry succeeds on both authorities.
+    gateway_available = True
+    response = server._apply_model_switch(
+        "desktop-replay",
+        session,
+        "gpt-5.6-sol --provider openai-codex --session",
+        parsed_flags=parsed,
+    )
+
+    assert response["value"] == "gpt-5.6-sol"
+    assert len(switch_calls) == 1
+    assert agent.model == "gpt-5.6-sol"
+    assert agent.provider == "openai-codex"
+    assert session["model_override"]["model"] == "gpt-5.6-sol"
 
 
 def test_busy_telegram_switch_updates_gateway_before_local_deferral(

--- a/tests/tui_gateway/test_external_session_model_scope.py
+++ b/tests/tui_gateway/test_external_session_model_scope.py
@@ -1,0 +1,391 @@
+"""Cross-process model scope for messaging sessions opened in Desktop."""
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import ANY
+
+import pytest
+
+from tui_gateway import server
+
+
+class _DB:
+    def __init__(self, row):
+        self.row = row
+
+    def get_session(self, _session_id):
+        return dict(self.row)
+
+
+def _result():
+    return SimpleNamespace(
+        new_model="gpt-5.6-sol",
+        target_provider="openai-codex",
+        base_url="https://api.openai.com/v1",
+    )
+
+
+def _switch_result():
+    return SimpleNamespace(
+        success=True,
+        new_model="gpt-5.6-sol",
+        target_provider="openai-codex",
+        base_url="https://api.openai.com/v1",
+        api_key="resolved-token",
+        api_mode="responses",
+        model_info=None,
+        warning_message="",
+    )
+
+
+def test_telegram_resume_updates_the_gateway_owned_routing_peer(monkeypatch, tmp_path):
+    calls = []
+    db = _DB({
+        "id": "stored-telegram-session",
+        "session_key": "agent:main:telegram:dm:7616809568",
+        "source": "telegram",
+    })
+    session: dict[str, Any] = {
+        "agent": SimpleNamespace(_session_db=db),
+        "profile_home": str(tmp_path),
+        "session_key": "stored-telegram-session",
+        "source": "telegram",
+    }
+
+    monkeypatch.setattr(
+        "gateway.control_socket.set_gateway_session_model_override",
+        lambda home, **kwargs: calls.append((home, kwargs)) or {"applied": True},
+    )
+
+    server._sync_gateway_owned_model_override(session, _result())
+
+    assert calls == [
+        (
+            tmp_path,
+            {
+                "session_key": "agent:main:telegram:dm:7616809568",
+                "model": "gpt-5.6-sol",
+                "provider": "openai-codex",
+                "base_url": "https://api.openai.com/v1",
+            },
+        )
+    ]
+
+
+def test_gateway_owned_switch_fails_closed_when_live_owner_is_unavailable(
+    monkeypatch, tmp_path
+):
+    db = _DB({
+        "id": "stored-telegram-session",
+        "session_key": "agent:main:telegram:dm:7616809568",
+        "source": "telegram",
+    })
+    session = {
+        "agent": SimpleNamespace(_session_db=db),
+        "profile_home": str(tmp_path),
+        "session_key": "stored-telegram-session",
+        "source": "telegram",
+    }
+    monkeypatch.setattr(
+        "gateway.control_socket.set_gateway_session_model_override",
+        lambda *_args, **_kwargs: None,
+    )
+
+    with pytest.raises(RuntimeError, match="telegram gateway is unavailable"):
+        server._sync_gateway_owned_model_override(session, _result())
+
+
+def test_gateway_timeout_reports_unknown_outcome_instead_of_unavailable(
+    monkeypatch, tmp_path
+):
+    from gateway.control_socket import GatewayControlTimeoutError
+
+    db = _DB({
+        "id": "stored-telegram-session",
+        "session_key": "agent:main:telegram:dm:7616809568",
+        "source": "telegram",
+    })
+    session = {
+        "agent": SimpleNamespace(_session_db=db),
+        "profile_home": str(tmp_path),
+        "session_key": "stored-telegram-session",
+        "source": "telegram",
+    }
+
+    def timed_out(*_args, **_kwargs):
+        raise GatewayControlTimeoutError("response timed out")
+
+    monkeypatch.setattr(
+        "gateway.control_socket.set_gateway_session_model_override", timed_out
+    )
+
+    with pytest.raises(RuntimeError, match="outcome is unknown"):
+        server._sync_gateway_owned_model_override(session, _result())
+
+
+def test_gateway_durability_warning_is_returned_to_the_model_switch_caller(
+    monkeypatch, tmp_path
+):
+    db = _DB({
+        "id": "stored-telegram-session",
+        "session_key": "agent:main:telegram:dm:7616809568",
+        "source": "telegram",
+    })
+    session = {
+        "agent": SimpleNamespace(_session_db=db),
+        "profile_home": str(tmp_path),
+        "session_key": "stored-telegram-session",
+        "source": "telegram",
+    }
+    monkeypatch.setattr(
+        "gateway.control_socket.set_gateway_session_model_override",
+        lambda *_args, **_kwargs: {
+            "applied": True,
+            "durability_warning": "saved transcript record could not be updated",
+        },
+    )
+
+    response = server._sync_gateway_owned_model_override(session, _result())
+
+    assert response == {
+        "applied": True,
+        "durability_warning": "saved transcript record could not be updated",
+    }
+
+
+def test_local_desktop_session_does_not_touch_gateway_control(monkeypatch, tmp_path):
+    db = _DB({"id": "desktop-session", "session_key": None, "source": "desktop"})
+    session = {
+        "agent": SimpleNamespace(_session_db=db),
+        "profile_home": str(tmp_path),
+        "session_key": "desktop-session",
+        "source": "desktop",
+    }
+
+    def unexpected(*_args, **_kwargs):
+        raise AssertionError("local sessions must not use gateway control")
+
+    monkeypatch.setattr(
+        "gateway.control_socket.set_gateway_session_model_override", unexpected
+    )
+
+    server._sync_gateway_owned_model_override(session, _result())
+
+
+def test_completed_desktop_handoff_updates_the_gateway_owned_peer(
+    monkeypatch, tmp_path
+):
+    calls = []
+    db = _DB({
+        "id": "desktop-session",
+        "session_key": "agent:main:telegram:dm:7616809568",
+        "source": "telegram",
+        "handoff_state": "completed",
+        "handoff_platform": "telegram",
+    })
+    session = {
+        "agent": SimpleNamespace(_session_db=db),
+        "profile_home": str(tmp_path),
+        "session_key": "desktop-session",
+        "source": "desktop",
+    }
+    monkeypatch.setattr(
+        "gateway.control_socket.set_gateway_session_model_override",
+        lambda home, **kwargs: calls.append((home, kwargs)) or {"applied": True},
+    )
+
+    server._sync_gateway_owned_model_override(session, _result())
+
+    assert calls == [
+        (
+            tmp_path,
+            {
+                "session_key": "agent:main:telegram:dm:7616809568",
+                "model": "gpt-5.6-sol",
+                "provider": "openai-codex",
+                "base_url": "https://api.openai.com/v1",
+            },
+        )
+    ]
+
+
+def test_incomplete_desktop_handoff_remains_locally_owned(monkeypatch, tmp_path):
+    db = _DB({
+        "id": "desktop-session",
+        "session_key": "agent:main:telegram:dm:7616809568",
+        "source": "desktop",
+        "handoff_state": "pending",
+        "handoff_platform": "telegram",
+    })
+    session = {
+        "agent": SimpleNamespace(_session_db=db),
+        "profile_home": str(tmp_path),
+        "session_key": "desktop-session",
+        "source": "desktop",
+    }
+
+    def unexpected(*_args, **_kwargs):
+        raise AssertionError("an incomplete handoff must remain locally owned")
+
+    monkeypatch.setattr(
+        "gateway.control_socket.set_gateway_session_model_override", unexpected
+    )
+
+    server._sync_gateway_owned_model_override(session, _result())
+
+
+def test_telegram_switch_fails_closed_when_peer_row_is_missing(monkeypatch, tmp_path):
+    session = {
+        "agent": SimpleNamespace(_session_db=_DB({})),
+        "profile_home": str(tmp_path),
+        "session_key": "stored-telegram-session",
+        "source": "telegram",
+    }
+
+    with pytest.raises(RuntimeError, match="no live gateway routing key"):
+        server._sync_gateway_owned_model_override(session, _result())
+
+
+def test_guarded_telegram_pick_does_not_reach_gateway_before_confirmation(
+    monkeypatch,
+):
+    agent = SimpleNamespace(
+        model="z-ai/glm-5.2",
+        provider="openrouter",
+        base_url="",
+        api_key="old-token",
+    )
+    session = {"agent": agent, "source": "telegram", "history": []}
+    parsed = SimpleNamespace(
+        model_input="gpt-5.6-sol",
+        explicit_provider="openai-codex",
+        is_global=False,
+        is_session=True,
+        is_once=False,
+    )
+
+    monkeypatch.setattr("hermes_cli.model_switch.switch_model", lambda **_kw: _switch_result())
+    monkeypatch.setattr(
+        "hermes_cli.model_selection_guards.combined_selection_warning",
+        lambda *_args, **_kwargs: SimpleNamespace(message="Confirmation required"),
+    )
+    monkeypatch.setattr(
+        server,
+        "_sync_gateway_owned_model_override",
+        lambda *_args: pytest.fail("unconfirmed picks must not mutate the gateway"),
+    )
+
+    response = server._apply_model_switch(
+        "telegram-live",
+        session,
+        "gpt-5.6-sol --provider openai-codex --session",
+        parsed_flags=parsed,
+        apply_local_agent=False,
+    )
+
+    assert response["confirm_required"] is True
+    assert agent.model == "z-ai/glm-5.2"
+
+
+def test_confirmed_telegram_pick_updates_gateway_without_mutating_replay_agent(
+    monkeypatch,
+):
+    calls = []
+
+    def unexpected_switch(**_kwargs):
+        raise AssertionError("the busy replay agent must not be switched in place")
+
+    agent = SimpleNamespace(
+        model="z-ai/glm-5.2",
+        provider="openrouter",
+        base_url="",
+        api_key="old-token",
+        switch_model=unexpected_switch,
+    )
+    session = {"agent": agent, "source": "telegram", "history": []}
+    parsed = SimpleNamespace(
+        model_input="gpt-5.6-sol",
+        explicit_provider="openai-codex",
+        is_global=False,
+        is_session=True,
+        is_once=False,
+    )
+
+    monkeypatch.setattr("hermes_cli.model_switch.switch_model", lambda **_kw: _switch_result())
+    def sync(received, result):
+        calls.append((received, result.new_model))
+        return {
+            "applied": True,
+            "durability_warning": "saved transcript record could not be updated",
+        }
+
+    monkeypatch.setattr(server, "_sync_gateway_owned_model_override", sync)
+
+    response = server._apply_model_switch(
+        "telegram-live",
+        session,
+        "gpt-5.6-sol --provider openai-codex --session",
+        parsed_flags=parsed,
+        confirm_expensive_model=True,
+        apply_local_agent=False,
+    )
+
+    assert response["confirm_required"] is False
+    assert response["warning"] == "saved transcript record could not be updated"
+    assert calls == [(session, "gpt-5.6-sol")]
+    assert agent.model == "z-ai/glm-5.2"
+
+
+def test_busy_telegram_switch_updates_gateway_before_local_deferral(
+    monkeypatch, tmp_path
+):
+    calls = []
+    session: dict[str, Any] = {
+        "agent": SimpleNamespace(),
+        "session_key": "stored-telegram-session",
+        "source": "telegram",
+        "running": True,
+    }
+    server._sessions["telegram-live"] = session
+
+    monkeypatch.setattr(
+        server,
+        "_gateway_owned_model_target",
+        lambda _session: ("telegram", "agent:main:telegram:dm:7616809568", tmp_path),
+    )
+
+    def resolve(*_args, **kwargs):
+        calls.append(kwargs)
+        return {
+            "value": "gpt-5.6-sol",
+            "warning": "",
+            "confirm_required": False,
+            "scope": "session",
+        }
+
+    monkeypatch.setattr(server, "_apply_model_switch", resolve)
+    try:
+        response = server.handle_request({
+            "id": "1",
+            "method": "config.set",
+            "params": {
+                "session_id": "telegram-live",
+                "key": "model",
+                "value": "gpt-5.6-sol --provider openai-codex --session",
+            },
+        })
+    finally:
+        server._sessions.pop("telegram-live", None)
+
+    assert response is not None
+    assert response["result"]["deferred"] is True
+    assert calls == [
+        {
+            "confirm_expensive_model": False,
+            "parsed_flags": ANY,
+            "apply_local_agent": False,
+        }
+    ]
+    pending = session["pending_model_switch"]
+    assert isinstance(pending, dict)
+    assert pending["display_model"] == "gpt-5.6-sol"

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5988,6 +5988,86 @@ def _restore_agent_model_runtime(agent, snapshot: dict | None) -> None:
         )
 
 
+def _gateway_owned_model_target(session: dict) -> tuple[str, str, Path] | None:
+    """Return the live gateway routing target for a messaging session."""
+    if not isinstance(session, dict):
+        return None
+
+    source = _session_source(session).strip().lower()
+    directly_gateway_owned = _is_gateway_owned_source(source)
+
+    agent = session.get("agent")
+    db = getattr(agent, "_session_db", None) or _get_db()
+    stored_session_id = str(session.get("session_key") or "").strip()
+    if db is None or not stored_session_id:
+        if not directly_gateway_owned:
+            return None
+        raise RuntimeError(
+            f"The {source} conversation routing record is unavailable, so its model was not changed."
+        )
+
+    try:
+        row = db.get_session(stored_session_id) or {}
+    except Exception as exc:
+        raise RuntimeError(
+            f"The {source} conversation routing record could not be read, so its model was not changed."
+        ) from exc
+
+    if not directly_gateway_owned:
+        handoff_state = str(row.get("handoff_state") or "").strip().lower()
+        handoff_platform = str(row.get("handoff_platform") or "").strip().lower()
+        if handoff_state != "completed" or not _is_gateway_owned_source(
+            handoff_platform
+        ):
+            return None
+        source = handoff_platform
+
+    gateway_session_key = str(row.get("session_key") or "").strip()
+    if not gateway_session_key:
+        raise RuntimeError(
+            f"The {source} conversation has no live gateway routing key, so its model was not changed."
+        )
+
+    profile_home = session.get("profile_home")
+    home = Path(profile_home) if profile_home else Path(get_hermes_home())
+    return source, gateway_session_key, home
+
+
+def _sync_gateway_owned_model_override(
+    session: dict, result: Any
+) -> dict[str, Any] | None:
+    """Apply a Desktop/TUI model pick to its live messaging owner."""
+    target = _gateway_owned_model_target(session)
+    if target is None:
+        return
+    source, gateway_session_key, home = target
+
+    from gateway.control_socket import (
+        GatewayControlTimeoutError,
+        set_gateway_session_model_override,
+    )
+
+    try:
+        response = set_gateway_session_model_override(
+            home,
+            session_key=gateway_session_key,
+            model=str(getattr(result, "new_model", "") or ""),
+            provider=str(getattr(result, "target_provider", "") or ""),
+            base_url=str(getattr(result, "base_url", "") or ""),
+        )
+    except GatewayControlTimeoutError as exc:
+        raise RuntimeError(
+            f"The {source} gateway did not confirm the model change in time, "
+            "so its outcome is unknown. Refresh the session before retrying."
+        ) from exc
+    if not response or response.get("applied") is not True:
+        raise RuntimeError(
+            f"The {source} gateway is unavailable, so this conversation's model was not changed. "
+            "Keep the gateway running and retry."
+        )
+    return response
+
+
 def _apply_model_switch(
     sid: str,
     session: dict,
@@ -5997,6 +6077,7 @@ def _apply_model_switch(
     pin_session_override: bool = True,
     parsed_flags: Any | None = None,
     persist_override: bool | None = None,
+    apply_local_agent: bool = True,
 ) -> dict:
     from hermes_cli.model_switch import (
         parse_model_switch_args,
@@ -6094,7 +6175,7 @@ def _apply_model_switch(
 
     restore_snapshot = _snapshot_agent_model_runtime(agent) if (one_turn and agent) else None
 
-    if agent:
+    if agent and apply_local_agent:
         try:
             from hermes_cli.context_switch_guard import merge_preflight_compression_warning
 
@@ -6140,7 +6221,13 @@ def _apply_model_switch(
                 "confirm_message": confirm_msg,
             }
 
-    if agent:
+    gateway_response = None
+    if not persist_global and not one_turn and isinstance(session, dict):
+        # Update the external owner before mutating the local replay agent.
+        # A failed bridge is therefore a clean no-op, not split-brain state.
+        gateway_response = _sync_gateway_owned_model_override(session, result)
+
+    if agent and apply_local_agent:
         try:
             agent.switch_model(
                 new_model=result.new_model,
@@ -6187,7 +6274,12 @@ def _apply_model_switch(
     # contamination bug). agent.switch_model() above already mutated the right
     # agent in place; the override dict makes that choice survive a rebuild
     # without touching shared process state.
-    if pin_session_override and isinstance(session, dict) and not one_turn:
+    if (
+        apply_local_agent
+        and pin_session_override
+        and isinstance(session, dict)
+        and not one_turn
+    ):
         session["model_override"] = {
             "model": result.new_model,
             "provider": result.target_provider,
@@ -6197,9 +6289,18 @@ def _apply_model_switch(
         }
     if persist_global:
         _persist_model_switch(result)
+    response_warning = result.warning_message or ""
+    if gateway_response:
+        durability_warning = str(
+            gateway_response.get("durability_warning") or ""
+        ).strip()
+        if durability_warning:
+            response_warning = "\n\n".join(
+                part for part in (response_warning, durability_warning) if part
+            )
     return {
         "value": result.new_model,
-        "warning": result.warning_message or "",
+        "warning": response_warning,
         "confirm_required": False,
         "scope": "once" if one_turn else ("global" if persist_global else "session"),
     }
@@ -13528,6 +13629,7 @@ def _(rid, params: dict) -> dict:
                         getattr(parsed, "explicit_provider", "") or ""
                     ).strip()
                     confirmed = bool(params.get("confirm_expensive_model", False))
+                    bridge_warning = ""
                     # Run the selection guards HERE, not only at apply time.
                     # This branch used to answer confirm_required=False without
                     # consulting them, so a client that implements the confirm
@@ -13566,6 +13668,35 @@ def _(rid, params: dict) -> dict:
                                     "deferred": False,
                                 },
                             )
+                    # The local replay agent cannot be mutated while it is
+                    # streaming, but an external messaging peer has a separate
+                    # gateway-owned runtime. Apply that peer now, then retain
+                    # the pending switch so this replay catches up next turn.
+                    if _gateway_owned_model_target(session) is not None:
+                        resolved = _apply_model_switch(
+                            params.get("session_id", ""),
+                            session,
+                            value,
+                            confirm_expensive_model=confirmed,
+                            parsed_flags=parsed,
+                            apply_local_agent=False,
+                        )
+                        if resolved.get("confirm_required"):
+                            return _ok(
+                                rid,
+                                {
+                                    "key": key,
+                                    "value": resolved["value"],
+                                    "warning": resolved.get("warning", ""),
+                                    "confirm_required": True,
+                                    "confirm_message": resolved.get(
+                                        "confirm_message", ""
+                                    ),
+                                    "scope": "session",
+                                    "deferred": False,
+                                },
+                            )
+                        bridge_warning = str(resolved.get("warning") or "")
                     session["pending_model_switch"] = {
                         "raw": value,
                         "confirm_expensive_model": confirmed,
@@ -13581,7 +13712,7 @@ def _(rid, params: dict) -> dict:
                         {
                             "key": key,
                             "value": pending_model,
-                            "warning": "",
+                            "warning": bridge_warning,
                             "confirm_required": False,
                             "confirm_message": "",
                             "scope": "session",

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5993,8 +5993,9 @@ def _gateway_owned_model_target(session: dict) -> tuple[str, str, Path] | None:
     if not isinstance(session, dict):
         return None
 
-    source = _session_source(session).strip().lower()
-    directly_gateway_owned = _is_gateway_owned_source(source)
+    runtime_source = _session_source(session).strip().lower()
+    source = runtime_source
+    directly_gateway_owned = _is_gateway_owned_source(runtime_source)
 
     agent = session.get("agent")
     db = getattr(agent, "_session_db", None) or _get_db()
@@ -6012,6 +6013,19 @@ def _gateway_owned_model_target(session: dict) -> tuple[str, str, Path] | None:
         raise RuntimeError(
             f"The {source} conversation routing record could not be read, so its model was not changed."
         ) from exc
+
+    # A messaging transcript resumed into Desktop is represented by a local
+    # ``source=desktop`` replay runtime even though its durable row still owns
+    # the Telegram/Discord/etc. origin and gateway routing key.  The renderer
+    # correctly session-scopes that model pick from the stored row, so authority
+    # resolution on this side must use the same durable origin.  Ignoring it
+    # lets an offline gateway appear to accept the pick by mutating only the
+    # replay agent; when the gateway later starts, the real conversation keeps
+    # its old provider/model.
+    stored_source = str(row.get("source") or "").strip().lower()
+    if _is_gateway_owned_source(stored_source):
+        source = stored_source
+        directly_gateway_owned = True
 
     if not directly_gateway_owned:
         handoff_state = str(row.get("handoff_state") or "").strip().lower()


### PR DESCRIPTION
## Problem

A Telegram or other messaging conversation opened in Desktop is still owned by the live messaging gateway. The Desktop model selector was scoping the change from pane placement, so it could mutate only the local replay agent (or the global default) while the live Telegram session kept its old model. Catalog failures could also leave the selector looking permanently busy.

Live Telegram UAT exposed a second form of this split-brain: resuming a Telegram transcript creates an in-memory Desktop replay runtime, while the durable session row correctly remains `source=telegram`. Authority resolution trusted only the replay source, so an offline gateway could appear to accept a model change that affected only the replay.

## What changed

- Resolve model-switch scope from durable session origin and completed handoff metadata. Messaging-origin sessions use session scope even when shown in Desktop; ordinary local Desktop sessions retain the existing global behavior.
- Treat the durable messaging origin as authoritative when a transcript is resumed into a Desktop replay runtime.
- Add the v2 local gateway-control `set-session-model` operation. It validates ownership, resolves provider credentials into the in-memory override, persists only the non-secret model/provider selection, updates the durable Desktop session row, and evicts only that session's cached agent.
- Apply a messaging-session switch to the live gateway immediately. If the Desktop replay agent is busy, its local catch-up remains deferred until the next safe turn instead of leaving Telegram on the old model.
- Fail closed when a messaging session has no authoritative gateway routing key or its gateway is offline; do not silently fall back to a global or replay-only switch. The Desktop selector rolls back and reports the failure so a later gateway start cannot silently apply a choice reported as successful.
- Bound catalog requests to 15 seconds and show an explicit error + Retry action in both model-picker surfaces.
- Preserve the existing guarded-model confirmation: no live gateway mutation occurs before confirmation.

## Review hardening

- Give the idempotent model-set operation one handler-owned 4-second mutation deadline and a longer 5-second client response budget. A response timeout is reported as an unknown outcome, never as an unavailable gateway or definitive failure.
- Defer cached-agent eviction when the messaging session has an active turn; the common turn-release funnel rebuilds it safely after the turn ends.
- Resolve completed Desktop-to-messaging handoffs from durable handoff metadata and the authoritative gateway session key, so the live peer receives the switch.
- Surface durable transcript-write failures as an applied-with-warning result rather than silently claiming full persistence.
- Document control protocol v2 as an internal Hermes coordination protocol. Existing zero-argument observer verbs remain accepted for mixed-version local processes; this socket is not a public extension API.
- Add direct handler coverage for store/state/DB/cache behavior, deadline rejection, running-turn eviction safety, timeout semantics, completed handoff routing, replay-origin routing, offline-gateway rollback, and durability-warning propagation.

## Operational boundary

Current `main` already contains fail-per-message credential handling and competing `--replace` ownership coverage. The earlier observed restart loop came from multiple stale installed launchers replacing one another, not from an OAuth failure crashing the gateway, so this change does not introduce a second lifecycle mechanism.

## Validation

- Review-focused control/handler/handoff suites: **36 passed**
- Session-state/model-persistence regression suites: **32 passed**
- Live-UAT follow-up Gateway/Python suites: **42 passed**
- Desktop focused UI suites: **48 passed** on the initial review head; **24 passed** in the follow-up selector suite
- Desktop renderer/electron/E2E typecheck: **passed**
- Desktop ESLint: **0 errors**
- Focused Ruff and `git diff --check`: **passed**
- Full PR CI: **all required checks passed** on `5bbdf58f06`; new head `fbb025f945` is running the same required checks

## Rollout

The live Telegram walkthrough found and now covers the Desktop-replay/durable-origin split-brain. Re-run the same Desktop provider/model switch against a live Telegram session on this head before merge.

Model: GPT-5.6-Sol (medium)
