### PR TITLE
fix(mcp): correct inverted stdio child liveness check

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -471,6 +471,52 @@ class TestCheckFunction:
 
 
 # ---------------------------------------------------------------------------
+# Stdio child liveness fast-fail
+# ---------------------------------------------------------------------------
+
+class TestStdioChildrenDead:
+    """Regression coverage for the inverted liveness check (#786f37071a).
+
+    _stdio_children_dead() must return False while any tracked stdio child
+    is alive; it must only return True when every tracked child has exited.
+    The Aug 2026 regression flipped the alive-branch to return True, which
+    made every tool call to a healthy stdio MCP server fail fast with
+    "MCP stdio subprocess has exited".
+    """
+
+    def test_alive_child_returns_false(self):
+        from tools.mcp_tool import MCPServerTask
+
+        server = MCPServerTask("test_server")
+        server._stdio_child_pids = {1234}
+        with patch("psutil.pid_exists", return_value=True):
+            assert server._stdio_children_dead() is False
+
+    def test_dead_child_returns_true(self):
+        from tools.mcp_tool import MCPServerTask
+
+        server = MCPServerTask("test_server")
+        server._stdio_child_pids = {1234}
+        with patch("psutil.pid_exists", return_value=False):
+            assert server._stdio_children_dead() is True
+
+    def test_mixed_alive_and_dead_returns_false(self):
+        from tools.mcp_tool import MCPServerTask
+
+        server = MCPServerTask("test_server")
+        server._stdio_child_pids = {1234, 5678}
+        with patch("psutil.pid_exists", side_effect=lambda pid: pid == 1234):
+            assert server._stdio_children_dead() is False
+
+    def test_no_tracked_pids_returns_false(self):
+        from tools.mcp_tool import MCPServerTask
+
+        server = MCPServerTask("test_server")
+        server._stdio_child_pids = set()
+        assert server._stdio_children_dead() is False
+
+
+# ---------------------------------------------------------------------------
 # MCP loop runner
 # ---------------------------------------------------------------------------
 

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -3001,7 +3001,6 @@ class MCPServerTask:
 
             if not psutil.pid_exists(pid):
                 continue  # this one is dead
-            return True  # alive (signal permission irrelevant for liveness)
             return False  # at least one child alive
         return True
 


### PR DESCRIPTION
## Bug Description

Every tool call to a healthy stdio MCP server fails fast with:

```
MCP call failed: TimeoutError: MCP stdio subprocess for 'donsetch' has exited; failing the call fast instead of waiting 180s
```

even though the server subprocess is running and healthy. Reproduced with two independent stdio MCP servers (donsetch, bladebro) on Windows; `hermes mcp test` and direct CLI invocation of the same binaries both work fine.

## Root Cause

`MCPServerTask._stdio_children_dead()` in `tools/mcp_tool.py` has an **inverted liveness check**. Commit `786f37071a` ("fix(mcp): psutil.pid_exists for stdio children liveness — Windows footgun") changed the alive-branch:

```python
# Before (correct):
            return False  # at least one child alive
        return True

# After (regression):
            return True  # alive (signal permission irrelevant for liveness)
            return False  # at least one child alive   ← unreachable
        return True
```

The function now returns `True` ("all children dead") whenever any tracked child is alive, so the fast-fail path (#81995) trips on every call to a healthy server. The `return False` line became dead code.

## Fix

Restore the original semantics — return `False` as soon as any tracked child is alive; only return `True` when every tracked child has exited:

```python
            if not psutil.pid_exists(pid):
                continue  # this one is dead
            return False  # at least one child alive
        return True
```

## How to Verify

1. Configure any stdio MCP server (e.g. `donsetch` or `bladebro`).
2. Call one of its tools from a Hermes session.
3. Before the fix: fails immediately with "MCP stdio subprocess has exited" despite the process being alive.
4. After the fix: the tool call succeeds and returns real results.

## Test Plan

- [x] Added regression tests: `TestStdioChildrenDead` covers alive, dead, mixed, and empty pid sets — all 4 pass with the fix
- [x] Verified the tests fail against the pre-fix code (alive + mixed cases fail with `assert True is False`)
- [x] Full `tests/tools/test_mcp_tool.py` suite: 98 passed, 5 pre-existing environment failures (TestBuildSafeEnv, TestRedirectHeaderStripper — confirmed failing on base commit too, unrelated to this change)
- [x] Manual verification: donsetch `web_search` and bladebro `act` both return real results through the MCP tool path after the fix

## Risk Assessment

Low — one-line logic correction restoring the pre-regression behavior, plus tests. The only behavioral change is that healthy stdio servers no longer get fast-failed; genuinely dead servers still fail fast (covered by `test_dead_child_returns_true`).
