### PR TITLE
fix(codex): assistant-history image parts no longer replay as input_image 400s (#96816)

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -165,6 +165,13 @@ def _chat_content_to_responses_parts(content: Any, *, role: str = "user") -> Lis
     ``output_text`` inside user messages, so callers MUST pass the correct
     role for the message being converted.
 
+    Image parts are likewise role-restricted: the API only accepts
+    ``input_image`` on user-role messages. An assistant message carrying
+    ``input_image`` is rejected with HTTP 400 on every history replay, which
+    permanently bricks the session (#96816), so image parts are dropped for
+    the assistant role here (the API cannot carry them in any form, so the
+    drop is lossless w.r.t. what would survive the wire).
+
     Returns an empty list when ``content`` is not a list or contains no
     recognized parts — callers fall back to the string path.
     """
@@ -186,6 +193,10 @@ def _chat_content_to_responses_parts(content: Any, *, role: str = "user") -> Lis
                 converted.append({"type": text_type, "text": text})
             continue
         if ptype in {"image_url", "input_image"}:
+            if role == "assistant":
+                # Responses API rejects input_image on assistant messages
+                # (HTTP 400 on every replay) — drop, see docstring (#96816).
+                continue
             image_ref = part.get("image_url")
             detail = part.get("detail")
             if isinstance(image_ref, dict):

--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -194,8 +194,13 @@ def _chat_content_to_responses_parts(content: Any, *, role: str = "user") -> Lis
             continue
         if ptype in {"image_url", "input_image"}:
             if role == "assistant":
-                # Responses API rejects input_image on assistant messages
-                # (HTTP 400 on every replay) — drop, see docstring (#96816).
+                # Responses output messages cannot carry input_image. Keep a
+                # text marker so image-only assistant turns still survive in
+                # replay and later references retain their conversational slot.
+                converted.append({
+                    "type": "output_text",
+                    "text": "[Assistant image omitted during replay]",
+                })
                 continue
             image_ref = part.get("image_url")
             detail = part.get("detail")
@@ -1167,6 +1172,14 @@ def _preflight_codex_input_items(
                             text = str(text or "")
                         validated.append({"type": text_type, "text": sanitize_text(text)})
                     elif ptype in {"input_image", "image_url"}:
+                        if role == "assistant":
+                            # Enforce the same output-message invariant for
+                            # raw request overrides as for normal history.
+                            validated.append({
+                                "type": "output_text",
+                                "text": "[Assistant image omitted during replay]",
+                            })
+                            continue
                         image_ref = part.get("image_url", "")
                         detail = part.get("detail")
                         if isinstance(image_ref, dict):

--- a/tests/agent/test_codex_responses_adapter.py
+++ b/tests/agent/test_codex_responses_adapter.py
@@ -30,6 +30,8 @@ def test_chat_content_drops_images_from_assistant_role():
 
     assert _chat_content_to_responses_parts(content, role="assistant") == [
         {"type": "output_text", "text": "generated image"},
+        {"type": "output_text", "text": "[Assistant image omitted during replay]"},
+        {"type": "output_text", "text": "[Assistant image omitted during replay]"},
     ]
 
 
@@ -43,6 +45,24 @@ def test_chat_content_keeps_images_on_user_role():
         "type": "input_image",
         "image_url": "https://example.invalid/p.png",
         "detail": "high",
+    }]
+
+
+def test_preflight_rewrites_raw_assistant_images_to_text_markers():
+    raw = [{
+        "role": "assistant",
+        "content": [{
+            "type": "input_image",
+            "image_url": "https://example.invalid/p.png",
+        }],
+    }]
+
+    assert _preflight_codex_input_items(raw) == [{
+        "role": "assistant",
+        "content": [{
+            "type": "output_text",
+            "text": "[Assistant image omitted during replay]",
+        }],
     }]
 
 

--- a/tests/agent/test_codex_responses_adapter.py
+++ b/tests/agent/test_codex_responses_adapter.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 import pytest
 
 from agent.codex_responses_adapter import (
+    _chat_content_to_responses_parts,
     _chat_messages_to_responses_input,
     _sanitize_replayed_fn_name,
     _format_responses_error,
@@ -18,6 +19,31 @@ _HARMONY_SOURCE_SNIPPET = (
     "Need to generate one image according to the description."
     "<|end|><|start|>assistant<|channel|>final<|message|>"
 )
+
+
+def test_chat_content_drops_images_from_assistant_role():
+    content = [
+        {"type": "text", "text": "generated image"},
+        {"type": "image_url", "image_url": {"url": "https://example.invalid/p.png"}},
+        {"type": "input_image", "image_url": "data:image/png;base64,AAAA"},
+    ]
+
+    assert _chat_content_to_responses_parts(content, role="assistant") == [
+        {"type": "output_text", "text": "generated image"},
+    ]
+
+
+def test_chat_content_keeps_images_on_user_role():
+    content = [{
+        "type": "image_url",
+        "image_url": {"url": "https://example.invalid/p.png", "detail": "high"},
+    }]
+
+    assert _chat_content_to_responses_parts(content, role="user") == [{
+        "type": "input_image",
+        "image_url": "https://example.invalid/p.png",
+        "detail": "high",
+    }]
 
 
 def _harmony_token(name: str) -> str:


### PR DESCRIPTION
## Summary

Fixes #96816 — salvage of #96820 by @lEWFkRAD (cherry-picked with authorship preserved).

The OpenAI Responses API only accepts `input_image` parts inside **user**-role input items. `agent/codex_responses_adapter.py::_chat_content_to_responses_parts` converted image parts to `input_image` regardless of role, so any assistant history message carrying an image (e.g. a vision round-trip) was replayed with an assistant-role `input_image` → HTTP 400 on **every** subsequent call — a permanent session brick. This complements #97059's reactive recovery for the same user-pain class (#69078) by removing a corruption source at the wire-format layer.

The fix rewrites assistant-role `image_url`/`input_image` parts to a deterministic `output_text` marker (`[Assistant image omitted during replay]`) at **both** conversion sites — history conversion (`_chat_content_to_responses_parts`) and the raw-override preflight (`_preflight_codex_input_items`) — preserving the assistant turn's text parts and conversational slot. User-role images and multimodal `function_call_output` images are unchanged. The marker is a fixed string (no random IDs), so identical input yields identical output and prompt-cache determinism is preserved.

## Changes

- `agent/codex_responses_adapter.py`
  - `_chat_content_to_responses_parts`: assistant-role image parts become an `output_text` replay marker instead of `input_image`.
  - `_preflight_codex_input_items`: same rewrite enforced for raw request overrides carrying assistant-role image parts.
- `tests/agent/test_codex_responses_adapter.py`: regression tests for assistant-role marker rewrite, raw-override preflight rewrite, and user-role images staying `input_image`.

## Validation

| Check | main (`7aebf300a`) | This branch |
| --- | --- | --- |
| Issue repro (`_chat_content_to_responses_parts(probe, role="assistant")`) | emits `input_image` in assistant parts (bug) | emits `output_text` marker, no `input_image` |
| `test_chat_content_drops_images_from_assistant_role` | **FAILED** | passed |
| `test_preflight_rewrites_raw_assistant_images_to_text_markers` | **FAILED** | passed |
| `tests/agent/test_codex_responses_adapter.py` + `tests/agent/transports/test_codex_transport.py` + `tests/run_agent/test_codex_multimodal_tool_result.py` + `tests/run_agent/test_run_agent_codex_responses.py` | — | **190 passed** |

**Live repro:** ran the issue's exact probe against the real conversion on origin/main code — `_chat_content_to_responses_parts([image_url part], role="assistant")` returned `[{'type': 'input_image', ...}]` (the shape the Responses API 400s on for assistant items), and `_chat_messages_to_responses_input` placed that `input_image` inside the assistant-role item; with the fix the same input deterministically yields the `output_text` marker. Sabotage check: swapping main's `codex_responses_adapter.py` under the new tests turns both regression tests red (`2 failed`), proving they exercise the live bug.

## Infographic

![infographic](https://v3b.fal.media/files/b/0aa82446/7exefOkiipExV2meC0UIa_gLMlV83N.png)

<!-- stand-in infographic URL; parent will replace -->

