### PR TITLE
fix(nous): fail fast on catalog-listed uncallable Muse Spark contributor

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -409,6 +409,12 @@ _MODEL_NOT_FOUND_PATTERNS = [
     # and the error surfaces as a confusing "model not found" message
     # instead of automatically failing over.  See PR #58446.
     "no endpoints found that support tool use",
+    # Nous Portal catalog-listed-but-not-callable 404 (#95837, #45362).
+    # Prefixed ids such as meta/muse-spark-1.2-contributor return this
+    # opaque body instead of "model not found" / "does not exist". Without
+    # this entry the 404 falls through to unknown+retryable and burns three
+    # identical attempts before the user sees anything.
+    "couldn't find that, sorry",
 ]
 
 

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -6004,6 +6004,25 @@ def _refresh_access_token(
     raise AuthError(description, provider="nous", code=code, relogin_required=relogin)
 
 
+def is_nous_catalog_uncallable(model_id: str) -> bool:
+    """True when Portal lists *model_id* but chat/responses cannot serve it.
+
+    Paid Muse Spark contributor slugs appear in GET /v1/models (and on the
+    Portal pricing page) but every POST /v1/chat/completions and
+    /v1/responses returns HTTP 404 ``Couldn't find that, sorry.`` — the
+    catalog-listed-but-not-callable class from #95837. The free Zen
+    ``-contributor-free`` SKU is a different provider and stays selectable.
+    """
+    low = (model_id or "").strip().lower()
+    if not low:
+        return False
+    return (
+        "muse-spark" in low
+        and "contributor" in low
+        and "free" not in low
+    )
+
+
 def fetch_nous_models(
     *,
     inference_base_url: str,
@@ -6042,6 +6061,8 @@ def fetch_nous_models(
             mid = model_id.strip()
             # Skip Hermes models — they're not reliable for agentic tool-calling
             if "hermes" in mid.lower():
+                continue
+            if is_nous_catalog_uncallable(mid):
                 continue
             model_ids.append(mid)
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2119,8 +2119,14 @@ def get_curated_nous_model_ids() -> list[str]:
     except Exception:
         remote = None
     if remote:
-        return list(remote)
-    return list(_PROVIDER_MODELS.get("nous", []))
+        ids = list(remote)
+    else:
+        ids = list(_PROVIDER_MODELS.get("nous", []))
+    try:
+        from hermes_cli.auth import is_nous_catalog_uncallable
+    except Exception:
+        return ids
+    return [mid for mid in ids if not is_nous_catalog_uncallable(mid)]
 
 
 def _ai_gateway_model_is_free(pricing: Any) -> bool:

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -594,19 +594,6 @@ class TestClassifyApiError:
         assert result.retryable is True
         assert result.should_fallback is False
 
-    def test_404_nous_opaque_couldnt_find_that_is_model_not_found(self):
-        e = MockAPIError(
-            'HTTP 404: {"status":404,"message":"Couldn\'t find that, sorry."}',
-            status_code=404,
-            body={"status": 404, "message": "Couldn't find that, sorry."},
-        )
-        result = classify_api_error(
-            e, provider="nous", model="meta/muse-spark-1.2-contributor"
-        )
-        assert result.reason == FailoverReason.model_not_found
-        assert result.retryable is False
-        assert result.should_fallback is True
-
     def test_404_bare_model_id_missing_prefix_is_model_not_found(self):
         """A bare id the provider only serves as ``vendor/id`` is malformed.
 

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -569,6 +569,20 @@ class TestClassifyApiError:
         assert result.should_fallback is True
         assert result.retryable is False
 
+    def test_404_nous_opaque_couldnt_find_that_is_model_not_found(self):
+        """Portal catalog-listed-but-uncallable 404 must not retry (#95837)."""
+        e = MockAPIError(
+            'HTTP 404: {"status":404,"message":"Couldn\'t find that, sorry."}',
+            status_code=404,
+            body={"status": 404, "message": "Couldn't find that, sorry."},
+        )
+        result = classify_api_error(
+            e, provider="nous", model="meta/muse-spark-1.2-contributor"
+        )
+        assert result.reason == FailoverReason.model_not_found
+        assert result.retryable is False
+        assert result.should_fallback is True
+
     def test_404_generic(self):
         # Generic 404 with no "model not found" signal — common for local
         # llama.cpp/Ollama/vLLM endpoints with slightly wrong paths.  Treat
@@ -579,6 +593,19 @@ class TestClassifyApiError:
         assert result.reason == FailoverReason.unknown
         assert result.retryable is True
         assert result.should_fallback is False
+
+    def test_404_nous_opaque_couldnt_find_that_is_model_not_found(self):
+        e = MockAPIError(
+            'HTTP 404: {"status":404,"message":"Couldn\'t find that, sorry."}',
+            status_code=404,
+            body={"status": 404, "message": "Couldn't find that, sorry."},
+        )
+        result = classify_api_error(
+            e, provider="nous", model="meta/muse-spark-1.2-contributor"
+        )
+        assert result.reason == FailoverReason.model_not_found
+        assert result.retryable is False
+        assert result.should_fallback is True
 
     def test_404_bare_model_id_missing_prefix_is_model_not_found(self):
         """A bare id the provider only serves as ``vendor/id`` is malformed.

--- a/tests/hermes_cli/test_auth_nous_provider.py
+++ b/tests/hermes_cli/test_auth_nous_provider.py
@@ -1178,3 +1178,114 @@ def test_nous_device_code_login_timeout_raises_actionable_message(monkeypatch):
     assert "CAPTCHA" in msg
     assert "hermes portal" in msg
     assert "https://portal.nousresearch.com/login" in msg
+
+
+@pytest.mark.parametrize(
+    "model_id, expected",
+    [
+        ("meta/muse-spark-1.2-contributor", True),
+        ("muse-spark-1.2-contributor", True),
+        ("meta/muse-spark-1.2-contributor-20260805", True),
+        ("meta/muse-spark-1.2", False),
+        ("muse-spark-1.2-contributor-free", False),
+        ("opencode/muse-spark-1.2-contributor-free", False),
+        ("", False),
+    ],
+)
+def test_is_nous_catalog_uncallable(model_id: str, expected: bool) -> None:
+    from hermes_cli.auth import is_nous_catalog_uncallable
+
+    assert is_nous_catalog_uncallable(model_id) is expected
+
+
+def test_fetch_nous_models_skips_catalog_uncallable_contributor(monkeypatch) -> None:
+    from hermes_cli import auth as auth_mod
+
+    class _Resp:
+        status_code = 200
+
+        def json(self):
+            return {
+                "data": [
+                    {"id": "meta/muse-spark-1.2-contributor"},
+                    {"id": "meta/muse-spark-1.2"},
+                    {"id": "anthropic/claude-opus-4.8"},
+                ]
+            }
+
+    class _Client:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def get(self, *args, **kwargs):
+            return _Resp()
+
+    monkeypatch.setattr(auth_mod.httpx, "Client", _Client)
+    ids = auth_mod.fetch_nous_models(
+        inference_base_url="https://inference-api.nousresearch.com/v1",
+        api_key="sk-test",
+    )
+    assert "meta/muse-spark-1.2-contributor" not in ids
+    assert "meta/muse-spark-1.2" in ids
+    assert "anthropic/claude-opus-4.8" in ids
+
+
+class TestNousCatalogUncallable:
+    def test_paid_muse_spark_contributor_is_uncallable(self):
+        from hermes_cli.auth import is_nous_catalog_uncallable
+
+        assert is_nous_catalog_uncallable("meta/muse-spark-1.2-contributor") is True
+        assert is_nous_catalog_uncallable("muse-spark-1.2-contributor") is True
+        assert is_nous_catalog_uncallable(
+            "meta/muse-spark-1.2-contributor-20260805"
+        ) is True
+
+    def test_standard_and_free_variants_stay_selectable(self):
+        from hermes_cli.auth import is_nous_catalog_uncallable
+
+        assert is_nous_catalog_uncallable("meta/muse-spark-1.2") is False
+        assert is_nous_catalog_uncallable("muse-spark-1.2-contributor-free") is False
+        assert is_nous_catalog_uncallable("anthropic/claude-sonnet-4.6") is False
+
+    def test_fetch_nous_models_drops_uncallable_contributor(self, monkeypatch):
+        from hermes_cli.auth import fetch_nous_models
+
+        class _Resp:
+            status_code = 200
+
+            def json(self):
+                return {
+                    "data": [
+                        {"id": "meta/muse-spark-1.2"},
+                        {"id": "meta/muse-spark-1.2-contributor"},
+                        {"id": "nousresearch/hermes-4-405b"},
+                    ]
+                }
+
+        class _Client:
+            def __init__(self, *a, **k):
+                pass
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+            def get(self, *a, **k):
+                return _Resp()
+
+        monkeypatch.setattr(httpx, "Client", _Client)
+        ids = fetch_nous_models(
+            inference_base_url="https://inference-api.nousresearch.com/v1",
+            api_key="test-key",
+        )
+        assert "meta/muse-spark-1.2" in ids
+        assert "meta/muse-spark-1.2-contributor" not in ids
+        assert all("hermes" not in mid.lower() for mid in ids)


### PR DESCRIPTION
## What does this PR do?

`meta/muse-spark-1.2-contributor` is listed on Nous Portal `GET /v1/models` and in the Hermes nous picker, but every `POST /v1/chat/completions` and `/v1/responses` call returns HTTP 404 with `{"status":404,"message":"Couldn't find that, sorry."}`. The standard SKU `meta/muse-spark-1.2` succeeds on the same credentials.

That opaque 404 did not match `_MODEL_NOT_FOUND_PATTERNS`, so Hermes classified it as `unknown` and `retryable=True` and burned three identical attempts. This change treats the Portal phrase as a deterministic model-not-found (fail fast + fallback) and removes paid Muse Spark contributor slugs from the Hermes nous catalog so the picker does not advertise an uncallable SKU. The Portal still cannot serve contributor-tier completions; use `meta/muse-spark-1.2`, `muse-spark-1.2-contributor-free` via opencode-zen, or the `meta-ai` provider.

## Related Issue

Fixes #95837

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/error_classifier.py` — add `couldn't find that, sorry` to `_MODEL_NOT_FOUND_PATTERNS`
- `hermes_cli/auth.py` — add `is_nous_catalog_uncallable()` and skip those ids in `fetch_nous_models()`
- `hermes_cli/models.py` — filter the same slugs from `get_curated_nous_model_ids()`
- `tests/agent/test_error_classifier.py` — regression for the opaque Portal 404
- `tests/hermes_cli/test_auth_nous_provider.py` — helper + `fetch_nous_models` filter tests

## How to Test

1. With a valid `NOUS_API_KEY`, call `POST https://inference-api.nousresearch.com/v1/chat/completions` with `model=meta/muse-spark-1.2-contributor` and confirm HTTP 404 `Couldn't find that, sorry.`
2. Repeat with `model=meta/muse-spark-1.2` and confirm HTTP 200.
3. Run `scripts/run_tests.sh tests/agent/test_error_classifier.py tests/hermes_cli/test_auth_nous_provider.py`
4. Confirm `is_nous_catalog_uncallable("meta/muse-spark-1.2-contributor")` is true and `fetch_nous_models` / `get_curated_nous_model_ids` no longer include that id.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
GET /v1/models → 200 (342 models; includes meta/muse-spark-1.2-contributor and meta/muse-spark-1.2)
POST /v1/chat/completions model=meta/muse-spark-1.2-contributor → 404 {"status":404,"message":"Couldn't find that, sorry."}
POST /v1/chat/completions model=meta/muse-spark-1.2 → 200 (provider Meta)
POST /v1/responses model=meta/muse-spark-1.2-contributor → 404 same body
scripts/run_tests.sh tests/agent/test_error_classifier.py tests/hermes_cli/test_auth_nous_provider.py → 142 passed
```
