### PR TITLE
fix(env): scope terminal config re-bridge to the true process profile

### DIFF
--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -539,10 +539,31 @@ def _load_secrets_config(home_path: Path) -> dict:
 
 
 def _process_hermes_home() -> Path:
-    """The HERMES_HOME the shared config cache is keyed to."""
-    try:
-        from hermes_constants import get_hermes_home
+    """The HERMES_HOME the running process was launched under.
 
-        return get_hermes_home()
+    Must be the *true* process home, ignoring any context-local
+    ``set_hermes_home_override`` a per-request task has installed. Both
+    callers depend on that:
+
+    * ``_reapply_terminal_config_bridge`` guards "only re-bridge config into
+      the shared ``os.environ`` when THIS load is for the process's own
+      profile". If this followed the task override, a per-turn handler scoped
+      to a *secondary* profile (the multiplex dashboard serving every profile
+      from one process) would satisfy the guard and bridge that profile's
+      ``terminal.backend`` into the shared env — e.g. a ``local`` sibling
+      profile clobbering the launch profile's ``TERMINAL_ENV=ssh`` while
+      leaving its ``TERMINAL_SSH_*`` untouched, so the session silently runs
+      commands locally (cross-profile terminal-backend leak).
+    * ``_load_secrets_config`` uses it to decide whether the shared
+      (mtime,size)-keyed config cache is safe to reuse; under an override it
+      must fall through to an isolated parse of the scoped profile.
+
+    ``hermes_constants.get_process_hermes_home()`` is the override-immune
+    resolver built for exactly this; delegate to it.
+    """
+    try:
+        from hermes_constants import get_process_hermes_home
+
+        return get_process_hermes_home()
     except Exception:
         return Path.home() / ".hermes"

--- a/tests/hermes_cli/test_terminal_bridge_profile_scope.py
+++ b/tests/hermes_cli/test_terminal_bridge_profile_scope.py
@@ -1,0 +1,93 @@
+"""Regression: the terminal config→env re-bridge is scoped to the *true*
+process profile, never a per-task ``set_hermes_home_override``.
+
+The multiplex dashboard serves every profile on the host from one process,
+so ``os.environ`` is shared across all of them. A per-turn handler scoped to
+a secondary profile (via ``set_hermes_home_override``) must NOT cause that
+profile's ``terminal.backend`` to be bridged into the shared environment —
+otherwise a ``local`` sibling profile silently clobbers the launch profile's
+``TERMINAL_ENV=ssh`` (leaving its ``TERMINAL_SSH_*`` intact), and the launch
+session runs every command locally instead of over SSH.
+
+The guard in ``env_loader._reapply_terminal_config_bridge`` compares the
+loaded home against the process home. It must use the override-immune
+``get_process_hermes_home()`` so the comparison reflects the launch scope,
+not whichever profile the current task is scoped to.
+"""
+
+import os
+
+import pytest
+
+import hermes_cli.env_loader as env_loader
+from hermes_constants import (
+    set_hermes_home_override,
+    reset_hermes_home_override,
+)
+
+
+def _write_terminal_config(home, text: str) -> None:
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text(text)
+
+
+@pytest.fixture(autouse=True)
+def _clean_terminal_env(monkeypatch):
+    for name in ("TERMINAL_ENV", "TERMINAL_SSH_HOST", "TERMINAL_SSH_USER"):
+        monkeypatch.delenv(name, raising=False)
+    yield
+
+
+def test_process_hermes_home_ignores_task_override(tmp_path, monkeypatch):
+    """The guard's home resolver must not follow a per-task override."""
+    launch_home = tmp_path / "laptop"
+    other_home = tmp_path / "tommy"
+    launch_home.mkdir()
+    other_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(launch_home))
+
+    token = set_hermes_home_override(str(other_home))
+    try:
+        assert (
+            env_loader._process_hermes_home().resolve() == launch_home.resolve()
+        ), "process home leaked to the per-task override profile"
+    finally:
+        reset_hermes_home_override(token)
+
+
+def test_secondary_profile_reload_does_not_bridge_into_shared_env(
+    tmp_path, monkeypatch
+):
+    """A secondary profile's terminal.backend must not touch os.environ.
+
+    Simulates the dashboard multiplex: process launched under ``laptop``
+    (ssh), a per-turn handler scoped to ``tommy`` (local) triggers a dotenv
+    reload for tommy's home. The launch session's TERMINAL_ENV must survive.
+    """
+    launch_home = tmp_path / "laptop"
+    other_home = tmp_path / "tommy"
+    _write_terminal_config(
+        launch_home,
+        "terminal:\n"
+        "  backend: ssh\n"
+        "  ssh_host: 10.10.0.103\n"
+        "  ssh_user: bergmann\n",
+    )
+    _write_terminal_config(other_home, "terminal:\n  backend: local\n")
+    monkeypatch.setenv("HERMES_HOME", str(launch_home))
+
+    # Launch profile's backend is what the shared env carries.
+    monkeypatch.setenv("TERMINAL_ENV", "ssh")
+    monkeypatch.setenv("TERMINAL_SSH_HOST", "10.10.0.103")
+
+    # A per-turn handler for the secondary profile is scoped via the contextvar
+    # and drives a reload for tommy's home.
+    token = set_hermes_home_override(str(other_home))
+    try:
+        env_loader._reapply_terminal_config_bridge(other_home)
+    finally:
+        reset_hermes_home_override(token)
+
+    # tommy's `local` must NOT have leaked into the shared process env.
+    assert os.environ["TERMINAL_ENV"] == "ssh"
+    assert os.environ["TERMINAL_SSH_HOST"] == "10.10.0.103"


### PR DESCRIPTION
## What does this PR do?

In a multiplexed dashboard/gateway (one process serving every profile on the host), a **secondary** profile's `terminal.backend` could leak into the shared `os.environ` and silently override the **launch** profile's terminal backend. A profile configured for `terminal.backend: ssh` would end up running every command on the local host because a sibling profile with `backend: local` had polluted the shared environment.

The tell is an asymmetric env state on the launch session:

```
TERMINAL_ENV=local             # leaked from a sibling profile
TERMINAL_SSH_HOST=10.10.0.103  # still the launch profile's — untouched
```

A restart does not help: as soon as the sibling profile is touched again (a turn, a cron tick), the shared env is re-poisoned.

### Root cause

`env_loader._reapply_terminal_config_bridge()` guards *"only re-bridge config into the shared `os.environ` when this load is for the process's own profile"*:

```python
if Path(home_path).resolve() != _process_hermes_home().resolve():
    return
```

`_process_hermes_home()` delegated to `get_hermes_home()`, which **follows the context-local `set_hermes_home_override`** a per-request task installs. When a per-turn handler is scoped to a secondary profile (via `_config_profile_scope` / `set_hermes_home_override`) and triggers a `load_hermes_dotenv()` reload, **both sides of the comparison resolve to that secondary profile** — the guard passes, and the bridge runs `apply_terminal_config_to_env(env=None)` against the shared `os.environ`, writing the *wrong* profile's `terminal.backend`.

Because the secondary profile's `config.yaml` carries no `TERMINAL_SSH_*` keys, only `TERMINAL_ENV` is overwritten (explicit-keys-only bridge semantics), producing the asymmetric state above.

The helper was originally introduced for the config-cache key (where following the active home is correct) and later reused for the terminal bridge guard, where the override-following semantics are wrong.

### The fix

Delegate `_process_hermes_home()` to `get_process_hermes_home()`, the override-immune resolver built for exactly this — it reflects the scope the process was **launched** under, ignoring per-task overrides. Both call sites (the bridge guard and the secrets-cache reuse check in `_load_secrets_config`) want the true process home.

This is the correct boundary: in a multiplex process `os.environ` belongs to the launch profile. A secondary profile's terminal config must reach its own sessions through session-scoped mechanisms (see Related), **never** by mutating the shared process environment.

## Related Issue

Same bug **class** (cross-profile terminal-backend leak under multiplexing), addressed here at a bridge site that no open PR touches:

- Related to #96992 (main-verified, desktop in-process; enumerates the layers of this class) and #72480 (wrong `HERMES_HOME` for tool env — same symptom class at the process-env layer).
- **Complementary, not a duplicate:**
  - #94206 / #94200 fix the `terminal_tool._ensure_terminal_env_bridged()` process-global one-shot latch.
  - #79117 / #68559 scope terminal config in `gateway/run.py` for routed multiplex profiles.
  - #88635 scopes `terminal.cwd` (not backend) for multiplex sessions.

Each of those fixes a **different** bridge site. This PR fixes a third, independent one — `env_loader._reapply_terminal_config_bridge()` — which runs on every `load_hermes_dotenv()` and is not covered by any of the above. Fixing only the others leaves this path as a live leak (and vice versa).

Happy to fold this into #96992's tracking or coordinate with #94206's author if the maintainers prefer to consolidate the cluster.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/env_loader.py` — `_process_hermes_home()` now delegates to `hermes_constants.get_process_hermes_home()` (override-immune) instead of `get_hermes_home()` (which follows the per-task context override). Docstring expanded to explain why both callers require the true process home.
- `tests/hermes_cli/test_terminal_bridge_profile_scope.py` — new regression test:
  - `test_process_hermes_home_ignores_task_override` — the resolver ignores an active `set_hermes_home_override`.
  - `test_secondary_profile_reload_does_not_bridge_into_shared_env` — a secondary-profile reload leaves the launch profile's `TERMINAL_ENV` and `TERMINAL_SSH_*` in `os.environ` untouched.

## How to Test

Reproduce the leak and confirm the fix:

1. Configure two profiles: `laptop` (`terminal.backend: ssh`, with `ssh_host`/`ssh_user`) and `tommy` (`terminal.backend: local`, no ssh keys).
2. Launch under `laptop` (`HERMES_HOME=…/laptop`), so the shared env carries `TERMINAL_ENV=ssh` + `TERMINAL_SSH_*`.
3. Simulate a per-turn handler scoped to the secondary profile and drive a reload for its home:

   ```python
   from hermes_constants import set_hermes_home_override, reset_hermes_home_override
   import hermes_cli.env_loader as env_loader

   tok = set_hermes_home_override(str(tommy_home))
   try:
       env_loader._reapply_terminal_config_bridge(tommy_home)
   finally:
       reset_hermes_home_override(tok)
   ```

4. **Before:** `os.environ["TERMINAL_ENV"] == "local"` (tommy's backend leaked), `TERMINAL_SSH_HOST` still laptop's — the launch session silently runs locally. **After:** `TERMINAL_ENV` stays `"ssh"`; nothing leaks.

Automated:

```bash
pytest tests/hermes_cli/test_terminal_bridge_profile_scope.py -q
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(env): …`)
- [x] I searched for existing PRs/issues to make sure this isn't a duplicate (found a related cluster — see Related Issue; this bridge site is uncovered)
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass <!-- Ran the new regression test's bodies directly against the patched tree (2/2 pass) plus an old-vs-new counterfactual proving the leak; please run the full suite via scripts/run_tests.sh in CI. -->
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux (aarch64, Docker)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings) — expanded `_process_hermes_home` docstring; no user-facing docs affected
- [x] `cli-config.yaml.example` — N/A (no config keys added/changed)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture/workflow change)
- [x] Cross-platform impact considered — resolver swap is platform-agnostic; single-profile / CLI behaviour is unchanged (with no active override the two resolvers are identical)
- [x] Tool descriptions/schemas — N/A (no tool behaviour change)
