### PR TITLE
fix(config): treat model/default_model as synonyms on named custom providers

### DIFF
--- a/contributors/emails/salch-cred@users.noreply.github.com
+++ b/contributors/emails/salch-cred@users.noreply.github.com
@@ -1,0 +1,1 @@
+salch-cred

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -779,7 +779,12 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                         "name": entry.get("name", ep_name),
                         "base_url": base_url.strip(),
                         "api_key": resolved_api_key,
-                        "model": entry.get("default_model", ""),
+                        # The named providers.<key> dict's default-model field is
+                        # keyed ``default_model`` by the CLI picker but ``model``
+                        # by the Desktop custom-endpoint panel (#71298). Treat
+                        # them as synonyms so whichever surface wrote it, the
+                        # runtime resolves it.
+                        "model": entry.get("default_model") or entry.get("model") or "",
                     }
                     extra_body = entry.get("extra_body")
                     if isinstance(extra_body, dict):

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -8670,7 +8670,7 @@ def activate_custom_endpoint(endpoint_id: str, profile: Optional[str] = None):
                 raise HTTPException(status_code=404, detail="custom endpoint not found")
 
             models = _models_from_custom_endpoint_entry(entry)
-            model = str(entry.get("model") or (models[0] if models else "")).strip()
+            model = str(entry.get("model") or entry.get("default_model") or (models[0] if models else "")).strip()
             base_url = str(entry.get("base_url") or "").strip()
             if not model or not base_url:
                 raise HTTPException(status_code=400, detail="custom endpoint is incomplete")

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -1747,3 +1747,34 @@ def test_custom_provider_pool_target_model_wins(monkeypatch):
 
     assert resolved is not None
     assert resolved["model"] == "myproxy/gemini-flash"
+
+
+def test_named_custom_provider_resolves_model_written_by_desktop_panel(monkeypatch):
+    """A providers.<name> dict whose default model is keyed ``model`` (the
+    spelling the Desktop custom-endpoint panel writes) must resolve, not just
+    ``default_model`` (the spelling the CLI picker writes). Regression for the
+    model-version-stuck-in-profile symptom (#71298)."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "providers": {
+                "acme": {
+                    "name": "ACME",
+                    "api": "https://acme.example.com/v1",
+                    "api_key": "acme-key",
+                    # Desktop writes ``model``; the named-custom resolver must
+                    # honor it the same as ``default_model``.
+                    "model": "acme-model-1",
+                }
+            }
+        },
+    )
+
+    resolved = rp._get_named_custom_provider("acme")
+
+    assert resolved is not None
+    assert resolved["model"] == "acme-model-1"
+    assert resolved["base_url"] == "https://acme.example.com/v1"


### PR DESCRIPTION
Fixes the "model version stuck in profile" symptom (#71298).

## Root cause

The named `providers.<key>` dict's default-model field is keyed **inconsistently across surfaces**:

- The CLI picker (`hermes setup model`) writes **`default_model`** (`model_setup_flows.py:1769`).
- The Desktop custom-endpoint panel writes/reads **`model`** (`web_server.py:8475` write, `8585` read).
- The runtime named-custom-provider resolver reads only **`default_model`** (`runtime_provider.py:782`).

So a model chosen via the CLI isn't honored when the Desktop "Use" button activates it (activate reads only `model`), and a model saved via the Desktop isn't picked up as the provider's default at runtime (resolver reads only `default_model`). Net effect: the model version appears stuck in the profile depending on which surface last wrote it.

## Fix

Treat `model` and `default_model` as synonyms on the raw `providers.<name>` dict at the two read sites that diverge, so whichever surface wrote the value, the other reads it:

- `runtime_provider.py` `_get_named_custom_provider`: `entry.get("default_model") or entry.get("model") or ""`.
- `web_server.py` `activate_custom_endpoint`: `entry.get("model") or entry.get("default_model") or models[0]`.

The CLI writer and Desktop writer are left as-is — both spellings are now read correctly everywhere.

## Validation

- New regression in `test_runtime_provider_resolution.py`: a `providers.<name>` entry keyed by `model` (the Desktop spelling) resolves via `_get_named_custom_provider`.
- Verified the `activate_custom_endpoint` model-resolution line honors a CLI-written `default_model` (no `models` map) — previously it would have raised "custom endpoint is incomplete".
