### PR TITLE
fix(desktop): retain owner on session search

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -15872,7 +15872,7 @@ async function dispatchRegistryApiRequest(
   })
 
   return (request?.method || 'GET').toUpperCase() === 'GET'
-    ? tagRegistrySessionResponse(requestPath, response, registryConnectionId)
+    ? tagRegistrySessionResponse(requestPath, response, registryConnectionId, routeProfile)
     : response
 }
 

--- a/apps/desktop/electron/profile-session-routing.test.ts
+++ b/apps/desktop/electron/profile-session-routing.test.ts
@@ -333,6 +333,46 @@ test('registry-pinned session responses retain their owning connection', () => {
   assert.equal(single.connection_id, 'test-amnezia')
 })
 
+test('registry-pinned session search results retain their owning connection', () => {
+  const search = tagRegistrySessionResponse(
+    '/api/sessions/search?q=archived%20project',
+    {
+      results: [
+        {
+          session_id: 'remote-chat',
+          snippet: 'Archived project notes'
+        }
+      ]
+    },
+    'registry-remote',
+    'default'
+  ) as any
+
+  assert.equal(search.results[0].connection_id, 'registry-remote')
+  assert.equal(search.results[0].profile, 'default')
+})
+
+test('aggregate session search does not stamp all as a concrete owner profile', () => {
+  const search = tagRegistrySessionResponse(
+    '/api/sessions/search?q=project',
+    {
+      results: [
+        { profile: 'research', session_id: 'research-chat' },
+        { session_id: 'legacy-chat' }
+      ]
+    },
+    'registry-remote',
+    'all'
+  ) as {
+    results: Array<{ connection_id?: string; profile?: string; session_id: string }>
+  }
+
+  assert.deepEqual(search.results, [
+    { connection_id: 'registry-remote', profile: 'research', session_id: 'research-chat' },
+    { connection_id: 'registry-remote', session_id: 'legacy-chat' }
+  ])
+})
+
 test('registry response ownership tagging ignores non-session payloads and transcript messages', () => {
   const status = { ok: true }
   const messages = { messages: [{ id: 'message-1' }], session_id: 'remote-chat' }

--- a/apps/desktop/electron/profile-session-routing.ts
+++ b/apps/desktop/electron/profile-session-routing.ts
@@ -20,11 +20,36 @@ function rowsOf(data: unknown): unknown[] {
   return Array.isArray(data.sessions) ? data.sessions : []
 }
 
+function searchResultsOf(data: unknown): unknown[] {
+  if (!data || typeof data !== 'object' || !('results' in data)) {
+    return []
+  }
+
+  return Array.isArray(data.results) ? data.results : []
+}
+
 function tagRowsWithConnection(rows: unknown[], connectionId: string): void {
   for (const row of rows) {
     if (row && typeof row === 'object') {
       const session = row as Record<string, unknown>
       session.connection_id = connectionId
+    }
+  }
+}
+
+function tagRowsWithOwner(rows: unknown[], connectionId: string, profile?: string): void {
+  tagRowsWithConnection(rows, connectionId)
+
+  const concreteProfile = profile?.trim()
+
+  if (!concreteProfile || concreteProfile === 'all') {
+    return
+  }
+
+  for (const row of rows) {
+    if (row && typeof row === 'object') {
+      const session = row as Record<string, unknown>
+      session.profile ||= concreteProfile
     }
   }
 }
@@ -35,7 +60,12 @@ function tagRowsWithConnection(rows: unknown[], connectionId: string): void {
  * own session rows naturally omit Desktop's synthetic `connection_id`. Without
  * restoring that provenance, a `profile: "default"` row later resumes through
  * the legacy local primary instead of the active registry gateway. */
-export function tagRegistrySessionResponse(path: string, data: unknown, connectionId: string): unknown {
+export function tagRegistrySessionResponse(
+  path: string,
+  data: unknown,
+  connectionId: string,
+  profile?: string
+): unknown {
   if (!data || typeof data !== 'object') {
     return data
   }
@@ -54,6 +84,12 @@ export function tagRegistrySessionResponse(path: string, data: unknown, connecti
     for (const key of ['recents', 'cron', 'messaging']) {
       tagRowsWithConnection(rowsOf(response[key]), connectionId)
     }
+
+    return data
+  }
+
+  if (pathname === '/api/sessions/search') {
+    tagRowsWithOwner(searchResultsOf(data), connectionId, profile)
 
     return data
   }

--- a/apps/desktop/src/api/sessions.ts
+++ b/apps/desktop/src/api/sessions.ts
@@ -334,6 +334,7 @@ export function setSessionUnreadRemote(id: string, unread: boolean, profile?: st
 
 export function searchSessions(query: string): Promise<SessionSearchResponse> {
   return hermesApi<SessionSearchResponse>({
+    ...profileScoped(),
     path: `/api/sessions/search?q=${encodeURIComponent(query)}`
   })
 }

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -268,11 +268,12 @@ export function stripFtsMarkers(snippet: string): string {
   return snippet.replaceAll('>>>', '').replaceAll('<<<', '')
 }
 
-function searchResultToSession(result: SessionSearchResult): SessionInfo {
+export function searchResultToSession(result: SessionSearchResult): SessionInfo {
   const ts = result.session_started ?? Date.now() / 1000
 
   return {
     archived: false,
+    ...(result.connection_id ? { connection_id: result.connection_id } : {}),
     cwd: null,
     ended_at: null,
     id: result.session_id,
@@ -284,6 +285,7 @@ function searchResultToSession(result: SessionSearchResult): SessionInfo {
     model: result.model ?? null,
     output_tokens: 0,
     preview: stripFtsMarkers(result.snippet ?? '').trim() || null,
+    ...(result.profile ? { profile: result.profile } : {}),
     source: result.source ?? null,
     started_at: ts,
     title: null,

--- a/apps/desktop/src/app/chat/sidebar/search-result-owner.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/search-result-owner.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+
+import { searchResultToSession } from './index'
+
+describe('searchResultToSession owner routing', () => {
+  it('preserves the registry connection and profile on a server-only search hit', () => {
+    const session = searchResultToSession({
+      connection_id: 'registry-remote',
+      lineage_root: null,
+      model: null,
+      profile: 'default',
+      role: null,
+      session_id: 'remote-chat',
+      session_started: 1,
+      snippet: 'Archived project notes',
+      source: 'telegram'
+    })
+
+    expect(session.connection_id).toBe('registry-remote')
+    expect(session.profile).toBe('default')
+  })
+})

--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -27,6 +27,7 @@ import {
   listSidebarSessions,
   pluginSocket,
   resetSidebarBatchCapability,
+  searchSessions,
   setApiRequestConnection,
   setApiRequestProfile,
   speakText,
@@ -71,6 +72,20 @@ describe('Hermes REST helpers', () => {
         timeoutMs: 60_000
       })
     )
+  })
+
+  it('routes session search through the active registry connection and profile', async () => {
+    api.mockResolvedValue({ results: [], total: 0 })
+    setApiRequestConnection('registry-remote')
+    setApiRequestProfile('research')
+
+    await searchSessions('archived project')
+
+    expect(api).toHaveBeenCalledWith({
+      connectionId: 'registry-remote',
+      path: '/api/sessions/search?q=archived%20project',
+      profile: 'research'
+    })
   })
 
   it('uses a longer timeout for the all-profile session list', async () => {

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -1174,10 +1174,12 @@ export interface ComputerUseStatus {
 }
 
 export interface SessionSearchResult {
+  connection_id?: string | null
   /** Lineage root of the matched conversation. Stable across compression and
    *  used as the durable pin id; falls back to session_id when absent. */
   lineage_root?: string | null
   model: string | null
+  profile?: string | null
   role: string | null
   /** Live compression tip of the matched conversation — resume by this id. */
   session_id: string


### PR DESCRIPTION
## Problem

Hermes Desktop registry responses preserve the serving `connection_id` for session lists, sidebar slices, and single-session details, but not for `/api/sessions/search`. Server-only full-text search hits are then converted into `SessionInfo` rows without either `connection_id` or `profile`.

For two connections that both expose a profile named `default` (for example, a Mac-local agent plus an SSH-connected VPS), clicking that remote search hit loses the row's `(connection, profile, session id)` identity. `onResumeSession` cannot pin the clicked owner, and the subsequent resume/retry can activate or query the wrong `default` gateway. The intended remote backend sees a healthy WebSocket but no `session.activate`/`session.resume` for the selected session.

## Root-cause evidence

- Exact Desktop version inspected: v0.20.6 / tag `v2026.8.27`.
- Electron `tagRegistrySessionResponse` covers `/api/sessions`, `/api/profiles/sessions`, `/api/profiles/sessions/sidebar`, and single-session detail, but not `/api/sessions/search`.
- Renderer `searchResultToSession` drops owner fields.
- A focused RED test reproduced `search.results[0].connection_id === undefined` for a registry-pinned search response.
- Source tracing shows that an ownerless server-only search row cannot pin the clicked `(connection, profile)` before resume, so same-named profiles on separate registered gateways can misroute consistently.

## Fix

1. Carry the active profile, together with the ambient registry connection, on the real search request.
2. Pass the authoritative Desktop route profile into the registry response tagger.
3. Tag `/api/sessions/search` hits with the serving registry `connection_id` and concrete route profile.
4. Extend `SessionSearchResult` with optional owner fields.
5. Preserve those fields when synthesizing `SessionInfo`.

Aggregate `profile=all` remains non-concrete: existing per-row profiles are preserved, but `all` is never stamped as a resumable owner.

This keeps owner recovery at the boundary that knows both pieces of identity and avoids SQLite, session lifecycle, retry, or gateway-wide changes.

## Verification

- Electron owner-routing suite: 22 passed.
- UI/session suites: 141 passed.
- Electron and renderer TypeScript: passed.
- ESLint on all changed files: passed.
- `git diff --check`: passed.
- Candidate is applied cleanly to current `origin/main`.

## How to test

1. Activate a registered remote connection and a concrete profile.
2. Search for a session that is not already loaded in the sidebar.
3. Confirm the search request carries both registry connection and profile ownership.
4. Open the result and confirm resume remains on the serving gateway, including when local and remote profiles share the same name.

Automated coverage exercises request scoping, Electron response tagging, aggregate `profile=all`, renderer conversion, and resume routing support.

## Platforms

- Automated Electron and renderer tests run on Linux.
- The reported failure path was Hermes Desktop on macOS connected to a remote Linux gateway; a signed client build was not available for final live verification.

## Risk

Low and bounded. Existing list/detail tagging behavior is unchanged. Search metadata fields are optional for backward compatibility; only registry-pinned search responses gain owner provenance. Existing profiles on result rows are preserved rather than overwritten.