### PR TITLE
test(desktop): make locale-sensitive UI suites deterministic

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.test.ts
@@ -1,5 +1,21 @@
 import type { AppendMessage } from '@assistant-ui/react'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, beforeAll, afterEach, describe, expect, it, vi } from 'vitest'
+
+// Pin the ICU default locale for this suite (#96382): the formatters under
+// test intentionally format numbers in the HOST locale, but these
+// assertions are written against the en-US shapes ('1,234'). A Persian /
+// Indic host locale renders '۱٬۲۳۴' and would fail the suite regardless of
+// code correctness. Scope the pin to this file and restore afterwards.
+const _realToLocaleString = Number.prototype.toLocaleString
+beforeAll(() => {
+  Number.prototype.toLocaleString = function (...args: unknown[]) {
+    return _realToLocaleString.apply(this, ['en-US', ...args] as never)
+  } as typeof Number.prototype.toLocaleString
+})
+afterAll(() => {
+  Number.prototype.toLocaleString = _realToLocaleString
+})
+
 
 import type { ChatMessage } from '@/lib/chat-messages'
 

--- a/apps/desktop/src/components/assistant-ui/tool/fallback-model.test.ts
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback-model.test.ts
@@ -1,4 +1,20 @@
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterAll, beforeAll, afterEach, describe, expect, it } from 'vitest'
+
+// Pin the ICU default locale for this suite (#96382): the formatters under
+// test intentionally format numbers in the HOST locale, but these
+// assertions are written against the en-US shapes ('1,234'). A Persian /
+// Indic host locale renders '۱٬۲۳۴' and would fail the suite regardless of
+// code correctness. Scope the pin to this file and restore afterwards.
+const _realToLocaleString = Number.prototype.toLocaleString
+beforeAll(() => {
+  Number.prototype.toLocaleString = function (...args: unknown[]) {
+    return _realToLocaleString.apply(this, ['en-US', ...args] as never)
+  } as typeof Number.prototype.toLocaleString
+})
+afterAll(() => {
+  Number.prototype.toLocaleString = _realToLocaleString
+})
+
 
 import { setRuntimeI18nLocale } from '@/i18n'
 


### PR DESCRIPTION
## What

Building/testing on a host with a non-Latin numeric locale (`fa_IR.UTF-8`) failed UI tests: the suites assert en-US-shaped output (`'1,234'`) while the formatters under test deliberately render in the **host** locale (`'۱٬۲۳۴'` under Persian). The production behaviour is correct — a dashboard formats numbers for its user's locale — the tests were environment-dependent.

Pin `Number.prototype.toLocaleString` to `'en-US'` for the two affected suites (`use-prompt-actions` utils, `fallback-model`) and restore it afterwards, so the assertions are deterministic on any host **without changing user-facing formatting**.

## Reproduction

```
LANG=fa_IR.UTF-8 node -e "console.log((1234567).toLocaleString())"
→ ۱٬۲۳۴٬۵۶۷
```

`LANG=fa_IR.UTF-8 npx vitest run --project ui` failed 3 tests across 2 files on current main (the issue's 4th failure no longer reproduces on main — upstream drift since v0.20.5); all three are covered by this pin. Same suites are green on an unmodified host.

## How to test

```
cd apps/desktop
LANG=fa_IR.UTF-8 npx vitest run src/app/session/hooks/use-prompt-actions/utils.test.ts src/components/assistant-ui/tool/fallback-model.test.ts --project ui   # 89 passed
npx vitest run src/app/session/hooks/use-prompt-actions/utils.test.ts src/components/assistant-ui/tool/fallback-model.test.ts --project ui                     # 89 passed
```

`eslint` clean (both files).

## Platforms

Linux (vitest). Test-only change — zero production code touched.

Fixes #96382
