### PR TITLE
fix(cli): normalize modified space insertion

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -17819,6 +17819,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # Key bindings for the input area
         kb = KeyBindings()
 
+        from hermes_cli.pt_input_extras import install_canonical_space_binding
+
+        install_canonical_space_binding(kb)
+
         _multiline_shortcuts_enabled = _cli_multiline_shortcuts_enabled(self.config or CLI_CONFIG)
 
         from prompt_toolkit.keys import Keys as _IgnoreKeys

--- a/hermes_cli/pt_input_extras.py
+++ b/hermes_cli/pt_input_extras.py
@@ -50,7 +50,7 @@ def _clear_vt100_prefix_cache() -> None:
 def install_canonical_space_binding(key_bindings) -> None:
     """Insert an ASCII space even when parser data retains escape bytes."""
 
-    @key_bindings.add(" ", eager=True)
+    @key_bindings.add(" ")
     def insert_ascii_space(event):
         event.current_buffer.insert_text(" " * event.arg)
 

--- a/hermes_cli/pt_input_extras.py
+++ b/hermes_cli/pt_input_extras.py
@@ -1,9 +1,8 @@
-"""Augmentations to prompt_toolkit's input-parsing tables.
+"""Augmentations to prompt_toolkit's input parsing and key bindings.
 
-Imported once at CLI startup. Each helper installs a small mapping into
-prompt_toolkit's `ANSI_SEQUENCES` so byte sequences emitted by modern
-keyboard protocols (Kitty / xterm `modifyOtherKeys`) decode to existing
-key tuples Hermes already binds.
+Imported once at CLI startup. Helpers install parser mappings or bindings so
+byte sequences emitted by modern keyboard protocols (Kitty / xterm
+`modifyOtherKeys`) behave like their legacy equivalents.
 
 Kept in a standalone module — separate from `cli.py` — so the registrations
 can be unit-tested without importing the whole CLI runtime.
@@ -46,6 +45,14 @@ def _clear_vt100_prefix_cache() -> None:
         _IS_PREFIX_OF_LONGER_MATCH_CACHE.clear()
     except Exception:
         pass
+
+
+def install_canonical_space_binding(key_bindings) -> None:
+    """Insert an ASCII space even when parser data retains escape bytes."""
+
+    @key_bindings.add(" ", eager=True)
+    def insert_ascii_space(event):
+        event.current_buffer.insert_text(" " * event.arg)
 
 
 def install_shift_enter_alias() -> int:

--- a/tests/cli/test_modify_other_keys_aliases.py
+++ b/tests/cli/test_modify_other_keys_aliases.py
@@ -15,16 +15,21 @@ the raw byte would.
 
 from __future__ import annotations
 
-from types import SimpleNamespace
 from typing import Any, cast
 
 import pytest
 
+from prompt_toolkit.application import Application
+from prompt_toolkit.application.current import set_app
 from prompt_toolkit.buffer import Buffer
+from prompt_toolkit.filters import Condition
+from prompt_toolkit.input import DummyInput
 from prompt_toolkit.input.ansi_escape_sequences import ANSI_SEQUENCES
 from prompt_toolkit.input.vt100_parser import Vt100Parser
 from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.keys import Keys
+from prompt_toolkit.layout import BufferControl, Layout, Window
+from prompt_toolkit.output import DummyOutput
 
 from hermes_cli.pt_input_extras import (
     install_canonical_space_binding,
@@ -62,6 +67,21 @@ def _parse_presses(byte_seq: str):
 def _parse(byte_seq: str):
     """Return the logical keys parsed from a terminal byte sequence."""
     return [kp.key for kp in _parse_presses(byte_seq)]
+
+
+def _dispatch(key_bindings, key_press, buffer):
+    """Dispatch one parsed key through prompt_toolkit's real key processor."""
+    app = Application(
+        layout=Layout(Window(BufferControl(buffer=buffer))),
+        key_bindings=key_bindings,
+        input=DummyInput(),
+        output=DummyOutput(),
+    )
+    cast(Any, app).timeoutlen = None
+    processor = app.key_processor
+    with set_app(app):
+        processor.feed(key_press)
+        processor.process_keys()
 
 
 # ---------------------------------------------------------------------------
@@ -387,12 +407,26 @@ def test_space_binding_inserts_canonical_space(byte_seq):
     assert len(presses) == 1
     assert presses[0].data == byte_seq
 
-    bindings = key_bindings.get_bindings_for_keys((presses[0].key,))
-    assert len(bindings) == 1
+    buffer = Buffer()
+    _dispatch(key_bindings, presses[0], buffer)
+    assert buffer.text == " "
+
+
+def test_specialized_space_binding_takes_precedence():
+    """A mode-specific Space handler must override canonical insertion."""
+    key_bindings = KeyBindings()
+    install_canonical_space_binding(key_bindings)
+    toggled = []
+
+    @key_bindings.add("space", filter=Condition(lambda: True))
+    def clarify_toggle(_event):
+        toggled.append(True)
 
     buffer = Buffer()
-    cast(Any, bindings[0].handler)(SimpleNamespace(current_buffer=buffer, arg=1))
-    assert buffer.text == " "
+    _dispatch(key_bindings, _parse_presses(" ")[0], buffer)
+
+    assert toggled == [True]
+    assert buffer.text == ""
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_modify_other_keys_aliases.py
+++ b/tests/cli/test_modify_other_keys_aliases.py
@@ -15,13 +15,21 @@ the raw byte would.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+from typing import Any, cast
+
 import pytest
 
+from prompt_toolkit.buffer import Buffer
 from prompt_toolkit.input.ansi_escape_sequences import ANSI_SEQUENCES
 from prompt_toolkit.input.vt100_parser import Vt100Parser
+from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.keys import Keys
 
-from hermes_cli.pt_input_extras import install_modify_other_keys_aliases
+from hermes_cli.pt_input_extras import (
+    install_canonical_space_binding,
+    install_modify_other_keys_aliases,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -41,15 +49,19 @@ def _ensure_alias_installed():
     _IS_PREFIX_OF_LONGER_MATCH_CACHE.clear()
 
 
-def _parse(byte_seq: str):
-    """Feed bytes through prompt_toolkit's VT100 parser and return the
-    list of KeyPress objects."""
+def _parse_presses(byte_seq: str):
+    """Feed bytes through the parser without discarding raw key data."""
     out = []
     parser = Vt100Parser(out.append)
     for ch in byte_seq:
         parser.feed(ch)
     parser.flush()
-    return [kp.key for kp in out]
+    return out
+
+
+def _parse(byte_seq: str):
+    """Return the logical keys parsed from a terminal byte sequence."""
+    return [kp.key for kp in _parse_presses(byte_seq)]
 
 
 # ---------------------------------------------------------------------------
@@ -364,6 +376,23 @@ def test_shift_space_inserts_space():
     """Shift+Space must insert a space, not leak escape text (#86866)."""
     assert _parse("\x1b[32;2u") == [" "]
     assert _parse("\x1b[27;2;32~") == [" "]
+
+
+@pytest.mark.parametrize("byte_seq", [" ", "\x1b[32;2u", "\x1b[27;2;32~"])
+def test_space_binding_inserts_canonical_space(byte_seq):
+    """Space insertion must ignore the parser's preserved source bytes."""
+    key_bindings = KeyBindings()
+    install_canonical_space_binding(key_bindings)
+    presses = _parse_presses(byte_seq)
+    assert len(presses) == 1
+    assert presses[0].data == byte_seq
+
+    bindings = key_bindings.get_bindings_for_keys((presses[0].key,))
+    assert len(bindings) == 1
+
+    buffer = Buffer()
+    cast(Any, bindings[0].handler)(SimpleNamespace(current_buffer=buffer, arg=1))
+    assert buffer.text == " "
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Add a canonical Space binding to the classic CLI.

## Why

For modified Space sequences, prompt_toolkit normalizes the logical key but retains the terminal escape sequence as event data. Generic self-insert therefore inserts the escape bytes.

Accidentally holding shift while pressing space produces this input in the hermes CLI under iTerm 3.6.10 in MacOS 15.6 (and bash 5.2.37 in case it matters)
<img width="335" height="90" alt="image" src="https://github.com/user-attachments/assets/e2b7362a-9c3b-45bf-9f66-44c06ba01ef6" />

The change on this branch produces a plain ascii space (0x20) instead.

## How

The binding inserts ASCII spaces from the repeat count instead of event data. It remains non-eager so mode-specific Space handlers retain precedence.
