### PR TITLE
fix(gateway): drain detached work before shutdown

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8725,6 +8725,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             self._running_agent_count()
             + self._active_cron_job_count()
             + self._active_api_run_count()
+            + self._active_async_delegation_count()
+            + self._active_process_registry_work_count()
         )
 
     def _active_cron_job_count(self) -> int:
@@ -8758,6 +8760,31 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             adapter = getattr(self, "adapters", {}).get(Platform.API_SERVER)
             helper = getattr(adapter, "active_agent_work_count", None)
             return max(0, int(helper())) if callable(helper) else 0
+        except Exception:
+            return 0
+
+    def _active_async_delegation_count(self) -> int:
+        """Count detached delegate_task work outside ``_running_agents``."""
+        try:
+            from tools.async_delegation import active_count
+
+            return max(0, int(active_count()))
+        except Exception:
+            return 0
+
+    def _active_process_registry_work_count(self) -> int:
+        """Count live terminal background work as one drain unit.
+
+        The registry exposes a boolean because one or many processes have the
+        same shutdown contract: wait for all of them to finish, then use the
+        existing global kill on timeout. Pending completion watchers are not
+        counted here; they need the gateway watcher loop to run and therefore
+        cannot make progress after shutdown begins.
+        """
+        try:
+            from tools.process_registry import process_registry
+
+            return int(process_registry.has_any_active())
         except Exception:
             return 0
 
@@ -10797,25 +10824,35 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         last_active_count = self._running_agent_count()
         last_cron_count = self._active_cron_job_count()
         last_api_count = self._active_api_run_count()
+        last_async_delegation_count = self._active_async_delegation_count()
+        last_process_registry_count = self._active_process_registry_work_count()
         last_status_at = 0.0
 
         def _maybe_update_status(force: bool = False) -> None:
-            nonlocal last_active_count, last_cron_count, last_api_count, last_status_at
+            nonlocal last_active_count, last_cron_count, last_api_count
+            nonlocal last_async_delegation_count, last_process_registry_count
+            nonlocal last_status_at
             now = asyncio.get_running_loop().time()
             active_count = self._running_agent_count()
             cron_count = self._active_cron_job_count()
             api_count = self._active_api_run_count()
+            async_delegation_count = self._active_async_delegation_count()
+            process_registry_count = self._active_process_registry_work_count()
             if (
                 force
                 or active_count != last_active_count
                 or cron_count != last_cron_count
                 or api_count != last_api_count
+                or async_delegation_count != last_async_delegation_count
+                or process_registry_count != last_process_registry_count
                 or (now - last_status_at) >= 1.0
             ):
                 self._update_runtime_status("draining")
                 last_active_count = active_count
                 last_cron_count = cron_count
                 last_api_count = api_count
+                last_async_delegation_count = async_delegation_count
+                last_process_registry_count = process_registry_count
                 last_status_at = now
 
         # Cron jobs run on the scheduler's own thread pool, outside
@@ -10823,8 +10860,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # same wait/timeout this method already applies to chat sessions,
         # or a cron job's tool work gets killed with zero warning the
         # instant it's the only active thing running (#60432).
-        # API-server / desk sessions have the same structural gap (#63529).
-        if not self._running_agents and last_cron_count == 0 and last_api_count == 0:
+        # API-server / desk sessions, detached async delegations, and terminal
+        # background processes have the same structural gap (#63529).
+        if (
+            not self._running_agents
+            and last_cron_count == 0
+            and last_api_count == 0
+            and last_async_delegation_count == 0
+            and last_process_registry_count == 0
+        ):
             _maybe_update_status(force=True)
             return snapshot, False
 
@@ -10845,7 +10889,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         def _still_draining() -> bool:
             now = loop.time()
             if (
-                len(self._running_agents) or self._active_api_run_count()
+                len(self._running_agents)
+                or self._active_api_run_count()
+                or self._active_async_delegation_count()
+                or self._active_process_registry_work_count()
             ) and now < deadline:
                 return True
             return bool(self._active_cron_job_count()) and now < cron_deadline
@@ -10861,6 +10908,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             bool(len(self._running_agents))
             or bool(self._active_cron_job_count())
             or bool(self._active_api_run_count())
+            or bool(self._active_async_delegation_count())
+            or bool(self._active_process_registry_work_count())
         )
         _maybe_update_status(force=True)
         return snapshot, timed_out
@@ -15081,6 +15130,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             await self._stop_task
             return
 
+        def _optional_active_count(method_name: str) -> int:
+            """Read additive work counters from minimal shutdown test doubles."""
+            helper = getattr(self, method_name, None)
+            if not callable(helper):
+                return 0
+            try:
+                return max(0, int(helper()))
+            except Exception:
+                return 0
+
         async def _stop_impl() -> None:
             def _kill_tool_subprocesses(phase: str) -> list:
                 """Kill tool subprocesses + tear down terminal envs + browsers.
@@ -15172,6 +15231,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "active_agents": self._running_agent_count(),
                     "active_cron_jobs": self._active_cron_job_count(),
                     "active_api_runs": self._active_api_run_count(),
+                    "active_async_delegations": _optional_active_count(
+                        "_active_async_delegation_count"
+                    ),
+                    "active_process_registry_work": (
+                        _optional_active_count("_active_process_registry_work_count")
+                    ),
                     "restart_drain_timeout": self._restart_drain_timeout,
                     "watchdog_delay_s": resolve_shutdown_watchdog_delay(
                         self._restart_drain_timeout
@@ -15247,6 +15312,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             _cron_at_start = self._active_cron_job_count()
             _api_at_start = self._active_api_run_count()
+            _async_delegations_at_start = _optional_active_count(
+                "_active_async_delegation_count"
+            )
+            _process_registry_at_start = _optional_active_count(
+                "_active_process_registry_work_count"
+            )
             # In-flight cron work gets its own floor, clamped to the watchdog
             # leash we're already running under so the extra wait can never
             # cost us the post-drain cleanup window (#82161).
@@ -15281,7 +15352,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "Shutdown phase: drain done at +%.2fs (drain took %.2fs, "
                 "timed_out=%s, active_at_start=%d, active_now=%d, "
                 "cron_at_start=%d, cron_now=%d, "
-                "api_at_start=%d, api_now=%d)",
+                "api_at_start=%d, api_now=%d, "
+                "async_delegations_at_start=%d, async_delegations_now=%d, "
+                "process_registry_at_start=%d, process_registry_now=%d)",
                 _phase_elapsed(),
                 _drain_elapsed,
                 timed_out,
@@ -15291,6 +15364,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 self._active_cron_job_count(),
                 _api_at_start,
                 self._active_api_run_count(),
+                _async_delegations_at_start,
+                _optional_active_count("_active_async_delegation_count"),
+                _process_registry_at_start,
+                _optional_active_count("_active_process_registry_work_count"),
             )
 
             if not timed_out:
@@ -15310,12 +15387,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if timed_out:
                 logger.warning(
                     "Gateway drain timed out after %.1fs with %d active agent(s), "
-                    "%d in-flight cron job(s), and %d api_server run(s); "
+                    "%d in-flight cron job(s), %d api_server run(s), "
+                    "%d async delegation(s), and %d process-registry work unit(s); "
                     "interrupting remaining work.",
                     _drain_elapsed,
                     self._running_agent_count(),
                     self._active_cron_job_count(),
                     self._active_api_run_count(),
+                    _optional_active_count("_active_async_delegation_count"),
+                    _optional_active_count("_active_process_registry_work_count"),
                 )
                 # Mark forcibly-interrupted sessions as resume_pending BEFORE
                 # interrupting the agents.  This preserves each session's

--- a/tests/gateway/test_async_delegation_active_work_drain.py
+++ b/tests/gateway/test_async_delegation_active_work_drain.py
@@ -1,0 +1,100 @@
+"""Regression coverage for background delegation shutdown draining."""
+
+import asyncio
+
+import pytest
+
+from tests.gateway.restart_test_helpers import make_restart_runner
+
+
+@pytest.mark.asyncio
+async def test_drain_waits_for_in_flight_async_delegation(monkeypatch):
+    """A detached delegate_task must remain visible after its parent turn ends."""
+    import tools.async_delegation as async_delegation
+
+    runner, _adapter = make_restart_runner()
+    active = [1]
+    drain_checked = asyncio.Event()
+
+    def active_count():
+        drain_checked.set()
+        return active[0]
+
+    monkeypatch.setattr(async_delegation, "active_count", active_count)
+
+    assert runner._active_work_count() == 1
+    drain_checked.clear()
+
+    drain_task = asyncio.create_task(runner._drain_active_agents(2.0))
+    await asyncio.wait_for(drain_checked.wait(), timeout=2.0)
+    assert not drain_task.done(), (
+        "drain returned with active_at_start=0 while a background delegation "
+        "was still running"
+    )
+
+    active[0] = 0
+    _snapshot, timed_out = await drain_task
+
+    assert timed_out is False
+
+
+@pytest.mark.asyncio
+async def test_drain_waits_for_terminal_background_process(monkeypatch):
+    """Process-registry work must not be killed before the drain budget."""
+    from tools.process_registry import process_registry
+
+    runner, _adapter = make_restart_runner()
+    active = [True]
+    drain_checked = asyncio.Event()
+
+    def has_any_active():
+        drain_checked.set()
+        return active[0]
+
+    monkeypatch.setattr(process_registry, "has_any_active", has_any_active)
+
+    assert runner._active_work_count() == 1
+    drain_checked.clear()
+
+    drain_task = asyncio.create_task(runner._drain_active_agents(2.0))
+    await asyncio.wait_for(drain_checked.wait(), timeout=2.0)
+    assert not drain_task.done()
+
+    active[0] = False
+    _snapshot, timed_out = await drain_task
+
+    assert timed_out is False
+
+
+@pytest.mark.asyncio
+async def test_background_work_drain_is_bounded(monkeypatch):
+    """Live detached work past the deadline must report a timeout."""
+    import tools.async_delegation as async_delegation
+    from tools.process_registry import process_registry
+
+    runner, _adapter = make_restart_runner()
+    monkeypatch.setattr(async_delegation, "active_count", lambda: 1)
+    monkeypatch.setattr(process_registry, "has_any_active", lambda: True)
+
+    _snapshot, timed_out = await runner._drain_active_agents(0.05)
+
+    assert timed_out is True
+
+
+@pytest.mark.asyncio
+async def test_permanent_supervised_watcher_does_not_block_drain():
+    """Gateway-lifetime watchers cannot be part of the shutdown work count."""
+    runner, _adapter = make_restart_runner()
+    blocker = asyncio.Event()
+    watcher = asyncio.create_task(blocker.wait())
+    watcher._hermes_supervised_watcher = True
+    runner._background_tasks.add(watcher)
+
+    try:
+        assert runner._active_work_count() == 0
+        _snapshot, timed_out = await runner._drain_active_agents(0.05)
+    finally:
+        watcher.cancel()
+        await asyncio.gather(watcher, return_exceptions=True)
+
+    assert timed_out is False


### PR DESCRIPTION
## Summary

- include detached async delegations in gateway active-work accounting and shutdown drain
- include terminal background processes tracked by the process registry
- keep the drain bounded and preserve existing timeout interruption behavior
- expose both counters in shutdown watchdog and drain diagnostics

## Bug

A gateway can receive SIGTERM while a top-level `delegate_task(background=true)` still owns a native child review. The parent chat turn has already returned, so `_running_agents`, cron, and API counts are all zero. `_drain_active_agents()` then returns immediately and shutdown calls `interrupt_all()`, amputating the live delegation.

The same structural gap exists for standalone `terminal(background=true)` work.

## Regression

Before the fix, an async delegation with `active_count() == 1` produced `snapshot=0, timed_out=False` without waiting. The new tests assert that async delegations and process-registry work remain visible until they finish, still time out at the configured bound, and do not count permanent supervised watchers.

## Validation

- 51 async/cron/API/scale-to-zero tests passed
- 21 restart/shutdown tests passed; 2 platform skips
- focused Ruff check passed
- `git diff --check` passed

This does not identify or prevent an external SIGTERM source; it makes graceful shutdown/restart drain the detached work that was previously invisible.