### PR TITLE
fix: preserve literal underscores in Slack rich headers

### DIFF
--- a/plugins/platforms/slack/block_kit.py
+++ b/plugins/platforms/slack/block_kit.py
@@ -75,8 +75,12 @@ def _indent_level(spaces: str) -> int:
 # Order matters: code first (opaque), then links, then emphasis.
 _INLINE_CODE_RE = re.compile(r"`([^`]+)`")
 _LINK_RE = re.compile(r"(?<!!)\[([^\]]+)\]\(([^()\s]+(?:\([^()]*\)[^()\s]*)*)\)")
-_BOLD_RE = re.compile(r"(?:\*\*|__)(.+?)(?:\*\*|__)")
-_ITALIC_RE = re.compile(r"(?<![\*_])(?:\*|_)(?![\*_\s])(.+?)(?<![\*_\s])(?:\*|_)(?![\*_])")
+_BOLD_STAR_RE = re.compile(r"(?<!\*)\*\*(?!\s)(.+?)(?<!\s)\*\*(?!\*)")
+_BOLD_UNDERSCORE_RE = re.compile(
+    r"(?<![\w_])__(?!\s)(.+?)(?<!\s)__(?![\w_])"
+)
+_ITALIC_STAR_RE = re.compile(r"(?<!\*)\*(?![\*\s])(.+?)(?<![\*\s])\*(?!\*)")
+_ITALIC_UNDERSCORE_RE = re.compile(r"(?<![\w_])_(?![_\s])(.+?)(?<![_\s])_(?![\w_])")
 _STRIKE_RE = re.compile(r"~~(.+?)~~")
 
 
@@ -126,7 +130,13 @@ def _inline_elements(text: str) -> List[Dict[str, Any]]:
         if not s:
             return
         # Try bold, then strike, then italic, recursing into the inner span.
-        for rx, key in ((_BOLD_RE, "bold"), (_STRIKE_RE, "strike"), (_ITALIC_RE, "italic")):
+        for rx, key in (
+            (_BOLD_STAR_RE, "bold"),
+            (_BOLD_UNDERSCORE_RE, "bold"),
+            (_STRIKE_RE, "strike"),
+            (_ITALIC_STAR_RE, "italic"),
+            (_ITALIC_UNDERSCORE_RE, "italic"),
+        ):
             m = rx.search(s)
             if m:
                 _walk_emphasis(s[:m.start()], style)
@@ -164,9 +174,13 @@ def _nonempty_elements(elements: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
 
 
 def _header_block(text: str) -> Optional[Block]:
-    # header blocks are plain_text only, 150 char cap.
-    clean = re.sub(r"[*_~`]", "", text).strip()
-    if not clean:
+    # Header blocks accept plain_text only. Reuse the inline parser so paired
+    # Markdown delimiters are removed without deleting literal identifier
+    # characters such as the underscore in ``SERVICE_US``.
+    clean = "".join(
+        str(element.get("text", "")) for element in _inline_elements(text)
+    ).strip()
+    if not clean or not re.sub(r"[*_~`]", "", clean).strip():
         # Emphasis-/whitespace-only header (e.g. "# ***" or "#   ") reduces to
         # empty; Slack rejects an empty plain_text with invalid_blocks. Skip it
         # (caller drops None) rather than poison the whole payload.

--- a/tests/gateway/test_slack_block_kit.py
+++ b/tests/gateway/test_slack_block_kit.py
@@ -25,6 +25,36 @@ class TestRenderBlocksBasics:
         assert blocks[0]["text"]["type"] == "plain_text"
         assert blocks[0]["text"]["text"] == "Title"
 
+    def test_header_preserves_literal_markup_characters(self):
+        blocks = render_blocks("# **SERVICE_US** `SA-03` _current status_")
+
+        assert blocks is not None
+        assert blocks[0]["text"]["text"] == "SERVICE_US SA-03 current status"
+
+    def test_header_does_not_treat_identifier_underscores_as_emphasis(self):
+        blocks = render_blocks("# SERVICE_US_EAST")
+
+        assert blocks is not None
+        assert blocks[0]["text"]["text"] == "SERVICE_US_EAST"
+
+    def test_header_does_not_treat_double_identifier_underscores_as_strong(self):
+        blocks = render_blocks("# SERVICE__US__EAST")
+
+        assert blocks is not None
+        assert blocks[0]["text"]["text"] == "SERVICE__US__EAST"
+
+    def test_header_requires_matching_strong_delimiters(self):
+        blocks = render_blocks("# **SERVICE_US__")
+
+        assert blocks is not None
+        assert blocks[0]["text"]["text"] == "**SERVICE_US__"
+
+    def test_header_strips_valid_underscore_strong_markup(self):
+        blocks = render_blocks("# __current status__")
+
+        assert blocks is not None
+        assert blocks[0]["text"]["text"] == "current status"
+
 
 class TestNestedLists:
     def test_nested_bullets_produce_increasing_indent(self):


### PR DESCRIPTION
## Summary
- flatten Slack rich header Markdown through the existing inline parser instead of deleting every marker character
- preserve single and double underscores inside identifiers while still parsing valid `_italic_` and `__strong__` spans
- require matching strong delimiters so malformed `**...__` text remains literal

## Problem
Slack `rich_blocks` headers use `plain_text`. The previous conversion removed `*`, `_`, `~`, and backticks unconditionally, so identifiers such as `SERVICE_US` became `SERVICEUS`. It also treated intraword `SERVICE__US__EAST` as strong markup.

## Approach
The header path now reuses `_inline_elements()` to keep visible text while removing valid Markdown wrappers. The inline emphasis regexes are split by marker so underscore delimiters follow word-boundary rules and strong delimiters must match.

## Verification
- `scripts/run_tests.sh tests/gateway/test_slack*.py` — 461 passed
- `uv run --locked --extra dev --extra messaging ruff check plugins/platforms/slack/block_kit.py tests/gateway/test_slack_block_kit.py`
- independent regression review: no security or logic findings
