### PR TITLE
fix(approval): don't render a plugin rule's approval card as a fake command

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -4231,6 +4231,10 @@ class BasePlatformAdapter(ABC):
     # sharing the assembly logic (header → fenced command preview → reason →
     # optional smart-deny note).
     _EA_HEADER: str = "⚠️ Command Approval Required\n\n"
+    # Used when there is no command to preview — a plugin approval rule gates
+    # a tool call, not a shell string, so "Command" would name something the
+    # human is not being shown.
+    _EA_HEADER_NO_COMMAND: str = "⚠️ Approval Required\n\n"
     _EA_CODE_OPEN: str = "```\n"
     _EA_CODE_CLOSE: str = "\n```\n"
     _EA_REASON_LABEL: str = "Reason: "
@@ -4269,8 +4273,20 @@ class BasePlatformAdapter(ABC):
         ``_EA_SMART_DENY_LINE`` when ``smart_denied``. Button construction
         stays platform-local; adapters with additional trailing instructions
         (e.g. reaction legends) append them to this core.
+
+        An empty ``command`` means there is nothing to preview — a plugin
+        approval rule gates a tool call rather than a shell string. Rendering
+        an empty code fence there frames the description as an aside about a
+        command the reader cannot see, when it is in fact the entire request,
+        so the fence and the ``Reason:`` label are both dropped and the
+        no-command header is used instead.
         """
         cmd_preview = self._truncate_preview(str(command or ""), self._EA_CMD_BUDGET)
+        if not cmd_preview:
+            text = f"{self._EA_HEADER_NO_COMMAND}{self._ea_escape(description)}"
+            if smart_denied:
+                text += self._EA_SMART_DENY_LINE
+            return text
         text = (
             f"{self._EA_HEADER}"
             f"{self._EA_CODE_OPEN}{self._ea_escape(cmd_preview)}{self._EA_CODE_CLOSE}"

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -713,7 +713,14 @@ def _format_exec_approval_fallback(
 ) -> str:
     """Render the text fallback from approval capabilities, not platform names."""
     cmd_preview = command[:200] + "..." if len(command) > 200 else command
-    heading = "⚠️ **Dangerous command requires approval:**"
+    # An empty command means there is nothing to preview: a plugin approval
+    # rule gates a tool call rather than a shell string, so the description
+    # is the request itself rather than a note about a command shown above.
+    has_command = bool(cmd_preview)
+    heading = (
+        "⚠️ **Dangerous command requires approval:**" if has_command
+        else "⚠️ **Approval required:**"
+    )
     if smart_denied:
         heading = "⚠️ **Smart DENY — owner override for one operation:**"
 
@@ -725,10 +732,11 @@ def _format_exec_approval_fallback(
         if allow_permanent:
             choices.append(f"`{command_prefix}approve always` to approve permanently")
     choices.append(f"`{command_prefix}deny` to cancel")
-    return (
-        f"{heading}\n```\n{cmd_preview}\n```\nReason: {description}\n\n"
-        + ", ".join(choices[:-1]) + f", or {choices[-1]}."
+    body = (
+        f"{heading}\n```\n{cmd_preview}\n```\nReason: {description}\n\n" if has_command
+        else f"{heading}\n{description}\n\n"
     )
+    return body + ", ".join(choices[:-1]) + f", or {choices[-1]}."
 
 def _gateway_provider_error_reply(text: str) -> str:
     """Map raw provider/API errors to a short user-safe Telegram reply."""

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -6171,6 +6171,8 @@ class _PreToolCallDirective:
     action: Optional[str] = None
     message: Optional[str] = None
     rule_key: Optional[str] = None
+    allow_session: bool = True
+    allow_permanent: bool = True
     modified_args: Optional[Dict[str, Any]] = None
 
 
@@ -6204,6 +6206,7 @@ def _get_pre_tool_call_directive_details(
         {"action": "block",   "message": "Reason the tool was blocked"}
         {"action": "approve", "message": "Why this needs human confirmation"}
         {"action": "approve", "message": "...", "rule_key": "write_file:ssh"}
+        {"action": "approve", "message": "...", "allow_permanent": False}
 
     from their ``pre_tool_call`` callback.
 
@@ -6218,6 +6221,12 @@ def _get_pre_tool_call_directive_details(
       :func:`tools.approval.request_tool_approval`).
     - ``rule_key`` is optional and only honored for ``approve`` directives. It
       lets plugins choose the allowlist grain for `[a]lways` approvals.
+    - ``allow_session`` / ``allow_permanent`` are optional and only honored
+      for ``approve`` directives. Set either to ``False`` to drop that scope
+      from the prompt — for a rule whose key already names one subject, an
+      `[a]lways` answer can only widen a decision the human meant to make
+      once. Anything other than an explicit ``False`` leaves the scope
+      offered, so existing plugins are unaffected.
 
     The first valid directive wins. Invalid or irrelevant hook return values
     are silently ignored so existing observer-only hooks are unaffected.
@@ -6275,8 +6284,18 @@ def _get_pre_tool_call_directive_details(
         rule_key = rule_key.strip() if isinstance(rule_key, str) else None
         if not rule_key:
             rule_key = None
+        # Only an explicit False narrows the offered scopes. A missing or
+        # malformed value keeps every scope, so a plugin written against the
+        # older contract behaves exactly as it did.
+        def _scope(name: str) -> bool:
+            if action != "approve":
+                return True
+            return result.get(name) is not False
+
         return _PreToolCallDirective(
             action=action, message=message, rule_key=rule_key,
+            allow_session=_scope("allow_session"),
+            allow_permanent=_scope("allow_permanent"),
             modified_args=modified_args,
         )
 
@@ -6409,6 +6428,8 @@ def _resolve_block_from_details(
                     tool_name,
                     details.message or "",
                     rule_key=details.rule_key or tool_name,
+                    allow_session=details.allow_session,
+                    allow_permanent=details.allow_permanent,
                 )
             finally:
                 if approval_tokens is not None:

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -7491,17 +7491,22 @@ class DiscordAdapter(BasePlatformAdapter):
             if len(reason_display) > reason_budget:
                 reason_display = reason_display[: reason_budget - 15] + "... [truncated]"
 
+            # An empty command means there is nothing to preview: a plugin
+            # approval rule gates a tool call rather than a shell string.
+            has_command = bool(command)
             prompt_prefix = (
                 "⚠️ **Command Approval Required**\n\n"
                 "Do you want Hermes to run this command?\n\n"
                 "**Requested command:**\n```bash\n"
-            )
+            ) if has_command else "⚠️ **Approval Required**\n\n"
             if smart_denied:
                 prompt_prefix += "**Smart DENY:** owner override applies to this one operation only.\n\n"
             mention_content = self._approval_mention_content()
             if mention_content:
                 prompt_prefix = f"{mention_content}\n{prompt_prefix}"
-            prompt_tail = f"\n```\n**Reason:** {reason_display}"
+            prompt_tail = (
+                f"\n```\n**Reason:** {reason_display}" if has_command else reason_display
+            )
             truncated_suffix = "\n... [truncated]"
             command_budget = max(0, self.MAX_MESSAGE_LENGTH - len(prompt_prefix) - len(prompt_tail))
             content_cmd_display = str(command or "")
@@ -7519,11 +7524,14 @@ class DiscordAdapter(BasePlatformAdapter):
             if len(embed_cmd_display) > max_embed_desc:
                 embed_cmd_display = embed_cmd_display[: max_embed_desc - 3] + "..."
             embed = discord.Embed(
-                title="⚠️ Command Approval Required",
-                description=f"```\n{embed_cmd_display}\n```",
+                title="⚠️ Command Approval Required" if has_command else "⚠️ Approval Required",
+                description=(
+                    f"```\n{embed_cmd_display}\n```" if has_command else reason_display
+                ),
                 color=discord.Color.orange(),
             )
-            embed.add_field(name="Reason", value=reason_display, inline=False)
+            if has_command:
+                embed.add_field(name="Reason", value=reason_display, inline=False)
 
             require_admin, admin_user_ids = _resolve_exec_approval_admin_gate(
                 getattr(self.config, "extra", None)

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -2050,6 +2050,7 @@ class FeishuAdapter(BasePlatformAdapter):
     # Template attrs for the shared _format_exec_approval core. The card
     # header carries the title, so the text core starts at the code fence.
     _EA_HEADER = ""
+    _EA_HEADER_NO_COMMAND = ""
     _EA_REASON_LABEL = "**Reason:** "
     _EA_SMART_DENY_LINE = "\n\n**Smart DENY:** owner override applies to this one operation only."
     _EA_CMD_BUDGET = 3000

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -2642,6 +2642,7 @@ class MatrixAdapter(BasePlatformAdapter):
     # the smart-deny/scope wording in its local tail (reaction legend), so the
     # core is used for the header + fence + reason head only.
     _EA_HEADER = "⚠️ **Dangerous command requires approval**\n"
+    _EA_HEADER_NO_COMMAND = "⚠️ **Approval required**\n"
     _EA_CMD_BUDGET = 2000
 
     async def send_exec_approval(

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -7054,10 +7054,18 @@ class SlackAdapter(BasePlatformAdapter):
             # ``command``, so budget the preview against the fixed parts
             # instead of a flat truncation that overflows once the header +
             # reason are added.
-            header = ":warning: *Command Approval Required*\n"
+            # An empty command means there is nothing to preview: a plugin
+            # approval rule gates a tool call rather than a shell string, and
+            # an empty fence would frame the reason as an aside about
+            # something the reader cannot see.
+            has_command = bool(command)
+            header = (
+                ":warning: *Command Approval Required*\n" if has_command
+                else ":warning: *Approval Required*\n"
+            )
             if smart_denied:
                 header += "*Smart DENY:* owner override applies to this one operation only.\n"
-            reason = f"Reason: {description[:500]}"
+            reason = f"Reason: {description[:500]}" if has_command else description[:500]
             budget = 3000 - len(header) - len(reason) - len("``````\n") - len("...")
             cmd_preview = command[:budget] + "..." if len(command) > budget else command
 
@@ -7091,20 +7099,25 @@ class SlackAdapter(BasePlatformAdapter):
                 "action_id": "hermes_deny",
                 "value": session_key,
             })
+            section_text = (
+                f"{header}```{cmd_preview}```\n{reason}" if has_command
+                else f"{header}{reason}"
+            )
             blocks = [
                 {
                     "type": "section",
-                    "text": {
-                        "type": "mrkdwn",
-                        "text": f"{header}```{cmd_preview}```\n{reason}",
-                    },
+                    "text": {"type": "mrkdwn", "text": section_text},
                 },
                 {"type": "actions", "elements": actions},
             ]
 
+            notification_text = (
+                f"⚠️ Command approval required: {cmd_preview[:100]}" if has_command
+                else f"⚠️ Approval required: {description[:100]}"
+            )
             kwargs: Dict[str, Any] = {
                 "channel": chat_id,
-                "text": f"⚠️ Command approval required: {cmd_preview[:100]}",
+                "text": notification_text,
                 "blocks": sanitize_blocks(blocks),
             }
             if thread_ts:

--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -1219,11 +1219,20 @@ class TeamsAdapter(BasePlatformAdapter):
             title="Deny", verb="hermes_approve",
             data={**btn_data_base, "hermes_action": "deny"}, style="destructive",
         ))
-        body = [
-            TextBlock(text="⚠️ Command Approval Required", wrap=True, weight="Bolder"),
-            TextBlock(text=f"```\n{cmd_preview}\n```", wrap=True),
-            TextBlock(text=f"Reason: {description}", wrap=True, isSubtle=True),
-        ]
+        # No command to preview: a plugin approval rule gates a tool call, not
+        # a shell string, so the description is the whole request rather than
+        # a note about something shown above it.
+        if cmd_preview:
+            body = [
+                TextBlock(text="⚠️ Command Approval Required", wrap=True, weight="Bolder"),
+                TextBlock(text=f"```\n{cmd_preview}\n```", wrap=True),
+                TextBlock(text=f"Reason: {description}", wrap=True, isSubtle=True),
+            ]
+        else:
+            body = [
+                TextBlock(text="⚠️ Approval Required", wrap=True, weight="Bolder"),
+                TextBlock(text=description, wrap=True),
+            ]
         if smart_denied:
             body.append(TextBlock(
                 text="Smart DENY: owner override applies to this one operation only.", wrap=True

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -6296,6 +6296,7 @@ class TelegramAdapter(BasePlatformAdapter):
 
     # Template attrs for the shared _format_exec_approval core (HTML mode).
     _EA_HEADER = "⚠️ <b>Command Approval Required</b>\n\n"
+    _EA_HEADER_NO_COMMAND = "⚠️ <b>Approval Required</b>\n\n"
     _EA_CODE_OPEN = "<pre>"
     _EA_CODE_CLOSE = "</pre>\n\n"
     _EA_SMART_DENY_LINE = "\n\n<b>Smart DENY:</b> owner override applies to this one operation only."

--- a/tests/gateway/test_interactive_prompt_base.py
+++ b/tests/gateway/test_interactive_prompt_base.py
@@ -106,3 +106,38 @@ class TestAdapterParity:
                     assert meta["page"] == o_page
                     assert meta["total_pages"] == o_tp
                     assert meta["page_info"] == o_info
+
+
+class TestExecApprovalWithoutACommand:
+    """A plugin approval rule gates a tool call, not a shell string.
+
+    ``request_tool_approval`` passes ``display_is_command=False``, so the
+    gateway payload carries no command. An empty code fence there would frame
+    the description as an aside about something the reader cannot see, when it
+    is in fact the entire request.
+    """
+
+    def _adapter(self):
+        return _bare(_DefaultAdapter)
+
+    def test_no_fence_and_no_reason_label(self):
+        text = self._adapter()._format_exec_approval("", "Add this to Basia's Calendar")
+        assert "```" not in text
+        assert "Reason:" not in text
+        assert "Add this to Basia's Calendar" in text
+
+    def test_header_does_not_say_command(self):
+        text = self._adapter()._format_exec_approval("", "delete one record")
+        assert "Command" not in text
+        assert "Approval Required" in text
+
+    def test_smart_deny_note_is_kept(self):
+        text = self._adapter()._format_exec_approval("", "reason", smart_denied=True)
+        assert "Smart DENY" in text
+
+    def test_a_real_command_is_unchanged(self):
+        text = self._adapter()._format_exec_approval("rm -rf /tmp/x", "recursive delete")
+        assert "```" in text
+        assert "rm -rf /tmp/x" in text
+        assert "Reason: recursive delete" in text
+        assert "Command Approval Required" in text

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -2104,3 +2104,61 @@ class TestDispatchToolWithoutCliRef:
             assert calls[0][1].get("parent_agent") is None
         finally:
             registry.deregister("_test_dispatch_probe")
+
+
+class TestPreToolCallApprovalScopes:
+    """``allow_session`` / ``allow_permanent`` on an ``approve`` directive."""
+
+    def _directive(self, monkeypatch, result):
+        from hermes_cli import lifecycle, plugins
+
+        monkeypatch.setattr(lifecycle, "invoke_hook", lambda *a, **k: [result])
+        return plugins._get_pre_tool_call_directive_details("terminal", {})
+
+    def test_scopes_default_to_offered(self, monkeypatch):
+        d = self._directive(monkeypatch, {"action": "approve", "message": "why"})
+        assert d.allow_session is True
+        assert d.allow_permanent is True
+
+    def test_explicit_false_narrows_the_prompt(self, monkeypatch):
+        d = self._directive(monkeypatch, {
+            "action": "approve", "message": "why",
+            "allow_session": False, "allow_permanent": False,
+        })
+        assert d.allow_session is False
+        assert d.allow_permanent is False
+
+    def test_only_an_explicit_false_narrows(self, monkeypatch):
+        """A missing or malformed value must not silently drop a scope."""
+        d = self._directive(monkeypatch, {
+            "action": "approve", "message": "why",
+            "allow_permanent": "no", "allow_session": None,
+        })
+        assert d.allow_permanent is True
+        assert d.allow_session is True
+
+    def test_block_directives_ignore_the_scope_keys(self, monkeypatch):
+        d = self._directive(monkeypatch, {
+            "action": "block", "message": "no", "allow_permanent": False,
+        })
+        assert d.action == "block"
+        assert d.allow_permanent is True
+
+    def test_scopes_reach_the_approval_gate(self, monkeypatch):
+        from hermes_cli import lifecycle, plugins
+
+        seen = {}
+
+        def _approve(tool_name, reason, **kw):
+            seen.update(kw)
+            return {"approved": True}
+
+        monkeypatch.setattr("tools.approval.request_tool_approval", _approve)
+        monkeypatch.setattr(lifecycle, "invoke_hook", lambda *a, **k: [{
+            "action": "approve", "message": "delete one record",
+            "rule_key": "rec:42", "allow_permanent": False,
+        }])
+        assert plugins.resolve_pre_tool_block("terminal", {}) is None
+        assert seen["rule_key"] == "rec:42"
+        assert seen["allow_permanent"] is False
+        assert seen["allow_session"] is True

--- a/tests/tools/test_request_tool_approval.py
+++ b/tests/tools/test_request_tool_approval.py
@@ -244,6 +244,28 @@ class TestOfferedApprovalScopes:
         assert sent["allow_permanent"] is False
         assert sent["allow_session"] is False
 
+    def test_gateway_payload_carries_no_synthetic_command(self, monkeypatch):
+        """The label identifies the gate in logs; it is not a command.
+
+        Sending it as one puts a placeholder inside a code fence on every
+        surface, which reads as a command the human is meant to inspect.
+        """
+        sent = {}
+        monkeypatch.setattr(approval, "_is_interactive_cli", lambda: False)
+        monkeypatch.setattr(approval, "_is_gateway_approval_context", lambda: True)
+        monkeypatch.setitem(approval._gateway_notify_cbs, "test-session", lambda *a, **k: True)
+        monkeypatch.setattr(
+            approval, "_await_gateway_decision",
+            lambda session_key, notify_cb, approval_data, surface="gateway": (
+                sent.update(approval_data)
+                or {"resolved": True, "choice": "once", "reason": None}
+            ),
+        )
+        res = request_tool_approval("terminal", "Add this to the Calendar")
+        assert res["approved"] is True
+        assert sent["command"] == ""
+        assert sent["description"] == "Add this to the Calendar"
+
     def test_gateway_unoffered_always_is_not_persisted(self, monkeypatch):
         calls = {"permanent": []}
         monkeypatch.setattr(approval, "_is_interactive_cli", lambda: False)

--- a/tests/tools/test_request_tool_approval.py
+++ b/tests/tools/test_request_tool_approval.py
@@ -151,3 +151,126 @@ class TestRequestToolApproval:
         )
         res = request_tool_approval("terminal", "curl PUT", rule_key="ext")
         assert res == {"approved": True, "message": None}
+
+
+class TestOfferedApprovalScopes:
+    """A plugin rule may drop [s]ession / [a]lways from the prompt.
+
+    ``rule_key`` already lets a plugin choose the allowlist *grain*, but a key
+    that names a single subject — one file, one recipient, one event — has no
+    future call a stored answer could correctly apply to. Before this, such a
+    rule still rendered an ``always`` button whose only possible effect was to
+    widen a decision the human meant to make once.
+    """
+
+    def test_cli_prompt_is_told_which_scopes_to_offer(self, monkeypatch):
+        seen = {}
+
+        def _prompt(command, description, *a, **kw):
+            seen.update(kw)
+            return "once"
+
+        monkeypatch.setattr(approval, "_is_interactive_cli", lambda: True)
+        monkeypatch.setattr(approval, "_is_gateway_approval_context", lambda: False)
+        monkeypatch.setattr(approval, "prompt_dangerous_approval", _prompt)
+
+        res = request_tool_approval(
+            "terminal", "delete one record", rule_key="rec:42",
+            allow_session=False, allow_permanent=False,
+        )
+        assert res["approved"] is True
+        assert seen["allow_permanent"] is False
+        assert seen["allow_session"] is False
+
+    def test_scopes_are_offered_by_default(self, monkeypatch):
+        seen = {}
+
+        def _prompt(command, description, *a, **kw):
+            seen.update(kw)
+            return "once"
+
+        monkeypatch.setattr(approval, "_is_interactive_cli", lambda: True)
+        monkeypatch.setattr(approval, "_is_gateway_approval_context", lambda: False)
+        monkeypatch.setattr(approval, "prompt_dangerous_approval", _prompt)
+
+        request_tool_approval("terminal", "smtp send")
+        assert seen["allow_permanent"] is True
+        assert seen["allow_session"] is True
+
+    def test_unoffered_always_is_not_persisted(self, monkeypatch):
+        """A scope that was never on screen is a stale client, not consent.
+
+        The action still goes through — a human did answer yes — but nothing
+        is written to the permanent allowlist.
+        """
+        calls = {"session": [], "permanent": []}
+        monkeypatch.setattr(approval, "_is_interactive_cli", lambda: True)
+        monkeypatch.setattr(approval, "_is_gateway_approval_context", lambda: False)
+        monkeypatch.setattr(approval, "prompt_dangerous_approval", lambda *a, **k: "always")
+        monkeypatch.setattr(
+            approval, "approve_session", lambda sk, pk: calls["session"].append(pk)
+        )
+        monkeypatch.setattr(
+            approval, "approve_permanent", lambda pk: calls["permanent"].append(pk)
+        )
+        monkeypatch.setattr(approval, "save_permanent_allowlist", lambda *a, **k: None)
+
+        res = request_tool_approval(
+            "terminal", "delete one record", rule_key="rec:42", allow_permanent=False,
+        )
+        assert res["approved"] is True
+        assert calls["permanent"] == []
+        assert calls["session"] == []
+
+    def test_gateway_payload_carries_the_offered_scopes(self, monkeypatch):
+        """The gateway surface renders buttons straight from this payload."""
+        sent = {}
+
+        monkeypatch.setattr(approval, "_is_interactive_cli", lambda: False)
+        monkeypatch.setattr(approval, "_is_gateway_approval_context", lambda: True)
+        monkeypatch.setitem(approval._gateway_notify_cbs, "test-session", lambda *a, **k: True)
+        monkeypatch.setattr(
+            approval, "_await_gateway_decision",
+            lambda session_key, notify_cb, approval_data, surface="gateway": (
+                sent.update(approval_data)
+                or {"resolved": True, "choice": "once", "reason": None}
+            ),
+        )
+        res = request_tool_approval(
+            "terminal", "delete one record", rule_key="rec:42",
+            allow_session=False, allow_permanent=False,
+        )
+        assert res["approved"] is True
+        assert sent["allow_permanent"] is False
+        assert sent["allow_session"] is False
+
+    def test_gateway_unoffered_always_is_not_persisted(self, monkeypatch):
+        calls = {"permanent": []}
+        monkeypatch.setattr(approval, "_is_interactive_cli", lambda: False)
+        monkeypatch.setattr(approval, "_is_gateway_approval_context", lambda: True)
+        monkeypatch.setitem(approval._gateway_notify_cbs, "test-session", lambda *a, **k: True)
+        monkeypatch.setattr(
+            approval, "_await_gateway_decision",
+            lambda *a, **kw: {"resolved": True, "choice": "always", "reason": None},
+        )
+        monkeypatch.setattr(approval, "approve_session", lambda sk, pk: None)
+        monkeypatch.setattr(
+            approval, "approve_permanent", lambda pk: calls["permanent"].append(pk)
+        )
+        monkeypatch.setattr(approval, "save_permanent_allowlist", lambda *a, **k: None)
+
+        res = request_tool_approval(
+            "terminal", "delete one record", rule_key="rec:42", allow_permanent=False,
+        )
+        assert res["approved"] is True
+        assert calls["permanent"] == []
+
+    def test_deny_is_never_reinterpreted(self, monkeypatch):
+        """Clamping narrows a scope; it must never turn a refusal into a yes."""
+        monkeypatch.setattr(approval, "_is_interactive_cli", lambda: True)
+        monkeypatch.setattr(approval, "_is_gateway_approval_context", lambda: False)
+        monkeypatch.setattr(approval, "prompt_dangerous_approval", lambda *a, **k: "deny")
+        res = request_tool_approval(
+            "terminal", "delete one record", allow_session=False, allow_permanent=False,
+        )
+        assert res["approved"] is False

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -3652,6 +3652,7 @@ def _run_approval_gate(
     no_human_block_message: str = "",
     allow_session: bool = True,
     allow_permanent: bool = True,
+    display_is_command: bool = True,
 ) -> dict:
     """Shared human-approval gate for a flagged action (command or tool).
 
@@ -3692,6 +3693,13 @@ def _run_approval_gate(
             ``fail_closed_when_no_human`` blocks.
         allow_session: When False, ``[s]ession`` is not offered and is not
             persisted if a surface returns it anyway.
+        display_is_command: False when ``display_target`` is a synthetic
+            label rather than something the user could inspect or run. The
+            gateway payload then carries no command, and every surface
+            renders the description as the whole request instead of framing
+            it as a note about a command preview. The CLI prompt, the
+            ``/approve`` queue, and the approval hooks keep the label, where
+            it identifies the gate in logs and listings.
         allow_permanent: When False, ``[a]lways`` is not offered and is not
             persisted if a surface returns it anyway. A gate whose key
             describes something narrower than the rule — one file, one
@@ -3797,7 +3805,9 @@ def _run_approval_gate(
         if notify_cb is not None:
             from agent.redact import redact_sensitive_text
             approval_data = {
-                "command": redact_sensitive_text(display_target),
+                "command": (
+                    redact_sensitive_text(display_target) if display_is_command else ""
+                ),
                 "pattern_key": pattern_key,
                 "pattern_keys": [pattern_key],
                 "description": redact_sensitive_text(description),
@@ -4118,8 +4128,11 @@ def request_tool_approval(
     # session/permanent allowlist machinery as command patterns, namespaced
     # to avoid ever colliding with a real command pattern key.
     pattern_key = f"plugin_rule:{key_suffix}"
-    # A synthetic "command" string for the display/allowlist layer. It never
-    # executes; it only labels the gate. Namespaced identically.
+    # A synthetic "command" string for the allowlist/log layer. It never
+    # executes; it only labels the gate. Namespaced identically. It is kept
+    # out of the approval surfaces themselves via display_is_command=False,
+    # since a placeholder in a code fence reads as a command the human is
+    # meant to inspect and cannot.
     display_target = f"<{tool_name}> (plugin approval rule)"
 
     return _run_approval_gate(
@@ -4129,6 +4142,7 @@ def request_tool_approval(
         approval_callback=approval_callback,
         allow_session=allow_session,
         allow_permanent=allow_permanent,
+        display_is_command=False,
         cron_deny_message=(
             f"BLOCKED: Tool '{tool_name}' requires approval ({description}) "
             "but cron jobs run without a user present to approve it. Find an "

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -3617,6 +3617,28 @@ def _smart_approve(command: str, description: str) -> str:
         return "escalate"
 
 
+def _clamp_choice_to_offered_scopes(
+    choice: Optional[str], *, allow_session: bool, allow_permanent: bool
+) -> Optional[str]:
+    """Narrow a decision to a scope the human was actually offered.
+
+    Surfaces are told which scopes to render, but the answer travels back as
+    a plain string — over a CLI callback, a button payload, or a queued
+    ``/approve``. A scope that was never on screen is a stale client or a
+    bug, not consent, and persisting it would widen an allowlist nobody
+    agreed to widen. Narrowing to ``once`` keeps the action approved, since
+    a human did answer yes, without remembering an answer they were never
+    asked for. The plugin-transport path already refuses an unoffered scope
+    (``hermes_cli.approval_transport``); this is the same rule for the
+    built-in surfaces.
+    """
+    if choice == "always" and not allow_permanent:
+        return "once"
+    if choice == "session" and not allow_session:
+        return "once"
+    return choice
+
+
 def _run_approval_gate(
     *,
     pattern_key: str,
@@ -3628,6 +3650,8 @@ def _run_approval_gate(
     autoapprove_log_prefix: str,
     fail_closed_when_no_human: bool = False,
     no_human_block_message: str = "",
+    allow_session: bool = True,
+    allow_permanent: bool = True,
 ) -> dict:
     """Shared human-approval gate for a flagged action (command or tool).
 
@@ -3666,6 +3690,14 @@ def _run_approval_gate(
             plugin-flagged action never runs ungated without a human.
         no_human_block_message: Message returned when
             ``fail_closed_when_no_human`` blocks.
+        allow_session: When False, ``[s]ession`` is not offered and is not
+            persisted if a surface returns it anyway.
+        allow_permanent: When False, ``[a]lways`` is not offered and is not
+            persisted if a surface returns it anyway. A gate whose key
+            describes something narrower than the rule — one file, one
+            record, one event — has nothing useful to remember, and offering
+            a permanent answer there teaches people to widen an allowlist
+            they only meant to answer once.
 
     Returns:
         ``{"approved": bool, "message": str|None, ...}`` — shape shared with
@@ -3769,8 +3801,8 @@ def _run_approval_gate(
                 "pattern_key": pattern_key,
                 "pattern_keys": [pattern_key],
                 "description": redact_sensitive_text(description),
-                "allow_permanent": True,
-                "allow_session": True,
+                "allow_permanent": allow_permanent,
+                "allow_session": allow_session,
             }
             decision = _await_gateway_decision(
                 session_key, notify_cb, approval_data, surface="gateway"
@@ -3785,7 +3817,11 @@ def _run_approval_gate(
                     "user_consent": False,
                 }
             resolved = decision["resolved"]
-            choice = decision["choice"]
+            choice = _clamp_choice_to_offered_scopes(
+                decision["choice"],
+                allow_session=allow_session,
+                allow_permanent=allow_permanent,
+            )
             deny_reason = decision.get("reason")
 
             if not resolved or choice is None or choice == "deny":
@@ -3859,8 +3895,16 @@ def _run_approval_gate(
         session_key=session_key,
         surface="cli",
     )
-    choice = prompt_dangerous_approval(display_target, description,
-                                       approval_callback=approval_callback)
+    choice = _clamp_choice_to_offered_scopes(
+        prompt_dangerous_approval(
+            display_target, description,
+            allow_permanent=allow_permanent,
+            approval_callback=approval_callback,
+            allow_session=allow_session,
+        ),
+        allow_session=allow_session,
+        allow_permanent=allow_permanent,
+    )
     _fire_approval_hook(
         "post_approval_response",
         command=display_target,
@@ -4007,6 +4051,8 @@ def request_tool_approval(
     reason: str,
     *,
     rule_key: str = "",
+    allow_session: bool = True,
+    allow_permanent: bool = True,
     approval_callback=None,
 ) -> dict:
     """Escalate an arbitrary tool call to the human-approval gate.
@@ -4033,6 +4079,17 @@ def request_tool_approval(
             on the same tool persist independently (answering ``[a]lways`` to
             "write to ~/.ssh" does NOT auto-approve a later "send email" rule
             on the same tool).
+        allow_session: Offer ``[s]ession``. Pass False for a rule that must
+            be answered every time.
+        allow_permanent: Offer ``[a]lways``. Pass False when remembering the
+            answer would be meaningless or unsafe — typically when
+            ``rule_key`` already names a single subject (one file, one
+            recipient, one record), so there is no future call a stored
+            answer could correctly apply to. Without this a plugin can choose
+            the allowlist *grain* but never opt out of the allowlist, so a
+            per-subject key still renders an ``always`` button whose only
+            possible effect is to widen a decision the human meant to make
+            once.
         approval_callback: Optional CLI callback for interactive prompts
             (same contract as ``check_dangerous_command``).
 
@@ -4070,6 +4127,8 @@ def request_tool_approval(
         description=description,
         display_target=display_target,
         approval_callback=approval_callback,
+        allow_session=allow_session,
+        allow_permanent=allow_permanent,
         cron_deny_message=(
             f"BLOCKED: Tool '{tool_name}' requires approval ({description}) "
             "but cron jobs run without a user present to approve it. Find an "


### PR DESCRIPTION
## What this changes

A `pre_tool_call` plugin can already return `{"action": "approve", ...}` to route a tool call through the human-approval gate (`request_tool_approval`). Today that always renders as a **command** approval card, regardless of whether there is an actual command to show:

**Before** (a plugin rule gating, say, a Calendar write):

```
⚠️ Command Approval Required

```
<terminal> (plugin approval rule)
```

Reason: Add this to Basia's Calendar
[Once] [Session] [Always] [Deny]
```

The human is shown a fenced placeholder they can't act on and didn't ask about, while the actual description — the thing they're approving — is demoted to a `Reason:` footnote. `Session`/`Always` are also always offered, even when the plugin's `rule_key` already names one non-recurring subject (one calendar event, one file, one record), so the only thing "Always" can do is widen a decision the human meant to make once.

**After:**

```
⚠️ Approval Required

Add this to Basia's Calendar
[Once] [Deny]
```

## The two changes

**1. `allow_session` / `allow_permanent` on the `approve` directive** (`0f4583266d`)

`rule_key` lets a plugin choose the allowlist *grain*, but not opt out of the allowlist. `request_tool_approval` now accepts `allow_session` / `allow_permanent` keyword args, and a `pre_tool_call` `approve` directive can carry the same two keys. Both default to `True`; only an explicit `False` narrows anything, so existing plugins and the dangerous-command path render byte-identically.

Scopes are also clamped on the way back: a choice arrives as a plain string over a CLI callback, a gateway button payload, or a queued `/approve`, so a scope that was never rendered is a stale client or a bug, not consent. It's narrowed to `once` — still approved, since a human did say yes, but not persisted. The plugin-transport path (`hermes_cli.approval_transport`) already refuses an unoffered scope; this gives the built-in surfaces the same rule. Denials and timeouts are untouched.

Prior art: #69095 proposed the same `allow_permanent` keyword and was closed by its own author four minutes after opening, without review. This adds the directive-level plumbing plus the return-path clamp on top.

**2. Don't render a placeholder as if it were a real command** (`df0507fe87`)

`request_tool_approval` builds a synthetic display string, `<terminal> (plugin approval rule)`, and every surface renders it inside a code fence under a "Command Approval Required" heading. A plugin rule gates a tool call, not a shell string — there's nothing to preview. `display_is_command=False` keeps that label out of the approval payload entirely; each surface drops the fence and the `Reason:` label and uses a no-command heading instead. The label is unchanged in the CLI prompt, the `/approve` queue, and the approval hooks, where it still identifies the gate in logs and listings.

Covered in all six renderers plus the gateway's plain-text fallback: the shared `_format_exec_approval` core (telegram, matrix, feishu) via a new `_EA_HEADER_NO_COMMAND` template attr, and the natively-built prompts in slack, discord, and teams (teams already guarded its resolved-decision card with `if cmd:`; this makes the send path agree with it).

**Dangerous-command approvals are untouched in both changes** — they pass a real command and both flags default `True`, so every existing prompt renders identically to before.

## Why

Built a Hermes plugin that gates a narrow, non-shell action (a Calendar write, keyed to the SHA-256 of that one event's facts) behind `request_tool_approval`. The resulting card showed a placeholder command block, a `Reason:` footnote for the actual facts, and `Session`/`Always` buttons that made no sense for a rule that can, by construction, only ever match one event. This closes that gap generally rather than papering over it in the plugin.

## Files changed

- `tools/approval.py` — `_run_approval_gate` gains `allow_session`, `allow_permanent`, `display_is_command`; new `_clamp_choice_to_offered_scopes` helper; `request_tool_approval` takes and forwards the first two.
- `hermes_cli/plugins.py` — `_PreToolCallDirective` gains `allow_session`/`allow_permanent` (explicit-`False`-only semantics); the `approve` → gate bridge forwards them.
- `gateway/platforms/base.py` — `_format_exec_approval` short-circuits on an empty command: no fence, no `Reason:` label, `_EA_HEADER_NO_COMMAND` heading.
- `gateway/run.py` — plain-text fallback gets the same empty-command branch.
- `plugins/platforms/{telegram,matrix,feishu}/adapter.py` — `_EA_HEADER_NO_COMMAND` override per platform's markup.
- `plugins/platforms/{slack,discord,teams}/adapter.py` — natively-built prompts branch on `has_command`.
- `tests/tools/test_request_tool_approval.py` — 8 new tests (offered-scopes defaults, CLI/gateway plumbing, non-persistence of an unoffered scope, no-synthetic-command payload).
- `tests/hermes_cli/test_plugins.py` — 5 new tests for the directive's scope fields.
- `tests/gateway/test_interactive_prompt_base.py` — 4 new tests for the no-command render (no fence, no "Command" in heading, smart-deny kept, real command unchanged).

## How to test

1. `pytest tests/tools/test_request_tool_approval.py tests/hermes_cli/test_plugins.py tests/gateway/test_interactive_prompt_base.py -q`
2. Write a plugin `pre_tool_call` hook returning `{"action": "approve", "message": "...", "rule_key": "...", "allow_session": False, "allow_permanent": False}` and confirm the card offers only Once/Deny.
3. Confirm a dangerous-command approval (a real shell command, no plugin involved) renders exactly as before — fence, `Reason:` label, all three scopes offered.
4. Confirm a plugin `approve` directive with no scope keys still offers Session/Always, unchanged from current behavior.

## Checklist

- [x] Ran the targeted suites above: 332 passed, 1 failed on my branch. Reproduced the same failure (`test_live_temp_home_fixture_plugin_routes_and_hardline_stays_core_owned`) on a clean checkout of `main` with the same multi-file run combination — pre-existing, unrelated to this change, not touched here.
- [x] `ruff check` clean on all 11 changed source/test files.
- [ ] Full `pytest tests/` — started locally but the run didn't finish in my environment before I opened this PR; happy to paste the full result once it completes, or if maintainers prefer to just run CI.
- [x] No behavior change for any existing dangerous-command approval or any plugin directive that doesn't set the new keys (both default `True`/unchanged).
