### PR TITLE
fix(agent): detect structured reasoning budget exhaustion

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3746,12 +3746,37 @@ def run_conversation(
                             re.IGNORECASE,
                         )
                     )
+                    _has_structured_reasoning = any(
+                        isinstance(value, str) and bool(value.strip())
+                        for value in (
+                            getattr(_trunc_msg, "reasoning", None),
+                            getattr(_trunc_msg, "reasoning_content", None),
+                        )
+                    )
+                    _structured_reasoning_only = (
+                        _has_structured_reasoning
+                        and (
+                            _trunc_content is None
+                            or (
+                                isinstance(_trunc_content, str)
+                                and not _trunc_content.strip()
+                            )
+                        )
+                    )
                     _thinking_exhausted = (
                         not _trunc_has_tool_calls
-                        and _has_think_tags
                         and (
-                            (_trunc_content is not None and not agent._has_content_after_think_block(_trunc_content))
-                            or _trunc_content is None
+                            (
+                                _has_think_tags
+                                and (
+                                    (
+                                        _trunc_content is not None
+                                        and not agent._has_content_after_think_block(_trunc_content)
+                                    )
+                                    or _trunc_content is None
+                                )
+                            )
+                            or _structured_reasoning_only
                         )
                     )
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4366,6 +4366,106 @@ class TestRunConversation:
         assert "Thinking Budget Exhausted" in result["final_response"]
         assert "/thinkon" in result["final_response"]
 
+    def test_length_structured_reasoning_exhausted_skips_continuation(self, agent):
+        """Structured reasoning with no visible content must not trigger continuation."""
+        self._setup_agent(agent)
+        resp = _mock_response(
+            content="",
+            reasoning="internal reasoning",
+            finish_reason="length",
+        )
+        agent.client.chat.completions.create.return_value = resp
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        # Structured reasoning exhausted the output budget just like an
+        # inline <think> block: continuing would only make the model reason again.
+        assert result["completed"] is False
+        assert result["api_calls"] == 1
+        assert "reasoning" in result["error"].lower()
+        assert "output tokens" in result["error"].lower()
+        assert result["final_response"] is not None
+        assert "Thinking Budget Exhausted" in result["final_response"]
+        assert "/thinkon" in result["final_response"]
+
+    def test_length_structured_reasoning_content_exhausted_skips_continuation(self, agent):
+        """reasoning_content with no visible content must also skip continuation."""
+        self._setup_agent(agent)
+        resp = _mock_response(
+            content="",
+            reasoning_content="internal reasoning",
+            finish_reason="length",
+        )
+        agent.client.chat.completions.create.return_value = resp
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["completed"] is False
+        assert result["api_calls"] == 1
+        assert "reasoning" in result["error"].lower()
+        assert "output tokens" in result["error"].lower()
+        assert "Thinking Budget Exhausted" in result["final_response"]
+
+    def test_length_structured_reasoning_with_visible_content_still_continues(self, agent):
+        """Visible truncated content must continue even when structured reasoning exists."""
+        self._setup_agent(agent)
+        first = _mock_response(
+            content="Part 1 ",
+            reasoning="internal reasoning",
+            finish_reason="length",
+        )
+        second = _mock_response(
+            content="Part 2",
+            finish_reason="stop",
+        )
+        agent.client.chat.completions.create.side_effect = [first, second]
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["completed"] is True
+        assert result["api_calls"] == 2
+        assert "Part 1" in result["final_response"]
+        assert "Part 2" in result["final_response"]
+
+
+    def test_length_empty_content_without_reasoning_still_continues(self, agent):
+        """Empty content without reasoning remains a normal truncation."""
+        self._setup_agent(agent)
+        first = _mock_response(
+            content="",
+            finish_reason="length",
+        )
+        second = _mock_response(
+            content="Recovered response",
+            finish_reason="stop",
+        )
+        agent.client.chat.completions.create.side_effect = [first, second]
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["completed"] is True
+        assert result["api_calls"] == 2
+        assert "Recovered response" in result["final_response"]
 
     def test_length_with_tool_calls_returns_partial_without_executing_tools(self, agent):
         self._setup_agent(agent)


### PR DESCRIPTION
## What does this PR do?

Fixes the length-truncation path for reasoning models that exhaust their output budget in structured reasoning fields while producing no visible response content.

When a response returns:

- `finish_reason="length"`
- empty or whitespace-only `content`
- non-empty `reasoning` or `reasoning_content`
- no tool calls

Hermes currently misses the existing thinking-budget exhaustion guard because that guard only recognizes inline `<think>`-style tags in `content`.

The response therefore enters the normal length-continuation path, causing repeated full-budget generations and empty assistant turns that later require pre-call sanitizer repair.

This change extends the existing exhaustion detection to structured reasoning while preserving normal continuation behavior for genuine text truncations.

## Related Issue

Fixes #83915

## Changes Made

- Detect non-empty structured reasoning in `reasoning` and `reasoning_content`.
- Treat it as reasoning-budget exhaustion only when visible content is absent or whitespace-only.
- Keep the existing no-tool-calls requirement.
- Preserve normal continuation when structured reasoning accompanies visible partial content.
- Preserve normal continuation for empty `length` responses without structured reasoning.
- Add regression tests for both structured reasoning fields and continuation guardrails.

## Reproduction

Before the fix, a response with `finish_reason="length"`, empty `content`, and non-empty structured reasoning fell through to normal length continuation.

The regression test reproduced the current behavior with four API calls instead of one, including three continuation attempts and successive sanitizer repairs of empty assistant messages.

With this patch, the same response immediately takes the existing `Thinking Budget Exhausted` path after one API call.

## Real-world validation

The issue was also reproduced against a local OpenAI-compatible Ollama endpoint using:

- `hf.co/bartowski/Ornith-1.5-35B-A3B-GGUF:Q2_K_L`
- `hf.co/bartowski/Qwen_Qwen3.5-35B-A3B-GGUF:Q2_K_L`

With reasoning effort `high` and `HERMES_MAX_TOKENS=256`, both models triggered continuation and sanitizer healing before the patch. After the patch, both stopped immediately with the existing reasoning-budget exhaustion response.

## Tests

- Targeted reasoning/guardrail tests: **5 passed**
- All length-related tests: **10 passed**
- Relevant continuation regression suites: **38 passed**

Full `pytest tests/ -q` was not run locally; the targeted regression suites above all pass.

## Checklist

- [x] Bug fix is narrowly scoped
- [x] Regression tests added
- [x] Existing length-continuation behavior preserved
- [x] Conventional Commit message used
- [x] Tested on Linux with local Ollama OpenAI-compatible endpoint
- [ ] Full test suite run locally
