### PR TITLE
fix(profiles): clarify default model scope

### DIFF
--- a/hermes_cli/web_routers/profiles.py
+++ b/hermes_cli/web_routers/profiles.py
@@ -1117,7 +1117,9 @@ async def update_profile_model_endpoint(name: str, body: ProfileModelUpdate):
     """Set the main model (``model.default`` + ``model.provider``) for a
     specific profile's config.yaml, without touching the dashboard's own
     active profile. Mirrors ``POST /api/model/set`` (main scope) but scoped
-    to the named profile via the HERMES_HOME override.
+    to the named profile via the HERMES_HOME override. This changes the
+    profile default only: durable per-session ``/model`` pins are preserved
+    deliberately so a config edit cannot silently reset active prompt caches.
     """
     profile_dir = _resolve_profile_dir(name)
     provider = (body.provider or "").strip()
@@ -1129,7 +1131,15 @@ async def update_profile_model_endpoint(name: str, body: ProfileModelUpdate):
     except Exception as e:
         _log.exception("PUT /api/profiles/%s/model failed", name)
         raise HTTPException(status_code=500, detail=str(e))
-    return {"ok": True, "provider": provider, "model": model}
+    return {
+        "ok": True,
+        "provider": provider,
+        "model": model,
+        # This endpoint changes the profile default only. Durable /model pins
+        # remain session-scoped by design so an operator cannot silently break
+        # prompt caches in active conversations.
+        "applies_to": "new_sessions",
+    }
 
 
 @router.post("/api/profiles/{name}/describe-auto")

--- a/tests/hermes_cli/test_profile_model_assignment_scope.py
+++ b/tests/hermes_cli/test_profile_model_assignment_scope.py
@@ -1,0 +1,39 @@
+import asyncio
+from pathlib import Path
+
+from hermes_cli.web_routers import profiles as profiles_router
+
+
+def test_profile_model_update_declares_new_session_scope(monkeypatch, tmp_path):
+    profile_dir = tmp_path / "profiles" / "chip"
+    profile_dir.mkdir(parents=True)
+    written = []
+
+    monkeypatch.setattr(
+        profiles_router,
+        "_resolve_profile_dir",
+        lambda name: profile_dir,
+    )
+    monkeypatch.setattr(
+        profiles_router,
+        "_write_profile_model",
+        lambda path, provider, model: written.append((path, provider, model)),
+    )
+
+    result = asyncio.run(
+        profiles_router.update_profile_model_endpoint(
+            "chip",
+            profiles_router.ProfileModelUpdate(
+                provider="openai-codex",
+                model="gpt-5.6-luna",
+            ),
+        )
+    )
+
+    assert written == [(profile_dir, "openai-codex", "gpt-5.6-luna")]
+    assert result == {
+        "ok": True,
+        "provider": "openai-codex",
+        "model": "gpt-5.6-luna",
+        "applies_to": "new_sessions",
+    }

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -373,8 +373,13 @@ export const en: Translations = {
     modelInherit: "Inherit from clone / default",
     modelLoading: "Loading models…",
     modelNone: "No authenticated providers — set a key first",
-    editModel: "Change model",
-    modelSaved: "Model updated",
+    editModel: "Change default model",
+    modelSaved: "Default model updated for new sessions",
+    modelExistingSessions:
+      "Existing sessions keep their current model and any /model override.",
+    modelScopeUnconfirmed:
+      "Default model saved; affected session scope unconfirmed",
+    modelDefaultLabel: "Default model",
     modelSelect: "Select a model",
     actions: "Actions",
   },

--- a/web/src/i18n/types.ts
+++ b/web/src/i18n/types.ts
@@ -429,6 +429,9 @@ export interface Translations {
     modelNone?: string;
     editModel?: string;
     modelSaved?: string;
+    modelExistingSessions?: string;
+    modelScopeUnconfirmed?: string;
+    modelDefaultLabel?: string;
     modelSelect?: string;
     actions?: string;
     manageSkills?: string;

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -702,7 +702,12 @@ export const api = {
       },
     ),
   setProfileModel: (name: string, provider: string, model: string) =>
-    fetchJSON<{ ok: boolean; provider: string; model: string }>(
+    fetchJSON<{
+      ok: boolean;
+      provider: string;
+      model: string;
+      applies_to?: string;
+    }>(
       `/api/profiles/${encodeURIComponent(name)}/model`,
       {
         method: "PUT",

--- a/web/src/lib/profileModelScope.test.ts
+++ b/web/src/lib/profileModelScope.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { describeProfileModelSave } from "./profileModelScope";
+
+describe("describeProfileModelSave", () => {
+  const copy = {
+    savedForNewSessions: "Default model updated for new sessions",
+    existingSessionsUnchanged:
+      "Existing sessions keep their current model and any /model override.",
+    scopeUnconfirmed: "Default model saved; affected session scope unconfirmed",
+  };
+
+  it("states both the saved default and unchanged live-session scope", () => {
+    expect(
+      describeProfileModelSave(
+        "gpt-5.6-luna",
+        { applies_to: "new_sessions" },
+        copy,
+      ),
+    ).toBe(
+      "Default model updated for new sessions: gpt-5.6-luna. Existing sessions keep their current model and any /model override.",
+    );
+  });
+
+  it("fails closed when an older server omits the scope", () => {
+    expect(describeProfileModelSave("gpt-5.6-luna", {}, copy)).toBe(
+      "Default model saved; affected session scope unconfirmed: gpt-5.6-luna",
+    );
+  });
+});

--- a/web/src/lib/profileModelScope.ts
+++ b/web/src/lib/profileModelScope.ts
@@ -1,0 +1,25 @@
+export interface ProfileModelScopeCopy {
+  savedForNewSessions: string;
+  existingSessionsUnchanged: string;
+  scopeUnconfirmed: string;
+}
+
+export interface ProfileModelAssignmentScope {
+  applies_to?: string;
+}
+
+/**
+ * Profile model writes are expected to change config defaults only. If an
+ * older or incompatible backend omits that contract, do not claim a live
+ * model changed (or that the scope is known).
+ */
+export function describeProfileModelSave(
+  model: string,
+  result: ProfileModelAssignmentScope,
+  copy: ProfileModelScopeCopy,
+): string {
+  if (result.applies_to !== "new_sessions") {
+    return `${copy.scopeUnconfirmed}: ${model}`;
+  }
+  return `${copy.savedForNewSessions}: ${model}. ${copy.existingSessionsUnchanged}`;
+}

--- a/web/src/pages/ProfilesPage.tsx
+++ b/web/src/pages/ProfilesPage.tsx
@@ -27,6 +27,7 @@ import { H2 } from "@nous-research/ui/ui/components/typography/h2";
 import { api } from "@/lib/api";
 import type { ActiveProfileInfo, ProfileInfo } from "@/lib/api";
 import { copyTextToClipboard } from "@/lib/clipboard";
+import { describeProfileModelSave } from "@/lib/profileModelScope";
 import { DeleteConfirmDialog } from "@/components/DeleteConfirmDialog";
 import { useToast } from "@nous-research/ui/hooks/use-toast";
 import { useConfirmDelete } from "@nous-research/ui/hooks/use-confirm-delete";
@@ -301,8 +302,15 @@ export default function ProfilesPage() {
       modelLoading: p.modelLoading ?? "Loading models…",
       modelNone:
         p.modelNone ?? "No authenticated providers — set a key first",
-      editModel: p.editModel ?? "Change model",
-      modelSaved: p.modelSaved ?? "Model updated",
+      editModel: p.editModel ?? "Change default model",
+      modelSaved: p.modelSaved ?? "Default model updated for new sessions",
+      modelExistingSessions:
+        p.modelExistingSessions ??
+        "Existing sessions keep their current model and any /model override.",
+      modelScopeUnconfirmed:
+        p.modelScopeUnconfirmed ??
+        "Default model saved; affected session scope unconfirmed",
+      modelDefaultLabel: p.modelDefaultLabel ?? "Default model",
       modelSelect: p.modelSelect ?? "Select a model",
       actions: p.actions ?? "Actions",
       manageSkills: p.manageSkills ?? "Manage skills & tools",
@@ -669,8 +677,19 @@ export default function ProfilesPage() {
     if (!picked) return;
     setModelSaving(true);
     try {
-      await api.setProfileModel(name, picked.provider, picked.model);
-      showToast(`${L.modelSaved}: ${picked.model}`, "success");
+      const result = await api.setProfileModel(
+        name,
+        picked.provider,
+        picked.model,
+      );
+      showToast(
+        describeProfileModelSave(picked.model, result, {
+          savedForNewSessions: L.modelSaved,
+          existingSessionsUnchanged: L.modelExistingSessions,
+          scopeUnconfirmed: L.modelScopeUnconfirmed,
+        }),
+        "success",
+      );
       setProfiles((prev) =>
         prev.map((p) =>
           p.name === name
@@ -1207,7 +1226,7 @@ export default function ProfilesPage() {
                       <div className="mt-auto flex flex-col gap-0.5 pt-1 text-xs text-muted-foreground">
                         {p.model && (
                           <span className="truncate">
-                            {t.profiles.model}: {p.model}
+                            {L.modelDefaultLabel}: {p.model}
                             {p.provider ? ` (${p.provider})` : ""}
                           </span>
                         )}
@@ -1295,6 +1314,10 @@ export default function ProfilesPage() {
                         </SelectOption>
                       ))}
                     </Select>
+
+                    <p className="text-xs text-muted-foreground">
+                      {L.modelExistingSessions}
+                    </p>
 
                     <div className="flex justify-end">
                       <Button

--- a/website/docs/user-guide/configuring-models.md
+++ b/website/docs/user-guide/configuring-models.md
@@ -47,6 +47,20 @@ Type in the filter box to narrow by provider name, slug, or model ID.
 
 Pick a model, hit **Switch**, and Hermes writes it to `~/.hermes/config.yaml` under the `model` section. **This applies to new sessions only** — any chat tab you already have open keeps running whatever model it started with. To hot-swap the current chat, use the `/model` slash command inside it.
 
+### How Hermes resolves the model
+
+Hermes keeps three model states separate on purpose:
+
+| Layer | Set by | Lifetime |
+|---|---|---|
+| **Profile default** | Dashboard, `hermes model`, config | Used when a new session starts |
+| **Session override** | `/model` inside a conversation | Persists for that conversation until replaced or reset |
+| **Effective turn route** | Primary route or automatic fallback | The model serving the current turn; fallback is restored according to its retry policy |
+
+The profile card and Models page therefore show a **default**, not a promise about every active conversation. A durable session override takes precedence over that default, including after a gateway restart. Automatic fallback does not rewrite either selection; it is runtime failover for the turn. See [Fallback Providers](./features/fallback-providers.md) for the retry and restoration rules.
+
+This separation preserves intentional per-conversation choices and avoids silently resetting prompt caches. If you want the new default immediately, start a new session or use `/model` explicitly in the active conversation.
+
 ### Mid-session switches and context warnings
 
 When you switch models **inside an active session** (Herm TUI model picker, `hermes` CLI, or `/model` on Telegram/Discord), Hermes estimates whether your **next message** will run **preflight context compression** against the new model's window. If the session is already near or above that model's compression threshold (see [Context Compression](./configuration.md#context-compression)), the switch reply includes a warning — the same `warning_message` path used for expensive-model notices. The switch still applies immediately; compression runs on the **first user message after the switch**, before the model answers.
@@ -227,7 +241,7 @@ Older configs used a top-level `custom_providers:` list (with `base_url` instead
 ## When does it take effect?
 
 - **CLI** (`hermes chat`): next `hermes chat` invocation.
-- **Gateway** (Telegram, Discord, Slack, etc.): next *new* session. Existing sessions keep their model. Restart the gateway (`hermes gateway restart`) if you want to force all sessions to pick up the change.
+- **Gateway** (Telegram, Discord, Slack, etc.): next *new* session. Existing sessions keep their model. Restarting the gateway rebuilds unpinned sessions from the profile default, but a durable `/model` override is intentionally rehydrated and continues to win. Use `/new` to start from the default or `/model` to switch that conversation explicitly.
 - **Dashboard chat tab** (`/chat`): next new PTY. The currently-open chat keeps its model — use `/model` inside it to hot-swap.
 
 Changes never invalidate prompt caches on running sessions. That's deliberate: swapping the main model inside a session requires a cache reset (the system prompt contains model-specific content), and we reserve that for the explicit `/model` slash command inside chat.
@@ -240,7 +254,9 @@ Hermes lists a provider only if it has a working credential. Check **Keys** in t
 
 ### Main model didn't change in my running chat
 
-Expected. The dashboard writes `config.yaml`, which new sessions read. The currently-open chat is a live agent process — it keeps whatever model it was spawned with. Use `/model <name>` inside the chat to hot-swap that specific session.
+Expected. The dashboard writes `config.yaml`, which new sessions read. The currently-open chat is a live agent process — it keeps whatever model it was spawned with, and a durable `/model` override survives gateway restarts. Use `/model <name>` inside the chat to hot-swap that specific session, or `/new` to start a conversation from the profile default.
+
+If logs show a third model, check `fallback_providers`: the configured default, a session override, and the model serving a failed-over turn are different layers. Fallback is turn-scoped and does not change the saved profile default.
 
 ### Auxiliary override "didn't take effect"
 


### PR DESCRIPTION
## What does this PR do?

Clarifies that changing a model from the Profiles page updates the profile default for new sessions; it does not replace a durable `/model` selection in an existing conversation.

Hermes intentionally separates the profile default, a per-session override, and the model serving a fallback turn. The previous Profiles UI called all of this simply `Model` and reported `Model updated`, which could imply that a running conversation changed when it had not.

The endpoint now declares `applies_to: "new_sessions"`. The UI consumes that value, labels the field **Default model**, and tells the operator that existing sessions remain unchanged. If an older or incompatible backend omits or changes the scope, the UI fails closed and reports that the affected session scope is unconfirmed.

The documentation now describes the three layers and corrects the previous claim that restarting a gateway necessarily forces every session onto the new default. Durable `/model` overrides are rehydrated by design.

## Related Issue

Fixes #96813

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/web_routers/profiles.py`: declare that profile-model writes apply to `new_sessions` and document why session pins are preserved.
- `tests/hermes_cli/test_profile_model_assignment_scope.py`: verify the backend response contract through the real profile endpoint.
- `web/src/lib/profileModelScope.ts`: format confirmed versus unconfirmed save scope without overclaiming.
- `web/src/lib/profileModelScope.test.ts`: cover confirmed and omitted-scope behavior.
- `web/src/lib/api.ts`: type the optional scope field for compatibility with older backends.
- `web/src/pages/ProfilesPage.tsx`: consume API scope, label the card and editor as a default, and disclose unchanged existing sessions.
- `web/src/i18n/en.ts`, `web/src/i18n/types.ts`: add the corresponding localized copy.
- `website/docs/user-guide/configuring-models.md`: distinguish profile defaults, session overrides, and effective fallback routes; correct gateway-restart guidance.

## How to Test

1. Run the focused backend tests:
   `HERMES_PYTHON=/tmp/hermes-pr-venv/bin/python scripts/run_tests.sh tests/hermes_cli/test_profile_model_assignment_scope.py tests/hermes_cli/test_web_server_profile_unification.py tests/hermes_cli/test_web_server_messaging_profiles.py`
2. Run the complete frontend suite and checks:
   `cd web && npm test -- --maxWorkers=1 && npm run typecheck && npx eslint src/lib/profileModelScope.ts src/lib/profileModelScope.test.ts src/pages/ProfilesPage.tsx src/lib/api.ts src/i18n/en.ts src/i18n/types.ts && npm run build`
3. Open Profiles, change a profile's default model, and verify the card/editor/toast state that it applies to new sessions while existing `/model` selections remain unchanged.

Verified locally:

- Backend: 37 passed, 0 failed.
- Frontend: 37 files / 280 tests passed.
- TypeScript typecheck passed.
- Targeted ESLint passed.
- Production frontend build passed.
- Ruff and `git diff --check` passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux 6.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A, existing model-state architecture is unchanged
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — text/API-only behavior with no platform-specific path or process handling
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A, no model tool schema changed

## Screenshots / Logs

No screenshot included. The behavior is covered by the API contract test and frontend formatter tests; the complete frontend suite and production build pass.
