### PR TITLE
fix(gateway): show awaiting approval when Discord protected-file prompts are pending

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -572,8 +572,18 @@ def _run_tool_activity_heartbeat(
     """
 
     try:
+        from tools.approval import tool_heartbeat_activity_label
+    except Exception:
+        tool_heartbeat_activity_label = None
+
+    try:
         while not stop_event.wait(interval):
-            agent._touch_activity(label)
+            desc = (
+                tool_heartbeat_activity_label(label)
+                if tool_heartbeat_activity_label is not None
+                else f"tool running: {label}"
+            )
+            agent._touch_activity(desc)
     except Exception:
         # A heartbeat must never break the agent loop.
         pass
@@ -722,7 +732,7 @@ def _run_agent_tool_execution_middleware(
         _hb_stop = threading.Event()
         _hb_thread = threading.Thread(
             target=_run_tool_activity_heartbeat,
-            args=(agent, _hb_stop, f"tool running: {function_name}"),
+            args=(agent, _hb_stop, function_name),
             kwargs={"interval": _TOOL_ACTIVITY_HEARTBEAT_INTERVAL_S},
             daemon=True,
             name=f"tool-activity-hb-{function_name[:24]}",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -938,6 +938,22 @@ def _approval_send_outcome(future, timeout: float) -> str:
     return "failed"
 
 
+def _approval_prompt_undeliverable(
+    button_outcome: str | None, text_outcome: str | None
+) -> bool:
+    """True when the originating surface got no usable approval prompt.
+
+    ``sent`` and ``ambiguous`` (timeout / late ack) both keep the prompt
+    armed — ``/approve`` remains a fallback. Only a definitive miss on
+    every attempted channel is undeliverable (#96959).
+    """
+    if button_outcome in ("sent", "ambiguous"):
+        return False
+    if text_outcome in ("sent", "ambiguous"):
+        return False
+    return True
+
+
 def _clarify_send_disposition(fut, *, session_key: str, clarify_mod) -> "str | None":
     """Decide whether a clarify prompt send aborts the wait, per the boundary rule.
 
@@ -6299,6 +6315,7 @@ class TurnRunner:
                     logger.warning(
                         "Button-based approval failed, falling back to text: %s", _e
                     )
+                    _outcome = "failed"
 
             # Fallback: plain text approval prompt.  Use the adapter's
             # typed prefix so Slack/Matrix users are told the form they
@@ -6328,10 +6345,28 @@ class TurnRunner:
                     logger=logger,
                     log_message="Approval text-send scheduling error",
                 )
-                if _approval_send_fut is not None:
-                    _approval_send_fut.result(timeout=15)
+                if _approval_send_fut is None:
+                    raise RuntimeError("approval text-send: loop unavailable")
+                try:
+                    _text_result = _approval_send_fut.result(timeout=15)
+                except concurrent.futures.TimeoutError:
+                    # Same physics as the button card: timeout is possibly
+                    # delivered. Do not fail-closed and do not re-send.
+                    logger.warning(
+                        "Approval text-send timed out — treating as "
+                        "possibly-delivered (prompt stays armed)"
+                    )
+                    return
+                if getattr(_text_result, "success", True) is False:
+                    raise RuntimeError(
+                        "approval prompt undeliverable: "
+                        f"{getattr(_text_result, 'error', None) or 'text send failed'}"
+                    )
             except Exception as _e:
                 logger.error("Failed to send approval request: %s", _e)
+                raise RuntimeError(
+                    f"approval prompt undeliverable: {_e}"
+                ) from _e
 
         # Keep real user text separate from API-only recovery guidance.  If
         # an auto-continue note is prepended below, persist the original

--- a/tests/gateway/test_approval_send_timeout_ambiguity.py
+++ b/tests/gateway/test_approval_send_timeout_ambiguity.py
@@ -60,3 +60,15 @@ def test_non_timeout_exception_is_failed():
 
 def test_missing_future_is_failed():
     assert _approval_send_outcome(None, timeout=1) == "failed"
+
+
+def test_undeliverable_only_when_every_channel_definitively_missed():
+    from gateway.run import _approval_prompt_undeliverable
+
+    assert _approval_prompt_undeliverable("sent", None) is False
+    assert _approval_prompt_undeliverable("ambiguous", None) is False
+    assert _approval_prompt_undeliverable("failed", "sent") is False
+    assert _approval_prompt_undeliverable("failed", "ambiguous") is False
+    assert _approval_prompt_undeliverable("failed", "failed") is True
+    assert _approval_prompt_undeliverable(None, "failed") is True
+    assert _approval_prompt_undeliverable(None, None) is True

--- a/tests/gateway/test_discord_exec_approval_content.py
+++ b/tests/gateway/test_discord_exec_approval_content.py
@@ -48,3 +48,39 @@ async def test_exec_approval_prompt_uses_visible_content_with_command_and_reason
     assert "script execution via -c flag" in prompt_text
 
 
+@pytest.mark.asyncio
+async def test_exec_approval_targets_originating_thread_from_metadata():
+    """A Discord thread session must post the card in that thread (#96959)."""
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    targeted: list[str] = []
+    sent = {}
+
+    async def fake_send(**kwargs):
+        sent.update(kwargs)
+        return SimpleNamespace(id=777)
+
+    channel = SimpleNamespace(send=AsyncMock(side_effect=fake_send))
+
+    def get_channel(cid):
+        targeted.append(str(cid))
+        return channel
+
+    adapter._client = SimpleNamespace(
+        get_channel=get_channel,
+        fetch_channel=AsyncMock(),
+    )
+
+    result = await adapter.send_exec_approval(
+        chat_id="1527380292229136536",
+        command="<write to AGENTS.md>",
+        session_key="discord:thread-96959",
+        description="Write to protected agent-instruction file(s): AGENTS.md.",
+        metadata={"thread_id": "888001122334455"},
+    )
+
+    assert result.success is True
+    assert targeted == ["888001122334455"]
+    assert "AGENTS.md" in sent["content"]
+    assert sent["view"] is not None
+
+

--- a/tests/run_agent/test_tool_activity_heartbeat.py
+++ b/tests/run_agent/test_tool_activity_heartbeat.py
@@ -117,7 +117,7 @@ def test_heartbeat_touches_periodically_and_stops():
 
     thread = threading.Thread(
         target=te._run_tool_activity_heartbeat,
-        args=(_Agent(), stop, "tool running: terminal"),
+        args=(_Agent(), stop, "terminal"),
         kwargs={"interval": 0.05},
         daemon=True,
     )
@@ -268,3 +268,47 @@ def test_concurrent_tool_call_heartbeat(monkeypatch):
     agent._execute_tool_calls_concurrent(msg, messages, "task")
 
     assert len(touches) >= 3, f"expected mid-call heartbeats, got {len(touches)}"
+
+
+def test_heartbeat_stamps_awaiting_approval_while_gateway_prompt_is_queued():
+    """A pending gateway approval must not keep looking like tool progress.
+
+    #96959: the 30s tool heartbeat overwrote ``waiting for user approval``
+    with ``tool running: patch``, so Discord status stayed on a generic
+    working indicator while /approve was the only visible path.
+    """
+    import agent.tool_executor as te
+    from tools.approval import (
+        AWAITING_APPROVAL_ACTIVITY,
+        _ApprovalEntry,
+        _gateway_queues,
+        _lock,
+    )
+
+    touches: list[str] = []
+    stop = threading.Event()
+
+    class _Agent:
+        def _touch_activity(self, desc):
+            touches.append(desc)
+
+    with _lock:
+        _gateway_queues["discord:thread-1"] = [_ApprovalEntry({"command": "x"})]
+    try:
+        thread = threading.Thread(
+            target=te._run_tool_activity_heartbeat,
+            args=(_Agent(), stop, "patch"),
+            kwargs={"interval": 0.05},
+            daemon=True,
+        )
+        thread.start()
+        time.sleep(0.12)
+        stop.set()
+        thread.join(timeout=1.0)
+    finally:
+        with _lock:
+            _gateway_queues.pop("discord:thread-1", None)
+
+    assert touches, "heartbeat never stamped"
+    assert all(label == AWAITING_APPROVAL_ACTIVITY for label in touches)
+    assert "tool running: patch" not in touches

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -1331,6 +1331,11 @@ class TestApprovalTimeoutIsNotConsent:
 
         monkeypatch.setattr(mod, "_fire_approval_hook", _capture)
 
+        activity: list[str] = []
+        from tools.environments.base import set_activity_callback
+
+        set_activity_callback(activity.append)
+
         def _fail_notify(_data):
             raise RuntimeError("private gateway failure")
 
@@ -1356,6 +1361,8 @@ class TestApprovalTimeoutIsNotConsent:
             "post_approval_response",
         ]
         assert hook_calls[-1][1]["choice"] == "notify_failed"
+        assert activity == ["awaiting approval", "approval prompt undeliverable"]
+        set_activity_callback(None)
 
     def test_pending_approval_is_replayable_and_acknowledged(self, monkeypatch):
         from tools import approval as mod

--- a/tests/tools/test_file_write_safety.py
+++ b/tests/tools/test_file_write_safety.py
@@ -444,6 +444,43 @@ class TestProtectedInstructionFiles:
         assert target.read_text(encoding="utf-8") == "approved content"
         assert len(approvals["calls"]) == 1
 
+    def test_gateway_discord_thread_one_prompt_approve_fallback(self, tmp_path):
+        """Foreground Discord/gateway: one prompt, /approve still resolves.
+
+        #96959: protected AGENTS.md writes must raise exactly one gateway
+        approval (button or text) and remain resolvable via /approve.
+        """
+        from tools import approval as ap
+        from tools.terminal_tool import set_approval_callback
+
+        set_approval_callback(None)
+        session_key = "discord:thread-96959"
+        notified = []
+
+        def notify(data):
+            notified.append(data)
+            resolved = ap.resolve_gateway_approval(session_key, "once")
+            assert resolved == 1
+
+        token = ap.set_current_session_key(session_key)
+        ap.register_gateway_notify(session_key, notify)
+        try:
+            target = tmp_path / "AGENTS.md"
+            res = self._write(target, "approved via slash fallback")
+            assert not res.get("error"), res
+            assert target.read_text(encoding="utf-8") == "approved via slash fallback"
+        finally:
+            ap.unregister_gateway_notify(session_key)
+            ap.reset_current_session_key(token)
+
+        assert len(notified) == 1
+        blob = (
+            f"{notified[0].get('command', '')} {notified[0].get('description', '')}"
+        )
+        assert "AGENTS.md" in blob
+        assert notified[0].get("allow_permanent") is False
+        assert notified[0].get("allow_session") is False
+
     def test_prompts_even_under_yolo(self, tmp_path, approvals, monkeypatch):
         """The whole point: auto-approve/yolo must NOT bypass this gate."""
         import tools.approval as A

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -2800,6 +2800,41 @@ class _ApprovalEntry:
 _gateway_queues: dict[str, list] = {}        # session_key → [_ApprovalEntry, …]
 _gateway_notify_cbs: dict[str, object] = {}  # session_key → callable(approval_data)
 
+# Activity labels. The in-flight tool heartbeat (#84491) otherwise keeps
+# stamping ``tool running: <name>`` while this queue is blocked on a human,
+# so session/status UI looks like progress instead of a consent wait (#96959).
+AWAITING_APPROVAL_ACTIVITY = "awaiting approval"
+APPROVAL_PROMPT_UNDELIVERABLE_ACTIVITY = "approval prompt undeliverable"
+
+
+def any_awaiting_gateway_approval() -> bool:
+    """True when any gateway session has a queued approval wait.
+
+    Safe to call from the tool-activity heartbeat thread (the queue lock is
+    the source of truth, not the thread-local session key).
+    """
+    with _lock:
+        return any(_gateway_queues.values())
+
+
+def tool_heartbeat_activity_label(function_name: str) -> str:
+    """Label the in-flight tool heartbeat should persist right now."""
+    if any_awaiting_gateway_approval():
+        return AWAITING_APPROVAL_ACTIVITY
+    return f"tool running: {function_name}"
+
+
+def _stamp_approval_activity(label: str) -> None:
+    """Best-effort activity stamp on the agent thread's callback."""
+    try:
+        from tools.environments.base import get_activity_callback
+
+        cb = get_activity_callback()
+        if cb:
+            cb(label)
+    except Exception:
+        pass
+
 
 def register_gateway_notify(session_key: str, cb) -> None:
     """Register a per-session callback for sending approval requests to the user.
@@ -4530,12 +4565,20 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
         session_key=session_key,
         surface=surface,
     )
+    logger.warning(
+        "Approval prompt raised session=%s surface=%s pattern=%s",
+        session_key,
+        surface,
+        primary_key,
+    )
+    _stamp_approval_activity(AWAITING_APPROVAL_ACTIVITY)
 
     # Notify the user (bridges sync agent thread → async gateway)
     try:
         notify_cb(dict(entry.data))
     except Exception as exc:
         logger.warning("Gateway approval notify failed: %s", exc)
+        _stamp_approval_activity(APPROVAL_PROMPT_UNDELIVERABLE_ACTIVITY)
         _drop_entry()
         _fire_approval_hook(
             "post_approval_response",
@@ -4611,7 +4654,7 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
                 resolved = True
                 break
             if touch_activity_if_due is not None:
-                touch_activity_if_due(_activity_state, "waiting for user approval")
+                touch_activity_if_due(_activity_state, AWAITING_APPROVAL_ACTIVITY)
 
     _drop_entry()
 


### PR DESCRIPTION
## What does this PR do?

A protected-file approval wait on Discord could look like the agent was still running `patch`/`write_file`. The in-flight tool heartbeat kept refreshing `tool running: <name>` while the human prompt was outstanding. If both the button card and the text fallback failed to send, the notify callback logged the error and returned, so the approval stayed pending with no visible prompt — `/approve` still worked, which made the wait look like progress.

This change stamps session activity as `awaiting approval` for the whole gateway approval wait (heartbeat included), logs prompt birth, and treats a definitive dual-send miss as `approval prompt undeliverable` so the tool fails closed instead of waiting silently. Late-ack send timeouts stay possibly-delivered so we do not re-send duplicate cards.

## Related Issue

Fixes #96959

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/approval.py` — queue-aware `awaiting approval` / `approval prompt undeliverable` activity labels, birth log on raise
- `agent/tool_executor.py` — tool heartbeat uses `tool_heartbeat_activity_label()` so it does not overwrite an approval wait as `tool running`
- `gateway/run.py` — raise `approval prompt undeliverable` after a definitive text-fallback send miss; keep ambiguous timeouts armed
- `tests/run_agent/test_tool_activity_heartbeat.py` — heartbeat stamps `awaiting approval` while a gateway prompt is queued
- `tests/tools/test_file_write_safety.py` — Discord-session AGENTS.md write: one prompt, `/approve`-style resolve
- `tests/gateway/test_discord_exec_approval_content.py` — `send_exec_approval` posts to `metadata.thread_id`
- `tests/gateway/test_approval_send_timeout_ambiguity.py` — undeliverable only when every channel definitively missed
- `tests/tools/test_approval.py` — notify failure stamps undeliverable activity

## How to Test

1. Enable Discord on the gateway (`approvals.mode: smart`) and start a foreground thread.
2. Ask the agent to edit a project-local `AGENTS.md` via `patch` or `write_file`.
3. Confirm the originating thread gets one approval card (or `/approve` text) and session activity reads `awaiting approval`, not `tool running: patch`.
4. Resolve with the buttons or `/approve` and confirm the write completes.
5. Targeted tests:
   `scripts/run_tests.sh tests/run_agent/test_tool_activity_heartbeat.py tests/gateway/test_approval_send_timeout_ambiguity.py tests/gateway/test_discord_exec_approval_content.py tests/tools/test_file_write_safety.py tests/tools/test_approval.py tests/gateway/test_approval_prompt_redaction.py -q`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5 (Darwin 25.5.0), live Discord REST to the Hermes test guild/channel

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Live Discord REST against the test guild: `GET /users/@me` 200, `GET /channels/{id}` 200 (`general`), created thread `96959-approval-repro`, posted a prompt in that thread (HTTP 200). After the fix, a queued gateway approval makes the tool heartbeat stamp `awaiting approval` instead of `tool running: patch`.
