### PR TITLE
fix(update): gate the fork-upstream prompt for --yes and non-tty runs

### DIFF
--- a/hermes_cli/subcommands/update.py
+++ b/hermes_cli/subcommands/update.py
@@ -59,7 +59,7 @@ def build_update_parser(subparsers, *, cmd_update: Callable) -> None:
         "-y",
         action="store_true",
         default=False,
-        help="Assume yes for interactive prompts (config migration, stash restore). API-key entry is skipped; run 'hermes config migrate' separately for those.",
+        help="Run without blocking on prompts: accepts the config-migration and stash-restore prompts, skips the fork-upstream prompt without adding a remote. API-key entry is skipped; run 'hermes config migrate' separately for those.",
     )
     update_parser.add_argument(
         "--keep-stash",

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -2711,7 +2711,13 @@ def _sync_fork_with_upstream(git_cmd: list[str], cwd: Path) -> bool:
     except Exception:
         return False
 
-def _sync_with_upstream_if_needed(git_cmd: list[str], cwd: Path) -> None:
+def _sync_with_upstream_if_needed(
+    git_cmd: list[str],
+    cwd: Path,
+    *,
+    assume_yes: bool = False,
+    input_fn=None,
+) -> None:
     """Check if fork is behind upstream and sync if safe.
 
     This implements the fork upstream sync logic:
@@ -2727,18 +2733,39 @@ def _sync_with_upstream_if_needed(git_cmd: list[str], cwd: Path) -> None:
         if _should_skip_upstream_prompt():
             return
 
-        # Ask user if they want to add upstream
         print()
         print("ℹ Your fork is not tracking the official Hermes repository.")
         print("  This means you may miss updates from NousResearch/hermes-agent.")
         print()
-        try:
-            response = (
-                input("Add official repo as 'upstream' remote? [Y/n]: ").strip().lower()
+
+        if assume_yes or (
+            input_fn is None and not (sys.stdin.isatty() and sys.stdout.isatty())
+        ):
+            # --yes means "don't block", not "mutate my git remotes". Skip
+            # without persisting the decline so interactive runs still get asked.
+            print("  Skipping upstream setup (non-interactive run).")
+            print(
+                "  Add it later with: git remote add upstream https://github.com/NousResearch/hermes-agent.git"
             )
-        except (EOFError, KeyboardInterrupt, UnicodeDecodeError):
-            print()
-            response = "n"
+            return
+
+        # Ask user if they want to add upstream
+        if input_fn is not None:
+            response = (
+                input_fn("Add official repo as 'upstream' remote? [y/N]", "n")
+                .strip()
+                .lower()
+            )
+        else:
+            try:
+                response = (
+                    input("Add official repo as 'upstream' remote? [Y/n]: ")
+                    .strip()
+                    .lower()
+                )
+            except (EOFError, KeyboardInterrupt, UnicodeDecodeError):
+                print()
+                response = "n"
 
         if response in {"", "y", "yes"}:
             print("→ Adding upstream remote...")
@@ -7835,7 +7862,12 @@ def _cmd_update_impl(args, gateway_mode: bool):
         # date!" and verified nothing).
         if commit_count == 0 and is_fork and branch == "main":
             pre_sync_sha = _capture_head_sha(git_cmd, _m().PROJECT_ROOT)
-            _m()._sync_with_upstream_if_needed(git_cmd, _m().PROJECT_ROOT)
+            _m()._sync_with_upstream_if_needed(
+                git_cmd,
+                _m().PROJECT_ROOT,
+                assume_yes=assume_yes,
+                input_fn=gw_input_fn,
+            )
             post_sync_sha = _capture_head_sha(git_cmd, _m().PROJECT_ROOT)
             if pre_sync_sha and post_sync_sha and pre_sync_sha != post_sync_sha:
                 synced_count = _count_commits_between(
@@ -8271,7 +8303,12 @@ def _cmd_update_impl(args, gateway_mode: bool):
 
         # Fork upstream sync logic (only for main branch on forks)
         if is_fork and branch == "main":
-            _m()._sync_with_upstream_if_needed(git_cmd, _m().PROJECT_ROOT)
+            _m()._sync_with_upstream_if_needed(
+                git_cmd,
+                _m().PROJECT_ROOT,
+                assume_yes=assume_yes,
+                input_fn=gw_input_fn,
+            )
 
         # Reinstall Python dependencies. Prefer .[all], but if one optional extra
         # breaks on this machine, keep base deps and reinstall the remaining extras

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -2717,7 +2717,7 @@ def _sync_with_upstream_if_needed(
     *,
     assume_yes: bool = False,
     input_fn=None,
-) -> None:
+) -> bool:
     """Check if fork is behind upstream and sync if safe.
 
     This implements the fork upstream sync logic:
@@ -2725,13 +2725,19 @@ def _sync_with_upstream_if_needed(
     - Compare origin/main with upstream/main
     - If origin/main is strictly behind upstream/main, pull from upstream
     - Try to sync fork back to origin if possible
+
+    Returns True when origin/main was actually verified against the official
+    upstream/main, False when the check never happened (prompt skipped or
+    declined, remote add failed, fetch or compare failed) so the caller can
+    avoid reporting the checkout as up to date on the strength of an origin
+    comparison alone (#97052 review).
     """
     has_upstream = _has_upstream_remote(git_cmd, cwd)
 
     if not has_upstream:
         # Check if user previously declined
         if _should_skip_upstream_prompt():
-            return
+            return False
 
         print()
         print("ℹ Your fork is not tracking the official Hermes repository.")
@@ -2747,7 +2753,7 @@ def _sync_with_upstream_if_needed(
             print(
                 "  Add it later with: git remote add upstream https://github.com/NousResearch/hermes-agent.git"
             )
-            return
+            return False
 
         # Ask user if they want to add upstream
         if input_fn is not None:
@@ -2776,13 +2782,13 @@ def _sync_with_upstream_if_needed(
                 has_upstream = True
             else:
                 print("  ✗ Failed to add upstream remote. Skipping upstream sync.")
-                return
+                return False
         else:
             print(
                 "  Skipped. Run 'git remote add upstream https://github.com/NousResearch/hermes-agent.git' to add later."
             )
             _mark_skip_upstream_prompt()
-            return
+            return False
 
     # Fetch upstream main only. This sync compares upstream/main with
     # origin/main, so there's no reason to pull every upstream ref — and a bare
@@ -2798,7 +2804,7 @@ def _sync_with_upstream_if_needed(
         )
     except subprocess.CalledProcessError:
         print("  ✗ Failed to fetch upstream. Skipping upstream sync.")
-        return
+        return False
 
     # Compare origin/main with upstream/main
     origin_ahead = _count_commits_between(git_cmd, cwd, "upstream/main", "origin/main")
@@ -2808,7 +2814,7 @@ def _sync_with_upstream_if_needed(
 
     if origin_ahead < 0 or upstream_ahead < 0:
         print("  ✗ Could not compare branches. Skipping upstream sync.")
-        return
+        return False
 
     # If origin/main has commits not on upstream, don't trample
     if origin_ahead > 0:
@@ -2817,12 +2823,12 @@ def _sync_with_upstream_if_needed(
         print("  Skipping upstream sync to preserve your changes.")
         print("  If you want to merge upstream changes, run:")
         print("    git pull upstream main")
-        return
+        return True
 
     # If upstream is not ahead, fork is up to date
     if upstream_ahead == 0:
         print("  ✓ Fork is up to date with upstream")
-        return
+        return True
 
     # origin/main is strictly behind upstream/main (can fast-forward)
     print()
@@ -2839,7 +2845,7 @@ def _sync_with_upstream_if_needed(
         print(
             "  ✗ Failed to pull from upstream. You may need to resolve conflicts manually."
         )
-        return
+        return False
 
     print("  ✓ Updated from upstream")
 
@@ -2852,6 +2858,7 @@ def _sync_with_upstream_if_needed(
             "  ℹ Got updates from upstream but couldn't push to fork (no write access?)"
         )
         print("    Your local repo is updated, but your fork on GitHub may be behind.")
+    return True
 
 def _invalidate_update_cache():
     """Delete the update-check cache for ALL profiles so no banner
@@ -3737,6 +3744,7 @@ def _repair_node_deps_on_current_checkout(
     assume_yes: bool = False,
     gateway_mode: bool = False,
     pre_update_snapshot_id: str | None = None,
+    completion_message: str = "✓ Already up to date!",
 ) -> None:
     """Repair Node deps on the ``commit_count == 0`` path (#77211).
 
@@ -3767,7 +3775,7 @@ def _repair_node_deps_on_current_checkout(
         gateway_mode=gateway_mode,
         pre_update_snapshot_id=pre_update_snapshot_id,
     )
-    print_completion("✓ Already up to date!")
+    print_completion(completion_message)
 
 
 def _update_node_dependencies() -> list[str]:
@@ -7860,9 +7868,12 @@ def _cmd_update_impl(args, gateway_mode: bool):
         # commit_count == 0 branch, which returns immediately after: an update
         # that pulled hundreds of upstream commits printed "Already up to
         # date!" and verified nothing).
+        # Non-fork checkouts have no upstream question: origin IS the official
+        # repo, so "Already up to date!" is fully verified there.
+        upstream_checked = True
         if commit_count == 0 and is_fork and branch == "main":
             pre_sync_sha = _capture_head_sha(git_cmd, _m().PROJECT_ROOT)
-            _m()._sync_with_upstream_if_needed(
+            upstream_checked = _m()._sync_with_upstream_if_needed(
                 git_cmd,
                 _m().PROJECT_ROOT,
                 assume_yes=assume_yes,
@@ -8026,6 +8037,11 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     assume_yes=assume_yes,
                     gateway_mode=gateway_mode,
                     pre_update_snapshot_id=pre_update_snapshot_id,
+                    completion_message=(
+                        "✓ Already up to date!"
+                        if upstream_checked
+                        else "✓ Up to date with your fork (official repo not checked)."
+                    ),
                 )
             if runtime_repaired is not None and not _m()._is_windows():
                 print()

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -312,6 +312,45 @@ class TestCmdUpdateBranchFallback:
 
     @patch("shutil.which", return_value=None)
     @patch("subprocess.run")
+    def test_yes_on_fork_without_upstream_does_not_claim_up_to_date(
+        self, mock_run, _mock_which, capsys
+    ):
+        """#97052 review: genuine fork, no upstream remote, HEAD == origin/main,
+        --yes. The prompt is skipped without mutating remotes, and because the
+        official repo was never consulted the completion line must not claim
+        plain "Already up to date!"."""
+        from hermes_cli import main as hm
+        from hermes_cli import update_cmd
+
+        mock_run.side_effect = _make_run_side_effect(
+            branch="main", verify_ok=True, commit_count="0"
+        )
+
+        with patch.object(
+            hm,
+            "_get_origin_url",
+            return_value="https://github.com/example/hermes-agent.git",
+        ), patch.object(
+            update_cmd, "_has_upstream_remote", return_value=False
+        ), patch.object(
+            update_cmd, "_should_skip_upstream_prompt", return_value=False
+        ), patch.object(
+            update_cmd, "_add_upstream_remote"
+        ) as add_remote, patch.object(
+            update_cmd, "_mark_skip_upstream_prompt"
+        ) as mark_skip, patch("builtins.input") as stdin_input:
+            cmd_update(SimpleNamespace(yes=True))
+
+        stdin_input.assert_not_called()
+        add_remote.assert_not_called()
+        mark_skip.assert_not_called()
+        captured = capsys.readouterr()
+        assert "Skipping upstream setup (non-interactive run)." in captured.out
+        assert "official repo not checked" in captured.out
+        assert "Already up to date!" not in captured.out
+
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
     def test_fork_upstream_sync_that_moves_head_runs_post_update_steps(
         self, mock_run, _mock_which, mock_args, capsys
     ):

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -301,7 +301,12 @@ class TestCmdUpdateBranchFallback:
         expected_git_cmd = (
             ["git", "-c", "windows.appendAtomically=false"] if hm._is_windows() else ["git"]
         )
-        sync_mock.assert_called_once_with(expected_git_cmd, PROJECT_ROOT)
+        sync_mock.assert_called_once_with(
+            expected_git_cmd,
+            PROJECT_ROOT,
+            assume_yes=False,
+            input_fn=None,
+        )
         captured = capsys.readouterr()
         assert "Already up to date!" in captured.out
 

--- a/tests/hermes_cli/test_update_upstream_prompt_noninteractive.py
+++ b/tests/hermes_cli/test_update_upstream_prompt_noninteractive.py
@@ -49,10 +49,11 @@ class TestUpstreamPromptNonInteractive:
     ):
         p_in, p_out = _tty(True, True)
         with p_in, p_out:
-            update_cmd._sync_with_upstream_if_needed(
+            checked = update_cmd._sync_with_upstream_if_needed(
                 ["git"], fork_without_upstream.cwd, assume_yes=True
             )
 
+        assert checked is False
         fork_without_upstream.stdin_input.assert_not_called()
         fork_without_upstream.add_remote.assert_not_called()
         fork_without_upstream.mark_skip.assert_not_called()
@@ -66,10 +67,11 @@ class TestUpstreamPromptNonInteractive:
     ):
         p_in, p_out = _tty(stdin_tty, stdout_tty)
         with p_in, p_out:
-            update_cmd._sync_with_upstream_if_needed(
+            checked = update_cmd._sync_with_upstream_if_needed(
                 ["git"], fork_without_upstream.cwd
             )
 
+        assert checked is False
         fork_without_upstream.stdin_input.assert_not_called()
         fork_without_upstream.add_remote.assert_not_called()
         fork_without_upstream.mark_skip.assert_not_called()

--- a/tests/hermes_cli/test_update_upstream_prompt_noninteractive.py
+++ b/tests/hermes_cli/test_update_upstream_prompt_noninteractive.py
@@ -1,0 +1,122 @@
+"""The fork-upstream prompt must never block a non-interactive update (#60240).
+
+`_sync_with_upstream_if_needed` asks "Add official repo as 'upstream' remote?"
+on fork checkouts with no upstream remote. In unattended contexts (CI, cron,
+the desktop updater hand-off) stdin is open but nobody answers, so a bare
+``input()`` blocks forever. These tests pin the gate: under ``assume_yes`` or
+a non-TTY stdio pair the prompt is skipped as a decline WITHOUT persisting the
+skip marker or touching git remotes, and both update call sites forward the
+interaction state.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli import update_cmd
+
+
+@pytest.fixture
+def fork_without_upstream(tmp_path):
+    with patch.object(
+        update_cmd, "_has_upstream_remote", return_value=False
+    ), patch.object(
+        update_cmd, "_should_skip_upstream_prompt", return_value=False
+    ), patch.object(
+        update_cmd, "_add_upstream_remote", return_value=True
+    ) as add_remote, patch.object(
+        update_cmd, "_mark_skip_upstream_prompt"
+    ) as mark_skip, patch("builtins.input") as stdin_input:
+        yield SimpleNamespace(
+            cwd=tmp_path,
+            add_remote=add_remote,
+            mark_skip=mark_skip,
+            stdin_input=stdin_input,
+        )
+
+
+def _tty(stdin: bool, stdout: bool):
+    return (
+        patch.object(update_cmd.sys.stdin, "isatty", return_value=stdin),
+        patch.object(update_cmd.sys.stdout, "isatty", return_value=stdout),
+    )
+
+
+class TestUpstreamPromptNonInteractive:
+    def test_assume_yes_skips_prompt_without_touching_remotes(
+        self, fork_without_upstream, capsys
+    ):
+        p_in, p_out = _tty(True, True)
+        with p_in, p_out:
+            update_cmd._sync_with_upstream_if_needed(
+                ["git"], fork_without_upstream.cwd, assume_yes=True
+            )
+
+        fork_without_upstream.stdin_input.assert_not_called()
+        fork_without_upstream.add_remote.assert_not_called()
+        fork_without_upstream.mark_skip.assert_not_called()
+        assert "Skipping upstream setup" in capsys.readouterr().out
+
+    @pytest.mark.parametrize(
+        "stdin_tty,stdout_tty", [(False, False), (False, True), (True, False)]
+    )
+    def test_non_tty_skips_prompt_without_persisting_decline(
+        self, fork_without_upstream, capsys, stdin_tty, stdout_tty
+    ):
+        p_in, p_out = _tty(stdin_tty, stdout_tty)
+        with p_in, p_out:
+            update_cmd._sync_with_upstream_if_needed(
+                ["git"], fork_without_upstream.cwd
+            )
+
+        fork_without_upstream.stdin_input.assert_not_called()
+        fork_without_upstream.add_remote.assert_not_called()
+        fork_without_upstream.mark_skip.assert_not_called()
+        assert "Skipping upstream setup" in capsys.readouterr().out
+
+    def test_gateway_prompt_routes_through_input_fn(self, fork_without_upstream):
+        prompts = []
+
+        def gw_input(prompt, default=""):
+            prompts.append((prompt, default))
+            return "n"
+
+        p_in, p_out = _tty(False, False)
+        with p_in, p_out:
+            update_cmd._sync_with_upstream_if_needed(
+                ["git"], fork_without_upstream.cwd, input_fn=gw_input
+            )
+
+        assert prompts == [("Add official repo as 'upstream' remote? [y/N]", "n")]
+        fork_without_upstream.stdin_input.assert_not_called()
+        fork_without_upstream.add_remote.assert_not_called()
+        fork_without_upstream.mark_skip.assert_called_once_with()
+
+    def test_interactive_decline_still_persists_marker(self, fork_without_upstream):
+        fork_without_upstream.stdin_input.return_value = "n"
+        p_in, p_out = _tty(True, True)
+        with p_in, p_out:
+            update_cmd._sync_with_upstream_if_needed(
+                ["git"], fork_without_upstream.cwd
+            )
+
+        fork_without_upstream.stdin_input.assert_called_once()
+        fork_without_upstream.add_remote.assert_not_called()
+        fork_without_upstream.mark_skip.assert_called_once_with()
+
+    def test_interactive_accept_adds_upstream(self, fork_without_upstream):
+        fork_without_upstream.stdin_input.return_value = "y"
+        with patch.object(
+            update_cmd, "_count_commits_between", return_value=-1
+        ), patch.object(update_cmd.subprocess, "run"):
+            p_in, p_out = _tty(True, True)
+            with p_in, p_out:
+                update_cmd._sync_with_upstream_if_needed(
+                    ["git"], fork_without_upstream.cwd
+                )
+
+        fork_without_upstream.add_remote.assert_called_once_with(
+            ["git"], fork_without_upstream.cwd
+        )
+        fork_without_upstream.mark_skip.assert_not_called()


### PR DESCRIPTION
Fixes the prompt half of #60240. Supersedes #78678 and #92448, and the fork-upstream prompt-hang portion of #92410.

### What happens

On a fork checkout of main with no `upstream` remote, `hermes update` asks "Add official repo as 'upstream' remote? [Y/n]:" through a bare `input()`. In any non-interactive context (CI, cron, the desktop updater hand-off) stdin is open but nobody answers, so the call blocks forever: `--yes` never reaches this prompt and the EOFError fallback only fires when stdin is closed. Observed as a 90-minute hang in a Windows open-app-update E2E leg, with the update marker never cleaned and the updater killed at teardown.

### The fix

`_sync_with_upstream_if_needed` now takes `assume_yes` and the gateway `input_fn`, and both call sites in `_cmd_update_impl` forward them. Under `assume_yes`, or when there is no `input_fn` and stdio is not a TTY pair, the prompt is skipped as a decline without writing the decline marker and without touching git remotes, so interactive users still get asked on their next update. Gateway updates route the question through the existing IPC prompt callback with a default of no. Interactive terminal behavior is unchanged.

This is the same gate the file already applies to its config-migration and stash-restore prompts; this prompt was the one that never got it.

`--yes` deliberately declines rather than adds the remote. Adding a remote is a repo mutation, and `--yes` in this command means "don't block on prompts", not "make git changes I didn't ask for". The add-on-yes alternative (what #78678 implemented) was considered and rejected on that ground.

### Relationship to the superseded PRs

#78678 (@BlackishGreen33) had the right structure (thread `assume_yes` + `input_fn`, non-persisting skip) but made `--yes` add the remote, and also bundled the `_is_fork` case-sensitivity fix that #68959 covers on its own. #92448 (@salch-cred) had the right diagnosis but its unattended decline flows into the branch that persists the skip marker, permanently silencing the prompt for interactive users, and its TTY guard alone cannot cover the hidden-console case that `--yes` threading does. #92410 (@jackulau) bounds every prompt with reader threads; with `assume_yes` and the TTY gate in place the residual population (interactive-looking console, no `--yes`, nobody present) does not justify the thread machinery for this prompt. That case is intentionally left unresolved here rather than fully superseded, and #92410's timeout bounding of the other prompts is likewise out of scope. All three authors are credited on the commit.

The `_is_fork` URL-normalization half of #60240 stays with #68959, which already covers more URL forms.

### Tests

`tests/hermes_cli/test_update_upstream_prompt_noninteractive.py` pins the gate: `assume_yes` and every non-TTY stdio combination return without calling `input()`, without touching remotes and without persisting the decline; the gateway path routes through `input_fn` and keeps its decline persistence; interactive accept and decline keep today's behavior. The suite fails on main (5/7, including TypeError on the new signature) and passes with the fix. Neighboring suites `test_cmd_update.py` (38) and `test_update_yes_flag.py` + `test_update_autostash.py` (52) pass; one assertion in `test_cmd_update.py` updated for the new call signature.

### Review follow-up (@helix4u)

On a genuine fork with no `upstream` remote whose `HEAD` matches the user's own `origin/main` while official main is ahead, the skip left the update printing plain "Already up to date!" even though the official repo was never consulted. `_sync_with_upstream_if_needed` now returns whether official upstream was actually checked, and that completion line reads "Up to date with your fork (official repo not checked)." when it was not. Skip semantics are unchanged: no prompt, no remote mutation, no decline marker. A caller-level regression test through `_cmd_update_impl` pins the path, and the `--yes` help text now states that the fork-upstream prompt is skipped rather than accepted.

### End-to-end verification

Verified on the end-to-end path the hang was found on: a Windows desktop-updater hand-off leg (install old build, click Update now in the app, detached updater runs `hermes update --yes --gateway --force --branch main` with an open unattended stdin, on a checkout that fork-detection classifies as a fork with no upstream remote). With a pre-fix baseline the leg wedges at `Add official repo as 'upstream' remote? [Y/n]:` until an external kill, and the update marker is never cleaned. With the fix in the running code the same leg logs `Skipping upstream setup (non-interactive run).`, the update exits 0 on the first attempt, the marker is cleaned, and the app relaunches. One caveat for anyone watching similar CI: an install whose baseline predates this fix still wedges once, because its first update runs the old code in memory; the fix applies from the next update on.