### PR TITLE
fix(agent): 'media exceeds size limit' 400s now shrink-and-retry instead of aborting (#76039, salvage #76056)

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -284,6 +284,16 @@ _IMAGE_TOO_LARGE_PATTERNS = [
     "image dimensions exceed",  # Anthropic: "image dimensions exceed max allowed size: 8000 pixels"
     "dimensions exceed max allowed size",  # Anthropic dimension-cap (wording variant)
     "max allowed size: 8000",  # Anthropic dimension-cap (explicit pixel ceiling)
+    # Vendors that reject the same oversized image without using the word
+    # "image".  MiniMax's Anthropic-compatible endpoint returns
+    # "media exceeds size limit: max 10485760 bytes (2013)" for a native
+    # image part above its 10 MB ceiling (#76039).  Matched on the "media"
+    # fragment to mirror "image exceeds" above and catch reworded variants.
+    # A non-image media rejection (audio/video) that lands here is safe: the
+    # shrink pass finds no image parts, returns False, and the caller
+    # surfaces the original error unchanged.
+    "media exceeds",
+    "media too large",
     # "request_too_large" on a request known to contain an image → image is
     # the likely culprit; we still try the shrink path before giving up.
 ]

--- a/tests/run_agent/test_image_shrink_recovery.py
+++ b/tests/run_agent/test_image_shrink_recovery.py
@@ -53,8 +53,39 @@ class TestImageTooLargeClassification:
         assert result.reason == FailoverReason.image_too_large
         assert result.retryable is True
 
+    def test_minimax_400_media_exceeds_message(self):
+        """A vendor that rejects an oversized image without the word "image".
 
+        MiniMax's Anthropic-compatible endpoint returns this for a native
+        image part over its 10 MB ceiling.  It used to fall through to
+        _REQUEST_VALIDATION_PATTERNS and classify as format_error /
+        non-retryable, which skipped shrink recovery and left the oversized
+        part baked into replayed history — every later turn re-sent the same
+        bytes and failed identically (#76039).
+        """
+        err = _FakeApiError(
+            status_code=400,
+            message="media exceeds size limit: max 10485760 bytes (2013)",
+            body={
+                "type": "error",
+                "error": {
+                    "type": "invalid_request_error",
+                    "message": "media exceeds size limit: max 10485760 bytes (2013)",
+                },
+            },
+        )
+        result = classify_api_error(err, provider="minimax", model="MiniMax-M3")
+        assert result.reason == FailoverReason.image_too_large
+        assert result.retryable is True
 
+    def test_unrelated_400_still_not_image_too_large(self):
+        """The new "media" patterns must not widen into ordinary 400s."""
+        err = _FakeApiError(
+            status_code=400,
+            message="messages: unexpected role \"tool\" at index 3",
+        )
+        result = classify_api_error(err, provider="minimax", model="MiniMax-M3")
+        assert result.reason != FailoverReason.image_too_large
 
 
 


### PR DESCRIPTION
## Summary

MiniMax 400s worded `media exceeds size limit: max 10485760 bytes (2013)` are now classified as `FailoverReason.image_too_large` (retryable), so the image-shrink recovery path fires instead of a non-retryable `format_error` abort that left the session permanently bricked. Salvages #76056 by @MaheshBhushan onto current main. Fixes #76039.

## Changes

- `agent/error_classifier.py` — add `"media exceeds"` and `"media too large"` to `_IMAGE_TOO_LARGE_PATTERNS`, mirroring the existing `"image exceeds"` fragment match. A non-image media rejection routed here is safe: the shrink pass finds no image parts, returns False, and the caller surfaces the original error unchanged. The `image_corrupt`-before-`image_too_large` precedence added by #97059 is preserved untouched (new patterns only extend the too-large list, which is checked second).
- `tests/run_agent/test_image_shrink_recovery.py` — regression test for the MiniMax wording plus a guard test that ordinary 400s do not widen into the shrink path.
- Not widened to `tools/vision_tools.py`: `_is_image_size_error` already matches this wording via its `"exceeds"` and `"size limit"` hints, so no change is needed there.

## Validation

| Check | Result |
| --- | --- |
| A/B before (origin/main classifier, exact #76039 wording) | `format_error` / `retryable=False` |
| A/B after (this branch) | `image_too_large` / `retryable=True` |
| Precedence: compound "Invalid PNG image; media exceeds size limit…" | still `image_corrupt` (corrupt-before-too-large intact) |
| `pytest tests/agent/test_error_classifier.py tests/run_agent/test_image_shrink_recovery.py -o addopts= -q` | 137 passed |
| Stale-base gate (`rev-list merge-base..origin/main`) | 0 |
| Attribution audit (`scripts/audit_pr_attribution.py --fix`) | all emails mapped |

**Live repro:** real `classify_api_error` called with a fake 400 (`status_code=400`, body `invalid_request_error`) carrying the exact MiniMax message from #76039 — misclassified as non-retryable `format_error` on origin/main, correctly `image_too_large`/retryable on this branch, with the corrupt-vs-too-large precedence verified on a compound message.

## Infographic

![infographic](https://v3b.fal.media/files/b/0aa8244c/ifBKI13txN_9b4I3M2Moz_BqmQKrl5.png)

