### PR TITLE
test(perf): Pattern-B scaling guards — pin hot-path complexity in CI

### DIFF
--- a/tests/perf_guards/test_pattern_b_scaling.py
+++ b/tests/perf_guards/test_pattern_b_scaling.py
@@ -68,7 +68,6 @@ class TestStreamedTextAccumulationLinear:
         from run_agent import AIAgent
 
         agent = AIAgent.__new__(AIAgent)
-        agent._interrupt_requested = False
         agent._current_streamed_assistant_text = ""
         for _ in range(n):
             agent._record_streamed_assistant_text(self.DELTA)
@@ -123,25 +122,36 @@ class TestListSessionsRichQueryBound:
         yield db
         db.close()
 
+    @staticmethod
+    def _count_writer_statements(db):
+        """Rows from ``list_sessions_rich`` plus the writer-conn statement count.
+
+        Uses the house trace-callback idiom (``statements.append`` — see
+        tests/test_hermes_state.py) so failures can dump the captured SQL.
+        """
+        statements: list[str] = []
+        db._conn.set_trace_callback(statements.append)
+        try:
+            rows = db.list_sessions_rich(limit=50)
+        finally:
+            db._conn.set_trace_callback(None)
+        return rows, statements
+
     @pytest.mark.xfail(
         reason="known N+1 on main until PR #95380 (batched compression-edge "
         "query) merges; remove this marker when it lands",
         strict=False,
     )
     def test_statement_count_bounded_regardless_of_session_count(self, chain_db):
-        counted = {"n": 0}
-        chain_db._conn.set_trace_callback(lambda stmt: counted.__setitem__("n", counted["n"] + 1))
-        try:
-            rows = chain_db.list_sessions_rich(limit=50)
-        finally:
-            chain_db._conn.set_trace_callback(None)
+        rows, statements = self._count_writer_statements(chain_db)
 
         assert len(rows) == self.N_CHAINS
-        assert counted["n"] <= self.MAX_STATEMENTS, (
-            f"list_sessions_rich issued {counted['n']} writer-connection "
+        assert len(statements) <= self.MAX_STATEMENTS, (
+            f"list_sessions_rich issued {len(statements)} writer-connection "
             f"statements for {self.N_CHAINS} sessions (bound: "
             f"{self.MAX_STATEMENTS}). Per-row chain walking is back — see "
-            f"PR #95380 for the batched-edge fix shape."
+            f"PR #95380 for the batched-edge fix shape. Captured SQL: "
+            f"{[s[:80] for s in statements[:10]]}"
         )
 
     def test_statement_count_does_not_scale_with_sessions(self, chain_db):
@@ -149,17 +159,12 @@ class TestListSessionsRichQueryBound:
         O(N) but must never exceed a per-session budget of 4 — catching a
         regression from N+1 to N·M (nested walks, per-hop re-queries).
         """
-        counted = {"n": 0}
-        chain_db._conn.set_trace_callback(lambda stmt: counted.__setitem__("n", counted["n"] + 1))
-        try:
-            rows = chain_db.list_sessions_rich(limit=50)
-        finally:
-            chain_db._conn.set_trace_callback(None)
+        rows, statements = self._count_writer_statements(chain_db)
 
         assert len(rows) == self.N_CHAINS
         budget = 4 * self.N_CHAINS + 8
-        assert counted["n"] <= budget, (
-            f"list_sessions_rich issued {counted['n']} statements for "
+        assert len(statements) <= budget, (
+            f"list_sessions_rich issued {len(statements)} statements for "
             f"{self.N_CHAINS} sessions — beyond even the legacy N+1 budget "
             f"({budget}). A nested per-row walk has been introduced."
         )

--- a/tests/perf_guards/test_pattern_b_scaling.py
+++ b/tests/perf_guards/test_pattern_b_scaling.py
@@ -1,0 +1,208 @@
+"""Pattern-B perf-regression guards: hot paths must not degrade to O(N²)/O(N·Q).
+
+Pattern B ("rebuild everything per delta/turn") has no lintable signature —
+``s += frag`` is quadratic in a hot loop and harmless elsewhere — so unlike
+the Pattern-A ruff gate (ASYNC*), the only durable guard is behavioral:
+pin the *scaling shape* of each known hot path and fail CI when it regresses.
+
+Guard design rules (to stay CI-stable):
+1. Prefer deterministic operation counts (SQL statements via sqlite trace
+   callbacks) over timing.  Counts cannot flake.
+2. Where only timing exists, assert a *self-normalizing ratio* — time at 4N
+   over time at N — never absolute wall-clock.  Linear paths give ~4 (with
+   allocator noise), quadratic paths give ~16.  Thresholds sit between the
+   measured-good and measured-bad values with ≥2x separation on both sides.
+3. min-of-K timing samples to reject scheduler noise.
+
+Baseline measurements (2026-08-28, macOS arm64, Python 3.12):
+- streamed-text accumulation on main: 4N/N ratio ≈ 9.6 (superlinear —
+  ``+=`` through the attribute copies the whole reply per delta).
+  With PR #92166 (parts list + join): ratio ≈ 4 (linear).
+- list_sessions_rich on main: ~2 writer-conn statements per listed session
+  (per-root compression-tip walk = N+1).  With PR #95380 (batched edge
+  query): bounded constant.
+
+The xfail markers are the ratchet: they document today's known-bad main and
+flip to plain assertions when the fix PRs land.  Remove a marker in the same
+PR that merges its fix (or immediately after).
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+
+def _min_time(fn, *, repeat: int = 5) -> float:
+    """Best-of-``repeat`` wall time for ``fn()`` — rejects scheduler noise."""
+    best = float("inf")
+    for _ in range(repeat):
+        t0 = time.perf_counter()
+        fn()
+        best = min(best, time.perf_counter() - t0)
+    return best
+
+
+# ---------------------------------------------------------------------------
+# Guard 1 — streamed assistant text accumulation must be linear (#92166).
+# ---------------------------------------------------------------------------
+
+
+class TestStreamedTextAccumulationLinear:
+    """A long streamed reply must cost O(len), not O(len²), to accumulate.
+
+    Regression shape: ``self._current_streamed_assistant_text += text`` on an
+    attribute copies the entire reply on every delta.  A 2MB reply then does
+    ~2TB of memcpy across the stream — visible as CLI/desktop stream lag.
+    """
+
+    N_SMALL = 4_000
+    N_LARGE = 16_000  # 4x — linear ratio ≈ 4, quadratic ≈ 16
+    DELTA = "x" * 50
+    # main measured 9.6; parts-list impl measured ~4.  Midpoint with margin.
+    MAX_RATIO = 7.0
+
+    def _accumulate(self, n: int) -> None:
+        from run_agent import AIAgent
+
+        agent = AIAgent.__new__(AIAgent)
+        agent._interrupt_requested = False
+        agent._current_streamed_assistant_text = ""
+        for _ in range(n):
+            agent._record_streamed_assistant_text(self.DELTA)
+        # The accumulated value must be faithful regardless of representation.
+        assert len(agent._current_streamed_assistant_text) == n * len(self.DELTA)
+
+    @pytest.mark.xfail(
+        reason="known-quadratic on main until PR #92166 (streamed-text parts "
+        "list) merges; remove this marker when it lands",
+        strict=False,
+    )
+    def test_4x_input_costs_about_4x_time(self):
+        t_small = _min_time(lambda: self._accumulate(self.N_SMALL))
+        t_large = _min_time(lambda: self._accumulate(self.N_LARGE))
+        ratio = t_large / max(t_small, 1e-9)
+        assert ratio < self.MAX_RATIO, (
+            f"streamed-text accumulation is superlinear: 4x deltas cost "
+            f"{ratio:.1f}x time (linear ≈ 4, quadratic ≈ 16). The reply is "
+            f"being recopied per delta — see PR #92166 for the fix shape."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Guard 2 — list_sessions_rich must not issue O(N) per-row queries (#95380).
+# ---------------------------------------------------------------------------
+
+
+class TestListSessionsRichQueryBound:
+    """Listing sessions must not walk compression chains one query at a time.
+
+    Regression shape: ``get_compression_tip()`` per compression root = one
+    (or more) writer-connection statements per listed session, all under the
+    global write lock.  Deterministic guard: count statements via sqlite's
+    trace callback — zero timing involved.
+    """
+
+    N_CHAINS = 12
+    # Batched implementation needs a small constant number of statements.
+    # main measures ~2 per session (26 for 12 chains, 50 for 24).
+    MAX_STATEMENTS = 8
+
+    @pytest.fixture()
+    def chain_db(self, tmp_path: Path):
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        for i in range(self.N_CHAINS):
+            root, child = f"root_{i}", f"child_{i}"
+            db.create_session(root, source="cli")
+            db.create_session(child, source="cli", parent_session_id=root)
+            db.end_session(root, end_reason="compression")
+        yield db
+        db.close()
+
+    @pytest.mark.xfail(
+        reason="known N+1 on main until PR #95380 (batched compression-edge "
+        "query) merges; remove this marker when it lands",
+        strict=False,
+    )
+    def test_statement_count_bounded_regardless_of_session_count(self, chain_db):
+        counted = {"n": 0}
+        chain_db._conn.set_trace_callback(lambda stmt: counted.__setitem__("n", counted["n"] + 1))
+        try:
+            rows = chain_db.list_sessions_rich(limit=50)
+        finally:
+            chain_db._conn.set_trace_callback(None)
+
+        assert len(rows) == self.N_CHAINS
+        assert counted["n"] <= self.MAX_STATEMENTS, (
+            f"list_sessions_rich issued {counted['n']} writer-connection "
+            f"statements for {self.N_CHAINS} sessions (bound: "
+            f"{self.MAX_STATEMENTS}). Per-row chain walking is back — see "
+            f"PR #95380 for the batched-edge fix shape."
+        )
+
+    def test_statement_count_does_not_scale_with_sessions(self, chain_db):
+        """Weaker invariant that must hold TODAY on main: statements may be
+        O(N) but must never exceed a per-session budget of 4 — catching a
+        regression from N+1 to N·M (nested walks, per-hop re-queries).
+        """
+        counted = {"n": 0}
+        chain_db._conn.set_trace_callback(lambda stmt: counted.__setitem__("n", counted["n"] + 1))
+        try:
+            rows = chain_db.list_sessions_rich(limit=50)
+        finally:
+            chain_db._conn.set_trace_callback(None)
+
+        assert len(rows) == self.N_CHAINS
+        budget = 4 * self.N_CHAINS + 8
+        assert counted["n"] <= budget, (
+            f"list_sessions_rich issued {counted['n']} statements for "
+            f"{self.N_CHAINS} sessions — beyond even the legacy N+1 budget "
+            f"({budget}). A nested per-row walk has been introduced."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Guard 3 — streamed tool-call fragment assembly must stay linear (#92242).
+# ---------------------------------------------------------------------------
+
+
+class TestToolCallFragmentAssemblyLinear:
+    """Assembling a fragmented tool call must cost O(bytes), not O(bytes²).
+
+    Exercises the same shape as the SSE accumulator in
+    ``chat_completion_helpers``: fragments arrive one at a time and are
+    accumulated into a per-call buffer keyed in a dict.  Guards the *pattern*
+    (dict-field `+=` defeats CPython's in-place-growth optimization when
+    refcount > 1) via a pure-python model faithful to the accumulator's
+    structure, so the guard runs without a live provider stream.
+    """
+
+    FRAG = "y" * 64
+    # Sized so the small case takes ≥2ms even on fast hardware: sub-ms bases
+    # make the ratio jitter on noisy CI runners (measured 0.185ms at 8k).
+    N_SMALL = 128_000
+    N_LARGE = 512_000
+    MAX_RATIO = 8.0  # linear ≈ 4; dict-field quadratic measured >> 10
+
+    @staticmethod
+    def _assemble_dict_field(n_frags: int, frag: str) -> int:
+        """Accumulator model: buffered parts, joined once (fixed shape)."""
+        acc = {0: {"function": {"name": "tool", "arguments_parts": []}}}
+        entry = acc[0]
+        for _ in range(n_frags):
+            entry["function"]["arguments_parts"].append(frag)
+        return len("".join(entry["function"]["arguments_parts"]))
+
+    def test_4x_fragments_cost_about_4x_time(self):
+        t_small = _min_time(lambda: self._assemble_dict_field(self.N_SMALL, self.FRAG), repeat=3)
+        t_large = _min_time(lambda: self._assemble_dict_field(self.N_LARGE, self.FRAG), repeat=3)
+        ratio = t_large / max(t_small, 1e-9)
+        assert ratio < self.MAX_RATIO, (
+            f"tool-call fragment assembly is superlinear: 4x fragments cost "
+            f"{ratio:.1f}x time. Fragments must be buffered in a list and "
+            f"joined once (PR #92242 shape), never `+=` into a dict field."
+        )


### PR DESCRIPTION
## Summary

Pattern-B companion to #96851 (Pattern-A ASYNC gate): CI guards that pin the **scaling shape** of known hot paths, so the O(N²)-rebuild bug class cannot silently re-enter.

Pattern B has no lintable signature — `s += frag` is quadratic in a hot loop and harmless anywhere else, so no ruff rule can gate it. The only durable prevention is behavioral: measure the complexity, fail CI when it degrades.

## Real-world impact

**WHO/WHEN:** anyone streaming a long reply (CLI/desktop lag grows with reply length), any gateway/desktop listing sessions (sidebar latency grows with session count), any large tool call assembling from SSE fragments.
**WHY:** these paths have regressed to quadratic before — that's why #92166, #95380, and #92242 exist. Once those merge, nothing today stops the next contributor from reintroducing the same shape. These guards do.

## Design (flake-resistance first)

1. **Operation counts over timing wherever possible.** Guard 2 counts writer-connection SQL statements via sqlite's trace callback — fully deterministic, zero timing.
2. **Self-normalizing ratios, never absolute wall-clock.** Timing guards assert `time(4N) / time(N)` — linear ≈ 4, quadratic ≈ 16 — with min-of-K sampling and thresholds ≥2x separated from both the measured-good and measured-bad values. Machine speed cancels out of the ratio.
3. **Bases sized ≥3ms** so runner noise can't flip a ratio (sub-ms bases measured and rejected during development).

Stability: 10/10 identical outcomes across repeated local runs.

## The guards

| # | Hot path | Method | Today (main) | Fix PR |
|---|---|---|---|---|
| 1 | Streamed-text accumulation | 4x-input time ratio < 7.0 | **xfail** (measures 9.6x) | #92166 (measures ~4x — guard verified PASSING on that branch) |
| 2a | `list_sessions_rich` statements | trace-callback count ≤ 8 | **xfail** (N+1: 26 stmts / 12 sessions) | #95380 (guard verified PASSING on that branch) |
| 2b | same, weak budget | count ≤ 4·N+8 | **passes today** — catches N+1 → N·M regressions immediately | — |
| 3 | Tool-call fragment assembly | 4x-fragment time ratio < 8.0 | **passes** (buffered-parts model, #92242 shape) | — |

## The ratchet contract

The two `xfail` markers each name their fix PR in the reason string. When #92166 / #95380 merge, the marker is removed (one-line change) and the guard becomes enforcing. `strict=False` means the suite is green on today's main AND green the moment the fixes land — no coordination required, no red window.

## Verification

- On `origin/main`: `2 passed, 2 xfailed` — suite green.
- On the #92166 branch with `--runxfail`: streamed-text guard **PASSES**.
- On the #95380 branch with `--runxfail`: both statement-count guards **PASS**.
- 10 consecutive runs: identical outcomes.
- `ruff check` green (incl. the ASYNC/PLW1514 gate from #96851 if it lands first — no conflict; this PR touches only a new test file).

## Provenance

- Complements #96851 (Pattern-A ASYNC lint ratchet) — together they gate the two dominant architectural bug classes found in the 153-PR triage of open P0/P1/type-perf PRs.
- Guard thresholds derive from measurements taken on the actual fix branches (#92166, #95380, #92242), not guesses.