### PR TITLE
fix(desktop): keep resolved primary connection identity

### DIFF
--- a/apps/desktop/src/store/gateway-connection-lifecycle.test.ts
+++ b/apps/desktop/src/store/gateway-connection-lifecycle.test.ts
@@ -53,6 +53,7 @@ vi.mock('@/store/session-states', () => reconnectStateMocks)
 
 const {
   activeGateway,
+  activeGatewayConnectionId,
   closeLegacySecondaryGateways,
   closeSecondaryGateways,
   configureGatewayRegistry,
@@ -66,7 +67,8 @@ const {
   reconnectSecondaryGateways,
   retainGatewayForAgent,
   retireLocalProfileGateways,
-  setPrimaryGateway
+  setPrimaryGateway,
+  setPrimaryGatewayConnection
 } = await import('./gateway')
 
 function installDesktop(stub: Record<string, unknown>): void {
@@ -95,6 +97,25 @@ afterEach(() => {
   vi.clearAllMocks()
   vi.useRealTimers()
   delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
+})
+
+describe('primary connection identity', () => {
+  it('does not reuse a stale secondary descriptor after the primary explicitly publishes an unqualified route', () => {
+    configureGatewayRegistry({
+      activeConnectionId: () => 'legacy-remote-profile',
+      onEvent: vi.fn()
+    } as never)
+
+    // Before Electron publishes the primary descriptor, the renderer may use
+    // the ambient descriptor as a boot-time compatibility fallback.
+    expect(activeGatewayConnectionId()).toBe('legacy-remote-profile')
+
+    // A published descriptor without connectionId is authoritative: this is a
+    // legacy/local primary, not the stale registry source the window just left.
+    setPrimaryGatewayConnection(null)
+
+    expect(activeGatewayConnectionId()).toBeNull()
+  })
 })
 
 describe('disposeSecondariesForConnection', () => {

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -133,6 +133,9 @@ interface GatewayRegistryState {
   primaryGateway: HermesGateway | null
   /** Registry source currently served by primaryGateway, when known. */
   primaryConnectionId: null | string
+  /** True after Electron explicitly published the primary descriptor, even
+   * when that descriptor deliberately has no registry connection id. */
+  primaryConnectionResolved?: boolean
   primaryProfile: string
   activeKey: string
   activationEpoch: number
@@ -154,6 +157,7 @@ function createRegistryState(): GatewayRegistryState {
     config: null,
     primaryGateway: null,
     primaryConnectionId: null,
+    primaryConnectionResolved: false,
     primaryProfile: 'default',
     activeKey: 'default',
     activationEpoch: 0,
@@ -190,6 +194,7 @@ function gatewayState(): GatewayRegistryState {
     // Existing dev-HMR containers predate whole-turn leases.
     store[STATE_KEY].turnLeases ??= new Map()
     store[STATE_KEY].turnLeaseReleaseTimers ??= new Map()
+    store[STATE_KEY].primaryConnectionResolved ??= false
 
     return store[STATE_KEY]
   }
@@ -241,6 +246,7 @@ export function setPrimaryGateway(gateway: HermesGateway | null, profile = 'defa
 
   if (g.primaryGateway !== gateway) {
     g.primaryConnectionId = null
+    g.primaryConnectionResolved = false
   }
 
   // Route identity is exact-scope, never bare-name (#93892 follow-up): when
@@ -274,6 +280,10 @@ export function setPrimaryGatewayConnectionId(connectionId: null | string | unde
   }
 
   g.primaryConnectionId = (connectionId ?? '').trim() || null
+  // Null is meaningful: Electron resolved this primary as the legacy/local
+  // route. Do not fall back to a stale descriptor from the secondary source
+  // the window just left.
+  g.primaryConnectionResolved = true
 
   if (g.activeKey === g.primaryProfile) {
     setApiRequestConnection(g.primaryConnectionId)
@@ -330,7 +340,9 @@ export function activeGateway(): HermesGateway | null {
  */
 export function activeGatewayConnectionId(): null | string {
   if (g.activeKey === g.primaryProfile) {
-    return g.primaryConnectionId ?? (g.config?.activeConnectionId?.()?.trim() || null)
+    return g.primaryConnectionResolved === true
+      ? g.primaryConnectionId
+      : (g.config?.activeConnectionId?.()?.trim() || null)
   }
 
   return g.secondaries.get(g.activeKey)?.connectionId ?? null


### PR DESCRIPTION
## Summary
- distinguish an unresolved primary descriptor from an explicitly unqualified legacy/local primary
- prevent a stale departed-source connection id from reaching registry-only routing after fallback
- add a regression test for the three-state primary identity contract

## User-visible failure
After a registered/secondary source was removed or the renderer fell back to its primary gateway, `$connection` could still describe the departed source. Because `null` was treated as “not resolved yet,” `activeGatewayConnectionId()` reused that stale id. A later profile selection could fail with `No connection with id "<stale-id>"`.

## Verification
- `npm run test:ui -- src/store/gateway.test.ts src/store/gateway-connection-lifecycle.test.ts src/store/gateway-profile-request.test.ts src/store/profile-select-source.test.ts src/app/session/hooks/profile-rail-fresh-chat-owner.test.tsx src/app/gateway/hooks/use-gateway-boot.test.tsx` (99 passed)
- `npm run typecheck`
- packaged Desktop build
- live legacy remote-profile switch, roster load, session creation, and assistant round-trip