### PR TITLE
security(p5js): integrity-check the default p5.js CDN runtime

### DIFF
--- a/skills/creative/p5js/SKILL.md
+++ b/skills/creative/p5js/SKILL.md
@@ -183,7 +183,7 @@ Single HTML file. Structure:
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Project Name</title>
   <script>p5.disableFriendlyErrors = true;</script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.11.3/p5.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.11.3/p5.min.js" integrity="sha512-I0Pwwz3PPNQkWes+rcSoQqikKFfRmTfGQrcNzZbm8ALaUyJuFdyRinl805shE8xT6iEWsWgvRxdXb3yhQNXKoA==" crossorigin="anonymous"></script>
   <!-- <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.11.3/addons/p5.sound.min.js"></script> -->
   <!-- <script src="https://unpkg.com/p5.js-svg@1.6.0"></script> -->  <!-- SVG export -->
   <!-- <script src="https://cdn.jsdelivr.net/npm/ccapture.js-npmfixed/build/CCapture.all.min.js"></script> -->  <!-- video capture -->

--- a/skills/creative/p5js/templates/viewer.html
+++ b/skills/creative/p5js/templates/viewer.html
@@ -25,7 +25,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Generative Art Viewer</title>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.11.3/p5.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.11.3/p5.min.js" integrity="sha512-I0Pwwz3PPNQkWes+rcSoQqikKFfRmTfGQrcNzZbm8ALaUyJuFdyRinl805shE8xT6iEWsWgvRxdXb3yhQNXKoA==" crossorigin="anonymous"></script>
 <style>
   * { margin: 0; padding: 0; box-sizing: border-box; }
   body {

--- a/tests/skills/test_p5js_cdn_integrity.py
+++ b/tests/skills/test_p5js_cdn_integrity.py
@@ -1,0 +1,55 @@
+"""The bundled p5.js skill ships an external executable dependency; the CDN
+script tag must carry subresource integrity so the browser refuses to execute
+any bytes that are not the pinned p5.js 1.11.3 build (#96888).
+
+Both authoritative entry points are covered: the viewer template and the
+bare-HTML scaffold embedded in SKILL.md. The test is deliberately a static
+source assertion — SRI is enforced by the browser at load time, so the
+regression we pin is "the attribute pair is present and matches the official
+cdnjs digest", not runtime behavior.
+"""
+import re
+from pathlib import Path
+
+import pytest
+
+_P5_SCRIPT = re.compile(r"<script\s+[^>]*>")
+_P5_CDN_PREFIX = (
+    "https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.11.3/p5.min.js"
+)
+_OFFICIAL_SRI = (
+    "sha512-I0Pwwz3PPNQkWes+rcSoQqikKFfRmTfGQrcNzZbm8ALaUyJuFdyRinl805shE8xT6iEWsWgvRxdXb3yhQNXKoA=="
+)
+
+_SKILL_ROOT = Path(__file__).resolve().parents[2] / "skills" / "creative" / "p5js"
+_ENTRY_POINTS = [
+    _SKILL_ROOT / "templates" / "viewer.html",
+    _SKILL_ROOT / "SKILL.md",
+]
+
+
+def _p5_cdn_tags(source: str) -> list[str]:
+    return [
+        tag
+        for tag in _P5_SCRIPT.findall(source)
+        if f'src="{_P5_CDN_PREFIX}"' in tag
+    ]
+
+
+@pytest.mark.parametrize("path", _ENTRY_POINTS, ids=lambda p: p.name)
+def test_p5_cdn_script_carries_integrity(path: Path) -> None:
+    source = path.read_text(encoding="utf-8")
+    tags = _p5_cdn_tags(source)
+    assert tags, (
+        f"{path.name} no longer references the pinned p5.js CDN script"
+    )
+
+    for tag in tags:
+        assert f'integrity="{_OFFICIAL_SRI}"' in tag, (
+            f"{path.name}: p5.js script tag lost its SRI attribute or the "
+            "digest no longer matches the official cdnjs digest for 1.11.3"
+        )
+        assert 'crossorigin="anonymous"' in tag, (
+            f"{path.name}: SRI requires the crossorigin attribute or the "
+            "browser skips the integrity check for cross-origin scripts"
+        )


### PR DESCRIPTION
## What does this PR do?

Adds browser-enforced subresource integrity to the p5.js CDN script tag shipped by the bundled creative skill.

The tag pinned an exact version (`1.11.3`), which prevents accidental version drift, but the browser would still execute any bytes returned from that URL — a contained supply-chain hardening gap (#96888). Both authoritative entry points now carry the official cdnjs `sha512` digest for p5.js 1.11.3 plus `crossorigin="anonymous"` (SRI is skipped for cross-origin scripts without the crossorigin attribute):

- `skills/creative/p5js/templates/viewer.html`
- the bare-HTML scaffold embedded in `skills/creative/p5js/SKILL.md`

The digest is the one published by the cdnjs API for that exact file and version (`api.cdnjs.com/libraries/p5.js/1.11.3?fields=sri`), not a locally computed one — pinning a self-computed digest would silently pin a compromised download path.

## Related Issue

Fixes #96888

## Type of Change

- [x] 🔒 Security fix

## Changes Made

- `skills/creative/p5js/templates/viewer.html` — p5.js script tag gains `integrity` + `crossorigin="anonymous"`.
- `skills/creative/p5js/SKILL.md` — same for the embedded bare-HTML scaffold.
- `tests/skills/test_p5js_cdn_integrity.py` — fail-closed static regression: both entry points must reference the pinned CDN script and carry the official digest + crossorigin pair; a stripped or drifted attribute fails the test.

## How to Test

1. `python -m pytest tests/skills/test_p5js_cdn_integrity.py -q` — should pass (2 passed).
2. Red/green verified locally: with `integrity` stripped from the viewer template, the viewer case fails (1 failed / 1 passed).
3. Manual equivalent: open a generated viewer.html in a browser with the network tab open — the p5.js request carries `Sec-Fetch-*`/CORS and loads; substituting one byte of the file (e.g. via a local proxy) makes the browser refuse execution with an integrity error instead of running it.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (targeted: `tests/skills/test_p5js_cdn_integrity.py` — 2 passed)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.5 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (SRI is enforced by all modern browsers)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
