### PR TITLE
fix(desktop): scope the local workspace-cwd memory per profile

### DIFF
--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -34,6 +34,7 @@ import {
   getConfiguredDefaultProjectDir,
   getRememberedRoute,
   getRememberedSessionId,
+  getRememberedWorkspaceCwd,
   getSessionOwnerHint,
   hydrateSessionOwnerHints,
   knownSessionOwner,
@@ -606,6 +607,9 @@ describe('workspaceCwdForNewSession', () => {
     $currentCwd.set('')
     $activeSessionId.set(null)
     window.localStorage.removeItem('hermes.desktop.workspace-cwd')
+    window.localStorage.removeItem('hermes.desktop.workspace-cwd.local.default')
+    window.localStorage.removeItem('hermes.desktop.workspace-cwd.local.profile-a')
+    window.localStorage.removeItem('hermes.desktop.workspace-cwd.local.profile-b')
     window.localStorage.removeItem('hermes.desktop.workspace-cwd.remote.http%3A%2F%2Fbackend-a.default')
     window.localStorage.removeItem('hermes.desktop.workspace-cwd.remote.http%3A%2F%2Fbackend-b.default')
     delete (window as { hermesDesktop?: unknown }).hermesDesktop
@@ -730,6 +734,39 @@ describe('workspaceCwdForNewSession', () => {
 
     expect($currentCwd.get()).toBe('/backend/some-other-project')
     expect(workspaceCwdForNewSession()).toBe('/backend/picked')
+  })
+
+  it('scopes the local workspace memory per profile (#96834)', () => {
+    // One desktop runs multiple local profiles; the remembered workspace must
+    // not leak from one profile's backend into another's new-session cwd
+    // seeding ($currentCwd's initial value reads the remembered key).
+    $connection.set({ baseUrl: '', mode: 'local', profile: 'profile-a' } as never)
+    setCurrentCwd('/home/user/project-a')
+
+    expect(getRememberedWorkspaceCwd()).toBe('/home/user/project-a')
+
+    $connection.set({ baseUrl: '', mode: 'local', profile: 'profile-b' } as never)
+    expect(getRememberedWorkspaceCwd()).toBe('')
+    expect(window.localStorage.getItem('hermes.desktop.workspace-cwd.local.profile-b')).toBeNull()
+
+    setCurrentCwd('/home/user/project-b')
+    expect(getRememberedWorkspaceCwd()).toBe('/home/user/project-b')
+
+    // Back on profile A: A's own memory, never B's.
+    $connection.set({ baseUrl: '', mode: 'local', profile: 'profile-a' } as never)
+    expect(getRememberedWorkspaceCwd()).toBe('/home/user/project-a')
+  })
+
+  it('discards the pre-scoping global workspace key instead of migrating it', () => {
+    // The un-suffixed key was shared by every local profile, so its value's
+    // owning profile is unknowable — migrating it into any one profile would
+    // be exactly the cross-profile leak the scoping prevents.
+    window.localStorage.removeItem('hermes.desktop.workspace-cwd.local.default')
+    window.localStorage.setItem('hermes.desktop.workspace-cwd', '/unknown-owner/project')
+    _resetLegacyDiscardForTests()
+
+    expect(getRememberedWorkspaceCwd()).toBe('')
+    expect(window.localStorage.getItem('hermes.desktop.workspace-cwd')).toBeNull()
   })
 
   it('settling a resumed session does not move where the next new chat starts', () => {

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -58,11 +58,16 @@ function profileNavigationKey(base: string, profile: string): string {
 // events, which are the only way another window can recontaminate between
 // ticks.
 let legacyDiscardNeeded = true
+let legacyWorkspaceDiscardNeeded = true
 
 if (typeof window !== 'undefined') {
   window.addEventListener('storage', e => {
     if (e.key === LAST_SESSION_KEY || e.key === LAST_ROUTE_KEY) {
       legacyDiscardNeeded = true
+    }
+
+    if (e.key === WORKSPACE_CWD_KEY) {
+      legacyWorkspaceDiscardNeeded = true
     }
   })
 }
@@ -86,9 +91,28 @@ function discardLegacyRememberedNavigation(): void {
   }
 }
 
-/** @internal Reset the legacy-discard flag for tests. */
+/** Drop the pre-#96834 global workspace-cwd key once per tick.
+ *
+ *  Same reasoning as the navigation keys above: the un-suffixed key was shared
+ *  by every local profile, so its value's owning profile is unknowable and
+ *  migrating it into any one profile would be exactly the cross-profile leak
+ *  the per-profile scoping exists to prevent. Users re-pick a project once. */
+function discardLegacyRememberedWorkspaceCwd(): void {
+  if (!legacyWorkspaceDiscardNeeded) {
+    return
+  }
+
+  legacyWorkspaceDiscardNeeded = false
+
+  if (storedString(WORKSPACE_CWD_KEY) !== null) {
+    persistString(WORKSPACE_CWD_KEY, null)
+  }
+}
+
+/** @internal Reset the legacy-discard flags for tests. */
 export function _resetLegacyDiscardForTests(): void {
   legacyDiscardNeeded = true
+  legacyWorkspaceDiscardNeeded = true
 }
 
 export function getRememberedSessionId(profile: string): null | string {
@@ -213,17 +237,26 @@ export function setRememberedRoute(path: null | string, profile: string): void {
 let configuredDefaultProjectDir = ''
 
 function workspaceCwdKey(connection: HermesConnection | null = $connection.get()): string {
+  const profile = encodeURIComponent(connection?.profile?.trim() || 'default')
+
   if (connection?.mode !== 'remote') {
-    return WORKSPACE_CWD_KEY
+    // Local connections are still per-profile: one desktop runs multiple
+    // local profiles, and a single global key let one profile's remembered
+    // project leak into another profile's new-session cwd seeding (#96834).
+    return `${WORKSPACE_CWD_KEY}.local.${profile}`
   }
 
   const base = encodeURIComponent(connection.baseUrl || 'remote')
-  const profile = encodeURIComponent(connection.profile || 'default')
 
   return `${WORKSPACE_CWD_KEY}.remote.${base}.${profile}`
 }
 
-export const getRememberedWorkspaceCwd = (): string => storedString(workspaceCwdKey())?.trim() || ''
+export const getRememberedWorkspaceCwd = (): string => {
+  discardLegacyRememberedWorkspaceCwd()
+
+  return storedString(workspaceCwdKey())?.trim() || ''
+}
+
 export type NewChatWorkspaceTarget = null | string | undefined
 
 export const getConfiguredDefaultProjectDir = (): string => configuredDefaultProjectDir


### PR DESCRIPTION
## What does this PR do?

Stops one local profile's remembered workspace from leaking into another profile's new sessions.

`workspaceCwdKey()` scoped the remembered workspace cwd per connection and profile only for **remote** connections; a local (non-remote) connection returned the bare global `hermes.desktop.workspace-cwd` key. One desktop runs multiple local profiles, so entering a project in one profile wrote that path to the shared key, and a new session in another profile read it back through `$currentCwd`'s initial value (`atom(getRememberedWorkspaceCwd())`) — inheriting the other profile's project folder as its working directory and sidebar repo lane (#96834; the same profile-boundary-leak class as #90021/#94724).

The fix scopes local connections too (`.local.<profile>` suffix, mirroring the existing `.remote.<base>.<profile>` form), and discards the legacy un-suffixed key on first read instead of migrating it — the old value's owning profile is unknowable, and guessing is exactly the cross-profile leak the scoping prevents (the same reasoning the navigation keys already document, #67709). Users re-pick a project once.

## Related Issue

Fixes #96834

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/store/session.ts` — `workspaceCwdKey()` local branch now returns a per-profile suffixed key; added `discardLegacyRememberedWorkspaceCwd()` (own per-tick flag + cross-window `storage` re-arm, mirroring the navigation-key discard) invoked from `getRememberedWorkspaceCwd()`; `_resetLegacyDiscardForTests` resets both flags.
- `apps/desktop/src/store/session.test.ts` — two regressions: per-profile local scoping (profile A remembers, profile B reads empty and gets its own memory, back on A restores A's) and legacy global-key discard (never migrated); afterEach/imports updated.

## How to Test

1. `cd apps/desktop && ../../node_modules/.bin/vitest run src/store/session.test.ts` — should pass (91 passed).
2. Red/green verified locally: with the pre-fix `session.ts` restored, the per-profile scoping regression fails (profile B reads profile A's remembered path); with this change all pass.
3. Manual equivalent: on a local connection, enter a project under profile A, then create a new session while profile B's backend is active — the new session's cwd/sidebar lane must not reference profile A's project.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (desktop suite: `vitest run src/store/session.test.ts` — 91 passed; eslint clean)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.5 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (comments in place)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (renderer storage scoping)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
