### PR TITLE
fix(desktop): make narrow sidebars click-only

### DIFF
--- a/apps/desktop/src/app/layout-constants.ts
+++ b/apps/desktop/src/app/layout-constants.ts
@@ -19,7 +19,7 @@ export const PAGE_INSET_NEG_X = '-mx-[clamp(1.25rem,4vw,4rem)]'
 export const PAGE_MAX_W = 'max-w-[75rem]'
 
 // Below this viewport width a docked sidebar leaves no room for content, so both
-// rails auto-collapse into the hover-reveal overlay. Single source of truth for
+// rails auto-collapse into explicitly toggled overlays. Single source of truth for
 // the responsive collapse point.
 export const SIDEBAR_COLLAPSE_BREAKPOINT_PX = 768
 export const SIDEBAR_COLLAPSE_MEDIA_QUERY = `(max-width: ${SIDEBAR_COLLAPSE_BREAKPOINT_PX}px)`

--- a/apps/desktop/src/components/pane-shell/tree/renderer/narrow-overlays.test.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/narrow-overlays.test.tsx
@@ -59,9 +59,20 @@ const revealPane = (id: string) => {
   })
 }
 
-const overlayTab = (paneId: string) => document.querySelector<HTMLElement>(`[data-narrow-overlay-tab="${paneId}"]`)
+const overlayTab = (paneId: string) => window.document.querySelector<HTMLElement>(`[data-narrow-overlay-tab="${paneId}"]`)
 
 describe('narrow overlay of a stacked zone', () => {
+  it('stays closed when the pointer merely crosses a viewport edge', () => {
+    const { container, queryByTestId } = render(<NarrowOverlays />)
+    const edge = container.querySelector<HTMLElement>('.w-1\\.5')
+
+    if (edge) {
+      fireEvent.mouseEnter(edge)
+    }
+
+    expect(queryByTestId('sessions-body')).toBeNull()
+  })
+
   it('mirrors the zone tab strip so every stacked collapsible stays reachable', () => {
     const { getByTestId, queryByTestId } = render(<NarrowOverlays />)
 

--- a/apps/desktop/src/components/pane-shell/tree/renderer/narrow-overlays.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/narrow-overlays.tsx
@@ -1,9 +1,8 @@
 /**
- * Narrow-viewport edge overlays — the tree's take on the app's hover-reveal
+ * Narrow-viewport edge overlays — the tree's take on the app's explicit reveal
  * collapse. Collapsible panes leave the grid below the sidebar-collapse
- * breakpoint; an edge strip (hover) or PANE_TOGGLE_REVEAL_EVENT (⌘B / ⌘G /
- * titlebar toggles route here on narrow) slides the pane OVER the layout
- * instead of squeezing it. Event reveals pin; hover reveals follow the mouse.
+ * breakpoint; PANE_TOGGLE_REVEAL_EVENT (⌘B / ⌘G / titlebar toggles route here
+ * on narrow) slides the pane OVER the layout instead of squeezing it.
  */
 
 import { useStore } from '@nanostores/react'
@@ -43,6 +42,8 @@ export function NarrowOverlays() {
 
   const collapsiblesRef = useRef(collapsibles)
   collapsiblesRef.current = collapsibles
+  const panesRef = useRef(panes)
+  panesRef.current = panes
 
   // ⌘B / ⌘G's narrow branch dispatches the app's toggle-reveal event with the
   // REAL pane id — accept those via each contribution's revealAliases.
@@ -61,7 +62,13 @@ export function NarrowOverlays() {
         return
       }
 
-      const match = collapsiblesRef.current.find(p => p.id === id || paneChrome(p).revealAliases?.includes(id))
+      // Match the registry, not only the previous render's in-tree list. An
+      // explicit reveal can re-adopt/unhide a pane and dispatch its alias in
+      // the same event turn; the next render then promotes it into
+      // `collapsibles` and paints the already-recorded reveal.
+      const match = panesRef.current.find(
+        p => paneChrome(p).collapsible && (p.id === id || paneChrome(p).revealAliases?.includes(id))
+      )
 
       if (!match) {
         return
@@ -107,7 +114,6 @@ export function NarrowOverlays() {
 
   const sideOf = (c: Contribution) => (paneChrome(c).placement === 'left' ? 'left' : 'right')
   const revealed = reveal ? collapsibles.find(p => p.id === reveal.id) : undefined
-  const sides = [...new Set(collapsibles.map(sideOf))]
 
   // The revealed pane's ZONE-mates that also left the grid (the sessions zone
   // stacks SESSIONS | BOTS): the overlay mirrors the zone's tab strip so a
@@ -127,21 +133,6 @@ export function NarrowOverlays() {
 
   return (
     <>
-      {/* Hover-intent strips on each edge that has a collapsed pane. */}
-      {sides.map(side => (
-        <div
-          className={cn('absolute inset-y-0 z-30 w-1.5', side === 'left' ? 'left-0' : 'right-0')}
-          key={side}
-          onMouseEnter={() => {
-            const first = collapsibles.find(p => sideOf(p) === side)
-
-            if (first) {
-              setReveal(current => (current?.pinned ? current : { id: first.id, pinned: false }))
-            }
-          }}
-        />
-      ))}
-
       {revealed && (
         <div
           className={cn(

--- a/apps/desktop/src/components/pane-shell/tree/store.ts
+++ b/apps/desktop/src/components/pane-shell/tree/store.ts
@@ -1043,6 +1043,16 @@ export function revealTreePane(paneId: string) {
     adoptContributedPanes()
   }
 
+  // A migrated/custom tree can be missing a registered pane without carrying
+  // an explicit dismissal record. An explicit reveal must still be able to
+  // restore it; use the same adoption policy as boot (which continues to
+  // respect every intentionally dismissed pane).
+  const beforeAdoption = $layoutTree.get()
+
+  if (beforeAdoption && !findGroupOfPane(beforeAdoption, paneId)) {
+    adoptContributedPanes()
+  }
+
   // Reveal beats a hide too: clear the persisted hide-only record, or the
   // pane pops back hidden on the next launch even though it's on screen now.
   if ($hiddenStripTabs.get().has(paneId)) {

--- a/apps/desktop/src/components/pane-shell/tree/tool-pane-toggle.test.ts
+++ b/apps/desktop/src/components/pane-shell/tree/tool-pane-toggle.test.ts
@@ -90,6 +90,17 @@ const stackTree = (options?: { active?: string; tabStrip?: 'always' | 'never' })
   )
 }
 
+describe('revealing a contributed pane missing from a custom layout', () => {
+  it('re-adopts the pane before trying to show it', () => {
+    $layoutTree.set(group(['workspace'], { active: 'workspace', id: 'grp-main' }))
+
+    revealTreePane('files')
+
+    expect(allPaneIds($layoutTree.get()!)).toContain('files')
+    expect(isPaneVisible('files')).toBe(true)
+  })
+})
+
 describe('binding a tool panel on boot', () => {
   it('does not front itself over the tab the persisted tree had active', () => {
     stackTree({ active: 'terminal' })

--- a/apps/desktop/src/store/layout.ts
+++ b/apps/desktop/src/store/layout.ts
@@ -480,7 +480,7 @@ export function setSidebarWidth(width: number) {
 }
 
 // Below the collapse breakpoint a collapsible rail leaves the grid and lives as
-// a hover/pin overlay, so open/toggle must route through the reveal event — the
+// a pinned overlay, so open/toggle must route through the reveal event — the
 // docked `open` flag renders a 0px track invisibly. Centralised here so every
 // caller (titlebar, keybinds, session-search, reveal-file) inherits it instead
 // of re-deriving the narrow branch. Returns true when it handled the intent.
@@ -506,7 +506,13 @@ export function toggleSidebarOpen() {
 }
 
 export function toggleFileBrowserOpen() {
-  if (revealNarrowPane(FILE_BROWSER_PANE_ID, 'toggle')) {
+  if (typeof window !== 'undefined' && matchesQuery(SIDEBAR_COLLAPSE_MEDIA_QUERY)) {
+    // A custom/migrated layout may not currently contain the Files pane. Put
+    // it back before firing the overlay intent; NarrowOverlays accepts the
+    // alias during this same render transition.
+    revealTreePane(FILES_PANE_ID)
+    revealNarrowPane(FILE_BROWSER_PANE_ID, 'toggle')
+
     return
   }
 


### PR DESCRIPTION
## Summary

On narrow desktop windows, collapsible sidebars currently reveal whenever the pointer reaches the corresponding window edge. This is disruptive when Hermes occupies only part of the screen because ordinary pointer movement repeatedly covers the chat and composer with Sessions/Bots or Files/Review.

This change makes narrow-viewport overlays explicitly controlled:

- pointer movement across either window edge no longer opens a sidebar;
- the left titlebar control continues to open and close Sessions/Bots;
- the right titlebar control opens and closes Files/Review;
- keyboard and programmatic pane-reveal events continue to work;
- explicitly opening a pane restores it when a migrated or custom layout does not currently contain it.

## Problem

Below the sidebar-collapse breakpoint, collapsible sidebars leave the normal pane grid and are rendered as overlays.

The renderer previously installed pointer-sensitive strips along both window edges. Hovering those strips revealed the corresponding overlay, making accidental activation common in narrow, non-full-screen windows.

Removing the hover strips exposed a related problem in the explicit right-side toggle path: a migrated or customised layout could omit the registered Files pane without recording it as intentionally dismissed. The toolbar then dispatched a reveal event, but no in-tree pane existed to render.

## Changes

- Remove narrow-window edge-hover reveal strips.
- Preserve `PANE_TOGGLE_REVEAL_EVENT` as the explicit overlay-control path.
- Re-adopt a registered pane when an explicit reveal targets a pane missing from a custom or migrated layout.
- Ensure the Files toolbar toggle restores the Files pane before dispatching the narrow-overlay event.
- Allow the overlay listener to recognise a registered collapsible pane during the same adoption/render transition.
- Update comments describing narrow-window behavior.
- Add regression tests for pointer-edge crossing and explicit reveal of a missing contributed pane.

## Behavioral contract

| Interaction | Expected result |
|---|---|
| Hover at extreme left edge | Nothing opens |
| Hover at extreme right edge | Nothing opens |
| Click left sidebar control | Sessions/Bots opens or closes |
| Click right sidebar control | Files/Review opens or closes |
| Explicitly reveal a missing registered pane | Pane is restored and shown |
| Press Escape while an overlay is active | Overlay closes under the existing Escape-layer rules |

## Test plan

- [x] Targeted narrow-overlay and tool-pane tests passed
- [x] Complete desktop UI suite: 6,115 tests passed
- [x] TypeScript checking passed
- [x] ESLint passed with no warnings
- [x] Packaged macOS application passed strict signature verification
- [x] Manual narrow-window verification on macOS: neither edge opens on hover; both toolbar controls open and close their overlays
