### PR TITLE
feat(gateway): add bot footer field fed by per-turn profile label

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -21093,6 +21093,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _footer_line = _bfl(
                     user_config=_load_gateway_config(),
                     platform_key=_platform_config_key(source.platform),
+                    profile=self._footer_profile_label(source),
                     model=agent_result.get("model"),
                     context_tokens=agent_result.get("last_prompt_tokens", 0) or 0,
                     context_length=agent_result.get("context_length") or None,
@@ -28712,6 +28713,27 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             getattr(source, "thread_id", None), getattr(source, "parent_chat_id", None),
         )
         return None
+
+    def _footer_profile_label(self, source: SessionSource) -> str:
+        """Resolve the profile name that served this turn (footer ``bot`` field).
+
+        Follows the same resolution order as
+        ``_resolve_profile_home_for_source``: ``source.profile``, then
+        profile routing, then the active profile. Never raises; falls back to
+        ``default`` so a footer render can never be blocked by routing state.
+        """
+        try:
+            name = (getattr(source, "profile", "") or "").strip()
+            if name:
+                return name
+            routed = self._profile_name_for_source(source)
+            if routed:
+                return routed
+            from hermes_cli.profiles import get_active_profile_name
+
+            return get_active_profile_name() or "default"
+        except Exception:
+            return "default"
 
     def _resolve_profile_home_for_source(self, source: SessionSource) -> "Path":
         """Resolve which profile's HERMES_HOME should serve this inbound source.

--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -16,6 +16,7 @@ Available fields:
     context_pct  — last-call context occupancy as a percent (``5%``)
     latency      — wall-clock duration of the turn (``22s``, ``1m05s``)
     cwd          — home-relative working dir (``~``)
+    bot          — active Hermes profile name (``finance``, ``default``)
 
 ``latency`` is opt-in: it is NOT in the default field set, so a footer whose
 ``fields`` are unset renders exactly as before.
@@ -73,7 +74,7 @@ def resolve_footer_config(
         2. ``display.runtime_footer``
         3. ``display.platforms.<platform_key>.runtime_footer``
     """
-    resolved = {"enabled": False, "fields": list(_DEFAULT_FIELDS)}
+    resolved = {"enabled": False, "fields": list(_DEFAULT_FIELDS), "bot_name": ""}
     cfg = (user_config or {}).get("display") or {}
 
     global_cfg = cfg.get("runtime_footer")
@@ -82,6 +83,8 @@ def resolve_footer_config(
             resolved["enabled"] = bool(global_cfg.get("enabled"))
         if isinstance(global_cfg.get("fields"), list) and global_cfg["fields"]:
             resolved["fields"] = [str(f) for f in global_cfg["fields"]]
+        if isinstance(global_cfg.get("bot_name"), str) and global_cfg["bot_name"]:
+            resolved["bot_name"] = global_cfg["bot_name"]
 
     if platform_key:
         platforms = cfg.get("platforms") or {}
@@ -93,6 +96,8 @@ def resolve_footer_config(
                     resolved["enabled"] = bool(plat_footer.get("enabled"))
                 if isinstance(plat_footer.get("fields"), list) and plat_footer["fields"]:
                     resolved["fields"] = [str(f) for f in plat_footer["fields"]]
+                if isinstance(plat_footer.get("bot_name"), str) and plat_footer["bot_name"]:
+                    resolved["bot_name"] = plat_footer["bot_name"]
 
     return resolved
 
@@ -115,6 +120,7 @@ def format_runtime_footer(
     context_length: Optional[int],
     cwd: Optional[str] = None,
     turn_seconds: Optional[float] = None,
+    bot_name: Optional[str] = None,
     fields: Iterable[str] = _DEFAULT_FIELDS,
 ) -> str:
     """Render the footer line, or return "" if no fields have data.
@@ -141,6 +147,11 @@ def format_runtime_footer(
             rel = _home_relative_cwd(cwd or os.environ.get("TERMINAL_CWD", ""))
             if rel:
                 parts.append(rel)
+        elif field == "bot":
+            # Local extension: active profile/bot name (auto-derived, or set
+            # explicitly via display.runtime_footer.bot_name).
+            if bot_name:
+                parts.append(bot_name)
         # Unknown field names are silently ignored.
 
     if not parts:
@@ -152,6 +163,7 @@ def build_footer_line(
     *,
     user_config: dict[str, Any] | None,
     platform_key: str | None,
+    profile: Optional[str] = None,
     model: Optional[str],
     context_tokens: int,
     context_length: Optional[int],
@@ -177,5 +189,6 @@ def build_footer_line(
         context_length=context_length,
         cwd=cwd,
         turn_seconds=turn_seconds,
+        bot_name=cfg.get("bot_name") or (profile or "").strip() or "default",
         fields=cfg.get("fields") or _DEFAULT_FIELDS,
     )

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -4243,12 +4243,23 @@ class GatewaySlashCommandsMixin:
         state = t("gateway.footer.state_on") if new_state else t("gateway.footer.state_off")
         example = ""
         if new_state:
-            # Show a preview using current agent state if available.
+            # Show a preview using current agent state if available. Resolve
+            # the bot label exactly as build_footer_line does for a real
+            # turn: bot_name override, then _footer_profile_label(source)
+            # (source.profile → routing → active profile), so the preview
+            # matches what real replies render even on multiplexed
+            # gateways.
             from gateway.runtime_footer import format_runtime_footer
+
+            bot_label = (
+                effective.get("bot_name")
+                or self._footer_profile_label(event.source)
+            )
             preview = format_runtime_footer(
                 model=_resolve_gateway_model(user_config) or None,
                 context_tokens=0,
                 context_length=None,
+                bot_name=bot_label,
                 fields=effective.get("fields") or ["model", "context_pct", "cwd"],
             )
             if preview:

--- a/tests/gateway/test_runtime_footer.py
+++ b/tests/gateway/test_runtime_footer.py
@@ -74,6 +74,47 @@ def test_format_footer_skips_missing_context_length():
     assert "/tmp/wd" in out
 
 
+def test_build_footer_line_bot_uses_explicit_profile():
+    out = build_footer_line(
+        user_config={
+            "display": {
+                "runtime_footer": {
+                    "enabled": True,
+                    "fields": ["bot"],
+                }
+            }
+        },
+        platform_key="telegram",
+        profile="finance",
+        model="deepseek-v4-flash",
+        context_tokens=0,
+        context_length=None,
+        cwd="",
+    )
+    assert out == "finance"
+
+
+def test_build_footer_line_bot_name_config_overrides_profile():
+    out = build_footer_line(
+        user_config={
+            "display": {
+                "runtime_footer": {
+                    "enabled": True,
+                    "fields": ["bot"],
+                    "bot_name": "Jimmy_Fin_bot",
+                }
+            }
+        },
+        platform_key="telegram",
+        profile="finance",
+        model="deepseek-v4-flash",
+        context_tokens=0,
+        context_length=None,
+        cwd="",
+    )
+    assert out == "Jimmy_Fin_bot"
+
+
 # ---------------------------------------------------------------------------
 # resolve_footer_config
 # ---------------------------------------------------------------------------

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1966,6 +1966,7 @@ Supported fields:
 
 | Field | Renders | Example |
 | --- | --- | --- |
+| `bot` | Active Hermes profile name (multi-bot fleets) | `finance` |
 | `model` | Bare model id, vendor prefix dropped | `gpt-5.4` |
 | `context_pct` | Last-call context occupancy as a percent | `5%` |
 | `latency` | Wall-clock duration of the turn | `22s`, `1m05s` |
@@ -1974,6 +1975,20 @@ Supported fields:
 The default field set is `["model", "context_pct", "cwd"]`. `latency` is opt-in — add it to `fields` to use it. Fields whose data is unavailable are skipped silently rather than rendering an empty slot.
 
 The `/footer` slash command toggles this at runtime in any session.
+
+The `bot` field shows the profile that served the turn (resolved from the
+source's profile context — `source.profile`, then profile routing, then the
+active profile). To display a custom label instead of the profile name, set
+`display.runtime_footer.bot_name` (a per-platform override is also honored
+under `display.platforms.<platform>.runtime_footer.bot_name`):
+
+```yaml
+display:
+  runtime_footer:
+    enabled: true
+    fields: ["bot", "model", "context_pct"]
+    bot_name: "Jimmy_Fin_bot"
+```
 
 Example footer appended to a Telegram/Discord/Slack reply:
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/configuration.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/configuration.md
@@ -1269,6 +1269,32 @@ display:
     fields: ["model", "context_pct", "cwd"]   # 支持字段：model、context_pct、cwd
 ```
 
+支持的字段：
+
+| 字段 | 显示内容 | 示例 |
+| --- | --- | --- |
+| `bot` | 服务该轮次的 Hermes profile 名称（多 bot 环境） | `finance` |
+| `model` | 裸模型 ID（去掉厂商前缀） | `gpt-5.4` |
+| `context_pct` | 上次调用的上下文占用百分比 | `5%` |
+| `latency` | 本轮次墙钟耗时 | `22s`、`1m05s` |
+| `cwd` | 相对主目录的工作目录 | `~` |
+
+默认字段集为 `["model", "context_pct", "cwd"]`。`latency` 为可选字段——加入
+`fields` 即可启用。数据不可用的字段会被静默跳过，不会渲染空位。
+
+`bot` 字段显示服务该轮次的 profile（解析顺序：来源的 profile 上下文——
+`source.profile` → profile 路由 → 当前激活 profile）。如需显示自定义名称
+而非 profile 名，可设置 `display.runtime_footer.bot_name`（也支持
+`display.platforms.<platform>.runtime_footer.bot_name` 每平台覆盖）：
+
+```yaml
+display:
+  runtime_footer:
+    enabled: true
+    fields: ["bot", "model", "context_pct"]
+    bot_name: "Jimmy_Fin_bot"
+```
+
 `/footer` 斜杠命令在任何会话中运行时切换此功能。
 
 附加到 Telegram/Discord/Slack 回复的示例页脚：


### PR DESCRIPTION
## Problem

For multi-bot fleet deployments (several Hermes profiles/gateways in the same
chat), the gateway runtime footer (`display.runtime_footer`) cannot identify
which bot produced a reply when all profiles pin the same model. Operators
must check sender metadata to attribute replies.

## Change

Add an opt-in `bot` runtime-footer field that renders the active Hermes
profile name. The profile is resolved from the turn's source context
(`source.profile` → profile routing → active profile), so multiplexed
gateways render the correct identity per turn — not a process-global value.

- `gateway/runtime_footer.py`: `build_footer_line()` takes an explicit
  `profile` kwarg; `display.runtime_footer.bot_name` still overrides the
  rendered label.
- `gateway/run.py`: `_footer_profile_label()` follows the same resolution
  order as `_resolve_profile_home_for_source` and never raises (footer
  rendering can never be blocked by routing state).
- docs (en + zh-Hans): document the new field and `bot_name` override.

## Verification

- `pytest tests/gateway/test_runtime_footer.py` — 39 passed
- `git diff origin/main...HEAD --check` — clean

## Relationship to other PRs

Complements #95135 (adds the `provider` field to the same footer). This PR is
the narrower, independent half (bot identity only); both apply cleanly on top
of each other.
