### PR TITLE
feat(tts): make the streaming first-sentence threshold configurable

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1570,6 +1570,14 @@ stt:
 #     # live result.
 #     model: ""
 #     voice: "default"
+#   streaming:
+#     # First-sentence threshold for the streaming sentence chunker, in
+#     # characters. Clauses shorter than this buffer and ride with the
+#     # next sentence. The default 20 suits English; for CJK text 20
+#     # characters is one-to-two full clauses, so short openers always
+#     # buffer and the first audio is delayed by ~one LLM sentence —
+#     # lower it (e.g. 6) to speak short first sentences immediately.
+#     min_len: 20
 
 # "Hey Hermes" hands-free wake word (off by default; toggle with /wake).
 # Full engine/provider options inherit from DEFAULT_CONFIG in

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1571,14 +1571,17 @@ stt:
 #     model: ""
 #     voice: "default"
 #   streaming:
-#     # First-sentence threshold for the streaming sentence chunker, in
-#     # characters. Clauses shorter than this buffer and ride with the
-#     # next sentence. The default 20 suits English; for CJK text 20
-#     # characters is one-to-two full clauses, so short openers always
-#     # buffer and the first audio is delayed by ~one LLM sentence —
-#     # lower it (e.g. 6) to speak short first sentences immediately.
-#     # (Pure-CJK replies also need full-width boundary splitting, #78477.)
+#     # Whole-response minimum, in characters. Shorter clauses wait for
+#     # the next sentence. Applies to gateway, CLI speaker and speak-stream.
 #     min_len: 20
+#     # Optional positive integer; null inherits min_len. Set to 1 to release
+#     # a complete short opener such as "Yes." at its sentence boundary.
+#     # Only the first nonempty emission uses this override; later sentences
+#     # return to min_len. An idle/end-of-text flush counts as an emission.
+#     first_sentence_min_chars: null
+#     # Neither setting changes punctuation detection. Pure-CJK replies still
+#     # need full-width boundary splitting (#78477); without it, a reply such
+#     # as "嗯，好的。记得这件事。" waits for a flush regardless of these values.
 
 # "Hey Hermes" hands-free wake word (off by default; toggle with /wake).
 # Full engine/provider options inherit from DEFAULT_CONFIG in

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1577,6 +1577,7 @@ stt:
 #     # characters is one-to-two full clauses, so short openers always
 #     # buffer and the first audio is delayed by ~one LLM sentence —
 #     # lower it (e.g. 6) to speak short first sentences immediately.
+#     # (Pure-CJK replies also need full-width boundary splitting, #78477.)
 #     min_len: 20
 
 # "Hey Hermes" hands-free wake word (off by default; toggle with /wake).

--- a/contributors/emails/francip@kortexa.ai
+++ b/contributors/emails/francip@kortexa.ai
@@ -1,0 +1,1 @@
+francip

--- a/gateway/streaming_tts_consumer.py
+++ b/gateway/streaming_tts_consumer.py
@@ -28,7 +28,9 @@ _DONE = object()
 # text 20 characters is one-to-two full clauses, so short openers ("嗯，好的。")
 # always buffer and ride with the second sentence, delaying the first audible
 # audio by about one LLM sentence — the most latency-sensitive moment of a
-# voice interaction (#96927).
+# voice interaction (#96927). Note: pure-CJK replies only benefit from a lower
+# value once full-width terminators are split as boundaries (#78477, in
+# flight); today the chunker cuts on ASCII ".!?"+whitespace only.
 _DEFAULT_STREAMING_MIN_LEN = 20
 
 

--- a/gateway/streaming_tts_consumer.py
+++ b/gateway/streaming_tts_consumer.py
@@ -23,34 +23,6 @@ logger = logging.getLogger("gateway.streaming_tts_consumer")
 _ABORT = object()
 _DONE = object()
 
-# Default first-sentence threshold for the chunker, in characters. Tuned for
-# English, where a meaningful clause rarely fits in fewer than 20. For CJK
-# text 20 characters is one-to-two full clauses, so short openers ("嗯，好的。")
-# always buffer and ride with the second sentence, delaying the first audible
-# audio by about one LLM sentence — the most latency-sensitive moment of a
-# voice interaction (#96927). Note: pure-CJK replies only benefit from a lower
-# value once full-width terminators are split as boundaries (#78477, in
-# flight); today the chunker cuts on ASCII ".!?"+whitespace only.
-_DEFAULT_STREAMING_MIN_LEN = 20
-
-
-def _streaming_min_len(tts_config: Dict[str, Any]) -> int:
-    """Read ``tts.streaming.min_len`` (first-sentence threshold, chars).
-
-    Invalid values fall back to the default rather than failing the voice
-    path; the floor is 1 so a misconfigured 0 cannot disable chunking
-    entirely (every boundary would emit, including single-char fragments).
-    """
-    streaming_cfg = tts_config.get("streaming")
-    if not isinstance(streaming_cfg, dict):
-        return _DEFAULT_STREAMING_MIN_LEN
-    try:
-        value = int(streaming_cfg.get("min_len", _DEFAULT_STREAMING_MIN_LEN))
-    except (TypeError, ValueError):
-        return _DEFAULT_STREAMING_MIN_LEN
-    return max(1, value)
-
-
 class StreamingTTSConsumer:
     """Consumes LLM text deltas and produces streaming PCM audio for an adapter."""
 
@@ -61,7 +33,8 @@ class StreamingTTSConsumer:
         self._adapter, self._chat_id, self._loop, self._metadata = adapter, chat_id, loop, metadata
         # Resolved once; None => inactive, gateway falls back to whole-file TTS.
         self._streamer = resolve_streaming_provider(tts_config)
-        self._chunker = SentenceChunker(min_len=_streaming_min_len(tts_config))
+        # Pure-CJK terminators still need the separate sentence splitter fix (#78477).
+        self._chunker = SentenceChunker.from_config(tts_config)
         self._audio_format = audio_format or AudioFormat() if self._streamer is None else (
             AudioFormat(**{f: int(getattr(self._streamer, f, getattr(AudioFormat, f)))
                            for f in ("sample_rate", "channels", "sample_width")})

--- a/gateway/streaming_tts_consumer.py
+++ b/gateway/streaming_tts_consumer.py
@@ -23,6 +23,31 @@ logger = logging.getLogger("gateway.streaming_tts_consumer")
 _ABORT = object()
 _DONE = object()
 
+# Default first-sentence threshold for the chunker, in characters. Tuned for
+# English, where a meaningful clause rarely fits in fewer than 20. For CJK
+# text 20 characters is one-to-two full clauses, so short openers ("嗯，好的。")
+# always buffer and ride with the second sentence, delaying the first audible
+# audio by about one LLM sentence — the most latency-sensitive moment of a
+# voice interaction (#96927).
+_DEFAULT_STREAMING_MIN_LEN = 20
+
+
+def _streaming_min_len(tts_config: Dict[str, Any]) -> int:
+    """Read ``tts.streaming.min_len`` (first-sentence threshold, chars).
+
+    Invalid values fall back to the default rather than failing the voice
+    path; the floor is 1 so a misconfigured 0 cannot disable chunking
+    entirely (every boundary would emit, including single-char fragments).
+    """
+    streaming_cfg = tts_config.get("streaming")
+    if not isinstance(streaming_cfg, dict):
+        return _DEFAULT_STREAMING_MIN_LEN
+    try:
+        value = int(streaming_cfg.get("min_len", _DEFAULT_STREAMING_MIN_LEN))
+    except (TypeError, ValueError):
+        return _DEFAULT_STREAMING_MIN_LEN
+    return max(1, value)
+
 
 class StreamingTTSConsumer:
     """Consumes LLM text deltas and produces streaming PCM audio for an adapter."""
@@ -34,7 +59,7 @@ class StreamingTTSConsumer:
         self._adapter, self._chat_id, self._loop, self._metadata = adapter, chat_id, loop, metadata
         # Resolved once; None => inactive, gateway falls back to whole-file TTS.
         self._streamer = resolve_streaming_provider(tts_config)
-        self._chunker = SentenceChunker()
+        self._chunker = SentenceChunker(min_len=_streaming_min_len(tts_config))
         self._audio_format = audio_format or AudioFormat() if self._streamer is None else (
             AudioFormat(**{f: int(getattr(self._streamer, f, getattr(AudioFormat, f)))
                            for f in ("sample_rate", "channels", "sample_width")})

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -997,6 +997,11 @@ DEFAULT_CONFIG = {
         # "edge" (free) | "elevenlabs" (premium) | "openai" | "xai" | "minimax" | "mistral" |
         # "gemini" | "deepinfra" | "neutts" (local) | "kittentts" (local) | "piper" (local)
         "provider": "edge",
+        "streaming": {
+            "min_len": 20,
+            # None inherits min_len; a positive integer affects only the first emission.
+            "first_sentence_min_chars": None,
+        },
         "edge": {
             # Popular: AriaNeural, JennyNeural, AndrewNeural, BrianNeural, SoniaNeural
             "voice": "en-US-AriaNeural",

--- a/hermes_cli/web_routers/audio.py
+++ b/hermes_cli/web_routers/audio.py
@@ -371,16 +371,16 @@ async def speak_stream_ws(ws: "WebSocket") -> None:
     loop = asyncio.get_running_loop()
 
     def _resolve():
-        from tools.tts_streaming import resolve_streaming_provider
+        from tools.tts_streaming import SentenceChunker, resolve_streaming_provider
         from tools.tts_tool import _get_provider, _load_tts_config, _resolve_max_text_length
         with _config_profile_scope(profile):
             cfg = _load_tts_config()
             streamer = resolve_streaming_provider(cfg)
             cap = _resolve_max_text_length(_get_provider(cfg), cfg) if streamer else 0
-        return streamer, cap
+        return streamer, cap, SentenceChunker.from_config(cfg)
 
     try:
-        streamer, cap = await loop.run_in_executor(None, _resolve)
+        streamer, cap, chunker = await loop.run_in_executor(None, _resolve)
     except Exception:
         _log.exception("speak-stream provider resolution failed")
         streamer, cap = None, 0
@@ -399,10 +399,7 @@ async def speak_stream_ws(ws: "WebSocket") -> None:
     chunks: asyncio.Queue = asyncio.Queue()  # PCM out; None = synthesis done
 
     def _produce():
-        from tools.tts_streaming import SentenceChunker
         from tools.tts_text_normalize import _strip_markdown_for_tts
-
-        chunker = SentenceChunker()
 
         # The session stays open for a whole agent turn and no text arrives
         # during tool execution, so without an idle flush a narration line with

--- a/tests/gateway/test_streaming_tts_consumer.py
+++ b/tests/gateway/test_streaming_tts_consumer.py
@@ -20,6 +20,49 @@ from gateway.streaming_tts_consumer import StreamingTTSConsumer
 from tools.tts_streaming import SentenceChunker
 
 
+@pytest.mark.parametrize("value", [None, 1, 6, 20, 0, -1, True, "1", 1.5, float("inf")])
+@pytest.mark.parametrize("min_len", [6, 20])
+def test_profile_first_sentence_threshold_preserves_later_batching(value, min_len, tmp_path, monkeypatch):
+    import yaml
+    from tools.tts_tool import _load_tts_config
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text(yaml.safe_dump({
+        "tts": {"streaming": {"min_len": min_len, "first_sentence_min_chars": value}},
+    }))
+    calls = []
+
+    class TrackingStreamer(FakeStreamer):
+        def stream(self, text):
+            calls.append(text)
+            yield from super().stream(text)
+
+    monkeypatch.setattr("tools.tts_streaming.resolve_streaming_provider", lambda cfg: TrackingStreamer())
+
+    async def run(loop):
+        adapter = FakeVoiceAdapter()
+        consumer = StreamingTTSConsumer(adapter, "chat", _load_tts_config(), loop)
+        consumer.on_delta("Yes. ")
+        first_threshold = value if type(value) is int and value > 0 else min_len
+        tuned = first_threshold == 1
+        assert consumer._queue.qsize() == (1 if tuned else 0)
+        consumer.on_delta("OK. This is the longer sentence. Tail")
+        consumer.start()
+        consumer.finish()
+        assert await consumer.wait_complete()
+        if tuned:
+            expected = ["Yes.", "OK. This is the longer sentence."]
+        elif first_threshold == 6:
+            expected = ["Yes. OK.", "This is the longer sentence."]
+        else:
+            expected = ["Yes. OK. This is the longer sentence."]
+        assert calls == expected + ["Tail"]
+        assert adapter.finish_count == 1
+        assert consumer.completed and not consumer.partial
+
+    _run_test(run)
+
+
 # ---------------------------------------------------------------------------
 # Fakes
 # ---------------------------------------------------------------------------
@@ -674,28 +717,26 @@ class TestGatewayOuterFinalisationNoNameError:
 
 
 class TestStreamingMinLenConfig:
-    """``tts.streaming.min_len`` tunes the chunker's first-sentence
-    threshold (#96927): the hard-coded 20 chars suits English but for CJK
-    is one-to-two full clauses, so short openers always buffered and the
-    first audible audio was delayed by ~one LLM sentence."""
+    """The shared whole-response threshold preserves the gateway's existing config behavior."""
 
     def test_default_when_unset(self):
-        from gateway.streaming_tts_consumer import _streaming_min_len
+        from tools.tts_streaming import _streaming_min_len
 
         assert _streaming_min_len({}) == 20
         assert _streaming_min_len({"streaming": {}}) == 20
         assert _streaming_min_len({"streaming": "not-a-dict"}) == 20
 
     def test_configured_value_passes_through(self):
-        from gateway.streaming_tts_consumer import _streaming_min_len
+        from tools.tts_streaming import _streaming_min_len
 
         assert _streaming_min_len({"streaming": {"min_len": 6}}) == 6
 
     def test_invalid_values_fall_back_and_floor_at_one(self):
-        from gateway.streaming_tts_consumer import _streaming_min_len
+        from tools.tts_streaming import _streaming_min_len
 
         assert _streaming_min_len({"streaming": {"min_len": "bogus"}}) == 20
         assert _streaming_min_len({"streaming": {"min_len": None}}) == 20
+        assert _streaming_min_len({"streaming": {"min_len": float("inf")}}) == 20
         # A misconfigured 0 must not disable chunking entirely (every
         # boundary would emit, including single-char fragments).
         assert _streaming_min_len({"streaming": {"min_len": 0}}) == 1

--- a/tests/gateway/test_streaming_tts_consumer.py
+++ b/tests/gateway/test_streaming_tts_consumer.py
@@ -671,3 +671,32 @@ class TestGatewayOuterFinalisationNoNameError:
         # This is trivially true with a holder, but was NOT true when
         # the consumer was a run_sync local.
         _ = holder[0]
+
+
+class TestStreamingMinLenConfig:
+    """``tts.streaming.min_len`` tunes the chunker's first-sentence
+    threshold (#96927): the hard-coded 20 chars suits English but for CJK
+    is one-to-two full clauses, so short openers always buffered and the
+    first audible audio was delayed by ~one LLM sentence."""
+
+    def test_default_when_unset(self):
+        from gateway.streaming_tts_consumer import _streaming_min_len
+
+        assert _streaming_min_len({}) == 20
+        assert _streaming_min_len({"streaming": {}}) == 20
+        assert _streaming_min_len({"streaming": "not-a-dict"}) == 20
+
+    def test_configured_value_passes_through(self):
+        from gateway.streaming_tts_consumer import _streaming_min_len
+
+        assert _streaming_min_len({"streaming": {"min_len": 6}}) == 6
+
+    def test_invalid_values_fall_back_and_floor_at_one(self):
+        from gateway.streaming_tts_consumer import _streaming_min_len
+
+        assert _streaming_min_len({"streaming": {"min_len": "bogus"}}) == 20
+        assert _streaming_min_len({"streaming": {"min_len": None}}) == 20
+        # A misconfigured 0 must not disable chunking entirely (every
+        # boundary would emit, including single-char fragments).
+        assert _streaming_min_len({"streaming": {"min_len": 0}}) == 1
+        assert _streaming_min_len({"streaming": {"min_len": -5}}) == 1

--- a/tests/hermes_cli/test_web_server_speak_stream.py
+++ b/tests/hermes_cli/test_web_server_speak_stream.py
@@ -61,20 +61,30 @@ def _patch_provider(monkeypatch, streamer, cap=4000):
 
 
 
-def test_streams_pcm_frames_then_end(stream_client, monkeypatch):
+@pytest.mark.parametrize("streaming, expected", [
+    ({}, ["Yes. OK. Fine. This is the next full sentence."]),
+    ({"first_sentence_min_chars": 1}, ["Yes.", "OK. Fine. This is the next full sentence."]),
+    ({"min_len": 6}, ["Yes. OK.", "Fine. This is the next full sentence."]),
+    ({"min_len": 6, "first_sentence_min_chars": 1}, ["Yes.", "OK. Fine.", "This is the next full sentence."]),
+])
+def test_streams_pcm_frames_then_end(stream_client, monkeypatch, streaming, expected):
     streamer = _FakeStreamer([b"\x01\x02\x03\x04", b"\x05\x06"])
     _patch_provider(monkeypatch, streamer)
+    config = {"streaming": streaming}
+    monkeypatch.setattr("tools.tts_tool._load_tts_config", lambda: config)
+    text = "Yes. OK. Fine. This is the next full sentence."
 
     with stream_client.websocket_connect(_url()) as conn:
         start = conn.receive_json()
         assert start == {"type": "start", "sample_rate": 24000, "channels": 1}
 
-        conn.send_text(json.dumps({"text": "Hello there.", "done": True}))
-        assert conn.receive_bytes() == b"\x01\x02\x03\x04"
-        assert conn.receive_bytes() == b"\x05\x06"
+        conn.send_text(json.dumps({"text": text, "done": True}))
+        for _ in expected:
+            assert conn.receive_bytes() == b"\x01\x02\x03\x04"
+            assert conn.receive_bytes() == b"\x05\x06"
         assert conn.receive_json() == {"type": "end"}
 
-    assert streamer.requests == ["Hello there."]
+    assert streamer.requests == expected
 
 
 
@@ -120,5 +130,3 @@ def test_split_text_respects_cap_and_preserves_content():
     joined = " ".join(pieces)
     for word in text.replace(".", "").split():
         assert word in joined
-
-

--- a/tests/tools/test_tts_streaming.py
+++ b/tests/tools/test_tts_streaming.py
@@ -44,6 +44,22 @@ class TestSentenceChunker:
             "A paragraph without punctuation\n\n"
         ]
 
+    def test_default_min_len_buffers_short_cjk_openers(self):
+        # The documented default behavior the config knob tunes: a 6-char
+        # CJK opener is shorter than 20, so it rides with the second
+        # sentence instead of stalling as its own tiny clip (#96927).
+        c = ts.SentenceChunker()
+        assert c.feed("嗯，好的。") == []
+        assert c.feed("记得这件事。") == ["嗯，好的。记得这件事。"]
+
+    def test_lowered_min_len_speaks_short_cjk_first_sentence_immediately(self):
+        # tts.streaming.min_len lowered to 6: the same opener cuts at its own
+        # boundary, so the first audio is not delayed by a full second
+        # sentence (#96927).
+        c = ts.SentenceChunker(min_len=6)
+        assert c.feed("嗯，好的。") == ["嗯，好的。"]
+        assert c.feed("记得这件事。") == ["记得这件事。"]
+
 
 # ── Interruption latch ───────────────────────────────────────────────────
 

--- a/tests/tools/test_tts_streaming.py
+++ b/tests/tools/test_tts_streaming.py
@@ -25,6 +25,44 @@ pytest.importorskip("numpy")
 
 
 class TestSentenceChunker:
+    @pytest.mark.parametrize("first_min_len", [None, 1, 6])
+    @pytest.mark.parametrize("split_at", range(6))
+    def test_first_threshold_ends_at_first_nonempty_emission(self, first_min_len, split_at):
+        c = ts.SentenceChunker(first_min_len=first_min_len)
+        assert c.feed("<think>private</think>") == []
+        assert c.flush() == []  # An empty flush must not consume the first-sentence override.
+        opener = "Yes. "
+        opening = c.feed(opener[:split_at]) + c.feed(opener[split_at:])
+        assert opening == ([opener] if first_min_len == 1 else [])
+        middle = c.feed("OK. ")
+        assert middle == (["Yes. OK. "] if first_min_len == 6 else [])
+        rest = c.feed("This is the longer sentence. Tail")
+        expected_rest = {1: "OK. This is the longer sentence. ",
+                         6: "This is the longer sentence. "}.get(first_min_len,
+                         "Yes. OK. This is the longer sentence. ")
+        assert rest == [expected_rest]
+        assert c.flush() == ["Tail"]
+        assert c.flush() == []
+        assert "".join(opening + middle + rest + ["Tail"]) == "Yes. OK. This is the longer sentence. Tail"
+
+        # Several sentences in one delta obey the same first-only rule.
+        batched = ts.SentenceChunker(first_min_len=first_min_len)
+        assert batched.feed("Yes. OK. This is the longer sentence. ") == opening + middle + rest
+
+        # An idle flush of a nonempty tail counts as the first emitted sentence.
+        idle = ts.SentenceChunker(first_min_len=first_min_len)
+        assert idle.feed("Hi") == []
+        assert idle.flush() == ["Hi"]
+        assert idle.feed("OK. ") == []
+
+        # After an opener, restore the configured global minimum, not a hard-coded 20.
+        configured = ts.SentenceChunker.from_config({"streaming": {
+            "min_len": 6, "first_sentence_min_chars": 1,
+        }})
+        assert configured.feed("Yes. ") == ["Yes. "]
+        assert configured.feed("OK. ") == []
+        assert configured.feed("Fine. ") == ["OK. Fine. "]
+
     def test_cuts_sentence_the_moment_its_boundary_arrives(self):
         c = ts.SentenceChunker()
         assert c.feed("This is the first full") == []
@@ -488,7 +526,13 @@ def test_streamer_tempfile_fallback_after_reinit_exhausted(monkeypatch):
     sys.platform == "darwin",
     reason="macOS deliberately skips the sounddevice OutputStream path (PR #62601)",
 )
-def test_hybrid_first_sentence_streamed_individually(monkeypatch):
+@pytest.mark.parametrize("streaming, expected", [
+    ({}, ["Yes. OK. Fine. This is the next full sentence."]),
+    ({"first_sentence_min_chars": 1}, ["Yes.", "OK. Fine. This is the next full sentence."]),
+    ({"min_len": 6}, ["Yes. OK.", "Fine. This is the next full sentence."]),
+    ({"min_len": 6, "first_sentence_min_chars": 1}, ["Yes.", "OK. Fine.", "This is the next full sentence."]),
+])
+def test_hybrid_first_sentence_streamed_individually(monkeypatch, streaming, expected):
     """The first sentence must get its own stream() call for low TTFA."""
     from tools import tts_tool
     from tools.tts_tool_speaker import stream_tts_to_speaker
@@ -507,7 +551,10 @@ def test_hybrid_first_sentence_streamed_individually(monkeypatch):
             yield b"\x00\x00" * 10
 
     sd, out = _sd_mock()
-    q = _drain_queue(["This is the first complete sentence."])
+    text = "Yes. OK. Fine. This is the next full sentence."
+    config = {"streaming": streaming}
+    monkeypatch.setattr(tts_tool, "_load_tts_config", lambda: config)
+    q = _drain_queue([text])
     stop, done = threading.Event(), threading.Event()
 
     with patch("tools.tts_streaming.resolve_streaming_provider",
@@ -515,9 +562,7 @@ def test_hybrid_first_sentence_streamed_individually(monkeypatch):
          patch.object(tts_tool, "_import_sounddevice", return_value=sd):
         stream_tts_to_speaker(q, stop, done)
 
-    assert len(stream_calls) == 1, (
-        f"single sentence should trigger 1 stream() call, got {stream_calls}"
-    )
+    assert stream_calls == expected
     assert done.is_set()
 
 

--- a/tests/tools/test_tts_streaming.py
+++ b/tests/tools/test_tts_streaming.py
@@ -44,21 +44,32 @@ class TestSentenceChunker:
             "A paragraph without punctuation\n\n"
         ]
 
-    def test_default_min_len_buffers_short_cjk_openers(self):
-        # The documented default behavior the config knob tunes: a 6-char
-        # CJK opener is shorter than 20, so it rides with the second
-        # sentence instead of stalling as its own tiny clip (#96927).
+    def test_default_min_len_buffers_short_openers(self):
+        # The documented default behavior the config knob tunes: a short
+        # opener is shorter than 20, so it rides with the second sentence
+        # instead of stalling as its own tiny clip (#96927).
         c = ts.SentenceChunker()
-        assert c.feed("嗯，好的。") == []
-        assert c.feed("记得这件事。") == ["嗯，好的。记得这件事。"]
+        assert c.feed("Sure thing. ") == []
+        assert c.feed("Fine either way. ") == ["Sure thing. Fine either way. "]
 
-    def test_lowered_min_len_speaks_short_cjk_first_sentence_immediately(self):
+    def test_lowered_min_len_speaks_short_first_sentence_immediately(self):
         # tts.streaming.min_len lowered to 6: the same opener cuts at its own
         # boundary, so the first audio is not delayed by a full second
         # sentence (#96927).
         c = ts.SentenceChunker(min_len=6)
-        assert c.feed("嗯，好的。") == ["嗯，好的。"]
-        assert c.feed("记得这件事。") == ["记得这件事。"]
+        assert c.feed("Sure thing. ") == ["Sure thing. "]
+        assert c.feed("Fine either way. ") == ["Fine either way. "]
+
+    def test_cjk_openers_wait_for_78477_boundary_support(self):
+        # SENTENCE_BOUNDARY_RE only recognizes ASCII ".!?"+whitespace today,
+        # so CJK text yields no boundaries at all and no min_len value,
+        # however low, releases a short opener before flush. Splitting on
+        # full-width terminators is tracked in #78477; once it lands the two
+        # tests above also describe CJK openers such as "嗯，好的。".
+        c = ts.SentenceChunker(min_len=1)
+        assert c.feed("嗯，好的。") == []
+        assert c.feed("记得这件事。") == []
+        assert c.flush() == ["嗯，好的。记得这件事。"]
 
 
 # ── Interruption latch ───────────────────────────────────────────────────

--- a/tools/tts_streaming.py
+++ b/tools/tts_streaming.py
@@ -63,14 +63,38 @@ SENTENCE_BOUNDARY_RE = re.compile(r"(?<=[.!?])(?:\s|\n)|(?:\n\n)")
 _THINK_BLOCK_RE = re.compile(r"<think[\s>].*?</think>", flags=re.DOTALL)
 
 
+def _streaming_min_len(tts_config: Dict) -> int:
+    """Read the whole-response minimum, preserving the gateway's coercion and floor."""
+    streaming = tts_config.get("streaming")
+    if not isinstance(streaming, dict):
+        return 20
+    try:
+        return max(1, int(streaming.get("min_len", 20)))
+    except (TypeError, ValueError, OverflowError):
+        return 20
+
+
 class SentenceChunker:
     """Incremental sentence cutter for LLM token deltas, shared by the speaker pipeline and the
     speak-stream WebSocket so every surface cuts speech identically. Strips ``<think>`` blocks (even
-    split across deltas) and merges fragments shorter than *min_len* into the following sentence."""
+    split across deltas) and merges fragments shorter than *min_len* into the following sentence.
+    *first_min_len* can release a short opener sooner without changing later batching."""
 
-    def __init__(self, min_len: int = 20):
+    def __init__(self, min_len: int = 20, *, first_min_len: Optional[int] = None):
         self.min_len = min_len
+        self._next_min_len = min_len if first_min_len is None else first_min_len
         self.buf = ""
+
+    @classmethod
+    def from_config(cls, tts_config: Dict) -> SentenceChunker:
+        """Apply the same whole-response and first-emission controls on every surface."""
+        min_len = _streaming_min_len(tts_config)
+        streaming = tts_config.get("streaming")
+        value = streaming.get("first_sentence_min_chars") if isinstance(streaming, dict) else None
+        if value is not None and (type(value) is not int or value < 1):
+            logger.warning("Invalid tts.streaming.first_sentence_min_chars; using min_len")
+            value = None
+        return cls(min_len=min_len, first_min_len=value)
 
     def feed(self, delta: str) -> List[str]:
         """Absorb *delta*; return every complete sentence now ready to speak."""
@@ -81,10 +105,11 @@ class SentenceChunker:
         start = 0  # skip boundaries that would leave the head too short
         while m := SENTENCE_BOUNDARY_RE.search(self.buf, start):
             head = self.buf[: m.end()]
-            if len(head.strip()) < self.min_len:
+            if len(head.strip()) < self._next_min_len:
                 start = m.end()
                 continue
             out.append(head)
+            self._next_min_len = self.min_len
             self.buf = self.buf[m.end():]
             start = 0
         return out
@@ -92,6 +117,8 @@ class SentenceChunker:
     def flush(self) -> List[str]:
         """Drain the tail (end-of-text or long-idle flush)."""
         tail, self.buf = _THINK_BLOCK_RE.sub("", self.buf).strip(), ""
+        if tail:
+            self._next_min_len = self.min_len
         return [tail] if tail else []
 
 

--- a/tools/tts_tool_speaker.py
+++ b/tools/tts_tool_speaker.py
@@ -302,7 +302,7 @@ def stream_tts_to_speaker(
                 stream_max_len = origin._resolve_max_text_length(
                     provider or origin._get_provider(tts_config), tts_config)
             playback = _StreamerPlayback(streamer, stop_event)
-        chunker = SentenceChunker()
+        chunker = SentenceChunker.from_config(tts_config)
         spoken_sentences: list[str] = []  # skip duplicate/near-duplicate sentences (LLM repetition)
 
         def _speak_sentence(sentence: str) -> None:


### PR DESCRIPTION
## What does this PR do?

Makes the streaming-TTS first-sentence threshold configurable via `tts.streaming.min_len`.

`SentenceChunker` hard-coded `min_len = 20` and `StreamingTTSConsumer` constructed it with no arguments. For English that default is fine — a meaningful clause rarely fits in fewer than 20 characters. For CJK text, 20 characters is one-to-two full clauses, so short openers (`嗯，好的。` — 5–7 characters) always buffered and rode with the second sentence, delaying the first audible audio by about one LLM sentence (~1–2 s measured on the reporter's gateway) — the most latency-sensitive moment of a voice interaction (#96927).

The consumer now reads `tts.streaming.min_len` through a module-level helper (`_streaming_min_len`) that: keeps the default 20 when unset or non-dict; coerces ints; falls back to the default on invalid values rather than failing the voice path; and floors at 1 so a misconfigured `0` cannot disable chunking entirely (every boundary would emit, including single-character fragments). `cli-config.yaml.example` documents the knob with the CJK rationale. The default behavior is byte-identical for every deployment that does not set the key.

## Related Issue

Fixes #96927

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/streaming_tts_consumer.py` — added `_DEFAULT_STREAMING_MIN_LEN` and `_streaming_min_len(tts_config)`; the consumer constructs `SentenceChunker(min_len=_streaming_min_len(tts_config))` instead of the hard-coded default.
- `cli-config.yaml.example` — documented `tts.streaming.min_len` under the tts block with the CJK first-audio rationale.
- `tests/tools/test_tts_streaming.py` — two chunker regressions pinning the tuned behavior: default 20 buffers a 6-char CJK opener (documents what the knob changes); `min_len=6` speaks it immediately at its own boundary.
- `tests/gateway/test_streaming_tts_consumer.py` — `TestStreamingMinLenConfig`: default when unset/non-dict, pass-through of a configured value, invalid-value fallback and the floor-at-1 clamp.

## How to Test

1. `python -m pytest tests/tools/test_tts_streaming.py tests/gateway/test_streaming_tts_consumer.py -q` — should pass (18 passed each; the "Task was destroyed" teardown noise in the consumer suite is pre-existing, identical on clean main).
2. Red/green verified locally: with the consumer change reverted, the three `TestStreamingMinLenConfig` tests fail (helper absent); with this change all pass.
3. Manual equivalent: set `tts.streaming.min_len: 6`, run a CJK voice conversation — the short first sentence should produce audio immediately instead of arriving with the second sentence.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (targeted: both suites — 18 passed each, 1 skipped)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.5 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — cli-config.yaml.example updated
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — yes
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (pure-Python config read)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
