### PR TITLE
fix(browser): fail closed when real-profile cookies don't survive launch

### DIFF
--- a/tests/tools/test_browser_real_profile.py
+++ b/tests/tools/test_browser_real_profile.py
@@ -124,6 +124,20 @@ class TestRealProfileCdpLaunch:
         import tools.browser_tool as bt
         bt._real_profile_cdp_cache.clear()
 
+    def _make_cookie_db(self, root, count=3):
+        """Build a real sqlite cookie DB in a profile copy dir."""
+        import sqlite3
+
+        (root / "Default").mkdir(parents=True, exist_ok=True)
+        db = root / "Default" / "Cookies"
+        con = sqlite3.connect(str(db))
+        con.execute("CREATE TABLE cookies (host_key TEXT, name TEXT, value TEXT, encrypted_value BLOB)")
+        for i in range(count):
+            con.execute("INSERT INTO cookies VALUES (?, ?, ?, ?)", (f".host{i}.com", f"c{i}", "", b"v11"))
+        con.commit()
+        con.close()
+        return db
+
     def test_consent_off_is_noop(self):
         import tools.browser_tool as bt
         self._reset()
@@ -214,6 +228,82 @@ class TestRealProfileCdpLaunch:
         assert closed["n"] == 1  # stale wrong-dir session was closed
         assert cdp == "http://127.0.0.1:41000"
         self._reset()
+
+    def test_launch_verifies_cookies_survive(self, tmp_path):
+        import tools.browser_tool as bt
+        self._reset()
+        self._make_cookie_db(tmp_path, count=3)
+        proc = Mock(returncode=0, stdout="", stderr="")
+        with patch.object(bt, "_use_real_profile", return_value=True), \
+             patch("hermes_cli.browser_connect.detect_default_chromium", return_value="chrome"), \
+             patch("hermes_cli.browser_connect.snapshot_real_profile", return_value=(str(tmp_path), None)), \
+             patch.object(bt, "_agent_browser_get_cdp",
+                          side_effect=[None, "http://127.0.0.1:41000"]), \
+             patch.object(bt, "_find_agent_browser", return_value="/usr/bin/agent-browser"), \
+             patch.object(bt.subprocess, "run", return_value=proc), \
+             patch.object(bt, "_is_headed_mode", return_value=False), \
+             patch.object(bt, "_live_cookie_count", return_value=3):
+            cdp, err = bt._real_profile_cdp()
+        assert err is None
+        assert cdp == "http://127.0.0.1:41000"
+        self._reset()
+
+    def test_launch_fails_closed_when_cookies_wiped(self, tmp_path):
+        import tools.browser_tool as bt
+        self._reset()
+        self._make_cookie_db(tmp_path, count=3)
+        proc = Mock(returncode=0, stdout="", stderr="")
+        closed = {"n": 0}
+        with patch.object(bt, "_use_real_profile", return_value=True), \
+             patch("hermes_cli.browser_connect.detect_default_chromium", return_value="chrome"), \
+             patch("hermes_cli.browser_connect.snapshot_real_profile", return_value=(str(tmp_path), None)), \
+             patch.object(bt, "_agent_browser_get_cdp",
+                          side_effect=[None, "http://127.0.0.1:41000"]), \
+             patch.object(bt, "_find_agent_browser", return_value="/usr/bin/agent-browser"), \
+             patch.object(bt.subprocess, "run", return_value=proc), \
+             patch.object(bt, "_is_headed_mode", return_value=False), \
+             patch.object(bt, "_live_cookie_count", return_value=0), \
+             patch.object(bt, "_agent_browser_close_session",
+                          side_effect=lambda s: closed.__setitem__("n", closed["n"] + 1)):
+            cdp, err = bt._real_profile_cdp()
+        assert cdp is None
+        assert err and "signed out" in err
+        assert closed["n"] == 1
+        assert "cdp" not in bt._real_profile_cdp_cache
+        self._reset()
+
+    def test_launch_skips_verification_when_snapshot_has_no_cookies(self, tmp_path):
+        import tools.browser_tool as bt
+        self._reset()
+        proc = Mock(returncode=0, stdout="", stderr="")
+        live = Mock()
+        with patch.object(bt, "_use_real_profile", return_value=True), \
+             patch("hermes_cli.browser_connect.detect_default_chromium", return_value="chrome"), \
+             patch("hermes_cli.browser_connect.snapshot_real_profile", return_value=(str(tmp_path), None)), \
+             patch.object(bt, "_agent_browser_get_cdp",
+                          side_effect=[None, "http://127.0.0.1:41000"]), \
+             patch.object(bt, "_find_agent_browser", return_value="/usr/bin/agent-browser"), \
+             patch.object(bt.subprocess, "run", return_value=proc), \
+             patch.object(bt, "_is_headed_mode", return_value=False), \
+             patch.object(bt, "_live_cookie_count", live):
+            cdp, err = bt._real_profile_cdp()
+        assert err is None
+        assert cdp == "http://127.0.0.1:41000"
+        live.assert_not_called()
+        self._reset()
+
+    def test_live_cookie_count_parses_output(self):
+        import tools.browser_tool as bt
+        proc = Mock(returncode=0, stdout="SID=abc\nNID=def\n", stderr="")
+        with patch.object(bt, "_find_agent_browser", return_value="/usr/bin/agent-browser"), \
+             patch.object(bt, "_agent_browser_argv", side_effect=lambda c: [c]), \
+             patch.object(bt.subprocess, "run", return_value=proc):
+            assert bt._live_cookie_count("http://127.0.0.1:41000") == 2
+
+    def test_live_cookie_count_zero_on_error(self):
+        import tools.browser_tool as bt
+        with patch.object(bt, "_find_agent_browser", side_effect=FileNotFoundError):
+            assert bt._live_cookie_count("http://127.0.0.1:41000") == 0
 
     def test_cdp_on_data_dir_matches_devtoolsactiveport(self, tmp_path):
         import tools.browser_tool as bt

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1535,6 +1535,68 @@ def _agent_browser_close_session(session_name: str) -> None:
         logger.debug("real-profile session close failed: %s", e)
 
 
+def _count_snapshot_cookies(copy_dir: str) -> int:
+    """Count rows in the copied profile's cookie DB (the auth state we intended
+    to load). Handles both modern (Default/Network/Cookies) and legacy
+    (Default/Cookies) locations. Returns 0 when the DB is missing or unreadable
+    — an empty jar to verify against means there is nothing to verify.
+    """
+    import sqlite3
+
+    for rel in ("Default/Network/Cookies", "Default/Cookies"):
+        db = os.path.join(copy_dir, rel)
+        if not os.path.isfile(db):
+            continue
+        try:
+            con = sqlite3.connect(f"file:{db}?mode=ro", uri=True, timeout=2)
+            try:
+                cur = con.execute("SELECT COUNT(*) FROM cookies")
+                return int(cur.fetchone()[0])
+            finally:
+                con.close()
+        except Exception as e:
+            logger.debug("could not count snapshot cookies in %s: %s", db, e)
+            return 0
+    return 0
+
+
+def _live_cookie_count(cdp_url: str) -> int:
+    """Query the launched browser's live cookie jar via
+    ``agent-browser --cdp <port> cookies get``. Returns the number of cookies
+    the browser actually holds in memory. Returns 0 on ANY failure (missing
+    port, CLI not found, subprocess error/nonzero exit, unparseable output) —
+    the caller treats 0-with-expected>0 as a wiped jar and fails closed.
+    """
+    m = re.search(r":(\d+)", cdp_url or "")
+    if not m:
+        return 0
+    try:
+        browser_cmd = _find_agent_browser()
+    except FileNotFoundError:
+        return 0
+    try:
+        proc = subprocess.run(
+            [*_agent_browser_argv(browser_cmd), "--cdp", m.group(1), "cookies", "get"],
+            capture_output=True, text=True, timeout=15, env=_build_browser_env(),
+        )
+    except (subprocess.SubprocessError, OSError) as e:
+        logger.debug("real-profile live cookie query failed: %s", e)
+        return 0
+    if proc.returncode != 0 or not (proc.stdout or "").strip():
+        stderr_tail = (proc.stderr or "").strip().splitlines()
+        logger.debug(
+            "real-profile live cookie query rc=%s stderr=%s",
+            proc.returncode, stderr_tail[-1] if stderr_tail else "",
+        )
+        return 0
+    count = 0
+    for line in (proc.stdout or "").splitlines():
+        line = line.strip()
+        if line and "=" in line and not line.startswith("["):
+            count += 1
+    return count
+
+
 def _real_profile_cdp() -> tuple:
     """Resolve ``(cdp_url, error)`` for consented real-profile browsing.
 
@@ -1701,6 +1763,32 @@ def _real_profile_cdp() -> tuple:
                 "browser.use_real_profile is on, but the real-profile browser "
                 "started without exposing a devtools endpoint. Retry, or turn "
                 "the toggle off."
+            )
+        # Fail closed if the launched browser's cookie jar came up empty while the
+        # snapshot carried cookies: the backend may have launched Chromium with a
+        # mock keychain / headless cookie store that cannot decrypt keyring-encrypted
+        # cookies, silently signing the session out. Never downgrade a consented
+        # user to a throwaway browser.
+        expected = _count_snapshot_cookies(copy_dir)
+        if expected > 0:
+            live = _live_cookie_count(cdp)
+            if live <= 0:
+                _agent_browser_close_session(_REAL_PROFILE_SESSION)
+                _real_profile_cdp_cache.pop("cdp", None)
+                return None, (
+                    "browser.use_real_profile is on, but the launched browser's "
+                    "cookie store came up empty: the copied profile has "
+                    f"{expected} cookies but the session reports {live}. This usually "
+                    "means the browser backend launched Chromium with a mock keychain "
+                    "or headless cookie store that cannot decrypt your keyring-encrypted "
+                    "cookies, so the session would run signed out — refusing to "
+                    "silently downgrade. Try a browser backend that launches real "
+                    "Chrome without a mock keychain, or connect a real Chrome via "
+                    "browser.cdp_url."
+                )
+            logger.info(
+                "real-profile cookie verification passed: %d cookies live (%d snapshotted)",
+                live, expected,
             )
         _real_profile_cdp_cache["cdp"] = cdp
         logger.info("real-profile browser ready for %s at %s (%s)", browser, cdp, copy_dir)


### PR DESCRIPTION
## Summary

Fixes the real-profile browsing path (`browser.use_real_profile`) silently downgrading a consented user to a **signed-out** browser session.

**The bug:** Hermes snapshots the user's real Chrome profile (cookies copied via sqlite online-backup) and launches the browser backend on the copy. But agent-browser 0.26.0 (the pinned version) launches its Chromium with `--use-mock-keychain` and a headless cookie store. On Linux, real cookies are keyring-encrypted (v11 scheme) — a mock keychain cannot decrypt them, so Chrome **deletes the cookie rows at startup**. Result: the "real-profile" session comes up with 0 cookies, Hermes logs "real-profile browser ready" and proceeds — violating the documented fail-closed invariant ("a consented user is never silently downgraded to a throwaway browser").

**The fix:** after the copy-browser launches, verify its live cookie jar via `agent-browser --cdp <port> cookies get`. If the snapshot carried cookies but the session reports none, close the session and fail closed with an actionable error (mentioning the mock-keychain/headless cause and the `browser.cdp_url` workaround) instead of silently running signed out.

## Changes

- `tools/browser_tool.py`
  - `_count_snapshot_cookies(copy_dir)` — rows in the copied profile's cookie DB (modern `Network/Cookies` and legacy `Cookies` paths); 0 means nothing to verify.
  - `_live_cookie_count(cdp_url)` — queries the launched browser's live jar via the agent-browser CLI; 0 on any failure.
  - `_real_profile_cdp()` — runs the verification after launch; on 0-live-with-expected>0 it closes the session, pops the cache, and returns an actionable error.
- `tests/tools/test_browser_real_profile.py` — 5 new tests + a real-sqlite cookie-DB helper:
  - launch verifies cookies survive (success path)
  - launch fails closed when cookies are wiped (session closed, cache popped, error mentions "signed out")
  - verification skipped when the snapshot has no cookies
  - `_live_cookie_count` parses agent-browser output / returns 0 on CLI error

## Test Plan

- `./venv/bin/python3 -m pytest tests/tools/test_browser_real_profile.py -v` → 78 passed
- `./venv/bin/python3 -m pytest tests/tools/test_browser_use_cli.py -q` → 95 passed

## Verified reproduction

On a Linux host with keyring-encrypted (v11) cookies: snapshot DB holds 100 cookie rows before launch; agent-browser's Chrome comes up with 0 (mock keychain wipes them); launching real Chrome on the same profile copy without mock keychain keeps all 100 and the account authenticates. The verification in this PR turns the first case into a clear failure instead of a silent signed-out session.
