### PR TITLE
fix(mcp): surface the provider's reason on a failed OAuth callback

### DIFF
--- a/hermes_cli/web_routers/mcp.py
+++ b/hermes_cli/web_routers/mcp.py
@@ -10,6 +10,7 @@ working unchanged.
 """
 
 import asyncio  # noqa: F401 — used by handlers
+import html
 import logging
 import secrets  # noqa: F401
 import threading  # noqa: F401
@@ -338,6 +339,8 @@ async def mcp_oauth_callback(
     code: Optional[str] = None,
     state: Optional[str] = None,
     error: Optional[str] = None,
+    error_description: Optional[str] = None,
+    error_uri: Optional[str] = None,
 ):
     _gc_mcp_oauth_flows()
     with _mcp_oauth_flows_lock:
@@ -359,6 +362,14 @@ async def mcp_oauth_callback(
     )
     if flow is None:
         return HTMLResponse("<h1>OAuth flow expired</h1><p>Return to Hermes and try again.</p>", status_code=404)
+    # RFC 6749 §4.1.2.1 puts the diagnosable part of a rejection in
+    # ``error_description``/``error_uri``, not in ``error``. Carrying only the
+    # bare code left both the log and the browser page saying "Authorization
+    # failed" with no way to tell a denied consent from a bad redirect URI.
+    if error:
+        detail = " — ".join(part for part in (error, error_description, error_uri) if part)
+        _log.warning("MCP OAuth callback for %r rejected by provider: %s", server_name, detail)
+        error = detail
     try:
         flow.deliver_callback(code=code, state=state, error=error)
     except ValueError as exc:
@@ -370,7 +381,14 @@ async def mcp_oauth_callback(
             status_code=status_code,
         )
     if error:
-        return HTMLResponse("<h1>Authorization failed</h1><p>Return to Hermes for details.</p>", status_code=400)
+        # Show the provider's own reason here: this tab is often the only
+        # surface the user sees when authorizing from another machine.
+        return HTMLResponse(
+            "<h1>Authorization failed</h1>"
+            f"<p>{html.escape(error)}</p>"
+            "<p>Return to Hermes and try again.</p>",
+            status_code=400,
+        )
     return HTMLResponse("<h1>Authorization received</h1><p>You can close this tab and return to Hermes.</p>")
 
 

--- a/tests/hermes_cli/test_mcp_dashboard_oauth.py
+++ b/tests/hermes_cli/test_mcp_dashboard_oauth.py
@@ -86,6 +86,78 @@ def test_hosted_callback_bypasses_gated_cookie_auth(monkeypatch):
     assert flow._callback == ("abc", "expected")
 
 
+def test_callback_surfaces_provider_error_description(monkeypatch, caplog):
+    """A rejection must name its reason, in the page and in the log.
+
+    RFC 6749 4.1.2.1 puts the diagnosable part in ``error_description`` /
+    ``error_uri``. Dropping them leaves the only surface the user sees when
+    authorizing from another machine saying just "Authorization failed", with
+    no way to tell a denied consent from a rejected redirect URI.
+    """
+    import asyncio
+    import logging
+
+    from starlette.testclient import TestClient
+
+    from hermes_cli import web_server
+    from tools.mcp_dashboard_oauth import DashboardOAuthFlow
+
+    flow = DashboardOAuthFlow(
+        flow_id="flow-error",
+        server_name="reports",
+        profile=None,
+        hermes_home="/tmp/hermes-test",
+        redirect_uri="https://agent.example/api/mcp/oauth/callback/reports",
+    )
+    asyncio.run(
+        flow.publish_authorization_url("https://idp.example/authorize?state=expected")
+    )
+    web_server._mcp_oauth_flows[flow.flow_id] = flow
+
+    with caplog.at_level(logging.WARNING, logger="hermes_cli.web_server"):
+        response = TestClient(web_server.app).get(
+            "/api/mcp/oauth/callback/reports"
+            "?state=expected&error=invalid_request"
+            "&error_description=Redirect+URL+is+using+an+insecure+protocol"
+        )
+
+    assert response.status_code == 400
+    assert "invalid_request" in response.text
+    assert "Redirect URL is using an insecure protocol" in response.text
+    assert "rejected by provider" in caplog.text
+
+
+def test_callback_escapes_provider_error_text(monkeypatch):
+    """The provider controls this string, so it must not reach the page raw."""
+    import asyncio
+
+    from starlette.testclient import TestClient
+
+    from hermes_cli import web_server
+    from tools.mcp_dashboard_oauth import DashboardOAuthFlow
+
+    flow = DashboardOAuthFlow(
+        flow_id="flow-escape",
+        server_name="reports",
+        profile=None,
+        hermes_home="/tmp/hermes-test",
+        redirect_uri="https://agent.example/api/mcp/oauth/callback/reports",
+    )
+    asyncio.run(
+        flow.publish_authorization_url("https://idp.example/authorize?state=expected")
+    )
+    web_server._mcp_oauth_flows[flow.flow_id] = flow
+
+    response = TestClient(web_server.app).get(
+        "/api/mcp/oauth/callback/reports"
+        "?state=expected&error=bad&error_description=%3Cscript%3Ealert(1)%3C/script%3E"
+    )
+
+    assert response.status_code == 400
+    assert "<script>" not in response.text
+    assert "&lt;script&gt;" in response.text
+
+
 def test_hosted_auth_allows_same_server_name_in_different_profiles(tmp_path, monkeypatch):
     from hermes_cli import web_server
     from tools.mcp_dashboard_oauth import DashboardOAuthFlow


### PR DESCRIPTION
## Problem

`mcp_oauth_callback` takes only the `error` query parameter and then throws it away:

```python
if error:
    return HTMLResponse("<h1>Authorization failed</h1><p>Return to Hermes for details.</p>", status_code=400)
```

Nothing is logged either, so "Return to Hermes for details" points at details that do not exist anywhere. A denied consent, an expired flow and a rejected redirect URI are indistinguishable.

RFC 6749 §4.1.2.1 puts the diagnosable part of a rejection in `error_description` and `error_uri`, neither of which the handler accepts.

## Change

Accept `error_description` / `error_uri`, log the combined detail at WARNING, and render it on the callback page. That page is often the only surface a user sees — authorizing from a different machine than the one running Hermes means the terminal is somewhere else entirely.

The string is provider-controlled, so it goes through `html.escape`.

## Why it matters

Debugging a Higgsfield MCP server behind Clerk, the bare page gave nothing to work with. With the description surfaced, the very first retry printed:

> `invalid_request — Redirect URL is using an insecure protocol, http is only allowed for hosts with suffix 'localhost'`

which named the fix directly (serve the dashboard over HTTPS). Before the change, the same failure was indistinguishable from a user declining consent.

## Tests

Two added to `tests/hermes_cli/test_mcp_dashboard_oauth.py`:

- the description reaches both the page and the log;
- provider-supplied markup is escaped rather than rendered.

`tests/hermes_cli/test_mcp_dashboard_oauth.py` and `tests/tools/test_mcp_dashboard_oauth.py` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)