### PR TITLE
fix(desktop): keep primary SSH session resumes remote

### DIFF
--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -72,8 +72,10 @@ import {
   $selectedStoredSessionId,
   $sessionResumeRequest,
   $sessions,
+  forgetSessionOwnerHintsForSession,
   requestSessionResume,
   sessionMatchesStoredId,
+  sessionOwnerRouteFromRow,
   sessionPinId,
   setAwaitingResponse,
   setBusy,
@@ -997,17 +999,18 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     // against whichever cached row is found first — the user clicks a row
     // previewing profile A and the resume dials profile B. Pin the row's own
     // (connection, profile) as the resume owner before navigating; untagged
-    // rows (single-profile installs, legacy pages) keep the id-only path.
+    // rows (single-profile installs and the legacy primary-SSH path) keep the
+    // ambient/id-only path. Clear any stale explicit hint first: older builds
+    // incorrectly persisted those rows as `local`, which made a remote session
+    // click switch to the Mac backend and fail with "session not found".
     onResumeSession: (sessionId, session) => {
-      const rowProfile = session?.profile?.trim()
+      const ownerRoute = sessionOwnerRouteFromRow(session)
 
-      if (rowProfile) {
-        requestSessionResume(sessionId, {
-          connectionId: session?.connection_id?.trim() || 'local',
-          ...(session?.connection_id?.trim() ? {} : { mode: 'local' as const }),
-          profile: rowProfile,
-          targetProfile: rowProfile
-        })
+      if (ownerRoute) {
+        requestSessionResume(sessionId, ownerRoute)
+      } else {
+        forgetSessionOwnerHintsForSession(sessionId)
+        requestSessionResume(sessionId)
       }
 
       openSession(sessionId, navigate)

--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -31,10 +31,12 @@ import {
   commitWorkspaceCwdForSelectedSession,
   ensureDefaultWorkspaceCwd,
   forgetSessionOwnerHintsForConnection,
+  forgetSessionOwnerHintsForSession,
   getConfiguredDefaultProjectDir,
   getRememberedRoute,
   getRememberedSessionId,
   getSessionOwnerHint,
+  getSessionOwnerHints,
   hydrateSessionOwnerHints,
   knownSessionOwner,
   knownSessionProfile,
@@ -42,6 +44,7 @@ import {
   rememberedSessionProfile,
   resolveComposerSessionKey,
   sessionBelongsToProfile,
+  sessionOwnerRouteFromRow,
   sessionPinId,
   setCurrentCwd,
   setCurrentCwdTransient,
@@ -175,6 +178,30 @@ describe('session owner hints', () => {
     hydrateSessionOwnerHints()
     expect(getSessionOwnerHint('stored-a')).toBeUndefined()
     expect(getSessionOwnerHint('stored-c')).toEqual({ connectionId: 'local', profile: 'omar' })
+  })
+
+  it('forgets every route for one session without disturbing other sessions', () => {
+    setSessionOwnerHint('poisoned', { connectionId: 'local', mode: 'local', profile: 'default' })
+    setSessionOwnerHint('poisoned', { connectionId: 'remote-a', mode: 'remote', profile: 'default' })
+    setSessionOwnerHint('healthy', { connectionId: 'remote-a', mode: 'remote', profile: 'default' })
+
+    forgetSessionOwnerHintsForSession('poisoned')
+
+    expect(getSessionOwnerHints('poisoned')).toEqual([])
+    expect(getSessionOwnerHint('healthy')).toMatchObject({ connectionId: 'remote-a' })
+
+    _resetSessionOwnerHintsForTests()
+    hydrateSessionOwnerHints()
+    expect(getSessionOwnerHints('poisoned')).toEqual([])
+    expect(getSessionOwnerHint('healthy')).toMatchObject({ connectionId: 'remote-a' })
+  })
+
+  it('pins only connection-tagged rows and leaves primary SSH rows ambient', () => {
+    expect(
+      sessionOwnerRouteFromRow(session({ connection_id: 'source-a', profile: 'worker' }))
+    ).toEqual({ connectionId: 'source-a', profile: 'worker', targetProfile: 'worker' })
+    expect(sessionOwnerRouteFromRow(session({ profile: 'default' }))).toBeUndefined()
+    expect(sessionOwnerRouteFromRow(session({ connection_id: '  ', profile: 'default' }))).toBeUndefined()
   })
 })
 

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -867,6 +867,46 @@ export function forgetSessionOwnerHintsForConnection(connectionId: string): void
   }
 }
 
+/** Drop every persisted route for one session. Untagged rows are owned by the
+ * ambient backend that returned them, so a stale explicit hint must not force a
+ * later resume onto a different connection. */
+export function forgetSessionOwnerHintsForSession(sessionId: string): void {
+  const id = sessionId.trim()
+
+  if (!id) {
+    return
+  }
+
+  let changed = false
+
+  for (const [key, entry] of [...sessionOwnerHints]) {
+    if (entry.id === id) {
+      sessionOwnerHints.delete(key)
+      changed = true
+    }
+  }
+
+  if (changed) {
+    persistSessionOwnerHints()
+  }
+}
+
+/** Exact route carried by a connection-tagged row. An untagged row deliberately
+ * returns undefined: it belongs to the ambient backend that supplied the list,
+ * including the legacy primary-SSH path whose rows have no registry id. */
+export function sessionOwnerRouteFromRow(
+  session?: Pick<SessionInfo, 'connection_id' | 'profile'>
+): SessionOwnerRoute | undefined {
+  const connectionId = (session?.connection_id ?? '').trim()
+  const profile = (session?.profile ?? '').trim()
+
+  if (!connectionId || !profile) {
+    return undefined
+  }
+
+  return { connectionId, profile, targetProfile: profile }
+}
+
 /** @internal Tests: forget every in-memory hint (storage untouched unless asked). */
 export function _resetSessionOwnerHintsForTests({ storage = false }: { storage?: boolean } = {}): void {
   sessionOwnerHints.clear()


### PR DESCRIPTION
## What does this PR do?

Desktop session rows from the legacy primary SSH path do not carry a registry `connection_id`. PR #95895 intended those untagged rows to keep the ambient, ID-only resume path, but its click handler instead substituted `connectionId: "local"`.

That persisted the remote session as locally owned. The next resume was sent to the Desktop machine's local backend, where the durable session did not exist. The result was a failed restore or a misleading provider configuration error, even though the SSH backend and its session were healthy.

This change keeps explicit routing for connection-tagged rows. For an untagged row, it removes any stale explicit owner hint and issues an ID-only resume against the ambient primary backend. This also repairs owner hints already poisoned by an earlier build.

## Related Issue

Related to #93888. This fixes the primary SSH, untagged-row case in the still-open stored-session restore issue. It does not claim to resolve every registered-gateway topology covered there.

Regression introduced by #95895 (`db127f750`).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/contrib/wiring.tsx` keeps untagged session rows on the ambient backend instead of synthesizing a local owner.
- `apps/desktop/src/store/session.ts` adds focused helpers for deriving an exact owner from tagged rows and removing stale hints for one session.
- `apps/desktop/src/store/session.test.ts` covers tagged versus untagged routing and persisted hint cleanup.

## How to Test

1. Configure Desktop with a legacy primary SSH connection and open a stored session whose row has a profile but no `connection_id`.
2. Confirm the session resumes on the SSH backend and no local Desktop backend is spawned.
3. Seed a stale `local` owner hint for that session, click it again, and confirm the hint is removed while unrelated session hints remain intact.

Validation completed:

- `npm exec -- vitest run --project ui src/store/session.test.ts`, 91 tests passed.
- `npm run test:ui`, 618 files and 6,120 tests passed.
- `npm run typecheck`, passed.
- ESLint on all three changed files, passed.
- Production macOS package build and code-sign verification, passed.
- Packaged macOS app tested against a Linux SSH backend. Previously failing stored sessions reopened and continued without a local backend spawn.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
  - N/A, no Python files changed. The complete Desktop UI suite, Desktop typecheck, changed-file lint, production package build, and live packaged app were tested instead.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS on Apple Silicon, with a Linux backend over SSH

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings), or N/A
  - N/A, this restores the documented ambient routing behavior and adds focused code comments.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys, or N/A
  - N/A, no configuration keys changed.
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows, or N/A
  - N/A, no architecture or workflow contract changed.
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility), or N/A
  - The fix is renderer-only and platform-neutral. Live validation was on macOS.
- [x] I've updated tool descriptions/schemas if I changed tool behavior, or N/A
  - N/A, no agent tools changed.

## Screenshots / Logs

Before the fix, clicking an untagged SSH session persisted this owner route:

```json
{"connectionId":"local","mode":"local","profile":"default","targetProfile":"default"}
```

The click then started a local backend and failed to restore the remote session. After the fix, the stale hint is removed, the ID-only resume stays on the ambient SSH backend, and the stored session opens normally.

---

🤖 Generated with Hermes Agent (GPT-5.6 Sol 900k)
🧑‍💻 Ideated, directed and reviewed by a human, @oliver-mee
