### PR TITLE
fix(desktop): preserve Bot tile scope on move

### DIFF
--- a/apps/desktop/src/store/session-states.test.ts
+++ b/apps/desktop/src/store/session-states.test.ts
@@ -315,6 +315,36 @@ describe('SessionTile workspace scope', () => {
     })
   })
 
+  it('preserves an existing Bot tile scope when moving it without an explicit scope', () => {
+    const scope = {
+      ownerRoute: {
+        connectionId: 'connection-a',
+        mode: 'remote' as const,
+        profile: 'default',
+        targetProfile: 'default'
+      },
+      workspaceMode: 'bots' as const,
+      workspaceOwnerKey: 'bot:connection-a::default',
+      workspaceTabTitle: 'Bot chat'
+    }
+
+    openSessionTile('bot-chat', 'right', undefined, undefined, scope)
+    $layoutTree.set(group(['workspace', 'session-tile:bot-chat'], { id: 'workspace-group' }))
+    openSessionTile('bot-chat', 'left', 'workspace')
+
+    expect($sessionTiles.get()).toEqual([
+      expect.objectContaining({
+        anchor: 'workspace',
+        dir: 'left',
+        ownerRoute: scope.ownerRoute,
+        storedSessionId: 'bot-chat',
+        workspaceMode: 'bots',
+        workspaceOwnerKey: scope.workspaceOwnerKey,
+        workspaceTabTitle: 'Bot chat'
+      })
+    ])
+  })
+
   it('preserves workspace scope while dropping a stale runtime binding', () => {
     $sessionTiles.set([
       {

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -1311,9 +1311,20 @@ export function openSessionTile(
   dir: TileDock = 'right',
   anchor?: string,
   before?: null | string,
-  workspaceScope: SessionTileWorkspaceScope = { workspaceMode: 'sessions' }
+  workspaceScope?: SessionTileWorkspaceScope
 ) {
   const tiles = $sessionTiles.get()
+  const existingTile = tiles.find(tile => tile.storedSessionId === storedSessionId)
+  const effectiveWorkspaceScope =
+    workspaceScope ??
+    (existingTile
+      ? {
+          ownerRoute: existingTile.ownerRoute,
+          workspaceMode: existingTile.workspaceMode ?? 'sessions',
+          workspaceOwnerKey: existingTile.workspaceOwnerKey,
+          workspaceTabTitle: existingTile.workspaceTabTitle
+        }
+      : { workspaceMode: 'sessions' })
 
   // Opening a session in a tab/tile is "reading" it — clear its unread dot
   // exactly like main-thread resume does. Previously only
@@ -1323,26 +1334,28 @@ export function openSessionTile(
   markSessionRead(storedSessionId)
   ackStoredSessionId(storedSessionId)
 
-  if (workspaceScope.workspaceMode === 'sessions' && storedSessionId === $selectedStoredSessionId.get()) {
+  if (effectiveWorkspaceScope.workspaceMode === 'sessions' && storedSessionId === $selectedStoredSessionId.get()) {
     return
   }
 
   const dock = anchor ?? focusedSessionTabAnchor() ?? undefined
 
-  const workspaceOwnerKey = workspaceScope.workspaceMode === 'bots' ? workspaceScope.workspaceOwnerKey : undefined
+  const workspaceOwnerKey =
+    effectiveWorkspaceScope.workspaceMode === 'bots' ? effectiveWorkspaceScope.workspaceOwnerKey : undefined
 
-  if (!tiles.some(t => t.storedSessionId === storedSessionId)) {
+  if (!existingTile) {
     saveTiles([
       ...tiles,
       {
         anchor: dock,
         before,
         dir,
-        ownerRoute: workspaceScope.workspaceMode === 'bots' ? workspaceScope.ownerRoute : undefined,
+        ownerRoute: effectiveWorkspaceScope.workspaceMode === 'bots' ? effectiveWorkspaceScope.ownerRoute : undefined,
         storedSessionId,
-        workspaceMode: workspaceScope.workspaceMode,
+        workspaceMode: effectiveWorkspaceScope.workspaceMode,
         workspaceOwnerKey,
-        workspaceTabTitle: workspaceScope.workspaceMode === 'bots' ? workspaceScope.workspaceTabTitle : undefined
+        workspaceTabTitle:
+          effectiveWorkspaceScope.workspaceMode === 'bots' ? effectiveWorkspaceScope.workspaceTabTitle : undefined
       }
     ])
     // Adoption is async via the registry — order sync runs after the move path
@@ -1351,7 +1364,7 @@ export function openSessionTile(
     return
   }
 
-  setSessionTileWorkspaceScope(storedSessionId, workspaceScope)
+  setSessionTileWorkspaceScope(storedSessionId, effectiveWorkspaceScope)
 
   // Already open: relocate the existing pane to the drop target (pane-mirror
   // only docks on first adoption, so a re-drag must move the tree pane itself).


### PR DESCRIPTION
Closes #96865. Preserve an existing tile's workspace scope when a drag move does not supply one, so Bot workspace tiles remain in their owner bucket. Adds a regression test for moving a Bot tile.