### PR TITLE
fix(tools): align inspection surfaces with disabled composite toolsets

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8504,7 +8504,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                         from model_tools import get_toolset_for_tool
                         tools = get_tool_definitions(
                             enabled_toolsets=self.enabled_toolsets,
-                            disabled_toolsets=self.disabled_toolsets,
+                            disabled_toolsets=getattr(self, "disabled_toolsets", None),
                             quiet_mode=True,
                         )
                         availability = compute_toolset_availability(self.enabled_toolsets)
@@ -8534,7 +8534,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 from model_tools import get_toolset_for_tool
                 tools = get_tool_definitions(
                     enabled_toolsets=self.enabled_toolsets,
-                    disabled_toolsets=self.disabled_toolsets,
+                    disabled_toolsets=getattr(self, "disabled_toolsets", None),
                     quiet_mode=True,
                 )
                 availability = compute_toolset_availability(self.enabled_toolsets)
@@ -9196,7 +9196,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         else:
             tools = get_tool_definitions(
                 enabled_toolsets=self.enabled_toolsets,
-                disabled_toolsets=self.disabled_toolsets,
+                disabled_toolsets=getattr(self, "disabled_toolsets", None),
                 quiet_mode=True,
             )
             tool_count = len(tools) if tools else 0
@@ -9499,7 +9499,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # tool_search bridge (users check this to verify an MCP installed).
         tools = get_tool_definitions(
             enabled_toolsets=self.enabled_toolsets,
-            disabled_toolsets=self.disabled_toolsets,
+            disabled_toolsets=getattr(self, "disabled_toolsets", None),
             quiet_mode=True,
             skip_tool_search_assembly=True,
         )
@@ -12140,7 +12140,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 else:
                     tools = get_tool_definitions(
                         enabled_toolsets=self.enabled_toolsets,
-                        disabled_toolsets=self.disabled_toolsets,
+                        disabled_toolsets=getattr(self, "disabled_toolsets", None),
                         quiet_mode=True,
                     )
                     cwd = os.getenv("TERMINAL_CWD", os.getcwd())

--- a/cli.py
+++ b/cli.py
@@ -8503,7 +8503,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     try:
                         from model_tools import get_toolset_for_tool
                         tools = get_tool_definitions(
-                            enabled_toolsets=self.enabled_toolsets, quiet_mode=True
+                            enabled_toolsets=self.enabled_toolsets,
+                            disabled_toolsets=self.disabled_toolsets,
+                            quiet_mode=True,
                         )
                         availability = compute_toolset_availability(self.enabled_toolsets)
                         tmap = {
@@ -8530,7 +8532,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 # Cold path: compute everything live, then persist the snapshot
                 # so the next launch replays it.
                 from model_tools import get_toolset_for_tool
-                tools = get_tool_definitions(enabled_toolsets=self.enabled_toolsets, quiet_mode=True)
+                tools = get_tool_definitions(
+                    enabled_toolsets=self.enabled_toolsets,
+                    disabled_toolsets=self.disabled_toolsets,
+                    quiet_mode=True,
+                )
                 availability = compute_toolset_availability(self.enabled_toolsets)
 
                 build_welcome_banner(
@@ -9188,7 +9194,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         if os.environ.get("HERMES_DEFER_AGENT_STARTUP") == "1":
             tool_status = "tools deferred"
         else:
-            tools = get_tool_definitions(enabled_toolsets=self.enabled_toolsets, quiet_mode=True)
+            tools = get_tool_definitions(
+                enabled_toolsets=self.enabled_toolsets,
+                disabled_toolsets=self.disabled_toolsets,
+                quiet_mode=True,
+            )
             tool_count = len(tools) if tools else 0
             tool_status = f"{tool_count} tools"
 
@@ -9487,8 +9497,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # Pre-assembly list: /tools is a discovery/inspection surface, so it
         # must show the full catalog including tools deferred behind the
         # tool_search bridge (users check this to verify an MCP installed).
-        tools = get_tool_definitions(enabled_toolsets=self.enabled_toolsets, quiet_mode=True,
-                                     skip_tool_search_assembly=True)
+        tools = get_tool_definitions(
+            enabled_toolsets=self.enabled_toolsets,
+            disabled_toolsets=self.disabled_toolsets,
+            quiet_mode=True,
+            skip_tool_search_assembly=True,
+        )
         
         if not tools:
             print("(;_;) No tools available")
@@ -12124,7 +12138,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 if self.compact or term_w < 80:
                     cc.print(_build_compact_banner())
                 else:
-                    tools = get_tool_definitions(enabled_toolsets=self.enabled_toolsets, quiet_mode=True)
+                    tools = get_tool_definitions(
+                        enabled_toolsets=self.enabled_toolsets,
+                        disabled_toolsets=self.disabled_toolsets,
+                        quiet_mode=True,
+                    )
                     cwd = os.getenv("TERMINAL_CWD", os.getcwd())
                     ctx_len = None
                     if hasattr(self, 'agent') and self.agent and hasattr(self.agent, 'context_compressor'):

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -2490,6 +2490,57 @@ def _platform_toolset_summary(config: dict, platforms: Optional[List[str]] = Non
     return summary
 
 
+def _prune_platform_toolsets_after_agent_disabled(
+    enabled_toolsets: set[str],
+    disabled_toolsets,
+) -> set[str]:
+    """Drop platform toolset names with no surviving tools after disabled subtraction.
+
+    ``_get_platform_tools`` historically subtracted ``agent.disabled_toolsets``
+    by *name* only, which is a no-op for composite entries like ``debugging``
+    when the platform holds constituent keys (``terminal``, ``web``, …).
+    Inspection surfaces must mirror runtime tool-level subtraction (#97015).
+    """
+    if not disabled_toolsets:
+        return enabled_toolsets
+
+    from agent.skill_utils import parse_config_string_list
+    from model_tools import _LEGACY_TOOLSET_MAP, apply_disabled_toolsets_to_tool_names
+    from toolsets import resolve_toolset, validate_toolset
+
+    disabled_names = [
+        name.strip() for name in parse_config_string_list(disabled_toolsets) if name.strip()
+    ]
+    if not disabled_names:
+        return enabled_toolsets
+
+    result = set(enabled_toolsets)
+    result -= set(disabled_names)
+
+    tools: set[str] = set()
+    for ts_key in result:
+        if validate_toolset(ts_key):
+            tools.update(resolve_toolset(ts_key))
+        elif ts_key in _LEGACY_TOOLSET_MAP:
+            tools.update(_LEGACY_TOOLSET_MAP[ts_key])
+
+    surviving = apply_disabled_toolsets_to_tool_names(tools, disabled_names)
+
+    pruned: set[str] = set()
+    passthrough: set[str] = set()
+    for ts_key in result:
+        if validate_toolset(ts_key):
+            ts_tools = set(resolve_toolset(ts_key))
+        elif ts_key in _LEGACY_TOOLSET_MAP:
+            ts_tools = set(_LEGACY_TOOLSET_MAP[ts_key])
+        else:
+            passthrough.add(ts_key)
+            continue
+        if ts_tools & surviving:
+            pruned.add(ts_key)
+    return pruned | passthrough
+
+
 def _parse_enabled_flag(value, default: bool = True) -> bool:
     """Parse bool-like config values used by tool/platform settings."""
     if value is None:
@@ -2898,12 +2949,9 @@ def _get_platform_tools(
     agent_cfg = config.get("agent") or {}
     disabled_toolsets = agent_cfg.get("disabled_toolsets") or []
     if disabled_toolsets:
-        from agent.skill_utils import parse_config_string_list
-
-        disabled_set = {
-            name.strip() for name in parse_config_string_list(disabled_toolsets) if name.strip()
-        }
-        enabled_toolsets -= disabled_set
+        enabled_toolsets = _prune_platform_toolsets_after_agent_disabled(
+            enabled_toolsets, disabled_toolsets
+        )
 
     # #38798: if this platform was explicitly configured but every toolset name
     # is invalid (e.g. a migration or hand-edit left `hermes` instead of

--- a/model_tools.py
+++ b/model_tools.py
@@ -423,7 +423,7 @@ def apply_disabled_toolsets_to_tool_names(
     Composite/scenario toolsets (e.g. ``debugging``) resolve to their member
     tools; platform bundles and posture toolsets only subtract their non-core
     delta so shared core tools stay available (#17309, #33924, #57315).
-  """
+    """
     if not disabled_toolsets:
         return set(tools_to_include)
 

--- a/model_tools.py
+++ b/model_tools.py
@@ -414,6 +414,33 @@ def get_tool_definitions(
     return result
 
 
+def apply_disabled_toolsets_to_tool_names(
+    tools_to_include: set[str],
+    disabled_toolsets: Optional[List[str]] = None,
+) -> set[str]:
+    """Subtract tools belonging to ``agent.disabled_toolsets`` at tool granularity.
+
+    Composite/scenario toolsets (e.g. ``debugging``) resolve to their member
+    tools; platform bundles and posture toolsets only subtract their non-core
+    delta so shared core tools stay available (#17309, #33924, #57315).
+  """
+    if not disabled_toolsets:
+        return set(tools_to_include)
+
+    result = set(tools_to_include)
+    for toolset_name in disabled_toolsets:
+        if validate_toolset(toolset_name):
+            from toolsets import bundle_non_core_tools, get_toolset
+
+            if toolset_name.startswith("hermes-") or (get_toolset(toolset_name) or {}).get("posture"):
+                result.difference_update(bundle_non_core_tools(toolset_name))
+            else:
+                result.difference_update(resolve_toolset(toolset_name))
+        elif toolset_name in _LEGACY_TOOLSET_MAP:
+            result.difference_update(_LEGACY_TOOLSET_MAP[toolset_name])
+    return result
+
+
 def _compute_tool_definitions(
     enabled_toolsets: Optional[List[str]] = None,
     disabled_toolsets: Optional[List[str]] = None,
@@ -462,43 +489,45 @@ def _compute_tool_definitions(
     # is enabled, any tools belonging to a disabled toolset are strictly
     # stripped out. See issue #17309.
     if disabled_toolsets:
-        for toolset_name in disabled_toolsets:
-            if validate_toolset(toolset_name):
-                from toolsets import bundle_non_core_tools, get_toolset
-                if toolset_name.startswith("hermes-") or (get_toolset(toolset_name) or {}).get("posture"):
-                    # Platform bundles (hermes-*) include _HERMES_CORE_TOOLS, and
-                    # posture toolsets (`posture: True`, e.g. `coding`) re-list
-                    # those same core tools without owning them, so subtracting
-                    # the whole toolset would strip core tools shared by other
-                    # enabled toolsets and empty the tool list (#33924, #57315).
-                    # Subtract only the non-core delta; keep core.
-                    to_remove = bundle_non_core_tools(toolset_name)
-                    tools_to_include.difference_update(to_remove)
-                    resolved = sorted(to_remove)
-                    if (not quiet_mode and toolset_name.startswith("hermes-")
-                            and toolset_name not in _WARNED_DISABLED_BUNDLES):
-                        _WARNED_DISABLED_BUNDLES.add(toolset_name)
-                        logger.info(
-                            "agent.disabled_toolsets contains platform-bundle "
-                            "name '%s'; core tools are preserved and only its "
-                            "platform-specific tools (%s) are removed. Bundle "
-                            "names usually belong in `toolsets:`, not "
-                            "`disabled_toolsets` (#33924).",
-                            toolset_name,
-                            ", ".join(resolved) if resolved else "none",
-                        )
+        tools_to_include = apply_disabled_toolsets_to_tool_names(
+            tools_to_include, disabled_toolsets
+        )
+        if not quiet_mode:
+            for toolset_name in disabled_toolsets:
+                if validate_toolset(toolset_name):
+                    from toolsets import bundle_non_core_tools, get_toolset
+
+                    if toolset_name.startswith("hermes-") or (get_toolset(toolset_name) or {}).get("posture"):
+                        to_remove = bundle_non_core_tools(toolset_name)
+                        resolved = sorted(to_remove)
+                        if (
+                            toolset_name.startswith("hermes-")
+                            and toolset_name not in _WARNED_DISABLED_BUNDLES
+                        ):
+                            _WARNED_DISABLED_BUNDLES.add(toolset_name)
+                            logger.info(
+                                "agent.disabled_toolsets contains platform-bundle "
+                                "name '%s'; core tools are preserved and only its "
+                                "platform-specific tools (%s) are removed. Bundle "
+                                "names usually belong in `toolsets:`, not "
+                                "`disabled_toolsets` (#33924).",
+                                toolset_name,
+                                ", ".join(resolved) if resolved else "none",
+                            )
+                    else:
+                        resolved = sorted(resolve_toolset(toolset_name))
+                    print(
+                        f"🚫 Disabled toolset '{toolset_name}': "
+                        f"{', '.join(resolved) if resolved else 'no tools'}"
+                    )
+                elif toolset_name in _LEGACY_TOOLSET_MAP:
+                    legacy_tools = _LEGACY_TOOLSET_MAP[toolset_name]
+                    print(
+                        f"🚫 Disabled legacy toolset '{toolset_name}': "
+                        f"{', '.join(legacy_tools)}"
+                    )
                 else:
-                    resolved = resolve_toolset(toolset_name)
-                    tools_to_include.difference_update(resolved)
-                if not quiet_mode:
-                    print(f"🚫 Disabled toolset '{toolset_name}': {', '.join(resolved) if resolved else 'no tools'}")
-            elif toolset_name in _LEGACY_TOOLSET_MAP:
-                legacy_tools = _LEGACY_TOOLSET_MAP[toolset_name]
-                tools_to_include.difference_update(legacy_tools)
-                if not quiet_mode:
-                    print(f"🚫 Disabled legacy toolset '{toolset_name}': {', '.join(legacy_tools)}")
-            elif not quiet_mode:
-                print(f"⚠️  Unknown toolset: {toolset_name}")
+                    print(f"⚠️  Unknown toolset: {toolset_name}")
 
     # Plugin-registered tools are now resolved through the normal toolset
     # path — validate_toolset() / resolve_toolset() / get_all_toolsets()

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -1103,6 +1103,42 @@ def test_agent_disabled_toolsets_python_literal_string_form_still_wins():
     assert not (_RECENTLY_SHIPPED_TOOLSETS & enabled)
 
 
+def test_disabled_composite_debugging_prunes_constituent_platform_toolsets():
+    """#97015: ``agent.disabled_toolsets: [debugging]`` must hide member
+    toolsets on ``hermes tools --summary``, not only strip them at runtime."""
+    config = {
+        "platform_toolsets": {"cli": ["hermes-cli"]},
+        "agent": {"disabled_toolsets": ["debugging"]},
+    }
+    enabled = _get_platform_tools(config, "cli", include_default_mcp_servers=False)
+
+    assert "terminal" not in enabled
+    assert "file" not in enabled
+    assert "web" not in enabled
+
+
+def test_disabled_composite_debugging_matches_runtime_tool_definitions():
+    """CLI inspection surfaces should list the same tools the agent receives."""
+    from model_tools import get_tool_definitions
+
+    config = {
+        "platform_toolsets": {"cli": ["hermes-cli"]},
+        "agent": {"disabled_toolsets": ["debugging"]},
+    }
+    enabled = sorted(_get_platform_tools(config, "cli", include_default_mcp_servers=False))
+    summary_tools = {
+        t["function"]["name"]
+        for t in get_tool_definitions(
+            enabled_toolsets=enabled,
+            disabled_toolsets=["debugging"],
+            quiet_mode=True,
+        )
+    }
+    assert "terminal" not in summary_tools
+    assert "read_file" not in summary_tools
+    assert "web_search" not in summary_tools
+
+
 @_requires_recently_shipped
 def test_platforms_whose_composite_excludes_it_are_left_narrow():
     """Parity is the justification, so don't widen a deliberately small


### PR DESCRIPTION
## Summary
- Fixes #97015: `hermes tools --summary`, welcome banner, `/tools`, and status-line tool counts used name-level `agent.disabled_toolsets` subtraction, so disabling a composite toolset like `debugging` still showed `terminal`/`web`/`file` as enabled while runtime stripped those tools via `resolve_toolset`.
- Prune platform toolset names after tool-level subtraction (shared helper with `model_tools`) and pass `disabled_toolsets` into CLI `get_tool_definitions` inspection paths.
