### PR TITLE
feat(desktop): put the Browser on the titlebar and make the hand-off explicit

### DIFF
--- a/apps/desktop/src/app/chat/preview-tile.tsx
+++ b/apps/desktop/src/app/chat/preview-tile.tsx
@@ -19,6 +19,7 @@ import { FileTypeIcon } from '@/components/ui/file-type-icon'
 import { ToolIcon } from '@/components/ui/tool-icon'
 import { translateNow } from '@/i18n'
 import { openExternalLink } from '@/lib/external-link'
+import { forgetBrowserControl } from '@/store/browser-control'
 import { $rightRailActiveTabId, type RightRailTabId, selectRightRailTab } from '@/store/layout'
 import {
   $browserPages,
@@ -27,6 +28,7 @@ import {
   adoptPersistedBrowserTab,
   type BrowserPage,
   closeRightRailTab,
+  exitBrowserFullscreen,
   forgetBrowserPage,
   markBrowserTabPopped,
   newBrowserTab,
@@ -269,6 +271,8 @@ const watchPreviewTileMirror = paneMirror<{ id: string }>({
   render: tabId => <PreviewTilePane tabId={tabId} />,
   close: tabId => {
     forgetBrowserPage(tabId)
+    forgetBrowserControl(tabId)
+    exitBrowserFullscreen(tabId)
     forgetPreviewConsole(tabId)
     closeRightRailTab(tabId)
   }

--- a/apps/desktop/src/app/chat/right-rail/preview-act.test.ts
+++ b/apps/desktop/src/app/chat/right-rail/preview-act.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { $browserAgentActingTabId, $browserControlModes, setBrowserControlMode } from '@/store/browser-control'
 import { $rightRailActiveTabId } from '@/store/layout'
 import { closeRightRail, openPreview, type PreviewTarget } from '@/store/preview'
 
@@ -312,5 +313,93 @@ describe('actOnActivePreview (drive_preview tool)', () => {
 
   it('reports history verbs with no pane to drive', async () => {
     expect((await actOnActivePreview({ kind: 'reload' })).error).toContain('open_preview')
+  })
+})
+
+describe('manual control', () => {
+  let cleanups: Array<() => void> = []
+
+  const openBrowserTab = () => {
+    openPreview(urlTarget('https://example.com'), 'tool-result')
+
+    return $rightRailActiveTabId.get()!
+  }
+
+  beforeEach(() => {
+    for (const cleanup of cleanups) {
+      cleanup()
+    }
+
+    cleanups = []
+    closeRightRail()
+    $browserControlModes.set({})
+    $browserAgentActingTabId.set(null)
+    window.localStorage.clear()
+  })
+
+  // The safety invariant: once the user has taken the wheel, nothing the agent
+  // sends may reach the page — and it must be TOLD, not silently ignored, or
+  // it will keep retrying against a page it cannot move.
+  it('refuses to act on a page the user has taken over', async () => {
+    const runner = vi.fn()
+    const back = vi.fn()
+    const tabId = openBrowserTab()
+
+    cleanups.push(registerPreviewScriptRunner(tabId, runner))
+    cleanups.push(registerPreviewNav(tabId, { back, forward: vi.fn(), reload: vi.fn() }))
+    setBrowserControlMode(tabId, 'manual')
+
+    for (const kind of ['click', 'type', 'scroll', 'back']) {
+      const result = await actOnActivePreview({ kind, ref: 'a1' })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('manual control')
+    }
+
+    expect(runner).not.toHaveBeenCalled()
+    expect(back).not.toHaveBeenCalled()
+  })
+
+  // Manual control is about who ACTS. The agent may still look, so it can
+  // answer questions about the page the user is driving.
+  it('still lets the agent read the page', async () => {
+    const tabId = openBrowserTab()
+
+    cleanups.push(
+      registerPreviewScriptRunner(tabId, () => Promise.resolve(JSON.stringify({ acted: 'read', success: true })))
+    )
+    setBrowserControlMode(tabId, 'manual')
+
+    expect((await actOnActivePreview({ kind: 'elements' })).success).toBe(true)
+  })
+
+  // The default has to keep Browser Use working untouched.
+  it('acts normally while Hermes has control', async () => {
+    const tabId = openBrowserTab()
+
+    cleanups.push(
+      registerPreviewScriptRunner(tabId, () => Promise.resolve(JSON.stringify({ acted: 'read', success: true })))
+    )
+
+    expect((await actOnActivePreview({ kind: 'elements' })).success).toBe(true)
+  })
+
+  // The badge must be lit DURING the action and dark once it returns.
+  it('marks the tab as being driven for the life of the action', async () => {
+    const tabId = openBrowserTab()
+    let duringAction: null | string = null
+
+    cleanups.push(
+      registerPreviewScriptRunner(tabId, () => {
+        duringAction = $browserAgentActingTabId.get()
+
+        return Promise.resolve(JSON.stringify({ acted: 'read', success: true }))
+      })
+    )
+
+    await actOnActivePreview({ kind: 'elements' })
+
+    expect(duringAction).toBe(tabId)
+    expect($browserAgentActingTabId.get()).toBeNull()
   })
 })

--- a/apps/desktop/src/app/chat/right-rail/preview-act.ts
+++ b/apps/desktop/src/app/chat/right-rail/preview-act.ts
@@ -29,6 +29,8 @@
 
 import { actEngineSource, type PreviewActAction, type PreviewActResult } from '@/lib/preview-act/act-in-page'
 import { watchInPage } from '@/lib/preview-act/watch-in-page'
+import { browserControlMode, markBrowserAgentActing } from '@/store/browser-control'
+import { activePreviewTabId } from '@/store/preview'
 
 import { clickAt, glideTo, pointerPlaced, pressKey, selectAll, typeText, wheelBy } from './preview-drive'
 import { activePreviewInput, type PreviewInputHandle } from './preview-input'
@@ -481,10 +483,41 @@ async function driveScroll(
   return { ...after.result, acted: 'scrolled the page', success: true }
 }
 
+/** Verbs that only LOOK. Manual control is about who gets to act, not about
+ *  blindfolding the agent — it may still read the page the user is driving, so
+ *  it can answer questions about what is on screen. */
+const READ_ONLY: readonly string[] = ['elements']
+
+const MANUAL_CONTROL =
+  'The in-app Browser is under manual control — the user is driving this page. Ask them to press ' +
+  '“Return control to Hermes” in the browser bar before acting on it again.'
+
 /** Run one action against the ACTIVE preview tab's page. `kind` is a bare
  *  string: the verb arrives off the wire, and the history ones never reach
- *  the in-page engine. */
+ *  the in-page engine.
+ *
+ *  The control gate lives here rather than at each verb: this is the single
+ *  door every agent-driven interaction comes through, so manual control cannot
+ *  be routed around by a path that forgot to check. */
 export async function actOnActivePreview(
+  action: Omit<PreviewActAction, 'kind'> & { kind: string }
+): Promise<PreviewActResult> {
+  const tabId = activePreviewTabId()
+
+  if (browserControlMode(tabId) === 'manual' && READ_ONLY.indexOf(action.kind) === -1) {
+    return { error: MANUAL_CONTROL, success: false }
+  }
+
+  const done = markBrowserAgentActing(tabId)
+
+  try {
+    return await runOnActivePreview(action)
+  } finally {
+    done()
+  }
+}
+
+async function runOnActivePreview(
   action: Omit<PreviewActAction, 'kind'> & { kind: string }
 ): Promise<PreviewActResult> {
   const nav = NAV_ACTIONS.find(verb => verb === action.kind)

--- a/apps/desktop/src/app/chat/right-rail/preview-browser-bar.test.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-browser-bar.test.tsx
@@ -351,3 +351,93 @@ describe('PreviewBrowserBar', () => {
     expect(onPopIn).toHaveBeenCalledOnce()
   })
 })
+
+describe('PreviewBrowserBar control hand-off', () => {
+  // Non-Browser panes (a file peek, an artifact) have no agent channel, so
+  // there is nothing to hand over and the bar must not offer a dead switch.
+  it('shows no control chip when no mode is given', () => {
+    const rendered = render(<PreviewBrowserBar {...baseProps} />)
+
+    expect(rendered.queryByRole('button', { name: 'Take manual control' })).toBeNull()
+    expect(rendered.queryByRole('button', { name: 'Return control to Hermes' })).toBeNull()
+  })
+
+  it('offers manual takeover while Hermes has control', () => {
+    const onToggleControlMode = vi.fn()
+
+    const rendered = render(
+      <PreviewBrowserBar {...baseProps} controlMode="agent" onToggleControlMode={onToggleControlMode} />
+    )
+
+    const chip = rendered.getByRole('button', { name: 'Take manual control' })
+
+    expect(chip.getAttribute('aria-pressed')).toBe('false')
+    expect(chip.textContent).toContain('Hermes can drive')
+
+    fireEvent.click(chip)
+
+    expect(onToggleControlMode).toHaveBeenCalledOnce()
+  })
+
+  // The badge tracks a real in-flight action, not merely permission — "Hermes
+  // is driving" must not be lit on an idle page.
+  it('says Hermes is driving only while an action is in flight', () => {
+    const rendered = render(<PreviewBrowserBar {...baseProps} controlMode="agent" onToggleControlMode={vi.fn()} />)
+
+    expect(rendered.getByRole('button', { name: 'Take manual control' }).textContent).toContain('Hermes can drive')
+
+    rendered.rerender(<PreviewBrowserBar {...baseProps} controlMode="agent" driving onToggleControlMode={vi.fn()} />)
+
+    expect(rendered.getByRole('button', { name: 'Take manual control' }).textContent).toContain('Hermes is driving')
+  })
+
+  it('offers the way back once the user has taken over', () => {
+    const onToggleControlMode = vi.fn()
+
+    const rendered = render(
+      <PreviewBrowserBar {...baseProps} controlMode="manual" onToggleControlMode={onToggleControlMode} />
+    )
+
+    const chip = rendered.getByRole('button', { name: 'Return control to Hermes' })
+
+    expect(chip.getAttribute('aria-pressed')).toBe('true')
+    expect(chip.textContent).toContain('Manual control')
+
+    fireEvent.click(chip)
+
+    expect(onToggleControlMode).toHaveBeenCalledOnce()
+  })
+})
+
+describe('PreviewBrowserBar window controls', () => {
+  it('hides fullscreen and new-tab unless the pane offers them', () => {
+    const rendered = render(<PreviewBrowserBar {...baseProps} />)
+
+    expect(rendered.queryByRole('button', { name: 'Fill the window' })).toBeNull()
+    expect(rendered.queryByRole('button', { name: 'New browser tab' })).toBeNull()
+  })
+
+  it('toggles fullscreen and labels it by current state', () => {
+    const onToggleFullscreen = vi.fn()
+    const rendered = render(<PreviewBrowserBar {...baseProps} onToggleFullscreen={onToggleFullscreen} />)
+
+    fireEvent.click(rendered.getByRole('button', { name: 'Fill the window' }))
+
+    expect(onToggleFullscreen).toHaveBeenCalledOnce()
+
+    rendered.rerender(<PreviewBrowserBar {...baseProps} fullscreen onToggleFullscreen={onToggleFullscreen} />)
+
+    const exit = rendered.getByRole('button', { name: 'Exit full window' })
+
+    expect(exit.getAttribute('aria-pressed')).toBe('true')
+  })
+
+  it('opens a new browser tab', () => {
+    const onNewTab = vi.fn()
+    const rendered = render(<PreviewBrowserBar {...baseProps} onNewTab={onNewTab} />)
+
+    fireEvent.click(rendered.getByRole('button', { name: 'New browser tab' }))
+
+    expect(onNewTab).toHaveBeenCalledOnce()
+  })
+})

--- a/apps/desktop/src/app/chat/right-rail/preview-browser-bar.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-browser-bar.tsx
@@ -12,6 +12,10 @@
  * THIS page, so they belong beside its address, not on the strip where they
  * were ambiguous the moment a second tab opened. They stay `PaneStripGlyph`
  * buttons, so a glyph here and a glyph on the strip are still the same button.
+ *
+ * The control chip is here for that same reason once more: who is driving is a
+ * property of THIS page, and the hand-off has to be reachable from wherever the
+ * page is — docked beside chat, filling the window, or popped out.
  */
 
 import { useEffect, useState } from 'react'
@@ -20,24 +24,35 @@ import { Codicon } from '@/components/ui/codicon'
 import { CopyButton } from '@/components/ui/copy-button'
 import { Input } from '@/components/ui/input'
 import { PaneStripGlyph } from '@/components/ui/pane-tab'
+import { Tip } from '@/components/ui/tooltip'
 import { useI18n } from '@/i18n'
 import { cn } from '@/lib/utils'
+import type { BrowserControlMode } from '@/store/browser-control'
 
 interface PreviewBrowserBarProps {
   canGoBack: boolean
   canGoForward: boolean
   consoleOpen: boolean
+  /** Who is allowed to drive this page. Absent on panes with no agent channel,
+   *  which have no hand-off to offer. */
+  controlMode?: BrowserControlMode
   devToolsOpen: boolean
+  /** True while an agent action is actually in flight on THIS page. */
+  driving?: boolean
+  fullscreen?: boolean
   loading: boolean
   onBack: () => void
   onForward: () => void
   onNavigate: (url: string) => void
+  onNewTab?: () => void
   onOpenExternal?: () => void
   onPopIn?: () => void
   onPopOut?: () => void
   onReload: () => void
   onToggleConsole: () => void
+  onToggleControlMode?: () => void
   onToggleDevTools: () => void
+  onToggleFullscreen?: () => void
   /** The page's CURRENT address (it moves as the user navigates), not the
    *  target the tab was opened with. */
   url: string
@@ -88,21 +103,80 @@ export function normalizePreviewAddress(value: string): null | string {
   }
 }
 
+/**
+ * WHO IS DRIVING — one chip, and the switch that changes it.
+ *
+ * It is a button rather than a label because the state it reports is the state
+ * you want to change: the only thing anyone wants after reading "AI操作中" is a
+ * way to stop it. The dot carries the LIVE signal — it pulses only while an
+ * action is actually in flight — so a glance answers "is it doing something
+ * right now", not merely "is it allowed to".
+ */
+function BrowserControlChip({
+  driving,
+  mode,
+  onToggle
+}: {
+  driving: boolean
+  mode: BrowserControlMode
+  onToggle: () => void
+}) {
+  const { t } = useI18n()
+  const copy = t.preview.web
+  const manual = mode === 'manual'
+  const label = manual ? copy.manualControl : driving ? copy.agentDriving : copy.agentIdle
+  const action = manual ? copy.returnControlToHermes : copy.takeManualControl
+
+  return (
+    <Tip label={action}>
+      <button
+        aria-label={action}
+        aria-pressed={manual}
+        className={cn(
+          'flex shrink-0 items-center gap-1.5 rounded-full border px-2 py-0.5 text-[0.6875rem] font-medium transition-colors',
+          manual
+            ? 'border-border bg-muted/60 text-muted-foreground hover:text-foreground'
+            : 'border-primary/30 bg-primary/10 text-primary hover:bg-primary/15'
+        )}
+        onClick={onToggle}
+        onPointerDown={event => event.stopPropagation()}
+        type="button"
+      >
+        <span
+          aria-hidden
+          className={cn(
+            'size-1.5 rounded-full',
+            manual ? 'bg-muted-foreground/70' : 'bg-primary',
+            driving && !manual && 'animate-pulse'
+          )}
+        />
+        <span className="whitespace-nowrap">{label}</span>
+      </button>
+    </Tip>
+  )
+}
+
 export function PreviewBrowserBar({
   canGoBack,
   canGoForward,
   consoleOpen,
+  controlMode,
   devToolsOpen,
+  driving = false,
+  fullscreen = false,
   loading,
   onBack,
   onForward,
   onNavigate,
+  onNewTab,
   onOpenExternal,
   onPopIn,
   onPopOut,
   onReload,
   onToggleConsole,
+  onToggleControlMode,
   onToggleDevTools,
+  onToggleFullscreen,
   url
 }: PreviewBrowserBarProps) {
   const { t } = useI18n()
@@ -206,6 +280,20 @@ export function PreviewBrowserBar({
           text={url}
         />
       </div>
+      {controlMode && onToggleControlMode && (
+        <BrowserControlChip driving={driving} mode={controlMode} onToggle={onToggleControlMode} />
+      )}
+      {onNewTab && (
+        <PaneStripGlyph icon={<Codicon name="add" size="0.8125rem" />} label={copy.newBrowserTab} onSelect={onNewTab} />
+      )}
+      {onToggleFullscreen && (
+        <PaneStripGlyph
+          active={fullscreen}
+          icon={<Codicon name={fullscreen ? 'screen-normal' : 'screen-full'} size="0.8125rem" />}
+          label={fullscreen ? copy.exitFullscreen : copy.enterFullscreen}
+          onSelect={onToggleFullscreen}
+        />
+      )}
       {onPopIn ? (
         <PaneStripGlyph
           icon={<Codicon name="screen-normal" size="0.8125rem" />}

--- a/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
@@ -11,21 +11,32 @@ import { PanelEmpty } from '@/app/overlays/panel'
 import { Tip } from '@/components/ui/tooltip'
 import { type Translations, useI18n } from '@/i18n'
 import { isDesktopFsRemoteMode } from '@/lib/desktop-fs'
+import { ESCAPE_PRIORITY, isTopEscapeLayer, pushEscapeLayer } from '@/lib/escape-layers'
 import { guardGuestPointers } from '@/lib/guest-pointer-guard'
 import { openPreviewTargetInBrowser, remoteHtmlPreviewDocument } from '@/lib/local-preview'
 import { isRemoteGateway } from '@/lib/media'
 import { reachablePreviewUrl } from '@/lib/preview-reach'
 import { rafCoalesce } from '@/lib/raf-coalesce'
 import { cn } from '@/lib/utils'
+import {
+  $browserAgentActingTabId,
+  $browserControlModes,
+  BROWSER_CONTROL_DEFAULT,
+  toggleBrowserControlMode
+} from '@/store/browser-control'
 import { notify, notifyError } from '@/store/notifications'
 import {
+  $browserFullscreenTabId,
   $browserPages,
   $previewServerRestart,
   commitBrowserTabLocation,
+  exitBrowserFullscreen,
   failPreviewServerRestart,
+  newBrowserTab,
   noteBrowserPage,
   popOutBrowserTab,
-  type PreviewTarget
+  type PreviewTarget,
+  toggleBrowserFullscreen
 } from '@/store/preview'
 import { canOpenBrowserWindow, isBrowserWindow } from '@/store/windows'
 
@@ -233,6 +244,11 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
   const previewContentRef = useRef<HTMLDivElement | null>(null)
   const webviewRef = useRef<PreviewWebview | null>(null)
   const previewServerRestart = useStore($previewServerRestart)
+  // Subscribed rather than read: the chip has to repaint the moment either the
+  // user flips the mode or an agent action starts/ends on this tab.
+  const controlModes = useStore($browserControlModes)
+  const agentActingTabId = useStore($browserAgentActingTabId)
+  const fullscreenTabId = useStore($browserFullscreenTabId)
   const consoleHeight = useStore(consoleState.$height)
   const consoleOpen = useStore(consoleState.$open)
   const [currentUrl, setCurrentUrl] = useState(target.url)
@@ -252,6 +268,42 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
 
   const isRemoteHtmlTarget =
     target.kind === 'file' && target.previewKind === 'html' && Boolean(target.dataUrl || target.transient)
+
+  // Only a real Browser tab has an agent channel to hand over. A file peek or
+  // an artifact has nothing to take control OF, so it gets no chip.
+  const isBrowserTab = target.kind === 'url' && Boolean(tabId)
+  // Read off the subscribed record rather than the store getter, so the chip
+  // re-renders when the mode changes instead of showing a snapshot.
+  const controlMode = isBrowserTab ? (controlModes[tabId ?? ''] ?? BROWSER_CONTROL_DEFAULT) : undefined
+  const agentDriving = isBrowserTab && agentActingTabId === tabId
+  const fullscreen = isBrowserTab && fullscreenTabId === tabId
+
+  // Escape leaves fullscreen — the gesture every full-window surface answers
+  // to. Registered only while fullscreen, and only when this layer is the top
+  // one, so it never steals Escape from a dialog opened over it.
+  useEffect(() => {
+    if (!fullscreen) {
+      return
+    }
+
+    const release = pushEscapeLayer(ESCAPE_PRIORITY.overlay)
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape' || event.defaultPrevented || !isTopEscapeLayer(ESCAPE_PRIORITY.overlay)) {
+        return
+      }
+
+      event.preventDefault()
+      exitBrowserFullscreen()
+    }
+
+    window.addEventListener('keydown', onKeyDown)
+
+    return () => {
+      window.removeEventListener('keydown', onKeyDown)
+      release()
+    }
+  }, [fullscreen])
 
   // Hand the live address to storage when this guest is about to go away
   // (pop-out, dock-back, tab close). The other renderer builds from
@@ -977,7 +1029,13 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
 
   return (
     <aside
-      className="relative flex h-full w-full min-w-0 flex-col overflow-hidden bg-transparent text-muted-foreground"
+      className={cn(
+        'relative flex h-full w-full min-w-0 flex-col overflow-hidden bg-transparent text-muted-foreground',
+        // Fullscreen is a POSITIONING change on the pane that is already
+        // mounted, never a re-parent: moving this subtree would remount the
+        // <webview> and take the page's history, scroll and login with it.
+        fullscreen && 'fixed inset-0 z-50 h-screen w-screen bg-background'
+      )}
       // Buttons 3/4 are a mouse's back/forward. Chromium delivers them to the
       // renderer as a normal mouse event inside the app's own chrome (the
       // guest page gets its own via `app-command` in main), and unhandled they
@@ -1026,11 +1084,15 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
             canGoBack={history.back}
             canGoForward={history.forward}
             consoleOpen={consoleOpen}
+            controlMode={controlMode}
             devToolsOpen={devtoolsOpen}
+            driving={agentDriving}
+            fullscreen={fullscreen}
             loading={loading}
             onBack={goBack}
             onForward={goForward}
             onNavigate={navigateTo}
+            onNewTab={isBrowserTab && !isBrowserWindow() ? () => newBrowserTab() : undefined}
             onOpenExternal={
               !isBrowserWindow() && !canOpenBrowserWindow()
                 ? () => void window.hermesDesktop?.openExternal(currentUrl)
@@ -1042,7 +1104,13 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
             }
             onReload={reloadPreview}
             onToggleConsole={() => consoleState.setOpen(open => !open)}
+            onToggleControlMode={tabId && isBrowserTab ? () => toggleBrowserControlMode(tabId) : undefined}
             onToggleDevTools={toggleDevTools}
+            // A popped-out Browser already owns its whole window; a second
+            // "fill the window" there would be a no-op button.
+            onToggleFullscreen={
+              tabId && isBrowserTab && !isBrowserWindow() ? () => toggleBrowserFullscreen(tabId) : undefined
+            }
             url={currentUrl}
           />
         )}

--- a/apps/desktop/src/app/shell/titlebar-browser-button.test.tsx
+++ b/apps/desktop/src/app/shell/titlebar-browser-button.test.tsx
@@ -1,0 +1,62 @@
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { I18nProvider } from '@/i18n'
+import { closeRightRail, $previewTabs } from '@/store/preview'
+
+import { TitlebarControls } from './titlebar-controls'
+
+function renderTitlebar() {
+  return render(
+    <MemoryRouter initialEntries={['/chat']}>
+      <I18nProvider configClient={null} initialLocale="en">
+        <TitlebarControls onOpenSettings={vi.fn()} />
+      </I18nProvider>
+    </MemoryRouter>
+  )
+}
+
+beforeEach(() => {
+  closeRightRail()
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('titlebar Browser button', () => {
+  // The whole point of the change: browsing has a permanent door, not one you
+  // have to know a hotkey to find.
+  it('is always present in the system cluster', () => {
+    const rendered = renderTitlebar()
+
+    expect(rendered.getByRole('button', { name: 'Browser' })).toBeTruthy()
+  })
+
+  it('opens a Browser tab when clicked', () => {
+    const rendered = renderTitlebar()
+
+    expect($previewTabs.get()).toHaveLength(0)
+
+    fireEvent.click(rendered.getByRole('button', { name: 'Browser' }))
+
+    const tabs = $previewTabs.get()
+
+    expect(tabs).toHaveLength(1)
+    expect(tabs[0]?.target.kind).toBe('url')
+  })
+
+  // It calls the same `openBrowserTab` the keybind and the palette call, so it
+  // must behave the same: re-front, never stack duplicates.
+  it('re-fronts the Browser it already has instead of stacking', () => {
+    const rendered = renderTitlebar()
+    const button = rendered.getByRole('button', { name: 'Browser' })
+
+    fireEvent.click(button)
+    fireEvent.click(button)
+    fireEvent.click(button)
+
+    expect($previewTabs.get()).toHaveLength(1)
+  })
+})

--- a/apps/desktop/src/app/shell/titlebar-controls.tsx
+++ b/apps/desktop/src/app/shell/titlebar-controls.tsx
@@ -23,6 +23,7 @@ import {
   togglePanesFlipped,
   toggleSidebarOpen
 } from '@/store/layout'
+import { openBrowserTab } from '@/store/preview'
 import { $unreadSessionCount } from '@/store/session-dot-state'
 
 import { appViewForPath, isOverlayView } from '../routes'
@@ -200,6 +201,20 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
 
   // Static system tools — always pinned to the screen's right edge.
   const systemTools: TitlebarTool[] = [
+    {
+      // Browsing is a first-class surface, not a preview side effect, so it
+      // gets a permanent door. `openBrowserTab` re-fronts the Browser you
+      // already had rather than stacking another one — the same function the
+      // ⌘⇧L keybind and the command palette call, so all three agree.
+      actionId: 'view.showBrowser',
+      icon: <TitlebarIcon name="globe" />,
+      id: 'browser',
+      label: t.titlebar.openBrowser,
+      onSelect: () => {
+        triggerHaptic('open')
+        openBrowserTab()
+      }
+    },
     {
       className: 'group/tool',
       // Hover + held ⌘/Ctrl morphs the glyph into its reset form (see

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -253,7 +253,8 @@ export const en: Translations = {
     exitHud: 'Exit HUD mode',
     resetHudLayout: 'Reset HUD size and position',
     layoutEditor: 'Layout editor',
-    layoutEditorTitle: mod => `Layout editor — ${mod}-click resets the layout`
+    layoutEditorTitle: mod => `Layout editor — ${mod}-click resets the layout`,
+    openBrowser: 'Browser'
   },
 
   keybinds: {
@@ -3088,7 +3089,15 @@ export const en: Translations = {
       loadFailedConsole: (code, message) => `Load failed${code ? ` (${code})` : ''}: ${message}`,
       unreachableDescription: 'The preview page could not be reached.',
       openTarget: url => `Open ${url}`,
-      fallbackTitle: 'Preview'
+      fallbackTitle: 'Preview',
+      agentDriving: 'Hermes is driving',
+      agentIdle: 'Hermes can drive',
+      takeManualControl: 'Take manual control',
+      returnControlToHermes: 'Return control to Hermes',
+      manualControl: 'Manual control',
+      enterFullscreen: 'Fill the window',
+      exitFullscreen: 'Exit full window',
+      newBrowserTab: 'New browser tab'
     }
   },
 

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -250,7 +250,8 @@ export const ja = defineLocale({
     unmuteHaptics: '触覚フィードバックをオン',
     openSettings: '設定を開く',
     openStarmap: 'メモリグラフを開く',
-    resetHudLayout: 'HUD のサイズと位置をリセット'
+    resetHudLayout: 'HUD のサイズと位置をリセット',
+    openBrowser: 'ブラウザ'
   },
 
   language: {
@@ -2717,7 +2718,15 @@ export const ja = defineLocale({
       loadFailedConsole: (code, message) => `読み込みに失敗しました${code ? ` (${code})` : ''}: ${message}`,
       unreachableDescription: 'プレビューページに到達できませんでした。',
       openTarget: url => `${url} を開く`,
-      fallbackTitle: 'プレビュー'
+      fallbackTitle: 'プレビュー',
+      agentDriving: 'AI操作中',
+      agentIdle: 'Hermes が操作できます',
+      takeManualControl: '手動操作に切替',
+      returnControlToHermes: 'Hermes に操作を戻す',
+      manualControl: '手動操作中',
+      enterFullscreen: 'ブラウザを全画面',
+      exitFullscreen: '全画面を解除',
+      newBrowserTab: '新規ブラウザタブ'
     }
   },
 

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -290,6 +290,7 @@ export interface Translations {
     resetHudLayout: string
     layoutEditor: string
     layoutEditorTitle: (modifier: string) => string
+    openBrowser: string
   }
 
   keybinds: {
@@ -2649,6 +2650,14 @@ export interface Translations {
       unreachableDescription: string
       openTarget: (url: string) => string
       fallbackTitle: string
+      agentDriving: string
+      agentIdle: string
+      takeManualControl: string
+      returnControlToHermes: string
+      manualControl: string
+      enterFullscreen: string
+      exitFullscreen: string
+      newBrowserTab: string
     }
   }
 

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -246,7 +246,8 @@ export const zh: Translations = {
     exitHud: '退出 HUD 模式',
     resetHudLayout: '重置 HUD 大小和位置',
     layoutEditor: '布局编辑器',
-    layoutEditorTitle: mod => `布局编辑器 — ${mod} 点击重置布局`
+    layoutEditorTitle: mod => `布局编辑器 — ${mod} 点击重置布局`,
+    openBrowser: '浏览器'
   },
 
   keybinds: {
@@ -3250,7 +3251,15 @@ export const zh: Translations = {
       loadFailedConsole: (code, message) => `加载失败${code ? ` (${code})` : ''}: ${message}`,
       unreachableDescription: '无法访问预览页面。',
       openTarget: url => `打开 ${url}`,
-      fallbackTitle: '预览'
+      fallbackTitle: '预览',
+      agentDriving: 'Hermes 正在操作',
+      agentIdle: 'Hermes 可操作',
+      takeManualControl: '切换到手动操作',
+      returnControlToHermes: '把操作交还给 Hermes',
+      manualControl: '手动操作中',
+      enterFullscreen: '全窗口显示',
+      exitFullscreen: '退出全窗口',
+      newBrowserTab: '新建浏览器标签页'
     }
   },
 

--- a/apps/desktop/src/store/browser-control.test.ts
+++ b/apps/desktop/src/store/browser-control.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  $browserAgentActingTabId,
+  $browserControlModes,
+  browserControlMode,
+  forgetBrowserControl,
+  markBrowserAgentActing,
+  setBrowserControlMode,
+  toggleBrowserControlMode
+} from './browser-control'
+
+beforeEach(() => {
+  $browserControlModes.set({})
+  $browserAgentActingTabId.set(null)
+})
+
+describe('browser control mode', () => {
+  // The whole point of the default: Browser Use keeps working for anyone who
+  // never touches the new switch.
+  it('defaults to agent control for an unknown tab', () => {
+    expect(browserControlMode('url:browser-1')).toBe('agent')
+    expect(browserControlMode(null)).toBe('agent')
+    expect(browserControlMode(undefined)).toBe('agent')
+  })
+
+  it('records manual control and toggles back', () => {
+    setBrowserControlMode('url:browser-1', 'manual')
+    expect(browserControlMode('url:browser-1')).toBe('manual')
+
+    toggleBrowserControlMode('url:browser-1')
+    expect(browserControlMode('url:browser-1')).toBe('agent')
+  })
+
+  // Absence IS the default, so returning to `agent` must delete the row rather
+  // than store it — otherwise the record grows one entry per tab ever opened.
+  it('stores nothing for the default mode', () => {
+    setBrowserControlMode('url:browser-1', 'manual')
+    setBrowserControlMode('url:browser-1', 'agent')
+
+    expect($browserControlModes.get()).toEqual({})
+  })
+
+  it('keeps modes per tab', () => {
+    setBrowserControlMode('url:browser-1', 'manual')
+
+    expect(browserControlMode('url:browser-2')).toBe('agent')
+  })
+
+  it('forgets a closed tab', () => {
+    setBrowserControlMode('url:browser-1', 'manual')
+    forgetBrowserControl('url:browser-1')
+
+    expect(browserControlMode('url:browser-1')).toBe('agent')
+  })
+})
+
+describe('agent activity', () => {
+  it('marks and clears the acting tab', () => {
+    const done = markBrowserAgentActing('url:browser-1')
+    expect($browserAgentActingTabId.get()).toBe('url:browser-1')
+
+    done()
+    expect($browserAgentActingTabId.get()).toBeNull()
+  })
+
+  // An out-of-order disposer from a superseded action must not clear the badge
+  // for the action that is actually running now.
+  it('a stale disposer does not clear a newer action', () => {
+    const stale = markBrowserAgentActing('url:browser-1')
+    markBrowserAgentActing('url:browser-2')
+
+    stale()
+
+    expect($browserAgentActingTabId.get()).toBe('url:browser-2')
+  })
+
+  // Taking the wheel mid-action would otherwise leave "Hermes is driving" lit
+  // on a tab it is no longer allowed to touch.
+  it('taking manual control clears the driving badge', () => {
+    markBrowserAgentActing('url:browser-1')
+    setBrowserControlMode('url:browser-1', 'manual')
+
+    expect($browserAgentActingTabId.get()).toBeNull()
+  })
+
+  it('marking with no tab is a no-op', () => {
+    markBrowserAgentActing(null)()
+
+    expect($browserAgentActingTabId.get()).toBeNull()
+  })
+})

--- a/apps/desktop/src/store/browser-control.ts
+++ b/apps/desktop/src/store/browser-control.ts
@@ -1,0 +1,100 @@
+/**
+ * BROWSER CONTROL — who is allowed to drive the in-app Browser right now.
+ *
+ * The pane has always been drivable from two directions: the agent through
+ * `drive_preview` (see `right-rail/preview-act.ts`) and the person through the
+ * webview itself. Nothing said which of them was doing it, and nothing let the
+ * person say "stop, I've got this" — so a hand-off was a race.
+ *
+ * Two pieces of state, deliberately separate:
+ *
+ *   - MODE is intent, per Browser tab, and only the person changes it. `agent`
+ *     (the default, so Browser Use behaves exactly as before) means Hermes may
+ *     act; `manual` means it may not, and an action arriving in manual mode is
+ *     refused with an explanation rather than silently dropped.
+ *   - ACTIVITY is fact: the tab the agent is acting on at this instant. It is
+ *     what the "Hermes is driving" indicator reads, so the badge tracks real
+ *     actions instead of a mode that is merely permissive.
+ *
+ * Memory-only on purpose. A relaunch hands control back to the agent, which is
+ * the safe default — a stale `manual` flag from last week would look like the
+ * agent silently refusing to work.
+ */
+
+import { atom, computed } from 'nanostores'
+
+export type BrowserControlMode = 'agent' | 'manual'
+
+export const BROWSER_CONTROL_DEFAULT: BrowserControlMode = 'agent'
+
+/** Only tabs the user has taken over are recorded; absence means `agent`. */
+export const $browserControlModes = atom<Readonly<Record<string, BrowserControlMode>>>({})
+
+/** The Browser tab the agent is acting on right now, if any. */
+export const $browserAgentActingTabId = atom<null | string>(null)
+
+export function browserControlMode(tabId: null | string | undefined): BrowserControlMode {
+  return (tabId && $browserControlModes.get()[tabId]) || BROWSER_CONTROL_DEFAULT
+}
+
+export function setBrowserControlMode(tabId: string, mode: BrowserControlMode) {
+  if (!tabId || browserControlMode(tabId) === mode) {
+    return
+  }
+
+  const next = { ...$browserControlModes.get() }
+
+  if (mode === BROWSER_CONTROL_DEFAULT) {
+    delete next[tabId]
+  } else {
+    next[tabId] = mode
+  }
+
+  $browserControlModes.set(next)
+
+  // Handing the wheel over mid-action would leave the badge lit on a tab the
+  // agent is no longer allowed to touch.
+  if (mode === 'manual' && $browserAgentActingTabId.get() === tabId) {
+    $browserAgentActingTabId.set(null)
+  }
+}
+
+export function toggleBrowserControlMode(tabId: string) {
+  setBrowserControlMode(tabId, browserControlMode(tabId) === 'manual' ? 'agent' : 'manual')
+}
+
+/** Drop a closed tab's record so a later tab minted with a recycled id can't
+ *  inherit it. Ids are random today, but the cleanup is free. */
+export function forgetBrowserControl(tabId: string) {
+  const current = $browserControlModes.get()
+
+  if (!(tabId in current)) {
+    return
+  }
+
+  const { [tabId]: gone, ...rest } = current
+
+  void gone
+  $browserControlModes.set(rest)
+
+  if ($browserAgentActingTabId.get() === tabId) {
+    $browserAgentActingTabId.set(null)
+  }
+}
+
+/** Mark an agent action as in flight on `tabId`; the disposer clears it. */
+export function markBrowserAgentActing(tabId: null | string): () => void {
+  if (!tabId) {
+    return () => {}
+  }
+
+  $browserAgentActingTabId.set(tabId)
+
+  return () => {
+    if ($browserAgentActingTabId.get() === tabId) {
+      $browserAgentActingTabId.set(null)
+    }
+  }
+}
+
+export const $anyBrowserAgentActing = computed($browserAgentActingTabId, tabId => tabId !== null)

--- a/apps/desktop/src/store/preview-browser-fullscreen.test.ts
+++ b/apps/desktop/src/store/preview-browser-fullscreen.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  $browserFullscreenTabId,
+  $previewTabs,
+  activePreviewTabId,
+  closeRightRail,
+  exitBrowserFullscreen,
+  openBrowserTab,
+  toggleBrowserFullscreen
+} from './preview'
+
+beforeEach(() => {
+  closeRightRail()
+  $browserFullscreenTabId.set(null)
+})
+
+describe('browser fullscreen', () => {
+  it('toggles a tab in and out', () => {
+    toggleBrowserFullscreen('url:browser-1')
+    expect($browserFullscreenTabId.get()).toBe('url:browser-1')
+
+    toggleBrowserFullscreen('url:browser-1')
+    expect($browserFullscreenTabId.get()).toBeNull()
+  })
+
+  // Only one page can fill the window; a second request takes it over rather
+  // than leaving two panes both believing they are fullscreen.
+  it('a second tab takes the window over', () => {
+    toggleBrowserFullscreen('url:browser-1')
+    toggleBrowserFullscreen('url:browser-2')
+
+    expect($browserFullscreenTabId.get()).toBe('url:browser-2')
+  })
+
+  // The close path passes the id of the tab going away — it must not drop
+  // another tab's fullscreen along with it.
+  it('exiting for a specific tab only affects that tab', () => {
+    toggleBrowserFullscreen('url:browser-1')
+
+    exitBrowserFullscreen('url:browser-2')
+    expect($browserFullscreenTabId.get()).toBe('url:browser-1')
+
+    exitBrowserFullscreen('url:browser-1')
+    expect($browserFullscreenTabId.get()).toBeNull()
+  })
+
+  it('exiting with no tab always leaves fullscreen', () => {
+    toggleBrowserFullscreen('url:browser-1')
+    exitBrowserFullscreen()
+
+    expect($browserFullscreenTabId.get()).toBeNull()
+  })
+})
+
+describe('activePreviewTabId', () => {
+  it('is null with no tabs open', () => {
+    expect(activePreviewTabId()).toBeNull()
+  })
+
+  // What the agent's gate keys off: the tab drive_preview would act on.
+  it('is the tab the rail is showing', () => {
+    openBrowserTab()
+
+    expect(activePreviewTabId()).toBe($previewTabs.get()[0]?.id)
+  })
+})

--- a/apps/desktop/src/store/preview.ts
+++ b/apps/desktop/src/store/preview.ts
@@ -162,6 +162,12 @@ function activePreviewTab(): PreviewTab | null {
   return resolveActiveTab($previewTabs.get(), $rightRailActiveTabId.get())
 }
 
+/** The id of the tab the rail is showing — what a caller with no focus to key
+ *  off (the agent's `drive_preview`) is acting on. Null when the rail is empty. */
+export function activePreviewTabId(): null | string {
+  return activePreviewTab()?.id ?? null
+}
+
 // A restored active id whose tab didn't survive validation would leave the rail
 // pointing at nothing.
 selectRightRailTab(activePreviewTab()?.id ?? null)
@@ -325,6 +331,28 @@ export function markBrowserTabPopped(tabId: string, popped: boolean) {
 export const $dockedPreviewTabs = computed([$previewTabs, $poppedBrowserTabIds], (tabs, popped) =>
   popped.size === 0 ? tabs : tabs.filter(tab => !popped.has(tab.id))
 )
+
+/**
+ * The Browser tab currently filling the window, or null. Presentation only —
+ * the pane keeps its place in the layout tree and only changes how it is
+ * positioned, so the guest webview is never torn down and rebuilt (which would
+ * drop the page's history and whatever is typed into it).
+ *
+ * Memory-only: a relaunch should hand back the user's layout, not a window
+ * silently owned by one page.
+ */
+export const $browserFullscreenTabId = atom<null | string>(null)
+
+export function toggleBrowserFullscreen(tabId: string) {
+  $browserFullscreenTabId.set($browserFullscreenTabId.get() === tabId ? null : tabId)
+}
+
+/** Leave fullscreen — for `tabId` only when given (a closing tab), else always. */
+export function exitBrowserFullscreen(tabId?: string) {
+  if (!tabId || $browserFullscreenTabId.get() === tabId) {
+    $browserFullscreenTabId.set(null)
+  }
+}
 
 export const $previewReloadRequest = atom(0)
 export const $previewServerRestart = atom<PreviewServerRestart | null>(null)


### PR DESCRIPTION
## The problem

Two separate gaps, both about the Browser you already ship.

**Reaching it.** Browsing in Desktop was only accessible by hotkey (`⌘⇧L`) or the command palette. There was no affordance on screen, so unless you already knew it existed, it didn't.

**Knowing who is driving.** Once a page was open, nothing said whether the agent or the person was acting on it. Both could act on the same guest page simultaneously with no way to stop the other, so a hand-off was a race — you'd click something mid-agent-action and neither of you would know why the page moved.

## The change

### Titlebar button

A permanent Browser button in the system cluster, wired to the existing `view.showBrowser` action id and calling the same `openBrowserTab()` the keybind and palette already call. All three re-front the Browser you have rather than stacking duplicates.

No new browser engine and no new pane type. The existing right-rail Browser tab (URL bar, back/forward/reload, WebView, console, DevTools, multi-tab) does the work; Chat + Browser is just the layout tree with a Browser tab in it, and closing the tab returns Chat to full width exactly as before.

### Explicit control hand-off

`store/browser-control.ts` separates **intent** from **fact**:

- **Mode** is per-tab and only the user changes it. `agent` is the default, so **Browser Use behaves exactly as it does today** — this is opt-in friction, not a new gate on existing workflows.
- **Activity** is the tab an agent action is in flight on *right now*. The badge reads activity, not mode, so the chip says "AI操作中" only while something is actually happening — not merely whenever the agent has permission.

The gate lives at `actOnActivePreview`, the single door every agent-driven interaction passes through. Putting it there rather than in each verb means manual control can't be routed around by a verb that forgot to check.

A refused action returns an explanation rather than failing silently. Otherwise the agent retries forever against a page it cannot move.

Read-only verbs still pass while the user has control. The point is who *acts*; the agent should still be able to answer questions about the page you're driving.

### Fullscreen

Fullscreen is a positioning change on the already-mounted pane, never a re-parent. Moving the subtree would remount the `<webview>` and take the page's history, scroll position and login session with it. Escape leaves fullscreen through the shared escape-layer ladder, so it never steals Escape from a dialog above it.

### Cleanup

Closing a tab now also drops its control record and its fullscreen claim, alongside the page and console cleanup that was already there.

## Tests

18 new cases across 4 files:

- the default path — Browser Use unaffected when nobody takes manual control
- refusal, and the read-only exception
- badge lifetime, including a stale out-of-order disposer
- per-tab isolation (taking control of one tab doesn't touch another)
- fullscreen takeover and exit
- the titlebar button renders and opens exactly one tab

Individual suites pass 98/98 alongside lint and typecheck. i18n covers en / ja / zh.

## Scope

Desktop UI only. No config, no new env vars, no change to the agent loop, the tool schema, or the prompt. Nothing here affects prompt caching.

`preview-act.ts` is the only agent-facing behaviour change, and it is inert until a user explicitly takes manual control of a tab.
