### PR TITLE
fix(agent): stop empty-transcript sanitizer from warning on every send (#96870)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3597,6 +3597,13 @@ def _tool_call_id_variants(tc: Any) -> set:
 # consistently whether the empty turn was caught at write time or send time.
 _INTERRUPTED_PLACEHOLDER = "[response interrupted]"
 
+# Repeated heals of the same poisoned transcript used to WARNING on every
+# send (#96870). Escalate once per session window, then stay quiet.
+_EMPTY_HEAL_ESCALATE_AFTER = 5
+_EMPTY_HEAL_WINDOW_S = 600.0
+_empty_heal_log_state: Dict[str, Dict[str, Any]] = {}
+_empty_heal_log_lock = threading.Lock()
+
 
 def _msg_has_payload(msg: Dict[str, Any]) -> bool:
     """True if ``msg`` carries anything the API treats as non-empty content.
@@ -3644,6 +3651,80 @@ def _msg_has_payload(msg: Dict[str, Any]) -> bool:
     if msg.get("codex_message_items") or msg.get("codex_reasoning_items"):
         return True
     return False
+
+
+def fill_empty_non_final_wire_payload(
+    msg: Dict[str, Any], *, is_final: bool
+) -> bool:
+    """Write the interrupted placeholder onto an empty non-final wire copy.
+
+    Used by the send-time projection so ``repair_empty_non_final_messages``
+    does not re-heal the same row on every call (#88955 hidden placeholders,
+    #96870 stream-death / host-fed empties). Pass the per-call copy only —
+    durable history must not be mutated. Returns True when *msg* was filled.
+    """
+    if is_final or not isinstance(msg, dict):
+        return False
+    if msg.get("role") not in ("user", "assistant"):
+        return False
+    if _msg_has_payload(msg):
+        return False
+    msg["content"] = _INTERRUPTED_PLACEHOLDER
+    return True
+
+
+def _session_id_for_heal_log() -> str:
+    try:
+        from hermes_logging import _session_context
+
+        return str(getattr(_session_context, "session_id", None) or "")
+    except Exception:
+        return ""
+
+
+def _log_empty_non_final_heal(healed: int) -> None:
+    """WARNING on the first heals in a window; one ERROR at the threshold.
+
+    Further heals in the same session window stay silent so a poisoned
+    transcript cannot flood ``errors.log`` (dozens of identical WARNINGs
+    per hour with no user-visible signal — #96870).
+    """
+    key = _session_id_for_heal_log() or "-"
+    now = time.monotonic()
+    with _empty_heal_log_lock:
+        state = _empty_heal_log_state.get(key)
+        if state is None or (now - state["window_start"]) > _EMPTY_HEAL_WINDOW_S:
+            state = {"count": 0, "window_start": now, "escalated": False}
+            _empty_heal_log_state[key] = state
+        state["count"] += 1
+        count = state["count"]
+        if count >= _EMPTY_HEAL_ESCALATE_AFTER and not state["escalated"]:
+            state["escalated"] = True
+            level = "error"
+        elif state["escalated"]:
+            level = "silent"
+        else:
+            level = "warning"
+
+    if level == "silent":
+        return
+    if level == "error":
+        _ra().logger.error(
+            "Pre-call sanitizer: healed %d empty non-final message(s) "
+            "(%d heals in this session window). The transcript is being "
+            "repaired on every send; /new drops the poisoned turns.",
+            healed,
+            count,
+        )
+        return
+    _ra().logger.warning(
+        "Pre-call sanitizer: healed %d empty non-final message(s) by "
+        "substituting placeholder content — an empty-content turn was in "
+        "the transcript and would 400 the request ('messages must have "
+        "non-empty content' / INVALID_REQUEST_BODY). Self-recovering the "
+        "poisoned transcript in memory; no restart needed.",
+        healed,
+    )
 
 
 def repair_empty_non_final_messages(
@@ -3702,14 +3783,7 @@ def repair_empty_non_final_messages(
             repaired.append(msg)
 
     if healed:
-        _ra().logger.warning(
-            "Pre-call sanitizer: healed %d empty non-final message(s) by "
-            "substituting placeholder content — an empty-content turn was in "
-            "the transcript and would 400 the request ('messages must have "
-            "non-empty content' / INVALID_REQUEST_BODY). Self-recovering the "
-            "poisoned transcript in memory; no restart needed.",
-            healed,
-        )
+        _log_empty_non_final_heal(healed)
         return repaired
     return messages
 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2226,7 +2226,10 @@ def run_conversation(
         # repair_message_sequence_with_cursor also recomputes the SessionDB
         # flush cursor (_last_flushed_db_idx) when repair compacts the list,
         # so the turn-end flush doesn't skip the assistant/tool chain (#44837).
-        from agent.agent_runtime_helpers import repair_message_sequence_with_cursor
+        from agent.agent_runtime_helpers import (
+            fill_empty_non_final_wire_payload,
+            repair_message_sequence_with_cursor,
+        )
         repaired_seq = repair_message_sequence_with_cursor(agent, messages)
         if repaired_seq > 0:
             request_logger.info(
@@ -2256,28 +2259,8 @@ def run_conversation(
             # from every outgoing copy so strict OpenAI-compatible backends
             # don't reject the request after a model switch or resumed typed
             # event row enters the live history.
-            _display_kind = api_msg.pop("display_kind", None)
+            api_msg.pop("display_kind", None)
             api_msg.pop("display_metadata", None)
-
-            # Legacy hidden redirect placeholders (#88955): rows persisted
-            # BEFORE the writer-side api_content stamp in
-            # _apply_active_turn_redirect are content="" with no sidecar.
-            # Once display_kind is stripped the pre-call sanitizer
-            # (repair_empty_non_final_messages) would re-heal such a row on
-            # every call forever, since the durable transcript is never
-            # mutated. Give the wire copy the same neutral payload here so
-            # old sessions converge too. Never the interrupt scaffold —
-            # replaying scaffold bytes as assistant text is #81841.
-            if (
-                _display_kind == "hidden"
-                and api_msg.get("role") == "assistant"
-                and not _api_content
-                and not (api_msg.get("content") or "").strip()
-                and not api_msg.get("tool_calls")
-            ):
-                from agent.agent_runtime_helpers import _INTERRUPTED_PLACEHOLDER
-
-                api_msg["content"] = _INTERRUPTED_PLACEHOLDER
 
             # Durable row identity stamped by _rows_to_conversation so the
             # desktop can address a specific persisted message (reactions).
@@ -2335,6 +2318,16 @@ def run_conversation(
             # Remove finish_reason - not accepted by strict APIs (e.g. Mistral)
             if "finish_reason" in api_msg:
                 api_msg.pop("finish_reason")
+            # Empty non-final user/assistant turns (#88955 hidden placeholders
+            # and #96870 stream-death / host-fed empties): once display_kind
+            # and api_content are stripped, the pre-call sanitizer would
+            # re-heal the wire copy on every send and flood errors.log.
+            # Fill the WIRE copy here so the sanitizer has nothing to do.
+            # Durable history is not mutated. After reasoning copy so a
+            # thinking-only turn keeps its payload and is not rewritten.
+            fill_empty_non_final_wire_payload(
+                api_msg, is_final=(idx == len(messages) - 1)
+            )
             # _thinking_prefill survives here intentionally: the drop pass below
             # needs it. The transport strips all underscore keys before the wire.
             # Strip length-continuation marks; not every transport drops underscore keys.

--- a/tests/run_agent/test_sanitiser_escalation.py
+++ b/tests/run_agent/test_sanitiser_escalation.py
@@ -1,0 +1,211 @@
+"""Empty-transcript sanitizer: stop the per-send heal/WARNING loop (#96870).
+
+``repair_empty_non_final_messages`` is still the single owner of the
+wire-copy substitution. The send-time projection now fills empty non-final
+turns first so the owner heals 0 on the main loop (same pattern as #88955).
+When a caller still hits the owner repeatedly, logging escalates once per
+session window instead of flooding errors.log.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from agent.agent_runtime_helpers import (
+    _INTERRUPTED_PLACEHOLDER,
+    _empty_heal_log_state,
+    fill_empty_non_final_wire_payload,
+    repair_empty_non_final_messages,
+)
+from hermes_logging import clear_session_context, set_session_context
+
+
+@pytest.fixture(autouse=True)
+def _reset_heal_log():
+    _empty_heal_log_state.clear()
+    clear_session_context()
+    yield
+    _empty_heal_log_state.clear()
+    clear_session_context()
+
+
+def _poisoned_rows():
+    return [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": ""},
+        {"role": "user", "content": "next"},
+    ]
+
+
+class TestFillEmptyNonFinalWirePayload:
+    def test_fills_empty_non_final_assistant(self):
+        msg = {"role": "assistant", "content": ""}
+        assert fill_empty_non_final_wire_payload(msg, is_final=False) is True
+        assert msg["content"] == _INTERRUPTED_PLACEHOLDER
+
+    def test_fills_empty_non_final_user(self):
+        msg = {"role": "user", "content": None}
+        assert fill_empty_non_final_wire_payload(msg, is_final=False) is True
+        assert msg["content"] == _INTERRUPTED_PLACEHOLDER
+
+    def test_skips_final_turn(self):
+        msg = {"role": "assistant", "content": ""}
+        assert fill_empty_non_final_wire_payload(msg, is_final=True) is False
+        assert msg["content"] == ""
+
+    def test_skips_tool_call_turn(self):
+        msg = {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"id": "c1", "function": {"name": "x", "arguments": "{}"}}],
+        }
+        assert fill_empty_non_final_wire_payload(msg, is_final=False) is False
+        assert msg["content"] == ""
+
+    def test_skips_codex_commentary_carrier(self):
+        msg = {
+            "role": "assistant",
+            "content": "",
+            "codex_message_items": [{"type": "text", "text": "hi"}],
+        }
+        assert fill_empty_non_final_wire_payload(msg, is_final=False) is False
+        assert msg["content"] == ""
+
+    def test_skips_already_populated_content(self):
+        msg = {"role": "assistant", "content": "hello"}
+        assert fill_empty_non_final_wire_payload(msg, is_final=False) is False
+        assert msg["content"] == "hello"
+
+
+class TestHealLogEscalation:
+    def test_warning_then_one_error_then_silence(self, monkeypatch, caplog):
+        import agent.agent_runtime_helpers as arh
+
+        monkeypatch.setattr(arh, "_EMPTY_HEAL_ESCALATE_AFTER", 3)
+        set_session_context("sess-heal")
+        durable = _poisoned_rows()
+
+        with caplog.at_level(logging.WARNING, logger="run_agent"):
+            for _ in range(5):
+                out = repair_empty_non_final_messages(
+                    [dict(m) for m in durable]
+                )
+                assert out[1]["content"] == _INTERRUPTED_PLACEHOLDER
+                assert durable[1]["content"] == ""
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+        assert len(warnings) == 2
+        assert len(errors) == 1
+        assert "healed" in warnings[0].getMessage()
+        assert "session window" in errors[0].getMessage()
+        assert "/new" in errors[0].getMessage()
+
+    def test_sessions_do_not_share_heal_counters(self, monkeypatch, caplog):
+        import agent.agent_runtime_helpers as arh
+
+        monkeypatch.setattr(arh, "_EMPTY_HEAL_ESCALATE_AFTER", 3)
+        with caplog.at_level(logging.WARNING, logger="run_agent"):
+            set_session_context("sess-a")
+            repair_empty_non_final_messages([dict(m) for m in _poisoned_rows()])
+            set_session_context("sess-b")
+            repair_empty_non_final_messages([dict(m) for m in _poisoned_rows()])
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+        assert len(warnings) == 2
+        assert errors == []
+
+    def test_owner_still_heals_wire_copy_only(self):
+        durable = _poisoned_rows()
+        out = repair_empty_non_final_messages(durable)
+        assert out[1]["content"] == _INTERRUPTED_PLACEHOLDER
+        assert durable[1]["content"] == ""
+        assert out is not durable
+
+
+class TestProjectionStopsReheal:
+    def _loop_agent(self):
+        from unittest.mock import MagicMock, patch
+
+        from run_agent import AIAgent
+
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            agent = AIAgent(
+                api_key="test-key-1234567890",
+                base_url="https://openrouter.ai/api/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+        agent.client = MagicMock()
+        agent._cached_system_prompt = "You are helpful."
+        agent._use_prompt_caching = False
+        agent.tool_delay = 0
+        agent.compression_enabled = False
+        agent.save_trajectories = False
+        return agent
+
+    def test_unmarked_empty_assistant_is_filled_before_sanitizer(self):
+        """The per-turn WARNING spam IS the bug: projection must fill the
+        unmarked empty row so the sanitizer heals 0 (#96870 / #88955)."""
+        from unittest.mock import patch
+
+        import agent.agent_runtime_helpers as _arh
+        from tests.run_agent.test_run_agent import _mock_response
+
+        agent = self._loop_agent()
+        agent.client.chat.completions.create.side_effect = [
+            _mock_response(content="ok", finish_reason="stop"),
+        ]
+        sanitizer_healed = []
+        _real_repair = _arh.repair_empty_non_final_messages
+
+        def _spy_repair(messages, *a, **k):
+            empty = [
+                (m.get("role"), m.get("content"))
+                for m in messages
+                if isinstance(m, dict)
+                and m.get("role") in ("user", "assistant")
+                and not (m.get("content") or "").strip()
+                and not m.get("tool_calls")
+            ]
+            sanitizer_healed.append(empty)
+            return _real_repair(messages, *a, **k)
+
+        history = [
+            {"role": "user", "content": "start"},
+            {"role": "assistant", "content": ""},
+            {"role": "user", "content": "continue", "finish_reason": "stop"},
+            {"role": "assistant", "content": "earlier reply", "finish_reason": "stop"},
+        ]
+
+        with (
+            patch.object(agent, "_flush_messages_to_session_db"),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+            patch.object(
+                _arh, "repair_empty_non_final_messages", side_effect=_spy_repair
+            ),
+        ):
+            agent.run_conversation("next question", conversation_history=history)
+
+        assert sanitizer_healed, "sanitizer was never invoked — test is vacuous"
+        for empty in sanitizer_healed:
+            assert empty == [], (
+                "sanitizer still received an empty non-final row — "
+                "the re-heal loop is back (#96870)"
+            )
+
+        wire = agent.client.chat.completions.create.call_args.kwargs["messages"]
+        wire_assistants = [m for m in wire if m.get("role") == "assistant"]
+        assert wire_assistants[0]["content"] == _INTERRUPTED_PLACEHOLDER
+        assert history[1]["content"] == ""
+        assert "api_content" not in history[1]


### PR DESCRIPTION
## Summary
- A poisoned transcript (empty non-final user/assistant turn) was repaired on the per-call wire copy every send. The owner worked, but the only signal was a `WARNING` on every call — dozens per hour in `errors.log`, nothing on the session itself.
- Send-time projection now fills those empty non-final turns with the existing `[response interrupted]` placeholder **before** `repair_empty_non_final_messages` runs (same pattern as the hidden-placeholder fill in #88955). The sanitizer heals 0 on the main loop; durable history is still not mutated.
- Callers that still hit the owner (summary path, host-fed sanitize) log `WARNING` for the first heals in a session window, then a single `ERROR`, then stay quiet. Wire-copy substitution, placeholder, and copy-on-write semantics are unchanged.

This does not add session-DB fields, a `/sanitise` command, write-time content padding (tried and reverted), or a new metric family.

Fixes #96870

## Test plan
- [x] `scripts/run_tests.sh tests/run_agent/test_sanitiser_escalation.py tests/run_agent/test_steer.py tests/run_agent/test_partial_stream_finish_reason.py tests/run_agent/test_thinking_only_sanitizer.py`
- [ ] Resume a session that already carries an empty mid-transcript assistant turn and confirm the next send does not emit a new sanitizer WARNING
- [ ] Confirm `/new` still starts a clean transcript