### PR TITLE
fix(desktop): unwrap code-skew 503 on Models page and make restart advice deployment-aware

### DIFF
--- a/apps/desktop/src/app/settings/model-settings.test.tsx
+++ b/apps/desktop/src/app/settings/model-settings.test.tsx
@@ -593,3 +593,69 @@ describe('ModelSettings MoA preset editor', () => {
     }
   })
 })
+
+// #97046: a backend code-skew 503 arrives over Electron IPC double-wrapped —
+// the IPC prefix plus the FastAPI detail as a serialized JSON blob. The Models
+// page must surface the backend's human detail (with its deployment-aware
+// restart advice) instead of the raw blob.
+const IPC_SKEW_ERROR =
+  'Error invoking remote method \'hermes:api\': Error: 503: {"detail":"Restart required: This desktop backend was started before the update — quit and reopen Hermes Desktop to load the new code."}'
+
+describe('unwrapCodeSkewError', () => {
+  it('unwraps the IPC prefix and extracts the 503 detail text', async () => {
+    const { unwrapCodeSkewError } = await import('./model-settings')
+
+    expect(unwrapCodeSkewError(new Error(IPC_SKEW_ERROR))).toBe(
+      'Restart required: This desktop backend was started before the update — quit and reopen Hermes Desktop to load the new code.'
+    )
+  })
+
+  it('accepts plain string errors too', async () => {
+    const { unwrapCodeSkewError } = await import('./model-settings')
+
+    expect(unwrapCodeSkewError(IPC_SKEW_ERROR)).toBe(
+      'Restart required: This desktop backend was started before the update — quit and reopen Hermes Desktop to load the new code.'
+    )
+  })
+
+  it('leaves ordinary (non-skew) errors untouched', async () => {
+    const { unwrapCodeSkewError } = await import('./model-settings')
+
+    expect(unwrapCodeSkewError(new Error('boom'))).toBe('boom')
+  })
+
+  it('leaves non-503 IPC errors untouched (current raw behavior)', async () => {
+    const { unwrapCodeSkewError } = await import('./model-settings')
+
+    const raw = 'Error invoking remote method \'hermes:api\': Error: 500: {"detail":"boom"}'
+    expect(unwrapCodeSkewError(new Error(raw))).toBe(raw)
+  })
+
+  it('falls back to the raw remainder when the 503 payload is not JSON', async () => {
+    const { unwrapCodeSkewError } = await import('./model-settings')
+
+    // The IPC wrapper is still stripped; the unparseable remainder after
+    // "503: " is shown as-is.
+    expect(unwrapCodeSkewError(new Error('Error invoking remote method \'hermes:api\': Error: 503: oops not json'))).toBe(
+      '503: oops not json'
+    )
+  })
+})
+
+describe('ModelSettings code-skew 503 unwrapping', () => {
+  it('shows the backend restart detail instead of the raw IPC blob', async () => {
+    getGlobalModelOptions.mockRejectedValueOnce(new Error(IPC_SKEW_ERROR))
+
+    await renderModelSettings()
+
+    const banner = await screen.findByText(
+      /Restart required: This desktop backend was started before the update/
+    )
+
+    expect(banner.textContent).toContain(
+      'quit and reopen Hermes Desktop to load the new code.'
+    )
+    expect(banner.textContent).not.toContain('Error invoking remote method')
+    expect(screen.queryByText(/Error invoking remote method/)).toBeNull()
+  })
+})

--- a/apps/desktop/src/app/settings/model-settings.tsx
+++ b/apps/desktop/src/app/settings/model-settings.tsx
@@ -39,6 +39,34 @@ import { getNested, setNested } from './helpers'
 import { ListRow, Pill, SectionHeading } from './primitives'
 import { useDeepLinkHighlight } from './use-deep-link-highlight'
 
+// A code-skew 503 from the backend arrives over Electron IPC double-wrapped:
+// the IPC layer prefixes it ("Error invoking remote method 'hermes:api':
+// Error: ") and the FastAPI detail rides inside as a serialized JSON blob
+// ("503: {\"detail\":\"Restart required: ...\"}"). Surface just the backend's
+// human detail text instead of the raw blob (#97046). Any other error shape
+// comes back unchanged, so non-skew behavior is untouched.
+export function unwrapCodeSkewError(error: unknown): string {
+  const raw = error instanceof Error ? error.message : String(error)
+  const inner = raw.match(/Error invoking remote method '[^']+': Error: (.+)$/)?.[1] ?? raw
+  const skew = /^503: (.+)$/.exec(inner)
+
+  if (!skew) {
+    return raw
+  }
+
+  try {
+    const detail = (JSON.parse(skew[1]) as { detail?: unknown }).detail
+
+    if (typeof detail === 'string' && detail.startsWith('Restart required:')) {
+      return detail
+    }
+  } catch {
+    // Not JSON — fall through to the raw remainder below.
+  }
+
+  return inner
+}
+
 // Skeleton mirror of the Model settings DOM so the page keeps its shape while
 // the provider/model catalog loads, instead of collapsing to a centered
 // spinner. Same containers/rhythm as the real render below.
@@ -270,7 +298,7 @@ export function ModelSettings({ onMainModelChanged, scopeProfile }: ModelSetting
         void invalidateHermesConfig(scopeProfile)
       } catch (err) {
         if (profileEpoch.current === epoch) {
-          setError(err instanceof Error ? err.message : String(err))
+          setError(unwrapCodeSkewError(err))
         }
       } finally {
         if (profileEpoch.current === epoch) {
@@ -408,7 +436,7 @@ export function ModelSettings({ onMainModelChanged, scopeProfile }: ModelSetting
           })
           .catch(err => {
             if (moaSaveGeneration.current === generation) {
-              setError(err instanceof Error ? err.message : String(err))
+              setError(unwrapCodeSkewError(err))
             }
           })
       }, 600)
@@ -477,7 +505,7 @@ export function ModelSettings({ onMainModelChanged, scopeProfile }: ModelSetting
 
         setMoa(saved)
       } catch (err) {
-        setError(err instanceof Error ? err.message : String(err))
+        setError(unwrapCodeSkewError(err))
       } finally {
         setApplying(false)
       }
@@ -592,7 +620,7 @@ export function ModelSettings({ onMainModelChanged, scopeProfile }: ModelSetting
       const fallbackModel = refreshedRow?.models?.[0] ?? ''
       setSelectedModel(nextModel || fallbackModel)
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err))
+      setError(unwrapCodeSkewError(err))
     } finally {
       setActivating(false)
     }
@@ -660,7 +688,7 @@ export function ModelSettings({ onMainModelChanged, scopeProfile }: ModelSetting
 
       await refresh()
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err))
+      setError(unwrapCodeSkewError(err))
     } finally {
       setApplying(false)
     }
@@ -702,7 +730,7 @@ export function ModelSettings({ onMainModelChanged, scopeProfile }: ModelSetting
         )
         await refresh()
       } catch (err) {
-        setError(err instanceof Error ? err.message : String(err))
+        setError(unwrapCodeSkewError(err))
       } finally {
         setApplying(false)
       }
@@ -733,7 +761,7 @@ export function ModelSettings({ onMainModelChanged, scopeProfile }: ModelSetting
         setEditingAuxTask(null)
         await refresh()
       } catch (err) {
-        setError(err instanceof Error ? err.message : String(err))
+        setError(unwrapCodeSkewError(err))
       } finally {
         setApplying(false)
       }
@@ -776,7 +804,7 @@ export function ModelSettings({ onMainModelChanged, scopeProfile }: ModelSetting
       setSwitchStaleAux([])
       await refresh()
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err))
+      setError(unwrapCodeSkewError(err))
     } finally {
       setApplying(false)
     }

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -7381,7 +7381,7 @@ _AUX_TASK_SLOTS: Tuple[str, ...] = (
 
 
 def _dashboard_code_skew_guard() -> Optional[str]:
-    """Return a clear \"restart required\" message when the dashboard runs stale code.
+    """Return a clear "restart required" message when the dashboard runs stale code.
 
     The dashboard is a long-lived process; its ``sys.modules`` is frozen at
     boot.  When ``hermes update`` (or a manual ``git pull``) replaces the
@@ -7393,6 +7393,11 @@ def _dashboard_code_skew_guard() -> Optional[str]:
     ``_model_switch_skew_guard``: refuse the risky call with an actionable
     message instead of crashing with a cryptic import error.
 
+    The remediation text is deployment-aware (#97046): backends spawned by the
+    Desktop app (local or SSH) run with ``HERMES_DESKTOP=1`` and are owned by
+    the Electron client, so systemd/dashboard CLI advice would be wrong — the
+    user must quit and reopen the Desktop app instead.
+
     Returns None when no drift is detectable (fresh process, or a non-git
     install where the boot fingerprint could not be read — never a false
     positive).
@@ -7403,11 +7408,20 @@ def _dashboard_code_skew_guard() -> Optional[str]:
     if not skew:
         return None
     boot_rev, disk_rev = skew
+    if os.environ.get("HERMES_DESKTOP") == "1":
+        remediation = (
+            "quit and reopen the Hermes Desktop app — it owns this backend "
+            "and will load the new code on the next launch"
+        )
+    else:
+        remediation = (
+            "restart the dashboard to load the new code "
+            "(systemctl --user restart hermes-dashboard, or hermes dashboard --port <port>)"
+        )
     return (
         f"This dashboard is running code from {boot_rev} but the checkout on "
         f"disk is now {disk_rev}. The model picker would risk a stale-module "
-        f"crash — restart the dashboard to load the new code "
-        f"(systemctl --user restart hermes-dashboard, or hermes dashboard --port <port>)"
+        f"crash — {remediation}"
     )
 
 

--- a/tests/test_code_skew.py
+++ b/tests/test_code_skew.py
@@ -88,6 +88,34 @@ class TestDashboardCodeSkewGuard:
         assert "def4567890" in msg
         assert "restart" in msg.lower()
 
+    def test_dashboard_guard_desktop_deployment_advises_reopening_app(self, monkeypatch):
+        # #97046: Desktop-owned backends (local or SSH) run with
+        # HERMES_DESKTOP=1 and are owned by the Electron client — there is no
+        # systemd on macOS and no dashboard process to restart via CLI.
+        from hermes_cli import web_server
+
+        monkeypatch.setenv("HERMES_DESKTOP", "1")
+        monkeypatch.setattr(code_skew, "detect_code_skew", lambda: ("abc1234567", "def4567890"))
+        msg = web_server._dashboard_code_skew_guard()
+        assert msg is not None
+        assert "abc1234567" in msg
+        assert "def4567890" in msg
+        assert "Hermes Desktop app" in msg
+        assert "reopen" in msg.lower()
+        assert "systemctl" not in msg
+
+    def test_dashboard_guard_browser_deployment_keeps_systemd_advice(self, monkeypatch):
+        # Without HERMES_DESKTOP the browser-dashboard remediation must stay
+        # exactly as before (#97046 must not change this behavior).
+        from hermes_cli import web_server
+
+        monkeypatch.delenv("HERMES_DESKTOP", raising=False)
+        monkeypatch.setattr(code_skew, "detect_code_skew", lambda: ("abc1234567", "def4567890"))
+        msg = web_server._dashboard_code_skew_guard()
+        assert msg is not None
+        assert "systemctl --user restart hermes-dashboard" in msg
+        assert "hermes dashboard --port <port>" in msg
+
 
 class TestModelOptionsSkewGuard:
     """/api/model/options must refuse with a clear 503 when the dashboard is stale.


### PR DESCRIPTION
## Summary

After a backend checkout update, Desktop-owned backends (local or SSH) keep serving stale code. `/api/model/options` correctly refuses with `503 {"detail": "Restart required: ..."}`, but the Desktop Models page then rendered the raw Electron IPC string — `Error invoking remote method 'hermes:api': Error: 503: {"detail": ...}` — and the remediation baked into the 503 told users on macOS/launchd hosts to run `systemctl --user restart hermes-dashboard`, which does not exist there and does not apply to a backend the Desktop client spawned itself (#97046).

Two changes:

- **Server (`hermes_cli/web_server.py`):** `_dashboard_code_skew_guard()` keys the remediation on the pre-existing `HERMES_DESKTOP=1` env (set by the Desktop client for every backend it spawns — local in `electron/main.ts`, SSH in `electron/remote-lifecycle.ts`): "quit and reopen the Hermes Desktop app" instead of systemd/dashboard-CLI commands. Without that env the advice text is byte-identical to today's.
- **Client (`apps/desktop/src/app/settings/model-settings.tsx`):** new exported `unwrapCodeSkewError()` strips the Electron IPC envelope, detects the `503: {"detail": "Restart required: ..."}` shape, and surfaces the backend's human detail text. Applied at all 8 `setError` paths (options load, apply, aux save, API-key activate, MoA autosave) so every failure mode on the page benefits. Ordinary errors, non-503 IPC errors, and unparseable payloads pass through unchanged.

Deferred on purpose: a one-click "Restart backend" action recycling the Desktop-owned backend over IPC. That needs new IPC surface in `electron/main.ts`; this PR only fixes the message layer, which both slices of the issue's proposed fix describe as independently helpful.

## Changes

- `hermes_cli/web_server.py`: deployment-aware skew-guard remediation (Desktop env → reopen-the-app advice; else unchanged).
- `apps/desktop/src/app/settings/model-settings.tsx`: `unwrapCodeSkewError()` helper + applied at all error sites.
- `tests/test_code_skew.py`: guard message advises reopening the Desktop app under `HERMES_DESKTOP=1` (and never mentions systemctl); non-Desktop message locked to the existing systemd advice.
- `apps/desktop/src/app/settings/model-settings.test.tsx`: 5 helper unit tests (IPC unwrap, string errors, ordinary errors untouched, non-503 untouched, non-JSON fallback) + 1 component test asserting the banner shows the backend detail instead of the raw IPC blob.

## Tests

- `bash scripts/run_tests.sh tests/test_code_skew.py -q` → **13 passed, 0 failed**
- `cd apps/desktop && npx vitest run src/app/settings/model-settings.test.tsx` → **28 passed (28)**
- Regression proof: reversing the two fix files (`git show <sha> -- <files> | git apply -R`) makes the new tests fail on the buggy code (1 Python / 6 TS), and restoring returns both suites to green.

Closes #97046