### PR TITLE
fix(plugins): isolate timed-out hook worker state

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -5644,21 +5644,25 @@ class PluginManager:
                         _cb: Callable[..., Any] = cb,
                         _key: tuple = callback_key,
                         _token: object = token,
+                        _context: contextvars.Context = context,
+                        _outcome: Dict[str, Any] = outcome,
+                        _failure: Dict[str, Exception] = failure,
+                        _done: threading.Event = done,
                     ) -> None:
                         try:
                             # Route through _invoke_hook_callback so the
                             # additive-payload signature filtering (narrow
                             # legacy callbacks) applies on the worker too.
-                            outcome["value"] = context.run(
+                            _outcome["value"] = _context.run(
                                 self._invoke_hook_callback, _cb, kwargs
                             )
                         except Exception as exc:
-                            failure["exc"] = exc
+                            _failure["exc"] = exc
                         finally:
                             with self._hook_timeout_lock:
                                 if self._hook_running_callbacks.get(_key) is _token:
                                     self._hook_running_callbacks.pop(_key, None)
-                            done.set()
+                            _done.set()
 
                     thread = threading.Thread(
                         target=_runner,

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -1051,6 +1051,41 @@ class TestForceReloadSymmetry:
         assert elapsed < 1.0, f"caller blocked for {elapsed:.2f}s after timeout"
         hold.set()
 
+    def test_late_timed_out_hook_cannot_complete_successor(self, monkeypatch):
+        """A late first worker cannot publish state for the next callback."""
+        monkeypatch.setattr(
+            "hermes_cli.plugins._resolve_hook_callback_timeout", lambda: 0.15
+        )
+
+        second_started = threading.Event()
+        release_second = threading.Event()
+        second_completed = threading.Event()
+
+        def first(**_kwargs):
+            assert second_started.wait(timeout=1.0)
+            return "late-first"
+
+        def second(**_kwargs):
+            second_started.set()
+            release_second.wait(timeout=10.0)
+            second_completed.set()
+            return "late-second"
+
+        def third(**_kwargs):
+            return "third"
+
+        mgr = PluginManager()
+        mgr._hooks["post_tool_call"] = [first, second, third]
+
+        try:
+            results = mgr.invoke_hook("post_tool_call")
+            assert not second_completed.is_set()
+            assert results == ["third"]
+        finally:
+            second_started.set()
+            release_second.set()
+            assert second_completed.wait(timeout=1.0)
+
     def test_hook_callback_within_timeout_returns_value(self, monkeypatch):
         monkeypatch.setattr(
             "hermes_cli.plugins._resolve_hook_callback_timeout", lambda: 1.0


### PR DESCRIPTION
## Summary

A timed-out plugin hook can currently publish its late result into a later callback invocation. This can return the wrong plugin value, surface the wrong exception, or complete a successor callback before that callback finishes.

The cause is late-bound closure state in `PluginManager.invoke_hook()`: the timeout worker closes over loop-local context, result, failure, and completion objects that are reassigned for the next callback. Each worker now owns its invocation state for its full lifetime.

## Changes

- Bind callback execution context, result, failure, and completion state to each timeout worker.
- Keep callback identity and timeout tokens invocation-specific so an abandoned worker cannot clear or replace a successor's running state.
- Add deterministic overlap coverage for a late first callback, a blocked second callback, and a healthy third callback.
- Preserve abandoned-worker timeout behavior, timeout suppression, fail-closed `pre_tool_call` behavior, caller-thread-only hooks, and context propagation.

## Validation

| Check | Result |
| --- | --- |
| Before fix: timed-out first callback overlaps a blocked successor | **Failed as expected**: `['late-first', 'third']` instead of `['third']` |
| After fix: same deterministic overlap reproduction | **Passed**: `['third']`; the late first result cannot complete or populate the successor |
| Targeted plugin-hook test suite | **75 passed, 0 failed** |
| Targeted subagent-stop-hook test suite | **7 passed, 0 failed** |
| Ruff B023 check for the plugin module | **Passed**: all checks passed |
| Gateway E2E suite on current main | **61 passed, 7 skipped** |
| Diff whitespace check | **Passed** |

The existing timeout test missed this overlap because it exercised one blocked callback followed by a healthy callback. It did not allow the timed-out worker to finish after the invocation loop advanced while a successor worker was also active. Therefore, it verified caller non-blocking behavior but not isolation of late completion state.

Timeout duration and configuration defaults are unchanged. Timeout suppression, timeout abandonment without joining, `pre_tool_call` fail-closed semantics, caller-thread-only hooks, and contextvars propagation are unchanged.

Duplicate search across current source and all issue/PR states found no equivalent report or change for late timed-out hook state. Related results were distinct: open #6622 covers the earlier hook-timeout/WAL work; merged #93824 established the current bounded-callback design; closed #39751 is an older lifecycle-timeout attempt; open #61656 requests opt-in strict policy hooks; merged #84901 covers shell-hook process-tree cleanup; and open #24557 is a broad plugin-isolation proposal. Exact searches for `timed-out hook next callback`, `stale hook result`, `hook worker closure`, `bind per-callback hook state`, and `B023 plugins module` found no equivalent issue or PR.

## Infographic

![Industrial relay schematic comparing plugin hook workers before and after per-worker state isolation: a late first completion corrupts shared closure state before the fix, while after the fix it cannot publish and the third callback returns alone.](https://v3b.fal.media/files/b/0aa81e35/rdmjA7lW8MGU7CXQiAv3b_31Knf85o.png)
