### PR TITLE
fix(compression): prevent duplicate rows across repeated boundaries

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -3642,6 +3642,33 @@ def compress_context(
 
         todo_snapshot = agent._todo_store.format_for_injection()
         if todo_snapshot:
+            # A prior standalone snapshot can be buried before later assistant/tool
+            # rows when another compression fires in the same turn. Refreshing only
+            # the tail then stacks one snapshot per boundary. Remove stale snapshot
+            # blocks across the whole compressed view first; preserve any real user
+            # text that previously carried a merged snapshot, and let the injection
+            # below place exactly one fresh snapshot at the newest safe boundary.
+            _without_stale_snapshots = []
+            for _message in compressed:
+                if not isinstance(_message, dict) or _message.get("role") != "user":
+                    _without_stale_snapshots.append(_message)
+                    continue
+                _stripped_content = _strip_stale_todo_snapshot(
+                    _message.get("content")
+                )
+                if _stripped_content == _message.get("content"):
+                    _without_stale_snapshots.append(_message)
+                    continue
+                _stripped_message = {
+                    key: value
+                    for key, value in _message.items()
+                    if key not in {"content", "_todo_snapshot_synthetic"}
+                }
+                _stripped_message["content"] = _stripped_content
+                if _is_real_user_message(_stripped_message):
+                    _without_stale_snapshots.append(_stripped_message)
+            compressed = _without_stale_snapshots
+
             # Retention parity (#84718): the snapshot below re-injects the
             # imperative verbatim. If this same boundary pruned skill bodies
             # to [SKILL_PRUNED: ...] markers, the policy that governed those

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -11834,17 +11834,90 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 )
 
             # Concurrent tail: active rows that arrived after the watermark.
-            # Snapshot their ids and tool_calls now — the clone below needs a
+            # A durable row can also already be represented in the compressor's
+            # handoff (for example when a preflight compaction overlaps a live
+            # append). Match those exact occurrences before cloning so the commit
+            # preserves the row once instead of inserting it and cloning it again.
+            def _watermark_overlap_identity(
+                role: Any,
+                content: Any,
+                tool_call_id: Any,
+                tool_calls: Any,
+                tool_name: Any,
+                timestamp: Any,
+            ) -> tuple:
+                if isinstance(tool_calls, str):
+                    try:
+                        tool_calls = json.loads(tool_calls)
+                    except (json.JSONDecodeError, TypeError):
+                        tool_calls = []
+                tool_calls_json = json.dumps(tool_calls) if tool_calls else None
+                try:
+                    normalized_timestamp = float(timestamp)
+                except (TypeError, ValueError):
+                    normalized_timestamp = None
+                return (
+                    role,
+                    self._encode_content(content),
+                    tool_call_id,
+                    tool_calls_json,
+                    _scrub_surrogates(tool_name),
+                    normalized_timestamp,
+                )
+
+            represented_tail_occurrences: Dict[tuple, int] = {}
+            represented_untimed_occurrences: Dict[tuple, int] = {}
+            for message in compacted_messages:
+                identity = _watermark_overlap_identity(
+                    message.get("role", "unknown"),
+                    message.get("content"),
+                    message.get("tool_call_id"),
+                    message.get("tool_calls"),
+                    message.get("tool_name"),
+                    message.get("timestamp"),
+                )
+                represented_tail_occurrences[identity] = (
+                    represented_tail_occurrences.get(identity, 0) + 1
+                )
+                if identity[-1] is None:
+                    untimed_identity = identity[:-1]
+                    represented_untimed_occurrences[untimed_identity] = (
+                        represented_untimed_occurrences.get(untimed_identity, 0) + 1
+                    )
+
+            # Snapshot tail ids and tool_calls now — the clone below needs a
             # stable id list, and the tool-call count keeps sessions.* honest.
             tail_ids: list[int] = []
             tail_tool_calls = 0
             if watermark is not None:
                 for row in conn.execute(
-                    "SELECT id, tool_calls FROM messages "
+                    "SELECT id, role, content, tool_call_id, tool_calls, "
+                    "tool_name, timestamp FROM messages "
                     "WHERE session_id = ? AND active = 1 AND id > ? "
                     "ORDER BY id",
                     (session_id, int(watermark)),
                 ).fetchall():
+                    identity = _watermark_overlap_identity(
+                        row["role"],
+                        self._decode_content(row["content"]),
+                        row["tool_call_id"],
+                        row["tool_calls"],
+                        row["tool_name"],
+                        row["timestamp"],
+                    )
+                    represented_count = represented_tail_occurrences.get(identity, 0)
+                    if represented_count > 0:
+                        represented_tail_occurrences[identity] = represented_count - 1
+                        continue
+                    untimed_identity = identity[:-1]
+                    untimed_count = represented_untimed_occurrences.get(
+                        untimed_identity, 0
+                    )
+                    if untimed_count > 0:
+                        represented_untimed_occurrences[untimed_identity] = (
+                            untimed_count - 1
+                        )
+                        continue
                     tail_ids.append(int(row["id"]))
                     raw = row["tool_calls"]
                     if raw:

--- a/tests/agent/test_compression_rotation_state.py
+++ b/tests/agent/test_compression_rotation_state.py
@@ -1584,6 +1584,43 @@ class TestTodoSnapshotScaffoldingTails:
             for previous, current in zip(compressed, compressed[1:])
         )
 
+    def test_buried_standalone_snapshot_is_replaced_not_duplicated(
+        self, tmp_path: Path
+    ):
+        """A tool result after a snapshot must not make the next boundary stack it."""
+        from tools.todo_tool import TODO_INJECTION_HEADER
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        agent = self._agent_with_todo(
+            db,
+            "PARENT_TODO_BURIED",
+            {"role": "tool", "tool_call_id": "call-1", "content": "done"},
+        )
+        agent.context_compressor.compress.return_value.insert(
+            -1,
+            {
+                "role": "user",
+                "content": (
+                    f"{TODO_INJECTION_HEADER}\n"
+                    "- [ ] t0. stale task (pending)"
+                ),
+                "_todo_snapshot_synthetic": True,
+            },
+        )
+
+        compressed, _ = agent._compress_context(
+            _msgs(), "sys", approx_tokens=120_000
+        )
+
+        snapshot_rows = [
+            message
+            for message in compressed
+            if TODO_INJECTION_HEADER in str(message.get("content") or "")
+        ]
+        assert len(snapshot_rows) == 1
+        assert "task A" in str(snapshot_rows[0]["content"])
+        assert "stale task" not in str(snapshot_rows[0]["content"])
+
     def test_empty_todo_store_injects_nothing(self, tmp_path: Path):
         from tools.todo_tool import TODO_INJECTION_HEADER
 

--- a/tests/test_compression_watermark_commit.py
+++ b/tests/test_compression_watermark_commit.py
@@ -60,6 +60,43 @@ class TestWatermarkCommit:
         ], "tail must follow the summary, in arrival order"
         assert count == 4
 
+    def test_tail_already_in_compacted_handoff_is_not_cloned_twice(
+        self, db: SessionDB
+    ) -> None:
+        _seed(db)
+        watermark = db.get_active_message_watermark("sess1")
+        db.append_message("sess1", role="user", content="mid-compression steer")
+        late_arrival = db.get_messages_as_conversation("sess1")[-1]
+        assert late_arrival.get("_db_persisted") is True
+        compacted = [*SUMMARY, late_arrival]
+
+        count = db.archive_and_compact("sess1", compacted, watermark=watermark)
+
+        contents = [row["content"] for row in db.get_messages("sess1")]
+        assert contents == [
+            "[CONTEXT COMPACTION] summary of turns 0-5",
+            "Continuing from the summary.",
+            "mid-compression steer",
+        ]
+        assert count == 3
+
+    def test_generated_handoff_replaces_same_concurrent_scaffold(
+        self, db: SessionDB
+    ) -> None:
+        _seed(db)
+        watermark = db.get_active_message_watermark("sess1")
+        db.append_message(
+            "sess1",
+            role="user",
+            content=SUMMARY[0]["content"],
+        )
+
+        count = db.archive_and_compact("sess1", SUMMARY, watermark=watermark)
+
+        contents = [row["content"] for row in db.get_messages("sess1")]
+        assert contents.count(SUMMARY[0]["content"]) == 1
+        assert count == 2
+
     def test_tail_clone_preserves_every_column(self, db: SessionDB) -> None:
         """The pure-SQL clone must carry sidecar fields byte-exact."""
         _seed(db, 2)


### PR DESCRIPTION
## Summary

- remove stale todo snapshot blocks across the entire compressed transcript before reinjection
- preserve human-authored text from messages that previously carried a merged snapshot
- keep exactly one current todo snapshot after repeated same-turn compression boundaries
- avoid cloning post-watermark rows already represented by the compacted handoff
- use occurrence-aware exact identities, with an untimed fallback for newly generated compaction scaffolding

## Root causes

Two independent in-place compaction paths can produce simultaneously active duplicates:

1. Todo refresh only inspected the trailing user message. Later assistant/tool rows can bury a standalone snapshot in the retained tail, so every subsequent compression appends another snapshot.
2. `archive_and_compact()` always cloned every post-watermark row, even when the compressor handoff already contained that logical row. That inserts the handoff copy and clones the durable source again.

## Regression coverage

- buried standalone todo snapshot followed by tool output
- timestamped durable tail already present in the compacted handoff
- untimed generated scaffold replacing the same concurrent durable scaffold
- existing watermark clone and column-preservation contracts

## Verification

- Todo RED: focused regression failed with `assert 2 == 1`
- Watermark RED: both overlap regressions failed with duplicated contents
- GREEN on current `origin/main`: `66 passed` across todo-retention, compression-rotation, and watermark-commit suites.