### PR TITLE
feat(gateway): compact over-threshold sessions when a turn settles

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -4829,6 +4829,168 @@ def test_ws_orphan_reap_defers_running_turn_for_active_delegation(monkeypatch):
         server._sessions.pop("delegating-turn", None)
 
 
+def _post_turn_agent(threshold=100, decision=True):
+    comp = types.SimpleNamespace(
+        threshold_tokens=threshold,
+        should_compress=lambda tokens=None: decision,
+    )
+    return types.SimpleNamespace(
+        context_compressor=comp,
+        _cached_system_prompt="",
+        tools=None,
+        session_id="post-turn-session",
+    )
+
+
+def test_post_turn_compress_fires_for_idle_over_threshold_session(monkeypatch):
+    """An over-threshold idle session compacts immediately at turn end —
+    no user message required (the "only compresses after I type" fix)."""
+    done = threading.Event()
+    calls = {"compress": 0, "sync": None}
+
+    def _fake_compress(session, focus_topic=None, **kwargs):
+        calls["compress"] += 1
+        return 5, {}
+
+    def _fake_sync(sid, session, *, clear_pending_title, restart_slash_worker):
+        calls["sync"] = (sid, clear_pending_title, restart_slash_worker)
+        done.set()
+
+    session = _session(
+        agent=_post_turn_agent(),
+        history=[{"role": "user", "content": "x"}],
+    )
+    server._sessions["pt-sid"] = session
+    monkeypatch.setattr(server, "_compress_session_history", _fake_compress)
+    monkeypatch.setattr(server, "_sync_session_key_after_compress", _fake_sync)
+    monkeypatch.setattr(server, "_emit", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_emit_settled_session_info", lambda *a, **k: None)
+
+    try:
+        server._maybe_post_turn_compress("pt-sid", session)
+        assert done.wait(5.0), "background compress worker never ran"
+        assert calls["compress"] == 1
+        # Post-turn policy: preserve pending title, restart slash worker.
+        assert calls["sync"] == ("pt-sid", False, True)
+        assert "_post_turn_compress_running" not in session
+        assert "_post_turn_compress_failed_at" not in session
+    finally:
+        server._sessions.pop("pt-sid", None)
+
+
+def test_post_turn_compress_installs_named_profile_scope(monkeypatch):
+    """The background worker must resolve config/secrets from the SESSION's
+    profile, not the root default — a named-profile session's compaction
+    otherwise reads the wrong config.yaml (thresholds, auxiliary compression
+    model) and the wrong secret scope."""
+    done = threading.Event()
+    seen = {}
+    installed = []
+
+    def _fake_set_home(home):
+        installed.append(home)
+        return f"token:{home}"
+
+    def _fake_reset_home(token):
+        seen["reset"] = token
+
+    def _fake_compress(session, focus_topic=None, **kwargs):
+        # Scope must still be installed while the compression call runs.
+        seen["home_during_compress"] = installed[-1] if installed else None
+        return 3, {}
+
+    session = _session(
+        agent=_post_turn_agent(),
+        history=[{"role": "user", "content": "x"}],
+        profile_home="/profiles/picasso",
+    )
+    server._sessions["pt-profile"] = session
+    monkeypatch.setattr(server, "set_hermes_home_override", _fake_set_home)
+    monkeypatch.setattr(server, "reset_hermes_home_override", _fake_reset_home)
+    monkeypatch.setattr(server, "_compress_session_history", _fake_compress)
+    monkeypatch.setattr(
+        server, "_sync_session_key_after_compress",
+        lambda *a, **k: done.set(),
+    )
+    monkeypatch.setattr(server, "_emit", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_emit_settled_session_info", lambda *a, **k: None)
+
+    try:
+        server._maybe_post_turn_compress("pt-profile", session)
+        assert done.wait(5.0)
+        deadline = time.time() + 5.0
+        while "reset" not in seen and time.time() < deadline:
+            time.sleep(0.02)
+        assert installed == ["/profiles/picasso"]
+        assert seen["home_during_compress"] == "/profiles/picasso"
+        # ...and released afterwards, so the worker thread leaks no scope.
+        assert seen["reset"] == "token:/profiles/picasso"
+    finally:
+        server._sessions.pop("pt-profile", None)
+
+
+def test_post_turn_compress_skips_running_under_threshold_and_cooldown(monkeypatch):
+    compressed = []
+    monkeypatch.setattr(
+        server, "_compress_session_history",
+        lambda *a, **k: compressed.append(1) or (0, {}),
+    )
+
+    # Running session: never fires.
+    running = _session(
+        agent=_post_turn_agent(), running=True,
+        history=[{"role": "user", "content": "x"}],
+    )
+    server._maybe_post_turn_compress("pt-running", running)
+
+    # Under threshold (should_compress False): never fires.
+    under = _session(
+        agent=_post_turn_agent(decision=False),
+        history=[{"role": "user", "content": "x"}],
+    )
+    server._maybe_post_turn_compress("pt-under", under)
+
+    # Recent failure: never fires inside the cooldown window.
+    cooled = _session(
+        agent=_post_turn_agent(),
+        history=[{"role": "user", "content": "x"}],
+        _post_turn_compress_failed_at=time.time(),
+    )
+    server._maybe_post_turn_compress("pt-cooled", cooled)
+
+    time.sleep(0.2)
+    assert compressed == []
+
+
+def test_post_turn_compress_failure_arms_cooldown(monkeypatch):
+    done = threading.Event()
+
+    def _boom(session, focus_topic=None, **kwargs):
+        try:
+            raise RuntimeError("summary model down")
+        finally:
+            done.set()
+
+    session = _session(
+        agent=_post_turn_agent(),
+        history=[{"role": "user", "content": "x"}],
+    )
+    server._sessions["pt-fail"] = session
+    monkeypatch.setattr(server, "_compress_session_history", _boom)
+    monkeypatch.setattr(server, "_emit", lambda *a, **k: None)
+
+    try:
+        server._maybe_post_turn_compress("pt-fail", session)
+        assert done.wait(5.0)
+        deadline = time.time() + 5.0
+        while "_post_turn_compress_running" in session and time.time() < deadline:
+            time.sleep(0.02)
+        assert session.get("_post_turn_compress_failed_at") is not None
+        assert "_post_turn_compress_running" not in session
+    finally:
+        server._sessions.pop("pt-fail", None)
+
+
 def test_ws_orphan_reap_interrupts_in_process_turn(monkeypatch):
     callbacks = []
     interrupted = []

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -6818,6 +6818,160 @@ def _compress_session_history(
     return len(history) - len(compressed), usage
 
 
+# A failed post-turn compaction must not refire at every turn boundary —
+# each attempt blocks the compression lock for minutes. One retry per
+# cooldown window; the next turn's preflight remains the safety net.
+_POST_TURN_COMPRESS_FAILURE_COOLDOWN_S = 300.0
+
+
+def _maybe_post_turn_compress(sid: str, session: dict) -> None:
+    """Start background compaction the moment a turn settles over-threshold.
+
+    Previously an over-threshold session only compressed at the NEXT turn's
+    preflight — from the user's chair the session "stopped", and
+    'Summarizing thread' only began after they typed something. This hook
+    runs the same automatic gate as preflight
+    (ContextCompressor.should_compress: threshold + summary-failure cooldown
+    + anti-thrash) as soon as the turn finishes, and compresses on a daemon
+    thread while the session sits idle, so the next user message starts on a
+    compacted transcript with no preflight stall.
+
+    A user prompt that races the compaction wins: _compress_session_history
+    drops its result on external history mutation, and the racing turn's
+    preflight defers on the held compression lock (#69870) instead of
+    double-compressing.
+    """
+    agent = session.get("agent")
+    if agent is None:
+        return
+    if session.get("running") or session.get("queued_prompt"):
+        return
+    # Codex app-server sessions compact natively — mirror the preflight skip.
+    if getattr(agent, "codex_app_server_auto_compaction", None):
+        return
+    if session.get("_post_turn_compress_running"):
+        return
+    failed_at = session.get("_post_turn_compress_failed_at")
+    if failed_at and (
+        time.time() - float(failed_at) < _POST_TURN_COMPRESS_FAILURE_COOLDOWN_S
+    ):
+        return
+    comp = getattr(agent, "context_compressor", None)
+    if comp is None or not getattr(comp, "threshold_tokens", 0):
+        return
+    from agent.model_metadata import estimate_request_tokens_rough
+
+    with session["history_lock"]:
+        history = list(session.get("history") or [])
+    if not history:
+        return
+    try:
+        tokens = estimate_request_tokens_rough(
+            history,
+            system_prompt=str(getattr(agent, "_cached_system_prompt", "") or ""),
+            tools=getattr(agent, "tools", None) or None,
+        )
+    except Exception:
+        return
+    try:
+        if not comp.should_compress(tokens):
+            return
+    except Exception:
+        return
+    session["_post_turn_compress_running"] = True
+
+    def _worker() -> None:
+        # A named-profile session's compaction must resolve config (thresholds,
+        # auxiliary compression model) and secrets from ITS profile, not the
+        # root default. The prompt path installs this scope per turn; a
+        # background worker running off-turn has to install it itself.
+        home_token = None
+        secret_token = None
+        profile_home = session.get("profile_home")
+        try:
+            if profile_home:
+                home_token = set_hermes_home_override(profile_home)
+                try:
+                    from agent.secret_scope import (
+                        build_profile_secret_scope,
+                        set_secret_scope,
+                    )
+
+                    secret_token = set_secret_scope(
+                        build_profile_secret_scope(Path(profile_home))
+                    )
+                except Exception:
+                    secret_token = None
+            with _sessions_lock:
+                if _sessions.get(sid) is not session:
+                    return
+            if session.get("running") or session.get("queued_prompt"):
+                return
+            logger.info(
+                "post-turn compression starting: sid=%s session=%s "
+                "~%s tokens >= %s threshold",
+                sid,
+                getattr(agent, "session_id", "") or "",
+                f"{tokens:,}",
+                f"{int(getattr(comp, 'threshold_tokens', 0) or 0):,}",
+            )
+            try:
+                _emit(
+                    "status.update",
+                    sid,
+                    {
+                        "kind": "compacting",
+                        "text": (
+                            "🗜️ Compacting context in the background — "
+                            "summarizing earlier conversation…"
+                        ),
+                    },
+                )
+            except Exception:
+                pass
+            removed, _usage = _compress_session_history(session)
+            _sync_session_key_after_compress(
+                sid,
+                session,
+                clear_pending_title=False,
+                restart_slash_worker=True,
+            )
+            session.pop("_post_turn_compress_failed_at", None)
+            logger.info(
+                "post-turn compression done: sid=%s removed=%d messages",
+                sid,
+                removed,
+            )
+            try:
+                _emit_settled_session_info(sid, session, agent)
+            except Exception:
+                pass
+        except CompressionLockHeld:
+            logger.info(
+                "post-turn compression skipped: lock held sid=%s", sid
+            )
+        except Exception:
+            session["_post_turn_compress_failed_at"] = time.time()
+            logger.warning(
+                "post-turn compression failed sid=%s", sid, exc_info=True
+            )
+        finally:
+            if secret_token is not None:
+                try:
+                    from agent.secret_scope import reset_secret_scope
+
+                    reset_secret_scope(secret_token)
+                except Exception:
+                    pass
+            if home_token is not None:
+                reset_hermes_home_override(home_token)
+            session.pop("_post_turn_compress_running", None)
+
+    threading.Thread(
+        target=_worker, daemon=True, name=f"post-turn-compress-{sid}"
+    ).start()
+
+
 def _sync_session_key_after_compress(
     sid: str,
     session: dict,
@@ -13173,6 +13327,19 @@ def _run_prompt_submit(
                 f"[tui_gateway] completion queue drain failed: "
                 f"{type(_drain_exc).__name__}: {_drain_exc}",
                 file=sys.stderr,
+            )
+
+        # The turn settled with no follow-up turn queued. If the session is
+        # over its compression threshold, start compacting NOW in the
+        # background instead of leaving it for the next user message's
+        # preflight — the "session stops, and only starts Summarizing thread
+        # after I type" experience.
+        try:
+            _maybe_post_turn_compress(sid, session)
+        except Exception:
+            logger.debug(
+                "post-turn compress scheduling failed sid=%s", sid,
+                exc_info=True,
             )
 
     run_thread = threading.Thread(target=run, daemon=True)


### PR DESCRIPTION
## What does this PR do?

An over-threshold TUI gateway session only compacts at the **next turn's preflight**. From the user's chair the session simply stops after a long turn; nothing happens while it sits idle; and when they finally send another message, that message blocks on a full summarization before any work resumes. The idle window right after the turn — the one moment compaction is free — goes unused.

This starts compaction at the **turn-finish boundary** instead. When a turn settles with no follow-up queued and the session is over threshold, a background daemon thread compacts while the session is idle, so the next prompt starts on an already-compacted transcript.

This is the background-timing delta that #32446 and #38956 were closed without. Both were superseded by #69360's `idle_compact_after_seconds`, which compacts long-idle sessions **at turn start** — it moves *which* turn pays, but a turn still pays. Both close-outs invited a fresh PR against current contracts if the latency proved painful in practice ("the right vehicle is a fresh issue/PR against the current contracts", #38956; "If background-timing proves worth it, a fresh issue against the current async session flow is the right vehicle", #32446). It did, so here it is, rebuilt against the contracts those reviews named.

Reported in practice as: a long session appears to stop, and "Compacting context" only begins after the user types something to ask what happened.

## Related Issue

Refs #35467 (progressive background pre-compaction — this implements the post-turn trigger half of that proposal, without the candidate-summary cache).
Refs #32446, #38956 (prior attempts, closed as superseded; this is the invited fresh vehicle).

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

`tui_gateway/server.py`

- `_maybe_post_turn_compress(sid, session)` — new. Runs the same automatic gate as preflight and, when it passes, compacts on a daemon thread.
- Called once at the end of the turn-finish path in `_run_prompt_submit`'s `run()`, after the queued-prompt drain, the turn-boundary continuation, the goal-continuation, and the completion-notification drain — so it only fires when nothing else is going to take the session.
- `_POST_TURN_COMPRESS_FAILURE_COOLDOWN_S = 300.0` — new module constant.

How it composes with the current contracts:

- **Automatic-compaction gate** — reuses `ContextCompressor.should_compress`, so the threshold, the summary-failure cooldown and the anti-thrash breaker all apply unchanged. Token estimate comes from `estimate_request_tokens_rough` over the session history with the agent's cached system prompt and tool schemas, matching preflight's accounting.
- **Per-session compression lock** — routes through `_compress_session_history`, so it takes the same lock as every other compaction path. `CompressionLockHeld` is a no-op skip. A racing turn's preflight defers on the same lock via the existing lock-skip feedback (#69870) rather than double-compacting.
- **Profile scope** — installs the session's `profile_home` HERMES_HOME override and secret scope for the worker's lifetime and releases both in the `finally`, mirroring what the prompt path does per turn. Without this a named-profile session's background compaction would resolve config (thresholds, `auxiliary.compression` model) and secrets from the root default profile. This is the profile-scope gap flagged in the #38956 review; a regression test covers it.
- **Busy input** — `prompt.submit` is untouched, so busy input keeps flowing through `_handle_busy_submit` exactly as it does today. Nothing is rejected or steered. The worker skips while `running` or `queued_prompt` is set, and a prompt that races the worker wins anyway because `_compress_session_history` drops its result on external history mutation.
- **Session-key rotation** — calls `_sync_session_key_after_compress(..., clear_pending_title=False, restart_slash_worker=True)`, the same post-turn policy the in-turn auto-compression path uses.
- **Native compaction** — skips sessions with `codex_app_server_auto_compaction` set, mirroring the preflight skip.
- **Failure brake** — one retry per 5-minute cooldown, so a failing summary model cannot re-fire at every turn boundary. The next turn's preflight remains the safety net, so a skipped background pass is never a correctness change.

Status is emitted as a `compacting` status update and a settled-session-info refresh on completion.

`tests/test_tui_gateway_server.py` — four tests: fires for an idle over-threshold session and syncs the session key; installs and releases the named-profile scope (and the scope is still installed *during* the compression call); skips while running / under threshold / inside the failure cooldown; arms the cooldown and clears the running flag on failure.

## How to Test

Reproduce the current behavior:

1. Run a TUI gateway session (Desktop or dashboard) until it is over the compression threshold — `compression.threshold` × the model window.
2. Let a turn finish and leave the session alone. Nothing happens; the transcript stays over threshold.
3. Send any message. Only now does "Compacting context" appear, and that message waits for the whole summarization.

With this change, step 2 compacts on its own and step 3 starts immediately on the compacted transcript.

Automated:

```
pytest tests/test_tui_gateway_server.py -k post_turn_compress -q
```

Full suites run on this branch:

```
pytest tests/test_tui_gateway_server.py -q
  → 617 passed, 1 failed
pytest tests/tui_gateway/test_compaction_status.py tests/tui_gateway/test_compress_lock_skip.py \
       tests/tui_gateway/test_compression_config_hot_reload.py tests/tui_gateway/test_auto_continue.py \
       tests/test_tui_gateway_ws.py -q
  → 43 passed
```

The one failure is `test_model_options_preserves_canonical_custom_row_after_agent_init`, which fails identically on this branch's base commit (99c3cad85) with no changes applied — it picks up real installed providers in this environment. Unrelated to this change.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — #32446 and #38956 are the closed prior attempts this supersedes; #68923 is open and adjacent (background compaction plus state-WAL bounding, a different scheduler and scope)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — for the affected suites; see above for the one pre-existing environment failure
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A: no new config key; the behavior rides the existing `compression` gate
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A: no new config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — no platform-specific code; threading and context-var scoping only

## Notes for review

- **Why a new trigger point rather than extending `idle_compact_after_seconds`:** that key answers "this session has been idle a while, compact before replying," and still puts the cost on a user turn. This answers "this session is over threshold and nothing is using it right now," which is the only moment compaction is free. They compose — neither supersedes the other.
- **No new config key on purpose.** It fires exactly when the existing automatic gate says compaction is due. If you would rather have it opt-in (or share a namespace with `compression.idle*`), say the word and I will add the key.
- The 5-minute failure cooldown and the 4 tests are the pieces I would most expect review to want changed.
