### PR TITLE
fix(desktop): retain the largest cacheable transcript tail

### DIFF
--- a/apps/desktop/src/store/transcript-tail-cache.test.ts
+++ b/apps/desktop/src/store/transcript-tail-cache.test.ts
@@ -54,6 +54,18 @@ describe('transcript tail cache', () => {
     expect(loaded?.[7].id).toBe('h39')
   })
 
+  it('keeps the largest complete suffix when fewer than eight heavy messages fit', () => {
+    // The old fixed 8-message retry discarded this otherwise cacheable tail:
+    // 3 x 100KB is oversized, while the newest 2 messages fit under the cap.
+    const heavy = Array.from({ length: 3 }, (_, index) => msg(`short-heavy-${index}`, 100_000))
+    saveTranscriptTail('sess-short-heavy', heavy)
+
+    const loaded = loadTranscriptTail('sess-short-heavy')
+
+    expect(loaded).toHaveLength(2)
+    expect(loaded?.map(message => message.id)).toEqual(['short-heavy-1', 'short-heavy-2'])
+  })
+
   it('ignores empty saves and blank ids', () => {
     saveTranscriptTail('', [msg('1')])
     saveTranscriptTail('sess-empty', [])

--- a/apps/desktop/src/store/transcript-tail-cache.ts
+++ b/apps/desktop/src/store/transcript-tail-cache.ts
@@ -158,6 +158,39 @@ function touchIndex(store: Storage, suffix: string): void {
   writeIndex(store, ids)
 }
 
+/** Serialize the largest complete suffix that fits the per-entry cap.
+ *  TAIL_MESSAGES is small, so a binary search needs at most six bounded
+ *  serializations while avoiding arbitrary fallback sizes that can discard a
+ *  perfectly cacheable recent turn. */
+function serializeLargestTail(messages: ChatMessage[], savedAt: number): string | null {
+  const bounded = messages.slice(-TAIL_MESSAGES)
+  let low = 1
+  let high = bounded.length
+  let best: string | null = null
+
+  while (low <= high) {
+    const count = Math.floor((low + high) / 2)
+    let serialized: string
+
+    try {
+      serialized = JSON.stringify({ messages: bounded.slice(-count), savedAt } satisfies CacheEntry)
+    } catch {
+      high = count - 1
+
+      continue
+    }
+
+    if (serialized.length <= MAX_ENTRY_BYTES) {
+      best = serialized
+      low = count + 1
+    } else {
+      high = count - 1
+    }
+  }
+
+  return best
+}
+
 /** Persist the tail of a session's transcript. No-op on empty/oversized.
  *  Pass the session's owning scope ({connectionId, profile}, or just the
  *  profile name) so the entry can only ever be read against that backend. */
@@ -173,30 +206,10 @@ export function saveTranscriptTail(
     return
   }
 
-  const entry: CacheEntry = { messages: messages.slice(-TAIL_MESSAGES), savedAt: Date.now() }
+  const serialized = serializeLargestTail(messages, Date.now())
 
-  let serialized: string
-
-  try {
-    serialized = JSON.stringify(entry)
-  } catch {
-    return // non-serializable parts (live handles) — skip, never throw
-  }
-
-  if (serialized.length > MAX_ENTRY_BYTES) {
-    // Retry with a shorter tail before giving up; a session dominated by a
-    // few huge tool results still caches its recent turns.
-    const shorter: CacheEntry = { messages: messages.slice(-8), savedAt: entry.savedAt }
-
-    try {
-      serialized = JSON.stringify(shorter)
-    } catch {
-      return
-    }
-
-    if (serialized.length > MAX_ENTRY_BYTES) {
-      return
-    }
+  if (!serialized) {
+    return
   }
 
   const suffix = entrySuffix(id, scope)


### PR DESCRIPTION
## What does this PR do?

The Desktop transcript cache currently serializes the newest 40 messages, then falls back directly to the newest 8 when that exceeds the 256 KiB cap. If those 8 are still too large, it drops the cache entry even when a smaller complete suffix would fit. That turns a cacheable recent transcript into a cold resume on the next launch.

This replaces the fixed fallback with a bounded binary search for the largest complete message suffix that fits. It preserves the existing 40-message and 256 KiB limits, never truncates a message, and needs at most six serialization attempts.

The durable transcript-tail cache is existing core Desktop behavior introduced by merged PR #89510. This PR fixes that core cache's serializer independently of #96721. PR #96721 is related because it keeps an already-cached transcript visible while the live session resumes; this PR ensures the existing cache does not unnecessarily discard a complete suffix that #96721 could paint.

This is intentionally separate from the transcript-provenance work in #96130. It changes only which bounded payload is retained after the caller has already established the cache identity.

## Desktop performance series

This change is one independently reviewable layer of the same Desktop startup and first-interaction performance pass.

- #96749 removes unrelated CLI parser work from the `hermes serve` entry path.
- #96750 overlaps independent cached startup preparation before the existing readiness join.
- #96751 lets the verified local Desktop control socket bind before nonessential runtime services finish loading.
- #97032 starts the backend before first-window setup and defers noncritical Electron integrations.
- #97027 releases the renderer boot barrier once the gateway socket and active profile are ready, while noncritical hydration continues.
- #96717 paints connection/profile-scoped session and project navigation from bounded snapshots while live refresh continues.
- #96721 paints the exact connection/profile-scoped remembered transcript before backend/profile hydration, then keeps it visible while the live runtime resumes.
- #96921 prevents the existing transcript cache from discarding a complete suffix that still fits its storage bound.
- #97037 warms common lazy route code serially during idle time in the connected primary window, without prefetching route data.
- #96728 progressively hydrates Bot Mode roster presentation without changing canonical chat identity.

The three Python backend PRs share startup files but solve separate stages. Recommended landing order is #96749, then #96750, then #96751, rebasing the next PR only after the preceding one lands. #97032 is an independently reviewable Electron ordering change. The remaining renderer and Bot Mode PRs can also land independently; their effects compose without making cached state authoritative.
This PR owns transcript-cache retention correctness: the existing bounded cache keeps the largest complete suffix that fits instead of dropping a cacheable tail.


## Related Issue

No linked issue.

Related work:

- #89510 introduced the durable core transcript-tail cache and its bounded storage contract (merged).
- #96721 keeps an existing cached transcript visible while live session resume continues (open).
- #96130 gates warm transcript paint on persisted provenance; this PR does not change that authority boundary (open).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Replace the fixed 8-message retry in `apps/desktop/src/store/transcript-tail-cache.ts` with a bounded search for the largest complete suffix under the existing cap.
- Add a regression case where three heavy messages exceed the cap but the newest two fit and must remain cacheable.

## How to Test

1. Run `npm run test:ui -- src/store/transcript-tail-cache.test.ts --maxWorkers=4 --reporter=verbose` from `apps/desktop`.
2. Run `npm run typecheck` from `apps/desktop`.
3. Run `npx eslint src/store/transcript-tail-cache.ts src/store/transcript-tail-cache.test.ts` from `apps/desktop`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (not applicable to this renderer-only TypeScript change; focused Vitest and Desktop typecheck passed)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A; behavior and bounds are documented beside the serializer
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - pure renderer/localStorage logic, no platform-specific path
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

Focused result: 15 tests passed, including the new short-heavy transcript regression. Desktop typecheck and affected-file ESLint also passed.