### PR TITLE
fix(install): pin cua-driver installer to a tagged ref and verify sha256

### DIFF
--- a/hermes_cli/cua_installer_pin.py
+++ b/hermes_cli/cua_installer_pin.py
@@ -1,0 +1,72 @@
+"""Pinned upstream cua-driver installer identity.
+
+Hermes installs the cua-driver binary by running the upstream trycua/cua
+installer script. To avoid executing whatever happens to be on the
+upstream ``main`` branch at install time, the pin file records the exact
+Git ref and the SHA-256 of the installer script at that ref.
+
+Bump ``scripts/cua_installer_pin.env`` deliberately, like any other
+dependency.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+_PIN_PATH = Path(__file__).resolve().parent.parent / "scripts" / "cua_installer_pin.env"
+
+
+class CuaInstallerIntegrityError(ValueError):
+    """Fetched installer bytes did not match the pinned SHA-256."""
+
+
+def _load_pin_file(path: Path = _PIN_PATH) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        values[key.strip()] = value.strip()
+    required = (
+        "CUA_INSTALLER_REF",
+        "CUA_INSTALLER_SHA256_SH",
+        "CUA_INSTALLER_SHA256_PS1",
+        "CUA_DRIVER_RS_VERSION",
+    )
+    missing = [key for key in required if not values.get(key)]
+    if missing:
+        raise ValueError(f"incomplete cua installer pin file {path}: missing {missing}")
+    return values
+
+
+_PIN = _load_pin_file()
+
+CUA_INSTALLER_REF: str = _PIN["CUA_INSTALLER_REF"]
+CUA_INSTALLER_SHA256_SH: str = _PIN["CUA_INSTALLER_SHA256_SH"]
+CUA_INSTALLER_SHA256_PS1: str = _PIN["CUA_INSTALLER_SHA256_PS1"]
+CUA_DRIVER_RS_VERSION: str = _PIN["CUA_DRIVER_RS_VERSION"]
+
+
+def cua_installer_url(*, is_windows: bool, ref: str | None = None) -> str:
+    """Return the pinned upstream installer URL for the requested platform."""
+    script = "install.ps1" if is_windows else "install.sh"
+    return (
+        f"https://raw.githubusercontent.com/trycua/cua/{ref or CUA_INSTALLER_REF}"
+        f"/libs/cua-driver/scripts/{script}"
+    )
+
+
+def cua_installer_expected_sha256(*, is_windows: bool) -> str:
+    return CUA_INSTALLER_SHA256_PS1 if is_windows else CUA_INSTALLER_SHA256_SH
+
+
+def verify_cua_installer_digest(data: bytes, expected_hex: str) -> str:
+    """Return the digest if it matches ``expected_hex``; otherwise raise."""
+    digest = hashlib.sha256(data).hexdigest()
+    if digest != expected_hex.lower():
+        raise CuaInstallerIntegrityError(
+            f"cua-driver installer sha256 mismatch: got {digest}, expected {expected_hex.lower()}"
+        )
+    return digest

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1618,6 +1618,33 @@ def _repair_cua_driver_autostart_windows(driver_cmd: str, *, verbose: bool) -> b
     return False
 
 
+
+def _write_verified_cua_installer(dest_path: str, *, is_windows: bool) -> None:
+    """Download the pinned cua-driver installer and refuse a digest mismatch."""
+    import urllib.error
+    import urllib.request
+
+    from hermes_cli.cua_installer_pin import (
+        cua_installer_expected_sha256,
+        cua_installer_url,
+        verify_cua_installer_digest,
+        CuaInstallerIntegrityError,
+    )
+
+    url = cua_installer_url(is_windows=is_windows)
+    try:
+        with urllib.request.urlopen(url, timeout=120) as resp:
+            data = resp.read()
+    except (urllib.error.URLError, TimeoutError, OSError) as e:
+        raise RuntimeError(f"cua-driver installer download failed: {e}") from e
+    try:
+        verify_cua_installer_digest(data, cua_installer_expected_sha256(is_windows=is_windows))
+    except CuaInstallerIntegrityError as e:
+        raise RuntimeError(str(e)) from e
+    with open(dest_path, "wb") as fh:
+        fh.write(data)
+
+
 def _run_cua_driver_installer(
     label: str = "Installing",
     verbose: bool = True,
@@ -1630,9 +1657,8 @@ def _run_cua_driver_installer(
     The scripts are idempotent: they always download the latest release, so
     re-running on an already-installed system performs an upgrade.
 
-    * macOS / Linux → ``curl -fsSL …/install.sh | /bin/bash``.
-    * Windows       → ``powershell -NoProfile -ExecutionPolicy Bypass -Command
-      "irm …/install.ps1 | iex"``.
+    The installer script itself is fetched from a pinned trycua/cua ref and
+    SHA-256-verified before execution (see ``hermes_cli.cua_installer_pin``).
 
     ``pin_version`` (e.g. ``"0.13.1"``) is exported as
     ``CUA_DRIVER_RS_VERSION`` so the installer downloads that exact release
@@ -1652,59 +1678,39 @@ def _run_cua_driver_installer(
     is_windows = system == "Windows"
     is_linux = system == "Linux"
 
+    from hermes_cli.cua_installer_pin import cua_installer_url
+    import tempfile as _tempfile
+
+    install_url = cua_installer_url(is_windows=is_windows)
     if is_windows:
-        # Mirror the one-liner printed by cua_driver_install_hint().
-        ps_oneliner = (
-            "irm https://raw.githubusercontent.com/trycua/cua/main/"
-            "libs/cua-driver/scripts/install.ps1 | iex"
-        )
-        install_cmd = [
-            "powershell", "-NoProfile", "-ExecutionPolicy", "Bypass",
-            "-Command", ps_oneliner,
-        ]
         manual_hint = (
-            'powershell -NoProfile -ExecutionPolicy Bypass -Command '
-            f'"{ps_oneliner}"'
+            'powershell -NoProfile -ExecutionPolicy Bypass -File '
+            "<verified install.ps1 from pinned trycua/cua ref>"
         )
-        script_path = None
+        suffix = ".ps1"
     else:
         # Download-then-exec instead of `bash -c "$(curl …)"`: no shell=True,
         # no command substitution, and the script lands in a mkstemp file
-        # (unpredictable name, 0600) rather than a fixed /tmp path — avoiding
-        # both the shell-injection surface and a symlink/TOCTOU race on
-        # multi-user machines. The manual hint stays the upstream one-liner
-        # since that's what the docs/README teach.
-        import tempfile as _tempfile
-
-        install_url = (
-            "https://raw.githubusercontent.com/trycua/cua/main/"
-            "libs/cua-driver/scripts/install.sh"
-        )
+        # (unpredictable name, 0600) rather than a fixed /tmp path.
         manual_hint = f'/bin/bash -c "$(curl -fsSL {install_url})"'
-        fd, script_path = _tempfile.mkstemp(prefix="cua-driver-install-", suffix=".sh")
-        os.close(fd)
+        suffix = ".sh"
+    fd, script_path = _tempfile.mkstemp(prefix="cua-driver-install-", suffix=suffix)
+    os.close(fd)
+    try:
+        _write_verified_cua_installer(script_path, is_windows=is_windows)
+    except RuntimeError as e:
+        _print_warning(f"    {e}")
         try:
-            dl = subprocess.run(
-                ["curl", "-fsSL", "-o", script_path, install_url],
-                capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=120,
-            )
-        except (subprocess.TimeoutExpired, OSError) as e:
-            _print_warning(f"    cua-driver installer download failed: {e}")
-            try:
-                os.remove(script_path)
-            except OSError:
-                pass
-            return False
-        if dl.returncode != 0:
-            _print_warning(
-                "    cua-driver installer download failed: "
-                f"{(dl.stderr or '').strip()[:200]}"
-            )
-            try:
-                os.remove(script_path)
-            except OSError:
-                pass
-            return False
+            os.remove(script_path)
+        except OSError:
+            pass
+        return False
+    if is_windows:
+        install_cmd = [
+            "powershell", "-NoProfile", "-ExecutionPolicy", "Bypass",
+            "-File", script_path,
+        ]
+    else:
         install_cmd = ["/bin/bash", script_path]
     use_shell = False
 
@@ -1765,14 +1771,11 @@ def _run_cua_driver_installer(
             # ONLY branch of install.ps1 that self-elevates (UAC). Cost: an
             # existing cua-driver-serve task keeps pointing at the previous
             # binary until the next interactive upgrade re-registers it.
-            # scriptblock invocation (instead of `| iex`) is what lets us
-            # pass the parameter to a piped script.
+            # -File plus a named switch works because the script is already
+            # on disk after the pinned digest check.
             install_cmd = [
                 "powershell", "-NoProfile", "-ExecutionPolicy", "Bypass",
-                "-Command",
-                "$sc = irm https://raw.githubusercontent.com/trycua/cua/"
-                "main/libs/cua-driver/scripts/install.ps1; "
-                "& ([scriptblock]::Create($sc)) -NoAutoStart",
+                "-File", script_path, "-NoAutoStart",
             ]
 
     # POSIX: run the installer in its own process group so a timeout kill

--- a/scripts/cua_installer_pin.env
+++ b/scripts/cua_installer_pin.env
@@ -1,0 +1,8 @@
+# Pinned trycua/cua installer identity. Bump deliberately, like any other
+# dependency: fetch the script at the new ref, record its SHA-256, then
+# update every value below. Consumed by hermes_cli/cua_installer_pin.py,
+# scripts/install.sh, and scripts/install.ps1.
+CUA_INSTALLER_REF=cua-driver-rs-v0.20.0
+CUA_INSTALLER_SHA256_SH=317ba3a49fdba10f2a7f1b9f392c1bc1b7657f3aae85e1e2e43684cf17a1bf3b
+CUA_INSTALLER_SHA256_PS1=6f8f435c75f12e1939c104ffb5bd0a7af8e3a90a213b3e8fcf0206520da6719c
+CUA_DRIVER_RS_VERSION=0.20.0

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -3694,8 +3694,30 @@ function Install-CuaDriver {
         # via a background job: the upstream installer serializes with its own
         # lock (600s stale window), so the ceiling sits above that -- matching
         # Hermes' _CUA_INSTALLER_TIMEOUT (660s).
-        $job = Start-Job -ScriptBlock {
-            Invoke-RestMethod -UseBasicParsing "https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/install.ps1" | Invoke-Expression
+        $pinFile = Join-Path $InstallDir "scripts\cua_installer_pin.env"
+        if (-not (Test-Path $pinFile)) {
+            Write-Warn "Computer Use driver pin file missing -- it will install on demand when you enable the tool."
+            Write-Info "Install later with: hermes computer-use install"
+            return
+        }
+        $pin = @{}
+        Get-Content $pinFile | ForEach-Object {
+            if ($_ -match "^\s*#" -or $_ -notmatch "=") { return }
+            $k, $v = $_ -split "=", 2
+            $pin[$k.Trim()] = $v.Trim()
+        }
+        $cuaRef = $pin["CUA_INSTALLER_REF"]
+        $expected = $pin["CUA_INSTALLER_SHA256_PS1"]
+        $cuaUrl = "https://raw.githubusercontent.com/trycua/cua/$cuaRef/libs/cua-driver/scripts/install.ps1"
+        $job = Start-Job -ArgumentList $cuaUrl, $expected -ScriptBlock {
+            param($Url, $Expected)
+            $tmp = Join-Path $env:TEMP ("cua-install-" + [guid]::NewGuid().ToString() + ".ps1")
+            Invoke-WebRequest -UseBasicParsing -Uri $Url -OutFile $tmp
+            $hash = (Get-FileHash -Algorithm SHA256 -Path $tmp).Hash.ToLowerInvariant()
+            if ($hash -ne $Expected.ToLowerInvariant()) {
+                throw "cua-driver installer sha256 mismatch"
+            }
+            & $tmp
         }
         if (Wait-Job $job -Timeout 660) {
             Receive-Job $job -ErrorAction SilentlyContinue | Out-Null

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2665,18 +2665,49 @@ install_computer_use_driver() {
     # upstream installer serializes with its own lock (600s stale window),
     # so give it a ceiling above that — matching Hermes'
     # _CUA_INSTALLER_TIMEOUT (660s).
-    local cua_log
+    # Fetch a pinned trycua/cua ref and verify SHA-256 before exec so a
+    # mutable `main` commit cannot run on every default install.
+    local pin_file cua_log cua_script actual
+    pin_file="$INSTALL_DIR/scripts/cua_installer_pin.env"
+    if [ ! -f "$pin_file" ]; then
+        log_warn "Computer Use driver pin file missing — it will install on demand when you enable the tool."
+        log_info "Install later with: hermes computer-use install"
+        return 0
+    fi
+    # shellcheck disable=SC1090
+    . "$pin_file"
     cua_log="$(mktemp)"
-    if run_with_timeout 660 /bin/bash -c \
-        'curl -fsSL https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/install.sh | /bin/bash' \
+    cua_script="$(mktemp)"
+    if ! curl -fsSL -o "$cua_script" \
+        "https://raw.githubusercontent.com/trycua/cua/${CUA_INSTALLER_REF}/libs/cua-driver/scripts/install.sh" \
         >"$cua_log" 2>&1; then
+        log_warn "Computer Use driver install failed — it will install on demand when you enable the tool."
+        log_info "Install later with: hermes computer-use install"
+        tail -n 5 "$cua_log" >&2 || true
+        rm -f "$cua_log" "$cua_script"
+        return 0
+    fi
+    if command -v sha256sum >/dev/null 2>&1; then
+        actual="$(sha256sum "$cua_script" | awk '{print $1}')"
+    elif command -v shasum >/dev/null 2>&1; then
+        actual="$(shasum -a 256 "$cua_script" | awk '{print $1}')"
+    else
+        actual="$(openssl dgst -sha256 "$cua_script" | awk '{print $NF}')"
+    fi
+    if [ "$actual" != "$CUA_INSTALLER_SHA256_SH" ]; then
+        log_warn "Computer Use driver installer sha256 mismatch — refusing to execute unpinned script."
+        log_info "Install later with: hermes computer-use install"
+        rm -f "$cua_log" "$cua_script"
+        return 0
+    fi
+    if run_with_timeout 660 /bin/bash "$cua_script" >"$cua_log" 2>&1; then
         log_success "Computer Use driver installed (enable via 'hermes tools' → Computer Use)"
     else
         log_warn "Computer Use driver install failed — it will install on demand when you enable the tool."
         log_info "Install later with: hermes computer-use install"
         tail -n 5 "$cua_log" >&2 || true
     fi
-    rm -f "$cua_log"
+    rm -f "$cua_log" "$cua_script"
 }
 
 run_setup_wizard() {

--- a/tests/hermes_cli/test_cua_installer_pin.py
+++ b/tests/hermes_cli/test_cua_installer_pin.py
@@ -1,0 +1,97 @@
+"""Pinned cua-driver installer identity and digest checks."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli.cua_installer_pin import (
+    CUA_INSTALLER_REF,
+    CUA_INSTALLER_SHA256_PS1,
+    CUA_INSTALLER_SHA256_SH,
+    CuaInstallerIntegrityError,
+    cua_installer_expected_sha256,
+    cua_installer_url,
+    verify_cua_installer_digest,
+)
+from hermes_cli.tools_config import _write_verified_cua_installer
+
+
+class _BytesResp:
+    def __init__(self, payload: bytes):
+        self._payload = payload
+
+    def read(self):
+        return self._payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+
+def test_url_is_pinned_not_main():
+    posix = cua_installer_url(is_windows=False)
+    windows = cua_installer_url(is_windows=True)
+    assert "/main/" not in posix
+    assert "/main/" not in windows
+    assert CUA_INSTALLER_REF in posix
+    assert CUA_INSTALLER_REF in windows
+    assert posix.endswith("/install.sh")
+    assert windows.endswith("/install.ps1")
+
+
+def test_verify_accepts_matching_digest():
+    payload = b"trusted installer\n"
+    expected = hashlib.sha256(payload).hexdigest()
+    assert verify_cua_installer_digest(payload, expected) == expected
+
+
+def test_verify_rejects_mismatch():
+    with pytest.raises(CuaInstallerIntegrityError, match="sha256 mismatch"):
+        verify_cua_installer_digest(b"evil", "0" * 64)
+
+
+def test_write_verified_refuses_tampered_bytes(tmp_path):
+    dest = tmp_path / "install.sh"
+    with patch("urllib.request.urlopen", return_value=_BytesResp(b"not the pinned installer\n")):
+        with pytest.raises(RuntimeError, match="sha256 mismatch"):
+            _write_verified_cua_installer(str(dest), is_windows=False)
+    assert not dest.exists()
+
+
+def test_write_verified_keeps_matching_bytes(tmp_path):
+    dest = tmp_path / "install.sh"
+    payload = b"trusted installer\n"
+    expected = hashlib.sha256(payload).hexdigest()
+    with patch("urllib.request.urlopen", return_value=_BytesResp(payload)), patch(
+        "hermes_cli.cua_installer_pin.cua_installer_expected_sha256",
+        return_value=expected,
+    ):
+        _write_verified_cua_installer(str(dest), is_windows=False)
+    assert dest.read_bytes() == payload
+
+
+def test_pin_file_matches_module_constants():
+    pin_path = Path(__file__).resolve().parents[2] / "scripts" / "cua_installer_pin.env"
+    raw = pin_path.read_text(encoding="utf-8")
+    assert f"CUA_INSTALLER_REF={CUA_INSTALLER_REF}" in raw
+    assert f"CUA_INSTALLER_SHA256_SH={CUA_INSTALLER_SHA256_SH}" in raw
+    assert f"CUA_INSTALLER_SHA256_PS1={CUA_INSTALLER_SHA256_PS1}" in raw
+    assert cua_installer_expected_sha256(is_windows=False) == CUA_INSTALLER_SHA256_SH
+    assert cua_installer_expected_sha256(is_windows=True) == CUA_INSTALLER_SHA256_PS1
+
+
+def test_live_pinned_posix_installer_matches_recorded_digest():
+    import urllib.request
+
+    url = cua_installer_url(is_windows=False)
+    with urllib.request.urlopen(url, timeout=30) as resp:
+        data = resp.read()
+        status = getattr(resp, "status", 200)
+    assert status == 200
+    assert verify_cua_installer_digest(data, CUA_INSTALLER_SHA256_SH) == CUA_INSTALLER_SHA256_SH

--- a/tests/hermes_cli/test_install_cua_driver.py
+++ b/tests/hermes_cli/test_install_cua_driver.py
@@ -24,10 +24,23 @@ from __future__ import annotations
 
 import json
 import sys
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
+
+
+@pytest.fixture(autouse=True)
+def _stub_verified_cua_installer():
+    """Unit tests must not fetch the live trycua installer."""
+    from hermes_cli import tools_config
+
+    def _write(dest_path, *, is_windows):
+        Path(dest_path).write_bytes(b"# stub cua installer\n")
+
+    with patch.object(tools_config, "_write_verified_cua_installer", side_effect=_write):
+        yield
 
 
 def _runtime_manifest(version="0.20.0", *, omit=None):
@@ -1739,22 +1752,25 @@ class TestUnattendedRefreshPreflights:
         assert ok is True
 
     def test_windows_unattended_command_passes_noautostart(self):
-        """The unattended Windows command must invoke install.ps1 with
-        -NoAutoStart — Register-CuaDriverAutostart is the only branch that
-        self-elevates (UAC)."""
+        """The unattended Windows command must invoke the verified install.ps1
+        with -NoAutoStart — Register-CuaDriverAutostart is the only branch
+        that self-elevates (UAC)."""
         ok, popen, _, _, _ = self._run(120, system="Windows")
         assert ok is True
         cmd = popen.call_args.args[0]
         joined = " ".join(cmd)
+        assert "-File" in cmd
         assert "-NoAutoStart" in joined
-        assert "scriptblock" in joined
+        assert "| iex" not in joined
 
-    def test_windows_explicit_command_keeps_plain_oneliner(self):
-        """Explicit installs keep upstream's documented `irm | iex` shape
-        (autostart re-registration included — human present for UAC)."""
+    def test_windows_explicit_command_runs_verified_file(self):
+        """Explicit installs run the digest-checked script as -File so
+        autostart re-registration stays available (human present for UAC)
+        without piping an unpinned remote script."""
         ok, popen, _, _, _ = self._run(None, system="Windows")
         assert ok is True
         cmd = popen.call_args.args[0]
         joined = " ".join(cmd)
+        assert "-File" in cmd
         assert "-NoAutoStart" not in joined
-        assert "| iex" in joined
+        assert "| iex" not in joined

--- a/tests/hermes_cli/test_install_cua_driver.py
+++ b/tests/hermes_cli/test_install_cua_driver.py
@@ -1321,7 +1321,8 @@ class TestInstallerNoShell:
     asserting a branch the host had already selected.
     """
 
-    def _run(self, download_rc=0):
+    def _run(self, download_ok=True):
+        from pathlib import Path
         from unittest.mock import MagicMock
         from hermes_cli import tools_config
 
@@ -1331,18 +1332,17 @@ class TestInstallerNoShell:
         fake_proc.returncode = 0
         fake_proc.communicate.return_value = ("", None)
 
-        def fake_run(cmd, **kw):
-            calls.append(("run", cmd, kw))
-            m = MagicMock()
-            m.returncode = download_rc
-            m.stderr = "curl: (6) could not resolve" if download_rc else ""
-            return m
+        def fake_write(dest_path, *, is_windows):
+            calls.append(("write", dest_path, is_windows))
+            if not download_ok:
+                raise RuntimeError("cua-driver installer download failed: simulated")
+            Path(dest_path).write_bytes(b"# stub cua installer\n")
 
         def fake_popen(cmd, **kw):
             calls.append(("popen", cmd, kw))
             return fake_proc
 
-        with patch("subprocess.run", side_effect=fake_run), \
+        with patch.object(tools_config, "_write_verified_cua_installer", side_effect=fake_write), \
              patch("subprocess.Popen", side_effect=fake_popen), \
              patch.object(tools_config.shutil, "which", return_value="/usr/local/bin/cua-driver"), \
              patch.object(tools_config, "_clear_stale_cua_install_lock"), \
@@ -1355,12 +1355,10 @@ class TestInstallerNoShell:
     def test_posix_path_downloads_then_execs_argv_list(self):
         ok, calls = self._run()
         assert ok is True
-        run_calls = [c for c in calls if c[0] == "run"]
+        write_calls = [c for c in calls if c[0] == "write"]
         popen_calls = [c for c in calls if c[0] == "popen"]
-        assert len(run_calls) == 1 and len(popen_calls) == 1
-        # Download: plain argv curl, no shell.
-        dl_cmd = run_calls[0][1]
-        assert isinstance(dl_cmd, list) and dl_cmd[0] == "curl"
+        assert len(write_calls) == 1 and len(popen_calls) == 1
+        assert write_calls[0][2] is False
         # Exec: argv list ["/bin/bash", <mkstemp path>], shell=False.
         exec_cmd, exec_kw = popen_calls[0][1], popen_calls[0][2]
         assert isinstance(exec_cmd, list) and exec_cmd[0] == "/bin/bash"
@@ -1368,7 +1366,7 @@ class TestInstallerNoShell:
         assert exec_kw.get("shell") is False
 
     def test_download_failure_returns_false_without_exec(self):
-        ok, calls = self._run(download_rc=6)
+        ok, calls = self._run(download_ok=False)
         assert ok is False
         assert not [c for c in calls if c[0] == "popen"]
 

--- a/tests/test_install_scripts_computer_use.py
+++ b/tests/test_install_scripts_computer_use.py
@@ -32,12 +32,25 @@ class TestInstallSh:
         window; a ceiling below that reintroduces the self-perpetuating
         wedge (#58762). Must stay >= 660."""
         text = INSTALL_SH.read_text()
-        assert "run_with_timeout 660 /bin/bash -c" in text
+        assert "run_with_timeout 660 /bin/bash" in text
 
     def test_install_is_best_effort(self) -> None:
         text = INSTALL_SH.read_text()
         assert "Computer Use driver install failed" in text
         assert "hermes computer-use install" in text
+
+    def test_install_uses_pinned_ref_and_sha256(self) -> None:
+        from hermes_cli.cua_installer_pin import (
+            CUA_INSTALLER_REF,
+            CUA_INSTALLER_SHA256_SH,
+        )
+
+        text = INSTALL_SH.read_text()
+        assert "trycua/cua/main/" not in text
+        assert "cua_installer_pin.env" in text
+        assert CUA_INSTALLER_SHA256_SH
+        assert "CUA_INSTALLER_SHA256_SH" in text
+        assert CUA_INSTALLER_REF.startswith("cua-driver-rs-")
 
     def test_skips_unwritable_applications_dir(self) -> None:
         """Non-admin macOS accounts can't receive CuaDriver.app (#47865
@@ -65,6 +78,15 @@ class TestInstallPs1:
         text = INSTALL_PS1.read_text()
         assert "Computer Use driver install timed out" in text
         assert "hermes computer-use install" in text
+
+    def test_install_uses_pinned_ref_and_sha256(self) -> None:
+        from hermes_cli.cua_installer_pin import CUA_INSTALLER_SHA256_PS1
+
+        text = INSTALL_PS1.read_text()
+        assert "trycua/cua/main/" not in text
+        assert "cua_installer_pin.env" in text
+        assert "CUA_INSTALLER_SHA256_PS1" in text
+        assert CUA_INSTALLER_SHA256_PS1
 
     def test_install_rechecks_runtime_contract_before_success(self) -> None:
         text = INSTALL_PS1.read_text()

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -17,11 +17,7 @@ in this file is OS-agnostic; per-host gaps (no DISPLAY, missing AT-SPI,
 etc.) surface as specific blocked checks via `hermes computer-use doctor`
 rather than failing silently.
 
-Install:
-  - **macOS**:
-      /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/install.sh)"
-  - **Windows** (PowerShell):
-      irm https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/install.ps1 | iex
+Install via ``hermes computer-use install`` (pinned trycua/cua ref + sha256).
 
 After install, `cua-driver` is on $PATH and supports `cua-driver mcp` (stdio
 transport) which is what we invoke.
@@ -1442,16 +1438,15 @@ def _maybe_nudge_update() -> None:
 
 
 def cua_driver_install_hint() -> str:
+    from hermes_cli.cua_installer_pin import cua_installer_url
     if sys.platform == "win32":
         installer = (
-            '  irm https://raw.githubusercontent.com/trycua/cua/main/'
-            'libs/cua-driver/scripts/install.ps1 | iex'
+            f'  irm {cua_installer_url(is_windows=True)} | iex'
         )
     else:
         installer = (
             '  /bin/bash -c "$(curl -fsSL '
-            'https://raw.githubusercontent.com/trycua/cua/main/'
-            'libs/cua-driver/scripts/install.sh)"'
+            f'{cua_installer_url(is_windows=False)})"'
         )
     return (
         "cua-driver is not installed. Install with one of:\n"


### PR DESCRIPTION
## What does this PR do?

The default Linux/macOS install, `hermes computer-use install`, and the Windows installer all fetched the trycua/cua computer-use installer from mutable `main` and executed it with no digest check. Two installs a day apart could run different script bytes, and a single bad commit on that branch would run on every default Hermes install.

This pins the installer to `cua-driver-rs-v0.20.0`, records the SHA-256 of `install.sh` / `install.ps1` at that ref in `scripts/cua_installer_pin.env`, and refuses to execute the downloaded script unless the digest matches. The pin is bumped the same way as any other dependency.

## Related Issue

Fixes #89158

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `scripts/cua_installer_pin.env` and `hermes_cli/cua_installer_pin.py` as the single installer identity (ref + sha256).
- `hermes_cli/tools_config.py`: download the pinned script, verify the digest, then exec (`/bin/bash` or `powershell -File`). Unattended Windows refresh still passes `-NoAutoStart`.
- `scripts/install.sh` / `scripts/install.ps1`: same pin + hash check on the default install stage (no `curl | bash` / `irm | iex` of `main`).
- `tools/computer_use/cua_backend.py`: install hint uses the pinned URL.
- Tests: `tests/hermes_cli/test_cua_installer_pin.py`, plus installer-script and Windows command-shape updates.

## How to Test

1. Confirm the old failure: on current main, `scripts/install.sh` and `_run_cua_driver_installer` fetch `https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/install.sh` with no sha256 check.
2. After this change, `cua_installer_url(is_windows=False)` contains `cua-driver-rs-v0.20.0` and not `/main/`.
3. Run `scripts/run_tests.sh tests/hermes_cli/test_cua_installer_pin.py tests/test_install_scripts_computer_use.py tests/hermes_cli/test_install_cua_driver.py -q` — digest mismatch refuses to write the script; a live GET of the pinned POSIX installer matches `CUA_INSTALLER_SHA256_SH`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
HTTP/2 200
pinned install.sh sha256: 317ba3a49fdba10f2a7f1b9f392c1bc1b7657f3aae85e1e2e43684cf17a1bf3b
main install.ps1 sha256 differs from cua-driver-rs-v0.20.0 (mutable main drift)

scripts/run_tests.sh tests/hermes_cli/test_cua_installer_pin.py tests/test_install_scripts_computer_use.py tests/hermes_cli/test_install_cua_driver.py -q
=== Summary: 3 files, 72 tests passed, 0 failed, 24 skipped ===
```
