### PR TITLE
fix(slack): keep final-only progress quiet

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -131,6 +131,7 @@ _TELEGRAM_NOISY_STATUS_RE = re.compile(
     r"|configured\s+auxiliary\s+compression\s+provider\s+.+\s+unavailable"
     r"|skipping\s+concurrent\s+compression"
     r"|compacting\s+context\s+[—-]\s+summarizing\s+earlier\s+conversation"
+    r"|context\s+compaction\s+complete\s+[—-]\s+continuing\s+turn"
     r"|resumed\s+after\s+\d+s\s+idle\s+[—-]\s+compacting"
     r"|preflight\s+compression"
     r"|pre[- ]api\s+compression"
@@ -4712,6 +4713,13 @@ class TurnRunner:
                 if getattr(result, "success", False):
                     return
                 native_failed = True
+                if not ctx.tool_progress_enabled:
+                    logger.warning(
+                        "Slack native task-card progress failed; text fallback "
+                        "is disabled by display.tool_progress: %s",
+                        getattr(result, "error", "unknown error"),
+                    )
+                    return
                 logger.warning(
                     "Slack native task-card progress failed; falling back "
                     "to an editable text update: %s",
@@ -4719,6 +4727,8 @@ class TurnRunner:
                 )
             # Once the native rail fails, every later lifecycle event
             # edits the same fallback message so progress remains live.
+            if not ctx.tool_progress_enabled:
+                return
             await _send_or_edit_fallback()
 
         def _drain_native_queue() -> bool:

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -1104,7 +1104,7 @@ async def test_slack_native_progress_correlates_concurrent_duplicate_tools_by_id
 
 
 @pytest.mark.asyncio
-async def test_slack_native_failure_keeps_editing_one_live_text_fallback(
+async def test_slack_native_failure_stays_silent_when_text_progress_is_off(
     monkeypatch, tmp_path
 ):
     adapter, result = await _run_with_agent(
@@ -1112,6 +1112,33 @@ async def test_slack_native_failure_keeps_editing_one_live_text_fallback(
         tmp_path,
         DuplicateNativeToolsAgent,
         session_id="sess-native-fallback",
+        platform=Platform.SLACK,
+        chat_id="C1",
+        thread_id="thread-1",
+        adapter_cls=FailingNativeTaskCardAdapter,
+        user_id="U1",
+        scope_id="T1",
+    )
+
+    assert result["final_response"] == "done"
+    assert len(adapter.native_updates) == 1
+    assert adapter.sent == []
+    assert adapter.edits == []
+    assert adapter.native_stops == 1
+
+
+@pytest.mark.asyncio
+async def test_slack_native_failure_keeps_one_text_fallback_when_enabled(
+    monkeypatch, tmp_path
+):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        DuplicateNativeToolsAgent,
+        session_id="sess-native-fallback-enabled",
+        config_data={
+            "display": {"platforms": {"slack": {"tool_progress": "all"}}}
+        },
         platform=Platform.SLACK,
         chat_id="C1",
         thread_id="thread-1",


### PR DESCRIPTION
## What does this PR do?

Final-only Slack sessions no longer leak a plain-text tool list when a native task-card stream ends during a long turn. If `display.tool_progress` is off, Hermes keeps the existing collapsed card quiet and continues to the final response. Profiles that explicitly enable text progress still receive the existing editable fallback.

The live failure returned `message_not_in_streaming_state` after Slack ended the native stream. The fallback path did not check the resolved text-progress setting before posting.

## Related Issue

No linked issue. Reproduced from a live Slack thread and gateway logs.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Respect the resolved `display.tool_progress` setting before creating a plain-text fallback.
- Keep the existing one-message fallback for profiles that explicitly enable text tool progress.
- Cover both settings through the real gateway progress path.

## How to Test

1. Enable Slack native task cards and set `display.tool_progress: off`.
2. Force the native progress call to fail. Confirm no plain-text progress message is sent and the final response still completes.
3. Repeat with `display.tool_progress: all`. Confirm Hermes keeps editing one fallback progress message.

Focused verification on Ubuntu 24.04.3 LTS: 398 gateway progress, Slack adapter, and chat-noise tests passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04.3 LTS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; this restores the existing display contract
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no config change
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; no architecture change
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the gate is platform-independent and only changes Slack delivery
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no tool schema change

## Screenshots / Logs

The production gateway reported `message_not_in_streaming_state`, then logged that it was falling back to an editable text update. The regression test reproduces that boundary without calling Slack.
