### PR TITLE
fix(terminal): make SSH lifecycle safe for native workspaces

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -665,6 +665,7 @@ def load_cli_config() -> Dict[str, Any]:
         "ssh_user": "TERMINAL_SSH_USER",
         "ssh_port": "TERMINAL_SSH_PORT",
         "ssh_key": "TERMINAL_SSH_KEY",
+        "ssh_file_sync": "TERMINAL_SSH_FILE_SYNC",
         # Container resource config (docker, singularity, modal, daytona, vercel_sandbox -- ignored for local/ssh)
         "container_cpu": "TERMINAL_CONTAINER_CPU",
         "container_memory": "TERMINAL_CONTAINER_MEMORY",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2369,6 +2369,7 @@ if _config_path.exists():
                 "ssh_user": "TERMINAL_SSH_USER",
                 "ssh_port": "TERMINAL_SSH_PORT",
                 "ssh_key": "TERMINAL_SSH_KEY",
+                "ssh_file_sync": "TERMINAL_SSH_FILE_SYNC",
                 "container_cpu": "TERMINAL_CONTAINER_CPU",
                 "container_memory": "TERMINAL_CONTAINER_MEMORY",
                 "container_disk": "TERMINAL_CONTAINER_DISK",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3656,6 +3656,7 @@ TERMINAL_CONFIG_ENV_MAP = {
     "ssh_user": "TERMINAL_SSH_USER",
     "ssh_port": "TERMINAL_SSH_PORT",
     "ssh_key": "TERMINAL_SSH_KEY",
+    "ssh_file_sync": "TERMINAL_SSH_FILE_SYNC",
     "container_cpu": "TERMINAL_CONTAINER_CPU",
     "container_memory": "TERMINAL_CONTAINER_MEMORY",
     "container_disk": "TERMINAL_CONTAINER_DISK",

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -381,6 +381,7 @@ DEFAULT_CONFIG = {
         # with a reason + retry hint so the model can act on it; "fail"
         # preserves the historical error + traceback behavior.
         "degraded_mode": "warn",
+        "ssh_file_sync": True,
         "cwd": ".",  # Use current directory
         # Terminal font family for the desktop app's embedded xterm.js terminal.
         # When set (e.g. "'CaskaydiaCoveNerdFont', 'JetBrains Mono', monospace"),

--- a/tests/tools/test_search_error_guard.py
+++ b/tests/tools/test_search_error_guard.py
@@ -88,6 +88,14 @@ class TestSearchErrorGuard:
         assert "Search failed" in res.error
         assert not res.matches
 
+    def test_pattern_beginning_with_hyphen_is_data_not_an_option(self, method, match_tree):
+        (match_tree / "flags.txt").write_text("--state open\n")
+
+        res = _search(_ops(match_tree), method, "--state", match_tree)
+
+        assert res.error is None
+        assert any(match.content == "--state open" for match in res.matches)
+
 
     def test_count_mode_with_partial_error(self, method, partial_error_tree):
         res = _search(_ops(partial_error_tree), method, "needle",

--- a/tests/tools/test_ssh_environment.py
+++ b/tests/tools/test_ssh_environment.py
@@ -3,6 +3,7 @@
 import json
 import os
 import subprocess
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -146,6 +147,22 @@ class TestControlSocketPath:
 
 
 class TestTerminalToolConfig:
+    def test_ssh_file_sync_can_be_disabled_for_native_remote_workspaces(self, monkeypatch):
+        from hermes_cli.config import apply_terminal_config_to_env
+        from tools.terminal_tool import _get_env_config, _ssh_config_from_config
+
+        bridged = apply_terminal_config_to_env(
+            env={},
+            config={"terminal": {"ssh_file_sync": False}},
+            override=True,
+        )
+        assert bridged["TERMINAL_SSH_FILE_SYNC"] == "False"
+        monkeypatch.setenv("TERMINAL_SSH_FILE_SYNC", bridged["TERMINAL_SSH_FILE_SYNC"])
+        config = _get_env_config()
+
+        assert config["ssh_file_sync"] is False
+        assert _ssh_config_from_config(config)["file_sync"] is False
+
     def test_ssh_persistent_default_true(self, monkeypatch):
         """SSH persistent defaults to True (via TERMINAL_PERSISTENT_SHELL)."""
         monkeypatch.delenv("TERMINAL_SSH_PERSISTENT", raising=False)
@@ -189,6 +206,55 @@ class TestSSHPreflight:
         assert called["count"] == 1
         assert env.host == "example.com"
         assert env.user == "alice"
+
+    def test_disabled_file_sync_never_scans_or_writes_remote_hermes_files(self, monkeypatch):
+        monkeypatch.setattr(ssh_env.shutil, "which", lambda _name: "/usr/bin/ssh")
+        monkeypatch.setattr(ssh_env.SSHEnvironment, "_establish_connection", lambda self: None)
+        monkeypatch.setattr(ssh_env.SSHEnvironment, "_detect_remote_home", lambda self: "/home/alice")
+        monkeypatch.setattr(ssh_env.SSHEnvironment, "init_session", lambda self: None)
+        monkeypatch.setattr(
+            ssh_env.SSHEnvironment,
+            "_ensure_remote_dirs",
+            lambda self: pytest.fail("disabled sync must not create remote .hermes directories"),
+        )
+        monkeypatch.setattr(
+            ssh_env,
+            "FileSyncManager",
+            lambda **_kwargs: pytest.fail("disabled sync must not enumerate or transfer files"),
+        )
+
+        env = ssh_env.SSHEnvironment(host="example.com", user="alice", file_sync=False)
+
+        assert env._sync_manager is None
+        env._before_execute()
+        env.cleanup()
+
+    def test_remote_command_uses_a_tracked_process_group_and_kill_cleans_it_up(self, monkeypatch):
+        monkeypatch.setattr(ssh_env.shutil, "which", lambda _name: "/usr/bin/ssh")
+        monkeypatch.setattr(ssh_env.SSHEnvironment, "_establish_connection", lambda self: None)
+        monkeypatch.setattr(ssh_env.SSHEnvironment, "_detect_remote_home", lambda self: "/Users/alice")
+        monkeypatch.setattr(ssh_env.SSHEnvironment, "init_session", lambda self: None)
+        process = SimpleNamespace(pid=123, kill=MagicMock())
+        monkeypatch.setattr(ssh_env, "_popen_bash", lambda command, stdin: (setattr(process, "command", command) or process))
+        cleanup_calls = []
+        monkeypatch.setattr(
+            ssh_env.subprocess,
+            "run",
+            lambda command, **kwargs: (cleanup_calls.append(command) or subprocess.CompletedProcess(command, 0)),
+        )
+
+        env = ssh_env.SSHEnvironment(host="example.com", user="alice", file_sync=False)
+        process = env._run_bash("sleep 300")
+        env._kill_process(process)
+
+        remote_command = process.command[-1]
+        assert "os.setsid" in remote_command
+        assert "/Users/alice/.hermes/run/" in remote_command
+        assert cleanup_calls
+        assert "kill -TERM" in cleanup_calls[-1][-1]
+        assert "kill -KILL" in cleanup_calls[-1][-1]
+        assert "rm -f" in cleanup_calls[-1][-1]
+        process.kill.assert_called_once()
 
 
 def _setup_ssh_env(monkeypatch, persistent: bool):

--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -13,6 +13,7 @@ import shlex
 import shutil
 import subprocess
 import tempfile
+import uuid
 from pathlib import Path
 
 from tools.environments.base import (
@@ -53,7 +54,8 @@ class SSHEnvironment(BaseEnvironment):
     """
 
     def __init__(self, host: str, user: str, cwd: str = "~",
-                 timeout: int = 60, port: int = 22, key_path: str = ""):
+                 timeout: int = 60, port: int = 22, key_path: str = "",
+                 file_sync: bool = True):
         super().__init__(cwd=cwd, timeout=timeout)
         self.host = host
         self.user = user
@@ -78,15 +80,17 @@ class SSHEnvironment(BaseEnvironment):
         self._establish_connection()
         self._remote_home = self._detect_remote_home()
 
-        self._ensure_remote_dirs()
-        self._sync_manager = FileSyncManager(
-            get_files_fn=lambda: iter_sync_files(f"{self._remote_home}/.hermes"),
-            upload_fn=self._scp_upload,
-            delete_fn=self._ssh_delete,
-            bulk_upload_fn=self._ssh_bulk_upload,
-            bulk_download_fn=self._ssh_bulk_download,
-        )
-        self._sync_manager.sync(force=True)
+        self._sync_manager = None
+        if file_sync:
+            self._ensure_remote_dirs()
+            self._sync_manager = FileSyncManager(
+                get_files_fn=lambda: iter_sync_files(f"{self._remote_home}/.hermes"),
+                upload_fn=self._scp_upload,
+                delete_fn=self._ssh_delete,
+                bulk_upload_fn=self._ssh_bulk_upload,
+                bulk_download_fn=self._ssh_bulk_download,
+            )
+            self._sync_manager.sync(force=True)
 
         self.init_session()
 
@@ -394,7 +398,8 @@ class SSHEnvironment(BaseEnvironment):
 
     def _before_execute(self) -> None:
         """Sync files to remote via FileSyncManager (rate-limited internally)."""
-        self._sync_manager.sync()
+        if self._sync_manager is not None:
+            self._sync_manager.sync()
 
     # ------------------------------------------------------------------
     # Execution
@@ -404,13 +409,62 @@ class SSHEnvironment(BaseEnvironment):
                   timeout: int = 120,
                   stdin_data: str | None = None) -> subprocess.Popen:
         """Spawn an SSH process that runs bash on the remote host."""
+        run_dir = f"{self._remote_home}/.hermes/run"
+        pid_file = f"{run_dir}/{uuid.uuid4().hex}.pid"
+        quoted_command = shlex.quote(cmd_string)
+        quoted_run_dir = shlex.quote(run_dir)
+        quoted_pid_file = shlex.quote(pid_file)
+        remote = (
+            f"mkdir -p {quoted_run_dir} || exit 125; "
+            "if command -v setsid >/dev/null 2>&1; then "
+            f"setsid /bin/bash -c {quoted_command} & child=$!; "
+            "elif command -v python3 >/dev/null 2>&1; then "
+            "python3 -c 'import os,sys; os.setsid(); "
+            "os.execv(\"/bin/bash\", [\"bash\", \"-c\", sys.argv[1]])' "
+            f"{quoted_command} & child=$!; "
+            "else echo 'remote process-group support unavailable' >&2; exit 126; fi; "
+            f"printf '%s\\n' \"$child\" > {quoted_pid_file}; "
+            "wait \"$child\"; rc=$?; "
+            f"rm -f {quoted_pid_file}; exit \"$rc\""
+        )
         cmd = self._build_ssh_command()
         if login:
-            cmd.extend(["bash", "-l", "-c", shlex.quote(cmd_string)])
+            cmd.extend(["bash", "-l", "-c", shlex.quote(remote)])
         else:
-            cmd.extend(["bash", "-c", shlex.quote(cmd_string)])
+            cmd.extend(["bash", "-c", shlex.quote(remote)])
 
-        return _popen_bash(cmd, stdin_data)
+        process = _popen_bash(cmd, stdin_data)
+        process._hermes_remote_pid_file = pid_file
+        return process
+
+    def _kill_process(self, proc):
+        """Stop the tracked remote process group before closing local SSH."""
+        pid_file = getattr(proc, "_hermes_remote_pid_file", None)
+        if pid_file:
+            quoted_pid_file = shlex.quote(pid_file)
+            cleanup = (
+                f"pid_file={quoted_pid_file}; "
+                "if [ -f \"$pid_file\" ]; then pid=$(cat \"$pid_file\"); "
+                "case \"$pid\" in ''|*[!0-9]*) exit 125;; esac; "
+                "kill -TERM -- \"-$pid\" 2>/dev/null || true; sleep 1; "
+                "kill -KILL -- \"-$pid\" 2>/dev/null || true; "
+                "rm -f \"$pid_file\"; fi"
+            )
+            command = self._build_ssh_command()
+            command.extend(["bash", "-c", shlex.quote(cleanup)])
+            try:
+                subprocess.run(
+                    command,
+                    capture_output=True,
+                    text=True,
+                    encoding="utf-8",
+                    errors="replace",
+                    timeout=5,
+                    stdin=subprocess.DEVNULL,
+                )
+            except (OSError, subprocess.SubprocessError):
+                logger.warning("SSH: remote process cleanup could not be confirmed")
+        super()._kill_process(proc)
 
     def cleanup(self):
         if self._sync_manager:

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -3257,6 +3257,9 @@ class ShellFileOperations(FileOperations):
         elif output_mode == "count":
             cmd_parts.append("-c")  # Count per file
         
+        # End option parsing before the user pattern so values such as
+        # ``--state`` are searched as data instead of interpreted as rg flags.
+        cmd_parts.append("--")
         # Add pattern and path
         cmd_parts.append(self._escape_shell_arg(pattern))
         # rg is a native Windows binary when installed via winget/cargo/choco:
@@ -3413,6 +3416,9 @@ class ShellFileOperations(FileOperations):
         elif output_mode == "count":
             cmd_parts.append("-c")
         
+        # End option parsing before the user pattern so leading-hyphen values
+        # remain search data for the grep fallback as well.
+        cmd_parts.append("--")
         # Add pattern and path. grep applies --exclude-dir to the command-line
         # search root too, so passing the default relative root ``.`` causes
         # ``.*`` to exclude the entire search. Anchor relative paths at the

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1858,6 +1858,9 @@ def _get_env_config() -> Dict[str, Any]:
             "TERMINAL_SSH_PERSISTENT",
             os.getenv("TERMINAL_PERSISTENT_SHELL", "true"),
         ).lower() in {"true", "1", "yes"},
+        "ssh_file_sync": os.getenv(
+            "TERMINAL_SSH_FILE_SYNC", "true"
+        ).lower() in {"true", "1", "yes"},
         "local_persistent": os.getenv("TERMINAL_LOCAL_PERSISTENT", "false").lower() in {"true", "1", "yes"},
         # Container resource config (applies to docker, singularity, modal,
         # daytona, and vercel_sandbox -- ignored for local/ssh)
@@ -1915,6 +1918,7 @@ def _ssh_config_from_config(config: Dict[str, Any]) -> dict:
         "port": config.get("ssh_port", 22),
         "key": config.get("ssh_key", ""),
         "persistent": config.get("ssh_persistent", False),
+        "file_sync": config.get("ssh_file_sync", True),
     }
 
 
@@ -2127,6 +2131,7 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
             user=ssh_config["user"],
             port=ssh_config.get("port", 22),
             key_path=ssh_config.get("key", ""),
+            file_sync=ssh_config.get("file_sync", True),
             cwd=cwd,
             timeout=timeout,
         )


### PR DESCRIPTION
## Summary

- allow SSH profiles backed by an authoritative remote workspace to disable Hermes file sync through normal config propagation
- treat leading-hyphen file-search patterns as data for both ripgrep and grep
- run remote commands in tracked process groups and terminate those groups on timeout or interruption before closing local SSH

## Validation

- `scripts/run_tests.sh tests/tools/test_ssh_environment.py tests/tools/test_search_error_guard.py tests/tools/test_sync_back_backends.py tests/tools/test_ssh_bulk_upload.py -q`
- 46 passed, 5 skipped
- additional behavior test proves `terminal.ssh_file_sync: false` reaches the SSH environment without scanning or writing remote Hermes files

Two unrelated tests on the source checkout remain red before and after this change: a config-map source-inspection test depends on separate uncommitted `cli.py` changes in the running host checkout, and a macOS local-process fixture cannot observe its `sleep 30` child. Neither path is changed here.