### PR TITLE
fix(agent): count blocked tool calls in guardrail failure counter (#96579)

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1781,14 +1781,15 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
             if blocked:
                 effect_disposition = "none"
 
-            if not blocked:
-                function_result = agent._append_guardrail_observation(
-                    function_name,
-                    function_args,
-                    function_result,
-                    failed=is_error,
-                    tool_call_id=tool_call_id,
-                )
+            # Count blocked calls as failures so the same_tool_failure_halt
+            # guardrail can fire when a tool is structurally blocked every try.
+            function_result = agent._append_guardrail_observation(
+                function_name,
+                function_args,
+                function_result,
+                failed=is_error or blocked,
+                tool_call_id=tool_call_id,
+            )
 
             if is_error:
                 _err_text = _multimodal_text_summary(function_result)


### PR DESCRIPTION
## Summary
Fixes #96579.

The `same_tool_failure_halt` guardrail only observed tool calls where `blocked=False`. Any call denied by an approval gate (`blocked=True`) was invisible to the failure counter, so a structurally-blocked tool could be retried past the halt threshold without the guardrail ever firing.

## Changes
- `agent/tool_executor.py`: Remove the `if not blocked:` guard around `_append_guardrail_observation`. Pass `failed=is_error or blocked` so blocked calls count as failures toward the guardrail counter.

## Testing
- Dangerous commands (`rm -rf /`) still blocked by hardline rules (unchanged).
- Blocked tool calls now increment the `same_tool_failure_halt` counter.
- Normal (non-blocked, non-error) calls still reset the counter as before.
