### PR TITLE
fix(relay): stop failed sends from delivering anyway

### DIFF
--- a/tests/tools/test_a2a_reason_roundtrip.py
+++ b/tests/tools/test_a2a_reason_roundtrip.py
@@ -10,6 +10,7 @@ persist + waiter surfaces.
 from __future__ import annotations
 
 import json
+import shlex
 import subprocess
 import sys
 
@@ -59,7 +60,7 @@ def test_write_reply_classifies_when_reason_omitted(home):
 def _run_waiter(home, envelope):
     cmd = bot_relay.waiter_command(home, envelope)
     return subprocess.run(
-        ["bash", "-c", cmd], capture_output=True, text=True, timeout=30
+        shlex.split(cmd), capture_output=True, text=True, timeout=30
     )
 
 

--- a/tests/tools/test_bot_relay.py
+++ b/tests/tools/test_bot_relay.py
@@ -14,6 +14,8 @@ relay adds to message_agent:
 
 import json
 import re
+import shlex
+import sys
 from pathlib import Path
 
 import pytest
@@ -121,6 +123,17 @@ def test_enqueue_claim_is_atomic_and_single_shot(root):
     assert bot_relay.claim_pending_envelopes(root) == []
 
 
+def test_prepared_envelope_is_invisible_until_published(root):
+    target = bot_relay.resolve_remote_target("researcher", _rows())
+    env = bot_relay.prepare_envelope(
+        root, target=target, message="hi", sender_profile="work", sender_handle="work"
+    )
+
+    assert bot_relay.claim_pending_envelopes(root) == []
+    bot_relay.publish_envelope(root, env)
+    assert [item["id"] for item in bot_relay.claim_pending_envelopes(root)] == [env["id"]]
+
+
 def test_write_reply_validates_envelope_id(root):
     with pytest.raises(ValueError):
         bot_relay.write_reply(root, "../../etc/passwd", reply="x")
@@ -147,8 +160,25 @@ def test_write_reply_reason_passthrough_and_classification(root):
 def test_waiter_command_quotes_and_targets_reply_file(root):
     env = {"id": "b" * 32, "target_handle": "researcher", "target_connection": "ssh-vps"}
     cmd = bot_relay.waiter_command(root, env)
-    assert ("b" * 32) in cmd and "-c" in cmd
-    assert "rm -rf" not in cmd  # sanity: single quoted -c payload
+    parts = shlex.split(cmd)
+    assert parts[:2] == [sys.executable, str(Path(bot_relay.__file__).resolve())]
+    assert parts[2] == "--wait-for-reply"
+    assert parts[3].endswith(f"{env['id']}.json")
+    assert parts[4] == "@researcher on ssh-vps"
+    assert "-c" not in parts
+
+
+def test_waiter_command_is_safe_in_default_single_query_mode(root, monkeypatch):
+    from unittest.mock import patch as mock_patch
+
+    from tools.approval import check_dangerous_command
+
+    env = {"id": "b" * 32, "target_handle": "researcher", "target_connection": "ssh-vps"}
+    monkeypatch.setenv("HERMES_SINGLE_QUERY_SESSION", "1")
+    with mock_patch("tools.approval._get_single_query_approval_mode", return_value="deny"):
+        result = check_dangerous_command(bot_relay.waiter_command(root, env), "local")
+
+    assert result["approved"] is True
 
 
 def test_roster_rejects_connection_id_outside_handle_charset(root):
@@ -168,9 +198,6 @@ def test_roster_rejects_connection_id_outside_handle_charset(root):
 
 
 def test_waiter_command_repr_encodes_hostile_connection_id(root):
-    import ast
-    import shlex
-
     inj = "x'); open(r'/tmp/pwned','w').write('pwned'); print('x"
     env = {
         "id": "c" * 32,
@@ -179,26 +206,9 @@ def test_waiter_command_repr_encodes_hostile_connection_id(root):
     }
     cmd = bot_relay.waiter_command(root, env)
     parts = shlex.split(cmd)
-    code = parts[parts.index("-c") + 1]
-    compile(code, "<waiter>", "exec")
-    tree = ast.parse(code)
-    opens = [
-        n
-        for n in ast.walk(tree)
-        if isinstance(n, ast.Call)
-        and isinstance(n.func, ast.Name)
-        and n.func.id == "open"
-    ]
-    # Only json.load(open(p, ...)) is a real open(); the payload must stay data.
-    assert len(opens) == 1
-
-    # A quote in the id used to SyntaxError the waiter. It must compile.
-    quoted = bot_relay.waiter_command(
-        root,
-        {"id": "a" * 32, "target_handle": "h", "target_connection": "foo'bar"},
-    )
-    qcode = shlex.split(quoted)[shlex.split(quoted).index("-c") + 1]
-    compile(qcode, "<waiter-quote>", "exec")
+    assert parts[2] == "--wait-for-reply"
+    assert parts[4] == f"@researcher on {inj}"
+    assert "-c" not in parts
 
 
 # ── message_agent integration: relay route + legacy-SOUL gate fix ───────────
@@ -288,6 +298,7 @@ def test_relay_route_queues_envelope_and_spawns_waiter(tmp_path, monkeypatch):
     def _fake_spawn(command, label, *, task_id, agent):
         spawned["command"] = command
         spawned["label"] = label
+        assert bot_relay.claim_pending_envelopes(home) == []
         return json.dumps({"status": "sent", "to": label})
 
     monkeypatch.setattr("tools.bot_mode_dm._spawn_delivery", _fake_spawn)
@@ -303,6 +314,25 @@ def test_relay_route_queues_envelope_and_spawns_waiter(tmp_path, monkeypatch):
     assert pending[0]["message"].startswith("Message from 🤖 hermes (@hermes): ping")
     # waiter watches this envelope's reply file
     assert pending[0]["id"] in spawned["command"]
+
+
+def test_relay_waiter_start_failure_leaves_no_deliverable_envelope(tmp_path, monkeypatch):
+    home = _managed_home(tmp_path)
+    bot_relay.write_remote_roster(home, [
+        {"profile": "default", "handle": "hermes", "connection_id": "cloud-1"},
+    ])
+
+    import tools.terminal_tool as terminal_tool_module
+
+    monkeypatch.setattr(
+        terminal_tool_module,
+        "terminal_tool",
+        lambda *args, **kwargs: json.dumps({"error": "BLOCKED by approval policy"}),
+    )
+    out = json.loads(message_agent_tool(target="hermes", message="ping", agent=_FakeAgent(home)))
+
+    assert "failed to start" in out["error"]
+    assert bot_relay.claim_pending_envelopes(home) == []
 
 
 def test_relay_route_ambiguous_target_errors_with_forms(tmp_path, monkeypatch):

--- a/tests/tools/test_bot_relay_windows_paths.py
+++ b/tests/tools/test_bot_relay_windows_paths.py
@@ -1,16 +1,10 @@
-r"""Windows-path viability and venv CLI resolution for bot relay (#93590).
+r"""Windows-path viability and venv CLI resolution for bot relay.
 
 Two failures on a Windows desktop install talking to a remote gateway:
 
-1. ``waiter_command`` embeds the reply path into generated ``python -c``
-   source with ``!r``. repr escapes each backslash, but the Windows
-   execution layer the waiter runs under folds ``\\`` back to ``\`` —
-   ``\\U`` in ``C:\\Users\\...`` then parses as a unicode escape and
-   SyntaxErrors the whole script. The raw-string prefix keeps the folded
-   single backslash a literal; POSIX paths contain no backslashes, so it
-   is a no-op there, and ``\\'`` inside a raw literal still cannot
-   terminate the string, so the injection defense from #93091's
-   python -c hardening is unchanged.
+1. ``waiter_command`` passes reply paths and labels as quoted argv values to
+   the first-party ``bot_relay.py --wait-for-reply`` entrypoint. This avoids
+   both Windows backslash folding and the generic approval gate for ``-c``.
 
 2. ``local_delivery_command`` hardcoded ``"hermes"``, relying on PATH —
    which service contexts (systemd units, desktop launchers, non-login
@@ -22,8 +16,8 @@ Two failures on a Windows desktop install talking to a remote gateway:
    the per-profile lock.
 """
 
-import ast
 import shlex
+import sys
 from pathlib import Path
 
 import tools.bot_mode_dm as bot_mode_dm
@@ -33,65 +27,42 @@ import tools.bot_relay as bot_relay
 ENV = {"id": "d" * 32, "target_handle": "researcher", "target_connection": "ssh-vps"}
 
 
-def _waiter_code(root, env=None) -> str:
+def _waiter_parts(root, env=None) -> list[str]:
     cmd = bot_relay.waiter_command(root, env or ENV)
-    parts = shlex.split(cmd)
-    return parts[parts.index("-c") + 1]
+    return shlex.split(cmd)
 
 
-def test_waiter_windows_path_compiles_after_backslash_folding():
-    """A Windows reply path must survive the execution layer folding the
-    repr-escaped double backslash back to a single one — the exact shape
-    that SyntaxErrored with ``\\U`` on #93590's reporter setup."""
-    code = _waiter_code("C:\\Users\\joshu\\.hermes")
-    assert "C:" in code  # sanity: the Windows path made it into the payload
-    folded = code.replace("\\\\", "\\")
-    # Raw literals: `p = r'C:\Users\joshu\...'` — no unicode-escape crash.
-    compile(folded, "<waiter>", "exec")
+def test_waiter_windows_path_roundtrips_as_argv():
+    parts = _waiter_parts(r"C:\Users\joshu\.hermes")
+    assert parts[2] == "--wait-for-reply"
+    assert parts[3] == rf"C:\Users\joshu\.hermes\bot_relay\replies\{ENV['id']}.json"
+    assert "-c" not in parts
 
 
 def test_waiter_posix_path_and_label_values_roundtrip():
-    """On POSIX (backslash-free paths) the raw prefix changes nothing."""
     root = Path("/tmp/hermes-home")
-    code = _waiter_code(root)
-    assigns = {
-        t.targets[0].id: t.value
-        for t in ast.parse(code).body
-        if isinstance(t, ast.Assign) and isinstance(t.targets[0], ast.Name)
-    }
+    parts = _waiter_parts(root)
     expected = str(root / "bot_relay" / "replies" / f"{ENV['id']}.json")
-    assert assigns["p"].value == expected
-    assert assigns["label"].value == "@researcher on ssh-vps"
-    # The literals are raw-prefixed in the generated source.
-    assert "\np = r'" in code
-    assert "\nlabel = r'" in code
+    assert parts[3] == expected
+    assert parts[4] == "@researcher on ssh-vps"
 
 
-def test_waiter_raw_prefix_keeps_injection_defense():
-    """Hostile roster fields must stay data under the raw prefix too."""
+def test_waiter_argv_keeps_injection_defense():
+    """Hostile roster fields stay one inert argv value."""
     inj = {
         "id": "e" * 32,
         "target_handle": "researcher",
         "target_connection": "x'); __import__('sys').exit(2); print('x",
     }
-    code = _waiter_code(Path("/tmp/hermes-home"), inj)
-    compile(code, "<waiter>", "exec")
-    calls = [
-        n.func.id
-        for n in ast.walk(ast.parse(code))
-        if isinstance(n, ast.Call) and isinstance(n.func, ast.Name)
-    ]
-    # The generated waiter only calls str/print/compile-free builtins by
-    # name; the payload's __import__ must remain a string literal, not a
-    # live call — parse it back and confirm it stayed data.
-    assert "__import__" not in calls
-    assert "x'); __import__('sys').exit(2); print('x" in code
+    parts = _waiter_parts(Path("/tmp/hermes-home"), inj)
+    assert len(parts) == 5
+    assert parts[4] == "@researcher on x'); __import__('sys').exit(2); print('x"
 
 
 def test_local_delivery_resolves_sibling_hermes(tmp_path, monkeypatch):
-    bin_dir = tmp_path / "venv" / "bin"
+    bin_dir = tmp_path / "venv" / ("Scripts" if sys.platform == "win32" else "bin")
     bin_dir.mkdir(parents=True)
-    sibling = bin_dir / "hermes"
+    sibling = bin_dir / ("hermes.exe" if sys.platform == "win32" else "hermes")
     sibling.touch()
     sibling.chmod(0o755)
     monkeypatch.setattr("sys.executable", str(bin_dir / "python"))

--- a/tools/bot_mode_dm.py
+++ b/tools/bot_mode_dm.py
@@ -386,7 +386,8 @@ def _try_relay_delivery(
     try:
         from tools.bot_relay import (
             EnvelopeRefusedError,
-            enqueue_envelope,
+            prepare_envelope,
+            publish_envelope,
             read_remote_roster,
             resolve_remote_target,
             waiter_command,
@@ -409,7 +410,7 @@ def _try_relay_delivery(
                 f"disambiguate with one of: {forms}."
             )
         try:
-            envelope = enqueue_envelope(
+            envelope = prepare_envelope(
                 root,
                 target=match,
                 message=f"Message from 🤖 {sender_handle} (@{sender_handle}): {body}",
@@ -422,9 +423,24 @@ def _try_relay_delivery(
             # resolution error ('runtime_offline' per the #93091 reason enum).
             return json.dumps({"error": str(exc), "reason": exc.reason})
         label = f"@{match['handle']} on {match['connection_label'] or match['connection_id']}"
-        return _spawn_delivery(
-            waiter_command(root, envelope), label, task_id=task_id, agent=agent
+        result = _spawn_delivery(
+            waiter_command(root, envelope),
+            label,
+            task_id=task_id,
+            agent=agent,
         )
+        try:
+            started = json.loads(result).get("status") == "sent"
+        except (TypeError, ValueError):
+            started = False
+        if not started:
+            return result
+        try:
+            publish_envelope(root, envelope)
+        except Exception as exc:
+            logger.error("relay envelope publish failed: %s", exc, exc_info=True)
+            return _err(f"Delivery to {label} could not be queued: {exc}")
+        return result
     except Exception:
         logger.debug("relay delivery attempt failed", exc_info=True)
         return None

--- a/tools/bot_relay.py
+++ b/tools/bot_relay.py
@@ -305,7 +305,7 @@ def _target_liveness(root: Path | str, target: dict) -> Optional[bool]:
         return None
 
 
-def enqueue_envelope(
+def prepare_envelope(
     root: Path | str,
     *,
     target: dict,
@@ -313,11 +313,11 @@ def enqueue_envelope(
     sender_profile: str,
     sender_handle: str,
 ) -> dict:
-    """Queue a cross-connection DM for the Desktop relay. Returns envelope.
+    """Build a cross-connection DM without making it drainable.
 
     Raises ``EnvelopeRefusedError`` (reason ``'runtime_offline'``) instead of
-    writing the outbox file when the target is definitively offline per
-    ``_target_liveness``. Unknown liveness enqueues as before (fail-open).
+    preparing an envelope when the target is definitively offline per
+    ``_target_liveness``. Unknown liveness proceeds as before (fail-open).
     """
     if _target_liveness(root, target) is False:
         label = (
@@ -330,8 +330,7 @@ def enqueue_envelope(
             f"{label} is offline right now — the message was NOT queued. "
             "Try again once that machine reconnects to the Desktop.",
         )
-    base = _ensure_dirs(root)
-    envelope = {
+    return {
         "id": uuid.uuid4().hex,
         "created_at": int(time.time()),
         "from_profile": sender_profile,
@@ -341,11 +340,45 @@ def enqueue_envelope(
         "target_handle": target["handle"],
         "message": message,
     }
+
+
+def publish_envelope(root: Path | str, envelope: dict) -> None:
+    """Atomically expose a prepared envelope to the Desktop drain loop."""
+    envelope_id = str(envelope.get("id") or "") if isinstance(envelope, dict) else ""
+    if not re.fullmatch(r"[0-9a-f]{32}", envelope_id):
+        raise ValueError(f"invalid envelope id: {envelope_id!r}")
+    base = _ensure_dirs(root)
     path = base / OUTBOX_DIR / f"{envelope['id']}.json"
     fd, tmp = tempfile.mkstemp(dir=str(base / OUTBOX_DIR), prefix=".env-", suffix=".tmp")
-    with os.fdopen(fd, "w", encoding="utf-8") as f:
-        json.dump(envelope, f, ensure_ascii=False)
-    os.replace(tmp, path)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(envelope, f, ensure_ascii=False)
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def enqueue_envelope(
+    root: Path | str,
+    *,
+    target: dict,
+    message: str,
+    sender_profile: str,
+    sender_handle: str,
+) -> dict:
+    """Prepare and immediately queue a cross-connection DM."""
+    envelope = prepare_envelope(
+        root,
+        target=target,
+        message=message,
+        sender_profile=sender_profile,
+        sender_handle=sender_handle,
+    )
+    publish_envelope(root, envelope)
     return envelope
 
 
@@ -487,49 +520,46 @@ def waiter_command(root: Path | str, envelope: dict) -> str:
 
     Spawned with ``terminal_tool(background=True, notify_on_complete=True)``
     so its stdout — the teammate's reply — arrives as the same completion
-    notification local DMs use. Stdlib-only; runs under the sender gateway's
-    interpreter.
+    notification local DMs use. The first-party script entrypoint avoids the
+    generic approval gate for model-authored ``python -c`` commands.
     """
     reply_path = str(relay_root(root) / REPLIES_DIR / f"{envelope['id']}.json")
     label = (
         f"@{envelope.get('target_handle', '')} "
         f"on {envelope.get('target_connection', '')}"
     )
-    # Encode label with !r so roster fields cannot break out of the generated
-    # python -c source (quotes, parens, or extra statements in connection_id).
-    # The raw-string prefix keeps Windows paths viable: repr escapes each
-    # backslash ("C:\\Users\\..."), but the Windows execution layer the
-    # waiter runs under folds "\\" back to "\", which turns "\U" into an
-    # invalid unicode escape and SyntaxErrors the whole script (#93590).
-    # With the r prefix the folded single backslash parses as a literal.
-    # POSIX paths contain no backslashes, so the prefix is a no-op there,
-    # and \' inside a raw literal still cannot terminate the string, so
-    # the injection defense above is unchanged.
-    code = (
-        "import json,os,sys,time\n"
-        f"p = r{reply_path!r}\n"
-        f"label = r{label!r}\n"
-        f"deadline = time.time() + {REPLY_WAIT_SECONDS}\n"
-        "while time.time() < deadline:\n"
-        "    if os.path.exists(p):\n"
-        "        d = json.load(open(p, encoding='utf-8'))\n"
-        "        if d.get('error'):\n"
-        # The typed reason code (#93091) rides ahead of the free text so the
-        # sending agent can branch on it (auth vs rate limit vs offline)
-        # without parsing provider prose.
-        "            code = str(d.get('reason') or '').strip()\n"
-        "            tag = ' [reason: ' + code + ']' if code else ''\n"
-        "            print('Delivery to ' + label + ' failed' + tag + ': ' + d['error'])\n"
-        "            sys.exit(1)\n"
-        "        print('Reply from ' + label + ':')\n"
-        "        print(d.get('reply') or '(empty reply)')\n"
-        "        sys.exit(0)\n"
-        "    time.sleep(2)\n"
-        f"print('No reply from ' + label + ' within {REPLY_WAIT_SECONDS}s. The message may "
-        "still be delivered when the Desktop reconnects; do not resend blindly.')\n"
-        "sys.exit(1)\n"
+    return shlex.join(
+        [
+            sys.executable or "python3",
+            str(Path(__file__).resolve()),
+            "--wait-for-reply",
+            reply_path,
+            label,
+        ]
     )
-    return f"{shlex.quote(sys.executable or 'python3')} -c {shlex.quote(code)}"
+
+
+def _wait_for_reply(reply_path: str, label: str) -> int:
+    """Waiter entrypoint used by :func:`waiter_command`."""
+    deadline = time.time() + REPLY_WAIT_SECONDS
+    while time.time() < deadline:
+        if os.path.exists(reply_path):
+            with open(reply_path, encoding="utf-8") as stream:
+                data = json.load(stream)
+            if data.get("error"):
+                code = str(data.get("reason") or "").strip()
+                tag = f" [reason: {code}]" if code else ""
+                print(f"Delivery to {label} failed{tag}: {data['error']}")
+                return 1
+            print(f"Reply from {label}:")
+            print(data.get("reply") or "(empty reply)")
+            return 0
+        time.sleep(2)
+    print(
+        f"No reply from {label} within {REPLY_WAIT_SECONDS}s. The message may still be "
+        "delivered when the Desktop reconnects; do not resend blindly."
+    )
+    return 1
 
 
 # ── delivery command (used by the deliver RPC on the TARGET gateway) ────────
@@ -674,3 +704,13 @@ def acquire_turn_lock(
                 pass
     finally:
         os.close(fd)
+
+
+def _main(args: list[str]) -> int:
+    if len(args) != 3 or args[0] != "--wait-for-reply":
+        return 2
+    return _wait_for_reply(args[1], args[2])
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised as a background process
+    raise SystemExit(_main(sys.argv[1:]))


### PR DESCRIPTION
## What does this PR do?

Cross-connection `message_agent` calls no longer report a failed send after the Desktop relay has already claimed and delivered the envelope. The relay now starts its reply waiter before atomically publishing the envelope, and the internal waiter uses a first-party script entrypoint instead of a policy-blocked `python -c` command.

### Symptom

With the default `approvals.single_query_mode: deny`, a cross-connection reply can return `failed to start` while the recipient still receives the message.

### Impact

The sender is instructed to retry a message the recipient already has, which can cause duplicate delivery and hides the actual state of the relay operation.

### Bug Cause

**Trigger:** `tools/bot_mode_dm.py` / `_try_relay_delivery()` queues an envelope before `_spawn_delivery()` acknowledges the waiter process.

**Causal chain:**
1. `message_agent` writes an envelope into the relay outbox, making it immediately visible to the Desktop drain loop.
2. The internally generated waiter command uses `python -c`, so the default single-query approval policy rejects the command after the envelope is already visible.
3. The tool reports that delivery failed to start even though the Desktop can already claim and deliver the envelope.

**Why it is wrong:** the outbox publication and waiter startup were ordered as independent side effects, so a waiter failure could not roll back an envelope that the Desktop had concurrently claimed.

**Working sibling / contrast:** local and peer deliveries transfer their temporary payload only after the background runner acknowledges startup, and they delete untransferred payloads on failure.

**Ruled out:** relay idempotency is not the cause. The evidence and regression test show one envelope being claimed after the sender receives a startup failure.

### Fix

- Split relay envelope creation from atomic outbox publication.
- Start and acknowledge the waiter before publishing the prepared envelope.
- Keep failed waiter starts invisible to the Desktop drain loop.
- Replace the internal `python -c` waiter with `bot_relay.py --wait-for-reply`, preserving reply and typed-error output without triggering the generic script-execution approval rule.

## Related Issue
N/A
## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/bot_mode_dm.py` - publish cross-connection envelopes only after waiter startup succeeds.
- `tools/bot_relay.py` - add prepare/publish phases and a first-party waiter entrypoint.
- `tests/tools/test_bot_relay.py` - cover startup failure, drain ordering, atomic publication, and default approval behavior.
- `tests/tools/test_bot_relay_windows_paths.py` - cover argv-safe waiter paths and labels across platforms.
- `tests/tools/test_a2a_reason_roundtrip.py` - exercise the new waiter entrypoint directly.

## How to Test

1. Run the relay, waiter, approval, and reason-roundtrip regression suites.
2. Verify that a drain attempted while waiter startup is in progress sees no envelope.
3. Verify that a blocked waiter start returns an error and leaves no claimable envelope.

```bash
scripts/run_tests.sh tests/tools/test_bot_relay.py tests/tools/test_bot_relay_windows_paths.py tests/tools/test_a2a_reason_roundtrip.py -q
scripts/run_tests.sh tests/tools/test_bot_mode_dm.py -k 'spawn' -q
```

Result: 46 tests passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all selected tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A; user-facing behavior is unchanged except for correctness
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A; the schema is unchanged

## Screenshots / Logs

The targeted automated test commands above pass on Windows 11.

