### PR TITLE
fix(update): enforce systemd worker generation boundary

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -7277,6 +7277,13 @@ def _cmd_update_impl(args, gateway_mode: bool):
     # every planned runtime against the phase's bookkeeping (restart via
     # declared mechanism — the plan is the worklist, not just a printout).
     _pre_update_plan = None
+    # Linux user-systemd installs get a stricter, exact worker-generation
+    # boundary in addition to the generic cross-platform runtime inventory.
+    # Keep the pre-mutation module object alive across the source swap: its
+    # injected runner and parsed snapshot are deliberately self-contained.
+    _systemd_worker_boundary = None
+    _systemd_boundary_snapshot = None
+    _systemd_boundary_units: set[str] = set()
     try:
         from hermes_cli.update_inventory import (
             collect_runtime_inventory,
@@ -7595,6 +7602,27 @@ def _cmd_update_impl(args, gateway_mode: bool):
 
     # Fetch and pull
     try:
+
+        # Capture exact user units before checkout/merge can mutate source.
+        # Once the existing capability probe says user systemd is relevant,
+        # inventory errors are fatal: an empty result cannot be distinguished
+        # from a failed user bus and must not permit an in-place code swap.
+        try:
+            from hermes_cli.gateway import supports_systemd_services
+            from hermes_cli.update_systemd_boundary import (
+                capture_systemd_worker_boundary,
+            )
+
+            _captured_boundary = capture_systemd_worker_boundary(
+                relevant=supports_systemd_services()
+            )
+            if _captured_boundary is not None:
+                _systemd_worker_boundary, _systemd_boundary_snapshot = (
+                    _captured_boundary
+                )
+        except Exception as exc:
+            print(f"✗ Cannot establish the systemd worker boundary: {exc}")
+            sys.exit(1)
 
         # Resolve the target branch up front so the fetch can be scoped to it.
         # A bare `git fetch origin` pulls every ref, and this repo carries
@@ -8829,6 +8857,35 @@ def _cmd_update_impl(args, gateway_mode: bool):
         # path forwards it to the update receipt.
         killed_pids: set = set()
 
+        # The source and dependencies now form the installed generation.  Move
+        # every exact user-systemd target captured before mutation through the
+        # canary/fleet boundary before the older generic restart logic runs.
+        # On failure monitors intentionally stay paused and the exception's
+        # recovery text names every affected unit.
+        if (
+            _systemd_worker_boundary is not None
+            and _systemd_boundary_snapshot is not None
+            and _systemd_boundary_snapshot.targets
+        ):
+            try:
+                _systemd_boundary_units = set(
+                    _systemd_worker_boundary.transition(_systemd_boundary_snapshot)
+                )
+                restarted_services.extend(sorted(_systemd_boundary_units))
+            except Exception as exc:
+                print(f"✗ Systemd worker generation transition failed: {exc}")
+                gateway_fleet_restart_incomplete = True
+                failed_or_stale_units.extend(
+                    sorted(_systemd_boundary_snapshot.targets)
+                )
+                try:
+                    from hermes_cli.update_receipt import finalize_update_receipt
+
+                    finalize_update_receipt("partial")
+                except Exception:
+                    pass
+                sys.exit(1)
+
         # Auto-restart ALL gateways after update.
         # The code update (git pull) is shared across all profiles, so every
         # running gateway needs restarting to pick up the new code.
@@ -9065,6 +9122,12 @@ def _cmd_update_impl(args, gateway_mode: bool):
                         continue
 
                     def _restart_one_systemd_gateway_unit(svc_name: str) -> None:
+                        # Already transitioned and exactly reconciled by the
+                        # user-systemd generation boundary above. Restarting it
+                        # again would destroy the canary proof and start-time
+                        # evidence we just established.
+                        if svc_name in _systemd_boundary_units:
+                            return
                         # Check if active
                         check = subprocess.run(
                             scope_cmd + ["is-active", svc_name],
@@ -9872,6 +9935,12 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 gateway_fleet_restart_incomplete = True
         except Exception as _fleet_exc:
             logger.debug("Fleet version verification failed: %s", _fleet_exc)
+            if _systemd_boundary_units:
+                print(
+                    "\n⚠ Fleet version verification raised after the systemd "
+                    f"transition: {_fleet_exc}"
+                )
+                gateway_fleet_restart_incomplete = True
 
         # Plan-vs-execution reconciliation (#91277 Phase 2, restart via
         # declared mechanism): every runtime the PLAN saw must be accounted
@@ -9906,6 +9975,33 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     pass
         except Exception as _outcome_exc:
             logger.debug("Runtime-outcome reconciliation failed: %s", _outcome_exc)
+            if _systemd_boundary_units:
+                print(
+                    "\n⚠ Runtime-outcome reconciliation raised after the "
+                    f"systemd transition: {_outcome_exc}"
+                )
+                gateway_fleet_restart_incomplete = True
+
+        # The systemd boundary intentionally left optional Buzz health/e2e
+        # monitors paused while the authoritative code-SHA fleet matrix and
+        # plan-vs-execution reconciliation ran. Re-arm only after both proofs
+        # pass; a failed timer/e2e start makes the update partial/non-zero.
+        if (
+            _systemd_worker_boundary is not None
+            and _systemd_boundary_snapshot is not None
+            and _systemd_boundary_units
+            and not gateway_fleet_restart_incomplete
+        ):
+            try:
+                _systemd_worker_boundary.rearm_monitors(
+                    _systemd_boundary_snapshot
+                )
+            except Exception as _monitor_exc:
+                print(f"✗ Systemd monitor re-arm failed: {_monitor_exc}")
+                gateway_fleet_restart_incomplete = True
+                failed_or_stale_units.extend(
+                    sorted(_systemd_boundary_snapshot.targets)
+                )
 
         try:
             from hermes_cli.update_receipt import finalize_update_receipt

--- a/hermes_cli/update_systemd_boundary.py
+++ b/hermes_cli/update_systemd_boundary.py
@@ -1,0 +1,447 @@
+"""Fail-closed systemd worker-generation boundary for ``hermes update``.
+
+The generic update inventory remains cross-platform.  This module is the
+Linux/systemd-specific execution boundary: it snapshots exact user units,
+quiesces them, starts a canary generation, and reconciles the complete unit
+set before health/e2e monitors are re-armed.  All command execution and
+runtime identity collection are injected so tests never contact a real user
+manager.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from typing import Callable, Mapping, Sequence
+
+
+class WorkerBoundaryError(RuntimeError):
+    """The generation boundary could not prove a complete, fresh fleet."""
+
+
+@dataclass(frozen=True)
+class SystemdUnit:
+    name: str
+    load_state: str
+    enabled_state: str
+    active_state: str
+    sub_state: str
+    main_pid: int
+    start_monotonic_usec: int
+    exec_start: str
+    fragment_path: str
+
+    @property
+    def enabled(self) -> bool:
+        return self.enabled_state in {
+            "enabled",
+            "enabled-runtime",
+            "linked",
+            "linked-runtime",
+        }
+
+    @property
+    def running(self) -> bool:
+        return self.main_pid > 0 or self.active_state in {
+            "active",
+            "activating",
+            "reloading",
+        }
+
+
+@dataclass(frozen=True)
+class WorkerBoundarySnapshot:
+    targets: Mapping[str, SystemdUnit]
+    monitors: tuple[str, ...]
+    concierge_e2e_services: tuple[str, ...]
+
+
+Runner = Callable[[Sequence[str]], subprocess.CompletedProcess]
+IdentityCollector = Callable[[], Mapping[str, Mapping[str, str]]]
+CanaryVerifier = Callable[[SystemdUnit], bool]
+
+_SHOW_PROPERTIES = (
+    "Id,LoadState,UnitFileState,ActiveState,SubState,MainPID,"
+    "ExecMainStartTimestampMonotonic,ExecStart,FragmentPath"
+)
+_ENABLED_STATES = {"enabled", "enabled-runtime", "linked", "linked-runtime"}
+
+
+def _default_runner(command: Sequence[str]) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        list(command),
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=15,
+        check=False,
+    )
+
+
+def _unit_is_target(name: str) -> bool:
+    return (
+        (name.startswith("hermes-gateway") and name.endswith(".service"))
+        or name in {"hermes-dashboard.service", "hermes-webui.service"}
+    )
+
+
+def _unit_is_monitor(name: str) -> bool:
+    lowered = name.lower()
+    return (
+        name.endswith(".timer")
+        and "buzz" in lowered
+        and ("health" in lowered or "e2e" in lowered)
+    )
+
+
+def _unit_is_concierge_e2e(name: str) -> bool:
+    lowered = name.lower()
+    return (
+        name.endswith(".service")
+        and "buzz" in lowered
+        and "concierge" in lowered
+        and "e2e" in lowered
+    )
+
+
+def _parse_list_names(text: str) -> set[str]:
+    names: set[str] = set()
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        name = line.split(None, 1)[0]
+        if name.endswith((".service", ".timer")):
+            names.add(name)
+    return names
+
+
+def _parse_show(text: str) -> dict[str, SystemdUnit]:
+    records: dict[str, SystemdUnit] = {}
+    for block in text.strip().split("\n\n") if text.strip() else []:
+        values: dict[str, str] = {}
+        for line in block.splitlines():
+            key, separator, value = line.partition("=")
+            if separator:
+                values[key] = value
+        name = values.get("Id", "")
+        if not name:
+            continue
+        try:
+            pid = int(values.get("MainPID", "0") or 0)
+            started = int(values.get("ExecMainStartTimestampMonotonic", "0") or 0)
+        except ValueError as exc:
+            raise WorkerBoundaryError(
+                f"systemd returned invalid process metadata for {name}: {exc}"
+            ) from exc
+        records[name] = SystemdUnit(
+            name=name,
+            load_state=values.get("LoadState", ""),
+            enabled_state=values.get("UnitFileState", ""),
+            active_state=values.get("ActiveState", ""),
+            sub_state=values.get("SubState", ""),
+            main_pid=pid,
+            start_monotonic_usec=started,
+            exec_start=values.get("ExecStart", ""),
+            fragment_path=values.get("FragmentPath", ""),
+        )
+    return records
+
+
+class SystemdWorkerBoundary:
+    """Own one update's exact user-service generation transition."""
+
+    def __init__(
+        self,
+        runner: Runner = _default_runner,
+        *,
+        identity_collector: IdentityCollector | None = None,
+        canary_verifier: CanaryVerifier | None = None,
+        monotonic: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._runner = runner
+        self._identity_collector = identity_collector
+        self._canary_verifier = canary_verifier
+        self._monotonic = monotonic
+
+    def _run(self, *args: str) -> subprocess.CompletedProcess:
+        command = ["systemctl", "--user", *args]
+        try:
+            result = self._runner(command)
+        except Exception as exc:
+            raise WorkerBoundaryError(
+                f"systemd user-manager command failed: {' '.join(command)}: {exc}"
+            ) from exc
+        if result.returncode != 0:
+            detail = (result.stderr or result.stdout or "no diagnostic").strip()
+            raise WorkerBoundaryError(
+                f"systemd user-manager command failed: {' '.join(command)}: {detail}"
+            )
+        return result
+
+    def _show(self, names: Sequence[str]) -> dict[str, SystemdUnit]:
+        if not names:
+            return {}
+        result = self._run(
+            "show",
+            *sorted(set(names)),
+            f"--property={_SHOW_PROPERTIES}",
+            "--no-pager",
+        )
+        units = _parse_show(result.stdout or "")
+        missing = sorted(set(names) - set(units))
+        if missing:
+            raise WorkerBoundaryError(
+                "systemd omitted requested unit metadata: " + ", ".join(missing)
+            )
+        return units
+
+    def inventory(self) -> WorkerBoundarySnapshot:
+        """Enumerate exact installed/loaded units without shell patterns."""
+        files = self._run(
+            "list-unit-files",
+            "--type=service,timer",
+            "--all",
+            "--plain",
+            "--no-legend",
+            "--no-pager",
+        )
+        loaded = self._run(
+            "list-units",
+            "--type=service,timer",
+            "--all",
+            "--plain",
+            "--no-legend",
+            "--no-pager",
+        )
+        names = _parse_list_names(files.stdout or "") | _parse_list_names(
+            loaded.stdout or ""
+        )
+        relevant = sorted(
+            name
+            for name in names
+            if _unit_is_target(name)
+            or _unit_is_monitor(name)
+            or _unit_is_concierge_e2e(name)
+        )
+        units = self._show(relevant)
+        targets = {
+            name: unit
+            for name, unit in units.items()
+            if _unit_is_target(name) and (unit.enabled or unit.running)
+        }
+        monitors = tuple(
+            sorted(
+                name
+                for name, unit in units.items()
+                if _unit_is_monitor(name) and (unit.enabled or unit.running)
+            )
+        )
+        concierge = tuple(
+            sorted(
+                name
+                for name, unit in units.items()
+                # One-shot services are commonly static/inactive. Presence as
+                # a loaded unit is enough to make them an installed lifecycle
+                # hook; unlike worker targets, they need not be enabled.
+                if _unit_is_concierge_e2e(name) and unit.load_state == "loaded"
+            )
+        )
+        return WorkerBoundarySnapshot(targets, monitors, concierge)
+
+    def _recover_hint(self, units: Sequence[str]) -> str:
+        names = ", ".join(sorted(set(units))) or "the affected Hermes units"
+        return (
+            f"Affected units: {names}. Monitors were left paused. Recover with "
+            "`systemctl --user reset-failed <unit>` and "
+            "`systemctl --user restart <unit>`, then verify the fleet before "
+            "starting its Buzz health/e2e timers."
+        )
+
+    def _verify_wave(
+        self,
+        names: Sequence[str],
+        before: WorkerBoundarySnapshot,
+        generation_usec: int,
+        expected_identity: Mapping[str, str] | None,
+    ) -> dict[str, SystemdUnit]:
+        current = self._show(names)
+        failures: list[str] = []
+        identities = self._identity_collector() if self._identity_collector else {}
+        for name in names:
+            old = before.targets[name]
+            new = current[name]
+            if new.active_state != "active" or new.main_pid <= 0:
+                failures.append(f"{name} is {new.active_state}/{new.sub_state} pid={new.main_pid}")
+                continue
+            if new.main_pid == old.main_pid:
+                failures.append(f"{name} retained stale MainPID {new.main_pid}")
+            if new.start_monotonic_usec <= max(
+                generation_usec, old.start_monotonic_usec
+            ):
+                failures.append(
+                    f"{name} has stale start time {new.start_monotonic_usec}"
+                )
+            if new.exec_start != old.exec_start:
+                failures.append(
+                    f"{name} ExecStart changed across the update boundary"
+                )
+            if new.fragment_path != old.fragment_path:
+                failures.append(
+                    f"{name} unit fragment changed across the update boundary"
+                )
+            if expected_identity:
+                actual = identities.get(name, {})
+                for key, expected in expected_identity.items():
+                    if expected and actual.get(key) and actual.get(key) != expected:
+                        failures.append(
+                            f"{name} {key}={actual.get(key)!r}, expected {expected!r}"
+                        )
+            if self._canary_verifier and not self._canary_verifier(new):
+                failures.append(f"{name} failed the canary health check")
+        if failures:
+            raise WorkerBoundaryError(
+                "; ".join(failures) + ". " + self._recover_hint(names)
+            )
+        return current
+
+    def transition(
+        self,
+        before: WorkerBoundarySnapshot,
+        *,
+        expected_identity: Mapping[str, str] | None = None,
+    ) -> tuple[str, ...]:
+        """Move every inventoried target to one provably fresh generation.
+
+        Ordering is deliberate: pause monitors; stop/quiesce all workers;
+        reset the intentional ``failed/MainPID=0`` state; start dashboard,
+        WebUI, and one gateway canary; verify; start remaining gateways;
+        reconcile exact membership. Monitor re-arm is deliberately a separate
+        call: the updater must first complete its authoritative code-SHA fleet
+        matrix and plan-vs-execution reconciliation.
+        """
+        targets = tuple(sorted(before.targets))
+        if not targets:
+            return ()
+        touched = list(targets)
+        try:
+            for timer in before.monitors:
+                self._run("stop", timer)
+
+            generation_usec = int(self._monotonic() * 1_000_000)
+            for name in targets:
+                self._run("stop", name)
+
+            quiesced = self._show(targets)
+            not_quiesced: list[str] = []
+            for name, unit in quiesced.items():
+                if unit.active_state == "failed" and unit.main_pid == 0:
+                    self._run("reset-failed", name)
+                elif unit.active_state != "inactive" or unit.main_pid > 0:
+                    not_quiesced.append(name)
+            if not_quiesced:
+                raise WorkerBoundaryError(
+                    "workers did not quiesce: " + ", ".join(not_quiesced)
+                )
+
+            frontends = [
+                name
+                for name in ("hermes-dashboard.service", "hermes-webui.service")
+                if name in before.targets
+            ]
+            gateways = sorted(
+                (name for name in targets if name.startswith("hermes-gateway")),
+                key=lambda name: (name != "hermes-gateway.service", name),
+            )
+            canary = gateways[:1]
+            first_wave = frontends + canary
+            for name in first_wave:
+                self._run("start", name)
+            self._verify_wave(
+                first_wave, before, generation_usec, expected_identity
+            )
+
+            remaining = [name for name in targets if name not in first_wave]
+            for name in remaining:
+                self._run("start", name)
+            self._verify_wave(
+                remaining, before, generation_usec, expected_identity
+            )
+
+            after = self.inventory()
+            expected = set(before.targets)
+            actual = set(after.targets)
+            missing = sorted(expected - actual)
+            extra_enabled = sorted(
+                name
+                for name in actual - expected
+                if after.targets[name].enabled_state in _ENABLED_STATES
+            )
+            if missing or extra_enabled:
+                parts = []
+                if missing:
+                    parts.append("missing enabled/running units: " + ", ".join(missing))
+                if extra_enabled:
+                    parts.append("extra enabled units: " + ", ".join(extra_enabled))
+                raise WorkerBoundaryError("; ".join(parts))
+
+            # Exact final state proof, after membership reconciliation.
+            self._verify_wave(targets, before, generation_usec, expected_identity)
+            return targets
+        except WorkerBoundaryError as exc:
+            message = str(exc)
+            if "Affected units:" not in message:
+                message += ". " + self._recover_hint(touched)
+            raise WorkerBoundaryError(message) from exc
+
+    def rearm_monitors(self, before: WorkerBoundarySnapshot) -> None:
+        """Re-arm optional monitors after the caller proves the whole fleet.
+
+        This method intentionally does no worker verification of its own.  The
+        only valid caller is the update tail after both the code-generation
+        matrix and runtime-outcome reconciliation have succeeded.  A timer or
+        e2e start failure is fatal so an update cannot report success without
+        its monitoring contract restored.
+        """
+        try:
+            for timer in before.monitors:
+                self._run("enable", "--now", timer)
+            for service in before.concierge_e2e_services:
+                self._run("start", service)
+        except WorkerBoundaryError as exc:
+            message = str(exc)
+            if "Affected units:" not in message:
+                message += ". " + self._recover_hint(tuple(before.targets))
+            raise WorkerBoundaryError(message) from exc
+
+
+def capture_systemd_worker_boundary(
+    *,
+    relevant: bool,
+    runner: Runner = _default_runner,
+    identity_collector: IdentityCollector | None = None,
+    canary_verifier: CanaryVerifier | None = None,
+) -> tuple[SystemdWorkerBoundary, WorkerBoundarySnapshot] | None:
+    """Capture the boundary only on a relevant Linux user-systemd install.
+
+    ``relevant`` is supplied by the existing platform capability probe.  Once
+    it says systemd applies, inventory errors propagate and abort the update
+    before source mutation; absence is never silently interpreted as an empty
+    fleet.
+    """
+    if not relevant or not sys.platform.startswith("linux"):
+        return None
+    if runner is _default_runner and shutil.which("systemctl") is None:
+        raise WorkerBoundaryError(
+            "systemd is relevant but systemctl is unavailable; refusing source mutation"
+        )
+    boundary = SystemdWorkerBoundary(
+        runner,
+        identity_collector=identity_collector,
+        canary_verifier=canary_verifier,
+    )
+    return boundary, boundary.inventory()

--- a/tests/hermes_cli/test_update_systemd_boundary.py
+++ b/tests/hermes_cli/test_update_systemd_boundary.py
@@ -1,0 +1,363 @@
+from __future__ import annotations
+
+import inspect
+import subprocess
+
+import pytest
+
+from hermes_cli.update_systemd_boundary import (
+    SystemdWorkerBoundary,
+    WorkerBoundaryError,
+    capture_systemd_worker_boundary,
+)
+
+
+class FakeSystemd:
+    def __init__(self, *, stale=(), fail_start=(), failed_on_stop=()):
+        self.calls = []
+        self.stale = set(stale)
+        self.fail_start = set(fail_start)
+        self.failed_on_stop = set(failed_on_stop)
+        self.after_transition = False
+        self.omit = set()
+        self.extra = set()
+        self.units = {
+            "hermes-dashboard.service": self._unit(11, 10, "enabled"),
+            "hermes-webui.service": self._unit(12, 11, "enabled"),
+            "hermes-gateway.service": self._unit(21, 12, "enabled"),
+            "hermes-gateway-work.service": self._unit(22, 13, "enabled"),
+            "buzz-health.timer": self._unit(31, 14, "enabled", kind="timer"),
+            "buzz-concierge-e2e.timer": self._unit(32, 15, "enabled", kind="timer"),
+            "buzz-concierge-e2e.service": self._unit(0, 0, "static", active="inactive"),
+        }
+
+    @staticmethod
+    def _unit(pid, started, enabled, *, active="active", kind="service"):
+        return {
+            "pid": pid,
+            "started": started,
+            "enabled": enabled,
+            "active": active,
+            "sub": "running" if active == "active" else "dead",
+            "kind": kind,
+        }
+
+    def _completed(self, cmd, rc=0, stdout="", stderr=""):
+        return subprocess.CompletedProcess(cmd, rc, stdout, stderr)
+
+    def __call__(self, command):
+        cmd = list(command)
+        self.calls.append(cmd)
+        args = cmd[2:]
+        verb = args[0]
+        if verb in {"list-unit-files", "list-units"}:
+            names = sorted(set(self.units) | self.extra)
+            if verb == "list-unit-files":
+                out = "".join(
+                    f"{name} {self.units.get(name, self._unit(0, 0, 'enabled'))['enabled']}\n"
+                    for name in names
+                )
+            else:
+                out = "".join(f"{name} loaded active running description\n" for name in names)
+            return self._completed(cmd, stdout=out)
+        if verb == "show":
+            names = [arg for arg in args[1:] if not arg.startswith("--")]
+            blocks = []
+            for name in names:
+                if name in self.omit:
+                    continue
+                state = self.units.get(name)
+                if state is None and name in self.extra:
+                    state = self._unit(90, 100_000_090, "enabled")
+                if state is None:
+                    continue
+                blocks.append(
+                    "\n".join(
+                        [
+                            f"Id={name}",
+                            "LoadState=loaded",
+                            f"UnitFileState={state['enabled']}",
+                            f"ActiveState={state['active']}",
+                            f"SubState={state['sub']}",
+                            f"MainPID={state['pid']}",
+                            f"ExecMainStartTimestampMonotonic={state['started']}",
+                            f"ExecStart={{ path=/opt/hermes/venv/bin/hermes ; argv[]=/opt/hermes/venv/bin/hermes {name} ; }}",
+                            f"FragmentPath=/home/test/.config/systemd/user/{name}",
+                        ]
+                    )
+                )
+            return self._completed(cmd, stdout="\n\n".join(blocks) + "\n")
+        name = args[-1]
+        if verb == "stop":
+            state = self.units[name]
+            state["old_pid"] = state["pid"]
+            state["old_started"] = state["started"]
+            state["pid"] = 0
+            state["active"] = "failed" if name in self.failed_on_stop else "inactive"
+            state["sub"] = "failed" if name in self.failed_on_stop else "dead"
+            return self._completed(cmd)
+        if verb == "reset-failed":
+            self.units[name]["active"] = "inactive"
+            self.units[name]["sub"] = "dead"
+            return self._completed(cmd)
+        if verb == "start" or (verb == "enable" and "--now" in args):
+            if name in self.fail_start:
+                return self._completed(cmd, rc=1, stderr="start failed")
+            state = self.units[name]
+            state["active"] = "active"
+            state["sub"] = "running"
+            if state["kind"] == "service" and "e2e" not in name:
+                if name in self.stale:
+                    state["pid"] = state["old_pid"]
+                    state["started"] = state["old_started"]
+                else:
+                    state["pid"] += 1000
+                    if state["pid"] == 1000:
+                        state["pid"] = 2000
+                    state["started"] = 100_000_000 + state["pid"]
+            self.after_transition = True
+            return self._completed(cmd)
+        if verb == "enable":
+            return self._completed(cmd)
+        raise AssertionError(cmd)
+
+
+def _transition(fake: FakeSystemd):
+    boundary = SystemdWorkerBoundary(fake, monotonic=lambda: 100.0)
+    before = boundary.inventory()
+    return boundary, before
+
+
+def test_exact_inventory_captures_required_process_metadata():
+    fake = FakeSystemd()
+    boundary, before = _transition(fake)
+
+    gateway = before.targets["hermes-gateway.service"]
+    assert gateway.enabled_state == "enabled"
+    assert gateway.active_state == "active"
+    assert gateway.sub_state == "running"
+    assert gateway.main_pid == 21
+    assert gateway.start_monotonic_usec == 12
+    assert "/opt/hermes/venv/bin/hermes" in gateway.exec_start
+    assert not any("hermes-gateway*" in part for call in fake.calls for part in call)
+    assert before.monitors == ("buzz-concierge-e2e.timer", "buzz-health.timer")
+    assert before.concierge_e2e_services == ("buzz-concierge-e2e.service",)
+
+
+def test_partial_fleet_restart_fails_closed_and_does_not_rearm_monitors():
+    fake = FakeSystemd(fail_start={"hermes-gateway-work.service"})
+    boundary, before = _transition(fake)
+
+    with pytest.raises(WorkerBoundaryError, match="hermes-gateway-work.service"):
+        boundary.transition(before)
+
+    assert not any(call[2:4] == ["enable", "--now"] for call in fake.calls)
+
+
+@pytest.mark.parametrize("stale", ["hermes-gateway.service", "hermes-gateway-work.service"])
+def test_stale_pid_or_start_time_fails_canary_or_fleet(stale):
+    fake = FakeSystemd(stale={stale})
+    boundary, before = _transition(fake)
+
+    with pytest.raises(WorkerBoundaryError, match="stale (MainPID|start time)"):
+        boundary.transition(before)
+
+
+def test_missing_enabled_unit_is_named():
+    fake = FakeSystemd()
+    boundary, before = _transition(fake)
+    original_inventory = boundary.inventory
+    calls = 0
+
+    def inventory_with_missing():
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            fake.units["hermes-gateway-work.service"]["enabled"] = "disabled"
+            fake.units["hermes-gateway-work.service"]["active"] = "inactive"
+            fake.units["hermes-gateway-work.service"]["pid"] = 0
+        return original_inventory()
+
+    boundary.inventory = inventory_with_missing
+    with pytest.raises(WorkerBoundaryError, match="missing enabled/running units: hermes-gateway-work.service"):
+        boundary.transition(before)
+
+
+def test_extra_enabled_unit_is_named():
+    fake = FakeSystemd()
+    boundary, before = _transition(fake)
+    original_inventory = boundary.inventory
+
+    def inventory_with_extra():
+        fake.extra.add("hermes-gateway-extra.service")
+        return original_inventory()
+
+    boundary.inventory = inventory_with_extra
+    with pytest.raises(WorkerBoundaryError, match="extra enabled units: hermes-gateway-extra.service"):
+        boundary.transition(before)
+
+
+def test_failed_mainpid_zero_is_quiesced_and_reset_before_start():
+    fake = FakeSystemd(failed_on_stop={"hermes-gateway.service"})
+    boundary, before = _transition(fake)
+    boundary.transition(before)
+
+    reset = fake.calls.index(["systemctl", "--user", "reset-failed", "hermes-gateway.service"])
+    start = fake.calls.index(["systemctl", "--user", "start", "hermes-gateway.service"])
+    assert reset < start
+
+
+def test_deactivating_mainpid_zero_is_not_yet_quiesced():
+    fake = FakeSystemd()
+    boundary, before = _transition(fake)
+    original_show = boundary._show
+    show_calls = 0
+
+    def show_deactivating(names):
+        nonlocal show_calls
+        show_calls += 1
+        current = original_show(names)
+        if show_calls == 1:
+            unit = fake.units["hermes-gateway.service"]
+            unit["active"] = "deactivating"
+            unit["sub"] = "stop-sigterm"
+            current = original_show(names)
+        return current
+
+    boundary._show = show_deactivating
+    with pytest.raises(WorkerBoundaryError, match="workers did not quiesce: hermes-gateway.service"):
+        boundary.transition(before)
+
+
+def test_failed_canary_does_not_start_remaining_gateways_or_monitors():
+    fake = FakeSystemd(fail_start={"hermes-gateway.service"})
+    boundary, before = _transition(fake)
+
+    with pytest.raises(WorkerBoundaryError, match="hermes-gateway.service"):
+        boundary.transition(before)
+
+    assert ["systemctl", "--user", "start", "hermes-gateway-work.service"] not in fake.calls
+    assert not any(call[2:4] == ["enable", "--now"] for call in fake.calls)
+
+
+def test_canary_health_callback_failure_stops_rollout():
+    fake = FakeSystemd()
+    boundary = SystemdWorkerBoundary(
+        fake,
+        monotonic=lambda: 100.0,
+        canary_verifier=lambda unit: unit.name != "hermes-gateway.service",
+    )
+    before = boundary.inventory()
+
+    with pytest.raises(WorkerBoundaryError, match="failed the canary health check"):
+        boundary.transition(before)
+
+    assert ["systemctl", "--user", "start", "hermes-gateway-work.service"] not in fake.calls
+    assert not any(call[2:4] == ["enable", "--now"] for call in fake.calls)
+
+
+def test_available_runtime_identity_stamp_must_match_installed_generation():
+    fake = FakeSystemd()
+
+    def identities():
+        return {
+            name: {"code_sha": "old-generation"}
+            for name in fake.units
+            if name.endswith(".service")
+        }
+
+    boundary = SystemdWorkerBoundary(
+        fake,
+        monotonic=lambda: 100.0,
+        identity_collector=identities,
+    )
+    before = boundary.inventory()
+
+    with pytest.raises(WorkerBoundaryError, match="code_sha='old-generation'"):
+        boundary.transition(before, expected_identity={"code_sha": "new-generation"})
+
+    assert not any(call[2:4] == ["enable", "--now"] for call in fake.calls)
+
+
+def test_changed_execstart_fails_intended_runtime_proof():
+    fake = FakeSystemd()
+    boundary, before = _transition(fake)
+    original_show = boundary._show
+
+    def show_changed_runtime(names):
+        current = original_show(names)
+        if fake.after_transition and "hermes-dashboard.service" in current:
+            old = current["hermes-dashboard.service"]
+            current["hermes-dashboard.service"] = type(old)(
+                **{**old.__dict__, "exec_start": "{ path=/wrong/hermes ; }"}
+            )
+        return current
+
+    boundary._show = show_changed_runtime
+    with pytest.raises(WorkerBoundaryError, match="ExecStart changed"):
+        boundary.transition(before)
+
+
+def test_monitor_and_concierge_rearm_order_after_fleet_proof():
+    fake = FakeSystemd()
+    boundary, before = _transition(fake)
+    boundary.transition(before)
+
+    # transition proves workers but must leave monitors paused until the
+    # updater's later code-SHA fleet matrix succeeds.
+    assert not any(call[2:4] == ["enable", "--now"] for call in fake.calls)
+    boundary.rearm_monitors(before)
+
+    def index(suffix):
+        return next(i for i, call in enumerate(fake.calls) if call[2:] == suffix)
+
+    first_stop = index(["stop", "hermes-dashboard.service"])
+    assert index(["stop", "buzz-health.timer"]) < first_stop
+    assert index(["start", "hermes-dashboard.service"]) < index(["start", "hermes-gateway.service"])
+    assert index(["start", "hermes-gateway.service"]) < index(["start", "hermes-gateway-work.service"])
+    timer = index(["enable", "--now", "buzz-concierge-e2e.timer"])
+    concierge = index(["start", "buzz-concierge-e2e.service"])
+    assert index(["start", "hermes-gateway-work.service"]) < timer < concierge
+
+
+def test_monitor_rearm_failure_is_fatal():
+    fake = FakeSystemd(fail_start={"buzz-concierge-e2e.timer"})
+    boundary, before = _transition(fake)
+    boundary.transition(before)
+
+    with pytest.raises(WorkerBoundaryError, match="buzz-concierge-e2e.timer"):
+        boundary.rearm_monitors(before)
+
+
+def test_probe_failure_is_fatal_when_systemd_is_relevant():
+    def failed(command):
+        return subprocess.CompletedProcess(command, 1, "", "user bus unavailable")
+
+    with pytest.raises(WorkerBoundaryError, match="user bus unavailable"):
+        capture_systemd_worker_boundary(relevant=True, runner=failed)
+
+
+def test_non_systemd_platform_path_is_noop():
+    def unused(command):
+        raise AssertionError(command)
+
+    assert capture_systemd_worker_boundary(relevant=False, runner=unused) is None
+
+
+def test_supported_update_entrypoint_orders_boundary_and_authoritative_proof():
+    """Pin the owning `hermes update` wiring, not only the pure helper."""
+    from hermes_cli import update_cmd
+
+    source = inspect.getsource(update_cmd._cmd_update_impl)
+    capture = source.index("capture_systemd_worker_boundary(")
+    source_mutation = source.index("# Resolve the target branch up front")
+    transition = source.index("_systemd_worker_boundary.transition(")
+    generic_restart = source.index("# Auto-restart ALL gateways after update.")
+    fleet_matrix = source.index("# Phase 1 (#91277): post-update fleet version verification")
+    rearm = source.index("_systemd_worker_boundary.rearm_monitors(")
+    receipt = source.index("from hermes_cli.update_receipt import finalize_update_receipt", rearm)
+
+    assert capture < source_mutation < transition < generic_restart
+    assert generic_restart < fleet_matrix < rearm < receipt
+    assert "if _systemd_boundary_units:" in source
+    assert "if svc_name in _systemd_boundary_units:" in source

--- a/tests/hermes_cli/test_update_worker_cross_generation.py
+++ b/tests/hermes_cli/test_update_worker_cross_generation.py
@@ -1,0 +1,139 @@
+"""A worker process must not survive an in-place source generation swap."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+import pytest
+
+
+WORKER = r'''import importlib
+import json
+import sys
+
+module = importlib.import_module(sys.argv[1])
+for line in sys.stdin:
+    request = json.loads(line)
+    try:
+        result = module._codex_cloudflare_headers(**request)
+        reply = {"ok": True, "result": result}
+    except Exception as exc:
+        reply = {"ok": False, "type": type(exc).__name__, "error": str(exc)}
+    print(json.dumps(reply), flush=True)
+'''
+
+
+def _call_worker(process, payload):
+    assert process.stdin is not None
+    assert process.stdout is not None
+    process.stdin.write(json.dumps(payload) + "\n")
+    process.stdin.flush()
+    return json.loads(process.stdout.readline())
+
+
+def _start_worker(tmp_path, module_name):
+    return subprocess.Popen(
+        [sys.executable, "-u", "-c", WORKER, module_name],
+        cwd=tmp_path,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+
+def test_old_worker_rejects_new_caller_contract_until_process_restarted(tmp_path):
+    module = tmp_path / "worker_contract.py"
+    module.write_text(
+        "def _codex_cloudflare_headers(headers):\n"
+        "    return {'generation': 'old', **headers}\n",
+        encoding="utf-8",
+    )
+    old_worker = _start_worker(tmp_path, "worker_contract")
+    try:
+        old_reply = _call_worker(
+            old_worker,
+            {"headers": {"x": "1"}, "base_url": "https://api.example.test"},
+        )
+        assert old_reply["ok"] is False
+        assert old_reply["type"] == "TypeError"
+        assert "base_url" in old_reply["error"]
+
+        # Swap the source underneath the already-imported worker.  It keeps the
+        # old callable object, proving that a same-process import test cannot
+        # establish compatibility across the updater boundary.
+        module.write_text(
+            "def _codex_cloudflare_headers(headers, *, base_url=None):\n"
+            "    return {'generation': 'new', 'base_url': base_url, **headers}\n",
+            encoding="utf-8",
+        )
+        still_old = _call_worker(
+            old_worker,
+            {"headers": {"x": "1"}, "base_url": "https://api.example.test"},
+        )
+        assert still_old["ok"] is False
+        assert still_old["type"] == "TypeError"
+    finally:
+        old_worker.terminate()
+        old_worker.wait(timeout=5)
+
+    new_worker = _start_worker(tmp_path, "worker_contract")
+    try:
+        fresh = _call_worker(
+            new_worker,
+            {"headers": {"x": "1"}, "base_url": "https://api.example.test"},
+        )
+        assert fresh == {
+            "ok": True,
+            "result": {
+                "generation": "new",
+                "base_url": "https://api.example.test",
+                "x": "1",
+            },
+        }
+    finally:
+        new_worker.terminate()
+        new_worker.wait(timeout=5)
+
+
+def test_update_autostash_preserves_dirty_working_tree(tmp_path):
+    """The new pre-mutation probe must not weaken the existing dirty-tree round trip."""
+    from hermes_cli.update_cmd import (
+        _restore_stashed_changes,
+        _stash_local_changes_if_needed,
+    )
+
+    if subprocess.run(
+        ["git", "--version"], capture_output=True, text=True, check=False
+    ).returncode:
+        pytest.skip("git is unavailable")
+
+    def git(*args):
+        return subprocess.run(
+            ["git", *args],
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+    git("init", "-q")
+    git("config", "user.email", "updater@example.test")
+    git("config", "user.name", "Updater Test")
+    tracked = tmp_path / "tracked.txt"
+    tracked.write_text("installed\n", encoding="utf-8")
+    git("add", "tracked.txt")
+    git("commit", "-qm", "installed generation")
+    tracked.write_text("local uncommitted work\n", encoding="utf-8")
+
+    stash_ref = _stash_local_changes_if_needed(["git"], tmp_path)
+    assert stash_ref
+    assert tracked.read_text(encoding="utf-8") == "installed\n"
+
+    assert _restore_stashed_changes(
+        ["git"], tmp_path, stash_ref, prompt_user=False
+    )
+    assert tracked.read_text(encoding="utf-8") == "local uncommitted work\n"
+    assert " M tracked.txt" in git("status", "--porcelain").stdout

--- a/website/docs/developer-guide/update-worker-generation.md
+++ b/website/docs/developer-guide/update-worker-generation.md
@@ -1,0 +1,90 @@
+---
+title: "Updater worker-generation boundary"
+description: "How Linux user-systemd services cross an in-place Hermes update safely"
+---
+
+# Updater worker-generation boundary
+
+Hermes source installs currently update a checkout in place. A long-lived
+Python process retains imported callables and module objects even after the
+files beneath it change. A stale-import incident demonstrated the generic
+failure mode: a new caller began passing a keyword accepted by the updated
+worker implementation, while an old worker process still held the previous
+callable contract. Updating files without proving process replacement can
+therefore create a mixed generation that neither revision supports.
+
+## Linux user-systemd design
+
+`hermes_cli/update_systemd_boundary.py` supplements the cross-platform update
+inventory. It is activated only when the existing platform probe says user
+systemd services are relevant. Its command runner, identity collector, clock,
+and canary verifier are injectable; isolated tests do not contact the real
+user manager.
+
+Before checkout or merge changes source, the updater:
+
+1. Runs `systemctl --user list-unit-files` and `list-units` without shell
+   patterns, filters names in Python, then requests exact `show` records.
+2. Captures enabled/running `hermes-gateway*.service`,
+   `hermes-dashboard.service`, and `hermes-webui.service` units, including
+   enabled state, `ActiveState`, `SubState`, `MainPID`, monotonic process start
+   time, `ExecStart`, and unit fragment path.
+3. Discovers installed/enabled Buzz health/e2e timers and the concierge e2e
+   service as optional lifecycle hooks. Site-specific units are never assumed
+   to exist.
+
+Once source and dependencies form the installed generation, the boundary:
+
+1. Stops discovered monitors, then stops every captured worker.
+2. Treats `failed` plus `MainPID=0` as quiesced after the intentional stop, but
+   runs `reset-failed` before restart. A live PID is never treated as quiesced.
+3. Starts dashboard/WebUI and the default (or first discovered) gateway
+   canary, and proves active state, a different PID, and a monotonic start time
+   newer than the generation boundary.
+4. Starts and proves the remaining gateways, re-inventories exact membership,
+   and names every missing or extra enabled unit. Existing gateway code stamps
+   provide the later checkout SHA/version proof in the generic fleet check;
+   injected runtime identity fields are compared when a deployment supplies
+   them.
+5. Leaves monitors paused while the updater's existing authoritative code-SHA
+   fleet matrix and plan-vs-execution reconciliation run. Only after both pass,
+   re-enables/starts discovered timers and explicitly starts the discovered
+   concierge e2e service once.
+
+Probe, stop, canary, restart, identity, or reconciliation failures are fatal.
+Monitors remain paused, and recovery guidance names affected units. The older
+generic update restart path skips units already proven by this boundary, while
+retaining its cross-platform and non-systemd coverage.
+
+## Recovery and rollback
+
+If the transition fails, do not re-arm health/e2e timers until the fleet is
+consistent. For every named unit:
+
+```bash
+systemctl --user reset-failed <unit>
+systemctl --user restart <unit>
+systemctl --user show <unit> -p ActiveState -p SubState -p MainPID -p ExecMainStartTimestampMonotonic
+```
+
+Check gateway runtime/code stamps with the normal Hermes status and update
+receipt diagnostics. If the new generation itself is faulty, restore the
+pre-update snapshot or reset the checkout to the recorded pre-update commit,
+refresh dependencies, and repeat the same controlled fleet transition. Never
+restart only a subset onto a checkout shared by the whole fleet.
+
+## Recommended deployment evolution
+
+The in-place checkout remains an avoidable source/worker race. Production
+installations should move toward immutable, versioned release directories:
+
+```text
+releases/<commit>/source + venv
+current -> releases/<commit>
+```
+
+Build and validate the new directory before activation, atomically repoint the
+`current` symlink (or update unit `ExecStart` paths), then restart workers
+through the same canary and exact-reconciliation boundary. Keep the previous
+release until proof completes so rollback is an atomic repoint plus controlled
+restart, rather than another mutation of files beneath running interpreters.


### PR DESCRIPTION
## Summary

- add an exact Linux user-systemd inventory for enabled/running Hermes gateways, dashboard, and WebUI before in-place source mutation
- stop and restart the captured fleet through a canary-first generation boundary, with fail-closed PID/start-time/runtime-path and exact membership checks
- treat intentional `failed` + `MainPID=0` stops as quiesced but reset the failed state before restart
- keep optional Buzz health/e2e monitors paused until the existing code-SHA fleet matrix and runtime-outcome reconciliation both pass, then explicitly trigger the concierge E2E service once
- add a separate-process compatibility regression reproducing an old `_codex_cloudflare_headers(headers)` worker rejecting a new caller's `base_url=` keyword until the worker is restarted
- document recovery, rollback, and the preferred versioned-release + atomic-repoint evolution

## Safety / scope

Implementation and isolated verification only. No production updater adoption or service restart was performed.

The systemd runner, clock, identity collector, and canary verifier are injectable; tests do not contact a real user manager.

## Tests

```text
58 passed
```

Command:

```bash
PYTHONPATH="$PWD:<existing-site-packages>" python3 -m pytest \
  tests/hermes_cli/test_update_systemd_boundary.py \
  tests/hermes_cli/test_update_worker_cross_generation.py \
  tests/hermes_cli/test_update_inventory.py \
  tests/hermes_cli/test_update_fleet_check_fail_closed.py \
  tests/hermes_cli/test_update_restart_recovery.py \
  -o 'addopts=' -q
```

Additional checks:

- `python3 -m py_compile` on all changed Python files
- `git diff --check`
- direct dirty-tree autostash round-trip test included in the new compatibility suite

`ruff` was not installed on the verification host.

Two pre-existing full-updater tests that discover live host gateways fail under the repository's live-system guard on both this branch and an unmodified baseline worktree; they are not regressions in this change.