### PR TITLE
fix(cli): stop dashboard OAuth login creating a duplicate anthropic pool row

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -11445,39 +11445,27 @@ def _save_anthropic_oauth_creds(access_token: str, refresh_token: str, expires_a
     from utils import atomic_json_write
 
     atomic_json_write(oauth_file, payload, indent=2, mode=0o600)
-    # Best-effort credential-pool insert. Failure here doesn't invalidate
-    # the file write — pool registration only matters for the rotation
-    # strategy, not for runtime credential resolution.
+    # Register the credential in the pool by seeding it from the file we just
+    # wrote — do NOT add a second, separate ``manual:dashboard_pkce`` row.
+    #
+    # ``load_pool("anthropic")`` already seeds a ``hermes_pkce`` entry from
+    # ~/.hermes/.anthropic_oauth.json (see ``_seed_*`` in credential_pool).
+    # A separate explicit insert produced a *second* pool row carrying the
+    # SAME refresh token. Anthropic OAuth refresh tokens are single-use: the
+    # first row to refresh rotates the pair, and the stale twin's next refresh
+    # 401s ("refresh_token_reused") and revokes the login. Seeding the single
+    # ``hermes_pkce`` row here mirrors what ``hermes auth add anthropic
+    # --type oauth`` does, keeping exactly one source of truth.
+    #
+    # Best-effort: a failure here doesn't invalidate the file write — pool
+    # registration only affects the rotation strategy, not runtime credential
+    # resolution (the file itself is read directly on load).
     try:
-        from agent.credential_pool import (
-            PooledCredential,
-            load_pool,
-            AUTH_TYPE_OAUTH,
-            SOURCE_MANUAL,
-        )
-        import uuid
-        pool = load_pool("anthropic")
-        # Avoid duplicate entries: delete any prior dashboard-issued OAuth entry
-        existing = [e for e in pool.entries() if getattr(e, "source", "").startswith(f"{SOURCE_MANUAL}:dashboard_pkce")]
-        for e in existing:
-            try:
-                pool.remove_entry(getattr(e, "id", ""))
-            except Exception:
-                pass
-        entry = PooledCredential(
-            provider="anthropic",
-            id=uuid.uuid4().hex[:6],
-            label="dashboard PKCE",
-            auth_type=AUTH_TYPE_OAUTH,
-            priority=0,
-            source=f"{SOURCE_MANUAL}:dashboard_pkce",
-            access_token=access_token,
-            refresh_token=refresh_token,
-            expires_at_ms=expires_at_ms,
-        )
-        pool.add_entry(entry)
+        from agent.credential_pool import load_pool
+
+        load_pool("anthropic")
     except Exception as e:
-        _log.warning("anthropic pool add (dashboard) failed: %s", e)
+        _log.warning("anthropic pool seed (dashboard) failed: %s", e)
 
 
 def _start_anthropic_pkce(profile: Optional[str] = None) -> Dict[str, Any]:

--- a/tests/hermes_cli/test_web_server_oauth_no_dup_pool_row.py
+++ b/tests/hermes_cli/test_web_server_oauth_no_dup_pool_row.py
@@ -1,0 +1,79 @@
+"""The dashboard OAuth login must not create duplicate pool rows for one
+single-use Anthropic refresh token.
+
+Anthropic OAuth refresh tokens are single-use. The dashboard save path used to
+insert an explicit ``manual:dashboard_pkce`` pool row *in addition to* the
+``hermes_pkce`` row that ``load_pool`` seeds from
+~/.hermes/.anthropic_oauth.json. Both rows carried the same refresh token, so
+the first to refresh rotated the pair and the stale twin's next refresh 401'd
+("refresh_token_reused") and revoked the login.
+
+Uses a real tmp HERMES_HOME so the pool + OAuth file resolve to disk exactly as
+in production; anthropic is marked as the explicitly-configured provider so the
+credential_pool auto-discovery gate (PR #4210) lets the file-seed through.
+"""
+import importlib
+
+import pytest
+
+
+@pytest.fixture
+def anthropic_home(monkeypatch, tmp_path):
+    home = tmp_path / "hermes_home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    for var in ("ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"):
+        monkeypatch.delenv(var, raising=False)
+
+    import agent.anthropic_adapter as aa
+    # External Claude Code creds on the dev/CI box are a separate credential —
+    # not part of the dashboard flow under test.
+    monkeypatch.setattr(aa, "read_claude_code_credentials", lambda: None)
+
+    import agent.credential_pool as cp
+    importlib.reload(cp)
+    monkeypatch.setattr(cp, "read_claude_code_credentials", lambda: None, raising=False)
+    monkeypatch.setattr(cp, "load_env", lambda: {}, raising=False)
+    # The user has chosen Anthropic (dashboard model picker) — this is what
+    # gates the pool's OAuth auto-discovery.
+    import hermes_cli.auth as auth
+    monkeypatch.setattr(auth, "is_provider_explicitly_configured", lambda p: True)
+    return home, cp
+
+
+def _anthropic_oauth_rows(cp, refresh_token):
+    pool = cp.load_pool("anthropic")
+    return [
+        e for e in pool.entries()
+        if e.auth_type == cp.AUTH_TYPE_OAUTH and e.refresh_token == refresh_token
+    ]
+
+
+def test_dashboard_login_creates_single_row_for_the_oauth_token(anthropic_home):
+    home, cp = anthropic_home
+    from hermes_cli.web_server import _save_anthropic_oauth_creds
+
+    _save_anthropic_oauth_creds("access-T1", "refresh-T1", 1_000_000)
+
+    rows = _anthropic_oauth_rows(cp, "refresh-T1")
+    sources = sorted(e.source for e in rows)
+    assert len(rows) == 1, (
+        f"dashboard login created {len(rows)} pool rows sharing one single-use "
+        f"refresh token: {sources}"
+    )
+    assert rows[0].source == "hermes_pkce"
+
+
+def test_dashboard_relogin_does_not_accumulate_rows(anthropic_home):
+    home, cp = anthropic_home
+    from hermes_cli.web_server import _save_anthropic_oauth_creds
+
+    # A second login (e.g. re-auth after expiry) rotates the token; the pool
+    # must still hold exactly one OAuth row, now with the new token.
+    _save_anthropic_oauth_creds("access-T1", "refresh-T1", 1_000_000)
+    _save_anthropic_oauth_creds("access-T2", "refresh-T2", 2_000_000)
+
+    assert _anthropic_oauth_rows(cp, "refresh-T1") == []
+    rows = _anthropic_oauth_rows(cp, "refresh-T2")
+    assert len(rows) == 1
+    assert rows[0].source == "hermes_pkce"


### PR DESCRIPTION
## What & why

The dashboard PKCE login path (`_save_anthropic_oauth_creds` in `hermes_cli/web_server.py`) wrote the OAuth token file **and** inserted an explicit `manual:dashboard_pkce` credential-pool row. But `load_pool("anthropic")` already seeds a `hermes_pkce` row from `~/.hermes/.anthropic_oauth.json` (the file that was just written). So a single dashboard OAuth login left **two** anthropic OAuth pool rows carrying the **same** refresh token.

Anthropic OAuth refresh tokens are **single-use**: a successful refresh rotates the pair and invalidates the old refresh token. With two rows holding the same token, whichever refreshes first rotates it, and the stale twin's next refresh fails with `refresh_token_reused` (401) — the login is silently revoked and the user has to re-authenticate.

The fix removes the redundant explicit insert and lets `load_pool()` seed the single `hermes_pkce` row from the file. This mirrors exactly what `hermes auth add anthropic --type oauth` does (a single `manual:hermes_pkce` row) and keeps one source of truth. It is also consistent with the credential-pool OAuth auto-discovery consent gate (PR #4210).

## How to reproduce (before this change)

1. `hermes` dashboard → Anthropic → OAuth (PKCE) login.
2. Inspect the pool:
   ```python
   from agent.credential_pool import load_pool, AUTH_TYPE_OAUTH
   rows = [e for e in load_pool("anthropic").entries() if e.auth_type == AUTH_TYPE_OAUTH]
   print([(e.source, e.refresh_token) for e in rows])
   # -> [('hermes_pkce', 'refresh-X'), ('manual:dashboard_pkce', 'refresh-X')]
   #    two rows, identical single-use refresh token
   ```
3. After the first token refresh (rotates `refresh-X`), the second row's next refresh returns
   `400/401 refresh_token_reused` and the OAuth login is revoked.

Observed vs expected:
- **Observed:** 2 pool rows share one single-use refresh token; login self-revokes on next refresh cycle.
- **Expected:** exactly 1 anthropic OAuth row after a dashboard login (as with the CLI `auth add` path).

## Tests

`tests/hermes_cli/test_web_server_oauth_no_dup_pool_row.py` (new):
- `test_dashboard_login_creates_single_row_for_the_oauth_token` — after a dashboard login, exactly one anthropic OAuth row holds the token, and its source is `hermes_pkce`.
- `test_dashboard_relogin_does_not_accumulate_rows` — a second login rotates the token and still leaves exactly one row.

Both tests use a real tmp `HERMES_HOME` so the pool and OAuth file resolve to disk as in production (no mocking of pool internals), and mark anthropic as the explicitly-configured provider so the #4210 auto-discovery gate lets the file-seed through.

Verification (Linux, Python 3.11):
- Both new tests **fail on the pre-fix code** and **pass after the fix** (confirmed by stashing the fix).
- No regression: `test_web_server_oauth_write`, `test_auth_commands`, `test_anthropic_oauth_routes_to_messages_api`, `test_credential_pool`, and the new file together — **95 passed**.
- `ruff check` clean on both changed files.
- Not manually exercised against a live Anthropic OAuth endpoint (no network token exchange in the test env); the token-exchange code itself is unchanged — only the local pool-registration step is.

## Platforms tested

Linux (Python 3.11). No OS-specific code paths touched (pure pool/file logic; the file write already used `atomic_json_write`).

## Security note

This touches credential handling. The change **reduces** duplication of a secret in the on-disk pool (one row instead of two) and does not alter file permissions — the OAuth file is still written `0o600` atomically via `atomic_json_write`, covered by the existing `test_web_server_oauth_write.py`. No secrets are logged.

## AI usage

AI-assisted. Provider: Anthropic. Model: Claude (Opus). The bug was one I hit on my own install (login silently revoked after a while); the agent reproduced it against current `main`, wrote the regression tests, and ran the suite.
