### PR TITLE
Default the in-app tip rotation on

### DIFF
--- a/apps/desktop/src/components/tips/use-tip-rotation.ts
+++ b/apps/desktop/src/components/tips/use-tip-rotation.ts
@@ -2,9 +2,8 @@
  * The rotation's clock: a few minutes into a launch, then hours apart, offer a
  * tip if the app happens to be quiet.
  *
- * Off unless the user turned it on (Settings → Appearance) — this is the half
- * of the feature that talks unprompted, so it is the half that has to be asked
- * for. An agent tip doesn't come through here at all.
+ * On unless the user turned it off (Settings → Appearance). An agent tip
+ * doesn't come through here at all.
  *
  * The pacing is a loading-screen tip's, not a notification's. Two clocks have
  * to agree: a per-launch settling delay, so opening the app is never met with a

--- a/apps/desktop/src/store/tips.ts
+++ b/apps/desktop/src/store/tips.ts
@@ -3,10 +3,10 @@
  *
  * Two sources, one bubble, and only one of them is behind a switch:
  *
- * - `$tipRotationEnabled` is the ambient rotation, OFF until asked for. The app
- *   volunteering commentary at idle is a taste, not a default, and a feature
- *   that talks unprompted has to be opted into rather than discovered and then
- *   switched off.
+ * - `$tipRotationEnabled` is the ambient rotation, ON with a switch to stop it.
+ *   A feature nobody meets is a feature nobody has, and the pacing is what
+ *   earns the default: minutes into a launch at the earliest, then six hours,
+ *   which is a nicety rather than the nag that would owe you an opt-in.
  * - An agent tip is not ambient. Hermes raises one mid-sentence, in a
  *   conversation the user is having, exactly as it raises a `tour` — so it
  *   answers to the same nothing a tour answers to.
@@ -44,7 +44,7 @@ export interface ActiveTip {
   title?: string
 }
 
-export const $tipRotationEnabled = persistentAtom('hermes.desktop.tips.rotation.v1', false, Codecs.bool)
+export const $tipRotationEnabled = persistentAtom('hermes.desktop.tips.rotation.v1', true, Codecs.bool)
 export const $retiredTips = persistentAtom<string[]>('hermes.desktop.tips.retired.v1', [], Codecs.stringArray)
 export const $lastTipId = persistentAtom<null | string>('hermes.desktop.tips.last.v1', null, Codecs.nullableText)
 export const $nextTipAt = persistentAtom<null | number>(

--- a/website/docs/reference/tools-reference.md
+++ b/website/docs/reference/tools-reference.md
@@ -265,14 +265,14 @@ discovery is one call for both, and the durable `data-tour` handles above name
 targets for either. One tip is on screen at a time; a new one replaces the last.
 
 The app can also show its own, walking a built-in catalog of app features in
-order. That half is off until switched on in Settings → Appearance, since it
-talks unprompted, and it is paced like a game's loading-screen tips rather than
-a notification: a few minutes into a launch at the earliest, then at most one
-every six hours, and only at a genuinely idle moment. Closing one of its tips
-with the ✕ retires that tip for good, and the same settings row brings them
-back. The tool is not behind that switch — like `tour`, it runs in answer to the
-conversation rather than at idle. It does share the cooldown, so a tip from
-Hermes also buys the user six hours of quiet from the rotation.
+order. That half is on by default and switched off in Settings → Appearance,
+and it is paced like a game's loading-screen tips rather than a notification: a
+few minutes into a launch at the earliest, then at most one every six hours, and
+only at a genuinely idle moment. Closing one of its tips with the ✕ retires that
+tip for good, and the same settings row brings them back. The tool is not behind
+that switch — like `tour`, it runs in answer to the conversation rather than at
+idle. It does share the cooldown, so a tip from Hermes also buys the user six
+hours of quiet from the rotation.
 
 ## `todo` toolset
 


### PR DESCRIPTION
The rotation shipped opt-in, from back when it fired a tip 45 seconds into a
launch and another every six minutes. That is a cadence that owes you a choice.

The pacing changed before merge and the switch never caught up: it is now a
settling delay of five to ten minutes per launch plus a six-hour cooldown
persisted across them, so it lands around one tip a day and takes weeks to walk
the catalog. At that weight there is nothing left for an opt-in to protect
anyone from, and a discovery feature nobody meets is one nobody has.

Settings → Appearance → In-App Tips still turns it off, and the ✕ still retires
a tip for good. The `tip` tool is unaffected — it was never behind this switch.

## Test plan

- [x] `npx prettier --check` and `npx eslint` on the touched files
- [ ] Fresh profile shows a tip a few minutes in; the switch still stops it