### PR TITLE
fix(tui): preserve remote session reasoning status

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -10795,6 +10795,35 @@ def test_session_status_reads_live_gateway_agent(monkeypatch):
     assert "Agent Running: Yes" in out
 
 
+def test_session_status_reports_remote_reasoning_and_fast(monkeypatch):
+    server._sessions["sid"] = _session(agent=None, running=False)
+    server._sessions["sid"].update(
+        {
+            "agent": None,
+            "_compute_host_active": True,
+            "create_reasoning_override": {"enabled": True, "effort": "high"},
+            "create_service_tier_override": "priority",
+        }
+    )
+
+    class _DB:
+        def get_session(self, _key):
+            return {"started_at": 1_700_000_000}
+
+    monkeypatch.setattr(server, "_get_db", lambda: _DB())
+    try:
+        resp = server.handle_request(
+            {"id": "1", "method": "session.status", "params": {"session_id": "sid"}}
+        )
+    finally:
+        server._sessions.pop("sid", None)
+
+    assert isinstance(resp, dict) and "result" in resp, resp
+    out = resp["result"]["output"]
+    assert "Reasoning: high" in out
+    assert "Fast: Yes" in out
+
+
 def test_skills_reload_runs_in_gateway_process(monkeypatch):
     import agent.skill_commands as skill_commands
 
@@ -19590,10 +19619,19 @@ def test_fallback_session_info_reports_session_cwd_not_launch_dir(monkeypatch):
     monkeypatch.setattr(server, "_project_info_for_cwd", lambda cwd: None)
     monkeypatch.setattr(server, "_resolve_model", lambda: "test-model")
 
-    info = server._fallback_session_info({"cwd": "/projects/session-own-repo"})
+    info = server._fallback_session_info(
+        {
+            "agent": None,
+            "cwd": "/projects/session-own-repo",
+            "create_reasoning_override": {"enabled": True, "effort": "high"},
+            "create_service_tier_override": "priority",
+        }
+    )
 
     assert info["cwd"] == "/projects/session-own-repo"
     assert info["branch"] == "bb/feature"
+    assert info["reasoning_effort"] == "high"
+    assert info["fast"] is True
 
 
 def test_fallback_session_info_always_emits_branch(monkeypatch):

--- a/tests/tui_gateway/test_reasoning_session_scope.py
+++ b/tests/tui_gateway/test_reasoning_session_scope.py
@@ -52,6 +52,51 @@ class TestSessionInfoReasoningEffort:
         info = _session_info(_agent(None))
         assert info["reasoning_effort"] == ""
 
+    def test_remote_agent_reports_session_overrides(self) -> None:
+        info = _session_info(
+            None,
+            {
+                "create_reasoning_override": {"enabled": True, "effort": "high"},
+                "create_service_tier_override": "priority",
+                "_compute_host_active": True,
+            },
+        )
+        assert info["reasoning_effort"] == "high"
+        assert info["service_tier"] == "priority"
+        assert info["fast"] is True
+
+    def test_remote_agent_preserves_override_precedence_and_sentinels(self) -> None:
+        mirrored = _session_info(
+            None,
+            {
+                "_metadata_mirror": {
+                    "reasoning_effort": "medium",
+                    "service_tier": "flex",
+                },
+                "create_reasoning_override": {"enabled": True, "effort": "high"},
+                "create_service_tier_override": "priority",
+            },
+        )
+        assert mirrored["reasoning_effort"] == "medium"
+        assert mirrored["service_tier"] == "flex"
+        assert mirrored["fast"] is False
+
+        disabled = _session_info(
+            None,
+            {
+                "create_reasoning_override": {"enabled": False},
+                "create_service_tier_override": "",
+            },
+        )
+        assert disabled["reasoning_effort"] == "none"
+        assert disabled["service_tier"] == ""
+        assert disabled["fast"] is False
+
+        inherited = _session_info(None, {})
+        assert inherited["reasoning_effort"] == ""
+        assert inherited["service_tier"] == ""
+        assert inherited["fast"] is False
+
 
 class TestConfigSetReasoningSessionScope:
     """Session-targeted reasoning changes must not touch global config."""

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -1093,12 +1093,7 @@ def _(rid, params: dict) -> dict:
     except ValueError as e:
         return _err(rid, 4017, str(e))
     agent = session.get("agent")
-    info = _session_info(agent, session) if agent is not None else {
-        "cwd": cwd,
-        "branch": _git_branch_for_cwd(cwd),
-        "project": _project_info_for_cwd(cwd),
-        "lazy": True,
-    }
+    info = _session_info(agent, session)
     _emit("session.info", params.get("session_id", ""), info)
     return _ok(rid, info)
 
@@ -1167,12 +1162,7 @@ def _(rid, params: dict) -> dict:
         except ValueError as e:
             return _err(rid, 4017, str(e))
         agent = live.get("agent")
-        info = _session_info(agent, live) if agent is not None else {
-            "cwd": resolved,
-            "branch": branch,
-            "project": _project_info_for_cwd(resolved),
-            "lazy": True,
-        }
+        info = _session_info(agent, live)
         _emit("session.info", live_sid, info)
 
     return _ok(rid, {"cwd": resolved, "branch": branch, "git_repo_root": root})
@@ -2745,10 +2735,11 @@ def _(rid, params: dict) -> dict:
             updated = _dt(meta.get(field), created)
             break
 
-    mirror = _metadata_mirror(session)
+    info = _session_info(agent, session)
     usage = _session_usage_snapshot(session)
-    provider = getattr(agent, "provider", None) or mirror.get("provider") or "unknown"
-    model = getattr(agent, "model", None) or mirror.get("model") or "(unknown)"
+    provider = info.get("provider") or "unknown"
+    model = info.get("model") or "(unknown)"
+    reasoning = info.get("reasoning_effort") or "default"
     project = _project_info_for_cwd(_display_session_cwd(session))
     lines = [
         "Hermes TUI Status",
@@ -2764,6 +2755,8 @@ def _(rid, params: dict) -> dict:
     lines.extend(
         [
             f"Model: {model} ({provider})",
+            f"Reasoning: {reasoning}",
+            f"Fast: {'Yes' if info.get('fast') else 'No'}",
             f"Created: {created.strftime('%Y-%m-%d %H:%M')}",
             f"Last Activity: {updated.strftime('%Y-%m-%d %H:%M')}",
             f"Tokens: {int(usage.get('total') or 0):,}",

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -7103,9 +7103,13 @@ def _session_info(agent, session: dict | None = None) -> dict:
     )
     cfg_personality = ((_load_cfg().get("display") or {}).get("personality") or "")
     personality = (session or {}).get("personality", cfg_personality)
-    reasoning_config = getattr(agent, "reasoning_config", None)
-    reasoning_effort = ""
-    if isinstance(reasoning_config, dict):
+    reasoning_config = (
+        getattr(agent, "reasoning_config", None)
+        if agent is not None
+        else (session or {}).get("create_reasoning_override")
+    )
+    reasoning_effort = str(mirror.get("reasoning_effort") or "") if agent is None else ""
+    if not reasoning_effort and isinstance(reasoning_config, dict):
         if reasoning_config.get("enabled") is False:
             # Disabled must be distinguishable from unset ("" = provider
             # default). Reporting "" here made the desktop adopt the empty
@@ -7114,7 +7118,14 @@ def _session_info(agent, session: dict | None = None) -> dict:
             reasoning_effort = "none"
         else:
             reasoning_effort = str(reasoning_config.get("effort", "") or "")
-    service_tier = getattr(agent, "service_tier", None) or mirror.get("service_tier") or ""
+    if agent is None:
+        service_tier = (
+            mirror.get("service_tier")
+            or (session or {}).get("create_service_tier_override")
+            or ""
+        )
+    else:
+        service_tier = getattr(agent, "service_tier", None) or mirror.get("service_tier") or ""
     # Effective approval-bypass state — the same three sources that
     # check_all_command_guards() ORs together: persistent config
     # (approvals.mode=off), the process-scoped --yolo env, and the
@@ -7162,6 +7173,7 @@ def _session_info(agent, session: dict | None = None) -> dict:
         "approval_mode": approval_mode,
         "tools": dict(mirror.get("tools") or {}) if isinstance(mirror.get("tools"), dict) else {},
         "skills": dict(mirror.get("skills") or {}) if isinstance(mirror.get("skills"), dict) else {},
+        "lazy": agent is None and not mirror,
         "cwd": cwd,
         "branch": _git_branch_for_cwd(cwd),
         "project": _project_info_for_cwd(cwd),
@@ -10343,29 +10355,15 @@ def _fallback_session_info(session: dict) -> dict:
     agent = session.get("agent")
     if agent is not None:
         return _session_info(agent)
-    # The SESSION's own workspace, not the gateway's launch directory. Reporting
-    # `_default_session_cwd()` here told a lazily-resumed session's client that
-    # its workspace was wherever the gateway process happened to start, so the
-    # desktop Files pane painted the wrong project even after the renderer
-    # rebound correctly (#71254). `branch` is always emitted ("" outside a git
-    # repo) so a client can clear a stale label instead of retaining it — the
-    # same contract `_lazy_session_info` above already follows.
     cwd = _session_cwd(session)
-    return {
-        "cwd": cwd,
-        "branch": _git_branch_for_cwd(cwd),
-        "project": _project_info_for_cwd(cwd),
-        "lazy": True,
-        "model": _resolve_model(),
-        "skills": {},
-        "tools": {},
-        # A lazy session (agent not built yet) is still served by *this* backend,
-        # so it must advertise the current contract. Desktop feeds this straight
-        # into reportBackendContract(); a missing field is read as contract 0 and
-        # a current backend is falsely flagged "out of date" (#68392). The sibling
-        # session.create shape (_lazy_resume_info) already carries it (#36112).
-        "desktop_contract": DESKTOP_BACKEND_CONTRACT,
-    }
+    info = _session_info(None, dict(session))
+    info.update(
+        cwd=cwd,
+        branch=_git_branch_for_cwd(cwd),
+        project=_project_info_for_cwd(cwd),
+        lazy=True,
+    )
+    return info
 
 
 def _reconcile_display_with_live(


### PR DESCRIPTION
## What does this PR do?

Fixes TUI session status when the serving process does not own the live Agent object, as happens with isolated compute-host turns.

`session.info` now falls back to the Session's persisted reasoning and service-tier overrides after checking live mirrored metadata. The no-Agent cwd/workspace/fallback paths reuse the same status builder, and `/status` now prints the effective reasoning and Fast state.

The change preserves the existing sentinels: disabled reasoning reports `none`, empty service tier means explicit normal, and `None` remains inherited/default state.

## Related Issue

Fixes #97020

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Make `tui_gateway.server._session_info()` report Session reasoning/service-tier overrides when `agent is None`.
- Preserve metadata-mirror precedence and reasoning/service-tier sentinel semantics.
- Route no-Agent cwd, workspace-move, and lazy fallback `session.info` payloads through the shared builder.
- Add `Reasoning` and `Fast` lines to TUI `/status`.
- Add regressions for compute-host overrides, mirror precedence, disabled reasoning, explicit normal tier, inherited defaults, fallback resume, and `/status` output.

## How to Test

1. Run the focused TUI gateway suites:
   ```bash
   scripts/run_tests.sh \
     tests/tui_gateway/test_reasoning_session_scope.py \
     tests/test_tui_gateway_server.py -q
   ```
   Result: **625 passed, 0 failed**.
2. Run lint and compile checks:
   ```bash
   ruff check tui_gateway/server.py tui_gateway/methods_session.py \
     tests/tui_gateway/test_reasoning_session_scope.py \
     tests/test_tui_gateway_server.py
   python -m py_compile tui_gateway/server.py tui_gateway/methods_session.py \
     tests/tui_gateway/test_reasoning_session_scope.py \
     tests/test_tui_gateway_server.py
   git diff --check
   ```
   Result: all passed.
3. Regression proof: with the production changes temporarily removed, the two new core regressions fail with empty `reasoning_effort` and missing `/status` fields; restoring the fix makes both pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — focused affected suites passed; the repository-wide suite was not run
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6.2, Python 3.11.16

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no public configuration changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — Python-only state formatting, no platform-specific APIs added
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

No visual layout change beyond two text lines in `/status`; regression output is covered by tests.
