### PR TITLE
fix(tools): mark wait-failure sessions as lost, not exited (#96362)

### DIFF
--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -1497,14 +1497,20 @@ class ProcessRegistry:
             except Exception:
                 pass
             # Always reap the child to prevent zombie processes.
+            _wait_failed = False
             try:
                 session.process.wait(timeout=5)
             except Exception as e:
+                _wait_failed = True
                 logger.debug("Process wait timed out or failed: %s", e)
             session.exited = True
             if session.completion_reason != "killed":
-                session.exit_code = session.process.returncode
-                session.completion_reason = "exited"
+                if _wait_failed:
+                    session.exit_code = session.process.returncode if session.process.returncode is not None else -1
+                    session.completion_reason = "lost"
+                else:
+                    session.exit_code = session.process.returncode
+                    session.completion_reason = "exited"
             self._move_to_finished(session)
 
     def _env_poller_loop(


### PR DESCRIPTION
## Summary
Fixes #96362.

When `process.wait()` times out or raises in the pipe-reader thread, the session was still marked `completion_reason="exited"` with `returncode=None`, hiding the reap failure from callers and cost auditing.

## Changes
- `tools/process_registry.py`: Track whether `wait()` failed. On failure, set `completion_reason="lost"` and `exit_code=-1` (or actual returncode if available) instead of the misleading "exited".

## Testing
- Clean exits still report `completion_reason="exited"` with the correct returncode.
- Wait failures now report `completion_reason="lost"` with `exit_code=-1`.
