### PR TITLE
fix(auxiliary): resolve ZAI vision fallback endpoints from detected endpoint

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -7548,9 +7548,30 @@ def resolve_vision_provider_client(
     # The Anthropic wire rejects max_tokens on multimodal calls (error 1210),
     # while the OpenAI wire handles it correctly.
     if requested == "zai" and not resolved_base_url:
-        zai_openai_urls = [
+        # Candidate OpenAI-wire endpoints, most preferred first. The
+        # coding-plan endpoint is tried first because accounts on a GLM
+        # Coding Plan subscription get 1113 ("Insufficient balance") on the
+        # pay-as-you-go endpoints — while pay-as-you-go keys work there and
+        # are rejected on /coding/. Users with an explicit base_url in
+        # config (resolved_base_url) never reach this block.
+        try:
+            from hermes_cli.auth import _resolve_zai_base_url
+            zai_openai_urls = []
+            _detected = _resolve_zai_base_url(resolved_api_key or "", "", "")
+            if _detected:
+                zai_openai_urls.append(_detected)
+        except Exception:
+            zai_openai_urls = []
+        zai_openai_urls += [
+            "https://api.z.ai/api/coding/paas/v4",
             "https://open.bigmodel.cn/api/paas/v4",
             "https://api.z.ai/api/paas/v4",
+        ]
+        # De-duplicate while preserving order.
+        _seen = set()
+        zai_openai_urls = [
+            u for u in zai_openai_urls
+            if not (u in _seen or _seen.add(u))
         ]
         for _zai_url in zai_openai_urls:
             client, final_model = _get_cached_client(


### PR DESCRIPTION
## Root cause

ZAI vision auxiliary with no explicit `base_url` tried only the two pay-as-you-go endpoints:

```python
zai_openai_urls = [
    "https://open.bigmodel.cn/api/paas/v4",
    "https://api.z.ai/api/paas/v4",
]
```

GLM **Coding Plan** subscriptions get `429 code 1113 — Insufficient balance` on the pay-as-you-go endpoints, so vision was permanently broken for coding-plan users while chat/delegation worked fine on `/api/coding/paas/v4`. Symptom: `vision_analyze` fails with error `1210` / `1113` depending on which endpoint rejected the call.

Additionally, on the coding-plan endpoint, `glm-5.2` is text-only (rejects `image_url` content with error `1210`); `glm-5v-turbo` is the vision model. That part is config-level (`auxiliary.vision.model`), not fixed by this patch.

## Fix

Try the cached `detected_endpoint` from auth.json first (already probed and persisted by `hermes setup` — see `_resolve_zai_base_url`), then the coding-plan endpoint, then the original pay-as-you-go list. Explicit `base_url` in config still wins (unchanged). De-duplicated, order preserved.

## Proof (RED → GREEN)

**RED (before):** with a coding-plan key, `vision_analyze` on a PNG failed with 429/1113 (pay-as-you-go rejects the key) or 1210 (wrong wire/model).

Direct API probes with the same key:
- `POST /api/paas/v4/chat/completions` glm-5.2 → `429 1113 Insufficient balance`
- `POST /api/coding/paas/v4` glm-5.2 + image → `400 1210 content.type invalid` (text-only there)
- `POST /api/coding/paas/v4` **glm-5v-turbo + image → 200 ✅**

**GREEN (after):** fresh process resolves `_resolve_zai_base_url(key, '', '')` → `https://api.z.ai/api/coding/paas/v4` from the auth.json cache, so the vision client now lands on the endpoint that accepts the key.

## Notes

- No core tool schema change; behavior only in the zai vision fallback path.
- Pay-as-you-go users are unaffected: their detected endpoint / successful probe still resolves to `/api/paas/v4` and is tried first.
- Verified live on v0.20.6 (a24c12d).