### PR TITLE
fix(gateway): honor explicit enabled:false against credential env vars

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -2233,10 +2233,8 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     # Home Assistant
     hass_token = getenv("HASS_TOKEN")
     if hass_token:
-        if Platform.HOMEASSISTANT not in config.platforms:
-            config.platforms[Platform.HOMEASSISTANT] = PlatformConfig()
-        config.platforms[Platform.HOMEASSISTANT].enabled = True
-        config.platforms[Platform.HOMEASSISTANT].token = hass_token
+        hass_cfg = _enable_from_env(Platform.HOMEASSISTANT)
+        hass_cfg.token = hass_token
         hass_url = getenv("HASS_URL")
         if hass_url:
             config.platforms[Platform.HOMEASSISTANT].extra["url"] = hass_url
@@ -2247,10 +2245,8 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     email_imap = getenv("EMAIL_IMAP_HOST")
     email_smtp = getenv("EMAIL_SMTP_HOST")
     if all([email_addr, email_pwd, email_imap, email_smtp]):
-        if Platform.EMAIL not in config.platforms:
-            config.platforms[Platform.EMAIL] = PlatformConfig()
-        config.platforms[Platform.EMAIL].enabled = True
-        config.platforms[Platform.EMAIL].extra.update({
+        email_cfg = _enable_from_env(Platform.EMAIL)
+        email_cfg.extra.update({
             "address": email_addr,
             "imap_host": email_imap,
             "smtp_host": email_smtp,
@@ -2267,10 +2263,8 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     # SMS (Twilio)
     twilio_sid = getenv("TWILIO_ACCOUNT_SID")
     if twilio_sid:
-        if Platform.SMS not in config.platforms:
-            config.platforms[Platform.SMS] = PlatformConfig()
-        config.platforms[Platform.SMS].enabled = True
-        config.platforms[Platform.SMS].api_key = getenv("TWILIO_AUTH_TOKEN", "")
+        sms_cfg = _enable_from_env(Platform.SMS)
+        sms_cfg.api_key = getenv("TWILIO_AUTH_TOKEN", "")
     sms_home = getenv("SMS_HOME_CHANNEL")
     if sms_home and Platform.SMS in config.platforms:
         config.platforms[Platform.SMS].home_channel = HomeChannel(
@@ -2443,10 +2437,8 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     wecom_bot_id = getenv("WECOM_BOT_ID")
     wecom_secret = getenv("WECOM_SECRET")
     if wecom_bot_id and wecom_secret:
-        if Platform.WECOM not in config.platforms:
-            config.platforms[Platform.WECOM] = PlatformConfig()
-        config.platforms[Platform.WECOM].enabled = True
-        config.platforms[Platform.WECOM].extra.update({
+        wecom_cfg = _enable_from_env(Platform.WECOM)
+        wecom_cfg.extra.update({
             "bot_id": wecom_bot_id,
             "secret": wecom_secret,
         })
@@ -2466,10 +2458,8 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     wecom_callback_corp_id = getenv("WECOM_CALLBACK_CORP_ID")
     wecom_callback_corp_secret = getenv("WECOM_CALLBACK_CORP_SECRET")
     if wecom_callback_corp_id and wecom_callback_corp_secret:
-        if Platform.WECOM_CALLBACK not in config.platforms:
-            config.platforms[Platform.WECOM_CALLBACK] = PlatformConfig()
-        config.platforms[Platform.WECOM_CALLBACK].enabled = True
-        config.platforms[Platform.WECOM_CALLBACK].extra.update({
+        wecom_callback_cfg = _enable_from_env(Platform.WECOM_CALLBACK)
+        wecom_callback_cfg.extra.update({
             "corp_id": wecom_callback_corp_id,
             "corp_secret": wecom_callback_corp_secret,
             "agent_id": getenv("WECOM_CALLBACK_AGENT_ID", ""),
@@ -2486,9 +2476,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     weixin_token = getenv("WEIXIN_TOKEN")
     weixin_account_id = getenv("WEIXIN_ACCOUNT_ID")
     if weixin_token or weixin_account_id:
-        if Platform.WEIXIN not in config.platforms:
-            config.platforms[Platform.WEIXIN] = PlatformConfig()
-        config.platforms[Platform.WEIXIN].enabled = True
+        weixin_cfg = _enable_from_env(Platform.WEIXIN)
         if weixin_token:
             config.platforms[Platform.WEIXIN].token = weixin_token
         extra = config.platforms[Platform.WEIXIN].extra

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -1391,3 +1391,62 @@ class TestApiServerEnvOverride:
         assert config.platforms[Platform.API_SERVER].enabled is False
         # The key is still wired through for the shared listener.
         assert config.platforms[Platform.API_SERVER].extra.get("key") == api_server_key
+
+
+class TestEnvCredentialDoesNotOverrideExplicitDisable:
+    """Credential env vars must not force-enable a platform the user disabled.
+
+    Telegram/Slack/API-server already honoured the ``_enabled_explicit``
+    marker; the SMS / Home Assistant / Email / WeCom / WeCom-callback / Weixin
+    blocks set ``enabled = True`` unconditionally whenever their credential
+    env var was present, silently overriding an explicit
+    ``platforms.<name>.enabled: false`` in config.yaml (#96499). All six now
+    route through the same ``_enable_from_env`` guard.
+    """
+
+    CASES = [
+        (Platform.SMS, {"TWILIO_ACCOUNT_SID": "AC123", "TWILIO_AUTH_TOKEN": "tok"}),
+        (Platform.HOMEASSISTANT, {"HASS_TOKEN": "tok"}),
+        (
+            Platform.EMAIL,
+            {
+                "EMAIL_ADDRESS": "a@b.c",
+                "EMAIL_PASSWORD": "pw",
+                "EMAIL_IMAP_HOST": "imap.b.c",
+                "EMAIL_SMTP_HOST": "smtp.b.c",
+            },
+        ),
+        (Platform.WECOM, {"WECOM_BOT_ID": "id", "WECOM_SECRET": "sec"}),
+        (
+            Platform.WECOM_CALLBACK,
+            {"WECOM_CALLBACK_CORP_ID": "cid", "WECOM_CALLBACK_CORP_SECRET": "sec"},
+        ),
+        (Platform.WEIXIN, {"WEIXIN_TOKEN": "tok", "WEIXIN_ACCOUNT_ID": "acc"}),
+    ]
+
+    def test_explicit_disabled_stays_disabled_with_credentials_present(self):
+        for platform, env in self.CASES:
+            config = GatewayConfig(
+                platforms={
+                    platform: PlatformConfig(
+                        enabled=False, extra={"_enabled_explicit": True}
+                    )
+                }
+            )
+            with patch.dict(os.environ, env, clear=True):
+                _apply_env_overrides(config)
+
+            assert config.platforms[platform].enabled is False, (
+                f"{platform.value}: credential env vars must not override an "
+                "explicit enabled: false"
+            )
+
+    def test_non_explicit_platform_still_auto_enables_from_env(self):
+        # Control: without the explicit-disable marker, env credentials keep
+        # auto-enabling the platform (pre-existing behaviour).
+        for platform, env in self.CASES:
+            config = GatewayConfig(platforms={platform: PlatformConfig(enabled=False)})
+            with patch.dict(os.environ, env, clear=True):
+                _apply_env_overrides(config)
+
+            assert config.platforms[platform].enabled is True, platform.value


### PR DESCRIPTION
## What

Six platform blocks in `_apply_env_overrides` force-enabled their platform whenever the credential env var was present — `TWILIO_ACCOUNT_SID` (SMS), `HASS_TOKEN` (Home Assistant), `EMAIL_*` (Email), `WECOM_*` (WeCom), `WECOM_CALLBACK_*` (WeCom callback), `WEIXIN_*` (Weixin) — silently overriding an explicit `platforms.<name>.enabled: false` in `config.yaml`. The same `enabled: false` was respected for Telegram/Matrix/Slack/API-server, which already guard on the `_enabled_explicit` marker.

All six blocks now route through `_enable_from_env`, the shared helper that creates the `PlatformConfig` when missing and skips re-enabling when the user explicitly set `enabled` in YAML.

## Why

#96499: a user who disables a platform but keeps (e.g.) a provisioned `TWILIO_ACCOUNT_SID` in `.env` watched the platform reconnect on every gateway start against their explicit config. The behaviour matrix is unchanged for every pre-existing configuration: fresh env-only installs still auto-enable; explicit `false` stays off; explicit `true` stays on.

## How to test

`pytest tests/gateway/test_config.py -q` — 63 passed, including 2 new tests:
- credentials present + explicit `enabled: false` → stays disabled, for all six platforms,
- control case without the marker → env credentials still auto-enable (pre-existing behaviour).

`ruff check gateway/config.py` clean.

## Platforms

Linux (pytest). Config-resolution change only; no adapter or network code touched.

Fixes #96499
