### PR TITLE
fix(desktop): strip markdown wrappers from file-open paths

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -30,6 +30,8 @@ import {
   systemPreferences
 } from 'electron'
 
+import { stripMarkdownPathWrappers } from '@hermes/shared/markdown-path'
+
 import { classifyActiveRuntime } from './active-runtime-state'
 import { destroyKeepaliveAgents, downloadAgentFor, jsonAgentFor, withRetry } from './api-transport'
 import { appIconCandidates, resolveAppIcon } from './app-icon'
@@ -1681,6 +1683,16 @@ function openExternalUrl(rawUrl) {
   // file association. If the OS can't open it (`error` is a non-empty
   // string), fall back to revealing the file in the system file manager.
   if (parsed.protocol === 'file:') {
+    // Markdown emphasis wrappers (`**`, `__`) and `@url:` directive prefixes
+    // leak from chat labels into link targets (issue #95713) — Windows then
+    // refuses to open '...xyz.pdf**'. Strip them from the URL path before
+    // resolving; the resolver's own safety checks still run afterwards.
+    try {
+      parsed.pathname = stripMarkdownPathWrappers(parsed.pathname)
+    } catch {
+      // Unparseable path — fall through and let the resolver report it.
+    }
+
     let localPath
 
     try {

--- a/apps/desktop/src/components/assistant-ui/markdown-text.filelinks.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.filelinks.test.tsx
@@ -42,6 +42,19 @@ describe('MarkdownLink filesystem hrefs', () => {
     expect(container.querySelector('a[href="/tmp/demo.mp4"]')).toBeNull()
   })
 
+  it('strips markdown emphasis wrappers from the href before resolving (#95713)', async () => {
+    // A bold-wrapped path whose emphasis markers bleed into the link
+    // destination (`[Open xyz.pdf](/home/user/xyz.pdf**)`) is path-relative,
+    // so rehype-harden lets it through and the '**' used to ride all the way
+    // into the on-disk path — Windows then refused to open '...xyz.pdf**'.
+    render(<MarkdownTextContent isRunning={false} text="Done: [Open xyz.pdf](/home/user/xyz.pdf**)" />)
+
+    // The preview attachment receives the bare path, not '...xyz.pdf**'.
+    await screen.findByText('xyz.pdf')
+    expect(screen.getByRole('button', { name: 'Open preview' })).toBeTruthy()
+    expect(document.querySelector('a[href="/home/user/xyz.pdf**"]')).toBeNull()
+  })
+
   it('leaves anchors and relative links out of the preview pipeline', () => {
     render(
       <MarkdownTextContent

--- a/apps/desktop/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.tsx
@@ -17,6 +17,7 @@ import { ZoomableImage } from '@/components/chat/zoomable-image'
 import { ErrorBoundary } from '@/components/error-boundary'
 import { detectArtifact } from '@/lib/artifact-detect'
 import { normalizeExternalUrl, openExternalLink, PrettyLink } from '@/lib/external-link'
+import { stripMarkdownPathWrappers } from '@hermes/shared/markdown-path'
 import { createMemoizedMathPlugin } from '@/lib/katex-memo'
 import { parseMarkdownIntoBlocksCached } from '@/lib/markdown-blocks'
 import { preprocessMarkdown } from '@/lib/markdown-preprocess'
@@ -255,7 +256,13 @@ function childrenToText(children: unknown): string {
 }
 
 function MarkdownLink({ children, className, href, ...props }: ComponentProps<'a'>) {
-  const mediaPath = mediaPathFromMarkdownHref(href)
+  // Markdown emphasis / directive wrappers (`**`, `__`, `@url:`) leak from
+  // labels into targets (issue #95713): a link rendered from bold text keeps
+  // the asterisks in its href, and every downstream resolver — media path,
+  // preview target, filesystem open — would then chase a path with `**` in
+  // it. Strip the wrappers before anything interprets the href.
+  const cleanedHref = typeof href === 'string' ? stripMarkdownPathWrappers(href) : href
+  const mediaPath = mediaPathFromMarkdownHref(cleanedHref)
 
   if (mediaPath) {
     // A delivered markdown document is renderable content, not an opaque
@@ -269,19 +276,19 @@ function MarkdownLink({ children, className, href, ...props }: ComponentProps<'a
     return <MediaAttachment path={mediaPath} />
   }
 
-  const previewTarget = previewTargetFromMarkdownHref(href)
+  const previewTarget = previewTargetFromMarkdownHref(cleanedHref)
 
   if (previewTarget) {
     return <PreviewAttachment source="explicit-link" target={previewTarget} />
   }
 
-  const sessionRef = sessionRefFromMarkdownHref(href)
+  const sessionRef = sessionRefFromMarkdownHref(cleanedHref)
 
   if (sessionRef) {
     return <SessionRefLink value={sessionRef} />
   }
 
-  const target = href ? normalizeExternalUrl(href) : href
+  const target = cleanedHref ? normalizeExternalUrl(cleanedHref) : cleanedHref
 
   if (!target || !/^https?:\/\//i.test(target)) {
     // A plain filesystem href (`[report](/home/user/report.md)`, `file://…`,
@@ -293,7 +300,7 @@ function MarkdownLink({ children, className, href, ...props }: ComponentProps<'a
     // remote fetches it over the authenticated /api/fs bridge), so the same
     // transcript works from every machine that opens it. Media extensions
     // keep their richer inline player.
-    const fileHref = href && !href.startsWith('#') && isFileMediaPath(href) ? href : null
+    const fileHref = cleanedHref && !cleanedHref.startsWith('#') && isFileMediaPath(cleanedHref) ? cleanedHref : null
 
     if (fileHref) {
       return mediaKind(fileHref) === 'file' ? (
@@ -306,7 +313,7 @@ function MarkdownLink({ children, className, href, ...props }: ComponentProps<'a
     return (
       <a
         className={cn('ref wrap-anywhere', className)}
-        href={href}
+        href={cleanedHref}
         rel="noopener noreferrer"
         target="_blank"
         {...props}
@@ -347,7 +354,9 @@ function MarkdownLink({ children, className, href, ...props }: ComponentProps<'a
 // conditional return inside it would have to sit after every hook call, which
 // would still fire an image resolve for media we never render as an image.
 export function MarkdownImage(props: ComponentProps<'img'>) {
-  const rawSrc = typeof props.src === 'string' ? props.src : ''
+  // Same wrapper-stripping as MarkdownLink (#95713): `![…](**clip.mp4**)`
+  // must not chase a media path with emphasis markers in it.
+  const rawSrc = typeof props.src === 'string' ? stripMarkdownPathWrappers(props.src) : ''
   const kind = rawSrc ? mediaKind(rawSrc) : 'file'
 
   if (kind === 'video' || kind === 'audio') {

--- a/apps/desktop/src/lib/markdown-path.test.ts
+++ b/apps/desktop/src/lib/markdown-path.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+
+import { stripMarkdownPathWrappers } from '@hermes/shared/markdown-path'
+
+describe('stripMarkdownPathWrappers', () => {
+  it('unwraps bold markers around file names (#95713)', () => {
+    expect(stripMarkdownPathWrappers('**Open xyz.pdf**')).toBe('Open xyz.pdf')
+    expect(stripMarkdownPathWrappers('**xyz.pdf**')).toBe('xyz.pdf')
+    expect(stripMarkdownPathWrappers('**/home/user/xyz.pdf**')).toBe('/home/user/xyz.pdf')
+    expect(stripMarkdownPathWrappers('**C:\\Users\\me\\xyz.pdf**')).toBe('C:\\Users\\me\\xyz.pdf')
+  })
+
+  it('unwraps underscore emphasis around labels', () => {
+    expect(stripMarkdownPathWrappers('__Open my report__')).toBe('Open my report')
+    expect(stripMarkdownPathWrappers('__quarterly report.pdf__')).toBe('quarterly report.pdf')
+  })
+
+  it('leaves dunder-style names alone', () => {
+    expect(stripMarkdownPathWrappers('__init__')).toBe('__init__')
+    expect(stripMarkdownPathWrappers('__pycache__')).toBe('__pycache__')
+    expect(stripMarkdownPathWrappers('__main__')).toBe('__main__')
+    expect(stripMarkdownPathWrappers('src/__init__.py')).toBe('src/__init__.py')
+  })
+
+  it('strips @url: directive prefixes', () => {
+    expect(stripMarkdownPathWrappers('@url:xyz.pdf')).toBe('xyz.pdf')
+    expect(stripMarkdownPathWrappers('@url: https://example.com')).toBe('https://example.com')
+    expect(stripMarkdownPathWrappers('**@url:xyz.pdf**')).toBe('xyz.pdf')
+  })
+
+  it('unwraps backtick-quoted paths', () => {
+    expect(stripMarkdownPathWrappers('`~/notes/todo.md`')).toBe('~/notes/todo.md')
+  })
+
+  it('handles single-asterisk emphasis and stray unmatched markers', () => {
+    expect(stripMarkdownPathWrappers('*report.pdf*')).toBe('report.pdf')
+    // Matches the exact Windows error from #95713: trailing '**' on the path.
+    expect(stripMarkdownPathWrappers('xyz.pdf**')).toBe('xyz.pdf')
+    expect(stripMarkdownPathWrappers('`~/notes/todo.md')).toBe('~/notes/todo.md')
+  })
+
+  it('never touches interior characters or plain paths', () => {
+    expect(stripMarkdownPathWrappers('/tmp/a*b/c.pdf')).toBe('/tmp/a*b/c.pdf')
+    expect(stripMarkdownPathWrappers('/home/u/notes.md')).toBe('/home/u/notes.md')
+    expect(stripMarkdownPathWrappers('  /home/u/notes.md  ')).toBe('/home/u/notes.md')
+    expect(stripMarkdownPathWrappers('file:///C:/dir/report final.pdf')).toBe('file:///C:/dir/report final.pdf')
+  })
+
+  it('returns the original when everything would strip away', () => {
+    expect(stripMarkdownPathWrappers('**')).toBe('**')
+    expect(stripMarkdownPathWrappers('')).toBe('')
+  })
+})

--- a/apps/desktop/tsconfig.electron.json
+++ b/apps/desktop/tsconfig.electron.json
@@ -16,6 +16,6 @@
     "rootDir": "..",
     "outDir": "build/electron-types"
   },
-  "include": ["electron", "../shared/src/data-url-read-max.ts", "../shared/src/translucency.ts"],
+  "include": ["electron", "../shared/src/data-url-read-max.ts", "../shared/src/translucency.ts", "../shared/src/markdown-path.ts"],
   "exclude": ["src", "electron/**/*.e2e.mts"]
 }

--- a/apps/desktop/tsconfig.json
+++ b/apps/desktop/tsconfig.json
@@ -19,6 +19,7 @@
       "@/*": ["./src/*"],
       "@hermes/plugin-sdk": ["./src/sdk/index.ts"],
       "@hermes/shared/billing": ["../shared/src/billing-types.ts"],
+        "@hermes/shared/markdown-path": ["../shared/src/markdown-path.ts"],
       "@hermes/shared/translucency": ["../shared/src/translucency.ts"],
       "@hermes/shared": ["../shared/src/index.ts"]
     }

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -189,6 +189,7 @@ export default defineConfig(({ command }) => ({
       '@': path.resolve(__dirname, './src'),
       '@hermes/plugin-sdk': path.resolve(__dirname, './src/sdk/index.ts'),
       '@hermes/shared/billing': path.resolve(__dirname, '../shared/src/billing-types.ts'),
+      '@hermes/shared/markdown-path': path.resolve(__dirname, '../shared/src/markdown-path.ts'),
       '@hermes/shared': path.resolve(__dirname, '../shared/src'),
       // The tour tool's preview surface injects driver.js's prebuilt IIFE into
       // the pane's guest page as raw source; the package's exports map doesn't

--- a/apps/shared/src/markdown-path.ts
+++ b/apps/shared/src/markdown-path.ts
@@ -1,0 +1,97 @@
+/**
+ * Markdown/UI wrapper stripping for file paths taken from chat content.
+ *
+ * Assistant messages often wrap a file name in emphasis — `**Open xyz.pdf**`,
+ * `__report final.docx__` — or in a composer directive prefix (`@url:`). When
+ * such a string is used as the display label AND as the on-disk target, the
+ * markdown syntax leaks into the path handed to the OS open handler and
+ * Windows rejects it with "Windows cannot find '...xyz.pdf**'" (issue #95713).
+ *
+ * `stripMarkdownPathWrappers` unwraps those decorations before a path is
+ * resolved or handed to `shell.openPath`. Only EDGES are touched: characters
+ * in the middle of the path are never removed, and a string that unwraps to
+ * nothing is returned unchanged.
+ *
+ * Consumed by the renderer (markdown link/image hrefs in
+ * components/assistant-ui/markdown-text.tsx) and by the Electron main process
+ * (openExternalUrl before shell.openPath). Keep both call sites wired — the
+ * renderer fix keeps the display/preview pipeline clean, the main-process fix
+ * is the last line of defense for the OS open handler.
+ */
+
+/** A `@url:`-style composer directive prefix (issue #95713). */
+const DIRECTIVE_PREFIX_RE = /^@url:\s*/i
+
+/**
+ * Balanced emphasis pairs around the whole string. `__…__` / `_…_` only
+ * unwrap when the inner text is NOT a bare word, so dunder-style names that
+ * legitimately start and end with underscores (`__init__`, `__pycache__`,
+ * `__main__`) survive untouched.
+ */
+const BALANCED_PAIRS: Array<{ re: RegExp; unwrapGuard?: (inner: string) => boolean }> = [
+  { re: /^\*\*([\s\S]+)\*\*$/ },
+  { re: /^__([\s\S]+)__$/, unwrapGuard: inner => /^[\w.-]+$/.test(inner) },
+  { re: /^\*([^*]+)\*$/ },
+  { re: /^_([^_]+)_$/, unwrapGuard: inner => /^[\w.-]+$/.test(inner) },
+  { re: /^`([\s\S]+)`$/ }
+]
+
+export function stripMarkdownPathWrappers(raw: string): string {
+  let value = String(raw ?? '').trim()
+
+  if (!value) {
+    return value
+  }
+
+  const original = value
+
+  // A path can carry several layers (`**@url:file.pdf**`), so unwrap until
+  // stable with a bounded number of passes.
+  for (let pass = 0; pass < 8; pass += 1) {
+    const before = value
+
+    let matched = true
+
+    while (matched) {
+      matched = false
+
+      const directive = DIRECTIVE_PREFIX_RE.exec(value)
+
+      if (directive && value.length > directive[0].length) {
+        value = value.slice(directive[0].length).trim()
+        matched = true
+      }
+
+      for (const pair of BALANCED_PAIRS) {
+        const match = pair.re.exec(value)
+
+        if (!match) {
+          continue
+        }
+
+        const inner = match[1] ?? ''
+
+        // Blank inner, or a dunder-style word guarded against unwrapping:
+        // leave this layer alone.
+        if (!inner.trim() || pair.unwrapGuard?.(inner.trim())) {
+          continue
+        }
+
+        value = inner.trim()
+        matched = true
+      }
+    }
+
+    if (value === before) {
+      break
+    }
+  }
+
+  // Stray unmatched decoration on the edges (`xyz.pdf**`, `**/logs/*.pdf`).
+  // `*` and backticks are illegal in Windows file names and effectively never
+  // appear at the edge of a real path; underscores stay — `report_final_` is
+  // a perfectly legal name.
+  value = value.replace(/^[*`]+/, '').replace(/[*`]+$/, '').trim()
+
+  return value || original
+}


### PR DESCRIPTION
## What

Bold emphasis around a file reference leaks into the on-disk target: a message like `[Open xyz.pdf](/home/user/xyz.pdf**)` is path-relative, so `rehype-harden` lets the href through and the trailing `**` rides all the way into the string handed to `shell.openPath` — Windows then refuses to open `'...xyz.pdf**'`. The same class of leak applies to `__emphasis__`, backtick-quoted paths, and `@url:` composer-directive prefixes.

- New pure helper `stripMarkdownPathWrappers()` in `apps/shared/src`: unwraps balanced emphasis pairs (`**`, `__`, `*`, `_`), backticks, and `@url:` prefixes from a path's **edges only**; dunder-style names (`__init__`, `__pycache__`, `__main__`) are guarded against unwrapping; interior characters are never touched; a string that unwraps to nothing is returned unchanged.
- `MarkdownLink` / `MarkdownImage` sanitize hrefs before media-path, preview-target, and filesystem resolution — a bold-wrapped absolute path now opens a clean preview instead of chasing `'...pdf**'`.
- `openExternalUrl` (Electron main) strips wrappers from the `file:` URL pathname before `resolveRequestedPathForIpc` — the last line of defense for the OS open handler across every caller (artifacts panel, preview rail, media players).
- tsconfig paths + vite alias + electron project include for the new `@hermes/shared/markdown-path` module.

## Why

Reported in #95713: the open-file handler resolved the on-disk path from a display label carrying markdown decoration, and Windows threw "Windows cannot find '...xyz.pdf**'". The helper is shared between the renderer and the Electron main process so the display pipeline and the OS hand-off can't drift.

## How to test

1. New unit tests: `apps/desktop/src/lib/markdown-path.test.ts` (8 cases — bold/underscore/backtick/`@url:` unwrapping, dunder guards, interior preservation).
2. Regression test in `markdown-text.filelinks.test.tsx`: a bold-contaminated filesystem href routes to the preview pipeline with the bare path.
3. `cd apps/desktop && npx vitest run --project ui --maxWorkers=2` — 6013/6013 green; `--project electron` — 1857/1857 green; `tsc -p tsconfig.electron.json` + eslint clean.

## Platforms

Verified on Linux (vitest ui + electron projects, tsc, eslint). The change is platform-neutral string sanitation; the OS-level symptom it fixes is Windows-specific.

Fixes #95713
