### PR TITLE
Add Orgo to the MCP catalog

### DIFF
--- a/contributors/emails/tugoph@gmail.com
+++ b/contributors/emails/tugoph@gmail.com
@@ -1,0 +1,2 @@
+TigerYWang
+# PR #96828 — Orgo MCP catalog entry

--- a/optional-mcps/orgo/manifest.yaml
+++ b/optional-mcps/orgo/manifest.yaml
@@ -4,7 +4,7 @@ manifest_version: 1
 
 name: orgo
 description: 'Orgo cloud computers: full Linux VMs with a desktop — lifecycle, files, screens, and computer use.'
-source: https://docs.orgo.ai
+source: https://docs.orgo.ai/guides/mcp
 
 # Vendor-hosted remote MCP (URL-only — Hermes never spawns a local process for
 # this entry). The server is generated from Orgo's published OpenAPI spec, so
@@ -29,14 +29,24 @@ auth:
       required: true
       secret: true
 
-# Excluded: the template registry — publish/build/delete/version surface (14
-# tools) that belongs to a release pipeline, not to a chat session, and which
-# would otherwise be a third of the tool list for every user. `orgo_wait` is
-# excluded too: the agent already has its own sleep, and a remote round trip to
-# do nothing is strictly worse. Everything not listed stays enabled, including
+# Excluded, in three groups. Everything not listed stays enabled, including
 # tools Orgo adds later.
+#
+#  1. The template registry (15 tools) — publish/build/version/delete. A release
+#     pipeline, not something a chat session reaches for, and otherwise nearly a
+#     third of the tool list for every user.
+#  2. `orgo_wait` — the agent already has its own sleep, and a remote round trip
+#     to do nothing is strictly worse than a local one.
+#  3. `orgo_upload_file` — on the HOSTED transport this one does not do what its
+#     description says. Its `file` argument is an OpenAPI `format: binary` field,
+#     so the server reads that path off the filesystem of whichever process runs
+#     the handler; over https://www.orgo.ai/mcp that is Orgo's own container, not
+#     the caller's machine. Excluding it keeps Hermes users away from a tool that
+#     can only confuse or misfire for them. (Use the stdio server if you want
+#     working uploads — there `readFile` runs on your own box.)
 tools:
   default_excluded:
+    - orgo_upload_file
     - orgo_get_template_schema
     - orgo_list_templates
     - orgo_publish_template
@@ -54,21 +64,32 @@ tools:
     - orgo_stop_template_run
     - orgo_wait
 
-# Composer-suggestion triggers (desktop brand pills).
-suggest:
-  keywords:
-    - orgo
-  hosts:
-    - orgo.ai
+# No `suggest:` block, deliberately. The desktop composer's brand pill routes
+# through a connect path that calls addMcpServer({name, url}) and then
+# completeMcpDesktopOAuth() unconditionally
+# (apps/desktop/src/store/suggestion-providers/mcp.ts), never consulting
+# auth_type and never carrying headers or env. For an api_key entry the only
+# reachable outcomes are an error toast and a rolled-back server, so advertising
+# the pill would be worse than having none.
 
 post_install: |
-  Every tool takes an optional `id` (a computer UUID). Pin a default with the
-  X-Orgo-Default-Computer-Id header if you work on one computer:
+  Restart the session (or run /reload-mcp) so the tools load.
+
+  Finding a computer id: every tool takes an optional `id`. Get one from
+  orgo_list_workspaces — each workspace comes back with its computers embedded.
+  There is no list-computers tool; the workspace listing is the documented way.
+
+  If you work on one computer, pin it as a default so you never pass an id:
 
       hermes config set mcp_servers.orgo.headers.X-Orgo-Default-Computer-Id <uuid>
 
   Note orgo_list_files takes `projectId`, not `workspace_id`.
 
+  This server can run shell commands and delete computers, workspaces, and
+  files. If you would rather approve each write, mark it untrusted — Orgo's
+  server emits readOnlyHint, so reads stay unprompted:
+
+      hermes config set mcp_servers.orgo.trust untrusted
+
   To run Hermes' own shell inside an Orgo computer rather than just managing
-  them, the terminal backend is a separate plugin:
-  https://github.com/OrgoAI/hermes-orgo
+  them over MCP, the terminal backend is a separate plugin (see docs.orgo.ai).

--- a/optional-mcps/orgo/manifest.yaml
+++ b/optional-mcps/orgo/manifest.yaml
@@ -1,0 +1,74 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: orgo
+description: 'Orgo cloud computers: full Linux VMs with a desktop — lifecycle, files, screens, and computer use.'
+source: https://docs.orgo.ai
+
+# Vendor-hosted remote MCP (URL-only — Hermes never spawns a local process for
+# this entry). The server is generated from Orgo's published OpenAPI spec, so
+# the tool list tracks the API rather than a hand-written table.
+#
+# api_key rather than oauth, deliberately. Orgo does serve RFC 9728 / RFC 8414
+# metadata, but its authorization server advertises only the device-code grant
+# and its `registration_endpoint` issues an API key rather than doing RFC 7591
+# Dynamic Client Registration. mcp_oauth_manager's discovery -> DCR -> PKCE
+# flow has nothing to register against, so declaring oauth here would fail at
+# connect time with a confusing error. A bearer key is what the server actually
+# wants; both `Authorization: Bearer` and `X-Orgo-API-Key` are accepted.
+transport:
+  type: http
+  url: https://www.orgo.ai/mcp
+
+auth:
+  type: api_key
+  env:
+    - name: MCP_ORGO_API_KEY
+      prompt: 'Orgo API key (create one at https://www.orgo.ai/account?tab=api-keys)'
+      required: true
+      secret: true
+
+# Excluded: the template registry — publish/build/delete/version surface (14
+# tools) that belongs to a release pipeline, not to a chat session, and which
+# would otherwise be a third of the tool list for every user. `orgo_wait` is
+# excluded too: the agent already has its own sleep, and a remote round trip to
+# do nothing is strictly worse. Everything not listed stays enabled, including
+# tools Orgo adds later.
+tools:
+  default_excluded:
+    - orgo_get_template_schema
+    - orgo_list_templates
+    - orgo_publish_template
+    - orgo_validate_template
+    - orgo_list_curated_templates
+    - orgo_list_curated_template_versions
+    - orgo_list_template_versions
+    - orgo_get_template
+    - orgo_delete_template
+    - orgo_build_template
+    - orgo_get_build_status
+    - orgo_cancel_build
+    - orgo_stream_build_events
+    - orgo_test_run_template
+    - orgo_stop_template_run
+    - orgo_wait
+
+# Composer-suggestion triggers (desktop brand pills).
+suggest:
+  keywords:
+    - orgo
+  hosts:
+    - orgo.ai
+
+post_install: |
+  Every tool takes an optional `id` (a computer UUID). Pin a default with the
+  X-Orgo-Default-Computer-Id header if you work on one computer:
+
+      hermes config set mcp_servers.orgo.headers.X-Orgo-Default-Computer-Id <uuid>
+
+  Note orgo_list_files takes `projectId`, not `workspace_id`.
+
+  To run Hermes' own shell inside an Orgo computer rather than just managing
+  them, the terminal backend is a separate plugin:
+  https://github.com/OrgoAI/hermes-orgo


### PR DESCRIPTION
Adds `optional-mcps/orgo/manifest.yaml`.

[Orgo](https://www.orgo.ai) runs persistent cloud Linux VMs with a real desktop — a filesystem that survives, a browser that stays logged in, and a screen an agent can look at. Its hosted MCP server is generated from the published OpenAPI spec, so the tool list tracks the API rather than a hand-written table that drifts.

```bash
hermes mcp install orgo
```

## Verified live

Against `https://www.orgo.ai/mcp` while writing this:

- `initialize` and `tools/list` succeed **without** a credential — they are served from the bundled spec and touch no socket, so a client can complete the handshake and read the tool list before it has a key. That is what lets the install flow prompt for one.
- An uncredentialed `tools/call` answers `401` with `WWW-Authenticate: Bearer resource_metadata="https://www.orgo.ai/.well-known/oauth-protected-resource"`.
- 48 tools.

## Why `api_key` and not `oauth`

Orgo does serve RFC 9728 protected-resource metadata and RFC 8414 authorization-server metadata, so it looks like an oauth candidate at first glance. It is not one for this catalog:

- `grant_types_supported` is `["urn:ietf:params:oauth:grant-type:device_code"]` — the device-code flow its CLI uses. No authorization-code grant.
- `registration_endpoint` points at `POST /api/keys`, which **issues an API key**. It is not an RFC 7591 Dynamic Client Registration endpoint.

`mcp_oauth_manager`'s discovery → DCR → PKCE path has nothing to register against, so declaring `auth: oauth` would install cleanly and then fail at connect time with an error that points nowhere. A bearer key is what the server actually wants; it accepts both `Authorization: Bearer` and `X-Orgo-API-Key`.

This is the catalog's first `http` + `api_key` entry, so for the record: `_parse_manifest`'s naming contract is satisfied — `auth.env` declares `MCP_ORGO_API_KEY`, which is what `_bearer_auth_headers` references.

## Tool selection

Exclude-mode, so tools Orgo adds later stay enabled.

Excluded are the 15 template-registry tools (`orgo_publish_template`, `orgo_build_template`, `orgo_get_build_status`, the version and curated-listing pairs, …). They are a release-pipeline surface — publish a golden image, poll the build, cut a version — not something a chat session reaches for, and they would otherwise be roughly a third of the tool list for every user.

`orgo_wait` is excluded too: the agent already has its own sleep, and a remote round trip to do nothing is strictly worse than a local one.

What is left is the part that earns its place in a session: workspaces and computers, lifecycle (start/stop/restart/clone/resize/move), files, screens, and computer use (screenshot, click, drag, type, key, scroll, bash, python).

## Checks

Both contract tests in `tests/hermes_cli/test_mcp_catalog.py` pass over the full catalog with this entry added:

- `test_all_shipped_manifests_parse` — 66 manifests parse.
- `test_all_shipped_manifests_are_version_locked` — no `install` block and an `http` transport, so nothing to pin.

## One note for users, in `post_install`

`orgo_list_files` takes `projectId`, not `workspace_id` — an easy 400 to hit otherwise. The note also mentions `X-Orgo-Default-Computer-Id`, which pins a default computer so single-computer users never have to pass an id.

## Not part of this PR

Running Hermes' *own* shell inside an Orgo computer (a `terminal.backend: orgo` provider) is a different thing from managing Orgo over MCP, and per CONTRIBUTING.md's third-party-integration policy it ships as a standalone plugin repo: <https://github.com/OrgoAI/orgo-hermes>. Nothing here depends on it.
