### PR TITLE
perf(desktop): make the shell interactive before startup hydration

### DIFF
--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -746,7 +746,7 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
     expect(FakeWebSocket.instances).toHaveLength(socketCount)
   })
 
-  it('passes switch ownership through a session refresh held across a newer switch', async () => {
+  it('keeps a switched connection interactive while stale session hydration is still pending', async () => {
     const staleRefresh = deferred<void>()
     const publications: string[] = []
     let switchRefresh = 0
@@ -774,6 +774,9 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
 
     act(() => connectionApplied?.())
     await vi.waitFor(() => expect(switchRefresh).toBe(1))
+
+    expect($gatewaySwitching.get()).toBe(false)
+    expect($desktopBoot.get().visible).toBe(false)
 
     act(() => connectionApplied?.())
     await vi.waitFor(() => expect(switchRefresh).toBe(2))
@@ -1415,20 +1418,20 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
     expect($desktopBoot.get().visible).toBe(false)
   })
 
-  it('FIX: a failed session-list fetch during boot is non-fatal — the app still boots', async () => {
-    // The version-skew report: gateway WS connects fine, but refreshSessions()
-    // rejects (e.g. older backend 404s an endpoint the fallback didn't cover,
-    // or a transient read error). That must NOT reject boot() into
-    // failDesktopBoot's "Hermes couldn't start" overlay — the socket is open
-    // and the app is fully usable with an empty sidebar.
+  it('keeps the connected app usable when noncritical startup hydration fails', async () => {
     const refreshSessions = vi.fn(async () => {
       throw new Error('404: {"detail":"No such API endpoint: /api/profiles/sessions/sidebar"}')
     })
 
-    render(<Harness refreshSessions={refreshSessions} />)
+    const refreshHermesConfig = vi.fn(async () => {
+      throw new Error('settings read failed')
+    })
+
+    render(<Harness refreshHermesConfig={refreshHermesConfig} refreshSessions={refreshSessions} />)
     await flushAsync()
 
     expect(refreshSessions).toHaveBeenCalled()
+    expect(refreshHermesConfig).toHaveBeenCalled()
     expect($gatewayState.get()).toBe('open')
     // Boot completed: no error, overlay dismissed.
     expect($desktopBoot.get().error).toBeNull()
@@ -1436,32 +1439,42 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
     expect($desktopBoot.get().phase).toBe('renderer.ready')
   })
 
-  it('seeds the configured default project dir pre-connect — no route-resume race (#71873)', async () => {
-    // The reporter's scenario: a configured default project dir must be applied
-    // at boot regardless of route-resume timing. The seed now runs BEFORE the
-    // gateway opens, so no session restore can race it (route-resume is gated
-    // on gatewayState === 'open').
+  it('makes the connected shell interactive before initial hydration finishes', async () => {
+    const sessions = deferred<void>()
+    const config = deferred<void>()
+    const refreshSessions = vi.fn(() => sessions.promise)
+    const refreshHermesConfig = vi.fn(() => config.promise)
+
+    render(<Harness refreshHermesConfig={refreshHermesConfig} refreshSessions={refreshSessions} />)
+    await flushAsync()
+
+    expect(refreshSessions).toHaveBeenCalledOnce()
+    expect(refreshHermesConfig).toHaveBeenCalledOnce()
+    expect($gatewayState.get()).toBe('open')
+    expect($desktopBoot.get().phase).toBe('renderer.ready')
+    expect($desktopBoot.get().visible).toBe(false)
+
+    sessions.resolve()
+    config.resolve()
+    await flushAsync()
+  })
+
+  it('does not hold gateway connection behind configured workspace validation', async () => {
     const desktop = fakeDesktop() as {
       sanitizeWorkspaceCwd?: unknown
       settings?: unknown
     }
 
+    const configuredDir = deferred<{ defaultLabel: string; dir: string; resolvedCwd: string }>()
+
     desktop.settings = {
-      getDefaultProjectDir: vi.fn(async () => ({
-        defaultLabel: 'C:\\Users\\sonny',
-        dir: 'C:\\Hermes',
-        resolvedCwd: 'C:\\Hermes'
-      })),
+      getDefaultProjectDir: vi.fn(() => configuredDir.promise),
       pickDefaultProjectDir: vi.fn(async () => undefined),
       setDefaultProjectDir: vi.fn(async () => undefined)
     }
     desktop.sanitizeWorkspaceCwd = vi.fn(async (cwd: string) => ({ cwd }))
     ;(window as { hermesDesktop?: unknown }).hermesDesktop = desktop
 
-    // Record the cwd at the exact moment the gateway opens its WebSocket: if
-    // the seed moved back post-connect, this would still be '' here and the
-    // end-state assertion would pass anyway (the seed would run later in the
-    // same flush). The construction-time snapshot is what proves ordering.
     let cwdAtConnect = ''
 
     class RecordingSocket extends FakeWebSocket {
@@ -1476,8 +1489,52 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
     render(<Harness />)
     await flushAsync()
 
-    expect(cwdAtConnect).toBe('C:\\Hermes')
+    expect(cwdAtConnect).toBe('')
+    expect($gatewayState.get()).toBe('open')
+    expect($desktopBoot.get().visible).toBe(false)
+
+    configuredDir.resolve({
+      defaultLabel: 'C:\\Users\\sonny',
+      dir: 'C:\\Hermes',
+      resolvedCwd: 'C:\\Hermes'
+    })
+    await flushAsync()
+
     expect($currentCwd.get()).toBe('C:\\Hermes')
+  })
+
+  it('does not let delayed workspace validation overwrite a resumed session cwd (#71873)', async () => {
+    const desktop = fakeDesktop() as {
+      sanitizeWorkspaceCwd?: unknown
+      settings?: unknown
+    }
+
+    const configuredDir = deferred<{ defaultLabel: string; dir: string; resolvedCwd: string }>()
+
+    desktop.settings = {
+      getDefaultProjectDir: vi.fn(() => configuredDir.promise),
+      pickDefaultProjectDir: vi.fn(async () => undefined),
+      setDefaultProjectDir: vi.fn(async () => undefined)
+    }
+    desktop.sanitizeWorkspaceCwd = vi.fn(async (cwd: string) => ({ cwd }))
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = desktop
+
+    render(<Harness />)
+    await flushAsync()
+
+    expect($gatewayState.get()).toBe('open')
+    setActiveSessionId('resumed-session')
+    $currentCwd.set('C:\\Session')
+
+    configuredDir.resolve({
+      defaultLabel: 'C:\\Users\\sonny',
+      dir: 'C:\\Hermes',
+      resolvedCwd: 'C:\\Hermes'
+    })
+    await flushAsync()
+
+    expect($activeSessionId.get()).toBe('resumed-session')
+    expect($currentCwd.get()).toBe('C:\\Session')
   })
 
   it('FIX: primary sleep/wake reconnect dials the window backend, not the active secondary profile', async () => {

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -552,6 +552,10 @@ export function useGatewayBoot({
     async function seedDefaultCwd(shouldPublish: () => boolean = () => true) {
       await ensureDefaultWorkspaceCwd(shouldPublish)
 
+      await seedBackendDefaultCwd(shouldPublish)
+    }
+
+    async function seedBackendDefaultCwd(shouldPublish: () => boolean = () => true) {
       if (!shouldPublish()) {
         return
       }
@@ -651,18 +655,40 @@ export function useGatewayBoot({
 
         void refreshActiveProfile().catch(() => undefined)
 
-        await Promise.all([
-          seedDefaultCwd(ownsSwitch),
-          callbacksRef.current.refreshHermesConfig(false, ownsSwitch).catch(() => undefined),
-          callbacksRef.current.refreshSessions(ownsSwitch).catch(() => undefined)
-        ])
+        // The connected socket/profile is the usable interaction boundary.
+        // Workspace validation, settings, and indexed session rows hydrate
+        // behind it; none is allowed to keep the switch overlay up. Preserve a
+        // source/activation guard so a late result from switch A cannot publish
+        // into a newer switch B after this switch token is released.
+        const hydrationEpoch = gatewayActivationEpoch()
 
-        if (!ownsSwitch()) {
-          return
-        }
+        const ownsHydration = () =>
+          !cancelled &&
+          gatewayActivationEpoch() === hydrationEpoch &&
+          $connection.get()?.connectionId === conn.connectionId &&
+          $connection.get()?.profile === conn.profile
 
         completeDesktopBoot()
         bootCompleted = true
+
+        void Promise.allSettled([
+          seedDefaultCwd(ownsHydration),
+          callbacksRef.current.refreshHermesConfig(false, ownsHydration),
+          callbacksRef.current.refreshSessions(ownsHydration)
+        ]).then(results => {
+          for (const [index, result] of results.entries()) {
+            if (result.status === 'rejected') {
+              console.warn(
+                [
+                  'Failed to sync workspace cwd after switch',
+                  'Failed to load Hermes settings',
+                  'Failed to load sessions'
+                ][index],
+                result.reason
+              )
+            }
+          }
+        })
       } catch (err) {
         const mayPublishFailure =
           !cancelled && (switchToken === null ? !$gatewaySwitching.get() : isCurrentGatewaySwitch(switchToken))
@@ -994,18 +1020,14 @@ export function useGatewayBoot({
         publish(conn)
         setPrimaryGatewayConnection(conn)
 
-        // Seed the workspace BEFORE the gateway opens: every session-restore
-        // path is gated on gatewayState === 'open', so nothing can be active yet
-        // and ensureDefaultWorkspaceCwd's live-session guard passes. The
-        // post-connect seed could lose that race on a slow start (#71873). A
-        // resumed session's own cwd still supersedes this once its runtime
-        // arrives. Non-fatal: the remembered cwd is a fine fallback and the
-        // post-connect pass retries the sync.
-        try {
-          await ensureDefaultWorkspaceCwd()
-        } catch (err) {
+        // Workspace validation is cache hydration, not a connection
+        // prerequisite. Start it now so the common fast result wins the race,
+        // but never hold the WebSocket or shell behind filesystem/settings IPC.
+        // Its own live-session guard ensures a later result cannot overwrite a
+        // resumed session's authoritative cwd.
+        const cwdSeed = ensureDefaultWorkspaceCwd().catch(err => {
           console.warn('Failed to seed default workspace cwd pre-connect', err)
-        }
+        })
 
         // Mint a fresh WS URL right before connecting. For OAuth gateways the
         // ticket is single-use with a short TTL, so the ticket baked into
@@ -1039,30 +1061,44 @@ export function useGatewayBoot({
           progress: 97
         })
 
-        await Promise.all([
-          // The pre-connect seed already applied the configured default; this
-          // post-connect pass covers the remote backend default. Non-fatal: a
-          // failed sync must not abort boot (the remembered cwd remains).
-          seedDefaultCwd().catch(err => console.warn('Failed to sync default workspace cwd post-connect', err)),
-          callbacksRef.current.refreshHermesConfig(),
-          // Session-list population is never boot-fatal. The gateway WS is
-          // already open by this point — a failed sidebar fetch (transient
-          // blip, or an endpoint the fallback couldn't cover) must leave the
-          // app usable with an empty sidebar (the reconnect/turn refreshes
-          // retry it), not brick boot behind the "Hermes couldn't start"
-          // overlay. Matches the reconnect + softSwitch call sites.
-          callbacksRef.current.refreshSessions().catch(() => {
-            setSessionsLoading(false)
-          })
-        ])
-
-        if (cancelled) {
-          return
-        }
-
+        // The socket and profile are the interaction boundary. Settings, cwd,
+        // and sidebar rows are independent cache hydration: let their existing
+        // skeleton/stale states fill in without holding the whole app in boot.
         completeDesktopBoot()
         bootCompleted = true
         bootRetryAttempt = 0
+
+        const stillCurrent = () =>
+          !cancelled &&
+          !$gatewaySwitching.get() &&
+          $connection.get()?.connectionId === conn.connectionId &&
+          $connection.get()?.profile === conn.profile
+
+        void Promise.allSettled([
+          // The pre-connect seed already applied the configured default; this
+          // post-connect pass covers the remote backend default. Non-fatal: a
+          // failed sync must not abort boot (the remembered cwd remains).
+          cwdSeed.then(() => seedBackendDefaultCwd(stillCurrent)),
+          callbacksRef.current.refreshHermesConfig(),
+          callbacksRef.current.refreshSessions()
+        ]).then(results => {
+          if (results[2]?.status === 'rejected' && stillCurrent()) {
+            setSessionsLoading(false)
+          }
+
+          for (const [index, result] of results.entries()) {
+            if (result.status === 'rejected') {
+              console.warn(
+                [
+                  'Failed to sync default workspace cwd post-connect',
+                  'Failed to load Hermes settings',
+                  'Failed to load sessions'
+                ][index],
+                result.reason
+              )
+            }
+          }
+        })
       } catch (err) {
         if (!cancelled) {
           const message = err instanceof Error ? err.message : String(err)


### PR DESCRIPTION
## What does this PR do?

Makes Desktop interactive as soon as its gateway socket and active profile are ready, instead of keeping the full-screen boot or connection-switch barrier up while workspace validation, settings, and session rows finish hydrating.

Those reads are noncritical cached/indexed hydration. They now continue in the background with connection, profile, and activation guards so a late result from an older source cannot publish over a newer connection. A resumed session also remains authoritative over a delayed default-workspace result.

The critical path changes from `gateway + profile + slowest(workspace, settings, sessions)` to `gateway + profile`. The focused regression tests deliberately hold hydration promises pending and prove both cold boot and a connection switch are already interactive before those promises settle.

This is the renderer-side companion to #96751: that PR exposes the bound backend earlier, while this PR stops the renderer from holding the usable shell behind unrelated hydration. It is compatible with #73821's stale-boot generation fence and #93186's pre-renderer RPC bridge probe; neither currently changes this interaction boundary.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Release the initial Desktop boot barrier after the WebSocket and active profile are ready.
- Release the soft connection-switch barrier at the same interaction boundary.
- Continue workspace, settings, and session hydration asynchronously with exact source guards.
- Preserve the active-session workspace race protection while removing workspace validation from the connection path.
- Add behavioral regressions for pending hydration, failed noncritical hydration, superseded switches, and delayed workspace results.

## How to Test

1. Run `npm --workspace apps/desktop test -- src/app/gateway/hooks/use-gateway-boot.test.tsx`.
2. Run `npm --workspace apps/desktop run typecheck`.
3. Run `npm --workspace apps/desktop exec eslint src/app/gateway/hooks/use-gateway-boot.ts src/app/gateway/hooks/use-gateway-boot.test.tsx`.

Focused result: 44 Vitest tests passed. Desktop renderer, Electron, and E2E typechecks passed. Affected-file ESLint and `git diff --check` passed.

## Desktop performance series

This change is one independently reviewable layer of the same Desktop startup and first-interaction performance pass.

- #96749 removes unrelated CLI parser work from the `hermes serve` entry path.
- #96750 overlaps independent cached startup preparation before the existing readiness join.
- #96751 lets the verified local Desktop control socket bind before nonessential runtime services finish loading.
- #97032 starts the backend before first-window setup and defers noncritical Electron integrations.
- #97027 releases the renderer boot barrier once the gateway socket and active profile are ready, while noncritical hydration continues.
- #96717 paints connection/profile-scoped session and project navigation from bounded snapshots while live refresh continues.
- #96721 paints the exact connection/profile-scoped remembered transcript before backend/profile hydration, then keeps it visible while the live runtime resumes.
- #96921 prevents the existing transcript cache from discarding a complete suffix that still fits its storage bound.
- #97037 warms common lazy route code serially during idle time in the connected primary window, without prefetching route data.
- #96728 progressively hydrates Bot Mode roster presentation without changing canonical chat identity.

The three Python backend PRs share startup files but solve separate stages. Recommended landing order is #96749, then #96750, then #96751, rebasing the next PR only after the preceding one lands. #97032 is an independently reviewable Electron ordering change. The remaining renderer and Bot Mode PRs can also land independently; their effects compose without making cached state authoritative.
This PR owns the renderer interaction boundary: the shell becomes usable at gateway/profile readiness while guarded hydration continues.


## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable. The behavioral tests hold each hydration path pending and assert that the connected shell is already usable.