### PR TITLE
fix(mcp-oauth): make Google Workspace MCP servers (gmail/drive/docs/sheets/calendar) authenticate

### DIFF
--- a/hermes_cli/web_routers/mcp.py
+++ b/hermes_cli/web_routers/mcp.py
@@ -338,6 +338,7 @@ async def mcp_oauth_callback(
     code: Optional[str] = None,
     state: Optional[str] = None,
     error: Optional[str] = None,
+    iss: Optional[str] = None,
 ):
     _gc_mcp_oauth_flows()
     with _mcp_oauth_flows_lock:
@@ -360,7 +361,7 @@ async def mcp_oauth_callback(
     if flow is None:
         return HTMLResponse("<h1>OAuth flow expired</h1><p>Return to Hermes and try again.</p>", status_code=404)
     try:
-        flow.deliver_callback(code=code, state=state, error=error)
+        flow.deliver_callback(code=code, state=state, error=error, iss=iss)
     except ValueError as exc:
         reason = str(exc)
         status_code = 409 if "already received" in reason else 400

--- a/tests/tools/test_mcp_dashboard_oauth.py
+++ b/tests/tools/test_mcp_dashboard_oauth.py
@@ -114,3 +114,27 @@ def test_failed_reauth_rollback_preserves_newer_oauth_state(tmp_path, monkeypatc
     storage.restore(backup, only_if_absent=True)
 
     assert storage._tokens_path().read_text() == "FRESH"
+
+
+def test_dashboard_flow_forwards_iss_to_sdk_result():
+    from tools.mcp_dashboard_oauth import DashboardOAuthFlow, dashboard_oauth_flow
+    from tools.mcp_oauth import _make_callback_waiter, _make_redirect_handler
+
+    flow = DashboardOAuthFlow(
+        flow_id="flow-5",
+        server_name="reports",
+        profile=None,
+        hermes_home="/tmp/hermes-test",
+        redirect_uri="http://127.0.0.1:1/callback",
+    )
+    with dashboard_oauth_flow(flow):
+        asyncio.run(_make_redirect_handler(0)("https://idp.example/authorize?state=state-5"))
+        flow.deliver_callback(
+            code="code-5", state="state-5", error=None, iss="https://accounts.google.com"
+        )
+        result = asyncio.run(_make_callback_waiter(0)())
+        assert (result.code, result.state, result.iss) == (
+            "code-5",
+            "state-5",
+            "https://accounts.google.com",
+        )

--- a/tests/tools/test_mcp_oauth_no_401_server.py
+++ b/tests/tools/test_mcp_oauth_no_401_server.py
@@ -1,0 +1,88 @@
+"""Servers that answer initialize/tools-list without auth (Google Workspace MCP)
+never return 401, so the SDK's reactive OAuth flow never starts. In an
+interactive login the provider must run the authorization flow anyway when no
+token exists on disk.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+pytest.importorskip("mcp.client.auth.oauth2", reason="MCP SDK 1.26.0+ required")
+
+
+async def _noop_redirect(_url: str) -> None:
+    return None
+
+
+async def _noop_callback() -> tuple[str, str | None]:
+    raise AssertionError("callback handler should not be invoked in this test")
+
+
+async def _make_provider(tmp_path, monkeypatch):
+    from mcp.shared.auth import OAuthClientInformationFull, OAuthClientMetadata
+    from pydantic import AnyUrl
+
+    from tools.mcp_oauth import HermesTokenStorage
+    from tools.mcp_oauth_manager import _HERMES_PROVIDER_CLS, reset_manager_for_tests
+
+    assert _HERMES_PROVIDER_CLS is not None
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    reset_manager_for_tests()
+
+    storage = HermesTokenStorage("srv")
+    await storage.set_client_info(
+        OAuthClientInformationFull(
+            client_id="test-client",
+            redirect_uris=[AnyUrl("http://127.0.0.1:12345/callback")],
+            grant_types=["authorization_code", "refresh_token"],
+            response_types=["code"],
+            token_endpoint_auth_method="none",
+        )
+    )
+    metadata = OAuthClientMetadata(
+        redirect_uris=[AnyUrl("http://127.0.0.1:12345/callback")],
+        client_name="Hermes Agent",
+    )
+    return _HERMES_PROVIDER_CLS(
+        server_name="srv",
+        server_url="https://example.com/mcp",
+        client_metadata=metadata,
+        storage=storage,
+        redirect_handler=_noop_redirect,
+        callback_handler=_noop_callback,
+    )
+
+
+@pytest.mark.asyncio
+async def test_interactive_no_token_200_starts_authorization(tmp_path, monkeypatch):
+    from tools.mcp_tool import sdk_httpx
+    from tools.mcp_oauth import force_interactive_oauth
+
+    httpx = sdk_httpx()
+    provider = await _make_provider(tmp_path, monkeypatch)
+
+    with force_interactive_oauth():
+        flow = provider.async_auth_flow(httpx.Request("POST", "https://example.com/mcp"))
+        outbound = await flow.__anext__()
+        assert "authorization" not in outbound.headers
+
+        next_request = await flow.asend(httpx.Response(200, request=outbound))
+        assert isinstance(next_request, httpx.Request)
+        assert "oauth-protected-resource" in str(next_request.url)
+        await flow.aclose()
+
+
+@pytest.mark.asyncio
+async def test_non_interactive_no_token_200_passes_through(tmp_path, monkeypatch):
+    from tools.mcp_tool import sdk_httpx
+    from tools import mcp_oauth
+
+    httpx = sdk_httpx()
+    provider = await _make_provider(tmp_path, monkeypatch)
+    monkeypatch.setattr(mcp_oauth, "_is_interactive", lambda: False)
+
+    flow = provider.async_auth_flow(httpx.Request("POST", "https://example.com/mcp"))
+    outbound = await flow.__anext__()
+    with pytest.raises(StopAsyncIteration):
+        await flow.asend(httpx.Response(200, request=outbound))

--- a/tests/tools/test_mcp_oauth_no_401_server.py
+++ b/tests/tools/test_mcp_oauth_no_401_server.py
@@ -86,3 +86,42 @@ async def test_non_interactive_no_token_200_passes_through(tmp_path, monkeypatch
     outbound = await flow.__anext__()
     with pytest.raises(StopAsyncIteration):
         await flow.asend(httpx.Response(200, request=outbound))
+
+
+class _AuthorizeReached(Exception):
+    pass
+
+
+async def _stop_callback() -> tuple[str, str | None]:
+    raise _AuthorizeReached()
+
+
+@pytest.mark.asyncio
+async def test_trailing_slash_authorization_server_matches_issuer(tmp_path, monkeypatch):
+    from tools.mcp_tool import sdk_httpx
+    from tools.mcp_oauth import force_interactive_oauth
+
+    httpx = sdk_httpx()
+    provider = await _make_provider(tmp_path, monkeypatch)
+    provider.context.callback_handler = _stop_callback
+
+    prm = {
+        "resource": "https://example.com/mcp",
+        "authorization_servers": ["https://accounts.google.com/"],
+    }
+    asm = {
+        "issuer": "https://accounts.google.com",
+        "authorization_endpoint": "https://accounts.google.com/o/oauth2/v2/auth",
+        "token_endpoint": "https://oauth2.googleapis.com/token",
+        "response_types_supported": ["code"],
+        "code_challenge_methods_supported": ["S256"],
+    }
+    with force_interactive_oauth():
+        flow = provider.async_auth_flow(httpx.Request("POST", "https://example.com/mcp"))
+        outbound = await flow.__anext__()
+        prm_req = await flow.asend(httpx.Response(200, request=outbound))
+        asm_req = await flow.asend(httpx.Response(200, request=prm_req, json=prm))
+        assert "oauth-authorization-server" in str(asm_req.url)
+        with pytest.raises(_AuthorizeReached):
+            await flow.asend(httpx.Response(200, request=asm_req, json=asm))
+    assert provider.context.auth_server_url == "https://accounts.google.com"

--- a/tools/mcp_dashboard_oauth.py
+++ b/tools/mcp_dashboard_oauth.py
@@ -33,6 +33,7 @@ class DashboardOAuthFlow:
     tools: list[dict] = field(default_factory=list)
     expected_state: str | None = field(default=None, init=False)
     _callback: tuple[str, str | None] | None = field(default=None, init=False, repr=False)
+    callback_iss: str | None = field(default=None, init=False)
     _callback_error: str | None = field(default=None, init=False, repr=False)
     _authorization_ready: threading.Event = field(default_factory=threading.Event, init=False, repr=False)
     _callback_ready: threading.Event = field(default_factory=threading.Event, init=False, repr=False)
@@ -65,6 +66,7 @@ class DashboardOAuthFlow:
         code: str | None,
         state: str | None,
         error: str | None,
+        iss: str | None = None,
     ) -> None:
         with self._lock:
             if self._callback_ready.is_set():
@@ -79,6 +81,7 @@ class DashboardOAuthFlow:
                 self._callback_error = error
             elif code:
                 self._callback = (code, state)
+                self.callback_iss = iss
             else:
                 self._callback_error = "OAuth callback did not include code or error"
             self._callback_ready.set()

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -955,7 +955,9 @@ def _make_callback_waiter(
             # The dashboard flow still speaks the legacy tuple; normalize it
             # here so both callback sources hand the SDK one shape.
             dash_code, dash_state = await dashboard_flow.wait_for_callback()
-            return _authorization_code_result(dash_code, dash_state)
+            return _authorization_code_result(
+                dash_code, dash_state, dashboard_flow.callback_iss
+            )
 
         # Reject before binding the callback listener in non-interactive
         # contexts. Reaching here means the SDK entered the authorization-code

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -524,6 +524,19 @@ def _make_hermes_provider_class() -> Optional[type]:
             )
             return True
 
+        def _normalize_auth_server_url(self) -> None:
+            """Google's PRM lists ``https://accounts.google.com/`` while its AS
+            metadata issuer is ``https://accounts.google.com``; the SDK compares
+            them as plain strings (RFC 8414 §3.3), so drop the slash of a bare
+            origin before the SDK validates."""
+            url = self.context.auth_server_url
+            if not url or not url.endswith("/"):
+                return
+            from urllib.parse import urlparse
+
+            if urlparse(url).path == "/":
+                self.context.auth_server_url = url.rstrip("/")
+
         @staticmethod
         def _synthetic_unauthorized(incoming):
             from tools.mcp_tool import sdk_httpx
@@ -570,6 +583,7 @@ def _make_hermes_provider_class() -> Optional[type]:
                     await self._maybe_flag_poisoned_client(incoming)
                     if self._needs_forced_authorization(request, outgoing, incoming):
                         incoming = self._synthetic_unauthorized(incoming)
+                    self._normalize_auth_server_url()
                     outgoing = await inner.asend(incoming)
             except StopAsyncIteration:
                 # Persist any metadata the SDK discovered lazily during the

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -501,6 +501,36 @@ def _make_hermes_provider_class() -> Optional[type]:
                     self._hermes_server_name, exc,
                 )
 
+        def _needs_forced_authorization(self, request, outgoing, incoming) -> bool:
+            """True when a server answered the unauthenticated MCP request with
+            2xx although no token exists — Google Workspace MCP servers accept
+            initialize/tools-list anonymously, so the SDK's 401-driven flow
+            would never start. Only in an interactive (login) context."""
+            from tools.mcp_oauth import _is_interactive
+
+            status = getattr(incoming, "status_code", None)
+            if status is None or not 200 <= status < 300:
+                return False
+            if outgoing is not request or self.context.is_token_valid():
+                return False
+            if "authorization" in (getattr(outgoing, "headers", None) or {}):
+                return False
+            if not _is_interactive():
+                return False
+            logger.info(
+                "MCP OAuth '%s': server accepted the request without a token; "
+                "forcing the authorization flow (no cached tokens)",
+                self._hermes_server_name,
+            )
+            return True
+
+        @staticmethod
+        def _synthetic_unauthorized(incoming):
+            from tools.mcp_tool import sdk_httpx
+
+            httpx = sdk_httpx()
+            return httpx.Response(401, request=incoming.request)
+
         async def async_auth_flow(self, request):  # type: ignore[override]
             # Pre-flow hook: ask the manager to refresh from disk if needed.
             # Any failure here is non-fatal — we just log and proceed with
@@ -538,6 +568,8 @@ def _make_hermes_provider_class() -> Optional[type]:
                     # Sniff the response for a dead-client-registration signal
                     # before handing it back to the SDK (best-effort, GH#36767).
                     await self._maybe_flag_poisoned_client(incoming)
+                    if self._needs_forced_authorization(request, outgoing, incoming):
+                        incoming = self._synthetic_unauthorized(incoming)
                     outgoing = await inner.asend(incoming)
             except StopAsyncIteration:
                 # Persist any metadata the SDK discovered lazily during the

--- a/tui_gateway/mcp_oauth_sessions.py
+++ b/tui_gateway/mcp_oauth_sessions.py
@@ -95,10 +95,11 @@ def _start_loopback_listener(flow) -> "http.server.HTTPServer":
             code = (qs.get("code") or [None])[0]
             state = (qs.get("state") or [None])[0]
             error = (qs.get("error") or [None])[0]
+            iss = (qs.get("iss") or [None])[0]
             body = b"<h1>Authorization received</h1><p>You can close this tab and return to Hermes.</p>"
             status = 200
             try:
-                flow.deliver_callback(code=code, state=state, error=error)
+                flow.deliver_callback(code=code, state=state, error=error, iss=iss)
             except Exception:
                 body = b"<h1>OAuth callback rejected</h1><p>The callback was invalid or already used.</p>"
                 status = 400


### PR DESCRIPTION
## Summary

Google's Workspace MCP servers (`gmailmcp|drivemcp|docsmcp|sheetsmcp|calendarmcp.googleapis.com/mcp/v1`) could not be authenticated from the desktop/dashboard (and `hermes mcp login` fails the same way). Three independent issues, each reproduced and covered by a test:

1. **No 401 → no OAuth flow.** Google answers `initialize` and `tools/list` with HTTP 200 *without* a token (only tool calls need a bearer). The SDK's `OAuthClientProvider.async_auth_flow` is purely 401-driven, so the browser flow never started and `_oauth_tokens_present()` raised *"The server responded, but no OAuth token was obtained"*. Fix: in `HermesMCPOAuthProvider`'s generator bridge, when the unauthenticated original request gets a 2xx, no token is cached and the context is interactive (login / dashboard `force_interactive_oauth`), feed a synthetic 401 into the SDK so standard PRM discovery → authorize → token exchange runs. Non-interactive behaviour is unchanged.
2. **Issuer mismatch.** Google's PRM lists `https://accounts.google.com/` while its AS metadata `issuer` is `https://accounts.google.com`; the SDK compares as plain strings (RFC 8414 §3.3) → *"Authorization server metadata issuer mismatch"*. Fix: strip the trailing slash of a bare-origin `auth_server_url` before the SDK validates.
3. **`iss` dropped on the dashboard path.** Google advertises `authorization_response_iss_parameter_supported`, so the SDK requires `iss` in the callback (RFC 9207). The CLI loopback handler already forwards it; the dashboard bridge (`DashboardOAuthFlow.deliver_callback`, the gateway session listener, the web callback route, the SDK adapter) did not → *"Authorization response missing iss parameter"*. Fix: thread `iss` through those four points (`callback_iss` on the flow; `wait_for_callback` keeps its tuple shape).

## Test plan

- New: `tests/tools/test_mcp_oauth_no_401_server.py` (3 tests), `test_dashboard_flow_forwards_iss_to_sdk_result` in `tests/tools/test_mcp_dashboard_oauth.py`.
- `pytest tests/tools/test_mcp_oauth*.py tests/tools/test_mcp_dashboard_oauth*.py tests/tools/test_mcp_cimd.py` → 159 passed.
- End-to-end on macOS desktop: all five Google servers now authenticate from the MCP page and register their tools (gmail 23, calendar 9, drive 8, sheets 6, docs 2); tokens include `refresh_token`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)