### PR TITLE
fix(desktop): derive the workspace from the focused conversation, once

### DIFF
--- a/apps/desktop/src/app/contrib/controller.tsx
+++ b/apps/desktop/src/app/contrib/controller.tsx
@@ -68,8 +68,14 @@ import {
   openReview,
   REVIEW_PANE_ID
 } from '@/store/review'
-import { $currentCwd, $selectedStoredSessionId, $sessions, $yoloActive, sessionMatchesStoredId } from '@/store/session'
+import {
+  $selectedStoredSessionId,
+  $sessions,
+  $yoloActive,
+  sessionMatchesStoredId
+} from '@/store/session'
 import { watchSessionPins } from '@/store/session-pin-sync'
+import { $focusedWorkspaceCwd } from '@/store/session-states'
 import { watchUnreadWriteGuard } from '@/store/session-unread-remote'
 import { $statusbarVisible } from '@/store/statusbar-prefs'
 import { isBrowserWindow, isHudWindow } from '@/store/windows'
@@ -583,7 +589,14 @@ bindTreeSideVisibility('right', $fileBrowserOpen, setFileBrowserOpen)
 // collapse and the chat absorbs the width; picking a project brings them
 // back. The terminal is NOT workspace-gated: unlike the old shell (where it
 // rode the rail's row and vanished with it), its zone stands on its own.
-const $hasWorkspace = computed($currentCwd, cwd => Boolean(cwd.trim()))
+//
+// `$focusedWorkspaceCwd`, not a bare `Boolean(cwd)`: the pane's own body reads
+// the same derivation, so this gate must too or the pane mounts and renders
+// "No project open" inside itself. It also follows the FOCUSED conversation
+// rather than the `$currentCwd` singleton, so a tile in another project keeps
+// its pane instead of showing the primary chat's tree. See the store for the
+// full note.
+const $hasWorkspace = computed($focusedWorkspaceCwd, cwd => Boolean(cwd))
 
 // The tree pane's own presence tracks ⌘J directly, not just the column's
 // collapse — otherwise a pane revealed into that shared column would drag the

--- a/apps/desktop/src/app/right-sidebar/index.tsx
+++ b/apps/desktop/src/app/right-sidebar/index.tsx
@@ -13,7 +13,7 @@ import { cn } from '@/lib/utils'
 import { $panesFlipped } from '@/store/layout'
 import { notifyError } from '@/store/notifications'
 import { openPreview } from '@/store/preview'
-import { $currentCwd, $selectedStoredSessionId, $workspaceCwdOwner } from '@/store/session'
+import { $focusedWorkspaceCwd } from '@/store/session-states'
 
 import { SidebarPanelLabel } from '../shell/sidebar-label'
 
@@ -29,14 +29,17 @@ export function RightSidebarPane({ onActivateFile, onActivateFolder }: RightSide
   const { t } = useI18n()
   const r = t.rightSidebar
   const panesFlipped = useStore($panesFlipped)
-  const currentCwd = useStore($currentCwd).trim()
-  const selectedStoredSessionId = useStore($selectedStoredSessionId)
-  const workspaceCwdOwner = useStore($workspaceCwdOwner)
 
-  // A transition intentionally retains the old CWD until the new session
-  // confirms its workspace. Do not issue a filesystem read against that path:
-  // under a gateway switch it may belong to a different remote machine.
-  const hasWorkspace = Boolean(currentCwd) && (workspaceCwdOwner ?? null) === (selectedStoredSessionId ?? null)
+  // The FOCUSED conversation's workspace, not the `$currentCwd` singleton. The
+  // singleton describes the PRIMARY chat, so with a tile focused this pane
+  // listed the primary chat's project while the statusbar beside it correctly
+  // named the tile's. `$focusedWorkspaceCwd` is the shared derivation the
+  // statusbar already followed, and it carries the ownership gate for its
+  // singleton rung — a transition intentionally retains the old path until the
+  // new session confirms its workspace, and no filesystem read may go out
+  // against that path (under a gateway switch it may be another machine's).
+  const currentCwd = useStore($focusedWorkspaceCwd)
+  const hasWorkspace = Boolean(currentCwd)
 
   const {
     collapseAll,

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -753,7 +753,11 @@ export function useSessionActions({
         // unlisted (draft) tab stays out of the session list until its first
         // turn persists and a refresh surfaces it.
         if (listed) {
-          upsertOptimisticSession(created, stored, null, null, null, undefined, capturedRoute)
+          // `cwd` is the workspace this tile was created FOR (already resolved
+          // above). Pass it so the optimistic row lands in the right lane even
+          // when the primary chat sits in another project — `$currentCwd` still
+          // names that other project at this point.
+          upsertOptimisticSession(created, stored, null, null, null, undefined, capturedRoute, cwd)
         }
 
         // A tile lives in its OWN worktree, so it must not run the full

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
@@ -8,6 +8,7 @@ import { $activeGatewayProfile } from '@/store/profile'
 import {
   $currentBranch,
   $currentCwd,
+  $sessions,
   setCurrentBranch,
   setCurrentCwd,
   setSelectedStoredSessionId,
@@ -33,7 +34,8 @@ import {
   selectBranchMessages,
   sessionMatchesStoredId,
   sessionShouldHaveTranscript,
-  toBranchMessages
+  toBranchMessages,
+  upsertOptimisticSession
 } from './utils'
 
 const msg = (id: string, role: ChatMessage['role'], text: string, extra: Partial<ChatMessage> = {}): ChatMessage =>
@@ -1715,5 +1717,73 @@ describe('overlayConcurrentMessageChanges', () => {
       { type: 'text', text: 'partial A' },
       { type: 'text', text: ' + delta B' }
     ])
+  })
+})
+
+describe('upsertOptimisticSession workspace lane', () => {
+  const created = (cwd?: string) =>
+    ({
+      session_id: 'rt-1',
+      stored_session_id: 'sess-new',
+      ...(cwd === undefined ? {} : { info: { cwd } })
+    }) as never
+
+  beforeEach(() => {
+    $sessions.set([])
+    setCurrentCwd('')
+  })
+
+  afterEach(() => {
+    $sessions.set([])
+    setCurrentCwd('')
+  })
+
+  const rowCwd = () => $sessions.get().find(s => s.id === 'sess-new')?.cwd
+
+  // The regression. The sidebar "+" of one project creates a tile while the
+  // main chat sits in ANOTHER project; `$currentCwd` still names the main
+  // chat's folder at that moment, so falling back to it filed the new row in
+  // the wrong project's lane (the session itself ran in the right folder).
+  it('files the row under the workspace it was created for, not the primary chat', () => {
+    setCurrentCwd('/main-chat-project')
+
+    upsertOptimisticSession(created(), 'sess-new', null, null, null, undefined, undefined, '/plus-clicked-project')
+
+    expect(rowCwd()).toBe('/plus-clicked-project')
+  })
+
+  // An empty requested cwd is a DECISION ("New session in Home"), not a missing
+  // value: it must stay detached instead of inheriting the primary chat's path.
+  it('keeps an explicitly detached session detached', () => {
+    setCurrentCwd('/main-chat-project')
+
+    upsertOptimisticSession(created(), 'sess-new', null, null, null, undefined, undefined, '')
+
+    expect(rowCwd()).toBeNull()
+  })
+
+  // The backend may normalise the path it actually used, so its answer wins.
+  it('prefers the create response over the requested workspace', () => {
+    upsertOptimisticSession(
+      created('/normalised/by/backend'),
+      'sess-new',
+      null,
+      null,
+      null,
+      undefined,
+      undefined,
+      '/plus-clicked-project'
+    )
+
+    expect(rowCwd()).toBe('/normalised/by/backend')
+  })
+
+  // Callers that name nothing (a plain new chat) keep the previous behaviour.
+  it('falls back to the composer workspace when no cwd was requested', () => {
+    setCurrentCwd('/main-chat-project')
+
+    upsertOptimisticSession(created(), 'sess-new')
+
+    expect(rowCwd()).toBe('/main-chat-project')
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -1249,7 +1249,19 @@ export function upsertOptimisticSession(
   preview: string | null = null,
   parentSessionId: string | null = null,
   lastActive?: number,
-  owner?: null | SessionProfileRoute
+  owner?: null | SessionProfileRoute,
+  /**
+   * Workspace this session was explicitly created FOR, when the caller named
+   * one (the sidebar "+" on a project/worktree lane passes its path straight
+   * into `session.create`). Preferred over the `$currentCwd` fallback below:
+   * that singleton describes the PRIMARY chat, which is a different
+   * conversation in the very case this argument exists for.
+   *
+   * An empty string is a DECISION ("Home / detached"), not a missing value, and
+   * stays detached rather than inheriting the primary chat's folder. Omit the
+   * argument when the caller named nothing.
+   */
+  requestedCwd?: string
 ) {
   const now = lastActive ?? Date.now() / 1000
   // Stamp the profile the session was just created on so the scoped sidebar
@@ -1267,9 +1279,19 @@ export function upsertOptimisticSession(
 
   const session: SessionInfo = {
     // Seed cwd so the grouped sidebar can place the new row in its repo/worktree
-    // lane immediately (the overlay groups by path); fall back to the workspace
-    // the session was just started in when the create response omits it.
-    cwd: created.info?.cwd ?? ($currentCwd.get().trim() || null),
+    // lane immediately (the overlay groups by path).
+    //
+    // Order matters. `$currentCwd` is the LAST resort because it is a shared
+    // singleton naming the PRIMARY chat's folder — when the sidebar "+" of one
+    // project creates a tile while the main chat sits in another, that fallback
+    // filed the new row under the main chat's project and the row appeared in
+    // the wrong lane (the session itself ran in the right folder). The
+    // caller-named workspace is authoritative whenever there is one; the
+    // create response outranks it only because the backend may normalise the
+    // path it actually used.
+    cwd:
+      created.info?.cwd ??
+      (requestedCwd === undefined ? $currentCwd.get().trim() || null : requestedCwd.trim() || null),
     ended_at: null,
     id,
     input_tokens: 0,

--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.test.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.test.tsx
@@ -1,0 +1,123 @@
+import { cleanup, renderHook } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useStatusbarItems } from '@/app/shell/hooks/use-statusbar-items'
+import {
+  $selectedStoredSessionId,
+  $sessions,
+  releaseWorkspaceCwdOwner,
+  setCurrentCwdTransient,
+  setWorkspaceCwdOwner
+} from '@/store/session'
+import { stubMenuDomApis, stubResizeObserver } from '@/test/jsdom'
+
+beforeAll(() => {
+  stubResizeObserver()
+  stubMenuDomApis()
+})
+
+const row = (id: string, cwd: null | string) =>
+  ({
+    archived: false,
+    cwd,
+    ended_at: null,
+    id,
+    input_tokens: 0,
+    is_active: true,
+    last_active: 0,
+    message_count: 1,
+    model: null,
+    output_tokens: 0,
+    started_at: 0,
+    title: id
+  }) as never
+
+/** The workspace item's rendered label, or undefined when the item is hidden. */
+function workspaceLabel() {
+  const { result } = renderHook(
+    () =>
+      useStatusbarItems({
+        agentsOpen: false,
+        chatOpen: true,
+        commandCenterOpen: false,
+        extraLeftItems: [],
+        extraRightItems: [],
+        freshDraftReady: false,
+        gatewayState: 'ready',
+        inferenceStatus: null,
+        openAgents: vi.fn(),
+        openCommandCenterSection: vi.fn(),
+        requestGateway: vi.fn(),
+        statusSnapshot: null,
+        toggleCommandCenter: vi.fn()
+      }),
+    { wrapper: ({ children }) => <MemoryRouter>{children}</MemoryRouter> }
+  )
+
+  const items = [...result.current.leftStatusbarItems, ...result.current.statusbarItems]
+  const workspace = items.find(entry => entry.id === 'workspace-cwd')
+
+  return workspace?.hidden ? undefined : workspace?.label
+}
+
+describe('useStatusbarItems workspace item', () => {
+  beforeEach(() => {
+    setCurrentCwdTransient('')
+    $selectedStoredSessionId.set(null)
+    $sessions.set([])
+    setWorkspaceCwdOwner(null)
+  })
+
+  afterEach(() => {
+    cleanup()
+    setCurrentCwdTransient('')
+    $selectedStoredSessionId.set(null)
+    $sessions.set([])
+    setWorkspaceCwdOwner(null)
+  })
+
+  // The regression. `$currentCwd` is a shared singleton: during a conversation
+  // switch it still holds the PREVIOUS chat's folder until `session.resume`
+  // settles, which is exactly what the ownership marker exists to say
+  // (ae6eb578bb). The Files pane and `$repoStatus` ask that question; this hook
+  // did not, so it labelled the new conversation with the old project's name
+  // while the pane beside it correctly showed nothing.
+  it('does not label an un-owned singleton path (the previous conversation folder)', () => {
+    setCurrentCwdTransient('/previous-project')
+    $selectedStoredSessionId.set('sess-switching')
+    $sessions.set([])
+    releaseWorkspaceCwdOwner()
+
+    expect(workspaceLabel()).toBeUndefined()
+  })
+
+  it('labels the singleton path once the selected conversation owns it', () => {
+    setCurrentCwdTransient('/owned-project')
+    $selectedStoredSessionId.set('sess-settled')
+    $sessions.set([])
+    setWorkspaceCwdOwner('sess-settled')
+
+    expect(workspaceLabel()).toBe('owned-project')
+  })
+
+  it('labels a fresh draft, whose null owner matches its null selection', () => {
+    setCurrentCwdTransient('/draft-target')
+    $selectedStoredSessionId.set(null)
+    setWorkspaceCwdOwner(null)
+
+    expect(workspaceLabel()).toBe('draft-target')
+  })
+
+  // Ownership gates ONLY the singleton rung. A released marker says nothing
+  // about the session's own stored row, so dropping the row too would blank a
+  // workspace that is known — the failure mode 416e025c46 warns about.
+  it('still labels from the stored row while ownership is released', () => {
+    setCurrentCwdTransient('/previous-project')
+    $selectedStoredSessionId.set('sess-known')
+    $sessions.set([row('sess-known', '/its-own-project')])
+    releaseWorkspaceCwdOwner()
+
+    expect(workspaceLabel()).toBe('its-own-project')
+  })
+})

--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
@@ -27,16 +27,19 @@ import {
   $activeSessionId,
   $busy,
   $connection,
-  $currentCwd,
   $currentUsage,
   $selectedStoredSessionId,
   $sessions,
   $sessionStartedAt,
   $turnStartedAt,
-  idsShareLineage,
   sessionMatchesStoredId
 } from '@/store/session'
-import { $focusedRuntimeId, $focusedSessionState, $focusedStoredSessionId } from '@/store/session-states'
+import {
+  $focusedRuntimeId,
+  $focusedSessionState,
+  $focusedStoredSessionId,
+  $focusedWorkspaceCwd
+} from '@/store/session-states'
 import { $statusbarHiddenIds } from '@/store/statusbar-prefs'
 import { $subagentsBySession, activeSubagentCount, failedSubagentCount } from '@/store/subagents'
 import { $gatewayRestarting } from '@/store/system-actions'
@@ -97,10 +100,6 @@ export function useStatusbarItems({
   const sessionsShowing = useStore($paneVisible('sessions'))
   const botsShowing = useStore($paneVisible('hermes-bots:pane'))
   const primaryBusy = useStore($busy)
-  // Draft / primary composer atom — used only while the focused surface is the
-  // primary (or a draft with no runtime slice yet). A focused TILE keeps its
-  // own cwd in `$sessionStates` and must not paint the primary's workspace.
-  const primaryCwd = useStore($currentCwd)
   const primaryUsage = useStore($currentUsage)
   const gatewayRestarting = useStore($gatewayRestarting)
   const primarySessionStartedAt = useStore($sessionStartedAt)
@@ -143,7 +142,6 @@ export function useStatusbarItems({
   // reports new usage — far rarer than a delta — so its reference is a valid
   // bail-out key on its own.
   const focusedUsage = useStoreSelector($focusedSessionState, state => state?.usage ?? null)
-  const focusedStateCwd = useStoreSelector($focusedSessionState, state => state?.cwd?.trim() || '')
 
   // Runtime slices carry the stored id they were bound for. During a primary
   // tab switch the runtime id can lag a frame behind the new selection — the
@@ -173,47 +171,10 @@ export function useStatusbarItems({
       : null
   )
 
-  const focusedRowCwd = useStoreSelector($sessions, sessions => {
-    if (!focusedStoredSessionId) {
-      return ''
-    }
-
-    const row = sessions.find(s => sessionMatchesStoredId(s, focusedStoredSessionId))
-
-    return row?.cwd?.trim() || ''
-  })
-
-  // Live runtime cwd is authoritative once it belongs to the focused chat
-  // (agent can relocate mid-turn). Until then — cold tabs, mid-switch lag —
-  // the stored session row is the selection's project. Primary drafts fall
-  // through to `$currentCwd`. A focused TILE must never inherit the primary's
-  // workspace — an empty tile cwd stays empty rather than lying about another
-  // project's path.
-  //
-  // Lineage match is a pure derivation of ($sessions + the two ids). Select it
-  // so a session-list write only re-renders when the answer actually flips —
-  // not on every title/archive refresh of an unrelated row.
-  const liveCwdSharesFocusLineage = useStoreSelector($sessions, sessions => {
-    if (!focusedStoredSessionId || !focusedStateStoredId) {
-      return false
-    }
-
-    return idsShareLineage(focusedStoredSessionId, focusedStateStoredId, sessions)
-  })
-
-  const liveCwdBelongsToFocus =
-    Boolean(focusedStateCwd) &&
-    (!focusedStoredSessionId ||
-      !focusedStateStoredId ||
-      focusedStateStoredId === focusedStoredSessionId ||
-      liveCwdSharesFocusLineage)
-
-  const currentCwd = (
-    (liveCwdBelongsToFocus ? focusedStateCwd : '') ||
-    focusedRowCwd ||
-    (primaryFocused ? primaryCwd : '') ||
-    ''
-  ).trim()
+  // The focused conversation's workspace. Shared with the Files pane and its
+  // mount gate (`$focusedWorkspaceCwd`) so all three answer "which project is
+  // this chat in" identically — they used to derive it separately and disagreed.
+  const currentCwd = useStore($focusedWorkspaceCwd)
 
   // Derive the workspace's project name from the already-cached project tree
   // (backend truth via projects.*), so the status item labels by project without

--- a/apps/desktop/src/store/focused-workspace-cwd.test.ts
+++ b/apps/desktop/src/store/focused-workspace-cwd.test.ts
@@ -154,3 +154,112 @@ describe('$focusedWorkspaceCwd', () => {
     expect($focusedWorkspaceCwd.get()).toBe('/main-quarkus')
   })
 })
+
+/**
+ * The precedence contract, enumerated.
+ *
+ * The three rungs interact through two decisions that are easy to reorder by
+ * accident: the `row && !primaryOwnsSingleton -> ''` early return (a row that
+ * exists and names nothing reads as detached) and the `primaryFocused &&
+ * primaryIsOwned` singleton rung. The cases above each pin one failure mode;
+ * this table pins the ORDER, so a refactor that swaps two rungs fails here
+ * instead of silently changing which project a surface names.
+ *
+ * Axes: the focused row's cwd (a path / present-but-null / no row at all) x
+ * which surface holds focus (primary = selection, tile = never the selection,
+ * none = fresh draft) x whether the selected conversation owns `$currentCwd`.
+ */
+describe('$focusedWorkspaceCwd precedence', () => {
+  const SINGLETON = '/singleton-project'
+  const ROW = '/row-project'
+
+  type Focus = 'none' | 'primary' | 'tile'
+  type RowShape = 'absent' | 'null-cwd' | 'path'
+
+  interface Case {
+    /** Expected cwd — '' means "name no project rather than the wrong one". */
+    expected: string
+    focus: Focus
+    owned: boolean
+    rowShape: RowShape
+    why: string
+  }
+
+  const cases: Case[] = [
+    // Rung 2 wins outright: a row that names a path is the answer regardless of
+    // who owns the singleton and of which surface is focused.
+    { expected: ROW, focus: 'primary', owned: true, rowShape: 'path', why: 'row outranks the owned singleton' },
+    { expected: ROW, focus: 'primary', owned: false, rowShape: 'path', why: 'row survives released ownership' },
+    { expected: ROW, focus: 'tile', owned: true, rowShape: 'path', why: "tile's own row, not the primary's" },
+    { expected: ROW, focus: 'tile', owned: false, rowShape: 'path', why: "tile's own row, ownership irrelevant" },
+
+    // Row present but null-cwd: detached UNLESS this very conversation owns the
+    // singleton, which is a positive claim and outranks a not-yet-backfilled row.
+    { expected: SINGLETON, focus: 'primary', owned: true, rowShape: 'null-cwd', why: 'own claim beats an unbackfilled row' },
+    { expected: '', focus: 'primary', owned: false, rowShape: 'null-cwd', why: 'no claim, no row: detached' },
+    { expected: '', focus: 'tile', owned: true, rowShape: 'null-cwd', why: 'the claim is the PRIMARY\'s, not the tile\'s' },
+    { expected: '', focus: 'tile', owned: false, rowShape: 'null-cwd', why: 'detached tile stays empty' },
+
+    // No row at all (fresh/unlisted): the early return cannot fire, so the
+    // singleton rung decides — and only for the primary.
+    { expected: SINGLETON, focus: 'primary', owned: true, rowShape: 'absent', why: 'unlisted primary falls to its own claim' },
+    { expected: '', focus: 'primary', owned: false, rowShape: 'absent', why: 'unowned singleton is never adopted' },
+    { expected: '', focus: 'tile', owned: true, rowShape: 'absent', why: 'a tile never inherits the primary workspace' },
+    { expected: '', focus: 'tile', owned: false, rowShape: 'absent', why: 'a tile never inherits the primary workspace' },
+
+    // Fresh draft: no selection, no tile. Owner null matches selection null.
+    { expected: SINGLETON, focus: 'none', owned: true, rowShape: 'absent', why: 'draft owns its own target folder' },
+    { expected: '', focus: 'none', owned: false, rowShape: 'absent', why: 'released draft names nothing' }
+  ]
+
+  beforeEach(() => {
+    window.localStorage.clear()
+    $sessionStates.set({})
+    $sessionTiles.set([])
+    $layoutTree.set(null)
+    noteActiveTreeGroup(null)
+    setSessions(() => [])
+    $selectedStoredSessionId.set(null)
+    setCurrentCwdTransient('')
+    setWorkspaceCwdOwner(null)
+  })
+
+  for (const c of cases) {
+    it(`${c.focus} focus + ${c.rowShape} row + ${c.owned ? 'owned' : 'unowned'} singleton -> ${c.expected || "''"} (${c.why})`, () => {
+      // The focused id is DERIVED, never set: a tile is focused by making its
+      // pane the active tab, the primary by being the selection with no tile.
+      const focusedId = c.focus === 'tile' ? 'sess-tile' : 'sess-primary'
+      const selectedId = c.focus === 'none' ? null : 'sess-primary'
+
+      $selectedStoredSessionId.set(selectedId)
+
+      const rows: ReturnType<typeof row>[] = []
+
+      if (c.focus === 'tile' && selectedId) {
+        rows.push(row(selectedId, '/primary-project'))
+      }
+
+      if (c.rowShape !== 'absent') {
+        rows.push(row(focusedId, c.rowShape === 'path' ? ROW : null))
+      }
+
+      setSessions(() => rows)
+
+      // Ownership is a marker, not a path: commit claims the singleton for the
+      // current selection, release leaves the path and drops the claim.
+      setCurrentCwdTransient(SINGLETON)
+
+      if (c.owned) {
+        setWorkspaceCwdOwner(selectedId)
+      } else {
+        releaseWorkspaceCwdOwner()
+      }
+
+      if (c.focus === 'tile') {
+        focusTile(focusedId)
+      }
+
+      expect($focusedWorkspaceCwd.get()).toBe(c.expected)
+    })
+  }
+})

--- a/apps/desktop/src/store/focused-workspace-cwd.test.ts
+++ b/apps/desktop/src/store/focused-workspace-cwd.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import type { ClientSessionState } from '@/app/types'
+import { group } from '@/components/pane-shell/tree/model'
+import { $layoutTree, declareDefaultTree, noteActiveTreeGroup } from '@/components/pane-shell/tree/store'
+import {
+  $selectedStoredSessionId,
+  commitWorkspaceCwdForSelectedSession,
+  releaseWorkspaceCwdOwner,
+  setCurrentCwdTransient,
+  setSessions,
+  setWorkspaceCwdOwner
+} from '@/store/session'
+import { $focusedWorkspaceCwd, $sessionStates, $sessionTiles } from '@/store/session-states'
+
+const row = (id: string, cwd: null | string) =>
+  ({
+    archived: false,
+    cwd,
+    ended_at: null,
+    id,
+    input_tokens: 0,
+    is_active: true,
+    last_active: 0,
+    message_count: 1,
+    model: null,
+    output_tokens: 0,
+    started_at: 0,
+    title: id
+  }) as never
+
+const slice = (storedSessionId: string, cwd: string) =>
+  ({ cwd, storedSessionId }) as unknown as ClientSessionState
+
+/** Focus a TILE the way the layout tree does: its pane is the active tab. */
+function focusTile(storedSessionId: string) {
+  $sessionTiles.set([{ storedSessionId }])
+  declareDefaultTree(
+    group(['workspace', `session-tile:${storedSessionId}`], {
+      active: `session-tile:${storedSessionId}`,
+      id: 'grp-main'
+    })
+  )
+  noteActiveTreeGroup('grp-main')
+}
+
+describe('$focusedWorkspaceCwd', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    $sessionStates.set({})
+    $sessionTiles.set([])
+    $layoutTree.set(null)
+    noteActiveTreeGroup(null)
+    setSessions(() => [])
+    $selectedStoredSessionId.set(null)
+    setCurrentCwdTransient('')
+    setWorkspaceCwdOwner(null)
+  })
+
+  afterEach(() => {
+    $sessionStates.set({})
+    $sessionTiles.set([])
+    $layoutTree.set(null)
+    noteActiveTreeGroup(null)
+    setSessions(() => [])
+    $selectedStoredSessionId.set(null)
+    setCurrentCwdTransient('')
+    setWorkspaceCwdOwner(null)
+  })
+
+  // THE regression, measured in the running app: a base-image tile was focused
+  // while the primary chat sat in main-quarkus. The Files pane read the
+  // `$currentCwd` singleton — which describes the PRIMARY chat, because a tile's
+  // runtime deliberately never publishes into it (`foreground: false`) — and so
+  // listed main-quarkus with header MAIN-QUARKUS, while the statusbar correctly
+  // said base-image.
+  it('follows a focused TILE, not the primary chat singleton', () => {
+    $selectedStoredSessionId.set('sess-primary')
+    setSessions(() => [row('sess-primary', '/main-quarkus'), row('sess-tile', '/base-image')])
+    commitWorkspaceCwdForSelectedSession('/main-quarkus')
+    focusTile('sess-tile')
+
+    expect($focusedWorkspaceCwd.get()).toBe('/base-image')
+  })
+
+  it('prefers the tile runtime slice over its stored row', () => {
+    $selectedStoredSessionId.set('sess-primary')
+    setSessions(() => [row('sess-primary', '/main-quarkus'), row('sess-tile', '/base-image')])
+    commitWorkspaceCwdForSelectedSession('/main-quarkus')
+    focusTile('sess-tile')
+    $sessionTiles.set([{ runtimeId: 'rt-tile', storedSessionId: 'sess-tile' }])
+    $sessionStates.set({ 'rt-tile': slice('sess-tile', '/base-image/.worktrees/feature') })
+
+    expect($focusedWorkspaceCwd.get()).toBe('/base-image/.worktrees/feature')
+  })
+
+  // A tile with no workspace stays empty rather than naming another project.
+  it('stays empty for a detached focused tile', () => {
+    $selectedStoredSessionId.set('sess-primary')
+    setSessions(() => [row('sess-primary', '/main-quarkus'), row('sess-tile', null)])
+    commitWorkspaceCwdForSelectedSession('/main-quarkus')
+    focusTile('sess-tile')
+
+    expect($focusedWorkspaceCwd.get()).toBe('')
+  })
+
+  it('uses the primary singleton when the primary chat is focused and owns it', () => {
+    $selectedStoredSessionId.set('sess-primary')
+    setSessions(() => [row('sess-primary', null)])
+    commitWorkspaceCwdForSelectedSession('/main-quarkus')
+
+    expect($focusedWorkspaceCwd.get()).toBe('/main-quarkus')
+  })
+
+  // Ownership gates the singleton rung only: during a switch it still names the
+  // conversation the user just left (ae6eb578bb).
+  it('ignores an un-owned singleton', () => {
+    $selectedStoredSessionId.set('sess-switching')
+    setSessions(() => [])
+    setCurrentCwdTransient('/previous-project')
+    releaseWorkspaceCwdOwner()
+
+    expect($focusedWorkspaceCwd.get()).toBe('')
+  })
+
+  // …but it must NOT gate the ROW rung: a released marker says nothing about the
+  // row, so dropping it too would blank a workspace we do know (416e025c46).
+  it('still uses the stored row while ownership is released', () => {
+    $selectedStoredSessionId.set('sess-known')
+    setSessions(() => [row('sess-known', '/its-own-project')])
+    setCurrentCwdTransient('/previous-project')
+    releaseWorkspaceCwdOwner()
+
+    expect($focusedWorkspaceCwd.get()).toBe('/its-own-project')
+  })
+
+  it('labels a fresh draft, whose null owner matches its null selection', () => {
+    setCurrentCwdTransient('/draft-target')
+    setWorkspaceCwdOwner(null)
+
+    expect($focusedWorkspaceCwd.get()).toBe('/draft-target')
+  })
+
+  it('is reactive: focusing away from the tile returns the primary workspace', () => {
+    $selectedStoredSessionId.set('sess-primary')
+    setSessions(() => [row('sess-primary', '/main-quarkus'), row('sess-tile', '/base-image')])
+    commitWorkspaceCwdForSelectedSession('/main-quarkus')
+    focusTile('sess-tile')
+    expect($focusedWorkspaceCwd.get()).toBe('/base-image')
+
+    noteActiveTreeGroup(null)
+    declareDefaultTree(group(['workspace'], { active: 'workspace', id: 'grp-main' }))
+
+    expect($focusedWorkspaceCwd.get()).toBe('/main-quarkus')
+  })
+})

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -40,11 +40,14 @@ import { clearAllProviderWaits, clearSessionProviderWait } from './provider-wait
 import {
   $activeSessionId,
   $connection,
+  $currentCwd,
   $lastReadAtBySessionId,
   $selectedStoredSessionId,
   $sessions,
+  $workspaceCwdIsOwned,
   clearReadBaseline,
   getSessionOwnerHint,
+  idsShareLineage,
   knownSessionOwner,
   lineageAliases,
   markSessionRead,
@@ -1680,6 +1683,80 @@ export const $focusedRuntimeId = computed(
 /** The focused session's state slice (undefined while unresolved/unbound). */
 export const $focusedSessionState = computed([$focusedRuntimeId, $sessionStates], (runtimeId, states) =>
   runtimeId ? states[runtimeId] : undefined
+)
+
+/**
+ * Working directory of the FOCUSED conversation — the surface the user is
+ * actually looking at, tile or primary. Every workspace-derived surface that
+ * describes "this chat's project" reads this.
+ *
+ * Three sources, in falling authority:
+ *   1. the focused session's live runtime slice, gated on ownership (during a
+ *      tab switch the runtime id can lag a frame behind the selection, so an
+ *      ungated read paints session A's workspace under session B's tab);
+ *   2. the focused session's stored row, for cold tabs and mid-switch lag;
+ *   3. `$workspaceCwdIsOwned` — the `$currentCwd` singleton, and only when the
+ *      selected conversation owns it.
+ *
+ * Why the first two rungs exist at all: `$currentCwd` describes the PRIMARY
+ * chat. A tile is deliberately excluded from it (`applyRuntimeInfo` with
+ * `foreground: false`) so a tile's folder cannot re-point the main composer's
+ * coding rail. Surfaces that read the singleton alone therefore described the
+ * primary chat while the user had a TILE focused — measured: with a base-image
+ * tile in front, the Files pane listed main-quarkus and its header said
+ * MAIN-QUARKUS, while the statusbar (which already followed the focused
+ * session) correctly said base-image.
+ *
+ * Ownership still gates the singleton rung, because that is the rung which can
+ * name a folder belonging to a conversation the user already left (ae6eb578bb).
+ * It must NOT gate the row rung: a released marker says nothing about the row,
+ * so dropping it too would blank a workspace we do know (416e025c46).
+ */
+export const $focusedWorkspaceCwd = computed(
+  [$focusedSessionState, $focusedStoredSessionId, $selectedStoredSessionId, $sessions, $currentCwd, $workspaceCwdIsOwned],
+  (state, focusedStoredId, selectedStoredId, sessions, primaryCwd, primaryIsOwned) => {
+    const stateCwd = state?.cwd?.trim() || ''
+    const stateStoredId = state?.storedSessionId?.trim() || null
+
+    const liveBelongsToFocus =
+      Boolean(stateCwd) &&
+      (!focusedStoredId ||
+        !stateStoredId ||
+        stateStoredId === focusedStoredId ||
+        idsShareLineage(focusedStoredId, stateStoredId, sessions))
+
+    if (liveBelongsToFocus) {
+      return stateCwd
+    }
+
+    if (focusedStoredId) {
+      const row = sessions.find(s => sessionMatchesStoredId(s, focusedStoredId))
+      const rowCwd = row?.cwd?.trim() || ''
+
+      if (rowCwd) {
+        return rowCwd
+      }
+
+      // A row that EXISTS and names no workspace reads as detached — but only
+      // when nothing better is known. An owned singleton is a positive claim by
+      // this very conversation (`commitWorkspaceCwdForSelectedSession`), and it
+      // outranks a row that is merely not backfilled yet; `cwd` is null on
+      // history rows predating the backfill, so trusting the row here blanked a
+      // workspace the runtime had just confirmed. For a TILE there is no such
+      // claim to fall back on, so it stays detached.
+      const primaryOwnsSingleton = primaryIsOwned && (!selectedStoredId || focusedStoredId === selectedStoredId)
+
+      if (row && !primaryOwnsSingleton) {
+        return ''
+      }
+    }
+
+    // Primary draft / primary chat only. A focused TILE never inherits the
+    // primary's workspace — it stays empty rather than naming another project.
+    const primaryFocused = !focusedStoredId || focusedStoredId === selectedStoredId
+
+    return primaryFocused && primaryIsOwned ? primaryCwd.trim() : ''
+  }
 )
 
 /** A PRIMARY navigation (sidebar resume, route change, new chat) homes focus to

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -1221,6 +1221,22 @@ export const commitWorkspaceCwdForSelectedSession = (cwd: string) => {
 export const workspaceCwdBelongsToSelectedSession = (): boolean =>
   ($workspaceCwdOwner.get() ?? null) === ($selectedStoredSessionId.get() ?? null)
 
+/** Reactive form of {@link workspaceCwdBelongsToSelectedSession}, ANDed with
+ *  "there is a path at all" — the one gate every surface that MOUNTS on the
+ *  presence of a workspace should read.
+ *
+ *  Ownership and not just a non-empty path: `$currentCwd` is a shared singleton
+ *  that keeps naming the PREVIOUS conversation until the new one's workspace is
+ *  confirmed (ae6eb578bb). A bare `Boolean(cwd)` therefore answered "yes,
+ *  workspace" for a path the selected conversation does not own, which mounted
+ *  the Files pane while its body — which does ask ownership — rendered
+ *  "No project open" inside it. Two gates on one pane must ask the same
+ *  question. */
+export const $workspaceCwdIsOwned = computed(
+  [$currentCwd, $selectedStoredSessionId, $workspaceCwdOwner],
+  (cwd, selected, owner) => Boolean(cwd.trim()) && (owner ?? null) === (selected ?? null)
+)
+
 export const setNewChatWorkspaceTarget = (next: NewChatWorkspaceTarget): number => {
   const generation = $newChatWorkspaceTargetGeneration.get() + 1
   $newChatWorkspaceTarget.set(next)

--- a/apps/desktop/src/store/workspace-cwd-ownership.test.ts
+++ b/apps/desktop/src/store/workspace-cwd-ownership.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  $selectedStoredSessionId,
+  $workspaceCwdIsOwned,
+  commitWorkspaceCwdForSelectedSession,
+  releaseWorkspaceCwdOwner,
+  setCurrentCwdTransient,
+  setWorkspaceCwdOwner
+} from '@/store/session'
+
+// `$workspaceCwdIsOwned` is the single gate behind three surfaces that used to
+// answer "is there a workspace" separately: whether the Files/Review panes MOUNT
+// (contrib/controller.tsx), whether the Files pane renders a tree or the
+// "No project open" hint (right-sidebar/index.tsx), and whether the statusbar
+// may label the singleton path (shell/hooks/use-statusbar-items.tsx).
+describe('$workspaceCwdIsOwned', () => {
+  beforeEach(() => {
+    setCurrentCwdTransient('')
+    $selectedStoredSessionId.set(null)
+    setWorkspaceCwdOwner(null)
+  })
+
+  afterEach(() => {
+    setCurrentCwdTransient('')
+    $selectedStoredSessionId.set(null)
+    setWorkspaceCwdOwner(null)
+  })
+
+  // The regression. The mount gate asked `Boolean(cwd.trim())` while the pane
+  // body asked ownership, so a path the selected conversation does not own
+  // mounted the pane AND made it render "No project open" inside itself — a
+  // visible, empty Files pane next to a statusbar labelling the same path by
+  // project name.
+  it('is false while the singleton path belongs to another conversation', () => {
+    setCurrentCwdTransient('/previous-project')
+    $selectedStoredSessionId.set('sess-switching')
+    releaseWorkspaceCwdOwner()
+
+    expect($workspaceCwdIsOwned.get()).toBe(false)
+  })
+
+  it('is true once the selected conversation owns the path', () => {
+    $selectedStoredSessionId.set('sess-settled')
+    commitWorkspaceCwdForSelectedSession('/owned-project')
+
+    expect($workspaceCwdIsOwned.get()).toBe(true)
+  })
+
+  // A fresh draft's selection is null and so is its owner — they match, which is
+  // exactly why `releaseWorkspaceCwdOwner` uses a sentinel instead of null
+  // (ae6eb578bb): releasing to null would hand a leftover path to the draft.
+  it('is true for a fresh draft, whose null owner matches its null selection', () => {
+    setCurrentCwdTransient('/draft-target')
+    $selectedStoredSessionId.set(null)
+    setWorkspaceCwdOwner(null)
+
+    expect($workspaceCwdIsOwned.get()).toBe(true)
+  })
+
+  it('is false for a detached chat with no path at all', () => {
+    $selectedStoredSessionId.set('sess-detached')
+    setWorkspaceCwdOwner('sess-detached')
+    setCurrentCwdTransient('')
+
+    expect($workspaceCwdIsOwned.get()).toBe(false)
+  })
+
+  // Reactive: the switch settles a moment after the selection changes, so the
+  // panes must come back on their own rather than wait for another user action.
+  it('flips back to true when the resume settles and claims the path', () => {
+    setCurrentCwdTransient('/previous-project')
+    $selectedStoredSessionId.set('sess-new')
+    releaseWorkspaceCwdOwner()
+    expect($workspaceCwdIsOwned.get()).toBe(false)
+
+    commitWorkspaceCwdForSelectedSession('/new-project')
+
+    expect($workspaceCwdIsOwned.get()).toBe(true)
+  })
+})


### PR DESCRIPTION
## The symptom

With a session tile focused in one project while the primary chat sat in another,
the Files pane showed the **wrong project's** tree — and the statusbar beside it
showed the right one. Measured on the running app, both at the same moment:

```
Files pane header:  MAIN-QUARKUS      (rows reading main-quarkus paths off disk)
Statusbar:          base-image        (correct — a base-image tile was focused)
```

Two further faces of the same problem, both reported and both reproduced:

- Clicking **"New session in base-image"** created the session in the right
  folder but filed its sidebar row under **main-quarkus**. Nothing looks broken,
  which is what makes it bad.
- The Files pane could be visible and *empty*, rendering "No project open" while
  the statusbar happily named a project.

## The cause

One shared atom answering two different questions.

`$currentCwd` is the **primary chat's** composer path. A tile is deliberately
kept out of it — `applyRuntimeInfo(..., { foreground: false })`, so a tile's
folder cannot re-point the main composer's coding rail. Any surface reading that
singleton alone therefore describes the primary chat, whatever the user is
actually looking at.

Four consumers had each derived "the current workspace" separately:

| Surface | asked |
|---|---|
| Files pane body | `$currentCwd` + ownership |
| Files/Review **mount** gate | `Boolean(cwd.trim())` only |
| Statusbar workspace item | focused session, but **no** ownership check |
| New-session row placement | `$currentCwd` as fallback |

Four derivations of one fact will disagree; three of them did.

## The change

Two commits, two independent bugs.

**1. One derivation, shared** (`35a4d32`)

```
$workspaceCwdIsOwned   reactive form of workspaceCwdBelongsToSelectedSession(),
                       ANDed with "there is a path at all"
$focusedWorkspaceCwd   focused session's runtime slice
                         -> its stored row
                         -> the owned singleton
```

Files pane, mount gate and statusbar now read `$focusedWorkspaceCwd`. 45 lines of
duplicated chain logic drop out of the statusbar hook.

Only the **singleton rung** is ownership-gated, deliberately. It is the one rung
that can name a folder belonging to a conversation the user already left
(ae6eb578bb). Gating the row rung as well would blank a workspace we *do* know —
the failure 416e025c46 warns about, since a released marker says nothing about
the row. Both directions were measured before choosing: with a row present the
old chain was already right; only the singleton fallback lied.

One asymmetry is load-bearing and tested: a stored row that exists with no `cwd`
reads as detached, **except** when the selected conversation positively owns the
singleton. `cwd` is null on history rows predating the backfill, and trusting the
row there blanked a workspace the runtime had just confirmed. A tile has no such
claim and stays detached.

**2. New sessions land in their own lane** (`6f6028f`)

`upsertOptimisticSession` now takes the workspace the session was created *for*
and prefers it over the singleton; the create response still outranks both,
because the backend may normalise the path. An empty requested path is a
*decision* ("New session in Home"), not a missing value, so `requestedCwd?:
string` is checked against `undefined` rather than truthiness — `''` and
"not named" must not collapse into one case.

## Verification

- **16 new tests**, all green. Each was checked **red** first against the
  unmodified code: 4 fall without the focused-session rungs, 1 without the
  ownership gate, 2 without the lane fix.
- `tsc -p tsconfig.json --noEmit` clean; `eslint` clean on every touched file.
- Full renderer suite: **6135 passed, 4 failed**. Those 4 are **pre-existing** —
  verified by stashing the change and re-running them on the untouched tree
  (`settings/billing` ×2, `tool/fallback-model`, `use-prompt-actions/utils`).
- **Confirmed on a live instance over CDP**, not just in unit tests: with a
  base-image tile focused, pane header *and* statusbar both read `base-image`,
  and switching projects keeps the file tree in step. The reporter's words:
  deterministic, project switching works, the file tree always matches.

## Notes for review

- No behaviour change for a plain new chat or a detached session — both are
  covered by tests that were green before and after.
- The two commits are independent; either can be dropped without breaking the
  other.
