### PR TITLE
feat(anthropic): opt-in 1M context for self-hosted gateways via config

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -389,6 +389,9 @@ _COMMON_BETAS = [
 _TOOL_STREAMING_BETA = "fine-grained-tool-streaming-2025-05-14"
 # 1M context beta. Native Anthropic does not get this by default because some
 # subscriptions reject it, but Bedrock/Azure still need it for 1M context.
+# Self-hosted / corporate Anthropic-Messages gateways (e.g. company LLM
+# proxies that front Claude with their own auth scheme) typically gate 1M
+# behind this same header — opt them in via ``HERMES_ANTHROPIC_CONTEXT_1M=1``.
 _CONTEXT_1M_BETA = "context-1m-2025-08-07"
 
 # Fast mode beta — enables the ``speed: "fast"`` request parameter for
@@ -669,8 +672,47 @@ def _requires_bearer_auth(base_url: str | None) -> bool:
     )
 
 
+def _force_context_1m_beta() -> bool:
+    """Return True when ``model.context_1m_beta`` is enabled in config.yaml.
+
+    Self-hosted / corporate Anthropic-Messages gateways (e.g. internal
+    LLM proxies that front Claude with a custom auth scheme) typically
+    expose 1M context behind the same ``anthropic-beta:
+    context-1m-2025-08-07`` header that Anthropic's own API uses, but
+    Hermes only auto-attaches the beta on hosts the adapter recognises
+    (Azure Foundry, Bedrock).
+
+    Config::
+
+        # ~/.hermes/config.yaml
+        model:
+          context_1m_beta: true
+    """
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+        model_cfg = cfg.get("model", {}) if isinstance(cfg, dict) else {}
+        val = model_cfg.get("context_1m_beta", False)
+        if isinstance(val, bool):
+            return val
+        if isinstance(val, str):
+            return val.strip().lower() in ("1", "true", "yes", "on")
+        return bool(val)
+    except Exception:
+        return False
+
+
 def _base_url_needs_context_1m_beta(base_url: str | None) -> bool:
-    """Return True for endpoints that still gate 1M context behind a beta."""
+    """Return True for endpoints that still gate 1M context behind a beta.
+
+    Honours the ``HERMES_ANTHROPIC_CONTEXT_1M`` env switch so that
+    self-hosted / corporate Anthropic-Messages gateways can opt their
+    requests in without per-host wiring. The drop_context_1m_beta path
+    in ``_common_betas_for_base_url`` still wins, so reactive recovery
+    after a 400 keeps working.
+    """
+    if _force_context_1m_beta():
+        return True
     normalized = _normalize_base_url_text(base_url).lower()
     if not normalized:
         return False

--- a/website/docs/guides/anthropic-corp-gateway-1m-context.md
+++ b/website/docs/guides/anthropic-corp-gateway-1m-context.md
@@ -1,0 +1,140 @@
+---
+sidebar_position: 18
+title: "Self-hosted Anthropic gateways: 1M context"
+description: "Enable Claude's 1M-token context window on corporate / self-hosted Anthropic-Messages gateways via config.yaml."
+---
+
+# Self-hosted Anthropic gateways: 1M context
+
+Hermes Agent talks the Anthropic Messages protocol to a number of endpoints
+beyond `api.anthropic.com` — AWS Bedrock, Microsoft Foundry, MiniMax, Kimi
+`/coding`, DeepSeek `/anthropic`, and arbitrary self-hosted / corporate
+gateways that front Claude with their own auth scheme. Most of those paths
+opt in or out of Anthropic's `context-1m-2025-08-07` beta on a per-host
+basis, but **arbitrary corporate gateways are not on the host allow-list**,
+so by default they only get the 200K-token short-context behaviour.
+
+The `context_1m_beta` config option lets you opt those gateways in
+without per-host wiring.
+
+## When to use this
+
+You need this if your gateway:
+
+- Speaks the Anthropic Messages protocol at `POST /v1/messages`
+- Authenticates via `x-api-key` or `Authorization: Bearer` with a non-Anthropic key
+- Gates 1M context behind the standard `anthropic-beta: context-1m-2025-08-07`
+  header (the same beta Anthropic's own API uses)
+- Is **not** Anthropic, AWS Bedrock, Microsoft Foundry, or MiniMax — those
+  paths are already auto-detected
+
+A typical example is a corporate LLM proxy that fronts Claude behind a
+non-Anthropic key prefix (`bsk-…`, `corp-…`, etc.) and re-exposes the
+Anthropic Messages route. Confirm with your gateway operator that the
+underlying Claude entitlement includes 1M context for the model you plan
+to use (Opus 4.6/4.7 and Sonnet 4.6 support 1M; older Claude tiers do not).
+
+## Quick start
+
+Add `context_1m_beta: true` to the `model:` section of your config:
+
+```yaml
+# ~/.hermes/config.yaml
+model:
+  default: claude-4.6-opus
+  provider: custom
+  base_url: https://llmapi.your-corp.example/v1
+  api_key: <your-corp-api-key>
+  context_length: 1000000
+  context_1m_beta: true
+```
+
+Once set, every Anthropic-client build attaches
+`anthropic-beta: context-1m-2025-08-07` to the wire. Combined with a
+`context_length` of 1000000, Hermes' context compressor will use the full
+1M window before deciding to compact.
+
+## Why this is opt-in instead of always-on
+
+Anthropic's own subscriptions reject `context-1m-2025-08-07` for accounts
+that don't have the long-context beta enabled — every Messages call,
+including short auxiliary ones like title generation, returns HTTP 400
+"long context beta is not yet available for this subscription". Hermes
+therefore only auto-attaches the beta on hosts that are known to accept
+or require it (Bedrock, Microsoft Foundry, the upcoming GA path).
+Corporate gateways are too varied to allow-list by hostname, so they
+opt in via config.
+
+The reactive recovery path in `run_agent.py` still wins: if the upstream
+returns a 400 telling Hermes to drop the beta, it will rebuild the client
+with `drop_context_1m_beta=True` and retry, regardless of the config flag.
+This means the flag is safe to leave on globally — a gateway that later
+loses the entitlement degrades gracefully.
+
+## Model name and context_length resolution
+
+Hermes ships defaults for the canonical Anthropic model slugs (`claude-sonnet-4-6`,
+`claude-opus-4-7`, etc.) and for a few common corporate-gateway variants
+that name the model with the version before the family
+(`claude-4.6-sonnet` / `claude-4.6-opus` / `claude-4.7-opus` —
+e.g. bilibili's internal `llmapi` gateway).
+
+If your gateway exposes a model under a slug that isn't in
+`agent/model_metadata.py::DEFAULT_CONTEXT_LENGTHS`, the lookup falls back
+to the `claude` catch-all at 200K and the agent will compact early even
+when the gateway accepts 1M-context requests. Two ways to fix this:
+
+1. **One-off override** — set the model's context length explicitly via
+   `context_length: 1000000` in the `model:` section (as shown above).
+2. **Permanent fix** — open a PR adding the slug to
+   `DEFAULT_CONTEXT_LENGTHS`. The dict matches by substring so adding
+   both the dot-form and dash-form (`claude-4.6-sonnet` and
+   `claude-4-6-sonnet`) covers callers that bypass `normalize_model_name`.
+
+## Verifying the gateway accepts 1M
+
+Before turning the flag on for real workloads, sanity-check the
+gateway with a payload that exceeds 200K tokens. Anthropic's tokeniser
+treats 4 chars/token as a rough lower bound, so a ~5MB English text body
+exceeds the 200K threshold:
+
+```bash
+# 1. Without the beta header — gateway should reject the size
+curl -sS -X POST "$ANTHROPIC_BASE_URL/v1/messages" \
+  -H "x-api-key: $ANTHROPIC_AUTH_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data-binary @huge_payload.json
+# → {"error":{"type":"invalid_request_error","message":"Input is too long."}}
+
+# 2. With the beta header — gateway should accept the size
+curl -sS -X POST "$ANTHROPIC_BASE_URL/v1/messages" \
+  -H "x-api-key: $ANTHROPIC_AUTH_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "anthropic-beta: context-1m-2025-08-07" \
+  --data-binary @huge_payload.json
+# → 200 OK with usage.input_tokens > 200_000
+```
+
+If step 2 also returns "Input is too long", the gateway gates 1M behind
+something other than the standard Anthropic beta header. Open an issue
+with the gateway operator first, then with Hermes if it turns out to be
+a host family Hermes should learn.
+
+## Interaction with other beta headers
+
+`context_1m_beta` only flips `context-1m-2025-08-07`. The other betas
+Hermes attaches by default (`interleaved-thinking-2025-05-14`,
+`fine-grained-tool-streaming-2025-05-14`) are unaffected — their gating
+is host-family-specific and independent of the long-context decision.
+
+The fast-mode beta (`fast-mode-2026-02-01`, only for native Anthropic
+Opus 4.6) is also unaffected: the config flag never adds it because
+fast-mode is gated explicitly on the model name.
+
+## See also
+
+- `agent/anthropic_adapter.py::_force_context_1m_beta` — the
+  implementation hook the config flag flips.
+- [Microsoft Foundry guide](./azure-foundry.md) — the canonical example
+  of a host-family that Hermes auto-opts in (Foundry's Anthropic-style
+  endpoint always gets 1M).


### PR DESCRIPTION
## What

Add `model.context_1m_beta` config option so self-hosted / corporate Anthropic-Messages gateways can opt into the `context-1m-2025-08-07` beta header without per-host wiring.

### Changes

**`agent/anthropic_adapter.py`:**
- New `_force_context_1m_beta()` function that reads `model.context_1m_beta` from config.yaml
- Short-circuits `_base_url_needs_context_1m_beta()` to return True when the config flag is set
- The reactive `drop_context_1m_beta` recovery path after a 400 still wins — graceful degradation

**`website/docs/guides/anthropic-corp-gateway-1m-context.md`:**
- Full usage guide covering when to use, configuration, verification, and interaction with other betas

## Why

Hermes only auto-attaches the `context-1m-2025-08-07` beta on hosts it recognises (Azure Foundry, Bedrock). Corporate gateways that proxy Claude behind custom auth (e.g. `bsk-*` keys, internal LLM proxies) are not on the host allow-list, so they get stuck at 200K context even when the underlying Claude entitlement supports 1M.

This is the same class of problem as #31277 (Bedrock path), but for arbitrary self-hosted gateways.

## Config

```yaml
# ~/.hermes/config.yaml
model:
  default: claude-4.6-opus
  provider: custom
  base_url: https://llmapi.your-corp.example/v1
  api_key: <your-corp-api-key>
  context_length: 1000000
  context_1m_beta: true
```

## How to test

1. Configure a custom provider with a base_url that is NOT Anthropic/Azure/Bedrock
2. Set `context_1m_beta: true` in the model config
3. Verify that API requests include `anthropic-beta: context-1m-2025-08-07` header
4. Verify that without the flag, the header is NOT sent for that base_url

Run tests:
```bash
python -m pytest tests/agent/test_anthropic_adapter.py -q
```
All 95 tests pass.

## Platforms tested

- macOS (Apple Silicon) with corporate Anthropic-Messages proxy

## Related issues

- #31277 — same problem for Bedrock (native Converse adapter does not forward context-1m beta)
