### PR TITLE
fix(tools): allow grep bracket-class quotes in shell tokenizer (#96776)

### DIFF
--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1588,7 +1588,18 @@ def _shell_tokens_with_spans(segment: str, start: int):
         while i < len(segment) and (quote or not segment[i].isspace()):
             char = segment[i]
             if quote:
-                if char == quote:
+                # Bracket-class member: a quote followed by ] inside a
+                # double-quoted word is a literal character-class member
+                # (e.g. grep "[^"]*"), not a closing quote.
+                if (
+                    quote == '"'
+                    and char == '"'
+                    and i + 1 < len(segment)
+                    and segment[i + 1] == "]"
+                ):
+                    value.append(char)
+                    i += 1
+                elif char == quote:
                     quote = None
                     i += 1
                 elif char == "\\" and quote == '"' and i + 1 < len(segment):


### PR DESCRIPTION
## Summary
Fixes #96776.

`_shell_tokens_with_spans` treated every `"` inside a double-quoted word as a closing quote. In grep regex bracket classes like `[^"]`, the `"` is a literal character-class member, not a quote terminator. The mis-parse left an unclosed quote, returned `None`, and triggered a hardline block with "malformed executable payload" — no approval prompt sent.

## Changes
- `tools/approval.py` `_shell_tokens_with_spans`: Add a `]`-lookahead — when `"` is followed by `]` inside a double-quoted word, treat it as a literal character instead of closing the quote.

## Testing
- `grep -o "[^"]*" file` — no longer hardline-blocked (was false-positive).
- `rm -rf /`, `shutdown -h now`, `mkfs.ext4 /dev/sda`, fork bombs — still blocked (unchanged).
- `grep -o "C:\Users\UPC\Desktop[^"]*" file.py` — no longer hardline-blocked.
