### PR TITLE
feat(auth): add Codex authorization-code OAuth flow

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -141,6 +141,10 @@ STEPFUN_STEP_PLAN_INTL_BASE_URL = "https://api.stepfun.ai/step_plan/v1"
 STEPFUN_STEP_PLAN_CN_BASE_URL = "https://api.stepfun.com/step_plan/v1"
 CODEX_OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
 CODEX_OAUTH_TOKEN_URL = "https://auth.openai.com/oauth/token"
+CODEX_OAUTH_AUTHORIZE_URL = "https://auth.openai.com/oauth/authorize"
+CODEX_OAUTH_SCOPE = "openai.chatgpt.experimental"
+CODEX_OAUTH_AUTHCODE_REDIRECT_PATH = "/callback"
+CODEX_OAUTH_AUTHCODE_CALLBACK_TIMEOUT = 300.0  # 5 min browser round-trip
 try:  # Version tag for the Codex token-endpoint User-Agent; fall back if unavailable.
     from hermes_cli import __version__ as _HERMES_CLI_VERSION
 except Exception:  # pragma: no cover - version import should always succeed
@@ -8031,9 +8035,12 @@ def _login_openai_codex(
     *,
     force_new_login: bool = False,
 ) -> None:
-    """OpenAI Codex login via device code flow. Tokens stored in ~/.hermes/auth.json."""
+    """OpenAI Codex login. Default is the browser authorization-code + PKCE flow;
+    falls back to the device-code flow when ``--device-code`` is set or no
+    graphical browser is available (e.g. over SSH). Tokens stored in
+    ~/.hermes/auth.json."""
 
-    del args, pconfig  # kept for parity with other provider login helpers
+    del pconfig  # kept for signature parity with other provider login helpers
 
     # Check for existing Hermes-owned credentials
     if not force_new_login:
@@ -8081,13 +8088,34 @@ def _login_openai_codex(
                 print(f"  Config updated: {config_path} (model.provider=openai-codex)")
                 return
 
-    # Run a fresh device code flow — Hermes gets its own OAuth session
-    print()
-    print("Signing in to OpenAI Codex...")
-    print("(Hermes creates its own session — won't affect Codex CLI or VS Code)")
-    print()
-
-    creds = _codex_device_code_login()
+    # Run a fresh OAuth flow — Hermes gets its own session. Default is the
+    # browser authorization-code + PKCE flow; fall back to device-code when the
+    # user asks for it (``--device-code``) or when no graphical browser is
+    # available (e.g. over SSH / a headless host).
+    force_device_code = bool(getattr(args, "device_code", False))
+    open_browser = not getattr(args, "no_browser", False)
+    use_authcode = (
+        not force_device_code
+        and open_browser
+        and not _is_remote_session()
+        and _can_open_graphical_browser()
+    )
+    if use_authcode:
+        creds = _codex_authcode_login(
+            open_browser=True,
+            timeout_seconds=getattr(args, "timeout", None),
+            scope_override=getattr(args, "scope", None),
+        )
+    else:
+        if force_device_code:
+            print("Using the device-code OAuth flow (--device-code).")
+        elif not use_authcode:
+            print("No graphical browser available; falling back to the device-code flow.")
+        print()
+        print("Signing in to OpenAI Codex...")
+        print("(Hermes creates its own session — won't affect Codex CLI or VS Code)")
+        print()
+        creds = _codex_device_code_login()
 
     # Save tokens to Hermes auth store
     _save_codex_tokens(creds["tokens"], creds.get("last_refresh"))
@@ -8548,6 +8576,310 @@ def _codex_device_code_login() -> Dict[str, Any]:
         "last_refresh": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
         "auth_mode": "chatgpt",
         "source": "device-code",
+    }
+
+
+# --------------------------------------------------------------------------------------
+# OpenAI Codex Authorization Code (browser + PKCE) OAuth flow
+# --------------------------------------------------------------------------------------
+# Alternative to the device-code flow above. Opens the system browser to OpenAI's
+# authorize endpoint, receives the authorization code on a loopback HTTP callback,
+# and exchanges it for tokens at the same CODEX_OAUTH_TOKEN_URL the device-code flow
+# uses. Token storage / refresh / pool wiring is identical (same return shape), so
+# callers (``_login_openai_codex`` and ``auth_add_command``) treat both flows the
+# same. The device-code flow remains available as a fallback (``--device-code`` or
+# when no graphical browser is available, e.g. over SSH).
+
+_CODEX_AUTHCODE_PORT_RANGE = (8765, 8785)
+
+
+def _codex_authcode_free_port() -> int:
+    """Return a free loopback port for the OAuth callback server."""
+    import socket
+
+    for port in range(_CODEX_AUTHCODE_PORT_RANGE[0], _CODEX_AUTHCODE_PORT_RANGE[1]):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            try:
+                s.bind(("127.0.0.1", port))
+                return port
+            except OSError:
+                continue
+    # Fall back to an OS-chosen port if the preferred range is exhausted.
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _codex_authcode_build_authorize_url(
+    *,
+    client_id: str,
+    redirect_uri: str,
+    scope: str,
+    state: str,
+    code_challenge: str,
+) -> str:
+    query = urlencode(
+        {
+            "client_id": client_id,
+            "response_type": "code",
+            "redirect_uri": redirect_uri,
+            "scope": scope,
+            "state": state,
+            "code_challenge_method": "S256",
+            "code_challenge": code_challenge,
+        }
+    )
+    return f"{CODEX_OAUTH_AUTHORIZE_URL}?{query}"
+
+
+def _codex_authcode_make_callback_handler(expected_path: str) -> tuple[type, dict[str, Any]]:
+    result: dict[str, Any] = {
+        "code": None,
+        "state": None,
+        "error": None,
+        "error_description": None,
+    }
+
+    class _CodexAuthcodeCallbackHandler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # noqa: N802
+            parsed = urlparse(self.path)
+            if parsed.path != expected_path:
+                self.send_response(404)
+                self.end_headers()
+                self.wfile.write(b"Not found.")
+                return
+            params = parse_qs(parsed.query)
+            result["code"] = params.get("code", [None])[0]
+            result["state"] = params.get("state", [None])[0]
+            result["error"] = params.get("error", [None])[0]
+            result["error_description"] = params.get("error_description", [None])[0]
+
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.end_headers()
+            if result.get("error"):
+                body = (
+                    "<html><body><h2>Authorization failed.</h2>"
+                    f"<p>{result.get('error')}: {result.get('error_description') or ''}</p>"
+                    "<p>You may close this window.</p>"
+                    "<script>window.close();</script>"
+                    "</body></html>"
+                )
+            else:
+                body = (
+                    "<html><body><h2>Authorization successful.</h2>"
+                    "<p>You may close this window and return to Hermes.</p>"
+                    "<script>window.close();</script>"
+                    "</body></html>"
+                )
+            self.wfile.write(body.encode("utf-8"))
+
+        def log_message(self, *args: Any) -> None:  # noqa: D401
+            pass
+
+    return _CodexAuthcodeCallbackHandler, result
+
+
+def _codex_authcode_wait_for_callback(
+    *,
+    host: str,
+    port: int,
+    path: str,
+    timeout_seconds: float,
+) -> dict[str, Any]:
+    handler_cls, result = _codex_authcode_make_callback_handler(path)
+    try:
+        server = HTTPServer((host, port), handler_cls)
+    except OSError as exc:
+        raise AuthError(
+            f"Could not start the local OAuth callback server on {host}:{port}: {exc}",
+            provider="openai-codex",
+            code="authcode_callback_bind_failed",
+        )
+    server.timeout = 1.0
+    deadline = time.monotonic() + max(1.0, float(timeout_seconds))
+    try:
+        while time.monotonic() < deadline:
+            server.handle_request()
+            if result.get("code") or result.get("error"):
+                break
+    finally:
+        server.server_close()
+    if not (result.get("code") or result.get("error")):
+        raise AuthError(
+            "Login timed out waiting for the browser callback.",
+            provider="openai-codex",
+            code="authcode_timeout",
+        )
+    return result
+
+
+def _codex_authcode_login(
+    *,
+    open_browser: bool = True,
+    timeout_seconds: float | None = None,
+    scope_override: str | None = None,
+) -> Dict[str, Any]:
+    """OpenAI Codex login via the browser Authorization Code + PKCE flow.
+
+    Returns the same credential dict shape as ``_codex_device_code_login`` so the
+    two flows are interchangeable to callers. Tokens are NOT persisted here; the
+    caller saves them via ``_save_codex_tokens`` / the pool-entry path.
+    """
+    client_id = CODEX_OAUTH_CLIENT_ID
+    scope = (scope_override or "").strip() or CODEX_OAUTH_SCOPE
+
+    code_verifier = _oauth_pkce_code_verifier()
+    code_challenge = _oauth_pkce_code_challenge(code_verifier)
+    state_nonce = uuid.uuid4().hex
+
+    port = _codex_authcode_free_port()
+    host = "127.0.0.1"
+    redirect_uri = f"http://{host}:{port}{CODEX_OAUTH_AUTHCODE_REDIRECT_PATH}"
+    authorize_url = _codex_authcode_build_authorize_url(
+        client_id=client_id,
+        redirect_uri=redirect_uri,
+        scope=scope,
+        state=state_nonce,
+        code_challenge=code_challenge,
+    )
+
+    print()
+    print("Signing in to OpenAI Codex (browser authorization)...")
+    print("(Hermes creates its own session — won't affect Codex CLI or VS Code)")
+    print()
+    print("Open this URL to authorize Hermes:")
+    print(f"  {authorize_url}")
+    print()
+    _print_loopback_ssh_hint(redirect_uri)
+
+    if open_browser and not _is_remote_session() and _can_open_graphical_browser():
+        try:
+            opened = webbrowser.open(authorize_url)
+        except Exception:
+            opened = False
+        if opened:
+            print("Browser opened for OpenAI authorization.")
+        else:
+            print("Could not open the browser automatically; use the URL above.")
+    else:
+        print("Open the URL above in your browser to continue.")
+
+    wait_timeout = float(timeout_seconds or CODEX_OAUTH_AUTHCODE_CALLBACK_TIMEOUT)
+    print(f"Waiting for authorization... (timeout {int(wait_timeout)}s, Ctrl+C to cancel)")
+
+    try:
+        callback = _codex_authcode_wait_for_callback(
+            host=host,
+            port=port,
+            path=CODEX_OAUTH_AUTHCODE_REDIRECT_PATH,
+            timeout_seconds=wait_timeout,
+        )
+    except KeyboardInterrupt:
+        print("\nLogin cancelled.")
+        raise SystemExit(130)
+
+    if callback.get("error"):
+        detail = callback.get("error_description") or callback["error"]
+        if callback["error"] == "access_denied":
+            raise AuthError(
+                f"Authorization cancelled: {detail}",
+                provider="openai-codex",
+                code="authcode_access_denied",
+            )
+        raise AuthError(
+            f"Authorization failed: {callback['error']} — {detail}",
+            provider="openai-codex",
+            code="authcode_callback_error",
+        )
+
+    authorization_code = callback.get("code") or ""
+    returned_state = callback.get("state") or ""
+    if not authorization_code:
+        raise AuthError(
+            "Authorization callback did not return a code.",
+            provider="openai-codex",
+            code="authcode_no_code",
+        )
+    if returned_state != state_nonce:
+        raise AuthError(
+            "Authorization state mismatch — possible CSRF. Aborting.",
+            provider="openai-codex",
+            code="authcode_state_mismatch",
+        )
+
+    # Exchange the authorization code for tokens at the same token endpoint the
+    # device-code flow uses. PKCE verifier binds the code to this request.
+    try:
+        with httpx.Client(timeout=httpx.Timeout(15.0)) as client:
+            token_resp = client.post(
+                CODEX_OAUTH_TOKEN_URL,
+                data={
+                    "grant_type": "authorization_code",
+                    "code": authorization_code,
+                    "redirect_uri": redirect_uri,
+                    "client_id": client_id,
+                    "code_verifier": code_verifier,
+                },
+                headers={
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "User-Agent": CODEX_OAUTH_USER_AGENT,
+                },
+            )
+    except Exception as exc:
+        raise AuthError(
+            f"Token exchange failed: {exc}",
+            provider="openai-codex",
+            code="token_exchange_failed",
+        )
+
+    if token_resp.status_code == 429:
+        retry_after = _parse_retry_after_seconds(getattr(token_resp, "headers", None))
+        wait_hint = (
+            f" Try again in about {retry_after}s."
+            if retry_after is not None
+            else " Wait a minute and run the login again."
+        )
+        raise AuthError(
+            "OpenAI is rate-limiting Codex login requests (HTTP 429) during "
+            "token exchange. This is a temporary throttle on OpenAI's side, "
+            f"not a credential problem.{wait_hint}",
+            provider="openai-codex",
+            code=CODEX_RATE_LIMITED_CODE,
+        )
+
+    if token_resp.status_code != 200:
+        raise AuthError(
+            f"Token exchange returned status {token_resp.status_code}.",
+            provider="openai-codex",
+            code="token_exchange_error",
+        )
+
+    tokens = token_resp.json()
+    access_token = tokens.get("access_token", "")
+    refresh_token = tokens.get("refresh_token", "")
+
+    if not access_token:
+        raise AuthError(
+            "Token exchange did not return an access_token.",
+            provider="openai-codex",
+            code="token_exchange_no_access_token",
+        )
+
+    base_url = (
+        os.getenv("HERMES_CODEX_BASE_URL", "").strip().rstrip("/")
+        or DEFAULT_CODEX_BASE_URL
+    )
+
+    return {
+        "tokens": {
+            "access_token": access_token,
+            "refresh_token": refresh_token,
+        },
+        "base_url": base_url,
+        "last_refresh": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "auth_mode": "chatgpt",
+        "source": "authcode",
     }
 
 

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -395,7 +395,29 @@ def auth_add_command(args) -> None:
         return
 
     if provider == "openai-codex":
-        creds = auth_mod._codex_device_code_login()
+        # Default is the browser authorization-code + PKCE flow; fall back to the
+        # device-code flow on ``--device-code`` or when no graphical browser is
+        # available. Both flows return the same credential dict shape.
+        force_device_code = bool(getattr(args, "device_code", False))
+        open_browser = not getattr(args, "no_browser", False)
+        use_authcode = (
+            not force_device_code
+            and open_browser
+            and not auth_mod._is_remote_session()
+            and auth_mod._can_open_graphical_browser()
+        )
+        if use_authcode:
+            creds = auth_mod._codex_authcode_login(
+                open_browser=True,
+                timeout_seconds=getattr(args, "timeout", None),
+                scope_override=getattr(args, "scope", None),
+            )
+            source = SOURCE_MANUAL_DEVICE_CODE  # OAuth pool source; refresh path is identical
+        else:
+            if force_device_code:
+                print("Using the device-code OAuth flow (--device-code).")
+            creds = auth_mod._codex_device_code_login()
+            source = SOURCE_MANUAL_DEVICE_CODE
         label = (getattr(args, "label", None) or "").strip() or label_from_token(
             creds["tokens"]["access_token"],
             _oauth_default_label(provider, len(pool.entries()) + 1),
@@ -416,7 +438,7 @@ def auth_add_command(args) -> None:
             label=label,
             auth_type=AUTH_TYPE_OAUTH,
             priority=0,
-            source=SOURCE_MANUAL_DEVICE_CODE,
+            source=source,
             access_token=creds["tokens"]["access_token"],
             refresh_token=creds["tokens"].get("refresh_token"),
             base_url=creds.get("base_url"),

--- a/hermes_cli/subcommands/auth.py
+++ b/hermes_cli/subcommands/auth.py
@@ -41,6 +41,13 @@ def build_auth_parser(subparsers, *, cmd_auth: Callable) -> None:
         help="Do not auto-open a browser for OAuth login",
     )
     auth_add.add_argument(
+        "--device-code",
+        dest="device_code",
+        action="store_true",
+        help="Force the legacy device-code OAuth flow (openai-codex default is "
+        "the browser authorization-code flow)",
+    )
+    auth_add.add_argument(
         "--timeout", type=float, help="OAuth/network timeout in seconds"
     )
     auth_add.add_argument(

--- a/tests/hermes_cli/test_auth_codex_authcode.py
+++ b/tests/hermes_cli/test_auth_codex_authcode.py
@@ -1,0 +1,368 @@
+"""Tests for the OpenAI Codex browser Authorization Code + PKCE OAuth flow.
+
+Covers PKCE helpers, authorize-URL building, the loopback callback server,
+token-exchange request shape, and error handling. Live OpenAI login is not
+required here — the handshake with auth.openai.com is attested separately.
+"""
+
+from __future__ import annotations
+
+from io import BytesIO
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_cli import auth as auth_mod
+from hermes_cli.auth import (
+    AuthError,
+    CODEX_OAUTH_AUTHORIZE_URL,
+    CODEX_OAUTH_CLIENT_ID,
+    CODEX_OAUTH_SCOPE,
+    CODEX_OAUTH_TOKEN_URL,
+    _codex_authcode_build_authorize_url,
+    _codex_authcode_free_port,
+    _codex_authcode_make_callback_handler,
+    _codex_authcode_wait_for_callback,
+    _oauth_pkce_code_challenge,
+    _oauth_pkce_code_verifier,
+)
+
+
+# --------------------------------------------------------------------------------------
+# PKCE primitives
+# --------------------------------------------------------------------------------------
+
+
+def test_pkce_verifier_is_urlsafe_and_bounded():
+    v = _oauth_pkce_code_verifier()
+    assert isinstance(v, str) and v
+    assert "+" not in v and "/" not in v and "=" not in v
+    assert len(v) <= 128
+
+
+def test_pkce_challenge_is_s256_of_verifier():
+    import base64
+    import hashlib
+
+    v = _oauth_pkce_code_verifier()
+    c = _oauth_pkce_code_challenge(v)
+    expected = base64.urlsafe_b64encode(hashlib.sha256(v.encode()).digest()).decode().rstrip("=")
+    assert c == expected
+
+
+# --------------------------------------------------------------------------------------
+# Authorize URL
+# --------------------------------------------------------------------------------------
+
+
+def test_build_authorize_url_contains_required_oauth_params():
+    url = _codex_authcode_build_authorize_url(
+        client_id="cid-123",
+        redirect_uri="http://127.0.0.1:8765/callback",
+        scope="openai.chatgpt.experimental",
+        state="state-xyz",
+        code_challenge="challenge-abc",
+    )
+    assert url.startswith(CODEX_OAUTH_AUTHORIZE_URL + "?")
+    for key in (
+        "client_id=cid-123",
+        "response_type=code",
+        "redirect_uri=http%3A%2F%2F127.0.0.1%3A8765%2Fcallback",
+        "scope=openai.chatgpt.experimental",
+        "state=state-xyz",
+        "code_challenge_method=S256",
+        "code_challenge=challenge-abc",
+    ):
+        assert key in url, f"missing {key!r} in {url}"
+
+
+def test_build_authorize_url_uses_loopback_redirect():
+    url = _codex_authcode_build_authorize_url(
+        client_id=CODEX_OAUTH_CLIENT_ID,
+        redirect_uri="http://127.0.0.1:9999/callback",
+        scope=CODEX_OAUTH_SCOPE,
+        state="s",
+        code_challenge="c",
+    )
+    assert "redirect_uri=http%3A%2F%2F127.0.0.1%3A9999%2Fcallback" in url
+
+
+# --------------------------------------------------------------------------------------
+# Free loopback port
+# --------------------------------------------------------------------------------------
+
+
+def test_free_port_is_in_range_or_os_chosen():
+    port = _codex_authcode_free_port()
+    assert isinstance(port, int) and 1024 < port < 65536
+
+
+# --------------------------------------------------------------------------------------
+# Callback handler
+# --------------------------------------------------------------------------------------
+
+
+def _drive_callback(path: str) -> dict:
+    handler_cls, result = _codex_authcode_make_callback_handler("/callback")
+    handler = handler_cls.__new__(handler_cls)
+    handler.path = path
+    handler.wfile = BytesIO()
+    handler.send_response = lambda *a, **k: None
+    handler.send_header = lambda *a, **k: None
+    handler.end_headers = lambda *a, **k: None
+    handler.do_GET()
+    return result
+
+
+def test_callback_handler_captures_code_and_state():
+    result = _drive_callback("/callback?code=AC123&state=st")
+    assert result["code"] == "AC123"
+    assert result["state"] == "st"
+    assert result.get("error") is None
+
+
+def test_callback_handler_captures_error():
+    result = _drive_callback("/callback?error=access_denied&error_description=user%20cancelled")
+    assert result["error"] == "access_denied"
+    assert result["error_description"] == "user cancelled"
+
+
+def test_callback_handler_404_on_wrong_path():
+    result = _drive_callback("/other?code=AC123&state=st")
+    assert result["code"] is None
+    assert result["state"] is None
+
+
+# --------------------------------------------------------------------------------------
+# Wait-for-callback: success and timeout against a real in-process callback
+# --------------------------------------------------------------------------------------
+
+
+def test_wait_for_callback_receives_code():
+    import threading
+    import time
+    import urllib.request
+
+    port = _codex_authcode_free_port()
+    path = "/callback"
+    state = "mystate"
+
+    def _hit_callback():
+        time.sleep(0.4)
+        url = f"http://127.0.0.1:{port}{path}?code=THE_CODE&state={state}"
+        try:
+            urllib.request.urlopen(url, timeout=2)
+        except Exception:
+            pass
+
+    t = threading.Thread(target=_hit_callback, daemon=True)
+    t.start()
+
+    result = _codex_authcode_wait_for_callback(
+        host="127.0.0.1",
+        port=port,
+        path=path,
+        timeout_seconds=5.0,
+    )
+    assert result["code"] == "THE_CODE"
+    assert result["state"] == state
+    assert result.get("error") is None
+
+
+def test_wait_for_callback_times_out():
+    with pytest.raises(AuthError) as exc:
+        _codex_authcode_wait_for_callback(
+            host="127.0.0.1",
+            port=_codex_authcode_free_port(),
+            path="/callback",
+            timeout_seconds=1.0,
+        )
+    assert exc.value.code == "authcode_timeout"
+
+
+# --------------------------------------------------------------------------------------
+# Token exchange shape
+# --------------------------------------------------------------------------------------
+
+
+def test_codex_authcode_login_exchanges_code_with_pkce_verifier(monkeypatch):
+    captured = {}
+    fixed = "fixed-state"
+
+    class _FakeResp:
+        status_code = 200
+
+        def json(self):
+            return {"access_token": "AT", "refresh_token": "RT"}
+
+    class _FakeClient:
+        def __init__(self, *a, **kw):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def post(self, url, data=None, headers=None):
+            captured["url"] = url
+            captured["data"] = data
+            captured["headers"] = headers
+            return _FakeResp()
+
+    monkeypatch.setattr(auth_mod.uuid, "uuid4", lambda: SimpleNamespace(hex=fixed))
+    monkeypatch.setattr(
+        auth_mod,
+        "_codex_authcode_wait_for_callback",
+        lambda **kw: {"code": "AC", "state": fixed, "error": None, "error_description": None},
+    )
+    monkeypatch.setattr(auth_mod, "_codex_authcode_free_port", lambda: 8765)
+    monkeypatch.setattr(auth_mod.webbrowser, "open", lambda *a, **k: True)
+    monkeypatch.setattr(auth_mod, "_is_remote_session", lambda: False)
+    monkeypatch.setattr(auth_mod, "_can_open_graphical_browser", lambda: True)
+    monkeypatch.setattr(auth_mod, "_print_loopback_ssh_hint", lambda *a, **k: None)
+    monkeypatch.setattr(auth_mod.httpx, "Client", _FakeClient)
+
+    creds = auth_mod._codex_authcode_login(open_browser=True)
+    assert creds["tokens"]["access_token"] == "AT"
+    assert creds["tokens"]["refresh_token"] == "RT"
+    assert creds["source"] == "authcode"
+    assert creds["auth_mode"] == "chatgpt"
+    assert captured["url"] == CODEX_OAUTH_TOKEN_URL
+    assert captured["data"]["grant_type"] == "authorization_code"
+    assert captured["data"]["code"] == "AC"
+    assert captured["data"]["client_id"] == CODEX_OAUTH_CLIENT_ID
+    assert "code_verifier" in captured["data"]
+    assert captured["data"]["redirect_uri"].startswith("http://127.0.0.1:")
+    assert captured["data"]["redirect_uri"].endswith("/callback")
+
+
+def test_codex_authcode_login_raises_on_access_denied(monkeypatch):
+    monkeypatch.setattr(
+        auth_mod,
+        "_codex_authcode_wait_for_callback",
+        lambda **kw: {
+            "error": "access_denied",
+            "error_description": "user cancelled",
+            "code": None,
+            "state": None,
+        },
+    )
+    monkeypatch.setattr(auth_mod, "_codex_authcode_free_port", lambda: 8765)
+    monkeypatch.setattr(auth_mod.webbrowser, "open", lambda *a, **k: True)
+    monkeypatch.setattr(auth_mod, "_is_remote_session", lambda: False)
+    monkeypatch.setattr(auth_mod, "_can_open_graphical_browser", lambda: True)
+    monkeypatch.setattr(auth_mod, "_print_loopback_ssh_hint", lambda *a, **k: None)
+    with pytest.raises(AuthError) as exc:
+        auth_mod._codex_authcode_login(open_browser=True)
+    assert exc.value.code == "authcode_access_denied"
+
+
+def test_codex_authcode_login_raises_on_state_mismatch(monkeypatch):
+    fixed = "fixed-state"
+
+    monkeypatch.setattr(auth_mod.uuid, "uuid4", lambda: SimpleNamespace(hex=fixed))
+    monkeypatch.setattr(
+        auth_mod,
+        "_codex_authcode_wait_for_callback",
+        lambda **kw: {"code": "AC", "state": "WRONG", "error": None, "error_description": None},
+    )
+    monkeypatch.setattr(auth_mod, "_codex_authcode_free_port", lambda: 8765)
+    monkeypatch.setattr(auth_mod.webbrowser, "open", lambda *a, **k: True)
+    monkeypatch.setattr(auth_mod, "_is_remote_session", lambda: False)
+    monkeypatch.setattr(auth_mod, "_can_open_graphical_browser", lambda: True)
+    monkeypatch.setattr(auth_mod, "_print_loopback_ssh_hint", lambda *a, **k: None)
+    with pytest.raises(AuthError) as exc:
+        auth_mod._codex_authcode_login(open_browser=True)
+    assert exc.value.code == "authcode_state_mismatch"
+
+
+def test_codex_authcode_login_raises_on_no_code(monkeypatch):
+    monkeypatch.setattr(
+        auth_mod,
+        "_codex_authcode_wait_for_callback",
+        lambda **kw: {"code": None, "state": None, "error": None, "error_description": None},
+    )
+    monkeypatch.setattr(auth_mod, "_codex_authcode_free_port", lambda: 8765)
+    monkeypatch.setattr(auth_mod.webbrowser, "open", lambda *a, **k: True)
+    monkeypatch.setattr(auth_mod, "_is_remote_session", lambda: False)
+    monkeypatch.setattr(auth_mod, "_can_open_graphical_browser", lambda: True)
+    monkeypatch.setattr(auth_mod, "_print_loopback_ssh_hint", lambda *a, **k: None)
+    with pytest.raises(AuthError) as exc:
+        auth_mod._codex_authcode_login(open_browser=True)
+    assert exc.value.code == "authcode_no_code"
+
+
+def test_codex_authcode_login_raises_on_token_exchange_error(monkeypatch):
+    fixed = "fixed-state"
+
+    monkeypatch.setattr(auth_mod.uuid, "uuid4", lambda: SimpleNamespace(hex=fixed))
+    monkeypatch.setattr(
+        auth_mod,
+        "_codex_authcode_wait_for_callback",
+        lambda **kw: {"code": "AC", "state": fixed, "error": None, "error_description": None},
+    )
+    monkeypatch.setattr(auth_mod, "_codex_authcode_free_port", lambda: 8765)
+    monkeypatch.setattr(auth_mod.webbrowser, "open", lambda *a, **k: True)
+    monkeypatch.setattr(auth_mod, "_is_remote_session", lambda: False)
+    monkeypatch.setattr(auth_mod, "_can_open_graphical_browser", lambda: True)
+    monkeypatch.setattr(auth_mod, "_print_loopback_ssh_hint", lambda *a, **k: None)
+
+    class _FakeResp:
+        status_code = 500
+
+        def json(self):
+            return {}
+
+    class _FakeClient:
+        def __init__(self, *a, **kw):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def post(self, url, data=None, headers=None):
+            return _FakeResp()
+
+    monkeypatch.setattr(auth_mod.httpx, "Client", _FakeClient)
+    with pytest.raises(AuthError) as exc:
+        auth_mod._codex_authcode_login(open_browser=True)
+    assert exc.value.code == "token_exchange_error"
+
+
+def test_login_openai_codex_uses_authcode_when_browser_available(monkeypatch):
+    """``_login_openai_codex`` must read ``args`` (not delete it) and default
+    to the authorization-code flow when a graphical browser is available."""
+    called = {"authcode": 0, "device": 0}
+
+    monkeypatch.setattr(auth_mod, "resolve_codex_runtime_credentials", lambda: (_ for _ in ()).throw(AuthError("none")))
+    monkeypatch.setattr(auth_mod, "_import_codex_cli_tokens", lambda: None)
+    monkeypatch.setattr(auth_mod, "_can_open_graphical_browser", lambda: True)
+    monkeypatch.setattr(auth_mod, "_is_remote_session", lambda: False)
+    monkeypatch.setattr(
+        auth_mod,
+        "_codex_authcode_login",
+        lambda **kw: (
+            called.__setitem__("authcode", called["authcode"] + 1)
+            or {
+                "tokens": {"access_token": "AT", "refresh_token": "RT"},
+                "base_url": "https://chatgpt.com/backend-api/codex",
+                "last_refresh": "2026-08-28T00:00:00Z",
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        auth_mod,
+        "_codex_device_code_login",
+        lambda: called.__setitem__("device", called["device"] + 1) or (_ for _ in ()).throw(AssertionError("device")),
+    )
+    monkeypatch.setattr(auth_mod, "_save_codex_tokens", lambda *a, **k: None)
+    monkeypatch.setattr(auth_mod, "_update_config_for_provider", lambda *a, **k: "/tmp/config.yaml")
+
+    args = SimpleNamespace(device_code=False, no_browser=False, timeout=None, scope=None)
+    auth_mod._login_openai_codex(args, auth_mod.PROVIDER_REGISTRY["openai-codex"], force_new_login=True)
+    assert called == {"authcode": 1, "device": 0}

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -533,6 +533,10 @@ def test_auth_add_codex_oauth_keeps_distinct_pool_accounts(tmp_path, monkeypatch
         ]
     )
     monkeypatch.setattr("hermes_cli.auth._codex_device_code_login", lambda: next(logins))
+    # Keep this regression on the device-code path so it stays independent of
+    # whether a graphical browser is available on the test host.
+    monkeypatch.setattr("hermes_cli.auth._can_open_graphical_browser", lambda: False)
+    monkeypatch.setattr("hermes_cli.auth._is_remote_session", lambda: False)
 
     from hermes_cli.auth_commands import auth_add_command
     from agent.credential_pool import load_pool
@@ -542,6 +546,10 @@ def test_auth_add_codex_oauth_keeps_distinct_pool_accounts(tmp_path, monkeypatch
         auth_type = "oauth"
         api_key = None
         label = None
+        device_code = False
+        no_browser = False
+        timeout = None
+        scope = None
 
     auth_add_command(_Args())
     auth_add_command(_Args())
@@ -568,6 +576,92 @@ def test_auth_add_codex_oauth_keeps_distinct_pool_accounts(tmp_path, monkeypatch
     assert "openai-codex" not in payload.get("providers", {})
     # First add activated the provider; second add left it as-is.
     assert payload["active_provider"] == "openai-codex"
+
+
+def test_auth_add_codex_defaults_to_authcode_when_browser_available(tmp_path, monkeypatch):
+    """``hermes auth add openai-codex`` uses the browser auth-code flow when a
+    graphical browser is available, unless ``--device-code`` is set."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, {"version": 1, "providers": {}})
+    token = _jwt_with_email("authcode@example.com")
+    called = {"authcode": 0, "device": 0}
+
+    def _authcode(**kwargs):
+        called["authcode"] += 1
+        return {
+            "tokens": {"access_token": token, "refresh_token": "rt"},
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "last_refresh": "2026-03-23T10:00:00Z",
+            "source": "authcode",
+        }
+
+    def _device():
+        called["device"] += 1
+        raise AssertionError("device-code flow should not run when a browser is available")
+
+    monkeypatch.setattr("hermes_cli.auth._codex_authcode_login", _authcode)
+    monkeypatch.setattr("hermes_cli.auth._codex_device_code_login", _device)
+    monkeypatch.setattr("hermes_cli.auth._can_open_graphical_browser", lambda: True)
+    monkeypatch.setattr("hermes_cli.auth._is_remote_session", lambda: False)
+
+    from hermes_cli.auth_commands import auth_add_command
+    from agent.credential_pool import load_pool
+
+    class _Args:
+        provider = "openai-codex"
+        auth_type = "oauth"
+        api_key = None
+        label = None
+        device_code = False
+        no_browser = False
+        timeout = None
+        scope = None
+
+    auth_add_command(_Args())
+    assert called == {"authcode": 1, "device": 0}
+    entries = load_pool("openai-codex").entries()
+    assert len(entries) == 1
+    assert entries[0].access_token == token
+    assert entries[0].source == "manual:device_code"
+
+
+def test_auth_add_codex_device_code_flag_forces_legacy_flow(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, {"version": 1, "providers": {}})
+    token = _jwt_with_email("device@example.com")
+    called = {"authcode": 0, "device": 0}
+
+    def _authcode(**kwargs):
+        called["authcode"] += 1
+        raise AssertionError("--device-code must not start the auth-code flow")
+
+    def _device():
+        called["device"] += 1
+        return {
+            "tokens": {"access_token": token, "refresh_token": "rt"},
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "last_refresh": "2026-03-23T10:00:00Z",
+        }
+
+    monkeypatch.setattr("hermes_cli.auth._codex_authcode_login", _authcode)
+    monkeypatch.setattr("hermes_cli.auth._codex_device_code_login", _device)
+    monkeypatch.setattr("hermes_cli.auth._can_open_graphical_browser", lambda: True)
+    monkeypatch.setattr("hermes_cli.auth._is_remote_session", lambda: False)
+
+    from hermes_cli.auth_commands import auth_add_command
+
+    class _Args:
+        provider = "openai-codex"
+        auth_type = "oauth"
+        api_key = None
+        label = None
+        device_code = True
+        no_browser = False
+        timeout = None
+        scope = None
+
+    auth_add_command(_Args())
+    assert called == {"authcode": 0, "device": 1}
 
 
 def test_codex_auth_status_reports_pool_only_credential(tmp_path, monkeypatch):


### PR DESCRIPTION
## What does this PR do?

`hermes auth add openai-codex` and the Codex setup login currently use OpenAI's device-code flow. Organizations that disable device-code OAuth cannot sign in.

This adds a browser Authorization Code + PKCE flow as the default when a graphical browser is available: Hermes opens `https://auth.openai.com/oauth/authorize`, receives the code on a loopback callback (`http://127.0.0.1:<port>/callback`), and exchanges it at the existing Codex token endpoint. Tokens are stored in the same `auth.json` / credential-pool paths as today, so refresh and model selection are unchanged.

Device-code remains available via `--device-code`, and as an automatic fallback over SSH or when no graphical browser is available.

## Related Issue

Fixes #95743

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/auth.py` — `_codex_authcode_login` (PKCE, loopback callback, token exchange); `_login_openai_codex` defaults to it
- `hermes_cli/auth_commands.py` — `hermes auth add openai-codex` uses the same default and fallback
- `hermes_cli/subcommands/auth.py` — `--device-code` on `hermes auth add`
- `tests/hermes_cli/test_auth_codex_authcode.py` — PKCE, authorize URL, callback server, token-exchange body, cancel/mismatch/error codes
- `tests/hermes_cli/test_auth_commands.py` — default auth-code dispatch vs `--device-code`

## How to Test

1. On a machine with a graphical browser: `hermes auth add openai-codex` — browser opens the OpenAI authorize page; after login, tokens appear in `auth.json` / `hermes auth list`.
2. `hermes auth add openai-codex --device-code` still runs the legacy user-code flow.
3. `scripts/run_tests.sh tests/hermes_cli/test_auth_codex_authcode.py tests/hermes_cli/test_auth_commands.py`

```
=== Summary: 2 files, 45 tests passed, 0 failed (100% complete) in 41.6s (16 workers) ===
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (darwin 25)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
▶ launching test runner
Discovered 2 test files (~45 tests) under ['tests/hermes_cli/test_auth_codex_authcode.py', 'tests/hermes_cli/test_auth_commands.py']; running with -j 16
[ 35.6% |    16/~45 | ✓16 | ✗ 0] ✓ tests/hermes_cli/test_auth_codex_authcode.py (16✓, 26.5s)
[100.0% |    45/~45 | ✓45 | ✗ 0] ✓ tests/hermes_cli/test_auth_commands.py (29✓, 41.6s)

=== Summary: 2 files, 45 tests passed, 0 failed (100% complete) in 41.6s (16 workers) ===
```
