### PR TITLE
fix: add GLM-5.x to reasoning stale-timeout floor allowlist

### DIFF
--- a/agent/reasoning_timeouts.py
+++ b/agent/reasoning_timeouts.py
@@ -131,6 +131,20 @@ _REASONING_STALE_TIMEOUT_FLOORS: tuple[tuple[str, int], ...] = (
     # reasoning variants.
     ("ox-alpha", 300),
     ("x-preview-f-free", 300),
+    # Z.AI GLM-5.3 — hybrid reasoning model: emits ``reasoning_content``
+    # before final content on EVERY request (measured 2026-08-28: even a
+    # trivial "reply OK" prompt thinks first; flash and non-flash alike).
+    # Without a floor entry the non-stream stale default is 90s, and the
+    # stale watchdog kills the call mid-thinking whenever the reasoning
+    # phase exceeds it under load — observed as three consecutive
+    # delegated-skeptic deaths (2x glm-5.3-flash, 1x glm-5.3) on
+    # 2026-08-26/27/28, each "Non-streaming API call timed out after 90s
+    # with no response" at ~278s = 3 retries.  Floor matches the
+    # deepseek-v4 class (600s): same reasoning_content emission pattern.
+    # ``glm-5.3`` right-anchors so glm-5.3-flash and any -YYYYMMDD
+    # suffix variant match as derivatives.
+    ("glm-5.3", 600),
+    ("glm-5.2", 600),
 )
 
 

--- a/tests/agent/test_reasoning_stale_timeout_floor.py
+++ b/tests/agent/test_reasoning_stale_timeout_floor.py
@@ -85,6 +85,14 @@ import pytest
     ("x-ai/grok-4.5", 300.0),
     ("x-ai/grok-4.6", 300.0),
     ("x-ai/grok-4-fast-non-reasoning", 180.0),
+    # Z.AI GLM-5.x — hybrid reasoning (reasoning_content before content on
+    # every request, flash and non-flash alike). Bare glm-5.3 right-anchors
+    # so flash and -YYYYMMDD variants match as derivatives; glm-4.x does not.
+    ("glm-5.3", 600.0),
+    ("glm-5.3-flash", 600.0),
+    ("zai-coding/glm-5.3", 600.0),
+    ("glm-5.3-20260801", 600.0),
+    ("glm-5.2", 600.0),
 ])
 def test_reasoning_stale_timeout_floor_positive_cases(model, expected):
     from agent.reasoning_timeouts import get_reasoning_stale_timeout_floor


### PR DESCRIPTION
## Problem

GLM-5.3 and GLM-5.2 are hybrid reasoning models — they emit `reasoning_content` before final content on **every** request (verified: even a trivial `reply OK` prompt thinks first; flash and non-flash variants alike). They were absent from `_REASONING_STALE_TIMEOUT_FLOORS`, so non-streaming calls (delegation subagents, cron jobs) resolved to the **90s implicit stale default**, and the stale watchdog killed them mid-thinking whenever the reasoning phase exceeded it under load.

Observed in production 2026-08-26/28: three consecutive delegated-skeptic subagent deaths (2× glm-5.3-flash, 1× glm-5.3) on the Z.AI direct provider, each failing with

```
Non-streaming API call timed out after 90s with no response (threshold: 90s)
```

at ~278s = exactly 3 retries, burning the iteration budget with zero analysis landed. A post-fix dispatch with a 600s explicit provider timeout completed in 243s with full output — same model, same provider, same prompt — confirming the timeout was the only variable.

## Fix

Add `glm-5.3` and `glm-5.2` to the allowlist at the 600s floor (same tier as the deepseek-v4 class, which has the identical reasoning_content emission pattern). The right-anchor semantics mean `glm-5.3-flash`, `glm-5.2-flash`, and `-YYYYMMDD` suffix variants all match as derivatives, while `glm-4.x` does not.

## Testing

- Existing parametrized suite extended with 5 GLM cases (bare, flash, aggregator-prefixed, date-suffixed, 5.2); verified `glm-4.6` still returns None.
- `tests/agent/test_reasoning_stale_timeout_floor.py`: **40 passed** (was 35).
- Related watchdog suite `tests/agent/test_codex_ttfb_watchdog.py`: 48 passed combined run.