### PR TITLE
fix: harden web runtime configuration boundaries

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -217,6 +217,25 @@ _CFG_ANCHORED_RE = re.compile(
     re.IGNORECASE | re.MULTILINE,
 )
 
+# TOML assignments permit whitespace around ``=`` and bare, basic-string, or
+# literal-string key segments. Keep this line-anchored and use possessive
+# quantifiers so malformed/very long quoted keys cannot trigger expensive
+# backtracking. This parser is only applied to file-tool output from .toml
+# paths; source-code examples retain the conservative code-file behavior.
+_TOML_KEY_SEGMENT = r'(?:[A-Za-z0-9_-]++|"(?:\\[^\r\n]|[^"\\\r\n])*+"|\'[^\'\r\n]*+\')'
+_TOML_SECRET_ASSIGN_RE = re.compile(
+    rf"(?P<toml_prefix>^[ \t]*(?:\d+\|)?[ \t]*)"
+    rf"(?P<toml_key>{_TOML_KEY_SEGMENT}"
+    rf"(?:[ \t]*+\.[ \t]*+{_TOML_KEY_SEGMENT})*+)"
+    rf"(?P<toml_sep>[ \t]*+=[ \t]*+)"
+    rf"(?:"
+    rf'(?P<toml_dquote>")(?P<toml_dvalue>(?:\\[^\r\n]|[^"\\\r\n])*+)"'
+    rf"|(?P<toml_squote>')(?P<toml_svalue>[^'\r\n]*+)'"
+    rf"|(?P<toml_bvalue>[^ \t\r\n#]++)"
+    rf")",
+    re.MULTILINE,
+)
+
 # Unquoted YAML / colon config (e.g. ``password: secret``,
 # ``spring.datasource.password: hunter2``). The secret keyword must be part of
 # the KEY (anchored to the start of the line/indent), and the value is a single
@@ -916,6 +935,41 @@ def redact_sensitive_text(
         code_file = not is_config_like_path(file_path)
 
     value_mask = _mask_file_value if file_read else _mask_token
+
+    # TOML's assignment grammar allows whitespace around ``=`` and quoted key
+    # segments, neither of which the generic dotted/bare config regexes fully
+    # cover. Restrict this richer parser to actual .toml file-tool surfaces so
+    # quoted assignment examples in source code remain editable.
+    if (
+        file_read
+        and os.path.splitext(str(file_path or ""))[1].casefold() == ".toml"
+        and "=" in text
+        and _CFG_SECRET_WORD_RE.search(text)
+    ):
+
+        def _redact_toml_assignment(m):
+            key = m.group("toml_key")
+            if not _key_has_secret_keyword(key):
+                return m.group(0)
+
+            if m.group("toml_dvalue") is not None:
+                quote = m.group("toml_dquote")
+                value = m.group("toml_dvalue")
+            elif m.group("toml_svalue") is not None:
+                quote = m.group("toml_squote")
+                value = m.group("toml_svalue")
+            else:
+                quote = ""
+                value = m.group("toml_bvalue")
+
+            if _ENV_LOOKUP_VALUE_RE.match(value):
+                return m.group(0)
+            return (
+                f"{m.group('toml_prefix')}{key}{m.group('toml_sep')}"
+                f"{quote}{value_mask(value)}{quote}"
+            )
+
+        text = _TOML_SECRET_ASSIGN_RE.sub(_redact_toml_assignment, text)
 
     # Known prefixes (sk-, ghp_, etc.) — gate on substring presence
     if _has_known_prefix_substring(text):

--- a/agent/redact.py
+++ b/agent/redact.py
@@ -208,7 +208,7 @@ _CFG_DOTTED_RE = re.compile(
 )
 # Line-anchored bare key: ``password=…`` / ``export api_key=…`` at start of line.
 _CFG_ANCHORED_RE = re.compile(
-    rf"(^[ \t]*(?:export[ \t]+)?[A-Za-z0-9_\-]*{_SECRET_CFG_NAMES}[A-Za-z0-9_\-]*)={_CFG_VALUE}",
+    rf"(^[ \t]*(?:\d+\|)?[ \t]*(?:export[ \t]+)?[A-Za-z0-9_\-]*{_SECRET_CFG_NAMES}[A-Za-z0-9_\-]*)={_CFG_VALUE}",
     re.IGNORECASE | re.MULTILINE,
 )
 
@@ -219,12 +219,13 @@ _CFG_ANCHORED_RE = re.compile(
 # value) and ``error: token expired`` are left alone. Bare ``auth`` is excluded
 # from the key set so ``Authorization:`` / ``author:`` don't match (the former
 # is masked by _AUTH_HEADER_RE); ``auth_token``/``auth-token`` still match via
-# the ``token`` keyword. Quoted values defer to _JSON_FIELD_RE via the lookahead.
+# the ``token`` keyword. Both quoted and unquoted scalar values are supported.
 _YAML_CFG_NAMES = r"(?:api[ _.\-]?key|token|secret|passwd|password|credential)"
 # NOTE(perf): possessive quantifiers wherever the successor is disjoint; the
 # leading ``[A-Za-z0-9_.\-]*`` stays backtrackable (see _CFG_DOTTED_RE note).
 _YAML_ASSIGN_RE = re.compile(
-    rf"(^[ \t]*+[A-Za-z0-9_.\-]*{_YAML_CFG_NAMES}[A-Za-z0-9_.\-]*+)(:[ \t]*+)(?!['\"])([^\s&]++)",
+    rf"(^[ \t]*+(?:\d+\|)?[ \t]*+[A-Za-z0-9_.\-]*{_YAML_CFG_NAMES}[A-Za-z0-9_.\-]*+)"
+    rf"(:[ \t]*+)(['\"]?)([^\s&]+?)\3(?=[\s&]|$)",
     re.IGNORECASE | re.MULTILINE,
 )
 
@@ -315,11 +316,12 @@ def _key_has_secret_keyword(key: str) -> bool:
             return True
     return False
 
-# JSON field patterns: "apiKey": "value", "token": "value", etc.
-_JSON_KEY_NAMES = r"(?:api_?[Kk]ey|token|secret|password|access_token|refresh_token|auth_token|bearer|secret_value|raw_secret|secret_input|key_material)"
+# JSON field pattern. Match a bounded key and validate secret-bearing word
+# boundaries in the callback so provider names such as ``exaApiKey`` and
+# ``braveSearchApiKey`` are covered without treating words like ``monkey`` as
+# credentials.
 _JSON_FIELD_RE = re.compile(
-    rf'("{_JSON_KEY_NAMES}")\s*:\s*"([^"]+)"',
-    re.IGNORECASE,
+    r'("([A-Za-z0-9_.-]{1,128})")\s*:\s*"([^"]+)"',
 )
 
 # Authorization headers — any scheme (Bearer, Basic, Token, Digest, …) plus the
@@ -771,12 +773,86 @@ def _mask_token_nonreusable(token: str) -> str:
     return f"«redacted:{label}…»" if label else "«redacted-secret»"
 
 
+def _mask_file_value(token: str) -> str:
+    """Mask file values without collapsing an existing non-reusable sentinel."""
+    if token == "«redacted-secret»" or (
+        token.startswith("«redacted:") and token.endswith("…»")
+    ):
+        return token
+    return _mask_token_nonreusable(token)
+
+
+_CONFIG_FILE_EXTENSIONS = frozenset({
+    ".cfg", ".conf", ".env", ".ini", ".json", ".properties", ".toml",
+    ".yaml", ".yml",
+})
+_SOURCE_OR_DOC_EXTENSIONS = frozenset({
+    ".adoc", ".bash", ".c", ".cc", ".cpp", ".cs", ".fish", ".go", ".h",
+    ".hpp", ".java", ".js", ".jsx", ".kt", ".kts", ".lua", ".md", ".php",
+    ".ps1", ".py", ".pyi", ".r", ".rb", ".rs", ".rst", ".scala", ".sh",
+    ".sql", ".svelte", ".swift", ".ts", ".tsx", ".vue", ".zsh",
+})
+_CONFIG_BASENAME_WORDS = frozenset({"config", "configuration", "settings"})
+
+
+def is_config_like_path(path: object) -> bool:
+    """Return whether ``path`` names a configuration/settings data file."""
+    if not path:
+        return False
+    basename = str(path).replace("\\", "/").rsplit("/", 1)[-1].casefold()
+    if basename == ".env" or basename.startswith(".env."):
+        return True
+    extension = os.path.splitext(basename)[1]
+    if extension in _CONFIG_FILE_EXTENSIONS:
+        return True
+    if extension in _SOURCE_OR_DOC_EXTENSIONS:
+        return False
+    words = re.split(r"[^a-z0-9]+", basename)
+    return any(word in _CONFIG_BASENAME_WORDS for word in words)
+
+
+def redact_patch_text(
+    text: str,
+    file_paths: tuple | list = (),
+    *,
+    force: bool = False,
+) -> str:
+    """Redact a unified diff using each section's target-file policy."""
+    if not text:
+        return text
+    paths = [str(path) for path in (file_paths or ()) if path]
+    current_path = paths[0] if len(paths) == 1 else None
+    redacted_lines = []
+    for line in text.splitlines(keepends=True):
+        if line.startswith(("--- ", "+++ ")):
+            candidate = line[4:].split("\t", 1)[0].strip()
+            if candidate != "/dev/null":
+                if candidate.startswith(("a/", "b/")):
+                    candidate = candidate[2:]
+                current_path = candidate
+            redacted_lines.append(line)
+            continue
+
+        if line[:1] in {"+", "-", " "}:
+            prefix, payload = line[:1], line[1:]
+            redacted_lines.append(prefix + redact_sensitive_text(
+                payload,
+                force=force,
+                file_read=True,
+                file_path=current_path,
+            ))
+        else:
+            redacted_lines.append(line)
+    return "".join(redacted_lines)
+
+
 def redact_sensitive_text(
     text: str,
     *,
     force: bool = False,
     code_file: bool = False,
     file_read: bool = False,
+    file_path: object = None,
     redact_url_credentials: bool = False,
 ) -> str:
     """Apply all redaction patterns to a block of text.
@@ -804,8 +880,9 @@ def redact_sensitive_text(
     an agent reading it from config.yaml and writing it back silently corrupted
     the stored credential into a dead 13-char value → 401 (issue #35519). The
     sentinel is syntactically invalid as a token, so it can't be mistaken for a
-    usable key or written back as one. Implies code_file=True (config/data
-    files shouldn't trigger the source-code ENV/JSON false-positive paths).
+    usable key or written back as one. Pass ``file_path`` when available so
+    configuration/settings data files can use generic key-name redaction while
+    source files retain the conservative ``code_file`` behavior.
 
     Performance: each regex pattern is gated behind a cheap substring
     pre-check (e.g. ``"=" in text`` for ENV assignments, ``"://" in text``
@@ -825,10 +902,13 @@ def redact_sensitive_text(
     if not (force or _REDACT_ENABLED):
         return text
 
-    # file_read content shouldn't hit the source-code ENV/JSON false-positive
-    # paths either (it's config/data, not log lines).
+    # File content defaults to the conservative source-code path. Configuration
+    # files are the exception: opaque values under secret-bearing keys are more
+    # likely credentials than examples, so enable the ENV/JSON/YAML passes.
     if file_read:
-        code_file = True
+        code_file = not is_config_like_path(file_path)
+
+    value_mask = _mask_file_value if file_read else _mask_token
 
     # Known prefixes (sk-, ghp_, etc.) — gate on substring presence
     if _has_known_prefix_substring(text):
@@ -859,7 +939,7 @@ def redact_sensitive_text(
                 # embedded matching inside the helper.
                 if not _key_has_secret_keyword(name):
                     return m.group(0)
-                return f"{name}={quote}{_mask_token(value)}{quote}"
+                return f"{name}={quote}{value_mask(value)}{quote}"
             text = _ENV_ASSIGN_RE.sub(_redact_env, text)
             # Lowercase env names (``openai_key=…``). Skip URLs — the query
             # string may contain ``token=``/``key=`` params that are
@@ -888,21 +968,24 @@ def redact_sensitive_text(
         # JSON fields: "apiKey": "***"  (skip for code files — false positives)
         if ":" in text and '"' in text:
             def _redact_json(m):
-                key, value = m.group(1), m.group(2)
+                key, key_name, value = m.group(1), m.group(2), m.group(3)
                 # Same programmatic-env-lookup exception as _redact_env above
                 # (issue #2852): "apiKey": "os.getenv('X')" is a code snippet,
                 # not a leaked secret value.
                 if _ENV_LOOKUP_VALUE_RE.match(value):
                     return m.group(0)
-                return f'{key}: "{_mask_token(value)}"'
+                if key_name.casefold() != "bearer" and not _key_has_secret_keyword(key_name):
+                    return m.group(0)
+                return f'{key}: "{value_mask(value)}"'
             text = _JSON_FIELD_RE.sub(_redact_json, text)
 
-        # Unquoted YAML / colon config: password: ***  (after JSON so quoted
-        # values are handled there; the lookahead in _YAML_ASSIGN_RE skips
-        # quotes). Skip URLs — web-URL query params pass through by design.
+        # YAML / colon config: password: *** (quoted or unquoted scalar).
+        # Skip URLs — web-URL query params pass through by design.
         if ":" in text and "://" not in text:
             def _redact_yaml(m):
-                key, sep, value = m.group(1), m.group(2), m.group(3)
+                key, sep, quote, value = (
+                    m.group(1), m.group(2), m.group(3), m.group(4)
+                )
                 # Same programmatic-env-lookup exception as _redact_env above
                 # (issue #2852): api_key: os.getenv('X') is a code snippet,
                 # not a leaked secret value.
@@ -913,7 +996,7 @@ def redact_sensitive_text(
                 # document text, not credentials (nearai/ironclaw#6129).
                 if not _key_has_secret_keyword(key):
                     return m.group(0)
-                return f"{key}{sep}{_mask_token(value)}"
+                return f"{key}{sep}{quote}{value_mask(value)}{quote}"
             text = _YAML_ASSIGN_RE.sub(_redact_yaml, text)
 
     # Authorization headers — _AUTH_HEADER_RE matches any scheme after

--- a/agent/redact.py
+++ b/agent/redact.py
@@ -206,9 +206,14 @@ _CFG_DOTTED_RE = re.compile(
     rf"={_CFG_VALUE}",
     re.IGNORECASE,
 )
-# Line-anchored bare key: ``password=…`` / ``export api_key=…`` at start of line.
+# Line-anchored bare key: ``password = …`` / ``export api_key=…`` at start of
+# line. Whitespace around ``=`` is captured separately so TOML formatting is
+# preserved in redacted file-tool output.
 _CFG_ANCHORED_RE = re.compile(
-    rf"(^[ \t]*(?:\d+\|)?[ \t]*(?:export[ \t]+)?[A-Za-z0-9_\-]*{_SECRET_CFG_NAMES}[A-Za-z0-9_\-]*)={_CFG_VALUE}",
+    rf"(?P<anchored_key>^[ \t]*(?:\d+\|)?[ \t]*(?:export[ \t]+)?"
+    rf"[A-Za-z0-9_\-]*{_SECRET_CFG_NAMES}[A-Za-z0-9_\-]*)"
+    rf"(?P<anchored_sep>[ \t]*=[ \t]*)(?P<anchored_quote>['\"]?)"
+    rf"(?P<anchored_value>[^\s&]+?)(?P=anchored_quote)(?=[\s&]|$)",
     re.IGNORECASE | re.MULTILINE,
 )
 
@@ -786,12 +791,7 @@ _CONFIG_FILE_EXTENSIONS = frozenset({
     ".cfg", ".conf", ".env", ".ini", ".json", ".properties", ".toml",
     ".yaml", ".yml",
 })
-_SOURCE_OR_DOC_EXTENSIONS = frozenset({
-    ".adoc", ".bash", ".c", ".cc", ".cpp", ".cs", ".fish", ".go", ".h",
-    ".hpp", ".java", ".js", ".jsx", ".kt", ".kts", ".lua", ".md", ".php",
-    ".ps1", ".py", ".pyi", ".r", ".rb", ".rs", ".rst", ".scala", ".sh",
-    ".sql", ".svelte", ".swift", ".ts", ".tsx", ".vue", ".zsh",
-})
+_CONFIG_VARIANT_EXTENSIONS = frozenset({".example", ".local", ".sample"})
 _CONFIG_BASENAME_WORDS = frozenset({"config", "configuration", "settings"})
 
 
@@ -805,10 +805,17 @@ def is_config_like_path(path: object) -> bool:
     extension = os.path.splitext(basename)[1]
     if extension in _CONFIG_FILE_EXTENSIONS:
         return True
-    if extension in _SOURCE_OR_DOC_EXTENSIONS:
-        return False
     words = re.split(r"[^a-z0-9]+", basename)
-    return any(word in _CONFIG_BASENAME_WORDS for word in words)
+    has_config_word = any(word in _CONFIG_BASENAME_WORDS for word in words)
+    if extension in _CONFIG_VARIANT_EXTENSIONS:
+        return has_config_word
+    # Unknown explicit extensions are source/data by default. This covers the
+    # broad and evolving set of code extensions (mjs/cjs/mts/cts included)
+    # without maintaining another finite allowlist. Extensionless config and
+    # settings basenames still use the conservative word fallback below.
+    if extension:
+        return False
+    return has_config_word
 
 
 def redact_patch_text(
@@ -963,7 +970,19 @@ def redact_sensitive_text(
             # text.
             if "://" not in text and _CFG_SECRET_WORD_RE.search(text):
                 text = _CFG_DOTTED_RE.sub(_redact_env, text)
-                text = _CFG_ANCHORED_RE.sub(_redact_env, text)
+
+                def _redact_anchored(m):
+                    key = m.group("anchored_key")
+                    value = m.group("anchored_value")
+                    if _ENV_LOOKUP_VALUE_RE.match(value):
+                        return m.group(0)
+                    if not _key_has_secret_keyword(key):
+                        return m.group(0)
+                    sep = m.group("anchored_sep")
+                    quote = m.group("anchored_quote")
+                    return f"{key}{sep}{quote}{value_mask(value)}{quote}"
+
+                text = _CFG_ANCHORED_RE.sub(_redact_anchored, text)
 
         # JSON fields: "apiKey": "***"  (skip for code files — false positives)
         if ":" in text and '"' in text:

--- a/agent/redact.py
+++ b/agent/redact.py
@@ -235,22 +235,26 @@ _TOML_SECRET_ASSIGN_RE = re.compile(
     rf")",
     re.MULTILINE,
 )
+_TOML_INLINE_KEY_RE = re.compile(
+    rf"(?P<toml_inline_key>{_TOML_KEY_SEGMENT}"
+    rf"(?:[ \t]*+\.[ \t]*+{_TOML_KEY_SEGMENT})*+)"
+    rf"(?P<toml_inline_sep>[ \t]*+=[ \t]*+)",
+)
 
-# Unquoted YAML / colon config (e.g. ``password: secret``,
-# ``spring.datasource.password: hunter2``). The secret keyword must be part of
-# the KEY (anchored to the start of the line/indent), and the value is a single
-# whitespace-free token — so prose like ``note: secret meeting`` (keyword in the
-# value) and ``error: token expired`` are left alone. Bare ``auth`` is excluded
-# from the key set so ``Authorization:`` / ``author:`` don't match (the former
-# is masked by _AUTH_HEADER_RE); ``auth_token``/``auth-token`` still match via
-# the ``token`` keyword. Both quoted and unquoted scalar values are supported.
-_YAML_CFG_NAMES = r"(?:api[ _.\-]?key|token|secret|passwd|password|credential)"
-# NOTE(perf): possessive quantifiers wherever the successor is disjoint; the
-# leading ``[A-Za-z0-9_.\-]*`` stays backtrackable (see _CFG_DOTTED_RE note).
+
+# YAML / colon config assignments. Keys may be plain scalars or single-/double-
+# quoted scalars; quoted keys are common when they contain dots. Keep the match
+# line-anchored and newline-bounded so prose/source snippets do not become a
+# broader redaction surface. Secret semantics are validated from the decoded-ish
+# key spelling in the callback rather than embedded in this structural regex.
+_YAML_KEY = r'(?:[A-Za-z0-9_.\-]++|"(?:\\[^\r\n]|[^"\\\r\n])*+"|\'(?:\'\'|[^\'\r\n])*+\')'
 _YAML_ASSIGN_RE = re.compile(
-    rf"(^[ \t]*+(?:\d+\|)?[ \t]*+[A-Za-z0-9_.\-]*{_YAML_CFG_NAMES}[A-Za-z0-9_.\-]*+)"
-    rf"(:[ \t]*+)(['\"]?)([^\s&]+?)\3(?=[\s&]|$)",
-    re.IGNORECASE | re.MULTILINE,
+    rf"(?P<yaml_prefix>^[ \t]*+(?:\d+\|)?[ \t]*+)"
+    rf"(?P<yaml_key>{_YAML_KEY})"
+    rf"(?P<yaml_sep>:[ \t]*+)"
+    rf"(?P<yaml_quote>['\"]?)(?P<yaml_value>[^\s&]+?)(?P=yaml_quote)"
+    rf"(?=[\s&]|$)",
+    re.MULTILINE,
 )
 
 # Word-boundary validation for the mixed/lowercase key patterns above
@@ -340,13 +344,117 @@ def _key_has_secret_keyword(key: str) -> bool:
             return True
     return False
 
-# JSON field pattern. Match a bounded key and validate secret-bearing word
-# boundaries in the callback so provider names such as ``exaApiKey`` and
-# ``braveSearchApiKey`` are covered without treating words like ``monkey`` as
-# credentials.
+# JSON field pattern. Match bounded key names and a complete JSON string value,
+# including escaped quotes/backslashes. Stopping at the first escaped quote can
+# leak the remaining tail and turn otherwise valid JSON into invalid output.
+_JSON_STRING_BODY = r'(?:\\(?:["\\/bfnrt]|u[0-9A-Fa-f]{4})|[^"\\\x00-\x1f])*+'
 _JSON_FIELD_RE = re.compile(
-    r'("([A-Za-z0-9_.-]{1,128})")\s*:\s*"([^"]+)"',
+    rf'(?P<json_key>"(?P<json_key_name>[A-Za-z0-9_.-]{{1,128}})")'
+    rf'(?P<json_sep>\s*+:\s*+)"(?P<json_value>{_JSON_STRING_BODY})"',
 )
+
+def _toml_string_end(text: str, start: int) -> tuple[int, int] | None:
+    """Return ``(exclusive_end, quote_width)`` for a TOML string at *start*.
+
+    The scan is linear and newline-bounded for ordinary strings. Triple-quoted
+    strings are recognized so braces inside them are never mistaken for inline
+    tables, even though inline-table secret values currently use scalar strings.
+    """
+    quote = text[start]
+    width = 3 if text.startswith(quote * 3, start) else 1
+    i = start + width
+    while i < len(text):
+        if text.startswith(quote * width, i):
+            return i + width, width
+        if quote == '"' and text[i] == "\\":
+            i += 2
+            continue
+        if width == 1 and text[i] in "\r\n":
+            return None
+        i += 1
+    return None
+
+
+def _redact_toml_inline_tables(text: str, value_mask) -> str:
+    """Redact scalar secret assignments inside structural TOML inline tables.
+
+    This small scanner tracks table/array nesting and skips strings and comments,
+    so dict-like text inside an ordinary TOML string is not treated as syntax.
+    Key and scalar-value token regexes are line-bounded and possessive; the
+    surrounding scan is iterative and linear rather than recursively parsing
+    nested inline tables.
+    """
+    stack: list[list[object]] = []  # [container delimiter, expects_key]
+    replacements: list[tuple[int, int, str]] = []
+    i = 0
+    while i < len(text):
+        ch = text[i]
+
+        if ch == "#":
+            newline = text.find("\n", i + 1)
+            i = len(text) if newline == -1 else newline + 1
+            continue
+
+        if stack and stack[-1][0] == "{" and stack[-1][1]:
+            if ch in " \t":
+                i += 1
+                continue
+            key_match = _TOML_INLINE_KEY_RE.match(text, i)
+            stack[-1][1] = False
+            if key_match:
+                key = key_match.group("toml_inline_key")
+                i = key_match.end()
+                if _key_has_secret_keyword(key) and i < len(text):
+                    if text[i] in "\"'":
+                        string_info = _toml_string_end(text, i)
+                        if string_info is not None:
+                            end, quote_width = string_info
+                            value_start = i + quote_width
+                            value_end = end - quote_width
+                            value = text[value_start:value_end]
+                            if not _ENV_LOOKUP_VALUE_RE.match(value):
+                                replacements.append(
+                                    (value_start, value_end, value_mask(value))
+                                )
+                            i = end
+                            continue
+                    else:
+                        value_end = i
+                        while (
+                            value_end < len(text)
+                            and text[value_end] not in " \t\r\n,#}"
+                        ):
+                            value_end += 1
+                        if value_end > i:
+                            value = text[i:value_end]
+                            if not _ENV_LOOKUP_VALUE_RE.match(value):
+                                replacements.append((i, value_end, value_mask(value)))
+                            i = value_end
+                            continue
+                continue
+
+        if ch in "\"'":
+            string_info = _toml_string_end(text, i)
+            if string_info is None:
+                break
+            i = string_info[0]
+            continue
+        if ch == "{":
+            stack.append(["{", True])
+        elif ch == "[":
+            stack.append(["[", False])
+        elif ch == "}" and stack and stack[-1][0] == "{":
+            stack.pop()
+        elif ch == "]" and stack and stack[-1][0] == "[":
+            stack.pop()
+        elif ch == "," and stack and stack[-1][0] == "{":
+            stack[-1][1] = True
+        i += 1
+
+    for start, end, replacement in reversed(replacements):
+        text = text[:start] + replacement + text[end:]
+    return text
+
 
 # Authorization headers — any scheme (Bearer, Basic, Token, Digest, …) plus the
 # bare-credential form, and Proxy-Authorization. The credential token is masked
@@ -970,6 +1078,7 @@ def redact_sensitive_text(
             )
 
         text = _TOML_SECRET_ASSIGN_RE.sub(_redact_toml_assignment, text)
+        text = _redact_toml_inline_tables(text, value_mask)
 
     # Known prefixes (sk-, ghp_, etc.) — gate on substring presence
     if _has_known_prefix_substring(text):
@@ -1041,7 +1150,10 @@ def redact_sensitive_text(
         # JSON fields: "apiKey": "***"  (skip for code files — false positives)
         if ":" in text and '"' in text:
             def _redact_json(m):
-                key, key_name, value = m.group(1), m.group(2), m.group(3)
+                key = m.group("json_key")
+                key_name = m.group("json_key_name")
+                sep = m.group("json_sep")
+                value = m.group("json_value")
                 # Same programmatic-env-lookup exception as _redact_env above
                 # (issue #2852): "apiKey": "os.getenv('X')" is a code snippet,
                 # not a leaked secret value.
@@ -1049,15 +1161,23 @@ def redact_sensitive_text(
                     return m.group(0)
                 if key_name.casefold() != "bearer" and not _key_has_secret_keyword(key_name):
                     return m.group(0)
-                return f'{key}: "{value_mask(value)}"'
+                return f'{key}{sep}"{value_mask(value)}"'
             text = _JSON_FIELD_RE.sub(_redact_json, text)
 
         # YAML / colon config: password: *** (quoted or unquoted scalar).
         # Skip URLs — web-URL query params pass through by design.
-        if ":" in text and "://" not in text:
+        if (
+            ":" in text
+            and "://" not in text
+            and _CFG_SECRET_WORD_RE.search(text)
+        ):
             def _redact_yaml(m):
-                key, sep, quote, value = (
-                    m.group(1), m.group(2), m.group(3), m.group(4)
+                prefix, key, sep, quote, value = (
+                    m.group("yaml_prefix"),
+                    m.group("yaml_key"),
+                    m.group("yaml_sep"),
+                    m.group("yaml_quote"),
+                    m.group("yaml_value"),
                 )
                 # Same programmatic-env-lookup exception as _redact_env above
                 # (issue #2852): api_key: os.getenv('X') is a code snippet,
@@ -1069,7 +1189,7 @@ def redact_sensitive_text(
                 # document text, not credentials (nearai/ironclaw#6129).
                 if not _key_has_secret_keyword(key):
                     return m.group(0)
-                return f"{key}{sep}{quote}{value_mask(value)}{quote}"
+                return f"{prefix}{key}{sep}{quote}{value_mask(value)}{quote}"
             text = _YAML_ASSIGN_RE.sub(_redact_yaml, text)
 
     # Authorization headers — _AUTH_HEADER_RE matches any scheme after

--- a/agent/web_search_registry.py
+++ b/agent/web_search_registry.py
@@ -391,6 +391,10 @@ def get_active_search_provider() -> Optional[WebSearchProvider]:
     fallback) from config.yaml; falls back per the module docstring.
     """
     explicit = _read_config_key("web", "search_backend") or _read_config_key("web", "backend")
+    if explicit:
+        from hermes_cli.config import normalize_web_backend_provider_id
+
+        explicit = normalize_web_backend_provider_id(explicit)
     return _resolve(explicit, capability="search")
 
 
@@ -401,6 +405,10 @@ def get_active_extract_provider() -> Optional[WebSearchProvider]:
     fallback) from config.yaml; falls back per the module docstring.
     """
     explicit = _read_config_key("web", "extract_backend") or _read_config_key("web", "backend")
+    if explicit:
+        from hermes_cli.config import normalize_web_backend_provider_id
+
+        explicit = normalize_web_backend_provider_id(explicit)
     return _resolve(explicit, capability="extract")
 
 

--- a/apps/desktop/src/lib/mcp-tool-filter.test.ts
+++ b/apps/desktop/src/lib/mcp-tool-filter.test.ts
@@ -20,6 +20,10 @@ describe('isToolEnabled', () => {
     expect(isToolEnabled({ command: 'x' }, 'anything')).toBe(true)
   })
 
+  it('disables everything with an explicit empty include', () => {
+    expect(isToolEnabled({ tools: { include: [] } }, 'anything')).toBe(false)
+  })
+
   it('include wins over exclude', () => {
     const server = { tools: { exclude: ['a'], include: ['a'] } }
     expect(isToolEnabled(server, 'a')).toBe(true)
@@ -54,6 +58,16 @@ describe('toggleToolInServer', () => {
     expect(next.tools).toEqual({ include: ['b', 'a'] })
   })
 
+  it('respects explicit empty include mode when re-enabling a tool', () => {
+    const next = toggleToolInServer({ tools: { include: [] } }, 'a')
+    expect(next.tools).toEqual({ include: ['a'] })
+  })
+
+  it('preserves an empty include after disabling its last tool', () => {
+    const next = toggleToolInServer({ tools: { include: ['a'] } }, 'a')
+    expect(next.tools).toEqual({ include: [] })
+  })
+
   it('preserves sibling tools keys like resources/prompts', () => {
     const next = toggleToolInServer({ tools: { resources: false } }, 'a')
     expect(next.tools).toEqual({ exclude: ['a'], resources: false })
@@ -70,5 +84,9 @@ describe('countEnabledTools', () => {
   it('counts enabled tools out of a discovered list', () => {
     const server = { tools: { exclude: ['b'] } }
     expect(countEnabledTools(server, ['a', 'b', 'c'])).toBe(2)
+  })
+
+  it('counts zero for an explicit empty include', () => {
+    expect(countEnabledTools({ tools: { include: [] } }, ['a', 'b'])).toBe(0)
   })
 })

--- a/apps/desktop/src/lib/mcp-tool-filter.ts
+++ b/apps/desktop/src/lib/mcp-tool-filter.ts
@@ -28,19 +28,20 @@ export function readToolsFilter(server: ServerConfig | null | undefined): McpToo
 export function isToolEnabled(server: ServerConfig | null | undefined, name: string): boolean {
   const { exclude, include } = readToolsFilter(server)
 
-  return include?.length ? include.includes(name) : !exclude?.includes(name)
+  return include !== undefined ? include.includes(name) : !exclude?.includes(name)
 }
 
 // Toggle one tool, preserving the config's mode (include if present, else an
-// exclude denylist). Empty lists — and an emptied `tools` — are dropped.
+// exclude denylist). An empty include is preserved because it means none;
+// empty excludes — and an otherwise emptied `tools` — are dropped.
 export function toggleToolInServer(server: ServerConfig, name: string): ServerConfig {
   const { exclude, include } = readToolsFilter(server)
-  const key = include?.length ? 'include' : 'exclude'
+  const key = include !== undefined ? 'include' : 'exclude'
   const current = (key === 'include' ? include : exclude) ?? []
   const names = current.includes(name) ? current.filter(n => n !== name) : [...current, name]
   const tools = { ...toolsObject(server) }
 
-  if (names.length) {
+  if (names.length || key === 'include') {
     tools[key] = names
   } else {
     delete tools[key]

--- a/contributors/emails/richjojo1206@gmail.com
+++ b/contributors/emails/richjojo1206@gmail.com
@@ -1,0 +1,1 @@
+rich-jojo

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2169,7 +2169,7 @@ def _known_web_backend_providers() -> Tuple[Dict[str, Any], Set[str]]:
     return registered, catalog_ids
 
 
-def _validate_web_backend_config_value(
+def validate_web_backend_config_value(
     key: str, value: Any
 ) -> Optional["ConfigIssue"]:
     """Validate a web backend ID and its per-key capability contract."""
@@ -2242,7 +2242,7 @@ def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["
         for leaf in ("backend", "search_backend", "extract_backend"):
             if leaf not in web_cfg:
                 continue
-            issue = _validate_web_backend_config_value(
+            issue = validate_web_backend_config_value(
                 f"web.{leaf}", web_cfg.get(leaf)
             )
             if issue is not None:
@@ -5732,7 +5732,7 @@ def set_config_value(key: str, value: str, force: bool = False):
         return
 
     if not force:
-        web_backend_issue = _validate_web_backend_config_value(key, value)
+        web_backend_issue = validate_web_backend_config_value(key, value)
         if web_backend_issue is not None:
             print(f"✗ {web_backend_issue.message}", file=sys.stderr)
             print(f"  {web_backend_issue.hint}", file=sys.stderr)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2130,6 +2130,96 @@ class ConfigIssue:
     hint: str
 
 
+_WEB_BACKEND_CONFIG_CAPABILITIES = {
+    "web.backend": None,
+    "web.search_backend": "search",
+    "web.extract_backend": "extract",
+}
+
+
+def _known_web_backend_providers() -> Tuple[Dict[str, Any], Set[str]]:
+    """Return registered providers and all discovered plugin catalog IDs.
+
+    Provider registration is independent of credentials, so capability checks
+    remain useful on fresh installs. Manifest IDs are included as a fallback
+    for known-but-disabled plugins that intentionally did not register.
+    """
+    from agent.web_search_registry import list_providers
+    from hermes_cli.plugins import _ensure_plugins_discovered
+
+    manager = _ensure_plugins_discovered()
+    registered = {provider.name: provider for provider in list_providers()}
+    catalog_ids = set(registered)
+    for loaded in manager._plugins.values():
+        plugin_path = Path(loaded.manifest.path or "")
+        manifest_path = plugin_path / "plugin.yaml"
+        if not manifest_path.is_file():
+            manifest_path = plugin_path / "plugin.yml"
+        if not manifest_path.is_file():
+            continue
+        try:
+            manifest_data = yaml.safe_load(
+                manifest_path.read_text(encoding="utf-8")
+            ) or {}
+        except (OSError, yaml.YAMLError):
+            continue
+        for provider_id in manifest_data.get("provides_web_providers") or []:
+            if isinstance(provider_id, str) and provider_id.strip():
+                catalog_ids.add(provider_id.strip())
+    return registered, catalog_ids
+
+
+def _validate_web_backend_config_value(
+    key: str, value: Any
+) -> Optional["ConfigIssue"]:
+    """Validate a web backend ID and its per-key capability contract."""
+    capability = _WEB_BACKEND_CONFIG_CAPABILITIES.get(key)
+    if key not in _WEB_BACKEND_CONFIG_CAPABILITIES:
+        return None
+    if isinstance(value, str) and not value.strip():
+        return None
+    if not isinstance(value, str):
+        return ConfigIssue(
+            "error",
+            f"{key} must be a web provider ID string, got {type(value).__name__}",
+            f"Run 'hermes tools' to choose a provider, or: hermes config set {key} <provider>",
+        )
+
+    registered, catalog_ids = _known_web_backend_providers()
+    provider = registered.get(value)
+    if provider is not None:
+        if capability == "search" and not provider.supports_search():
+            return ConfigIssue(
+                "error",
+                f"{key} provider {value!r} does not support search",
+                f"Run 'hermes tools' to choose a search provider, or: hermes config set {key} <provider>",
+            )
+        if capability == "extract" and not provider.supports_extract():
+            return ConfigIssue(
+                "error",
+                f"{key} provider {value!r} does not support extraction",
+                f"Run 'hermes tools' to choose an extract provider, or: hermes config set {key} <provider>",
+            )
+        return None
+    if value in catalog_ids:
+        return None
+
+    eligible_ids = set(catalog_ids) - set(registered)
+    for provider_id, candidate in registered.items():
+        if capability == "search" and not candidate.supports_search():
+            continue
+        if capability == "extract" and not candidate.supports_extract():
+            continue
+        eligible_ids.add(provider_id)
+    known = ", ".join(sorted(eligible_ids)) or "none discovered"
+    return ConfigIssue(
+        "error",
+        f"{key} names unknown web provider {value!r} (eligible: {known})",
+        f"Run 'hermes tools' to choose a provider, or: hermes config set {key} <provider>. "
+        "For an advanced custom plugin provider, use 'hermes config set --force ...'.",
+    )
+
+
 def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["ConfigIssue"]:
     """Validate config.yaml structure and return a list of detected issues.
 
@@ -2145,6 +2235,18 @@ def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["
             return [ConfigIssue("error", "Could not load config.yaml", "Run 'hermes setup' to create a valid config")]
 
     issues: List[ConfigIssue] = []
+
+    # ── web backend IDs and per-capability support ───────────────────────
+    web_cfg = config.get("web")
+    if isinstance(web_cfg, dict):
+        for leaf in ("backend", "search_backend", "extract_backend"):
+            if leaf not in web_cfg:
+                continue
+            issue = _validate_web_backend_config_value(
+                f"web.{leaf}", web_cfg.get(leaf)
+            )
+            if issue is not None:
+                issues.append(issue)
 
     # ── voice.submit_mode: direct | draft ────────────────────────────────
     voice_cfg = config.get("voice")
@@ -5576,13 +5678,14 @@ def set_config_value(key: str, value: str, force: bool = False):
     Args:
         key: Dotted config path (e.g. ``terminal.backend``).
         value: String value (auto-coerced to bool/int/float when matching).
-        force: When True, skip the unknown-key warning — useful for scripted
-            writes of keys the running version doesn't recognize yet — AND
-            authorize destructive replacement of a mapping section by a
-            scalar (e.g. ``--force model gpt-x`` replaces the whole ``model:``
-            mapping). Without --force, scalar writes over mapping sections are
-            refused (bare ``model`` is redirected to ``model.default``). The
-            CLI exposes this via ``hermes config set --force``.
+        force: When True, bypass key/value validation — useful for advanced
+            custom plugin settings or scripted writes of keys the running
+            version does not recognize yet — AND authorize destructive
+            replacement of a mapping section by a scalar (e.g. ``--force
+            model gpt-x`` replaces the whole ``model:`` mapping). Without
+            --force, scalar writes over mapping sections are refused (bare
+            ``model`` is redirected to ``model.default``). The CLI exposes
+            this via ``hermes config set --force``.
     """
     if is_managed():
         managed_error("set configuration values")
@@ -5627,6 +5730,13 @@ def set_config_value(key: str, value: str, force: bool = False):
         save_provider_env_credential(key.upper(), value)
         print(f"✓ Set {key} in {get_env_path()}")
         return
+
+    if not force:
+        web_backend_issue = _validate_web_backend_config_value(key, value)
+        if web_backend_issue is not None:
+            print(f"✗ {web_backend_issue.message}", file=sys.stderr)
+            print(f"  {web_backend_issue.hint}", file=sys.stderr)
+            sys.exit(1)
 
     # Unknown-key notice (#34067): the key is still written (arbitrary keys
     # are supported — top-level scalars are bridged into os.environ for
@@ -5946,7 +6056,7 @@ def config_command(args):
             print("  hermes config set terminal.backend docker")
             print("  hermes config set OPENROUTER_API_KEY sk-or-...")
             print()
-            print("  --force: skip the unknown-key notice for unrecognized keys,")
+            print("  --force: bypass key/value validation for advanced custom plugins,")
             print("           and allow a scalar to replace a whole mapping section")
             sys.exit(1)
         try:
@@ -6071,8 +6181,20 @@ def config_command(args):
             print()
             print(color(f"  {len(missing_config)} new config option(s) available", Colors.YELLOW))
             print("    Run 'hermes config migrate' to add them")
+
+        config_issues = validate_config_structure()
+        if config_issues:
+            print()
+            print(color("  Config validation:", Colors.BOLD))
+            for issue in config_issues:
+                marker = "✗" if issue.severity == "error" else "⚠"
+                issue_color = Colors.RED if issue.severity == "error" else Colors.YELLOW
+                print(color(f"    {marker} {issue.message}", issue_color))
+                print(f"      {issue.hint}")
         
         print()
+        if any(issue.severity == "error" for issue in config_issues):
+            sys.exit(1)
     
     else:
         print(f"Unknown config command: {subcmd}")

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2131,18 +2131,74 @@ class ConfigIssue:
 
 
 _WEB_BACKEND_CONFIG_CAPABILITIES = {
-    "web.backend": None,
-    "web.search_backend": "search",
-    "web.extract_backend": "extract",
+    # The shared backend services both tools; capability-specific overrides
+    # may select providers that implement only their one tool.
+    "web.backend": ("search", "extract"),
+    "web.search_backend": ("search",),
+    "web.extract_backend": ("extract",),
+}
+_WEB_BACKEND_PROVIDER_ALIASES = {
+    # ``hermes tools`` stores this sentinel so Firecrawl routes through the
+    # managed Nous gateway. The registry provider remains ``firecrawl``.
+    "nous": "firecrawl",
 }
 
 
-def _known_web_backend_providers() -> Tuple[Dict[str, Any], Set[str]]:
-    """Return registered providers and all discovered plugin catalog IDs.
+def normalize_web_backend_provider_id(value: str) -> str:
+    """Return the registry provider ID that implements a stored selection."""
+    normalized = value.strip()
+    return _WEB_BACKEND_PROVIDER_ALIASES.get(normalized, normalized)
+
+
+@dataclass(frozen=True)
+class EffectiveWebBackendSelection:
+    """One capability's effective explicit web provider selection."""
+
+    source_key: str
+    configured_value: Any
+    provider_id: Optional[str]
+
+
+def effective_web_backend_selection(
+    web_config: Any, capability: str
+) -> Optional[EffectiveWebBackendSelection]:
+    """Resolve per-capability override → shared backend and normalize aliases."""
+    if capability not in {"search", "extract"} or not isinstance(web_config, dict):
+        return None
+    capability_leaf = f"{capability}_backend"
+    for leaf in (capability_leaf, "backend"):
+        if leaf not in web_config:
+            continue
+        value = web_config.get(leaf)
+        if isinstance(value, str):
+            if not value.strip():
+                continue
+            configured_value: Any = value.strip()
+            provider_id: Optional[str] = normalize_web_backend_provider_id(
+                configured_value
+            )
+        else:
+            # Preserve malformed explicit values so doctor can report the same
+            # type error as config set/check rather than showing a healthy auto
+            # fallback. No registry provider can resolve a non-string ID.
+            configured_value = value
+            provider_id = None
+        return EffectiveWebBackendSelection(
+            source_key=f"web.{leaf}",
+            configured_value=configured_value,
+            provider_id=provider_id,
+        )
+    return None
+
+
+def _known_web_backend_providers(
+) -> Tuple[Dict[str, Any], Set[str], Dict[str, str]]:
+    """Return registered providers, catalog IDs, and disabled plugin keys.
 
     Provider registration is independent of credentials, so capability checks
-    remain useful on fresh installs. Manifest IDs are included as a fallback
-    for known-but-disabled plugins that intentionally did not register.
+    remain useful on fresh installs. Manifest IDs are included for diagnostics
+    when a plugin did not register; explicitly disabled plugins are tracked
+    separately so a known catalog ID cannot be mistaken for a usable provider.
     """
     from agent.web_search_registry import list_providers
     from hermes_cli.plugins import _ensure_plugins_discovered
@@ -2150,7 +2206,8 @@ def _known_web_backend_providers() -> Tuple[Dict[str, Any], Set[str]]:
     manager = _ensure_plugins_discovered()
     registered = {provider.name: provider for provider in list_providers()}
     catalog_ids = set(registered)
-    for loaded in manager._plugins.values():
+    disabled_plugins: Dict[str, str] = {}
+    for plugin_key, loaded in manager._plugins.items():
         plugin_path = Path(loaded.manifest.path or "")
         manifest_path = plugin_path / "plugin.yaml"
         if not manifest_path.is_file():
@@ -2165,17 +2222,33 @@ def _known_web_backend_providers() -> Tuple[Dict[str, Any], Set[str]]:
             continue
         for provider_id in manifest_data.get("provides_web_providers") or []:
             if isinstance(provider_id, str) and provider_id.strip():
-                catalog_ids.add(provider_id.strip())
-    return registered, catalog_ids
+                normalized_id = provider_id.strip()
+                catalog_ids.add(normalized_id)
+                if not loaded.enabled and loaded.error == "disabled via config":
+                    disabled_plugins[normalized_id] = plugin_key
+    return registered, catalog_ids, disabled_plugins
 
 
 def validate_web_backend_config_value(
-    key: str, value: Any
+    key: str,
+    value: Any,
+    *,
+    required_capabilities: Optional[Tuple[str, ...]] = None,
 ) -> Optional["ConfigIssue"]:
-    """Validate a web backend ID and its per-key capability contract."""
-    capability = _WEB_BACKEND_CONFIG_CAPABILITIES.get(key)
+    """Validate a web backend ID and its effective capability contract.
+
+    ``required_capabilities`` lets capability-specific consumers validate a
+    shared ``web.backend`` selection while retaining the actual source key in
+    diagnostics. Config writes/checks omit it and enforce the key's full
+    contract (both search and extract for the shared backend).
+    """
     if key not in _WEB_BACKEND_CONFIG_CAPABILITIES:
         return None
+    capabilities = (
+        required_capabilities
+        if required_capabilities is not None
+        else _WEB_BACKEND_CONFIG_CAPABILITIES[key]
+    )
     if isinstance(value, str) and not value.strip():
         return None
     if not isinstance(value, str):
@@ -2185,30 +2258,38 @@ def validate_web_backend_config_value(
             f"Run 'hermes tools' to choose a provider, or: hermes config set {key} <provider>",
         )
 
-    registered, catalog_ids = _known_web_backend_providers()
-    provider = registered.get(value)
+    provider_id = normalize_web_backend_provider_id(value)
+    registered, catalog_ids, disabled_plugins = _known_web_backend_providers()
+    disabled_plugin = disabled_plugins.get(provider_id)
+    if disabled_plugin is not None:
+        return ConfigIssue(
+            "error",
+            f"{key} provider {value!r} is unavailable because plugin {disabled_plugin!r} is disabled",
+            f"Re-enable it with 'hermes plugins enable {disabled_plugin}', or remove it from plugins.disabled.",
+        )
+    provider = registered.get(provider_id)
     if provider is not None:
-        if capability == "search" and not provider.supports_search():
+        if "search" in capabilities and not provider.supports_search():
             return ConfigIssue(
                 "error",
                 f"{key} provider {value!r} does not support search",
                 f"Run 'hermes tools' to choose a search provider, or: hermes config set {key} <provider>",
             )
-        if capability == "extract" and not provider.supports_extract():
+        if "extract" in capabilities and not provider.supports_extract():
             return ConfigIssue(
                 "error",
                 f"{key} provider {value!r} does not support extraction",
                 f"Run 'hermes tools' to choose an extract provider, or: hermes config set {key} <provider>",
             )
         return None
-    if value in catalog_ids:
+    if provider_id in catalog_ids:
         return None
 
-    eligible_ids = set(catalog_ids) - set(registered)
+    eligible_ids = set(catalog_ids) - set(registered) - set(disabled_plugins)
     for provider_id, candidate in registered.items():
-        if capability == "search" and not candidate.supports_search():
+        if "search" in capabilities and not candidate.supports_search():
             continue
-        if capability == "extract" and not candidate.supports_extract():
+        if "extract" in capabilities and not candidate.supports_extract():
             continue
         eligible_ids.add(provider_id)
     known = ", ".join(sorted(eligible_ids)) or "none discovered"

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -299,15 +299,20 @@ def _doctor_web_capability_rows() -> list[tuple[str, str, str]]:
     """Return doctor rows for web search/extract provider readiness (#78412).
 
     Each row is ``(status, label, detail)`` where *status* is ``ok`` or ``warn``.
-    Uses the same active-provider resolvers as the tools, but reports readiness
-    from ``is_available()`` so an explicitly selected but unconfigured backend
-    does not look healthy.
+    Explicit selections are validated before provider resolution so an unknown
+    or capability-incompatible backend cannot silently look healthy via an
+    unrelated fallback. Auto selection still uses the same active-provider
+    resolvers as the tools. Readiness comes from ``is_available()``.
     """
     rows: list[tuple[str, str, str]] = []
     try:
         from agent.web_search_registry import (
             get_active_extract_provider,
             get_active_search_provider,
+        )
+        from hermes_cli.config import (
+            load_config,
+            validate_web_backend_config_value,
         )
         from tools.web_tools import _ensure_web_plugins_loaded, _provider_is_ready
 
@@ -316,13 +321,25 @@ def _doctor_web_capability_rows() -> list[tuple[str, str, str]]:
         # Without this the registry is empty and every row reads
         # "no provider selected or registered" (idempotent, cheap on rerun).
         _ensure_web_plugins_loaded()
+        web_config = load_config().get("web") or {}
+        if not isinstance(web_config, dict):
+            web_config = {}
     except Exception:
         return rows
 
-    for capability, getter in (
-        ("web search", get_active_search_provider),
-        ("web extract", get_active_extract_provider),
+    for capability, label, getter in (
+        ("search", "web search", get_active_search_provider),
+        ("extract", "web extract", get_active_extract_provider),
     ):
+        key = f"web.{capability}_backend"
+        explicit = (
+            web_config.get(f"{capability}_backend") or web_config.get("backend")
+        )
+        if explicit:
+            issue = validate_web_backend_config_value(key, explicit)
+            if issue is not None:
+                rows.append(("warn", label, f"({issue.message})"))
+                continue
         try:
             provider = getter()
         except Exception:
@@ -331,19 +348,19 @@ def _doctor_web_capability_rows() -> list[tuple[str, str, str]]:
             rows.append(
                 (
                     "warn",
-                    capability,
+                    label,
                     "(no provider selected or registered)",
                 )
             )
             continue
         name = getattr(provider, "name", None) or type(provider).__name__
         if _provider_is_ready(provider):
-            rows.append(("ok", capability, f"({name})"))
+            rows.append(("ok", label, f"({name})"))
         else:
             rows.append(
                 (
                     "warn",
-                    capability,
+                    label,
                     f"({name} selected; provider not configured)",
                 )
             )

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -309,8 +309,10 @@ def _doctor_web_capability_rows() -> list[tuple[str, str, str]]:
         from agent.web_search_registry import (
             get_active_extract_provider,
             get_active_search_provider,
+            get_provider as get_web_provider,
         )
         from hermes_cli.config import (
+            effective_web_backend_selection,
             load_config,
             validate_web_backend_config_value,
         )
@@ -331,17 +333,22 @@ def _doctor_web_capability_rows() -> list[tuple[str, str, str]]:
         ("search", "web search", get_active_search_provider),
         ("extract", "web extract", get_active_extract_provider),
     ):
-        key = f"web.{capability}_backend"
-        explicit = (
-            web_config.get(f"{capability}_backend") or web_config.get("backend")
-        )
-        if explicit:
-            issue = validate_web_backend_config_value(key, explicit)
+        selection = effective_web_backend_selection(web_config, capability)
+        if selection is not None:
+            issue = validate_web_backend_config_value(
+                selection.source_key,
+                selection.configured_value,
+                required_capabilities=(capability,),
+            )
             if issue is not None:
                 rows.append(("warn", label, f"({issue.message})"))
                 continue
         try:
-            provider = getter()
+            provider = (
+                get_web_provider(selection.provider_id)
+                if selection is not None
+                else getter()
+            )
         except Exception:
             provider = None
         if provider is None:

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -1052,7 +1052,8 @@ def cmd_mcp_configure(args):
         def matches_name_filter(tool_name, patterns):
             return tool_name in patterns
 
-    if include and isinstance(include, list):
+    include_mode = isinstance(include, list)
+    if include_mode:
         include_set = {str(p) for p in include}
         pre_selected = {
             i for i, tn in enumerate(tool_names)
@@ -1091,7 +1092,9 @@ def cmd_mcp_configure(args):
     config = load_config()
     server_entry = cfg_get(config, "mcp_servers", name, default={})
 
-    exclude_mode = bool(exclude) and isinstance(exclude, list) and not include
+    exclude_mode = (
+        isinstance(exclude, list) and bool(exclude) and not include_mode
+    )
 
     if len(chosen) == total and not exclude_mode:
         # All selected → remove include/exclude (register all)

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -721,7 +721,7 @@ def cmd_mcp_list(args=None):
         if isinstance(tools_cfg, dict):
             include = tools_cfg.get("include")
             exclude = tools_cfg.get("exclude")
-            if include and isinstance(include, list):
+            if isinstance(include, list):
                 tools_str = f"{len(include)} selected"
             elif exclude and isinstance(exclude, list):
                 tools_str = f"-{len(exclude)} excluded"
@@ -796,6 +796,23 @@ def cmd_mcp_test(args):
 
     _success(f"Connected ({elapsed_ms:.0f}ms)")
     _success(f"Tools discovered: {len(tools)}")
+
+    # The probe intentionally reports the server's raw tools/list response, but
+    # a configured include/exclude filter can expose fewer tools to the agent.
+    # Use the runtime predicate so explicit include: [] cannot false-green as
+    # "4 tools" when the active agent-visible count is actually zero.
+    from tools.mcp_tool import mcp_tool_filter_predicate
+
+    tool_enabled, filter_active = mcp_tool_filter_predicate(cfg, name)
+    if filter_active:
+        enabled_count = sum(tool_enabled(tool_name) for tool_name, _ in tools)
+        message = (
+            f"Active config enables {enabled_count}/{len(tools)} discovered tools"
+        )
+        if enabled_count == 0:
+            _warning(message + "; agent will see none.")
+        else:
+            _info(message + ".")
 
     if tools:
         print()

--- a/hermes_cli/subcommands/config.py
+++ b/hermes_cli/subcommands/config.py
@@ -43,8 +43,8 @@ def build_config_parser(subparsers, *, cmd_config: Callable) -> None:
     config_set.add_argument(
         "--force",
         action="store_true",
-        help="Skip the unknown-key notice printed after writing a key the "
-        "running version doesn't recognize (the value is saved either way).",
+        help="Bypass config key/value validation for advanced custom plugin "
+        "settings, and allow replacing a mapping section with a scalar.",
     )
 
     # config unset

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -6146,9 +6146,12 @@ def _print_tools_list(enabled_toolsets: set, mcp_servers: dict, platform: str = 
         print("MCP servers:")
         for srv_name, srv_cfg in mcp_servers.items():
             tools_cfg = srv_cfg.get("tools") or {}
-            exclude = tools_cfg.get("exclude") or []
-            include = tools_cfg.get("include") or []
-            if include:
+            exclude = tools_cfg.get("exclude")
+            include = tools_cfg.get("include")
+            if isinstance(include, list):
+                if not include:
+                    _print_info(f"{srv_name}  [0 selected]")
+                    continue
                 _print_info(f"{srv_name}  [include only: {', '.join(include)}]")
             elif exclude:
                 _print_info(f"{srv_name}  [excluded: {color(', '.join(exclude), Colors.YELLOW)}]")

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -5901,8 +5901,8 @@ def _configure_mcp_tools_interactive(config: dict):
     """Probe MCP servers for available tools and let user toggle them on/off.
 
     Connects to each configured MCP server, discovers tools, then shows
-    a per-server curses checklist.  Writes changes back as ``tools.exclude``
-    entries in config.yaml.
+    a per-server curses checklist. Writes changes back using the server's
+    active ``tools.include`` or ``tools.exclude`` filter mode.
     """
     from hermes_cli.curses_ui import curses_checklist
 
@@ -5955,8 +5955,8 @@ def _configure_mcp_tools_interactive(config: dict):
 
         srv_cfg = mcp_servers.get(server_name, {})
         tools_cfg = srv_cfg.get("tools") or {}
-        include_list = tools_cfg.get("include") or []
-        exclude_list = tools_cfg.get("exclude") or []
+        include_list = tools_cfg.get("include")
+        exclude_list = tools_cfg.get("exclude")
 
         # Build checklist labels
         labels = []
@@ -5980,10 +5980,15 @@ def _configure_mcp_tools_interactive(config: dict):
 
         pre_selected: Set[int] = set()
         tool_names = [t[0] for t in tools]
-        include_set = {str(p) for p in include_list} if include_list else None
-        exclude_set = {str(p) for p in exclude_list} if exclude_list else None
+        include_mode = isinstance(include_list, list)
+        include_set = {str(p) for p in include_list} if include_mode else set()
+        exclude_set = (
+            {str(p) for p in exclude_list}
+            if isinstance(exclude_list, list)
+            else set()
+        )
         for i, tool_name in enumerate(tool_names):
-            if include_set:
+            if include_mode:
                 # Include mode: only included tools are selected
                 if _match_filter(tool_name, include_set):
                     pre_selected.add(i)
@@ -6010,7 +6015,7 @@ def _configure_mcp_tools_interactive(config: dict):
         srv_cfg = mcp_servers.setdefault(server_name, {})
         tools_cfg = srv_cfg.setdefault("tools", {})
 
-        exclude_mode = bool(exclude_set) and not include_set
+        exclude_mode = bool(exclude_set) and not include_mode
 
         if len(chosen) == len(tools) and not exclude_mode:
             # All tools enabled — clear filters (cleanest config shape; the

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2820,6 +2820,55 @@ def preflight_db_writability(
             _ensure_writable(p)
 
 
+def _restrict_state_db_permissions(
+    db_path: Path,
+    *,
+    create_main: bool = False,
+) -> None:
+    """Best-effort owner-only permissions for state.db and its sidecars.
+
+    SQLite creates WAL/SHM sidecars with the main database's mode on POSIX, so
+    securing the main file before the WAL pragma prevents permissive umasks
+    from producing 0644 sidecars.  The second pass after schema setup covers
+    existing sidecars and filesystems with different creation behaviour.
+    """
+    if sys.platform.startswith("win"):
+        return
+
+    if create_main and not db_path.exists():
+        try:
+            fd = os.open(
+                db_path,
+                os.O_CREAT | os.O_EXCL | os.O_WRONLY,
+                0o600,
+            )
+        except FileExistsError:
+            pass
+        except OSError:
+            logger.debug(
+                "Failed to create state database with private permissions: %s",
+                db_path,
+                exc_info=True,
+            )
+        else:
+            os.close(fd)
+
+    for candidate in (
+        db_path,
+        db_path.with_name(db_path.name + "-wal"),
+        db_path.with_name(db_path.name + "-shm"),
+    ):
+        try:
+            if candidate.exists():
+                candidate.chmod(0o600)
+        except OSError:
+            logger.debug(
+                "Failed to restrict state database permissions for %s",
+                candidate,
+                exc_info=True,
+            )
+
+
 def _connect_repair_durable(
     db_path: Path, *, timeout: float = 5.0
 ) -> sqlite3.Connection:
@@ -4694,6 +4743,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 if qpath is None and self.db_path.exists() and is_zeroed_state_db(self.db_path):
                     raise sqlite3.DatabaseError(msg)
 
+            # Pre-create a missing main file at 0600 and tighten restored or
+            # legacy files before SQLite derives WAL/SHM modes from it.
+            _restrict_state_db_permissions(self.db_path, create_main=True)
+
             def _connect_and_init():
                 self._conn = _connect_tracked_db(
                     str(self.db_path),
@@ -4715,6 +4768,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 self._conn.execute("PRAGMA foreign_keys=ON")
                 self._fts_cjk_loaded = load_fts5_cjk_extension(self._conn)
                 self._init_schema()
+                _restrict_state_db_permissions(self.db_path)
 
             def _connect_and_init_with_lock_patience():
                 # Lock contention during open: _init_schema's DDL/reconcile

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -170,6 +170,54 @@ class TestDoctorWebBackendSelectionIntegration:
         assert "does not support extraction" in extract_row[2]
         assert extract_row[2] != "(tavily)"
 
+    def test_shared_search_only_backend_reports_extract_capability_mismatch(
+        self, monkeypatch, tmp_path
+    ):
+        self._configure(monkeypatch, tmp_path, {"backend": "searxng"})
+
+        rows = doctor._doctor_web_capability_rows()
+        extract_row = next(row for row in rows if row[1] == "web extract")
+
+        assert extract_row[0] == "warn"
+        assert "web.backend" in extract_row[2]
+        assert "searxng" in extract_row[2]
+        assert "does not support extraction" in extract_row[2]
+        assert extract_row[2] != "(tavily)"
+
+    def test_managed_nous_alias_resolves_to_firecrawl_not_fallback(
+        self, monkeypatch, tmp_path
+    ):
+        self._configure(monkeypatch, tmp_path, {"backend": "nous"})
+
+        rows = doctor._doctor_web_capability_rows()
+
+        assert [label for _, label, _ in rows] == ["web search", "web extract"]
+        assert all("firecrawl" in detail for _, _, detail in rows)
+        assert not any("tavily" in detail for _, _, detail in rows)
+
+    def test_disabled_selected_plugin_is_reported_instead_of_healthy_fallback(
+        self, monkeypatch, tmp_path
+    ):
+        self._configure(monkeypatch, tmp_path, {"extract_backend": "firecrawl"})
+        home = tmp_path / ".hermes"
+        (home / "config.yaml").write_text(
+            "plugins:\n"
+            "  disabled:\n"
+            "    - web/firecrawl\n"
+            "web:\n"
+            "  extract_backend: firecrawl\n",
+            encoding="utf-8",
+        )
+
+        rows = doctor._doctor_web_capability_rows()
+        extract_row = next(row for row in rows if row[1] == "web extract")
+
+        assert extract_row[0] == "warn"
+        assert "firecrawl" in extract_row[2]
+        assert "web/firecrawl" in extract_row[2]
+        assert "disabled" in extract_row[2]
+        assert extract_row[2] != "(tavily)"
+
 
 class TestDoctorEnvFileEncoding:
     """Regression for #18637 (bug 3): `hermes doctor` crashed on Windows

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -125,6 +125,52 @@ class TestDoctorToolAvailabilitySummary:
         ]
 
 
+class TestDoctorWebBackendSelectionIntegration:
+    @staticmethod
+    def _configure(monkeypatch, tmp_path, web_config):
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.setenv("TAVILY_API_KEY", "test-key")
+        (home / "config.yaml").write_text(
+            "web:\n" + "".join(
+                f"  {key}: {value}\n" for key, value in web_config.items()
+            ),
+            encoding="utf-8",
+        )
+
+    def test_explicit_unknown_backends_do_not_report_healthy_fallback(
+        self, monkeypatch, tmp_path
+    ):
+        self._configure(
+            monkeypatch,
+            tmp_path,
+            {"search_backend": "smart-web", "extract_backend": "smart-web"},
+        )
+
+        rows = doctor._doctor_web_capability_rows()
+
+        assert [(status, label) for status, label, _ in rows] == [
+            ("warn", "web search"),
+            ("warn", "web extract"),
+        ]
+        assert all("smart-web" in detail for _, _, detail in rows)
+        assert not any(status == "ok" and detail == "(tavily)" for status, _, detail in rows)
+
+    def test_explicit_extract_capability_mismatch_does_not_report_healthy_fallback(
+        self, monkeypatch, tmp_path
+    ):
+        self._configure(monkeypatch, tmp_path, {"extract_backend": "searxng"})
+
+        rows = doctor._doctor_web_capability_rows()
+        extract_row = next(row for row in rows if row[1] == "web extract")
+
+        assert extract_row[0] == "warn"
+        assert "searxng" in extract_row[2]
+        assert "does not support extraction" in extract_row[2]
+        assert extract_row[2] != "(tavily)"
+
+
 class TestDoctorEnvFileEncoding:
     """Regression for #18637 (bug 3): `hermes doctor` crashed on Windows
     Chinese locale (GBK) because `.env` was read with Path.read_text() which

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -122,6 +122,47 @@ class TestMcpList:
         assert "myserver" in out
         assert "enabled" in out
 
+    def test_list_explicit_empty_include_reports_zero_selected(self, tmp_path, capsys):
+        _seed_config(tmp_path, {
+            "none": {
+                "url": "https://example.com/mcp",
+                "tools": {"include": []},
+            },
+        })
+        from hermes_cli.mcp_config import cmd_mcp_list
+
+        cmd_mcp_list()
+        out = capsys.readouterr().out
+        assert "0 selected" in out
+
+    def test_list_absent_include_reports_all(self, tmp_path, capsys):
+        _seed_config(tmp_path, {
+            "all": {"url": "https://example.com/mcp"},
+        })
+        from hermes_cli.mcp_config import cmd_mcp_list
+
+        cmd_mcp_list()
+        out = capsys.readouterr().out
+        assert "all" in out
+
+    def test_list_nonempty_include_and_exclude_report_filters(self, tmp_path, capsys):
+        _seed_config(tmp_path, {
+            "selected": {
+                "url": "https://example.com/selected",
+                "tools": {"include": ["read", "write"]},
+            },
+            "excluded": {
+                "url": "https://example.com/excluded",
+                "tools": {"exclude": ["delete"]},
+            },
+        })
+        from hermes_cli.mcp_config import cmd_mcp_list
+
+        cmd_mcp_list()
+        out = capsys.readouterr().out
+        assert "2 selected" in out
+        assert "-1 excluded" in out
+
 
 # ---------------------------------------------------------------------------
 # Tests: cmd_mcp_remove
@@ -301,6 +342,81 @@ class TestMcpTest:
         out = capsys.readouterr().out
         assert "Connected" in out
         assert "Tools discovered: 2" in out
+
+    def test_test_explicit_empty_include_warns_agent_sees_none(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        _seed_config(tmp_path, {
+            "smart-web": {
+                "url": "https://example.com/mcp",
+                "tools": {"include": []},
+            },
+        })
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server",
+            lambda name, config, **kw: [
+                ("search_web", "Search"),
+                ("search_news", "News"),
+                ("extract", "Extract"),
+                ("admin_reset", "Reset"),
+            ],
+        )
+        from hermes_cli.mcp_config import cmd_mcp_test
+
+        cmd_mcp_test(_make_args(name="smart-web"))
+        out = capsys.readouterr().out
+        assert "Tools discovered: 4" in out
+        assert "Active config enables 0/4 discovered tools" in out
+        assert "agent will see none" in out
+
+    def test_test_absent_include_keeps_normal_success_output(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        _seed_config(tmp_path, {
+            "smart-web": {"url": "https://example.com/mcp"},
+        })
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server",
+            lambda name, config, **kw: [("search", "Search")],
+        )
+        from hermes_cli.mcp_config import cmd_mcp_test
+
+        cmd_mcp_test(_make_args(name="smart-web"))
+        out = capsys.readouterr().out
+        assert "Tools discovered: 1" in out
+        assert "Active config enables" not in out
+
+    @pytest.mark.parametrize(
+        ("tools_filter", "expected"),
+        [
+            ({"include": ["search_*"]}, "2/4"),
+            ({"exclude": ["admin_*"]}, "3/4"),
+        ],
+    )
+    def test_test_nonempty_filter_reports_agent_visible_count(
+        self, tmp_path, capsys, monkeypatch, tools_filter, expected
+    ):
+        _seed_config(tmp_path, {
+            "smart-web": {
+                "url": "https://example.com/mcp",
+                "tools": tools_filter,
+            },
+        })
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server",
+            lambda name, config, **kw: [
+                ("search_web", "Search"),
+                ("search_news", "News"),
+                ("extract", "Extract"),
+                ("admin_reset", "Reset"),
+            ],
+        )
+        from hermes_cli.mcp_config import cmd_mcp_test
+
+        cmd_mcp_test(_make_args(name="smart-web"))
+        out = capsys.readouterr().out
+        assert "Tools discovered: 4" in out
+        assert f"Active config enables {expected} discovered tools" in out
 
     def test_probe_uses_configured_connect_timeout(self, monkeypatch):
         """OAuth-capable probes must not hard-code a short 30s timeout."""

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -458,6 +458,57 @@ class TestMcpTest:
 
 
 # ---------------------------------------------------------------------------
+# Tests: cmd_mcp_configure
+# ---------------------------------------------------------------------------
+
+class TestMcpConfigure:
+    @pytest.mark.parametrize(
+        ("tools_filter", "expected_pre_selected", "expected_status"),
+        [
+            (None, {0, 1}, "Currently 2/2 tools enabled"),
+            ({"include": []}, set(), "Currently 0/2 tools enabled"),
+            ({"include": ["write"]}, {1}, "Currently 1/2 tools enabled"),
+        ],
+        ids=["absent-include", "empty-include", "nonempty-include"],
+    )
+    def test_configure_preselection_matches_active_include_filter(
+        self,
+        tmp_path,
+        capsys,
+        monkeypatch,
+        tools_filter,
+        expected_pre_selected,
+        expected_status,
+    ):
+        server = {"url": "https://example.com/mcp"}
+        if tools_filter is not None:
+            server["tools"] = tools_filter
+        _seed_config(tmp_path, {"test-server": server})
+        _set_interactive_stdin(monkeypatch)
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server",
+            lambda name, config: [("read", "Read"), ("write", "Write")],
+        )
+
+        captured = {}
+
+        def capture_checklist(title, labels, pre_selected, **kwargs):
+            captured["pre_selected"] = pre_selected
+            return pre_selected
+
+        monkeypatch.setattr(
+            "hermes_cli.curses_ui.curses_checklist", capture_checklist
+        )
+
+        from hermes_cli.mcp_config import cmd_mcp_configure
+
+        cmd_mcp_configure(_make_args())
+
+        assert captured["pre_selected"] == expected_pre_selected
+        assert expected_status in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
 # Tests: env var interpolation
 # ---------------------------------------------------------------------------
 

--- a/tests/hermes_cli/test_mcp_tools_config.py
+++ b/tests/hermes_cli/test_mcp_tools_config.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import patch
 
+import pytest
+
 from hermes_cli.tools_config import _configure_mcp_tools_interactive
 
 # Patch targets: imports happen inside the function body, so patch at source
@@ -10,10 +12,35 @@ _CHECKLIST = "hermes_cli.curses_ui.curses_checklist"
 _SAVE = "hermes_cli.tools_config.save_config"
 
 
+@pytest.mark.parametrize(
+    ("tools_filter", "expected_pre_selected"),
+    [
+        (None, {0, 1}),
+        ({"include": []}, set()),
+        ({"include": ["write"]}, {1}),
+    ],
+    ids=["absent-include", "empty-include", "nonempty-include"],
+)
+def test_configure_preselection_matches_active_include_filter(
+    tools_filter, expected_pre_selected
+):
+    server = {"command": "npx"}
+    if tools_filter is not None:
+        server["tools"] = tools_filter
+    config = {"mcp_servers": {"demo": server}}
+    captured = {}
 
+    def capture_checklist(title, labels, pre_selected, **kwargs):
+        captured["pre_selected"] = pre_selected
+        return pre_selected
 
+    with patch(
+        _PROBE,
+        return_value={"demo": [("read", "Read"), ("write", "Write")]},
+    ), patch(_CHECKLIST, side_effect=capture_checklist), patch(_SAVE):
+        _configure_mcp_tools_interactive(config)
 
-
+    assert captured["pre_selected"] == expected_pre_selected
 
 
 def test_disabling_tool_writes_include_list(capsys):

--- a/tests/hermes_cli/test_tools_disable_enable.py
+++ b/tests/hermes_cli/test_tools_disable_enable.py
@@ -65,6 +65,33 @@ class TestToolsList:
         assert "github" in out
         assert "create_issue" in out
 
+    def test_list_explicit_empty_include_reports_zero_selected(self, capsys):
+        config = {
+            "mcp_servers": {"smart-web": {"tools": {"include": []}}},
+        }
+        with patch("hermes_cli.tools_config.load_config", return_value=config):
+            tools_disable_enable_command(Namespace(tools_action="list", platform="cli"))
+        out = capsys.readouterr().out
+        assert "smart-web" in out
+        assert "0 selected" in out
+
+    def test_list_absent_include_reports_all_tools_enabled(self, capsys):
+        config = {"mcp_servers": {"smart-web": {}}}
+        with patch("hermes_cli.tools_config.load_config", return_value=config):
+            tools_disable_enable_command(Namespace(tools_action="list", platform="cli"))
+        out = capsys.readouterr().out
+        assert "smart-web" in out
+        assert "all tools enabled" in out
+
+    def test_list_nonempty_include_reports_selected_tools(self, capsys):
+        config = {
+            "mcp_servers": {"smart-web": {"tools": {"include": ["search", "extract"]}}},
+        }
+        with patch("hermes_cli.tools_config.load_config", return_value=config):
+            tools_disable_enable_command(Namespace(tools_action="list", platform="cli"))
+        out = capsys.readouterr().out
+        assert "include only: search, extract" in out
+
 
 # ── Validation ───────────────────────────────────────────────────────────────
 

--- a/tests/hermes_cli/test_web_backend_config_validation.py
+++ b/tests/hermes_cli/test_web_backend_config_validation.py
@@ -65,6 +65,19 @@ def test_set_accepts_known_provider_without_credentials(
     assert config[section][leaf] == value
 
 
+def test_set_accepts_managed_nous_alias_as_firecrawl_backend(
+    _isolated_hermes_home
+):
+    set_config_value("web.backend", "nous")
+
+    config = yaml.safe_load(
+        (_isolated_hermes_home / "config.yaml").read_text(encoding="utf-8")
+    )
+    # Preserve the managed-routing selection; only validation normalizes it to
+    # the search+extract-capable Firecrawl provider implementation.
+    assert config["web"]["backend"] == "nous"
+
+
 def test_set_rejects_provider_without_requested_capability(
     _isolated_hermes_home, capsys
 ):
@@ -74,6 +87,42 @@ def test_set_rejects_provider_without_requested_capability(
     assert exc_info.value.code == 1
     assert not (_isolated_hermes_home / "config.yaml").exists()
     assert "does not support extraction" in capsys.readouterr().err
+
+
+def test_set_rejects_search_only_provider_for_shared_backend(
+    _isolated_hermes_home, capsys
+):
+    with pytest.raises(SystemExit) as exc_info:
+        set_config_value("web.backend", "searxng")
+
+    assert exc_info.value.code == 1
+    assert not (_isolated_hermes_home / "config.yaml").exists()
+    error = capsys.readouterr().err
+    assert "web.backend" in error
+    assert "searxng" in error
+    assert "does not support extraction" in error
+
+
+def test_set_rejects_backend_whose_plugin_is_disabled(
+    _isolated_hermes_home, capsys
+):
+    config_path = _isolated_hermes_home / "config.yaml"
+    config_path.write_text(
+        yaml.safe_dump({"plugins": {"disabled": ["web/firecrawl"]}}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        set_config_value("web.search_backend", "firecrawl")
+
+    assert exc_info.value.code == 1
+    assert yaml.safe_load(config_path.read_text(encoding="utf-8")) == {
+        "plugins": {"disabled": ["web/firecrawl"]}
+    }
+    error = capsys.readouterr().err
+    assert "firecrawl" in error
+    assert "web/firecrawl" in error
+    assert "disabled" in error
 
 
 def test_set_force_allows_unregistered_plugin_provider(_isolated_hermes_home):
@@ -108,3 +157,69 @@ def test_config_check_fails_for_stored_unknown_web_backend(
     assert "smart-web" in combined
     assert "hermes config set" in combined
     assert "--force" in combined
+
+
+def test_config_check_reports_backend_whose_plugin_is_disabled(
+    _isolated_hermes_home, capsys
+):
+    from argparse import Namespace
+
+    from hermes_cli.config import config_command
+
+    (_isolated_hermes_home / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "plugins": {"disabled": ["web/firecrawl"]},
+                "web": {"extract_backend": "firecrawl"},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        config_command(Namespace(config_command="check"))
+
+    assert exc_info.value.code == 1
+    combined = "".join(capsys.readouterr())
+    assert "web.extract_backend" in combined
+    assert "web/firecrawl" in combined
+    assert "disabled" in combined
+
+
+def test_config_check_reports_search_only_shared_backend(
+    _isolated_hermes_home, capsys
+):
+    from argparse import Namespace
+
+    from hermes_cli.config import config_command
+
+    (_isolated_hermes_home / "config.yaml").write_text(
+        yaml.safe_dump({"web": {"backend": "searxng"}}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        config_command(Namespace(config_command="check"))
+
+    assert exc_info.value.code == 1
+    combined = "".join(capsys.readouterr())
+    assert "web.backend" in combined
+    assert "searxng" in combined
+    assert "does not support extraction" in combined
+
+
+def test_config_check_accepts_managed_nous_alias(_isolated_hermes_home, capsys):
+    from argparse import Namespace
+
+    from hermes_cli.config import config_command
+
+    (_isolated_hermes_home / "config.yaml").write_text(
+        yaml.safe_dump({"web": {"backend": "nous"}}),
+        encoding="utf-8",
+    )
+
+    config_command(Namespace(config_command="check"))
+
+    combined = "".join(capsys.readouterr())
+    assert "unknown web provider 'nous'" not in combined
+    assert "Config validation" not in combined

--- a/tests/hermes_cli/test_web_backend_config_validation.py
+++ b/tests/hermes_cli/test_web_backend_config_validation.py
@@ -1,0 +1,110 @@
+"""Validation for web provider values written through ``hermes config``."""
+
+import os
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from hermes_cli.config import set_config_value
+
+
+@pytest.fixture(autouse=True)
+def _isolated_hermes_home(tmp_path):
+    """Keep config writes and plugin registry scope away from the real profile."""
+    with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+        yield tmp_path
+
+
+def test_set_rejects_unknown_search_backend_without_persisting(
+    _isolated_hermes_home, capsys
+):
+    with pytest.raises(SystemExit) as exc_info:
+        set_config_value("web.search_backend", "smart-web")
+
+    assert exc_info.value.code == 1
+    assert not (_isolated_hermes_home / "config.yaml").exists()
+    output = capsys.readouterr()
+    combined = output.out + output.err
+    assert "smart-web" in combined
+    assert "web.search_backend" in combined
+    assert "--force" in combined
+
+
+def test_set_rejects_unknown_extract_backend_without_persisting(
+    _isolated_hermes_home, capsys
+):
+    with pytest.raises(SystemExit) as exc_info:
+        set_config_value("web.extract_backend", "smart-web")
+
+    assert exc_info.value.code == 1
+    assert not (_isolated_hermes_home / "config.yaml").exists()
+    output = capsys.readouterr()
+    combined = output.out + output.err
+    assert "smart-web" in combined
+    assert "web.extract_backend" in combined
+    assert "--force" in combined
+
+
+@pytest.mark.parametrize(
+    ("key", "value"),
+    [
+        ("web.search_backend", "searxng"),
+        ("web.extract_backend", "keenable"),
+    ],
+)
+def test_set_accepts_known_provider_without_credentials(
+    _isolated_hermes_home, key, value
+):
+    set_config_value(key, value)
+
+    config = yaml.safe_load(
+        (_isolated_hermes_home / "config.yaml").read_text(encoding="utf-8")
+    )
+    section, leaf = key.split(".")
+    assert config[section][leaf] == value
+
+
+def test_set_rejects_provider_without_requested_capability(
+    _isolated_hermes_home, capsys
+):
+    with pytest.raises(SystemExit) as exc_info:
+        set_config_value("web.extract_backend", "searxng")
+
+    assert exc_info.value.code == 1
+    assert not (_isolated_hermes_home / "config.yaml").exists()
+    assert "does not support extraction" in capsys.readouterr().err
+
+
+def test_set_force_allows_unregistered_plugin_provider(_isolated_hermes_home):
+    set_config_value("web.search_backend", "my-private-search", force=True)
+
+    config = yaml.safe_load(
+        (_isolated_hermes_home / "config.yaml").read_text(encoding="utf-8")
+    )
+    assert config["web"]["search_backend"] == "my-private-search"
+
+
+@pytest.mark.parametrize("key", ["search_backend", "extract_backend"])
+def test_config_check_fails_for_stored_unknown_web_backend(
+    _isolated_hermes_home, capsys, key
+):
+    from argparse import Namespace
+
+    from hermes_cli.config import config_command
+
+    (_isolated_hermes_home / "config.yaml").write_text(
+        yaml.safe_dump({"web": {key: "smart-web"}}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        config_command(Namespace(config_command="check"))
+
+    assert exc_info.value.code == 1
+    output = capsys.readouterr()
+    combined = output.out + output.err
+    assert f"web.{key}" in combined
+    assert "smart-web" in combined
+    assert "hermes config set" in combined
+    assert "--force" in combined

--- a/tests/test_state_db_private_permissions.py
+++ b/tests/test_state_db_private_permissions.py
@@ -20,8 +20,8 @@ pytestmark = pytest.mark.skipif(
 
 
 @contextmanager
-def _permissive_umask():
-    previous = os.umask(0o002)
+def _permissive_umask(mask: int = 0o002):
+    previous = os.umask(mask)
     try:
         yield
     finally:
@@ -40,6 +40,38 @@ def _force_wal(monkeypatch):
         lambda version_info=None: False,
     )
     monkeypatch.setattr(hermes_state, "resolve_journal_mode", lambda: "wal")
+
+
+def test_session_db_first_creation_is_private_with_permissive_umask(
+    tmp_path, monkeypatch
+):
+    db_path = tmp_path / "state.db"
+    assert not db_path.exists()
+
+    real_connect = hermes_state._connect_tracked_db
+
+    def connect_after_private_creation(path, *args, **kwargs):
+        assert db_path.exists()
+        assert _mode(db_path) == 0o600
+        return real_connect(path, *args, **kwargs)
+
+    monkeypatch.setattr(
+        hermes_state, "_connect_tracked_db", connect_after_private_creation
+    )
+
+    with _permissive_umask(0o000):
+        db = SessionDB(db_path=db_path)
+        try:
+            assert db._wal_active is True
+            paths = [db_path, Path(f"{db_path}-wal"), Path(f"{db_path}-shm")]
+            assert all(path.exists() for path in paths)
+            assert {path.name: _mode(path) for path in paths} == {
+                "state.db": 0o600,
+                "state.db-wal": 0o600,
+                "state.db-shm": 0o600,
+            }
+        finally:
+            db.close()
 
 
 def test_session_db_tightens_database_and_created_wal_sidecars(tmp_path):

--- a/tests/test_state_db_private_permissions.py
+++ b/tests/test_state_db_private_permissions.py
@@ -1,0 +1,88 @@
+"""POSIX privacy invariants for the canonical SQLite session store."""
+
+import os
+import sqlite3
+import stat
+import sys
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+
+import hermes_state
+from hermes_state import SessionDB
+
+
+pytestmark = pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason="POSIX mode bits not enforced on Windows",
+)
+
+
+@contextmanager
+def _permissive_umask():
+    previous = os.umask(0o002)
+    try:
+        yield
+    finally:
+        os.umask(previous)
+
+
+def _mode(path: Path) -> int:
+    return stat.S_IMODE(path.stat().st_mode)
+
+
+@pytest.fixture(autouse=True)
+def _force_wal(monkeypatch):
+    monkeypatch.setattr(
+        hermes_state,
+        "is_sqlite_wal_reset_vulnerable",
+        lambda version_info=None: False,
+    )
+    monkeypatch.setattr(hermes_state, "resolve_journal_mode", lambda: "wal")
+
+
+def test_session_db_tightens_database_and_created_wal_sidecars(tmp_path):
+    db_path = tmp_path / "state.db"
+    db_path.touch()
+    db_path.chmod(0o644)
+
+    with _permissive_umask():
+        db = SessionDB(db_path=db_path)
+        try:
+            assert db._wal_active is True
+            paths = [db_path, Path(f"{db_path}-wal"), Path(f"{db_path}-shm")]
+            assert all(path.exists() for path in paths)
+            assert {path.name: _mode(path) for path in paths} == {
+                "state.db": 0o600,
+                "state.db-wal": 0o600,
+                "state.db-shm": 0o600,
+            }
+        finally:
+            db.close()
+
+
+def test_session_db_tightens_existing_wal_sidecars(tmp_path):
+    db_path = tmp_path / "state.db"
+
+    with _permissive_umask():
+        seed = sqlite3.connect(db_path, isolation_level=None)
+        try:
+            assert seed.execute("PRAGMA journal_mode=WAL").fetchone()[0] == "wal"
+            seed.execute("CREATE TABLE seed (value INTEGER)")
+            paths = [db_path, Path(f"{db_path}-wal"), Path(f"{db_path}-shm")]
+            assert all(path.exists() for path in paths)
+            for path in paths:
+                path.chmod(0o644)
+
+            db = SessionDB(db_path=db_path)
+            try:
+                assert {path.name: _mode(path) for path in paths} == {
+                    "state.db": 0o600,
+                    "state.db-wal": 0o600,
+                    "state.db-shm": 0o600,
+                }
+            finally:
+                db.close()
+        finally:
+            seed.close()

--- a/tests/tools/test_file_tool_config_redaction.py
+++ b/tests/tools/test_file_tool_config_redaction.py
@@ -132,6 +132,214 @@ def test_patch_redacts_toml_secret_key_assignment(
     )
 
 
+_INLINE_TOML_SECRET_ASSIGNMENT = (
+    'mcp = { exaApiKey = "syntheticOpaqueInlineTomlSecret" }'
+)
+_INLINE_TOML_SECRET = "syntheticOpaqueInlineTomlSecret"
+_INLINE_TOML_REDACTED = 'mcp = { exaApiKey = "«redacted-secret»" }'
+
+
+def test_read_file_redacts_secret_in_toml_inline_table(tmp_path):
+    config = tmp_path / "providers.toml"
+    config.write_text(f"{_INLINE_TOML_SECRET_ASSIGNMENT}\n", encoding="utf-8")
+
+    result = json.loads(
+        read_file_tool(str(config), task_id="config-redaction-inline-toml-read")
+    )
+
+    assert _INLINE_TOML_SECRET not in result["content"]
+    assert _INLINE_TOML_REDACTED in result["content"]
+
+
+def test_search_redacts_secret_in_toml_inline_table(tmp_path):
+    config = tmp_path / "providers.toml"
+    config.write_text(f"{_INLINE_TOML_SECRET_ASSIGNMENT}\n", encoding="utf-8")
+
+    result = json.loads(
+        search_tool(
+            pattern="exaApiKey",
+            target="content",
+            path=str(tmp_path),
+            task_id="config-redaction-inline-toml-search",
+        )
+    )
+    rendered = json.dumps(result, ensure_ascii=False)
+
+    assert _INLINE_TOML_SECRET not in rendered
+    assert any(
+        match["content"] == _INLINE_TOML_REDACTED for match in result["matches"]
+    )
+
+
+def test_patch_redacts_secret_in_toml_inline_table(tmp_path):
+    replacement = f"replacement{_INLINE_TOML_SECRET}"
+    config = tmp_path / "providers.toml"
+    config.write_text(f"{_INLINE_TOML_SECRET_ASSIGNMENT}\n", encoding="utf-8")
+
+    result = json.loads(
+        patch_tool(
+            path=str(config),
+            old_string=_INLINE_TOML_SECRET,
+            new_string=replacement,
+            task_id="config-redaction-inline-toml-patch",
+        )
+    )
+
+    assert result["success"] is True
+    assert _INLINE_TOML_SECRET not in result["diff"]
+    assert replacement not in result["diff"]
+    assert _INLINE_TOML_REDACTED in result["diff"]
+    assert config.read_text(encoding="utf-8") == (
+        f"{_INLINE_TOML_SECRET_ASSIGNMENT.replace(_INLINE_TOML_SECRET, replacement)}\n"
+    )
+
+
+_QUOTED_YAML_SECRET_ASSIGNMENTS = [
+    pytest.param(
+        '"api.key": syntheticOpaqueDoubleQuotedYamlSecret',
+        "syntheticOpaqueDoubleQuotedYamlSecret",
+        '"api.key": «redacted-secret»',
+        id="double-quoted-dotted-key",
+    ),
+    pytest.param(
+        "'api_key': syntheticOpaqueSingleQuotedYamlSecret",
+        "syntheticOpaqueSingleQuotedYamlSecret",
+        "'api_key': «redacted-secret»",
+        id="single-quoted-key",
+    ),
+]
+
+
+@pytest.mark.parametrize("assignment,secret,redacted", _QUOTED_YAML_SECRET_ASSIGNMENTS)
+def test_read_file_redacts_quoted_yaml_secret_key_assignment(
+    tmp_path, assignment, secret, redacted
+):
+    config = tmp_path / "providers.yaml"
+    config.write_text(f"{assignment}\n", encoding="utf-8")
+
+    result = json.loads(
+        read_file_tool(str(config), task_id="config-redaction-quoted-yaml-read")
+    )
+
+    assert secret not in result["content"]
+    assert redacted in result["content"]
+
+
+@pytest.mark.parametrize("assignment,secret,redacted", _QUOTED_YAML_SECRET_ASSIGNMENTS)
+def test_search_redacts_quoted_yaml_secret_key_assignment(
+    tmp_path, assignment, secret, redacted
+):
+    config = tmp_path / "providers.yaml"
+    config.write_text(f"{assignment}\n", encoding="utf-8")
+
+    result = json.loads(
+        search_tool(
+            pattern="api",
+            target="content",
+            path=str(tmp_path),
+            task_id="config-redaction-quoted-yaml-search",
+        )
+    )
+    rendered = json.dumps(result, ensure_ascii=False)
+
+    assert secret not in rendered
+    assert any(match["content"] == redacted for match in result["matches"])
+
+
+@pytest.mark.parametrize("assignment,secret,redacted", _QUOTED_YAML_SECRET_ASSIGNMENTS)
+def test_patch_redacts_quoted_yaml_secret_key_assignment(
+    tmp_path, assignment, secret, redacted
+):
+    replacement = f"replacement{secret}"
+    config = tmp_path / "providers.yaml"
+    config.write_text(f"{assignment}\n", encoding="utf-8")
+
+    result = json.loads(
+        patch_tool(
+            path=str(config),
+            old_string=secret,
+            new_string=replacement,
+            task_id="config-redaction-quoted-yaml-patch",
+        )
+    )
+
+    assert result["success"] is True
+    assert secret not in result["diff"]
+    assert replacement not in result["diff"]
+    assert redacted in result["diff"]
+    assert (
+        config.read_text(encoding="utf-8")
+        == f"{assignment.replace(secret, replacement)}\n"
+    )
+
+
+def _escaped_json_secret_config():
+    value = 'syntheticEscapedJsonHead"syntheticEscapedJsonTail'
+    return value, json.dumps({"apiKey": value}, ensure_ascii=False)
+
+
+def test_read_file_redacts_complete_escaped_json_string_and_keeps_json_valid(tmp_path):
+    secret, serialized = _escaped_json_secret_config()
+    config = tmp_path / "providers.json"
+    config.write_text(f"{serialized}\n", encoding="utf-8")
+
+    result = json.loads(
+        read_file_tool(str(config), task_id="config-redaction-escaped-json-read")
+    )
+    redacted_line = result["content"].splitlines()[0].split("|", 1)[1]
+
+    assert all(part not in result["content"] for part in secret.split('"'))
+    assert json.loads(redacted_line) == {"apiKey": "«redacted-secret»"}
+
+
+def test_search_redacts_complete_escaped_json_string_and_keeps_json_valid(tmp_path):
+    secret, serialized = _escaped_json_secret_config()
+    config = tmp_path / "providers.json"
+    config.write_text(f"{serialized}\n", encoding="utf-8")
+
+    result = json.loads(
+        search_tool(
+            pattern="apiKey",
+            target="content",
+            path=str(tmp_path),
+            task_id="config-redaction-escaped-json-search",
+        )
+    )
+    rendered = json.dumps(result, ensure_ascii=False)
+
+    assert all(part not in rendered for part in secret.split('"'))
+    assert len(result["matches"]) == 1
+    assert json.loads(result["matches"][0]["content"]) == {
+        "apiKey": "«redacted-secret»"
+    }
+
+
+def test_patch_redacts_complete_escaped_json_strings_and_keeps_json_valid(tmp_path):
+    secret, serialized = _escaped_json_secret_config()
+    replacement_head = "replacementEscapedJsonHead"
+    config = tmp_path / "providers.json"
+    config.write_text(f"{serialized}\n", encoding="utf-8")
+
+    result = json.loads(
+        patch_tool(
+            path=str(config),
+            old_string=secret.split('"', 1)[0],
+            new_string=replacement_head,
+            task_id="config-redaction-escaped-json-patch",
+        )
+    )
+
+    assert result["success"] is True
+    assert all(part not in result["diff"] for part in secret.split('"'))
+    assert replacement_head not in result["diff"]
+    redacted_json = json.dumps({"apiKey": "«redacted-secret»"}, ensure_ascii=False)
+    assert f"-{redacted_json}" in result["diff"]
+    assert f"+{redacted_json}" in result["diff"]
+    assert json.loads(config.read_text(encoding="utf-8"))["apiKey"].startswith(
+        replacement_head
+    )
+
+
 def test_read_file_preserves_editable_json_example_in_mjs_source(tmp_path):
     example = "syntheticEditableJsonExample24680"
     source = tmp_path / "config.mjs"

--- a/tests/tools/test_file_tool_config_redaction.py
+++ b/tests/tools/test_file_tool_config_redaction.py
@@ -1,0 +1,164 @@
+"""Regression tests for path-aware secret redaction at file-tool boundaries."""
+
+import json
+
+import pytest
+
+from agent.redact import is_config_like_path
+from tools.file_tools import patch_tool, read_file_tool, search_tool
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "config.yaml",
+        "config.yml",
+        "providers.json",
+        "settings.toml",
+        ".env",
+        ".env.local",
+        "service-settings",
+        "runtime.config.local",
+    ],
+)
+def test_config_like_path_recognizes_config_and_settings_surfaces(name):
+    assert is_config_like_path(name)
+
+
+@pytest.mark.parametrize("name", ["settings.py", "config.ts", "config.md"])
+def test_config_like_path_keeps_source_and_docs_conservative(name):
+    assert not is_config_like_path(name)
+
+
+def test_read_file_redacts_opaque_secret_values_from_yaml_config(tmp_path):
+    secret = "syntheticOpaqueYamlCredential12345"
+    config = tmp_path / "service-settings.yml"
+    config.write_text(f"model:\n  api_key: {secret}\n  name: public-model\n", encoding="utf-8")
+
+    result = json.loads(read_file_tool(str(config), task_id="config-redaction-read"))
+
+    assert secret not in result["content"]
+    assert "«redacted-secret»" in result["content"]
+    assert "name: public-model" in result["content"]
+
+
+def test_read_file_keeps_nonreusable_vendor_sentinel_in_config(tmp_path):
+    synthetic_vendor_shape = "ghp_" + "A" * 30
+    config = tmp_path / "vendor-config.yml"
+    config.write_text(
+        f"api_key: {synthetic_vendor_shape}\n", encoding="utf-8"
+    )
+
+    result = json.loads(
+        read_file_tool(str(config), task_id="config-redaction-vendor-sentinel")
+    )
+
+    assert synthetic_vendor_shape not in result["content"]
+    assert "«redacted:ghp_…»" in result["content"]
+
+
+def test_read_file_redacts_extensionless_settings_surface(tmp_path):
+    secret = "syntheticExtensionlessSettingsCredential86420"
+    settings = tmp_path / "service-settings"
+    settings.write_text(f"api_key={secret}\nmode=public\n", encoding="utf-8")
+
+    result = json.loads(
+        read_file_tool(str(settings), task_id="config-redaction-extensionless")
+    )
+
+    assert secret not in result["content"]
+    assert "«redacted-secret»" in result["content"]
+    assert "mode=public" in result["content"]
+
+
+def test_read_file_redacts_quoted_yaml_secret_value(tmp_path):
+    secret = "syntheticQuotedYamlCredential97531"
+    config = tmp_path / "quoted-config.yaml"
+    config.write_text(f'api_key: "{secret}"\nmode: public\n', encoding="utf-8")
+
+    result = json.loads(
+        read_file_tool(str(config), task_id="config-redaction-quoted-yaml")
+    )
+
+    assert secret not in result["content"]
+    assert 'api_key: "«redacted-secret»"' in result["content"]
+    assert "mode: public" in result["content"]
+
+
+def test_search_redacts_mcp_and_provider_credentials_only_in_config(tmp_path):
+    config_secrets = {
+        "exaApiKey": "syntheticOpaqueExaCredential24680",
+        "braveSearchApiKey": "syntheticOpaqueBraveCredential10293",
+        "SERVICE_TOKEN": "syntheticOpaqueMcpEnvCredential38475",
+        "x-api-key": "syntheticOpaqueMcpHeaderCredential65748",
+    }
+    source_example = "syntheticSourceExampleValue13579"
+    (tmp_path / "providers.json").write_text(
+        json.dumps(
+            {
+                "exaApiKey": config_secrets["exaApiKey"],
+                "braveSearchApiKey": config_secrets["braveSearchApiKey"],
+                "mcp": {
+                    "env": {"SERVICE_TOKEN": config_secrets["SERVICE_TOKEN"]},
+                    "headers": {"x-api-key": config_secrets["x-api-key"]},
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / "provider_settings.py").write_text(
+        f'EXAMPLE = {{"exaApiKey": "{source_example}"}}\n', encoding="utf-8"
+    )
+
+    result = json.loads(
+        search_tool(
+            pattern="exaApiKey",
+            target="content",
+            path=str(tmp_path),
+            task_id="config-redaction-search",
+        )
+    )
+    rendered = json.dumps(result, ensure_ascii=False)
+
+    assert all(secret not in rendered for secret in config_secrets.values())
+    assert "«redacted-secret»" in rendered
+    assert source_example in rendered
+
+
+def test_patch_redacts_config_diff_without_redacting_source_example(tmp_path):
+    old_secret = "syntheticOldPatchCredential11223"
+    new_secret = "syntheticNewPatchCredential44556"
+    config = tmp_path / "settings.yml"
+    config.write_text(f"secret_key: {old_secret}\n", encoding="utf-8")
+
+    config_result = json.loads(
+        patch_tool(
+            path=str(config),
+            old_string=old_secret,
+            new_string=new_secret,
+            task_id="config-redaction-patch",
+        )
+    )
+
+    assert config_result["success"] is True
+    assert old_secret not in config_result["diff"]
+    assert new_secret not in config_result["diff"]
+    assert "«redacted-secret»" in config_result["diff"]
+    assert config.read_text(encoding="utf-8") == f"secret_key: {new_secret}\n"
+
+    source_example = "syntheticSourcePatchExample77889"
+    source = tmp_path / "provider_settings.py"
+    source.write_text(
+        f'EXAMPLE = {{"secret_key": "{source_example}"}}\n', encoding="utf-8"
+    )
+    source_result = json.loads(
+        patch_tool(
+            path=str(source),
+            old_string="EXAMPLE =",
+            new_string="UPDATED_EXAMPLE =",
+            task_id="source-example-patch",
+        )
+    )
+
+    assert source_result["success"] is True
+    assert source_example in source_result["diff"]

--- a/tests/tools/test_file_tool_config_redaction.py
+++ b/tests/tools/test_file_tool_config_redaction.py
@@ -41,58 +41,95 @@ def test_config_like_path_keeps_source_and_docs_conservative(name):
     assert not is_config_like_path(name)
 
 
-def test_read_file_redacts_spaced_toml_assignment(tmp_path):
-    secret = "syntheticOpaqueTomlCredential24680"
+_TOML_SECRET_ASSIGNMENTS = [
+    pytest.param(
+        'mcp.exaApiKey = "syntheticOpaqueDottedTomlSecret"',
+        "syntheticOpaqueDottedTomlSecret",
+        'mcp.exaApiKey = "«redacted-secret»"',
+        id="dotted-bare-key",
+    ),
+    pytest.param(
+        '"braveSearchApiKey" = "syntheticOpaqueQuotedTomlSecret"',
+        "syntheticOpaqueQuotedTomlSecret",
+        '"braveSearchApiKey" = "«redacted-secret»"',
+        id="quoted-key",
+    ),
+    pytest.param(
+        "'braveSearchApiKey' = 'syntheticOpaqueSingleQuotedTomlSecret'",
+        "syntheticOpaqueSingleQuotedTomlSecret",
+        "'braveSearchApiKey' = '«redacted-secret»'",
+        id="single-quoted-key-and-value",
+    ),
+    pytest.param(
+        "mcp.'exaApiKey' = 'syntheticOpaqueQuotedDottedTomlSecret'",
+        "syntheticOpaqueQuotedDottedTomlSecret",
+        "mcp.'exaApiKey' = '«redacted-secret»'",
+        id="quoted-dotted-segment",
+    ),
+]
+
+
+@pytest.mark.parametrize("assignment,secret,redacted", _TOML_SECRET_ASSIGNMENTS)
+def test_read_file_redacts_toml_secret_key_assignment(
+    tmp_path, assignment, secret, redacted
+):
     config = tmp_path / "providers.toml"
-    config.write_text(f'exaApiKey = "{secret}"\n', encoding="utf-8")
+    config.write_text(f"{assignment}\n", encoding="utf-8")
 
     result = json.loads(
-        read_file_tool(str(config), task_id="config-redaction-spaced-toml-read")
+        read_file_tool(str(config), task_id="config-redaction-toml-read")
     )
 
     assert secret not in result["content"]
-    assert 'exaApiKey = "«redacted-secret»"' in result["content"]
+    assert redacted in result["content"]
 
 
-def test_search_redacts_spaced_toml_assignment(tmp_path):
-    secret = "syntheticOpaqueTomlCredential24680"
+@pytest.mark.parametrize("assignment,secret,redacted", _TOML_SECRET_ASSIGNMENTS)
+def test_search_redacts_toml_secret_key_assignment(
+    tmp_path, assignment, secret, redacted
+):
     config = tmp_path / "providers.toml"
-    config.write_text(f'exaApiKey = "{secret}"\n', encoding="utf-8")
+    config.write_text(f"{assignment}\n", encoding="utf-8")
 
     result = json.loads(
         search_tool(
-            pattern="exaApiKey",
+            pattern="ApiKey",
             target="content",
             path=str(tmp_path),
-            task_id="config-redaction-spaced-toml-search",
+            task_id="config-redaction-toml-search",
         )
     )
     rendered = json.dumps(result, ensure_ascii=False)
 
     assert secret not in rendered
-    assert "«redacted-secret»" in rendered
+    assert any(match["content"] == redacted for match in result["matches"])
 
 
-def test_patch_redacts_spaced_toml_assignment(tmp_path):
-    old_secret = "syntheticOpaqueTomlCredential24680"
-    new_secret = "syntheticReplacementTomlCredential13579"
+@pytest.mark.parametrize("assignment,secret,redacted", _TOML_SECRET_ASSIGNMENTS)
+def test_patch_redacts_toml_secret_key_assignment(
+    tmp_path, assignment, secret, redacted
+):
+    replacement = f"replacement{secret}"
     config = tmp_path / "providers.toml"
-    config.write_text(f'exaApiKey = "{old_secret}"\n', encoding="utf-8")
+    config.write_text(f"{assignment}\n", encoding="utf-8")
 
     result = json.loads(
         patch_tool(
             path=str(config),
-            old_string=old_secret,
-            new_string=new_secret,
-            task_id="config-redaction-spaced-toml-patch",
+            old_string=secret,
+            new_string=replacement,
+            task_id="config-redaction-toml-patch",
         )
     )
 
     assert result["success"] is True
-    assert old_secret not in result["diff"]
-    assert new_secret not in result["diff"]
-    assert "«redacted-secret»" in result["diff"]
-    assert config.read_text(encoding="utf-8") == f'exaApiKey = "{new_secret}"\n'
+    assert secret not in result["diff"]
+    assert replacement not in result["diff"]
+    assert redacted in result["diff"]
+    assert (
+        config.read_text(encoding="utf-8")
+        == f"{assignment.replace(secret, replacement)}\n"
+    )
 
 
 def test_read_file_preserves_editable_json_example_in_mjs_source(tmp_path):

--- a/tests/tools/test_file_tool_config_redaction.py
+++ b/tests/tools/test_file_tool_config_redaction.py
@@ -25,9 +25,127 @@ def test_config_like_path_recognizes_config_and_settings_surfaces(name):
     assert is_config_like_path(name)
 
 
-@pytest.mark.parametrize("name", ["settings.py", "config.ts", "config.md"])
+@pytest.mark.parametrize(
+    "name",
+    [
+        "settings.py",
+        "config.ts",
+        "config.md",
+        "config.mjs",
+        "config.cjs",
+        "config.mts",
+        "config.cts",
+    ],
+)
 def test_config_like_path_keeps_source_and_docs_conservative(name):
     assert not is_config_like_path(name)
+
+
+def test_read_file_redacts_spaced_toml_assignment(tmp_path):
+    secret = "syntheticOpaqueTomlCredential24680"
+    config = tmp_path / "providers.toml"
+    config.write_text(f'exaApiKey = "{secret}"\n', encoding="utf-8")
+
+    result = json.loads(
+        read_file_tool(str(config), task_id="config-redaction-spaced-toml-read")
+    )
+
+    assert secret not in result["content"]
+    assert 'exaApiKey = "«redacted-secret»"' in result["content"]
+
+
+def test_search_redacts_spaced_toml_assignment(tmp_path):
+    secret = "syntheticOpaqueTomlCredential24680"
+    config = tmp_path / "providers.toml"
+    config.write_text(f'exaApiKey = "{secret}"\n', encoding="utf-8")
+
+    result = json.loads(
+        search_tool(
+            pattern="exaApiKey",
+            target="content",
+            path=str(tmp_path),
+            task_id="config-redaction-spaced-toml-search",
+        )
+    )
+    rendered = json.dumps(result, ensure_ascii=False)
+
+    assert secret not in rendered
+    assert "«redacted-secret»" in rendered
+
+
+def test_patch_redacts_spaced_toml_assignment(tmp_path):
+    old_secret = "syntheticOpaqueTomlCredential24680"
+    new_secret = "syntheticReplacementTomlCredential13579"
+    config = tmp_path / "providers.toml"
+    config.write_text(f'exaApiKey = "{old_secret}"\n', encoding="utf-8")
+
+    result = json.loads(
+        patch_tool(
+            path=str(config),
+            old_string=old_secret,
+            new_string=new_secret,
+            task_id="config-redaction-spaced-toml-patch",
+        )
+    )
+
+    assert result["success"] is True
+    assert old_secret not in result["diff"]
+    assert new_secret not in result["diff"]
+    assert "«redacted-secret»" in result["diff"]
+    assert config.read_text(encoding="utf-8") == f'exaApiKey = "{new_secret}"\n'
+
+
+def test_read_file_preserves_editable_json_example_in_mjs_source(tmp_path):
+    example = "syntheticEditableJsonExample24680"
+    source = tmp_path / "config.mjs"
+    source.write_text(
+        f'export const EXAMPLE = {{"exaApiKey": "{example}"}};\n', encoding="utf-8"
+    )
+
+    result = json.loads(
+        read_file_tool(str(source), task_id="source-mjs-redaction-read")
+    )
+
+    assert example in result["content"]
+
+
+def test_search_preserves_editable_json_example_in_mjs_source(tmp_path):
+    example = "syntheticEditableJsonExample24680"
+    source = tmp_path / "config.mjs"
+    source.write_text(
+        f'export const EXAMPLE = {{"exaApiKey": "{example}"}};\n', encoding="utf-8"
+    )
+
+    result = json.loads(
+        search_tool(
+            pattern="exaApiKey",
+            target="content",
+            path=str(tmp_path),
+            task_id="source-mjs-redaction-search",
+        )
+    )
+
+    assert example in json.dumps(result, ensure_ascii=False)
+
+
+def test_patch_preserves_editable_json_example_in_mjs_source(tmp_path):
+    example = "syntheticEditableJsonExample24680"
+    source = tmp_path / "config.mjs"
+    source.write_text(
+        f'export const EXAMPLE = {{"exaApiKey": "{example}"}};\n', encoding="utf-8"
+    )
+
+    result = json.loads(
+        patch_tool(
+            path=str(source),
+            old_string="EXAMPLE",
+            new_string="EDITABLE_EXAMPLE",
+            task_id="source-mjs-redaction-patch",
+        )
+    )
+
+    assert result["success"] is True
+    assert example in result["diff"]
 
 
 def test_read_file_redacts_opaque_secret_values_from_yaml_config(tmp_path):

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -23,7 +23,7 @@ from tools.file_operations import (
     normalize_search_pagination,
 )
 from tools import file_state
-from agent.redact import redact_sensitive_text
+from agent.redact import redact_patch_text, redact_sensitive_text
 
 logger = logging.getLogger(__name__)
 
@@ -1763,7 +1763,9 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 2000, task_id: str =
                             "retrievable via offset."
                         )
                 if result_dict["content"]:
-                    result_dict["content"] = redact_sensitive_text(result_dict["content"], file_read=True)
+                    result_dict["content"] = redact_sensitive_text(
+                        result_dict["content"], file_read=True, file_path=str(_resolved)
+                    )
                 return json.dumps(result_dict, ensure_ascii=False)
 
         # ── Binary file guard ─────────────────────────────────────────
@@ -1919,7 +1921,9 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 2000, task_id: str =
 
         # ── Redact secrets (after guard check to skip oversized content) ──
         if result.content:
-            result.content = redact_sensitive_text(result.content, file_read=True)
+            result.content = redact_sensitive_text(
+                result.content, file_read=True, file_path=str(_resolved)
+            )
             result_dict["content"] = result.content
 
         # Large-file hint: if the file is big and the caller didn't ask
@@ -2486,6 +2490,10 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
             _resolved_modified = [
                 _path_to_resolved.get(_p) or _p for _p in _paths_to_check
             ]
+            if result_dict.get("diff"):
+                result_dict["diff"] = redact_patch_text(
+                    result_dict["diff"], _resolved_modified
+                )
             # Refresh stored timestamps for all successfully-patched paths so
             # consecutive edits by this task don't trigger false warnings.
             if not result_dict.get("error"):
@@ -2614,7 +2622,9 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
         if hasattr(result, 'matches'):
             for m in result.matches:
                 if hasattr(m, 'content') and m.content:
-                    m.content = redact_sensitive_text(m.content, file_read=True)
+                    m.content = redact_sensitive_text(
+                        m.content, file_read=True, file_path=getattr(m, "path", None)
+                    )
         result_dict = result.to_dict(densify=True)
 
         if omitted:

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -7001,6 +7001,40 @@ def matches_name_filter(tool_name: str, patterns: set[str]) -> bool:
     )
 
 
+def mcp_tool_filter_predicate(
+    config: dict, server_name: str
+) -> tuple[Callable[[str], bool], bool]:
+    """Return the runtime tool predicate and whether a filter is active.
+
+    The distinction between a missing ``include`` and an explicit empty one is
+    intentional: absent means all tools, while ``include: []`` is an active
+    whitelist that matches nothing. A non-empty include takes precedence over
+    exclude; without include, a non-empty exclude removes matching names.
+
+    The boolean lets reporting surfaces describe filtered discovery without
+    reimplementing (and potentially drifting from) runtime registration.
+    """
+    tools_filter = config.get("tools") or {}
+    include_raw = tools_filter.get("include")
+    include_set = _normalize_name_filter(
+        include_raw, f"mcp_servers.{server_name}.tools.include"
+    )
+    include_active = isinstance(include_raw, (str, list, tuple, set))
+    exclude_set = _normalize_name_filter(
+        tools_filter.get("exclude"),
+        f"mcp_servers.{server_name}.tools.exclude",
+    )
+
+    def _should_register(tool_name: str) -> bool:
+        if include_active:
+            return matches_name_filter(tool_name, include_set)
+        if exclude_set:
+            return not matches_name_filter(tool_name, exclude_set)
+        return True
+
+    return _should_register, include_active or bool(exclude_set)
+
+
 def _parse_boolish(value: Any, default: bool = True) -> bool:
     """Parse a bool-like config value with safe fallback."""
     if value is None:
@@ -7186,22 +7220,7 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
     #   include: [] → register nothing (an explicit empty whitelist, as
     #   written by the install checklist's "uncheck everything" path)
     #   Neither set → register all tools (backward-compatible default)
-    tools_filter = config.get("tools") or {}
-    include_raw = tools_filter.get("include")
-    include_set = _normalize_name_filter(
-        include_raw, f"mcp_servers.{name}.tools.include"
-    )
-    include_active = isinstance(include_raw, (str, list, tuple, set))
-    exclude_set = _normalize_name_filter(
-        tools_filter.get("exclude"), f"mcp_servers.{name}.tools.exclude"
-    )
-
-    def _should_register(tool_name: str) -> bool:
-        if include_active:
-            return matches_name_filter(tool_name, include_set)
-        if exclude_set:
-            return not matches_name_filter(tool_name, exclude_set)
-        return True
+    _should_register, _filter_active = mcp_tool_filter_predicate(config, name)
 
     check_fn = _make_check_fn(name)
     candidates: List[dict] = []
@@ -7450,24 +7469,7 @@ def _register_from_cache_sync(name: str, config: dict, entry: dict) -> List[str]
     toolset_name = f"mcp-{name}"
     fingerprint = config_fingerprint(config)
     tool_timeout = _resolve_tool_timeout(config)
-    tools_filter = config.get("tools") or {}
-    include_raw = tools_filter.get("include")
-    include_set = _normalize_name_filter(
-        include_raw, f"mcp_servers.{name}.tools.include"
-    )
-    # include: [] is an explicit empty whitelist (register nothing) — see the
-    # live discovery path above for the full filter rules.
-    include_active = isinstance(include_raw, (str, list, tuple, set))
-    exclude_set = _normalize_name_filter(
-        tools_filter.get("exclude"), f"mcp_servers.{name}.tools.exclude"
-    )
-
-    def _should_register(tool_name: str) -> bool:
-        if include_active:
-            return matches_name_filter(tool_name, include_set)
-        if exclude_set:
-            return not matches_name_filter(tool_name, exclude_set)
-        return True
+    _should_register, _filter_active = mcp_tool_filter_predicate(config, name)
 
     check_fn = _make_check_fn(name)
     # Trust-tier metadata for the lazy path: the cached manifest carries


### PR DESCRIPTION
## Summary

This PR hardens four web-runtime/configuration boundaries found while diagnosing a stale web backend selection:

- validate explicit web backend selections in `config set`, `config check`, and `doctor`
  - reject unknown, disabled, and capability-incompatible providers
  - preserve the managed `nous` alias mapping
  - validate a shared backend against both search and extract capabilities
- report and preserve explicit MCP `tools.include: []` consistently across list/test/configurator surfaces
- redact secret-bearing values from config-like file read/search/patch output, including YAML/JSON/TOML dotted and quoted keys, without over-redacting source files
- enforce owner-only (`0600`) permissions for SQLite state DB, WAL, and SHM files, including first creation under a permissive umask

## Regression coverage

- temporary-HERMES_HOME config set/check/doctor tests
- disabled provider, managed alias, and shared capability mismatch tests
- MCP empty filter reporting and both interactive configurators
- real file-tool redaction through read/search/patch for YAML/JSON/TOML/env/config-like paths
- state DB first creation, existing-file tightening, WAL/SHM while connected

## Verification

- focused integration suite: 462 passed, 0 failed (Linux; 8 platform-specific skipped)
- real read/search/patch smoke for quoted YAML, escaped JSON, and inline TOML: no secret remnants; JSON/TOML remained parseable
- upstream CI results will be attached by GitHub

No credentials or secret values are included in this change.
