### PR TITLE
feat(dingtalk): outbound image/file upload via OpenAPI robot send (replaces failure stubs)

### DIFF
--- a/plugins/platforms/dingtalk/adapter.py
+++ b/plugins/platforms/dingtalk/adapter.py
@@ -29,11 +29,13 @@ Configuration in config.yaml:
 import asyncio
 import json
 import logging
+import mimetypes
 import os
 import re
 import traceback
 import uuid
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Set
 
 try:
@@ -1152,6 +1154,218 @@ class DingTalkAdapter(BasePlatformAdapter):
             metadata=metadata,
         )
 
+    # -- Outbound media helpers -----------------------------------------------
+
+    async def _upload_media(
+        self, file_path: str, media_type: str = "image"
+    ) -> str:
+        """Upload a file to DingTalk via the old oapi media/upload endpoint."""
+        if not self._http_client:
+            raise RuntimeError("HTTP client not initialized")
+        if not os.path.exists(file_path):
+            raise RuntimeError(f"File not found: {file_path}")
+
+        token = await self._get_access_token()
+        if not token:
+            raise RuntimeError("Failed to obtain access token")
+
+        file_name = Path(file_path).name
+        content_type = mimetypes.guess_type(file_name)[0] or "application/octet-stream"
+
+        with open(file_path, "rb") as f:
+            files = {"media": (file_name, f, content_type)}
+            response = await self._http_client.post(
+                "https://oapi.dingtalk.com/media/upload",
+                params={"access_token": token, "type": media_type},
+                files=files,
+                timeout=60.0,
+            )
+
+        if response.status_code >= 400:
+            raise RuntimeError(
+                f"DingTalk media upload failed: HTTP {response.status_code}"
+            )
+
+        payload = response.json()
+        media_id = str(payload.get("media_id") or "")
+        if not media_id:
+            raise RuntimeError(
+                f"DingTalk media upload response missing media_id: {payload}"
+            )
+
+        logger.debug(
+            "[%s] Uploaded media %s -> %s", self.name, file_name, media_id
+        )
+        return media_id
+
+    async def _resolve_outbound_endpoint(
+        self, chat_id: str
+    ) -> tuple[str, dict[str, Any]]:
+        """Determine the robot message endpoint and target payload for a chat.
+
+        Uses the same heuristic as ``get_chat_info`` to distinguish group vs
+        DM conversations.  For DMs without a cached user ID, falls back to
+        the group send endpoint with a logged warning.
+        """
+        chat_info = await self.get_chat_info(chat_id)
+        chat_type = str(chat_info.get("type", "dm")).strip().lower()
+
+        if chat_type == "group":
+            return (
+                "https://api.dingtalk.com/v1.0/robot/groupMessages/send",
+                {"openConversationId": chat_id},
+            )
+
+        # DM — no persistent user-id cache in this adapter, so fall back
+        # to groupMessages/send with a warning so the message still reaches
+        # the user in most group-chat-like DM scenarios.
+        logger.warning(
+            "[%s] Cannot determine DM target for outbound media; "
+            "falling back to group send with chat_id as openConversationId. "
+            "chat_id=%s",
+            self.name, chat_id,
+        )
+        return (
+            "https://api.dingtalk.com/v1.0/robot/groupMessages/send",
+            {"openConversationId": chat_id},
+        )
+
+    async def _send_robot_media_message(
+        self,
+        chat_id: str,
+        *,
+        msg_key: str,
+        msg_param: dict[str, Any],
+        kind_label: str,
+    ) -> SendResult:
+        """Send a native robot media message through the DingTalk robot API."""
+        if not self._http_client:
+            return SendResult(success=False, error="HTTP client not initialized")
+
+        token = await self._get_access_token()
+        if not token:
+            return SendResult(
+                success=False, error="Failed to obtain access token"
+            )
+
+        endpoint, target = await self._resolve_outbound_endpoint(chat_id)
+        robot_code = self._robot_code or self._client_id
+
+        body: dict[str, Any] = {
+            "robotCode": robot_code,
+            "msgKey": msg_key,
+            "msgParam": json.dumps(msg_param),
+            **target,
+        }
+
+        try:
+            resp = await self._http_client.post(
+                endpoint,
+                headers={
+                    "x-acs-dingtalk-access-token": token,
+                    "Content-Type": "application/json",
+                },
+                json=body,
+                timeout=15.0,
+            )
+
+            if resp.status_code < 400:
+                resp_data = resp.json()
+                # DingTalk robot send returns a processQueryKey on success
+                process_query_key = resp_data.get("processQueryKey")
+                if not process_query_key:
+                    business_error = (
+                        resp_data.get("message")
+                        or resp_data.get("errmsg")
+                        or ""
+                    )
+                    if resp_data.get("success") is False or business_error:
+                        error_msg = (
+                            f"{kind_label.title()} send failed: "
+                            f"{business_error or resp_data}"
+                        )
+                        logger.warning("[%s] %s", self.name, error_msg)
+                        return SendResult(success=False, error=error_msg)
+
+                logger.debug(
+                    "[%s] %s message sent: processQueryKey=%s",
+                    self.name,
+                    kind_label.title(),
+                    resp_data.get("processQueryKey", ""),
+                )
+                return SendResult(
+                    success=True,
+                    message_id=str(
+                        resp_data.get("processQueryKey")
+                        or uuid.uuid4().hex[:12]
+                    ),
+                )
+
+            body_text = resp.text[:200]
+            logger.warning(
+                "[%s] %s send failed HTTP %d: %s",
+                self.name, kind_label.title(), resp.status_code, body_text,
+            )
+            return SendResult(
+                success=False,
+                error=f"HTTP {resp.status_code}: {body_text}",
+            )
+        except httpx.TimeoutException:
+            return SendResult(
+                success=False,
+                error=f"Timeout sending {kind_label} message to DingTalk",
+            )
+        except Exception as e:
+            logger.error(
+                "[%s] %s send error: %s", self.name, kind_label.title(), e
+            )
+            return SendResult(success=False, error=str(e))
+
+    async def _send_image_message(
+        self,
+        chat_id: str,
+        media_id: str,
+        caption: Optional[str] = None,
+    ) -> SendResult:
+        """Send an image message using the robot messaging API.
+
+        Uses ``sampleImageMsg`` with the uploaded media_id.  An optional
+        ``text`` field is included when a caption is provided.
+        """
+        msg_param: dict[str, Any] = {"photoURL": media_id}
+        if caption:
+            msg_param["text"] = caption
+        return await self._send_robot_media_message(
+            chat_id,
+            msg_key="sampleImageMsg",
+            msg_param=msg_param,
+            kind_label="image",
+        )
+
+    async def _send_file_message(
+        self,
+        chat_id: str,
+        media_id: str,
+        file_name: str,
+    ) -> SendResult:
+        """Send a native DingTalk file message using the robot messaging API."""
+        file_type = Path(file_name).suffix.lstrip(".").lower()
+        if not file_type:
+            return SendResult(
+                success=False,
+                error="Missing file extension for DingTalk file message",
+            )
+        return await self._send_robot_media_message(
+            chat_id,
+            msg_key="sampleFile",
+            msg_param={
+                "mediaId": media_id,
+                "fileName": file_name,
+                "fileType": file_type,
+            },
+            kind_label="file",
+        )
+
     async def send_image_file(
         self,
         chat_id: str,
@@ -1161,14 +1375,54 @@ class DingTalkAdapter(BasePlatformAdapter):
         metadata: Optional[Dict[str, Any]] = None,
         **kwargs,
     ) -> SendResult:
-        """DingTalk webhook replies cannot send local image files directly."""
-        return SendResult(
-            success=False,
-            error=(
-                "DingTalk session webhook replies do not support local image uploads. "
-                "Only markdown/text replies are supported without OpenAPI media upload."
-            ),
+        """Send a local image file via DingTalk media upload and native image message.
+
+        Uploads the local image to DingTalk's media storage, then sends it as
+        a native ``sampleImageMsg`` through the robot OpenAPI.  If a caption
+        is provided and a session webhook is available, the caption is sent
+        as a follow-up markdown message.
+        """
+        if not os.path.exists(image_path):
+            return SendResult(success=False, error=f"File not found: {image_path}")
+        if not os.path.isfile(image_path):
+            return SendResult(success=False, error=f"Not a file: {image_path}")
+
+        try:
+            media_id = await self._upload_media(image_path, media_type="image")
+        except Exception as e:
+            logger.error("[%s] send_image_file upload error: %s", self.name, e)
+            return SendResult(success=False, error=str(e))
+
+        # Send caption as follow-up markdown via session webhook if available
+        if caption:
+            webhook_info = self._get_valid_webhook(chat_id)
+            if webhook_info:
+                caption_result = await self.send(
+                    chat_id=chat_id,
+                    content=caption,
+                    reply_to=reply_to,
+                    metadata=metadata,
+                )
+                if not caption_result.success:
+                    logger.warning(
+                        "[%s] Failed to send image caption: %s",
+                        self.name, caption_result.error,
+                    )
+            else:
+                logger.debug(
+                    "[%s] No session webhook available for image caption", self.name,
+                )
+
+        result = await self._send_image_message(
+            chat_id, media_id, caption=caption
         )
+        if result.success:
+            logger.info(
+                "[%s] Image sent to DingTalk: chat=%s file=%s message_id=%s",
+                self.name, chat_id, Path(image_path).name,
+                result.message_id or "-",
+            )
+        return result
 
     async def send_document(
         self,
@@ -1180,14 +1434,55 @@ class DingTalkAdapter(BasePlatformAdapter):
         metadata: Optional[Dict[str, Any]] = None,
         **kwargs,
     ) -> SendResult:
-        """DingTalk webhook replies cannot send local file attachments directly."""
-        return SendResult(
-            success=False,
-            error=(
-                "DingTalk session webhook replies do not support local file attachments. "
-                "Only markdown/text replies are supported without OpenAPI message send."
-            ),
-        )
+        """Send a document as a native DingTalk file message via media upload.
+
+        Uploads the local file to DingTalk's media storage, then sends it as
+        a native ``sampleFile`` message through the robot OpenAPI.  If a
+        caption is provided and a session webhook is available, the caption
+        is sent as a follow-up markdown message.
+        """
+        if not os.path.exists(file_path):
+            return SendResult(success=False, error=f"File not found: {file_path}")
+        if not os.path.isfile(file_path):
+            return SendResult(success=False, error=f"Not a file: {file_path}")
+
+        display_name = file_name or Path(file_path).name
+
+        try:
+            media_id = await self._upload_media(file_path, media_type="file")
+        except Exception as e:
+            logger.error("[%s] send_document upload error: %s", self.name, e)
+            return SendResult(success=False, error=str(e))
+
+        # Send caption as follow-up markdown via session webhook if available
+        if caption:
+            webhook_info = self._get_valid_webhook(chat_id)
+            if webhook_info:
+                caption_result = await self.send(
+                    chat_id=chat_id,
+                    content=caption,
+                    reply_to=reply_to,
+                    metadata=metadata,
+                )
+                if not caption_result.success:
+                    logger.warning(
+                        "[%s] Failed to send document caption: %s",
+                        self.name, caption_result.error,
+                    )
+            else:
+                logger.debug(
+                    "[%s] No session webhook available for document caption",
+                    self.name,
+                )
+
+        result = await self._send_file_message(chat_id, media_id, display_name)
+        if result.success:
+            logger.info(
+                "[%s] File sent to DingTalk: chat=%s file=%s message_id=%s",
+                self.name, chat_id, display_name,
+                result.message_id or "-",
+            )
+        return result
 
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         """Return basic info about a DingTalk conversation."""

--- a/plugins/platforms/dingtalk/adapter.py
+++ b/plugins/platforms/dingtalk/adapter.py
@@ -1313,7 +1313,7 @@ class DingTalkAdapter(BasePlatformAdapter):
         except httpx.TimeoutException:
             return SendResult(
                 success=False,
-                error=f"Timeout sending {kind_label} message to DingTalk",
+                error=f"Timeout sending {kind_label.title()} message to DingTalk",
             )
         except Exception as e:
             logger.error(
@@ -1379,8 +1379,8 @@ class DingTalkAdapter(BasePlatformAdapter):
 
         Uploads the local image to DingTalk's media storage, then sends it as
         a native ``sampleImageMsg`` through the robot OpenAPI.  If a caption
-        is provided and a session webhook is available, the caption is sent
-        as a follow-up markdown message.
+        is provided, it is delivered natively inside the robot message's
+        ``text`` field -- sent once as a single combined message.
         """
         if not os.path.exists(image_path):
             return SendResult(success=False, error=f"File not found: {image_path}")
@@ -1392,26 +1392,6 @@ class DingTalkAdapter(BasePlatformAdapter):
         except Exception as e:
             logger.error("[%s] send_image_file upload error: %s", self.name, e)
             return SendResult(success=False, error=str(e))
-
-        # Send caption as follow-up markdown via session webhook if available
-        if caption:
-            webhook_info = self._get_valid_webhook(chat_id)
-            if webhook_info:
-                caption_result = await self.send(
-                    chat_id=chat_id,
-                    content=caption,
-                    reply_to=reply_to,
-                    metadata=metadata,
-                )
-                if not caption_result.success:
-                    logger.warning(
-                        "[%s] Failed to send image caption: %s",
-                        self.name, caption_result.error,
-                    )
-            else:
-                logger.debug(
-                    "[%s] No session webhook available for image caption", self.name,
-                )
 
         result = await self._send_image_message(
             chat_id, media_id, caption=caption
@@ -1438,8 +1418,8 @@ class DingTalkAdapter(BasePlatformAdapter):
 
         Uploads the local file to DingTalk's media storage, then sends it as
         a native ``sampleFile`` message through the robot OpenAPI.  If a
-        caption is provided and a session webhook is available, the caption
-        is sent as a follow-up markdown message.
+        caption is provided, it is delivered natively inside the robot
+        message's ``text`` field -- sent once as a single combined message.
         """
         if not os.path.exists(file_path):
             return SendResult(success=False, error=f"File not found: {file_path}")
@@ -1453,27 +1433,6 @@ class DingTalkAdapter(BasePlatformAdapter):
         except Exception as e:
             logger.error("[%s] send_document upload error: %s", self.name, e)
             return SendResult(success=False, error=str(e))
-
-        # Send caption as follow-up markdown via session webhook if available
-        if caption:
-            webhook_info = self._get_valid_webhook(chat_id)
-            if webhook_info:
-                caption_result = await self.send(
-                    chat_id=chat_id,
-                    content=caption,
-                    reply_to=reply_to,
-                    metadata=metadata,
-                )
-                if not caption_result.success:
-                    logger.warning(
-                        "[%s] Failed to send document caption: %s",
-                        self.name, caption_result.error,
-                    )
-            else:
-                logger.debug(
-                    "[%s] No session webhook available for document caption",
-                    self.name,
-                )
 
         result = await self._send_file_message(chat_id, media_id, display_name)
         if result.success:

--- a/plugins/platforms/dingtalk/adapter.py
+++ b/plugins/platforms/dingtalk/adapter.py
@@ -1172,13 +1172,21 @@ class DingTalkAdapter(BasePlatformAdapter):
         file_name = Path(file_path).name
         content_type = mimetypes.guess_type(file_name)[0] or "application/octet-stream"
 
-        with open(file_path, "rb") as f:
-            files = {"media": (file_name, f, content_type)}
+        content = await asyncio.to_thread(Path(file_path).read_bytes)
+        files = {"media": (file_name, content, content_type)}
+
+        try:
             response = await self._http_client.post(
                 "https://oapi.dingtalk.com/media/upload",
                 params={"access_token": token, "type": media_type},
                 files=files,
                 timeout=60.0,
+            )
+        except httpx.TimeoutException:
+            raise RuntimeError("DingTalk media upload timed out after 60s")
+        except httpx.RequestError as e:
+            raise RuntimeError(
+                f"DingTalk media upload network error: {e.__class__.__name__}: {e}"
             )
 
         if response.status_code >= 400:
@@ -1250,6 +1258,11 @@ class DingTalkAdapter(BasePlatformAdapter):
 
         endpoint, target = await self._resolve_outbound_endpoint(chat_id)
         robot_code = self._robot_code or self._client_id
+        if not robot_code:
+            return SendResult(
+                success=False,
+                error="DingTalk robot code not configured (set platforms.dingtalk client_id)",
+            )
 
         body: dict[str, Any] = {
             "robotCode": robot_code,
@@ -1279,26 +1292,22 @@ class DingTalkAdapter(BasePlatformAdapter):
                         or resp_data.get("errmsg")
                         or ""
                     )
-                    if resp_data.get("success") is False or business_error:
-                        error_msg = (
-                            f"{kind_label.title()} send failed: "
-                            f"{business_error or resp_data}"
-                        )
-                        logger.warning("[%s] %s", self.name, error_msg)
-                        return SendResult(success=False, error=error_msg)
+                    error_msg = (
+                        f"{kind_label.title()} send failed: "
+                        f"{business_error or resp_data.get('code') or str(resp_data)}"
+                    )
+                    logger.warning("[%s] %s", self.name, error_msg)
+                    return SendResult(success=False, error=error_msg)
 
                 logger.debug(
                     "[%s] %s message sent: processQueryKey=%s",
                     self.name,
                     kind_label.title(),
-                    resp_data.get("processQueryKey", ""),
+                    process_query_key,
                 )
                 return SendResult(
                     success=True,
-                    message_id=str(
-                        resp_data.get("processQueryKey")
-                        or uuid.uuid4().hex[:12]
-                    ),
+                    message_id=str(process_query_key),
                 )
 
             body_text = resp.text[:200]
@@ -1418,8 +1427,8 @@ class DingTalkAdapter(BasePlatformAdapter):
 
         Uploads the local file to DingTalk's media storage, then sends it as
         a native ``sampleFile`` message through the robot OpenAPI.  If a
-        caption is provided, it is delivered natively inside the robot
-        message's ``text`` field -- sent once as a single combined message.
+        caption is provided, it is delivered as a separate companion text
+        message (sampleFile has no ``text`` field for native caption delivery).
         """
         if not os.path.exists(file_path):
             return SendResult(success=False, error=f"File not found: {file_path}")
@@ -1427,6 +1436,14 @@ class DingTalkAdapter(BasePlatformAdapter):
             return SendResult(success=False, error=f"Not a file: {file_path}")
 
         display_name = file_name or Path(file_path).name
+
+        # Validate file extension BEFORE uploading
+        file_type = Path(display_name).suffix.lstrip(".").lower()
+        if not file_type:
+            return SendResult(
+                success=False,
+                error=f"Missing file extension for DingTalk file message: {display_name}",
+            )
 
         try:
             media_id = await self._upload_media(file_path, media_type="file")
@@ -1441,6 +1458,19 @@ class DingTalkAdapter(BasePlatformAdapter):
                 self.name, chat_id, display_name,
                 result.message_id or "-",
             )
+            # Deliver caption as a companion text message (sampleFile has no text field)
+            if caption:
+                caption_result = await self.send(
+                    chat_id=chat_id,
+                    content=caption,
+                    reply_to=reply_to,
+                    metadata=metadata,
+                )
+                if not caption_result.success:
+                    logger.warning(
+                        "[%s] Failed to send caption companion for file: %s",
+                        self.name, caption_result.error,
+                    )
         return result
 
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:

--- a/tests/gateway/test_dingtalk.py
+++ b/tests/gateway/test_dingtalk.py
@@ -5,6 +5,7 @@ from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 
 from gateway.config import Platform, PlatformConfig
@@ -1007,6 +1008,7 @@ class TestSendRobotMediaMessage:
     async def test_success(self):
         from plugins.platforms.dingtalk.adapter import DingTalkAdapter
         adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        adapter._client_id = "test-client-id"
         adapter._http_client = AsyncMock()
         adapter._get_access_token = AsyncMock(return_value="token")
 
@@ -1057,6 +1059,7 @@ class TestSendRobotMediaMessage:
     async def test_http_error(self):
         from plugins.platforms.dingtalk.adapter import DingTalkAdapter
         adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        adapter._client_id = "test-client-id"
         adapter._http_client = AsyncMock()
         adapter._get_access_token = AsyncMock(return_value="token")
 
@@ -1151,3 +1154,173 @@ class TestSendFileMessage:
         result = await adapter._send_file_message("group-1", "mid-1", "noext")
         assert result.success is False
         assert "Missing file extension" in result.error
+
+
+# ===========================================================================
+# Regression tests for recent fixes (FIX 1-6)
+# ===========================================================================
+
+
+class TestSendRobotMediaMessageFixes:
+
+    @pytest.mark.asyncio
+    async def test_http_200_empty_body_fails(self):
+        """FIX 1: HTTP 200 with empty body must NOT fabricate a message_id."""
+        from plugins.platforms.dingtalk.adapter import DingTalkAdapter
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        adapter._client_id = "test-client-id"
+        adapter._http_client = AsyncMock()
+        adapter._get_access_token = AsyncMock(return_value="token")
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {}
+        adapter._http_client.post = AsyncMock(return_value=mock_resp)
+
+        result = await adapter._send_robot_media_message(
+            "group-1",
+            msg_key="sampleImageMsg",
+            msg_param={"photoURL": "mid-1"},
+            kind_label="image",
+        )
+        assert result.success is False
+        assert result.message_id is None
+
+    @pytest.mark.asyncio
+    async def test_http_200_with_error_code(self):
+        """FIX 1: HTTP 200 with error code returns success=False."""
+        from plugins.platforms.dingtalk.adapter import DingTalkAdapter
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        adapter._client_id = "test-client-id"
+        adapter._http_client = AsyncMock()
+        adapter._get_access_token = AsyncMock(return_value="token")
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"code": "Conversation.NotFound"}
+        adapter._http_client.post = AsyncMock(return_value=mock_resp)
+
+        result = await adapter._send_robot_media_message(
+            "group-1",
+            msg_key="sampleFile",
+            msg_param={"mediaId": "mid-1", "fileName": "test.pdf", "fileType": "pdf"},
+            kind_label="file",
+        )
+        assert result.success is False
+        assert "Conversation.NotFound" in result.error
+
+    @pytest.mark.asyncio
+    async def test_no_robot_code(self):
+        """FIX 5: Missing robot_code fails without HTTP call."""
+        from plugins.platforms.dingtalk.adapter import DingTalkAdapter
+        from gateway.config import PlatformConfig
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        # Neither _robot_code nor _client_id is set
+        adapter._http_client = AsyncMock()
+        adapter._get_access_token = AsyncMock(return_value="token")
+
+        result = await adapter._send_robot_media_message(
+            "group-1",
+            msg_key="sampleImageMsg",
+            msg_param={"photoURL": "mid-1"},
+            kind_label="image",
+        )
+        assert result.success is False
+        assert "robot code" in result.error
+        adapter._http_client.post.assert_not_called()
+
+
+class TestSendDocumentFixes:
+
+    @pytest.mark.asyncio
+    async def test_with_caption_sends_companion(self, tmp_path):
+        """FIX 2: Caption delivered as companion text message after file send."""
+        from plugins.platforms.dingtalk.adapter import DingTalkAdapter
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        doc = tmp_path / "report.pdf"
+        doc.write_bytes(b"%PDF" + b"\x00" * 100)
+
+        adapter._upload_media = AsyncMock(return_value="mid-doc")
+        adapter._send_file_message = AsyncMock(
+            return_value=MagicMock(success=True, message_id="file-msg-1")
+        )
+        adapter.send = AsyncMock(
+            return_value=MagicMock(success=True)
+        )
+
+        result = await adapter.send_document(
+            "group-1", str(doc), caption="See attached report"
+        )
+        assert result.success is True
+        # File delivered first
+        adapter._upload_media.assert_called_once_with(str(doc), media_type="file")
+        adapter._send_file_message.assert_called_once_with(
+            "group-1", "mid-doc", "report.pdf"
+        )
+        # Then companion text delivered
+        adapter.send.assert_called_once_with(
+            chat_id="group-1",
+            content="See attached report",
+            reply_to=None,
+            metadata=None,
+        )
+
+    @pytest.mark.asyncio
+    async def test_caption_not_sent_on_file_failure(self, tmp_path):
+        """FIX 2: Caption NOT sent when file delivery fails."""
+        from plugins.platforms.dingtalk.adapter import DingTalkAdapter
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        doc = tmp_path / "report.pdf"
+        doc.write_bytes(b"%PDF" + b"\x00" * 100)
+
+        adapter._upload_media = AsyncMock(return_value="mid-doc")
+        adapter._send_file_message = AsyncMock(
+            return_value=MagicMock(success=False, error="File send failed")
+        )
+        adapter.send = AsyncMock()
+
+        result = await adapter.send_document(
+            "group-1", str(doc), caption="See attached report"
+        )
+        assert result.success is False
+        # self.send must NOT be called when file delivery failed
+        adapter.send.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_extensionless_fails_before_upload(self, tmp_path):
+        """FIX 3: Extensionless file_name fails before _upload_media."""
+        from plugins.platforms.dingtalk.adapter import DingTalkAdapter
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        doc = tmp_path / "report.pdf"
+        doc.write_bytes(b"%PDF" + b"\x00" * 100)
+
+        adapter._upload_media = AsyncMock()
+        adapter._send_file_message = AsyncMock()
+
+        result = await adapter.send_document(
+            "group-1", str(doc), file_name="noextension"
+        )
+        assert result.success is False
+        assert "Missing file extension" in result.error
+        adapter._upload_media.assert_not_called()
+        adapter._send_file_message.assert_not_called()
+
+
+class TestUploadMediaFixes:
+
+    @pytest.mark.asyncio
+    async def test_timeout_exception(self, tmp_path):
+        """FIX 6: httpx.TimeoutException propagates as RuntimeError with 'timed out'."""
+        from plugins.platforms.dingtalk.adapter import DingTalkAdapter
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        img = tmp_path / "photo.png"
+        img.write_bytes(b"\x89PNG" + b"\x00" * 100)
+
+        adapter._http_client = AsyncMock()
+        adapter._get_access_token = AsyncMock(return_value="token")
+        adapter._http_client.post = AsyncMock(
+            side_effect=httpx.TimeoutException("Connection timed out")
+        )
+
+        with pytest.raises(RuntimeError, match="timed out"):
+            await adapter._upload_media(str(img))

--- a/tests/gateway/test_dingtalk.py
+++ b/tests/gateway/test_dingtalk.py
@@ -880,7 +880,6 @@ class TestSendImageFile:
         adapter._send_image_message = AsyncMock(
             return_value=MagicMock(success=True, message_id="img-msg-1")
         )
-        adapter._get_valid_webhook = MagicMock(return_value=None)
 
         with caplog.at_level(logging.INFO, logger="plugins.platforms.dingtalk.adapter"):
             result = await adapter.send_image_file(
@@ -888,6 +887,9 @@ class TestSendImageFile:
             )
         assert result.success is True
         adapter._upload_media.assert_called_once_with(str(img), media_type="image")
+        adapter._send_image_message.assert_called_once_with(
+            "group-1", "mid-img", caption="Look!"
+        )
         assert "Image sent to DingTalk" in caplog.text
         assert "photo.png" in caplog.text
         assert "img-msg-1" in caplog.text
@@ -941,7 +943,6 @@ class TestSendDocument:
         adapter._send_file_message = AsyncMock(
             return_value=MagicMock(success=True, message_id="file-msg-1")
         )
-        adapter._get_valid_webhook = MagicMock(return_value=None)
 
         with caplog.at_level(logging.INFO, logger="plugins.platforms.dingtalk.adapter"):
             result = await adapter.send_document("group-1", str(doc))
@@ -962,7 +963,6 @@ class TestSendDocument:
         adapter._send_file_message = AsyncMock(
             return_value=MagicMock(success=True)
         )
-        adapter._get_valid_webhook = MagicMock(return_value=None)
 
         result = await adapter.send_document(
             "group-1", str(doc), file_name="quarterly.pdf"

--- a/tests/gateway/test_dingtalk.py
+++ b/tests/gateway/test_dingtalk.py
@@ -1,5 +1,6 @@
 """Tests for DingTalk platform adapter."""
 import asyncio
+import logging
 from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -765,3 +766,388 @@ class TestDingTalkAdapterAICards:
         mock_card_sdk.deliver_card_with_options_async.assert_called_once()
         mock_card_sdk.streaming_update_with_options_async.assert_called_once()
         assert result.success is True
+
+
+# ===========================================================================
+# Outbound media — endpoint selection
+# ===========================================================================
+
+
+class TestResolveOutboundEndpoint:
+
+    @pytest.mark.asyncio
+    async def test_group(self):
+        from plugins.platforms.dingtalk.adapter import DingTalkAdapter
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        endpoint, target = await adapter._resolve_outbound_endpoint(
+            "group-chat-123"
+        )
+        assert "groupMessages/send" in endpoint
+        assert target == {"openConversationId": "group-chat-123"}
+
+    @pytest.mark.asyncio
+    async def test_dm_falls_back_to_group(self):
+        from plugins.platforms.dingtalk.adapter import DingTalkAdapter
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        endpoint, target = await adapter._resolve_outbound_endpoint(
+            "user-abc"
+        )
+        assert "groupMessages/send" in endpoint
+        assert target == {"openConversationId": "user-abc"}
+
+
+# ===========================================================================
+# Outbound media — upload
+# ===========================================================================
+
+
+class TestUploadMedia:
+
+    @pytest.mark.asyncio
+    async def test_success(self, tmp_path):
+        from plugins.platforms.dingtalk.adapter import DingTalkAdapter
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        img = tmp_path / "test.jpg"
+        img.write_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 100)
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"media_id": "mid-123"}
+        adapter._http_client = AsyncMock()
+        adapter._http_client.post = AsyncMock(return_value=mock_resp)
+        adapter._get_access_token = AsyncMock(return_value="token")
+
+        media_id = await adapter._upload_media(str(img), media_type="image")
+        assert media_id == "mid-123"
+
+    @pytest.mark.asyncio
+    async def test_file_not_found(self):
+        from plugins.platforms.dingtalk.adapter import DingTalkAdapter
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        adapter._http_client = AsyncMock()
+        with pytest.raises(RuntimeError, match="File not found"):
+            await adapter._upload_media("/nonexistent/file.jpg")
+
+    @pytest.mark.asyncio
+    async def test_http_error(self, tmp_path):
+        from plugins.platforms.dingtalk.adapter import DingTalkAdapter
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        img = tmp_path / "test.jpg"
+        img.write_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 100)
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 500
+        adapter._http_client = AsyncMock()
+        adapter._http_client.post = AsyncMock(return_value=mock_resp)
+        adapter._get_access_token = AsyncMock(return_value="token")
+
+        with pytest.raises(RuntimeError, match="DingTalk media upload failed"):
+            await adapter._upload_media(str(img))
+
+    @pytest.mark.asyncio
+    async def test_missing_media_id(self, tmp_path):
+        from plugins.platforms.dingtalk.adapter import DingTalkAdapter
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        img = tmp_path / "test.jpg"
+        img.write_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 100)
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"errcode": 0}
+        adapter._http_client = AsyncMock()
+        adapter._http_client.post = AsyncMock(return_value=mock_resp)
+        adapter._get_access_token = AsyncMock(return_value="token")
+
+        with pytest.raises(RuntimeError, match="missing media_id"):
+            await adapter._upload_media(str(img))
+
+
+# ===========================================================================
+# send_image_file
+# ===========================================================================
+
+
+class TestSendImageFile:
+
+    @pytest.mark.asyncio
+    async def test_success(self, tmp_path, caplog):
+        from plugins.platforms.dingtalk.adapter import DingTalkAdapter
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        img = tmp_path / "photo.png"
+        img.write_bytes(b"\x89PNG" + b"\x00" * 100)
+
+        adapter._upload_media = AsyncMock(return_value="mid-img")
+        adapter._send_image_message = AsyncMock(
+            return_value=MagicMock(success=True, message_id="img-msg-1")
+        )
+        adapter._get_valid_webhook = MagicMock(return_value=None)
+
+        with caplog.at_level(logging.INFO, logger="plugins.platforms.dingtalk.adapter"):
+            result = await adapter.send_image_file(
+                "group-1", str(img), caption="Look!"
+            )
+        assert result.success is True
+        adapter._upload_media.assert_called_once_with(str(img), media_type="image")
+        assert "Image sent to DingTalk" in caplog.text
+        assert "photo.png" in caplog.text
+        assert "img-msg-1" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_missing_file(self):
+        from plugins.platforms.dingtalk.adapter import DingTalkAdapter
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        result = await adapter.send_image_file("chat-1", "/no/such/file.jpg")
+        assert result.success is False
+        assert result.error == "File not found: /no/such/file.jpg"
+
+    @pytest.mark.asyncio
+    async def test_directory_path(self, tmp_path):
+        from plugins.platforms.dingtalk.adapter import DingTalkAdapter
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        result = await adapter.send_image_file("chat-1", str(tmp_path))
+        assert result.success is False
+        assert "Not a file" in result.error
+
+    @pytest.mark.asyncio
+    async def test_upload_error(self, tmp_path):
+        from plugins.platforms.dingtalk.adapter import DingTalkAdapter
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        img = tmp_path / "photo.png"
+        img.write_bytes(b"\x89PNG" + b"\x00" * 100)
+
+        adapter._upload_media = AsyncMock(
+            side_effect=RuntimeError("Upload timeout")
+        )
+        result = await adapter.send_image_file("chat-1", str(img))
+        assert result.success is False
+        assert "Upload timeout" in result.error
+
+
+# ===========================================================================
+# send_document
+# ===========================================================================
+
+
+class TestSendDocument:
+
+    @pytest.mark.asyncio
+    async def test_success(self, tmp_path, caplog):
+        from plugins.platforms.dingtalk.adapter import DingTalkAdapter
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        doc = tmp_path / "report.pdf"
+        doc.write_bytes(b"%PDF" + b"\x00" * 100)
+
+        adapter._upload_media = AsyncMock(return_value="mid-doc")
+        adapter._send_file_message = AsyncMock(
+            return_value=MagicMock(success=True, message_id="file-msg-1")
+        )
+        adapter._get_valid_webhook = MagicMock(return_value=None)
+
+        with caplog.at_level(logging.INFO, logger="plugins.platforms.dingtalk.adapter"):
+            result = await adapter.send_document("group-1", str(doc))
+        assert result.success is True
+        adapter._upload_media.assert_called_once_with(str(doc), media_type="file")
+        assert "File sent to DingTalk" in caplog.text
+        assert "report.pdf" in caplog.text
+        assert "file-msg-1" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_with_custom_filename(self, tmp_path):
+        from plugins.platforms.dingtalk.adapter import DingTalkAdapter
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        doc = tmp_path / "report_v2.pdf"
+        doc.write_bytes(b"%PDF" + b"\x00" * 100)
+
+        adapter._upload_media = AsyncMock(return_value="mid")
+        adapter._send_file_message = AsyncMock(
+            return_value=MagicMock(success=True)
+        )
+        adapter._get_valid_webhook = MagicMock(return_value=None)
+
+        result = await adapter.send_document(
+            "group-1", str(doc), file_name="quarterly.pdf"
+        )
+        assert result.success is True
+        adapter._send_file_message.assert_called_once_with(
+            "group-1", "mid", "quarterly.pdf"
+        )
+
+    @pytest.mark.asyncio
+    async def test_missing_file(self):
+        from plugins.platforms.dingtalk.adapter import DingTalkAdapter
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        result = await adapter.send_document(
+            "chat-1", "/no/such/file.pdf"
+        )
+        assert result.success is False
+        assert result.error == "File not found: /no/such/file.pdf"
+
+    @pytest.mark.asyncio
+    async def test_upload_error(self, tmp_path):
+        from plugins.platforms.dingtalk.adapter import DingTalkAdapter
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        doc = tmp_path / "doc.pdf"
+        doc.write_bytes(b"%PDF" + b"\x00" * 100)
+
+        adapter._upload_media = AsyncMock(
+            side_effect=RuntimeError("Upload failed")
+        )
+        result = await adapter.send_document("chat-1", str(doc))
+        assert result.success is False
+
+
+# ===========================================================================
+# _send_robot_media_message
+# ===========================================================================
+
+
+class TestSendRobotMediaMessage:
+
+    @pytest.mark.asyncio
+    async def test_success(self):
+        from plugins.platforms.dingtalk.adapter import DingTalkAdapter
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        adapter._http_client = AsyncMock()
+        adapter._get_access_token = AsyncMock(return_value="token")
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"processQueryKey": "pqk-123"}
+        adapter._http_client.post = AsyncMock(return_value=mock_resp)
+
+        result = await adapter._send_robot_media_message(
+            "group-1",
+            msg_key="sampleImageMsg",
+            msg_param={"photoURL": "mid-1"},
+            kind_label="image",
+        )
+        assert result.success is True
+        assert result.message_id == "pqk-123"
+
+    @pytest.mark.asyncio
+    async def test_no_http_client(self):
+        from plugins.platforms.dingtalk.adapter import DingTalkAdapter
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        result = await adapter._send_robot_media_message(
+            "group-1",
+            msg_key="sampleImageMsg",
+            msg_param={"photoURL": "mid-1"},
+            kind_label="image",
+        )
+        assert result.success is False
+        assert "HTTP client not initialized" in result.error
+
+    @pytest.mark.asyncio
+    async def test_token_failure(self):
+        from plugins.platforms.dingtalk.adapter import DingTalkAdapter
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        adapter._http_client = AsyncMock()
+        adapter._get_access_token = AsyncMock(return_value=None)
+
+        result = await adapter._send_robot_media_message(
+            "group-1",
+            msg_key="sampleImageMsg",
+            msg_param={"photoURL": "mid-1"},
+            kind_label="image",
+        )
+        assert result.success is False
+        assert "access token" in result.error
+
+    @pytest.mark.asyncio
+    async def test_http_error(self):
+        from plugins.platforms.dingtalk.adapter import DingTalkAdapter
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        adapter._http_client = AsyncMock()
+        adapter._get_access_token = AsyncMock(return_value="token")
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 500
+        mock_resp.text = "Internal Server Error"
+        adapter._http_client.post = AsyncMock(return_value=mock_resp)
+
+        result = await adapter._send_robot_media_message(
+            "group-1",
+            msg_key="sampleFile",
+            msg_param={
+                "mediaId": "mid-1",
+                "fileName": "test.pdf",
+                "fileType": "pdf",
+            },
+            kind_label="file",
+        )
+        assert result.success is False
+        assert "HTTP 500" in result.error
+
+
+# ===========================================================================
+# _send_image_message
+# ===========================================================================
+
+
+class TestSendImageMessage:
+
+    @pytest.mark.asyncio
+    async def test_without_caption(self):
+        from plugins.platforms.dingtalk.adapter import DingTalkAdapter
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        adapter._send_robot_media_message = AsyncMock(
+            return_value=MagicMock(success=True)
+        )
+
+        result = await adapter._send_image_message("group-1", "mid-1")
+        assert result.success is True
+        call_kwargs = adapter._send_robot_media_message.call_args.kwargs
+        assert call_kwargs["msg_key"] == "sampleImageMsg"
+        assert call_kwargs["msg_param"] == {"photoURL": "mid-1"}
+
+    @pytest.mark.asyncio
+    async def test_with_caption(self):
+        from plugins.platforms.dingtalk.adapter import DingTalkAdapter
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        adapter._send_robot_media_message = AsyncMock(
+            return_value=MagicMock(success=True)
+        )
+
+        result = await adapter._send_image_message(
+            "group-1", "mid-1", caption="Hello"
+        )
+        assert result.success is True
+        call_kwargs = adapter._send_robot_media_message.call_args.kwargs
+        assert call_kwargs["msg_param"] == {"photoURL": "mid-1", "text": "Hello"}
+
+
+# ===========================================================================
+# _send_file_message
+# ===========================================================================
+
+
+class TestSendFileMessage:
+
+    @pytest.mark.asyncio
+    async def test_success(self):
+        from plugins.platforms.dingtalk.adapter import DingTalkAdapter
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        adapter._send_robot_media_message = AsyncMock(
+            return_value=MagicMock(success=True)
+        )
+
+        result = await adapter._send_file_message(
+            "group-1", "mid-1", "report.pdf"
+        )
+        assert result.success is True
+        call_kwargs = adapter._send_robot_media_message.call_args.kwargs
+        assert call_kwargs["msg_key"] == "sampleFile"
+        assert call_kwargs["msg_param"] == {
+            "mediaId": "mid-1",
+            "fileName": "report.pdf",
+            "fileType": "pdf",
+        }
+
+    @pytest.mark.asyncio
+    async def test_missing_extension(self):
+        from plugins.platforms.dingtalk.adapter import DingTalkAdapter
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+
+        result = await adapter._send_file_message("group-1", "mid-1", "noext")
+        assert result.success is False
+        assert "Missing file extension" in result.error


### PR DESCRIPTION
Closes #34329.

## Summary

Implements **outbound image/file upload** for the DingTalk plugin adapter, replacing two failure stubs with working native media delivery.

This re-implements the outbound half of #9451 (@dingtalkwukong — thank you for the original implementation and reference; the inbound half of that PR was made redundant by the plugin migration) against the plugin architecture introduced in `560010547`, which deleted the PR's target file `gateway/platforms/dingtalk.py` and left it structurally unmergeable.

## What changed

`plugins/platforms/dingtalk/adapter.py`:

- `send_image_file()` / `send_document()` — were `SendResult(success=False, error="webhook replies do not support ...")` stubs; now upload via `POST https://oapi.dingtalk.com/media/upload` (multipart, `type=image|file`) and send native robot messages via `POST https://api.dingtalk.com/v1.0/robot/groupMessages/send` (`msgKey` `sampleImageMsg` / `sampleFile`, `x-acs-dingtalk-access-token` header).
- New private helpers: `_upload_media`, `_resolve_outbound_endpoint`, `_send_robot_media_message`, `_send_image_message`, `_send_file_message`.
- Image captions are delivered **once**, natively, in the `sampleImageMsg` `text` field.
- Document captions are delivered as a **companion text message** after successful file delivery (`sampleFile` has no text field).
- All error paths return `SendResult(success=False, ...)` — nothing raises out of the public methods. Send fails closed on HTTP 200 responses missing `processQueryKey`.
- Upload reads the file via `asyncio.to_thread` (no event-loop blocking); explicit `httpx.TimeoutException` / `RequestError` handling with actionable error messages; local-path validation and file-extension validation both happen **before** any network I/O.

`tests/gateway/test_dingtalk.py`: +29 tests (mocked httpx, no network) covering upload success/failure, endpoint selection, path/extension validation, token failure, business-error payloads, caption delivery, and the fail-closed response branch.

## Notes

**Open question:** DM (1:1) outbound media currently falls back to `groupMessages/send` with a logged warning, because the adapter has no `chat_id → staff_id` cache; doing DM-native delivery via `oToMessages/batchSend` would require persisting sender staff IDs from inbound messages. Happy to add that as a follow-up if maintainers prefer DM-native delivery.

Follow-ups (intentionally out of scope here): voice/video outbound; upload size guard (DingTalk caps: 20 MB images / 100 MB files); DM log-spam suppression.

## Verification

- `pytest tests/gateway/test_dingtalk.py -q` → **60 passed** (31 existing + 29 new), no network.
- Full review trail: spec compliance review → code quality review → two rounds of cross-vendor review (Gemini 3.7 Flash + GPT-OSS 120B). Round 1 surfaced 2 BLOCKERs (fail-open on missing `processQueryKey`; silently dropped document captions) and 4 SHOULD-FIXs — all fixed in `71042f7fab` / `9db4021ae1`; round 2 returned APPROVED.
