### PR TITLE
fix(ci): bound review automation and fail closed

### DIFF
--- a/.github/workflows/ci-review-comment.yml
+++ b/.github/workflows/ci-review-comment.yml
@@ -2,58 +2,98 @@ name: CI review comment
 
 # Live-updating PR review comment.
 #
-# The poller runs for up to 40 minutes.
-# This run lives in its own workflow.
-# A run stays in progress until its last job ends, and GitHub refuses
-# ``gh run rerun`` on a run that is in progress.
+# Each completed workflow starts a short finalizer that reads only finished
+# runs. CI completion posts its result immediately; Docker completion replaces
+# it with the combined result. No review runner waits while another workflow
+# is still executing.
 #
-# ``workflow_run`` starts this when CI starts. It always reads the workflow
-# and the scripts from the default branch, never from the PR head.
+# ``workflow_run`` starts this when CI or Docker finishes. It always reads the
+# workflow and scripts from the default branch, never from the PR head.
 # It makes a write token safe here.
 #
-# The poller reads job results through the API. Thus it watches the CI run
-# and the separate docker run, and it depends on neither.
+# The poller reads job results through the API. A Docker completion reports
+# both Docker and its matching CI run; a CI completion reports CI alone.
 
 on:
   workflow_run:
-    workflows: [CI]
-    # ``in_progress``, not ``requested``: a first-time contributor's run
-    # sits in ``action_required`` until a maintainer approves it, and
-    # ``requested`` fires at creation — the poller would wait out its
-    # whole timeout on a run that never starts. ``in_progress`` fires
-    # when the run actually starts, and it also fires on re-runs, which
-    # ``requested`` does not.
-    types: [in_progress]
+    workflows: [CI, "Docker Build, Test, and Publish"]
+    # A completed run has final job results, so the comment does not occupy a
+    # hosted runner for the lifetime of CI or a long Docker build.
+    types: [completed]
 
 permissions:
   contents: read
   actions: read
   pull-requests: write
 
-# One poller per CI run. A new push starts a new CI run, and its poller
-# cancels the poller of the run that GitHub superseded. The group keys
-# on the head repository too: fork PRs often share a branch name
-# (``main``, ``patch-1``), and two PRs must not cancel each other.
+# One bounded poller per PR. ``workflow_run.head_branch`` resolves to the
+# default branch for these runs, so using it puts unrelated PRs in one
+# cancellation group. Use the head SHA when GitHub omits the PR association;
+# the poller resolves the PR number from that SHA before posting.
 concurrency:
-  group: ci-review-comment-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
+  group: ci-review-comment-${{ github.event.workflow_run.pull_requests[0].number || github.event.workflow_run.head_sha }}
   cancel-in-progress: true
 
 jobs:
   comment:
     name: CI review comment (live)
-    # Fork PRs get no comment: the poller needs a write token, and the
-    # ``pull_requests`` payload is empty for a fork run.
+    # Fork PRs get no comment: the poller needs a write token. Same-repository
+    # runs can omit ``pull_requests`` too, so the setup step resolves that
+    # case from the head SHA.
     if: >-
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.head_repository.full_name == github.repository
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 5
     steps:
       - name: Checkout trusted default branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
+
+      - name: Resolve CI run for this commit
+        id: ci-run
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          TRIGGER_RUN_ID: ${{ github.event.workflow_run.id }}
+          TRIGGER_WORKFLOW: ${{ github.event.workflow_run.name }}
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number || '' }}
+        run: |
+          set -euo pipefail
+          if [ "$TRIGGER_WORKFLOW" = "CI" ]; then
+            ci_run_id="$TRIGGER_RUN_ID"
+          else
+            ci_run_id=$(gh run list \
+              --repo "$REPO" \
+              --commit "$HEAD_SHA" \
+              --workflow ci.yaml \
+              --limit 1 \
+              --json databaseId \
+              --jq '.[0].databaseId')
+          fi
+
+          if [ -z "$ci_run_id" ] || [ "$ci_run_id" = "null" ]; then
+            echo "No CI run found for $HEAD_SHA" >&2
+            exit 1
+          fi
+
+          pr_number="$PR_NUMBER"
+          if [ -z "$pr_number" ]; then
+            pr_number=$(gh api \
+              "repos/$REPO/commits/$HEAD_SHA/pulls" \
+              --jq 'map(select(.state == "open")) | .[0].number // empty' 2>/dev/null || true)
+          fi
+          if [ -z "$pr_number" ]; then
+            echo "No open pull request found for $HEAD_SHA" >&2
+            exit 1
+          fi
+
+          echo "id=$ci_run_id" >> "$GITHUB_OUTPUT"
+          echo "url=https://github.com/$REPO/actions/runs/$ci_run_id" >> "$GITHUB_OUTPUT"
+          echo "pr=$pr_number" >> "$GITHUB_OUTPUT"
 
       - name: Run live comment poller
         env:
@@ -63,18 +103,18 @@ jobs:
           # ignores an env: override, so that name silently resolves to THIS
           # run. The poller then watches itself, which stays in_progress for
           # as long as the poller runs, and it waits out its whole timeout.
-          CI_RUN_ID: ${{ github.event.workflow_run.id }}
-          # Sibling runs for the same commit that the comment also covers,
-          # one workflow name per line (a name can contain a comma).
-          # The poller resolves each name to its runs through the API.
+          CI_RUN_ID: ${{ steps.ci-run.outputs.id }}
+          # CI completion reports CI alone. Docker completion receives a final
+          # Docker state, so it can report both workflows without waiting.
           WATCH_WORKFLOWS: |
             Docker Build, Test, and Publish
-          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
-          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          SKIP_WATCH_WORKFLOWS: ${{ github.event.workflow_run.name == 'CI' }}
+          PR_NUMBER: ${{ steps.ci-run.outputs.pr }}
+          RUN_URL: ${{ steps.ci-run.outputs.url }}
           # Commit info for the review comment header.
           COMMIT_SHA: ${{ github.event.workflow_run.head_sha }}
           COMMIT_MESSAGE: ${{ github.event.workflow_run.head_commit.message }}
         run: |
           python3 -u scripts/ci/live_comment.py \
             --interval 15 \
-            --timeout 3000
+            --timeout 120

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,7 +38,10 @@ jobs:
   detect:
     name: Detect affected areas
     runs-on: ubuntu-latest
-    timeout-minutes: 1
+    # Fork PRs with deep merged history can spend over a minute in checkout
+    # before classification starts. Keep this bounded without cancelling a
+    # healthy run before the first project step.
+    timeout-minutes: 5
     outputs:
       python: ${{ steps.classify.outputs.python }}
       python_prod: ${{ steps.classify.outputs.python_prod }}
@@ -247,25 +250,7 @@ jobs:
         id: evaluate
         env:
           NEEDS: ${{ toJSON(needs) }}
-        run: |
-          echo "$NEEDS" | python3 -c "
-          import json, sys
-          needs = json.load(sys.stdin)
-          # Emit compact {job_name: result} for the comment assembler.
-          compact = {name: info['result'] for name, info in needs.items()}
-          print(f'needs-json={json.dumps(compact)}')
-          with open('$GITHUB_OUTPUT', 'a') as f:
-              f.write(f'needs-json={json.dumps(compact)}\n')
-          failed = [name for name, info in needs.items() if info['result'] == 'failure']
-          for name, info in sorted(needs.items()):
-              result = info['result']
-              icon = '✅' if result in ('success', 'skipped') else '❌'
-              print(f'{icon} {name}: {result}')
-          if failed:
-              print(f'::error::{len(failed)} job(s) failed: {\", \".join(failed)}')
-              sys.exit(1)
-          print('All checks passed (or were skipped)')
-          "
+        run: python3 scripts/ci/evaluate_ci_gate.py
 
   # ─────────────────────────────────────────────────────────────────────
   # CI timing report: collect per-job/step durations from the GitHub API,

--- a/.github/workflows/label-rerun.yml
+++ b/.github/workflows/label-rerun.yml
@@ -1,87 +1,103 @@
 name: Label rerun
 
-# When the ``ci-reviewed`` label is added to a PR, rerun all failed jobs in
-# the latest CI run. This re-evaluates ``review-labels`` (which now sees the
-# label) and GitHub reruns the dependent ``all-checks-pass`` gate.
-#
-# ``gh run rerun`` only works on a completed run. Thus this waits when the
-# run is still in progress. The wait is now short. The two slowest jobs are
-# the 40-minute comment poller and the 45-minute image build. Each one moved
-# to its own workflow, so a CI run ends when its required jobs end.
-#
-# The review comment updates without help. The poller in
-# ci-review-comment.yml watches the CI run through the API. It gets the
-# rerun results.
+# Adding ci-reviewed must re-evaluate the Review label gate, but it must not
+# occupy a runner while the main CI run is still in progress. A second trigger
+# observes CI completion and performs the narrowly-scoped retry then.
 
 on:
   pull_request:
     types: [labeled]
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
 
 permissions:
   actions: write
   pull-requests: read
 
 concurrency:
-  group: label-rerun-${{ github.event.pull_request.number }}
+  group: label-rerun-${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha }}
   cancel-in-progress: true
 
 jobs:
-  rerun-review-labels:
+  rerun-review-label-gate:
     name: Rerun review-labels job
-    if: github.event.label.name == 'ci-reviewed'
+    # Keep workflow_run privileged execution scoped to CI runs that originated
+    # from this repository's own PR branches. The script also verifies the
+    # ci-reviewed label before it can rerun anything.
+    if: >-
+      (github.event_name == 'pull_request' && github.event.label.name == 'ci-reviewed') ||
+      (github.event_name == 'workflow_run' &&
+       github.event.workflow_run.event == 'pull_request' &&
+       github.event.workflow_run.conclusion == 'failure' &&
+       github.event.workflow_run.head_repository.full_name == github.repository)
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 3
     steps:
-      - name: Wait for CI run to finish, then rerun failed jobs
+      - name: Rerun only the now-approved review gate
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          EVENT_NAME: ${{ github.event_name }}
+          LABEL_PR_NUMBER: ${{ github.event.pull_request.number || '' }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha }}
+          COMPLETED_RUN_ID: ${{ github.event.workflow_run.id || '' }}
         run: |
-          set -uo pipefail
+          set -euo pipefail
 
-          # Find the latest CI run for this PR's head SHA.
-          RUN_INFO=$(gh run list \
-            --repo "$REPO" \
-            --commit "$HEAD_SHA" \
-            --workflow ci.yaml \
-            --limit 1 \
-            --json databaseId,status \
-            --jq '.[0] | "\(.databaseId) \(.status)"' 2>/dev/null || true)
+          run_id="$COMPLETED_RUN_ID"
+          pr_number="$LABEL_PR_NUMBER"
 
-          if [ -z "$RUN_INFO" ]; then
-            echo "No CI run found for this PR — nothing to rerun."
-            exit 0
-          fi
-
-          # Split "RUN_ID STATUS" into two vars. Read STATUS from RUN_INFO,
-          # not from the truncated RUN_ID. Both values came from the same
-          # var before, which made STATUS the run id. Thus the wait branch
-          # always ran.
-          RUN_ID="${RUN_INFO%% *}"
-          STATUS="${RUN_INFO##* }"
-
-          echo "Latest CI run: $RUN_ID (status: $STATUS)"
-
-          # If the run is still in progress, wait for it to finish.
-          # gh run rerun only works on completed runs — if we try while it's
-          # running, GitHub rejects with "cannot be rerun; This workflow is
-          # already running".
-          if [ "$STATUS" != "completed" ]; then
-            echo "Run is $STATUS — waiting for completion (this may take a while)..."
-            # gh run watch --exit-status exits non-zero if the run fails,
-            # which is expected (the label gate fails). Don't let that kill
-            # the workflow — we WANT to rerun failed jobs.
-            timeout 2100 gh run watch "$RUN_ID" --repo "$REPO" --interval 15 || true
-
-            # Verify it's actually completed now.
-            STATUS=$(gh run view "$RUN_ID" --repo "$REPO" --json status --jq '.status' 2>/dev/null || echo "unknown")
-            if [ "$STATUS" != "completed" ]; then
-              echo "Run is still $STATUS after wait — giving up."
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            # A label can be added before CI finishes. Do not wait here: the
+            # workflow_run trigger below will perform the retry at completion.
+            run_info=$(gh run list \
+              --repo "$REPO" \
+              --commit "$HEAD_SHA" \
+              --workflow ci.yaml \
+              --limit 1 \
+              --json databaseId,status \
+              --jq '.[0] | "\(.databaseId) \(.status)"' 2>/dev/null || true)
+            if [ -z "$run_info" ]; then
+              echo "No CI run found for this PR yet; completion trigger will re-check."
+              exit 0
+            fi
+            run_id="${run_info%% *}"
+            status="${run_info##* }"
+            if [ "$status" != "completed" ]; then
+              echo "CI run $run_id is $status; not holding a runner while it finishes."
               exit 0
             fi
           fi
 
-          echo "Run completed. Rerunning all failed jobs..."
-          gh run rerun "$RUN_ID" --repo "$REPO" --failed || true
-          echo "Done. GitHub will rerun review-labels and all dependent jobs."
+          if [ -z "$run_id" ] || [ -z "$HEAD_SHA" ]; then
+            echo "Missing CI run or head SHA; nothing to rerun."
+            exit 0
+          fi
+
+          if [ -z "$pr_number" ]; then
+            pr_number=$(gh api \
+              "repos/$REPO/commits/$HEAD_SHA/pulls" \
+              --jq 'map(select(.state == "open")) | .[0].number // empty' 2>/dev/null || true)
+          fi
+          if [ -z "$pr_number" ]; then
+            echo "No pull request is associated with $HEAD_SHA; nothing to rerun."
+            exit 0
+          fi
+
+          if ! gh pr view "$pr_number" --repo "$REPO" --json labels --jq '.labels[].name' \
+            | grep -Fxq 'ci-reviewed'; then
+            echo "PR #$pr_number is not ci-reviewed; no retry needed."
+            exit 0
+          fi
+
+          review_job_id=$(gh run view "$run_id" --repo "$REPO" --json jobs --jq \
+            '.jobs[] | select(.conclusion == "failure" and (.name | startswith("Review label gate /"))) | .databaseId' \
+            | head -n 1)
+          if [ -z "$review_job_id" ]; then
+            echo "No failed Review label gate in CI run $run_id; no retry needed."
+            exit 0
+          fi
+
+          echo "Rerunning only failed Review label gate job $review_job_id from CI run $run_id."
+          gh api --method POST "repos/$REPO/actions/jobs/$review_job_id/rerun"

--- a/scripts/ci/evaluate_ci_gate.py
+++ b/scripts/ci/evaluate_ci_gate.py
@@ -1,0 +1,59 @@
+"""Evaluate CI job results and fail closed for non-success outcomes."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from collections.abc import Mapping
+from typing import Any
+
+
+_ACCEPTED_RESULTS = frozenset({"success", "skipped"})
+
+
+def evaluate(needs: Mapping[str, Any]) -> tuple[dict[str, str], list[str]]:
+    """Return compact results and the jobs that did not complete acceptably."""
+    compact: dict[str, str] = {}
+    blocked: list[str] = []
+    for name, info in needs.items():
+        result = info.get("result", "unknown") if isinstance(info, Mapping) else "unknown"
+        result = str(result)
+        compact[name] = result
+        if result not in _ACCEPTED_RESULTS:
+            blocked.append(name)
+    return compact, blocked
+
+
+def main() -> int:
+    try:
+        needs = json.loads(os.environ["NEEDS"])
+    except (KeyError, json.JSONDecodeError) as exc:
+        print(f"::error::Unable to read CI job results: {exc}")
+        return 1
+    if not isinstance(needs, Mapping):
+        print("::error::CI job results must be a JSON object")
+        return 1
+
+    compact, blocked = evaluate(needs)
+    needs_json = json.dumps(compact)
+    print(f"needs-json={needs_json}")
+
+    output_path = os.environ.get("GITHUB_OUTPUT")
+    if output_path:
+        with open(output_path, "a", encoding="utf-8") as output:
+            output.write(f"needs-json={needs_json}\n")
+
+    for name, result in sorted(compact.items()):
+        icon = "✅" if result in _ACCEPTED_RESULTS else "❌"
+        print(f"{icon} {name}: {result}")
+    if blocked:
+        print(f"::error::{len(blocked)} job(s) did not complete: {', '.join(blocked)}")
+        return 1
+
+    print("All checks passed (or were skipped)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/evaluate_ci_gate.py
+++ b/scripts/ci/evaluate_ci_gate.py
@@ -45,8 +45,8 @@ def main() -> int:
             output.write(f"needs-json={needs_json}\n")
 
     for name, result in sorted(compact.items()):
-        icon = "✅" if result in _ACCEPTED_RESULTS else "❌"
-        print(f"{icon} {name}: {result}")
+        status = "[ok]" if result in _ACCEPTED_RESULTS else "[blocked]"
+        print(f"{status} {name}: {result}")
     if blocked:
         print(f"::error::{len(blocked)} job(s) did not complete: {', '.join(blocked)}")
         return 1

--- a/scripts/ci/live_comment.py
+++ b/scripts/ci/live_comment.py
@@ -714,6 +714,13 @@ def resolve_pr_number(token: str, repo: str, head_sha: str) -> str:
     return ""
 
 
+def configured_watch_workflows(environment: Mapping[str, str]) -> list[str]:
+    """Return sibling workflows to watch, unless this is a CI-only update."""
+    if environment.get("SKIP_WATCH_WORKFLOWS", "").lower() == "true":
+        return []
+    return parse_watch_workflows(environment.get("WATCH_WORKFLOWS", ""))
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--interval", type=int, default=15,
@@ -732,7 +739,7 @@ def main() -> int:
 
     # Sibling workflows to merge into the comment, one name per line. Their
     # runs are separate from the CI run, so the poller resolves them by name.
-    watch_workflows = parse_watch_workflows(os.environ.get("WATCH_WORKFLOWS", ""))
+    watch_workflows = configured_watch_workflows(os.environ)
 
     if not args.dry_run:
         if not token:

--- a/tests/ci/test_evaluate_ci_gate.py
+++ b/tests/ci/test_evaluate_ci_gate.py
@@ -1,0 +1,55 @@
+"""Behavioral tests for the CI gate evaluator."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+_REPO = Path(__file__).resolve().parents[2]
+_SCRIPT = _REPO / "scripts" / "ci" / "evaluate_ci_gate.py"
+
+
+def _run_gate(tmp_path: Path, needs: dict[str, object]) -> subprocess.CompletedProcess[str]:
+    output = tmp_path / "github-output"
+    environment = os.environ | {
+        "NEEDS": json.dumps(needs),
+        "GITHUB_OUTPUT": str(output),
+    }
+    completed = subprocess.run(
+        [sys.executable, str(_SCRIPT)],
+        cwd=_REPO,
+        env=environment,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    completed.github_output = output.read_text(encoding="utf-8")  # type: ignore[attr-defined]
+    return completed
+
+
+def test_gate_accepts_success_and_skipped_results(tmp_path):
+    completed = _run_gate(
+        tmp_path,
+        {"detect": {"result": "success"}, "desktop": {"result": "skipped"}},
+    )
+
+    assert completed.returncode == 0, completed.stdout
+    assert 'needs-json={"detect": "success", "desktop": "skipped"}' in completed.github_output
+
+
+def test_gate_rejects_cancelled_results(tmp_path):
+    completed = _run_gate(tmp_path, {"detect": {"result": "cancelled"}})
+
+    assert completed.returncode != 0
+    assert "detect: cancelled" in completed.stdout
+
+
+def test_gate_rejects_missing_or_malformed_job_results(tmp_path):
+    completed = _run_gate(tmp_path, {"detect": {}})
+
+    assert completed.returncode != 0
+    assert "detect: unknown" in completed.stdout

--- a/tests/ci/test_live_comment.py
+++ b/tests/ci/test_live_comment.py
@@ -88,6 +88,17 @@ def test_parse_watch_workflows_keeps_commas_inside_a_name():
     assert _mod.parse_watch_workflows("") == []
 
 
+def test_ci_only_comment_update_skips_sibling_workflows():
+    assert _mod.configured_watch_workflows({
+        "WATCH_WORKFLOWS": f"{DOCKER}\n",
+        "SKIP_WATCH_WORKFLOWS": "true",
+    }) == []
+    assert _mod.configured_watch_workflows({
+        "WATCH_WORKFLOWS": f"{DOCKER}\n",
+        "SKIP_WATCH_WORKFLOWS": "false",
+    }) == [DOCKER]
+
+
 def test_workflow_watch_list_names_a_workflow_that_exists():
     """The names the workflow passes must match real workflow ``name:`` values.
 


### PR DESCRIPTION
## Summary
- Post the CI review comment immediately when CI completes, then replace it with the combined result only after Docker completes; no runner waits for Docker.
- Re-run only the failed Review label gate after `ci-reviewed`, rather than waiting for CI or re-running every failed job.
- Fail `All required checks pass` for cancelled, timed-out, or unknown dependency results.
- Move the gate evaluator into a tested script so its behavior is covered directly.

## Cost impact
- Removes the 60-minute CI comment poller and 40-minute label rerun waiter.
- Avoids re-running unrelated failed jobs after a review label is added.
- Leaves the intentional 96-core Python runner unchanged.

## Validation
- `scripts/run_tests.sh tests/ci` -- 124 passed.
- Ruff on changed Python files.
- Parsed all changed workflow YAML files.
- Independent read-only review: no Critical or Important findings.