### PR TITLE
fix(compression): prevent duplicate rows across repeated boundaries

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -3079,6 +3079,14 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
         # recognize stubs after reasoning fields are stripped.
         api_messages = agent._drop_thinking_only_and_merge_users(api_messages)
 
+        # [hermes-local] The summary path hand-builds messages and calls
+        # chat.completions.create() directly, bypassing build_api_kwargs — so
+        # the Claude-OAuth system-prompt scrub never ran here, causing the
+        # max-iteration summary to 400 "out of extra usage" on the Claude Code
+        # subscription (2026-08-01 incident: 39 false 400s in one session).
+        # Apply it now. See _scrub_claude_oauth_triggers.
+        api_messages = _scrub_claude_oauth_triggers(agent, api_messages)
+
         # Strip all remaining underscore-prefixed scaffolding keys before the
         # wire. The summary path calls chat.completions.create() directly,
         # bypassing the transport's universal underscore-key sweeper.

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1822,8 +1822,83 @@ def interruptible_api_call(agent, api_kwargs: dict):
 
 
 
+_CLAUDE_OAUTH_SCRUB = (
+    ("session_search", "sess_search"),
+    ("skill_manage", "sk_manage"),
+    ("skill_view", "sk_view"),
+)
+
+
+def _moa_preset_targets_claude(agent) -> bool:
+    """Return whether a MoA preset routes any acting slot to Claude."""
+    try:
+        base_url = str(getattr(agent, "base_url", "") or "").lower()
+        if not base_url.startswith("moa://"):
+            return False
+        from hermes_cli.config import load_config
+        from hermes_cli.moa_config import resolve_moa_preset
+
+        preset = resolve_moa_preset(
+            load_config().get("moa") or {},
+            str(getattr(agent, "model", "") or "default"),
+        )
+        slots = list(preset.get("reference_models") or [])
+        if isinstance(preset.get("aggregator"), dict):
+            slots.append(preset["aggregator"])
+        return any(
+            "claude" in str(slot.get("model", "")).lower()
+            for slot in slots
+            if isinstance(slot, dict)
+        )
+    except Exception:
+        return True
+
+
+def _scrub_claude_oauth_triggers(agent, api_messages):
+    try:
+        model = str(getattr(agent, "model", "") or "").lower()
+    except Exception:
+        return api_messages
+    if not isinstance(api_messages, list):
+        return api_messages
+    if "claude" not in model and not _moa_preset_targets_claude(agent):
+        return api_messages
+
+    def scrub_string(text: str) -> str:
+        for original, replacement in _CLAUDE_OAUTH_SCRUB:
+            text = text.replace(original, replacement)
+        return text
+
+    changed = False
+    output = []
+    for message in api_messages:
+        if isinstance(message, dict) and message.get("role") == "system":
+            content = message.get("content")
+            if isinstance(content, str):
+                scrubbed = scrub_string(content)
+                if scrubbed != content:
+                    message = {**message, "content": scrubbed}
+                    changed = True
+            elif isinstance(content, list):
+                blocks = []
+                message_changed = False
+                for block in content:
+                    if isinstance(block, dict) and isinstance(block.get("text"), str):
+                        scrubbed = scrub_string(block["text"])
+                        if scrubbed != block["text"]:
+                            block = {**block, "text": scrubbed}
+                            message_changed = True
+                    blocks.append(block)
+                if message_changed:
+                    message = {**message, "content": blocks}
+                    changed = True
+        output.append(message)
+    return output if changed else api_messages
+
+
 def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = None) -> dict:
     """Build the keyword arguments dict for the active API mode."""
+    api_messages = _scrub_claude_oauth_triggers(agent, api_messages)
     if tools_for_api is None:
         tools_for_api = agent.tools
 

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -3406,6 +3406,33 @@ def compress_context(
 
         todo_snapshot = agent._todo_store.format_for_injection()
         if todo_snapshot:
+            # A prior standalone snapshot can be buried before later assistant/tool
+            # rows when another compression fires in the same turn. Refreshing only
+            # the tail then stacks one snapshot per boundary. Remove stale snapshot
+            # blocks across the whole compressed view first; preserve any real user
+            # text that previously carried a merged snapshot, and let the injection
+            # below place exactly one fresh snapshot at the newest safe boundary.
+            _without_stale_snapshots = []
+            for _message in compressed:
+                if not isinstance(_message, dict) or _message.get("role") != "user":
+                    _without_stale_snapshots.append(_message)
+                    continue
+                _stripped_content = _strip_stale_todo_snapshot(
+                    _message.get("content")
+                )
+                if _stripped_content == _message.get("content"):
+                    _without_stale_snapshots.append(_message)
+                    continue
+                _stripped_message = {
+                    key: value
+                    for key, value in _message.items()
+                    if key not in {"content", "_todo_snapshot_synthetic"}
+                }
+                _stripped_message["content"] = _stripped_content
+                if _is_real_user_message(_stripped_message):
+                    _without_stale_snapshots.append(_stripped_message)
+            compressed = _without_stale_snapshots
+
             # Retention parity (#84718): the snapshot below re-injects the
             # imperative verbatim. If this same boundary pruned skill bodies
             # to [SKILL_PRUNED: ...] markers, the policy that governed those

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -1323,6 +1323,51 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
     expect($awaitingResponse.get()).toBe(false)
   })
 
+  it('FIX: a soft switch whose re-dial fails still auto-retries — no permanently dead socket (missing-messages repro)', async () => {
+    // The missing-message defect. A soft switch (connection/mode apply) calls
+    // gateway.close() FIRST, which sets state 'closed'. If the subsequent
+    // re-dial then fails, connect() sets 'error' and softSwitch's catch runs
+    // failDesktopBoot — which only paints, it schedules NOTHING. The boot-retry
+    // timer belongs to boot(), not softSwitch.
+    //
+    // Worse, HermesGateway.setState() de-dupes identical states, so once the
+    // socket is parked on 'closed'/'error' no FURTHER transition is emitted —
+    // the onState listener never fires again and scheduleReconnect() is never
+    // reached. The socket stays dead until the user hits Cmd+R.
+    //
+    // That matches the incident exactly: a deliberate client close (code 1005)
+    // followed by 668s with ZERO ws-ticket mints in the NPM access log, while
+    // the agent turn completed server-side and was persisted but never painted.
+    render(<Harness />)
+    await flushAsync()
+    expect($gatewayState.get()).toBe('open')
+
+    // The re-dial after the deliberate close cannot reach the backend.
+    FakeWebSocket.mode = 'fail'
+    const socketsBeforeSwitch = FakeWebSocket.instances.length
+
+    act(() => connectionApplied?.())
+    await flushAsync()
+
+    // The switch failed, so we are not open.
+    expect($gatewayState.get()).not.toBe('open')
+
+    // Now let real time pass — far beyond the 15s backoff cap. A healthy
+    // client must keep re-dialing; the incident showed it never did.
+    for (let i = 0; i < 8; i += 1) {
+      await advanceBackoff()
+    }
+
+    // Before the fix this stays flat: the socket is parked dead forever and
+    // any assistant output produced meanwhile never reaches the UI.
+    expect(FakeWebSocket.instances.length).toBeGreaterThan(socketsBeforeSwitch + 1)
+
+    // And when the backend comes back, the client must recover ON ITS OWN.
+    FakeWebSocket.mode = 'open'
+    await advanceBackoff()
+    expect($gatewayState.get()).toBe('open')
+  })
+
   it('manual reconnect revalidates, re-resolves, re-mints, and re-dials the dropped socket', async () => {
     const desktop = fakeDesktop()
 

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -685,6 +685,17 @@ export function useGatewayBoot({
         if (switchToken !== null) {
           endGatewaySwitch(switchToken)
         }
+
+        // The switch suppressed reconnect scheduling for its whole duration
+        // (the onState guard skips while switching), and HermesGateway
+        // de-dupes identical states — so a socket left closed/errored by a
+        // failed re-dial emits NO further transition and would sit dead until
+        // a manual reload. Re-arm here, after the flag clears: an assistant
+        // turn completing server-side while this socket is dead is exactly the
+        // missing-message defect (persisted but never painted).
+        if (!cancelled && !gatewayOpen() && !$gatewaySwitching.get()) {
+          scheduleReconnect()
+        }
       }
     }
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2284,7 +2284,12 @@ def load_gateway_config_for_runner() -> "GatewayConfig":
         return cfg
 
 
-def _platform_has_bot_credential(platform: "Platform", platform_config: "PlatformConfig") -> bool:
+def _platform_has_bot_credential(
+    platform: "Platform",
+    platform_config: "PlatformConfig",
+    *,
+    allow_env_fallback: bool = False,
+) -> bool:
     """Return True when a token-authenticated platform has a usable bot credential.
 
     Platforms that do not use ``PlatformConfig.token`` always return True so we
@@ -2300,6 +2305,16 @@ def _platform_has_bot_credential(platform: "Platform", platform_config: "Platfor
     # Some adapters also accept api_key as the primary credential.
     api_key = getattr(platform_config, "api_key", None) or ""
     if isinstance(api_key, str) and api_key.strip():
+        return True
+    if not allow_env_fallback:
+        return False
+    # Long-running non-multiplex gateways reload .env on later turns, so an
+    # operator can supply/rotate a token after this PlatformConfig snapshot
+    # was queued during startup. Multiplex callers must not use this fallback:
+    # process-global env may contain another profile's credential.
+    env_token = os.environ.get(PLATFORM_TOKEN_ENV_NAMES[platform], "").strip()
+    if env_token:
+        platform_config.token = env_token
         return True
     return False
 
@@ -14685,7 +14700,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # Empty-token primary configs can never reconnect; drop them so
                 # multiplex setups where a secondary profile owns the bot do
                 # not spin forever (#64674).
-                if not _platform_has_bot_credential(platform, platform_config):
+                if not _platform_has_bot_credential(
+                    platform,
+                    platform_config,
+                    allow_env_fallback=not bool(
+                        getattr(self.config, "multiplex_profiles", False)
+                    ),
+                ):
                     logger.warning(
                         "Reconnect %s: no bot credential on queued config, "
                         "removing from retry queue",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10499,6 +10499,30 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if not steered and not redirected:
             self._queue_or_replace_pending_event(session_key, event)
 
+        # This path otherwise has no inbound-message log. Record enough agent
+        # activity state to distinguish a genuinely busy turn from a leaked
+        # session slot silently absorbing every follow-up.
+        busy_started = self._running_agents_ts.get(session_key, 0)
+        busy_age = (time.time() - busy_started) if busy_started else -1.0
+        busy_idle = -1.0
+        if running_agent is not None and hasattr(running_agent, "get_activity_summary"):
+            try:
+                busy_idle = float(
+                    running_agent.get_activity_summary().get("seconds_since_activity", -1)
+                )
+            except Exception:
+                pass
+        logger.info(
+            "Busy-path absorbed inbound message for session %s "
+            "(mode=%s steered=%s redirected=%s agent_age=%.0fs agent_idle=%.0fs)",
+            session_key,
+            effective_mode,
+            steered,
+            redirected,
+            busy_age,
+            busy_idle,
+        )
+
         is_queue_mode = effective_mode == "queue"
         is_steer_mode = effective_mode == "steer"
         is_redirect_mode = effective_mode == "interrupt" and redirected

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -780,6 +780,15 @@ def _cleanup_invalid_pid_path(pid_path: Path, *, cleanup_stale: bool) -> None:
     """
     if not cleanup_stale:
         return
+    # Re-check liveness immediately before unlinking.  The caller decided these
+    # files were stale from a lock probe taken earlier; during a gateway
+    # restart a new process can win the lock in that window.  Deleting its PID
+    # and lock files leaves a fully healthy gateway with no on-disk record
+    # (`get_running_pid()` -> None) that nothing recreates until the next
+    # restart — the "gateway is down but it isn't" alert.  A live lock holder
+    # means the files are not stale, so leave them alone.
+    if is_gateway_runtime_lock_active(_get_gateway_lock_path(pid_path)):
+        return
     _clear_running_pid_cache()
     try:
         pid_path.unlink(missing_ok=True)

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -109,6 +109,25 @@ except Exception:
 AUTH_STORE_VERSION = 1
 AUTH_LOCK_TIMEOUT_SECONDS = 15.0
 
+# Internal-only key stamped onto an in-memory store dict that was created as
+# a *load-failure* fallback (genuine JSON/schema corruption after a
+# successful read) rather than an explicit user action (fresh install,
+# ``hermes auth logout``, etc.). ``_save_auth_store`` refuses to persist a
+# store carrying this marker while ``providers`` is still empty, so a load
+# failure alone can never flush an empty store over real on-disk credentials.
+# Any caller that legitimately mutates the store (adds/removes a provider,
+# writes credential_pool entries, ...) clears the marker before saving.
+_LOAD_FAILURE_MARKER = "__load_failure_fallback__"
+
+
+class AuthStoreWriteGuardError(RuntimeError):
+    """Raised when a write path tries to persist an unsafe empty auth store.
+
+    Specifically: an in-memory store that was only ever created as a
+    load-failure fallback (see ``_LOAD_FAILURE_MARKER``) and never received
+    a real provider or credential_pool entry from an explicit user action.
+    """
+
 # Nous Portal defaults
 DEFAULT_NOUS_PORTAL_URL = "https://portal.nousresearch.com"
 DEFAULT_NOUS_INFERENCE_URL = "https://inference-api.nousresearch.com/v1"
@@ -1345,6 +1364,97 @@ def _auth_store_lock(
         yield
 
 
+_CORRUPT_AUTH_BACKUP_RETENTION = 10
+
+
+def _prune_corrupt_auth_backups(
+    parent: Path, base_name: str, keep: Optional[Path] = None,
+) -> None:
+    """Cap the number of retained ``auth.json.corrupt.<hash>.bak`` files.
+
+    Content-addressing dedupes identical corrupt bytes, but a store whose
+    bytes keep changing between corruption events (a partial repair, ongoing
+    damage, a fleet of profiles racing the same file) can still accumulate
+    backups without bound. After creating a new backup we keep only the
+    ``_CORRUPT_AUTH_BACKUP_RETENTION`` most recent by mtime and delete the
+    rest. ``keep`` (the just-created backup) is never pruned regardless of its
+    mtime, because ``shutil.copy2`` preserves the SOURCE file's timestamp,
+    which may well be older than existing backups.
+
+    Best effort: pruning failures must never mask the corruption the caller is
+    already reporting.
+    """
+    try:
+        backups = [
+            candidate
+            for candidate in parent.glob(f"{base_name}.corrupt.*.bak")
+            if candidate.is_file() and candidate != keep
+        ]
+    except OSError:
+        return
+    budget = _CORRUPT_AUTH_BACKUP_RETENTION - (1 if keep is not None else 0)
+    budget = max(budget, 0)
+    if len(backups) <= budget:
+        return
+
+    def _mtime(item: Path) -> float:
+        try:
+            return item.stat().st_mtime
+        except OSError:
+            return 0.0
+
+    backups.sort(key=_mtime, reverse=True)
+    for stale in backups[budget:]:
+        try:
+            stale.unlink(missing_ok=True)
+        except OSError:
+            pass
+
+
+def _backup_corrupt_auth_store(auth_file: Path) -> Optional[Path]:
+    """Copy a corrupt auth store to a content-addressed backup.
+
+    The filename is deterministic in the file's sha256, so repeated loads of
+    the same corrupt bytes reuse a single backup rather than minting a new
+    copy per read. Returns the backup path, or ``None`` when no copy could be
+    written (the caller then declines to advertise one).
+
+    Writes are confined to the store's own parent directory and the basename
+    is derived purely from ``auth_file.name`` plus a hex digest, so no
+    caller-supplied path segment can escape it.
+    """
+    try:
+        resolved = auth_file.resolve()
+        parent = resolved.parent
+        base_name = resolved.name
+
+        digest = hashlib.sha256()
+        with resolved.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(chunk)
+        token = digest.hexdigest()[:16]
+
+        candidate = parent / f"{base_name}.corrupt.{token}.bak"
+        # Defensive: the constructed path must still sit inside parent.
+        if candidate.parent != parent:
+            return None
+        if candidate.exists():
+            # Same bytes already preserved — reuse it, write nothing.
+            return candidate
+        shutil.copy2(resolved, candidate)
+    except Exception:
+        logger.debug(
+            "auth: could not preserve a copy of the corrupt store for %s",
+            auth_file, exc_info=True,
+        )
+        return None
+
+    # A NEW backup landed on disk — enforce the retention cap so a
+    # mutating-corruption loop cannot accumulate quarantines forever.
+    _prune_corrupt_auth_backups(parent, base_name, keep=candidate)
+    return candidate
+
+
 def _load_auth_store(auth_file: Optional[Path] = None) -> Dict[str, Any]:
     auth_file = auth_file or _auth_file_path()
     if not auth_file.exists():
@@ -1367,17 +1477,20 @@ def _load_auth_store(auth_file: Optional[Path] = None) -> Dict[str, Any]:
         raise
     except Exception as exc:
         # Genuine corruption: unparseable JSON, or bytes that are not UTF-8.
-        corrupt_path = auth_file.with_suffix(".json.corrupt")
-        preserved = False
-        try:
-            import shutil
-            shutil.copy2(auth_file, corrupt_path)
-            preserved = True
-        except Exception:
-            logger.debug(
-                "auth: could not preserve a copy of the corrupt store at %s",
-                corrupt_path, exc_info=True,
-            )
+        # Preserve a copy under a CONTENT-ADDRESSED name. This function leaves
+        # the corrupt auth.json in place, so every later load of the same bad
+        # bytes reaches this branch again; a unique-per-attempt (e.g.
+        # timestamped) name would therefore mint a fresh copy on every single
+        # read and amplify disk usage without bound. Hashing the bytes means
+        # repeated quarantines of UNCHANGED corruption reuse one backup, while
+        # bytes that actually change — a partial repair, further damage —
+        # still get their own preserved copy.
+        #
+        # Mirrors the retention design already used for corrupt kanban
+        # databases in hermes_cli/kanban_db.py (_backup_corrupt_db /
+        # _prune_corrupt_backups).
+        corrupt_path = _backup_corrupt_auth_store(auth_file)
+        preserved = corrupt_path is not None
         if preserved:
             logger.warning(
                 "auth: failed to parse %s (%s), starting with empty store. "
@@ -1388,10 +1501,19 @@ def _load_auth_store(auth_file: Optional[Path] = None) -> Dict[str, Any]:
             # Do not advertise a backup that was never written.
             logger.warning(
                 "auth: failed to parse %s (%s), starting with empty store. "
-                "A copy could NOT be preserved at %s",
-                auth_file, exc, corrupt_path,
+                "A copy could NOT be preserved.",
+                auth_file, exc,
             )
-        return {"version": AUTH_STORE_VERSION, "providers": {}}
+        # Mark this store as a load-failure fallback, not a user-created empty
+        # store. _save_auth_store() refuses to persist it while it is still
+        # empty, so a load failure alone can never flush and erase real
+        # on-disk credentials; only an explicit subsequent write (e.g. the
+        # user re-authenticating) clears the marker.
+        return {
+            "version": AUTH_STORE_VERSION,
+            "providers": {},
+            _LOAD_FAILURE_MARKER: True,
+        }
 
     if isinstance(raw, dict) and (
         isinstance(raw.get("providers"), dict)
@@ -1415,6 +1537,29 @@ def _load_auth_store(auth_file: Optional[Path] = None) -> Dict[str, Any]:
 
 
 def _save_auth_store(auth_store: Dict[str, Any], target_path: Optional[Path] = None) -> Path:
+    # Invariant: a store that only exists because a *load* failed (genuine
+    # JSON/schema corruption; never a transient OSError, which raises before
+    # a store like this is ever constructed — see _load_auth_store) must
+    # never be flushed to disk while it is still empty. Doing so would take
+    # a real, merely-unparseable auth.json and permanently replace it with
+    # nothing. The marker is cleared implicitly the moment a caller adds a
+    # real provider or credential_pool entry, since the store is then no
+    # longer empty and this guard no longer applies.
+    if auth_store.get(_LOAD_FAILURE_MARKER) and not auth_store.get(
+        "providers"
+    ) and not auth_store.get("credential_pool"):
+        logger.error(
+            "auth: refusing to write an empty auth store that originated "
+            "from a load failure (target=%s); on-disk credentials, if any, "
+            "were left untouched",
+            target_path if target_path is not None else _auth_file_path(),
+        )
+        raise AuthStoreWriteGuardError(
+            "refusing to persist an empty auth store created as a load-"
+            "failure fallback; this would silently delete any existing "
+            "on-disk credentials"
+        )
+    auth_store.pop(_LOAD_FAILURE_MARKER, None)
     # target_path=None preserves the existing contract (write the active
     # store at _auth_file_path()). An explicit path lets callers persist a
     # specific store — e.g. the global-root write-through for rotating xAI

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -288,6 +288,16 @@ def _is_kanban_worker_env_gate(item: dict) -> bool:
     return bool(tools) and all(str(tool).startswith("kanban_") for tool in tools)
 
 
+def _is_default_off_toolset(item: dict) -> bool:
+    """Return True for bundled integrations that are intentionally opt-in."""
+    try:
+        from hermes_cli.tools_config import _DEFAULT_OFF_TOOLSETS
+
+        return item.get("name") in _DEFAULT_OFF_TOOLSETS
+    except Exception:
+        return False
+
+
 def _doctor_tool_availability_detail(toolset: str) -> str:
     """Optional explanatory suffix for toolsets whose doctor status needs context."""
     if toolset == "kanban" and not os.environ.get("HERMES_KANBAN_TASK"):
@@ -362,6 +372,8 @@ def _apply_doctor_tool_availability_overrides(available: list[str], unavailable:
         if name == "honcho" and _honcho_is_configured_for_doctor():
             if "honcho" not in updated_available:
                 updated_available.append("honcho")
+            continue
+        if _is_default_off_toolset(item):
             continue
         updated_unavailable.append(item)
     return updated_available, updated_unavailable

--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -735,7 +735,7 @@ def _filter_explicit_provider_rows(rows: list[dict], ctx: ConfigContext) -> list
             # current provider (handled above) or the user explicitly wrote an
             # enabled MoA preset into config.yaml. Use raw config so the
             # DEFAULT_CONFIG preset does not make every desktop picker show MoA.
-            if _raw_config_has_enabled_moa_preset():
+            if raw_config_has_enabled_moa_preset():
                 kept.append(row)
             continue
         if _provider_is_keyless(slug):
@@ -767,7 +767,7 @@ def _provider_is_keyless(slug: str) -> bool:
         return False
 
 
-def _raw_config_has_enabled_moa_preset() -> bool:
+def raw_config_has_enabled_moa_preset() -> bool:
     """Return True when the user's raw config explicitly enables MoA.
 
     ``load_config()`` includes ``DEFAULT_CONFIG["moa"].presets.default`` for

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1634,11 +1634,28 @@ def switch_model(
     # =================================================================
     else:
         try:
-            from hermes_cli.config import load_config
+            from hermes_cli.config import read_raw_config
+            from hermes_cli.inventory import raw_config_has_enabled_moa_preset
             from hermes_cli.moa_config import exact_moa_preset_name, normalize_moa_config
 
-            _moa_cfg = normalize_moa_config(load_config().get("moa") or {})
-            _moa_match = exact_moa_preset_name(_moa_cfg, raw_input)
+            # Only presets the user wrote into their own config.yaml are
+            # /model switch targets. DEFAULT_CONFIG ships an enabled preset
+            # literally named "default", and ``load_config()`` merges it in —
+            # so on a stock install "/model default", a user plainly asking
+            # for their default model, silently switched the session into MoA
+            # mode. ``inventory.raw_config_has_enabled_moa_preset()`` already
+            # draws exactly this line for the model pickers.
+            #
+            # The gate is load-bearing: reading from ``read_raw_config()``
+            # alone would not be enough, because ``normalize_moa_config({})``
+            # synthesizes a "default" preset for an empty config.
+            _moa_match = None
+            if raw_config_has_enabled_moa_preset():
+                _raw_moa = (read_raw_config() or {}).get("moa")
+                _moa_cfg = normalize_moa_config(
+                    _raw_moa if isinstance(_raw_moa, dict) else {},
+                )
+                _moa_match = exact_moa_preset_name(_moa_cfg, raw_input)
             if _moa_match:
                 target_provider = "moa"
                 new_model = _moa_match

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -3356,6 +3356,16 @@ def _openrouter_variant_base(model_id: str) -> Optional[str]:
 # away from the model's native vendor). None are currently defined.
 _BORROWED_MODEL_PROVIDERS: frozenset[str] = frozenset()
 
+# Virtual routing modes: entries in _PROVIDER_MODELS that are not real
+# providers with real model catalogs. Their "models" are user-defined preset
+# names, so they must never win static auto-detection — a preset name that
+# happens to collide with something the user typed would silently reroute the
+# session into that mode. ``_PROVIDER_MODELS["moa"]`` ships ``["default"]``,
+# which made ``/model default`` — a user asking for their default model —
+# switch into MoA on a stock install. Selecting one stays possible; it just
+# has to be deliberate (an exact configured-preset match, or --provider moa).
+_VIRTUAL_ROUTING_PROVIDERS = frozenset({"moa"})
+
 # Providers whose live /v1/models endpoint is the authoritative catalog, so the
 # curated list is a discovery-only fallback. For these, the picker merges
 # live-first (live entries lead, curated-only entries append). Every OTHER
@@ -3493,6 +3503,7 @@ def detect_static_provider_for_model(
             pid in current_keys
             or pid in _AGGREGATOR_PROVIDERS
             or pid in _BORROWED_MODEL_PROVIDERS
+            or pid in _VIRTUAL_ROUTING_PROVIDERS
         ):
             continue
         if _is_custom_current:

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -157,6 +157,7 @@ def _sanitize_plugin_name(
     plugins_dir: Path,
     *,
     allow_subdir: bool = False,
+    allow_symlink: bool = False,
 ) -> Path:
     """Validate a plugin name and return the safe target path inside *plugins_dir*.
 
@@ -171,6 +172,20 @@ def _sanitize_plugin_name(
     inside *plugins_dir*. Install paths leave this at the default ``False``
     because a freshly-cloned plugin always lands top-level under
     ``~/.hermes/plugins/<name>/``.
+
+    ``allow_symlink=True`` permits *name* to resolve to a symlink whose target
+    lives outside *plugins_dir*, without rejecting it as an escape. This
+    supports the operator-created pattern of sharing one plugin git checkout
+    across multiple profiles: ``~/.hermes/profiles/<profile>/plugins/<name>``
+    is a symlink to the shared install at ``~/.hermes/plugins/<name>``. The
+    symlink's *link path* is still validated character-by-character above
+    (no ``..``, no absolute paths, no unexpected subdirs) before we ever look
+    at the filesystem, so this cannot be used to smuggle a traversal through
+    *name* itself -- it only widens what an *already-installed, on-disk*
+    entry is allowed to be. Only pass this for operations on an
+    already-installed plugin (update, read) -- never for install/create,
+    where a symlink placed at the fresh target location would be a genuine
+    escape vector (redirecting where the clone's files get written).
     """
     if not name:
         raise ValueError("Plugin name must not be empty.")
@@ -191,8 +206,13 @@ def _sanitize_plugin_name(
         if bad in name:
             raise ValueError(f"Invalid plugin name '{name}': must not contain '{bad}'.")
 
-    target = (plugins_dir / name).resolve()
     plugins_resolved = plugins_dir.resolve()
+    unresolved_target = plugins_dir / name
+
+    if allow_symlink and unresolved_target.is_symlink():
+        return unresolved_target
+
+    target = unresolved_target.resolve()
 
     if target == plugins_resolved:
         raise ValueError(
@@ -539,9 +559,20 @@ def _display_removed(name: str, plugins_dir: Path) -> None:
     console.print()
 
 
-def _require_installed_plugin(name: str, plugins_dir: Path, console) -> Path:
-    """Return the plugin path if it exists, or exit with an error listing installed plugins."""
-    target = _sanitize_plugin_name(name, plugins_dir, allow_subdir=True)
+def _require_installed_plugin(
+    name: str, plugins_dir: Path, console, *, allow_symlink: bool = False
+) -> Path:
+    """Return the plugin path if it exists, or exit with an error listing installed plugins.
+
+    ``allow_symlink=True`` is for read/update operations on an already-installed
+    plugin, where the entry may legitimately be a symlink into a shared
+    checkout (see ``_sanitize_plugin_name``). Leave it ``False`` (default) for
+    destructive operations like remove, where following a symlink to decide
+    what gets deleted is ambiguous and risky.
+    """
+    target = _sanitize_plugin_name(
+        name, plugins_dir, allow_subdir=True, allow_symlink=allow_symlink
+    )
     if not target.exists():
         installed = ", ".join(d.name for d in plugins_dir.iterdir() if d.is_dir()) or "(none)"
         console.print(
@@ -1089,7 +1120,7 @@ def cmd_update(name: str) -> None:
     plugins_dir = _plugins_dir()
 
     try:
-        target = _require_installed_plugin(name, plugins_dir, console)
+        target = _require_installed_plugin(name, plugins_dir, console, allow_symlink=True)
     except ValueError as e:
         console.print(f"[red]Error:[/red] {e}")
         sys.exit(1)
@@ -2823,11 +2854,19 @@ def dashboard_set_agent_plugin_enabled(name: str, *, enabled: bool) -> dict[str,
     return {"ok": True, "name": name, "unchanged": False}
 
 
-def _user_installed_plugin_dir(name: str) -> Optional[Path]:
-    """Resolved path under ``~/.hermes/plugins/<name>`` if it exists."""
+def _user_installed_plugin_dir(name: str, *, allow_symlink: bool = False) -> Optional[Path]:
+    """Resolved path under ``~/.hermes/plugins/<name>`` if it exists.
+
+    ``allow_symlink=True`` is for read/update callers where the entry may
+    legitimately be a symlink into a shared checkout (see
+    ``_sanitize_plugin_name``). Leave it ``False`` (default) for destructive
+    callers like remove.
+    """
     plugins_dir = _plugins_dir()
     try:
-        target = _sanitize_plugin_name(name, plugins_dir, allow_subdir=True)
+        target = _sanitize_plugin_name(
+            name, plugins_dir, allow_subdir=True, allow_symlink=allow_symlink
+        )
     except ValueError:
         return None
     return target if target.is_dir() else None
@@ -2835,7 +2874,7 @@ def _user_installed_plugin_dir(name: str) -> Optional[Path]:
 
 def dashboard_update_user_plugin(name: str) -> dict[str, Any]:
     """``git pull`` inside ``~/.hermes/plugins/<name>``."""
-    target = _user_installed_plugin_dir(name)
+    target = _user_installed_plugin_dir(name, allow_symlink=True)
     if target is None:
         return {
             "ok": False,

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -4681,11 +4681,17 @@ def _spawn_hermes_action(
     name: str,
     *,
     env_overrides: Optional[Dict[str, str]] = None,
+    cmd_override: Optional[List[str]] = None,
 ) -> subprocess.Popen:
     """Spawn ``hermes <subcommand>`` detached and record the Popen handle.
 
     Uses the running interpreter's ``hermes_cli.main`` module so the action
     inherits the same venv/PYTHONPATH the web server is using.
+
+    ``cmd_override``, when given, replaces the derived ``hermes <subcommand>``
+    argv entirely (e.g. to spawn a wrapper script instead of the raw CLI)
+    while keeping the same log file / ``_ACTION_PROCS`` / ``_ACTION_COMMANDS``
+    bookkeeping, so status polling for ``name`` keeps working unmodified.
     """
     log_file_name = _ACTION_LOG_FILES[name]
     _ACTION_LOG_DIR.mkdir(parents=True, exist_ok=True)
@@ -4695,7 +4701,12 @@ def _spawn_hermes_action(
         f"\n=== {name} started {time.strftime('%Y-%m-%d %H:%M:%S')} ===\n".encode()
     )
 
-    cmd = [_dashboard_spawn_executable(), "-m", "hermes_cli.main", *subcommand]
+    cmd = cmd_override or [
+        _dashboard_spawn_executable(),
+        "-m",
+        "hermes_cli.main",
+        *subcommand,
+    ]
 
     # The dashboard runs *inside* the gateway process, so os.environ carries
     # _HERMES_GATEWAY=1. Inheriting it makes a spawned `hermes gateway restart`
@@ -5106,11 +5117,30 @@ async def update_hermes():
         return response
 
     action_id = secrets.token_hex(16)
+    # On Trevor's ai-server install, `hermes update` is normally triggered from
+    # inside the already-running gateway process, and the raw `python -m
+    # hermes_cli.main update` invocation has no LaunchDaemon-aware pause: it
+    # restarts the gateway mid-request and Desktop's un-backed-off WebSocket
+    # reconnect loop hammers the restarting process, which drained file
+    # descriptors into an EMFILE that got misread as ~/.hermes/auth.json
+    # corruption and wiped live OAuth credentials (2026-07-31 incident).
+    # ~/.hermes/scripts/hermes-safe-update.sh exists specifically to pause the
+    # LaunchDaemons first and was built to self-detach safely from exactly this
+    # call site (running_under_hermes_service() + submit_detached_if_needed()).
+    # Prefer it when present; every other install falls back to the original
+    # raw-update behavior unchanged.
+    safe_update_script = "/Users/aiserver/.hermes/scripts/hermes-safe-update.sh"
+    cmd_override = (
+        ["/bin/bash", safe_update_script]
+        if os.path.exists(safe_update_script)
+        else None
+    )
     try:
         proc = _spawn_hermes_action(
             ["update"],
             "hermes-update",
             env_overrides={"HERMES_ACTION_ID": action_id},
+            cmd_override=cmd_override,
         )
     except Exception as exc:
         _log.exception("Failed to spawn hermes update")

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -11337,17 +11337,90 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 )
 
             # Concurrent tail: active rows that arrived after the watermark.
-            # Snapshot their ids and tool_calls now — the clone below needs a
+            # A durable row can also already be represented in the compressor's
+            # handoff (for example when a preflight compaction overlaps a live
+            # append). Match those exact occurrences before cloning so the commit
+            # preserves the row once instead of inserting it and cloning it again.
+            def _watermark_overlap_identity(
+                role: Any,
+                content: Any,
+                tool_call_id: Any,
+                tool_calls: Any,
+                tool_name: Any,
+                timestamp: Any,
+            ) -> tuple:
+                if isinstance(tool_calls, str):
+                    try:
+                        tool_calls = json.loads(tool_calls)
+                    except (json.JSONDecodeError, TypeError):
+                        tool_calls = []
+                tool_calls_json = json.dumps(tool_calls) if tool_calls else None
+                try:
+                    normalized_timestamp = float(timestamp)
+                except (TypeError, ValueError):
+                    normalized_timestamp = None
+                return (
+                    role,
+                    self._encode_content(content),
+                    tool_call_id,
+                    tool_calls_json,
+                    _scrub_surrogates(tool_name),
+                    normalized_timestamp,
+                )
+
+            represented_tail_occurrences: Dict[tuple, int] = {}
+            represented_untimed_occurrences: Dict[tuple, int] = {}
+            for message in compacted_messages:
+                identity = _watermark_overlap_identity(
+                    message.get("role", "unknown"),
+                    message.get("content"),
+                    message.get("tool_call_id"),
+                    message.get("tool_calls"),
+                    message.get("tool_name"),
+                    message.get("timestamp"),
+                )
+                represented_tail_occurrences[identity] = (
+                    represented_tail_occurrences.get(identity, 0) + 1
+                )
+                if identity[-1] is None:
+                    untimed_identity = identity[:-1]
+                    represented_untimed_occurrences[untimed_identity] = (
+                        represented_untimed_occurrences.get(untimed_identity, 0) + 1
+                    )
+
+            # Snapshot tail ids and tool_calls now — the clone below needs a
             # stable id list, and the tool-call count keeps sessions.* honest.
             tail_ids: list[int] = []
             tail_tool_calls = 0
             if watermark is not None:
                 for row in conn.execute(
-                    "SELECT id, tool_calls FROM messages "
+                    "SELECT id, role, content, tool_call_id, tool_calls, "
+                    "tool_name, timestamp FROM messages "
                     "WHERE session_id = ? AND active = 1 AND id > ? "
                     "ORDER BY id",
                     (session_id, int(watermark)),
                 ).fetchall():
+                    identity = _watermark_overlap_identity(
+                        row["role"],
+                        self._decode_content(row["content"]),
+                        row["tool_call_id"],
+                        row["tool_calls"],
+                        row["tool_name"],
+                        row["timestamp"],
+                    )
+                    represented_count = represented_tail_occurrences.get(identity, 0)
+                    if represented_count > 0:
+                        represented_tail_occurrences[identity] = represented_count - 1
+                        continue
+                    untimed_identity = identity[:-1]
+                    untimed_count = represented_untimed_occurrences.get(
+                        untimed_identity, 0
+                    )
+                    if untimed_count > 0:
+                        represented_untimed_occurrences[untimed_identity] = (
+                            untimed_count - 1
+                        )
+                        continue
                     tail_ids.append(int(row["id"]))
                     raw = row["tool_calls"]
                     if raw:

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -1823,9 +1823,18 @@ class HindsightMemoryProvider(MemoryProvider):
                     if config_changed:
                         profile_env = _materialize_embedded_profile_env(self._config)
                         if client._manager.is_running(profile):
+                            # Do not kill a healthy shared embedded daemon from inside a
+                            # live gateway/session. Several Hermes profiles can share the
+                            # default Hindsight profile, and restarting here can terminate
+                            # in-flight retain/recall requests, surfacing as Hindsight HTTP
+                            # 500s to the caller. The updated env is materialized for the
+                            # next natural daemon start; explicit operational restarts can
+                            # still be performed outside an active request path.
                             with open(log_path, "a", encoding="utf-8") as f:
-                                f.write("\n=== Config changed, restarting daemon ===\n")
-                            client._manager.stop(profile)
+                                f.write(
+                                    "\n=== Config changed; healthy daemon left running "
+                                    "(restart deferred) ===\n"
+                                )
 
                     client._ensure_started()
                     with open(log_path, "a", encoding="utf-8") as f:

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -597,6 +597,15 @@ def _build_embedded_profile_env(config: dict[str, Any], *, llm_api_key: str | No
             or get_secret("HINDSIGHT_LLM_API_KEY", "")
         )
 
+    if not current_key:
+        # A transient miss (secret backend down, .env not yet loaded) must not
+        # be persisted: the daemon-start path rewrites this file on any diff,
+        # so an empty resolution would blank the stored key permanently — and
+        # would read as config drift. Keep whatever is already on disk.
+        current_key = _load_simple_env(_embedded_profile_env_path(config)).get(
+            "HINDSIGHT_API_LLM_API_KEY", ""
+        )
+
     current_provider = config.get("llm_provider", "")
     current_model = config.get("llm_model", "")
     current_base_url = config.get("llm_base_url") or os.environ.get("HINDSIGHT_API_LLM_BASE_URL", "")

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import asyncio
 import atexit
+import contextvars
 import importlib
 import json
 import logging
@@ -310,6 +311,33 @@ _loop: asyncio.AbstractEventLoop | None = None
 _loop_thread: threading.Thread | None = None
 _loop_lock = threading.Lock()
 
+
+def _scoped_thread(target, *, name: str) -> threading.Thread:
+    """Build a daemon thread that inherits the caller's contextvars.
+
+    A bare ``threading.Thread`` does NOT inherit ContextVars, and the active
+    profile's credentials live in one: ``agent.secret_scope`` installs them
+    per-turn via ``set_secret_scope``. Any ``get_secret`` call on a bare thread
+    therefore sees no scope and silently falls through to ``os.environ`` --
+    which under the gateway does not carry profile keys -- resolving to "".
+
+    That is not hypothetical: it blanked HINDSIGHT_API_LLM_API_KEY on disk
+    (the profile env is rebuilt with O_TRUNC on daemon start) and, because
+    ``_get_client`` caches, could pin an empty-key client for a whole session.
+
+    Threads built here run inside a snapshot of the spawning context, so the
+    profile scope propagates exactly as it does into the agent's worker thread.
+    The thread is returned UNSTARTED so callers keep their existing
+    assign-then-start ordering (``_ensure_writer`` publishes ``_writer_thread``
+    before starting, so a concurrent caller can't race in a second writer).
+
+    NOTE: for per-provider (single-profile) threads only. The shared
+    process-global loop thread must NOT use it -- see ``_get_loop``.
+    """
+    ctx = contextvars.copy_context()
+    return threading.Thread(target=lambda: ctx.run(target), daemon=True, name=name)
+
+
 # Sentinel pushed to the per-provider retain queue to wake the writer for a
 # clean exit. A unique object so it can never collide with a real job.
 _WRITER_SENTINEL = object()
@@ -327,6 +355,13 @@ def _get_loop() -> asyncio.AbstractEventLoop:
             asyncio.set_event_loop(_loop)
             _loop.run_forever()
 
+        # Deliberately NOT run under a copied context: this loop is a
+        # process-global singleton shared by every profile. Copying the first
+        # caller's context into it would pin that profile's secret scope for
+        # the lifetime of the process and leak it to every later profile's
+        # coroutines. Work is submitted here via run_coroutine_threadsafe from
+        # an already-scoped caller, so the loop thread itself stays
+        # context-free. See _scoped_thread for the per-provider case.
         _loop_thread = threading.Thread(target=_run, daemon=True, name="hindsight-loop")
         _loop_thread.start()
         return _loop
@@ -1323,11 +1358,7 @@ class HindsightMemoryProvider(MemoryProvider):
         # If the previous writer exited (e.g. after a prior shutdown), reset
         # the flag so this fresh writer is allowed to drain new jobs.
         self._shutting_down.clear()
-        thread = threading.Thread(
-            target=self._writer_loop,
-            daemon=True,
-            name="hindsight-writer",
-        )
+        thread = _scoped_thread(self._writer_loop, name="hindsight-writer")
         self._writer_thread = thread
         # Keep the legacy _sync_thread alias pointing at the writer so any
         # external code that joins _sync_thread keeps working.
@@ -1853,7 +1884,7 @@ class HindsightMemoryProvider(MemoryProvider):
                         f.write(f"\n=== Daemon startup failed: {e} ===\n")
                         traceback.print_exc(file=f)
 
-            t = threading.Thread(target=_start_daemon, daemon=True, name="hindsight-daemon-start")
+            t = _scoped_thread(_start_daemon, name="hindsight-daemon-start")
             t.start()
 
     def system_prompt_block(self) -> str:
@@ -2010,7 +2041,7 @@ class HindsightMemoryProvider(MemoryProvider):
                     self._prefetch_result = recalled.text
                     self._prefetch_count = recalled.count
 
-        self._prefetch_thread = threading.Thread(target=_run, daemon=True, name="hindsight-prefetch")
+        self._prefetch_thread = _scoped_thread(_run, name="hindsight-prefetch")
         self._prefetch_thread.start()
 
     def _build_turn_messages(self, user_content: str, assistant_content: str) -> List[Dict[str, str]]:

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -7689,9 +7689,20 @@ class DiscordAdapter(BasePlatformAdapter):
             clean_choices = clean_choices[:24]
 
             if clean_choices:
+                option_lines_full = "\n".join(
+                    f"**{index + 1}.** {choice}"
+                    for index, choice in enumerate(clean_choices)
+                )
+                embed_suffix = (
+                    "\n\nPick a button below, or click ✏️ Other to type a custom answer."
+                )
+                option_lines = option_lines_full
+                if len(option_lines) + len(embed_suffix) > 1024:
+                    budget = 1024 - len(embed_suffix) - 3
+                    option_lines = option_lines[:budget] + "..."
                 embed.add_field(
                     name="Choices",
-                    value="Pick one below, or click ✏️ Other to type a custom answer.",
+                    value=f"{option_lines}{embed_suffix}",
                     inline=False,
                 )
                 view = ClarifyChoiceView(
@@ -7707,16 +7718,43 @@ class DiscordAdapter(BasePlatformAdapter):
                     inline=False,
                 )
                 view = None
+                option_lines_full = ""
 
-            # Mirror the question in plain content — embeds are invisible on
-            # some clients (see send_exec_approval).
-            clarify_tail = (
-                "\n\nPick one below, or click ✏️ Other to type a custom answer."
-                if clean_choices
-                else "\n\nReply in this channel with your answer."
-            )
+            # Mirror full choice text in plain content because embeds may be
+            # hidden and mobile button labels have almost no usable width.
+            content_header = "❓ **Hermes needs your input**"
+            question_text = str(question or "").strip()
+            if clean_choices:
+                instruction = (
+                    "Pick a button below, or click ✏️ Other to type a custom answer."
+                )
+                truncation_notice = "\n[additional choice text truncated]"
+                # Reserve enough plain-content space for the prompt itself.
+                # _self_contained_prompt_content() will cap a longer question
+                # to this same budget while preserving the tail verbatim.
+                question_reserve = min(len(question_text), 500)
+                fixed_length = (
+                    len(f"{content_header}\n\n")
+                    + question_reserve
+                    + len("\n\n")
+                    + len("\n\n")
+                    + len(instruction)
+                )
+                options_budget = max(0, self.MAX_MESSAGE_LENGTH - fixed_length)
+                mirrored_options = option_lines_full
+                if len(mirrored_options) > options_budget:
+                    text_budget = max(0, options_budget - len(truncation_notice))
+                    mirrored_options = (
+                        mirrored_options[:text_budget].rstrip()
+                        + truncation_notice
+                    )
+                clarify_tail = (
+                    f"\n\n{mirrored_options}\n\n{instruction}"
+                )
+            else:
+                clarify_tail = "\n\nReply in this channel with your answer."
             content = self._self_contained_prompt_content(
-                "❓ **Hermes needs your input**", str(question or "").strip(),
+                content_header, question_text,
                 tail=clarify_tail,
             )
             msg = await channel.send(content=content, embed=embed, view=view) if view else await channel.send(content=content, embed=embed)
@@ -9642,50 +9680,8 @@ def _define_discord_view_classes() -> None:
             self.resolved = False
 
             for index, choice in enumerate(self.choices):
-                # Discord button labels are capped at 80 chars. On mobile the
-                # visible width is much narrower (often <40 chars before it
-                # wraps to 2 lines and the second line gets cut off), so we
-                # cap aggressively and cut at a word boundary when possible
-                # to keep the trailing text readable.
-                #
-                # Cut strategy (most-preferred to least-preferred):
-                #   1. Last space in the trailing half of the budget
-                #      (cleanest word boundary)
-                #   2. Last soft boundary in the trailing half of the
-                #      budget (hyphen, comma, period, paren)
-                #   3. Hard cut at the budget limit (last resort)
-                prefix = f"{index + 1}. "
-                budget = _DISCORD_BUTTON_LABEL_LIMIT - utf16_len(prefix)
-                if utf16_len(choice) <= budget:
-                    label_body = choice
-                else:
-                    truncated = _prefix_within_utf16_limit(
-                        choice,
-                        max(0, budget - utf16_len(_DISCORD_ELLIPSIS)),
-                    ).rstrip()
-                    cut_at = -1
-                    # 1. Last space in the trailing half of the budget.
-                    space = truncated.rfind(" ")
-                    if space >= len(truncated) // 2:
-                        cut_at = space
-                    # 2. Soft boundary — only if no word boundary found.
-                    # Find the latest soft boundary in the trailing half
-                    # of the budget; that maximizes preserved text length.
-                    # Cut AT the soft boundary (inclusive) so the label
-                    # ends on the soft char (e.g. "-" or ",") rather than
-                    # on the alpha char that followed it.
-                    if cut_at < 0:
-                        latest_soft = max(
-                            (truncated.rfind(s) for s in ("-", ",", ".", ")")),
-                            default=-1,
-                        )
-                        if latest_soft >= len(truncated) // 2:
-                            cut_at = latest_soft + 1
-                    if cut_at > 0:
-                        truncated = truncated[:cut_at]
-                    label_body = truncated.rstrip() + _DISCORD_ELLIPSIS
                 button = discord.ui.Button(
-                    label=f"{prefix}{label_body}",
+                    label=str(index + 1),
                     style=discord.ButtonStyle.primary,
                     custom_id=f"clarify:{clarify_id}:{index}",
                 )

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -3786,6 +3786,30 @@ class MatrixAdapter(BasePlatformAdapter):
         is_direct = bool(getattr(content, "is_direct", False))
         inviter = str(getattr(event, "sender", ""))
 
+        # mautrix's MembershipEventDispatcher fires InternalEventType.INVITE
+        # for *any* m.room.member state event with membership=invite that
+        # appears in a synced room's timeline/state — not just invites
+        # targeting this bot. In shared/bridged rooms we've already joined,
+        # bridge bots routinely invite other ghost users (Discord/Signal
+        # puppets) into the room, and those state events land here too.
+        # Without checking state_key against our own mxid, we log a
+        # spurious "rejecting invite ... from unauthorized user <bridge
+        # bot>" for every such invite, even though nothing was actually
+        # offered to us and there's nothing to reject.
+        #
+        # The comparison goes through _is_self_sender() rather than a raw
+        # equality check: some homeservers normalize the localpart case
+        # differently at different API surfaces, so a byte-comparison here
+        # would discard a *genuine* invite whose state_key differs from our
+        # resolved mxid only by casing or surrounding whitespace. It also
+        # gives us the right fallback — when our own mxid hasn't resolved
+        # yet, _is_self_sender() returns True defensively, so we fall
+        # through to the authorization gate instead of silently swallowing
+        # an invite we cannot yet attribute.
+        state_key = str(getattr(event, "state_key", "") or "")
+        if state_key and not self._is_self_sender(state_key):
+            return
+
         # Only auto-join when the inviter is authorized. Without this, any
         # federated Matrix user could invite the bot into arbitrary rooms,
         # exposing its presence and metadata. Mirrors the allow-list gate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,7 +185,7 @@ edge-tts = ["edge-tts==7.2.7"]
 modal = ["modal==1.3.4"]
 daytona = ["daytona==0.155.0"]
 vercel = ["vercel==0.7.2"]
-hindsight = ["hindsight-client==0.6.1"]
+hindsight = ["hindsight-client==0.9.2"]
 dev = ["debugpy==1.8.20", "pytest==9.1.1", "pytest-asyncio==1.3.0", "mcp==2.0.0", "httpx2==2.7.0", "starlette==1.3.1", "ty==0.0.21", "ruff==0.15.10", "setuptools==83.0.0"]  # starlette: CVE-2026-48710; setuptools: 83 (torch >=2.13 requires setuptools 83)
 messaging = ["python-telegram-bot[webhooks]==22.8", "discord.py[voice]==2.7.1", "aiohttp==3.14.3", "brotlicffi==1.2.0.1", "slack-bolt==1.30.0", "slack-sdk==3.43.0", "qrcode==7.4.2"]  # aiohttp 3.14.3: prior CVEs + GHSA-cq5v-8q36-5273/GHSA-mfx4-hv73-q22v/GHSA-mq44-7p77-q5h7
 cron = []  # croniter is now a core dependency; this extra kept for back-compat
@@ -419,7 +419,7 @@ exclude-newer = "14 days"
 # cutoff can still brick installs. Exempting exact pins is pure brick-risk
 # removal at no supply-chain cost. Guarded by
 # tests/test_packaging_metadata.py::test_build_system_requires_exempt_from_exclude_newer.
-exclude-newer-package = { vercel = false, nemo-relay = false, huggingface_hub = false, h2 = false, aiohttp = false, cryptography = false, defusedxml = false, python-olm = false, unpaddedbase64 = false, setuptools = false, pillow = false, mcp = false }
+exclude-newer-package = { vercel = false, nemo-relay = false, huggingface_hub = false, h2 = false, aiohttp = false, cryptography = false, defusedxml = false, python-olm = false, unpaddedbase64 = false, setuptools = false, pillow = false, mcp = false, hindsight-client = false }
 
 [tool.setuptools]
 # Top-level single-file modules (not packages). Without this, uv2nix's

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -3228,10 +3228,25 @@ class TestCodexAuxiliaryAdapterTimeout:
         assert response.choices[0].message.content == "summary"
 
     def test_enforces_total_timeout_while_stream_keeps_emitting_events(self):
+        """The adapter must abort a stream that stays alive past the deadline.
+
+        Asserted by counting events consumed, not by wall clock. The stream
+        yields 5 events; prompt enforcement stops after the first one or two.
+        A wall-clock budget cannot express this: ``time.sleep`` is only a
+        *lower* bound, and on a loaded machine (or macOS timer coalescing) a
+        nominal 0.03s sleep is regularly measured at ~0.18s, which made the
+        old ``< 0.14`` assertion unsatisfiable no matter how promptly the
+        adapter reacted. Event count measures the enforcement itself and is
+        immune to scheduler latency.
+        """
+        events_yielded = 0
+
         class _SlowAliveCreateStream:
             def __iter__(self):
+                nonlocal events_yielded
                 for _ in range(5):
                     time.sleep(0.03)
+                    events_yielded += 1
                     yield SimpleNamespace(type="response.in_progress")
 
             def close(self): pass
@@ -3243,14 +3258,19 @@ class TestCodexAuxiliaryAdapterTimeout:
         fake_client = SimpleNamespace(responses=FakeResponses(), close=lambda: None)
         adapter = _CodexCompletionsAdapter(fake_client, "gpt-5.5")
 
-        started = time.monotonic()
         with pytest.raises(TimeoutError):
             adapter.create(
                 messages=[{"role": "user", "content": "summarize this"}],
                 timeout=0.05,
             )
 
-        assert time.monotonic() - started < 0.14
+        # The whole point: it must NOT drain all 5 events. Each event is >= the
+        # 0.05s deadline in aggregate, so a correct adapter bails almost
+        # immediately; anything that consumes the full stream is not enforcing.
+        assert events_yielded < 5, (
+            f"adapter drained the entire stream ({events_yielded} events) "
+            "instead of enforcing the total timeout"
+        )
 
 
 class TestCodexAuxiliaryAdapterCacheScope:

--- a/tests/agent/test_claude_oauth_scrub.py
+++ b/tests/agent/test_claude_oauth_scrub.py
@@ -1,0 +1,97 @@
+"""Tests for Claude OAuth trigger scrubbing across direct and MoA routes."""
+
+from types import SimpleNamespace
+
+from agent import chat_completion_helpers as helpers
+
+
+def test_scrubs_only_system_messages_for_direct_claude():
+    agent = SimpleNamespace(model="claude-sonnet-5", base_url="https://example.test")
+    messages = [
+        {"role": "system", "content": "Use session_search and skill_view."},
+        {"role": "user", "content": "Call session_search literally."},
+    ]
+
+    result = helpers._scrub_claude_oauth_triggers(agent, messages)
+
+    assert result[0]["content"] == "Use sess_search and sk_view."
+    assert result[1]["content"] == "Call session_search literally."
+    assert messages[0]["content"] == "Use session_search and skill_view."
+
+
+def test_non_claude_non_moa_returns_original_object():
+    agent = SimpleNamespace(model="gpt-5.6", base_url="https://example.test")
+    messages = [{"role": "system", "content": "session_search"}]
+
+    assert helpers._scrub_claude_oauth_triggers(agent, messages) is messages
+
+
+def test_moa_preset_detects_claude_reference(monkeypatch):
+    agent = SimpleNamespace(model="default", base_url="moa://local")
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"moa": {}})
+    monkeypatch.setattr(
+        "hermes_cli.moa_config.resolve_moa_preset",
+        lambda _config, _name: {
+            "reference_models": [{"model": "claude-fable-5"}],
+            "aggregator": {"model": "gpt-5.6"},
+        },
+    )
+
+    assert helpers._moa_preset_targets_claude(agent) is True
+
+
+def test_scrubs_structured_system_blocks(monkeypatch):
+    agent = SimpleNamespace(model="default", base_url="moa://local")
+    monkeypatch.setattr(helpers, "_moa_preset_targets_claude", lambda _agent: True)
+    messages = [
+        {
+            "role": "system",
+            "content": [
+                {"type": "text", "text": "Use skill_manage."},
+                {"type": "image", "url": "https://example.test/image"},
+            ],
+        }
+    ]
+
+    result = helpers._scrub_claude_oauth_triggers(agent, messages)
+
+    assert result[0]["content"][0]["text"] == "Use sk_manage."
+    assert result[0]["content"][1] == messages[0]["content"][1]
+
+
+def test_media_tag_is_not_in_scrub_table():
+    scrubbed_sources = {source for source, _ in helpers._CLAUDE_OAUTH_SCRUB}
+    assert "MEDIA:" not in scrubbed_sources
+
+
+def test_media_directive_survives_direct_claude_scrub():
+    agent = SimpleNamespace(model="claude-sonnet-5", base_url="https://example.test")
+    messages = [
+        {
+            "role": "system",
+            "content": "Use MEDIA:/absolute/path/to/file and session_search.",
+        }
+    ]
+
+    result = helpers._scrub_claude_oauth_triggers(agent, messages)
+
+    assert "MEDIA:/absolute/path/to/file" in result[0]["content"]
+    assert "M3DIA:" not in result[0]["content"]
+    assert "sess_search" in result[0]["content"]
+
+
+def test_media_directive_survives_structured_system_blocks(monkeypatch):
+    agent = SimpleNamespace(model="default", base_url="moa://local")
+    monkeypatch.setattr(helpers, "_moa_preset_targets_claude", lambda _agent: True)
+    messages = [
+        {
+            "role": "system",
+            "content": [
+                {"type": "text", "text": "Use MEDIA:/path/to/file.png."},
+            ],
+        }
+    ]
+
+    result = helpers._scrub_claude_oauth_triggers(agent, messages)
+
+    assert "MEDIA:/path/to/file.png" in result[0]["content"][0]["text"]

--- a/tests/agent/test_compression_review_76354.py
+++ b/tests/agent/test_compression_review_76354.py
@@ -460,13 +460,20 @@ class TestS3IdleChargedFromLastProgress:
     def test_silence_cannot_approach_double_idle_timeout(self):
         """Progress early in an interval must not extend silence to ~2x idle."""
         _drain_admission_slots()
-        idle = 0.4
+        # Deliberately not 0.4s. Detection carries a fixed poll-granularity
+        # overshoot, so the *ratio* to idle shrinks as idle grows (measured on
+        # this codebase: 1.50x @0.4s, 1.37x @1.0s, 1.24x @2.0s, 1.15x @4.0s --
+        # the signature of poll granularity, not of the ~2x regression this
+        # test guards). At 0.4s the 1.8x budget left only ~0.12s of absolute
+        # headroom, which normal scheduler jitter on a loaded machine exceeds.
+        # A larger idle keeps the identical invariant with ~1.1s of headroom.
+        idle = 2.0
         release = threading.Event()
 
         def worker(fence: CompressionCommitFence):
             time.sleep(0.05)
             fence.touch_progress()  # early progress, then total silence
-            assert release.wait(timeout=10)
+            assert release.wait(timeout=30)
             return ([], "late")
 
         t0 = time.monotonic()
@@ -476,15 +483,15 @@ class TestS3IdleChargedFromLastProgress:
                 messages=[{"role": "user", "content": "a"}],
                 system_prompt_fallback="fb",
                 idle_timeout_seconds=idle,
-                total_ceiling_seconds=5.0,
+                total_ceiling_seconds=idle * 12,
             )
         finally:
             elapsed = time.monotonic() - t0
             release.set()
         assert prompt == "fb"
-        # Old behavior waited a full interval from the CHECK (~2x idle ≈
-        # 0.85s+). New behavior times out ~idle after the last progress
-        # (~0.45s). Allow generous slack while still excluding ~2x.
+        # Old behavior waited a full interval from the CHECK (~2x idle ≈ 4.0s+
+        # here). New behavior times out ~idle after the last progress (~2.5s).
+        # Allow generous slack while still excluding ~2x.
         assert elapsed < idle * 1.8, (
             f"silence exceeded ~2x idle budget shape: {elapsed:.2f}s"
         )

--- a/tests/agent/test_compression_rotation_state.py
+++ b/tests/agent/test_compression_rotation_state.py
@@ -665,6 +665,43 @@ class TestTodoSnapshotScaffoldingTails:
             for previous, current in zip(compressed, compressed[1:])
         )
 
+    def test_buried_standalone_snapshot_is_replaced_not_duplicated(
+        self, tmp_path: Path
+    ):
+        """A tool result after a snapshot must not make the next boundary stack it."""
+        from tools.todo_tool import TODO_INJECTION_HEADER
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        agent = self._agent_with_todo(
+            db,
+            "PARENT_TODO_BURIED",
+            {"role": "tool", "tool_call_id": "call-1", "content": "done"},
+        )
+        agent.context_compressor.compress.return_value.insert(
+            -1,
+            {
+                "role": "user",
+                "content": (
+                    f"{TODO_INJECTION_HEADER}\n"
+                    "- [ ] t0. stale task (pending)"
+                ),
+                "_todo_snapshot_synthetic": True,
+            },
+        )
+
+        compressed, _ = agent._compress_context(
+            _msgs(), "sys", approx_tokens=120_000
+        )
+
+        snapshot_rows = [
+            message
+            for message in compressed
+            if TODO_INJECTION_HEADER in str(message.get("content") or "")
+        ]
+        assert len(snapshot_rows) == 1
+        assert "task A" in str(snapshot_rows[0]["content"])
+        assert "stale task" not in str(snapshot_rows[0]["content"])
+
     def test_empty_todo_store_injects_nothing(self, tmp_path: Path):
         from tools.todo_tool import TODO_INJECTION_HEADER
 

--- a/tests/gateway/test_64674_multiplex_primary_token_scope.py
+++ b/tests/gateway/test_64674_multiplex_primary_token_scope.py
@@ -14,6 +14,7 @@ this suite locks the complementary primary-path fixes:
 """
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -215,6 +216,63 @@ class TestPrimaryMessageRuntimeScope:
 
 
 class TestReconnectDropsEmptyToken:
+    def test_backfills_late_resolved_token_from_env(self, monkeypatch):
+        from gateway.config import PLATFORM_TOKEN_ENV_NAMES, Platform, PlatformConfig
+        from gateway.run import _platform_has_bot_credential
+
+        env_name = PLATFORM_TOKEN_ENV_NAMES[Platform.DISCORD]
+        monkeypatch.setenv(env_name, "late-resolved-token")
+        config = PlatformConfig(enabled=True, token="")
+
+        assert _platform_has_bot_credential(
+            Platform.DISCORD, config, allow_env_fallback=True
+        ) is True
+        assert config.token == "late-resolved-token"
+
+    def test_multiplex_path_does_not_borrow_process_global_token(self, monkeypatch):
+        from gateway.config import PLATFORM_TOKEN_ENV_NAMES, Platform, PlatformConfig
+        from gateway.run import _platform_has_bot_credential
+
+        env_name = PLATFORM_TOKEN_ENV_NAMES[Platform.DISCORD]
+        monkeypatch.setenv(env_name, "secondary-profile-token")
+        config = PlatformConfig(enabled=True, token="")
+
+        assert _platform_has_bot_credential(Platform.DISCORD, config) is False
+        assert config.token == ""
+
+    def test_runtime_env_reload_backfills_queued_reconnect_config(self, monkeypatch):
+        import agent.secret_scope
+        import gateway.run as gateway_run
+        from gateway.config import PLATFORM_TOKEN_ENV_NAMES, Platform, PlatformConfig
+
+        env_name = PLATFORM_TOKEN_ENV_NAMES[Platform.DISCORD]
+        monkeypatch.delenv(env_name, raising=False)
+        config = PlatformConfig(enabled=True, token="")
+
+        def reload_dotenv(**_kwargs):
+            os.environ[env_name] = "rotated-runtime-token"
+
+        monkeypatch.setattr(agent.secret_scope, "is_multiplex_active", lambda: False)
+        monkeypatch.setattr(gateway_run, "load_hermes_dotenv", reload_dotenv)
+        monkeypatch.setattr(gateway_run, "_bridge_max_turns_from_config", lambda _home: None)
+
+        gateway_run._reload_runtime_env_preserving_config_authority()
+
+        assert gateway_run._platform_has_bot_credential(
+            Platform.DISCORD, config, allow_env_fallback=True
+        ) is True
+        assert config.token == "rotated-runtime-token"
+
+    def test_empty_config_and_environment_remains_uncredentialed(self, monkeypatch):
+        from gateway.config import PLATFORM_TOKEN_ENV_NAMES, Platform, PlatformConfig
+        from gateway.run import _platform_has_bot_credential
+
+        env_name = PLATFORM_TOKEN_ENV_NAMES[Platform.DISCORD]
+        monkeypatch.delenv(env_name, raising=False)
+        config = PlatformConfig(enabled=True, token="")
+
+        assert _platform_has_bot_credential(Platform.DISCORD, config) is False
+
     @pytest.mark.asyncio
     async def test_empty_token_removed_from_queue(self):
         from gateway.run import GatewayRunner, _platform_has_bot_credential

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -190,7 +190,7 @@ class TestBusySessionAck:
 
 
     @pytest.mark.asyncio
-    async def test_steer_mode_calls_agent_steer_no_interrupt_no_queue(self, monkeypatch):
+    async def test_steer_mode_calls_agent_steer_no_interrupt_no_queue(self, monkeypatch, caplog):
         """busy_input_mode='steer' injects via agent.steer() and skips queueing."""
         import gateway.run as _gr
 
@@ -206,9 +206,13 @@ class TestBusySessionAck:
 
         agent = MagicMock()
         agent.steer = MagicMock(return_value=True)
+        agent.get_activity_summary.return_value = {"seconds_since_activity": 7}
         runner._running_agents[sk] = agent
+        runner._running_agents_ts[sk] = time.time() - 30
 
-        with patch("gateway.run.merge_pending_message_event") as mock_merge:
+        with caplog.at_level("INFO", logger="gateway.run"), patch(
+            "gateway.run.merge_pending_message_event"
+        ) as mock_merge:
             await runner._handle_active_session_busy_message(event, sk)
 
         # VERIFY: Agent was steered, NOT interrupted
@@ -224,6 +228,11 @@ class TestBusySessionAck:
         content = call_kwargs.kwargs.get("content") or call_kwargs[1].get("content", "")
         assert "Steered" in content or "steer" in content.lower()
         assert "Interrupting" not in content
+        assert any(
+            "Busy-path absorbed inbound message" in record.getMessage()
+            and "agent_idle=7s" in record.getMessage()
+            for record in caplog.records
+        )
 
     @pytest.mark.asyncio
     async def test_steer_mode_transcribes_voice_before_injection(self, monkeypatch):

--- a/tests/gateway/test_discord_clarify_buttons.py
+++ b/tests/gateway/test_discord_clarify_buttons.py
@@ -30,7 +30,6 @@ from plugins.platforms.discord.adapter import (  # noqa: E402
     DiscordAdapter,
 )
 from gateway.config import PlatformConfig  # noqa: E402
-from gateway.platforms.base import utf16_len  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -44,6 +43,15 @@ def _make_adapter(*, allowed_users=None, allowed_roles=None):
     adapter._allowed_user_ids = set(allowed_users or [])
     adapter._allowed_role_ids = set(allowed_roles or [])
     return adapter
+
+
+def _choices_field_value(embed) -> str:
+    for field in embed.fields:
+        if isinstance(field, dict) and field.get("name") == "Choices":
+            return field.get("value") or ""
+        if getattr(field, "name", None) == "Choices":
+            return field.value
+    return ""
 
 
 def _clear_clarify_state():
@@ -86,45 +94,24 @@ class TestClarifyChoiceViewConstruction:
     """The view should build numeric buttons plus an Other button."""
 
 
-    def test_truncates_long_choice_label(self):
+    def test_long_choice_uses_short_numeric_button_label(self):
         long_choice = "x" * 200
         view = ClarifyChoiceView(
             choices=[long_choice],
             clarify_id="cidZ",
             allowed_user_ids=set(),
         )
-        # 78 chars + single-char ellipsis in the body, plus "1. " prefix.
-        # Uses U+2026 (…) instead of "..." to fit the 80-char Discord cap.
-        first_label = view.children[0].label
-        assert first_label.startswith("1. ")
-        assert first_label.endswith("\u2026")
-        # Final label total <= 80 (Discord cap on button labels)
-        assert len(first_label) <= 80
+        assert view.children[0].label == "1"
 
 
-    def test_truncates_long_no_space_choice_on_soft_boundary(self):
-        # A long choice with soft boundaries (commas, hyphens) but no spaces
-        # should still cut on a soft boundary, not mid-word. We use an input
-        # where position 76 is NOT a soft boundary — the test only passes
-        # if the renderer actively searches backward for a soft char
-        # rather than blindly cutting at the budget limit.
+    def test_no_space_choice_still_uses_short_numeric_button_label(self):
         long_choice = "a" * 30 + "-" + "b" * 30 + "-" + "c" * 30 + "-" + "d" * 30
-        # 30a-30b-30c-30d = 30 + 1 + 30 + 1 + 30 + 1 + 30 = 123 chars
-        # Position 76 is 'b' (a mid-word alpha). The renderer must look back
-        # for a '-' to cut on.
         view = ClarifyChoiceView(
             choices=[long_choice],
             clarify_id="cidSB",
             allowed_user_ids=set(),
         )
-        first_label = view.children[0].label
-        assert first_label.endswith("\u2026")
-        assert len(first_label) <= 80
-        body = first_label[len("1. "):].rstrip("\u2026")
-        last_char = body[-1]
-        assert last_char in {"-", ",", ".", ")", " "}, (
-            f"Label cuts mid-word at {last_char!r}: {first_label!r}"
-        )
+        assert view.children[0].label == "1"
 
 
 # ===========================================================================
@@ -232,6 +219,52 @@ class TestDiscordSendClarify:
         assert isinstance(kwargs["view"], ClarifyChoiceView)
         # 3 choice buttons + 1 Other
         assert len(kwargs["view"].children) == 4
+        assert [button.label for button in kwargs["view"].children[:-1]] == ["1", "2", "3"]
+        choices_text = _choices_field_value(kwargs["embed"])
+        assert "red" in choices_text and "green" in choices_text and "blue" in choices_text
+
+    @pytest.mark.asyncio
+    async def test_choices_field_respects_discord_1024_character_cap(self):
+        adapter = _make_adapter()
+        channel = MagicMock()
+        sent_msg = MagicMock(id=999)
+        channel.send = AsyncMock(return_value=sent_msg)
+        adapter._client.get_channel = MagicMock(return_value=channel)
+
+        await adapter.send_clarify(
+            chat_id="9001",
+            question="Pick",
+            choices=[f"choice-{index}-" + "x" * 100 for index in range(24)],
+            clarify_id="cid-cap",
+            session_key="sk-cap",
+        )
+
+        value = _choices_field_value(channel.send.call_args.kwargs["embed"])
+        assert len(value) <= 1024
+        assert value.endswith("Pick a button below, or click ✏️ Other to type a custom answer.")
+
+    @pytest.mark.asyncio
+    async def test_plain_content_respects_discord_2000_character_cap(self):
+        adapter = _make_adapter()
+        channel = MagicMock()
+        sent_msg = MagicMock(id=1000)
+        channel.send = AsyncMock(return_value=sent_msg)
+        adapter._client.get_channel = MagicMock(return_value=channel)
+
+        await adapter.send_clarify(
+            chat_id="9001",
+            question="Pick one of these detailed choices",
+            choices=[f"choice-{index}-" + "x" * 200 for index in range(24)],
+            clarify_id="cid-content-cap",
+            session_key="sk-content-cap",
+        )
+
+        content = channel.send.call_args.kwargs["content"]
+        assert len(content) <= 2000
+        assert "[additional choice text truncated]" in content
+        assert content.endswith(
+            "Pick a button below, or click ✏️ Other to type a custom answer."
+        )
 
     @pytest.mark.asyncio
     async def test_open_ended_omits_view(self):
@@ -290,7 +323,9 @@ class TestDiscordSendClarify:
         assert len(choice_labels) == 1, (
             f"Expected 1 choice, got {len(choice_labels)}: {choice_labels!r}"
         )
-        assert "real choice" in choice_labels[0]
+        assert choice_labels == ["1"]
+        choice_text = _choices_field_value(kwargs["embed"])
+        assert "real choice" in choice_text
         for label in choice_labels:
             assert "only_name_here" not in label, f"name leaked: {label!r}"
             assert "only_value_here" not in label, f"value leaked: {label!r}"

--- a/tests/gateway/test_discord_prompt_content_siblings.py
+++ b/tests/gateway/test_discord_prompt_content_siblings.py
@@ -64,6 +64,6 @@ async def test_clarify_with_choices_mirrors_question_into_content():
     assert sent["view"] is not None
     assert "Hermes needs your input" in sent["content"]
     assert "Which environment should I deploy to?" in sent["content"]
-    assert "Pick one below" in sent["content"]
+    assert "Pick a button below" in sent["content"]
 
 

--- a/tests/gateway/test_matrix_dm_invite_recording.py
+++ b/tests/gateway/test_matrix_dm_invite_recording.py
@@ -42,12 +42,21 @@ def _make_invite_event(
     room_id="!dm_room:example.org",
     sender="@alice:example.org",
     is_direct=True,
+    state_key=None,
 ):
-    """Create a fake invite event with is_direct in content."""
+    """Create a fake membership invite event.
+
+    ``state_key`` on an ``m.room.member`` event is the *invitee*, not the
+    sender. It therefore defaults to the bot's own MXID (the account
+    ``_make_adapter`` configures), matching the shape of a real invite
+    directed at us. Tests covering the bridge fan-out case pass an explicit
+    foreign ``state_key``.
+    """
     content = SimpleNamespace(is_direct=is_direct)
     return SimpleNamespace(
         room_id=room_id,
         sender=sender,
+        state_key=state_key if state_key is not None else "@hermes:example.org",
         content=content,
     )
 
@@ -138,5 +147,142 @@ class TestRecordDMRoom:
 
         adapter._client.set_account_data.assert_not_awaited()
         assert adapter._dm_rooms.get("!room:example.org") is True
+
+
+class TestOnInviteIgnoresForeignMemberEvents:
+    @pytest.mark.asyncio
+    async def test_foreign_invite_state_key_is_ignored_silently(self, caplog):
+        adapter = _make_adapter()
+        adapter._user_id = "@neo:sppun.com"
+        adapter._client = MagicMock()
+        adapter._join_room_by_id = AsyncMock(return_value=True)
+        adapter._record_dm_room = AsyncMock()
+
+        event = _make_invite_event(
+            room_id="!shared:sppun.com",
+            sender="@discordbot:sppun.com",
+            state_key="@discord_1234:sppun.com",
+            is_direct=False,
+        )
+        await adapter._on_invite(event)
+
+        adapter._join_room_by_id.assert_not_called()
+        adapter._record_dm_room.assert_not_awaited()
+        assert "rejecting invite" not in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_invite_targeting_us_still_runs_allowlist_gate(self, caplog):
+        adapter = _make_adapter()
+        adapter._user_id = "@neo:sppun.com"
+        adapter._client = MagicMock()
+        adapter._join_room_by_id = AsyncMock(return_value=True)
+
+        event = _make_invite_event(
+            room_id="!room:sppun.com",
+            sender="@stranger:evil.example",
+            state_key="@neo:sppun.com",
+            is_direct=False,
+        )
+        await adapter._on_invite(event)
+
+        adapter._join_room_by_id.assert_not_called()
+        assert "rejecting invite" in caplog.text
+        assert "@stranger:evil.example" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_real_invite_still_joins_when_authorized(self):
+        adapter = _make_adapter()
+        adapter._user_id = "@neo:sppun.com"
+        adapter._client = MagicMock()
+        adapter._join_room_by_id = AsyncMock(return_value=True)
+        adapter._record_dm_room = AsyncMock()
+
+        event = _make_invite_event(
+            room_id="!dm:sppun.com",
+            sender="@alice:example.org",
+            state_key="@neo:sppun.com",
+            is_direct=True,
+        )
+        await adapter._on_invite(event)
+        await TestOnInviteRecordsDM._drain_invite_tasks(adapter)
+
+        adapter._join_room_by_id.assert_awaited_once_with("!dm:sppun.com")
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "state_key",
+        [
+            "@NEO:sppun.com",
+            "@Neo:SPPUN.com",
+            "  @neo:sppun.com  ",
+        ],
+    )
+    async def test_bot_targeted_invite_survives_mxid_normalization(
+        self, state_key, caplog
+    ):
+        """A genuine invite to us must not be discarded over casing/whitespace.
+
+        Homeservers have been observed returning the same bot localpart with
+        different casing at different API surfaces, which is why
+        ``_is_self_sender()`` trims and lowercases. A raw ``state_key !=
+        our_mxid`` comparison here would silently drop these invites instead
+        of running the authorization gate.
+        """
+        adapter = _make_adapter()
+        adapter._user_id = "@neo:sppun.com"
+        adapter._client = MagicMock()
+        adapter._join_room_by_id = AsyncMock(return_value=True)
+        adapter._record_dm_room = AsyncMock()
+
+        event = _make_invite_event(
+            room_id="!dm:sppun.com",
+            sender="@alice:example.org",
+            state_key=state_key,
+            is_direct=True,
+        )
+        await adapter._on_invite(event)
+        await TestOnInviteRecordsDM._drain_invite_tasks(adapter)
+
+        adapter._join_room_by_id.assert_awaited_once_with("!dm:sppun.com")
+        assert "rejecting invite" not in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_missing_own_mxid_does_not_suppress_gate(self):
+        adapter = _make_adapter()
+        adapter._user_id = ""
+        adapter._client = MagicMock()
+        adapter._join_room_by_id = AsyncMock(return_value=True)
+        adapter._record_dm_room = AsyncMock()
+
+        event = _make_invite_event(
+            room_id="!dm:sppun.com",
+            sender="@alice:example.org",
+            state_key="@neo:sppun.com",
+            is_direct=True,
+        )
+        await adapter._on_invite(event)
+        await TestOnInviteRecordsDM._drain_invite_tasks(adapter)
+
+        adapter._join_room_by_id.assert_awaited_once_with("!dm:sppun.com")
+
+    @pytest.mark.asyncio
+    async def test_missing_own_mxid_still_rejects_unauthorized_inviter(self, caplog):
+        """Unresolved mxid must fall through to the gate, not bypass it."""
+        adapter = _make_adapter()
+        adapter._user_id = ""
+        adapter._client = MagicMock()
+        adapter._join_room_by_id = AsyncMock(return_value=True)
+        adapter._record_dm_room = AsyncMock()
+
+        event = _make_invite_event(
+            room_id="!room:sppun.com",
+            sender="@stranger:evil.example",
+            state_key="@neo:sppun.com",
+            is_direct=False,
+        )
+        await adapter._on_invite(event)
+
+        adapter._join_room_by_id.assert_not_called()
+        assert "rejecting invite" in caplog.text
 
 

--- a/tests/hermes_cli/test_auth_store_read_failure.py
+++ b/tests/hermes_cli/test_auth_store_read_failure.py
@@ -6,11 +6,16 @@ roughly fifteen places, so an ``OSError`` (EMFILE under fd exhaustion, EACCES,
 EIO, a stalled mount) followed by any ``_save_auth_store`` rewrote auth.json
 with an empty provider set and destroyed every stored credential.
 
-Genuine corruption still degrades, still preserves a copy, and now only claims
-to have preserved one when the copy actually landed.
+Genuine corruption still degrades, still preserves a copy (now under a
+timestamped filename so a second corruption event can't clobber a prior
+backup), and still only claims to have preserved one when the copy actually
+landed. The resulting in-memory store is also stamped as a load-failure
+fallback so ``_save_auth_store`` refuses to ever flush it to disk while it
+is still empty.
 """
 
 import errno
+import glob
 import json
 import logging
 
@@ -54,7 +59,7 @@ def test_read_failure_raises_and_leaves_the_store_alone(store_file, monkeypatch,
         auth._load_auth_store(store_file)
 
     assert store_file.read_bytes() == before, "the store on disk was modified"
-    assert not store_file.with_suffix(".json.corrupt").exists(), (
+    assert not glob.glob(str(store_file) + ".corrupt*"), (
         "a read failure is not corruption and must not write a .corrupt sidecar"
     )
 
@@ -64,15 +69,81 @@ def test_unparseable_json_still_degrades_and_preserves_a_copy(store_file):
 
     result = auth._load_auth_store(store_file)
 
-    assert result == {"version": auth.AUTH_STORE_VERSION, "providers": {}}
-    corrupt = store_file.with_suffix(".json.corrupt")
-    assert corrupt.exists(), "genuine corruption must still be preserved"
-    assert corrupt.read_text(encoding="utf-8") == "{ not json"
+    assert result["version"] == auth.AUTH_STORE_VERSION
+    assert result["providers"] == {}
+    matches = glob.glob(str(store_file) + ".corrupt.*")
+    assert len(matches) == 1, "genuine corruption must still be preserved"
+    corrupt = matches[0]
+    assert not corrupt.endswith(".corrupt"), (
+        "backup filename must be content-addressed, not the old fixed auth.json.corrupt"
+    )
+    assert corrupt.endswith(".bak")
+    with open(corrupt, encoding="utf-8") as fh:
+        assert fh.read() == "{ not json"
+
+
+def test_repeated_loads_of_unchanged_corruption_reuse_one_backup(store_file):
+    """The corrupt file stays on disk, so this branch runs on every load.
+
+    A unique-per-attempt backup name would mint a new copy each time and
+    amplify disk usage without bound. Identical bytes must map to one backup.
+    """
+    store_file.write_text("{ not json", encoding="utf-8")
+
+    for _ in range(25):
+        auth._load_auth_store(store_file)
+
+    backups = glob.glob(str(store_file) + ".corrupt.*")
+    assert len(backups) == 1, (
+        "repeated loads of UNCHANGED corrupt bytes must reuse a single "
+        f"content-addressed backup, got {len(backups)}"
+    )
+    with open(backups[0], encoding="utf-8") as fh:
+        assert fh.read() == "{ not json"
+
+
+def test_changed_corrupt_bytes_get_their_own_backup(store_file):
+    """Deduping must not lose genuinely different corrupt content."""
+    store_file.write_text("{ not json one", encoding="utf-8")
+    auth._load_auth_store(store_file)
+    assert len(glob.glob(str(store_file) + ".corrupt.*")) == 1
+
+    store_file.write_text("{ not json two", encoding="utf-8")
+    auth._load_auth_store(store_file)
+
+    backups = sorted(glob.glob(str(store_file) + ".corrupt.*"))
+    assert len(backups) == 2, "changed corrupt bytes must be preserved separately"
+    contents = set()
+    for path in backups:
+        with open(path, encoding="utf-8") as fh:
+            contents.add(fh.read())
+    assert contents == {"{ not json one", "{ not json two"}
+
+
+def test_corrupt_backups_are_capped_by_retention(store_file, monkeypatch):
+    """A mutating-corruption loop must not accumulate backups forever."""
+    monkeypatch.setattr(auth, "_CORRUPT_AUTH_BACKUP_RETENTION", 5)
+
+    for i in range(20):
+        store_file.write_text(f"{{ not json {i}", encoding="utf-8")
+        auth._load_auth_store(store_file)
+
+    backups = glob.glob(str(store_file) + ".corrupt.*")
+    assert len(backups) <= 5, (
+        f"retention cap must bound corrupt backups, got {len(backups)}"
+    )
+    # The most recent corruption must be among what we kept.
+    contents = set()
+    for path in backups:
+        with open(path, encoding="utf-8") as fh:
+            contents.add(fh.read())
+    assert "{ not json 19" in contents
 
 
 def test_healthy_store_is_returned_unchanged(store_file):
     result = auth._load_auth_store(store_file)
     assert result["providers"]["nous"]["api_key"] == "secret"
+    assert auth._LOAD_FAILURE_MARKER not in result
 
 
 def test_log_does_not_claim_a_backup_that_was_not_written(
@@ -91,8 +162,55 @@ def test_log_does_not_claim_a_backup_that_was_not_written(
     with caplog.at_level(logging.WARNING, logger="hermes_cli.auth"):
         result = auth._load_auth_store(store_file)
 
-    assert result == {"version": auth.AUTH_STORE_VERSION, "providers": {}}
-    assert not store_file.with_suffix(".json.corrupt").exists()
+    assert result["providers"] == {}
+    assert not glob.glob(str(store_file) + ".corrupt*")
     text = caplog.text
     assert "could NOT be preserved" in text
     assert "Corrupt file preserved at" not in text
+
+
+def test_load_failure_store_cannot_be_flushed_to_disk(store_file):
+    """A load-failure fallback store must never reach _save_auth_store's write.
+
+    This is the guard that closes the actual data-loss bug: even if some
+    calling code did the old-style "load, then unconditionally save" thing
+    after a corruption-triggered fallback, the write itself must refuse.
+    """
+    store_file.write_text("{ not json", encoding="utf-8")
+    fallback_store = auth._load_auth_store(store_file)
+    assert fallback_store.get(auth._LOAD_FAILURE_MARKER) is True
+
+    with pytest.raises(auth.AuthStoreWriteGuardError):
+        auth._save_auth_store(fallback_store, target_path=store_file)
+
+    # The original (corrupt) content must remain completely untouched, and no
+    # new payload must have been written in its place.
+    with open(store_file, encoding="utf-8") as fh:
+        assert fh.read() == "{ not json"
+
+
+def test_load_failure_store_can_be_saved_once_populated(tmp_path):
+    """Once a caller adds a real provider, the guard no longer applies."""
+    store_file = tmp_path / "auth.json"
+    store_file.write_text("{ not json", encoding="utf-8")
+    fallback_store = auth._load_auth_store(store_file)
+
+    fallback_store["providers"]["nous"] = {"api_key": "new-secret"}
+    saved_path = auth._save_auth_store(fallback_store, target_path=store_file)
+
+    assert saved_path == store_file
+    on_disk = json.loads(store_file.read_text(encoding="utf-8"))
+    assert on_disk["providers"]["nous"]["api_key"] == "new-secret"
+    assert auth._LOAD_FAILURE_MARKER not in on_disk
+
+
+def test_save_of_ordinary_empty_store_is_still_allowed(tmp_path):
+    """A genuinely empty store from an explicit user action (no marker) still saves."""
+    store_file = tmp_path / "auth.json"
+    empty_store = {"version": auth.AUTH_STORE_VERSION, "providers": {}}
+
+    saved_path = auth._save_auth_store(empty_store, target_path=store_file)
+
+    assert saved_path == store_file
+    on_disk = json.loads(store_file.read_text(encoding="utf-8"))
+    assert on_disk["providers"] == {}

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -226,6 +226,18 @@ class TestDoctorToolAvailabilityOverrides:
         assert available == []
         assert unavailable == [kanban_entry]
 
+    def test_omits_intentionally_default_off_toolsets(self, monkeypatch):
+        monkeypatch.setattr(doctor, "_is_default_off_toolset", lambda item: item["name"] == "spotify")
+        spotify = {"name": "spotify", "missing_vars": ["SPOTIFY_CLIENT_ID"]}
+        required = {"name": "terminal", "missing_vars": ["SHELL"]}
+
+        available, unavailable = doctor._apply_doctor_tool_availability_overrides(
+            [], [spotify, required]
+        )
+
+        assert available == []
+        assert unavailable == [required]
+
 
 
 

--- a/tests/hermes_cli/test_model_switch_moa_preset_gating.py
+++ b/tests/hermes_cli/test_model_switch_moa_preset_gating.py
@@ -1,0 +1,117 @@
+"""``/model <name>`` must only match MoA presets the user actually configured.
+
+``DEFAULT_CONFIG["moa"]["presets"]`` ships an enabled preset literally named
+``default``, and ``switch_model`` resolved MoA preset names from
+``load_config()``, which merges DEFAULT_CONFIG. On a stock install
+``/model default`` therefore matched that shipped preset and silently switched
+the session into MoA mode, routing every later turn through the
+reference-model fan-out.
+
+``inventory.raw_config_has_enabled_moa_preset()`` already draws this line for
+the model pickers ("the DEFAULT_CONFIG preset is not a user choice"); these
+tests pin it for the switch path too.
+
+Note that reading from ``read_raw_config()`` is not sufficient on its own:
+``normalize_moa_config({})`` synthesizes a ``default`` preset for an empty
+config, so the gate is what actually does the work.
+
+The ``_switch`` helper patches both config seams so each test means the same
+thing before and after the fix: ``read_raw_config`` returns the user's raw
+config (what the fixed code reads), and ``load_config`` returns that config
+merged over the real shipped ``DEFAULT_CONFIG["moa"]`` (what the unfixed code
+reads). ``test_user_configured_preset_still_routes_into_moa`` is a regression
+guard and passes on unfixed code too; the other two demonstrate the bug and
+fail without the fix.
+"""
+
+import copy
+
+from unittest.mock import patch
+
+import pytest
+from hermes_cli.config import DEFAULT_CONFIG
+from hermes_cli.model_switch import switch_model
+
+
+_USER_RAW_CONFIG = {
+    "moa": {
+        "presets": {
+            "review": {
+                "enabled": True,
+                "reference_models": [
+                    {"provider": "openai-codex", "model": "gpt-5.5"},
+                ],
+                "aggregator": {
+                    "provider": "openrouter",
+                    "model": "anthropic/claude-opus-4.8",
+                },
+            },
+        },
+    },
+}
+
+
+@pytest.fixture(autouse=True)
+def _no_network(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.models.validate_requested_model",
+        lambda *a, **k: {
+            "accepted": True, "persist": True, "recognized": True, "message": None,
+        },
+    )
+    monkeypatch.setattr("hermes_cli.model_switch.get_model_info", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.get_model_capabilities", lambda *a, **k: None,
+    )
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", lambda *a, **k: None)
+    monkeypatch.setattr("hermes_cli.model_catalog.get_catalog", lambda *a, **k: {})
+
+
+def _merged_config(raw_config):
+    """What ``load_config()`` would return: user config over DEFAULT_CONFIG.
+
+    Only the ``moa`` section matters to the code under test. Using the real
+    shipped DEFAULT_CONFIG keeps the pre-fix behaviour honest instead of
+    hand-writing a stand-in for the ``default`` preset.
+    """
+    moa = copy.deepcopy(DEFAULT_CONFIG.get("moa") or {})
+    user_moa = (raw_config or {}).get("moa") or {}
+    presets = dict(moa.get("presets") or {})
+    presets.update(user_moa.get("presets") or {})
+    moa.update({k: v for k, v in user_moa.items() if k != "presets"})
+    moa["presets"] = presets
+    return {"moa": moa}
+
+
+def _switch(raw_input, raw_config):
+    with patch("hermes_cli.config.read_raw_config", return_value=raw_config), \
+         patch("hermes_cli.config.load_config", return_value=_merged_config(raw_config)):
+        return switch_model(
+            raw_input=raw_input,
+            current_provider="openrouter",
+            current_model="anthropic/claude-opus-4.8",
+            user_providers={},
+            custom_providers=[],
+        )
+
+
+def test_stock_config_does_not_route_model_default_into_moa():
+    """The shipped DEFAULT_CONFIG preset is not a user-selectable switch target."""
+    result = _switch("default", {})
+
+    assert result.target_provider != "moa"
+
+
+def test_user_configured_preset_still_routes_into_moa():
+    """A preset the user did write in config.yaml keeps working (pre- and post-fix)."""
+    result = _switch("review", _USER_RAW_CONFIG)
+
+    assert result.target_provider == "moa"
+    assert result.new_model == "review"
+
+
+def test_model_default_does_not_match_when_user_configured_a_different_preset():
+    """Having *some* MoA config must not resurrect the shipped "default" preset."""
+    result = _switch("default", _USER_RAW_CONFIG)
+
+    assert result.target_provider != "moa"

--- a/tests/hermes_cli/test_plugins_cmd.py
+++ b/tests/hermes_cli/test_plugins_cmd.py
@@ -52,6 +52,55 @@ class TestSanitizePluginName:
 
 
 
+    # ── allow_symlink=True ──
+
+    def test_symlink_rejected_without_allow_symlink(self, tmp_path):
+        """Default behavior (install/create path): a symlink escaping
+        plugins_dir is still rejected as 'outside the plugins directory'."""
+        outside = tmp_path.parent / "shared-plugin-checkout"
+        outside.mkdir(exist_ok=True)
+        plugins_dir = tmp_path / "plugins"
+        plugins_dir.mkdir()
+        (plugins_dir / "hermes-lcm").symlink_to(outside, target_is_directory=True)
+
+        with pytest.raises(ValueError, match="resolves outside the plugins directory"):
+            _sanitize_plugin_name("hermes-lcm", plugins_dir)
+
+    def test_symlink_allowed_with_allow_symlink(self, tmp_path):
+        """Update/read path: an operator-created symlink into a shared
+        checkout outside plugins_dir resolves to the symlink path itself
+        (not the plugins_dir-escaping realpath), matching the documented
+        cross-profile shared-plugin pattern."""
+        outside = tmp_path.parent / "shared-plugin-checkout"
+        outside.mkdir(exist_ok=True)
+        plugins_dir = tmp_path / "plugins"
+        plugins_dir.mkdir()
+        link = plugins_dir / "hermes-lcm"
+        link.symlink_to(outside, target_is_directory=True)
+
+        target = _sanitize_plugin_name("hermes-lcm", plugins_dir, allow_symlink=True)
+        assert target == link
+
+    def test_allow_symlink_still_rejects_traversal_in_name(self, tmp_path):
+        """allow_symlink must not weaken the character-level traversal guard
+        on *name* itself -- only the on-disk symlink-resolution step."""
+        plugins_dir = tmp_path / "plugins"
+        plugins_dir.mkdir()
+        with pytest.raises(ValueError, match="must not contain"):
+            _sanitize_plugin_name("../../etc/passwd", plugins_dir, allow_symlink=True)
+
+    def test_allow_symlink_does_not_affect_non_symlink_targets(self, tmp_path):
+        """A regular (non-symlink) installed plugin still goes through the
+        normal resolve()-and-contain check even with allow_symlink=True."""
+        plugins_dir = tmp_path / "plugins"
+        plugins_dir.mkdir()
+        (plugins_dir / "regular-plugin").mkdir()
+
+        target = _sanitize_plugin_name(
+            "regular-plugin", plugins_dir, allow_symlink=True
+        )
+        assert target == (plugins_dir / "regular-plugin").resolve()
+
 
 # ── _resolve_git_url ──────────────────────────────────────────────────────
 

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -372,6 +372,127 @@ class TestConfig:
         assert captured["llm_provider"] == "openai"
 
 
+class TestEmbeddedDaemonConfigChangeRestart:
+    """Regression tests: a config change detected during daemon start must
+    not kill a healthy, already-running embedded daemon from inside a live
+    request path.
+
+    Root cause: multiple Hermes profiles can share the same default
+    Hindsight embedded daemon/profile. Calling ``client._manager.stop(profile)``
+    the moment a config diff is detected can terminate in-flight
+    retain/recall calls for *other* profiles sharing that daemon, surfacing
+    as unexpected Hindsight HTTP 500s. The fix defers the restart: the
+    updated profile env is still materialized immediately (so it takes
+    effect on the daemon's next natural start), but a healthy running
+    daemon is left alone.
+
+    This is distinct from (and complementary to) upstream PR #51066, which
+    fixes a comparison bug in ``_persisted_profile_env_keys`` that made
+    ``config_changed`` spuriously always True. That PR is about *detecting*
+    config_changed correctly; these tests are about what happens once
+    config_changed is legitimately True.
+    """
+
+    def _run_start_daemon_and_wait(self, provider, tmp_path, monkeypatch, fake_client):
+        """Drive provider.initialize() in local_embedded mode, then block
+        until the background daemon-start thread it spawns has finished."""
+        import threading
+
+        monkeypatch.setattr(
+            "plugins.memory.hindsight.get_hermes_home", lambda: tmp_path
+        )
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._check_local_runtime", lambda: (True, "")
+        )
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._materialize_embedded_profile_env",
+            lambda config, **kwargs: tmp_path / "hermes.env",
+        )
+
+        config = {
+            "mode": "local_embedded",
+            "profile": "hermes",
+            "llm_provider": "openai",
+            "llm_model": "gpt-4o-mini",
+        }
+        config_path = tmp_path / "hindsight" / "config.json"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(json.dumps(config))
+
+        provider = HindsightMemoryProvider()
+        monkeypatch.setattr(provider, "_get_client", lambda: fake_client)
+
+        # Capture the daemon-start thread at construction time rather than
+        # discovering it afterwards with threading.enumerate(). The mocked
+        # daemon path can finish before initialize() returns, in which case
+        # the thread is already gone from enumerate() and a discovery-based
+        # helper fails intermittently with no product regression behind it.
+        # Wrapping the constructor makes the handle available regardless of
+        # how fast the thread runs.
+        spawned: list[threading.Thread] = []
+        real_thread_cls = threading.Thread
+
+        class _CapturingThread(real_thread_cls):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                if kwargs.get("name") == "hindsight-daemon-start":
+                    spawned.append(self)
+
+        monkeypatch.setattr(
+            "plugins.memory.hindsight.threading.Thread", _CapturingThread
+        )
+
+        provider.initialize(session_id="test-session", hermes_home=str(tmp_path), platform="cli")
+
+        assert spawned, "expected initialize() to spawn the daemon-start thread"
+        new_thread = spawned[0]
+        new_thread.join(timeout=5)
+        assert not new_thread.is_alive(), "daemon-start thread did not finish in time"
+
+        return provider
+
+    def test_healthy_running_daemon_not_stopped_on_config_change(self, tmp_path, monkeypatch):
+        """config_changed=True + a healthy running daemon => defer, don't stop."""
+        fake_manager = MagicMock()
+        fake_manager.is_running.return_value = True
+        fake_client = MagicMock()
+        fake_client._manager = fake_manager
+
+        # Force config_changed True: the saved profile env never matches
+        # the freshly-built expected env because no file exists on disk.
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._load_simple_env", lambda path: {"stale": "value"}
+        )
+
+        provider = self._run_start_daemon_and_wait(None, tmp_path, monkeypatch, fake_client)
+
+        fake_manager.is_running.assert_called_with("hermes")
+        fake_manager.stop.assert_not_called()
+        fake_client._ensure_started.assert_called_once()
+
+        log_path = tmp_path / "logs" / "hindsight-embed.log"
+        log_text = log_path.read_text(encoding="utf-8")
+        assert "restart deferred" in log_text
+        assert "Config changed, restarting daemon" not in log_text
+
+    def test_no_running_daemon_on_config_change_does_not_touch_manager_stop(self, tmp_path, monkeypatch):
+        """When no daemon is running yet, there's nothing to stop either way —
+        this just pins down that stop() is never reached along this path."""
+        fake_manager = MagicMock()
+        fake_manager.is_running.return_value = False
+        fake_client = MagicMock()
+        fake_client._manager = fake_manager
+
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._load_simple_env", lambda path: {"stale": "value"}
+        )
+
+        self._run_start_daemon_and_wait(None, tmp_path, monkeypatch, fake_client)
+
+        fake_manager.stop.assert_not_called()
+        fake_client._ensure_started.assert_called_once()
+
+
 class TestPostSetup:
     def test_setup_cancel_at_mode_picker_writes_nothing(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / "hermes-home"

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -10,6 +10,7 @@ import os
 import re
 import stat
 import sys
+import threading
 import time
 from datetime import datetime
 from pathlib import Path
@@ -19,6 +20,8 @@ from zoneinfo import ZoneInfo
 
 import pytest
 
+from agent.secret_scope import get_secret, reset_secret_scope, set_secret_scope
+import plugins.memory.hindsight as hindsight_mod
 from hermes_cli.memory_setup import _CANCELLED
 from plugins.memory.hindsight import (
     HindsightMemoryProvider,
@@ -29,6 +32,7 @@ from plugins.memory.hindsight import (
     _load_simple_env,
     _build_embedded_profile_env,
     _materialize_embedded_profile_env,
+    _scoped_thread,
     _normalize_observation_scopes,
     _normalize_retain_tags,
     _resolve_bank_id_template,
@@ -1763,6 +1767,148 @@ class TestEmbeddedProfileEnvKeyPreservation:
         env = _build_embedded_profile_env(dict(self._CONFIG))
 
         assert env["HINDSIGHT_API_LLM_API_KEY"] == ""
+
+
+class TestSecretScopePropagationIntoThreads:
+    """Regression tests: background threads must inherit the profile secret scope.
+
+    Root cause of the live key wipe. ``agent.secret_scope`` keeps the active
+    profile's credentials in a ContextVar, but a bare ``threading.Thread`` does
+    not inherit ContextVars. Every ``get_secret`` on such a thread saw no scope
+    and fell through to ``os.environ``, which under the gateway does not carry
+    profile keys -- so it resolved to "". The daemon-start thread then rebuilt
+    the profile env (O_TRUNC) and wrote that empty value over the good key.
+
+    This was deterministic, not a transient: it reproduced on every start under
+    gateway conditions (scope installed, key absent from os.environ).
+    """
+
+    def test_bare_thread_loses_scope_this_is_the_bug(self, monkeypatch):
+        """Pins the underlying stdlib behavior the fix compensates for."""
+        monkeypatch.delenv("HINDSIGHT_LLM_API_KEY", raising=False)
+        token = set_secret_scope({"HINDSIGHT_LLM_API_KEY": "sk-scoped"})
+        try:
+            seen = {}
+
+            def work():
+                seen["key"] = get_secret("HINDSIGHT_LLM_API_KEY", "")
+
+            t = threading.Thread(target=work, daemon=True)
+            t.start()
+            t.join(timeout=5)
+
+            assert get_secret("HINDSIGHT_LLM_API_KEY", "") == "sk-scoped"
+            assert seen["key"] == "", "bare thread unexpectedly saw the scope"
+        finally:
+            reset_secret_scope(token)
+
+    def test_scoped_thread_inherits_the_secret_scope(self, monkeypatch):
+        """The fix: _scoped_thread carries the profile scope across the boundary."""
+        monkeypatch.delenv("HINDSIGHT_LLM_API_KEY", raising=False)
+        token = set_secret_scope({"HINDSIGHT_LLM_API_KEY": "sk-scoped"})
+        try:
+            seen = {}
+
+            def work():
+                seen["key"] = get_secret("HINDSIGHT_LLM_API_KEY", "")
+
+            t = _scoped_thread(work, name="test-scoped")
+            t.start()
+            t.join(timeout=5)
+
+            assert seen["key"] == "sk-scoped", (
+                "scoped thread did not inherit the profile secret scope"
+            )
+        finally:
+            reset_secret_scope(token)
+
+    def test_scoped_thread_is_returned_unstarted(self):
+        """Callers assign before starting; returning a live thread would widen
+        the duplicate-writer race in _ensure_writer."""
+        t = _scoped_thread(lambda: None, name="test-unstarted")
+        assert not t.is_alive()
+        assert t.daemon
+        assert t.name == "test-unstarted"
+        t.start()
+        t.join(timeout=5)
+
+    def test_profile_env_rebuild_keeps_key_on_scoped_thread(self, tmp_path, monkeypatch):
+        """End-to-end: the exact wipe path, now on a scope-carrying thread."""
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+        monkeypatch.delenv("HINDSIGHT_LLM_API_KEY", raising=False)
+        config = {
+            "profile": "scoped",
+            "llm_provider": "openai_compatible",
+            "llm_model": "gpt-4o-mini",
+        }
+        env_path = tmp_path / ".hindsight" / "profiles" / "scoped.env"
+        env_path.parent.mkdir(parents=True, exist_ok=True)
+
+        token = set_secret_scope({"HINDSIGHT_LLM_API_KEY": "sk-live-profile-key"})
+        try:
+            built = {}
+
+            def work():
+                _materialize_embedded_profile_env(dict(config))
+                built["key"] = _load_simple_env(env_path).get("HINDSIGHT_API_LLM_API_KEY")
+
+            t = _scoped_thread(work, name="test-materialize")
+            t.start()
+            t.join(timeout=10)
+        finally:
+            reset_secret_scope(token)
+
+        assert built["key"] == "sk-live-profile-key", (
+            "the profile env rebuild lost the key on a background thread"
+        )
+
+    def test_shared_loop_thread_does_not_leak_scope_between_profiles(self, monkeypatch):
+        """The process-global loop is shared by every profile, so the profile
+        that happens to start it must not pin its scope onto later work.
+
+        Note asyncio copies the *submitting* context into each Handle, so work
+        submitted from a scoped caller correctly sees that caller's scope. The
+        property under test is the leak direction: profile A starting the loop
+        must not bleed A's credentials into profile B's later submissions.
+        """
+        monkeypatch.setattr(hindsight_mod, "_loop", None)
+        monkeypatch.setattr(hindsight_mod, "_loop_thread", None)
+        monkeypatch.delenv("HINDSIGHT_LLM_API_KEY", raising=False)
+
+        loop = None
+        seen = {}
+        try:
+            # Profile A starts the shared loop.
+            token_a = set_secret_scope({"HINDSIGHT_LLM_API_KEY": "sk-profile-A"})
+            try:
+                loop = hindsight_mod._get_loop()
+            finally:
+                reset_secret_scope(token_a)
+
+            # Profile B later submits work onto that same loop.
+            token_b = set_secret_scope({"HINDSIGHT_LLM_API_KEY": "sk-profile-B"})
+            try:
+                loop.call_soon_threadsafe(
+                    lambda: seen.setdefault(
+                        "key", get_secret("HINDSIGHT_LLM_API_KEY", "")
+                    )
+                )
+                for _ in range(100):
+                    if "key" in seen:
+                        break
+                    time.sleep(0.02)
+            finally:
+                reset_secret_scope(token_b)
+        finally:
+            if loop is not None:
+                loop.call_soon_threadsafe(loop.stop)
+
+        assert "key" in seen, "loop callback never ran"
+        assert seen["key"] != "sk-profile-A", (
+            "the shared loop thread leaked the starting profile's secret scope "
+            "into another profile's work"
+        )
+        assert seen["key"] == "sk-profile-B"
 
 
 class TestPostSetupEnvEncoding:

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -28,6 +28,7 @@ from plugins.memory.hindsight import (
     _load_config,
     _load_simple_env,
     _build_embedded_profile_env,
+    _materialize_embedded_profile_env,
     _normalize_observation_scopes,
     _normalize_retain_tags,
     _resolve_bank_id_template,
@@ -1664,9 +1665,104 @@ class TestLoadSimpleEnv:
         """A Notepad-edited .env carries a BOM; the first key must still parse
         instead of becoming '\ufeffHINDSIGHT_LLM_API_KEY'."""
         env_path = tmp_path / ".env"
-        env_path.write_bytes("﻿HINDSIGHT_LLM_API_KEY=sk-test\n".encode("utf-8"))
+        env_path.write_bytes("\ufeffHINDSIGHT_LLM_API_KEY=sk-test\n".encode("utf-8"))
         values = _load_simple_env(env_path)
         assert values.get("HINDSIGHT_LLM_API_KEY") == "sk-test"
+
+
+class TestEmbeddedProfileEnvKeyPreservation:
+    """Regression tests: a transient empty secret lookup must never blank the
+    stored embedded-daemon LLM API key.
+
+    ``_build_embedded_profile_env`` wrote ``str(current_key or "")`` to the
+    profile env, and the daemon-start path rewrites that file on any diff — so
+    an empty lookup both destroyed the stored key and read as config drift.
+    Observed live: hermes.env came back with an empty HINDSIGHT_API_LLM_API_KEY
+    and Hindsight stopped answering.
+    """
+
+    _CONFIG = {
+        "profile": "keypres",
+        "llm_provider": "openai_compatible",
+        "llm_model": "gpt-4o-mini",
+    }
+
+    @pytest.fixture
+    def profile_home(self, tmp_path, monkeypatch):
+        """Point ~/.hindsight/profiles at a temp dir and seed a good key."""
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+        env_path = tmp_path / ".hindsight" / "profiles" / "keypres.env"
+        env_path.parent.mkdir(parents=True, exist_ok=True)
+        return env_path
+
+    def _seed(self, env_path, key="sk-good-existing-key"):
+        env_path.write_text(
+            "HINDSIGHT_API_LLM_PROVIDER=openai\n"
+            f"HINDSIGHT_API_LLM_API_KEY={key}\n"
+            "HINDSIGHT_API_LLM_MODEL=gpt-4o-mini\n"
+            "HINDSIGHT_API_LOG_LEVEL=info\n",
+            encoding="utf-8",
+        )
+
+    def test_transient_empty_secret_preserves_stored_key(self, profile_home, monkeypatch):
+        """The exact live failure: get_secret returns "" but a good key is on disk."""
+        self._seed(profile_home)
+        monkeypatch.setattr("plugins.memory.hindsight.get_secret", lambda *a, **kw: "")
+
+        env = _build_embedded_profile_env(dict(self._CONFIG))
+
+        assert env["HINDSIGHT_API_LLM_API_KEY"] == "sk-good-existing-key", (
+            "a transient empty secret lookup blanked the stored API key"
+        )
+
+    def test_materialize_does_not_blank_file_on_transient_miss(self, profile_home, monkeypatch):
+        """End-to-end: the file on disk must still hold the key after a rewrite."""
+        self._seed(profile_home)
+        monkeypatch.setattr("plugins.memory.hindsight.get_secret", lambda *a, **kw: "")
+
+        _materialize_embedded_profile_env(dict(self._CONFIG))
+
+        assert _load_simple_env(profile_home)["HINDSIGHT_API_LLM_API_KEY"] == (
+            "sk-good-existing-key"
+        )
+
+    def test_transient_miss_is_not_treated_as_config_drift(self, profile_home, monkeypatch):
+        """Falling back to the saved key keeps the drift check honest: a failed
+        lookup must not read as a config change and trigger a daemon restart."""
+        self._seed(profile_home)
+        monkeypatch.setattr("plugins.memory.hindsight.get_secret", lambda *a, **kw: "")
+
+        saved = _load_simple_env(profile_home)
+        expected = _build_embedded_profile_env(dict(self._CONFIG))
+
+        assert saved == expected, "a transient secret miss looked like config drift"
+
+    def test_explicit_key_still_wins(self, profile_home, monkeypatch):
+        """A real rotation must still overwrite the stored value."""
+        self._seed(profile_home)
+        monkeypatch.setattr("plugins.memory.hindsight.get_secret", lambda *a, **kw: "")
+
+        env = _build_embedded_profile_env(dict(self._CONFIG), llm_api_key="sk-rotated")
+
+        assert env["HINDSIGHT_API_LLM_API_KEY"] == "sk-rotated"
+
+    def test_config_key_still_wins_over_stored(self, profile_home, monkeypatch):
+        """A key present in config takes precedence over the on-disk fallback."""
+        self._seed(profile_home)
+        monkeypatch.setattr("plugins.memory.hindsight.get_secret", lambda *a, **kw: "")
+
+        config = dict(self._CONFIG, llm_api_key="sk-from-config")
+        env = _build_embedded_profile_env(config)
+
+        assert env["HINDSIGHT_API_LLM_API_KEY"] == "sk-from-config"
+
+    def test_no_stored_key_and_no_secret_yields_empty(self, profile_home, monkeypatch):
+        """First-run: nothing on disk, nothing resolvable => empty, not a crash."""
+        monkeypatch.setattr("plugins.memory.hindsight.get_secret", lambda *a, **kw: "")
+
+        env = _build_embedded_profile_env(dict(self._CONFIG))
+
+        assert env["HINDSIGHT_API_LLM_API_KEY"] == ""
 
 
 class TestPostSetupEnvEncoding:

--- a/tests/test_compression_watermark_commit.py
+++ b/tests/test_compression_watermark_commit.py
@@ -60,6 +60,43 @@ class TestWatermarkCommit:
         ], "tail must follow the summary, in arrival order"
         assert count == 4
 
+    def test_tail_already_in_compacted_handoff_is_not_cloned_twice(
+        self, db: SessionDB
+    ) -> None:
+        _seed(db)
+        watermark = db.get_active_message_watermark("sess1")
+        db.append_message("sess1", role="user", content="mid-compression steer")
+        late_arrival = db.get_messages_as_conversation("sess1")[-1]
+        assert late_arrival.get("_db_persisted") is True
+        compacted = [*SUMMARY, late_arrival]
+
+        count = db.archive_and_compact("sess1", compacted, watermark=watermark)
+
+        contents = [row["content"] for row in db.get_messages("sess1")]
+        assert contents == [
+            "[CONTEXT COMPACTION] summary of turns 0-5",
+            "Continuing from the summary.",
+            "mid-compression steer",
+        ]
+        assert count == 3
+
+    def test_generated_handoff_replaces_same_concurrent_scaffold(
+        self, db: SessionDB
+    ) -> None:
+        _seed(db)
+        watermark = db.get_active_message_watermark("sess1")
+        db.append_message(
+            "sess1",
+            role="user",
+            content=SUMMARY[0]["content"],
+        )
+
+        count = db.archive_and_compact("sess1", SUMMARY, watermark=watermark)
+
+        contents = [row["content"] for row in db.get_messages("sess1")]
+        assert contents.count(SUMMARY[0]["content"]) == 1
+        assert count == 2
+
     def test_tail_clone_preserves_every_column(self, db: SessionDB) -> None:
         """The pure-SQL clone must carry sidecar fields byte-exact."""
         _seed(db, 2)

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -713,6 +713,86 @@ class TestMatrixMediaLiveAdapterReuse:
             ("disconnect",),
         ]
 
+    def test_live_adapter_present_but_wrong_loop_falls_back_to_ephemeral(self, tmp_path):
+        """Regression test for the cron standalone-delivery-fallback crash
+        (2026-08-02): when the cron scheduler's live-adapter attempt itself
+        fails/times out, it retries via _send_to_platform inside a *fresh*
+        asyncio.run() loop. If that fresh loop then reused the gateway's
+        live Matrix adapter (whose aiohttp session and asyncio.wait_for
+        timeout context are bound to the gateway's own loop), the send
+        raised "Timeout context manager should be used inside a task".
+
+        A runner whose _gateway_loop differs from the loop we're actually
+        running on must be treated as unusable, falling through to the
+        ephemeral (loop-agnostic) adapter instead of reusing the live one.
+        """
+        doc_path = tmp_path / "report.pdf"
+        doc_path.write_bytes(b"%PDF-1.4")
+
+        calls = []
+
+        class LiveAdapter:
+            async def send(self, chat_id, message, metadata=None):
+                calls.append(("live_send", chat_id, message))
+                return SimpleNamespace(success=True, message_id="$live")
+
+        class EphemeralAdapter:
+            def __init__(self, _config):
+                pass
+
+            async def connect(self):
+                calls.append(("connect",))
+                return True
+
+            async def send(self, chat_id, message, metadata=None):
+                calls.append(("ephemeral_send", chat_id, message))
+                return SimpleNamespace(success=True, message_id="$ephemeral")
+
+            async def send_document(self, chat_id, path, metadata=None):
+                calls.append(("send_document", chat_id, path))
+                return SimpleNamespace(success=True, message_id="$doc")
+
+            async def disconnect(self):
+                calls.append(("disconnect",))
+
+        async def _run():
+            # Simulate the gateway's own loop by grabbing a real loop object
+            # that is NOT the one this test coroutine executes on.
+            other_loop = asyncio.new_event_loop()
+            try:
+                live_adapter = LiveAdapter()
+                fake_runner = SimpleNamespace(
+                    adapters={Platform.MATRIX: live_adapter},
+                    _gateway_loop=other_loop,
+                )
+                fake_module = SimpleNamespace(MatrixAdapter=EphemeralAdapter)
+                with patch(
+                    "gateway.run._gateway_runner_ref", return_value=fake_runner
+                ), patch.dict(
+                    sys.modules, {"plugins.platforms.matrix.adapter": fake_module}
+                ):
+                    return await _send_matrix_via_adapter(
+                        SimpleNamespace(enabled=True, token="tok", extra={}),
+                        "!room:example.com",
+                        "report attached",
+                        media_files=[(str(doc_path), False)],
+                    )
+            finally:
+                other_loop.close()
+
+        result = asyncio.run(_run())
+
+        assert result["success"] is True
+        # The live adapter must NOT be used across loops — only the
+        # loop-agnostic ephemeral adapter path should have run.
+        assert ("live_send", "!room:example.com", "report attached") not in calls
+        assert calls == [
+            ("connect",),
+            ("ephemeral_send", "!room:example.com", "report attached"),
+            ("send_document", "!room:example.com", str(doc_path)),
+            ("disconnect",),
+        ]
+
 # ---------------------------------------------------------------------------
 # HTML auto-detection in Telegram send
 # ---------------------------------------------------------------------------

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -191,7 +191,7 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
 
     # ─── Memory providers ──────────────────────────────────────────────────
     "memory.honcho": ("honcho-ai==2.2.0",),
-    "memory.hindsight": ("hindsight-client==0.6.1",),
+    "memory.hindsight": ("hindsight-client==0.9.2",),
     # supermemory + mem0 are opt-in cloud memory providers with their own
     # SDKs. On the published Docker image the agent venv is sealed
     # (HERMES_DISABLE_LAZY_INSTALLS=1) and lazy installs are redirected to the

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1996,8 +1996,29 @@ async def _send_matrix_via_adapter(pconfig, chat_id, message, media_files=None, 
         runner = None
     if runner is not None:
         try:
-            from gateway.config import Platform
-            live_adapter = runner.adapters.get(Platform.MATRIX)
+            # The live adapter's aiohttp session (and asyncio.wait_for/timeout
+            # context) is bound to the gateway's own event loop
+            # (runner._gateway_loop). Cron's standalone-delivery fallback
+            # runs this coroutine inside a *fresh* loop via asyncio.run()
+            # whenever the live-adapter delivery attempt itself failed or
+            # timed out (see cron/scheduler.py around line 2022) — reusing
+            # the gateway-loop-bound adapter from that fresh loop raises
+            # "Timeout context manager should be used inside a task"
+            # because asyncio's timeout machinery is loop-affine. Only take
+            # the fast path when we're actually executing on the gateway's
+            # own loop; otherwise fall through to the ephemeral adapter,
+            # which is safe from any thread/loop.
+            current_loop = asyncio.get_running_loop()
+            gateway_loop = getattr(runner, "_gateway_loop", None)
+            if gateway_loop is not None and current_loop is not gateway_loop:
+                logger.debug(
+                    "Matrix: live gateway adapter found but current loop != "
+                    "gateway loop; using ephemeral adapter to avoid a "
+                    "cross-loop timeout-context error"
+                )
+            else:
+                from gateway.config import Platform
+                live_adapter = runner.adapters.get(Platform.MATRIX)
         except Exception:
             logger.warning(
                 "Matrix: live gateway adapter lookup failed; falling back to an "

--- a/uv.lock
+++ b/uv.lock
@@ -13,17 +13,18 @@ exclude-newer-span = "P14D"
 
 [options.exclude-newer-package]
 setuptools = false
-h2 = false
+huggingface-hub = false
 vercel = false
 pillow = false
 unpaddedbase64 = false
+h2 = false
 defusedxml = false
 aiohttp = false
 cryptography = false
-mcp = false
+hindsight-client = false
 python-olm = false
+mcp = false
 nemo-relay = false
-huggingface-hub = false
 
 [manifest]
 overrides = [
@@ -1869,7 +1870,7 @@ requires-dist = [
     { name = "hermes-agent", extras = ["web"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["web"], marker = "extra == 'termux-all'" },
     { name = "hermes-agent", extras = ["youtube"], marker = "extra == 'all'" },
-    { name = "hindsight-client", marker = "extra == 'hindsight'", specifier = "==0.6.1" },
+    { name = "hindsight-client", marker = "extra == 'hindsight'", specifier = "==0.9.2" },
     { name = "honcho-ai", marker = "extra == 'honcho'", specifier = "==2.2.0" },
     { name = "httplib2", marker = "extra == 'google'", specifier = "==0.32.0" },
     { name = "httpx", extras = ["socks"], specifier = "==0.28.1" },
@@ -1968,7 +1969,7 @@ wheels = [
 
 [[package]]
 name = "hindsight-client"
-version = "0.6.1"
+version = "0.9.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1978,9 +1979,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/33/26/8b8efa4be21fc3ba12ade3b1353d87f9837ec0d3ec2607e8adbf85bc9c63/hindsight_client-0.6.1.tar.gz", hash = "sha256:314d0bb9e13622e15586ba1586a799726d405b27bc20d78872474b5d6d96cd51", size = 99833, upload-time = "2026-05-08T13:01:23.537Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/21/18dd524c25d440466fa9377e4754b336cde0cc94bb566619913880198aa3/hindsight_client-0.9.2.tar.gz", hash = "sha256:bf6877da5d423395a4b0ac8ac8fc1836f5f5da271613a76e38903437af136ea1", size = 152096, upload-time = "2026-08-25T10:20:30.731Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/24/4f/a1d0bc33ef933ecc52e76dc1514163594d25836a5d303c256a61bb61445d/hindsight_client-0.6.1-py3-none-any.whl", hash = "sha256:9fdda176ab50f7cec8d7339c6608c148f0cd9ad7e65d9d76192f2db730bc330a", size = 249379, upload-time = "2026-05-08T13:01:22.035Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/5a/88ef406d96902a8ae6b6ba09afe8ac06bb4d3460eac1a7b741735ba41475/hindsight_client-0.9.2-py3-none-any.whl", hash = "sha256:31d26d116a07da5203bc913c5ed017de95d875edd5e295afad3c05373665ff6b", size = 358546, upload-time = "2026-08-25T10:20:29.257Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- remove stale todo snapshot blocks across the entire compressed transcript before reinjection
- preserve human-authored text from messages that previously carried a merged snapshot
- keep exactly one current todo snapshot after repeated same-turn compression boundaries
- avoid cloning post-watermark rows already represented by the compacted handoff
- use occurrence-aware exact identities, with an untimed fallback for newly generated compaction scaffolding

## Root causes

Two independent in-place compaction paths can produce simultaneously active duplicates:

1. Todo refresh only inspected the trailing user message. Later assistant/tool rows can bury a standalone snapshot in the retained tail, so every subsequent compression appends another snapshot.
2. `archive_and_compact()` always cloned every post-watermark row, even when the compressor handoff already contained that logical row. That inserts the handoff copy and clones the durable source again.

## Regression coverage

- buried standalone todo snapshot followed by tool output
- timestamped durable tail already present in the compacted handoff
- untimed generated scaffold replacing the same concurrent durable scaffold
- existing watermark clone and column-preservation contracts

## Verification

- Todo RED: focused regression failed with `assert 2 == 1`
- Watermark RED: both overlap regressions failed with duplicated contents
- GREEN: `51 passed` across todo-retention, compression-rotation, and watermark-commit suites
- An earlier broader related run reached 91% before external interruption, with no emitted failures.