### PR TITLE
fix(terminal): scope config bridge to active profile

### DIFF
--- a/agent/context_references.py
+++ b/agent/context_references.py
@@ -665,15 +665,15 @@ def _agent_visible_path(path: Path) -> str:
     host path when the backend is local or translation is unavailable.
     """
     try:
-        # Desktop/in-process gateways may not have bridged ``terminal.*``
-        # config into ``TERMINAL_ENV`` at startup; run the idempotent bridge so
-        # the credential_files translation gate sees the active backend.
-        from tools.terminal_tool import _ensure_terminal_env_bridged
-
-        _ensure_terminal_env_bridged()
+        # Desktop/in-process gateways select HERMES_HOME per session.  Ask the
+        # terminal config reader for this context rather than relying on the
+        # process-global TERMINAL_ENV value (#96992).
+        from tools.terminal_tool import _get_env_config
         from tools.credential_files import to_agent_visible_cache_path
 
-        return to_agent_visible_cache_path(str(path))
+        return to_agent_visible_cache_path(
+            str(path), backend=_get_env_config()["env_type"]
+        )
     except Exception:
         return str(path)
 

--- a/tests/tools/test_docker_session_isolation.py
+++ b/tests/tools/test_docker_session_isolation.py
@@ -44,8 +44,6 @@ def _clean_state(monkeypatch):
     with terminal_tool._session_cwd_lock:
         before_cwd = dict(terminal_tool._session_cwd)
         terminal_tool._session_cwd.clear()
-    # The config→env bridge is one-shot; mark it done so tests control env vars.
-    monkeypatch.setattr(terminal_tool, "_terminal_config_bridge_attempted", True)
     yield
     terminal_tool._task_env_overrides.clear()
     terminal_tool._task_env_overrides.update(before_overrides)

--- a/tests/tools/test_terminal_degraded_mode.py
+++ b/tests/tools/test_terminal_degraded_mode.py
@@ -27,9 +27,6 @@ def isolated_env(tmp_path, monkeypatch):
     import tools.terminal_tool as tt
 
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
-    # The one-shot config bridge would overwrite our TERMINAL_* test vars
-    # from the developer's real config.yaml; mark it as already attempted.
-    monkeypatch.setattr(tt, "_terminal_config_bridge_attempted", True)
 
     def _clear():
         with tt._env_lock:

--- a/tests/tools/test_terminal_env_bridge.py
+++ b/tests/tools/test_terminal_env_bridge.py
@@ -1,9 +1,10 @@
-"""Behavioral regressions for the terminal config → env bridge.
+"""Behavioral regressions for profile-scoped terminal configuration.
 
 ``terminal_tool._get_env_config()`` reads TERMINAL_* variables.  The bridge
 must let explicitly configured terminal keys override stale launcher/.env
 values while preserving environment values for terminal keys omitted from
-config.yaml.
+config.yaml.  It must never write one Desktop session's profile config into
+the process environment used by another session.
 """
 
 import os
@@ -11,13 +12,16 @@ import os
 import pytest
 
 import tools.terminal_tool as terminal_tool
-from hermes_constants import get_hermes_home
+from hermes_constants import (
+    get_hermes_home,
+    reset_hermes_home_override,
+    set_hermes_home_override,
+)
 
 
 @pytest.fixture(autouse=True)
 def _reset_bridge_state(monkeypatch):
-    """Each test starts with an un-attempted bridge and clean mapped env."""
-    monkeypatch.setattr(terminal_tool, "_terminal_config_bridge_attempted", False)
+    """Each test starts with clean mapped process environment."""
     for name in (
         "TERMINAL_ENV",
         "TERMINAL_CWD",
@@ -45,7 +49,7 @@ def test_unset_terminal_env_backfills_backend_from_config():
 
     assert config["env_type"] == "docker"
     assert config["docker_image"] == "custom/image:1"
-    assert os.environ["TERMINAL_ENV"] == "docker"
+    assert "TERMINAL_ENV" not in os.environ
 
 
 def test_explicit_config_backend_overrides_stale_env(monkeypatch):
@@ -55,7 +59,7 @@ def test_explicit_config_backend_overrides_stale_env(monkeypatch):
     config = terminal_tool._get_env_config()
 
     assert config["env_type"] == "docker"
-    assert os.environ["TERMINAL_ENV"] == "docker"
+    assert os.environ["TERMINAL_ENV"] == "local"
 
 
 def test_partial_terminal_config_preserves_unrelated_env_values(monkeypatch):
@@ -93,7 +97,7 @@ def test_ssh_config_preserves_remote_tilde_cwd(monkeypatch):
 
     config = terminal_tool._get_env_config()
 
-    assert os.environ["TERMINAL_CWD"] == "~"
+    assert "TERMINAL_CWD" not in os.environ
     assert config["cwd"] == "~"
 
 
@@ -114,27 +118,40 @@ def test_defaults_backfill_when_neither_config_nor_env_selects_backend():
     config = terminal_tool._get_env_config()
 
     assert config["env_type"] == "local"
-    assert os.environ["TERMINAL_ENV"] == "local"
+    assert "TERMINAL_ENV" not in os.environ
 
 
-def test_bridge_only_attempted_once(monkeypatch):
-    calls = []
+def test_profile_contexts_do_not_share_docker_settings(tmp_path):
+    """A Desktop worker must read its own profile, not a prior session's."""
+    home_a = tmp_path / "profiles" / "coder"
+    home_b = tmp_path / "profiles" / "reviewer"
+    (home_a / "config.yaml").parent.mkdir(parents=True)
+    (home_b / "config.yaml").parent.mkdir(parents=True)
+    (home_a / "config.yaml").write_text(
+        "terminal:\n  backend: docker\n  docker_image: coder/image:1\n"
+        "  docker_volumes: ['~/coder:/workspace']\n"
+    )
+    (home_b / "config.yaml").write_text(
+        "terminal:\n  backend: docker\n  docker_image: reviewer/image:2\n"
+        "  docker_volumes: ['~/reviewer:/workspace']\n"
+    )
 
-    import hermes_cli.config as config_mod
+    token_a = set_hermes_home_override(home_a)
+    try:
+        coder = terminal_tool._get_env_config()
+    finally:
+        reset_hermes_home_override(token_a)
+    token_b = set_hermes_home_override(home_b)
+    try:
+        reviewer = terminal_tool._get_env_config()
+    finally:
+        reset_hermes_home_override(token_b)
 
-    real = config_mod.apply_terminal_config_to_env
-
-    def _counting(*args, **kwargs):
-        calls.append(1)
-        return real(*args, **kwargs)
-
-    monkeypatch.setattr(config_mod, "apply_terminal_config_to_env", _counting)
-    _write_config("{}\n")
-
-    terminal_tool._get_env_config()
-    terminal_tool._get_env_config()
-
-    assert len(calls) == 1
+    assert coder["docker_image"] == "coder/image:1"
+    assert coder["docker_volumes"] == ["~/coder:/workspace"]
+    assert reviewer["docker_image"] == "reviewer/image:2"
+    assert reviewer["docker_volumes"] == ["~/reviewer:/workspace"]
+    assert "TERMINAL_DOCKER_IMAGE" not in os.environ
 
 
 def test_bridge_config_failure_does_not_crash(monkeypatch):

--- a/tools/credential_files.py
+++ b/tools/credential_files.py
@@ -521,6 +521,8 @@ def from_agent_visible_cache_path(
 def to_agent_visible_cache_path(
     host_path: str,
     container_base: str = "/root/.hermes",
+    *,
+    backend: str | None = None,
 ) -> str:
     """Translate a host cache path to its mounted path inside the sandbox.
 
@@ -546,7 +548,7 @@ def to_agent_visible_cache_path(
     Backend is identified by TERMINAL_ENV (same env var
     tools/terminal_tool.py reads in _get_environment_config).
     """
-    backend = (os.environ.get("TERMINAL_ENV") or "local").strip().lower()
+    backend = (backend or os.environ.get("TERMINAL_ENV") or "local").strip().lower()
     if backend in ("docker", "modal"):
         pass  # /root/.hermes default
     elif backend in ("ssh", "daytona", "vercel_sandbox"):
@@ -599,5 +601,4 @@ def iter_cache_files(
 def clear_credential_files() -> None:
     """Reset the skill-scoped registry (e.g. on session reset)."""
     _get_registered().clear()
-
 

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -839,7 +839,7 @@ def _sudo_nopasswd_works() -> bool:
     cache) so an expired sudo timestamp cannot make a later command silently
     block waiting for a password.
     """
-    terminal_env = os.getenv("TERMINAL_ENV", "local").strip().lower() or "local"
+    terminal_env = _get_env_config()["env_type"].strip().lower() or "local"
     if terminal_env != "local":
         return False
 
@@ -1383,13 +1383,13 @@ def _session_isolation_enabled() -> bool:
       under non-persistent mode would let two independent ephemeral runs
       attach one live VM and delete it out from under each other).
     """
-    _ensure_terminal_env_bridged()
-    env_type = os.getenv("TERMINAL_ENV", "local")
+    config = _get_env_config()
+    env_type = config["env_type"]
     if env_type != "docker" and not _plugin_env_flag(
         env_type, "session_isolated_when_nonpersistent"
     ):
         return False
-    return os.getenv("TERMINAL_CONTAINER_PERSISTENT", "true").lower() not in {"true", "1", "yes"}
+    return not config["container_persistent"]
 
 
 def _docker_session_isolation_enabled() -> bool:
@@ -1399,7 +1399,7 @@ def _docker_session_isolation_enabled() -> bool:
     selection, session-scoped container teardown) key off it; those must
     not fire for other backends.
     """
-    if os.getenv("TERMINAL_ENV", "local") != "docker":
+    if _get_env_config()["env_type"] != "docker":
         return False
     return _session_isolation_enabled()
 
@@ -1418,10 +1418,10 @@ def _docker_persistent_profile_scoped() -> bool:
     profile scoping for exactly this backend/mode; SSH and other backends
     keep the session-scoped cache key that fixed the original leak.
     """
-    _ensure_terminal_env_bridged()
-    if os.getenv("TERMINAL_ENV", "local") != "docker":
+    config = _get_env_config()
+    if config["env_type"] != "docker":
         return False
-    return os.getenv("TERMINAL_CONTAINER_PERSISTENT", "true").lower() in {"true", "1", "yes"}
+    return config["container_persistent"]
 
 
 def _current_session_profile() -> str:
@@ -1515,7 +1515,10 @@ def _resolve_container_task_id(task_id: Optional[str]) -> str:
             # Explicit opt-in: trusted profiles configuring the same
             # terminal.docker_shared_container_key share ONE container/cache
             # slot (and sandbox dir) regardless of profile name (#84671).
-            shared = os.getenv("TERMINAL_DOCKER_SHARED_CONTAINER_KEY", "").strip()
+            # Some lightweight callers/tests provide only the backend and
+            # persistence fields.  Missing the optional sharing setting means
+            # the historical unshared container behavior.
+            shared = _get_env_config().get("docker_shared_container_key", "")
             if shared:
                 return f"shared:{shared}"
             profile = _current_session_profile() or "default"
@@ -1528,7 +1531,7 @@ def _resolve_container_task_id(task_id: Optional[str]) -> str:
     # sessions land in "shared:<key>" — splitting the very container the
     # setting exists to unify.
     if _docker_persistent_profile_scoped():
-        shared = os.getenv("TERMINAL_DOCKER_SHARED_CONTAINER_KEY", "").strip()
+        shared = _get_env_config().get("docker_shared_container_key", "")
         if shared:
             return f"shared:{shared}"
     return "default"
@@ -1600,13 +1603,20 @@ def _resolve_task_host_cwd(config: Dict[str, Any], task_id: Optional[str]) -> Op
 
 # Configuration from environment variables
 
-def _parse_env_var(name: str, default: str, converter: Any = int, type_label: str = "integer"):
+def _parse_env_var(
+    name: str,
+    default: str,
+    converter: Any = int,
+    type_label: str = "integer",
+    *,
+    env: Optional[Dict[str, str]] = None,
+):
     """Parse an environment variable with *converter*, raising a clear error on bad values.
 
     Without this wrapper, a single malformed env var (e.g. TERMINAL_TIMEOUT=5m)
     causes an unhandled ValueError that kills every terminal command.
     """
-    raw = os.getenv(name, default)
+    raw = (env or os.environ).get(name, default)
     try:
         return converter(raw)
     except (ValueError, json.JSONDecodeError):
@@ -1707,21 +1717,15 @@ def _is_unusable_container_cwd(cwd: str) -> bool:
 # optimization: after the first attempt either TERMINAL_ENV is set (bridge
 # succeeded — merged config always carries terminal.backend) or the import
 # failed and retrying every call would be wasted work.
-_terminal_config_bridge_attempted = False
+def _terminal_config_env() -> Dict[str, str]:
+    """Return terminal settings for the *current* Hermes-home context.
 
-
-def _ensure_terminal_env_bridged() -> None:
-    """Backfill TERMINAL_* env vars from config.yaml when no launcher did.
-
-    terminal_tool reads ALL terminal settings from os.environ (TERMINAL_*).
-    The CLI (cli.py ``env_mappings``), the gateway (gateway/run.py
-    ``_terminal_env_map``), and TUI/dashboard PTY launches
-    (``apply_terminal_config_to_env``) bridge ``terminal.*`` config into env
-    vars at startup — but processes that skip all of those paths (``hermes
-    serve`` / the Desktop app backend's in-process agents, the desktop cron
-    ticker, ACP) used to silently fall back to the local backend even when
-    config.yaml selects ``terminal.backend: docker``, running commands on the
-    host the user intended to sandbox (#63141, #54449, #61115, #65696).
+    Desktop and gateway agents switch ``HERMES_HOME`` with a ContextVar for
+    each session.  Writing that profile's ``terminal.*`` settings back to
+    process-global ``os.environ`` leaked Docker image, mounts, and lifecycle
+    settings into the next profile handled by this process (#96992).  Build a
+    disposable environment instead: it preserves launcher-provided values for
+    omitted keys while applying the active profile's explicit terminal config.
 
     Explicit terminal config keys win: when config.yaml has a ``terminal``
     section, each key present there overrides its matching env value (which may
@@ -1729,10 +1733,7 @@ def _ensure_terminal_env_bridged() -> None:
     keys are preserved. When no terminal section exists, exported/.env values
     keep working unchanged.
     """
-    global _terminal_config_bridge_attempted
-    if _terminal_config_bridge_attempted:
-        return
-    _terminal_config_bridge_attempted = True
+    env = dict(os.environ)
     try:
         from hermes_cli.config import apply_terminal_config_to_env, read_raw_config
 
@@ -1746,25 +1747,36 @@ def _ensure_terminal_env_bridged() -> None:
 
         if has_terminal_section:
             # Explicit terminal keys in config.yaml win over matching env values.
-            apply_terminal_config_to_env(env=None, override=True)
-        elif "TERMINAL_ENV" not in os.environ:
+            apply_terminal_config_to_env(env=env, override=True)
+        elif "TERMINAL_ENV" not in env:
             # No terminal section in config.yaml, TERMINAL_ENV not set —
             # backfill from config defaults
-            apply_terminal_config_to_env(env=None, override=False)
+            apply_terminal_config_to_env(env=env, override=False)
     except Exception:
         # Never let a config problem take the terminal tool down — the
         # historical local default still applies.
         logger.debug("terminal config → env fallback bridge failed", exc_info=True)
+    return env
+
+
+def _ensure_terminal_env_bridged() -> Dict[str, str]:
+    """Compatibility wrapper for readers that only need terminal settings.
+
+    Historically this helper mutated ``os.environ``.  Keeping that mutation
+    would reintroduce the cross-profile leak fixed in #96992, so callers that
+    need the values should consume this returned snapshot instead.
+    """
+    return _terminal_config_env()
 
 
 def _get_env_config() -> Dict[str, Any]:
     """Get terminal environment configuration from environment variables."""
     # Default image with Python and Node.js for maximum compatibility
     default_image = "nikolaik/python-nodejs:python3.11-nodejs20"
-    _ensure_terminal_env_bridged()
-    env_type = os.getenv("TERMINAL_ENV", "local")
+    env = _terminal_config_env()
+    env_type = env.get("TERMINAL_ENV", "local")
     
-    mount_docker_cwd = os.getenv("TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", "false").lower() in {"true", "1", "yes"}
+    mount_docker_cwd = env.get("TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", "false").lower() in {"true", "1", "yes"}
     container_backend = _is_container_backend(env_type)
     docker_backend = env_type == "docker"
 
@@ -1773,20 +1785,20 @@ def _get_env_config() -> Dict[str, Any]:
     # until a backend that can consume them is selected; a stale or invalid
     # Docker value should not make local terminal/execute_code unusable.
     if container_backend:
-        container_cpu = _parse_env_var("TERMINAL_CONTAINER_CPU", "1", float, "number")
-        container_memory = _parse_env_var("TERMINAL_CONTAINER_MEMORY", "5120")
-        container_disk = _parse_env_var("TERMINAL_CONTAINER_DISK", "51200")
+        container_cpu = _parse_env_var("TERMINAL_CONTAINER_CPU", "1", float, "number", env=env)
+        container_memory = _parse_env_var("TERMINAL_CONTAINER_MEMORY", "5120", env=env)
+        container_disk = _parse_env_var("TERMINAL_CONTAINER_DISK", "51200", env=env)
     else:
         container_cpu = 1.0
         container_memory = 5120
         container_disk = 51200
 
     if docker_backend:
-        docker_forward_env = _parse_env_var("TERMINAL_DOCKER_FORWARD_ENV", "[]", json.loads, "valid JSON")
-        docker_volumes = _parse_env_var("TERMINAL_DOCKER_VOLUMES", "[]", json.loads, "valid JSON")
-        docker_env = _parse_env_var("TERMINAL_DOCKER_ENV", "{}", json.loads, "valid JSON")
-        docker_extra_args = _parse_env_var("TERMINAL_DOCKER_EXTRA_ARGS", "[]", json.loads, "valid JSON")
-        docker_shm_size = os.getenv("TERMINAL_DOCKER_SHM_SIZE", "1g")
+        docker_forward_env = _parse_env_var("TERMINAL_DOCKER_FORWARD_ENV", "[]", json.loads, "valid JSON", env=env)
+        docker_volumes = _parse_env_var("TERMINAL_DOCKER_VOLUMES", "[]", json.loads, "valid JSON", env=env)
+        docker_env = _parse_env_var("TERMINAL_DOCKER_ENV", "{}", json.loads, "valid JSON", env=env)
+        docker_extra_args = _parse_env_var("TERMINAL_DOCKER_EXTRA_ARGS", "[]", json.loads, "valid JSON", env=env)
+        docker_shm_size = env.get("TERMINAL_DOCKER_SHM_SIZE", "1g")
     else:
         docker_forward_env = []
         docker_volumes = []
@@ -1810,13 +1822,13 @@ def _get_env_config() -> Dict[str, Any]:
     # If Docker cwd passthrough is explicitly enabled, remap the host path to
     # /workspace and track the original host path separately. Otherwise keep the
     # normal sandbox behavior and discard host paths.
-    cwd = os.getenv("TERMINAL_CWD", default_cwd)
+    cwd = env.get("TERMINAL_CWD", default_cwd)
     from hermes_cli.config import _is_ssh_remote_tilde_cwd
     if cwd and not _is_ssh_remote_tilde_cwd(env_type, cwd):
         cwd = os.path.expanduser(cwd)
     host_cwd = None
     if env_type == "docker" and mount_docker_cwd:
-        docker_cwd_source = os.getenv("TERMINAL_CWD") or _safe_getcwd()
+        docker_cwd_source = env.get("TERMINAL_CWD") or _safe_getcwd()
         candidate = os.path.abspath(os.path.expanduser(docker_cwd_source))
         if (
             any(candidate.startswith(p) for p in _HOST_CWD_PREFIXES)
@@ -1834,41 +1846,42 @@ def _get_env_config() -> Dict[str, Any]:
 
     return {
         "env_type": env_type,
-        "modal_mode": coerce_modal_mode(os.getenv("TERMINAL_MODAL_MODE", "auto")),
-        "docker_image": os.getenv("TERMINAL_DOCKER_IMAGE", default_image),
+        "degraded_mode": env.get("TERMINAL_DEGRADED_MODE", "warn").strip().lower(),
+        "modal_mode": coerce_modal_mode(env.get("TERMINAL_MODAL_MODE", "auto")),
+        "docker_image": env.get("TERMINAL_DOCKER_IMAGE", default_image),
         "docker_forward_env": docker_forward_env,
-        "singularity_image": os.getenv("TERMINAL_SINGULARITY_IMAGE", f"docker://{default_image}"),
-        "modal_image": os.getenv("TERMINAL_MODAL_IMAGE", default_image),
-        "daytona_image": os.getenv("TERMINAL_DAYTONA_IMAGE", default_image),
-        "vercel_runtime": os.getenv("TERMINAL_VERCEL_RUNTIME", "").strip(),
+        "singularity_image": env.get("TERMINAL_SINGULARITY_IMAGE", f"docker://{default_image}"),
+        "modal_image": env.get("TERMINAL_MODAL_IMAGE", default_image),
+        "daytona_image": env.get("TERMINAL_DAYTONA_IMAGE", default_image),
+        "vercel_runtime": env.get("TERMINAL_VERCEL_RUNTIME", "").strip(),
         "cwd": cwd,
         "host_cwd": host_cwd,
         "docker_mount_cwd_to_workspace": mount_docker_cwd,
-        "timeout": _parse_env_var("TERMINAL_TIMEOUT", "180"),
-        "lifetime_seconds": _parse_env_var("TERMINAL_LIFETIME_SECONDS", "300"),
+        "timeout": _parse_env_var("TERMINAL_TIMEOUT", "180", env=env),
+        "lifetime_seconds": _parse_env_var("TERMINAL_LIFETIME_SECONDS", "300", env=env),
         # SSH-specific config
-        "ssh_host": os.getenv("TERMINAL_SSH_HOST", ""),
-        "ssh_user": os.getenv("TERMINAL_SSH_USER", ""),
-        "ssh_port": _parse_env_var("TERMINAL_SSH_PORT", "22"),
-        "ssh_key": os.getenv("TERMINAL_SSH_KEY", ""),
+        "ssh_host": env.get("TERMINAL_SSH_HOST", ""),
+        "ssh_user": env.get("TERMINAL_SSH_USER", ""),
+        "ssh_port": _parse_env_var("TERMINAL_SSH_PORT", "22", env=env),
+        "ssh_key": env.get("TERMINAL_SSH_KEY", ""),
         # Persistent shell: SSH defaults to the config-level persistent_shell
         # setting (true by default for non-local backends); local is always opt-in.
         # Per-backend env vars override if explicitly set.
-        "ssh_persistent": os.getenv(
+        "ssh_persistent": env.get(
             "TERMINAL_SSH_PERSISTENT",
-            os.getenv("TERMINAL_PERSISTENT_SHELL", "true"),
+            env.get("TERMINAL_PERSISTENT_SHELL", "true"),
         ).lower() in {"true", "1", "yes"},
-        "local_persistent": os.getenv("TERMINAL_LOCAL_PERSISTENT", "false").lower() in {"true", "1", "yes"},
+        "local_persistent": env.get("TERMINAL_LOCAL_PERSISTENT", "false").lower() in {"true", "1", "yes"},
         # Container resource config (applies to docker, singularity, modal,
         # daytona, and vercel_sandbox -- ignored for local/ssh)
         "container_cpu": container_cpu,
         "container_memory": container_memory,     # MB (default 5GB)
         "container_disk": container_disk,        # MB (default 50GB)
-        "container_persistent": os.getenv("TERMINAL_CONTAINER_PERSISTENT", "true").lower() in {"true", "1", "yes"},
+        "container_persistent": env.get("TERMINAL_CONTAINER_PERSISTENT", "true").lower() in {"true", "1", "yes"},
         "docker_volumes": docker_volumes,
         "docker_env": docker_env,
-        "docker_run_as_host_user": os.getenv("TERMINAL_DOCKER_RUN_AS_HOST_USER", "false").lower() in {"true", "1", "yes"},
-        "docker_network": os.getenv("TERMINAL_DOCKER_NETWORK", "true").lower() in {"true", "1", "yes"},
+        "docker_run_as_host_user": env.get("TERMINAL_DOCKER_RUN_AS_HOST_USER", "false").lower() in {"true", "1", "yes"},
+        "docker_network": env.get("TERMINAL_DOCKER_NETWORK", "true").lower() in {"true", "1", "yes"},
         "docker_extra_args": docker_extra_args,
         "docker_shm_size": docker_shm_size,
         # Cross-process container reuse (issue #20561).  The docs claim
@@ -1877,17 +1890,17 @@ def _get_env_config() -> Dict[str, Any]:
         # attaching to it instead of always starting a fresh one.  Set to
         # ``false`` for hard per-process isolation (no reuse, container is
         # removed on exit).
-        "docker_persist_across_processes": os.getenv(
+        "docker_persist_across_processes": env.get(
             "TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES", "true"
         ).lower() in {"true", "1", "yes"},
-        "docker_shared_container_key": os.getenv(
+        "docker_shared_container_key": env.get(
             "TERMINAL_DOCKER_SHARED_CONTAINER_KEY", ""
         ).strip(),
         # Startup orphan reaper for hermes-tagged containers left behind by
         # crashed / SIGKILL'd previous processes that bypassed atexit.
         # Conservative: only sweeps Exited containers older than 2× the
         # idle-reap window AND scoped to the current profile. Issue #20561.
-        "docker_orphan_reaper": os.getenv(
+        "docker_orphan_reaper": env.get(
             "TERMINAL_DOCKER_ORPHAN_REAPER", "true"
         ).lower() in {"true", "1", "yes"},
     }
@@ -3858,7 +3871,16 @@ def terminal_tool(
         #   warn (default) — return a structured degraded result the model
         #                    can act on (reason + retry hint, no traceback).
         #   fail           — preserve the historical error+traceback result.
-        degraded_mode = os.getenv("TERMINAL_DEGRADED_MODE", "warn").strip().lower()
+        # Configuration normally exists by the time an environment can fail.
+        # Keep the exception path self-contained as well: config parsing itself
+        # can raise EnvironmentConnectionError (and tests deliberately exercise
+        # that boundary), so no local ``config`` binding is guaranteed here.
+        if "config" in locals():
+            degraded_mode = config["degraded_mode"]
+        else:
+            degraded_mode = _terminal_config_env().get(
+                "TERMINAL_DEGRADED_MODE", "warn"
+            ).strip().lower()
         if degraded_mode == "fail":
             import traceback
             tb_str = traceback.format_exc()


### PR DESCRIPTION
## Summary

Fixes the Desktop in-process terminal configuration leak between Hermes profiles (#96992).

Terminal config is now projected into a disposable environment for the current context-local `HERMES_HOME`, instead of being written into process-global `os.environ`. This keeps each profile's Docker image, mounts, lifecycle settings, and shared-container key isolated while retaining launcher-provided values for config keys the profile does not set.

## Tests

- Added a regression covering two profile contexts in one process with distinct Docker images and volume mounts.
- `pytest -q tests/tools/test_terminal_*.py tests/tools/test_docker_config_migrate.py tests/tools/test_docker_network_config.py tests/tools/test_docker_session_isolation.py` (278 passed)
- `ruff check tools/terminal_tool.py tests/tools/test_terminal_env_bridge.py tests/tools/test_docker_session_isolation.py tests/tools/test_terminal_degraded_mode.py`
- `git diff origin/main...HEAD --check`
