### PR TITLE
perf(desktop): warm common route chunks while idle

### DIFF
--- a/apps/desktop/src/app/contrib/route-loaders.test.ts
+++ b/apps/desktop/src/app/contrib/route-loaders.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest'
+
+import { shouldWarmCommonRoutes } from './route-loaders'
+
+describe('common route warmup eligibility', () => {
+  it('runs only in the connected primary window', () => {
+    expect(shouldWarmCommonRoutes(true, false)).toBe(true)
+    expect(shouldWarmCommonRoutes(false, false)).toBe(false)
+    expect(shouldWarmCommonRoutes(true, true)).toBe(false)
+  })
+})

--- a/apps/desktop/src/app/contrib/route-loaders.ts
+++ b/apps/desktop/src/app/contrib/route-loaders.ts
@@ -1,0 +1,14 @@
+export const loadArtifactsView = () => import('../artifacts')
+export const loadCronView = () => import('../cron')
+export const loadMessagingView = () => import('../messaging')
+export const loadSettingsView = () => import('../settings')
+export const loadSkillsView = () => import('../skills')
+
+/** Common first-click routes, ordered from lighter/more frequent to heavier. */
+export const COMMON_ROUTE_WARMUP_LOADERS = [
+  loadMessagingView,
+  loadArtifactsView,
+  loadCronView,
+  loadSettingsView,
+  loadSkillsView
+] as const

--- a/apps/desktop/src/app/contrib/route-loaders.ts
+++ b/apps/desktop/src/app/contrib/route-loaders.ts
@@ -12,3 +12,7 @@ export const COMMON_ROUTE_WARMUP_LOADERS = [
   loadSettingsView,
   loadSkillsView
 ] as const
+
+export function shouldWarmCommonRoutes(gatewayOpen: boolean, auxiliaryWindow: boolean): boolean {
+  return gatewayOpen && !auxiliaryWindow
+}

--- a/apps/desktop/src/app/contrib/surfaces.tsx
+++ b/apps/desktop/src/app/contrib/surfaces.tsx
@@ -29,14 +29,15 @@ import { StatusbarControls } from '../shell/statusbar-controls'
 
 import { latestChatActions, latestSidebarActions } from './latest-actions'
 import { setStatusbarItemGroup, useStatusbarContributions } from './panes'
+import { loadArtifactsView, loadMessagingView, loadSkillsView } from './route-loaders'
 import type { SidebarActions, WiringActions } from './types'
 
 // Same lazy-view split as DesktopController — pages load on demand. The
 // full-page views the workspace route table mounts live here; overlay views
 // (agents/settings/…) are the controller's and stay in wiring.tsx.
-const ArtifactsView = lazy(async () => ({ default: (await import('../artifacts')).ArtifactsView }))
-const MessagingView = lazy(async () => ({ default: (await import('../messaging')).MessagingView }))
-const SkillsView = lazy(async () => ({ default: (await import('../skills')).SkillsView }))
+const ArtifactsView = lazy(async () => ({ default: (await loadArtifactsView()).ArtifactsView }))
+const MessagingView = lazy(async () => ({ default: (await loadMessagingView()).MessagingView }))
+const SkillsView = lazy(async () => ({ default: (await loadSkillsView()).SkillsView }))
 
 export function LegacySessionRedirect() {
   const { sessionId } = useParams()

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -36,6 +36,7 @@ import { TipHost } from '@/components/tips'
 import { emitGatewayEvent } from '@/contrib/events'
 import { getLatestSessionMessages } from '@/hermes'
 import { type ChatMessage, chatMessageText, preserveLocalAssistantErrors, toChatMessages } from '@/lib/chat-messages'
+import { scheduleIdleWarmup } from '@/lib/idle-warmup'
 import { isMessagingSource } from '@/lib/session-source'
 import { latestSessionTodos } from '@/lib/todos'
 import { activateWakeIndicator } from '@/lib/wake-indicator'
@@ -149,6 +150,7 @@ import { useQuickEntryBridge } from './hooks/use-quick-entry-bridge'
 import { useSessionTileDelegate } from './hooks/use-session-tile-delegate'
 import { McpInstallDeepLinkDialog } from './mcp-install-deeplink-dialog'
 import { $restartPreviewServer, useTitlebarToolContributions } from './panes'
+import { COMMON_ROUTE_WARMUP_LOADERS, loadCronView, loadSettingsView } from './route-loaders'
 import { createSessionRpcDispatcher } from './session-rpc-dispatcher'
 import { ChatRoutesSurface, SidebarSurface, StatusbarSurface, TerminalSurface } from './surfaces'
 import type { WiringActions, WiringApi } from './types'
@@ -158,10 +160,10 @@ import type { WiringActions, WiringApi } from './types'
 // ChatRoutesSurface's and live in ./surfaces.
 const AgentsView = lazy(async () => ({ default: (await import('../agents')).AgentsView }))
 const CommandCenterView = lazy(async () => ({ default: (await import('../command-center')).CommandCenterView }))
-const CronView = lazy(async () => ({ default: (await import('../cron')).CronView }))
+const CronView = lazy(async () => ({ default: (await loadCronView()).CronView }))
 const WebhooksView = lazy(async () => ({ default: (await import('../webhooks')).WebhooksView }))
 const ProfilesView = lazy(async () => ({ default: (await import('../profiles')).ProfilesView }))
-const SettingsView = lazy(async () => ({ default: (await import('../settings')).SettingsView }))
+const SettingsView = lazy(async () => ({ default: (await loadSettingsView()).SettingsView }))
 const StarmapView = lazy(async () => ({ default: (await import('../starmap')).StarmapView }))
 
 // Surfaces (the four wired panes), the render context + WiredPane, and the
@@ -192,6 +194,19 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   const billingSettingsRequest = useStore($billingSettingsRequest)
   const cronReviewRequest = useStore($cronReviewRequest)
   const currentCwd = useStore($currentCwd)
+
+  useEffect(() => {
+    if (gatewayState !== 'open') {
+      return
+    }
+
+    // Warm only common route code, never route data. One shared queue keeps
+    // parsing serialized so background preparation cannot compete with chat.
+    return scheduleIdleWarmup(COMMON_ROUTE_WARMUP_LOADERS, {
+      gapMs: 350,
+      initialDelayMs: 1_500
+    })
+  }, [gatewayState])
 
   // eslint-disable-next-line no-restricted-syntax -- one-shot request-seen sentinel, not an atom mirror
   useEffect(() => {

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -150,7 +150,7 @@ import { useQuickEntryBridge } from './hooks/use-quick-entry-bridge'
 import { useSessionTileDelegate } from './hooks/use-session-tile-delegate'
 import { McpInstallDeepLinkDialog } from './mcp-install-deeplink-dialog'
 import { $restartPreviewServer, useTitlebarToolContributions } from './panes'
-import { COMMON_ROUTE_WARMUP_LOADERS, loadCronView, loadSettingsView } from './route-loaders'
+import { COMMON_ROUTE_WARMUP_LOADERS, loadCronView, loadSettingsView, shouldWarmCommonRoutes } from './route-loaders'
 import { createSessionRpcDispatcher } from './session-rpc-dispatcher'
 import { ChatRoutesSurface, SidebarSurface, StatusbarSurface, TerminalSurface } from './surfaces'
 import type { WiringActions, WiringApi } from './types'
@@ -196,7 +196,10 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   const currentCwd = useStore($currentCwd)
 
   useEffect(() => {
-    if (gatewayState !== 'open') {
+    // Secondary/HUD/browser windows do not own normal navigation. Preloading
+    // the full primary route set there wastes CPU and memory without making a
+    // user interaction faster.
+    if (!shouldWarmCommonRoutes(gatewayState === 'open', isAuxiliaryWindow())) {
       return
     }
 

--- a/apps/desktop/src/lib/idle-warmup.test.ts
+++ b/apps/desktop/src/lib/idle-warmup.test.ts
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { scheduleIdleWarmup } from './idle-warmup'
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('scheduleIdleWarmup', () => {
+  it('waits for each module before scheduling the next one', async () => {
+    vi.useFakeTimers()
+    const order: string[] = []
+    let finishFirst: () => void = () => undefined
+
+    const first = new Promise<void>(resolve => {
+      finishFirst = resolve
+    })
+
+    scheduleIdleWarmup(
+      [
+        async () => {
+          order.push('messaging')
+          await first
+        },
+        async () => void order.push('artifacts'),
+        async () => void order.push('capabilities')
+      ],
+      { gapMs: 20, initialDelayMs: 100 }
+    )
+
+    await vi.advanceTimersByTimeAsync(100)
+    expect(order).toEqual(['messaging'])
+
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(order).toEqual(['messaging'])
+
+    finishFirst()
+    await vi.runAllTimersAsync()
+    expect(order).toEqual(['messaging', 'artifacts', 'capabilities'])
+  })
+
+  it('continues after a module fails to load', async () => {
+    vi.useFakeTimers()
+    const next = vi.fn(async () => undefined)
+
+    scheduleIdleWarmup([async () => Promise.reject(new Error('chunk unavailable')), next], {
+      gapMs: 20,
+      initialDelayMs: 100
+    })
+    await vi.runAllTimersAsync()
+
+    expect(next).toHaveBeenCalledOnce()
+  })
+
+  it('cancels work that has not started', async () => {
+    vi.useFakeTimers()
+    const loader = vi.fn(async () => undefined)
+    const cancel = scheduleIdleWarmup([loader], { initialDelayMs: 100 })
+
+    cancel()
+    await vi.runAllTimersAsync()
+
+    expect(loader).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/lib/idle-warmup.ts
+++ b/apps/desktop/src/lib/idle-warmup.ts
@@ -1,0 +1,71 @@
+type ModuleLoader = () => Promise<unknown>
+
+interface IdleWarmupOptions {
+  gapMs?: number
+  idleTimeoutMs?: number
+  initialDelayMs?: number
+}
+
+/**
+ * Load code chunks one at a time after the foreground settles. Dynamic imports
+ * are cached by the module loader, so opening a warmed surface avoids its
+ * first-click parse/load pause without putting every route on the startup path.
+ */
+export function scheduleIdleWarmup(loaders: readonly ModuleLoader[], options: IdleWarmupOptions = {}): () => void {
+  const initialDelayMs = options.initialDelayMs ?? 1_500
+  const gapMs = options.gapMs ?? 250
+  const idleTimeoutMs = options.idleTimeoutMs ?? 5_000
+  let cancelled = false
+  let idleHandle: null | number = null
+  let timeoutHandle: null | number = null
+  let index = 0
+
+  const schedule = (delayMs: number) => {
+    timeoutHandle = window.setTimeout(() => {
+      timeoutHandle = null
+
+      const run = () => {
+        idleHandle = null
+
+        if (cancelled || index >= loaders.length) {
+          return
+        }
+
+        const loader = loaders[index]
+
+        index += 1
+
+        void Promise.resolve()
+          .then(loader)
+          .catch(() => undefined)
+          .finally(() => {
+            if (!cancelled && index < loaders.length) {
+              schedule(gapMs)
+            }
+          })
+      }
+
+      if (window.requestIdleCallback) {
+        idleHandle = window.requestIdleCallback(run, { timeout: idleTimeoutMs })
+      } else {
+        run()
+      }
+    }, delayMs)
+  }
+
+  if (loaders.length > 0) {
+    schedule(initialDelayMs)
+  }
+
+  return () => {
+    cancelled = true
+
+    if (timeoutHandle !== null) {
+      window.clearTimeout(timeoutHandle)
+    }
+
+    if (idleHandle !== null) {
+      window.cancelIdleCallback(idleHandle)
+    }
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Warms the JavaScript chunks for five common Desktop routes after the gateway is open and the foreground has had time to settle. This removes the first-click chunk load/parse pause from Messaging, Artifacts, Cron, Settings, and Capabilities without moving those routes or their data fetches onto the startup critical path.

The warmup is deliberately bounded: it starts after a 1.5 second delay, uses `requestIdleCallback` when available, imports one chunk at a time with a 350 ms gap after completion, cancels if the gateway closes, and continues after an individual import failure. It runs only in the connected primary window; HUD, browser, and other auxiliary windows do not own normal navigation and do not pay this CPU or memory cost.

It warms code only. Each route still performs its authoritative data load when opened. Agents, Command Center, Profiles, Webhooks, and Starmap remain cold so Desktop does not eagerly parse every optional surface.


## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add a cancellable idle warmup scheduler for dynamic imports.
- Serialize route imports by completion rather than merely staggering their start times.
- Continue the queue after an individual chunk fails.
- Share loader functions between React lazy routes and the warmup queue so each module uses the same cached dynamic import.
- Warm Messaging, Artifacts, Cron, Settings, and Capabilities from one owner after gateway readiness.
- Limit warmup to the connected primary window so HUD, browser, and auxiliary windows do not load routes they cannot navigate to.


## How to Test

1. Run `npm --workspace apps/desktop exec vitest run src/lib/idle-warmup.test.ts src/app/contrib/route-loaders.test.ts`.
2. Run `npm --workspace apps/desktop run typecheck`.
3. Run affected-file ESLint for the scheduler, route loaders, wiring, surfaces, and tests.

Focused result: 4 Vitest tests passed. Desktop renderer, Electron, and E2E typechecks passed. Affected-file ESLint and `git diff --check` passed.


## Desktop performance series

This change is one independently reviewable layer of the same Desktop startup and first-interaction performance pass.

- #96749 removes unrelated CLI parser work from the `hermes serve` entry path.
- #96750 overlaps independent cached startup preparation before the existing readiness join.
- #96751 lets the verified local Desktop control socket bind before nonessential runtime services finish loading.
- #97032 starts the backend before first-window setup and defers noncritical Electron integrations.
- #97027 releases the renderer boot barrier once the gateway socket and active profile are ready, while noncritical hydration continues.
- #96717 paints connection/profile-scoped session and project navigation from bounded snapshots while live refresh continues.
- #96721 paints the exact connection/profile-scoped remembered transcript before backend/profile hydration, then keeps it visible while the live runtime resumes.
- #96921 prevents the existing transcript cache from discarding a complete suffix that still fits its storage bound.
- #97037 warms common lazy route code serially during idle time in the connected primary window, without prefetching route data.
- #96728 progressively hydrates Bot Mode roster presentation without changing canonical chat identity.

The three Python backend PRs share startup files but solve separate stages. Recommended landing order is #96749, then #96750, then #96751, rebasing the next PR only after the preceding one lands. #97032 is an independently reviewable Electron ordering change. The remaining renderer and Bot Mode PRs can also land independently; their effects compose without making cached state authoritative.
This PR owns idle code warmup: the connected primary window warms a small route set after the foreground settles, without prefetching route data.


## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable. The focused tests verify serialization, cancellation, and failure continuation.