### PR TITLE
fix(gateway): stale model/provider keys no longer survive session model_config writes (salvage #96748)

### DIFF
--- a/contributors/emails/ahraz.arifuddin@gmail.com
+++ b/contributors/emails/ahraz.arifuddin@gmail.com
@@ -1,0 +1,1 @@
+ahrazzle

--- a/tests/tui_gateway/test_custom_provider_session_persistence.py
+++ b/tests/tui_gateway/test_custom_provider_session_persistence.py
@@ -28,6 +28,7 @@ import types
 from unittest.mock import MagicMock, patch
 
 import hermes_cli.runtime_provider as rp
+from hermes_state import SessionDB
 
 MIMO_URL = "https://token-plan-cn.xiaomimimo.com/v1"
 MIMO_KEY = "sk-mimo-entry-key"
@@ -702,3 +703,147 @@ class TestFollowProfileConfigRuntimeOverrides:
         }
         server._ensure_session_db_row(session)
         assert captured["model_config"].get("follow_profile_config") is None
+
+
+# --- Regression: model column vs model_config desync (stale provider) ----------
+#
+# _runtime_model_config merges the agent's CURRENT identity onto the row's
+# existing model_config. For model/provider it only SET the key when the agent
+# attribute was truthy — so a falsy agent provider (agent inherits the profile
+# default) left the PREVIOUS provider in the JSON while
+# _persist_live_session_runtime updated the model column separately. Resume
+# then read the fresh model from the column but the STALE provider/endpoint
+# from model_config, silently routing the chat to the wrong provider (e.g. a
+# VeniceAI/empero endpoint under a model that should run on Nous). The sibling
+# CLI path (_persist_model_switch_to_session) already deletes stale keys with
+# or-None; the gateway writer must drop them too, not merely omit the write.
+
+
+def _agent_like(model="deepseek/deepseek-v4-flash-0731", provider=""):
+    return types.SimpleNamespace(
+        model=model,
+        provider=provider,
+        base_url="",
+        api_mode="",
+        reasoning_config=None,
+        service_tier=None,
+    )
+
+
+class TestRuntimeModelConfigDropsStaleKeys:
+    def test_falsy_provider_drops_stale_existing_provider(self):
+        """Agent inherits the profile default (empty provider): the previously
+        persisted provider must NOT survive the merge."""
+        from tui_gateway.server import _runtime_model_config
+
+        existing = {
+            "model": "deepseek/deepseek-v4-flash-0731",
+            "provider": "stealth-ox-alpha",  # stale from an earlier state
+            "base_url": "https://api.venice.ai/api/v1",
+            "api_mode": "chat_completions",
+        }
+        config = _runtime_model_config(_agent_like(), existing)
+
+        assert config["model"] == "deepseek/deepseek-v4-flash-0731"
+        assert "provider" not in config, config
+        assert "base_url" not in config, config
+        assert "api_mode" not in config, config
+
+    def test_falsy_model_drops_stale_existing_model(self):
+        """Mirror the provider rule: an empty agent model cannot keep the row's
+        old model as its own."""
+        from tui_gateway.server import _runtime_model_config
+
+        agent = _agent_like(model="", provider="nous")
+        existing = {"model": "meituan/longcat-2.0:free", "provider": "nous"}
+        config = _runtime_model_config(agent, existing)
+
+        assert "model" not in config, config
+        assert config["provider"] == "nous"
+
+    def test_truthy_provider_overwrites_stale_existing(self):
+        from tui_gateway.server import _runtime_model_config
+
+        existing = {
+            "model": "deepseek/deepseek-v4-flash-0731",
+            "provider": "stealth-ox-alpha",
+            "base_url": "https://api.venice.ai/api/v1",
+        }
+        config = _runtime_model_config(_agent_like(provider="nous"), existing)
+
+        assert config["provider"] == "nous"
+        assert config["model"] == "deepseek/deepseek-v4-flash-0731"
+
+    def test_resume_overrides_get_no_stale_provider(self):
+        """End-to-end shape: a config merged from an empty-provider agent must
+        NOT resurrect the stale endpoint on resume — the chat falls back to
+        the row's billing provider (the profile default) instead of the stale
+        VeniceAI/empero route."""
+        from tui_gateway.server import (
+            _runtime_model_config,
+            _stored_session_runtime_overrides,
+        )
+
+        existing = {
+            "model": "deepseek/deepseek-v4-flash-0731",
+            "provider": "stealth-ox-alpha",
+            "base_url": "https://api.venice.ai/api/v1",
+        }
+        config = _runtime_model_config(_agent_like(), existing)
+        row = {
+            "model": "deepseek/deepseek-v4-flash-0731",
+            "model_config": json.dumps(config),
+            "billing_provider": "nous",
+        }
+        overrides = _stored_session_runtime_overrides(row)
+
+        assert overrides["model_override"]["model"] == "deepseek/deepseek-v4-flash-0731"
+        # The stale endpoint identity is gone; resume routes through the
+        # billing fallback to the profile's real provider.
+        assert overrides["model_override"]["provider"] == "nous"
+        assert overrides["provider_override"] == "nous"
+
+    def test_real_db_persist_heals_desynced_row(self, tmp_path, monkeypatch):
+        """A row already desynced (fresh model column + stale model_config
+        provider) self-heals on the next live metadata persist."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session(session_id="desync1", source="desktop", model="old-model")
+        db.update_session_meta(
+            "desync1",
+            json.dumps(
+                {
+                    "model": "deepseek/deepseek-v4-flash-0731",
+                    "provider": "stealth-ox-alpha",
+                    "base_url": "https://api.venice.ai/api/v1",
+                }
+            ),
+            model="deepseek/deepseek-v4-flash-0731",
+        )
+
+        from tui_gateway.server import _runtime_model_config
+
+        row = db.get_session("desync1")
+        assert row is not None
+        existing = json.loads(row["model_config"])
+        merged = _runtime_model_config(_agent_like(), existing)
+        db.update_session_meta("desync1", json.dumps(merged), model="deepseek/deepseek-v4-flash-0731")
+
+        healed_row = db.get_session("desync1")
+        assert healed_row is not None
+        healed = json.loads(healed_row["model_config"])
+        assert healed["model"] == "deepseek/deepseek-v4-flash-0731"
+        assert "provider" not in healed, healed
+        assert "base_url" not in healed, healed
+
+    def test_existing_none_returns_only_agent_identity(self):
+        """First write (no existing row): the merge starts from an empty dict
+        and reflects only the agent's current identity — no stale keys, no
+        crash on the None existing_config."""
+        from tui_gateway.server import _runtime_model_config
+
+        config = _runtime_model_config(_agent_like(provider="nous"), None)
+
+        assert config == {"model": "deepseek/deepseek-v4-flash-0731", "provider": "nous"}
+
+

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5428,6 +5428,20 @@ def _stored_session_runtime_overrides(row: dict | None) -> dict:
 
 
 def _runtime_model_config(agent, existing: dict | None = None) -> dict:
+    """Merge the agent's CURRENT runtime identity onto an existing config.
+
+    ``existing`` is the row's previously-persisted ``model_config`` JSON (may
+    be absent on first write). The returned dict must mirror the agent's live
+    state: falsy agent attributes DELETE the corresponding key rather than
+    merely omit the write, so a stale value from an earlier session state can
+    never survive into the merged config. Keeping stale values here is what
+    desynced the ``sessions.model`` column (fresh) from ``model_config``
+    (stale provider/endpoint): ``_persist_live_session_runtime`` writes the
+    model column separately, and on resume ``_stored_session_runtime_overrides``
+    reads provider/endpoint from this JSON — so a stale provider would silently
+    route the resumed chat to the wrong endpoint while the model column claimed
+    the new one.
+    """
     config = dict(existing or {})
     model = str(getattr(agent, "model", "") or "").strip()
     provider = str(getattr(agent, "provider", "") or "").strip()
@@ -5438,6 +5452,8 @@ def _runtime_model_config(agent, existing: dict | None = None) -> dict:
 
     if model:
         config["model"] = model
+    else:
+        config.pop("model", None)
     if provider:
         if provider.strip().lower() == "custom":
             # ``agent.provider`` is the RESOLVED provider, and for any named
@@ -5468,6 +5484,8 @@ def _runtime_model_config(agent, existing: dict | None = None) -> dict:
                     "custom provider identity lookup failed", exc_info=True
                 )
         config["provider"] = provider
+    else:
+        config.pop("provider", None)
     if base_url:
         config["base_url"] = base_url
     else:


### PR DESCRIPTION
Stale `model`/`provider` keys in a session row's `model_config` no longer survive gateway persist writes — a resumed chat can no longer be silently routed to the wrong (but still-routable) provider.

Salvage of #96748 onto current `main` (rebased over the #97008 resume-side changes).

## Problem

`tui_gateway/server.py::_runtime_model_config` merges the agent's current identity onto the row's existing `model_config` JSON. For `model` and `provider` it only **set** the key when the agent attribute was truthy — while `base_url`/`api_mode`/`reasoning_config`/`service_tier` already deleted stale values when falsy. So an agent rebuilt with an empty provider (inheriting the profile default) left the PREVIOUS provider/endpoint in the JSON while `_persist_live_session_runtime` updated the `model` column separately. On resume, `_stored_session_runtime_overrides` read the fresh model from the column but the STALE provider from `model_config` — silently routing the chat to the wrong endpoint (e.g. a VeniceAI route under a model that should run on the profile default).

Note this is complementary to #97008 (merged as 547f4c952): that fixed the **resume/read side** for *non-routable* providers. This PR fixes the **write side**, where the stale key can name a still-routable but WRONG provider — a case #97008's routability check does not (and cannot) drop.

## Changes

- `_runtime_model_config`: falsy agent `model`/`provider` now DELETE the corresponding key from the merged config (`config.pop(...)`), mirroring the or-None semantics the CLI's `_persist_model_switch_to_session` already uses. Existing desynced rows self-heal on the next live metadata persist.
- Docstring documenting the merge contract (falsy attributes delete, never merely omit).
- 6 regression tests in `tests/tui_gateway/test_custom_provider_session_persistence.py` (`TestRuntimeModelConfigDropsStaleKeys`): falsy provider drops stale provider, falsy model drops stale model, truthy provider overwrites, end-to-end resume override falls back to billing provider, real-SQLite desynced-row heal, and first-write (`existing=None`) shape.
- `contributors/emails/ahraz.arifuddin@gmail.com` → `ahrazzle` attribution mapping.

## Validation

| Check | Result |
| --- | --- |
| Premise on current main | Confirmed live — `_runtime_model_config` on `origin/main` still only sets `model`/`provider` when truthy (lines 5439–5470), no `pop` on the falsy path |
| Sabotage A/B — fix reverted, tests kept | 4 new tests **FAIL** (`test_falsy_provider_drops_stale_existing_provider`, `test_falsy_model_drops_stale_existing_model`, `test_resume_overrides_get_no_stale_provider`, `test_real_db_persist_heals_desynced_row`) |
| Fix restored | `tests/tui_gateway/test_custom_provider_session_persistence.py` — **34 passed** |
| Full targeted run (incl. #97008's live suite) | `test_custom_provider_session_persistence.py` + `test_stale_provider_resume_live.py` — **37 passed** |
| Stale-base gate | 0 commits behind `origin/main`; diff touches only the 3 files above |

## Credit

Fix and regression tests by **@ahrazzle** (#96748) — cherry-picked with authorship preserved; test-file conflict with the post-#97008 classes on main resolved keeping both sides.

## Infographic

![Stale provider keys dropped — gateway session model_config fix](https://v3b.fal.media/files/b/0aa82419/cjob-PevROoOF2FT3ssZB_Y0pg8UsU.png)
