### PR TITLE
fix(zai): drop reasoning_effort medium on the glm-5.3 flash SKU

### DIFF
--- a/plugins/model-providers/zai/__init__.py
+++ b/plugins/model-providers/zai/__init__.py
@@ -112,6 +112,16 @@ def _glm_5_2_reasoning_effort(
 
     if _is_glm_5_3(model):
         efforts, overrides, floor = GLM53_EFFORTS, GLM53_OVERRIDES, "low"
+        # The flash SKU of GLM-5.3 rejects ``medium`` with HTTP 400 code
+        # 1210 ("This model always engages in thinking and cannot be
+        # disabled; please use low, high, or max") even though the base
+        # GLM-5.3 accepts the four-step graded scale. Map medium down to
+        # low (nearest-weaker, mirroring the China-endpoint precedent)
+        # rather than letting the request die at the wire (#96838).
+        m = (model or "").strip().lower()
+        if "flash" in m:
+            efforts = tuple(e for e in efforts if e != "medium")
+            overrides = {**overrides, "medium": "low"}
     else:
         efforts, overrides, floor = GLM52_EFFORTS, GLM52_OVERRIDES, "high"
 

--- a/tests/plugins/model_providers/test_zai_profile.py
+++ b/tests/plugins/model_providers/test_zai_profile.py
@@ -181,6 +181,36 @@ class TestZaiGLM53ReasoningEffort:
         )
         assert top_level == {"reasoning_effort": "high"}
 
+    @pytest.mark.parametrize(
+        ("effort", "expected"),
+        [
+            ("low", "low"),
+            # The flash SKU rejects ``medium`` with HTTP 400 code 1210 —
+            # its ladder is low/high/max only (#96838). medium maps to low
+            # (nearest-weaker, declared as an override).
+            ("medium", "low"),
+            ("high", "high"),
+            ("max", "max"),
+            ("xhigh", "max"),
+            ("minimal", "low"),
+        ],
+    )
+    def test_glm_5_3_flash_drops_medium(self, zai_profile, effort, expected):
+        _, top_level = zai_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": effort},
+            model="glm-5.3-flash",
+        )
+        assert top_level == {"reasoning_effort": expected}
+
+    def test_base_glm_5_3_still_accepts_medium(self, zai_profile):
+        """Only the flash SKU loses ``medium``; the base model keeps the
+        four-step graded scale verified live in #91789."""
+        _, top_level = zai_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "medium"},
+            model="glm-5.3",
+        )
+        assert top_level == {"reasoning_effort": "medium"}
+
 
 class TestZaiModelGating:
     """GLM 4.5+ get thinking; earlier GLM models are left untouched."""


### PR DESCRIPTION
## What does this PR do?

Stops `glm-5.3-flash` turns from dying at the wire with HTTP 400 code 1210 when the session's reasoning config carries `medium`.

The base `glm-5.3` accepts the four-step graded effort scale (`low`/`medium`/`high`/`max`, verified live in #91789), but its **flash SKU** rejects `medium` — the error text names its actual ladder: "please use low, high, or max". The declared `GLM53_EFFORTS` vocabulary applied uniformly to every 5.3 model, so any session whose reasoning config carried `medium` (stale session snapshot or explicit config — both observed in #96838) failed on every turn.

The fix narrows the flash SKU's ladder to `low`/`high`/`max` inside the GLM-5.3 branch of the effort mapping and declares `medium → low` as an override (nearest-weaker, mirroring the China-endpoint precedent in this provider). The base model keeps the full graded scale. This also absorbs the reported symptom's payload: even a stale `medium` now lands as `low` instead of a 400.

Scope note: #96838 also describes a deeper defect — the request path building from `_session_init_model_config["reasoning_config"]` captured at session creation rather than the freshly switched config. That is comp/agent session-state territory and is not addressed here; this PR fixes the provider-side vocabulary so the declared effort is always servable.

## Related Issue

Fixes #96838

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/model-providers/zai/__init__.py` — in `_glm_5_2_reasoning_effort`'s GLM-5.3 branch, detect the flash SKU and narrow the ladder to `low`/`high`/`max` with a declared `medium → low` override.
- `tests/plugins/model_providers/test_zai_profile.py` — parametrized regression for the flash SKU ladder (medium→low, the rest unchanged) plus a guard that the base `glm-5.3` still accepts `medium`.

## How to Test

1. `python -m pytest tests/plugins/model_providers/test_zai_profile.py -q` — should pass (47 passed).
2. Red/green verified locally: with the pre-fix mapping restored, the flash `medium → low` case fails (emits `medium`, which the SKU rejects with 1210); with this change all pass.
3. Manual equivalent: `hermes --provider zai --model glm-5.3-flash` with `agent.reasoning_effort: medium` (or a session created under that config) — turns should succeed instead of HTTP 400 code 1210.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (targeted: `tests/plugins/model_providers/test_zai_profile.py` — 47 passed)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.5 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (comment in place)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
