### PR TITLE
fix(vision): corrupt or truncated images are rejected before embedding, not after a provider 400 (salvage #53307 + #76896)

### DIFF
--- a/contributors/emails/haiyimei@gmail.com
+++ b/contributors/emails/haiyimei@gmail.com
@@ -1,0 +1,1 @@
+HaiyiMei

--- a/tests/tools/test_image_source.py
+++ b/tests/tools/test_image_source.py
@@ -15,8 +15,14 @@ from unittest.mock import patch
 import pytest
 
 
-PNG = b"\x89PNG\r\n\x1a\n" + b"\x00" * 64
+# Minimal valid 1x1 PNG bytes. Resolver validation requires a decodable fixture.
+PNG = base64.b64decode(
+    b"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
+)
 JPEG = b"\xff\xd8\xff" + b"\x00" * 64
+CORRUPT_PNG = base64.b64decode(
+    b"iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAIAAAACUFjqAAAAFElEQVR4nGP8z8Dwn4EIwESJ5gAAVQ4CH1evYJQAAAAASUVORK5CYII="
+)
 
 
 def _reload(monkeypatch, hermes_home: Path):
@@ -56,6 +62,16 @@ class TestDataUrl:
         with pytest.raises(isrc.NotAnImage):
             await isrc.resolve_image_source(
                 f"data:text/plain;base64,{b64}", isrc.ResolveContext())
+
+    @pytest.mark.asyncio
+    async def test_corrupt_png_rejected_at_resolver_boundary(self, tmp_path, monkeypatch):
+        """A PNG-shaped but undecodable payload never becomes a resolved image."""
+        isrc = _reload(monkeypatch, tmp_path / "hermes")
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        img = tmp_path / "corrupt.png"
+        img.write_bytes(CORRUPT_PNG)
+        with pytest.raises(isrc.NotAnImage):
+            await isrc.resolve_image_source(str(img), isrc.ResolveContext())
 
 
 class TestLocalBackend:

--- a/tests/tools/test_vision_native_fast_path.py
+++ b/tests/tools/test_vision_native_fast_path.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import json
+from io import BytesIO
 from unittest.mock import patch
 
 
@@ -26,6 +27,47 @@ from tools.vision_tools import (
 _TINY_PNG = base64.b64decode(
     b"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
 )
+
+
+def _animated_gif_bytes(colors, *, size=(4, 4)):
+    from PIL import Image
+
+    frames = [Image.new("RGB", size, color) for color in colors]
+    encoded = BytesIO()
+    frames[0].save(
+        encoded,
+        format="GIF",
+        save_all=True,
+        append_images=frames[1:],
+        duration=100,
+        loop=0,
+    )
+    return encoded.getvalue()
+
+
+def _track_validated_frame_loads(monkeypatch):
+    from PIL import ImageSequence
+
+    loaded_frames = []
+    real_iterator = ImageSequence.Iterator
+
+    class TrackedFrame:
+        def __init__(self, frame, frame_number):
+            self.frame = frame
+            self.frame_number = frame_number
+            self.width = frame.width
+            self.height = frame.height
+
+        def load(self):
+            loaded_frames.append(self.frame_number)
+            return self.frame.load()
+
+    def tracking_iterator(image):
+        for frame_number, frame in enumerate(real_iterator(image), start=1):
+            yield TrackedFrame(frame, frame_number)
+
+    monkeypatch.setattr(ImageSequence, "Iterator", tracking_iterator)
+    return loaded_frames
 
 
 # ─── _supports_media_in_tool_results ─────────────────────────────────────────
@@ -94,6 +136,121 @@ class TestVisionAnalyzeNative:
         url = next(p["image_url"]["url"] for p in parts if p.get("type") == "image_url")
         assert url.startswith("data:image/")
 
+    def test_truncated_supported_image_is_rejected_before_embedding(self, tmp_path):
+        """A valid header must not let partially downloaded bytes poison history."""
+        pytest = __import__("pytest")
+        Image = pytest.importorskip(
+            "PIL.Image", reason="Pillow is required for full raster decode validation"
+        )
+
+        truncated = tmp_path / "truncated.png"
+        truncated.write_bytes(_TINY_PNG[:-22])
+
+        # This is the production failure shape: header parsing succeeds, but a
+        # complete decode fails after the partial download is read.
+        with Image.open(truncated) as image:
+            assert image.format == "PNG"
+            with pytest.raises(OSError, match="truncated"):
+                image.load()
+
+        result = asyncio.get_event_loop().run_until_complete(
+            _vision_analyze_native(str(truncated), "describe")
+        )
+
+        assert isinstance(result, str), "corrupt image must not return a multimodal envelope"
+        payload = json.loads(result)
+        assert payload["success"] is False
+        assert "decode" in payload["error"].lower()
+
+    def test_truncated_animated_gif_frame_is_rejected_before_embedding(
+        self, tmp_path, monkeypatch
+    ):
+        """Every frame must decode before an animated raster enters history."""
+        pytest = __import__("pytest")
+        pytest.importorskip(
+            "PIL.Image", reason="Pillow is required for full raster decode validation"
+        )
+        from PIL import Image, ImageSequence
+
+        truncated = tmp_path / "truncated.gif"
+        truncated.write_bytes(_animated_gif_bytes(["red", "blue"])[:-3])
+        monkeypatch.setattr(
+            "tools.vision_tools._VISION_MAX_VALIDATED_FRAME_COUNT", 2
+        )
+        monkeypatch.setattr(
+            "tools.vision_tools._VISION_MAX_VALIDATED_AGGREGATE_PIXELS", 32
+        )
+
+        with Image.open(truncated) as image:
+            assert image.format == "GIF"
+            assert getattr(image, "n_frames", 1) == 2
+            with pytest.raises(OSError, match="truncated"):
+                for frame in ImageSequence.Iterator(image):
+                    frame.load()
+
+        result = asyncio.get_event_loop().run_until_complete(
+            _vision_analyze_native(str(truncated), "describe")
+        )
+
+        assert isinstance(result, str), "corrupt animation must not return a multimodal envelope"
+        payload = json.loads(result)
+        assert payload["success"] is False
+        assert "decode" in payload["error"].lower()
+
+    def test_animation_over_frame_validation_limit_is_rejected(
+        self, tmp_path, monkeypatch
+    ):
+        """A small animation is rejected before an excess frame is decoded."""
+        pytest = __import__("pytest")
+        pytest.importorskip(
+            "PIL.Image", reason="Pillow is required for full raster decode validation"
+        )
+
+        animation = tmp_path / "too-many-frames.gif"
+        animation.write_bytes(_animated_gif_bytes(["red", "green", "blue"]))
+        monkeypatch.setattr(
+            "tools.vision_tools._VISION_MAX_VALIDATED_FRAME_COUNT", 2
+        )
+        loaded_frames = _track_validated_frame_loads(monkeypatch)
+
+        result = asyncio.get_event_loop().run_until_complete(
+            _vision_analyze_native(str(animation), "describe")
+        )
+
+        assert isinstance(result, str)
+        payload = json.loads(result)
+        assert payload["success"] is False
+        assert "frame 3" in payload["error"].lower()
+        assert "maximum 2" in payload["error"].lower()
+        assert loaded_frames == [1, 2]
+
+    def test_animation_over_aggregate_pixel_validation_limit_is_rejected(
+        self, tmp_path, monkeypatch
+    ):
+        """Aggregate decoded pixels are bounded independently of file size."""
+        pytest = __import__("pytest")
+        pytest.importorskip(
+            "PIL.Image", reason="Pillow is required for full raster decode validation"
+        )
+
+        animation = tmp_path / "too-many-pixels.gif"
+        animation.write_bytes(_animated_gif_bytes(["red", "blue"]))
+        monkeypatch.setattr(
+            "tools.vision_tools._VISION_MAX_VALIDATED_AGGREGATE_PIXELS", 31
+        )
+        loaded_frames = _track_validated_frame_loads(monkeypatch)
+
+        result = asyncio.get_event_loop().run_until_complete(
+            _vision_analyze_native(str(animation), "describe")
+        )
+
+        assert isinstance(result, str)
+        payload = json.loads(result)
+        assert payload["success"] is False
+        assert "aggregate decoded pixel" in payload["error"].lower()
+        assert "32" in payload["error"]
+        assert "maximum 31" in payload["error"].lower()
+        assert loaded_frames == [1]
 
     def test_file_url_scheme_resolves(self, tmp_path):
         img = tmp_path / "t.png"

--- a/tests/tools/test_vision_native_fast_path.py
+++ b/tests/tools/test_vision_native_fast_path.py
@@ -28,6 +28,11 @@ _TINY_PNG = base64.b64decode(
     b"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
 )
 
+# PNG-shaped but undecodable; resolver/native fast path must reject it.
+_CORRUPT_PNG = base64.b64decode(
+    b"iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAIAAAACUFjqAAAAFElEQVR4nGP8z8Dwn4EIwESJ5gAAVQ4CH1evYJQAAAAASUVORK5CYII="
+)
+
 
 def _animated_gif_bytes(colors, *, size=(4, 4)):
     from PIL import Image
@@ -260,6 +265,19 @@ class TestVisionAnalyzeNative:
         )
         assert isinstance(result, dict)
         assert result.get("_multimodal") is True
+
+    def test_corrupt_png_rejected_before_native_embed(self, tmp_path):
+        """Header-only PNG bytes must not enter conversation history."""
+        img = tmp_path / "bad.png"
+        img.write_bytes(_CORRUPT_PNG)
+        result = asyncio.get_event_loop().run_until_complete(
+            _vision_analyze_native(str(img), "what is this?")
+        )
+        assert isinstance(result, str)
+        parsed = json.loads(result)
+        assert parsed.get("success") is False
+        assert "multimodal" not in parsed
+        assert "recognized image" in parsed.get("error", "")
 
     def test_oversized_image_resized_under_embed_cap(self, tmp_path):
         """Regression for the wedged-session incident (May 2026).

--- a/tests/tools/test_vision_native_fast_path.py
+++ b/tests/tools/test_vision_native_fast_path.py
@@ -165,7 +165,12 @@ class TestVisionAnalyzeNative:
         assert isinstance(result, str), "corrupt image must not return a multimodal envelope"
         payload = json.loads(result)
         assert payload["success"] is False
-        assert "decode" in payload["error"].lower()
+        # Two stacked gates can catch this: the resolver-boundary verify()
+        # (salvaged #53307) reports "not a recognized image"; the full-decode
+        # gate (salvaged #76896) reports a decode failure. Either rejection
+        # keeps the truncated bytes out of history.
+        err = payload["error"].lower()
+        assert "decode" in err or "not a recognized image" in err
 
     def test_truncated_animated_gif_frame_is_rejected_before_embedding(
         self, tmp_path, monkeypatch

--- a/tests/tools/test_vision_tools.py
+++ b/tests/tools/test_vision_tools.py
@@ -26,6 +26,17 @@ from tools.vision_tools import (
     check_vision_requirements,
 )
 
+# A minimal but STRUCTURALLY VALID 1x1 RGB PNG (passes PIL verify/decode).
+# The proactive corrupt-image gates (salvaged #53307/#76896) now reject
+# magic-bytes-only fakes, so fixtures must be real images. Trailing padding
+# after IEND is ignored by decoders, letting size-sensitive tests keep
+# inflating fixtures with zero bytes.
+VALID_PNG = (
+    b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01"
+    b"\x08\x02\x00\x00\x00\x90wS\xde\x00\x00\x00\x0cIDATx\x9cc```\x00\x00"
+    b"\x00\x04\x00\x01\xf6\x178U\x00\x00\x00\x00IEND\xaeB`\x82"
+)
+
 
 _RESOLVES = [(2, 1, 6, "", ("93.184.216.34", 0))]
 
@@ -90,7 +101,7 @@ class TestDetermineMimeType:
 class TestImageToBase64DataUrl:
     def test_returns_data_url_with_detected_or_given_mime(self, tmp_path):
         img = tmp_path / "test.png"
-        img.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 8)
+        img.write_bytes(VALID_PNG + b"\x00" * 8)
         assert _image_to_base64_data_url(img).startswith("data:image/png;base64,")
 
         other = tmp_path / "test.bin"
@@ -245,7 +256,7 @@ class TestVisionConfig:
     @pytest.mark.asyncio
     async def test_temperature_and_timeout_come_from_config_with_defaults(self, tmp_path):
         img = tmp_path / "test.png"
-        img.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 8)
+        img.write_bytes(VALID_PNG + b"\x00" * 8)
 
         async def call_with(config):
             mock_response = MagicMock()
@@ -384,7 +395,7 @@ class TestVisionSafetyGuards:
                 return None
 
             async def aiter_bytes(self):
-                yield b"\x89PNG\r\n\x1a\n" + b"\x00" * 16
+                yield VALID_PNG + b"\x00" * 16
 
         class _FakeAsyncStream:
             def __init__(self, response):
@@ -463,7 +474,7 @@ class TestVisionSafetyGuards:
         """Malformed Content-Length is ignored; streaming size cap still works."""
         from tools.vision_tools import _download_image
 
-        body = b"\x89PNG\r\n\x1a\n" + b"\x00" * 16
+        body = VALID_PNG + b"\x00" * 16
         dest = tmp_path / "cat.png"
 
         class _FakeStreamResponse:
@@ -539,7 +550,7 @@ class TestLocalPathForms:
         fake_home = tmp_path / "fakehome"
         fake_home.mkdir()
         img = fake_home / "test_image.png"
-        img.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 8)
+        img.write_bytes(VALID_PNG + b"\x00" * 8)
 
         # Windows expanduser() prefers USERPROFILE over HOME; POSIX uses HOME.
         monkeypatch.setenv("HOME", str(fake_home))
@@ -576,7 +587,7 @@ class TestLocalPathForms:
     @pytest.mark.asyncio
     async def test_file_uri_resolved_as_local_path(self, tmp_path):
         img = tmp_path / "photo.png"
-        img.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 8)
+        img.write_bytes(VALID_PNG + b"\x00" * 8)
 
         mock_response = MagicMock()
         mock_choice = MagicMock()
@@ -617,10 +628,16 @@ class TestBase64SizeLimit:
     @pytest.mark.asyncio
     async def test_oversized_rejected_before_api_call_small_passes(self, tmp_path):
         img = tmp_path / "huge.png"
-        img.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * (4 * 1024 * 1024))
+        img.write_bytes(VALID_PNG + b"\x00" * (4 * 1024 * 1024))
 
-        # Patch the hard limit to a small value so the test runs fast.
+        # Patch the hard limit to a small value so the test runs fast, and pin
+        # the resize target above it so the auto-resize can't legitimately
+        # shrink the (now decodable) fixture under the limit — this test
+        # isolates the pre-flight size REJECTION, not the resize recovery.
         with patch("tools.vision_tools._MAX_BASE64_BYTES", 1000), \
+             patch("tools.vision_tools._resize_image_for_vision",
+                   side_effect=lambda p, *a, **k: "data:image/png;base64," +
+                   base64.b64encode(Path(p).read_bytes()).decode("ascii")), \
              patch("tools.vision_tools.async_call_llm", new_callable=AsyncMock) as mock_llm:
             result = json.loads(await vision_analyze_tool(str(img), "describe this"))
 
@@ -630,7 +647,7 @@ class TestBase64SizeLimit:
 
         # An image well under the limit passes the size check.
         small = tmp_path / "small.png"
-        small.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 64)
+        small.write_bytes(VALID_PNG + b"\x00" * 64)
 
         mock_response = MagicMock()
         mock_choice = MagicMock()
@@ -661,7 +678,7 @@ class TestErrorClassification:
     async def test_invalid_request_error_gives_image_guidance(self, tmp_path):
         """An invalid_request_error from the API should mention image size/format."""
         img = tmp_path / "test.png"
-        img.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 8)
+        img.write_bytes(VALID_PNG + b"\x00" * 8)
 
         api_error = Exception(
             "Error code: 400 - {'type': 'error', 'error': "
@@ -730,7 +747,7 @@ class TestResizeImageForVision:
         # Create a dummy file
         path = tmp_path / "test.png"
         # Write enough bytes to exceed a tiny limit
-        path.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 1000)
+        path.write_bytes(VALID_PNG + b"\x00" * 1000)
 
         with patch("tools.vision_tools._image_to_base64_data_url") as mock_b64:
             # Simulate a large base64 result
@@ -873,7 +890,7 @@ class TestImageExceedsDimension:
         # dimensions, so return False: the byte-based checks still apply and a
         # missing soft dep never breaks the embed path.
         path = tmp_path / "x.png"
-        path.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 100)
+        path.write_bytes(VALID_PNG + b"\x00" * 100)
         with patch.dict("sys.modules", {"PIL": None, "PIL.Image": None}):
             assert _image_exceeds_dimension(path, _EMBED_MAX_DIMENSION) is False
 

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -33,6 +33,7 @@ import contextlib
 import asyncio
 import json
 from concurrent.futures import ThreadPoolExecutor
+from io import BytesIO
 import logging
 import os
 import uuid
@@ -251,6 +252,15 @@ def _detect_image_mime_type_from_bytes(data: bytes) -> Optional[str]:
     """
     header = data[:64]
     if header.startswith(b"\x89PNG\r\n\x1a\n"):
+        # Magic bytes alone are insufficient: native vision history is
+        # immutable, so reject corrupt PNGs before they can be embedded.
+        try:
+            from PIL import Image
+
+            with Image.open(BytesIO(data)) as image:
+                image.verify()
+        except Exception:
+            return None
         return "image/png"
     if header.startswith(b"\xff\xd8\xff"):
         return "image/jpeg"

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -254,9 +254,15 @@ def _detect_image_mime_type_from_bytes(data: bytes) -> Optional[str]:
     if header.startswith(b"\x89PNG\r\n\x1a\n"):
         # Magic bytes alone are insufficient: native vision history is
         # immutable, so reject corrupt PNGs before they can be embedded.
+        # Pillow is an optional dependency — when it is missing we fall back
+        # to header-only sniffing (the full-decode gate in
+        # _validate_raster_image_decodable is likewise skipped without PIL);
+        # only an actual failed verify() rejects the bytes.
         try:
             from PIL import Image
-
+        except ImportError:
+            return "image/png"
+        try:
             with Image.open(BytesIO(data)) as image:
                 image.verify()
         except Exception:
@@ -410,7 +416,11 @@ def _validate_raster_image_decodable(image_path: Path) -> Optional[str]:
     try:
         from PIL import Image as _PILImage
         from PIL import ImageSequence as _PILImageSequence
-
+    except ImportError:
+        # Pillow is optional — without it we cannot decode-validate, so pass
+        # the image through unvalidated rather than rejecting everything.
+        return None
+    try:
         with _PILImage.open(image_path) as image:
             image.verify()
         with _PILImage.open(image_path) as image:

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -379,6 +379,62 @@ def _normalize_to_supported_image(
     )
 
 
+# Full raster validation runs on untrusted images in a shared CPU executor.
+# Bound animated-image work by both iteration count and total decoded area so a
+# compact file cannot monopolize a worker with an effectively unbounded number
+# of frames. Images at or below both limits still have every frame decoded.
+_VISION_MAX_VALIDATED_FRAME_COUNT = 100
+_VISION_MAX_VALIDATED_AGGREGATE_PIXELS = 100_000_000
+
+
+def _validate_raster_image_decodable(image_path: Path) -> Optional[str]:
+    """Return an error when Pillow cannot completely decode every image frame.
+
+    Magic-byte MIME sniffing and ``Image.open`` only inspect container headers.
+    A timed-out download can therefore look like a supported PNG/JPEG/GIF/WebP
+    while its pixel stream is truncated. Native vision results are retained in
+    conversation history, so embedding those bytes poisons every later provider
+    request. Verify structure, then reopen and force every frame within the
+    validation resource limits to decode before the image can enter history.
+    """
+    try:
+        from PIL import Image as _PILImage
+        from PIL import ImageSequence as _PILImageSequence
+
+        with _PILImage.open(image_path) as image:
+            image.verify()
+        with _PILImage.open(image_path) as image:
+            validated_pixels = 0
+            for frame_number, frame in enumerate(
+                _PILImageSequence.Iterator(image), start=1
+            ):
+                if frame_number > _VISION_MAX_VALIDATED_FRAME_COUNT:
+                    return (
+                        "Image validation rejected animation: "
+                        f"frame {frame_number} exceeds the maximum "
+                        f"{_VISION_MAX_VALIDATED_FRAME_COUNT} validated frames."
+                    )
+
+                frame_pixels = frame.width * frame.height
+                next_validated_pixels = validated_pixels + frame_pixels
+                if (
+                    next_validated_pixels
+                    > _VISION_MAX_VALIDATED_AGGREGATE_PIXELS
+                ):
+                    return (
+                        "Image validation rejected animation: aggregate decoded "
+                        f"pixel count would reach {next_validated_pixels} at frame "
+                        f"{frame_number}, exceeding the maximum "
+                        f"{_VISION_MAX_VALIDATED_AGGREGATE_PIXELS}."
+                    )
+
+                frame.load()
+                validated_pixels = next_validated_pixels
+    except Exception as exc:
+        return f"Image could not be fully decoded: {exc}"
+    return None
+
+
 def _is_retryable_download_error(error: Exception) -> bool:
     """Return True only for transient image-download failures worth retrying.
 
@@ -1225,6 +1281,12 @@ async def _vision_analyze_native(
             temp_image_path = normalized_path
             should_cleanup = True
             image_size_bytes = temp_image_path.stat().st_size
+
+        decode_error = await _run_encode_on_cpu_executor(
+            _validate_raster_image_decodable, temp_image_path,
+        )
+        if decode_error:
+            return tool_error(decode_error, success=False)
 
         # Optional region zoom: crop BEFORE the downscale/embed-cap pipeline
         # so the cropped area gets the full resolution budget.


### PR DESCRIPTION
## Summary

Salvages two overlapping community PRs that add **proactive corrupt/truncated image validation before embedding** into native vision history — the proactive half of the corrupt-image story, complementing #97059's reactive strip-and-retry recovery. Fixes #76884.

Credit to both contributors, whose commits are cherry-picked with authorship intact:

- **@CannibalKush** (#53307, submitted first — June 26): `verify()` gate at the shared resolver boundary (`_detect_image_mime_type_from_bytes`), so PNG-shaped garbage is rejected at the choke point every embed path flows through.
- **@HaiyiMei** (#76896, fixes #76884): full-decode validation (`_validate_raster_image_decodable`) in `_vision_analyze_native` — catches truncated pixel streams that pass header checks, decodes every animation frame with frame-count and aggregate-pixel resource caps.

The two gates stack: the resolver `verify()` catches structurally corrupt bytes early; the full-decode gate catches truncation that only surfaces on `frame.load()`. Rejection is surgical — only the failing image is refused with a normal tool error; no multimodal envelope enters immutable conversation history, so later provider requests are never poisoned by a 400-provoking payload.

A maintainer follow-up commit makes both validators degrade gracefully when Pillow is missing (PIL is an optional dep everywhere else in `tools/vision_tools.py`): missing PIL means pass-through header sniffing, not blanket rejection. The overlapping reactive `_is_image_rejection_error` refactor in #76896 was dropped — main already ships that recovery via #97059.

## Changes

- `tools/vision_tools.py`
  - `_detect_image_mime_type_from_bytes`: Pillow `verify()` on PNG payloads before returning `image/png` (from #53307), with graceful fallback when Pillow is absent.
  - New `_validate_raster_image_decodable` + full-decode gate in `_vision_analyze_native`, bounded by `_VISION_MAX_VALIDATED_FRAME_COUNT` (100) and `_VISION_MAX_VALIDATED_AGGREGATE_PIXELS` (100M) (from #76896), same Pillow-optional fallback.
- `tests/tools/test_image_source.py`: corrupt PNG rejected at the resolver boundary (from #53307).
- `tests/tools/test_vision_native_fast_path.py`: corrupt PNG, truncated PNG, truncated animated GIF, frame-count cap, aggregate-pixel cap (union of both PRs' tests; truncated-PNG test accepts rejection at either stacked gate).
- `contributors/emails/`: mapping for HaiyiMei.

## Validation

| Input | Before (origin/main) | After (this branch) |
|---|---|---|
| Valid 1×1 PNG | embedded (multimodal envelope) | embedded (multimodal envelope) ✅ |
| Truncated PNG (cut at 60%) | **embedded → provider 400** | rejected: "source is not a recognized image" ✅ |
| Garbage bytes with PNG magic | **embedded → provider 400** | rejected: "source is not a recognized image" ✅ |

**Live repro:** real `_vision_analyze_native()` calls against origin/main file copies vs this branch with the venv Python — before: all three inputs produced multimodal envelopes; after: both corrupt inputs return tool errors, valid PNG still embeds. Targeted suite: `tests/tools/test_image_source.py tests/tools/test_vision_native_fast_path.py tests/run_agent/test_image_rejection_fallback.py` → **44 passed**.

## Infographic

![infographic](https://v3b.fal.media/files/b/0aa82440/0PHnVkxmRkd2O88c6k78z_IyXqMuw0.png)

