### PR TITLE
fix(auxiliary_client): stop closing in-flight clients on cache key collision (#96491)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -7732,7 +7732,13 @@ def _store_cached_client(cache_key: tuple, client: Any, default_model: Optional[
     with _client_cache_lock:
         old_entry = _client_cache.get(cache_key)
         if old_entry is not None and old_entry[0] is not client:
-            _close_cached_client(old_entry[0])
+            # Do NOT close the old client — another caller may be mid-request
+            # with it (see #96491). Closing an in-flight client tears down its
+            # socket, causing a spurious APIConnectionError on the concurrent
+            # caller. Instead, drop the cache reference and let normal refcount/
+            # GC cleanup happen after in-flight users release it — matching the
+            # eviction policy in _get_cached_client (lines ~8030-8034).
+            pass
         _client_cache[cache_key] = (client, default_model, bound_loop)
 
 


### PR DESCRIPTION
## Summary

Rebase of #96613 onto current `main` (was 41 commits behind, `mergeStateStatus: BLOCKED`).

The original PR had a positive review from @trevorgordon981 but was blocked because it fell behind main. This is a clean cherry-pick with no conflicts — the fix touches only `agent/auxiliary_client.py` (7 lines).

## The Fix

When `_store_cached_client` encounters a cache-key collision, it was calling `.close()` on the previous client — which could tear down a socket another caller was mid-request on. This removes the eager close, letting the old client be garbage-collected naturally when its last reference is released.

Supersedes #96613.