### PR TITLE
fix(cli): add hermes start/stop/restart root aliases for gateway (#68247) (salvage of #68481)

### DIFF
--- a/hermes_cli/_parser.py
+++ b/hermes_cli/_parser.py
@@ -114,6 +114,9 @@ Examples:
     hermes -s hermes-agent-dev,github-auth
     hermes -w                     Start in isolated git worktree
     hermes gateway install        Install gateway background service
+    hermes start                  Alias for gateway start
+    hermes stop                   Alias for gateway stop
+    hermes restart                Alias for gateway restart
     hermes sessions list          List past sessions
     hermes sessions browse        Interactive session picker
     hermes sessions rename ID T   Rename/title a session

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8,6 +8,7 @@ Usage:
     hermes gateway             # Run gateway in foreground
     hermes gateway start       # Start gateway as service
     hermes gateway stop        # Stop gateway service
+    hermes start / stop        # Aliases for gateway start / stop
     hermes gateway status      # Show gateway status
     hermes gateway install     # Install gateway service
     hermes gateway uninstall   # Uninstall gateway service
@@ -12365,7 +12366,7 @@ _BUILTIN_SUBCOMMANDS = frozenset(
         "prompt-size",
         "resume",
         "send", "sessions", "setup",
-        "skin", "skills", "slack", "status", "sync", "tools", "uninstall", "update",
+        "skin", "skills", "slack", "start", "stop", "restart", "status", "sync", "tools", "uninstall", "update",
         "webhook", "whatsapp", "whatsapp-cloud", "worktree", "chat", "secrets", "security",
         "browser",
         "verify",

--- a/hermes_cli/subcommands/gateway.py
+++ b/hermes_cli/subcommands/gateway.py
@@ -307,6 +307,51 @@ def build_gateway_parser(
     )
     gateway_enroll.set_defaults(func=cmd_gateway_enroll)
 
+    # Top-level start/stop/restart aliases (#68247).
+    # Users often type `hermes stop` / `hermes start` (supervisor-style) and hit
+    # "invalid choice". These root verbs dispatch to the same ``cmd_gateway``
+    # handler with ``gateway_command`` set, keeping behaviour identical to
+    # ``hermes gateway start|stop|restart`` including ``--system`` / ``--all``.
+    # Mirror nested parser parity: the hidden ``--platform`` compat flag is only
+    # accepted by ``gateway start`` and ``gateway restart`` (see :115, :144),
+    # not by ``gateway stop``. Root aliases must match exactly.
+    def _add_gateway_lifecycle_root_alias(
+        name: str, *, help_text: str, all_help: str, compat_platform: bool
+    ) -> None:
+        alias = subparsers.add_parser(name, help=help_text)
+        alias.add_argument(
+            "--system",
+            action="store_true",
+            help="Target the Linux system-level gateway service",
+        )
+        alias.add_argument(
+            "--all",
+            action="store_true",
+            help=all_help,
+        )
+        if compat_platform:
+            _add_compat_platform_flag(alias)
+        alias.set_defaults(func=cmd_gateway, gateway_command=name)
+
+    _add_gateway_lifecycle_root_alias(
+        "start",
+        help_text="Alias for 'hermes gateway start' — start the messaging gateway service",
+        all_help="Kill ALL stale gateway processes across all profiles before starting",
+        compat_platform=True,
+    )
+    _add_gateway_lifecycle_root_alias(
+        "stop",
+        help_text="Alias for 'hermes gateway stop' — stop the messaging gateway service",
+        all_help="Stop ALL gateway processes across all profiles",
+        compat_platform=False,
+    )
+    _add_gateway_lifecycle_root_alias(
+        "restart",
+        help_text="Alias for 'hermes gateway restart' — restart the messaging gateway service",
+        all_help="Kill ALL gateway processes across all profiles before restarting",
+        compat_platform=True,
+    )
+
     # =========================================================================
     # proxy command — local OpenAI-compatible proxy that attaches the user's
     # OAuth-authenticated provider credentials to outbound requests. Lets

--- a/tests/hermes_cli/test_gateway_lifecycle_root_aliases_68247.py
+++ b/tests/hermes_cli/test_gateway_lifecycle_root_aliases_68247.py
@@ -1,0 +1,92 @@
+"""Regression (#68247): top-level ``hermes start|stop|restart`` aliases.
+
+Users (and agent-generated scripts) often expect supervisor-style verbs at the
+root CLI. Historically only ``hermes gateway start|stop`` worked, and
+``hermes stop`` printed ``invalid choice: 'stop'``. These aliases parse to the
+same ``cmd_gateway`` handler with ``gateway_command`` set.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import pytest
+
+from hermes_cli.subcommands.gateway import build_gateway_parser
+
+
+def _parser():
+    parser = argparse.ArgumentParser(prog="hermes")
+    sub = parser.add_subparsers(dest="command")
+    calls = []
+
+    def _cmd_gateway(args):
+        calls.append(
+            (
+                args.gateway_command,
+                bool(getattr(args, "system", False)),
+                bool(getattr(args, "all", False)),
+            )
+        )
+        return 0
+
+    build_gateway_parser(
+        sub,
+        cmd_gateway=_cmd_gateway,
+        cmd_proxy=lambda _a: None,
+        cmd_gateway_enroll=lambda _a: None,
+    )
+    return parser, calls
+
+
+def test_root_stop_dispatches_like_gateway_stop():
+    parser, calls = _parser()
+    ns = parser.parse_args(["stop"])
+    assert ns.command == "stop"
+    assert ns.gateway_command == "stop"
+    ns.func(ns)
+    assert calls == [("stop", False, False)]
+
+
+def test_root_start_system_all_flags():
+    parser, calls = _parser()
+    ns = parser.parse_args(["start", "--system", "--all"])
+    ns.func(ns)
+    assert calls == [("start", True, True)]
+
+
+def test_root_restart_parity_with_nested():
+    parser, calls = _parser()
+    nested = parser.parse_args(["gateway", "restart", "--all"])
+    root = parser.parse_args(["restart", "--all"])
+    nested.func(nested)
+    root.func(root)
+    assert calls[0] == calls[1] == ("restart", False, True)
+
+
+def test_platform_flag_parity_with_nested_parsers():
+    """``--platform`` is a hidden compat flag accepted only by start/restart.
+
+    Nested ``gateway start`` / ``gateway restart`` accept it, but ``gateway
+    stop`` does not. The root aliases must match that parser surface exactly.
+    """
+    for verb in ("start", "restart"):
+        parser, _ = _parser()
+        # Both nested and root accept --platform for start/restart.
+        parser.parse_args(["gateway", verb, "--platform", "linux"])
+        parser.parse_args([verb, "--platform", "linux"])
+
+    # stop rejects --platform at both nested and root level.
+    for argv in (["gateway", "stop", "--platform", "linux"], ["stop", "--platform", "linux"]):
+        parser, _ = _parser()
+        with pytest.raises(SystemExit):
+            parser.parse_args(argv)
+
+
+def test_nested_gateway_stop_still_works():
+    parser, calls = _parser()
+    ns = parser.parse_args(["gateway", "stop"])
+    assert ns.command == "gateway"
+    assert ns.gateway_command == "stop"
+    ns.func(ns)
+    assert calls == [("stop", False, False)]


### PR DESCRIPTION
## Summary
- Register top-level `hermes start`, `hermes stop`, and `hermes restart` as aliases for the nested gateway lifecycle commands.
- Flags `--system` and `--all` match the nested parsers; hidden `--platform` only on start/restart (parity with nested).
- Rebuild of stale/conflicting #68481 onto current `main` (issue #68247 still open; root verbs still missing).

## Motivation
Closes #68247.

`hermes stop` / `hermes start` fail with `invalid choice` because only `hermes gateway start|stop|restart` exist. Root aliases fix the footgun without changing the nested API.

## Credit
Salvage of #68481 by @Bartok9 (original implementation).

## Verification
- `pytest tests/hermes_cli/test_gateway_lifecycle_root_aliases_68247.py` — 5 passed
- Nested `hermes gateway stop` path unchanged