### PR TITLE
fix(browser): CDP screenshots survive redaction byte-identical — no more provider 400 invalid_image (#94138, salvage #94142)

### DIFF
--- a/tests/tools/test_browser_cdp_tool.py
+++ b/tests/tools/test_browser_cdp_tool.py
@@ -201,6 +201,59 @@ def test_browser_level_redacts_secret_result(cdp_server):
     assert result["result"]["result"]["value"].startswith("sk-")
 
 
+def test_screenshot_base64_passes_through_unredacted(cdp_server):
+    """The Fernet pattern matches arbitrary spans inside base64 payloads —
+    a screenshot whose base64 contains "gAAAA..." must stay byte-identical
+    instead of being collapsed to "first6...last4" (#94138)."""
+    # Real-world shape: the Fernet pattern fires when "gAAAA" follows a "+"
+    # or "/" inside the base64 stream (word-boundary requirement).
+    shot_b64 = "iVBORw0KGgoAAAANSUhEUg+" + "gAAAA" + "B" * 60 + "=="
+    cdp_server.on(
+        "Page.captureScreenshot",
+        lambda params, sid: {"data": shot_b64},
+    )
+
+    result = json.loads(browser_cdp_tool.browser_cdp(method="Page.captureScreenshot"))
+
+    assert result["success"] is True
+    assert result["result"]["data"] == shot_b64
+
+
+def test_print_to_pdf_base64_passes_through_unredacted(cdp_server):
+    pdf_b64 = "JVBERi0xLjcK/" + "gAAAA" + "C" * 60 + "="
+    cdp_server.on(
+        "Page.printToPDF",
+        lambda params, sid: {"data": pdf_b64},
+    )
+
+    result = json.loads(browser_cdp_tool.browser_cdp(method="Page.printToPDF"))
+
+    assert result["success"] is True
+    assert result["result"]["data"] == pdf_b64
+
+
+def test_binary_payload_flag_keeps_secret_redaction_off_method_list(cdp_server):
+    """Fail-closed pin: only the two binary-payload methods skip redaction;
+    any other method's text output keeps full secret redaction."""
+    fake_key = "sk-" + "CDPSECRETSTILLREDACTED1234567890"
+    cdp_server.on(
+        "Runtime.evaluate",
+        lambda params, sid: {"result": {"type": "string", "value": fake_key}},
+    )
+    cdp_server.on(
+        "Page.captureScreenshot",
+        lambda params, sid: {"data": "gAAAA" + "B" * 60},
+    )
+
+    text_result = json.loads(browser_cdp_tool.browser_cdp(method="Runtime.evaluate"))
+    assert "CDPSECRETSTILLREDACTED" not in json.dumps(text_result)
+
+    shot_result = json.loads(
+        browser_cdp_tool.browser_cdp(method="Page.captureScreenshot")
+    )
+    assert shot_result["result"]["data"] == "gAAAA" + "B" * 60
+
+
 # ---------------------------------------------------------------------------
 # Happy-path: target-attached call
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_browser_cdp_tool.py
+++ b/tests/tools/test_browser_cdp_tool.py
@@ -233,8 +233,8 @@ def test_print_to_pdf_base64_passes_through_unredacted(cdp_server):
 
 
 def test_binary_payload_flag_keeps_secret_redaction_off_method_list(cdp_server):
-    """Fail-closed pin: only the two binary-payload methods skip redaction;
-    any other method's text output keeps full secret redaction."""
+    """Fail-closed pin: methods without a binary payload field keep full
+    secret redaction; the listed methods pass their payload through."""
     fake_key = "sk-" + "CDPSECRETSTILLREDACTED1234567890"
     cdp_server.on(
         "Runtime.evaluate",
@@ -252,6 +252,90 @@ def test_binary_payload_flag_keeps_secret_redaction_off_method_list(cdp_server):
         browser_cdp_tool.browser_cdp(method="Page.captureScreenshot")
     )
     assert shot_result["result"]["data"] == "gAAAA" + "B" * 60
+
+
+def test_binary_payload_field_sibling_string_still_redacted(cdp_server):
+    """Path-scoped exemption: on a binary-bearing result only the payload
+    field skips redaction; a sibling string keeps full secret redaction,
+    proving the exemption cannot widen to the whole result object."""
+    fake_key = "sk-" + "CDPSECRETSIBLING1234567890"
+    shot_b64 = "iVBORw0KGgoAAAANSUhEUg+" + "gAAAA" + "B" * 60 + "=="
+    cdp_server.on(
+        "Page.captureScreenshot",
+        lambda params, sid: {"data": shot_b64, "note": fake_key},
+    )
+
+    result = json.loads(browser_cdp_tool.browser_cdp(method="Page.captureScreenshot"))
+
+    assert result["success"] is True
+    assert result["result"]["data"] == shot_b64
+    assert "CDPSECRETSIBLING" not in json.dumps(result)
+    assert result["result"]["note"].startswith("sk-")
+
+
+def test_get_response_body_base64_discriminator_passes_through(cdp_server):
+    """Network.getResponseBody with base64Encoded: true — the body is opaque
+    base64 bytes and must remain byte-identical (#94138 review on #94142)."""
+    body_b64 = "q9Z7" + "gAAAA" + "B" * 60 + "=="
+    cdp_server.on(
+        "Network.getResponseBody",
+        lambda params, sid: {"body": body_b64, "base64Encoded": True},
+    )
+
+    result = json.loads(
+        browser_cdp_tool.browser_cdp(method="Network.getResponseBody")
+    )
+
+    assert result["success"] is True
+    assert result["result"]["body"] == body_b64
+
+
+def test_get_response_body_text_discriminator_still_redacts(cdp_server):
+    """Same method with base64Encoded: false — the body is text and a real
+    secret in it must still be redacted."""
+    fake_key = "sk-" + "CDPSECRETBODY1234567890"
+    cdp_server.on(
+        "Network.getResponseBody",
+        lambda params, sid: {"body": f"leak {fake_key} here", "base64Encoded": False},
+    )
+
+    result = json.loads(
+        browser_cdp_tool.browser_cdp(method="Network.getResponseBody")
+    )
+
+    assert result["success"] is True
+    assert "CDPSECRETBODY" not in json.dumps(result)
+
+
+def test_io_read_base64_discriminator_passes_through(cdp_server):
+    """IO.read honors the same discriminator contract for its data field."""
+    chunk_b64 = "AAA" + "gAAAA" + "C" * 60 + "="
+    cdp_server.on(
+        "IO.read",
+        lambda params, sid: {"data": chunk_b64, "base64Encoded": True, "eof": True},
+    )
+
+    result = json.loads(browser_cdp_tool.browser_cdp(method="IO.read"))
+
+    assert result["success"] is True
+    assert result["result"]["data"] == chunk_b64
+    assert result["result"]["eof"] is True
+
+
+def test_fetch_get_response_body_base64_discriminator_passes_through(cdp_server):
+    """Fetch.getResponseBody pins the same body/base64Encoded contract."""
+    body_b64 = "zz7+" + "gAAAA" + "D" * 60 + "=="
+    cdp_server.on(
+        "Fetch.getResponseBody",
+        lambda params, sid: {"body": body_b64, "base64Encoded": True},
+    )
+
+    result = json.loads(
+        browser_cdp_tool.browser_cdp(method="Fetch.getResponseBody")
+    )
+
+    assert result["success"] is True
+    assert result["result"]["body"] == body_b64
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_browser_cdp_tool.py
+++ b/tests/tools/test_browser_cdp_tool.py
@@ -338,6 +338,106 @@ def test_fetch_get_response_body_base64_discriminator_passes_through(cdp_server)
     assert result["result"]["body"] == body_b64
 
 
+def test_runtime_evaluate_spoofed_base64_flag_still_redacts(cdp_server):
+    """base64Encoded is trusted ONLY on the protocol-defined carrier paths.
+    A Runtime.evaluate by-value object carrying
+    {"base64Encoded": true, "data": "<secret>"} is untrusted nested JSON —
+    the secret must still be redacted (second review on #94142)."""
+    fake_key = "sk-" + "CDPSPOOFEDFLAG1234567890"
+    cdp_server.on(
+        "Runtime.evaluate",
+        lambda params, sid: {
+            "result": {
+                "type": "object",
+                "value": {"base64Encoded": True, "data": fake_key},
+            }
+        },
+    )
+
+    result = json.loads(browser_cdp_tool.browser_cdp(method="Runtime.evaluate"))
+
+    assert result["success"] is True
+    assert "CDPSPOOFEDFLAG" not in json.dumps(result)
+
+
+def test_stream_resource_content_unflagged_buffered_data_passes_through(cdp_server):
+    """Network.streamResourceContent returns bare binary bufferedData with no
+    base64Encoded sibling — declared-binary path, must stay byte-identical."""
+    chunk_b64 = "Q2FjaGU/" + "gAAAA" + "E" * 60 + "=="
+    cdp_server.on(
+        "Network.streamResourceContent",
+        lambda params, sid: {"bufferedData": chunk_b64},
+    )
+
+    result = json.loads(
+        browser_cdp_tool.browser_cdp(method="Network.streamResourceContent")
+    )
+
+    assert result["success"] is True
+    assert result["result"]["bufferedData"] == chunk_b64
+
+
+def test_get_request_post_data_flagged_passes_through(cdp_server):
+    """Network.getRequestPostData's postData honors its base64Encoded
+    discriminator on the trusted result path."""
+    post_b64 = "cG9zdA==" + "gAAAA" + "F" * 60 + "="
+    cdp_server.on(
+        "Network.getRequestPostData",
+        lambda params, sid: {"postData": post_b64, "base64Encoded": True},
+    )
+
+    result = json.loads(
+        browser_cdp_tool.browser_cdp(method="Network.getRequestPostData")
+    )
+
+    assert result["success"] is True
+    assert result["result"]["postData"] == post_b64
+
+
+def test_get_request_post_data_unflagged_still_redacts(cdp_server):
+    fake_key = "sk-" + "CDPPOSTDATASECRET1234567890"
+    cdp_server.on(
+        "Network.getRequestPostData",
+        lambda params, sid: {
+            "postData": f"leak {fake_key} here",
+            "base64Encoded": False,
+        },
+    )
+
+    result = json.loads(
+        browser_cdp_tool.browser_cdp(method="Network.getRequestPostData")
+    )
+
+    assert result["success"] is True
+    assert "CDPPOSTDATASECRET" not in json.dumps(result)
+
+
+def test_nested_unflagged_binary_path_passes_through(cdp_server):
+    """CacheStorage.requestCachedResponse.response.body is a nested binary
+    carrier — the path must exempt the nested field while unrelated nested
+    text keeps redaction."""
+    fake_key = "sk-" + "CDPNESTEDSECRET1234567890"
+    body_b64 = "SUNBRQ/" + "gAAAA" + "G" * 60 + "=="
+    cdp_server.on(
+        "CacheStorage.requestCachedResponse",
+        lambda params, sid: {
+            "response": {
+                "url": "https://example.test/x",
+                "body": body_b64,
+                "note": fake_key,
+            }
+        },
+    )
+
+    result = json.loads(
+        browser_cdp_tool.browser_cdp(method="CacheStorage.requestCachedResponse")
+    )
+
+    assert result["success"] is True
+    assert result["result"]["response"]["body"] == body_b64
+    assert "CDPNESTEDSECRET" not in json.dumps(result)
+
+
 # ---------------------------------------------------------------------------
 # Happy-path: target-attached call
 # ---------------------------------------------------------------------------

--- a/tools/browser_cdp_tool.py
+++ b/tools/browser_cdp_tool.py
@@ -43,38 +43,52 @@ _CDP_PRIVATE_PAGE_ALLOWED_METHODS = {
 }
 
 
-_CDP_BINARY_RESULT_FIELDS: Dict[str, frozenset] = {
-    # Protocol carriers whose result.<field> is an opaque base64 payload with
-    # no discriminator flag of their own. redact_sensitive_text's Fernet
-    # pattern ("gAAAA" + base64 alphabet) can match arbitrary spans inside
-    # such payloads — collapsing them to "first6...last4" and corrupting the
-    # decoded bytes (#94138). The payload is binary, not free text the model
-    # reads, so redaction has no secret to protect there. The generic
-    # body/read methods (Network.getResponseBody, Fetch.getResponseBody,
-    # IO.read, Network.streamResourceContent) are NOT here: they carry a
-    # base64Encoded sibling and go through the discriminator below.
-    "Page.captureScreenshot": frozenset({"data"}),
-    "Page.printToPDF": frozenset({"data"}),
+_CDP_ALWAYS_BINARY_PATHS: Dict[str, tuple] = {
+    # method → result paths that are ALWAYS opaque base64 payloads (the
+    # protocol declares them binary with no flag of their own).
+    # redact_sensitive_text's Fernet pattern ("gAAAA" + base64 alphabet) can
+    # match arbitrary spans inside such payloads — collapsing them to
+    # "first6...last4" and corrupting the decoded bytes (#94138). The payload
+    # is binary, not free text the model reads, so redaction has no secret to
+    # protect there.
+    "Page.captureScreenshot": (("data",),),
+    "Page.printToPDF": (("data",),),
+    "Network.streamResourceContent": (("bufferedData",),),
+    "HeadlessExperimental.beginFrame": (("screenshotData",),),
+    "CacheStorage.requestCachedResponse": (("response", "body"),),
 }
 
-# Generic body/read methods signal "this string is opaque base64 bytes" via a
-# sibling boolean. Honor the protocol discriminator anywhere it appears: the
-# flag is type information, so it is safe to trust even for methods not
-# listed above (#94138 review on #94142).
-_BASE64_DISCRIMINATED_FIELDS = frozenset({"body", "data", "bufferedData"})
+_CDP_FLAGGED_BINARY_PATHS: Dict[str, tuple] = {
+    # method → result paths that are opaque base64 ONLY when the dict that
+    # carries the final field has a ``base64Encoded`` sibling that is exactly
+    # ``True``. The discriminator is type information only at these
+    # protocol-defined paths; ``base64Encoded: false`` or absent means text,
+    # which is redacted.
+    "Network.getResponseBody": (("body",),),
+    "Fetch.getResponseBody": (("body",),),
+    "IO.read": (("data",),),
+    "Network.getRequestPostData": (("postData",),),
+}
 
 
-def _redact_cdp_output(value: Any, *, exempt_fields: frozenset = frozenset()) -> Any:
+def _redact_cdp_output(
+    value: Any,
+    *,
+    always_paths: tuple = (),
+    flagged_paths: tuple = (),
+) -> Any:
     """Redact browser-originated CDP result data before returning it.
 
     Policy: semantic text is redacted; opaque bytes stay byte-identical
-    (#94138). *exempt_fields* names the calling method's top-level binary
-    payload fields (``_CDP_BINARY_RESULT_FIELDS``), so only those exact
-    ``method.result.<field>`` slots skip redaction — sibling fields keep
-    full redaction. Any dict whose ``base64Encoded`` sibling is exactly
-    ``True`` exempts its ``body``/``data``/``bufferedData`` string the same
-    way; ``base64Encoded: false`` or absent means the value is text and is
-    redacted.
+    (#94138). Exemptions come ONLY from the calling method's spec
+    (``_CDP_ALWAYS_BINARY_PATHS`` / ``_CDP_FLAGGED_BINARY_PATHS``) as exact
+    result paths — every other string in every result keeps full
+    ``redact_sensitive_text(force=True)``. Path suffixes are propagated only
+    into the matching subtree, so ``base64Encoded`` is honored solely as a
+    sibling on the trusted carrier object, never as ambient trust in
+    arbitrary nested JSON (a ``Runtime.evaluate`` by-value object could
+    otherwise spoof ``{"base64Encoded": true, "data": "<secret>"}`` past the
+    redactor — second review on #94142).
     """
     from agent.redact import redact_sensitive_text
 
@@ -88,16 +102,26 @@ def _redact_cdp_output(value: Any, *, exempt_fields: frozenset = frozenset()) ->
         base64_flagged = value.get("base64Encoded") is True
         redacted: Dict[str, Any] = {}
         for key, item in value.items():
-            if (
-                isinstance(item, str)
-                and (
-                    key in exempt_fields
-                    or (base64_flagged and key in _BASE64_DISCRIMINATED_FIELDS)
-                )
+            terminal_always = any(
+                len(p) == 1 and p[0] == key for p in always_paths
+            )
+            terminal_flagged = any(
+                len(p) == 1 and p[0] == key for p in flagged_paths
+            )
+            if isinstance(item, str) and (
+                terminal_always or (terminal_flagged and base64_flagged)
             ):
                 redacted[key] = item
             else:
-                redacted[key] = _redact_cdp_output(item)
+                redacted[key] = _redact_cdp_output(
+                    item,
+                    always_paths=tuple(
+                        p[1:] for p in always_paths if len(p) > 1 and p[0] == key
+                    ),
+                    flagged_paths=tuple(
+                        p[1:] for p in flagged_paths if len(p) > 1 and p[0] == key
+                    ),
+                )
         return redacted
     return value
 
@@ -571,7 +595,8 @@ def browser_cdp(
         "method": method,
         "result": _redact_cdp_output(
             result,
-            exempt_fields=_CDP_BINARY_RESULT_FIELDS.get(method, frozenset())
+            always_paths=_CDP_ALWAYS_BINARY_PATHS.get(method, ()),
+            flagged_paths=_CDP_FLAGGED_BINARY_PATHS.get(method, ()),
         ),
     }
     if target_id:

--- a/tools/browser_cdp_tool.py
+++ b/tools/browser_cdp_tool.py
@@ -43,18 +43,37 @@ _CDP_PRIVATE_PAGE_ALLOWED_METHODS = {
 }
 
 
-def _redact_cdp_output(value: Any) -> Any:
-    """Redact browser-originated CDP result data before returning it."""
+_BINARY_PAYLOAD_CDP_METHODS = {
+    # Methods whose result is dominated by a base64-encoded binary payload.
+    # redact_sensitive_text's Fernet pattern ("gAAAA" + base64 alphabet) can
+    # match arbitrary spans inside such payloads — collapsing them to
+    # "first6...last4" and corrupting the decoded screenshot/PDF (#94138).
+    # The payload is binary, not free text the model reads, so redaction has
+    # no secret to protect there; every other method keeps full redaction.
+    "Page.captureScreenshot",
+    "Page.printToPDF",
+}
+
+
+def _redact_cdp_output(value: Any, *, binary_payload: bool = False) -> Any:
+    """Redact browser-originated CDP result data before returning it.
+
+    When *binary_payload* is set (the calling method's result is a base64
+    binary payload, see ``_BINARY_PAYLOAD_CDP_METHODS``), strings pass
+    through unchanged so the payload stays byte-identical (#94138).
+    """
     from agent.redact import redact_sensitive_text
 
     if isinstance(value, str):
+        if binary_payload:
+            return value
         return redact_sensitive_text(value, force=True)
     if isinstance(value, list):
-        return [_redact_cdp_output(item) for item in value]
+        return [_redact_cdp_output(item, binary_payload=binary_payload) for item in value]
     if isinstance(value, tuple):
-        return tuple(_redact_cdp_output(item) for item in value)
+        return tuple(_redact_cdp_output(item, binary_payload=binary_payload) for item in value)
     if isinstance(value, dict):
-        return {key: _redact_cdp_output(item) for key, item in value.items()}
+        return {key: _redact_cdp_output(item, binary_payload=binary_payload) for key, item in value.items()}
     return value
 
 # ``websockets`` is a direct hermes-agent dependency because the browser CDP
@@ -525,7 +544,9 @@ def browser_cdp(
     payload: Dict[str, Any] = {
         "success": True,
         "method": method,
-        "result": _redact_cdp_output(result),
+        "result": _redact_cdp_output(
+            result, binary_payload=method in _BINARY_PAYLOAD_CDP_METHODS
+        ),
     }
     if target_id:
         payload["target_id"] = target_id

--- a/tools/browser_cdp_tool.py
+++ b/tools/browser_cdp_tool.py
@@ -43,37 +43,62 @@ _CDP_PRIVATE_PAGE_ALLOWED_METHODS = {
 }
 
 
-_BINARY_PAYLOAD_CDP_METHODS = {
-    # Methods whose result is dominated by a base64-encoded binary payload.
-    # redact_sensitive_text's Fernet pattern ("gAAAA" + base64 alphabet) can
-    # match arbitrary spans inside such payloads — collapsing them to
-    # "first6...last4" and corrupting the decoded screenshot/PDF (#94138).
-    # The payload is binary, not free text the model reads, so redaction has
-    # no secret to protect there; every other method keeps full redaction.
-    "Page.captureScreenshot",
-    "Page.printToPDF",
+_CDP_BINARY_RESULT_FIELDS: Dict[str, frozenset] = {
+    # Protocol carriers whose result.<field> is an opaque base64 payload with
+    # no discriminator flag of their own. redact_sensitive_text's Fernet
+    # pattern ("gAAAA" + base64 alphabet) can match arbitrary spans inside
+    # such payloads — collapsing them to "first6...last4" and corrupting the
+    # decoded bytes (#94138). The payload is binary, not free text the model
+    # reads, so redaction has no secret to protect there. The generic
+    # body/read methods (Network.getResponseBody, Fetch.getResponseBody,
+    # IO.read, Network.streamResourceContent) are NOT here: they carry a
+    # base64Encoded sibling and go through the discriminator below.
+    "Page.captureScreenshot": frozenset({"data"}),
+    "Page.printToPDF": frozenset({"data"}),
 }
 
+# Generic body/read methods signal "this string is opaque base64 bytes" via a
+# sibling boolean. Honor the protocol discriminator anywhere it appears: the
+# flag is type information, so it is safe to trust even for methods not
+# listed above (#94138 review on #94142).
+_BASE64_DISCRIMINATED_FIELDS = frozenset({"body", "data", "bufferedData"})
 
-def _redact_cdp_output(value: Any, *, binary_payload: bool = False) -> Any:
+
+def _redact_cdp_output(value: Any, *, exempt_fields: frozenset = frozenset()) -> Any:
     """Redact browser-originated CDP result data before returning it.
 
-    When *binary_payload* is set (the calling method's result is a base64
-    binary payload, see ``_BINARY_PAYLOAD_CDP_METHODS``), strings pass
-    through unchanged so the payload stays byte-identical (#94138).
+    Policy: semantic text is redacted; opaque bytes stay byte-identical
+    (#94138). *exempt_fields* names the calling method's top-level binary
+    payload fields (``_CDP_BINARY_RESULT_FIELDS``), so only those exact
+    ``method.result.<field>`` slots skip redaction — sibling fields keep
+    full redaction. Any dict whose ``base64Encoded`` sibling is exactly
+    ``True`` exempts its ``body``/``data``/``bufferedData`` string the same
+    way; ``base64Encoded: false`` or absent means the value is text and is
+    redacted.
     """
     from agent.redact import redact_sensitive_text
 
     if isinstance(value, str):
-        if binary_payload:
-            return value
         return redact_sensitive_text(value, force=True)
     if isinstance(value, list):
-        return [_redact_cdp_output(item, binary_payload=binary_payload) for item in value]
+        return [_redact_cdp_output(item) for item in value]
     if isinstance(value, tuple):
-        return tuple(_redact_cdp_output(item, binary_payload=binary_payload) for item in value)
+        return tuple(_redact_cdp_output(item) for item in value)
     if isinstance(value, dict):
-        return {key: _redact_cdp_output(item, binary_payload=binary_payload) for key, item in value.items()}
+        base64_flagged = value.get("base64Encoded") is True
+        redacted: Dict[str, Any] = {}
+        for key, item in value.items():
+            if (
+                isinstance(item, str)
+                and (
+                    key in exempt_fields
+                    or (base64_flagged and key in _BASE64_DISCRIMINATED_FIELDS)
+                )
+            ):
+                redacted[key] = item
+            else:
+                redacted[key] = _redact_cdp_output(item)
+        return redacted
     return value
 
 # ``websockets`` is a direct hermes-agent dependency because the browser CDP
@@ -545,7 +570,8 @@ def browser_cdp(
         "success": True,
         "method": method,
         "result": _redact_cdp_output(
-            result, binary_payload=method in _BINARY_PAYLOAD_CDP_METHODS
+            result,
+            exempt_fields=_CDP_BINARY_RESULT_FIELDS.get(method, frozenset())
         ),
     }
     if target_id:


### PR DESCRIPTION
## Summary

Salvages #94142 by @liuhao1024 onto current main. Fixes #94138: `_redact_cdp_output` applied `redact_sensitive_text(force=True)` to every string in every CDP result, so the Fernet-token pattern (`gAAAA` + base64 alphabet, ≥20 chars) matched inside `Page.captureScreenshot` base64 wherever `+gAAAA…`/`/gAAAA…` occurred, collapsing spans to `first6...last4` and corrupting the decoded PNG. Downstream `vision_analyze` then hit deterministic provider 400 `invalid_image` — one of the corruption SOURCES behind the #69078 bug class whose recovery path just merged as #97059.

The invariant landed here: **semantic text is redacted; opaque bytes stay byte-identical.** Exemptions are bound to explicit method + exact result paths (no ambient trust of `base64Encoded` in arbitrary nested JSON — a `Runtime.evaluate` by-value spoof still redacts).

## Changes

- `tools/browser_cdp_tool.py`
  - `_CDP_ALWAYS_BINARY_PATHS`: protocol-declared unflagged binary carriers — `Page.captureScreenshot.data`, `Page.printToPDF.data`, `Network.streamResourceContent.bufferedData`, `HeadlessExperimental.beginFrame.screenshotData`, nested `CacheStorage.requestCachedResponse.response.body`.
  - `_CDP_FLAGGED_BINARY_PATHS`: carriers exempt only when the trusted carrier object's own `base64Encoded` sibling is exactly `True` — `Network.getResponseBody.body`, `Fetch.getResponseBody.body`, `IO.read.data`, `Network.getRequestPostData.postData`.
  - `_redact_cdp_output` propagates path suffixes only down matching subtrees; every other string in every result keeps full `redact_sensitive_text(force=True)`.
- `tests/tools/test_browser_cdp_tool.py`: regressions for screenshot/PDF byte-identity, all flagged carriers in binary and text modes, the `Runtime.evaluate` `base64Encoded` spoof, unflagged stream content, nested CacheStorage carrier, and sibling-text-still-redacted on binary-bearing results.

Sibling-site audit: `browser_tool.py` / `browser_camofox.py` / `browser_supervisor.py` redact only text (snapshots, console, vision analysis text) — none pass base64 image payloads through `redact_sensitive_text`; the screenshot data-URL path in `browser_tool.py` builds its base64 after redaction boundaries. `browser_cdp` was the sole corrupting site; no widening needed.

## Validation

| Check | Result |
|---|---|
| Live A/B BEFORE (origin/main `_redact_cdp_output`) on real PNG whose base64 contains `+gAAAA`+26 chars | base64 altered; `b64decode` fails (`Incorrect padding`) — corruption reproduced |
| Live A/B AFTER (this branch, `Page.captureScreenshot` paths) | base64 byte-identical; decoded PNG bytes identical |
| Negative: plaintext `sk-…` key in ordinary text | still redacted → `sk-abc...ef12` |
| Sibling string on screenshot result | still redacted while `data` stays intact |
| `Runtime.evaluate` spoof `{"base64Encoded": true, "data": "<secret>"}` | secret still redacted (no ambient trust) |
| `pytest tests/tools/test_browser_cdp_tool.py` + 5 existing redaction test files (`-o addopts=`, MemoryMax=8G) | 60 passed |

**Live repro:** built a real 8×8 PNG, padded to a 3-byte boundary and appended bytes whose base64 is `+gAAAA` + `B`×26 (the issue #94138 Fernet-shape repro); ran it through origin/main's `_redact_cdp_output` (corrupted, undecodable) vs this branch's (byte-identical round-trip), plus the plaintext-key negative — all with the repo venv against worktree imports.

## Attribution

All three substantive commits cherry-picked with original authorship preserved: @liuhao1024 (`sunsky.lau@gmail.com`, already mapped). Review hardening across the three commits driven by @andrexibiza's boundary reviews on #94142.

## Infographic

![infographic](https://v3b.fal.media/files/b/0aa8243f/HSclfe8-nKdHvIIC41C55_umMfJz1u.png)

