### PR TITLE
feat(tui): show a status-bar badge when an MCP server fails to connect

### DIFF
--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -475,6 +475,7 @@ export function StatusRule({
   modelFast,
   modelReasoningEffort,
   indicatorStyle = 'kaomoji',
+  mcpFailedCount = 0,
   notice,
   usage,
   bgCount,
@@ -603,6 +604,14 @@ export function StatusRule({
   // Dev-gated readout (HERMES_DEV_CREDITS), lowest priority,
   // so it consumes tail budget LAST and drops first on a narrow terminal.
   const showDevCredits = !!devCreditsText && fits(SEP + stringWidth(devCreditsText))
+
+  // MCP failure badge. Pinned rather than tail-budgeted: a server that failed
+  // to connect silently removes its tools, and a user who cannot see that will
+  // read the missing capability as the agent refusing to work. It must survive
+  // a narrow terminal, so it is exempt from the width budget above. Renders
+  // only when something is actually broken.
+  const mcpFailedText = mcpFailedCount > 0 ? `⚠ mcp×${mcpFailedCount}` : ''
+  const showMcpFailed = !!mcpFailedText
 
   // Focus-view badge. Pinned (not tail-budgeted) on purpose: the whole point of
   // the indicator is that the user can never be in reduced-output mode without
@@ -740,6 +749,13 @@ export function StatusRule({
             {devCreditsText}
           </Text>
         ) : null}
+        {/* Pinned, not tail-budgeted — see mcpFailedText above. */}
+        {showMcpFailed ? (
+          <Text color={t.color.error} wrap="truncate-end">
+            {' │ '}
+            {mcpFailedText}
+          </Text>
+        ) : null}
         {/* SpawnHud isn't part of the tail budget (its width is dynamic), so it
             renders last — any overflow truncates the HUD itself rather than the
             budgeted segments before it. It self-hides when no delegation runs. */}
@@ -861,6 +877,8 @@ interface StatusRuleProps {
   bgCount: number
   lastTurnEndedAt?: null | number
   liveSessionCount: number
+  // Number of MCP servers whose connection failed. 0 hides the badge.
+  mcpFailedCount?: number
   busy: boolean
   cols: number
   cwdLabel: string

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -482,6 +482,10 @@ const StatusRulePane = memo(function StatusRulePane({
 }: Pick<AppLayoutProps, 'composer' | 'status'> & { at: 'bottom' | 'top' }) {
   const ui = useStore($uiState)
 
+  // Only 'failed' counts. 'connecting' and 'configured' are in-progress states
+  // and a disabled server is an intentional user choice, so neither is a fault.
+  const mcpFailedCount = (ui.info?.mcp_servers ?? []).filter(s => s.status === 'failed').length
+
   if (ui.statusBar !== at) {
     return null
   }
@@ -498,6 +502,7 @@ const StatusRulePane = memo(function StatusRulePane({
         indicatorStyle={ui.indicatorStyle}
         lastTurnEndedAt={status.lastTurnEndedAt}
         liveSessionCount={ui.liveSessionCount}
+        mcpFailedCount={mcpFailedCount}
         model={ui.info?.model ?? ''}
         modelFast={ui.info?.fast || ui.info?.service_tier === 'priority'}
         modelReasoningEffort={ui.info?.reasoning_effort}


### PR DESCRIPTION
## The problem

When an MCP server fails to connect, its tools silently disappear from the session.

The failure is visible in `hermes mcp` and in the dashboard, but nothing surfaces it where the user actually is. So the first signal they get is the agent behaving as though a capability it should have just isn't there — which reads as the agent refusing to do the work, not as a broken server. The user retries, rephrases, and gets nowhere, because the real problem is one line away in a command they have no reason to run.

## The change

A red `⚠ mcp×N` segment in the status bar, counting servers whose status is `failed`.

```
… │ ⚠ mcp×1
```

**What counts as failed:** only `status === 'failed'`. `connecting` and `configured` are in-progress states, and a `disabled` server is a deliberate user choice — none of those are faults, and badging them would train the user to ignore the badge.

**Why it's pinned, not tail-budgeted:** every other optional segment yields when the terminal gets narrow. This one doesn't. A silently degraded toolset is precisely the thing that must not be the first item dropped on an 80-column terminal — the narrower the terminal, the more likely the user is on a constrained setup where they'd never notice otherwise.

It renders only when the count is above zero, so nothing changes in the healthy case.

## Verification

`npx tsc --noEmit -p tsconfig.json` — clean.

Test failures on this Windows host: `terminalParity.test.ts`, `terminalSetup.test.ts` and `editor.test.ts` fail identically on unmodified `main` (verified against a separate clone). Two further files — `virtualHistoryOffsetCache.test.ts` and `memory.test.ts` — failed only in the parallel run and **pass when run in isolation**, so they're flaky under concurrency rather than affected by this change. Neither touches the status bar.

## Scope

Display only. No config, no new env vars, no tool-schema surface, no change to the agent loop or prompt. Nothing here affects prompt caching.

Companion to #96901 (tool verbs in the status bar), which touches the same two files. Deliberately split so each change can be judged on its own; happy to rebase whichever lands second.
