### PR TITLE
fix(cli): fail closed on Kanban skill preload timeout

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8354,6 +8354,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         and safe to call from any other consumer of the system prompt.
         Raises ``ValueError`` when EVERY requested skill was unknown —
         the same contract the old synchronous path enforced in cmd_chat.
+        Raises ``TimeoutError`` rather than starting a Kanban worker without
+        its pinned skills when the preload is still running after the join.
         """
         if getattr(self, "_preload_skills_finalized", False):
             return
@@ -8362,6 +8364,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             self._preload_skills_finalized = True
             return
         thread.join(timeout=120)
+        if thread.is_alive() and os.environ.get("HERMES_KANBAN_TASK"):
+            raise TimeoutError("Pinned skill preload timed out after 120 seconds")
         self._preload_skills_finalized = True
         err = getattr(self, "_preload_skills_error", None)
         if err is not None:

--- a/tests/cli/test_cli_preloaded_skills.py
+++ b/tests/cli/test_cli_preloaded_skills.py
@@ -54,6 +54,11 @@ class _DummyCLI:
         self.session_id = "session-123"
         self.system_prompt = "base prompt"
         self.preloaded_skills = []
+        self._preload_skills_thread: MagicMock | None = None
+        self._preload_skills_result = None
+        self._preload_skills_error = None
+        self._preload_skills_requested = []
+        self._preload_skills_finalized = False
 
     def show_banner(self):
         return None
@@ -132,6 +137,42 @@ def test_main_raises_for_unknown_preloaded_skill(monkeypatch):
     # finalized (agent init), preserving the fail-loud contract.
     with pytest.raises(ValueError, match=r"Unknown skill\(s\): missing-skill"):
         _real_finalize(created["cli"])
+
+
+def test_kanban_worker_fails_closed_when_skill_preload_times_out(monkeypatch):
+    cli_obj = _DummyCLI()
+    preload_thread = MagicMock()
+    preload_thread.is_alive.return_value = True
+    cli_obj._preload_skills_thread = preload_thread
+    cli_obj._preload_skills_result = None
+    cli_obj._preload_skills_error = None
+    cli_obj._preload_skills_finalized = False
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "task-123")
+
+    with pytest.raises(TimeoutError, match="Pinned skill preload timed out"):
+        _real_finalize(cli_obj)
+
+    preload_thread.join.assert_called_once_with(timeout=120)
+    assert cli_obj._preload_skills_finalized is False
+    assert cli_obj.preloaded_skills == []
+
+
+def test_interactive_cli_keeps_skill_preload_timeout_fallback(monkeypatch):
+    cli_obj = _DummyCLI()
+    preload_thread = MagicMock()
+    preload_thread.is_alive.return_value = True
+    cli_obj._preload_skills_thread = preload_thread
+    cli_obj._preload_skills_result = None
+    cli_obj._preload_skills_error = None
+    cli_obj._preload_skills_finalized = False
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+
+    _real_finalize(cli_obj)
+
+    preload_thread.join.assert_called_once_with(timeout=120)
+    assert cli_obj._preload_skills_finalized is True
+    assert cli_obj.system_prompt == "base prompt"
+    assert cli_obj.preloaded_skills == []
 
 
 def test_show_banner_does_not_print_skills():


### PR DESCRIPTION
## Problem

A dispatcher-owned Kanban worker can start without its requested pinned skills when the asynchronous skill-preload thread is still alive after `finalize_preloaded_skills()` waits 120 seconds. The finalizer currently marks the preload complete and continues, which weakens any policy or safety boundary carried by those skills.

## Approach

- After the existing bounded join, detect a still-running preload thread.
- Fail closed with `TimeoutError` when `HERMES_KANBAN_TASK` identifies a durable Kanban worker.
- Preserve the existing best-effort timeout behavior for interactive/non-Kanban CLI sessions.

## Tests

- Added a regression proving a Kanban worker raises before finalization when the preload thread remains alive.
- Added coverage proving interactive CLI behavior remains unchanged.
- Canonical focused suite: `5 passed`.
- Related Kanban spawn tests: `4 passed` in independent review.
- `py_compile`, Ruff, Windows-footgun scan, and `git diff --check`: passed.

## Risk

Small and scoped to the timeout edge after the existing 120-second wait. Normal completed preloads are unchanged. The durable worker fails rather than executing without its requested skills; interactive callers retain legacy fallback behavior.
