### PR TITLE
CLI startup offers to restore sessions orphaned by a crash (Copilot CLI port)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -10070,7 +10070,15 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             _cprint("  Use /resume with no arguments to see available sessions.")
             return True
 
-        self._handle_resume_command(f"/resume {index}")
+        # Resolve against the ARMED list's own session id rather than
+        # re-numbering through _list_recent_sessions: the armed list may be a
+        # crash-restore offer (different ordering/contents), and even for the
+        # /resume list the DB contents can shift between display and reply.
+        selected_id = str((pending[index - 1] or {}).get("id") or "").strip()
+        if not selected_id:
+            _cprint(f"  Resume index {index} could not be resolved.")
+            return True
+        self._handle_resume_command(f"/resume {selected_id}")
         return True
 
 
@@ -13232,6 +13240,81 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             write_breadcrumb(self.session_id)
         except Exception:
             pass
+        # Keep the crash-restore liveness marker pointed at the current
+        # session id too — same trigger set (start + every reassignment).
+        self._update_crash_live_marker()
+
+    def _update_crash_live_marker(self) -> None:
+        """Point the crash-restore liveness marker at the current session.
+
+        Only active for interactive sessions (``run()`` arms it); one-shot
+        ``-q`` runs end their rows cleanly and never need a restore offer.
+        Best-effort — never raises.
+        """
+        if not getattr(self, "_crash_marker_armed", False):
+            return
+        try:
+            from hermes_cli.crash_restore import remove_live_marker, write_live_marker
+
+            previous = getattr(self, "_crash_marker_session", None)
+            if previous and previous != self.session_id:
+                remove_live_marker(previous)
+            write_live_marker(self.session_id)
+            self._crash_marker_session = self.session_id
+        except Exception:
+            logger.debug("crash-restore marker update failed", exc_info=True)
+
+    def _remove_crash_live_marker(self) -> None:
+        """Drop the crash-restore marker on clean exit. Never raises."""
+        try:
+            from hermes_cli.crash_restore import remove_live_marker
+
+            for sid in {getattr(self, "_crash_marker_session", None), self.session_id}:
+                if sid:
+                    remove_live_marker(sid)
+        except Exception:
+            pass
+
+    def _offer_crash_restore(self) -> None:
+        """Offer to restore CLI sessions whose owning process crashed.
+
+        Inspired by GitHub Copilot CLI's startup session-restore flow
+        (v1.0.81): a crash or machine restart no longer means digging the
+        session id out of ``hermes sessions list`` by hand. Shows up to a
+        few crashed sessions and arms the same one-shot numbered selection
+        that a bare ``/resume`` uses, so typing ``1`` restores immediately.
+        """
+        from hermes_cli.crash_restore import find_crashed_sessions
+
+        offers = find_crashed_sessions(
+            self._session_db, current_session_id=self.session_id
+        )
+        if not offers:
+            return
+
+        from hermes_cli.main import _relative_time
+
+        _cli_visible_print()
+        _cli_visible_print(
+            "  (o_o) Found session(s) that were still open when their CLI went away:"
+        )
+        _cli_visible_print()
+        for idx, row in enumerate(offers, start=1):
+            title = row.get("title") or "—"
+            msgs = row.get("message_count") or 0
+            last = _relative_time(row.get("last_activity_at") or row.get("started_at"))
+            _cli_visible_print(
+                f"  {idx:<3} {title:<32} {msgs:>4} msgs  {last:<13} {row['id']}"
+            )
+        _cli_visible_print()
+        _cli_visible_print(
+            "  Type a number to restore it, /resume <id> anytime, or just start chatting to ignore."
+        )
+        _cli_visible_print()
+        # Reuse the bare-/resume one-shot numbered selection (#34584): the
+        # consume path resolves against THIS list's ids, so numbering is
+        # exact even though the ordering differs from /resume's table.
+        self._pending_resume_sessions = offers
 
     def _transfer_session_yolo(self, old_session_id: str, new_session_id: str) -> None:
         """Move YOLO bypass state from an old session key to a new one.
@@ -17593,6 +17676,17 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             if self._preload_resumed_session():
                 self._display_resumed_history()
 
+        # Arm the crash-restore liveness marker for this interactive session
+        # and offer to restore any sessions whose CLI process died without a
+        # clean exit (crash, SIGKILL, machine restart, closed window).
+        # Inspired by GitHub Copilot CLI v1.0.81's startup restore flow.
+        try:
+            self._crash_marker_armed = True
+            self._update_crash_live_marker()
+            self._offer_crash_restore()
+        except Exception:
+            logger.debug("crash-restore startup offer failed", exc_info=True)
+
         try:
             from hermes_cli.skin_engine import get_active_skin
             _welcome_skin = get_active_skin()
@@ -20925,6 +21019,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     pass
             _run_cleanup()
             self._print_exit_summary()
+            # Clean exit — drop the crash-restore liveness marker so the next
+            # startup doesn't offer to restore a session that ended normally.
+            self._remove_crash_live_marker()
             self._release_active_session()
 
         # Deferred relaunch: /update sets _pending_relaunch so the exec

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1117,6 +1117,10 @@ class CLICommandsMixin:
         self._resumed = True
         self._pending_title = None
         _sync_process_session_id(target_id)
+        # Re-point the per-terminal breadcrumb AND the crash-restore liveness
+        # marker at the newly adopted session (the old one was just ended
+        # with "resumed_other", so its marker must not linger).
+        getattr(self, "_write_terminal_breadcrumb", lambda: None)()
 
         # Load conversation history (strip transcript-only metadata entries).
         # repair_alternation: this /resume feeds LIVE REPLAY — ``restored``

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -41,6 +41,13 @@ DEFAULT_CONFIG = {
         # most-recent one. Set false to restore the old latest-session
         # behavior everywhere.
         "terminal_continue": True,
+        # Startup crash-restore offers: each interactive CLI session keeps a
+        # liveness marker under $HERMES_HOME/runtime/cli-live/. When a CLI
+        # process dies without a clean exit (crash, SIGKILL, reboot, closed
+        # terminal window), the next interactive startup offers to restore
+        # the orphaned session(s) with a one-keystroke numbered pick.
+        # Set false to disable the markers and the offer entirely.
+        "crash_restore": True,
     },
     "agent": {
         # Unlimited by default. The agent turn cap caused more problems than

--- a/hermes_cli/crash_restore.py
+++ b/hermes_cli/crash_restore.py
@@ -1,0 +1,194 @@
+"""Startup crash-restore offers for interactive CLI sessions.
+
+A cleanly exited interactive CLI always finalizes its session row
+(``end_session(..., "cli_close")``).  A crash — SIGKILL, machine restart,
+terminal window closed — skips that path and leaves the row open
+(``ended_at IS NULL``) with no pointer back to it: the user has to dig the
+id out of ``hermes sessions list`` by hand.
+
+This module gives each interactive CLI session a tiny liveness marker file
+``$HERMES_HOME/runtime/cli-live/<session_id>.json`` containing the owning
+``pid`` + ``process_start_time``.  The marker is written when the
+interactive loop starts (and re-pointed when the session id changes via
+``/new`` / ``/resume``), and removed on clean exit.  At the next
+interactive startup, markers whose owning process is gone but whose session
+row is still open with content are offered for restore — mirroring GitHub
+Copilot CLI's "restore sessions that were still open when their CLI went
+away" startup flow (v1.0.81).
+
+Everything is best-effort: no function raises, and the feature is gated by
+``session.crash_restore`` in config.yaml (default true).
+
+Pid liveness reuses :func:`hermes_cli.active_sessions._pid_alive`, which
+pairs the pid with the process create time so a recycled pid cannot keep a
+dead session looking alive.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from pathlib import Path
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+# Markers older than this are removed regardless of row state — a marker
+# that survived 30 days belongs to a session the user has moved past.
+_STALE_AFTER_SECONDS = 30 * 24 * 60 * 60
+
+# Cap on how many crashed sessions one startup will offer.
+DEFAULT_OFFER_LIMIT = 3
+
+
+def _markers_dir() -> Path:
+    from hermes_constants import get_hermes_home
+
+    return Path(get_hermes_home()) / "runtime" / "cli-live"
+
+
+def is_enabled() -> bool:
+    """Config gate: ``session.crash_restore`` (default true)."""
+    try:
+        from hermes_cli.config import load_config
+
+        return bool((load_config().get("session") or {}).get("crash_restore", True))
+    except Exception:
+        return True
+
+
+def _process_start_time(pid: int) -> Optional[float]:
+    try:
+        import psutil  # type: ignore
+
+        return float(psutil.Process(pid).create_time())
+    except Exception:
+        return None
+
+
+def write_live_marker(session_id: str) -> None:
+    """Record that this process currently owns ``session_id``.
+
+    Synchronous, best-effort, never raises.  No-op when the feature is
+    disabled or the session id is empty.
+    """
+    try:
+        if not session_id or not is_enabled():
+            return
+        directory = _markers_dir()
+        directory.mkdir(parents=True, exist_ok=True)
+        pid = os.getpid()
+        payload = {
+            "session_id": str(session_id),
+            "pid": pid,
+            "process_start_time": _process_start_time(pid),
+            "ts": time.time(),
+        }
+        path = directory / f"{session_id}.json"
+        tmp = directory / f".{session_id}.{pid}.tmp"
+        tmp.write_text(json.dumps(payload), encoding="utf-8")
+        os.replace(tmp, path)
+    except Exception:
+        logger.debug("crash-restore marker write failed", exc_info=True)
+
+
+def remove_live_marker(session_id: str) -> None:
+    """Drop the marker on clean exit (or session-id handoff). Never raises."""
+    try:
+        if not session_id:
+            return
+        (_markers_dir() / f"{session_id}.json").unlink(missing_ok=True)
+    except Exception:
+        logger.debug("crash-restore marker removal failed", exc_info=True)
+
+
+def _read_marker(path: Path) -> Optional[dict[str, Any]]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    if not isinstance(data, dict):
+        return None
+    if not str(data.get("session_id") or "").strip():
+        return None
+    return data
+
+
+def find_crashed_sessions(
+    session_db,
+    *,
+    current_session_id: str = "",
+    limit: int = DEFAULT_OFFER_LIMIT,
+) -> list[dict[str, Any]]:
+    """Return crashed-session rows worth offering for restore, newest first.
+
+    A marker qualifies when ALL of:
+
+    - its owning process is gone (pid dead, or alive-but-different process
+      via the create-time pair check);
+    - its session row still exists, is still open (``ended_at IS NULL``),
+      and has at least one message to restore.
+
+    Housekeeping happens inline: markers for cleanly-ended or deleted rows
+    and markers past the staleness window are removed so the directory
+    can't accumulate.  Never raises; returns ``[]`` on any failure.
+    """
+    try:
+        if session_db is None or not is_enabled():
+            return []
+        directory = _markers_dir()
+        if not directory.is_dir():
+            return []
+        from hermes_cli.active_sessions import _pid_alive
+
+        now = time.time()
+        offers: list[dict[str, Any]] = []
+        for path in sorted(directory.glob("*.json")):
+            marker = _read_marker(path)
+            if marker is None:
+                _unlink_quietly(path)
+                continue
+            session_id = str(marker["session_id"])
+            ts = marker.get("ts")
+            if isinstance(ts, (int, float)) and now - ts > _STALE_AFTER_SECONDS:
+                _unlink_quietly(path)
+                continue
+            if session_id == current_session_id:
+                continue
+            if _pid_alive(marker.get("pid"), marker.get("process_start_time")):
+                continue  # live in another terminal — not ours to offer
+            row = None
+            try:
+                row = session_db.get_session(session_id)
+            except Exception:
+                continue
+            if not row:
+                _unlink_quietly(path)
+                continue
+            if row.get("ended_at") is not None:
+                # Ended cleanly elsewhere (e.g. resumed + closed) — stale marker.
+                _unlink_quietly(path)
+                continue
+            if not row.get("message_count"):
+                # Nothing to restore; leave the empty-row pruning to the
+                # existing exit-time discard logic.
+                _unlink_quietly(path)
+                continue
+            offers.append(row)
+        offers.sort(
+            key=lambda r: r.get("last_activity_at") or r.get("started_at") or 0,
+            reverse=True,
+        )
+        return offers[: max(1, int(limit))]
+    except Exception:
+        logger.debug("crash-restore scan failed", exc_info=True)
+        return []
+
+
+def _unlink_quietly(path: Path) -> None:
+    try:
+        path.unlink(missing_ok=True)
+    except OSError:
+        pass

--- a/tests/hermes_cli/test_crash_restore.py
+++ b/tests/hermes_cli/test_crash_restore.py
@@ -1,0 +1,175 @@
+"""Tests for hermes_cli/crash_restore.py — startup crash-restore offers.
+
+Covers the marker write/remove roundtrip under a temp HERMES_HOME, the
+crashed-session scan (dead pid + open row + messages), live-pid exclusion,
+cleanly-ended and deleted-row housekeeping, the current-session exclusion,
+the offer limit/ordering, and the session.crash_restore config gate.
+"""
+
+import json
+import os
+import time
+
+import pytest
+
+from hermes_cli import crash_restore as cr
+
+
+@pytest.fixture
+def hermes_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    return home
+
+
+@pytest.fixture
+def session_db(hermes_home):
+    from hermes_state import SessionDB
+
+    db = SessionDB()
+    yield db
+    db.close()
+
+
+def _make_session(db, session_id, *, messages=1, ended=None):
+    db.create_session(session_id=session_id, source="cli")
+    for i in range(messages):
+        db.append_message(session_id, "user", f"msg {i}")
+    if ended:
+        db.end_session(session_id, ended)
+
+
+def _write_dead_marker(session_id, *, pid=None, ts=None):
+    """Write a marker owned by a definitely-dead process."""
+    directory = cr._markers_dir()
+    directory.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "session_id": session_id,
+        # A pid we can guarantee is not running: fork-and-reap.
+        "pid": pid if pid is not None else _dead_pid(),
+        "process_start_time": None,
+        "ts": ts if ts is not None else time.time(),
+    }
+    (directory / f"{session_id}.json").write_text(json.dumps(payload))
+
+
+def _dead_pid():
+    import subprocess
+    import sys
+
+    proc = subprocess.Popen([sys.executable, "-c", "pass"])
+    proc.wait()
+    return proc.pid
+
+
+# ---------------------------------------------------------------- markers
+
+def test_marker_write_and_remove_roundtrip(hermes_home):
+    cr.write_live_marker("sess-a")
+    path = cr._markers_dir() / "sess-a.json"
+    assert path.is_file()
+    data = json.loads(path.read_text())
+    assert data["session_id"] == "sess-a"
+    assert data["pid"] == os.getpid()
+    cr.remove_live_marker("sess-a")
+    assert not path.exists()
+
+
+def test_marker_write_noop_when_disabled(hermes_home, monkeypatch):
+    monkeypatch.setattr(cr, "is_enabled", lambda: False)
+    cr.write_live_marker("sess-a")
+    assert not (cr._markers_dir() / "sess-a.json").exists()
+
+
+def test_marker_write_noop_on_empty_id(hermes_home):
+    cr.write_live_marker("")
+    assert not cr._markers_dir().exists() or not any(cr._markers_dir().iterdir())
+
+
+# ------------------------------------------------------------------ scan
+
+def test_scan_offers_crashed_session(hermes_home, session_db):
+    _make_session(session_db, "crashed-1", messages=2)
+    _write_dead_marker("crashed-1")
+    offers = cr.find_crashed_sessions(session_db)
+    assert [o["id"] for o in offers] == ["crashed-1"]
+
+
+def test_scan_skips_live_process(hermes_home, session_db):
+    _make_session(session_db, "live-1", messages=2)
+    # Marker owned by THIS (very alive) process.
+    cr.write_live_marker("live-1")
+    assert cr.find_crashed_sessions(session_db) == []
+    # Marker must survive — it belongs to a live session.
+    assert (cr._markers_dir() / "live-1.json").is_file()
+
+
+def test_scan_skips_current_session(hermes_home, session_db):
+    _make_session(session_db, "self-1", messages=1)
+    _write_dead_marker("self-1")
+    assert cr.find_crashed_sessions(session_db, current_session_id="self-1") == []
+
+
+def test_scan_prunes_cleanly_ended_row(hermes_home, session_db):
+    _make_session(session_db, "done-1", messages=1, ended="cli_close")
+    _write_dead_marker("done-1")
+    assert cr.find_crashed_sessions(session_db) == []
+    assert not (cr._markers_dir() / "done-1.json").exists()
+
+
+def test_scan_prunes_deleted_row(hermes_home, session_db):
+    _write_dead_marker("ghost-1")
+    assert cr.find_crashed_sessions(session_db) == []
+    assert not (cr._markers_dir() / "ghost-1.json").exists()
+
+
+def test_scan_prunes_empty_session(hermes_home, session_db):
+    _make_session(session_db, "empty-1", messages=0)
+    _write_dead_marker("empty-1")
+    assert cr.find_crashed_sessions(session_db) == []
+    assert not (cr._markers_dir() / "empty-1.json").exists()
+
+
+def test_scan_prunes_stale_marker(hermes_home, session_db):
+    _make_session(session_db, "old-1", messages=1)
+    _write_dead_marker("old-1", ts=time.time() - cr._STALE_AFTER_SECONDS - 60)
+    assert cr.find_crashed_sessions(session_db) == []
+    assert not (cr._markers_dir() / "old-1.json").exists()
+
+
+def test_scan_prunes_corrupt_marker(hermes_home, session_db):
+    directory = cr._markers_dir()
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / "junk.json").write_text("{not json")
+    assert cr.find_crashed_sessions(session_db) == []
+    assert not (directory / "junk.json").exists()
+
+
+def test_scan_limit_and_ordering(hermes_home, session_db):
+    now = time.time()
+    for i in range(5):
+        sid = f"many-{i}"
+        _make_session(session_db, sid, messages=1)
+        _write_dead_marker(sid)
+        # Stagger last activity so ordering is deterministic (newest first).
+        session_db._execute_write(
+            lambda conn, sid=sid, i=i: conn.execute(
+                "UPDATE sessions SET last_activity_at = ? WHERE id = ?",
+                (now - (5 - i) * 60, sid),
+            )
+        )
+    offers = cr.find_crashed_sessions(session_db, limit=3)
+    assert len(offers) == 3
+    assert [o["id"] for o in offers] == ["many-4", "many-3", "many-2"]
+
+
+def test_scan_disabled_by_config(hermes_home, session_db, monkeypatch):
+    _make_session(session_db, "gated-1", messages=1)
+    _write_dead_marker("gated-1")
+    monkeypatch.setattr(cr, "is_enabled", lambda: False)
+    assert cr.find_crashed_sessions(session_db) == []
+
+
+def test_scan_none_db_is_safe(hermes_home):
+    assert cr.find_crashed_sessions(None) == []

--- a/website/docs/user-guide/sessions.md
+++ b/website/docs/user-guide/sessions.md
@@ -119,6 +119,20 @@ This looks up the most recent `cli` session from the SQLite database and loads i
 
 A bare `-c` is terminal-aware: each CLI session drops a small breadcrumb file under `~/.hermes/terminal-sessions/` keyed by the terminal it runs in (tty device, tmux pane, kitty window, wezterm pane, Zellij pane, Windows Terminal session, ...). When you run `hermes -c` again in the *same* terminal, Hermes resumes that terminal's own session — so two panes side by side each continue their own conversation instead of both grabbing the globally most-recent one. If there's no breadcrumb for the terminal (first use, deleted session, or a stale breadcrumb older than 30 days), `-c` falls back to the most-recent-session behavior. `-c "name"` and `--resume` are unaffected. Disable with `session.terminal_continue: false` in `config.yaml`.
 
+#### Crash Restore Offers
+
+When a CLI process dies without a clean exit — a crash, `kill -9`, a machine restart, or a closed terminal window — the session row is left open with no pointer back to it. Each interactive session keeps a tiny liveness marker under `~/.hermes/runtime/cli-live/` (session id + owning pid), removed on clean exit. At the next interactive startup, Hermes checks for markers whose owning process is gone but whose session still has messages, and offers to restore them:
+
+```
+(o_o) Found session(s) that were still open when their CLI went away:
+
+1   fix auth bug                     42 msgs  2h ago   20260827_141502_a1b2c3
+
+Type a number to restore it, /resume <id> anytime, or just start chatting to ignore.
+```
+
+Typing the number restores the session in place (same mechanics as `/resume`). Sessions still live in another terminal are never offered — pid liveness is paired with the process start time, so a recycled pid can't fake a live session. Disable with `session.crash_restore: false` in `config.yaml`.
+
 ### Resume by Name
 
 If you've given a session a title (see [Session Naming](#session-naming) below), you can resume it by name:


### PR DESCRIPTION
## Summary

Interactive CLI startup now offers to restore sessions whose owning process died without a clean exit — a crash, `kill -9`, a machine restart, or a closed terminal window no longer means digging the session id out of `hermes sessions list` by hand.

Inspired by GitHub Copilot CLI v1.0.81 ([changelog](https://github.com/github/copilot-cli/blob/main/changelog.md)): *"Startup now offers to restore sessions that were still open when their CLI went away, so a crash or a machine restart no longer means reopening each terminal by hand."*

**Their mechanism:** Copilot CLI is closed-source, but the changelog describes a startup restore flow keyed on sessions still open when the process disappeared.

**Our adaptation:** each interactive CLI session writes a liveness marker `$HERMES_HOME/runtime/cli-live/<session_id>.json` (pid + `process_start_time`) when `run()` starts and on every session-id reassignment (`/new`, `/resume`, `/branch`, compression rotation — piggybacked on the existing `_write_terminal_breadcrumb` trigger set). Clean exit removes it. Next interactive startup scans the markers: dead owner + open session row (`ended_at IS NULL`) + at least one message ⇒ offer:

```
(o_o) Found session(s) that were still open when their CLI went away:

1   pre-crash work                     42 msgs  2h ago   20260827_141502_a1b2c3

Type a number to restore it, /resume <id> anytime, or just start chatting to ignore.
```

Typing the number restores in place via the existing `/resume` machinery (the same one-shot numbered selection a bare `/resume` arms, #34584).

## Changes

- `hermes_cli/crash_restore.py` (new): marker write/remove + crashed-session scan with inline housekeeping — markers for cleanly-ended, deleted, empty, or stale (>30d) rows and corrupt files are pruned so the directory can't accumulate
- `cli.py`: marker lifecycle + startup offer (after resume preload, before the input loop); clean-exit removal in the `run()` teardown; `_consume_pending_resume_selection` now resolves against the armed list's own session ids instead of re-numbering through `_list_recent_sessions` (correct for both the `/resume` list and the crash-offer list, and immune to DB shifts between display and reply)
- `hermes_cli/cli_commands_mixin.py`: `/resume` re-points the breadcrumb AND marker at the adopted session
- `hermes_cli/config_defaults.py`: `session.crash_restore` (default true)
- `website/docs/user-guide/sessions.md`: "Crash Restore Offers" section

## Safety properties

- Pid liveness reuses `active_sessions._pid_alive` — pid paired with process create time, so a recycled pid can't fake a live session; sessions genuinely live in another terminal are never offered
- One-shot runs (`-q`/`-Q`) never arm the marker — they end their rows cleanly and need no offer
- Everything is best-effort (never blocks or breaks startup); feature fully off via `session.crash_restore: false`
- No prompt-cache impact: the offer renders before any agent exists; restore goes through the existing `/resume` path

## Validation

| Check | Result |
|---|---|
| `tests/hermes_cli/test_crash_restore.py` (14 new tests) | 14/14 pass |
| Sibling suites (`test_terminal_breadcrumbs`, `test_cli_resume_command`, `test_cli_queue_paste`, `test_pre_command_hook`) | 38/38 pass |
| E2E: real child process writes marker then `os._exit(1)`; real `_offer_crash_restore` on a temp HERMES_HOME | offer rendered, armed list correct, clean-exit removal verified |
| ruff on all touched files | clean |

## Infographic

![Crash Restore infographic](https://v3b.fal.media/files/b/0aa819bc/zcYNaSswzqxkuqhCxJYUQ_P54JqmPS.png)
