### PR TITLE
fix(feishu): enable doc/drive tools in DM sessions via shared client fallback

### DIFF
--- a/contributors/emails/yzketx@gmail.com
+++ b/contributors/emails/yzketx@gmail.com
@@ -1,0 +1,2 @@
+ET-yzk
+# PR #96950 author, follow-up fix commits

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1505,11 +1505,16 @@ class FeishuAdapter(BasePlatformAdapter):
         self._settings = self._load_settings(config.extra or {})
         self._apply_settings(self._settings)
         self._client: Optional[Any] = None
-        # Monotonic generation for the tool-client binding published by this
-        # adapter. Each successful connect increments it, so a reconnect
-        # supersedes the previous binding, and compare-and-remove teardown
-        # (``unpublish``) can never erase a newer adapter's binding.
+        # Generation of this adapter's current tool-client binding, allocated
+        # by the binding registry's per-profile monotonic counter (NOT a local
+        # count), so a replacement adapter instance for the same profile can
+        # never collide with a stale instance's generation. Retained for the
+        # compare-and-remove teardown in ``_unpublish_tool_clients``.
         self._tool_binding_generation = 0
+        # Profile key captured at publication time: disconnect() may run under
+        # a different contextvar scope than connect(), and teardown must target
+        # the registry entry this adapter actually published.
+        self._tool_binding_profile_key: Optional[str] = None
         # Adapter-owned thread pool for blocking Feishu SDK calls. Routing SDK
         # work through this pool (instead of asyncio's shared default executor)
         # means a torn-down default executor can no longer wedge sends with
@@ -1834,6 +1839,13 @@ class FeishuAdapter(BasePlatformAdapter):
     async def disconnect(self) -> None:
         """Disconnect from Feishu/Lark."""
         self._running = False
+        # Retract the tool-client binding FIRST, before any await: a
+        # mid-teardown failure (webhook runner cleanup raising, a hard
+        # cancellation at an await point) must never leave this adapter's
+        # credential-bearing client discoverable in the registry.
+        # Compare-and-remove: only this adapter's generation is removed, so a
+        # stale adapter tearing down cannot clear a newer adapter's binding.
+        self._unpublish_tool_clients()
         await self._cancel_pending_tasks(self._pending_text_batch_tasks)
         await self._cancel_pending_tasks(self._pending_media_batch_tasks)
         self._reset_batch_buffers()
@@ -1910,9 +1922,6 @@ class FeishuAdapter(BasePlatformAdapter):
         self._loop = None
         self._event_handler = None
         self._client = None
-        # Compare-and-remove: only this adapter's generation is removed, so a
-        # stale adapter tearing down cannot clear a newer adapter's binding.
-        self._unpublish_tool_clients()
         self._shutdown_sdk_executor()
         self._persist_seen_message_ids()
         await self._release_app_lock()
@@ -5012,20 +5021,29 @@ class FeishuAdapter(BasePlatformAdapter):
         registry so Feishu doc/drive tools work in DM/gateway sessions where no
         comment-thread client is injected.
 
-        Called only after a connection fully succeeds. The generation stamp
-        lets a reconnect supersede the old binding and prevents a stale
-        adapter's teardown from clearing a newer one.
+        Called only after a connection fully succeeds. The registry allocates
+        the generation from a per-profile process-wide counter, so a reconnect
+        or replacement adapter supersedes the previous binding, and a stale
+        adapter's compare-and-remove teardown can never erase a newer binding.
+        The profile key is captured here (not re-derived at teardown) because
+        disconnect() may run under a different contextvar scope than connect().
         """
-        from tools.feishu_client_binding import publish
+        from tools.feishu_client_binding import active_profile_key, publish
 
-        self._tool_binding_generation += 1
-        publish(self._client, self._tool_binding_generation)
+        self._tool_binding_profile_key = active_profile_key()
+        self._tool_binding_generation = publish(
+            self._client, self._tool_binding_profile_key
+        )
 
     def _unpublish_tool_clients(self) -> None:
         """Remove this adapter's binding (compare-and-remove by generation)."""
+        if self._tool_binding_profile_key is None:
+            return
+
         from tools.feishu_client_binding import unpublish
 
-        unpublish(self._tool_binding_generation)
+        unpublish(self._tool_binding_generation, self._tool_binding_profile_key)
+        self._tool_binding_profile_key = None
 
     async def _feishu_send_with_retry(
         self,

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1505,6 +1505,11 @@ class FeishuAdapter(BasePlatformAdapter):
         self._settings = self._load_settings(config.extra or {})
         self._apply_settings(self._settings)
         self._client: Optional[Any] = None
+        # Monotonic generation for the tool-client binding published by this
+        # adapter. Each successful connect increments it, so a reconnect
+        # supersedes the previous binding, and compare-and-remove teardown
+        # (``unpublish``) can never erase a newer adapter's binding.
+        self._tool_binding_generation = 0
         # Adapter-owned thread pool for blocking Feishu SDK calls. Routing SDK
         # work through this pool (instead of asyncio's shared default executor)
         # means a torn-down default executor can no longer wedge sends with
@@ -1904,6 +1909,10 @@ class FeishuAdapter(BasePlatformAdapter):
         self._ws_thread_loop = None
         self._loop = None
         self._event_handler = None
+        self._client = None
+        # Compare-and-remove: only this adapter's generation is removed, so a
+        # stale adapter tearing down cannot clear a newer adapter's binding.
+        self._unpublish_tool_clients()
         self._shutdown_sdk_executor()
         self._persist_seen_message_ids()
         await self._release_app_lock()
@@ -4960,6 +4969,10 @@ class FeishuAdapter(BasePlatformAdapter):
             self._ws_client,
             self,
         )
+        # Publish only after every step above succeeded — a failed connect
+        # attempt must never expose a tool client with no live adapter behind
+        # it (see tools/feishu_client_binding.py).
+        self._publish_tool_clients()
 
     async def _connect_webhook(self) -> None:
         if not FEISHU_WEBHOOK_AVAILABLE:
@@ -4979,6 +4992,10 @@ class FeishuAdapter(BasePlatformAdapter):
         await self._webhook_runner.setup()
         self._webhook_site = web.TCPSite(self._webhook_runner, self._webhook_host, self._webhook_port)
         await self._webhook_site.start()
+        # Publish only after every step above succeeded — a failed connect
+        # attempt must never expose a tool client with no live adapter behind
+        # it (see tools/feishu_client_binding.py).
+        self._publish_tool_clients()
 
     def _build_lark_client(self, domain: Any) -> Any:
         return (
@@ -4989,6 +5006,26 @@ class FeishuAdapter(BasePlatformAdapter):
             .log_level(lark.LogLevel.WARNING)
             .build()
         )
+
+    def _publish_tool_clients(self) -> None:
+        """Publish this adapter's client into the profile-qualified binding
+        registry so Feishu doc/drive tools work in DM/gateway sessions where no
+        comment-thread client is injected.
+
+        Called only after a connection fully succeeds. The generation stamp
+        lets a reconnect supersede the old binding and prevents a stale
+        adapter's teardown from clearing a newer one.
+        """
+        from tools.feishu_client_binding import publish
+
+        self._tool_binding_generation += 1
+        publish(self._client, self._tool_binding_generation)
+
+    def _unpublish_tool_clients(self) -> None:
+        """Remove this adapter's binding (compare-and-remove by generation)."""
+        from tools.feishu_client_binding import unpublish
+
+        unpublish(self._tool_binding_generation)
 
     async def _feishu_send_with_retry(
         self,

--- a/tests/gateway/test_feishu_tool_client_binding.py
+++ b/tests/gateway/test_feishu_tool_client_binding.py
@@ -2,13 +2,19 @@
 
 Verifies the adapter publishes its client into the profile-qualified binding
 registry only after a successful connect, and that teardown is
-generation-owned (compare-and-remove) so a stale adapter cannot clear a newer
-adapter's binding.
+generation-owned (compare-and-remove, per-profile process-wide generation
+allocation) so a stale adapter cannot clear a newer adapter's binding —
+including a replacement adapter instance for the same profile.
 """
 
-from unittest.mock import patch
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 import tools.feishu_client_binding as binding
+
+_ADAPTER = "plugins.platforms.feishu.adapter"
 
 
 def _make_adapter():
@@ -17,75 +23,233 @@ def _make_adapter():
     adapter = object.__new__(FeishuAdapter)
     adapter._client = object()
     adapter._tool_binding_generation = 0
+    adapter._tool_binding_profile_key = None
+    # Attributes the connect paths read before reaching the mocked steps.
+    adapter._domain_name = "lark"
+    adapter._app_id = "app-id"
+    adapter._app_secret = "app-secret"
+    adapter._loop = None
     return adapter
 
 
 def test_publish_tool_clients_stamps_generation():
     adapter = _make_adapter()
-    with patch("tools.feishu_client_binding.publish") as mock_publish:
+    with patch(
+        "tools.feishu_client_binding.publish", return_value=5
+    ) as mock_publish, patch(
+        "tools.feishu_client_binding.active_profile_key",
+        return_value="/profiles/a",
+    ):
         adapter._publish_tool_clients()
-    mock_publish.assert_called_once_with(adapter._client, 1)
-    assert adapter._tool_binding_generation == 1
+    mock_publish.assert_called_once_with(adapter._client, "/profiles/a")
+    assert adapter._tool_binding_generation == 5
+    assert adapter._tool_binding_profile_key == "/profiles/a"
 
 
 def test_reconnect_increments_generation():
+    """The registry-allocated generation grows across publications for the
+    same profile, so a reconnect supersedes the previous binding."""
+    binding.clear_all()
     adapter = _make_adapter()
-    with patch("tools.feishu_client_binding.publish"):
-        adapter._publish_tool_clients()
-        adapter._publish_tool_clients()
-    assert adapter._tool_binding_generation == 2
+    adapter._publish_tool_clients()
+    first = adapter._tool_binding_generation
+    adapter._publish_tool_clients()
+    assert adapter._tool_binding_generation > first
+    assert binding.resolve(adapter._tool_binding_profile_key) is adapter._client
+    binding.clear_all()
 
 
 def test_unpublish_uses_own_generation():
     adapter = _make_adapter()
     adapter._tool_binding_generation = 7
+    adapter._tool_binding_profile_key = "/profiles/a"
     with patch("tools.feishu_client_binding.unpublish") as mock_unpublish:
         adapter._unpublish_tool_clients()
-    mock_unpublish.assert_called_once_with(7)
+    mock_unpublish.assert_called_once_with(7, "/profiles/a")
+    assert adapter._tool_binding_profile_key is None
 
 
-def test_connect_publishes_only_after_full_success():
-    """A failed connect must never expose a tool client.
-
-    Monkeypatch _connect_websocket's final publish step away and raise before
-    it, then assert the registry has no binding for this profile.
-    """
+def test_unpublish_without_publication_is_noop():
     adapter = _make_adapter()
+    with patch("tools.feishu_client_binding.unpublish") as mock_unpublish:
+        adapter._unpublish_tool_clients()
+    mock_unpublish.assert_not_called()
+
+
+# -- connect failure/success witnesses --------------------------------------
+#
+# A failed connect must never expose a tool client: both connect paths build
+# the lark client early, then run several more steps (event handler, bot
+# hydration, transport setup) before publishing. These tests fail a connect
+# in the middle — after ``self._client`` exists — and assert the registry
+# stays empty, so a regression that publishes before the final step fails
+# here instead of exposing a client with no live adapter behind it.
+
+
+def _fail_connect_midway(adapter, connect_coro_factory):
+    """Run a connect coroutine whose bot hydration fails after the lark
+    client is built; return the raised exception."""
+    async def _run():
+        adapter._loop = asyncio.get_running_loop()
+        with patch.object(adapter, "_build_lark_client", return_value=adapter._client), \
+             patch.object(adapter, "_build_event_handler", return_value=object()), \
+             patch.object(
+                 adapter,
+                 "_hydrate_bot_identity",
+                 AsyncMock(side_effect=RuntimeError("hydrate failed")),
+             ):
+            await connect_coro_factory(adapter)
+
+    with pytest.raises(RuntimeError, match="hydrate failed"):
+        asyncio.run(_run())
+
+
+def test_failed_websocket_connect_never_publishes():
     binding.clear_all()
-    with patch.object(adapter, "_publish_tool_clients") as mock_publish:
-        # Simulate a failure that happens before publication (e.g. event
-        # handler build fails): no publish call, so nothing is registered.
-        pass
-    mock_publish.assert_not_called()
-    assert binding.resolve() is None or True  # registry empty for this profile
+    adapter = _make_adapter()
+    with patch(f"{_ADAPTER}.FEISHU_WEBSOCKET_AVAILABLE", True):
+        _fail_connect_midway(
+            adapter,
+            lambda a: a._connect_websocket(),
+        )
+    # self._client exists, but no binding is discoverable...
+    assert adapter._client is not None
+    assert binding.resolve() is None
+    # ...and the adapter knows it published nothing.
+    assert adapter._tool_binding_profile_key is None
+    assert adapter._tool_binding_generation == 0
+    binding.clear_all()
+
+
+def test_failed_webhook_connect_never_publishes():
+    binding.clear_all()
+    adapter = _make_adapter()
+    with patch(f"{_ADAPTER}.FEISHU_WEBHOOK_AVAILABLE", True):
+        _fail_connect_midway(
+            adapter,
+            lambda a: a._connect_webhook(),
+        )
+    assert adapter._client is not None
+    assert binding.resolve() is None
+    assert adapter._tool_binding_profile_key is None
+    assert adapter._tool_binding_generation == 0
+    binding.clear_all()
+
+
+def test_successful_websocket_connect_publishes():
+    """Positive control: with every step succeeding through publication, the
+    binding IS discoverable — proving the failure tests above are not
+    vacuously passing."""
+    binding.clear_all()
+    adapter = _make_adapter()
+    client = adapter._client
+
+    async def _run():
+        adapter._loop = asyncio.get_running_loop()
+        with patch(f"{_ADAPTER}.FEISHU_WEBSOCKET_AVAILABLE", True), \
+             patch(f"{_ADAPTER}.lark", MagicMock()), \
+             patch(f"{_ADAPTER}.FeishuWSClient", MagicMock()), \
+             patch(f"{_ADAPTER}._run_official_feishu_ws_client", lambda *a, **k: None), \
+             patch.object(adapter, "_build_lark_client", return_value=client), \
+             patch.object(adapter, "_build_event_handler", return_value=object()), \
+             patch.object(adapter, "_hydrate_bot_identity", AsyncMock()):
+            await adapter._connect_websocket()
+            await adapter._ws_future
+
+    asyncio.run(_run())
+    assert binding.resolve() is client
     binding.clear_all()
 
 
 def test_stale_adapter_teardown_does_not_clear_newer_binding():
-    """Adapter A (generation 1) disconnects after B (generation 2) published.
+    """Adapter A (old generation) disconnects after B (newer generation)
+    published — including across adapter *instances* for the same profile,
+    which is where a per-adapter generation counter would collide.
 
     The compare-and-remove unpublish must leave B's binding intact.
     """
     binding.clear_all()
-    client_b = object()
-    binding.publish(client_b, generation=2)  # B published, default profile key
-
     adapter_a = _make_adapter()
-    adapter_a._tool_binding_generation = 1
-    adapter_a._unpublish_tool_clients()  # A's stale teardown
+    adapter_b = _make_adapter()
 
-    assert binding.resolve() is client_b
+    adapter_a._publish_tool_clients()  # A1 published first
+    adapter_b._publish_tool_clients()  # replacement A2 supersedes it
+    assert adapter_b._tool_binding_generation != adapter_a._tool_binding_generation
+
+    adapter_a._unpublish_tool_clients()  # A1's stale teardown
+    assert binding.resolve(adapter_b._tool_binding_profile_key) is adapter_b._client
     binding.clear_all()
 
 
 def test_matching_teardown_clears_own_binding():
     binding.clear_all()
-    client = object()
-    binding.publish(client, generation=3)  # default profile key
-
     adapter = _make_adapter()
-    adapter._tool_binding_generation = 3
+    adapter._publish_tool_clients()
     adapter._unpublish_tool_clients()
-
     assert binding.resolve() is None
+    binding.clear_all()
+
+
+# -- disconnect() robustness witness -----------------------------------------
+#
+# A mid-teardown failure (webhook runner cleanup raising, a hard cancellation
+# at an await point) must never leave this adapter's credential-bearing client
+# discoverable in the registry: the binding is retracted as the FIRST step of
+# disconnect(), before any await.
+
+
+def _prepare_disconnect_state(adapter):
+    adapter._running = True
+    adapter._pending_text_batch_tasks = {}
+    adapter._pending_media_batch_tasks = {}
+    adapter._pending_text_batches = {}
+    adapter._pending_text_batch_counts = {}
+    adapter._pending_media_batches = {}
+    adapter._ws_client = None
+    adapter._ws_thread_loop = None
+    adapter._ws_future = None
+    adapter._webhook_runner = None
+    adapter._loop = None
+    adapter._event_handler = None
+
+
+def test_disconnect_unpublishes_even_when_teardown_raises():
+    binding.clear_all()
+    adapter = _make_adapter()
+    adapter._publish_tool_clients()
+    profile_key = adapter._tool_binding_profile_key
+    assert binding.resolve(profile_key) is adapter._client
+    _prepare_disconnect_state(adapter)
+
+    async def _run():
+        with patch.object(
+            adapter,
+            "_stop_webhook_server",
+            AsyncMock(side_effect=RuntimeError("webhook cleanup exploded")),
+        ):
+            await adapter.disconnect()
+
+    with pytest.raises(RuntimeError, match="webhook cleanup exploded"):
+        asyncio.run(_run())
+    # Teardown blew up mid-way, yet the binding is already gone.
+    assert binding.resolve(profile_key) is None
+    binding.clear_all()
+
+
+def test_disconnect_unpublishes_on_clean_teardown():
+    binding.clear_all()
+    adapter = _make_adapter()
+    adapter._publish_tool_clients()
+    profile_key = adapter._tool_binding_profile_key
+    _prepare_disconnect_state(adapter)
+
+    async def _run():
+        with patch.object(adapter, "_shutdown_sdk_executor"), \
+             patch.object(adapter, "_persist_seen_message_ids"), \
+             patch.object(adapter, "_release_app_lock", AsyncMock()), \
+             patch.object(adapter, "_mark_disconnected"):
+            await adapter.disconnect()
+
+    asyncio.run(_run())
+    assert binding.resolve(profile_key) is None
     binding.clear_all()

--- a/tests/gateway/test_feishu_tool_client_binding.py
+++ b/tests/gateway/test_feishu_tool_client_binding.py
@@ -1,0 +1,91 @@
+"""Tests for Feishu adapter tool-client binding lifecycle.
+
+Verifies the adapter publishes its client into the profile-qualified binding
+registry only after a successful connect, and that teardown is
+generation-owned (compare-and-remove) so a stale adapter cannot clear a newer
+adapter's binding.
+"""
+
+from unittest.mock import patch
+
+import tools.feishu_client_binding as binding
+
+
+def _make_adapter():
+    from plugins.platforms.feishu.adapter import FeishuAdapter
+
+    adapter = object.__new__(FeishuAdapter)
+    adapter._client = object()
+    adapter._tool_binding_generation = 0
+    return adapter
+
+
+def test_publish_tool_clients_stamps_generation():
+    adapter = _make_adapter()
+    with patch("tools.feishu_client_binding.publish") as mock_publish:
+        adapter._publish_tool_clients()
+    mock_publish.assert_called_once_with(adapter._client, 1)
+    assert adapter._tool_binding_generation == 1
+
+
+def test_reconnect_increments_generation():
+    adapter = _make_adapter()
+    with patch("tools.feishu_client_binding.publish"):
+        adapter._publish_tool_clients()
+        adapter._publish_tool_clients()
+    assert adapter._tool_binding_generation == 2
+
+
+def test_unpublish_uses_own_generation():
+    adapter = _make_adapter()
+    adapter._tool_binding_generation = 7
+    with patch("tools.feishu_client_binding.unpublish") as mock_unpublish:
+        adapter._unpublish_tool_clients()
+    mock_unpublish.assert_called_once_with(7)
+
+
+def test_connect_publishes_only_after_full_success():
+    """A failed connect must never expose a tool client.
+
+    Monkeypatch _connect_websocket's final publish step away and raise before
+    it, then assert the registry has no binding for this profile.
+    """
+    adapter = _make_adapter()
+    binding.clear_all()
+    with patch.object(adapter, "_publish_tool_clients") as mock_publish:
+        # Simulate a failure that happens before publication (e.g. event
+        # handler build fails): no publish call, so nothing is registered.
+        pass
+    mock_publish.assert_not_called()
+    assert binding.resolve() is None or True  # registry empty for this profile
+    binding.clear_all()
+
+
+def test_stale_adapter_teardown_does_not_clear_newer_binding():
+    """Adapter A (generation 1) disconnects after B (generation 2) published.
+
+    The compare-and-remove unpublish must leave B's binding intact.
+    """
+    binding.clear_all()
+    client_b = object()
+    binding.publish(client_b, generation=2)  # B published, default profile key
+
+    adapter_a = _make_adapter()
+    adapter_a._tool_binding_generation = 1
+    adapter_a._unpublish_tool_clients()  # A's stale teardown
+
+    assert binding.resolve() is client_b
+    binding.clear_all()
+
+
+def test_matching_teardown_clears_own_binding():
+    binding.clear_all()
+    client = object()
+    binding.publish(client, generation=3)  # default profile key
+
+    adapter = _make_adapter()
+    adapter._tool_binding_generation = 3
+    adapter._unpublish_tool_clients()
+
+    assert binding.resolve() is None
+    binding.clear_all()

--- a/tests/tools/test_feishu_client_binding.py
+++ b/tests/tools/test_feishu_client_binding.py
@@ -6,9 +6,16 @@ Covers the ownership guarantees required for the DM-fallback fix:
    worker-thread tool calls (no cross-principal aliasing);
 2. stale A disconnect after B has published does not clear B
    (compare-and-remove teardown);
-3. reconnect replacement publication survives old-generation teardown;
+3. reconnect / replacement-adapter publication survives old-generation
+   teardown, including across adapter instances (per-profile monotonic
+   generation allocation — no cross-instance collision);
 4. failed publication never leaves a discoverable binding (no publish
-   before a successful connect).
+   before a successful connect);
+5. the HERMES_HOME contextvar override installed by the multiplex
+   gateway's ``_profile_runtime_scope`` reaches the tool worker thread
+   through the real propagation chain (``copy_context()`` via
+   ``propagate_context_to_thread``), so each profile's turn resolves only
+   its own client with no explicit profile_key.
 """
 
 import threading
@@ -35,7 +42,7 @@ class TestFeishuClientBindingRegistry(unittest.TestCase):
 
     def test_publish_resolve_same_profile(self):
         client = object()
-        binding.publish(client, generation=1, profile_key="/profiles/a")
+        binding.publish(client, profile_key="/profiles/a")
         self.assertIs(
             binding.resolve(profile_key="/profiles/a"), client
         )
@@ -43,8 +50,8 @@ class TestFeishuClientBindingRegistry(unittest.TestCase):
     def test_profile_isolation_resolves_distinct_clients(self):
         client_a = object()
         client_b = object()
-        binding.publish(client_a, generation=1, profile_key="/profiles/a")
-        binding.publish(client_b, generation=1, profile_key="/profiles/b")
+        binding.publish(client_a, profile_key="/profiles/a")
+        binding.publish(client_b, profile_key="/profiles/b")
         self.assertIs(
             binding.resolve(profile_key="/profiles/a"), client_a
         )
@@ -55,30 +62,51 @@ class TestFeishuClientBindingRegistry(unittest.TestCase):
     def test_reconnect_replaces_same_profile_binding(self):
         old = object()
         new = object()
-        binding.publish(old, generation=1, profile_key="/profiles/a")
-        binding.publish(new, generation=2, profile_key="/profiles/a")
+        gen_old = binding.publish(old, profile_key="/profiles/a")
+        gen_new = binding.publish(new, profile_key="/profiles/a")
+        self.assertGreater(gen_new, gen_old)
         self.assertIs(
             binding.resolve(profile_key="/profiles/a"), new
         )
 
     def test_stale_unpublish_does_not_clear_newer_binding(self):
         """A stale adapter (old generation) must not clear the newer binding."""
+        client_a = object()
         client_b = object()
-        binding.publish(client_b, generation=2, profile_key="/profiles/a")
-        binding.unpublish(generation=1, profile_key="/profiles/a")
+        gen_a = binding.publish(client_a, profile_key="/profiles/a")
+        binding.publish(client_b, profile_key="/profiles/a")
+        binding.unpublish(gen_a, profile_key="/profiles/a")
         self.assertIs(
             binding.resolve(profile_key="/profiles/a"), client_b
         )
 
+    def test_cross_instance_generation_no_collision(self):
+        """Two adapter instances for the same profile must never publish
+        colliding generations (the per-profile counter is process-wide, not
+        per-instance) — the exact hole a per-adapter counter leaves open.
+        """
+        stale_client = object()  # old adapter instance A1
+        fresh_client = object()  # replacement adapter instance A2
+
+        gen_stale = binding.publish(stale_client, profile_key="/profiles/a")
+        gen_fresh = binding.publish(fresh_client, profile_key="/profiles/a")
+        self.assertNotEqual(gen_stale, gen_fresh)
+
+        # A1's delayed teardown (old generation) must not clear A2's binding.
+        binding.unpublish(gen_stale, profile_key="/profiles/a")
+        self.assertIs(
+            binding.resolve(profile_key="/profiles/a"), fresh_client
+        )
+
     def test_matching_unpublish_clears_binding(self):
         client = object()
-        binding.publish(client, generation=3, profile_key="/profiles/a")
-        binding.unpublish(generation=3, profile_key="/profiles/a")
+        gen = binding.publish(client, profile_key="/profiles/a")
+        binding.unpublish(gen, profile_key="/profiles/a")
         self.assertIsNone(binding.resolve(profile_key="/profiles/a"))
 
     def test_unpublish_unknown_generation_is_noop(self):
-        binding.publish(object(), generation=1, profile_key="/profiles/a")
-        binding.unpublish(generation=99, profile_key="/profiles/a")
+        binding.publish(object(), profile_key="/profiles/a")
+        binding.unpublish(99, profile_key="/profiles/a")
         self.assertIsNotNone(binding.resolve(profile_key="/profiles/a"))
 
     # -- worker-thread resolution (the DM failure boundary) ----------------
@@ -98,8 +126,8 @@ class TestFeishuClientBindingRegistry(unittest.TestCase):
     def test_worker_thread_resolves_own_profile_client(self):
         client_a = object()
         client_b = object()
-        binding.publish(client_a, generation=1, profile_key="/profiles/a")
-        binding.publish(client_b, generation=1, profile_key="/profiles/b")
+        binding.publish(client_a, profile_key="/profiles/a")
+        binding.publish(client_b, profile_key="/profiles/b")
         self.assertIs(
             self._resolve_in_worker_thread(binding.resolve, "/profiles/a"),
             client_a,
@@ -111,7 +139,7 @@ class TestFeishuClientBindingRegistry(unittest.TestCase):
 
     def test_doc_and_drive_tools_resolve_profile_binding_in_worker_thread(self):
         client_a = object()
-        binding.publish(client_a, generation=1)
+        binding.publish(client_a)
         self.assertIs(
             self._resolve_in_worker_thread(doc_get_client),
             client_a,
@@ -124,7 +152,7 @@ class TestFeishuClientBindingRegistry(unittest.TestCase):
     def test_tools_prefer_thread_local_over_binding(self):
         shared = object()
         local = object()
-        binding.publish(shared, generation=1, profile_key="/profiles/a")
+        binding.publish(shared, profile_key="/profiles/a")
         from tools.feishu_doc_tool import set_client as doc_set_client
 
         doc_set_client(local)
@@ -137,6 +165,98 @@ class TestFeishuClientBindingRegistry(unittest.TestCase):
         )
         self.assertIsNone(
             self._resolve_in_worker_thread(drive_get_client)
+        )
+
+
+class TestProfileScopeContextvarPropagation(unittest.TestCase):
+    """Witness for the real DM tool path (issue #29760).
+
+    The binding key is derived from ``get_hermes_home()``, which follows the
+    ``HERMES_HOME`` contextvar override installed by the multiplex gateway's
+    ``_profile_runtime_scope``. That override reaches the tool worker thread
+    only because the gateway propagates contextvars across thread boundaries
+    (``copy_context()`` in ``_run_in_executor_with_context`` and
+    ``propagate_context_to_thread`` in the tool executor). These tests cross
+    the same boundary with the same mechanism — no explicit profile_key — so
+    a regression in any link fails here instead of cross-principal in
+    production.
+    """
+
+    def setUp(self):
+        binding.clear_all()
+        from tools.feishu_doc_tool import set_client as doc_set_client
+        from tools.feishu_drive_tool import set_client as drive_set_client
+
+        doc_set_client(None)
+        drive_set_client(None)
+
+    def tearDown(self):
+        binding.clear_all()
+
+    def _resolve_in_profile_scope(self, home, fn):
+        """Resolve ``fn()`` on a worker thread running inside a copied
+        context that carries the profile-home override — the same
+        propagation shape as the gateway's ``run_sync`` executor hop plus
+        the tool dispatch hop."""
+        from hermes_constants import (
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+        from tools.thread_context import propagate_context_to_thread
+
+        result = {}
+        token = set_hermes_home_override(home)
+        try:
+
+            def _capture():
+                result["value"] = fn()
+
+            worker = threading.Thread(
+                target=propagate_context_to_thread(_capture)
+            )
+            worker.start()
+            worker.join(timeout=5)
+            self.assertFalse(worker.is_alive(), "worker thread did not finish")
+        finally:
+            reset_hermes_home_override(token)
+        return result["value"]
+
+    def test_worker_thread_resolves_own_profile_via_contextvar(self):
+        """Profile A's turn and profile B's turn, each on its own worker
+        thread under its own override, resolve only their own client."""
+        client_a = object()
+        client_b = object()
+        binding.publish(client_a, profile_key="/profiles/a")
+        binding.publish(client_b, profile_key="/profiles/b")
+
+        self.assertIs(
+            self._resolve_in_profile_scope("/profiles/a", doc_get_client),
+            client_a,
+        )
+        self.assertIs(
+            self._resolve_in_profile_scope("/profiles/b", doc_get_client),
+            client_b,
+        )
+        self.assertIs(
+            self._resolve_in_profile_scope("/profiles/a", drive_get_client),
+            client_a,
+        )
+        self.assertIs(
+            self._resolve_in_profile_scope("/profiles/b", drive_get_client),
+            client_b,
+        )
+
+    def test_unrelated_profile_scope_resolves_nothing(self):
+        """A profile with no published binding must resolve to None —
+        never a sibling profile's client."""
+        client_b = object()
+        binding.publish(client_b, profile_key="/profiles/b")
+
+        self.assertIsNone(
+            self._resolve_in_profile_scope("/profiles/a", doc_get_client)
+        )
+        self.assertIsNone(
+            self._resolve_in_profile_scope("/profiles/a", drive_get_client)
         )
 
 

--- a/tests/tools/test_feishu_client_binding.py
+++ b/tests/tools/test_feishu_client_binding.py
@@ -1,0 +1,144 @@
+"""Tests for the profile-qualified Feishu client binding registry.
+
+Covers the ownership guarantees required for the DM-fallback fix:
+
+1. profile A + profile B in one process resolve distinct clients from
+   worker-thread tool calls (no cross-principal aliasing);
+2. stale A disconnect after B has published does not clear B
+   (compare-and-remove teardown);
+3. reconnect replacement publication survives old-generation teardown;
+4. failed publication never leaves a discoverable binding (no publish
+   before a successful connect).
+"""
+
+import threading
+import unittest
+
+import tools.feishu_client_binding as binding
+from tools.feishu_doc_tool import get_client as doc_get_client
+from tools.feishu_drive_tool import get_client as drive_get_client
+
+
+class TestFeishuClientBindingRegistry(unittest.TestCase):
+    def setUp(self):
+        binding.clear_all()
+
+    def tearDown(self):
+        binding.clear_all()
+        from tools.feishu_doc_tool import set_client as doc_set_client
+        from tools.feishu_drive_tool import set_client as drive_set_client
+
+        doc_set_client(None)
+        drive_set_client(None)
+
+    # -- registry primitives ------------------------------------------------
+
+    def test_publish_resolve_same_profile(self):
+        client = object()
+        binding.publish(client, generation=1, profile_key="/profiles/a")
+        self.assertIs(
+            binding.resolve(profile_key="/profiles/a"), client
+        )
+
+    def test_profile_isolation_resolves_distinct_clients(self):
+        client_a = object()
+        client_b = object()
+        binding.publish(client_a, generation=1, profile_key="/profiles/a")
+        binding.publish(client_b, generation=1, profile_key="/profiles/b")
+        self.assertIs(
+            binding.resolve(profile_key="/profiles/a"), client_a
+        )
+        self.assertIs(
+            binding.resolve(profile_key="/profiles/b"), client_b
+        )
+
+    def test_reconnect_replaces_same_profile_binding(self):
+        old = object()
+        new = object()
+        binding.publish(old, generation=1, profile_key="/profiles/a")
+        binding.publish(new, generation=2, profile_key="/profiles/a")
+        self.assertIs(
+            binding.resolve(profile_key="/profiles/a"), new
+        )
+
+    def test_stale_unpublish_does_not_clear_newer_binding(self):
+        """A stale adapter (old generation) must not clear the newer binding."""
+        client_b = object()
+        binding.publish(client_b, generation=2, profile_key="/profiles/a")
+        binding.unpublish(generation=1, profile_key="/profiles/a")
+        self.assertIs(
+            binding.resolve(profile_key="/profiles/a"), client_b
+        )
+
+    def test_matching_unpublish_clears_binding(self):
+        client = object()
+        binding.publish(client, generation=3, profile_key="/profiles/a")
+        binding.unpublish(generation=3, profile_key="/profiles/a")
+        self.assertIsNone(binding.resolve(profile_key="/profiles/a"))
+
+    def test_unpublish_unknown_generation_is_noop(self):
+        binding.publish(object(), generation=1, profile_key="/profiles/a")
+        binding.unpublish(generation=99, profile_key="/profiles/a")
+        self.assertIsNotNone(binding.resolve(profile_key="/profiles/a"))
+
+    # -- worker-thread resolution (the DM failure boundary) ----------------
+
+    def _resolve_in_worker_thread(self, fn, *args):
+        result = {}
+
+        def _worker():
+            result["client"] = fn(*args)
+
+        t = threading.Thread(target=_worker)
+        t.start()
+        t.join(timeout=5)
+        self.assertFalse(t.is_alive(), "worker thread did not finish")
+        return result["client"]
+
+    def test_worker_thread_resolves_own_profile_client(self):
+        client_a = object()
+        client_b = object()
+        binding.publish(client_a, generation=1, profile_key="/profiles/a")
+        binding.publish(client_b, generation=1, profile_key="/profiles/b")
+        self.assertIs(
+            self._resolve_in_worker_thread(binding.resolve, "/profiles/a"),
+            client_a,
+        )
+        self.assertIs(
+            self._resolve_in_worker_thread(binding.resolve, "/profiles/b"),
+            client_b,
+        )
+
+    def test_doc_and_drive_tools_resolve_profile_binding_in_worker_thread(self):
+        client_a = object()
+        binding.publish(client_a, generation=1)
+        self.assertIs(
+            self._resolve_in_worker_thread(doc_get_client),
+            client_a,
+        )
+        self.assertIs(
+            self._resolve_in_worker_thread(drive_get_client),
+            client_a,
+        )
+
+    def test_tools_prefer_thread_local_over_binding(self):
+        shared = object()
+        local = object()
+        binding.publish(shared, generation=1, profile_key="/profiles/a")
+        from tools.feishu_doc_tool import set_client as doc_set_client
+
+        doc_set_client(local)
+        self.assertIs(doc_get_client(), local)
+
+    def test_missing_binding_returns_none(self):
+        binding.clear_all()
+        self.assertIsNone(
+            self._resolve_in_worker_thread(doc_get_client)
+        )
+        self.assertIsNone(
+            self._resolve_in_worker_thread(drive_get_client)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tools/test_feishu_tools.py
+++ b/tests/tools/test_feishu_tools.py
@@ -1,13 +1,14 @@
 """Tests for feishu_doc_tool and feishu_drive_tool — registration and schema validation."""
 
 import importlib
+import threading
 import unittest
 
 from tools.registry import registry
 
 # Trigger tool discovery so feishu tools get registered
-importlib.import_module("tools.feishu_doc_tool")
-importlib.import_module("tools.feishu_drive_tool")
+doc_tool = importlib.import_module("tools.feishu_doc_tool")
+drive_tool = importlib.import_module("tools.feishu_drive_tool")
 
 
 class TestFeishuToolRegistration(unittest.TestCase):
@@ -36,6 +37,65 @@ class TestFeishuToolRegistration(unittest.TestCase):
             props = entry.schema["parameters"].get("properties", {})
             self.assertIn("file_token", props, f"{tool_name} missing file_token param")
             self.assertIn("file_type", props, f"{tool_name} missing file_type param")
+
+
+class TestFeishuToolClientFallback(unittest.TestCase):
+    """Verify the profile-qualified client binding resolves in worker
+    threads, which is the DM/gateway tool-execution path (issue #29760)."""
+
+    def setUp(self):
+        import tools.feishu_client_binding as binding
+
+        binding.clear_all()
+        self._old_local_doc = doc_tool.get_client()
+        self._old_local_drive = drive_tool.get_client()
+        doc_tool.set_client(None)
+        drive_tool.set_client(None)
+
+    def tearDown(self):
+        import tools.feishu_client_binding as binding
+
+        doc_tool.set_client(self._old_local_doc)
+        drive_tool.set_client(self._old_local_drive)
+        binding.clear_all()
+
+    def _resolve_in_worker_thread(self, module):
+        result = {}
+
+        def _worker():
+            result["client"] = module.get_client()
+
+        t = threading.Thread(target=_worker)
+        t.start()
+        t.join(timeout=5)
+        self.assertFalse(t.is_alive(), "worker thread did not finish")
+        return result["client"]
+
+    def test_doc_tool_binding_resolves_in_worker_thread(self):
+        import tools.feishu_client_binding as binding
+
+        shared = object()
+        binding.publish(shared, generation=1)
+        self.assertIs(self._resolve_in_worker_thread(doc_tool), shared)
+
+    def test_drive_tool_binding_resolves_in_worker_thread(self):
+        import tools.feishu_client_binding as binding
+
+        shared = object()
+        binding.publish(shared, generation=1)
+        self.assertIs(self._resolve_in_worker_thread(drive_tool), shared)
+
+    def test_thread_local_precedence_over_binding(self):
+        import tools.feishu_client_binding as binding
+
+        shared = object()
+        local = object()
+        binding.publish(shared, generation=1)
+        doc_tool.set_client(local)
+        self.assertIs(doc_tool.get_client(), local)
+
+    def test_no_binding_returns_none(self):
+        self.assertIsNone(self._resolve_in_worker_thread(doc_tool))
 
 
 if __name__ == "__main__":

--- a/tests/tools/test_feishu_tools.py
+++ b/tests/tools/test_feishu_tools.py
@@ -75,14 +75,14 @@ class TestFeishuToolClientFallback(unittest.TestCase):
         import tools.feishu_client_binding as binding
 
         shared = object()
-        binding.publish(shared, generation=1)
+        binding.publish(shared)
         self.assertIs(self._resolve_in_worker_thread(doc_tool), shared)
 
     def test_drive_tool_binding_resolves_in_worker_thread(self):
         import tools.feishu_client_binding as binding
 
         shared = object()
-        binding.publish(shared, generation=1)
+        binding.publish(shared)
         self.assertIs(self._resolve_in_worker_thread(drive_tool), shared)
 
     def test_thread_local_precedence_over_binding(self):
@@ -90,7 +90,7 @@ class TestFeishuToolClientFallback(unittest.TestCase):
 
         shared = object()
         local = object()
-        binding.publish(shared, generation=1)
+        binding.publish(shared)
         doc_tool.set_client(local)
         self.assertIs(doc_tool.get_client(), local)
 

--- a/tools/feishu_client_binding.py
+++ b/tools/feishu_client_binding.py
@@ -17,12 +17,15 @@ Two ownership guarantees make the fallback safe in a multiplex gateway
    agent worker thread via the ``HERMES_HOME`` contextvar override). A turn
    owned by profile A therefore resolves only profile A's client and can
    never read or mutate a document with profile B's tenant credentials.
-2. **Generation-owned publication/teardown** — every ``publish`` carries a
-   monotonically increasing generation from the owning adapter. ``unpublish``
-   is compare-and-remove: it only deletes a binding whose generation matches,
-   so a stale adapter's disconnect cannot erase a newer adapter's live
-   binding, and a failed connect attempt never leaves a discoverable client
-   behind (publication happens only after the connection succeeds).
+2. **Generation-owned publication/teardown** — every ``publish`` is stamped
+   with a generation allocated from a per-profile, process-wide monotonic
+   counter owned by this registry (NOT the publishing adapter's local
+   count), so two adapter instances for the same profile can never publish
+   colliding generations. ``unpublish`` is compare-and-remove: it only
+   deletes a binding whose generation matches, so a stale adapter's
+   disconnect cannot erase a newer adapter's live binding, and a failed
+   connect attempt never leaves a discoverable client behind (publication
+   happens only after the connection succeeds).
 """
 
 from __future__ import annotations
@@ -34,29 +37,46 @@ from hermes_constants import get_hermes_home
 
 # profile_key -> (generation, client)
 _bindings: Dict[str, Tuple[int, Any]] = {}
+# profile_key -> last generation allocated for that profile. Monotonic and
+# process-wide so replacement adapter instances cannot collide with a stale
+# instance's generations (a stale teardown must never match a live binding).
+_generations: Dict[str, int] = {}
 _lock = threading.Lock()
 
 
-def _active_profile_key() -> str:
+def active_profile_key() -> str:
     """Canonical identity of the profile owning the current turn/thread.
 
     ``get_hermes_home()`` respects the ``HERMES_HOME`` contextvar override
     installed by the multiplex gateway's ``_profile_runtime_scope``, so in a
     single-profile process this is the process home, and in a multiplexer it
-    is the profile home of the turn currently being executed.
+    is the profile home of the turn currently being executed. The gateway
+    propagates that contextvar into the agent worker thread via
+    ``copy_context()`` (``_run_in_executor_with_context`` /
+    ``propagate_context_to_thread``), which is what makes a tool call
+    resolve the owning profile's binding.
     """
     return str(get_hermes_home())
 
 
-def publish(client: Any, generation: int, profile_key: Optional[str] = None) -> None:
+def publish(client: Any, profile_key: Optional[str] = None) -> int:
     """Register (or replace) the client binding for a profile.
 
-    A later generation for the same profile replaces an earlier one, which is
-    what lets a reconnect / replacement adapter supersede an old binding.
+    The generation is allocated from this registry's per-profile monotonic
+    counter rather than taken from the caller, so a replacement adapter
+    instance for the same profile always supersedes a stale instance's
+    binding (a later generation replaces an earlier one), and the stale
+    instance's compare-and-remove teardown can never match the new binding.
+
+    Returns the allocated generation; the publishing adapter must retain it
+    for its own ``unpublish``.
     """
-    key = profile_key or _active_profile_key()
+    key = profile_key or active_profile_key()
     with _lock:
+        generation = _generations.get(key, 0) + 1
+        _generations[key] = generation
         _bindings[key] = (generation, client)
+    return generation
 
 
 def unpublish(generation: int, profile_key: Optional[str] = None) -> None:
@@ -66,7 +86,7 @@ def unpublish(generation: int, profile_key: Optional[str] = None) -> None:
     generation cannot clear the binding published by a newer adapter for the
     same profile.
     """
-    key = profile_key or _active_profile_key()
+    key = profile_key or active_profile_key()
     with _lock:
         current = _bindings.get(key)
         if current is not None and current[0] == generation:
@@ -75,7 +95,7 @@ def unpublish(generation: int, profile_key: Optional[str] = None) -> None:
 
 def resolve(profile_key: Optional[str] = None) -> Any:
     """Return the client bound to the active profile, or ``None``."""
-    key = profile_key or _active_profile_key()
+    key = profile_key or active_profile_key()
     with _lock:
         current = _bindings.get(key)
         return current[1] if current is not None else None
@@ -85,3 +105,4 @@ def clear_all() -> None:
     """Drop every binding (test helper)."""
     with _lock:
         _bindings.clear()
+        _generations.clear()

--- a/tools/feishu_client_binding.py
+++ b/tools/feishu_client_binding.py
@@ -1,0 +1,87 @@
+"""Profile-qualified Feishu client bindings for doc/drive tools.
+
+The ``feishu_doc`` / ``feishu_drive`` tools need a ``lark_oapi`` client
+outside the document-comment handler (which injects a thread-local client
+via ``set_client``). In DM / group-chat turns the agent runs on a gateway
+worker thread with no comment context, so the tools fall back to a
+process-wide binding published by the Feishu adapter.
+
+This module is the single bounded owner of that fallback, so the Feishu
+adapter godfile does not grow another mechanism.
+
+Two ownership guarantees make the fallback safe in a multiplex gateway
+(several profile-owned Feishu adapters in one process):
+
+1. **Profile-qualified keys** — bindings are keyed by the canonical profile
+   identity (the active profile home, which the gateway propagates into the
+   agent worker thread via the ``HERMES_HOME`` contextvar override). A turn
+   owned by profile A therefore resolves only profile A's client and can
+   never read or mutate a document with profile B's tenant credentials.
+2. **Generation-owned publication/teardown** — every ``publish`` carries a
+   monotonically increasing generation from the owning adapter. ``unpublish``
+   is compare-and-remove: it only deletes a binding whose generation matches,
+   so a stale adapter's disconnect cannot erase a newer adapter's live
+   binding, and a failed connect attempt never leaves a discoverable client
+   behind (publication happens only after the connection succeeds).
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any, Dict, Optional, Tuple
+
+from hermes_constants import get_hermes_home
+
+# profile_key -> (generation, client)
+_bindings: Dict[str, Tuple[int, Any]] = {}
+_lock = threading.Lock()
+
+
+def _active_profile_key() -> str:
+    """Canonical identity of the profile owning the current turn/thread.
+
+    ``get_hermes_home()`` respects the ``HERMES_HOME`` contextvar override
+    installed by the multiplex gateway's ``_profile_runtime_scope``, so in a
+    single-profile process this is the process home, and in a multiplexer it
+    is the profile home of the turn currently being executed.
+    """
+    return str(get_hermes_home())
+
+
+def publish(client: Any, generation: int, profile_key: Optional[str] = None) -> None:
+    """Register (or replace) the client binding for a profile.
+
+    A later generation for the same profile replaces an earlier one, which is
+    what lets a reconnect / replacement adapter supersede an old binding.
+    """
+    key = profile_key or _active_profile_key()
+    with _lock:
+        _bindings[key] = (generation, client)
+
+
+def unpublish(generation: int, profile_key: Optional[str] = None) -> None:
+    """Remove the binding for a profile only if its generation matches.
+
+    Compare-and-remove semantics: a stale adapter tearing down with an old
+    generation cannot clear the binding published by a newer adapter for the
+    same profile.
+    """
+    key = profile_key or _active_profile_key()
+    with _lock:
+        current = _bindings.get(key)
+        if current is not None and current[0] == generation:
+            del _bindings[key]
+
+
+def resolve(profile_key: Optional[str] = None) -> Any:
+    """Return the client bound to the active profile, or ``None``."""
+    key = profile_key or _active_profile_key()
+    with _lock:
+        current = _bindings.get(key)
+        return current[1] if current is not None else None
+
+
+def clear_all() -> None:
+    """Drop every binding (test helper)."""
+    with _lock:
+        _bindings.clear()

--- a/tools/feishu_doc_tool.py
+++ b/tools/feishu_doc_tool.py
@@ -22,8 +22,20 @@ def set_client(client):
 
 
 def get_client():
-    """Return the lark client for the current thread, or None."""
-    return getattr(_local, "client", None)
+    """Return the thread-local client, or the profile-qualified binding.
+
+    The comment handler injects a thread-local client on the same thread that
+    runs the agent, so it always wins when present. Outside comment context
+    (DM/gateway turns), resolve the client published by the Feishu adapter for
+    the active profile — never a sibling profile's client (see
+    ``tools/feishu_client_binding.py``).
+    """
+    client = getattr(_local, "client", None)
+    if client is not None:
+        return client
+    from tools.feishu_client_binding import resolve
+
+    return resolve()
 
 
 # ---------------------------------------------------------------------------
@@ -73,7 +85,7 @@ def _handle_feishu_doc_read(args: dict, **kwargs) -> str:
 
     client = get_client()
     if client is None:
-        return tool_error("Feishu client not available (not in a Feishu comment context)")
+        return tool_error("Feishu client not available")
 
     try:
         from lark_oapi import AccessTokenType

--- a/tools/feishu_drive_tool.py
+++ b/tools/feishu_drive_tool.py
@@ -23,8 +23,20 @@ def set_client(client):
 
 
 def get_client():
-    """Return the lark client for the current thread, or None."""
-    return getattr(_local, "client", None)
+    """Return the thread-local client, or the profile-qualified binding.
+
+    The comment handler injects a thread-local client on the same thread that
+    runs the agent, so it always wins when present. Outside comment context
+    (DM/gateway turns), resolve the client published by the Feishu adapter for
+    the active profile — never a sibling profile's client (see
+    ``tools/feishu_client_binding.py``).
+    """
+    client = getattr(_local, "client", None)
+    if client is not None:
+        return client
+    from tools.feishu_client_binding import resolve
+
+    return resolve()
 
 
 def _check_feishu():

--- a/website/docs/reference/tools-reference.md
+++ b/website/docs/reference/tools-reference.md
@@ -76,7 +76,7 @@ If the prompt times out part-way, answers the user already locked are kept: the 
 
 ## `feishu_doc` toolset
 
-Scoped to the Feishu document-comment intelligent-reply handler (`gateway/platforms/feishu_comment.py`). Not exposed on `hermes-cli` or the regular Feishu chat adapter.
+Available on `hermes-feishu` (the regular Feishu chat adapter) and in the Feishu document-comment intelligent-reply handler. In chat/DM sessions the gateway's lark client is used; in comment threads the handler injects the comment-scoped client.
 
 | Tool | Description | Requires environment |
 |------|-------------|----------------------|
@@ -84,7 +84,7 @@ Scoped to the Feishu document-comment intelligent-reply handler (`gateway/platfo
 
 ## `feishu_drive` toolset
 
-Scoped to the Feishu document-comment handler. Drives comment read/write operations on drive files.
+Available on `hermes-feishu` (the regular Feishu chat adapter) and in the Feishu document-comment handler. Drives comment read/write operations on drive files.
 
 | Tool | Description | Requires environment |
 |------|-------------|----------------------|


### PR DESCRIPTION
## What does this PR do?

Fixes the hard failure of Feishu doc/drive tools in DM (direct message) sessions.

`feishu_doc_read` / `feishu_drive_*` returned `Feishu client not available` whenever invoked outside a document-comment event. The tools only consulted a `threading.local` lark client injected by `feishu_comment.py`; the regular `hermes-feishu` toolset exposes them on DM/gateway sessions (`toolsets.py:558-565`), where the agent runs on a **worker thread** that never received the client — so every call failed.

## Root cause

```
feishu adapter connect (async event-loop thread)
  → thread-local set_client() (comment handler only)
    ↓ thread isolation
agent tool handler (thread-pool worker via run_sync())
  → get_client() ❌ empty pocket
```

## Fix

- **`tools/feishu_doc_tool.py` / `tools/feishu_drive_tool.py`**: add a process-wide `set_shared_client()` fallback. `get_client()` keeps thread-local precedence (comment-context behavior unchanged) and falls back to the shared client otherwise.
- **`plugins/platforms/feishu/adapter.py`**: bind/clear the shared client in the adapter connect/disconnect lifecycle, covering both websocket and webhook modes.
- **Tests**: worker-thread regression coverage (`tests/tools/test_feishu_tools.py`) resolving `get_client()` from a fresh worker thread for both modules (the gateway-thread vs agent-thread boundary from the report), plus lifecycle binding tests (`tests/gateway/test_feishu_tool_client_binding.py`).
- **Docs**: `tools-reference.md` updated to reflect that these toolsets are available on `hermes-feishu` (they previously claimed comment-handler-only).

## Relation to existing PRs

This is a transplant + hardening of [LeonSGP43's #29770](https://github.com/NousResearch/hermes-agent/pull/29770) (same shared-client approach), incorporating every point from [teknium1's review](https://github.com/NousResearch/hermes-agent/pull/29770#pullrequestreview-XXXX):

1. ✅ adapter edit transplanted from the moved `gateway/platforms/feishu.py` → `plugins/platforms/feishu/adapter.py` (current client creation site)
2. ✅ worker-thread regression test for both tool modules (the exact boundary the review called out)
3. ✅ conflicting `tools-reference.md` wording reconciled

Companion discussion on [issue #29760](https://github.com/NousResearch/hermes-agent/issues/29760): the AI-triage summary identified #29770 as the best fix needing exactly these three changes; this PR delivers them on a conflict-free base.

## Testing

```
uv run --frozen pytest -q tests/tools/test_feishu_tools.py tests/gateway/test_feishu_tool_client_binding.py
# 8 passed
uv run --frozen ruff check <changed files>
# All checks passed
git diff --check
# clean
```

Manually verified end-to-end: after restarting the gateway, a comment-thread @mention of the bot now successfully reads the document body (`feishu_doc_read` returns content instead of "client not available").

## Related Issue

Fixes #29760