### PR TITLE
fix(gateway): arm loop-tick witness only on POSIX

### DIFF
--- a/gateway/shutdown_watchdog.py
+++ b/gateway/shutdown_watchdog.py
@@ -526,13 +526,16 @@ async def loop_heartbeat_forever(
     # disables the witness, and the payload flag tells probes that staleness is
     # no longer sufficient authority to escalate.
     #
-    # Windows: asyncio.start_unix_server raises (no AF_UNIX event-loop
-    # support), so the witness is PERMANENTLY absent there — the payload
-    # records loop_tick_socket=False and every stale-file probe classifies
-    # UNKNOWN, never WEDGED. That is deliberate fail-safe: a wedged native
-    # Windows gateway keeps the graceful-drain backstop instead of an
-    # escalation verdict built on a witness that cannot exist. (WSL2 — the
-    # #90502 incident environment — is Linux and arms the socket normally.)
+    # Windows (non-POSIX generally): the server creation below is explicitly
+    # gated to POSIX — asyncio AF_UNIX support is POSIX-only, and an ungated
+    # call would raise AttributeError on every native-Windows gateway start.
+    # The witness is therefore DELIBERATELY left absent there (debug log only,
+    # no warning): the payload records loop_tick_socket=False and every
+    # stale-file probe classifies UNKNOWN, never WEDGED. That is deliberate
+    # fail-safe: a wedged native Windows gateway keeps the graceful-drain
+    # backstop instead of an escalation verdict built on a witness that cannot
+    # exist. (WSL2 — the #90502 incident environment — is Linux and arms the
+    # socket normally.)
     tick_server = None
     tick_socket_path = None
     try:
@@ -569,9 +572,16 @@ async def loop_heartbeat_forever(
                 logger.debug(
                     "stale loop-tick socket sweep failed", exc_info=True
                 )
-        tick_server = await asyncio.start_unix_server(
-            _tick_socket_handler, path=str(tick_socket_path)
-        )
+            tick_server = await asyncio.start_unix_server(
+                _tick_socket_handler, path=str(tick_socket_path)
+            )
+        else:
+            logger.debug(
+                "loop-tick witness intentionally not armed on non-POSIX "
+                "platform (os.name=%r): asyncio AF_UNIX support is "
+                "POSIX-only; heartbeat payload records loop_tick_socket=False",
+                os.name,
+            )
     except Exception:
         tick_server = None
         logger.warning(

--- a/tests/gateway/test_shutdown_watchdog.py
+++ b/tests/gateway/test_shutdown_watchdog.py
@@ -8,11 +8,15 @@ structurally unable to fire. These tests pin the out-of-loop backstop
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
+import logging
+import os
 import threading
 import time
 from unittest.mock import patch
 
+import gateway.shutdown_watchdog as shutdown_watchdog_module
 import pytest
 
 from gateway.shutdown_watchdog import (
@@ -66,3 +70,83 @@ def test_arm_shutdown_watchdog_fires_with_dump_and_exit(tmp_path):
     assert get_shutdown_watchdog_dump_path(tmp_path).name == "gateway-shutdown-watchdog.log"
 
 
+
+
+async def _run_heartbeat_until_payload(tmp_path, timeout_s=10.0):
+    """Run loop_heartbeat_forever as a task until a heartbeat payload exists.
+
+    Returns (task, payload). Cancels the task and awaits it (suppressing
+    CancelledError) before returning so the tick server is closed cleanly.
+    """
+    task = asyncio.ensure_future(
+        loop_heartbeat_forever(interval_s=1.0, home=tmp_path)
+    )
+    heartbeat_path = get_loop_heartbeat_path(tmp_path)
+    deadline = time.monotonic() + timeout_s
+    payload = None
+    while time.monotonic() < deadline:
+        if heartbeat_path.is_file():
+            with contextlib.suppress(OSError, json.JSONDecodeError):
+                payload = json.loads(heartbeat_path.read_text(encoding="utf-8"))
+                if payload:
+                    break
+                payload = None
+        await asyncio.sleep(0.05)
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task
+    if payload is None:
+        pytest.fail(
+            f"heartbeat payload did not appear at {heartbeat_path} within "
+            f"{timeout_s}s"
+        )
+    return payload
+
+
+@pytest.mark.asyncio
+async def test_loop_tick_witness_skipped_intentionally_on_windows(
+    tmp_path, caplog, monkeypatch
+):
+    # Pretend the platform is Windows as seen from the module under test.
+    # A plain monkeypatch of the global os.name would flip pathlib.Path
+    # dispatch (Path.__new__ reads os.name at runtime) and crash pytest's
+    # own tmp-dir machinery, so swap the module's `os` binding for a proxy
+    # whose `.name` is "nt" and which delegates everything else to real os.
+    class _WindowsOsProxy:
+        name = "nt"
+
+        def __getattr__(self, item):
+            return getattr(os, item)
+
+    monkeypatch.setattr(shutdown_watchdog_module, "os", _WindowsOsProxy())
+
+    start_unix_server_calls = []
+
+    def _forbid_start_unix_server(*args, **kwargs):
+        start_unix_server_calls.append((args, kwargs))
+        raise AssertionError("start_unix_server must not be called on non-POSIX")
+
+    with patch.object(
+        shutdown_watchdog_module.asyncio,
+        "start_unix_server",
+        side_effect=_forbid_start_unix_server,
+    ), caplog.at_level(logging.DEBUG, logger="gateway.shutdown_watchdog"):
+        payload = await _run_heartbeat_until_payload(tmp_path)
+
+    # (a) the witness server was never attempted
+    assert start_unix_server_calls == []
+    # (b) no warning about an unavailable tick socket
+    assert not [
+        r
+        for r in caplog.records
+        if r.levelname == "WARNING"
+        and "Loop tick socket unavailable" in r.getMessage()
+    ]
+    # (c) the fail-safe flag is still recorded
+    assert payload["loop_tick_socket"] is False
+
+
+@pytest.mark.asyncio
+async def test_loop_tick_witness_arms_on_posix(tmp_path):
+    payload = await _run_heartbeat_until_payload(tmp_path)
+    assert payload["loop_tick_socket"] is True


### PR DESCRIPTION
Closes #96956

## Summary

`loop_heartbeat_forever` in `gateway/shutdown_watchdog.py` called `asyncio.start_unix_server` unconditionally. That function only exists on POSIX (AF_UNIX asyncio support), so on native Windows every gateway start raised `AttributeError` — swallowed by the surrounding broad `except` into a noisy `WARNING` + traceback in the logs. The loop-tick liveness witness was never armed on Windows and the heartbeat payload always recorded `loop_tick_socket: false`.

That witness absence on Windows is deliberate fail-safe (documented in the adjacent comment block): a wedged native-Windows gateway keeps the graceful-drain backstop instead of an escalation verdict built on a witness that cannot exist. The bug was that the code attempted the impossible call anyway and "failed" into that state via an accident, logging a warning every single start. The stale-socket sweep immediately above the call site was already correctly gated with `if os.name == "posix":` — this PR extends that same gate to the server creation, mirroring it exactly, and logs the non-POSIX skip at DEBUG (expected condition, not a failure).

## Changes

- `gateway/shutdown_watchdog.py`: moved `tick_server = await asyncio.start_unix_server(...)` inside the existing `if os.name == "posix":` block; added an `else:` branch logging at DEBUG that the witness is intentionally not armed on non-POSIX. The outer `except Exception:` → `WARNING` path is untouched, so genuine POSIX bind failures (permissions, path length) still warn. Updated the comment block to describe the skip as explicit/gated rather than an `AttributeError` accident.
- `tests/gateway/test_shutdown_watchdog.py`: two regression tests:
  - `test_loop_tick_witness_skipped_intentionally_on_windows` — simulates a non-POSIX platform as seen from the module (the module's `os` binding is swapped for a proxy with `name = "nt"`; a direct global `os.name` patch would flip `pathlib.Path` dispatch and crash pytest itself) and installs a never-call recorder on `asyncio.start_unix_server`. Asserts the server creation is never attempted, no `Loop tick socket unavailable` warning is logged, and the payload still records `loop_tick_socket: false` (fail-safe preserved).
  - `test_loop_tick_witness_arms_on_posix` — the real POSIX path still arms the witness (`loop_tick_socket: true`).

## Tests

- `tests/gateway/test_shutdown_watchdog.py` + `tests/gateway/test_loop_liveness_watchdog.py`: 15 passed (the existing source-scan test `test_loop_scheduling_witness_is_served_by_the_loop_itself` still holds — the awaited `start_unix_server` call remains in the function body, now gated).
- `tests/hermes_cli/test_update_wedged_gateway.py` (exercises `loop_heartbeat_forever` with a real socket through the consumer probe path): 30 passed.
- Revert-proof: checking out the pre-fix module makes `test_loop_tick_witness_skipped_intentionally_on_windows` fail with exactly the bug's signature (the recorder catches the call, and the module logs the real bug's `Loop tick socket unavailable` warning); re-applying the fix turns it green.

POSIX behavior is unchanged; on Windows the only observable difference is the absence of the spurious warning + traceback on every start (witness-absence semantics are identical to before, by design).