### PR TITLE
fix(desktop): keep closeable pane tabs visible

### DIFF
--- a/apps/desktop/src/components/pane-shell/tree/renderer/stranded-close-affordance.test.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/stranded-close-affordance.test.tsx
@@ -1,0 +1,139 @@
+import { useStore } from '@nanostores/react'
+import { cleanup, render } from '@testing-library/react'
+import { act } from 'react'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { registry } from '@/contrib/registry'
+import { setTabStripDefault } from '@/store/tabstrip-prefs'
+
+import { group, split } from '../model'
+import {
+  $dismissedPanes,
+  $hiddenTreePanes,
+  $layoutTree,
+  closeTreePane,
+  registerPaneCloser,
+  setTreePaneHidden
+} from '../store'
+
+import { TreeGroup } from './tree-group'
+
+class TestResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+beforeAll(() => {
+  vi.stubGlobal('ResizeObserver', TestResizeObserver)
+  vi.stubGlobal('CSS', { ...globalThis.CSS, escape: (value: string) => value })
+  Element.prototype.hasPointerCapture ??= () => false
+  Element.prototype.setPointerCapture ??= () => undefined
+  Element.prototype.releasePointerCapture ??= () => undefined
+  HTMLElement.prototype.scrollIntoView ??= () => undefined
+})
+
+const disposers: (() => void)[] = []
+
+function registerPane(id: string, data: Record<string, unknown>, source?: string) {
+  disposers.push(
+    registry.register({
+      area: 'panes',
+      data,
+      id,
+      render: () => <div>{id}</div>,
+      source,
+      title: id
+    })
+  )
+}
+
+function LiveTreeGroups() {
+  const tree = useStore($layoutTree)
+
+  if (!tree) {
+    return null
+  }
+
+  const groups = tree.type === 'group' ? [tree] : tree.children.filter(child => child.type === 'group')
+  const parentAxis = tree.type === 'split' ? tree.orientation : 'row'
+
+  return groups.map(node => <TreeGroup key={node.id} node={node} parentAxis={parentAxis} />)
+}
+
+const tab = (paneId: string) => globalThis.document.querySelector(`[data-tree-tab="${paneId}"]`)
+const closeButton = (paneId: string) => tab(paneId)?.querySelector('button[aria-label]')
+
+beforeEach(() => {
+  window.localStorage.clear()
+  setTabStripDefault('auto')
+  $dismissedPanes.set(new Set())
+  $hiddenTreePanes.set(new Set())
+  $layoutTree.set(null)
+})
+
+afterEach(() => {
+  cleanup()
+  registerPaneCloser('workspace')
+  registerPaneCloser('core-side-pane')
+  disposers.splice(0).forEach(dispose => dispose())
+})
+
+describe('a closeable pane never loses its only visible Close affordance', () => {
+  it('keeps a private runtime-plugin tab after its core sibling closes', () => {
+    registerPane('core-side-pane', { placement: 'right' })
+    registerPane('custom-plugin:pane', { placement: 'right', width: '320px' }, 'plugin:custom-plugin')
+    registerPaneCloser('core-side-pane', () => setTreePaneHidden('core-side-pane', true))
+    $layoutTree.set(
+      group(['core-side-pane', 'custom-plugin:pane'], {
+        active: 'core-side-pane',
+        id: 'grp-right'
+      })
+    )
+
+    render(<LiveTreeGroups />)
+    expect(tab('custom-plugin:pane')).not.toBeNull()
+
+    act(() => closeTreePane('core-side-pane'))
+
+    expect(tab('custom-plugin:pane')).not.toBeNull()
+  })
+
+  it('keeps the closable workspace tab after its session sibling closes', () => {
+    registerPane('workspace', { placement: 'main', uncloseable: true })
+    registerPane('session-tile:other', { placement: 'main' })
+    registerPaneCloser('workspace', vi.fn())
+    $layoutTree.set(
+      group(['workspace', 'session-tile:other'], {
+        active: 'session-tile:other',
+        id: 'grp-main'
+      })
+    )
+
+    render(<LiveTreeGroups />)
+    expect(tab('workspace')).not.toBeNull()
+
+    act(() => closeTreePane('session-tile:other'))
+
+    expect(tab('workspace')).not.toBeNull()
+  })
+
+  it('keeps title, drag and Close tabs on both vertically split chat zones', () => {
+    registerPane('workspace', { placement: 'main', uncloseable: true })
+    registerPane('session-tile:lower', { placement: 'main' })
+    $layoutTree.set(
+      split('column', [
+        group(['workspace'], { active: 'workspace', id: 'grp-chat-top' }),
+        group(['session-tile:lower'], { active: 'session-tile:lower', id: 'grp-chat-bottom' })
+      ])
+    )
+
+    render(<LiveTreeGroups />)
+    act(() => registerPaneCloser('workspace', vi.fn()))
+
+    expect(tab('workspace')).not.toBeNull()
+    expect(closeButton('workspace')).not.toBeNull()
+    expect(tab('session-tile:lower')).not.toBeNull()
+    expect(closeButton('session-tile:lower')).not.toBeNull()
+  })
+})

--- a/apps/desktop/src/components/pane-shell/tree/renderer/strip-visibility.test.ts
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/strip-visibility.test.ts
@@ -10,6 +10,28 @@ const workspace = (): StripPane => ({ collapsePane: false, placement: 'main', un
 const toolPanel = (): StripPane => ({ collapsePane: true, placement: 'bottom' })
 const sideChrome = (): StripPane => ({ collapsePane: false, placement: 'right' })
 
+const pluginSidePane = (): StripPane => ({
+  collapsePane: false,
+  placement: 'right',
+  source: 'plugin:custom-plugin'
+})
+
+// Bots is hide-only AND plugin-registered — the plugin stranding rung must
+// not claim it, or `never` becomes a silent no-op again (960dee7fe).
+const hideOnlyPluginPane = (): StripPane => ({
+  collapsePane: false,
+  hideOnly: true,
+  placement: 'left',
+  source: 'plugin:hermes-bots'
+})
+
+const closableWorkspace = (): StripPane => ({
+  collapsePane: false,
+  hasCloser: true,
+  placement: 'main',
+  uncloseable: true
+})
+
 describe('auto (no stored choice)', () => {
   it('gives a lone workspace no strip and a stack of two a strip', () => {
     expect(resolveTabStripVisible({ shown: [workspace()] })).toBe(false)
@@ -44,10 +66,25 @@ describe('no dead zone', () => {
     expect(resolveTabStripVisible({ mode: 'never', shown: [toolPanel()] })).toBe(true)
   })
 
+  it('keeps the host-owned Close surface for a lone runtime-plugin side pane', () => {
+    expect(resolveTabStripVisible({ mode: 'never', shown: [pluginSidePane()] })).toBe(true)
+  })
+
+  it('does not let the plugin rung claim hide-only plugin chrome (Bots)', () => {
+    // 960dee7fe: hide-only chrome is not stranded — never works, ⌘⌥T
+    // recovers. The plugin-provenance rung must respect the hideOnly guard.
+    expect(resolveTabStripVisible({ mode: 'never', shown: [hideOnlyPluginPane()] })).toBe(false)
+  })
+
+  it('keeps a main tab whose app-owned closer overrides structural uncloseability', () => {
+    expect(resolveTabStripVisible({ mode: 'never', shown: [closableWorkspace()] })).toBe(true)
+  })
+
   it('still hides a zone that cannot strand anything', () => {
-    // The workspace is uncloseable, a stack is reachable by tab cycling, and
-    // hide-only chrome (sessions / Bots) keeps its panes + ⌘⌥T — the invariant
-    // protects handles, it does not veto hiding as such.
+    // The workspace is uncloseable (without an app-owned closer), a stack is
+    // reachable by tab cycling, and hide-only chrome (sessions / Bots) keeps
+    // its panes + ⌘⌥T — the invariant protects handles, it does not veto
+    // hiding as such.
     expect(resolveTabStripVisible({ mode: 'never', shown: [workspace()] })).toBe(false)
     expect(resolveTabStripVisible({ mode: 'never', shown: [toolPanel(), toolPanel()] })).toBe(false)
     expect(resolveTabStripVisible({ mode: 'never', shown: [sideChrome()] })).toBe(false)
@@ -104,6 +141,7 @@ describe('tabStripVisibleForZone', () => {
   const visible = (shown: string[], mode?: 'always' | 'never') =>
     tabStripVisibleForZone({
       active: shown[0],
+      hasCloser: () => false,
       isCollapsePane: id => id === 'terminal',
       mode,
       paneFor: id => contributions[id],

--- a/apps/desktop/src/components/pane-shell/tree/renderer/strip-visibility.ts
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/strip-visibility.ts
@@ -9,7 +9,8 @@
  * a function of what it currently holds plus one deliberate choice.
  */
 
-import type { Contribution } from '@/contrib/types'
+import { isPluginSource } from '@/contrib/plugin-source'
+import type { Contribution, ContributionSource } from '@/contrib/types'
 import { effectiveTabStripMode } from '@/store/tabstrip-prefs'
 
 import type { TabStripMode } from '../model'
@@ -33,7 +34,7 @@ export interface StripPane {
   placement?: string
   /** Runtime-plugin provenance. A contributed pane has no guaranteed core
    *  titlebar toggle, so its tab is the host-owned Close surface. */
-  source?: string
+  source?: ContributionSource
   /** Panes that never leave the tree (the workspace). */
   uncloseable?: boolean
 }
@@ -83,7 +84,7 @@ function closeNeedsStrip(pane: StripPane): boolean {
   // Main tenants are tabs by design. Runtime plugins also need host chrome:
   // unlike core sidebars, they have no guaranteed titlebar/palette toggle to
   // replace the tab's Close action when they become a lone side pane.
-  return pane.placement === 'main' || Boolean(pane.source?.startsWith('plugin:'))
+  return pane.placement === 'main' || isPluginSource(pane.source)
 }
 
 function stranded(shown: readonly StripPane[]): boolean {

--- a/apps/desktop/src/components/pane-shell/tree/renderer/strip-visibility.ts
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/strip-visibility.ts
@@ -19,9 +19,21 @@ import { paneChrome } from './track-model'
 export interface StripPane {
   /** A tool panel (terminal / logs) that collapses rather than closes. */
   collapsePane: boolean
+  /** An app-owned close route can make a structurally uncloseable pane's TAB
+   *  closeable (the workspace empties into the next session / a fresh draft). */
+  hasCloser?: boolean
+  /** Standing chrome (sessions / Bots) whose only handle is the strip:
+   *  show/hide replaces Close, and the Show/Hide rows live on the strip.
+   *  Read as a GUARD, not a stranding rung — per 960dee7fe, hide-only chrome
+   *  is NOT stranded at any count (never works, ⌘⌥T recovers) — but Bots is
+   *  plugin-registered, so the plugin rung below must not claim it either. */
+  hideOnly?: boolean
   /** Contribution placement — `'main'` marks a docked tile (session, page,
    *  preview) as opposed to standing side chrome. */
   placement?: string
+  /** Runtime-plugin provenance. A contributed pane has no guaranteed core
+   *  titlebar toggle, so its tab is the host-owned Close surface. */
+  source?: string
   /** Panes that never leave the tree (the workspace). */
   uncloseable?: boolean
 }
@@ -43,7 +55,11 @@ export interface StripZone {
  * or lost, so a lone chat is free to be chromeless. Hide-only chrome (sessions
  * / Bots) is the same: the panes stay, Show/Hide is a separate verb, and a
  * hidden strip comes back via ⌘⌥T. Treating it as stranded at any count made
- * Hide tabs a silent no-op on the sessions sidebar.
+ * Hide tabs a silent no-op on the sessions sidebar. An app-owned close route
+ * (the workspace empties into the next session / a fresh draft) makes even a
+ * structurally fixed pane's TAB actionable, and a runtime-plugin pane has no
+ * core titlebar toggle to fall back on — both keep the strip as the last
+ * handle (#96852).
  *
  * This outranks an explicit `never` on purpose. "Hide the strip" is a request
  * about chrome, never a request to make a surface unreachable, and a zone that
@@ -57,6 +73,19 @@ export interface StripZone {
  * accumulates tabs: unscoped, one session tab in main pinned the strip on and
  * both the menu row and ⌘⌥T became silent no-ops.
  */
+function closeNeedsStrip(pane: StripPane): boolean {
+  const closeable = !pane.hideOnly && (!pane.uncloseable || pane.hasCloser)
+
+  if (!closeable) {
+    return false
+  }
+
+  // Main tenants are tabs by design. Runtime plugins also need host chrome:
+  // unlike core sidebars, they have no guaranteed titlebar/palette toggle to
+  // replace the tab's Close action when they become a lone side pane.
+  return pane.placement === 'main' || Boolean(pane.source?.startsWith('plugin:'))
+}
+
 function stranded(shown: readonly StripPane[]): boolean {
   if (shown.length !== 1) {
     return false
@@ -64,7 +93,11 @@ function stranded(shown: readonly StripPane[]): boolean {
 
   const [only] = shown
 
-  return only.collapsePane || (!only.uncloseable && only.placement === 'main')
+  // Lone-pane rungs (scoped per 2c5294597 — a multi-tab stack answers cycling
+  // and ⌘1…⌘9, so its strip is chrome, not a handle): a lone collapsing panel
+  // needs its chip, and a lone pane whose tab carries Close (closeable tile,
+  // workspace with an app-owned closer, runtime-plugin pane) needs its ✕.
+  return only.collapsePane || closeNeedsStrip(only)
 }
 
 export function resolveTabStripVisible(zone: StripZone): boolean {
@@ -101,6 +134,7 @@ export function resolveTabStripVisible(zone: StripZone): boolean {
 export function tabStripVisibleForZone(zone: {
   /** The zone's ACTIVE pane. */
   active: string
+  hasCloser: (id: string) => boolean
   isCollapsePane: (id: string) => boolean
   /** The zone's own choice, before the app default applies. */
   mode: TabStripMode | undefined
@@ -112,11 +146,15 @@ export function tabStripVisibleForZone(zone: {
     headerVeto: paneChrome(zone.paneFor(zone.active)).headerVeto,
     mode: effectiveTabStripMode(zone.mode),
     shown: zone.shown.map(id => {
-      const chrome = paneChrome(zone.paneFor(id))
+      const pane = zone.paneFor(id)
+      const chrome = paneChrome(pane)
 
       return {
         collapsePane: zone.isCollapsePane(id),
+        hasCloser: zone.hasCloser(id),
+        hideOnly: chrome.hideOnly,
         placement: chrome.placement,
+        source: pane?.source,
         uncloseable: chrome.uncloseable
       }
     })

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
@@ -339,6 +339,8 @@ export function TreeGroup({
   // the keystroke and the screen always agree about which way "toggle" points.
   const stripVisible = tabStripVisibleForZone({
     active: activeId,
+    // Reactive snapshot of the same atom tabStripVisibleForGroup reads via
+    // `.get()`, so the rendered strip and imperative toggle cannot diverge.
     hasCloser: id => panesWithCloser.has(id),
     isCollapsePane,
     mode: node.tabStrip,

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
@@ -339,6 +339,7 @@ export function TreeGroup({
   // the keystroke and the screen always agree about which way "toggle" points.
   const stripVisible = tabStripVisibleForZone({
     active: activeId,
+    hasCloser: id => panesWithCloser.has(id),
     isCollapsePane,
     mode: node.tabStrip,
     paneFor,

--- a/apps/desktop/src/components/pane-shell/tree/store.ts
+++ b/apps/desktop/src/components/pane-shell/tree/store.ts
@@ -7,6 +7,7 @@
 import { atom, computed, type ReadableAtom } from 'nanostores'
 
 import { SIDEBAR_COLLAPSE_MEDIA_QUERY } from '@/app/layout-constants'
+import { isPluginSource, pluginIdFromSource } from '@/contrib/plugin-source'
 import { setPluginEnabled } from '@/contrib/plugins-store'
 import { registry } from '@/contrib/registry'
 import { translateNow } from '@/i18n'
@@ -769,7 +770,9 @@ export function tabStripVisibleForGroup(group: GroupNode): boolean {
 
   return tabStripVisibleForZone({
     active: group.active,
-    hasCloser: id => Boolean(paneClosers[id]),
+    // Same source as TreeGroup's reactive snapshot; `.get()` serves this
+    // imperative command path without creating a second closability concept.
+    hasCloser: id => $panesWithCloser.get().has(id),
     isCollapsePane,
     mode: group.tabStrip,
     paneFor: (id: string) => registered.find(c => c.id === id),
@@ -937,7 +940,7 @@ export function closeTreePane(paneId: string) {
   const panes = registry.getArea('panes')
   const source = panes.find(c => c.id === paneId)?.source
 
-  if (source?.startsWith('plugin:')) {
+  if (isPluginSource(source)) {
     // A plugin may own several independent panes. Closing one of them must not
     // unload every contribution from that plugin (for example, closing Bot
     // Mode's Cronjobs pane must leave its Bots roster and composer middleware
@@ -952,7 +955,7 @@ export function closeTreePane(paneId: string) {
     // A single-pane plugin keeps the existing symmetric behavior: Close uses
     // the same switch as Capabilities → Plugins. Its contribution unregisters but
     // the pane id stays in the tree, so re-enabling restores its exact place.
-    const pluginId = source.slice('plugin:'.length)
+    const pluginId = pluginIdFromSource(source)
     void setPluginEnabled(pluginId, false)
     notify({
       kind: 'info',

--- a/apps/desktop/src/components/pane-shell/tree/store.ts
+++ b/apps/desktop/src/components/pane-shell/tree/store.ts
@@ -769,6 +769,7 @@ export function tabStripVisibleForGroup(group: GroupNode): boolean {
 
   return tabStripVisibleForZone({
     active: group.active,
+    hasCloser: id => Boolean(paneClosers[id]),
     isCollapsePane,
     mode: group.tabStrip,
     paneFor: (id: string) => registered.find(c => c.id === id),

--- a/apps/desktop/src/contrib/plugin-source.ts
+++ b/apps/desktop/src/contrib/plugin-source.ts
@@ -1,0 +1,13 @@
+import type { ContributionSource } from './types'
+
+/** Canonical provenance vocabulary for host-scoped plugin contributions. */
+export const PLUGIN_SOURCE_PREFIX = 'plugin:' as const
+export type PluginSource = `${typeof PLUGIN_SOURCE_PREFIX}${string}`
+
+export const pluginSource = (pluginId: string): PluginSource => `${PLUGIN_SOURCE_PREFIX}${pluginId}`
+
+export function isPluginSource(source: ContributionSource | undefined): source is PluginSource {
+  return source?.startsWith(PLUGIN_SOURCE_PREFIX) ?? false
+}
+
+export const pluginIdFromSource = (source: PluginSource): string => source.slice(PLUGIN_SOURCE_PREFIX.length)

--- a/apps/desktop/src/contrib/plugin.test.ts
+++ b/apps/desktop/src/contrib/plugin.test.ts
@@ -3,8 +3,21 @@ import { describe, expect, it, vi } from 'vitest'
 import { dispatchPluginNativeNotification } from '@/store/native-notifications'
 
 import { createPluginContext } from './plugin'
+import { isPluginSource, pluginIdFromSource } from './plugin-source'
 
 vi.mock('@/store/native-notifications', () => ({ dispatchPluginNativeNotification: vi.fn() }))
+
+describe('plugin contribution source contract', () => {
+  it('emits and recognizes the canonical plugin:<id> provenance', () => {
+    const source = createPluginContext('demo').source
+
+    expect(source).toBe('plugin:demo')
+    expect(isPluginSource(source)).toBe(true)
+    expect(pluginIdFromSource(source)).toBe('demo')
+    expect(isPluginSource('core')).toBe(false)
+    expect(isPluginSource(undefined)).toBe(false)
+  })
+})
 
 describe('createPluginContext.onDispose', () => {
   it('collects arbitrary cleanups so the host runs them on deactivate', () => {

--- a/apps/desktop/src/contrib/plugin.ts
+++ b/apps/desktop/src/contrib/plugin.ts
@@ -17,6 +17,7 @@ import { createPluginI18n, type PluginI18n } from '@/i18n'
 import { readKey, writeKey } from '@/lib/storage'
 import { dispatchPluginNativeNotification, type PluginNativeNotificationInput } from '@/store/native-notifications'
 
+import { pluginSource, type PluginSource } from './plugin-source'
 import { registry } from './registry'
 import type { Contribution } from './types'
 
@@ -74,7 +75,7 @@ export interface PluginFileDialogOptions {
 
 export interface PluginContext {
   /** The resolved plugin source tag, e.g. `'plugin:cost-meter'`. */
-  readonly source: string
+  readonly source: PluginSource
   /** Register one contribution (id namespaced, source stamped). */
   register: (c: PluginContribution) => () => void
   /** Register several at once; the returned disposer removes all of them. */
@@ -197,7 +198,7 @@ function createPluginOs(pluginId: string): PluginOs {
 /** Build the scoped context handed to a plugin's `register`. `onDispose`
  *  receives every registration's disposer (the loader's unload/reload hook). */
 export function createPluginContext(pluginId: string, onDispose?: (dispose: () => void) => void): PluginContext {
-  const source = `plugin:${pluginId}`
+  const source = pluginSource(pluginId)
   const scope = (c: PluginContribution): Contribution => ({ ...c, id: `${pluginId}:${c.id}`, source })
 
   const track = (dispose: () => void) => {


### PR DESCRIPTION
## Summary

- keep a runtime-contributed pane's host tab/title strip visible when a sibling closes and the tab carries its only visible Close action
- treat the main workspace's registered tab closer as real closability, so closing another session tab cannot leave the surviving chat without its tab/title strip
- preserve full-page header vetoes, hide-only chrome, tool-panel restore handles, and the clean headerless behavior of ordinary core sidebars

## Root cause

The tab-strip resolver classified stranding from static pane chrome only. It protected closeable `placement: 'main'` tiles, but it did not receive either:

1. runtime contribution provenance for a side pane with no guaranteed core titlebar toggle; or
2. the app-owned closer that makes the structurally `uncloseable` workspace tab actionable.

After a sibling closed, auto mode saw one apparent standing/uncloseable pane and removed the strip that owned Close.

## Regression history

`315307f139d` centralized tab-strip visibility around static pane metadata. `584f3a748bc` later repaired the same reachability invariant for `hideOnly` panes, but effective closability from registered pane owners and runtime contribution provenance still never reached the resolver. This change completes that existing invariant without changing full-page or core-sidebar policy.

## Test plan

- [x] regression test: a generic runtime plugin side pane keeps its tab after its core sibling closes through its visibility owner
- [x] regression test: the closable workspace keeps its tab after a sibling session tile closes
- [x] regression test: two vertically stacked middle chat zones both retain title/drag tabs and visible Close buttons
- [x] focused strip tests: 17 passed
- [x] complete pane-shell tree suite: 156 passed
- [x] changed-file ESLint: 0 errors, 0 warnings
- [x] production renderer/Electron build, native dependency staging, and `assert-dist-built`: passed

## Local baseline notes

- Repository-wide TypeScript currently fails in the untouched checkout with duplicate React type identities; no diagnostics point to the changed files.
- The full UI run reaches 6,097 passing tests but retains unrelated `@assistant-ui/tap` update-depth failures in existing thread-edit/streaming tests. The complete affected pane-shell suite is green.

Related: #89350, #87411
