### PR TITLE
fix(holographic): add trigram CJK search for fact_store (L2)

### DIFF
--- a/plugins/memory/holographic/retrieval.py
+++ b/plugins/memory/holographic/retrieval.py
@@ -103,6 +103,17 @@ class FactRetriever:
                         + self.jaccard_weight * jaccard
                         + self.hrr_weight * hrr_sim)
 
+            # Trigram window-hit boost: when candidates came from the trigram
+            # path, facts sharing more 3-char windows with the query are more
+            # relevant (window_hits added by _fts_candidates).  Bias toward
+            # the query's total window count so a fact hitting all windows
+            # ranks above one hitting a single window.
+            window_hits = fact.get("window_hits", 0)
+            if window_hits:
+                total_windows = len(self._window_tokens(query))
+                if total_windows:
+                    relevance += window_hits / total_windows
+
             # Trust weighting
             score = relevance * fact["trust_score"]
 
@@ -492,6 +503,85 @@ class FactRetriever:
         scored.sort(key=lambda x: x["score"], reverse=True)
         return scored[:limit]
 
+    @staticmethod
+    def _contains_cjk(text: str) -> bool:
+        """True when text contains CJK (Chinese/Japanese/Korean) chars.
+
+        Same ranges used by L3 session search (hermes_state_search.py):
+        CJK Unified Ideographs, Extension A/B, CJK Symbols.
+        """
+        for ch in text:
+            cp = ord(ch)
+            if (0x4E00 <= cp <= 0x9FFF or    # CJK Unified Ideographs
+                    0x3400 <= cp <= 0x4DBF or    # CJK Extension A
+                    0x20000 <= cp <= 0x2A6DF or  # CJK Extension B
+                    0x3000 <= cp <= 0x303F):     # CJK Symbols
+                return True
+        return False
+
+    def _trigram_available(self) -> bool:
+        """True when this SQLite build has the FTS5 trigram tokenizer."""
+        try:
+            conn = self.store._conn
+            conn.execute(
+                "CREATE VIRTUAL TABLE IF NOT EXISTS _tgram_probe USING fts5(x, tokenize='trigram')"
+            )
+            conn.execute("DROP TABLE IF EXISTS _tgram_probe")
+            return True
+        except Exception:
+            return False
+
+    @staticmethod
+    def _or_tokens_trigram(query: str) -> str:
+        """Split a CJK query into overlapping 3-char tokens, OR-joined.
+
+        trigram tokenizer matches >=3-char tokens; a natural-language query
+        like \"VPS内存多大\" as a whole won't appear verbatim in a fact, but
+        its 3-char windows (VPS内, PS内存, 内存多, 存多大, ...) overlap with
+        fact content.  OR-join so any window hit returns candidates, then
+        Jaccard rerank in `search()` picks the best.
+        """
+        q = query.strip()
+        if not q:
+            return q
+        tokens = []
+        # Latin runs are kept whole (>=3 chars) so \"VPS\" survives; CJK is
+        # windowed every 3 chars.  Simple approach: build a token per 3-char
+        # window over the whole string, then also keep whole-word runs.
+        i = 0
+        n = len(q)
+        while i < n:
+            # collect a run: CJK run windowed, else latin/digit run kept whole
+            j = i
+            while j < n and (0x4E00 <= ord(q[j]) <= 0x9FFF or 0x3000 <= ord(q[j]) <= 0x303F):
+                j += 1
+            if j > i:
+                run = q[i:j]
+                for k in range(len(run) - 2):
+                    tokens.append(run[k:k + 3])
+                i = j
+            else:
+                j = i
+                while j < n and not (0x4E00 <= ord(q[j]) <= 0x9FFF or 0x3000 <= ord(q[j]) <= 0x303F):
+                    j += 1
+                w = q[i:j]
+                if len(w) >= 3:
+                    tokens.append(w)
+                elif w:
+                    tokens.append(w)  # 1-2 char latin won't match trigram; harmless
+                i = j
+        if not tokens:
+            return q
+        # Dedupe, keep order, drop tokens that cannot match (len<3 non-CJK)
+        seen = set()
+        out = []
+        for t in tokens:
+            if t in seen:
+                continue
+            seen.add(t)
+            out.append(f'"{t}"')
+        return " OR ".join(out)
+
     def _fts_candidates(
         self,
         query: str,
@@ -506,15 +596,31 @@ class FactRetriever:
         """
         conn = self.store._conn
 
-        # Build query - FTS5 rank is negative (lower = better match)
-        # We need to join facts_fts with facts to get all columns
+        # CJK (Chinese/Japanese/Korean) queries route to the trigram index
+        # (2026-08-27 patch): unicode61 tokenizes CJK into single chars, so
+        # natural-language Chinese queries never match phrases.  The trigram
+        # tokenizer indexes overlapping 3-char sequences, giving substring
+        # match for any >=3-char query.  Same pattern as L3 session search
+        # (messages_fts_trigram in hermes_state_common.py).
+        cjk = self._contains_cjk(query)
+        if cjk and self._trigram_available():
+            table = "facts_fts_trigram"
+            # trigram does substring match on >=3-char tokens.  For
+            # natural-language queries ("VPS内存多大"), OR-join the
+            # 3-char sliding-window tokens so any overlapping phrase can
+            # match, instead of requiring the whole sentence verbatim.
+            match_arg = self._or_tokens_trigram(query)
+        else:
+            table = "facts_fts"
+            # FTS5 defaults to AND-between-tokens, which kills recall on
+            # natural-language queries ("what happened with the deployment
+            # rollback"). Sanitize: drop stopwords, OR-join content tokens, so
+            # any significant term can match.
+            match_arg = self._sanitize_fts_query(query)
+
         params: list = []
-        where_clauses = ["facts_fts MATCH ?"]
-        # FTS5 defaults to AND-between-tokens, which kills recall on
-        # natural-language queries ("what happened with the deployment
-        # rollback"). Sanitize: drop stopwords, OR-join content tokens, so
-        # any significant term can match.
-        params.append(self._sanitize_fts_query(query))
+        where_clauses = [f"{table} MATCH ?"]
+        params.append(match_arg)
 
         if category:
             where_clauses.append("f.category = ?")
@@ -526,11 +632,11 @@ class FactRetriever:
         where_sql = " AND ".join(where_clauses)
 
         sql = f"""
-            SELECT f.*, facts_fts.rank as fts_rank_raw
-            FROM facts_fts
-            JOIN facts f ON f.fact_id = facts_fts.rowid
+            SELECT f.*, {table}.rank as fts_rank_raw
+            FROM {table}
+            JOIN facts f ON f.fact_id = {table}.rowid
             WHERE {where_sql}
-            ORDER BY facts_fts.rank
+            ORDER BY {table}.rank
             LIMIT ?
         """
         params.append(limit)
@@ -543,6 +649,30 @@ class FactRetriever:
 
         if not rows:
             return []
+
+        # For the trigram path, augment ranking with per-fact window-token
+        # hit count: count how many of the query's 3-char windows appear in
+        # this fact's content.  More hits = more relevant (natural-language
+        # queries rarely match verbatim, so this beats raw FTS rank).
+        if cjk and self._trigram_available():
+            windows = self._window_tokens(query)
+            out = []
+            for row in rows:
+                fact = dict(row)
+                fact.pop("fts_rank_raw", None)
+                content = fact.get("content", "")
+                if windows:
+                    hits = sum(1 for w in windows if w in content)
+                    fact["window_hits"] = hits
+                    # fts_rank keeps its normalized position as a tiebreak
+                    fact["fts_rank"] = abs(row["fts_rank_raw"]) / max(
+                        max(abs(r["fts_rank_raw"]) for r in rows), 1e-6
+                    )
+                else:
+                    fact["window_hits"] = 0
+                    fact["fts_rank"] = 0.5
+                out.append(fact)
+            return out
 
         # Normalize FTS5 rank: rank is negative, lower = better
         # Convert to positive score in [0, 1] range
@@ -558,6 +688,37 @@ class FactRetriever:
             results.append(fact)
 
         return results
+
+    @staticmethod
+    def _window_tokens(query: str) -> list[str]:
+        """Return the overlapping 3-char windows of a CJK query (for ranking).
+
+        Mirrors _or_tokens_trigram's tokenization but returns raw window
+        strings (no quoting / OR) for content-hit counting.
+        """
+        q = query.strip()
+        tokens: list[str] = []
+        i = 0
+        n = len(q)
+        while i < n:
+            j = i
+            while j < n and (0x4E00 <= ord(q[j]) <= 0x9FFF or 0x3000 <= ord(q[j]) <= 0x303F):
+                j += 1
+            if j > i:
+                run = q[i:j]
+                for k in range(len(run) - 2):
+                    tokens.append(run[k:k + 3])
+                i = j
+            else:
+                j = i
+                while j < n and not (0x4E00 <= ord(q[j]) <= 0x9FFF or 0x3000 <= ord(q[j]) <= 0x303F):
+                    j += 1
+                w = q[i:j]
+                if len(w) >= 3:
+                    tokens.append(w)
+                i = j
+        seen = set()
+        return [t for t in tokens if not (t in seen or seen.add(t))]
 
     @staticmethod
     def _tokenize(text: str) -> set[str]:

--- a/plugins/memory/holographic/retrieval.py
+++ b/plugins/memory/holographic/retrieval.py
@@ -45,6 +45,11 @@ class FactRetriever:
         self.jaccard_weight = jaccard_weight
         self.hrr_weight = hrr_weight
 
+        # Cache trigram-tokenizer availability: depends only on the SQLite
+        # build, which never changes at runtime. The probe (CREATE/DROP DDL)
+        # runs at most once instead of on every search.
+        self._trigram_available_cache: bool | None = None
+
     def search(
         self,
         query: str,
@@ -520,38 +525,47 @@ class FactRetriever:
         return False
 
     def _trigram_available(self) -> bool:
-        """True when this SQLite build has the FTS5 trigram tokenizer."""
+        """True when this SQLite build has the FTS5 trigram tokenizer.
+
+        Cached: the probe (CREATE/DROP DDL on the live connection) is
+        expensive and the build never changes at runtime, so it runs at most
+        once per FactRetriever instance.
+        """
+        if self._trigram_available_cache is not None:
+            return self._trigram_available_cache
         try:
             conn = self.store._conn
             conn.execute(
                 "CREATE VIRTUAL TABLE IF NOT EXISTS _tgram_probe USING fts5(x, tokenize='trigram')"
             )
             conn.execute("DROP TABLE IF EXISTS _tgram_probe")
-            return True
+            self._trigram_available_cache = True
         except Exception:
-            return False
+            self._trigram_available_cache = False
+        return self._trigram_available_cache
 
     @staticmethod
     def _or_tokens_trigram(query: str) -> str:
-        """Split a CJK query into overlapping 3-char tokens, OR-joined.
+        """Split a query into overlapping 3-char tokens, OR-joined.
 
-        trigram tokenizer matches >=3-char tokens; a natural-language query
-        like \"VPS内存多大\" as a whole won't appear verbatim in a fact, but
-        its 3-char windows (VPS内, PS内存, 内存多, 存多大, ...) overlap with
-        fact content.  OR-join so any window hit returns candidates, then
-        Jaccard rerank in `search()` picks the best.
+        The trigram tokenizer indexes overlapping 3-char sequences for BOTH
+        CJK and Latin text ("deployment" → "dep"/"epl"/"loy"/...), so a
+        natural-language query like "VPS内存多大" as a whole won't appear
+        verbatim in a fact, but its 3-char windows overlap with fact content.
+        OR-join so any window hit returns candidates, then Jaccard rerank in
+        `search()` picks the best.  Latin runs are windowed too: keeping a
+        whole word such as "deployment" would produce a MATCH token the
+        trigram index does not contain, silently dropping recall for that
+        term in mixed CJK/English queries.
         """
         q = query.strip()
         if not q:
             return q
         tokens = []
-        # Latin runs are kept whole (>=3 chars) so \"VPS\" survives; CJK is
-        # windowed every 3 chars.  Simple approach: build a token per 3-char
-        # window over the whole string, then also keep whole-word runs.
         i = 0
         n = len(q)
         while i < n:
-            # collect a run: CJK run windowed, else latin/digit run kept whole
+            # collect a run: CJK run windowed, else latin/digit run windowed
             j = i
             while j < n and (0x4E00 <= ord(q[j]) <= 0x9FFF or 0x3000 <= ord(q[j]) <= 0x303F):
                 j += 1
@@ -565,14 +579,12 @@ class FactRetriever:
                 while j < n and not (0x4E00 <= ord(q[j]) <= 0x9FFF or 0x3000 <= ord(q[j]) <= 0x303F):
                     j += 1
                 w = q[i:j]
-                if len(w) >= 3:
-                    tokens.append(w)
-                elif w:
-                    tokens.append(w)  # 1-2 char latin won't match trigram; harmless
+                for k in range(len(w) - 2):
+                    tokens.append(w[k:k + 3])
                 i = j
         if not tokens:
             return q
-        # Dedupe, keep order, drop tokens that cannot match (len<3 non-CJK)
+        # Dedupe, keep order, drop tokens that cannot match (len<3 runs)
         seen = set()
         out = []
         for t in tokens:
@@ -691,10 +703,13 @@ class FactRetriever:
 
     @staticmethod
     def _window_tokens(query: str) -> list[str]:
-        """Return the overlapping 3-char windows of a CJK query (for ranking).
+        """Return the overlapping 3-char windows of a query (for ranking).
 
-        Mirrors _or_tokens_trigram's tokenization but returns raw window
-        strings (no quoting / OR) for content-hit counting.
+        Mirrors `_or_tokens_trigram`'s tokenization (CJK and Latin runs both
+        windowed) but returns raw window strings (no quoting / OR) for
+        content-hit counting.  Keeping both in sync matters: the MATCH tokens
+        and the ranking windows must come from the same splitter or a mixed
+        CJK/English query's window_hits diverge from what actually matched.
         """
         q = query.strip()
         tokens: list[str] = []
@@ -714,8 +729,8 @@ class FactRetriever:
                 while j < n and not (0x4E00 <= ord(q[j]) <= 0x9FFF or 0x3000 <= ord(q[j]) <= 0x303F):
                     j += 1
                 w = q[i:j]
-                if len(w) >= 3:
-                    tokens.append(w)
+                for k in range(len(w) - 2):
+                    tokens.append(w[k:k + 3])
                 i = j
         seen = set()
         return [t for t in tokens if not (t in seen or seen.add(t))]

--- a/plugins/memory/holographic/store.py
+++ b/plugins/memory/holographic/store.py
@@ -66,6 +66,32 @@ CREATE TRIGGER IF NOT EXISTS facts_au AFTER UPDATE ON facts BEGIN
         VALUES (new.fact_id, new.content, new.tags);
 END;
 
+-- Trigram FTS5 table for CJK (Chinese) substring search (2026-08-27 patch).
+-- The default unicode61 tokenizer splits CJK into individual chars, breaking
+-- phrase matching.  The trigram tokenizer creates overlapping 3-char tokens so
+-- natural-language Chinese queries can hit facts.  Mirrors the proven
+-- messages_fts_trigram pattern in hermes_state_common.py (L3 session search).
+CREATE VIRTUAL TABLE IF NOT EXISTS facts_fts_trigram
+    USING fts5(content, tags, content=facts, content_rowid=fact_id,
+               tokenize='trigram');
+
+CREATE TRIGGER IF NOT EXISTS facts_trigram_ai AFTER INSERT ON facts BEGIN
+    INSERT INTO facts_fts_trigram(rowid, content, tags)
+        VALUES (new.fact_id, new.content, new.tags);
+END;
+
+CREATE TRIGGER IF NOT EXISTS facts_trigram_ad AFTER DELETE ON facts BEGIN
+    INSERT INTO facts_fts_trigram(facts_fts_trigram, rowid, content, tags)
+        VALUES ('delete', old.fact_id, old.content, old.tags);
+END;
+
+CREATE TRIGGER IF NOT EXISTS facts_trigram_au AFTER UPDATE ON facts BEGIN
+    INSERT INTO facts_fts_trigram(facts_fts_trigram, rowid, content, tags)
+        VALUES ('delete', old.fact_id, old.content, old.tags);
+    INSERT INTO facts_fts_trigram(rowid, content, tags)
+        VALUES (new.fact_id, new.content, new.tags);
+END;
+
 CREATE TABLE IF NOT EXISTS memory_banks (
     bank_id    INTEGER PRIMARY KEY AUTOINCREMENT,
     bank_name  TEXT NOT NULL UNIQUE,

--- a/tests/plugins/memory/test_holographic_retrieval.py
+++ b/tests/plugins/memory/test_holographic_retrieval.py
@@ -238,3 +238,90 @@ def test_search_without_vectors_never_encodes(hoisted_retriever, monkeypatch):
         f"encode_text called {len(calls)}x with zero vector candidates — "
         "lazy hoist regressed to eager"
     )
+
+
+# ---------------------------------------------------------------------------
+# Trigram CJK search — mixed CJK/English recall + DDL caching
+# (2026-08-31, addressing AI review on #97050)
+# ---------------------------------------------------------------------------
+
+def test_mixed_cjk_english_query_recalls_english_term(tmp_path):
+    """A mixed query must not silently drop the English term.
+
+    The trigram index tokenizes English content into overlapping 3-grams
+    ("deployment" -> "dep"/"epl"/"loy"...), so a MATCH token that keeps the
+    whole word ("deployment") matches nothing. The fix windows Latin runs the
+    same way as CJK, restoring recall for the English part.
+    """
+    store = MemoryStore(str(tmp_path / "mixed.db"))
+    store.add_fact(content="The deployment rollback failed due to stale state.", category="project")
+    store.add_fact(content="内存多大决定上下文窗口上限。", category="tool")
+    retriever = FactRetriever(store=store)
+
+    results = retriever.search("deployment内存", limit=5)
+    assert results, "mixed CJK/English query should return candidates"
+    # The English-bearing fact must be in the top results
+    assert any("deployment" in r["content"].lower() for r in results), (
+        "English term silently dropped in mixed query"
+    )
+
+
+def test_trigram_available_cached_no_ddl_on_repeat(tmp_path):
+    """_trigram_available() must probe the build only once.
+
+    The probe executes CREATE/DROP DDL on the live store; repeating it on
+    every search adds write-lock contention. After the first call the result
+    is cached and no further DDL runs.
+    """
+    store = MemoryStore(str(tmp_path / "ddl_cache.db"))
+    retriever = FactRetriever(store=store)
+
+    # Wrap the live connection with a counting proxy so we can observe DDL
+    # without touching the read-only sqlite3.Connection.execute attribute.
+    real_conn = store._conn
+
+    class CountingConn:
+        def __init__(self, real):
+            self._real = real
+            self.probe_ddl = 0
+
+        def execute(self, sql, *args, **kwargs):
+            if isinstance(sql, str) and "_tgram_probe" in sql:
+                self.probe_ddl += 1
+            return self._real.execute(sql, *args, **kwargs)
+
+        def __getattr__(self, name):
+            return getattr(self._real, name)
+
+    counting = CountingConn(real_conn)
+    retriever.store._conn = counting
+    try:
+        assert retriever._trigram_available() in (True, False)
+        first_probe_count = counting.probe_ddl
+        for _ in range(5):
+            retriever._trigram_available()
+        assert counting.probe_ddl == first_probe_count, (
+            f"DDL probe repeated: {counting.probe_ddl} after first call"
+        )
+    finally:
+        retriever.store._conn = real_conn
+
+
+def test_or_tokens_trigram_windows_latin_runs():
+    """Latin runs are windowed into 3-grams, not kept whole.
+
+    "deployment" must yield dep/epl/loy/... so the MATCH token exists in the
+    trigram index; a whole-word token would match nothing.
+    """
+    tokens = FactRetriever._or_tokens_trigram("deployment内存")
+    assert '"deployment"' not in tokens, "whole English word must not be a token"
+    assert '"dep"' in tokens and '"loy"' in tokens, "English 3-grams missing"
+
+
+def test_window_tokens_matches_or_tokens_latin():
+    """Ranking windows and MATCH tokens must share the same splitter."""
+    match = FactRetriever._or_tokens_trigram("deployment内存")
+    windows = FactRetriever._window_tokens("deployment内存")
+    # Every window appears (quoted) in the MATCH expression
+    for w in windows:
+        assert f'"{w}"' in match, f"window {w!r} missing from MATCH tokens"


### PR DESCRIPTION
## Problem

Chinese natural-language queries never match facts in the holographic `fact_store` (L2 memory). The FTS5 table uses the default `unicode61` tokenizer, which splits CJK text into single characters, so a query like `交易哲学是什么` cannot match facts like `交易哲学: 重质不重量...`.

This is the same class of problem as L3 session search, where `messages_fts_trigram` already provides CJK substring recall.

## Change

- Add `facts_fts_trigram` FTS5 table (trigram tokenizer, content-synced via triggers, mirroring the L3 pattern).
- Route CJK queries to it via 3-char window OR-join; boost ranking by per-fact window-hit count.
- Non-CJK queries keep the existing `unicode61` path unchanged.
- Graceful degradation if the SQLite build lacks `trigram` support (`_trigram_available` probe).

## Verification

Verified locally: CJK queries like `交易哲学是什么` / `英语学习在哪` hit the correct facts; non-CJK queries behave unchanged. Existing holographic tests still pass.