### PR TITLE
fix(agent): quarantine same-workspace delegated mutations until stale child exits

### DIFF
--- a/agent/workspace_mutation_fence.py
+++ b/agent/workspace_mutation_fence.py
@@ -1,0 +1,283 @@
+"""Owner-aware workspace mutation admission for delegated children.
+
+When a delegated child times out or is cancelled but stays live after the
+existing tool-interrupt grace window, later known built-in mutations in the
+same trusted local workspace are denied until every stale owner actually
+finishes. Reads, unknown plugin/MCP tools, and other workspace domains stay
+available. Release is driven by real completion, not elapsed time alone.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterator, Optional, Set
+
+from agent.tool_result_classification import FILE_MUTATING_TOOL_NAMES
+
+logger = logging.getLogger(__name__)
+
+# Mirrors agent.tool_executor's cooperative abandon wait after interrupt.
+DEFAULT_QUARANTINE_GRACE_SECONDS = 3.0
+
+KNOWN_BUILTIN_MUTATING_TOOLS = FILE_MUTATING_TOOL_NAMES
+
+
+@dataclass
+class _Owner:
+    owner_id: str
+    domain: Path
+    mutation_gate_open: bool = True
+    stale: bool = False
+    is_live: Callable[[], bool] = field(default=lambda: False)
+    quarantine_timer: Optional[threading.Timer] = None
+
+
+_lock = threading.Lock()
+_owners: Dict[str, _Owner] = {}
+_quarantined: Dict[Path, Set[str]] = {}
+_grace_seconds = DEFAULT_QUARANTINE_GRACE_SECONDS
+_CURRENT_FENCE_OWNER: ContextVar[Optional[str]] = ContextVar(
+    "hermes_workspace_fence_owner",
+    default=None,
+)
+
+
+@contextmanager
+def owning_delegated_child(owner_id: str) -> Iterator[None]:
+    """Mark the current delegated child as the fence owner for this stack."""
+    token = _CURRENT_FENCE_OWNER.set(str(owner_id) if owner_id else None)
+    try:
+        yield
+    finally:
+        _CURRENT_FENCE_OWNER.reset(token)
+
+
+def reset_for_tests() -> None:
+    """Drop all fence state. Tests only."""
+    with _lock:
+        for owner in _owners.values():
+            timer = owner.quarantine_timer
+            if timer is not None:
+                timer.cancel()
+        _owners.clear()
+        _quarantined.clear()
+
+
+def set_grace_seconds_for_tests(seconds: float) -> None:
+    """Override the post-interrupt grace used before domain quarantine."""
+    global _grace_seconds
+    _grace_seconds = max(0.0, float(seconds))
+
+
+def resolve_workspace_domain(
+    raw: Optional[str] = None,
+    *,
+    child: Any = None,
+) -> Path:
+    """Resolve the trusted local workspace domain for a delegated child."""
+    explicit = getattr(child, "_delegate_workspace_domain", None) if child is not None else None
+    candidate = explicit or raw
+    if not candidate:
+        candidate = os.environ.get("TERMINAL_CWD") or os.getcwd()
+    path = Path(str(candidate)).expanduser()
+    try:
+        return path.resolve()
+    except OSError:
+        return path
+
+
+def bind_owner(
+    owner_id: str,
+    domain: Path,
+    *,
+    is_live: Optional[Callable[[], bool]] = None,
+) -> None:
+    """Register a delegated child as an owner of ``domain``."""
+    if not owner_id:
+        return
+    owner = _Owner(
+        owner_id=str(owner_id),
+        domain=Path(domain),
+        is_live=is_live or (lambda: False),
+    )
+    with _lock:
+        _owners[owner.owner_id] = owner
+
+
+def set_owner_liveness(owner_id: str, is_live: Callable[[], bool]) -> None:
+    with _lock:
+        owner = _owners.get(owner_id)
+        if owner is not None:
+            owner.is_live = is_live
+
+
+def close_mutation_gate(owner_id: str) -> None:
+    """Stop the named child from starting further known mutations."""
+    with _lock:
+        owner = _owners.get(owner_id)
+        if owner is None:
+            return
+        owner.mutation_gate_open = False
+        owner.stale = True
+
+
+def schedule_quarantine_if_still_live(owner_id: str) -> None:
+    """After the existing grace window, quarantine the domain if the child is live."""
+    delay = _grace_seconds
+    if delay <= 0:
+        _quarantine_if_still_live(owner_id)
+        return
+    timer = threading.Timer(delay, _quarantine_if_still_live, args=(owner_id,))
+    timer.daemon = True
+    with _lock:
+        owner = _owners.get(owner_id)
+        if owner is None:
+            return
+        if owner.quarantine_timer is not None:
+            owner.quarantine_timer.cancel()
+        owner.quarantine_timer = timer
+    timer.start()
+
+
+def mark_timeout_or_cancel(owner_id: str) -> None:
+    """Close the child's mutation gate and arm domain quarantine after grace."""
+    close_mutation_gate(owner_id)
+    schedule_quarantine_if_still_live(owner_id)
+
+
+def release_owner(owner_id: str) -> None:
+    """Release on real completion. Lifts quarantine when no stale live owners remain."""
+    if not owner_id:
+        return
+    with _lock:
+        owner = _owners.pop(owner_id, None)
+        if owner is None:
+            return
+        if owner.quarantine_timer is not None:
+            owner.quarantine_timer.cancel()
+        holders = _quarantined.get(owner.domain)
+        if holders is not None:
+            holders.discard(owner_id)
+            if not holders:
+                _quarantined.pop(owner.domain, None)
+
+
+def mutation_target_path(function_name: str, function_args: Optional[dict]) -> Optional[Path]:
+    if function_name not in KNOWN_BUILTIN_MUTATING_TOOLS:
+        return None
+    args = function_args or {}
+    raw = args.get("path") or args.get("file")
+    if not raw:
+        return None
+    path = Path(str(raw)).expanduser()
+    if not path.is_absolute():
+        path = Path.cwd() / path
+    try:
+        return path.resolve()
+    except OSError:
+        return path
+
+
+def path_in_domain(path: Path, domain: Path) -> bool:
+    try:
+        path.relative_to(domain)
+        return True
+    except ValueError:
+        return False
+
+
+def deny_delegated_mutation(
+    function_name: str,
+    function_args: Optional[dict] = None,
+) -> Optional[str]:
+    """Return a deny message when a later delegated mutation is fenced.
+
+    Non-delegated callers, read-only tools, and unknown plugin/MCP tools
+    are never fenced.
+    """
+    if function_name not in KNOWN_BUILTIN_MUTATING_TOOLS:
+        return None
+    try:
+        from agent.delegation_context import is_delegated_child_context
+    except Exception:
+        return None
+    if not is_delegated_child_context():
+        return None
+
+    target = mutation_target_path(function_name, function_args)
+    current_id = _current_owner_id()
+
+    with _lock:
+        owner = _owners.get(current_id) if current_id else None
+        if owner is not None and not owner.mutation_gate_open:
+            if target is None or path_in_domain(target, owner.domain):
+                return (
+                    "Delegated mutation denied: this child was timed out or "
+                    "cancelled and its mutation gate is closed."
+                )
+
+        for domain, holders in _quarantined.items():
+            if not holders:
+                continue
+            in_domain = (
+                path_in_domain(target, domain)
+                if target is not None
+                else (owner is not None and owner.domain == domain)
+            )
+            if not in_domain:
+                continue
+            other_holders = set(holders)
+            if current_id:
+                other_holders.discard(current_id)
+            if other_holders:
+                return _quarantine_message(domain)
+    return None
+
+
+def _quarantine_message(domain: Path) -> str:
+    return (
+        "Delegated mutation denied: a timed-out or cancelled child is still "
+        f"live in workspace {domain}. Reads remain available; wait until "
+        "that child actually exits."
+    )
+
+
+def _current_owner_id() -> Optional[str]:
+    bound = _CURRENT_FENCE_OWNER.get()
+    if bound:
+        return bound
+    try:
+        from gateway.session_context import get_current_session_id
+    except Exception:
+        return None
+    try:
+        session_id = get_current_session_id()
+    except Exception:
+        return None
+    return str(session_id) if session_id else None
+
+
+def _quarantine_if_still_live(owner_id: str) -> None:
+    with _lock:
+        owner = _owners.get(owner_id)
+        if owner is None or not owner.stale:
+            return
+        try:
+            still_live = bool(owner.is_live())
+        except Exception:
+            still_live = True
+        if not still_live:
+            return
+        holders = _quarantined.setdefault(owner.domain, set())
+        holders.add(owner_id)
+        logger.warning(
+            "Quarantined workspace %s until stale delegated owner %s exits",
+            owner.domain,
+            owner_id,
+        )

--- a/model_tools.py
+++ b/model_tools.py
@@ -1466,6 +1466,38 @@ def handle_function_call(
                 )
                 return result
 
+        # --------------------------------------------------------------------------------------
+        # Workspace Mutation Fence (issue #95874)
+        # --------------------------------------------------------------------------------------
+        # Deny known built-in mutating tools for a delegated child whose
+        # workspace domain is quarantined because a prior timed-out / cancelled
+        # child is still live there. Reads, unknown plugin/MCP tools, other
+        # domains, and non-delegated callers are never fenced here.
+        try:
+            from agent.workspace_mutation_fence import deny_delegated_mutation
+
+            _fence_deny = deny_delegated_mutation(function_name, function_args)
+        except Exception as _fence_err:
+            logger.debug("workspace mutation fence error: %s", _fence_err)
+            _fence_deny = None
+        if _fence_deny:
+            result = tool_error(_fence_deny)
+            _emit_post_tool_call_hook(
+                function_name=function_name,
+                function_args=function_args,
+                result=result,
+                task_id=task_id,
+                session_id=session_id,
+                tool_call_id=tool_call_id,
+                turn_id=turn_id,
+                api_request_id=api_request_id,
+                status="blocked",
+                error_type="workspace_quarantine",
+                error_message=_fence_deny,
+                middleware_trace=list(_tool_middleware_trace),
+            )
+            return result
+
         # ACP/Zed edit approval runs before any file mutation.  The requester
         # is bound via ContextVar only for ACP sessions, so CLI/gateway paths
         # are unaffected when it is unset.

--- a/tests/tools/test_workspace_mutation_fence.py
+++ b/tests/tools/test_workspace_mutation_fence.py
@@ -1,0 +1,341 @@
+"""Regression tests for the owner-aware workspace mutation fence (#95874).
+
+The fence denies known built-in mutating tools for a delegated child whose
+workspace domain is quarantined because a prior timed-out / cancelled child
+is still live there. Reads, unknown plugin/MCP tools, other domains, and
+non-delegated callers are never fenced. Release is driven by real completion.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import threading
+from pathlib import Path
+
+import pytest
+
+# Importing model_tools triggers discover_builtin_tools(), which registers
+# the built-in tools (write_file, read_file, patch, ...) into the registry
+# before any test inspects or stubs a handler.
+import model_tools  # noqa: F401
+
+
+def _fence():
+    import agent.workspace_mutation_fence as fence
+    return fence
+
+
+def _registry():
+    from tools.registry import registry as tool_registry
+    return tool_registry
+
+
+@pytest.fixture(autouse=True)
+def _clean_fence(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    (tmp_path / ".hermes").mkdir()
+    fence = _fence()
+    fence.reset_for_tests()
+    fence.set_grace_seconds_for_tests(0.0)
+    yield
+    fence.reset_for_tests()
+    fence.set_grace_seconds_for_tests(fence.DEFAULT_QUARANTINE_GRACE_SECONDS)
+
+
+def _stub_handler(name: str, sentinel: str, captured: dict):
+    reg = _registry()
+    entry = reg._tools.get(name)
+    assert entry is not None, f"{name} not registered"
+
+    def _h(args, **kw):
+        captured["called"] = True
+        captured["args"] = args
+        return sentinel
+
+    real = entry.handler
+    entry.handler = _h
+    return real
+
+
+def _restore_handler(name: str, real):
+    reg = _registry()
+    entry = reg._tools.get(name)
+    if entry is not None:
+        entry.handler = real
+
+
+def _call(function_name, function_args, *, delegated=False, owner_id=None):
+    import model_tools
+    from agent.delegation_context import delegated_child_context
+    fence = _fence()
+
+    def _do():
+        return model_tools.handle_function_call(
+            function_name=function_name,
+            function_args=function_args,
+            task_id="t",
+            tool_call_id="tc",
+            skip_pre_tool_call_hook=True,
+            skip_tool_request_middleware=True,
+            skip_tool_execution_middleware=True,
+        )
+
+    if delegated:
+        with fence.owning_delegated_child(owner_id or "child-2"):
+            with delegated_child_context(owner_id or "child-2"):
+                return _do()
+    return _do()
+
+
+def test_fence_module_present():
+    assert importlib.util.find_spec("agent.workspace_mutation_fence") is not None
+
+
+def test_mutation_denied_when_stale_live_owner_in_same_domain(tmp_path):
+    fence = _fence()
+    domain = tmp_path / "workspace-a"
+    domain.mkdir()
+    target = domain / "f.txt"
+
+    # First child: dispatched, then times out / is cancelled while still live.
+    live = threading.Event()
+    live.set()  # still live
+    fence.bind_owner("child-1", domain, is_live=lambda: live.is_set())
+    fence.mark_timeout_or_cancel("child-1")  # grace=0 -> immediate quarantine
+
+    captured = {}
+    real = _stub_handler("write_file", '{"ok": true}', captured)
+    try:
+        result = _call("write_file", {"path": str(target), "content": "x"},
+                       delegated=True, owner_id="child-2")
+    finally:
+        _restore_handler("write_file", real)
+
+    assert "denied" in result.lower(), f"expected deny, got: {result!r}"
+    assert not captured.get("called"), "handler should not have been reached"
+
+
+def test_readonly_in_same_domain_remains_available(tmp_path):
+    fence = _fence()
+    domain = tmp_path / "workspace-a"
+    domain.mkdir()
+    target = domain / "f.txt"
+
+    live = threading.Event(); live.set()
+    fence.bind_owner("child-1", domain, is_live=lambda: live.is_set())
+    fence.mark_timeout_or_cancel("child-1")
+
+    captured = {}
+    real = _stub_handler("read_file", '{"ok": true}', captured)
+    try:
+        result = _call("read_file", {"path": str(target)}, delegated=True, owner_id="child-2")
+    finally:
+        _restore_handler("read_file", real)
+
+    assert captured.get("called") is True, "read should be admitted"
+    assert "denied" not in result.lower()
+
+
+def test_mutation_in_other_domain_remains_available(tmp_path):
+    fence = _fence()
+    domain_a = tmp_path / "workspace-a"; domain_a.mkdir()
+    domain_b = tmp_path / "workspace-b"; domain_b.mkdir()
+    target_b = domain_b / "f.txt"
+
+    live = threading.Event(); live.set()
+    fence.bind_owner("child-1", domain_a, is_live=lambda: live.is_set())
+    fence.mark_timeout_or_cancel("child-1")
+
+    captured = {}
+    real = _stub_handler("write_file", '{"ok": true}', captured)
+    try:
+        result = _call("write_file", {"path": str(target_b), "content": "x"},
+                       delegated=True, owner_id="child-2")
+    finally:
+        _restore_handler("write_file", real)
+
+    assert captured.get("called") is True, "other-domain mutation should be admitted"
+    assert "denied" not in result.lower()
+
+
+def test_nondelegated_caller_not_fenced(tmp_path):
+    fence = _fence()
+    domain = tmp_path / "workspace-a"; domain.mkdir()
+    target = domain / "f.txt"
+
+    live = threading.Event(); live.set()
+    fence.bind_owner("child-1", domain, is_live=lambda: live.is_set())
+    fence.mark_timeout_or_cancel("child-1")
+
+    captured = {}
+    real = _stub_handler("write_file", '{"ok": true}', captured)
+    try:
+        result = _call("write_file", {"path": str(target), "content": "x"}, delegated=False)
+    finally:
+        _restore_handler("write_file", real)
+
+    assert captured.get("called") is True, "non-delegated caller must not be fenced"
+    assert "denied" not in result.lower()
+
+
+def test_release_on_real_completion_re_admits(tmp_path):
+    fence = _fence()
+    domain = tmp_path / "workspace-a"; domain.mkdir()
+    target = domain / "f.txt"
+
+    live = threading.Event(); live.set()
+    fence.bind_owner("child-1", domain, is_live=lambda: live.is_set())
+    fence.mark_timeout_or_cancel("child-1")
+
+    # While stale-live: denied.
+    captured = {}
+    real = _stub_handler("write_file", '{"ok": true}', captured)
+    try:
+        denied = _call("write_file", {"path": str(target), "content": "x"},
+                        delegated=True, owner_id="child-2")
+        assert "denied" in denied.lower()
+
+        # Stale owner actually finishes -> release.
+        live.clear()
+        fence.release_owner("child-1")
+
+        result = _call("write_file", {"path": str(target), "content": "x"},
+                       delegated=True, owner_id="child-2")
+    finally:
+        _restore_handler("write_file", real)
+
+    assert captured.get("called") is True, "after release, mutation should be admitted"
+    assert "denied" not in result.lower()
+
+
+def test_stale_owner_own_mutations_denied_via_gate(tmp_path):
+    fence = _fence()
+    domain = tmp_path / "workspace-a"; domain.mkdir()
+    target = domain / "f.txt"
+
+    live = threading.Event(); live.set()
+    fence.bind_owner("child-1", domain, is_live=lambda: live.is_set())
+    fence.mark_timeout_or_cancel("child-1")
+
+    # The stale owner itself (same owner_id) has its mutation gate closed.
+    captured = {}
+    real = _stub_handler("write_file", '{"ok": true}', captured)
+    try:
+        result = _call("write_file", {"path": str(target), "content": "x"},
+                       delegated=True, owner_id="child-1")
+    finally:
+        _restore_handler("write_file", real)
+
+    assert "denied" in result.lower()
+    assert not captured.get("called")
+
+
+def test_unknown_plugin_tool_not_fenced(tmp_path):
+    """Unknown plugin/MCP tools are left outside the initial fencing claim."""
+    fence = _fence()
+    domain = tmp_path / "workspace-a"; domain.mkdir()
+
+    live = threading.Event(); live.set()
+    fence.bind_owner("child-1", domain, is_live=lambda: live.is_set())
+    fence.mark_timeout_or_cancel("child-1")
+
+    # An unknown tool name is not in KNOWN_BUILTIN_MUTATING_TOOLS -> never fenced.
+    assert "some_plugin_tool" not in fence.KNOWN_BUILTIN_MUTATING_TOOLS
+    msg = fence.deny_delegated_mutation("some_plugin_tool", {"path": str(domain / "x")})
+    assert msg is None
+
+
+def test_run_single_child_arms_fence_on_timeout(tmp_path, monkeypatch):
+    """End-to-end wiring: the real ``_run_single_child`` binds an owner,
+    marks it stale on timeout, and releases on real completion — so a later
+    delegated mutation in the same domain is denied while the child is live
+    and re-admitted after the child actually finishes.
+    """
+    import tools.delegate_tool as dt
+    fence = _fence()
+    fence.reset_for_tests()
+    fence.set_grace_seconds_for_tests(0.0)
+
+    domain = tmp_path / "workspace-a"
+    domain.mkdir()
+    target = domain / "f.txt"
+
+    release = threading.Event()
+
+    class _StubChild:
+        _subagent_id = "stale-child-1"
+        session_id = "stale-child-1"
+        _delegate_role = "leaf"
+        _delegate_workspace_domain = str(domain)
+        tool_progress_callback = None
+        _credential_pool = None
+        _delegate_saved_tool_names = []
+        _delegate_output_schema = None
+
+        def run_conversation(self, user_message, task_id=None, stream_callback=None):
+            release.wait(5.0)
+            return {"final_response": "done"}
+
+        def get_activity_summary(self):
+            return {"api_call_count": 0, "max_iterations": 0,
+                    "current_tool": None, "last_activity_ts": None}
+
+    class _StubParent:
+        platform = "cli"
+        _delegate_depth = 1
+        _active_children = []
+        _active_children_lock = threading.Lock()
+        _print_fn = None
+        tool_progress_callback = None
+        thinking_callback = None
+
+        def _touch_activity(self, *a, **k):
+            pass
+
+    monkeypatch.setattr(dt, "_get_child_timeout", lambda: 0.3)
+    monkeypatch.setattr(dt, "_dump_subagent_timeout_diagnostic",
+                        lambda **kw: None)
+    monkeypatch.setattr(dt, "_register_subagent", lambda *a, **k: None)
+    monkeypatch.setattr(dt, "_unregister_subagent", lambda *a, **k: None)
+
+    child = _StubChild()
+    parent = _StubParent()
+
+    entry = dt._run_single_child(
+        task_index=0,
+        goal="work",
+        child=child,
+        parent_agent=parent,
+    )
+    assert entry["status"] == "timeout"
+
+    # While the stale child is still live (release not yet set), a later
+    # delegated mutation in the same domain must be denied.
+    captured = {}
+    real = _stub_handler("write_file", '{"ok": true}', captured)
+    try:
+        denied = _call("write_file", {"path": str(target), "content": "x"},
+                       delegated=True, owner_id="child-2")
+    finally:
+        _restore_handler("write_file", real)
+    assert "denied" in denied.lower()
+    assert not captured.get("called")
+
+    # Now the stale child actually finishes -> release fires -> re-admitted.
+    release.set()
+    import time as _time
+    _time.sleep(0.3)
+
+    captured2 = {}
+    real2 = _stub_handler("write_file", '{"ok": true}', captured2)
+    try:
+        result = _call("write_file", {"path": str(target), "content": "x"},
+                       delegated=True, owner_id="child-2")
+    finally:
+        _restore_handler("write_file", real2)
+    assert captured2.get("called") is True
+    assert "denied" not in result.lower()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2774,6 +2774,38 @@ def _run_single_child(
 
                 goal = goal + build_worktree_context_note(_worktree_info)
 
+        # --------------------------------------------------------------------------------------
+        # Workspace Mutation Fence (issue #95874)
+        # --------------------------------------------------------------------------------------
+        # Bind this delegated child as an owner of its trusted local workspace
+        # domain so that, if it times out or is cancelled but stays live after
+        # the existing grace window, later known built-in mutations in the same
+        # domain are denied until this child actually exits.
+        from agent.workspace_mutation_fence import (
+            bind_owner as _fence_bind_owner,
+            mark_timeout_or_cancel as _fence_mark_stale,
+            release_owner as _fence_release_owner,
+            resolve_workspace_domain as _fence_resolve_domain,
+            set_owner_liveness as _fence_set_liveness,
+        )
+
+        _fence_owner_id = (
+            _subagent_id
+            or str(getattr(child, "session_id", "") or "")
+            or child_task_id
+        )
+        _fence_domain_raw = None
+        try:
+            from tools.terminal_tool import get_session_cwd as _fence_gsc
+
+            _fence_domain_raw = _fence_gsc(child_task_id) or _fence_gsc(parent_task_id)
+        except Exception:
+            _fence_domain_raw = None
+        if not _fence_domain_raw:
+            _fence_domain_raw = _resolve_workspace_hint(parent_agent)
+        _fence_domain = _fence_resolve_domain(_fence_domain_raw, child=child)
+        _fence_bind_owner(_fence_owner_id, _fence_domain)
+
         wall_start = time.time()
         parent_reads_snapshot = (
             list(file_state.known_reads(parent_task_id)) if parent_task_id else []
@@ -2814,19 +2846,24 @@ def _run_single_child(
         def _run_with_thread_capture():
             _worker_thread_holder["t"] = threading.current_thread()
             from agent.delegation_context import delegated_child_context
+            from agent.workspace_mutation_fence import owning_delegated_child
 
-            with delegated_child_context(str(getattr(child, "session_id", "") or "")):
-                return child.run_conversation(
-                    user_message=goal,
-                    task_id=child_task_id,
-                    stream_callback=_relay_child_text,
-                )
+            session_id = str(getattr(child, "session_id", "") or "")
+            with delegated_child_context(session_id):
+                with owning_delegated_child(_fence_owner_id):
+                    return child.run_conversation(
+                        user_message=goal,
+                        task_id=child_task_id,
+                        stream_callback=_relay_child_text,
+                    )
 
         _child_context = contextvars.copy_context()
         _child_future = _timeout_executor.submit(
             _child_context.run,
             _run_with_thread_capture,
         )
+        _fence_set_liveness(_fence_owner_id, lambda: not _child_future.done())
+        _child_future.add_done_callback(lambda _f: _fence_release_owner(_fence_owner_id))
         try:
             result = _child_future.result(timeout=child_timeout)
         except Exception as _timeout_exc:
@@ -2845,6 +2882,8 @@ def _run_single_child(
                 pass
 
             is_timeout = isinstance(_timeout_exc, (FuturesTimeoutError, TimeoutError))
+            if is_timeout:
+                _fence_mark_stale(_fence_owner_id)
             duration = round(time.monotonic() - child_start, 2)
             logger.warning(
                 "Subagent %d %s after %.1fs",
@@ -4014,6 +4053,20 @@ def delegate_task(
                                         ),
                                     }
                             else:
+                                _abandoned = _child_by_index.get(idx)
+                                try:
+                                    from agent.workspace_mutation_fence import (
+                                        mark_timeout_or_cancel as _fence_cancel,
+                                    )
+
+                                    _abandon_id = (
+                                        getattr(_abandoned, "_subagent_id", None)
+                                        or getattr(_abandoned, "session_id", None)
+                                    )
+                                    if _abandon_id:
+                                        _fence_cancel(str(_abandon_id))
+                                except Exception:
+                                    pass
                                 entry = {
                                     "task_index": idx,
                                     "status": "interrupted",
@@ -4022,7 +4075,7 @@ def delegate_task(
                                     "api_calls": 0,
                                     "duration_seconds": 0,
                                     "_child_role": getattr(
-                                        _child_by_index.get(idx), "_delegate_role", None
+                                        _abandoned, "_delegate_role", None
                                     ),
                                 }
                             results.append(entry)


### PR DESCRIPTION
## What does this PR do?

Adds an owner-aware workspace mutation admission fence for delegated children. When a delegated child times out or is cancelled but stays live after the existing tool-interrupt grace window, later known built-in mutations in the same trusted local workspace are now denied until every stale owner actually completes. Reads, unknown plugin/MCP tools, mutations in other workspace domains, and non-delegated callers remain unaffected. The quarantine is released only by real completion (the child's future finishing), not by elapsed time alone.

This is the small, explicit lifecycle contract the issue asks for, rather than an unconditional global lock: each delegated child is bound to its workspace domain at dispatch; on genuine timeout/cancel its mutation gate closes and interruption is requested; after the existing bounded grace the domain is quarantined only if the child is still live; at the central execution boundary only known built-in mutating tools for later delegated work in that quarantined domain are denied.

## Related Issue

Fixes #95874

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/workspace_mutation_fence.py` (new): owner registry, mutation gate, grace-then-quarantine-if-still-live, `deny_delegated_mutation` admission decision, and `release_owner` on real completion. Fencing is scoped to `FILE_MUTATING_TOOL_NAMES` (`write_file`, `patch`) and delegated-child contexts only.
- `tools/delegate_tool.py`: in `_run_single_child`, bind the child as owner of its resolved workspace domain at dispatch, set liveness to `not future.done()`, register a done-callback that releases the owner on real completion, and call `mark_timeout_or_cancel` on the timeout branch. The batch abandon path also calls `mark_timeout_or_cancel` for abandoned children. The existing timeout/cancellation result returned to the caller is unchanged.
- `model_tools.py`: in `handle_function_call`, add a pre-dispatch admission check (`deny_delegated_mutation`) between the plugin-block check and the ACP edit-approval check; on deny it returns a `tool_error` with `error_type="workspace_quarantine"` and emits the post-tool hook with `status="blocked"`.
- `tests/tools/test_workspace_mutation_fence.py` (new): 9 tests covering the deny/allow/release contract, the controls (reads, other-domain mutations, non-delegated callers, unknown plugin tools), and an end-to-end test driving the real `_run_single_child` timeout path to confirm the fence is armed and released.

## How to Test

1. `scripts/run_tests.sh tests/tools/test_workspace_mutation_fence.py -q` — all 9 tests pass.
2. The end-to-end test `test_run_single_child_arms_fence_on_timeout` drives the real `_run_single_child` with a stub child that blocks past `child_timeout`; it asserts a later delegated `write_file` in the same workspace is denied while the stale child is live, and re-admitted after the child actually finishes.
3. Regression check: `scripts/run_tests.sh tests/tools/test_delegate.py tests/tools/test_async_delegation.py tests/tools/test_delegate_subagent_timeout_diagnostic.py -q` — 100/100 pass (no regressions in the delegation suite).
4. Reproduction of the original gap on `main` (before this PR): no `agent.workspace_mutation_fence` module exists and a delegated-child `write_file` reaches the tool handler with no quarantine deny.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (darwin 25.5.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
$ scripts/run_tests.sh tests/tools/test_workspace_mutation_fence.py -q
[100.0% | 9/~9 | ✓9 | ✗0] ✓ tests/tools/test_workspace_mutation_fence.py (9✓, 10.1s)
=== Summary: 1 files, 9 tests passed, 0 failed (100% complete) in 10.1s ===
```
