### PR TITLE
fix(photon): stop advertising fenced code-block support on iMessage

### DIFF
--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -797,9 +797,20 @@ class PhotonAdapter(BasePlatformAdapter):
         # A non-positive interval disables the watchdog entirely (escape hatch).
         self._probe_enabled = self._probe_interval > 0
 
-        # With markdown on, format_message preserves fences and the sidecar's
-        # markdown() builder renders them (or degrades them readably).
-        self.supports_code_blocks = _markdown_enabled()
+        # Prose markdown passthrough is on (bold/italic/headings render
+        # natively), but the adapter must NOT advertise fenced code-block
+        # support. Two reasons, both user-visible:
+        #   1. The sidecar's /send router (send-format.mjs) silently routes
+        #      every URL-bearing message through the plain-text builder, so
+        #      fences arrive as literal ``` characters.
+        #   2. Even on the markdown path, spectrum-ts renders a fence as
+        #      inline monospace text — not a block — so the "code block" the
+        #      gateway asked for doesn't exist on this surface either way.
+        # With the flag False, the gateway's tool-progress path emits the
+        # compact ``terminal: "cmd..."`` one-liner instead of a fenced block,
+        # and ``_outgoing_message_parts`` fence-tracking stays a no-op.
+        # Fixes raw fenced terminal commands leaking into iMessage bubbles.
+        self.supports_code_blocks = False
 
         # Runtime state
         self._sidecar_proc: Optional[subprocess.Popen] = None

--- a/tests/plugins/platforms/photon/test_code_block_capability.py
+++ b/tests/plugins/platforms/photon/test_code_block_capability.py
@@ -1,0 +1,57 @@
+"""Behavior tests: Photon never receives gateway-emitted fenced code blocks.
+
+Root cause (#photon-terminal-fences): the gateway's tool-progress path emits
+terminal commands as fenced blocks on any adapter whose
+``supports_code_blocks`` is True. The Photon adapter set that flag from
+``PHOTON_MARKDOWN`` — but the sidecar's own outbound router
+(``sidecar/send-format.mjs``) silently routes every URL-bearing message
+through the plain-text builder, where fences survive as literal `` ``` ``.
+Even on the markdown path, iMessage renders a fence as inline monospace
+text, not a block. Either way the user saw raw commands in the bubble.
+
+The fix: the adapter stops advertising fence support, so the gateway emits
+the compact one-line ``terminal: "cmd..."`` preview instead. These tests pin
+that contract.
+"""
+from __future__ import annotations
+
+import pytest
+
+from gateway.config import PlatformConfig
+from plugins.platforms.photon.adapter import PhotonAdapter
+
+
+def _make_adapter(monkeypatch: pytest.MonkeyPatch) -> PhotonAdapter:
+    monkeypatch.setenv("PHOTON_PROJECT_ID", "test-project-id")
+    monkeypatch.setenv("PHOTON_PROJECT_SECRET", "test-project-secret")
+    cfg = PlatformConfig(enabled=True, token="", extra={})
+    return PhotonAdapter(cfg)
+
+
+def test_never_claims_code_block_support_even_with_markdown_on(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Markdown passthrough is for prose styling only; fenced blocks degrade
+    (URL fallback -> raw text with literal fences; markdown path -> inline
+    monospace). The adapter must not tell the gateway it can render blocks."""
+    monkeypatch.delenv("PHOTON_MARKDOWN", raising=False)
+    adapter = _make_adapter(monkeypatch)
+    assert adapter.supports_code_blocks is False
+
+
+def test_never_claims_code_block_support_with_markdown_off(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PHOTON_MARKDOWN", "false")
+    adapter = _make_adapter(monkeypatch)
+    assert adapter.supports_code_blocks is False
+
+
+def test_format_message_still_passthrough_with_markdown_on(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The fix narrows the capability flag only — prose markdown passthrough
+    (bold/italic/headings) is unchanged."""
+    monkeypatch.delenv("PHOTON_MARKDOWN", raising=False)
+    adapter = _make_adapter(monkeypatch)
+    assert adapter.format_message("**bold** and _ital_") == "**bold** and _ital_"

--- a/tests/plugins/platforms/photon/test_markdown.py
+++ b/tests/plugins/platforms/photon/test_markdown.py
@@ -43,9 +43,16 @@ def test_format_message_passthrough_by_default(
     assert adapter.format_message(_MD) == _MD
 
 
-def test_supports_code_blocks_mirrors_env(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_supports_code_blocks_never_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Fenced code blocks are not renderable on iMessage: URL-bearing
+    messages fall back to raw text (literal fences), and the markdown path
+    renders a fence as inline monospace, not a block. The adapter therefore
+    never advertises code-block support — the gateway emits its compact
+    one-line tool preview instead (see test_code_block_capability.py)."""
     monkeypatch.delenv("PHOTON_MARKDOWN", raising=False)
-    assert _make_adapter(monkeypatch).supports_code_blocks is True
+    assert _make_adapter(monkeypatch).supports_code_blocks is False
     monkeypatch.setenv("PHOTON_MARKDOWN", "false")
     assert _make_adapter(monkeypatch).supports_code_blocks is False
 

--- a/tests/plugins/platforms/photon/test_terminal_progress_e2e.py
+++ b/tests/plugins/platforms/photon/test_terminal_progress_e2e.py
@@ -1,0 +1,45 @@
+"""E2E: the gateway's tool-progress path must not emit fenced terminal
+blocks for the Photon adapter, using the REAL resolution code paths.
+
+Runs the actual flag handoff the way the gateway does it:
+  adapter.supports_code_blocks  ->  the run.py progress branch builds either
+  a fenced block or the compact preview. We re-implement only the tiny
+  branch body (copied verbatim from run.py's decision) and drive it with
+  the real PhotonAdapter + real config resolution from this tree.
+"""
+from __future__ import annotations
+
+import yaml
+
+from gateway.config import PlatformConfig
+from gateway.display_config import resolve_display_setting
+from plugins.platforms.photon.adapter import PhotonAdapter
+
+
+def _progress_message(supports_blocks: bool, command: str) -> str:
+    """The exact branch shape from gateway/run.py tool-progress handling."""
+    if supports_blocks:
+        return f"💻 terminal\n```\n{command}\n```"
+    cap = 40
+    short = command.splitlines()[0]
+    if len(short) > cap:
+        short = short[: cap - 3] + "..."
+    return f'💻 terminal: "{short}"'
+
+
+def test_gateway_would_not_fence_terminal_for_photon(tmp_path) -> None:
+    cfg = {"display": {"tool_progress": "all"}}
+    platform_key = "photon"
+    # Real resolution: mode must still be "all" (we did NOT ask users to
+    # change config for the fix to work).
+    assert resolve_display_setting(cfg, platform_key, "tool_progress") == "all"
+
+    import os
+    os.environ.setdefault("PHOTON_PROJECT_ID", "test-project-id")
+    os.environ.setdefault("PHOTON_PROJECT_SECRET", "test-project-secret")
+    adapter = PhotonAdapter(PlatformConfig(enabled=True, token="", extra={}))
+
+    cmd = "export HOME=/opt/data/home; ls /opt/data"
+    msg = _progress_message(adapter.supports_code_blocks, cmd)
+    assert "```" not in msg, f"fenced block would reach iMessage: {msg!r}"
+    assert "ls /opt/data" in msg  # compact preview still shows the action


### PR DESCRIPTION
## What does this PR do?

Photon/iMessage users see raw fenced terminal commands (and other raw markdown) delivered as message bubbles, regardless of any prompt-level style rules. This PR fixes the adapter-level cause: the Photon adapter advertised `supports_code_blocks = PHOTON_MARKDOWN`, but fenced code blocks are not actually renderable on this surface:

1. **URL fallback path:** the sidecar's `/send` router (`sidecar/send-format.mjs`) silently routes every URL-bearing message through the plain-text builder (`spectrumText`) to avoid the data-detection 500. Fences survive as literal ` ``` ` characters in the delivered bubble.
2. **Markdown path:** even URL-free fences don't render as blocks — spectrum-ts's iMessage renderer (`renderBlockToken`, case `"code"`) maps a fenced block to *inline* Unicode mathematical monospace text, not a block.

So when the gateway's tool-progress path (gated on `supports_code_blocks`) built a fenced `terminal` command block, at least one of those two paths degraded it into raw source on the user's screen. The adapter now sets `supports_code_blocks = False` unconditionally, so the gateway emits its compact one-line `💻 terminal: "cmd…"` preview instead. Prose markdown passthrough (bold/italic/headings via `format_message`) is unchanged, and `PHOTON_MARKDOWN` remains the kill-switch for that passthrough.

## Related Issue

Fixes the raw-fenced-terminal-commands-in-iMessage-bubbles behavior (observed live on a Photon personal line; no pre-existing issue number).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/photon/adapter.py`: `self.supports_code_blocks = False` unconditionally (was `_markdown_enabled()`), with a comment explaining both degradation paths.
- `tests/plugins/platforms/photon/test_markdown.py`: `test_supports_code_blocks_mirrors_env` (which pinned the buggy True-with-markdown behavior) replaced by `test_supports_code_blocks_never_enabled`.
- `tests/plugins/platforms/photon/test_code_block_capability.py` (new): capability contract tests for both `PHOTON_MARKDOWN` states, plus a prose-passthrough-unchanged guard.
- `tests/plugins/platforms/photon/test_terminal_progress_e2e.py` (new): E2E-style test that drives the real `PhotonAdapter` + the real `gateway.display_config.resolve_display_setting` and asserts the gateway's tool-progress branch shape (`run.py`'s fenced-vs-compact decision) cannot produce a fence for Photon with `display.tool_progress: all` — no config change needed for the fix to work.

## How to Test

1. Reproduce on `main`: run a gateway with the Photon platform enabled and `display.tool_progress: all`; ask the agent anything that triggers a terminal call whose reply contains a URL. The iMessage thread shows a bubble with literal ` ``` ` fences around the command (and, in markdown-styled replies with links, literal `**bold**` markers).
2. Apply this branch, restart, repeat: terminal progress now arrives as a single compact preview line (`💻 terminal: "export HOME=…"`), and the final reply is unchanged prose markdown.
3. Run the focused suites:
   - `pytest tests/plugins/platforms/photon/test_code_block_capability.py tests/plugins/platforms/photon/test_terminal_progress_e2e.py tests/plugins/platforms/photon/test_markdown.py -q` → 8 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the full `tests/plugins/platforms/photon/` suite instead: 132 passed, 1 pre-existing failure on pristine `main` in this environment (`test_spectrum_patch.py::test_sidecar_patch_failure_still_reaches_health_endpoint` — the conftest live-system guard blocks a real `os.kill` inside this container; fails identically without this branch)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 22.04 (container), live Photon/iMessage line

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A — N/A: no config keys or user-facing settings changed; the inline comment documents the two degradation paths
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A — change is Photon-adapter-local; no platform-conditional logic added
