### PR TITLE
security(whatsapp): suppress Express fingerprinting

### DIFF
--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -20,7 +20,6 @@
  */
 
 import { makeWASocket, useMultiFileAuthState, DisconnectReason, fetchLatestBaileysVersion, downloadMediaMessage, getAggregateVotesInPollMessage, decryptPollVote, getKeyAuthor, jidNormalizedUser } from '@whiskeysockets/baileys';
-import express from 'express';
 import { Boom } from '@hapi/boom';
 import pino from 'pino';
 import path from 'path';
@@ -33,6 +32,7 @@ import qrcode from 'qrcode-terminal';
 import { matchesAllowedUser, parseAllowedUsers } from './allowlist.js';
 import { createOutboundIdTracker } from './outbound_ids.js';
 import { classifyOwnerMessageGate } from './owner_message_gate.js';
+import { createBridgeApp } from './http_app.js';
 import {
   buildPollPayload,
   createReconnectScheduler,
@@ -779,39 +779,7 @@ async function startSocket() {
 }
 
 // HTTP server
-const app = express();
-app.use(express.json());
-
-// Host-header validation — defends against DNS rebinding.
-// The bridge binds loopback-only (127.0.0.1) but a victim browser on
-// the same machine could be tricked into fetching from an attacker
-// hostname that TTL-flips to 127.0.0.1. Reject any request whose Host
-// header doesn't resolve to a loopback alias.
-// See GHSA-ppp5-vxwm-4cf7.
-const _ACCEPTED_HOST_VALUES = new Set([
-  'localhost',
-  '127.0.0.1',
-  '[::1]',
-  '::1',
-]);
-
-app.use((req, res, next) => {
-  const raw = (req.headers.host || '').trim();
-  if (!raw) {
-    return res.status(400).json({ error: 'Missing Host header' });
-  }
-  // Strip port suffix: "localhost:3000" → "localhost"
-  const hostOnly = (raw.includes(':')
-    ? raw.substring(0, raw.lastIndexOf(':'))
-    : raw
-  ).replace(/^\[|\]$/g, '').toLowerCase();
-  if (!_ACCEPTED_HOST_VALUES.has(hostOnly)) {
-    return res.status(400).json({
-      error: 'Invalid Host header. Bridge accepts loopback hosts only.',
-    });
-  }
-  next();
-});
+const app = createBridgeApp();
 
 // Poll for new messages (long-poll style)
 app.get('/messages', (req, res) => {

--- a/scripts/whatsapp-bridge/http_app.js
+++ b/scripts/whatsapp-bridge/http_app.js
@@ -1,0 +1,36 @@
+import express from 'express';
+
+const ACCEPTED_HOST_VALUES = new Set([
+  'localhost',
+  '127.0.0.1',
+  '[::1]',
+  '::1',
+]);
+
+export function createBridgeApp() {
+  const app = express();
+  app.disable('x-powered-by');
+  app.use(express.json());
+
+  // The bridge is loopback-only, but hostile DNS can still resolve to
+  // 127.0.0.1. Reject non-loopback Host values before endpoint dispatch.
+  app.use((req, res, next) => {
+    const raw = (req.headers.host || '').trim();
+    if (!raw) {
+      return res.status(400).json({ error: 'Missing Host header' });
+    }
+
+    const hostOnly = (raw.includes(':')
+      ? raw.substring(0, raw.lastIndexOf(':'))
+      : raw
+    ).replace(/^\[|\]$/g, '').toLowerCase();
+    if (!ACCEPTED_HOST_VALUES.has(hostOnly)) {
+      return res.status(400).json({
+        error: 'Invalid Host header. Bridge accepts loopback hosts only.',
+      });
+    }
+    next();
+  });
+
+  return app;
+}

--- a/scripts/whatsapp-bridge/http_app.test.mjs
+++ b/scripts/whatsapp-bridge/http_app.test.mjs
@@ -1,0 +1,47 @@
+import { strict as assert } from 'node:assert';
+import { once } from 'node:events';
+import http from 'node:http';
+
+import { createBridgeApp } from './http_app.js';
+
+function request(server, host) {
+  const address = server.address();
+  return new Promise((resolve, reject) => {
+    const req = http.request({
+      hostname: '127.0.0.1',
+      port: address.port,
+      path: '/health',
+      headers: { Host: host },
+    }, (res) => {
+      let body = '';
+      res.setEncoding('utf8');
+      res.on('data', (chunk) => { body += chunk; });
+      res.on('end', () => resolve({ body, headers: res.headers, status: res.statusCode }));
+    });
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+const app = createBridgeApp();
+app.get('/health', (req, res) => res.json({ status: 'ok' }));
+
+const server = app.listen(0, '127.0.0.1');
+await once(server, 'listening');
+
+try {
+  const accepted = await request(server, '127.0.0.1');
+  assert.equal(accepted.status, 200);
+  assert.deepEqual(JSON.parse(accepted.body), { status: 'ok' });
+  assert.equal(accepted.headers['x-powered-by'], undefined);
+
+  const rejected = await request(server, 'example.com');
+  assert.equal(rejected.status, 400);
+  assert.deepEqual(JSON.parse(rejected.body), {
+    error: 'Invalid Host header. Bridge accepts loopback hosts only.',
+  });
+  assert.equal(rejected.headers['x-powered-by'], undefined);
+} finally {
+  server.close();
+  await once(server, 'close');
+}

--- a/scripts/whatsapp-bridge/package.json
+++ b/scripts/whatsapp-bridge/package.json
@@ -5,7 +5,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "start": "node bridge.js"
+    "start": "node bridge.js",
+    "test": "node --test *.test.mjs"
   },
   "dependencies": {
     "@whiskeysockets/baileys": "7.0.0-rc13",


### PR DESCRIPTION
## Summary

- disable Express `x-powered-by` on the local WhatsApp bridge
- keep the existing loopback Host validation unchanged while extracting the HTTP app setup for direct testing
- add real HTTP regression coverage for both an accepted `/health` request and a rejected non-loopback Host request
- add the existing bridge test files to an `npm test` script

Fixes #96898

## Validation

- red phase: removing `app.disable("x-powered-by")` made the HTTP regression fail with actual header value `Express`
- `npm test`: 23 passed, 0 failed
- `node --check` on `bridge.js`, `http_app.js`, and `http_app.test.mjs`: passed
- `git diff --check`: passed
- `package-lock.json`: unchanged

The bridge remains bound by its existing caller to `127.0.0.1`; accepted Host values, endpoint bodies, and status codes are unchanged.