### PR TITLE
fix(desktop): localize browser settings in Chinese

### DIFF
--- a/apps/desktop/src/i18n/runtime.test.ts
+++ b/apps/desktop/src/i18n/runtime.test.ts
@@ -59,6 +59,17 @@ describe('desktop i18n runtime translator', () => {
     expect(fieldCopyForSchemaKey(zh.settings.fieldDescriptions, field)).toBe('当后端提供推理内容时予以显示。')
   })
 
+  it('localizes the browser real-profile setting instead of falling back to English', () => {
+    const field = 'browser.use_real_profile'
+
+    expect(fieldCopyForSchemaKey(zh.settings.fieldLabels, field)).toBe('使用我的真实浏览器配置文件')
+    expect(fieldCopyForSchemaKey(zh.settings.fieldDescriptions, field)).toContain('真实登录状态')
+  })
+
+  it('localizes the browser settings section title', () => {
+    expect(zh.settings.sections.browser).toBe('浏览器')
+  })
+
   it('falls back to English when the active locale cannot resolve a key', () => {
     const boot = TRANSLATIONS.ja.boot as { ready?: string }
     const originalReady = boot.ready

--- a/apps/desktop/src/i18n/runtime.test.ts
+++ b/apps/desktop/src/i18n/runtime.test.ts
@@ -61,23 +61,33 @@ describe('desktop i18n runtime translator', () => {
     expect(fieldCopyForSchemaKey(zh.settings.fieldDescriptions, field)).toBe('当后端提供推理内容时予以显示。')
   })
 
+  // Contract shape: the zh overlay supplies a real translation (non-empty,
+  // contains CJK) instead of falling through to the English source. Assumes
+  // the intended translation never equals the English text — don't reuse
+  // this shape for keys where zh legitimately mirrors en (brand names etc.).
+  const CJK = /[\u4e00-\u9fff]/
+
   it('localizes the browser real-profile setting instead of falling back to English', () => {
     const field = 'browser.use_real_profile'
 
     const label = fieldCopyForSchemaKey(zh.settings.fieldLabels, field)
     const description = fieldCopyForSchemaKey(zh.settings.fieldDescriptions, field)
 
-    expect(label).toBeDefined()
+    expect(label).toBeTruthy()
     expect(label).not.toBe(fieldCopyForSchemaKey(en.settings.fieldLabels, field))
-    expect(description).toBeDefined()
+    expect(label).toMatch(CJK)
+    expect(description).toBeTruthy()
     expect(description).not.toBe(fieldCopyForSchemaKey(en.settings.fieldDescriptions, field))
+    expect(description).toMatch(CJK)
   })
 
   it('localizes the browser settings section title', () => {
     const englishLabel = SECTIONS.find(section => section.id === 'browser')?.label
+    const title = zh.settings.sections.browser
 
-    expect(zh.settings.sections.browser).toBeDefined()
-    expect(zh.settings.sections.browser).not.toBe(englishLabel)
+    expect(title).toBeTruthy()
+    expect(title).not.toBe(englishLabel)
+    expect(title).toMatch(CJK)
   })
 
   it('falls back to English when the active locale cannot resolve a key', () => {

--- a/apps/desktop/src/i18n/runtime.test.ts
+++ b/apps/desktop/src/i18n/runtime.test.ts
@@ -1,8 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
+import { SECTIONS } from '@/app/settings/constants'
 import { fieldCopyForSchemaKey } from '@/app/settings/field-copy'
 
 import { TRANSLATIONS } from './catalog'
+import { en } from './en'
 import { setRuntimeI18nLocale, translateNow } from './runtime'
 import { zh } from './zh'
 
@@ -62,12 +64,20 @@ describe('desktop i18n runtime translator', () => {
   it('localizes the browser real-profile setting instead of falling back to English', () => {
     const field = 'browser.use_real_profile'
 
-    expect(fieldCopyForSchemaKey(zh.settings.fieldLabels, field)).toBe('使用我的真实浏览器配置文件')
-    expect(fieldCopyForSchemaKey(zh.settings.fieldDescriptions, field)).toContain('真实登录状态')
+    const label = fieldCopyForSchemaKey(zh.settings.fieldLabels, field)
+    const description = fieldCopyForSchemaKey(zh.settings.fieldDescriptions, field)
+
+    expect(label).toBeDefined()
+    expect(label).not.toBe(fieldCopyForSchemaKey(en.settings.fieldLabels, field))
+    expect(description).toBeDefined()
+    expect(description).not.toBe(fieldCopyForSchemaKey(en.settings.fieldDescriptions, field))
   })
 
   it('localizes the browser settings section title', () => {
-    expect(zh.settings.sections.browser).toBe('浏览器')
+    const englishLabel = SECTIONS.find(section => section.id === 'browser')?.label
+
+    expect(zh.settings.sections.browser).toBeDefined()
+    expect(zh.settings.sections.browser).not.toBe(englishLabel)
   })
 
   it('falls back to English when the active locale cannot resolve a key', () => {

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -504,6 +504,7 @@ export const zh: Translations = {
       appearance: '外观',
       workspace: '工作区',
       safety: '安全',
+      browser: '浏览器',
       memory: '记忆与上下文',
       voice: '语音',
       advanced: '高级'
@@ -699,7 +700,8 @@ export const zh: Translations = {
       },
       browser: {
         allowPrivateUrls: '浏览器私有 URL',
-        autoLocalForPrivateUrls: '私有 URL 使用本地浏览器'
+        autoLocalForPrivateUrls: '私有 URL 使用本地浏览器',
+        useRealProfile: '使用我的真实浏览器配置文件'
       },
       checkpoints: {
         enabled: '文件检查点',
@@ -840,6 +842,10 @@ export const zh: Translations = {
       },
       security: {
         redactSecrets: '尽可能从模型可见内容中隐藏检测到的密钥。'
+      },
+      browser: {
+        useRealProfile:
+          '本地浏览会使用你的真实登录状态。Hermes 会将默认浏览器的配置文件（Cookie、登录信息和偏好设置）复制到受管理的快照中，并使用随附的 Chromium 驱动；不会直接打开你的实时配置文件，每次运行都会从中刷新副本。即使配置了云端浏览器后端，也允许智能体按需打开本地真实配置文件会话。仅支持 Chromium 浏览器（Chrome、Edge、Brave、Chromium）；如果默认浏览器不是 Chromium，会显示明确错误。默认关闭。'
       },
       checkpoints: {
         enabled: '在文件编辑前创建可回滚的快照。'


### PR DESCRIPTION
## Summary

- Localize the existing Browser settings section in Simplified Chinese.
- Add the missing `browser.use_real_profile` label and description.
- Add runtime regression coverage so these settings do not silently fall back to English.

## Context

The desktop settings schema already exposes `browser.use_real_profile`, but the `zh` catalog was missing its field copy and the Browser section title. As a result, these existing settings remained in English when the interface was set to Simplified Chinese.

This complements #96679, which adds real-profile browser functionality; this PR only fixes the missing Chinese localization for the existing settings and does not change browser behavior.

## Validation

- `npm run test:ui -- src/i18n/runtime.test.ts --run` — 9 passed
- `npm run test:ui` — 6,120 passed
- `npm run typecheck` — passed
- `npm run lint` — passed (warnings only)