### PR TITLE
test(desktop): guard first user message against Show-earlier paging loss (#90473 regression)

### DIFF
--- a/apps/desktop/src/app/chat/transcript-window.test.ts
+++ b/apps/desktop/src/app/chat/transcript-window.test.ts
@@ -230,3 +230,51 @@ describe('alignToBranchGroup', () => {
     expect(alignToBranchGroup(messages, 99)).toBe(messages.length)
   })
 })
+
+// Regression guard for #90473 / #96606: for a LIGHT transcript (the reported
+// shape — a long chat of short messages, e.g. 142 turns), the store window
+// must surface messages[0] (the opening user greeting) as the first rendered
+// message. The 30-message floor and the weight budget both keep a light
+// transcript uncut, so paging to the top can never drop the oldest user turn.
+describe('opening user message is the first rendered message (light transcript)', () => {
+  const light = (count: number): ChatMessage[] => transcript(count, 20)
+
+  it('selectTranscriptWindow keeps messages[0] first when the whole transcript is light', () => {
+    const messages = light(142)
+
+    const window = selectTranscriptWindow(messages)
+
+    expect(window.windowed).toBe(false)
+    expect(window.messages[0]).toBe(messages[0])
+  })
+
+  it('growing the window terminates at the full transcript with messages[0] still first', () => {
+    const messages = light(142)
+
+    let pages = 1
+    let window = selectTranscriptWindow(messages, pages)
+
+    while (window.windowed && pages < 100) {
+      window = selectTranscriptWindow(messages, ++pages)
+    }
+
+    expect(window.windowed).toBe(false)
+    expect(window.messages).toHaveLength(messages.length)
+    // The first user message is the head of the fully-rendered transcript.
+    expect(window.messages[0]).toBe(messages[0])
+  })
+
+  it('advanceTranscriptWindow also surfaces messages[0] once pages cover the transcript', () => {
+    const messages = light(142)
+
+    let pages = 1
+    let state = advanceTranscriptWindow(null, messages, pages)
+
+    while (state.window.windowed && pages < 100) {
+      state = advanceTranscriptWindow(state, messages, ++pages)
+    }
+
+    expect(state.window.windowed).toBe(false)
+    expect(state.window.messages[0]).toBe(messages[0])
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/thread/list.test.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/list.test.ts
@@ -322,3 +322,51 @@ describe('liveTailStart', () => {
     }
   })
 })
+
+// Regression guard for #90473 / #96606: after "Show earlier" has paged a
+// session to its very top, the opening user message must still be rendered and
+// head the visible set — it must never be swallowed by the hidden-slice cut.
+// The store window keeps at least TRANSCRIPT_WINDOW_MIN_MESSAGES (30) and the
+// DOM budget only hides a contiguous prefix, so for a light transcript that
+// fits the budget the first user message is the first visible group.
+describe('first user message is never swallowed (Show-earlier paging)', () => {
+  it('keeps the opening user greeting visible when the render budget covers the whole transcript', () => {
+    const groups = buildGroups(
+      signature([
+        ['u1', 'user', 1],
+        ['a1', 'assistant', 4],
+        ['a2', 'assistant', 2],
+        ['u2', 'user', 1],
+        ['a3', 'assistant', 3]
+      ])
+    )
+
+    // A render budget at or above the total weight hides nothing — the state
+    // after "Show earlier" has paged to the top of a light session.
+    const totalWeight = groups.reduce((sum, g) => sum + g.weight, 0)
+    const hidden = firstVisibleGroupIndex(groups, totalWeight)
+
+    expect(hidden).toBe(0)
+    // The first user message is the head of the visible set, not dropped.
+    expect(groups[0]?.id).toBe('u1')
+  })
+
+  it('a leading assistant message (tool-only opening turn) does not hide the first user message', () => {
+    const groups = buildGroups(
+      signature([
+        ['a0', 'assistant', 2],
+        ['u1', 'user', 1],
+        ['a1', 'assistant', 4],
+        ['u2', 'user', 1],
+        ['a2', 'assistant', 3]
+      ])
+    )
+
+    const totalWeight = groups.reduce((sum, g) => sum + g.weight, 0)
+    const hidden = firstVisibleGroupIndex(groups, totalWeight)
+
+    expect(hidden).toBe(0)
+    // The first user message survives as a distinct visible group.
+    expect(groups.some(g => g.id === 'u1')).toBe(true)
+  })
+})


### PR DESCRIPTION
## What does this PR do?

Regression **tests** for #90473 / PR #96606. It is a test-only PR — no production code change.

#96606 fixed the dead "Show earlier" button, but explicitly left *compacted-history reachability / paging UX* as a separate, unfixed slice (`Does not close #90473 — compacted-history reachability and the paging UX are separate`). After the button started working, a reporter found that **the opening user message of a session is missing at the top of the transcript** — only the first assistant reply renders. The reporter's session is a light (non tool-heavy) ~142-message chat, so neither the store window (hard floor `TRANSCRIPT_WINDOW_MIN_MESSAGES = 30`, weight budget not exceeded) nor the DOM budget (`hiddenCount === 0` when paged to the top) should drop it on their own — pointing at the compaction-boundary path #96606 declined to fix.

## Added guards

- `apps/desktop/src/components/assistant-ui/thread/list.test.ts` — `buildGroups` + `firstVisibleGroupIndex`: when the render budget covers the whole transcript, `groups[0]` is the opening user message and is never swallowed by the hidden-slice cut; a leading assistant (tool-only) opening turn does not hide the first user message.
- `apps/desktop/src/app/chat/transcript-window.test.ts` — `selectTranscriptWindow` / `advanceTranscriptWindow`: for a light 142-message transcript, `messages[0]` (the opening user greeting) is the first rendered message and stays first as the window is grown to full.

Both test files pass locally (`vitest run`, list: 29, transcript-window: 20). These lock the render-layer invariants and will catch a regression if a future change to `buildGroups` / `firstVisibleGroupIndex` / the window cut drops the oldest user turn.

## What this PR does NOT do

It cannot assert the actual reported failure, which lives in the **durable/compacted-history boundary** (the desktop prepend only pulls messages inside the runtime window and does not reach the first user message when it sits before the compaction boundary). That needs an E2E against a real compacted session, which I could not run locally. A separate issue tracks the user-visible symptom: https://github.com/NousResearch/hermes-agent/issues/90473 (and a follow-up regression issue should be filed for the compaction-boundary path).

## Related

Refs #90473. Supersedes nothing. Test-only.

## Type of Change

- [x] ✅ Tests (adding or improving test coverage)

## How to Test

```
cd apps/desktop && npx vitest run src/components/assistant-ui/thread/list.test.ts src/app/chat/transcript-window.test.ts
```

## Checklist

- [x] Tests added and passing locally
- [ ] No production code touched