### PR TITLE
fix(web): match extract results to requested URLs instead of by position

### DIFF
--- a/tests/tools/test_web_extract_url_matching.py
+++ b/tests/tools/test_web_extract_url_matching.py
@@ -1,0 +1,84 @@
+"""web_extract pairs backend results to the URLs that were REQUESTED, never by list position (#97378).
+
+Parallel appends failures after successes, Exa omits pages it could not fetch, and the keyless ring
+inherits both shapes. Positional pairing cached one page's text under another URL's key and served it
+for the whole cache TTL.
+"""
+
+import json
+
+import pytest
+
+import tools.web_result_cache as wrc
+import tools.web_tools as web_tools
+from tools.web_tools_extract import _pair_results
+
+A, B = "https://a.example/page", "https://b.example/page"
+
+
+def _doc(url, text):
+    return {"url": url, "title": url, "content": text, "raw_content": text, "metadata": {"sourceURL": url}}
+
+
+def _fail(url, error="fetch failed"):
+    return {"url": url, "title": "", "content": "", "error": error}
+
+
+class _ScriptedProvider:
+    name = "scripted"
+
+    def __init__(self, results):
+        self._results = results
+
+    def extract(self, urls, **kwargs):
+        return self._results
+
+
+@pytest.mark.asyncio
+async def test_results_are_paired_by_url_not_position(tmp_path, monkeypatch):
+    """A batch returned as [failure(B), document(A)] for the request [A, B] must yield A's document at
+    A's position and cache A's text under A's key only — B stays a miss."""
+    cache_dir = tmp_path / "cache" / "web"
+    cache_dir.mkdir(parents=True)
+    monkeypatch.setattr(wrc, "_cache_dir", lambda: cache_dir)
+    monkeypatch.setattr(wrc, "_web_config", lambda: {})
+    provider = _ScriptedProvider([_fail(B), _doc(A, "text of A")])
+    monkeypatch.setattr(web_tools, "_get_extract_backend", lambda: provider.name)
+    monkeypatch.setattr(web_tools, "_ensure_web_plugins_loaded", lambda: None)
+    monkeypatch.setattr(web_tools, "_resolve_extract_provider", lambda backend: (provider, None))
+
+    async def _allow(url):
+        return True
+
+    monkeypatch.setattr(web_tools, "async_is_safe_url", _allow)
+
+    results = json.loads(await web_tools.web_extract_tool([A, B]))["results"]
+
+    assert [r["url"] for r in results] == [A, B]
+    assert results[0]["content"] == "text of A" and not results[0].get("error")
+    assert results[1]["error"] == "fetch failed"
+    assert wrc.extract_cache_get(A, provider=provider.name)["content"] == "text of A"
+    assert wrc.extract_cache_get(B, provider=provider.name) is None
+
+
+@pytest.mark.parametrize(
+    "urls, results, expected",
+    [
+        # A backend echoing a cosmetically different URL still pairs: trailing slash, http->https, apex->www.
+        (["https://a.example/x"], [_doc("https://a.example/x/", "slash")], ["slash"]),
+        (["http://a.example/x"], [_doc("https://a.example/x", "https")], ["https"]),
+        (["https://a.example/x"], [_doc("https://www.a.example/x", "www")], ["www"]),
+        # The keyless ring emits a "no content" stub NEXT TO the document when it rewrites a URL.
+        (["https://a.example/x"], [_fail("https://a.example/x", "no content returned"), _doc("https://a.example/x/", "doc")], ["doc"]),
+        # The query is part of the page: a missing ?page=1 never inherits ?page=2's document.
+        (["https://a.example/x?page=1", "https://a.example/x?page=2"], [_doc("https://a.example/x?page=2", "p2")], [None, "p2"]),
+        # A lone unmatched result belongs to the lone unmatched URL (redirect to another host).
+        ([A, B], [_doc("https://cdn.b.example/home", "moved"), _doc(A, "a")], ["a", "moved"]),
+        # Several unmatched results are never guessed at: they are dropped, not attached.
+        ([A, B], [_doc("https://x.example/1", "x1"), _doc("https://x.example/2", "x2")], [None, None]),
+    ],
+    ids=["trailing-slash", "scheme", "www", "document-beats-stub", "query-is-a-page", "lone-leftover", "no-guessing"],
+)
+def test_pair_results_matches_canonical_variants_only(urls, results, expected):
+    paired = _pair_results(urls, results)
+    assert [None if r.get("error") else r["content"] for r in paired] == expected

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -379,8 +379,8 @@ async def web_extract_tool(urls: List[Any], format: str = None, char_limit: Opti
             if error_json is not None:
                 return error_json
             results = await _extract_safe_urls(provider, safe_urls, format)
-        # Reconstruct input order across invalid, blocked, and provider entries (providers preserve
-        # the order of the safe URL list they receive).
+        # Reconstruct input order across invalid, blocked, and provider entries (fetched entries were
+        # paired to their requested URL in _dispatch_extract, so they sit in safe_urls order).
         if invalid_urls or ssrf_blocked:
             fixed = {**ssrf_blocked, **invalid_urls}
             results = _merge_in_order(len(urls), fixed, safe_indices, safe_urls, results)

--- a/tools/web_tools_extract.py
+++ b/tools/web_tools_extract.py
@@ -10,6 +10,7 @@ import asyncio
 import json
 import logging
 from typing import Any, Dict, List, Optional
+from urllib.parse import urlsplit
 
 from tools.tool_backend_helpers import selection_error, selection_exists
 from tools.url_safety import normalize_url_for_request, sensitive_query_param_name
@@ -139,11 +140,72 @@ def _resolve_extract_provider(backend: str):
     return provider, None
 
 
+def _url_key(url: Any, *, loose: bool = False) -> str:
+    """Pairing key for a requested/returned URL. Drops only what cannot change WHICH document was
+    fetched: case, userinfo, a default port, a trailing slash, the fragment. The query stays
+    (``?page=2`` is another page). ``loose`` also drops the scheme and a leading ``www.`` for
+    backends that report the post-redirect URL instead of the string they were handed."""
+    if not isinstance(url, str) or not url.strip():
+        return ""
+    try:
+        parts = urlsplit(normalize_url_for_request(url.strip()))
+        scheme, host, port = parts.scheme.lower(), (parts.hostname or "").lower(), parts.port
+    except ValueError:
+        return url.strip().lower()
+    if port == {"http": 80, "https": 443}.get(scheme):
+        port = None
+    if loose and host.startswith("www."):
+        host = host[4:]
+    prefix = "" if loose else f"{scheme}://"
+    query = f"?{parts.query}" if parts.query else ""
+    return f"{prefix}{host}{f':{port}' if port else ''}{parts.path.rstrip('/')}{query}"
+
+
+def _pair_results(urls: List[str], results: List[dict]) -> List[dict]:
+    """One entry per requested URL, in request order, paired by URL — never by list position:
+    Parallel appends failures after successes, Exa omits pages it could not fetch, the keyless ring
+    inherits both shapes, and a rescued batch comes back in ring order. Positional pairing cached one
+    page's text under another URL's key for the whole TTL (#97378).
+
+    Exact keys pair first, then loose ones (an exact pairing is never a loose candidate elsewhere).
+    A document beats an error stub for the same key — the keyless ring emits both when it rewrites a
+    URL. A lone leftover result goes to the lone unmatched URL (redirect to another host); any other
+    unmatched result is dropped rather than attached to some other URL. ``metadata.sourceURL`` is
+    indexed alongside ``url`` because Keenable reports the requested URL only there."""
+    entries = [r for r in results if isinstance(r, dict)]
+    by_key: Dict[tuple, List[int]] = {}
+    for index, entry in enumerate(entries):
+        meta = entry.get("metadata")
+        source = meta.get("sourceURL") if isinstance(meta, dict) else None
+        for loose in (False, True):
+            for key in {_url_key(entry.get("url"), loose=loose), _url_key(source, loose=loose)} - {""}:
+                by_key.setdefault((loose, key), []).append(index)
+
+    paired: Dict[int, dict] = {}
+    used: set[int] = set()
+    for loose in (False, True):
+        taken = set(used)
+        for position, url in enumerate(urls):
+            candidates = [i for i in by_key.get((loose, _url_key(url, loose=loose)), ()) if i not in taken]
+            if position in paired or not candidates:
+                continue
+            paired[position] = entries[next((i for i in candidates if not entries[i].get("error")), candidates[0])]
+            used.update(candidates)
+    missing = [position for position in range(len(urls)) if position not in paired]
+    leftover = [i for i in range(len(entries)) if i not in used]
+    if len(missing) == 1 and len(leftover) == 1:
+        paired[missing[0]] = entries[leftover[0]]
+    elif leftover:
+        logger.warning("web_extract: dropping %d result(s) matching no requested URL", len(leftover))
+    return [paired.get(position) or _result_entry(url, _NO_RESULT_ERROR) for position, url in enumerate(urls)]
+
+
 async def _dispatch_extract(provider, fetch_urls: List[str], format: Optional[str]) -> List[dict]:
     """Call ``provider.extract`` (async or sync-in-thread), with one-shot keyless rescue.
 
     Rescue fires on a raised exception or when the WHOLE batch failed (backend outage, not per-page
-    problems). Rescued batches are never cached.
+    problems). Rescued batches are never cached. Every batch, rescued or not, is paired to
+    ``fetch_urls`` by URL before it is returned or cached.
     """
     import inspect
     from tools.web_result_cache import extract_cache_put
@@ -155,12 +217,13 @@ async def _dispatch_extract(provider, fetch_urls: List[str], format: Optional[st
     except Exception as exc:  # noqa: BLE001 — candidate for rescue
         if not _rescue_eligible(provider):
             raise
-        failed = [_result_entry(u, str(exc)) for u in fetch_urls]
-        return await asyncio.to_thread(_rescue_extract, provider.name, fetch_urls, failed)
+        results = [_result_entry(u, str(exc)) for u in fetch_urls]
     if results and all(r.get("error") for r in results) and _rescue_eligible(provider):
-        return await asyncio.to_thread(_rescue_extract, provider.name, fetch_urls, results)
+        rescued = await asyncio.to_thread(_rescue_extract, provider.name, fetch_urls, results)
+        return _pair_results(fetch_urls, rescued)
 
-    # Cache each successful fetch's full clean text (best-effort; oversized skipped).
+    results = _pair_results(fetch_urls, results)
+    # Cache each successful fetch's full clean text under the REQUESTED url (best-effort; oversized skipped).
     for url, fetched in zip(fetch_urls, results):
         _content = fetched.get("raw_content", "") or fetched.get("content", "")
         if _content and not fetched.get("error"):


### PR DESCRIPTION
## What does this PR do?

`web_extract` paired the documents a provider returned with the URLs that were requested **by list position**. Most extract backends do not preserve request order or length — Parallel appends failures *after* successes, Exa omits failed URLs, the keyless ring inherits both shapes, and a rescued batch comes back in ring-vendor order — so after any failure, reorder, or omission in a batch the dispatcher cached **one page's text under another URL's key** and served it, labeled with the requested URL, for the rest of the cache TTL. Single-URL retries hit the poisoned entry and never recovered. Full write-up, real-world case, and offline repro in the linked issue.

The fix is one pairing step in the dispatcher, no provider changes:

- **`_pair_results()`** in `tools/web_tools_extract.py` pairs every backend result to a requested URL by URL. Exact canonical keys first (case, userinfo, default port, trailing slash, and fragment dropped; the query kept — `?page=2` is another page), then a loose key (scheme and leading `www.` dropped) for backends that report the post-redirect URL, then the single remaining result to the single remaining URL when exactly one of each is left. It never guesses among several leftovers: an unmatched requested URL gets the existing `"Extract backend returned no result for this URL"` entry, and an unmatched result is dropped with a warning. A document beats an error stub for the same key (the keyless ring emits both when it rewrites a URL). Both `url` and `metadata.sourceURL` are indexed because Keenable reports the requested URL only in the latter.
- **Applied once, in `_dispatch_extract`**, before the batch is cached or merged. The two rescue branches collapse into one so there is a single return path to pair; rescued batches are paired too and remain uncached. The cache write is now correct by construction: `zip(fetch_urls, results)` keys each page on the URL that was requested.
- `_merge_in_order` and `_rescue_extract` are untouched. Their short-list fallbacks are no longer reachable from the fetched path, but removing them widens the diff for no behavior change.
- The now-false comment *"providers preserve the order of the safe URL list they receive"* states the real invariant.

Why URL matching in the dispatcher rather than per-provider order fixes: the assumption was violated in nine provider paths (keyed + keyless × Tavily/Parallel/Exa, plus the ring and rescue), the vendor docs make no order promise, and the new Perplexity provider already pairs by URL inside its own normalizer — this does the same thing once for every backend, current and future.

Intentional, visible behavior changes:

- `web_extract` output always has exactly one entry per requested URL, in request order; documents for URLs that were not requested are dropped instead of appended.
- An empty provider result list yields one explicit per-URL error per requested URL instead of the generic *"Content was inaccessible or not found"* error.

Not in this PR: retiring already-poisoned cache entries. They expire with the normal TTL (default 20 min, capped at 24 h), which is not worth a permanent cache-key version bump.

## Related Issue

Fixes #97378

Related: #90744 (acknowledges the missing one-to-one mapping, but only skips rescue on length mismatch), #56972 (final-URL SSRF guard — compatible: paired entries keep the provider-reported `url`), #47611 (Firecrawl fanout — robust regardless of collection order once the dispatcher matches by URL).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/web_tools_extract.py` — new `_url_key()` and `_pair_results()`; `_dispatch_extract` pairs every batch (provider or rescued) before caching or returning, with the two rescue branches folded into one.
- `tools/web_tools.py` — the reconstruction comment in `web_extract_tool` states the real invariant.
- `tests/tools/test_web_extract_url_matching.py` (new, no network) — two invariant tests, both red on `main`: an end-to-end run through `web_extract_tool` with a scripted provider returning `[failure(B), document(A)]` for `[A, B]`, asserting request order and that A's text is cached under A's key only; and a parametrized `_pair_results` contract covering trailing slash, `http→https`, apex→`www`, document-over-stub, query-is-a-page, the lone-leftover redirect, and no-guessing among several leftovers.

## How to Test

1. Reproduce on `main` with the script from the issue: B's text is cached under A and served for A with no provider call.
2. On this branch the same script shows A carrying its own error, nothing cached under A, and the single re-fetch reaching the provider.
3. Regression tests and neighbouring web suites:
   ```
   scripts/run_tests.sh tests/tools/test_web_extract_url_matching.py -q
   scripts/run_tests.sh tests/tools/test_web_result_cache.py tests/tools/test_web_keyless_rescue.py tests/tools/test_web_keyless_fallback.py tests/tools/test_read_extract.py tests/tools/test_web_tools_tavily.py -q
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — via `scripts/run_tests.sh` (CI parity) over every test file that imports the web modules plus `tests/plugins/`; the remaining failures are optional-dependency failures with a byte-identical ID set on `main` (details under Logs)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 (Python 3.12)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings and the dispatcher comment state the per-URL contract
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config changes)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure-Python logic, no platform I/O
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (the tool's external schema is unchanged)

## Screenshots / Logs

Branch rebuilt on current `main` (`b2aa855b62`) after the `tools/web_tools.py` → `web_tools_extract.py` / `web_tools_rescue.py` split; one commit. Ubuntu 24.04, Python 3.12, out-of-tree venv from `uv sync --extra dev`.

```
$ scripts/run_tests.sh tests/tools/test_web_extract_url_matching.py -q
=== Summary: 1 files, 8 tests passed, 0 failed (100% complete) in 1.9s (24 workers) ===
```

Nine neighbouring web suites (`test_web_result_cache`, `test_web_keyless_rescue`, `test_web_keyless_fallback`, `test_web_extract_robustness`, `test_read_extract`, `test_web_providers`, `test_web_tools_perplexity`, `test_web_tools_tavily`, `test_web_tools_config`): 245 passed, 2 failed — the two `TestParallelClientConfig` cases need the Parallel SDK and fail identically on `main`.

Every test file importing `web_tools*` / `web_result_cache` plus `tests/plugins/` (171 files): 3,871 passed, 20 failed. The 20 failing IDs (hindsight, fal, one auxiliary-transport, one TUI, the two Parallel-SDK cases) were re-run on a `git worktree` of `main` under the same venv: identical set, so no outcome differs from `main`.

`ruff check` on the three touched files: clean. `scripts/check_compat_pointers.py`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pk832kz8USn3W81HAtxBr6
