### PR TITLE
fix(compression): use the route-aware pruned estimate in the mid-turn pre-API guard

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -122,6 +122,51 @@ RUN_BUDGET_WRAPUP_NOTICE = (
 )
 
 
+def _midturn_request_pressure_tokens(
+    agent: Any,
+    api_messages: List[Dict[str, Any]],
+    effective_system: str,
+    approx_tokens: int,
+) -> int:
+    """Token figure the mid-turn pre-API compression guard compares.
+
+    When the upcoming request is eligible for native Responses compaction the
+    transport will checkpoint-prune the payload before sending, so the generic
+    durable-history estimate overstates the wire by orders of magnitude on a
+    compacted session and fires a 600s local compression the main request
+    never needed (#96995). Mirror the turn-prologue preflight (#96644 /
+    #96155): use the pruned estimate when native eligibility is proven, the
+    generic message+tools figure otherwise.
+
+    The native estimator adds the system prompt and tool schemas itself and
+    its converter skips system-role rows, so passing the assembled
+    ``api_messages`` (which carries the system row) alongside
+    ``effective_system`` counts the system prompt exactly once.
+    """
+    try:
+        from agent.codex_responses_adapter import (
+            estimate_native_responses_preflight_tokens,
+        )
+
+        native = estimate_native_responses_preflight_tokens(
+            agent,
+            api_messages,
+            system_prompt=effective_system or "",
+            tools=getattr(agent, "tools", None) or None,
+        )
+        if isinstance(native, int) and not isinstance(native, bool) and native >= 0:
+            return native
+    except Exception:
+        logger.debug(
+            "native Responses mid-turn estimate unavailable; "
+            "using generic transcript estimate",
+            exc_info=True,
+        )
+    return approx_tokens + (
+        _estimate_tools_tokens_rough(agent.tools) if agent.tools else 0
+    )
+
+
 def _review_input_budget_exhausted(agent: Any) -> bool:
     """True when a detached review fork has replayed its aggregate input budget.
 
@@ -2588,8 +2633,14 @@ def run_conversation(
         # separately (compression needs them: 50+ tools = 20-30K tokens).
         # total_chars is a rough (~) proxy — verbose log + hook metric only.
         approx_tokens = estimate_messages_tokens_rough(api_messages)
-        request_pressure_tokens = approx_tokens + (
-            _estimate_tools_tokens_rough(agent.tools) if agent.tools else 0
+        # Route-aware pressure: when the upcoming request is eligible for
+        # native Responses compaction the transport will checkpoint-prune
+        # the payload before sending — the generic durable-history figure
+        # overstates the wire by orders of magnitude on a compacted session
+        # and fires a 600s local compression the main request never needed
+        # (#96995, mirroring the turn-prologue preflight #96644/#96155).
+        request_pressure_tokens = _midturn_request_pressure_tokens(
+            agent, api_messages, effective_system or "", approx_tokens
         )
         total_chars = approx_tokens * 4
         # Stash this request's rough estimate so update_from_response() can

--- a/tests/agent/test_native_preflight_estimate.py
+++ b/tests/agent/test_native_preflight_estimate.py
@@ -98,3 +98,51 @@ def test_preflight_wrapper_falls_back_to_generic_when_ineligible():
     generic = estimate_request_tokens_rough(messages)
 
     assert _preflight_request_tokens(agent, messages, "") == generic
+
+
+# ── Mid-turn pre-API guard parity (#96995) ────────────────────────────────
+# The mid-turn guard in conversation_loop must measure the same pruned wire
+# payload the turn-prologue preflight does (#96644/#96155); before #96995 it
+# used the generic durable-history estimate and false-tripped 600s local
+# compression on compacted native-Codex sessions.
+
+
+def test_midturn_pressure_uses_pruned_estimate_when_eligible():
+    from agent.conversation_loop import (
+        _midturn_request_pressure_tokens,
+        estimate_messages_tokens_rough,
+    )
+
+    agent = _codex_agent()
+    messages = [{"role": "system", "content": "be brief"}] + _history_with_checkpoint()
+    native = estimate_native_responses_preflight_tokens(
+        agent, messages, system_prompt="be brief"
+    )
+    generic = estimate_messages_tokens_rough(messages)
+
+    assert native is not None
+    assert generic > native * 2
+    # The assembled api_messages carry the system row; the helper must not
+    # double-count it (converter skips system rows, system_prompt adds it once).
+    assert _midturn_request_pressure_tokens(
+        agent, messages, "be brief", generic
+    ) == native
+
+
+def test_midturn_pressure_falls_back_to_generic_plus_tools_when_ineligible():
+    from agent.conversation_loop import (
+        _estimate_tools_tokens_rough,
+        _midturn_request_pressure_tokens,
+        estimate_messages_tokens_rough,
+    )
+
+    agent = _codex_agent(
+        api_mode="chat_completions",
+        tools=[{"type": "function", "function": {"name": "t", "parameters": {}}}],
+    )
+    messages = [{"role": "system", "content": "be brief"}] + _history_with_checkpoint()
+    approx = estimate_messages_tokens_rough(messages)
+
+    assert _midturn_request_pressure_tokens(
+        agent, messages, "be brief", approx
+    ) == approx + _estimate_tools_tokens_rough(agent.tools)


### PR DESCRIPTION
## What does this PR do?

Aligns the mid-turn pre-API compression guard with the turn-prologue preflight so both measure the same route-aware wire payload on native-Codex sessions.

The #96155 fix (#96644) made the **turn-prologue** preflight estimate the checkpoint-pruned native Responses payload. The independent **mid-turn** guard in `conversation_loop` still estimated the full assembled durable history, so on a compacted native-Codex session it false-triggered a 600-second local compression the main request never needed: the issue's deterministic, credential-free probe on clean main shows the generic figure at 1,037,241 tokens versus 6,036 pruned (171x), and the live sequence shows the actual request then fitting comfortably (164k input against a 765k threshold) after the wasted ten-minute compression (#96995).

The guard's pressure figure is extracted into `_midturn_request_pressure_tokens`, which mirrors the turn-prologue: when native Responses compaction is proven eligible it uses `estimate_native_responses_preflight_tokens` (checkpoint-pruned, system prompt and tool schemas included); otherwise it keeps the generic message+tools figure. Passing the assembled `api_messages` (which carry the system row) alongside `effective_system` counts the system prompt exactly once — the estimator's converter skips system-role rows and adds the prompt separately. `total_chars` (a verbose-log proxy) and every non-codex path are unchanged.

## Related Issue

Fixes #96995

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/conversation_loop.py` — new module-level `_midturn_request_pressure_tokens(agent, api_messages, effective_system, approx_tokens)`; the pre-API guard now computes `request_pressure_tokens` through it instead of the unconditional generic `estimate + tools` figure.
- `tests/agent/test_native_preflight_estimate.py` — two regressions mirroring the prologue tests: eligible route returns the pruned estimate against the assembled (system-carrying) messages without double-counting the system prompt; ineligible route falls back to generic + tools exactly as before.

## How to Test

1. `python -m pytest tests/agent/test_native_preflight_estimate.py -q` — should pass (8 passed, including the two new regressions).
2. Red/green verified locally: with the `conversation_loop.py` change reverted, the two new mid-turn tests fail (helper absent); with this change all pass.
3. Adjacent suites unchanged: `tests/agent/test_compress_context_progress_timeout.py`, `test_compress_focus.py`, `test_compress_signal_leak.py` — 18 passed.
4. Deterministic probe from the issue: build the checkpointed synthetic history and compare — both the prologue and the mid-turn figure should now report the pruned estimate (below threshold) instead of the prologue below / mid-turn 171x above.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (targeted: preflight + compress suites — 8 and 18 passed)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.5 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (docstring on the new helper)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (pure-Python estimate routing)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
