### PR TITLE
fix(tool-search): allow freeform bridge arguments

### DIFF
--- a/tests/tools/test_tool_search.py
+++ b/tests/tools/test_tool_search.py
@@ -51,6 +51,21 @@ class TestConfigParsing:
         cfg = ToolSearchConfig.from_raw(True)
         assert cfg.enabled == "auto"
 
+    def test_tool_call_bridge_allows_freeform_arguments(self):
+        from tools.tool_search import bridge_tool_schemas
+
+        tool_call = next(
+            schema for schema in bridge_tool_schemas(1)
+            if schema["function"]["name"] == "tool_call"
+        )
+        arguments = (
+            tool_call["function"]["parameters"]["properties"]["calls"]
+            ["items"]["properties"]["arguments"]
+        )
+
+        assert arguments["type"] == "object"
+        assert arguments["additionalProperties"] is True
+
 
     def test_search_limits_clamped(self):
         from tools.tool_search import ToolSearchConfig

--- a/tools/tool_search.py
+++ b/tools/tool_search.py
@@ -311,7 +311,11 @@ def bridge_tool_schemas(deferred_count: int, listing: Optional[str] = None,
                         "type": "object",
                         "properties": {
                             "name": {"type": "string", "description": "Exact tool name to invoke."},
-                            "arguments": {"type": "object", "description": "Arguments matching the tool schema."},
+                            "arguments": {
+                                "type": "object",
+                                "description": "Arguments matching the tool schema.",
+                                "additionalProperties": True,
+                            },
                         },
                         "required": ["name", "arguments"],
                     },


### PR DESCRIPTION
Closes #96610. Declare the deferred tool bridge arguments as a free-form object so schema-constrained providers preserve nested tool arguments. Adds a regression test for the bridge schema.