### PR TITLE
perf(desktop): start the backend before first-window setup

### DIFF
--- a/apps/desktop/electron/desktop-startup.test.ts
+++ b/apps/desktop/electron/desktop-startup.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { startDesktopFirstWindow } from './desktop-startup'
+
+describe('startDesktopFirstWindow', () => {
+  it('starts the backend first and defers noncritical integrations until after window creation', () => {
+    const order: string[] = []
+    const deferred: Array<() => void> = []
+
+    startDesktopFirstWindow({
+      createWindow: () => order.push('window'),
+      defer: task => deferred.push(task),
+      initializeAfterWindow: () => order.push('deferred'),
+      initializeRendererDependencies: () => order.push('renderer-dependencies'),
+      onBackendError: vi.fn(),
+      startBackend: async () => {
+        order.push('backend')
+      }
+    })
+
+    expect(order).toEqual(['backend', 'renderer-dependencies', 'window'])
+    expect(deferred).toHaveLength(1)
+
+    deferred[0]()
+
+    expect(order).toEqual(['backend', 'renderer-dependencies', 'window', 'deferred'])
+  })
+
+  it('reports an asynchronous backend failure without blocking the first window', async () => {
+    const error = new Error('backend failed')
+    const onBackendError = vi.fn()
+    const createWindow = vi.fn()
+
+    startDesktopFirstWindow({
+      createWindow,
+      defer: vi.fn(),
+      initializeAfterWindow: vi.fn(),
+      initializeRendererDependencies: vi.fn(),
+      onBackendError,
+      startBackend: () => Promise.reject(error)
+    })
+
+    expect(createWindow).toHaveBeenCalledOnce()
+    await Promise.resolve()
+    expect(onBackendError).toHaveBeenCalledWith(error)
+  })
+})

--- a/apps/desktop/electron/desktop-startup.ts
+++ b/apps/desktop/electron/desktop-startup.ts
@@ -1,0 +1,27 @@
+export interface DesktopFirstWindowStartupOptions {
+  createWindow: () => void
+  defer?: (task: () => void) => unknown
+  initializeAfterWindow: () => void
+  initializeRendererDependencies: () => void
+  onBackendError: (error: unknown) => void
+  startBackend: () => Promise<unknown>
+}
+
+/**
+ * Start the backend before renderer-only setup, then create the first window
+ * before noncritical shell integrations run. The backend is single-flight, so
+ * the renderer's later connection request joins this attempt.
+ */
+export function startDesktopFirstWindow({
+  createWindow,
+  defer = task => setImmediate(task),
+  initializeAfterWindow,
+  initializeRendererDependencies,
+  onBackendError,
+  startBackend
+}: DesktopFirstWindowStartupOptions): void {
+  void startBackend().catch(onBackendError)
+  initializeRendererDependencies()
+  createWindow()
+  void defer(initializeAfterWindow)
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -156,6 +156,7 @@ import { adoptServedDashboardToken } from './dashboard-token'
 import { loadOrCreateInstallationId, sshOwnershipId } from './desktop-installation'
 import { formatDesktopLogLine } from './desktop-log-line'
 import { resolveDesktopRemoteRoute } from './desktop-remote-route'
+import { startDesktopFirstWindow } from './desktop-startup'
 import {
   buildPosixCleanupScript,
   buildWindowsCleanupScript,
@@ -13919,7 +13920,7 @@ function closeQuickEntryWindow() {
   quickEntryWindow = null
 }
 
-function createWindow() {
+function createWindow({ startBackend = true }: { startBackend?: boolean } = {}) {
   const icon = getAppIconPath()
   const savedWindowState = readWindowState()
   mainWindow = new BrowserWindow({
@@ -14153,14 +14154,16 @@ function createWindow() {
     )
   }
 
-  // Start the Python backend NOW, in parallel with the renderer load — not on
-  // did-finish-load. The backend cold boot (spawn → port announce → /api/status)
-  // is the dominant startup cost, and serializing it behind Chromium's load
-  // added the whole renderer load time to first-usable-composer. The promise is
-  // shared (backendConnectionState), so the renderer's getConnection() joins
-  // this in-flight boot instead of duplicating it; early boot-progress events
-  // the renderer misses are recovered by its getBootProgress() pull on mount.
-  startHermes().catch(error => rememberLog(error.stack || error.message))
+  if (startBackend) {
+    // Start the Python backend NOW, in parallel with the renderer load — not on
+    // did-finish-load. The backend cold boot (spawn → port announce → /api/status)
+    // is the dominant startup cost, and serializing it behind Chromium's load
+    // added the whole renderer load time to first-usable-composer. The promise is
+    // shared (backendConnectionState), so the renderer's getConnection() joins
+    // this in-flight boot instead of duplicating it; early boot-progress events
+    // the renderer misses are recovered by its getBootProgress() pull on mount.
+    startHermes().catch(error => rememberLog(error.stack || error.message))
+  }
 
   mainWindow.webContents.once('did-finish-load', () => {
     // Zoom restore is handled by wireCommonWindowHandlers (shared with session
@@ -17352,17 +17355,6 @@ app.whenReady().then(() => {
     Menu.setApplicationMenu(null)
   }
 
-  installMediaPermissions()
-  installDownloadHandling()
-  registerMediaProtocol()
-  installEmbedReferer()
-  installRemoteHeaderRules()
-  registerDeepLinkProtocol()
-
-  ensureWslWindowsFonts()
-  configureSpellChecker()
-  registerPowerResumeListeners()
-  keepAwake.set(readPersistedKeepAwake())
   f12Blocked = readPersistedDisableF12()
   // Seed this before the first window exists: a picker can open before
   // startHermes() finishes resolving the configured backend.
@@ -17370,10 +17362,32 @@ app.whenReady().then(() => {
 
   setActiveGatewayProfile(primaryProfile)
   setWslBridgeProfileState(primaryProfile, !primaryBackendIsRemote())
-  // Quick Entry's global chord — registered on ready so a cold launch restores
-  // it without the renderer visiting Settings. A failed registration is logged
-  // here and surfaced in Settings via the IPC state (never silent).
-  applyQuickEntrySettings(readQuickEntrySettings())
+
+  startDesktopFirstWindow({
+    startBackend: () => startHermes(),
+    onBackendError: error =>
+      rememberLog(error instanceof Error ? error.stack || error.message : String(error)),
+    initializeRendererDependencies: () => {
+      installMediaPermissions()
+      installDownloadHandling()
+      registerMediaProtocol()
+      installEmbedReferer()
+      installRemoteHeaderRules()
+      registerDeepLinkProtocol()
+    },
+    createWindow: () => createWindow({ startBackend: false }),
+    initializeAfterWindow: () => {
+      ensureWslWindowsFonts()
+      configureSpellChecker()
+      registerPowerResumeListeners()
+      keepAwake.set(readPersistedKeepAwake())
+
+      // Quick Entry's global chord is restored on every cold launch. A failed
+      // registration remains surfaced through its IPC state; it simply no
+      // longer delays the primary window or backend.
+      applyQuickEntrySettings(readQuickEntrySettings())
+    }
+  })
 
   if (IS_MAC) {
     const reposition = () => wakeIndicatorController.reposition()
@@ -17390,7 +17404,6 @@ app.whenReady().then(() => {
   // its worker waits for the install marker to clear, then reopens every scope
   // captured by the original transaction before removing the journal entry.
   void resumeManagedSshRecoveries()
-  createWindow()
 
   // Win/Linux cold start: the launching hermes:// URL is in our own argv.
   const _coldStartLink = _extractDeepLink(process.argv)


### PR DESCRIPTION
## What does this PR do?

Starts the Desktop backend before renderer-only first-window setup, creates the first window before noncritical shell integrations run, and preserves the existing single-flight backend behavior for later window recreation.

On current `main`, Windows/WSL font setup, Chromium spellcheck configuration, power listeners, keep-awake restoration, and Quick Entry shortcut restoration all run before `createWindow()`. The backend also starts from inside `createWindow()`, after those tasks. This puts unrelated synchronous work in front of both Python startup and the first renderer navigation.

The new startup coordinator establishes the intended order behaviorally:

1. Start the single-flight backend.
2. Install renderer prerequisites while the backend is already starting.
3. Create and navigate the first window.
4. Defer noncritical shell integrations to the next main-loop turn.

This does not change later window recreation: `createWindow()` still starts the backend by default. The cold-start caller suppresses only the redundant second call because it already owns the same startup attempt.

This PR does not include #63492's packaged-renderer transport change. If that PR is rebased later, its renderer listener can remain a navigation prerequisite while backend startup continues independently in parallel.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add a small Electron startup coordinator with an explicit, behavior-tested ordering contract.
- Start the existing single-flight `startHermes()` attempt before renderer prerequisite registration.
- Create the first window before WSL font setup, spellcheck, power listeners, keep-awake restoration, and Quick Entry restoration.
- Keep media, download, protocol, header, and deep-link registration ahead of renderer navigation.
- Preserve the existing `createWindow()` backend-start behavior for later macOS activation and recreated windows.

## How to Test

1. Run `npm --workspace apps/desktop test -- electron/desktop-startup.test.ts`.
2. Run `npm --workspace apps/desktop run typecheck`.
3. Run `npm --workspace apps/desktop exec eslint electron/main.ts electron/desktop-startup.ts electron/desktop-startup.test.ts`.

Focused result: 2 Vitest tests passed. Desktop renderer, Electron, and E2E typechecks passed. Affected-file ESLint and `git diff --check` passed.

## Desktop performance series

This change is one independently reviewable layer of the same Desktop startup and first-interaction performance pass.

- #96749 removes unrelated CLI parser work from the `hermes serve` entry path.
- #96750 overlaps independent cached startup preparation before the existing readiness join.
- #96751 lets the verified local Desktop control socket bind before nonessential runtime services finish loading.
- #97032 starts the backend before first-window setup and defers noncritical Electron integrations.
- #97027 releases the renderer boot barrier once the gateway socket and active profile are ready, while noncritical hydration continues.
- #96717 paints connection/profile-scoped session and project navigation from bounded snapshots while live refresh continues.
- #96721 paints the exact connection/profile-scoped remembered transcript before backend/profile hydration, then keeps it visible while the live runtime resumes.
- #96921 prevents the existing transcript cache from discarding a complete suffix that still fits its storage bound.
- #97037 warms common lazy route code serially during idle time in the connected primary window, without prefetching route data.
- #96728 progressively hydrates Bot Mode roster presentation without changing canonical chat identity.

The three Python backend PRs share startup files but solve separate stages. Recommended landing order is #96749, then #96750, then #96751, rebasing the next PR only after the preceding one lands. #97032 is an independently reviewable Electron ordering change. The remaining renderer and Bot Mode PRs can also land independently; their effects compose without making cached state authoritative.
This PR owns Electron startup ordering: backend startup begins before first-window setup, and noncritical shell integrations run after the first window is created.


## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable. The focused test verifies the startup ordering and the non-blocking failure path.