### PR TITLE
fix(cli): recognize bare preview/dry-run flags in /compress (#96074)

### DIFF
--- a/hermes_cli/partial_compress.py
+++ b/hermes_cli/partial_compress.py
@@ -133,9 +133,9 @@ def extract_compress_flags(raw_args: str) -> Tuple[str, bool, bool]:
     kept: List[str] = []
     for tok in (raw_args or "").split():
         low = tok.lower()
-        if low in ("--preview", "--dry-run", "--dryrun"):
+        if low in ("--preview", "--dry-run", "--dryrun", "preview", "dry-run", "dryrun"):
             preview = True
-        elif low == "--aggressive":
+        elif low in ("--aggressive", "aggressive"):
             aggressive = True
         else:
             kept.append(tok)


### PR DESCRIPTION
## Summary
Fixes #96074.

`/compress here 10 preview` (bare `preview` without `--` dashes) silently ran the real destructive compression. `extract_compress_flags` only matched `--preview`, `--dry-run`, `--dryrun` — the bare word was kept as a positional arg and the command executed as if it were `/compress here 10`.

## Changes
- `hermes_cli/partial_compress.py`: Also recognize bare `preview`, `dry-run`, `dryrun`, and `aggressive` without dashes.

## Testing
- `/compress here 10 preview` now correctly triggers preview mode.
- `/compress here 10 --preview` still works (unchanged).
- `/compress here 10 aggressive` now correctly triggers aggressive mode.
