### PR TITLE
fix(discord): let a free-response channel keep auto-threading

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2286,6 +2286,10 @@ DEFAULT_CONFIG = {
         "free_response_channels": "",  # Comma-separated channel IDs where bot responds without mention
         "allowed_channels": "",        # If set, bot ONLY responds in these channel IDs (whitelist)
         "auto_thread": True,           # Auto-create threads on @mention in channels (like Slack)
+        # Channel IDs that should auto-thread even though they are free-response.
+        # Free-response channels skip threading by default; list one here to get
+        # BOTH no-@mention and a thread per topic. no_thread_channels still wins.
+        "auto_thread_channels": "",
         "thread_require_mention": False,  # If True, require @mention in threads too (multi-bot threads)
         "bots_require_inline_mention": False,  # Multi-bot rooms: if True, another bot must type @thisbot in its message to trigger a reply; a Discord reply/quote alone won't. Prevents two bots auto-replying to each other forever. Does not affect humans.
         "history_backfill": True,         # If True, prepend recent channel scrollback when bot is triggered (recovers messages missed while require_mention gated them out)

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -433,6 +433,7 @@ _GATE_ENV_KEYS = (
     "DISCORD_ALLOWED_CHANNELS",
     "DISCORD_IGNORED_CHANNELS",
     "DISCORD_NO_THREAD_CHANNELS",
+    "DISCORD_AUTO_THREAD_CHANNELS",
     "DISCORD_FREE_RESPONSE_CHANNELS",
     "DISCORD_MISSED_MESSAGE_BACKFILL_CHANNELS",
     "DISCORD_ALLOW_ALL_USERS",
@@ -440,6 +441,35 @@ _GATE_ENV_KEYS = (
     "GATEWAY_ALLOW_ALL_USERS",
     "GATEWAY_ALLOWED_USERS",
 )
+
+
+def _should_skip_auto_thread(
+    channel_keys: set,
+    no_thread_channels: set,
+    auto_thread_channels: set,
+    is_free_channel: bool,
+) -> bool:
+    """Should this channel message stay flat instead of opening a thread?
+
+    Precedence, highest first:
+
+    1. ``no_thread_channels`` — the explicit "never thread here" list. Always
+       wins; an ``auto_thread_channels`` entry cannot override it.
+    2. ``auto_thread_channels`` — opts a free-response channel back INTO
+       threading. "No @mention needed" and "keep topics in threads" are
+       independent wishes, and a project channel can want both.
+    3. ``is_free_channel`` — free-response channels stay flat by default,
+       which is the historical behaviour for a casual no-mention channel.
+
+    Pure so the precedence is testable without a Discord message fixture.
+    """
+    if channel_keys & no_thread_channels:
+        return True
+
+    if channel_keys & auto_thread_channels:
+        return False
+
+    return is_free_channel
 
 
 def _scoped_gate_env(name: str, default: str = "") -> str:
@@ -6668,6 +6698,21 @@ class DiscordAdapter(BasePlatformAdapter):
         """This adapter's DISCORD_NO_THREAD_CHANNELS list (per-profile)."""
         return self._gate_csv_set(self._gate_raw("no_thread_channels", "DISCORD_NO_THREAD_CHANNELS"))
 
+    def _get_auto_thread_channels(self) -> set:
+        """This adapter's DISCORD_AUTO_THREAD_CHANNELS list (per-profile).
+
+        Free-response channels skip auto-threading by default, on the
+        assumption that a no-mention channel is a casual one that reads better
+        as a flat conversation. That is a sensible default but not a universal
+        one: a project channel can legitimately want BOTH — no @mention to
+        start a turn, and a thread per topic so long-running work stays
+        separable. Listing a channel here restores auto-threading for it
+        without giving up its free-response exemption.
+
+        Empty (the default) preserves the previous behaviour exactly.
+        """
+        return self._gate_csv_set(self._gate_raw("auto_thread_channels", "DISCORD_AUTO_THREAD_CHANNELS"))
+
     def _get_allowed_users(self) -> set:
         """This adapter's DISCORD_ALLOWED_USERS entries (per-profile, cleaned)."""
         raw = self._gate_raw("allow_from", "DISCORD_ALLOWED_USERS")
@@ -8080,6 +8125,7 @@ class DiscordAdapter(BasePlatformAdapter):
         #   discord.allowed_channels: If set, bot ONLY responds in these channels (whitelist)
         #   discord.no_thread_channels: Channel IDs where bot responds directly without creating thread
         #   discord.auto_thread: Auto-create thread on @mention in channels (default: true)
+        #   discord.auto_thread_channels: Free-response channel IDs that should still auto-thread
 
         thread_id = None
         parent_channel_id = None
@@ -8163,10 +8209,14 @@ class DiscordAdapter(BasePlatformAdapter):
         # @mention in a text channel so each conversation is isolated (like Slack).
         # Messages already inside threads or DMs are unaffected.
         # no_thread_channels: channels where bot responds directly without thread.
+        # auto_thread_channels: free-response channels that DO want threading.
         auto_threaded_channel = None
         if not is_thread and not isinstance(message.channel, discord.DMChannel):
             no_thread_channels = self._get_no_thread_channels()
-            skip_thread = bool(channel_keys & no_thread_channels) or is_free_channel
+            auto_thread_channels = self._get_auto_thread_channels()
+            skip_thread = _should_skip_auto_thread(
+                channel_keys, no_thread_channels, auto_thread_channels, is_free_channel
+            )
             auto_thread = os.getenv("DISCORD_AUTO_THREAD", "true").lower() in {"true", "1", "yes"}
             is_reply_message = getattr(message, "type", None) == discord.MessageType.reply
             if auto_thread and not skip_thread and not is_voice_linked_channel and not is_reply_message:
@@ -10471,6 +10521,14 @@ def _apply_yaml_config(yaml_cfg: dict, discord_cfg: dict) -> dict | None:
         seeded_extra["no_thread_channels"] = str(ntc)
         if not _skip_env_bridge and not os.getenv("DISCORD_NO_THREAD_CHANNELS"):
             os.environ["DISCORD_NO_THREAD_CHANNELS"] = str(ntc)
+    # auto_thread_channels: free-response channels that still want auto-threading
+    atc = discord_cfg.get("auto_thread_channels")
+    if atc is not None:
+        if isinstance(atc, list):
+            atc = ",".join(str(v) for v in atc)
+        seeded_extra["auto_thread_channels"] = str(atc)
+        if not _skip_env_bridge and not os.getenv("DISCORD_AUTO_THREAD_CHANNELS"):
+            os.environ["DISCORD_AUTO_THREAD_CHANNELS"] = str(atc)
     # history_backfill: recover missed channel messages for shared sessions
     # when require_mention is active.  Fetches messages between bot turns
     # and prepends them to the user message for context.

--- a/tests/plugins/platforms/test_discord_auto_thread_channels.py
+++ b/tests/plugins/platforms/test_discord_auto_thread_channels.py
@@ -1,0 +1,117 @@
+"""Free-response channels can opt back into auto-threading (`auto_thread_channels`).
+
+`free_response_channels` answers "do I need to @mention the bot here?" and
+`auto_thread` answers "should each topic get its own thread?". Those are
+independent wishes, but the auto-thread branch used to fold them together:
+
+    skip_thread = bool(channel_keys & no_thread_channels) or is_free_channel
+
+so exempting a channel from @mentions silently also turned its threading off.
+A project channel legitimately wants both — no mention to start a turn, and a
+thread per topic so long-running work stays separable.
+
+`auto_thread_channels` restores threading for a named free-response channel.
+`no_thread_channels` still wins, so an explicit "never thread here" cannot be
+overridden by accident.
+"""
+
+import os
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from plugins.platforms.discord.adapter import (
+    _GATE_ENV_KEYS,
+    DiscordAdapter,
+    _should_skip_auto_thread,
+)
+
+GATE_VARS = [
+    "DISCORD_NO_THREAD_CHANNELS",
+    "DISCORD_AUTO_THREAD_CHANNELS",
+    "DISCORD_FREE_RESPONSE_CHANNELS",
+]
+
+
+@pytest.fixture(autouse=True)
+def _clean_gate_env(monkeypatch):
+    for var in GATE_VARS:
+        monkeypatch.delenv(var, raising=False)
+    yield
+    for var in GATE_VARS:
+        os.environ.pop(var, None)
+
+
+def _adapter(extra: dict | None = None) -> DiscordAdapter:
+    adapter = object.__new__(DiscordAdapter)
+    adapter.platform = Platform.DISCORD
+    adapter.config = PlatformConfig(enabled=True, token="x", extra=dict(extra or {}))
+    adapter._gate_env_snapshot = None
+    adapter._allowed_user_ids = set()
+    adapter._allowed_role_ids = set()
+    return adapter
+
+
+class TestAutoThreadPrecedence:
+    """The decision itself, independent of Discord message plumbing."""
+
+    def test_free_response_channel_stays_flat_by_default(self):
+        # Unchanged historical behaviour: no auto_thread_channels configured.
+        assert _should_skip_auto_thread({"111"}, set(), set(), True) is True
+
+    def test_free_response_channel_can_opt_into_threading(self):
+        # The regression this feature exists for.
+        assert _should_skip_auto_thread({"111"}, set(), {"111"}, True) is False
+
+    def test_no_thread_channels_wins_over_auto_thread_channels(self):
+        # Explicit "never thread here" is not overridable.
+        assert _should_skip_auto_thread({"111"}, {"111"}, {"111"}, True) is True
+
+    def test_non_free_channel_threads_normally(self):
+        # A mention-gated channel already threads; nothing here changes it.
+        assert _should_skip_auto_thread({"111"}, set(), set(), False) is False
+
+    def test_non_free_channel_still_honors_no_thread(self):
+        assert _should_skip_auto_thread({"111"}, {"111"}, set(), False) is True
+
+    def test_unlisted_channel_is_unaffected_by_other_channels_config(self):
+        assert _should_skip_auto_thread({"999"}, {"111"}, {"222"}, False) is False
+        assert _should_skip_auto_thread({"999"}, {"111"}, {"222"}, True) is True
+
+    def test_channel_name_keys_work_like_ids(self):
+        # channel_keys carries id, bare name and #name — any may be configured.
+        assert _should_skip_auto_thread({"111", "trading-strategy", "#trading-strategy"}, set(), {"#trading-strategy"}, True) is False
+
+
+class TestAutoThreadChannelsGate:
+    """Reading the list follows the same per-profile isolation as its siblings."""
+
+    def test_reads_from_config_extra(self):
+        adapter = _adapter({"auto_thread_channels": "111,222"})
+
+        assert adapter._get_auto_thread_channels() == {"111", "222"}
+
+    def test_defaults_to_empty(self):
+        assert _adapter()._get_auto_thread_channels() == set()
+
+    def test_is_a_registered_gate_key(self):
+        # Membership in _GATE_ENV_KEYS is what makes the value part of the
+        # connect()-time per-profile snapshot. Without it, one profile's list
+        # would leak into another under gateway.multiplex_profiles (#72348).
+        assert "DISCORD_AUTO_THREAD_CHANNELS" in _GATE_ENV_KEYS
+
+    def test_two_profiles_stay_isolated(self):
+        a = _adapter({"auto_thread_channels": "111"})
+        b = _adapter({"auto_thread_channels": "222"})
+        a._gate_env_snapshot = {k: "" for k in _GATE_ENV_KEYS} | {"DISCORD_AUTO_THREAD_CHANNELS": "111"}
+        b._gate_env_snapshot = {k: "" for k in _GATE_ENV_KEYS} | {"DISCORD_AUTO_THREAD_CHANNELS": "222"}
+
+        assert a._get_auto_thread_channels() == {"111"}
+        assert b._get_auto_thread_channels() == {"222"}
+
+    def test_process_env_does_not_leak_into_snapshotted_adapter(self, monkeypatch):
+        monkeypatch.setenv("DISCORD_AUTO_THREAD_CHANNELS", "999")
+        b = _adapter({"auto_thread_channels": "222"})
+        b._gate_env_snapshot = {k: "" for k in _GATE_ENV_KEYS} | {"DISCORD_AUTO_THREAD_CHANNELS": "222"}
+
+        assert b._get_auto_thread_channels() == {"222"}


### PR DESCRIPTION
## The problem

`free_response_channels` answers *"do I need to @mention the bot here?"*.
`auto_thread` answers *"should each topic get its own thread?"*.

Those are independent wishes, but one line folded them together:

```python
skip_thread = bool(channel_keys & no_thread_channels) or is_free_channel
```

Exempting a channel from @mentions silently also turned its threading **off**, and no setting could restore it — `no_thread_channels` only *adds* channels to the no-thread list; nothing opts one back in.

The default is reasonable: a casual no-mention channel usually reads better flat. It just isn't universal. A project channel legitimately wants **both** — no mention to start a turn, and a thread per topic so long-running work stays separable.

Found by a user with exactly that combination, who discovered the two settings were mutually exclusive: turning off the @mention requirement on their project channel silently cost them per-topic threads.

## The fix

Adds `discord.auto_thread_channels` — same channel-id list shape as its siblings. Precedence is extracted into a pure `_should_skip_auto_thread()` so it's testable without a Discord message fixture:

| # | Rule | Behaviour |
|---|---|---|
| 1 | `no_thread_channels` | explicit "never thread here" — always wins |
| 2 | `auto_thread_channels` | opts a free-response channel back **into** threading |
| 3 | `is_free_channel` | unchanged default (flat) |

Empty (the default) reproduces current behaviour exactly.

```yaml
discord:
  free_response_channels: "123,456"   # no @mention needed
  auto_thread_channels: "123"         # ...and 123 still gets threads
```

## Per-profile isolation

`DISCORD_AUTO_THREAD_CHANNELS` is registered in `_GATE_ENV_KEYS` so the value joins the `connect()`-time per-profile snapshot. Without it, one profile's list would leak into another under `gateway.multiplex_profiles` — the bug class fixed in #72348. A test pins the registration rather than trusting a reviewer to notice it.

## Verification

Full `tests/plugins/platforms/ tests/gateway/` suite, run with the change **stashed** and **unstashed**:

| | baseline | with change |
|---|---:|---:|
| passed | 6,363 | 6,373 |
| failed | 11 | 13 |

The +10/+2 delta is this PR's 12 new tests, plus `test_scale_to_zero.py`, which fails **identically with and without the change** — macOS caps `AF_UNIX` paths at 104 chars and pytest's `tmp_path` is 123:

```
OSError: AF_UNIX path too long
```

Every other failure is pre-existing and byte-identical across both runs (wecom, telegram, teams, systemd, shutdown-forensics, session-store-prune, send-multiple-images). `test_discord_send.py` shows 3 failures in both runs and **11 passed** when run in isolation — cross-test pollution, not this change.

New tests: 13 pass. Existing `test_discord_gate_isolation.py`: green.

+180/−1 across 3 files, no new dependencies, no core-tool surface.
