### PR TITLE
fix(agent): preserve active Codex Responses streams

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1501,28 +1501,14 @@ def interruptible_api_call(agent, api_kwargs: dict):
         if _codex_floor:
             _stale_timeout = max(_stale_timeout, _codex_floor)
 
-    # ── Codex absolute hard ceiling (#64507) ──────────────────────────
-    # ``openai_codex_stale_timeout_floor`` *raises* the stale timeout (up to
-    # 1200s at >100k tokens) so healthy gateway-scale payloads aren't aborted.
-    # The scaled no-byte TTFB watchdog catches dead streams that never emit a
-    # first byte, but a request that emits SOME bytes and then wedges (the
-    # issue-64507 symptom: vision-inflated request, worker idle, no ended_at)
-    # is only reclaimed at the (high) stale floor. Add a flat, finite hard
-    # ceiling on total request time that ALWAYS applies to openai-codex
-    # requests regardless of the TTFB/stale interaction, so a stalled request
-    # is recovered (retry loop / visible failure) instead of hanging
-    # indefinitely. The default sits ABOVE the maximum stale floor (1200s) so
-    # it never clamps an intentionally-raised timeout for healthy large
-    # requests — it is a backstop against unbounded growth, not a tighter
-    # limit. Tunable via HERMES_CODEX_HARD_TIMEOUT_SECONDS (set to 0 to
-    # disable the ceiling entirely; that restores the pre-fix behavior).
+    # ── Codex Responses absolute hard ceiling (#64507) ────────────────
+    # This is provider-neutral and independent of the generic non-stream stale
+    # timeout: TTFB owns the pre-event phase, parsed-event idle owns the active
+    # stream phase, and this ceiling is the final absolute-from-start bound.
+    # The default remains above the maximum openai-codex stale floor (1200s).
+    # Set to 0 to preserve the existing operator override that disables it.
     _codex_hard_timeout = _env_float("HERMES_CODEX_HARD_TIMEOUT_SECONDS", 1500.0)
-    if (
-        _codex_watchdog_enabled
-        and _openai_codex_backend
-        and _codex_hard_timeout > 0
-    ):
-        _stale_timeout = min(_stale_timeout, _codex_hard_timeout)
+    _codex_hard_enabled = _codex_watchdog_enabled and _codex_hard_timeout > 0
 
     if _est_tokens_for_codex_watchdog > 100_000:
         _codex_idle_timeout_default = 180.0
@@ -1589,7 +1575,6 @@ def interruptible_api_call(agent, api_kwargs: dict):
         # Reset before the worker starts so a marker left over from a previous
         # call on this agent can't be misread as first-byte for this one.
         agent._codex_stream_last_event_ts = None
-        agent._codex_stream_last_progress_ts = None
 
     _call_start = time.time()
     agent._touch_activity("waiting for non-streaming API response")
@@ -1732,9 +1717,43 @@ def interruptible_api_call(agent, api_kwargs: dict):
                 )
             break
 
+        # Absolute hard ceiling: unlike TTFB and event-idle this is deliberately
+        # measured from request start and applies even while parsed events flow.
+        # It is provider-neutral for every codex_responses request.
+        if _codex_hard_enabled and _elapsed > _codex_hard_timeout:
+            logger.warning(
+                "Codex Responses request exceeded absolute hard ceiling "
+                "(%.0fs > %.0fs, model=%s). Killing connection.",
+                _elapsed,
+                _codex_hard_timeout,
+                api_kwargs.get("model", "unknown"),
+            )
+            agent._buffer_status(
+                f"⚠️ Codex Responses request exceeded its {int(_codex_hard_timeout)}s "
+                f"absolute hard ceiling (model: {api_kwargs.get('model', 'unknown')}). "
+                f"Reconnecting."
+            )
+            try:
+                _close_request_client_once("codex_hard_timeout_kill")
+            except Exception:
+                pass
+            agent._touch_activity(
+                f"codex stream killed at {int(_elapsed)}s absolute hard ceiling"
+            )
+            t.join(timeout=2.0)
+            if result["error"] is None and result["response"] is None:
+                result["error"] = TimeoutError(
+                    f"Codex Responses request exceeded the absolute hard ceiling "
+                    f"of {int(_codex_hard_timeout)}s"
+                )
+            break
+
         # Stale-call detector: kill the connection if no response
-        # arrives within the configured timeout.
-        if _elapsed > _stale_timeout:
+        # arrives within the configured timeout. Codex Responses has the
+        # phase-aware TTFB → parsed-event idle → hard-ceiling hierarchy above;
+        # applying this generic absolute-from-start detector as well would kill
+        # a healthy active stream merely because total generation is long.
+        if not _codex_watchdog_enabled and _elapsed > _stale_timeout:
             _silent_hint: Optional[str] = None
             _hint_fn = getattr(agent, "_codex_silent_hang_hint", None)
             if callable(_hint_fn):

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -1094,8 +1094,8 @@ def _consume_codex_event_stream(
     * ``on_commentary_message(str)`` — fires once per completed
       ``phase=commentary`` message, before any following tool item executes.
     * ``on_first_delta()`` — one-shot, fires on the first text delta only.
-    * ``on_event(event)`` — fires for every event before any other processing.
-      Used for watchdog activity, debug logging, anything wire-shape-agnostic.
+    * ``on_event(event)`` — fires for every parsed Responses/provider-status
+      event before processing. Raw bytes and SSE comments are not activity.
     * ``interrupt_check()`` — returns True to break the loop early.
     """
     collected_output_items: List[Any] = []
@@ -1136,7 +1136,20 @@ def _consume_codex_event_stream(
     next_output_sequence = 0
 
     for event in event_iter:
-        if on_event is not None:
+        event_type = _event_field(event, "type", "")
+        if not isinstance(event_type, str):
+            event_type = ""
+
+        # The watchdog measures parsed protocol activity, not socket reads.
+        # Responses events cover reasoning/content/tools/usage/lifecycle status;
+        # ``codex.*`` covers provider status such as rate-limit updates. Raw
+        # bytes and comment-only SSE keepalives intentionally do not satisfy
+        # TTFB or refresh event-idle.
+        if on_event is not None and (
+            event_type.startswith("response.")
+            or event_type.startswith("codex.")
+            or event_type == "error"
+        ):
             try:
                 on_event(event)
             except (TimeoutError, InterruptedError):
@@ -1149,10 +1162,6 @@ def _consume_codex_event_stream(
                 logger.debug("Codex stream on_event hook raised", exc_info=True)
         if interrupt_check is not None and interrupt_check():
             break
-
-        event_type = _event_field(event, "type", "")
-        if not isinstance(event_type, str):
-            event_type = ""
 
         # ``error`` SSE frames carry the provider's real failure reason
         # (subscription / quota / model-not-available / rejected-reasoning-replay)
@@ -1613,7 +1622,7 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
         agent._fire_streamed_codex_commentary(text)
 
     def _on_event(event: Any) -> None:
-        # TTFB watchdog and activity touch — runs once per SSE event.
+        # TTFB watchdog and activity touch — one authoritative parsed-event clock.
         agent._codex_stream_last_event_ts = time.time()
         agent._touch_activity("receiving stream response")
 

--- a/tests/agent/test_codex_ttfb_watchdog.py
+++ b/tests/agent/test_codex_ttfb_watchdog.py
@@ -340,9 +340,10 @@ def test_large_codex_request_hard_ceiling_reclaims_silent_stall(tmp_path, monkey
         elapsed = time.time() - t0
         # Must die at the hard ceiling (3s), nowhere near the raised stale floor.
         assert elapsed < 30, f"hard ceiling took {elapsed:.1f}s — stall not reclaimed"
-        assert "stale_call_kill" in closes, f"stale kill expected, got {closes}"
-        assert "timed out after" in str(excinfo.value)
-        assert "with no response" in str(excinfo.value)
+        assert "codex_hard_timeout_kill" in closes, (
+            f"hard-ceiling kill expected, got {closes}"
+        )
+        assert "hard ceiling" in str(excinfo.value)
     finally:
         stop["flag"] = True
 

--- a/tests/agent/test_codex_watchdog_hierarchy.py
+++ b/tests/agent/test_codex_watchdog_hierarchy.py
@@ -1,0 +1,352 @@
+"""Behavior contract for Codex Responses stream watchdog ordering and activity."""
+
+from __future__ import annotations
+
+import sys
+import time
+import types
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+sys.modules.setdefault("fire", types.SimpleNamespace(Fire=lambda *a, **k: None))
+sys.modules.setdefault("firecrawl", types.SimpleNamespace(Firecrawl=object))
+sys.modules.setdefault("fal_client", types.SimpleNamespace())
+
+
+def _make_agent(tmp_path, monkeypatch, *, provider="openai-codex"):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / ".env").write_text("", encoding="utf-8")
+    (tmp_path / "config.yaml").write_text("{}\n", encoding="utf-8")
+
+    from run_agent import AIAgent
+
+    base_url = (
+        "https://chatgpt.com/backend-api/codex"
+        if provider == "openai-codex"
+        else "https://api.x.ai/v1"
+    )
+    agent = AIAgent(
+        model="gpt-5.5" if provider == "openai-codex" else "grok-4.3",
+        provider=provider,
+        api_key="test-key",
+        base_url=base_url,
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+        platform="cli",
+    )
+    agent.api_mode = "codex_responses"
+    monkeypatch.setattr(agent, "_emit_status", lambda *args, **kwargs: None)
+    monkeypatch.setattr(agent, "_buffer_status", lambda *args, **kwargs: None)
+    monkeypatch.setattr(agent, "_emit_wait_notice", lambda *args, **kwargs: None)
+    return agent
+
+
+def _completed_event():
+    return SimpleNamespace(
+        type="response.completed",
+        response=SimpleNamespace(status="completed", id="resp-test", usage=None),
+    )
+
+
+class _EventStream:
+    def __init__(self, events, *, delay=0.0):
+        self._events = events
+        self._delay = delay
+
+    def __iter__(self):
+        for event in self._events:
+            if self._delay:
+                time.sleep(self._delay)
+            yield event
+
+    def close(self):
+        pass
+
+
+def _install_stream(agent, monkeypatch, stream_factory):
+    closes = []
+
+    class Responses:
+        def create(self, **kwargs):
+            return stream_factory()
+
+    client = SimpleNamespace(responses=Responses())
+    monkeypatch.setattr(
+        agent, "_create_request_openai_client", lambda **kwargs: client
+    )
+    monkeypatch.setattr(
+        agent,
+        "_abort_request_openai_client",
+        lambda request_client, reason=None: closes.append(reason),
+    )
+    monkeypatch.setattr(
+        agent,
+        "_close_request_openai_client",
+        lambda request_client, reason=None: closes.append(reason),
+    )
+    return closes
+
+
+@pytest.mark.parametrize(
+    "events",
+    [
+        [SimpleNamespace(type="response.reasoning_text.delta", delta="thinking")],
+        [SimpleNamespace(type="response.output_text.delta", delta="answer")],
+        [SimpleNamespace(type="response.function_call_arguments.delta", delta="{}")],
+        [
+            SimpleNamespace(type="response.in_progress"),
+            SimpleNamespace(type="response.usage", input_tokens=10),
+            SimpleNamespace(type="codex.rate_limits", remaining=10),
+        ],
+    ],
+    ids=["reasoning", "content", "tool", "usage-provider-status"],
+)
+def test_parsed_activity_can_stream_beyond_generic_stale_timeout(
+    tmp_path, monkeypatch, events
+):
+    """Parsed reasoning/content/tool/provider-status events refresh one clock."""
+    from agent import chat_completion_helpers as helpers
+
+    agent = _make_agent(tmp_path, monkeypatch)
+    monkeypatch.setattr(
+        agent, "_compute_non_stream_stale_timeout", lambda _kwargs: 0.35
+    )
+    monkeypatch.setenv("HERMES_CODEX_TTFB_TIMEOUT_SECONDS", "0.35")
+    monkeypatch.setenv("HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS", "0.35")
+    monkeypatch.setenv("HERMES_CODEX_HARD_TIMEOUT_SECONDS", "5")
+    closes = _install_stream(
+        agent,
+        monkeypatch,
+        lambda: _EventStream(events * 7 + [_completed_event()], delay=0.1),
+    )
+
+    response = helpers.interruptible_api_call(
+        agent, {"model": agent.model, "input": "hi"}
+    )
+
+    assert response.status == "completed"
+    assert "stale_call_kill" not in closes
+    assert "codex_ttfb_kill" not in closes
+    assert "codex_stream_idle_kill" not in closes
+    assert "codex_hard_timeout_kill" not in closes
+
+
+def test_no_first_parsed_event_uses_ttfb_watchdog(tmp_path, monkeypatch):
+    from agent import chat_completion_helpers as helpers
+
+    agent = _make_agent(tmp_path, monkeypatch)
+    monkeypatch.setattr(
+        agent, "_compute_non_stream_stale_timeout", lambda _kwargs: 5.0
+    )
+    monkeypatch.setenv("HERMES_CODEX_TTFB_TIMEOUT_SECONDS", "0.35")
+    monkeypatch.setenv("HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS", "0.35")
+    monkeypatch.setenv("HERMES_CODEX_HARD_TIMEOUT_SECONDS", "2")
+    stop = {"value": False}
+
+    def no_parsed_events(api_kwargs, client=None, on_first_delta=None):
+        while not stop["value"]:
+            time.sleep(0.05)
+
+    monkeypatch.setattr(agent, "_run_codex_stream", no_parsed_events)
+    closes = _install_stream(agent, monkeypatch, lambda: _EventStream([]))
+
+    try:
+        with pytest.raises(TimeoutError, match="TTFB"):
+            helpers.interruptible_api_call(
+                agent, {"model": agent.model, "input": "hi"}
+            )
+    finally:
+        stop["value"] = True
+
+    assert "codex_ttfb_kill" in closes
+    assert "codex_stream_idle_kill" not in closes
+
+
+def test_stream_then_true_event_idle_uses_idle_watchdog(tmp_path, monkeypatch):
+    from agent import chat_completion_helpers as helpers
+
+    agent = _make_agent(tmp_path, monkeypatch)
+    monkeypatch.setattr(
+        agent, "_compute_non_stream_stale_timeout", lambda _kwargs: 5.0
+    )
+    monkeypatch.setenv("HERMES_CODEX_TTFB_TIMEOUT_SECONDS", "0.35")
+    monkeypatch.setenv("HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS", "0.35")
+    monkeypatch.setenv("HERMES_CODEX_HARD_TIMEOUT_SECONDS", "2")
+
+    def stream_factory():
+        def events():
+            yield SimpleNamespace(type="response.in_progress")
+            time.sleep(5)
+
+        return _EventStream(events())
+
+    closes = _install_stream(agent, monkeypatch, stream_factory)
+
+    with pytest.raises(TimeoutError, match="after first byte"):
+        helpers.interruptible_api_call(agent, {"model": agent.model, "input": "hi"})
+
+    assert "codex_stream_idle_kill" in closes
+    assert "codex_ttfb_kill" not in closes
+
+
+def test_comment_only_and_raw_unparsed_bytes_do_not_establish_activity():
+    from agent.codex_runtime import _consume_codex_event_stream
+
+    seen = []
+    with pytest.raises(RuntimeError, match="did not emit a terminal response"):
+        _consume_codex_event_stream(
+            iter([b": keepalive\n\n", b"raw unparsed bytes"]),
+            model="gpt-5.5",
+            on_event=seen.append,
+        )
+
+    assert seen == []
+
+
+def _install_active_fake_stream(agent, monkeypatch, *, duration=5.0):
+    sentinel = SimpleNamespace(status="completed")
+    stop = {"value": False}
+
+    def fake_stream(api_kwargs, client=None, on_first_delta=None):
+        deadline = time.monotonic() + duration
+        while time.monotonic() < deadline and not stop["value"]:
+            agent._codex_stream_last_event_ts = time.time()
+            time.sleep(0.08)
+        return sentinel
+
+    monkeypatch.setattr(agent, "_run_codex_stream", fake_stream)
+    closes = _install_stream(agent, monkeypatch, lambda: _EventStream([]))
+    return sentinel, closes, stop
+
+
+def test_active_stream_is_killed_only_at_absolute_hard_ceiling(tmp_path, monkeypatch):
+    from agent import chat_completion_helpers as helpers
+
+    agent = _make_agent(tmp_path, monkeypatch)
+    monkeypatch.setattr(
+        agent, "_compute_non_stream_stale_timeout", lambda _kwargs: 0.35
+    )
+    monkeypatch.setenv("HERMES_CODEX_TTFB_TIMEOUT_SECONDS", "0.35")
+    monkeypatch.setenv("HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS", "0.35")
+    monkeypatch.setenv("HERMES_CODEX_HARD_TIMEOUT_SECONDS", "0.75")
+    _, closes, stop = _install_active_fake_stream(agent, monkeypatch)
+
+    try:
+        with pytest.raises(TimeoutError, match="hard ceiling"):
+            helpers.interruptible_api_call(
+                agent, {"model": agent.model, "input": "hi"}
+            )
+    finally:
+        stop["value"] = True
+
+    assert "codex_hard_timeout_kill" in closes
+    assert "stale_call_kill" not in closes
+
+
+def test_hard_ceiling_zero_override_remains_disabled(tmp_path, monkeypatch):
+    from agent import chat_completion_helpers as helpers
+
+    agent = _make_agent(tmp_path, monkeypatch)
+    monkeypatch.setattr(
+        agent, "_compute_non_stream_stale_timeout", lambda _kwargs: 0.35
+    )
+    monkeypatch.setenv("HERMES_CODEX_TTFB_TIMEOUT_SECONDS", "0.35")
+    monkeypatch.setenv("HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS", "0.35")
+    monkeypatch.setenv("HERMES_CODEX_HARD_TIMEOUT_SECONDS", "0")
+    sentinel, closes, _ = _install_active_fake_stream(
+        agent, monkeypatch, duration=0.8
+    )
+
+    response = helpers.interruptible_api_call(
+        agent, {"model": agent.model, "input": "hi"}
+    )
+
+    assert response is sentinel
+    assert "codex_hard_timeout_kill" not in closes
+    assert "stale_call_kill" not in closes
+
+
+@pytest.mark.parametrize("provider", ["xai-oauth", "openai-codex"])
+def test_hard_ceiling_applies_to_every_codex_responses_provider(
+    tmp_path, monkeypatch, provider
+):
+    from agent import chat_completion_helpers as helpers
+
+    agent = _make_agent(tmp_path, monkeypatch, provider=provider)
+    monkeypatch.setattr(
+        agent, "_compute_non_stream_stale_timeout", lambda _kwargs: 5.0
+    )
+    monkeypatch.setenv("HERMES_CODEX_TTFB_TIMEOUT_SECONDS", "0.35")
+    monkeypatch.setenv("HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS", "0.35")
+    monkeypatch.setenv("HERMES_CODEX_HARD_TIMEOUT_SECONDS", "0.75")
+    _, closes, stop = _install_active_fake_stream(agent, monkeypatch)
+
+    try:
+        with pytest.raises(TimeoutError, match="hard ceiling"):
+            helpers.interruptible_api_call(
+                agent, {"model": agent.model, "input": "hi"}
+            )
+    finally:
+        stop["value"] = True
+
+    assert "codex_hard_timeout_kill" in closes
+
+
+def test_codex_transport_retry_is_preserved(tmp_path, monkeypatch):
+    agent = _make_agent(tmp_path, monkeypatch)
+    calls = {"count": 0}
+
+    class Responses:
+        def create(self, **kwargs):
+            calls["count"] += 1
+            if calls["count"] == 1:
+                def broken():
+                    raise httpx.ReadTimeout("retry me")
+                    yield  # pragma: no cover
+
+                return _EventStream(broken())
+            return _EventStream([_completed_event()])
+
+    client = SimpleNamespace(responses=Responses())
+
+    response = agent._run_codex_stream({"model": agent.model}, client=client)
+
+    assert response.status == "completed"
+    assert calls["count"] == 2
+
+
+def test_non_codex_request_keeps_generic_stale_watchdog(tmp_path, monkeypatch):
+    from agent import chat_completion_helpers as helpers
+
+    agent = _make_agent(tmp_path, monkeypatch)
+    agent.api_mode = "chat_completions"
+    monkeypatch.setattr(
+        agent, "_compute_non_stream_stale_timeout", lambda _kwargs: 0.35
+    )
+    closes = []
+    client = SimpleNamespace(
+        chat=SimpleNamespace(
+            completions=SimpleNamespace(create=lambda **kwargs: time.sleep(5))
+        )
+    )
+    monkeypatch.setattr(
+        agent, "_create_request_openai_client", lambda **kwargs: client
+    )
+    monkeypatch.setattr(
+        agent,
+        "_abort_request_openai_client",
+        lambda request_client, reason=None: closes.append(reason),
+    )
+    monkeypatch.setattr(
+        agent,
+        "_close_request_openai_client",
+        lambda request_client, reason=None: closes.append(reason),
+    )
+
+    with pytest.raises(TimeoutError, match="with no response"):
+        helpers.interruptible_api_call(agent, {"model": agent.model, "messages": []})
+
+    assert "stale_call_kill" in closes


### PR DESCRIPTION
## Problem

An active `codex_responses` stream could be aborted by the generic absolute-from-start stale detector even while parsed SSE events continued to arrive.

The stream-aware TTFB and event-idle watchdogs correctly observed progress, but generic stale detection did not consult that activity. Its forced socket close could subsequently surface as `Broken pipe`.

## Root cause

`codex_responses` requests were simultaneously governed by:

1. time-to-first-event;
2. parsed-event idle;
3. generic non-stream absolute-from-start stale timeout.

The third authority could contradict the first two and classify a long, actively progressing stream as stale.

## Fix

Establish one watchdog hierarchy for `codex_responses`:

- TTFB owns the pre-event phase.
- Parsed-event idle owns inactivity after valid parsed events.
- Generic stale remains for non-`codex_responses` calls.
- `HERMES_CODEX_HARD_TIMEOUT_SECONDS` remains the provider-neutral absolute duration ceiling.

Parsed activity includes response lifecycle, reasoning, content, tool-call, usage, provider-status, and error events. Raw/unclassified objects and comment-only keepalives do not reset parsed activity.

This does **not** increase a timeout and introduces no new configuration key.

## Deterministic regression evidence

On exact upstream base with the new regression tests only:

- 4 passed
- 9 failed

With this patch:

- 13 passed
- 0 failed

The RED failures include active reasoning/content/tool/status streams being closed by `stale_call_kill`, plus missing provider-neutral hard-ceiling behavior.

## Regression

- `scripts/run_tests.sh tests/agent/test_codex*.py -q`
- 119 passed
- 0 failed
- `git diff --check`: PASS
- affected-file `py_compile`: PASS
- affected-file Ruff: PASS

## Operational evidence

Supporting evidence from a locally activated runtime:

- 5 completed Grok 4.6/xAI OAuth agent sessions
- 212 successful API calls
- longest successful call: 391 seconds
- no `stale_call_kill` or `Broken pipe` observed in the inspected post-activation interval

This operational evidence is supplementary; deterministic regression tests carry the correctness claim.

## Scope

- `codex_responses` watchdog authority;
- parsed-event activity classification;
- focused regression tests;
- no provider/model routing change;
- no auth change;
- no retry-policy change;
- no dependency change;
- no timeout increase.

## Limitations

- Does not claim to eliminate every transport failure.
- Does not change provider availability or OAuth behavior.
- Does not replace the existing retry loop.
- Upstream CI remains authoritative for broader/cross-platform validation.
