### PR TITLE
fix(desktop): heal SSH-only v1 connection drift into v2 registry

### DIFF
--- a/apps/desktop/electron/connection-registry.test.ts
+++ b/apps/desktop/electron/connection-registry.test.ts
@@ -1595,12 +1595,11 @@ test('drift heal respects a deliberate primary pick on a registered route', () =
   assert.equal(drifted.registry.primary, LOCAL_CONNECTION_ID)
 })
 
-test('drift heal ignores local, ssh, and unparseable v1 routes', () => {
+test('drift heal ignores local and unparseable v1 routes', () => {
   const registry = emptyRegistry()
 
   for (const v1 of [
     { mode: 'local', remote: {} },
-    { mode: 'ssh', remote: { host: 'box' } },
     { mode: 'remote', remote: { url: 'not a url' } },
     { mode: 'remote', remote: {} },
     null
@@ -1610,6 +1609,34 @@ test('drift heal ignores local, ssh, and unparseable v1 routes', () => {
     assert.equal(drifted.changed, false, `expected no heal for ${JSON.stringify(v1)}`)
     assert.equal(drifted.registry, registry)
   }
+})
+
+test('drift heal registers a missing SSH-only v1 route and makes it primary', () => {
+  let registry = emptyRegistry()
+
+  const drifted = reconcileRegistryDrift(registry, {
+    mode: 'ssh',
+    remote: { mode: 'ssh', host: 'vps', user: 'root', keyPath: '~/.ssh/id_ed25519' }
+  })
+
+  assert.equal(drifted.changed, true)
+  const ssh = drifted.registry.connections.find(connection => connection.kind === 'ssh')
+  assert.ok(ssh, 'SSH entry should be registered')
+  assert.equal(ssh?.host, 'vps')
+  assert.equal(ssh?.user, 'root')
+  assert.equal(drifted.registry.primary, ssh?.id)
+  assert.equal(drifted.registry.lastUsed, ssh?.id)
+})
+
+test('drift heal leaves an already-registered SSH host unchanged', () => {
+  const registry = emptyRegistry()
+  const first = reconcileRegistryDrift(registry, { mode: 'ssh', remote: { mode: 'ssh', host: 'vps', user: 'root' } })
+  assert.equal(first.changed, true)
+
+  const drifted = reconcileRegistryDrift(first.registry, { mode: 'ssh', remote: { mode: 'ssh', host: 'vps', user: 'root' } })
+
+  assert.equal(drifted.changed, false)
+  assert.equal(drifted.registry.connections.filter(connection => connection.kind === 'ssh').length, 1)
 })
 
 test('drift heal adds the missing remote without disturbing other registered sources', () => {

--- a/apps/desktop/electron/connection-registry.ts
+++ b/apps/desktop/electron/connection-registry.ts
@@ -1504,11 +1504,45 @@ export function reconcileRegistryDrift(
   const config = v1 && typeof v1 === 'object' ? (v1 as Record<string, any>) : {}
   const unchanged = { changed: false, registry }
 
-  if (!modeIsRemoteLike(config.mode)) {
+  if (!modeIsRemoteLike(config.mode) && config.mode !== 'ssh') {
     return unchanged
   }
 
   const block = config.remote && typeof config.remote === 'object' ? config.remote : {}
+
+  if (config.mode === 'ssh') {
+    // SSH-only v1 route: register it when no matching ssh entry exists. This
+    // is the drift state — the one-time migration ran before this SSH host was
+    // configured, so the registry never learned about it (#96742).
+    const ssh = normalizeSshConfig({ ...block, mode: 'ssh' })
+
+    if (!ssh) {
+      return unchanged
+    }
+
+    const { mode: _mode, ...sshFields } = ssh
+    const sshKey = (c: { host?: string; port?: number; remoteProfile?: string; user?: string }) =>
+      `${(c.user || '').toLowerCase()}@${(c.host || '').toLowerCase()}:${c.port ?? 22}::${(c.remoteProfile || '').trim()}`
+
+    const alreadyRegistered = registry.connections.some(
+      c => c.kind === 'ssh' && sshKey(c) === sshKey(sshFields)
+    )
+
+    if (alreadyRegistered) {
+      return unchanged
+    }
+
+    const entry = normalizeConnectionInput(
+      {
+        kind: 'ssh',
+        label: uniqueLabel(ssh.host, registry.connections.map(c => c.label)),
+        ...sshFields
+      },
+      registry
+    )
+
+    return { changed: true, registry: { ...upsertConnection(registry, entry), primary: entry.id, lastUsed: entry.id } }
+  }
 
   let url = ''
 


### PR DESCRIPTION
## Summary

Fixes #96742: an SSH-only v1 `connection.json` (mode `ssh`, no `url`) is never reconciled into the v2 `connections.json` registry, so Desktop silently falls back to "This device" after the one-time migration ran before the SSH host existed.

## Approach

`reconcileRegistryDrift` (apps/desktop/electron/connection-registry.ts) already heals URL-based remote v1 routes; it skipped `mode: 'ssh'`. Added an SSH branch symmetric to the URL branch:

- `normalizeSshConfig` the v1 `remote` block
- fingerprint check (user@host:port) for an existing registry entry
- register via `normalizeConnectionInput` + `upsertConnection` when missing, adopt as primary/last-used

Deliberately narrow (matching the URL branch): an already-registered SSH host is left alone — that is the user's pick in the Connections panel, not drift.

## Note on existing test change

The previous test asserted SSH routes are never healed ("drift heal ignores local, ssh, and unparseable v1 routes"). That exclusion predates this issue — SSH-only configs have no registry editor interaction, so the drift never self-heals. The updated test moves SSH from the ignored list to its own heal tests.

## Test Plan

- 2 new tests: registers a missing SSH-only v1 route (becomes primary), leaves an already-registered SSH host unchanged
- Updated existing test (SSH removed from ignored list)
- 89/89 pass in connection-registry.test.ts; `tsc --noEmit` clean

## Risk / Exclusions

- Pure registry helpers (`electron/` only, no main.ts changes)
- Does not touch URL/remote drift behavior
- No prompt-cache or session-state impact

References #96742