### PR TITLE
fix(desktop): route browser profiles over primary gateway

### DIFF
--- a/apps/desktop/src/store/gateway-profile-request.test.ts
+++ b/apps/desktop/src/store/gateway-profile-request.test.ts
@@ -129,6 +129,19 @@ describe('requestGatewayForProfile', () => {
     expect($gateway.get()).toBe(primary)
   })
 
+  it('uses the same-origin primary socket and adds profile scope in the browser Dashboard', async () => {
+    const primary = makePrimary()
+    setPrimaryGateway(primary as never, 'default')
+    await ensureGatewayForProfile('default')
+
+    const result = await requestGatewayForProfile('venture', 'session.list', { limit: 20, profile: 'wrong' })
+
+    expect(result).toEqual({ method: 'session.list', params: { limit: 20, profile: 'venture' } })
+    expect(primary.request).toHaveBeenCalledWith('session.list', { limit: 20, profile: 'venture' })
+    expect(secondaryGateways).toHaveLength(0)
+    expect($gateway.get()).toBe(primary)
+  })
+
   it('serializes concurrent requests while a secondary gateway is connecting', async () => {
     let releaseConnect: () => void = () => undefined
     connectGate = new Promise<void>(resolve => {

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -711,7 +711,9 @@ async function sharedPrimaryRoute(profile: string): Promise<boolean> {
   const desktop = window.hermesDesktop
 
   if (!desktop) {
-    return false
+    // Browser Dashboard has no Electron IPC for secondary sockets. Its
+    // same-origin gateway multiplexes named profiles over the primary socket.
+    return true
   }
 
   try {


### PR DESCRIPTION
## Summary

- route named profiles through the existing same-origin WebSocket when the Dashboard is running in a browser without `window.hermesDesktop`
- stamp the requested profile into browser RPC parameters instead of attempting to create an Electron-only secondary gateway
- preserve the existing secondary-socket behavior for packaged Electron profile switching

## Problem

`requestGatewayForProfile()` treated the browser Dashboard as if it could create a per-profile secondary gateway. In a browser, `window.hermesDesktop` is absent, so selecting a named profile could leave the prompt on an unusable route and produce no visible response.

The browser already has an authenticated primary same-origin WebSocket. This change reuses that connection and includes the selected profile in the RPC payload.

## Testing

- `npm run test -- --run src/store/gateway-profile-request.test.ts` — 17 passed
- `npm run typecheck` — passed
- `git diff --check origin/main...HEAD` — passed
