### PR TITLE
feat(kanban): configurable notification excerpt limit (kanban.notify_max_chars)

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -33,6 +33,64 @@ _LOCAL_PATH_RE = re.compile(
 )
 
 
+_NOTIFY_CHARS_DEFAULT = 200
+_NOTIFY_CHARS_MAX = 3500  # Slack hard-caps a message at 4000 chars; leave headroom.
+
+
+def _first_line_excerpt(value: Any, limit: int) -> str:
+    """Return the first non-empty line of *value*, bounded to *limit* chars."""
+    text = "" if value is None else str(value)
+    lines = text.strip().splitlines()
+    head = lines[0] if lines else text
+    if len(head) <= limit:
+        return head
+    return head[:limit]
+
+
+def _mobile_excerpt(value: Any, limit: int) -> str:
+    """Bound *value* to *limit* chars, reserving room for an ellipsis."""
+    text = "" if value is None else str(value)
+    if len(text) <= limit:
+        return text
+    return text[: max(1, limit - 1)].rstrip() + "…"
+
+
+def _notify_max_chars_from_config(cfg: Any) -> int:
+    """Resolve ``kanban.notify_max_chars`` with fail-safe bounds.
+
+    One shared budget for every notification excerpt (summaries, reasons,
+    errors). Defaults to the historical 200; clamps to ``[1, 3500]`` — the
+    ceiling keeps even a maxed-out ping safely under Slack's 4000-char
+    message cap. Junk values (strings, lists, None, NaN) fall back to the
+    default rather than raising: a typo'd config must not kill delivery.
+    """
+    kcfg = cfg.get("kanban", {}) if isinstance(cfg, dict) else {}
+    raw = kcfg.get("notify_max_chars", _NOTIFY_CHARS_DEFAULT)
+    try:
+        value = int(float(raw))
+    except (TypeError, ValueError, OverflowError):
+        return _NOTIFY_CHARS_DEFAULT
+    return max(1, min(value, _NOTIFY_CHARS_MAX))
+
+
+def _resolve_notify_max_chars(runner: Any) -> int:
+    """Read the excerpt budget once at notifier boot and stamp it on the runner.
+
+    Same boot-captured pattern as every other background watcher here: users
+    who flip the value restart the gateway. Missing config loader or a failed
+    read is not fatal — delivery proceeds with the default budget.
+    """
+    try:
+        from hermes_cli.config import load_config as _load_config
+
+        cfg = _load_config()
+    except Exception:
+        cfg = {}
+    resolved = _notify_max_chars_from_config(cfg)
+    runner._kanban_notify_max_chars = resolved
+    return resolved
+
+
 def _safe_review_reason(value: Any, limit: int = 160) -> str:
     """Return a mobile-friendly review reason safe for external delivery."""
     from agent.redact import redact_sensitive_text
@@ -256,6 +314,12 @@ class GatewayKanbanWatchersMixin:
         except Exception:
             logger.warning("kanban notifier: kanban_db not importable; notifier disabled")
             return
+
+        # Excerpt budget for every notification this watcher sends. Resolved
+        # once per watcher start (boot-captured, same pattern as the other
+        # watchers here); ``kanban.notify_max_chars`` in config.yaml raises
+        # the historical 200-char excerpt cap up to 3500.
+        limit = _resolve_notify_max_chars(self)
 
         # "status" covers dashboard drag-drop and `_set_status_direct()`
         # writes — surface those transitions to subscribers too.
@@ -589,13 +653,11 @@ class GatewayKanbanWatchersMixin:
                             if ev.payload and ev.payload.get("summary"):
                                 payload_summary = str(ev.payload["summary"])
                             if payload_summary:
-                                lines = payload_summary.strip().splitlines()
-                                h = lines[0][:200] if lines else payload_summary[:200]
+                                h = _first_line_excerpt(payload_summary, limit)
                                 handoff = f"\n{h}"
                                 wake_handoff = h
                             elif task and task.result:
-                                lines = task.result.strip().splitlines()
-                                r = lines[0][:160] if lines else task.result[:160]
+                                r = _first_line_excerpt(task.result, limit)
                                 handoff = f"\n{r}"
                                 wake_handoff = r
                             msg = (
@@ -605,12 +667,12 @@ class GatewayKanbanWatchersMixin:
                         elif kind == "blocked":
                             reason = ""
                             if ev.payload and ev.payload.get("reason"):
-                                reason = f": {str(ev.payload['reason'])[:160]}"
+                                reason = f": {_mobile_excerpt(ev.payload['reason'], limit)}"
                             msg = f"⏸ {board_tag}{tag}Kanban {sub['task_id']} blocked{reason}"
                         elif kind == "gave_up":
                             err = ""
                             if ev.payload and ev.payload.get("error"):
-                                err = f"\n{str(ev.payload['error'])[:200]}"
+                                err = f"\n{_mobile_excerpt(ev.payload['error'], limit)}"
                             msg = (
                                 f"✖ {board_tag}{tag}Kanban {sub['task_id']} gave up "
                                 f"after repeated spawn failures{err}"
@@ -639,15 +701,12 @@ class GatewayKanbanWatchersMixin:
                             handoff = ""
                             if ev.payload and ev.payload.get("summary"):
                                 summary = str(ev.payload["summary"])
-                                handoff = f"\n{summary[:200]}"
+                                handoff = f"\n{_first_line_excerpt(summary, limit)}"
                                 # Carry the worker's handoff into the wake turn
                                 # like ``completed`` does: a reviewer woken with
                                 # a bare "ready for review" has to re-read the
                                 # board to learn what was implemented.
-                                lines = summary.strip().splitlines()
-                                wake_handoff = (
-                                    lines[0][:200] if lines else summary[:200]
-                                )
+                                wake_handoff = _first_line_excerpt(summary, limit)
                             msg = (
                                 f"👀 {board_tag}{tag}Kanban {sub['task_id']} ready for review"
                                 f" — {title}{handoff}"

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2745,6 +2745,13 @@ DEFAULT_CONFIG = {
     # each claimable ready task. One dispatcher per profile is sufficient;
     # running more than one on the same kanban.db will race for claims.
     "kanban": {
+        # Max characters for a kanban notification excerpt (completion
+        # summaries, blocked reasons, errors, review handoffs). The
+        # historical default is 200; raise it for longer handoffs on
+        # platforms that allow bigger messages. Clamped to [1, 3500] —
+        # Slack hard-caps a chat message at 4000 chars. Junk values fall
+        # back to the default. Takes effect at the next gateway restart.
+        "notify_max_chars": 200,
         # Auto-subscribe the originating gateway/TUI session to task
         # completion + block events when ``kanban_create`` is called from
         # inside a session that has a persistent delivery channel. The

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5528,13 +5528,15 @@ def complete_task(
             )
         # Carry the handoff summary in the event payload so gateway
         # notifiers and dashboard WS consumers can render it without a
-        # second SQL round-trip. First line only, 400 char cap — the
-        # full summary stays on the run row.
+        # second SQL round-trip. First line only, capped to match the
+        # notifier's ``kanban.notify_max_chars`` ceiling (3500 — see
+        # gateway.kanban_watchers._NOTIFY_CHARS_MAX) — the full summary
+        # stays on the run row.
         event_summary = summary if summary is not None else result
         if prior_status == "review" and not event_summary:
             event_summary = "Review approved without additional evidence."
         _ev_lines = (event_summary or "").strip().splitlines()
-        ev_summary = _ev_lines[0][:400] if _ev_lines else ""
+        ev_summary = _ev_lines[0][:3500] if _ev_lines else ""
         completed_payload: dict = {
             "result_len": len(result) if result else 0,
             "summary": ev_summary or None,
@@ -6238,7 +6240,8 @@ def edit_completed_task_result(
                     (json.dumps(metadata, ensure_ascii=False), run_id),
                 )
         _ev_lines = (handoff_summary or "").strip().splitlines()
-        ev_summary = _ev_lines[0][:400] if _ev_lines else ""
+        # 3500 cap mirrors gateway.kanban_watchers._NOTIFY_CHARS_MAX.
+        ev_summary = _ev_lines[0][:3500] if _ev_lines else ""
         _append_event(
             conn, task_id, "edited",
             {
@@ -6645,7 +6648,8 @@ def request_review(
                 metadata=metadata,
             )
         lines = (summary or "").strip().splitlines()
-        event_summary = lines[0][:400] if lines else ""
+        # 3500 cap mirrors gateway.kanban_watchers._NOTIFY_CHARS_MAX.
+        event_summary = lines[0][:3500] if lines else ""
         _append_event(
             conn,
             task_id,

--- a/tests/gateway/test_kanban_notify_limit.py
+++ b/tests/gateway/test_kanban_notify_limit.py
@@ -1,0 +1,227 @@
+"""Configurable kanban notification excerpt limits (kanban.notify_max_chars).
+
+The notifier historically hard-coded excerpt budgets (200 for summaries and
+errors, 160 for legacy results and blocked reasons), which silently chopped
+worker handoffs mid-information. ``notify_max_chars`` raises the budget while
+keeping a single shared ceiling: Slack hard-caps messages at 4000 chars, so
+the knob clamps to 3500 and falls back to the 200-char default on junk input.
+"""
+
+import asyncio
+
+import pytest
+
+from gateway.config import Platform
+from gateway.kanban_watchers import (
+    _notify_max_chars_from_config,
+    _resolve_notify_max_chars,
+)
+from gateway.run import GatewayRunner
+from hermes_cli import kanban_db as kb
+
+
+class RecordingAdapterStub:
+    def __init__(self):
+        self.sent = []
+
+    async def send(self, chat_id, text, metadata=None):
+        self.sent.append({"chat_id": chat_id, "text": text, "metadata": metadata or {}})
+
+    async def handle_message(self, event):
+        pass
+
+
+def _make_runner(adapter=None):
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._running = True
+    runner.adapters = {Platform.TELEGRAM: adapter or RecordingAdapterStub()}
+    runner._kanban_sub_fail_counts = {}
+    runner._kanban_dispatcher_lock_handle = object()
+    return runner
+
+
+# --------------------------------------------------------------------------
+# Config resolution
+# --------------------------------------------------------------------------
+
+
+def test_default_is_200_when_config_absent():
+    assert _notify_max_chars_from_config({}) == 200
+    assert _notify_max_chars_from_config({"kanban": {}}) == 200
+
+
+def test_valid_config_value_is_used():
+    assert _notify_max_chars_from_config({"kanban": {"notify_max_chars": 1200}}) == 1200
+
+
+def test_min_is_one():
+    # 0 and negatives would silently swallow the whole ping; clamp to 1.
+    assert _notify_max_chars_from_config({"kanban": {"notify_max_chars": 0}}) == 1
+    assert _notify_max_chars_from_config({"kanban": {"notify_max_chars": -50}}) == 1
+
+
+def test_max_is_3500_slack_ceiling():
+    assert _notify_max_chars_from_config({"kanban": {"notify_max_chars": 9999}}) == 3500
+
+
+def test_junk_values_fall_back_to_default():
+    for junk in ("banana", None, [400]):
+        assert _notify_max_chars_from_config({"kanban": {"notify_max_chars": junk}}) == 200
+
+
+def test_float_with_integral_value_is_accepted():
+    assert _notify_max_chars_from_config({"kanban": {"notify_max_chars": 800.0}}) == 800
+
+
+def test_resolve_uses_load_config(monkeypatch):
+    # _resolve_notify_max_chars imports load_config from hermes_cli.config at
+    # call time, so patch the attribute at its source module.
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"kanban": {"notify_max_chars": 2500}},
+    )
+    runner = _make_runner()
+    assert _resolve_notify_max_chars(runner) == 2500
+    assert runner._kanban_notify_max_chars == 2500
+
+
+def test_resolve_falls_back_when_config_loader_missing(monkeypatch):
+    def _boom():
+        raise RuntimeError("no config")
+
+    monkeypatch.setattr("hermes_cli.config.load_config", _boom)
+    runner = _make_runner()
+    _resolve_notify_max_chars(runner)
+    assert runner._kanban_notify_max_chars == 200
+
+
+# --------------------------------------------------------------------------
+# End-to-end: a completed event's summary honours the resolved limit
+# --------------------------------------------------------------------------
+
+
+async def _run_one_tick(runner, monkeypatch):
+    real_sleep = asyncio.sleep
+
+    async def fake_sleep(delay):
+        if delay == 5:
+            return None
+        runner._running = False
+        await real_sleep(0)
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+    await runner._kanban_notifier_watcher(interval=1)
+
+
+def test_long_summary_is_delivered_up_to_resolved_limit(tmp_path, monkeypatch):
+    long_summary = "x" * 900 + " END"
+    db_path = tmp_path / "limit.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="long handoff", assignee="worker")
+        kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat-1")
+        kb.complete_task(conn, tid, summary=long_summary)
+    finally:
+        conn.close()
+
+    runner = _make_runner()
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"kanban": {"notify_max_chars": 1000}},
+    )
+
+    asyncio.run(_run_one_tick(runner, monkeypatch))
+
+    sent = runner.adapters[Platform.TELEGRAM].sent
+    assert sent, "notifier did not send any message"
+    text = sent[0]["text"]
+    assert "END" in text, "summary was truncated below the configured limit"
+
+
+def test_default_limit_still_truncates_long_summary(tmp_path, monkeypatch):
+    long_summary = "y" * 900 + " END"
+    db_path = tmp_path / "default-limit.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="long handoff default", assignee="worker")
+        kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat-1")
+        kb.complete_task(conn, tid, summary=long_summary)
+    finally:
+        conn.close()
+
+    runner = _make_runner()
+    runner._kanban_notify_max_chars = 200
+
+    asyncio.run(_run_one_tick(runner, monkeypatch))
+
+    sent = runner.adapters[Platform.TELEGRAM].sent
+    assert sent, "notifier did not send any message"
+    text = sent[0]["text"]
+    assert "END" not in text, "default limit did not truncate"
+    assert "y" * 100 in text
+
+
+def test_write_time_event_payload_carries_full_summary(tmp_path, monkeypatch):
+    # Two-stage truncation guard: kanban_db.complete_task writes the event
+    # payload the notifier renders. If the write-time cap is ever lowered
+    # below the notifier ceiling again, this catches it — the payload must
+    # carry at least the notifier's max budget.
+    db_path = tmp_path / "write-cap.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="write cap", assignee="worker")
+        kb.complete_task(conn, tid, summary="z" * 900 + " TAIL")
+    finally:
+        conn.close()
+
+    conn = kb.connect()
+    try:
+        row = conn.execute(
+            "SELECT payload FROM task_events WHERE task_id=? AND kind='completed'",
+            (tid,),
+        ).fetchone()
+    finally:
+        conn.close()
+    import json
+
+    payload = json.loads(row[0])
+    summary = payload.get("summary") or ""
+    assert "TAIL" in summary, (
+        "complete_task truncated the event payload below the notifier ceiling "
+        f"(payload summary is {len(summary)} chars)"
+    )
+
+
+def test_block_task_event_payload_keeps_full_reason(tmp_path, monkeypatch):
+    db_path = tmp_path / "block-cap.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="block cap", assignee="worker")
+        kb.block_task(conn, tid, reason="R" * 900 + " TAIL", kind="needs_input")
+    finally:
+        conn.close()
+
+    conn = kb.connect()
+    try:
+        row = conn.execute(
+            "SELECT payload FROM task_events WHERE task_id=? AND kind='blocked'",
+            (tid,),
+        ).fetchone()
+    finally:
+        conn.close()
+    import json
+
+    payload = json.loads(row[0])
+    assert "TAIL" in (payload.get("reason") or "")


### PR DESCRIPTION
## What does this PR do?

Kanban notification excerpts were hard-capped at 160/200 chars at send time — and, less visibly, at **400 chars at event-write time** — so worker handoffs arrived silently chopped mid-information (`worktree provably unch`). This PR makes the excerpt budget configurable end-to-end.

- **New knob `kanban.notify_max_chars`** (config.yaml). Resolved once at notifier boot (same boot-captured pattern as the other watchers). Clamped to `[1, 3500]` — the ceiling keeps even a maxed-out ping under Slack's 4000-char message cap. Junk values (strings, lists, None, NaN) fall back to the historical default of 200; a typo'd config must not kill delivery.
- **Applies to every excerpt site** in the notifier: completion summaries, legacy `task.result` fallbacks, blocked reasons, gave-up errors, and review handoffs. Titles keep their 120-char caps (labels, not content).
- **The write-time cap rises to match.** `kanban_db.complete_task` / `request_review` / the edited-event path truncate the event payload's first-line summary before any notifier sees it — the regression test that exposed this (`test_write_time_event_payload_carries_full_summary`) initially failed with the notifier knob alone because `complete_task`'s 400-char payload cap bounded what any send-time limit could deliver. All three payload caps are now 3500 with a cross-reference comment to `_NOTIFY_CHARS_MAX`. The full summary is unchanged on the run row.
- **Documented** in `config_defaults` with the clamp and restart semantics.

## Why a knob instead of just raising the limit

Excerpts are a mobile-legibility trade-off (see #96757, which fixes *where* the cut lands at the same budgets). Operators running long engineering handoffs want the substance; the default stays 200 so nobody's phone experience changes without opting in.

## Test plan

- [x] New suite `tests/gateway/test_kanban_notify_limit.py` (12 tests): default fallback, valid value, min clamp, 3500 ceiling, junk-value fallback, float acceptance, config-loader failure fallback, end-to-end delivery at a raised limit, end-to-end default truncation, and the two write-time payload guards
- [x] All 12 existing notifier tests pass unchanged (`test_kanban_notifier.py`)
- [x] Full kanban neighborhood green: 91 passed across notifier / changes-requested / wake-ordering / dispatch-gate / watchers-mixin / wake-scope / reconcile / auto-decompose / kanban tools
- [x] `ruff check` clean on all touched files
- [x] Pre-existing failure `test_25107_stale_base_url_api_mode.py` reproduced on clean `origin/main` (unrelated: env/config-mode test)
- [x] `tests/gateway/relay` collection errors are pre-existing (`pytest_asyncio` missing from the local venv), unrelated

Stacks cleanly with #96757 — that PR's word-boundary helper and this knob touch the same sites but compose (its helper takes the limit as a parameter; this PR supplies a configurable one). Happy to rebase onto it if reviewers prefer it lands first.