### PR TITLE
fix(skills-guard): benign skills no longer blocked by five false-positive scanner patterns (#60709, salvage #60750)

### DIFF
--- a/tests/tools/test_skills_guard.py
+++ b/tests/tools/test_skills_guard.py
@@ -415,6 +415,52 @@ class TestFalsePositiveReductions:
         assert sec
         assert all(fi.severity == "medium" for fi in sec)
 
+    # ── python_os_environ: inline-comment / docstring false positives ──
+
+    def test_os_environ_in_inline_comment_not_flagged(self, tmp_path):
+        """Inline comment like 'x = 1  # os.environ must not trigger."""
+        f = tmp_path / "lib.py"
+        f.write_text('cfg = environ.get("HOME")  # os.environ available globally\n')
+        findings = scan_file(f, "lib.py")
+        assert not any(fi.pattern_id == "python_os_environ" for fi in findings)
+
+    def test_os_environ_in_docstring_not_flagged(self, tmp_path):
+        """os.environ inside a docstring/multiline comment must not trigger."""
+        f = tmp_path / "lib.py"
+        f.write_text(
+            '"""\n'
+            'This module uses os.environ to read configuration. The\n'
+            'os.environ dictionary is populated from the shell at startup.\n'
+            '"""\n'
+        )
+        findings = scan_file(f, "lib.py")
+        assert not any(fi.pattern_id == "python_os_environ" for fi in findings)
+
+    def test_os_environ_in_triple_single_quote_docstring_not_flagged(self, tmp_path):
+        """os.environ inside ''' tripled-quoted string must not trigger."""
+        f = tmp_path / "lib.py"
+        f.write_text(
+            "'''\n"
+            "Example: os.environ['PATH'] gives the system path.\n"
+            "'''\n"
+        )
+        findings = scan_file(f, "lib.py")
+        assert not any(fi.pattern_id == "python_os_environ" for fi in findings)
+
+    def test_os_environ_comment_line_not_flagged(self, tmp_path):
+        """Full-line comment with os.environ must not trigger."""
+        f = tmp_path / "lib.py"
+        f.write_text("# os.environ is available after import os\n")
+        findings = scan_file(f, "lib.py")
+        assert not any(fi.pattern_id == "python_os_environ" for fi in findings)
+
+    def test_os_environ_bare_dict_fork_for_real_code_still_flagged(self, tmp_path):
+        """Bare dict() cast on os.environ without .get() still triggers."""
+        f = tmp_path / "lib.py"
+        f.write_text("env_copy = dict(os.environ)\n")
+        findings = scan_file(f, "lib.py")
+        assert any(fi.pattern_id == "python_os_environ" for fi in findings)
+
 
 # ---------------------------------------------------------------------------
 # .skillignore / .clawhubignore support

--- a/tests/tools/test_skills_guard.py
+++ b/tests/tools/test_skills_guard.py
@@ -408,10 +408,12 @@ class TestFalsePositiveReductions:
         assert 1 not in env_lines
         # Bare os.environ access is still flagged.
         assert 3 in env_lines
-        # Secret-named lookups stay critical.
+        # Secret-named lookups are medium (informational): reading your own
+        # API key from the environment is the normal auth pattern — the read
+        # itself sends nothing (#60709). Exfil sinks are scored separately.
         sec = [fi for fi in findings if fi.pattern_id == "python_environ_get_secret"]
         assert sec
-        assert all(fi.severity == "critical" for fi in sec)
+        assert all(fi.severity == "medium" for fi in sec)
 
 
 # ---------------------------------------------------------------------------

--- a/tools/skills_guard.py
+++ b/tools/skills_guard.py
@@ -238,10 +238,11 @@ THREAT_PATTERNS = [
     # `os.environ` bare access (dict dump / iteration) is suspicious, but the
     # common `os.environ.get("SOME_CONFIG")` form is just a config read and is
     # the OPPOSITE of exfiltration (it reads a local var, sends nothing). The
-    # ^(?!\s*#) prevents matching inside comment lines (lines starting
-    # with '#' outside docstrings). os.environ in prose/docstrings is not
-    # an exfiltration signal.
-    (r'^(?!\s*#).*os\.environ\b(?!\s*\.get\s*\(\s*["\'](?![^"\']*(?:KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL)))',
+    # ^[^#\n]* prevents matching when a '#' comment appears anywhere before
+    # os.environ on the line — handles both full-line comments and inline
+    # comments like `x = 1  # os.environ`. The docstring pre-filter in
+    # scan_file() skips lines inside triple-quoted strings entirely.
+    (r'^[^#\n]*os\.environ\b(?!\s*\.get\s*\(\s*["\'](?![^"\']*(?:KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL)))',
      "python_os_environ", "high", "exfiltration",
      "accesses os.environ outside comments/docstrings (potential env dump)"),
     (r'os\.environ\s*\.get\s*\(\s*["\'][^"\']*(?:KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL)',
@@ -695,9 +696,46 @@ INVISIBLE_CHARS = {
 }
 
 
+def _compute_docstring_lines(lines: list) -> set:
+    """Return a set of 1-indexed line numbers inside triple-quoted strings.
+
+    Uses a simple state machine: toggles ``in_docstring`` each time a line
+    contains an odd number of ``\"\"\"`` or triple-single-quote markers.  Lines
+    that are *themselves* part of a docstring (opening line, interior lines,
+    and closing line) are all included in the returned set.
+
+    Single-line docstrings (e.g. ``x = \"\"\" ... \"\"\"``) where both the
+    opening and closing markers appear on the same line are also flagged,
+    since ``os.environ`` in such a context is not real exfiltration.
+
+    This is a heuristic -- it does not handle
+    ``'\\\"\"\"'  # triple quote inside a string literal``
+    or similar edge cases -- but it catches the common skill-content patterns
+    (docstrings, multiline comments containing prose samples) that trigger
+    false-positive ``python_os_environ`` matches.
+    """
+    doc_lines: set = set()
+    in_docstring = False
+    for i, line in enumerate(lines):
+        was_in = in_docstring
+        has_marker = False
+        for marker in ('"""', "'''"):
+            count = line.count(marker)
+            if count > 0:
+                has_marker = True
+            if count % 2 == 1:
+                in_docstring = not in_docstring
+        # Include line if we were already in a docstring, just entered one,
+        # or this is a self-contained single-line docstring (e.g. """foo""")
+        if was_in or in_docstring or (has_marker and not was_in and not in_docstring):
+            doc_lines.add(i + 1)
+    return doc_lines
+
+
 # ---------------------------------------------------------------------------
 # Scanning functions
 # ---------------------------------------------------------------------------
+
 
 def scan_file(file_path: Path, rel_path: str = "") -> List[Finding]:
     """
@@ -725,10 +763,16 @@ def scan_file(file_path: Path, rel_path: str = "") -> List[Finding]:
     lines = content.split('\n')
     seen = set()  # (pattern_id, line_number) for deduplication
 
+    # Pre-compute line numbers inside triple-quoted strings (docstrings)
+    # so code patterns like python_os_environ don't fire on prose.
+    docstring_lines = _compute_docstring_lines(lines)
+
     # Regex pattern matching
     for pattern, pid, severity, category, description in _COMPILED_THREAT_PATTERNS:
         for i, line in enumerate(lines, start=1):
             if (pid, i) in seen:
+                continue
+            if i in docstring_lines:
                 continue
             if pattern.search(line):
                 seen.add((pid, i))

--- a/tools/skills_guard.py
+++ b/tools/skills_guard.py
@@ -242,15 +242,19 @@ THREAT_PATTERNS = [
     # os.environ on the line — handles both full-line comments and inline
     # comments like `x = 1  # os.environ`. The docstring pre-filter in
     # scan_file() skips lines inside triple-quoted strings entirely.
-    (r'^[^#\n]*os\.environ\b(?!\s*\.get\s*\(\s*["\'](?![^"\']*(?:KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL)))',
+    # ANY `.get("<name>")` form is exempt here — non-secret names are plain
+    # config reads, and secret-shaped names are scored (medium) by the
+    # dedicated python_environ_get_secret pattern below; without the blanket
+    # exemption the high severity here would swamp that intended medium.
+    (r'^[^#\n]*os\.environ\b(?!\s*\.get\s*\()',
      "python_os_environ", "high", "exfiltration",
      "accesses os.environ outside comments/docstrings (potential env dump)"),
     (r'os\.environ\s*\.get\s*\(\s*["\'][^"\']*(?:KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL)',
      "python_environ_get_secret", "medium", "exfiltration",
      "reads secret via os.environ.get() (normal API-key access; informational)"),
     (r'os\.getenv\s*\(\s*[^\)]*(?:KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL)',
-     "python_getenv_secret", "critical", "exfiltration",
-     "reads secret via os.getenv()"),
+     "python_getenv_secret", "medium", "exfiltration",
+     "reads secret via os.getenv() (normal API-key access; informational)"),
     (r'process\.env\[',
      "node_process_env", "high", "exfiltration",
      "accesses process.env (Node.js environment)"),

--- a/tools/skills_guard.py
+++ b/tools/skills_guard.py
@@ -238,22 +238,24 @@ THREAT_PATTERNS = [
     # `os.environ` bare access (dict dump / iteration) is suspicious, but the
     # common `os.environ.get("SOME_CONFIG")` form is just a config read and is
     # the OPPOSITE of exfiltration (it reads a local var, sends nothing). The
-    # lookahead exempts `os.environ.get("<name>")` only when <name> is NOT a
-    # secret-shaped identifier — `os.environ.get("OPENAI_API_KEY")` still trips
-    # via the dedicated secret pattern just below.
-    (r'os\.environ\b(?!\s*\.get\s*\(\s*["\'](?![^"\']*(?:KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL)))',
+    # ^(?!\s*#) prevents matching inside comment lines (lines starting
+    # with '#' outside docstrings). os.environ in prose/docstrings is not
+    # an exfiltration signal.
+    (r'^(?!\s*#).*os\.environ\b(?!\s*\.get\s*\(\s*["\'](?![^"\']*(?:KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL)))',
      "python_os_environ", "high", "exfiltration",
-     "accesses os.environ (potential env dump)"),
+     "accesses os.environ outside comments/docstrings (potential env dump)"),
     (r'os\.environ\s*\.get\s*\(\s*["\'][^"\']*(?:KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL)',
-     "python_environ_get_secret", "critical", "exfiltration",
-     "reads secret via os.environ.get()"),
+     "python_environ_get_secret", "medium", "exfiltration",
+     "reads secret via os.environ.get() (normal API-key access; informational)"),
     (r'os\.getenv\s*\(\s*[^\)]*(?:KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL)',
      "python_getenv_secret", "critical", "exfiltration",
      "reads secret via os.getenv()"),
     (r'process\.env\[',
      "node_process_env", "high", "exfiltration",
      "accesses process.env (Node.js environment)"),
-    (r'ENV\[.*(?:KEY|TOKEN|SECRET|PASSWORD)',
+    # Case-sensitive ENV (Ruby constant) — the (?-i:) prevents matching
+    # Python lowercase `env[...]` dict accesses under IGNORECASE.
+    (r'(?-i:ENV)\[.*(?:KEY|TOKEN|SECRET|PASSWORD)',
      "ruby_env_secret", "critical", "exfiltration",
      "reads secret via Ruby ENV[]"),
 
@@ -281,8 +283,12 @@ THREAT_PATTERNS = [
     (r'you\s+are\s+(?:\w+\s+)*now\s+',
      "role_hijack", "high", "injection",
      "attempts to override the agent's role"),
-    (r'do\s+not\s+(?:\w+\s+)*tell\s+(?:\w+\s+)*the\s+user',
-     "deception_hide", "critical", "injection",
+    # Only flag when the instruction is about concealing information, not
+    # ordinary UX guidance ("don't tell the user X unless Y confirms").
+    # The negative lookahead excludes patterns common in UX instructions
+    # like "unless", "except", "until", "confirm", "diagnose", "verify".
+    (r'do\s+not\s+(?:\w+\s+)*tell\s+(?:\w+\s+)*the\s+user(?!.*\b(?:unless|except|until|confirm|diagnose|verify|check)\b)',
+     "deception_hide", "high", "injection",
      "instructs agent to hide information from user"),
     (r'system\s+(?:\w+\s+)*prompt\s+(?:\w+\s+)*override',
      "sys_prompt_override", "critical", "injection",
@@ -651,7 +657,7 @@ _COMPILED_THREAT_PATTERNS = [
 
 # Structural limits for skill directories
 MAX_FILE_COUNT = 50       # skills shouldn't have 50+ files
-MAX_TOTAL_SIZE_KB = 1024  # 1MB total is suspicious for a skill
+MAX_TOTAL_SIZE_KB = 5120  # 5MB — large skills are informational only, not blocking
 MAX_SINGLE_FILE_KB = 256  # individual file > 256KB is suspicious
 
 # File extensions to scan (text files only — skip binary)
@@ -1117,11 +1123,12 @@ def _check_structure(skill_dir: Path, ignore=None) -> List[Finding]:
             description=f"skill has {file_count} files (limit: {MAX_FILE_COUNT})",
         ))
 
-    # Total size limit
+    # Total size limit — informational only (low severity, non-verdict-gating).
+    # Large skills are legitimate for feature-rich capabilities.
     if total_size > MAX_TOTAL_SIZE_KB * 1024:
         findings.append(Finding(
             pattern_id="oversized_skill",
-            severity="high",
+            severity="low",
             category="structural",
             file="(directory)",
             line=0,


### PR DESCRIPTION
## Summary
Benign community skills no longer get hard-blocked by five scanner false-positive patterns — the skills-guard now language-scopes its Ruby rule, treats reading your own API key as informational, skips comments/docstrings, exempts UX guidance prose, and stops letting skill size alone gate the verdict. Salvages #60750 by @AIalliAI (authorship preserved); closes #60709.

Root cause: several `THREAT_PATTERNS` regexes matched benign shapes — `ENV\[` fired case-insensitively on Python `env[key]` dicts, secret-named env reads were CRITICAL (any skill talking to an authenticated API scanned dangerous), `os.environ` matched inside comments/docstrings, `deception_hide` tripped on "don't tell the user X unless Y confirms", and a 1MB size cap alone forced `caution`.

## Changes
- `tools/skills_guard.py` (base: @AIalliAI's two commits from #60750, rebased onto the compiled-patterns main):
  - `ruby_env_secret`: `(?-i:ENV)` — case-sensitive Ruby constant only.
  - `python_environ_get_secret`: critical → medium; follow-up widens the `python_os_environ` exemption to ALL `.get()` forms so the high-severity dump pattern no longer re-escalates the same line, and applies the same medium grade to the sibling `os.getenv()` secret pattern (same shape, same rationale).
  - `python_os_environ`: skips comment lines and (via a new `_compute_docstring_lines()` pre-filter in `scan_file`) triple-quoted docstrings.
  - `deception_hide`: critical → high, with a lookahead excluding conditional UX guidance (`unless`/`confirm`/`verify`/...).
  - `oversized_skill`: high → low (informational), cap 1MB → 5MB.
- `tests/tools/test_skills_guard.py`: contributor's coverage for all five shapes, merged with the current main test structure.

## Validation
| shape (#60709) | main | this PR |
|---|---|---|
| Python `env[key] = value` | critical ruby_env_secret | clean |
| `os.environ.get("OPENAI_API_KEY")` | critical (+high env dump) | medium only |
| `os.getenv("...KEY")` | critical | medium |
| `os.environ` in docstring/comment | high | clean |
| "do not tell the user ... unless diagnose confirms" | critical injection | clean |
| 2MB benign skill | caution | safe (low informational) |
| Attacks: `dict(os.environ)`, `env \| curl`, Ruby `ENV["API_KEY"]`, real deception prose | flagged | still flagged |

82 targeted tests pass (`test_skills_guard*`, `test_openclaw_migration`) + 17 `test_plugin_guard`; ruff clean. E2E: realistic skill combining all five benign shapes scans `safe` on this branch, `dangerous`-blocked on main.

## Credit
Base implementation and tests by @AIalliAI (#60750) — commits cherry-picked with authorship preserved. Issue analysis by the #60709 reporter.

Closes #60709
Closes #60750

## Infographic

![skills-guard false-positive fixes](https://v3b.fal.media/files/b/0aa823b0/LHGggrjBXrQrZRjHsYFnw_kbSJNihg.png)
