### PR TITLE
fix(feishu): dedupe card text extraction and add message recall

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -2054,6 +2054,11 @@ class FeishuAdapter(BasePlatformAdapter):
         been delivered as a new message — without this, a failed final edit
         leaves the truncated ``▉``-suffixed preview on screen next to the
         complete answer (duplicate content).
+
+        ``chat_id`` is required by the base adapter contract and callers pass
+        it positionally, but Feishu's recall API addresses a message purely by
+        ``message_id`` (``DELETE /im/v1/messages/{message_id}``) — it does not
+        scope deletion to a chat, so ``chat_id`` is intentionally unused.
         """
         if not self._client:
             return False

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -95,6 +95,7 @@ CreateImageRequest = None  # type: ignore[assignment]
 CreateImageRequestBody = None  # type: ignore[assignment]
 CreateMessageRequest = None  # type: ignore[assignment]
 CreateMessageRequestBody = None  # type: ignore[assignment]
+DeleteMessageRequest = None  # type: ignore[assignment]
 GetChatRequest = None  # type: ignore[assignment]
 GetMessageRequest = None  # type: ignore[assignment]
 GetMessageResourceRequest = None  # type: ignore[assignment]
@@ -315,19 +316,6 @@ _MENTION_PLACEHOLDER_RE = re.compile(r"@_user_\d+")
 _MENTION_BOUNDARY_CHARS = frozenset(" \t\n\r.,;:!?、，。；：！？()[]{}<>\"'`")
 _TRAILING_TERMINAL_PUNCT = frozenset(" \t\n\r.!?。！？")
 _WHITESPACE_RE = re.compile(r"\s+")
-_SUPPORTED_CARD_TEXT_KEYS = (
-    "title",
-    "text",
-    "content",
-    "label",
-    "value",
-    "name",
-    "summary",
-    "subtitle",
-    "description",
-    "placeholder",
-    "hint",
-)
 _SKIP_TEXT_KEYS = {
     "tag",
     "type",
@@ -983,11 +971,18 @@ def _normalize_interactive_message(message_type: str, payload: Dict[str, Any]) -
     body_lines = _collect_card_lines(card_payload)
     actions = _collect_action_labels(card_payload)
 
+    # Button/select labels are collected both as body lines (buttons are
+    # rich-block tags) and by _collect_action_labels — collapsing the exact
+    # duplicates here stops the same label from appearing twice in the card
+    # text rendered to the agent (e.g. "View Logs" as a line and again in
+    # "Actions: View Logs, Retry").
+    action_set = set(actions)
+
     lines: List[str] = []
     if title:
         lines.append(title)
     for line in body_lines:
-        if line != title:
+        if line != title and line not in action_set:
             lines.append(line)
     if actions:
         lines.append(f"Actions: {', '.join(actions)}")
@@ -1095,14 +1090,12 @@ def _collect_text_segments(value: Any, *, in_rich_block: bool) -> List[str]:
         "date_picker",
     }
 
+    # A single recursive walk collects every leaf string exactly once: the
+    # walk descends into all values (including those under `text`/`content`
+    # style keys), and the string branch emits the text when the enclosing
+    # node is a rich block. Collecting keys directly here too would
+    # double-report the same string.
     segments: List[str] = []
-    for key in _SUPPORTED_CARD_TEXT_KEYS:
-        item = value.get(key)
-        if isinstance(item, str) and next_in_rich_block:
-            normalized = _normalize_feishu_text(item)
-            if normalized:
-                segments.append(normalized)
-
     for key, item in value.items():
         if key in _SKIP_TEXT_KEYS:
             continue
@@ -1400,6 +1393,7 @@ def _load_lark_oapi() -> bool:
                 CreateFileRequest, CreateFileRequestBody,
                 CreateImageRequest, CreateImageRequestBody,
                 CreateMessageRequest, CreateMessageRequestBody,
+                DeleteMessageRequest,
                 GetChatRequest, GetMessageRequest, GetMessageResourceRequest,
                 P2ImMessageMessageReadV1,
                 ReplyMessageRequest, ReplyMessageRequestBody,
@@ -1425,6 +1419,7 @@ def _load_lark_oapi() -> bool:
             "CreateImageRequestBody": CreateImageRequestBody,
             "CreateMessageRequest": CreateMessageRequest,
             "CreateMessageRequestBody": CreateMessageRequestBody,
+            "DeleteMessageRequest": DeleteMessageRequest,
             "GetChatRequest": GetChatRequest,
             "GetMessageRequest": GetMessageRequest,
             "GetMessageResourceRequest": GetMessageResourceRequest,
@@ -2046,6 +2041,37 @@ class FeishuAdapter(BasePlatformAdapter):
         except Exception as exc:
             logger.error("[Feishu] Failed to edit message %s: %s", message_id, exc, exc_info=True)
             return SendResult(success=False, error=str(exc))
+
+    async def delete_message(
+        self,
+        chat_id: str,
+        message_id: str,
+    ) -> bool:
+        """Delete a previously sent Feishu message (recall).
+
+        Used by the stream consumer's fresh-final / fallback cleanup paths to
+        remove a stale streaming preview message once the completed reply has
+        been delivered as a new message — without this, a failed final edit
+        leaves the truncated ``▉``-suffixed preview on screen next to the
+        complete answer (duplicate content).
+        """
+        if not self._client:
+            return False
+        if not message_id or message_id == "__no_edit__":
+            return False
+        try:
+            request = self._build_delete_message_request(message_id)
+            response = await self._run_blocking(self._client.im.v1.message.delete, request)
+            if not self._response_succeeded(response):
+                code = getattr(response, "code", "unknown")
+                msg = getattr(response, "msg", "message delete failed")
+                logger.warning("[Feishu] Failed to delete message %s: [%s] %s", message_id, code, msg)
+                return False
+            logger.debug("[Feishu] Deleted message %s", message_id)
+            return True
+        except Exception as exc:
+            logger.warning("[Feishu] Failed to delete message %s: %s", message_id, exc)
+            return False
 
     # Template attrs for the shared _format_exec_approval core. The card
     # header carries the title, so the text core starts at the code fence.
@@ -5080,6 +5106,12 @@ class FeishuAdapter(BasePlatformAdapter):
     def _build_get_message_request(message_id: str) -> Any:
         if GetMessageRequest is not None:
             return GetMessageRequest.builder().message_id(message_id).build()
+        return SimpleNamespace(message_id=message_id)
+
+    @staticmethod
+    def _build_delete_message_request(message_id: str) -> Any:
+        if DeleteMessageRequest is not None:
+            return DeleteMessageRequest.builder().message_id(message_id).build()
         return SimpleNamespace(message_id=message_id)
 
     @staticmethod

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -94,10 +94,59 @@ class TestFeishuMessageNormalization(unittest.TestCase):
         )
 
         self.assertEqual(normalized.relation_kind, "interactive")
+        # Button labels are action labels, not body text — they must appear
+        # once (in the Actions summary), not twice (also as body lines).
         self.assertEqual(
             normalized.text_content,
-            "Build Failed\nService: payments-api\nBranch: main\nView Logs\nRetry\nActions: View Logs, Retry",
+            "Build Failed\nService: payments-api\nBranch: main\nActions: View Logs, Retry",
         )
+
+    def test_collect_text_segments_collects_each_leaf_once(self):
+        """Every card string is collected exactly once.
+
+        Regression for the double-collection bug where the direct
+        _SUPPORTED_CARD_TEXT_KEYS scan and the recursive value walk both
+        emitted the same string.
+        """
+        from plugins.platforms.feishu.adapter import _collect_text_segments
+
+        payload = {
+            "header": {"title": {"tag": "plain_text", "content": "Build Failed"}},
+            "elements": [
+                {"tag": "div", "text": {"tag": "lark_md", "content": "Service: payments-api"}},
+                {"tag": "note", "elements": [{"tag": "plain_text", "content": "note here"}]},
+                {
+                    "tag": "action",
+                    "actions": [
+                        {"tag": "button", "text": {"tag": "plain_text", "content": "Retry"}},
+                    ],
+                },
+            ],
+        }
+        segments = _collect_text_segments(payload, in_rich_block=False)
+        self.assertEqual(
+            segments,
+            ["Build Failed", "Service: payments-api", "note here", "Retry"],
+        )
+        # No string may appear more than once in the raw output.
+        self.assertEqual(len(segments), len(set(segments)))
+
+    def test_collect_text_segments_keeps_non_duplicate_repeated_text(self):
+        """Two *distinct* card elements with the same text are both preserved.
+
+        Only the accidental double-collection of a single element is removed;
+        genuinely repeated card content still shows up (once per element).
+        """
+        from plugins.platforms.feishu.adapter import _collect_text_segments
+
+        payload = {
+            "elements": [
+                {"tag": "div", "text": {"tag": "plain_text", "content": "Retry"}},
+                {"tag": "div", "text": {"tag": "plain_text", "content": "Retry"}},
+            ],
+        }
+        segments = _collect_text_segments(payload, in_rich_block=False)
+        self.assertEqual(segments, ["Retry", "Retry"])
 
 
 class TestFeishuAdapterMessaging(unittest.TestCase):
@@ -284,6 +333,156 @@ class TestFeishuAdapterMessaging(unittest.TestCase):
             captured["calls"][1].request_body.content,
             json.dumps({"text": "可以用 粗体 和 斜体。"}, ensure_ascii=False),
         )
+
+    def test_delete_message_recalls_sent_message(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {"calls": []}
+
+        class _MessageAPI:
+            def delete(self, request):
+                captured["calls"].append(request)
+                return SimpleNamespace(success=lambda: True, code=0, msg="success")
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    message=_MessageAPI(),
+                )
+            )
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        # delete_message routes through _run_blocking (adapter SDK executor),
+        # not asyncio.to_thread — patch the real dispatch point and keep the
+        # SDK round-trip intact without spinning up a worker pool.
+        adapter._run_blocking = _direct
+        ok = asyncio.run(
+            adapter.delete_message(
+                chat_id="oc_chat",
+                message_id="om_stale_preview",
+            )
+        )
+
+        self.assertTrue(ok)
+        self.assertEqual(captured["calls"][0].message_id, "om_stale_preview")
+
+    def test_delete_message_failure_returns_false(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {"calls": []}
+
+        class _MessageAPI:
+            def delete(self, request):
+                captured["calls"].append(request)
+                return SimpleNamespace(success=lambda: False, code=230004, msg="bot cannot delete")
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    message=_MessageAPI(),
+                )
+            )
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        adapter._run_blocking = _direct
+        ok = asyncio.run(
+            adapter.delete_message(
+                chat_id="oc_chat",
+                message_id="om_stale_preview",
+            )
+        )
+
+        self.assertFalse(ok)
+        self.assertEqual(captured["calls"][0].message_id, "om_stale_preview")
+
+    def test_delete_message_validates_message_id_before_sdk_call(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {"calls": []}
+
+        class _MessageAPI:
+            def delete(self, request):
+                captured["calls"].append(request)
+                return SimpleNamespace(success=lambda: True, code=0, msg="success")
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    message=_MessageAPI(),
+                )
+            )
+        )
+
+        # Sentinel/empty ids must short-circuit before any SDK call — the
+        # stream consumer passes these during degraded fallback states.
+        for bad_id in ("", "__no_edit__"):
+            captured["calls"].clear()
+            ok = asyncio.run(
+                adapter.delete_message(
+                    chat_id="oc_chat",
+                    message_id=bad_id,
+                )
+            )
+            self.assertFalse(ok)
+            self.assertEqual(captured["calls"], [])
+
+    def test_delete_message_without_client_returns_false(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        self.assertIsNone(adapter._client)
+        ok = asyncio.run(
+            adapter.delete_message(
+                chat_id="oc_chat",
+                message_id="om_stale_preview",
+            )
+        )
+        self.assertFalse(ok)
+
+    def test_delete_message_survives_sdk_exception(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+
+        class _MessageAPI:
+            def delete(self, _request):
+                raise RuntimeError("network down")
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    message=_MessageAPI(),
+                )
+            )
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        adapter._run_blocking = _direct
+        ok = asyncio.run(
+            adapter.delete_message(
+                chat_id="oc_chat",
+                message_id="om_stale_preview",
+            )
+        )
+        # Deletion is best-effort for the stream consumer — an SDK failure
+        # must surface as False, never raise.
+        self.assertFalse(ok)
 
 
 class TestAdapterModule(unittest.TestCase):


### PR DESCRIPTION
## What

Two root causes for `hermes 回复飞书卡片内容存在重复` (duplicated content in Feishu card replies):

1. **Card text double-collection** — `_collect_text_segments` emitted every string twice (a direct `_SUPPORTED_CARD_TEXT_KEYS` scan plus the recursive `value.items()` walk reaching the same value with `in_rich_block=True`), and button/select labels appeared both as body lines (buttons are rich-block tags) **and** again in the `Actions:` summary line.

2. **Stale stream preview residue** — when a streamed preview fails its final edit, the stream consumer (`gateway/stream_consumer.py`) falls back to sending the complete answer as a new message and attempts to recall the stale truncated `▉`-suffixed preview via `adapter.delete_message()`. The Feishu adapter had no such method (base returns `False`), leaving the truncated preview on screen next to the complete reply — the exact duplicate-content symptom the user reported.

## Changes

**`plugins/platforms/feishu/adapter.py`**
- Remove the redundant direct-key collection loop in `_collect_text_segments` plus the now-dead `_SUPPORTED_CARD_TEXT_KEYS` constant — a single recursive walk already collects every leaf string exactly once.
- `_normalize_interactive_message`: skip exact action-set members when assembling body lines so each button label appears once (in the `Actions:` summary), not twice.
- Add `DeleteMessageRequest` lazy-import wiring and `delete_message()` backed by `im.v1.message.delete` (recall), with `__no_edit__`/empty-id/no-client guards and swallow-only error handling so the consumer's best-effort cleanup semantics hold.

**`tests/gateway/test_feishu.py`**
- Card dedup regressions: each leaf string collected exactly once; genuinely repeated text across distinct elements still preserved.
- `delete_message` tests: success, API failure, sentinel/empty-id short-circuit (no SDK call), no-client, and SDK exception (never raises). Tests route through `_run_blocking` rather than the ineffective `asyncio.to_thread` patch.

## Verification

- `test_feishu.py`: **79 passed** (3 pre-existing webhook/environment failures identical at HEAD with changes stashed).
- Gateway restarted with the new code; `delete_message` present, `_SUPPORTED_CARD_TEXT_KEYS` removed, card parse output deduped (verified against the running venv).