### PR TITLE
fix(acp): handle null response on cancellation

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -2158,7 +2158,7 @@ class HermesACPAgent(acp.Agent):
                     exc_info=True,
                 )
 
-        final_response = result.get("final_response", "")
+        final_response = result.get("final_response") or ""
         cancelled = bool(state.cancel_event and state.cancel_event.is_set())
         interrupted = bool(result.get("interrupted")) or cancelled
         # Hermes' local "waiting for model response" interrupt status is metadata,

--- a/tests/acp_adapter/test_acp_commands.py
+++ b/tests/acp_adapter/test_acp_commands.py
@@ -163,6 +163,28 @@ async def test_acp_cancel_publishes_hard_stop_while_holding_runtime_lock():
     assert state.interrupted_prompt_text == "original request"
 
 
+@pytest.mark.asyncio
+async def test_acp_cancel_accepts_none_final_response():
+    acp_agent, state, fake, _conn = make_agent_and_state()
+
+    def interrupted_run(**_kwargs):
+        state.cancel_event.set()
+        return {
+            "final_response": None,
+            "messages": [],
+            "interrupted": True,
+        }
+
+    fake.run_conversation = interrupted_run
+
+    response = await acp_agent.prompt(
+        session_id=state.session_id,
+        prompt=[TextContentBlock(type="text", text="long-running request")],
+    )
+
+    assert response.stop_reason == "cancelled"
+
+
 
 
 


### PR DESCRIPTION
## What

Normalize an ACP turn's null `final_response` to an empty string before interrupt handling.

## Why

Cancellation can return `final_response: null`; calling `.startswith()` on that value failed the turn with JSON-RPC `-32603`.

## How

Use the existing empty-response path for missing and null values, with a regression test covering the cancellation payload.
