### PR TITLE
fix(cron): resolve profile store paths per call

### DIFF
--- a/cron/notepad.py
+++ b/cron/notepad.py
@@ -26,21 +26,32 @@ from __future__ import annotations
 import sqlite3
 import threading
 from contextlib import contextmanager
+from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional
 
 from hermes_constants import get_hermes_home
 from hermes_time import now as _hermes_now
 
-NOTEPAD_FILE = get_hermes_home().resolve() / "cron" / "notepad.db"
+# Optional test override. Production resolves the path at transaction time so
+# multiplexed profile ticks (set_hermes_home_override) cannot leak one
+# profile's notepad rows into the import-time home — and remove_job's
+# clear_notepad cannot wipe the wrong profile's DB (#86519). Same pattern as
+# cron/executions.py.
+NOTEPAD_FILE: Optional[Path] = None
 MAX_VALUE_BYTES = 16 * 1024
 MAX_KEY_CHARS = 128
 MAX_JOB_TOTAL_BYTES = 64 * 1024
 _lock = threading.RLock()
 
 
+def _current_notepad_file() -> Path:
+    return NOTEPAD_FILE or (get_hermes_home().resolve() / "cron" / "notepad.db")
+
+
 def _connect() -> sqlite3.Connection:
-    NOTEPAD_FILE.parent.mkdir(parents=True, exist_ok=True)
-    return sqlite3.connect(NOTEPAD_FILE, timeout=5)
+    path = _current_notepad_file()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return sqlite3.connect(path, timeout=5)
 
 
 def _initialize_schema(conn: sqlite3.Connection) -> None:
@@ -155,7 +166,7 @@ def clear_notepad(job_id: str) -> int:
     Called from ``cron.jobs.remove_job`` so deleted jobs don't orphan their
     rows. No-ops without creating the DB when no notepad file exists yet.
     """
-    if not NOTEPAD_FILE.exists():
+    if not _current_notepad_file().exists():
         return 0
     with _transaction() as conn:
         cur = conn.execute(

--- a/cron/suggestions.py
+++ b/cron/suggestions.py
@@ -46,11 +46,10 @@ logger = logging.getLogger(__name__)
 # profile's cron store. Anchor on get_hermes_home() (profile home), not the
 # shared default root. See cron/jobs.py for the full rationale.
 #
-# Optional test overrides. Production resolves the path at call time so
+# Optional test override. Production resolves the path at call time so
 # multiplexed profile ticks (set_hermes_home_override) cannot leak one
 # profile's suggestions into the import-time home (#86519). Same pattern as
 # cron/executions.py.
-CRON_DIR: Optional[Path] = None
 SUGGESTIONS_FILE: Optional[Path] = None
 
 

--- a/cron/suggestions.py
+++ b/cron/suggestions.py
@@ -45,8 +45,17 @@ logger = logging.getLogger(__name__)
 # Per-profile by design (issue #4707): suggestions live alongside the active
 # profile's cron store. Anchor on get_hermes_home() (profile home), not the
 # shared default root. See cron/jobs.py for the full rationale.
-CRON_DIR = get_hermes_home().resolve() / "cron"
-SUGGESTIONS_FILE = CRON_DIR / "suggestions.json"
+#
+# Optional test overrides. Production resolves the path at call time so
+# multiplexed profile ticks (set_hermes_home_override) cannot leak one
+# profile's suggestions into the import-time home (#86519). Same pattern as
+# cron/executions.py.
+CRON_DIR: Optional[Path] = None
+SUGGESTIONS_FILE: Optional[Path] = None
+
+
+def _current_suggestions_file() -> Path:
+    return SUGGESTIONS_FILE or (get_hermes_home().resolve() / "cron" / "suggestions.json")
 
 # In-process lock protecting load->modify->save cycles (the background review
 # fork and the main agent can both write).
@@ -70,14 +79,15 @@ def _secure_file(path: Path) -> None:
 
 
 def _ensure_dir() -> None:
-    CRON_DIR.mkdir(parents=True, exist_ok=True)
+    _current_suggestions_file().parent.mkdir(parents=True, exist_ok=True)
 
 
 def _load_raw() -> Dict[str, Any]:
-    if not SUGGESTIONS_FILE.exists():
+    suggestions_file = _current_suggestions_file()
+    if not suggestions_file.exists():
         return {"suggestions": []}
     try:
-        with open(SUGGESTIONS_FILE, "r", encoding="utf-8") as f:
+        with open(suggestions_file, "r", encoding="utf-8") as f:
             data = json.load(f)
     except (json.JSONDecodeError, OSError) as e:
         logger.warning("suggestions.json unreadable (%s); starting empty", e)
@@ -92,7 +102,8 @@ def _load_raw() -> Dict[str, Any]:
 
 def _save_raw(suggestions: List[Dict[str, Any]]) -> None:
     _ensure_dir()
-    fd, tmp_path = tempfile.mkstemp(dir=str(SUGGESTIONS_FILE.parent), suffix=".tmp", prefix=".sugg_")
+    suggestions_file = _current_suggestions_file()
+    fd, tmp_path = tempfile.mkstemp(dir=str(suggestions_file.parent), suffix=".tmp", prefix=".sugg_")
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             json.dump(
@@ -102,8 +113,8 @@ def _save_raw(suggestions: List[Dict[str, Any]]) -> None:
             )
             f.flush()
             os.fsync(f.fileno())
-        atomic_replace(tmp_path, SUGGESTIONS_FILE)
-        _secure_file(SUGGESTIONS_FILE)
+        atomic_replace(tmp_path, suggestions_file)
+        _secure_file(suggestions_file)
     except BaseException:
         try:
             os.unlink(tmp_path)

--- a/tests/cron/test_notepad.py
+++ b/tests/cron/test_notepad.py
@@ -8,6 +8,7 @@ use the notepad, and the `hermes cron notepad` CLI handler.
 from __future__ import annotations
 
 import argparse
+import importlib
 import sys
 from pathlib import Path
 
@@ -101,6 +102,33 @@ class TestNotepadCrud:
         (remove_job calls clear_notepad unconditionally)."""
         assert notepad.clear_notepad("never-used") == 0
         assert not notepad.NOTEPAD_FILE.exists()
+
+
+class TestNotepadProfileIsolation:
+    def test_profile_override_routes_writes_to_current_home(self, tmp_path):
+        from hermes_constants import (
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+        import cron.notepad as notepad_mod
+
+        profile_a = tmp_path / "profile-a"
+        profile_b = tmp_path / "profile-b"
+
+        import_token = set_hermes_home_override(profile_a)
+        try:
+            importlib.reload(notepad_mod)
+        finally:
+            reset_hermes_home_override(import_token)
+
+        runtime_token = set_hermes_home_override(profile_b)
+        try:
+            notepad_mod.set_note("job-1", "cursor", "page=7")
+        finally:
+            reset_hermes_home_override(runtime_token)
+
+        assert (profile_b / "cron" / "notepad.db").exists()
+        assert not (profile_a / "cron" / "notepad.db").exists()
 
 
 class TestJobRemovalCleanup:

--- a/tests/cron/test_suggestions.py
+++ b/tests/cron/test_suggestions.py
@@ -19,7 +19,6 @@ def store(tmp_path, monkeypatch):
     home = tmp_path / ".hermes"
     home.mkdir()
     monkeypatch.setenv("HERMES_HOME", str(home))
-    # Reload so module-level CRON_DIR/SUGGESTIONS_FILE pick up the temp home.
     import hermes_constants
     importlib.reload(hermes_constants)
     import cron.suggestions as s
@@ -38,6 +37,31 @@ def _add(store, key="k1", title="Test", source="catalog", schedule="0 9 * * *"):
 
 
 class TestStore:
+    def test_profile_override_routes_writes_to_current_home(self, tmp_path):
+        from hermes_constants import (
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+        import cron.suggestions as suggestions_mod
+
+        profile_a = tmp_path / "profile-a"
+        profile_b = tmp_path / "profile-b"
+
+        import_token = set_hermes_home_override(profile_a)
+        try:
+            importlib.reload(suggestions_mod)
+        finally:
+            reset_hermes_home_override(import_token)
+
+        runtime_token = set_hermes_home_override(profile_b)
+        try:
+            _add(suggestions_mod, key="profile-b")
+        finally:
+            reset_hermes_home_override(runtime_token)
+
+        assert (profile_b / "cron" / "suggestions.json").exists()
+        assert not (profile_a / "cron" / "suggestions.json").exists()
+
     def test_add_and_list_pending(self, store):
         rec = _add(store)
         assert rec is not None

--- a/tests/cron/test_suggestions.py
+++ b/tests/cron/test_suggestions.py
@@ -37,6 +37,26 @@ def _add(store, key="k1", title="Test", source="catalog", schedule="0 9 * * *"):
 
 
 class TestStore:
+    def test_explicit_file_override_wins_over_profile_home(self, tmp_path, monkeypatch):
+        from hermes_constants import (
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+        import cron.suggestions as suggestions_mod
+
+        explicit_file = tmp_path / "explicit" / "suggestions.json"
+        profile_home = tmp_path / "profile"
+        monkeypatch.setattr(suggestions_mod, "SUGGESTIONS_FILE", explicit_file)
+
+        token = set_hermes_home_override(profile_home)
+        try:
+            _add(suggestions_mod, key="explicit-file")
+        finally:
+            reset_hermes_home_override(token)
+
+        assert explicit_file.exists()
+        assert not (profile_home / "cron" / "suggestions.json").exists()
+
     def test_profile_override_routes_writes_to_current_home(self, tmp_path):
         from hermes_constants import (
             reset_hermes_home_override,


### PR DESCRIPTION
## Summary

- resolve `notepad.db` and `suggestions.json` from the active profile home at operation time instead of freezing the import-time home
- preserve explicit `NOTEPAD_FILE` and `SUGGESTIONS_FILE` test/caller overrides
- add regressions for import-under-profile-A followed by write-under-profile-B, plus explicit suggestions-file precedence

This fixes the remaining affected stores from #86519. `cron/executions.py` already resolves its path at call time on current `main`.

## Related work and credit

- #74017 overlaps on `cron/suggestions.py`, but does not cover `cron/notepad.py` and was authored against older execution-ledger code. This PR is rebased onto current `main` and keeps the remaining fix focused on notepad/suggestions.
- The implementation commit was salvaged from the first commit of closed, unmerged #87623 and retains @wanliqin as its author. The follow-up commit removes a misleading unused override and adds regression coverage.

Fixes #86519

## Validation

- focused profile-routing and explicit-override tests: `3 passed`
- complete changed test files: `45 passed`
- Ruff on changed files: passed
- `py_compile` on changed files: passed
- `ty` on changed source files: passed
- `git diff --check`: passed
- manual import-under-A/write-under-B probe: only profile B received `notepad.db` and `suggestions.json`

Five independent pre-PR review lanes (goal alignment, runtime QA, code quality, security, and upstream overlap) passed on commit `cd5e6b1fda3ed2667516b1d0ea88490f8518cfc6`.