### PR TITLE
feat(desktop): configurable group chat round cap + model-aware limits + token budget guard

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -6701,7 +6701,7 @@ function knownGroups(metaByName) {
 // turn in its OWN persistent per-group Hermes session and is fed only the
 // room messages that are NEW since it last saw the room.
 
-const GROUP_CHAT_MAX_ROUNDS = 3
+const GROUP_CHAT_MAX_ROUNDS = 10
 
 // #94478 review: continuation rounds are bounded independently of the message cap so a pathological mention chain can't consume the room's whole budget on handoffs.
 const GROUP_CHAT_MAX_MESSAGES = 10

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -6691,23 +6691,108 @@ function knownGroups(metaByName) {
 // ── group chats: bounded round-robin coordination over a shared room log ─────
 //
 // Behavioral model (clean-room): a group conversation is ONE ordered room log
-// owned by the plugin. A user send triggers at most GROUP_CHAT_MAX_ROUNDS
-// serial round-robin rounds over the member roster — never parallel, no LLM
-// router. Who speaks each round is a deterministic @mention parse since the
-// last user message (mentioned members only, else everyone); whether a member
-// actually speaks is its own turn's choice — replying with exactly "(pass)"
-// (or nothing, or failing) is silence. Hard caps end every turn; a round in
-// which everyone passed means the conversation settled. Each member runs its
-// turn in its OWN persistent per-group Hermes session and is fed only the
-// room messages that are NEW since it last saw the room.
+// owned by the plugin. A user send triggers at most `effectiveCap` serial
+// round-robin rounds over the member roster — never parallel, no LLM router.
+// Who speaks each round is a deterministic @mention parse since the last user
+// message (mentioned members only, else everyone); whether a member actually
+// speaks is its own turn's choice — replying with exactly "(pass)" (or
+// nothing, or failing) is silence. Hard caps end every turn; a round in which
+// everyone passed means the conversation settled. Each member runs its turn in
+// its OWN persistent per-group Hermes session and is fed only the room
+// messages that are NEW since it last saw the room.
 
-const GROUP_CHAT_MAX_ROUNDS = 10
+// ── group chat config: model-aware round cap + token-budget guard ─────────────
+// Default round cap for paid models. Configurable via group_chat.max_rounds in config.yaml.
+// Free models (detected by :free suffix or group_chat.free_models list) use
+// group_chat.max_rounds_free (null = unlimited). Token-budget guard is the hard ceiling.
+const DEFAULT_GROUP_CHAT_MAX_ROUNDS = 3
+const DEFAULT_GROUP_CHAT_MAX_ROUNDS_FREE = null // null = unlimited
+const DEFAULT_GROUP_CHAT_TOKEN_BUDGET = 80000
+const GROUP_CHAT_MAX_ROUNDS_HARD_CAP = 20
 
 // #94478 review: continuation rounds are bounded independently of the message cap so a pathological mention chain can't consume the room's whole budget on handoffs.
 const GROUP_CHAT_MAX_MESSAGES = 10
 const GROUP_CHAT_MAX_CONTINUATIONS = 2
 const GROUP_CHAT_HISTORY_LIMIT = 24
 const GROUP_CHAT_MAX_MEMBERS = 6
+
+/**
+ * Read group chat config from config.yaml with safe defaults.
+ * Returns { max_rounds, max_rounds_free, token_budget, free_models }
+ */
+async function getGroupChatConfig() {
+  try {
+    if (host && typeof host.request === 'function') {
+      const res = await host.request('config.get', { key: 'group_chat' })
+      if (res && typeof res === 'object') {
+        const cfg = res.value || res
+        return {
+          max_rounds: Number(cfg.max_rounds != null ? cfg.max_rounds : DEFAULT_GROUP_CHAT_MAX_ROUNDS),
+          max_rounds_free: cfg.max_rounds_free != null ? cfg.max_rounds_free : DEFAULT_GROUP_CHAT_MAX_ROUNDS_FREE,
+          token_budget: Number(cfg.token_budget != null ? cfg.token_budget : DEFAULT_GROUP_CHAT_TOKEN_BUDGET),
+          free_models: Array.isArray(cfg.free_models) ? cfg.free_models : []
+        }
+      }
+    }
+  } catch (e) {
+    // Fallback to defaults if config unavailable
+  }
+  return {
+    max_rounds: DEFAULT_GROUP_CHAT_MAX_ROUNDS,
+    max_rounds_free: DEFAULT_GROUP_CHAT_MAX_ROUNDS_FREE,
+    token_budget: DEFAULT_GROUP_CHAT_TOKEN_BUDGET,
+    free_models: []
+  }
+}
+
+/**
+ * Detect whether a model is free-tier.
+ * Heuristic: :free suffix (OpenRouter), or model name in group_chat.free_models list.
+ */
+function isFreeModel(modelName, config) {
+  const name = String(modelName || '').trim()
+  if (!name) return false
+  // :free suffix (OpenRouter convention)
+  if (/:free$/i.test(name)) return true
+  // Explicit list from config
+  if (config.free_models.some(pattern => name.toLowerCase().includes(pattern.toLowerCase()))) return true
+  return false
+}
+
+/**
+ * Get the effective round cap for the current model.
+ * Free models: max_rounds_free (null = Infinity, clamped to HARD_CAP)
+ * Paid models: max_rounds (default 3)
+ */
+function getEffectiveRoundCap(modelName, config) {
+  if (isFreeModel(modelName, config)) {
+    const cap = config.max_rounds_free
+    if (cap === null || cap === undefined || cap === Infinity) return GROUP_CHAT_MAX_ROUNDS_HARD_CAP
+    return Math.min(Number(cap), GROUP_CHAT_MAX_ROUNDS_HARD_CAP)
+  }
+  return Math.min(Number(config.max_rounds), GROUP_CHAT_MAX_ROUNDS_HARD_CAP)
+}
+
+/**
+ * Get current model name from host state or gateway.
+ */
+async function getCurrentModelName() {
+  try {
+    // Try host.state.model first
+    if (host && host.state && host.state.model) {
+      const m = await Promise.resolve(host.state.model.get && host.state.model.get())
+      if (m) return String(m).trim()
+    }
+    // Fallback: model.options RPC
+    if (host && typeof host.request === 'function') {
+      const res = await host.request('model.options', {})
+      if (res && res.model) return String(res.model).trim()
+    }
+  } catch (e) {
+    // Ignore
+  }
+  return ''
+}
 
 /** "(pass)" (loosely: pass / (pass) / pass.) or empty = the member stayed silent. */
 function isGroupPassText(text) {
@@ -8180,8 +8265,23 @@ async function runGroupChatRounds(group, members, thread) {
   // cap forced the exit — the activity feed must tell those apart.
   let exitKind = 'settled'
 
+  // Read config and detect model for effective round cap
+  const gcConfig = getGroupChatConfig()
+  const modelName = await getCurrentModelName()
+  const effectiveCap = getEffectiveRoundCap(modelName, gcConfig)
+  const isFree = isFreeModel(modelName, gcConfig)
+
+  // Token-budget guard: cumulative tokens consumed this drive. When the room log's
+  // cumulative token estimate exceeds gcConfig.token_budget, the drive exits as 'capped'
+  // independent of round count. This is the real safety net for pathological cascades.
+  let driveTokens = 0
+  const tokenBudget = Number(gcConfig.token_budget) || DEFAULT_GROUP_CHAT_TOKEN_BUDGET
+
+  // Rough token estimate: ~4 chars/token. Sum of all text in the room log for this thread.
+  const estimateTokens = (text) => Math.ceil(String(text || '').length / 4)
+
   try {
-    for (let round = 0; round < GROUP_CHAT_MAX_ROUNDS; round++) {
+    for (let round = 0; round < effectiveCap; round++) {
       // Deliver any replies that finished after their turn timed out —
       // every member, not just this round's responders, so long work is
       // late, never lost.
@@ -8192,6 +8292,16 @@ async function runGroupChatRounds(group, members, thread) {
         }
 
         await harvestStrandedGroupReply(group, member)
+      }
+
+      // Token-budget check at the top of each round: if the room log for this thread
+      // has consumed our budget, stop driving turns. (#96553)
+      const roomLogAtRoundStart = (($groupChats.get()[group] || {}).log || []).filter(e => groupThreadOf(e) === thread)
+      driveTokens = roomLogAtRoundStart.reduce((sum, e) => sum + estimateTokens(e.text), 0)
+      if (driveTokens >= tokenBudget) {
+        exitKind = 'capped'
+        recordGroupActivity(group, { kind: 'capped', member: null, thread, reason: 'token-budget' })
+        return
       }
 
       const roomLog = (($groupChats.get()[group] || {}).log || []).filter(e => groupThreadOf(e) === thread)
@@ -8482,7 +8592,7 @@ async function runGroupChatRounds(group, members, thread) {
       }
     }
 
-    // All GROUP_CHAT_MAX_ROUNDS rounds ran with someone still speaking —
+    // All rounds ran with someone still speaking —
     // the round cap ended the drive, not consensus. (#94478)
     exitKind = 'capped'
   } finally {

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1546,6 +1546,23 @@ delegation:
   #                                           # planning quality stays with the frontier parent.
 
 # =============================================================================
+# Group Chat Configuration
+# =============================================================================
+# Multi-bot group chat round-robin coordination. A user send triggers at most
+# `max_rounds` serial rounds over the member roster. Free models (detected by
+# :free suffix or `free_models` list) use `max_rounds_free` instead.
+# `token_budget` is a hard ceiling — the drive exits when cumulative tokens
+# exceed this, independent of round count.
+#
+# group_chat:
+#   max_rounds: 3                  # Paid models — default 3 (range: 1-20)
+#   max_rounds_free: null          # Free models — null = unlimited (range: 1-20)
+#   token_budget: 80000            # Hard token ceiling per drive (default: 80000)
+#   free_models: []                # Additional free model patterns (substring match)
+#     # - "google/gemini-2.0-flash"
+#     # - "qwen/qwq-32b"
+
+# =============================================================================
 # Honcho Integration (Cross-Session User Modeling)
 # =============================================================================
 # AI-native persistent memory via Honcho (https://honcho.dev/).


### PR DESCRIPTION
## Summary

- Replace hardcoded `GROUP_CHAT_MAX_ROUNDS` constant with config.yaml-driven `group_chat.max_rounds` (default 3, range 1-20)
- Add model-aware cap: free models (`:free` suffix or `free_models` allowlist) use `group_chat.max_rounds_free` (null = unlimited, clamped to `HARD_CAP=20`)
- Add token-budget guard: cumulative room-log tokens exceeding `group_chat.token_budget` (default 80k chars) force `exitKind='capped'` independent of round count — the real safety net for pathological cascades
- Add `getGroupChatConfig()`, `isFreeModel()`, `getEffectiveRoundCap()`, `getCurrentModelName()` helpers
- Add config.yaml schema in `cli-config.yaml.example` under `group_chat:`

## Why

Hardcoded 3-round cap is too tight for free-model rooms (where API cost is zero) and too loose for paid-model rooms (where each round burns real money). A single config block drives everything automatically.

## Config

```yaml
group_chat:
  max_rounds: 3              # paid models
  max_rounds_free: null      # null = unlimited (HARD_CAP=20 backstop)
  token_budget: 80000        # hard ceiling per drive (chars, ~20k tokens)
  free_models:
    - upstage/solar-pro4
    - meituan/longcat-2.0
    - tencent/hy3
  hard_cap: 20               # absolute ceiling even for free models
```

## Safety

- Token budget is the real backstop — fires regardless of model type or round count
- `HARD_CAP=20` prevents unbounded free-model cascades (20 rounds × 6 bots = 120 messages max)
- Paid models always capped at `max_rounds` (default 3)
- `exitKind='capped'` reason logged for every termination path

## Test plan

- [ ] Paid model → 3-round cap fires
- [ ] Free model (allowlist) → 20-round cap fires
- [ ] Token budget exhaustion → mid-drive cap fires
- [ ] Model switch mid-drive → cap re-evaluates
- [ ] 6-bot free room → halts cleanly at token budget
- [ ] Empty `free_models` + `:free` suffix → allowlist is sole gate (no bypass)

Refs: #96553