### PR TITLE
fix(compression): stop the summary when the commit fence is cancelled (#96953)

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -846,6 +846,71 @@ class CompressionCommitFence:
             release()
 
 
+class SummaryCancelSource:
+    """Event-shaped cancel source: hard interrupt OR commit-fence cancellation.
+
+    ``aux_interrupt_protection`` accepts any object exposing ``is_set()``, and
+    the protected-call seam polls it every 20ms while the summary streams
+    (``_run_protected_sync_provider_call``). The compression worker installs
+    this for the duration of the summary call so a host that has stopped
+    waiting unwinds the provider call promptly.
+
+    Why the fence alone was not enough (#96953): the fence is consulted once
+    *before* summary dispatch (F6) and never again while the stream runs, and
+    :meth:`CompressionCommitFence.try_cancel_before_commit` — the only cancel
+    path an async host can take without blocking its event loop — has no
+    ``cancel_event`` parameter to signal with. A gateway-hygiene host that gave
+    up at its total ceiling therefore left the worker streaming a summary the
+    commit fence was already guaranteed to refuse: minutes of paid provider
+    tokens, one of the four bounded compression-pool slots
+    (``_COMPRESS_EXECUTOR_MAX_WORKERS``) held the whole time, and a
+    ``commit_fence_cancelled`` abort at the end with nothing to show for it.
+    """
+
+    __slots__ = ("_hard_event", "_fence", "_flag")
+
+    def __init__(self, hard_event: Any, fence: Any) -> None:
+        self._hard_event = hard_event
+        self._fence = fence
+        self._flag = False
+
+    def set(self) -> None:
+        """Set the underlying hard-interrupt event (duck-typed Event API)."""
+        self._flag = True
+        setter = getattr(self._hard_event, "set", None)
+        if callable(setter):
+            try:
+                setter()
+            except Exception:
+                logger.debug("hard cancel set failed", exc_info=True)
+
+    def is_set(self) -> bool:
+        if self._flag:
+            return True
+        if hard_interrupt_requested(self._hard_event):
+            return True
+        fence = self._fence
+        if fence is None:
+            return False
+        try:
+            return bool(fence.is_cancelled)
+        except Exception:
+            logger.debug("fence cancellation probe failed", exc_info=True)
+            return False
+
+
+def hard_interrupt_requested(hard_event: Any) -> bool:
+    """Read an explicit hard-interrupt event without leaking its failures."""
+    checker = getattr(hard_event, "is_set", None)
+    if not callable(checker):
+        return False
+    try:
+        return bool(checker())
+    except Exception:
+        logger.debug("hard cancel probe failed", exc_info=True)
+        return False
+
+
 # Defaults for the in-agent (non-hygiene) progress-aware compress_context wrap.
 # Mirror hermes_cli.config.DEFAULT_CONFIG["compression"] keys of the same name.
 DEFAULT_CONTEXT_TIMEOUT_SECONDS = 120.0
@@ -3531,6 +3596,17 @@ def compress_context(
         # atomic summary in half (#23975). Explicit stop surfaces set a separate
         # Event atomically; never infer cause from the racy message fields.
         _hard_cancel_event = getattr(agent, "_hard_interrupt_requested", None)
+        # #96953: the aux layer polls this every 20ms while the summary
+        # streams, so a fence cancellation (hygiene ceiling, /stop, /restart,
+        # admission revoke) unwinds the provider call instead of letting the
+        # worker stream to completion for a commit the fence will refuse.
+        # Left as ``None`` when there is nothing to signal, so the aux scope
+        # keeps inheriting an outer cancel source exactly as it did before.
+        _summary_cancel_source = (
+            SummaryCancelSource(_hard_cancel_event, commit_fence)
+            if (_hard_cancel_event is not None or commit_fence is not None)
+            else None
+        )
         try:
             # F6: never start expensive summary work for an already-cancelled
             # fence (a stale queued job admitted after host departure).
@@ -3543,7 +3619,7 @@ def compress_context(
                 compressed = messages
             else:
                 with aux_progress_hook(_progress_hook), aux_interrupt_protection(
-                    cancel_event=_hard_cancel_event
+                    cancel_event=_summary_cancel_source
                 ):
                     compressed = compress_fn(messages, **compress_kwargs)
                     # Freeze a hard stop that arrived after the final provider
@@ -3560,6 +3636,24 @@ def compress_context(
                     agent.context_compressor, _attempt_generation
                 )
     except AuxiliaryExplicitCancellation:
+        # A fence cancellation now reaches the streaming summary call (#96953),
+        # so this unwind is no longer necessarily an operator interrupt.
+        # Classify by source: the hard-interrupt event is authoritative when it
+        # is set, otherwise a cancelled fence means the host stopped waiting.
+        _cancel_was_fence = bool(
+            commit_fence is not None
+            and not hard_interrupt_requested(
+                getattr(agent, "_hard_interrupt_requested", None)
+            )
+            and commit_fence.is_cancelled
+        )
+        if _cancel_was_fence:
+            logger.info(
+                "Compression summary aborted by commit-fence cancellation "
+                "(session=%s) — the host stopped waiting, so the summary was "
+                "stopped instead of run to completion for a refused commit.",
+                agent.session_id or "none",
+            )
         try:
             _restore_compressor_attempt_state(
                 agent.context_compressor,
@@ -3602,7 +3696,10 @@ def compress_context(
             started_at=_attempt_started_at,
             commit_status="aborted",
             split_status="aborted",
-            failure_class="explicit_interrupt",
+            failure_class=(
+                "commit_fence_cancelled" if _cancel_was_fence
+                else "explicit_interrupt"
+            ),
         )
         _existing_sp = getattr(agent, "_cached_system_prompt", None)
         if not _existing_sp:

--- a/tests/agent/test_compression_fence_cancel_stops_summary.py
+++ b/tests/agent/test_compression_fence_cancel_stops_summary.py
@@ -1,0 +1,278 @@
+"""A cancelled commit fence must stop the in-flight summary call (#96953).
+
+Before this seam the fence was consulted once before summary dispatch and never
+again while the stream ran, and ``try_cancel_before_commit`` (the only cancel
+path an async host can take) had no cancel event to signal with. A gateway
+session-hygiene host that gave up at its total ceiling therefore left the
+compression worker streaming a summary for minutes, holding one of the four
+bounded compression-pool slots and paying for tokens, only to abort at the
+commit fence with nothing committed.
+"""
+
+import json
+import logging
+import threading
+import time
+from unittest.mock import patch
+
+import pytest
+
+from agent.auxiliary_client import _run_protected_sync_provider_call
+from agent.context_compressor import ContextCompressor
+from agent.conversation_compression import (
+    CompressionCommitFence,
+    SummaryCancelSource,
+    compress_context,
+)
+
+
+class _TodoStore:
+    def format_for_injection(self):
+        return ""
+
+
+class _Agent:
+    def __init__(self, compressor):
+        self.context_compressor = compressor
+        self.session_id = "session-fence-cancel-test"
+        self.platform = "cli"
+        self.model = "test/main-model"
+        self.provider = "test-provider"
+        self.tools = []
+        self._compression_feasibility_checked = True
+        self.compression_in_place = False
+        self._memory_manager = None
+        self._session_db = None
+        self._todo_store = _TodoStore()
+        self._cached_system_prompt = None
+
+    def _emit_status(self, _message):
+        pass
+
+    def _emit_warning(self, _message):
+        pass
+
+    def _invalidate_system_prompt(self):
+        self._cached_system_prompt = None
+
+    def _build_system_prompt(self, system_message):
+        return system_message
+
+    def commit_memory_session(self, _messages):
+        pass
+
+
+def _messages():
+    msgs = [{"role": "system", "content": "system prompt"}]
+    for idx in range(10):
+        msgs.append({"role": "user", "content": f"user message {idx}"})
+        msgs.append({"role": "assistant", "content": f"assistant reply {idx}"})
+    return msgs
+
+
+def _telemetry(caplog):
+    records = [
+        record.getMessage()
+        for record in caplog.records
+        if "context compression attempt telemetry:" in record.getMessage()
+    ]
+    assert len(records) == 1, records
+    return json.loads(
+        records[0].split("context compression attempt telemetry: ", 1)[1]
+    )
+
+
+def _compressor():
+    with patch(
+        "agent.context_compressor.get_model_context_length", return_value=100_000
+    ):
+        compressor = ContextCompressor(
+            model="test/main-model",
+            provider="test-provider",
+            threshold_percent=0.50,
+            quiet_mode=True,
+            config_context_length=100_000,
+        )
+    compressor.tail_token_budget = 10
+    return compressor
+
+
+# ── SummaryCancelSource unit semantics ──────────────────────────────────────
+
+
+def test_source_reports_fence_cancellation():
+    fence = CompressionCommitFence()
+    source = SummaryCancelSource(None, fence)
+
+    assert source.is_set() is False
+    assert fence.try_cancel_before_commit() is True
+    assert source.is_set() is True
+
+
+def test_source_reports_revoked_admission():
+    fence = CompressionCommitFence()
+    source = SummaryCancelSource(threading.Event(), fence)
+
+    assert source.is_set() is False
+    fence.revoke_commit_admission()
+    assert source.is_set() is True
+
+
+def test_source_reports_hard_interrupt_without_fence():
+    event = threading.Event()
+    source = SummaryCancelSource(event, None)
+
+    assert source.is_set() is False
+    event.set()
+    assert source.is_set() is True
+
+
+def test_source_set_forwards_to_the_hard_event():
+    event = threading.Event()
+    source = SummaryCancelSource(event, CompressionCommitFence())
+
+    source.set()
+
+    assert event.is_set() is True
+    assert source.is_set() is True
+
+
+def test_source_survives_broken_probes():
+    class _Boom:
+        def is_set(self):
+            raise RuntimeError("probe exploded")
+
+    class _BoomFence:
+        @property
+        def is_cancelled(self):
+            raise RuntimeError("fence exploded")
+
+    assert SummaryCancelSource(_Boom(), _BoomFence()).is_set() is False
+
+
+# ── End-to-end: the streaming summary actually unwinds ──────────────────────
+
+
+def test_fence_cancel_unwinds_a_streaming_summary(caplog):
+    """The worker returns on cancellation instead of streaming to completion."""
+    compressor = _compressor()
+    agent = _Agent(compressor)
+    fence = CompressionCommitFence()
+    summary_finished = threading.Event()
+    summary_entered = threading.Event()
+
+    def _slow_streaming_summary(*_args, **_kwargs):
+        # Emulate a provider call consumed through the protected seam: the
+        # callback runs on a daemon thread while the compression worker polls
+        # its captured cancel source.
+        def _provider(_kwargs):
+            summary_entered.set()
+            for _ in range(600):  # 60s worth of "streaming"
+                fence.touch_progress()
+                time.sleep(0.1)
+            summary_finished.set()
+            return "SUMMARY THAT ARRIVES FAR TOO LATE"
+
+        return _run_protected_sync_provider_call(_provider, {})
+
+    def _cancel_when_streaming():
+        assert summary_entered.wait(10.0), "summary never dispatched"
+        # Exactly what gateway session hygiene does once it stops waiting.
+        assert fence.try_cancel_before_commit() is True
+
+    canceller = threading.Thread(target=_cancel_when_streaming, daemon=True)
+    canceller.start()
+
+    original = list(_messages())
+    started = time.monotonic()
+    with patch.object(compressor, "_generate_summary", _slow_streaming_summary):
+        with caplog.at_level(logging.INFO, logger="agent.conversation_compression"):
+            compressed, system_prompt = compress_context(
+                agent,
+                list(original),
+                "system prompt",
+                approx_tokens=75_000,
+                force=True,
+                commit_fence=fence,
+            )
+    elapsed = time.monotonic() - started
+    canceller.join(timeout=5.0)
+
+    # The worker unwound on cancellation rather than riding the stream out.
+    assert elapsed < 20.0, f"worker did not unwind promptly ({elapsed:.1f}s)"
+    assert not summary_finished.is_set()
+    # Nothing was committed and the transcript is untouched.
+    assert compressed == original
+    assert system_prompt == "system prompt"
+
+    payload = _telemetry(caplog)
+    assert payload["commit_status"] == "aborted"
+    assert payload["failure_class"] == "commit_fence_cancelled"
+
+
+def test_hard_interrupt_still_reports_explicit_interrupt(caplog):
+    """An operator /stop keeps its own failure class, not the fence's."""
+    compressor = _compressor()
+    agent = _Agent(compressor)
+    agent._hard_interrupt_requested = threading.Event()
+    fence = CompressionCommitFence()
+    summary_entered = threading.Event()
+
+    def _slow_streaming_summary(*_args, **_kwargs):
+        def _provider(_kwargs):
+            summary_entered.set()
+            for _ in range(600):
+                fence.touch_progress()
+                time.sleep(0.1)
+            return "SUMMARY THAT ARRIVES FAR TOO LATE"
+
+        return _run_protected_sync_provider_call(_provider, {})
+
+    def _interrupt_when_streaming():
+        assert summary_entered.wait(10.0), "summary never dispatched"
+        agent._hard_interrupt_requested.set()
+
+    interrupter = threading.Thread(target=_interrupt_when_streaming, daemon=True)
+    interrupter.start()
+
+    with patch.object(compressor, "_generate_summary", _slow_streaming_summary):
+        with caplog.at_level(logging.INFO, logger="agent.conversation_compression"):
+            compress_context(
+                agent,
+                _messages(),
+                "system prompt",
+                approx_tokens=75_000,
+                force=True,
+                commit_fence=fence,
+            )
+    interrupter.join(timeout=5.0)
+
+    payload = _telemetry(caplog)
+    assert payload["commit_status"] == "aborted"
+    assert payload["failure_class"] == "explicit_interrupt"
+
+
+def test_uncancelled_fence_lets_the_summary_commit(caplog):
+    """The new cancel source must not abort a healthy compression."""
+    compressor = _compressor()
+    agent = _Agent(compressor)
+    fence = CompressionCommitFence()
+
+    with patch.object(compressor, "_generate_summary", return_value="SUMMARY"):
+        with caplog.at_level(logging.INFO, logger="agent.conversation_compression"):
+            compressed, _ = compress_context(
+                agent,
+                _messages(),
+                "system prompt",
+                approx_tokens=75_000,
+                force=True,
+                commit_fence=fence,
+            )
+
+    assert compressed is not None
+    payload = _telemetry(caplog)
+    assert payload["commit_status"] == "committed"
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

A cancelled commit fence could not reach the **streaming summary call**. The fence is consulted once *before* summary dispatch (#76354 F6) and never again while the stream runs, and `CompressionCommitFence.try_cancel_before_commit()` — the only cancel path an async host can take without blocking its event loop — has no `cancel_event` parameter to signal with. The sole cancel source wired into `aux_interrupt_protection` was `agent._hard_interrupt_requested`, which no host sets when it merely stops waiting.

So when the gateway session-hygiene host gave up at its 600s total ceiling, the compression worker kept streaming a summary that the fence was **already guaranteed to refuse**:

- minutes of extra paid provider tokens per doomed attempt,
- one of the four bounded compression-pool slots (`_COMPRESS_EXECUTOR_MAX_WORKERS`) held for the whole overrun, so later legitimate compressions hit `pool_saturated`,
- a `commit_fence_cancelled` abort at the end with nothing committed.

In [#96953](https://github.com/NousResearch/hermes-agent/issues/96953) three of these workers overlapped, running **723s / 936s / 870s against a 600s ceiling** — every one of them doing its full summary *after* the host had already walked away.

This PR installs a `SummaryCancelSource` for the summary call: an Event-shaped OR of the hard-interrupt event and the fence's cancellation state. The protected provider seam (`_run_protected_sync_provider_call`) already polls its captured cancel source every 20ms, so the worker now unwinds within one poll of the host giving up — or of a `/stop`, `/restart`, or admission revoke — releasing its durable lease and pool slot and rolling the transcript back exactly as before.

The resulting `AuxiliaryExplicitCancellation` is classified by source: an operator stop stays `explicit_interrupt`, a fence cancellation is reported as `commit_fence_cancelled`.

## Relationship to #96967

Complementary, no overlap — different file, different layer.

| | #96967 (`gateway/run.py`) | this PR (`agent/conversation_compression.py`) |
|---|---|---|
| Layer | hygiene **retry** policy | compression **worker** cancellation |
| Fixes | re-arming after a cancel, wait extension, sibling attempts | the abandoned worker that keeps streaming |
| Issue bullets | "should not be immediately re-attempted", "cap consecutive attempts" | "should not stay demoted behind attempts that have already been aborted" |

#96967 stops the storm of new attempts; this stops the *previous* attempt from burning tokens and pool slots for minutes after it was abandoned. Both are needed: without this change, backing off harder just means the doomed worker runs unobserved.

## Root cause

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#00f0ff', 'mainBkg': '#0a0a16', 'primaryTextColor': '#ffffff', 'primaryBorderColor': '#ff007f', 'lineColor': '#00f0ff'}}}%%
graph TD
    A[Session Hygiene Host] -->|dispatch| B[Compression Worker]
    B -->|streamed tokens| C[Summary Model]
    C -->|touch_progress| A
    A -->|600s ceiling reached| D[try_cancel_before_commit]
    D -->|fence cancelled| E{Reaches the stream?}
    E -->|BEFORE: no cancel event| F[Worker streams on for minutes]
    F --> G[Pool slot held / tokens paid]
    G --> H[Commit refused: zero chunks]
    E -->|AFTER: SummaryCancelSource| I[Unwind within one 20ms poll]
    I --> J[Lease + pool slot released]
    J --> K[Transcript rolled back, no commit]
```

## Verification

Old wiring vs new, same cancelled fence and the same 3s provider callback:

```text
old captured source: None
old elapsed 3.00s                      <- ran to completion, cancel unreachable
new aborted in 0.00s via AuxiliaryExplicitCancellation
```

## Test plan

- [x] `python -m pytest tests/agent/test_compression_fence_cancel_stops_summary.py` — 8 passed (fence cancel, admission revoke, hard interrupt, `set()` forwarding, broken probes, end-to-end unwind of a streaming summary, `explicit_interrupt` still classified as such, healthy compression still commits)
- [x] `python -m pytest tests/agent/test_compression_interrupt_protection.py tests/agent/test_compression_attempt_telemetry.py tests/agent/test_compression_progress.py tests/agent/test_auxiliary_compression_timeout_floor.py` — passed
- [x] Regression baseline: `test_compression_concurrent_fork.py` (33F/13P), `test_compression_worker_isolation_76354.py`, `test_compression_rotation_state.py`, `test_compression_orphan_recovery.py`, `test_compression_fallback_budget.py`, `test_compression_abort_state_reset.py`, `test_compression_in_flight_check.py`, `test_compression_interrupt_demotion_56391.py` — **identical pass/fail counts with and without this change** (these failures reproduce on clean `origin/main` in this environment: `'DaemonThreadPoolExecutor' object has no attribute '_initializer'`)
- [x] `ruff check` clean on both files
- [ ] On a large gateway session: force a hygiene ceiling timeout and confirm the worker's telemetry arrives at ~the ceiling with `failure_class=commit_fence_cancelled` instead of hundreds of seconds later

Fixes #96953

