### PR TITLE
fix(gateway): resolve the /save adapter via the adapters dict

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -4803,7 +4803,7 @@ class GatewaySlashCommandsMixin:
             with open(temp_path, "w", encoding="utf-8") as f:
                 f.write(content)
 
-            adapter = self.get_adapter(source.platform)
+            adapter = getattr(self, "adapters", {}).get(source.platform)
             if adapter:
                 await adapter.send_document(
                     chat_id=source.chat_id,

--- a/tests/gateway/test_save_command_adapter_lookup.py
+++ b/tests/gateway/test_save_command_adapter_lookup.py
@@ -1,0 +1,81 @@
+"""Regression tests for the /save slash command's adapter lookup (#95744).
+
+``_handle_save_command`` used to call the non-existent ``self.get_adapter()``,
+so every ``/save`` crashed with ``AttributeError: 'GatewayRunner' object has
+no attribute 'get_adapter'`` before any document was sent. It must use the
+same ``self.adapters.get(platform)`` lookup as the rest of the mixin.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.slash_commands import GatewaySlashCommandsMixin
+
+
+class _FakeStore:
+    async def get_or_create_session(self, source):
+        return SimpleNamespace(session_id="save-regression-session")
+
+
+class _FakeSessionDB:
+    async def export_session(self, session_id):
+        return {
+            "session_id": session_id,
+            "messages": [
+                {"role": "user", "content": "hello"},
+                {"role": "assistant", "content": "hi"},
+            ],
+        }
+
+
+class _FakeAdapter:
+    def __init__(self):
+        self.send_document = AsyncMock()
+
+
+def _fake_runner(adapter):
+    return SimpleNamespace(
+        adapters={"telegram": adapter} if adapter is not None else {},
+        async_session_store=_FakeStore(),
+        _session_db=_FakeSessionDB(),
+    )
+
+
+def _save_event():
+    return SimpleNamespace(
+        get_command_args=lambda: "md",
+        source=SimpleNamespace(platform="telegram", chat_id="chat-1"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_save_command_sends_document_via_adapter_dict_lookup():
+    """A platform with a registered adapter receives the export document."""
+    adapter = _FakeAdapter()
+    fake = _fake_runner(adapter)
+
+    result = await GatewaySlashCommandsMixin._handle_save_command(fake, _save_event())
+
+    assert result == "Export complete."
+    adapter.send_document.assert_awaited_once()
+    kwargs = adapter.send_document.await_args.kwargs
+    assert kwargs["chat_id"] == "chat-1"
+    assert kwargs["file_name"].endswith(".md")
+
+
+@pytest.mark.asyncio
+async def test_save_command_reports_missing_adapter_without_crashing():
+    """An unregistered platform takes the graceful 'no adapter' path (#95744).
+
+    Before the fix this raised AttributeError('... has no attribute
+    'get_adapter'') instead of returning a usable message.
+    """
+    fake = _fake_runner(None)
+
+    result = await GatewaySlashCommandsMixin._handle_save_command(fake, _save_event())
+
+    assert result == "Platform adapter not found to send the document."


### PR DESCRIPTION
## What

`_handle_save_command` called the non-existent `self.get_adapter()`, so **every `/save`** crashed with `AttributeError: 'GatewayRunner' object has no attribute 'get_adapter'` before any document was sent. It now uses the same `self.adapters.get(platform)` lookup the rest of `GatewaySlashCommandsMixin` already uses.

## Why

#95744: the root cause is a single line (`gateway/slash_commands.py:4806`) calling a method that exists nowhere on the class; the correct pattern is used a dozen lines away and in five other places in the same file.

## How to test

New regression tests (`tests/gateway/test_save_command_adapter_lookup.py`, both passing):
- a registered adapter receives the export document (`Export complete.`),
- an unknown platform returns the graceful "Platform adapter not found to send the document." instead of raising.

`pytest tests/gateway/test_save_command_adapter_lookup.py -q` → 2 passed. `ruff check` clean.

## Platforms

Linux (pytest). Platform-neutral change (dict lookup vs bogus method).

Fixes #95744
