### PR TITLE
fix(gateway): skip paused/non-running SCM services instead of aborting update

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1086,9 +1086,17 @@ def find_windows_gateway_services(
             if service_status == "stopped":
                 continue
             if service_status != "running":
-                raise RuntimeError(
-                    f"SCM service {service_name} has indeterminate status: {service_status}"
+                # Non-running, non-stopped statuses (paused, pause_pending,
+                # continue_pending, start_pending, stop_pending) are not active
+                # SCM hosts for a gateway — skip them instead of aborting the
+                # entire enumeration.  A single paused third-party service
+                # (e.g. Siemens SmartServer) must not block updates. (#96860)
+                logger.debug(
+                    "Skipping SCM service %s with non-running status: %s",
+                    service_name,
+                    service_status,
                 )
+                continue
             if service_pid <= 0:
                 raise RuntimeError(
                     f"Running SCM service {service_name} has no valid process ID"

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -1126,6 +1126,27 @@ def test_find_windows_gateway_services_fails_closed_on_service_access_error(
         )
 
 
+def test_find_windows_gateway_services_skips_paused_service(monkeypatch):
+    """A paused third-party service must not abort the SCM enumeration (#96860)."""
+    monkeypatch.setattr(gateway.sys, "platform", "win32")
+    profile = SimpleNamespace(profile="default", pid=300, create_time=300.0)
+
+    class PausedService:
+        def as_dict(self):
+            return {"name": "cortsmartserver", "pid": 0, "status": "paused"}
+
+    fake_psutil = SimpleNamespace(
+        win_service_iter=lambda: [PausedService()],
+    )
+
+    # Must not raise — paused services are skipped, not fatal.
+    result = gateway.find_windows_gateway_services(
+        psutil_module=fake_psutil,
+        profile_processes=[profile],
+    )
+    assert result == []
+
+
 def test_find_windows_gateway_services_fails_closed_when_scm_scan_is_indeterminate(
     monkeypatch,
 ):


### PR DESCRIPTION
## Summary

`find_windows_gateway_services()` aborts the entire SCM service enumeration when it encounters any service whose status is not `running` or `stopped`. A single paused third-party service (e.g. Siemens SmartServer `cortsmartserver`) raises `RuntimeError: SCM service {name} has indeterminate status: paused`, which wraps as `SCM service enumeration failed` and blocks `hermes update` entirely — even though the code update itself would succeed.

## Root Cause

`hermes_cli/gateway.py:find_windows_gateway_services()` only handles `stopped` (skip) and `running` (track PID). Any other status (`paused`, `pause_pending`, `continue_pending`, `start_pending`, `stop_pending`) raises a `RuntimeError` that aborts the fleet enumeration:

```python
if service_status != "running":
    raise RuntimeError(
        f"SCM service {service_name} has indeterminate status: {service_status}"
    )
```

The ownership check only needs `running` services with a valid PID — a paused service cannot supervise a live gateway process tree.

## Fix

Treat any non-`running` status as "not an active SCM host — skip", matching the existing `stopped` handling. This is future-proof against any status Windows may add:

```python
if service_status != "running":
    logger.debug(
        "Skipping SCM service %s with non-running status: %s",
        service_name,
        service_status,
    )
    continue
```

## Test

Added `test_find_windows_gateway_services_skips_paused_service` — verifies a paused service is skipped and the function returns an empty list (no crash). The existing `fails_closed` tests for genuine SCM access errors and enumeration failures remain unchanged.

## Verified

Reporter confirmed the same fix works locally: `hermes update --yes --gateway --force --branch main` succeeded after patching to `!= running → continue`.

Closes #96860