### PR TITLE
feat(gateway): expose read-only MCP server connection status

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2224,6 +2224,7 @@ class APIServerAdapter(BasePlatformAdapter):
             ("GET", "/v1/models", self._handle_models),
             ("GET", "/api/model/options", self._handle_model_options),
             ("GET", "/v1/capabilities", self._handle_capabilities),
+            ("GET", "/v1/mcp/servers", self._handle_mcp_servers),
             # Authenticated browser-control surface: POST registration
             # mints a short-lived ticket; the controller then opens the WS with
             # that ticket. Both are gated on browser.extension_control.enabled
@@ -3362,6 +3363,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "jobs_admin": False,
                 "memory_write_api": False,
                 "skills_api": True,
+                "mcp_server_status": True,
                 "audio_api": False,
                 "realtime_voice": False,
                 "session_continuity_header": "X-Hermes-Session-Id",
@@ -3409,6 +3411,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "run_stop": {"method": "POST", "path": "/v1/runs/{run_id}/stop"},
                 "skills": {"method": "GET", "path": "/v1/skills"},
                 "toolsets": {"method": "GET", "path": "/v1/toolsets"},
+                "mcp_servers": {"method": "GET", "path": "/v1/mcp/servers"},
                 "sessions": {"method": "GET", "path": "/api/sessions"},
                 "session_create": {"method": "POST", "path": "/api/sessions"},
                 "session": {"method": "GET", "path": "/api/sessions/{session_id}"},
@@ -3428,6 +3431,49 @@ class APIServerAdapter(BasePlatformAdapter):
                 },
             },
         })
+
+    async def _handle_mcp_servers(self, request: "web.Request") -> "web.Response":
+        """GET /v1/mcp/servers — report MCP runtime connection state."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        # MCP runtime ownership is process-global and keyed by bare server
+        # name. A multiplex gateway can run same-named servers for several
+        # profile scopes, so no request profile can be joined to that runtime
+        # state safely. Fail closed on both bare and /p/<profile> routes until
+        # runtime ownership itself is profile-keyed.
+        runner_config = getattr(getattr(self, "gateway_runner", None), "config", None)
+        if getattr(runner_config, "multiplex_profiles", False):
+            return web.json_response(
+                _openai_error(
+                    "MCP runtime status is unavailable while profile multiplexing is enabled",
+                    err_type="service_unavailable_error",
+                    code="mcp_status_profile_isolation_unavailable",
+                ),
+                status=503,
+            )
+
+        from tools.mcp_tool import get_mcp_connection_status
+
+        try:
+            servers = await asyncio.to_thread(get_mcp_connection_status)
+        except Exception as exc:
+            logger.warning(
+                "MCP runtime status snapshot failed: %s",
+                type(exc).__name__,
+            )
+            return web.json_response(
+                {
+                    "error": {
+                        "message": "Unable to read MCP runtime status",
+                        "type": "server_error",
+                        "code": "mcp_status_unavailable",
+                    }
+                },
+                status=500,
+            )
+        return web.json_response({"object": "list", "data": servers})
 
     # ------------------------------------------------------------------
     # Browser-extension control (authenticated local/VPS API)

--- a/tests/gateway/test_api_server_mcp_status.py
+++ b/tests/gateway/test_api_server_mcp_status.py
@@ -1,0 +1,165 @@
+"""Behavior tests for the authenticated MCP connection-status API."""
+
+from types import SimpleNamespace
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.config import PlatformConfig
+from gateway.platforms.api_server import APIServerAdapter
+
+
+def _make_adapter(api_key: str = "sk-secret") -> APIServerAdapter:
+    return APIServerAdapter(PlatformConfig(enabled=True, extra={"key": api_key}))
+
+
+def test_mcp_server_status_route_is_registered():
+    adapter = _make_adapter()
+
+    routes = {(method, path) for method, path, _handler in adapter._http_route_table()}
+
+    assert ("GET", "/v1/mcp/servers") in routes
+
+
+@pytest.mark.asyncio
+async def test_mcp_server_status_requires_bearer_auth():
+    adapter = _make_adapter()
+    app = web.Application()
+    app.router.add_get("/v1/mcp/servers", adapter._handle_mcp_servers)
+
+    async with TestClient(TestServer(app)) as client:
+        response = await client.get("/v1/mcp/servers")
+
+    assert response.status == 401
+
+
+@pytest.mark.asyncio
+async def test_mcp_server_status_returns_runtime_snapshot(monkeypatch):
+    import tools.mcp_tool as mcp_tool
+
+    adapter = _make_adapter()
+    expected = [
+        {"name": "alpha", "state": "connected", "transport": "stdio", "tool_count": 2},
+        {"name": "beta", "state": "failed", "error_code": "connection_failed"},
+    ]
+    monkeypatch.setattr(mcp_tool, "get_mcp_connection_status", lambda: expected, raising=False)
+    app = web.Application()
+    app.router.add_get("/v1/mcp/servers", adapter._handle_mcp_servers)
+
+    async with TestClient(TestServer(app)) as client:
+        response = await client.get(
+            "/v1/mcp/servers",
+            headers={"Authorization": "Bearer sk-secret"},
+        )
+        payload = await response.json()
+
+    assert response.status == 200
+    assert payload == {"object": "list", "data": expected}
+
+
+@pytest.mark.asyncio
+async def test_mcp_server_status_fails_closed_for_multiplexed_same_name_profiles(monkeypatch):
+    """A process-global same-name runtime must not be joined to either profile."""
+    import tools.mcp_tool as mcp_tool
+
+    adapter = _make_adapter()
+    adapter.gateway_runner = SimpleNamespace(
+        config=SimpleNamespace(multiplex_profiles=True)
+    )
+    leaked = [{"name": "shared", "state": "connected", "tool_count": 7}]
+    monkeypatch.setattr(
+        mcp_tool,
+        "get_mcp_connection_status",
+        lambda: leaked,
+        raising=False,
+    )
+    app = web.Application(middlewares=[adapter._make_profile_prefix_middleware()])
+    app.router.add_get("/v1/mcp/servers", adapter._handle_mcp_servers)
+    app.router.add_get("/p/{profile}/v1/mcp/servers", adapter._handle_mcp_servers)
+
+    with monkeypatch.context() as scoped:
+        scoped.setattr(
+            adapter,
+            "_resolve_request_profile",
+            lambda request: request.match_info.get("profile") or None,
+        )
+        scoped.setattr(adapter, "_profile_scope", lambda profile: __import__("contextlib").nullcontext())
+        scoped.setattr(adapter, "_expected_api_key", lambda: "sk-secret")
+        async with TestClient(TestServer(app)) as client:
+            default_response = await client.get(
+                "/v1/mcp/servers",
+                headers={"Authorization": "Bearer sk-secret"},
+            )
+            worker_response = await client.get(
+                "/p/worker/v1/mcp/servers",
+                headers={"Authorization": "Bearer sk-secret"},
+            )
+            default_payload = await default_response.json()
+            worker_payload = await worker_response.json()
+
+    assert default_response.status == 503
+    assert worker_response.status == 503
+    assert default_payload == worker_payload == {
+        "error": {
+            "message": "MCP runtime status is unavailable while profile multiplexing is enabled",
+            "type": "service_unavailable_error",
+            "param": None,
+            "code": "mcp_status_profile_isolation_unavailable",
+        }
+    }
+    assert "shared" not in str(default_payload)
+    assert "shared" not in str(worker_payload)
+
+
+@pytest.mark.asyncio
+async def test_mcp_server_status_returns_stable_json_on_snapshot_failure(monkeypatch):
+    import tools.mcp_tool as mcp_tool
+
+    adapter = _make_adapter()
+    monkeypatch.setattr(
+        mcp_tool,
+        "get_mcp_connection_status",
+        lambda: (_ for _ in ()).throw(RuntimeError("Bearer raw-secret")),
+        raising=False,
+    )
+    app = web.Application()
+    app.router.add_get("/v1/mcp/servers", adapter._handle_mcp_servers)
+
+    async with TestClient(TestServer(app)) as client:
+        response = await client.get(
+            "/v1/mcp/servers",
+            headers={"Authorization": "Bearer sk-secret"},
+        )
+        payload = await response.json()
+
+    assert response.status == 500
+    assert payload == {
+        "error": {
+            "message": "Unable to read MCP runtime status",
+            "type": "server_error",
+            "code": "mcp_status_unavailable",
+        }
+    }
+    assert "raw-secret" not in str(payload)
+
+
+@pytest.mark.asyncio
+async def test_capabilities_advertises_mcp_server_status():
+    adapter = _make_adapter()
+    app = web.Application()
+    app.router.add_get("/v1/capabilities", adapter._handle_capabilities)
+
+    async with TestClient(TestServer(app)) as client:
+        response = await client.get(
+            "/v1/capabilities",
+            headers={"Authorization": "Bearer sk-secret"},
+        )
+        payload = await response.json()
+
+    assert response.status == 200
+    assert payload["features"]["mcp_server_status"] is True
+    assert payload["endpoints"]["mcp_servers"] == {
+        "method": "GET",
+        "path": "/v1/mcp/servers",
+    }

--- a/tests/tools/test_mcp_connection_status.py
+++ b/tests/tools/test_mcp_connection_status.py
@@ -1,0 +1,294 @@
+"""Behavior tests for the public MCP connection-status snapshot."""
+
+import json
+import threading
+import time
+from types import SimpleNamespace
+
+
+def test_connection_status_snapshot_is_closed_ordered_and_non_sensitive(monkeypatch):
+    import tools.mcp_tool as mcp_tool
+
+    secret = "Bearer super-secret-token"
+    monkeypatch.setattr(
+        mcp_tool,
+        "_load_mcp_config",
+        lambda: {
+            "zeta": {"url": "https://secret.example/mcp", "headers": {"Authorization": secret}},
+            "alpha": {"command": "secret-command", "args": [secret], "enabled": False},
+            "reloading": {"url": "https://private.invalid/mcp"},
+            "failed": {"transport": "sse", "url": "https://private.invalid/sse"},
+            "idle": {"command": "private-command"},
+        },
+    )
+    ready = threading.Event()
+    ready.set()
+    connected = SimpleNamespace(
+        session=object(),
+        _ready=ready,
+        _reconnecting=False,
+        _registered_tool_names=["zeta__one", "zeta__two"],
+        _error=None,
+        _was_parked=False,
+    )
+    reconnecting_ready = threading.Event()
+    reconnecting = SimpleNamespace(
+        session=None,
+        _ready=reconnecting_ready,
+        _reconnecting=True,
+        _registered_tool_names=[],
+        _error=None,
+        _was_parked=False,
+    )
+    mcp_tool._ensure_mcp_loop()
+
+    with mcp_tool._lock:
+        saved_servers = dict(mcp_tool._servers)
+        saved_connecting = set(mcp_tool._server_connecting)
+        saved_errors = dict(mcp_tool._server_connect_errors)
+        mcp_tool._servers.clear()
+        mcp_tool._servers.update({"zeta": connected, "reloading": reconnecting})
+        mcp_tool._server_connecting.clear()
+        mcp_tool._server_connect_errors.clear()
+        mcp_tool._server_connect_errors["failed"] = secret
+
+    try:
+        snapshot = mcp_tool.get_mcp_connection_status()
+    finally:
+        with mcp_tool._lock:
+            mcp_tool._servers.clear()
+            mcp_tool._servers.update(saved_servers)
+            mcp_tool._server_connecting.clear()
+            mcp_tool._server_connecting.update(saved_connecting)
+            mcp_tool._server_connect_errors.clear()
+            mcp_tool._server_connect_errors.update(saved_errors)
+
+    assert snapshot == [
+        {"name": "alpha", "state": "disabled", "transport": "stdio"},
+        {"name": "failed", "state": "failed", "transport": "sse", "error_code": "connection_failed"},
+        {"name": "idle", "state": "unknown", "transport": "stdio"},
+        {"name": "reloading", "state": "connecting", "transport": "streamable_http"},
+        {"name": "zeta", "state": "connected", "transport": "streamable_http", "tool_count": 2},
+    ]
+    serialized = json.dumps(snapshot)
+    assert secret not in serialized
+    assert "secret-command" not in serialized
+    assert "secret.example" not in serialized
+
+
+def test_connection_status_reads_server_lifecycle_only_on_mcp_loop(monkeypatch):
+    import tools.mcp_tool as mcp_tool
+
+    monkeypatch.setattr(
+        mcp_tool,
+        "_load_mcp_config",
+        lambda: {"guarded": {"command": "private-command"}},
+    )
+    mcp_tool._ensure_mcp_loop()
+
+    async def _thread_id():
+        return threading.get_ident()
+
+    owner_thread = mcp_tool._run_on_mcp_loop(_thread_id)
+
+    class _OwnerOnlyReady:
+        def is_set(self):
+            assert threading.get_ident() == owner_thread
+            return True
+
+    class _OwnerOnlyServer:
+        def __getattribute__(self, name):
+            if name in {
+                "session",
+                "_ready",
+                "_error",
+                "_was_parked",
+                "_registered_tool_names",
+            }:
+                assert threading.get_ident() == owner_thread
+            return object.__getattribute__(self, name)
+
+        session = object()
+        _ready = _OwnerOnlyReady()
+        _error = None
+        _was_parked = False
+        _registered_tool_names = ["guarded__callable"]
+
+    with mcp_tool._lock:
+        saved_servers = dict(mcp_tool._servers)
+        mcp_tool._servers.clear()
+        mcp_tool._servers["guarded"] = _OwnerOnlyServer()
+
+    try:
+        assert mcp_tool.get_mcp_connection_status() == [
+            {
+                "name": "guarded",
+                "state": "connected",
+                "transport": "stdio",
+                "tool_count": 1,
+            }
+        ]
+    finally:
+        with mcp_tool._lock:
+            mcp_tool._servers.clear()
+            mcp_tool._servers.update(saved_servers)
+
+
+def test_recovered_live_server_ignores_latched_reconnecting_flag(monkeypatch):
+    import tools.mcp_tool as mcp_tool
+
+    monkeypatch.setattr(
+        mcp_tool,
+        "_load_mcp_config",
+        lambda: {"recovered": {"url": "https://private.invalid/mcp"}},
+    )
+    ready = threading.Event()
+    ready.set()
+    recovered = SimpleNamespace(
+        session=object(),
+        _ready=ready,
+        _reconnecting=True,
+        _error=None,
+        _was_parked=False,
+        _registered_tool_names=["recovered__one", "recovered__two"],
+    )
+    mcp_tool._ensure_mcp_loop()
+    with mcp_tool._lock:
+        saved_servers = dict(mcp_tool._servers)
+        saved_connecting = set(mcp_tool._server_connecting)
+        saved_errors = dict(mcp_tool._server_connect_errors)
+        mcp_tool._servers.clear()
+        mcp_tool._servers["recovered"] = recovered
+        mcp_tool._server_connecting.clear()
+        mcp_tool._server_connect_errors.clear()
+
+    try:
+        assert mcp_tool.get_mcp_connection_status() == [
+            {
+                "name": "recovered",
+                "state": "connected",
+                "transport": "streamable_http",
+                "tool_count": 2,
+            }
+        ]
+    finally:
+        with mcp_tool._lock:
+            mcp_tool._servers.clear()
+            mcp_tool._servers.update(saved_servers)
+            mcp_tool._server_connecting.clear()
+            mcp_tool._server_connecting.update(saved_connecting)
+            mcp_tool._server_connect_errors.clear()
+            mcp_tool._server_connect_errors.update(saved_errors)
+
+
+def test_parked_after_live_failure_is_failed_not_unknown(monkeypatch):
+    import tools.mcp_tool as mcp_tool
+
+    monkeypatch.setattr(
+        mcp_tool,
+        "_load_mcp_config",
+        lambda: {"parked": {"command": "private-command"}},
+    )
+    stale_ready = threading.Event()
+    stale_ready.set()
+    parked = SimpleNamespace(
+        session=None,
+        _ready=stale_ready,
+        _reconnecting=False,
+        _error=None,
+        _was_parked=True,
+        _registered_tool_names=[],
+    )
+    mcp_tool._ensure_mcp_loop()
+    with mcp_tool._lock:
+        saved_servers = dict(mcp_tool._servers)
+        saved_connecting = set(mcp_tool._server_connecting)
+        saved_errors = dict(mcp_tool._server_connect_errors)
+        mcp_tool._servers.clear()
+        mcp_tool._servers["parked"] = parked
+        mcp_tool._server_connecting.clear()
+        mcp_tool._server_connect_errors.clear()
+
+    try:
+        assert mcp_tool.get_mcp_connection_status() == [
+            {
+                "name": "parked",
+                "state": "failed",
+                "transport": "stdio",
+                "error_code": "connection_failed",
+            }
+        ]
+    finally:
+        with mcp_tool._lock:
+            mcp_tool._servers.clear()
+            mcp_tool._servers.update(saved_servers)
+            mcp_tool._server_connecting.clear()
+            mcp_tool._server_connecting.update(saved_connecting)
+            mcp_tool._server_connect_errors.clear()
+            mcp_tool._server_connect_errors.update(saved_errors)
+
+
+def test_connection_status_state_precedence_table():
+    import tools.mcp_tool as mcp_tool
+
+    cases = [
+        ("live_disabled", False, {"live": True}, "disabled"),
+        ("live_with_error", True, {"live": True, "error": True}, "connected"),
+        (
+            "connecting_with_error",
+            True,
+            {"connecting": True, "error": True},
+            "failed",
+        ),
+        ("disabled_with_error", False, {"error": True}, "disabled"),
+        (
+            "reconnecting_with_stale_ready",
+            True,
+            {"present": True, "ready": True, "reconnecting": True},
+            "connecting",
+        ),
+        (
+            "parked_after_live_failure",
+            True,
+            {"present": True, "ready": True, "parked": True},
+            "failed",
+        ),
+        (
+            "active_post_live_retry_with_stale_ready",
+            True,
+            {"present": True, "ready": True},
+            "connecting",
+        ),
+    ]
+
+    for case, enabled, runtime, expected in cases:
+        assert mcp_tool._mcp_connection_state(enabled, runtime) == expected, case
+
+
+def test_connection_status_rejects_same_mcp_loop_call_without_stalling(monkeypatch):
+    import tools.mcp_tool as mcp_tool
+
+    monkeypatch.setattr(
+        mcp_tool,
+        "_load_mcp_config",
+        lambda: {"same-loop": {"command": "private-command"}},
+    )
+    mcp_tool._ensure_mcp_loop()
+
+    async def _call_status_on_owner_loop():
+        started = time.monotonic()
+        try:
+            mcp_tool.get_mcp_connection_status()
+        except RuntimeError as exc:
+            return time.monotonic() - started, str(exc)
+        raise AssertionError("same-loop call unexpectedly succeeded")
+
+    elapsed, message = mcp_tool._run_on_mcp_loop(
+        _call_status_on_owner_loop,
+        timeout=2,
+    )
+
+    assert elapsed < 0.5
+    assert message == (
+        "MCP connection status cannot be read synchronously from the MCP event loop"
+    )

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -7954,6 +7954,143 @@ def is_mcp_tool_parallel_safe(tool_name: str) -> bool:
         return bool(server_name and server_name in _parallel_safe_servers)
 
 
+async def _mcp_runtime_status_snapshot() -> Dict[str, dict]:
+    """Project loop-owned lifecycle fields on the dedicated MCP loop."""
+    with _lock:
+        servers = dict(_servers)
+        connecting = set(_server_connecting)
+        connect_errors = set(_server_connect_errors)
+
+    snapshot: Dict[str, dict] = {}
+    for name, server in servers.items():
+        ready_event = getattr(server, "_ready", None)
+        is_ready = bool(
+            ready_event is not None
+            and callable(getattr(ready_event, "is_set", None))
+            and ready_event.is_set()
+        )
+        registered_names = getattr(server, "_registered_tool_names", None)
+        snapshot[name] = {
+            "present": True,
+            "live": getattr(server, "session", None) is not None and is_ready,
+            "ready": is_ready,
+            "reconnecting": bool(getattr(server, "_reconnecting", False)),
+            "error": getattr(server, "_error", None) is not None,
+            "parked": bool(getattr(server, "_was_parked", False)),
+            "tool_count": (
+                len(registered_names)
+                if isinstance(registered_names, (list, tuple, set))
+                else 0
+            ),
+        }
+    for name in connecting | connect_errors:
+        runtime = snapshot.setdefault(
+            name,
+            {
+                "present": False,
+                "live": False,
+                "ready": False,
+                "reconnecting": False,
+                "error": False,
+                "parked": False,
+            },
+        )
+        runtime["connecting"] = name in connecting
+        runtime["connect_error"] = name in connect_errors
+    return snapshot
+
+
+def _mcp_connection_state(enabled: bool, runtime: dict) -> str:
+    """Resolve one MCP server's closed public state by explicit precedence."""
+    if not enabled:
+        return "disabled"
+    if runtime.get("live"):
+        return "connected"
+    if (
+        runtime.get("parked")
+        or runtime.get("connect_error")
+        or runtime.get("error")
+    ):
+        return "failed"
+    if (
+        runtime.get("connecting")
+        or runtime.get("reconnecting")
+        or runtime.get("present")
+    ):
+        return "connecting"
+    return "unknown"
+
+
+def get_mcp_connection_status() -> List[dict]:
+    """Return a deterministic, non-sensitive MCP runtime status snapshot.
+
+    Config is read in the caller's profile scope. Mutable server lifecycle
+    fields are projected on the dedicated MCP loop that owns their writers;
+    the module lock is used only for the global map copies it actually guards.
+    This projection intentionally exposes only closed state values and safe
+    transport classes. It never includes connection configuration or raw
+    exception text.
+    """
+    configured = _load_mcp_config()
+    if not configured:
+        return []
+
+    with _lock:
+        loop = _mcp_loop
+        loop_thread = _mcp_thread
+        if loop is None or not loop.is_running():
+            connecting = set(_server_connecting)
+            connect_errors = set(_server_connect_errors)
+            runtime_snapshot = {
+                name: {
+                    "present": False,
+                    "live": False,
+                    "ready": False,
+                    "reconnecting": False,
+                    "error": False,
+                    "parked": False,
+                    "connecting": name in connecting,
+                    "connect_error": name in connect_errors,
+                }
+                for name in connecting | connect_errors
+            }
+        else:
+            runtime_snapshot = None
+    if runtime_snapshot is None:
+        if threading.current_thread() is loop_thread:
+            raise RuntimeError(
+                "MCP connection status cannot be read synchronously from the MCP event loop"
+            )
+        runtime_snapshot = _run_on_mcp_loop(_mcp_runtime_status_snapshot)
+
+    result: List[dict] = []
+    for raw_name, cfg in configured.items():
+        name = str(raw_name)
+        runtime = runtime_snapshot.get(raw_name, {})
+        entry: Dict[str, Any] = {"name": name}
+        transport = None
+        if isinstance(cfg, dict):
+            if "url" in cfg:
+                transport = "sse" if cfg.get("transport") == "sse" else "streamable_http"
+            elif "command" in cfg:
+                transport = "stdio"
+        if transport is not None:
+            entry["transport"] = transport
+
+        enabled = isinstance(cfg, dict) and _parse_boolish(
+            cfg.get("enabled", True), default=True
+        )
+        state = _mcp_connection_state(enabled, runtime)
+        entry["state"] = state
+        if state == "connected":
+            entry["tool_count"] = int(runtime.get("tool_count", 0))
+        elif state == "failed":
+            entry["error_code"] = "connection_failed"
+        result.append(entry)
+
+    return sorted(result, key=lambda entry: entry["name"])
+
+
 def get_mcp_status() -> List[dict]:
     """Return status of all configured MCP servers for banner display.
 


### PR DESCRIPTION
## Summary

Add an authenticated, read-only gateway API endpoint for clients that need truthful MCP runtime health without exposing MCP configuration or credentials:

```http
GET /v1/mcp/servers
Authorization: Bearer <API server key>
```

The endpoint is advertised through `/v1/capabilities` and returns deterministic rows derived from the live MCP runtime:

```json
{
  "object": "list",
  "data": [
    {
      "name": "awork",
      "state": "connected",
      "transport": "streamable_http",
      "tool_count": 4
    }
  ]
}
```

Closed states are `connected`, `connecting`, `failed`, `disabled`, and `unknown`.

## Safety and privacy

The response intentionally excludes:

- URLs, commands, arguments, headers, and environment variables
- OAuth material and credentials
- raw exceptions/error strings
- server-advertised-but-filtered tool schemas

Failed rows expose only the fixed error code `connection_failed`. `tool_count` reflects registered callable tool names.

Mutable `MCPServerTask` lifecycle fields are projected on the dedicated MCP event loop. The synchronous wrapper rejects same-loop calls immediately rather than blocking its owner loop.

Current MCP runtime ownership is process-global and keyed by bare server name. Therefore, when `gateway.multiplex_profiles` is enabled, both bare and profile-prefixed endpoint forms fail closed with a sanitized `503`; they never join profile-scoped configuration to ambiguous runtime state. This can be relaxed after profile-scoped runtime ownership such as #80746 lands.

## Capabilities

Adds:

```json
{
  "features": { "mcp_server_status": true },
  "endpoints": {
    "mcp_servers": { "method": "GET", "path": "/v1/mcp/servers" }
  }
}
```

## Verification

Strict TDD regression coverage includes:

- bearer authentication
- route/capability advertisement
- deterministic redacted response shape
- multiplex same-name profile isolation
- owner-loop lifecycle reads
- recovered-live and post-live retry state precedence
- parked/failed state
- same-MCP-loop non-stalling rejection
- stable sanitized error envelope

Canonical test runner results:

```text
scripts/run_tests.sh tests/gateway/test_api_server_mcp_status.py \
  tests/tools/test_mcp_connection_status.py tests/tools/test_mcp_tool.py
# 111 passed, 0 failed

scripts/run_tests.sh tests/tools/test_mcp*.py tests/gateway/test_api_server*.py
# 74 files, 835 passed, 0 failed
```

Additional checks:

```text
ruff check <changed files>  # passed
git diff --check            # passed
```

The final diff received an independent fail-closed review with no security concerns or logic errors.