### PR TITLE
fix(gateway): report current session override in /status

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -676,6 +676,22 @@ class GatewaySlashCommandsMixin:
                 context_used = _int_value(getattr(ctx, "last_prompt_tokens", 0))
                 context_total = _int_value(getattr(ctx, "context_length", 0))
 
+        # Between turns there may be no resident agent. In that state the
+        # persisted session override is the current routing decision and must
+        # win over lifetime-dominant usage. A long-running conversation can
+        # legitimately have more historical calls on its former provider;
+        # reporting that provider as current makes /status lie after a model
+        # switch even though the next turn is routed through the override.
+        session_override = getattr(session_entry, "model_override", None)
+        if not route_resolved and isinstance(session_override, dict):
+            override_model = _clean_str(session_override.get("model"))
+            override_provider = _clean_str(session_override.get("provider"))
+            if override_model and override_provider:
+                model_name = override_model
+                provider_name = override_provider
+                base_url = _clean_str(session_override.get("base_url"))
+                route_resolved = True
+
         persisted_model = _clean_str(persisted_route.get("model"))
         persisted_provider = _clean_str(persisted_route.get("billing_provider"))
         if not route_resolved and persisted_model and persisted_provider:

--- a/tests/gateway/test_status_command.py
+++ b/tests/gateway/test_status_command.py
@@ -190,6 +190,53 @@ async def test_status_command_uses_dominant_persisted_model_route(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_status_command_prefers_current_session_override_over_historical_route(tmp_path):
+    """A provider switch must change /status without erasing usage history."""
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        model_override={
+            "model": "gpt-5.6-terra-900k",
+            "provider": "openai-codex",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+        },
+    )
+    runner = _make_runner(session_entry)
+    db = SessionDB(db_path=tmp_path / "state.db")
+    runner._session_db = AsyncSessionDB(db)
+    try:
+        db.create_session("sess-1", "telegram", model="gpt-5.6-terra-900k")
+        db.update_token_counts(
+            "sess-1",
+            model="grok-4.6",
+            billing_provider="xai-oauth",
+            billing_base_url="https://api.x.ai/v1",
+            input_tokens=5_000_000,
+            api_call_count=100,
+        )
+        db.update_token_counts(
+            "sess-1",
+            model="gpt-5.6-terra-900k",
+            billing_provider="openai-codex",
+            billing_base_url="https://chatgpt.com/backend-api/codex",
+            input_tokens=100,
+            api_call_count=1,
+        )
+
+        result = await runner._handle_message(_make_event("/status"))
+
+        assert "**Model:** `gpt-5.6-terra-900k` (openai-codex)" in result
+        assert "**Model:** `grok-4.6` (xai-oauth)" not in result
+        assert "**Lifetime tokens billed:** 5,000,100" in result
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
 async def test_agents_command_reports_active_agents_and_processes(monkeypatch):
     session_key = build_session_key(_make_source())
     session_entry = SessionEntry(


### PR DESCRIPTION
[GPT-5.6-SOL] RESPONDING ON BEHALF OF PRAGGY

## Summary

- Prefer the persisted current session model override when `/status` runs between turns and no live agent is resident.
- Fall back to lifetime-dominant usage only when no current override is available.
- Preserve historical usage and lifetime token accounting.

## Reproduction

1. Use provider/model A long enough for it to dominate lifetime usage.
2. Switch the session to provider/model B.
3. Run `/status` between turns, when no live agent is resident.
4. Current `main` reports A even though the next turn is routed through B.

The persisted `SessionEntry.model_override` is the current routing decision, while the dominant route is historical accounting data.

## Validation

`python3 -m pytest tests/gateway/test_status_command.py -q`

Result: 12 passed.

This is intentionally separate from #75549, which handles active fallback runtime snapshots; this case is an explicit persisted session override after a model/provider switch.