### PR TITLE
fix(state): classify the transient NULL SystemError as lock contention

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1925,6 +1925,18 @@ def classify_persistence_error(exc_or_str) -> str:
         return "compression_closed"
     if "being compressed" in text or "compression lease" in text:
         return "compression"
+    # A CPython sqlite3 driver glitch — "<connection> returned NULL without
+    # setting an exception" (SystemError) — surfaces under WAL after very
+    # long turns while the database itself is healthy (PRAGMA integrity_check
+    # clean, BEGIN IMMEDIATE + ROLLBACK succeed, disk has space). It is not
+    # SQLITE_BUSY, so the driver's own busy-retry never sees it, and it rode
+    # up as a generic write failure ending the turn with unhelpful advice.
+    # Classify it as lock-shaped TRANSIENT contention so the turn explanation
+    # carries the same "storage was busy, send it again" retry-later guidance
+    # as the locked bucket — the next send re-flushes the unmarked tail via
+    # the existing recovery contract (#94258).
+    if "returned null without setting an exception" in text:
+        return "locked"
     # Structural corruption BEFORE the lock and disk buckets: "database disk
     # image is malformed" contains "disk" (and some wrapped corruption
     # strings mention "locked" recovery attempts), so later buckets would

--- a/tests/run_agent/test_turn_completion_explainer.py
+++ b/tests/run_agent/test_turn_completion_explainer.py
@@ -426,3 +426,36 @@ def test_run_conversation_partial_stream_recovery_surfaces_explanation():
     assert result["response_previewed"] is False
 
 
+
+
+def test_classify_persistence_error_transient_null_systemerror_is_locked():
+    """The CPython sqlite3 'returned NULL without setting an exception'
+    SystemError is a transient driver glitch on a HEALTHY database (#94258):
+    integrity_check clean, BEGIN IMMEDIATE + ROLLBACK succeed, disk has
+    space. It must land in the 'locked' (transient, retry-later) bucket so
+    the turn explanation says "storage was busy, send it again" instead of
+    the generic unknown-caused advice."""
+    import sqlite3
+
+    from hermes_state import classify_persistence_error
+
+    assert (
+        classify_persistence_error(
+            SystemError(
+                "<hermes_cli.sqlite_safe_read.TrackedConnection object at "
+                "0x7f3a1c2b3d40> returned NULL without setting an exception"
+            )
+        )
+        == "locked"
+    )
+    assert (
+        classify_persistence_error(
+            sqlite3.OperationalError(
+                "statement returned NULL without setting an exception"
+            )
+        )
+        == "locked"
+    )
+    # The phrase must not swallow unrelated errors.
+    assert classify_persistence_error("database is locked") == "locked"
+    assert classify_persistence_error("something else entirely") == "unknown"


### PR DESCRIPTION
## What

A session transcript write can die with `SystemError('<connection> returned NULL without setting an exception')` — a CPython sqlite3 driver glitch under WAL after very long turns (reported after a 163-tool-turn / ~273k-token / 597-API-call session). The database itself is healthy: `PRAGMA integrity_check` passes, `BEGIN IMMEDIATE` + `ROLLBACK` succeed, disk has space. It is **not** `SQLITE_BUSY`, so the driver's busy-retry never sees it; the error rode up unclassified (`"unknown"`) and failed the turn with generic advice.

`classify_persistence_error` now maps the phrase to the **`locked`** bucket, so the turn explanation carries the same transient "session storage was busy — please send it again" guidance as lock contention. The next send re-flushes the unmarked tail through the existing all-or-nothing batch recovery contract, so no rows are lost.

## How to test

`pytest tests/run_agent/test_turn_completion_explainer.py -q` — 23 passed, including a new test asserting the exact reported `SystemError` text and a wrapped variant classify as `locked`, with an explicit no-collision check.

## Platforms

Linux (pytest). Classification + guidance change only; no storage-layer behaviour altered.

Fixes #94258
