### PR TITLE
refactor(execute_code): schema diet — persistence woven in, not bolted on (712 → 654 tok/call)

### DIFF
--- a/tests/tools/test_code_kernel.py
+++ b/tests/tools/test_code_kernel.py
@@ -159,17 +159,18 @@ class TestSchemaSurface(unittest.TestCase):
             schema = build_execute_code_schema(mode="strict")
         self.assertIn("reset", schema["parameters"]["properties"])
 
-    def test_session_note_is_always_present(self):
-        """The schema's kernel note is unconditional now — session kernels
-        are always on for local execution (kernel_mode retired), so every
-        session is told about persistence and reset=true."""
+    def test_kernel_persistence_is_taught_unconditionally(self):
+        """Persistence is woven into the tool's main description (always-on
+        since #96787, integrated in the schema diet) — every session must be
+        told state survives across calls, in strict and project mode alike,
+        regardless of any stale kernel_mode key in config."""
         with _kernel_config():
-            session_schema = build_execute_code_schema(mode="strict")
-        self.assertIn("Session kernel is active", session_schema["description"])
-        # Even with a stale per-call key in config, the note stays.
+            schema = build_execute_code_schema(mode="strict")
+        self.assertIn("persistent session kernel", schema["description"])
+        self.assertIn("reset", schema["parameters"]["properties"])
         with _kernel_config(kernel_mode="per-call"):
             stale_schema = build_execute_code_schema(mode="strict")
-        self.assertIn("Session kernel is active", stale_schema["description"])
+        self.assertIn("persistent session kernel", stale_schema["description"])
 
 
 if __name__ == "__main__":

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -2318,32 +2318,31 @@ def build_execute_code_schema(enabled_sandbox_tools: set = None,
             "so project deps (pandas, etc.) and relative paths work like in terminal()."
         )
 
-    kernel_note = ""
-    if _get_kernel_mode() == "session":
-        kernel_note = (
-            "\n\nSession kernel is active: variables, imports, and loaded "
-            "data persist across execute_code calls in this session. Pass "
-            "reset=true to discard that state. A timed-out or interrupted "
-            "cell kills the kernel and loses its state."
-        )
+    # Session kernels are always on (kernel_mode retired in #96787):
+    # persistence is part of the tool's one description, not a bolt-on
+    # paragraph behind a dead conditional. Remote hosts that cannot sustain
+    # a kernel fail open to per-call silently — not worth schema words;
+    # the result's `kernel` field tells the truth per call.
     description = (
-        "Run a Python script that calls Hermes tools programmatically. "
-        "Use when you need 3+ tool calls with logic between them: "
-        "filtering/reducing large outputs before they enter context, "
-        "conditional branching, or loops (N pages/files, retry on failure). "
-        "Use normal tool calls for single calls, results you must reason "
-        "over in full, or anything needing user interaction.\n\n"
+        "Run Python that calls Hermes tools programmatically. Use when you "
+        "need 3+ tool calls with logic between them: filtering/reducing "
+        "large outputs before they enter context, branching, or loops "
+        "(N pages/files, retry on failure). Use normal tool calls for "
+        "single calls, results you must reason over in full, or anything "
+        "needing user interaction.\n\n"
+        "Calls run in a persistent session kernel: variables, imports, and "
+        "loaded data survive across execute_code calls, so build on earlier "
+        "work instead of re-loading it. A timed-out or interrupted call "
+        "loses that state.\n\n"
         f"Available via `from hermes_tools import ...`:\n\n"
         f"{tool_lines}\n\n"
-        "Limits: 5-minute timeout, 50KB stdout cap, max 50 tool calls per script. "
-        "terminal() is foreground-only (no background or pty).\n\n"
+        "Limits: 5-minute timeout, 50KB stdout cap, max 50 tool calls per "
+        "call.\n\n"
         f"{cwd_note}\n\n"
-        "Print your final result to stdout; stdlib (json, re, csv, datetime, ...) "
-        "is available for processing.\n\n"
-        "Built-in helpers (no import): json_parse(text) — tolerant json.loads for "
-        "terminal() output; shell_quote(s) — shlex.quote for dynamic shell args; "
-        "retry(fn, max_attempts=3, delay=2) — exponential backoff for transient failures."
-        + kernel_note
+        "Built-in helpers (no import): json_parse(text) — tolerant "
+        "json.loads for terminal() output; shell_quote(s) — shlex.quote for "
+        "dynamic shell args; retry(fn, max_attempts=3, delay=2) — "
+        "exponential backoff."
     )
 
     return {
@@ -2363,9 +2362,8 @@ def build_execute_code_schema(enabled_sandbox_tools: set = None,
                 "reset": {
                     "type": "boolean",
                     "description": (
-                        "Session-kernel mode only: discard the persistent "
-                        "kernel's state and start fresh before running this "
-                        "code. Ignored in per-call mode."
+                        "Discard the kernel's persistent state and start "
+                        "fresh before running this code."
                     ),
                 },
             },

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -2314,8 +2314,11 @@ def build_execute_code_schema(enabled_sandbox_tools: set = None,
         )
     else:
         cwd_note = (
-            "Scripts run in the session's working directory with the active venv's python, "
-            "so project deps (pandas, etc.) and relative paths work like in terminal()."
+            "Scripts run in the session's working directory. Interpreter: "
+            "the project's activated venv/conda python when one is active "
+            "(VIRTUAL_ENV/CONDA_PREFIX — matches terminal()); otherwise "
+            "Hermes's own python (the common case — stdlib plus Hermes's "
+            "deps; check `import x` before relying on project packages)."
         )
 
     # Session kernels are always on (kernel_mode retired in #96787):


### PR DESCRIPTION
Campaign entry (#95681), post-kernel-adoption cleanup. The kernel arc (#94647/#96787/#96991) grew execute_code's served schema 631 → 712 by APPENDING a conditional kernel paragraph behind a now-dead `_get_kernel_mode()` check. This PR makes persistence part of the tool's one story instead of a bolt-on, and sweeps prose the kernel made stale.

## Changes (all editorial — zero behavior)
- **Kernel note → core description.** Persistence is the tool's second sentence now ("build on earlier work instead of re-loading it"), not a trailing afterthought. The dead conditional is gone from the builder.
- **"per script" → "per call"** in the limits line: with a persistent kernel there is no per-script world; the tool-call budget is per call (it resets each cell — matches runtime).
- **Stale/duplicated prose swept:** "Print your final result to stdout" was taught twice (description + code param) — now once, in the param where it's read at write-time; terminal foreground-only was taught twice (limits line + terminal stub line) — the stub, which session-filters correctly, keeps it; "conditional branching" → "branching"; "for transient failures" tail dropped.
- **reset param**: "Session-kernel mode only … Ignored in per-call mode" described a mode that no longer exists → "Discard the kernel's persistent state and start fresh."
- **Remote fail-open deliberately NOT in the schema** (comment documents the choice): hosts that can't sustain a kernel degrade silently and the result's `kernel` field tells the truth per call — teaching every session about a rare degraded path is rent not worth paying.

## Numbers (as served, o200k_base, full toolset)
| | tok/call |
|---|---|
| pre-kernel-arc | 631 |
| main today (kernel note appended) | 712 |
| this PR | **654 (−58 vs main; +23 vs pre-kernel for a genuinely new capability)** |

The dynamic machinery (per-session tool-stub filtering, strict/project cwd variants) is untouched — it's the good kind of dynamic. Contract test updated: `test_kernel_persistence_is_taught_unconditionally` pins that every session learns persistence + reset, in both modes, regardless of stale config keys.

Tests: 86 passed / 1 pre-existing failure (TestRpcTokenAuthorization, predates the arc).