### PR TITLE
feat(models): qwen3.8-flash now selectable on OpenRouter and Nous portal

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -504,6 +504,7 @@ DEFAULT_CONTEXT_LENGTHS = {
     # Qwen — specific model families before the catch-all.
     # Official docs: https://help.aliyun.com/zh/model-studio/developer-reference/
     "qwen3.8-max": 1_000_000,     # 1M context (OpenRouter & Nous portal, verified 2026-08-03)
+    "qwen3.8-flash": 1_000_000,   # 1M context (OpenRouter & Nous portal, verified 2026-08-28)
     "qwen3.6-plus": 1048576,      # 1M context (DashScope/Alibaba & OpenRouter)
     "qwen3.7-plus": 1048576,      # 1M context (DashScope/Alibaba)
     "qwen3-coder-plus": 1000000,  # 1M context

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -111,6 +111,7 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     ("deepseek/deepseek-v4-flash-0731",        "dated snapshot of v4-flash"),
     # Qwen
     ("qwen/qwen3.8-max",                       ""),
+    ("qwen/qwen3.8-flash",                     ""),
     # MoonshotAI
     ("moonshotai/kimi-k3",                     "recommended"),
     # MiniMax
@@ -291,6 +292,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "deepseek/deepseek-v4-flash-0731",
         # Qwen
         "qwen/qwen3.8-max",
+        "qwen/qwen3.8-flash",
         # MoonshotAI
         "moonshotai/kimi-k3",
         # MiniMax

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-08-27T11:03:10Z",
+  "updated_at": "2026-08-28T07:53:26Z",
   "metadata": {
     "source": "hermes-agent repo",
     "docs": "https://hermes-agent.nousresearch.com/docs/reference/model-catalog"
@@ -106,6 +106,10 @@
         },
         {
           "id": "qwen/qwen3.8-max",
+          "description": ""
+        },
+        {
+          "id": "qwen/qwen3.8-flash",
           "description": ""
         },
         {
@@ -266,6 +270,9 @@
         },
         {
           "id": "qwen/qwen3.8-max"
+        },
+        {
+          "id": "qwen/qwen3.8-flash"
         },
         {
           "id": "moonshotai/kimi-k3"


### PR DESCRIPTION
## Summary
`qwen/qwen3.8-flash` is now selectable in the `/model` picker on OpenRouter and the Nous portal — it was live on both provider endpoints (verified 2026-08-28) but missing from both curated lists.

## Changes
- `hermes_cli/models.py`: added to `OPENROUTER_MODELS` and `_PROVIDER_MODELS["nous"]`, directly below `qwen3.8-max` (newest-first family ordering)
- `agent/model_metadata.py`: explicit `"qwen3.8-flash": 1_000_000` context entry — without it the new family slug falls through to the generic `qwen` 131072 catch-all (same class as #69881)
- `website/static/api/model-catalog.json`: regenerated via `scripts/build_model_catalog.py`

## Scope notes (deliberate skips)
- Pricing snapshot skipped: both requested routes bill via `official_models_api` live pricing (verified with `resolve_billing_route` for openrouter and nous)
- Reasoning stale-timeout floor already fires via the `qwen3` prefix entry (verified: 180s)
- Other surfaces (alibaba/opencode lists, copilot aliases, setup defaults) untouched — only the two named providers are in scope

## Validation
| Check | Result |
|---|---|
| OpenRouter live `/api/v1/models` | present, ctx 1,000,000, $0.15/$0.47 per M |
| Nous portal live `/v1/models` | present |
| Curated-fallback E2E (temp HERMES_HOME, network denied) | in both pickers, no dupes, slotted after qwen3.8-max |
| `DEFAULT_CONTEXT_LENGTHS` resolution | `qwen3.8-flash` → 1,000,000 (no longer generic 131K) |
| Targeted suites (models, gmi lockstep, catalog manifest, pricing, metadata, reasoning floors) | 311 passed; 1 pre-existing failure unrelated to this diff (see below) |
| Fixture sweep (`grep qwen3.8-flash tests/ plugins/`) | no hits |

Pre-existing test pollution (fails on clean origin/main too, not introduced here): `test_switch_model_on_current_ollama_custom_endpoint_keeps_base_url` leaves state that breaks `TestMoAContextLength::test_moa_custom_context_configures_compressor_threshold` when run in the same process.

## Infographic

![Qwen3.8 Flash joins the catalog](https://v3b.fal.media/files/b/0aa8200b/-2Y27ciCgFtqlH1-5s-gb_1xLFn4XR.png)
