### PR TITLE
fix(desktop): let a per-profile remote override win over the forced-local route

### DIFF
--- a/apps/desktop/electron/connection-registry.test.ts
+++ b/apps/desktop/electron/connection-registry.test.ts
@@ -697,8 +697,21 @@ test('registry local route: v1 REMOTE global mode forces a genuinely-local backe
   assert.notEqual(route.poolKey, backendScopeKey(LOCAL_CONNECTION_ID, 'default'))
 })
 
-test('registry local route: a per-profile remote override also forces local', () => {
+test('registry local route: a per-profile remote override delegates to the override (#90477)', () => {
+  // The per-profile SSH/remote override is the authoritative route for that
+  // profile. Forcing local here made the roster list the profile via its
+  // override but open the thread in a local child — which fails when the
+  // profile exists only on the remote. The override must win.
   const route = resolveRegistryLocalRoute('research', { profileRemoteOverride: true })
+
+  assert.deepEqual(route, { delegate: true, poolKey: 'research' })
+})
+
+test('registry local route: global remote keeps forced-local even when a profile override is absent', () => {
+  // Witness for the other half of the split: app-global remote mode still
+  // forces "This device" to spawn genuinely-local children (migration
+  // scenario above) — only the per-profile override delegates.
+  const route = resolveRegistryLocalRoute('research', { globalRemote: true })
 
   assert.deepEqual(route, { delegate: false, poolKey: 'conn:local::research' })
 })

--- a/apps/desktop/electron/connection-registry.test.ts
+++ b/apps/desktop/electron/connection-registry.test.ts
@@ -707,6 +707,15 @@ test('registry local route: a per-profile remote override delegates to the overr
   assert.deepEqual(route, { delegate: true, poolKey: 'research' })
 })
 
+test('registry local route: per-profile override wins when global remote is also active', () => {
+  const route = resolveRegistryLocalRoute('research', {
+    globalRemote: true,
+    profileRemoteOverride: true
+  })
+
+  assert.deepEqual(route, { delegate: true, poolKey: 'research' })
+})
+
 test('registry local route: global remote keeps forced-local even when a profile override is absent', () => {
   // Witness for the other half of the split: app-global remote mode still
   // forces "This device" to spawn genuinely-local children (migration

--- a/apps/desktop/electron/connection-registry.ts
+++ b/apps/desktop/electron/connection-registry.ts
@@ -493,7 +493,17 @@ export function resolveRegistryLocalRoute(
 ): RegistryLocalRoute {
   const profileKey = String(profile ?? '').trim() || 'default'
 
-  if (opts.globalRemote || opts.profileRemoteOverride) {
+  // A per-profile SSH/remote override is an explicit per-profile routing
+  // decision: the override owns this profile's backend, so the 'local' entry
+  // must delegate to the legacy profile route (which resolves the override),
+  // not spawn a forced-local child. Forcing local here is the #90477 split:
+  // the roster lists the profile via its override, but opening the thread
+  // spawned a local backend that fails when the profile doesn't exist locally.
+  if (opts.profileRemoteOverride) {
+    return { delegate: true, poolKey: profileKey }
+  }
+
+  if (opts.globalRemote) {
     return { delegate: false, poolKey: `${backendScopePrefix(LOCAL_CONNECTION_ID)}${profileKey}` }
   }
 


### PR DESCRIPTION
Refs #90477 (partial — the registered-connection ownership classes were fixed in #95087/#95407; this covers the remaining per-profile-override route @addelh identified in https://github.com/NousResearch/hermes-agent/issues/90477#issuecomment-... ).

## Problem

`resolveRegistryLocalRoute` collapsed `globalRemote` and `profileRemoteOverride` into a single forced-local branch, and the existing unit test pinned that. The two cases are different:

- **`globalRemote`** — forcing the registry `local` entry ("This device") to spawn genuinely-local children is the intended migration behavior (prevents the roster's local rows from enumerating/dialing the remote box). **Unchanged.**
- **`profileRemoteOverride`** — a per-profile SSH/remote override is an explicit, authoritative routing decision for that profile. Forcing local made the roster list the profile via its override but open the thread in a forced-local child, which dies with `Profile "<name>" no longer exists` when the profile only exists on the remote — and then spawn-loops on retry.

Reproduced live on a macOS Desktop in v1 global SSH mode (three profiles `default`/`mythony-agent`/`q-agent` existing only on the remote): the default profile connected fine while the other two failed exactly this way; reported in https://github.com/NousResearch/hermes-agent/issues/90477#issuecomment-5451068539.

## Fix

When `profileRemoteOverride` is set, the registry `local` entry now delegates to the legacy profile route, keeping the override authoritative. `globalRemote` behavior is untouched.

## Regression coverage

- The override test now pins **delegation** (`{ delegate: true, poolKey: 'research' }`).
- A new witness pins that **`globalRemote` alone still forces local** (`conn:local::research`) — both halves of the contract asserted together.

## Test plan

- [x] 88 `connection-registry` tests pass
- [x] 91 `remote-lifecycle` + 73 routing-suite (`desktop-remote-route`, `profile-delete/session/rename-routing`) tests pass
- [x] `tsc --build tsconfig.electron.json` clean
- [ ] End-to-end on a multi-profile SSH remote (the reporter's setup in #90477) after CI approves

Not in scope (flagged in the issue for maintainer input): migrating a pre-registry v1 global SSH config into a registered v2 `ssh` connection — that migration gap is what routes migrated users into this path in the first place.
