### PR TITLE
fix(memory): forward checkpoint requirement to v2 providers

### DIFF
--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -1122,7 +1122,13 @@ class MemoryManager:
             if is_checkpoint_provider and evidence_messages is not None:
                 provider_messages = evidence_messages
             try:
-                result = provider.on_pre_compress(provider_messages)
+                if is_checkpoint_provider:
+                    result = provider.on_pre_compress(
+                        provider_messages,
+                        require_checkpoint=require_checkpoint,
+                    )
+                else:
+                    result = provider.on_pre_compress(provider_messages)
                 if result and result.strip():
                     parts.append(result)
             except Exception as e:

--- a/tests/agent/test_pre_compress_checkpoint_contract.py
+++ b/tests/agent/test_pre_compress_checkpoint_contract.py
@@ -50,10 +50,21 @@ class _BaseStubProvider(MemoryProvider):
 class _CheckpointProvider(_BaseStubProvider):
     pre_compress_checkpoint_api_version = PRE_COMPRESS_CHECKPOINT_API_VERSION
 
+    def __init__(self, name="stub"):
+        super().__init__(name)
+        self.require_checkpoint_calls = []
+
+    def on_pre_compress(self, messages, *, require_checkpoint=False):
+        self.require_checkpoint_calls.append(require_checkpoint)
+        return super().on_pre_compress(messages)
+
 
 class _FailingCheckpointProvider(_CheckpointProvider):
-    def on_pre_compress(self, messages):
-        raise RuntimeError("durable store unreachable")
+    def on_pre_compress(self, messages, *, require_checkpoint=False):
+        self.require_checkpoint_calls.append(require_checkpoint)
+        if require_checkpoint:
+            raise RuntimeError("durable store unreachable")
+        return ""
 
 
 class _FailingLegacyProvider(_BaseStubProvider):
@@ -163,6 +174,45 @@ def test_manager_require_checkpoint_raises_without_capable_provider():
             require_checkpoint=True,
             checkpoint_api_version=PRE_COMPRESS_CHECKPOINT_API_VERSION,
         )
+
+
+def test_manager_passes_required_signal_to_checkpoint_provider():
+    manager = MemoryManager()
+    durable = _CheckpointProvider("durable")
+    manager.add_provider(durable)
+
+    manager.on_pre_compress(
+        [{"role": "user", "content": "evidence"}],
+        require_checkpoint=True,
+    )
+
+    assert durable.require_checkpoint_calls == [True]
+
+
+def test_manager_does_not_pass_checkpoint_keyword_to_legacy_provider():
+    manager = MemoryManager()
+    legacy = _BaseStubProvider("legacy")
+    manager.add_provider(legacy)
+
+    combined = manager.on_pre_compress(
+        [{"role": "user", "content": "evidence"}],
+    )
+
+    assert combined == "legacy context"
+    assert legacy.pre_compress_calls
+
+
+def test_checkpoint_provider_receives_false_in_best_effort_mode():
+    manager = MemoryManager()
+    durable = _FailingCheckpointProvider("durable")
+    manager.add_provider(durable)
+
+    combined = manager.on_pre_compress(
+        [{"role": "user", "content": "evidence"}],
+    )
+
+    assert combined == ""
+    assert durable.require_checkpoint_calls == [False]
 
 
 def test_manager_require_checkpoint_propagates_checkpoint_provider_failure():


### PR DESCRIPTION
## Symptom

With `compression.checkpoint_required: true` and a memory provider advertising `pre_compress_checkpoint_api_version = 2`, a failing durable write does **not** block compression. The provider swallows the failure, the host treats the checkpoint as succeeded, and lossy compression proceeds — silently defeating the guarantee the option exists to provide.

## Root cause

`MemoryManager.on_pre_compress()` detects v2 providers, selects the normalized `evidence_messages` for them, and re-raises their failures under `require_checkpoint` — but the actual call never forwards the flag:

```python
result = provider.on_pre_compress(provider_messages)
```

A v2 provider therefore runs in its default best-effort mode (`require_checkpoint=False`), so the exception path the host is prepared to re-raise is never taken.

## Reproduction

Probe provider registering what it receives:

```python
class ProbeProvider:
    pre_compress_checkpoint_api_version = 2
    def on_pre_compress(self, messages, **kwargs):
        observed.update(kwargs)   # -> {} : require_checkpoint never arrives
        return ""
```

A v2 provider whose durable write always fails passes `require_checkpoint=True` through `MemoryManager.on_pre_compress` without raising — compression proceeds, original messages are lost.

## Fix

Forward `require_checkpoint` only to providers advertising the requested checkpoint API version. Legacy providers keep the strict one-argument `on_pre_compress(self, messages)` contract, so bundled v1 providers (honcho, mem0, supermemory, …) are unaffected — passing the kwarg unconditionally would `TypeError` on every one of them.

## Tests

`tests/agent/test_pre_compress_checkpoint_contract.py` (+54 lines on the existing file): required and best-effort signaling, legacy signature compatibility, and required-mode failure propagation. 20 passed on current `main` (`7aebf300a7`).