### PR TITLE
fix(whatsapp): preserve Cloud contact details in inbound messages

### DIFF
--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -100,11 +100,28 @@ def _interactive_inner(raw_message: Dict[str, Any]) -> Dict[str, Any]:
     return inter.get("button_reply") or inter.get("list_reply") or {}
 
 
+def _contacts_body(raw_message: Dict[str, Any]) -> str:
+    """Shared contact cards as ``[Contact: <name> <numbers…>]`` lines; Meta sends no caption."""
+    lines = []
+    for contact in raw_message.get("contacts") or []:
+        if not isinstance(contact, dict):
+            continue
+        name = contact.get("name")
+        formatted = str(name.get("formatted_name") or "").strip() if isinstance(name, dict) else ""
+        numbers = [
+            number for phone in contact.get("phones") or [] if isinstance(phone, dict)
+            for number in [str(phone.get("phone") or phone.get("wa_id") or "").strip()] if number
+        ]
+        lines.append(f"[Contact: {' '.join([formatted or 'unknown', *numbers])}]")
+    return "\n".join(lines)
+
+
 # Inbound message type → body text extractor; media kinds use the caption.
 _BODY_BY_KIND = {
     "text": lambda m: (m.get("text") or {}).get("body"),
     "button": lambda m: (m.get("button") or {}).get("text"),
     "interactive": lambda m: _interactive_inner(m).get("title"),
+    "contacts": _contacts_body,
     **{kind: (lambda m, k=kind: (m.get(k) or {}).get("caption")) for kind in _INBOUND_MEDIA_KINDS},
 }
 

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -875,6 +875,64 @@ class TestInboundMediaDispatch:
 
 
 # ---------------------------------------------------------------------------
+# Inbound contact dispatch
+# ---------------------------------------------------------------------------
+
+class TestInboundContactDispatch:
+    @pytest.mark.asyncio
+    async def test_shared_contacts_include_names_and_phone_numbers(self):
+        adapter = _make_adapter()
+        captured = []
+
+        async def _capture(event):
+            captured.append(event)
+
+        adapter.handle_message = _capture
+        payload = {
+            "object": "whatsapp_business_account",
+            "entry": [{
+                "id": "x",
+                "changes": [{
+                    "field": "messages",
+                    "value": {
+                        "metadata": {"phone_number_id": "1"},
+                        "contacts": [
+                            {"profile": {"name": "Sender"}, "wa_id": "1555"}
+                        ],
+                        "messages": [{
+                            "from": "1555",
+                            "id": "wamid.contacts1",
+                            "timestamp": "0",
+                            "type": "contacts",
+                            "contacts": [
+                                {
+                                    "name": {"formatted_name": "Ada Lovelace"},
+                                    "phones": [
+                                        {"phone": "+44 20 1234", "type": "WORK"},
+                                        {"wa_id": "15551234567", "type": "CELL"},
+                                    ],
+                                },
+                                {
+                                    "name": {"formatted_name": "Grace Hopper"},
+                                    "phones": [],
+                                },
+                            ],
+                        }],
+                    },
+                }],
+            }],
+        }
+
+        await adapter._dispatch_payload(payload)
+
+        assert len(captured) == 1
+        assert captured[0].text == (
+            "[Contact: Ada Lovelace +44 20 1234 15551234567]\n"
+            "[Contact: Grace Hopper]"
+        )
+
+
+# ---------------------------------------------------------------------------
 # Group-shaped message guard
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

WhatsApp Cloud contact messages currently reach the agent as empty text events, so shared names and phone numbers are lost.

The Cloud adapter maps `contacts` to `MessageType.TEXT` but never builds text from `messages[].contacts`.

## Changes

- Format each shared contact as `[Contact: name phone…]`, matching the existing Baileys-facing representation.
- Preserve multiple contacts and phone numbers, falling back from `phone` to `wa_id` when needed.
- Add an end-to-end payload regression test that distinguishes sender profile contacts from shared contact messages.
- Keep location and reaction handling out of scope to avoid overlapping their existing work.

## Validation

- `scripts/run_tests.sh tests/gateway/test_whatsapp_cloud.py -q` — 44 passed
- `ruff check gateway/platforms/whatsapp_cloud.py tests/gateway/test_whatsapp_cloud.py`
- `git diff --check`

Addresses the contacts portion of #80053.
