### PR TITLE
fix(install): Windows installs no longer die at npm ci on an engine-blocked system npm (salvage #82033)

### DIFF
--- a/.github/workflows/installer-tests.yml
+++ b/.github/workflows/installer-tests.yml
@@ -36,3 +36,11 @@ jobs:
       - name: 8.3 short-path normalization (Windows PowerShell 5.1)
         shell: powershell
         run: powershell -NoProfile -ExecutionPolicy Bypass -File scripts/tests/test-install-ps1-longpath.ps1
+
+      - name: System Node and npm compatibility (pwsh 7)
+        shell: pwsh
+        run: pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/tests/test-install-ps1-node-compatibility.ps1
+
+      - name: System Node and npm compatibility (Windows PowerShell 5.1)
+        shell: powershell
+        run: powershell -NoProfile -ExecutionPolicy Bypass -File scripts/tests/test-install-ps1-node-compatibility.ps1

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -934,6 +934,88 @@ function Get-NpmRange {
     return $NpmRange
 }
 
+# Convert the numeric core of an npm version or range operand into a stable
+# three-component System.Version. npm reports semantic versions, but the
+# installer only needs the numeric core for the comparator ranges authored in
+# package.json (for example, <11.10.0 || >=11.17.0).
+function ConvertTo-NpmVersion {
+    param([string]$Version)
+
+    if (-not $Version) { return $null }
+
+    $core = ($Version.Trim() -replace '^v', '' -replace '-.*$', '')
+    $parts = @($core -split '\.')
+    if ($parts.Count -lt 1 -or $parts.Count -gt 3) { return $null }
+    foreach ($part in $parts) {
+        if ($part -notmatch '^\d+$') { return $null }
+    }
+    while ($parts.Count -lt 3) { $parts += '0' }
+
+    try {
+        return [version]($parts -join '.')
+    } catch {
+        return $null
+    }
+}
+
+# Evaluate the comparator-only npm ranges used by the root manifest and the
+# pre-clone fallback. Alternatives are separated with || and each alternative
+# may contain one or more whitespace-separated <, <=, >, or >= comparators.
+# Unknown range syntax fails closed so an incompatible system npm cannot reach
+# npm ci and fail later with EBADENGINE.
+function Test-NpmVersionOk {
+    param(
+        [string]$Version,
+        [string]$Range = (Get-NpmRange)
+    )
+
+    $actual = ConvertTo-NpmVersion $Version
+    if (-not $actual -or -not $Range) { return $false }
+
+    foreach ($alternative in @($Range -split '\s*\|\|\s*')) {
+        $clause = $alternative.Trim()
+        if (-not $clause) { continue }
+
+        $comparators = [regex]::Matches(
+            $clause,
+            '(?:^|\s)(<=|>=|<|>)\s*(\d+(?:\.\d+){0,2})(?=\s|$)'
+        )
+        if ($comparators.Count -eq 0) { continue }
+
+        $remainder = [regex]::Replace(
+            $clause,
+            '(?:^|\s)(?:<=|>=|<|>)\s*\d+(?:\.\d+){0,2}(?=\s|$)',
+            ''
+        ).Trim()
+        if ($remainder) { continue }
+
+        $matchesClause = $true
+        foreach ($comparator in $comparators) {
+            $target = ConvertTo-NpmVersion $comparator.Groups[2].Value
+            if (-not $target) {
+                $matchesClause = $false
+                break
+            }
+
+            $matchesComparator = switch ($comparator.Groups[1].Value) {
+                '<'  { $actual -lt $target }
+                '<=' { $actual -le $target }
+                '>'  { $actual -gt $target }
+                '>=' { $actual -ge $target }
+                default { $false }
+            }
+            if (-not $matchesComparator) {
+                $matchesClause = $false
+                break
+            }
+        }
+
+        if ($matchesClause) { return $true }
+    }
+
+    return $false
+}
+
 # Upgrade the Hermes-managed Node tree's bundled npm into $NpmRange.
 #
 # The nodejs.org zip ships whatever npm that Node major bundles -- Node 26.5.1
@@ -1587,19 +1669,54 @@ function Test-NodeVersionOk {
     return ($v.Major -gt 22)
 }
 
+# Accept a system Node only when its companion npm also satisfies the same
+# range used to provision the Hermes-managed tree. Keeping this probe separate
+# lets the initial PATH check and the post-winget check share one authority.
+function Test-SystemNodeReady {
+    if (-not (Get-Command node -ErrorAction SilentlyContinue)) { return $false }
+
+    $version = node --version
+    if (-not (Test-NodeVersionOk $version)) {
+        Write-Warn "Node.js $version is too old (Hermes requires Node >=22.22.0)"
+        return $false
+    }
+
+    Ensure-NodeExeOnPath | Out-Null
+    $npmRange = Get-NpmRange
+    $npmCmd = Get-Command npm.cmd -ErrorAction SilentlyContinue
+    if (-not $npmCmd) {
+        $npmCmd = Get-Command npm -ErrorAction SilentlyContinue
+    }
+
+    $npmVersion = $null
+    if ($npmCmd) {
+        try {
+            $npmVersion = (& $npmCmd --version 2>$null | Select-Object -First 1)
+        } catch { }
+    }
+
+    if ($npmVersion -and (Test-NpmVersionOk $npmVersion $npmRange)) {
+        Write-Success "Node.js $version with npm $npmVersion found"
+        return $true
+    }
+
+    if ($npmVersion) {
+        Write-Warn "Node.js $version uses npm $npmVersion, which does not satisfy Hermes requirement $npmRange"
+    } else {
+        Write-Warn "Node.js $version was found, but npm is missing or could not report its version"
+    }
+    return $false
+}
+
 function Test-Node {
     Write-Info "Checking Node.js (for browser tools)..."
 
-    if (Get-Command node -ErrorAction SilentlyContinue) {
-        $version = node --version
-        if (Test-NodeVersionOk $version) {
-            Ensure-NodeExeOnPath | Out-Null
-            Write-Success "Node.js $version found"
-            $script:HasNode = $true
-            return $true
-        }
-        Write-Warn "Node.js $version is too old (Hermes requires Node >=26)"
+    if (Test-SystemNodeReady) {
+        $script:HasNode = $true
+        return $true
     }
+
+    Write-Info "Using a Hermes-managed Node.js installation instead..."
 
     # Prefer a Hermes-managed Node from a previous run over a too-old system one.
     $managedNode = "$HermesHome\node\node.exe"
@@ -1774,9 +1891,7 @@ function Test-Node {
             $ErrorActionPreference = $prevEAP
             # Refresh PATH
             $env:Path = [Environment]::GetEnvironmentVariable("Path", "User") + ";" + [Environment]::GetEnvironmentVariable("Path", "Machine")
-            if (Get-Command node -ErrorAction SilentlyContinue) {
-                $version = node --version
-                Write-Success "Node.js $version installed via winget"
+            if (Test-SystemNodeReady) {
                 $script:HasNode = $true
                 return $true
             }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1676,12 +1676,13 @@ function Test-SystemNodeReady {
     if (-not (Get-Command node -ErrorAction SilentlyContinue)) { return $false }
 
     $version = node --version
-    if (-not (Test-NodeVersionOk $version)) {
+    if (Test-NodeVersionOk $version) {
+        Ensure-NodeExeOnPath | Out-Null
+    } else {
         Write-Warn "Node.js $version is too old (Hermes requires Node >=22.22.0)"
         return $false
     }
 
-    Ensure-NodeExeOnPath | Out-Null
     $npmRange = Get-NpmRange
     $npmCmd = Get-Command npm.cmd -ErrorAction SilentlyContinue
     if (-not $npmCmd) {

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -395,10 +395,9 @@ $NodeVersion = "22"
 # The npm range the root package.json pins in `engines.npm`.  A constant rather
 # than a manifest read like the POSIX side does: Test-Node runs BEFORE the repo
 # is cloned, so there is usually no package.json on disk yet (and none at all
-# when install.ps1 is piped straight from the web).  Get-NpmRange prefers the
-# manifest whenever it does exist, so a drifted constant self-corrects on any
-# run against an existing checkout.
-$NpmRange = ">=12.0.0"
+# when install.ps1 is piped straight from the web). Keep this fallback in sync
+# with package.json; Get-NpmRange prefers the manifest once a checkout exists.
+$NpmRange = "<11.10.0 || >=11.17.0"
 
 # Stage-protocol version.  Bumped only for genuinely breaking changes to the
 # manifest schema, stage-name set semantics, or stdout JSON shape.  Adding a
@@ -1016,14 +1015,11 @@ function Test-NpmVersionOk {
     return $false
 }
 
-# Upgrade the Hermes-managed Node tree's bundled npm into $NpmRange.
-#
-# The nodejs.org zip ships whatever npm that Node major bundles -- Node 26.5.1
-# bundles npm 11.17.0, one minor below the root package.json's own
-# `engines.npm` floor of >=12.  The repo .npmrc sets `engine-strict=true`, so
-# that is fatal rather than a warning and a brand-new install dies at the first
-# `npm ci` with EBADENGINE.  Provision the right npm here instead of reacting
-# to the failure later.
+# Upgrade the Hermes-managed Node tree's bundled npm into $NpmRange when
+# needed. Managed Node trees survive updates, so their bundled npm can drift
+# outside a newer root package.json engine range. The repo .npmrc sets
+# `engine-strict=true`, making that mismatch fatal at the first `npm ci`.
+# Provision the right npm here instead of reacting to EBADENGINE later.
 #
 # Three details are load-bearing, mirroring _nb_ensure_bundled_npm_range in
 # scripts/lib/node-bootstrap.sh and upgrade_managed_npm in
@@ -1045,17 +1041,11 @@ function Update-ManagedNpm {
     $range = Get-NpmRange
 
     # Skip the network round-trip when the bundled npm already satisfies the
-    # range.  Only the ">=N" shape we actually author is parsed; anything more
-    # exotic falls through to letting npm itself decide.
-    if ($range -match '^>=(\d+)') {
-        $want = [int]$Matches[1]
-        try {
-            $have = (& $npmCmd --version 2>$null)
-            if ($have -match '^(\d+)') {
-                if ([int]$Matches[1] -ge $want) { return $true }
-            }
-        } catch { }
-    }
+    # same range used by the system-Node acceptance gate.
+    try {
+        $have = (& $npmCmd --version 2>$null | Select-Object -First 1)
+        if ($have -and (Test-NpmVersionOk $have $range)) { return $true }
+    } catch { }
 
     # In-app updates run while the desktop app's Node processes are alive.
     # The managed npm lives inside the very tree they execute from, so an
@@ -4003,7 +3993,7 @@ function Install-Desktop {
 
     # Always re-resolve Node here. Stages run in separate PowerShell processes,
     # so $script:HasNode from Stage-Node isn't visible; more importantly Test-Node
-    # enforces the build floor (Node >=26) and prepends the Hermes-managed
+    # enforces the build floor (Node >=22.22.0) and prepends the Hermes-managed
     # Node to PATH, so the build never runs on a too-old system Node -- the cause
     # of the opaque "Build desktop app ... exit code 1" failure (Vite crashes on
     # old Node).
@@ -4917,6 +4907,13 @@ function Main {
 # All branches funnel through one try/catch so errors don't kill an `irm |
 # iex` PowerShell session, and so failures in stage-driver mode produce a
 # structured JSON error frame instead of a bare exception.
+
+# Dot-sourcing loads the installer's real functions for isolated behavioral
+# tests without running an install. Normal script and `irm | iex` entry points
+# are unchanged.
+if ($MyInvocation.InvocationName -eq ".") {
+    return
+}
 
 try {
     if ($Ensure -ne "") {

--- a/scripts/tests/test-install-ps1-node-compatibility.ps1
+++ b/scripts/tests/test-install-ps1-node-compatibility.ps1
@@ -1,43 +1,19 @@
 # Behavioral tests for install.ps1 system Node/npm compatibility selection.
 #
-# The installer itself is not executed. The real shipped functions are lifted
-# through the PowerShell AST, then external commands and downloads are replaced
-# with deterministic in-process stubs. This exercises the actual range parser
-# and Test-Node acceptance gate without changing PATH, installing software, or
-# touching the user's Hermes home.
-
-Set-StrictMode -Version Latest
-$ErrorActionPreference = 'Stop'
+# The installer is dot-sourced without running its entry point, then external
+# commands and downloads are replaced with deterministic in-process stubs.
+# This exercises the shipped range parser and Test-Node acceptance gate without
+# changing PATH, installing software, or touching the user's Hermes home.
 
 $repoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path))
 $installScript = Join-Path $repoRoot 'scripts\install.ps1'
-$tokens = $null
-$parseErrors = $null
-$ast = [System.Management.Automation.Language.Parser]::ParseFile(
-    $installScript, [ref]$tokens, [ref]$parseErrors
-)
-if ($parseErrors.Count -gt 0) {
-    throw "install.ps1 has parse errors: $($parseErrors -join '; ')"
-}
+$testRoot = Join-Path $env:TEMP ("hermes-node-compatibility-test-" + [Guid]::NewGuid().ToString('N'))
+$HermesHome = Join-Path $testRoot 'home'
+$InstallDir = Join-Path $testRoot 'missing-checkout'
+. $installScript -HermesHome $HermesHome -InstallDir $InstallDir
 
-foreach ($name in @(
-    'ConvertTo-NpmVersion',
-    'Test-NpmVersionOk',
-    'Test-NodeVersionOk',
-    'Test-SystemNodeReady',
-    'Test-Node'
-)) {
-    $fn = $ast.FindAll(
-        {
-            param($node)
-            $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
-            $node.Name -eq $name
-        },
-        $true
-    ) | Select-Object -First 1
-    if (-not $fn) { throw "$name not found in install.ps1" }
-    . ([scriptblock]::Create($fn.Extent.Text))
-}
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
 
 $script:Failures = 0
 function Assert-Equal {
@@ -53,26 +29,25 @@ function Assert-Equal {
 }
 
 Write-Host '-- npm range evaluation --'
-$supportedRange = '<11.10.0 || >=11.17.0'
-Assert-Equal $true (Test-NpmVersionOk '11.9.9' $supportedRange) 'lower alternative is accepted'
-Assert-Equal $false (Test-NpmVersionOk '11.10.0' $supportedRange) 'excluded band starts at 11.10.0'
-Assert-Equal $false (Test-NpmVersionOk '11.16.0' $supportedRange) 'reported npm 11.16.0 is rejected'
-Assert-Equal $true (Test-NpmVersionOk '11.17.0' $supportedRange) 'upper alternative starts at 11.17.0'
-Assert-Equal $false (Test-NpmVersionOk '11.17.0' '>=12.0.0') 'pre-clone npm floor rejects 11.x'
-Assert-Equal $true (Test-NpmVersionOk '12.0.0' '>=12.0.0') 'pre-clone npm floor accepts 12.0.0'
-Assert-Equal $false (Test-NpmVersionOk 'not-a-version' $supportedRange) 'malformed version fails closed'
+$supportedRange = Get-NpmRange
+Assert-Equal '<11.10.0 || >=11.17.0' $supportedRange 'fresh-install fallback matches the supported npm range'
+Assert-Equal $true (Test-NpmVersionOk '10.9.8') 'bundled npm 10.9.8 is accepted before clone'
+Assert-Equal $true (Test-NpmVersionOk '11.9.9') 'lower alternative is accepted'
+Assert-Equal $false (Test-NpmVersionOk '11.10.0') 'excluded band starts at 11.10.0'
+Assert-Equal $false (Test-NpmVersionOk '11.16.0') 'reported npm 11.16.0 is rejected'
+Assert-Equal $true (Test-NpmVersionOk '11.17.0') 'upper alternative starts at 11.17.0'
+Assert-Equal $false (Test-NpmVersionOk 'not-a-version') 'malformed version fails closed'
 Assert-Equal $false (Test-NpmVersionOk '12.0.0' '^12.0.0') 'unsupported range syntax fails closed'
 
-# Controlled command surface used by the lifted Test-Node function.
+# Controlled command surface used by the real Test-Node function.
 $script:FakeNpmAvailable = $true
 $script:FakeNpmVersion = '11.16.0'
-$script:FakeNpmRange = $supportedRange
+$script:FakeNodeVersion = 'v24.18.0'
 $script:DownloadAttempts = 0
 $script:HasNode = $null
-$HermesHome = Join-Path $env:TEMP ("hermes-node-compatibility-test-" + [Guid]::NewGuid().ToString('N'))
 $NodeVersion = '22'
 
-function node { 'v24.18.0' }
+function node { $script:FakeNodeVersion }
 function npm.cmd { $script:FakeNpmVersion }
 function Get-Command {
     [CmdletBinding()]
@@ -93,7 +68,6 @@ function Get-Command {
         default { return $null }
     }
 }
-function Get-NpmRange { $script:FakeNpmRange }
 function Ensure-NodeExeOnPath { $true }
 function Get-WindowsArch { 'x64' }
 function Invoke-WebRequest {
@@ -105,8 +79,13 @@ function Write-Warn { param([string]$Message) }
 function Write-Success { param([string]$Message) }
 
 function Invoke-SystemNodeProbe {
-    param([string]$NpmVersion, [bool]$NpmAvailable = $true)
+    param(
+        [string]$NodeVersion,
+        [string]$NpmVersion,
+        [bool]$NpmAvailable = $true
+    )
 
+    $script:FakeNodeVersion = $NodeVersion
     $script:FakeNpmVersion = $NpmVersion
     $script:FakeNpmAvailable = $NpmAvailable
     $script:DownloadAttempts = 0
@@ -120,17 +99,36 @@ function Invoke-SystemNodeProbe {
 
 Write-Host ''
 Write-Host '-- system Node acceptance --'
-$result = Invoke-SystemNodeProbe '11.17.0'
+$result = Invoke-SystemNodeProbe 'v24.18.0' '11.17.0'
 Assert-Equal $true $result.HasNode 'compatible system Node/npm is accepted'
 Assert-Equal 0 $result.DownloadAttempts 'compatible system npm avoids managed download'
 
-$result = Invoke-SystemNodeProbe '11.16.0'
+$result = Invoke-SystemNodeProbe 'v22.22.0' '10.9.8'
+Assert-Equal $true $result.HasNode 'minimum Node with bundled npm is accepted'
+Assert-Equal 0 $result.DownloadAttempts 'bundled npm avoids managed download'
+
+$result = Invoke-SystemNodeProbe 'v24.18.0' '11.16.0'
 Assert-Equal $false $result.HasNode 'incompatible system npm is not accepted'
 Assert-Equal 1 $result.DownloadAttempts 'incompatible system npm falls through to managed Node'
 
-$result = Invoke-SystemNodeProbe '' $false
+$result = Invoke-SystemNodeProbe 'v24.18.0' '' $false
 Assert-Equal $false $result.HasNode 'missing system npm is not accepted'
 Assert-Equal 1 $result.DownloadAttempts 'missing system npm falls through to managed Node'
+
+Write-Host ''
+Write-Host '-- managed npm reuse --'
+$managedDir = Join-Path $testRoot 'managed-node'
+New-Item -ItemType Directory -Force -Path $managedDir | Out-Null
+$managedNpm = Join-Path $managedDir 'npm.cmd'
+@'
+@echo off
+if "%~1"=="--version" (
+  echo 10.9.8
+  exit /b 0
+)
+exit /b 42
+'@ | Set-Content -LiteralPath $managedNpm -Encoding Ascii
+Assert-Equal $true (Update-ManagedNpm $managedDir) 'compatible managed npm skips the upgrade command'
 
 if ($script:Failures -gt 0) {
     Write-Host ''
@@ -140,3 +138,7 @@ if ($script:Failures -gt 0) {
 
 Write-Host ''
 Write-Host 'all assertions passed'
+
+if (Test-Path $testRoot) {
+    Remove-Item -LiteralPath $testRoot -Recurse -Force
+}

--- a/scripts/tests/test-install-ps1-node-compatibility.ps1
+++ b/scripts/tests/test-install-ps1-node-compatibility.ps1
@@ -1,0 +1,142 @@
+# Behavioral tests for install.ps1 system Node/npm compatibility selection.
+#
+# The installer itself is not executed. The real shipped functions are lifted
+# through the PowerShell AST, then external commands and downloads are replaced
+# with deterministic in-process stubs. This exercises the actual range parser
+# and Test-Node acceptance gate without changing PATH, installing software, or
+# touching the user's Hermes home.
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path))
+$installScript = Join-Path $repoRoot 'scripts\install.ps1'
+$tokens = $null
+$parseErrors = $null
+$ast = [System.Management.Automation.Language.Parser]::ParseFile(
+    $installScript, [ref]$tokens, [ref]$parseErrors
+)
+if ($parseErrors.Count -gt 0) {
+    throw "install.ps1 has parse errors: $($parseErrors -join '; ')"
+}
+
+foreach ($name in @(
+    'ConvertTo-NpmVersion',
+    'Test-NpmVersionOk',
+    'Test-NodeVersionOk',
+    'Test-SystemNodeReady',
+    'Test-Node'
+)) {
+    $fn = $ast.FindAll(
+        {
+            param($node)
+            $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+            $node.Name -eq $name
+        },
+        $true
+    ) | Select-Object -First 1
+    if (-not $fn) { throw "$name not found in install.ps1" }
+    . ([scriptblock]::Create($fn.Extent.Text))
+}
+
+$script:Failures = 0
+function Assert-Equal {
+    param($Expected, $Actual, [string]$Label)
+    if ($Expected -ceq $Actual) {
+        Write-Host "PASS: $Label"
+    } else {
+        Write-Host "FAIL: $Label"
+        Write-Host "  expected: [$Expected]"
+        Write-Host "  actual:   [$Actual]"
+        $script:Failures++
+    }
+}
+
+Write-Host '-- npm range evaluation --'
+$supportedRange = '<11.10.0 || >=11.17.0'
+Assert-Equal $true (Test-NpmVersionOk '11.9.9' $supportedRange) 'lower alternative is accepted'
+Assert-Equal $false (Test-NpmVersionOk '11.10.0' $supportedRange) 'excluded band starts at 11.10.0'
+Assert-Equal $false (Test-NpmVersionOk '11.16.0' $supportedRange) 'reported npm 11.16.0 is rejected'
+Assert-Equal $true (Test-NpmVersionOk '11.17.0' $supportedRange) 'upper alternative starts at 11.17.0'
+Assert-Equal $false (Test-NpmVersionOk '11.17.0' '>=12.0.0') 'pre-clone npm floor rejects 11.x'
+Assert-Equal $true (Test-NpmVersionOk '12.0.0' '>=12.0.0') 'pre-clone npm floor accepts 12.0.0'
+Assert-Equal $false (Test-NpmVersionOk 'not-a-version' $supportedRange) 'malformed version fails closed'
+Assert-Equal $false (Test-NpmVersionOk '12.0.0' '^12.0.0') 'unsupported range syntax fails closed'
+
+# Controlled command surface used by the lifted Test-Node function.
+$script:FakeNpmAvailable = $true
+$script:FakeNpmVersion = '11.16.0'
+$script:FakeNpmRange = $supportedRange
+$script:DownloadAttempts = 0
+$script:HasNode = $null
+$HermesHome = Join-Path $env:TEMP ("hermes-node-compatibility-test-" + [Guid]::NewGuid().ToString('N'))
+$NodeVersion = '22'
+
+function node { 'v24.18.0' }
+function npm.cmd { $script:FakeNpmVersion }
+function Get-Command {
+    [CmdletBinding()]
+    param([string]$Name)
+
+    switch ($Name) {
+        'node' {
+            return Microsoft.PowerShell.Core\Get-Command node -CommandType Function
+        }
+        'npm.cmd' {
+            if ($script:FakeNpmAvailable) {
+                return Microsoft.PowerShell.Core\Get-Command npm.cmd -CommandType Function
+            }
+            return $null
+        }
+        'npm' { return $null }
+        'winget' { return $null }
+        default { return $null }
+    }
+}
+function Get-NpmRange { $script:FakeNpmRange }
+function Ensure-NodeExeOnPath { $true }
+function Get-WindowsArch { 'x64' }
+function Invoke-WebRequest {
+    $script:DownloadAttempts++
+    throw 'network disabled by test'
+}
+function Write-Info { param([string]$Message) }
+function Write-Warn { param([string]$Message) }
+function Write-Success { param([string]$Message) }
+
+function Invoke-SystemNodeProbe {
+    param([string]$NpmVersion, [bool]$NpmAvailable = $true)
+
+    $script:FakeNpmVersion = $NpmVersion
+    $script:FakeNpmAvailable = $NpmAvailable
+    $script:DownloadAttempts = 0
+    $script:HasNode = $null
+    [void](Test-Node)
+    return [pscustomobject]@{
+        HasNode = $script:HasNode
+        DownloadAttempts = $script:DownloadAttempts
+    }
+}
+
+Write-Host ''
+Write-Host '-- system Node acceptance --'
+$result = Invoke-SystemNodeProbe '11.17.0'
+Assert-Equal $true $result.HasNode 'compatible system Node/npm is accepted'
+Assert-Equal 0 $result.DownloadAttempts 'compatible system npm avoids managed download'
+
+$result = Invoke-SystemNodeProbe '11.16.0'
+Assert-Equal $false $result.HasNode 'incompatible system npm is not accepted'
+Assert-Equal 1 $result.DownloadAttempts 'incompatible system npm falls through to managed Node'
+
+$result = Invoke-SystemNodeProbe '' $false
+Assert-Equal $false $result.HasNode 'missing system npm is not accepted'
+Assert-Equal 1 $result.DownloadAttempts 'missing system npm falls through to managed Node'
+
+if ($script:Failures -gt 0) {
+    Write-Host ''
+    Write-Host "$script:Failures assertion(s) failed"
+    exit 1
+}
+
+Write-Host ''
+Write-Host 'all assertions passed'


### PR DESCRIPTION
## Summary
The Windows installer now rejects a system Node whose npm falls in the engine-blocked band (`11.10.0`–`11.16.x`) and falls back to the Hermes-managed toolchain, instead of accepting it and dying later at `npm ci` with EBADENGINE mid-"Building desktop app".

Salvage of #82033 by @helix4u (commits cherry-picked with authorship preserved). This is the incompatible-system-npm path hit by 8 distinct Windows reporters in Discord support.

Root cause: `Test-Node` gated only on the Node version. With `.npmrc` `engine-strict=true` and `package.json` pinning `npm: <11.10.0 || >=11.17.0`, a passing Node with npm 11.12.x sailed through the gate and the install failed opaquely at the desktop build stage.

## Changes
- `scripts/install.ps1`: new `Test-NpmVersionOk` comparator-range evaluator + `Test-SystemNodeReady` gate (Node AND npm must satisfy the manifest ranges); pre-clone `$NpmRange` fallback synced to the manifest (`<11.10.0 || >=11.17.0`); `Update-ManagedNpm` reuses the same range check; post-winget re-probe shares the same authority.
- `scripts/tests/test-install-ps1-node-compatibility.ps1`: new installer test covering accept/reject on both range arms and the pre-clone fallback.
- `.github/workflows/installer-tests.yml`: runs the new test under pwsh 7 and Windows PowerShell 5.1 on windows-latest.

## Validation
| | Before | After |
|---|---|---|
| System Node 26 + npm 11.12.x | accepted → EBADENGINE at `npm ci` | rejected → managed Node provisioned |
| System Node 26 + npm 11.17.0 | rejected pre-clone (stale `>=12.0.0` fallback) | accepted |
| Windows proof | — | installer-tests windows-latest legs (pwsh 7 + PS 5.1) execute the new test |

## Infographic

![Windows installer now rejects incompatible system npm](https://v3b.fal.media/files/b/0aa82410/2_WcKn33C_ptJ2El5hPOJ_K7XXOVdm.png)
