### PR TITLE
fix(background-review): inject skill-creation hard rules (desc≤60, no near-duplicates)

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -612,6 +612,25 @@ _SKILL_REVIEW_PROMPT = (
     "Otherwise, act."
 )
 
+# 声明于两条技能 review prompt 末尾的技能创建硬规则（后台 review 低注意预算——
+# 以独立标注块追加，便于模型在 create 前识别）。
+_SKILL_CREATION_RULES = (
+    "\n\n---\n"
+    "SKILL CREATION RULES — read before any skill_manage(action='create'):\n"
+    "  • DESCRIPTION must be <=60 chars (one sentence, end with a period). The "
+    "skill index truncates at 60 and silently drops the rest — COUNT the chars "
+    "and cut. If skill_manage returns 'Description exceeds...'/'must fit the "
+    "60-char budget', SHORTEN the description and retry the SAME skill — do "
+    "NOT retry with a renamed skill to dodge the error.\n"
+    "  • FOLD-IN, DON'T DUPLICATE. If an existing skill already covers this "
+    "class (including one whose name has a path prefix, e.g. "
+    "'web3/audit-v3-workflow/using-audit-v3-workflow' vs 'using-audit-v3-"
+    "workflow'), PATCH or extend it instead of creating a near-duplicate. "
+    "Only create when NO skill (matching by normalized name) exists. If you "
+    "spot overlapping skills, note it for the curator; never create a third.\n"
+)
+_SKILL_REVIEW_PROMPT += _SKILL_CREATION_RULES
+
 _COMBINED_REVIEW_PROMPT = (
     "Review the conversation above and update two things:\n\n"
     "**Memory**: who the user is. Did the user reveal persona, "
@@ -723,6 +742,7 @@ _COMBINED_REVIEW_PROMPT = (
     "genuinely nothing stands out on either, say 'Nothing to save.' "
     "and stop — but don't reach for that conclusion as a default."
 )
+_COMBINED_REVIEW_PROMPT += _SKILL_CREATION_RULES
 
 
 


### PR DESCRIPTION
## Problem

The background review forks (`agent/background_review.py`) autonomously create/update skills after a turn, but their prompts carried **no explicit skill-authoring constraints**. Two recurring failure modes resulted:

### 1. Descriptions > 60 chars — repeated hard-validation wall
The skill index truncates every skill's `description` to 60 chars in the system prompt and silently drops the rest, yet no review prompt told the fork to keep the description within that budget. The fork writes an over-long description and hits `skill_manage`'s hard validation error (`skill_manager_tool._validate_frontmatter`, `Description must fit the 60-char budget`). It often then "works around" the error by **renaming the skill and retrying**, which yields a *different* near-duplicate skill instead of simply shortening the description.

### 2. Near-duplicate skills because dedup only matches exact directory name
`_create_skill()` dedupes on exact directory name only (`skill_manager_tool._find_skill`). When a fork proposes a skill whose `name` carries a path prefix (e.g. `web3/audit-v3-workflow/using-audit-v3-workflow` vs `using-audit-v3-workflow`), the name mismatch defeats dedup and a second overlapping skill is created for the same class.

## Fix

Added `_SKILL_CREATION_RULES`, a short shared block in `agent/background_review.py` that pins both rules, and appended it to **both** `_SKILL_REVIEW_PROMPT` and `_COMBINED_REVIEW_PROMPT` so the guidance is present on every background-review path (memory-only review is left untouched):

- **Description must be ≤ 60 chars** — if `skill_manage` returns the 60-char budget error, shorten the description and retry the **same** skill; do NOT retry with a renamed skill to dodge the error.
- **Fold-in, don't duplicate** — if an existing skill already covers this class (including one whose name has a path prefix), PATCH/extend it instead of creating a near-duplicate; only create when no skill (matching by normalized name) exists.

The block is deliberately terse (~825 chars) because background forks run with a low attention/token budget — a full authoring-standards block would be diluted and ignored.

## Verification
- `py_compile` clean.
- Both `_SKILL_REVIEW_PROMPT` and `_COMBINED_REVIEW_PROMPT` now contain the rules; `_MEMORY_REVIEW_PROMPT` is unaffected.
- Module imports without error.
- Gateway restarted and running clean (no skill-related tracebacks).

## Notes
- Backup kept at `agent/background_review.py.bak.20260828` (not committed).
- `learning_prompt` already carries full authoring standards for the interactive `/learn` flow; this targets only the autonomous background-review path.
