### PR TITLE
Make the tips/tours switches reach the agent

### DIFF
--- a/apps/desktop/src/store/display-toggles.test.ts
+++ b/apps/desktop/src/store/display-toggles.test.ts
@@ -2,7 +2,7 @@ import { atom } from 'nanostores'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const $gateway = atom<unknown>(null)
-const request = vi.fn(async () => undefined)
+const request = vi.fn(async (_method: string, _params?: Record<string, unknown>) => undefined)
 
 vi.mock('@/store/gateway', () => ({
   $gateway,

--- a/apps/desktop/src/store/display-toggles.test.ts
+++ b/apps/desktop/src/store/display-toggles.test.ts
@@ -1,0 +1,51 @@
+import { atom } from 'nanostores'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const $gateway = atom<unknown>(null)
+const request = vi.fn(async () => undefined)
+
+vi.mock('@/store/gateway', () => ({
+  $gateway,
+  activeGateway: () => ({ request })
+}))
+
+const { mirrorDisplayToggle } = await import('./display-toggles')
+
+const STORAGE_KEY = 'hermes.desktop.test-toggle.v1'
+
+const $enabled = atom(true)
+
+mirrorDisplayToggle('display.test_toggle', STORAGE_KEY, $enabled)
+
+const sets = () => request.mock.calls.filter(([method]) => method === 'config.set').map(([, params]) => params)
+
+beforeEach(() => {
+  localStorage.clear()
+  request.mockClear()
+  $enabled.set(true)
+  request.mockClear()
+})
+
+describe('display toggle mirror', () => {
+  it('sends the user answer to the gateway when it changes', () => {
+    $enabled.set(false)
+
+    expect(sets()).toEqual([{ key: 'display.test_toggle', value: 'false' }])
+  })
+
+  it('re-sends a touched setting to a gateway that has never seen it', () => {
+    localStorage.setItem(STORAGE_KEY, 'false')
+    $enabled.set(false)
+    request.mockClear()
+
+    $gateway.set({})
+
+    expect(sets()).toEqual([{ key: 'display.test_toggle', value: 'false' }])
+  })
+
+  it('leaves an untouched setting alone, so a hand-edited config.yaml wins', () => {
+    $gateway.set({})
+
+    expect(sets()).toEqual([])
+  })
+})

--- a/apps/desktop/src/store/display-toggles.ts
+++ b/apps/desktop/src/store/display-toggles.ts
@@ -1,0 +1,68 @@
+/**
+ * Appearance switches the BACKEND also has to know about.
+ *
+ * Most of what Settings → Appearance controls is the renderer's own business.
+ * A few switches aren't: they decide whether a tool is in the model's schema at
+ * all (`react_to_message`, `tip`, `tour`), and that decision is made where the
+ * agent runs. So the value has to travel to whichever gateway the app is
+ * actually talking to — local, SSH, plain URL, or cloud — which is why this is
+ * `config.set` on the live connection and not an env var on some process.
+ *
+ * Two moments matter, and shipping only the first is why the reactions toggle
+ * has never worked end to end:
+ *
+ * - **On change**, because that is the user answering.
+ * - **On connect**, because a gateway the app has never spoken to holds no
+ *   answer at all — and for a switch that defaults ON, silence reads as consent
+ *   to exactly the thing the user turned off.
+ *
+ * The connect push is deliberately narrow: only settings the user has actually
+ * touched (a stored value exists) are re-sent. Otherwise a fresh install would
+ * broadcast its defaults over a `config.yaml` somebody hand-edited on the
+ * server, which is a worse failure than the one being fixed.
+ */
+
+import type { ReadableAtom } from 'nanostores'
+
+import { readKey } from '@/lib/storage'
+import { $gateway, activeGateway } from '@/store/gateway'
+
+interface Mirror {
+  configKey: string
+  read: () => boolean
+  storageKey: string
+}
+
+const mirrors: Mirror[] = []
+
+function push(mirror: Mirror): void {
+  void activeGateway()
+    ?.request('config.set', { key: mirror.configKey, value: mirror.read() ? 'true' : 'false' })
+    .catch(() => {
+      // Not connected, or a gateway too old to know the key. The next toggle
+      // and the next connection both try again.
+    })
+}
+
+/** Keep `display.<configKey>` on the live gateway in step with a renderer atom. */
+export function mirrorDisplayToggle(configKey: string, storageKey: string, $enabled: ReadableAtom<boolean>): void {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  const mirror: Mirror = { configKey, read: () => $enabled.get(), storageKey }
+
+  mirrors.push(mirror)
+  // listen, not subscribe: fire on CHANGE only. Module init must not write.
+  $enabled.listen(() => push(mirror))
+}
+
+if (typeof window !== 'undefined') {
+  $gateway.listen(() => {
+    for (const mirror of mirrors) {
+      if (readKey(mirror.storageKey) !== null) {
+        push(mirror)
+      }
+    }
+  })
+}

--- a/apps/desktop/src/store/reactions-enabled.ts
+++ b/apps/desktop/src/store/reactions-enabled.ts
@@ -13,7 +13,7 @@
 import { atom } from 'nanostores'
 
 import { persistString, storedString } from '@/lib/storage'
-import { activeGateway } from '@/store/gateway'
+import { mirrorDisplayToggle } from '@/store/display-toggles'
 
 const KEY = 'hermes.desktop.reactions.v1'
 
@@ -24,17 +24,9 @@ export function setReactionsEnabled(enabled: boolean): void {
 }
 
 if (typeof window !== 'undefined') {
-  // listen, not subscribe: fire on CHANGE only, so app startup doesn't write
-  // config.set (or clobber a profile's setting with another window's default).
-  $reactionsEnabled.listen(enabled => {
-    persistString(KEY, enabled ? 'on' : 'off')
-    // Mirror into gateway config: the backend gates the agent's
-    // react_to_message tool and the model-context annotation on
-    // display.message_reactions, so the renderer toggle is the one lever.
-    void activeGateway()
-      ?.request('config.set', { key: 'display.message_reactions', value: enabled ? 'true' : 'false' })
-      .catch(() => {
-        // Not connected yet — the next toggle (or default-off) still holds.
-      })
-  })
+  $reactionsEnabled.listen(enabled => persistString(KEY, enabled ? 'on' : 'off'))
 }
+
+// The backend gates the agent's react_to_message tool and the model-context
+// annotation on display.message_reactions, so this toggle is the one lever.
+mirrorDisplayToggle('display.message_reactions', KEY, $reactionsEnabled)

--- a/apps/desktop/src/store/tips.ts
+++ b/apps/desktop/src/store/tips.ts
@@ -8,8 +8,9 @@
  *   default: minutes into a launch at the earliest, then six hours, which is a
  *   nicety rather than the nag that would owe you an opt-in.
  * - It covers Hermes too. "Off" from someone who has just closed a bubble means
- *   no bubbles, not "no bubbles unless the agent sends one", so an agent tip is
- *   dropped at the bridge like a rotation tip is skipped here.
+ *   no bubbles, not "no bubbles unless the agent sends one" — so the switch is
+ *   mirrored to the gateway, where it takes the `tip` tool out of the model's
+ *   schema, and the bridge drops a stray tip on top of that.
  * - `$retiredTips` is the hard-close ledger for the rotation. A tip the user ✕'d
  *   never comes back on its own; Settings → Reset is the only way, and that is
  *   the whole contract behind the ✕ being a heavier gesture than letting the
@@ -26,6 +27,7 @@ import { atom } from 'nanostores'
 
 import { Codecs, persistentAtom } from '@/lib/persisted'
 import type { TipSide } from '@/lib/tips/catalog'
+import { mirrorDisplayToggle } from '@/store/display-toggles'
 
 /** Hours, not minutes. The catalog is ten tips and it should take weeks. */
 const COOLDOWN_MS = 6 * 60 * 60_000
@@ -47,7 +49,9 @@ export interface ActiveTip {
 // Key still says `rotation` from when the switch only covered that half.
 // Renaming it would read as unset for anyone who had already turned tips off,
 // and silently turning them back on is the one outcome worth avoiding here.
-export const $tipsEnabled = persistentAtom('hermes.desktop.tips.rotation.v1', true, Codecs.bool)
+const ENABLED_KEY = 'hermes.desktop.tips.rotation.v1'
+
+export const $tipsEnabled = persistentAtom(ENABLED_KEY, true, Codecs.bool)
 export const $retiredTips = persistentAtom<string[]>('hermes.desktop.tips.retired.v1', [], Codecs.stringArray)
 export const $lastTipId = persistentAtom<null | string>('hermes.desktop.tips.last.v1', null, Codecs.nullableText)
 export const $nextTipAt = persistentAtom<null | number>(
@@ -56,6 +60,10 @@ export const $nextTipAt = persistentAtom<null | number>(
   Codecs.json(value => (typeof value === 'number' && Number.isFinite(value) ? value : null))
 )
 export const $activeTip = atom<ActiveTip | null>(null)
+
+// Off has to reach the agent, not just the renderer: the `tip` tool leaves the
+// model's schema entirely rather than staying on offer and being dropped.
+mirrorDisplayToggle('display.in_app_tips', ENABLED_KEY, $tipsEnabled)
 
 export function setTipsEnabled(enabled: boolean): void {
   if (!enabled) {

--- a/apps/desktop/src/store/tours.ts
+++ b/apps/desktop/src/store/tours.ts
@@ -12,8 +12,15 @@
  */
 
 import { Codecs, persistentAtom } from '@/lib/persisted'
+import { mirrorDisplayToggle } from '@/store/display-toggles'
 
-export const $toursEnabled = persistentAtom('hermes.desktop.tours.v1', true, Codecs.bool)
+const KEY = 'hermes.desktop.tours.v1'
+
+export const $toursEnabled = persistentAtom(KEY, true, Codecs.bool)
+
+// Off has to reach the agent, not just the renderer: the `tour` tool leaves the
+// model's schema entirely rather than staying on offer and failing.
+mirrorDisplayToggle('display.in_app_tours', KEY, $toursEnabled)
 
 export function setToursEnabled(enabled: boolean): void {
   $toursEnabled.set(enabled)

--- a/tests/tools/test_display_toggles.py
+++ b/tests/tools/test_display_toggles.py
@@ -1,0 +1,63 @@
+"""The desktop's Appearance switches, as the AGENT experiences them.
+
+Each of these toggles decides whether a tool is in the model's schema at all,
+so the contract under test is end to end: a real ``config.yaml`` in a temp
+``HERMES_HOME``, read through the real config loader, answering a real
+``check_fn``. Mocking the loader here would test nothing that matters — the
+whole failure this guards against was a value that never reached the config.
+"""
+
+import textwrap
+
+import pytest
+
+from hermes_constants import get_hermes_home
+from tools import desktop_ui
+from tools.react_to_message_tool import check_react_requirements
+from tools.tip_tool import check_tips_enabled
+from tools.tour_tool import check_tours_enabled
+
+
+@pytest.fixture
+def display_config():
+    """Write a ``display:`` section into this test's HERMES_HOME."""
+
+    def _write(**flags: bool) -> None:
+        home = get_hermes_home()
+        home.mkdir(parents=True, exist_ok=True)
+        body = "".join(f"  {name}: {str(on).lower()}\n" for name, on in flags.items())
+        (home / "config.yaml").write_text(textwrap.dedent("display:\n") + body)
+
+    return _write
+
+
+def test_a_missing_setting_leaves_the_feature_at_its_default():
+    """Absence is not an answer: an opt-out feature stays on, opt-in stays off."""
+    assert desktop_ui.user_enabled("in_app_tips", default=True) is True
+    assert desktop_ui.user_enabled("message_reactions", default=False) is False
+
+
+def test_the_users_answer_wins_in_both_directions(display_config):
+    display_config(in_app_tips=False, message_reactions=True)
+
+    assert desktop_ui.user_enabled("in_app_tips", default=True) is False
+    assert desktop_ui.user_enabled("message_reactions", default=False) is True
+
+
+@pytest.mark.parametrize(
+    ("setting", "check", "default_on"),
+    [
+        ("in_app_tips", check_tips_enabled, True),
+        ("in_app_tours", check_tours_enabled, True),
+        ("message_reactions", check_react_requirements, False),
+    ],
+)
+def test_switching_a_feature_off_withdraws_its_tool(display_config, setting, check, default_on):
+    """The point of the mirror: off means the model is never told it exists."""
+    assert check() is default_on
+
+    display_config(**{setting: False})
+    assert check() is False
+
+    display_config(**{setting: True})
+    assert check() is True

--- a/tests/tools/test_tip_tool.py
+++ b/tests/tools/test_tip_tool.py
@@ -30,12 +30,13 @@ def test_lives_in_the_gui_surface_toolset(monkeypatch):
     assert entry.toolset == "desktop_ui"
 
 
-def test_is_ungated_like_tour():
-    """The Appearance switch governs the app's idle rotation, not this."""
+def test_answers_to_the_appearance_switch():
+    """Tips off has to mean the model never sees the tool. See
+    tests/tools/test_display_toggles.py for the config end of it."""
     entry = registry.get_entry("tip")
 
     assert entry is not None
-    assert entry.check_fn is None
+    assert entry.check_fn is tt.check_tips_enabled
 
 
 def test_requires_the_desktop_bridge(monkeypatch):

--- a/tests/tools/test_tour_tool.py
+++ b/tests/tools/test_tour_tool.py
@@ -18,7 +18,15 @@ def test_lives_in_the_gui_surface_toolset(monkeypatch):
 
     assert entry is not None
     assert entry.toolset == "desktop_ui"
-    assert entry.check_fn is None
+
+
+def test_answers_to_the_appearance_switch():
+    """Tours off has to mean the model never sees the tool. See
+    tests/tools/test_display_toggles.py for the config end of it."""
+    entry = registry.get_entry("tour")
+
+    assert entry is not None
+    assert entry.check_fn is tt.check_tours_enabled
 
 
 def test_requires_callback():

--- a/tests/tui_gateway/test_config_set_display_toggles.py
+++ b/tests/tui_gateway/test_config_set_display_toggles.py
@@ -1,0 +1,56 @@
+"""`config.set` has to accept the Appearance switches the desktop mirrors.
+
+The handler matches an explicit key list and answers 4002 for everything else,
+so a renderer mirroring an unlisted key writes nothing at all — and the
+renderer's `.catch()` swallows the refusal, which is how message reactions
+shipped with a toggle that never reached the backend gating the tool.
+"""
+
+import pytest
+import yaml
+
+from tui_gateway import server
+
+
+@pytest.fixture
+def config_home(tmp_path, monkeypatch):
+    """Point the server's config read/write at a temp file."""
+    monkeypatch.setattr(server, "_hermes_home", tmp_path)
+    server._cfg_cache = server._cfg_mtime = server._cfg_path = None
+    yield tmp_path / "config.yaml"
+    server._cfg_cache = server._cfg_mtime = server._cfg_path = None
+
+
+def _set(key, value):
+    return server._methods["config.set"](1, {"key": key, "value": value})
+
+
+@pytest.mark.parametrize("key", sorted(server._DISPLAY_TOGGLE_KEYS))
+def test_a_mirrored_switch_reaches_the_config_file(config_home, key):
+    """Both directions land on disk, where the tools' check_fn reads them."""
+    assert _set(key, "false")["result"] == {"key": key, "value": False}
+
+    section, name = key.split(".")
+    assert yaml.safe_load(config_home.read_text())[section][name] is False
+
+    assert _set(key, "true")["result"] == {"key": key, "value": True}
+    assert yaml.safe_load(config_home.read_text())[section][name] is True
+
+
+def test_a_non_boolean_is_refused_rather_than_written(config_home):
+    answer = _set("display.in_app_tips", "sometimes")
+
+    assert answer["error"]["code"] == 4002
+    assert not config_home.exists()
+
+
+def test_every_key_the_renderer_mirrors_is_listed():
+    """The list is the contract: a switch missing from it silently does nothing.
+
+    Kept as a relationship rather than a snapshot — it asserts that the tools
+    which gate on `display.<x>` all have `<x>` reachable through config.set,
+    not that the set has some particular size.
+    """
+    gated = {"display.message_reactions", "display.in_app_tips", "display.in_app_tours"}
+
+    assert gated <= server._DISPLAY_TOGGLE_KEYS

--- a/tools/desktop_ui.py
+++ b/tools/desktop_ui.py
@@ -29,6 +29,30 @@ def available() -> bool:
     return _emit is not None
 
 
+def user_enabled(setting: str, default: bool) -> bool:
+    """Read one of the desktop's Appearance switches from ``display.<setting>``.
+
+    The renderer owns these toggles and mirrors them onto the CONNECTED
+    gateway's config (``config.set``), so this reads the user's real answer
+    whether that gateway is local, SSH, URL, or cloud — where an env var would
+    only ever describe the process. Tool ``check_fn``s call it to withdraw
+    themselves from the schema when the user has switched the feature off:
+    Hermes should not be told about a surface it isn't allowed to use.
+
+    An unreadable config falls back to ``default``, which is how a feature that
+    ships on stays on rather than disappearing on a transient read error.
+    """
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        display = load_config_readonly().get("display")
+    except Exception:
+        return default
+    if not isinstance(display, dict) or setting not in display:
+        return default
+    return bool(display.get(setting))
+
+
 def emit(event: str, payload: dict) -> bool:
     """Route ``event`` to the window that owns the current turn.
 

--- a/tools/react_to_message_tool.py
+++ b/tools/react_to_message_tool.py
@@ -120,17 +120,9 @@ def check_react_requirements() -> bool:
     """Opt-in feature flag — surface eligibility is the toolset's job.
 
     ``desktop_ui`` already restricts this to GUI sessions. What's left is the
-    user's own toggle (Settings → Appearance), which the desktop mirrors into
-    ``display.message_reactions`` on the CONNECTED gateway's config — so this
-    reads the right config whether that gateway is local, SSH, URL, or cloud.
+    user's own toggle (Settings → Appearance).
     """
-    try:
-        from hermes_cli.config import load_config_readonly
-
-        display = load_config_readonly().get("display")
-    except Exception:
-        return False
-    return isinstance(display, dict) and bool(display.get("message_reactions", False))
+    return desktop_ui.user_enabled("message_reactions", default=False)
 
 
 REACT_TO_MESSAGE_SCHEMA = {

--- a/tools/tip_tool.py
+++ b/tools/tip_tool.py
@@ -10,12 +10,11 @@ sentence.
 Fire-and-forget, unlike ``tour``: a tip is not a question, so blocking the turn
 on a round-trip would stall the reply it belongs to.
 
-Ungated, also like ``tour``. The desktop's Settings → Appearance switch governs
-the app's own idle rotation — the half that talks unprompted — not this, which
-Hermes raises mid-conversation in answer to something the user said.
-
 Lives in the ``desktop_ui`` toolset, which the GUI gateway enables only for
-desktop-sourced sessions.
+desktop-sourced sessions, and withdraws itself entirely when the user has
+turned tips off (Settings → Appearance). Off means the model is never told the
+tool exists — a switch that only made the call fail would leave Hermes
+promising to point at things it cannot point at.
 """
 
 import json
@@ -95,6 +94,11 @@ TIP_SCHEMA = {
 }
 
 
+def check_tips_enabled() -> bool:
+    """The user's Settings → Appearance switch. On unless they turned it off."""
+    return desktop_ui.user_enabled("in_app_tips", default=True)
+
+
 registry.register(
     name="tip",
     toolset="desktop_ui",
@@ -105,5 +109,6 @@ registry.register(
         title=args.get("title", ""),
         side=args.get("side", ""),
     ),
+    check_fn=check_tips_enabled,
     emoji="💡",
 )

--- a/tools/tour_tool.py
+++ b/tools/tour_tool.py
@@ -19,12 +19,16 @@ outcome, so the agent knows whether the selector matched. This module is just
 schema + a thin dispatcher over the platform-injected callback.
 
 Lives in the ``desktop_ui`` toolset, which the GUI gateway enables only for
-desktop-sourced sessions.
+desktop-sourced sessions, and withdraws itself when the user has switched tours
+off (Settings → Appearance). A tour takes the whole screen, so "no thanks" has
+to mean the model is never told the tool exists — a switch that only made the
+call fail would leave Hermes offering walkthroughs it cannot give.
 """
 
 import json
 from typing import Callable, Optional
 
+from tools import desktop_ui
 from tools.registry import registry, tool_error
 
 ACTIONS = ("targets", "show", "start", "next", "prev", "stop")
@@ -179,6 +183,11 @@ TOUR_SCHEMA = {
 }
 
 
+def check_tours_enabled() -> bool:
+    """The user's Settings → Appearance switch. On unless they turned it off."""
+    return desktop_ui.user_enabled("in_app_tours", default=True)
+
+
 registry.register(
     name="tour",
     toolset="desktop_ui",
@@ -194,5 +203,6 @@ registry.register(
         step_index=args.get("step_index"),
         callback=kw.get("callback"),
     ),
+    check_fn=check_tours_enabled,
     emoji="🧭",
 )

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5838,6 +5838,34 @@ def _write_config_key(key_path: str, value):
 _STATUSBAR_MODES = frozenset({"off", "top", "bottom"})
 _APPROVAL_MODES = frozenset({"manual", "smart", "off"})
 
+# Appearance switches the desktop renderer owns but the AGENT has to see: each
+# one gates a tool's `check_fn`, so the toggle has to reach the config of
+# whichever gateway the app is actually talking to — local, SSH, URL, or cloud.
+#
+# `config.set` matches an explicit key list and answers 4002 for anything else,
+# so a renderer mirroring a key that is not listed here writes nothing at all.
+# That is not hypothetical: the reactions toggle shipped mirroring
+# `display.message_reactions`, every write was rejected into a swallowed
+# `.catch()`, and `react_to_message` therefore stayed dark no matter what the
+# user picked. Adding a mirrored switch to the renderer means adding it here.
+_DISPLAY_TOGGLE_KEYS = frozenset(
+    {
+        "display.message_reactions",
+        "display.in_app_tips",
+        "display.in_app_tours",
+    }
+)
+_BOOL_WORDS = {
+    "1": True,
+    "on": True,
+    "true": True,
+    "yes": True,
+    "0": False,
+    "off": False,
+    "false": False,
+    "no": False,
+}
+
 
 def _load_approval_mode() -> str:
     """Resolve the effective ``approvals.mode`` for the TUI surface.
@@ -14882,6 +14910,13 @@ def _(rid, params: dict) -> dict:
             return _ok(rid, resp)
         except Exception as e:
             return _err(rid, 5001, str(e))
+
+    if key in _DISPLAY_TOGGLE_KEYS:
+        on = _BOOL_WORDS.get(str(value).strip().lower())
+        if on is None:
+            return _err(rid, 4002, f"{key} takes true or false")
+        _write_config_key(key, on)
+        return _ok(rid, {"key": key, "value": on})
 
     return _err(rid, 4002, f"unknown config key: {key}")
 

--- a/website/docs/reference/tools-reference.md
+++ b/website/docs/reference/tools-reference.md
@@ -265,14 +265,19 @@ discovery is one call for both, and the durable `data-tour` handles above name
 targets for either. One tip is on screen at a time; a new one replaces the last.
 
 The app can also show its own, walking a built-in catalog of app features in
-order. That half is on by default and switched off in Settings → Appearance,
-and it is paced like a game's loading-screen tips rather than a notification: a
-few minutes into a launch at the earliest, then at most one every six hours, and
-only at a genuinely idle moment. Closing one of its tips with the ✕ retires that
-tip for good, and the same settings row brings them back. The tool is not behind
-that switch — like `tour`, it runs in answer to the conversation rather than at
-idle. It does share the cooldown, so a tip from Hermes also buys the user six
-hours of quiet from the rotation.
+order, paced like a game's loading-screen tips rather than a notification: a few
+minutes into a launch at the earliest, then at most one every six hours, and
+only at a genuinely idle moment. A tip from Hermes shares that cooldown, so it
+also buys the user six hours of quiet from the rotation. Closing a rotation tip
+with the ✕ retires that tip for good, and the settings row brings them back.
+
+Both tips and tours are on by default and switched off in Settings → Appearance
+(`display.in_app_tips`, `display.in_app_tours`). Off covers Hermes as well as
+the app: the switch reaches the connected gateway's config and the tool leaves
+the model's schema, so the agent is never told about a surface it isn't allowed
+to use. Like every schema change, that lands on the next session — a running
+conversation keeps the toolset it started with, and the app declines the call in
+the meantime.
 
 ## `todo` toolset
 


### PR DESCRIPTION
Follow-up to [#96835](https://github.com/NousResearch/hermes-agent/pull/96835),
which added the tips and tours switches but stopped at the app's edge: the `tip`
and `tour` tools stay in the model's schema and their calls simply don't land.
This finishes the thought — off means the model is never told the tool exists,
so Hermes doesn't offer a walkthrough it can't give.

Getting there turned up a bug that predates any of this. `config.set` matches an
explicit key list and answers 4002 for anything else, so the renderer's
`display.message_reactions` mirror has never written anything: every attempt was
refused into a swallowed `.catch()`, and `react_to_message` stayed out of the
schema no matter what the user picked. Reactions work again as a side effect of
making tips and tours work at all.

## What's here

1. **`config.set` recognizes the display booleans.** They're a named group now,
   because a mirrored switch that isn't listed there is a no-op.
2. **`tip` and `tour` gate on the switch** via a shared
   `desktop_ui.user_enabled`, which is the reactions `check_fn` generalized.
   It reads config rather than an env var for the usual reason: the switch
   belongs to the session's client, and the client may be on another machine.
3. **The renderer mirrors on connect, not only on change.** A gateway the app has
   never spoken to holds no answer, and for a default-on switch silence reads as
   consent to the thing the user turned off. The connect push only re-sends
   settings the user has actually touched, so a fresh install can't broadcast its
   defaults over a hand-edited `config.yaml` on a server.

Schema changes land on the next session, as they must — a running conversation
keeps the toolset it started with, and the renderer declines the call meanwhile.

## Test plan

- [x] `scripts/run_tests.sh tests/tools/test_display_toggles.py tests/tui_gateway/test_config_set_display_toggles.py tests/tools/test_tip_tool.py tests/tools/test_tour_tool.py tests/tools/test_react_to_message_tool.py tests/tui_gateway/test_gui_surface_toolsets.py`
- [x] `npx vitest run src/store` (1313 tests), `npx tsc -p .`, `npx eslint`
- [ ] Toggle tips off, restart the session, confirm Hermes says it has no tip tool