### PR TITLE
fix(kanban): make initial blocked tasks sticky atomically

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3190,6 +3190,8 @@ def create_task(
     goal_mode: bool = False,
     goal_max_turns: Optional[int] = None,
     initial_status: str = "running",
+    block_kind: Optional[str] = None,
+    block_reason: Optional[str] = None,
     session_id: Optional[str] = None,
     board: Optional[str] = None,
     project_id: Optional[str] = None,
@@ -3227,6 +3229,11 @@ def create_task(
     (``minimal``…``ultra``, or ``none`` to disable thinking), passed as
     ``--reasoning <level>``. It is independent of ``model_override``: a task
     can run the profile's own model at a different depth.
+
+    ``initial_status='blocked'`` writes a sticky ``blocked`` event in the same
+    transaction as the task row. ``block_kind`` (one of
+    :data:`VALID_BLOCK_KINDS`) and ``block_reason`` optionally describe that
+    initial blocker; neither is accepted for another initial status.
 
     ``project_source_task_id`` is an internal cross-profile fallback for a
     worker-created child. When the active profile cannot resolve ``project_id``
@@ -3404,6 +3411,19 @@ def create_task(
             )
         skills_list = cleaned
 
+    if initial_status != "blocked":
+        if block_kind is not None or block_reason is not None:
+            raise ValueError(
+                "block_kind and block_reason require initial_status='blocked'"
+            )
+    else:
+        if block_kind is not None and block_kind not in VALID_BLOCK_KINDS:
+            raise ValueError(
+                f"block kind must be one of {sorted(VALID_BLOCK_KINDS)} or None"
+            )
+        if block_reason is not None and not isinstance(block_reason, str):
+            raise ValueError("block_reason must be a string or None")
+
     # Idempotency check — return the existing task instead of creating a
     # duplicate. Done BEFORE entering write_txn to keep the fast path fast
     # and to avoid holding a write lock during the lookup. Race is
@@ -3507,9 +3527,9 @@ def create_task(
                         branch_name, project_id, tenant, idempotency_key,
                         max_runtime_seconds,
                         skills, max_retries, model_override, provider_override,
-                        reasoning_effort,
+                        reasoning_effort, block_kind,
                         goal_mode, goal_max_turns, session_id
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         task_id,
@@ -3532,6 +3552,7 @@ def create_task(
                         model_override,
                         provider_override,
                         reasoning_effort,
+                        block_kind,
                         1 if goal_mode else 0,
                         int(goal_max_turns) if goal_max_turns is not None else None,
                         session_id,
@@ -3565,6 +3586,18 @@ def create_task(
                         "provider_override": provider_override,
                     },
                 )
+                if initial_status == "blocked":
+                    _append_event(
+                        conn,
+                        task_id,
+                        "blocked",
+                        {
+                            "reason": block_reason,
+                            "kind": block_kind,
+                            "recurrences": 0,
+                            "source_status": "ready",
+                        },
+                    )
                 _inherit_notify_subs(conn, task_id, parents, created_at=now)
             return task_id
         except sqlite3.IntegrityError:

--- a/tests/hermes_cli/test_kanban_blocked_sticky.py
+++ b/tests/hermes_cli/test_kanban_blocked_sticky.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import time
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -76,6 +77,65 @@ def test_worker_block_is_not_auto_promoted_by_recompute_ready(kanban_home: Path)
             assert kb.get_task(conn, tid).status == "blocked"
 
 
+def test_initial_block_is_sticky_and_not_auto_promoted(kanban_home: Path) -> None:
+    """An initially blocked parentless task must have a durable block event.
+
+    Without that event, ``recompute_ready`` mistakes the task for a recoverable
+    circuit-breaker block and promotes it because an empty parent set is done.
+    """
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="awaiting human ops", initial_status="blocked")
+
+        task = kb.get_task(conn, tid)
+        assert task.status == "blocked"
+        events = kb.list_events(conn, tid)
+        assert [event.kind for event in events] == ["created", "blocked"]
+
+        assert kb.recompute_ready(conn) == 0
+        assert kb.get_task(conn, tid).status == "blocked"
+
+
+def test_initial_typed_block_persists_reason_kind_and_stays_sticky(kanban_home: Path) -> None:
+    """Typed initial blocks use the same durable blocker contract as block_task."""
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="awaiting credential grant",
+            initial_status="blocked",
+            block_kind="capability",
+            block_reason="Production credential must be granted by an operator.",
+        )
+
+        task = kb.get_task(conn, tid)
+        assert task.status == "blocked"
+        assert task.block_kind == "capability"
+        blocked = [event for event in kb.list_events(conn, tid) if event.kind == "blocked"]
+        assert len(blocked) == 1
+        assert blocked[0].payload == {
+            "reason": "Production credential must be granted by an operator.",
+            "kind": "capability",
+            "recurrences": 0,
+            "source_status": "ready",
+        }
+
+        assert kb.recompute_ready(conn) == 0
+        assert kb.get_task(conn, tid).status == "blocked"
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"block_kind": "not-a-kind", "initial_status": "blocked"}, "block kind must be one of"),
+        ({"block_kind": "capability", "initial_status": "running"}, "require initial_status='blocked'"),
+        ({"block_reason": "needs approval", "initial_status": "running"}, "require initial_status='blocked'"),
+    ],
+)
+def test_initial_block_metadata_is_valid_only_for_blocked_status(
+    kanban_home: Path, kwargs: dict[str, Any], message: str,
+) -> None:
+    with kb.connect() as conn:
+        with pytest.raises(ValueError, match=message):
+            getattr(kb, "create_task")(conn, title="invalid initial block metadata", **kwargs)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -416,6 +416,44 @@ def test_create_happy_path(worker_env):
         conn.close()
 
 
+def test_create_initial_typed_block_persists_through_tool_handler(worker_env):
+    """kanban_create forwards an initial typed blocker atomically to the DB."""
+    from tools import kanban_tools as kt
+    from hermes_cli import kanban_db as kb
+
+    out = kt._handle_create({
+        "title": "await operator approval",
+        "assignee": "peer",
+        "initial_status": "blocked",
+        "block_kind": "needs_input",
+        "block_reason": "Which production tenant should be used?",
+    })
+    result = json.loads(out)
+    assert result["ok"] is True, result
+    assert result["status"] == "blocked"
+
+    conn = kb.connect()
+    try:
+        task = kb.get_task(conn, result["task_id"])
+        assert task.block_kind == "needs_input"
+        blocked = [event for event in kb.list_events(conn, task.id) if event.kind == "blocked"]
+        assert blocked[-1].payload["reason"] == "Which production tenant should be used?"
+        assert kb.recompute_ready(conn) == 0
+        assert kb.get_task(conn, task.id).status == "blocked"
+    finally:
+        conn.close()
+
+
+def test_create_schema_documents_typed_blocker_dependency():
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    properties = kt.KANBAN_CREATE_SCHEMA["parameters"]["properties"]
+    assert set(properties["block_kind"]["enum"]) == kb.VALID_BLOCK_KINDS
+    assert "initial_status is 'blocked'" in properties["block_kind"]["description"]
+    assert "initial_status is 'blocked'" in properties["block_reason"]["description"]
+
+
 def test_link_happy_path(worker_env):
     from hermes_cli import kanban_db as kb
     conn = kb.connect()

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -1397,6 +1397,8 @@ def _handle_create(args: dict, **kw) -> str:
     idempotency_key = args.get("idempotency_key")
     max_runtime_seconds = args.get("max_runtime_seconds")
     initial_status = args.get("initial_status") or "running"
+    block_kind = args.get("block_kind")
+    block_reason = args.get("block_reason")
     skills = args.get("skills")
     if isinstance(skills, str):
         # Accept a single skill name as a string for convenience.
@@ -1459,6 +1461,8 @@ def _handle_create(args: dict, **kw) -> str:
                     int(goal_max_turns) if goal_max_turns is not None else None
                 ),
                 initial_status=str(initial_status),
+                block_kind=block_kind,
+                block_reason=block_reason,
                 created_by=os.environ.get("HERMES_PROFILE") or "worker",
                 session_id=session_id,
             )
@@ -2245,6 +2249,22 @@ KANBAN_CREATE_SCHEMA = {
                     "require immediate human ops (R3 gate) to skip the "
                     "brief running-to-blocked transition. Defaults to "
                     "'running', which preserves the usual dispatch path."
+                ),
+            },
+            "block_kind": {
+                "type": "string",
+                "enum": ["dependency", "needs_input", "capability", "transient"],
+                "description": (
+                    "Optional typed reason for an initially blocked card. "
+                    "Only valid when initial_status is 'blocked'; use the same "
+                    "kinds as kanban_block. Omit for a generic sticky human blocker."
+                ),
+            },
+            "block_reason": {
+                "type": "string",
+                "description": (
+                    "Human-readable blocker reason for an initially blocked card. "
+                    "Only valid when initial_status is 'blocked'."
                 ),
             },
             "skills": {


### PR DESCRIPTION
## Summary

- make `create_task(initial_status="blocked")` emit a sticky `blocked` event in the same SQLite transaction as task creation
- add atomic `block_kind` / `block_reason` support to `kanban_create`
- persist the typed block metadata and reject block fields on non-blocked initial states

## Root cause

An initially blocked task had `status="blocked"` but no `blocked` event. `recompute_ready()` deliberately treats event-less blocked rows as recoverable legacy/circuit-breaker state, so a parentless task could be promoted to `ready` and dispatched. Trying to create in `triage` and block in a second call leaves a race window for auto-decomposition.

This change makes the intended human/capability block durable at creation time, while preserving generic initial blocks and idempotent retries.

## Verification

- RED reproduced: event sequence was `["created"]`, not `["created", "blocked"]`
- targeted Kanban suites: **74 passed, 1 skipped**
- independent review: PASS, including injected blocked-event write failure with full transaction rollback
- `compileall` and `git diff --check`: PASS
- static scan: no secrets, shell injection, eval/exec, pickle, or raw SQL interpolation

No runtime configuration or external provider behavior is changed.