### PR TITLE
fix(dashboard): make session rows and sortable headers tappable on iOS WebKit

### DIFF
--- a/web/src/pages/AnalyticsPage.tsx
+++ b/web/src/pages/AnalyticsPage.tsx
@@ -88,7 +88,8 @@ function useTableSort<T>(
   return { sorted, sortKey, sortDir, toggle };
 }
 
-function SortHeader({
+// Exported for a11y regression tests (SessionRow.a11y.test.tsx).
+export function SortHeader({
   label,
   col,
   sortKey,
@@ -104,9 +105,22 @@ function SortHeader({
   className?: string;
 }) {
   const active = col === sortKey;
+  // tabIndex: iOS WebKit does not reliably synthesize a click from a tap on
+  // a non-interactive element, so the bare onClick was dead on iOS
+  // Safari/Brave (#96918). Focusability makes iOS treat the header as a
+  // control; no role="button" here — that would be invalid ARIA on a <th>.
   return (
     <th
+      tabIndex={0}
+      aria-sort={active ? (sortDir === "asc" ? "ascending" : "descending") : "none"}
       onClick={() => toggle(col)}
+      onKeyDown={(e) => {
+        if (e.target !== e.currentTarget) return;
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          toggle(col);
+        }
+      }}
       className={`cursor-pointer select-none ${className ?? ""}`}
     >
       <span className="inline-flex items-center gap-1.5 rounded px-1 -mx-1 py-0.5 hover:bg-muted/40 transition-colors">

--- a/web/src/pages/SessionRow.a11y.test.tsx
+++ b/web/src/pages/SessionRow.a11y.test.tsx
@@ -1,0 +1,260 @@
+// @vitest-environment jsdom
+import { act, type ReactNode } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { MemoryRouter } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Regression tests for #96918: iOS WebKit does not reliably synthesize click
+// events from taps on non-interactive elements, so a bare `<div onClick>`
+// session row header and a bare `<th onClick>` sortable header are dead on
+// iOS Safari/Brave while working on desktop Chromium. The fix gives the row
+// header role="button" + tabIndex + aria-expanded + Enter/Space keydown, and
+// makes SortHeader focusable/keyboard-operable with aria-sort state.
+
+const apiMocks = vi.hoisted(() => ({
+  getSessionMessages: vi.fn(async () => ({
+    session_id: "s1",
+    messages: [{ role: "user", content: "hello", timestamp: 1 }],
+  })),
+}));
+
+vi.mock("@/lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api")>();
+  return { ...actual, api: { ...actual.api, ...apiMocks } };
+});
+
+vi.mock("@/i18n", () => ({
+  useI18n: () => ({
+    t: {
+      common: {
+        live: "Live",
+        msgs: "msgs",
+        tools: "tools",
+        of: "of",
+        page: "Page",
+        collapse: "Collapse",
+        expand: "Expand",
+      },
+      sessions: {
+        untitledSession: "Untitled session",
+        noMessages: "No messages",
+        deleteSession: "Delete session",
+        selectSession: "Select session",
+        resumeInChat: "Resume in Chat",
+        roles: { user: "User", assistant: "Assistant", system: "System", tool: "Tool" },
+      },
+      analytics: {},
+    },
+  }),
+}));
+
+vi.mock("@/components/Markdown", () => ({
+  Markdown: ({ content }: { content: string }) => <>{content}</>,
+}));
+
+vi.mock("@/plugins", () => ({
+  PluginSlot: () => null,
+}));
+
+import { SessionRow } from "./SessionsPage";
+import { SortHeader } from "./AnalyticsPage";
+import type { SessionInfo } from "@/lib/api";
+
+let container: HTMLDivElement;
+let root: Root;
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+async function render(ui: ReactNode) {
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+  await act(async () => root.render(ui));
+}
+
+beforeEach(() => {
+  apiMocks.getSessionMessages.mockClear();
+});
+
+afterEach(async () => {
+  await act(async () => root?.unmount());
+  container?.remove();
+});
+
+const baseSession: SessionInfo = {
+  id: "s1",
+  source: "cli",
+  model: "org/model-x",
+  title: "Test session",
+  started_at: 0,
+  ended_at: null,
+  last_active: 0,
+  is_active: false,
+  message_count: 3,
+  tool_call_count: 0,
+  input_tokens: 0,
+  output_tokens: 0,
+  preview: "hello world",
+};
+
+function makeRowProps(overrides: Partial<Parameters<typeof SessionRow>[0]> = {}) {
+  return {
+    session: baseSession,
+    isExpanded: false,
+    isSelected: false,
+    onToggle: vi.fn(),
+    onSelectClick: vi.fn(),
+    onDelete: vi.fn(),
+    onExport: vi.fn(),
+    onRename: vi.fn(async () => {}),
+    resumeInChatEnabled: false,
+    ...overrides,
+  };
+}
+
+function keydown(el: Element, key: string, target?: Element) {
+  const event = new KeyboardEvent("keydown", { key, bubbles: true });
+  (target ?? el).dispatchEvent(event);
+}
+
+describe("SessionRow a11y (#96918)", () => {
+  it("exposes the header as an accessible toggle control", async () => {
+    await render(
+      <MemoryRouter>
+        <SessionRow {...makeRowProps()} />
+      </MemoryRouter>,
+    );
+    const header = container.querySelector('div[role="button"]');
+    expect(header).not.toBeNull();
+    expect(header!.getAttribute("tabindex")).toBe("0");
+    expect(header!.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("toggles via Enter and Space keydown on the focused header", async () => {
+    const onToggle = vi.fn();
+    await render(
+      <MemoryRouter>
+        <SessionRow {...makeRowProps({ onToggle })} />
+      </MemoryRouter>,
+    );
+    const header = container.querySelector('div[role="button"]')!;
+    await act(async () => {
+      keydown(header, "Enter");
+    });
+    await act(async () => {
+      keydown(header, " ");
+    });
+    expect(onToggle).toHaveBeenCalledTimes(2);
+    await act(async () => {
+      keydown(header, "a");
+    });
+    expect(onToggle).toHaveBeenCalledTimes(2);
+  });
+
+  it("ignores keydown originating from a nested focused control", async () => {
+    const onToggle = vi.fn();
+    await render(
+      <MemoryRouter>
+        <SessionRow {...makeRowProps({ onToggle })} />
+      </MemoryRouter>,
+    );
+    const header = container.querySelector('div[role="button"]')!;
+    const nested = header.querySelector("span")!;
+    await act(async () => {
+      keydown(header, "Enter", nested);
+    });
+    expect(onToggle).not.toHaveBeenCalled();
+  });
+
+  it("lazy-loads messages when expanded", async () => {
+    await render(
+      <MemoryRouter>
+        <SessionRow {...makeRowProps({ isExpanded: true })} />
+      </MemoryRouter>,
+    );
+    await act(async () => {});
+    expect(apiMocks.getSessionMessages).toHaveBeenCalledWith("s1");
+    expect(container.textContent).toContain("hello");
+  });
+});
+
+describe("SortHeader a11y (#96918)", () => {
+  function renderHeader(props: {
+    col?: string;
+    sortKey?: string;
+    sortDir?: "asc" | "desc";
+    toggle?: (key: string) => void;
+  }) {
+    const toggle =
+      props.toggle ?? vi.fn();
+    const ui = (
+      <table>
+        <thead>
+          <tr>
+            <SortHeader
+              label="Messages"
+              col={props.col ?? "messages"}
+              sortKey={props.sortKey ?? "messages"}
+              sortDir={props.sortDir ?? "asc"}
+              toggle={toggle}
+            />
+          </tr>
+        </thead>
+      </table>
+    );
+    return { toggle, promise: render(ui) };
+  }
+
+  it("is focusable and reports aria-sort ascending when active asc", async () => {
+    const { promise } = renderHeader({ sortDir: "asc" });
+    await promise;
+    const th = container.querySelector("th")!;
+    expect(th.getAttribute("tabindex")).toBe("0");
+    expect(th.getAttribute("aria-sort")).toBe("ascending");
+  });
+
+  it("reports aria-sort descending when active desc", async () => {
+    const { promise } = renderHeader({ sortDir: "desc" });
+    await promise;
+    const th = container.querySelector("th")!;
+    expect(th.getAttribute("aria-sort")).toBe("descending");
+  });
+
+  it("reports aria-sort none when the column is not the active sort key", async () => {
+    const { promise } = renderHeader({ col: "messages", sortKey: "tokens" });
+    await promise;
+    const th = container.querySelector("th")!;
+    expect(th.getAttribute("aria-sort")).toBe("none");
+  });
+
+  it("toggles via Enter and Space keydown on the th", async () => {
+    const toggle = vi.fn();
+    const { promise } = renderHeader({ toggle });
+    await promise;
+    const th = container.querySelector("th")!;
+    await act(async () => {
+      keydown(th, "Enter");
+    });
+    await act(async () => {
+      keydown(th, " ");
+    });
+    expect(toggle).toHaveBeenCalledWith("messages");
+    expect(toggle).toHaveBeenCalledTimes(2);
+    await act(async () => {
+      keydown(th, "Tab");
+    });
+    expect(toggle).toHaveBeenCalledTimes(2);
+  });
+
+  it("still toggles on click", async () => {
+    const toggle = vi.fn();
+    const { promise } = renderHeader({ toggle });
+    await promise;
+    const th = container.querySelector("th")!;
+    await act(async () => {
+      th.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(toggle).toHaveBeenCalledWith("messages");
+  });
+});

--- a/web/src/pages/SessionsPage.tsx
+++ b/web/src/pages/SessionsPage.tsx
@@ -462,7 +462,8 @@ function MessageList({
   );
 }
 
-function SessionRow({
+// Exported for a11y regression tests (SessionRow.a11y.test.tsx).
+export function SessionRow({
   session,
   snippet,
   searchQuery,
@@ -620,8 +621,26 @@ function SessionRow({
       className={`max-w-full min-w-0 overflow-hidden border transition-colors ${containerClasses}`}
     >
       <div
+        // role="button" + tabIndex: iOS WebKit does not reliably synthesize a
+        // click event from a tap on a non-interactive element (its
+        // cursor:pointer tap heuristic is unreliable, especially when the tap
+        // lands on inline descendants like the title <span>), so the bare
+        // onClick above was dead on iOS Safari/Brave (#96918). Making the
+        // header an actual control fixes taps and adds keyboard access. Not a
+        // real <button> because the header contains nested interactive
+        // elements (checkbox, rename input, action buttons).
+        role="button"
+        tabIndex={0}
+        aria-expanded={isExpanded}
         className="flex cursor-pointer items-start gap-3 p-3 transition-colors hover:bg-secondary/30"
         onClick={onToggle}
+        onKeyDown={(e) => {
+          if (e.target !== e.currentTarget) return;
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            onToggle();
+          }
+        }}
       >
         <span className="flex shrink-0 items-center pt-0.5">
           <Checkbox


### PR DESCRIPTION
## Summary

On iOS (Safari and Brave — both WebKit), tapping a session card in the web dashboard did nothing: no expansion, no network request. Desktop Chromium/Electron (same bundle) was unaffected. Root cause (confirmed by the reporter on a real iPhone in [#96918](https://github.com/NousResearch/hermes-agent/issues/96918)): iOS WebKit does not reliably synthesize a `click` event from a tap on a non-interactive element — the session row header was a bare `<div onClick>` with only a `cursor: pointer` class, and the tap heuristic is especially unreliable when the tap lands on inline descendants (the title `<span>`, metadata spans).

The issue body's Navigation-API theory was a red herring (it's React 19's `<ViewTransition>` helper, gated behind `typeof navigation == "object"` — a clean no-op on WebKit, and not on the tap path at all). The reporter's follow-up comment root-caused it and confirmed the fix shape used here on iOS Safari + Brave.

## Changes

- **`web/src/pages/SessionsPage.tsx`** — the `SessionRow` header `<div>` gets `role="button"`, `tabIndex={0}`, `aria-expanded={isExpanded}`, and an `onKeyDown` handler (Enter/Space → `preventDefault()` + toggle, guarded by `e.target !== e.currentTarget` so focused nested controls — checkbox, rename input, action buttons — don't double-toggle the row). Not a real `<button>` because the header contains nested interactive elements, which would be invalid HTML. Purely additive; mouse behavior unchanged. Exported for regression tests.
- **`web/src/pages/AnalyticsPage.tsx`** — the `SortHeader` `<th onClick>` (all 15 sortable columns route through this one component) gets `tabIndex={0}`, a standard `aria-sort` value (`ascending`/`descending`/`none`), and the same Enter/Space `onKeyDown` treatment. No `role="button"` on the `<th>` — invalid ARIA; focusability alone makes iOS synthesize taps. Exported for regression tests.
- **`web/src/pages/SessionRow.a11y.test.tsx`** — new: 9 regression tests (vitest + jsdom, same `createRoot`/`act` pattern as `ChatPage.test.tsx`) covering role/tabIndex/aria-expanded presence, click toggle, Enter/Space activation, non-activation for other keys and for keydown originating from a nested focused control, fetch-on-expand, and the `SortHeader` tabIndex/aria-sort/keyboard behavior.

No dependency changes, no i18n string changes, no other files touched. The Overview "Recent sessions" cards flagged in the issue are static display cards (no `onClick`) — verified not clickable, so intentionally untouched. A sibling audit of every other `cursor-pointer`/`onClick` surface in `web/src` found each already sits on a native interactive element (`<button>`, `<a>`, `<label htmlFor>`, `<summary>`), so no residual dead-tap sites remain.

## Tests

TDD, RED→GREEN proof captured in `/tmp` during development:

- **RED** on pre-fix code: `7 failed | 2 passed (9)` — the `div[role="button"]`, `tabIndex`, `aria-sort`, and keyboard-toggle assertions all fail against the bare `<div onClick>` / `<th onClick>`. (The 2 passing tests are behaviors that already worked: mouse click toggle and fetch-on-expand.)
- **GREEN** after the fix: `Tests 9 passed (9)`.
- Focused suite incl. sibling regression check: `npx vitest run src/pages/SessionRow.a11y.test.tsx src/pages/ChatPage.test.tsx` → `Test Files 2 passed (2) / Tests 15 passed (15)`.
- `npm run typecheck` → clean. `npx eslint` on the three touched files → 0 errors (one pre-existing `react-hooks/set-state-in-effect` warning in untouched code).

The keyboard tests dispatch real DOM `KeyboardEvent`s on focused elements (not direct handler calls), and the nested-target test exercises the `e.target !== e.currentTarget` guard — a mutation check removing the guard makes it fail.

Closes #96918