### PR TITLE
fix(tools): fail delegate_task closed when output_schema stays invalid

### DIFF
--- a/tests/tools/test_delegate_output_schema.py
+++ b/tests/tools/test_delegate_output_schema.py
@@ -229,6 +229,44 @@ class TestRunSingleChildSchemaValidation:
         # exactly ONE retry — bounded
         assert len(child.calls) == 2
 
+    def test_schema_invalid_after_retry_fails_closed(self):
+        """A schema-invalid result must not be reported as completed (#96355).
+
+        The child produced a non-empty summary, so the old status derivation
+        (summary present -> "completed") exposed status="completed" with
+        schema_valid=false. A structured delegation whose machine-readable
+        contract was not fulfilled has failed.
+        """
+        child = _StubChild(["nope", "still nope"])
+        child._delegate_output_schema = ADDRESS_SCHEMA
+        entry = _run(child)
+        assert entry["status"] == "failed"
+        assert entry["schema_valid"] is False
+
+    def test_retry_exception_degrades_to_failed_status(self):
+        child = _StubChild(["nope"])
+        child._delegate_output_schema = ADDRESS_SCHEMA
+
+        original = child.run_conversation
+
+        def flaky(user_message, task_id=None, **kw):
+            if child.calls:
+                raise RuntimeError("child died on retry")
+            return original(user_message, task_id=task_id, **kw)
+
+        child.run_conversation = flaky
+        entry = _run(child)
+        assert entry["status"] == "failed"
+        assert entry["schema_valid"] is False
+
+    def test_schema_valid_completion_keeps_completed_status(self):
+        # Control: a valid structured delegation is still "completed".
+        child = _StubChild(['{"city": "Berlin"}'])
+        child._delegate_output_schema = ADDRESS_SCHEMA
+        entry = _run(child)
+        assert entry["status"] == "completed"
+        assert entry["schema_valid"] is True
+
     def test_retry_exception_degrades_to_invalid(self):
         child = _StubChild(["nope"])
         child._delegate_output_schema = ADDRESS_SCHEMA

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -3049,6 +3049,13 @@ def _run_single_child(
 
         if interrupted:
             status = "interrupted"
+        elif _schema_valid is False:
+            # A schema-constrained delegation whose final response still fails
+            # validation after the bounded retry must fail CLOSED (#96355):
+            # reporting "completed" alongside schema_valid=false would let
+            # automated consumers treat an unfulfilled machine-readable
+            # contract as a successful structured delegation.
+            status = "failed"
         elif summary and not _empty_sentinel:
             # A summary means the subagent produced usable output.
             # exit_reason ("completed" vs "max_iterations") already


### PR DESCRIPTION
## What

A schema-constrained `delegate_task` could report `status="completed"` with `schema_valid=false`: the status derivation only looked at whether a non-empty `final_response` existed, while the T1-24 validation outcome was recorded alongside it. Automated consumers reading `"completed"` would treat an unfulfilled machine-readable contract as a successful structured delegation.

When a schema was attached and the final response still fails validation after the one bounded retry, the delegation now **fails closed** to `status="failed"` (`schema_valid` stays `false`, `schema_errors` ride along as before).

Schema-less delegations keep their exact legacy status behaviour — `_schema_valid` stays `None` for them, so the new branch never fires and the result entry stays byte-identical (wire-shape pinning preserved).

## How to test

`pytest tests/tools/test_delegate_output_schema.py -q` — 27 passed, including 3 new tests:
- invalid-after-retry → `status="failed"`, `schema_valid=false` (the #96355 combination is now impossible),
- retry-exception → `failed`,
- control: valid structured completion → still `completed`.

## Platforms

Linux (pytest). Deterministic status-derivation change in the delegation finalizer.

Fixes #96355
