### PR TITLE
feat(kanban): add an authenticated bounded owner-read contract

### DIFF
--- a/hermes_cli/dashboard_auth/token_auth.py
+++ b/hermes_cli/dashboard_auth/token_auth.py
@@ -38,6 +38,7 @@ seam remembers and surfaces as 503 only if NO provider accepts the token.
 """
 from __future__ import annotations
 
+import hmac
 import logging
 import threading
 from typing import Awaitable, Callable, Optional, Tuple
@@ -151,7 +152,8 @@ async def token_auth_middleware(
     :func:`register_token_route`. For a registered path, token auth is the
     only accepted scheme:
 
-      * valid token  → attach principal + ``token_authenticated`` flag, pass through.
+      * exact process-internal bearer → attach the server principal and pass through;
+      * valid provider token → attach principal + ``token_authenticated`` flag, pass through.
       * unreachable  → 503 (provider backing store down; not "bad credentials").
       * otherwise    → 401 unauthenticated.
 
@@ -163,7 +165,22 @@ async def token_auth_middleware(
     if not is_token_route(path):
         return await call_next(request)
 
-    principal, unreachable = authenticate_token(request)
+    token = extract_bearer_token(request)
+    internal_token = getattr(request.app.state, "internal_api_token", None)
+    if (
+        token
+        and isinstance(internal_token, str)
+        and internal_token
+        and hmac.compare_digest(token.encode(), internal_token.encode())
+    ):
+        principal = TokenPrincipal(
+            principal="dashboard-internal",
+            provider="dashboard-internal",
+            scopes=("dashboard-internal",),
+        )
+        unreachable = None
+    else:
+        principal, unreachable = authenticate_token(request)
     if principal is not None:
         request.state.token_principal = principal
         request.state.token_authenticated = True

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -546,6 +546,7 @@ def _resolve_session_token() -> str:
 
 _SESSION_TOKEN = _resolve_session_token()
 _SESSION_HEADER_NAME = "X-Hermes-Session-Token"
+app.state.internal_api_token = _SESSION_TOKEN
 _SSH_OWNER_NONCE: Optional[str] = None
 _SSH_RUNTIME_PURELIB: Optional[Tuple[str, int, int]] = None
 _SSH_RUNTIME_MARKER: Optional[str] = None
@@ -555,6 +556,7 @@ def _apply_ssh_session_token(token: str) -> None:
     global _SESSION_TOKEN
     if token:
         _SESSION_TOKEN = token
+        app.state.internal_api_token = token
 
 
 def _apply_ssh_owner_nonce(nonce: Optional[str]) -> None:

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -45,16 +45,36 @@ from dataclasses import asdict
 from pathlib import Path
 from typing import Any, Optional
 
-from fastapi import APIRouter, File, Form, HTTPException, Query, UploadFile, WebSocket, WebSocketDisconnect, status as http_status
+from fastapi import APIRouter, File, Form, HTTPException, Query, Request, UploadFile, WebSocket, WebSocketDisconnect, status as http_status
 from fastapi.responses import FileResponse
 from pydantic import BaseModel, Field
 
 from hermes_cli import kanban_db
 from hermes_cli import kanban_diagnostics as kd
+from hermes_cli.dashboard_auth.token_auth import register_token_route
 
 log = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+def register_owner_token_routes() -> None:
+    register_token_route("/api/plugins/kanban/owner-snapshot")
+    register_token_route("/api/plugins/kanban/owner-events")
+
+
+register_owner_token_routes()
+router.add_event_handler("startup", register_owner_token_routes)
+
+
+def _require_owner_read(request: Request) -> None:
+    principal = getattr(request.state, "token_principal", None)
+    if principal is not None and (
+        getattr(principal, "provider", None) == "dashboard-internal"
+        or _OWNER_READ_SCOPE in set(getattr(principal, "scopes", ()))
+    ):
+        return
+    raise HTTPException(status_code=403, detail="owner-read scope required")
 
 
 # ---------------------------------------------------------------------------
@@ -154,6 +174,12 @@ BOARD_COLUMNS: list[str] = [
 
 
 _CARD_SUMMARY_PREVIEW_CHARS = 200
+_OWNER_CONTRACT_VERSION = 1
+_OWNER_SNAPSHOT_DEFAULT_LIMIT = 1_000
+_OWNER_SNAPSHOT_MAX_LIMIT = 10_000
+_OWNER_EVENTS_DEFAULT_LIMIT = 200
+_OWNER_EVENTS_MAX_LIMIT = 1_000
+_OWNER_READ_SCOPE = "kanban:owner:read"
 
 
 def _task_dict(
@@ -185,6 +211,68 @@ def _event_dict(event: kanban_db.Event) -> dict[str, Any]:
         "payload": event.payload,
         "created_at": event.created_at,
         "run_id": event.run_id,
+    }
+
+
+def _owner_identity(board: Optional[str]) -> tuple[str, str]:
+    from hermes_cli.profiles import get_active_profile_name
+
+    board_id = board or kanban_db.get_current_board()
+    return get_active_profile_name(), board_id
+
+
+def _owner_event_cursor(conn: sqlite3.Connection) -> int:
+    """Return the monotonic task-event sequence, including deleted rows."""
+    sequence = conn.execute(
+        "SELECT seq FROM sqlite_sequence WHERE name = 'task_events'"
+    ).fetchone()
+    maximum = conn.execute(
+        "SELECT COALESCE(MAX(id), 0) FROM task_events"
+    ).fetchone()
+    return max(int(sequence[0]) if sequence is not None else 0, int(maximum[0]))
+
+
+def _owner_task(row: sqlite3.Row) -> dict[str, Any]:
+    task_id = row["id"]
+    title = row["title"]
+    created_by = row["created_by"]
+    created_at = row["created_at"]
+    if (
+        not isinstance(task_id, str) or not task_id
+        or not isinstance(title, str) or not title.strip()
+        or not isinstance(created_by, str) or not created_by.strip()
+        or type(created_at) is not int or created_at < 0
+    ):
+        raise HTTPException(
+            status_code=409,
+            detail="Kanban task has malformed immutable creation identity",
+        )
+    return {
+        "id": task_id,
+        "title": title,
+        "created_by": created_by,
+        "created_at": created_at,
+    }
+
+
+def _owner_event(row: sqlite3.Row) -> dict[str, Any]:
+    try:
+        payload = json.loads(row["payload"]) if row["payload"] else None
+    except (TypeError, json.JSONDecodeError) as exc:
+        raise HTTPException(
+            status_code=409,
+            detail="Kanban creation provenance payload is malformed",
+        ) from exc
+    if row["kind"] == "created" and not isinstance(payload, dict):
+        raise HTTPException(
+            status_code=409,
+            detail="Kanban creation provenance payload is malformed",
+        )
+    return {
+        "id": int(row["event_id"]),
+        "kind": row["kind"],
+        "payload": payload,
+        "created_at": int(row["event_created_at"]),
     }
 
 
@@ -372,6 +460,161 @@ def _links_for(conn: sqlite3.Connection, task_id: str) -> dict[str, list[str]]:
         )
     ]
     return {"parents": parents, "children": children}
+
+
+# ---------------------------------------------------------------------------
+# Stable owner receipts for authenticated subsystem materializers
+# ---------------------------------------------------------------------------
+
+@router.get("/owner-snapshot")
+def owner_snapshot(
+    request: Request,
+    board: Optional[str] = Query(None, description="Kanban board slug (omit for current)"),
+    limit: int = Query(_OWNER_SNAPSHOT_DEFAULT_LIMIT),
+):
+    """Return one bounded board snapshot of immutable task-creation receipts.
+
+    This contract is for authenticated server-side plugin integrations that
+    materialize their own read models. It intentionally excludes dependency
+    edges and mutable task status. The returned event cursor is captured in the
+    same SQLite read transaction as the receipts, so callers can continue with
+    ``/owner-events`` without a snapshot/event gap.
+    """
+    _require_owner_read(request)
+    if not 1 <= limit <= _OWNER_SNAPSHOT_MAX_LIMIT:
+        raise HTTPException(
+            status_code=400,
+            detail=f"limit must be 1..{_OWNER_SNAPSHOT_MAX_LIMIT}",
+        )
+    board = _resolve_board(board)
+    profile_id, board_id = _owner_identity(board)
+    conn = _conn(board=board)
+    try:
+        conn.execute("BEGIN")
+        task_rows = conn.execute(
+            "SELECT id, title, status, created_by, created_at FROM tasks "
+            "ORDER BY id ASC LIMIT ?",
+            (limit + 1,),
+        ).fetchall()
+        if len(task_rows) > limit:
+            raise HTTPException(
+                status_code=413,
+                detail=f"Kanban board exceeds the requested {limit}-task snapshot bound",
+            )
+        task_ids = [row["id"] for row in task_rows]
+        created_by_task: dict[str, list[sqlite3.Row]] = {task_id: [] for task_id in task_ids}
+        if task_ids:
+            placeholders = ",".join("?" for _ in task_ids)
+            event_rows = conn.execute(
+                "SELECT id AS event_id, task_id, kind, payload, "
+                "created_at AS event_created_at FROM task_events "
+                f"WHERE kind = 'created' AND task_id IN ({placeholders}) "
+                "ORDER BY id ASC",
+                tuple(task_ids),
+            ).fetchall()
+            for row in event_rows:
+                created_by_task[row["task_id"]].append(row)
+        cursor = _owner_event_cursor(conn)
+        receipts = []
+        for task_row in task_rows:
+            task_id = task_row["id"]
+            creation_rows = created_by_task[task_id]
+            if len(creation_rows) != 1:
+                raise HTTPException(
+                    status_code=409,
+                    detail=f"Kanban task {task_id} does not have exactly one creation receipt",
+                )
+            receipts.append({
+                "task": _owner_task(task_row),
+                "created_event": _owner_event(creation_rows[0]),
+                "archived": task_row["status"] == "archived",
+            })
+        return {
+            "contract_version": _OWNER_CONTRACT_VERSION,
+            "profile_id": profile_id,
+            "board_id": board_id,
+            "complete": True,
+            "task_count": len(receipts),
+            "event_cursor": cursor,
+            "receipts": receipts,
+        }
+    finally:
+        if conn.in_transaction:
+            conn.rollback()
+        conn.close()
+
+
+@router.get("/owner-events")
+def owner_events(
+    request: Request,
+    board: Optional[str] = Query(None, description="Kanban board slug (omit for current)"),
+    after: int = Query(0),
+    limit: int = Query(_OWNER_EVENTS_DEFAULT_LIMIT),
+):
+    """Return a cursor-safe bounded slice of topology-materialization receipts."""
+    _require_owner_read(request)
+    if after < 0:
+        raise HTTPException(status_code=400, detail="after must be non-negative")
+    if not 1 <= limit <= _OWNER_EVENTS_MAX_LIMIT:
+        raise HTTPException(
+            status_code=400,
+            detail=f"limit must be 1..{_OWNER_EVENTS_MAX_LIMIT}",
+        )
+    board = _resolve_board(board)
+    profile_id, board_id = _owner_identity(board)
+    conn = _conn(board=board)
+    try:
+        conn.execute("BEGIN")
+        latest_cursor = _owner_event_cursor(conn)
+        if after > latest_cursor:
+            raise HTTPException(
+                status_code=409,
+                detail="owner event cursor is ahead of the authoritative stream",
+            )
+        rows = conn.execute(
+            "SELECT e.id AS event_id, e.task_id, e.kind, e.payload, "
+            "e.created_at AS event_created_at, "
+            "t.id, t.title, t.created_by, t.created_at "
+            "FROM task_events e LEFT JOIN tasks t ON t.id = e.task_id "
+            "WHERE e.id > ? ORDER BY e.id ASC LIMIT ?",
+            (after, limit + 1),
+        ).fetchall()
+        has_more = len(rows) > limit
+        scanned = rows[:limit]
+        events = []
+        for row in scanned:
+            if row["kind"] not in {"created", "archived", "edited"}:
+                continue
+            if row["id"] is None:
+                raise HTTPException(
+                    status_code=409,
+                    detail="Kanban materialization event references a missing task",
+                )
+            event = {
+                **_owner_event(row),
+                "task": _owner_task(row),
+            }
+            if row["kind"] == "edited":
+                event["kind"] = "updated"
+            events.append(event)
+        next_cursor = (
+            int(scanned[-1]["event_id"])
+            if has_more
+            else latest_cursor
+        )
+        return {
+            "contract_version": _OWNER_CONTRACT_VERSION,
+            "profile_id": profile_id,
+            "board_id": board_id,
+            "after": after,
+            "next_cursor": next_cursor,
+            "has_more": has_more,
+            "events": events,
+        }
+    finally:
+        if conn.in_transaction:
+            conn.rollback()
+        conn.close()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_dashboard_token_auth.py
+++ b/tests/hermes_cli/test_dashboard_token_auth.py
@@ -127,6 +127,7 @@ class _FakeRequest:
             pass
 
         self.state = _State()
+        self.app = type("App", (), {"state": _State()})()
 
 
 def _run(coro):
@@ -233,5 +234,20 @@ def test_seam_rejects_wrong_token_401():
     )
     resp = _run(token_auth.token_auth_middleware(req, _call_next_ok))
     assert resp.status_code == 401
+
+
+def test_seam_accepts_exact_server_internal_bearer_on_registered_route():
+    token_auth.register_token_route("/api/plugins/kanban/owner-snapshot")
+    req = _FakeRequest(
+        path="/api/plugins/kanban/owner-snapshot",
+        headers={"authorization": "Bearer server-secret"},
+    )
+    req.app.state.internal_api_token = "server-secret"
+
+    resp = _run(token_auth.token_auth_middleware(req, _call_next_ok))
+
+    assert resp.status_code == 200
+    assert req.state.token_authenticated is True
+    assert req.state.token_principal.provider == "dashboard-internal"
 
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -213,6 +213,17 @@ class TestSessionTokenInjection:
             assert ws._resolve_session_token() == "generated-token"
         token_urlsafe.assert_called_once_with(32)
 
+    def test_ssh_session_token_rotation_updates_internal_bearer(self):
+        import hermes_cli.web_server as ws
+
+        original = ws._SESSION_TOKEN
+        try:
+            ws._apply_ssh_session_token("ssh-rotated-token")
+            assert ws._SESSION_TOKEN == "ssh-rotated-token"
+            assert ws.app.state.internal_api_token == "ssh-rotated-token"
+        finally:
+            ws._apply_ssh_session_token(original)
+
     def test_session_token_resolution_preserves_loaded_app_auth(self, monkeypatch):
         import hermes_cli.web_server as ws
         from starlette.testclient import TestClient
@@ -4145,7 +4156,6 @@ class TestPluginAPIAuth:
         # With auth: handler runs.
         resp = self.auth_client.get("/api/plugins/example/hello")
         assert resp.status_code == 200
-
 
     def test_plugin_patch_requires_auth(self):
         """Plugin PATCH routes should return 401 without a valid session token.

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -20,6 +20,8 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from hermes_cli import kanban_db as kb
+from hermes_cli.dashboard_auth import TokenPrincipal
+from hermes_cli.dashboard_auth.token_auth import is_token_route
 
 
 # ---------------------------------------------------------------------------
@@ -57,6 +59,17 @@ def kanban_home(tmp_path, monkeypatch):
 @pytest.fixture
 def client(kanban_home):
     app = FastAPI()
+
+    @app.middleware("http")
+    async def owner_principal(request, call_next):
+        request.state.token_principal = TokenPrincipal(
+            principal="dashboard-internal",
+            provider="dashboard-internal",
+            scopes=("dashboard-internal",),
+        )
+        request.state.token_authenticated = True
+        return await call_next(request)
+
     app.include_router(_load_plugin_router(), prefix="/api/plugins/kanban")
     return TestClient(app)
 
@@ -218,6 +231,267 @@ def test_task_detail_includes_links_and_events(client):
 
     # Events exist from creation.
     assert len(data["events"]) >= 1
+
+
+def test_owner_snapshot_returns_bounded_creation_receipts_with_exact_provenance(
+    client, kanban_home,
+):
+    conn = kb.connect()
+    try:
+        root_id = kb.create_task(
+            conn, title="Reviewed semantic root", created_by="agent:main",
+            triage=True, board="default", priority=0,
+        )
+        child_ids = kb.decompose_triage_task(
+            conn, root_id, root_assignee="vlad",
+            children=[{"title": "Technical child", "assignee": "vlad"}],
+            author="auto-decomposer", auto_promote=False,
+        )
+        assert child_ids is not None
+    finally:
+        conn.close()
+
+    response = client.get(
+        "/api/plugins/kanban/owner-snapshot?board=default&limit=10"
+    )
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["contract_version"] == 1
+    assert payload["profile_id"] == "default"
+    assert payload["board_id"] == "default"
+    assert payload["complete"] is True
+    assert payload["task_count"] == 2
+    assert payload["event_cursor"] >= 2
+    receipts = {row["task"]["id"]: row for row in payload["receipts"]}
+    assert receipts[root_id]["task"] == {
+        "id": root_id,
+        "title": "Reviewed semantic root",
+        "created_by": "agent:main",
+        "created_at": receipts[root_id]["task"]["created_at"],
+    }
+    child_receipt = receipts[child_ids[0]]
+    assert child_receipt["task"]["created_by"] == "auto-decomposer"
+    assert child_receipt["created_event"]["payload"] == {
+        "by": "auto-decomposer", "from_decompose_of": root_id,
+    }
+    assert child_receipt["archived"] is False
+
+
+def test_owner_contract_routes_opt_into_generic_bearer_auth():
+    _load_plugin_router()
+    assert is_token_route("/api/plugins/kanban/owner-snapshot")
+    assert is_token_route("/api/plugins/kanban/owner-events")
+
+
+def test_owner_contract_rejects_an_unrelated_provider_scope(kanban_home):
+    app = FastAPI()
+
+    @app.middleware("http")
+    async def drain_principal(request, call_next):
+        request.state.token_principal = TokenPrincipal(
+            principal="drain-service", provider="drain", scopes=("drain",),
+        )
+        request.state.token_authenticated = True
+        return await call_next(request)
+
+    app.include_router(_load_plugin_router(), prefix="/api/plugins/kanban")
+
+    response = TestClient(app).get(
+        "/api/plugins/kanban/owner-snapshot?board=default&limit=10"
+    )
+
+    assert response.status_code == 403
+
+
+def test_owner_contract_accepts_the_exact_owner_read_scope(kanban_home):
+    app = FastAPI()
+
+    @app.middleware("http")
+    async def owner_scope_principal(request, call_next):
+        request.state.token_principal = TokenPrincipal(
+            principal="portfolio-service", provider="service-token",
+            scopes=("kanban:owner:read",),
+        )
+        request.state.token_authenticated = True
+        return await call_next(request)
+
+    app.include_router(_load_plugin_router(), prefix="/api/plugins/kanban")
+
+    response = TestClient(app).get(
+        "/api/plugins/kanban/owner-snapshot?board=default&limit=10"
+    )
+
+    assert response.status_code == 200
+
+
+def test_owner_snapshot_fails_closed_when_board_exceeds_requested_bound(client):
+    for index in range(2):
+        response = client.post(
+            "/api/plugins/kanban/tasks",
+            json={"title": f"root-{index}"},
+        )
+        assert response.status_code == 200
+
+    response = client.get(
+        "/api/plugins/kanban/owner-snapshot?board=default&limit=1"
+    )
+
+    assert response.status_code == 413
+    assert "exceeds" in response.json()["detail"]
+
+
+def test_owner_events_advance_stable_cursor_and_emit_only_materialization_receipts(
+    client,
+):
+    created = client.post(
+        "/api/plugins/kanban/tasks", json={"title": "root"},
+    ).json()["task"]
+    initial = client.get(
+        "/api/plugins/kanban/owner-snapshot?board=default&limit=10"
+    ).json()
+    cursor = initial["event_cursor"]
+
+    conn = kb.connect()
+    try:
+        with kb.write_txn(conn):
+            kb._append_event(conn, created["id"], "commented", {"len": 4})
+        child_id = kb.create_task(
+            conn, title="later root", created_by="agent:main", board="default",
+        )
+        assert kb.archive_task(conn, created["id"])
+    finally:
+        conn.close()
+
+    response = client.get(
+        f"/api/plugins/kanban/owner-events?board=default&after={cursor}&limit=20"
+    )
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["profile_id"] == "default"
+    assert payload["board_id"] == "default"
+    assert payload["after"] == cursor
+    assert payload["next_cursor"] > cursor
+    assert payload["has_more"] is False
+    assert [(event["kind"], event["task"]["id"]) for event in payload["events"]] == [
+        ("created", child_id), ("archived", created["id"]),
+    ]
+    assert payload["events"][0]["payload"]["parents"] == []
+
+
+def test_owner_events_reject_a_cursor_ahead_of_the_authoritative_stream(client):
+    client.post("/api/plugins/kanban/tasks", json={"title": "root"})
+    cursor = client.get(
+        "/api/plugins/kanban/owner-snapshot?board=default&limit=10"
+    ).json()["event_cursor"]
+
+    response = client.get(
+        f"/api/plugins/kanban/owner-events?board=default&after={cursor + 1}&limit=20"
+    )
+
+    assert response.status_code == 409
+    assert "cursor" in response.json()["detail"]
+
+
+def test_owner_cursor_never_regresses_when_the_latest_task_is_hard_deleted(client):
+    created = client.post(
+        "/api/plugins/kanban/tasks", json={"title": "temporary"},
+    ).json()["task"]
+    before = client.get(
+        "/api/plugins/kanban/owner-snapshot?board=default&limit=10"
+    ).json()["event_cursor"]
+    conn = kb.connect()
+    try:
+        assert kb.delete_task(conn, created["id"])
+    finally:
+        conn.close()
+
+    after_delete = client.get(
+        "/api/plugins/kanban/owner-snapshot?board=default&limit=10"
+    ).json()
+    assert after_delete["task_count"] == 0
+    assert after_delete["event_cursor"] == before
+    deleted_gap = client.get(
+        "/api/plugins/kanban/owner-events?board=default&after=0&limit=20"
+    ).json()
+    assert deleted_gap["events"] == []
+    assert deleted_gap["next_cursor"] == before
+
+    next_task = client.post(
+        "/api/plugins/kanban/tasks", json={"title": "next"},
+    ).json()["task"]
+    events = client.get(
+        f"/api/plugins/kanban/owner-events?board=default&after={before}&limit=20"
+    ).json()
+    assert events["next_cursor"] > before
+    assert [(event["kind"], event["task"]["id"]) for event in events["events"]] == [
+        ("created", next_task["id"]),
+    ]
+
+
+def test_owner_cursor_crosses_a_trailing_deleted_gap_after_a_surviving_event(client):
+    kept = client.post(
+        "/api/plugins/kanban/tasks", json={"title": "kept"},
+    ).json()["task"]
+    doomed = client.post(
+        "/api/plugins/kanban/tasks", json={"title": "doomed"},
+    ).json()["task"]
+    latest = client.get(
+        "/api/plugins/kanban/owner-snapshot?board=default&limit=10"
+    ).json()["event_cursor"]
+    conn = kb.connect()
+    try:
+        assert kb.delete_task(conn, doomed["id"])
+    finally:
+        conn.close()
+
+    response = client.get(
+        "/api/plugins/kanban/owner-events?board=default&after=0&limit=20"
+    ).json()
+
+    assert [event["task"]["id"] for event in response["events"]] == [kept["id"]]
+    assert response["next_cursor"] == latest
+    assert response["has_more"] is False
+
+
+def test_owner_events_publish_current_title_updates_without_rewriting_creation(client):
+    task = client.post(
+        "/api/plugins/kanban/tasks", json={"title": "Original"},
+    ).json()["task"]
+    cursor = client.get(
+        "/api/plugins/kanban/owner-snapshot?board=default&limit=10"
+    ).json()["event_cursor"]
+    response = client.patch(
+        f"/api/plugins/kanban/tasks/{task['id']}", json={"title": "Renamed"},
+    )
+    assert response.status_code == 200
+
+    payload = client.get(
+        f"/api/plugins/kanban/owner-events?board=default&after={cursor}&limit=20"
+    ).json()
+
+    assert [(event["kind"], event["task"]["title"]) for event in payload["events"]] == [
+        ("updated", "Renamed"),
+    ]
+
+
+def test_owner_snapshot_retains_archived_receipts_for_provenance_audit(client):
+    task = client.post(
+        "/api/plugins/kanban/tasks", json={"title": "Archived topology node"},
+    ).json()["task"]
+    conn = kb.connect()
+    try:
+        assert kb.archive_task(conn, task["id"])
+    finally:
+        conn.close()
+
+    snapshot = client.get(
+        "/api/plugins/kanban/owner-snapshot?board=default&limit=10"
+    ).json()
+
+    receipt = next(row for row in snapshot["receipts"] if row["task"]["id"] == task["id"])
+    assert receipt["archived"] is True
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Adds a generic, authenticated, bounded Kanban owner-read boundary for plugins that need to materialize task ownership and creation provenance without reading Kanban's private SQLite database or invoking the CLI.

The Kanban Dashboard plugin now exposes:

- a bounded, complete owner snapshot for cold materialization;
- a monotonic owner event stream for incremental catch-up;
- exact creation provenance, including `created_by` and `from_decompose_of`;
- current title and archived state;
- cursor semantics that remain safe when tasks are hard-deleted.

External bearer providers must have the exact `kanban:owner:read` scope. Unrelated provider scopes fail closed. Existing authenticated server-internal callers continue to use the supported internal path.

This is a generic plugin boundary motivated by the standalone Hermes Portfolio plugin. It contains no Portfolio-specific core behavior, does not expose dependency topology, and does not add a model-facing tool.

## Related Issue

N/A — this capability gap was found while building a standalone plugin. Searches for existing open and closed PRs/issues did not find an equivalent Kanban owner snapshot/event contract.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/kanban/dashboard/plugin_api.py`
  - add bounded owner snapshot and event endpoints;
  - emit only materialization-relevant receipts;
  - preserve stable creation identity, decomposition provenance, title, archived state, and monotonic cursor behavior;
  - reject incomplete, over-bound, or future-cursor requests.
- `hermes_cli/dashboard_auth/token_auth.py`
  - add the dedicated `kanban:owner:read` scope to the authenticated route policy.
- `hermes_cli/web_server.py`
  - wire the owner-read routes through the existing bearer authentication boundary.
- Tests
  - cover exact-scope authorization and unrelated-scope rejection;
  - cover bounded snapshots, stable cursors, archive events, hard-delete gaps, provenance, and server integration.

## Security Boundary

This PR changes an authenticated read boundary, not task mutation behavior.

- The routes are read-only.
- External bearer callers require the exact `kanban:owner:read` scope.
- Unrelated provider scopes receive `403`.
- Snapshot size and event pagination are bounded and fail closed.
- No credentials or provider secrets are returned.
- No private Kanban database path is exposed to plugin consumers.

## How to Test

1. Run the affected suite through the repository test wrapper:
   ```bash
   scripts/run_tests.sh \
     tests/hermes_cli/test_dashboard_token_auth.py \
     tests/hermes_cli/test_web_server.py \
     tests/plugins/test_kanban_dashboard_plugin.py
   ```
2. Verify exact owner scope acceptance and unrelated-scope rejection.
3. Verify a bounded owner snapshot preserves creation provenance and archived state.
4. Verify event catch-up advances a stable cursor, omits irrelevant events, and remains safe after hard deletion.

Local result: **233 affected tests passed** through `scripts/run_tests.sh`.

Tested locally on **Ubuntu 22.04 x86_64, Python 3.11.15**.

## AI Assistance Disclosure

This implementation was developed and locally verified with Hermes Agent under the contributor's direction. The security review referenced during development was an independent **agent review pass**, not a review by a Nous Research maintainer or an external security firm. The contributor is submitting the change and remains responsible for the pull request.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature
- [x] I've run the affected tests through `scripts/run_tests.sh` and they pass
- [x] I've added tests for the new behavior
- [x] I've tested on Ubuntu 22.04 x86_64 with Python 3.11.15

### Documentation & Housekeeping

- [x] Relevant behavior and security-boundary details are documented in this PR; no user-facing documentation change is required
- [x] `cli-config.yaml.example` is unchanged because no config keys were added or changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` are unchanged because this uses the existing plugin/auth architecture
- [x] Cross-platform impact was considered; the change uses existing Python/FastAPI/SQLite abstractions and introduces no platform-specific process or filesystem behavior
- [x] No model tool description or schema changes are required

## Screenshots / Logs

Not applicable; this PR adds a server/plugin contract and automated coverage rather than a user-facing interface.
