### PR TITLE
fix(sandbox/install): npm TLS bypass + node-gyp headers in dev-sandbox E2E

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -953,6 +953,10 @@ check_node() {
     if command -v node &> /dev/null && command -v npm &> /dev/null \
         && node_satisfies_build "$(node --version)"; then
         if npm_supports_npmrc "$(npm --version 2>/dev/null)"; then
+            # `node` on PATH may be the managed Node's symlink (install_node
+            # links it into the command link dir), so node-gyp must use the
+            # managed headers, not the host-derived npm_config_nodedir.
+            point_node_gyp_at_managed_node
             log_success "Node.js $(node --version) found"
             HAS_NODE=true
             return 0

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2421,6 +2421,9 @@ install_node_deps() {
         return 0
     fi
 
+    # diag: confirm node-gyp will see the managed Node's headers
+    log_info "npm_config_nodedir=$npm_config_nodedir HERMES_HOME=$HERMES_HOME node=$(command -v node 2>/dev/null)"
+
     if [ "$DISTRO" = "termux" ]; then
         log_info "Skipping automatic Node/browser dependency setup on Termux"
         log_info "Browser automation is not part of the tested Termux install path yet."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2425,7 +2425,7 @@ install_node_deps() {
         # Capture npm output so failures are diagnosable (#87340).
         local npm_log
         npm_log="$(mktemp)"
-        if ! run_with_timeout "$NODE_DEPS_TIMEOUT" npm install --silent \
+        if ! run_with_timeout "$NODE_DEPS_TIMEOUT" npm install --loglevel error \
                 >"$npm_log" 2>&1; then
             log_error "npm install failed or timed out; Node.js dependencies were not installed"
             if [ -s "$npm_log" ]; then
@@ -2541,7 +2541,7 @@ install_node_deps() {
         # Capture npm output so failures are diagnosable (#87340).
         local tui_npm_log
         tui_npm_log="$(mktemp)"
-        if ! run_with_timeout "$NODE_DEPS_TIMEOUT" npm install --silent \
+        if ! run_with_timeout "$NODE_DEPS_TIMEOUT" npm install --loglevel error \
                 >"$tui_npm_log" 2>&1; then
             log_error "TUI npm install failed or timed out; TUI dependencies were not installed"
             if [ -s "$tui_npm_log" ]; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -492,6 +492,18 @@ configure_managed_node_npm_prefix() {
     printf 'prefix=%s\n' "$(dirname "$link_dir")" > "$HERMES_HOME/node/etc/npmrc"
 }
 
+# Make node-gyp compile native addons (node-pty, etc.) against the managed
+# Node's own headers instead of resolving a host Node's install dir. The dev
+# sandbox exports npm_config_nodedir from the *host*'s `command -v node`
+# (e.g. /usr/local on a runner), which has no headers — node-gyp then fails
+# with "common.gypi not found". The managed Node ships include/node/, so point
+# node-gyp at it once the managed Node is on PATH.
+point_node_gyp_at_managed_node() {
+    if [ -d "$HERMES_HOME/node/include/node" ]; then
+        export npm_config_nodedir="$HERMES_HOME/node"
+    fi
+}
+
 get_hermes_command_path() {
     local link_dir
     link_dir="$(get_command_link_dir)"
@@ -954,6 +966,7 @@ check_node() {
     # Prefer a Hermes-managed Node from a previous run over a too-old system one.
     if [ -x "$HERMES_HOME/node/bin/node" ] && [ -x "$HERMES_HOME/node/bin/npm" ] \
         && node_satisfies_build "$("$HERMES_HOME/node/bin/node" --version)"; then
+        point_node_gyp_at_managed_node
         export PATH="$HERMES_HOME/node/bin:$PATH"
         log_success "Node.js $("$HERMES_HOME/node/bin/node" --version) found (Hermes-managed)"
         HAS_NODE=true
@@ -1078,6 +1091,7 @@ install_node() {
     ln -sf "$HERMES_HOME/node/bin/npx"  "$node_link_dir/npx"
 
     configure_managed_node_npm_prefix
+    point_node_gyp_at_managed_node
 
     export PATH="$HERMES_HOME/node/bin:$PATH"
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2425,9 +2425,6 @@ install_node_deps() {
         return 0
     fi
 
-    # diag: confirm node-gyp will see the managed Node's headers
-    log_info "npm_config_nodedir=$npm_config_nodedir HERMES_HOME=$HERMES_HOME node=$(command -v node 2>/dev/null)"
-
     if [ "$DISTRO" = "termux" ]; then
         log_info "Skipping automatic Node/browser dependency setup on Termux"
         log_info "Browser automation is not part of the tested Termux install path yet."

--- a/scripts/sandbox/proxy.py
+++ b/scripts/sandbox/proxy.py
@@ -150,7 +150,14 @@ def relay(source, destination):
         destination.sendall(chunk)
 
 
+# Which upstream host a failure belongs to. Set around every upstream
+# connection; read by handle() so a dropped proxy request names its target.
+_ACTIVE_HOST = ''
+
+
 def forward_https(conn, host, port, request):
+    global _ACTIVE_HOST
+    _ACTIVE_HOST = host
     context = ssl.create_default_context(cafile=str(REAL_CA))
     with socket.create_connection((host, port), timeout=UPSTREAM_TIMEOUT_SECONDS) as raw:
         with context.wrap_socket(raw, server_hostname=host) as upstream:
@@ -159,6 +166,8 @@ def forward_https(conn, host, port, request):
 
 
 def forward_http(conn, host, port, request, target):
+    global _ACTIVE_HOST
+    _ACTIVE_HOST = host
     parsed = urlsplit(target)
     path = parsed.path or '/'
     if parsed.query:
@@ -220,7 +229,12 @@ def handle(conn):
     try:
         handle_request(conn)
     except Exception as error:
-        print(f'proxy request failed: {error!r}', file=sys.stderr, flush=True)
+        host = _ACTIVE_HOST or 'unknown'
+        print(
+            f'proxy request failed: {host} -> {error!r}',
+            file=sys.stderr,
+            flush=True,
+        )
 
 
 def main():

--- a/scripts/sandbox/stage2-run.sh
+++ b/scripts/sandbox/stage2-run.sh
@@ -196,6 +196,11 @@ if [ "$DEV_SANDBOX_INTERACTIVE" = true ]; then
   dev_mounts=(--dev /dev)
 fi
 
+# npm bypasses the MITM proxy on purpose. Node trusts only the real CA bundle
+# (NODE_EXTRA_CA_CERTS above), never the sandbox's minted CA, so every registry
+# fetch through the proxy dies with UNABLE_TO_VERIFY_LEAF_SIGNATURE. Direct
+# connection (slirp NAT, real certs) is the intended reach: the sandbox
+# isolates from the host, not from the internet.
 exec bwrap \
   --unshare-pid \
   --die-with-parent --proc /proc --tmpfs /tmp \
@@ -221,7 +226,7 @@ exec bwrap \
   --setenv HTTP_PROXY http://127.0.0.1:8080 \
   --setenv HTTPS_PROXY http://127.0.0.1:8080 \
   --setenv ALL_PROXY http://127.0.0.1:8080 \
-  --setenv NO_PROXY '' \
+  --setenv NO_PROXY registry.npmjs.org \
   --setenv DEV_SANDBOX_INTERACTIVE "$DEV_SANDBOX_INTERACTIVE" \
   --setenv ELECTRON_DISABLE_SANDBOX 1 \
   "${node_env[@]}" \


### PR DESCRIPTION
Fixes the Install & Update E2E workflow, red every 12h on both this fork and upstream since the fatal npm-failure change (#85537). Verified: installer route passes on CI for v2026.3.12 and v2026.5.29.2.

**Two independent root causes:**

1. **npm cannot trust the sandbox MITM proxy.** `stage2-run.sh` points https_proxy at a MITM proxy minting certs from its own CA, but Node trusts only the real bundle (`NODE_EXTRA_CA_CERTS`), so every registry fetch died with `UNABLE_TO_VERIFY_LEAF_SIGNATURE`. `npm install --silent` swallowed it → empty `npm output:` in E2E logs and a misleading SSL EOF in proxy.log.
   → Fix: `NO_PROXY=registry.npmjs.org`. The sandbox isolates from the host, not from the internet; npm reaches the real registry directly (slirp NAT, real certs).

2. **node-gyp compiles node-pty against a headerless host Node dir.** dev-sandbox exports `npm_config_nodedir` from the host's `command -v node` (/usr/local on runners) which has no headers → `gyp: /usr/local/common.gypi not found ... while reading includes of binding.gyp` on every native rebuild (node-pty now built at install time).
   → Fix: `point_node_gyp_at_managed_node()` sets `npm_config_nodedir` to the managed Node ($HERMES_HOME/node ships include/node/) on every branch that puts node on PATH.

Also: `npm install --silent` → `--loglevel error` so npm failures are actually visible in install logs (the #87340 intent); and the sandbox proxy now logs the failing upstream host instead of an anonymous `SSLEOFError`.

Files: scripts/sandbox/stage2-run.sh, scripts/sandbox/proxy.py, scripts/install.sh