### PR TITLE
fix(desktop): keep This-device Default on the local source

### DIFF
--- a/apps/desktop/src/store/profile-select-source.test.ts
+++ b/apps/desktop/src/store/profile-select-source.test.ts
@@ -6,7 +6,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 // names one of THAT source's profiles. Routing it through the profile-only
 // path resolved the descriptor with a bare name, which the main process
 // answers against the primary — the gateway snapped back home and the pick
-// looked like it never took.
+// looked like it never took. Default on the explicit `local` source is the
+// exception: that name is also the window primary's profile key, so the
+// profile-only door would activate a remote-primary VPS.
 
 const ensureGatewayForProfile = vi.fn(async (_profile: string) => undefined)
 const ensureGatewayForAgent = vi.fn(async (_connectionId: null | string, _profile: string) => true)
@@ -70,6 +72,15 @@ describe('selectProfile', () => {
     await vi.waitFor(() => expect(ensureGatewayForProfile).toHaveBeenCalledWith('override-profile'))
     expect(ensureGatewayForAgent).not.toHaveBeenCalled()
   })
+
+  it('keeps Default on the explicit local source instead of the window primary', async () => {
+    activeGatewayConnectionId.mockReturnValue('local')
+
+    selectProfile('default')
+
+    await vi.waitFor(() => expect(ensureGatewayForAgent).toHaveBeenCalledWith('local', 'default'))
+    expect(ensureGatewayForProfile).not.toHaveBeenCalled()
+  })
 })
 
 describe('newSessionInProfile', () => {
@@ -89,6 +100,15 @@ describe('newSessionInProfile', () => {
 
     await vi.waitFor(() => expect(ensureGatewayForProfile).toHaveBeenCalledWith('override-profile'))
     expect(ensureGatewayForAgent).not.toHaveBeenCalled()
+  })
+
+  it('opens a Default new chat on the explicit local source, not the window primary', async () => {
+    activeGatewayConnectionId.mockReturnValue('local')
+
+    newSessionInProfile('default')
+
+    await vi.waitFor(() => expect(ensureGatewayForAgent).toHaveBeenCalledWith('local', 'default'))
+    expect(ensureGatewayForProfile).not.toHaveBeenCalled()
   })
 })
 

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -268,8 +268,8 @@ export const $newChatRoute = atom<AgentProfileRoute | null>(null)
 // string "omar", and every follow-up RPC dialed requestGatewayForProfile
 // ("omar") — a DIFFERENT socket than the one that created the session —
 // and 4001'd "session not found" (#94071). null = the intent dials the legacy
-// profile-only path (a v1 primary with no registry identity, or a profile
-// pick on the explicit `local` source — see profilePickConnectionId).
+// profile-only path (a v1 primary with no registry identity, or a named
+// profile pick on the explicit `local` source — see profilePickConnectionId).
 export const $newChatConnectionId = atom<null | string>(null)
 
 /** Capture the registry source a new-chat profile intent lands on — by
@@ -281,17 +281,30 @@ export function captureNewChatSource(connectionId: null | string = activeGateway
 
 /**
  * The registry source a PROFILE PICK dials, mirroring activateOnCurrentSource:
- * a live remote registry source keeps its connection id, while the primary and
- * the explicit `local` source take the legacy profile-only path (null) so the
- * main process can resolve a per-profile remote override before falling back
- * to a local backend. The draft's owner must name the socket that activation
- * dials — capturing `local` for a pick would mint the session on the registry
- * entry local::x while the window shows the override's socket.
+ * a live remote registry source keeps its connection id. Named picks on the
+ * explicit `local` source (and the window primary) take the legacy
+ * profile-only path (null) so the main process can resolve a per-profile
+ * remote override before falling back to a local backend (#94166).
+ *
+ * Default on that same `local` source is different: it is also the window
+ * primary's profile key. The legacy door would activate the remote primary on
+ * a VPS-primary desktop, and Bots would show the VPS as Current Gateway.
+ * Keep Default on `local` so This-device home stays on This device.
  */
-function profilePickConnectionId(): null | string {
+function profilePickConnectionId(profile?: string): null | string {
   const connectionId = activeGatewayConnectionId()
 
-  return connectionId && connectionId !== LOCAL_CONNECTION_ID ? connectionId : null
+  if (connectionId && connectionId !== LOCAL_CONNECTION_ID) {
+    return connectionId
+  }
+
+  if (connectionId === LOCAL_CONNECTION_ID) {
+    const key = normalizeProfileKey(profile ?? $newChatProfile.get())
+
+    return key === 'default' ? LOCAL_CONNECTION_ID : null
+  }
+
+  return null
 }
 
 /**
@@ -314,7 +327,9 @@ export function resolveNewChatOwnerRoute(): AgentProfileRoute | null {
   const intentProfile = $newChatProfile.get()
 
   const connectionId = (
-    (intentProfile ? ($newChatConnectionId.get() ?? profilePickConnectionId()) : activeGatewayConnectionId()) ?? ''
+    (intentProfile
+      ? ($newChatConnectionId.get() ?? profilePickConnectionId(intentProfile))
+      : activeGatewayConnectionId()) ?? ''
   ).trim()
 
   if (!connectionId) {
@@ -763,7 +778,7 @@ export function selectProfile(name: string): void {
   // is made on the source the user is looking at (activateOnCurrentSource
   // dials exactly that pair), so the draft's exact owner is that pair — or the
   // legacy profile-only path when that is the door the pick takes.
-  captureNewChatSource(profilePickConnectionId())
+  captureNewChatSource(profilePickConnectionId(target))
 
   if (switching) {
     requestFreshSession()
@@ -825,12 +840,13 @@ async function isLocalDesktopProfile(target: string): Promise<boolean> {
 
 // Route a profile pick at the source the user is LOOKING at. $profiles is the
 // active gateway's list, so a pick made while a remote registry source is live
-// names one of THAT source's profiles and must keep its connection id. The
-// primary and explicit "local" source stay on the legacy profile-only path so
-// the main process can resolve a per-profile remote override before falling
-// back to a local backend.
+// names one of THAT source's profiles and must keep its connection id. Named
+// picks on the primary and explicit "local" source stay on the legacy
+// profile-only path so the main process can resolve a per-profile remote
+// override before falling back to a local backend. Default on `local` stays
+// on that source — see profilePickConnectionId.
 function activateOnCurrentSource(target: string): Promise<void> {
-  const connectionId = profilePickConnectionId()
+  const connectionId = profilePickConnectionId(target)
 
   return connectionId ? ensureGatewayAgent(connectionId, target) : ensureGatewayProfile(target)
 }
@@ -845,7 +861,7 @@ export function newSessionInProfile(name: string): void {
   const target = normalizeProfileKey(name)
   $newChatProfile.set(target)
   $newChatRoute.set(null)
-  captureNewChatSource(profilePickConnectionId())
+  captureNewChatSource(profilePickConnectionId(target))
   requestFreshSession()
   // #81094: surface the failed dial instead of failing silently.
   void activateOnCurrentSource(target).catch((error: unknown) => {


### PR DESCRIPTION
## Summary
- Selecting Default while This device is already active took the legacy profile door, whose key is also the window primary's profile.
- On a VPS-primary desktop that activated the remote gateway, so the Bots page showed the VPS as Current Gateway even though Sessions still looked like This device.
- Default on the explicit `local` source now stays on `local`. Named This-device picks still use the legacy door so a per-profile remote override can resolve.

## Test plan
- [ ] Desktop with a remote VPS as primary plus at least one local bot profile
- [ ] In Sessions, select the named local bot, open Bots — Current Gateway is This device
- [ ] In Sessions, select Default on this device, open Bots — Current Gateway stays This device
- [ ] Repeat Default → Bots after the named local bot; it must not snap back to the VPS
- [ ] A named This-device profile with a remote override still opens through the v1 profile door
- [ ] From `apps/desktop`: `npx vitest run src/store/profile-select-source.test.ts`