### PR TITLE
fix(compaction): enforce route-scoped native ownership

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1888,6 +1888,12 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
             is_codex_backend=is_codex_backend,
             is_xai_responses=is_xai_responses,
             is_github_responses=is_github_responses,
+            messages=_msgs_for_codex,
+        )
+        _native_checkpoint_digests = list(
+            (getattr(agent, "native_compaction_ownership_state", None) or {}).get(
+                "checkpoint_digests", []
+            )
         )
 
         # xAI's /responses endpoint rejects ``pattern`` and ``format`` keywords
@@ -1942,6 +1948,7 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
                 getattr(agent, "_codex_reasoning_replay_enabled", True)
             ),
             context_management=_context_management,
+            native_compaction_checkpoint_digests=_native_checkpoint_digests,
         )
 
     # ── chat_completions (default) ─────────────────────────────────────

--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -48,7 +48,10 @@ def _classify_responses_issuer(
     if is_codex_backend:
         return "codex_backend"
     if base_url:
-        return f"other:{base_url}"
+        from agent.native_compaction import canonical_responses_endpoint
+
+        endpoint = canonical_responses_endpoint(base_url)
+        return f"other:{endpoint}" if endpoint else "other"
     return "other"
 
 
@@ -462,6 +465,22 @@ def _normalize_responses_message_status(value: Any, *, default: str = "completed
     return default
 
 
+def _sidecar_mapping(raw: Any) -> Optional[Dict[str, Any]]:
+    """Return a plain mapping for persisted dict or SDK-model sidecars."""
+    if isinstance(raw, dict):
+        return raw
+    model_dump = getattr(raw, "model_dump", None)
+    if callable(model_dump):
+        try:
+            dumped = model_dump()
+            if isinstance(dumped, dict):
+                return dumped
+        except (AttributeError, TypeError, ValueError):
+            return None
+    attributes = getattr(raw, "__dict__", None)
+    return dict(attributes) if isinstance(attributes, dict) else None
+
+
 def _chat_messages_to_responses_input(
     messages: List[Dict[str, Any]],
     *,
@@ -470,6 +489,7 @@ def _chat_messages_to_responses_input(
     replay_encrypted_reasoning: bool = True,
     current_issuer_kind: Optional[str] = None,
     native_compaction_eligible: bool = False,
+    native_compaction_checkpoint_digests: Any = None,
 ) -> List[Dict[str, Any]]:
     """Convert internal chat-style messages to Responses input items.
 
@@ -523,8 +543,8 @@ def _chat_messages_to_responses_input(
     items, and restructuring the wire around them
     (``prune_pre_checkpoint_items``). Checkpoints are persisted in the
     ``codex_reasoning_items`` sidecar and survive a mid-session model swap,
-    a ``compression.enabled: false`` flip, the rejection kill switch and a
-    resumed session; without this flag a single captured checkpoint would
+    a ``compression.enabled: false`` flip, route-local fallback, and a resumed
+    session; without this flag a single captured checkpoint would
     keep deleting every pre-checkpoint item from every later request, on a
     model that cannot decrypt the blob (#85914). Default False = pre-feature
     wire, which is also correct for every caller that never sends
@@ -534,6 +554,15 @@ def _chat_messages_to_responses_input(
     conversation is still on the wire.
     """
     items: List[Dict[str, Any]] = []
+    known_checkpoint_digests = {
+        digest
+        for digest in (
+            native_compaction_checkpoint_digests
+            if isinstance(native_compaction_checkpoint_digests, list)
+            else ()
+        )
+        if isinstance(digest, str)
+    }
     # Parallel to `items`: the raw chat message each converted item came
     # from. Pruning needs this to read a canonical summary carrier's
     # up-to-date, provenance-tagged content directly — the converted `item`
@@ -574,7 +603,8 @@ def _chat_messages_to_responses_input(
                 )
                 has_codex_reasoning = False
                 if isinstance(codex_reasoning, list):
-                    for ri in codex_reasoning:
+                    for raw_reasoning in codex_reasoning:
+                        ri = _sidecar_mapping(raw_reasoning)
                         if isinstance(ri, dict) and ri.get("encrypted_content"):
                             item_id = ri.get("id")
                             if item_id and item_id in seen_item_ids:
@@ -584,7 +614,7 @@ def _chat_messages_to_responses_input(
                             # AND only while this request still asks for
                             # server-side compaction. Once the gate closes
                             # (model swapped out of the gpt-5.6 family,
-                            # compression disabled, rejection kill switch),
+                            # compression disabled, route-local fallback),
                             # the persisted checkpoint must not be replayed —
                             # replaying it is what makes the wire restructure
                             # below erase pre-checkpoint history forever.
@@ -600,6 +630,15 @@ def _chat_messages_to_responses_input(
                             # request with HTTP 400 invalid_encrypted_content.
                             # Unstamped (legacy) items pass through.
                             item_issuer = ri.get("_issuer_kind")
+                            if ri.get("type") == "compaction":
+                                encrypted = ri.get("encrypted_content")
+                                if not isinstance(encrypted, str) or not encrypted.strip():
+                                    continue
+                                checkpoint_digest = hashlib.sha256(
+                                    encrypted.encode("utf-8")
+                                ).hexdigest()
+                                if checkpoint_digest not in known_checkpoint_digests:
+                                    continue
                             if (
                                 current_issuer_kind is not None
                                 and item_issuer is not None
@@ -641,16 +680,18 @@ def _chat_messages_to_responses_input(
                 replayed_message_items = 0
                 if isinstance(codex_message_items, list):
                     for raw_item in codex_message_items:
-                        if not isinstance(raw_item, dict):
+                        message_item = _sidecar_mapping(raw_item)
+                        if not isinstance(message_item, dict):
                             continue
-                        if raw_item.get("type") != "message" or raw_item.get("role") != "assistant":
+                        if message_item.get("type") != "message" or message_item.get("role") != "assistant":
                             continue
-                        raw_content_parts = raw_item.get("content")
+                        raw_content_parts = message_item.get("content")
                         if not isinstance(raw_content_parts, list):
                             continue
 
                         normalized_content_parts = []
-                        for part in raw_content_parts:
+                        for raw_part in raw_content_parts:
+                            part = _sidecar_mapping(raw_part)
                             if not isinstance(part, dict):
                                 continue
                             part_type = str(part.get("type") or "").strip()
@@ -669,10 +710,10 @@ def _chat_messages_to_responses_input(
                         replay_item = {
                             "type": "message",
                             "role": "assistant",
-                            "status": _normalize_responses_message_status(raw_item.get("status")),
+                            "status": _normalize_responses_message_status(message_item.get("status")),
                             "content": normalized_content_parts,
                         }
-                        item_id = raw_item.get("id")
+                        item_id = message_item.get("id")
                         if (
                             not is_github_responses
                             and isinstance(item_id, str)
@@ -681,7 +722,7 @@ def _chat_messages_to_responses_input(
                             stripped_id = item_id.strip()
                             if len(stripped_id) <= _MAX_RESPONSES_ITEM_ID_LENGTH:
                                 replay_item["id"] = stripped_id
-                        phase = raw_item.get("phase")
+                        phase = message_item.get("phase")
                         if isinstance(phase, str) and phase.strip():
                             replay_item["phase"] = phase.strip()
                         items.append(replay_item)
@@ -901,6 +942,7 @@ def estimate_native_responses_preflight_tokens(
         is_codex_backend=is_codex_backend,
         is_xai_responses=is_xai_responses,
         is_github_responses=is_github_responses,
+        messages=messages,
     )
     if not context_management:
         return None
@@ -920,6 +962,11 @@ def estimate_native_responses_preflight_tokens(
                 base_url=getattr(agent, "base_url", None),
             ),
             native_compaction_eligible=True,
+            native_compaction_checkpoint_digests=list(
+                (getattr(agent, "native_compaction_ownership_state", None) or {}).get(
+                    "checkpoint_digests", []
+                )
+            ),
         )
     except Exception:
         logger.debug(
@@ -1686,8 +1733,8 @@ def _normalize_codex_response(
             # OpenAI/Codex routes). The encrypted blob stands in for the
             # pruned older context on subsequent requests. It rides the
             # codex_reasoning_items sidecar so it inherits persistence
-            # (state.db), session replay, the cross-issuer guard, and the
-            # invalid-encrypted-content kill switch without new state.
+            # (state.db), session replay, and the cross-issuer guard. Replay
+            # authorization additionally comes from route-scoped ownership.
             encrypted = getattr(item, "encrypted_content", None)
             if isinstance(encrypted, str) and encrypted:
                 raw_item = {"type": "compaction", "encrypted_content": encrypted}

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -2713,6 +2713,20 @@ def compress_context(
         prompt — the session is NOT rotated.  Callers should detect the
         no-op via ``len(returned) == len(input)`` and stop the retry loop.
     """
+    from agent.native_compaction import (
+        OWNER_NATIVE,
+        native_compaction_ownership,
+        suppress_automatic_local_compaction,
+        transition_native_compaction_to_local,
+    )
+
+    if not force and suppress_automatic_local_compaction(
+        agent, messages, approx_tokens
+    ):
+        return messages, getattr(agent, "_cached_system_prompt", None) or system_message
+    if force and native_compaction_ownership(agent, messages).get("owner") == OWNER_NATIVE:
+        transition_native_compaction_to_local(agent, "manual_compression")
+
     _compressor_attempt_snapshot = _snapshot_compressor_attempt_state(
         agent.context_compressor
     )

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2674,7 +2674,7 @@ def run_conversation(
         _compression_cooldown = getattr(
             _compressor, "get_active_compression_failure_cooldown", lambda: None
         )()
-        if (
+        _pre_api_compression_requested = bool(
             agent.compression_enabled
             and not _review_fork_first_request_pending(agent)
             and len(messages) > 1
@@ -2683,7 +2683,15 @@ def run_conversation(
             and not _defer_preflight(request_pressure_tokens)
             and not _compression_cooldown
             and _compressor.should_compress(request_pressure_tokens)
-        ):
+        )
+        _native_suppresses_pre_api = False
+        if _pre_api_compression_requested:
+            from agent.native_compaction import suppress_automatic_local_compaction
+
+            _native_suppresses_pre_api = suppress_automatic_local_compaction(
+                agent, messages, request_pressure_tokens
+            )
+        if _pre_api_compression_requested and not _native_suppresses_pre_api:
             if _moa_prepared_request is not None:
                 pending_moa_prepared_request = _moa_prepared_request
             compression_attempts += 1
@@ -2883,10 +2891,12 @@ def run_conversation(
         finish_reason = "stop"
         response = None  # Guard against UnboundLocalError if all retries fail
         api_kwargs = None  # Guard against UnboundLocalError in except handler
+        _native_request_generation = None
         api_request_id = f"{turn_id}:api:{api_call_count}"
         agent._current_api_request_id = api_request_id
 
         while retry_count < max_retries:
+            _native_request_generation = None
             # ── Nous Portal rate limit guard ──────────────────────
             # If another session already recorded that Nous is rate-
             # limited, skip the API call entirely.  Each attempt
@@ -3209,6 +3219,16 @@ def run_conversation(
                     )
 
                 from hermes_cli.middleware import run_llm_execution_middleware
+
+                if (
+                    agent.api_mode == "codex_responses"
+                    and api_kwargs.get("context_management")
+                ):
+                    from agent.native_compaction import begin_native_compaction_request
+
+                    _native_request_generation = begin_native_compaction_request(
+                        agent, request_pressure_tokens
+                    )
 
                 _model_request_active = getattr(agent, "_model_request_active", None)
                 _redirect_lock = getattr(agent, "_pending_redirect_lock", None)
@@ -5112,33 +5132,37 @@ def run_conversation(
 
                 # ── Native compaction rejection recovery ──────────────
                 # Provider explicitly rejected the ``context_management``
-                # field (structured 400 naming the param). One-shot: turn
-                # native compaction off for the rest of the session and
-                # retry — the next _build_api_kwargs re-resolves the gate
-                # and omits the field, and Hermes' local compression takes
-                # over as the sole owner. Generic 4xx/5xx/timeouts do NOT
-                # match (see is_native_compaction_rejection) and take the
-                # normal retry path.
+                # field (structured 400 naming the param). One-shot: transfer
+                # this route to durable local ownership and retry. The next
+                # _build_api_kwargs re-resolves ownership and omits the field.
+                # Generic 4xx/5xx/timeouts do NOT match (see
+                # is_native_compaction_rejection) and take the normal retry
+                # path.
                 if (
                     agent.api_mode == "codex_responses"
                     and not _retry.native_compaction_reject_retry_attempted
                     and bool(getattr(agent, "codex_responses_native_compaction", False))
                 ):
-                    from agent.native_compaction import is_native_compaction_rejection
+                    from agent.native_compaction import (
+                        is_native_compaction_rejection,
+                        transition_native_compaction_to_local,
+                    )
                     if is_native_compaction_rejection(
                         api_error, getattr(api_error, "status_code", None)
                     ):
                         _retry.native_compaction_reject_retry_attempted = True
-                        agent.codex_responses_native_compaction = False
+                        transition_native_compaction_to_local(
+                            agent, "structured_rejection"
+                        )
                         agent._vprint(
                             f"{agent.log_prefix}⚠️  Provider rejected native compaction "
-                            f"(context_management) — disabled for this session, "
-                            f"local compression stays active. Retrying...",
+                            f"(context_management) — using local compression "
+                            f"for this route. Retrying...",
                             force=True,
                         )
                         logger.warning(
-                            "%sNative compaction rejection recovery: disabled "
-                            "codex_responses_native for this session and retrying",
+                            "%sNative compaction rejection recovery: transferred "
+                            "this route to local ownership and retrying",
                             agent.log_prefix,
                         )
                         continue
@@ -6758,6 +6782,14 @@ def run_conversation(
             _normalize_kwargs = {}
             if agent.api_mode == "anthropic_messages":
                 _normalize_kwargs["strip_tool_prefix"] = agent._is_anthropic_oauth
+            if agent.api_mode == "codex_responses":
+                from agent.native_compaction import observe_native_compaction_response
+
+                observe_native_compaction_response(
+                    agent,
+                    response,
+                    request_generation=_native_request_generation,
+                )
             normalized = _transport.normalize_response(response, **_normalize_kwargs)
             assistant_message = normalized
             finish_reason = normalized.finish_reason
@@ -7546,11 +7578,19 @@ def run_conversation(
                         messages, tools=agent.tools or None
                     )
 
-                if (
+                _post_tool_compression_requested = bool(
                     agent.compression_enabled
                     and compression_attempts < max_compression_attempts
                     and _compressor.should_compress(_real_tokens)
-                ):
+                )
+                _native_suppresses_post_tool = False
+                if _post_tool_compression_requested:
+                    from agent.native_compaction import suppress_automatic_local_compaction
+
+                    _native_suppresses_post_tool = suppress_automatic_local_compaction(
+                        agent, messages, _real_tokens
+                    )
+                if _post_tool_compression_requested and not _native_suppresses_post_tool:
                     compression_attempts += 1
                     # Compression is actually running (block cleared / was
                     # never blocked) — reset the blocked-overflow warning
@@ -7631,7 +7671,14 @@ def run_conversation(
                     # minimal test doubles (SimpleNamespace compressors) lack the
                     # method — treat absence as a no-op.
                     _prune = getattr(_compressor, "prune_tool_results_only", None)
+                    _native_suppresses_prune = False
                     if callable(_prune):
+                        from agent.native_compaction import suppress_automatic_local_compaction
+
+                        _native_suppresses_prune = suppress_automatic_local_compaction(
+                            agent, messages, _real_tokens
+                        )
+                    if callable(_prune) and not _native_suppresses_prune:
                         try:
                             _pruned_msgs, _pruned_n = _prune(
                                 messages, current_tokens=_real_tokens

--- a/agent/native_compaction.py
+++ b/agent/native_compaction.py
@@ -291,6 +291,12 @@ def _cache_ownership_document(agent: Any, document: Dict[str, Any]) -> None:
 def _load_ownership_document(agent: Any) -> Dict[str, Any]:
     session_id = str(getattr(agent, "session_id", None) or "")
     document = _ownership_default_document()
+    cached = getattr(agent, "_native_compaction_ownership_cache", None)
+    cached_document = None
+    if isinstance(cached, dict) and cached.get("session_id") == session_id:
+        candidate = cached.get("document")
+        if isinstance(candidate, dict) and isinstance(candidate.get("routes"), dict):
+            cached_document = candidate
     session_db = getattr(agent, "_session_db", None)
     getter = getattr(session_db, "get_session_model_config_value", None)
     if session_id and callable(getter) and not getattr(agent, "_persist_disabled", False):
@@ -300,12 +306,25 @@ def _load_ownership_document(agent: Any) -> Dict[str, Any]:
                 document = persisted
         except (sqlite3.Error, OSError, RuntimeError, TypeError, ValueError):
             logger.warning("native ownership metadata read failed", exc_info=True)
-    else:
-        cached = getattr(agent, "_native_compaction_ownership_cache", None)
-        if isinstance(cached, dict) and cached.get("session_id") == session_id:
-            candidate = cached.get("document")
-            if isinstance(candidate, dict) and isinstance(candidate.get("routes"), dict):
-                document = candidate
+    elif cached_document is not None:
+        document = cached_document
+
+    # A failed atomic write leaves the database at an older revision. Local
+    # ownership is one-way, so that older native row must never weaken a
+    # fail-closed transition already observed by this agent.
+    if cached_document is not None:
+        cached_local = {
+            key: dict(state)
+            for key, state in cached_document["routes"].items()
+            if isinstance(state, dict) and state.get("owner") == OWNER_LOCAL
+        }
+        if cached_local:
+            routes = dict(document.get("routes", {}))
+            for key, state in cached_local.items():
+                persisted = routes.get(key)
+                if not isinstance(persisted, dict) or persisted.get("owner") != OWNER_LOCAL:
+                    routes[key] = state
+            document = {**document, "routes": routes}
     _cache_ownership_document(agent, document)
     return document
 
@@ -603,7 +622,17 @@ def suppress_automatic_local_compaction(
         current_tokens = 0
 
     at_boundary = current_tokens >= boundary
-    if state.get("phase") == PHASE_CHECKPOINT_ACCEPTED:
+    compatible_checkpoint_present = bool(
+        _compatible_checkpoint_items(
+            agent,
+            messages,
+            known_digests=state.get("checkpoint_digests", []),
+        )
+    )
+    if (
+        state.get("phase") == PHASE_CHECKPOINT_ACCEPTED
+        and compatible_checkpoint_present
+    ):
         episode_start = state.get("episode_start_tokens")
         checkpoint_generation = state.get("checkpoint_generation")
         if (

--- a/agent/native_compaction.py
+++ b/agent/native_compaction.py
@@ -23,14 +23,12 @@ Hermes' support is deliberately narrow (live verification, Aug 2026):
   most would 400 on the unknown parameter, and none can mint or decrypt
   the compaction blob.
 
-Ownership model: Hermes' local compression stays fully armed as the
-fallback owner. The native threshold is clamped safely below the local
-compressor's trigger so the server compacts first; if it doesn't (native
-disabled mid-session, provider hiccup, non-eligible route), the local
-summarizer fires exactly as before. There is no new custody state — the
-captured compaction items ride the existing ``codex_reasoning_items``
-sidecar, which already handles persistence (state.db), gateway session
-replay, cross-issuer stamping, and the encrypted-replay kill switch.
+Ownership model: an eligible native route/model owns automatic compaction.
+Hermes' local summarizer is suppressed until ownership transfers because of
+a structured rejection, malformed checkpoint, explicit manual compression,
+or hard-boundary starvation. Ownership is route-scoped and persisted in the
+session's existing ``model_config`` JSON; opaque checkpoints continue to ride
+the existing ``codex_reasoning_items`` sidecar.
 
 This module stays free of transport/adapter dependencies so the transport,
 adapter, and conversation loop can share the gate without import cycles. The
@@ -42,7 +40,10 @@ introduces no cycle.
 
 from __future__ import annotations
 
+import hashlib
 import logging
+import re
+import sqlite3
 from typing import Any, Dict, List, Optional
 from urllib.parse import urlsplit
 
@@ -60,6 +61,25 @@ DEFAULT_COMPACT_THRESHOLD = 200_000
 # Model-family gate. Substring match on the lowercased model id so dated
 # snapshots (gpt-5.6-2026-07-xx) and variants (gpt-5.6-mini) stay eligible.
 _ELIGIBLE_MODEL_MARKER = "gpt-5.6"
+
+NATIVE_OWNERSHIP_METADATA_KEY = "native_compaction_ownership"
+NATIVE_OWNERSHIP_VERSION = 1
+NATIVE_HARD_EMERGENCY_RESERVE_TOKENS = 8_192
+
+OWNER_NATIVE = "native"
+OWNER_LOCAL = "local"
+PHASE_AWAITING_CHECKPOINT = "awaiting_checkpoint"
+PHASE_CHECKPOINT_ACCEPTED = "checkpoint_accepted"
+PHASE_LOCAL_FALLBACK = "local_fallback"
+
+_LOCAL_FALLBACK_REASONS = frozenset(
+    {
+        "structured_rejection",
+        "malformed_checkpoint",
+        "hard_emergency_no_checkpoint",
+        "manual_compression",
+    }
+)
 
 
 def is_native_compaction_model(model: Optional[str]) -> bool:
@@ -80,6 +100,522 @@ def is_direct_openai_route(
     except ValueError:
         return False
     return hostname == "api.openai.com"
+
+
+def canonical_responses_endpoint(base_url: Any) -> str:
+    """Return a stable, credential-free endpoint identity."""
+    try:
+        parsed = urlsplit(str(base_url or ""))
+        hostname = (parsed.hostname or "").lower()
+        port = parsed.port
+    except (TypeError, ValueError):
+        return ""
+    if not parsed.scheme or not hostname:
+        return ""
+    if ":" in hostname:
+        hostname = f"[{hostname}]"
+    default_port = (parsed.scheme.lower(), port) in {("http", 80), ("https", 443)}
+    authority = hostname if port is None or default_port else f"{hostname}:{port}"
+    path = (parsed.path or "/").rstrip("/") or "/"
+    return f"{parsed.scheme.lower()}://{authority}{path}"
+
+
+def _responses_route_flags(agent: Any):
+    """Use the canonical Responses route classifier owned by the adapter."""
+    from agent.codex_responses_adapter import classify_responses_route
+
+    return classify_responses_route(agent)
+
+
+def native_compaction_route_key(agent: Any) -> str:
+    """Stable route/model key for session-scoped ownership."""
+    flags = _responses_route_flags(agent)
+    route_kind = "codex" if flags.is_codex_backend else "api"
+    return "|".join(
+        (
+            str(getattr(agent, "api_mode", None) or ""),
+            str(getattr(agent, "provider", None) or "").lower(),
+            canonical_responses_endpoint(getattr(agent, "base_url", None)),
+            str(getattr(agent, "model", None) or "").lower(),
+            route_kind,
+        )
+    )
+
+
+def native_compaction_route_eligible(
+    agent: Any,
+    *,
+    is_codex_backend: Optional[bool] = None,
+    is_xai_responses: Optional[bool] = None,
+    is_github_responses: Optional[bool] = None,
+) -> bool:
+    """Whether the current route/model owns automatic native compaction."""
+    flags = _responses_route_flags(agent)
+    codex_backend = (
+        flags.is_codex_backend
+        if is_codex_backend is None
+        else bool(is_codex_backend)
+    )
+    xai_responses = (
+        flags.is_xai_responses
+        if is_xai_responses is None
+        else bool(is_xai_responses)
+    )
+    github_responses = (
+        flags.is_github_responses
+        if is_github_responses is None
+        else bool(is_github_responses)
+    )
+    if getattr(agent, "api_mode", "codex_responses") != "codex_responses":
+        return False
+    if not bool(getattr(agent, "codex_responses_native_compaction", False)):
+        return False
+    if not bool(getattr(agent, "compression_enabled", True)):
+        return False
+    if getattr(agent, "compression_checkpoint_required", False) is True:
+        return False
+    if xai_responses or github_responses:
+        return False
+    if not is_native_compaction_model(getattr(agent, "model", None)):
+        return False
+    return is_direct_openai_route(
+        getattr(agent, "base_url", None), is_codex_backend=codex_backend
+    )
+
+
+def _checkpoint_items(messages: Any) -> List[Dict[str, Any]]:
+    checkpoints: List[Dict[str, Any]] = []
+    for message in messages if isinstance(messages, list) else ():
+        if not isinstance(message, dict):
+            continue
+        sidecar = message.get("codex_reasoning_items")
+        for item in sidecar if isinstance(sidecar, list) else ():
+            if isinstance(item, dict) and item.get("type") == "compaction":
+                checkpoints.append(item)
+    return checkpoints
+
+
+def is_usable_compaction_checkpoint(item: Any) -> bool:
+    """A replayable checkpoint has non-empty ciphertext and a good status."""
+    status = item.get("status") if isinstance(item, dict) else None
+    return (
+        isinstance(item, dict)
+        and item.get("type") == "compaction"
+        and isinstance(item.get("encrypted_content"), str)
+        and bool(item["encrypted_content"].strip())
+        and not (
+            isinstance(status, str)
+            and status.strip().lower()
+            in {"failed", "incomplete", "cancelled", "canceled"}
+        )
+    )
+
+
+def has_usable_compaction_checkpoint(items: Any) -> bool:
+    return any(
+        is_usable_compaction_checkpoint(item)
+        for item in (items if isinstance(items, list) else ())
+    )
+
+
+def _current_native_issuer_kind(agent: Any) -> str:
+    flags = _responses_route_flags(agent)
+    if flags.is_codex_backend:
+        return "codex_backend"
+    endpoint = canonical_responses_endpoint(getattr(agent, "base_url", None))
+    return f"other:{endpoint}" if endpoint else "other"
+
+
+def _checkpoint_digest(item: Dict[str, Any]) -> str:
+    return hashlib.sha256(item["encrypted_content"].encode("utf-8")).hexdigest()
+
+
+def _compatible_checkpoint_items(
+    agent: Any,
+    messages: Any,
+    *,
+    known_digests: Any = (),
+) -> List[Dict[str, Any]]:
+    """Return usable checkpoints authorized by this exact route/model."""
+    current_issuer = _current_native_issuer_kind(agent)
+    known = {
+        digest
+        for digest in (known_digests if isinstance(known_digests, list) else ())
+        if isinstance(digest, str)
+    }
+    compatible = []
+    for item in _checkpoint_items(messages):
+        if not is_usable_compaction_checkpoint(item):
+            continue
+        if _checkpoint_digest(item) not in known:
+            continue
+        issuer = item.get("_issuer_kind")
+        if issuer is None or issuer == current_issuer:
+            compatible.append(item)
+    return compatible
+
+
+def _default_native_state(route_key: str) -> Dict[str, Any]:
+    return {
+        "version": NATIVE_OWNERSHIP_VERSION,
+        "route_key": route_key,
+        "owner": OWNER_NATIVE,
+        "phase": PHASE_AWAITING_CHECKPOINT,
+        "reason": "eligible_route",
+        "checkpoint_digests": [],
+        "latest_request_generation": 0,
+        "latest_request_tokens": None,
+        "checkpoint_generation": None,
+        "episode_start_generation": None,
+        "episode_start_tokens": None,
+    }
+
+
+def _ownership_default_document() -> Dict[str, Any]:
+    return {"version": NATIVE_OWNERSHIP_VERSION, "routes": {}}
+
+
+def _cache_ownership_document(agent: Any, document: Dict[str, Any]) -> None:
+    session_id = str(getattr(agent, "session_id", None) or "")
+    agent._native_compaction_ownership_cache = {
+        "session_id": session_id,
+        "document": document,
+    }
+    initial = getattr(agent, "_session_init_model_config", None)
+    if isinstance(initial, dict):
+        updated = dict(initial)
+        updated[NATIVE_OWNERSHIP_METADATA_KEY] = document
+        agent._session_init_model_config = updated
+
+
+def _load_ownership_document(agent: Any) -> Dict[str, Any]:
+    session_id = str(getattr(agent, "session_id", None) or "")
+    document = _ownership_default_document()
+    session_db = getattr(agent, "_session_db", None)
+    getter = getattr(session_db, "get_session_model_config_value", None)
+    if session_id and callable(getter) and not getattr(agent, "_persist_disabled", False):
+        try:
+            persisted = getter(session_id, NATIVE_OWNERSHIP_METADATA_KEY, None)
+            if isinstance(persisted, dict) and isinstance(persisted.get("routes"), dict):
+                document = persisted
+        except (sqlite3.Error, OSError, RuntimeError, TypeError, ValueError):
+            logger.warning("native ownership metadata read failed", exc_info=True)
+    else:
+        cached = getattr(agent, "_native_compaction_ownership_cache", None)
+        if isinstance(cached, dict) and cached.get("session_id") == session_id:
+            candidate = cached.get("document")
+            if isinstance(candidate, dict) and isinstance(candidate.get("routes"), dict):
+                document = candidate
+    _cache_ownership_document(agent, document)
+    return document
+
+
+def _persist_ownership_document(agent: Any, document: Dict[str, Any]) -> None:
+    _cache_ownership_document(agent, document)
+    session_id = str(getattr(agent, "session_id", None) or "")
+    session_db = getattr(agent, "_session_db", None)
+    setter = getattr(session_db, "patch_session_model_config", None)
+    if not session_id or not callable(setter) or getattr(agent, "_persist_disabled", False):
+        return
+    try:
+        ensure = getattr(agent, "_ensure_db_session", None)
+        if callable(ensure):
+            ensure()
+        setter(session_id, {NATIVE_OWNERSHIP_METADATA_KEY: document})
+    except (sqlite3.Error, OSError, RuntimeError, TypeError, ValueError):
+        logger.warning("native ownership metadata write failed", exc_info=True)
+
+
+def _mutate_ownership_route(agent: Any, route_key: str, mutator) -> Dict[str, Any]:
+    """Merge one route atomically so local fallback can never flip back."""
+    session_id = str(getattr(agent, "session_id", None) or "")
+    session_db = getattr(agent, "_session_db", None)
+    atomic = getattr(session_db, "mutate_session_model_config_value", None)
+
+    def update_document(raw: Any) -> Dict[str, Any]:
+        if isinstance(raw, dict) and isinstance(raw.get("routes"), dict):
+            document = dict(raw)
+            document["routes"] = dict(raw["routes"])
+        else:
+            document = _ownership_default_document()
+        document["version"] = NATIVE_OWNERSHIP_VERSION
+        prior = document["routes"].get(route_key)
+        updated = mutator(dict(prior) if isinstance(prior, dict) else None)
+        if isinstance(updated, dict):
+            updated["version"] = NATIVE_OWNERSHIP_VERSION
+            updated["route_key"] = route_key
+            document["routes"][route_key] = updated
+        return document
+
+    if (
+        session_id
+        and callable(atomic)
+        and not getattr(agent, "_persist_disabled", False)
+    ):
+        try:
+            ensure = getattr(agent, "_ensure_db_session", None)
+            if callable(ensure):
+                ensure()
+            document = atomic(
+                session_id,
+                NATIVE_OWNERSHIP_METADATA_KEY,
+                update_document,
+                _ownership_default_document(),
+            )
+            if not isinstance(document, dict):
+                document = _ownership_default_document()
+        except (sqlite3.Error, OSError, RuntimeError, TypeError, ValueError):
+            logger.warning("native ownership metadata atomic write failed", exc_info=True)
+            document = update_document(_load_ownership_document(agent))
+    else:
+        document = update_document(_load_ownership_document(agent))
+        _persist_ownership_document(agent, document)
+
+    _cache_ownership_document(agent, document)
+    state = document.get("routes", {}).get(route_key)
+    return dict(state) if isinstance(state, dict) else _default_native_state(route_key)
+
+
+def native_compaction_ownership(agent: Any, messages: Any = None) -> Dict[str, Any]:
+    """Return the monotonic ownership record for the current route/model."""
+    route_key = native_compaction_route_key(agent)
+    if not native_compaction_route_eligible(agent):
+        state = {
+            "version": NATIVE_OWNERSHIP_VERSION,
+            "route_key": route_key,
+            "owner": OWNER_LOCAL,
+            "phase": PHASE_LOCAL_FALLBACK,
+            "reason": "native_ineligible",
+            "checkpoint_digests": [],
+        }
+        agent.native_compaction_ownership_state = dict(state)
+        return state
+
+    document = _load_ownership_document(agent)
+    state = document.get("routes", {}).get(route_key)
+    if not isinstance(state, dict):
+        state = _default_native_state(route_key)
+    compatible = _compatible_checkpoint_items(
+        agent,
+        messages,
+        known_digests=state.get("checkpoint_digests", []),
+    )
+    if (
+        state.get("owner") == OWNER_NATIVE
+        and compatible
+        and state.get("phase") != PHASE_CHECKPOINT_ACCEPTED
+    ):
+        def accept_existing(prior):
+            if not isinstance(prior, dict) or prior.get("owner") != OWNER_NATIVE:
+                return prior
+            updated = dict(prior)
+            updated["phase"] = PHASE_CHECKPOINT_ACCEPTED
+            updated["reason"] = "usable_checkpoint"
+            updated["checkpoint_digests"] = list(
+                dict.fromkeys(
+                    [
+                        *updated.get("checkpoint_digests", []),
+                        *(_checkpoint_digest(item) for item in compatible),
+                    ]
+                )
+            )[-16:]
+            return updated
+
+        state = _mutate_ownership_route(agent, route_key, accept_existing)
+    agent.native_compaction_ownership_state = dict(state)
+    return state
+
+
+def transition_native_compaction_to_local(agent: Any, reason: str) -> Dict[str, Any]:
+    """Transfer this route to durable local ownership exactly once."""
+    if reason not in _LOCAL_FALLBACK_REASONS:
+        raise ValueError(f"unsupported native compaction fallback reason: {reason}")
+    route_key = native_compaction_route_key(agent)
+    current = native_compaction_ownership(agent)
+    if current.get("owner") == OWNER_LOCAL:
+        return current
+
+    def transfer(prior):
+        if isinstance(prior, dict) and prior.get("owner") == OWNER_LOCAL:
+            return prior
+        previous = prior or {}
+        return {
+            "owner": OWNER_LOCAL,
+            "phase": PHASE_LOCAL_FALLBACK,
+            "reason": reason,
+            "checkpoint_digests": list(previous.get("checkpoint_digests", [])),
+            "latest_request_generation": int(
+                previous.get("latest_request_generation", 0) or 0
+            ),
+            "checkpoint_generation": previous.get("checkpoint_generation"),
+        }
+
+    state = _mutate_ownership_route(agent, route_key, transfer)
+    agent.native_compaction_ownership_state = dict(state)
+    return state
+
+
+def begin_native_compaction_request(
+    agent: Any, request_tokens: Optional[int] = None
+) -> Optional[int]:
+    """Allocate the current route's next monotonic request generation."""
+    if not native_compaction_route_eligible(agent):
+        return None
+    route_key = native_compaction_route_key(agent)
+
+    def advance(prior):
+        state = dict(prior) if isinstance(prior, dict) else _default_native_state(route_key)
+        if state.get("owner") == OWNER_LOCAL:
+            return state
+        generation = state.get("latest_request_generation", 0)
+        if not isinstance(generation, int) or isinstance(generation, bool):
+            generation = 0
+        state["latest_request_generation"] = generation + 1
+        try:
+            state["latest_request_tokens"] = max(0, int(request_tokens or 0))
+        except (TypeError, ValueError):
+            state["latest_request_tokens"] = 0
+        return state
+
+    state = _mutate_ownership_route(agent, route_key, advance)
+    if state.get("owner") != OWNER_NATIVE:
+        return None
+    generation = state.get("latest_request_generation")
+    return generation if isinstance(generation, int) else None
+
+
+def observe_native_compaction_response(
+    agent: Any,
+    response: Any,
+    *,
+    request_generation: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Accept only a fresh, usable checkpoint from the current route."""
+    if not native_compaction_route_eligible(agent):
+        return native_compaction_ownership(agent)
+    output = response.get("output") if isinstance(response, dict) else getattr(response, "output", None)
+    output_items = list(output) if isinstance(output, list) else []
+    compactions = []
+    for raw in output_items:
+        item = raw if isinstance(raw, dict) else getattr(raw, "__dict__", {})
+        if isinstance(item, dict) and item.get("type") == "compaction":
+            compactions.append(item)
+    if not compactions:
+        return native_compaction_ownership(agent)
+
+    observed = native_compaction_ownership(agent)
+    if (
+        request_generation is not None
+        and request_generation != observed.get("latest_request_generation")
+    ):
+        state = observed
+        accepted_digests: set[str] = set()
+    else:
+        usable = [item for item in compactions if is_usable_compaction_checkpoint(item)]
+        if not usable:
+            accepted_digests = set()
+            state = transition_native_compaction_to_local(agent, "malformed_checkpoint")
+        else:
+            route_key = native_compaction_route_key(agent)
+            response_digests = [_checkpoint_digest(item) for item in usable]
+            accepted_digests = set()
+
+            def accept_response(prior):
+                state = dict(prior) if isinstance(prior, dict) else _default_native_state(route_key)
+                if state.get("owner") == OWNER_LOCAL:
+                    return state
+                latest = state.get("latest_request_generation", 0)
+                generation = latest if request_generation is None else request_generation
+                if generation != latest:
+                    return state
+                digests = list(state.get("checkpoint_digests", []))
+                for digest in response_digests:
+                    if digest not in digests:
+                        digests.append(digest)
+                        accepted_digests.add(digest)
+                if not accepted_digests:
+                    return state
+                request_tokens = state.get("latest_request_tokens")
+                if not isinstance(request_tokens, int) or isinstance(request_tokens, bool):
+                    request_tokens = None
+                state.update(
+                    owner=OWNER_NATIVE,
+                    phase=PHASE_CHECKPOINT_ACCEPTED,
+                    reason="usable_checkpoint",
+                    checkpoint_digests=digests[-16:],
+                    checkpoint_generation=generation,
+                    episode_start_generation=generation,
+                    episode_start_tokens=request_tokens,
+                )
+                return state
+
+            state = _mutate_ownership_route(agent, route_key, accept_response)
+            if state.get("owner") == OWNER_LOCAL:
+                accepted_digests.clear()
+
+    filtered = []
+    for raw in output_items:
+        item = raw if isinstance(raw, dict) else getattr(raw, "__dict__", {})
+        if not (isinstance(item, dict) and item.get("type") == "compaction"):
+            filtered.append(raw)
+        elif is_usable_compaction_checkpoint(item) and _checkpoint_digest(item) in accepted_digests:
+            filtered.append(raw)
+    if len(filtered) != len(output_items):
+        if isinstance(response, dict):
+            response["output"] = filtered
+        else:
+            response.output = filtered
+    agent.native_compaction_ownership_state = dict(state)
+    return state
+
+
+def native_hard_emergency_boundary(agent: Any) -> Optional[int]:
+    compressor = getattr(agent, "context_compressor", None)
+    context_length = getattr(compressor, "context_length", None)
+    if (
+        not isinstance(context_length, int)
+        or isinstance(context_length, bool)
+        or context_length <= 0
+    ):
+        return None
+    return max(1_024, context_length - NATIVE_HARD_EMERGENCY_RESERVE_TOKENS)
+
+
+def suppress_automatic_local_compaction(
+    agent: Any,
+    messages: Any,
+    approx_tokens: Optional[int] = None,
+) -> bool:
+    """True while native owns this episode; transfer at the hard boundary."""
+    state = native_compaction_ownership(agent, messages)
+    if state.get("owner") != OWNER_NATIVE:
+        return False
+    boundary = native_hard_emergency_boundary(agent)
+    if boundary is None:
+        return True
+    if approx_tokens is None:
+        from agent.model_metadata import estimate_messages_tokens_rough
+
+        approx_tokens = estimate_messages_tokens_rough(messages)
+    try:
+        current_tokens = max(0, int(approx_tokens or 0))
+    except (TypeError, ValueError):
+        current_tokens = 0
+
+    at_boundary = current_tokens >= boundary
+    if state.get("phase") == PHASE_CHECKPOINT_ACCEPTED:
+        episode_start = state.get("episode_start_tokens")
+        checkpoint_generation = state.get("checkpoint_generation")
+        if (
+            isinstance(episode_start, int)
+            and not isinstance(episode_start, bool)
+            and state.get("episode_start_generation") == checkpoint_generation
+        ):
+            at_boundary = max(0, current_tokens - episode_start) >= boundary
+    if at_boundary:
+        transition_native_compaction_to_local(agent, "hard_emergency_no_checkpoint")
+        return False
+    return True
 
 
 def resolve_compact_threshold(
@@ -142,36 +678,25 @@ def native_compaction_context_management(
     is_codex_backend: bool,
     is_xai_responses: bool = False,
     is_github_responses: bool = False,
+    messages: Any = None,
 ) -> Optional[List[Dict[str, Any]]]:
     """Return the ``context_management`` payload for this request, or None.
 
     None means "do not send the field" — the request is byte-identical to
-    pre-feature behavior. All gates are re-checked per request so a
-    mid-session model switch or the in-session kill switch
-    (``agent.codex_responses_native_compaction = False``, set by the
-    conversation loop's rejection recovery) takes effect on the next call.
+    pre-feature behavior. All gates and route-scoped ownership are re-checked
+    per request, so model/provider switches and durable fallback transitions
+    take effect on the next call.
     """
-    if not bool(getattr(agent, "codex_responses_native_compaction", False)):
-        return None
-    # compression.enabled: false disables ALL automatic compaction, native
-    # included — mirrors the codex_app_server_auto contract.
-    if not bool(getattr(agent, "compression_enabled", True)):
-        return None
-    # compression.checkpoint_required: server-side compaction is a lossy
-    # boundary the provider owns — no pre-compress checkpoint can run before
-    # the server replaces older context. Keep the checkpoint-aware Hermes
-    # compressor authoritative instead of silently letting the server
-    # compact. Explicit-True check matches the compress_context() gate.
-    if getattr(agent, "compression_checkpoint_required", False) is True:
-        _warn_native_compaction_suppressed_by_checkpoint_gate()
-        return None
-    if is_xai_responses or is_github_responses:
-        return None
-    if not is_native_compaction_model(getattr(agent, "model", None)):
-        return None
-    if not is_direct_openai_route(
-        getattr(agent, "base_url", None), is_codex_backend=is_codex_backend
+    if not native_compaction_route_eligible(
+        agent,
+        is_codex_backend=is_codex_backend,
+        is_xai_responses=is_xai_responses,
+        is_github_responses=is_github_responses,
     ):
+        if getattr(agent, "compression_checkpoint_required", False) is True:
+            _warn_native_compaction_suppressed_by_checkpoint_gate()
+        return None
+    if native_compaction_ownership(agent, messages).get("owner") != OWNER_NATIVE:
         return None
 
     compressor = getattr(agent, "context_compressor", None)
@@ -311,7 +836,7 @@ def prune_pre_checkpoint_items(
 
     last_cp = None
     for i, item in enumerate(items):
-        if isinstance(item, dict) and item.get("type") == "compaction":
+        if is_usable_compaction_checkpoint(item):
             last_cp = i
     if last_cp is None:
         return items
@@ -320,8 +845,7 @@ def prune_pre_checkpoint_items(
     first_cp = last_cp
     while (
         first_cp > 0
-        and isinstance(items[first_cp - 1], dict)
-        and items[first_cp - 1].get("type") == "compaction"
+        and is_usable_compaction_checkpoint(items[first_cp - 1])
     ):
         first_cp -= 1
 
@@ -434,17 +958,16 @@ def is_native_compaction_rejection(error: Any, status_code: Any = None) -> bool:
     """True when a provider error is a STRUCTURED rejection of the
     context_management field.
 
-    Used by the conversation loop's one-shot recovery: strip the field,
-    disable native compaction for the rest of the session, retry. Matching
-    is deliberately narrow — a transient 5xx/timeout whose body merely
-    ECHOES the request (and therefore contains the field name) must NOT
-    permanently downgrade native compaction for the session (#82777).
+    Used by the conversation loop's one-shot recovery: transfer this route to
+    local ownership, strip the field, and retry. Matching is deliberately
+    narrow — a transient 5xx/timeout whose body merely ECHOES the request
+    (and therefore contains the field name) must NOT permanently downgrade
+    native compaction for the route (#82777).
 
-    Two conditions, both required when a status is known:
+    Two conditions are always required:
 
-    * ``status_code`` is 400 (or unknown/None — some transports surface
-      only a message string; field-name matching alone is then the best
-      available signal, preserving pre-#82777 behavior for them), and
+    * ``status_code`` parses to 400, or the message explicitly embeds the
+      SDK-style ``Error code: 400`` marker, and
     * the error text names ``context_management`` / ``compact_threshold``
       alongside rejection language ("unknown", "unsupported", "invalid",
       "unexpected", "not permitted"...). A bare field-name echo without
@@ -453,12 +976,24 @@ def is_native_compaction_rejection(error: Any, status_code: Any = None) -> bool:
     text = str(error or "").lower()
     if "context_management" not in text and "compact_threshold" not in text:
         return False
-    if status_code is not None:
+    parsed_status = None
+    if status_code is not None and not isinstance(status_code, bool):
         try:
-            if int(status_code) != 400:
-                return False
+            parsed_status = int(status_code)
         except (TypeError, ValueError):
             pass
+    if parsed_status is None:
+        if re.search(
+            r"(?:\btimeout(?:error)?\b|\btimed\s+out\b|\bconnection\s+reset\b|"
+            r"\bhttp\s+5\d\d\b|\b5xx\b)",
+            text,
+        ):
+            return False
+        embedded = re.search(r"\berror\s+code\s*:\s*(\d{3})\b", text)
+        if embedded is not None:
+            parsed_status = int(embedded.group(1))
+    if parsed_status != 400:
+        return False
     rejection_markers = (
         "unknown", "unsupported", "invalid", "unexpected", "not permitted",
         "not allowed", "unrecognized", "extra field", "no such", "bad request",
@@ -501,9 +1036,9 @@ def merge_interim_reasoning_items(
     kept_checkpoints = [
         item
         for item in (prior_items if isinstance(prior_items, list) else [])
-        if isinstance(item, dict) and item.get("type") == "compaction"
+        if is_usable_compaction_checkpoint(item)
     ]
     new_list = list(new_items) if isinstance(new_items, list) else []
-    if has_compaction_checkpoint(new_list) or not kept_checkpoints:
+    if has_usable_compaction_checkpoint(new_list) or not kept_checkpoints:
         return new_list
     return kept_checkpoints + new_list

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -388,6 +388,9 @@ class ResponsesApiTransport(ProviderTransport):
             native_compaction_eligible=_native_compaction_active(
                 kwargs.get("context_management")
             ),
+            native_compaction_checkpoint_digests=kwargs.get(
+                "native_compaction_checkpoint_digests"
+            ),
         )
 
     def convert_tools(self, tools: List[Dict[str, Any]]) -> Any:
@@ -590,6 +593,9 @@ class ResponsesApiTransport(ProviderTransport):
                 replay_encrypted_reasoning=replay_encrypted_reasoning,
                 current_issuer_kind=issuer_kind,
                 native_compaction_eligible=native_compaction_active,
+                native_compaction_checkpoint_digests=params.get(
+                    "native_compaction_checkpoint_digests"
+                ),
             ),
             "store": False,
         }

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -884,14 +884,21 @@ def build_turn_context(
             _idle_cooldown = getattr(
                 _compressor, "get_active_compression_failure_cooldown", lambda: None
             )()
-            if _should_idle_compact(
+            _idle_should_compact = _should_idle_compact(
                 enabled=agent.compression_enabled,
                 idle_after_seconds=_idle_after,
                 idle_gap_seconds=_idle_gap,
                 tokens=_idle_tokens,
                 floor_tokens=_idle_floor,
                 cooldown_active=bool(_idle_cooldown),
-            ):
+            )
+            if _idle_should_compact:
+                from agent.native_compaction import suppress_automatic_local_compaction
+
+                _idle_should_compact = not suppress_automatic_local_compaction(
+                    agent, messages, _idle_tokens
+                )
+            if _idle_should_compact:
                 logger.info(
                     "Idle compaction: %ss idle >= %ss, ~%s tokens > %s floor "
                     "(session %s)",
@@ -1051,6 +1058,12 @@ def build_turn_context(
                         _compress_block_reason = _info(_preflight_tokens)[1]
                     except Exception:
                         _compress_block_reason = None
+        if _should_compress_now:
+            from agent.native_compaction import suppress_automatic_local_compaction
+
+            _should_compress_now = not suppress_automatic_local_compaction(
+                agent, messages, _preflight_tokens
+            )
         if _should_compress_now:
             _preflight_compressed = True
             # Compression is actually running (block cleared / was never
@@ -1216,6 +1229,12 @@ def build_turn_context(
                         _preflight_exc,
                     )
                     _wants_engine_preflight = False
+            if _wants_engine_preflight:
+                from agent.native_compaction import suppress_automatic_local_compaction
+
+                _wants_engine_preflight = not suppress_automatic_local_compaction(
+                    agent, messages, _preflight_tokens
+                )
             if _wants_engine_preflight:
                 logger.info(
                     "Engine-driven preflight maintenance: %s requested "

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -409,6 +409,13 @@ def finalize_turn(
                 # checks with truthy auto-attributes — a bare truthiness check
                 # here called _micro_compact on a mock and spliced its (empty-
                 # iterating) return value over the transcript, wiping it.
+                _native_suppresses_micro = False
+                if _compressor and final_response:
+                    from agent.native_compaction import suppress_automatic_local_compaction
+
+                    _native_suppresses_micro = suppress_automatic_local_compaction(
+                        agent, messages
+                    )
                 if (
                     _compressor
                     and getattr(_compressor, '_micro_compact_enabled', False) is True
@@ -429,6 +436,7 @@ def finalize_turn(
                     # archive_and_compact the CANONICAL session rows — the
                     # exact write class _persist_disabled exists to stop.
                     and not getattr(agent, "_persist_disabled", False)
+                    and not _native_suppresses_micro
                 ):
                     _before = len(messages)
                     _compacted = _compressor._micro_compact(messages)

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -8397,6 +8397,49 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
         self._execute_write(_do)
 
+    def mutate_session_model_config_value(
+        self,
+        session_id: str,
+        key: str,
+        mutator: Callable[[Any], Any],
+        default: Any = None,
+    ) -> Any:
+        """Atomically read, mutate, and persist one model-config value."""
+        if not session_id or not key or not callable(mutator):
+            return default
+
+        def _do(conn):
+            row = conn.execute(
+                "SELECT model_config FROM sessions WHERE id = ?",
+                (session_id,),
+            ).fetchone()
+            if row is None:
+                return default
+            raw = row["model_config"] if isinstance(row, sqlite3.Row) else row[0]
+            config: Dict[str, Any] = {}
+            if isinstance(raw, str) and raw.strip():
+                try:
+                    parsed = json.loads(raw)
+                    if isinstance(parsed, dict):
+                        config = parsed
+                except (json.JSONDecodeError, TypeError):
+                    pass
+            elif isinstance(raw, dict):
+                config = dict(raw)
+
+            updated = mutator(config.get(key, default))
+            if updated is None:
+                config.pop(key, None)
+            else:
+                config[key] = updated
+            conn.execute(
+                "UPDATE sessions SET model_config = ? WHERE id = ?",
+                (json.dumps(config) if config else None, session_id),
+            )
+            return updated
+
+        return self._execute_write(_do)
+
     def get_session_model_config_value(
         self, session_id: str, key: str, default: Any = None
     ) -> Any:

--- a/tests/agent/test_native_preflight_estimate.py
+++ b/tests/agent/test_native_preflight_estimate.py
@@ -1,9 +1,16 @@
 """Native Responses preflight must count the checkpoint-pruned wire (#96155)."""
 
+import hashlib
 from types import SimpleNamespace
 
 from agent.codex_responses_adapter import estimate_native_responses_preflight_tokens
 from agent.model_metadata import estimate_request_tokens_rough
+from agent.native_compaction import (
+    NATIVE_OWNERSHIP_VERSION,
+    OWNER_NATIVE,
+    PHASE_CHECKPOINT_ACCEPTED,
+    native_compaction_route_key,
+)
 from agent.turn_context import _preflight_request_tokens
 
 
@@ -23,6 +30,23 @@ def _codex_agent(**over):
     )
     for key, value in over.items():
         setattr(agent, key, value)
+    route_key = native_compaction_route_key(agent)
+    digest = hashlib.sha256(b"blob").hexdigest()
+    agent._native_compaction_ownership_cache = {
+        "session_id": "",
+        "document": {
+            "version": NATIVE_OWNERSHIP_VERSION,
+            "routes": {
+                route_key: {
+                    "version": NATIVE_OWNERSHIP_VERSION,
+                    "route_key": route_key,
+                    "owner": OWNER_NATIVE,
+                    "phase": PHASE_CHECKPOINT_ACCEPTED,
+                    "checkpoint_digests": [digest],
+                }
+            },
+        },
+    }
     return agent
 
 

--- a/tests/run_agent/test_native_compaction.py
+++ b/tests/run_agent/test_native_compaction.py
@@ -7,17 +7,24 @@ structured rejection — hence the hard model-family gate these tests pin.
 """
 
 import hashlib
+import sqlite3
 from types import SimpleNamespace
 
 import pytest
 
 from agent.native_compaction import (
     DEFAULT_COMPACT_THRESHOLD,
+    OWNER_LOCAL,
+    begin_native_compaction_request,
     is_direct_openai_route,
     is_native_compaction_model,
     is_native_compaction_rejection,
     native_compaction_context_management,
+    native_compaction_ownership,
+    observe_native_compaction_response,
     resolve_compact_threshold,
+    suppress_automatic_local_compaction,
+    transition_native_compaction_to_local,
 )
 
 
@@ -41,6 +48,25 @@ def _agent(
 
 def _known_checkpoint_digest(encrypted: str) -> list[str]:
     return [hashlib.sha256(encrypted.encode("utf-8")).hexdigest()]
+
+
+def _ownership_agent(session_db, *, session_id="native-ownership-test"):
+    return SimpleNamespace(
+        api_mode="codex_responses",
+        provider="openai-api",
+        model="gpt-5.6",
+        base_url="https://api.openai.com/v1",
+        codex_responses_native_compaction=True,
+        compression_enabled=True,
+        compression_checkpoint_required=False,
+        context_compressor=SimpleNamespace(
+            context_length=100_000,
+            threshold_tokens=20_000,
+        ),
+        session_id=session_id,
+        _session_db=session_db,
+        _persist_disabled=False,
+    )
 
 
 class TestModelGate:
@@ -390,6 +416,67 @@ class TestResponseCapture:
 
 
 class TestNativePrimaryOwnershipRegression:
+    def test_failed_local_transition_cannot_resurrect_native_ownership(
+        self, monkeypatch, tmp_path
+    ):
+        from hermes_state import SessionDB
+
+        session_id = "locked-local-transition"
+        session_db = SessionDB(tmp_path / "state.db")
+        session_db.create_session(session_id, "test")
+        agent = _ownership_agent(session_db, session_id=session_id)
+
+        def locked_mutation(*_args, **_kwargs):
+            raise sqlite3.OperationalError("database is locked")
+
+        monkeypatch.setattr(
+            session_db,
+            "mutate_session_model_config_value",
+            locked_mutation,
+        )
+
+        transitioned = transition_native_compaction_to_local(
+            agent, "structured_rejection"
+        )
+        observed_next_request = native_compaction_ownership(agent, [])
+
+        assert transitioned["owner"] == OWNER_LOCAL
+        assert observed_next_request["owner"] == OWNER_LOCAL
+
+    def test_hard_boundary_without_compatible_checkpoint_transfers_local(
+        self, tmp_path
+    ):
+        from hermes_state import SessionDB
+
+        session_id = "checkpoint-missing-at-hard-boundary"
+        session_db = SessionDB(tmp_path / "state.db")
+        session_db.create_session(session_id, "test")
+        agent = _ownership_agent(session_db, session_id=session_id)
+        generation = begin_native_compaction_request(agent, request_tokens=90_000)
+        observe_native_compaction_response(
+            agent,
+            {
+                "output": [
+                    {
+                        "type": "compaction",
+                        "encrypted_content": "checkpoint-no-longer-in-history",
+                    }
+                ]
+            },
+            request_generation=generation,
+        )
+
+        suppressed = suppress_automatic_local_compaction(
+            agent,
+            messages=[],
+            approx_tokens=100_000,
+        )
+        observed_next_request = native_compaction_ownership(agent, [])
+
+        assert suppressed is False
+        assert observed_next_request["owner"] == OWNER_LOCAL
+        assert observed_next_request["reason"] == "hard_emergency_no_checkpoint"
+
     def test_accepted_checkpoint_keeps_local_automatic_compression_out_of_episode(
         self, monkeypatch, tmp_path
     ):

--- a/tests/run_agent/test_native_compaction.py
+++ b/tests/run_agent/test_native_compaction.py
@@ -6,6 +6,7 @@ gpt-5.1/gpt-5.2 fail server-side (HTTP 500 / stream stall) with no
 structured rejection — hence the hard model-family gate these tests pin.
 """
 
+import hashlib
 from types import SimpleNamespace
 
 import pytest
@@ -36,6 +37,10 @@ def _agent(
         codex_responses_compact_threshold=threshold,
         context_compressor=compressor,
     )
+
+
+def _known_checkpoint_digest(encrypted: str) -> list[str]:
+    return [hashlib.sha256(encrypted.encode("utf-8")).hexdigest()]
 
 
 class TestModelGate:
@@ -168,7 +173,7 @@ class TestRejectionMatcher:
             "Error code: 400 - Unknown parameter: 'context_management'"
         )
         assert is_native_compaction_rejection(
-            "invalid value for compact_threshold"
+            "invalid value for compact_threshold", 400
         )
 
     def test_generic_errors_do_not_match(self):
@@ -204,13 +209,15 @@ class TestRejectionMatcher:
         msg = "Unknown parameter: 'context_management'"
         assert is_native_compaction_rejection(msg, 400)
 
-    def test_unknown_status_preserves_message_only_matching(self):
-        # Transports that surface only a string keep working.
+    def test_unknown_status_requires_embedded_400(self):
         assert is_native_compaction_rejection(
             "Error code: 400 - Unknown parameter: 'context_management'", None
         )
-        assert is_native_compaction_rejection(
+        assert not is_native_compaction_rejection(
             "unsupported field compact_threshold", "not-a-number"
+        )
+        assert not is_native_compaction_rejection(
+            "TimeoutError: Error code: 400 invalid context_management", None
         )
 
 
@@ -350,6 +357,7 @@ class TestResponseCapture:
             ],
             current_issuer_kind="codex_backend",
             native_compaction_eligible=True,
+            native_compaction_checkpoint_digests=_known_checkpoint_digest("blob123"),
         )
         replayed = [item for item in items if item.get("type") == "compaction"]
         assert len(replayed) == 1
@@ -379,6 +387,126 @@ class TestResponseCapture:
             native_compaction_eligible=True,
         )
         assert all(item.get("type") != "compaction" for item in items)
+
+
+class TestNativePrimaryOwnershipRegression:
+    def test_accepted_checkpoint_keeps_local_automatic_compression_out_of_episode(
+        self, monkeypatch, tmp_path
+    ):
+        """One growth episode has exactly one automatic compaction owner."""
+        import run_agent
+        from agent.context_compressor import is_compaction_summary_message
+        from hermes_state import SessionDB
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(run_agent, "get_tool_definitions", lambda **_kw: [])
+        monkeypatch.setattr(run_agent, "check_toolset_requirements", lambda: {})
+        monkeypatch.setattr(
+            "agent.title_generator.maybe_auto_title", lambda *_args, **_kwargs: None
+        )
+
+        agent = run_agent.AIAgent(
+            api_key="fixture-token",
+            base_url="https://api.openai.com/v1",
+            provider="openai-api",
+            api_mode="codex_responses",
+            model="gpt-5.6",
+            quiet_mode=True,
+            max_iterations=4,
+            skip_context_files=True,
+            skip_memory=True,
+            enabled_toolsets=[],
+        )
+        agent.codex_responses_native_compaction = True
+        agent.codex_responses_compact_threshold = 4_000
+        agent.context_compressor.context_length = 40_000
+        agent.context_compressor.threshold_tokens = 10_000
+        agent._session_db = SessionDB(tmp_path / "state.db")
+        agent._cached_system_prompt = "fixture system"
+
+        def response(text, *, checkpoint=None, input_tokens):
+            output = []
+            if checkpoint is not None:
+                output.append(
+                    SimpleNamespace(
+                        type="compaction",
+                        encrypted_content=checkpoint,
+                        status="completed",
+                    )
+                )
+            output.append(
+                SimpleNamespace(
+                    type="message",
+                    status="completed",
+                    phase="final_answer",
+                    content=[SimpleNamespace(type="output_text", text=text)],
+                    id=f"msg_{text}",
+                )
+            )
+            return SimpleNamespace(
+                output=output,
+                usage=SimpleNamespace(
+                    input_tokens=input_tokens,
+                    output_tokens=2,
+                    total_tokens=input_tokens + 2,
+                ),
+                status="completed",
+                model="gpt-5.6",
+            )
+
+        responses = iter(
+            [
+                response(
+                    "checkpointed",
+                    checkpoint="opaque-native-checkpoint",
+                    input_tokens=5_000,
+                ),
+                response("done", input_tokens=5_000),
+            ]
+        )
+        requests = []
+        monkeypatch.setattr(
+            agent,
+            "_interruptible_api_call",
+            lambda kwargs: requests.append(kwargs) or next(responses),
+        )
+
+        local_summaries = []
+
+        def generate_summary(turns_to_summarize, focus_topic=None, memory_context=""):
+            local_summaries.append(len(turns_to_summarize))
+            return "## Active Task\nHermes local compression owned this episode."
+
+        agent.context_compressor._generate_summary = generate_summary
+        agent._compression_feasibility_checked = True
+
+        history = []
+        for index in range(20):
+            history.extend(
+                [
+                    {"role": "user", "content": f"turn-{index}-" + "u" * 2_000},
+                    {"role": "assistant", "content": f"reply-{index}"},
+                ]
+            )
+
+        first = agent.run_conversation(
+            "n" * 18_000,
+            conversation_history=history,
+        )
+        result = agent.run_conversation(
+            "m" * 30_000,
+            conversation_history=first["messages"],
+        )
+
+        assert result["completed"] is True
+        assert len(requests) == 2
+        assert requests[1]["input"][0] == {
+            "type": "compaction",
+            "encrypted_content": "opaque-native-checkpoint",
+        }
+        assert local_summaries == []
+        resumed, _display = agent._session_db.get_resume_conversations(agent.session_id)
+        assert not any(is_compaction_summary_message(message) for message in resumed)
 
 
 class TestAgentInitConfig:
@@ -551,7 +679,11 @@ class TestPrunePreCheckpointItems:
             },
             {"role": "user", "content": "follow-up"},
         ]
-        items = _chat_messages_to_responses_input(msgs, native_compaction_eligible=True)
+        items = _chat_messages_to_responses_input(
+            msgs,
+            native_compaction_eligible=True,
+            native_compaction_checkpoint_digests=_known_checkpoint_digest("blob"),
+        )
         assert items[0] == {"type": "compaction", "encrypted_content": "blob"}
         users = [i["content"] for i in items if i.get("role") == "user"]
         assert users == ["the goal", "follow-up"]
@@ -577,8 +709,8 @@ class TestCheckpointGatedOnCurrentEligibility:
     """A captured checkpoint must not outlive the native gate.
 
     The checkpoint is persisted in the ``codex_reasoning_items`` sidecar, so
-    it survives a mid-session model swap, ``compression.enabled: false``, the
-    rejection kill switch and a resumed session. Every one of those closes the
+    it survives a mid-session model swap, ``compression.enabled: false``, a
+    route-local fallback and a resumed session. Every one of those closes the
     gate; if the wire kept being restructured around the stale checkpoint,
     pre-checkpoint history would be deleted from requests that were never
     natively compacted — on a model that cannot even decrypt the blob.
@@ -630,6 +762,7 @@ class TestCheckpointGatedOnCurrentEligibility:
             self._history(),
             current_issuer_kind="codex_backend",
             native_compaction_eligible=True,
+            native_compaction_checkpoint_digests=_known_checkpoint_digest("blob"),
         )
         assert items[0]["type"] == "compaction"
         assert {"role": "assistant", "content": "on it"} not in items
@@ -642,7 +775,7 @@ class TestCheckpointGatedOnCurrentEligibility:
         assert {"role": "assistant", "content": "on it"} in items
 
     def test_build_kwargs_without_field_does_not_prune(self):
-        """Model swapped out of the gpt-5.6 family / kill switch fired:
+        """Model swapped out of the gpt-5.6 family / route fallback fired:
         the gate returns None, so the wire must be the pre-feature one."""
         from agent.transports.codex import ResponsesApiTransport
 
@@ -663,6 +796,7 @@ class TestCheckpointGatedOnCurrentEligibility:
             messages=self._history(),
             is_codex_backend=True,
             context_management=[{"type": "compaction", "compact_threshold": 4000}],
+            native_compaction_checkpoint_digests=_known_checkpoint_digest("blob"),
         )
         assert kwargs["input"][0]["type"] == "compaction"
         assert {"role": "assistant", "content": "on it"} not in kwargs["input"]

--- a/tests/run_agent/test_native_compaction_summary_retention.py
+++ b/tests/run_agent/test_native_compaction_summary_retention.py
@@ -8,6 +8,8 @@ reliance on the canonical ``agent.context_compressor`` provenance check (not
 an ad-hoc heuristic), whole-or-drop truncation, and idempotency.
 """
 
+import hashlib
+
 from agent.context_compressor import (
     COMPRESSED_SUMMARY_METADATA_KEY,
     ContextCompressor,
@@ -263,6 +265,10 @@ def _checkpoint_message(item_id: str = "rs_cp1", blob: str = "cp_blob_1"):
     }
 
 
+def _checkpoint_digests(blob: str = "cp_blob_1") -> list[str]:
+    return [hashlib.sha256(blob.encode("utf-8")).hexdigest()]
+
+
 class TestChatMessagesToResponsesInputSummaryCarrierLoss:
     """Adapter-level witnesses for the second blocking review (#90976):
     ``prune_pre_checkpoint_items`` only ever saw whatever ``_is_summary_item``
@@ -311,7 +317,9 @@ class TestChatMessagesToResponsesInputSummaryCarrierLoss:
         ]
 
         items = _chat_messages_to_responses_input(
-            messages, native_compaction_eligible=True,
+            messages,
+            native_compaction_eligible=True,
+            native_compaction_checkpoint_digests=_checkpoint_digests(),
         )
 
         # The summary survives, exactly once, as a plain message item —
@@ -361,7 +369,9 @@ class TestChatMessagesToResponsesInputSummaryCarrierLoss:
         ]
 
         items = _chat_messages_to_responses_input(
-            messages, native_compaction_eligible=True,
+            messages,
+            native_compaction_eligible=True,
+            native_compaction_checkpoint_digests=_checkpoint_digests(),
         )
 
         assert not any(


### PR DESCRIPTION
## What does this PR do?

This draft makes automatic compaction ownership explicit and monotonic for eligible OpenAI Codex Responses episodes. It prevents Hermes local summarization from rewriting an episode while provider-native compaction owns that same route/model episode, and transfers to local ownership only at explicit fallback boundaries.

This is published as a draft immediately after the focused current-main port and RED/GREEN proof. Broader repository verification, independent review, and any CI repairs will continue on this same PR.

## Related Issue

Fixes #96968

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add route/model-scoped native/local ownership state and durable session persistence.
- Reuse the centralized Responses route classifier for canonical route identity.
- Keep local automatic compression suppressed while an eligible native episode owns compaction.
- Preserve accepted native checkpoints across ordinary progression and resume.
- Transfer monotonically to local ownership on explicit rejection, malformed checkpoint, manual compression, or hard-boundary checkpoint starvation.
- Reject stale, foreign, unauthorized, and malformed checkpoint replay.
- Preserve unsupported/disabled/checkpoint-required local fallback and transient/opaque-error behavior.
- Add focused ownership, preflight, and summary-retention regression coverage.

## How to Test

Current-main RED proof before the implementation:

```text
HERMES_PYTHON=<isolated-dev-python> HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh tests/run_agent/test_native_compaction.py -k accepted_checkpoint_keeps_local_automatic_compression_out_of_episode -q

E assert [15, 3, 15, 2] == []
1 failed, 52 deselected
```

The same regression is GREEN with this commit:

```text
1 test passed, 0 failed
```

Focused and adjacent verification reported on the current draft head:

```text
scripts/run_tests.sh <16 focused/adjacent files>
428 tests passed, 0 failed
ruff: All checks passed
git diff --check: clean
```

Still in progress for this draft:

- repository-wide `scripts/run_tests.sh` plus an unmodified-main differential if needed;
- targeted `ty` and `compileall` receipts;
- independent read-only review;
- live CI and any candidate-caused repairs;
- a final live eligible Responses structural proof.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched open and closed issues, PRs, and recent commits for duplicates
- [x] My PR contains only changes related to this fix
- [ ] I've run the complete repository suite and all tests pass — not claimed yet; draft verification is ongoing
- [x] I've added tests for my changes
- [x] I've tested on macOS with Python 3.11

### Documentation & Housekeeping

- [ ] Documentation review is still pending for the final ownership contract
- [x] `cli-config.yaml.example` is N/A; no config key changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` changes are N/A
- [x] Cross-platform impact considered; the implementation is platform-independent Python
- [x] Tool descriptions/schemas are N/A

## Existing overlap and exclusions

- #81747 introduced the narrow native Responses compaction path.
- #76950 was a much broader custody proposal closed after #81747 landed.
- #94036, #96740, and #88722 are complementary capability/settings/threshold work.
- This PR does not change provider credentials, public config keys, prompt construction, tool schemas, or role alternation.

## Risks / current draft state

The ownership state touches request construction, response checkpoint capture, local compression gates, persistence, resume, and error recovery. Focused behavior is green, but this remains a draft until broader differential testing, independent review, and live CI are complete. No production deployment or runtime restart is part of this PR.
