### PR TITLE
fix(vision): keep auxiliary runtime coherent after restore

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1801,6 +1801,12 @@ def restore_primary_runtime(agent) -> bool:
         from agent.chat_completion_helpers import rewrite_prompt_model_identity
         rewrite_prompt_model_identity(agent, rt["model"], rt["provider"])
 
+        # Auxiliary work may run immediately after this helper returns, outside
+        # the shared turn prologue. Replace any fallback-era or partial binding
+        # with the same coherent runtime snapshot restored above.
+        from agent.auxiliary_client import set_runtime_main_from_agent
+        set_runtime_main_from_agent(agent)
+
         logger.info(
             "Primary runtime restored for new turn: %s (%s)",
             agent.model, agent.provider,

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3586,6 +3586,32 @@ def set_runtime_main(
     return token
 
 
+def set_runtime_main_from_agent(
+    agent: Any,
+    *,
+    cache_scope: Optional[str] = None,
+) -> contextvars.Token:
+    """Publish one coherent auxiliary-runtime snapshot from a live agent."""
+    if cache_scope is None:
+        current = _RUNTIME_MAIN_CONTEXT.get()
+        cache_scope = (
+            str(current.get("cache_scope") or "")
+            if isinstance(current, dict)
+            else ""
+        )
+    return set_runtime_main(
+        getattr(agent, "provider", "") or "",
+        getattr(agent, "model", "") or "",
+        requested_provider=getattr(agent, "requested_provider", "") or "",
+        base_url=getattr(agent, "base_url", "") or "",
+        api_key=getattr(agent, "api_key", "") or "",
+        api_mode=getattr(agent, "api_mode", "") or "",
+        auth_mode=getattr(agent, "auth_mode", "") or "",
+        session_id=getattr(agent, "session_id", "") or "",
+        cache_scope=cache_scope,
+    )
+
+
 def reset_runtime_main(token: contextvars.Token) -> None:
     """Restore the runtime binding that preceded one scoped turn."""
     if token is None:
@@ -4076,6 +4102,15 @@ def _normalize_main_runtime(main_runtime: Optional[Dict[str, Any]]) -> Dict[str,
         if isinstance(identity, str):
             normalized[identity_field] = identity.lower()
     return normalized
+
+
+def _resolve_main_identity(runtime: Dict[str, Any]) -> Tuple[str, str]:
+    """Resolve provider/model atomically from runtime or persistent config."""
+    runtime_provider = str(runtime.get("provider") or "")
+    runtime_model = str(runtime.get("model") or "")
+    if runtime_provider and runtime_model:
+        return runtime_provider, runtime_model
+    return str(_read_main_provider() or ""), str(_read_main_model() or "")
 
 
 def _get_provider_chain() -> List[tuple]:
@@ -5989,7 +6024,6 @@ def _resolve_auto_route(
     auxiliary_is_nous = False  # Reset — _try_nous() will set True if it wins
     runtime = _normalize_main_runtime(main_runtime)
     runtime_provider = runtime.get("provider", "")
-    runtime_model = str(runtime.get("model") or "")
     runtime_base_url = str(runtime.get("base_url") or "")
     runtime_api_key = runtime.get("api_key", "")
     runtime_api_mode = str(runtime.get("api_mode") or "")
@@ -6020,8 +6054,7 @@ def _resolve_auto_route(
     # on aggregators (OpenRouter, Nous) who previously got routed to a
     # cheap provider-side default.  Explicit per-task overrides set via
     # config.yaml (auxiliary.<task>.provider) still win over this.
-    main_provider = str(runtime_provider or _read_main_provider() or "")
-    main_model = str(runtime_model or _read_main_model() or "")
+    main_provider, main_model = _resolve_main_identity(runtime)
 
     # Latency-critical tasks can explicitly prefer the provider's registered
     # fast model over the main chat model. Titling is the only eligible task:
@@ -7415,8 +7448,7 @@ def resolve_vision_provider_client(
         #                   live from the catalog — tried when
         #                   DEEPINFRA_API_KEY is set)
         #   5. Stop
-        main_provider = str(runtime.get("provider") or _read_main_provider())
-        main_model = str(runtime.get("model") or _read_main_model())
+        main_provider, main_model = _resolve_main_identity(runtime)
         if main_provider.strip().lower() == "moa":
             # MoA virtual provider: main_model is a preset NAME, and every
             # capability probe below (_PROVIDERS_WITHOUT_VISION,

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -550,7 +550,7 @@ def build_turn_context(
     # Tell auxiliary_client what the live main provider/model are for this turn
     # after primary restoration has settled the runtime.
     try:
-        from agent.auxiliary_client import set_runtime_main
+        from agent.auxiliary_client import set_runtime_main_from_agent
         from agent.prompt_cache_scope import resolve_prompt_cache_scope_safe
         # Rotation-stable prompt-cache scope. Memoized per segment on the
         # agent, so this is a DB walk at most once per segment — except a
@@ -562,17 +562,7 @@ def build_turn_context(
         # never-raising variant OUTSIDE the argument list, so a resolution
         # failure can only lose the scope — never the whole runtime binding.
         _cache_scope = resolve_prompt_cache_scope_safe(agent) or ""
-        set_runtime_main(
-            getattr(agent, "provider", "") or "",
-            getattr(agent, "model", "") or "",
-            requested_provider=getattr(agent, "requested_provider", "") or "",
-            base_url=getattr(agent, "base_url", "") or "",
-            api_key=getattr(agent, "api_key", "") or "",
-            api_mode=getattr(agent, "api_mode", "") or "",
-            auth_mode=getattr(agent, "auth_mode", "") or "",
-            session_id=getattr(agent, "session_id", "") or "",
-            cache_scope=_cache_scope,
-        )
+        set_runtime_main_from_agent(agent, cache_scope=_cache_scope)
     except Exception:
         pass
 

--- a/tests/agent/test_auxiliary_main_first.py
+++ b/tests/agent/test_auxiliary_main_first.py
@@ -51,6 +51,30 @@ class TestResolveAutoMainFirst:
         assert model == main_model
         assert mock_resolve.call_args.args[:2] == ("opencode-zen", main_model)
 
+    def test_partial_runtime_does_not_mix_provider_with_config_model(self):
+        """Provider and model fall back as one identity, never independently."""
+        resolved_client = MagicMock()
+
+        with (
+            patch("agent.auxiliary_client._read_main_provider", return_value="zai"),
+            patch("agent.auxiliary_client._read_main_model", return_value="glm-5"),
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(resolved_client, "glm-5"),
+            ) as resolve_client,
+            patch("agent.auxiliary_client._is_provider_unhealthy", return_value=False),
+        ):
+            from agent.auxiliary_client import _resolve_auto
+
+            client, model = _resolve_auto(
+                main_runtime={"provider": "anthropic", "model": ""},
+                task="title_generation",
+            )
+
+        assert client is resolved_client
+        assert model == "glm-5"
+        assert resolve_client.call_args.args[:2] == ("zai", "glm-5")
+
     def test_title_generation_can_opt_into_provider_fast_model(self):
         """The latency optimization remains available as an explicit opt-in."""
         fast_model = "gemini-3-flash"

--- a/tests/run_agent/test_primary_runtime_restore.py
+++ b/tests/run_agent/test_primary_runtime_restore.py
@@ -155,6 +155,70 @@ class TestRestorePrimaryRuntime:
         assert agent.model == original_model
         assert agent.provider == original_provider
 
+    def test_restore_rebinds_auxiliary_vision_to_coherent_primary_runtime(self):
+        """A restored primary must replace a partial stale auxiliary runtime."""
+        from agent import auxiliary_client as aux
+
+        agent = _make_agent(
+            provider="zai",
+            base_url="https://api.z.ai/api/paas/v4",
+            fallback_model={"provider": "anthropic", "model": "claude-opus-4-6"},
+        )
+        agent.model = "glm-5"
+        agent._primary_runtime.update(
+            provider="zai",
+            model="glm-5",
+            base_url="https://api.z.ai/api/paas/v4",
+        )
+
+        fallback_client = _mock_resolve(
+            base_url="https://api.anthropic.com",
+            api_key="fallback-key-1234",
+        )
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(fallback_client, "claude-opus-4-6"),
+        ):
+            assert agent._try_activate_fallback() is True
+
+        # Reproduce a partial stale snapshot: provider survived from fallback,
+        # while the model is reconstructed from the restored primary config.
+        aux.set_runtime_main("anthropic", "", cache_scope="root-session")
+        resolved_client = MagicMock()
+
+        def vision_default(provider):
+            return "glm-4.6v" if provider == "zai" else None
+
+        try:
+            with patch("run_agent.OpenAI", return_value=MagicMock()):
+                assert agent._restore_primary_runtime() is True
+
+            with (
+                patch("agent.auxiliary_client._read_main_provider", return_value="zai"),
+                patch("agent.auxiliary_client._read_main_model", return_value="glm-5"),
+                patch(
+                    "agent.auxiliary_client._resolve_provider_vision_default",
+                    side_effect=vision_default,
+                ),
+                patch(
+                    "agent.auxiliary_client._resolve_task_provider_model",
+                    return_value=("auto", None, None, None, None),
+                ),
+                patch(
+                    "agent.auxiliary_client.resolve_provider_client",
+                    return_value=(resolved_client, "glm-4.6v"),
+                ) as resolve_client,
+            ):
+                provider, client, model = aux.resolve_vision_provider_client()
+                cache_scope = aux._runtime_main_value("cache_scope")
+        finally:
+            aux.clear_runtime_main()
+
+        assert (provider, model) == ("zai", "glm-4.6v")
+        assert client is resolved_client
+        assert cache_scope == "root-session"
+        assert resolve_client.call_args.args[:2] == ("zai", "glm-4.6v")
+
     def test_emits_user_visible_primary_restore_notice(self):
         agent = _make_agent(
             fallback_model={"provider": "openrouter", "model": "anthropic/claude-sonnet-4"},


### PR DESCRIPTION
## Summary

- republish the restored primary runtime to auxiliary consumers
- resolve provider and model as an atomic identity
- preserve prompt-cache scope and provider-specific vision defaults
- add regressions for fallback restoration and partial runtime snapshots

## Verification

- 46 primary-runtime restoration tests pass
- 94 auxiliary routing, cache and vision tests pass
- focused vision tests pass
- Ruff and diff checks pass

Closes #96924