### PR TITLE
feat(webhook): shard durable authority pipeline

### DIFF
--- a/agent/outbound_webhooks.py
+++ b/agent/outbound_webhooks.py
@@ -14,17 +14,25 @@ changes; outbound tells the world when Hermes does something.
 Design notes
 ------------
 * Delivery is fire-and-forget through a bounded in-process queue and a
-  single daemon worker thread.  ``invoke_hook()`` runs inside the agent
+  single daemon worker thread. ``invoke_hook()`` runs inside the agent
   loop, so callbacks must never block on network I/O — they serialize,
-  enqueue, and return ``None`` immediately.  Outbound targets can never
+  enqueue, and return ``None`` immediately. Outbound targets can never
   block a tool call, inject context, or otherwise influence agent flow.
-* Payloads are signed with HMAC-SHA256 (GitHub-style
-  ``X-Hermes-Signature-256: sha256=<hexdigest>`` over the raw body) when
-  a secret is configured.  Receivers verify exactly like they verify
-  GitHub webhooks.
+* The version-1 body is signed with HMAC-SHA256 when a secret reference
+  resolves. ``X-Hermes-Signature-256`` remains for compatibility;
+  ``X-Hermes-Signature-V2`` binds the raw ``X-Hermes-Timestamp`` value,
+  a literal ``.`` byte, and the exact raw body.
+* A configured ``secret_ref`` or compatibility ``secret_env`` is
+  fail-closed. An empty, malformed, unscoped, or unresolved reference
+  disables that target; Hermes never silently downgrades it to unsigned
+  delivery. Unsigned delivery is possible only when neither reference
+  field is present.
+* Inline plaintext ``secret`` values are no longer accepted. Move the
+  value to the environment or active profile secret scope and configure
+  its name through ``secret_ref`` (preferred) or ``secret_env``.
 * No consent prompt: unlike shell hooks, an outbound target executes no
   code on this machine — it POSTs JSON to a URL the user themselves put
-  in config.  ``HERMES_SAFE_MODE=1`` still skips registration, matching
+  in config. ``HERMES_SAFE_MODE=1`` still skips registration, matching
   plugins / MCP / shell hooks.
 * Registration is idempotent — safe to invoke from both the CLI entry
   point and the gateway entry point.
@@ -35,16 +43,17 @@ Config schema (``~/.hermes/config.yaml``)::
       outbound:
         - url: https://ci.example.com/hermes-events
           events: [on_session_end, subagent_stop]
-          # secret literal (discouraged) or env var name (preferred):
-          secret_env: HERMES_OUTBOUND_WEBHOOK_SECRET
-          # optional regex, honored for pre/post_tool_call only:
-          matcher: "terminal|delegate_task"
+          # Name of a secret in the active profile scope or environment.
+          secret_ref: HERMES_OUTBOUND_WEBHOOK_SECRET
+          # ``secret_env`` is accepted as a compatibility alias.
+          matcher: "terminal|delegate_task"  # pre/post_tool_call only
           timeout: 10       # per-attempt seconds, clamped to [1, 60]
           name: ci-notify   # optional label for logs / `hermes hooks list`
 
 Wire format (POST body)::
 
     {
+        "schema_version":  1,
         "hook_event_name": "on_session_end",
         "tool_name":       null,
         "tool_input":      null,
@@ -58,10 +67,25 @@ Wire format (POST body)::
 Headers::
 
     Content-Type:            application/json
-    User-Agent:              Hermes-Agent-Outbound-Webhook
+    User-Agent:              Hermes-Agent-Outbound-Webhook/1
     X-Hermes-Event:          <hook event name>
     X-Hermes-Delivery:       <delivery_id>
-    X-Hermes-Signature-256:  sha256=<hmac hexdigest>   # only when secret set
+    X-Hermes-Schema-Version: 1
+    X-Hermes-Timestamp:      <unix seconds>
+    X-Hermes-Signature-256:  sha256=<HMAC(raw body)>  # compatibility
+    X-Hermes-Signature-V2:   sha256=<HMAC(timestamp + b"." + raw body)>
+
+Receiver verification contract
+------------------------------
+``X-Hermes-Signature-V2`` makes replay checks possible; the receiver must
+complete them before performing side effects. Parse ``X-Hermes-Timestamp``
+as integer Unix seconds and reject requests outside a bounded freshness
+window (300 seconds is the recommended default, with clock skew included).
+Compute HMAC-SHA256 over the exact timestamp header bytes, ``b"."``, and
+the untouched request body, then compare the full ``sha256=...`` value with
+``hmac.compare_digest``. Finally, accept each ``X-Hermes-Delivery`` value at
+most once for at least the freshness window. A valid HMAC without freshness
+and delivery-ID deduplication is authenticated but still replayable.
 """
 
 from __future__ import annotations
@@ -71,7 +95,6 @@ import hashlib
 import hmac
 import json
 import logging
-import os
 import queue
 import re
 import threading
@@ -83,6 +106,8 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
 from urllib import error as urlerror
 from urllib import request as urlrequest
+
+from agent.secret_scope import UnscopedSecretError, get_secret
 
 logger = logging.getLogger(__name__)
 
@@ -97,6 +122,17 @@ _TOOL_SCOPED_EVENTS = {"pre_tool_call", "post_tool_call"}
 
 # kwargs promoted to top-level payload keys (mirrors shell hooks wire).
 _TOP_LEVEL_PAYLOAD_KEYS = {"tool_name", "args", "session_id", "parent_session_id"}
+
+_KNOWN_FIELDS = frozenset({
+    "url",
+    "events",
+    "name",
+    "secret_ref",
+    "secret_env",
+    "matcher",
+    "timeout",
+})
+_SECRET_REFERENCE_FIELDS = ("secret_ref", "secret_env")
 
 # (event, url) pairs already wired to the plugin manager in this process.
 _registered: Set[Tuple[str, str]] = set()
@@ -131,7 +167,9 @@ class WebhookTarget:
             except re.error as exc:
                 logger.warning(
                     "outbound webhook matcher %r is invalid (%s) — treating "
-                    "as literal equality", self.matcher, exc,
+                    "as literal equality",
+                    self.matcher,
+                    exc,
                 )
                 self.compiled_matcher = None
 
@@ -153,10 +191,11 @@ class WebhookTarget:
 # Public API
 # ---------------------------------------------------------------------------
 
+
 def register_from_config(cfg: Optional[Dict[str, Any]]) -> List[WebhookTarget]:
     """Register every configured outbound webhook on the plugin manager.
 
-    ``cfg`` is the full parsed config dict.  Missing, empty, or malformed
+    ``cfg`` is the full parsed config dict. Missing, empty, or malformed
     ``hooks.outbound`` is treated as zero targets — config parsing never
     raises, because a broken webhook entry must not crash the agent.
 
@@ -197,9 +236,11 @@ def register_from_config(cfg: Optional[Dict[str, Any]]) -> List[WebhookTarget]:
                 _registered.add(key)
                 wired_any = True
                 logger.info(
-                    "outbound webhook registered: %s -> %s (matcher=%s, "
-                    "timeout=%ds)",
-                    event, target.label, target.matcher, target.timeout,
+                    "outbound webhook registered: %s -> %s (matcher=%s, timeout=%ds)",
+                    event,
+                    target.label,
+                    target.matcher,
+                    target.timeout,
                 )
             if wired_any:
                 registered.append(target)
@@ -220,7 +261,7 @@ def iter_configured_targets(cfg: Optional[Dict[str, Any]]) -> List[WebhookTarget
 
 def flush(timeout: float = 5.0) -> bool:
     """Block until all queued deliveries are done (or *timeout* elapses).
-    Returns ``True`` when the queue fully drained.  Test/shutdown helper."""
+    Returns ``True`` when the queue fully drained. Test/shutdown helper."""
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         with _delivery_queue.all_tasks_done:
@@ -232,7 +273,7 @@ def flush(timeout: float = 5.0) -> bool:
 
 
 def reset_for_tests() -> None:
-    """Clear the idempotence set and drain the queue.  Test-only helper."""
+    """Clear the idempotence set and drain the queue. Test-only helper."""
     with _registered_lock:
         _registered.clear()
     try:
@@ -246,6 +287,7 @@ def reset_for_tests() -> None:
 # ---------------------------------------------------------------------------
 # Config parsing
 # ---------------------------------------------------------------------------
+
 
 def _parse_outbound_block(raw: Any) -> List[WebhookTarget]:
     if raw is None:
@@ -270,9 +312,31 @@ def _parse_single_target(index: int, raw: Any) -> Optional[WebhookTarget]:
 
     if not isinstance(raw, dict):
         logger.warning(
-            "hooks.outbound[%d] must be a mapping with 'url' and 'events' "
-            "keys; got %s", index, type(raw).__name__,
+            "hooks.outbound[%d] must be a mapping with 'url' and 'events' keys; got %s",
+            index,
+            type(raw).__name__,
         )
+        return None
+
+    unknown = sorted(set(raw) - _KNOWN_FIELDS)
+    if unknown:
+        if "secret" in unknown:
+            logger.error(
+                "hooks.outbound[%d].secret contains unsupported inline "
+                "plaintext. Move the value to the environment or active "
+                "profile secret scope and set secret_ref (preferred) or "
+                "secret_env to that name — target disabled",
+                index,
+            )
+        other_unknown = [field for field in unknown if field != "secret"]
+        if other_unknown:
+            logger.warning(
+                "hooks.outbound[%d] has unknown field(s) %s. Known fields: %s "
+                "— target disabled",
+                index,
+                ", ".join(other_unknown),
+                ", ".join(sorted(_KNOWN_FIELDS)),
+            )
         return None
 
     url = raw.get("url")
@@ -283,20 +347,23 @@ def _parse_single_target(index: int, raw: Any) -> Optional[WebhookTarget]:
     if not url.lower().startswith(("http://", "https://")):
         logger.warning(
             "hooks.outbound[%d].url must be http(s); got %r — skipped",
-            index, url,
+            index,
+            url,
         )
         return None
     if url.lower().startswith("http://"):
         logger.warning(
             "hooks.outbound[%d].url uses plain http:// — payloads (including "
-            "tool inputs) travel unencrypted. Prefer https.", index,
+            "tool inputs) travel unencrypted. Prefer https.",
+            index,
         )
 
     events_raw = raw.get("events")
     if not isinstance(events_raw, list) or not events_raw:
         logger.warning(
             "hooks.outbound[%d] needs a non-empty 'events' list (valid: %s)",
-            index, ", ".join(sorted(VALID_HOOKS)),
+            index,
+            ", ".join(sorted(VALID_HOOKS)),
         )
         return None
     events: List[str] = []
@@ -306,11 +373,14 @@ def _parse_single_target(index: int, raw: Any) -> Optional[WebhookTarget]:
         else:
             logger.warning(
                 "hooks.outbound[%d]: unknown event %r ignored (valid: %s)",
-                index, ev, ", ".join(sorted(VALID_HOOKS)),
+                index,
+                ev,
+                ", ".join(sorted(VALID_HOOKS)),
             )
     if not events:
         logger.warning(
-            "hooks.outbound[%d] has no valid events — skipped", index,
+            "hooks.outbound[%d] has no valid events — skipped",
+            index,
         )
         return None
 
@@ -324,7 +394,9 @@ def _parse_single_target(index: int, raw: Any) -> Optional[WebhookTarget]:
     if matcher is not None and not any(e in _TOOL_SCOPED_EVENTS for e in events):
         logger.warning(
             "hooks.outbound[%d].matcher=%r will be ignored — matcher is only "
-            "honored for pre_tool_call / post_tool_call.", index, matcher,
+            "honored for pre_tool_call / post_tool_call.",
+            index,
+            matcher,
         )
         matcher = None
 
@@ -333,13 +405,17 @@ def _parse_single_target(index: int, raw: Any) -> Optional[WebhookTarget]:
         timeout = int(timeout_raw)
     except (TypeError, ValueError):
         logger.warning(
-            "hooks.outbound[%d].timeout must be an int (got %r); using "
-            "default %ds", index, timeout_raw, DEFAULT_TIMEOUT_SECONDS,
+            "hooks.outbound[%d].timeout must be an int (got %r); using default %ds",
+            index,
+            timeout_raw,
+            DEFAULT_TIMEOUT_SECONDS,
         )
         timeout = DEFAULT_TIMEOUT_SECONDS
     timeout = max(1, min(timeout, MAX_TIMEOUT_SECONDS))
 
-    secret = _resolve_secret(index, raw)
+    secret, usable = _resolve_secret(index, raw)
+    if not usable:
+        return None
 
     name = raw.get("name")
     if not isinstance(name, str):
@@ -355,27 +431,69 @@ def _parse_single_target(index: int, raw: Any) -> Optional[WebhookTarget]:
     )
 
 
-def _resolve_secret(index: int, raw: Dict[str, Any]) -> Optional[str]:
-    """``secret_env`` (env var name, preferred) wins over inline ``secret``."""
-    secret_env = raw.get("secret_env")
-    if isinstance(secret_env, str) and secret_env.strip():
-        value = os.environ.get(secret_env.strip(), "")
-        if value:
-            return value
-        logger.warning(
-            "hooks.outbound[%d].secret_env=%r is not set in the environment "
-            "— deliveries will be UNSIGNED", index, secret_env.strip(),
+def _resolve_secret(
+    index: int,
+    raw: Dict[str, Any],
+) -> Tuple[Optional[str], bool]:
+    """Resolve one optional secret reference.
+
+    Returns ``(secret, usable)``. ``(None, True)`` means no secret field was
+    configured and unsigned delivery was intentionally requested.
+    ``(None, False)`` means a reference was configured but could not be used,
+    so the caller must disable the target rather than downgrade it.
+    """
+    configured = [field for field in _SECRET_REFERENCE_FIELDS if field in raw]
+    if not configured:
+        return None, True
+    if len(configured) != 1:
+        logger.error(
+            "hooks.outbound[%d] configures both secret_ref and secret_env. "
+            "Configure exactly one reference field — target disabled",
+            index,
         )
-        return None
-    secret = raw.get("secret")
-    if isinstance(secret, str) and secret:
-        return secret
-    return None
+        return None, False
+
+    field_name = configured[0]
+    reference = raw.get(field_name)
+    if not isinstance(reference, str) or not reference.strip():
+        logger.error(
+            "hooks.outbound[%d].%s must be a non-empty secret name — target "
+            "disabled; Hermes will not send this webhook unsigned",
+            index,
+            field_name,
+        )
+        return None, False
+    reference = reference.strip()
+
+    try:
+        value = get_secret(reference, "")
+    except UnscopedSecretError as exc:
+        logger.error(
+            "hooks.outbound[%d] secret reference %r cannot be resolved "
+            "without an active profile secret scope (%s) — target disabled; "
+            "no process-environment fallback was attempted",
+            index,
+            reference,
+            exc,
+        )
+        return None, False
+
+    if value:
+        return str(value), True
+
+    logger.error(
+        "hooks.outbound[%d] secret reference %r did not resolve — target "
+        "disabled; Hermes will not send this webhook unsigned",
+        index,
+        reference,
+    )
+    return None, False
 
 
 # ---------------------------------------------------------------------------
 # Callback + delivery
 # ---------------------------------------------------------------------------
+
 
 def _make_callback(event: str, target: WebhookTarget):
     """Build the notify-only closure ``invoke_hook()`` calls per firing."""
@@ -389,8 +507,10 @@ def _make_callback(event: str, target: WebhookTarget):
             body = _serialize_payload(event, kwargs, delivery_id)
         except Exception:  # defensive — a bad payload must not hurt the loop
             logger.warning(
-                "outbound webhook payload serialization failed (event=%s "
-                "target=%s)", event, target.label, exc_info=True,
+                "outbound webhook payload serialization failed (event=%s target=%s)",
+                event,
+                target.label,
+                exc_info=True,
             )
             return None
         _enqueue(_build_delivery(event, target, body, delivery_id))
@@ -402,14 +522,17 @@ def _make_callback(event: str, target: WebhookTarget):
 
 
 def _serialize_payload(
-    event: str, kwargs: Dict[str, Any], delivery_id: str,
+    event: str,
+    kwargs: Dict[str, Any],
+    delivery_id: str,
 ) -> bytes:
-    """Render the POST body.  Same top-level shape as shell hooks' stdin
-    (documented in :mod:`agent.shell_hooks`), plus delivery metadata.
+    """Render the version-1 POST body.
 
-    ``delivery_id`` is shared with the ``X-Hermes-Delivery`` header so
-    receivers can dedupe on either — and since it (plus ``timestamp``)
-    lives inside the HMAC-signed body, it doubles as replay protection.
+    The shape mirrors shell hooks' stdin (documented in
+    :mod:`agent.shell_hooks`) plus delivery metadata. ``delivery_id`` is shared
+    with ``X-Hermes-Delivery`` so receivers can deduplicate. Replay protection
+    is complete only when the receiver also validates the V2 timestamp and
+    rejects a delivery ID it has already accepted.
     """
     extras = {k: v for k, v in kwargs.items() if k not in _TOP_LEVEL_PAYLOAD_KEYS}
     try:
@@ -417,34 +540,49 @@ def _serialize_payload(
     except OSError:
         cwd = ""
     payload = {
+        "schema_version": 1,
         "hook_event_name": event,
         "tool_name": kwargs.get("tool_name"),
-        "tool_input": kwargs.get("args") if isinstance(kwargs.get("args"), dict) else None,
+        "tool_input": kwargs.get("args")
+        if isinstance(kwargs.get("args"), dict)
+        else None,
         "session_id": kwargs.get("session_id") or kwargs.get("parent_session_id") or "",
         "cwd": cwd,
         "extra": extras,
         "delivery_id": delivery_id,
-        "timestamp": datetime.now(tz=timezone.utc)
-        .isoformat()
-        .replace("+00:00", "Z"),
+        "timestamp": datetime.now(tz=timezone.utc).isoformat().replace("+00:00", "Z"),
     }
     return json.dumps(payload, ensure_ascii=False, default=str).encode("utf-8")
 
 
 def _build_delivery(
-    event: str, target: WebhookTarget, body: bytes, delivery_id: str,
+    event: str,
+    target: WebhookTarget,
+    body: bytes,
+    delivery_id: str,
 ) -> Dict[str, Any]:
+    timestamp = str(int(time.time()))
     headers = {
         "Content-Type": "application/json",
-        "User-Agent": "Hermes-Agent-Outbound-Webhook",
+        "User-Agent": "Hermes-Agent-Outbound-Webhook/1",
         "X-Hermes-Event": event,
         "X-Hermes-Delivery": delivery_id,
+        "X-Hermes-Schema-Version": "1",
+        "X-Hermes-Timestamp": timestamp,
     }
     if target.secret:
-        digest = hmac.new(
+        # Compatibility header for existing receivers.
+        legacy = hmac.new(
             target.secret.encode("utf-8"), body, hashlib.sha256
         ).hexdigest()
-        headers["X-Hermes-Signature-256"] = f"sha256={digest}"
+        headers["X-Hermes-Signature-256"] = f"sha256={legacy}"
+
+        # V2 binds time + body so receivers can enforce bounded freshness.
+        signed = timestamp.encode("ascii") + b"." + body
+        digest = hmac.new(
+            target.secret.encode("utf-8"), signed, hashlib.sha256
+        ).hexdigest()
+        headers["X-Hermes-Signature-V2"] = f"sha256={digest}"
     return {
         "url": target.url,
         "label": target.label,
@@ -461,8 +599,10 @@ def _enqueue(delivery: Dict[str, Any]) -> None:
         _delivery_queue.put_nowait(delivery)
     except queue.Full:
         logger.warning(
-            "outbound webhook queue full (%d pending) — dropping %s event "
-            "for %s", QUEUE_MAX_SIZE, delivery["event"], delivery["label"],
+            "outbound webhook queue full (%d pending) — dropping %s event for %s",
+            QUEUE_MAX_SIZE,
+            delivery["event"],
+            delivery["label"],
         )
 
 
@@ -474,13 +614,15 @@ def _ensure_worker() -> None:
         if _worker is not None and _worker.is_alive():
             return
         _worker = threading.Thread(
-            target=_worker_loop, name="outbound-webhooks", daemon=True,
+            target=_worker_loop,
+            name="outbound-webhooks",
+            daemon=True,
         )
         _worker.start()
         # The worker is a daemon thread, so a short-lived process (a `-q`
         # CLI run, a cron session) can exit right after enqueuing the
         # final events — silently dropping on_session_end, the headline
-        # use case.  Drain the queue at interpreter shutdown, bounded so
+        # use case. Drain the queue at interpreter shutdown, bounded so
         # a dead endpoint can only delay exit, never hang it.
         atexit.register(flush, timeout=5.0)
 
@@ -506,7 +648,7 @@ class _NoRedirectHandler(urlrequest.HTTPRedirectHandler):
 
     urllib's default handler converts a redirected POST into a body-less
     GET — the signed payload would be silently dropped and the headers
-    re-sent to a location the user never configured.  Treat any 3xx as a
+    re-sent to a location the user never configured. Treat any 3xx as a
     delivery failure instead (surfaced as HTTPError by returning None).
     """
 
@@ -518,7 +660,7 @@ _opener = urlrequest.build_opener(_NoRedirectHandler)
 
 
 def _deliver(delivery: Dict[str, Any]) -> None:
-    """POST with bounded retries.  Retries on connection errors and 5xx;
+    """POST with bounded retries. Retries on connection errors and 5xx;
     4xx is the receiver telling us the request itself is wrong — no retry.
     3xx redirects are never followed (misconfiguration — fix the URL)."""
     last_error = ""
@@ -535,7 +677,9 @@ def _deliver(delivery: Dict[str, Any]) -> None:
             if 200 <= status < 300:
                 logger.debug(
                     "outbound webhook delivered: %s -> %s (HTTP %d)",
-                    delivery["event"], delivery["label"], status,
+                    delivery["event"],
+                    delivery["label"],
+                    status,
                 )
                 return
             last_error = f"HTTP {status}"
@@ -545,14 +689,18 @@ def _deliver(delivery: Dict[str, Any]) -> None:
                 logger.warning(
                     "outbound webhook target redirected (event=%s target=%s): "
                     "%s -> %s — redirects are not followed; update the "
-                    "configured url", delivery["event"], delivery["label"],
-                    last_error, exc.headers.get("Location", "?"),
+                    "configured url",
+                    delivery["event"],
+                    delivery["label"],
+                    last_error,
+                    exc.headers.get("Location", "?"),
                 )
                 return
             if 400 <= exc.code < 500:
                 logger.warning(
-                    "outbound webhook rejected (event=%s target=%s): %s — "
-                    "not retrying", delivery["event"], delivery["label"],
+                    "outbound webhook rejected (event=%s target=%s): %s — not retrying",
+                    delivery["event"],
+                    delivery["label"],
                     last_error,
                 )
                 return
@@ -563,7 +711,9 @@ def _deliver(delivery: Dict[str, Any]) -> None:
             time.sleep(RETRY_BACKOFF_SECONDS * attempt)
 
     logger.warning(
-        "outbound webhook delivery failed after %d attempt(s) (event=%s "
-        "target=%s): %s",
-        MAX_DELIVERY_ATTEMPTS, delivery["event"], delivery["label"], last_error,
+        "outbound webhook delivery failed after %d attempt(s) (event=%s target=%s): %s",
+        MAX_DELIVERY_ATTEMPTS,
+        delivery["event"],
+        delivery["label"],
+        last_error,
     )

--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -103,7 +103,7 @@ class GatewayAuthorizationMixin:
         if not platform:
             return None
         profile_name = (profile or "").strip() or None
-        if profile_name and profile_name != "default":
+        if profile_name:
             active_profile = None
             active_profile_fn = getattr(self, "_active_profile_name", None)
             if callable(active_profile_fn):
@@ -114,12 +114,27 @@ class GatewayAuthorizationMixin:
             if profile_name == active_profile:
                 adapters = getattr(self, "adapters", None) or {}
                 return adapters.get(platform)
+            if (
+                profile_name == "default"
+                and getattr(
+                    getattr(self, "config", None),
+                    "multiplex_profiles",
+                    False,
+                )
+                is not True
+            ):
+                # ``default`` is the canonical durable stamp for routes that
+                # omit a profile. On a named single-profile install it aliases
+                # that one active adapter registry; only multiplex mode gives
+                # ``default`` an identity distinct from the active profile.
+                adapters = getattr(self, "adapters", None) or {}
+                return adapters.get(platform)
             profile_adapters = getattr(self, "_profile_adapters", None) or {}
             if profile_name in profile_adapters:
                 return profile_adapters[profile_name].get(platform)
-            # Fail closed: a stamped secondary profile with no registry entry
-            # (e.g. its adapter failed to connect) must NOT fall back to the
-            # default profile's adapter — that sends replies out the wrong bot.
+            # Fail closed: every explicit profile, including ``default`` when
+            # a named profile owns ``self.adapters``, must resolve through its
+            # exact registry. Falling back sends through the wrong bot/account.
             return None
         adapters = getattr(self, "adapters", None) or {}
         return adapters.get(platform)

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3030,6 +3030,12 @@ class BasePlatformAdapter(ABC):
     # set this to False to stay correct-by-default.
     supports_async_delivery: bool = True
 
+    # Some adapters own a stronger, domain-specific final-delivery ledger.
+    # Those adapters must not also be enrolled in the generic best-effort
+    # obligation ledger: two independent recovery authorities can race and
+    # turn one final response into duplicate external effects.
+    owns_final_delivery_ledger: bool = False
+
     # Whether this adapter's ``send()`` splits long content into multiple
     # messages via ``truncate_message()``.  When True, the delivery router
     # (gateway/delivery.py) skips gateway-level truncation and lets the
@@ -3077,6 +3083,12 @@ class BasePlatformAdapter(ABC):
     # "interactive_resume", True)`` — no per-platform branching at the call
     # site.
     interactive_resume: bool = True
+
+    # Whether the gateway's generic restart path may synthesize a new agent
+    # turn for this adapter's interrupted sessions. Domain transports with an
+    # exact operation ledger can set this false so a generic session replay
+    # cannot bypass an indeterminate-operation fence.
+    allows_automatic_session_resume: bool = True
 
     # Back-reference to the running ``GatewayRunner``, injected by
     # ``gateway/run.py`` after the adapter is created. Adapters consume it via
@@ -4688,6 +4700,20 @@ class BasePlatformAdapter(ABC):
         notice — never echo the local audio_path into chat, since it is a
         host filesystem path that would leak the Hermes home layout.
         """
+        if getattr(self, "owns_final_delivery_ledger", False) is True:
+            # A ledger-owned final is one exact carrier. Converting an
+            # unsupported voice attachment into a second text send would let
+            # this fallback notice claim that carrier before the prepared
+            # agent final reaches the adapter's durable mutation gate.
+            logger.warning(
+                "[%s] send_voice fallback refused for ledger-owned final",
+                self.name,
+            )
+            return SendResult(
+                success=False,
+                error="Voice delivery is unavailable for ledger-owned finals",
+            )
+
         # audio_path is intentionally NOT included in the chat text — it is a
         # host-local path that leaks filesystem layout. The path is logged for
         # operator diagnostics instead.
@@ -6495,6 +6521,37 @@ class BasePlatformAdapter(ABC):
                 response = None
             if not response:
                 logger.debug("[%s] Handler returned empty/None response for %s", self.name, event.source.chat_id)
+            if response and getattr(self, "owns_final_delivery_ledger", False):
+                # A domain ledger owns one exact final object, not the generic
+                # gateway's sequence of text, image, audio, document, and
+                # fallback-notice sends. Hand the complete response to that
+                # adapter once, before extraction can split it into separately
+                # mutating calls.
+                delivery_adapter = self._final_delivery_adapter(event.source)
+                if not getattr(
+                    delivery_adapter, "owns_final_delivery_ledger", False
+                ):
+                    raise RuntimeError(
+                        "ledger-owned final delivery adapter is unavailable"
+                    )
+                final_content = delivery_adapter.prepare_ledger_owned_final_content(
+                    str(response),
+                    session_key=session_key,
+                )
+                logger.info(
+                    "[%s] Sending one ledger-owned final response (%d chars) to %s",
+                    delivery_adapter.name,
+                    len(final_content),
+                    event.source.chat_id,
+                )
+                result = await delivery_adapter._send_with_retry(
+                    chat_id=event.source.chat_id,
+                    content=final_content,
+                    reply_to=_reply_anchor_for_event(event),
+                    metadata=_mark_notify_metadata(_thread_metadata),
+                )
+                _record_delivery(result)
+                response = None
             if response:
                 # Capture [[as_document]] before extract_media strips it, so the
                 # dispatch partition below can route image-extension files
@@ -6700,9 +6757,15 @@ class BasePlatformAdapter(ABC):
                     # Slash-command and ephemeral replies are cheap to
                     # regenerate and are not recorded.
                     _obligation_id = None
-                    if not is_ephemeral_response and not str(
-                        event.text or ""
-                    ).lstrip().startswith(("/", self.typed_command_prefix or "!")):
+                    if (
+                        not is_ephemeral_response
+                        and not getattr(
+                            delivery_adapter, "owns_final_delivery_ledger", False
+                        )
+                        and not str(event.text or "")
+                        .lstrip()
+                        .startswith(("/", self.typed_command_prefix or "!"))
+                    ):
                         try:
                             from gateway.delivery_ledger import (
                                 compute_obligation_id,
@@ -7393,18 +7456,47 @@ class BasePlatformAdapter(ABC):
         the ``toolsets`` key in ``webhook_subscriptions.json``.
         """
         return None
-    
+
+    def resolved_toolsets_for_source(
+        self, source: "SessionSource"
+    ) -> Optional[List[str]]:
+        """Return an exact, already-validated source grant when available.
+
+        Unlike :meth:`toolsets_for_source`, this list is not resolved again
+        against mutable config, plugin defaults, or newly enabled MCP servers.
+        ``None`` means no exact carrier; ``[]`` is an explicit deny-all grant.
+        """
+
+        return None
+
+    def prepare_ledger_owned_final_content(
+        self,
+        content: str,
+        *,
+        session_key: str,
+    ) -> str:
+        """Build the one final carrier consumed by an adapter-owned ledger.
+
+        Adapters that set :attr:`owns_final_delivery_ledger` bypass the generic
+        text/media fan-out and receive exactly one final send. They may
+        deterministically reduce unsupported attachment directives here before
+        that content is durably staged.
+        """
+
+        del session_key
+        return content
+
     def format_message(self, content: str) -> str:
         """
         Format a message for this platform.
-        
+
         Override in subclasses to handle platform-specific formatting
         (e.g., Telegram MarkdownV2, Discord markdown).
-        
+
         Default implementation returns content as-is.
         """
         return content
-    
+
     @staticmethod
     def truncate_message(
         content: str,

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -32,6 +32,7 @@ Security:
 """
 
 import asyncio
+import errno
 import json
 import logging
 import os
@@ -131,7 +132,10 @@ from gateway.platforms.webhook_common import (
 from gateway.platforms.webhook_delivery import WebhookDeliveryMixin
 from gateway.platforms.webhook_intake import WebhookIntakeMixin
 from gateway.platforms.webhook_recovery import WebhookRecoveryMixin
-from gateway.platforms.webhook_route_authority import WebhookRouteAuthorityMixin
+from gateway.platforms.webhook_route_authority import (
+    WebhookRouteAuthorityMixin,
+    WebhookRouteKey,
+)
 
 
 class WebhookAdapter(
@@ -185,8 +189,29 @@ class WebhookAdapter(
         )
         self._dynamic_routes_integrity_recheck_after = 0.0
         self._dynamic_routes_file_present = False
-        self._routes: Dict[str, dict] = dict(self._static_routes)
+        self._routes: Dict[str, dict] = {}
+        self._replace_live_route_candidates({}, self._static_routes)
         self._authenticated_route_snapshot: Optional[tuple[Any, ...]] = None
+        self._authenticated_route_authorities_by_key: Mapping[
+            WebhookRouteKey, tuple[Any, ...]
+        ] = MappingProxyType({})
+        self._authenticated_route_effective_toolsets_by_key: Mapping[
+            WebhookRouteKey, tuple[str, ...]
+        ] = MappingProxyType({})
+        self._authenticated_route_scripts_by_key: Mapping[
+            WebhookRouteKey, Optional[WebhookPreparedScript]
+        ] = MappingProxyType({})
+        self._authenticated_route_profile_generations_by_key: Mapping[
+            WebhookRouteKey, str
+        ] = MappingProxyType({})
+        self._authenticated_route_bundles_by_key: Mapping[
+            WebhookRouteKey, AuthenticatedRouteAuthority
+        ] = MappingProxyType({})
+        self._authenticated_route_registry: Mapping[
+            WebhookRouteKey, AuthenticatedRouteAuthority
+        ] = MappingProxyType({})
+        # Name-only maps remain compatibility facades. They deliberately omit
+        # a name when more than one public profile owns it.
         self._authenticated_route_authorities: Mapping[str, tuple[Any, ...]] = (
             MappingProxyType({})
         )
@@ -451,12 +476,7 @@ class WebhookAdapter(
         self._reload_dynamic_routes()
 
         # Validate routes at startup — secret is required per route.
-        for name, route in self._routes.items():
-            request_profile = (
-                route.get("profile", "default")
-                if isinstance(route, dict)
-                else "default"
-            )
+        for (request_profile, name), route in self._routes_by_key.items():
             try:
                 bound_route = WebhookRouteConfig.bind(
                     name,
@@ -468,7 +488,11 @@ class WebhookAdapter(
                 return self._reject_connect_configuration(
                     f"Route '{name}' has invalid authority binding: {exc}"
                 )
-            secret = route.get("secret", self._global_secret)
+            secret = (
+                ""
+                if "secret_ref" in route and "secret" not in route
+                else route.get("secret", self._global_secret)
+            )
             if not isinstance(secret, str) or not secret:
                 return self._reject_connect_configuration(
                     f"Route '{name}' has no HMAC secret. "
@@ -503,7 +527,7 @@ class WebhookAdapter(
         # durable route/policy authority. Invalid routes must not consume a
         # permanent key binding when no listener could ever have opened.
         try:
-            self._bind_route_authentication_authorities(self._routes)
+            self._bind_route_authentication_authorities(self._routes_by_key)
         except (
             WebhookContractError,
             WebhookLedgerCapacityError,
@@ -526,6 +550,7 @@ class WebhookAdapter(
         # Content-Length and would otherwise bypass the header check below.
         app = web.Application(client_max_size=self._max_body_bytes)
         app.router.add_get("/health", self._handle_health)
+        app.router.add_get("/ready", self._handle_ready)
         app.router.add_post("/webhooks/{route_name}", self._handle_webhook)
         # Multi-profile multiplexing: a /p/<profile>/webhooks/<route> prefix
         # routes the inbound event to that profile. Same handler; the profile is
@@ -559,14 +584,30 @@ class WebhookAdapter(
         except OSError as exc:
             await self._runner.cleanup()
             self._runner = None
+            where = self._host or "all IPv4+IPv6 interfaces"
             logger.error(
                 "[webhook] Could not bind %s:%d: %s. "
                 "Set a different host or port in config.yaml under "
                 "platforms.webhook.extra.",
-                self._host or "all IPv4+IPv6 interfaces",
+                where,
                 self._port,
                 exc,
             )
+            if getattr(exc, "errno", None) == errno.EADDRINUSE:
+                self._set_fatal_error(
+                    "webhook_port_in_use",
+                    f"Port {self._port} on {where} is already in use. Set "
+                    "platforms.webhook.extra.port to a different value, then "
+                    "resume the webhook platform.",
+                    retryable=False,
+                )
+            else:
+                self._set_fatal_error(
+                    "webhook_bind_failed",
+                    f"Could not bind the webhook listener to "
+                    f"{where}:{self._port}: {exc}",
+                    retryable=True,
+                )
             return False
         # Runner-owned listeners stay closed until the runner has published
         # this exact adapter and claimed every recoverable durable operation.
@@ -589,7 +630,10 @@ class WebhookAdapter(
         self._accepting_webhooks = standalone_intake
         self._mark_connected()
 
-        route_names = ", ".join(self._routes.keys()) or "(none configured)"
+        route_names = (
+            ", ".join(f"{profile}/{name}" for profile, name in self._routes_by_key)
+            or "(none configured)"
+        )
         logger.info(
             "[webhook] Listening on %s:%d — routes: %s",
             self._host or "* (all interfaces, IPv4+IPv6)",
@@ -853,19 +897,21 @@ class WebhookAdapter(
 
     def _prune_rate_limit_buckets(
         self,
-        bundles: Optional[Mapping[str, AuthenticatedRouteAuthority]] = None,
+        bundles: Optional[Mapping[Any, AuthenticatedRouteAuthority]] = None,
     ) -> None:
         """Discard counters whose exact published route authority is gone."""
 
         if bundles is None:
             bundles = {
-                route_name: bundle
-                for route_name, bundle in self._authenticated_route_bundles.items()
-                if route_name in self._routes
+                route_key: bundle
+                for route_key, bundle in self._authenticated_route_registry.items()
             }
         active_authorities = {
-            (str(bundle.authority[0]), route_name)
-            for route_name, bundle in bundles.items()
+            (
+                str(bundle.authority[0]),
+                route_key[1] if isinstance(route_key, tuple) else str(route_key),
+            )
+            for route_key, bundle in bundles.items()
         }
         for key in tuple(self._rate_counts):
             if key not in active_authorities:

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -21,28 +21,26 @@ Each route defines:
 Security:
   - HMAC secret is required per route (validated at startup)
   - Rate limiting per route (fixed-window, configurable)
-  - Idempotency cache prevents duplicate agent runs on webhook retries
+  - A durable replay ledger prevents duplicate agent runs across retries/restarts
   - Body size limits checked before reading payload
   - Generic HMAC supports a V2 signature (X-Webhook-Signature-V2) that
-    binds a timestamp into the signed data for replay protection; the
-    legacy body-only V1 (X-Webhook-Signature) is deprecated but still
-    accepted with a warning, since it has no replay protection
+    binds a timestamp into the signed data for cryptographic freshness.
+    Legacy body-only V1 (X-Webhook-Signature) has no signed nonce/time;
+    the durable ledger permanently fences an identical body, which also
+    means legitimate identical V1 payloads collapse. Migrate to V2.
   - Set secret to "INSECURE_NO_AUTH" to skip validation (testing only)
 """
 
 import asyncio
-import base64
-import binascii
-import hashlib
-import hmac
 import json
 import logging
+import os
 import re
-import subprocess
 import sys
-import time
+import threading
 from collections import deque
-from typing import Any, Deque, Dict, List, Optional
+from types import MappingProxyType
+from typing import Any, Callable, Deque, Dict, Mapping, Optional
 
 try:
     from aiohttp import web
@@ -55,118 +53,38 @@ except ImportError:
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import (
     BasePlatformAdapter,
-    MessageEvent,
-    MessageType,
     SendResult,
+)
+from gateway.platforms.webhook_auth import WebhookAuthMixin, _hmac_str_equal
+from gateway.platforms.webhook_contract import (
+    WebhookContractError,
+    WebhookRouteConfig,
 )
 from gateway.platforms.webhook_filters import (
     DEFAULT_SCRIPT_TIMEOUT_SECONDS,
+    WebhookPreparedScript,
     WebhookRouteProcessor,
 )
-from gateway.response_filters import is_autonomous_silence_response
+from gateway.platforms.webhook_ledger import (
+    MINIMUM_MAX_STORAGE_BYTES,
+    OperationAuthority,
+    RecoveryCursor,
+    WebhookLedgerConfigurationError,
+    WebhookLedgerError,
+    WebhookLedgerCapacityError,
+    WebhookLedgerTransitionError,
+    WebhookOperationLedger,
+)
 
 logger = logging.getLogger(__name__)
 
-
-def _is_webhook_silence_response(content: Any) -> bool:
-    """Whether an agent response means "deliberately say nothing".
-
-    Webhook routes are autonomous background lanes: a subscription prompt tells
-    the agent to answer with ``[SILENT]`` when a tick produced nothing worth a
-    human's attention (a duplicate inbound, a stand-down because a sibling lane
-    already replied, a routine close).  Nobody is waiting on the other end, so
-    there is no reader for whom a "nothing happened" message is useful.
-
-    The reason this is the loose autonomous rule rather than the live gateway's
-    is what the two lanes optimise for.  In an interactive chat, swallowing a
-    real answer because it happens to open with a marker is much worse than
-    showing a stray marker, so ``is_intentional_silence_response`` demands the
-    response be EXACTLY a marker.  A webhook run has the opposite payoff: the
-    cost of a leaked non-story is a pointless notification on every tick, and
-    models reliably add a sentence explaining why they stayed quiet — which
-    under the strict rule flips the whole thing back to "deliver".  That is not
-    a hypothetical: it is why a Helper support lane kept messaging its owner to
-    report that it had nothing to report.
-
-    So use the shared autonomous-lane matcher (also used by cron), which treats
-    a marker on its own first or last line as silence while still delivering
-    prose that merely mentions one mid-sentence.  Sharing the function keeps
-    the two autonomous lanes from drifting apart, and keeps the interactive
-    path untouched.
-    """
-    return is_autonomous_silence_response(content)
-
-# Sentinel returned by _resolve_request_profile when a /p/<profile>/ prefix
-# names a profile this gateway does not serve (→ 404). Distinct from None
-# (no prefix / multiplexing off → handle as the default profile).
-_PROFILE_REJECTED = object()
-
-_BUILTIN_DELIVER_PLATFORMS = {
-    "telegram", "discord", "slack", "signal", "sms", "whatsapp",
-    "matrix", "mattermost", "homeassistant", "email", "dingtalk",
-    "feishu", "wecom", "wecom_callback", "weixin", "bluebubbles",
-    "qqbot", "yuanbao",
-}
-
-# Default bind host. ``None`` tells aiohttp/asyncio's ``create_server`` to bind
-# BOTH address families (IPv4 + IPv6) — the portable dual-stack default.
-#
-# Why not "0.0.0.0" (the old default) or "::"?
-#   - "0.0.0.0" binds IPv4 ONLY. On IPv6-only private networks — notably Fly.io
-#     6PN, where an agent's ``<app>.internal`` name resolves to an ``fdaa:…``
-#     IPv6 address — an IPv4-only listener is unreachable. That is exactly why
-#     hosted-agent webhook routes were publicly unreachable: the edge router
-#     reverse-proxies to ``<app>.internal:8644`` over 6PN (IPv6) but the adapter
-#     was listening on 0.0.0.0 (v4 only) → connection refused.
-#   - "::" is NOT a safe fix: on hosts where the kernel sets IPV6_V6ONLY=1
-#     (verified on Fly machines), binding "::" yields an IPv6-ONLY socket, which
-#     then breaks the IPv4 loopback health check (``curl 127.0.0.1:8644/health``)
-#     and the AF_INET port-conflict probe in connect().
-#   - ``None`` asks the event loop to create a listening socket per resolved
-#     family, so both 127.0.0.1 (v4) and the 6PN fdaa (v6) are served regardless
-#     of the bindv6only sysctl. Users can still pin a specific host via
-#     ``platforms.webhook.extra.host``.
-DEFAULT_HOST = None
-DEFAULT_PORT = 8644
-_INSECURE_NO_AUTH = "INSECURE_NO_AUTH"
-_DYNAMIC_ROUTES_FILENAME = "webhook_subscriptions.json"
-_RATE_WINDOW_SECONDS = 60.0
-# Hostnames/IP literals that only serve connections originating on the same
-# machine. Anything else is treated as a public bind for safety-rail purposes.
-_LOOPBACK_HOSTS = frozenset({
-    "127.0.0.1",
-    "localhost",
-    "::1",
-    "ip6-localhost",
-    "ip6-loopback",
-})
-
-
-def _is_loopback_host(host: Optional[str]) -> bool:
-    """True when `host` binds only to the local machine.
-
-    Covers IPv4 loopback, the standard `localhost` alias, IPv6 loopback in
-    both bracketed and bare form, and the common Debian-style aliases. Any
-    falsy value (empty string, None) is conservatively treated as non-loopback
-    because an unset host usually means the platform-default public bind.
-    """
-    if not host:
-        return False
-    return host.strip().lower() in _LOOPBACK_HOSTS
-
-
-def _hmac_str_equal(provided: str, expected: str) -> bool:
-    """Timing-safe equality for two ``str`` values, tolerant of non-ASCII input.
-
-    ``hmac.compare_digest`` raises ``TypeError`` when given a ``str`` that
-    contains non-ASCII characters. The ``provided`` value here is an
-    attacker-controlled signature/token header on a public, unauthenticated
-    webhook endpoint, so a single non-ASCII byte would otherwise raise out of
-    the request handler and return a 500 instead of rejecting the request.
-    Comparing as UTF-8 bytes keeps the constant-time guarantee while making a
-    hostile header fail closed with a clean rejection.
-    """
-    return hmac.compare_digest(provided.encode(), expected.encode())
+__all__ = [
+    "WebhookAdapter",
+    "WebhookConfigurationError",
+    "WebhookMessageEvent",
+    "_hmac_str_equal",
+    "check_webhook_requirements",
+]
 
 
 def check_webhook_requirements() -> bool:
@@ -174,13 +92,65 @@ def check_webhook_requirements() -> bool:
     return AIOHTTP_AVAILABLE
 
 
-class WebhookAdapter(BasePlatformAdapter):
+from gateway.platforms.webhook_common import (
+    AuthenticatedRouteAuthority,
+    DEFAULT_HOST,
+    DEFAULT_PORT,
+    WebhookConfigurationError,
+    WebhookMessageEvent,
+    WebhookTargetDeliveryDisposition,
+    WebhookTargetDeliveryResult,  # noqa: F401 - compatibility re-export
+    _DYNAMIC_ROUTES_FILENAME,  # noqa: F401 - compatibility re-export
+    _IDEMPOTENCY_DEFAULT_MAX_ENTRIES,
+    _IDEMPOTENCY_DEFAULT_MAX_STORAGE_BYTES,
+    _IDEMPOTENCY_MAX_ENTRIES_LIMIT,
+    _IDEMPOTENCY_MAX_STORAGE_BYTES_LIMIT,
+    _INSECURE_NO_AUTH,
+    _MAX_BODY_BYTES_LIMIT,
+    _MAX_CONCURRENT_AUTHORITY_PROOFS,
+    _MAX_RATE_LIMIT_PER_MINUTE,
+    _MAX_SCRIPT_TIMEOUT_SECONDS,
+    _PROFILE_AUTHORITY_INCARNATION_FILENAME,  # noqa: F401 - compatibility re-export
+    _PROFILE_REJECTED,  # noqa: F401 - compatibility re-export
+    _PROMPT_TOKEN_RE,
+    _RATE_WINDOW_SECONDS,
+    _RAW_PAYLOAD_DEFAULT_CAP_BYTES,
+    _RAW_PAYLOAD_MAX_CAP_BYTES,
+    _RAW_PAYLOAD_MIN_CAP_BYTES,
+    _bounded_positive_int,
+    _clear_quarantined_retirement_owner,
+    _is_loopback_host,
+    _profile_incarnation_token,  # noqa: F401 - compatibility re-export
+    _quarantine_failed_retirement,
+    _quarantined_retirement_owners,
+    _retirement_quarantine_key,
+    _route_worker_slots,
+    _strict_bounded_int,
+)
+
+from gateway.platforms.webhook_delivery import WebhookDeliveryMixin
+from gateway.platforms.webhook_intake import WebhookIntakeMixin
+from gateway.platforms.webhook_recovery import WebhookRecoveryMixin
+from gateway.platforms.webhook_route_authority import WebhookRouteAuthorityMixin
+
+
+class WebhookAdapter(
+    WebhookRecoveryMixin,
+    WebhookIntakeMixin,
+    WebhookDeliveryMixin,
+    WebhookRouteAuthorityMixin,
+    WebhookAuthMixin,
+    BasePlatformAdapter,
+):
     """Generic webhook receiver that triggers agent runs from HTTP POSTs."""
 
-    # No human is present to answer a "session restored — what next?" prompt:
-    # webhook runs are event-triggered.  The startup auto-resume turn must
-    # instruct the model to FINISH the interrupted work instead of emitting an
-    # interactive acknowledgement that abandons the task (#57056).
+    owns_final_delivery_ledger: bool = True
+    allows_automatic_session_resume: bool = False
+    supports_async_delivery: bool = False
+
+    # No human is present to answer a "session restored — what next?" prompt.
+    # Generic session replay is disabled above; the durable operation ledger
+    # decides whether an interrupted carrier is replayable or indeterminate.
     interactive_resume: bool = False
 
     def __init__(self, config: PlatformConfig):
@@ -189,83 +159,329 @@ class WebhookAdapter(BasePlatformAdapter):
         # A config value of empty string / null is normalised to None so it
         # also means "bind all families" rather than an invalid "" host.
         _cfg_host = config.extra.get("host", DEFAULT_HOST)
+        if _cfg_host is not None and not isinstance(_cfg_host, str):
+            raise WebhookConfigurationError("host must be a string or null")
         self._host: Optional[str] = _cfg_host or None
-        self._port: int = int(config.extra.get("port", DEFAULT_PORT))
+        self._port = _strict_bounded_int(
+            config.extra.get("port", DEFAULT_PORT),
+            label="port",
+            minimum=0,
+            maximum=65_535,
+        )
         self._global_secret: str = config.extra.get("secret", "")
-        self._static_routes: Dict[str, dict] = config.extra.get("routes", {})
+        configured_routes = config.extra.get("routes", {})
+        if not isinstance(configured_routes, Mapping):
+            raise WebhookConfigurationError("routes must be an object")
+        self._static_routes: Dict[str, dict] = dict(configured_routes)
         self._dynamic_routes: Dict[str, dict] = {}
-        self._dynamic_routes_mtime: float = 0.0
+        self._dynamic_routes_content_sha256: Optional[str] = None
+        self._dynamic_routes_file_identity: Optional[tuple[int, ...]] = None
+        self._dynamic_routes_rejected_content_sha256: Optional[str] = None
+        self._dynamic_routes_rejected_file_identity: Optional[tuple[int, ...]] = None
+        self._dynamic_routes_transient_file_identity: Optional[tuple[int, ...]] = None
+        self._dynamic_routes_retry_after = 0.0
+        self._dynamic_routes_integrity_recheck_identity: Optional[tuple[int, ...]] = (
+            None
+        )
+        self._dynamic_routes_integrity_recheck_after = 0.0
+        self._dynamic_routes_file_present = False
         self._routes: Dict[str, dict] = dict(self._static_routes)
+        self._authenticated_route_snapshot: Optional[tuple[Any, ...]] = None
+        self._authenticated_route_authorities: Mapping[str, tuple[Any, ...]] = (
+            MappingProxyType({})
+        )
+        self._authenticated_route_effective_toolsets: Mapping[str, tuple[str, ...]] = (
+            MappingProxyType({})
+        )
+        self._authenticated_route_scripts: Mapping[
+            str, Optional[WebhookPreparedScript]
+        ] = MappingProxyType({})
+        self._authenticated_route_profile_generations: Mapping[str, str] = (
+            MappingProxyType({})
+        )
+        # This is the request-facing publication point. A request captures one
+        # bundle object and never rejoins execution authority through mutable,
+        # name-indexed caches after an await.
+        self._authenticated_route_bundles: Mapping[str, AuthenticatedRouteAuthority] = (
+            MappingProxyType({})
+        )
         self._runner = None
-        # Routes already warned about legacy V1 body-only signatures
-        # (once-per-route so a busy sender doesn't spam the log).
-        self._v1_signature_warned: set[str] = set()
-
-        # Delivery info keyed by session chat_id.
-        #
-        # Read by every send() invocation for the chat_id (status messages
-        # AND the final response).  Cleaned up via TTL on each POST so the
-        # dict stays bounded — see _prune_delivery_info().  Do NOT pop on
-        # send(), or interim status messages (e.g. fallback notifications,
-        # context-pressure warnings) will consume the entry before the
-        # final response arrives, causing the response to silently fall
-        # back to the "log" deliver type.
-        self._delivery_info: Dict[str, dict] = {}
-        self._delivery_info_created: Dict[str, float] = {}
-        self._delivery_info_order: Deque[tuple[float, str]] = deque()
-
+        self._accepting_webhooks = True
+        self._global_ledger_saturated = False
+        self._health_capacity_lock = asyncio.Lock()
+        self._authentication_authority_proof_slots = threading.BoundedSemaphore(
+            _MAX_CONCURRENT_AUTHORITY_PROOFS
+        )
         # Reference to gateway runner for cross-platform delivery (set externally)
         self.gateway_runner = None
 
-        # Idempotency: TTL cache of recently processed delivery IDs.
-        # Prevents duplicate agent runs when webhook providers retry.
-        self._seen_deliveries: Dict[str, float] = {}
-        self._idempotency_ttl: int = 3600  # 1 hour
-        self._seen_deliveries_next_prune_at: float = 0.0
+        # Durable replay admission and exact delivery settlement. There is no
+        # process-local authority cache or fallback delivery configuration.
+        self._idempotency_max_entries: int = _bounded_positive_int(
+            config.extra.get(
+                "idempotency_max_entries", _IDEMPOTENCY_DEFAULT_MAX_ENTRIES
+            ),
+            default=_IDEMPOTENCY_DEFAULT_MAX_ENTRIES,
+            maximum=_IDEMPOTENCY_MAX_ENTRIES_LIMIT,
+        )
+        self._idempotency_max_storage_bytes: int = _strict_bounded_int(
+            config.extra.get(
+                "idempotency_max_storage_bytes",
+                _IDEMPOTENCY_DEFAULT_MAX_STORAGE_BYTES,
+            ),
+            label="idempotency_max_storage_bytes",
+            minimum=MINIMUM_MAX_STORAGE_BYTES,
+            maximum=_IDEMPOTENCY_MAX_STORAGE_BYTES_LIMIT,
+            unit="bytes",
+        )
 
-        # Rate limiting: per-route timestamps in a fixed window.
-        self._rate_counts: Dict[str, Deque[float]] = {}
-        self._rate_limit: int = int(config.extra.get("rate_limit", 30))  # per minute
+        # Rate limiting is qualified by the selected profile and route.
+        self._rate_counts: Dict[tuple[str, str], Deque[float]] = {}
+        self._rate_limit = _strict_bounded_int(
+            config.extra.get("rate_limit", 30),
+            label="rate_limit",
+            minimum=1,
+            maximum=_MAX_RATE_LIMIT_PER_MINUTE,
+            unit="requests per minute",
+        )
 
         # Body size limit (auth-before-body pattern)
-        self._max_body_bytes: int = int(
-            config.extra.get("max_body_bytes", 1_048_576)
-        )  # 1MB
-        self._script_timeout_seconds: int = int(
+        self._max_body_bytes = _strict_bounded_int(
+            config.extra.get("max_body_bytes", _MAX_BODY_BYTES_LIMIT),
+            label="max_body_bytes",
+            minimum=1,
+            maximum=_MAX_BODY_BYTES_LIMIT,
+            unit="bytes",
+        )
+        self._script_timeout_seconds = _strict_bounded_int(
             config.extra.get(
                 "script_timeout_seconds",
                 DEFAULT_SCRIPT_TIMEOUT_SECONDS,
-            )
+            ),
+            label="script_timeout_seconds",
+            minimum=1,
+            maximum=_MAX_SCRIPT_TIMEOUT_SECONDS,
+            unit="seconds",
         )
         self._route_processor = WebhookRouteProcessor(
             script_timeout_seconds=self._script_timeout_seconds
         )
+        # Replay proofs belong to the stable Hermes installation, never to the
+        # profile or multiplex mode that happened to launch this process.  The
+        # operation key already carries profile+route scope, and the ledger
+        # enforces per-scope quotas.  Keeping one root DB prevents an exact
+        # signed delivery from re-executing when operators switch named
+        # profiles or toggle multiplexing.
+        from hermes_constants import get_default_hermes_root
+
+        operation_authority_path = get_default_hermes_root() / "state.db"
+        self._operation_ledger = WebhookOperationLedger(
+            operation_authority_path,
+            max_records=self._idempotency_max_entries,
+            max_storage_bytes=self._idempotency_max_storage_bytes,
+        )
+        # Credential ownership spans the same stable installation scope.
+        # Sharing the object also shares its in-process lock for all writes to
+        # the one physical schema.
+        self._authentication_authority_ledger = self._operation_ledger
+        self._recovery_tasks_by_operation: dict[str, asyncio.Task] = {}
+        self._recovery_pump_lock = asyncio.Lock()
+        self._recovery_cycle_active = False
+        self._recovery_backlog_pending = False
+        self._recovery_last_progress = False
+        self._recovery_last_error = False
+        self._recovery_restart_dead_scan = False
+        self._dead_owner_recovery_cursor: Optional[RecoveryCursor] = None
+        self._dead_owner_recovery_complete = False
+        self._current_recovery_cursor: Optional[RecoveryCursor] = None
+        self._current_recovery_complete = False
+        self._recovery_current_scan_required = False
+        self._dead_claim_handoff_in_progress = False
+        self._recovery_authority_profiles: tuple[str, ...] = ()
+        self._lifecycle_retiring = False
 
     # ------------------------------------------------------------------
     # Lifecycle
     # ------------------------------------------------------------------
 
+    def _select_stable_operation_ledger(self) -> None:
+        """Pin replay authority to the stable Hermes root before connect.
+
+        This is normally a no-op because ``__init__`` already selects the root.
+        It also protects embedders/tests that change the active profile between
+        construction and connection: the final listener can never publish with
+        a profile-local replay ledger.
+        """
+
+        from hermes_constants import get_default_hermes_root
+
+        root_db_path = get_default_hermes_root() / "state.db"
+        current_key = _retirement_quarantine_key(self._operation_ledger)
+        root_key = os.path.normcase(str(root_db_path.resolve(strict=False)))
+        if current_key == root_key:
+            # Operation and authentication authority share both the physical
+            # database and the in-process lock once the listener is root-owned.
+            self._authentication_authority_ledger = self._operation_ledger
+            return
+        if self._runner is not None or any(
+            not task.done() for task in self._recovery_tasks_by_operation.values()
+        ):
+            raise WebhookLedgerTransitionError(
+                "multiplex webhook ledger cannot move after listener work started"
+            )
+
+        previous = self._operation_ledger
+        replacement = WebhookOperationLedger(
+            root_db_path,
+            max_records=self._idempotency_max_entries,
+            max_storage_bytes=self._idempotency_max_storage_bytes,
+            terminal_retention_seconds=previous.terminal_retention_seconds,
+            local_bypass_replay_retention_seconds=(
+                previous.local_bypass_replay_retention_seconds
+            ),
+            instance_id=previous.instance_id,
+        )
+        self._operation_ledger = replacement
+        self._authentication_authority_ledger = replacement
+        logger.info(
+            "[webhook] Listener replay authority pinned to %s",
+            root_db_path,
+        )
+
+    def _fence_intake_for_durable_transition_failure(self, context: str) -> None:
+        """Quarantine this exact owner and queue bounded asynchronous recovery.
+
+        Returning a 503 is not enough when a failed transition may have left a
+        PREPARING row owned by this still-live process: ordinary dead-owner
+        recovery correctly refuses to steal it, so exact retries would remain
+        ACTIVE forever.  Close intake, fence the whole exact adapter instance,
+        and let the runner's bounded recovery loop safely reclaim replayable
+        carriers.  A failed/ambiguous retirement is quarantined for the same
+        exact-owner retry used by disconnect replacement.
+        """
+
+        self._accepting_webhooks = False
+        self._recovery_backlog_pending = True
+        self._recovery_restart_dead_scan = True
+        marker_recorded = False
+        try:
+            marker_recorded = _quarantine_failed_retirement(self._operation_ledger)
+        except Exception:
+            logger.exception("[webhook] Could not quarantine owner after %s", context)
+        if not marker_recorded:
+            logger.critical(
+                "[webhook] Durable transition quarantine is saturated; "
+                "process restart is required"
+            )
+        logger.error(
+            "[webhook] Intake fenced after %s; exact-owner recovery queued",
+            context,
+        )
+
+        runner = self.gateway_runner
+        update_status = getattr(runner, "_update_platform_runtime_status", None)
+        if callable(update_status):
+            update_status(
+                Platform.WEBHOOK.value,
+                platform_state="retrying",
+                error_code="webhook_transition_failed",
+                error_message="Durable webhook transition requires recovery",
+            )
+        schedule_retry = getattr(runner, "_schedule_webhook_recovery_retry", None)
+        if callable(schedule_retry):
+            schedule_retry(self)
+
+    def _mark_indeterminate_or_fence(
+        self,
+        authority: OperationAuthority,
+        reason: object,
+        *,
+        context: str,
+    ) -> bool:
+        """Persist one unknown outcome or fence the owner if that write fails."""
+
+        try:
+            preserved = self._operation_ledger.mark_indeterminate(
+                authority,
+                reason,
+            )
+        except BaseException as exc:
+            logger.exception(
+                "[webhook] Indeterminate reconciliation failed after %s", context
+            )
+            self._fence_intake_for_durable_transition_failure(context)
+            if not isinstance(exc, Exception):
+                raise
+            return False
+        if not preserved:
+            logger.error("[webhook] Indeterminate authority was lost after %s", context)
+            self._fence_intake_for_durable_transition_failure(context)
+            return False
+        return True
+
+    def _reject_connect_configuration(self, detail: object) -> bool:
+        """Publish one deterministic startup failure as non-retryable."""
+
+        message = str(detail) or "Webhook configuration is invalid"
+        self._accepting_webhooks = False
+        self._set_fatal_error(
+            "webhook_configuration_invalid",
+            message,
+            retryable=False,
+        )
+        logger.error("[webhook] Refusing invalid static configuration: %s", message)
+        return False
+
     async def connect(self, *, is_reconnect: bool = False) -> bool:
+        self._accepting_webhooks = False
+        self._lifecycle_retiring = False
+        try:
+            self._select_stable_operation_ledger()
+        except WebhookLedgerConfigurationError as exc:
+            return self._reject_connect_configuration(exc)
+        except WebhookLedgerError as exc:
+            self._set_fatal_error(
+                "webhook_storage_unavailable",
+                "Durable webhook storage is unavailable",
+                retryable=True,
+            )
+            logger.error("[webhook] Durable ledger selection failed: %s", exc)
+            return False
         # Load agent-created subscriptions before validating
         self._reload_dynamic_routes()
 
-        # Validate routes at startup — secret is required per route
+        # Validate routes at startup — secret is required per route.
         for name, route in self._routes.items():
+            request_profile = (
+                route.get("profile", "default")
+                if isinstance(route, dict)
+                else "default"
+            )
+            try:
+                bound_route = WebhookRouteConfig.bind(
+                    name,
+                    route,
+                    headers={},
+                    request_profile=request_profile,
+                )
+            except WebhookContractError as exc:
+                return self._reject_connect_configuration(
+                    f"Route '{name}' has invalid authority binding: {exc}"
+                )
             secret = route.get("secret", self._global_secret)
-            if not secret:
-                raise ValueError(
-                    f"[webhook] Route '{name}' has no HMAC secret. "
+            if not isinstance(secret, str) or not secret:
+                return self._reject_connect_configuration(
+                    f"Route '{name}' has no HMAC secret. "
                     f"Set 'secret' on the route or globally. "
                     f"For testing without auth, set secret to '{_INSECURE_NO_AUTH}'."
                 )
-
             # Safety rail: refuse to start if INSECURE_NO_AUTH is combined with a
             # non-loopback bind. The escape hatch is for local testing only;
             # serving an unauthenticated route on a public interface is a
             # deployment-grade footgun we'd rather crash early than ship.
             if secret == _INSECURE_NO_AUTH and not _is_loopback_host(self._host):
-                raise ValueError(
-                    f"[webhook] Route '{name}' uses INSECURE_NO_AUTH secret "
+                return self._reject_connect_configuration(
+                    f"Route '{name}' uses INSECURE_NO_AUTH secret "
                     f"but is bound to non-loopback host '{self._host}'. "
                     f"INSECURE_NO_AUTH is for local testing only. "
                     f"Refusing to start to prevent accidental exposure."
@@ -277,11 +493,33 @@ class WebhookAdapter(BasePlatformAdapter):
             if route.get("deliver_only"):
                 deliver = route.get("deliver", "log")
                 if not deliver or deliver == "log":
-                    raise ValueError(
-                        f"[webhook] Route '{name}' has deliver_only=true but "
+                    return self._reject_connect_configuration(
+                        f"Route '{name}' has deliver_only=true but "
                         f"deliver is '{deliver}'. Direct delivery requires a "
                         f"real target (telegram, discord, slack, github_comment, etc.)."
                     )
+
+        # Only after every startup rule passes, bind each credential to one
+        # durable route/policy authority. Invalid routes must not consume a
+        # permanent key binding when no listener could ever have opened.
+        try:
+            self._bind_route_authentication_authorities(self._routes)
+        except (
+            WebhookContractError,
+            WebhookLedgerCapacityError,
+            WebhookLedgerTransitionError,
+        ) as exc:
+            return self._reject_connect_configuration(
+                f"Route authentication authority is invalid: {exc}"
+            )
+        except WebhookLedgerError as exc:
+            self._set_fatal_error(
+                "webhook_storage_unavailable",
+                "Durable webhook storage is unavailable",
+                retryable=True,
+            )
+            logger.error("[webhook] Authentication authority storage failed: %s", exc)
+            return False
 
         # client_max_size makes aiohttp enforce the cap on every read path,
         # including Transfer-Encoding: chunked bodies that carry no
@@ -294,9 +532,7 @@ class WebhookAdapter(BasePlatformAdapter):
         # captured from the path and stamped onto the SessionSource so the agent
         # turn resolves that profile's config/skills/credentials. Only honored
         # when gateway.multiplex_profiles is on (the handler validates).
-        app.router.add_post(
-            "/p/{profile}/webhooks/{route_name}", self._handle_webhook
-        )
+        app.router.add_post("/p/{profile}/webhooks/{route_name}", self._handle_webhook)
 
         self._runner = web.AppRunner(app)
         await self._runner.setup()
@@ -332,6 +568,25 @@ class WebhookAdapter(BasePlatformAdapter):
                 exc,
             )
             return False
+        # Runner-owned listeners stay closed until the runner has published
+        # this exact adapter and claimed every recoverable durable operation.
+        # Standalone use has no registry/recovery coordinator, so connect may
+        # open its own gate immediately.
+        standalone_intake = self.gateway_runner is None
+        if standalone_intake:
+            try:
+                standalone_intake = not bool(
+                    _quarantined_retirement_owners(self._operation_ledger)
+                )
+            except WebhookLedgerError:
+                # A bounded-registry overflow is intentionally unrecoverable
+                # in-process.  The listener may stay up for health diagnostics,
+                # but it must not admit work under unresolved ownership.
+                standalone_intake = False
+                logger.exception(
+                    "[webhook] Durable retirement quarantine blocks intake"
+                )
+        self._accepting_webhooks = standalone_intake
         self._mark_connected()
 
         route_names = ", ".join(self._routes.keys()) or "(none configured)"
@@ -345,12 +600,159 @@ class WebhookAdapter(BasePlatformAdapter):
         self._wire_plugin_handlers(None)
         return True
 
+    async def _run_ledger_mutation_barrier(
+        self,
+        operation: Callable[[], Any],
+    ) -> Any:
+        """Run one bounded SQLite mutation off-loop without late commits.
+
+        ``asyncio.to_thread`` workers cannot be stopped after SQLite starts.
+        If the awaiting lifecycle task is cancelled, wait for the bounded
+        transaction to finish before propagating cancellation so disconnect
+        can never retire an owner and then have an older recovery claim commit.
+        """
+
+        worker = asyncio.create_task(asyncio.to_thread(operation))
+        try:
+            return await asyncio.shield(worker)
+        except asyncio.CancelledError:
+            try:
+                await asyncio.shield(worker)
+            except BaseException:
+                logger.exception(
+                    "[webhook] Bounded ledger mutation failed during cancellation"
+                )
+            raise
+
+    async def _run_retained_route_worker(
+        self,
+        operation: Callable[..., Any],
+        *args: Any,
+        cancellation_event: Optional[threading.Event] = None,
+        slot_gate: Optional[Any] = None,
+    ) -> Any:
+        """Await an acquired route worker without freeing its slot early.
+
+        Python executor work cannot be stopped when its awaiting request task is
+        cancelled.  The caller acquires ``_route_worker_slots`` before any
+        durable effect; cancellation detaches the await but keeps the process-wide
+        slot until the real thread (and any bounded child process it owns) exits.
+        """
+
+        acquired_gate = slot_gate if slot_gate is not None else _route_worker_slots
+        worker: Optional[asyncio.Task] = None
+        detached = False
+        try:
+            worker = asyncio.create_task(asyncio.to_thread(operation, *args))
+            return await asyncio.shield(worker)
+        except asyncio.CancelledError:
+            if worker is None:  # pragma: no cover - create_task is synchronous
+                raise
+            if cancellation_event is not None:
+                # Route scripts own a subprocess and can terminate it
+                # cooperatively. Do not let handler cancellation reach owner
+                # retirement until the actual worker has acknowledged that
+                # signal and exited.
+                cancellation_event.set()
+                while not worker.done():
+                    try:
+                        await asyncio.shield(worker)
+                    except asyncio.CancelledError:
+                        cancellation_event.set()
+                        continue
+                    except BaseException:
+                        break
+                try:
+                    worker.exception()
+                except BaseException:
+                    pass
+                raise
+            detached = True
+
+            def release_when_worker_exits(completed: asyncio.Task) -> None:
+                try:
+                    completed.exception()
+                except BaseException:
+                    # The request path has already reconciled its durable claim.
+                    # This callback owns only resource-slot finalization.
+                    pass
+                try:
+                    acquired_gate.release()
+                except ValueError:
+                    logger.critical(
+                        "[webhook] Route worker slot accounting was corrupted"
+                    )
+
+            worker.add_done_callback(release_when_worker_exits)
+            raise
+        finally:
+            if not detached:
+                acquired_gate.release()
+
     async def disconnect(self) -> None:
-        if self._runner:
-            await self._runner.cleanup()
-            self._runner = None
-        self._mark_disconnected()
-        logger.info("[webhook] Disconnected")
+        # Close the admission gate first, then let aiohttp drain every handler
+        # that already crossed it. Only after no handler can create another row
+        # may this instance retire/fence all of its durable operations.
+        self._accepting_webhooks = False
+        self._lifecycle_retiring = True
+        marker_recorded = False
+        try:
+            marker_recorded = _quarantine_failed_retirement(self._operation_ledger)
+        except Exception:
+            logger.exception(
+                "[webhook] Could not register owner retirement before disconnect"
+            )
+        try:
+            if self._runner:
+                await self._runner.cleanup()
+                self._runner = None
+        finally:
+            try:
+                async with self._recovery_pump_lock:
+                    while True:
+                        retired = await self._run_ledger_mutation_barrier(
+                            self._operation_ledger.retire_instance
+                        )
+                        if not retired.has_more:
+                            break
+                        # Bound each transaction and give transport/shutdown
+                        # coordination a chance to run between pages.  The
+                        # exact marker remains installed across every yield.
+                        await asyncio.sleep(0)
+            except BaseException:
+                if not marker_recorded:
+                    try:
+                        marker_recorded = _quarantine_failed_retirement(
+                            self._operation_ledger
+                        )
+                    except Exception:
+                        logger.exception(
+                            "[webhook] Could not identify the failed retirement ledger"
+                        )
+                self._set_fatal_error(
+                    "webhook_retirement_failed",
+                    "Durable webhook ownership could not be fenced during disconnect",
+                    retryable=True,
+                )
+                logger.exception(
+                    "[webhook] Failed to fence durable operations during disconnect"
+                )
+                if not marker_recorded:
+                    logger.critical(
+                        "[webhook] Retirement quarantine capacity was exhausted; "
+                        "webhook intake will remain fail-closed until process restart"
+                    )
+                # A caller coordinating replacement must observe that this was
+                # not a clean disconnect.  Runner cleanup wrappers may choose to
+                # swallow the error, but the exact owner quarantine remains for
+                # the replacement's mandatory recovery pass.
+                raise
+            _clear_quarantined_retirement_owner(
+                self._operation_ledger,
+                self._operation_ledger.instance_id,
+            )
+            self._mark_disconnected()
+            logger.info("[webhook] Disconnected")
 
     async def send(
         self,
@@ -359,904 +761,118 @@ class WebhookAdapter(BasePlatformAdapter):
         reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
-        """Deliver the agent's response to the configured destination.
+        """Consume only a positively marked final response under durable authority."""
 
-        chat_id is ``webhook:{route}:{delivery_id}``.  The delivery info
-        stored during webhook receipt is read with ``.get()`` (not popped)
-        so that interim status messages emitted before the final response
-        — fallback-model notifications, context-pressure warnings, etc. —
-        do not consume the entry and silently downgrade the final response
-        to the ``log`` deliver type.  TTL cleanup happens on POST.
-        """
-        if _is_webhook_silence_response(content):
-            logger.info(
-                "[webhook] Response for %s is a silence marker — not delivering", chat_id
+        try:
+            authority = self._operation_ledger.lookup_session(chat_id)
+        except WebhookLedgerError as exc:
+            logger.error(
+                "[webhook] Durable authority lookup failed for %s: %s", chat_id, exc
             )
-            return SendResult(success=True)
-
-        delivery = self._delivery_info.get(chat_id, {})
-        deliver_type = delivery.get("deliver", "log")
-
-        if deliver_type == "log":
-            logger.info("[webhook] Response for %s: %s", chat_id, content[:200])
-            return SendResult(success=True)
-
-        if deliver_type == "github_comment":
-            return await self._deliver_github_comment(content, delivery)
-
-        # Cross-platform delivery — any platform with a gateway adapter.
-        # Check both built-in names and plugin-registered platforms.
-        _is_known_platform = deliver_type in _BUILTIN_DELIVER_PLATFORMS
-        if not _is_known_platform:
-            try:
-                from gateway.platform_registry import platform_registry
-                _is_known_platform = platform_registry.is_registered(deliver_type)
-            except Exception:
-                pass
-        if self.gateway_runner and _is_known_platform:
-            return await self._deliver_cross_platform(
-                deliver_type, content, delivery
+            return SendResult(success=False, error="Webhook authority lookup failed")
+        if authority is None:
+            logger.error("[webhook] Missing durable delivery authority for %s", chat_id)
+            return SendResult(
+                success=False,
+                error="Missing admitted webhook delivery authority",
             )
 
-        logger.warning("[webhook] Unknown deliver type: %s", deliver_type)
+        is_final = (
+            isinstance(metadata, Mapping)
+            and metadata.get("notify") is True
+            and metadata.get("_interim_send") is not True
+        )
+        if not is_final:
+            logger.debug("[webhook] Suppressed non-final send for %s", chat_id)
+            return SendResult(success=True)
+
+        carrier = {"v": 1, "kind": "agent_final"}
+        try:
+            staged = self._stage_exact_delivery(authority, content, carrier)
+        except WebhookLedgerError as exc:
+            logger.error(
+                "[webhook] Could not stage final response for %s: %s", chat_id, exc
+            )
+            return SendResult(
+                success=False,
+                error="Webhook final response conflicts with durable authority",
+            )
+
+        result = await self._invoke_staged_target(staged)
         return SendResult(
-            success=False, error=f"Unknown deliver type: {deliver_type}"
+            success=result.success,
+            message_id=result.message_id,
+            error=result.error,
+            retryable=(
+                result.disposition is WebhookTargetDeliveryDisposition.PRE_EFFECT_FAILED
+            ),
+            raw_response={"webhook_settlement": result.disposition.value},
         )
 
-    def _prune_delivery_info(self, now: float) -> None:
-        """Drop delivery_info entries older than the idempotency TTL.
+    async def _send_with_retry(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
+        metadata: Any = None,
+        max_retries: int = 2,
+        base_delay: float = 2.0,
+    ) -> SendResult:
+        """One exact final attempt; webhook settlement owns all retry decisions."""
 
-        Mirrors the cleanup pattern used for ``_seen_deliveries``.  Called
-        on each POST so the dict size is bounded by ``rate_limit * TTL``
-        even if many webhooks fire and never receive a final response.
-        """
-        if len(self._delivery_info_order) < len(self._delivery_info_created):
-            self._delivery_info_order = deque(
-                (created_at, key)
-                for key, created_at in sorted(
-                    self._delivery_info_created.items(), key=lambda item: item[1]
-                )
-            )
-        cutoff = now - self._idempotency_ttl
-        while self._delivery_info_order and self._delivery_info_order[0][0] < cutoff:
-            created_at, key = self._delivery_info_order.popleft()
-            if self._delivery_info_created.get(key) != created_at:
-                continue
-            self._delivery_info.pop(key, None)
-            self._delivery_info_created.pop(key, None)
+        del max_retries, base_delay
+        return await self.send(
+            chat_id=chat_id,
+            content=content,
+            reply_to=reply_to,
+            metadata=metadata,
+        )
 
-    def _prune_seen_deliveries(self, now: float) -> None:
-        """Occasionally prune expired delivery IDs without scanning every POST."""
-        if now < self._seen_deliveries_next_prune_at:
-            return
-        cutoff = now - self._idempotency_ttl
-        stale = [k for k, t in self._seen_deliveries.items() if t < cutoff]
-        for k in stale:
-            self._seen_deliveries.pop(k, None)
-        self._seen_deliveries_next_prune_at = now + min(60.0, max(1.0, self._idempotency_ttl / 10))
+    def _record_rate_limit_hit(
+        self,
+        route_name: str,
+        now: float,
+        *,
+        profile: Optional[str] = None,
+    ) -> bool:
+        """Return True when the profile/route remains inside its window."""
 
-    def _record_rate_limit_hit(self, route_name: str, now: float) -> bool:
-        """Return True if route is still within limit after recording this hit."""
-        window = self._rate_counts.get(route_name)
+        key = (profile or "default", route_name)
+        window = self._rate_counts.get(key)
         if not isinstance(window, deque):
             new_window: Deque[float] = deque(window or ())
-            self._rate_counts[route_name] = new_window
+            self._rate_counts[key] = new_window
             window = new_window
         cutoff = now - _RATE_WINDOW_SECONDS
-        while window and window[0] < cutoff:
+        while window and window[0] <= cutoff:
             window.popleft()
         if len(window) >= self._rate_limit:
             return False
         window.append(now)
         return True
 
-    def _record_delivery_id(self, delivery_id: str, now: float) -> bool:
-        """Return True when this delivery should be processed."""
-        seen_at = self._seen_deliveries.get(delivery_id)
-        if seen_at is not None and now - seen_at < self._idempotency_ttl:
-            return False
-        if seen_at is not None:
-            self._seen_deliveries.pop(delivery_id, None)
-        self._seen_deliveries[delivery_id] = now
-        if len(self._seen_deliveries) > max(self._rate_limit * 2, 128):
-            self._prune_seen_deliveries(now)
-        return True
+    def _prune_rate_limit_buckets(
+        self,
+        bundles: Optional[Mapping[str, AuthenticatedRouteAuthority]] = None,
+    ) -> None:
+        """Discard counters whose exact published route authority is gone."""
+
+        if bundles is None:
+            bundles = {
+                route_name: bundle
+                for route_name, bundle in self._authenticated_route_bundles.items()
+                if route_name in self._routes
+            }
+        active_authorities = {
+            (str(bundle.authority[0]), route_name)
+            for route_name, bundle in bundles.items()
+        }
+        for key in tuple(self._rate_counts):
+            if key not in active_authorities:
+                self._rate_counts.pop(key, None)
 
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         return {"name": chat_id, "type": "webhook"}
-
-    def toolsets_for_source(self, source) -> Optional[List[str]]:
-        """Per-route toolset override.
-
-        Webhook session chat_ids are ``webhook:{route}:{delivery_id}``.
-        When the matching route config carries a ``toolsets`` list, that list
-        replaces the platform-level ``platform_toolsets.webhook`` resolution
-        for this run only. Routes without the key keep the platform default
-        (the intentionally constrained webhook-safe toolset), so a single
-        trusted route (e.g. a localhost monitoring push) can be granted
-        ``terminal`` without widening every other webhook route.
-
-        Set via ``platforms.webhook.extra.routes.<name>.toolsets`` in
-        config.yaml or a ``toolsets`` key on a subscription in
-        ``webhook_subscriptions.json`` (manual edit — deliberately NOT
-        exposed through `hermes webhook subscribe`, so an agent-created
-        subscription cannot self-grant elevated tools).
-        """
-        chat_id = str(getattr(source, "chat_id", "") or "")
-        parts = chat_id.split(":", 2)
-        if len(parts) < 2 or parts[0] != "webhook":
-            return None
-        route_config = self._routes.get(parts[1])
-        if not isinstance(route_config, dict):
-            return None
-        toolsets = route_config.get("toolsets")
-        if not isinstance(toolsets, list) or not toolsets:
-            return None
-        cleaned = [str(t).strip() for t in toolsets if str(t).strip()]
-        return cleaned or None
-
-    # ------------------------------------------------------------------
-    # HTTP handlers
-    # ------------------------------------------------------------------
-
-    async def _handle_health(self, request: "web.Request") -> "web.Response":
-        """GET /health — simple health check."""
-        return web.json_response({"status": "ok", "platform": "webhook"})
-
-    def _reload_dynamic_routes(self) -> None:
-        """Reload agent-created subscriptions from disk if the file changed."""
-        from hermes_constants import get_hermes_home
-        hermes_home = get_hermes_home()
-        subs_path = hermes_home / _DYNAMIC_ROUTES_FILENAME
-        if not subs_path.exists():
-            if self._dynamic_routes:
-                self._dynamic_routes = {}
-                self._routes = dict(self._static_routes)
-                logger.debug("[webhook] Dynamic subscriptions file removed, cleared dynamic routes")
-            return
-        try:
-            mtime = subs_path.stat().st_mtime
-            if mtime <= self._dynamic_routes_mtime:
-                return  # No change
-            data = json.loads(subs_path.read_text(encoding="utf-8"))
-            if not isinstance(data, dict):
-                return
-            # Merge: static routes take precedence over dynamic ones.
-            # Reject any dynamic route whose effective secret is empty —
-            # an empty secret would cause _handle_webhook to skip HMAC
-            # validation entirely, letting unauthenticated callers in.
-            new_dynamic: Dict[str, dict] = {}
-            for k, v in data.items():
-                if k in self._static_routes:
-                    continue
-                effective_secret = v.get("secret", self._global_secret)
-                if not effective_secret:
-                    logger.warning(
-                        "[webhook] Dynamic route '%s' skipped: 'secret' is "
-                        "missing or empty. Set a valid HMAC secret, or use "
-                        "'%s' to explicitly disable auth (testing only).",
-                        k,
-                        _INSECURE_NO_AUTH,
-                    )
-                    continue
-                if (
-                    effective_secret == _INSECURE_NO_AUTH
-                    and not _is_loopback_host(self._host)
-                ):
-                    logger.warning(
-                        "[webhook] Dynamic route '%s' skipped: INSECURE_NO_AUTH "
-                        "is only allowed on loopback hosts. Current host: '%s'.",
-                        k,
-                        self._host,
-                    )
-                    continue
-                new_dynamic[k] = v
-            self._dynamic_routes = new_dynamic
-            self._routes = {**self._dynamic_routes, **self._static_routes}
-            self._dynamic_routes_mtime = mtime
-            logger.info(
-                "[webhook] Reloaded %d dynamic route(s): %s",
-                len(self._dynamic_routes),
-                ", ".join(self._dynamic_routes.keys()) or "(none)",
-            )
-        except Exception as e:
-            logger.error("[webhook] Failed to reload dynamic routes: %s", e)
-
-    def _resolve_request_profile(self, request: "web.Request"):
-        """Resolve + validate the /p/<profile>/ URL prefix on a webhook request.
-
-        Returns:
-          - ``None`` when no profile prefix is present, or when multiplexing
-            is off and the prefix names this gateway's own profile (the
-            request is handled as the serving profile).
-          - the profile name (str) when present, multiplexing is on, and the
-            profile is one this gateway serves.
-          - ``_PROFILE_REJECTED`` when a prefix is present but the profile is
-            unknown/unconfigured, or names a profile this single-profile
-            gateway does not serve (handler returns 404).
-        """
-        profile = (request.match_info.get("profile") or "").strip()
-        if not profile:
-            return None
-        runner = self.gateway_runner
-        cfg = getattr(runner, "config", None)
-        if not getattr(cfg, "multiplex_profiles", False):
-            # Prefix supplied but multiplexing is off. Only a self-referential
-            # prefix (naming this gateway's own profile) may fall through to
-            # the bare route; anything else fails closed — silently ignoring
-            # the prefix served the gateway owner's routes/config under
-            # another profile's URL (#91583 defect 2).
-            try:
-                from hermes_cli.profiles import profile_matches_home
-
-                if profile_matches_home(profile):
-                    return None
-            except Exception:
-                pass
-            return _PROFILE_REJECTED
-        try:
-            from hermes_cli.profiles import profiles_to_serve
-            served = {
-                name
-                for name, _ in profiles_to_serve(
-                    multiplex=True,
-                    profile_allowlist=getattr(
-                        cfg, "multiplex_profile_allowlist", None
-                    ),
-                )
-            }
-        except Exception:
-            return _PROFILE_REJECTED
-        if profile not in served:
-            return _PROFILE_REJECTED
-        return profile
-
-    @staticmethod
-    def _route_allows_profile(
-        route_config: dict,
-        request_profile: Optional[str],
-    ) -> bool:
-        """Return whether a route is bound to the URL-selected profile.
-
-        Omitting ``profile`` keeps a route on the default profile. An explicit
-        null, blank, or non-string value is malformed and fails closed.
-        """
-        if "profile" not in route_config:
-            configured_profile = "default"
-        else:
-            configured_profile = route_config.get("profile")
-        if not isinstance(configured_profile, str):
-            return False
-        configured_profile = configured_profile.strip()
-        if not configured_profile:
-            return False
-        effective_profile = request_profile or "default"
-        return configured_profile == effective_profile
-
-    async def _handle_webhook(self, request: "web.Request") -> "web.Response":
-        """POST /webhooks/{route_name} — receive and process a webhook event."""
-        # Hot-reload dynamic subscriptions on each request (mtime-gated, cheap)
-        self._reload_dynamic_routes()
-
-        route_name = request.match_info.get("route_name", "")
-        route_config = self._routes.get(route_name)
-
-        # Multi-profile: resolve + validate the /p/<profile>/ prefix if present.
-        profile = self._resolve_request_profile(request)
-        if profile is _PROFILE_REJECTED:
-            return web.json_response(
-                {"error": "Unknown or unconfigured profile"}, status=404
-            )
-
-        if not route_config:
-            return web.json_response(
-                {"error": f"Unknown route: {route_name}"}, status=404
-            )
-
-        if not self._route_allows_profile(route_config, profile):
-            effective_profile = profile or "default"
-            logger.warning(
-                "[webhook] Route %s is not authorized for profile %r",
-                route_name,
-                effective_profile,
-            )
-            # Match the unknown-route response so callers cannot use profile
-            # mismatches to enumerate route bindings.
-            return web.json_response(
-                {"error": f"Unknown route: {route_name}"}, status=404
-            )
-
-        # Disabled routes are kept in the subscriptions file (so the dashboard
-        # can re-enable them) but reject incoming events.  Default-enabled:
-        # only an explicit ``enabled: false`` turns a route off, matching the
-        # mcp_servers ``enabled`` semantics.
-        if route_config.get("enabled", True) is False:
-            return web.json_response(
-                {"error": f"Route disabled: {route_name}"}, status=403
-            )
-
-        # ── Auth-before-body ─────────────────────────────────────
-        # Check Content-Length before reading the full payload.
-        content_length = request.content_length or 0
-        if content_length > self._max_body_bytes:
-            return web.json_response(
-                {"error": "Payload too large"}, status=413
-            )
-
-        # Read body (must be done before any validation)
-        try:
-            raw_body = await request.read()
-        except web.HTTPRequestEntityTooLarge:
-            # aiohttp's client_max_size tripped — chunked or lying
-            # Content-Length. Same 413 as the header check above.
-            return web.json_response(
-                {"error": "Payload too large"}, status=413
-            )
-        except Exception as e:
-            logger.error("[webhook] Failed to read body: %s", e)
-            return web.json_response({"error": "Bad request"}, status=400)
-        if len(raw_body) > self._max_body_bytes:
-            # Defense in depth: enforce the cap on the actual bytes read even
-            # if the server-level limit was bypassed or misconfigured.
-            return web.json_response(
-                {"error": "Payload too large"}, status=413
-            )
-
-        # Validate HMAC signature FIRST (skip only for the explicit local-test
-        # INSECURE_NO_AUTH mode). Missing/empty secrets must fail closed here,
-        # not only during connect(), so direct handler reuse cannot turn a
-        # network webhook route into an unauthenticated agent-dispatch surface.
-        secret = route_config.get("secret", self._global_secret)
-        if not secret:
-            logger.error(
-                "[webhook] Route %s has no HMAC secret; refusing request",
-                route_name,
-            )
-            return web.json_response(
-                {"error": "Webhook route is missing an HMAC secret"},
-                status=403,
-            )
-        if secret != _INSECURE_NO_AUTH:
-            if not self._validate_signature(request, raw_body, secret):
-                logger.warning(
-                    "[webhook] Invalid signature for route %s", route_name
-                )
-                return web.json_response(
-                    {"error": "Invalid signature"}, status=401
-                )
-
-        # ── Rate limiting (after auth) ───────────────────────────
-        now = time.time()
-        if not self._record_rate_limit_hit(route_name, now):
-            return web.json_response(
-                {"error": "Rate limit exceeded"}, status=429
-            )
-
-        # Parse payload
-        try:
-            payload = json.loads(raw_body)
-        except json.JSONDecodeError:
-            # Try form-encoded as fallback
-            try:
-                import urllib.parse
-
-                payload = dict(
-                    urllib.parse.parse_qsl(raw_body.decode("utf-8"))
-                )
-            except Exception:
-                return web.json_response(
-                    {"error": "Cannot parse body"}, status=400
-                )
-
-        # Check event type filter
-        event_type = (
-            request.headers.get("X-GitHub-Event", "")
-            or request.headers.get("X-GitLab-Event", "")
-            or payload.get("event_type", "")
-            or payload.get("type", "")
-            or "unknown"
-        )
-        allowed_events = route_config.get("events", [])
-        if allowed_events and event_type not in allowed_events:
-            logger.debug(
-                "[webhook] Ignoring event %s for route %s (allowed: %s)",
-                event_type,
-                route_name,
-                allowed_events,
-            )
-            return web.json_response(
-                {"status": "ignored", "event": event_type}
-            )
-
-        if not self._route_processor.route_filters_match(
-            route_config, payload, event_type, request.headers
-        ):
-            logger.info(
-                "[webhook] filtered event=%s route=%s",
-                event_type,
-                route_name,
-            )
-            return web.json_response(
-                {
-                    "status": "ignored",
-                    "reason": "filter",
-                    "route": route_name,
-                }
-            )
-
-        if route_config.get("script"):
-            # run_route_script shells out (subprocess.run, up to its timeout);
-            # run it in a worker thread so it can't block the gateway event loop.
-            keep, transformed_payload = await asyncio.to_thread(
-                self._route_processor.run_route_script,
-                route_config.get("script"),
-                payload,
-            )
-            if not keep:
-                logger.info(
-                    "[webhook] script ignored event=%s route=%s",
-                    event_type,
-                    route_name,
-                )
-                return web.json_response(
-                    {
-                        "status": "ignored",
-                        "reason": "script",
-                        "route": route_name,
-                    }
-                )
-            payload = transformed_payload or payload
-
-        # Format prompt from template
-        prompt_template = route_config.get("prompt", "")
-        prompt = self._render_prompt(
-            prompt_template, payload, event_type, route_name
-        )
-
-        # Inject skill content if configured.
-        # We call build_skill_invocation_message() directly rather than
-        # using /skill-name slash commands — the gateway's command parser
-        # would intercept those and break the flow.
-        skills = route_config.get("skills", [])
-        if skills:
-            try:
-                from agent.skill_commands import (
-                    build_skill_invocation_message,
-                    get_skill_commands,
-                )
-
-                skill_cmds = get_skill_commands()
-                for skill_name in skills:
-                    cmd_key = f"/{skill_name}"
-                    if cmd_key in skill_cmds:
-                        skill_content = build_skill_invocation_message(
-                            cmd_key, user_instruction=prompt
-                        )
-                        if skill_content:
-                            prompt = skill_content
-                            break  # Load the first matching skill
-                    else:
-                        logger.warning(
-                            "[webhook] Skill '%s' not found", skill_name
-                        )
-            except Exception as e:
-                logger.warning("[webhook] Skill loading failed: %s", e)
-
-        # Build a unique delivery ID
-        delivery_id = request.headers.get(
-            "X-GitHub-Delivery",
-            request.headers.get(
-                "svix-id",
-                request.headers.get("X-Request-ID", str(int(time.time() * 1000))),
-            ),
-        )
-
-        # ── Idempotency ─────────────────────────────────────────
-        # Skip duplicate deliveries (webhook retries).
-        now = time.time()
-        if not self._record_delivery_id(delivery_id, now):
-            logger.info(
-                "[webhook] Skipping duplicate delivery %s", delivery_id
-            )
-            return web.json_response(
-                {"status": "duplicate", "delivery_id": delivery_id},
-                status=200,
-            )
-
-        # ── Direct delivery mode (deliver_only) ─────────────────
-        # Skip the agent entirely — the rendered prompt IS the message we
-        # deliver.  Use case: external services (Supabase, monitoring,
-        # cron jobs, other agents) that need to push a plain notification
-        # to a user's chat with zero LLM cost.  Reuses the same HMAC auth,
-        # rate limiting, idempotency, and template rendering as agent mode.
-        if route_config.get("deliver_only"):
-            delivery = {
-                "deliver": route_config.get("deliver", "log"),
-                "deliver_extra": self._render_delivery_extra(
-                    route_config.get("deliver_extra", {}), payload
-                ),
-                "payload": payload,
-            }
-            logger.info(
-                "[webhook] direct-deliver event=%s route=%s target=%s msg_len=%d delivery=%s",
-                event_type,
-                route_name,
-                delivery["deliver"],
-                len(prompt),
-                delivery_id,
-            )
-            try:
-                result = await self._direct_deliver(prompt, delivery)
-            except Exception:
-                logger.exception(
-                    "[webhook] direct-deliver failed route=%s delivery=%s",
-                    route_name,
-                    delivery_id,
-                )
-                return web.json_response(
-                    {"status": "error", "error": "Delivery failed", "delivery_id": delivery_id},
-                    status=502,
-                )
-
-            if result.success:
-                return web.json_response(
-                    {
-                        "status": "delivered",
-                        "route": route_name,
-                        "target": delivery["deliver"],
-                        "delivery_id": delivery_id,
-                    },
-                    status=200,
-                )
-            # Delivery attempted but target rejected it — surface as 502
-            # with a generic error (don't leak adapter-level detail).
-            logger.warning(
-                "[webhook] direct-deliver target rejected route=%s target=%s error=%s",
-                route_name,
-                delivery["deliver"],
-                result.error,
-            )
-            return web.json_response(
-                {"status": "error", "error": "Delivery failed", "delivery_id": delivery_id},
-                status=502,
-            )
-
-        # Use delivery_id in session key so concurrent webhooks on the
-        # same route get independent agent runs (not queued/interrupted).
-        session_chat_id = f"webhook:{route_name}:{delivery_id}"
-
-        # Store delivery info for send().  Read by every send() invocation
-        # for this chat_id (interim status messages and the final response),
-        # so we do NOT pop on send.  TTL-based cleanup keeps the dict bounded.
-        deliver_config = {
-            "deliver": route_config.get("deliver", "log"),
-            "deliver_extra": self._render_delivery_extra(
-                route_config.get("deliver_extra", {}), payload
-            ),
-        }
-        self._delivery_info[session_chat_id] = deliver_config
-        self._delivery_info_created[session_chat_id] = now
-        self._delivery_info_order.append((now, session_chat_id))
-        self._prune_delivery_info(now)
-
-        # Build source and event
-        source = self.build_source(
-            chat_id=session_chat_id,
-            chat_name=f"webhook/{route_name}",
-            chat_type="webhook",
-            user_id=f"webhook:{route_name}",
-            user_name=route_name,
-        )
-        if profile and isinstance(profile, str):
-            source.profile = profile
-        event = MessageEvent(
-            text=prompt,
-            message_type=MessageType.TEXT,
-            source=source,
-            raw_message=payload,
-            message_id=delivery_id,
-        )
-
-        logger.info(
-            "[webhook] %s event=%s route=%s prompt_len=%d delivery=%s",
-            request.method,
-            event_type,
-            route_name,
-            len(prompt),
-            delivery_id,
-        )
-
-        # Non-blocking — return 202 Accepted immediately.  The per-delivery
-        # session is closed by the ``on_processing_complete`` override below
-        # once the agent run actually finishes (``handle_message`` itself is
-        # fire-and-forget: it spawns ``_process_message_background`` and
-        # returns before the run starts, so nothing can be closed here).
-        task = asyncio.create_task(self.handle_message(event))
-        self._background_tasks.add(task)
-        task.add_done_callback(self._background_tasks.discard)
-
-        return web.json_response(
-            {
-                "status": "accepted",
-                "route": route_name,
-                "event": event_type,
-                "delivery_id": delivery_id,
-            },
-            status=202,
-        )
-
-    async def on_processing_complete(
-        self, event: "MessageEvent", outcome: Any
-    ) -> None:
-        """Close the per-delivery webhook session once its run finishes.
-
-        A webhook delivery is one-shot: the ``delivery_id`` is baked into the
-        session key, so the session will never receive a second turn.  Mirror
-        the cron completion path (``cron/scheduler.py`` →
-        ``end_session(..., "cron_complete")``) by marking the session ended
-        when the run completes.  Without this, webhook sessions keep
-        ``ended_at`` NULL forever; ``SessionDB.prune_sessions`` only reaps
-        rows with ``ended_at`` set, so unclosed webhook sessions accumulate
-        unbounded and drive state.db bloat (the ghost-session leak).
-
-        This hook is the one seam that runs at the TRUE end of the run:
-        ``BasePlatformAdapter._process_message_background`` fires it after the
-        message handler returns, on the success, failure, and cancellation
-        paths alike — so error runs are reaped too.  (``handle_message`` is
-        fire-and-forget; wrapping IT closes before the run even starts.)
-        ``end_session()`` is first-reason-wins and no-ops on an already-ended
-        row, so this never clobbers a ``compression``/``agent_close`` reason.
-        """
-        await self._end_webhook_session(event, event.source.chat_id)
-
-    async def _end_webhook_session(
-        self, event: "MessageEvent", session_chat_id: str
-    ) -> None:
-        """Mark the per-delivery webhook session ended in state.db.
-
-        Resolves the persisted ``session_id`` from the gateway session store
-        using the SAME source the run was keyed on (so profile multiplexing
-        and key construction match exactly), then closes it via the existing
-        ``SessionDB.end_session`` API — never a hand-written UPDATE.
-        """
-        runner = self.gateway_runner
-        if runner is None:
-            return
-        session_db = getattr(runner, "_session_db", None)
-        store = getattr(runner, "session_store", None)
-        if session_db is None or store is None:
-            return
-        try:
-            key_fn = getattr(runner, "_session_key_for_source", None)
-            if key_fn is None:
-                return
-            session_key = key_fn(event.source)
-            # Resolve the persisted session_id via the store's public,
-            # lock-held accessor (peek_session_id) rather than reaching into
-            # the private _entries dict without the store lock. Fall back to
-            # the private path only for older stores / test doubles that
-            # predate the accessor.
-            peek = getattr(store, "peek_session_id", None)
-            if callable(peek):
-                session_id = peek(session_key)
-            else:
-                if hasattr(store, "_ensure_loaded"):
-                    try:
-                        store._ensure_loaded()
-                    except Exception:
-                        pass
-                entries = getattr(store, "_entries", {}) or {}
-                entry = entries.get(session_key)
-                session_id = getattr(entry, "session_id", None) if entry else None
-            if not session_id:
-                logger.debug(
-                    "[webhook] No session_id to close for %s (key=%s)",
-                    session_chat_id,
-                    session_key,
-                )
-                return
-            # AsyncSessionDB forwards end_session via asyncio.to_thread; a
-            # plain SessionDB exposes it synchronously.  Handle both.
-            _end = session_db.end_session
-            result = _end(session_id, "webhook_complete")
-            if asyncio.iscoroutine(result):
-                await result
-            logger.debug(
-                "[webhook] Closed session %s for delivery %s",
-                session_id,
-                session_chat_id,
-            )
-        except Exception as e:
-            logger.debug(
-                "[webhook] Failed to close session for %s: %s",
-                session_chat_id,
-                e,
-            )
-
-    # ------------------------------------------------------------------
-    # Signature validation
-    # ------------------------------------------------------------------
-
-    def _validate_signature(
-        self, request: "web.Request", body: bytes, secret: str
-    ) -> bool:
-        """Validate webhook signature (GitHub, GitLab, Svix, Linear, generic HMAC-SHA256)."""
-        def _header(name: str) -> str:
-            return (
-                request.headers.get(name, "")
-                or request.headers.get(name.lower(), "")
-                or request.headers.get(name.upper(), "")
-            )
-
-        # Svix / AgentMail:
-        #   svix-id: msg_...
-        #   svix-timestamp: unix seconds
-        #   svix-signature: v1,<base64-hmac> [v1,<base64-hmac> ...]
-        # Signed content is: "{id}.{timestamp}.{raw_body}".  Svix secrets
-        # usually start with "whsec_" and the remainder is base64-encoded.
-        svix_id = _header("svix-id")
-        svix_timestamp = _header("svix-timestamp")
-        svix_signature = _header("svix-signature")
-        if svix_id or svix_timestamp or svix_signature:
-            return self._validate_svix_signature(
-                body=body,
-                secret=secret,
-                msg_id=svix_id,
-                timestamp=svix_timestamp,
-                signature_header=svix_signature,
-            )
-
-        # Linear: linear-signature = <hex HMAC-SHA256 of the raw body, keyed
-        # by the webhook signing key>. Linear's documented scheme signs the
-        # body only (no timestamp binding), so this mirrors it exactly;
-        # without this branch every Linear delivery to a secret-configured
-        # route was rejected as unrecognized (#87348).
-        linear_sig = _header("linear-signature")
-        if linear_sig:
-            expected_linear = hmac.new(
-                secret.encode(), body, hashlib.sha256
-            ).hexdigest()
-            return _hmac_str_equal(linear_sig, expected_linear)
-
-        # GitHub: X-Hub-Signature-256 = sha256=<hex>
-        gh_sig = request.headers.get("X-Hub-Signature-256", "")
-        if gh_sig:
-            expected = "sha256=" + hmac.new(
-                secret.encode(), body, hashlib.sha256
-            ).hexdigest()
-            return _hmac_str_equal(gh_sig, expected)
-
-        # GitLab: X-Gitlab-Token = <plain secret>
-        gl_token = request.headers.get("X-Gitlab-Token", "")
-        if gl_token:
-            return _hmac_str_equal(gl_token, secret)
-
-        # Generic V2: X-Webhook-Signature-V2 = <hex HMAC-SHA256 of "<timestamp>.<body>">
-        #             X-Webhook-Timestamp = <unix seconds> (required for V2)
-        # Checked independently of (and before) legacy V1 below — a sender
-        # that only ever sends V2 headers must still validate here; nesting
-        # this inside `if generic_sig:` would silently skip V2-only senders.
-        #
-        # The presence of X-Webhook-Signature-V2 alone selects V2 mode and
-        # commits to it — it must NOT fall through to the V1 branch just
-        # because the timestamp is missing/malformed/expired. A sender
-        # migrating to V2 typically sends both V1 and V2 headers together
-        # for compatibility; if incomplete V2 fell through to V1, an
-        # attacker who captured one such mixed request could strip the
-        # X-Webhook-Timestamp header from a replay and have it validate
-        # against the still-present, still-unprotected V1 signature instead
-        # — silently downgrading a V2-protected request back to the replay
-        # hole V2 exists to close.
-        v2_sig = request.headers.get("X-Webhook-Signature-V2", "")
-        if v2_sig:
-            v2_timestamp = request.headers.get("X-Webhook-Timestamp", "")
-            if not v2_timestamp:
-                logger.warning(
-                    "[webhook] Route '%s' sent X-Webhook-Signature-V2 with "
-                    "no X-Webhook-Timestamp — rejecting rather than "
-                    "falling back to legacy V1",
-                    request.match_info.get("route_name", ""),
-                )
-                return False
-            try:
-                ts = int(v2_timestamp)
-            except (TypeError, ValueError):
-                return False
-            if abs(int(time.time()) - ts) > 300:
-                logger.warning(
-                    "[webhook] Route '%s' generic HMAC V2 timestamp outside replay window",
-                    request.match_info.get("route_name", ""),
-                )
-                return False
-            signed_content = v2_timestamp.encode() + b"." + body
-            expected_v2 = hmac.new(
-                secret.encode(), signed_content, hashlib.sha256
-            ).hexdigest()
-            return _hmac_str_equal(v2_sig, expected_v2)
-
-        # Generic V1 (legacy): X-Webhook-Signature = <hex HMAC-SHA256 of body>
-        # (deprecated — no replay protection, since the signature only
-        # covers the body: a captured (body, signature) pair replays
-        # indefinitely with no timestamp binding it to a specific delivery.)
-        # Only reachable when X-Webhook-Signature-V2 was not sent at all —
-        # see the guard above.
-        generic_sig = request.headers.get("X-Webhook-Signature", "")
-        if generic_sig:
-            expected = hmac.new(
-                secret.encode(), body, hashlib.sha256
-            ).hexdigest()
-            route_name = request.match_info.get("route_name", "")
-            if route_name not in self._v1_signature_warned:
-                self._v1_signature_warned.add(route_name)
-                logger.warning(
-                    "[webhook] Route '%s' uses legacy body-only HMAC (no "
-                    "timestamp), which is vulnerable to replay attacks. Add "
-                    "an 'X-Webhook-Timestamp' header and switch to "
-                    "'X-Webhook-Signature-V2' (HMAC-SHA256 of "
-                    "'<timestamp>.<body>').",
-                    route_name,
-                )
-            return _hmac_str_equal(generic_sig, expected)
-
-        # No recognised signature header but secret is configured → reject
-        logger.debug(
-            "[webhook] Secret configured but no signature header found"
-        )
-        return False
-
-    def _validate_svix_signature(
-        self,
-        body: bytes,
-        secret: str,
-        msg_id: str,
-        timestamp: str,
-        signature_header: str,
-        tolerance_seconds: int = 300,
-    ) -> bool:
-        """Validate Svix-compatible signatures used by AgentMail webhooks."""
-        if not (msg_id and timestamp and signature_header and secret):
-            return False
-
-        try:
-            ts = int(timestamp)
-        except (TypeError, ValueError):
-            return False
-        if abs(int(time.time()) - ts) > tolerance_seconds:
-            logger.warning("[webhook] Svix signature timestamp outside replay window")
-            return False
-
-        if secret.startswith("whsec_"):
-            encoded_secret = secret.removeprefix("whsec_")
-            try:
-                key = base64.b64decode(encoded_secret, validate=True)
-            except (binascii.Error, ValueError):
-                logger.debug("[webhook] Invalid whsec_ Svix signing secret")
-                return False
-        else:
-            # Be permissive for providers that document Svix-style headers but
-            # hand out raw shared secrets rather than whsec_ base64 secrets.
-            logger.debug("[webhook] Validating Svix-style signature with raw secret")
-            key = secret.encode()
-
-        signed_content = msg_id.encode() + b"." + timestamp.encode() + b"." + body
-        expected = base64.b64encode(
-            hmac.new(key, signed_content, hashlib.sha256).digest()
-        ).decode()
-
-        # Svix can send multiple signatures separated by spaces during secret
-        # rotation. Each entry is formatted as "vN,<base64>".
-        for part in signature_header.split():
-            try:
-                version, signature = part.split(",", 1)
-            except ValueError:
-                continue
-            if version == "v1" and _hmac_str_equal(signature, expected):
-                return True
-        return False
-
-    # ------------------------------------------------------------------
-    # Prompt rendering
-    # ------------------------------------------------------------------
 
     def _render_prompt(
         self,
@@ -1265,44 +881,110 @@ class WebhookAdapter(BasePlatformAdapter):
         event_type: str,
         route_name: str,
     ) -> str:
-        """Render a prompt template with the webhook payload.
+        """Render a prompt template with bounded, parseable raw envelopes.
 
         Supports dot-notation access into nested dicts:
         ``{pull_request.title}`` → ``payload["pull_request"]["title"]``
 
-        Special token ``{__raw__}`` dumps the entire payload as indented
-        JSON (truncated to 4000 chars).  Useful for monitoring alerts or
-        any webhook where the agent needs to see the full payload.
+        ``{__raw__}`` retains the 4,000-byte default. ``{__raw__:N}``
+        selects an explicit complete-envelope byte cap between 64 and
+        1,000,000 bytes. The cap includes metadata and JSON escaping.
         """
         if not template:
-            truncated = json.dumps(payload, indent=2)[:4000]
+            raw_envelope = self._render_raw_payload(
+                payload, _RAW_PAYLOAD_DEFAULT_CAP_BYTES
+            )
             return (
                 f"Webhook event '{event_type}' on route "
-                f"'{route_name}':\n\n```json\n{truncated}\n```"
+                f"'{route_name}':\n\n```json\n{raw_envelope}\n```"
             )
 
         def _resolve(match: re.Match) -> str:
-            key = match.group(1)
-            # Special token: dump the entire payload as JSON
-            if key == "__raw__":
-                return json.dumps(payload, indent=2)[:4000]
-            if key == "event_type":
+            token = match.group("token")
+            if token.startswith("__raw__"):
+                cap_text = match.group("raw_cap")
+                if cap_text is None:
+                    cap = _RAW_PAYLOAD_DEFAULT_CAP_BYTES
+                else:
+                    try:
+                        cap = int(cap_text)
+                    except (TypeError, ValueError) as exc:
+                        raise ValueError(
+                            f"invalid raw payload cap: {cap_text!r}"
+                        ) from exc
+                return self._render_raw_payload(payload, cap)
+            if token == "event_type":
                 return event_type
             value: Any = payload
-            for part in key.split("."):
+            for part in token.split("."):
                 if isinstance(value, dict):
-                    value = value.get(part, f"{{{key}}}")
+                    value = value.get(part, f"{{{token}}}")
                 else:
-                    return f"{{{key}}}"
+                    return f"{{{token}}}"
             if isinstance(value, (dict, list)):
                 return json.dumps(value, indent=2)[:2000]
             return str(value)
 
-        return re.sub(r"\{([a-zA-Z0-9_.]+)\}", _resolve, template)
+        # Deliberately one pass: brace-shaped strings emitted from payloads do
+        # not become a second template language.
+        return _PROMPT_TOKEN_RE.sub(_resolve, template)
 
-    def _render_delivery_extra(
-        self, extra: dict, payload: dict
-    ) -> dict:
+    def _render_raw_payload(
+        self, payload: dict, cap: int = _RAW_PAYLOAD_DEFAULT_CAP_BYTES
+    ) -> str:
+        """Render valid JSON whose complete UTF-8 encoding fits ``cap``."""
+
+        try:
+            requested_cap = int(cap)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"invalid raw payload cap: {cap!r}") from exc
+        if not (
+            _RAW_PAYLOAD_MIN_CAP_BYTES <= requested_cap <= _RAW_PAYLOAD_MAX_CAP_BYTES
+        ):
+            raise ValueError(
+                "raw payload cap must be between "
+                f"{_RAW_PAYLOAD_MIN_CAP_BYTES} and "
+                f"{_RAW_PAYLOAD_MAX_CAP_BYTES} bytes"
+            )
+
+        serialized = json.dumps(payload, indent=2, ensure_ascii=False)
+        serialized_bytes = serialized.encode("utf-8")
+        original_bytes = len(serialized_bytes)
+
+        def _envelope(payload_text: str, *, truncated: bool) -> str:
+            return json.dumps(
+                {
+                    "payload": payload_text,
+                    "truncated": truncated,
+                    "original_bytes": original_bytes,
+                },
+                ensure_ascii=False,
+                separators=(",", ":"),
+            )
+
+        full = _envelope(serialized, truncated=False)
+        if len(full.encode("utf-8")) <= requested_cap:
+            return full
+
+        smallest = _envelope("", truncated=True)
+        if len(smallest.encode("utf-8")) > requested_cap:
+            raise ValueError("raw payload cap is too small for envelope metadata")
+
+        low = 0
+        high = min(original_bytes, requested_cap)
+        best = smallest
+        while low <= high:
+            midpoint = (low + high) // 2
+            bounded = serialized_bytes[:midpoint].decode("utf-8", errors="ignore")
+            candidate = _envelope(bounded, truncated=True)
+            if len(candidate.encode("utf-8")) <= requested_cap:
+                best = candidate
+                low = midpoint + 1
+            else:
+                high = midpoint - 1
+        return best
+
+    def _render_delivery_extra(self, extra: dict, payload: dict) -> dict:
         """Render delivery_extra template values with payload data."""
         rendered: Dict[str, Any] = {}
         for key, value in extra.items():
@@ -1311,166 +993,3 @@ class WebhookAdapter(BasePlatformAdapter):
             else:
                 rendered[key] = value
         return rendered
-
-    # ------------------------------------------------------------------
-    # Response delivery
-    # ------------------------------------------------------------------
-
-    async def _direct_deliver(
-        self, content: str, delivery: dict
-    ) -> SendResult:
-        """Deliver *content* directly without invoking the agent.
-
-        Used by ``deliver_only`` routes: the rendered template becomes the
-        literal message body, and we dispatch to the same delivery helpers
-        that the agent-mode ``send()`` flow uses.  All target types that
-        work in agent mode work here — Telegram, Discord, Slack, GitHub
-        PR comments, etc.
-        """
-        deliver_type = delivery.get("deliver", "log")
-
-        if deliver_type == "log":
-            # Shouldn't reach here — startup validation rejects deliver_only
-            # with deliver=log — but guard defensively.
-            logger.info("[webhook] direct-deliver log-only: %s", content[:200])
-            return SendResult(success=True)
-
-        if deliver_type == "github_comment":
-            return await self._deliver_github_comment(content, delivery)
-
-        # Fall through to the cross-platform dispatcher, which validates the
-        # target name and routes via the gateway runner.
-        return await self._deliver_cross_platform(
-            deliver_type, content, delivery
-        )
-
-    async def _deliver_github_comment(
-        self, content: str, delivery: dict
-    ) -> SendResult:
-        """Post agent response as a GitHub PR/issue comment via ``gh`` CLI."""
-        extra = delivery.get("deliver_extra", {})
-        repo = extra.get("repo", "")
-        pr_number = extra.get("pr_number", "")
-
-        if not repo or not pr_number:
-            logger.error(
-                "[webhook] github_comment delivery missing repo or pr_number"
-            )
-            return SendResult(
-                success=False, error="Missing repo or pr_number"
-            )
-
-        # --- Input validation (prevent CLI argument injection) ---
-        # pr_number must be a positive integer.
-        try:
-            pr_int = int(pr_number)
-            if pr_int <= 0:
-                raise ValueError("non-positive")
-        except (ValueError, TypeError):
-            logger.error(
-                "[webhook] invalid pr_number: %r", pr_number
-            )
-            return SendResult(
-                success=False, error="Invalid pr_number"
-            )
-
-        # repo must match owner/name (alphanumeric, hyphens, underscores, dots).
-        if not re.fullmatch(r"[A-Za-z0-9._-]+/[A-Za-z0-9._-]+", repo):
-            logger.error("[webhook] invalid repo format: %r", repo)
-            return SendResult(
-                success=False, error="Invalid repo format"
-            )
-
-        try:
-            result = subprocess.run(
-                [
-                    "gh",
-                    "pr",
-                    "comment",
-                    str(pr_int),
-                    "--repo",
-                    repo,
-                    "--body",
-                    content,
-                ],
-                capture_output=True,
-                text=True, encoding='utf-8', errors='replace',
-                timeout=30,
-            )
-            if result.returncode == 0:
-                logger.info(
-                    "[webhook] Posted comment on %s#%s", repo, pr_number
-                )
-                return SendResult(success=True)
-            else:
-                logger.error(
-                    "[webhook] gh pr comment failed: %s", result.stderr
-                )
-                return SendResult(success=False, error=result.stderr)
-        except FileNotFoundError:
-            logger.error(
-                "[webhook] 'gh' CLI not found — install GitHub CLI for "
-                "github_comment delivery"
-            )
-            return SendResult(
-                success=False, error="gh CLI not installed"
-            )
-        except Exception as e:
-            logger.error("[webhook] github_comment delivery error: %s", e)
-            return SendResult(success=False, error=str(e))
-
-    async def _deliver_cross_platform(
-        self, platform_name: str, content: str, delivery: dict
-    ) -> SendResult:
-        """Route response to another platform (telegram, discord, etc.)."""
-        if not self.gateway_runner:
-            return SendResult(
-                success=False,
-                error="No gateway runner for cross-platform delivery",
-            )
-
-        try:
-            target_platform = Platform(platform_name)
-        except ValueError:
-            return SendResult(
-                success=False, error=f"Unknown platform: {platform_name}"
-            )
-
-        # Default adapters first; multiplex may park Slack/etc. only on a
-        # secondary profile (self._profile_adapters). Fall back so webhook
-        # deliver:slack still works when default has slack disabled.
-        adapter = self.gateway_runner.adapters.get(target_platform)
-        if not adapter:
-            for _prof, amap in (getattr(self.gateway_runner, "_profile_adapters", None) or {}).items():
-                if not isinstance(amap, dict):
-                    continue
-                cand = amap.get(target_platform)
-                if cand is not None:
-                    adapter = cand
-                    break
-        if not adapter:
-            return SendResult(
-                success=False,
-                error=f"Platform {platform_name} not connected",
-            )
-
-        # Use home channel if no specific chat_id in deliver_extra
-        extra = delivery.get("deliver_extra", {})
-        chat_id = extra.get("chat_id", "")
-        if not chat_id:
-            home = self.gateway_runner.config.get_home_channel(target_platform)
-            if home:
-                chat_id = home.chat_id
-            else:
-                return SendResult(
-                    success=False,
-                    error=f"No chat_id or home channel for {platform_name}",
-                )
-
-        # Pass thread_id from deliver_extra so Telegram forum topics work
-        metadata = None
-        thread_id = extra.get("message_thread_id") or extra.get("thread_id")
-        if thread_id:
-            metadata = {"thread_id": thread_id}
-
-        return await adapter.send(chat_id, content, metadata=metadata)

--- a/gateway/platforms/webhook_auth.py
+++ b/gateway/platforms/webhook_auth.py
@@ -1,0 +1,616 @@
+"""Explicit webhook signature verification.
+
+The normalized route binding selects one canonical verifier mode before this
+module is called.  Verifiers inspect only their own wire contract and never
+infer or fall through to a different provider from request headers.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import hmac
+import logging
+import time
+from dataclasses import dataclass
+from enum import Enum
+from types import MappingProxyType
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from aiohttp import web
+
+    from gateway.platforms.webhook_contract import WebhookRouteConfig
+
+
+logger = logging.getLogger("gateway.platforms.webhook")
+
+
+def _hmac_str_equal(provided: str, expected: str) -> bool:
+    """Timing-safe string equality that rejects hostile non-ASCII cleanly."""
+
+    try:
+        provided_bytes = provided.encode("utf-8")
+        expected_bytes = expected.encode("utf-8")
+    except UnicodeEncodeError:
+        return False
+    return hmac.compare_digest(provided_bytes, expected_bytes)
+
+
+DEFAULT_REPLAY_TOLERANCE_SECONDS = 300
+
+# These are executable verifier names, not configuration aliases.  Aliases are
+# normalized exactly once by webhook_contract.WebhookRouteConfig.bind().
+SIGNATURE_MODES = frozenset({
+    "github",
+    "gitlab",
+    "standard_webhooks",
+    "hindsight",
+    "hermes",
+    "linear",
+    "stripe",
+    "svix",
+    "generic_v2",
+    "generic_v1",
+})
+
+
+class WebhookVerificationCoverage(str, Enum):
+    """Exact material authenticated by the selected verifier.
+
+    A successful credential comparison is deliberately distinct from a MAC of
+    the request body.  Likewise, a body MAC does not authenticate adjacent
+    provider metadata headers.  Consumers must use this type instead of
+    treating "signature accepted" as proof over the whole HTTP request.
+    """
+
+    BODY_MAC = "body_mac"
+    TIMESTAMP_BODY_MAC = "timestamp_body_mac"
+    ID_TIMESTAMP_BODY_MAC = "id_timestamp_body_mac"
+    CREDENTIAL_ONLY = "credential_only"
+    LOCAL_BYPASS = "local_bypass"
+
+
+def _header_from_mapping(headers, name: str) -> str:
+    def valid_text(value: object) -> str:
+        text = str(value)
+        try:
+            text.encode("utf-8")
+        except UnicodeEncodeError:
+            return ""
+        return text
+
+    get_all = getattr(headers, "getall", None)
+    if callable(get_all):
+        try:
+            values = list(get_all(name, ()))
+        except (KeyError, TypeError):
+            values = []
+        if values:
+            # Multiple physical occurrences are ambiguous even when their text
+            # matches. Authentication must never depend on which duplicate an
+            # HTTP stack or intermediary happens to select.
+            if len(values) != 1:
+                return ""
+            return valid_text(values[0]) if values[0] not in (None, "") else ""
+    direct = headers.get(name, "")
+    if direct:
+        return valid_text(direct)
+    target = name.lower()
+    for key, value in headers.items():
+        if str(key).lower() == target and value:
+            return valid_text(value)
+    return ""
+
+
+def _snapshot_observed_claims(
+    route: "WebhookRouteConfig",
+    headers,
+    *,
+    excluding: tuple[tuple[str, str], ...] = (),
+) -> tuple[tuple[str, str], ...]:
+    """Snapshot unbound transport hints, never credentials or signatures."""
+
+    names = (
+        *route.provider_spec.delivery_id_headers,
+        *route.provider_spec.event_headers,
+    )
+    excluded_names = {name.lower() for name, _value in excluding}
+    return tuple(
+        (name, value)
+        for name in dict.fromkeys(names)
+        if name.lower() not in excluded_names
+        and (value := _header_from_mapping(headers, name))
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class _VerifiedWebhookMaterial:
+    """Internal exact output of one selected verifier."""
+
+    coverage: WebhookVerificationCoverage
+    verified_claims: tuple[tuple[str, str], ...] = ()
+    signed_timestamp: Optional[str] = None
+
+
+def _coverage_for_mode(signature_mode: str) -> WebhookVerificationCoverage:
+    """Coverage used only by private test receipt factories."""
+
+    if signature_mode == "gitlab":
+        return WebhookVerificationCoverage.CREDENTIAL_ONLY
+    if signature_mode in {"stripe", "generic_v2"}:
+        return WebhookVerificationCoverage.TIMESTAMP_BODY_MAC
+    if signature_mode in {"svix", "standard_webhooks"}:
+        return WebhookVerificationCoverage.ID_TIMESTAMP_BODY_MAC
+    return WebhookVerificationCoverage.BODY_MAC
+
+
+@dataclass(frozen=True, slots=True, init=False)
+class WebhookSignatureVerificationReceipt:
+    """Exact successful verifier output containing no credential material.
+
+    ``verified_claims`` are values consumed by the MAC itself.  Provider
+    delivery/event headers merely observed next to a valid signature live in
+    ``observed_claims`` and can never become durable authority by accident.
+    """
+
+    route: "WebhookRouteConfig"
+    body_sha256: str
+    verified_at: float
+    coverage: WebhookVerificationCoverage
+    verified_claims: tuple[tuple[str, str], ...]
+    observed_claims: tuple[tuple[str, str], ...]
+    signed_timestamp: Optional[str]
+
+    @classmethod
+    def _from_verified_material(
+        cls,
+        route: "WebhookRouteConfig",
+        body: bytes,
+        headers,
+        material: _VerifiedWebhookMaterial,
+    ) -> "WebhookSignatureVerificationReceipt":
+        receipt = object.__new__(cls)
+        object.__setattr__(receipt, "route", route)
+        object.__setattr__(
+            receipt,
+            "body_sha256",
+            hashlib.sha256(body).hexdigest(),
+        )
+        object.__setattr__(receipt, "verified_at", time.time())
+        object.__setattr__(receipt, "coverage", material.coverage)
+        object.__setattr__(receipt, "verified_claims", material.verified_claims)
+        object.__setattr__(
+            receipt,
+            "observed_claims",
+            _snapshot_observed_claims(
+                route,
+                headers,
+                excluding=material.verified_claims,
+            ),
+        )
+        object.__setattr__(receipt, "signed_timestamp", material.signed_timestamp)
+        return receipt
+
+    @classmethod
+    def _issue(
+        cls,
+        route: "WebhookRouteConfig",
+        body: bytes,
+        headers,
+    ) -> "WebhookSignatureVerificationReceipt":
+        """Private deterministic fixture factory; production uses a verifier.
+
+        The factory intentionally derives only registry-declared authenticated
+        header claims.  In particular, GitHub/GitLab/Chatwoot transport IDs
+        remain observed hints even in tests.
+        """
+
+        verified_claims = tuple(
+            (name, value)
+            for name in route.provider_spec.authenticated_delivery_id_headers
+            if (value := _header_from_mapping(headers, name))
+        )
+        return cls._from_verified_material(
+            route,
+            body,
+            headers,
+            _VerifiedWebhookMaterial(
+                coverage=_coverage_for_mode(route.signature_mode),
+                verified_claims=verified_claims,
+            ),
+        )
+
+    @property
+    def verified_headers(self):
+        return MappingProxyType(dict(self.verified_claims))
+
+    @property
+    def observed_headers(self):
+        return MappingProxyType(dict(self.observed_claims))
+
+
+@dataclass(frozen=True, slots=True, init=False)
+class WebhookLocalBypassReceipt:
+    """Distinct receipt issued only after the loopback test gate."""
+
+    route: "WebhookRouteConfig"
+    body_sha256: str
+    verified_at: float
+    coverage: WebhookVerificationCoverage
+    verified_claims: tuple[tuple[str, str], ...]
+    observed_claims: tuple[tuple[str, str], ...]
+    signed_timestamp: Optional[str]
+
+    @classmethod
+    def _issue(
+        cls,
+        route: "WebhookRouteConfig",
+        body: bytes,
+        headers,
+    ) -> "WebhookLocalBypassReceipt":
+        receipt = object.__new__(cls)
+        object.__setattr__(receipt, "route", route)
+        object.__setattr__(
+            receipt,
+            "body_sha256",
+            hashlib.sha256(body).hexdigest(),
+        )
+        object.__setattr__(receipt, "verified_at", time.time())
+        object.__setattr__(
+            receipt,
+            "coverage",
+            WebhookVerificationCoverage.LOCAL_BYPASS,
+        )
+        object.__setattr__(receipt, "verified_claims", ())
+        object.__setattr__(
+            receipt,
+            "observed_claims",
+            _snapshot_observed_claims(route, headers),
+        )
+        object.__setattr__(receipt, "signed_timestamp", None)
+        return receipt
+
+    @property
+    def verified_headers(self):
+        return MappingProxyType({})
+
+    @property
+    def observed_headers(self):
+        return MappingProxyType(dict(self.observed_claims))
+
+
+def _header(request: "web.Request", name: str) -> str:
+    return _header_from_mapping(request.headers, name)
+
+
+class WebhookAuthMixin:
+    """Validate the verifier selected by the canonical route binding."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._v1_signature_warned: set[str] = set()
+
+    def _verify_github(
+        self, request, body: bytes, secret: str
+    ) -> Optional[_VerifiedWebhookMaterial]:
+        signature = _header(request, "X-Hub-Signature-256")
+        if not signature:
+            return None
+        expected = (
+            "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+        )
+        if not _hmac_str_equal(signature, expected):
+            return None
+        return _VerifiedWebhookMaterial(WebhookVerificationCoverage.BODY_MAC)
+
+    def _verify_gitlab(
+        self, request, secret: str
+    ) -> Optional[_VerifiedWebhookMaterial]:
+        token = _header(request, "X-Gitlab-Token")
+        if not token or not _hmac_str_equal(token, secret):
+            return None
+        return _VerifiedWebhookMaterial(WebhookVerificationCoverage.CREDENTIAL_ONLY)
+
+    def _verify_hindsight(
+        self, request, body: bytes, secret: str
+    ) -> Optional[_VerifiedWebhookMaterial]:
+        signature = _header(request, "X-Hindsight-Signature")
+        if not signature:
+            return None
+        expected = (
+            "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+        )
+        if not _hmac_str_equal(signature, expected):
+            return None
+        return _VerifiedWebhookMaterial(WebhookVerificationCoverage.BODY_MAC)
+
+    def _verify_hermes(
+        self, request, body: bytes, secret: str
+    ) -> Optional[_VerifiedWebhookMaterial]:
+        signature = _header(request, "X-Hermes-Signature-256")
+        if not signature:
+            return None
+        expected = (
+            "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+        )
+        if not _hmac_str_equal(signature, expected):
+            return None
+        return _VerifiedWebhookMaterial(WebhookVerificationCoverage.BODY_MAC)
+
+    def _verify_linear(
+        self, request, body: bytes, secret: str
+    ) -> Optional[_VerifiedWebhookMaterial]:
+        signature = _header(request, "linear-signature")
+        if not signature:
+            return None
+        expected = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+        if not _hmac_str_equal(signature, expected):
+            return None
+        return _VerifiedWebhookMaterial(WebhookVerificationCoverage.BODY_MAC)
+
+    def _verify_stripe(
+        self, request, body: bytes, secret: str
+    ) -> Optional[_VerifiedWebhookMaterial]:
+        signature_header = _header(request, "Stripe-Signature")
+        if not signature_header:
+            return None
+        timestamp = ""
+        signatures: list[str] = []
+        for part in signature_header.split(","):
+            key, separator, value = part.strip().partition("=")
+            if not separator or not value:
+                continue
+            if key == "t" and not timestamp:
+                timestamp = value
+            elif key == "v1":
+                signatures.append(value)
+        try:
+            parsed_timestamp = int(timestamp)
+        except (TypeError, ValueError):
+            return None
+        if abs(int(time.time()) - parsed_timestamp) > DEFAULT_REPLAY_TOLERANCE_SECONDS:
+            logger.warning("[webhook] Stripe signature timestamp outside replay window")
+            return None
+        signed_content = timestamp.encode() + b"." + body
+        expected = hmac.new(secret.encode(), signed_content, hashlib.sha256).hexdigest()
+        if not any(_hmac_str_equal(signature, expected) for signature in signatures):
+            return None
+        return _VerifiedWebhookMaterial(
+            WebhookVerificationCoverage.TIMESTAMP_BODY_MAC,
+            signed_timestamp=timestamp,
+        )
+
+    def _verify_generic_v2(
+        self, request, body: bytes, secret: str
+    ) -> Optional[_VerifiedWebhookMaterial]:
+        signature = _header(request, "X-Webhook-Signature-V2")
+        if not signature:
+            return None
+        timestamp = _header(request, "X-Webhook-Timestamp")
+        if not timestamp:
+            logger.warning(
+                "[webhook] Route '%s' sent X-Webhook-Signature-V2 with no "
+                "X-Webhook-Timestamp; refusing downgrade to legacy V1",
+                request.match_info.get("route_name", ""),
+            )
+            return None
+        try:
+            parsed_timestamp = int(timestamp)
+        except (TypeError, ValueError):
+            return None
+        if abs(int(time.time()) - parsed_timestamp) > DEFAULT_REPLAY_TOLERANCE_SECONDS:
+            logger.warning(
+                "[webhook] Route '%s' generic HMAC V2 timestamp outside replay window",
+                request.match_info.get("route_name", ""),
+            )
+            return None
+        signed_content = timestamp.encode() + b"." + body
+        expected = hmac.new(secret.encode(), signed_content, hashlib.sha256).hexdigest()
+        if not _hmac_str_equal(signature, expected):
+            return None
+        return _VerifiedWebhookMaterial(
+            WebhookVerificationCoverage.TIMESTAMP_BODY_MAC,
+            signed_timestamp=timestamp,
+        )
+
+    def _verify_generic_v1(
+        self, request, body: bytes, secret: str
+    ) -> Optional[_VerifiedWebhookMaterial]:
+        signature = _header(request, "X-Webhook-Signature")
+        if not signature:
+            return None
+        expected = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+        route_name = request.match_info.get("route_name", "")
+        if route_name not in self._v1_signature_warned:
+            self._v1_signature_warned.add(route_name)
+            logger.warning(
+                "[webhook] Route '%s' uses legacy body-only HMAC without signed "
+                "freshness; identical bodies are durably collapsed, so migrate "
+                "to generic_v2",
+                route_name,
+            )
+        if not _hmac_str_equal(signature, expected):
+            return None
+        return _VerifiedWebhookMaterial(WebhookVerificationCoverage.BODY_MAC)
+
+    def _verify_material(
+        self,
+        request: "web.Request",
+        body: bytes,
+        secret: str,
+        signature_mode: str,
+    ) -> Optional[_VerifiedWebhookMaterial]:
+        """Return exact material from one selected verifier, failing closed."""
+
+        if not isinstance(body, bytes) or not isinstance(secret, str) or not secret:
+            return None
+        if signature_mode == "github":
+            return self._verify_github(request, body, secret)
+        if signature_mode == "gitlab":
+            return self._verify_gitlab(request, secret)
+        if signature_mode == "standard_webhooks":
+            return self._verify_svix_material(
+                body=body,
+                secret=secret,
+                msg_id=_header(request, "webhook-id"),
+                timestamp=_header(request, "webhook-timestamp"),
+                signature_header=_header(request, "webhook-signature"),
+                id_claim_name="webhook-id",
+            )
+        if signature_mode == "hindsight":
+            return self._verify_hindsight(request, body, secret)
+        if signature_mode == "hermes":
+            return self._verify_hermes(request, body, secret)
+        if signature_mode == "linear":
+            return self._verify_linear(request, body, secret)
+        if signature_mode == "stripe":
+            return self._verify_stripe(request, body, secret)
+        if signature_mode == "svix":
+            return self._verify_svix_material(
+                body=body,
+                secret=secret,
+                msg_id=_header(request, "svix-id"),
+                timestamp=_header(request, "svix-timestamp"),
+                signature_header=_header(request, "svix-signature"),
+                id_claim_name="svix-id",
+            )
+        if signature_mode == "generic_v1":
+            return self._verify_generic_v1(request, body, secret)
+        if signature_mode == "generic_v2":
+            return self._verify_generic_v2(request, body, secret)
+
+        logger.warning(
+            "[webhook] Route '%s' has unsupported signature_mode %r",
+            request.match_info.get("route_name", ""),
+            signature_mode,
+        )
+        return None
+
+    def _validate_signature(
+        self,
+        request: "web.Request",
+        body: bytes,
+        secret: str,
+        signature_mode: str,
+    ) -> bool:
+        """Compatibility boolean over the typed verification result."""
+
+        return self._verify_material(request, body, secret, signature_mode) is not None
+
+    def _verify_signature_receipt(
+        self,
+        request: "web.Request",
+        body: bytes,
+        secret: str,
+        route: "WebhookRouteConfig",
+    ) -> WebhookSignatureVerificationReceipt | None:
+        """Return the exact proof emitted by the already-selected verifier."""
+
+        material = self._verify_material(
+            request,
+            body,
+            secret,
+            route.signature_mode,
+        )
+        if material is None:
+            return None
+        return WebhookSignatureVerificationReceipt._from_verified_material(
+            route,
+            body,
+            request.headers,
+            material,
+        )
+
+    def _issue_local_bypass_receipt(
+        self,
+        request: "web.Request",
+        body: bytes,
+        route: "WebhookRouteConfig",
+    ) -> WebhookLocalBypassReceipt:
+        return WebhookLocalBypassReceipt._issue(route, body, request.headers)
+
+    def _verify_svix_material(
+        self,
+        body: bytes,
+        secret: str,
+        msg_id: str,
+        timestamp: str,
+        signature_header: str,
+        id_claim_name: str,
+        tolerance_seconds: int = DEFAULT_REPLAY_TOLERANCE_SECONDS,
+    ) -> Optional[_VerifiedWebhookMaterial]:
+        """Verify and return the exact ID/timestamp/body MAC components."""
+
+        if not (msg_id and timestamp and signature_header and secret):
+            return None
+        try:
+            parsed_timestamp = int(timestamp)
+        except (TypeError, ValueError):
+            return None
+        if abs(int(time.time()) - parsed_timestamp) > tolerance_seconds:
+            logger.warning("[webhook] Svix signature timestamp outside replay window")
+            return None
+
+        if secret.startswith("whsec_"):
+            encoded_secret = secret.removeprefix("whsec_")
+            try:
+                key = base64.b64decode(encoded_secret, validate=True)
+            except (binascii.Error, ValueError):
+                logger.debug("[webhook] Invalid whsec_ signing secret")
+                return None
+            if not key:
+                logger.debug("[webhook] Empty decoded whsec_ signing secret")
+                return None
+        else:
+            try:
+                key = secret.encode("utf-8")
+            except UnicodeEncodeError:
+                return None
+
+        try:
+            signed_content = (
+                msg_id.encode("utf-8") + b"." + timestamp.encode("utf-8") + b"." + body
+            )
+        except UnicodeEncodeError:
+            return None
+        expected = base64.b64encode(
+            hmac.new(key, signed_content, hashlib.sha256).digest()
+        ).decode()
+        for part in signature_header.split():
+            try:
+                version, signature = part.split(",", 1)
+            except ValueError:
+                continue
+            if version == "v1" and _hmac_str_equal(signature, expected):
+                return _VerifiedWebhookMaterial(
+                    WebhookVerificationCoverage.ID_TIMESTAMP_BODY_MAC,
+                    verified_claims=((id_claim_name, msg_id),),
+                    signed_timestamp=timestamp,
+                )
+        return None
+
+    def _validate_svix_signature(
+        self,
+        body: bytes,
+        secret: str,
+        msg_id: str,
+        timestamp: str,
+        signature_header: str,
+        tolerance_seconds: int = DEFAULT_REPLAY_TOLERANCE_SECONDS,
+    ) -> bool:
+        """Compatibility boolean over typed Svix verification material."""
+
+        return (
+            self._verify_svix_material(
+                body=body,
+                secret=secret,
+                msg_id=msg_id,
+                timestamp=timestamp,
+                signature_header=signature_header,
+                id_claim_name="message-id",
+                tolerance_seconds=tolerance_seconds,
+            )
+            is not None
+        )

--- a/gateway/platforms/webhook_auth.py
+++ b/gateway/platforms/webhook_auth.py
@@ -11,7 +11,9 @@ import base64
 import binascii
 import hashlib
 import hmac
+import json
 import logging
+import re
 import time
 from dataclasses import dataclass
 from enum import Enum
@@ -39,6 +41,8 @@ def _hmac_str_equal(provided: str, expected: str) -> bool:
 
 
 DEFAULT_REPLAY_TOLERANCE_SECONDS = 300
+_MAX_CUSTOM_SIGNATURE_HEADER_BYTES = 16_384
+_MAX_CUSTOM_SIGNATURE_PARTS = 64
 
 # These are executable verifier names, not configuration aliases.  Aliases are
 # normalized exactly once by webhook_contract.WebhookRouteConfig.bind().
@@ -49,6 +53,24 @@ SIGNATURE_MODES = frozenset({
     "hindsight",
     "hermes",
     "linear",
+    "sentry",
+    "pocket",
+    "todoist",
+    "juniper_mist",
+    "fireflies",
+    "redmine",
+    "gitea",
+    "forgejo",
+    "asana",
+    "notion",
+    "exit1",
+    "jira",
+    "attio",
+    "attio_x",
+    "plain_token",
+    "bearer_token",
+    "trello",
+    "custom_hmac",
     "stripe",
     "svix",
     "generic_v2",
@@ -134,13 +156,17 @@ class _VerifiedWebhookMaterial:
     signed_timestamp: Optional[str] = None
 
 
-def _coverage_for_mode(signature_mode: str) -> WebhookVerificationCoverage:
+def _coverage_for_route(route: "WebhookRouteConfig") -> WebhookVerificationCoverage:
     """Coverage used only by private test receipt factories."""
 
-    if signature_mode == "gitlab":
+    signature_mode = route.signature_mode
+    if signature_mode in {"gitlab", "plain_token", "bearer_token"}:
         return WebhookVerificationCoverage.CREDENTIAL_ONLY
-    if signature_mode in {"stripe", "generic_v2"}:
+    if signature_mode in {"linear", "stripe", "generic_v2"}:
         return WebhookVerificationCoverage.TIMESTAMP_BODY_MAC
+    if signature_mode == "custom_hmac" and route.custom_signature is not None:
+        if route.custom_signature.uses_timestamp:
+            return WebhookVerificationCoverage.TIMESTAMP_BODY_MAC
     if signature_mode in {"svix", "standard_webhooks"}:
         return WebhookVerificationCoverage.ID_TIMESTAMP_BODY_MAC
     return WebhookVerificationCoverage.BODY_MAC
@@ -217,7 +243,7 @@ class WebhookSignatureVerificationReceipt:
             body,
             headers,
             _VerifiedWebhookMaterial(
-                coverage=_coverage_for_mode(route.signature_mode),
+                coverage=_coverage_for_route(route),
                 verified_claims=verified_claims,
             ),
         )
@@ -285,12 +311,60 @@ def _header(request: "web.Request", name: str) -> str:
     return _header_from_mapping(request.headers, name)
 
 
+def _split_custom_signature_header(
+    value: str,
+) -> Optional[dict[str, tuple[str, ...]]]:
+    """Parse a bounded ``name=value`` list without positional authority."""
+
+    try:
+        if len(value.encode("utf-8")) > _MAX_CUSTOM_SIGNATURE_HEADER_BYTES:
+            return None
+    except UnicodeEncodeError:
+        return None
+    chunks = value.split(",")
+    if len(chunks) > _MAX_CUSTOM_SIGNATURE_PARTS:
+        return None
+    parsed: dict[str, list[str]] = {}
+    for chunk in chunks:
+        label, separator, part = chunk.partition("=")
+        if not separator:
+            # Providers may append unrelated version markers. Named fields,
+            # never list position, decide what is authoritative.
+            continue
+        label = label.strip()
+        if not label:
+            continue
+        parsed.setdefault(label, []).append(part.strip())
+    return {label: tuple(values) for label, values in parsed.items()}
+
+
+def _render_custom_signature_message(
+    template: str,
+    timestamp: str,
+    body: bytes,
+) -> Optional[bytes]:
+    """Splice the on-wire body bytes into the already-validated template."""
+
+    head, marker, tail = template.partition("{body}")
+    if not marker:
+        return None
+    try:
+        return (
+            head.replace("{timestamp}", timestamp).encode("utf-8")
+            + body
+            + tail.replace("{timestamp}", timestamp).encode("utf-8")
+        )
+    except UnicodeEncodeError:
+        return None
+
+
 class WebhookAuthMixin:
     """Validate the verifier selected by the canonical route binding."""
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._v1_signature_warned: set[str] = set()
+        self._custom_body_only_warned: set[str] = set()
 
     def _verify_github(
         self, request, body: bytes, secret: str
@@ -342,10 +416,127 @@ class WebhookAuthMixin:
     def _verify_linear(
         self, request, body: bytes, secret: str
     ) -> Optional[_VerifiedWebhookMaterial]:
-        signature = _header(request, "linear-signature")
+        signature = _header(request, "Linear-Signature")
         if not signature:
             return None
         expected = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+        if not _hmac_str_equal(signature, expected):
+            return None
+        try:
+            payload = json.loads(body)
+            timestamp_ms = int(payload.get("webhookTimestamp"))
+        except (AttributeError, TypeError, ValueError, json.JSONDecodeError):
+            return None
+        timestamp_header = _header(request, "Linear-Timestamp")
+        if timestamp_header:
+            try:
+                if int(timestamp_header) != timestamp_ms:
+                    return None
+            except (TypeError, ValueError):
+                return None
+        if abs(time.time() * 1000 - timestamp_ms) > 60_000:
+            logger.warning("[webhook] Linear signature timestamp outside replay window")
+            return None
+        return _VerifiedWebhookMaterial(
+            WebhookVerificationCoverage.TIMESTAMP_BODY_MAC,
+            signed_timestamp=str(timestamp_ms),
+        )
+
+    @staticmethod
+    def _verify_hex_body_header(
+        request,
+        body: bytes,
+        secret: str,
+        header: str,
+        *,
+        prefix: str = "",
+    ) -> Optional[_VerifiedWebhookMaterial]:
+        signature = _header(request, header)
+        if not signature:
+            return None
+        expected = prefix + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+        if not _hmac_str_equal(signature, expected):
+            return None
+        return _VerifiedWebhookMaterial(WebhookVerificationCoverage.BODY_MAC)
+
+    def _verify_pocket(
+        self, request, body: bytes, secret: str
+    ) -> Optional[_VerifiedWebhookMaterial]:
+        signature = _header(request, "X-HeyPocket-Signature")
+        timestamp = _header(request, "X-HeyPocket-Timestamp")
+        if not signature or not timestamp:
+            return None
+        try:
+            timestamp_ms = int(timestamp)
+        except (TypeError, ValueError):
+            return None
+        if abs(time.time() * 1000 - timestamp_ms) > (
+            DEFAULT_REPLAY_TOLERANCE_SECONDS * 1000
+        ):
+            logger.warning("[webhook] Pocket signature timestamp outside replay window")
+            return None
+        signed = timestamp.encode() + b"." + body
+        expected = hmac.new(secret.encode(), signed, hashlib.sha256).hexdigest()
+        if not _hmac_str_equal(signature, expected):
+            return None
+        return _VerifiedWebhookMaterial(
+            WebhookVerificationCoverage.TIMESTAMP_BODY_MAC,
+            signed_timestamp=timestamp,
+        )
+
+    def _verify_todoist(
+        self, request, body: bytes, secret: str
+    ) -> Optional[_VerifiedWebhookMaterial]:
+        signature = _header(request, "X-Todoist-Hmac-SHA256")
+        if not signature:
+            return None
+        expected = base64.b64encode(
+            hmac.new(secret.encode(), body, hashlib.sha256).digest()
+        ).decode("ascii")
+        if not _hmac_str_equal(signature, expected):
+            return None
+        return _VerifiedWebhookMaterial(WebhookVerificationCoverage.BODY_MAC)
+
+    def _verify_plain_token(
+        self, request, secret: str
+    ) -> Optional[_VerifiedWebhookMaterial]:
+        token = _header(request, "X-Webhook-Secret")
+        if not token or not _hmac_str_equal(token, secret):
+            return None
+        return _VerifiedWebhookMaterial(WebhookVerificationCoverage.CREDENTIAL_ONLY)
+
+    def _verify_bearer_token(
+        self, request, secret: str
+    ) -> Optional[_VerifiedWebhookMaterial]:
+        authorization = _header(request, "Authorization")
+        scheme, separator, token = authorization.partition(" ")
+        token = token.strip()
+        if (
+            not separator
+            or scheme.lower() != "bearer"
+            or not token
+            or not _hmac_str_equal(token, secret)
+        ):
+            return None
+        return _VerifiedWebhookMaterial(WebhookVerificationCoverage.CREDENTIAL_ONLY)
+
+    def _verify_trello(
+        self,
+        request,
+        body: bytes,
+        secret: str,
+        callback_url: Optional[str],
+    ) -> Optional[_VerifiedWebhookMaterial]:
+        signature = _header(request, "X-Trello-Webhook")
+        if not signature or not callback_url:
+            return None
+        expected = base64.b64encode(
+            hmac.new(
+                secret.encode(),
+                body + callback_url.encode(),
+                hashlib.sha1,
+            ).digest()
+        ).decode("ascii")
         if not _hmac_str_equal(signature, expected):
             return None
         return _VerifiedWebhookMaterial(WebhookVerificationCoverage.BODY_MAC)
@@ -435,12 +626,128 @@ class WebhookAuthMixin:
             return None
         return _VerifiedWebhookMaterial(WebhookVerificationCoverage.BODY_MAC)
 
+    def _verify_custom_hmac(
+        self,
+        request,
+        body: bytes,
+        secret: str,
+        spec,
+    ) -> Optional[_VerifiedWebhookMaterial]:
+        """Verify exactly one immutable route-configured HMAC contract."""
+
+        if spec is None:
+            return None
+        signature_header = _header(request, spec.header)
+        if not signature_header:
+            return None
+        try:
+            if (
+                len(signature_header.encode("utf-8"))
+                > _MAX_CUSTOM_SIGNATURE_HEADER_BYTES
+            ):
+                return None
+        except UnicodeEncodeError:
+            return None
+
+        parts: dict[str, tuple[str, ...]] = {}
+        if spec.signature_part is not None or spec.timestamp_part is not None:
+            parsed = _split_custom_signature_header(signature_header)
+            if parsed is None:
+                return None
+            parts = parsed
+
+        if spec.signature_part is None:
+            candidates = (signature_header.strip(),)
+        else:
+            candidates = parts.get(spec.signature_part, ())
+        if not candidates:
+            return None
+
+        if spec.signature_prefix:
+            candidates = tuple(
+                candidate[len(spec.signature_prefix) :]
+                for candidate in candidates
+                if candidate.startswith(spec.signature_prefix)
+            )
+        candidates = tuple(candidate for candidate in candidates if candidate)
+        if not candidates:
+            return None
+
+        timestamp = ""
+        if spec.uses_timestamp:
+            if spec.timestamp_part is not None:
+                timestamps = parts.get(spec.timestamp_part, ())
+                if not timestamps or len(set(timestamps)) != 1:
+                    return None
+                timestamp = timestamps[0]
+            elif spec.timestamp_header is not None:
+                timestamp = _header(request, spec.timestamp_header).strip()
+            if not timestamp or re.fullmatch(r"[0-9]{1,20}", timestamp) is None:
+                return None
+            try:
+                timestamp_value = int(timestamp)
+            except (TypeError, ValueError, OverflowError):
+                return None
+            if spec.timestamp_unit == "milliseconds":
+                now_value = int(time.time() * 1000)
+                tolerance = int(spec.tolerance_seconds) * 1000
+            elif spec.timestamp_unit == "seconds":
+                now_value = int(time.time())
+                tolerance = int(spec.tolerance_seconds)
+            else:
+                return None
+            if abs(now_value - timestamp_value) > tolerance:
+                logger.warning(
+                    "[webhook] Route '%s' custom signature timestamp outside "
+                    "the configured replay window",
+                    request.match_info.get("route_name", ""),
+                )
+                return None
+        else:
+            route_name = request.match_info.get("route_name", "")
+            if route_name not in self._custom_body_only_warned:
+                self._custom_body_only_warned.add(route_name)
+                logger.warning(
+                    "[webhook] Route '%s' custom signature authenticates the "
+                    "body without signed freshness; identical bodies are "
+                    "durably collapsed",
+                    route_name,
+                )
+
+        message = _render_custom_signature_message(spec.template, timestamp, body)
+        if message is None:
+            return None
+        try:
+            key = secret.encode("utf-8")
+            digest = hmac.new(key, message, spec.algorithm).digest()
+        except (UnicodeEncodeError, TypeError, ValueError):
+            return None
+        if spec.encoding == "hex":
+            expected = digest.hex()
+            candidates = tuple(candidate.lower() for candidate in candidates)
+        elif spec.encoding == "base64":
+            expected = base64.b64encode(digest).decode("ascii")
+        else:
+            return None
+        if not any(_hmac_str_equal(candidate, expected) for candidate in candidates):
+            return None
+        return _VerifiedWebhookMaterial(
+            (
+                WebhookVerificationCoverage.TIMESTAMP_BODY_MAC
+                if spec.uses_timestamp
+                else WebhookVerificationCoverage.BODY_MAC
+            ),
+            signed_timestamp=timestamp or None,
+        )
+
     def _verify_material(
         self,
         request: "web.Request",
         body: bytes,
         secret: str,
         signature_mode: str,
+        signature_context: Optional[str] = None,
+        custom_signature=None,
     ) -> Optional[_VerifiedWebhookMaterial]:
         """Return exact material from one selected verifier, failing closed."""
 
@@ -465,6 +772,87 @@ class WebhookAuthMixin:
             return self._verify_hermes(request, body, secret)
         if signature_mode == "linear":
             return self._verify_linear(request, body, secret)
+        if signature_mode == "sentry":
+            return self._verify_hex_body_header(
+                request, body, secret, "sentry-hook-signature"
+            )
+        if signature_mode == "pocket":
+            return self._verify_pocket(request, body, secret)
+        if signature_mode == "todoist":
+            return self._verify_todoist(request, body, secret)
+        if signature_mode == "juniper_mist":
+            return self._verify_hex_body_header(
+                request, body, secret, "X-Mist-Signature-v2"
+            )
+        if signature_mode == "fireflies":
+            return self._verify_hex_body_header(
+                request, body, secret, "X-Hub-Signature", prefix="sha256="
+            )
+        if signature_mode == "redmine":
+            return self._verify_hex_body_header(
+                request,
+                body,
+                secret,
+                "X-Redmine-Signature-256",
+                prefix="sha256=",
+            )
+        if signature_mode == "gitea":
+            return self._verify_hex_body_header(
+                request, body, secret, "X-Gitea-Signature"
+            )
+        if signature_mode == "forgejo":
+            return self._verify_hex_body_header(
+                request, body, secret, "X-Forgejo-Signature"
+            )
+        if signature_mode == "asana":
+            return self._verify_hex_body_header(
+                request, body, secret, "X-Hook-Signature"
+            )
+        if signature_mode == "notion":
+            return self._verify_hex_body_header(
+                request,
+                body,
+                secret,
+                "X-Notion-Signature",
+                prefix="sha256=",
+            )
+        if signature_mode == "exit1":
+            return self._verify_hex_body_header(
+                request,
+                body,
+                secret,
+                "X-Exit1-Signature",
+                prefix="sha256=",
+            )
+        if signature_mode == "jira":
+            return self._verify_hex_body_header(
+                request,
+                body,
+                secret,
+                "X-Hub-Signature",
+                prefix="sha256=",
+            )
+        if signature_mode == "attio":
+            return self._verify_hex_body_header(
+                request, body, secret, "Attio-Signature"
+            )
+        if signature_mode == "attio_x":
+            return self._verify_hex_body_header(
+                request, body, secret, "X-Attio-Signature"
+            )
+        if signature_mode == "plain_token":
+            return self._verify_plain_token(request, secret)
+        if signature_mode == "bearer_token":
+            return self._verify_bearer_token(request, secret)
+        if signature_mode == "trello":
+            return self._verify_trello(request, body, secret, signature_context)
+        if signature_mode == "custom_hmac":
+            return self._verify_custom_hmac(
+                request,
+                body,
+                secret,
+                custom_signature,
+            )
         if signature_mode == "stripe":
             return self._verify_stripe(request, body, secret)
         if signature_mode == "svix":
@@ -494,10 +882,20 @@ class WebhookAuthMixin:
         body: bytes,
         secret: str,
         signature_mode: str,
+        custom_signature=None,
     ) -> bool:
         """Compatibility boolean over the typed verification result."""
 
-        return self._verify_material(request, body, secret, signature_mode) is not None
+        return (
+            self._verify_material(
+                request,
+                body,
+                secret,
+                signature_mode,
+                custom_signature=custom_signature,
+            )
+            is not None
+        )
 
     def _verify_signature_receipt(
         self,
@@ -513,6 +911,8 @@ class WebhookAuthMixin:
             body,
             secret,
             route.signature_mode,
+            route.signature_context,
+            route.custom_signature,
         )
         if material is None:
             return None

--- a/gateway/platforms/webhook_callbacks.py
+++ b/gateway/platforms/webhook_callbacks.py
@@ -1,0 +1,358 @@
+"""Signed asynchronous webhook callbacks (Task 13, #4386/#73828).
+
+A route may declare a ``callback`` (an http(s) URL + optional secret). After
+the agent run finishes, the adapter POSTs a signed envelope — execution ID,
+event ID, terminal status, output/error, timestamp, attempt number — to that
+URL. The URL is an untrusted boundary: private/link-local/metadata
+destinations are rejected by default to prevent SSRF; redirects are refused;
+DNS resolution is bound to the exact address dialed; delivery is bounded.
+
+``deliver_callback`` is the synchronous transport primitive. Async gateway
+callers must use ``deliver_callback_async`` so DNS, connect, TLS, response I/O,
+and retry backoff execute off the event loop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import hmac
+import http.client
+import ipaddress
+import json
+import logging
+import socket
+import ssl
+import time
+import urllib.parse
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+logger = logging.getLogger(__name__)
+
+CALLBACK_TIMEOUT_SECONDS = 10
+CALLBACK_MAX_ATTEMPTS = 2
+CALLBACK_BACKOFF_SECONDS = 1.0
+
+
+@dataclass(frozen=True)
+class _CallbackDestination:
+    scheme: str
+    hostname: str
+    port: int
+    connect_host: str
+    request_target: str
+    host_header: str
+
+
+def _unsafe_ip(value: str) -> bool:
+    try:
+        ip = ipaddress.ip_address(value)
+    except ValueError:
+        return True
+    return bool(
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_multicast
+        or ip.is_reserved
+        or ip.is_unspecified
+    )
+
+
+def _resolve_public_destination(url: str) -> tuple[_CallbackDestination | None, str]:
+    """Resolve once, reject every unsafe answer, and return the address to dial."""
+    try:
+        parsed = urllib.parse.urlsplit(url)
+    except ValueError:
+        return None, "callback URL is malformed"
+    if parsed.scheme not in {"http", "https"}:
+        return None, "callback must be http(s)"
+    if parsed.username is not None or parsed.password is not None:
+        return None, "callback URL must not contain userinfo"
+    hostname = parsed.hostname
+    if not hostname:
+        return None, "callback missing host"
+    try:
+        port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    except ValueError:
+        return None, "callback port is invalid"
+
+    try:
+        infos = socket.getaddrinfo(
+            hostname,
+            port,
+            type=socket.SOCK_STREAM,
+            proto=socket.IPPROTO_TCP,
+        )
+    except OSError:
+        return None, "callback host could not be resolved"
+    if not infos:
+        return None, "callback host could not be resolved"
+
+    resolved: list[str] = []
+    for info in infos:
+        addr = str(info[4][0])
+        if addr in resolved:
+            continue
+        if _unsafe_ip(addr):
+            return (
+                None,
+                "callback host resolves to a private/loopback/metadata address (SSRF blocked)",
+            )
+        resolved.append(addr)
+    if not resolved:
+        return None, "callback host could not be resolved"
+
+    default_port = 443 if parsed.scheme == "https" else 80
+    host_literal = hostname
+    if ":" in host_literal and not host_literal.startswith("["):
+        host_literal = f"[{host_literal}]"
+    host_header = host_literal if port == default_port else f"{host_literal}:{port}"
+    request_target = urllib.parse.urlunsplit((
+        "",
+        "",
+        parsed.path or "/",
+        parsed.query,
+        "",
+    ))
+    return (
+        _CallbackDestination(
+            scheme=parsed.scheme,
+            hostname=hostname,
+            port=port,
+            connect_host=resolved[0],
+            request_target=request_target,
+            host_header=host_header,
+        ),
+        "",
+    )
+
+
+def _is_private_host(host: str) -> bool:
+    """Compatibility helper: fail closed if any resolved address is unsafe."""
+    try:
+        infos = socket.getaddrinfo(
+            host,
+            None,
+            type=socket.SOCK_STREAM,
+            proto=socket.IPPROTO_TCP,
+        )
+    except OSError:
+        return True
+    if not infos:
+        return True
+    return any(_unsafe_ip(str(info[4][0])) for info in infos)
+
+
+def validate_callback_url(url: str) -> tuple[bool, str]:
+    """Validate that a callback URL resolves only to public http(s) addresses."""
+    destination, reason = _resolve_public_destination(url)
+    return destination is not None, reason
+
+
+class _PinnedHTTPConnection(http.client.HTTPConnection):
+    """HTTP connection whose socket dials a previously validated IP address."""
+
+    def __init__(
+        self,
+        hostname: str,
+        port: int,
+        connect_host: str,
+        *,
+        timeout: int,
+    ) -> None:
+        super().__init__(hostname, port=port, timeout=timeout)
+        self._connect_host = connect_host
+
+    def connect(self) -> None:
+        self.sock = socket.create_connection(
+            (self._connect_host, self.port),
+            self.timeout,
+            self.source_address,
+        )
+        if self._tunnel_host:
+            self._tunnel()
+
+
+class _PinnedHTTPSConnection(http.client.HTTPSConnection):
+    """HTTPS connection pinned to an IP while preserving hostname SNI/cert checks."""
+
+    def __init__(
+        self,
+        hostname: str,
+        port: int,
+        connect_host: str,
+        *,
+        timeout: int,
+    ) -> None:
+        super().__init__(
+            hostname,
+            port=port,
+            timeout=timeout,
+            context=ssl.create_default_context(),
+        )
+        self._connect_host = connect_host
+
+    def connect(self) -> None:
+        sock = socket.create_connection(
+            (self._connect_host, self.port),
+            self.timeout,
+            self.source_address,
+        )
+        if self._tunnel_host:
+            self.sock = sock
+            self._tunnel()
+            sock = self.sock
+        self.sock = self._context.wrap_socket(sock, server_hostname=self.host)
+
+
+def _open_pinned(
+    destination: _CallbackDestination,
+    body: bytes,
+    headers: Mapping[str, str],
+    *,
+    timeout: int,
+) -> int:
+    connection_cls = (
+        _PinnedHTTPSConnection
+        if destination.scheme == "https"
+        else _PinnedHTTPConnection
+    )
+    connection = connection_cls(
+        destination.hostname,
+        destination.port,
+        destination.connect_host,
+        timeout=timeout,
+    )
+    request_headers = dict(headers)
+    request_headers["Host"] = destination.host_header
+    try:
+        connection.request(
+            "POST",
+            destination.request_target,
+            body=body,
+            headers=request_headers,
+        )
+        response = connection.getresponse()
+        status = int(response.status)
+        # Drain the bounded response stream enough to permit a clean close;
+        # callback response bodies are not part of the transport contract.
+        response.read(64 * 1024)
+        return status
+    finally:
+        connection.close()
+
+
+def _sign(body: bytes, secret: str) -> str:
+    return "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+
+
+def build_callback_envelope(
+    *,
+    execution_id: str,
+    event_id: str,
+    status: str,
+    output: str | None,
+    error: str | None,
+    attempt: int,
+) -> dict:
+    return {
+        "execution_id": execution_id,
+        "event_id": event_id,
+        "status": status,
+        "output": output,
+        "error": error,
+        "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "attempt": attempt,
+    }
+
+
+def _valid_envelope(envelope: object) -> bool:
+    if not isinstance(envelope, dict):
+        return False
+    execution_id = envelope.get("execution_id")
+    event_id = envelope.get("event_id")
+    status = envelope.get("status")
+    return all(
+        isinstance(value, str) and bool(value.strip())
+        for value in (execution_id, event_id, status)
+    )
+
+
+def deliver_callback(
+    url: str,
+    secret: str | None,
+    envelope: dict,
+    *,
+    timeout: int = CALLBACK_TIMEOUT_SECONDS,
+) -> bool:
+    """Synchronously POST a signed envelope using one validated DNS generation.
+
+    The host is resolved exactly once for this delivery. Every returned address
+    must be public, and the socket is then connected to that validated address
+    directly. HTTPS still uses the configured hostname for SNI and certificate
+    verification, while the original hostname is retained in ``Host``.
+
+    Redirects are never followed: any 3xx is a terminal delivery failure.
+    Async callers must invoke :func:`deliver_callback_async`.
+    """
+    if not _valid_envelope(envelope):
+        logger.warning("[webhook] callback refused: malformed callback envelope")
+        return False
+    destination, reason = _resolve_public_destination(url)
+    if destination is None:
+        logger.warning("[webhook] callback refused: %s", reason)
+        return False
+
+    body = json.dumps(envelope, ensure_ascii=False).encode("utf-8")
+    headers = {
+        "Content-Type": "application/json",
+        "X-Hermes-Delivery": str(envelope["execution_id"]),
+    }
+    if secret:
+        headers["X-Hermes-Signature-256"] = _sign(body, secret)
+
+    last_error = ""
+    for attempt in range(1, CALLBACK_MAX_ATTEMPTS + 1):
+        try:
+            status = _open_pinned(
+                destination,
+                body,
+                headers,
+                timeout=timeout,
+            )
+            if 200 <= status < 300:
+                return True
+            last_error = f"HTTP {status}"
+            if 300 <= status < 500:
+                # Redirects and receiver-declared client errors are terminal.
+                return False
+        except Exception as exc:
+            last_error = str(exc) or type(exc).__name__
+        if attempt < CALLBACK_MAX_ATTEMPTS:
+            time.sleep(CALLBACK_BACKOFF_SECONDS * attempt)
+
+    logger.warning(
+        "[webhook] callback delivery failed after %d attempts: %s",
+        CALLBACK_MAX_ATTEMPTS,
+        last_error,
+    )
+    return False
+
+
+async def deliver_callback_async(
+    url: str,
+    secret: str | None,
+    envelope: dict,
+    *,
+    timeout: int = CALLBACK_TIMEOUT_SECONDS,
+) -> bool:
+    """Run the blocking callback transport off the asyncio event loop."""
+    return await asyncio.to_thread(
+        deliver_callback,
+        url,
+        secret,
+        envelope,
+        timeout=timeout,
+    )

--- a/gateway/platforms/webhook_common.py
+++ b/gateway/platforms/webhook_common.py
@@ -471,6 +471,7 @@ def _strict_bounded_int(
 def _authentication_key_fingerprints(
     secret: str,
     signature_mode: str,
+    hmac_algorithm: Optional[str] = "sha256",
 ) -> frozenset[bytes]:
     """Return log-safe equality keys for every reusable secret material.
 
@@ -499,19 +500,32 @@ def _authentication_key_fingerprints(
             raise WebhookContractError(
                 "webhook whsec_ secret must decode to a non-empty key"
             )
+    if hmac_algorithm is not None:
+        try:
+            digest = hashlib.new(hmac_algorithm)
+        except (TypeError, ValueError) as exc:
+            raise WebhookContractError(
+                "webhook HMAC algorithm is not supported"
+            ) from exc
+        block_size = digest.block_size
+    else:
+        block_size = 0
+
     fingerprints: set[bytes] = set()
     for material in {raw_key, effective_key}:
         fingerprints.add(hashlib.sha256(material).digest())
-        # HMAC-SHA256 first hashes keys longer than its 64-byte block, then
-        # zero-pads shorter keys. Consequently b"key" and b"key\0" (and a
-        # long key versus its 32-byte SHA-256 digest) are verifier-equivalent.
-        normalized = (
-            hashlib.sha256(material).digest()
-            if len(material) > hashlib.sha256().block_size
-            else material
-        )
-        hmac_key_block = normalized.ljust(hashlib.sha256().block_size, b"\0")
-        fingerprints.add(hashlib.sha256(hmac_key_block).digest())
+        if hmac_algorithm is not None:
+            # HMAC first hashes keys longer than the selected digest's block,
+            # then zero-pads shorter keys. Record the exact normalized block so
+            # verifier-equivalent custom SHA-1/SHA-512 keys cannot be assigned
+            # to distinct authorities.
+            normalized = (
+                hashlib.new(hmac_algorithm, material).digest()
+                if len(material) > block_size
+                else material
+            )
+            hmac_key_block = normalized.ljust(block_size, b"\0")
+            fingerprints.add(hashlib.sha256(hmac_key_block).digest())
     return frozenset(fingerprints)
 
 

--- a/gateway/platforms/webhook_common.py
+++ b/gateway/platforms/webhook_common.py
@@ -1,0 +1,717 @@
+"""Shared immutable carriers and validation helpers for webhook shards."""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import json
+import logging
+import os
+import re
+import secrets
+import stat
+import threading
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+try:
+    from aiohttp import web
+
+    AIOHTTP_AVAILABLE = True
+except ImportError:
+    AIOHTTP_AVAILABLE = False
+    web = None  # type: ignore[assignment]
+
+from gateway.platforms.base import (
+    MessageEvent,
+)
+from gateway.platforms.webhook_contract import (
+    WebhookContractError,
+    WebhookEnvelope,
+)
+from gateway.platforms.webhook_filters import (
+    WebhookPreparedScript,
+)
+from gateway.platforms.webhook_ledger import (
+    DEFAULT_RECOVERY_BATCH_SIZE,
+    DEFAULT_MAX_STORAGE_BYTES,
+    MAXIMUM_MAX_RECORDS,
+    MAXIMUM_MAX_STORAGE_BYTES,
+    OperationAuthority,
+    WebhookLedgerError,
+    WebhookOperationLedger,
+)
+from gateway.response_filters import is_autonomous_silence_response
+
+logger = logging.getLogger(__name__)
+
+
+def _is_webhook_silence_response(content: Any) -> bool:
+    """Whether an agent response means "deliberately say nothing".
+
+    Webhook routes are autonomous background lanes: a subscription prompt tells
+    the agent to answer with ``[SILENT]`` when a tick produced nothing worth a
+    human's attention (a duplicate inbound, a stand-down because a sibling lane
+    already replied, a routine close).  Nobody is waiting on the other end, so
+    there is no reader for whom a "nothing happened" message is useful.
+
+    The reason this is the loose autonomous rule rather than the live gateway's
+    is what the two lanes optimise for.  In an interactive chat, swallowing a
+    real answer because it happens to open with a marker is much worse than
+    showing a stray marker, so ``is_intentional_silence_response`` demands the
+    response be EXACTLY a marker.  A webhook run has the opposite payoff: the
+    cost of a leaked non-story is a pointless notification on every tick, and
+    models reliably add a sentence explaining why they stayed quiet — which
+    under the strict rule flips the whole thing back to "deliver".  That is not
+    a hypothetical: it is why a Helper support lane kept messaging its owner to
+    report that it had nothing to report.
+
+    So use the shared autonomous-lane matcher (also used by cron), which treats
+    a marker on its own first or last line as silence while still delivering
+    prose that merely mentions one mid-sentence.  Sharing the function keeps
+    the two autonomous lanes from drifting apart, and keeps the interactive
+    path untouched.
+    """
+    return is_autonomous_silence_response(content)
+
+
+# Sentinel returned by _resolve_request_profile when a /p/<profile>/ prefix
+# names a profile this gateway does not serve (→ 404). Distinct from None
+# (no prefix / multiplexing off → handle as the default profile).
+_PROFILE_REJECTED = object()
+
+# Default bind host. ``None`` tells aiohttp/asyncio's ``create_server`` to bind
+# BOTH address families (IPv4 + IPv6) — the portable dual-stack default.
+#
+# Why not "0.0.0.0" (the old default) or "::"?
+#   - "0.0.0.0" binds IPv4 ONLY. On IPv6-only private networks — notably Fly.io
+#     6PN, where an agent's ``<app>.internal`` name resolves to an ``fdaa:…``
+#     IPv6 address — an IPv4-only listener is unreachable. That is exactly why
+#     hosted-agent webhook routes were publicly unreachable: the edge router
+#     reverse-proxies to ``<app>.internal:8644`` over 6PN (IPv6) but the adapter
+#     was listening on 0.0.0.0 (v4 only) → connection refused.
+#   - "::" is NOT a safe fix: on hosts where the kernel sets IPV6_V6ONLY=1
+#     (verified on Fly machines), binding "::" yields an IPv6-ONLY socket, which
+#     then breaks the IPv4 loopback health check (``curl 127.0.0.1:8644/health``)
+#     and the AF_INET port-conflict probe in connect().
+#   - ``None`` asks the event loop to create a listening socket per resolved
+#     family, so both 127.0.0.1 (v4) and the 6PN fdaa (v6) are served regardless
+#     of the bindv6only sysctl. Users can still pin a specific host via
+#     ``platforms.webhook.extra.host``.
+DEFAULT_HOST = None
+DEFAULT_PORT = 8644
+_INSECURE_NO_AUTH = "INSECURE_NO_AUTH"
+_DYNAMIC_ROUTES_FILENAME = "webhook_subscriptions.json"
+_MAX_DYNAMIC_ROUTES_FILE_BYTES = 4 * 1024 * 1024
+_DYNAMIC_ROUTES_CONTENT_RECHECK_SECONDS = 1.0
+_MAX_BODY_BYTES_LIMIT = 1024 * 1024
+_MAX_RENDERED_PROMPT_BYTES = 512 * 1024
+_MAX_DURABLE_EVENT_SNAPSHOT_BYTES = 2 * 1024 * 1024
+_MAX_DURABLE_AUTHORITY_SNAPSHOT_BYTES = 64 * 1024
+_PROFILE_AUTHORITY_INCARNATION_FILENAME = ".webhook-profile-incarnation"
+_PROFILE_AUTHORITY_INCARNATION_BYTES = 32
+_MAX_CONCURRENT_AUTHORITY_PROOFS = 4
+_MAX_CONCURRENT_ROUTE_WORKERS = 4
+_RATE_WINDOW_SECONDS = 60.0
+_MAX_RATE_LIMIT_PER_MINUTE = 10_000
+_MAX_SCRIPT_TIMEOUT_SECONDS = 300
+_IDEMPOTENCY_DEFAULT_MAX_ENTRIES = 4096
+_IDEMPOTENCY_MAX_ENTRIES_LIMIT = MAXIMUM_MAX_RECORDS
+_IDEMPOTENCY_DEFAULT_MAX_STORAGE_BYTES = DEFAULT_MAX_STORAGE_BYTES
+_IDEMPOTENCY_MAX_STORAGE_BYTES_LIMIT = MAXIMUM_MAX_STORAGE_BYTES
+_RAW_PAYLOAD_DEFAULT_CAP_BYTES = 4_000
+_RAW_PAYLOAD_MIN_CAP_BYTES = 64
+_RAW_PAYLOAD_MAX_CAP_BYTES = 1_000_000
+
+
+class WebhookConfigurationError(ValueError):
+    """A deterministic webhook setting that cannot improve on retry."""
+
+
+# ``disconnect()`` normally fences every operation owned by its exact ledger
+# instance before returning.  A SQLite/I/O failure at that seam is special:
+# another adapter in the same process has the same PID, so ordinary dead-owner
+# recovery correctly refuses to steal the first adapter's rows.  Keep the exact
+# failed owner ID in a process-local quarantine, scoped by the canonical DB
+# path, so a replacement can retry that one retirement transaction first.
+#
+# The registry is deliberately bounded.  Overflow is represented by a
+# fail-closed sentinel rather than evicting an owner ID and accidentally
+# reopening intake while an unretired same-process owner still exists.
+_MAX_RETIREMENT_QUARANTINE_DATABASES = 128
+_MAX_RETIREMENT_QUARANTINE_OWNERS_PER_DATABASE = 128
+_RECOVERY_CONCURRENCY_LIMIT = DEFAULT_RECOVERY_BATCH_SIZE
+_RECOVERY_PAGE_BUDGET = 4
+_route_worker_slots = threading.BoundedSemaphore(_MAX_CONCURRENT_ROUTE_WORKERS)
+
+
+@dataclass
+class _RetirementQuarantine:
+    owners: dict[str, None] = field(default_factory=dict)
+    saturated: bool = False
+
+
+_retirement_quarantine_lock = threading.Lock()
+_retirement_quarantines: dict[str, _RetirementQuarantine] = {}
+_retirement_quarantine_registry_saturated = False
+
+
+def _reset_retirement_quarantines_after_fork() -> None:
+    """Never inherit same-process owner assertions into a child process."""
+
+    global _retirement_quarantine_lock
+    global _retirement_quarantines
+    global _retirement_quarantine_registry_saturated
+    global _route_worker_slots
+
+    # Replacing the lock also avoids inheriting a lock held by a vanished
+    # parent thread at the fork boundary.
+    _retirement_quarantine_lock = threading.Lock()
+    _retirement_quarantines = {}
+    _retirement_quarantine_registry_saturated = False
+    # No executor worker survives fork. Reset the process-global filter/script
+    # budget so inherited acquisitions cannot permanently fence the child.
+    _route_worker_slots = threading.BoundedSemaphore(_MAX_CONCURRENT_ROUTE_WORKERS)
+
+
+if hasattr(os, "register_at_fork"):
+    os.register_at_fork(after_in_child=_reset_retirement_quarantines_after_fork)
+
+
+def _retirement_quarantine_key(ledger: WebhookOperationLedger) -> str:
+    """Return the physical durable-ledger identity used for quarantine."""
+
+    try:
+        return os.path.normcase(str(ledger.db_path.resolve(strict=False)))
+    except (AttributeError, OSError, RuntimeError) as exc:
+        raise WebhookLedgerError(
+            "webhook retirement ledger path cannot be resolved"
+        ) from exc
+
+
+def _quarantine_failed_retirement(ledger: WebhookOperationLedger) -> bool:
+    """Record one exact failed owner, returning false on bounded overflow."""
+
+    global _retirement_quarantine_registry_saturated
+
+    try:
+        key = _retirement_quarantine_key(ledger)
+    except Exception:
+        # Losing the path identity means no replacement can safely determine
+        # which durable store contains this owner.  Preserve safety with the
+        # bounded process-wide fail-closed sentinel.
+        with _retirement_quarantine_lock:
+            _retirement_quarantine_registry_saturated = True
+        raise
+    owner = ledger.instance_id
+    with _retirement_quarantine_lock:
+        quarantine = _retirement_quarantines.get(key)
+        if quarantine is None:
+            if len(_retirement_quarantines) >= _MAX_RETIREMENT_QUARANTINE_DATABASES:
+                _retirement_quarantine_registry_saturated = True
+                return False
+            quarantine = _RetirementQuarantine()
+            _retirement_quarantines[key] = quarantine
+        if owner in quarantine.owners:
+            return True
+        if len(quarantine.owners) >= _MAX_RETIREMENT_QUARANTINE_OWNERS_PER_DATABASE:
+            quarantine.saturated = True
+            return False
+        quarantine.owners[owner] = None
+        return True
+
+
+def _quarantined_retirement_owners(
+    ledger: WebhookOperationLedger,
+) -> tuple[str, ...]:
+    """Snapshot exact prior owners for this ledger, or fail closed."""
+
+    key = _retirement_quarantine_key(ledger)
+    with _retirement_quarantine_lock:
+        if _retirement_quarantine_registry_saturated:
+            raise WebhookLedgerError(
+                "webhook retirement quarantine registry is saturated; "
+                "process restart is required"
+            )
+        quarantine = _retirement_quarantines.get(key)
+        if quarantine is None:
+            return ()
+        if quarantine.saturated:
+            raise WebhookLedgerError(
+                "webhook retirement quarantine for this ledger is saturated; "
+                "process restart is required"
+            )
+        return tuple(quarantine.owners)
+
+
+def _clear_quarantined_retirement_owner(
+    ledger: WebhookOperationLedger,
+    owner: str,
+) -> None:
+    """Clear only one successfully retired owner marker."""
+
+    key = _retirement_quarantine_key(ledger)
+    with _retirement_quarantine_lock:
+        quarantine = _retirement_quarantines.get(key)
+        if quarantine is None:
+            return
+        quarantine.owners.pop(owner, None)
+        if not quarantine.owners and not quarantine.saturated:
+            _retirement_quarantines.pop(key, None)
+
+
+_PROMPT_TOKEN_RE = re.compile(
+    r"\{(?P<token>__raw__(?::(?P<raw_cap>[^{}]*))?|[a-zA-Z0-9_.]+)\}"
+)
+# Hostnames/IP literals that only serve connections originating on the same
+# machine. Anything else is treated as a public bind for safety-rail purposes.
+_LOOPBACK_HOSTS = frozenset({
+    "127.0.0.1",
+    "localhost",
+    "::1",
+    "ip6-localhost",
+    "ip6-loopback",
+})
+
+
+def _is_loopback_host(host: Optional[str]) -> bool:
+    """True when `host` binds only to the local machine.
+
+    Covers IPv4 loopback, the standard `localhost` alias, IPv6 loopback in
+    both bracketed and bare form, and the common Debian-style aliases. Any
+    falsy value (empty string, None) is conservatively treated as non-loopback
+    because an unset host usually means the platform-default public bind.
+    """
+    if not host:
+        return False
+    return host.strip().lower() in _LOOPBACK_HOSTS
+
+
+def check_webhook_requirements() -> bool:
+    """Check if webhook adapter dependencies are available."""
+    return AIOHTTP_AVAILABLE
+
+
+def _reject_nonfinite_json(constant: str) -> None:
+    raise ValueError(f"non-finite JSON number {constant}")
+
+
+def _reject_duplicate_json_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    value: dict[str, Any] = {}
+    for key, item in pairs:
+        if key in value:
+            raise ValueError(f"duplicate JSON key {key!r}")
+        value[key] = item
+    return value
+
+
+def _snapshot_route_config(route: Any) -> dict[str, Any]:
+    """Detach one JSON-only execution policy from hot-reloadable config."""
+
+    if not isinstance(route, dict):
+        raise WebhookContractError("webhook route config must be an object")
+    try:
+        encoded = json.dumps(
+            route,
+            ensure_ascii=False,
+            allow_nan=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        snapshot = json.loads(encoded, parse_constant=_reject_nonfinite_json)
+    except (TypeError, ValueError, RecursionError, json.JSONDecodeError) as exc:
+        raise WebhookContractError(
+            "webhook route execution policy must use JSON values"
+        ) from exc
+    if not isinstance(snapshot, dict):  # pragma: no cover - guarded above
+        raise WebhookContractError("webhook route config must be an object")
+    return snapshot
+
+
+def _plain_json_snapshot(value: Any) -> Any:
+    """Detach frozen JSON containers without accepting arbitrary objects."""
+
+    if isinstance(value, Mapping):
+        return {str(key): _plain_json_snapshot(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_plain_json_snapshot(item) for item in value]
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    raise WebhookContractError("durable webhook carrier contains a non-JSON value")
+
+
+@dataclass
+class WebhookMessageEvent(MessageEvent):
+    """Agent event carrying durable execution authority across async seams."""
+
+    webhook_authority: OperationAuthority = field(kw_only=True)
+    webhook_envelope: Optional[WebhookEnvelope] = field(default=None, kw_only=True)
+
+
+@dataclass(frozen=True)
+class PreparedTargetTemplate:
+    """Structurally validated delivery choice plus snapshotted home fallback."""
+
+    kind: str
+    profile: str
+    platform: Optional[str] = None
+    home_chat_id: Optional[str] = None
+    home_thread_id: Optional[str] = None
+    home_scope_id: Optional[str] = None
+    slack_static_chat_id: Optional[str] = None
+    slack_static_scope_id: Optional[str] = None
+    slack_scope_locked: bool = False
+
+
+@dataclass(frozen=True)
+class PreparedSkillInvocation:
+    """Exact skill scaffold captured before an authenticated request runs."""
+
+    command: str
+    prefix: str
+    suffix: str
+    source_sha256: str
+    inject_prompt: bool = True
+
+    def render(self, prompt: str) -> str:
+        if not self.inject_prompt:
+            return self.prefix
+        return f"{self.prefix}{prompt}{self.suffix}"
+
+
+@dataclass(frozen=True)
+class AuthenticatedRouteAuthority:
+    """One immutable publication consumed as a unit by request handling."""
+
+    authority: tuple[Any, ...]
+    secret: str
+    route_config: dict[str, Any]
+    filter_route_config: dict[str, Any]
+    effective_toolsets: tuple[str, ...]
+    prepared_script: Optional[WebhookPreparedScript]
+    prepared_skill: Optional[PreparedSkillInvocation]
+    prepared_target: PreparedTargetTemplate
+    profile_generation: str
+
+
+class WebhookTargetDeliveryDisposition(str, Enum):
+    """Typed result of consuming one durably staged target carrier."""
+
+    CONFIRMED = "confirmed"
+    SUPPRESSED = "suppressed"
+    CACHED = "cached"
+    PRE_EFFECT_FAILED = "pre_effect_failed"
+    IN_PROGRESS = "in_progress"
+    INDETERMINATE = "indeterminate"
+
+
+@dataclass(frozen=True)
+class WebhookTargetDeliveryResult:
+    disposition: WebhookTargetDeliveryDisposition
+    message_id: Optional[str] = None
+    error: Optional[str] = None
+
+    @property
+    def success(self) -> bool:
+        return self.disposition in {
+            WebhookTargetDeliveryDisposition.CONFIRMED,
+            WebhookTargetDeliveryDisposition.SUPPRESSED,
+            WebhookTargetDeliveryDisposition.CACHED,
+        }
+
+
+def _bounded_positive_int(
+    value: Any,
+    *,
+    default: int,
+    maximum: int,
+    minimum: int = 1,
+) -> int:
+    """Parse an integer setting and keep it inside a safe positive range."""
+
+    if isinstance(value, bool):
+        parsed = default
+    else:
+        try:
+            parsed = int(value)
+        except (TypeError, ValueError, OverflowError):
+            parsed = default
+    return min(max(parsed, minimum), maximum)
+
+
+def _strict_bounded_int(
+    value: Any,
+    *,
+    label: str,
+    minimum: int,
+    maximum: int,
+    unit: Optional[str] = None,
+) -> int:
+    """Parse a safety authority without silently widening invalid input."""
+
+    if isinstance(value, bool):
+        raise WebhookConfigurationError(f"{label} must be an integer")
+    if isinstance(value, int):
+        parsed = value
+    elif isinstance(value, str) and re.fullmatch(r"[+-]?\d+", value.strip()):
+        parsed = int(value.strip())
+    else:
+        raise WebhookConfigurationError(f"{label} must be an integer")
+    if parsed < minimum or parsed > maximum:
+        suffix = f" {unit}" if unit else ""
+        raise WebhookConfigurationError(
+            f"{label} must be between {minimum} and {maximum}{suffix}"
+        )
+    return parsed
+
+
+def _authentication_key_fingerprints(
+    secret: str,
+    signature_mode: str,
+) -> frozenset[bytes]:
+    """Return log-safe equality keys for every reusable secret material.
+
+    Svix and Standard Webhooks decode ``whsec_`` values before verification.
+    Both the configured text and the decoded verifier key are authority: a
+    caller who knows either representation can derive the other.  Comparing
+    both closes collisions with raw-key modes in both directions.
+    """
+
+    try:
+        raw_key = secret.encode("utf-8")
+    except UnicodeEncodeError as exc:
+        raise WebhookContractError("webhook secret is not valid Unicode text") from exc
+    effective_key = raw_key
+    if signature_mode in {"svix", "standard_webhooks"} and secret.startswith("whsec_"):
+        try:
+            effective_key = base64.b64decode(
+                secret.removeprefix("whsec_"),
+                validate=True,
+            )
+        except (binascii.Error, ValueError) as exc:
+            raise WebhookContractError(
+                "webhook whsec_ secret is not valid base64"
+            ) from exc
+        if not effective_key:
+            raise WebhookContractError(
+                "webhook whsec_ secret must decode to a non-empty key"
+            )
+    fingerprints: set[bytes] = set()
+    for material in {raw_key, effective_key}:
+        fingerprints.add(hashlib.sha256(material).digest())
+        # HMAC-SHA256 first hashes keys longer than its 64-byte block, then
+        # zero-pads shorter keys. Consequently b"key" and b"key\0" (and a
+        # long key versus its 32-byte SHA-256 digest) are verifier-equivalent.
+        normalized = (
+            hashlib.sha256(material).digest()
+            if len(material) > hashlib.sha256().block_size
+            else material
+        )
+        hmac_key_block = normalized.ljust(hashlib.sha256().block_size, b"\0")
+        fingerprints.add(hashlib.sha256(hmac_key_block).digest())
+    return frozenset(fingerprints)
+
+
+def _route_policy_sha256(
+    route: Mapping[str, Any],
+    authority_profile: str,
+    effective_toolsets: tuple[str, ...],
+    script_sha256: Optional[str],
+    profile_generation: str,
+    filter_authority: tuple[tuple[str, str], ...],
+    skill_sha256: Optional[str],
+    target_authority: Mapping[str, Any],
+) -> str:
+    """Digest the complete non-secret execution policy for key continuity."""
+
+    if any(not isinstance(key, str) for key in route):
+        raise WebhookContractError("webhook route policy keys must be strings")
+    route_policy = {
+        key: value for key, value in route.items() if key not in {"secret", "profile"}
+    }
+    # URL routing keeps its canonical ``default``/explicit-profile shape, but
+    # execution policy continuity belongs to the physical authority domain.
+    # This makes named nonmultiplex A (omitted profile) equivalent to
+    # multiplex A (explicit profile=A) without widening either URL route.
+    route_policy["profile"] = authority_profile
+    policy = {
+        "route": route_policy,
+        "effective_toolsets": list(effective_toolsets),
+        "script_sha256": script_sha256,
+        "profile_generation": profile_generation,
+        "filter_authority": [list(item) for item in filter_authority],
+        "skill_sha256": skill_sha256,
+        "target_authority": dict(target_authority),
+    }
+    try:
+        canonical = json.dumps(
+            policy,
+            ensure_ascii=True,
+            allow_nan=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("ascii")
+    except (TypeError, ValueError, UnicodeEncodeError, RecursionError) as exc:
+        raise WebhookContractError(
+            "webhook route policy must be finite JSON data"
+        ) from exc
+    return hashlib.sha256(canonical).hexdigest()
+
+
+def _canonical_snapshot_size(value: Mapping[str, Any]) -> int:
+    """Return the exact UTF-8 size used by durable canonical JSON."""
+
+    try:
+        encoded = json.dumps(
+            value,
+            ensure_ascii=False,
+            allow_nan=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    except (TypeError, ValueError, UnicodeEncodeError, RecursionError) as exc:
+        raise WebhookContractError(
+            "webhook execution snapshot is not canonical JSON"
+        ) from exc
+    return len(encoded)
+
+
+def _read_profile_incarnation(path: Path) -> str:
+    """Read one bounded, regular, owner-only physical-profile token."""
+
+    flags = os.O_RDONLY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        fd = os.open(path, flags)
+    except OSError as exc:
+        raise WebhookContractError(
+            "profile authority incarnation token is unavailable"
+        ) from exc
+    try:
+        file_stat = os.fstat(fd)
+        if not stat.S_ISREG(file_stat.st_mode):
+            raise WebhookContractError(
+                "profile authority incarnation token is not a regular file"
+            )
+        if os.name == "posix" and stat.S_IMODE(file_stat.st_mode) != 0o600:
+            raise WebhookContractError(
+                "profile authority incarnation token must have mode 0600"
+            )
+        expected_size = _PROFILE_AUTHORITY_INCARNATION_BYTES * 2 + 1
+        raw = os.read(fd, expected_size + 1)
+        if len(raw) != expected_size:
+            raise WebhookContractError(
+                "profile authority incarnation token has invalid length"
+            )
+    finally:
+        os.close(fd)
+    try:
+        token = raw.decode("ascii")
+    except UnicodeDecodeError as exc:
+        raise WebhookContractError(
+            "profile authority incarnation token is not ASCII"
+        ) from exc
+    if not re.fullmatch(
+        rf"[0-9a-f]{{{_PROFILE_AUTHORITY_INCARNATION_BYTES * 2}}}\n",
+        token,
+    ):
+        raise WebhookContractError(
+            "profile authority incarnation token is not canonical"
+        )
+    return token[:-1]
+
+
+def _profile_incarnation_token(profile_home: Path) -> str:
+    """Atomically create or load the durable random profile incarnation."""
+
+    token_path = profile_home / _PROFILE_AUTHORITY_INCARNATION_FILENAME
+    try:
+        return _read_profile_incarnation(token_path)
+    except WebhookContractError as exc:
+        # Creation is authorized only by a true missing-path result. A
+        # malformed, symlinked, or unreadable final token is existing authority
+        # corruption and must fail closed rather than being replaced.
+        if not isinstance(exc.__cause__, FileNotFoundError):
+            raise
+    token = secrets.token_hex(_PROFILE_AUTHORITY_INCARNATION_BYTES)
+    payload = f"{token}\n".encode("ascii")
+    temporary_path = profile_home / (
+        f".{_PROFILE_AUTHORITY_INCARNATION_FILENAME}.{secrets.token_hex(16)}.tmp"
+    )
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    fd: Optional[int] = None
+    try:
+        try:
+            fd = os.open(temporary_path, flags, 0o600)
+        except OSError as exc:
+            raise WebhookContractError(
+                "profile authority incarnation token cannot be created"
+            ) from exc
+        try:
+            if os.name == "posix":
+                os.fchmod(fd, 0o600)
+            offset = 0
+            while offset < len(payload):
+                written = os.write(fd, payload[offset:])
+                if written <= 0:
+                    raise OSError("short profile incarnation token write")
+                offset += written
+            os.fsync(fd)
+        except OSError as exc:
+            raise WebhookContractError(
+                "profile authority incarnation token cannot be persisted"
+            ) from exc
+        finally:
+            open_fd = fd
+            fd = None
+            os.close(open_fd)
+
+        published = False
+        try:
+            os.link(
+                temporary_path,
+                token_path,
+                follow_symlinks=False,
+            )
+            published = True
+        except FileExistsError:
+            return _read_profile_incarnation(token_path)
+        except OSError as exc:
+            raise WebhookContractError(
+                "profile authority incarnation token cannot be published"
+            ) from exc
+        if published and os.name == "posix" and hasattr(os, "O_DIRECTORY"):
+            directory_flags = os.O_RDONLY | os.O_DIRECTORY
+            try:
+                directory_fd = os.open(profile_home, directory_flags)
+                try:
+                    os.fsync(directory_fd)
+                finally:
+                    os.close(directory_fd)
+            except OSError as exc:
+                raise WebhookContractError(
+                    "profile authority incarnation directory cannot be persisted"
+                ) from exc
+        return token
+    finally:
+        if fd is not None:
+            try:
+                os.close(fd)
+            except OSError:
+                logger.warning(
+                    "[webhook] Could not close temporary profile incarnation %s",
+                    temporary_path,
+                )
+        try:
+            temporary_path.unlink(missing_ok=True)
+        except OSError:
+            logger.warning(
+                "[webhook] Could not remove temporary profile incarnation %s",
+                temporary_path,
+            )

--- a/gateway/platforms/webhook_contract.py
+++ b/gateway/platforms/webhook_contract.py
@@ -19,6 +19,7 @@ from datetime import datetime
 from enum import Enum
 from types import MappingProxyType
 from typing import Any, Callable, Mapping, Optional
+from urllib.parse import urlsplit
 
 
 class WebhookContractError(ValueError):
@@ -36,8 +37,43 @@ class WebhookPayloadContractError(WebhookContractError):
 MAX_EVENT_TYPE_UTF8_BYTES = 1024
 MAX_ROUTE_NAME_BYTES = 128
 MAX_AUTHENTICATED_JSON_NESTING = 128
+MAX_CUSTOM_SIGNATURE_HEADER_BYTES = 16_384
+MAX_CUSTOM_SIGNATURE_TEMPLATE_BYTES = 1024
+MAX_CUSTOM_SIGNATURE_TOLERANCE_SECONDS = 86_400
 _ROUTE_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,127}$")
 _PROFILE_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
+_HTTP_TOKEN_RE = re.compile(r"^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$")
+_SIGNATURE_TEMPLATE_FIELD_RE = re.compile(r"\{([^{}]*)\}")
+
+_CUSTOM_SIGNATURE_KEYS = frozenset({
+    "header",
+    "signature_part",
+    "signature_prefix",
+    "timestamp_part",
+    "timestamp_header",
+    "template",
+    "algorithm",
+    "encoding",
+    "timestamp_unit",
+    "tolerance_seconds",
+})
+_CUSTOM_SIGNATURE_ALGORITHMS = MappingProxyType({
+    "sha1": "sha1",
+    "hmac_sha1": "sha1",
+    "sha256": "sha256",
+    "hmac_sha256": "sha256",
+    "sha512": "sha512",
+    "hmac_sha512": "sha512",
+})
+_CUSTOM_SIGNATURE_ENCODINGS = frozenset({"hex", "base64"})
+_CUSTOM_SIGNATURE_TIMESTAMP_UNITS = MappingProxyType({
+    "s": "seconds",
+    "second": "seconds",
+    "seconds": "seconds",
+    "ms": "milliseconds",
+    "millisecond": "milliseconds",
+    "milliseconds": "milliseconds",
+})
 
 
 _GITHUB_PULL_REQUEST_ACTIONS = frozenset({
@@ -200,6 +236,226 @@ _GITHUB_EVENT_BODY_CLASSIFIERS: Mapping[str, Callable[[Mapping[str, Any]], bool]
 GITHUB_AUTHENTICATED_EVENTS = frozenset(_GITHUB_EVENT_BODY_CLASSIFIERS)
 
 
+@dataclass(frozen=True, slots=True)
+class WebhookCustomSignatureSpec:
+    """One immutable, route-selected HMAC wire contract.
+
+    The request path never parses mutable route dictionaries. It receives this
+    normalized authority, reads exactly the declared credential fields, and
+    either verifies that one scheme or rejects the request.
+    """
+
+    header: str
+    signature_part: Optional[str]
+    signature_prefix: str
+    timestamp_part: Optional[str]
+    timestamp_header: Optional[str]
+    template: str
+    algorithm: str
+    encoding: str
+    timestamp_unit: Optional[str]
+    tolerance_seconds: Optional[int]
+
+    @property
+    def uses_timestamp(self) -> bool:
+        return self.timestamp_part is not None or self.timestamp_header is not None
+
+    @classmethod
+    def bind(
+        cls,
+        route_name: str,
+        raw: Any,
+    ) -> "WebhookCustomSignatureSpec":
+        prefix = f"route {route_name!r} custom signature"
+        if not isinstance(raw, Mapping):
+            raise WebhookContractError(f"{prefix} must be an object")
+        unknown = [
+            key
+            for key in raw
+            if not isinstance(key, str) or key not in _CUSTOM_SIGNATURE_KEYS
+        ]
+        if unknown:
+            raise WebhookContractError(f"{prefix} has unsupported field {unknown[0]!r}")
+
+        def text_field(
+            key: str,
+            *,
+            required: bool = False,
+            default: Optional[str] = None,
+            canonical_spacing: bool = True,
+        ) -> Optional[str]:
+            value = raw.get(key) if key in raw else default
+            if value is None:
+                if required:
+                    raise WebhookContractError(f"{prefix} requires non-empty {key!r}")
+                return None
+            if not isinstance(value, str):
+                raise WebhookContractError(f"{prefix} field {key!r} must be text")
+            if canonical_spacing and value != value.strip():
+                raise WebhookContractError(
+                    f"{prefix} field {key!r} must not have surrounding whitespace"
+                )
+            if required and not value:
+                raise WebhookContractError(f"{prefix} requires non-empty {key!r}")
+            try:
+                value.encode("utf-8")
+            except UnicodeEncodeError as exc:
+                raise WebhookContractError(
+                    f"{prefix} field {key!r} is not valid Unicode"
+                ) from exc
+            return value
+
+        header = text_field("header", required=True)
+        assert header is not None
+        if len(header) > 128 or _HTTP_TOKEN_RE.fullmatch(header) is None:
+            raise WebhookContractError(
+                f"{prefix} field 'header' must be an HTTP field-name token"
+            )
+        header = header.lower()
+
+        signature_part = text_field("signature_part")
+        timestamp_part = text_field("timestamp_part")
+        for key, value in (
+            ("signature_part", signature_part),
+            ("timestamp_part", timestamp_part),
+        ):
+            if value is not None and (
+                not value or len(value) > 128 or _HTTP_TOKEN_RE.fullmatch(value) is None
+            ):
+                raise WebhookContractError(
+                    f"{prefix} field {key!r} must be a non-empty header-part token"
+                )
+        if signature_part is not None and signature_part == timestamp_part:
+            raise WebhookContractError(
+                f"{prefix} signature_part and timestamp_part must differ"
+            )
+
+        timestamp_header = text_field("timestamp_header")
+        if timestamp_header is not None:
+            if (
+                not timestamp_header
+                or len(timestamp_header) > 128
+                or _HTTP_TOKEN_RE.fullmatch(timestamp_header) is None
+            ):
+                raise WebhookContractError(
+                    f"{prefix} field 'timestamp_header' must be an HTTP "
+                    "field-name token"
+                )
+            timestamp_header = timestamp_header.lower()
+        if timestamp_part is not None and timestamp_header is not None:
+            raise WebhookContractError(
+                f"{prefix} must choose timestamp_part or timestamp_header, not both"
+            )
+        if timestamp_header == header:
+            raise WebhookContractError(
+                f"{prefix} must use timestamp_part when both values share a header"
+            )
+
+        signature_prefix = text_field("signature_prefix", default="")
+        assert signature_prefix is not None
+        signature_prefix_bytes = signature_prefix.encode("utf-8")
+        if len(signature_prefix_bytes) > 256 or any(
+            byte < 0x20 or byte == 0x7F for byte in signature_prefix_bytes
+        ):
+            raise WebhookContractError(
+                f"{prefix} field 'signature_prefix' contains invalid header text"
+            )
+
+        template = text_field(
+            "template",
+            required=True,
+            default="{timestamp}.{body}",
+            canonical_spacing=False,
+        )
+        assert template is not None
+        template_bytes = template.encode("utf-8")
+        if len(template_bytes) > MAX_CUSTOM_SIGNATURE_TEMPLATE_BYTES:
+            raise WebhookContractError(
+                f"{prefix} template exceeds "
+                f"{MAX_CUSTOM_SIGNATURE_TEMPLATE_BYTES} UTF-8 bytes"
+            )
+        if template.count("{body}") != 1:
+            raise WebhookContractError(
+                f"{prefix} template must contain exactly one '{{body}}' marker"
+            )
+        fields = _SIGNATURE_TEMPLATE_FIELD_RE.findall(template)
+        unknown_fields = sorted(set(fields) - {"body", "timestamp"})
+        if unknown_fields:
+            raise WebhookContractError(
+                f"{prefix} template has unsupported marker {{{unknown_fields[0]}}}"
+            )
+        literal = template.replace("{body}", "").replace("{timestamp}", "")
+        if "{" in literal or "}" in literal:
+            raise WebhookContractError(f"{prefix} template contains an unmatched brace")
+        uses_timestamp = "timestamp" in fields
+        has_timestamp_source = (
+            timestamp_part is not None or timestamp_header is not None
+        )
+        if uses_timestamp != has_timestamp_source:
+            if uses_timestamp:
+                raise WebhookContractError(
+                    f"{prefix} template uses '{{timestamp}}' without a timestamp source"
+                )
+            raise WebhookContractError(
+                f"{prefix} declares a timestamp source not covered by the template"
+            )
+
+        algorithm_raw = text_field("algorithm", default="sha256")
+        assert algorithm_raw is not None
+        algorithm = _CUSTOM_SIGNATURE_ALGORITHMS.get(_normalize_token(algorithm_raw))
+        if algorithm is None:
+            raise WebhookContractError(
+                f"{prefix} algorithm must be sha1, sha256, or sha512"
+            )
+
+        encoding_raw = text_field("encoding", default="hex")
+        assert encoding_raw is not None
+        encoding = _normalize_token(encoding_raw)
+        if encoding not in _CUSTOM_SIGNATURE_ENCODINGS:
+            raise WebhookContractError(f"{prefix} encoding must be 'hex' or 'base64'")
+
+        timestamp_unit: Optional[str] = None
+        tolerance_seconds: Optional[int] = None
+        if uses_timestamp:
+            unit_raw = text_field("timestamp_unit", default="seconds")
+            assert unit_raw is not None
+            timestamp_unit = _CUSTOM_SIGNATURE_TIMESTAMP_UNITS.get(
+                _normalize_token(unit_raw)
+            )
+            if timestamp_unit is None:
+                raise WebhookContractError(
+                    f"{prefix} timestamp_unit must be seconds or milliseconds"
+                )
+            tolerance = raw.get("tolerance_seconds", 300)
+            if isinstance(tolerance, bool) or not isinstance(tolerance, int):
+                raise WebhookContractError(
+                    f"{prefix} tolerance_seconds must be an integer"
+                )
+            if not 1 <= tolerance <= MAX_CUSTOM_SIGNATURE_TOLERANCE_SECONDS:
+                raise WebhookContractError(
+                    f"{prefix} tolerance_seconds must be between 1 and "
+                    f"{MAX_CUSTOM_SIGNATURE_TOLERANCE_SECONDS}"
+                )
+            tolerance_seconds = tolerance
+        elif "timestamp_unit" in raw or "tolerance_seconds" in raw:
+            raise WebhookContractError(
+                f"{prefix} timestamp policy requires '{{timestamp}}' in the template"
+            )
+
+        return cls(
+            header=header,
+            signature_part=signature_part,
+            signature_prefix=signature_prefix,
+            timestamp_part=timestamp_part,
+            timestamp_header=timestamp_header,
+            template=template,
+            algorithm=algorithm,
+            encoding=encoding,
+            timestamp_unit=timestamp_unit,
+            tolerance_seconds=tolerance_seconds,
+        )
+
+
 @dataclass(frozen=True)
 class WebhookProviderSpec:
     """Wire facts owned by one webhook provider namespace."""
@@ -285,9 +541,133 @@ _PROVIDER_SPECS = (
     ),
     WebhookProviderSpec(
         name="linear",
+        delivery_id_headers=("Linear-Delivery", "Linear-Delivery-ID"),
+        event_headers=("Linear-Event",),
         legacy_detection_headers=("linear-signature",),
         signature_modes=("linear",),
         default_signature_mode="linear",
+    ),
+    WebhookProviderSpec(
+        name="sentry",
+        delivery_id_headers=("sentry-hook-request-id",),
+        legacy_detection_headers=("sentry-hook-signature",),
+        payload_delivery_id_keys=("id",),
+        signature_modes=("sentry",),
+        default_signature_mode="sentry",
+    ),
+    WebhookProviderSpec(
+        name="pocket",
+        aliases=("heypocket", "heypocketai"),
+        legacy_detection_headers=(
+            "X-HeyPocket-Signature",
+            "X-HeyPocket-Timestamp",
+        ),
+        payload_delivery_id_keys=("id", "event_id"),
+        signature_modes=("pocket",),
+        default_signature_mode="pocket",
+    ),
+    WebhookProviderSpec(
+        name="todoist",
+        legacy_detection_headers=("X-Todoist-Hmac-SHA256",),
+        payload_delivery_id_keys=("event_id", "id"),
+        signature_modes=("todoist",),
+        default_signature_mode="todoist",
+    ),
+    WebhookProviderSpec(
+        name="juniper_mist",
+        aliases=("mist",),
+        legacy_detection_headers=("X-Mist-Signature-v2",),
+        payload_delivery_id_keys=("id",),
+        signature_modes=("juniper_mist",),
+        default_signature_mode="juniper_mist",
+    ),
+    WebhookProviderSpec(
+        name="fireflies",
+        legacy_detection_headers=("X-Hub-Signature",),
+        payload_event_keys=("event", "eventType"),
+        signature_modes=("fireflies",),
+        default_signature_mode="fireflies",
+    ),
+    WebhookProviderSpec(
+        name="redmine",
+        legacy_detection_headers=("X-Redmine-Signature-256",),
+        payload_delivery_id_keys=("id",),
+        signature_modes=("redmine",),
+        default_signature_mode="redmine",
+    ),
+    WebhookProviderSpec(
+        name="gitea",
+        delivery_id_headers=("X-Gitea-Delivery",),
+        event_headers=("X-Gitea-Event",),
+        legacy_detection_headers=("X-Gitea-Signature",),
+        payload_delivery_id_keys=("id",),
+        signature_modes=("gitea",),
+        default_signature_mode="gitea",
+    ),
+    WebhookProviderSpec(
+        name="forgejo",
+        delivery_id_headers=("X-Forgejo-Delivery",),
+        event_headers=("X-Forgejo-Event",),
+        legacy_detection_headers=("X-Forgejo-Signature",),
+        payload_delivery_id_keys=("id",),
+        signature_modes=("forgejo",),
+        default_signature_mode="forgejo",
+    ),
+    WebhookProviderSpec(
+        name="asana",
+        legacy_detection_headers=("X-Hook-Signature",),
+        payload_delivery_id_keys=("id",),
+        signature_modes=("asana",),
+        default_signature_mode="asana",
+    ),
+    WebhookProviderSpec(
+        name="notion",
+        legacy_detection_headers=("X-Notion-Signature",),
+        signature_modes=("notion",),
+        default_signature_mode="notion",
+    ),
+    WebhookProviderSpec(
+        name="exit1",
+        legacy_detection_headers=("X-Exit1-Signature",),
+        signature_modes=("exit1",),
+        default_signature_mode="exit1",
+    ),
+    WebhookProviderSpec(
+        name="jira",
+        aliases=("atlassian",),
+        legacy_detection_headers=("X-Hub-Signature",),
+        payload_event_keys=("webhookEvent",),
+        signature_modes=("jira",),
+        default_signature_mode="jira",
+    ),
+    WebhookProviderSpec(
+        name="attio",
+        legacy_detection_headers=("Attio-Signature", "X-Attio-Signature"),
+        payload_delivery_id_keys=("id",),
+        signature_modes=("attio", "attio_x"),
+        default_signature_mode="attio",
+    ),
+    WebhookProviderSpec(
+        name="plain_token",
+        aliases=("shared_secret",),
+        legacy_detection_headers=("X-Webhook-Secret",),
+        signature_modes=("plain_token",),
+        default_signature_mode="plain_token",
+    ),
+    WebhookProviderSpec(
+        name="bearer_token",
+        aliases=("bearer",),
+        legacy_detection_headers=("Authorization",),
+        signature_modes=("bearer_token",),
+        default_signature_mode="bearer_token",
+    ),
+    WebhookProviderSpec(
+        name="trello",
+        legacy_detection_headers=("X-Trello-Webhook",),
+        payload_delivery_id_keys=("action.id",),
+        payload_event_keys=("action.type",),
+        signature_modes=("trello",),
+        default_signature_mode="trello",
     ),
     WebhookProviderSpec(
         name="hindsight",
@@ -322,6 +702,12 @@ _PROVIDER_SPECS = (
         default_signature_mode="stripe",
     ),
     WebhookProviderSpec(
+        name="custom",
+        aliases=("custom_hmac",),
+        signature_modes=("custom_hmac",),
+        default_signature_mode="custom_hmac",
+    ),
+    WebhookProviderSpec(
         name="generic",
         aliases=("generic_v1", "generic_v2"),
         legacy_detection_headers=(
@@ -352,12 +738,37 @@ _SIGNATURE_MODE_ALIASES = MappingProxyType({
     "standard_webhooks": "standard_webhooks",
     "gitlab_standard": "standard_webhooks",
     "linear": "linear",
+    "sentry": "sentry",
+    "pocket": "pocket",
+    "heypocket": "pocket",
+    "heypocketai": "pocket",
+    "todoist": "todoist",
+    "juniper_mist": "juniper_mist",
+    "mist": "juniper_mist",
+    "fireflies": "fireflies",
+    "redmine": "redmine",
+    "gitea": "gitea",
+    "forgejo": "forgejo",
+    "asana": "asana",
+    "notion": "notion",
+    "exit1": "exit1",
+    "jira": "jira",
+    "atlassian": "jira",
+    "attio": "attio",
+    "attio_x": "attio_x",
+    "plain_token": "plain_token",
+    "shared_secret": "plain_token",
+    "bearer": "bearer_token",
+    "bearer_token": "bearer_token",
+    "trello": "trello",
     "hindsight": "hindsight",
     "hindsight_hmac_sha256": "hindsight",
     "hermes": "hermes",
     "hermes_agent": "hermes",
     "stripe": "stripe",
     "stripe_signature": "stripe",
+    "custom": "custom_hmac",
+    "custom_hmac": "custom_hmac",
     "generic": "generic_v2",
     "generic_v1": "generic_v1",
     "generic_v2": "generic_v2",
@@ -368,9 +779,27 @@ _SIGNATURE_MODE_TO_PROVIDER = MappingProxyType({
     "gitlab": "gitlab",
     "standard_webhooks": "standard_webhooks",
     "linear": "linear",
+    "sentry": "sentry",
+    "pocket": "pocket",
+    "todoist": "todoist",
+    "juniper_mist": "juniper_mist",
+    "fireflies": "fireflies",
+    "redmine": "redmine",
+    "gitea": "gitea",
+    "forgejo": "forgejo",
+    "asana": "asana",
+    "notion": "notion",
+    "exit1": "exit1",
+    "jira": "jira",
+    "attio": "attio",
+    "attio_x": "attio",
+    "plain_token": "plain_token",
+    "bearer_token": "bearer_token",
+    "trello": "trello",
     "hindsight": "hindsight",
     "hermes": "hermes",
     "stripe": "stripe",
+    "custom_hmac": "custom",
     "generic_v1": "generic",
     "generic_v2": "generic",
 })
@@ -387,6 +816,20 @@ def _nonempty_scalar(value: Any) -> Optional[str]:
         return None
     normalized = str(value).strip()
     return normalized or None
+
+
+def _payload_value(payload: Mapping[str, Any], path: str) -> Any:
+    """Resolve a bounded dotted provider field without list/index semantics."""
+
+    current: Any = payload
+    parts = path.split(".")
+    if not parts or len(parts) > 8:
+        return None
+    for part in parts:
+        if not part or not isinstance(current, Mapping):
+            return None
+        current = current.get(part)
+    return current
 
 
 def _header(headers: Mapping[str, Any], name: str) -> str:
@@ -437,6 +880,8 @@ class WebhookRouteConfig:
     signature_mode: str
     enabled: bool
     events: tuple[str, ...]
+    signature_context: Optional[str]
+    custom_signature: Optional[WebhookCustomSignatureSpec]
 
     @classmethod
     def bind(
@@ -531,6 +976,22 @@ class WebhookRouteConfig:
                     "explicit signature_mode"
                 )
 
+        custom_signature: Optional[WebhookCustomSignatureSpec] = None
+        if signature_mode == "custom_hmac":
+            if "signature" not in route:
+                raise WebhookContractError(
+                    f"route {route_name!r} custom_hmac requires a 'signature' object"
+                )
+            custom_signature = WebhookCustomSignatureSpec.bind(
+                route_name,
+                route.get("signature"),
+            )
+        elif "signature" in route:
+            raise WebhookContractError(
+                f"route {route_name!r} may declare 'signature' only with "
+                "signature_mode 'custom_hmac'"
+            )
+
         enabled_raw = route.get("enabled", True)
         if not isinstance(enabled_raw, bool):
             raise WebhookContractError(
@@ -583,6 +1044,36 @@ class WebhookRouteConfig:
                     f"{supported}"
                 )
 
+        signature_context: Optional[str] = None
+        callback_url = route.get("callback_url")
+        if provider == "trello":
+            if not isinstance(callback_url, str) or not callback_url.strip():
+                raise WebhookContractError(
+                    f"route {route_name!r} provider 'trello' requires callback_url"
+                )
+            callback_url = callback_url.strip()
+            try:
+                parsed_callback = urlsplit(callback_url)
+            except ValueError as exc:
+                raise WebhookContractError(
+                    f"route {route_name!r} has malformed callback_url"
+                ) from exc
+            if (
+                parsed_callback.scheme not in {"http", "https"}
+                or not parsed_callback.hostname
+                or parsed_callback.username is not None
+                or parsed_callback.password is not None
+                or parsed_callback.fragment
+            ):
+                raise WebhookContractError(
+                    f"route {route_name!r} has invalid Trello callback_url"
+                )
+            signature_context = callback_url
+        elif callback_url is not None:
+            raise WebhookContractError(
+                f"route {route_name!r} callback_url is valid only for Trello"
+            )
+
         return cls(
             name=route_name,
             profile=configured_profile,
@@ -591,11 +1082,29 @@ class WebhookRouteConfig:
             signature_mode=signature_mode,
             enabled=enabled_raw,
             events=events,
+            signature_context=signature_context,
+            custom_signature=custom_signature,
         )
 
     @property
     def provider_spec(self) -> WebhookProviderSpec:
         return PROVIDER_REGISTRY[self.provider]
+
+    @property
+    def hmac_algorithm(self) -> Optional[str]:
+        """Digest defining verifier-equivalent HMAC key material, if any."""
+
+        if self.signature_mode in {"gitlab", "plain_token", "bearer_token"}:
+            return None
+        if self.signature_mode == "trello":
+            return "sha1"
+        if self.signature_mode == "custom_hmac":
+            return (
+                self.custom_signature.algorithm
+                if self.custom_signature is not None
+                else None
+            )
+        return "sha256"
 
 
 @dataclass(frozen=True)
@@ -659,7 +1168,8 @@ def resolve_delivery_identity(
             (
                 candidate
                 for key in spec.authenticated_delivery_id_payload_keys
-                if (candidate := _nonempty_scalar(payload.get(key))) is not None
+                if (candidate := _nonempty_scalar(_payload_value(payload, key)))
+                is not None
             ),
             None,
         )
@@ -690,7 +1200,7 @@ def resolve_delivery_identity(
 
     if allow_authenticated_payload and route.provider_declared:
         for key in spec.payload_delivery_id_keys:
-            candidate = _nonempty_scalar(payload.get(key))
+            candidate = _nonempty_scalar(_payload_value(payload, key))
             if candidate is not None:
                 return WebhookDeliveryIdentity(route.provider, candidate)
     return None
@@ -755,7 +1265,8 @@ def resolve_event_type(
             (
                 candidate
                 for key in spec.authenticated_event_payload_keys
-                if (candidate := _nonempty_scalar(payload.get(key))) is not None
+                if (candidate := _nonempty_scalar(_payload_value(payload, key)))
+                is not None
             ),
             None,
         )
@@ -780,7 +1291,7 @@ def resolve_event_type(
         return authenticated_event(payload_event)
 
     for key in (*spec.payload_event_keys, "event_type", "type"):
-        value = _nonempty_scalar(payload.get(key))
+        value = _nonempty_scalar(_payload_value(payload, key))
         if value is not None:
             return authenticated_event(value)
     return "unknown"
@@ -854,7 +1365,7 @@ def _resolve_observed_event_type(
         (
             candidate
             for key in (*spec.payload_event_keys, "event_type", "type")
-            if (candidate := _nonempty_scalar(payload.get(key))) is not None
+            if (candidate := _nonempty_scalar(_payload_value(payload, key))) is not None
         ),
         None,
     )

--- a/gateway/platforms/webhook_contract.py
+++ b/gateway/platforms/webhook_contract.py
@@ -1,0 +1,1236 @@
+"""Canonical webhook route, provider, identity, and intake-envelope authority.
+
+HTTP owns byte acquisition and response codes.  This module owns the domain
+facts handed across that boundary: the provider/verifier binding, provider-
+native retry identity, event type, body digest, and request trace. Provider
+authority must be declared in configuration; request headers never select it.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import re
+import time
+import uuid
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+from types import MappingProxyType
+from typing import Any, Callable, Mapping, Optional
+
+
+class WebhookContractError(ValueError):
+    """Webhook configuration cannot be normalized without ambiguity."""
+
+
+class WebhookRouteScopeError(WebhookContractError):
+    """A route is not bound to the request-selected profile."""
+
+
+class WebhookPayloadContractError(WebhookContractError):
+    """Authenticated request payload metadata violates the wire contract."""
+
+
+MAX_EVENT_TYPE_UTF8_BYTES = 1024
+MAX_ROUTE_NAME_BYTES = 128
+MAX_AUTHENTICATED_JSON_NESTING = 128
+_ROUTE_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,127}$")
+_PROFILE_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
+
+
+_GITHUB_PULL_REQUEST_ACTIONS = frozenset({
+    "assigned",
+    "auto_merge_disabled",
+    "auto_merge_enabled",
+    "closed",
+    "converted_to_draft",
+    "demilestoned",
+    "dequeued",
+    "edited",
+    "enqueued",
+    "labeled",
+    "locked",
+    "milestoned",
+    "opened",
+    "ready_for_review",
+    "reopened",
+    "review_request_removed",
+    "review_requested",
+    "synchronize",
+    "unassigned",
+    "unlabeled",
+    "unlocked",
+})
+_GITHUB_ISSUES_ACTIONS = frozenset({
+    "assigned",
+    "closed",
+    "deleted",
+    "demilestoned",
+    "edited",
+    "labeled",
+    "locked",
+    "milestoned",
+    "opened",
+    "pinned",
+    "reopened",
+    "transferred",
+    "typed",
+    "unassigned",
+    "unlabeled",
+    "unlocked",
+    "unpinned",
+    "untyped",
+})
+_GITHUB_CHECK_RUN_ACTIONS = frozenset({
+    "completed",
+    "created",
+    "rerequested",
+    "requested_action",
+})
+
+
+def _is_json_object(value: Any) -> bool:
+    return isinstance(value, Mapping)
+
+
+def _is_json_integer(value: Any) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _is_nonempty_json_string(value: Any) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def _github_ping_body(payload: Mapping[str, Any]) -> bool:
+    return (
+        _is_nonempty_json_string(payload.get("zen"))
+        and _is_json_integer(payload.get("hook_id"))
+        and _is_json_object(payload.get("hook"))
+    )
+
+
+def _github_pull_request_body(payload: Mapping[str, Any]) -> bool:
+    pull_request = payload.get("pull_request")
+    number = payload.get("number")
+    return (
+        payload.get("action") in _GITHUB_PULL_REQUEST_ACTIONS
+        and _is_json_integer(number)
+        and _is_json_object(pull_request)
+        and _is_json_integer(pull_request.get("number"))
+        and pull_request.get("number") == number
+        and _is_json_object(payload.get("repository"))
+        and _is_json_object(payload.get("sender"))
+        # Neighboring GitHub events include the same complete pull-request
+        # object. Their event-specific object is the conservative discriminator.
+        and not any(key in payload for key in ("comment", "review", "thread"))
+    )
+
+
+def _github_push_body(payload: Mapping[str, Any]) -> bool:
+    return (
+        all(
+            _is_nonempty_json_string(payload.get(key))
+            for key in ("ref", "before", "after")
+        )
+        and all(
+            isinstance(payload.get(key), bool)
+            for key in ("created", "deleted", "forced")
+        )
+        and isinstance(payload.get("commits"), list)
+        and _is_json_object(payload.get("repository"))
+        and _is_json_object(payload.get("pusher"))
+        and _is_json_object(payload.get("sender"))
+    )
+
+
+def _github_issues_body(payload: Mapping[str, Any]) -> bool:
+    issue = payload.get("issue")
+    return (
+        payload.get("action") in _GITHUB_ISSUES_ACTIONS
+        and _is_json_object(issue)
+        and _is_json_integer(issue.get("number"))
+        and _is_json_object(payload.get("repository"))
+        and _is_json_object(payload.get("sender"))
+        # Neighboring issue_comment, sub_issues, and issue_dependencies events
+        # carry an ``issue`` too. Their event-specific object is authoritative.
+        and not any(
+            key in payload
+            for key in (
+                "blocked_by_issue",
+                "blocked_issue",
+                "blocking_issue",
+                "comment",
+                "dependency",
+                "parent_issue",
+                "sub_issue",
+            )
+        )
+    )
+
+
+def _github_check_run_body(payload: Mapping[str, Any]) -> bool:
+    check_run = payload.get("check_run")
+    return (
+        payload.get("action") in _GITHUB_CHECK_RUN_ACTIONS
+        and _is_json_object(check_run)
+        and _is_json_integer(check_run.get("id"))
+        and _is_nonempty_json_string(check_run.get("name"))
+        and _is_nonempty_json_string(check_run.get("status"))
+        and _is_json_object(payload.get("repository"))
+        and _is_json_object(payload.get("sender"))
+        # deployment_status may include a complete check_run object, while
+        # check_suite has its own neighboring object and overlapping actions.
+        and not any(
+            key in payload for key in ("check_suite", "deployment", "deployment_status")
+        )
+    )
+
+
+_GITHUB_EVENT_BODY_CLASSIFIERS: Mapping[str, Callable[[Mapping[str, Any]], bool]] = (
+    MappingProxyType({
+        "check_run": _github_check_run_body,
+        "issues": _github_issues_body,
+        "ping": _github_ping_body,
+        "pull_request": _github_pull_request_body,
+        "push": _github_push_body,
+    })
+)
+GITHUB_AUTHENTICATED_EVENTS = frozenset(_GITHUB_EVENT_BODY_CLASSIFIERS)
+
+
+@dataclass(frozen=True)
+class WebhookProviderSpec:
+    """Wire facts owned by one webhook provider namespace."""
+
+    name: str
+    aliases: tuple[str, ...] = ()
+    delivery_id_headers: tuple[str, ...] = ()
+    authenticated_delivery_id_headers: tuple[str, ...] = ()
+    event_headers: tuple[str, ...] = ()
+    route_bound_event_authority: bool = False
+    legacy_detection_headers: tuple[str, ...] = ()
+    payload_delivery_id_keys: tuple[str, ...] = ()
+    payload_event_keys: tuple[str, ...] = ()
+    authenticated_delivery_id_payload_keys: tuple[str, ...] = ()
+    authenticated_event_payload_keys: tuple[str, ...] = ()
+    authenticated_timestamp_payload_keys: tuple[str, ...] = ()
+    payload_replay_tolerance_seconds: Optional[int] = None
+    signature_modes: tuple[str, ...] = ()
+    default_signature_mode: str = ""
+
+
+_PROVIDER_SPECS = (
+    WebhookProviderSpec(
+        name="svix",
+        aliases=("agentmail",),
+        delivery_id_headers=("svix-id",),
+        authenticated_delivery_id_headers=("svix-id",),
+        legacy_detection_headers=("svix-id", "svix-signature", "svix-timestamp"),
+        signature_modes=("svix",),
+        default_signature_mode="svix",
+    ),
+    WebhookProviderSpec(
+        name="github",
+        aliases=("github_hmac_sha256",),
+        delivery_id_headers=("X-GitHub-Delivery",),
+        event_headers=("X-GitHub-Event",),
+        route_bound_event_authority=True,
+        legacy_detection_headers=(
+            "X-Hub-Signature-256",
+            "X-GitHub-Delivery",
+            "X-GitHub-Event",
+        ),
+        signature_modes=("github",),
+        default_signature_mode="github",
+    ),
+    WebhookProviderSpec(
+        name="gitlab",
+        aliases=("gitlab_token",),
+        delivery_id_headers=(
+            "X-Gitlab-Event-UUID",
+            "X-Gitlab-Webhook-UUID",
+            "X-Gitlab-Idempotency-Key",
+            "Idempotency-Key",
+        ),
+        event_headers=("X-GitLab-Event",),
+        route_bound_event_authority=True,
+        legacy_detection_headers=(
+            "X-Gitlab-Token",
+            "X-Gitlab-Event-UUID",
+            "X-Gitlab-Webhook-UUID",
+            "X-Gitlab-Idempotency-Key",
+            "X-GitLab-Event",
+        ),
+        payload_event_keys=("object_kind", "event_name"),
+        signature_modes=("gitlab",),
+        default_signature_mode="gitlab",
+    ),
+    WebhookProviderSpec(
+        name="standard_webhooks",
+        aliases=("gitlab_standard",),
+        delivery_id_headers=("webhook-id", "Idempotency-Key"),
+        authenticated_delivery_id_headers=("webhook-id",),
+        legacy_detection_headers=("webhook-id", "webhook-signature"),
+        signature_modes=("standard_webhooks",),
+        default_signature_mode="standard_webhooks",
+    ),
+    WebhookProviderSpec(
+        name="chatwoot",
+        delivery_id_headers=("X-Chatwoot-Delivery",),
+        legacy_detection_headers=("X-Chatwoot-Delivery",),
+        payload_event_keys=("event",),
+        signature_modes=("generic_v1", "generic_v2"),
+    ),
+    WebhookProviderSpec(
+        name="linear",
+        legacy_detection_headers=("linear-signature",),
+        signature_modes=("linear",),
+        default_signature_mode="linear",
+    ),
+    WebhookProviderSpec(
+        name="hindsight",
+        aliases=("hindsight_hmac_sha256",),
+        legacy_detection_headers=("X-Hindsight-Signature",),
+        signature_modes=("hindsight",),
+        default_signature_mode="hindsight",
+    ),
+    WebhookProviderSpec(
+        name="hermes",
+        aliases=("hermes_agent",),
+        delivery_id_headers=("X-Hermes-Delivery",),
+        event_headers=("X-Hermes-Event",),
+        legacy_detection_headers=(
+            "X-Hermes-Signature-256",
+            "X-Hermes-Delivery",
+            "X-Hermes-Event",
+        ),
+        authenticated_delivery_id_payload_keys=("delivery_id",),
+        authenticated_event_payload_keys=("hook_event_name",),
+        authenticated_timestamp_payload_keys=("timestamp",),
+        payload_replay_tolerance_seconds=300,
+        signature_modes=("hermes",),
+        default_signature_mode="hermes",
+    ),
+    WebhookProviderSpec(
+        name="stripe",
+        aliases=("stripe_signature",),
+        legacy_detection_headers=("Stripe-Signature",),
+        payload_delivery_id_keys=("id",),
+        signature_modes=("stripe",),
+        default_signature_mode="stripe",
+    ),
+    WebhookProviderSpec(
+        name="generic",
+        aliases=("generic_v1", "generic_v2"),
+        legacy_detection_headers=(
+            "X-Webhook-Signature-V2",
+            "X-Webhook-Signature",
+        ),
+        signature_modes=("generic_v1", "generic_v2"),
+        default_signature_mode="generic_v2",
+    ),
+)
+
+PROVIDER_REGISTRY: Mapping[str, WebhookProviderSpec] = MappingProxyType({
+    spec.name: spec for spec in _PROVIDER_SPECS
+})
+_PROVIDER_ALIASES = MappingProxyType({
+    alias: spec.name for spec in _PROVIDER_SPECS for alias in (spec.name, *spec.aliases)
+})
+
+# Configuration aliases normalize to the executable verifier names.  The
+# verifier receives only these canonical values; it never interprets aliases.
+_SIGNATURE_MODE_ALIASES = MappingProxyType({
+    "agentmail": "svix",
+    "svix": "svix",
+    "github": "github",
+    "github_hmac_sha256": "github",
+    "gitlab": "gitlab",
+    "gitlab_token": "gitlab",
+    "standard_webhooks": "standard_webhooks",
+    "gitlab_standard": "standard_webhooks",
+    "linear": "linear",
+    "hindsight": "hindsight",
+    "hindsight_hmac_sha256": "hindsight",
+    "hermes": "hermes",
+    "hermes_agent": "hermes",
+    "stripe": "stripe",
+    "stripe_signature": "stripe",
+    "generic": "generic_v2",
+    "generic_v1": "generic_v1",
+    "generic_v2": "generic_v2",
+})
+_SIGNATURE_MODE_TO_PROVIDER = MappingProxyType({
+    "svix": "svix",
+    "github": "github",
+    "gitlab": "gitlab",
+    "standard_webhooks": "standard_webhooks",
+    "linear": "linear",
+    "hindsight": "hindsight",
+    "hermes": "hermes",
+    "stripe": "stripe",
+    "generic_v1": "generic",
+    "generic_v2": "generic",
+})
+
+
+def _normalize_token(value: str) -> str:
+    return str(value or "").strip().lower().replace("-", "_")
+
+
+def _nonempty_scalar(value: Any) -> Optional[str]:
+    if isinstance(value, bool) or value is None:
+        return None
+    if not isinstance(value, (str, int)):
+        return None
+    normalized = str(value).strip()
+    return normalized or None
+
+
+def _header(headers: Mapping[str, Any], name: str) -> str:
+    """Read a case-insensitive HTTP header from real or test mappings."""
+
+    direct = headers.get(name)
+    if direct not in (None, ""):
+        return str(direct)
+    target = name.lower()
+    for key, value in headers.items():
+        if str(key).lower() == target and value not in (None, ""):
+            return str(value)
+    return ""
+
+
+def canonical_provider(value: str) -> str:
+    """Return the canonical provider namespace or fail closed."""
+
+    normalized = _normalize_token(value)
+    if not normalized:
+        raise WebhookContractError("webhook provider must be non-empty")
+    provider = _PROVIDER_ALIASES.get(normalized)
+    if provider is None:
+        raise WebhookContractError(f"unsupported webhook provider {value!r}")
+    return provider
+
+
+def canonical_signature_mode(value: str) -> str:
+    """Return one executable verifier mode or fail closed."""
+
+    normalized = _normalize_token(value)
+    if not normalized:
+        raise WebhookContractError("webhook signature mode must be non-empty")
+    mode = _SIGNATURE_MODE_ALIASES.get(normalized)
+    if mode is None:
+        raise WebhookContractError(f"unsupported webhook signature mode {value!r}")
+    return mode
+
+
+@dataclass(frozen=True)
+class WebhookRouteConfig:
+    """Normalized route identity/security binding consumed by intake."""
+
+    name: str
+    profile: str
+    provider: str
+    provider_declared: bool
+    signature_mode: str
+    enabled: bool
+    events: tuple[str, ...]
+
+    @classmethod
+    def bind(
+        cls,
+        name: str,
+        route: Mapping[str, Any],
+        *,
+        headers: Mapping[str, Any],
+        request_profile: Optional[str] = None,
+    ) -> "WebhookRouteConfig":
+        if not isinstance(route, Mapping):
+            raise WebhookContractError("webhook route config must be an object")
+        if not isinstance(name, str) or not _ROUTE_NAME_RE.fullmatch(name):
+            raise WebhookContractError(
+                "webhook route name must already be a canonical lowercase "
+                f"URL slug of at most {MAX_ROUTE_NAME_BYTES} ASCII bytes"
+            )
+        route_name = name
+
+        if "profile" in route:
+            profile_value = route.get("profile")
+            if not isinstance(profile_value, str) or not _PROFILE_NAME_RE.fullmatch(
+                profile_value
+            ):
+                raise WebhookContractError(
+                    f"route {route_name!r} has a non-canonical profile binding"
+                )
+            configured_profile = profile_value
+        else:
+            configured_profile = "default"
+
+        effective_profile = request_profile or "default"
+        if not isinstance(effective_profile, str) or not _PROFILE_NAME_RE.fullmatch(
+            effective_profile
+        ):
+            raise WebhookRouteScopeError("request profile is not canonical")
+        if configured_profile != effective_profile:
+            raise WebhookRouteScopeError(
+                f"route {route_name!r} is not bound to profile {effective_profile!r}"
+            )
+
+        provider_raw = route.get("provider")
+        if provider_raw is not None and (
+            not isinstance(provider_raw, str) or not provider_raw.strip()
+        ):
+            raise WebhookContractError(f"route {route_name!r} has malformed provider")
+        signature_raw = route.get("signature_mode")
+        if signature_raw is not None and (
+            not isinstance(signature_raw, str) or not signature_raw.strip()
+        ):
+            raise WebhookContractError(
+                f"route {route_name!r} has malformed signature_mode"
+            )
+
+        provider_declared = bool(provider_raw or signature_raw)
+        if not provider_declared:
+            raise WebhookContractError(
+                f"route {route_name!r} requires an explicit provider or signature_mode"
+            )
+        if provider_raw:
+            provider = canonical_provider(provider_raw)
+        elif signature_raw:
+            canonical_mode = canonical_signature_mode(signature_raw)
+            provider = _SIGNATURE_MODE_TO_PROVIDER[canonical_mode]
+        else:  # pragma: no cover - guarded by provider_declared above
+            raise WebhookContractError("unreachable provider binding")
+
+        spec = PROVIDER_REGISTRY[provider]
+        if signature_raw:
+            signature_mode = canonical_signature_mode(signature_raw)
+            if signature_mode not in spec.signature_modes:
+                raise WebhookContractError(
+                    f"route {route_name!r} provider {provider!r} does not allow "
+                    f"signature mode {signature_mode!r}"
+                )
+        else:
+            # Some legacy configs put a verifier alias in ``provider`` (most
+            # importantly ``generic_v1``). Preserve that declared strength
+            # instead of silently replacing it with the provider default.
+            provider_mode = (
+                _SIGNATURE_MODE_ALIASES.get(_normalize_token(provider_raw))
+                if provider_raw
+                else None
+            )
+            if provider_mode in spec.signature_modes:
+                signature_mode = provider_mode
+            elif spec.default_signature_mode:
+                signature_mode = spec.default_signature_mode
+            else:
+                raise WebhookContractError(
+                    f"route {route_name!r} provider {provider!r} requires an "
+                    "explicit signature_mode"
+                )
+
+        enabled_raw = route.get("enabled", True)
+        if not isinstance(enabled_raw, bool):
+            raise WebhookContractError(
+                f"route {route_name!r} enabled must be a boolean"
+            )
+
+        if "events" not in route:
+            events: tuple[str, ...] = ()
+        else:
+            events_raw = route.get("events")
+            if not isinstance(events_raw, (list, tuple)):
+                raise WebhookContractError(
+                    f"route {route_name!r} events must be a sequence"
+                )
+            normalized_events: list[str] = []
+            for item in events_raw:
+                if not isinstance(item, str) or not item.strip():
+                    raise WebhookContractError(
+                        f"route {route_name!r} events must contain non-empty strings"
+                    )
+                value = item.strip()
+                try:
+                    encoded_event = value.encode("utf-8")
+                except UnicodeEncodeError as exc:
+                    raise WebhookContractError(
+                        f"route {route_name!r} event is not valid Unicode"
+                    ) from exc
+                if len(encoded_event) > MAX_EVENT_TYPE_UTF8_BYTES:
+                    raise WebhookContractError(
+                        f"route {route_name!r} event exceeds "
+                        f"{MAX_EVENT_TYPE_UTF8_BYTES} UTF-8 bytes"
+                    )
+                if value not in normalized_events:
+                    normalized_events.append(value)
+            events = tuple(normalized_events)
+        if spec.route_bound_event_authority and len(events) > 1:
+            raise WebhookContractError(
+                f"route {route_name!r} provider {provider!r} uses an unsigned "
+                "event header and therefore permits at most one route-bound event"
+            )
+        if provider == "github" and events:
+            unsupported = [
+                event for event in events if event not in GITHUB_AUTHENTICATED_EVENTS
+            ]
+            if unsupported:
+                supported = ", ".join(sorted(GITHUB_AUTHENTICATED_EVENTS))
+                raise WebhookContractError(
+                    f"route {route_name!r} provider 'github' cannot authenticate "
+                    f"event body shape for {unsupported[0]!r}; supported events: "
+                    f"{supported}"
+                )
+
+        return cls(
+            name=route_name,
+            profile=configured_profile,
+            provider=provider,
+            provider_declared=provider_declared,
+            signature_mode=signature_mode,
+            enabled=enabled_raw,
+            events=events,
+        )
+
+    @property
+    def provider_spec(self) -> WebhookProviderSpec:
+        return PROVIDER_REGISTRY[self.provider]
+
+
+@dataclass(frozen=True)
+class WebhookDeliveryIdentity:
+    provider: str
+    value: str
+
+    @property
+    def namespaced(self) -> str:
+        return f"{self.provider}:{self.value}"
+
+
+class WebhookReplayIdentityKind(str, Enum):
+    """Provenance of the value used to fence repeated execution."""
+
+    AUTHENTICATED_DELIVERY = "authenticated_delivery"
+    AUTHENTICATED_TIMESTAMP_BODY_SHA256 = "authenticated_timestamp_body_sha256"
+    AUTHENTICATED_BODY_SHA256 = "authenticated_body_sha256"
+    CREDENTIAL_OBSERVED_BODY_SHA256 = "credential_observed_body_sha256"
+    LOCAL_BYPASS_BODY_SHA256 = "local_bypass_body_sha256"
+
+
+@dataclass(frozen=True)
+class WebhookReplayIdentity:
+    """Durable replay key, distinct from provider delivery diagnostics."""
+
+    provider: str
+    kind: WebhookReplayIdentityKind
+    value: str
+
+    @property
+    def storage_key(self) -> str:
+        if self.kind is WebhookReplayIdentityKind.AUTHENTICATED_DELIVERY:
+            # Provider IDs may be attacker-controlled HTTP/payload strings.
+            # Persist only a fixed-width collision-resistant projection while
+            # retaining the verified raw value in ``delivery_identity`` for
+            # provider-facing diagnostics.
+            digest = hashlib.sha256(self.value.encode("utf-8")).hexdigest()
+            return f"{self.kind.value}_sha256:{digest}"
+        return f"{self.kind.value}:{self.value}"
+
+    @property
+    def namespaced(self) -> str:
+        return f"{self.provider}:{self.storage_key}"
+
+
+def resolve_delivery_identity(
+    route: WebhookRouteConfig,
+    verified_headers: Mapping[str, Any],
+    payload: Mapping[str, Any],
+    *,
+    observed_headers: Optional[Mapping[str, Any]] = None,
+    allow_authenticated_payload: bool = True,
+) -> Optional[WebhookDeliveryIdentity]:
+    """Return only a provider-native identity authenticated by the verifier."""
+
+    spec = route.provider_spec
+    transport_headers = observed_headers or verified_headers
+    if allow_authenticated_payload and spec.authenticated_delivery_id_payload_keys:
+        payload_identity = next(
+            (
+                candidate
+                for key in spec.authenticated_delivery_id_payload_keys
+                if (candidate := _nonempty_scalar(payload.get(key))) is not None
+            ),
+            None,
+        )
+        header_identity = next(
+            (
+                candidate
+                for header_name in spec.delivery_id_headers
+                if (
+                    candidate := _nonempty_scalar(
+                        _header(transport_headers, header_name)
+                    )
+                )
+                is not None
+            ),
+            None,
+        )
+        if payload_identity is None or header_identity != payload_identity:
+            raise WebhookContractError(
+                f"provider {route.provider!r} delivery metadata does not match "
+                "the authenticated payload"
+            )
+        return WebhookDeliveryIdentity(route.provider, payload_identity)
+
+    for header_name in spec.authenticated_delivery_id_headers:
+        candidate = _nonempty_scalar(_header(verified_headers, header_name))
+        if candidate is not None:
+            return WebhookDeliveryIdentity(route.provider, candidate)
+
+    if allow_authenticated_payload and route.provider_declared:
+        for key in spec.payload_delivery_id_keys:
+            candidate = _nonempty_scalar(payload.get(key))
+            if candidate is not None:
+                return WebhookDeliveryIdentity(route.provider, candidate)
+    return None
+
+
+def resolve_event_type(
+    route: WebhookRouteConfig,
+    verified_headers: Mapping[str, Any],
+    payload: Mapping[str, Any],
+    *,
+    observed_headers: Optional[Mapping[str, Any]] = None,
+) -> str:
+    """Resolve event authority without promoting an unsigned provider header."""
+
+    def authenticated_event(value: str) -> str:
+        try:
+            encoded = value.encode("utf-8")
+        except UnicodeEncodeError as exc:
+            raise WebhookPayloadContractError(
+                "authenticated webhook event type is not valid Unicode"
+            ) from exc
+        if len(encoded) > MAX_EVENT_TYPE_UTF8_BYTES:
+            raise WebhookPayloadContractError(
+                "authenticated webhook event type exceeds "
+                f"{MAX_EVENT_TYPE_UTF8_BYTES} UTF-8 bytes"
+            )
+        return value
+
+    spec = route.provider_spec
+    transport_headers = observed_headers or verified_headers
+    if spec.route_bound_event_authority:
+        if not route.events:
+            return "unknown"
+        event_authority = route.events[0]
+        observed_event = next(
+            (
+                candidate
+                for header_name in spec.event_headers
+                if (
+                    candidate := _nonempty_scalar(
+                        _header(transport_headers, header_name)
+                    )
+                )
+                is not None
+            ),
+            None,
+        )
+        if observed_event is None:
+            raise WebhookContractError(
+                f"provider {route.provider!r} is missing the route-bound "
+                "event metadata header"
+            )
+        if observed_event != event_authority:
+            raise WebhookContractError(
+                f"provider {route.provider!r} observed event metadata does not "
+                "match the route-bound event authority"
+            )
+        return event_authority
+
+    if spec.authenticated_event_payload_keys:
+        payload_event = next(
+            (
+                candidate
+                for key in spec.authenticated_event_payload_keys
+                if (candidate := _nonempty_scalar(payload.get(key))) is not None
+            ),
+            None,
+        )
+        header_event = next(
+            (
+                candidate
+                for header_name in spec.event_headers
+                if (
+                    candidate := _nonempty_scalar(
+                        _header(transport_headers, header_name)
+                    )
+                )
+                is not None
+            ),
+            None,
+        )
+        if payload_event is None or header_event != payload_event:
+            raise WebhookContractError(
+                f"provider {route.provider!r} event metadata does not match "
+                "the authenticated payload"
+            )
+        return authenticated_event(payload_event)
+
+    for key in (*spec.payload_event_keys, "event_type", "type"):
+        value = _nonempty_scalar(payload.get(key))
+        if value is not None:
+            return authenticated_event(value)
+    return "unknown"
+
+
+def validate_authenticated_event_body(
+    route: WebhookRouteConfig,
+    event_type: str,
+    payload: Mapping[str, Any],
+) -> None:
+    """Require body-authenticated GitHub payloads to prove their event class.
+
+    GitHub's HMAC covers the raw request body, not ``X-GitHub-Event``. A
+    route/header equality check alone would therefore let a captured signed
+    ping or neighboring pull-request event be relabeled for a configured
+    ``pull_request`` route. Only explicitly registered, conservative body
+    shapes can supply route-bound GitHub event authority.
+    """
+
+    if route.provider != "github" or event_type == "unknown":
+        return
+    matches = tuple(
+        candidate
+        for candidate, classifier in _GITHUB_EVENT_BODY_CLASSIFIERS.items()
+        if classifier(payload)
+    )
+    if matches != (event_type,):
+        raise WebhookContractError(
+            "provider 'github' authenticated payload shape does not match "
+            f"route-bound event {event_type!r}"
+        )
+
+
+def _resolve_observed_delivery_id(
+    route: WebhookRouteConfig,
+    observed_headers: Mapping[str, Any],
+) -> Optional[str]:
+    """Return an untrusted provider transport ID for diagnostics only."""
+
+    return next(
+        (
+            candidate
+            for header_name in route.provider_spec.delivery_id_headers
+            if (candidate := _nonempty_scalar(_header(observed_headers, header_name)))
+            is not None
+        ),
+        None,
+    )
+
+
+def _resolve_observed_event_type(
+    route: WebhookRouteConfig,
+    observed_headers: Mapping[str, Any],
+    payload: Mapping[str, Any],
+) -> Optional[str]:
+    """Return provider event metadata without granting it dispatch authority."""
+
+    spec = route.provider_spec
+    header_event = next(
+        (
+            candidate
+            for header_name in spec.event_headers
+            if (candidate := _nonempty_scalar(_header(observed_headers, header_name)))
+            is not None
+        ),
+        None,
+    )
+    if header_event is not None:
+        return header_event
+    return next(
+        (
+            candidate
+            for key in (*spec.payload_event_keys, "event_type", "type")
+            if (candidate := _nonempty_scalar(payload.get(key))) is not None
+        ),
+        None,
+    )
+
+
+def validate_payload_replay_policy(
+    route: WebhookRouteConfig,
+    payload: Mapping[str, Any],
+    *,
+    received_at: Optional[float] = None,
+) -> None:
+    """Enforce provider-declared freshness over authenticated body metadata."""
+
+    spec = route.provider_spec
+    tolerance = spec.payload_replay_tolerance_seconds
+    if tolerance is None:
+        return
+    timestamp = next(
+        (
+            candidate
+            for key in spec.authenticated_timestamp_payload_keys
+            if (candidate := _nonempty_scalar(payload.get(key))) is not None
+        ),
+        None,
+    )
+    if timestamp is None:
+        raise WebhookContractError(
+            f"provider {route.provider!r} payload is missing authenticated timestamp"
+        )
+    try:
+        parsed = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            raise ValueError("timezone is required")
+        timestamp_seconds = parsed.timestamp()
+    except (OverflowError, ValueError):
+        raise WebhookContractError(
+            f"provider {route.provider!r} payload has malformed authenticated timestamp"
+        ) from None
+    now = time.time() if received_at is None else float(received_at)
+    if not math.isfinite(now):
+        raise WebhookContractError("received_at must be a finite timestamp")
+    if abs(now - timestamp_seconds) > tolerance:
+        raise WebhookContractError(
+            f"provider {route.provider!r} authenticated timestamp is outside replay window"
+        )
+
+
+def _parse_authenticated_payload(raw_body: bytes, media_type: str) -> dict[str, Any]:
+    """Reconstruct the payload from the exact bytes covered by authentication."""
+
+    normalized_media_type = str(media_type or "").split(";", 1)[0].strip().lower()
+    if normalized_media_type == "application/json" or normalized_media_type.endswith(
+        "+json"
+    ):
+
+        def reject_duplicate_keys(
+            pairs: list[tuple[str, Any]],
+        ) -> dict[str, Any]:
+            decoded: dict[str, Any] = {}
+            for key, item in pairs:
+                if key in decoded:
+                    raise ValueError(f"duplicate JSON key {key!r}")
+                decoded[key] = item
+            return decoded
+
+        try:
+            value = json.loads(
+                bytes(raw_body),
+                parse_constant=lambda constant: (_ for _ in ()).throw(
+                    ValueError(f"non-finite JSON number {constant}")
+                ),
+                object_pairs_hook=reject_duplicate_keys,
+            )
+        except (
+            json.JSONDecodeError,
+            UnicodeDecodeError,
+            ValueError,
+            RecursionError,
+        ) as exc:
+            raise WebhookContractError(
+                "authenticated JSON body cannot be parsed"
+            ) from exc
+        if not isinstance(value, dict):
+            raise WebhookContractError("authenticated webhook body must be an object")
+        stack: list[tuple[Any, int]] = [(value, 1)]
+        while stack:
+            item, depth = stack.pop()
+            if depth > MAX_AUTHENTICATED_JSON_NESTING:
+                raise WebhookPayloadContractError(
+                    "authenticated webhook JSON nesting is too deep"
+                )
+            if isinstance(item, str):
+                try:
+                    item.encode("utf-8")
+                except UnicodeEncodeError as exc:
+                    raise WebhookPayloadContractError(
+                        "authenticated webhook JSON contains invalid Unicode"
+                    ) from exc
+            elif isinstance(item, Mapping):
+                stack.extend((key, depth) for key in item.keys())
+                stack.extend((child, depth + 1) for child in item.values())
+            elif isinstance(item, (list, tuple)):
+                stack.extend((child, depth + 1) for child in item)
+            elif isinstance(item, float) and not math.isfinite(item):
+                # ``json.loads`` routes the non-standard NaN/Infinity tokens
+                # through ``parse_constant``, but an otherwise-valid JSON
+                # exponent such as ``1e9999`` overflows directly to infinity.
+                # Reject both forms before authenticated values reach policy,
+                # rendering, or the durable ledger.
+                raise WebhookPayloadContractError(
+                    "authenticated webhook JSON contains a non-finite number"
+                )
+        return value
+    raise WebhookContractError(
+        "authenticated webhook media type must use JSON semantics"
+    )
+
+
+def _freeze_json(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return MappingProxyType({
+            str(key): _freeze_json(item) for key, item in value.items()
+        })
+    if isinstance(value, (list, tuple)):
+        return tuple(_freeze_json(item) for item in value)
+    return value
+
+
+def _thaw_json(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {str(key): _thaw_json(item) for key, item in value.items()}
+    if isinstance(value, tuple):
+        return [_thaw_json(item) for item in value]
+    return value
+
+
+@dataclass(frozen=True)
+class WebhookAuthProvenance:
+    provider: str
+    signature_mode: str
+    coverage: str
+    provider_declared: bool
+    verified: bool
+    bypass: Optional[str] = None
+
+    @property
+    def compatibility_inferred(self) -> bool:
+        return not self.provider_declared
+
+
+@dataclass(frozen=True, init=False)
+class WebhookEnvelope:
+    """Immutable domain object handed across the HTTP intake boundary."""
+
+    route: WebhookRouteConfig
+    authority_profile: str
+    auth: WebhookAuthProvenance
+    event_type: str
+    delivery_identity: Optional[WebhookDeliveryIdentity]
+    replay_identity: WebhookReplayIdentity
+    observed_delivery_id: Optional[str]
+    observed_event_type: Optional[str]
+    trace_id: str
+    body_sha256: str
+    payload: Mapping[str, Any]
+
+    @classmethod
+    def from_receipt(
+        cls,
+        receipt: Any,
+        *,
+        raw_body: bytes,
+        media_type: str,
+        trace_id: Optional[str] = None,
+        authority_profile: Optional[str] = None,
+    ) -> "WebhookEnvelope":
+        from gateway.platforms.webhook_auth import (
+            WebhookLocalBypassReceipt,
+            WebhookSignatureVerificationReceipt,
+            WebhookVerificationCoverage,
+        )
+
+        if not isinstance(
+            receipt,
+            (WebhookSignatureVerificationReceipt, WebhookLocalBypassReceipt),
+        ):
+            raise WebhookContractError(
+                "webhook envelope requires an exact verification receipt"
+            )
+        if not isinstance(raw_body, (bytes, bytearray)):
+            raise WebhookContractError("raw_body must be bytes")
+        body_hash = hashlib.sha256(bytes(raw_body)).hexdigest()
+        if body_hash != receipt.body_sha256:
+            raise WebhookContractError(
+                "verification receipt does not cover the supplied raw body"
+            )
+
+        authenticated_payload = _parse_authenticated_payload(
+            bytes(raw_body), media_type
+        )
+        route = receipt.route
+        physical_profile = (
+            route.profile if authority_profile is None else authority_profile
+        )
+        if not isinstance(physical_profile, str) or not _PROFILE_NAME_RE.fullmatch(
+            physical_profile
+        ):
+            raise WebhookContractError("webhook authority profile must be canonical")
+        verified_headers = receipt.verified_headers
+        observed_headers = receipt.observed_headers
+        transport_headers = dict(observed_headers)
+        transport_headers.update(verified_headers)
+        validate_payload_replay_policy(
+            route,
+            authenticated_payload,
+            received_at=receipt.verified_at,
+        )
+        body_authenticated = receipt.coverage in {
+            WebhookVerificationCoverage.BODY_MAC,
+            WebhookVerificationCoverage.TIMESTAMP_BODY_MAC,
+            WebhookVerificationCoverage.ID_TIMESTAMP_BODY_MAC,
+        }
+        delivery_identity = resolve_delivery_identity(
+            route,
+            verified_headers,
+            authenticated_payload,
+            observed_headers=observed_headers,
+            allow_authenticated_payload=body_authenticated,
+        )
+        event_type = resolve_event_type(
+            route,
+            verified_headers,
+            authenticated_payload,
+            observed_headers=observed_headers,
+        )
+        if body_authenticated:
+            validate_authenticated_event_body(
+                route,
+                event_type,
+                authenticated_payload,
+            )
+        observed_delivery_id = _resolve_observed_delivery_id(
+            route,
+            transport_headers,
+        )
+        observed_event_type = _resolve_observed_event_type(
+            route,
+            transport_headers,
+            authenticated_payload,
+        )
+        if delivery_identity is not None:
+            replay_identity = WebhookReplayIdentity(
+                provider=route.provider,
+                kind=WebhookReplayIdentityKind.AUTHENTICATED_DELIVERY,
+                value=delivery_identity.value,
+            )
+        elif (
+            body_authenticated
+            and receipt.coverage is WebhookVerificationCoverage.TIMESTAMP_BODY_MAC
+            and receipt.signed_timestamp
+        ):
+            timestamp_body_digest = hashlib.sha256(
+                receipt.signed_timestamp.encode("utf-8")
+                + b"."
+                + body_hash.encode("ascii")
+            ).hexdigest()
+            replay_identity = WebhookReplayIdentity(
+                provider=route.provider,
+                kind=(WebhookReplayIdentityKind.AUTHENTICATED_TIMESTAMP_BODY_SHA256),
+                value=timestamp_body_digest,
+            )
+        elif body_authenticated:
+            replay_identity = WebhookReplayIdentity(
+                provider=route.provider,
+                kind=WebhookReplayIdentityKind.AUTHENTICATED_BODY_SHA256,
+                value=body_hash,
+            )
+        elif receipt.coverage is WebhookVerificationCoverage.CREDENTIAL_ONLY:
+            replay_identity = WebhookReplayIdentity(
+                provider=route.provider,
+                kind=WebhookReplayIdentityKind.CREDENTIAL_OBSERVED_BODY_SHA256,
+                value=body_hash,
+            )
+        elif receipt.coverage is WebhookVerificationCoverage.LOCAL_BYPASS:
+            replay_identity = WebhookReplayIdentity(
+                provider=route.provider,
+                kind=WebhookReplayIdentityKind.LOCAL_BYPASS_BODY_SHA256,
+                value=body_hash,
+            )
+        else:  # pragma: no cover - exhaustive over the closed coverage enum
+            raise WebhookContractError("unsupported webhook verification coverage")
+        trace = _nonempty_scalar(trace_id) or uuid.uuid4().hex
+        verified = isinstance(receipt, WebhookSignatureVerificationReceipt)
+        envelope = object.__new__(cls)
+        object.__setattr__(envelope, "route", route)
+        object.__setattr__(envelope, "authority_profile", physical_profile)
+        object.__setattr__(
+            envelope,
+            "auth",
+            WebhookAuthProvenance(
+                provider=route.provider,
+                signature_mode=route.signature_mode,
+                coverage=receipt.coverage.value,
+                provider_declared=route.provider_declared,
+                verified=verified,
+                bypass=None if verified else "insecure_local_test",
+            ),
+        )
+        object.__setattr__(envelope, "event_type", event_type)
+        object.__setattr__(envelope, "delivery_identity", delivery_identity)
+        object.__setattr__(envelope, "replay_identity", replay_identity)
+        object.__setattr__(
+            envelope,
+            "observed_delivery_id",
+            observed_delivery_id,
+        )
+        object.__setattr__(
+            envelope,
+            "observed_event_type",
+            observed_event_type,
+        )
+        object.__setattr__(envelope, "trace_id", trace)
+        object.__setattr__(
+            envelope,
+            "body_sha256",
+            body_hash,
+        )
+        try:
+            frozen_payload = _freeze_json(authenticated_payload)
+        except RecursionError as exc:  # defense if the bound changes later
+            raise WebhookPayloadContractError(
+                "authenticated webhook JSON nesting is too deep"
+            ) from exc
+        object.__setattr__(envelope, "payload", frozen_payload)
+        return envelope
+
+    @property
+    def delivery_id(self) -> str:
+        """Provider delivery ID when stable, otherwise this request trace."""
+
+        if self.delivery_identity is not None:
+            return self.delivery_identity.value
+        return self.trace_id
+
+    @property
+    def replay_id(self) -> str:
+        """Storage-safe replay identity used by durable admission."""
+
+        return self.replay_identity.storage_key
+
+    @property
+    def idempotency_scope(self) -> tuple[str, str, str, str]:
+        return (
+            self.authority_profile,
+            self.route.name,
+            self.replay_identity.provider,
+            self.replay_identity.storage_key,
+        )
+
+    @property
+    def idempotency_key(self) -> str:
+        return ":".join(self.idempotency_scope)
+
+    @property
+    def session_key(self) -> str:
+        """Execution identity, deliberately distinct from provider delivery ID."""
+
+        return ":".join((
+            "webhook",
+            self.authority_profile,
+            self.route.name,
+            self.route.provider,
+            self.trace_id,
+        ))
+
+    def mutable_payload(self) -> dict[str, Any]:
+        """Return a detached projection for filters and configured transforms."""
+
+        return _thaw_json(self.payload)

--- a/gateway/platforms/webhook_delivery.py
+++ b/gateway/platforms/webhook_delivery.py
@@ -1,0 +1,487 @@
+"""Delivery responsibilities for the webhook adapter."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import shutil
+import subprocess
+import weakref
+from typing import Any, Mapping, Optional
+
+try:
+    from aiohttp import web
+except ImportError:
+    web = None  # type: ignore[assignment]
+
+from gateway.config import Platform
+from gateway.platforms.webhook_contract import (
+    WebhookContractError,
+    WebhookEnvelope,
+)
+from gateway.platforms.webhook_ledger import (
+    OperationAuthority,
+    OperationState,
+    Settlement,
+    SettlementKind,
+    TargetAttemptDisposition,
+    WebhookLedgerError,
+    WebhookLedgerTransitionError,
+)
+
+from gateway.platforms.webhook_common import (
+    WebhookTargetDeliveryDisposition,
+    WebhookTargetDeliveryResult,
+    _is_webhook_silence_response,
+    _plain_json_snapshot,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class WebhookDeliveryMixin:
+    def _source_for_envelope(self, envelope: WebhookEnvelope):
+        """Create the exact webhook source without mutable profile-route lookup."""
+
+        from gateway.session import SessionSource
+
+        source = SessionSource(
+            platform=Platform.WEBHOOK,
+            chat_id=envelope.session_key,
+            chat_name=f"webhook/{envelope.route.name}",
+            chat_type="webhook",
+            user_id=f"webhook:{envelope.route.name}",
+            user_name=envelope.route.name,
+            profile=envelope.authority_profile,
+        )
+        source._transport_adapter_ref = weakref.ref(self)
+        return source
+
+    def _stage_exact_delivery(
+        self,
+        authority: OperationAuthority,
+        content: str,
+        carrier_snapshot: Mapping[str, Any],
+    ) -> OperationAuthority:
+        """Stage once, rejecting every later widening or content substitution."""
+
+        current = self._operation_ledger.lookup_session(authority.session_key)
+        if current is None:
+            raise WebhookLedgerTransitionError("webhook operation no longer exists")
+        if current.delivery is not None:
+            exact_carrier = _plain_json_snapshot(current.delivery.carrier)
+            requested_carrier = _plain_json_snapshot(carrier_snapshot)
+            if (
+                current.delivery.content != content
+                or exact_carrier != requested_carrier
+            ):
+                if current.state is not OperationState.SETTLED:
+                    self._operation_ledger.mark_indeterminate(
+                        current,
+                        "multiple final webhook contents attempted for one target",
+                    )
+                raise WebhookLedgerTransitionError(
+                    "webhook target already owns different final content"
+                )
+            return current
+        return self._operation_ledger.stage_delivery(
+            current,
+            content=content,
+            carrier_snapshot=carrier_snapshot,
+        )
+
+    def _settle_attempt_result(
+        self,
+        attempt: Any,
+        settlement: Settlement,
+        success_disposition: WebhookTargetDeliveryDisposition,
+    ) -> WebhookTargetDeliveryResult:
+        def preserve_unknown(reason: str) -> None:
+            try:
+                self._operation_ledger.settle_target(
+                    attempt,
+                    Settlement(SettlementKind.INDETERMINATE, error=reason),
+                )
+            except Exception:
+                logger.exception(
+                    "[webhook] Could not preserve failed target settlement"
+                )
+
+        try:
+            committed = self._operation_ledger.settle_target(attempt, settlement)
+        except BaseException as exc:
+            logger.exception("[webhook] Target settlement commit failed")
+            preserve_unknown(f"durable target settlement failed: {exc}")
+            self._fence_intake_for_durable_transition_failure(
+                "target settlement transition failure"
+            )
+            if not isinstance(exc, Exception):
+                raise
+            return WebhookTargetDeliveryResult(
+                WebhookTargetDeliveryDisposition.INDETERMINATE,
+                error=f"durable target settlement failed: {exc}",
+            )
+        if not committed:
+            preserve_unknown("durable target settlement fence was lost")
+            self._fence_intake_for_durable_transition_failure(
+                "target settlement authority loss"
+            )
+            return WebhookTargetDeliveryResult(
+                WebhookTargetDeliveryDisposition.INDETERMINATE,
+                error="durable target settlement fence was lost",
+            )
+        return WebhookTargetDeliveryResult(
+            success_disposition,
+            message_id=settlement.external_id,
+            error=settlement.error,
+        )
+
+    def _prepare_github_invocation(
+        self,
+        authority: OperationAuthority,
+    ) -> tuple[Optional[str], Optional[dict[str, str]], Optional[str]]:
+        """Resolve one profile-scoped GitHub executable and minimal environment."""
+
+        source = self._source_from_authority(authority)
+        with self._profile_runtime_context(source):
+            executable = shutil.which("gh")
+            if not executable:
+                return None, None, "gh CLI is unavailable"
+            try:
+                from agent.secret_scope import get_secret, is_multiplex_active
+                from tools.environments.local import build_subprocess_env
+
+                env = build_subprocess_env()
+                token = get_secret("GH_TOKEN") or get_secret("GITHUB_TOKEN")
+                if is_multiplex_active() and not token:
+                    return (
+                        None,
+                        None,
+                        "multiplexed GitHub delivery requires a profile-scoped token",
+                    )
+                if token:
+                    env["GH_TOKEN"] = token
+                env["GH_PROMPT_DISABLED"] = "1"
+                env["GH_NO_UPDATE_NOTIFIER"] = "1"
+            except Exception as exc:
+                return None, None, f"GitHub delivery environment failed: {exc}"
+        return executable, env, None
+
+    @staticmethod
+    def _run_github_comment(
+        executable: str,
+        target: Mapping[str, Any],
+        content: str,
+        env: Mapping[str, str],
+    ) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [
+                executable,
+                "pr",
+                "comment",
+                str(target["pr_number"]),
+                "--repo",
+                str(target["repo"]),
+                "--body",
+                content,
+            ],
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=30,
+            env=dict(env),
+            check=False,
+        )
+
+    async def _invoke_staged_target(
+        self,
+        authority: OperationAuthority,
+    ) -> WebhookTargetDeliveryResult:
+        """Consume the exact durable target/content through one mutation gate."""
+
+        try:
+            current = self._operation_ledger.lookup_session(authority.session_key)
+            if current is None or current.delivery is None:
+                raise WebhookLedgerTransitionError(
+                    "webhook delivery carrier is not durably staged"
+                )
+            target = self._validate_target_snapshot(current.target_snapshot)
+            if target["profile"] != current.profile:
+                raise WebhookContractError(
+                    "durable target profile conflicts with operation authority"
+                )
+        except (WebhookContractError, WebhookLedgerError) as exc:
+            logger.error("[webhook] Refusing invalid durable target: %s", exc)
+            self._mark_indeterminate_or_fence(
+                authority,
+                exc,
+                context="invalid durable target",
+            )
+            return WebhookTargetDeliveryResult(
+                WebhookTargetDeliveryDisposition.INDETERMINATE,
+                error=str(exc),
+            )
+
+        suppress = target["kind"] == "log" or _is_webhook_silence_response(
+            current.delivery.content
+        )
+        adapter = None
+        executable = None
+        github_env = None
+        pre_effect_error = None
+        if not suppress and target["kind"] == "platform":
+            adapter = self._resolve_target_adapter(
+                target["platform"], target["profile"]
+            )
+            if adapter is None:
+                pre_effect_error = (
+                    f"platform {target['platform']!r} is not connected for "
+                    f"profile {target['profile']!r}"
+                )
+            elif target[
+                "platform"
+            ] == Platform.SLACK.value and not self._live_slack_scope_matches(
+                target, adapter
+            ):
+                pre_effect_error = "Slack target workspace authority is unavailable"
+        elif not suppress and target["kind"] == "github_comment":
+            executable, github_env, pre_effect_error = self._prepare_github_invocation(
+                current
+            )
+
+        try:
+            generation_is_current = await asyncio.to_thread(
+                self._recovery_profile_generation_is_current,
+                current,
+            )
+        except asyncio.CancelledError:
+            self._mark_indeterminate_or_fence(
+                current,
+                "webhook target generation check was cancelled",
+                context="target generation-check cancellation",
+            )
+            raise
+        except BaseException as exc:
+            self._mark_indeterminate_or_fence(
+                current,
+                exc,
+                context="target generation-check failure",
+            )
+            if not isinstance(exc, Exception):
+                raise
+            return WebhookTargetDeliveryResult(
+                WebhookTargetDeliveryDisposition.INDETERMINATE,
+                error="webhook profile authority could not be checked",
+            )
+        if not generation_is_current:
+            self._mark_indeterminate_or_fence(
+                current,
+                "webhook profile incarnation changed before target attempt",
+                context="target profile generation mismatch",
+            )
+            return WebhookTargetDeliveryResult(
+                WebhookTargetDeliveryDisposition.INDETERMINATE,
+                error="webhook profile authority changed before delivery",
+            )
+
+        try:
+            attempt = self._operation_ledger.begin_target(current)
+        except BaseException as exc:
+            self._fence_intake_for_durable_transition_failure(
+                "target-attempt transition failure"
+            )
+            if not isinstance(exc, Exception):
+                raise
+            return WebhookTargetDeliveryResult(
+                WebhookTargetDeliveryDisposition.INDETERMINATE,
+                error=f"target mutation gate failed: {exc}",
+            )
+        if attempt.disposition is TargetAttemptDisposition.CACHED:
+            return WebhookTargetDeliveryResult(WebhookTargetDeliveryDisposition.CACHED)
+        if attempt.disposition is TargetAttemptDisposition.IN_PROGRESS:
+            return WebhookTargetDeliveryResult(
+                WebhookTargetDeliveryDisposition.IN_PROGRESS,
+                error="webhook target attempt is already in progress",
+            )
+        if attempt.disposition is TargetAttemptDisposition.INDETERMINATE:
+            return WebhookTargetDeliveryResult(
+                WebhookTargetDeliveryDisposition.INDETERMINATE,
+                error="webhook target outcome requires reconciliation",
+            )
+        if attempt.delivery is None:
+            return self._settle_attempt_result(
+                attempt,
+                Settlement(
+                    SettlementKind.INDETERMINATE,
+                    error="target gate returned no durable delivery",
+                ),
+                WebhookTargetDeliveryDisposition.INDETERMINATE,
+            )
+        if pre_effect_error:
+            return self._settle_attempt_result(
+                attempt,
+                Settlement(
+                    SettlementKind.PRE_EFFECT_FAILED,
+                    error=pre_effect_error,
+                ),
+                WebhookTargetDeliveryDisposition.PRE_EFFECT_FAILED,
+            )
+        if suppress:
+            if target["kind"] == "log":
+                logger.info(
+                    "[webhook] Response for %s: %s",
+                    current.session_key,
+                    attempt.delivery.content[:200],
+                )
+            return self._settle_attempt_result(
+                attempt,
+                Settlement(SettlementKind.SUPPRESSED),
+                WebhookTargetDeliveryDisposition.SUPPRESSED,
+            )
+
+        if target["kind"] == "platform":
+            metadata: dict[str, str] = {}
+            if target.get("thread_id"):
+                metadata["thread_id"] = target["thread_id"]
+            if target.get("scope_id"):
+                metadata["scope_id"] = target["scope_id"]
+            try:
+                source = self._source_from_authority(current)
+                with self._profile_runtime_context(source):
+                    send_result = await adapter.send(
+                        target["chat_id"],
+                        attempt.delivery.content,
+                        metadata=metadata or None,
+                    )
+            except asyncio.CancelledError:
+                self._settle_attempt_result(
+                    attempt,
+                    Settlement(
+                        SettlementKind.INDETERMINATE,
+                        error="platform delivery was cancelled after invocation",
+                    ),
+                    WebhookTargetDeliveryDisposition.INDETERMINATE,
+                )
+                raise
+            except BaseException as exc:
+                result = self._settle_attempt_result(
+                    attempt,
+                    Settlement(SettlementKind.INDETERMINATE, error=str(exc)),
+                    WebhookTargetDeliveryDisposition.INDETERMINATE,
+                )
+                if not isinstance(exc, Exception):
+                    raise
+                return result
+            if getattr(send_result, "success", None) is True:
+                message_id = getattr(send_result, "message_id", None)
+                return self._settle_attempt_result(
+                    attempt,
+                    Settlement(
+                        SettlementKind.CONFIRMED,
+                        external_id=str(message_id) if message_id else None,
+                    ),
+                    WebhookTargetDeliveryDisposition.CONFIRMED,
+                )
+            return self._settle_attempt_result(
+                attempt,
+                Settlement(
+                    SettlementKind.INDETERMINATE,
+                    error=str(getattr(send_result, "error", None) or "send rejected"),
+                ),
+                WebhookTargetDeliveryDisposition.INDETERMINATE,
+            )
+
+        try:
+            completed = await asyncio.to_thread(
+                self._run_github_comment,
+                executable,
+                target,
+                attempt.delivery.content,
+                github_env,
+            )
+        except asyncio.CancelledError:
+            self._settle_attempt_result(
+                attempt,
+                Settlement(
+                    SettlementKind.INDETERMINATE,
+                    error="GitHub delivery was cancelled after invocation",
+                ),
+                WebhookTargetDeliveryDisposition.INDETERMINATE,
+            )
+            raise
+        except FileNotFoundError as exc:
+            return self._settle_attempt_result(
+                attempt,
+                Settlement(SettlementKind.PRE_EFFECT_FAILED, error=str(exc)),
+                WebhookTargetDeliveryDisposition.PRE_EFFECT_FAILED,
+            )
+        except BaseException as exc:
+            result = self._settle_attempt_result(
+                attempt,
+                Settlement(SettlementKind.INDETERMINATE, error=str(exc)),
+                WebhookTargetDeliveryDisposition.INDETERMINATE,
+            )
+            if not isinstance(exc, Exception):
+                raise
+            return result
+        if completed.returncode == 0:
+            return self._settle_attempt_result(
+                attempt,
+                Settlement(SettlementKind.CONFIRMED),
+                WebhookTargetDeliveryDisposition.CONFIRMED,
+            )
+        return self._settle_attempt_result(
+            attempt,
+            Settlement(
+                SettlementKind.INDETERMINATE,
+                error=f"gh exited with status {completed.returncode}",
+            ),
+            WebhookTargetDeliveryDisposition.INDETERMINATE,
+        )
+
+    @staticmethod
+    def _target_http_response(
+        result: WebhookTargetDeliveryResult,
+        *,
+        route: str,
+        delivery_id: str,
+        target_kind: Optional[str] = None,
+    ):
+        payload: dict[str, Any] = {
+            "route": route,
+            "delivery_id": delivery_id,
+            "settlement": result.disposition.value,
+        }
+        if target_kind:
+            payload["target"] = target_kind
+        if result.success:
+            payload["status"] = (
+                "suppressed"
+                if result.disposition is WebhookTargetDeliveryDisposition.SUPPRESSED
+                else "delivered"
+            )
+            return web.json_response(payload, status=200)
+        if result.disposition is WebhookTargetDeliveryDisposition.PRE_EFFECT_FAILED:
+            payload.update({
+                "status": "unavailable",
+                "error": "Webhook target is unavailable",
+            })
+            return web.json_response(
+                payload,
+                status=503,
+                headers={"Retry-After": "5"},
+            )
+        if result.disposition is WebhookTargetDeliveryDisposition.IN_PROGRESS:
+            payload["status"] = "in_progress"
+            return web.json_response(payload, status=202)
+        payload.update({
+            "status": "indeterminate",
+            "error": "Webhook target outcome requires reconciliation",
+        })
+        return web.json_response(payload, status=502)
+
+    # ------------------------------------------------------------------
+    # HTTP handlers
+    # ------------------------------------------------------------------

--- a/gateway/platforms/webhook_executions.py
+++ b/gateway/platforms/webhook_executions.py
@@ -1,0 +1,843 @@
+"""Authenticated execution control projected from the webhook operation ledger.
+
+The operation ledger remains the only owner of webhook lifecycle state.  This
+module adds a small, operation-owned capability record to the *same* SQLite
+database and projects status by joining that record back to
+``webhook_operations``/``webhook_targets``.  It deliberately does not maintain
+an independent accepted/running/completed state machine.
+
+Cancellation is also a request, not a claimed outcome.  A caller can durably
+request cancellation for one exact operation generation; the runtime must
+observe that request and perform the existing ledger-owned transition.  Once a
+target attempt has started, cancellation is too late and this module never
+pretends otherwise.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+import hashlib
+import hmac
+import math
+import secrets
+import sqlite3
+import time
+from typing import Any, Optional
+
+from gateway.platforms.webhook_ledger import (
+    OperationAuthority,
+    OperationState,
+    TargetState,
+    WebhookLedgerCorruptionError,
+    WebhookLedgerError,
+    WebhookOperationLedger,
+)
+
+
+_SCHEMA_NAME = "webhook_execution_projection"
+_SCHEMA_VERSION = 1
+_CAPABILITY_TABLE = "webhook_execution_capabilities"
+_META_TABLE = "webhook_execution_projection_meta"
+
+DEFAULT_CAPABILITY_TTL_SECONDS = 60 * 60
+MINIMUM_CAPABILITY_TTL_SECONDS = 60
+MAXIMUM_CAPABILITY_TTL_SECONDS = 30 * 24 * 60 * 60
+DEFAULT_AUTH_WINDOW_SECONDS = 60
+DEFAULT_AUTH_MAX_ATTEMPTS = 60
+MAXIMUM_AUTH_MAX_ATTEMPTS = 10_000
+MAXIMUM_PRUNE_BATCH = 128
+
+
+class ExecutionPhase(str, Enum):
+    """Stable public phase derived from the durable operation state."""
+
+    ACCEPTED = "accepted"
+    RUNNING = "running"
+    DELIVERY = "delivery"
+    SETTLED = "settled"
+    INDETERMINATE = "indeterminate"
+
+
+class CancellationState(str, Enum):
+    """State of the remote cancellation *request*, not the operation."""
+
+    NONE = "none"
+    REQUESTED = "requested"
+    OBSERVED = "observed"
+    STALE = "stale"
+
+
+class CancelDisposition(str, Enum):
+    """Result of an authenticated cancellation request."""
+
+    REQUESTED = "requested"
+    ALREADY_REQUESTED = "already_requested"
+    OBSERVED = "observed"
+    TOO_LATE = "too_late"
+    TERMINAL = "terminal"
+
+
+@dataclass(frozen=True)
+class IssuedExecutionCapability:
+    """One public execution handle.
+
+    ``access_token`` is returned only for the first successful issuance.  A
+    repeated call returns the existing execution ID with ``access_token=None``;
+    plaintext capability recovery is intentionally impossible.
+    """
+
+    execution_id: str
+    access_token: Optional[str]
+    created: bool
+    expires_at: float
+
+
+@dataclass(frozen=True)
+class ExecutionStatus:
+    """Redacted public projection of one operation-owned execution."""
+
+    execution_id: str
+    phase: ExecutionPhase
+    operation_state: OperationState
+    target_state: Optional[TargetState]
+    generation: int
+    cancellation: CancellationState
+    can_cancel: bool
+    effects_possible: bool
+    created_at: float
+    updated_at: float
+    settled_at: Optional[float]
+    needs_attention: bool
+
+
+@dataclass(frozen=True)
+class CancelRequestResult:
+    """Authenticated cancellation decision plus the current public status."""
+
+    disposition: CancelDisposition
+    status: ExecutionStatus
+
+
+def _finite_time(value: Any, *, label: str) -> float:
+    try:
+        result = float(value)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise WebhookLedgerCorruptionError(f"{label} is invalid") from exc
+    if not math.isfinite(result):
+        raise WebhookLedgerCorruptionError(f"{label} is invalid")
+    return result
+
+
+def _phase_for_state(state: OperationState) -> ExecutionPhase:
+    if state in {OperationState.PREPARING, OperationState.READY}:
+        return ExecutionPhase.ACCEPTED
+    if state is OperationState.RUNNING:
+        return ExecutionPhase.RUNNING
+    if state in {OperationState.DELIVERY_READY, OperationState.DELIVERING}:
+        return ExecutionPhase.DELIVERY
+    if state is OperationState.SETTLED:
+        return ExecutionPhase.SETTLED
+    return ExecutionPhase.INDETERMINATE
+
+
+def _is_cancellable(state: OperationState) -> bool:
+    return state in {
+        OperationState.PREPARING,
+        OperationState.READY,
+        OperationState.RUNNING,
+        OperationState.DELIVERY_READY,
+    }
+
+
+class WebhookExecutionProjection:
+    """Capability/status/cancel projection over ``WebhookOperationLedger``.
+
+    All reads and writes share the ledger's lock and SQLite transaction
+    boundary.  The added table contains only capability and cancellation
+    request material; operation/target state is always read from the canonical
+    ledger tables.
+    """
+
+    def __init__(
+        self,
+        ledger: WebhookOperationLedger,
+        *,
+        capability_ttl_seconds: int = DEFAULT_CAPABILITY_TTL_SECONDS,
+        auth_window_seconds: int = DEFAULT_AUTH_WINDOW_SECONDS,
+        auth_max_attempts: int = DEFAULT_AUTH_MAX_ATTEMPTS,
+    ) -> None:
+        if not isinstance(ledger, WebhookOperationLedger):
+            raise TypeError("ledger must be a WebhookOperationLedger")
+        if (
+            not isinstance(capability_ttl_seconds, int)
+            or isinstance(capability_ttl_seconds, bool)
+            or capability_ttl_seconds < MINIMUM_CAPABILITY_TTL_SECONDS
+            or capability_ttl_seconds > MAXIMUM_CAPABILITY_TTL_SECONDS
+        ):
+            raise ValueError("capability_ttl_seconds is outside the supported range")
+        if (
+            not isinstance(auth_window_seconds, int)
+            or isinstance(auth_window_seconds, bool)
+            or auth_window_seconds < 1
+        ):
+            raise ValueError("auth_window_seconds must be positive")
+        if (
+            not isinstance(auth_max_attempts, int)
+            or isinstance(auth_max_attempts, bool)
+            or auth_max_attempts < 1
+            or auth_max_attempts > MAXIMUM_AUTH_MAX_ATTEMPTS
+        ):
+            raise ValueError("auth_max_attempts is outside the supported range")
+        self.ledger = ledger
+        self.capability_ttl_seconds = capability_ttl_seconds
+        self.auth_window_seconds = auth_window_seconds
+        self.auth_max_attempts = auth_max_attempts
+        self.migrate_schema()
+
+    @staticmethod
+    def _token_hash(token: str) -> str:
+        return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+    @staticmethod
+    def _normalize_public_text(value: Any, *, label: str, maximum: int = 1024) -> str:
+        if not isinstance(value, str):
+            raise WebhookLedgerError(f"{label} must be text")
+        normalized = value.strip()
+        if not normalized or len(normalized.encode("utf-8")) > maximum:
+            raise WebhookLedgerError(f"{label} is outside the supported range")
+        return normalized
+
+    def migrate_schema(self) -> None:
+        """Install the v1 projection schema or validate an existing one.
+
+        The method is intentionally idempotent and fail-closed.  A partially
+        present or unknown-version schema is treated as corruption rather than
+        silently shadowed with a second authority table.
+        """
+
+        with self.ledger._lock, self.ledger._transaction() as conn:
+            tables = {
+                str(row["name"])
+                for row in conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table'"
+                )
+            }
+            has_capabilities = _CAPABILITY_TABLE in tables
+            has_meta = _META_TABLE in tables
+            if has_capabilities != has_meta:
+                raise WebhookLedgerCorruptionError(
+                    "webhook execution projection schema is incomplete"
+                )
+            if has_meta:
+                rows = conn.execute(
+                    f"SELECT schema_name, schema_version FROM {_META_TABLE}"
+                ).fetchall()
+                try:
+                    schema_is_current = (
+                        len(rows) == 1
+                        and rows[0]["schema_name"] == _SCHEMA_NAME
+                        and int(rows[0]["schema_version"]) == _SCHEMA_VERSION
+                    )
+                except (TypeError, ValueError, OverflowError):
+                    schema_is_current = False
+                if not schema_is_current:
+                    raise WebhookLedgerCorruptionError(
+                        "webhook execution projection schema version is unsupported"
+                    )
+
+            conn.execute(
+                f"""CREATE TABLE IF NOT EXISTS {_META_TABLE} (
+                    schema_name TEXT PRIMARY KEY CHECK (
+                        schema_name='{_SCHEMA_NAME}'
+                    ),
+                    schema_version INTEGER NOT NULL CHECK (
+                        schema_version={_SCHEMA_VERSION}
+                    )
+                )"""
+            )
+            conn.execute(
+                f"""INSERT OR IGNORE INTO {_META_TABLE}
+                    (schema_name, schema_version) VALUES (?, ?)""",
+                (_SCHEMA_NAME, _SCHEMA_VERSION),
+            )
+            conn.execute(
+                f"""CREATE TABLE IF NOT EXISTS {_CAPABILITY_TABLE} (
+                    execution_id TEXT PRIMARY KEY CHECK (
+                        length(CAST(execution_id AS BLOB)) BETWEEN 20 AND 128
+                    ),
+                    operation_id TEXT NOT NULL UNIQUE CHECK (
+                        length(CAST(operation_id AS BLOB)) BETWEEN 1 AND 1024
+                    ),
+                    issued_generation INTEGER NOT NULL CHECK (
+                        issued_generation >= 1
+                    ),
+                    token_hash TEXT NOT NULL UNIQUE CHECK (
+                        length(CAST(token_hash AS BLOB))=64
+                    ),
+                    created_at REAL NOT NULL,
+                    expires_at REAL NOT NULL CHECK (expires_at > created_at),
+                    cancel_requested_at REAL,
+                    cancel_requested_generation INTEGER CHECK (
+                        cancel_requested_generation IS NULL OR
+                        cancel_requested_generation >= 1
+                    ),
+                    cancel_observed_at REAL,
+                    auth_window_started_at REAL NOT NULL,
+                    auth_attempts INTEGER NOT NULL DEFAULT 0 CHECK (
+                        auth_attempts >= 0
+                    ),
+                    CHECK (
+                        (cancel_requested_at IS NULL AND
+                         cancel_requested_generation IS NULL AND
+                         cancel_observed_at IS NULL)
+                        OR
+                        (cancel_requested_at IS NOT NULL AND
+                         cancel_requested_generation IS NOT NULL)
+                    ),
+                    CHECK (
+                        cancel_observed_at IS NULL OR
+                        cancel_requested_at IS NOT NULL
+                    ),
+                    FOREIGN KEY(operation_id)
+                        REFERENCES webhook_operations(operation_id)
+                        ON DELETE CASCADE
+                )"""
+            )
+            conn.execute(
+                f"""CREATE INDEX IF NOT EXISTS
+                    idx_webhook_execution_capabilities_expires
+                    ON {_CAPABILITY_TABLE}(expires_at, execution_id)"""
+            )
+            conn.execute(
+                f"""CREATE TRIGGER IF NOT EXISTS
+                    trg_webhook_execution_capability_authority_immutable
+                    BEFORE UPDATE OF execution_id, operation_id,
+                        issued_generation, token_hash, created_at, expires_at
+                    ON {_CAPABILITY_TABLE}
+                    BEGIN
+                        SELECT RAISE(
+                            ABORT,
+                            'webhook_execution_capability_authority_immutable'
+                        );
+                    END"""
+            )
+            self._validate_schema(conn)
+
+    @staticmethod
+    def _validate_schema(conn: sqlite3.Connection) -> None:
+        capability_info = conn.execute(
+            f"PRAGMA table_info({_CAPABILITY_TABLE})"
+        ).fetchall()
+        expected_columns = (
+            "execution_id",
+            "operation_id",
+            "issued_generation",
+            "token_hash",
+            "created_at",
+            "expires_at",
+            "cancel_requested_at",
+            "cancel_requested_generation",
+            "cancel_observed_at",
+            "auth_window_started_at",
+            "auth_attempts",
+        )
+        if tuple(row["name"] for row in capability_info) != expected_columns:
+            raise WebhookLedgerCorruptionError(
+                "webhook execution projection schema is incompatible"
+            )
+        if [int(row["pk"]) for row in capability_info] != [1] + [0] * 10:
+            raise WebhookLedgerCorruptionError(
+                "webhook execution projection primary key is incompatible"
+            )
+        meta_info = conn.execute(f"PRAGMA table_info({_META_TABLE})").fetchall()
+        if tuple(row["name"] for row in meta_info) != (
+            "schema_name",
+            "schema_version",
+        ) or [int(row["pk"]) for row in meta_info] != [1, 0]:
+            raise WebhookLedgerCorruptionError(
+                "webhook execution projection metadata is incompatible"
+            )
+        foreign_keys = conn.execute(
+            f"PRAGMA foreign_key_list({_CAPABILITY_TABLE})"
+        ).fetchall()
+        if not any(
+            row["table"] == "webhook_operations"
+            and row["from"] == "operation_id"
+            and row["to"] == "operation_id"
+            and str(row["on_delete"]).upper() == "CASCADE"
+            for row in foreign_keys
+        ):
+            raise WebhookLedgerCorruptionError(
+                "webhook execution projection ownership constraint is unavailable"
+            )
+        indexes = {
+            row["name"]: row
+            for row in conn.execute(f"PRAGMA index_list({_CAPABILITY_TABLE})")
+        }
+        expiry = indexes.get("idx_webhook_execution_capabilities_expires")
+        if (
+            expiry is None
+            or bool(expiry["unique"])
+            or bool(expiry["partial"])
+            or tuple(
+                row["name"]
+                for row in conn.execute(
+                    "SELECT name FROM pragma_index_info(?)",
+                    ("idx_webhook_execution_capabilities_expires",),
+                )
+            )
+            != ("expires_at", "execution_id")
+        ):
+            raise WebhookLedgerCorruptionError(
+                "webhook execution expiry index is unavailable"
+            )
+        unique_columns = {
+            tuple(
+                row["name"]
+                for row in conn.execute(
+                    "SELECT name FROM pragma_index_info(?)", (name,)
+                )
+            )
+            for name, index in indexes.items()
+            if bool(index["unique"]) and not bool(index["partial"])
+        }
+        if ("operation_id",) not in unique_columns or (
+            "token_hash",
+        ) not in unique_columns:
+            raise WebhookLedgerCorruptionError(
+                "webhook execution capability uniqueness is unavailable"
+            )
+        trigger = conn.execute(
+            """SELECT tbl_name FROM sqlite_master
+                 WHERE type='trigger'
+                   AND name='trg_webhook_execution_capability_authority_immutable'"""
+        ).fetchone()
+        if trigger is None or trigger["tbl_name"] != _CAPABILITY_TABLE:
+            raise WebhookLedgerCorruptionError(
+                "webhook execution capability immutability guard is unavailable"
+            )
+
+    @staticmethod
+    def _operation_join(
+        conn: sqlite3.Connection, *, execution_id: str
+    ) -> Optional[sqlite3.Row]:
+        return conn.execute(
+            f"""SELECT
+                    c.execution_id, c.operation_id, c.issued_generation,
+                    c.token_hash, c.created_at AS capability_created_at,
+                    c.expires_at, c.cancel_requested_at,
+                    c.cancel_requested_generation, c.cancel_observed_at,
+                    c.auth_window_started_at, c.auth_attempts,
+                    o.profile, o.route, o.state, o.generation,
+                    o.script_started, o.created_at, o.updated_at,
+                    o.settled_at, o.last_error,
+                    t.state AS target_state, t.last_error AS target_error
+               FROM {_CAPABILITY_TABLE} AS c
+               JOIN webhook_operations AS o
+                 ON o.operation_id=c.operation_id
+               LEFT JOIN webhook_targets AS t
+                 ON t.operation_id=o.operation_id
+              WHERE c.execution_id=?""",
+            (execution_id,),
+        ).fetchone()
+
+    @staticmethod
+    def _status_from_row(row: sqlite3.Row) -> ExecutionStatus:
+        try:
+            operation_state = OperationState(row["state"])
+            target_state = (
+                TargetState(row["target_state"])
+                if row["target_state"] is not None
+                else None
+            )
+            generation = int(row["generation"])
+            cancel_generation = (
+                int(row["cancel_requested_generation"])
+                if row["cancel_requested_generation"] is not None
+                else None
+            )
+        except (TypeError, ValueError, OverflowError) as exc:
+            raise WebhookLedgerCorruptionError(
+                "webhook execution projection contains invalid state"
+            ) from exc
+        if generation < 1:
+            raise WebhookLedgerCorruptionError(
+                "webhook execution projection contains invalid generation"
+            )
+        if row["cancel_requested_at"] is None:
+            cancellation = CancellationState.NONE
+        elif cancel_generation != generation:
+            cancellation = CancellationState.STALE
+        elif row["cancel_observed_at"] is not None:
+            cancellation = CancellationState.OBSERVED
+        else:
+            cancellation = CancellationState.REQUESTED
+        created_at = _finite_time(row["created_at"], label="operation created_at")
+        updated_at = _finite_time(row["updated_at"], label="operation updated_at")
+        settled_at = (
+            _finite_time(row["settled_at"], label="operation settled_at")
+            if row["settled_at"] is not None
+            else None
+        )
+        effects_possible = bool(row["script_started"]) or operation_state in {
+            OperationState.RUNNING,
+            OperationState.DELIVERY_READY,
+            OperationState.DELIVERING,
+            OperationState.SETTLED,
+            OperationState.INDETERMINATE,
+        }
+        return ExecutionStatus(
+            execution_id=str(row["execution_id"]),
+            phase=_phase_for_state(operation_state),
+            operation_state=operation_state,
+            target_state=target_state,
+            generation=generation,
+            cancellation=cancellation,
+            can_cancel=_is_cancellable(operation_state),
+            effects_possible=effects_possible,
+            created_at=created_at,
+            updated_at=updated_at,
+            settled_at=settled_at,
+            needs_attention=(
+                operation_state is OperationState.INDETERMINATE
+                or row["last_error"] is not None
+                or row["target_error"] is not None
+            ),
+        )
+
+    def _prune_expired_in_transaction(
+        self, conn: sqlite3.Connection, *, now: float, limit: int
+    ) -> int:
+        cursor = conn.execute(
+            f"""DELETE FROM {_CAPABILITY_TABLE}
+                 WHERE execution_id IN (
+                    SELECT execution_id FROM {_CAPABILITY_TABLE}
+                     WHERE expires_at <= ?
+                     ORDER BY expires_at, execution_id
+                     LIMIT ?
+                 )""",
+            (now, limit),
+        )
+        return max(0, int(cursor.rowcount))
+
+    def prune_expired(
+        self, *, now: Optional[float] = None, limit: int = MAXIMUM_PRUNE_BATCH
+    ) -> int:
+        """Delete a bounded page of expired capabilities, never operations."""
+
+        timestamp = (
+            time.time() if now is None else _finite_time(now, label="prune time")
+        )
+        if (
+            not isinstance(limit, int)
+            or isinstance(limit, bool)
+            or not 1 <= limit <= MAXIMUM_PRUNE_BATCH
+        ):
+            raise ValueError("limit is outside the supported range")
+        with self.ledger._lock, self.ledger._transaction() as conn:
+            return self._prune_expired_in_transaction(conn, now=timestamp, limit=limit)
+
+    def issue(
+        self,
+        authority: OperationAuthority,
+        *,
+        now: Optional[float] = None,
+    ) -> IssuedExecutionCapability:
+        """Issue one non-recoverable bearer capability for an operation."""
+
+        if not isinstance(authority, OperationAuthority):
+            raise TypeError("authority must be an OperationAuthority")
+        timestamp = (
+            time.time() if now is None else _finite_time(now, label="issue time")
+        )
+        expires_at = _finite_time(
+            timestamp + self.capability_ttl_seconds,
+            label="capability expires_at",
+        )
+        with self.ledger._lock, self.ledger._transaction() as conn:
+            self._prune_expired_in_transaction(
+                conn,
+                now=timestamp,
+                limit=MAXIMUM_PRUNE_BATCH,
+            )
+            operation = conn.execute(
+                """SELECT operation_id, profile, route, generation
+                     FROM webhook_operations WHERE operation_id=?""",
+                (authority.operation_id,),
+            ).fetchone()
+            if operation is None:
+                raise WebhookLedgerError("execution operation does not exist")
+            if (
+                operation["profile"] != authority.profile
+                or operation["route"] != authority.route
+                or int(operation["generation"]) != authority.generation
+            ):
+                raise WebhookLedgerError("execution authority is stale")
+            existing = conn.execute(
+                f"""SELECT execution_id, expires_at
+                      FROM {_CAPABILITY_TABLE} WHERE operation_id=?""",
+                (authority.operation_id,),
+            ).fetchone()
+            if existing is not None:
+                return IssuedExecutionCapability(
+                    execution_id=str(existing["execution_id"]),
+                    access_token=None,
+                    created=False,
+                    expires_at=_finite_time(
+                        existing["expires_at"], label="capability expires_at"
+                    ),
+                )
+
+            for _attempt in range(8):
+                execution_id = secrets.token_urlsafe(24)
+                access_token = secrets.token_urlsafe(32)
+                try:
+                    conn.execute(
+                        f"""INSERT INTO {_CAPABILITY_TABLE} (
+                                execution_id, operation_id, issued_generation,
+                                token_hash, created_at, expires_at,
+                                auth_window_started_at, auth_attempts
+                            ) VALUES (?, ?, ?, ?, ?, ?, ?, 0)""",
+                        (
+                            execution_id,
+                            authority.operation_id,
+                            authority.generation,
+                            self._token_hash(access_token),
+                            timestamp,
+                            expires_at,
+                            timestamp,
+                        ),
+                    )
+                except sqlite3.IntegrityError as exc:
+                    message = str(exc)
+                    if "execution_id" in message or "token_hash" in message:
+                        continue
+                    raise
+                return IssuedExecutionCapability(
+                    execution_id=execution_id,
+                    access_token=access_token,
+                    created=True,
+                    expires_at=expires_at,
+                )
+        raise WebhookLedgerError("could not allocate a unique execution capability")
+
+    def _authorize_row(
+        self,
+        conn: sqlite3.Connection,
+        *,
+        execution_id: str,
+        token: str,
+        profile: str,
+        route: str,
+        now: float,
+    ) -> Optional[sqlite3.Row]:
+        row = self._operation_join(conn, execution_id=execution_id)
+        if row is None:
+            return None
+        expires_at = _finite_time(row["expires_at"], label="capability expires_at")
+        if expires_at <= now:
+            return None
+        window_started = _finite_time(
+            row["auth_window_started_at"], label="authorization window"
+        )
+        try:
+            attempts = int(row["auth_attempts"])
+        except (TypeError, ValueError, OverflowError) as exc:
+            raise WebhookLedgerCorruptionError(
+                "webhook execution authorization counter is invalid"
+            ) from exc
+        if attempts < 0:
+            raise WebhookLedgerCorruptionError(
+                "webhook execution authorization counter is invalid"
+            )
+        if now - window_started >= self.auth_window_seconds:
+            window_started = now
+            attempts = 0
+        if attempts >= self.auth_max_attempts:
+            return None
+        updated = conn.execute(
+            f"""UPDATE {_CAPABILITY_TABLE}
+                   SET auth_window_started_at=?, auth_attempts=?
+                 WHERE execution_id=?""",
+            (window_started, attempts + 1, execution_id),
+        )
+        if updated.rowcount != 1:
+            raise WebhookLedgerError("execution capability disappeared")
+        supplied_hash = self._token_hash(token)
+        token_ok = hmac.compare_digest(supplied_hash, str(row["token_hash"]))
+        scope_ok = row["profile"] == profile and row["route"] == route
+        return row if token_ok and scope_ok else None
+
+    def status(
+        self,
+        execution_id: str,
+        token: str,
+        *,
+        profile: str,
+        route: str,
+        now: Optional[float] = None,
+    ) -> Optional[ExecutionStatus]:
+        """Return an authenticated, redacted status projection.
+
+        Unknown IDs, wrong scopes, expired/rate-limited capabilities, and bad
+        tokens all return ``None`` so an HTTP facade can map them to the same
+        non-enumerable 404 response.
+        """
+
+        try:
+            execution = self._normalize_public_text(
+                execution_id, label="execution_id", maximum=128
+            )
+            supplied_token = self._normalize_public_text(
+                token, label="execution token", maximum=1024
+            )
+            scope_profile = self._normalize_public_text(profile, label="profile")
+            scope_route = self._normalize_public_text(route, label="route")
+        except WebhookLedgerError:
+            return None
+        timestamp = (
+            time.time() if now is None else _finite_time(now, label="status time")
+        )
+        with self.ledger._lock, self.ledger._transaction() as conn:
+            row = self._authorize_row(
+                conn,
+                execution_id=execution,
+                token=supplied_token,
+                profile=scope_profile,
+                route=scope_route,
+                now=timestamp,
+            )
+            return self._status_from_row(row) if row is not None else None
+
+    def request_cancel(
+        self,
+        execution_id: str,
+        token: str,
+        *,
+        profile: str,
+        route: str,
+        now: Optional[float] = None,
+    ) -> Optional[CancelRequestResult]:
+        """Durably request cancellation for the operation's current generation."""
+
+        try:
+            execution = self._normalize_public_text(
+                execution_id, label="execution_id", maximum=128
+            )
+            supplied_token = self._normalize_public_text(
+                token, label="execution token", maximum=1024
+            )
+            scope_profile = self._normalize_public_text(profile, label="profile")
+            scope_route = self._normalize_public_text(route, label="route")
+        except WebhookLedgerError:
+            return None
+        timestamp = (
+            time.time() if now is None else _finite_time(now, label="cancel time")
+        )
+        with self.ledger._lock, self.ledger._transaction() as conn:
+            row = self._authorize_row(
+                conn,
+                execution_id=execution,
+                token=supplied_token,
+                profile=scope_profile,
+                route=scope_route,
+                now=timestamp,
+            )
+            if row is None:
+                return None
+            state = OperationState(row["state"])
+            generation = int(row["generation"])
+            if state is OperationState.DELIVERING:
+                disposition = CancelDisposition.TOO_LATE
+            elif state in {OperationState.SETTLED, OperationState.INDETERMINATE}:
+                disposition = CancelDisposition.TERMINAL
+            else:
+                requested_generation = (
+                    int(row["cancel_requested_generation"])
+                    if row["cancel_requested_generation"] is not None
+                    else None
+                )
+                if requested_generation == generation:
+                    disposition = (
+                        CancelDisposition.OBSERVED
+                        if row["cancel_observed_at"] is not None
+                        else CancelDisposition.ALREADY_REQUESTED
+                    )
+                else:
+                    updated = conn.execute(
+                        f"""UPDATE {_CAPABILITY_TABLE}
+                               SET cancel_requested_at=?,
+                                   cancel_requested_generation=?,
+                                   cancel_observed_at=NULL
+                             WHERE execution_id=?""",
+                        (timestamp, generation, execution),
+                    )
+                    if updated.rowcount != 1:
+                        raise WebhookLedgerError(
+                            "execution cancellation request disappeared"
+                        )
+                    disposition = CancelDisposition.REQUESTED
+                    row = self._operation_join(conn, execution_id=execution)
+                    if row is None:  # pragma: no cover - FK + same transaction
+                        raise WebhookLedgerError("execution operation disappeared")
+            return CancelRequestResult(
+                disposition=disposition,
+                status=self._status_from_row(row),
+            )
+
+    def claim_cancel(
+        self,
+        operation_id: str,
+        generation: int,
+        *,
+        now: Optional[float] = None,
+    ) -> bool:
+        """Mark an exact-generation cancellation request observed by runtime.
+
+        This trusted runtime seam is what closes the pre-bind race: if a remote
+        request arrives before the real processing task exists, task creation
+        calls ``claim_cancel`` and cancels that exact task.  Stale generations
+        and post-target-attempt operations are never claimed.
+        """
+
+        operation = self._normalize_public_text(operation_id, label="operation_id")
+        if (
+            not isinstance(generation, int)
+            or isinstance(generation, bool)
+            or generation < 1
+        ):
+            raise ValueError("generation must be a positive integer")
+        timestamp = (
+            time.time() if now is None else _finite_time(now, label="observe time")
+        )
+        with self.ledger._lock, self.ledger._transaction() as conn:
+            row = conn.execute(
+                f"""SELECT c.cancel_requested_generation,
+                            c.cancel_observed_at, o.state, o.generation
+                       FROM {_CAPABILITY_TABLE} AS c
+                       JOIN webhook_operations AS o
+                         ON o.operation_id=c.operation_id
+                      WHERE c.operation_id=?""",
+                (operation,),
+            ).fetchone()
+            if row is None:
+                return False
+            if (
+                int(row["generation"]) != generation
+                or row["cancel_requested_generation"] is None
+                or int(row["cancel_requested_generation"]) != generation
+                or not _is_cancellable(OperationState(row["state"]))
+            ):
+                return False
+            if row["cancel_observed_at"] is not None:
+                return True
+            cursor = conn.execute(
+                f"""UPDATE {_CAPABILITY_TABLE}
+                       SET cancel_observed_at=?
+                     WHERE operation_id=?
+                       AND cancel_requested_generation=?
+                       AND cancel_observed_at IS NULL""",
+                (timestamp, operation, generation),
+            )
+            return cursor.rowcount == 1

--- a/gateway/platforms/webhook_filters.py
+++ b/gateway/platforms/webhook_filters.py
@@ -3,27 +3,1475 @@
 from __future__ import annotations
 
 import json
+import hashlib
 import logging
+import math
 import os
-import re
+import signal
 import shutil
+import stat
 import subprocess
 import sys
+import tempfile
+import threading
+import time
+from dataclasses import dataclass
+from enum import Enum
 from pathlib import Path
 from typing import Any, Optional
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_SCRIPT_TIMEOUT_SECONDS = 30
+MAX_SCRIPT_SNAPSHOT_BYTES = 64 * 1024
+MAX_SCRIPT_INTERPRETER_SNAPSHOT_BYTES = 256 * 1024 * 1024
+MAX_SCRIPT_OUTPUT_STREAM_BYTES = 1024 * 1024
+MAX_SCRIPT_OUTPUT_COMBINED_BYTES = 1024 * 1024
+MAX_FILTER_FILE_SNAPSHOT_BYTES = 1024 * 1024
+_SCRIPT_PIPE_CHUNK_BYTES = 64 * 1024
+_SCRIPT_TERMINATE_GRACE_SECONDS = 0.5
+_SCRIPT_CWD_CONTRACT = "isolated-empty-home-v1"
+_SCRIPT_CWD_ENV_TOKEN = "<isolated-cwd>"
+_SCRIPT_ENVIRONMENT_VERSION = 1
+_SCRIPT_SOURCE_HANDOFF_FILENAME = ".hermes-webhook-source.py"
+MAX_FILTER_REGEX_BYTES = 4 * 1024
+MAX_FILTER_REGEX_INPUT_BYTES = 256 * 1024
+FILTER_REGEX_TIMEOUT_SECONDS = 0.1
+FILTER_REGEX_STARTUP_TIMEOUT_SECONDS = 2.0
+MAX_FILTER_NODES = 64
+MAX_FILTER_DEPTH = 8
+MAX_FILTER_REGEX_NODES = 8
 _MISSING = object()
+_REGEX_WORKER = """\
+import json
+import re
+import sys
+
+sys.stdout.write("R")
+sys.stdout.flush()
+pattern, value = json.load(sys.stdin)
+try:
+    matched = re.search(pattern, value) is not None
+except (re.error, RecursionError):
+    raise SystemExit(2)
+sys.stdout.write("1" if matched else "0")
+"""
+_PYTHON_SNAPSHOT_LAUNCHER = f"""\
+import hashlib
+import os
+import sys
+
+source_path = {_SCRIPT_SOURCE_HANDOFF_FILENAME!r}
+with open(source_path, "rb") as source_file:
+    source_bytes = source_file.read()
+os.unlink(source_path)
+if hashlib.sha256(source_bytes).hexdigest() != sys.argv[1]:
+    raise SystemExit("webhook script source handoff digest mismatch")
+script_identifier = sys.argv[2]
+original_interpreter = sys.argv[3]
+sys.argv[:] = [script_identifier]
+sys.executable = original_interpreter
+if hasattr(sys, "_base_executable"):
+    sys._base_executable = original_interpreter
+__file__ = script_identifier
+exec(compile(source_bytes.decode("utf-8"), __file__, "exec"), globals(), globals())
+"""
+
+
+class WebhookScriptDisposition(str, Enum):
+    """Knowledge produced by one route-script attempt."""
+
+    CONTINUE = "continue"
+    IGNORED = "ignored"
+    FAILED = "failed"
+    INDETERMINATE = "indeterminate"
+
+
+@dataclass(frozen=True)
+class WebhookScriptResult:
+    """Typed route-script result; failures cannot masquerade as silence."""
+
+    disposition: WebhookScriptDisposition
+    payload: Optional[dict] = None
+    error: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class WebhookPreparedScript:
+    """Exact route-script source and bounded, non-secret spawn contract."""
+
+    path: str
+    source: str
+    source_sha256: str
+    interpreter: str
+    interpreter_kind: str
+    interpreter_sha256: str
+    environment: tuple[tuple[str, str], ...]
+    cwd_contract: str
+    execution_sha256: str
+
+
+@dataclass(frozen=True)
+class BoundedRegularFileSnapshot:
+    """Bytes and descriptor identity captured from one bounded regular file."""
+
+    content: bytes
+    stat_result: os.stat_result
+
+
+class BoundedFileSnapshotTooLarge(OSError):
+    """A regular file exceeded its declared snapshot authority."""
+
+
+class BoundedFileSnapshotNotRegular(OSError):
+    """A snapshot path opened as a FIFO, device, directory, or socket."""
+
+
+class BoundedFileSnapshotChanged(OSError):
+    """A regular file changed while its bounded snapshot was being read."""
+
+
+class BoundedFileSnapshotOutsideRoot(OSError):
+    """A snapshot descriptor escaped its resolved path-containment root."""
+
+
+@dataclass(frozen=True)
+class _BoundedProcessResult:
+    returncode: int
+    stdout: bytes
+    stderr: bytes
+
+
+class _ScriptOutputLimitExceeded(RuntimeError):
+    """A route script crossed its hard stdout/stderr authority bound."""
+
+
+class _ScriptCancellationRequested(RuntimeError):
+    """The owner cancelled a route script after its effect boundary."""
+
+
+class _RegexWorkerStartupTimeout(RuntimeError):
+    """The isolated regex worker did not become ready within its startup bound."""
+
+
+def _captured_script_environment() -> tuple[tuple[str, str], ...]:
+    """Build the complete non-secret environment for one route script.
+
+    Webhook scripts are documented as bounded JSON filters/transforms, not as
+    a trusted interactive shell.  In particular they must never inherit the
+    gateway's live process environment: that environment can contain another
+    multiplexed profile's credentials, shell startup hooks, import paths, or
+    new capabilities added after a route key was bound.
+
+    Keep the contract deliberately small and deterministic. ``HOME`` is a
+    symbolic reference to the fresh execution directory, so home-directory
+    lookup cannot rejoin mutable profile state. ``PATH`` is Python's platform
+    default rather than the mutable process value. Locale/time values make
+    text transforms reproducible. Windows needs its system-root variables to
+    create child processes; those non-secret values are captured now and never
+    reread at spawn time.
+    """
+
+    environment: dict[str, str] = {
+        "HOME": _SCRIPT_CWD_ENV_TOKEN,
+        "LANG": "C",
+        "LC_ALL": "C",
+        "PATH": os.defpath,
+        "TZ": "UTC",
+    }
+    if os.name == "nt":
+        # Environment names are case-insensitive on Windows.  Preserve the
+        # canonical spelling in the captured contract without forwarding any
+        # unrelated process variable.
+        process_values = {key.upper(): value for key, value in os.environ.items()}
+        for name in ("SYSTEMROOT", "WINDIR"):
+            value = process_values.get(name)
+            if value:
+                environment[name] = value
+    return tuple(sorted(environment.items()))
+
+
+def _prepared_script_argv(
+    *,
+    interpreter: str,
+    interpreter_kind: str,
+    source_sha256: str,
+    source: str,
+) -> tuple[str, ...]:
+    """Return the one allowed interpreter invocation for captured source."""
+
+    if len(source_sha256) != 64 or any(
+        character not in "0123456789abcdef" for character in source_sha256
+    ):
+        raise ValueError("prepared script source digest is invalid")
+    suffix = ".sh" if interpreter_kind == "bash" else ".py"
+    script_identifier = f"hermes-webhook-script:{source_sha256}{suffix}"
+
+    if interpreter_kind == "bash":
+        # BASH_ENV is absent from the minimal environment as the primary
+        # non-interactive startup-hook fence.  These flags independently keep
+        # profile and interactive rc files out of the execution contract.
+        return (
+            interpreter,
+            "--noprofile",
+            "--norc",
+            "-c",
+            source,
+            script_identifier,
+        )
+    if interpreter_kind == "python":
+        # -I ignores PYTHON* environment controls and removes the working
+        # directory/user site from imports. -S also excludes mutable venv and
+        # system site-packages. -X utf8 keeps JSON stdin/stdout deterministic
+        # even under the deliberately minimal C locale. The captured source is
+        # handed over through a private file that the launcher reads, verifies,
+        # and unlinks before user code starts. Keeping source out of argv avoids
+        # the per-argument OS limit while retaining synthetic __file__/argv[0].
+        return (
+            interpreter,
+            "-I",
+            "-S",
+            "-X",
+            "utf8",
+            "-c",
+            _PYTHON_SNAPSHOT_LAUNCHER,
+            source_sha256,
+            script_identifier,
+            interpreter,
+        )
+    raise ValueError("prepared script interpreter kind is invalid")
+
+
+def _script_execution_sha256(
+    *,
+    path: str,
+    source_sha256: str,
+    interpreter: str,
+    interpreter_kind: str,
+    interpreter_sha256: str,
+    environment: tuple[tuple[str, str], ...],
+    cwd_contract: str,
+    argv: tuple[str, ...],
+) -> str:
+    """Digest every non-secret input that selects script capabilities."""
+
+    canonical = json.dumps(
+        {
+            "v": _SCRIPT_ENVIRONMENT_VERSION,
+            "path": path,
+            "source_sha256": source_sha256,
+            "interpreter": interpreter,
+            "interpreter_kind": interpreter_kind,
+            "interpreter_sha256": interpreter_sha256,
+            "environment": [list(item) for item in environment],
+            "cwd_contract": cwd_contract,
+            "argv": list(argv),
+        },
+        ensure_ascii=True,
+        allow_nan=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("ascii")
+    return hashlib.sha256(canonical).hexdigest()
+
+
+def _validate_prepared_script_environment(
+    environment: tuple[tuple[str, str], ...],
+) -> bool:
+    """Reject any widened or non-canonical prepared environment."""
+
+    if not isinstance(environment, tuple):
+        return False
+    allowed = {
+        "HOME",
+        "LANG",
+        "LC_ALL",
+        "PATH",
+        "TZ",
+    }
+    if os.name == "nt":
+        allowed.update({"SYSTEMROOT", "WINDIR"})
+    seen: set[str] = set()
+    for item in environment:
+        if (
+            not isinstance(item, tuple)
+            or len(item) != 2
+            or not isinstance(item[0], str)
+            or not isinstance(item[1], str)
+            or item[0] not in allowed
+            or item[0] in seen
+        ):
+            return False
+        seen.add(item[0])
+    values = dict(environment)
+    return (
+        seen.issuperset({"HOME", "LANG", "LC_ALL", "PATH", "TZ"})
+        and values["HOME"] == _SCRIPT_CWD_ENV_TOKEN
+        and values["LANG"] == "C"
+        and values["LC_ALL"] == "C"
+        and values["PATH"] == os.defpath
+        and values["TZ"] == "UTC"
+        and tuple(sorted(environment)) == environment
+    )
+
+
+def _materialize_isolated_environment(
+    environment: tuple[tuple[str, str], ...],
+    *,
+    isolated_cwd: str,
+) -> dict[str, str]:
+    """Replace the sole symbolic environment value for one isolated spawn."""
+
+    materialized = dict(environment)
+    materialized["HOME"] = isolated_cwd
+    return materialized
+
+
+def _valid_sha256(value: Any) -> bool:
+    return (
+        isinstance(value, str)
+        and len(value) == 64
+        and all(character in "0123456789abcdef" for character in value)
+    )
+
+
+def _stat_identity(stat_result: os.stat_result) -> tuple[int, ...]:
+    """Return metadata that changes on replacement or ordinary mutation."""
+
+    return (
+        stat_result.st_dev,
+        stat_result.st_ino,
+        stat_result.st_mode,
+        stat_result.st_size,
+        stat_result.st_mtime_ns,
+        stat_result.st_ctime_ns,
+    )
+
+
+def _windows_final_path_from_fd(fd: int) -> Path:
+    """Resolve a Windows CRT descriptor through its already-open HANDLE."""
+
+    if os.name != "nt":
+        raise OSError("Windows descriptor paths are unavailable")
+    import ctypes
+    import msvcrt
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    get_final_path = kernel32.GetFinalPathNameByHandleW
+    get_final_path.argtypes = (
+        ctypes.c_void_p,
+        ctypes.c_wchar_p,
+        ctypes.c_uint32,
+        ctypes.c_uint32,
+    )
+    get_final_path.restype = ctypes.c_uint32
+    handle = msvcrt.get_osfhandle(fd)
+    required = get_final_path(handle, None, 0, 0)
+    if required == 0:
+        raise ctypes.WinError(ctypes.get_last_error())
+    buffer = ctypes.create_unicode_buffer(required + 1)
+    written = get_final_path(handle, buffer, len(buffer), 0)
+    if written == 0 or written >= len(buffer):
+        raise ctypes.WinError(ctypes.get_last_error())
+    final_path = buffer.value
+    if final_path.startswith("\\\\?\\UNC\\"):
+        final_path = "\\\\" + final_path.removeprefix("\\\\?\\UNC\\")
+    elif final_path.startswith("\\\\?\\"):
+        final_path = final_path.removeprefix("\\\\?\\")
+    return Path(final_path)
+
+
+def _open_windows_read_locked(path: Path) -> int:
+    """Open a Windows file while denying concurrent writes and replacement."""
+
+    if os.name != "nt":
+        raise OSError("Windows locked file opens are unavailable")
+    path_text = os.fspath(path)
+    if "\x00" in path_text:
+        raise ValueError("embedded NUL character in path")
+
+    import ctypes
+    import msvcrt
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    create_file = kernel32.CreateFileW
+    create_file.argtypes = (
+        ctypes.c_wchar_p,
+        ctypes.c_uint32,
+        ctypes.c_uint32,
+        ctypes.c_void_p,
+        ctypes.c_uint32,
+        ctypes.c_uint32,
+        ctypes.c_void_p,
+    )
+    create_file.restype = ctypes.c_void_p
+    close_handle = kernel32.CloseHandle
+    close_handle.argtypes = (ctypes.c_void_p,)
+    close_handle.restype = ctypes.c_int
+
+    generic_read = 0x80000000
+    file_share_read = 0x00000001
+    open_existing = 3
+    file_attribute_normal = 0x00000080
+    file_flag_sequential_scan = 0x08000000
+    handle = create_file(
+        path_text,
+        generic_read,
+        file_share_read,
+        None,
+        open_existing,
+        file_attribute_normal | file_flag_sequential_scan,
+        None,
+    )
+    if handle == ctypes.c_void_p(-1).value:
+        raise ctypes.WinError(ctypes.get_last_error())
+    try:
+        descriptor_flags = os.O_RDONLY | int(getattr(os, "O_BINARY", 0))
+        # Ownership of a successfully converted HANDLE transfers to the CRT
+        # descriptor and is released by os.close().
+        return msvcrt.open_osfhandle(int(handle), descriptor_flags)
+    except BaseException:
+        close_handle(handle)
+        raise
+
+
+def _open_readonly_descriptor(path: Path, flags: int) -> int:
+    if os.name == "nt":
+        return _open_windows_read_locked(path)
+    return os.open(path, flags)
+
+
+def _secure_open_beneath_resolved_root(
+    path: Path,
+    *,
+    resolved_root: Path,
+    flags: int,
+) -> int:
+    """Open a resolved path without following a post-resolution escape.
+
+    On POSIX, walk every already-resolved component from the filesystem root
+    using ``dir_fd`` plus ``O_NOFOLLOW``. Existing in-root symlinks remain
+    supported because callers resolve them before this walk; replacing any
+    canonical component with a symlink after resolution is rejected.
+
+    On Windows the opened target is share-locked against writes/deletion and its
+    kernel-resolved final path is checked beneath the root. Other platforms use
+    a descriptor/path identity fallback; they cannot provide the same race-free
+    path walk as POSIX or the same mandatory sharing lock as Windows.
+    """
+
+    path = Path(path)
+    resolved_root = Path(resolved_root)
+    if not path.is_absolute() or not resolved_root.is_absolute():
+        raise ValueError("snapshot containment paths must be absolute")
+    try:
+        relative = path.relative_to(resolved_root)
+    except ValueError as exc:
+        raise BoundedFileSnapshotOutsideRoot(
+            f"snapshot path resolves outside {resolved_root}: {path}"
+        ) from exc
+
+    secure_walk_available = (
+        os.name == "posix"
+        and os.open in getattr(os, "supports_dir_fd", set())
+        and bool(getattr(os, "O_DIRECTORY", 0))
+        and bool(getattr(os, "O_NOFOLLOW", 0))
+    )
+    if secure_walk_available:
+        directory_flags = (
+            os.O_RDONLY
+            | int(getattr(os, "O_CLOEXEC", 0))
+            | int(getattr(os, "O_DIRECTORY", 0))
+            | int(getattr(os, "O_NOFOLLOW", 0))
+        )
+        anchor = Path(resolved_root.anchor)
+        directory_fd = os.open(anchor, directory_flags)
+        try:
+            root_parts = resolved_root.parts[1:]
+            for part in root_parts:
+                next_fd = os.open(
+                    part,
+                    directory_flags,
+                    dir_fd=directory_fd,
+                )
+                os.close(directory_fd)
+                directory_fd = next_fd
+            relative_parts = relative.parts
+            for part in relative_parts[:-1]:
+                next_fd = os.open(
+                    part,
+                    directory_flags,
+                    dir_fd=directory_fd,
+                )
+                os.close(directory_fd)
+                directory_fd = next_fd
+            if not relative_parts:
+                return os.dup(directory_fd)
+            return os.open(
+                relative_parts[-1],
+                flags | int(getattr(os, "O_NOFOLLOW", 0)),
+                dir_fd=directory_fd,
+            )
+        finally:
+            os.close(directory_fd)
+
+    fd = _open_readonly_descriptor(path, flags)
+    try:
+        opened_stat = os.fstat(fd)
+        if os.name == "nt":
+            final_path = _windows_final_path_from_fd(fd)
+            try:
+                final_path.relative_to(resolved_root)
+            except ValueError as exc:
+                raise BoundedFileSnapshotOutsideRoot(
+                    f"snapshot descriptor is outside {resolved_root}: {final_path}"
+                ) from exc
+            return fd
+        try:
+            resolved_after_open = path.resolve(strict=True)
+            resolved_after_open.relative_to(resolved_root)
+            path_stat = os.stat(resolved_after_open, follow_symlinks=False)
+        except (OSError, ValueError) as exc:
+            raise BoundedFileSnapshotOutsideRoot(
+                f"snapshot descriptor is outside {resolved_root}: {path}"
+            ) from exc
+        if (
+            opened_stat.st_dev,
+            opened_stat.st_ino,
+        ) != (
+            path_stat.st_dev,
+            path_stat.st_ino,
+        ):
+            raise BoundedFileSnapshotChanged(
+                f"snapshot path changed while being opened: {path}"
+            )
+        return fd
+    except BaseException:
+        os.close(fd)
+        raise
+
+
+def _write_all_to_fd(fd: int, content: bytes) -> None:
+    view = memoryview(content)
+    offset = 0
+    while offset < len(view):
+        written = os.write(fd, view[offset:])
+        if written <= 0:
+            raise OSError("short executable snapshot write")
+        offset += written
+
+
+def _stable_regular_fd_digest(
+    fd: int,
+    *,
+    path: Path,
+    copy_fd: Optional[int] = None,
+) -> str:
+    """Boundedly hash one descriptor, optionally copying the exact bytes."""
+
+    initial_stat = os.fstat(fd)
+    if not stat.S_ISREG(initial_stat.st_mode):
+        raise BoundedFileSnapshotNotRegular(
+            f"interpreter is not a regular file: {path}"
+        )
+    if initial_stat.st_size > MAX_SCRIPT_INTERPRETER_SNAPSHOT_BYTES:
+        raise BoundedFileSnapshotTooLarge(
+            "interpreter exceeds "
+            f"{MAX_SCRIPT_INTERPRETER_SNAPSHOT_BYTES} byte snapshot limit: {path}"
+        )
+    os.lseek(fd, 0, os.SEEK_SET)
+    digest = hashlib.sha256()
+    total = 0
+    remaining = MAX_SCRIPT_INTERPRETER_SNAPSHOT_BYTES + 1
+    while remaining > 0:
+        chunk = os.read(fd, min(remaining, 1024 * 1024))
+        if not chunk:
+            break
+        digest.update(chunk)
+        if copy_fd is not None:
+            _write_all_to_fd(copy_fd, chunk)
+        total += len(chunk)
+        remaining -= len(chunk)
+    if total > MAX_SCRIPT_INTERPRETER_SNAPSHOT_BYTES:
+        raise BoundedFileSnapshotTooLarge(
+            "interpreter grew beyond "
+            f"{MAX_SCRIPT_INTERPRETER_SNAPSHOT_BYTES} byte snapshot limit: {path}"
+        )
+    final_stat = os.fstat(fd)
+    if _stat_identity(initial_stat) != _stat_identity(final_stat) or (
+        total != initial_stat.st_size
+    ):
+        raise BoundedFileSnapshotChanged(
+            f"interpreter changed while being hashed: {path}"
+        )
+    os.lseek(fd, 0, os.SEEK_SET)
+    return digest.hexdigest()
+
+
+def _open_stable_regular_file_digest(path: Path) -> tuple[int, str]:
+    """Open and boundedly hash one regular file, retaining its descriptor."""
+
+    flags = os.O_RDONLY
+    for optional_flag in ("O_NONBLOCK", "O_CLOEXEC", "O_BINARY"):
+        flags |= int(getattr(os, optional_flag, 0))
+    fd = _open_readonly_descriptor(path, flags)
+    try:
+        return fd, _stable_regular_fd_digest(fd, path=path)
+    except BaseException:
+        os.close(fd)
+        raise
+
+
+def _stable_regular_file_sha256(path: Path) -> str:
+    """Hash one stable regular-file descriptor and close it."""
+
+    fd, digest = _open_stable_regular_file_digest(path)
+    os.close(fd)
+    return digest
+
+
+def _verified_interpreter_fd_path(fd: int) -> Optional[str]:
+    """Return an executable inherited-fd path where the platform exposes one."""
+
+    if os.name != "posix":
+        return None
+    descriptor_stat = os.fstat(fd)
+    for prefix in ("/proc/self/fd", "/dev/fd"):
+        candidate = f"{prefix}/{fd}"
+        try:
+            candidate_stat = os.stat(candidate)
+        except OSError:
+            continue
+        if (candidate_stat.st_dev, candidate_stat.st_ino) == (
+            descriptor_stat.st_dev,
+            descriptor_stat.st_ino,
+        ):
+            return candidate
+    return None
+
+
+def _create_posix_executable_snapshot_fd() -> tuple[int, Optional[str], bool]:
+    """Create a private writable destination for an executable snapshot."""
+
+    if os.name != "posix":
+        raise OSError("executable snapshots require POSIX")
+    if hasattr(os, "memfd_create"):
+        memfd_flags = int(getattr(os, "MFD_CLOEXEC", 0)) | int(
+            getattr(os, "MFD_ALLOW_SEALING", 0)
+        )
+        try:
+            return os.memfd_create("hermes-webhook-interpreter", memfd_flags), None, True
+        except OSError:
+            pass
+    fd, path = tempfile.mkstemp(prefix="hermes-webhook-interpreter-")
+    return fd, path, False
+
+
+def _snapshot_posix_executable(path: Path, expected_sha256: Optional[str]) -> tuple[int, str]:
+    """Copy one verified executable into a private immutable execution inode."""
+
+    source_flags = (
+        os.O_RDONLY
+        | int(getattr(os, "O_CLOEXEC", 0))
+        | int(getattr(os, "O_NONBLOCK", 0))
+    )
+    source_fd = os.open(path, source_flags)
+    snapshot_fd = -1
+    snapshot_path: Optional[str] = None
+    is_memfd = False
+    try:
+        snapshot_fd, snapshot_path, is_memfd = _create_posix_executable_snapshot_fd()
+        digest = _stable_regular_fd_digest(
+            source_fd,
+            path=path,
+            copy_fd=snapshot_fd,
+        )
+        if expected_sha256 is not None and digest != expected_sha256:
+            raise BoundedFileSnapshotChanged(
+                f"interpreter content changed after snapshot: {path}"
+            )
+        os.fchmod(snapshot_fd, 0o500)
+        if is_memfd:
+            import fcntl
+
+            seals = (
+                int(getattr(fcntl, "F_SEAL_SEAL", 0x0001))
+                | int(getattr(fcntl, "F_SEAL_SHRINK", 0x0002))
+                | int(getattr(fcntl, "F_SEAL_GROW", 0x0004))
+                | int(getattr(fcntl, "F_SEAL_WRITE", 0x0008))
+            )
+            fcntl.fcntl(
+                snapshot_fd,
+                int(getattr(fcntl, "F_ADD_SEALS", 1033)),
+                seals,
+            )
+        else:
+            assert snapshot_path is not None
+            readonly_fd = os.open(
+                snapshot_path,
+                os.O_RDONLY | int(getattr(os, "O_CLOEXEC", 0)),
+            )
+            os.close(snapshot_fd)
+            snapshot_fd = readonly_fd
+        os.lseek(snapshot_fd, 0, os.SEEK_SET)
+        return snapshot_fd, digest
+    except BaseException:
+        if snapshot_fd >= 0:
+            os.close(snapshot_fd)
+        raise
+    finally:
+        os.close(source_fd)
+        if snapshot_path is not None:
+            try:
+                os.unlink(snapshot_path)
+            except FileNotFoundError:
+                pass
+
+
+_REGEX_INTERPRETER_PATH = sys.executable
+_REGEX_INTERPRETER_CAPTURE_PATH = (
+    "/proc/self/exe"
+    if os.name == "posix" and Path("/proc/self/exe").exists()
+    else _REGEX_INTERPRETER_PATH
+)
+
+
+def _capture_regex_interpreter_authority(
+    *,
+    platform_name: Optional[str] = None,
+) -> tuple[int, str, str, tuple[int, ...]]:
+    """Capture the startup regex executable, closing provisional FDs on failure."""
+
+    platform = os.name if platform_name is None else platform_name
+    interpreter_fd = -1
+    try:
+        interpreter_fd, interpreter_sha256 = _open_stable_regular_file_digest(
+            Path(_REGEX_INTERPRETER_CAPTURE_PATH)
+        )
+        if platform == "posix":
+            runtime_path = str(Path(_REGEX_INTERPRETER_PATH).absolute())
+        elif platform == "nt":
+            runtime_path = str(_windows_final_path_from_fd(interpreter_fd))
+        else:
+            runtime_path = _REGEX_INTERPRETER_PATH
+        os.set_inheritable(interpreter_fd, False)
+        identity = _stat_identity(os.fstat(interpreter_fd))
+        return interpreter_fd, interpreter_sha256, runtime_path, identity
+    except BaseException:
+        if interpreter_fd >= 0:
+            os.close(interpreter_fd)
+        raise
+
+
+try:
+    # Capture one bounded interpreter authority at module startup. POSIX keeps
+    # the already-running image descriptor; Windows keeps its canonical target
+    # share-locked against writes and deletion for the gateway lifetime.
+    (
+        _REGEX_INTERPRETER_FD,
+        _REGEX_INTERPRETER_SHA256,
+        _REGEX_INTERPRETER_RUNTIME_PATH,
+        _REGEX_INTERPRETER_IDENTITY,
+    ) = _capture_regex_interpreter_authority()
+except (AttributeError, OSError, ValueError):
+    _REGEX_INTERPRETER_FD = -1
+    _REGEX_INTERPRETER_SHA256: Optional[str] = None
+    _REGEX_INTERPRETER_RUNTIME_PATH: Optional[str] = None
+    _REGEX_INTERPRETER_IDENTITY: Optional[tuple[int, ...]] = None
+
+
+def read_bounded_regular_file_snapshot(
+    path: Path,
+    *,
+    max_bytes: int,
+    resolved_root: Optional[Path] = None,
+) -> BoundedRegularFileSnapshot:
+    """Read one descriptor-stable, bounded regular-file snapshot.
+
+    ``O_NONBLOCK`` makes opening a FIFO prompt even when it has no writer.  The
+    descriptor is type-checked before the first read, so devices and directories
+    cannot masquerade as small files through a zero ``st_size``.  Symlinks remain
+    supported for existing profile/config workflows, but their opened target
+    must be a regular file.
+    """
+
+    if not isinstance(max_bytes, int) or isinstance(max_bytes, bool) or max_bytes < 0:
+        raise ValueError("max_bytes must be a non-negative integer")
+
+    flags = os.O_RDONLY
+    for optional_flag in ("O_NONBLOCK", "O_CLOEXEC", "O_BINARY"):
+        flags |= int(getattr(os, optional_flag, 0))
+
+    fd = (
+        _secure_open_beneath_resolved_root(
+            path,
+            resolved_root=resolved_root,
+            flags=flags,
+        )
+        if resolved_root is not None
+        else _open_readonly_descriptor(path, flags)
+    )
+    try:
+        stat_result = os.fstat(fd)
+        if not stat.S_ISREG(stat_result.st_mode):
+            raise BoundedFileSnapshotNotRegular(
+                f"snapshot path is not a regular file: {path}"
+            )
+        if stat_result.st_size > max_bytes:
+            raise BoundedFileSnapshotTooLarge(
+                f"snapshot file exceeds {max_bytes} bytes: {path}"
+            )
+
+        def read_once() -> bytes:
+            chunks: list[bytes] = []
+            remaining = max_bytes + 1
+            while remaining > 0:
+                chunk = os.read(fd, min(remaining, 64 * 1024))
+                if not chunk:
+                    break
+                chunks.append(chunk)
+                remaining -= len(chunk)
+            content = b"".join(chunks)
+            if len(content) > max_bytes:
+                raise BoundedFileSnapshotTooLarge(
+                    f"snapshot file grew beyond {max_bytes} bytes: {path}"
+                )
+            return content
+
+        first_content = read_once()
+        middle_stat = os.fstat(fd)
+        os.lseek(fd, 0, os.SEEK_SET)
+        second_content = read_once()
+        final_stat = os.fstat(fd)
+        if (
+            _stat_identity(middle_stat) != _stat_identity(stat_result)
+            or _stat_identity(final_stat) != _stat_identity(stat_result)
+            or len(first_content) != stat_result.st_size
+            or len(second_content) != stat_result.st_size
+            or first_content != second_content
+        ):
+            raise BoundedFileSnapshotChanged(
+                f"snapshot file changed while being read: {path}"
+            )
+        return BoundedRegularFileSnapshot(second_content, final_stat)
+    finally:
+        os.close(fd)
+
+
+def _terminate_script_process(process: subprocess.Popen[bytes]) -> None:
+    """Terminate the isolated script process group, escalating when needed."""
+
+    if os.name == "posix":
+        if process.returncode is not None:
+            # poll()/wait() already reaped the leader. Its numeric PID is no
+            # longer a safely reserved process-group identifier.
+            return
+        # Do not call wait()/poll() during the TERM grace period. Keeping the
+        # leader unreaped reserves its PID, so its process-group ID cannot be
+        # recycled before the group-wide SIGKILL below.
+        leader_is_unreaped = process.returncode is None
+        try:
+            os.killpg(process.pid, signal.SIGTERM)  # windows-footgun: ok - POSIX-only branch
+        except ProcessLookupError:
+            pass
+        except (OSError, RuntimeError):
+            try:
+                process.terminate()
+            except (OSError, RuntimeError):
+                pass
+        if leader_is_unreaped:
+            time.sleep(_SCRIPT_TERMINATE_GRACE_SECONDS)
+        try:
+            os.killpg(process.pid, signal.SIGKILL)  # windows-footgun: ok - POSIX-only branch
+        except ProcessLookupError:
+            pass
+        except (OSError, RuntimeError):
+            try:
+                process.kill()
+            except (OSError, RuntimeError):
+                pass
+        try:
+            process.wait(timeout=_SCRIPT_TERMINATE_GRACE_SECONDS)
+        except subprocess.TimeoutExpired:
+            logger.error("[webhook] route script did not exit after forced termination")
+        return
+
+    if process.poll() is None:
+        try:
+            process.terminate()
+        except OSError:
+            pass
+    try:
+        process.wait(timeout=_SCRIPT_TERMINATE_GRACE_SECONDS)
+        return
+    except subprocess.TimeoutExpired:
+        pass
+    try:
+        process.kill()
+    except (OSError, RuntimeError):
+        pass
+    try:
+        process.wait(timeout=_SCRIPT_TERMINATE_GRACE_SECONDS)
+    except subprocess.TimeoutExpired:
+        logger.error("[webhook] route script did not exit after forced termination")
+
+
+def _script_process_has_exited(process: subprocess.Popen[bytes]) -> bool:
+    """Observe POSIX leader exit without releasing its PID/process-group ID."""
+
+    if process.returncode is not None:
+        return True
+    if _can_observe_posix_exit_without_reaping():
+        try:
+            status = os.waitid(
+                os.P_PID,
+                process.pid,
+                os.WEXITED | os.WNOHANG | os.WNOWAIT,
+            )
+        except ChildProcessError:
+            return process.poll() is not None
+        return status is not None
+    return process.poll() is not None
+
+
+def _can_observe_posix_exit_without_reaping() -> bool:
+    return (
+        os.name == "posix"
+        and hasattr(os, "waitid")
+        and hasattr(os, "WNOWAIT")
+        and hasattr(os, "P_PID")
+    )
+
+
+def _reap_finished_script_process_group(
+    process: subprocess.Popen[bytes],
+) -> None:
+    """End descendants before reaping a normally exited script leader."""
+
+    if os.name == "posix" and _can_observe_posix_exit_without_reaping():
+        # The leader was observed with waitid(WNOWAIT), so its PID still
+        # reserves this PGID. Once the authoritative program has exited, any
+        # remaining descendant is outside the route-script contract.
+        try:
+            os.killpg(process.pid, signal.SIGKILL)  # windows-footgun: ok - POSIX-only branch
+        except ProcessLookupError:
+            pass
+        except (OSError, RuntimeError):
+            pass
+    try:
+        process.wait(timeout=_SCRIPT_TERMINATE_GRACE_SECONDS)
+    except subprocess.TimeoutExpired:
+        _terminate_script_process(process)
+
+
+def _write_script_source_handoff(isolated_cwd: str, source_bytes: bytes) -> None:
+    """Create the private Python source handoff consumed before user code."""
+
+    handoff_path = Path(isolated_cwd) / _SCRIPT_SOURCE_HANDOFF_FILENAME
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    for optional_flag in ("O_CLOEXEC", "O_BINARY"):
+        flags |= int(getattr(os, optional_flag, 0))
+    fd = os.open(handoff_path, flags, 0o600)
+    try:
+        view = memoryview(source_bytes)
+        offset = 0
+        while offset < len(view):
+            written = os.write(fd, view[offset:])
+            if written <= 0:
+                raise OSError("short route script source handoff write")
+            offset += written
+    finally:
+        os.close(fd)
+
+
+_WINDOWS_PEEK_NAMED_PIPE: Any = None
+
+
+def _windows_pipe_available(fd: int) -> tuple[int, bool]:
+    """Return queued anonymous-pipe bytes and whether its writer is gone."""
+
+    if sys.platform != "win32":
+        raise OSError("Windows pipe inspection is unavailable")
+    import ctypes
+    import msvcrt
+
+    global _WINDOWS_PEEK_NAMED_PIPE
+    if _WINDOWS_PEEK_NAMED_PIPE is None:
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        peek_named_pipe = kernel32.PeekNamedPipe
+        peek_named_pipe.argtypes = (
+            ctypes.c_void_p,
+            ctypes.c_void_p,
+            ctypes.c_uint32,
+            ctypes.c_void_p,
+            ctypes.POINTER(ctypes.c_uint32),
+            ctypes.c_void_p,
+        )
+        peek_named_pipe.restype = ctypes.c_int
+        _WINDOWS_PEEK_NAMED_PIPE = peek_named_pipe
+
+    available = ctypes.c_uint32()
+    handle = msvcrt.get_osfhandle(fd)
+    if _WINDOWS_PEEK_NAMED_PIPE(
+        handle,
+        None,
+        0,
+        None,
+        ctypes.byref(available),
+        None,
+    ):
+        return int(available.value), False
+    error = ctypes.get_last_error()
+    if error in {38, 109, 232, 233}:  # EOF, broken/no-data/disconnected pipe
+        return 0, True
+    raise ctypes.WinError(error)
+
+
+def _read_available_script_pipe(
+    pipe: Any,
+    *,
+    nonblocking: bool,
+) -> Optional[bytes]:
+    """Read one ready chunk without ever parking a route-worker thread."""
+
+    fd = pipe.fileno()
+    if nonblocking:
+        try:
+            return os.read(fd, _SCRIPT_PIPE_CHUNK_BYTES)
+        except BlockingIOError:
+            return None
+    if sys.platform == "win32":
+        available, closed = _windows_pipe_available(fd)
+        if closed:
+            return b""
+        if available <= 0:
+            return None
+        return os.read(fd, min(available, _SCRIPT_PIPE_CHUNK_BYTES))
+    if os.name == "posix":
+        import select
+
+        readable, _, _ = select.select([fd], [], [], 0)
+        if not readable:
+            return None
+        return os.read(fd, _SCRIPT_PIPE_CHUNK_BYTES)
+    raise OSError("safe script pipe polling is unsupported")
+
+
+def _run_bounded_script_process(
+    argv: list[str],
+    *,
+    input_bytes: bytes,
+    timeout_seconds: float,
+    cwd: str,
+    env: dict[str, str],
+    cancellation_event: Optional[threading.Event] = None,
+    pass_fds: tuple[int, ...] = (),
+) -> _BoundedProcessResult:
+    """Run a script with bounded, single-worker output polling."""
+
+    if cancellation_event is not None and cancellation_event.is_set():
+        raise _ScriptCancellationRequested("route script was cancelled before spawn")
+
+    popen_kwargs: dict[str, Any] = {}
+    if os.name == "posix":
+        # A private session lets timeout/output-limit handling terminate helpers
+        # that inherited the pipes instead of waiting forever for their EOF.
+        popen_kwargs["start_new_session"] = True
+        if pass_fds:
+            popen_kwargs["pass_fds"] = pass_fds
+    elif sys.platform == "win32":
+        popen_kwargs["creationflags"] = 0x08000000  # CREATE_NO_WINDOW
+    elif pass_fds:
+        raise OSError("verified interpreter descriptors are unsupported")
+    input_file = tempfile.TemporaryFile(mode="w+b")
+    process: Optional[subprocess.Popen[bytes]] = None
+    try:
+        _write_all_to_fd(input_file.fileno(), input_bytes)
+        input_file.flush()
+        input_file.seek(0)
+        if cancellation_event is not None and cancellation_event.is_set():
+            raise _ScriptCancellationRequested(
+                "route script was cancelled before spawn"
+            )
+        process = subprocess.Popen(
+            argv,
+            stdin=input_file,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=False,
+            bufsize=0,
+            cwd=cwd,
+            env=env,
+            **popen_kwargs,
+        )
+        if process.stdout is None or process.stderr is None:
+            _terminate_script_process(process)
+            raise OSError("route script output pipes are unavailable")
+
+        pipes_nonblocking = True
+        try:
+            for pipe in (process.stdout, process.stderr):
+                os.set_blocking(pipe.fileno(), False)
+        except (AttributeError, OSError, ValueError):
+            # Python 3.11 cannot make anonymous Windows pipes nonblocking.
+            # PeekNamedPipe (or select on POSIX) gates every subsequent read.
+            pipes_nonblocking = False
+
+        buffers = {"stdout": bytearray(), "stderr": bytearray()}
+        combined_size = 0
+        output_limit = False
+        timed_out = False
+        cancelled = False
+        pipe_error: Optional[Exception] = None
+        streams = (("stdout", process.stdout), ("stderr", process.stderr))
+
+        def drain_one(name: str, pipe: Any) -> bool:
+            nonlocal combined_size, output_limit, pipe_error
+            try:
+                chunk = _read_available_script_pipe(
+                    pipe,
+                    nonblocking=pipes_nonblocking,
+                )
+            except (OSError, ValueError) as exc:
+                pipe_error = exc
+                return False
+            if chunk is None or chunk == b"":
+                return False
+            stream_remaining = MAX_SCRIPT_OUTPUT_STREAM_BYTES - len(buffers[name])
+            combined_remaining = MAX_SCRIPT_OUTPUT_COMBINED_BYTES - combined_size
+            accepted = min(
+                len(chunk),
+                max(0, stream_remaining),
+                max(0, combined_remaining),
+            )
+            if accepted:
+                buffers[name].extend(chunk[:accepted])
+                combined_size += accepted
+            if accepted != len(chunk):
+                output_limit = True
+            return True
+
+        deadline = time.monotonic() + timeout_seconds
+        leader_exited_normally = False
+        while True:
+            if cancellation_event is not None and cancellation_event.is_set():
+                cancelled = True
+                _terminate_script_process(process)
+                break
+
+            for name, pipe in streams:
+                drain_one(name, pipe)
+                if output_limit or pipe_error is not None:
+                    break
+            if output_limit or pipe_error is not None:
+                _terminate_script_process(process)
+                break
+
+            if _script_process_has_exited(process):
+                leader_exited_normally = True
+                break
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                timed_out = True
+                _terminate_script_process(process)
+                break
+            delay = min(0.01, remaining)
+            if cancellation_event is None:
+                time.sleep(delay)
+            else:
+                cancellation_event.wait(delay)
+
+        if leader_exited_normally:
+            _reap_finished_script_process_group(process)
+            # Drain only bytes already queued by the authoritative leader. An
+            # escaped descendant retaining a writer handle cannot keep this
+            # request or its global worker slot alive.
+            while True:
+                made_progress = False
+                for name, pipe in streams:
+                    made_progress = drain_one(name, pipe) or made_progress
+                    if output_limit or pipe_error is not None:
+                        break
+                if not made_progress or output_limit or pipe_error is not None:
+                    break
+
+        if cancellation_event is not None and cancellation_event.is_set():
+            cancelled = True
+        if cancelled:
+            raise _ScriptCancellationRequested("route script cancellation requested")
+        if output_limit:
+            raise _ScriptOutputLimitExceeded(
+                "route script output exceeded its byte limit"
+            )
+        if timed_out:
+            raise subprocess.TimeoutExpired(argv, timeout_seconds)
+        if pipe_error is not None:
+            raise OSError(f"route script pipe failed: {pipe_error}")
+        return _BoundedProcessResult(
+            returncode=int(process.returncode),
+            stdout=bytes(buffers["stdout"]),
+            stderr=bytes(buffers["stderr"]),
+        )
+    finally:
+        if process is not None:
+            if not _script_process_has_exited(process):
+                _terminate_script_process(process)
+            for pipe in (process.stdout, process.stderr):
+                if pipe is not None:
+                    try:
+                        pipe.close()
+                    except (OSError, ValueError):
+                        pass
+        input_file.close()
+
+
+def _validate_json_filter_value(
+    value: Any,
+    active_containers: Optional[set[int]] = None,
+) -> None:
+    """Reject values that could only acquire regex meaning through ``str``."""
+
+    value_type = type(value)
+    if value is None or value_type in {str, bool, int}:
+        return
+    if value_type is float:
+        if not math.isfinite(value):
+            raise ValueError("filter regex numeric values must be finite")
+        return
+    if value_type not in {dict, list}:
+        raise TypeError("filter regex values must use JSON-compatible types")
+
+    if active_containers is None:
+        active_containers = set()
+    identity = id(value)
+    if identity in active_containers:
+        raise ValueError("filter regex values must not contain cycles")
+    active_containers.add(identity)
+    try:
+        if value_type is dict:
+            for key, item in value.items():
+                if type(key) is not str:
+                    raise TypeError("filter regex object keys must be strings")
+                _validate_json_filter_value(item, active_containers)
+        else:
+            for item in value:
+                _validate_json_filter_value(item, active_containers)
+    finally:
+        active_containers.remove(identity)
 
 
 def _stringify_filter_value(value: Any) -> str:
     if value is _MISSING:
         return ""
+    _validate_json_filter_value(value)
     if isinstance(value, (dict, list)):
-        return json.dumps(value, sort_keys=True)
+        # Preserve non-ASCII text so the regex boundary's strict UTF-8 check
+        # also rejects lone surrogates nested inside containers.  Escaping them
+        # here would turn invalid text into matchable ASCII such as ``\\ud800``.
+        return json.dumps(value, sort_keys=True, ensure_ascii=False)
     return str(value)
+
+
+def _bounded_regex_search(pattern: str, value: str) -> Optional[bool]:
+    """Evaluate a route regex outside the gateway process with hard deadlines."""
+
+    try:
+        pattern_size = len(pattern.encode("utf-8"))
+        value_size = len(value.encode("utf-8"))
+    except UnicodeEncodeError:
+        logger.warning("[webhook] Filter regex pattern/input must be valid UTF-8")
+        return None
+    if pattern_size > MAX_FILTER_REGEX_BYTES:
+        logger.warning(
+            "[webhook] Filter regex exceeds %d UTF-8 bytes",
+            MAX_FILTER_REGEX_BYTES,
+        )
+        return None
+    if value_size > MAX_FILTER_REGEX_INPUT_BYTES:
+        logger.warning(
+            "[webhook] Filter regex input exceeds %d UTF-8 bytes",
+            MAX_FILTER_REGEX_INPUT_BYTES,
+        )
+        return None
+    interpreter_fd = -1
+    process: Optional[subprocess.Popen[bytes]] = None
+    isolated_directory: Optional[tempfile.TemporaryDirectory[str]] = None
+    try:
+        if (
+            _REGEX_INTERPRETER_FD < 0
+            or _REGEX_INTERPRETER_SHA256 is None
+            or _REGEX_INTERPRETER_IDENTITY is None
+        ):
+            raise OSError("filter regex interpreter authority is unavailable")
+        interpreter_fd = os.dup(_REGEX_INTERPRETER_FD)
+        if _stat_identity(os.fstat(interpreter_fd)) != _REGEX_INTERPRETER_IDENTITY:
+            raise OSError("filter regex interpreter descriptor identity changed")
+
+        runtime_interpreter = _REGEX_INTERPRETER_RUNTIME_PATH
+        run_kwargs: dict[str, Any] = {}
+        if os.name == "posix":
+            interpreter_fd_path = _verified_interpreter_fd_path(interpreter_fd)
+            if interpreter_fd_path is None:
+                raise OSError(
+                    "verified filter regex interpreter descriptor cannot be executed"
+                )
+            runtime_interpreter = interpreter_fd_path
+            run_kwargs["pass_fds"] = (interpreter_fd,)
+        if runtime_interpreter is None:
+            raise OSError("filter regex interpreter runtime path is unavailable")
+
+        input_bytes = json.dumps(
+            [pattern, value],
+            ensure_ascii=False,
+        ).encode("utf-8")
+
+        isolated_directory = tempfile.TemporaryDirectory(
+            prefix="hermes-webhook-regex-"
+        )
+        isolated_cwd = isolated_directory.name
+        process = subprocess.Popen(
+            [
+                runtime_interpreter,
+                "-I",
+                "-S",
+                "-X",
+                "utf8",
+                "-c",
+                _REGEX_WORKER,
+            ],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=False,
+            bufsize=0,
+            cwd=isolated_cwd,
+            env=_materialize_isolated_environment(
+                _captured_script_environment(),
+                isolated_cwd=isolated_cwd,
+            ),
+            **run_kwargs,
+        )
+        if process.stdout is None or process.stderr is None:
+            raise OSError("filter regex worker pipes are unavailable")
+
+        stdout_nonblocking = True
+        try:
+            os.set_blocking(process.stdout.fileno(), False)
+        except (AttributeError, OSError, ValueError):
+            # Python 3.11 cannot make anonymous Windows pipes nonblocking.
+            # The shared pipe helper uses PeekNamedPipe there and select on
+            # POSIX, so the startup deadline remains enforceable.
+            stdout_nonblocking = False
+
+        startup_deadline = time.monotonic() + FILTER_REGEX_STARTUP_TIMEOUT_SECONDS
+        ready = bytearray()
+        while ready != b"R":
+            chunk = _read_available_script_pipe(
+                process.stdout,
+                nonblocking=stdout_nonblocking,
+            )
+            if chunk:
+                ready.extend(chunk)
+                if ready != b"R":
+                    raise OSError("filter regex worker sent an invalid READY frame")
+                break
+            if process.poll() is not None:
+                raise OSError("filter regex worker exited before READY")
+            remaining = startup_deadline - time.monotonic()
+            if remaining <= 0:
+                raise _RegexWorkerStartupTimeout
+            time.sleep(min(0.005, remaining))
+
+        if stdout_nonblocking:
+            os.set_blocking(process.stdout.fileno(), True)
+        stdout, _stderr = process.communicate(
+            input=input_bytes,
+            timeout=FILTER_REGEX_TIMEOUT_SECONDS,
+        )
+        returncode = process.returncode
+        process = None
+    except _RegexWorkerStartupTimeout:
+        logger.warning(
+            "[webhook] Filter regex worker startup exceeded %.3f seconds",
+            FILTER_REGEX_STARTUP_TIMEOUT_SECONDS,
+        )
+        return None
+    except subprocess.TimeoutExpired:
+        logger.warning(
+            "[webhook] Filter regex match exceeded %.3f seconds",
+            FILTER_REGEX_TIMEOUT_SECONDS,
+        )
+        return None
+    except (OSError, ValueError) as exc:
+        logger.warning("[webhook] Filter regex worker failed: %s", exc)
+        return None
+    finally:
+        if process is not None:
+            try:
+                if process.poll() is None:
+                    process.kill()
+            except (OSError, RuntimeError):
+                pass
+            try:
+                process.communicate(timeout=_SCRIPT_TERMINATE_GRACE_SECONDS)
+            except (OSError, ValueError, subprocess.TimeoutExpired):
+                pass
+        if isolated_directory is not None:
+            try:
+                isolated_directory.cleanup()
+            except OSError as exc:
+                logger.warning(
+                    "[webhook] Filter regex working directory cleanup failed: %s",
+                    exc,
+                )
+        if interpreter_fd >= 0:
+            try:
+                os.close(interpreter_fd)
+            except OSError:
+                pass
+    if returncode == 2:
+        logger.warning("[webhook] Invalid webhook filter regex")
+        return None
+    if returncode != 0 or stdout not in {b"0", b"1"}:
+        logger.warning(
+            "[webhook] Filter regex worker returned status %d",
+            returncode,
+        )
+        return None
+    return stdout == b"1"
+
+
+def _filter_shape_is_bounded(spec: Any) -> bool:
+    """Bound recursive filter work before evaluating operator semantics."""
+
+    roots = spec if isinstance(spec, list) else [spec]
+    if len(roots) > MAX_FILTER_NODES:
+        return False
+    stack = [(item, 1) for item in reversed(roots)]
+    nodes = 0
+    regex_nodes = 0
+    while stack:
+        item, depth = stack.pop()
+        nodes += 1
+        if nodes > MAX_FILTER_NODES or depth > MAX_FILTER_DEPTH:
+            return False
+        if not isinstance(item, dict):
+            continue
+        if "regex" in item:
+            regex_nodes += 1
+            if regex_nodes > MAX_FILTER_REGEX_NODES:
+                return False
+        for operator in ("all", "any"):
+            children = item.get(operator)
+            if not isinstance(children, list):
+                continue
+            if len(children) > MAX_FILTER_NODES - nodes:
+                return False
+            stack.extend((child, depth + 1) for child in reversed(children))
+        nested = item.get("not")
+        if isinstance(nested, dict):
+            stack.append((nested, depth + 1))
+    return True
 
 
 def _resolve_profile_path(path_value: Any) -> Optional[Path]:
@@ -52,14 +1500,21 @@ def _resolve_script_path(script_value: Any) -> tuple[Optional[Path], Optional[st
         return None, "script path is empty"
     from hermes_constants import get_hermes_home
 
-    scripts_root = (get_hermes_home() / "scripts").resolve()
-    raw_text = os.path.expandvars(script_value.strip())
-    if raw_text == "~/.hermes" or raw_text.startswith("~/.hermes/"):
-        mapped = _resolve_profile_path(raw_text)
-        candidate = mapped.resolve() if mapped is not None else scripts_root
-    else:
-        raw = Path(raw_text).expanduser()
-        candidate = raw.resolve() if raw.is_absolute() else (scripts_root / raw).resolve()
+    try:
+        scripts_root = (get_hermes_home() / "scripts").resolve()
+        raw_text = os.path.expandvars(script_value.strip())
+        if raw_text == "~/.hermes" or raw_text.startswith("~/.hermes/"):
+            mapped = _resolve_profile_path(raw_text)
+            candidate = mapped.resolve() if mapped is not None else scripts_root
+        else:
+            raw = Path(raw_text).expanduser()
+            candidate = (
+                raw.resolve()
+                if raw.is_absolute()
+                else (scripts_root / raw).resolve()
+            )
+    except (OSError, RuntimeError, ValueError) as exc:
+        return None, f"script path is invalid: {exc}"
     try:
         candidate.relative_to(scripts_root)
     except ValueError:
@@ -71,19 +1526,51 @@ def _resolve_script_path(script_value: Any) -> tuple[Optional[Path], Optional[st
     return candidate, None
 
 
-def _load_filter_file_values(path_value: Any) -> list[Any]:
-    path = _resolve_profile_path(path_value)
-    if path is None:
-        return []
+def _load_filter_file_values(path_value: Any) -> Optional[list[Any]]:
+    """Load one compatibility ``in_file`` operand under a finite file cap.
+
+    Authority publication replaces these lookups with frozen values before a
+    production request runs.  The compatibility evaluator still needs the
+    same regular-file and 1 MiB safety boundary so direct callers cannot block
+    on FIFOs/devices or allocate an unbounded file.
+    """
+
     try:
-        raw = path.read_text(encoding="utf-8")
-    except OSError as exc:
+        path = _resolve_profile_path(path_value)
+    except (OSError, RuntimeError, ValueError) as exc:
+        logger.warning("[webhook] filter in_file path is invalid: %s", exc)
+        return None
+    if path is None:
+        return None
+    try:
+        raw_bytes = read_bounded_regular_file_snapshot(
+            path,
+            max_bytes=MAX_FILTER_FILE_SNAPSHOT_BYTES,
+        ).content
+        raw = raw_bytes.decode("utf-8")
+    except BoundedFileSnapshotTooLarge:
+        logger.warning(
+            "[webhook] filter in_file exceeds %d bytes: %s",
+            MAX_FILTER_FILE_SNAPSHOT_BYTES,
+            path,
+        )
+        return None
+    except UnicodeDecodeError:
+        logger.warning("[webhook] filter in_file must be UTF-8: %s", path)
+        return None
+    except (OSError, ValueError) as exc:
         logger.warning("[webhook] filter in_file read failed for %s: %s", path, exc)
-        return []
+        return None
     try:
         data = json.loads(raw)
+    except RecursionError:
+        logger.warning("[webhook] filter in_file JSON nesting is too deep: %s", path)
+        return None
     except json.JSONDecodeError:
         return [line.strip() for line in raw.splitlines() if line.strip()]
+    except ValueError:
+        logger.warning("[webhook] filter in_file JSON value is too large: %s", path)
+        return None
     if isinstance(data, list):
         return data
     if isinstance(data, dict):
@@ -138,46 +1625,92 @@ class WebhookRouteProcessor:
                 return _MISSING
         return value
 
-    def filter_matches(
+    def _evaluate_filter(
         self,
         spec: Any,
         payload: dict,
         event_type: str,
         headers: Any,
-    ) -> bool:
-        """Evaluate one declarative webhook filter spec."""
+    ) -> Optional[bool]:
+        """Return a match verdict, or ``None`` for malformed filter syntax.
+
+        Negation needs this third state: treating a malformed nested filter as
+        an ordinary non-match would let ``not`` invert configuration failure
+        into authorization.
+        """
         if not isinstance(spec, dict):
             logger.warning("[webhook] Ignoring invalid filter spec: %r", spec)
-            return False
+            return None
+
+        operators = {
+            "all",
+            "any",
+            "not",
+            "exists",
+            "missing",
+            "equals",
+            "not_equals",
+            "contains",
+            "in",
+            "in_file",
+            "regex",
+        }
+        selected = operators.intersection(spec)
+        if len(selected) != 1:
+            logger.warning(
+                "[webhook] filter must select exactly one operator: %r",
+                sorted(selected),
+            )
+            return None
 
         if "all" in spec:
             items = spec.get("all")
-            return isinstance(items, list) and all(
-                self.filter_matches(item, payload, event_type, headers)
+            if not isinstance(items, list) or not items:
+                logger.warning("[webhook] 'all' filter must contain items")
+                return None
+            results = [
+                self._evaluate_filter(item, payload, event_type, headers)
                 for item in items
-            )
+            ]
+            return None if any(result is None for result in results) else all(results)
         if "any" in spec:
             items = spec.get("any")
-            return isinstance(items, list) and any(
-                self.filter_matches(item, payload, event_type, headers)
+            if not isinstance(items, list) or not items:
+                logger.warning("[webhook] 'any' filter must contain items")
+                return None
+            results = [
+                self._evaluate_filter(item, payload, event_type, headers)
                 for item in items
-            )
+            ]
+            return None if any(result is None for result in results) else any(results)
         if "not" in spec:
-            return not self.filter_matches(spec.get("not"), payload, event_type, headers)
+            nested = spec.get("not")
+            if not isinstance(nested, dict):
+                logger.warning("[webhook] 'not' filter must contain an object")
+                return None
+            nested_result = self._evaluate_filter(nested, payload, event_type, headers)
+            return None if nested_result is None else not nested_result
 
-        value = self.resolve_filter_field(
-            spec.get("field"), payload, event_type, headers
-        )
+        field = spec.get("field")
+        if not isinstance(field, str) or not field.strip():
+            logger.warning("[webhook] filter field must be a non-empty string")
+            return None
+
+        value = self.resolve_filter_field(field, payload, event_type, headers)
 
         if "exists" in spec:
+            expected = spec.get("exists")
+            if not isinstance(expected, bool):
+                logger.warning("[webhook] filter 'exists' must be a boolean")
+                return None
             exists = value is not _MISSING
-            return exists is bool(spec.get("exists"))
+            return exists is expected
         if spec.get("missing") is True:
             return value is _MISSING
         if "equals" in spec:
             return value is not _MISSING and value == spec.get("equals")
         if "not_equals" in spec:
-            return value is _MISSING or value != spec.get("not_equals")
+            return value is not _MISSING and value != spec.get("not_equals")
         if "contains" in spec:
             needle = spec.get("contains")
             if value is _MISSING:
@@ -187,23 +1720,53 @@ class WebhookRouteProcessor:
             return str(needle) in _stringify_filter_value(value)
         if "in" in spec:
             haystack = spec.get("in")
-            return isinstance(haystack, list) and value in haystack
+            if not isinstance(haystack, list):
+                logger.warning("[webhook] filter 'in' must contain a list")
+                return None
+            return value in haystack
         if "in_file" in spec:
-            return value in _load_filter_file_values(spec.get("in_file"))
+            file_values = _load_filter_file_values(spec.get("in_file"))
+            return None if file_values is None else value in file_values
         if "regex" in spec:
             if value is _MISSING:
                 return False
-            try:
-                return (
-                    re.search(str(spec.get("regex")), _stringify_filter_value(value))
-                    is not None
-                )
-            except re.error as exc:
-                logger.warning("[webhook] Invalid webhook filter regex: %s", exc)
-                return False
+            pattern = spec.get("regex")
+            if not isinstance(pattern, str):
+                logger.warning("[webhook] filter 'regex' must be a string")
+                return None
+            return _bounded_regex_search(
+                pattern,
+                _stringify_filter_value(value),
+            )
 
         logger.warning("[webhook] Filter spec has no supported operator: %r", spec)
-        return False
+        return None
+
+    def filter_matches(
+        self,
+        spec: Any,
+        payload: dict,
+        event_type: str,
+        headers: Any,
+    ) -> bool:
+        """Evaluate one declarative filter; malformed syntax fails closed."""
+
+        if not _filter_shape_is_bounded(spec):
+            logger.warning(
+                "[webhook] Filter exceeds the %d-node, %d-depth, or %d-regex limit",
+                MAX_FILTER_NODES,
+                MAX_FILTER_DEPTH,
+                MAX_FILTER_REGEX_NODES,
+            )
+            return False
+        try:
+            result = self._evaluate_filter(spec, payload, event_type, headers)
+        except (TypeError, ValueError, UnicodeError, RecursionError) as exc:
+            logger.warning("[webhook] Filter value cannot be evaluated safely: %s", exc)
+            return False
+        if result is None:
+            return False
+        return result
 
     def route_filters_match(
         self,
@@ -212,91 +1775,402 @@ class WebhookRouteProcessor:
         event_type: str,
         headers: Any,
     ) -> bool:
-        filters = route_config.get("filters") or []
-        if not filters:
+        if "filters" not in route_config:
+            return True
+        filters = route_config.get("filters")
+        if not _filter_shape_is_bounded(filters):
+            logger.warning(
+                "[webhook] Route filters exceed the configured complexity limits"
+            )
+            return False
+        if filters == []:
             return True
         if isinstance(filters, dict):
+            if not filters:
+                logger.warning("[webhook] filters object must not be empty")
+                return False
             return self.filter_matches(filters, payload, event_type, headers)
         if not isinstance(filters, list):
             logger.warning("[webhook] filters must be a list or object")
             return False
         return all(
-            self.filter_matches(spec, payload, event_type, headers)
-            for spec in filters
+            self.filter_matches(spec, payload, event_type, headers) for spec in filters
         )
 
-    def run_route_script(self, script_value: Any, payload: dict) -> tuple[bool, Optional[dict]]:
-        """Run a route script and return (should_continue, transformed_payload)."""
+    def prepare_route_script(
+        self, script_value: Any
+    ) -> tuple[Optional[WebhookPreparedScript], Optional[str]]:
+        """Snapshot one exact script before any subprocess can start."""
+
         path, error = _resolve_script_path(script_value)
         if error or path is None:
-            logger.warning("[webhook] script ignored webhook: %s", error)
-            return False, None
+            return None, error or "script path cannot be resolved"
+
+        from hermes_constants import get_hermes_home
+
+        try:
+            scripts_root = (get_hermes_home() / "scripts").resolve(strict=True)
+        except (OSError, RuntimeError, ValueError) as exc:
+            return None, f"script root cannot be resolved safely: {exc}"
+        try:
+            path.relative_to(scripts_root)
+        except ValueError:
+            return None, f"script path resolves outside {scripts_root}"
+        try:
+            source_bytes = read_bounded_regular_file_snapshot(
+                path,
+                max_bytes=MAX_SCRIPT_SNAPSHOT_BYTES,
+                resolved_root=scripts_root,
+            ).content
+        except BoundedFileSnapshotTooLarge:
+            return None, (
+                f"script exceeds {MAX_SCRIPT_SNAPSHOT_BYTES} byte snapshot limit"
+            )
+        except (OSError, RuntimeError, ValueError) as exc:
+            return None, f"script cannot be read: {exc}"
+        if not source_bytes:
+            return None, "script is empty"
+        try:
+            source = source_bytes.decode("utf-8")
+        except UnicodeDecodeError:
+            return None, "script must be UTF-8"
+        if "\x00" in source:
+            return None, "script contains a NUL byte"
 
         suffix = path.suffix.lower()
         if suffix in {".sh", ".bash"}:
-            bash = shutil.which("bash") or (
+            bash = shutil.which("bash", path=os.defpath) or (
                 "/bin/bash" if os.path.isfile("/bin/bash") else None
             )
             if bash is None:
-                logger.warning("[webhook] script ignored webhook: bash not found")
-                return False, None
-            argv = [bash, str(path)]
+                return None, "bash not found"
+            interpreter_kind = "bash"
+            interpreter_path = Path(bash)
         else:
-            argv = [sys.executable, str(path)]
+            interpreter_kind = "python"
+            interpreter_path = Path(sys.executable)
 
         try:
-            from tools.environments.local import build_subprocess_env
+            if interpreter_kind == "python":
+                # Keep the venv launcher path: resolving its symlink to the
+                # base interpreter loses pyvenv.cfg discovery and therefore
+                # the current interpreter's installed packages.
+                interpreter = str(interpreter_path.absolute())
+                if not Path(interpreter).is_file():
+                    raise FileNotFoundError(interpreter)
+            else:
+                interpreter = str(interpreter_path.resolve(strict=True))
+        except (OSError, RuntimeError, ValueError) as exc:
+            return None, f"script interpreter is unavailable: {exc}"
 
-            popen_kwargs = {"creationflags": 0x08000000} if sys.platform == "win32" else {}
-            result = subprocess.run(
-                argv,
-                input=json.dumps(payload),
-                capture_output=True,
-                text=True, encoding="utf-8", errors="replace",
-                timeout=self.script_timeout_seconds,
-                cwd=str(path.parent),
-                env=build_subprocess_env(),
-                **popen_kwargs,
+        try:
+            interpreter_sha256 = _stable_regular_file_sha256(Path(interpreter))
+        except (OSError, RuntimeError, ValueError) as exc:
+            return None, f"script interpreter cannot be snapshotted: {exc}"
+
+        environment = _captured_script_environment()
+        cwd_contract = _SCRIPT_CWD_CONTRACT
+        source_sha256 = hashlib.sha256(source_bytes).hexdigest()
+        argv = _prepared_script_argv(
+            interpreter=interpreter,
+            interpreter_kind=interpreter_kind,
+            source_sha256=source_sha256,
+            source=source,
+        )
+        execution_sha256 = _script_execution_sha256(
+            path=str(path),
+            source_sha256=source_sha256,
+            interpreter=interpreter,
+            interpreter_kind=interpreter_kind,
+            interpreter_sha256=interpreter_sha256,
+            environment=environment,
+            cwd_contract=cwd_contract,
+            argv=argv,
+        )
+
+        return (
+            WebhookPreparedScript(
+                path=str(path),
+                source=source,
+                source_sha256=source_sha256,
+                interpreter=interpreter,
+                interpreter_kind=interpreter_kind,
+                interpreter_sha256=interpreter_sha256,
+                environment=environment,
+                cwd_contract=cwd_contract,
+                execution_sha256=execution_sha256,
+            ),
+            None,
+        )
+
+    def run_prepared_script(
+        self,
+        prepared: WebhookPreparedScript,
+        payload: dict,
+        *,
+        cancellation_event: Optional[threading.Event] = None,
+    ) -> WebhookScriptResult:
+        """Execute only the exact source captured by ``prepare_route_script``."""
+
+        if cancellation_event is not None and cancellation_event.is_set():
+            return WebhookScriptResult(
+                WebhookScriptDisposition.INDETERMINATE,
+                error="script was cancelled after execution started",
+            )
+
+        try:
+            source_bytes = prepared.source.encode("utf-8")
+        except (AttributeError, UnicodeEncodeError):
+            return WebhookScriptResult(
+                WebhookScriptDisposition.FAILED,
+                error="prepared script source is invalid",
+            )
+        if hashlib.sha256(source_bytes).hexdigest() != prepared.source_sha256:
+            return WebhookScriptResult(
+                WebhookScriptDisposition.FAILED,
+                error="prepared script source does not match its snapshot digest",
+            )
+
+        try:
+            if prepared.cwd_contract != _SCRIPT_CWD_CONTRACT:
+                raise ValueError("prepared script cwd contract is invalid")
+            if not _valid_sha256(prepared.interpreter_sha256):
+                raise ValueError("prepared script interpreter digest is invalid")
+            if not _validate_prepared_script_environment(prepared.environment):
+                raise ValueError("prepared script environment is invalid")
+            argv = _prepared_script_argv(
+                interpreter=prepared.interpreter,
+                interpreter_kind=prepared.interpreter_kind,
+                source_sha256=prepared.source_sha256,
+                source=prepared.source,
+            )
+            execution_sha256 = _script_execution_sha256(
+                path=prepared.path,
+                source_sha256=prepared.source_sha256,
+                interpreter=prepared.interpreter,
+                interpreter_kind=prepared.interpreter_kind,
+                interpreter_sha256=prepared.interpreter_sha256,
+                environment=prepared.environment,
+                cwd_contract=prepared.cwd_contract,
+                argv=argv,
+            )
+        except (AttributeError, TypeError, ValueError) as exc:
+            logger.warning("[webhook] prepared script contract is invalid: %s", exc)
+            return WebhookScriptResult(
+                WebhookScriptDisposition.FAILED,
+                error="prepared script execution contract is invalid",
+            )
+        if execution_sha256 != prepared.execution_sha256:
+            return WebhookScriptResult(
+                WebhookScriptDisposition.FAILED,
+                error=(
+                    "prepared script execution contract does not match "
+                    "its snapshot digest"
+                ),
+            )
+
+        path = Path(prepared.path)
+
+        try:
+            input_bytes = json.dumps(payload).encode("utf-8")
+        except (TypeError, ValueError, UnicodeEncodeError, RecursionError) as exc:
+            logger.warning("[webhook] script payload cannot be serialized: %s", exc)
+            return WebhookScriptResult(
+                WebhookScriptDisposition.FAILED,
+                error="script payload cannot be serialized safely",
+            )
+
+        try:
+            if os.name == "posix":
+                if (
+                    prepared.interpreter_sha256 == _REGEX_INTERPRETER_SHA256
+                    and _REGEX_INTERPRETER_FD >= 0
+                    and _REGEX_INTERPRETER_IDENTITY is not None
+                ):
+                    interpreter_fd = os.dup(_REGEX_INTERPRETER_FD)
+                    if (
+                        _stat_identity(os.fstat(interpreter_fd))
+                        != _REGEX_INTERPRETER_IDENTITY
+                    ):
+                        os.close(interpreter_fd)
+                        raise BoundedFileSnapshotChanged(
+                            "retained interpreter descriptor identity changed"
+                        )
+                    live_interpreter_sha256 = prepared.interpreter_sha256
+                else:
+                    interpreter_fd, live_interpreter_sha256 = (
+                        _snapshot_posix_executable(
+                            Path(prepared.interpreter),
+                            expected_sha256=prepared.interpreter_sha256,
+                        )
+                    )
+            else:
+                interpreter_fd, live_interpreter_sha256 = (
+                    _open_stable_regular_file_digest(Path(prepared.interpreter))
+                )
+        except BoundedFileSnapshotChanged as exc:
+            logger.warning("[webhook] prepared script interpreter changed: %s", exc)
+            return WebhookScriptResult(
+                WebhookScriptDisposition.FAILED,
+                error="prepared script interpreter content changed after snapshot",
+            )
+        except (OSError, ValueError) as exc:
+            logger.warning("[webhook] prepared script interpreter is unavailable: %s", exc)
+            return WebhookScriptResult(
+                WebhookScriptDisposition.FAILED,
+                error="prepared script interpreter cannot be verified",
+            )
+        if live_interpreter_sha256 != prepared.interpreter_sha256:
+            os.close(interpreter_fd)
+            return WebhookScriptResult(
+                WebhookScriptDisposition.FAILED,
+                error="prepared script interpreter content changed after snapshot",
+            )
+
+        runtime_argv = list(argv)
+        inherited_interpreter_fds: tuple[int, ...] = ()
+        if os.name == "posix":
+            interpreter_fd_path = _verified_interpreter_fd_path(interpreter_fd)
+            if interpreter_fd_path is None:
+                os.close(interpreter_fd)
+                return WebhookScriptResult(
+                    WebhookScriptDisposition.FAILED,
+                    error="verified interpreter descriptor cannot be executed safely",
+                )
+            runtime_argv[0] = interpreter_fd_path
+            inherited_interpreter_fds = (interpreter_fd,)
+        elif os.name == "nt":
+            # CreateProcess has no execute-by-handle API. The descriptor was
+            # opened without FILE_SHARE_WRITE/FILE_SHARE_DELETE, and its final
+            # target path avoids a mutable reparse-point alias. Retain that lock
+            # through process creation and execution.
+            try:
+                runtime_argv[0] = str(_windows_final_path_from_fd(interpreter_fd))
+            except (OSError, ValueError) as exc:
+                os.close(interpreter_fd)
+                logger.warning(
+                    "[webhook] verified interpreter path is unavailable: %s",
+                    exc,
+                )
+                return WebhookScriptResult(
+                    WebhookScriptDisposition.FAILED,
+                    error="verified interpreter descriptor cannot be executed safely",
+                )
+        else:
+            os.close(interpreter_fd)
+            interpreter_fd = -1
+
+        try:
+            # A fresh 0700 directory has no pre-existing helpers to import or
+            # source.  Its random path does not carry authority; the frozen
+            # capability is specifically "isolated empty cwd".  Keep it alive
+            # until bounded process-group cleanup has completed.
+            with tempfile.TemporaryDirectory(
+                prefix="hermes-webhook-script-"
+            ) as isolated_cwd:
+                if prepared.interpreter_kind == "python":
+                    _write_script_source_handoff(isolated_cwd, source_bytes)
+                execution_environment = _materialize_isolated_environment(
+                    prepared.environment,
+                    isolated_cwd=isolated_cwd,
+                )
+                result = _run_bounded_script_process(
+                    runtime_argv,
+                    input_bytes=input_bytes,
+                    timeout_seconds=self.script_timeout_seconds,
+                    cwd=isolated_cwd,
+                    env=execution_environment,
+                    cancellation_event=cancellation_event,
+                    pass_fds=inherited_interpreter_fds,
+                )
+        except _ScriptCancellationRequested:
+            logger.warning("[webhook] script cancelled: %s", path)
+            return WebhookScriptResult(
+                WebhookScriptDisposition.INDETERMINATE,
+                error="script was cancelled after execution started",
+            )
+        except _ScriptOutputLimitExceeded:
+            logger.warning("[webhook] script output exceeded its limit: %s", path)
+            return WebhookScriptResult(
+                WebhookScriptDisposition.INDETERMINATE,
+                error="script output exceeded its byte limit after execution started",
             )
         except subprocess.TimeoutExpired:
             logger.warning("[webhook] script timed out: %s", path)
-            return False, None
+            return WebhookScriptResult(
+                WebhookScriptDisposition.INDETERMINATE,
+                error="script timed out after execution started",
+            )
         except Exception as exc:
             logger.warning("[webhook] script execution failed: %s", exc)
-            return False, None
+            return WebhookScriptResult(
+                WebhookScriptDisposition.INDETERMINATE,
+                error=f"script execution failed: {exc}",
+            )
+        finally:
+            if interpreter_fd >= 0:
+                try:
+                    os.close(interpreter_fd)
+                except OSError:
+                    pass
 
-        stdout = (result.stdout or "").strip()
-        stderr = (result.stderr or "").strip()
+        stdout = (result.stdout or b"").decode("utf-8", errors="replace").strip()
+        stderr = (result.stderr or b"").decode("utf-8", errors="replace").strip()
         try:
             from agent.redact import redact_sensitive_text
 
             stdout = redact_sensitive_text(stdout)
             stderr = redact_sensitive_text(stderr)
+            if not isinstance(stdout, str) or not isinstance(stderr, str):
+                raise TypeError("script output redactor must return text")
         except Exception as exc:
             logger.warning("[webhook] Failed to redact script output: %s", exc)
-            stdout = "[REDACTED - redaction failed]"
-            stderr = "[REDACTED - redaction failed]"
+            return WebhookScriptResult(
+                WebhookScriptDisposition.INDETERMINATE,
+                error="script output redaction failed after execution started",
+            )
         if result.returncode != 0:
             logger.info(
-                "[webhook] script ignored webhook path=%s code=%s stderr=%s",
+                "[webhook] script outcome indeterminate path=%s code=%s stderr=%s",
                 path.name,
                 result.returncode,
                 stderr[:200],
             )
-            return False, None
+            return WebhookScriptResult(
+                WebhookScriptDisposition.INDETERMINATE,
+                error=f"script exited with status {result.returncode}",
+            )
         if not stdout or stdout == "[SILENT]":
-            return False, None
+            return WebhookScriptResult(WebhookScriptDisposition.IGNORED)
 
         try:
             transformed = json.loads(stdout)
-        except json.JSONDecodeError:
+        except (json.JSONDecodeError, RecursionError, ValueError):
             transformed = {**payload, "script_output": stdout}
         if not isinstance(transformed, dict):
             logger.warning("[webhook] script stdout must be a JSON object or text")
-            return False, None
+            return WebhookScriptResult(
+                WebhookScriptDisposition.INDETERMINATE,
+                error="script stdout is not a JSON object or text",
+            )
         if (
             transformed.get("[SILENT]") is True
             or transformed.get("__hermes_ignore__") is True
         ):
-            return False, None
-        return True, transformed
+            return WebhookScriptResult(WebhookScriptDisposition.IGNORED)
+        return WebhookScriptResult(
+            WebhookScriptDisposition.CONTINUE,
+            payload=transformed,
+        )
+
+    def run_route_script(self, script_value: Any, payload: dict) -> WebhookScriptResult:
+        """Compatibility wrapper over exact preflight and execution."""
+
+        prepared, error = self.prepare_route_script(script_value)
+        if error or prepared is None:
+            logger.warning("[webhook] script preparation failed: %s", error)
+            return WebhookScriptResult(
+                WebhookScriptDisposition.FAILED,
+                error=error or "script path cannot be resolved",
+            )
+        return self.run_prepared_script(prepared, payload)

--- a/gateway/platforms/webhook_intake.py
+++ b/gateway/platforms/webhook_intake.py
@@ -65,7 +65,21 @@ logger = logging.getLogger(__name__)
 
 class WebhookIntakeMixin:
     async def _handle_health(self, request: "web.Request") -> "web.Response":
-        """Report readiness from the same authority that gates webhook intake."""
+        """Report listener liveness without consulting downstream authorities."""
+
+        del request
+        return web.json_response({
+            "status": "ok",
+            "platform": "webhook",
+        })
+
+    async def _handle_ready(self, request: "web.Request") -> "web.Response":
+        """Report readiness from the exact authority that gates intake.
+
+        This probe deliberately exposes only bounded operational facts.  Route
+        policy, credentials, target configuration, and failure detail remain
+        private.
+        """
 
         del request
         accepting_webhooks = self._intake_is_authoritative("default")
@@ -88,23 +102,30 @@ class WebhookIntakeMixin:
             )
             return web.json_response(
                 {
-                    "status": "degraded",
+                    "status": "not_ready",
                     "platform": "webhook",
                     "accepting_webhooks": False,
+                    "host": self._host,
+                    "port": self._port,
+                    "routes": len(self._authenticated_route_bundles_by_key),
+                    "problems": [error],
                     "error": error,
                 },
                 status=503,
                 headers=({} if not global_capacity_available else {"Retry-After": "5"}),
             )
         return web.json_response({
-            "status": "ok",
+            "status": "ready",
             "platform": "webhook",
             "accepting_webhooks": True,
+            "host": self._host,
+            "port": self._port,
+            "routes": len(self._authenticated_route_bundles_by_key),
         })
 
     def _withdraw_changed_dynamic_authorities(
         self,
-        candidate_dynamic: Mapping[str, dict],
+        candidate_dynamic: Mapping[Any, dict],
     ) -> None:
         """Keep only candidate routes with the exact already-bound authority.
 
@@ -113,44 +134,426 @@ class WebhookIntakeMixin:
         available, so JSON ordering cannot choose which shared-key scope wins.
         """
 
-        unchanged: dict[str, dict] = {}
-        for route_name, route in candidate_dynamic.items():
-            if route_name not in self._dynamic_routes:
+        candidate_by_key = self._qualified_route_candidates(candidate_dynamic)
+        unchanged: dict[tuple[str, str], dict] = {}
+        for route_key, route in candidate_by_key.items():
+            if route_key not in self._dynamic_routes_by_key:
                 continue
             try:
                 _, _, authorities, _, _, _, _ = (
                     self._route_authentication_authority_snapshot({
-                        route_name: route,
+                        route_key: route,
                     })
                 )
             except (WebhookContractError, WebhookLedgerError):
                 continue
-            if authorities.get(route_name) == (
-                self._authenticated_route_authorities.get(route_name)
+            if authorities.get(route_key) == (
+                self._authenticated_route_authorities_by_key.get(route_key)
             ):
-                unchanged[route_name] = route
-        self._dynamic_routes = unchanged
-        self._routes = {**unchanged, **self._static_routes}
+                unchanged[route_key] = route
+        static_by_key = self._qualified_route_candidates(self._static_routes)
+        self._replace_live_route_candidates(
+            unchanged,
+            {**unchanged, **static_by_key},
+        )
+        self._retain_published_route_authorities(self._routes_by_key)
+
+    def _reload_multiplex_dynamic_routes(self) -> None:
+        """Publish one deterministic snapshot from every admitted profile.
+
+        The shared listener owns the socket, while each admitted profile owns
+        its own route store.  The aggregate is published through the existing
+        durable authentication binding chokepoint; the store never bypasses
+        the content hash, exact route snapshot, or revocation behavior.
+
+        Public authority is qualified by ``(profile, route name)``. Equal route
+        names in different served profiles therefore remain independent; only
+        an exact qualified static key shadows its dynamic counterpart.
+        """
+
+        from gateway.platforms.webhook_models import to_persisted_route
+        from gateway.platforms.webhook_store import (
+            WebhookRouteStoreError,
+            stores_for_served_profiles,
+        )
+        from hermes_cli.profiles import profiles_to_serve
+
+        now = time.monotonic()
+        if now < getattr(self, "_dynamic_profile_reload_after", 0.0):
+            return
+        # Publish the amplification gate before directory scans, locks, or
+        # bounded reads. A request flood can trigger at most one profile-store
+        # sweep per interval.
+        self._dynamic_profile_reload_after = (
+            now + _DYNAMIC_ROUTES_CONTENT_RECHECK_SECONDS
+        )
+        runner = self.gateway_runner
+        config = getattr(runner, "config", None)
+        previous_state = getattr(self, "_dynamic_profile_store_state", {})
+        try:
+            served_profiles = profiles_to_serve(
+                multiplex=True,
+                profile_allowlist=getattr(
+                    config,
+                    "multiplex_profile_allowlist",
+                    None,
+                ),
+            )
+            stores = stores_for_served_profiles(served_profiles)
+        except Exception as exc:
+            # Losing the admission/store set is loss of all dynamic authority.
+            # Static configuration remains independently owned.
+            candidate_dynamic: dict[tuple[str, str], dict] = {}
+            static_by_key = self._qualified_route_candidates(self._static_routes)
+            try:
+                self._bind_route_authentication_authorities(static_by_key)
+            except (WebhookContractError, WebhookLedgerError):
+                self._withdraw_changed_dynamic_authorities(candidate_dynamic)
+            else:
+                self._replace_live_route_candidates({}, static_by_key)
+                self._dynamic_profile_store_state = {}
+                self._prune_rate_limit_buckets()
+            logger.error(
+                "[webhook] Multiplex route-store admission failed; dynamic "
+                "routes withdrawn: %s",
+                exc,
+            )
+            return
+
+        profiles_in_order = sorted(stores)
+        integrity_profile: Optional[str] = None
+        if profiles_in_order:
+            cursor = int(getattr(self, "_dynamic_profile_integrity_cursor", 0))
+            integrity_profile = profiles_in_order[cursor % len(profiles_in_order)]
+            self._dynamic_profile_integrity_cursor = (cursor + 1) % len(
+                profiles_in_order
+            )
+
+        observations: dict[str, dict[str, Any]] = {}
+        profile_candidates: dict[str, dict[str, dict]] = {}
+        transient_profiles: set[str] = set()
+        for profile in profiles_in_order:
+            store = stores[profile]
+            prior = previous_state.get(profile, {})
+            try:
+                generation_before = self._current_profile_authority_generation(
+                    profile,
+                    route_name="profile-store",
+                )
+            except (OSError, WebhookContractError) as exc:
+                transient_profiles.add(profile)
+                logger.error(
+                    "[webhook] Profile %s physical store authority is "
+                    "unavailable; its dynamic routes are withdrawn: %s",
+                    profile,
+                    exc,
+                )
+                continue
+            try:
+                probed_identity = store.probe_identity()
+            except (OSError, WebhookRouteStoreError) as exc:
+                # An actual path/type/permission failure is authority loss,
+                # unlike cooperative lock contention below.
+                transient_profiles.add(profile)
+                logger.error(
+                    "[webhook] Profile %s route-store identity is unavailable; "
+                    "its dynamic routes are withdrawn: %s",
+                    profile,
+                    exc,
+                )
+                continue
+
+            try:
+                generation_after_probe = self._current_profile_authority_generation(
+                    profile,
+                    route_name="profile-store",
+                )
+            except (OSError, WebhookContractError) as exc:
+                transient_profiles.add(profile)
+                logger.error(
+                    "[webhook] Profile %s physical store authority disappeared; "
+                    "its dynamic routes are withdrawn: %s",
+                    profile,
+                    exc,
+                )
+                continue
+            if not secrets.compare_digest(
+                generation_before,
+                generation_after_probe,
+            ):
+                transient_profiles.add(profile)
+                logger.error(
+                    "[webhook] Profile %s physical store authority changed "
+                    "during identity capture; its dynamic routes are withdrawn",
+                    profile,
+                )
+                continue
+
+            has_prior = profile in previous_state
+            prior_generation = prior.get("profile_generation")
+            same_generation = isinstance(
+                prior_generation, str
+            ) and secrets.compare_digest(prior_generation, generation_before)
+            needs_integrity_read = profile == integrity_profile
+            if (
+                has_prior
+                and same_generation
+                and probed_identity == prior.get("file_identity")
+                and not needs_integrity_read
+            ):
+                prior_candidates = prior.get("candidates", {})
+                if isinstance(prior_candidates, Mapping):
+                    profile_candidates[profile] = {
+                        name: dict(route)
+                        for name, route in prior_candidates.items()
+                        if isinstance(name, str) and isinstance(route, Mapping)
+                    }
+                observations[profile] = {
+                    "content_sha256": prior.get("content_sha256"),
+                    "file_identity": probed_identity,
+                    "profile_generation": generation_before,
+                }
+                continue
+            if not has_prior and probed_identity is None:
+                # Missing is an authoritative empty store; no lock/deep read.
+                profile_candidates[profile] = {}
+                observations[profile] = {
+                    "content_sha256": None,
+                    "file_identity": None,
+                    "profile_generation": generation_before,
+                }
+                continue
+
+            try:
+                snapshot = store.load_runtime()
+            except TimeoutError:
+                # A cooperative writer still owns the lock and has not yet
+                # published its atomic rename. Retain only the prior exact
+                # snapshot for this profile and retry after the gate.
+                prior_candidates = prior.get("candidates", {})
+                if same_generation and isinstance(prior_candidates, Mapping):
+                    profile_candidates[profile] = {
+                        name: dict(route)
+                        for name, route in prior_candidates.items()
+                        if isinstance(name, str) and isinstance(route, Mapping)
+                    }
+                observations[profile] = {
+                    "content_sha256": prior.get("content_sha256"),
+                    "file_identity": prior.get("file_identity"),
+                    "profile_generation": generation_before,
+                }
+                transient_profiles.add(profile)
+                logger.debug(
+                    "[webhook] Profile %s route store is busy; retaining its "
+                    "prior exact snapshot",
+                    profile,
+                )
+                continue
+            except (OSError, WebhookRouteStoreError) as exc:
+                # A symlink/race/permission failure is not permission to keep
+                # that profile's previous keys live. Retry on the next reload.
+                transient_profiles.add(profile)
+                logger.error(
+                    "[webhook] Profile %s route store is unavailable; its "
+                    "dynamic routes are withdrawn: %s",
+                    profile,
+                    exc,
+                )
+                continue
+            try:
+                generation_after_load = self._current_profile_authority_generation(
+                    profile,
+                    route_name="profile-store",
+                )
+            except (OSError, WebhookContractError) as exc:
+                transient_profiles.add(profile)
+                logger.error(
+                    "[webhook] Profile %s physical store authority disappeared "
+                    "during load; its dynamic routes are withdrawn: %s",
+                    profile,
+                    exc,
+                )
+                continue
+            if not secrets.compare_digest(
+                generation_before,
+                generation_after_load,
+            ):
+                transient_profiles.add(profile)
+                logger.error(
+                    "[webhook] Profile %s physical store authority changed "
+                    "during load; its dynamic routes are withdrawn",
+                    profile,
+                )
+                continue
+            observations[profile] = {
+                "content_sha256": snapshot.content_sha256,
+                "file_identity": (
+                    None
+                    if snapshot.quarantined_path is not None
+                    else snapshot.file_identity
+                ),
+                "profile_generation": generation_after_load,
+            }
+            accepted_for_profile: dict[str, dict] = {}
+            if snapshot.quarantined_path is not None:
+                logger.error(
+                    "[webhook] Profile %s route store was corrupt; exact bytes "
+                    "were quarantined and its dynamic routes withdrawn",
+                    profile,
+                )
+            for name, document in snapshot.routes.items():
+                candidate = to_persisted_route(document)
+                if candidate.get("enabled", True) is not True:
+                    continue
+                # A named profile must never inherit the listener owner's
+                # process-global secret. Secret references are resolved by the
+                # profile-scoped Task 8 layer; until then they fail closed.
+                effective_secret = candidate.get("secret")
+                if (
+                    effective_secret is None
+                    and "secret_ref" not in candidate
+                    and profile == "default"
+                ):
+                    effective_secret = self._global_secret
+                if not isinstance(effective_secret, str) or not effective_secret:
+                    logger.warning(
+                        "[webhook] Profile %s dynamic route %s skipped: no "
+                        "profile-owned authentication secret is available",
+                        profile,
+                        name,
+                    )
+                    continue
+                if effective_secret == _INSECURE_NO_AUTH and not _is_loopback_host(
+                    self._host
+                ):
+                    logger.warning(
+                        "[webhook] Profile %s dynamic route %s skipped: local "
+                        "auth bypass is not allowed on this listener",
+                        profile,
+                        name,
+                    )
+                    continue
+                accepted_for_profile[name] = candidate
+            profile_candidates[profile] = accepted_for_profile
+
+        static_by_key = self._qualified_route_candidates(self._static_routes)
+        candidate_dynamic: dict[tuple[str, str], dict] = {}
+        for profile in sorted(profile_candidates):
+            for name, candidate in sorted(profile_candidates[profile].items()):
+                route_key = (profile, name)
+                if route_key not in static_by_key:
+                    candidate_dynamic[route_key] = candidate
+
+        candidate_routes = {**candidate_dynamic, **static_by_key}
+        try:
+            observed_generations = {
+                profile: observation["profile_generation"]
+                for profile, observation in observations.items()
+                if isinstance(observation.get("profile_generation"), str)
+            }
+            aggregate_fingerprint = hashlib.sha256(
+                json.dumps(
+                    {
+                        "routes": [
+                            {
+                                "profile": profile,
+                                "route": name,
+                                "config": route,
+                            }
+                            for (profile, name), route in sorted(
+                                candidate_routes.items()
+                            )
+                        ],
+                        "profile_generations": observed_generations,
+                    },
+                    ensure_ascii=False,
+                    allow_nan=False,
+                    sort_keys=True,
+                    separators=(",", ":"),
+                ).encode("utf-8")
+            ).hexdigest()
+        except (TypeError, ValueError, UnicodeEncodeError, RecursionError) as exc:
+            self._withdraw_changed_dynamic_authorities(candidate_dynamic)
+            logger.error(
+                "[webhook] Multiplex aggregate route snapshot is not canonical: %s",
+                exc,
+            )
+            return
+
+        new_state: dict[str, dict[str, Any]] = {}
+        for profile, observation in observations.items():
+            new_state[profile] = {
+                **observation,
+                "candidates": profile_candidates.get(profile, {}),
+            }
+        if (
+            aggregate_fingerprint
+            == getattr(self, "_dynamic_profile_aggregate_sha256", None)
+            and candidate_routes == self._routes_by_key
+        ):
+            self._dynamic_profile_store_state = new_state
+            self._dynamic_profile_store_transient = tuple(sorted(transient_profiles))
+            return
+
+        try:
+            self._bind_route_authentication_authorities(
+                candidate_routes,
+                expected_profile_generations=observed_generations,
+            )
+        except (
+            WebhookContractError,
+            WebhookLedgerCapacityError,
+            WebhookLedgerTransitionError,
+        ) as exc:
+            self._withdraw_changed_dynamic_authorities(candidate_dynamic)
+            logger.error(
+                "[webhook] Multiplex dynamic route snapshot was rejected: %s",
+                exc,
+            )
+            return
+        except WebhookLedgerError as exc:
+            self._withdraw_changed_dynamic_authorities(candidate_dynamic)
+            logger.error(
+                "[webhook] Multiplex dynamic route publication is unavailable; "
+                "changed authorities withdrawn for retry: %s",
+                exc,
+            )
+            return
+
+        self._replace_live_route_candidates(candidate_dynamic, candidate_routes)
+        self._dynamic_profile_store_state = new_state
+        self._dynamic_profile_aggregate_sha256 = aggregate_fingerprint
+        self._dynamic_profile_store_transient = tuple(sorted(transient_profiles))
         self._prune_rate_limit_buckets()
+        logger.info(
+            "[webhook] Published %d multiplex dynamic route(s) from %d "
+            "profile store(s)",
+            len(candidate_dynamic),
+            len(stores),
+        )
 
     def _reload_dynamic_routes(self) -> None:
         """Atomically publish a content-versioned dynamic route snapshot."""
+
+        runner_config = getattr(getattr(self, "gateway_runner", None), "config", None)
+        if getattr(runner_config, "multiplex_profiles", False) is True:
+            self._reload_multiplex_dynamic_routes()
+            return
 
         from hermes_constants import get_hermes_home
 
         hermes_home = get_hermes_home()
         subs_path = hermes_home / _DYNAMIC_ROUTES_FILENAME
         if not subs_path.exists():
-            if self._dynamic_routes_file_present or self._dynamic_routes:
+            if self._dynamic_routes_file_present or self._dynamic_routes_by_key:
                 # File removal is itself authoritative revocation. Publish it
                 # before touching unrelated static authorities so a static
                 # policy mismatch or storage fault cannot keep deleted dynamic
                 # keys live.
-                self._dynamic_routes = {}
-                self._routes = dict(self._static_routes)
-                self._prune_rate_limit_buckets()
+                static_routes = self._qualified_route_candidates(self._static_routes)
+                self._replace_live_route_candidates({}, static_routes)
+                self._retain_published_route_authorities(static_routes)
                 try:
-                    static_routes = dict(self._static_routes)
                     self._bind_route_authentication_authorities(static_routes)
                 except (WebhookContractError, WebhookLedgerError) as exc:
                     logger.error(
@@ -189,7 +592,7 @@ class WebhookIntakeMixin:
         # authority loss, not permission to retain the previous dynamic keys.
         # Initialize the fail-closed candidate before stat/read so a removal,
         # replacement, or permission race at either syscall withdraws them.
-        candidate_dynamic: Optional[dict[str, dict]] = {}
+        candidate_dynamic: Optional[dict[Any, dict]] = {}
         try:
             path_stat = subs_path.stat()
             path_identity = (
@@ -270,10 +673,9 @@ class WebhookIntakeMixin:
             # Reject any dynamic route whose effective secret is empty —
             # an empty secret would cause _handle_webhook to skip HMAC
             # validation entirely, letting unauthenticated callers in.
-            new_dynamic: Dict[str, dict] = {}
+            new_dynamic: Dict[Any, dict] = {}
+            static_by_key = self._qualified_route_candidates(self._static_routes)
             for k, v in data.items():
-                if k in self._static_routes:
-                    continue
                 if not isinstance(v, dict):
                     logger.warning(
                         "[webhook] Dynamic route '%s' skipped: route must be an object",
@@ -304,6 +706,9 @@ class WebhookIntakeMixin:
                         )
                         continue
                 request_profile = candidate.get("profile", "default")
+                route_key = (request_profile, k)
+                if route_key in static_by_key:
+                    continue
                 try:
                     WebhookRouteConfig.bind(
                         k,
@@ -314,7 +719,11 @@ class WebhookIntakeMixin:
                 except WebhookContractError as exc:
                     logger.warning("[webhook] Dynamic route '%s' skipped: %s", k, exc)
                     continue
-                effective_secret = candidate.get("secret", self._global_secret)
+                effective_secret = (
+                    ""
+                    if "secret_ref" in candidate and "secret" not in candidate
+                    else candidate.get("secret", self._global_secret)
+                )
                 if not isinstance(effective_secret, str) or not effective_secret:
                     logger.warning(
                         "[webhook] Dynamic route '%s' skipped: 'secret' is "
@@ -334,13 +743,12 @@ class WebhookIntakeMixin:
                         self._host,
                     )
                     continue
-                new_dynamic[k] = candidate
+                new_dynamic[route_key] = candidate
 
-            candidate_routes = {**new_dynamic, **self._static_routes}
+            candidate_routes = {**new_dynamic, **static_by_key}
             candidate_dynamic = new_dynamic
             self._bind_route_authentication_authorities(candidate_routes)
-            self._dynamic_routes = new_dynamic
-            self._routes = candidate_routes
+            self._replace_live_route_candidates(new_dynamic, candidate_routes)
             self._dynamic_routes_content_sha256 = observed_digest
             self._dynamic_routes_file_identity = observed_identity
             self._dynamic_routes_rejected_content_sha256 = None
@@ -480,22 +888,92 @@ class WebhookIntakeMixin:
 
         self._reload_dynamic_routes()
         route_name = request.match_info.get("route_name", "")
-        live_route_config = self._routes.get(route_name)
-        if not isinstance(live_route_config, dict):
+        try:
+            if self._authenticated_route_snapshot is None:
+                # Compatibility for direct handler tests/embedders that replace
+                # the historical name map before first publication.
+                if not self._authenticated_route_registry and self._routes:
+                    legacy_routes = self._qualified_route_candidates(self._routes)
+                    if legacy_routes != dict(self._routes_by_key):
+                        self._replace_live_route_candidates(
+                            self._dynamic_routes,
+                            legacy_routes,
+                        )
+                self._bind_route_authentication_authorities(self._routes_by_key)
+            # One immutable carrier holds each bundle and its frozen route
+            # snapshot. Never join a candidate map to another generation.
+            route_registry = self._authenticated_route_registry
+        except (WebhookContractError, WebhookLedgerError) as exc:
+            logger.error("[webhook] Invalid route registry: %s", exc)
+            if "uses INSECURE_NO_AUTH on a non-loopback host" in str(
+                exc
+            ) and not _is_loopback_host(self._host):
+                return web.json_response(
+                    {"error": "Local auth bypass is not allowed on this host"},
+                    status=403,
+                )
+            target_unavailable = "not an outbound webhook target" in str(exc)
+            return web.json_response(
+                {
+                    "status": "unavailable" if target_unavailable else "failed",
+                    "error": (
+                        "Webhook target or grant is unavailable"
+                        if target_unavailable
+                        else "Webhook route is misconfigured"
+                    ),
+                },
+                status=503 if target_unavailable else 500,
+            )
+        raw_profile = (request.match_info.get("profile") or "").strip()
+        runner_config = getattr(
+            getattr(self, "gateway_runner", None),
+            "config",
+            None,
+        )
+        multiplexed = getattr(runner_config, "multiplex_profiles", False) is True
+        if multiplexed:
+            profile = self._resolve_request_profile(request)
+            if profile is _PROFILE_REJECTED:
+                return web.json_response(
+                    {"error": "Unknown or unconfigured profile"}, status=404
+                )
+            route_key = (profile or "default", route_name)
+            route_bundle = route_registry.get(route_key)
+        else:
+            # A self-prefix may refer either to an explicitly profile-bound
+            # route or to this gateway's canonical default route. Resolve only
+            # against those exact candidates; never fall back to a same-name
+            # sibling owned by another profile.
+            if raw_profile:
+                route_bundle = route_registry.get((
+                    raw_profile,
+                    route_name,
+                )) or route_registry.get(("default", route_name))
+            else:
+                route_bundle = route_registry.get(("default", route_name))
+            if route_bundle is None:
+                return web.json_response(
+                    {"error": f"Unknown route: {route_name}"}, status=404
+                )
+            live_route_config = route_bundle.route_config
+            profile = self._resolve_request_profile(request, live_route_config)
+            if profile is _PROFILE_REJECTED:
+                return web.json_response(
+                    {"error": "Unknown or unconfigured profile"}, status=404
+                )
+            route_key = (profile or "default", route_name)
+            route_bundle = route_registry.get(route_key)
+        if route_bundle is None:
             return web.json_response(
                 {"error": f"Unknown route: {route_name}"}, status=404
             )
+        live_route_config = route_bundle.route_config
         if live_route_config.get(
             "secret", self._global_secret
         ) == _INSECURE_NO_AUTH and not _is_loopback_host(self._host):
             return web.json_response(
                 {"error": "Local auth bypass is not allowed on this host"},
                 status=403,
-            )
-        profile = self._resolve_request_profile(request, live_route_config)
-        if profile is _PROFILE_REJECTED:
-            return web.json_response(
-                {"error": "Unknown or unconfigured profile"}, status=404
             )
         try:
             preliminary_route = WebhookRouteConfig.bind(
@@ -525,32 +1003,6 @@ class WebhookIntakeMixin:
         if not preliminary_route.enabled:
             return web.json_response(
                 {"error": f"Route disabled: {route_name}"}, status=403
-            )
-        try:
-            if self._authenticated_route_snapshot is None:
-                # Compatibility for direct handler tests/embedders. A real
-                # listener publishes every bundle before it opens intake.
-                self._bind_route_authentication_authorities(self._routes)
-            route_bundle = self._authenticated_route_bundles.get(route_name)
-            if route_bundle is None or (
-                _snapshot_route_config(live_route_config) != route_bundle.route_config
-            ):
-                raise WebhookContractError(
-                    "webhook route has no exact published authority bundle"
-                )
-        except (WebhookContractError, WebhookLedgerError) as exc:
-            logger.error("[webhook] Invalid route %s: %s", route_name, exc)
-            target_unavailable = "not an outbound webhook target" in str(exc)
-            return web.json_response(
-                {
-                    "status": "unavailable" if target_unavailable else "failed",
-                    "error": (
-                        "Webhook target or grant is unavailable"
-                        if target_unavailable
-                        else "Webhook route is misconfigured"
-                    ),
-                },
-                status=503 if target_unavailable else 500,
             )
         route_config = route_bundle.route_config
         try:
@@ -591,7 +1043,7 @@ class WebhookIntakeMixin:
             return web.json_response({"error": "Bad request"}, status=400)
         if len(raw_body) > self._max_body_bytes:
             return web.json_response({"error": "Payload too large"}, status=413)
-        if not self._route_bundle_is_current(route_name, route_bundle):
+        if not self._route_bundle_is_current(route_key, route_bundle):
             return web.json_response(
                 {
                     "status": "unavailable",
@@ -612,7 +1064,7 @@ class WebhookIntakeMixin:
                 status=403,
             )
         if not self._route_owns_unique_authenticated_secret(
-            route_name,
+            route_key,
             secret,
             bound_route.signature_mode,
             route_bundle,
@@ -814,7 +1266,7 @@ class WebhookIntakeMixin:
         # newly admitted identity. Durable duplicates/conflicts/active retries
         # above are indexed ledger results and cannot amplify filesystem,
         # profile, skill, or adapter-resolution work.
-        if not self._route_bundle_is_current(route_name, route_bundle):
+        if not self._route_bundle_is_current(route_key, route_bundle):
             release_before_effect()
             return web.json_response(
                 {
@@ -902,14 +1354,14 @@ class WebhookIntakeMixin:
                     release_before_effect()
                     raise
             bundle_still_current = self._route_bundle_is_current(
-                route_name,
+                route_key,
                 route_bundle,
             )
             if not durable_authority_matches or not bundle_still_current:
                 release_before_effect()
                 withdrew = False
                 if not durable_authority_matches and bundle_still_current:
-                    withdrew = self._withdraw_live_route(route_name, route_bundle)
+                    withdrew = self._withdraw_live_route(route_key, route_bundle)
                 if authority_error is not None:
                     logger.error(
                         "[webhook] Durable authentication authority proof failed "
@@ -932,7 +1384,7 @@ class WebhookIntakeMixin:
             try:
                 live_authority_matches = await run_authority_worker(
                     self._live_route_authority_matches,
-                    route_name,
+                    route_key,
                     route_bundle,
                 )
             except asyncio.CancelledError:
@@ -956,14 +1408,14 @@ class WebhookIntakeMixin:
                 release_before_effect()
                 raise
             bundle_still_current = self._route_bundle_is_current(
-                route_name,
+                route_key,
                 route_bundle,
             )
             if not live_authority_matches or not bundle_still_current:
                 release_before_effect()
                 withdrew = False
                 if not live_authority_matches and bundle_still_current:
-                    withdrew = self._withdraw_live_route(route_name, route_bundle)
+                    withdrew = self._withdraw_live_route(route_key, route_bundle)
                 if withdrew:
                     logger.error(
                         "[webhook] Withdrew route %s after its effective authority "
@@ -1055,7 +1507,7 @@ class WebhookIntakeMixin:
         except BaseException:
             release_before_effect()
             raise
-        if not self._route_bundle_is_current(route_name, route_bundle):
+        if not self._route_bundle_is_current(route_key, route_bundle):
             release_before_effect()
             return web.json_response(
                 {
@@ -1145,7 +1597,7 @@ class WebhookIntakeMixin:
             except Exception as exc:
                 script_worker_slots.release()
                 release_before_effect()
-                self._withdraw_live_route(route_name, route_bundle)
+                self._withdraw_live_route(route_key, route_bundle)
                 logger.error(
                     "[webhook] Script profile authority is unavailable for %s: %s",
                     route_name,
@@ -1164,7 +1616,7 @@ class WebhookIntakeMixin:
             ):
                 script_worker_slots.release()
                 release_before_effect()
-                self._withdraw_live_route(route_name, route_bundle)
+                self._withdraw_live_route(route_key, route_bundle)
                 return web.json_response(
                     {
                         "status": "unavailable",
@@ -1235,7 +1687,7 @@ class WebhookIntakeMixin:
                     },
                     status=500,
                 )
-            if not self._route_bundle_is_current(route_name, route_bundle):
+            if not self._route_bundle_is_current(route_key, route_bundle):
                 self._mark_indeterminate_or_fence(
                     authority,
                     "webhook route authority changed after script start",

--- a/gateway/platforms/webhook_intake.py
+++ b/gateway/platforms/webhook_intake.py
@@ -1,0 +1,1567 @@
+"""Intake responsibilities for the webhook adapter."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+import secrets
+import threading
+import time
+from typing import Any, Callable, Dict, Mapping, Optional
+
+try:
+    from aiohttp import web
+except ImportError:
+    web = None  # type: ignore[assignment]
+
+from gateway.platforms.base import (
+    MessageType,
+)
+from gateway.platforms.webhook_contract import (
+    WebhookContractError,
+    WebhookEnvelope,
+    WebhookPayloadContractError,
+    WebhookRouteConfig,
+    WebhookRouteScopeError,
+)
+from gateway.platforms.webhook_filters import (
+    WebhookPreparedScript,
+    WebhookScriptDisposition,
+    read_bounded_regular_file_snapshot,
+)
+from gateway.platforms.webhook_ledger import (
+    AdmitDisposition,
+    AdmitSaturationReason,
+    OperationState,
+    WebhookLedgerError,
+    WebhookLedgerCapacityError,
+    WebhookLedgerTransitionError,
+)
+
+from gateway.platforms.webhook_common import (
+    WebhookMessageEvent,
+    _DYNAMIC_ROUTES_CONTENT_RECHECK_SECONDS,
+    _DYNAMIC_ROUTES_FILENAME,
+    _INSECURE_NO_AUTH,
+    _MAX_DURABLE_AUTHORITY_SNAPSHOT_BYTES,
+    _MAX_DURABLE_EVENT_SNAPSHOT_BYTES,
+    _MAX_DYNAMIC_ROUTES_FILE_BYTES,
+    _MAX_RENDERED_PROMPT_BYTES,
+    _PROFILE_REJECTED,
+    _RATE_WINDOW_SECONDS,
+    _canonical_snapshot_size,
+    _is_loopback_host,
+    _plain_json_snapshot,
+    _reject_duplicate_json_keys,
+    _reject_nonfinite_json,
+    _route_worker_slots,
+    _snapshot_route_config,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class WebhookIntakeMixin:
+    async def _handle_health(self, request: "web.Request") -> "web.Response":
+        """Report readiness from the same authority that gates webhook intake."""
+
+        del request
+        accepting_webhooks = self._intake_is_authoritative("default")
+        try:
+            # Serialize durable probes and keep SQLite lock/disk latency off
+            # the public aiohttp event loop.
+            async with self._health_capacity_lock:
+                global_capacity_available = await asyncio.to_thread(
+                    self._operation_ledger.has_global_admission_capacity
+                )
+        except WebhookLedgerError:
+            global_capacity_available = False
+            logger.exception("[webhook] Durable capacity health check failed")
+        self._global_ledger_saturated = not global_capacity_available
+        if not accepting_webhooks or not global_capacity_available:
+            error = (
+                "Durable webhook evidence capacity is exhausted"
+                if accepting_webhooks and not global_capacity_available
+                else "Webhook intake is not active"
+            )
+            return web.json_response(
+                {
+                    "status": "degraded",
+                    "platform": "webhook",
+                    "accepting_webhooks": False,
+                    "error": error,
+                },
+                status=503,
+                headers=({} if not global_capacity_available else {"Retry-After": "5"}),
+            )
+        return web.json_response({
+            "status": "ok",
+            "platform": "webhook",
+            "accepting_webhooks": True,
+        })
+
+    def _withdraw_changed_dynamic_authorities(
+        self,
+        candidate_dynamic: Mapping[str, dict],
+    ) -> None:
+        """Keep only candidate routes with the exact already-bound authority.
+
+        A rejected policy update must not leave the prior, broader route live.
+        New conflicting routes are also excluded. Unchanged routes remain
+        available, so JSON ordering cannot choose which shared-key scope wins.
+        """
+
+        unchanged: dict[str, dict] = {}
+        for route_name, route in candidate_dynamic.items():
+            if route_name not in self._dynamic_routes:
+                continue
+            try:
+                _, _, authorities, _, _, _, _ = (
+                    self._route_authentication_authority_snapshot({
+                        route_name: route,
+                    })
+                )
+            except (WebhookContractError, WebhookLedgerError):
+                continue
+            if authorities.get(route_name) == (
+                self._authenticated_route_authorities.get(route_name)
+            ):
+                unchanged[route_name] = route
+        self._dynamic_routes = unchanged
+        self._routes = {**unchanged, **self._static_routes}
+        self._prune_rate_limit_buckets()
+
+    def _reload_dynamic_routes(self) -> None:
+        """Atomically publish a content-versioned dynamic route snapshot."""
+
+        from hermes_constants import get_hermes_home
+
+        hermes_home = get_hermes_home()
+        subs_path = hermes_home / _DYNAMIC_ROUTES_FILENAME
+        if not subs_path.exists():
+            if self._dynamic_routes_file_present or self._dynamic_routes:
+                # File removal is itself authoritative revocation. Publish it
+                # before touching unrelated static authorities so a static
+                # policy mismatch or storage fault cannot keep deleted dynamic
+                # keys live.
+                self._dynamic_routes = {}
+                self._routes = dict(self._static_routes)
+                self._prune_rate_limit_buckets()
+                try:
+                    static_routes = dict(self._static_routes)
+                    self._bind_route_authentication_authorities(static_routes)
+                except (WebhookContractError, WebhookLedgerError) as exc:
+                    logger.error(
+                        "[webhook] Dynamic routes removed, but static route "
+                        "authority refresh failed: %s",
+                        exc,
+                    )
+                self._dynamic_routes_content_sha256 = None
+                self._dynamic_routes_file_identity = None
+                self._dynamic_routes_rejected_content_sha256 = None
+                self._dynamic_routes_rejected_file_identity = None
+                self._dynamic_routes_transient_file_identity = None
+                self._dynamic_routes_retry_after = 0.0
+                self._dynamic_routes_integrity_recheck_identity = None
+                self._dynamic_routes_integrity_recheck_after = 0.0
+                self._dynamic_routes_file_present = False
+                logger.debug(
+                    "[webhook] Dynamic subscriptions file removed; cleared "
+                    "dynamic routes"
+                )
+            else:
+                self._dynamic_routes_content_sha256 = None
+                self._dynamic_routes_file_identity = None
+                self._dynamic_routes_rejected_content_sha256 = None
+                self._dynamic_routes_rejected_file_identity = None
+                self._dynamic_routes_transient_file_identity = None
+                self._dynamic_routes_retry_after = 0.0
+                self._dynamic_routes_integrity_recheck_identity = None
+                self._dynamic_routes_integrity_recheck_after = 0.0
+                self._dynamic_routes_file_present = False
+            return
+
+        observed_digest: Optional[str] = None
+        observed_identity: Optional[tuple[int, ...]] = None
+        # Once existence has been observed, any inability to read the file is
+        # authority loss, not permission to retain the previous dynamic keys.
+        # Initialize the fail-closed candidate before stat/read so a removal,
+        # replacement, or permission race at either syscall withdraws them.
+        candidate_dynamic: Optional[dict[str, dict]] = {}
+        try:
+            path_stat = subs_path.stat()
+            path_identity = (
+                int(path_stat.st_dev),
+                int(path_stat.st_ino),
+                int(path_stat.st_size),
+                int(path_stat.st_mtime_ns),
+                int(path_stat.st_ctime_ns),
+            )
+            now = time.monotonic()
+            # Stat identity changes are loaded immediately. For unchanged
+            # identity, periodically reopen and hash because neither Windows
+            # creation time nor POSIX mtime/ctime reliably exposes every
+            # same-size mmap write. Publish the gate before the bounded read so
+            # request floods cannot amplify a 4 MiB integrity check.
+            if (
+                path_identity == self._dynamic_routes_integrity_recheck_identity
+                and now < self._dynamic_routes_integrity_recheck_after
+            ):
+                return
+            self._dynamic_routes_integrity_recheck_identity = path_identity
+            self._dynamic_routes_integrity_recheck_after = (
+                now + _DYNAMIC_ROUTES_CONTENT_RECHECK_SECONDS
+            )
+            if (
+                path_identity == self._dynamic_routes_transient_file_identity
+                and now < self._dynamic_routes_retry_after
+            ):
+                return
+            snapshot = read_bounded_regular_file_snapshot(
+                subs_path,
+                max_bytes=_MAX_DYNAMIC_ROUTES_FILE_BYTES,
+            )
+            stat_result = snapshot.stat_result
+            observed_identity = (
+                int(stat_result.st_dev),
+                int(stat_result.st_ino),
+                int(stat_result.st_size),
+                int(stat_result.st_mtime_ns),
+                int(stat_result.st_ctime_ns),
+            )
+            self._dynamic_routes_integrity_recheck_identity = observed_identity
+            if (
+                observed_identity == self._dynamic_routes_transient_file_identity
+                and now < self._dynamic_routes_retry_after
+            ):
+                return
+            raw_config = snapshot.content
+            observed_digest = hashlib.sha256(raw_config).hexdigest()
+            if observed_digest == self._dynamic_routes_content_sha256:
+                self._dynamic_routes_file_identity = observed_identity
+                self._dynamic_routes_transient_file_identity = None
+                self._dynamic_routes_retry_after = 0.0
+                return
+            if observed_digest == self._dynamic_routes_rejected_content_sha256:
+                self._dynamic_routes_rejected_file_identity = observed_identity
+                return
+            try:
+                data = json.loads(
+                    raw_config.decode("utf-8"),
+                    object_pairs_hook=_reject_duplicate_json_keys,
+                    parse_constant=_reject_nonfinite_json,
+                )
+            except (
+                UnicodeDecodeError,
+                json.JSONDecodeError,
+                ValueError,
+                RecursionError,
+            ) as exc:
+                raise WebhookContractError(
+                    "dynamic subscriptions file is not canonical JSON"
+                ) from exc
+            if not isinstance(data, dict):
+                raise WebhookContractError(
+                    "dynamic subscriptions root must be an object"
+                )
+            # Merge: static routes take precedence over dynamic ones.
+            # Reject any dynamic route whose effective secret is empty —
+            # an empty secret would cause _handle_webhook to skip HMAC
+            # validation entirely, letting unauthenticated callers in.
+            new_dynamic: Dict[str, dict] = {}
+            for k, v in data.items():
+                if k in self._static_routes:
+                    continue
+                if not isinstance(v, dict):
+                    logger.warning(
+                        "[webhook] Dynamic route '%s' skipped: route must be an object",
+                        k,
+                    )
+                    continue
+                candidate = dict(v)
+                if not candidate.get("provider") and not candidate.get(
+                    "signature_mode"
+                ):
+                    description = str(candidate.get("description") or "")
+                    if description.startswith("Agent-created subscription:"):
+                        # Historical CLI subscriptions were emitted with the
+                        # GitHub-style body HMAC but omitted the provider. This
+                        # content-derived migration runs once at config load;
+                        # request headers never participate.
+                        candidate["provider"] = "github"
+                        logger.warning(
+                            "[webhook] Dynamic route '%s' migrated in memory to "
+                            "provider=github; re-save it with a provider field",
+                            k,
+                        )
+                    else:
+                        logger.warning(
+                            "[webhook] Dynamic route '%s' skipped: explicit "
+                            "provider or signature_mode is required",
+                            k,
+                        )
+                        continue
+                request_profile = candidate.get("profile", "default")
+                try:
+                    WebhookRouteConfig.bind(
+                        k,
+                        candidate,
+                        headers={},
+                        request_profile=request_profile,
+                    )
+                except WebhookContractError as exc:
+                    logger.warning("[webhook] Dynamic route '%s' skipped: %s", k, exc)
+                    continue
+                effective_secret = candidate.get("secret", self._global_secret)
+                if not isinstance(effective_secret, str) or not effective_secret:
+                    logger.warning(
+                        "[webhook] Dynamic route '%s' skipped: 'secret' is "
+                        "missing or empty. Set a valid HMAC secret, or use "
+                        "'%s' to explicitly disable auth (testing only).",
+                        k,
+                        _INSECURE_NO_AUTH,
+                    )
+                    continue
+                if effective_secret == _INSECURE_NO_AUTH and not _is_loopback_host(
+                    self._host
+                ):
+                    logger.warning(
+                        "[webhook] Dynamic route '%s' skipped: INSECURE_NO_AUTH "
+                        "is only allowed on loopback hosts. Current host: '%s'.",
+                        k,
+                        self._host,
+                    )
+                    continue
+                new_dynamic[k] = candidate
+
+            candidate_routes = {**new_dynamic, **self._static_routes}
+            candidate_dynamic = new_dynamic
+            self._bind_route_authentication_authorities(candidate_routes)
+            self._dynamic_routes = new_dynamic
+            self._routes = candidate_routes
+            self._dynamic_routes_content_sha256 = observed_digest
+            self._dynamic_routes_file_identity = observed_identity
+            self._dynamic_routes_rejected_content_sha256 = None
+            self._dynamic_routes_rejected_file_identity = None
+            self._dynamic_routes_transient_file_identity = None
+            self._dynamic_routes_retry_after = 0.0
+            self._dynamic_routes_file_present = True
+            logger.info(
+                "[webhook] Reloaded %d dynamic route(s): %s",
+                len(self._dynamic_routes),
+                ", ".join(self._dynamic_routes.keys()) or "(none)",
+            )
+        except (
+            WebhookContractError,
+            WebhookLedgerCapacityError,
+            WebhookLedgerTransitionError,
+        ) as exc:
+            # Keep the last complete, durably bound snapshot. A candidate that
+            # cannot be validated must never be partially published according
+            # to JSON order.
+            if observed_identity is not None:
+                self._dynamic_routes_rejected_file_identity = observed_identity
+                self._dynamic_routes_rejected_content_sha256 = observed_digest
+                self._dynamic_routes_file_present = True
+            if candidate_dynamic is not None:
+                self._withdraw_changed_dynamic_authorities(candidate_dynamic)
+            logger.error("[webhook] Failed to reload dynamic routes: %s", exc)
+        except Exception as exc:
+            # Store or filesystem failures are retried after a short bounded
+            # delay. They must not mark unapplied configuration as current,
+            # otherwise a one-off SQLite fault leaves a revoked key live.
+            if observed_identity is not None:
+                self._dynamic_routes_transient_file_identity = observed_identity
+                self._dynamic_routes_retry_after = time.monotonic() + 1.0
+                self._dynamic_routes_file_present = True
+            if candidate_dynamic is not None:
+                # Availability of the global binding store cannot override a
+                # locally observed revocation. Preserve only routes whose old
+                # immutable authority exactly matches the candidate and retry
+                # publication later.
+                self._withdraw_changed_dynamic_authorities(candidate_dynamic)
+            logger.error(
+                "[webhook] Transient dynamic route reload failure; will retry: %s",
+                exc,
+            )
+
+    def _resolve_request_profile(
+        self,
+        request: "web.Request",
+        route_config: Optional[Mapping[str, Any]] = None,
+    ):
+        """Resolve + validate the /p/<profile>/ URL prefix on a webhook request.
+
+        Returns:
+          - ``None`` when no profile prefix is present.
+          - the profile name (str) when multiplexing serves it, or when a
+            single-profile self prefix matches an explicitly bound route.
+            For an ordinary default-bound route, that same self prefix returns
+            ``None`` so the canonical ``default`` stamp retains its authority.
+          - ``_PROFILE_REJECTED`` when a prefix is present but the profile is
+            unknown/unconfigured, or names a profile this single-profile
+            gateway does not serve (handler returns 404).
+        """
+        profile = (request.match_info.get("profile") or "").strip()
+        if not profile:
+            return None
+        runner = self.gateway_runner
+        cfg = getattr(runner, "config", None)
+        if getattr(cfg, "multiplex_profiles", False) is not True:
+            # Prefix supplied but multiplexing is off. Only a self-referential
+            # prefix (naming this gateway's own profile) may fall through to
+            # the bare route; anything else fails closed — silently ignoring
+            # the prefix served the gateway owner's routes/config under
+            # another profile's URL (#91583 defect 2).
+            try:
+                from hermes_cli.profiles import profile_matches_home
+
+                if profile_matches_home(profile):
+                    configured_profile = (
+                        route_config.get("profile")
+                        if isinstance(route_config, Mapping)
+                        and "profile" in route_config
+                        else None
+                    )
+                    if (
+                        isinstance(configured_profile, str)
+                        and configured_profile.strip() == profile
+                    ):
+                        return profile
+                    return None
+            except Exception:
+                pass
+            return _PROFILE_REJECTED
+        try:
+            from hermes_cli.profiles import profiles_to_serve
+
+            served = {
+                name
+                for name, _ in profiles_to_serve(
+                    multiplex=True,
+                    profile_allowlist=getattr(cfg, "multiplex_profile_allowlist", None),
+                )
+            }
+        except Exception:
+            return _PROFILE_REJECTED
+        if profile not in served:
+            return _PROFILE_REJECTED
+        return profile
+
+    @staticmethod
+    def _route_allows_profile(
+        route_config: dict,
+        request_profile: Optional[str],
+    ) -> bool:
+        """Compatibility facade over the canonical route-binding authority."""
+
+        try:
+            WebhookRouteConfig.bind(
+                "profile-check",
+                route_config,
+                headers={},
+                request_profile=request_profile,
+            )
+        except WebhookContractError:
+            return False
+        return True
+
+    async def _handle_webhook(self, request: "web.Request") -> "web.Response":
+        """Authenticate, durably admit, snapshot, and dispatch one webhook."""
+
+        if not self._accepting_webhooks:
+            return web.json_response(
+                {"status": "unavailable", "error": "Webhook intake is draining"},
+                status=503,
+                headers={"Retry-After": "5"},
+            )
+
+        self._reload_dynamic_routes()
+        route_name = request.match_info.get("route_name", "")
+        live_route_config = self._routes.get(route_name)
+        if not isinstance(live_route_config, dict):
+            return web.json_response(
+                {"error": f"Unknown route: {route_name}"}, status=404
+            )
+        if live_route_config.get(
+            "secret", self._global_secret
+        ) == _INSECURE_NO_AUTH and not _is_loopback_host(self._host):
+            return web.json_response(
+                {"error": "Local auth bypass is not allowed on this host"},
+                status=403,
+            )
+        profile = self._resolve_request_profile(request, live_route_config)
+        if profile is _PROFILE_REJECTED:
+            return web.json_response(
+                {"error": "Unknown or unconfigured profile"}, status=404
+            )
+        try:
+            preliminary_route = WebhookRouteConfig.bind(
+                route_name,
+                live_route_config,
+                headers=request.headers,
+                request_profile=profile,
+            )
+        except WebhookRouteScopeError:
+            return web.json_response(
+                {"error": f"Unknown route: {route_name}"}, status=404
+            )
+        except WebhookContractError:
+            return web.json_response(
+                {
+                    "status": "failed",
+                    "error": "Webhook route is misconfigured",
+                },
+                status=500,
+            )
+        if not self._intake_is_authoritative(preliminary_route.profile):
+            return web.json_response(
+                {"status": "unavailable", "error": "Webhook intake is not active"},
+                status=503,
+                headers={"Retry-After": "5"},
+            )
+        if not preliminary_route.enabled:
+            return web.json_response(
+                {"error": f"Route disabled: {route_name}"}, status=403
+            )
+        try:
+            if self._authenticated_route_snapshot is None:
+                # Compatibility for direct handler tests/embedders. A real
+                # listener publishes every bundle before it opens intake.
+                self._bind_route_authentication_authorities(self._routes)
+            route_bundle = self._authenticated_route_bundles.get(route_name)
+            if route_bundle is None or (
+                _snapshot_route_config(live_route_config) != route_bundle.route_config
+            ):
+                raise WebhookContractError(
+                    "webhook route has no exact published authority bundle"
+                )
+        except (WebhookContractError, WebhookLedgerError) as exc:
+            logger.error("[webhook] Invalid route %s: %s", route_name, exc)
+            target_unavailable = "not an outbound webhook target" in str(exc)
+            return web.json_response(
+                {
+                    "status": "unavailable" if target_unavailable else "failed",
+                    "error": (
+                        "Webhook target or grant is unavailable"
+                        if target_unavailable
+                        else "Webhook route is misconfigured"
+                    ),
+                },
+                status=503 if target_unavailable else 500,
+            )
+        route_config = route_bundle.route_config
+        try:
+            bound_route = WebhookRouteConfig.bind(
+                route_name,
+                route_config,
+                headers=request.headers,
+                request_profile=profile,
+            )
+        except WebhookRouteScopeError:
+            logger.warning(
+                "[webhook] Route %s is not authorized for profile %r",
+                route_name,
+                profile or "default",
+            )
+            return web.json_response(
+                {"error": f"Unknown route: {route_name}"}, status=404
+            )
+        except WebhookContractError as exc:
+            logger.error("[webhook] Invalid route %s: %s", route_name, exc)
+            return web.json_response(
+                {"error": "Webhook route is misconfigured"}, status=500
+            )
+        content_length = request.content_length or 0
+        if content_length > self._max_body_bytes:
+            return web.json_response({"error": "Payload too large"}, status=413)
+        content_encoding = request.headers.get("Content-Encoding", "").strip().lower()
+        if content_encoding not in {"", "identity"}:
+            return web.json_response(
+                {"error": "Unsupported Content-Encoding"}, status=415
+            )
+        try:
+            raw_body = await request.read()
+        except web.HTTPRequestEntityTooLarge:
+            return web.json_response({"error": "Payload too large"}, status=413)
+        except Exception as exc:
+            logger.error("[webhook] Failed to read body: %s", exc)
+            return web.json_response({"error": "Bad request"}, status=400)
+        if len(raw_body) > self._max_body_bytes:
+            return web.json_response({"error": "Payload too large"}, status=413)
+        if not self._route_bundle_is_current(route_name, route_bundle):
+            return web.json_response(
+                {
+                    "status": "unavailable",
+                    "error": "Webhook route authority changed during request",
+                },
+                status=503,
+            )
+
+        secret = route_bundle.secret
+        if not isinstance(secret, str) or not secret:
+            logger.error("[webhook] Route %s has no HMAC secret", route_name)
+            return web.json_response(
+                {"error": "Webhook route is missing an HMAC secret"}, status=403
+            )
+        if secret == _INSECURE_NO_AUTH and not _is_loopback_host(self._host):
+            return web.json_response(
+                {"error": "Local auth bypass is not allowed on this host"},
+                status=403,
+            )
+        if not self._route_owns_unique_authenticated_secret(
+            route_name,
+            secret,
+            bound_route.signature_mode,
+            route_bundle,
+        ):
+            logger.error(
+                "[webhook] Route %s does not own a unique authentication secret",
+                route_name,
+            )
+            return web.json_response(
+                {
+                    "status": "failed",
+                    "error": "Webhook route authentication is misconfigured",
+                },
+                status=500,
+            )
+        if secret == _INSECURE_NO_AUTH:
+            verification_receipt = self._issue_local_bypass_receipt(
+                request, raw_body, bound_route
+            )
+        else:
+            verification_receipt = self._verify_signature_receipt(
+                request, raw_body, secret, bound_route
+            )
+            if verification_receipt is None:
+                logger.warning("[webhook] Invalid signature for route %s", route_name)
+                return web.json_response({"error": "Invalid signature"}, status=401)
+
+        media_type = (
+            request.headers.get("Content-Type", "").split(";", 1)[0].strip().lower()
+        )
+        if media_type != "application/json" and not media_type.endswith("+json"):
+            return web.json_response({"error": "Unsupported Content-Type"}, status=415)
+        try:
+            parsed_payload = json.loads(
+                raw_body,
+                parse_constant=_reject_nonfinite_json,
+                object_pairs_hook=_reject_duplicate_json_keys,
+            )
+        except (
+            json.JSONDecodeError,
+            UnicodeDecodeError,
+            ValueError,
+            RecursionError,
+        ):
+            return web.json_response({"error": "Cannot parse JSON body"}, status=400)
+        if not isinstance(parsed_payload, dict):
+            return web.json_response(
+                {"error": "JSON body must be an object"}, status=400
+            )
+        try:
+            envelope = WebhookEnvelope.from_receipt(
+                verification_receipt,
+                raw_body=raw_body,
+                media_type=media_type,
+                authority_profile=str(route_bundle.authority[0]),
+            )
+        except WebhookPayloadContractError as exc:
+            logger.warning(
+                "[webhook] Authenticated payload rejected for route %s: %s",
+                route_name,
+                exc,
+            )
+            return web.json_response(
+                {"error": "Invalid authenticated webhook payload"}, status=400
+            )
+        except WebhookContractError as exc:
+            logger.warning(
+                "[webhook] Authenticated metadata rejected for route %s: %s",
+                route_name,
+                exc,
+            )
+            return web.json_response(
+                {"error": "Invalid authenticated webhook metadata"}, status=401
+            )
+
+        # Only authenticated identity material may enter the execution carrier.
+        # Provider IDs observed beside a body-only MAC remain diagnostics and
+        # must not become the event message ID or any downstream reply anchor.
+        delivery_id = envelope.delivery_id
+        # Recheck at the last synchronous seam before admission. Registry
+        # removal and disconnect run on this event loop, so no retirement can
+        # interleave between this check and the non-awaiting SQLite claim.
+        if not self._intake_is_authoritative(bound_route.profile):
+            return web.json_response(
+                {"status": "unavailable", "error": "Webhook intake is draining"},
+                status=503,
+                headers={"Retry-After": "5"},
+            )
+        try:
+            admission = self._operation_ledger.admit(envelope)
+        except WebhookLedgerError:
+            logger.exception("[webhook] Durable admission failed for %s", route_name)
+            self._fence_intake_for_durable_transition_failure(
+                "durable admission failure"
+            )
+            return web.json_response(
+                {"status": "unavailable", "error": "Durable admission failed"},
+                status=503,
+                headers={"Retry-After": "5"},
+            )
+        if admission.disposition is AdmitDisposition.CONFLICT:
+            return web.json_response(
+                {
+                    "status": "conflict",
+                    "delivery_id": delivery_id,
+                    "error": "Replay identity was reused with a different body",
+                },
+                status=409,
+            )
+        if admission.disposition is AdmitDisposition.INDETERMINATE:
+            return web.json_response(
+                {
+                    "status": "indeterminate",
+                    "delivery_id": delivery_id,
+                    "error": "Previous outcome requires reconciliation",
+                },
+                status=409,
+            )
+        if admission.disposition is AdmitDisposition.SATURATED:
+            global_saturation = admission.saturation not in {
+                AdmitSaturationReason.SCOPE_RECORD_LIMIT,
+                AdmitSaturationReason.SCOPE_STORAGE_LIMIT,
+            }
+            if global_saturation:
+                self._global_ledger_saturated = True
+            capacity_scope = "global" if global_saturation else "route scope"
+            return web.json_response(
+                {
+                    "status": "unavailable",
+                    "error": (
+                        f"Durable webhook evidence capacity exhausted for "
+                        f"{capacity_scope}"
+                    ),
+                },
+                status=503,
+            )
+        if admission.disposition is AdmitDisposition.DUPLICATE:
+            return web.json_response(
+                {"status": "duplicate", "delivery_id": delivery_id}, status=200
+            )
+        if admission.disposition is AdmitDisposition.ACTIVE:
+            active = admission.authority
+            if (
+                active is not None
+                and active.state is OperationState.DELIVERY_READY
+                and active.owner_instance == self._operation_ledger.instance_id
+            ):
+                resumed = await self._invoke_staged_target(active)
+                target_kind = (
+                    str(active.target_snapshot.get("kind"))
+                    if isinstance(active.target_snapshot, Mapping)
+                    else None
+                )
+                return self._target_http_response(
+                    resumed,
+                    route=active.route,
+                    delivery_id=delivery_id,
+                    target_kind=target_kind,
+                )
+            return web.json_response(
+                {"status": "in_progress", "delivery_id": delivery_id}, status=202
+            )
+
+        authority = admission.authority
+        if admission.disposition is not AdmitDisposition.ACCEPTED or authority is None:
+            logger.error("[webhook] Ledger returned an invalid admission result")
+            return web.json_response(
+                {"status": "unavailable", "error": "Webhook admission failed"},
+                status=503,
+            )
+        self._global_ledger_saturated = False
+        script_started = False
+
+        def release_before_effect() -> bool:
+            try:
+                released = self._operation_ledger.release_pre_effect(authority)
+                if not released:
+                    logger.warning(
+                        "[webhook] Claim was not releasable for %s",
+                        authority.operation_id,
+                    )
+                    self._fence_intake_for_durable_transition_failure(
+                        "pre-effect release authority loss"
+                    )
+                return released
+            except BaseException as exc:
+                logger.exception(
+                    "[webhook] Could not release operation %s",
+                    authority.operation_id,
+                )
+                self._fence_intake_for_durable_transition_failure(
+                    "pre-effect release failure"
+                )
+                if not isinstance(exc, Exception):
+                    raise
+                return False
+
+        # Resource-backed authority validation is deliberately paid only by a
+        # newly admitted identity. Durable duplicates/conflicts/active retries
+        # above are indexed ledger results and cannot amplify filesystem,
+        # profile, skill, or adapter-resolution work.
+        if not self._route_bundle_is_current(route_name, route_bundle):
+            release_before_effect()
+            return web.json_response(
+                {
+                    "status": "unavailable",
+                    "error": "Webhook route authority changed during request",
+                },
+                status=503,
+            )
+
+        # Charge each fresh authenticated identity before any resource-backed
+        # proof. Durable duplicates never reach this path, while unique IDs
+        # over quota stay an indexed release + 429.
+        if not self._record_rate_limit_hit(
+            route_name,
+            time.time(),
+            profile=envelope.authority_profile,
+        ):
+            if not release_before_effect():
+                return web.json_response(
+                    {
+                        "status": "unavailable",
+                        "error": "Rate-limited claim could not be released",
+                    },
+                    status=503,
+                )
+            return web.json_response(
+                {"error": "Rate limit exceeded"},
+                status=429,
+                headers={"Retry-After": str(int(_RATE_WINDOW_SECONDS))},
+            )
+
+        if not self._authentication_authority_proof_slots.acquire(blocking=False):
+            release_before_effect()
+            return web.json_response(
+                {
+                    "status": "unavailable",
+                    "error": "Webhook authentication authority is busy",
+                },
+                status=503,
+                headers={"Retry-After": "1"},
+            )
+
+        slot_detached = False
+
+        async def run_authority_worker(
+            worker: Callable[..., Any],
+            *args: Any,
+        ) -> Any:
+            nonlocal slot_detached
+            task = asyncio.create_task(asyncio.to_thread(worker, *args))
+            try:
+                return await asyncio.shield(task)
+            except asyncio.CancelledError:
+                slot_detached = True
+
+                def release_when_worker_exits(completed: asyncio.Task) -> None:
+                    try:
+                        completed.exception()
+                    except asyncio.CancelledError:
+                        pass
+                    except Exception:
+                        pass
+                    self._authentication_authority_proof_slots.release()
+
+                task.add_done_callback(release_when_worker_exits)
+                raise
+
+        try:
+            durable_bindings = self._route_bundle_authentication_bindings(route_bundle)
+            authority_error: Optional[Exception] = None
+            durable_authority_matches = True
+            if durable_bindings:
+                try:
+                    durable_authority_matches = await run_authority_worker(
+                        self._authentication_authority_ledger.authentication_keys_match,
+                        durable_bindings,
+                    )
+                except asyncio.CancelledError:
+                    release_before_effect()
+                    raise
+                except Exception as exc:
+                    authority_error = exc
+                    durable_authority_matches = False
+                except BaseException:
+                    release_before_effect()
+                    raise
+            bundle_still_current = self._route_bundle_is_current(
+                route_name,
+                route_bundle,
+            )
+            if not durable_authority_matches or not bundle_still_current:
+                release_before_effect()
+                withdrew = False
+                if not durable_authority_matches and bundle_still_current:
+                    withdrew = self._withdraw_live_route(route_name, route_bundle)
+                if authority_error is not None:
+                    logger.error(
+                        "[webhook] Durable authentication authority proof failed "
+                        "for %s: %s",
+                        route_name,
+                        authority_error,
+                    )
+                return web.json_response(
+                    {
+                        "status": "unavailable",
+                        "error": (
+                            "Webhook authentication authority was withdrawn"
+                            if withdrew
+                            else "Webhook route authority changed during request"
+                        ),
+                    },
+                    status=503,
+                )
+
+            try:
+                live_authority_matches = await run_authority_worker(
+                    self._live_route_authority_matches,
+                    route_name,
+                    route_bundle,
+                )
+            except asyncio.CancelledError:
+                release_before_effect()
+                raise
+            except Exception as exc:
+                release_before_effect()
+                logger.error(
+                    "[webhook] Live route authority proof failed for %s: %s",
+                    route_name,
+                    exc,
+                )
+                return web.json_response(
+                    {
+                        "status": "unavailable",
+                        "error": "Webhook route authority proof failed",
+                    },
+                    status=503,
+                )
+            except BaseException:
+                release_before_effect()
+                raise
+            bundle_still_current = self._route_bundle_is_current(
+                route_name,
+                route_bundle,
+            )
+            if not live_authority_matches or not bundle_still_current:
+                release_before_effect()
+                withdrew = False
+                if not live_authority_matches and bundle_still_current:
+                    withdrew = self._withdraw_live_route(route_name, route_bundle)
+                if withdrew:
+                    logger.error(
+                        "[webhook] Withdrew route %s after its effective authority "
+                        "changed; rotate the route secret before re-enabling it",
+                        route_name,
+                    )
+                return web.json_response(
+                    {
+                        "status": "unavailable",
+                        "error": (
+                            "Webhook route authority changed and was withdrawn"
+                            if withdrew
+                            else "Webhook route authority changed during request"
+                        ),
+                    },
+                    status=503,
+                )
+        finally:
+            if not slot_detached:
+                self._authentication_authority_proof_slots.release()
+
+        payload = envelope.mutable_payload()
+        event_type = envelope.event_type
+        source = self._source_for_envelope(envelope)
+
+        def settle_without_effect(reason: str) -> bool:
+            try:
+                settled = self._operation_ledger.settle_no_effect(authority, reason)
+            except BaseException as exc:
+                logger.exception(
+                    "[webhook] Could not settle operation %s", authority.operation_id
+                )
+                self._fence_intake_for_durable_transition_failure(
+                    "no-effect settlement failure"
+                )
+                if not isinstance(exc, Exception):
+                    raise
+                return False
+            if not settled:
+                self._fence_intake_for_durable_transition_failure(
+                    "no-effect settlement authority loss"
+                )
+            return settled
+
+        if bound_route.events and event_type not in bound_route.events:
+            if not settle_without_effect("event not selected by route"):
+                return web.json_response(
+                    {"status": "unavailable", "error": "Settlement failed"},
+                    status=503,
+                )
+            return web.json_response({"status": "ignored", "event": event_type})
+
+        def evaluate_route_filters() -> bool:
+            with self._profile_runtime_context(source):
+                filters_match = self._route_processor.route_filters_match(
+                    route_bundle.filter_route_config,
+                    payload,
+                    event_type,
+                    verification_receipt.verified_headers,
+                )
+            return filters_match
+
+        filter_worker_slots = _route_worker_slots
+        if not filter_worker_slots.acquire(blocking=False):
+            release_before_effect()
+            return web.json_response(
+                {
+                    "status": "unavailable",
+                    "error": "Webhook route workers are busy",
+                },
+                status=503,
+                headers={"Retry-After": "1"},
+            )
+        try:
+            filters_match = await self._run_retained_route_worker(
+                evaluate_route_filters,
+                slot_gate=filter_worker_slots,
+            )
+        except asyncio.CancelledError:
+            release_before_effect()
+            raise
+        except Exception:
+            release_before_effect()
+            logger.exception("[webhook] Route filter evaluation failed")
+            return web.json_response(
+                {"status": "failed", "error": "Webhook route filter failed"},
+                status=500,
+            )
+        except BaseException:
+            release_before_effect()
+            raise
+        if not self._route_bundle_is_current(route_name, route_bundle):
+            release_before_effect()
+            return web.json_response(
+                {
+                    "status": "unavailable",
+                    "error": "Webhook route authority changed during request",
+                },
+                status=503,
+            )
+        if not filters_match:
+            if not settle_without_effect("route filter did not match"):
+                return web.json_response(
+                    {"status": "unavailable", "error": "Settlement failed"},
+                    status=503,
+                )
+            return web.json_response({
+                "status": "ignored",
+                "reason": "filter",
+                "route": route_name,
+            })
+
+        deliver_only = route_config.get("deliver_only", False)
+        if not isinstance(deliver_only, bool):
+            release_before_effect()
+            return web.json_response(
+                {"error": "Webhook route has invalid deliver_only configuration"},
+                status=500,
+            )
+        try:
+            prepared_target = route_bundle.prepared_target
+            admitted_toolsets = (
+                [] if deliver_only else list(route_bundle.effective_toolsets)
+            )
+        except WebhookContractError as exc:
+            release_before_effect()
+            logger.error("[webhook] Target/grant preflight failed: %s", exc)
+            return web.json_response(
+                {
+                    "status": "unavailable",
+                    "error": "Webhook target or grant is unavailable",
+                },
+                status=503,
+                headers={"Retry-After": "5"},
+            )
+        except Exception:
+            release_before_effect()
+            logger.exception("[webhook] Target/grant preflight failed")
+            return web.json_response(
+                {"status": "unavailable", "error": "Webhook preflight failed"},
+                status=503,
+                headers={"Retry-After": "5"},
+            )
+
+        prepared_script: Optional[WebhookPreparedScript] = None
+        if route_config.get("script"):
+            prepared_script = route_bundle.prepared_script
+            if prepared_script is None:
+                release_before_effect()
+                logger.error(
+                    "[webhook] Frozen script authority is unavailable for %s",
+                    route_name,
+                )
+                return web.json_response(
+                    {"status": "failed", "error": "Webhook route script failed"},
+                    status=500,
+                )
+            script_worker_slots = _route_worker_slots
+            if not script_worker_slots.acquire(blocking=False):
+                release_before_effect()
+                return web.json_response(
+                    {
+                        "status": "unavailable",
+                        "error": "Webhook route workers are busy",
+                    },
+                    status=503,
+                    headers={"Retry-After": "1"},
+                )
+            try:
+                current_profile_generation = await asyncio.to_thread(
+                    self._current_profile_authority_generation,
+                    envelope.authority_profile,
+                    route_name=route_name,
+                )
+            except asyncio.CancelledError:
+                script_worker_slots.release()
+                release_before_effect()
+                raise
+            except Exception as exc:
+                script_worker_slots.release()
+                release_before_effect()
+                self._withdraw_live_route(route_name, route_bundle)
+                logger.error(
+                    "[webhook] Script profile authority is unavailable for %s: %s",
+                    route_name,
+                    exc,
+                )
+                return web.json_response(
+                    {
+                        "status": "unavailable",
+                        "error": "Webhook script profile authority is unavailable",
+                    },
+                    status=503,
+                )
+            if not secrets.compare_digest(
+                route_bundle.profile_generation,
+                current_profile_generation,
+            ):
+                script_worker_slots.release()
+                release_before_effect()
+                self._withdraw_live_route(route_name, route_bundle)
+                return web.json_response(
+                    {
+                        "status": "unavailable",
+                        "error": "Webhook script profile authority changed",
+                    },
+                    status=503,
+                )
+            try:
+                script_started = self._operation_ledger.mark_script_started(authority)
+            except BaseException as exc:
+                script_worker_slots.release()
+                logger.exception("[webhook] Script start fence failed")
+                self._fence_intake_for_durable_transition_failure(
+                    "script-start transition failure"
+                )
+                if not isinstance(exc, Exception):
+                    raise
+                return web.json_response(
+                    {"status": "unavailable", "error": "Script authority failed"},
+                    status=503,
+                )
+            if not script_started:
+                script_worker_slots.release()
+                self._fence_intake_for_durable_transition_failure(
+                    "script-start authority loss"
+                )
+                return web.json_response(
+                    {"status": "unavailable", "error": "Script authority was lost"},
+                    status=503,
+                )
+
+            script_cancellation = threading.Event()
+
+            def execute_route_script():
+                with self._profile_runtime_context(source):
+                    return self._route_processor.run_prepared_script(
+                        prepared_script,
+                        payload,
+                        cancellation_event=script_cancellation,
+                    )
+
+            try:
+                script_result = await self._run_retained_route_worker(
+                    execute_route_script,
+                    cancellation_event=script_cancellation,
+                    slot_gate=script_worker_slots,
+                )
+            except asyncio.CancelledError:
+                self._mark_indeterminate_or_fence(
+                    authority,
+                    "webhook route script was cancelled after start",
+                    context="script cancellation",
+                )
+                raise
+            except BaseException as exc:
+                self._mark_indeterminate_or_fence(
+                    authority,
+                    exc,
+                    context="unexpected script processing failure",
+                )
+                if not isinstance(exc, Exception):
+                    raise
+                logger.exception("[webhook] Route script processing failed")
+                return web.json_response(
+                    {
+                        "status": "indeterminate",
+                        "error": "Webhook route script requires reconciliation",
+                    },
+                    status=500,
+                )
+            if not self._route_bundle_is_current(route_name, route_bundle):
+                self._mark_indeterminate_or_fence(
+                    authority,
+                    "webhook route authority changed after script start",
+                    context="post-script authority change",
+                )
+                return web.json_response(
+                    {
+                        "status": "indeterminate",
+                        "error": "Webhook route script requires reconciliation",
+                    },
+                    status=500,
+                )
+            if script_result.disposition is WebhookScriptDisposition.IGNORED:
+                if not settle_without_effect("route script suppressed delivery"):
+                    return web.json_response(
+                        {"status": "unavailable", "error": "Settlement failed"},
+                        status=503,
+                    )
+                return web.json_response({
+                    "status": "ignored",
+                    "reason": "script",
+                    "route": route_name,
+                })
+            if script_result.disposition is not WebhookScriptDisposition.CONTINUE:
+                self._mark_indeterminate_or_fence(
+                    authority,
+                    script_result.error or "route script outcome is unknown",
+                    context="unknown script disposition",
+                )
+                return web.json_response(
+                    {
+                        "status": "indeterminate",
+                        "error": "Webhook route script requires reconciliation",
+                    },
+                    status=500,
+                )
+            payload = script_result.payload or payload
+
+        try:
+            prompt = self._render_prompt(
+                route_config.get("prompt", ""), payload, event_type, route_name
+            )
+            if route_bundle.prepared_skill is not None:
+                prompt = route_bundle.prepared_skill.render(prompt)
+            rendered_extra = self._render_delivery_extra(
+                route_config.get("deliver_extra", {}), payload
+            )
+            with self._profile_runtime_context(source):
+                target_snapshot = self._materialize_target(
+                    prepared_target, rendered_extra
+                )
+        except BaseException as exc:
+            if script_started:
+                self._mark_indeterminate_or_fence(
+                    authority,
+                    exc,
+                    context="post-script materialization failure",
+                )
+            else:
+                release_before_effect()
+            if not isinstance(exc, Exception):
+                raise
+            logger.error(
+                "[webhook] Prompt/target materialization failed for %s: %s",
+                route_name,
+                exc,
+            )
+            return web.json_response(
+                {"error": "Webhook route has invalid execution configuration"},
+                status=500,
+            )
+
+        event_snapshot = {
+            "v": 1,
+            "mode": "direct" if deliver_only else "agent",
+            "text": prompt,
+            "payload": payload,
+            "message_id": delivery_id,
+            "source": source.to_dict(),
+        }
+        grant_snapshot = {
+            "v": 1,
+            "toolsets": admitted_toolsets,
+            "profile_generation": route_bundle.profile_generation,
+        }
+        try:
+            prompt_size = len(prompt.encode("utf-8"))
+            event_snapshot_size = _canonical_snapshot_size(event_snapshot)
+            target_snapshot_size = _canonical_snapshot_size(target_snapshot)
+            grant_snapshot_size = _canonical_snapshot_size(grant_snapshot)
+        except BaseException as exc:
+            if script_started:
+                self._mark_indeterminate_or_fence(
+                    authority,
+                    exc,
+                    context="invalid post-script carrier",
+                )
+                if not isinstance(exc, Exception):
+                    raise
+                return web.json_response(
+                    {
+                        "status": "indeterminate",
+                        "error": "Script produced an invalid durable carrier",
+                    },
+                    status=500,
+                )
+            release_before_effect()
+            if not isinstance(exc, Exception):
+                raise
+            return web.json_response(
+                {"error": "Webhook execution carrier is invalid"}, status=500
+            )
+        carrier_too_large = (
+            prompt_size > _MAX_RENDERED_PROMPT_BYTES
+            or event_snapshot_size > _MAX_DURABLE_EVENT_SNAPSHOT_BYTES
+            or target_snapshot_size > _MAX_DURABLE_AUTHORITY_SNAPSHOT_BYTES
+            or grant_snapshot_size > _MAX_DURABLE_AUTHORITY_SNAPSHOT_BYTES
+        )
+        if carrier_too_large:
+            if script_started:
+                self._mark_indeterminate_or_fence(
+                    authority,
+                    "script output exceeded durable webhook carrier limits",
+                    context="oversized post-script carrier",
+                )
+                return web.json_response(
+                    {
+                        "status": "indeterminate",
+                        "error": "Script output exceeded durable carrier limits",
+                    },
+                    status=500,
+                )
+            release_before_effect()
+            return web.json_response(
+                {"error": "Payload expands beyond durable webhook limits"},
+                status=413,
+            )
+        try:
+            prepared = self._operation_ledger.prepare(
+                authority,
+                event_snapshot=event_snapshot,
+                target_snapshot=target_snapshot,
+                grant_snapshot=grant_snapshot,
+            )
+        except BaseException as exc:
+            if script_started:
+                self._mark_indeterminate_or_fence(
+                    authority,
+                    exc,
+                    context="post-script durable prepare failure",
+                )
+            else:
+                release_before_effect()
+            if not isinstance(exc, Exception):
+                raise
+            logger.exception("[webhook] Durable prepare failed")
+            return web.json_response(
+                {"status": "unavailable", "error": "Webhook prepare failed"},
+                status=503,
+                headers={"Retry-After": "5"},
+            )
+
+        if deliver_only:
+            try:
+                generation_is_current = await asyncio.to_thread(
+                    self._recovery_profile_generation_is_current,
+                    prepared,
+                )
+            except asyncio.CancelledError:
+                self._mark_indeterminate_or_fence(
+                    prepared,
+                    "direct profile generation check was cancelled",
+                    context="direct generation-check cancellation",
+                )
+                raise
+            except BaseException as exc:
+                self._mark_indeterminate_or_fence(
+                    prepared,
+                    exc,
+                    context="direct generation-check failure",
+                )
+                if not isinstance(exc, Exception):
+                    raise
+                return web.json_response(
+                    {
+                        "status": "indeterminate",
+                        "error": "Webhook profile authority could not be checked",
+                        "delivery_id": delivery_id,
+                    },
+                    status=503,
+                )
+            if not generation_is_current:
+                self._mark_indeterminate_or_fence(
+                    prepared,
+                    "webhook profile incarnation changed before direct execution",
+                    context="direct profile generation mismatch",
+                )
+                return web.json_response(
+                    {
+                        "status": "indeterminate",
+                        "error": "Webhook profile authority changed",
+                        "delivery_id": delivery_id,
+                    },
+                    status=409,
+                )
+            try:
+                entered_running = self._operation_ledger.mark_running(prepared)
+            except BaseException as exc:
+                logger.exception("[webhook] Direct running gate failed")
+                self._fence_intake_for_durable_transition_failure(
+                    "direct running-gate transition failure"
+                )
+                if not isinstance(exc, Exception):
+                    raise
+                return web.json_response(
+                    {
+                        "status": "unavailable",
+                        "error": "Webhook running authority failed",
+                        "delivery_id": delivery_id,
+                    },
+                    status=503,
+                )
+            if not entered_running:
+                self._fence_intake_for_durable_transition_failure(
+                    "direct running-gate authority loss"
+                )
+                return web.json_response(
+                    {
+                        "status": "unavailable",
+                        "error": "Webhook running authority was lost",
+                        "delivery_id": delivery_id,
+                    },
+                    status=503,
+                )
+            try:
+                staged = self._stage_exact_delivery(
+                    prepared, prompt, {"v": 1, "kind": "direct"}
+                )
+                result = await self._invoke_staged_target(staged)
+            except asyncio.CancelledError:
+                self._mark_indeterminate_or_fence(
+                    prepared,
+                    "direct delivery was cancelled after execution started",
+                    context="direct-delivery cancellation",
+                )
+                raise
+            except BaseException as exc:
+                self._mark_indeterminate_or_fence(
+                    prepared,
+                    exc,
+                    context="direct-delivery failure",
+                )
+                if not isinstance(exc, Exception):
+                    raise
+                logger.exception("[webhook] Direct delivery failed")
+                return web.json_response(
+                    {
+                        "status": "indeterminate",
+                        "error": "Direct delivery failed",
+                        "delivery_id": delivery_id,
+                    },
+                    status=502,
+                )
+            return self._target_http_response(
+                result,
+                route=route_name,
+                delivery_id=delivery_id,
+                target_kind=target_snapshot["kind"],
+            )
+
+        try:
+            event = WebhookMessageEvent(
+                text=prompt,
+                message_type=MessageType.TEXT,
+                source=source,
+                raw_message=_plain_json_snapshot(payload),
+                message_id=delivery_id,
+                webhook_authority=prepared,
+                webhook_envelope=envelope,
+                allow_gateway_control=False,
+            )
+            logger.info(
+                "[webhook] admitted event=%s route=%s operation=%s",
+                event_type,
+                route_name,
+                prepared.operation_id,
+            )
+            task = asyncio.create_task(self.handle_message(event))
+        except BaseException as exc:
+            self._mark_indeterminate_or_fence(
+                prepared,
+                exc,
+                context="admission dispatch failure",
+            )
+            if not isinstance(exc, Exception):
+                raise
+            logger.exception("[webhook] Could not dispatch admitted operation")
+            return web.json_response(
+                {"error": "Webhook dispatch failed", "delivery_id": delivery_id},
+                status=503,
+            )
+        self._background_tasks.add(task)
+
+        def admission_task_done(done: "asyncio.Task") -> None:
+            self._background_tasks.discard(done)
+            failed = done.cancelled()
+            if not failed:
+                try:
+                    failed = done.exception() is not None
+                except BaseException:
+                    failed = True
+            if failed:
+                self._mark_indeterminate_or_fence(
+                    prepared,
+                    "webhook admission task failed",
+                    context="admission task failure",
+                )
+
+        task.add_done_callback(admission_task_done)
+        return web.json_response(
+            {
+                "status": "accepted",
+                "route": route_name,
+                "event": event_type,
+                "delivery_id": delivery_id,
+                "deduplication": envelope.replay_identity.kind.value,
+            },
+            status=202,
+        )

--- a/gateway/platforms/webhook_ledger.py
+++ b/gateway/platforms/webhook_ledger.py
@@ -1,0 +1,5133 @@
+"""Durable authority and settlement ledger for inbound webhook operations.
+
+The webhook HTTP adapter has two facts that must survive an adapter replacement
+or a process restart:
+
+* the provider delivery identity that already owns an execution; and
+* the exact grant and delivery target selected at admission time.
+
+This module owns those facts.  It deliberately contains no HTTP, adapter, or
+agent orchestration.  Callers must durably prepare an operation before they
+dispatch it and must cross the target-attempt gate before invoking an external
+delivery primitive.
+
+The ledger is a guest of the stable Hermes-root ``state.db`` shared across
+profile and multiplex-mode adapters. Like the durable async delegation
+registry, guest connections preserve the journal mode selected by ``SessionDB``
+and apply only the per-connection durability barriers. Every write uses
+``BEGIN IMMEDIATE`` and every connection is closed explicitly.
+
+There is no in-memory fallback.  If SQLite cannot establish or commit the
+authority record, the caller must fail closed before dispatching an effect.
+
+``max_storage_bytes`` is a conservative logical allocation bound for this
+ledger's rows and indexes. The ledger shares ``state.db`` with other Hermes
+state, so it is not a physical cap on that database file or its journal/WAL.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+import sqlite3
+import threading
+import time
+import uuid
+from contextlib import contextmanager
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any, Iterable, Iterator, Mapping, Optional
+
+from hermes_constants import get_hermes_home
+
+
+DEFAULT_MAX_RECORDS = 4096
+MAXIMUM_MAX_RECORDS = 1_000_000
+DEFAULT_MAX_STORAGE_BYTES = 1024 * 1024 * 1024
+MAXIMUM_MAX_STORAGE_BYTES = 64 * 1024 * 1024 * 1024
+DEFAULT_TERMINAL_RETENTION_SECONDS = 30 * 24 * 60 * 60
+DEFAULT_LOCAL_BYPASS_REPLAY_RETENTION_SECONDS = 60 * 60
+_SCHEMA_NAME = "webhook_operation_ledger"
+_SCHEMA_VERSION = 5
+_MAX_ERROR_CHARS = 1024
+_MAX_ERROR_UTF8_BYTES = _MAX_ERROR_CHARS * 4
+_MAX_EXTERNAL_ID_UTF8_BYTES = 512 * 4
+_MAX_LEDGER_TEXT_BYTES = 1024
+_MAX_EVENT_JSON_BYTES = 2 * 1024 * 1024
+_MAX_AUTHORITY_JSON_BYTES = 64 * 1024
+_MAX_SCOPE_CAPACITY_RESERVE = 64
+_MAX_PRUNE_BATCH = 128
+# Recovery is intentionally much smaller than the configurable durable-record
+# ceiling.  One authority can contain multiple MiB of canonical JSON, so even
+# a seemingly modest unbounded recovery query can exhaust the gateway process.
+DEFAULT_RECOVERY_BATCH_SIZE = 8
+MAXIMUM_RECOVERY_BATCH_SIZE = 16
+MAXIMUM_RECOVERY_PROFILES = 256
+# Admission reserves the worst-case durable payload before any effect can run:
+# one event snapshot, one staged delivery, two authority snapshots, bounded
+# scalar/index storage, and SQLite page overhead. Tombstones hold only compact
+# replay proof fields and their indexes. Fixed reservations let admission check
+# total ledger growth in O(1) without scanning permanent history.
+_OPERATION_STORAGE_RESERVATION_BYTES = 5 * 1024 * 1024
+_TOMBSTONE_STORAGE_RESERVATION_BYTES = 16 * 1024
+_AUTH_BINDING_STORAGE_RESERVATION_BYTES = 16 * 1024
+# Authentication-key ownership is permanent evidence, but it must not compete
+# with operation carriers: otherwise a full operation budget can strand a key
+# rotation and leave the superseded verifier live.  These fixed logical caps
+# bound that evidence independently, while the scope cap prevents one route's
+# rotation history from consuming the shared binding reserve.
+_AUTH_BINDING_GLOBAL_LIMIT_BYTES = 16 * 1024 * 1024
+_AUTH_BINDING_SCOPE_LIMIT_BYTES = 1 * 1024 * 1024
+_MAX_AUTH_BINDINGS_PER_AUTHORITY_CHECK = 8
+# A valid v4 operation can carry multiple MiB of JSON. Keep migration
+# validation bounded independently of the configured record/storage ceiling.
+_V4_MIGRATION_VALIDATION_BATCH_SIZE = 8
+MINIMUM_MAX_STORAGE_BYTES = _OPERATION_STORAGE_RESERVATION_BYTES
+_BOUNDED_REPLAY_PREFIXES = ("local_bypass_body_sha256:",)
+
+
+def _scope_storage_limit(max_storage_bytes: int) -> int:
+    """Reserve global room that no single webhook authority scope can consume."""
+
+    if max_storage_bytes <= _OPERATION_STORAGE_RESERVATION_BYTES:
+        return _OPERATION_STORAGE_RESERVATION_BYTES
+    reserve = max(
+        _OPERATION_STORAGE_RESERVATION_BYTES,
+        max_storage_bytes // 4,
+    )
+    return max(
+        _OPERATION_STORAGE_RESERVATION_BYTES,
+        max_storage_bytes - reserve,
+    )
+
+
+class WebhookLedgerError(RuntimeError):
+    """The durable webhook authority store could not answer safely."""
+
+
+class WebhookLedgerTransitionError(WebhookLedgerError):
+    """A caller attempted a state transition it does not own."""
+
+
+class WebhookLedgerConfigurationError(WebhookLedgerError):
+    """Configured limits conflict with deterministic persisted authority."""
+
+
+class WebhookLedgerCapacityError(WebhookLedgerError):
+    """A durable authority quota is exhausted and cannot recover by retry."""
+
+
+class WebhookLedgerCorruptionError(WebhookLedgerError):
+    """Persisted webhook authority data violates the ledger contract."""
+
+
+class OperationState(str, Enum):
+    PREPARING = "preparing"
+    READY = "ready"
+    RUNNING = "running"
+    DELIVERY_READY = "delivery_ready"
+    DELIVERING = "delivering"
+    SETTLED = "settled"
+    INDETERMINATE = "indeterminate"
+
+
+class TargetState(str, Enum):
+    PENDING = "pending"
+    ATTEMPTING = "attempting"
+    CONFIRMED = "confirmed"
+    SUPPRESSED = "suppressed"
+    INDETERMINATE = "indeterminate"
+
+
+class AdmitDisposition(str, Enum):
+    ACCEPTED = "accepted"
+    ACTIVE = "active"
+    DUPLICATE = "duplicate"
+    CONFLICT = "conflict"
+    INDETERMINATE = "indeterminate"
+    SATURATED = "saturated"
+
+
+class AdmitSaturationReason(str, Enum):
+    GLOBAL_RECORD_LIMIT = "global_record_limit"
+    SCOPE_RECORD_LIMIT = "scope_record_limit"
+    GLOBAL_STORAGE_LIMIT = "global_storage_limit"
+    SCOPE_STORAGE_LIMIT = "scope_storage_limit"
+
+
+class TargetAttemptDisposition(str, Enum):
+    STARTED = "started"
+    IN_PROGRESS = "in_progress"
+    CACHED = "cached"
+    INDETERMINATE = "indeterminate"
+
+
+class SettlementKind(str, Enum):
+    CONFIRMED = "confirmed"
+    SUPPRESSED = "suppressed"
+    PRE_EFFECT_FAILED = "pre_effect_failed"
+    INDETERMINATE = "indeterminate"
+
+
+@dataclass(frozen=True)
+class Settlement:
+    """Typed knowledge produced by one exact target attempt."""
+
+    kind: SettlementKind
+    external_id: Optional[str] = None
+    error: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class OperationAuthority:
+    """Immutable durable carrier returned to the execution layer."""
+
+    operation_id: str
+    generation: int
+    session_key: str
+    profile: str
+    route: str
+    provider: str
+    replay_id: str
+    body_sha256: str
+    event_type: str
+    state: OperationState
+    owner_instance: str
+    target_id: Optional[str]
+    target_state: Optional[TargetState]
+    event_snapshot: Optional[Mapping[str, Any]]
+    target_snapshot: Optional[Mapping[str, Any]]
+    grant_snapshot: Optional[Mapping[str, Any]]
+    delivery: Optional["StagedDelivery"]
+
+
+@dataclass(frozen=True)
+class StagedDelivery:
+    """Exact rendered outbound effect persisted before its mutation gate."""
+
+    content: str
+    carrier: Mapping[str, Any]
+    content_sha256: str
+    delivery_sha256: str
+
+
+@dataclass(frozen=True)
+class AdmitResult:
+    disposition: AdmitDisposition
+    authority: Optional[OperationAuthority] = None
+    tombstone: Optional["DeliveryTombstone"] = None
+    saturation: Optional[AdmitSaturationReason] = None
+
+
+@dataclass(frozen=True)
+class DeliveryTombstone:
+    """Compact replay verdict for one terminal provider identity."""
+
+    profile: str
+    route: str
+    provider: str
+    replay_id: str
+    body_sha256: str
+    operation_id: str
+    state: OperationState
+    settled_at: float
+    expires_at: Optional[float]
+
+
+@dataclass(frozen=True)
+class TargetAttempt:
+    disposition: TargetAttemptDisposition
+    operation_id: str
+    generation: int
+    target_id: str
+    content_sha256: str
+    delivery_sha256: str
+    delivery: Optional[StagedDelivery] = None
+    attempt_token: Optional[str] = None
+    owner_instance: Optional[str] = None
+
+
+@dataclass(frozen=True, order=True)
+class RecoveryCursor:
+    """Stable keyset cursor for one bounded recovery scan."""
+
+    created_at: float
+    operation_id: str
+
+
+@dataclass(frozen=True)
+class RecoveryBatch:
+    """One strictly bounded durable-recovery page.
+
+    ``scanned_count`` includes live-owner rows skipped while looking for dead
+    work.  Callers must therefore use ``has_more``/``next_cursor`` rather than
+    infer exhaustion from the number of returned authorities.  The cursor is
+    a keyset continuation over immutable ``(created_at, operation_id)``.
+    """
+
+    event_ready: tuple[OperationAuthority, ...] = ()
+    delivery_ready: tuple[OperationAuthority, ...] = ()
+    released: tuple[str, ...] = ()
+    indeterminate: tuple[str, ...] = ()
+    scanned_count: int = 0
+    has_more: bool = False
+    next_cursor: Optional[RecoveryCursor] = None
+
+    @property
+    def ready(self) -> tuple[OperationAuthority, ...]:
+        """Compatibility alias for pre-agent work only."""
+
+        return self.event_ready
+
+
+def _normalize_recovery_batch_limit(limit: Any) -> int:
+    if (
+        not isinstance(limit, int)
+        or isinstance(limit, bool)
+        or limit < 1
+        or limit > MAXIMUM_RECOVERY_BATCH_SIZE
+    ):
+        raise ValueError(
+            f"recovery batch limit must be between 1 and {MAXIMUM_RECOVERY_BATCH_SIZE}"
+        )
+    return limit
+
+
+def _normalize_recovery_cursor(
+    cursor: Optional[RecoveryCursor],
+) -> Optional[RecoveryCursor]:
+    if cursor is None:
+        return None
+    if not isinstance(cursor, RecoveryCursor):
+        raise ValueError("recovery cursor must be a RecoveryCursor")
+    try:
+        created_at = float(cursor.created_at)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError("recovery cursor timestamp must be finite") from exc
+    if not math.isfinite(created_at):
+        raise ValueError("recovery cursor timestamp must be finite")
+    try:
+        operation_id = _normalize_nonempty(
+            cursor.operation_id,
+            label="recovery cursor operation_id",
+        )
+    except WebhookLedgerError as exc:
+        raise ValueError(str(exc)) from exc
+    if created_at != cursor.created_at or operation_id != cursor.operation_id:
+        raise ValueError("recovery cursor must be canonical")
+    return RecoveryCursor(created_at=created_at, operation_id=operation_id)
+
+
+def _normalize_recovery_profiles(
+    profiles: Optional[Iterable[str]],
+) -> Optional[tuple[str, ...]]:
+    if profiles is None:
+        return None
+    if isinstance(profiles, (str, bytes, Mapping)) or not isinstance(
+        profiles, Iterable
+    ):
+        raise ValueError("recovery profiles must be an iterable of profile names")
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for raw_profile in profiles:
+        if len(normalized) >= MAXIMUM_RECOVERY_PROFILES:
+            raise ValueError(
+                "recovery profiles exceed the supported profile-count limit"
+            )
+        if not isinstance(raw_profile, str):
+            raise ValueError("recovery profile must be a canonical string")
+        try:
+            profile = _normalize_nonempty(
+                raw_profile,
+                label="recovery profile",
+            )
+        except WebhookLedgerError as exc:
+            raise ValueError(str(exc)) from exc
+        if profile != raw_profile:
+            raise ValueError("recovery profile must be canonical")
+        normalized.append(profile)
+        seen.add(profile)
+    return tuple(sorted(seen))
+
+
+def _owner_stamp() -> tuple[int, Optional[int]]:
+    pid = os.getpid()
+    try:
+        from gateway.status import get_process_start_time
+
+        return pid, get_process_start_time(pid)
+    except Exception:
+        return pid, None
+
+
+def _owner_alive(pid: Any, started_at: Any) -> bool:
+    """Return whether an owner stamp still names the same live process."""
+
+    if not pid:
+        return False
+    try:
+        normalized_pid = int(pid)
+    except (TypeError, ValueError):
+        return False
+    if normalized_pid == os.getpid():
+        # The current interpreter is definitive evidence that its PID is live,
+        # even in constrained PID namespaces where psutil cannot enumerate it.
+        current_started_at = _owner_stamp()[1]
+        if started_at is None or current_started_at is None:
+            return True
+        try:
+            return int(current_started_at) == int(started_at)
+        except (TypeError, ValueError):
+            return True
+    try:
+        from gateway.status import _pid_exists, get_process_start_time
+
+        if not _pid_exists(normalized_pid):
+            return False
+        current_start = get_process_start_time(normalized_pid)
+    except Exception:
+        # A liveness probe that cannot establish death must not make work
+        # stealable.  On POSIX, retain the conservative EPERM-means-alive
+        # behavior; never use os.kill(pid, 0) on Windows.
+        if os.name == "nt":
+            return True
+        try:
+            os.kill(normalized_pid, 0)  # windows-footgun: ok - POSIX-only branch
+        except ProcessLookupError:
+            return False
+        except PermissionError:
+            return True
+        except OSError:
+            return True
+        return True
+    if started_at is None or current_start is None:
+        return True
+    try:
+        return int(current_start) == int(started_at)
+    except (TypeError, ValueError):
+        return True
+
+
+def _safe_error(value: object) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value)
+    try:
+        from agent.redact import redact_sensitive_text
+
+        text = redact_sensitive_text(text, force=True)
+    except Exception:
+        pass
+    return text[:_MAX_ERROR_CHARS]
+
+
+def _freeze_json(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return MappingProxyType({
+            str(key): _freeze_json(item) for key, item in value.items()
+        })
+    if isinstance(value, list):
+        return tuple(_freeze_json(item) for item in value)
+    return value
+
+
+def _plain_json(value: Any) -> Any:
+    """Detach supported JSON containers, including immutable projections."""
+
+    if isinstance(value, Mapping):
+        plain: dict[str, Any] = {}
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise TypeError("JSON object keys must be strings")
+            plain[key] = _plain_json(item)
+        return plain
+    if isinstance(value, (list, tuple)):
+        return [_plain_json(item) for item in value]
+    return value
+
+
+def _canonical_json(value: Mapping[str, Any], *, label: str, max_bytes: int) -> str:
+    if not isinstance(value, Mapping):
+        raise WebhookLedgerError(f"{label} must be an object")
+    try:
+        encoded = json.dumps(
+            _plain_json(value),
+            ensure_ascii=False,
+            allow_nan=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+    except (TypeError, ValueError, RecursionError) as exc:
+        raise WebhookLedgerError(f"{label} is not canonical JSON") from exc
+    if len(encoded.encode("utf-8")) > max_bytes:
+        raise WebhookLedgerError(f"{label} exceeds its durable size limit")
+    return encoded
+
+
+def _decode_json(
+    value: Optional[str], *, label: str, max_bytes: int
+) -> Optional[Mapping[str, Any]]:
+    if value is None:
+        return None
+    if not isinstance(value, str) or len(value.encode("utf-8")) > max_bytes:
+        raise WebhookLedgerCorruptionError(
+            f"stored {label} exceeds its durable size limit"
+        )
+
+    def reject_constant(token: str) -> None:
+        raise ValueError(f"non-finite JSON number {token!r}")
+
+    def reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        decoded_object: dict[str, Any] = {}
+        for key, item in pairs:
+            if key in decoded_object:
+                raise ValueError(f"duplicate JSON key {key!r}")
+            decoded_object[key] = item
+        return decoded_object
+
+    try:
+        decoded = json.loads(
+            value,
+            object_pairs_hook=reject_duplicate_keys,
+            parse_constant=reject_constant,
+        )
+    except (json.JSONDecodeError, TypeError, ValueError, RecursionError) as exc:
+        raise WebhookLedgerCorruptionError(f"stored {label} is invalid JSON") from exc
+    if not isinstance(decoded, dict):
+        raise WebhookLedgerCorruptionError(f"stored {label} is not an object")
+    try:
+        canonical = json.dumps(
+            decoded,
+            ensure_ascii=False,
+            allow_nan=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+    except (TypeError, ValueError, RecursionError) as exc:
+        raise WebhookLedgerCorruptionError(
+            f"stored {label} is not canonical JSON"
+        ) from exc
+    if canonical != value:
+        raise WebhookLedgerCorruptionError(
+            f"stored {label} is not the canonical authority snapshot"
+        )
+    return _freeze_json(decoded)
+
+
+def _decode_staged_delivery(
+    value: Optional[str],
+    content_digest: Optional[str],
+    delivery_digest: Optional[str],
+) -> Optional[StagedDelivery]:
+    decoded = _decode_json(
+        value,
+        label="staged delivery",
+        max_bytes=_MAX_EVENT_JSON_BYTES,
+    )
+    if decoded is None:
+        if content_digest is not None or delivery_digest is not None:
+            raise WebhookLedgerCorruptionError(
+                "stored delivery digest has no staged delivery"
+            )
+        return None
+    if set(decoded) != {"carrier", "content"}:
+        raise WebhookLedgerCorruptionError(
+            "stored staged delivery has an invalid shape"
+        )
+    content = decoded["content"]
+    carrier = decoded["carrier"]
+    if not isinstance(content, str) or not isinstance(carrier, Mapping):
+        raise WebhookLedgerCorruptionError(
+            "stored staged delivery has invalid field types"
+        )
+    try:
+        normalized_digest = _normalize_sha256(
+            content_digest, label="stored content_sha256"
+        )
+    except WebhookLedgerError as exc:
+        raise WebhookLedgerCorruptionError(
+            "stored staged delivery digest is invalid"
+        ) from exc
+    actual_digest = content_sha256(content)
+    if normalized_digest != actual_digest:
+        raise WebhookLedgerCorruptionError(
+            "stored staged delivery content does not match its digest"
+        )
+    try:
+        normalized_delivery_digest = _normalize_sha256(
+            delivery_digest, label="stored delivery_sha256"
+        )
+    except WebhookLedgerError as exc:
+        raise WebhookLedgerCorruptionError(
+            "stored staged delivery authority digest is invalid"
+        ) from exc
+    actual_delivery_digest = hashlib.sha256(value.encode("utf-8")).hexdigest()
+    if normalized_delivery_digest != actual_delivery_digest:
+        raise WebhookLedgerCorruptionError(
+            "stored staged delivery carrier does not match its digest"
+        )
+    return StagedDelivery(
+        content=content,
+        carrier=carrier,
+        content_sha256=normalized_digest,
+        delivery_sha256=normalized_delivery_digest,
+    )
+
+
+def _normalize_nonempty(value: Any, *, label: str) -> str:
+    normalized = str(value or "").strip()
+    if not normalized:
+        raise WebhookLedgerError(f"{label} must be non-empty")
+    if len(normalized.encode("utf-8")) > _MAX_LEDGER_TEXT_BYTES:
+        raise WebhookLedgerError(
+            f"{label} exceeds {_MAX_LEDGER_TEXT_BYTES} UTF-8 bytes"
+        )
+    return normalized
+
+
+def _normalize_sha256(value: Any, *, label: str) -> str:
+    normalized = _normalize_nonempty(value, label=label).lower()
+    if len(normalized) != 64 or any(ch not in "0123456789abcdef" for ch in normalized):
+        raise WebhookLedgerError(f"{label} must be a SHA-256 hex digest")
+    return normalized
+
+
+def _normalize_authentication_binding(
+    binding: object,
+) -> tuple[str, str, str, str, str, str]:
+    if isinstance(binding, (str, bytes)) or not isinstance(binding, Iterable):
+        raise WebhookLedgerError("authentication key binding must contain six fields")
+    values = tuple(binding)
+    if len(values) != 6:
+        raise WebhookLedgerError("authentication key binding must contain six fields")
+    (
+        fingerprint,
+        profile,
+        route,
+        provider,
+        signature_mode,
+        policy_sha256,
+    ) = values
+    return (
+        _normalize_sha256(
+            fingerprint,
+            label="authentication key fingerprint",
+        ),
+        _normalize_nonempty(profile, label="authentication key profile"),
+        _normalize_nonempty(route, label="authentication key route"),
+        _normalize_nonempty(provider, label="authentication key provider"),
+        _normalize_nonempty(
+            signature_mode,
+            label="authentication key signature mode",
+        ),
+        _normalize_sha256(
+            policy_sha256,
+            label="authentication policy fingerprint",
+        ),
+    )
+
+
+class WebhookOperationLedger:
+    """SQLite-backed webhook admission, authority, and target mutation gate."""
+
+    def __init__(
+        self,
+        db_path: Optional[Path] = None,
+        *,
+        max_records: int = DEFAULT_MAX_RECORDS,
+        max_storage_bytes: int = DEFAULT_MAX_STORAGE_BYTES,
+        terminal_retention_seconds: int = DEFAULT_TERMINAL_RETENTION_SECONDS,
+        local_bypass_replay_retention_seconds: int = (
+            DEFAULT_LOCAL_BYPASS_REPLAY_RETENTION_SECONDS
+        ),
+        instance_id: Optional[str] = None,
+        _adopt_persisted_operation_limits: bool = False,
+    ) -> None:
+        if (
+            not isinstance(max_records, int)
+            or isinstance(max_records, bool)
+            or max_records < 1
+            or max_records > MAXIMUM_MAX_RECORDS
+        ):
+            raise ValueError("max_records is outside the supported record range")
+        if (
+            not isinstance(max_storage_bytes, int)
+            or isinstance(max_storage_bytes, bool)
+            or max_storage_bytes < MINIMUM_MAX_STORAGE_BYTES
+            or max_storage_bytes > MAXIMUM_MAX_STORAGE_BYTES
+        ):
+            raise ValueError("max_storage_bytes is outside the supported storage range")
+        if (
+            isinstance(terminal_retention_seconds, bool)
+            or int(terminal_retention_seconds) < 1
+        ):
+            raise ValueError("terminal_retention_seconds must be positive")
+        if (
+            isinstance(local_bypass_replay_retention_seconds, bool)
+            or int(local_bypass_replay_retention_seconds) < 1
+        ):
+            raise ValueError("local_bypass_replay_retention_seconds must be positive")
+        self.db_path = (
+            Path(db_path) if db_path is not None else get_hermes_home() / "state.db"
+        )
+        self.max_records = int(max_records)
+        self.max_storage_bytes = int(max_storage_bytes)
+        self.terminal_retention_seconds = int(terminal_retention_seconds)
+        self.local_bypass_replay_retention_seconds = int(
+            local_bypass_replay_retention_seconds
+        )
+        self._adopt_persisted_operation_limits = bool(_adopt_persisted_operation_limits)
+        self.instance_id = _normalize_nonempty(
+            instance_id or uuid.uuid4().hex,
+            label="instance_id",
+        )
+        self._lock = threading.RLock()
+        self._initialize_schema()
+
+    @classmethod
+    def for_authentication_bindings(
+        cls,
+        db_path: Optional[Path] = None,
+    ) -> "WebhookOperationLedger":
+        """Open root key authority without renegotiating operation quotas.
+
+        Named profiles share authentication-key ownership at the Hermes root,
+        while their own operation ledgers may use different record/storage
+        limits.  An existing root ledger therefore remains authoritative for
+        its operation limits; this handle adopts and validates those values.
+        """
+
+        return cls(
+            db_path,
+            _adopt_persisted_operation_limits=True,
+        )
+
+    def _connect(self) -> sqlite3.Connection:
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(
+            str(self.db_path),
+            timeout=10,
+            isolation_level=None,
+        )
+        try:
+            from hermes_state import apply_durability_barriers
+
+            apply_durability_barriers(conn)
+            conn.execute("PRAGMA foreign_keys=ON")
+            conn.row_factory = sqlite3.Row
+        except BaseException:
+            conn.close()
+            raise
+        return conn
+
+    @staticmethod
+    def _storage_failure(exc: BaseException) -> WebhookLedgerError:
+        """Classify SQLite/filesystem failures at the durable-store boundary."""
+
+        error_name = getattr(exc, "sqlite_errorname", None)
+        error_code = getattr(exc, "sqlite_errorcode", None)
+        if error_name:
+            detail = str(error_name)
+        elif error_code is not None:
+            detail = f"SQLite error {error_code}"
+        else:
+            detail = type(exc).__name__
+        return WebhookLedgerError(f"durable webhook storage failed ({detail})")
+
+    @contextmanager
+    def _connection(self) -> Iterator[sqlite3.Connection]:
+        conn: Optional[sqlite3.Connection] = None
+        try:
+            conn = self._connect()
+            yield conn
+        except WebhookLedgerError:
+            raise
+        except (sqlite3.Error, OSError) as exc:
+            raise self._storage_failure(exc) from exc
+        finally:
+            if conn is not None:
+                conn.close()
+
+    @contextmanager
+    def _transaction(self) -> Iterator[sqlite3.Connection]:
+        with self._connection() as conn:
+            from hermes_cli.sqlite_util import write_txn
+
+            with write_txn(conn):
+                yield conn
+
+    @staticmethod
+    def _prepare_v4_migration(conn: sqlite3.Connection) -> bool:
+        """Validate and park one canonical v4 ledger inside this transaction."""
+
+        table_names = {
+            str(row["name"])
+            for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+        }
+        webhook_tables = {
+            "webhook_operations",
+            "webhook_targets",
+            "webhook_delivery_tombstones",
+            "webhook_ledger_meta",
+            "webhook_ledger_usage",
+            "webhook_ledger_scope_usage",
+            "webhook_auth_key_bindings",
+        }
+        if "webhook_ledger_meta" not in table_names:
+            if table_names & webhook_tables:
+                raise WebhookLedgerCorruptionError(
+                    "webhook ledger metadata is unavailable"
+                )
+            return False
+
+        meta_info = conn.execute("PRAGMA table_info(webhook_ledger_meta)").fetchall()
+        if tuple(row["name"] for row in meta_info) != (
+            "schema_name",
+            "schema_version",
+        ) or [int(row["pk"]) for row in meta_info] != [1, 0]:
+            raise WebhookLedgerCorruptionError(
+                "webhook ledger metadata schema is incompatible"
+            )
+        metadata = conn.execute(
+            "SELECT schema_name, schema_version FROM webhook_ledger_meta"
+        ).fetchall()
+        if len(metadata) != 1 or metadata[0]["schema_name"] != _SCHEMA_NAME:
+            raise WebhookLedgerCorruptionError("webhook ledger metadata is unavailable")
+        try:
+            version = int(metadata[0]["schema_version"])
+        except (TypeError, ValueError, OverflowError) as exc:
+            raise WebhookLedgerCorruptionError(
+                "webhook operation ledger schema version is invalid"
+            ) from exc
+        if version == _SCHEMA_VERSION:
+            required_v5_tables = webhook_tables
+            if not required_v5_tables.issubset(table_names):
+                raise WebhookLedgerCorruptionError(
+                    "webhook v5 ledger structure is incomplete"
+                )
+            return False
+        if version != 4:
+            raise WebhookLedgerCorruptionError(
+                "webhook operation ledger schema version is unsupported"
+            )
+
+        required_v4_tables = {
+            "webhook_operations",
+            "webhook_targets",
+            "webhook_delivery_tombstones",
+            "webhook_ledger_meta",
+        }
+        forbidden_v5_tables = {
+            "webhook_ledger_usage",
+            "webhook_ledger_scope_usage",
+            "webhook_auth_key_bindings",
+        }
+        if (
+            not required_v4_tables.issubset(table_names)
+            or table_names & forbidden_v5_tables
+            or table_names
+            & {
+                "webhook_operations_v4",
+                "webhook_targets_v4",
+                "webhook_delivery_tombstones_v4",
+            }
+        ):
+            raise WebhookLedgerCorruptionError(
+                "webhook v4 ledger structure is incompatible"
+            )
+
+        def normalized_sql(sql: object) -> str:
+            return "".join(str(sql).lower().split())
+
+        expected_table_sql = {
+            "webhook_operations": """
+                CREATE TABLE webhook_operations (
+                    operation_id TEXT PRIMARY KEY,
+                    profile TEXT NOT NULL,
+                    route TEXT NOT NULL,
+                    provider TEXT NOT NULL,
+                    replay_id TEXT NOT NULL,
+                    body_sha256 TEXT NOT NULL,
+                    event_type TEXT NOT NULL,
+                    session_key TEXT NOT NULL UNIQUE,
+                    state TEXT NOT NULL CHECK (
+                        state IN (
+                            'preparing','ready','running','delivery_ready',
+                            'delivering','settled','indeterminate'
+                        )
+                    ),
+                    generation INTEGER NOT NULL CHECK (generation >= 1),
+                    owner_pid INTEGER,
+                    owner_started_at INTEGER,
+                    owner_instance TEXT NOT NULL,
+                    event_json TEXT,
+                    target_json TEXT,
+                    grant_json TEXT,
+                    script_started INTEGER NOT NULL DEFAULT 0 CHECK (
+                        script_started IN (0,1)
+                    ),
+                    created_at REAL NOT NULL,
+                    updated_at REAL NOT NULL,
+                    settled_at REAL,
+                    last_error TEXT
+                )
+            """,
+            "webhook_targets": """
+                CREATE TABLE webhook_targets (
+                    operation_id TEXT NOT NULL,
+                    target_id TEXT NOT NULL,
+                    state TEXT NOT NULL CHECK (
+                        state IN (
+                            'pending','attempting','confirmed','suppressed',
+                            'indeterminate'
+                        )
+                    ),
+                    attempt_token TEXT,
+                    content_sha256 TEXT,
+                    delivery_json TEXT,
+                    delivery_sha256 TEXT,
+                    external_id TEXT,
+                    owner_pid INTEGER,
+                    owner_started_at INTEGER,
+                    owner_instance TEXT,
+                    started_at REAL,
+                    settled_at REAL,
+                    updated_at REAL NOT NULL,
+                    last_error TEXT,
+                    PRIMARY KEY(operation_id, target_id),
+                    FOREIGN KEY(operation_id)
+                        REFERENCES webhook_operations(operation_id)
+                        ON DELETE CASCADE
+                )
+            """,
+            "webhook_delivery_tombstones": """
+                CREATE TABLE webhook_delivery_tombstones (
+                    profile TEXT NOT NULL,
+                    route TEXT NOT NULL,
+                    provider TEXT NOT NULL,
+                    replay_id TEXT NOT NULL,
+                    body_sha256 TEXT NOT NULL,
+                    operation_id TEXT NOT NULL,
+                    state TEXT NOT NULL CHECK (
+                        state IN ('settled','indeterminate')
+                    ),
+                    settled_at REAL NOT NULL,
+                    expires_at REAL,
+                    PRIMARY KEY(profile, route, provider, replay_id)
+                )
+            """,
+            "webhook_ledger_meta": """
+                CREATE TABLE webhook_ledger_meta (
+                    schema_name TEXT PRIMARY KEY CHECK (
+                        schema_name='webhook_operation_ledger'
+                    ),
+                    schema_version INTEGER NOT NULL CHECK (schema_version=4)
+                )
+            """,
+        }
+        actual_table_sql = {
+            str(row["name"]): normalized_sql(row["sql"])
+            for row in conn.execute(
+                """SELECT name, sql FROM sqlite_master
+                    WHERE type='table' AND name IN (?, ?, ?, ?)""",
+                tuple(expected_table_sql),
+            )
+        }
+        if actual_table_sql != {
+            name: normalized_sql(sql) for name, sql in expected_table_sql.items()
+        }:
+            raise WebhookLedgerCorruptionError(
+                "webhook v4 ledger table definitions are incompatible"
+            )
+
+        expected_index_sql = {
+            "idx_webhook_operations_replay_identity": """
+                CREATE UNIQUE INDEX idx_webhook_operations_replay_identity
+                    ON webhook_operations(profile, route, provider, replay_id)
+            """,
+            "idx_webhook_operations_state_updated": """
+                CREATE INDEX idx_webhook_operations_state_updated
+                    ON webhook_operations(state, updated_at)
+            """,
+            "idx_webhook_tombstones_expires_at": """
+                CREATE INDEX idx_webhook_tombstones_expires_at
+                    ON webhook_delivery_tombstones(expires_at)
+                    WHERE expires_at IS NOT NULL
+            """,
+        }
+        actual_v4_objects = {
+            (str(row["type"]), str(row["name"])): (
+                str(row["tbl_name"]),
+                normalized_sql(row["sql"]),
+            )
+            for row in conn.execute(
+                """SELECT type, name, tbl_name, sql FROM sqlite_master
+                    WHERE type IN ('index','trigger')
+                      AND tbl_name IN (?, ?, ?, ?)
+                      AND sql IS NOT NULL""",
+                tuple(expected_table_sql),
+            )
+        }
+        expected_v4_objects = {
+            ("index", name): (
+                "webhook_delivery_tombstones"
+                if name == "idx_webhook_tombstones_expires_at"
+                else "webhook_operations",
+                normalized_sql(sql),
+            )
+            for name, sql in expected_index_sql.items()
+        }
+        if actual_v4_objects != expected_v4_objects:
+            raise WebhookLedgerCorruptionError(
+                "webhook v4 ledger indexes or triggers are incompatible"
+            )
+
+        expected_operation_columns = (
+            "operation_id",
+            "profile",
+            "route",
+            "provider",
+            "replay_id",
+            "body_sha256",
+            "event_type",
+            "session_key",
+            "state",
+            "generation",
+            "owner_pid",
+            "owner_started_at",
+            "owner_instance",
+            "event_json",
+            "target_json",
+            "grant_json",
+            "script_started",
+            "created_at",
+            "updated_at",
+            "settled_at",
+            "last_error",
+        )
+        expected_target_columns = (
+            "operation_id",
+            "target_id",
+            "state",
+            "attempt_token",
+            "content_sha256",
+            "delivery_json",
+            "delivery_sha256",
+            "external_id",
+            "owner_pid",
+            "owner_started_at",
+            "owner_instance",
+            "started_at",
+            "settled_at",
+            "updated_at",
+            "last_error",
+        )
+        expected_tombstone_columns = (
+            "profile",
+            "route",
+            "provider",
+            "replay_id",
+            "body_sha256",
+            "operation_id",
+            "state",
+            "settled_at",
+            "expires_at",
+        )
+        operation_info = conn.execute(
+            "PRAGMA table_info(webhook_operations)"
+        ).fetchall()
+        target_info = conn.execute("PRAGMA table_info(webhook_targets)").fetchall()
+        tombstone_info = conn.execute(
+            "PRAGMA table_info(webhook_delivery_tombstones)"
+        ).fetchall()
+        if (
+            tuple(row["name"] for row in operation_info) != expected_operation_columns
+            or [int(row["pk"]) for row in operation_info]
+            != [1] + [0] * (len(operation_info) - 1)
+            or tuple(row["name"] for row in target_info) != expected_target_columns
+            or [int(row["pk"]) for row in target_info]
+            != [1, 2] + [0] * (len(target_info) - 2)
+            or tuple(row["name"] for row in tombstone_info)
+            != expected_tombstone_columns
+            or [int(row["pk"]) for row in tombstone_info] != [1, 2, 3, 4] + [0] * 5
+        ):
+            raise WebhookLedgerCorruptionError(
+                "webhook v4 ledger structure is incompatible"
+            )
+
+        operation_indexes = {
+            row["name"]: row
+            for row in conn.execute("PRAGMA index_list(webhook_operations)")
+        }
+        replay_index = operation_indexes.get("idx_webhook_operations_replay_identity")
+        replay_columns = (
+            tuple(
+                row["name"]
+                for row in conn.execute(
+                    "PRAGMA index_info(idx_webhook_operations_replay_identity)"
+                )
+            )
+            if replay_index is not None
+            else ()
+        )
+        session_unique = any(
+            bool(index["unique"])
+            and not bool(index["partial"])
+            and tuple(
+                row["name"]
+                for row in conn.execute(
+                    "SELECT name FROM pragma_index_info(?)",
+                    (index["name"],),
+                )
+            )
+            == ("session_key",)
+            for index in operation_indexes.values()
+        )
+        if (
+            replay_index is None
+            or not bool(replay_index["unique"])
+            or bool(replay_index["partial"])
+            or replay_columns != ("profile", "route", "provider", "replay_id")
+            or not session_unique
+        ):
+            raise WebhookLedgerCorruptionError(
+                "webhook v4 uniqueness authority is unavailable"
+            )
+
+        foreign_keys = conn.execute(
+            "PRAGMA foreign_key_list(webhook_targets)"
+        ).fetchall()
+        duplicate_target = conn.execute(
+            """SELECT operation_id FROM webhook_targets
+                GROUP BY operation_id HAVING COUNT(*) > 1 LIMIT 1"""
+        ).fetchone()
+        overlapping_identity = conn.execute(
+            """SELECT 1
+                 FROM webhook_operations AS operation
+                 JOIN webhook_delivery_tombstones AS tombstone
+                   ON tombstone.profile=operation.profile
+                  AND tombstone.route=operation.route
+                  AND tombstone.provider=operation.provider
+                  AND tombstone.replay_id=operation.replay_id
+                LIMIT 1"""
+        ).fetchone()
+        if (
+            not any(
+                row["table"] == "webhook_operations"
+                and row["from"] == "operation_id"
+                and row["to"] == "operation_id"
+                and str(row["on_delete"]).upper() == "CASCADE"
+                for row in foreign_keys
+            )
+            or duplicate_target is not None
+            or overlapping_identity is not None
+            or conn.execute("PRAGMA foreign_key_check(webhook_targets)").fetchone()
+            is not None
+        ):
+            raise WebhookLedgerCorruptionError(
+                "webhook v4 ledger contents are incompatible"
+            )
+
+        ambiguous_default_evidence = conn.execute(
+            """SELECT 1 FROM webhook_operations WHERE profile='default'
+               UNION ALL
+               SELECT 1 FROM webhook_delivery_tombstones
+                WHERE profile='default'
+               LIMIT 1"""
+        ).fetchone()
+        if ambiguous_default_evidence is not None:
+            raise WebhookLedgerConfigurationError(
+                "webhook v4 profile='default' evidence cannot be migrated: "
+                "its physical authority profile is ambiguous; preserve the "
+                "database and remove or explicitly re-home the unpublished "
+                "v4 evidence before retrying"
+            )
+
+        for index_name in (
+            "idx_webhook_operations_replay_identity",
+            "idx_webhook_operations_state_updated",
+            "idx_webhook_tombstones_expires_at",
+        ):
+            conn.execute(f"DROP INDEX IF EXISTS {index_name}")
+        conn.execute("ALTER TABLE webhook_operations RENAME TO webhook_operations_v4")
+        conn.execute("ALTER TABLE webhook_targets RENAME TO webhook_targets_v4")
+        conn.execute(
+            """ALTER TABLE webhook_delivery_tombstones
+               RENAME TO webhook_delivery_tombstones_v4"""
+        )
+        conn.execute("DROP TABLE webhook_ledger_meta")
+        return True
+
+    def _restore_v4_rows(self, conn: sqlite3.Connection) -> None:
+        """Copy parked v4 authority through v5 constraints and counters."""
+
+        operation_columns = (
+            "operation_id, profile, route, provider, replay_id, body_sha256, "
+            "event_type, session_key, state, generation, owner_pid, "
+            "owner_started_at, owner_instance, event_json, target_json, "
+            "grant_json, script_started, created_at, updated_at, settled_at, "
+            "last_error"
+        )
+        target_columns = (
+            "operation_id, target_id, state, attempt_token, content_sha256, "
+            "delivery_json, delivery_sha256, external_id, owner_pid, "
+            "owner_started_at, owner_instance, started_at, settled_at, "
+            "updated_at, last_error"
+        )
+        tombstone_columns = (
+            "profile, route, provider, replay_id, body_sha256, operation_id, "
+            "state, settled_at, expires_at"
+        )
+        conn.execute(
+            f"""INSERT INTO webhook_operations ({operation_columns})
+                SELECT {operation_columns} FROM webhook_operations_v4"""
+        )
+        conn.execute(
+            f"""INSERT INTO webhook_targets ({target_columns})
+                SELECT {target_columns} FROM webhook_targets_v4"""
+        )
+        conn.execute(
+            f"""INSERT INTO webhook_delivery_tombstones ({tombstone_columns})
+                SELECT {tombstone_columns}
+                  FROM webhook_delivery_tombstones_v4"""
+        )
+        if conn.execute("PRAGMA foreign_key_check(webhook_targets)").fetchone():
+            raise WebhookLedgerCorruptionError(
+                "webhook v4 migration produced invalid target ownership"
+            )
+
+        def require_exact_text(row: sqlite3.Row, key: str, label: str) -> None:
+            try:
+                normalized = _normalize_nonempty(row[key], label=label)
+            except WebhookLedgerError as exc:
+                raise WebhookLedgerCorruptionError(
+                    f"stored {label} is invalid"
+                ) from exc
+            if row[key] != normalized:
+                raise WebhookLedgerCorruptionError(f"stored {label} is not canonical")
+
+        def require_sha256(row: sqlite3.Row, key: str, label: str) -> None:
+            try:
+                normalized = _normalize_sha256(row[key], label=label)
+            except WebhookLedgerError as exc:
+                raise WebhookLedgerCorruptionError(
+                    f"stored {label} is invalid"
+                ) from exc
+            if row[key] != normalized:
+                raise WebhookLedgerCorruptionError(f"stored {label} is not canonical")
+
+        def require_finite_time(
+            row: sqlite3.Row,
+            key: str,
+            label: str,
+            *,
+            optional: bool = False,
+        ) -> None:
+            value = row[key]
+            if optional and value is None:
+                return
+            try:
+                finite = math.isfinite(float(value))
+            except (TypeError, ValueError, OverflowError):
+                finite = False
+            if not finite:
+                raise WebhookLedgerCorruptionError(f"stored {label} is invalid")
+
+        operation_cursor = conn.execute(
+            "SELECT * FROM webhook_operations ORDER BY operation_id"
+        )
+        while rows := operation_cursor.fetchmany(_V4_MIGRATION_VALIDATION_BATCH_SIZE):
+            for row in rows:
+                for key in (
+                    "operation_id",
+                    "profile",
+                    "route",
+                    "provider",
+                    "replay_id",
+                    "event_type",
+                    "session_key",
+                    "owner_instance",
+                ):
+                    require_exact_text(row, key, f"operation {key}")
+                require_sha256(row, "body_sha256", "operation body_sha256")
+                if (
+                    not isinstance(row["generation"], int)
+                    or isinstance(row["generation"], bool)
+                    or int(row["generation"]) < 1
+                    or row["script_started"] not in (0, 1)
+                ):
+                    raise WebhookLedgerCorruptionError(
+                        "stored operation generation or script gate is invalid"
+                    )
+                # This validates operation/target states, canonical authority JSON,
+                # and staged-delivery content/digests as one joined authority.
+                authority = self._authority_from_row(conn, row)
+                snapshot_presence = tuple(
+                    row[key] is not None
+                    for key in ("event_json", "target_json", "grant_json")
+                )
+                if any(snapshot_presence) and not all(snapshot_presence):
+                    raise WebhookLedgerCorruptionError(
+                        "stored operation authority snapshot is incomplete"
+                    )
+                if (authority.target_id is not None) != bool(row["target_json"]):
+                    raise WebhookLedgerCorruptionError(
+                        "stored operation target ownership is incomplete"
+                    )
+                if row["target_json"] is not None:
+                    expected_target_id = hashlib.sha256(
+                        str(row["target_json"]).encode("utf-8")
+                    ).hexdigest()[:32]
+                    if authority.target_id != expected_target_id:
+                        raise WebhookLedgerCorruptionError(
+                            "stored operation target identity is invalid"
+                        )
+                require_finite_time(row, "created_at", "operation created_at")
+                require_finite_time(row, "updated_at", "operation updated_at")
+                require_finite_time(
+                    row,
+                    "settled_at",
+                    "operation settled_at",
+                    optional=True,
+                )
+
+        for row in conn.execute("SELECT * FROM webhook_targets"):
+            require_exact_text(row, "operation_id", "target operation_id")
+            require_exact_text(row, "target_id", "target target_id")
+            for key in ("attempt_token", "owner_instance"):
+                if row[key] is not None:
+                    require_exact_text(row, key, f"target {key}")
+            for key in ("started_at", "settled_at"):
+                require_finite_time(
+                    row,
+                    key,
+                    f"target {key}",
+                    optional=True,
+                )
+            require_finite_time(row, "updated_at", "target updated_at")
+
+        for row in conn.execute("SELECT * FROM webhook_delivery_tombstones"):
+            self._tombstone_from_row(row)
+
+        conn.execute("DROP TABLE webhook_targets_v4")
+        conn.execute("DROP TABLE webhook_delivery_tombstones_v4")
+        conn.execute("DROP TABLE webhook_operations_v4")
+
+    def _initialize_schema(self) -> None:
+        with self._lock, self._transaction() as conn:
+            migrate_v4 = self._prepare_v4_migration(conn)
+            conn.execute(
+                f"""CREATE TABLE IF NOT EXISTS webhook_operations (
+                    operation_id TEXT PRIMARY KEY CHECK (
+                        length(CAST(operation_id AS BLOB)) BETWEEN 1 AND 1024
+                    ),
+                    profile TEXT NOT NULL CHECK (
+                        length(CAST(profile AS BLOB)) BETWEEN 1 AND 1024
+                    ),
+                    route TEXT NOT NULL CHECK (
+                        length(CAST(route AS BLOB)) BETWEEN 1 AND 1024
+                    ),
+                    provider TEXT NOT NULL CHECK (
+                        length(CAST(provider AS BLOB)) BETWEEN 1 AND 1024
+                    ),
+                    replay_id TEXT NOT NULL CHECK (
+                        length(CAST(replay_id AS BLOB)) BETWEEN 1 AND 1024
+                    ),
+                    body_sha256 TEXT NOT NULL CHECK (
+                        length(CAST(body_sha256 AS BLOB))=64
+                    ),
+                    event_type TEXT NOT NULL CHECK (
+                        length(CAST(event_type AS BLOB)) BETWEEN 1 AND 1024
+                    ),
+                    session_key TEXT NOT NULL UNIQUE CHECK (
+                        length(CAST(session_key AS BLOB)) BETWEEN 1 AND 1024
+                    ),
+                    state TEXT NOT NULL CHECK (
+                        state IN (
+                            'preparing','ready','running','delivery_ready',
+                            'delivering','settled','indeterminate'
+                        )
+                    ),
+                    generation INTEGER NOT NULL CHECK (generation >= 1),
+                    owner_pid INTEGER,
+                    owner_started_at INTEGER,
+                    owner_instance TEXT NOT NULL CHECK (
+                        length(CAST(owner_instance AS BLOB)) BETWEEN 1 AND 1024
+                    ),
+                    event_json TEXT CHECK (
+                        event_json IS NULL OR
+                        length(CAST(event_json AS BLOB)) <= {_MAX_EVENT_JSON_BYTES}
+                    ),
+                    target_json TEXT CHECK (
+                        target_json IS NULL OR
+                        length(CAST(target_json AS BLOB)) <= {_MAX_AUTHORITY_JSON_BYTES}
+                    ),
+                    grant_json TEXT CHECK (
+                        grant_json IS NULL OR
+                        length(CAST(grant_json AS BLOB)) <= {_MAX_AUTHORITY_JSON_BYTES}
+                    ),
+                    script_started INTEGER NOT NULL DEFAULT 0 CHECK (
+                        script_started IN (0,1)
+                    ),
+                    created_at REAL NOT NULL,
+                    updated_at REAL NOT NULL,
+                    settled_at REAL,
+                    last_error TEXT CHECK (
+                        last_error IS NULL OR
+                        length(CAST(last_error AS BLOB)) <= {_MAX_ERROR_UTF8_BYTES}
+                    )
+                )"""
+            )
+            conn.execute(
+                """CREATE UNIQUE INDEX IF NOT EXISTS
+                    idx_webhook_operations_replay_identity
+                    ON webhook_operations(profile, route, provider, replay_id)"""
+            )
+            conn.execute(
+                """CREATE INDEX IF NOT EXISTS idx_webhook_operations_state_updated
+                    ON webhook_operations(state, updated_at)"""
+            )
+            conn.execute(
+                """CREATE INDEX IF NOT EXISTS
+                    idx_webhook_operations_scope_state_updated
+                    ON webhook_operations(
+                        profile, route, provider, state, updated_at
+                    )"""
+            )
+            conn.execute(
+                """CREATE INDEX IF NOT EXISTS
+                    idx_webhook_operations_recovery_order
+                    ON webhook_operations(created_at, operation_id)
+                    WHERE state IN (
+                        'preparing','ready','running','delivery_ready','delivering'
+                    )"""
+            )
+            conn.execute(
+                """CREATE INDEX IF NOT EXISTS
+                    idx_webhook_operations_owner_recovery_order
+                    ON webhook_operations(
+                        owner_instance, created_at, operation_id
+                    )
+                    WHERE state IN (
+                        'preparing','ready','running','delivery_ready','delivering'
+                    )"""
+            )
+            conn.execute(
+                """CREATE INDEX IF NOT EXISTS
+                    idx_webhook_operations_profile_recovery_order
+                    ON webhook_operations(
+                        profile, created_at, operation_id
+                    )
+                    WHERE state IN (
+                        'preparing','ready','running','delivery_ready','delivering'
+                    )"""
+            )
+            conn.execute(
+                """CREATE INDEX IF NOT EXISTS
+                    idx_webhook_operations_owner_delivery_ready
+                    ON webhook_operations(
+                        owner_instance, created_at, operation_id
+                    )
+                    WHERE state='delivery_ready'"""
+            )
+            conn.execute(
+                """CREATE INDEX IF NOT EXISTS
+                    idx_webhook_operations_owner_profile_delivery_ready
+                    ON webhook_operations(
+                        owner_instance, profile, created_at, operation_id
+                    )
+                    WHERE state='delivery_ready'"""
+            )
+            conn.execute(
+                """CREATE INDEX IF NOT EXISTS
+                    idx_webhook_operations_owner_current_recovery
+                    ON webhook_operations(
+                        owner_instance, created_at, operation_id
+                    )
+                    WHERE state='delivery_ready'
+                       OR (state='ready' AND generation>=2)"""
+            )
+            conn.execute(
+                """CREATE INDEX IF NOT EXISTS
+                    idx_webhook_operations_owner_profile_current_recovery
+                    ON webhook_operations(
+                        owner_instance, profile, created_at, operation_id
+                    )
+                    WHERE state='delivery_ready'
+                       OR (state='ready' AND generation>=2)"""
+            )
+            conn.execute(
+                f"""CREATE TABLE IF NOT EXISTS webhook_targets (
+                    operation_id TEXT NOT NULL CHECK (
+                        length(CAST(operation_id AS BLOB)) BETWEEN 1 AND 1024
+                    ),
+                    target_id TEXT NOT NULL CHECK (
+                        length(CAST(target_id AS BLOB)) BETWEEN 1 AND 1024
+                    ),
+                    state TEXT NOT NULL CHECK (
+                        state IN ('pending','attempting','confirmed','suppressed','indeterminate')
+                    ),
+                    attempt_token TEXT CHECK (
+                        attempt_token IS NULL OR
+                        length(CAST(attempt_token AS BLOB)) <= 1024
+                    ),
+                    content_sha256 TEXT CHECK (
+                        content_sha256 IS NULL OR
+                        length(CAST(content_sha256 AS BLOB))=64
+                    ),
+                    delivery_json TEXT CHECK (
+                        delivery_json IS NULL OR
+                        length(CAST(delivery_json AS BLOB)) <= {_MAX_EVENT_JSON_BYTES}
+                    ),
+                    delivery_sha256 TEXT CHECK (
+                        delivery_sha256 IS NULL OR
+                        length(CAST(delivery_sha256 AS BLOB))=64
+                    ),
+                    external_id TEXT CHECK (
+                        external_id IS NULL OR
+                        length(CAST(external_id AS BLOB)) <= {_MAX_EXTERNAL_ID_UTF8_BYTES}
+                    ),
+                    owner_pid INTEGER,
+                    owner_started_at INTEGER,
+                    owner_instance TEXT CHECK (
+                        owner_instance IS NULL OR
+                        length(CAST(owner_instance AS BLOB)) BETWEEN 1 AND 1024
+                    ),
+                    started_at REAL,
+                    settled_at REAL,
+                    updated_at REAL NOT NULL,
+                    last_error TEXT CHECK (
+                        last_error IS NULL OR
+                        length(CAST(last_error AS BLOB)) <= {_MAX_ERROR_UTF8_BYTES}
+                    ),
+                    PRIMARY KEY(operation_id),
+                    FOREIGN KEY(operation_id) REFERENCES webhook_operations(operation_id)
+                        ON DELETE CASCADE
+                )"""
+            )
+            bounded_replay_prefix = _BOUNDED_REPLAY_PREFIXES[0]
+            conn.execute(
+                f"""CREATE TABLE IF NOT EXISTS webhook_delivery_tombstones (
+                    profile TEXT NOT NULL CHECK (
+                        length(CAST(profile AS BLOB)) BETWEEN 1 AND 1024
+                    ),
+                    route TEXT NOT NULL CHECK (
+                        length(CAST(route AS BLOB)) BETWEEN 1 AND 1024
+                    ),
+                    provider TEXT NOT NULL CHECK (
+                        length(CAST(provider AS BLOB)) BETWEEN 1 AND 1024
+                    ),
+                    replay_id TEXT NOT NULL CHECK (
+                        length(CAST(replay_id AS BLOB)) BETWEEN 1 AND 1024
+                    ),
+                    body_sha256 TEXT NOT NULL CHECK (
+                        length(CAST(body_sha256 AS BLOB))=64
+                    ),
+                    operation_id TEXT NOT NULL CHECK (
+                        length(CAST(operation_id AS BLOB)) BETWEEN 1 AND 1024
+                    ),
+                    state TEXT NOT NULL CHECK (
+                        state IN ('settled','indeterminate')
+                    ),
+                    settled_at REAL NOT NULL,
+                    expires_at REAL CHECK (
+                        expires_at IS NULL OR (
+                            state='settled' AND
+                            substr(replay_id, 1, {len(bounded_replay_prefix)})=
+                                '{bounded_replay_prefix}'
+                        )
+                    ),
+                    PRIMARY KEY(profile, route, provider, replay_id)
+                )"""
+            )
+            conn.execute(
+                """CREATE INDEX IF NOT EXISTS idx_webhook_tombstones_expires_at
+                    ON webhook_delivery_tombstones(expires_at)
+                    WHERE expires_at IS NOT NULL"""
+            )
+            conn.execute(
+                f"""CREATE INDEX IF NOT EXISTS
+                    idx_webhook_operations_bounded_settled_expiry
+                    ON webhook_operations(COALESCE(settled_at, updated_at))
+                    WHERE state='settled'
+                      AND substr(replay_id, 1, {len(bounded_replay_prefix)})=
+                          '{bounded_replay_prefix}'"""
+            )
+            conn.execute(
+                f"""CREATE TABLE IF NOT EXISTS webhook_ledger_usage (
+                    schema_name TEXT PRIMARY KEY CHECK (
+                        schema_name='webhook_operation_ledger'
+                    ),
+                    reserved_bytes INTEGER NOT NULL CHECK (reserved_bytes >= 0),
+                    proof_count INTEGER NOT NULL CHECK (proof_count >= 0),
+                    active_record_count INTEGER NOT NULL CHECK (
+                        active_record_count >= 0
+                    ),
+                    settled_operation_count INTEGER NOT NULL CHECK (
+                        settled_operation_count >= 0
+                    ),
+                    indeterminate_operation_count INTEGER NOT NULL CHECK (
+                        indeterminate_operation_count >= 0
+                    ),
+                    auth_binding_reserved_bytes INTEGER NOT NULL DEFAULT 0 CHECK (
+                        auth_binding_reserved_bytes >= 0
+                    ),
+                    auth_binding_count INTEGER NOT NULL DEFAULT 0 CHECK (
+                        auth_binding_count >= 0
+                    ),
+                    max_records INTEGER NOT NULL CHECK (
+                        max_records BETWEEN 1 AND {MAXIMUM_MAX_RECORDS}
+                    ),
+                    max_storage_bytes INTEGER NOT NULL CHECK (
+                        max_storage_bytes >= {_OPERATION_STORAGE_RESERVATION_BYTES}
+                        AND max_storage_bytes <= {MAXIMUM_MAX_STORAGE_BYTES}
+                    ),
+                    scope_limit_bytes INTEGER NOT NULL CHECK (
+                        scope_limit_bytes >= {_OPERATION_STORAGE_RESERVATION_BYTES}
+                        AND scope_limit_bytes <= max_storage_bytes
+                    ),
+                    operation_limits_provisional INTEGER NOT NULL CHECK (
+                        operation_limits_provisional IN (0,1)
+                    ),
+                    auth_binding_limit_bytes INTEGER NOT NULL CHECK (
+                        auth_binding_limit_bytes=
+                            {_AUTH_BINDING_GLOBAL_LIMIT_BYTES}
+                    ),
+                    auth_binding_scope_limit_bytes INTEGER NOT NULL CHECK (
+                        auth_binding_scope_limit_bytes=
+                            {_AUTH_BINDING_SCOPE_LIMIT_BYTES}
+                        AND auth_binding_scope_limit_bytes <=
+                            auth_binding_limit_bytes
+                    ),
+                    CHECK (
+                        active_record_count + settled_operation_count
+                            + indeterminate_operation_count <= proof_count
+                    ),
+                    CHECK (
+                        auth_binding_reserved_bytes=
+                            auth_binding_count*
+                                {_AUTH_BINDING_STORAGE_RESERVATION_BYTES}
+                        AND auth_binding_reserved_bytes <=
+                            auth_binding_limit_bytes
+                    )
+                )"""
+            )
+            conn.execute(
+                """INSERT OR IGNORE INTO webhook_ledger_usage (
+                       schema_name, reserved_bytes, proof_count,
+                       active_record_count, settled_operation_count,
+                       indeterminate_operation_count,
+                       auth_binding_reserved_bytes, auth_binding_count,
+                       max_records, max_storage_bytes, scope_limit_bytes,
+                       operation_limits_provisional,
+                       auth_binding_limit_bytes,
+                       auth_binding_scope_limit_bytes
+                   ) VALUES (?, 0, 0, 0, 0, 0, 0, 0, ?, ?, ?, ?, ?, ?)""",
+                (
+                    _SCHEMA_NAME,
+                    self.max_records,
+                    self.max_storage_bytes,
+                    _scope_storage_limit(self.max_storage_bytes),
+                    int(self._adopt_persisted_operation_limits and not migrate_v4),
+                    _AUTH_BINDING_GLOBAL_LIMIT_BYTES,
+                    _AUTH_BINDING_SCOPE_LIMIT_BYTES,
+                ),
+            )
+            current_usage = conn.execute(
+                """SELECT reserved_bytes, max_records, max_storage_bytes,
+                          proof_count, active_record_count,
+                          settled_operation_count,
+                          indeterminate_operation_count, scope_limit_bytes,
+                          operation_limits_provisional,
+                          auth_binding_limit_bytes,
+                          auth_binding_scope_limit_bytes
+                     FROM webhook_ledger_usage
+                   WHERE schema_name=?""",
+                (_SCHEMA_NAME,),
+            ).fetchone()
+            if current_usage is None:
+                raise WebhookLedgerCorruptionError(
+                    "webhook ledger usage authority is unavailable"
+                )
+            if not self._adopt_persisted_operation_limits and bool(
+                current_usage["operation_limits_provisional"]
+            ):
+                has_operation_evidence = (
+                    int(current_usage["reserved_bytes"]) != 0
+                    or int(current_usage["proof_count"]) != 0
+                    or int(current_usage["active_record_count"]) != 0
+                    or int(current_usage["settled_operation_count"]) != 0
+                    or int(current_usage["indeterminate_operation_count"]) != 0
+                )
+                requested_limits_match = (
+                    int(current_usage["max_records"]) == self.max_records
+                    and int(current_usage["max_storage_bytes"])
+                    == self.max_storage_bytes
+                    and int(current_usage["scope_limit_bytes"])
+                    == _scope_storage_limit(self.max_storage_bytes)
+                )
+                if has_operation_evidence and not requested_limits_match:
+                    raise WebhookLedgerConfigurationError(
+                        "provisional webhook operation limits cannot change "
+                        "after durable operation evidence exists"
+                    )
+                if not has_operation_evidence:
+                    conn.execute(
+                        """UPDATE webhook_ledger_usage
+                              SET max_records=?, max_storage_bytes=?,
+                                  scope_limit_bytes=?,
+                                  operation_limits_provisional=0
+                            WHERE schema_name=?
+                              AND operation_limits_provisional=1
+                              AND reserved_bytes=0 AND proof_count=0
+                              AND active_record_count=0
+                              AND settled_operation_count=0
+                              AND indeterminate_operation_count=0""",
+                        (
+                            self.max_records,
+                            self.max_storage_bytes,
+                            _scope_storage_limit(self.max_storage_bytes),
+                            _SCHEMA_NAME,
+                        ),
+                    )
+                else:
+                    conn.execute(
+                        """UPDATE webhook_ledger_usage
+                              SET operation_limits_provisional=0
+                            WHERE schema_name=?
+                              AND operation_limits_provisional=1""",
+                        (_SCHEMA_NAME,),
+                    )
+                current_usage = conn.execute(
+                    """SELECT reserved_bytes, max_records, max_storage_bytes,
+                              proof_count, active_record_count,
+                              settled_operation_count,
+                              indeterminate_operation_count, scope_limit_bytes,
+                              operation_limits_provisional,
+                              auth_binding_limit_bytes,
+                              auth_binding_scope_limit_bytes
+                         FROM webhook_ledger_usage
+                       WHERE schema_name=?""",
+                    (_SCHEMA_NAME,),
+                ).fetchone()
+                if current_usage is None:  # pragma: no cover - singleton update
+                    raise WebhookLedgerCorruptionError(
+                        "webhook ledger usage authority is unavailable"
+                    )
+            if self._adopt_persisted_operation_limits:
+                # The singleton row already existed (or was initialized above
+                # with canonical defaults).  Never rewrite it from a named
+                # profile's unrelated operation settings.
+                self.max_records = int(current_usage["max_records"])
+                self.max_storage_bytes = int(current_usage["max_storage_bytes"])
+            if int(current_usage["reserved_bytes"]) > int(
+                current_usage["max_storage_bytes"]
+            ):
+                raise WebhookLedgerConfigurationError(
+                    "persisted webhook storage limit is below reserved evidence"
+                )
+            if int(current_usage["reserved_bytes"]) > self.max_storage_bytes:
+                raise WebhookLedgerConfigurationError(
+                    "configured webhook storage limit is below reserved evidence"
+                )
+            if not self._adopt_persisted_operation_limits and (
+                int(current_usage["max_records"]) != self.max_records
+                or int(current_usage["max_storage_bytes"]) != self.max_storage_bytes
+                or int(current_usage["scope_limit_bytes"])
+                != _scope_storage_limit(self.max_storage_bytes)
+                or int(current_usage["auth_binding_limit_bytes"])
+                != _AUTH_BINDING_GLOBAL_LIMIT_BYTES
+                or int(current_usage["auth_binding_scope_limit_bytes"])
+                != _AUTH_BINDING_SCOPE_LIMIT_BYTES
+            ):
+                raise WebhookLedgerConfigurationError(
+                    "configured webhook ledger limits do not match persisted authority"
+                )
+
+            conn.execute(
+                f"""CREATE TABLE IF NOT EXISTS webhook_ledger_scope_usage (
+                    profile TEXT NOT NULL CHECK (
+                        length(CAST(profile AS BLOB)) BETWEEN 1 AND 1024
+                    ),
+                    route TEXT NOT NULL CHECK (
+                        length(CAST(route AS BLOB)) BETWEEN 1 AND 1024
+                    ),
+                    provider TEXT NOT NULL CHECK (
+                        length(CAST(provider AS BLOB)) BETWEEN 1 AND 1024
+                    ),
+                    reserved_bytes INTEGER NOT NULL CHECK (reserved_bytes >= 0),
+                    proof_count INTEGER NOT NULL CHECK (proof_count >= 0),
+                    active_record_count INTEGER NOT NULL DEFAULT 0 CHECK (
+                        active_record_count >= 0 AND
+                        active_record_count <= proof_count
+                    ),
+                    settled_operation_count INTEGER NOT NULL DEFAULT 0 CHECK (
+                        settled_operation_count >= 0 AND
+                        active_record_count + settled_operation_count <=
+                            proof_count
+                    ),
+                    auth_binding_reserved_bytes INTEGER NOT NULL DEFAULT 0 CHECK (
+                        auth_binding_reserved_bytes >= 0
+                    ),
+                    auth_binding_count INTEGER NOT NULL DEFAULT 0 CHECK (
+                        auth_binding_count >= 0 AND
+                        auth_binding_reserved_bytes=
+                            auth_binding_count*
+                                {_AUTH_BINDING_STORAGE_RESERVATION_BYTES} AND
+                        auth_binding_reserved_bytes <=
+                            {_AUTH_BINDING_SCOPE_LIMIT_BYTES}
+                    ),
+                    PRIMARY KEY(profile, route, provider)
+                ) WITHOUT ROWID"""
+            )
+            # Recreate the counter triggers on every open so a shadowed
+            # trigger cannot silently disable the O(1) storage authority.
+            for trigger_name in (
+                "trg_webhook_operations_budget_insert",
+                "trg_webhook_operations_usage_insert",
+                "trg_webhook_operations_usage_delete",
+                "trg_webhook_operations_usage_state",
+                "trg_webhook_tombstones_budget_insert",
+                "trg_webhook_tombstones_usage_insert",
+                "trg_webhook_tombstones_usage_delete",
+                "trg_webhook_auth_bindings_budget_insert",
+                "trg_webhook_auth_bindings_usage_insert",
+                "trg_webhook_auth_bindings_immutable_update",
+                "trg_webhook_auth_bindings_immutable_delete",
+            ):
+                conn.execute(f"DROP TRIGGER IF EXISTS {trigger_name}")
+            conn.execute(
+                f"""CREATE TRIGGER trg_webhook_operations_budget_insert
+                    BEFORE INSERT ON webhook_operations
+                    WHEN NOT EXISTS (
+                             SELECT 1 FROM webhook_ledger_usage
+                              WHERE schema_name='{_SCHEMA_NAME}'
+                                AND reserved_bytes <= max_storage_bytes-
+                                        {_OPERATION_STORAGE_RESERVATION_BYTES}
+                         )
+                         OR COALESCE((
+                                SELECT reserved_bytes
+                                  FROM webhook_ledger_scope_usage
+                                 WHERE profile=NEW.profile
+                                   AND route=NEW.route
+                                   AND provider=NEW.provider
+                            ), 0) > (
+                                SELECT scope_limit_bytes-
+                                       {_OPERATION_STORAGE_RESERVATION_BYTES}
+                                  FROM webhook_ledger_usage
+                                 WHERE schema_name='{_SCHEMA_NAME}'
+                            )
+                    BEGIN
+                        SELECT RAISE(ABORT, 'webhook_ledger_full');
+                    END"""
+            )
+            conn.execute(
+                f"""CREATE TRIGGER trg_webhook_operations_usage_insert
+                    AFTER INSERT ON webhook_operations
+                    BEGIN
+                        UPDATE webhook_ledger_usage
+                           SET reserved_bytes=reserved_bytes+
+                                   {_OPERATION_STORAGE_RESERVATION_BYTES},
+                               proof_count=proof_count+1,
+                               active_record_count=active_record_count+
+                                   CASE WHEN NEW.state NOT IN (
+                                       'settled','indeterminate'
+                                   ) THEN 1 ELSE 0 END,
+                               settled_operation_count=
+                                   settled_operation_count+
+                                   CASE WHEN NEW.state='settled'
+                                        THEN 1 ELSE 0 END,
+                               indeterminate_operation_count=
+                                   indeterminate_operation_count+
+                                   CASE WHEN NEW.state='indeterminate'
+                                        THEN 1 ELSE 0 END
+                         WHERE schema_name='{_SCHEMA_NAME}';
+                        INSERT INTO webhook_ledger_scope_usage (
+                            profile, route, provider, reserved_bytes, proof_count,
+                            active_record_count, settled_operation_count
+                        ) VALUES (
+                            NEW.profile, NEW.route, NEW.provider,
+                            {_OPERATION_STORAGE_RESERVATION_BYTES}, 1,
+                            CASE WHEN NEW.state NOT IN (
+                                'settled','indeterminate'
+                            ) THEN 1 ELSE 0 END,
+                            CASE WHEN NEW.state='settled' THEN 1 ELSE 0 END
+                        ) ON CONFLICT(profile, route, provider) DO UPDATE SET
+                            reserved_bytes=reserved_bytes+
+                                {_OPERATION_STORAGE_RESERVATION_BYTES},
+                            proof_count=proof_count+1,
+                            active_record_count=active_record_count+
+                                CASE WHEN NEW.state NOT IN (
+                                    'settled','indeterminate'
+                                ) THEN 1 ELSE 0 END,
+                            settled_operation_count=settled_operation_count+
+                                CASE WHEN NEW.state='settled' THEN 1 ELSE 0 END;
+                    END"""
+            )
+            conn.execute(
+                f"""CREATE TRIGGER trg_webhook_operations_usage_delete
+                    AFTER DELETE ON webhook_operations
+                    BEGIN
+                        UPDATE webhook_ledger_usage
+                           SET reserved_bytes=reserved_bytes-
+                                   {_OPERATION_STORAGE_RESERVATION_BYTES},
+                               proof_count=proof_count-1,
+                               active_record_count=active_record_count-
+                                   CASE WHEN OLD.state NOT IN (
+                                       'settled','indeterminate'
+                                   ) THEN 1 ELSE 0 END,
+                               settled_operation_count=
+                                   settled_operation_count-
+                                   CASE WHEN OLD.state='settled'
+                                        THEN 1 ELSE 0 END,
+                               indeterminate_operation_count=
+                                   indeterminate_operation_count-
+                                   CASE WHEN OLD.state='indeterminate'
+                                        THEN 1 ELSE 0 END
+                         WHERE schema_name='{_SCHEMA_NAME}';
+                        UPDATE webhook_ledger_scope_usage
+                           SET reserved_bytes=reserved_bytes-
+                                   {_OPERATION_STORAGE_RESERVATION_BYTES},
+                               proof_count=proof_count-1,
+                               active_record_count=active_record_count-
+                                   CASE WHEN OLD.state NOT IN (
+                                       'settled','indeterminate'
+                                   ) THEN 1 ELSE 0 END,
+                               settled_operation_count=settled_operation_count-
+                                   CASE WHEN OLD.state='settled'
+                                        THEN 1 ELSE 0 END
+                         WHERE profile=OLD.profile AND route=OLD.route
+                           AND provider=OLD.provider;
+                        DELETE FROM webhook_ledger_scope_usage
+                         WHERE profile=OLD.profile AND route=OLD.route
+                           AND provider=OLD.provider AND proof_count=0
+                           AND auth_binding_count=0;
+                    END"""
+            )
+            conn.execute(
+                f"""CREATE TRIGGER trg_webhook_operations_usage_state
+                    AFTER UPDATE OF state ON webhook_operations
+                    WHEN OLD.state != NEW.state
+                    BEGIN
+                        UPDATE webhook_ledger_usage
+                           SET active_record_count=active_record_count
+                                   - CASE WHEN OLD.state NOT IN (
+                                       'settled','indeterminate'
+                                   ) THEN 1 ELSE 0 END
+                                   + CASE WHEN NEW.state NOT IN (
+                                       'settled','indeterminate'
+                                   ) THEN 1 ELSE 0 END,
+                               settled_operation_count=
+                                   settled_operation_count
+                                   - CASE WHEN OLD.state='settled'
+                                        THEN 1 ELSE 0 END
+                                   + CASE WHEN NEW.state='settled'
+                                        THEN 1 ELSE 0 END,
+                               indeterminate_operation_count=
+                                   indeterminate_operation_count
+                                   - CASE WHEN OLD.state='indeterminate'
+                                        THEN 1 ELSE 0 END
+                                   + CASE WHEN NEW.state='indeterminate'
+                                        THEN 1 ELSE 0 END
+                         WHERE schema_name='{_SCHEMA_NAME}';
+                        UPDATE webhook_ledger_scope_usage
+                           SET active_record_count=active_record_count
+                                   - CASE WHEN OLD.state NOT IN (
+                                       'settled','indeterminate'
+                                   ) THEN 1 ELSE 0 END
+                                   + CASE WHEN NEW.state NOT IN (
+                                       'settled','indeterminate'
+                                   ) THEN 1 ELSE 0 END
+                               , settled_operation_count=
+                                   settled_operation_count
+                                   - CASE WHEN OLD.state='settled'
+                                        THEN 1 ELSE 0 END
+                                   + CASE WHEN NEW.state='settled'
+                                        THEN 1 ELSE 0 END
+                         WHERE profile=OLD.profile AND route=OLD.route
+                           AND provider=OLD.provider;
+                    END"""
+            )
+            conn.execute(
+                f"""CREATE TRIGGER trg_webhook_tombstones_budget_insert
+                    BEFORE INSERT ON webhook_delivery_tombstones
+                    WHEN NOT EXISTS (
+                             SELECT 1 FROM webhook_ledger_usage
+                              WHERE schema_name='{_SCHEMA_NAME}'
+                                AND reserved_bytes <= max_storage_bytes-
+                                        {_TOMBSTONE_STORAGE_RESERVATION_BYTES}
+                         )
+                         OR COALESCE((
+                                SELECT reserved_bytes
+                                  FROM webhook_ledger_scope_usage
+                                 WHERE profile=NEW.profile
+                                   AND route=NEW.route
+                                   AND provider=NEW.provider
+                            ), 0) > (
+                                SELECT scope_limit_bytes-
+                                       {_TOMBSTONE_STORAGE_RESERVATION_BYTES}
+                                  FROM webhook_ledger_usage
+                                 WHERE schema_name='{_SCHEMA_NAME}'
+                            )
+                    BEGIN
+                        SELECT RAISE(ABORT, 'webhook_ledger_full');
+                    END"""
+            )
+            conn.execute(
+                f"""CREATE TRIGGER trg_webhook_tombstones_usage_insert
+                    AFTER INSERT ON webhook_delivery_tombstones
+                    BEGIN
+                        UPDATE webhook_ledger_usage
+                           SET reserved_bytes=reserved_bytes+
+                                   {_TOMBSTONE_STORAGE_RESERVATION_BYTES},
+                               proof_count=proof_count+1
+                         WHERE schema_name='{_SCHEMA_NAME}';
+                        INSERT INTO webhook_ledger_scope_usage (
+                            profile, route, provider, reserved_bytes, proof_count
+                        ) VALUES (
+                            NEW.profile, NEW.route, NEW.provider,
+                            {_TOMBSTONE_STORAGE_RESERVATION_BYTES}, 1
+                        ) ON CONFLICT(profile, route, provider) DO UPDATE SET
+                            reserved_bytes=reserved_bytes+
+                                {_TOMBSTONE_STORAGE_RESERVATION_BYTES},
+                            proof_count=proof_count+1;
+                    END"""
+            )
+            conn.execute(
+                f"""CREATE TRIGGER trg_webhook_tombstones_usage_delete
+                    AFTER DELETE ON webhook_delivery_tombstones
+                    BEGIN
+                        UPDATE webhook_ledger_usage
+                           SET reserved_bytes=reserved_bytes-
+                                   {_TOMBSTONE_STORAGE_RESERVATION_BYTES},
+                               proof_count=proof_count-1
+                         WHERE schema_name='{_SCHEMA_NAME}';
+                        UPDATE webhook_ledger_scope_usage
+                           SET reserved_bytes=reserved_bytes-
+                                   {_TOMBSTONE_STORAGE_RESERVATION_BYTES},
+                               proof_count=proof_count-1
+                         WHERE profile=OLD.profile AND route=OLD.route
+                           AND provider=OLD.provider;
+                        DELETE FROM webhook_ledger_scope_usage
+                         WHERE profile=OLD.profile AND route=OLD.route
+                           AND provider=OLD.provider AND proof_count=0
+                           AND auth_binding_count=0;
+                    END"""
+            )
+            conn.execute(
+                """CREATE TABLE IF NOT EXISTS webhook_ledger_meta (
+                    schema_name TEXT PRIMARY KEY CHECK (
+                        schema_name='webhook_operation_ledger'
+                    ),
+                    schema_version INTEGER NOT NULL CHECK (schema_version=5)
+                )"""
+            )
+            conn.execute(
+                """INSERT OR IGNORE INTO webhook_ledger_meta (
+                       schema_name, schema_version
+                   ) VALUES (?, ?)""",
+                (_SCHEMA_NAME, _SCHEMA_VERSION),
+            )
+            conn.execute(
+                """CREATE TABLE IF NOT EXISTS webhook_auth_key_bindings (
+                    key_fingerprint TEXT PRIMARY KEY CHECK (
+                        length(key_fingerprint)=64 AND
+                        key_fingerprint NOT GLOB '*[^0-9a-f]*'
+                    ),
+                    profile TEXT NOT NULL CHECK (
+                        length(CAST(profile AS BLOB)) BETWEEN 1 AND 1024
+                    ),
+                    route TEXT NOT NULL CHECK (
+                        length(CAST(route AS BLOB)) BETWEEN 1 AND 1024
+                    ),
+                    provider TEXT NOT NULL CHECK (
+                        length(CAST(provider AS BLOB)) BETWEEN 1 AND 1024
+                    ),
+                    signature_mode TEXT NOT NULL CHECK (
+                        length(CAST(signature_mode AS BLOB)) BETWEEN 1 AND 1024
+                    ),
+                    policy_sha256 TEXT NOT NULL CHECK (
+                        length(policy_sha256)=64 AND
+                        policy_sha256 NOT GLOB '*[^0-9a-f]*'
+                    ),
+                    bound_at REAL NOT NULL
+                )"""
+            )
+            conn.execute(
+                f"""CREATE TRIGGER trg_webhook_auth_bindings_budget_insert
+                    BEFORE INSERT ON webhook_auth_key_bindings
+                    WHEN NOT EXISTS (
+                        SELECT 1 FROM webhook_ledger_usage
+                         WHERE schema_name='{_SCHEMA_NAME}'
+                           AND auth_binding_reserved_bytes <=
+                               auth_binding_limit_bytes-
+                               {_AUTH_BINDING_STORAGE_RESERVATION_BYTES}
+                    )
+                    OR COALESCE((
+                           SELECT auth_binding_reserved_bytes
+                             FROM webhook_ledger_scope_usage
+                            WHERE profile=NEW.profile
+                              AND route=NEW.route
+                              AND provider=NEW.provider
+                       ), 0) > (
+                           SELECT auth_binding_scope_limit_bytes-
+                                  {_AUTH_BINDING_STORAGE_RESERVATION_BYTES}
+                             FROM webhook_ledger_usage
+                            WHERE schema_name='{_SCHEMA_NAME}'
+                       )
+                    BEGIN
+                        SELECT RAISE(ABORT, 'webhook_ledger_full');
+                    END"""
+            )
+            conn.execute(
+                f"""CREATE TRIGGER trg_webhook_auth_bindings_usage_insert
+                    AFTER INSERT ON webhook_auth_key_bindings
+                    BEGIN
+                        UPDATE webhook_ledger_usage
+                           SET auth_binding_reserved_bytes=
+                                   auth_binding_reserved_bytes+
+                                   {_AUTH_BINDING_STORAGE_RESERVATION_BYTES},
+                               auth_binding_count=auth_binding_count+1
+                         WHERE schema_name='{_SCHEMA_NAME}';
+                        INSERT INTO webhook_ledger_scope_usage (
+                            profile, route, provider, reserved_bytes, proof_count,
+                            active_record_count, settled_operation_count,
+                            auth_binding_reserved_bytes, auth_binding_count
+                        ) VALUES (
+                            NEW.profile, NEW.route, NEW.provider,
+                            0, 0, 0, 0,
+                            {_AUTH_BINDING_STORAGE_RESERVATION_BYTES}, 1
+                        ) ON CONFLICT(profile, route, provider) DO UPDATE SET
+                            auth_binding_reserved_bytes=
+                                auth_binding_reserved_bytes+
+                                {_AUTH_BINDING_STORAGE_RESERVATION_BYTES},
+                            auth_binding_count=auth_binding_count+1;
+                    END"""
+            )
+            conn.execute(
+                """CREATE TRIGGER trg_webhook_auth_bindings_immutable_update
+                    BEFORE UPDATE ON webhook_auth_key_bindings
+                    BEGIN
+                        SELECT RAISE(ABORT, 'webhook_auth_binding_immutable');
+                    END"""
+            )
+            conn.execute(
+                """CREATE TRIGGER trg_webhook_auth_bindings_immutable_delete
+                    BEFORE DELETE ON webhook_auth_key_bindings
+                    BEGIN
+                        SELECT RAISE(ABORT, 'webhook_auth_binding_immutable');
+                    END"""
+            )
+            if migrate_v4:
+                try:
+                    self._restore_v4_rows(conn)
+                except sqlite3.IntegrityError as exc:
+                    if "webhook_ledger_full" in str(exc):
+                        raise WebhookLedgerCapacityError(
+                            "webhook v4 migration exceeds the configured "
+                            "storage capacity; increase "
+                            "idempotency_max_storage_bytes"
+                        ) from exc
+                    raise WebhookLedgerCorruptionError(
+                        "webhook v4 ledger contains invalid durable authority"
+                    ) from exc
+            self._validate_schema(conn)
+
+    @staticmethod
+    def _validate_schema(conn: sqlite3.Connection) -> None:
+        """Reject silently shadowed or incompatible authority tables/indexes."""
+
+        expected_operation_columns = (
+            "operation_id",
+            "profile",
+            "route",
+            "provider",
+            "replay_id",
+            "body_sha256",
+            "event_type",
+            "session_key",
+            "state",
+            "generation",
+            "owner_pid",
+            "owner_started_at",
+            "owner_instance",
+            "event_json",
+            "target_json",
+            "grant_json",
+            "script_started",
+            "created_at",
+            "updated_at",
+            "settled_at",
+            "last_error",
+        )
+        expected_target_columns = (
+            "operation_id",
+            "target_id",
+            "state",
+            "attempt_token",
+            "content_sha256",
+            "delivery_json",
+            "delivery_sha256",
+            "external_id",
+            "owner_pid",
+            "owner_started_at",
+            "owner_instance",
+            "started_at",
+            "settled_at",
+            "updated_at",
+            "last_error",
+        )
+        operation_info = conn.execute(
+            "PRAGMA table_info(webhook_operations)"
+        ).fetchall()
+        target_info = conn.execute("PRAGMA table_info(webhook_targets)").fetchall()
+        tombstone_info = conn.execute(
+            "PRAGMA table_info(webhook_delivery_tombstones)"
+        ).fetchall()
+        usage_info = conn.execute("PRAGMA table_info(webhook_ledger_usage)").fetchall()
+        scope_usage_info = conn.execute(
+            "PRAGMA table_info(webhook_ledger_scope_usage)"
+        ).fetchall()
+        auth_binding_info = conn.execute(
+            "PRAGMA table_info(webhook_auth_key_bindings)"
+        ).fetchall()
+        if tuple(row["name"] for row in operation_info) != expected_operation_columns:
+            raise WebhookLedgerCorruptionError(
+                "webhook operation ledger schema is incompatible"
+            )
+        if tuple(row["name"] for row in target_info) != expected_target_columns:
+            raise WebhookLedgerCorruptionError(
+                "webhook target ledger schema is incompatible"
+            )
+        expected_tombstone_columns = (
+            "profile",
+            "route",
+            "provider",
+            "replay_id",
+            "body_sha256",
+            "operation_id",
+            "state",
+            "settled_at",
+            "expires_at",
+        )
+        if tuple(row["name"] for row in tombstone_info) != expected_tombstone_columns:
+            raise WebhookLedgerCorruptionError(
+                "webhook delivery tombstone schema is incompatible"
+            )
+        expected_usage_columns = (
+            "schema_name",
+            "reserved_bytes",
+            "proof_count",
+            "active_record_count",
+            "settled_operation_count",
+            "indeterminate_operation_count",
+            "auth_binding_reserved_bytes",
+            "auth_binding_count",
+            "max_records",
+            "max_storage_bytes",
+            "scope_limit_bytes",
+            "operation_limits_provisional",
+            "auth_binding_limit_bytes",
+            "auth_binding_scope_limit_bytes",
+        )
+        if tuple(row["name"] for row in usage_info) != expected_usage_columns:
+            raise WebhookLedgerCorruptionError(
+                "webhook ledger usage schema is incompatible"
+            )
+        if [int(row["pk"]) for row in operation_info] != [1] + [0] * (
+            len(operation_info) - 1
+        ):
+            raise WebhookLedgerCorruptionError(
+                "webhook operation primary key is incompatible"
+            )
+        if [int(row["pk"]) for row in target_info] != [1] + [0] * (
+            len(target_info) - 1
+        ):
+            raise WebhookLedgerCorruptionError(
+                "webhook target primary key is incompatible"
+            )
+        if [int(row["pk"]) for row in tombstone_info] != [1, 2, 3, 4] + [0] * 5:
+            raise WebhookLedgerCorruptionError(
+                "webhook delivery tombstone primary key is incompatible"
+            )
+        if [int(row["pk"]) for row in usage_info] != [1] + [0] * 13:
+            raise WebhookLedgerCorruptionError(
+                "webhook ledger usage primary key is incompatible"
+            )
+        expected_scope_usage_columns = (
+            "profile",
+            "route",
+            "provider",
+            "reserved_bytes",
+            "proof_count",
+            "active_record_count",
+            "settled_operation_count",
+            "auth_binding_reserved_bytes",
+            "auth_binding_count",
+        )
+        if tuple(
+            row["name"] for row in scope_usage_info
+        ) != expected_scope_usage_columns or [
+            int(row["pk"]) for row in scope_usage_info
+        ] != [1, 2, 3, 0, 0, 0, 0, 0, 0]:
+            raise WebhookLedgerCorruptionError(
+                "webhook ledger scope usage schema is incompatible"
+            )
+        expected_auth_binding_columns = (
+            "key_fingerprint",
+            "profile",
+            "route",
+            "provider",
+            "signature_mode",
+            "policy_sha256",
+            "bound_at",
+        )
+        if tuple(
+            row["name"] for row in auth_binding_info
+        ) != expected_auth_binding_columns or [
+            int(row["pk"]) for row in auth_binding_info
+        ] != [1, 0, 0, 0, 0, 0, 0]:
+            raise WebhookLedgerCorruptionError(
+                "webhook authentication key binding schema is incompatible"
+            )
+
+        expected_trigger_owners = {
+            "trg_webhook_operations_budget_insert": "webhook_operations",
+            "trg_webhook_operations_usage_insert": "webhook_operations",
+            "trg_webhook_operations_usage_delete": "webhook_operations",
+            "trg_webhook_operations_usage_state": "webhook_operations",
+            "trg_webhook_tombstones_budget_insert": ("webhook_delivery_tombstones"),
+            "trg_webhook_tombstones_usage_insert": ("webhook_delivery_tombstones"),
+            "trg_webhook_tombstones_usage_delete": ("webhook_delivery_tombstones"),
+            "trg_webhook_auth_bindings_budget_insert": ("webhook_auth_key_bindings"),
+            "trg_webhook_auth_bindings_usage_insert": ("webhook_auth_key_bindings"),
+            "trg_webhook_auth_bindings_immutable_update": ("webhook_auth_key_bindings"),
+            "trg_webhook_auth_bindings_immutable_delete": ("webhook_auth_key_bindings"),
+        }
+        trigger_names = tuple(expected_trigger_owners)
+        trigger_owners = {
+            row["name"]: row["tbl_name"]
+            for row in conn.execute(
+                f"""SELECT name, tbl_name FROM sqlite_master
+                    WHERE type='trigger' AND name IN (
+                        {",".join("?" for _name in trigger_names)}
+                    )""",
+                trigger_names,
+            )
+        }
+        if trigger_owners != expected_trigger_owners:
+            raise WebhookLedgerCorruptionError(
+                "webhook ledger usage triggers are unavailable"
+            )
+
+        usage_rows = conn.execute(
+            "SELECT * FROM webhook_ledger_usage WHERE schema_name=?",
+            (_SCHEMA_NAME,),
+        ).fetchall()
+        if len(usage_rows) != 1:
+            raise WebhookLedgerCorruptionError(
+                "webhook ledger usage authority is unavailable"
+            )
+        operation_state_counts = conn.execute(
+            """SELECT COUNT(*) AS operation_count,
+                      COALESCE(SUM(
+                          CASE WHEN state NOT IN ('settled','indeterminate')
+                               THEN 1 ELSE 0 END
+                      ), 0) AS active_record_count,
+                      COALESCE(SUM(
+                          CASE WHEN state='settled' THEN 1 ELSE 0 END
+                      ), 0) AS settled_operation_count,
+                      COALESCE(SUM(
+                          CASE WHEN state='indeterminate' THEN 1 ELSE 0 END
+                      ), 0) AS indeterminate_operation_count
+                 FROM webhook_operations"""
+        ).fetchone()
+        if operation_state_counts is None:  # pragma: no cover - aggregate row
+            raise WebhookLedgerCorruptionError(
+                "webhook operation state counters are unavailable"
+            )
+        operation_count = int(operation_state_counts["operation_count"])
+        tombstone_count = int(
+            conn.execute("SELECT COUNT(*) FROM webhook_delivery_tombstones").fetchone()[
+                0
+            ]
+        )
+        auth_binding_count = int(
+            conn.execute("SELECT COUNT(*) FROM webhook_auth_key_bindings").fetchone()[0]
+        )
+        for binding in conn.execute("SELECT * FROM webhook_auth_key_bindings"):
+            try:
+                fingerprint = _normalize_sha256(
+                    binding["key_fingerprint"],
+                    label="stored authentication key fingerprint",
+                )
+                policy_sha256 = _normalize_sha256(
+                    binding["policy_sha256"],
+                    label="stored authentication policy fingerprint",
+                )
+                owner = tuple(
+                    _normalize_nonempty(
+                        binding[key],
+                        label=f"stored authentication {key}",
+                    )
+                    for key in (
+                        "profile",
+                        "route",
+                        "provider",
+                        "signature_mode",
+                    )
+                )
+                bound_at = float(binding["bound_at"])
+            except (TypeError, ValueError, OverflowError, WebhookLedgerError) as exc:
+                raise WebhookLedgerCorruptionError(
+                    "webhook authentication key binding is invalid"
+                ) from exc
+            if (
+                fingerprint != binding["key_fingerprint"]
+                or policy_sha256 != binding["policy_sha256"]
+                or owner
+                != tuple(
+                    binding[key]
+                    for key in (
+                        "profile",
+                        "route",
+                        "provider",
+                        "signature_mode",
+                    )
+                )
+                or not math.isfinite(bound_at)
+            ):
+                raise WebhookLedgerCorruptionError(
+                    "webhook authentication key binding is invalid"
+                )
+        usage = usage_rows[0]
+        expected_proof_count = operation_count + tombstone_count
+        expected_reserved_bytes = (
+            operation_count * _OPERATION_STORAGE_RESERVATION_BYTES
+            + tombstone_count * _TOMBSTONE_STORAGE_RESERVATION_BYTES
+        )
+        expected_auth_binding_reserved_bytes = (
+            auth_binding_count * _AUTH_BINDING_STORAGE_RESERVATION_BYTES
+        )
+        if (
+            int(usage["proof_count"]) != expected_proof_count
+            or int(usage["reserved_bytes"]) != expected_reserved_bytes
+            or int(usage["active_record_count"])
+            != int(operation_state_counts["active_record_count"])
+            or int(usage["settled_operation_count"])
+            != int(operation_state_counts["settled_operation_count"])
+            or int(usage["indeterminate_operation_count"])
+            != int(operation_state_counts["indeterminate_operation_count"])
+            or int(usage["auth_binding_reserved_bytes"])
+            != expected_auth_binding_reserved_bytes
+            or int(usage["auth_binding_count"]) != auth_binding_count
+            or int(usage["max_records"]) < 1
+            or int(usage["max_records"]) > MAXIMUM_MAX_RECORDS
+            or int(usage["max_storage_bytes"]) < MINIMUM_MAX_STORAGE_BYTES
+            or int(usage["max_storage_bytes"]) > MAXIMUM_MAX_STORAGE_BYTES
+            or int(usage["scope_limit_bytes"])
+            != _scope_storage_limit(int(usage["max_storage_bytes"]))
+            or int(usage["operation_limits_provisional"]) not in (0, 1)
+            or int(usage["auth_binding_limit_bytes"])
+            != _AUTH_BINDING_GLOBAL_LIMIT_BYTES
+            or int(usage["auth_binding_scope_limit_bytes"])
+            != _AUTH_BINDING_SCOPE_LIMIT_BYTES
+        ):
+            raise WebhookLedgerCorruptionError(
+                "webhook ledger usage counter is inconsistent"
+            )
+
+        expected_scope_usage = {
+            (row["profile"], row["route"], row["provider"]): (
+                int(row["reserved_bytes"]),
+                int(row["proof_count"]),
+                int(row["active_record_count"]),
+                int(row["settled_operation_count"]),
+                int(row["auth_binding_reserved_bytes"]),
+                int(row["auth_binding_count"]),
+            )
+            for row in conn.execute(
+                f"""SELECT profile, route, provider,
+                            SUM(reserved_bytes) AS reserved_bytes,
+                            SUM(proof_count) AS proof_count,
+                            SUM(active_record_count) AS active_record_count,
+                            SUM(settled_operation_count)
+                                AS settled_operation_count,
+                            SUM(auth_binding_reserved_bytes)
+                                AS auth_binding_reserved_bytes,
+                            SUM(auth_binding_count) AS auth_binding_count
+                       FROM (
+                           SELECT profile, route, provider,
+                                  {_OPERATION_STORAGE_RESERVATION_BYTES}
+                                      AS reserved_bytes,
+                                  1 AS proof_count,
+                                  CASE WHEN state NOT IN (
+                                      'settled','indeterminate'
+                                  ) THEN 1 ELSE 0 END AS active_record_count,
+                                  CASE WHEN state='settled'
+                                       THEN 1 ELSE 0 END
+                                      AS settled_operation_count,
+                                  0 AS auth_binding_reserved_bytes,
+                                  0 AS auth_binding_count
+                             FROM webhook_operations
+                           UNION ALL
+                           SELECT profile, route, provider,
+                                  {_TOMBSTONE_STORAGE_RESERVATION_BYTES}
+                                      AS reserved_bytes,
+                                  1 AS proof_count,
+                                  0 AS active_record_count,
+                                  0 AS settled_operation_count,
+                                  0 AS auth_binding_reserved_bytes,
+                                  0 AS auth_binding_count
+                             FROM webhook_delivery_tombstones
+                           UNION ALL
+                           SELECT profile, route, provider,
+                                  0 AS reserved_bytes,
+                                  0 AS proof_count,
+                                  0 AS active_record_count,
+                                  0 AS settled_operation_count,
+                                  {_AUTH_BINDING_STORAGE_RESERVATION_BYTES}
+                                      AS auth_binding_reserved_bytes,
+                                  1 AS auth_binding_count
+                             FROM webhook_auth_key_bindings
+                       )
+                      GROUP BY profile, route, provider"""
+            )
+        }
+        actual_scope_usage = {
+            (row["profile"], row["route"], row["provider"]): (
+                int(row["reserved_bytes"]),
+                int(row["proof_count"]),
+                int(row["active_record_count"]),
+                int(row["settled_operation_count"]),
+                int(row["auth_binding_reserved_bytes"]),
+                int(row["auth_binding_count"]),
+            )
+            for row in conn.execute("SELECT * FROM webhook_ledger_scope_usage")
+        }
+        if actual_scope_usage != expected_scope_usage or any(
+            reserved_bytes > int(usage["scope_limit_bytes"])
+            or auth_binding_reserved_bytes
+            > int(usage["auth_binding_scope_limit_bytes"])
+            or active_record_count < 0
+            or active_record_count > _proof_count
+            or settled_operation_count < 0
+            or active_record_count + settled_operation_count > _proof_count
+            for (
+                reserved_bytes,
+                _proof_count,
+                active_record_count,
+                settled_operation_count,
+                auth_binding_reserved_bytes,
+                _auth_binding_count,
+            ) in actual_scope_usage.values()
+        ):
+            raise WebhookLedgerCorruptionError(
+                "webhook ledger scope usage counter is inconsistent"
+            )
+
+        bounded_expiry_clause = " OR ".join(
+            "substr(replay_id, 1, ?)=?" for _prefix in _BOUNDED_REPLAY_PREFIXES
+        )
+        bounded_expiry_params: list[Any] = []
+        for prefix in _BOUNDED_REPLAY_PREFIXES:
+            bounded_expiry_params.extend((len(prefix), prefix))
+        invalid_expiry = conn.execute(
+            f"""SELECT expires_at FROM webhook_delivery_tombstones
+                 WHERE expires_at IS NOT NULL
+                   AND (state!='settled' OR NOT ({bounded_expiry_clause}))
+                 LIMIT 1""",
+            bounded_expiry_params,
+        ).fetchone()
+        nonfinite_expiry = any(
+            not math.isfinite(float(row["expires_at"]))
+            for row in conn.execute(
+                """SELECT expires_at FROM webhook_delivery_tombstones
+                    WHERE expires_at IS NOT NULL"""
+            )
+        )
+        if invalid_expiry is not None or nonfinite_expiry:
+            raise WebhookLedgerCorruptionError(
+                "webhook delivery tombstone expiry is invalid"
+            )
+
+        tombstone_indexes = {
+            row["name"]: row
+            for row in conn.execute("PRAGMA index_list(webhook_delivery_tombstones)")
+        }
+        expiry_index = tombstone_indexes.get("idx_webhook_tombstones_expires_at")
+        if (
+            expiry_index is None
+            or bool(expiry_index["unique"])
+            or not bool(expiry_index["partial"])
+            or tuple(
+                row["name"]
+                for row in conn.execute(
+                    "PRAGMA index_info(idx_webhook_tombstones_expires_at)"
+                )
+            )
+            != ("expires_at",)
+        ):
+            raise WebhookLedgerCorruptionError(
+                "webhook tombstone expiry index is unavailable"
+            )
+
+        indexes = {
+            row["name"]: row
+            for row in conn.execute("PRAGMA index_list(webhook_operations)")
+        }
+        stable = indexes.get("idx_webhook_operations_replay_identity")
+        if (
+            stable is None
+            or not bool(stable["unique"])
+            or bool(stable["partial"])
+            or tuple(
+                row["name"]
+                for row in conn.execute(
+                    "PRAGMA index_info(idx_webhook_operations_replay_identity)"
+                )
+            )
+            != ("profile", "route", "provider", "replay_id")
+        ):
+            raise WebhookLedgerCorruptionError(
+                "webhook replay-identity uniqueness is unavailable"
+            )
+        expected_admission_indexes = {
+            "idx_webhook_operations_state_updated": (
+                "state",
+                "updated_at",
+            ),
+            "idx_webhook_operations_scope_state_updated": (
+                "profile",
+                "route",
+                "provider",
+                "state",
+                "updated_at",
+            ),
+        }
+        for index_name, expected_columns in expected_admission_indexes.items():
+            index = indexes.get(index_name)
+            if (
+                index is None
+                or bool(index["unique"])
+                or bool(index["partial"])
+                or tuple(
+                    row["name"]
+                    for row in conn.execute(
+                        "SELECT name FROM pragma_index_info(?)",
+                        (index_name,),
+                    )
+                )
+                != expected_columns
+            ):
+                raise WebhookLedgerCorruptionError(
+                    "webhook bounded admission indexes are unavailable"
+                )
+        expected_recovery_indexes = {
+            "idx_webhook_operations_recovery_order": (
+                ("created_at", "operation_id"),
+                """CREATE INDEX idx_webhook_operations_recovery_order
+                    ON webhook_operations(created_at, operation_id)
+                    WHERE state IN (
+                        'preparing','ready','running','delivery_ready','delivering'
+                    )""",
+            ),
+            "idx_webhook_operations_owner_recovery_order": (
+                ("owner_instance", "created_at", "operation_id"),
+                """CREATE INDEX idx_webhook_operations_owner_recovery_order
+                    ON webhook_operations(
+                        owner_instance, created_at, operation_id
+                    )
+                    WHERE state IN (
+                        'preparing','ready','running','delivery_ready','delivering'
+                    )""",
+            ),
+            "idx_webhook_operations_profile_recovery_order": (
+                ("profile", "created_at", "operation_id"),
+                """CREATE INDEX idx_webhook_operations_profile_recovery_order
+                    ON webhook_operations(
+                        profile, created_at, operation_id
+                    )
+                    WHERE state IN (
+                        'preparing','ready','running','delivery_ready','delivering'
+                    )""",
+            ),
+            "idx_webhook_operations_owner_delivery_ready": (
+                ("owner_instance", "created_at", "operation_id"),
+                """CREATE INDEX idx_webhook_operations_owner_delivery_ready
+                    ON webhook_operations(
+                        owner_instance, created_at, operation_id
+                    )
+                    WHERE state='delivery_ready'""",
+            ),
+            "idx_webhook_operations_owner_profile_delivery_ready": (
+                ("owner_instance", "profile", "created_at", "operation_id"),
+                """CREATE INDEX idx_webhook_operations_owner_profile_delivery_ready
+                    ON webhook_operations(
+                        owner_instance, profile, created_at, operation_id
+                    )
+                    WHERE state='delivery_ready'""",
+            ),
+            "idx_webhook_operations_owner_current_recovery": (
+                ("owner_instance", "created_at", "operation_id"),
+                """CREATE INDEX idx_webhook_operations_owner_current_recovery
+                    ON webhook_operations(
+                        owner_instance, created_at, operation_id
+                    )
+                    WHERE state='delivery_ready'
+                       OR (state='ready' AND generation>=2)""",
+            ),
+            "idx_webhook_operations_owner_profile_current_recovery": (
+                ("owner_instance", "profile", "created_at", "operation_id"),
+                """CREATE INDEX
+                    idx_webhook_operations_owner_profile_current_recovery
+                    ON webhook_operations(
+                        owner_instance, profile, created_at, operation_id
+                    )
+                    WHERE state='delivery_ready'
+                       OR (state='ready' AND generation>=2)""",
+            ),
+        }
+        for index_name, (
+            expected_columns,
+            expected_sql,
+        ) in expected_recovery_indexes.items():
+            index = indexes.get(index_name)
+            stored_sql = conn.execute(
+                """SELECT sql FROM sqlite_master
+                     WHERE type='index' AND name=?""",
+                (index_name,),
+            ).fetchone()
+            if (
+                index is None
+                or bool(index["unique"])
+                or not bool(index["partial"])
+                or tuple(
+                    row["name"]
+                    for row in conn.execute(
+                        "SELECT name FROM pragma_index_info(?)",
+                        (index_name,),
+                    )
+                )
+                != expected_columns
+                or stored_sql is None
+                or "".join(str(stored_sql["sql"]).lower().split())
+                != "".join(expected_sql.lower().split())
+            ):
+                raise WebhookLedgerCorruptionError(
+                    "webhook bounded recovery indexes are unavailable"
+                )
+        bounded_replay_prefix = _BOUNDED_REPLAY_PREFIXES[0]
+        bounded_expiry_index = indexes.get(
+            "idx_webhook_operations_bounded_settled_expiry"
+        )
+        bounded_expiry_sql = conn.execute(
+            """SELECT sql FROM sqlite_master
+                 WHERE type='index'
+                   AND name='idx_webhook_operations_bounded_settled_expiry'"""
+        ).fetchone()
+        expected_bounded_expiry_sql = f"""CREATE INDEX
+            idx_webhook_operations_bounded_settled_expiry
+            ON webhook_operations(COALESCE(settled_at, updated_at))
+            WHERE state='settled'
+              AND substr(replay_id, 1, {len(bounded_replay_prefix)})=
+                  '{bounded_replay_prefix}'"""
+        if (
+            bounded_expiry_index is None
+            or bool(bounded_expiry_index["unique"])
+            or not bool(bounded_expiry_index["partial"])
+            or bounded_expiry_sql is None
+            or "".join(str(bounded_expiry_sql["sql"]).lower().split())
+            != "".join(expected_bounded_expiry_sql.lower().split())
+        ):
+            raise WebhookLedgerCorruptionError(
+                "webhook bounded-settlement expiry index is unavailable"
+            )
+        session_unique = any(
+            bool(index["unique"])
+            and not bool(index["partial"])
+            and tuple(
+                row["name"]
+                for row in conn.execute(
+                    "SELECT name FROM pragma_index_info(?)", (index["name"],)
+                )
+            )
+            == ("session_key",)
+            for index in indexes.values()
+        )
+        if not session_unique:
+            raise WebhookLedgerCorruptionError(
+                "webhook session uniqueness is unavailable"
+            )
+
+        foreign_keys = conn.execute(
+            "PRAGMA foreign_key_list(webhook_targets)"
+        ).fetchall()
+        if not any(
+            row["table"] == "webhook_operations"
+            and row["from"] == "operation_id"
+            and row["to"] == "operation_id"
+            and str(row["on_delete"]).upper() == "CASCADE"
+            for row in foreign_keys
+        ):
+            raise WebhookLedgerCorruptionError(
+                "webhook target ownership constraint is unavailable"
+            )
+
+        metadata = conn.execute(
+            """SELECT schema_version FROM webhook_ledger_meta
+               WHERE schema_name=?""",
+            (_SCHEMA_NAME,),
+        ).fetchone()
+        if metadata is None or int(metadata["schema_version"]) != _SCHEMA_VERSION:
+            raise WebhookLedgerCorruptionError(
+                "webhook operation ledger schema version is unsupported"
+            )
+
+    @staticmethod
+    def _target_row(
+        conn: sqlite3.Connection, operation_id: str
+    ) -> Optional[sqlite3.Row]:
+        rows = conn.execute(
+            """SELECT target_id, state, attempt_token, content_sha256,
+                      delivery_json, delivery_sha256, external_id,
+                      owner_pid, owner_started_at,
+                      owner_instance, started_at, settled_at, updated_at, last_error
+               FROM webhook_targets WHERE operation_id=?""",
+            (operation_id,),
+        ).fetchall()
+        if len(rows) > 1:
+            raise WebhookLedgerCorruptionError(
+                f"operation {operation_id!r} has more than one target"
+            )
+        return rows[0] if rows else None
+
+    def _authority_from_row(
+        self, conn: sqlite3.Connection, row: sqlite3.Row
+    ) -> OperationAuthority:
+        try:
+            state = OperationState(row["state"])
+        except (KeyError, ValueError) as exc:
+            raise WebhookLedgerCorruptionError(
+                "stored operation state is invalid"
+            ) from exc
+        target = self._target_row(conn, row["operation_id"])
+        try:
+            target_state = TargetState(target["state"]) if target is not None else None
+        except ValueError as exc:
+            raise WebhookLedgerCorruptionError(
+                "stored target state is invalid"
+            ) from exc
+        delivery = (
+            _decode_staged_delivery(
+                target["delivery_json"],
+                target["content_sha256"],
+                target["delivery_sha256"],
+            )
+            if target is not None
+            else None
+        )
+        owner_instance = row["owner_instance"]
+        if not isinstance(owner_instance, str) or not owner_instance:
+            raise WebhookLedgerCorruptionError(
+                "stored operation owner instance is invalid"
+            )
+        return OperationAuthority(
+            operation_id=row["operation_id"],
+            generation=int(row["generation"]),
+            session_key=row["session_key"],
+            profile=row["profile"],
+            route=row["route"],
+            provider=row["provider"],
+            replay_id=row["replay_id"],
+            body_sha256=row["body_sha256"],
+            event_type=row["event_type"],
+            state=state,
+            owner_instance=owner_instance,
+            target_id=target["target_id"] if target is not None else None,
+            target_state=target_state,
+            event_snapshot=_decode_json(
+                row["event_json"],
+                label="event snapshot",
+                max_bytes=_MAX_EVENT_JSON_BYTES,
+            ),
+            target_snapshot=_decode_json(
+                row["target_json"],
+                label="target snapshot",
+                max_bytes=_MAX_AUTHORITY_JSON_BYTES,
+            ),
+            grant_snapshot=_decode_json(
+                row["grant_json"],
+                label="grant snapshot",
+                max_bytes=_MAX_AUTHORITY_JSON_BYTES,
+            ),
+            delivery=delivery,
+        )
+
+    @staticmethod
+    def _operation_row(
+        conn: sqlite3.Connection, operation_id: str
+    ) -> Optional[sqlite3.Row]:
+        return conn.execute(
+            "SELECT * FROM webhook_operations WHERE operation_id=?",
+            (operation_id,),
+        ).fetchone()
+
+    @staticmethod
+    def _disposition_for_state(state: OperationState) -> AdmitDisposition:
+        if state is OperationState.SETTLED:
+            return AdmitDisposition.DUPLICATE
+        if state is OperationState.INDETERMINATE:
+            return AdmitDisposition.INDETERMINATE
+        return AdmitDisposition.ACTIVE
+
+    @staticmethod
+    def _tombstone_from_row(row: sqlite3.Row) -> DeliveryTombstone:
+        try:
+            body_sha256 = _normalize_sha256(
+                row["body_sha256"], label="tombstone body_sha256"
+            )
+            replay_id = _normalize_nonempty(
+                row["replay_id"], label="tombstone replay_id"
+            )
+            operation_id = _normalize_nonempty(
+                row["operation_id"], label="tombstone operation_id"
+            )
+            state = OperationState(row["state"])
+            if state not in {
+                OperationState.SETTLED,
+                OperationState.INDETERMINATE,
+            }:
+                raise ValueError("nonterminal tombstone state")
+            settled_at = float(row["settled_at"])
+            if not math.isfinite(settled_at):
+                raise ValueError("non-finite settled_at")
+            expires_raw = row["expires_at"]
+            expires_at = None if expires_raw is None else float(expires_raw)
+            if expires_at is not None and (
+                not math.isfinite(expires_at)
+                or state is not OperationState.SETTLED
+                or not replay_id.startswith(_BOUNDED_REPLAY_PREFIXES)
+            ):
+                raise ValueError("invalid tombstone expiry")
+            return DeliveryTombstone(
+                profile=_normalize_nonempty(row["profile"], label="tombstone profile"),
+                route=_normalize_nonempty(row["route"], label="tombstone route"),
+                provider=_normalize_nonempty(
+                    row["provider"], label="tombstone provider"
+                ),
+                replay_id=replay_id,
+                body_sha256=body_sha256,
+                operation_id=operation_id,
+                state=state,
+                settled_at=settled_at,
+                expires_at=expires_at,
+            )
+        except (KeyError, TypeError, ValueError, WebhookLedgerError) as exc:
+            raise WebhookLedgerCorruptionError(
+                "stored delivery tombstone is invalid"
+            ) from exc
+
+    @staticmethod
+    def _tombstone_row(
+        conn: sqlite3.Connection,
+        *,
+        profile: str,
+        route: str,
+        provider: str,
+        replay_id: str,
+    ) -> Optional[sqlite3.Row]:
+        return conn.execute(
+            """SELECT * FROM webhook_delivery_tombstones
+               WHERE profile=? AND route=? AND provider=? AND replay_id=?""",
+            (profile, route, provider, replay_id),
+        ).fetchone()
+
+    @staticmethod
+    def _bounded_replay_id(replay_id: str) -> bool:
+        return str(replay_id).startswith(_BOUNDED_REPLAY_PREFIXES)
+
+    def _body_replay_expired(
+        self,
+        *,
+        replay_id: str,
+        terminal_at: float,
+        now: float,
+    ) -> bool:
+        return self._bounded_replay_id(replay_id) and (
+            now - terminal_at >= self.local_bypass_replay_retention_seconds
+        )
+
+    def _compact_terminal_row(
+        self,
+        conn: sqlite3.Connection,
+        row: sqlite3.Row,
+        *,
+        now: float,
+    ) -> None:
+        """Replace one heavy terminal row with its exact replay verdict."""
+
+        try:
+            state = OperationState(row["state"])
+        except ValueError as exc:
+            raise WebhookLedgerCorruptionError(
+                "terminal operation has an invalid state"
+            ) from exc
+        if state is not OperationState.SETTLED:
+            raise WebhookLedgerTransitionError(
+                "only settled webhook operations can be compacted"
+            )
+        terminal_at = float(row["settled_at"] or row["updated_at"])
+        replay_id = row["replay_id"]
+        bounded_settlement_expired = (
+            state is OperationState.SETTLED
+            and self._body_replay_expired(
+                replay_id=replay_id,
+                terminal_at=terminal_at,
+                now=now,
+            )
+        )
+        existing = self._tombstone_row(
+            conn,
+            profile=row["profile"],
+            route=row["route"],
+            provider=row["provider"],
+            replay_id=replay_id,
+        )
+        if existing is not None:
+            raise WebhookLedgerCorruptionError(
+                "replay identity exists as both an operation and a tombstone"
+            )
+        cursor = conn.execute(
+            """DELETE FROM webhook_operations
+               WHERE operation_id=? AND generation=? AND state=?""",
+            (row["operation_id"], int(row["generation"]), state.value),
+        )
+        if cursor.rowcount != 1:
+            raise WebhookLedgerTransitionError(
+                "terminal operation changed while being compacted"
+            )
+        if not bounded_settlement_expired:
+            expires_at = (
+                terminal_at + self.local_bypass_replay_retention_seconds
+                if state is OperationState.SETTLED
+                and self._bounded_replay_id(replay_id)
+                else None
+            )
+            conn.execute(
+                """INSERT INTO webhook_delivery_tombstones (
+                       profile, route, provider, replay_id, body_sha256,
+                       operation_id, state, settled_at, expires_at
+                   ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    row["profile"],
+                    row["route"],
+                    row["provider"],
+                    replay_id,
+                    row["body_sha256"],
+                    row["operation_id"],
+                    state.value,
+                    terminal_at,
+                    expires_at,
+                ),
+            )
+
+    def _compact_terminal_for_capacity(
+        self,
+        conn: sqlite3.Connection,
+        *,
+        now: float,
+        required: int,
+        scope: Optional[tuple[str, str, str]] = None,
+    ) -> int:
+        if required <= 0:
+            return 0
+        where = "state='settled'"
+        params: list[Any] = []
+        if scope is not None:
+            where += " AND profile=? AND route=? AND provider=?"
+            params.extend(scope)
+        index_name = (
+            "idx_webhook_operations_state_updated"
+            if scope is None
+            else "idx_webhook_operations_scope_state_updated"
+        )
+        rows = conn.execute(
+            f"""SELECT * FROM webhook_operations INDEXED BY {index_name}
+                WHERE {where}
+                ORDER BY updated_at
+                LIMIT ?""",
+            (*params, required),
+        ).fetchall()
+        for row in rows:
+            self._compact_terminal_row(conn, row, now=now)
+        return len(rows)
+
+    @staticmethod
+    def _storage_usage_row(conn: sqlite3.Connection) -> sqlite3.Row:
+        row = conn.execute(
+            "SELECT * FROM webhook_ledger_usage WHERE schema_name=?",
+            (_SCHEMA_NAME,),
+        ).fetchone()
+        if row is None:
+            raise WebhookLedgerCorruptionError(
+                "webhook ledger usage authority is unavailable"
+            )
+        return row
+
+    @staticmethod
+    def _scope_storage_usage(
+        conn: sqlite3.Connection,
+        scope: tuple[str, str, str],
+    ) -> tuple[int, int, int, int]:
+        row = conn.execute(
+            """SELECT reserved_bytes, proof_count, active_record_count,
+                      settled_operation_count
+                 FROM webhook_ledger_scope_usage
+                WHERE profile=? AND route=? AND provider=?""",
+            scope,
+        ).fetchone()
+        if row is None:
+            return 0, 0, 0, 0
+        return (
+            int(row["reserved_bytes"]),
+            int(row["proof_count"]),
+            int(row["active_record_count"]),
+            int(row["settled_operation_count"]),
+        )
+
+    def _reserve_operation_storage(
+        self,
+        conn: sqlite3.Connection,
+        *,
+        now: float,
+        scope: tuple[str, str, str],
+    ) -> Optional[AdmitSaturationReason]:
+        """Fit one carrier, returning the exact exhausted byte authority."""
+
+        usage = self._storage_usage_row(conn)
+        (
+            scope_reserved,
+            _scope_proofs,
+            _scope_active,
+            _scope_settled,
+        ) = self._scope_storage_usage(conn, scope)
+        required_scope_bytes = (
+            scope_reserved
+            + _OPERATION_STORAGE_RESERVATION_BYTES
+            - int(usage["scope_limit_bytes"])
+        )
+        savings_per_compaction = (
+            _OPERATION_STORAGE_RESERVATION_BYTES - _TOMBSTONE_STORAGE_RESERVATION_BYTES
+        )
+        if required_scope_bytes > 0:
+            self._compact_terminal_for_capacity(
+                conn,
+                now=now,
+                required=max(
+                    1,
+                    math.ceil(required_scope_bytes / savings_per_compaction),
+                ),
+                scope=scope,
+            )
+
+        usage = self._storage_usage_row(conn)
+        required_bytes = (
+            int(usage["reserved_bytes"])
+            + _OPERATION_STORAGE_RESERVATION_BYTES
+            - int(usage["max_storage_bytes"])
+        )
+        if required_bytes > 0:
+            self._compact_terminal_for_capacity(
+                conn,
+                now=now,
+                required=max(
+                    1,
+                    math.ceil(required_bytes / savings_per_compaction),
+                ),
+            )
+
+        usage = self._storage_usage_row(conn)
+        (
+            scope_reserved,
+            _scope_proofs,
+            _scope_active,
+            _scope_settled,
+        ) = self._scope_storage_usage(conn, scope)
+        if int(usage["reserved_bytes"]) + _OPERATION_STORAGE_RESERVATION_BYTES > int(
+            usage["max_storage_bytes"]
+        ):
+            return AdmitSaturationReason.GLOBAL_STORAGE_LIMIT
+        if scope_reserved + _OPERATION_STORAGE_RESERVATION_BYTES > int(
+            usage["scope_limit_bytes"]
+        ):
+            return AdmitSaturationReason.SCOPE_STORAGE_LIMIT
+        return None
+
+    def _prune_terminal(self, conn: sqlite3.Connection, now: float) -> int:
+        """Maintain at most one bounded batch of terminal proof history."""
+
+        expired = conn.execute(
+            """DELETE FROM webhook_delivery_tombstones
+                WHERE rowid IN (
+                    SELECT rowid FROM webhook_delivery_tombstones INDEXED BY
+                           idx_webhook_tombstones_expires_at
+                     WHERE expires_at IS NOT NULL AND expires_at <= ?
+                     ORDER BY expires_at, rowid
+                     LIMIT ?
+                )""",
+            (now, _MAX_PRUNE_BATCH),
+        )
+        maintained = max(0, int(expired.rowcount))
+        remaining = _MAX_PRUNE_BATCH - maintained
+        if remaining <= 0:
+            return maintained
+
+        retention_cutoff = now - self.terminal_retention_seconds
+        bounded_cutoff = now - self.local_bypass_replay_retention_seconds
+        rows = conn.execute(
+            """SELECT * FROM webhook_operations INDEXED BY
+                      idx_webhook_operations_state_updated
+                 WHERE state='settled'
+                   AND updated_at <= ?
+                 ORDER BY updated_at
+                 LIMIT ?""",
+            (retention_cutoff, remaining),
+        ).fetchall()
+        for row in rows:
+            self._compact_terminal_row(conn, row, now=now)
+            maintained += 1
+        remaining = _MAX_PRUNE_BATCH - maintained
+        if remaining <= 0:
+            return maintained
+
+        bounded_replay_prefix = _BOUNDED_REPLAY_PREFIXES[0]
+        rows = conn.execute(
+            f"""SELECT * FROM webhook_operations INDEXED BY
+                      idx_webhook_operations_bounded_settled_expiry
+                 WHERE state='settled'
+                   AND substr(
+                       replay_id, 1, {len(bounded_replay_prefix)}
+                   )='{bounded_replay_prefix}'
+                   AND COALESCE(settled_at, updated_at) <= ?
+                 ORDER BY COALESCE(settled_at, updated_at)
+                 LIMIT ?""",
+            (bounded_cutoff, remaining),
+        ).fetchall()
+        for row in rows:
+            self._compact_terminal_row(conn, row, now=now)
+            maintained += 1
+        return maintained
+
+    def admit(self, envelope: Any) -> AdmitResult:
+        """Atomically reserve an immutable webhook delivery identity.
+
+        The contract's authenticated replay identity is unique across profile,
+        route, and provider.  The same identity with a different authenticated
+        body is a conflict. Compact authenticated-ID/timestamp and unknown-
+        outcome tombstones remain authoritative indefinitely. Remotely
+        authenticated body-only proofs are permanent because their wire
+        contracts contain no nonce that can distinguish a replay. Only the
+        explicit loopback test bypass uses a bounded replay window.
+        """
+
+        try:
+            route = envelope.route
+            operation_id = _normalize_nonempty(envelope.trace_id, label="operation_id")
+            session_key = _normalize_nonempty(envelope.session_key, label="session_key")
+            profile = _normalize_nonempty(
+                envelope.authority_profile,
+                label="authority profile",
+            )
+            route_name = _normalize_nonempty(route.name, label="route")
+            provider = _normalize_nonempty(route.provider, label="provider")
+            body_sha256 = _normalize_sha256(envelope.body_sha256, label="body_sha256")
+            event_type = _normalize_nonempty(envelope.event_type, label="event_type")
+            replay_identity = envelope.replay_identity
+            replay_provider = _normalize_nonempty(
+                replay_identity.provider, label="replay provider"
+            )
+            replay_id = _normalize_nonempty(envelope.replay_id, label="replay_id")
+            if replay_provider != provider or replay_id != replay_identity.storage_key:
+                raise WebhookLedgerError(
+                    "envelope replay identity is outside its route authority"
+                )
+        except AttributeError as exc:
+            raise WebhookLedgerError("admit requires a webhook envelope") from exc
+
+        now = time.time()
+        owner_pid, owner_started_at = _owner_stamp()
+        with self._lock, self._transaction() as conn:
+            by_operation = self._operation_row(conn, operation_id)
+            if by_operation is not None:
+                exact = (
+                    by_operation["profile"] == profile
+                    and by_operation["route"] == route_name
+                    and by_operation["provider"] == provider
+                    and by_operation["replay_id"] == replay_id
+                    and by_operation["body_sha256"] == body_sha256
+                    and by_operation["session_key"] == session_key
+                )
+                authority = self._authority_from_row(conn, by_operation)
+                if not exact:
+                    return AdmitResult(AdmitDisposition.CONFLICT, authority)
+                return AdmitResult(
+                    self._disposition_for_state(authority.state), authority
+                )
+
+            existing = conn.execute(
+                """SELECT * FROM webhook_operations
+                   WHERE profile=? AND route=? AND provider=? AND replay_id=?""",
+                (profile, route_name, provider, replay_id),
+            ).fetchone()
+            tombstone_row = self._tombstone_row(
+                conn,
+                profile=profile,
+                route=route_name,
+                provider=provider,
+                replay_id=replay_id,
+            )
+            if existing is not None and tombstone_row is not None:
+                raise WebhookLedgerCorruptionError(
+                    "replay identity exists as both an operation and a tombstone"
+                )
+            tombstone = (
+                self._tombstone_from_row(tombstone_row)
+                if tombstone_row is not None
+                else None
+            )
+            if (
+                tombstone is not None
+                and tombstone.expires_at is not None
+                and tombstone.expires_at <= now
+            ):
+                conn.execute(
+                    """DELETE FROM webhook_delivery_tombstones
+                        WHERE profile=? AND route=? AND provider=? AND replay_id=?""",
+                    (profile, route_name, provider, replay_id),
+                )
+                tombstone_row = None
+                tombstone = None
+            if existing is not None:
+                authority = self._authority_from_row(conn, existing)
+                if existing["body_sha256"] != body_sha256:
+                    return AdmitResult(AdmitDisposition.CONFLICT, authority)
+                return AdmitResult(
+                    self._disposition_for_state(authority.state), authority
+                )
+            if tombstone is not None:
+                if tombstone.body_sha256 != body_sha256:
+                    disposition = AdmitDisposition.CONFLICT
+                elif tombstone.state is OperationState.INDETERMINATE:
+                    disposition = AdmitDisposition.INDETERMINATE
+                else:
+                    disposition = AdmitDisposition.DUPLICATE
+                return AdmitResult(disposition, tombstone=tombstone)
+
+            # Historical maintenance is bounded and runs only for a genuinely
+            # new identity. Exact replay/conflict decisions stay indexed and
+            # available even when the ledger is saturated.
+            self._prune_terminal(conn, now)
+            persisted_usage = self._storage_usage_row(conn)
+            max_records = int(persisted_usage["max_records"])
+            global_record_count = int(persisted_usage["active_record_count"]) + int(
+                persisted_usage["settled_operation_count"]
+            )
+            if (
+                global_record_count >= max_records
+                and int(persisted_usage["settled_operation_count"]) > 0
+            ):
+                self._compact_terminal_for_capacity(
+                    conn,
+                    now=now,
+                    required=min(
+                        _MAX_PRUNE_BATCH,
+                        global_record_count - max_records + 1,
+                    ),
+                )
+                persisted_usage = self._storage_usage_row(conn)
+                global_record_count = int(persisted_usage["active_record_count"]) + int(
+                    persisted_usage["settled_operation_count"]
+                )
+            if global_record_count >= max_records:
+                return AdmitResult(
+                    AdmitDisposition.SATURATED,
+                    saturation=AdmitSaturationReason.GLOBAL_RECORD_LIMIT,
+                )
+
+            reserve = (
+                0
+                if max_records <= 1
+                else max(
+                    1,
+                    min(
+                        _MAX_SCOPE_CAPACITY_RESERVE,
+                        max_records // 4,
+                    ),
+                )
+            )
+            scope_limit = max_records - reserve
+            scope = (profile, route_name, provider)
+            (
+                _scope_bytes,
+                _scope_proofs,
+                scope_active,
+                scope_settled,
+            ) = self._scope_storage_usage(conn, scope)
+            scope_record_count = scope_active + scope_settled
+            if scope_record_count >= scope_limit and scope_settled > 0:
+                self._compact_terminal_for_capacity(
+                    conn,
+                    now=now,
+                    required=min(
+                        _MAX_PRUNE_BATCH,
+                        scope_record_count - scope_limit + 1,
+                    ),
+                    scope=scope,
+                )
+                (
+                    _scope_bytes,
+                    _scope_proofs,
+                    scope_active,
+                    scope_settled,
+                ) = self._scope_storage_usage(conn, scope)
+                scope_record_count = scope_active + scope_settled
+            if scope_record_count >= scope_limit:
+                return AdmitResult(
+                    AdmitDisposition.SATURATED,
+                    saturation=AdmitSaturationReason.SCOPE_RECORD_LIMIT,
+                )
+
+            storage_saturation = self._reserve_operation_storage(
+                conn,
+                now=now,
+                scope=scope,
+            )
+            if storage_saturation is not None:
+                return AdmitResult(
+                    AdmitDisposition.SATURATED,
+                    saturation=storage_saturation,
+                )
+
+            conn.execute(
+                """INSERT INTO webhook_operations (
+                       operation_id, profile, route, provider, replay_id,
+                       body_sha256, event_type, session_key, state, generation,
+                       owner_pid, owner_started_at, owner_instance,
+                       created_at, updated_at
+                   ) VALUES (
+                       ?, ?, ?, ?, ?, ?, ?, ?, 'preparing', 1, ?, ?, ?, ?, ?
+                   )""",
+                (
+                    operation_id,
+                    profile,
+                    route_name,
+                    provider,
+                    replay_id,
+                    body_sha256,
+                    event_type,
+                    session_key,
+                    owner_pid,
+                    owner_started_at,
+                    self.instance_id,
+                    now,
+                    now,
+                ),
+            )
+            row = self._operation_row(conn, operation_id)
+            if row is None:  # pragma: no cover - SQLite acknowledged the insert
+                raise WebhookLedgerError("admitted operation disappeared")
+            return AdmitResult(
+                AdmitDisposition.ACCEPTED,
+                self._authority_from_row(conn, row),
+            )
+
+    def prepare(
+        self,
+        authority: OperationAuthority,
+        *,
+        event_snapshot: Mapping[str, Any],
+        target_snapshot: Mapping[str, Any],
+        grant_snapshot: Mapping[str, Any],
+    ) -> OperationAuthority:
+        """Persist the exact execution carrier and make it replayable."""
+
+        event_json = _canonical_json(
+            event_snapshot,
+            label="event_snapshot",
+            max_bytes=_MAX_EVENT_JSON_BYTES,
+        )
+        target_json = _canonical_json(
+            target_snapshot,
+            label="target_snapshot",
+            max_bytes=_MAX_AUTHORITY_JSON_BYTES,
+        )
+        grant_json = _canonical_json(
+            grant_snapshot,
+            label="grant_snapshot",
+            max_bytes=_MAX_AUTHORITY_JSON_BYTES,
+        )
+        target_id = hashlib.sha256(target_json.encode("utf-8")).hexdigest()[:32]
+        now = time.time()
+        with self._lock, self._transaction() as conn:
+            row = self._operation_row(conn, authority.operation_id)
+            if row is None:
+                raise WebhookLedgerTransitionError("operation no longer exists")
+            if int(row["generation"]) != authority.generation:
+                raise WebhookLedgerTransitionError("operation generation is stale")
+            if (
+                authority.owner_instance != self.instance_id
+                or row["owner_instance"] != self.instance_id
+            ):
+                raise WebhookLedgerTransitionError(
+                    "operation belongs to a different adapter instance"
+                )
+            if row["state"] == OperationState.READY.value:
+                target = self._target_row(conn, authority.operation_id)
+                if (
+                    row["event_json"] == event_json
+                    and row["target_json"] == target_json
+                    and row["grant_json"] == grant_json
+                    and target is not None
+                    and target["target_id"] == target_id
+                ):
+                    return self._authority_from_row(conn, row)
+                raise WebhookLedgerTransitionError(
+                    "ready operation cannot be rebound to different authority"
+                )
+            if row["state"] != OperationState.PREPARING.value:
+                raise WebhookLedgerTransitionError(
+                    f"cannot prepare operation in state {row['state']!r}"
+                )
+            conn.execute(
+                """INSERT INTO webhook_targets (
+                       operation_id, target_id, state, updated_at
+                   ) VALUES (?, ?, 'pending', ?)""",
+                (authority.operation_id, target_id, now),
+            )
+            cursor = conn.execute(
+                """UPDATE webhook_operations
+                   SET event_json=?, target_json=?, grant_json=?, state='ready',
+                       updated_at=?
+                   WHERE operation_id=? AND generation=? AND state='preparing'
+                     AND owner_instance=?""",
+                (
+                    event_json,
+                    target_json,
+                    grant_json,
+                    now,
+                    authority.operation_id,
+                    authority.generation,
+                    self.instance_id,
+                ),
+            )
+            if cursor.rowcount != 1:
+                raise WebhookLedgerTransitionError("prepare lost its operation claim")
+            updated = self._operation_row(conn, authority.operation_id)
+            if updated is None:  # pragma: no cover - guarded by UPDATE
+                raise WebhookLedgerError("prepared operation disappeared")
+            return self._authority_from_row(conn, updated)
+
+    def mark_script_started(self, authority: OperationAuthority) -> bool:
+        """Fence a route script before its subprocess may produce effects."""
+
+        with self._lock, self._transaction() as conn:
+            cursor = conn.execute(
+                """UPDATE webhook_operations
+                   SET script_started=1, updated_at=?
+                   WHERE operation_id=? AND generation=? AND state='preparing'
+                     AND script_started=0
+                     AND owner_instance=?""",
+                (
+                    time.time(),
+                    authority.operation_id,
+                    authority.generation,
+                    self.instance_id,
+                ),
+            )
+            return cursor.rowcount == 1
+
+    def release_pre_effect(self, authority: OperationAuthority) -> bool:
+        """Delete a claim only while durable knowledge proves no effect began."""
+
+        with self._lock, self._transaction() as conn:
+            cursor = conn.execute(
+                """DELETE FROM webhook_operations
+                   WHERE operation_id=? AND generation=? AND state='preparing'
+                     AND script_started=0 AND owner_instance=?""",
+                (authority.operation_id, authority.generation, self.instance_id),
+            )
+            return cursor.rowcount == 1
+
+    def mark_running(self, authority: OperationAuthority) -> bool:
+        """Atomically bind a READY carrier to exactly one processing task."""
+
+        now = time.time()
+        owner_pid, owner_started_at = _owner_stamp()
+        with self._lock, self._transaction() as conn:
+            row = self._operation_row(conn, authority.operation_id)
+            if row is None or int(row["generation"]) != authority.generation:
+                return False
+            if (
+                authority.owner_instance != self.instance_id
+                or row["owner_instance"] != self.instance_id
+            ):
+                return False
+            cursor = conn.execute(
+                """UPDATE webhook_operations
+                   SET state='running', owner_pid=?, owner_started_at=?, updated_at=?
+                   WHERE operation_id=? AND generation=? AND state='ready'
+                     AND owner_instance=?""",
+                (
+                    owner_pid,
+                    owner_started_at,
+                    now,
+                    authority.operation_id,
+                    authority.generation,
+                    self.instance_id,
+                ),
+            )
+            return cursor.rowcount == 1
+
+    def stage_delivery(
+        self,
+        authority: OperationAuthority,
+        *,
+        content: str,
+        carrier_snapshot: Mapping[str, Any],
+    ) -> OperationAuthority:
+        """Persist the exact post-agent outbound effect before it is attempted.
+
+        Once this commits, crash recovery resumes only this delivery carrier;
+        it never replays the agent turn that produced it.
+        """
+
+        if not isinstance(content, str):
+            raise WebhookLedgerError("delivery content must be text")
+        delivery_json = _canonical_json(
+            {"content": content, "carrier": carrier_snapshot},
+            label="staged_delivery",
+            max_bytes=_MAX_EVENT_JSON_BYTES,
+        )
+        digest = content_sha256(content)
+        delivery_digest = hashlib.sha256(delivery_json.encode("utf-8")).hexdigest()
+        now = time.time()
+        with self._lock, self._transaction() as conn:
+            row = self._operation_row(conn, authority.operation_id)
+            if row is None or int(row["generation"]) != authority.generation:
+                raise WebhookLedgerTransitionError("operation generation is stale")
+            if (
+                authority.owner_instance != self.instance_id
+                or row["owner_instance"] != self.instance_id
+            ):
+                raise WebhookLedgerTransitionError(
+                    "operation belongs to a different adapter instance"
+                )
+            target = self._target_row(conn, authority.operation_id)
+            if target is None:
+                raise WebhookLedgerTransitionError("target authority does not exist")
+            if row["state"] == OperationState.DELIVERY_READY.value:
+                if (
+                    target["state"] == TargetState.PENDING.value
+                    and target["delivery_json"] == delivery_json
+                    and target["content_sha256"] == digest
+                    and target["delivery_sha256"] == delivery_digest
+                ):
+                    return self._authority_from_row(conn, row)
+                raise WebhookLedgerTransitionError(
+                    "delivery-ready operation cannot be rebound"
+                )
+            if row["state"] != OperationState.RUNNING.value:
+                raise WebhookLedgerTransitionError(
+                    f"cannot stage delivery in state {row['state']!r}"
+                )
+            target_cursor = conn.execute(
+                """UPDATE webhook_targets
+                   SET delivery_json=?, content_sha256=?, delivery_sha256=?, updated_at=?,
+                       last_error=NULL
+                   WHERE operation_id=? AND target_id=? AND state='pending'
+                     AND delivery_json IS NULL AND content_sha256 IS NULL
+                     AND delivery_sha256 IS NULL""",
+                (
+                    delivery_json,
+                    digest,
+                    delivery_digest,
+                    now,
+                    authority.operation_id,
+                    target["target_id"],
+                ),
+            )
+            if target_cursor.rowcount != 1:
+                raise WebhookLedgerTransitionError(
+                    "staged delivery lost its target claim"
+                )
+            operation_cursor = conn.execute(
+                """UPDATE webhook_operations
+                   SET state='delivery_ready', updated_at=?, last_error=NULL
+                   WHERE operation_id=? AND generation=? AND state='running'
+                     AND owner_instance=?""",
+                (
+                    now,
+                    authority.operation_id,
+                    authority.generation,
+                    self.instance_id,
+                ),
+            )
+            if operation_cursor.rowcount != 1:
+                raise WebhookLedgerTransitionError(
+                    "staged delivery lost its operation claim"
+                )
+            updated = self._operation_row(conn, authority.operation_id)
+            if updated is None:  # pragma: no cover - guarded by UPDATE
+                raise WebhookLedgerError("staged operation disappeared")
+            return self._authority_from_row(conn, updated)
+
+    def lookup_session(self, session_key: str) -> Optional[OperationAuthority]:
+        """Resolve delivery and grants from the durable session join."""
+
+        normalized = _normalize_nonempty(session_key, label="session_key")
+        with self._lock:
+            with self._connection() as conn:
+                # Operation and target rows are one authority snapshot.  A
+                # deferred read transaction keeps a concurrent settlement
+                # from becoming visible between the two SELECTs.
+                try:
+                    conn.execute("BEGIN")
+                    row = conn.execute(
+                        "SELECT * FROM webhook_operations WHERE session_key=?",
+                        (normalized,),
+                    ).fetchone()
+                    authority = (
+                        self._authority_from_row(conn, row) if row is not None else None
+                    )
+                    conn.execute("COMMIT")
+                    return authority
+                except BaseException:
+                    try:
+                        conn.execute("ROLLBACK")
+                    except sqlite3.OperationalError:
+                        pass
+                    raise
+
+    def _list_current_recovery_page(
+        self,
+        *,
+        limit: int,
+        after: Optional[RecoveryCursor],
+        delivery_only: bool,
+        profiles: Optional[Iterable[str]],
+    ) -> RecoveryBatch:
+        batch_limit = _normalize_recovery_batch_limit(limit)
+        cursor = _normalize_recovery_cursor(after)
+        normalized_profiles = _normalize_recovery_profiles(profiles)
+        if normalized_profiles == ():
+            return RecoveryBatch()
+        if delivery_only:
+            index_name = "idx_webhook_operations_owner_delivery_ready"
+            profile_index_name = "idx_webhook_operations_owner_profile_delivery_ready"
+            state_predicate = "o.state='delivery_ready'"
+        else:
+            index_name = "idx_webhook_operations_owner_current_recovery"
+            profile_index_name = "idx_webhook_operations_owner_profile_current_recovery"
+            # Generation one READY is ordinary freshly prepared inbound work
+            # still owned by its original handler. Only a dead-owner claim
+            # increments READY to a rediscoverable recovery generation.
+            state_predicate = (
+                "(o.state='delivery_ready' OR (o.state='ready' AND o.generation>=2))"
+            )
+        cursor_predicate = ""
+        cursor_params: tuple[Any, ...] = ()
+        if cursor is not None:
+            cursor_predicate = "AND (o.created_at, o.operation_id) > (?, ?)"
+            cursor_params = (cursor.created_at, cursor.operation_id)
+
+        with self._lock:
+            with self._connection() as conn:
+                try:
+                    conn.execute("BEGIN")
+                    has_more = False
+                    next_cursor: Optional[RecoveryCursor] = None
+                    continuation: Optional[RecoveryCursor] = None
+                    if normalized_profiles is None:
+                        page_query = f"""SELECT o.operation_id, o.created_at
+                                              FROM webhook_operations AS o
+                                                   INDEXED BY {index_name}
+                                              JOIN webhook_targets AS t
+                                                ON t.operation_id=o.operation_id
+                                             WHERE o.owner_instance=?
+                                               AND {state_predicate}
+                                               AND t.state='pending'
+                                               {cursor_predicate}
+                                             ORDER BY o.created_at, o.operation_id
+                                             LIMIT ?"""
+                        page_rows = conn.execute(
+                            page_query,
+                            (self.instance_id, *cursor_params, batch_limit),
+                        ).fetchall()
+                        if len(page_rows) == batch_limit:
+                            last = page_rows[-1]
+                            continuation = RecoveryCursor(
+                                created_at=float(last["created_at"]),
+                                operation_id=str(last["operation_id"]),
+                            )
+                            more_query = f"""SELECT 1
+                                                  FROM webhook_operations AS o
+                                                       INDEXED BY {index_name}
+                                                  JOIN webhook_targets AS t
+                                                    ON t.operation_id=o.operation_id
+                                                 WHERE o.owner_instance=?
+                                                   AND {state_predicate}
+                                                   AND t.state='pending'
+                                                   AND (o.created_at, o.operation_id) >
+                                                       (?, ?)
+                                                 ORDER BY o.created_at, o.operation_id
+                                                 LIMIT 1"""
+                            has_more = (
+                                conn.execute(
+                                    more_query,
+                                    (
+                                        self.instance_id,
+                                        continuation.created_at,
+                                        continuation.operation_id,
+                                    ),
+                                ).fetchone()
+                                is not None
+                            )
+                    else:
+                        candidate_rows: list[sqlite3.Row] = []
+                        for profile in normalized_profiles:
+                            candidate_rows.extend(
+                                conn.execute(
+                                    f"""SELECT o.operation_id, o.created_at
+                                           FROM webhook_operations AS o
+                                                INDEXED BY {profile_index_name}
+                                           JOIN webhook_targets AS t
+                                             ON t.operation_id=o.operation_id
+                                          WHERE o.owner_instance=? AND o.profile=?
+                                            AND {state_predicate}
+                                            AND t.state='pending'
+                                            {cursor_predicate}
+                                          ORDER BY o.created_at, o.operation_id
+                                          LIMIT ?""",
+                                    (
+                                        self.instance_id,
+                                        profile,
+                                        *cursor_params,
+                                        batch_limit + 1,
+                                    ),
+                                ).fetchall()
+                            )
+                        candidate_rows.sort(
+                            key=lambda row: (
+                                float(row["created_at"]),
+                                str(row["operation_id"]),
+                            )
+                        )
+                        page_rows = candidate_rows[:batch_limit]
+                        has_more = len(candidate_rows) > batch_limit
+                        if has_more:
+                            last = page_rows[-1]
+                            continuation = RecoveryCursor(
+                                created_at=float(last["created_at"]),
+                                operation_id=str(last["operation_id"]),
+                            )
+                    if has_more:
+                        if continuation is None:  # pragma: no cover - invariant
+                            raise WebhookLedgerCorruptionError(
+                                "current recovery continuation is unavailable"
+                            )
+                        next_cursor = continuation
+
+                    event_ready: list[OperationAuthority] = []
+                    delivery_ready: list[OperationAuthority] = []
+                    for page_row in page_rows:
+                        operation_id = str(page_row["operation_id"])
+                        row = self._operation_row(conn, operation_id)
+                        if row is None:  # pragma: no cover - same read transaction
+                            raise WebhookLedgerCorruptionError(
+                                "current recovery operation disappeared"
+                            )
+                        authority = self._authority_from_row(conn, row)
+                        if authority.state is OperationState.READY:
+                            if delivery_only or authority.delivery is not None:
+                                raise WebhookLedgerCorruptionError(
+                                    "event-ready operation has a staged delivery"
+                                )
+                            event_ready.append(authority)
+                        elif authority.state is OperationState.DELIVERY_READY:
+                            if authority.delivery is None:
+                                raise WebhookLedgerCorruptionError(
+                                    "delivery-ready operation has no staged delivery"
+                                )
+                            delivery_ready.append(authority)
+                        else:  # pragma: no cover - guarded by indexed predicate
+                            raise WebhookLedgerCorruptionError(
+                                "current recovery operation has an invalid state"
+                            )
+                    conn.execute("COMMIT")
+                    return RecoveryBatch(
+                        event_ready=tuple(event_ready),
+                        delivery_ready=tuple(delivery_ready),
+                        scanned_count=len(page_rows),
+                        has_more=has_more,
+                        next_cursor=next_cursor,
+                    )
+                except BaseException:
+                    try:
+                        conn.execute("ROLLBACK")
+                    except sqlite3.OperationalError:
+                        pass
+                    raise
+
+    def list_current_recovery_ready(
+        self,
+        *,
+        limit: int = DEFAULT_RECOVERY_BATCH_SIZE,
+        after: Optional[RecoveryCursor] = None,
+        profiles: Optional[Iterable[str]] = None,
+    ) -> RecoveryBatch:
+        """List one bounded page of replay-safe work owned by this instance.
+
+        This includes event-ready and delivery-ready claims, allowing a runner
+        to rediscover a page claimed immediately before an interrupted task
+        scheduling handoff. State transition methods remain the exact-once
+        mutation gates when independently triggered recovery passes overlap.
+        A supplied profile tuple restricts the read to those exact physical
+        authority domains; an empty tuple returns no work.
+        """
+
+        return self._list_current_recovery_page(
+            limit=limit,
+            after=after,
+            delivery_only=False,
+            profiles=profiles,
+        )
+
+    def list_delivery_ready(
+        self,
+        *,
+        limit: int = DEFAULT_RECOVERY_BATCH_SIZE,
+        after: Optional[RecoveryCursor] = None,
+        profiles: Optional[Iterable[str]] = None,
+    ) -> RecoveryBatch:
+        """List one bounded page of this instance's retryable deliveries."""
+
+        return self._list_current_recovery_page(
+            limit=limit,
+            after=after,
+            delivery_only=True,
+            profiles=profiles,
+        )
+
+    def current_delivery_ready(
+        self,
+        *,
+        limit: int = DEFAULT_RECOVERY_BATCH_SIZE,
+        after: Optional[RecoveryCursor] = None,
+        profiles: Optional[Iterable[str]] = None,
+    ) -> tuple[OperationAuthority, ...]:
+        """Compatibility projection of :meth:`list_delivery_ready`.
+
+        The result is always bounded. New recovery code should consume the
+        batch API so it can honor ``has_more`` and ``next_cursor``.
+        """
+
+        return self.list_delivery_ready(
+            limit=limit,
+            after=after,
+            profiles=profiles,
+        ).delivery_ready
+
+    def relinquish_recovery_claim(self, authority: OperationAuthority) -> bool:
+        """Return an unstarted recovery carrier to dead-owner claimability.
+
+        This is valid only while the carrier is still replay-safe. It is used
+        when shutdown cancels a newly scheduled recovery task before that
+        coroutine executes even one instruction.
+        """
+
+        retired_owner = f"cancelled-recovery:{self.instance_id}"
+        with self._lock, self._transaction() as conn:
+            cursor = conn.execute(
+                """UPDATE webhook_operations
+                   SET owner_pid=NULL, owner_started_at=NULL,
+                       owner_instance=?, updated_at=?
+                   WHERE operation_id=? AND generation=?
+                     AND owner_instance=?
+                     AND state IN ('ready','delivery_ready')
+                     AND NOT EXISTS (
+                         SELECT 1 FROM webhook_targets
+                         WHERE operation_id=? AND state='attempting'
+                     )""",
+                (
+                    retired_owner,
+                    time.time(),
+                    authority.operation_id,
+                    authority.generation,
+                    self.instance_id,
+                    authority.operation_id,
+                ),
+            )
+            return cursor.rowcount == 1
+
+    def begin_target(
+        self,
+        authority: OperationAuthority,
+        *,
+        content_sha256: Optional[str] = None,
+        target_id: Optional[str] = None,
+    ) -> TargetAttempt:
+        """Claim the already-staged exact delivery immediately before invocation.
+
+        ``content_sha256`` is an optional assertion for compatibility; it never
+        supplies delivery authority.  The returned attempt carries the durable
+        content and carrier that the caller must invoke.
+        """
+
+        expected_hash = (
+            _normalize_sha256(content_sha256, label="content_sha256")
+            if content_sha256 is not None
+            else None
+        )
+        selected_target = target_id or authority.target_id
+        selected_target = _normalize_nonempty(selected_target, label="target_id")
+        now = time.time()
+        owner_pid, owner_started_at = _owner_stamp()
+        with self._lock, self._transaction() as conn:
+            operation = self._operation_row(conn, authority.operation_id)
+            if (
+                operation is None
+                or int(operation["generation"]) != authority.generation
+            ):
+                raise WebhookLedgerTransitionError("operation generation is stale")
+            target = conn.execute(
+                """SELECT * FROM webhook_targets
+                   WHERE operation_id=? AND target_id=?""",
+                (authority.operation_id, selected_target),
+            ).fetchone()
+            if target is None:
+                raise WebhookLedgerTransitionError("target authority does not exist")
+            target_state = TargetState(target["state"])
+            delivery = _decode_staged_delivery(
+                target["delivery_json"],
+                target["content_sha256"],
+                target["delivery_sha256"],
+            )
+            if expected_hash is not None and (
+                delivery is None or delivery.content_sha256 != expected_hash
+            ):
+                raise WebhookLedgerTransitionError(
+                    "target content does not match its durable staged delivery"
+                )
+            attempt_hash = delivery.content_sha256 if delivery is not None else ""
+            if operation["state"] == OperationState.INDETERMINATE.value:
+                return TargetAttempt(
+                    disposition=TargetAttemptDisposition.INDETERMINATE,
+                    operation_id=authority.operation_id,
+                    generation=authority.generation,
+                    target_id=selected_target,
+                    content_sha256=attempt_hash,
+                    delivery_sha256=(
+                        delivery.delivery_sha256 if delivery is not None else ""
+                    ),
+                    delivery=delivery,
+                    owner_instance=self.instance_id,
+                )
+            if target_state in {TargetState.CONFIRMED, TargetState.SUPPRESSED}:
+                if delivery is None:
+                    raise WebhookLedgerCorruptionError(
+                        "settled target has no staged delivery"
+                    )
+                return TargetAttempt(
+                    disposition=TargetAttemptDisposition.CACHED,
+                    operation_id=authority.operation_id,
+                    generation=authority.generation,
+                    target_id=selected_target,
+                    content_sha256=delivery.content_sha256,
+                    delivery_sha256=delivery.delivery_sha256,
+                    delivery=delivery,
+                    owner_instance=self.instance_id,
+                )
+            if target_state is TargetState.INDETERMINATE:
+                return TargetAttempt(
+                    disposition=TargetAttemptDisposition.INDETERMINATE,
+                    operation_id=authority.operation_id,
+                    generation=authority.generation,
+                    target_id=selected_target,
+                    content_sha256=attempt_hash,
+                    delivery_sha256=(
+                        delivery.delivery_sha256 if delivery is not None else ""
+                    ),
+                    delivery=delivery,
+                    owner_instance=self.instance_id,
+                )
+            if target_state is TargetState.ATTEMPTING:
+                if delivery is None:
+                    raise WebhookLedgerCorruptionError(
+                        "attempting target has no staged delivery"
+                    )
+                return TargetAttempt(
+                    disposition=TargetAttemptDisposition.IN_PROGRESS,
+                    operation_id=authority.operation_id,
+                    generation=authority.generation,
+                    target_id=selected_target,
+                    content_sha256=delivery.content_sha256,
+                    delivery_sha256=delivery.delivery_sha256,
+                    delivery=delivery,
+                    owner_instance=self.instance_id,
+                )
+            if (
+                authority.owner_instance != self.instance_id
+                or operation["owner_instance"] != self.instance_id
+            ):
+                raise WebhookLedgerTransitionError(
+                    "operation belongs to a different adapter instance"
+                )
+            if delivery is None:
+                raise WebhookLedgerTransitionError(
+                    "target delivery has not been durably staged"
+                )
+            if operation["state"] != OperationState.DELIVERY_READY.value:
+                raise WebhookLedgerTransitionError(
+                    f"cannot attempt target in operation state {operation['state']!r}"
+                )
+            attempt_token = uuid.uuid4().hex
+            cursor = conn.execute(
+                """UPDATE webhook_targets
+                   SET state='attempting', attempt_token=?,
+                       owner_pid=?, owner_started_at=?, started_at=?, updated_at=?,
+                       owner_instance=?, settled_at=NULL, external_id=NULL,
+                       last_error=NULL
+                   WHERE operation_id=? AND target_id=? AND state='pending'""",
+                (
+                    attempt_token,
+                    owner_pid,
+                    owner_started_at,
+                    now,
+                    now,
+                    self.instance_id,
+                    authority.operation_id,
+                    selected_target,
+                ),
+            )
+            if cursor.rowcount != 1:
+                raise WebhookLedgerTransitionError("target attempt lost its claim")
+            operation_cursor = conn.execute(
+                """UPDATE webhook_operations
+                   SET state='delivering', owner_pid=?, owner_started_at=?, updated_at=?
+                   WHERE operation_id=? AND generation=? AND state='delivery_ready'
+                     AND owner_instance=?""",
+                (
+                    owner_pid,
+                    owner_started_at,
+                    now,
+                    authority.operation_id,
+                    authority.generation,
+                    self.instance_id,
+                ),
+            )
+            if operation_cursor.rowcount != 1:
+                raise WebhookLedgerTransitionError(
+                    "target attempt lost its delivery-ready operation"
+                )
+            return TargetAttempt(
+                disposition=TargetAttemptDisposition.STARTED,
+                operation_id=authority.operation_id,
+                generation=authority.generation,
+                target_id=selected_target,
+                content_sha256=delivery.content_sha256,
+                delivery_sha256=delivery.delivery_sha256,
+                delivery=delivery,
+                attempt_token=attempt_token,
+                owner_instance=self.instance_id,
+            )
+
+    def settle_target(self, attempt: TargetAttempt, settlement: Settlement) -> bool:
+        """Settle only the exact fenced target attempt supplied by the caller."""
+
+        if attempt.disposition is not TargetAttemptDisposition.STARTED:
+            return False
+        if not attempt.attempt_token:
+            raise WebhookLedgerTransitionError("started attempt has no fence token")
+        if not isinstance(settlement.kind, SettlementKind):
+            raise WebhookLedgerError("settlement kind must be typed")
+        now = time.time()
+        error = _safe_error(settlement.error)
+        external_id = (
+            str(settlement.external_id)[:512]
+            if settlement.external_id is not None
+            else None
+        )
+        with self._lock, self._transaction() as conn:
+            operation = self._operation_row(conn, attempt.operation_id)
+            if operation is None or int(operation["generation"]) != attempt.generation:
+                return False
+            if (
+                attempt.owner_instance != self.instance_id
+                or operation["owner_instance"] != self.instance_id
+            ):
+                return False
+            guard = (
+                attempt.operation_id,
+                attempt.target_id,
+                attempt.attempt_token,
+                attempt.content_sha256,
+                attempt.delivery_sha256,
+                self.instance_id,
+            )
+            if settlement.kind is SettlementKind.PRE_EFFECT_FAILED:
+                cursor = conn.execute(
+                    """UPDATE webhook_targets
+                       SET state='pending', attempt_token=NULL,
+                           owner_pid=NULL, owner_started_at=NULL, started_at=NULL,
+                           owner_instance=NULL, updated_at=?, last_error=?
+                       WHERE operation_id=? AND target_id=? AND state='attempting'
+                         AND attempt_token=? AND content_sha256=?
+                         AND delivery_sha256=?
+                         AND owner_instance=?""",
+                    (now, error, *guard),
+                )
+                if cursor.rowcount != 1:
+                    return False
+                operation_cursor = conn.execute(
+                    """UPDATE webhook_operations
+                       SET state='delivery_ready', updated_at=?, last_error=?
+                       WHERE operation_id=? AND generation=? AND state='delivering'
+                         AND owner_instance=?""",
+                    (
+                        now,
+                        error,
+                        attempt.operation_id,
+                        attempt.generation,
+                        self.instance_id,
+                    ),
+                )
+                if operation_cursor.rowcount != 1:
+                    raise WebhookLedgerTransitionError(
+                        "pre-effect target reset lost its operation claim"
+                    )
+                return True
+
+            target_state = (
+                TargetState.CONFIRMED
+                if settlement.kind is SettlementKind.CONFIRMED
+                else TargetState.SUPPRESSED
+                if settlement.kind is SettlementKind.SUPPRESSED
+                else TargetState.INDETERMINATE
+            )
+            cursor = conn.execute(
+                """UPDATE webhook_targets
+                   SET state=?, external_id=?, settled_at=?, updated_at=?,
+                       last_error=?
+                   WHERE operation_id=? AND target_id=? AND state='attempting'
+                     AND attempt_token=? AND content_sha256=?
+                     AND delivery_sha256=?
+                     AND owner_instance=?""",
+                (
+                    target_state.value,
+                    external_id,
+                    now,
+                    now,
+                    error,
+                    *guard,
+                ),
+            )
+            if cursor.rowcount != 1:
+                return False
+            if target_state is TargetState.INDETERMINATE:
+                operation_cursor = conn.execute(
+                    """UPDATE webhook_operations
+                       SET state='indeterminate', updated_at=?, last_error=?
+                       WHERE operation_id=? AND generation=? AND state='delivering'
+                         AND owner_instance=?""",
+                    (
+                        now,
+                        error,
+                        attempt.operation_id,
+                        attempt.generation,
+                        self.instance_id,
+                    ),
+                )
+            else:
+                operation_cursor = conn.execute(
+                    """UPDATE webhook_operations
+                       SET state='settled', settled_at=?, updated_at=?, last_error=NULL
+                       WHERE operation_id=? AND generation=?
+                         AND state='delivering' AND owner_instance=?""",
+                    (
+                        now,
+                        now,
+                        attempt.operation_id,
+                        attempt.generation,
+                        self.instance_id,
+                    ),
+                )
+            if operation_cursor.rowcount != 1:
+                raise WebhookLedgerTransitionError(
+                    "target settlement lost its delivering operation"
+                )
+            return True
+
+    def settle_no_effect(
+        self, authority: OperationAuthority, reason: Optional[str] = None
+    ) -> bool:
+        """Record a terminal operation for which no external effect was required."""
+
+        now = time.time()
+        safe_reason = _safe_error(reason)
+        with self._lock, self._transaction() as conn:
+            cursor = conn.execute(
+                """UPDATE webhook_operations
+                   SET state='settled', settled_at=?, updated_at=?, last_error=?
+                   WHERE operation_id=? AND generation=?
+                     AND state IN ('preparing','ready','running')
+                     AND owner_instance=?
+                     AND NOT EXISTS (
+                         SELECT 1 FROM webhook_targets
+                         WHERE operation_id=? AND state='attempting'
+                     )""",
+                (
+                    now,
+                    now,
+                    safe_reason,
+                    authority.operation_id,
+                    authority.generation,
+                    self.instance_id,
+                    authority.operation_id,
+                ),
+            )
+            if cursor.rowcount != 1:
+                return False
+            conn.execute(
+                """UPDATE webhook_targets
+                   SET state='suppressed', settled_at=?, updated_at=?, last_error=?
+                   WHERE operation_id=? AND state='pending'""",
+                (now, now, safe_reason, authority.operation_id),
+            )
+            return True
+
+    def mark_indeterminate(self, authority: OperationAuthority, reason: object) -> bool:
+        """Preserve an operation whose external postcondition is unknown."""
+
+        now = time.time()
+        safe_reason = _safe_error(reason) or "webhook operation outcome is unknown"
+        with self._lock, self._transaction() as conn:
+            cursor = conn.execute(
+                """UPDATE webhook_operations
+                   SET state='indeterminate', updated_at=?, last_error=?
+                   WHERE operation_id=? AND generation=? AND state!='settled'
+                     AND owner_instance=?""",
+                (
+                    now,
+                    safe_reason,
+                    authority.operation_id,
+                    authority.generation,
+                    self.instance_id,
+                ),
+            )
+            if cursor.rowcount != 1:
+                return False
+            conn.execute(
+                """UPDATE webhook_targets
+                   SET state='indeterminate', settled_at=?, updated_at=?, last_error=?
+                   WHERE operation_id=? AND state='attempting'
+                     AND owner_instance=?""",
+                (
+                    now,
+                    now,
+                    safe_reason,
+                    authority.operation_id,
+                    self.instance_id,
+                ),
+            )
+            return True
+
+    def retire_instance(
+        self,
+        *,
+        now: Optional[float] = None,
+        limit: int = DEFAULT_RECOVERY_BATCH_SIZE,
+    ) -> RecoveryBatch:
+        """Compatibility wrapper that fences one bounded retirement page.
+
+        Callers must continue with :meth:`retire_instance_page` while
+        ``has_more`` is true before treating the whole instance as fenced.
+        """
+
+        return self.retire_instance_page(now=now, limit=limit)
+
+    def retire_instance_page(
+        self,
+        *,
+        now: Optional[float] = None,
+        limit: int = DEFAULT_RECOVERY_BATCH_SIZE,
+    ) -> RecoveryBatch:
+        """Fence one bounded page before same-process replacement.
+
+        Replay-safe carriers are relinquished with a non-live owner stamp so a
+        replacement instance can claim them through :meth:`recover_dead_owners`.
+        Work that may already have produced agent or external effects is made
+        indeterminate.  After this commits, this instance's old authorities can
+        no longer mutate any relinquished row.
+        """
+
+        return self.retire_owner_instance_page(
+            self.instance_id,
+            now=now,
+            limit=limit,
+        )
+
+    def retire_owner_instance(
+        self,
+        owner_instance: str,
+        *,
+        now: Optional[float] = None,
+        limit: int = DEFAULT_RECOVERY_BATCH_SIZE,
+    ) -> RecoveryBatch:
+        """Compatibility wrapper that fences one exact bounded owner page.
+
+        Callers must continue with :meth:`retire_owner_instance_page` while
+        ``has_more`` is true before clearing the owner's quarantine.
+        """
+
+        return self.retire_owner_instance_page(
+            owner_instance,
+            now=now,
+            limit=limit,
+        )
+
+    def retire_owner_instance_page(
+        self,
+        owner_instance: str,
+        *,
+        now: Optional[float] = None,
+        limit: int = DEFAULT_RECOVERY_BATCH_SIZE,
+    ) -> RecoveryBatch:
+        """Fence one page of an exact quarantined adapter owner.
+
+        This is the retry form of :meth:`retire_instance`: an in-process
+        replacement may supply the prior instance ID after the prior adapter's
+        retirement transaction failed or had an unknown result.  Every mutation
+        remains guarded by that exact durable owner ID, so live peer instances
+        are not selected.  Repeating a committed retirement is a no-op.
+        """
+
+        prior_owner = _normalize_nonempty(
+            owner_instance,
+            label="retired webhook owner instance",
+        )
+        batch_limit = _normalize_recovery_batch_limit(limit)
+        try:
+            timestamp = time.time() if now is None else float(now)
+        except (TypeError, ValueError, OverflowError) as exc:
+            raise WebhookLedgerError("retirement timestamp must be finite") from exc
+        if not math.isfinite(timestamp):
+            raise WebhookLedgerError("retirement timestamp must be finite")
+        retired_owner = (
+            "retired:" + hashlib.sha256(prior_owner.encode("utf-8")).hexdigest()
+        )
+        released: list[str] = []
+        indeterminate: list[str] = []
+        with self._lock, self._transaction() as conn:
+            page_rows = conn.execute(
+                """SELECT operation_id, created_at
+                     FROM webhook_operations INDEXED BY
+                          idx_webhook_operations_owner_recovery_order
+                    WHERE owner_instance=?
+                      AND state IN (
+                          'preparing','ready','running','delivery_ready','delivering'
+                      )
+                    ORDER BY created_at, operation_id
+                    LIMIT ?""",
+                (prior_owner, batch_limit),
+            ).fetchall()
+            has_more = False
+            if len(page_rows) == batch_limit:
+                last = page_rows[-1]
+                has_more = (
+                    conn.execute(
+                        """SELECT 1
+                             FROM webhook_operations INDEXED BY
+                                  idx_webhook_operations_owner_recovery_order
+                            WHERE owner_instance=?
+                              AND state IN (
+                                  'preparing','ready','running',
+                                  'delivery_ready','delivering'
+                              )
+                              AND (created_at, operation_id) > (?, ?)
+                            ORDER BY created_at, operation_id
+                            LIMIT 1""",
+                        (
+                            prior_owner,
+                            float(last["created_at"]),
+                            str(last["operation_id"]),
+                        ),
+                    ).fetchone()
+                    is not None
+                )
+            for page_row in page_rows:
+                row = self._operation_row(conn, str(page_row["operation_id"]))
+                if row is None:  # pragma: no cover - same write transaction
+                    raise WebhookLedgerCorruptionError(
+                        "retired webhook operation disappeared"
+                    )
+                operation_id = row["operation_id"]
+                if row["state"] == OperationState.PREPARING.value and not bool(
+                    row["script_started"]
+                ):
+                    conn.execute(
+                        """DELETE FROM webhook_operations
+                           WHERE operation_id=? AND generation=?
+                             AND owner_instance=? AND state='preparing'
+                             AND script_started=0""",
+                        (
+                            operation_id,
+                            int(row["generation"]),
+                            prior_owner,
+                        ),
+                    )
+                    released.append(operation_id)
+                    continue
+                if row["state"] in {
+                    OperationState.READY.value,
+                    OperationState.DELIVERY_READY.value,
+                }:
+                    cursor = conn.execute(
+                        """UPDATE webhook_operations
+                           SET owner_pid=NULL, owner_started_at=NULL,
+                               owner_instance=?, updated_at=?
+                           WHERE operation_id=? AND generation=?
+                             AND owner_instance=? AND state=?""",
+                        (
+                            retired_owner,
+                            timestamp,
+                            operation_id,
+                            int(row["generation"]),
+                            prior_owner,
+                            row["state"],
+                        ),
+                    )
+                    if cursor.rowcount != 1:
+                        raise WebhookLedgerTransitionError(
+                            "adapter retirement lost a replayable operation"
+                        )
+                    continue
+
+                reason = (
+                    "adapter instance retired after webhook effects may have started"
+                )
+                cursor = conn.execute(
+                    """UPDATE webhook_operations
+                       SET state='indeterminate', updated_at=?, last_error=?
+                       WHERE operation_id=? AND generation=? AND owner_instance=?
+                         AND state IN ('preparing','running','delivering')""",
+                    (
+                        timestamp,
+                        reason,
+                        operation_id,
+                        int(row["generation"]),
+                        prior_owner,
+                    ),
+                )
+                if cursor.rowcount != 1:
+                    raise WebhookLedgerTransitionError(
+                        "adapter retirement lost an active operation"
+                    )
+                conn.execute(
+                    """UPDATE webhook_targets
+                       SET state='indeterminate', settled_at=?, updated_at=?,
+                           last_error=?
+                       WHERE operation_id=? AND state='attempting'
+                         AND owner_instance=?""",
+                    (
+                        timestamp,
+                        timestamp,
+                        reason,
+                        operation_id,
+                        prior_owner,
+                    ),
+                )
+                indeterminate.append(operation_id)
+        return RecoveryBatch(
+            released=tuple(released),
+            indeterminate=tuple(indeterminate),
+            scanned_count=len(page_rows),
+            has_more=has_more,
+        )
+
+    def recover_dead_owners(
+        self,
+        *,
+        now: Optional[float] = None,
+        limit: int = DEFAULT_RECOVERY_BATCH_SIZE,
+        after: Optional[RecoveryCursor] = None,
+        profiles: Optional[Iterable[str]] = None,
+    ) -> RecoveryBatch:
+        """Compatibility wrapper for one bounded dead-owner recovery page."""
+
+        return self.recover_dead_owners_page(
+            now=now,
+            limit=limit,
+            after=after,
+            profiles=profiles,
+        )
+
+    def recover_dead_owners_page(
+        self,
+        *,
+        now: Optional[float] = None,
+        limit: int = DEFAULT_RECOVERY_BATCH_SIZE,
+        after: Optional[RecoveryCursor] = None,
+        profiles: Optional[Iterable[str]] = None,
+    ) -> RecoveryBatch:
+        """Reconcile one bounded page whose exact process owner disappeared.
+
+        ``ready`` rows replay the event because no agent task began.
+        ``delivery_ready`` rows replay only their exact staged outbound carrier.
+        ``running`` and ``delivering`` rows are ambiguous and become
+        indeterminate.  A pre-script ``preparing`` claim is safe to release;
+        once a route script was started it is ambiguous too.
+
+        ``has_more`` means more nonterminal rows remain to *scan*, not that the
+        current page necessarily recovered an authority. Live owners are
+        intentionally counted in ``scanned_count`` and advanced by the keyset
+        cursor so they cannot starve dead rows later in the ordered index.
+        When ``profiles`` is supplied, only those exact physical authority
+        domains are scanned and the same frozen tuple must accompany every
+        continuation page. An empty tuple claims nothing.
+        """
+
+        batch_limit = _normalize_recovery_batch_limit(limit)
+        cursor = _normalize_recovery_cursor(after)
+        normalized_profiles = _normalize_recovery_profiles(profiles)
+        try:
+            timestamp = time.time() if now is None else float(now)
+        except (TypeError, ValueError, OverflowError) as exc:
+            raise WebhookLedgerError("recovery timestamp must be finite") from exc
+        if not math.isfinite(timestamp):
+            raise WebhookLedgerError("recovery timestamp must be finite")
+        if normalized_profiles == ():
+            return RecoveryBatch()
+        owner_pid, owner_started_at = _owner_stamp()
+        event_ready: list[OperationAuthority] = []
+        delivery_ready: list[OperationAuthority] = []
+        released: list[str] = []
+        indeterminate: list[str] = []
+        with self._lock, self._transaction() as conn:
+            has_more = False
+            next_cursor: Optional[RecoveryCursor] = None
+            continuation: Optional[RecoveryCursor] = None
+            cursor_predicate = ""
+            cursor_params: tuple[Any, ...] = ()
+            if cursor is not None:
+                cursor_predicate = "AND (created_at, operation_id) > (?, ?)"
+                cursor_params = (cursor.created_at, cursor.operation_id)
+            if normalized_profiles is None:
+                page_rows = conn.execute(
+                    f"""SELECT operation_id, created_at
+                           FROM webhook_operations INDEXED BY
+                                idx_webhook_operations_recovery_order
+                          WHERE state IN (
+                              'preparing','ready','running',
+                              'delivery_ready','delivering'
+                          )
+                            {cursor_predicate}
+                          ORDER BY created_at, operation_id
+                          LIMIT ?""",
+                    (*cursor_params, batch_limit),
+                ).fetchall()
+                if len(page_rows) == batch_limit:
+                    last = page_rows[-1]
+                    continuation = RecoveryCursor(
+                        created_at=float(last["created_at"]),
+                        operation_id=str(last["operation_id"]),
+                    )
+                    has_more = (
+                        conn.execute(
+                            """SELECT 1
+                                 FROM webhook_operations INDEXED BY
+                                      idx_webhook_operations_recovery_order
+                                WHERE state IN (
+                                    'preparing','ready','running',
+                                    'delivery_ready','delivering'
+                                )
+                                  AND (created_at, operation_id) > (?, ?)
+                                ORDER BY created_at, operation_id
+                                LIMIT 1""",
+                            (
+                                continuation.created_at,
+                                continuation.operation_id,
+                            ),
+                        ).fetchone()
+                        is not None
+                    )
+            else:
+                candidate_rows: list[sqlite3.Row] = []
+                for profile in normalized_profiles:
+                    candidate_rows.extend(
+                        conn.execute(
+                            f"""SELECT operation_id, created_at
+                                   FROM webhook_operations INDEXED BY
+                                        idx_webhook_operations_profile_recovery_order
+                                  WHERE profile=? AND state IN (
+                                      'preparing','ready','running',
+                                      'delivery_ready','delivering'
+                                  )
+                                    {cursor_predicate}
+                                  ORDER BY created_at, operation_id
+                                  LIMIT ?""",
+                            (
+                                profile,
+                                *cursor_params,
+                                batch_limit + 1,
+                            ),
+                        ).fetchall()
+                    )
+                candidate_rows.sort(
+                    key=lambda row: (
+                        float(row["created_at"]),
+                        str(row["operation_id"]),
+                    )
+                )
+                page_rows = candidate_rows[:batch_limit]
+                has_more = len(candidate_rows) > batch_limit
+                if has_more:
+                    last = page_rows[-1]
+                    continuation = RecoveryCursor(
+                        created_at=float(last["created_at"]),
+                        operation_id=str(last["operation_id"]),
+                    )
+            if has_more:
+                if continuation is None:  # pragma: no cover - invariant
+                    raise WebhookLedgerCorruptionError(
+                        "dead-owner recovery continuation is unavailable"
+                    )
+                next_cursor = continuation
+            for page_row in page_rows:
+                row = self._operation_row(conn, str(page_row["operation_id"]))
+                if row is None:  # pragma: no cover - same write transaction
+                    raise WebhookLedgerCorruptionError("recovery operation disappeared")
+                if _owner_alive(row["owner_pid"], row["owner_started_at"]):
+                    continue
+                operation_id = row["operation_id"]
+                target = self._target_row(conn, operation_id)
+                target_attempting = (
+                    target is not None
+                    and target["state"] == TargetState.ATTEMPTING.value
+                )
+                if row["state"] == OperationState.PREPARING.value:
+                    if not bool(row["script_started"]):
+                        conn.execute(
+                            "DELETE FROM webhook_operations WHERE operation_id=?",
+                            (operation_id,),
+                        )
+                        released.append(operation_id)
+                        continue
+                elif (
+                    row["state"]
+                    in {
+                        OperationState.READY.value,
+                        OperationState.DELIVERY_READY.value,
+                    }
+                    and not target_attempting
+                    and target is not None
+                    and target["state"] == TargetState.PENDING.value
+                ):
+                    cursor = conn.execute(
+                        """UPDATE webhook_operations
+                           SET generation=generation+1, owner_pid=?,
+                               owner_started_at=?, owner_instance=?, updated_at=?
+                           WHERE operation_id=? AND generation=? AND state=?""",
+                        (
+                            owner_pid,
+                            owner_started_at,
+                            self.instance_id,
+                            timestamp,
+                            operation_id,
+                            int(row["generation"]),
+                            row["state"],
+                        ),
+                    )
+                    if cursor.rowcount == 1:
+                        claimed = self._operation_row(conn, operation_id)
+                        if claimed is None:  # pragma: no cover - guarded by UPDATE
+                            raise WebhookLedgerError("recovered operation disappeared")
+                        authority = self._authority_from_row(conn, claimed)
+                        if authority.state is OperationState.READY:
+                            if authority.delivery is not None:
+                                raise WebhookLedgerCorruptionError(
+                                    "event-ready operation has a staged delivery"
+                                )
+                            event_ready.append(authority)
+                        else:
+                            if authority.delivery is None:
+                                raise WebhookLedgerCorruptionError(
+                                    "delivery-ready operation has no staged delivery"
+                                )
+                            delivery_ready.append(authority)
+                        continue
+
+                reason = "gateway owner exited after webhook effects may have started"
+                conn.execute(
+                    """UPDATE webhook_operations
+                       SET state='indeterminate', updated_at=?, last_error=?
+                       WHERE operation_id=? AND state!='settled'""",
+                    (timestamp, reason, operation_id),
+                )
+                conn.execute(
+                    """UPDATE webhook_targets
+                       SET state='indeterminate', settled_at=?, updated_at=?,
+                           last_error=?
+                       WHERE operation_id=? AND state='attempting'""",
+                    (timestamp, timestamp, reason, operation_id),
+                )
+                indeterminate.append(operation_id)
+        return RecoveryBatch(
+            event_ready=tuple(event_ready),
+            delivery_ready=tuple(delivery_ready),
+            released=tuple(released),
+            indeterminate=tuple(indeterminate),
+            scanned_count=len(page_rows),
+            has_more=has_more,
+            next_cursor=next_cursor,
+        )
+
+    def prune(self, *, now: Optional[float] = None) -> int:
+        """Compact old terminal rows and expire local-bypass proofs."""
+
+        timestamp = time.time() if now is None else float(now)
+        with self._lock, self._transaction() as conn:
+            return self._prune_terminal(conn, timestamp)
+
+    def count(self) -> int:
+        """Return heavy/live operation rows; compact tombstones do not count."""
+
+        with self._lock:
+            with self._connection() as conn:
+                return int(
+                    conn.execute("SELECT COUNT(*) FROM webhook_operations").fetchone()[
+                        0
+                    ]
+                )
+
+    def tombstone_count(self) -> int:
+        """Return compact durable replay proofs, including temporary bypasses."""
+
+        with self._lock:
+            with self._connection() as conn:
+                return int(
+                    conn.execute(
+                        "SELECT COUNT(*) FROM webhook_delivery_tombstones"
+                    ).fetchone()[0]
+                )
+
+    def storage_usage(self) -> tuple[int, int, int]:
+        """Return reserved bytes, proof count, and the persisted global limit."""
+
+        with self._lock:
+            with self._connection() as conn:
+                row = self._storage_usage_row(conn)
+                return (
+                    int(row["reserved_bytes"]),
+                    int(row["proof_count"]),
+                    int(row["max_storage_bytes"]),
+                )
+
+    def bind_authentication_keys(
+        self,
+        bindings: Iterable[tuple[str, str, str, str, str, str]],
+    ) -> None:
+        """Permanently bind verifier-key fingerprints to one route authority.
+
+        A key that ever authenticated one profile/route/provider/mode cannot
+        later be reassigned to a different authority. This prevents captured
+        proofs from gaining a fresh route-scoped replay namespace after a hot
+        reload, rename, profile move, provider change, or process restart.
+        """
+
+        normalized = [
+            _normalize_authentication_binding(binding) for binding in bindings
+        ]
+
+        with self._lock, self._transaction() as conn:
+            for binding in normalized:
+                (
+                    fingerprint,
+                    profile,
+                    route,
+                    provider,
+                    signature_mode,
+                    policy_sha256,
+                ) = binding
+                existing = conn.execute(
+                    """SELECT profile, route, provider, signature_mode,
+                              policy_sha256
+                         FROM webhook_auth_key_bindings
+                        WHERE key_fingerprint=?""",
+                    (fingerprint,),
+                ).fetchone()
+                owner = (
+                    profile,
+                    route,
+                    provider,
+                    signature_mode,
+                    policy_sha256,
+                )
+                if existing is not None:
+                    persisted_owner = (
+                        existing["profile"],
+                        existing["route"],
+                        existing["provider"],
+                        existing["signature_mode"],
+                        existing["policy_sha256"],
+                    )
+                    if persisted_owner != owner:
+                        raise WebhookLedgerTransitionError(
+                            "webhook authentication key is permanently bound "
+                            "to another route policy authority"
+                        )
+                    continue
+                usage = self._storage_usage_row(conn)
+                if int(usage["auth_binding_reserved_bytes"]) > (
+                    int(usage["auth_binding_limit_bytes"])
+                    - _AUTH_BINDING_STORAGE_RESERVATION_BYTES
+                ):
+                    raise WebhookLedgerCapacityError(
+                        "webhook authentication binding capacity exhausted"
+                    )
+                scope_binding_usage = conn.execute(
+                    """SELECT auth_binding_reserved_bytes
+                         FROM webhook_ledger_scope_usage
+                        WHERE profile=? AND route=? AND provider=?""",
+                    (profile, route, provider),
+                ).fetchone()
+                scope_binding_reserved = (
+                    0
+                    if scope_binding_usage is None
+                    else int(scope_binding_usage["auth_binding_reserved_bytes"])
+                )
+                if scope_binding_reserved > (
+                    int(usage["auth_binding_scope_limit_bytes"])
+                    - _AUTH_BINDING_STORAGE_RESERVATION_BYTES
+                ):
+                    raise WebhookLedgerCapacityError(
+                        "webhook authentication binding route-scope capacity exhausted"
+                    )
+                conn.execute(
+                    """INSERT INTO webhook_auth_key_bindings (
+                           key_fingerprint, profile, route, provider,
+                           signature_mode, policy_sha256, bound_at
+                       ) VALUES (?, ?, ?, ?, ?, ?, ?)""",
+                    (*binding, time.time()),
+                )
+
+    def authentication_keys_match(
+        self,
+        bindings: Iterable[tuple[str, str, str, str, str, str]],
+    ) -> bool:
+        """Prove a bounded route-key authority still exists exactly.
+
+        The check reconnects to the database path and uses one read snapshot,
+        so an unlinked/replaced root database cannot be hidden by the adapter's
+        cached route bundle. Missing fingerprints or owner/policy mismatches are
+        ordinary negative proofs. Storage and schema failures remain errors so
+        callers fail closed rather than treating an unavailable authority as a
+        legitimate key rejection.
+        """
+
+        normalized: list[tuple[str, str, str, str, str, str]] = []
+        for binding in bindings:
+            if len(normalized) >= _MAX_AUTH_BINDINGS_PER_AUTHORITY_CHECK:
+                raise WebhookLedgerError(
+                    "authentication authority check exceeds its fingerprint bound"
+                )
+            normalized.append(_normalize_authentication_binding(binding))
+
+        expected_columns = (
+            "key_fingerprint",
+            "profile",
+            "route",
+            "provider",
+            "signature_mode",
+            "policy_sha256",
+            "bound_at",
+        )
+        with self._lock, self._connection() as conn:
+            conn.execute("BEGIN")
+            try:
+                metadata = conn.execute(
+                    """SELECT schema_version FROM webhook_ledger_meta
+                        WHERE schema_name=?""",
+                    (_SCHEMA_NAME,),
+                ).fetchall()
+                binding_info = conn.execute(
+                    "PRAGMA table_info(webhook_auth_key_bindings)"
+                ).fetchall()
+                try:
+                    schema_version = (
+                        int(metadata[0]["schema_version"])
+                        if len(metadata) == 1
+                        else None
+                    )
+                except (TypeError, ValueError, OverflowError) as exc:
+                    raise WebhookLedgerCorruptionError(
+                        "webhook authentication key binding schema is incompatible"
+                    ) from exc
+                if (
+                    len(metadata) != 1
+                    or schema_version != _SCHEMA_VERSION
+                    or tuple(row["name"] for row in binding_info) != expected_columns
+                    or [int(row["pk"]) for row in binding_info] != [1, 0, 0, 0, 0, 0, 0]
+                ):
+                    raise WebhookLedgerCorruptionError(
+                        "webhook authentication key binding schema is incompatible"
+                    )
+                for (
+                    fingerprint,
+                    profile,
+                    route,
+                    provider,
+                    signature_mode,
+                    policy_sha256,
+                ) in normalized:
+                    existing = conn.execute(
+                        """SELECT profile, route, provider, signature_mode,
+                                  policy_sha256
+                             FROM webhook_auth_key_bindings
+                            WHERE key_fingerprint=?""",
+                        (fingerprint,),
+                    ).fetchone()
+                    if existing is None or (
+                        existing["profile"],
+                        existing["route"],
+                        existing["provider"],
+                        existing["signature_mode"],
+                        existing["policy_sha256"],
+                    ) != (
+                        profile,
+                        route,
+                        provider,
+                        signature_mode,
+                        policy_sha256,
+                    ):
+                        return False
+                return True
+            finally:
+                conn.rollback()
+
+    def has_global_admission_capacity(self, *, now: Optional[float] = None) -> bool:
+        """Return whether one new heavy carrier fits the global authorities.
+
+        This is a read-only readiness snapshot. Settled heavy rows count at
+        their compact replay-proof size because admission may safely compact
+        them before reserving another carrier. Scope limits are deliberately
+        excluded: one saturated route must not make the shared listener
+        unhealthy while the global reserve remains available.
+        """
+
+        timestamp = time.time() if now is None else float(now)
+        bounded_replay_prefix = _BOUNDED_REPLAY_PREFIXES[0]
+
+        with self._lock, self._connection() as conn:
+            # A deferred read transaction gives every capacity component one
+            # SQLite snapshot without taking the writer lock used by mutation.
+            conn.execute("BEGIN")
+            try:
+                usage = self._storage_usage_row(conn)
+                effective_global_records = (
+                    int(usage["active_record_count"])
+                    + int(usage["settled_operation_count"])
+                    - min(
+                        int(usage["settled_operation_count"]),
+                        _MAX_PRUNE_BATCH,
+                    )
+                )
+                if effective_global_records >= int(usage["max_records"]):
+                    return False
+
+                expired_proofs = len(
+                    conn.execute(
+                        """SELECT rowid
+                             FROM webhook_delivery_tombstones INDEXED BY
+                                  idx_webhook_tombstones_expires_at
+                            WHERE expires_at IS NOT NULL AND expires_at <= ?
+                            ORDER BY expires_at, rowid
+                            LIMIT ?""",
+                        (timestamp, _MAX_PRUNE_BATCH),
+                    ).fetchall()
+                )
+                expired_bounded_settlements = len(
+                    conn.execute(
+                        f"""SELECT operation_id
+                             FROM webhook_operations INDEXED BY
+                                  idx_webhook_operations_bounded_settled_expiry
+                            WHERE state='settled'
+                              AND substr(
+                                  replay_id, 1, {len(bounded_replay_prefix)}
+                              )='{bounded_replay_prefix}'
+                              AND COALESCE(settled_at, updated_at) <= ?
+                            ORDER BY COALESCE(settled_at, updated_at)
+                            LIMIT ?""",
+                        (
+                            timestamp - self.local_bypass_replay_retention_seconds,
+                            _MAX_PRUNE_BATCH,
+                        ),
+                    ).fetchall()
+                )
+                effective_reserved = (
+                    int(usage["reserved_bytes"])
+                    - expired_proofs * _TOMBSTONE_STORAGE_RESERVATION_BYTES
+                    - int(usage["settled_operation_count"])
+                    * (
+                        _OPERATION_STORAGE_RESERVATION_BYTES
+                        - _TOMBSTONE_STORAGE_RESERVATION_BYTES
+                    )
+                    - expired_bounded_settlements * _TOMBSTONE_STORAGE_RESERVATION_BYTES
+                )
+                return effective_reserved + _OPERATION_STORAGE_RESERVATION_BYTES <= int(
+                    usage["max_storage_bytes"]
+                )
+            finally:
+                conn.rollback()
+
+
+def content_sha256(content: str) -> str:
+    """Canonical digest helper for target-attempt joins."""
+
+    return hashlib.sha256(str(content).encode("utf-8", "replace")).hexdigest()
+
+
+__all__ = [
+    "AdmitDisposition",
+    "AdmitResult",
+    "AdmitSaturationReason",
+    "DEFAULT_MAX_STORAGE_BYTES",
+    "DEFAULT_RECOVERY_BATCH_SIZE",
+    "DeliveryTombstone",
+    "MAXIMUM_MAX_STORAGE_BYTES",
+    "MAXIMUM_MAX_RECORDS",
+    "MAXIMUM_RECOVERY_BATCH_SIZE",
+    "MAXIMUM_RECOVERY_PROFILES",
+    "MINIMUM_MAX_STORAGE_BYTES",
+    "OperationAuthority",
+    "OperationState",
+    "RecoveryBatch",
+    "RecoveryCursor",
+    "Settlement",
+    "SettlementKind",
+    "StagedDelivery",
+    "TargetAttempt",
+    "TargetAttemptDisposition",
+    "TargetState",
+    "WebhookLedgerCapacityError",
+    "WebhookLedgerConfigurationError",
+    "WebhookLedgerCorruptionError",
+    "WebhookLedgerError",
+    "WebhookLedgerTransitionError",
+    "WebhookOperationLedger",
+    "content_sha256",
+]

--- a/gateway/platforms/webhook_models.py
+++ b/gateway/platforms/webhook_models.py
@@ -1,0 +1,322 @@
+"""Persistent webhook route documents layered on the intake contract.
+
+``webhook_contract.WebhookRouteConfig`` remains the sole authority for route
+identity, provider selection, signature mode, event binding, and profile
+scope.  This module owns only the larger *stored document* used by management
+surfaces.  Keeping those responsibilities separate prevents a persisted model
+from drifting into a second authentication contract.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Literal, Mapping
+from urllib.parse import urlsplit
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    PrivateAttr,
+    field_validator,
+    model_validator,
+)
+
+from gateway.platforms.webhook_contract import (
+    WebhookContractError,
+    WebhookRouteConfig,
+)
+
+
+_ROUTE_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,127}$")
+_PROFILE_NAME_RE = re.compile(r"^(?:default|[a-z0-9][a-z0-9_-]{0,63})$")
+_SECRET_REF_RE = re.compile(r"^[A-Z_][A-Z0-9_]{0,127}$")
+_LEGACY_CLI_DESCRIPTION_PREFIX = "Agent-created subscription:"
+
+
+class WebhookRouteDocument(BaseModel):
+    """Typed, profile-bound webhook route persistence document.
+
+    Unknown JSON fields are retained so provider extensions and newer route
+    policy survive a read/write cycle by an older management surface.  A
+    legacy plaintext ``secret`` can be loaded, but it is deliberately kept
+    separate from ``secret_ref``: only the secret migration may turn one into
+    the other after secure write/readback verification.
+    """
+
+    model_config = ConfigDict(
+        extra="allow",
+        populate_by_name=False,
+        validate_assignment=True,
+    )
+
+    name: str
+    enabled: bool = True
+    description: str = ""
+    profile: str = "default"
+    events: list[str] = Field(default_factory=list)
+    provider: str | None = None
+    signature_mode: str | None = None
+    signature_context: str | None = None
+    secret_ref: str | None = None
+
+    prompt: str = ""
+    skills: list[str] = Field(default_factory=list)
+    script: str | None = None
+    filters: list[dict[str, Any]] = Field(default_factory=list)
+    model: str | None = None
+
+    session_mode: Literal["event", "thread", "keyed"] = "event"
+    session_key_template: str | None = None
+    approval_mode: Literal["deny", "delivery_target"] = "deny"
+    clarification_mode: Literal["fail", "delivery_target"] = "fail"
+    response_mode: Literal["accepted", "wait", "callback"] = "accepted"
+    callback: dict[str, Any] | None = None
+    deliveries: list[dict[str, Any]] = Field(default_factory=list)
+    deliver_only: bool = False
+    completion_script: str | None = None
+
+    # Plaintext is accepted only for lossless loading of the pre-reference
+    # format.  It never appears in repr/model_dump and is never interpreted as
+    # a reference.  ``to_persisted_route`` writes it back unchanged until the
+    # dedicated migration has durably moved it.
+    legacy_secret: str | None = Field(
+        default=None,
+        alias="secret",
+        exclude=True,
+        repr=False,
+    )
+    legacy_secret_value: str | None = Field(
+        default=None,
+        alias="secret_value",
+        exclude=True,
+        repr=False,
+    )
+    _contract: WebhookRouteConfig | None = PrivateAttr(default=None)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _default_new_generic_route(cls, value: Any) -> Any:
+        """Default only a genuinely undeclared *new* route to generic_v2.
+
+        A provider-only document must let the canonical provider choose its
+        own default verifier.  Persisted legacy input that had neither field
+        explicitly supplies ``signature_mode=None`` in ``from_persisted_route``
+        so it fails closed (or takes the one content-derived CLI migration).
+        """
+
+        if isinstance(value, Mapping):
+            candidate = dict(value)
+            if not candidate.get("provider") and "signature_mode" not in candidate:
+                candidate["signature_mode"] = "generic_v2"
+            return candidate
+        return value
+
+    @field_validator("name")
+    @classmethod
+    def _valid_name(cls, value: str) -> str:
+        if not isinstance(value, str) or not _ROUTE_NAME_RE.fullmatch(value):
+            raise ValueError("route name must be a canonical lowercase URL slug")
+        return value
+
+    @field_validator("profile")
+    @classmethod
+    def _valid_profile(cls, value: str) -> str:
+        if not isinstance(value, str) or not _PROFILE_NAME_RE.fullmatch(value):
+            raise ValueError("profile must be a canonical profile id")
+        return value
+
+    @field_validator("secret_ref")
+    @classmethod
+    def _valid_secret_ref(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        if not isinstance(value, str) or not _SECRET_REF_RE.fullmatch(value):
+            raise ValueError("secret_ref must be a canonical secret identifier")
+        return value
+
+    @field_validator("events", "skills")
+    @classmethod
+    def _nonempty_unique_strings(cls, values: list[str]) -> list[str]:
+        result: list[str] = []
+        for item in values:
+            if not isinstance(item, str) or not item.strip():
+                raise ValueError("route string lists require non-empty strings")
+            clean = item.strip()
+            if clean not in result:
+                result.append(clean)
+        return result
+
+    @model_validator(mode="after")
+    def _validate_policy(self) -> "WebhookRouteDocument":
+        # These are internal Python attribute names for the two accepted
+        # on-disk aliases below. With ``extra='allow'``, retaining them as
+        # unknown fields would put plaintext into repr/model_dump.
+        extras = self.model_extra or {}
+        if "legacy_secret" in extras or "legacy_secret_value" in extras:
+            raise ValueError("route contains a reserved secret field name")
+
+        plaintext_values = [
+            value
+            for value in (self.legacy_secret, self.legacy_secret_value)
+            if value is not None
+        ]
+        if len(plaintext_values) > 1:
+            raise ValueError("route has more than one legacy plaintext secret")
+        if self.secret_ref is not None and plaintext_values:
+            raise ValueError(
+                "route cannot contain both secret_ref and plaintext secret"
+            )
+        if plaintext_values and (
+            not isinstance(plaintext_values[0], str) or not plaintext_values[0]
+        ):
+            raise ValueError("legacy plaintext secret must be a non-empty string")
+
+        if self.deliver_only and not self.deliveries:
+            raise ValueError("deliver_only routes require at least one delivery target")
+        if self.deliver_only and self.response_mode != "accepted":
+            raise ValueError("deliver_only routes must use response_mode='accepted'")
+        if self.session_mode == "keyed" and not self.session_key_template:
+            raise ValueError("keyed session_mode requires session_key_template")
+        if self.session_mode != "keyed" and self.session_key_template is not None:
+            raise ValueError("session_key_template is only valid for keyed sessions")
+        if self.approval_mode == "delivery_target" and not self.deliveries:
+            raise ValueError("delivery-target approvals require a delivery target")
+        if self.clarification_mode == "delivery_target" and not self.deliveries:
+            raise ValueError("delivery-target clarification requires a delivery target")
+
+        if self.response_mode == "callback":
+            callback_url = (
+                self.callback.get("url") if isinstance(self.callback, dict) else None
+            )
+            if not isinstance(callback_url, str):
+                raise ValueError("callback response mode requires callback.url")
+            parsed = urlsplit(callback_url)
+            if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+                raise ValueError("callback.url must be an absolute HTTP(S) URL")
+        elif self.callback is not None:
+            raise ValueError("callback is only valid with response_mode='callback'")
+
+        # Delegate every security/identity decision to the canonical contract.
+        try:
+            self._contract = WebhookRouteConfig.bind(
+                self.name,
+                self.contract_mapping(),
+                headers={},
+                request_profile=self.profile,
+            )
+        except WebhookContractError as exc:
+            raise ValueError(str(exc)) from exc
+        return self
+
+    @property
+    def contract(self) -> WebhookRouteConfig:
+        """The exact canonical intake binding for this stored document."""
+
+        if self._contract is None:  # pragma: no cover - validators populate it
+            self._contract = WebhookRouteConfig.bind(
+                self.name,
+                self.contract_mapping(),
+                headers={},
+                request_profile=self.profile,
+            )
+        return self._contract
+
+    @property
+    def has_legacy_plaintext_secret(self) -> bool:
+        return self.legacy_secret is not None or self.legacy_secret_value is not None
+
+    def contract_mapping(self) -> dict[str, Any]:
+        """Return the safe full document consumed by the intake contract.
+
+        Provider-specific authority such as Trello's ``callback_url`` and a
+        custom-HMAC ``signature`` object lives in retained extra fields.  The
+        canonical contract must see those fields; filtering down to a small
+        common subset would validate a weaker/different route.  Only secret
+        persistence fields are excluded here.
+        """
+
+        result = self.model_dump(mode="python", exclude={"name"})
+        for key in ("secret_ref", "secret", "secret_value"):
+            result.pop(key, None)
+        result = {key: value for key, value in result.items() if value is not None}
+        return result
+
+
+def _legacy_delivery(route: Mapping[str, Any]) -> list[dict[str, Any]]:
+    target = route.get("deliver")
+    extra = route.get("deliver_extra")
+    if target is None and not extra:
+        return []
+    delivery: dict[str, Any] = {}
+    if target is not None:
+        delivery["target"] = target
+    if isinstance(extra, Mapping):
+        delivery.update(extra)
+    elif extra is not None:
+        delivery["extra"] = extra
+    return [delivery]
+
+
+def from_persisted_route(
+    name: str,
+    route: Mapping[str, Any],
+    *,
+    profile: str,
+) -> WebhookRouteDocument:
+    """Parse one persisted route without changing its secret authority."""
+
+    if not isinstance(route, Mapping):
+        raise TypeError("persisted webhook route must be an object")
+    raw = dict(route)
+    embedded_name = raw.pop("name", name)
+    embedded_profile = raw.get("profile", profile)
+    if embedded_profile != profile:
+        raise ValueError("stored route profile does not match its profile store")
+    raw["profile"] = profile
+
+    if "deliveries" not in raw:
+        raw["deliveries"] = _legacy_delivery(raw)
+    # Keep the old singular fields only as extras so a read/write is lossless
+    # until the delivery architecture consumes the canonical list.
+
+    if raw.get("provider") and "signature_mode" not in raw:
+        # Provider-only routes delegate verifier selection to that provider.
+        raw["signature_mode"] = None
+    elif not raw.get("provider") and not raw.get("signature_mode"):
+        description = raw.get("description")
+        if isinstance(description, str) and description.startswith(
+            _LEGACY_CLI_DESCRIPTION_PREFIX
+        ):
+            raw["provider"] = "github"
+            # Suppress the creation-time generic_v2 default. Provider-only
+            # binding lets the canonical contract select GitHub's own default.
+            raw["signature_mode"] = None
+        else:
+            # ``None`` suppresses the model's creation-time default. The
+            # canonical contract then fails closed instead of guessing from
+            # attacker-controlled request headers.
+            raw["signature_mode"] = None
+
+    return WebhookRouteDocument.model_validate({"name": embedded_name, **raw})
+
+
+def to_persisted_route(route: WebhookRouteDocument) -> dict[str, Any]:
+    """Serialize one route document, preserving unmigrated plaintext exactly."""
+
+    data = route.model_dump(mode="json", exclude={"name"}, by_alias=False)
+    # ``None`` is not useful in the on-disk JSON and can accidentally look like
+    # an explicit policy override to older readers.
+    data = {key: value for key, value in data.items() if value is not None}
+    if route.legacy_secret is not None:
+        data["secret"] = route.legacy_secret
+    if route.legacy_secret_value is not None:
+        data["secret_value"] = route.legacy_secret_value
+    return data
+
+
+__all__ = [
+    "WebhookRouteDocument",
+    "from_persisted_route",
+    "to_persisted_route",
+]

--- a/gateway/platforms/webhook_recovery.py
+++ b/gateway/platforms/webhook_recovery.py
@@ -29,6 +29,11 @@ from gateway.platforms.webhook_ledger import (
     WebhookLedgerError,
     WebhookLedgerTransitionError,
 )
+from gateway.platforms.webhook_terminal import (
+    WebhookTerminalOutcome,
+    terminal_outcome_carrier,
+    terminal_outcome_notice,
+)
 
 from gateway.platforms.webhook_common import (
     WebhookMessageEvent,
@@ -654,6 +659,26 @@ class WebhookRecoveryMixin:
                             current,
                             "agent completed without a provable final settlement",
                         )
+                elif outcome is ProcessingOutcome.FAILURE:
+                    try:
+                        staged = self._stage_exact_delivery(
+                            current,
+                            terminal_outcome_notice(WebhookTerminalOutcome.ERROR),
+                            terminal_outcome_carrier(WebhookTerminalOutcome.ERROR),
+                        )
+                    except BaseException as exc:
+                        self._mark_indeterminate_or_fence(
+                            current,
+                            exc,
+                            context="terminal error carrier staging failure",
+                        )
+                        if not isinstance(exc, Exception):
+                            raise
+                        return
+                    # This is the same durable target gate used by normal finals.
+                    # A pre-effect failure remains recoverable; anything after
+                    # invocation is settled indeterminate and never retried blind.
+                    await self._invoke_staged_target(staged)
                 else:
                     self._operation_ledger.mark_indeterminate(
                         current,

--- a/gateway/platforms/webhook_recovery.py
+++ b/gateway/platforms/webhook_recovery.py
@@ -1,0 +1,760 @@
+"""Recovery responsibilities for the webhook adapter."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import secrets
+from typing import Any, Awaitable, Callable, Mapping
+
+try:
+    from aiohttp import web
+except ImportError:
+    web = None  # type: ignore[assignment]
+
+from gateway.platforms.base import (
+    MessageEvent,
+    MessageType,
+    ProcessingOutcome,
+)
+from gateway.platforms.webhook_contract import (
+    WebhookContractError,
+)
+from gateway.platforms.webhook_ledger import (
+    DEFAULT_RECOVERY_BATCH_SIZE,
+    MAXIMUM_RECOVERY_PROFILES,
+    OperationAuthority,
+    OperationState,
+    RecoveryBatch,
+    WebhookLedgerError,
+    WebhookLedgerTransitionError,
+)
+
+from gateway.platforms.webhook_common import (
+    WebhookMessageEvent,
+    _RECOVERY_CONCURRENCY_LIMIT,
+    _RECOVERY_PAGE_BUDGET,
+    _clear_quarantined_retirement_owner,
+    _plain_json_snapshot,
+    _quarantined_retirement_owners,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class WebhookRecoveryMixin:
+    def _event_from_authority(
+        self, authority: OperationAuthority
+    ) -> WebhookMessageEvent:
+        snapshot = authority.event_snapshot
+        if not isinstance(snapshot, Mapping) or snapshot.get("v") != 1:
+            raise WebhookContractError("durable event snapshot is invalid")
+        if set(snapshot) != {
+            "v",
+            "mode",
+            "text",
+            "payload",
+            "message_id",
+            "source",
+        }:
+            raise WebhookContractError("durable event snapshot has unknown fields")
+        if snapshot.get("mode") != "agent":
+            raise WebhookContractError("durable event is not an agent operation")
+        text = snapshot.get("text")
+        message_id = snapshot.get("message_id")
+        payload = snapshot.get("payload")
+        if not isinstance(text, str) or not isinstance(message_id, str):
+            raise WebhookContractError("durable event text or message_id is invalid")
+        if not isinstance(payload, Mapping):
+            raise WebhookContractError("durable event payload is invalid")
+        return WebhookMessageEvent(
+            text=text,
+            message_type=MessageType.TEXT,
+            source=self._source_from_authority(authority),
+            raw_message=_plain_json_snapshot(payload),
+            message_id=message_id,
+            webhook_authority=authority,
+            webhook_envelope=None,
+            allow_gateway_control=False,
+        )
+
+    async def _recover_event_ready(self, authority: OperationAuthority) -> None:
+        snapshot = authority.event_snapshot
+        if not isinstance(snapshot, Mapping):
+            raise WebhookContractError("recovered event snapshot is missing")
+        mode = snapshot.get("mode")
+        if mode == "agent":
+            event = self._event_from_authority(authority)
+            # Revalidate durable profile authority before Base can cross the
+            # RUNNING gate or dispatch an agent. A profile directory may still
+            # exist after the operator removes it from the served allowlist.
+            with self._profile_runtime_context(event.source):
+                pass
+            await self.handle_message(event)
+            # Base dispatch is intentionally backgrounded. Keep this recovery
+            # carrier registered until that exact task crosses RUNNING and
+            # completes; otherwise a refill page can observe generation>=2
+            # READY after the wrapper returns and schedule it a second time.
+            from gateway.session import build_session_key
+
+            session_key = build_session_key(
+                event.source,
+                group_sessions_per_user=self.config.extra.get(
+                    "group_sessions_per_user", True
+                ),
+                thread_sessions_per_user=self.config.extra.get(
+                    "thread_sessions_per_user", False
+                ),
+                profile=self._session_key_profile(event.source),
+            )
+            processing_task = self._session_tasks.get(session_key)
+            if processing_task is not None:
+                await processing_task
+            current = self._operation_ledger.lookup_session(authority.session_key)
+            if current is not None and current.state is OperationState.READY:
+                raise WebhookLedgerTransitionError(
+                    "recovered event dispatch did not cross the running gate"
+                )
+            return
+        if mode != "direct":
+            raise WebhookContractError("recovered event mode is invalid")
+        if set(snapshot) != {
+            "v",
+            "mode",
+            "text",
+            "payload",
+            "message_id",
+            "source",
+        }:
+            raise WebhookContractError("recovered direct event has unknown fields")
+        content = snapshot.get("text")
+        if not isinstance(content, str):
+            raise WebhookContractError("recovered direct content is invalid")
+        # Cross-check source/profile authority even though direct mode does not
+        # enter the agent pipeline.
+        self._source_from_authority(authority)
+        try:
+            generation_is_current = await asyncio.to_thread(
+                self._recovery_profile_generation_is_current,
+                authority,
+            )
+        except asyncio.CancelledError:
+            self._mark_indeterminate_or_fence(
+                authority,
+                "recovered direct generation check was cancelled",
+                context="recovered direct generation-check cancellation",
+            )
+            raise
+        except BaseException as exc:
+            self._mark_indeterminate_or_fence(
+                authority,
+                exc,
+                context="recovered direct generation-check failure",
+            )
+            raise
+        if not generation_is_current:
+            self._mark_indeterminate_or_fence(
+                authority,
+                "webhook profile incarnation changed before recovered direct execution",
+                context="recovered direct profile generation mismatch",
+            )
+            return
+        try:
+            entered_running = self._operation_ledger.mark_running(authority)
+        except BaseException:
+            self._fence_intake_for_durable_transition_failure(
+                "recovered direct running-gate transition failure"
+            )
+            raise
+        if not entered_running:
+            self._fence_intake_for_durable_transition_failure(
+                "recovered direct running-gate authority loss"
+            )
+            raise WebhookLedgerTransitionError(
+                "recovered direct operation lost its running gate"
+            )
+        staged = self._stage_exact_delivery(
+            authority, content, {"v": 1, "kind": "direct"}
+        )
+        await self._invoke_staged_target(staged)
+
+    def _track_recovery_task(
+        self,
+        task: "asyncio.Task",
+        authority: OperationAuthority,
+        label: str,
+        started: list[bool],
+    ) -> None:
+        self._background_tasks.add(task)
+        self._recovery_tasks_by_operation[authority.operation_id] = task
+
+        def done(completed: "asyncio.Task") -> None:
+            self._background_tasks.discard(completed)
+            if (
+                self._recovery_tasks_by_operation.get(authority.operation_id)
+                is completed
+            ):
+                self._recovery_tasks_by_operation.pop(authority.operation_id, None)
+            failed = completed.cancelled()
+            error: object = f"{label} task was cancelled"
+            if failed and not started[0]:
+                try:
+                    if self._operation_ledger.relinquish_recovery_claim(authority):
+                        self._recovery_restart_dead_scan = True
+                        self._recovery_backlog_pending = True
+                        schedule_retry = getattr(
+                            self.gateway_runner,
+                            "_schedule_webhook_recovery_retry",
+                            None,
+                        )
+                        if callable(schedule_retry):
+                            schedule_retry(self)
+                        return
+                except Exception:
+                    logger.exception(
+                        "[webhook] Failed to relinquish unstarted %s task", label
+                    )
+                    self._fence_intake_for_durable_transition_failure(
+                        f"{label} claim relinquishment failure"
+                    )
+                    return
+                self._fence_intake_for_durable_transition_failure(
+                    f"{label} claim relinquishment authority loss"
+                )
+                return
+            if not failed:
+                try:
+                    exception = completed.exception()
+                    failed = exception is not None
+                    if exception is not None:
+                        error = exception
+                except BaseException as exc:
+                    failed = True
+                    error = exc
+            if failed:
+                self._mark_indeterminate_or_fence(
+                    authority,
+                    error,
+                    context=f"{label} task failure",
+                )
+            if self._recovery_backlog_pending:
+                schedule_retry = getattr(
+                    self.gateway_runner,
+                    "_schedule_webhook_recovery_retry",
+                    None,
+                )
+                if callable(schedule_retry):
+                    schedule_retry(self)
+
+        task.add_done_callback(done)
+
+    def _schedule_recovery_task(
+        self,
+        authority: OperationAuthority,
+        label: str,
+        operation: Callable[[], Awaitable[None]],
+    ) -> bool:
+        """Schedule one carrier per operation without creating it prematurely."""
+
+        existing = self._recovery_tasks_by_operation.get(authority.operation_id)
+        if existing is not None and not existing.done():
+            return False
+        active_count = sum(
+            not active.done() for active in self._recovery_tasks_by_operation.values()
+        )
+        if active_count >= _RECOVERY_CONCURRENCY_LIMIT:
+            return False
+
+        started = [False]
+
+        async def run() -> None:
+            started[0] = True
+            await operation()
+
+        task = asyncio.create_task(run())
+        self._track_recovery_task(task, authority, label, started)
+        return True
+
+    def _served_recovery_profiles(self) -> tuple[str, ...]:
+        """Freeze the exact physical profile domains served by this gateway."""
+
+        from hermes_cli.profiles import get_active_profile_name, profiles_to_serve
+
+        runner_config = getattr(self.gateway_runner, "config", None)
+        multiplex = getattr(runner_config, "multiplex_profiles", False) is True
+        if multiplex:
+            served = profiles_to_serve(
+                multiplex=True,
+                profile_allowlist=getattr(
+                    runner_config,
+                    "multiplex_profile_allowlist",
+                    None,
+                ),
+            )
+            profiles = {name for name, _home in served}
+        else:
+            active = get_active_profile_name() or "default"
+            profiles = {"default" if active == "custom" else active}
+        if len(profiles) > MAXIMUM_RECOVERY_PROFILES:
+            raise WebhookContractError(
+                "webhook recovery profile authority exceeds its bounded limit"
+            )
+        return tuple(sorted(profiles))
+
+    def _schedule_recovery_batch(self, batch: RecoveryBatch) -> int:
+        """Schedule every authority returned by one slot-bounded claim page."""
+
+        scheduled = 0
+        for authority in batch.event_ready:
+            if not self._recovery_profile_generation_is_current(authority):
+                self._mark_indeterminate_or_fence(
+                    authority,
+                    "webhook profile incarnation changed before event recovery",
+                    context="recovered event profile generation mismatch",
+                )
+                continue
+            if self._schedule_recovery_task(
+                authority,
+                "event recovery",
+                lambda authority=authority: self._recover_event_ready(authority),
+            ):
+                scheduled += 1
+        for authority in batch.delivery_ready:
+            if not self._recovery_profile_generation_is_current(authority):
+                self._mark_indeterminate_or_fence(
+                    authority,
+                    "webhook profile incarnation changed before delivery recovery",
+                    context="recovered delivery profile generation mismatch",
+                )
+                continue
+            if self._schedule_recovery_task(
+                authority,
+                "delivery recovery",
+                lambda authority=authority: self._invoke_staged_target(authority),
+            ):
+                scheduled += 1
+        return scheduled
+
+    def _recovery_profile_generation_is_current(
+        self,
+        authority: OperationAuthority,
+    ) -> bool:
+        """Require a recovered carrier to belong to the same profile instance."""
+
+        grant = authority.grant_snapshot
+        durable_generation = (
+            grant.get("profile_generation") if isinstance(grant, Mapping) else None
+        )
+        if not isinstance(durable_generation, str) or not durable_generation:
+            return False
+        try:
+            current_generation = self._current_profile_authority_generation(
+                authority.profile,
+                route_name=authority.route,
+            )
+        except Exception:
+            logger.exception(
+                "[webhook] Could not resolve current profile generation for %s/%s",
+                authority.profile,
+                authority.route,
+            )
+            return False
+        return secrets.compare_digest(durable_generation, current_generation)
+
+    async def recover_pending_operations(self, *, trigger: str = "manual") -> int:
+        """Pump bounded recovery pages and resume only replay-safe carriers."""
+
+        self._accepting_webhooks = False
+        try:
+            async with self._recovery_pump_lock:
+                if self._lifecycle_retiring:
+                    self._recovery_backlog_pending = True
+                    return 0
+
+                if not self._recovery_cycle_active:
+                    self._recovery_cycle_active = True
+                    self._dead_owner_recovery_cursor = None
+                    self._dead_owner_recovery_complete = False
+                    self._current_recovery_cursor = None
+                    self._current_recovery_complete = False
+                    self._recovery_authority_profiles = await asyncio.to_thread(
+                        self._served_recovery_profiles
+                    )
+                if self._recovery_restart_dead_scan:
+                    self._dead_owner_recovery_cursor = None
+                    self._dead_owner_recovery_complete = False
+                    self._recovery_restart_dead_scan = False
+
+                page_budget = _RECOVERY_PAGE_BUDGET
+                scheduled = 0
+                released = 0
+                indeterminate = 0
+                progress = False
+
+                # A same-process predecessor has our PID, so ordinary owner
+                # liveness cannot identify it as stale. Retire exact marked
+                # owners first, keeping each marker until its final page.
+                quarantined_owners = _quarantined_retirement_owners(
+                    self._operation_ledger
+                )
+                while quarantined_owners and page_budget > 0:
+                    prior_owner = quarantined_owners[0]
+                    retired = await self._run_ledger_mutation_barrier(
+                        lambda prior_owner=prior_owner: (
+                            self._operation_ledger.retire_owner_instance(
+                                prior_owner,
+                            )
+                        )
+                    )
+                    page_budget -= 1
+                    released += len(retired.released)
+                    indeterminate += len(retired.indeterminate)
+                    progress = progress or retired.scanned_count > 0
+                    if not retired.has_more:
+                        _clear_quarantined_retirement_owner(
+                            self._operation_ledger,
+                            prior_owner,
+                        )
+                    quarantined_owners = _quarantined_retirement_owners(
+                        self._operation_ledger
+                    )
+                    if quarantined_owners and page_budget > 0:
+                        await asyncio.sleep(0)
+
+                # Rediscover current-owner delivery carriers and any claim
+                # committed immediately before a cancelled scheduling handoff.
+                # Do this before new dead-owner claims, so every newly claimed
+                # authority returned below can be scheduled synchronously and
+                # a completed dead scan needs no second discovery pass.
+                while (
+                    not quarantined_owners
+                    and page_budget > 0
+                    and not self._current_recovery_complete
+                ):
+                    active_count = sum(
+                        not task.done()
+                        for task in self._recovery_tasks_by_operation.values()
+                    )
+                    free_slots = _RECOVERY_CONCURRENCY_LIMIT - active_count
+                    if free_slots <= 0:
+                        break
+                    cursor = self._current_recovery_cursor
+                    page = await asyncio.to_thread(
+                        self._operation_ledger.list_current_recovery_ready,
+                        limit=min(DEFAULT_RECOVERY_BATCH_SIZE, free_slots),
+                        after=cursor,
+                        profiles=self._recovery_authority_profiles,
+                    )
+                    page_budget -= 1
+                    progress = progress or page.scanned_count > 0
+                    page_scheduled = self._schedule_recovery_batch(page)
+                    scheduled += page_scheduled
+                    if page.has_more:
+                        if page.next_cursor is None:
+                            raise WebhookLedgerError(
+                                "current recovery page lost its continuation"
+                            )
+                        self._current_recovery_cursor = page.next_cursor
+                    else:
+                        self._current_recovery_cursor = None
+                        self._current_recovery_complete = True
+                        self._recovery_current_scan_required = False
+                    if page_scheduled:
+                        page_budget = 0
+                    elif page_budget > 0:
+                        await asyncio.sleep(0)
+
+                # Never claim work while any exact same-process owner remains
+                # unfenced or while previously claimed work is not scheduled.
+                if not quarantined_owners and self._current_recovery_complete:
+                    while page_budget > 0 and not self._dead_owner_recovery_complete:
+                        active_count = sum(
+                            not task.done()
+                            for task in self._recovery_tasks_by_operation.values()
+                        )
+                        free_slots = _RECOVERY_CONCURRENCY_LIMIT - active_count
+                        if free_slots <= 0:
+                            break
+                        claim_limit = min(
+                            DEFAULT_RECOVERY_BATCH_SIZE,
+                            free_slots,
+                        )
+                        cursor = self._dead_owner_recovery_cursor
+                        profiles = self._recovery_authority_profiles
+                        self._dead_claim_handoff_in_progress = True
+                        batch = await self._run_ledger_mutation_barrier(
+                            lambda cursor=cursor, profiles=profiles, claim_limit=claim_limit: (
+                                self._operation_ledger.recover_dead_owners_page(
+                                    limit=claim_limit,
+                                    after=cursor,
+                                    profiles=profiles,
+                                )
+                            )
+                        )
+                        page_budget -= 1
+                        released += len(batch.released)
+                        indeterminate += len(batch.indeterminate)
+                        progress = progress or batch.scanned_count > 0
+                        page_scheduled = self._schedule_recovery_batch(batch)
+                        self._dead_claim_handoff_in_progress = False
+                        scheduled += page_scheduled
+                        if batch.has_more:
+                            if batch.next_cursor is None:
+                                raise WebhookLedgerError(
+                                    "bounded recovery page lost its continuation"
+                                )
+                            self._dead_owner_recovery_cursor = batch.next_cursor
+                        else:
+                            self._dead_owner_recovery_cursor = None
+                            self._dead_owner_recovery_complete = True
+                        if page_scheduled:
+                            page_budget = 0
+                        elif page_budget > 0:
+                            await asyncio.sleep(0)
+
+                self._recovery_backlog_pending = bool(
+                    quarantined_owners
+                    or not self._dead_owner_recovery_complete
+                    or not self._current_recovery_complete
+                )
+                self._recovery_last_progress = progress
+                self._recovery_last_error = False
+                if not self._recovery_backlog_pending:
+                    self._recovery_cycle_active = False
+                    self._dead_owner_recovery_cursor = None
+                    self._current_recovery_cursor = None
+                else:
+                    schedule_retry = getattr(
+                        self.gateway_runner,
+                        "_schedule_webhook_recovery_retry",
+                        None,
+                    )
+                    if callable(schedule_retry):
+                        schedule_retry(self)
+
+                if scheduled or released or indeterminate or progress:
+                    logger.info(
+                        "[webhook] Recovery trigger=%s scheduled=%d released=%d "
+                        "indeterminate=%d quarantined_owners=%d backlog=%s",
+                        trigger,
+                        scheduled,
+                        released,
+                        indeterminate,
+                        len(quarantined_owners),
+                        self._recovery_backlog_pending,
+                    )
+                return scheduled
+        except BaseException:
+            self._accepting_webhooks = False
+            self._recovery_backlog_pending = True
+            self._recovery_last_progress = False
+            self._recovery_last_error = True
+            self._recovery_cycle_active = False
+            self._dead_owner_recovery_cursor = None
+            self._dead_owner_recovery_complete = False
+            self._current_recovery_cursor = None
+            self._current_recovery_complete = False
+            self._recovery_current_scan_required = bool(
+                self._recovery_current_scan_required
+                or self._dead_claim_handoff_in_progress
+            )
+            self._dead_claim_handoff_in_progress = False
+            raise
+
+    async def on_processing_start(self, event: "MessageEvent") -> None:
+        """Cross the durable execution gate before the agent or any tool runs."""
+
+        authority = getattr(event, "webhook_authority", None)
+        if not isinstance(authority, OperationAuthority):
+            raise WebhookLedgerTransitionError(
+                "webhook event has no exact durable operation authority"
+            )
+        try:
+            generation_is_current = await asyncio.to_thread(
+                self._recovery_profile_generation_is_current,
+                authority,
+            )
+        except asyncio.CancelledError:
+            self._mark_indeterminate_or_fence(
+                authority,
+                "webhook agent generation check was cancelled",
+                context="agent generation-check cancellation",
+            )
+            raise
+        except BaseException as exc:
+            self._mark_indeterminate_or_fence(
+                authority,
+                exc,
+                context="agent generation-check failure",
+            )
+            raise
+        if not generation_is_current:
+            self._mark_indeterminate_or_fence(
+                authority,
+                "webhook profile incarnation changed before agent execution",
+                context="agent profile generation mismatch",
+            )
+            raise WebhookLedgerTransitionError(
+                "webhook profile authority changed before execution"
+            )
+        try:
+            entered_running = self._operation_ledger.mark_running(authority)
+        except BaseException:
+            self._fence_intake_for_durable_transition_failure(
+                "agent running-gate transition failure"
+            )
+            raise
+        if not entered_running:
+            self._fence_intake_for_durable_transition_failure(
+                "agent running-gate authority loss"
+            )
+            raise WebhookLedgerTransitionError(
+                "webhook operation could not enter running state"
+            )
+
+    async def _run_processing_hook(
+        self, hook_name: str, *args: Any, **kwargs: Any
+    ) -> None:
+        """Make the webhook start gate fail closed; keep completion best-effort."""
+
+        if hook_name == "on_processing_start":
+            await self.on_processing_start(*args, **kwargs)
+            return
+        await super()._run_processing_hook(hook_name, *args, **kwargs)
+
+    async def on_processing_complete(
+        self, event: "MessageEvent", outcome: ProcessingOutcome
+    ) -> None:
+        """Reconcile exact durable state, then close the one-shot session."""
+
+        authority = getattr(event, "webhook_authority", None)
+        try:
+            if not isinstance(authority, OperationAuthority):
+                logger.error("[webhook] Completion event lacks durable authority")
+                return
+            current = self._operation_ledger.lookup_session(authority.session_key)
+            if current is None:
+                logger.error(
+                    "[webhook] Completion authority disappeared for %s",
+                    authority.operation_id,
+                )
+                return
+            if current.state in {
+                OperationState.SETTLED,
+                OperationState.INDETERMINATE,
+                OperationState.DELIVERY_READY,
+            }:
+                return
+            if current.state is OperationState.RUNNING:
+                if outcome is ProcessingOutcome.SUCCESS:
+                    if not self._operation_ledger.settle_no_effect(
+                        current, "agent produced no final webhook effect"
+                    ):
+                        self._operation_ledger.mark_indeterminate(
+                            current,
+                            "agent completed without a provable final settlement",
+                        )
+                else:
+                    self._operation_ledger.mark_indeterminate(
+                        current,
+                        f"agent processing ended with {outcome.value}",
+                    )
+                return
+            self._operation_ledger.mark_indeterminate(
+                current,
+                f"agent completion observed unexpected state {current.state.value}",
+            )
+        except Exception:
+            logger.exception("[webhook] Durable completion reconciliation failed")
+        finally:
+            await self._end_webhook_session(event, event.source.chat_id)
+
+    async def _end_webhook_session(
+        self, event: "MessageEvent", session_chat_id: str
+    ) -> None:
+        """Mark the per-delivery webhook session ended in state.db.
+
+        Resolves the persisted ``session_id`` from the gateway session store
+        using the SAME source the run was keyed on (so profile multiplexing
+        and key construction match exactly), then closes it via the existing
+        ``SessionDB.end_session`` API — never a hand-written UPDATE.
+        """
+        runner = self.gateway_runner
+        if runner is None:
+            return
+
+        async def _close_in_active_profile_scope() -> None:
+            # Both handles resolve through the active HERMES_HOME. They must be
+            # acquired inside the admitted profile scope, never before it.
+            session_db = getattr(runner, "_session_db", None)
+            store = getattr(runner, "session_store", None)
+            if session_db is None or store is None:
+                return
+            key_fn = getattr(runner, "_session_key_for_source", None)
+            if key_fn is None:
+                return
+            session_key = key_fn(event.source)
+            # Resolve the persisted session_id via the store's public,
+            # lock-held accessor (peek_session_id) rather than reaching into
+            # the private _entries dict without the store lock. Fall back to
+            # the private path only for older stores / test doubles that
+            # predate the accessor.
+            peek = getattr(store, "peek_session_id", None)
+            if callable(peek):
+                session_id = peek(session_key)
+            else:
+                if hasattr(store, "_ensure_loaded"):
+                    try:
+                        store._ensure_loaded()
+                    except Exception:
+                        pass
+                entries = getattr(store, "_entries", {}) or {}
+                entry = entries.get(session_key)
+                session_id = getattr(entry, "session_id", None) if entry else None
+            if not session_id:
+                logger.debug(
+                    "[webhook] No session_id to close for %s (key=%s)",
+                    session_chat_id,
+                    session_key,
+                )
+                return
+            # AsyncSessionDB forwards end_session via asyncio.to_thread; a
+            # plain SessionDB exposes it synchronously.  Handle both.
+            _end = session_db.end_session
+            result = _end(session_id, "webhook_complete")
+            if asyncio.iscoroutine(result):
+                await result
+            logger.debug(
+                "[webhook] Closed session %s for delivery %s",
+                session_id,
+                session_chat_id,
+            )
+
+        try:
+            config = getattr(runner, "config", None)
+            if getattr(config, "multiplex_profiles", False) is True:
+                resolve_home = getattr(runner, "_resolve_profile_home_for_source", None)
+                if not callable(resolve_home):
+                    logger.warning(
+                        "[webhook] Cannot close multiplexed session %s: "
+                        "profile resolver is unavailable",
+                        session_chat_id,
+                    )
+                    return
+                profile_home = resolve_home(event.source)
+                from gateway.run import _profile_runtime_scope
+
+                with _profile_runtime_scope(profile_home):
+                    await _close_in_active_profile_scope()
+            else:
+                await _close_in_active_profile_scope()
+        except Exception as e:
+            logger.debug(
+                "[webhook] Failed to close session for %s: %s",
+                session_chat_id,
+                e,
+            )
+
+    # ------------------------------------------------------------------
+    # Prompt rendering
+    # ------------------------------------------------------------------

--- a/gateway/platforms/webhook_route_authority.py
+++ b/gateway/platforms/webhook_route_authority.py
@@ -1,0 +1,1569 @@
+"""Route responsibilities for the webhook adapter."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import re
+import secrets
+import shutil
+import weakref
+from contextlib import nullcontext
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any, List, Mapping, Optional
+
+try:
+    from aiohttp import web
+except ImportError:
+    web = None  # type: ignore[assignment]
+
+from gateway.config import Platform
+from gateway.platforms.webhook_contract import (
+    WebhookContractError,
+    WebhookRouteConfig,
+)
+from gateway.platforms.webhook_filters import (
+    BoundedFileSnapshotTooLarge,
+    MAX_FILTER_FILE_SNAPSHOT_BYTES,
+    WebhookPreparedScript,
+    _resolve_profile_path,
+    read_bounded_regular_file_snapshot,
+)
+from gateway.platforms.webhook_ledger import (
+    MAXIMUM_RECOVERY_PROFILES,
+    OperationAuthority,
+    WebhookLedgerError,
+)
+
+from gateway.platforms.webhook_common import (
+    AuthenticatedRouteAuthority,
+    PreparedSkillInvocation,
+    PreparedTargetTemplate,
+    _INSECURE_NO_AUTH,
+    _MAX_DYNAMIC_ROUTES_FILE_BYTES,
+    _PROMPT_TOKEN_RE,
+    _authentication_key_fingerprints,
+    _is_loopback_host,
+    _plain_json_snapshot,
+    _profile_incarnation_token,
+    _reject_nonfinite_json,
+    _route_policy_sha256,
+    _snapshot_route_config,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class WebhookRouteAuthorityMixin:
+    def _intake_is_authoritative(self, profile: str) -> bool:
+        """Return whether this exact shared listener may admit requests."""
+
+        if not self._accepting_webhooks:
+            return False
+        runner = self.gateway_runner
+        if runner is None:
+            # Standalone adapter use and direct handler tests have no registry.
+            return True
+        if (
+            getattr(runner, "_startup_restore_in_progress", False) is True
+            or getattr(runner, "_draining", False) is True
+            or getattr(runner, "_external_drain_active", False) is True
+            or getattr(runner, "_running", True) is False
+        ):
+            return False
+        shutdown_event = getattr(runner, "_shutdown_event", None)
+        shutdown_is_set = getattr(shutdown_event, "is_set", None)
+        if callable(shutdown_is_set) and shutdown_is_set() is True:
+            return False
+        # Webhook is a port-binding platform. Multiplexing deliberately starts
+        # one process-level listener in ``runner.adapters`` and routes named
+        # profiles through its /p/<profile>/ prefix; secondary profile maps may
+        # never contain another webhook adapter. Profile-specific authorization
+        # is enforced by the bound route and runtime scope after this transport
+        # ownership check.
+        del profile
+        return (getattr(runner, "adapters", None) or {}).get(Platform.WEBHOOK) is self
+
+    def prepare_ledger_owned_final_content(
+        self,
+        content: str,
+        *,
+        session_key: str,
+    ) -> str:
+        """Reduce one agent response to a replayable text-only carrier.
+
+        Local attachments cannot be snapshotted as stable outbound objects:
+        the referenced files can change or disappear before crash recovery.
+        Strip those directives before staging and include one non-sensitive
+        notice in the same exact final text. Public image links remain ordinary
+        text and are delivered without invoking a second media API.
+        """
+
+        del session_key
+        media_files, cleaned = self.extract_media(content)
+        local_files, cleaned = self.extract_local_files(cleaned)
+        if media_files or local_files:
+            notice = "⚠️ Local attachments were omitted from webhook delivery."
+            cleaned = f"{cleaned.rstrip()}\n\n{notice}" if cleaned.strip() else notice
+        return cleaned or "[SILENT]"
+
+    def resolved_toolsets_for_source(self, source) -> List[str]:
+        """Return the already-validated durable grant, or deny all."""
+
+        chat_id = str(getattr(source, "chat_id", "") or "")
+        if not chat_id:
+            return []
+        try:
+            authority = self._operation_ledger.lookup_session(chat_id)
+        except Exception:
+            logger.exception(
+                "[webhook] Failed to resolve durable toolset authority for %s",
+                chat_id,
+            )
+            return []
+        grant = authority.grant_snapshot if authority is not None else None
+        if not isinstance(grant, Mapping) or grant.get("v") != 1:
+            return []
+        toolsets = grant.get("toolsets")
+        if not isinstance(toolsets, (list, tuple)):
+            return []
+        if any(not isinstance(value, str) or not value for value in toolsets):
+            return []
+        return list(toolsets)
+
+    def toolsets_for_source(self, source) -> Optional[List[str]]:
+        """Compatibility facade for callers predating resolved grant carriers."""
+
+        return self.resolved_toolsets_for_source(source)
+
+    @staticmethod
+    def _source_for_route_authority(
+        bound_route: WebhookRouteConfig,
+        *,
+        authority_profile: Optional[str] = None,
+    ):
+        """Build the profile-stamped source used for config publication."""
+
+        from gateway.session import SessionSource
+
+        return SessionSource(
+            platform=Platform.WEBHOOK,
+            chat_id=(f"webhook-policy/{bound_route.profile}/{bound_route.name}"),
+            chat_name=f"webhook/{bound_route.name}",
+            chat_type="webhook",
+            user_id=f"webhook:{bound_route.name}",
+            user_name=bound_route.name,
+            profile=authority_profile or bound_route.profile,
+        )
+
+    def _credential_authority_profile(
+        self,
+        bound_route: WebhookRouteConfig,
+    ) -> str:
+        """Return the real profile domain behind a canonical default route."""
+
+        if bound_route.profile != "default":
+            return bound_route.profile
+        runner_config = getattr(self.gateway_runner, "config", None)
+        if getattr(runner_config, "multiplex_profiles", False) is True:
+            return "default"
+        try:
+            from hermes_cli.profiles import get_active_profile_name
+
+            active_profile = get_active_profile_name()
+        except Exception:
+            active_profile = "default"
+        if active_profile == "custom":
+            # A custom HERMES_HOME is the installation root, not a named
+            # profile below ``profiles/``.  Its physical root already scopes
+            # the shared ledger, and runner profile resolution recognizes the
+            # base authority as ``default``.
+            return "default"
+        return active_profile or "default"
+
+    def _validate_route_profile_reachable(
+        self,
+        route: Mapping[str, Any],
+        bound_route: WebhookRouteConfig,
+    ) -> None:
+        """Reject unreachable explicit profile authority before key binding."""
+
+        if "profile" not in route:
+            return
+        runner_config = getattr(self.gateway_runner, "config", None)
+        if getattr(runner_config, "multiplex_profiles", False) is True:
+            try:
+                from hermes_cli.profiles import profiles_to_serve
+
+                served = {
+                    name
+                    for name, _home in profiles_to_serve(
+                        multiplex=True,
+                        profile_allowlist=getattr(
+                            runner_config,
+                            "multiplex_profile_allowlist",
+                            None,
+                        ),
+                    )
+                }
+            except Exception as exc:
+                raise WebhookContractError(
+                    "served webhook profile authority cannot be resolved"
+                ) from exc
+            if bound_route.profile not in served:
+                raise WebhookContractError(
+                    f"route {bound_route.name!r} profile "
+                    f"{bound_route.profile!r} is not served"
+                )
+            return
+        if bound_route.profile == "default":
+            # Canonical default is also the omitted-profile spelling. In a
+            # named single-profile process its credential owner and physical
+            # generation are deliberately mapped to that active profile.
+            return
+        try:
+            from hermes_cli.profiles import profile_matches_home
+
+            matches = profile_matches_home(bound_route.profile)
+        except Exception as exc:
+            raise WebhookContractError(
+                "active webhook profile authority cannot be resolved"
+            ) from exc
+        if not matches:
+            raise WebhookContractError(
+                f"route {bound_route.name!r} profile "
+                f"{bound_route.profile!r} is not this gateway's profile"
+            )
+
+    def _profile_authority_generation(
+        self,
+        bound_route: WebhookRouteConfig,
+        *,
+        authority_profile: str,
+    ) -> str:
+        """Bind keys to one physical profile incarnation, not only its name."""
+
+        return self._current_profile_authority_generation(
+            authority_profile,
+            route_name=bound_route.name,
+        )
+
+    def _current_profile_authority_generation(
+        self,
+        authority_profile: str,
+        *,
+        route_name: str,
+    ) -> str:
+        """Return the current incarnation for one physical profile domain."""
+
+        from gateway.session import SessionSource
+
+        source = SessionSource(
+            platform=Platform.WEBHOOK,
+            chat_id=f"webhook-policy/{authority_profile}/{route_name}",
+            chat_name=f"webhook/{route_name}",
+            chat_type="webhook",
+            user_id=f"webhook:{route_name}",
+            user_name=route_name,
+            profile=authority_profile,
+        )
+
+        runner_config = getattr(self.gateway_runner, "config", None)
+        multiplexed = getattr(runner_config, "multiplex_profiles", False) is True
+        resolver = getattr(
+            self.gateway_runner,
+            "_resolve_profile_home_for_source",
+            None,
+        )
+        if multiplexed:
+            if callable(resolver):
+                profile_home = Path(resolver(source))
+            else:
+                # Narrow compatibility for publication-focused test doubles;
+                # a real multiplex GatewayRunner always owns the resolver.
+                from hermes_constants import get_hermes_home
+
+                profile_home = get_hermes_home()
+        else:
+            # In a named single-profile process, an omitted route profile is
+            # canonically stamped "default" for URL routing, but its physical
+            # authority is the process launch HERMES_HOME. Asking the runner to
+            # resolve that synthetic stamp can incorrectly select the root
+            # default profile instead of the named profile actually executing.
+            from hermes_constants import get_hermes_home
+
+            profile_home = get_hermes_home()
+        try:
+            resolved = profile_home.resolve(strict=True)
+        except OSError as exc:
+            raise WebhookContractError(
+                f"profile home for route {route_name!r} is unavailable"
+            ) from exc
+        incarnation = _profile_incarnation_token(resolved)
+        material = f"{resolved}\0{incarnation}".encode("utf-8")
+        return hashlib.sha256(material).hexdigest()
+
+    @staticmethod
+    def _prepared_target_authority(
+        prepared: PreparedTargetTemplate,
+    ) -> dict[str, Any]:
+        """Return canonical JSON authority for one frozen target template."""
+
+        return {
+            "kind": prepared.kind,
+            "profile": prepared.profile,
+            "platform": prepared.platform,
+            "home_chat_id": prepared.home_chat_id,
+            "home_thread_id": prepared.home_thread_id,
+            "home_scope_id": prepared.home_scope_id,
+            "slack_static_chat_id": prepared.slack_static_chat_id,
+            "slack_static_scope_id": prepared.slack_static_scope_id,
+            "slack_scope_locked": prepared.slack_scope_locked,
+        }
+
+    def _prepare_route_filter_authority(
+        self,
+        route: dict[str, Any],
+        bound_route: WebhookRouteConfig,
+        *,
+        authority_profile: str,
+    ) -> tuple[dict[str, Any], tuple[tuple[str, str], ...]]:
+        """Replace every mutable in_file lookup with exact captured values."""
+
+        if "filters" not in route:
+            return _snapshot_route_config(route), ()
+
+        source = self._source_for_route_authority(
+            bound_route,
+            authority_profile=authority_profile,
+        )
+        captured: dict[str, tuple[list[Any], str, str]] = {}
+
+        def capture(path_value: Any) -> tuple[list[Any], str, str]:
+            path = _resolve_profile_path(path_value)
+            if path is None:
+                raise WebhookContractError("webhook filter in_file path is invalid")
+            try:
+                resolved = path.resolve(strict=True)
+                raw = read_bounded_regular_file_snapshot(
+                    resolved,
+                    max_bytes=MAX_FILTER_FILE_SNAPSHOT_BYTES,
+                ).content
+            except BoundedFileSnapshotTooLarge as exc:
+                raise WebhookContractError(
+                    "webhook filter in_file exceeds the 1 MiB authority limit"
+                ) from exc
+            except (OSError, ValueError) as exc:
+                raise WebhookContractError(
+                    f"webhook filter in_file is unavailable: {path}"
+                ) from exc
+            try:
+                text = raw.decode("utf-8")
+            except UnicodeDecodeError as exc:
+                raise WebhookContractError(
+                    "webhook filter in_file must be UTF-8"
+                ) from exc
+            try:
+                data = json.loads(text)
+            except RecursionError as exc:
+                raise WebhookContractError(
+                    "webhook filter in_file JSON nesting is too deep"
+                ) from exc
+            except json.JSONDecodeError:
+                values: list[Any] = [
+                    line.strip() for line in text.splitlines() if line.strip()
+                ]
+            except ValueError as exc:
+                raise WebhookContractError(
+                    "webhook filter in_file contains an invalid JSON value"
+                ) from exc
+            else:
+                if isinstance(data, list):
+                    values = data
+                elif isinstance(data, dict):
+                    values = list(data.keys())
+                else:
+                    values = [data]
+            # The frozen evaluator and the route-policy digest both require
+            # finite, detached JSON. This also rejects NaN/Infinity accepted
+            # by Python's permissive json.loads default.
+            try:
+                values = json.loads(
+                    json.dumps(
+                        values,
+                        ensure_ascii=False,
+                        allow_nan=False,
+                        separators=(",", ":"),
+                    ),
+                    parse_constant=_reject_nonfinite_json,
+                )
+            except (
+                TypeError,
+                ValueError,
+                json.JSONDecodeError,
+                RecursionError,
+            ) as exc:
+                raise WebhookContractError(
+                    "webhook filter in_file must contain finite JSON values"
+                ) from exc
+            digest = hashlib.sha256(raw).hexdigest()
+            return values, str(resolved), digest
+
+        def freeze_filter_node(value: Any, *, root_list: bool = False) -> Any:
+            if root_list and isinstance(value, list):
+                return [freeze_filter_node(item) for item in value]
+            if not isinstance(value, dict):
+                return _plain_json_snapshot(value)
+            # Only recurse through filter grammar edges. Operand JSON under
+            # equals/contains/in may legitimately contain a literal key named
+            # "in_file" and must never be interpreted as another filter node.
+            frozen = _plain_json_snapshot(value)
+            for operator in ("all", "any"):
+                children = value.get(operator)
+                if isinstance(children, list):
+                    frozen[operator] = [freeze_filter_node(item) for item in children]
+            nested = value.get("not")
+            if isinstance(nested, dict):
+                frozen["not"] = freeze_filter_node(nested)
+            if "in_file" not in value:
+                return frozen
+            if "in" in value:
+                raise WebhookContractError(
+                    "webhook filter cannot combine in and in_file"
+                )
+            path_key = json.dumps(value.get("in_file"), ensure_ascii=False)
+            cached = captured.get(path_key)
+            if cached is None:
+                values, resolved_path, digest = capture(value.get("in_file"))
+                captured[path_key] = (values, resolved_path, digest)
+            else:
+                values, resolved_path, digest = cached
+            frozen.pop("in_file", None)
+            frozen["in"] = _plain_json_snapshot(values)
+            return frozen
+
+        try:
+            with self._profile_runtime_context(source):
+                filters = route.get("filters")
+                frozen_filters = freeze_filter_node(
+                    filters,
+                    root_list=isinstance(filters, list),
+                )
+            frozen_route = _snapshot_route_config(route)
+        except RecursionError as exc:
+            raise WebhookContractError(
+                "webhook filter authority nesting is too deep"
+            ) from exc
+        frozen_route["filters"] = frozen_filters
+        authority_items: list[tuple[str, str]] = []
+        for values, resolved_path, digest in captured.values():
+            del values
+            authority_items.append((resolved_path, digest))
+        return frozen_route, tuple(sorted(authority_items))
+
+    def _prepare_route_skill_authority(
+        self,
+        route: Mapping[str, Any],
+        bound_route: WebhookRouteConfig,
+        *,
+        authority_profile: str,
+    ) -> Optional[PreparedSkillInvocation]:
+        """Capture the exact expanded scaffold for the first available skill."""
+
+        skills = route.get("skills", [])
+        if skills is None:
+            skills = []
+        if not isinstance(skills, list) or any(
+            not isinstance(name, str) or not name.strip() for name in skills
+        ):
+            raise WebhookContractError(
+                "webhook route skills must be a list of non-empty names"
+            )
+        if not skills:
+            return None
+
+        source = self._source_for_route_authority(
+            bound_route,
+            authority_profile=authority_profile,
+        )
+        marker_seed = hashlib.sha256(
+            f"{authority_profile}\0{bound_route.name}".encode("utf-8")
+        ).hexdigest()
+        marker = f"__HERMES_WEBHOOK_PROMPT_{marker_seed}__"
+        with self._profile_runtime_context(source):
+            from agent.skill_commands import (
+                build_skill_invocation_message,
+                get_skill_commands,
+            )
+
+            commands = get_skill_commands()
+            for skill_name in skills:
+                command = f"/{skill_name.strip()}"
+                if command not in commands:
+                    continue
+                rendered = build_skill_invocation_message(
+                    command,
+                    user_instruction=marker,
+                )
+                if not rendered:
+                    continue
+                if not isinstance(rendered, str):
+                    raise WebhookContractError(
+                        f"webhook skill {command!r} cannot be frozen safely"
+                    )
+                if marker in rendered:
+                    prefix, suffix = rendered.rsplit(marker, 1)
+                    inject_prompt = True
+                else:
+                    # Compatibility with a fixed-output/custom builder: its
+                    # exact output is still immutable authority, it simply
+                    # elects not to include the caller's rendered prompt.
+                    prefix, suffix = rendered, ""
+                    inject_prompt = False
+                return PreparedSkillInvocation(
+                    command=command,
+                    prefix=prefix,
+                    suffix=suffix,
+                    source_sha256=hashlib.sha256(rendered.encode("utf-8")).hexdigest(),
+                    inject_prompt=inject_prompt,
+                )
+        raise WebhookContractError(
+            f"route {bound_route.name!r} has no available configured skill"
+        )
+
+    def _effective_toolsets_for_route_authority(
+        self,
+        route: Mapping[str, Any],
+        bound_route: WebhookRouteConfig,
+        *,
+        authority_profile: str,
+    ) -> tuple[str, ...]:
+        """Resolve the immutable grant joined to one credential policy."""
+
+        deliver_only = route.get("deliver_only", False)
+        if not isinstance(deliver_only, bool):
+            raise WebhookContractError(
+                f"route {bound_route.name!r} has invalid deliver_only"
+            )
+        if deliver_only:
+            return ()
+        if self.gateway_runner is not None and (
+            not hasattr(self.gateway_runner, "config")
+            or not callable(
+                getattr(
+                    self.gateway_runner,
+                    "_resolve_profile_home_for_source",
+                    None,
+                )
+            )
+        ):
+            # Legacy lifecycle doubles have no configuration authority at all;
+            # bind them to an explicit deny-all grant rather than broadening
+            # through process-global defaults.
+            return ()
+
+        source = self._source_for_route_authority(
+            bound_route,
+            authority_profile=authority_profile,
+        )
+        resolver = self._resolve_admitted_toolsets
+        if (
+            getattr(resolver, "__func__", None)
+            is WebhookRouteAuthorityMixin._resolve_admitted_toolsets
+        ):
+            return tuple(resolver(route, source, strict_config=True))
+        # Compatibility for narrow test/embedding overrides that provide an
+        # already-strict grant resolver with the historical two-argument API.
+        return tuple(resolver(route, source))
+
+    def _profile_runtime_context(self, source: Any):
+        runner = self.gateway_runner
+        config = getattr(runner, "config", None)
+        if getattr(config, "multiplex_profiles", False) is not True:
+            return nullcontext()
+        resolver = getattr(runner, "_resolve_profile_home_for_source", None)
+        if not callable(resolver):
+            raise WebhookContractError(
+                "multiplexed webhook profile resolver is unavailable"
+            )
+        from gateway.run import _profile_runtime_scope
+
+        return _profile_runtime_scope(resolver(source))
+
+    def _route_authentication_authority_snapshot(
+        self,
+        routes: Mapping[str, Any],
+        *,
+        prepared_skill_overrides: Optional[
+            Mapping[str, PreparedSkillInvocation]
+        ] = None,
+    ) -> tuple[
+        tuple[Any, ...],
+        list[tuple[str, str, str, str, str, str]],
+        Mapping[str, tuple[Any, ...]],
+        Mapping[str, tuple[str, ...]],
+        Mapping[str, Optional[WebhookPreparedScript]],
+        Mapping[str, str],
+        Mapping[str, AuthenticatedRouteAuthority],
+    ]:
+        """Validate a complete route set and build its durable key bindings."""
+
+        material_owners: dict[str, tuple[str, str, str, str]] = {}
+        bindings: list[tuple[str, str, str, str, str, str]] = []
+        snapshot: list[tuple[Any, ...]] = []
+        authorities: dict[str, tuple[Any, ...]] = {}
+        effective_toolsets_by_route: dict[str, tuple[str, ...]] = {}
+        prepared_scripts: dict[str, Optional[WebhookPreparedScript]] = {}
+        profile_generations: dict[str, str] = {}
+        observed_profile_generations: dict[str, str] = {}
+        bundles: dict[str, AuthenticatedRouteAuthority] = {}
+        authority_profiles: set[str] = set()
+        for route_name in sorted(routes):
+            route = routes[route_name]
+            if not isinstance(route, Mapping):
+                raise WebhookContractError(
+                    f"route {route_name!r} configuration must be an object"
+                )
+            route_snapshot = _snapshot_route_config(dict(route))
+            bound_route = WebhookRouteConfig.bind(
+                route_name,
+                route_snapshot,
+                headers={},
+                request_profile=route_snapshot.get("profile", "default"),
+            )
+            self._validate_route_profile_reachable(route_snapshot, bound_route)
+            secret = route_snapshot.get("secret", self._global_secret)
+            if not isinstance(secret, str) or not secret:
+                raise WebhookContractError(f"route {route_name!r} has no HMAC secret")
+            if secret == _INSECURE_NO_AUTH and not _is_loopback_host(self._host):
+                raise WebhookContractError(
+                    f"route {route_name!r} uses INSECURE_NO_AUTH on a non-loopback host"
+                )
+            deliver_only = route_snapshot.get("deliver_only", False)
+            if not isinstance(deliver_only, bool):
+                raise WebhookContractError(
+                    f"route {route_name!r} has invalid deliver_only"
+                )
+            if deliver_only:
+                deliver = route_snapshot.get("deliver", "log")
+                if not isinstance(deliver, str) or not deliver or deliver == "log":
+                    raise WebhookContractError(
+                        f"route {route_name!r} has deliver_only=true without "
+                        "a real delivery target"
+                    )
+            owner = (
+                self._credential_authority_profile(bound_route),
+                bound_route.name,
+                bound_route.provider,
+                bound_route.signature_mode,
+            )
+            authority_profiles.add(owner[0])
+            if len(authority_profiles) > MAXIMUM_RECOVERY_PROFILES:
+                raise WebhookContractError(
+                    "webhook routes exceed the supported physical profile limit"
+                )
+            profile_generation_before = self._profile_authority_generation(
+                bound_route,
+                authority_profile=owner[0],
+            )
+            effective_toolsets = self._effective_toolsets_for_route_authority(
+                route_snapshot,
+                bound_route,
+                authority_profile=owner[0],
+            )
+            effective_toolsets_by_route[route_name] = effective_toolsets
+            prepared_script: Optional[WebhookPreparedScript] = None
+            if route_snapshot.get("script"):
+                source = self._source_for_route_authority(
+                    bound_route,
+                    authority_profile=owner[0],
+                )
+                with self._profile_runtime_context(source):
+                    prepared_script, script_error = (
+                        self._route_processor.prepare_route_script(
+                            route_snapshot.get("script")
+                        )
+                    )
+                if prepared_script is None:
+                    raise WebhookContractError(
+                        f"route {route_name!r} script is unavailable: "
+                        f"{script_error or 'unknown error'}"
+                    )
+            prepared_scripts[route_name] = prepared_script
+            script_sha256 = (
+                prepared_script.execution_sha256
+                if prepared_script is not None
+                else None
+            )
+            filter_route, filter_authority = self._prepare_route_filter_authority(
+                route_snapshot,
+                bound_route,
+                authority_profile=owner[0],
+            )
+            prepared_skill = (
+                prepared_skill_overrides.get(route_name)
+                if prepared_skill_overrides is not None
+                and route_name in prepared_skill_overrides
+                else self._prepare_route_skill_authority(
+                    route_snapshot,
+                    bound_route,
+                    authority_profile=owner[0],
+                )
+            )
+            source = self._source_for_route_authority(
+                bound_route,
+                authority_profile=owner[0],
+            )
+            with self._profile_runtime_context(source):
+                prepared_target = self._preflight_target_template(
+                    profile=owner[0],
+                    deliver=route_snapshot.get("deliver", "log"),
+                    deliver_extra=route_snapshot.get("deliver_extra", {}),
+                )
+            profile_generation = self._profile_authority_generation(
+                bound_route,
+                authority_profile=owner[0],
+            )
+            if not secrets.compare_digest(
+                profile_generation_before,
+                profile_generation,
+            ):
+                raise WebhookContractError(
+                    f"route {route_name!r} profile authority changed while "
+                    "execution dependencies were snapshotted"
+                )
+            observed_profile_generation = observed_profile_generations.get(owner[0])
+            if observed_profile_generation is not None and not secrets.compare_digest(
+                observed_profile_generation,
+                profile_generation,
+            ):
+                raise WebhookContractError(
+                    f"profile {owner[0]!r} authority changed while the route set "
+                    "was snapshotted"
+                )
+            observed_profile_generations[owner[0]] = profile_generation
+            profile_generations[route_name] = profile_generation
+            policy_sha256 = _route_policy_sha256(
+                route_snapshot,
+                owner[0],
+                effective_toolsets,
+                script_sha256,
+                profile_generation,
+                filter_authority,
+                (prepared_skill.source_sha256 if prepared_skill is not None else None),
+                self._prepared_target_authority(prepared_target),
+            )
+            if secret == _INSECURE_NO_AUTH:
+                authority = (*owner, policy_sha256, ("local-bypass",))
+                snapshot.append(authority)
+                authorities[route_name] = authority
+                bundles[route_name] = AuthenticatedRouteAuthority(
+                    authority=authority,
+                    secret=secret,
+                    route_config=route_snapshot,
+                    filter_route_config=filter_route,
+                    effective_toolsets=effective_toolsets,
+                    prepared_script=prepared_script,
+                    prepared_skill=prepared_skill,
+                    prepared_target=prepared_target,
+                    profile_generation=profile_generation,
+                )
+                continue
+
+            fingerprints = tuple(
+                sorted(
+                    fingerprint.hex()
+                    for fingerprint in _authentication_key_fingerprints(
+                        secret,
+                        bound_route.signature_mode,
+                    )
+                )
+            )
+            for fingerprint in fingerprints:
+                prior_owner = material_owners.get(fingerprint)
+                if prior_owner is not None and prior_owner != owner:
+                    prior_scope = f"{prior_owner[0]}/{prior_owner[1]}"
+                    current_scope = f"{owner[0]}/{owner[1]}"
+                    raise WebhookContractError(
+                        "authenticated webhook routes must not reuse secret "
+                        f"material across authority scopes {prior_scope!r} "
+                        f"and {current_scope!r}"
+                    )
+                material_owners[fingerprint] = owner
+                bindings.append((fingerprint, *owner, policy_sha256))
+            authority = (*owner, policy_sha256, fingerprints)
+            snapshot.append(authority)
+            authorities[route_name] = authority
+            bundles[route_name] = AuthenticatedRouteAuthority(
+                authority=authority,
+                secret=secret,
+                route_config=route_snapshot,
+                filter_route_config=filter_route,
+                effective_toolsets=effective_toolsets,
+                prepared_script=prepared_script,
+                prepared_skill=prepared_skill,
+                prepared_target=prepared_target,
+                profile_generation=profile_generation,
+            )
+        return (
+            tuple(snapshot),
+            bindings,
+            MappingProxyType(authorities),
+            MappingProxyType(effective_toolsets_by_route),
+            MappingProxyType(prepared_scripts),
+            MappingProxyType(profile_generations),
+            MappingProxyType(bundles),
+        )
+
+    def _bind_route_authentication_authorities(
+        self,
+        routes: Mapping[str, Any],
+    ) -> tuple[Any, ...]:
+        """Publish one complete route-key snapshot to durable authority."""
+
+        (
+            snapshot,
+            bindings,
+            authorities,
+            effective_toolsets,
+            prepared_scripts,
+            profile_generations,
+            bundles,
+        ) = self._route_authentication_authority_snapshot(routes)
+        if snapshot == self._authenticated_route_snapshot:
+            self._prune_rate_limit_buckets(self._authenticated_route_bundles)
+            return snapshot
+        self._authentication_authority_ledger.bind_authentication_keys(bindings)
+        self._authenticated_route_snapshot = snapshot
+        self._authenticated_route_authorities = authorities
+        self._authenticated_route_effective_toolsets = effective_toolsets
+        self._authenticated_route_scripts = prepared_scripts
+        self._authenticated_route_profile_generations = profile_generations
+        # Publish last: this single reference swap is the request-facing
+        # generation token and makes the complete bundle registry atomic.
+        self._authenticated_route_bundles = bundles
+        self._prune_rate_limit_buckets(bundles)
+        return snapshot
+
+    def _route_owns_unique_authenticated_secret(
+        self,
+        route_name: str,
+        secret: str,
+        signature_mode: str,
+        bundle: Optional[AuthenticatedRouteAuthority] = None,
+    ) -> bool:
+        """Defensively reject unbound or reassigned keys after config mutation."""
+
+        try:
+            if self._authenticated_route_snapshot is None:
+                # Compatibility for tests/embedders that exercise the handler
+                # without connect(). Production listeners bind before opening.
+                self._bind_route_authentication_authorities(self._routes)
+            bundle = bundle or self._authenticated_route_bundles.get(route_name)
+            expected = bundle.authority if bundle is not None else None
+            route = self._routes.get(route_name)
+            if bundle is None or expected is None or not isinstance(route, Mapping):
+                return False
+            if bundle.secret != secret:
+                return False
+            live_snapshot = _snapshot_route_config(dict(route))
+            if live_snapshot != bundle.route_config:
+                return False
+            bound_route = WebhookRouteConfig.bind(
+                route_name,
+                bundle.route_config,
+                headers={},
+                request_profile=bundle.route_config.get("profile", "default"),
+            )
+            if bound_route.signature_mode != signature_mode:
+                return False
+            fingerprints: tuple[str, ...]
+            if secret == _INSECURE_NO_AUTH:
+                fingerprints = ("local-bypass",)
+            else:
+                fingerprints = tuple(
+                    sorted(
+                        fingerprint.hex()
+                        for fingerprint in _authentication_key_fingerprints(
+                            secret,
+                            signature_mode,
+                        )
+                    )
+                )
+            observed = (
+                self._credential_authority_profile(bound_route),
+                bound_route.name,
+                bound_route.provider,
+                bound_route.signature_mode,
+                expected[4],
+                fingerprints,
+            )
+        except (WebhookContractError, WebhookLedgerError):
+            return False
+        return observed == expected
+
+    def _live_route_authority_matches(
+        self,
+        route_name: str,
+        bundle: AuthenticatedRouteAuthority,
+    ) -> bool:
+        """Revalidate mutable profile grants/code against the bound snapshot."""
+
+        try:
+            _, _, authorities, _, _, _, _ = (
+                self._route_authentication_authority_snapshot(
+                    {
+                        route_name: bundle.route_config,
+                    },
+                    prepared_skill_overrides=(
+                        {route_name: bundle.prepared_skill}
+                        if bundle.prepared_skill is not None
+                        and not bundle.prepared_skill.inject_prompt
+                        else None
+                    ),
+                )
+            )
+        except Exception:
+            return False
+        return authorities.get(route_name) == bundle.authority
+
+    def _route_bundle_is_current(
+        self,
+        route_name: str,
+        bundle: AuthenticatedRouteAuthority,
+    ) -> bool:
+        """Check the request's exact registry object, not merely its name."""
+
+        return (
+            self._authenticated_route_bundles.get(route_name) is bundle
+            and route_name in self._routes
+        )
+
+    @staticmethod
+    def _route_bundle_authentication_bindings(
+        bundle: AuthenticatedRouteAuthority,
+    ) -> tuple[tuple[str, str, str, str, str, str], ...]:
+        """Project one immutable bundle into its exact durable key proofs."""
+
+        profile, route, provider, signature_mode, policy_sha256, fingerprints = (
+            bundle.authority
+        )
+        if fingerprints == ("local-bypass",):
+            return ()
+        return tuple(
+            (
+                fingerprint,
+                profile,
+                route,
+                provider,
+                signature_mode,
+                policy_sha256,
+            )
+            for fingerprint in fingerprints
+        )
+
+    def _withdraw_live_route(
+        self,
+        route_name: str,
+        expected: Optional[AuthenticatedRouteAuthority] = None,
+    ) -> bool:
+        """Fence one route in memory until a valid rotated snapshot publishes."""
+
+        if expected is not None and (
+            self._authenticated_route_bundles.get(route_name) is not expected
+        ):
+            return False
+        self._dynamic_routes.pop(route_name, None)
+        self._routes.pop(route_name, None)
+        self._prune_rate_limit_buckets()
+        return True
+
+    def _resolve_admitted_toolsets(
+        self,
+        route_config: Mapping[str, Any],
+        source: Any,
+        *,
+        strict_config: bool = False,
+    ) -> list[str]:
+        """Resolve and validate the exact effective grants once at admission."""
+
+        if self.gateway_runner is None:
+            return []
+        with self._profile_runtime_context(source):
+            from gateway.run import _load_gateway_config
+            from hermes_cli.tools_config import _get_platform_tools
+
+            config = (
+                self._load_gateway_config_for_authority()
+                if strict_config
+                else _load_gateway_config()
+            )
+            if "toolsets" in route_config:
+                raw = route_config.get("toolsets")
+                if not isinstance(raw, list):
+                    raise WebhookContractError("webhook route toolsets must be a list")
+                normalized: list[str] = []
+                for value in raw:
+                    if not isinstance(value, str) or not value.strip():
+                        raise WebhookContractError(
+                            "webhook route toolset names must be non-empty strings"
+                        )
+                    name = value.strip()
+                    if name not in normalized:
+                        normalized.append(name)
+                if not normalized:
+                    return []
+                config = dict(config)
+                platform_toolsets = dict(config.get("platform_toolsets") or {})
+                platform_toolsets[Platform.WEBHOOK.value] = normalized
+                config["platform_toolsets"] = platform_toolsets
+            return sorted(_get_platform_tools(config, Platform.WEBHOOK.value))
+
+    @staticmethod
+    def _load_gateway_config_for_authority() -> dict[str, Any]:
+        """Strictly load the profile config that defines webhook grants."""
+
+        from hermes_constants import get_hermes_home
+
+        config_path = get_hermes_home() / "config.yaml"
+        try:
+            raw_bytes = read_bounded_regular_file_snapshot(
+                config_path,
+                max_bytes=_MAX_DYNAMIC_ROUTES_FILE_BYTES,
+            ).content
+        except BoundedFileSnapshotTooLarge as exc:
+            raise WebhookContractError(
+                "webhook toolset authority config exceeds 4 MiB"
+            ) from exc
+        except OSError as exc:
+            raise WebhookContractError(
+                "webhook toolset authority config is unavailable"
+            ) from exc
+        try:
+            import yaml
+
+            loaded = yaml.safe_load(raw_bytes.decode("utf-8"))
+        except Exception as exc:
+            raise WebhookContractError(
+                "webhook toolset authority config is malformed"
+            ) from exc
+        if not isinstance(loaded, dict):
+            raise WebhookContractError(
+                "webhook toolset authority config must be an object"
+            )
+        try:
+            from hermes_cli import managed_scope
+            from hermes_cli.config import _normalize_root_model_keys
+
+            loaded = managed_scope.apply_managed_overlay(loaded)
+            if not isinstance(loaded, dict):
+                raise TypeError("managed config overlay is not an object")
+            loaded = _normalize_root_model_keys(loaded)
+        except Exception as exc:
+            raise WebhookContractError(
+                "webhook managed toolset authority cannot be resolved"
+            ) from exc
+        if not isinstance(loaded, dict):
+            raise WebhookContractError(
+                "webhook toolset authority config must remain an object"
+            )
+        return loaded
+
+    def _resolve_target_adapter(self, platform_name: str, profile: str):
+        runner = self.gateway_runner
+        if runner is None:
+            return None
+        try:
+            platform = Platform(platform_name)
+        except ValueError:
+            return None
+        resolver = getattr(runner, "_authorization_adapter", None)
+        if callable(resolver):
+            return resolver(platform, profile)
+
+        # Narrow exact fallback for legacy test doubles. It preserves the same
+        # profile ownership rules and never borrows a sibling profile adapter.
+        normalized_profile = str(profile or "default").strip() or "default"
+        active_name = None
+        active_name_fn = getattr(runner, "_active_profile_name", None)
+        if callable(active_name_fn):
+            active_name = active_name_fn()
+        if active_name == normalized_profile:
+            return (getattr(runner, "adapters", None) or {}).get(platform)
+        profile_map = (getattr(runner, "_profile_adapters", None) or {}).get(
+            normalized_profile
+        )
+        if isinstance(profile_map, dict):
+            return profile_map.get(platform)
+        if (
+            normalized_profile == "default"
+            and getattr(
+                getattr(runner, "config", None),
+                "multiplex_profiles",
+                False,
+            )
+            is not True
+        ):
+            return (getattr(runner, "adapters", None) or {}).get(platform)
+        return None
+
+    def _preflight_target_template(
+        self,
+        *,
+        profile: str,
+        deliver: Any,
+        deliver_extra: Any,
+    ) -> PreparedTargetTemplate:
+        """Validate target structure and freeze any home-channel fallback."""
+
+        if not isinstance(deliver, str) or not deliver.strip():
+            raise WebhookContractError("webhook deliver target must be a string")
+        kind = deliver.strip().lower()
+        if not isinstance(deliver_extra, Mapping):
+            raise WebhookContractError("webhook deliver_extra must be an object")
+        extra_keys = set(deliver_extra)
+        if kind == "log":
+            if extra_keys:
+                raise WebhookContractError("log delivery does not accept deliver_extra")
+            return PreparedTargetTemplate(kind="log", profile=profile)
+        if kind == "github_comment":
+            unknown = extra_keys - {"repo", "pr_number"}
+            if unknown:
+                raise WebhookContractError(
+                    f"github delivery has unsupported fields: {sorted(unknown)}"
+                )
+            if not shutil.which("gh"):
+                raise WebhookContractError("gh CLI is unavailable")
+            return PreparedTargetTemplate(kind=kind, profile=profile)
+
+        unknown = extra_keys - {
+            "chat_id",
+            "thread_id",
+            "message_thread_id",
+            "scope_id",
+        }
+        if unknown:
+            raise WebhookContractError(
+                f"platform delivery has unsupported fields: {sorted(unknown)}"
+            )
+        try:
+            platform = Platform(kind)
+        except ValueError as exc:
+            raise WebhookContractError(f"unknown delivery platform {kind!r}") from exc
+        if platform in {
+            Platform.LOCAL,
+            Platform.API_SERVER,
+            Platform.WEBHOOK,
+            Platform.MSGRAPH_WEBHOOK,
+            Platform.RELAY,
+        }:
+            raise WebhookContractError(
+                f"platform {kind!r} is not an outbound webhook target"
+            )
+        explicit_chat = "chat_id" in deliver_extra
+        configured_chat = deliver_extra.get("chat_id")
+        if explicit_chat:
+            configured_chat = self._optional_nonempty_string(
+                configured_chat,
+                label="chat_id",
+            )
+        configured_scope_value = deliver_extra.get("scope_id")
+        if configured_scope_value is not None:
+            configured_scope_value = self._optional_nonempty_string(
+                configured_scope_value,
+                label="scope_id",
+            )
+
+        # An explicit non-Slack destination is fully route-bound and needs no
+        # startup-time adapter registry join. Gateway adapters are published
+        # concurrently; requiring one here makes otherwise valid webhook
+        # startup depend on connection order.
+        if platform is not Platform.SLACK and explicit_chat:
+            return PreparedTargetTemplate(
+                kind="platform",
+                profile=profile,
+                platform=kind,
+            )
+
+        chat_is_static = (
+            isinstance(configured_chat, str)
+            and _PROMPT_TOKEN_RE.search(configured_chat) is None
+        )
+        scope_is_static = (
+            isinstance(configured_scope_value, str)
+            and _PROMPT_TOKEN_RE.search(configured_scope_value) is None
+        )
+        if (
+            platform is Platform.SLACK
+            and explicit_chat
+            and configured_scope_value is not None
+        ):
+            return PreparedTargetTemplate(
+                kind="platform",
+                profile=profile,
+                platform=kind,
+                slack_static_chat_id=(configured_chat if chat_is_static else None),
+                slack_static_scope_id=(
+                    configured_scope_value
+                    if chat_is_static and scope_is_static
+                    else None
+                ),
+                slack_scope_locked=chat_is_static and scope_is_static,
+            )
+
+        adapter = self._resolve_target_adapter(kind, profile)
+        home = (
+            getattr(getattr(adapter, "config", None), "home_channel", None)
+            if adapter is not None
+            else None
+        )
+        runner = self.gateway_runner
+        runner_config = getattr(runner, "config", None)
+        multiplex = getattr(runner_config, "multiplex_profiles", False) is True
+        if home is None and multiplex:
+            # Secondary adapters are published after the shared webhook
+            # listener.  While already inside this route's exact profile
+            # runtime scope, strictly load that physical profile's config and
+            # freeze its home target; never borrow the default/sibling config.
+            from gateway.config import GatewayConfig
+            from hermes_constants import get_hermes_home
+
+            profile_config_path = get_hermes_home() / "config.yaml"
+            try:
+                profile_config = GatewayConfig.from_dict(
+                    self._load_gateway_config_for_authority()
+                    if profile_config_path.exists()
+                    else {}
+                )
+            except Exception as exc:
+                raise WebhookContractError(
+                    "webhook target authority config is invalid"
+                ) from exc
+            home = profile_config.get_home_channel(platform)
+        elif home is None:
+            get_home = getattr(runner_config, "get_home_channel", None)
+            if callable(get_home):
+                home = get_home(platform)
+        home_chat_id = None
+        home_thread_id = None
+        home_scope_id = None
+        if home is not None:
+            if getattr(home, "platform", None) != platform:
+                raise WebhookContractError("home channel belongs to another platform")
+            home_chat_id = self._optional_nonempty_string(
+                getattr(home, "chat_id", None), label="home chat_id"
+            )
+            home_thread_id = self._optional_nonempty_string(
+                getattr(home, "thread_id", None), label="home thread_id"
+            )
+            home_scope_id = self._optional_nonempty_string(
+                getattr(home, "scope_id", None), label="home scope_id"
+            )
+        if "chat_id" not in deliver_extra and home_chat_id is None:
+            if self.gateway_runner is None:
+                # Standalone compatibility: capture the absence itself. A
+                # later request cannot acquire a newly configured home through
+                # this frozen template and therefore still fails closed during
+                # materialization.
+                return PreparedTargetTemplate(
+                    kind="platform",
+                    profile=profile,
+                    platform=kind,
+                )
+            raise WebhookContractError(
+                f"platform {kind!r} has no explicit chat_id or home channel"
+            )
+        slack_static_chat_id = None
+        slack_static_scope_id = None
+        slack_scope_locked = False
+        if platform is Platform.SLACK:
+            if "chat_id" not in deliver_extra:
+                slack_static_chat_id = home_chat_id
+            elif chat_is_static:
+                slack_static_chat_id = configured_chat
+            configured_static_scope = (
+                configured_scope_value if scope_is_static else None
+            )
+            if slack_static_chat_id is not None:
+                resolver = (
+                    getattr(adapter, "scope_id_for_chat", None)
+                    if adapter is not None
+                    else None
+                )
+                observed_scope = (
+                    resolver(slack_static_chat_id) if callable(resolver) else None
+                )
+                observed_scope = self._optional_nonempty_string(
+                    observed_scope,
+                    label="resolved scope_id",
+                )
+                home_owns_target = home_chat_id == slack_static_chat_id
+                asserted_scope = configured_static_scope or (
+                    home_scope_id if home_owns_target else None
+                )
+                if observed_scope is not None and (
+                    asserted_scope is not None and asserted_scope != observed_scope
+                ):
+                    raise WebhookContractError(
+                        "configured Slack scope does not own the target channel"
+                    )
+                slack_static_scope_id = observed_scope or asserted_scope
+                if slack_static_scope_id is None:
+                    raise WebhookContractError(
+                        "Slack target workspace scope cannot be established"
+                    )
+                slack_scope_locked = True
+            elif "scope_id" not in deliver_extra:
+                # A payload-templated channel cannot be joined to a mutable
+                # live channel-to-workspace map after authentication. Require
+                # the workspace selector itself to be part of the signed,
+                # route-bound target template.
+                raise WebhookContractError(
+                    "templated Slack chat_id requires an explicit scope_id"
+                )
+        return PreparedTargetTemplate(
+            kind="platform",
+            profile=profile,
+            platform=kind,
+            home_chat_id=home_chat_id,
+            home_thread_id=home_thread_id,
+            home_scope_id=home_scope_id,
+            slack_static_chat_id=slack_static_chat_id,
+            slack_static_scope_id=slack_static_scope_id,
+            slack_scope_locked=slack_scope_locked,
+        )
+
+    @staticmethod
+    def _optional_nonempty_string(value: Any, *, label: str) -> Optional[str]:
+        if value is None or value == "":
+            return None
+        if not isinstance(value, str) or not value.strip():
+            raise WebhookContractError(f"{label} must be a non-empty string")
+        return value.strip()
+
+    def _materialize_target(
+        self,
+        prepared: PreparedTargetTemplate,
+        rendered_extra: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        """Build the strict canonical target snapshot from captured authority."""
+
+        if prepared.kind == "log":
+            return {"v": 1, "kind": "log", "profile": prepared.profile}
+        if prepared.kind == "github_comment":
+            repo = rendered_extra.get("repo")
+            pr_number = rendered_extra.get("pr_number")
+            if not isinstance(repo, str) or not re.fullmatch(
+                r"[A-Za-z0-9._-]+/[A-Za-z0-9._-]+", repo
+            ):
+                raise WebhookContractError("github repo must use owner/name syntax")
+            if isinstance(pr_number, bool):
+                raise WebhookContractError(
+                    "github pr_number must be a positive integer"
+                )
+            if isinstance(pr_number, str):
+                if not pr_number.isdigit():
+                    raise WebhookContractError(
+                        "github pr_number must be a positive integer"
+                    )
+                pr_number = int(pr_number)
+            if not isinstance(pr_number, int) or pr_number <= 0:
+                raise WebhookContractError(
+                    "github pr_number must be a positive integer"
+                )
+            return {
+                "v": 1,
+                "kind": "github_comment",
+                "profile": prepared.profile,
+                "repo": repo,
+                "pr_number": pr_number,
+            }
+
+        if prepared.kind != "platform" or not prepared.platform:
+            raise WebhookContractError("prepared webhook target is invalid")
+        explicit_chat = self._optional_nonempty_string(
+            rendered_extra.get("chat_id"), label="chat_id"
+        )
+        chat_id = explicit_chat or prepared.home_chat_id
+        if chat_id is None:
+            raise WebhookContractError("platform delivery has no chat_id")
+
+        thread_id = self._optional_nonempty_string(
+            rendered_extra.get("thread_id"), label="thread_id"
+        )
+        message_thread_id = self._optional_nonempty_string(
+            rendered_extra.get("message_thread_id"), label="message_thread_id"
+        )
+        if thread_id and message_thread_id and thread_id != message_thread_id:
+            raise WebhookContractError(
+                "thread_id and message_thread_id identify different targets"
+            )
+        selected_thread = thread_id or message_thread_id
+        if selected_thread is None and explicit_chat is None:
+            selected_thread = prepared.home_thread_id
+
+        configured_scope = self._optional_nonempty_string(
+            rendered_extra.get("scope_id"), label="scope_id"
+        )
+        scope_id = configured_scope
+        if prepared.platform == Platform.SLACK.value:
+            if prepared.slack_scope_locked:
+                if chat_id != prepared.slack_static_chat_id:
+                    raise WebhookContractError(
+                        "rendered Slack target conflicts with frozen authority"
+                    )
+                if configured_scope and (
+                    configured_scope != prepared.slack_static_scope_id
+                ):
+                    raise WebhookContractError(
+                        "configured Slack scope does not own the target channel"
+                    )
+                scope_id = prepared.slack_static_scope_id
+            else:
+                scope_id = configured_scope
+            if scope_id is None:
+                raise WebhookContractError(
+                    "Slack target workspace scope cannot be established"
+                )
+        elif scope_id is not None:
+            raise WebhookContractError("scope_id is supported only for Slack delivery")
+
+        target: dict[str, Any] = {
+            "v": 1,
+            "kind": "platform",
+            "profile": prepared.profile,
+            "platform": prepared.platform,
+            "chat_id": chat_id,
+        }
+        if selected_thread is not None:
+            target["thread_id"] = selected_thread
+        if scope_id is not None:
+            target["scope_id"] = scope_id
+        return target
+
+    @staticmethod
+    def _live_slack_scope_matches(
+        target: Mapping[str, Any],
+        adapter: Any,
+    ) -> bool:
+        """Rejoin a durable Slack target to one live workspace authority."""
+
+        chat_id = target.get("chat_id")
+        scope_id = target.get("scope_id")
+        resolver = getattr(adapter, "scope_id_for_chat", None)
+        try:
+            observed_scope = resolver(chat_id) if callable(resolver) else None
+        except Exception:
+            return False
+        if observed_scope:
+            return str(observed_scope) == scope_id
+
+        home = getattr(getattr(adapter, "config", None), "home_channel", None)
+        return bool(
+            home is not None
+            and getattr(home, "platform", None) is Platform.SLACK
+            and str(getattr(home, "chat_id", "") or "") == chat_id
+            and str(getattr(home, "scope_id", "") or "") == scope_id
+        )
+
+    @staticmethod
+    def _validate_target_snapshot(snapshot: Any) -> dict[str, Any]:
+        """Validate durable target semantics before every external attempt."""
+
+        if not isinstance(snapshot, Mapping):
+            raise WebhookContractError("durable target snapshot is missing")
+        target = _plain_json_snapshot(snapshot)
+        if type(target.get("v")) is not int or target.get("v") != 1:
+            raise WebhookContractError("durable target version is invalid")
+        kind = target.get("kind")
+        profile = target.get("profile")
+        if not isinstance(profile, str) or not profile:
+            raise WebhookContractError("durable target profile is invalid")
+        if kind == "log":
+            if set(target) != {"v", "kind", "profile"}:
+                raise WebhookContractError("durable log target has unknown fields")
+            return target
+        if kind == "github_comment":
+            if set(target) != {
+                "v",
+                "kind",
+                "profile",
+                "repo",
+                "pr_number",
+            }:
+                raise WebhookContractError("durable GitHub target has unknown fields")
+            repo = target.get("repo")
+            number = target.get("pr_number")
+            if not isinstance(repo, str) or not re.fullmatch(
+                r"[A-Za-z0-9._-]+/[A-Za-z0-9._-]+", repo
+            ):
+                raise WebhookContractError("durable GitHub repo is invalid")
+            if type(number) is not int or number <= 0:
+                raise WebhookContractError("durable GitHub PR number is invalid")
+            return target
+        if kind != "platform":
+            raise WebhookContractError("durable target kind is invalid")
+        allowed = {
+            "v",
+            "kind",
+            "profile",
+            "platform",
+            "chat_id",
+            "thread_id",
+            "scope_id",
+        }
+        if not set(target).issubset(allowed):
+            raise WebhookContractError("durable platform target has unknown fields")
+        if not {"v", "kind", "profile", "platform", "chat_id"}.issubset(target):
+            raise WebhookContractError("durable platform target is incomplete")
+        platform_name = target.get("platform")
+        chat_id = target.get("chat_id")
+        if not isinstance(platform_name, str) or not platform_name:
+            raise WebhookContractError("durable target platform is invalid")
+        try:
+            Platform(platform_name)
+        except ValueError as exc:
+            raise WebhookContractError("durable target platform is unknown") from exc
+        if not isinstance(chat_id, str) or not chat_id:
+            raise WebhookContractError("durable target chat_id is invalid")
+        for key in ("thread_id", "scope_id"):
+            value = target.get(key)
+            if value is not None and (not isinstance(value, str) or not value):
+                raise WebhookContractError(f"durable target {key} is invalid")
+        if platform_name == Platform.SLACK.value and not target.get("scope_id"):
+            raise WebhookContractError("durable Slack target lacks workspace scope")
+        if platform_name != Platform.SLACK.value and "scope_id" in target:
+            raise WebhookContractError("durable non-Slack target has scope_id")
+        return target
+
+    def _source_from_authority(self, authority: OperationAuthority):
+        """Rebuild and cross-check only the source stored by durable prepare."""
+
+        snapshot = authority.event_snapshot
+        if not isinstance(snapshot, Mapping):
+            raise WebhookContractError("durable event snapshot is missing")
+        source_blob = snapshot.get("source")
+        if not isinstance(source_blob, Mapping):
+            raise WebhookContractError("durable event source is missing")
+        from gateway.session import SessionSource
+
+        try:
+            source = SessionSource.from_dict(_plain_json_snapshot(source_blob))
+        except Exception as exc:
+            raise WebhookContractError("durable event source is invalid") from exc
+        if (
+            source.platform is not Platform.WEBHOOK
+            or source.chat_id != authority.session_key
+            or (source.profile or "default") != authority.profile
+            or source.chat_type != "webhook"
+            or source.user_id != f"webhook:{authority.route}"
+            or source.user_name != authority.route
+        ):
+            raise WebhookContractError(
+                "durable event source conflicts with operation authority"
+            )
+        source.profile = authority.profile
+        source._transport_adapter_ref = weakref.ref(self)
+        return source

--- a/gateway/platforms/webhook_route_authority.py
+++ b/gateway/platforms/webhook_route_authority.py
@@ -55,8 +55,94 @@ from gateway.platforms.webhook_common import (
 
 logger = logging.getLogger(__name__)
 
+WebhookRouteKey = tuple[str, str]
+
+
+def _route_key_from_candidate(
+    raw_key: Any,
+    route: Any,
+) -> WebhookRouteKey:
+    """Return the canonical public ``(profile, route)`` registry key."""
+
+    if isinstance(raw_key, tuple):
+        if (
+            len(raw_key) != 2
+            or not isinstance(raw_key[0], str)
+            or not isinstance(raw_key[1], str)
+        ):
+            raise WebhookContractError("webhook route authority key is malformed")
+        key = raw_key
+        configured_profile = (
+            route.get("profile", "default") if isinstance(route, Mapping) else "default"
+        )
+        if configured_profile != key[0]:
+            raise WebhookContractError(
+                f"webhook route authority {key[0]!r}/{key[1]!r} carries "
+                f"profile {configured_profile!r}"
+            )
+        return key
+    if not isinstance(raw_key, str):
+        raise WebhookContractError("webhook route name must be text")
+    profile = (
+        route.get("profile", "default") if isinstance(route, Mapping) else "default"
+    )
+    if not isinstance(profile, str):
+        raise WebhookContractError("webhook route profile must be text")
+    return (profile, raw_key)
+
+
+def _qualified_route_candidates(
+    routes: Mapping[Any, Any],
+) -> dict[WebhookRouteKey, Any]:
+    """Normalize route candidates without collapsing equal names by profile."""
+
+    qualified: dict[WebhookRouteKey, Any] = {}
+    for raw_key, route in routes.items():
+        key = _route_key_from_candidate(raw_key, route)
+        if key in qualified:
+            raise WebhookContractError(
+                f"duplicate webhook route authority {key[0]!r}/{key[1]!r}"
+            )
+        qualified[key] = route
+    return qualified
+
+
+def _unique_name_facade(routes: Mapping[WebhookRouteKey, Any]) -> dict[str, Any]:
+    """Compatibility view containing only globally unambiguous route names."""
+
+    counts: dict[str, int] = {}
+    for _profile, name in routes:
+        counts[name] = counts.get(name, 0) + 1
+    return {
+        name: value for (_profile, name), value in routes.items() if counts[name] == 1
+    }
+
 
 class WebhookRouteAuthorityMixin:
+    @staticmethod
+    def _qualified_route_candidates(
+        routes: Mapping[Any, Any],
+    ) -> dict[WebhookRouteKey, Any]:
+        """Expose canonical qualification to intake without a second parser."""
+
+        return _qualified_route_candidates(routes)
+
+    def _replace_live_route_candidates(
+        self,
+        dynamic_routes: Mapping[Any, Any],
+        routes: Mapping[Any, Any],
+    ) -> None:
+        """Install qualified candidates and non-authoritative legacy facades."""
+
+        dynamic_by_key = _qualified_route_candidates(dynamic_routes)
+        routes_by_key = _qualified_route_candidates(routes)
+        self._dynamic_routes_by_key = MappingProxyType(dynamic_by_key)
+        self._routes_by_key = MappingProxyType(routes_by_key)
+        # Older tests/embedders inspect these maps. Ambiguous names are omitted
+        # so no legacy access path can choose one profile by iteration order.
+        self._dynamic_routes = _unique_name_facade(dynamic_by_key)
+        self._routes = _unique_name_facade(routes_by_key)
+
     def _intake_is_authoritative(self, profile: str) -> bool:
         """Return whether this exact shared listener may admit requests."""
 
@@ -594,34 +680,36 @@ class WebhookRouteAuthorityMixin:
 
     def _route_authentication_authority_snapshot(
         self,
-        routes: Mapping[str, Any],
+        routes: Mapping[Any, Any],
         *,
         prepared_skill_overrides: Optional[
-            Mapping[str, PreparedSkillInvocation]
+            Mapping[Any, PreparedSkillInvocation]
         ] = None,
     ) -> tuple[
         tuple[Any, ...],
         list[tuple[str, str, str, str, str, str]],
-        Mapping[str, tuple[Any, ...]],
-        Mapping[str, tuple[str, ...]],
-        Mapping[str, Optional[WebhookPreparedScript]],
-        Mapping[str, str],
-        Mapping[str, AuthenticatedRouteAuthority],
+        Mapping[WebhookRouteKey, tuple[Any, ...]],
+        Mapping[WebhookRouteKey, tuple[str, ...]],
+        Mapping[WebhookRouteKey, Optional[WebhookPreparedScript]],
+        Mapping[WebhookRouteKey, str],
+        Mapping[WebhookRouteKey, AuthenticatedRouteAuthority],
     ]:
         """Validate a complete route set and build its durable key bindings."""
 
         material_owners: dict[str, tuple[str, str, str, str]] = {}
         bindings: list[tuple[str, str, str, str, str, str]] = []
         snapshot: list[tuple[Any, ...]] = []
-        authorities: dict[str, tuple[Any, ...]] = {}
-        effective_toolsets_by_route: dict[str, tuple[str, ...]] = {}
-        prepared_scripts: dict[str, Optional[WebhookPreparedScript]] = {}
-        profile_generations: dict[str, str] = {}
+        authorities: dict[WebhookRouteKey, tuple[Any, ...]] = {}
+        effective_toolsets_by_route: dict[WebhookRouteKey, tuple[str, ...]] = {}
+        prepared_scripts: dict[WebhookRouteKey, Optional[WebhookPreparedScript]] = {}
+        profile_generations: dict[WebhookRouteKey, str] = {}
         observed_profile_generations: dict[str, str] = {}
-        bundles: dict[str, AuthenticatedRouteAuthority] = {}
+        bundles: dict[WebhookRouteKey, AuthenticatedRouteAuthority] = {}
         authority_profiles: set[str] = set()
-        for route_name in sorted(routes):
-            route = routes[route_name]
+        qualified_routes = _qualified_route_candidates(routes)
+        for route_key in sorted(qualified_routes):
+            public_profile, route_name = route_key
+            route = qualified_routes[route_key]
             if not isinstance(route, Mapping):
                 raise WebhookContractError(
                     f"route {route_name!r} configuration must be an object"
@@ -631,10 +719,17 @@ class WebhookRouteAuthorityMixin:
                 route_name,
                 route_snapshot,
                 headers={},
-                request_profile=route_snapshot.get("profile", "default"),
+                request_profile=public_profile,
             )
             self._validate_route_profile_reachable(route_snapshot, bound_route)
-            secret = route_snapshot.get("secret", self._global_secret)
+            # An explicit reference is an isolation boundary. Until Task 8
+            # resolves it inside the bound profile scope, it must not silently
+            # borrow the listener owner's global secret.
+            secret = (
+                ""
+                if "secret_ref" in route_snapshot and "secret" not in route_snapshot
+                else route_snapshot.get("secret", self._global_secret)
+            )
             if not isinstance(secret, str) or not secret:
                 raise WebhookContractError(f"route {route_name!r} has no HMAC secret")
             if secret == _INSECURE_NO_AUTH and not _is_loopback_host(self._host):
@@ -673,7 +768,7 @@ class WebhookRouteAuthorityMixin:
                 bound_route,
                 authority_profile=owner[0],
             )
-            effective_toolsets_by_route[route_name] = effective_toolsets
+            effective_toolsets_by_route[route_key] = effective_toolsets
             prepared_script: Optional[WebhookPreparedScript] = None
             if route_snapshot.get("script"):
                 source = self._source_for_route_authority(
@@ -691,7 +786,7 @@ class WebhookRouteAuthorityMixin:
                         f"route {route_name!r} script is unavailable: "
                         f"{script_error or 'unknown error'}"
                     )
-            prepared_scripts[route_name] = prepared_script
+            prepared_scripts[route_key] = prepared_script
             script_sha256 = (
                 prepared_script.execution_sha256
                 if prepared_script is not None
@@ -703,7 +798,10 @@ class WebhookRouteAuthorityMixin:
                 authority_profile=owner[0],
             )
             prepared_skill = (
-                prepared_skill_overrides.get(route_name)
+                prepared_skill_overrides.get(route_key)
+                if prepared_skill_overrides is not None
+                and route_key in prepared_skill_overrides
+                else prepared_skill_overrides.get(route_name)
                 if prepared_skill_overrides is not None
                 and route_name in prepared_skill_overrides
                 else self._prepare_route_skill_authority(
@@ -744,7 +842,7 @@ class WebhookRouteAuthorityMixin:
                     "was snapshotted"
                 )
             observed_profile_generations[owner[0]] = profile_generation
-            profile_generations[route_name] = profile_generation
+            profile_generations[route_key] = profile_generation
             policy_sha256 = _route_policy_sha256(
                 route_snapshot,
                 owner[0],
@@ -757,9 +855,9 @@ class WebhookRouteAuthorityMixin:
             )
             if secret == _INSECURE_NO_AUTH:
                 authority = (*owner, policy_sha256, ("local-bypass",))
-                snapshot.append(authority)
-                authorities[route_name] = authority
-                bundles[route_name] = AuthenticatedRouteAuthority(
+                snapshot.append((route_key, authority))
+                authorities[route_key] = authority
+                bundles[route_key] = AuthenticatedRouteAuthority(
                     authority=authority,
                     secret=secret,
                     route_config=route_snapshot,
@@ -778,6 +876,7 @@ class WebhookRouteAuthorityMixin:
                     for fingerprint in _authentication_key_fingerprints(
                         secret,
                         bound_route.signature_mode,
+                        bound_route.hmac_algorithm,
                     )
                 )
             )
@@ -794,9 +893,9 @@ class WebhookRouteAuthorityMixin:
                 material_owners[fingerprint] = owner
                 bindings.append((fingerprint, *owner, policy_sha256))
             authority = (*owner, policy_sha256, fingerprints)
-            snapshot.append(authority)
-            authorities[route_name] = authority
-            bundles[route_name] = AuthenticatedRouteAuthority(
+            snapshot.append((route_key, authority))
+            authorities[route_key] = authority
+            bundles[route_key] = AuthenticatedRouteAuthority(
                 authority=authority,
                 secret=secret,
                 route_config=route_snapshot,
@@ -819,9 +918,18 @@ class WebhookRouteAuthorityMixin:
 
     def _bind_route_authentication_authorities(
         self,
-        routes: Mapping[str, Any],
+        routes: Mapping[Any, Any],
+        *,
+        expected_profile_generations: Optional[Mapping[str, str]] = None,
     ) -> tuple[Any, ...]:
-        """Publish one complete route-key snapshot to durable authority."""
+        """Publish one complete route-key snapshot to durable authority.
+
+        ``expected_profile_generations`` joins a profile-store snapshot to the
+        physical profile incarnation observed while it was loaded. The guard
+        runs after all bundle preparation and immediately before the durable
+        credential bind, so a profile re-home cannot publish keys for route
+        bytes captured from its prior incarnation.
+        """
 
         (
             snapshot,
@@ -832,24 +940,114 @@ class WebhookRouteAuthorityMixin:
             profile_generations,
             bundles,
         ) = self._route_authentication_authority_snapshot(routes)
+        if expected_profile_generations is not None:
+            for profile, expected in sorted(expected_profile_generations.items()):
+                if not isinstance(profile, str) or not isinstance(expected, str):
+                    raise WebhookContractError(
+                        "webhook profile-store generation proof is malformed"
+                    )
+                current = self._current_profile_authority_generation(
+                    profile,
+                    route_name="profile-store",
+                )
+                if not secrets.compare_digest(current, expected):
+                    raise WebhookContractError(
+                        f"profile {profile!r} authority changed before route "
+                        "publication"
+                    )
+            for bundle in bundles.values():
+                public_profile = bundle.route_config.get("profile", "default")
+                expected = expected_profile_generations.get(public_profile)
+                physical_profile = bundle.authority[0]
+                if (
+                    expected is not None
+                    and physical_profile == public_profile
+                    and not secrets.compare_digest(
+                        bundle.profile_generation,
+                        expected,
+                    )
+                ):
+                    raise WebhookContractError(
+                        f"profile {public_profile!r} route bundle was captured "
+                        "from a different physical incarnation"
+                    )
         if snapshot == self._authenticated_route_snapshot:
-            self._prune_rate_limit_buckets(self._authenticated_route_bundles)
+            self._prune_rate_limit_buckets(self._authenticated_route_registry)
             return snapshot
+        # A registry publication is a whole-map swap, but an unchanged exact
+        # qualified route remains the same authority generation.  Preserve its
+        # bundle object so a request that captured that route before an
+        # unrelated sibling changed is not spuriously fenced by the sibling's
+        # publication.  Dataclass equality covers the complete detached route
+        # and filter configs, secret, prepared dependencies, toolsets, durable
+        # authority, and physical-profile generation; a changed key therefore
+        # always receives a fresh object and keeps the identity fence below.
+        prior_registry = self._authenticated_route_registry
+        bundles = MappingProxyType({
+            route_key: (
+                prior_registry[route_key]
+                if route_key in prior_registry
+                and prior_registry[route_key] == candidate_bundle
+                else candidate_bundle
+            )
+            for route_key, candidate_bundle in bundles.items()
+        })
         self._authentication_authority_ledger.bind_authentication_keys(bindings)
         self._authenticated_route_snapshot = snapshot
-        self._authenticated_route_authorities = authorities
-        self._authenticated_route_effective_toolsets = effective_toolsets
-        self._authenticated_route_scripts = prepared_scripts
-        self._authenticated_route_profile_generations = profile_generations
-        # Publish last: this single reference swap is the request-facing
-        # generation token and makes the complete bundle registry atomic.
-        self._authenticated_route_bundles = bundles
+        self._authenticated_route_authorities_by_key = authorities
+        self._authenticated_route_effective_toolsets_by_key = effective_toolsets
+        self._authenticated_route_scripts_by_key = prepared_scripts
+        self._authenticated_route_profile_generations_by_key = profile_generations
+        self._authenticated_route_authorities = MappingProxyType(
+            _unique_name_facade(authorities)
+        )
+        self._authenticated_route_effective_toolsets = MappingProxyType(
+            _unique_name_facade(effective_toolsets)
+        )
+        self._authenticated_route_scripts = MappingProxyType(
+            _unique_name_facade(prepared_scripts)
+        )
+        self._authenticated_route_profile_generations = MappingProxyType(
+            _unique_name_facade(profile_generations)
+        )
+        self._authenticated_route_bundles_by_key = bundles
+        self._authenticated_route_bundles = MappingProxyType(
+            _unique_name_facade(bundles)
+        )
+        # Publish last: each immutable bundle includes its exact frozen route
+        # snapshot, so this one reference is the complete request-facing
+        # registry generation. Intake never rejoins it through candidate maps.
+        self._authenticated_route_registry = bundles
         self._prune_rate_limit_buckets(bundles)
         return snapshot
 
+    def _canonical_live_route_key(
+        self,
+        route: Any,
+        bundle: Optional[AuthenticatedRouteAuthority] = None,
+    ) -> Optional[WebhookRouteKey]:
+        """Resolve a route reference without guessing between profile siblings."""
+
+        if isinstance(route, tuple):
+            if (
+                len(route) == 2
+                and isinstance(route[0], str)
+                and isinstance(route[1], str)
+            ):
+                return (route[0], route[1])
+            return None
+        if not isinstance(route, str):
+            return None
+        if bundle is not None:
+            profile = bundle.route_config.get("profile", "default")
+            if isinstance(profile, str):
+                return (profile, route)
+        matches = [key for key in self._authenticated_route_registry if key[1] == route]
+        return matches[0] if len(matches) == 1 else None
+
     def _route_owns_unique_authenticated_secret(
         self,
-        route_name: str,
+        route_name: Any,
         secret: str,
         signature_mode: str,
         bundle: Optional[AuthenticatedRouteAuthority] = None,
@@ -860,22 +1058,24 @@ class WebhookRouteAuthorityMixin:
             if self._authenticated_route_snapshot is None:
                 # Compatibility for tests/embedders that exercise the handler
                 # without connect(). Production listeners bind before opening.
-                self._bind_route_authentication_authorities(self._routes)
-            bundle = bundle or self._authenticated_route_bundles.get(route_name)
+                self._bind_route_authentication_authorities(self._routes_by_key)
+            route_key = self._canonical_live_route_key(route_name, bundle)
+            if route_key is None:
+                return False
+            public_profile, public_route_name = route_key
+            bundle = bundle or self._authenticated_route_registry.get(route_key)
             expected = bundle.authority if bundle is not None else None
-            route = self._routes.get(route_name)
-            if bundle is None or expected is None or not isinstance(route, Mapping):
+            if bundle is None or expected is None:
                 return False
             if bundle.secret != secret:
                 return False
-            live_snapshot = _snapshot_route_config(dict(route))
-            if live_snapshot != bundle.route_config:
+            if self._authenticated_route_registry.get(route_key) is not bundle:
                 return False
             bound_route = WebhookRouteConfig.bind(
-                route_name,
+                public_route_name,
                 bundle.route_config,
                 headers={},
-                request_profile=bundle.route_config.get("profile", "default"),
+                request_profile=public_profile,
             )
             if bound_route.signature_mode != signature_mode:
                 return False
@@ -889,6 +1089,7 @@ class WebhookRouteAuthorityMixin:
                         for fingerprint in _authentication_key_fingerprints(
                             secret,
                             signature_mode,
+                            bound_route.hmac_algorithm,
                         )
                     )
                 )
@@ -906,19 +1107,22 @@ class WebhookRouteAuthorityMixin:
 
     def _live_route_authority_matches(
         self,
-        route_name: str,
+        route_name: Any,
         bundle: AuthenticatedRouteAuthority,
     ) -> bool:
         """Revalidate mutable profile grants/code against the bound snapshot."""
 
         try:
+            route_key = self._canonical_live_route_key(route_name, bundle)
+            if route_key is None:
+                return False
             _, _, authorities, _, _, _, _ = (
                 self._route_authentication_authority_snapshot(
                     {
-                        route_name: bundle.route_config,
+                        route_key: bundle.route_config,
                     },
                     prepared_skill_overrides=(
-                        {route_name: bundle.prepared_skill}
+                        {route_key: bundle.prepared_skill}
                         if bundle.prepared_skill is not None
                         and not bundle.prepared_skill.inject_prompt
                         else None
@@ -927,18 +1131,18 @@ class WebhookRouteAuthorityMixin:
             )
         except Exception:
             return False
-        return authorities.get(route_name) == bundle.authority
+        return authorities.get(route_key) == bundle.authority
 
     def _route_bundle_is_current(
         self,
-        route_name: str,
+        route_name: Any,
         bundle: AuthenticatedRouteAuthority,
     ) -> bool:
         """Check the request's exact registry object, not merely its name."""
 
-        return (
-            self._authenticated_route_bundles.get(route_name) is bundle
-            and route_name in self._routes
+        route_key = self._canonical_live_route_key(route_name, bundle)
+        return route_key is not None and (
+            self._authenticated_route_registry.get(route_key) is bundle
         )
 
     @staticmethod
@@ -964,20 +1168,98 @@ class WebhookRouteAuthorityMixin:
             for fingerprint in fingerprints
         )
 
+    def _retain_published_route_authorities(
+        self,
+        routes: Mapping[Any, Any],
+    ) -> None:
+        """Atomically retain only bundles matching exact candidate snapshots."""
+
+        qualified = _qualified_route_candidates(routes)
+        retained_keys: set[WebhookRouteKey] = set()
+        for route_key, route in qualified.items():
+            bundle = self._authenticated_route_registry.get(route_key)
+            if bundle is None or not isinstance(route, Mapping):
+                continue
+            try:
+                candidate = _snapshot_route_config(dict(route))
+            except WebhookContractError:
+                continue
+            if candidate == bundle.route_config:
+                retained_keys.add(route_key)
+        if retained_keys == set(self._authenticated_route_registry):
+            return
+        self._authenticated_route_snapshot = None
+        authorities = {
+            key: value
+            for key, value in self._authenticated_route_authorities_by_key.items()
+            if key in retained_keys
+        }
+        toolsets = {
+            key: value
+            for key, value in self._authenticated_route_effective_toolsets_by_key.items()
+            if key in retained_keys
+        }
+        scripts = {
+            key: value
+            for key, value in self._authenticated_route_scripts_by_key.items()
+            if key in retained_keys
+        }
+        generations = {
+            key: value
+            for key, value in self._authenticated_route_profile_generations_by_key.items()
+            if key in retained_keys
+        }
+        bundles = MappingProxyType({
+            key: value
+            for key, value in self._authenticated_route_registry.items()
+            if key in retained_keys
+        })
+        self._authenticated_route_authorities_by_key = MappingProxyType(authorities)
+        self._authenticated_route_effective_toolsets_by_key = MappingProxyType(toolsets)
+        self._authenticated_route_scripts_by_key = MappingProxyType(scripts)
+        self._authenticated_route_profile_generations_by_key = MappingProxyType(
+            generations
+        )
+        self._authenticated_route_authorities = MappingProxyType(
+            _unique_name_facade(authorities)
+        )
+        self._authenticated_route_effective_toolsets = MappingProxyType(
+            _unique_name_facade(toolsets)
+        )
+        self._authenticated_route_scripts = MappingProxyType(
+            _unique_name_facade(scripts)
+        )
+        self._authenticated_route_profile_generations = MappingProxyType(
+            _unique_name_facade(generations)
+        )
+        self._authenticated_route_bundles_by_key = bundles
+        self._authenticated_route_bundles = MappingProxyType(
+            _unique_name_facade(bundles)
+        )
+        # Request-facing withdrawal is one immutable registry generation swap.
+        self._authenticated_route_registry = bundles
+        self._prune_rate_limit_buckets(bundles)
+
     def _withdraw_live_route(
         self,
-        route_name: str,
+        route_name: Any,
         expected: Optional[AuthenticatedRouteAuthority] = None,
     ) -> bool:
         """Fence one route in memory until a valid rotated snapshot publishes."""
 
+        route_key = self._canonical_live_route_key(route_name, expected)
+        if route_key is None:
+            return False
         if expected is not None and (
-            self._authenticated_route_bundles.get(route_name) is not expected
+            self._authenticated_route_registry.get(route_key) is not expected
         ):
             return False
-        self._dynamic_routes.pop(route_name, None)
-        self._routes.pop(route_name, None)
-        self._prune_rate_limit_buckets()
+        dynamic = dict(self._dynamic_routes_by_key)
+        routes = dict(self._routes_by_key)
+        dynamic.pop(route_key, None)
+        routes.pop(route_key, None)
+        self._replace_live_route_candidates(dynamic, routes)
+        self._retain_published_route_authorities(routes)
         return True
 
     def _resolve_admitted_toolsets(

--- a/gateway/platforms/webhook_store.py
+++ b/gateway/platforms/webhook_store.py
@@ -1,0 +1,1381 @@
+"""Profile-scoped, crash-safe persistence for webhook route documents.
+
+The store is a management authority, not a replacement for runtime intake's
+content-hash and revocation publication gates.  It provides descriptor-stable
+reads, an interprocess read/modify/write lock, deterministic serialization,
+and an explicit runtime quarantine mode.  Ordinary callers fail closed on
+corruption instead of silently treating a broken file as an empty route set.
+"""
+
+from __future__ import annotations
+
+import errno
+import hashlib
+import importlib
+import json
+import os
+import secrets
+import stat
+import threading
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Iterable, Iterator, Literal, Mapping
+
+from gateway.platforms.webhook_models import (
+    WebhookRouteDocument,
+    from_persisted_route,
+    to_persisted_route,
+)
+
+
+_FILENAME = "webhook_subscriptions.json"
+_LOCK_FILENAME = ".webhook_subscriptions.lock"
+_FILE_MODE = 0o600
+_DIRECTORY_MODE = 0o700
+_MAX_STORE_BYTES = 4 * 1024 * 1024
+_LOCK_TIMEOUT_SECONDS = 30.0
+_WINDOWS_OPEN_REPARSE_POINT = 0x00200000
+_WINDOWS_MOVE_REPLACE_EXISTING = 0x00000001
+_WINDOWS_MOVE_WRITE_THROUGH = 0x00000008
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - native Windows
+    fcntl = None  # type: ignore[assignment]
+
+try:
+    import msvcrt
+except ImportError:  # pragma: no cover - POSIX
+    msvcrt = None  # type: ignore[assignment]
+
+
+class WebhookRouteStoreError(RuntimeError):
+    """Base class for route-store failures."""
+
+
+class WebhookRouteStoreUnsafePathError(WebhookRouteStoreError):
+    """A store path contains traversal, a symlink, or a non-directory node."""
+
+
+class WebhookRouteStoreCorruptError(WebhookRouteStoreError):
+    """A route file exists but is not one complete valid store document."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        content_sha256: str | None = None,
+        file_identity: tuple[int, ...] | None = None,
+    ):
+        super().__init__(message)
+        self.content_sha256 = content_sha256
+        # Oversize runtime files are deliberately not read in full merely to
+        # hash them.  Retain the descriptor identity so quarantine can still
+        # move only the exact inode that failed the bounded-read contract.
+        self.file_identity = file_identity
+
+
+@dataclass(frozen=True)
+class WebhookRouteStoreSnapshot:
+    """One descriptor-stable store view suitable for runtime publication."""
+
+    routes: Mapping[str, WebhookRouteDocument]
+    content_sha256: str | None
+    file_identity: tuple[int, ...] | None
+    path: Path
+    quarantined_path: Path | None = None
+
+
+@dataclass(frozen=True)
+class _RawSnapshot:
+    content: bytes
+    identity: tuple[int, ...]
+
+
+@dataclass
+class _DirectoryAuthority:
+    """A profile directory pinned for the lifetime of one store operation."""
+
+    path: Path
+    fd: int | None = None
+    windows_handle: object | None = None
+
+
+def _win32() -> tuple[Any, ...]:
+    """Import the optional native-Windows API only when it is needed."""
+
+    return (
+        importlib.import_module("ntsecuritycon"),
+        importlib.import_module("pywintypes"),
+        importlib.import_module("win32api"),
+        importlib.import_module("win32con"),
+        importlib.import_module("win32file"),
+        importlib.import_module("win32security"),
+    )
+
+
+def _windows_move_flags(*, replace_existing: bool) -> int:
+    """Return durable Win32 publication flags as platform-independent data."""
+
+    flags = _WINDOWS_MOVE_WRITE_THROUGH
+    if replace_existing:
+        flags |= _WINDOWS_MOVE_REPLACE_EXISTING
+    return flags
+
+
+def _windows_current_sid():
+    _, _, win32api, win32con, _, win32security = _win32()
+    token = win32security.OpenProcessToken(
+        win32api.GetCurrentProcess(),
+        win32con.TOKEN_QUERY,
+    )
+    try:
+        return win32security.GetTokenInformation(
+            token,
+            win32security.TokenUser,
+        )[0]
+    finally:
+        close = getattr(token, "Close", None)
+        if callable(close):
+            close()
+
+
+def _windows_allowed_sids() -> set[str]:
+    *_, win32security = _win32()
+    return {
+        win32security.ConvertSidToStringSid(_windows_current_sid()),
+        win32security.ConvertSidToStringSid(
+            win32security.ConvertStringSidToSid("S-1-5-18")
+        ),
+        win32security.ConvertSidToStringSid(
+            win32security.ConvertStringSidToSid("S-1-5-32-544")
+        ),
+    }
+
+
+def _windows_security_attributes():
+    ntsecuritycon, _, _, _, _, win32security = _win32()
+    owner = _windows_current_sid()
+    system = win32security.ConvertStringSidToSid("S-1-5-18")
+    administrators = win32security.ConvertStringSidToSid("S-1-5-32-544")
+    acl = win32security.ACL()
+    for sid in (owner, system, administrators):
+        acl.AddAccessAllowedAceEx(
+            win32security.ACL_REVISION,
+            0,
+            ntsecuritycon.FILE_ALL_ACCESS,
+            sid,
+        )
+    descriptor = win32security.SECURITY_DESCRIPTOR()
+    descriptor.SetSecurityDescriptorOwner(owner, False)
+    descriptor.SetSecurityDescriptorDacl(True, acl, False)
+    descriptor.SetSecurityDescriptorControl(
+        win32security.SE_DACL_PROTECTED,
+        win32security.SE_DACL_PROTECTED,
+    )
+    attributes = win32security.SECURITY_ATTRIBUTES()
+    attributes.SECURITY_DESCRIPTOR = descriptor
+    return attributes
+
+
+def _verify_windows_security(handle: object, *, label: str) -> None:
+    """Require current-user ownership and a private Windows DACL."""
+
+    *_, win32security = _win32()
+    info = (
+        win32security.OWNER_SECURITY_INFORMATION
+        | win32security.DACL_SECURITY_INFORMATION
+    )
+    descriptor = win32security.GetSecurityInfo(
+        handle,
+        win32security.SE_FILE_OBJECT,
+        info,
+    )
+    owner = descriptor.GetSecurityDescriptorOwner()
+    current = win32security.ConvertSidToStringSid(_windows_current_sid())
+    if win32security.ConvertSidToStringSid(owner) != current:
+        raise WebhookRouteStoreUnsafePathError(
+            f"{label} must be owned by the current account"
+        )
+    dacl = descriptor.GetSecurityDescriptorDacl()
+    if dacl is None:
+        raise WebhookRouteStoreUnsafePathError(f"{label} has a null DACL")
+    allowed = _windows_allowed_sids()
+    allow_types = {
+        win32security.ACCESS_ALLOWED_ACE_TYPE,
+        win32security.ACCESS_ALLOWED_OBJECT_ACE_TYPE,
+        getattr(win32security, "ACCESS_ALLOWED_CALLBACK_ACE_TYPE", 9),
+        getattr(win32security, "ACCESS_ALLOWED_CALLBACK_OBJECT_ACE_TYPE", 11),
+    }
+    for index in range(dacl.GetAceCount()):
+        ace = dacl.GetAce(index)
+        if ace[0][0] in allow_types and ace[1]:
+            sid = win32security.ConvertSidToStringSid(ace[-1])
+            if sid not in allowed:
+                raise WebhookRouteStoreUnsafePathError(f"{label} has a permissive DACL")
+
+
+def _windows_final_path(handle: object) -> Path:
+    _, _, _, _, win32file, _ = _win32()
+    value = win32file.GetFinalPathNameByHandle(handle, 0)
+    if value.startswith("\\\\?\\UNC\\"):
+        value = "\\\\" + value[8:]
+    elif value.startswith("\\\\?\\"):
+        value = value[4:]
+    return Path(value)
+
+
+def _verify_windows_handle(
+    handle: object,
+    expected: Path,
+    *,
+    label: str,
+    require_directory: bool,
+) -> Path:
+    _, _, _, _, win32file, _ = _win32()
+    actual = _windows_final_path(handle)
+    if os.path.normcase(os.path.abspath(actual)) != os.path.normcase(
+        os.path.abspath(expected)
+    ):
+        raise WebhookRouteStoreUnsafePathError(f"{label} escaped its expected path")
+    attributes = int(win32file.GetFileInformationByHandle(handle)[0])
+    directory_flag = int(getattr(stat, "FILE_ATTRIBUTE_DIRECTORY", 0x10))
+    reparse_flag = int(getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400))
+    if attributes & reparse_flag:
+        raise WebhookRouteStoreUnsafePathError(f"{label} must not be a reparse point")
+    if bool(attributes & directory_flag) != require_directory:
+        kind = "directory" if require_directory else "regular file"
+        raise WebhookRouteStoreUnsafePathError(f"{label} is not a {kind}")
+    _verify_windows_security(handle, label=label)
+    return actual
+
+
+def _close_directory(authority: _DirectoryAuthority) -> None:
+    if authority.fd is not None:
+        os.close(authority.fd)
+        authority.fd = None
+    if authority.windows_handle is not None:
+        _, _, _, _, win32file, _ = _win32()
+        win32file.CloseHandle(authority.windows_handle)
+        authority.windows_handle = None
+
+
+def _directory_fd(authority: _DirectoryAuthority) -> int:
+    if authority.fd is None:
+        raise WebhookRouteStoreError("profile directory has no POSIX descriptor")
+    return authority.fd
+
+
+_thread_locks_guard = threading.Lock()
+_thread_locks: dict[str, threading.RLock] = {}
+
+
+def _thread_lock_for(path: Path) -> threading.RLock:
+    key = os.path.normcase(str(path))
+    with _thread_locks_guard:
+        lock = _thread_locks.get(key)
+        if lock is None:
+            lock = threading.RLock()
+            _thread_locks[key] = lock
+        return lock
+
+
+def _absolute_without_traversal(path: str | os.PathLike[str]) -> Path:
+    try:
+        raw = Path(path).expanduser()
+        if "\x00" in os.fspath(raw):
+            raise ValueError("embedded null byte")
+        if ".." in raw.parts:
+            raise WebhookRouteStoreUnsafePathError(
+                "webhook store root contains traversal"
+            )
+        return Path(os.path.abspath(os.fspath(raw)))
+    except WebhookRouteStoreUnsafePathError:
+        raise
+    except (OSError, TypeError, ValueError) as exc:
+        raise WebhookRouteStoreUnsafePathError(
+            "webhook store root is not a valid path"
+        ) from exc
+
+
+def _stat_identity(value: os.stat_result) -> tuple[int, ...]:
+    return (
+        int(value.st_dev),
+        int(value.st_ino),
+        int(value.st_size),
+        int(value.st_mtime_ns),
+        int(value.st_ctime_ns),
+    )
+
+
+def _is_reparse_point(value: os.stat_result) -> bool:
+    attributes = int(getattr(value, "st_file_attributes", 0))
+    reparse_flag = int(getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400))
+    return bool(attributes & reparse_flag)
+
+
+def _assert_owned_single_link(value: os.stat_result, *, label: str) -> None:
+    """Reject hard-linked or foreign-owned store authority before mutation."""
+
+    if int(value.st_nlink) != 1:
+        raise WebhookRouteStoreUnsafePathError(
+            f"{label} must have exactly one filesystem link"
+        )
+    get_effective_uid = getattr(os, "geteuid", None)
+    if callable(get_effective_uid) and int(value.st_uid) != int(get_effective_uid()):
+        raise WebhookRouteStoreUnsafePathError(
+            f"{label} must be owned by the current account"
+        )
+
+
+def _assert_safe_profile_directory(fd: int) -> None:
+    """Reject a profile directory another local account can replace entries in."""
+
+    observed = os.fstat(fd)
+    if not stat.S_ISDIR(observed.st_mode):
+        raise WebhookRouteStoreUnsafePathError(
+            "webhook store parent is not a directory"
+        )
+    get_effective_uid = getattr(os, "geteuid", None)
+    if callable(get_effective_uid):
+        if int(observed.st_uid) != int(get_effective_uid()):
+            raise WebhookRouteStoreUnsafePathError(
+                "webhook profile directory must be owned by the current account"
+            )
+        if stat.S_IMODE(observed.st_mode) & 0o022:
+            raise WebhookRouteStoreUnsafePathError(
+                "webhook profile directory must not be group- or world-writable"
+            )
+
+
+def _assert_no_link_components(path: Path, *, allow_missing: bool) -> None:
+    """Best available non-POSIX containment check.
+
+    POSIX operations use a descriptor walk with ``O_NOFOLLOW`` below.  This
+    fallback also rejects Windows junctions/reparse points, not just Python
+    symlinks.
+    """
+
+    current = Path(path.anchor)
+    for part in path.parts[1:]:
+        current = current / part
+        try:
+            node = os.lstat(current)
+        except FileNotFoundError:
+            if allow_missing:
+                continue
+            raise WebhookRouteStoreUnsafePathError(
+                "webhook store path does not exist"
+            ) from None
+        except OSError as exc:
+            raise WebhookRouteStoreUnsafePathError(
+                "webhook store path cannot be inspected"
+            ) from exc
+        if stat.S_ISLNK(node.st_mode) or _is_reparse_point(node):
+            raise WebhookRouteStoreUnsafePathError(
+                "webhook store path must not contain links"
+            )
+        if not stat.S_ISDIR(node.st_mode):
+            raise WebhookRouteStoreUnsafePathError(
+                "webhook store parent is not a directory"
+            )
+
+
+def _open_windows_directory_tree(path: Path) -> _DirectoryAuthority:
+    _, pywintypes, _, win32con, win32file, _ = _win32()
+    _assert_no_link_components(path, allow_missing=True)
+    current = Path(path.anchor)
+    for part in path.parts[1:]:
+        current = current / part
+        try:
+            win32file.CreateDirectory(
+                str(current),
+                _windows_security_attributes(),
+            )
+        except pywintypes.error as exc:
+            if getattr(exc, "winerror", None) not in {80, 183}:
+                raise WebhookRouteStoreUnsafePathError(
+                    "webhook store directory cannot be created"
+                ) from exc
+    _assert_no_link_components(path, allow_missing=False)
+    handle = win32file.CreateFile(
+        str(path),
+        win32con.GENERIC_READ | win32con.READ_CONTROL,
+        win32con.FILE_SHARE_READ | win32con.FILE_SHARE_WRITE,
+        None,
+        win32con.OPEN_EXISTING,
+        win32con.FILE_FLAG_BACKUP_SEMANTICS | _WINDOWS_OPEN_REPARSE_POINT,
+        None,
+    )
+    try:
+        actual = _verify_windows_handle(
+            handle,
+            path,
+            label="webhook profile directory",
+            require_directory=True,
+        )
+        return _DirectoryAuthority(actual, windows_handle=handle)
+    except BaseException:
+        win32file.CloseHandle(handle)
+        raise
+
+
+def _open_directory_tree(path: Path) -> _DirectoryAuthority:
+    """Open/create an absolute directory tree without following symlinks."""
+
+    if os.name == "nt":
+        return _open_windows_directory_tree(path)
+
+    secure_posix = (
+        os.name == "posix"
+        and os.open in getattr(os, "supports_dir_fd", set())
+        and bool(getattr(os, "O_DIRECTORY", 0))
+        and bool(getattr(os, "O_NOFOLLOW", 0))
+    )
+    if not secure_posix:
+        _assert_no_link_components(path, allow_missing=True)
+        path.mkdir(parents=True, exist_ok=True, mode=_DIRECTORY_MODE)
+        _assert_no_link_components(path, allow_missing=False)
+        flags = os.O_RDONLY | int(getattr(os, "O_BINARY", 0))
+        descriptor = os.open(path, flags)
+        try:
+            _assert_safe_profile_directory(descriptor)
+            return _DirectoryAuthority(path, fd=descriptor)
+        except BaseException:
+            os.close(descriptor)
+            raise
+
+    flags = (
+        os.O_RDONLY
+        | int(getattr(os, "O_CLOEXEC", 0))
+        | int(getattr(os, "O_DIRECTORY", 0))
+        | int(getattr(os, "O_NOFOLLOW", 0))
+    )
+    descriptor = os.open(path.anchor, flags)
+    try:
+        for part in path.parts[1:]:
+            if part in {"", ".", ".."}:
+                raise WebhookRouteStoreUnsafePathError(
+                    "webhook store path contains an unsafe component"
+                )
+            try:
+                os.mkdir(part, _DIRECTORY_MODE, dir_fd=descriptor)
+            except FileExistsError:
+                pass
+            except OSError as exc:
+                raise WebhookRouteStoreUnsafePathError(
+                    "webhook store directory cannot be created"
+                ) from exc
+            try:
+                next_descriptor = os.open(part, flags, dir_fd=descriptor)
+            except OSError as exc:
+                raise WebhookRouteStoreUnsafePathError(
+                    "webhook store path must contain only real directories"
+                ) from exc
+            os.close(descriptor)
+            descriptor = next_descriptor
+        _assert_safe_profile_directory(descriptor)
+        return _DirectoryAuthority(path, fd=descriptor)
+    except BaseException:
+        os.close(descriptor)
+        raise
+
+
+def _read_all(fd: int, max_bytes: int) -> bytes:
+    os.lseek(fd, 0, os.SEEK_SET)
+    chunks: list[bytes] = []
+    remaining = max_bytes + 1
+    while remaining:
+        chunk = os.read(fd, min(remaining, 64 * 1024))
+        if not chunk:
+            break
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    result = b"".join(chunks)
+    if len(result) > max_bytes:
+        raise WebhookRouteStoreCorruptError(
+            "webhook route store exceeds its size limit"
+        )
+    return result
+
+
+def _open_windows_file(
+    authority: _DirectoryAuthority,
+    name: str,
+    flags: int,
+    *,
+    create_new: bool = False,
+    share_delete: bool,
+) -> int:
+    _, _, _, win32con, win32file, _ = _win32()
+    if authority.windows_handle is None:
+        raise WebhookRouteStoreError("profile directory has no Windows handle")
+    candidate = authority.path / name
+    readable = not bool(flags & os.O_WRONLY) or bool(flags & os.O_RDWR)
+    writable = bool(flags & (os.O_WRONLY | os.O_RDWR))
+    access = win32con.READ_CONTROL
+    if readable:
+        access |= win32con.GENERIC_READ
+    if writable:
+        access |= win32con.GENERIC_WRITE
+    share = win32con.FILE_SHARE_READ | win32con.FILE_SHARE_WRITE
+    if share_delete:
+        share |= win32con.FILE_SHARE_DELETE
+    creation = win32con.CREATE_NEW if create_new else win32con.OPEN_EXISTING
+    security = _windows_security_attributes() if create_new else None
+    try:
+        handle = win32file.CreateFile(
+            str(candidate),
+            access,
+            share,
+            security,
+            creation,
+            win32con.FILE_ATTRIBUTE_NORMAL | _WINDOWS_OPEN_REPARSE_POINT,
+            None,
+        )
+    except Exception as exc:
+        winerror = getattr(exc, "winerror", None)
+        if winerror in {2, 3}:
+            raise FileNotFoundError(
+                errno.ENOENT, os.strerror(errno.ENOENT), candidate
+            ) from None
+        if winerror in {80, 183}:
+            raise FileExistsError(
+                errno.EEXIST, os.strerror(errno.EEXIST), candidate
+            ) from None
+        raise
+    try:
+        _verify_windows_handle(
+            handle,
+            candidate,
+            label="webhook store file",
+            require_directory=False,
+        )
+        raw_handle = handle.Detach()
+    except BaseException:
+        win32file.CloseHandle(handle)
+        raise
+    descriptor_flags = flags | int(getattr(os, "O_BINARY", 0))
+    descriptor_flags |= int(getattr(os, "O_NOINHERIT", 0))
+    try:
+        open_osfhandle = getattr(msvcrt, "open_osfhandle", None)
+        if not callable(open_osfhandle):  # pragma: no cover - native Windows has it
+            raise WebhookRouteStoreError(
+                "Windows CRT descriptor support is unavailable"
+            )
+        return open_osfhandle(raw_handle, descriptor_flags)
+    except BaseException:
+        win32file.CloseHandle(raw_handle)
+        raise
+
+
+def _open_relative_file(
+    authority: _DirectoryAuthority,
+    directory: Path,
+    name: str,
+    flags: int,
+) -> int:
+    if authority.windows_handle is not None:
+        return _open_windows_file(
+            authority,
+            name,
+            flags,
+            share_delete=name != _LOCK_FILENAME,
+        )
+    directory_fd = _directory_fd(authority)
+    flags |= int(getattr(os, "O_CLOEXEC", 0))
+    flags |= int(getattr(os, "O_BINARY", 0))
+    flags |= int(getattr(os, "O_NOFOLLOW", 0))
+    if os.open in getattr(os, "supports_dir_fd", set()):
+        return os.open(name, flags, dir_fd=directory_fd)
+    candidate = directory / name
+    try:
+        node = os.lstat(candidate)
+    except FileNotFoundError:
+        raise
+    if stat.S_ISLNK(node.st_mode) or _is_reparse_point(node):
+        raise WebhookRouteStoreUnsafePathError("webhook store file must not be a link")
+    return os.open(candidate, flags)
+
+
+def _replace_relative(
+    authority: _DirectoryAuthority,
+    source: str,
+    destination: str,
+    *,
+    replace_existing: bool,
+) -> None:
+    if authority.windows_handle is not None:
+        _, _, _, _, win32file, _ = _win32()
+        _verify_windows_handle(
+            authority.windows_handle,
+            authority.path,
+            label="webhook profile directory",
+            require_directory=True,
+        )
+        win32file.MoveFileEx(
+            str(authority.path / source),
+            str(authority.path / destination),
+            _windows_move_flags(replace_existing=replace_existing),
+        )
+        return
+    directory_fd = _directory_fd(authority)
+    if os.replace in getattr(os, "supports_dir_fd", set()):
+        os.replace(
+            source,
+            destination,
+            src_dir_fd=directory_fd,
+            dst_dir_fd=directory_fd,
+        )
+        return
+    target = authority.path / destination
+    if not replace_existing and target.exists():
+        raise WebhookRouteStoreError("webhook quarantine target already exists")
+    os.replace(authority.path / source, target)
+
+
+def _sync_directory(authority: _DirectoryAuthority) -> None:
+    # Windows has no supported equivalent of fsync on a directory handle.
+    # Every namespace publication above instead uses MOVEFILE_WRITE_THROUGH.
+    if authority.windows_handle is None:
+        os.fsync(_directory_fd(authority))
+
+
+def _unlink_relative(authority: _DirectoryAuthority, name: str) -> None:
+    if authority.windows_handle is not None:
+        (authority.path / name).unlink()
+        return
+    directory_fd = _directory_fd(authority)
+    if os.unlink in getattr(os, "supports_dir_fd", set()):
+        os.unlink(name, dir_fd=directory_fd)
+    else:
+        (authority.path / name).unlink()
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError("webhook route store contains a duplicate key")
+        result[key] = value
+    return result
+
+
+def _reject_nonfinite(value: str) -> object:
+    raise ValueError("webhook route store contains a non-finite number")
+
+
+def _parse_finite_float(value: str) -> float:
+    """Reject exponent overflow as well as JSON's named NaN/Infinity values."""
+
+    parsed = float(value)
+    if parsed == float("inf") or parsed == float("-inf"):
+        raise ValueError("webhook route store contains a non-finite number")
+    return parsed
+
+
+class WebhookRouteStore:
+    """Persist one profile's route documents beneath a shared Hermes root."""
+
+    def __init__(self, root: str | os.PathLike[str], profile: str = "default"):
+        from hermes_cli.profiles import normalize_profile_name, validate_profile_name
+
+        canonical_profile = normalize_profile_name(profile)
+        validate_profile_name(canonical_profile)
+        if canonical_profile != profile:
+            raise ValueError("webhook store profile must already be canonical")
+        self.root = _absolute_without_traversal(root)
+        self.profile = canonical_profile
+        self._thread_lock = _thread_lock_for(self.lock_path)
+
+    @classmethod
+    def for_profile_home(
+        cls,
+        profile: str,
+        home: str | os.PathLike[str],
+    ) -> "WebhookRouteStore":
+        """Construct from an exact profile home returned by admission."""
+
+        home_path = _absolute_without_traversal(home)
+        if profile == "default":
+            return cls(home_path, profile="default")
+        if home_path.name != profile or home_path.parent.name != "profiles":
+            raise WebhookRouteStoreUnsafePathError(
+                "served profile home does not match its canonical profile id"
+            )
+        return cls(home_path.parent.parent, profile=profile)
+
+    @property
+    def profile_root(self) -> Path:
+        if self.profile == "default":
+            return self.root
+        return self.root / "profiles" / self.profile
+
+    @property
+    def path(self) -> Path:
+        return self.profile_root / _FILENAME
+
+    @property
+    def lock_path(self) -> Path:
+        return self.profile_root / _LOCK_FILENAME
+
+    @contextmanager
+    def _lock(
+        self,
+        *,
+        timeout_seconds: float = _LOCK_TIMEOUT_SECONDS,
+    ) -> Iterator[_DirectoryAuthority]:
+        """Yield a pinned profile-directory descriptor under both locks."""
+
+        if timeout_seconds < 0:
+            raise ValueError("webhook route lock timeout must be non-negative")
+        deadline = time.monotonic() + timeout_seconds
+        acquired = self._thread_lock.acquire(timeout=timeout_seconds)
+        if not acquired:
+            raise TimeoutError("webhook route store is busy")
+        try:
+            directory_fd = _open_directory_tree(self.profile_root)
+            lock_fd = -1
+            directory_locked = False
+            sidecar_locked = False
+            try:
+                # POSIX exclusion belongs to the pinned profile-directory
+                # inode. A sidecar pathname can be atomically replaced after a
+                # writer opens it, splitting writers across unrelated flock
+                # inodes. The already-open directory descriptor cannot be
+                # swapped out from under this operation.
+                if fcntl is not None:
+                    while True:
+                        try:
+                            fcntl.flock(
+                                _directory_fd(directory_fd),
+                                fcntl.LOCK_EX | fcntl.LOCK_NB,
+                            )
+                            directory_locked = True
+                            break
+                        except OSError as exc:
+                            if exc.errno not in {
+                                errno.EACCES,
+                                errno.EAGAIN,
+                                errno.EWOULDBLOCK,
+                            }:
+                                raise
+                            if time.monotonic() >= deadline:
+                                raise TimeoutError(
+                                    "webhook route store is busy"
+                                ) from exc
+                            time.sleep(0.01)
+
+                if fcntl is not None:
+                    # A legacy sidecar is metadata only on POSIX. Validate it
+                    # if present, but never mutate or lock it; directory flock
+                    # above is the stable exclusion authority.
+                    flags = os.O_RDONLY | int(getattr(os, "O_NONBLOCK", 0))
+                    try:
+                        lock_fd = _open_relative_file(
+                            directory_fd,
+                            self.profile_root,
+                            _LOCK_FILENAME,
+                            flags,
+                        )
+                    except FileNotFoundError:
+                        lock_fd = -1
+                    except OSError as exc:
+                        if exc.errno in {errno.ELOOP, errno.EMLINK}:
+                            raise WebhookRouteStoreUnsafePathError(
+                                "webhook route lock must not be a link"
+                            ) from exc
+                        raise
+                    if lock_fd >= 0:
+                        lock_stat = os.fstat(lock_fd)
+                        if not stat.S_ISREG(lock_stat.st_mode):
+                            raise WebhookRouteStoreUnsafePathError(
+                                "webhook route lock is not a regular file"
+                            )
+                        _assert_owned_single_link(
+                            lock_stat,
+                            label="webhook route lock",
+                        )
+                        if (
+                            stat.S_IMODE(lock_stat.st_mode) != _FILE_MODE
+                            or lock_stat.st_size < 1
+                        ):
+                            raise WebhookRouteStoreUnsafePathError(
+                                "webhook route lock has unsafe metadata"
+                            )
+                else:
+                    # Native Windows needs a byte-range sidecar lock. Create
+                    # it once with exclusive creation, or validate the exact
+                    # descriptor opened without following reparse points.
+                    flags = (
+                        os.O_RDWR
+                        | int(getattr(os, "O_CLOEXEC", 0))
+                        | int(getattr(os, "O_NOFOLLOW", 0))
+                    )
+                    created_lock = False
+                    try:
+                        if directory_fd.windows_handle is not None:
+                            lock_fd = _open_windows_file(
+                                directory_fd,
+                                _LOCK_FILENAME,
+                                flags,
+                                create_new=True,
+                                share_delete=False,
+                            )
+                        else:
+                            lock_fd = os.open(
+                                self.profile_root / _LOCK_FILENAME,
+                                flags | os.O_CREAT | os.O_EXCL,
+                                _FILE_MODE,
+                            )
+                        created_lock = True
+                    except FileExistsError:
+                        try:
+                            lock_fd = _open_relative_file(
+                                directory_fd,
+                                self.profile_root,
+                                _LOCK_FILENAME,
+                                flags,
+                            )
+                        except OSError as exc:
+                            if exc.errno in {errno.ELOOP, errno.EMLINK}:
+                                raise WebhookRouteStoreUnsafePathError(
+                                    "webhook route lock must not be a link"
+                                ) from exc
+                            raise
+                    lock_stat = os.fstat(lock_fd)
+                    if not stat.S_ISREG(lock_stat.st_mode):
+                        raise WebhookRouteStoreUnsafePathError(
+                            "webhook route lock is not a regular file"
+                        )
+                    _assert_owned_single_link(
+                        lock_stat,
+                        label="webhook route lock",
+                    )
+                    if created_lock or lock_stat.st_size < 1:
+                        os.lseek(lock_fd, 0, os.SEEK_SET)
+                        os.write(lock_fd, b"0")
+                        os.fsync(lock_fd)
+                    os.lseek(lock_fd, 0, os.SEEK_SET)
+                    while True:
+                        try:
+                            if msvcrt is not None:
+                                msvcrt.locking(lock_fd, msvcrt.LK_NBLCK, 1)
+                                sidecar_locked = True
+                            else:  # pragma: no cover - unsupported interpreter
+                                raise WebhookRouteStoreError(
+                                    "no interprocess webhook lock is available"
+                                )
+                            break
+                        except OSError as exc:
+                            if exc.errno not in {
+                                errno.EACCES,
+                                errno.EAGAIN,
+                                errno.EDEADLK,
+                                errno.EWOULDBLOCK,
+                            }:
+                                raise
+                            if time.monotonic() >= deadline:
+                                raise TimeoutError(
+                                    "webhook route store is busy"
+                                ) from exc
+                            time.sleep(0.01)
+                try:
+                    yield directory_fd
+                finally:
+                    if sidecar_locked and msvcrt is not None:
+                        os.lseek(lock_fd, 0, os.SEEK_SET)
+                        msvcrt.locking(lock_fd, msvcrt.LK_UNLCK, 1)
+                    if directory_locked and fcntl is not None:
+                        fcntl.flock(_directory_fd(directory_fd), fcntl.LOCK_UN)
+            finally:
+                if lock_fd >= 0:
+                    os.close(lock_fd)
+                _close_directory(directory_fd)
+        finally:
+            self._thread_lock.release()
+
+    def _raw_snapshot_unlocked(
+        self,
+        directory_fd: _DirectoryAuthority,
+    ) -> _RawSnapshot | None:
+        try:
+            fd = _open_relative_file(
+                directory_fd,
+                self.profile_root,
+                _FILENAME,
+                os.O_RDONLY | int(getattr(os, "O_NONBLOCK", 0)),
+            )
+        except FileNotFoundError:
+            return None
+        except OSError as exc:
+            if exc.errno in {errno.ELOOP, errno.EMLINK}:
+                raise WebhookRouteStoreUnsafePathError(
+                    "webhook route store must not be a link"
+                ) from exc
+            raise
+        try:
+            opened = os.fstat(fd)
+            if not stat.S_ISREG(opened.st_mode):
+                raise WebhookRouteStoreUnsafePathError(
+                    "webhook route store is not a regular file"
+                )
+            _assert_owned_single_link(
+                opened,
+                label="webhook route store",
+            )
+            if hasattr(os, "fchmod"):
+                os.fchmod(fd, _FILE_MODE)
+            # Tightening legacy permissions changes ctime; capture the stable
+            # identity only after that one authorized metadata mutation.
+            before = os.fstat(fd)
+            if before.st_size > _MAX_STORE_BYTES:
+                raise WebhookRouteStoreCorruptError(
+                    "webhook route store exceeds its size limit",
+                    file_identity=_stat_identity(before),
+                )
+            first = _read_all(fd, _MAX_STORE_BYTES)
+            middle = os.fstat(fd)
+            second = _read_all(fd, _MAX_STORE_BYTES)
+            after = os.fstat(fd)
+            if (
+                _stat_identity(before) != _stat_identity(middle)
+                or _stat_identity(before) != _stat_identity(after)
+                or len(first) != before.st_size
+                or first != second
+            ):
+                raise WebhookRouteStoreError(
+                    "webhook route store changed while being read"
+                )
+            return _RawSnapshot(second, _stat_identity(after))
+        finally:
+            os.close(fd)
+
+    def _parse(self, raw: bytes) -> dict[str, WebhookRouteDocument]:
+        digest = hashlib.sha256(raw).hexdigest()
+        try:
+            decoded = raw.decode("utf-8")
+            data = json.loads(
+                decoded,
+                object_pairs_hook=_reject_duplicate_keys,
+                parse_constant=_reject_nonfinite,
+                parse_float=_parse_finite_float,
+            )
+            if not isinstance(data, dict):
+                raise ValueError("webhook route store root must be an object")
+            # Python's JSON decoder accepts escaped lone UTF-16 surrogates,
+            # but they cannot be encoded as canonical UTF-8 on the next save.
+            # Validate the complete tree now so every successful load is also
+            # a serializable store document.
+            json.dumps(
+                data,
+                ensure_ascii=False,
+                allow_nan=False,
+                separators=(",", ":"),
+            ).encode("utf-8")
+            routes: dict[str, WebhookRouteDocument] = {}
+            for name, value in data.items():
+                if not isinstance(name, str) or not isinstance(value, Mapping):
+                    raise ValueError("webhook route entries must be named objects")
+                document = from_persisted_route(
+                    name,
+                    value,
+                    profile=self.profile,
+                )
+                if document.name != name:
+                    raise ValueError(
+                        "embedded webhook route name does not match its key"
+                    )
+                routes[name] = document
+            return dict(sorted(routes.items()))
+        except WebhookRouteStoreCorruptError:
+            raise
+        except Exception:
+            raise WebhookRouteStoreCorruptError(
+                "webhook route store is not a valid canonical document",
+                content_sha256=digest,
+            ) from None
+
+    def _quarantine_unlocked(
+        self,
+        directory_fd: _DirectoryAuthority,
+        identity: tuple[int, ...],
+    ) -> Path:
+        """Move only the inode whose exact bytes failed validation."""
+
+        if directory_fd.windows_handle is not None:
+            current_fd = _open_relative_file(
+                directory_fd,
+                self.profile_root,
+                _FILENAME,
+                os.O_RDONLY,
+            )
+            try:
+                current = os.fstat(current_fd)
+            finally:
+                os.close(current_fd)
+        elif os.stat in getattr(os, "supports_dir_fd", set()):
+            current = os.stat(
+                _FILENAME,
+                dir_fd=_directory_fd(directory_fd),
+                follow_symlinks=False,
+            )
+        else:
+            current = os.lstat(self.path)
+        if not stat.S_ISREG(current.st_mode) or _stat_identity(current) != identity:
+            raise WebhookRouteStoreError(
+                "webhook route store changed before corrupt quarantine"
+            )
+        _assert_owned_single_link(
+            current,
+            label="webhook route store",
+        )
+        quarantine_name = (
+            f"{_FILENAME}.corrupt-{time.strftime('%Y%m%dT%H%M%SZ', time.gmtime())}-"
+            f"{secrets.token_hex(8)}"
+        )
+        _replace_relative(
+            directory_fd,
+            _FILENAME,
+            quarantine_name,
+            replace_existing=False,
+        )
+        try:
+            _sync_directory(directory_fd)
+        except OSError:
+            pass
+        return self.profile_root / quarantine_name
+
+    def load_snapshot(
+        self,
+        *,
+        on_corrupt: Literal["raise", "quarantine"] = "raise",
+        lock_timeout_seconds: float = _LOCK_TIMEOUT_SECONDS,
+    ) -> WebhookRouteStoreSnapshot:
+        """Load one stable snapshot; corruption handling is always explicit."""
+
+        if on_corrupt not in {"raise", "quarantine"}:
+            raise ValueError("on_corrupt must be 'raise' or 'quarantine'")
+        with self._lock(timeout_seconds=lock_timeout_seconds) as directory_fd:
+            try:
+                raw = self._raw_snapshot_unlocked(directory_fd)
+            except WebhookRouteStoreCorruptError as exc:
+                if on_corrupt == "raise" or exc.file_identity is None:
+                    raise
+                quarantined = self._quarantine_unlocked(
+                    directory_fd,
+                    exc.file_identity,
+                )
+                return WebhookRouteStoreSnapshot(
+                    {},
+                    exc.content_sha256,
+                    exc.file_identity,
+                    self.path,
+                    quarantined_path=quarantined,
+                )
+            if raw is None:
+                return WebhookRouteStoreSnapshot({}, None, None, self.path)
+            digest = hashlib.sha256(raw.content).hexdigest()
+            try:
+                routes = self._parse(raw.content)
+            except WebhookRouteStoreCorruptError:
+                if on_corrupt == "raise":
+                    raise
+                quarantined = self._quarantine_unlocked(directory_fd, raw.identity)
+                return WebhookRouteStoreSnapshot(
+                    {},
+                    digest,
+                    raw.identity,
+                    self.path,
+                    quarantined_path=quarantined,
+                )
+            return WebhookRouteStoreSnapshot(
+                routes,
+                digest,
+                raw.identity,
+                self.path,
+            )
+
+    def load(self) -> dict[str, WebhookRouteDocument]:
+        """CLI/management read: malformed data raises and is left untouched."""
+
+        return dict(self.load_snapshot(on_corrupt="raise").routes)
+
+    def probe_identity(self) -> tuple[int, ...] | None:
+        """Return a cheap descriptor-safe file identity without taking the lock.
+
+        Management writes publish by atomic rename, so a reader either opens
+        the previous complete inode or the next complete inode. Runtime uses
+        this probe to avoid re-reading every admitted profile on every reload
+        interval. A separately budgeted integrity pass still re-hashes one
+        unchanged inode at a time to detect metadata-preserving writes.
+        """
+
+        directory_fd = _open_directory_tree(self.profile_root)
+        try:
+            try:
+                fd = _open_relative_file(
+                    directory_fd,
+                    self.profile_root,
+                    _FILENAME,
+                    os.O_RDONLY | int(getattr(os, "O_NONBLOCK", 0)),
+                )
+            except FileNotFoundError:
+                return None
+            except OSError as exc:
+                if exc.errno in {errno.ELOOP, errno.EMLINK}:
+                    raise WebhookRouteStoreUnsafePathError(
+                        "webhook route store must not be a link"
+                    ) from exc
+                raise
+            try:
+                observed = os.fstat(fd)
+                if not stat.S_ISREG(observed.st_mode):
+                    raise WebhookRouteStoreUnsafePathError(
+                        "webhook route store is not a regular file"
+                    )
+                _assert_owned_single_link(
+                    observed,
+                    label="webhook route store",
+                )
+                return _stat_identity(observed)
+            finally:
+                os.close(fd)
+        finally:
+            _close_directory(directory_fd)
+
+    def load_runtime(self) -> WebhookRouteStoreSnapshot:
+        """Runtime read: quarantine exact corrupt bytes and expose revocation."""
+
+        # Request-path reloads must never wait behind a management writer.
+        # The adapter retains the prior exact published snapshot on this busy
+        # signal and retries after its amplification gate.
+        return self.load_snapshot(
+            on_corrupt="quarantine",
+            lock_timeout_seconds=0.0,
+        )
+
+    def _normalize(
+        self,
+        routes: Mapping[str, WebhookRouteDocument | Mapping[str, object]],
+    ) -> dict[str, WebhookRouteDocument]:
+        normalized: dict[str, WebhookRouteDocument] = {}
+        for name, value in routes.items():
+            if not isinstance(name, str):
+                raise TypeError("webhook route names must be strings")
+            if isinstance(value, WebhookRouteDocument):
+                declared_name = value.name
+                raw_document = to_persisted_route(value)
+            elif isinstance(value, Mapping):
+                raw = dict(value)
+                embedded_name = raw.pop("name", name)
+                raw.setdefault("profile", self.profile)
+                initial = WebhookRouteDocument.model_validate({
+                    "name": embedded_name,
+                    **raw,
+                })
+                declared_name = initial.name
+                raw_document = to_persisted_route(initial)
+            else:
+                raise TypeError("webhook routes must be route documents or objects")
+            if declared_name != name:
+                raise ValueError("webhook route key does not match document name")
+
+            # A Pydantic model's nested dict/list members remain mutable after
+            # construction. Canonical JSON round-tripping detaches the store
+            # snapshot, rejects non-finite/non-JSON mutations, and then runs
+            # every model + canonical-contract validator again.
+            try:
+                detached = json.loads(
+                    json.dumps(
+                        raw_document,
+                        ensure_ascii=False,
+                        allow_nan=False,
+                        separators=(",", ":"),
+                    ),
+                    object_pairs_hook=_reject_duplicate_keys,
+                    parse_constant=_reject_nonfinite,
+                )
+            except (TypeError, ValueError, UnicodeEncodeError, RecursionError) as exc:
+                raise WebhookRouteStoreError(
+                    "webhook route mutation is not canonical JSON"
+                ) from exc
+            document = from_persisted_route(
+                name,
+                detached,
+                profile=self.profile,
+            )
+            if document.name != name:
+                raise ValueError("webhook route key does not match document name")
+            if document.profile != self.profile:
+                raise ValueError("webhook route belongs to a different profile store")
+            normalized[name] = document
+        return dict(sorted(normalized.items()))
+
+    def _serialize(self, routes: Mapping[str, WebhookRouteDocument]) -> bytes:
+        data = {
+            name: to_persisted_route(route) for name, route in sorted(routes.items())
+        }
+        try:
+            payload = (
+                json.dumps(
+                    data,
+                    ensure_ascii=False,
+                    allow_nan=False,
+                    indent=2,
+                    sort_keys=True,
+                )
+                + "\n"
+            ).encode("utf-8")
+        except (TypeError, ValueError, UnicodeEncodeError, RecursionError) as exc:
+            raise WebhookRouteStoreError(
+                "webhook route documents are not canonical JSON"
+            ) from exc
+        if len(payload) > _MAX_STORE_BYTES:
+            raise WebhookRouteStoreError("webhook route store exceeds its size limit")
+        return payload
+
+    def _save_unlocked(
+        self,
+        directory_fd: _DirectoryAuthority,
+        routes: Mapping[str, WebhookRouteDocument],
+    ) -> None:
+        payload = self._serialize(routes)
+        temporary_name = f".{_FILENAME}.{secrets.token_hex(16)}.tmp"
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+        flags |= int(getattr(os, "O_CLOEXEC", 0))
+        flags |= int(getattr(os, "O_NOFOLLOW", 0))
+        temporary_fd = -1
+        try:
+            if directory_fd.windows_handle is not None:
+                temporary_fd = _open_windows_file(
+                    directory_fd,
+                    temporary_name,
+                    os.O_WRONLY,
+                    create_new=True,
+                    share_delete=False,
+                )
+            elif os.open in getattr(os, "supports_dir_fd", set()):
+                temporary_fd = os.open(
+                    temporary_name,
+                    flags,
+                    _FILE_MODE,
+                    dir_fd=_directory_fd(directory_fd),
+                )
+            else:
+                temporary_fd = os.open(
+                    self.profile_root / temporary_name,
+                    flags,
+                    _FILE_MODE,
+                )
+            if hasattr(os, "fchmod"):
+                os.fchmod(temporary_fd, _FILE_MODE)
+            view = memoryview(payload)
+            offset = 0
+            while offset < len(view):
+                written = os.write(temporary_fd, view[offset:])
+                if written <= 0:
+                    raise OSError("short webhook route store write")
+                offset += written
+            os.fsync(temporary_fd)
+            os.close(temporary_fd)
+            temporary_fd = -1
+
+            # Reject a pre-existing link/non-regular target. A replacement
+            # race cannot redirect the rename because both names are relative
+            # to the already-open directory descriptor.
+            try:
+                if directory_fd.windows_handle is not None:
+                    target_fd = _open_relative_file(
+                        directory_fd,
+                        self.profile_root,
+                        _FILENAME,
+                        os.O_RDONLY,
+                    )
+                    try:
+                        target_stat = os.fstat(target_fd)
+                    finally:
+                        os.close(target_fd)
+                elif os.stat in getattr(os, "supports_dir_fd", set()):
+                    target_stat = os.stat(
+                        _FILENAME,
+                        dir_fd=_directory_fd(directory_fd),
+                        follow_symlinks=False,
+                    )
+                else:
+                    target_stat = os.lstat(self.path)
+            except FileNotFoundError:
+                target_stat = None
+            if target_stat is not None and not stat.S_ISREG(target_stat.st_mode):
+                raise WebhookRouteStoreUnsafePathError(
+                    "webhook route store target is not a regular file"
+                )
+            if target_stat is not None:
+                _assert_owned_single_link(
+                    target_stat,
+                    label="webhook route store target",
+                )
+
+            _replace_relative(
+                directory_fd,
+                temporary_name,
+                _FILENAME,
+                replace_existing=True,
+            )
+            _sync_directory(directory_fd)
+        finally:
+            if temporary_fd >= 0:
+                os.close(temporary_fd)
+            try:
+                _unlink_relative(directory_fd, temporary_name)
+            except FileNotFoundError:
+                pass
+
+    def save(
+        self,
+        routes: Mapping[str, WebhookRouteDocument | Mapping[str, object]],
+    ) -> None:
+        normalized = self._normalize(routes)
+        with self._lock() as directory_fd:
+            self._save_unlocked(directory_fd, normalized)
+
+    def update(
+        self,
+        mutator: Callable[
+            [dict[str, WebhookRouteDocument]],
+            Mapping[str, WebhookRouteDocument | Mapping[str, object]],
+        ],
+    ) -> dict[str, WebhookRouteDocument]:
+        """Apply one lossless read/modify/write under the interprocess lock."""
+
+        with self._lock() as directory_fd:
+            raw = self._raw_snapshot_unlocked(directory_fd)
+            current = {} if raw is None else self._parse(raw.content)
+            updated = self._normalize(mutator(dict(current)))
+            self._save_unlocked(directory_fd, updated)
+            return updated
+
+
+def stores_for_served_profiles(
+    served_profiles: Iterable[tuple[str, str | os.PathLike[str]]],
+) -> dict[str, WebhookRouteStore]:
+    """Build stores from the exact profile homes admitted by the listener."""
+
+    result: dict[str, WebhookRouteStore] = {}
+    for profile, home in served_profiles:
+        if profile in result:
+            raise ValueError("served webhook profile list contains a duplicate")
+        result[profile] = WebhookRouteStore.for_profile_home(profile, home)
+    return result
+
+
+__all__ = [
+    "WebhookRouteStore",
+    "WebhookRouteStoreCorruptError",
+    "WebhookRouteStoreError",
+    "WebhookRouteStoreSnapshot",
+    "WebhookRouteStoreUnsafePathError",
+    "stores_for_served_profiles",
+]

--- a/gateway/platforms/webhook_terminal.py
+++ b/gateway/platforms/webhook_terminal.py
@@ -1,0 +1,39 @@
+"""Typed, privacy-bounded terminal carriers for webhook agent runs."""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any
+
+
+class WebhookTerminalOutcome(str, Enum):
+    """Terminal agent outcomes that may become durable outbound effects."""
+
+    ERROR = "error"
+
+
+_TERMINAL_NOTICES = {
+    WebhookTerminalOutcome.ERROR: (
+        "Webhook processing failed before a final response was produced."
+    ),
+}
+
+
+def terminal_outcome_notice(outcome: WebhookTerminalOutcome) -> str:
+    """Return stable user text without provider errors, payloads, or secrets."""
+
+    if not isinstance(outcome, WebhookTerminalOutcome):
+        raise TypeError("webhook terminal outcome must be typed")
+    return _TERMINAL_NOTICES[outcome]
+
+
+def terminal_outcome_carrier(outcome: WebhookTerminalOutcome) -> dict[str, Any]:
+    """Return the exact JSON carrier persisted beside the terminal notice."""
+
+    if not isinstance(outcome, WebhookTerminalOutcome):
+        raise TypeError("webhook terminal outcome must be typed")
+    return {
+        "v": 1,
+        "kind": "terminal_outcome",
+        "outcome": outcome.value,
+    }

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -95,6 +95,9 @@ _TELEGRAM_CONNECT_TIMEOUT_SECS_DEFAULT = 180.0
 # 180s budget (is_reconnect=True preserves the offline update queue, #46621).
 _TELEGRAM_INITIAL_CONNECT_TIMEOUT_SECS_DEFAULT = 45.0
 _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT = 5.0
+_WEBHOOK_RECOVERY_RETRY_INITIAL_SECONDS = 1.0
+_WEBHOOK_RECOVERY_RETRY_MAX_SECONDS = 60.0
+_WEBHOOK_RECOVERY_PUMP_IDLE_SECONDS = 0.05
 # End reasons that mean the USER deliberately closed this thread of work
 # (/new -> session_reset / new_session, an explicit exit, or a /switch).
 # Shared by _classify_completion_target (pre-flight verdict) and
@@ -4249,6 +4252,41 @@ async def _dispose_unused_adapter(adapter: "BasePlatformAdapter | None") -> None
         )
 
 
+def _classify_adapter_construction_failure(
+    platform: "Platform",
+    exc: BaseException,
+) -> Optional[tuple[str, str]]:
+    """Return a fatal config descriptor for deterministic constructor errors.
+
+    Most adapter-construction exceptions are programming errors or transient
+    dependency/storage failures and must retain their existing behavior.  The
+    webhook constructor has two narrower failure classes that cannot heal by
+    retrying the same immutable configuration:
+
+    * ``WebhookConfigurationError`` for invalid typed numeric/config values;
+    * ``WebhookLedgerConfigurationError`` when configured limits conflict with
+      already-persisted durable authority.
+
+    Import lazily because ``gateway.platforms.webhook`` itself imports runner
+    helpers at execution time.  ``_create_adapter`` has already loaded that
+    module before either exception can reach this classifier.
+    """
+
+    if platform is not Platform.WEBHOOK:
+        return None
+
+    from gateway.platforms.webhook import WebhookConfigurationError
+    from gateway.platforms.webhook_ledger import WebhookLedgerConfigurationError
+
+    if not isinstance(
+        exc,
+        (WebhookConfigurationError, WebhookLedgerConfigurationError),
+    ):
+        return None
+    message = str(exc).strip() or "Webhook configuration is invalid"
+    return "webhook_configuration_invalid", message
+
+
 # Max seconds between platform reconnect retries (primary watcher and
 # secondary-profile reconnects share this policy — tune in one place).
 _RECONNECT_BACKOFF_CAP = 300
@@ -5463,6 +5501,14 @@ class TurnRunner:
             if _plat_streaming is None
             else bool(_plat_streaming)
         )
+        # A webhook operation owns exactly one durable outbound target. Token
+        # previews and multi-chunk streaming finals would create multiple
+        # external effects for that one authority record, so no display
+        # override may enable streaming on this transport.
+        from gateway.config import Platform as _StreamingPlatform
+
+        if ctx.source.platform == _StreamingPlatform.WEBHOOK:
+            _streaming_enabled = False
         _want_stream_deltas = _streaming_enabled
         _want_interim_messages = ctx.interim_assistant_messages_enabled
         _want_interim_consumer = _want_interim_messages
@@ -7376,6 +7422,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         # Track background tasks to prevent garbage collection mid-execution
         self._background_tasks: set = set()
+        self._webhook_recovery_retry_task: Optional[asyncio.Task] = None
+        self._webhook_recovery_retry_adapter = None
 
         # Event-loop liveness heartbeat (#66892): rewritten every 30s while
         # the loop is dispatching. External supervisors use the file mtime /
@@ -12034,7 +12082,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             drained += 1
         return drained
 
-    async def _finish_startup_restore(self) -> None:
+    async def _finish_startup_restore(
+        self,
+        *,
+        before_gate_release: Optional[Callable[[], Awaitable[Any]]] = None,
+    ) -> None:
         """Wait (BOUNDED) for startup auto-resume, then release + drain inbound.
 
         The wait is bounded by ``_startup_restore_drain_timeout_secs`` so that
@@ -12088,6 +12140,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     )
         self._startup_restore_tasks = []
         drained = await self._drain_startup_restore_queue()
+        if before_gate_release is not None:
+            # Webhook recovery must claim every dead durable owner while fresh
+            # HTTP admission is still closed. The recovery method schedules
+            # replay carriers synchronously; they run only after this coroutine
+            # releases the startup flag below.
+            await before_gate_release()
         self._startup_restore_in_progress = False
         if drained:
             logger.info("Drained %d inbound message(s) queued during startup restore", drained)
@@ -12493,6 +12551,34 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             logger.warning("Failed to enumerate resume-pending sessions: %s", exc)
             return 0
 
+        # Resolve the transport authority before touching the process-wide
+        # restart breaker.  A domain adapter can own recovery through a
+        # stronger ledger (webhook does), in which case its session marker is
+        # evidence for that ledger rather than permission for this generic
+        # replay path.  Counting such a marker here would let webhook-only
+        # restarts advance -- and eventually trip -- a breaker for work this
+        # scheduler is forbidden to run.
+        generic_candidates = []
+        for entry in candidates:
+            source = entry.origin
+            adapter = self._adapter_for_source(source)
+            if adapter is None:
+                logger.debug(
+                    "Skipping auto-resume for %s: adapter not ready for %s",
+                    entry.session_key,
+                    getattr(source.platform, "value", source.platform),
+                )
+                continue
+            if not getattr(adapter, "allows_automatic_session_resume", True):
+                logger.info(
+                    "Skipping generic auto-resume for %s: %s owns restart "
+                    "recovery through its operation ledger",
+                    entry.session_key,
+                    getattr(source.platform, "value", source.platform),
+                )
+                continue
+            generic_candidates.append((entry, adapter))
+
         # Defense-3 (#30719): break the SIGTERM-respawn loop. Only count this
         # boot when there are restart-interrupted sessions to resume — a clean
         # boot must not accrue toward the breaker. If too many such boots have
@@ -12503,7 +12589,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # is now in the loop). Defenses 1-2 cover the cron/CLI/terminal paths;
         # this catches every other SIGTERM source (e.g. a raw `terminal(
         # "launchctl kickstart ai.hermes.gateway")`).
-        if candidates:
+        if generic_candidates:
             try:
                 from gateway import restart_loop_guard as _rlg
 
@@ -12517,7 +12603,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         now = datetime.now()
         scheduled = 0
-        for entry in candidates:
+        for entry, adapter in generic_candidates:
             marker = entry.last_resume_marked_at or entry.updated_at
             if marker is not None and (now - marker).total_seconds() > window:
                 continue
@@ -12528,14 +12614,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 continue
 
             source = entry.origin
-            adapter = self._adapter_for_source(source)
-            if adapter is None:
-                logger.debug(
-                    "Skipping auto-resume for %s: adapter not ready for %s",
-                    entry.session_key,
-                    getattr(source.platform, "value", source.platform),
-                )
-                continue
 
             # Validate the session owner against the current allowlist
             # before auto-resuming. A session created before
@@ -12595,6 +12673,208 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 scheduled,
             )
         return scheduled
+
+    def _webhook_recovery_should_stop(self) -> bool:
+        """Return whether webhook recovery must stay fenced for shutdown."""
+
+        shutdown_event = getattr(self, "_shutdown_event", None)
+        running = getattr(self, "_running", None)
+        return bool(
+            running is False
+            or getattr(self, "_draining", False)
+            or getattr(self, "_external_drain_active", False)
+            or (
+                shutdown_event is not None
+                and callable(getattr(shutdown_event, "is_set", None))
+                and shutdown_event.is_set()
+            )
+        )
+
+    def _schedule_webhook_recovery_retry(self, adapter) -> None:
+        """Keep a fenced listener recoverable after a transient ledger fault."""
+
+        background_tasks = getattr(self, "_background_tasks", None)
+        if not isinstance(background_tasks, set):
+            return
+        if GatewayRunner._webhook_recovery_should_stop(self):
+            return
+        if (getattr(self, "adapters", None) or {}).get(Platform.WEBHOOK) is not adapter:
+            return
+
+        existing = getattr(self, "_webhook_recovery_retry_task", None)
+        if existing is not None and not existing.done():
+            if (
+                getattr(self, "_webhook_recovery_retry_adapter", None)
+                is adapter
+            ):
+                return
+            # A reconnect may replace the published adapter while its old
+            # recovery retry is sleeping.  The stale task must not prevent
+            # the replacement from establishing its own retry loop.
+            existing.cancel()
+
+        task = asyncio.create_task(self._retry_webhook_recovery(adapter))
+        self._webhook_recovery_retry_task = task
+        self._webhook_recovery_retry_adapter = adapter
+        background_tasks.add(task)
+
+        def cleanup(completed: asyncio.Task) -> None:
+            background_tasks.discard(completed)
+            if getattr(self, "_webhook_recovery_retry_task", None) is completed:
+                self._webhook_recovery_retry_task = None
+                self._webhook_recovery_retry_adapter = None
+
+        task.add_done_callback(cleanup)
+
+    async def _retry_webhook_recovery(self, adapter) -> None:
+        """Retry exact-adapter recovery with bounded exponential backoff."""
+
+        if getattr(adapter, "_recovery_last_error", False):
+            delay = _WEBHOOK_RECOVERY_RETRY_INITIAL_SECONDS
+        elif getattr(adapter, "_recovery_backlog_pending", False):
+            delay = (
+                0.0
+                if getattr(adapter, "_recovery_last_progress", False)
+                else _WEBHOOK_RECOVERY_PUMP_IDLE_SECONDS
+            )
+        else:
+            delay = _WEBHOOK_RECOVERY_RETRY_INITIAL_SECONDS
+        while (getattr(self, "adapters", None) or {}).get(Platform.WEBHOOK) is adapter:
+            if GatewayRunner._webhook_recovery_should_stop(self):
+                return
+            await asyncio.sleep(delay)
+            # Drain can begin while this retry is asleep.  Recheck before
+            # touching the durable ledger: stop() intentionally cancels the
+            # general background set only after adapter teardown, so relying
+            # on late cancellation here can otherwise schedule carriers or
+            # reopen admission during shutdown.
+            if GatewayRunner._webhook_recovery_should_stop(self):
+                return
+            if (
+                (getattr(self, "adapters", None) or {}).get(Platform.WEBHOOK)
+                is not adapter
+            ):
+                return
+            await self._recover_webhook_operations(trigger="retry")
+            if getattr(adapter, "_accepting_webhooks", False):
+                logger.info("Webhook operation recovery retry succeeded")
+                return
+            if getattr(adapter, "_recovery_last_error", False):
+                delay = min(
+                    max(delay, _WEBHOOK_RECOVERY_RETRY_INITIAL_SECONDS) * 2,
+                    _WEBHOOK_RECOVERY_RETRY_MAX_SECONDS,
+                )
+            elif getattr(adapter, "_recovery_backlog_pending", False):
+                delay = (
+                    0.0
+                    if getattr(adapter, "_recovery_last_progress", False)
+                    else _WEBHOOK_RECOVERY_PUMP_IDLE_SECONDS
+                )
+            else:
+                delay = _WEBHOOK_RECOVERY_RETRY_INITIAL_SECONDS
+
+    async def _recover_webhook_operations(self, *, trigger: str) -> int:
+        """Run webhook-owned recovery after runtime registries are authoritative."""
+
+        adapter = (getattr(self, "adapters", None) or {}).get(Platform.WEBHOOK)
+        recover = getattr(adapter, "recover_pending_operations", None)
+        if not callable(recover):
+            return 0
+        if GatewayRunner._webhook_recovery_should_stop(self):
+            try:
+                adapter._accepting_webhooks = False
+            except Exception:
+                pass
+            return 0
+        try:
+            recovered = int(await recover(trigger=trigger) or 0)
+            try:
+                adapter._recovery_last_error = False
+            except Exception:
+                pass
+            # connect() deliberately leaves runner-owned webhook listeners
+            # closed. Open this exact published adapter only after recovery
+            # has atomically claimed every replay-safe durable carrier.
+            if (getattr(self, "adapters", None) or {}).get(Platform.WEBHOOK) is adapter:
+                backlog = bool(
+                    getattr(adapter, "_recovery_backlog_pending", False)
+                )
+                adapter._accepting_webhooks = not (
+                    GatewayRunner._webhook_recovery_should_stop(self) or backlog
+                )
+                update_status = getattr(
+                    self, "_update_platform_runtime_status", None
+                )
+                if callable(update_status) and adapter._accepting_webhooks:
+                    update_status(
+                        Platform.WEBHOOK.value,
+                        platform_state="connected",
+                        error_code=None,
+                        error_message=None,
+                        needs_attention=False,
+                        retrying_since=None,
+                    )
+                elif callable(update_status) and backlog:
+                    update_status(
+                        Platform.WEBHOOK.value,
+                        platform_state="retrying",
+                        error_code="webhook_recovery_pending",
+                        error_message="Durable webhook recovery is still in progress",
+                    )
+                if backlog:
+                    schedule_retry = getattr(
+                        self, "_schedule_webhook_recovery_retry", None
+                    )
+                    if callable(schedule_retry):
+                        schedule_retry(adapter)
+                else:
+                    retry_task = getattr(
+                        self, "_webhook_recovery_retry_task", None
+                    )
+                    current_task = asyncio.current_task()
+                    if (
+                        retry_task is not None
+                        and retry_task is not current_task
+                        and not retry_task.done()
+                    ):
+                        retry_task.cancel()
+            return recovered
+        except Exception:
+            # A listener with unreconciled durable ownership cannot safely
+            # admit fresh operations: identical retries could remain stuck
+            # behind dead owners, while new work would obscure the outage.
+            # Keep the transport connected for diagnostics but close its
+            # admission gate until an operator restarts or reconnects it.
+            try:
+                adapter._accepting_webhooks = False
+                adapter._recovery_last_error = True
+            except Exception:
+                pass
+            update_status = getattr(self, "_update_platform_runtime_status", None)
+            if callable(update_status):
+                update_status(
+                    Platform.WEBHOOK.value,
+                    platform_state="retrying",
+                    error_code="webhook_recovery_failed",
+                    error_message="Durable webhook recovery failed",
+                )
+            logger.exception("Webhook operation recovery failed (%s)", trigger)
+            schedule_retry = getattr(self, "_schedule_webhook_recovery_retry", None)
+            if (
+                callable(schedule_retry)
+                and not GatewayRunner._webhook_recovery_should_stop(self)
+            ):
+                schedule_retry(adapter)
+            return 0
+
+    async def _finish_startup_with_webhook_recovery(self) -> None:
+        """Claim webhook recovery before releasing fresh startup admission."""
+
+        await self._finish_startup_restore(
+            before_gate_release=lambda: self._recover_webhook_operations(
+                trigger="startup"
+            )
+        )
 
     def _startup_should_abort(self) -> bool:
         return (
@@ -13212,7 +13492,31 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 continue
             enabled_platform_count += 1
 
-            adapter = self._create_adapter(platform, platform_config)
+            try:
+                adapter = self._create_adapter(platform, platform_config)
+            except Exception as exc:
+                classified = _classify_adapter_construction_failure(platform, exc)
+                if classified is None:
+                    # Do not launder arbitrary constructor bugs into a parked
+                    # configuration failure.  The pre-existing fail-loud path
+                    # remains authoritative for every untyped exception.
+                    raise
+                error_code, error_message = classified
+                logger.error(
+                    "✗ %s configuration error: %s",
+                    platform.value,
+                    error_message,
+                )
+                self._update_platform_runtime_status(
+                    platform.value,
+                    platform_state="fatal",
+                    error_code=error_code,
+                    error_message=error_message,
+                )
+                startup_nonretryable_errors.append(
+                    f"{platform.value}: {error_message}"
+                )
+                continue
             if not adapter:
                 # Distinguish between missing builtin deps and missing plugin
                 _pval = platform.value
@@ -13360,10 +13664,29 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if hasattr(adapter, "_voice_input_callback"):
                     adapter._voice_input_callback = self._handle_voice_channel_input
                 connected_count += 1
-                self._update_platform_runtime_status(
-                    platform.value, platform_state="connected", error_code=None, error_message=None,
-                )
-                logger.info("\u2713 %s connected", platform.value)
+                if platform is Platform.WEBHOOK:
+                    # The socket is bound, but the shared intake gate stays
+                    # closed until startup recovery fences/claims every durable
+                    # carrier.  Publishing "connected" here makes runtime
+                    # health lie while every POST correctly returns 503.
+                    self._update_platform_runtime_status(
+                        platform.value,
+                        platform_state="retrying",
+                        error_code="webhook_recovery_pending",
+                        error_message="Durable webhook recovery is pending",
+                    )
+                    logger.info(
+                        "\u2713 %s listener connected; durable recovery pending",
+                        platform.value,
+                    )
+                else:
+                    self._update_platform_runtime_status(
+                        platform.value,
+                        platform_state="connected",
+                        error_code=None,
+                        error_message=None,
+                    )
+                    logger.info("\u2713 %s connected", platform.value)
             else:  # outcome == "failed"
                 logger.warning("\u2717 %s failed to connect", platform.value)
                 # Defensive cleanup: a failed connect() may have allocated resources
@@ -13613,7 +13936,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # confirmed-delivered has its answer in the ledger — redelivering it
         # is strictly cheaper and more correct than re-running the whole turn.
         self._schedule_resume_pending_sessions()
-        await self._finish_startup_restore()
+        await self._finish_startup_with_webhook_recovery()
 
         # Surface state.db init failures to the user's messaging platforms
         # so they know persistence is broken before losing data (#88235).
@@ -14838,6 +15161,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
 
                 adapter = None
+                published = False
                 try:
                     adapter = self._create_adapter(platform, platform_config)
                     if not adapter:
@@ -14866,23 +15190,65 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     success = await self._connect_adapter_with_timeout(
                         adapter, platform, is_reconnect=True
                     )
+                    # stop() flips both flags before adapter teardown, while a
+                    # reconnect connect() may still be in flight.  Publishing
+                    # after that boundary would put a fresh adapter behind the
+                    # teardown snapshot and could run webhook recovery during
+                    # drain.  The still-unowned candidate must be disposed here.
+                    if not self._running or getattr(self, "_draining", False):
+                        await _dispose_unused_adapter(adapter)
+                        return
                     if success:
                         self.adapters[platform] = adapter
+                        published = True
                         self._sync_voice_mode_state_to_adapter(adapter)
                         # Wire voice input callback on reconnect as well (#60623).
                         if hasattr(adapter, "_voice_input_callback"):
                             adapter._voice_input_callback = self._handle_voice_channel_input
                         self.delivery_router.adapters = self.adapters
                         del self._failed_platforms[platform]
-                        self._update_platform_runtime_status(
-                            platform.value,
-                            platform_state="connected",
-                            error_code=None,
-                            error_message=None,
-                            needs_attention=False,
-                            retrying_since=None,
+                        if platform is Platform.WEBHOOK:
+                            self._update_platform_runtime_status(
+                                platform.value,
+                                platform_state="retrying",
+                                error_code="webhook_recovery_pending",
+                                error_message=(
+                                    "Durable webhook recovery is pending"
+                                ),
+                                needs_attention=False,
+                                retrying_since=None,
+                            )
+                            logger.info(
+                                "✓ %s listener reconnected; durable recovery pending",
+                                platform.value,
+                            )
+                        else:
+                            self._update_platform_runtime_status(
+                                platform.value,
+                                platform_state="connected",
+                                error_code=None,
+                                error_message=None,
+                                needs_attention=False,
+                                retrying_since=None,
+                            )
+                            logger.info(
+                                "✓ %s reconnected successfully", platform.value
+                            )
+                        await self._recover_webhook_operations(
+                            trigger=f"reconnect:{platform.value}"
                         )
-                        logger.info("✓ %s reconnected successfully", platform.value)
+                        if platform is Platform.WEBHOOK:
+                            if getattr(adapter, "_accepting_webhooks", False):
+                                logger.info(
+                                    "✓ %s durable recovery completed",
+                                    platform.value,
+                                )
+                            else:
+                                logger.warning(
+                                    "%s listener remains fenced while durable "
+                                    "recovery retries",
+                                    platform.value,
+                                )
 
                         # Final responses rejected while this adapter was down
                         # are still owned by this live process, so startup
@@ -14972,8 +15338,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         # etc.) already drop out of the queue via the
                         # `not fatal_error_retryable` branch above, so anything
                         # reaching here is by definition retryable.
+                except asyncio.CancelledError:
+                    # Cancellation while connect() is in flight bypasses the
+                    # Exception arm on modern Python.  Dispose only while this
+                    # watcher still owns the candidate; once published, normal
+                    # gateway shutdown owns adapter teardown.
+                    if adapter is not None and not published:
+                        await _dispose_unused_adapter(adapter)
+                    raise
                 except Exception as e:
-                    if adapter is not None:
+                    if adapter is not None and not published:
                         # An exception escaping the connect call path
                         # (DNS timeout, aiohttp server.start() crash, etc.)
                         # leaves the adapter in the same unowned state as
@@ -14981,6 +15355,27 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         # resources don't accumulate while the watcher
                         # keeps retrying.
                         await _dispose_unused_adapter(adapter)
+                    classified = _classify_adapter_construction_failure(
+                        platform,
+                        e,
+                    )
+                    if classified is not None:
+                        error_code, error_message = classified
+                        self._update_platform_runtime_status(
+                            platform.value,
+                            platform_state="fatal",
+                            error_code=error_code,
+                            error_message=error_message,
+                        )
+                        logger.warning(
+                            "Reconnect %s: non-retryable configuration error "
+                            "(%s), removing from retry queue",
+                            platform.value,
+                            error_message,
+                        )
+                        if self._failed_platforms.get(platform) is info:
+                            del self._failed_platforms[platform]
+                        continue
                     self._update_platform_runtime_status(
                         platform.value,
                         platform_state="retrying",
@@ -16015,6 +16410,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 "✓ %s reconnected (profile: %s)",
                                 platform.value,
                                 profile_name,
+                            )
+                            await self._recover_webhook_operations(
+                                trigger=(
+                                    f"profile-reconnect:{profile_name}:{platform.value}"
+                                )
                             )
                             await self._redeliver_failed_obligations_for_platform(
                                 platform, profile=profile_name
@@ -22739,7 +23139,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         voice_mode = self._voice_mode.get(voice_key)
         is_voice_input = (event.message_type == MessageType.VOICE)
 
-        adapter = self.adapters.get(event.source.platform)
+        adapter = self._adapter_for_source(event.source)
+        if getattr(adapter, "owns_final_delivery_ledger", False) is True:
+            # That adapter owns one exact durable final carrier. Generic
+            # auto-TTS would add a voice effect before Base hands over the
+            # prepared text, and an inherited send_voice fallback could turn
+            # an audio failure into the text that consumes the carrier.
+            return False
+
         adapter_auto_tts = False
         if adapter and hasattr(adapter, "_should_auto_tts_for_chat"):
             try:
@@ -22798,6 +23205,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         audio_path = None
         actual_paths: List[str] = []
         try:
+            adapter = self._adapter_for_source(event.source)
+            if getattr(adapter, "owns_final_delivery_ledger", False) is True:
+                # Defense in depth for direct/future callers that bypass the
+                # decision helper: synthesis itself is outside the adapter's
+                # one-carrier final-delivery authority.
+                return
+
             from tools.tts_tool import text_to_speech_tool, _strip_markdown_for_tts
 
             tts_text = _strip_markdown_for_tts(text)
@@ -22833,8 +23247,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if not result.get("success") or not actual_paths:
                 logger.warning("Auto voice reply TTS failed: %s", result.get("error"))
                 return
-
-            adapter = self._adapter_for_source(event.source)
 
             # If connected to a voice channel, play there instead of sending a file
             guild_id = self._get_guild_id(event)
@@ -23102,13 +23514,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 prompt, source, task_id, event_message_id, media_urls, media_types,
             )
 
-    def _resolve_enabled_toolsets_for_source(
+    def _resolve_toolset_authority_for_source(
         self,
         user_config: dict,
         source: "SessionSource",
         platform_key: str,
-    ) -> list:
-        """Resolve enabled toolsets for an agent run, honoring per-source overrides.
+    ) -> tuple[list, bool, bool]:
+        """Resolve toolsets and retain the per-source authority verdict.
 
         Asks the receiving adapter for a ``toolsets_for_source()`` override
         (e.g. per-route webhook toolsets). When present, the override list is
@@ -23117,25 +23529,86 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         so unknown names and platform-restricted toolsets are dropped rather
         than trusted. When absent, falls back to standard
         ``platform_toolsets.<platform>`` resolution.
+
+        Returns ``(enabled_toolsets, has_source_override, resolution_failed)``.
+        The latter two values matter at delegation boundaries: a remote
+        executor that cannot carry the exact source override must not silently
+        replace it with its own process-level toolsets, and an adapter error
+        must not be mistaken for "no override" there.
         """
         from hermes_cli.tools_config import _get_platform_tools
 
         override = None
+        resolution_failed = False
         try:
             adapter = self._adapter_for_source(source)
+            if (
+                adapter is None
+                and platform_key == Platform.WEBHOOK.value
+            ):
+                # Every admitted webhook grant lives in its transport's
+                # durable operation ledger. If that adapter is no longer
+                # registered, mutable platform defaults are not a substitute
+                # for the missing per-operation authority.
+                return [], True, True
             if adapter is not None:
+                exact_resolver = getattr(adapter, "resolved_toolsets_for_source", None)
+                if callable(exact_resolver):
+                    exact = exact_resolver(source)
+                    if exact is not None:
+                        if not isinstance(exact, list) or any(
+                            not isinstance(value, str) or not value for value in exact
+                        ):
+                            return [], True, True
+                        # This is an immutable, admission-time resolved carrier.
+                        # Re-running _get_platform_tools here could add a newly
+                        # enabled MCP server or plugin default and widen it.
+                        return list(dict.fromkeys(exact)), True, False
                 override = adapter.toolsets_for_source(source)
         except Exception:
-            override = None
+            resolution_failed = True
+            logger.warning(
+                "Failed to resolve per-source toolset authority for %s/%s",
+                platform_key,
+                getattr(source, "chat_id", ""),
+                exc_info=True,
+            )
 
-        if override and isinstance(override, list):
+        if isinstance(override, list):
+            if not override:
+                return [], True, False
             cfg = dict(user_config)
             pts = dict(cfg.get("platform_toolsets") or {})
             pts[platform_key] = [str(t) for t in override]
             cfg["platform_toolsets"] = pts
-            return sorted(_get_platform_tools(cfg, platform_key))
+            return sorted(_get_platform_tools(cfg, platform_key)), True, False
 
-        return sorted(_get_platform_tools(user_config, platform_key))
+        return (
+            sorted(_get_platform_tools(user_config, platform_key)),
+            False,
+            resolution_failed,
+        )
+
+    def _resolve_enabled_toolsets_for_source(
+        self,
+        user_config: dict,
+        source: "SessionSource",
+        platform_key: str,
+    ) -> list:
+        """Resolve enabled toolsets for a local agent run."""
+        enabled_toolsets, _, resolution_failed = (
+            self._resolve_toolset_authority_for_source(
+                user_config,
+                source,
+                platform_key,
+            )
+        )
+        if resolution_failed:
+            # A per-source authority resolver is an admission boundary. An
+            # exception cannot mean "use the broader live platform default"
+            # for local execution any more than it can at the proxy boundary.
+            return []
+        return enabled_toolsets
 
     async def _run_background_task_inner(
         self,
@@ -28426,6 +28899,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if _plat_streaming is None
             else bool(_plat_streaming)
         )
+        # The proxy's SSE response is only an inbound transport for assembling
+        # the remote result.  A webhook operation still owns exactly one
+        # durable outbound final, so it must never create the downstream
+        # GatewayStreamConsumer that previews/edits platform messages.  The
+        # source-authority gate currently rejects webhook proxy delegation;
+        # keep this execution-boundary guard for any future authority carrier
+        # that makes the path reachable.
+        if source.platform == Platform.WEBHOOK:
+            _streaming_enabled = False
 
         _thread_metadata: Optional[Dict[str, Any]] = self._thread_metadata_for_source(source, event_message_id)
 
@@ -28745,22 +29227,67 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 name = get_active_profile_name() or "default"
             
             profile_dir = get_profile_dir(name)
-            # Warn if an explicit profile doesn't exist on disk
+            # An explicit/stamped profile is durable execution authority. It
+            # must never degrade to the process-global home after that profile
+            # is removed or becomes unreadable: doing so would substitute a
+            # different profile's config, memory, tools, and credentials.
             if explicit_profile and not profile_exists(name):
                 logger.warning(
                     "Profile %r does not exist for source %s/%s (guild_id=%s), "
-                    "falling back to global HERMES_HOME",
+                    "rejecting explicit profile authority",
                     explicit_profile,
                     source.platform.value,
                     source.chat_id,
                     getattr(source, "guild_id", None),
                 )
-                return get_hermes_home()
+                raise ProfileRouteRejected(explicit_profile)
+            if explicit_profile and (
+                getattr(getattr(self, "config", None), "multiplex_profiles", False)
+                is True
+            ):
+                try:
+                    served = {
+                        profile_name
+                        for profile_name, _home in _multiplex_profile_homes(
+                            self.config
+                        )
+                    }
+                except Exception as exc:
+                    logger.warning(
+                        "Failed to resolve served profiles for explicit source "
+                        "%s/%s, rejecting profile %s",
+                        source.platform.value,
+                        source.chat_id,
+                        explicit_profile,
+                        exc_info=True,
+                    )
+                    raise ProfileRouteRejected(explicit_profile) from exc
+                if name not in served:
+                    logger.warning(
+                        "Profile %r is no longer served for source %s/%s "
+                        "(guild_id=%s), rejecting explicit profile authority",
+                        explicit_profile,
+                        source.platform.value,
+                        source.chat_id,
+                        getattr(source, "guild_id", None),
+                    )
+                    raise ProfileRouteRejected(explicit_profile)
             return profile_dir
         except ProfileRouteRejected:
             raise
-        except Exception:
+        except Exception as exc:
             # Catch normalization errors, path errors, etc.
+            if explicit_profile:
+                logger.warning(
+                    "Failed to resolve explicit profile directory for %s/%s "
+                    "(guild_id=%s), rejecting profile %s",
+                    source.platform.value,
+                    source.chat_id,
+                    getattr(source, "guild_id", None),
+                    explicit_profile,
+                    exc_info=True,
+                )
+                raise ProfileRouteRejected(explicit_profile) from exc
             logger.warning(
                 "Failed to resolve profile directory for source %s/%s (guild_id=%s), "
                 "falling back to global HERMES_HOME: %s",
@@ -28804,6 +29331,51 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """
         # ---- Proxy mode: delegate to remote API server ----
         if self._get_proxy_url():
+            # The OpenAI-compatible proxy endpoint currently chooses
+            # ``platform_toolsets.api_server`` in the remote process and has
+            # no request-bound carrier for a source-specific override. Resolve
+            # the admitted source authority before crossing that boundary and
+            # fail closed when it cannot be preserved. In particular, a
+            # webhook route pinned to a constrained toolset must never be
+            # widened to the proxy server's process-level capabilities.
+            proxy_user_config = _load_gateway_config()
+            proxy_platform_key = _platform_config_key(source.platform)
+            (
+                _proxy_enabled_toolsets,
+                has_source_toolset_override,
+                source_toolset_resolution_failed,
+            ) = self._resolve_toolset_authority_for_source(
+                proxy_user_config,
+                source,
+                proxy_platform_key,
+            )
+            if has_source_toolset_override or source_toolset_resolution_failed:
+                failure_reason = (
+                    "proxy_source_toolset_resolution_failed"
+                    if source_toolset_resolution_failed
+                    else "proxy_source_toolsets_unsupported"
+                )
+                logger.error(
+                    "Refusing proxy delegation for %s/%s: source toolset "
+                    "authority cannot be enforced by the remote API "
+                    "(reason=%s, resolved=%s)",
+                    proxy_platform_key,
+                    source.chat_id,
+                    failure_reason,
+                    _proxy_enabled_toolsets,
+                )
+                return {
+                    "final_response": (
+                        "⚠️ Proxy mode cannot enforce this source's toolset policy; "
+                        "the request was not delegated."
+                    ),
+                    "messages": [],
+                    "api_calls": 0,
+                    "tools": [],
+                    "failed": True,
+                    "completed": False,
+                    "failure_reason": failure_reason,
+                }
             return await self._run_agent_via_proxy(
                 message=message,
                 context_prompt=context_prompt,

--- a/hermes_cli/subcommands/webhook.py
+++ b/hermes_cli/subcommands/webhook.py
@@ -6,7 +6,38 @@ Handler injected to avoid importing ``main``.
 
 from __future__ import annotations
 
+import argparse
 from typing import Callable
+
+
+def _non_negative_fd(value: str) -> int:
+    """Parse one file descriptor without accepting signs or whitespace."""
+
+    if not value.isascii() or not value.isdecimal():
+        raise argparse.ArgumentTypeError("must be a non-negative integer")
+    try:
+        fd = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be a non-negative integer") from exc
+    if fd < 0:
+        raise argparse.ArgumentTypeError("must be a non-negative integer")
+    return fd
+
+
+def _add_profile_flag(parser) -> None:
+    parser.add_argument(
+        "--profile",
+        default="",
+        help="Profile whose webhook subscriptions to manage (default: active profile)",
+    )
+
+
+def _add_json_flag(parser) -> None:
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON (secrets are masked on read)",
+    )
 
 
 def build_webhook_parser(subparsers, *, cmd_webhook: Callable) -> None:
@@ -17,12 +48,12 @@ def build_webhook_parser(subparsers, *, cmd_webhook: Callable) -> None:
     webhook_parser = subparsers.add_parser(
         "webhook",
         help="Manage dynamic webhook subscriptions",
-        description="Create, list, and remove webhook subscriptions for event-driven agent activation",
+        description="Create, list, and manage webhook subscriptions for event-driven agent activation",
     )
     webhook_subparsers = webhook_parser.add_subparsers(dest="webhook_action")
 
     wh_sub = webhook_subparsers.add_parser(
-        "subscribe", aliases=["add"], help="Create a webhook subscription"
+        "subscribe", aliases=["add", "create"], help="Create a webhook subscription"
     )
     wh_sub.add_argument("name", help="Route name (used in URL: /webhooks/<name>)")
     wh_sub.add_argument(
@@ -44,8 +75,8 @@ def build_webhook_parser(subparsers, *, cmd_webhook: Callable) -> None:
     wh_sub.add_argument(
         "--route-profile",
         dest="route_profile",
-        default="default",
-        help="Gateway profile authorized to receive this route (default: default)",
+        default="",
+        help="Gateway profile authorized to receive this route (default: managed profile)",
     )
     wh_sub.add_argument("--description", default="", help="What this subscription does")
     wh_sub.add_argument(
@@ -61,8 +92,16 @@ def build_webhook_parser(subparsers, *, cmd_webhook: Callable) -> None:
         default="",
         help="Target chat ID for cross-platform delivery",
     )
-    wh_sub.add_argument(
+    secret_group = wh_sub.add_mutually_exclusive_group()
+    secret_group.add_argument(
         "--secret", default="", help="HMAC secret (auto-generated if omitted)"
+    )
+    secret_group.add_argument(
+        "--secret-fd",
+        type=_non_negative_fd,
+        default=None,
+        metavar="FD",
+        help="Read HMAC secret from FD (UTF-8, max 4096 bytes; avoids argv exposure)",
     )
     wh_sub.add_argument(
         "--deliver-only",
@@ -80,15 +119,66 @@ def build_webhook_parser(subparsers, *, cmd_webhook: Callable) -> None:
         "starts returns HTTP 500 as indeterminate and fences same-delivery "
         "retries.",
     )
+    wh_sub.add_argument(
+        "--replace",
+        action="store_true",
+        help="Overwrite an existing route of the same name (default: error)",
+    )
+    _add_profile_flag(wh_sub)
+    _add_json_flag(wh_sub)
 
-    webhook_subparsers.add_parser(
+    wh_list = webhook_subparsers.add_parser(
         "list", aliases=["ls"], help="List all dynamic subscriptions"
     )
+    _add_profile_flag(wh_list)
+    _add_json_flag(wh_list)
+
+    wh_show = webhook_subparsers.add_parser(
+        "show", help="Show one subscription's details"
+    )
+    wh_show.add_argument("name", help="Subscription name to show")
+    _add_profile_flag(wh_show)
+    _add_json_flag(wh_show)
+
+    wh_update = webhook_subparsers.add_parser(
+        "update", help="Patch fields on an existing subscription"
+    )
+    wh_update.add_argument("name", help="Subscription name to update")
+    wh_update.add_argument("--prompt", default="", help="New prompt template")
+    wh_update.add_argument(
+        "--events", default="", help="New comma-separated event types"
+    )
+    wh_update.add_argument("--description", default="", help="New description")
+    wh_update.add_argument(
+        "--skills", default="", help="New comma-separated skill names"
+    )
+    wh_update.add_argument("--deliver", default="", help="New delivery target")
+    wh_update.add_argument("--deliver-chat-id", default="", help="New target chat ID")
+    _add_profile_flag(wh_update)
+
+    wh_enable = webhook_subparsers.add_parser(
+        "enable", help="Enable a disabled subscription"
+    )
+    wh_enable.add_argument("name", help="Subscription name to enable")
+    _add_profile_flag(wh_enable)
+
+    wh_disable = webhook_subparsers.add_parser(
+        "disable", help="Disable a subscription without removing it"
+    )
+    wh_disable.add_argument("name", help="Subscription name to disable")
+    _add_profile_flag(wh_disable)
+
+    wh_rotate = webhook_subparsers.add_parser(
+        "rotate-secret", help="Rotate a subscription's HMAC secret"
+    )
+    wh_rotate.add_argument("name", help="Subscription name to rotate")
+    _add_profile_flag(wh_rotate)
 
     wh_rm = webhook_subparsers.add_parser(
         "remove", aliases=["rm"], help="Remove a subscription"
     )
     wh_rm.add_argument("name", help="Subscription name to remove")
+    _add_profile_flag(wh_rm)
 
     wh_test = webhook_subparsers.add_parser(
         "test", help="Send a test POST to a webhook route"
@@ -97,5 +187,6 @@ def build_webhook_parser(subparsers, *, cmd_webhook: Callable) -> None:
     wh_test.add_argument(
         "--payload", default="", help="JSON payload to send (default: test payload)"
     )
+    _add_profile_flag(wh_test)
 
     webhook_parser.set_defaults(func=cmd_webhook)

--- a/hermes_cli/subcommands/webhook.py
+++ b/hermes_cli/subcommands/webhook.py
@@ -31,6 +31,22 @@ def build_webhook_parser(subparsers, *, cmd_webhook: Callable) -> None:
     wh_sub.add_argument(
         "--events", default="", help="Comma-separated event types to accept"
     )
+    wh_sub.add_argument(
+        "--provider",
+        default="github",
+        help="Webhook provider contract (default: github)",
+    )
+    wh_sub.add_argument(
+        "--signature-mode",
+        default="",
+        help="Explicit verifier override for providers that require one",
+    )
+    wh_sub.add_argument(
+        "--route-profile",
+        dest="route_profile",
+        default="default",
+        help="Gateway profile authorized to receive this route (default: default)",
+    )
     wh_sub.add_argument("--description", default="", help="What this subscription does")
     wh_sub.add_argument(
         "--skills", default="", help="Comma-separated skill names to load"
@@ -59,8 +75,10 @@ def build_webhook_parser(subparsers, *, cmd_webhook: Callable) -> None:
         "--script",
         default="",
         help="Filter/transform script under ~/.hermes/scripts/. The route "
-        "payload is passed as JSON on stdin; empty stdout, [SILENT], or a "
-        "nonzero exit code ignores the webhook.",
+        "payload is passed as JSON on stdin; empty stdout or [SILENT] "
+        "suppresses delivery. A timeout or nonzero exit after execution "
+        "starts returns HTTP 500 as indeterminate and fences same-delivery "
+        "retries.",
     )
 
     webhook_subparsers.add_parser(

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -14046,12 +14046,22 @@ async def clear_pending_pairing(profile: Optional[str] = None):
 
 
 def _webhook_route_summary(name: str, route: Dict[str, Any], base_url: str) -> Dict[str, Any]:
+    # Project only the known non-secret destination field. Never return the
+    # raw deliver_extra bag: future target fields may carry sensitive values.
+    deliver_chat_id = None
+    deliver_extra = route.get("deliver_extra")
+    if isinstance(deliver_extra, dict):
+        raw_chat_id = deliver_extra.get("chat_id")
+        if isinstance(raw_chat_id, str):
+            deliver_chat_id = raw_chat_id
+
     return {
         "name": name,
         "description": route.get("description", ""),
         "events": list(route.get("events") or []),
         "deliver": route.get("deliver", "log"),
         "deliver_only": bool(route.get("deliver_only")),
+        "deliver_chat_id": deliver_chat_id,
         "prompt": route.get("prompt", ""),
         "script": route.get("script", ""),
         "skills": list(route.get("skills") or []),

--- a/hermes_cli/webhook.py
+++ b/hermes_cli/webhook.py
@@ -2,15 +2,19 @@
 
 Usage:
     hermes webhook subscribe <name> [options]
-    hermes webhook list
+    hermes webhook list [--json]
+    hermes webhook show <name> [--json]
+    hermes webhook update <name> [options]
+    hermes webhook enable|disable|rotate-secret <name>
     hermes webhook remove <name>
     hermes webhook test <name> [--payload '{"key": "value"}']
 
-Subscriptions persist to ~/.hermes/webhook_subscriptions.json and are
-hot-reloaded by the webhook adapter without a gateway restart.
+Subscriptions persist in each profile's canonical route store and are
+hot-reloaded by the sharded webhook adapter without a gateway restart.
 """
 
 import base64
+import copy
 import hashlib
 import hmac
 import ipaddress
@@ -18,79 +22,183 @@ import json
 import os
 import re
 import secrets
-import tempfile
 import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, Mapping
 from urllib.parse import urlsplit
 
+from gateway.platforms.webhook_models import (
+    WebhookRouteDocument,
+    from_persisted_route,
+    to_persisted_route,
+)
+from gateway.platforms.webhook_store import (
+    WebhookRouteStore,
+    WebhookRouteStoreError,
+)
 from hermes_constants import display_hermes_home
-from utils import atomic_replace
 from hermes_cli.config import cfg_get
 
 
-_SUBSCRIPTIONS_FILENAME = "webhook_subscriptions.json"
-_SUBSCRIPTIONS_FILE_MODE = 0o600
+_MAX_SECRET_BYTES = 4096
 _LEGACY_CLI_DESCRIPTION_PREFIX = "Agent-created subscription:"
+
+
+class WebhookCommandError(RuntimeError):
+    """A webhook management command cannot proceed safely."""
+
+
+class ConcurrentWebhookUpdateError(WebhookCommandError):
+    """A route changed divergently after a caller loaded its snapshot."""
+
+
+class _SubscriptionSnapshot(dict[str, dict]):
+    """Compatibility view retaining a baseline for an atomic three-way save."""
+
+    def __init__(self, value: Mapping[str, dict], *, profile: str):
+        super().__init__(copy.deepcopy(dict(value)))
+        self._baseline = copy.deepcopy(dict(value))
+        self._profile = profile
+
+
+def _merge_subscription_snapshot(
+    baseline: Mapping[str, dict],
+    desired: Mapping[str, dict],
+    current: Mapping[str, dict],
+) -> dict[str, dict]:
+    """Preserve unrelated writes and reject divergent same-route changes."""
+
+    missing = object()
+    merged: dict[str, dict] = {}
+    conflicts: list[str] = []
+    for name in sorted(set(baseline) | set(desired) | set(current)):
+        before = baseline.get(name, missing)
+        wanted = desired.get(name, missing)
+        live = current.get(name, missing)
+        if wanted == before:
+            chosen = live
+        elif live == before or live == wanted:
+            chosen = wanted
+        else:
+            conflicts.append(name)
+            continue
+        if chosen is not missing:
+            merged[name] = copy.deepcopy(chosen)
+    if conflicts:
+        raise ConcurrentWebhookUpdateError(
+            "Concurrent webhook route update conflict: " + ", ".join(conflicts)
+        )
+    return merged
 
 
 def _hermes_home() -> Path:
     from hermes_constants import get_hermes_home
+
     return get_hermes_home()
 
 
-def _subscriptions_path() -> Path:
-    return _hermes_home() / _SUBSCRIPTIONS_FILENAME
+def _profile_root(profile: str | None = None) -> Path:
+    """Return the exact sharded root owned by a subscription profile."""
+
+    return _route_store(profile).profile_root
 
 
-def _load_subscriptions() -> Dict[str, dict]:
-    path = _subscriptions_path()
-    if not path.exists():
-        return {}
-    try:
-        data = json.loads(path.read_text(encoding="utf-8"))
-        return data if isinstance(data, dict) else {}
-    except Exception:
-        return {}
+def _route_store(profile: str | None = None) -> WebhookRouteStore:
+    """Build the canonical locked store for an explicit or active profile."""
 
+    from hermes_constants import get_default_hermes_root
 
-def _save_subscriptions(subs: Dict[str, dict]) -> None:
-    path = _subscriptions_path()
-    path.parent.mkdir(parents=True, exist_ok=True)
-    # webhook_subscriptions.json contains per-route HMAC secrets — write
-    # via tempfile + chmod 0o600 before the atomic rename so a permissive
-    # umask cannot leave the secrets readable to other local users in the
-    # window between create and rename.
-    fd, tmp_name = tempfile.mkstemp(
-        prefix=f".{path.name}.",
-        suffix=".tmp",
-        dir=path.parent,
-        text=True,
+    return WebhookRouteStore(
+        get_default_hermes_root(),
+        profile=_storage_profile_name(profile),
     )
-    tmp_path = Path(tmp_name)
-    try:
-        with os.fdopen(fd, "w", encoding="utf-8") as fh:
-            json.dump(subs, fh, indent=2, ensure_ascii=False)
-            fh.flush()
-            os.fsync(fh.fileno())
-        os.chmod(tmp_path, _SUBSCRIPTIONS_FILE_MODE)
-        atomic_replace(tmp_path, path)
-        # Re-assert after rename in case the destination existed with a
-        # broader mode and atomic_replace preserved it.
-        os.chmod(path, _SUBSCRIPTIONS_FILE_MODE)
-    except Exception:
-        try:
-            tmp_path.unlink(missing_ok=True)
-        except OSError:
-            pass
-        raise
+
+
+def _subscriptions_path(profile: str | None = None) -> Path:
+    return _route_store(profile).path
+
+
+def _load_subscriptions(profile: str | None = None) -> Dict[str, dict]:
+    """Return lossless canonical projections for compatibility callers."""
+
+    store = _route_store(profile)
+    current = {name: to_persisted_route(route) for name, route in store.load().items()}
+    return _SubscriptionSnapshot(current, profile=store.profile)
+
+
+def _save_subscriptions(
+    subs: Dict[str, dict],
+    profile: str | None = None,
+) -> None:
+    requested_profile = _storage_profile_name(profile)
+    if isinstance(subs, _SubscriptionSnapshot):
+        if profile is not None and requested_profile != subs._profile:
+            raise ValueError("webhook subscription snapshot belongs to another profile")
+        store = _route_store(subs._profile)
+        baseline = copy.deepcopy(subs._baseline)
+        desired = copy.deepcopy(dict(subs))
+
+        def _mutate(
+            current_documents: Dict[str, WebhookRouteDocument],
+        ) -> Dict[str, WebhookRouteDocument]:
+            current = {
+                name: to_persisted_route(route)
+                for name, route in current_documents.items()
+            }
+            merged = _merge_subscription_snapshot(baseline, desired, current)
+            return {
+                name: _new_route_document(name, route, profile=store.profile)
+                for name, route in merged.items()
+            }
+
+        saved = store.update(_mutate)
+        refreshed = {name: to_persisted_route(route) for name, route in saved.items()}
+        subs.clear()
+        subs.update(copy.deepcopy(refreshed))
+        subs._baseline = copy.deepcopy(refreshed)
+        return
+
+    store = _route_store(profile)
+    documents = {
+        name: _new_route_document(name, route, profile=store.profile)
+        for name, route in subs.items()
+    }
+    store.save(documents)
+
+
+def _new_route_document(
+    name: str,
+    route: Mapping[str, Any],
+    *,
+    profile: str,
+) -> WebhookRouteDocument:
+    """Validate a newly authored mapping through the canonical document."""
+
+    raw = dict(route)
+    raw.pop("name", None)
+    embedded_profile = raw.get("profile", profile)
+    if embedded_profile != profile:
+        raise ValueError("webhook route belongs to a different profile store")
+    raw["profile"] = profile
+    if "deliveries" not in raw:
+        delivery: dict[str, Any] = {}
+        if raw.get("deliver") is not None:
+            delivery["target"] = raw["deliver"]
+        extra = raw.get("deliver_extra")
+        if isinstance(extra, Mapping):
+            delivery.update(extra)
+        elif extra is not None:
+            delivery["extra"] = extra
+        raw["deliveries"] = [delivery] if delivery else []
+    return WebhookRouteDocument.model_validate({"name": name, **raw})
 
 
 def _get_webhook_config() -> dict:
     """Load webhook platform config. Returns {} if not configured."""
     try:
         from hermes_cli.config import load_config
+
         cfg = load_config()
         return cfg_get(cfg, "platforms", "webhook", default={})
     except Exception:
@@ -173,6 +281,100 @@ def _require_webhook_enabled() -> bool:
         return True
     print(_setup_hint())
     return False
+
+
+def _args_profile(args) -> str | None:
+    """Return the optional profile store selected by a management command."""
+
+    raw = getattr(args, "profile", "") or ""
+    if not isinstance(raw, str):
+        raise WebhookCommandError("Invalid webhook profile selector.")
+    if not raw.strip():
+        return None
+    try:
+        return _normalize_subscription_profile(raw)
+    except ValueError as exc:
+        raise WebhookCommandError(f"Invalid webhook profile: {exc}") from exc
+
+
+def _storage_profile_name(profile: str | None) -> str:
+    """Return the profile authority represented by one subscription store."""
+
+    if profile:
+        return _normalize_subscription_profile(profile)
+    try:
+        from hermes_cli.profiles import get_active_profile_name
+
+        active = get_active_profile_name()
+    except Exception:
+        active = "default"
+    # A custom HERMES_HOME is the root/default profile for this installation.
+    if not active or active == "custom":
+        return "default"
+    return _normalize_subscription_profile(active)
+
+
+def _route_for_json(name: str, route: Mapping[str, Any], base_url: str) -> dict:
+    """Build a stable read model that never contains a plaintext secret."""
+
+    try:
+        route_url = _subscription_url(
+            base_url,
+            name,
+            route.get("profile", "default"),
+        )
+    except ValueError:
+        route_url = None
+    secret_set = bool(
+        route.get("secret") or route.get("secret_value") or route.get("secret_ref")
+    )
+    return {
+        "name": name,
+        "description": route.get("description", ""),
+        "profile": route.get("profile", "default"),
+        "provider": route.get("provider"),
+        "signature_mode": route.get("signature_mode"),
+        "enabled": route.get("enabled", True) is not False,
+        "events": list(route.get("events") or []),
+        "deliver": route.get("deliver", "log"),
+        "deliver_only": bool(route.get("deliver_only")),
+        "prompt": route.get("prompt", ""),
+        "script": route.get("script"),
+        "skills": list(route.get("skills") or []),
+        "created_at": route.get("created_at"),
+        "updated_at": route.get("updated_at"),
+        "url": route_url,
+        "secret_set": secret_set,
+        "secret_masked": "***" if secret_set else "",
+    }
+
+
+def _read_secret_fd(fd: int) -> str | None:
+    """Read bounded UTF-8 from *fd* without closing or echoing it."""
+
+    data = bytearray()
+    try:
+        while len(data) <= _MAX_SECRET_BYTES:
+            chunk = os.read(fd, min(4096, _MAX_SECRET_BYTES + 1 - len(data)))
+            if not chunk:
+                break
+            data.extend(chunk)
+    except (OSError, OverflowError):
+        print("Error: Could not read --secret-fd.")
+        return None
+
+    if len(data) > _MAX_SECRET_BYTES:
+        print(f"Error: --secret-fd input exceeds {_MAX_SECRET_BYTES} bytes.")
+        return None
+    try:
+        secret = data.decode("utf-8").rstrip()
+    except UnicodeDecodeError:
+        print("Error: --secret-fd input must be valid UTF-8.")
+        return None
+    if not secret:
+        print("Error: --secret-fd input is empty after trimming trailing whitespace.")
+        return None
+    return secret
 
 
 def _bind_subscription(name: str, route: Mapping[str, Any]):
@@ -298,6 +500,14 @@ def _default_test_payload(bound_route) -> Dict[str, Any]:
             "type": event_type,
             "message": "Hello from hermes webhook test",
         }
+    if bound_route.provider == "linear":
+        return {
+            "test": True,
+            "test_id": f"test_{secrets.token_hex(12)}",
+            "type": event_type,
+            "webhookTimestamp": int(time.time() * 1000),
+            "message": "Hello from hermes webhook test",
+        }
     if bound_route.provider == "chatwoot":
         payload = {
             "test": True,
@@ -372,6 +582,10 @@ def _test_headers(
         headers["X-Hermes-Event"] = hermes_event
     elif mode == "linear":
         headers["linear-signature"] = body_digest
+        timestamp_ms = payload_object.get("webhookTimestamp")
+        if not isinstance(timestamp_ms, int) or isinstance(timestamp_ms, bool):
+            raise ValueError("Linear test payload requires an integer webhookTimestamp")
+        headers["linear-timestamp"] = str(timestamp_ms)
     elif mode == "stripe":
         timestamp = str(int(time.time()))
         signed = timestamp.encode() + b"." + payload
@@ -395,21 +609,46 @@ def webhook_command(args):
     sub = getattr(args, "webhook_action", None)
 
     if not sub:
-        print("Usage: hermes webhook {subscribe|list|remove|test}")
+        print(
+            "Usage: hermes webhook "
+            "{subscribe|list|show|update|enable|disable|rotate-secret|remove|test}"
+        )
         print("Run 'hermes webhook --help' for details.")
         return
 
     if not _require_webhook_enabled():
         return
 
-    if sub in {"subscribe", "add"}:
-        _cmd_subscribe(args)
-    elif sub in {"list", "ls"}:
-        _cmd_list(args)
-    elif sub in {"remove", "rm"}:
-        _cmd_remove(args)
-    elif sub == "test":
-        _cmd_test(args)
+    try:
+        if sub in {"subscribe", "add", "create"}:
+            _cmd_subscribe(args)
+        elif sub in {"list", "ls"}:
+            _cmd_list(args)
+        elif sub == "show":
+            _cmd_show(args)
+        elif sub == "update":
+            _cmd_update(args)
+        elif sub == "enable":
+            _cmd_set_enabled(args, True)
+        elif sub == "disable":
+            _cmd_set_enabled(args, False)
+        elif sub == "rotate-secret":
+            _cmd_rotate_secret(args)
+        elif sub in {"remove", "rm"}:
+            _cmd_remove(args)
+        elif sub == "test":
+            _cmd_test(args)
+        else:
+            print(f"Error: Unknown webhook action '{sub}'.")
+    except WebhookCommandError as exc:
+        print(f"Error: {exc}")
+    except (WebhookRouteStoreError, TimeoutError) as exc:
+        print(
+            "Error: Cannot safely access the webhook subscription store "
+            f"({exc}). No changes were made."
+        )
+    except OSError:
+        print("Error: Could not safely update the webhook subscription store.")
 
 
 def _cmd_subscribe(args):
@@ -421,33 +660,83 @@ def _cmd_subscribe(args):
         )
         return
 
+    store_profile = _args_profile(args)
+    route_profile_arg = getattr(args, "route_profile", "") or ""
     try:
-        profile = _normalize_subscription_profile(
-            getattr(args, "route_profile", "default")
+        requested_route_profile = (
+            _normalize_subscription_profile(route_profile_arg)
+            if route_profile_arg
+            else None
         )
     except ValueError as exc:
         print(f"Error: Invalid webhook profile: {exc}")
         return
+    # ``--route-profile`` predates sharded storage.  When it is the only
+    # selector, preserve the spelling as an alias for the owning shard.  A
+    # document can never claim an authority different from its physical store.
+    if store_profile is None and requested_route_profile is not None:
+        store_profile = requested_route_profile
+    store = _route_store(store_profile)
+    profile = store.profile
+    if requested_route_profile not in {None, profile}:
+        print(
+            "Error: --route-profile must match the selected --profile store; "
+            "webhook route authority is profile-sharded."
+        )
+        return
 
-    subs = _load_subscriptions()
-    is_update = name in subs
+    is_update = name in store.load()
+    if is_update and not getattr(args, "replace", False):
+        print(
+            f"Error: A subscription named '{name}' already exists. "
+            f"Use 'hermes webhook update {name}' to patch fields, or pass "
+            "--replace to overwrite."
+        )
+        return
 
-    secret = args.secret or secrets.token_urlsafe(32)
+    secret_arg = getattr(args, "secret", "") or ""
+    secret_fd = getattr(args, "secret_fd", None)
+    if secret_arg and secret_fd is not None:
+        print("Error: --secret and --secret-fd are mutually exclusive.")
+        return
+    if secret_fd is not None:
+        if (
+            not isinstance(secret_fd, int)
+            or isinstance(secret_fd, bool)
+            or secret_fd < 0
+        ):
+            print("Error: --secret-fd must be a non-negative integer.")
+            return
+        secret = _read_secret_fd(secret_fd)
+        if secret is None:
+            return
+    else:
+        secret = secret_arg or secrets.token_urlsafe(32)
+
     events = (
-        [event for item in args.events.split(",") if (event := item.strip())]
-        if args.events
+        [
+            event
+            for item in (getattr(args, "events", "") or "").split(",")
+            if (event := item.strip())
+        ]
+        if getattr(args, "events", "")
         else []
     )
 
     route = {
-        "description": args.description or f"Agent-created subscription: {name}",
+        "description": getattr(args, "description", "")
+        or f"Agent-created subscription: {name}",
         "profile": profile,
         "provider": getattr(args, "provider", "github") or "github",
         "events": events,
         "secret": secret,
-        "prompt": args.prompt or "",
-        "skills": [s.strip() for s in args.skills.split(",")] if args.skills else [],
-        "deliver": args.deliver or "log",
+        "prompt": getattr(args, "prompt", "") or "",
+        "skills": [
+            skill.strip()
+            for skill in (getattr(args, "skills", "") or "").split(",")
+            if skill.strip()
+        ],
+        "deliver": getattr(args, "deliver", "") or "log",
         "created_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
     }
     signature_mode = getattr(args, "signature_mode", "") or ""
@@ -479,21 +768,53 @@ def _cmd_subscribe(args):
     if script.strip():
         route["script"] = script.strip()
 
-    if args.deliver_chat_id:
-        route["deliver_extra"] = {"chat_id": args.deliver_chat_id}
+    deliver_chat_id = getattr(args, "deliver_chat_id", "") or ""
+    if deliver_chat_id:
+        route["deliver_extra"] = {"chat_id": deliver_chat_id}
 
-    subs[name] = route
-    _save_subscriptions(subs)
+    try:
+        document = _new_route_document(name, route, profile=profile)
+    except Exception:
+        # Pydantic may include input values in its error rendering. Never print
+        # an exception that was constructed from a plaintext secret.
+        print("Error: Invalid webhook route document. No changes were made.")
+        return
+
+    replace = bool(getattr(args, "replace", False))
+    mutation = {"replaced": False}
+
+    def _insert(current: Dict[str, WebhookRouteDocument]):
+        exists = name in current
+        if exists and not replace:
+            raise WebhookCommandError(
+                f"A subscription named '{name}' already exists. "
+                f"Use 'hermes webhook update {name}' to patch fields, or pass "
+                "--replace to overwrite."
+            )
+        mutation["replaced"] = exists
+        current[name] = document
+        return current
+
+    saved = store.update(_insert)
+    document = saved[name]
+    route = to_persisted_route(document)
+    is_update = mutation["replaced"]
 
     base_url = _get_webhook_base_url()
     status = "Updated" if is_update else "Created"
     subscription_url = _subscription_url(base_url, name, bound_route.profile)
     local_test_url = _is_loopback_webhook_url(subscription_url)
 
+    if getattr(args, "json", False):
+        result = _route_for_json(name, route, base_url)
+        result["operation"] = status.lower()
+        print(json.dumps(result, indent=2, ensure_ascii=False))
+        return
+
     print(f"\n  {status} webhook subscription: {name}")
     url_label = "Local test URL" if local_test_url else "Callback URL"
     print(f"  {url_label}: {subscription_url}")
-    print(f"  Secret: {secret}")
+    print(f"  HMAC secret stored in {store.path} (mode 0600); value not displayed.")
     print(f"  Provider: {bound_route.provider} ({bound_route.signature_mode})")
     if events:
         print(f"  Events: {', '.join(events)}")
@@ -503,7 +824,9 @@ def _cmd_subscribe(args):
     if route.get("deliver_only"):
         print("  Mode: direct delivery (no agent, zero LLM cost)")
     if route.get("prompt"):
-        prompt_preview = route["prompt"][:80] + ("..." if len(route["prompt"]) > 80 else "")
+        prompt_preview = route["prompt"][:80] + (
+            "..." if len(route["prompt"]) > 80 else ""
+        )
         label = "Message" if route.get("deliver_only") else "Prompt"
         print(f"  {label}: {prompt_preview}")
     if route.get("script"):
@@ -534,83 +857,287 @@ def _cmd_subscribe(args):
     print("  The gateway must be running to receive events (hermes gateway run).\n")
 
 
+def _delivery_label(route: Mapping[str, Any]) -> str:
+    target = route.get("deliver")
+    if not target:
+        deliveries = route.get("deliveries")
+        if isinstance(deliveries, list) and deliveries:
+            first = deliveries[0]
+            if isinstance(first, Mapping):
+                target = first.get("target")
+    result = str(target or "log")
+    if route.get("deliver_only"):
+        result = f"{result} (direct — no agent)"
+    return result
+
+
+def _cmd_show(args):
+    name = args.name.strip().lower()
+    store = _route_store(_args_profile(args))
+    document = store.load().get(name)
+    if document is None:
+        print(f"  No subscription named '{name}'.")
+        return
+
+    route = to_persisted_route(document)
+    base_url = _get_webhook_base_url()
+    if getattr(args, "json", False):
+        print(
+            json.dumps(
+                _route_for_json(name, route, base_url),
+                indent=2,
+                ensure_ascii=False,
+            )
+        )
+        return
+
+    summary = _route_for_json(name, route, base_url)
+    events = ", ".join(summary["events"]) or "(all)"
+    provider = summary["provider"] or "legacy github"
+    if summary["signature_mode"]:
+        provider = f"{provider} ({summary['signature_mode']})"
+    print(f"\n  ◆ {name}")
+    if summary["description"]:
+        print(f"    {summary['description']}")
+    print(f"    URL:      {summary['url']}")
+    print(f"    Enabled:  {'yes' if summary['enabled'] else 'no'}")
+    print(f"    Provider: {provider}")
+    print(f"    Events:   {events}")
+    print(f"    Deliver:  {_delivery_label(route)}")
+    secret_display = "***" if summary["secret_set"] else "(none)"
+    print(f"    Secret:   {secret_display}")
+    if summary["script"]:
+        print(f"    Script:   {summary['script']}")
+    if summary["skills"]:
+        print(f"    Skills:   {', '.join(summary['skills'])}")
+    if summary["prompt"]:
+        print(f"    Prompt:   {summary['prompt'][:80]}")
+    print()
+
+
+def _cmd_update(args):
+    name = args.name.strip().lower()
+    store = _route_store(_args_profile(args))
+    values = {
+        "prompt": getattr(args, "prompt", "") or "",
+        "events": getattr(args, "events", "") or "",
+        "description": getattr(args, "description", "") or "",
+        "skills": getattr(args, "skills", "") or "",
+        "deliver": getattr(args, "deliver", "") or "",
+        "deliver_chat_id": getattr(args, "deliver_chat_id", "") or "",
+    }
+    if not any(values.values()):
+        print("Error: No update fields were specified. No changes were made.")
+        return
+
+    def _patch(current: Dict[str, WebhookRouteDocument]):
+        document = current.get(name)
+        if document is None:
+            raise WebhookCommandError(f"No subscription named '{name}'.")
+        route = to_persisted_route(document)
+        if values["prompt"]:
+            route["prompt"] = values["prompt"]
+        if values["events"]:
+            route["events"] = [
+                item.strip() for item in values["events"].split(",") if item.strip()
+            ]
+        if values["description"]:
+            route["description"] = values["description"]
+        if values["skills"]:
+            route["skills"] = [
+                item.strip() for item in values["skills"].split(",") if item.strip()
+            ]
+
+        if values["deliver"] or values["deliver_chat_id"]:
+            deliveries = [
+                dict(item)
+                for item in route.get("deliveries", [])
+                if isinstance(item, Mapping)
+            ]
+            primary = deliveries[0] if deliveries else {}
+            if values["deliver"]:
+                route["deliver"] = values["deliver"]
+                primary["target"] = values["deliver"]
+            if values["deliver_chat_id"]:
+                extra = route.get("deliver_extra")
+                extra = dict(extra) if isinstance(extra, Mapping) else {}
+                extra["chat_id"] = values["deliver_chat_id"]
+                route["deliver_extra"] = extra
+                primary["chat_id"] = values["deliver_chat_id"]
+            if primary:
+                if deliveries:
+                    deliveries[0] = primary
+                else:
+                    deliveries.append(primary)
+            route["deliveries"] = deliveries
+
+        route["updated_at"] = time.strftime(
+            "%Y-%m-%dT%H:%M:%SZ",
+            time.gmtime(),
+        )
+        current[name] = from_persisted_route(
+            name,
+            route,
+            profile=store.profile,
+        )
+        return current
+
+    try:
+        store.update(_patch)
+    except ValueError:
+        # ValidationError formatting can include the plaintext legacy secret.
+        print("Error: Invalid webhook update. No changes were made.")
+        return
+    print(f"  Updated webhook subscription: {name}")
+
+
+def _cmd_set_enabled(args, enabled: bool):
+    name = args.name.strip().lower()
+    store = _route_store(_args_profile(args))
+
+    def _toggle(current: Dict[str, WebhookRouteDocument]):
+        document = current.get(name)
+        if document is None:
+            raise WebhookCommandError(f"No subscription named '{name}'.")
+        route = to_persisted_route(document)
+        route["enabled"] = enabled
+        route["updated_at"] = time.strftime(
+            "%Y-%m-%dT%H:%M:%SZ",
+            time.gmtime(),
+        )
+        current[name] = from_persisted_route(
+            name,
+            route,
+            profile=store.profile,
+        )
+        return current
+
+    store.update(_toggle)
+    action = "Enabled" if enabled else "Disabled"
+    print(f"  {action} webhook subscription: {name}")
+
+
+def _cmd_rotate_secret(args):
+    name = args.name.strip().lower()
+    store = _route_store(_args_profile(args))
+    new_secret = secrets.token_urlsafe(32)
+
+    def _rotate(current: Dict[str, WebhookRouteDocument]):
+        document = current.get(name)
+        if document is None:
+            raise WebhookCommandError(f"No subscription named '{name}'.")
+        if document.secret_ref:
+            raise WebhookCommandError(
+                "Referenced webhook secrets must be rotated in their secret backend."
+            )
+        route = to_persisted_route(document)
+        route.pop("secret_value", None)
+        route["secret"] = new_secret
+        route["updated_at"] = time.strftime(
+            "%Y-%m-%dT%H:%M:%SZ",
+            time.gmtime(),
+        )
+        current[name] = from_persisted_route(
+            name,
+            route,
+            profile=store.profile,
+        )
+        return current
+
+    store.update(_rotate)
+    print(f"  Rotated secret for {name}.")
+    print(f"  New secret (shown once): {new_secret}")
+    print("  Store this in your provider's webhook configuration.")
+
+
 def _cmd_list(args):
-    subs = _load_subscriptions()
-    if not subs:
+    store = _route_store(_args_profile(args))
+    documents = store.load()
+    base_url = _get_webhook_base_url()
+    rows = [
+        _route_for_json(name, to_persisted_route(document), base_url)
+        for name, document in documents.items()
+    ]
+    if getattr(args, "json", False):
+        print(json.dumps(rows, indent=2, ensure_ascii=False))
+        return
+    if not documents:
         print("  No dynamic webhook subscriptions.")
         print("  Create one with: hermes webhook subscribe <name>")
         return
 
-    base_url = _get_webhook_base_url()
-    print(f"\n  {len(subs)} webhook subscription(s):\n")
-    for name, route in subs.items():
-        events = ", ".join(route.get("events", [])) or "(all)"
-        deliver = route.get("deliver", "log")
-        if route.get("deliver_only"):
-            deliver = f"{deliver} (direct — no agent)"
-        desc = route.get("description", "")
-        print(f"  ◆ {name}")
-        if desc:
-            print(f"    {desc}")
-        try:
-            route_url = _subscription_url(
-                base_url,
-                name,
-                route.get("profile", "default"),
-            )
-        except ValueError:
-            route_url = "(invalid profile binding)"
-        print(f"    URL:     {route_url}")
-        provider = route.get("provider") or "legacy github"
-        signature_mode = route.get("signature_mode")
-        if signature_mode:
-            provider = f"{provider} ({signature_mode})"
+    print(f"\n  {len(documents)} webhook subscription(s):\n")
+    for (name, document), summary in zip(documents.items(), rows):
+        route = to_persisted_route(document)
+        events = ", ".join(summary["events"]) or "(all)"
+        status = "enabled" if summary["enabled"] else "disabled"
+        print(f"  ◆ {name} ({status})")
+        if summary["description"]:
+            print(f"    {summary['description']}")
+        print(f"    URL:      {summary['url']}")
+        provider = summary["provider"] or "legacy github"
+        if summary["signature_mode"]:
+            provider = f"{provider} ({summary['signature_mode']})"
         print(f"    Provider: {provider}")
-        print(f"    Events:  {events}")
-        print(f"    Deliver: {deliver}")
-        if route.get("script"):
-            print(f"    Script:  {route['script']}")
+        print(f"    Events:   {events}")
+        print(f"    Deliver:  {_delivery_label(route)}")
+        if summary["script"]:
+            print(f"    Script:   {summary['script']}")
         print()
 
 
 def _cmd_remove(args):
     name = args.name.strip().lower()
-    subs = _load_subscriptions()
+    store = _route_store(_args_profile(args))
 
-    if name not in subs:
-        print(f"  No subscription named '{name}'.")
-        print("  Note: Static routes from config.yaml cannot be removed here.")
-        return
+    def _remove(current: Dict[str, WebhookRouteDocument]):
+        if name not in current:
+            raise WebhookCommandError(
+                f"No subscription named '{name}'. "
+                "Static routes from config.yaml cannot be removed here."
+            )
+        del current[name]
+        return current
 
-    del subs[name]
-    _save_subscriptions(subs)
+    store.update(_remove)
     print(f"  Removed webhook subscription: {name}")
 
 
 def _cmd_test(args):
     """Send a test POST to a webhook route."""
     name = args.name.strip().lower()
-    subs = _load_subscriptions()
+    store = _route_store(_args_profile(args))
+    document = store.load().get(name)
 
-    if name not in subs:
+    if document is None:
         print(f"  No subscription named '{name}'.")
         return
+    if document.enabled is False:
+        print(f"  Error: Subscription '{name}' is disabled.")
+        return
 
-    route = subs[name]
     try:
-        bound_route = _bind_subscription(name, route)
+        bound_route = document.contract
     except (TypeError, ValueError) as exc:
         print(f"  Error: Invalid webhook provider contract: {exc}")
         return
-    secret = route.get("secret", "")
+    if document.legacy_secret is not None:
+        secret = document.legacy_secret
+    elif document.legacy_secret_value is not None:
+        secret = document.legacy_secret_value
+    elif document.secret_ref:
+        secret = os.environ.get(document.secret_ref, "")
+    else:
+        secret = ""
     if not isinstance(secret, str) or not secret:
         print("  Error: Subscription has no usable webhook secret.")
         return
     base_url = _get_webhook_base_url()
     url = _subscription_url(base_url, name, bound_route.profile)
 
-    if args.payload:
-        payload = args.payload
+    supplied_payload = getattr(args, "payload", "") or ""
+    if supplied_payload:
+        payload = supplied_payload
         try:
             payload_object = json.loads(payload)
         except (json.JSONDecodeError, RecursionError):

--- a/hermes_cli/webhook.py
+++ b/hermes_cli/webhook.py
@@ -10,14 +10,20 @@ Subscriptions persist to ~/.hermes/webhook_subscriptions.json and are
 hot-reloaded by the webhook adapter without a gateway restart.
 """
 
+import base64
+import hashlib
+import hmac
+import ipaddress
 import json
 import os
 import re
 import secrets
 import tempfile
 import time
+from datetime import datetime, timezone
 from pathlib import Path
-from typing import Dict
+from typing import Any, Dict, Mapping
+from urllib.parse import urlsplit
 
 from hermes_constants import display_hermes_home
 from utils import atomic_replace
@@ -26,6 +32,7 @@ from hermes_cli.config import cfg_get
 
 _SUBSCRIPTIONS_FILENAME = "webhook_subscriptions.json"
 _SUBSCRIPTIONS_FILE_MODE = 0o600
+_LEGACY_CLI_DESCRIPTION_PREFIX = "Agent-created subscription:"
 
 
 def _hermes_home() -> Path:
@@ -104,6 +111,37 @@ def _get_webhook_base_url() -> str:
     return f"http://{display_host}:{port}"
 
 
+def _is_loopback_webhook_url(url: str) -> bool:
+    """Return whether a displayed webhook URL is local to this host."""
+
+    hostname = (urlsplit(url).hostname or "").strip().lower()
+    if hostname == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(hostname).is_loopback
+    except ValueError:
+        return False
+
+
+def _normalize_subscription_profile(value: Any) -> str:
+    """Return one canonical, URL-safe gateway profile binding."""
+
+    from hermes_cli.profiles import normalize_profile_name, validate_profile_name
+
+    profile = normalize_profile_name(str(value or "default"))
+    validate_profile_name(profile)
+    return profile
+
+
+def _subscription_url(base_url: str, name: str, profile: Any) -> str:
+    """Render the route URL that selects its bound execution profile."""
+
+    normalized_profile = _normalize_subscription_profile(profile)
+    if normalized_profile == "default":
+        return f"{base_url}/webhooks/{name}"
+    return f"{base_url}/p/{normalized_profile}/webhooks/{name}"
+
+
 def _setup_hint() -> str:
     _dhh = display_hermes_home()
     return f"""
@@ -137,6 +175,221 @@ def _require_webhook_enabled() -> bool:
     return False
 
 
+def _bind_subscription(name: str, route: Mapping[str, Any]):
+    """Bind a saved CLI subscription to the canonical webhook contract.
+
+    New subscriptions always persist an explicit provider and signature mode.
+    The narrow description check preserves ``hermes webhook test`` for routes
+    written by older CLI versions; the gateway uses the same one-time legacy
+    classification when it loads dynamic subscriptions.
+    """
+
+    from gateway.platforms.webhook_contract import WebhookRouteConfig
+
+    candidate = dict(route)
+    if not candidate.get("provider") and not candidate.get("signature_mode"):
+        description = str(candidate.get("description") or "")
+        if description.startswith(_LEGACY_CLI_DESCRIPTION_PREFIX):
+            candidate["provider"] = "github"
+    request_profile = candidate.get("profile", "default")
+    return WebhookRouteConfig.bind(
+        name,
+        candidate,
+        headers={},
+        request_profile=request_profile,
+    )
+
+
+def _selected_test_event(bound_route) -> str:
+    return bound_route.events[0] if bound_route.events else "test"
+
+
+def _default_test_payload(bound_route) -> Dict[str, Any]:
+    """Return a provider-valid default payload for ``hermes webhook test``."""
+
+    event_type = _selected_test_event(bound_route)
+    if bound_route.provider == "github" and bound_route.events:
+        test_id = f"test_{secrets.token_hex(12)}"
+        repository = {"id": 801, "full_name": "example/hermes-webhook-test"}
+        sender = {"id": 901, "login": "hermes-webhook-test"}
+        if event_type == "check_run":
+            return {
+                "action": "completed",
+                "check_run": {
+                    "id": 401,
+                    "name": "Hermes webhook test",
+                    "status": "completed",
+                    "conclusion": "success",
+                    "details_url": "https://example.invalid/checks/401",
+                    "pull_requests": [],
+                },
+                "repository": repository,
+                "sender": sender,
+                "test": True,
+                "test_id": test_id,
+            }
+        if event_type == "pull_request":
+            return {
+                "action": "opened",
+                "number": 1,
+                "pull_request": {
+                    "id": 701,
+                    "number": 1,
+                    "state": "open",
+                    "title": "Hermes webhook test",
+                    "head": {"ref": "hermes-webhook-test"},
+                    "base": {"ref": "main"},
+                },
+                "repository": repository,
+                "sender": sender,
+                "test": True,
+                "test_id": test_id,
+            }
+        if event_type == "push":
+            return {
+                "ref": "refs/heads/main",
+                "before": "0" * 40,
+                "after": "1" * 40,
+                "created": False,
+                "deleted": False,
+                "forced": False,
+                "commits": [],
+                "head_commit": None,
+                "repository": repository,
+                "pusher": {"name": "hermes-webhook-test"},
+                "sender": sender,
+                "test": True,
+                "test_id": test_id,
+            }
+        if event_type == "issues":
+            return {
+                "action": "opened",
+                "issue": {"id": 601, "number": 1, "title": "Webhook test"},
+                "repository": repository,
+                "sender": sender,
+                "test": True,
+                "test_id": test_id,
+            }
+        if event_type == "ping":
+            return {
+                "zen": "Keep it logically awesome.",
+                "hook_id": 501,
+                "hook": {"id": 501, "type": "Repository", "name": "web"},
+                "repository": repository,
+                "sender": sender,
+                "test": True,
+                "test_id": test_id,
+            }
+        raise ValueError(f"Unsupported authenticated GitHub event: {event_type}")
+    if bound_route.provider == "hermes":
+        return {
+            "test": True,
+            "message": "Hello from hermes webhook test",
+            "delivery_id": f"test_{secrets.token_hex(12)}",
+            "hook_event_name": event_type,
+            "timestamp": datetime
+            .now(tz=timezone.utc)
+            .isoformat()
+            .replace("+00:00", "Z"),
+        }
+    if bound_route.provider == "stripe":
+        return {
+            "id": f"evt_test_{secrets.token_hex(12)}",
+            "type": event_type,
+            "message": "Hello from hermes webhook test",
+        }
+    if bound_route.provider == "chatwoot":
+        payload = {
+            "test": True,
+            "event": event_type,
+            "message": "Hello from hermes webhook test",
+        }
+    else:
+        payload = {
+            "test": True,
+            "event_type": event_type,
+            "message": "Hello from hermes webhook test",
+        }
+
+    # Body- or credential-only contracts have no authenticated provider ID.
+    # Give each generated test a fresh value inside the covered body so two
+    # deliberate CLI tests cannot collapse onto the same durable replay key.
+    # Svix/Standard Webhooks already authenticate the fresh message ID that
+    # _test_headers emits; Hermes and Stripe carry their native IDs above.
+    if not bound_route.provider_spec.authenticated_delivery_id_headers:
+        payload["test_id"] = f"test_{secrets.token_hex(12)}"
+    return payload
+
+
+def _svix_signature(secret: str, message: bytes) -> str:
+    key = secret.encode()
+    if secret.startswith("whsec_"):
+        key = base64.b64decode(secret.removeprefix("whsec_"), validate=True)
+    digest = hmac.new(key, message, hashlib.sha256).digest()
+    return "v1," + base64.b64encode(digest).decode()
+
+
+def _test_headers(
+    bound_route,
+    secret: str,
+    payload: bytes,
+    payload_object: Mapping[str, Any],
+) -> Dict[str, str]:
+    """Build one request for the verifier selected by the saved route."""
+
+    mode = bound_route.signature_mode
+    event_type = _selected_test_event(bound_route)
+    headers = {"Content-Type": "application/json"}
+    body_digest = hmac.new(secret.encode(), payload, hashlib.sha256).hexdigest()
+
+    if mode == "github":
+        headers["X-Hub-Signature-256"] = f"sha256={body_digest}"
+        headers["X-GitHub-Event"] = event_type
+    elif mode == "gitlab":
+        headers["X-Gitlab-Token"] = secret
+        headers["X-GitLab-Event"] = event_type
+    elif mode in {"svix", "standard_webhooks"}:
+        message_id = f"msg_{secrets.token_hex(12)}"
+        timestamp = str(int(time.time()))
+        prefix = "svix" if mode == "svix" else "webhook"
+        headers[f"{prefix}-id"] = message_id
+        headers[f"{prefix}-timestamp"] = timestamp
+        headers[f"{prefix}-signature"] = _svix_signature(
+            secret,
+            message_id.encode() + b"." + timestamp.encode() + b"." + payload,
+        )
+    elif mode == "hindsight":
+        headers["X-Hindsight-Signature"] = f"sha256={body_digest}"
+    elif mode == "hermes":
+        delivery_id = str(payload_object.get("delivery_id") or "").strip()
+        hermes_event = str(payload_object.get("hook_event_name") or "").strip()
+        if not delivery_id or not hermes_event:
+            raise ValueError(
+                "Hermes test payload requires delivery_id and hook_event_name"
+            )
+        headers["X-Hermes-Signature-256"] = f"sha256={body_digest}"
+        headers["X-Hermes-Delivery"] = delivery_id
+        headers["X-Hermes-Event"] = hermes_event
+    elif mode == "linear":
+        headers["linear-signature"] = body_digest
+    elif mode == "stripe":
+        timestamp = str(int(time.time()))
+        signed = timestamp.encode() + b"." + payload
+        digest = hmac.new(secret.encode(), signed, hashlib.sha256).hexdigest()
+        headers["Stripe-Signature"] = f"t={timestamp},v1={digest}"
+    elif mode == "generic_v1":
+        headers["X-Webhook-Signature"] = body_digest
+    elif mode == "generic_v2":
+        timestamp = str(int(time.time()))
+        signed = timestamp.encode() + b"." + payload
+        digest = hmac.new(secret.encode(), signed, hashlib.sha256).hexdigest()
+        headers["X-Webhook-Timestamp"] = timestamp
+        headers["X-Webhook-Signature-V2"] = digest
+    else:  # WebhookRouteConfig currently makes this unreachable.
+        raise ValueError(f"Unsupported webhook signature mode: {mode}")
+    return headers
+
+
 def webhook_command(args):
     """Entry point for 'hermes webhook' subcommand."""
     sub = getattr(args, "webhook_action", None)
@@ -161,18 +414,35 @@ def webhook_command(args):
 
 def _cmd_subscribe(args):
     name = args.name.strip().lower().replace(" ", "-")
-    if not re.match(r'^[a-z0-9][a-z0-9_-]*$', name):
-        print(f"Error: Invalid name '{name}'. Use lowercase alphanumeric with hyphens/underscores.")
+    if not re.fullmatch(r"[a-z0-9][a-z0-9_-]{0,127}", name):
+        print(
+            f"Error: Invalid name '{name}'. Use at most 128 lowercase "
+            "alphanumeric, hyphen, or underscore characters."
+        )
+        return
+
+    try:
+        profile = _normalize_subscription_profile(
+            getattr(args, "route_profile", "default")
+        )
+    except ValueError as exc:
+        print(f"Error: Invalid webhook profile: {exc}")
         return
 
     subs = _load_subscriptions()
     is_update = name in subs
 
     secret = args.secret or secrets.token_urlsafe(32)
-    events = [e.strip() for e in args.events.split(",")] if args.events else []
+    events = (
+        [event for item in args.events.split(",") if (event := item.strip())]
+        if args.events
+        else []
+    )
 
     route = {
         "description": args.description or f"Agent-created subscription: {name}",
+        "profile": profile,
+        "provider": getattr(args, "provider", "github") or "github",
         "events": events,
         "secret": secret,
         "prompt": args.prompt or "",
@@ -180,6 +450,21 @@ def _cmd_subscribe(args):
         "deliver": args.deliver or "log",
         "created_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
     }
+    signature_mode = getattr(args, "signature_mode", "") or ""
+    if signature_mode.strip():
+        route["signature_mode"] = signature_mode.strip()
+
+    try:
+        bound_route = _bind_subscription(name, route)
+    except (TypeError, ValueError) as exc:
+        print(f"Error: Invalid webhook provider contract: {exc}")
+        return
+    # Persist canonical values so hot reload and ``hermes webhook test`` use
+    # exactly the verifier that was validated here.
+    route["provider"] = bound_route.provider
+    route["signature_mode"] = bound_route.signature_mode
+    route["events"] = list(bound_route.events)
+    events = route["events"]
 
     if getattr(args, "deliver_only", False):
         if route["deliver"] == "log":
@@ -202,10 +487,14 @@ def _cmd_subscribe(args):
 
     base_url = _get_webhook_base_url()
     status = "Updated" if is_update else "Created"
+    subscription_url = _subscription_url(base_url, name, bound_route.profile)
+    local_test_url = _is_loopback_webhook_url(subscription_url)
 
     print(f"\n  {status} webhook subscription: {name}")
-    print(f"  URL:    {base_url}/webhooks/{name}")
+    url_label = "Local test URL" if local_test_url else "Callback URL"
+    print(f"  {url_label}: {subscription_url}")
     print(f"  Secret: {secret}")
+    print(f"  Provider: {bound_route.provider} ({bound_route.signature_mode})")
     if events:
         print(f"  Events: {', '.join(events)}")
     else:
@@ -219,8 +508,29 @@ def _cmd_subscribe(args):
         print(f"  {label}: {prompt_preview}")
     if route.get("script"):
         print(f"  Script: {route['script']}")
-    print("\n  Configure your service to POST to the URL above.")
-    print("  Use the secret for HMAC-SHA256 signature validation.")
+    if local_test_url:
+        callback_path = urlsplit(subscription_url).path
+        print(
+            "\n  External callback: a public HTTPS reverse proxy is required; "
+            f"use https://<public-host>{callback_path} and preserve the exact path."
+        )
+        print("  Do not configure an external service with the local test URL.")
+    else:
+        print("\n  Configure your service to POST to the callback URL above.")
+    authentication_hints = {
+        "github": "GitHub webhook secret (X-Hub-Signature-256 HMAC-SHA256)",
+        "gitlab": "GitLab Secret token (X-Gitlab-Token exact string match)",
+        "generic_v1": "generic_v1 secret (X-Webhook-Signature HMAC-SHA256)",
+        "generic_v2": (
+            "generic_v2 secret (X-Webhook-Timestamp + "
+            "X-Webhook-Signature-V2 HMAC-SHA256)"
+        ),
+    }
+    authentication_hint = authentication_hints.get(
+        bound_route.signature_mode,
+        f"{bound_route.provider}/{bound_route.signature_mode} verifier secret",
+    )
+    print(f"  Authentication: {authentication_hint}.")
     print("  The gateway must be running to receive events (hermes gateway run).\n")
 
 
@@ -242,7 +552,20 @@ def _cmd_list(args):
         print(f"  ◆ {name}")
         if desc:
             print(f"    {desc}")
-        print(f"    URL:     {base_url}/webhooks/{name}")
+        try:
+            route_url = _subscription_url(
+                base_url,
+                name,
+                route.get("profile", "default"),
+            )
+        except ValueError:
+            route_url = "(invalid profile binding)"
+        print(f"    URL:     {route_url}")
+        provider = route.get("provider") or "legacy github"
+        signature_mode = route.get("signature_mode")
+        if signature_mode:
+            provider = f"{provider} ({signature_mode})"
+        print(f"    Provider: {provider}")
         print(f"    Events:  {events}")
         print(f"    Deliver: {deliver}")
         if route.get("script"):
@@ -274,29 +597,55 @@ def _cmd_test(args):
         return
 
     route = subs[name]
+    try:
+        bound_route = _bind_subscription(name, route)
+    except (TypeError, ValueError) as exc:
+        print(f"  Error: Invalid webhook provider contract: {exc}")
+        return
     secret = route.get("secret", "")
+    if not isinstance(secret, str) or not secret:
+        print("  Error: Subscription has no usable webhook secret.")
+        return
     base_url = _get_webhook_base_url()
-    url = f"{base_url}/webhooks/{name}"
+    url = _subscription_url(base_url, name, bound_route.profile)
 
-    payload = args.payload or '{"test": true, "event_type": "test", "message": "Hello from hermes webhook test"}'
+    if args.payload:
+        payload = args.payload
+        try:
+            payload_object = json.loads(payload)
+        except (json.JSONDecodeError, RecursionError):
+            print("  Error: --payload must be valid JSON.")
+            return
+        if not isinstance(payload_object, dict):
+            print("  Error: --payload must be a JSON object.")
+            return
+    else:
+        payload_object = _default_test_payload(bound_route)
+        payload = json.dumps(payload_object, ensure_ascii=False)
 
-    import hmac
-    import hashlib
-    sig = "sha256=" + hmac.new(
-        secret.encode(), payload.encode(), hashlib.sha256
-    ).hexdigest()
+    payload_bytes = payload.encode()
+    try:
+        headers = _test_headers(
+            bound_route,
+            secret,
+            payload_bytes,
+            payload_object,
+        )
+    except (ValueError, TypeError) as exc:
+        print(f"  Error: Cannot build provider test request: {exc}")
+        return
 
-    print(f"  Sending test POST to {url}")
+    print(
+        f"  Sending {bound_route.provider}/{bound_route.signature_mode} "
+        f"test POST to {url}"
+    )
     try:
         import urllib.request
+
         req = urllib.request.Request(
             url,
-            data=payload.encode(),
-            headers={
-                "Content-Type": "application/json",
-                "X-Hub-Signature-256": sig,
-                "X-GitHub-Event": "test",
-            },
+            data=payload_bytes,
+            headers=headers,
             method="POST",
         )
         with urllib.request.urlopen(req, timeout=10) as resp:

--- a/tests/agent/test_outbound_webhook_contract.py
+++ b/tests/agent/test_outbound_webhook_contract.py
@@ -1,0 +1,135 @@
+"""Strict Task 14 outbound configuration and signature contract."""
+
+import hashlib
+import hmac
+import json
+import logging
+
+import pytest
+
+from agent import outbound_webhooks as ow
+from agent import secret_scope
+
+
+def _cfg(entry):
+    return {"hooks": {"outbound": [entry]}}
+
+
+def _entry(**overrides):
+    entry = {
+        "url": "https://example.com/hook",
+        "events": ["on_session_end"],
+    }
+    entry.update(overrides)
+    return entry
+
+
+def test_unknown_field_rejects_entire_target():
+    assert ow.iter_configured_targets(_cfg(_entry(secrete="typo"))) == []
+
+
+def test_inline_plaintext_secret_reports_migration_and_disables_target(caplog):
+    caplog.set_level(logging.ERROR, logger=ow.__name__)
+
+    assert ow.iter_configured_targets(_cfg(_entry(secret="super-secret-value"))) == []
+
+    message = caplog.text
+    assert "unsupported inline plaintext" in message
+    assert "secret_ref" in message
+    assert "secret_env" in message
+    assert "target disabled" in message
+    assert "super-secret-value" not in message
+
+
+def test_missing_explicit_secret_reference_fails_closed(monkeypatch, caplog):
+    monkeypatch.delenv("MISSING_WR_SECRET", raising=False)
+    caplog.set_level(logging.ERROR, logger=ow.__name__)
+
+    assert (
+        ow.iter_configured_targets(_cfg(_entry(secret_ref="MISSING_WR_SECRET"))) == []
+    )
+
+    assert "target disabled" in caplog.text
+    assert "will not send this webhook unsigned" in caplog.text
+
+
+@pytest.mark.parametrize("value", ["", "   ", None, 7])
+def test_malformed_explicit_secret_reference_never_downgrades_to_unsigned(
+    value,
+    caplog,
+):
+    caplog.set_level(logging.ERROR, logger=ow.__name__)
+
+    assert ow.iter_configured_targets(_cfg(_entry(secret_ref=value))) == []
+
+    assert "must be a non-empty secret name" in caplog.text
+    assert "will not send this webhook unsigned" in caplog.text
+
+
+def test_multiple_reference_fields_are_rejected(monkeypatch, caplog):
+    monkeypatch.setenv("A", "one")
+    monkeypatch.setenv("B", "two")
+    caplog.set_level(logging.ERROR, logger=ow.__name__)
+
+    assert (
+        ow.iter_configured_targets(_cfg(_entry(secret_ref="A", secret_env="B"))) == []
+    )
+
+    assert "exactly one reference field" in caplog.text
+
+
+def test_no_secret_fields_is_the_only_unsigned_configuration():
+    target = ow.iter_configured_targets(_cfg(_entry()))[0]
+    assert target.secret is None
+
+
+def test_unscoped_reference_fails_closed_without_process_env_fallback(
+    monkeypatch,
+    caplog,
+):
+    monkeypatch.setattr(secret_scope, "_MULTIPLEX_ACTIVE", True)
+    monkeypatch.setenv("PROFILE_ONLY_SECRET", "must-not-leak")
+    caplog.set_level(logging.ERROR, logger=ow.__name__)
+
+    assert (
+        ow.iter_configured_targets(_cfg(_entry(secret_ref="PROFILE_ONLY_SECRET"))) == []
+    )
+
+    assert "active profile secret scope" in caplog.text
+    assert "no process-environment fallback was attempted" in caplog.text
+
+
+def test_unexpected_secret_resolver_failure_is_not_swallowed(monkeypatch):
+    def explode(_name, _default):
+        raise RuntimeError("resolver import/state failure")
+
+    monkeypatch.setattr(ow, "get_secret", explode)
+
+    with pytest.raises(RuntimeError, match="resolver import/state failure"):
+        ow.iter_configured_targets(_cfg(_entry(secret_ref="WR_SECRET")))
+
+
+def test_v2_signature_binds_timestamp_and_body(monkeypatch):
+    monkeypatch.setenv("WR_SECRET", "s3cret")
+    target = ow.iter_configured_targets(_cfg(_entry(secret_ref="WR_SECRET")))[0]
+    body = json.dumps({"schema_version": 1, "x": 1}).encode()
+    delivery = ow._build_delivery("on_session_end", target, body, "d1")
+    headers = delivery["headers"]
+    timestamp = headers["X-Hermes-Timestamp"]
+
+    expected_v2 = hmac.new(
+        b"s3cret", timestamp.encode("ascii") + b"." + body, hashlib.sha256
+    ).hexdigest()
+    expected_legacy = hmac.new(b"s3cret", body, hashlib.sha256).hexdigest()
+
+    assert headers["X-Hermes-Signature-V2"] == f"sha256={expected_v2}"
+    assert headers["X-Hermes-Signature-256"] == f"sha256={expected_legacy}"
+    assert headers["X-Hermes-Schema-Version"] == "1"
+
+
+def test_receiver_contract_documents_complete_replay_checks():
+    docs = ow.__doc__ or ""
+    assert "300 seconds" in docs
+    assert "hmac.compare_digest" in docs
+    assert "X-Hermes-Delivery" in docs
+    assert "still replayable" in docs

--- a/tests/agent/test_outbound_webhooks.py
+++ b/tests/agent/test_outbound_webhooks.py
@@ -219,7 +219,7 @@ class TestParseConfig:
         )
         assert targets[0].matcher == "terminal|delegate_task"
 
-    def test_secret_env_wins_over_literal(self, monkeypatch):
+    def test_inline_secret_field_rejects_the_target(self, monkeypatch):
         monkeypatch.setenv("MY_HOOK_SECRET", "from-env")
         targets = outbound_webhooks.iter_configured_targets(
             _cfg(
@@ -231,9 +231,9 @@ class TestParseConfig:
                 }
             )
         )
-        assert targets[0].secret == "from-env"
+        assert targets == []
 
-    def test_unset_secret_env_means_unsigned(self, monkeypatch):
+    def test_unset_secret_reference_skips_target(self, monkeypatch):
         monkeypatch.delenv("MISSING_SECRET_VAR", raising=False)
         targets = outbound_webhooks.iter_configured_targets(
             _cfg(
@@ -244,7 +244,7 @@ class TestParseConfig:
                 }
             )
         )
-        assert targets[0].secret is None
+        assert targets == []
 
 
 # ── matcher behaviour ─────────────────────────────────────────────────────
@@ -300,6 +300,7 @@ class TestPayload:
         assert payload["extra"]["duration_ms"] == 42
         assert payload["delivery_id"] == "did_1234"
         assert payload["timestamp"].endswith("Z")
+        assert payload["schema_version"] == 1
 
     def test_unserialisable_values_stringified(self):
         body = outbound_webhooks._serialize_payload(
@@ -349,16 +350,15 @@ class TestRegistration:
 
 
 class TestDelivery:
-    def test_delivery_with_hmac_signature(self, http_server):
+    def test_delivery_with_hmac_signature(self, http_server, monkeypatch):
         secret = "s3cret"
-        cfg = _cfg(
-            {
-                "url": _url(http_server),
-                "events": ["on_session_end"],
-                "secret": secret,
-                "name": "e2e",
-            }
-        )
+        monkeypatch.setenv("WR_OUTBOUND_SECRET", secret)
+        cfg = _cfg({
+            "url": _url(http_server),
+            "events": ["on_session_end"],
+            "secret_ref": "WR_OUTBOUND_SECRET",
+            "name": "e2e",
+        })
         registered = outbound_webhooks.register_from_config(cfg)
         assert len(registered) == 1
 
@@ -376,19 +376,16 @@ class TestDelivery:
 
         assert len(http_server.captured) == 1
         req = http_server.captured[0]
-
         payload = json.loads(req["body"])
-        assert payload["hook_event_name"] == "on_session_end"
-        assert payload["session_id"] == "sess_e2e"
-        assert payload["extra"]["completed"] is True
-        assert payload["extra"]["model"] == "test-model"
-
-        assert req["headers"]["X-Hermes-Event"] == "on_session_end"
-        assert req["headers"]["X-Hermes-Delivery"]
-        expected = hmac.new(
-            secret.encode(), req["body"], hashlib.sha256
+        assert payload["schema_version"] == 1
+        assert req["headers"]["X-Hermes-Schema-Version"] == "1"
+        timestamp = req["headers"]["X-Hermes-Timestamp"]
+        expected_v2 = hmac.new(
+            secret.encode(),
+            timestamp.encode("ascii") + b"." + req["body"],
+            hashlib.sha256,
         ).hexdigest()
-        assert req["headers"]["X-Hermes-Signature-256"] == f"sha256={expected}"
+        assert req["headers"]["X-Hermes-Signature-V2"] == f"sha256={expected_v2}"
 
     def test_unsigned_delivery_has_no_signature_header(self, http_server):
         cfg = _cfg({"url": _url(http_server), "events": ["on_session_end"]})
@@ -466,13 +463,15 @@ class TestDelivery:
         assert [c["method"] for c in http_server.captured] == ["POST"]
         assert http_server.captured[0]["path"] == "/hook"
 
-    def test_delivery_id_matches_header_and_body(self, http_server):
+    def test_delivery_id_matches_header_and_body(self, http_server, monkeypatch):
         """The X-Hermes-Delivery header and the signed body's delivery_id
         must be the same value, or receiver-side dedupe breaks."""
-        cfg = _cfg(
-            {"url": _url(http_server), "events": ["on_session_end"],
-             "secret": "s"}
-        )
+        monkeypatch.setenv("WR_OUTBOUND_SECRET", "s")
+        cfg = _cfg({
+            "url": _url(http_server),
+            "events": ["on_session_end"],
+            "secret_ref": "WR_OUTBOUND_SECRET",
+        })
         outbound_webhooks.register_from_config(cfg)
 
         from hermes_cli.plugins import get_plugin_manager

--- a/tests/gateway/test_multiplex_profile_authz.py
+++ b/tests/gateway/test_multiplex_profile_authz.py
@@ -74,6 +74,36 @@ def test_active_profile_stamp_resolves_primary_adapter(monkeypatch):
     assert runner._authorization_adapter(Platform.WECOM, profile="dev") is default_adapter
 
 
+def test_default_stamp_aliases_named_primary_only_when_multiplex_is_off(monkeypatch):
+    """Unprofiled durable routes remain usable on a named single-profile home."""
+
+    runner, primary_adapter, _secondary_adapter = _make_multiplex_runner(monkeypatch)
+    runner.config = GatewayConfig(multiplex_profiles=False)
+    runner._active_profile_name = lambda: "dev"
+
+    assert (
+        runner._authorization_adapter(Platform.WECOM, profile="default")
+        is primary_adapter
+    )
+
+
+def test_explicit_default_profile_uses_its_secondary_registry_when_active_is_named(
+    monkeypatch,
+):
+    """A named active gateway cannot borrow its adapter for default egress."""
+
+    runner, named_adapter, _secondary_adapter = _make_multiplex_runner(monkeypatch)
+    default_adapter = SimpleNamespace(send=AsyncMock())
+    runner._active_profile_name = lambda: "dev"
+    runner._profile_adapters["default"] = {Platform.WECOM: default_adapter}
+
+    assert runner.adapters[Platform.WECOM] is named_adapter
+    assert (
+        runner._authorization_adapter(Platform.WECOM, profile="default")
+        is default_adapter
+    )
+
+
 def test_secondary_allowlist_dm_behavior_ignores_unauthorized(monkeypatch):
     """Unauthorized-DM behavior must read the secondary adapter's dm_policy."""
     runner, _default_adapter, secondary_adapter = _make_multiplex_runner(monkeypatch)

--- a/tests/gateway/test_platform_reconnect.py
+++ b/tests/gateway/test_platform_reconnect.py
@@ -29,6 +29,7 @@ class StubAdapter(BasePlatformAdapter):
         # Records the is_reconnect value of every connect() call so tests can
         # assert that the watcher distinguishes reconnect from cold boot (#46621).
         self.connect_calls: list[bool] = []
+        self.disconnect_calls = 0
 
     async def connect(self, *, is_reconnect: bool = False):
         self.connect_calls.append(is_reconnect)
@@ -38,6 +39,7 @@ class StubAdapter(BasePlatformAdapter):
         return self._succeed
 
     async def disconnect(self):
+        self.disconnect_calls += 1
         return None
 
     async def send(self, chat_id, content, reply_to=None, metadata=None):
@@ -198,6 +200,88 @@ class TestPlatformReconnectWatcher:
             f"watcher must pass is_reconnect=True; got {succeed_adapter.connect_calls!r}"
         )
         assert Platform.TELEGRAM in runner.adapters
+
+    @pytest.mark.asyncio
+    async def test_shutdown_after_connect_disposes_candidate_without_publishing(self):
+        """A connect that loses the shutdown race cannot escape teardown."""
+
+        runner = _make_runner()
+        runner._draining = False
+        platform_config = PlatformConfig(enabled=True, token="test")
+        runner._failed_platforms[Platform.TELEGRAM] = {
+            "config": platform_config,
+            "attempts": 1,
+            "next_retry": time.monotonic() - 1,
+        }
+        candidate = StubAdapter(succeed=True)
+        real_sleep = asyncio.sleep
+
+        async def connect_finishes_after_shutdown(*_args, **_kwargs):
+            runner._running = False
+            runner._draining = True
+            return True
+
+        async def immediate_sleep(_delay):
+            await real_sleep(0)
+
+        with (
+            patch.object(runner, "_create_adapter", return_value=candidate),
+            patch.object(
+                runner,
+                "_connect_adapter_with_timeout",
+                new=AsyncMock(side_effect=connect_finishes_after_shutdown),
+            ),
+            patch("asyncio.sleep", side_effect=immediate_sleep),
+        ):
+            await runner._platform_reconnect_watcher()
+
+        assert Platform.TELEGRAM not in runner.adapters
+        assert Platform.TELEGRAM in runner._failed_platforms
+        assert candidate.disconnect_calls == 1
+
+    @pytest.mark.asyncio
+    async def test_cancellation_during_connect_disposes_unpublished_candidate(self):
+        """CancelledError must not bypass cleanup of an in-flight candidate."""
+
+        runner = _make_runner()
+        runner._draining = False
+        platform_config = PlatformConfig(enabled=True, token="test")
+        runner._failed_platforms[Platform.TELEGRAM] = {
+            "config": platform_config,
+            "attempts": 1,
+            "next_retry": time.monotonic() - 1,
+        }
+        candidate = StubAdapter(succeed=True)
+        connect_entered = asyncio.Event()
+        never_finishes = asyncio.Event()
+        real_sleep = asyncio.sleep
+
+        async def blocking_connect(*_args, **_kwargs):
+            connect_entered.set()
+            await never_finishes.wait()
+            return True
+
+        async def immediate_sleep(_delay):
+            await real_sleep(0)
+
+        with (
+            patch.object(runner, "_create_adapter", return_value=candidate),
+            patch.object(
+                runner,
+                "_connect_adapter_with_timeout",
+                new=AsyncMock(side_effect=blocking_connect),
+            ),
+            patch("asyncio.sleep", side_effect=immediate_sleep),
+        ):
+            watcher = asyncio.create_task(runner._platform_reconnect_watcher())
+            await asyncio.wait_for(connect_entered.wait(), timeout=1)
+            watcher.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await watcher
+
+        assert Platform.TELEGRAM not in runner.adapters
+        assert Platform.TELEGRAM in runner._failed_platforms
+        assert candidate.disconnect_calls == 1
 
     @pytest.mark.asyncio
     async def test_cold_connect_defaults_to_is_reconnect_false(self):

--- a/tests/gateway/test_profile_resolution.py
+++ b/tests/gateway/test_profile_resolution.py
@@ -73,10 +73,10 @@ class TestResolutionOrder:
 
 
 class TestMissingProfileWarning:
-    """Tests for warning when a profile doesn't exist on disk."""
+    """Explicit missing profiles fail closed instead of changing authority."""
     
     def test_nonexistent_profile_warning(self, mock_runner, discord_source, caplog):
-        """When source.profile points to a nonexistent profile, log a WARNING."""
+        """A removed source.profile is rejected with a warning."""
         discord_source.profile = "nonexistent"
         
         with patch("hermes_cli.profiles.get_active_profile_name", return_value="active"):
@@ -85,10 +85,8 @@ class TestMissingProfileWarning:
                 with patch("hermes_cli.profiles.profile_exists", return_value=False):
                     with patch("hermes_constants.get_hermes_home", return_value=Path("/hermes")):
                         with caplog.at_level(logging.WARNING):
-                            result = mock_runner._resolve_profile_home_for_source(discord_source)
-                            
-                            # Should fall back to global HERMES_HOME
-                            assert result == Path("/hermes")
+                            with pytest.raises(ProfileRouteRejected):
+                                mock_runner._resolve_profile_home_for_source(discord_source)
                             
                             # Should have logged a warning
                             assert len(caplog.records) == 1
@@ -105,24 +103,27 @@ class TestMissingProfileWarning:
 class TestExceptionHandling:
     """Tests for exception handling in profile resolution."""
     
-    def test_get_profile_dir_exception_logs_warning(self, mock_runner, discord_source, caplog):
-        """When get_profile_dir raises an exception, log a WARNING with context."""
+    def test_get_profile_dir_exception_rejects_explicit_profile(
+        self, mock_runner, discord_source, caplog
+    ):
+        """Resolution errors cannot fall back to another profile's home."""
         discord_source.profile = "bad-profile"
         
         with patch("hermes_cli.profiles.get_active_profile_name", return_value="active"):
             with patch("hermes_cli.profiles.get_profile_dir", side_effect=ValueError("Invalid profile name")):
                 with patch("hermes_constants.get_hermes_home", return_value=Path("/hermes")):
                     with caplog.at_level(logging.WARNING):
-                        result = mock_runner._resolve_profile_home_for_source(discord_source)
-                        
-                        # Should fall back to global HERMES_HOME
-                        assert result == Path("/hermes")
+                        with pytest.raises(ProfileRouteRejected):
+                            mock_runner._resolve_profile_home_for_source(discord_source)
                         
                         # Should have logged a warning with exception info
                         assert len(caplog.records) == 1
                         assert caplog.records[0].levelname == "WARNING"
                         assert "bad-profile" in caplog.records[0].message
-                        assert "Failed to resolve profile directory" in caplog.records[0].message
+                        assert (
+                            "Failed to resolve explicit profile directory"
+                            in caplog.records[0].message
+                        )
     
 
 
@@ -136,10 +137,11 @@ class TestRoutingConsultation:
         with patch("hermes_cli.profiles.get_active_profile_name", return_value="active"):
             with patch("hermes_cli.profiles.get_profile_dir") as mock_get_dir:
                 mock_get_dir.return_value = Path("/hermes/profiles/routed")
-                
+
                 mock_runner._profile_name_for_source = MagicMock(return_value="routed")
-                
-                mock_runner._resolve_profile_home_for_source(discord_source)
+
+                with patch("hermes_cli.profiles.profile_exists", return_value=True):
+                    mock_runner._resolve_profile_home_for_source(discord_source)
                 
                 # Should have called routing
                 mock_runner._profile_name_for_source.assert_called_once_with(discord_source)
@@ -385,5 +387,3 @@ class TestMultiplexGate:
         discord_source.profile = None
 
         assert mock_runner._profile_name_for_source(discord_source) is None
-
-

--- a/tests/gateway/test_proxy_source_toolset_authority.py
+++ b/tests/gateway/test_proxy_source_toolset_authority.py
@@ -1,0 +1,489 @@
+"""Proxy delegation must preserve per-source toolset authority."""
+
+from copy import deepcopy
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import Platform
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+
+
+class _SourceToolsetAdapter:
+    def __init__(self, toolsets, events):
+        self._toolsets = toolsets
+        self._events = events
+
+    def toolsets_for_source(self, source):
+        self._events.append(("authority", source.chat_id))
+        if isinstance(self._toolsets, Exception):
+            raise self._toolsets
+        return self._toolsets
+
+
+class _ExactSourceToolsetAdapter:
+    def __init__(self, exact, events, *, legacy=None):
+        self._exact = exact
+        self._events = events
+        self._legacy = legacy
+
+    def resolved_toolsets_for_source(self, source):
+        self._events.append(("exact", source.chat_id))
+        if isinstance(self._exact, Exception):
+            raise self._exact
+        return self._exact
+
+    def toolsets_for_source(self, source):
+        self._events.append(("legacy", source.chat_id))
+        if isinstance(self._legacy, Exception):
+            raise self._legacy
+        return self._legacy
+
+
+def _webhook_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.WEBHOOK,
+        chat_id="webhook:default:deploy:github:trace-1",
+        chat_name="webhook/deploy",
+        chat_type="webhook",
+        user_id="webhook:deploy",
+        user_name="deploy",
+    )
+
+
+def _proxy_runner(adapter) -> GatewayRunner:
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {Platform.WEBHOOK: adapter}
+    runner._get_proxy_url = lambda: "http://proxy.invalid:8642"
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_admitted_webhook_toolsets_cannot_be_bypassed_by_proxy(
+    monkeypatch,
+):
+    events = []
+    admitted_toolsets = ["web", "discord_admin"]
+    adapter = _SourceToolsetAdapter(admitted_toolsets, events)
+    runner = _proxy_runner(adapter)
+    source = _webhook_source()
+    user_config = {"platform_toolsets": {"webhook": ["terminal"]}}
+    resolved_configs = []
+
+    def resolve_toolsets(config, platform_key):
+        resolved_configs.append((deepcopy(config), platform_key))
+        events.append(("validated", tuple(config["platform_toolsets"][platform_key])))
+        # Model the normal resolver dropping a platform-restricted toolset.
+        return {"web"}
+
+    monkeypatch.setattr(
+        "gateway.run._load_gateway_config",
+        lambda: deepcopy(user_config),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._get_platform_tools",
+        resolve_toolsets,
+    )
+    runner._run_agent_via_proxy = AsyncMock()
+
+    result = await runner._run_agent_inner(
+        message="deploy",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="session-1",
+    )
+
+    assert events == [
+        ("authority", source.chat_id),
+        ("validated", tuple(admitted_toolsets)),
+    ]
+    assert resolved_configs == [
+        (
+            {"platform_toolsets": {"webhook": admitted_toolsets}},
+            "webhook",
+        )
+    ]
+    assert user_config == {"platform_toolsets": {"webhook": ["terminal"]}}
+    runner._run_agent_via_proxy.assert_not_awaited()
+    assert result["failed"] is True
+    assert result["completed"] is False
+    assert result["api_calls"] == 0
+    assert result["failure_reason"] == "proxy_source_toolsets_unsupported"
+
+
+@pytest.mark.asyncio
+async def test_explicit_empty_source_toolsets_are_deny_all_and_block_proxy(
+    monkeypatch,
+):
+    events = []
+    adapter = _SourceToolsetAdapter([], events)
+    runner = _proxy_runner(adapter)
+    source = _webhook_source()
+
+    monkeypatch.setattr(
+        "gateway.run._load_gateway_config",
+        lambda: {"platform_toolsets": {"webhook": ["terminal"]}},
+    )
+
+    def resolve_toolsets(config, platform_key):
+        events.append(("validated", tuple(config["platform_toolsets"][platform_key])))
+        return set()
+
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._get_platform_tools",
+        resolve_toolsets,
+    )
+    runner._run_agent_via_proxy = AsyncMock()
+
+    result = await runner._run_agent_inner(
+        message="deploy",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="session-1",
+    )
+
+    assert events == [("authority", source.chat_id)]
+    runner._run_agent_via_proxy.assert_not_awaited()
+    assert result["failed"] is True
+    assert result["completed"] is False
+    assert result["api_calls"] == 0
+    assert result["failure_reason"] == "proxy_source_toolsets_unsupported"
+
+
+def test_exact_admission_grant_bypasses_mutable_toolset_resolution(monkeypatch):
+    events = []
+    adapter = _ExactSourceToolsetAdapter(
+        ["web", "newly_removed_plugin", "web"],
+        events,
+        legacy=AssertionError("legacy authority must not replace the durable grant"),
+    )
+    runner = _proxy_runner(adapter)
+    source = _webhook_source()
+
+    def reject_live_resolution(_config, _platform_key):
+        raise AssertionError("durable grants must not be re-resolved")
+
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._get_platform_tools",
+        reject_live_resolution,
+    )
+
+    resolved, has_override, failed = runner._resolve_toolset_authority_for_source(
+        {"platform_toolsets": {"webhook": ["terminal"]}},
+        source,
+        "webhook",
+    )
+
+    assert resolved == ["web", "newly_removed_plugin"]
+    assert has_override is True
+    assert failed is False
+    assert events == [("exact", source.chat_id)]
+
+
+@pytest.mark.asyncio
+async def test_exact_nonempty_grant_blocks_proxy_without_live_resolution(monkeypatch):
+    events = []
+    adapter = _ExactSourceToolsetAdapter(
+        ["web", "durable_plugin"],
+        events,
+        legacy=AssertionError("legacy authority must not replace the durable grant"),
+    )
+    runner = _proxy_runner(adapter)
+    source = _webhook_source()
+    runner._run_agent_via_proxy = AsyncMock()
+
+    monkeypatch.setattr(
+        "gateway.run._load_gateway_config",
+        lambda: {"platform_toolsets": {"webhook": ["terminal"]}},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._get_platform_tools",
+        lambda *_args: (_ for _ in ()).throw(
+            AssertionError("durable grants must not be re-resolved")
+        ),
+    )
+
+    result = await runner._run_agent_inner(
+        message="deploy",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="session-1",
+    )
+
+    assert events == [("exact", source.chat_id)]
+    runner._run_agent_via_proxy.assert_not_awaited()
+    assert result["failed"] is True
+    assert result["completed"] is False
+    assert result["failure_reason"] == "proxy_source_toolsets_unsupported"
+
+
+@pytest.mark.parametrize(
+    "malformed",
+    [
+        pytest.param(("web",), id="tuple"),
+        pytest.param(["web", ""], id="blank-name"),
+        pytest.param(["web", 7], id="non-string"),
+    ],
+)
+def test_malformed_exact_grant_fails_closed_without_legacy_fallback(
+    malformed,
+    monkeypatch,
+):
+    events = []
+    adapter = _ExactSourceToolsetAdapter(
+        malformed,
+        events,
+        legacy=["terminal"],
+    )
+    runner = _proxy_runner(adapter)
+    source = _webhook_source()
+
+    def reject_live_resolution(_config, _platform_key):
+        raise AssertionError("malformed exact authority must fail before fallback")
+
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._get_platform_tools",
+        reject_live_resolution,
+    )
+
+    resolved, has_override, failed = runner._resolve_toolset_authority_for_source(
+        {"platform_toolsets": {"webhook": ["terminal"]}},
+        source,
+        "webhook",
+    )
+
+    assert resolved == []
+    assert has_override is True
+    assert failed is True
+    assert events == [("exact", source.chat_id)]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "malformed",
+    [pytest.param(("web",), id="tuple"), pytest.param(["web", 7], id="non-string")],
+)
+async def test_malformed_exact_grant_blocks_full_proxy_path(malformed, monkeypatch):
+    events = []
+    adapter = _ExactSourceToolsetAdapter(malformed, events, legacy=["terminal"])
+    runner = _proxy_runner(adapter)
+    source = _webhook_source()
+    runner._run_agent_via_proxy = AsyncMock()
+
+    monkeypatch.setattr(
+        "gateway.run._load_gateway_config",
+        lambda: {"platform_toolsets": {"webhook": ["terminal"]}},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._get_platform_tools",
+        lambda *_args: (_ for _ in ()).throw(
+            AssertionError("malformed authority must fail before live resolution")
+        ),
+    )
+
+    result = await runner._run_agent_inner(
+        message="deploy",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="session-1",
+    )
+
+    assert events == [("exact", source.chat_id)]
+    runner._run_agent_via_proxy.assert_not_awaited()
+    assert result["failure_reason"] == "proxy_source_toolset_resolution_failed"
+
+
+@pytest.mark.asyncio
+async def test_exact_empty_grant_blocks_proxy_without_live_resolution(monkeypatch):
+    events = []
+    adapter = _ExactSourceToolsetAdapter(
+        [],
+        events,
+        legacy=AssertionError("legacy authority must not replace deny-all"),
+    )
+    runner = _proxy_runner(adapter)
+    source = _webhook_source()
+    runner._run_agent_via_proxy = AsyncMock()
+
+    monkeypatch.setattr(
+        "gateway.run._load_gateway_config",
+        lambda: {"platform_toolsets": {"webhook": ["terminal"]}},
+    )
+
+    def reject_live_resolution(_config, _platform_key):
+        raise AssertionError("deny-all must not be re-resolved")
+
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._get_platform_tools",
+        reject_live_resolution,
+    )
+
+    result = await runner._run_agent_inner(
+        message="deploy",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="session-1",
+    )
+
+    assert events == [("exact", source.chat_id)]
+    runner._run_agent_via_proxy.assert_not_awaited()
+    assert result["failure_reason"] == "proxy_source_toolsets_unsupported"
+
+
+@pytest.mark.asyncio
+async def test_proxy_delegation_remains_available_without_source_override(
+    monkeypatch,
+):
+    events = []
+    adapter = _SourceToolsetAdapter(None, events)
+    runner = _proxy_runner(adapter)
+    source = _webhook_source()
+    expected = {
+        "final_response": "remote",
+        "messages": [],
+        "api_calls": 1,
+        "tools": [],
+    }
+
+    monkeypatch.setattr(
+        "gateway.run._load_gateway_config",
+        lambda: {"platform_toolsets": {"webhook": ["web"]}},
+    )
+
+    def resolve_toolsets(config, platform_key):
+        events.append(("validated", tuple(config["platform_toolsets"][platform_key])))
+        return {"web"}
+
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._get_platform_tools",
+        resolve_toolsets,
+    )
+
+    async def run_proxy(**_kwargs):
+        events.append(("proxy", source.chat_id))
+        return expected
+
+    runner._run_agent_via_proxy = AsyncMock(side_effect=run_proxy)
+
+    result = await runner._run_agent_inner(
+        message="deploy",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="session-1",
+    )
+
+    assert result is expected
+    assert events == [
+        ("authority", source.chat_id),
+        ("validated", ("web",)),
+        ("proxy", source.chat_id),
+    ]
+    runner._run_agent_via_proxy.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_proxy_fails_closed_when_source_authority_resolution_errors(
+    monkeypatch,
+):
+    events = []
+    adapter = _SourceToolsetAdapter(RuntimeError("snapshot unavailable"), events)
+    runner = _proxy_runner(adapter)
+    source = _webhook_source()
+
+    monkeypatch.setattr(
+        "gateway.run._load_gateway_config",
+        lambda: {"platform_toolsets": {"webhook": ["web"]}},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._get_platform_tools",
+        lambda _config, _platform_key: {"web"},
+    )
+    runner._run_agent_via_proxy = AsyncMock()
+
+    result = await runner._run_agent_inner(
+        message="deploy",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="session-1",
+    )
+
+    assert events == [("authority", source.chat_id)]
+    runner._run_agent_via_proxy.assert_not_awaited()
+    assert result["failed"] is True
+    assert result["completed"] is False
+    assert result["api_calls"] == 0
+    assert result["failure_reason"] == "proxy_source_toolset_resolution_failed"
+
+
+def test_local_toolsets_fail_closed_when_exact_authority_resolution_errors(
+    monkeypatch,
+):
+    events = []
+    adapter = _ExactSourceToolsetAdapter(
+        RuntimeError("durable grant unavailable"),
+        events,
+        legacy=["terminal"],
+    )
+    runner = _proxy_runner(adapter)
+    source = _webhook_source()
+
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._get_platform_tools",
+        lambda _config, _platform_key: {"terminal"},
+    )
+
+    resolved = runner._resolve_enabled_toolsets_for_source(
+        {"platform_toolsets": {"webhook": ["terminal"]}},
+        source,
+        "webhook",
+    )
+
+    assert resolved == []
+    assert events == [("exact", source.chat_id)]
+
+
+@pytest.mark.asyncio
+async def test_webhook_recovery_delegates_to_primary_adapter_with_trigger():
+    adapter = SimpleNamespace(recover_pending_operations=AsyncMock(return_value=3))
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {Platform.WEBHOOK: adapter}
+
+    recovered = await runner._recover_webhook_operations(trigger="reconnect:webhook")
+
+    assert recovered == 3
+    adapter.recover_pending_operations.assert_awaited_once_with(
+        trigger="reconnect:webhook"
+    )
+
+
+@pytest.mark.asyncio
+async def test_webhook_recovery_is_noop_without_recovery_capability():
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {Platform.WEBHOOK: object()}
+
+    assert await runner._recover_webhook_operations(trigger="startup") == 0
+
+
+@pytest.mark.asyncio
+async def test_webhook_recovery_failure_does_not_break_gateway_reconnect():
+    adapter = SimpleNamespace(
+        recover_pending_operations=AsyncMock(
+            side_effect=RuntimeError("ledger unavailable")
+        )
+    )
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {Platform.WEBHOOK: adapter}
+
+    assert await runner._recover_webhook_operations(trigger="reconnect:webhook") == 0
+    adapter.recover_pending_operations.assert_awaited_once_with(
+        trigger="reconnect:webhook"
+    )

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -5,12 +5,12 @@ Covers:
 - Prompt rendering with dot-notation template variables
 - Event type filtering
 - HTTP handler behaviour (404, 202, health)
-- Idempotency cache (duplicate delivery IDs)
+- Durable replay admission and duplicate delivery identities
 - Rate limiting (fixed-window, per route)
 - Body size limits
 - INSECURE_NO_AUTH bypass
 - Session isolation for concurrent webhooks
-- Delivery info cleanup after send()
+- Durable final-delivery settlement
 - connect / disconnect lifecycle
 """
 
@@ -22,6 +22,7 @@ import json
 import socket
 import time
 from collections import deque
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -41,12 +42,13 @@ from gateway.platforms.webhook import (
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _make_config(
     routes=None,
     secret="",
     rate_limit=30,
     max_body_bytes=1_048_576,
-    host="0.0.0.0",
+    host="127.0.0.1",
     port=0,  # let OS pick a free port in tests
 ):
     """Build a PlatformConfig suitable for WebhookAdapter."""
@@ -66,6 +68,15 @@ def _make_adapter(routes=None, **kwargs):
     """Create a WebhookAdapter with sensible defaults for testing."""
     config = _make_config(routes=routes, **kwargs)
     return WebhookAdapter(config)
+
+
+def _write_deny_all_toolset_authority(home):
+    """Create the profile config that production startup requires for grants."""
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text(
+        "platform_toolsets:\n  webhook: []\n",
+        encoding="utf-8",
+    )
 
 
 def _create_app(adapter: WebhookAdapter) -> web.Application:
@@ -94,9 +105,25 @@ def _mock_request(headers=None, body=b"", content_length=None, match_info=None):
 
 def _github_signature(body: bytes, secret: str) -> str:
     """Compute X-Hub-Signature-256 for *body* using *secret*."""
-    return "sha256=" + hmac.new(
-        secret.encode(), body, hashlib.sha256
-    ).hexdigest()
+    return "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+
+
+def _github_pull_request_body(number: int = 42) -> bytes:
+    return json.dumps(
+        {
+            "action": "opened",
+            "number": number,
+            "pull_request": {
+                "id": 701,
+                "number": number,
+                "state": "open",
+                "title": "Authenticated PR",
+            },
+            "repository": {"id": 801, "full_name": "org/repo"},
+            "sender": {"id": 901, "login": "octocat"},
+        },
+        separators=(",", ":"),
+    ).encode()
 
 
 def _generic_signature(body: bytes, secret: str) -> str:
@@ -130,12 +157,13 @@ def _svix_signature(body: bytes, secret: str, msg_id: str, timestamp: str) -> st
 class TestValidateSignature:
     """Tests for WebhookAdapter._validate_signature."""
 
-
     def test_validate_no_signature_with_secret_rejects(self):
         """Secret configured but no recognised signature header → reject."""
         adapter = _make_adapter()
         req = _mock_request(headers={})  # no sig headers at all
-        assert adapter._validate_signature(req, b"{}", "my-secret") is False
+        assert (
+            adapter._validate_signature(req, b"{}", "my-secret", "generic_v2") is False
+        )
 
     def test_non_ascii_signature_headers_reject_without_raising(self):
         """The signature headers are attacker-controlled on a public, unauth
@@ -145,15 +173,15 @@ class TestValidateSignature:
         body = b'{"action": "opened"}'
         secret = "webhook-secret-42"
         hostile = "ské-not-a-valid-signature"
-        for header in (
-            "X-Hub-Signature-256",
-            "X-Gitlab-Token",
-            "X-Webhook-Signature",
-            "linear-signature",
+        for header, mode in (
+            ("X-Hub-Signature-256", "github"),
+            ("X-Gitlab-Token", "gitlab"),
+            ("X-Webhook-Signature", "generic_v1"),
+            ("linear-signature", "linear"),
         ):
             req = _mock_request(headers={header: hostile})
             # Must return False, never raise.
-            assert adapter._validate_signature(req, body, secret) is False
+            assert adapter._validate_signature(req, body, secret, mode) is False
 
     def test_linear_signature_valid_accepts(self):
         """Linear signs the raw body (hex HMAC-SHA256) in linear-signature."""
@@ -164,7 +192,7 @@ class TestValidateSignature:
 
         req = _mock_request(headers={"linear-signature": sig})
 
-        assert adapter._validate_signature(req, body, secret) is True
+        assert adapter._validate_signature(req, body, secret, "linear") is True
 
     def test_linear_signature_mismatch_rejects(self):
         """A well-formed linear-signature computed with the wrong key fails closed."""
@@ -174,20 +202,23 @@ class TestValidateSignature:
 
         req = _mock_request(headers={"linear-signature": sig})
 
-        assert adapter._validate_signature(req, body, "real-secret") is False
-
+        assert adapter._validate_signature(req, body, "real-secret", "linear") is False
 
     def test_non_ascii_svix_signature_rejected(self):
         """The Svix branch also runs its `v1,<sig>` comparison through the
         hardened helper: a valid svix-id + fresh timestamp reaches the compare,
         and a non-ASCII signature must reject rather than raise."""
         adapter = _make_adapter()
-        req = _mock_request(headers={
-            "svix-id": "msg_2xabc",
-            "svix-timestamp": str(int(time.time())),  # inside the replay window
-            "svix-signature": "v1,ské-not-a-valid-base64-sig",
-        })
-        assert adapter._validate_signature(req, b'{"x":1}', "shh-secret") is False
+        req = _mock_request(
+            headers={
+                "svix-id": "msg_2xabc",
+                "svix-timestamp": str(int(time.time())),  # inside the replay window
+                "svix-signature": "v1,ské-not-a-valid-base64-sig",
+            }
+        )
+        assert (
+            adapter._validate_signature(req, b'{"x":1}', "shh-secret", "svix") is False
+        )
 
     def test_non_ascii_secret_still_validates_a_matching_token(self):
         """A non-ASCII configured secret must still match its exact GitLab
@@ -195,25 +226,7 @@ class TestValidateSignature:
         adapter = _make_adapter()
         secret = "gl-tökén-välue"
         req = _mock_request(headers={"X-Gitlab-Token": secret})
-        assert adapter._validate_signature(req, b"{}", secret) is True
-
-    def test_validate_no_secret_allows_all(self):
-        """When the secret is empty/falsy, the validator is never even called
-        by the handler (secret check is 'if secret and secret != _INSECURE...').
-        Verify that an empty secret isn't accidentally passed to the validator."""
-        # This tests the semantics: empty secret means skip validation entirely.
-        # The handler code does: if secret and secret != _INSECURE_NO_AUTH: validate
-        # So with an empty secret, _validate_signature is never reached.
-        # We just verify the code path is correct by constructing an adapter
-        # with no secret and confirming the route config resolves to "".
-        adapter = _make_adapter(
-            routes={"test": {"prompt": "hello"}},
-            secret="",
-        )
-        # The route has no secret, global secret is empty
-        route_secret = adapter._routes["test"].get("secret", adapter._global_secret)
-        assert not route_secret  # empty → validation is skipped in handler
-
+        assert adapter._validate_signature(req, b"{}", secret, "gitlab") is True
 
     def test_validate_generic_v2_wrong_timestamp_rejects(self):
         """The timestamp is cryptographically bound into the V2 signature —
@@ -228,12 +241,13 @@ class TestValidateSignature:
         real_timestamp = str(int(time.time()))
         sig = _generic_v2_signature(body, secret, real_timestamp)
         forged_timestamp = str(int(time.time()) + 1)
-        req = _mock_request(headers={
-            "X-Webhook-Signature-V2": sig,
-            "X-Webhook-Timestamp": forged_timestamp,
-        })
-        assert adapter._validate_signature(req, body, secret) is False
-
+        req = _mock_request(
+            headers={
+                "X-Webhook-Signature-V2": sig,
+                "X-Webhook-Timestamp": forged_timestamp,
+            }
+        )
+        assert adapter._validate_signature(req, body, secret, "generic_v2") is False
 
     def test_validate_generic_v2_stripped_timestamp_does_not_downgrade_to_v1(self):
         """Regression test for a downgrade attack found in review: a sender
@@ -245,7 +259,7 @@ class TestValidateSignature:
         reject — it must NOT silently fall through to validating the
         still-present, still-unprotected V1 signature instead. Falling
         through would let an attacker downgrade a V2-protected request
-        back into the exact replay hole V2 exists to close, just by
+        back into the signed-freshness gap V2 exists to close, just by
         deleting one header from a captured request."""
         adapter = _make_adapter()
         body = b'{"event": "push"}'
@@ -256,32 +270,39 @@ class TestValidateSignature:
         # Simulates a captured mixed V1+V2 request replayed with the
         # timestamp header stripped — V1 signature is still valid on its
         # own, but must not be reachable via this path.
-        req = _mock_request(headers={
-            "X-Webhook-Signature-V2": v2_sig,
-            "X-Webhook-Signature": v1_sig,
-            # X-Webhook-Timestamp deliberately omitted.
-        })
-        assert adapter._validate_signature(req, body, secret) is False
+        req = _mock_request(
+            headers={
+                "X-Webhook-Signature-V2": v2_sig,
+                "X-Webhook-Signature": v1_sig,
+                # X-Webhook-Timestamp deliberately omitted.
+            }
+        )
+        assert adapter._validate_signature(req, body, secret, "generic_v2") is False
 
-    def test_v1_replay_attack_succeeds_demonstrating_the_hole_v2_closes(self):
-        """Regression/documentation test: a captured (body, signature) V1
-        pair replays successfully no matter how much time has passed,
-        because the V1 signature has no timestamp binding at all. This is
-        the exact vulnerability V2 fixes — it is not asserting desired
-        behavior, it is pinning the known, accepted-with-warning legacy
-        gap so a future change to V1's semantics doesn't silently alter it
-        without a deliberate decision."""
+    def test_v1_mac_revalidates_later_but_durable_body_fence_is_separate(self):
+        """V1 authentication has no clock binding of its own.
+
+        This verifier-only test deliberately does not exercise HTTP admission:
+        the durable ledger separately prevents an identical authenticated body
+        from executing twice. V2 additionally rejects a captured request whose
+        first presentation occurs outside its signed freshness window.
+        """
         adapter = _make_adapter()
         body = b'{"event": "push"}'
         secret = "generic-secret"
         sig = _generic_signature(body, secret)
         original_request = _mock_request(headers={"X-Webhook-Signature": sig})
-        assert adapter._validate_signature(original_request, body, secret) is True
+        assert (
+            adapter._validate_signature(original_request, body, secret, "generic_v1")
+            is True
+        )
         # "Time passes" — nothing about a V1 signature depends on time, so
         # a captured pair replayed much later still validates.
         replayed_request = _mock_request(headers={"X-Webhook-Signature": sig})
-        assert adapter._validate_signature(replayed_request, body, secret) is True
-
+        assert (
+            adapter._validate_signature(replayed_request, body, secret, "generic_v1")
+            is True
+        )
 
     def test_validate_svix_signature_raw_secret_valid(self):
         """Raw shared secrets are accepted for Svix-style senders without whsec_ secrets."""
@@ -298,7 +319,7 @@ class TestValidateSignature:
                 "svix-signature": sig,
             }
         )
-        assert adapter._validate_signature(req, body, secret) is True
+        assert adapter._validate_signature(req, body, secret, "svix") is True
 
 
 # ===================================================================
@@ -331,7 +352,11 @@ class TestRenderDeliveryExtra:
     def test_render_delivery_extra_templates(self):
         """String values in deliver_extra are rendered with payload data."""
         adapter = _make_adapter()
-        extra = {"repo": "{repository.full_name}", "pr_number": "{number}", "static": 42}
+        extra = {
+            "repo": "{repository.full_name}",
+            "pr_number": "{number}",
+            "static": 42,
+        }
         payload = {"repository": {"full_name": "org/repo"}, "number": 7}
         result = adapter._render_delivery_extra(extra, payload)
         assert result["repo"] == "org/repo"
@@ -353,6 +378,7 @@ class TestEventFilter:
         routes = {
             "gh": {
                 "secret": _INSECURE_NO_AUTH,
+                "provider": "github",
                 "events": ["pull_request"],
                 "prompt": "PR: {action}",
             }
@@ -379,7 +405,6 @@ class TestEventFilter:
 class TestPayloadFilters:
     """Tests for route-level payload filters in _handle_webhook."""
 
-
     @pytest.mark.asyncio
     async def test_filter_accepts_nested_any_and_in_file(self, tmp_path, monkeypatch):
         """Nested any groups can match dynamic watchlists under HERMES_HOME."""
@@ -390,6 +415,7 @@ class TestPayloadFilters:
         routes = {
             "waha": {
                 "secret": _INSECURE_NO_AUTH,
+                "provider": "github",
                 "filters": [
                     {"field": "payload.fromMe", "equals": False},
                     {
@@ -435,9 +461,10 @@ class TestPayloadFilters:
         assert len(captured) == 1
         assert captured[0].text == "Message from chat-2: hello"
 
-
     @pytest.mark.asyncio
-    async def test_script_transforms_payload_before_prompt_rendering(self, tmp_path, monkeypatch):
+    async def test_script_transforms_payload_before_prompt_rendering(
+        self, tmp_path, monkeypatch
+    ):
         """A script can replace the payload used by prompt templates."""
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         scripts = tmp_path / "scripts"
@@ -453,6 +480,7 @@ class TestPayloadFilters:
         routes = {
             "todoist": {
                 "secret": _INSECURE_NO_AUTH,
+                "provider": "github",
                 "script": "todoist_filter.py",
                 "prompt": "Task: {body}",
             }
@@ -485,45 +513,59 @@ class TestPayloadFilters:
 
 
 class TestHTTPHandling:
-
     @pytest.mark.asyncio
     async def test_unknown_route_returns_404(self):
         """POST to an unknown route returns 404."""
-        adapter = _make_adapter(routes={"real": {"secret": _INSECURE_NO_AUTH, "prompt": "x"}})
+        adapter = _make_adapter(
+            routes={
+                "real": {
+                    "secret": _INSECURE_NO_AUTH,
+                    "provider": "generic",
+                    "prompt": "x",
+                }
+            }
+        )
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
             resp = await cli.post("/webhooks/nonexistent", json={"a": 1})
             assert resp.status == 404
 
-
     @pytest.mark.asyncio
-    async def test_route_without_secret_rejects_unsigned_request(self):
-        """Missing HMAC secret must fail closed even if connect() was bypassed."""
-        routes = {"test": {"prompt": "hi"}}
+    async def test_route_without_secret_is_route_misconfiguration(self):
+        """A missing HMAC secret fails at route publication, before authentication."""
+        routes = {"test": {"provider": "generic", "prompt": "hi"}}
         adapter = _make_adapter(routes=routes, secret="")
         adapter.handle_message = AsyncMock()
 
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
             resp = await cli.post("/webhooks/test", json={"data": "value"})
-            assert resp.status == 403
+            assert resp.status == 500
             data = await resp.json()
-            assert data["error"] == "Webhook route is missing an HMAC secret"
+            assert data == {
+                "status": "failed",
+                "error": "Webhook route is misconfigured",
+            }
 
         adapter.handle_message.assert_not_called()
 
 
 # ===================================================================
-# Idempotency
+# Durable replay admission
 # ===================================================================
 
 
 class TestIdempotency:
-
     @pytest.mark.asyncio
-    async def test_duplicate_delivery_id_returns_200(self):
-        """Second request with same delivery ID returns 200 duplicate."""
-        routes = {"idem": {"secret": _INSECURE_NO_AUTH, "prompt": "test"}}
+    async def test_in_flight_delivery_id_returns_202(self):
+        """A retry cannot turn an in-flight operation into duplicate success."""
+        routes = {
+            "idem": {
+                "secret": _INSECURE_NO_AUTH,
+                "provider": "github",
+                "prompt": "test",
+            }
+        }
         adapter = _make_adapter(routes=routes)
         adapter.handle_message = AsyncMock()
 
@@ -534,9 +576,9 @@ class TestIdempotency:
             assert resp1.status == 202
 
             resp2 = await cli.post("/webhooks/idem", json={"a": 1}, headers=headers)
-            assert resp2.status == 200
+            assert resp2.status == 202
             data = await resp2.json()
-            assert data["status"] == "duplicate"
+            assert data["status"] == "in_progress"
 
 
 # ===================================================================
@@ -545,11 +587,16 @@ class TestIdempotency:
 
 
 class TestRateLimiting:
-
     @pytest.mark.asyncio
     async def test_rate_limit_rejects_excess(self):
         """Exceeding the rate limit returns 429."""
-        routes = {"limited": {"secret": _INSECURE_NO_AUTH, "prompt": "test"}}
+        routes = {
+            "limited": {
+                "secret": _INSECURE_NO_AUTH,
+                "provider": "github",
+                "prompt": "test",
+            }
+        }
         adapter = _make_adapter(routes=routes, rate_limit=2)
         adapter.handle_message = AsyncMock()
 
@@ -579,11 +626,16 @@ class TestRateLimiting:
 
 
 class TestBodySize:
-
     @pytest.mark.asyncio
     async def test_oversized_payload_rejected(self):
         """Content-Length > max_body_bytes returns 413."""
-        routes = {"big": {"secret": _INSECURE_NO_AUTH, "prompt": "test"}}
+        routes = {
+            "big": {
+                "secret": _INSECURE_NO_AUTH,
+                "provider": "generic",
+                "prompt": "test",
+            }
+        }
         adapter = _make_adapter(routes=routes, max_body_bytes=100)
 
         app = _create_app(adapter)
@@ -603,11 +655,16 @@ class TestBodySize:
 
 
 class TestInsecureNoAuth:
-
     @pytest.mark.asyncio
     async def test_insecure_no_auth_skips_validation(self):
         """Setting secret to _INSECURE_NO_AUTH bypasses signature check."""
-        routes = {"open": {"secret": _INSECURE_NO_AUTH, "prompt": "hello"}}
+        routes = {
+            "open": {
+                "secret": _INSECURE_NO_AUTH,
+                "provider": "generic",
+                "prompt": "hello",
+            }
+        }
         adapter = _make_adapter(routes=routes)
         adapter.handle_message = AsyncMock()
 
@@ -624,11 +681,16 @@ class TestInsecureNoAuth:
 
 
 class TestSessionIsolation:
-
     @pytest.mark.asyncio
     async def test_concurrent_webhooks_get_independent_sessions(self):
         """Two events on the same route produce different session keys."""
-        routes = {"ci": {"secret": _INSECURE_NO_AUTH, "prompt": "build"}}
+        routes = {
+            "ci": {
+                "secret": _INSECURE_NO_AUTH,
+                "provider": "github",
+                "prompt": "build",
+            }
+        }
         adapter = _make_adapter(routes=routes)
 
         captured_events = []
@@ -678,47 +740,80 @@ class TestWebhookSilenceSuppression:
     repeatedly messaging its owner to say it had nothing to say.
     """
 
-    def _adapter_with_mock_target(self):
-        adapter = _make_adapter()
+    async def _adapter_with_mock_target(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _write_deny_all_toolset_authority(tmp_path)
+        adapter = _make_adapter(
+            routes={
+                "helper-events": {
+                    "secret": _INSECURE_NO_AUTH,
+                    "provider": "github",
+                    "prompt": "Tick: {message}",
+                    "deliver": "telegram",
+                    "deliver_extra": {"chat_id": "-100123"},
+                }
+            }
+        )
         mock_target = AsyncMock()
         mock_target.send = AsyncMock(return_value=SendResult(success=True))
+        mock_target.config = PlatformConfig(enabled=True)
         mock_runner = MagicMock()
-        mock_runner.adapters = {Platform("telegram"): mock_target}
-        mock_runner.config.get_home_channel.return_value = None
-        adapter.gateway_runner = mock_runner
-
-        chat_id = "webhook:helper-events:d-1"
-        adapter._delivery_info[chat_id] = {
-            "deliver": "telegram",
-            "deliver_extra": {"chat_id": "-100123"},
+        mock_runner.adapters = {
+            Platform.WEBHOOK: adapter,
+            Platform("telegram"): mock_target,
         }
-        adapter._delivery_info_created[chat_id] = time.time()
-        return adapter, mock_target, chat_id
+        mock_runner.config.get_home_channel.return_value = None
+        mock_runner._authorization_adapter = None
+        adapter.gateway_runner = mock_runner
+        adapter.handle_message = AsyncMock()
+
+        async with TestClient(TestServer(_create_app(adapter))) as cli:
+            response = await cli.post(
+                "/webhooks/helper-events",
+                json={"message": "nothing new"},
+                headers={"X-GitHub-Delivery": "silence-1"},
+            )
+            assert response.status == 202
+        await asyncio.sleep(0.01)
+        event = adapter.handle_message.await_args.args[0]
+        await adapter.on_processing_start(event)
+        return adapter, mock_target, event.source.chat_id
 
     @pytest.mark.asyncio
-    async def test_bare_marker_is_not_delivered(self):
-        adapter, target, chat_id = self._adapter_with_mock_target()
+    async def test_bare_marker_is_not_delivered(self, tmp_path, monkeypatch):
+        adapter, target, chat_id = await self._adapter_with_mock_target(
+            tmp_path,
+            monkeypatch,
+        )
 
-        result = await adapter.send(chat_id, "[SILENT]")
+        result = await adapter.send(chat_id, "[SILENT]", metadata={"notify": True})
 
         assert result.success is True
         target.send.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_marker_followed_by_prose_is_not_delivered(self):
+    async def test_marker_followed_by_prose_is_not_delivered(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
         """The regression this suppression exists for.
 
         The agent explains its own silence on the lines after the marker.  The
         strict interactive rule reads that as substantive prose and delivers the
         whole thing, marker included.
         """
-        adapter, target, chat_id = self._adapter_with_mock_target()
+        adapter, target, chat_id = await self._adapter_with_mock_target(
+            tmp_path,
+            monkeypatch,
+        )
 
         result = await adapter.send(
             chat_id,
             "[SILENT]\n\nThe new inbound was the same email quoted back a second "
             "time, on a ticket we already answered. Nothing new to reply to, so I "
             "closed it; it reopens by itself if they write back.",
+            metadata={"notify": True},
         )
 
         assert result.success is True
@@ -731,35 +826,82 @@ class TestWebhookSilenceSuppression:
 
 
 class TestDeliveryCleanup:
+    @pytest.mark.asyncio
+    async def test_missing_delivery_authority_never_falls_back_to_log_success(self):
+        adapter = _make_adapter()
+        result = await adapter.send(
+            "webhook:default:events:github:missing",
+            "Final agent response",
+        )
+        assert result.success is False
+        assert result.error == "Missing admitted webhook delivery authority"
 
     @pytest.mark.asyncio
-    async def test_delivery_info_survives_multiple_sends(self):
-        """send() must NOT pop delivery_info.
+    async def test_interim_send_cannot_consume_final_delivery_authority(self):
+        """Only an explicitly marked final response may stage the exact effect."""
+        adapter = _make_adapter(
+            routes={
+                "test": {
+                    "secret": _INSECURE_NO_AUTH,
+                    "provider": "github",
+                    "prompt": "{message}",
+                    "deliver": "log",
+                }
+            }
+        )
+        adapter.handle_message = AsyncMock()
+        async with TestClient(TestServer(_create_app(adapter))) as cli:
+            response = await cli.post(
+                "/webhooks/test",
+                json={"message": "run"},
+                headers={"X-GitHub-Delivery": "delivery-authority-1"},
+            )
+            assert response.status == 202
+        await asyncio.sleep(0.01)
+        event = adapter.handle_message.await_args.args[0]
+        chat_id = event.source.chat_id
 
-        Interim status messages (fallback notifications, context-pressure
-        warnings, etc.) flow through the same send() path as the final
-        response.  If the entry were popped on the first send, the final
-        response would silently downgrade to the ``log`` deliver type.
-        Regression test for that bug.
-        """
-        adapter = _make_adapter()
-        chat_id = "webhook:test:d-xyz"
-        adapter._delivery_info[chat_id] = {
-            "deliver": "log",
-            "deliver_extra": {},
-        }
-        adapter._delivery_info_created[chat_id] = time.time()
+        admitted = adapter._operation_ledger.lookup_session(chat_id)
+        assert admitted is not None
+        assert admitted.delivery is None
 
-        # First send (e.g. an interim status message)
-        result1 = await adapter.send(chat_id, "Status: switching to fallback")
+        # An interim status is acknowledged but cannot stage or consume the target.
+        result1 = await adapter.send(
+            chat_id,
+            "Status: switching to fallback",
+            metadata={"notify": True, "_interim_send": True},
+        )
         assert result1.success is True
-        # Entry must still be present so the final send can read it
-        assert chat_id in adapter._delivery_info
+        after_interim = adapter._operation_ledger.lookup_session(chat_id)
+        assert after_interim is not None
+        assert after_interim.delivery is None
 
-        # Second send (the final agent response)
-        result2 = await adapter.send(chat_id, "Final agent response")
+        # The marked final response is durably staged and settled exactly once.
+        await adapter.on_processing_start(event)
+        result2 = await adapter.send(
+            chat_id,
+            "Final agent response",
+            metadata={"notify": True},
+        )
         assert result2.success is True
-        assert chat_id in adapter._delivery_info
+        settled = adapter._operation_ledger.lookup_session(chat_id)
+        assert settled is not None
+        assert settled.delivery is not None
+        assert settled.delivery.content == "Final agent response"
+
+        # An exact repeat reads the cached settlement; contradictory content fails.
+        repeat = await adapter.send(
+            chat_id,
+            "Final agent response",
+            metadata={"notify": True},
+        )
+        assert repeat.success is True
+        conflict = await adapter.send(
+            chat_id,
+            "Different final response",
+            metadata={"notify": True},
+        )
+        assert conflict.success is False
 
 
 # ===================================================================
@@ -768,7 +910,6 @@ class TestDeliveryCleanup:
 
 
 class TestCheckRequirements:
-
     @patch("gateway.platforms.webhook.AIOHTTP_AVAILABLE", False)
     def test_returns_false_without_aiohttp(self):
         assert check_webhook_requirements() is False
@@ -782,7 +923,6 @@ class TestCheckRequirements:
 class TestRawTemplateToken:
     """Tests for the {__raw__} special token in _render_prompt."""
 
-
     def test_raw_mixed_with_other_variables(self):
         """{__raw__} can be mixed with regular template variables."""
         adapter = _make_adapter()
@@ -791,8 +931,10 @@ class TestRawTemplateToken:
             "Action={action} Raw={__raw__}", payload, "push", "test"
         )
         assert result.startswith("Action=closed Raw=")
-        assert '"action": "closed"' in result
-        assert '"number": 7' in result
+        envelope = json.loads(result.split(" Raw=", 1)[1])
+        assert envelope["truncated"] is False
+        assert '"action": "closed"' in envelope["payload"]
+        assert '"number": 7' in envelope["payload"]
 
 
 # ===================================================================
@@ -801,32 +943,66 @@ class TestRawTemplateToken:
 
 
 class TestDeliverCrossPlatformThreadId:
-    """Tests for thread_id passthrough in _deliver_cross_platform."""
+    """Tests for thread_id passthrough through the durable target gate."""
 
-    def _setup_adapter_with_mock_target(self):
+    def _setup_adapter_with_mock_target(self, tmp_path, monkeypatch):
         """Set up a webhook adapter with a mocked gateway_runner and target adapter."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _write_deny_all_toolset_authority(tmp_path)
         adapter = _make_adapter()
         mock_target = AsyncMock()
         mock_target.send = AsyncMock(return_value=SendResult(success=True))
+        mock_target.config = PlatformConfig(enabled=True)
 
         mock_runner = MagicMock()
-        mock_runner.adapters = {Platform("telegram"): mock_target}
+        mock_runner.adapters = {
+            Platform.WEBHOOK: adapter,
+            Platform("telegram"): mock_target,
+        }
         mock_runner.config.get_home_channel.return_value = None
+        mock_runner._authorization_adapter = None
 
         adapter.gateway_runner = mock_runner
         return adapter, mock_target
 
     @pytest.mark.asyncio
-    async def test_thread_id_passed_as_metadata(self):
+    async def test_thread_id_passed_as_metadata(self, tmp_path, monkeypatch):
         """thread_id from deliver_extra is passed as metadata to adapter.send()."""
-        adapter, mock_target = self._setup_adapter_with_mock_target()
-        delivery = {
-            "deliver_extra": {
-                "chat_id": "12345",
-                "thread_id": "999",
+        adapter, mock_target = self._setup_adapter_with_mock_target(
+            tmp_path,
+            monkeypatch,
+        )
+        adapter._static_routes = {
+            "threaded": {
+                "secret": _INSECURE_NO_AUTH,
+                "provider": "github",
+                "prompt": "{message}",
+                "deliver": "telegram",
+                "deliver_extra": {
+                    "chat_id": "12345",
+                    "thread_id": "999",
+                },
             }
         }
-        await adapter._deliver_cross_platform("telegram", "hello", delivery)
+        adapter._routes = dict(adapter._static_routes)
+        adapter.handle_message = AsyncMock()
+        async with TestClient(TestServer(_create_app(adapter))) as cli:
+            response = await cli.post(
+                "/webhooks/threaded",
+                json={"message": "run"},
+                headers={"X-GitHub-Delivery": "thread-1"},
+            )
+            assert response.status == 202
+        await asyncio.sleep(0.01)
+        event = adapter.handle_message.await_args.args[0]
+        await adapter.on_processing_start(event)
+
+        result = await adapter.send(
+            event.source.chat_id,
+            "hello",
+            metadata={"notify": True},
+        )
+        assert result.success is True
         mock_target.send.assert_awaited_once_with(
             "12345", "hello", metadata={"thread_id": "999"}
         )
@@ -837,7 +1013,6 @@ class TestInsecureNoAuthSafetyRail:
     non-loopback bind. Guards against accidentally exposing an unauthenticated
     webhook endpoint on a public interface."""
 
-
     @pytest.mark.parametrize(
         "host",
         ["127.0.0.1", "localhost"],
@@ -845,7 +1020,13 @@ class TestInsecureNoAuthSafetyRail:
     @pytest.mark.asyncio
     async def test_connect_allows_insecure_no_auth_on_loopback(self, host):
         """Recognised loopback hosts are permitted with INSECURE_NO_AUTH."""
-        routes = {"r1": {"secret": _INSECURE_NO_AUTH, "prompt": "x"}}
+        routes = {
+            "r1": {
+                "secret": _INSECURE_NO_AUTH,
+                "provider": "generic",
+                "prompt": "x",
+            }
+        }
         adapter = _make_adapter(routes=routes, host=host, port=0)
         try:
             with patch.object(adapter, "_reload_dynamic_routes"):
@@ -854,11 +1035,16 @@ class TestInsecureNoAuthSafetyRail:
         finally:
             await adapter.disconnect()
 
-
     @pytest.mark.asyncio
     async def test_connect_allows_real_secret_on_public_bind(self):
         """A real HMAC secret bound to 0.0.0.0 is the normal production case."""
-        routes = {"r1": {"secret": "real-secret-abc123", "prompt": "x"}}
+        routes = {
+            "r1": {
+                "secret": "real-secret-abc123",
+                "provider": "generic",
+                "prompt": "x",
+            }
+        }
         adapter = _make_adapter(routes=routes, host="0.0.0.0", port=0)
         try:
             with patch.object(adapter, "_reload_dynamic_routes"):
@@ -884,13 +1070,11 @@ class TestDualStackBind:
     loopback health check and the AF_INET port-conflict probe.
     """
 
-
     def test_missing_host_key_resolves_to_none(self):
         """Config with no host key → dual-stack (None), not a literal string."""
         cfg = PlatformConfig(enabled=True, extra={"port": 0, "routes": {}})
         adapter = WebhookAdapter(cfg)
         assert adapter._host is None
-
 
     @pytest.mark.asyncio
     async def test_default_bind_serves_both_families(self):
@@ -902,13 +1086,19 @@ class TestDualStackBind:
         on an OS-assigned port (no mock) and inspects the runner's addresses.
         """
         # Build config WITHOUT a host key so the real DEFAULT_HOST (None)
-        # applies — _make_adapter's helper injects host="0.0.0.0" by default,
+        # applies — _make_adapter's helper injects a loopback host by default,
         # which would mask the dual-stack default under test here.
         cfg = PlatformConfig(
             enabled=True,
             extra={
                 "port": 0,
-                "routes": {"r1": {"secret": "real-secret-abc123", "prompt": "x"}},
+                "routes": {
+                    "r1": {
+                        "secret": "real-secret-abc123",
+                        "provider": "generic",
+                        "prompt": "x",
+                    }
+                },
             },
         )
         adapter = WebhookAdapter(cfg)
@@ -926,9 +1116,7 @@ class TestDualStackBind:
             has_v6 = any(len(a) == 4 for a in addrs)
             has_v4 = any(len(a) == 2 for a in addrs)
             assert has_v4, f"IPv4 bind missing — got {addrs}"
-            assert has_v6, (
-                f"IPv6 bind missing (the 6PN reachability bug) — got {addrs}"
-            )
+            assert has_v6, f"IPv6 bind missing (the 6PN reachability bug) — got {addrs}"
         finally:
             await adapter.disconnect()
 
@@ -937,15 +1125,25 @@ class TestDualStackBind:
 class TestMultiplexProfileWebhookAuthentication:
     @staticmethod
     def _configure_profiles(adapter, tmp_path, monkeypatch):
+        worker_home = tmp_path / "profiles" / "worker"
+        other_home = tmp_path / "profiles" / "other"
+        _write_deny_all_toolset_authority(worker_home)
+        _write_deny_all_toolset_authority(other_home)
         runner = MagicMock()
         runner.config.multiplex_profiles = True
+        runner._authorization_adapter = None
+        runner.adapters = {Platform.WEBHOOK: adapter}
+        runner._profile_adapters = {}
+        runner._resolve_profile_home_for_source = lambda source: (
+            tmp_path / "profiles" / str(source.profile)
+        )
         adapter.gateway_runner = runner
         monkeypatch.setattr(
             "hermes_cli.profiles.profiles_to_serve",
             lambda multiplex, profile_allowlist=None: [
                 ("default", tmp_path),
-                ("worker", tmp_path / "profiles" / "worker"),
-                ("other", tmp_path / "profiles" / "other"),
+                ("worker", worker_home),
+                ("other", other_home),
             ],
         )
 
@@ -963,21 +1161,19 @@ class TestMultiplexProfileWebhookAuthentication:
         return {
             "Content-Type": "application/json",
             "X-Hub-Signature-256": _github_signature(body, secret),
-            # Stop after successful authentication without dispatching an
-            # agent run; the route accepts only pull_request events.
-            "X-GitHub-Event": "push",
+            "X-GitHub-Event": "pull_request",
+            "X-GitHub-Delivery": "profile-bound-1",
         }
 
     @pytest.mark.asyncio
-    async def test_route_secret_is_bound_to_named_profile(
-        self, tmp_path, monkeypatch
-    ):
+    async def test_route_secret_is_bound_to_named_profile(self, tmp_path, monkeypatch):
         route_secret = "worker-route-secret-abc123"
         adapter = _make_adapter(
             routes={
                 "gh": {
                     "profile": "worker",
                     "secret": route_secret,
+                    "provider": "github",
                     "events": ["pull_request"],
                     "prompt": "PR: {action}",
                 }
@@ -985,7 +1181,8 @@ class TestMultiplexProfileWebhookAuthentication:
             host="127.0.0.1",
         )
         self._configure_profiles(adapter, tmp_path, monkeypatch)
-        body = b'{"action":"opened"}'
+        adapter.handle_message = AsyncMock()
+        body = _github_pull_request_body()
         headers = self._headers(body, route_secret)
 
         async with TestClient(TestServer(self._app(adapter))) as cli:
@@ -994,8 +1191,8 @@ class TestMultiplexProfileWebhookAuthentication:
                 data=body,
                 headers=headers,
             )
-            assert accepted.status == 200
-            assert (await accepted.json())["status"] == "ignored"
+            assert accepted.status == 202
+            assert (await accepted.json())["status"] == "accepted"
 
             wrong_profile = await cli.post(
                 "/p/other/webhooks/gh",
@@ -1011,16 +1208,65 @@ class TestMultiplexProfileWebhookAuthentication:
             )
             assert default_profile.status == 404
 
+    @pytest.mark.asyncio
+    async def test_single_profile_gateway_accepts_its_self_referential_prefix(
+        self,
+        monkeypatch,
+    ):
+        secret = "worker-route-secret-abc123"
+        adapter = _make_adapter(
+            routes={
+                "gh": {
+                    "profile": "worker",
+                    "secret": secret,
+                    "provider": "github",
+                    "events": ["pull_request"],
+                }
+            },
+            host="127.0.0.1",
+        )
+        adapter.gateway_runner = SimpleNamespace(
+            config=SimpleNamespace(multiplex_profiles=False),
+            adapters={Platform.WEBHOOK: adapter},
+        )
+        adapter.handle_message = AsyncMock()
+        monkeypatch.setattr(
+            "hermes_cli.profiles.profile_matches_home",
+            lambda profile: profile == "worker",
+        )
+        body = _github_pull_request_body()
+
+        async with TestClient(TestServer(self._app(adapter))) as client:
+            response = await client.post(
+                "/p/worker/webhooks/gh",
+                data=body,
+                headers=self._headers(body, secret),
+            )
+            response_body = await response.json()
+
+        assert response.status == 202
+        assert response_body["status"] == "accepted"
+        adapter.handle_message.assert_awaited_once()
+
 
 def test_route_profile_validation_fails_closed():
-    assert WebhookAdapter._route_allows_profile({}, None) is True
-    assert WebhookAdapter._route_allows_profile(
-        {"profile": "worker"}, "worker"
-    ) is True
-    assert WebhookAdapter._route_allows_profile(
-        {"profile": "worker"}, "other"
-    ) is False
+    assert WebhookAdapter._route_allows_profile({"provider": "generic"}, None) is True
+    assert (
+        WebhookAdapter._route_allows_profile(
+            {"profile": "worker", "provider": "generic"}, "worker"
+        )
+        is True
+    )
+    assert (
+        WebhookAdapter._route_allows_profile(
+            {"profile": "worker", "provider": "generic"}, "other"
+        )
+        is False
+    )
     for malformed in (None, "", "   ", 123, ["worker"]):
-        assert WebhookAdapter._route_allows_profile(
-            {"profile": malformed}, "worker"
-        ) is False
+        assert (
+            WebhookAdapter._route_allows_profile(
+                {"profile": malformed, "provider": "generic"}, "worker"
+            )
+            is False
+        )

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -184,23 +184,42 @@ class TestValidateSignature:
             assert adapter._validate_signature(req, body, secret, mode) is False
 
     def test_linear_signature_valid_accepts(self):
-        """Linear signs the raw body (hex HMAC-SHA256) in linear-signature."""
+        """Linear signs a fresh payload timestamp in the raw body HMAC."""
         adapter = _make_adapter()
-        body = b'{"type": "Issue", "data": {"id": "abc"}}'
+        timestamp = int(time.time() * 1000)
+        body = json.dumps({
+            "type": "Issue",
+            "data": {"id": "abc"},
+            "webhookTimestamp": timestamp,
+        }).encode()
         secret = "linear-webhook-key"
         sig = _generic_signature(body, secret)  # same math as linear-signature
 
-        req = _mock_request(headers={"linear-signature": sig})
+        req = _mock_request(
+            headers={
+                "linear-signature": sig,
+                "linear-timestamp": str(timestamp),
+            }
+        )
 
         assert adapter._validate_signature(req, body, secret, "linear") is True
 
     def test_linear_signature_mismatch_rejects(self):
         """A well-formed linear-signature computed with the wrong key fails closed."""
         adapter = _make_adapter()
-        body = b'{"type": "Issue"}'
+        timestamp = int(time.time() * 1000)
+        body = json.dumps({
+            "type": "Issue",
+            "webhookTimestamp": timestamp,
+        }).encode()
         sig = _generic_signature(body, "attacker-controlled-key")
 
-        req = _mock_request(headers={"linear-signature": sig})
+        req = _mock_request(
+            headers={
+                "linear-signature": sig,
+                "linear-timestamp": str(timestamp),
+            }
+        )
 
         assert adapter._validate_signature(req, body, "real-secret", "linear") is False
 

--- a/tests/gateway/test_webhook_auth_authority.py
+++ b/tests/gateway/test_webhook_auth_authority.py
@@ -1,0 +1,704 @@
+"""Focused contracts for explicit webhook signature authority."""
+
+import asyncio
+import base64
+import hashlib
+import hmac
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestServer
+from multidict import CIMultiDict
+
+from gateway.config import PlatformConfig
+from gateway.platforms import webhook_auth as auth
+from gateway.platforms.webhook import WebhookAdapter
+from gateway.platforms.webhook_contract import WebhookEnvelope, WebhookRouteConfig
+from gateway.platforms.webhook_ledger import AdmitDisposition, WebhookOperationLedger
+
+
+class _Headers(dict):
+    def get(self, key, default=""):
+        for candidate, value in self.items():
+            if str(candidate).lower() == str(key).lower():
+                return value
+        return default
+
+
+class _Request:
+    def __init__(self, headers=None, route="alerts"):
+        self.headers = (
+            headers
+            if callable(getattr(headers, "getall", None))
+            else _Headers(headers or {})
+        )
+        self.match_info = {"route_name": route}
+
+
+class _Verifier(auth.WebhookAuthMixin):
+    pass
+
+
+def _verifier():
+    return _Verifier()
+
+
+def _route(provider="github"):
+    return WebhookRouteConfig.bind(
+        "alerts",
+        {"provider": provider},
+        headers={},
+    )
+
+
+def test_unknown_signature_mode_fails_closed():
+    request = _Request({"X-Hub-Signature-256": "sha256=deadbeef"})
+    assert _verifier()._validate_signature(request, b"body", "secret", "wat") is False
+
+
+def test_duplicate_signature_header_is_rejected_even_when_values_match():
+    body = b'{"value":1}'
+    signature = "sha256=" + hmac.new(b"secret", body, hashlib.sha256).hexdigest()
+    headers = CIMultiDict()
+    headers.add("X-Hub-Signature-256", signature)
+    headers.add("X-Hub-Signature-256", signature)
+
+    assert (
+        _verifier()._validate_signature(_Request(headers), body, "secret", "github")
+        is False
+    )
+
+
+def test_empty_secret_never_authenticates_even_with_matching_empty_key_hmac():
+    body = b"body"
+    signature = "sha256=" + hmac.new(b"", body, hashlib.sha256).hexdigest()
+    request = _Request({"X-Hub-Signature-256": signature})
+    assert _verifier()._validate_signature(request, body, "", "github") is False
+
+
+def test_github_mode_does_not_accept_other_provider_headers():
+    request = _Request({
+        "X-Gitlab-Token": "secret",
+        "linear-signature": hmac.new(b"secret", b"body", hashlib.sha256).hexdigest(),
+    })
+    assert (
+        _verifier()._validate_signature(request, b"body", "secret", "github") is False
+    )
+
+
+def test_github_mode_accepts_exact_body_hmac():
+    body = b'{"ok":true}'
+    signature = "sha256=" + hmac.new(b"secret", body, hashlib.sha256).hexdigest()
+    request = _Request({"X-Hub-Signature-256": signature})
+    assert _verifier()._validate_signature(request, body, "secret", "github") is True
+
+
+def test_successful_verifier_returns_exact_non_secret_receipt():
+    body = b'{"ok":true}'
+    signature = "sha256=" + hmac.new(b"secret", body, hashlib.sha256).hexdigest()
+    request = _Request({
+        "X-Hub-Signature-256": signature,
+        "X-GitHub-Delivery": "delivery-1",
+        "X-GitHub-Event": "push",
+        "Authorization": "must-not-be-snapshotted",
+    })
+    route = _route()
+    receipt = _verifier()._verify_signature_receipt(
+        request,
+        body,
+        "secret",
+        route,
+    )
+    assert isinstance(receipt, auth.WebhookSignatureVerificationReceipt)
+    assert receipt.route is route
+    assert receipt.coverage is auth.WebhookVerificationCoverage.BODY_MAC
+    assert receipt.verified_headers == {}
+    assert receipt.observed_headers == {
+        "X-GitHub-Delivery": "delivery-1",
+        "X-GitHub-Event": "push",
+    }
+    assert "secret" not in repr(receipt)
+    assert "Authorization" not in repr(receipt)
+
+
+def test_receipt_snapshots_claims_and_cannot_be_constructed_directly():
+    body = b'{"ok":true}'
+    signature = "sha256=" + hmac.new(b"secret", body, hashlib.sha256).hexdigest()
+    headers = {
+        "X-Hub-Signature-256": signature,
+        "X-GitHub-Delivery": "delivery-1",
+    }
+    request = _Request(headers)
+    receipt = _verifier()._verify_signature_receipt(
+        request,
+        body,
+        "secret",
+        _route(),
+    )
+    headers["X-GitHub-Delivery"] = "attacker"
+    request.headers["X-GitHub-Delivery"] = "attacker"
+    assert receipt.observed_headers["X-GitHub-Delivery"] == "delivery-1"
+    with pytest.raises(TypeError):
+        auth.WebhookSignatureVerificationReceipt(  # type: ignore[call-arg]
+            route=_route(),
+            body_sha256="forged",
+            verified_at=0.0,
+            coverage=auth.WebhookVerificationCoverage.BODY_MAC,
+            verified_claims=(),
+            observed_claims=(),
+            signed_timestamp=None,
+        )
+
+
+def test_gitlab_receipt_is_credential_only_and_does_not_claim_body_or_headers():
+    body = b'{"object_kind":"push"}'
+    request = _Request({
+        "X-Gitlab-Token": "secret",
+        "X-Gitlab-Event-UUID": "event-1",
+        "X-GitLab-Event": "Push Hook",
+    })
+    receipt = _verifier()._verify_signature_receipt(
+        request,
+        body,
+        "secret",
+        _route("gitlab"),
+    )
+    assert receipt is not None
+    assert receipt.coverage is auth.WebhookVerificationCoverage.CREDENTIAL_ONLY
+    assert receipt.verified_headers == {}
+    assert receipt.observed_headers == {
+        "X-Gitlab-Event-UUID": "event-1",
+        "X-GitLab-Event": "Push Hook",
+    }
+
+
+def test_linear_mode_preserves_current_main_wire_contract():
+    body = b'{"type":"Issue"}'
+    signature = hmac.new(b"secret", body, hashlib.sha256).hexdigest()
+    request = _Request({"linear-signature": signature})
+    assert _verifier()._validate_signature(request, body, "secret", "linear") is True
+
+
+def test_hindsight_mode_uses_its_own_sha256_header():
+    body = b'{"event":"memory"}'
+    signature = "sha256=" + hmac.new(b"secret", body, hashlib.sha256).hexdigest()
+    request = _Request({"X-Hindsight-Signature": signature})
+    assert _verifier()._validate_signature(request, body, "secret", "hindsight") is True
+
+
+def test_hermes_mode_accepts_outbound_agent_signature_without_github_aliasing():
+    body = b'{"hook_event_name":"post_tool_call"}'
+    signature = "sha256=" + hmac.new(b"secret", body, hashlib.sha256).hexdigest()
+    request = _Request({"X-Hermes-Signature-256": signature})
+    assert _verifier()._validate_signature(request, body, "secret", "hermes") is True
+    assert _verifier()._validate_signature(request, body, "secret", "github") is False
+
+
+def test_generic_v2_requires_timestamp_even_when_v1_is_valid():
+    body = b"payload"
+    v1 = hmac.new(b"secret", body, hashlib.sha256).hexdigest()
+    request = _Request({
+        "X-Webhook-Signature-V2": "present-but-invalid-without-timestamp",
+        "X-Webhook-Signature": v1,
+    })
+    assert (
+        _verifier()._validate_signature(request, body, "secret", "generic_v2") is False
+    )
+
+
+def test_generic_v2_binds_timestamp_and_body(monkeypatch):
+    now = 1_800_000_000
+    monkeypatch.setattr(auth.time, "time", lambda: now)
+    body = b"payload"
+    timestamp = str(now)
+    signature = hmac.new(
+        b"secret", timestamp.encode() + b"." + body, hashlib.sha256
+    ).hexdigest()
+    request = _Request({
+        "X-Webhook-Timestamp": timestamp,
+        "X-Webhook-Signature-V2": signature,
+    })
+    verifier = _verifier()
+    assert verifier._validate_signature(request, body, "secret", "generic_v2") is True
+    assert (
+        verifier._validate_signature(request, body + b"!", "secret", "generic_v2")
+        is False
+    )
+
+
+def test_generic_v2_rejects_expired_timestamp(monkeypatch):
+    now = 1_800_000_000
+    monkeypatch.setattr(auth.time, "time", lambda: now)
+    timestamp = str(now - auth.DEFAULT_REPLAY_TOLERANCE_SECONDS - 1)
+    body = b"payload"
+    signature = hmac.new(
+        b"secret", timestamp.encode() + b"." + body, hashlib.sha256
+    ).hexdigest()
+    request = _Request({
+        "X-Webhook-Timestamp": timestamp,
+        "X-Webhook-Signature-V2": signature,
+    })
+    assert (
+        _verifier()._validate_signature(request, body, "secret", "generic_v2") is False
+    )
+
+
+def test_generic_v2_rejects_future_timestamp_outside_replay_window(monkeypatch):
+    now = 1_800_000_000
+    monkeypatch.setattr(auth.time, "time", lambda: now)
+    timestamp = str(now + auth.DEFAULT_REPLAY_TOLERANCE_SECONDS + 1)
+    body = b"payload"
+    signature = hmac.new(
+        b"secret", timestamp.encode() + b"." + body, hashlib.sha256
+    ).hexdigest()
+    request = _Request({
+        "X-Webhook-Timestamp": timestamp,
+        "X-Webhook-Signature-V2": signature,
+    })
+
+    assert (
+        _verifier()._validate_signature(request, body, "secret", "generic_v2") is False
+    )
+
+
+@pytest.mark.parametrize(
+    "offset",
+    [
+        -auth.DEFAULT_REPLAY_TOLERANCE_SECONDS,
+        auth.DEFAULT_REPLAY_TOLERANCE_SECONDS,
+    ],
+)
+def test_generic_v2_accepts_exact_replay_window_boundaries(monkeypatch, offset):
+    now = 1_800_000_000
+    monkeypatch.setattr(auth.time, "time", lambda: now)
+    timestamp = str(now + offset)
+    body = b"payload"
+    signature = hmac.new(
+        b"secret", timestamp.encode() + b"." + body, hashlib.sha256
+    ).hexdigest()
+    request = _Request({
+        "X-Webhook-Timestamp": timestamp,
+        "X-Webhook-Signature-V2": signature,
+    })
+
+    assert (
+        _verifier()._validate_signature(request, body, "secret", "generic_v2") is True
+    )
+
+
+@pytest.mark.parametrize(
+    "duplicated_header",
+    ["X-Webhook-Timestamp", "X-Webhook-Signature-V2"],
+)
+def test_generic_v2_rejects_duplicate_physical_authority_headers(
+    monkeypatch,
+    duplicated_header,
+):
+    now = 1_800_000_000
+    monkeypatch.setattr(auth.time, "time", lambda: now)
+    timestamp = str(now)
+    body = b"payload"
+    signature = hmac.new(
+        b"secret", timestamp.encode() + b"." + body, hashlib.sha256
+    ).hexdigest()
+    headers = CIMultiDict()
+    headers.add("X-Webhook-Timestamp", timestamp)
+    headers.add("X-Webhook-Signature-V2", signature)
+    headers.add(
+        duplicated_header,
+        timestamp if duplicated_header == "X-Webhook-Timestamp" else signature,
+    )
+
+    assert (
+        _verifier()._validate_signature(_Request(headers), body, "secret", "generic_v2")
+        is False
+    )
+
+
+def test_generic_v2_timestamp_and_body_compose_the_durable_replay_identity(
+    monkeypatch,
+    tmp_path,
+):
+    now = 1_800_000_000
+    monkeypatch.setattr(auth.time, "time", lambda: now)
+    body = b'{"type":"tick"}'
+    route = _route("generic")
+    verifier = _verifier()
+
+    def envelope(timestamp_value, trace_id):
+        timestamp = str(timestamp_value)
+        signature = hmac.new(
+            b"secret", timestamp.encode() + b"." + body, hashlib.sha256
+        ).hexdigest()
+        receipt = verifier._verify_signature_receipt(
+            _Request({
+                "X-Webhook-Timestamp": timestamp,
+                "X-Webhook-Signature-V2": signature,
+            }),
+            body,
+            "secret",
+            route,
+        )
+        assert receipt is not None
+        return WebhookEnvelope.from_receipt(
+            receipt,
+            raw_body=body,
+            media_type="application/json",
+            trace_id=trace_id,
+        )
+
+    first = envelope(now, "trace-first")
+    exact_replay = envelope(now, "trace-replay")
+    fresh_timestamp = envelope(now + 1, "trace-fresh")
+    ledger = WebhookOperationLedger(tmp_path / "webhooks.db")
+
+    assert ledger.admit(first).disposition is AdmitDisposition.ACCEPTED
+    assert ledger.admit(exact_replay).disposition is AdmitDisposition.ACTIVE
+    assert ledger.admit(fresh_timestamp).disposition is AdmitDisposition.ACCEPTED
+    assert first.body_sha256 == fresh_timestamp.body_sha256
+    assert first.replay_identity != fresh_timestamp.replay_identity
+    assert ledger.count() == 2
+
+
+def test_stripe_mode_binds_timestamp_and_body(monkeypatch):
+    now = 1_800_000_000
+    monkeypatch.setattr(auth.time, "time", lambda: now)
+    body = b'{"id":"evt_123"}'
+    timestamp = str(now)
+    signature = hmac.new(
+        b"whsec_test", timestamp.encode() + b"." + body, hashlib.sha256
+    ).hexdigest()
+    request = _Request({"Stripe-Signature": f"t={timestamp},v1={signature}"})
+    verifier = _verifier()
+    assert verifier._validate_signature(request, body, "whsec_test", "stripe") is True
+    assert (
+        verifier._validate_signature(request, body + b"!", "whsec_test", "stripe")
+        is False
+    )
+    receipt = verifier._verify_signature_receipt(
+        request,
+        body,
+        "whsec_test",
+        _route("stripe"),
+    )
+    assert receipt is not None
+    assert receipt.coverage is auth.WebhookVerificationCoverage.TIMESTAMP_BODY_MAC
+    assert receipt.signed_timestamp == timestamp
+    assert receipt.verified_headers == {}
+
+
+def test_stripe_mode_rejects_expired_timestamp(monkeypatch):
+    now = 1_800_000_000
+    monkeypatch.setattr(auth.time, "time", lambda: now)
+    timestamp = str(now - auth.DEFAULT_REPLAY_TOLERANCE_SECONDS - 1)
+    body = b'{"id":"evt_123"}'
+    signature = hmac.new(
+        b"whsec_test", timestamp.encode() + b"." + body, hashlib.sha256
+    ).hexdigest()
+    request = _Request({"Stripe-Signature": f"t={timestamp},v1={signature}"})
+    assert (
+        _verifier()._validate_signature(request, body, "whsec_test", "stripe") is False
+    )
+
+
+def test_stripe_mode_rejects_future_timestamp_outside_replay_window(monkeypatch):
+    now = 1_800_000_000
+    monkeypatch.setattr(auth.time, "time", lambda: now)
+    timestamp = str(now + auth.DEFAULT_REPLAY_TOLERANCE_SECONDS + 1)
+    body = b'{"id":"evt_123"}'
+    signature = hmac.new(
+        b"whsec_test", timestamp.encode() + b"." + body, hashlib.sha256
+    ).hexdigest()
+    request = _Request({"Stripe-Signature": f"t={timestamp},v1={signature}"})
+
+    assert (
+        _verifier()._validate_signature(request, body, "whsec_test", "stripe") is False
+    )
+
+
+def _svix_signature(body, secret, msg_id, timestamp):
+    signed = msg_id.encode() + b"." + timestamp.encode() + b"." + body
+    return (
+        "v1,"
+        + base64.b64encode(
+            hmac.new(secret.encode(), signed, hashlib.sha256).digest()
+        ).decode()
+    )
+
+
+@pytest.mark.parametrize(
+    ("mode", "id_header", "timestamp_header", "signature_header"),
+    [
+        ("svix", "svix-id", "svix-timestamp", "svix-signature"),
+        (
+            "standard_webhooks",
+            "webhook-id",
+            "webhook-timestamp",
+            "webhook-signature",
+        ),
+    ],
+)
+def test_id_timestamp_modes_reject_future_timestamp_outside_replay_window(
+    monkeypatch,
+    mode,
+    id_header,
+    timestamp_header,
+    signature_header,
+):
+    now = 1_800_000_000
+    monkeypatch.setattr(auth.time, "time", lambda: now)
+    timestamp = str(now + auth.DEFAULT_REPLAY_TOLERANCE_SECONDS + 1)
+    body = b'{"value":1}'
+    signature = _svix_signature(body, "secret", "message-1", timestamp)
+    request = _Request({
+        id_header: "message-1",
+        timestamp_header: timestamp,
+        signature_header: signature,
+    })
+
+    assert _verifier()._validate_signature(request, body, "secret", mode) is False
+
+
+@pytest.mark.parametrize(
+    ("mode", "id_header", "timestamp_header", "signature_header"),
+    [
+        ("svix", "svix-id", "svix-timestamp", "svix-signature"),
+        (
+            "standard_webhooks",
+            "webhook-id",
+            "webhook-timestamp",
+            "webhook-signature",
+        ),
+    ],
+)
+def test_id_timestamp_modes_reject_identity_substitution(
+    monkeypatch,
+    mode,
+    id_header,
+    timestamp_header,
+    signature_header,
+):
+    now = 1_800_000_000
+    monkeypatch.setattr(auth.time, "time", lambda: now)
+    body = b'{"value":1}'
+    signature = _svix_signature(body, "secret", "signed-id", str(now))
+    request = _Request({
+        id_header: "attacker-id",
+        timestamp_header: str(now),
+        signature_header: signature,
+    })
+
+    assert _verifier()._validate_signature(request, body, "secret", mode) is False
+
+
+@pytest.mark.parametrize(
+    ("mode", "id_header", "timestamp_header", "signature_header"),
+    [
+        ("svix", "svix-id", "svix-timestamp", "svix-signature"),
+        (
+            "standard_webhooks",
+            "webhook-id",
+            "webhook-timestamp",
+            "webhook-signature",
+        ),
+    ],
+)
+@pytest.mark.parametrize("duplicated", ["id", "timestamp"])
+def test_id_timestamp_modes_reject_duplicate_physical_authority_headers(
+    monkeypatch,
+    mode,
+    id_header,
+    timestamp_header,
+    signature_header,
+    duplicated,
+):
+    now = 1_800_000_000
+    monkeypatch.setattr(auth.time, "time", lambda: now)
+    body = b'{"value":1}'
+    signature = _svix_signature(body, "secret", "message-1", str(now))
+    headers = CIMultiDict()
+    headers.add(id_header, "message-1")
+    headers.add(timestamp_header, str(now))
+    headers.add(signature_header, signature)
+    headers.add(
+        id_header if duplicated == "id" else timestamp_header,
+        ("message-1" if duplicated == "id" else str(now)),
+    )
+
+    assert (
+        _verifier()._validate_signature(_Request(headers), body, "secret", mode)
+        is False
+    )
+
+
+def test_standard_webhooks_uses_standard_headers(monkeypatch):
+    now = 1_800_000_000
+    monkeypatch.setattr(auth.time, "time", lambda: now)
+    body = b"payload"
+    timestamp = str(now)
+    signature = _svix_signature(body, "secret", "wh_1", timestamp)
+    request = _Request({
+        "webhook-id": "wh_1",
+        "webhook-timestamp": timestamp,
+        "webhook-signature": signature,
+        "svix-id": "attacker",
+    })
+    verifier = _verifier()
+    assert (
+        verifier._validate_signature(request, body, "secret", "standard_webhooks")
+        is True
+    )
+    receipt = verifier._verify_signature_receipt(
+        request,
+        body,
+        "secret",
+        _route("standard_webhooks"),
+    )
+    assert receipt is not None
+    assert receipt.coverage is auth.WebhookVerificationCoverage.ID_TIMESTAMP_BODY_MAC
+    assert receipt.verified_headers == {"webhook-id": "wh_1"}
+    assert receipt.observed_headers == {}
+    assert receipt.signed_timestamp == timestamp
+
+
+def test_svix_receipt_carries_the_exact_signed_id(monkeypatch):
+    now = 1_800_000_000
+    monkeypatch.setattr(auth.time, "time", lambda: now)
+    body = b'{"type":"message.received"}'
+    timestamp = str(now)
+    signature = _svix_signature(body, "secret", "msg_1", timestamp)
+    request = _Request({
+        "svix-id": "msg_1",
+        "svix-timestamp": timestamp,
+        "svix-signature": signature,
+    })
+    receipt = _verifier()._verify_signature_receipt(
+        request,
+        body,
+        "secret",
+        _route("svix"),
+    )
+    assert receipt is not None
+    request.headers["svix-id"] = "attacker"
+    assert receipt.verified_headers == {"svix-id": "msg_1"}
+    assert receipt.signed_timestamp == timestamp
+
+
+def test_svix_uses_explicit_replay_tolerance(monkeypatch):
+    now = 1_800_000_000
+    monkeypatch.setattr(auth.time, "time", lambda: now)
+    body = b"payload"
+    timestamp = str(now - 11)
+    signature = _svix_signature(body, "secret", "msg_1", timestamp)
+    assert (
+        _verifier()._validate_svix_signature(
+            body,
+            "secret",
+            "msg_1",
+            timestamp,
+            signature,
+            tolerance_seconds=10,
+        )
+        is False
+    )
+
+
+def test_direct_svix_compatibility_verifier_rejects_surrogate_message_id():
+    assert (
+        _verifier()._validate_svix_signature(
+            b"body",
+            "secret",
+            "\udcff",
+            "1800000000",
+            "v1,unused",
+        )
+        is False
+    )
+
+
+def test_non_ascii_attacker_header_fails_cleanly():
+    request = _Request({"X-Gitlab-Token": "sécret"})
+    assert _verifier()._validate_signature(request, b"", "secret", "gitlab") is False
+
+
+@pytest.mark.parametrize(
+    ("mode", "header"),
+    [
+        ("github", "X-Hub-Signature-256"),
+        ("gitlab", "X-Gitlab-Token"),
+    ],
+)
+def test_surrogate_authentication_header_fails_closed(mode, header):
+    request = _Request({header: "\udcff"})
+
+    assert _verifier()._validate_signature(request, b"body", "secret", mode) is False
+
+
+@pytest.mark.asyncio
+async def test_raw_invalid_utf8_signature_header_returns_401():
+    adapter = WebhookAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={
+                "host": "127.0.0.1",
+                "port": 0,
+                "routes": {
+                    "alerts": {"secret": "secret", "provider": "github"},
+                },
+            },
+        )
+    )
+    app = web.Application()
+    app.router.add_post("/webhooks/{route_name}", adapter._handle_webhook)
+
+    async with TestServer(app) as server:
+        reader, writer = await asyncio.open_connection(server.host, server.port)
+        try:
+            writer.write(
+                b"POST /webhooks/alerts HTTP/1.1\r\n"
+                b"Host: localhost\r\n"
+                b"Connection: close\r\n"
+                b"Content-Type: application/json\r\n"
+                b"Content-Length: 2\r\n"
+                b"X-Hub-Signature-256: \xff\r\n"
+                b"\r\n{}"
+            )
+            await writer.drain()
+            status_line = await asyncio.wait_for(reader.readline(), timeout=2)
+            response_body = await asyncio.wait_for(reader.read(), timeout=2)
+        finally:
+            writer.close()
+            await writer.wait_closed()
+
+    assert status_line == b"HTTP/1.1 401 Unauthorized\r\n"
+    assert b'{"error": "Invalid signature"}' in response_body
+
+
+@pytest.mark.parametrize(
+    ("mode", "id_header", "timestamp_header", "signature_header"),
+    [
+        ("svix", "svix-id", "svix-timestamp", "svix-signature"),
+        (
+            "standard_webhooks",
+            "webhook-id",
+            "webhook-timestamp",
+            "webhook-signature",
+        ),
+    ],
+)
+def test_id_timestamp_mode_rejects_surrogate_message_id_before_mac_encoding(
+    monkeypatch,
+    mode,
+    id_header,
+    timestamp_header,
+    signature_header,
+):
+    now = 1_800_000_000
+    monkeypatch.setattr(auth.time, "time", lambda: now)
+    request = _Request({
+        id_header: "\udcff",
+        timestamp_header: str(now),
+        signature_header: "v1,unused",
+    })
+
+    assert _verifier()._validate_signature(request, b"body", "secret", mode) is False

--- a/tests/gateway/test_webhook_auth_authority.py
+++ b/tests/gateway/test_webhook_auth_authority.py
@@ -4,6 +4,8 @@ import asyncio
 import base64
 import hashlib
 import hmac
+import json
+import time
 
 import pytest
 from aiohttp import web
@@ -172,10 +174,17 @@ def test_gitlab_receipt_is_credential_only_and_does_not_claim_body_or_headers():
     }
 
 
-def test_linear_mode_preserves_current_main_wire_contract():
-    body = b'{"type":"Issue"}'
+def test_linear_mode_requires_fresh_body_authenticated_timestamp():
+    timestamp = int(time.time() * 1000)
+    body = json.dumps({
+        "type": "Issue",
+        "webhookTimestamp": timestamp,
+    }).encode()
     signature = hmac.new(b"secret", body, hashlib.sha256).hexdigest()
-    request = _Request({"linear-signature": signature})
+    request = _Request({
+        "linear-signature": signature,
+        "linear-timestamp": str(timestamp),
+    })
     assert _verifier()._validate_signature(request, body, "secret", "linear") is True
 
 

--- a/tests/gateway/test_webhook_auth_key_binding.py
+++ b/tests/gateway/test_webhook_auth_key_binding.py
@@ -1,0 +1,409 @@
+"""Authority tests for durable webhook authentication-key ownership."""
+
+import base64
+import hashlib
+import hmac
+import json
+import time
+from unittest.mock import AsyncMock
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.config import PlatformConfig
+from gateway.platforms import webhook_intake as webhook_intake_module
+from gateway.platforms.webhook import WebhookAdapter
+from gateway.platforms.webhook_ledger import (
+    WebhookLedgerError,
+    WebhookLedgerTransitionError,
+)
+
+
+_LONG_HMAC_KEY = "a" * 65
+_LONG_HMAC_DIGEST_WHSEC = (
+    "whsec_"
+    + base64.b64encode(hashlib.sha256(_LONG_HMAC_KEY.encode()).digest()).decode()
+)
+
+
+def _adapter(routes, **extra) -> WebhookAdapter:
+    return WebhookAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={"host": "127.0.0.1", "port": 0, "routes": routes, **extra},
+        )
+    )
+
+
+async def _assert_invalid_connect(adapter: WebhookAdapter, message: str) -> None:
+    assert await adapter.connect() is False
+    assert adapter._runner is None
+    assert adapter.fatal_error_code == "webhook_configuration_invalid"
+    assert adapter.fatal_error_retryable is False
+    assert message in (adapter.fatal_error_message or "")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "routes",
+    [
+        {
+            "first": {"secret": "shared-secret", "provider": "generic"},
+            "second": {"secret": "shared-secret", "provider": "github"},
+        },
+        {
+            "raw": {"secret": "secret", "provider": "generic"},
+            "decoded": {
+                "secret": "whsec_c2VjcmV0",
+                "provider": "standard_webhooks",
+            },
+        },
+        {
+            "raw": {
+                "secret": "whsec_c2VjcmV0",
+                "provider": "generic",
+            },
+            "decoded": {
+                "secret": "whsec_c2VjcmV0",
+                "provider": "standard_webhooks",
+            },
+        },
+        {
+            "plain": {"secret": "shared", "provider": "generic"},
+            "zero-padded": {
+                "secret": "shared\0",
+                "provider": "generic",
+            },
+        },
+        {
+            "long": {"secret": _LONG_HMAC_KEY, "provider": "generic"},
+            "digest": {
+                "secret": _LONG_HMAC_DIGEST_WHSEC,
+                "provider": "standard_webhooks",
+            },
+        },
+    ],
+)
+async def test_connect_rejects_secret_material_shared_across_routes(routes):
+    adapter = _adapter(routes)
+
+    await _assert_invalid_connect(adapter, "must not reuse secret material")
+
+
+@pytest.mark.asyncio
+async def test_connect_rejects_global_secret_fallback_for_multiple_routes():
+    adapter = _adapter(
+        {
+            "first": {"provider": "generic"},
+            "second": {"provider": "generic"},
+        },
+        secret="shared-global-secret",
+    )
+
+    await _assert_invalid_connect(adapter, "must not reuse secret material")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("provider", ["svix", "standard_webhooks"])
+async def test_connect_rejects_empty_decoded_whsec_key(provider):
+    adapter = _adapter({
+        "hook": {"secret": "whsec_", "provider": provider},
+    })
+
+    await _assert_invalid_connect(adapter, "must decode to a non-empty key")
+
+
+@pytest.mark.asyncio
+async def test_connect_classifies_surrogate_event_as_nonretryable_configuration():
+    adapter = _adapter({
+        "hook": {
+            "secret": "event-secret",
+            "provider": "github",
+            "events": ["\udcff"],
+        },
+    })
+
+    await _assert_invalid_connect(adapter, "event is not valid Unicode")
+
+
+@pytest.mark.asyncio
+async def test_invalid_startup_does_not_permanently_consume_key_binding():
+    invalid = _adapter({
+        "hook": {
+            "secret": "correctable-secret",
+            "provider": "generic",
+            "deliver_only": True,
+            "deliver": "log",
+        },
+    })
+    await _assert_invalid_connect(invalid, "deliver_only=true")
+
+    corrected = _adapter({
+        "hook": {
+            "secret": "correctable-secret",
+            "provider": "generic",
+            "deliver_only": True,
+            "deliver": "telegram",
+            "deliver_extra": {"chat_id": "12345"},
+        },
+    })
+    assert await corrected.connect() is True
+    await corrected.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_deep_route_policy_is_fatal_nonretryable_configuration():
+    nested: object = "value"
+    for _ in range(2_000):
+        nested = {"nested": nested}
+    adapter = _adapter({
+        "hook": {
+            "secret": "deep-policy-secret",
+            "provider": "generic",
+            "custom_policy": nested,
+        }
+    })
+
+    await _assert_invalid_connect(adapter, "execution policy")
+
+
+@pytest.mark.parametrize(
+    ("mode", "id_header", "time_header", "signature_header"),
+    [
+        ("svix", "svix-id", "svix-timestamp", "svix-signature"),
+        (
+            "standard_webhooks",
+            "webhook-id",
+            "webhook-timestamp",
+            "webhook-signature",
+        ),
+    ],
+)
+def test_verifier_rejects_signature_forged_with_empty_whsec_key(
+    mode,
+    id_header,
+    time_header,
+    signature_header,
+):
+    body = b'{"event":"forged"}'
+    message_id = "message-1"
+    timestamp = str(int(time.time()))
+    signed = message_id.encode() + b"." + timestamp.encode() + b"." + body
+    forged = (
+        "v1,"
+        + base64.b64encode(hmac.new(b"", signed, hashlib.sha256).digest()).decode()
+    )
+    request = type(
+        "Request",
+        (),
+        {
+            "headers": {
+                id_header: message_id,
+                time_header: timestamp,
+                signature_header: forged,
+            },
+            "match_info": {"route_name": "hook"},
+        },
+    )()
+    adapter = _adapter({
+        "hook": {"secret": "whsec_", "provider": mode},
+    })
+
+    assert adapter._validate_signature(request, body, "whsec_", mode) is False
+
+
+def test_persisted_key_cannot_move_to_renamed_route_after_restart():
+    first = _adapter({
+        "old-route": {"secret": "durable-secret", "provider": "generic"},
+    })
+    first._bind_route_authentication_authorities(first._routes)
+    replacement = _adapter({
+        "new-route": {"secret": "durable-secret", "provider": "generic"},
+    })
+
+    with pytest.raises(WebhookLedgerTransitionError):
+        replacement._bind_route_authentication_authorities(replacement._routes)
+
+
+def test_key_cannot_move_between_named_single_profiles(tmp_path, monkeypatch):
+    root = tmp_path / "hermes-root"
+    profile_a = root / "profiles" / "alpha"
+    profile_b = root / "profiles" / "beta"
+    profile_a.mkdir(parents=True)
+    profile_b.mkdir(parents=True)
+    route = {
+        "hook": {"secret": "cross-profile-secret", "provider": "generic"},
+    }
+
+    monkeypatch.setenv("HERMES_HOME", str(profile_a))
+    first = _adapter(route)
+    first._bind_route_authentication_authorities(first._routes)
+
+    monkeypatch.setenv("HERMES_HOME", str(profile_b))
+    replacement = _adapter(route)
+    assert (
+        first._authentication_authority_ledger.db_path
+        == replacement._authentication_authority_ledger.db_path
+        == root / "state.db"
+    )
+    with pytest.raises(WebhookLedgerTransitionError):
+        replacement._bind_route_authentication_authorities(replacement._routes)
+
+
+def test_policy_elevation_requires_key_rotation_after_restart():
+    first = _adapter({
+        "hook": {
+            "secret": "old-policy-secret",
+            "provider": "generic",
+            "events": ["notice"],
+            "toolsets": [],
+        },
+    })
+    first._bind_route_authentication_authorities(first._routes)
+    elevated = _adapter({
+        "hook": {
+            "secret": "old-policy-secret",
+            "provider": "generic",
+            "events": ["admin"],
+            "toolsets": ["terminal"],
+        },
+    })
+
+    with pytest.raises(WebhookLedgerTransitionError):
+        elevated._bind_route_authentication_authorities(elevated._routes)
+
+    rotated = _adapter({
+        "hook": {
+            "secret": "rotated-policy-secret",
+            "provider": "generic",
+            "events": ["admin"],
+            "toolsets": ["terminal"],
+        },
+    })
+    rotated._bind_route_authentication_authorities(rotated._routes)
+
+
+@pytest.mark.asyncio
+async def test_handler_bypass_of_connect_rejects_duplicate_key_without_effect():
+    secret = "duplicate-handler-secret"
+    adapter = _adapter({
+        "first": {
+            "secret": secret,
+            "provider": "generic",
+            "signature_mode": "generic_v1",
+        },
+        "second": {
+            "secret": secret,
+            "provider": "generic",
+            "signature_mode": "generic_v1",
+        },
+    })
+    adapter.handle_message = AsyncMock()
+    app = web.Application()
+    app.router.add_get("/health", adapter._handle_health)
+    app.router.add_post("/webhooks/{route_name}", adapter._handle_webhook)
+    body = json.dumps({"event": "notice"}).encode()
+    signature = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+
+    async with TestClient(TestServer(app)) as client:
+        response = await client.post(
+            "/webhooks/first",
+            data=body,
+            headers={"X-Webhook-Signature": signature},
+        )
+        health = await client.get("/health")
+
+    assert response.status == 500
+    assert health.status == 200
+    assert adapter._operation_ledger.count() == 0
+    adapter.handle_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_bound_many_route_listener_checks_only_selected_route(monkeypatch):
+    routes = {
+        f"route-{index}": {
+            "secret": f"secret-{index}",
+            "provider": "generic",
+            "signature_mode": "generic_v1",
+        }
+        for index in range(200)
+    }
+    adapter = _adapter(routes)
+    adapter._bind_route_authentication_authorities(adapter._routes)
+
+    def fail_full_snapshot(_routes):
+        raise AssertionError("request path rebuilt the complete route set")
+
+    monkeypatch.setattr(
+        adapter,
+        "_route_authentication_authority_snapshot",
+        fail_full_snapshot,
+    )
+    app = web.Application()
+    app.router.add_post("/webhooks/{route_name}", adapter._handle_webhook)
+
+    async with TestClient(TestServer(app)) as client:
+        response = await client.post(
+            "/webhooks/route-0",
+            json={"event": "notice"},
+            headers={"X-Webhook-Signature": "invalid"},
+        )
+
+    assert response.status == 401
+
+
+def test_transient_binding_failure_withdraws_old_and_retries_candidate(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    subscriptions = tmp_path / "webhook_subscriptions.json"
+    subscriptions.write_text(
+        json.dumps({
+            "hook": {"secret": "old-secret", "provider": "generic"},
+        })
+    )
+    adapter = _adapter({})
+    adapter._reload_dynamic_routes()
+    assert adapter._routes["hook"]["secret"] == "old-secret"
+
+    subscriptions.write_text(
+        json.dumps({
+            "hook": {"secret": "new-secret", "provider": "generic"},
+        })
+    )
+    real_bind = adapter._authentication_authority_ledger.bind_authentication_keys
+    attempts = 0
+
+    def transient_once(bindings):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise WebhookLedgerError("temporary store failure")
+        return real_bind(bindings)
+
+    clock = [100.0]
+    monkeypatch.setattr(
+        adapter._authentication_authority_ledger,
+        "bind_authentication_keys",
+        transient_once,
+    )
+    monkeypatch.setattr(
+        webhook_intake_module.time,
+        "monotonic",
+        lambda: clock[0],
+    )
+
+    adapter._reload_dynamic_routes()
+    assert "hook" not in adapter._routes
+    adapter._reload_dynamic_routes()
+    assert attempts == 1
+    assert "hook" not in adapter._routes
+
+    clock[0] = 101.1
+    adapter._reload_dynamic_routes()
+
+    assert attempts == 2
+    assert adapter._routes["hook"]["secret"] == "new-secret"

--- a/tests/gateway/test_webhook_authority_join.py
+++ b/tests/gateway/test_webhook_authority_join.py
@@ -101,7 +101,11 @@ def _isolated_ledger_home(tmp_path, monkeypatch):
 
 def _app(adapter):
     app = web.Application(client_max_size=adapter._max_body_bytes)
-    app.router.add_get("/health", adapter._handle_health)
+    # This focused harness predates the public liveness/readiness split. Keep
+    # its historical authority assertions pointed at readiness; production
+    # connect() exposes readiness at /ready and keeps /health liveness-only.
+    app.router.add_get("/health", adapter._handle_ready)
+    app.router.add_get("/ready", adapter._handle_ready)
     app.router.add_post("/webhooks/{route_name}", adapter._handle_webhook)
     app.router.add_post(
         "/p/{profile}/webhooks/{route_name}",
@@ -446,7 +450,7 @@ class TestFilterAuthority:
             # must not stall the aiohttp event loop or its health endpoint.
             process = real_popen(*args, **kwargs)
             started.set()
-            assert release.wait(2)
+            assert release.wait(5)
             return process
 
         monkeypatch.setattr(
@@ -466,7 +470,9 @@ class TestFilterAuthority:
                 client.post("/webhooks/events", json={"value": "unsafe"})
             )
             try:
-                assert await asyncio.to_thread(started.wait, 1)
+                # Process startup competes with the full 18-worker CI shard;
+                # this wait synchronizes the test and is not the health SLA.
+                assert await asyncio.to_thread(started.wait, 5)
                 health = await asyncio.wait_for(client.get("/health"), timeout=0.5)
                 assert health.status == 200
             finally:
@@ -1379,7 +1385,7 @@ class TestHTTPComposition:
         adapter.handle_message.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_failed_agent_processing_becomes_indeterminate_for_retry(self):
+    async def test_failed_agent_processing_stages_terminal_error_once(self):
         adapter = _adapter({
             "events": {
                 "secret": _INSECURE_NO_AUTH,
@@ -1403,13 +1409,28 @@ class TestHTTPComposition:
             assert event.webhook_envelope.delivery_identity is None
             await adapter.on_processing_start(event)
             await adapter.on_processing_complete(event, ProcessingOutcome.FAILURE)
+            settled = adapter._operation_ledger.lookup_session(
+                event.webhook_authority.session_key
+            )
             retry = await client.post(
                 "/webhooks/events", json={"value": 1}, headers=headers
             )
             retry_body = await retry.json()
         assert first.status == 202
-        assert retry.status == 409
-        assert retry_body["status"] == "indeterminate"
+        assert settled is not None
+        assert settled.state is OperationState.SETTLED
+        assert settled.target_state is TargetState.SUPPRESSED
+        assert settled.delivery is not None
+        assert settled.delivery.content == (
+            "Webhook processing failed before a final response was produced."
+        )
+        assert dict(settled.delivery.carrier) == {
+            "v": 1,
+            "kind": "terminal_outcome",
+            "outcome": "error",
+        }
+        assert retry.status == 200
+        assert retry_body["status"] == "duplicate"
 
 
 class TestRuntimeOwnershipAndFinalCarrier:
@@ -1611,10 +1632,10 @@ class TestRuntimeOwnershipAndFinalCarrier:
         assert saturated.status == 503
         assert saturated_payload["error"].endswith("for global")
         assert degraded.status == 503
-        assert degraded_payload["status"] == "degraded"
+        assert degraded_payload["status"] == "not_ready"
         assert first.status == first_status
         assert healthy.status == 200
-        assert healthy_payload["status"] == "ok"
+        assert healthy_payload["status"] == "ready"
         assert healthy_payload["accepting_webhooks"] is True
         assert adapter._global_ledger_saturated is False
         assert adapter._operation_ledger.count() == remaining_rows
@@ -1692,12 +1713,10 @@ class TestRuntimeOwnershipAndFinalCarrier:
         assert saturated.status == 503
         assert saturated_payload["error"].endswith("for global")
         assert health.status == 503
-        assert payload == {
-            "status": "degraded",
-            "platform": "webhook",
-            "accepting_webhooks": False,
-            "error": "Durable webhook evidence capacity is exhausted",
-        }
+        assert payload["status"] == "not_ready"
+        assert payload["platform"] == "webhook"
+        assert payload["accepting_webhooks"] is False
+        assert payload["problems"] == ["Durable webhook evidence capacity is exhausted"]
         assert "Retry-After" not in health.headers
         assert replay.status == 200
         assert replay_payload["status"] == "duplicate"
@@ -1778,12 +1797,10 @@ class TestRuntimeOwnershipAndFinalCarrier:
             health_payload = await health.json()
             response = await client.post("/webhooks/events", json={"value": 1})
         assert health.status == 503
-        assert health_payload == {
-            "status": "degraded",
-            "platform": "webhook",
-            "accepting_webhooks": False,
-            "error": "Webhook intake is not active",
-        }
+        assert health_payload["status"] == "not_ready"
+        assert health_payload["platform"] == "webhook"
+        assert health_payload["accepting_webhooks"] is False
+        assert health_payload["problems"] == ["Webhook intake is not active"]
         assert health.headers["Retry-After"] == "5"
         assert response.status == 503
         assert adapter._operation_ledger.count() == 0
@@ -2139,7 +2156,7 @@ class TestRuntimeOwnershipAndFinalCarrier:
             health_payload = await health.json()
             response = await client.post("/webhooks/events", json={"value": 1})
         assert health.status == 503
-        assert health_payload["status"] == "degraded"
+        assert health_payload["status"] == "not_ready"
         assert response.status == 503
         assert adapter._operation_ledger.count() == 0
         adapter.handle_message.assert_not_awaited()
@@ -2183,7 +2200,7 @@ class TestRuntimeOwnershipAndFinalCarrier:
             health_payload = await health.json()
             response = await client.post("/webhooks/events", json={"value": 1})
         assert health.status == 503
-        assert health_payload["status"] == "degraded"
+        assert health_payload["status"] == "not_ready"
         assert response.status == 503
         assert adapter._operation_ledger.count() == 0
         adapter.handle_message.assert_not_awaited()
@@ -2197,11 +2214,9 @@ class TestRuntimeOwnershipAndFinalCarrier:
             health = await client.get("/health")
             health_payload = await health.json()
         assert health.status == 200
-        assert health_payload == {
-            "status": "ok",
-            "platform": "webhook",
-            "accepting_webhooks": True,
-        }
+        assert health_payload["status"] == "ready"
+        assert health_payload["platform"] == "webhook"
+        assert health_payload["accepting_webhooks"] is True
 
     @pytest.mark.asyncio
     async def test_runner_owned_reconnect_listener_stays_closed_through_recovery(self):
@@ -2517,7 +2532,7 @@ class TestRuntimeOwnershipAndFinalCarrier:
         assert authority.target_state is TargetState.CONFIRMED
 
     @pytest.mark.asyncio
-    async def test_real_base_pipeline_failure_becomes_indeterminate(self):
+    async def test_real_base_pipeline_failure_stages_terminal_error(self):
         adapter = _adapter({
             "events": {
                 "secret": _INSECURE_NO_AUTH,
@@ -2540,8 +2555,17 @@ class TestRuntimeOwnershipAndFinalCarrier:
         event = adapter._message_handler.await_args.args[0]
         authority = adapter._operation_ledger.lookup_session(event.source.chat_id)
         assert authority is not None
-        assert authority.state is OperationState.INDETERMINATE
-        assert authority.delivery is None
+        assert authority.state is OperationState.SETTLED
+        assert authority.target_state is TargetState.SUPPRESSED
+        assert authority.delivery is not None
+        assert authority.delivery.content == (
+            "Webhook processing failed before a final response was produced."
+        )
+        assert dict(authority.delivery.carrier) == {
+            "v": 1,
+            "kind": "terminal_outcome",
+            "outcome": "error",
+        }
 
     @pytest.mark.asyncio
     async def test_primary_reconnect_replacement_recovers_staged_target_once(self):

--- a/tests/gateway/test_webhook_authority_join.py
+++ b/tests/gateway/test_webhook_authority_join.py
@@ -1,0 +1,3505 @@
+"""Current-main composition tests for webhook intake authority."""
+
+import asyncio
+import hashlib
+import hmac
+import json
+import subprocess
+import threading
+import time
+from contextlib import contextmanager
+from dataclasses import replace
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+from multidict import CIMultiDict
+
+from agent.outbound_webhooks import (
+    WebhookTarget,
+    _build_delivery,
+    _serialize_payload,
+)
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import ProcessingOutcome, SendResult
+from gateway.platforms.webhook import (
+    WebhookAdapter,
+    WebhookConfigurationError,
+    WebhookTargetDeliveryDisposition,
+    WebhookTargetDeliveryResult,
+    _IDEMPOTENCY_DEFAULT_MAX_ENTRIES,
+    _IDEMPOTENCY_DEFAULT_MAX_STORAGE_BYTES,
+    _IDEMPOTENCY_MAX_ENTRIES_LIMIT,
+    _IDEMPOTENCY_MAX_STORAGE_BYTES_LIMIT,
+    _INSECURE_NO_AUTH,
+    _RAW_PAYLOAD_DEFAULT_CAP_BYTES,
+    _RAW_PAYLOAD_MAX_CAP_BYTES,
+    _RAW_PAYLOAD_MIN_CAP_BYTES,
+    _clear_quarantined_retirement_owner,
+    _quarantined_retirement_owners,
+)
+from gateway.platforms.webhook_auth import WebhookLocalBypassReceipt
+from gateway.platforms.webhook_contract import WebhookEnvelope, WebhookRouteConfig
+from gateway.platforms.webhook_filters import (
+    MAX_SCRIPT_SNAPSHOT_BYTES,
+    WebhookRouteProcessor,
+    WebhookScriptDisposition,
+    WebhookScriptResult,
+)
+from gateway.platforms.webhook_ledger import (
+    AdmitDisposition,
+    AdmitResult,
+    AdmitSaturationReason,
+    MINIMUM_MAX_STORAGE_BYTES,
+    OperationState,
+    TargetState,
+    WebhookOperationLedger,
+    _TOMBSTONE_STORAGE_RESERVATION_BYTES,
+)
+
+
+def _adapter(
+    routes=None,
+    max_entries=8,
+    rate_limit=30,
+    max_storage_bytes=_IDEMPOTENCY_DEFAULT_MAX_STORAGE_BYTES,
+):
+    return WebhookAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={
+                "host": "127.0.0.1",
+                "port": 0,
+                "routes": routes or {},
+                "rate_limit": rate_limit,
+                "idempotency_max_entries": max_entries,
+                "idempotency_max_storage_bytes": max_storage_bytes,
+            },
+        )
+    )
+
+
+def _grant_snapshot(adapter: WebhookAdapter, envelope: WebhookEnvelope) -> dict:
+    return {
+        "v": 1,
+        "toolsets": [],
+        "profile_generation": adapter._current_profile_authority_generation(
+            envelope.authority_profile,
+            route_name=envelope.route.name,
+        ),
+    }
+
+
+@pytest.fixture(autouse=True)
+def _isolated_ledger_home(tmp_path, monkeypatch):
+    """Every adapter in this module owns a fresh durable ledger."""
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+
+def _app(adapter):
+    app = web.Application(client_max_size=adapter._max_body_bytes)
+    app.router.add_get("/health", adapter._handle_health)
+    app.router.add_post("/webhooks/{route_name}", adapter._handle_webhook)
+    app.router.add_post(
+        "/p/{profile}/webhooks/{route_name}",
+        adapter._handle_webhook,
+    )
+    return app
+
+
+def _stage_replay_safe_platform_delivery(
+    adapter: WebhookAdapter,
+    *,
+    trace_id: str,
+):
+    """Leave one exact target carrier ready for a replacement to recover."""
+
+    raw_body = json.dumps({"trace": trace_id}, separators=(",", ":")).encode()
+    route = WebhookRouteConfig.bind(
+        "primary-reconnect",
+        {"provider": "generic"},
+        headers={},
+        request_profile="default",
+    )
+    envelope = WebhookEnvelope.from_receipt(
+        WebhookLocalBypassReceipt._issue(route, raw_body, {}),
+        raw_body=raw_body,
+        media_type="application/json",
+        trace_id=trace_id,
+    )
+    admitted = adapter._operation_ledger.admit(envelope)
+    assert admitted.authority is not None
+    source = adapter._source_for_envelope(envelope)
+    prepared = adapter._operation_ledger.prepare(
+        admitted.authority,
+        event_snapshot={
+            "v": 1,
+            "mode": "direct",
+            "text": "one reconnect recovery response",
+            "payload": {"trace": trace_id},
+            "message_id": envelope.delivery_id,
+            "source": source.to_dict(),
+        },
+        target_snapshot={
+            "v": 1,
+            "kind": "platform",
+            "profile": "default",
+            "platform": "telegram",
+            "chat_id": "recovery-chat",
+        },
+        grant_snapshot=_grant_snapshot(adapter, envelope),
+    )
+    assert adapter._operation_ledger.mark_running(prepared)
+    staged = adapter._stage_exact_delivery(
+        prepared,
+        "one reconnect recovery response",
+        {"v": 1, "kind": "direct"},
+    )
+    assert staged.state is OperationState.DELIVERY_READY
+    assert adapter._operation_ledger.relinquish_recovery_claim(staged)
+    return envelope
+
+
+def _prepare_owned_direct_operation(
+    adapter: WebhookAdapter,
+    *,
+    raw_body: bytes,
+    content: str,
+    target_snapshot=None,
+):
+    """Leave one exact direct-delivery carrier owned by ``adapter``."""
+
+    route = WebhookRouteConfig.bind(
+        "events",
+        {"provider": "generic"},
+        headers={},
+        request_profile="default",
+    )
+    envelope = WebhookEnvelope.from_receipt(
+        WebhookLocalBypassReceipt._issue(route, raw_body, {}),
+        raw_body=raw_body,
+        media_type="application/json",
+    )
+    admitted = adapter._operation_ledger.admit(envelope)
+    assert admitted.authority is not None
+    source = adapter._source_for_envelope(envelope)
+    prepared = adapter._operation_ledger.prepare(
+        admitted.authority,
+        event_snapshot={
+            "v": 1,
+            "mode": "direct",
+            "text": content,
+            "payload": envelope.mutable_payload(),
+            "message_id": envelope.delivery_id,
+            "source": source.to_dict(),
+        },
+        target_snapshot=(
+            target_snapshot
+            or {
+                "v": 1,
+                "kind": "platform",
+                "profile": "default",
+                "platform": "telegram",
+                "chat_id": "recovery-chat",
+            }
+        ),
+        grant_snapshot=_grant_snapshot(adapter, envelope),
+    )
+    return envelope, prepared
+
+
+def _runner_for_primary_webhook_reconnect(
+    old_adapter: WebhookAdapter,
+    replacement_adapter: WebhookAdapter,
+    target_adapter,
+):
+    """Build the minimum real runner registry used by the primary watcher."""
+
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.WEBHOOK: replacement_adapter.config},
+        multiplex_profiles=False,
+    )
+    runner._running = True
+    runner._draining = False
+    runner._external_drain_active = False
+    runner._shutdown_event = asyncio.Event()
+    runner._failed_platforms = {
+        Platform.WEBHOOK: {
+            "config": replacement_adapter.config,
+            "attempts": 0,
+            "next_retry": time.monotonic() - 1,
+        }
+    }
+    runner.adapters = {
+        Platform.WEBHOOK: old_adapter,
+        Platform.TELEGRAM: target_adapter,
+    }
+    runner.delivery_router = SimpleNamespace(adapters=runner.adapters)
+    runner.session_store = MagicMock()
+    runner._profile_adapters = {}
+    runner._active_profile_name = lambda: "default"
+    runner._background_tasks = set()
+    runner._webhook_recovery_retry_task = None
+    runner._webhook_recovery_retry_adapter = None
+    runner._startup_restore_in_progress = False
+    runner._sync_voice_mode_state_to_adapter = MagicMock()
+    runner._update_platform_runtime_status = MagicMock()
+    runner._redeliver_failed_obligations_for_platform = AsyncMock(return_value=0)
+    runner._schedule_resume_pending_sessions = MagicMock(return_value=0)
+    old_adapter.gateway_runner = runner
+    replacement_adapter.gateway_runner = runner
+    return runner
+
+
+class TestLedgerConfiguration:
+    @pytest.mark.parametrize(
+        ("configured", "expected"),
+        [
+            (0, 1),
+            (-1, 1),
+            ("bad", _IDEMPOTENCY_DEFAULT_MAX_ENTRIES),
+            (True, _IDEMPOTENCY_DEFAULT_MAX_ENTRIES),
+            (False, _IDEMPOTENCY_DEFAULT_MAX_ENTRIES),
+            (float("inf"), _IDEMPOTENCY_DEFAULT_MAX_ENTRIES),
+            (_IDEMPOTENCY_MAX_ENTRIES_LIMIT + 1, _IDEMPOTENCY_MAX_ENTRIES_LIMIT),
+        ],
+    )
+    def test_ceiling_normalization(self, configured, expected):
+        assert _adapter(max_entries=configured)._idempotency_max_entries == expected
+
+    @pytest.mark.parametrize(
+        "configured",
+        [
+            None,
+            True,
+            False,
+            1.5,
+            "bad",
+            MINIMUM_MAX_STORAGE_BYTES - 1,
+            _IDEMPOTENCY_MAX_STORAGE_BYTES_LIMIT + 1,
+        ],
+    )
+    def test_storage_safety_limit_rejects_invalid_configuration(self, configured):
+        with pytest.raises(
+            WebhookConfigurationError,
+            match="idempotency_max_storage_bytes",
+        ):
+            _adapter(max_storage_bytes=configured)
+
+    @pytest.mark.parametrize(
+        "configured",
+        [
+            MINIMUM_MAX_STORAGE_BYTES,
+            str(MINIMUM_MAX_STORAGE_BYTES),
+            _IDEMPOTENCY_MAX_STORAGE_BYTES_LIMIT,
+        ],
+    )
+    def test_storage_safety_limit_accepts_exact_bounded_integers(self, configured):
+        assert _adapter(
+            max_storage_bytes=configured
+        )._idempotency_max_storage_bytes == int(configured)
+
+
+class TestRateLimitContract:
+    def test_exact_window_boundary_is_expired(self):
+        adapter = _adapter(rate_limit=1)
+        assert adapter._record_rate_limit_hit("events", 100.0) is True
+        assert adapter._record_rate_limit_hit("events", 160.0) is True
+
+
+class TestRawEnvelopeContract:
+    @pytest.mark.parametrize("cap", [64, 128, 4000, 8192])
+    def test_envelope_is_valid_json_and_never_exceeds_utf8_cap(self, cap):
+        payload = {"text": "🦊" * 5000, "quote": '"\\' * 200}
+        rendered = _adapter()._render_raw_payload(payload, cap)
+        assert len(rendered.encode("utf-8")) <= cap
+        envelope = json.loads(rendered)
+        assert set(envelope) == {"payload", "truncated", "original_bytes"}
+        assert isinstance(envelope["payload"], str)
+        assert envelope["original_bytes"] > 0
+
+    def test_default_raw_token_uses_complete_envelope(self):
+        rendered = _adapter()._render_prompt("raw={__raw__}", {"a": "b"}, "push", "r")
+        envelope = json.loads(rendered.split("raw=", 1)[1])
+        assert envelope["truncated"] is False
+        assert '"a": "b"' in envelope["payload"]
+        assert (
+            len(
+                json.dumps(envelope, ensure_ascii=False, separators=(",", ":")).encode(
+                    "utf-8"
+                )
+            )
+            <= _RAW_PAYLOAD_DEFAULT_CAP_BYTES
+        )
+
+    def test_explicit_raw_cap_is_supported(self):
+        rendered = _adapter()._render_prompt(
+            "{__raw__:128}", {"x": "z" * 5000}, "push", "r"
+        )
+        assert len(rendered.encode("utf-8")) <= 128
+        assert json.loads(rendered)["truncated"] is True
+
+    @pytest.mark.parametrize(
+        "template",
+        [
+            "{__raw__:63}",
+            f"{{__raw__:{_RAW_PAYLOAD_MAX_CAP_BYTES + 1}}}",
+            "{__raw__:banana}",
+            "{__raw__:}",
+        ],
+    )
+    def test_invalid_raw_caps_fail_closed(self, template):
+        with pytest.raises(ValueError):
+            _adapter()._render_prompt(template, {"x": 1}, "push", "r")
+
+    def test_raw_payload_does_not_trigger_second_template_pass(self):
+        rendered = _adapter()._render_prompt(
+            "{__raw__}", {"x": "{event_type}"}, "push", "r"
+        )
+        assert "{event_type}" in json.loads(rendered)["payload"]
+
+    def test_constants_are_ordered(self):
+        assert (
+            _RAW_PAYLOAD_MIN_CAP_BYTES
+            < _RAW_PAYLOAD_DEFAULT_CAP_BYTES
+            < _RAW_PAYLOAD_MAX_CAP_BYTES
+        )
+
+
+class TestFilterAuthority:
+    def test_regex_filter_preserves_normal_search_semantics(self):
+        processor = WebhookRouteProcessor()
+
+        assert processor.filter_matches(
+            {"field": "ref", "regex": r"^refs/heads/(main|release-\d+)$"},
+            {"ref": "refs/heads/release-42"},
+            "push",
+            {},
+        )
+
+    def test_pathological_regex_is_timed_out_outside_the_gateway_process(self):
+        processor = WebhookRouteProcessor()
+        started = time.monotonic()
+
+        matched = processor.filter_matches(
+            {"field": "value", "regex": r"(a+)+$"},
+            {"value": "a" * 50_000 + "!"},
+            "push",
+            {},
+        )
+
+        assert matched is False
+        assert time.monotonic() - started < 1.0
+
+    @pytest.mark.parametrize(
+        "filters",
+        [
+            [{"field": "value", "equals": 1}] * 65,
+            {
+                "not": {
+                    "not": {
+                        "not": {
+                            "not": {
+                                "not": {
+                                    "not": {
+                                        "not": {
+                                            "not": {
+                                                "field": "value",
+                                                "equals": 1,
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            {"all": [{"field": "value", "regex": "1"} for _ in range(9)]},
+        ],
+    )
+    def test_filter_complexity_limits_fail_closed(self, filters):
+        processor = WebhookRouteProcessor()
+
+        assert not processor.route_filters_match(
+            {"filters": filters},
+            {"value": 1},
+            "push",
+            {},
+        )
+
+    @pytest.mark.asyncio
+    async def test_blocked_regex_worker_does_not_block_health(self, monkeypatch):
+        started = threading.Event()
+        release = threading.Event()
+        real_popen = subprocess.Popen
+
+        def blocked_regex_worker(*args, **kwargs):
+            # Preserve the production READY/stdin/match protocol.  Holding the
+            # caller after the real spawn only models a route-worker stall; it
+            # must not stall the aiohttp event loop or its health endpoint.
+            process = real_popen(*args, **kwargs)
+            started.set()
+            assert release.wait(2)
+            return process
+
+        monkeypatch.setattr(
+            "gateway.platforms.webhook_filters.subprocess.Popen",
+            blocked_regex_worker,
+        )
+        adapter = _adapter({
+            "events": {
+                "secret": _INSECURE_NO_AUTH,
+                "provider": "generic",
+                "filters": {"field": "value", "regex": "^safe$"},
+            }
+        })
+
+        async with TestClient(TestServer(_app(adapter))) as client:
+            post_task = asyncio.create_task(
+                client.post("/webhooks/events", json={"value": "unsafe"})
+            )
+            try:
+                assert await asyncio.to_thread(started.wait, 1)
+                health = await asyncio.wait_for(client.get("/health"), timeout=0.5)
+                assert health.status == 200
+            finally:
+                release.set()
+            response = await asyncio.wait_for(post_task, timeout=2)
+
+        assert response.status == 200
+
+    @pytest.mark.parametrize(
+        "nested",
+        [
+            None,
+            "bad",
+            [],
+            7,
+            {},
+            {"field": "admin", "exists": "bad"},
+            {"field": "admin", "regex": "["},
+            {"field": "admin", "in_file": None},
+            {"all": []},
+            {"any": []},
+            {
+                "field": "admin",
+                "equals": True,
+                "regex": "^True$",
+            },
+            {
+                "all": [{"field": "admin", "equals": True}],
+                "not": {"field": "admin", "equals": False},
+            },
+        ],
+    )
+    def test_malformed_not_filter_cannot_invert_failure_into_acceptance(self, nested):
+        processor = WebhookRouteProcessor()
+
+        assert not processor.filter_matches(
+            {"not": nested},
+            {"admin": True},
+            "push",
+            {},
+        )
+
+    def test_valid_not_filter_can_invert_an_exact_non_match(self):
+        processor = WebhookRouteProcessor()
+
+        assert processor.filter_matches(
+            {"not": {"field": "admin", "equals": True}},
+            {"admin": False},
+            "push",
+            {},
+        )
+
+    def test_not_equals_requires_the_guarded_field_to_exist(self):
+        processor = WebhookRouteProcessor()
+
+        assert not processor.filter_matches(
+            {"field": "role", "not_equals": "admin"},
+            {},
+            "push",
+            {},
+        )
+
+    @pytest.mark.parametrize("expected", [None, "false", 0, 1])
+    def test_exists_filter_requires_a_boolean(self, expected):
+        processor = WebhookRouteProcessor()
+
+        assert not processor.filter_matches(
+            {"field": "admin", "exists": expected},
+            {"admin": True},
+            "push",
+            {},
+        )
+
+    @pytest.mark.parametrize("filters", [None, "", {}, 0, False])
+    def test_explicit_malformed_filters_do_not_mean_allow_all(self, filters):
+        processor = WebhookRouteProcessor()
+
+        assert not processor.route_filters_match(
+            {"filters": filters},
+            {"admin": True},
+            "push",
+            {},
+        )
+
+    @pytest.mark.asyncio
+    async def test_unsigned_observed_provider_header_is_not_filter_authority(self):
+        adapter = _adapter({
+            "events": {
+                "secret": _INSECURE_NO_AUTH,
+                "provider": "github",
+                "events": ["push"],
+                "filters": {
+                    "field": "headers.X-GitHub-Event",
+                    "equals": "push",
+                },
+            }
+        })
+        adapter.handle_message = AsyncMock()
+
+        async with TestClient(TestServer(_app(adapter))) as client:
+            response = await client.post(
+                "/webhooks/events",
+                json={"value": 1},
+                headers={
+                    "X-GitHub-Event": "push",
+                    "X-GitHub-Delivery": "observed-only",
+                },
+            )
+            payload = await response.json()
+
+        assert response.status == 200
+        assert payload["status"] == "ignored"
+        assert payload["reason"] == "filter"
+        adapter.handle_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_duplicate_event_headers_cannot_satisfy_route_authority(self):
+        adapter = _adapter({
+            "events": {
+                "secret": _INSECURE_NO_AUTH,
+                "provider": "github",
+                "events": ["push"],
+            }
+        })
+        adapter.handle_message = AsyncMock()
+        headers = CIMultiDict()
+        headers.add("Content-Type", "application/json")
+        headers.add("X-GitHub-Event", "push")
+        headers.add("X-GitHub-Event", "push")
+
+        async with TestClient(TestServer(_app(adapter))) as client:
+            response = await client.post(
+                "/webhooks/events",
+                data=b'{"value":1}',
+                headers=headers,
+            )
+
+        assert response.status == 401
+        assert adapter._operation_ledger.count() == 0
+        adapter.handle_message.assert_not_awaited()
+
+
+class TestAuthenticatedGitHubEventBodyAuthority:
+    @pytest.mark.asyncio
+    async def test_signed_deployment_status_cannot_be_relabelled_as_check_run(self):
+        secret = "github-check-run-body-secret"
+        adapter = _adapter({
+            "checks": {
+                "secret": secret,
+                "provider": "github",
+                "events": ["check_run"],
+            }
+        })
+        adapter.handle_message = AsyncMock()
+        body = json.dumps(
+            {
+                "action": "created",
+                "check_run": {"id": 401, "name": "deploy", "status": "queued"},
+                "deployment": {"id": 301},
+                "deployment_status": {"id": 302, "state": "pending"},
+                "repository": {"id": 801, "full_name": "org/repo"},
+                "sender": {"id": 901, "login": "octocat"},
+            },
+            separators=(",", ":"),
+        ).encode()
+        signature = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+
+        async with TestClient(TestServer(_app(adapter))) as client:
+            response = await client.post(
+                "/webhooks/checks",
+                data=body,
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Hub-Signature-256": f"sha256={signature}",
+                    "X-GitHub-Event": "check_run",
+                },
+            )
+            response_body = await response.json()
+
+        assert response.status == 401
+        assert response_body == {"error": "Invalid authenticated webhook metadata"}
+        assert adapter._operation_ledger.count() == 0
+        adapter.handle_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_signed_sub_issues_cannot_be_relabelled_as_issues(self):
+        secret = "github-issues-body-secret"
+        adapter = _adapter({
+            "issues": {
+                "secret": secret,
+                "provider": "github",
+                "events": ["issues"],
+            }
+        })
+        adapter.handle_message = AsyncMock()
+        body = json.dumps(
+            {
+                "action": "parent_issue_added",
+                "issue": {"id": 601, "number": 3},
+                "sub_issue": {"id": 602, "number": 4},
+                "repository": {"id": 801, "full_name": "org/repo"},
+                "sender": {"id": 901, "login": "octocat"},
+            },
+            separators=(",", ":"),
+        ).encode()
+        signature = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+
+        async with TestClient(TestServer(_app(adapter))) as client:
+            response = await client.post(
+                "/webhooks/issues",
+                data=body,
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Hub-Signature-256": f"sha256={signature}",
+                    # The captured sub_issues body is relabeled only here.
+                    "X-GitHub-Event": "issues",
+                    "X-GitHub-Delivery": "signed-sub-issues",
+                },
+            )
+            response_body = await response.json()
+
+        assert response.status == 401
+        assert response_body == {"error": "Invalid authenticated webhook metadata"}
+        assert adapter._operation_ledger.count() == 0
+        adapter.handle_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_signed_ping_cannot_be_relabelled_but_signed_pr_is_accepted(self):
+        secret = "github-event-body-secret"
+        adapter = _adapter({
+            "pulls": {
+                "secret": secret,
+                "provider": "github",
+                "events": ["pull_request"],
+                "prompt": "Review PR #{number}: {pull_request.title}",
+            }
+        })
+        adapter.handle_message = AsyncMock()
+
+        ping_body = json.dumps(
+            {
+                "zen": "Keep it logically awesome.",
+                "hook_id": 12345,
+                "hook": {"id": 12345, "type": "Repository", "name": "web"},
+                "repository": {"id": 801, "full_name": "org/repo"},
+                "sender": {"id": 901, "login": "octocat"},
+            },
+            separators=(",", ":"),
+        ).encode()
+        pull_request_body = json.dumps(
+            {
+                "action": "opened",
+                "number": 42,
+                "pull_request": {
+                    "id": 701,
+                    "number": 42,
+                    "state": "open",
+                    "title": "Authenticated PR",
+                },
+                "repository": {"id": 801, "full_name": "org/repo"},
+                "sender": {"id": 901, "login": "octocat"},
+            },
+            separators=(",", ":"),
+        ).encode()
+
+        def headers(body, delivery):
+            signature = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+            return {
+                "Content-Type": "application/json",
+                "X-Hub-Signature-256": f"sha256={signature}",
+                # The attack changes only this unsigned header to pull_request.
+                "X-GitHub-Event": "pull_request",
+                "X-GitHub-Delivery": delivery,
+            }
+
+        async with TestClient(TestServer(_app(adapter))) as client:
+            relabelled = await client.post(
+                "/webhooks/pulls",
+                data=ping_body,
+                headers=headers(ping_body, "signed-ping"),
+            )
+            relabelled_body = await relabelled.json()
+
+            assert relabelled.status == 401
+            assert relabelled_body == {
+                "error": "Invalid authenticated webhook metadata"
+            }
+            assert adapter._operation_ledger.count() == 0
+            adapter.handle_message.assert_not_awaited()
+
+            legitimate = await client.post(
+                "/webhooks/pulls",
+                data=pull_request_body,
+                headers=headers(pull_request_body, "signed-pull-request"),
+            )
+            legitimate_body = await legitimate.json()
+
+        assert legitimate.status == 202
+        assert legitimate_body["status"] == "accepted"
+        assert legitimate_body["event"] == "pull_request"
+        await asyncio.sleep(0.05)
+        adapter.handle_message.assert_awaited_once()
+
+
+class TestRouteScriptAuthority:
+    def test_script_snapshot_read_is_bounded_at_one_byte_past_limit(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        scripts = tmp_path / "scripts"
+        scripts.mkdir()
+        script = scripts / "oversized.py"
+        script.write_bytes(b"x" * (MAX_SCRIPT_SNAPSHOT_BYTES + 4096))
+        processor = WebhookRouteProcessor()
+
+        prepared, error = processor.prepare_route_script("oversized.py")
+
+        assert prepared is None
+        assert error == (
+            f"script exceeds {MAX_SCRIPT_SNAPSHOT_BYTES} byte snapshot limit"
+        )
+
+    def test_snapshotted_python_script_preserves_file_and_argv_contract(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        scripts = tmp_path / "scripts"
+        scripts.mkdir()
+        script = scripts / "identity.py"
+        script.write_text(
+            "import json, sys\n"
+            "print(json.dumps({'file': __file__, 'argv0': sys.argv[0]}))\n",
+            encoding="utf-8",
+        )
+        processor = WebhookRouteProcessor()
+
+        prepared, error = processor.prepare_route_script("identity.py")
+        assert error is None
+        assert prepared is not None
+
+        result = processor.run_prepared_script(prepared, {})
+
+        assert result.disposition is WebhookScriptDisposition.CONTINUE
+        identifier = f"hermes-webhook-script:{prepared.source_sha256}.py"
+        assert result.payload == {"file": identifier, "argv0": identifier}
+
+    def test_prepared_script_executes_snapshotted_bytes_after_file_changes(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        scripts = tmp_path / "scripts"
+        scripts.mkdir()
+        script = scripts / "transform.py"
+        script.write_text("print('{\"version\": 1}')\n", encoding="utf-8")
+        processor = WebhookRouteProcessor()
+
+        prepared, error = processor.prepare_route_script("transform.py")
+        assert error is None
+        assert prepared is not None
+        script.write_text("print('{\"version\": 2}')\n", encoding="utf-8")
+
+        result = processor.run_prepared_script(prepared, {})
+        assert result.disposition is WebhookScriptDisposition.CONTINUE
+        assert result.payload == {"version": 1}
+
+        substituted = processor.run_prepared_script(
+            replace(prepared, source="print('substituted')\n"),
+            {},
+        )
+        assert substituted.disposition is WebhookScriptDisposition.FAILED
+        assert "snapshot digest" in str(substituted.error)
+
+
+class TestHTTPComposition:
+    @pytest.mark.asyncio
+    async def test_unverified_provider_id_cannot_alias_distinct_bodies(self):
+        adapter = _adapter({
+            "events": {"secret": _INSECURE_NO_AUTH, "provider": "github"}
+        })
+        captured = []
+
+        async def capture(event):
+            captured.append(event)
+
+        adapter.handle_message = capture
+        headers = {"X-GitHub-Delivery": "delivery-1"}
+        async with TestClient(TestServer(_app(adapter))) as client:
+            first = await client.post(
+                "/webhooks/events", json={"value": 1}, headers=headers
+            )
+            second = await client.post(
+                "/webhooks/events", json={"value": 2}, headers=headers
+            )
+        assert first.status == second.status == 202
+        await asyncio.sleep(0.05)
+        assert len(captured) == 2
+        assert len({event.source.chat_id for event in captured}) == 2
+
+    @pytest.mark.asyncio
+    async def test_authenticated_delivery_id_conflicts_on_different_body(self):
+        secret = "shared-hermes-secret"
+        delivery_id = "delivery-1"
+        first_body = _serialize_payload("post_tool_call", {"value": 1}, delivery_id)
+        second_body = _serialize_payload("post_tool_call", {"value": 2}, delivery_id)
+        target = WebhookTarget(
+            url="https://receiver.invalid/events",
+            events=["post_tool_call"],
+            secret=secret,
+        )
+        first_delivery = _build_delivery(
+            "post_tool_call", target, first_body, delivery_id
+        )
+        second_delivery = _build_delivery(
+            "post_tool_call", target, second_body, delivery_id
+        )
+        adapter = _adapter({"events": {"secret": secret, "provider": "hermes"}})
+        adapter.handle_message = AsyncMock()
+
+        async with TestClient(TestServer(_app(adapter))) as client:
+            first = await client.post(
+                "/webhooks/events",
+                data=first_delivery["body"],
+                headers=first_delivery["headers"],
+            )
+            conflict = await client.post(
+                "/webhooks/events",
+                data=second_delivery["body"],
+                headers=second_delivery["headers"],
+            )
+            conflict_body = await conflict.json()
+        assert first.status == 202
+        assert conflict.status == 409
+        assert conflict_body["status"] == "conflict"
+        adapter.handle_message.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_body_replay_identity_deduplicates_without_provider_id(self):
+        adapter = _adapter({
+            "events": {"secret": _INSECURE_NO_AUTH, "provider": "generic"}
+        })
+        captured = []
+
+        async def capture(event):
+            captured.append(event)
+
+        adapter.handle_message = capture
+        async with TestClient(TestServer(_app(adapter))) as client:
+            first = await client.post("/webhooks/events", json={"value": 1})
+            second = await client.post("/webhooks/events", json={"value": 1})
+            first_body = await first.json()
+            second_body = await second.json()
+        assert first.status == second.status == 202
+        assert first_body["deduplication"] == "local_bypass_body_sha256"
+        assert second_body["status"] == "in_progress"
+        await asyncio.sleep(0.05)
+        assert len(captured) == 1
+        assert captured[0].source.chat_id.startswith("webhook:default:events:generic:")
+
+    @pytest.mark.asyncio
+    async def test_tool_grants_are_snapshotted_at_admission(self, monkeypatch):
+        adapter = _adapter({
+            "events": {
+                "secret": _INSECURE_NO_AUTH,
+                "provider": "generic",
+                "toolsets": ["terminal"],
+            }
+        })
+        admitted_profile_generation = adapter._current_profile_authority_generation(
+            "default",
+            route_name="events",
+        )
+        monkeypatch.setattr(
+            adapter,
+            "_resolve_admitted_toolsets",
+            lambda route_config, source: ["terminal"],
+        )
+        captured = []
+
+        async def capture(event):
+            captured.append(event)
+
+        adapter.handle_message = capture
+        async with TestClient(TestServer(_app(adapter))) as client:
+            response = await client.post("/webhooks/events", json={"value": 1})
+        assert response.status == 202
+        await asyncio.sleep(0.05)
+        source = captured[0].source
+        adapter._routes["events"]["toolsets"] = ["web"]
+        assert adapter.resolved_toolsets_for_source(source) == ["terminal"]
+        authority = adapter._operation_ledger.lookup_session(source.chat_id)
+        assert authority is not None
+        assert dict(authority.grant_snapshot) == {
+            "v": 1,
+            "toolsets": ("terminal",),
+            "profile_generation": admitted_profile_generation,
+        }
+
+    @pytest.mark.asyncio
+    async def test_declared_provider_cannot_be_switched_by_valid_other_signature(self):
+        adapter = _adapter({"events": {"secret": "secret", "provider": "github"}})
+        body = b'{"value":1}'
+        async with TestClient(TestServer(_app(adapter))) as client:
+            response = await client.post(
+                "/webhooks/events",
+                data=body,
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Gitlab-Token": "secret",
+                },
+            )
+        assert response.status == 401
+
+    @pytest.mark.asyncio
+    async def test_failed_direct_effect_is_not_laundered_as_duplicate_success(
+        self, monkeypatch
+    ):
+        adapter = _adapter({
+            "events": {
+                "secret": _INSECURE_NO_AUTH,
+                "provider": "github",
+                "deliver_only": True,
+                "deliver": "telegram",
+                "deliver_extra": {"chat_id": "target-chat"},
+            }
+        })
+        target_adapter = SimpleNamespace(
+            config=SimpleNamespace(home_channel=None),
+            send=AsyncMock(
+                return_value=SendResult(success=False, error="unknown effect")
+            ),
+        )
+        adapter.gateway_runner = SimpleNamespace(
+            config=SimpleNamespace(multiplex_profiles=False),
+            adapters={
+                Platform.WEBHOOK: adapter,
+                Platform.TELEGRAM: target_adapter,
+            },
+            _profile_adapters={},
+            _authorization_adapter=lambda platform, profile: (
+                target_adapter
+                if platform is Platform.TELEGRAM and profile == "default"
+                else None
+            ),
+        )
+        grant_resolver = MagicMock(
+            side_effect=AssertionError("direct delivery must not resolve agent grants")
+        )
+        monkeypatch.setattr(adapter, "_resolve_admitted_toolsets", grant_resolver)
+        headers = {"X-GitHub-Delivery": "delivery-unknown"}
+        async with TestClient(TestServer(_app(adapter))) as client:
+            first = await client.post(
+                "/webhooks/events", json={"value": 1}, headers=headers
+            )
+            first_body = await first.json()
+            retry = await client.post(
+                "/webhooks/events", json={"value": 1}, headers=headers
+            )
+            retry_body = await retry.json()
+        assert first.status == 502
+        assert first_body["status"] == "indeterminate"
+        assert retry.status == 409
+        assert retry_body["status"] == "indeterminate"
+        target_adapter.send.assert_awaited_once()
+        grant_resolver.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_pre_execution_script_failure_releases_claim_for_safe_retry(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        adapter = _adapter({
+            "events": {
+                "secret": _INSECURE_NO_AUTH,
+                "provider": "github",
+                "script": "late.py",
+            }
+        })
+        headers = {"X-GitHub-Delivery": "script-retry-1"}
+        async with TestClient(TestServer(_app(adapter))) as client:
+            first = await client.post(
+                "/webhooks/events", json={"value": 1}, headers=headers
+            )
+            first_body = await first.json()
+            scripts = tmp_path / "scripts"
+            scripts.mkdir()
+            (scripts / "late.py").write_text("print('[SILENT]')\n", encoding="utf-8")
+            retry = await client.post(
+                "/webhooks/events", json={"value": 1}, headers=headers
+            )
+            retry_body = await retry.json()
+        assert first.status == 500
+        assert first_body["status"] == "failed"
+        assert retry.status == 200
+        assert retry_body["status"] == "ignored"
+
+    @pytest.mark.asyncio
+    async def test_started_script_failure_is_indeterminate_not_completed(
+        self, tmp_path
+    ):
+        scripts = tmp_path / "scripts"
+        scripts.mkdir()
+        (scripts / "effectful.py").write_text(
+            "print('{\"value\": 1}')\n", encoding="utf-8"
+        )
+        adapter = _adapter({
+            "events": {
+                "secret": _INSECURE_NO_AUTH,
+                "provider": "github",
+                "script": "effectful.py",
+            }
+        })
+        adapter._route_processor.run_prepared_script = MagicMock(
+            return_value=WebhookScriptResult(
+                WebhookScriptDisposition.INDETERMINATE,
+                error="script timed out after execution started",
+            )
+        )
+        headers = {"X-GitHub-Delivery": "script-unknown-1"}
+        async with TestClient(TestServer(_app(adapter))) as client:
+            first = await client.post(
+                "/webhooks/events", json={"value": 1}, headers=headers
+            )
+            first_body = await first.json()
+            retry = await client.post(
+                "/webhooks/events", json={"value": 1}, headers=headers
+            )
+            retry_body = await retry.json()
+        assert first.status == 500
+        assert first_body["status"] == "indeterminate"
+        assert retry.status == 409
+        assert retry_body["status"] == "indeterminate"
+        adapter._route_processor.run_prepared_script.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_strict_media_encoding_and_object_contract(self):
+        adapter = _adapter({
+            "events": {"secret": _INSECURE_NO_AUTH, "provider": "generic"}
+        })
+        adapter.handle_message = AsyncMock()
+        async with TestClient(TestServer(_app(adapter))) as client:
+            unsupported = await client.post(
+                "/webhooks/events",
+                data=b"{}",
+                headers={"Content-Type": "text/plain"},
+            )
+            array = await client.post("/webhooks/events", json=[1, 2])
+            duplicate = await client.post(
+                "/webhooks/events",
+                data=b'{"value":1,"value":2}',
+                headers={"Content-Type": "application/json"},
+            )
+        assert unsupported.status == 415
+        assert array.status == 400
+        assert duplicate.status == 400
+
+        # aiohttp may reject unsupported encodings in its parser before a
+        # handler is entered, so pin the adapter's own defense in depth at the
+        # direct handler boundary as well.
+        request = MagicMock()
+        request.match_info = {"route_name": "events"}
+        request.headers = {
+            "Content-Type": "application/json",
+            "Content-Encoding": "br",
+        }
+        request.content_length = 2
+        encoded = await adapter._handle_webhook(request)
+        assert encoded.status == 415
+
+    @pytest.mark.asyncio
+    async def test_non_finite_json_is_malformed_body_not_auth_failure(self):
+        adapter = _adapter({
+            "events": {"secret": _INSECURE_NO_AUTH, "provider": "generic"}
+        })
+        adapter.handle_message = AsyncMock()
+        async with TestClient(TestServer(_app(adapter))) as client:
+            response = await client.post(
+                "/webhooks/events",
+                data=b'{"amount":NaN}',
+                headers={"Content-Type": "application/json"},
+            )
+            response_body = await response.json()
+        assert response.status == 400
+        assert response_body["error"] == "Cannot parse JSON body"
+        adapter.handle_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_oversized_signed_event_isolated_before_durable_admission(self):
+        secret = "bounded-event-secret"
+        adapter = _adapter({
+            "events": {
+                "secret": secret,
+                "signature_mode": "generic_v1",
+            }
+        })
+        adapter.handle_message = AsyncMock()
+
+        def signed(payload):
+            body = json.dumps(payload, separators=(",", ":")).encode()
+            signature = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+            return body, {
+                "Content-Type": "application/json",
+                "X-Webhook-Signature": signature,
+            }
+
+        oversized_body, oversized_headers = signed({"type": "é" * 513})
+        valid_body, valid_headers = signed({"type": "tick", "value": 1})
+        async with TestClient(TestServer(_app(adapter))) as client:
+            rejected = await client.post(
+                "/webhooks/events",
+                data=oversized_body,
+                headers=oversized_headers,
+            )
+            rejected_payload = await rejected.json()
+            healthy = await client.get("/health")
+            accepted = await client.post(
+                "/webhooks/events",
+                data=valid_body,
+                headers=valid_headers,
+            )
+
+        assert rejected.status == 400
+        assert rejected_payload == {"error": "Invalid authenticated webhook payload"}
+        assert healthy.status == 200
+        assert accepted.status == 202
+        assert adapter._accepting_webhooks is True
+        assert adapter._operation_ledger.count() == 1
+        adapter.handle_message.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_bounded_legacy_v1_route_uses_explicit_selected_mode(self):
+        secret = "legacy-secret"
+        body = b'{"event_type":"tick"}'
+        signature = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+        adapter = _adapter({
+            "events": {"secret": secret, "signature_mode": "generic_v1"}
+        })
+        adapter.handle_message = AsyncMock()
+        async with TestClient(TestServer(_app(adapter))) as client:
+            response = await client.post(
+                "/webhooks/events",
+                data=body,
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Webhook-Signature": signature,
+                    "X-Request-ID": "legacy-1",
+                },
+            )
+        assert response.status == 202
+
+    @pytest.mark.asyncio
+    async def test_providerless_route_fails_closed_before_header_inference(self):
+        secret = "route-secret"
+        body = b'{"event_type":"tick"}'
+        signature = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+        adapter = _adapter({"events": {"secret": secret}})
+        adapter.handle_message = AsyncMock()
+        async with TestClient(TestServer(_app(adapter))) as client:
+            response = await client.post(
+                "/webhooks/events",
+                data=body,
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Webhook-Signature": signature,
+                    "X-Hub-Signature-256": f"sha256={signature}",
+                },
+            )
+        assert response.status == 500
+        adapter.handle_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_local_auth_bypass_fails_closed_on_public_host_at_request_gate(self):
+        adapter = _adapter({
+            "events": {"secret": _INSECURE_NO_AUTH, "provider": "generic"}
+        })
+        adapter._host = "0.0.0.0"
+        adapter.handle_message = AsyncMock()
+        async with TestClient(TestServer(_app(adapter))) as client:
+            response = await client.post("/webhooks/events", json={"value": 1})
+        assert response.status == 403
+        adapter.handle_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_exact_signed_hermes_outbound_delivery_is_valid_inbound(self):
+        secret = "shared-hermes-secret"
+        delivery_id = "h-1"
+        body = _serialize_payload(
+            "post_tool_call", {"tool_name": "terminal"}, delivery_id
+        )
+        delivery = _build_delivery(
+            "post_tool_call",
+            WebhookTarget(
+                url="https://receiver.invalid/events",
+                events=["post_tool_call"],
+                secret=secret,
+            ),
+            body,
+            delivery_id,
+        )
+        adapter = _adapter({"events": {"secret": secret, "provider": "hermes"}})
+        adapter.handle_message = AsyncMock()
+        async with TestClient(TestServer(_app(adapter))) as client:
+            first = await client.post(
+                "/webhooks/events",
+                data=delivery["body"],
+                headers=delivery["headers"],
+            )
+            first_body = await first.json()
+            retry = await client.post(
+                "/webhooks/events",
+                data=delivery["body"],
+                headers=delivery["headers"],
+            )
+            retry_body = await retry.json()
+        assert first.status == 202
+        assert first_body["event"] == "post_tool_call"
+        assert first_body["deduplication"] == "authenticated_delivery"
+        assert retry.status == 202
+        assert retry_body["status"] == "in_progress"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("header", "attacker_value"),
+        [
+            ("X-Hermes-Delivery", "attacker-delivery"),
+            ("X-Hermes-Event", "attacker-event"),
+        ],
+    )
+    async def test_signed_hermes_body_rejects_mutated_unsigned_metadata_header(
+        self, header, attacker_value
+    ):
+        secret = "shared-hermes-secret"
+        delivery_id = "real-delivery"
+        body = _serialize_payload("post_tool_call", {}, delivery_id)
+        delivery = _build_delivery(
+            "post_tool_call",
+            WebhookTarget(
+                url="https://receiver.invalid/events",
+                events=["post_tool_call"],
+                secret=secret,
+            ),
+            body,
+            delivery_id,
+        )
+        headers = {**delivery["headers"], header: attacker_value}
+        adapter = _adapter({"events": {"secret": secret, "provider": "hermes"}})
+        adapter.handle_message = AsyncMock()
+        async with TestClient(TestServer(_app(adapter))) as client:
+            response = await client.post(
+                "/webhooks/events", data=delivery["body"], headers=headers
+            )
+        assert response.status == 401
+        adapter.handle_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("missing_header", ["X-Hermes-Delivery", "X-Hermes-Event"])
+    async def test_signed_hermes_body_requires_matching_metadata_header(
+        self, missing_header
+    ):
+        secret = "shared-hermes-secret"
+        delivery_id = "real-delivery"
+        body = _serialize_payload("post_tool_call", {}, delivery_id)
+        delivery = _build_delivery(
+            "post_tool_call",
+            WebhookTarget(
+                url="https://receiver.invalid/events",
+                events=["post_tool_call"],
+                secret=secret,
+            ),
+            body,
+            delivery_id,
+        )
+        headers = {
+            key: value
+            for key, value in delivery["headers"].items()
+            if key != missing_header
+        }
+        adapter = _adapter({"events": {"secret": secret, "provider": "hermes"}})
+        adapter.handle_message = AsyncMock()
+        async with TestClient(TestServer(_app(adapter))) as client:
+            response = await client.post(
+                "/webhooks/events", data=delivery["body"], headers=headers
+            )
+        assert response.status == 401
+        adapter.handle_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_exact_signed_hermes_delivery_rejects_stale_body_timestamp(self):
+        secret = "shared-hermes-secret"
+        delivery_id = "stale-delivery"
+        current = json.loads(_serialize_payload("post_tool_call", {}, delivery_id))
+        current["timestamp"] = "2020-01-01T00:00:00Z"
+        stale_body = json.dumps(current).encode("utf-8")
+        delivery = _build_delivery(
+            "post_tool_call",
+            WebhookTarget(
+                url="https://receiver.invalid/events",
+                events=["post_tool_call"],
+                secret=secret,
+            ),
+            stale_body,
+            delivery_id,
+        )
+        adapter = _adapter({"events": {"secret": secret, "provider": "hermes"}})
+        adapter.handle_message = AsyncMock()
+        async with TestClient(TestServer(_app(adapter))) as client:
+            response = await client.post(
+                "/webhooks/events", data=delivery["body"], headers=delivery["headers"]
+            )
+        assert response.status == 401
+        adapter.handle_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_failed_agent_processing_becomes_indeterminate_for_retry(self):
+        adapter = _adapter({
+            "events": {
+                "secret": _INSECURE_NO_AUTH,
+                "provider": "github",
+            }
+        })
+        captured = []
+
+        async def capture(event):
+            captured.append(event)
+
+        adapter.handle_message = capture
+        headers = {"X-GitHub-Delivery": "agent-failed"}
+        async with TestClient(TestServer(_app(adapter))) as client:
+            first = await client.post(
+                "/webhooks/events", json={"value": 1}, headers=headers
+            )
+            await asyncio.sleep(0.05)
+            event = captured[0]
+            assert event.webhook_envelope.observed_delivery_id == "agent-failed"
+            assert event.webhook_envelope.delivery_identity is None
+            await adapter.on_processing_start(event)
+            await adapter.on_processing_complete(event, ProcessingOutcome.FAILURE)
+            retry = await client.post(
+                "/webhooks/events", json={"value": 1}, headers=headers
+            )
+            retry_body = await retry.json()
+        assert first.status == 202
+        assert retry.status == 409
+        assert retry_body["status"] == "indeterminate"
+
+
+class TestRuntimeOwnershipAndFinalCarrier:
+    @pytest.mark.asyncio
+    async def test_final_send_invokes_staged_target_once_and_preserves_result(self):
+        adapter = _adapter()
+        _envelope, prepared = _prepare_owned_direct_operation(
+            adapter,
+            raw_body=b'{"case":"single-final-send"}',
+            content="one final response",
+        )
+        assert adapter._operation_ledger.mark_running(prepared)
+        invoke = AsyncMock(
+            return_value=WebhookTargetDeliveryResult(
+                WebhookTargetDeliveryDisposition.CONFIRMED,
+                message_id="confirmed-message-id",
+            )
+        )
+        adapter._invoke_staged_target = invoke
+
+        result = await adapter.send(
+            prepared.session_key,
+            "one final response",
+            metadata={"notify": True},
+        )
+
+        invoke.assert_awaited_once()
+        assert result.success is True
+        assert result.message_id == "confirmed-message-id"
+        assert result.retryable is False
+        assert result.raw_response == {"webhook_settlement": "confirmed"}
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("route_profile", "expected_profile"),
+        [(None, "default"), ("ops", "ops")],
+    )
+    async def test_named_single_profile_self_prefix_reaches_bound_route(
+        self,
+        monkeypatch,
+        route_profile,
+        expected_profile,
+    ):
+        from gateway.run import GatewayRunner
+
+        route = {
+            "secret": _INSECURE_NO_AUTH,
+            "provider": "generic",
+            "deliver": "telegram",
+            "deliver_extra": {"chat_id": "named-home-chat"},
+        }
+        if route_profile is not None:
+            route["profile"] = route_profile
+        adapter = _adapter({"events": route})
+        target_adapter = SimpleNamespace(
+            config=PlatformConfig(enabled=True),
+        )
+        runner = object.__new__(GatewayRunner)
+        runner.config = GatewayConfig(multiplex_profiles=False)
+        runner.adapters = {
+            Platform.WEBHOOK: adapter,
+            Platform.TELEGRAM: target_adapter,
+        }
+        runner._profile_adapters = {}
+        runner._active_profile_name = lambda: "ops"
+        runner._startup_restore_in_progress = False
+        runner._draining = False
+        runner._external_drain_active = False
+        runner._running = True
+        adapter.gateway_runner = runner
+        adapter._resolve_admitted_toolsets = lambda *_args: []
+        adapter.handle_message = AsyncMock()
+        monkeypatch.setattr(
+            "hermes_cli.profiles.profile_matches_home",
+            lambda profile: profile == "ops",
+        )
+
+        async with TestClient(TestServer(_app(adapter))) as client:
+            response = await client.post(
+                "/p/ops/webhooks/events",
+                json={"value": 1},
+            )
+
+        assert response.status == 202
+        assert adapter._operation_ledger.count() == 1
+        adapter.handle_message.assert_awaited_once()
+        event = adapter.handle_message.await_args.args[0]
+        assert event.source.profile == expected_profile
+
+    @pytest.mark.asyncio
+    async def test_saturated_unique_admission_has_no_false_retry_interval(self):
+        adapter = _adapter({
+            "events": {"secret": _INSECURE_NO_AUTH, "provider": "generic"}
+        })
+        adapter.handle_message = AsyncMock()
+        adapter._operation_ledger.admit = MagicMock(
+            return_value=AdmitResult(
+                AdmitDisposition.SATURATED,
+                saturation=AdmitSaturationReason.GLOBAL_STORAGE_LIMIT,
+            )
+        )
+
+        async with TestClient(TestServer(_app(adapter))) as client:
+            response = await client.post("/webhooks/events", json={"value": 1})
+            payload = await response.json()
+
+        assert response.status == 503
+        assert payload == {
+            "status": "unavailable",
+            "error": "Durable webhook evidence capacity exhausted for global",
+        }
+        assert "Retry-After" not in response.headers
+        assert adapter._global_ledger_saturated is True
+        adapter.handle_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_scope_saturation_does_not_claim_global_health_failure(self):
+        adapter = _adapter({
+            "events": {"secret": _INSECURE_NO_AUTH, "provider": "generic"}
+        })
+        adapter.handle_message = AsyncMock()
+        adapter._operation_ledger.admit = MagicMock(
+            return_value=AdmitResult(
+                AdmitDisposition.SATURATED,
+                saturation=AdmitSaturationReason.SCOPE_STORAGE_LIMIT,
+            )
+        )
+
+        async with TestClient(TestServer(_app(adapter))) as client:
+            response = await client.post("/webhooks/events", json={"value": 1})
+            payload = await response.json()
+            health = await client.get("/health")
+            health_payload = await health.json()
+
+        assert response.status == 503
+        assert payload["error"].endswith("for route scope")
+        assert "Retry-After" not in response.headers
+        assert health.status == 200
+        assert health_payload["accepting_webhooks"] is True
+        assert adapter._global_ledger_saturated is False
+        adapter.handle_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("terminal_outcome", "first_status", "remaining_rows"),
+        [
+            ("settle", 200, 1),
+            ("release", 500, 0),
+        ],
+    )
+    async def test_global_saturation_health_recovers_when_active_capacity_frees(
+        self,
+        monkeypatch,
+        terminal_outcome,
+        first_status,
+        remaining_rows,
+    ):
+        routes = {
+            name: {"secret": _INSECURE_NO_AUTH, "provider": "generic"}
+            for name in ("first", "second")
+        }
+        adapter = _adapter(routes, max_entries=1)
+        adapter.handle_message = AsyncMock()
+        filter_entered = threading.Event()
+        release_filter = threading.Event()
+
+        def blocking_filter(*_args, **_kwargs):
+            filter_entered.set()
+            assert release_filter.wait(2)
+            if terminal_outcome == "settle":
+                return False
+            raise RuntimeError("injected pre-effect filter failure")
+
+        monkeypatch.setattr(
+            adapter._route_processor,
+            "route_filters_match",
+            blocking_filter,
+        )
+
+        async with TestClient(TestServer(_app(adapter))) as client:
+            first_request = asyncio.create_task(
+                client.post("/webhooks/first", json={"value": 1})
+            )
+            try:
+                assert await asyncio.to_thread(filter_entered.wait, 1)
+                saturated = await client.post(
+                    "/webhooks/second",
+                    json={"value": 2},
+                )
+                saturated_payload = await saturated.json()
+                degraded = await client.get("/health")
+                degraded_payload = await degraded.json()
+            finally:
+                release_filter.set()
+            first = await asyncio.wait_for(first_request, timeout=2)
+            healthy = await client.get("/health")
+            healthy_payload = await healthy.json()
+
+        assert saturated.status == 503
+        assert saturated_payload["error"].endswith("for global")
+        assert degraded.status == 503
+        assert degraded_payload["status"] == "degraded"
+        assert first.status == first_status
+        assert healthy.status == 200
+        assert healthy_payload["status"] == "ok"
+        assert healthy_payload["accepting_webhooks"] is True
+        assert adapter._global_ledger_saturated is False
+        assert adapter._operation_ledger.count() == remaining_rows
+        adapter.handle_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_permanent_global_proofs_keep_health_degraded_without_retry_hint(
+        self,
+    ):
+        route_names = [f"proof-{index}" for index in range(4)]
+        secrets = {name: f"permanent-proof-secret-{name}" for name in route_names}
+        routes = {
+            name: {
+                "secret": secrets[name],
+                "provider": "generic",
+                "signature_mode": "generic_v1",
+                "events": ["never-selected"],
+            }
+            for name in route_names
+        }
+        storage_limit = (
+            MINIMUM_MAX_STORAGE_BYTES + 2 * _TOMBSTONE_STORAGE_RESERVATION_BYTES
+        )
+        adapter = _adapter(
+            routes,
+            max_entries=8,
+            max_storage_bytes=storage_limit,
+        )
+        adapter.handle_message = AsyncMock()
+
+        def signed_request(route_name, index):
+            body = json.dumps(
+                {"value": index},
+                separators=(",", ":"),
+                sort_keys=True,
+            ).encode()
+            signature = hmac.new(
+                secrets[route_name].encode(),
+                body,
+                hashlib.sha256,
+            ).hexdigest()
+            return body, {
+                "Content-Type": "application/json",
+                "X-Webhook-Signature": signature,
+            }
+
+        async with TestClient(TestServer(_app(adapter))) as client:
+            for index, route_name in enumerate(route_names[:3]):
+                body, headers = signed_request(route_name, index)
+                settled = await client.post(
+                    f"/webhooks/{route_name}",
+                    data=body,
+                    headers=headers,
+                )
+                assert settled.status == 200
+
+            overflow_body, overflow_headers = signed_request(route_names[3], 3)
+            saturated = await client.post(
+                f"/webhooks/{route_names[3]}",
+                data=overflow_body,
+                headers=overflow_headers,
+            )
+            saturated_payload = await saturated.json()
+            health = await client.get("/health")
+            payload = await health.json()
+
+            replay_body, replay_headers = signed_request(route_names[0], 0)
+            replay = await client.post(
+                f"/webhooks/{route_names[0]}",
+                data=replay_body,
+                headers=replay_headers,
+            )
+            replay_payload = await replay.json()
+
+        assert saturated.status == 503
+        assert saturated_payload["error"].endswith("for global")
+        assert health.status == 503
+        assert payload == {
+            "status": "degraded",
+            "platform": "webhook",
+            "accepting_webhooks": False,
+            "error": "Durable webhook evidence capacity is exhausted",
+        }
+        assert "Retry-After" not in health.headers
+        assert replay.status == 200
+        assert replay_payload["status"] == "duplicate"
+        assert adapter._operation_ledger.count() == 0
+        assert adapter._operation_ledger.tombstone_count() == 3
+        assert adapter._operation_ledger.storage_usage() == (
+            3 * _TOMBSTONE_STORAGE_RESERVATION_BYTES,
+            3,
+            storage_limit,
+        )
+        adapter.handle_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("lifecycle_attribute", "lifecycle_value"),
+        [
+            ("_startup_restore_in_progress", True),
+            ("_draining", True),
+            ("_external_drain_active", True),
+            ("_running", False),
+        ],
+    )
+    async def test_runner_lifecycle_gate_rejects_before_durable_admission(
+        self,
+        lifecycle_attribute,
+        lifecycle_value,
+    ):
+        adapter = _adapter({
+            "events": {"secret": _INSECURE_NO_AUTH, "provider": "generic"}
+        })
+        runner = SimpleNamespace(
+            config=SimpleNamespace(multiplex_profiles=False),
+            adapters={Platform.WEBHOOK: adapter},
+            _startup_restore_in_progress=False,
+            _draining=False,
+            _external_drain_active=False,
+            _running=True,
+        )
+        setattr(runner, lifecycle_attribute, lifecycle_value)
+        adapter.gateway_runner = runner
+        adapter.handle_message = AsyncMock()
+
+        async with TestClient(TestServer(_app(adapter))) as client:
+            response = await client.post("/webhooks/events", json={"value": 1})
+
+        assert response.status == 503
+        assert adapter._operation_ledger.count() == 0
+        adapter.handle_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_reconnect_recovery_failure_closes_intake_and_degrades_health(self):
+        from gateway.run import GatewayRunner
+
+        adapter = _adapter({
+            "events": {"secret": _INSECURE_NO_AUTH, "provider": "generic"}
+        })
+        adapter.handle_message = AsyncMock()
+        adapter.recover_pending_operations = AsyncMock(
+            side_effect=RuntimeError("injected recovery outage")
+        )
+        runner = SimpleNamespace(
+            adapters={Platform.WEBHOOK: adapter},
+            _startup_restore_in_progress=False,
+            _running=True,
+            _update_platform_runtime_status=MagicMock(),
+        )
+        adapter.gateway_runner = runner
+
+        recovered = await GatewayRunner._recover_webhook_operations(
+            runner,
+            trigger="reconnect:webhook",
+        )
+
+        assert recovered == 0
+        assert adapter._accepting_webhooks is False
+        async with TestClient(TestServer(_app(adapter))) as client:
+            health = await client.get("/health")
+            health_payload = await health.json()
+            response = await client.post("/webhooks/events", json={"value": 1})
+        assert health.status == 503
+        assert health_payload == {
+            "status": "degraded",
+            "platform": "webhook",
+            "accepting_webhooks": False,
+            "error": "Webhook intake is not active",
+        }
+        assert health.headers["Retry-After"] == "5"
+        assert response.status == 503
+        assert adapter._operation_ledger.count() == 0
+        adapter.handle_message.assert_not_awaited()
+        runner._update_platform_runtime_status.assert_called_once_with(
+            Platform.WEBHOOK.value,
+            platform_state="retrying",
+            error_code="webhook_recovery_failed",
+            error_message="Durable webhook recovery failed",
+        )
+
+    @pytest.mark.asyncio
+    async def test_transient_recovery_failure_retries_and_reopens_exact_adapter(
+        self,
+        monkeypatch,
+    ):
+        from gateway import run as gateway_run
+        from gateway.run import GatewayRunner
+
+        adapter = _adapter()
+        adapter.recover_pending_operations = AsyncMock(
+            side_effect=[RuntimeError("transient storage fault"), 0]
+        )
+        runner = object.__new__(GatewayRunner)
+        runner.config = GatewayConfig(multiplex_profiles=False)
+        runner.adapters = {Platform.WEBHOOK: adapter}
+        runner._background_tasks = set()
+        runner._webhook_recovery_retry_task = None
+        runner._startup_restore_in_progress = False
+        runner._draining = False
+        runner._external_drain_active = False
+        runner._running = True
+        runner._shutdown_event = asyncio.Event()
+        runner._update_platform_runtime_status = MagicMock()
+        adapter.gateway_runner = runner
+        monkeypatch.setattr(
+            gateway_run,
+            "_WEBHOOK_RECOVERY_RETRY_INITIAL_SECONDS",
+            0,
+        )
+        monkeypatch.setattr(
+            gateway_run,
+            "_WEBHOOK_RECOVERY_RETRY_MAX_SECONDS",
+            0,
+        )
+
+        recovered = await runner._recover_webhook_operations(trigger="startup")
+        retry_task = runner._webhook_recovery_retry_task
+        assert recovered == 0
+        assert adapter._accepting_webhooks is False
+        assert retry_task is not None
+
+        await retry_task
+        await asyncio.sleep(0)
+
+        assert adapter.recover_pending_operations.await_count == 2
+        assert adapter.recover_pending_operations.await_args_list[1].kwargs == {
+            "trigger": "retry"
+        }
+        assert adapter._accepting_webhooks is True
+        assert runner._webhook_recovery_retry_task is None
+        assert runner._background_tasks == set()
+        assert runner._update_platform_runtime_status.call_args_list == [
+            (
+                (Platform.WEBHOOK.value,),
+                {
+                    "platform_state": "retrying",
+                    "error_code": "webhook_recovery_failed",
+                    "error_message": "Durable webhook recovery failed",
+                },
+            ),
+            (
+                (Platform.WEBHOOK.value,),
+                {
+                    "platform_state": "connected",
+                    "error_code": None,
+                    "error_message": None,
+                    "needs_attention": False,
+                    "retrying_since": None,
+                },
+            ),
+        ]
+
+        async with TestClient(TestServer(_app(adapter))) as client:
+            health = await client.get("/health")
+        assert health.status == 200
+
+    @pytest.mark.asyncio
+    async def test_sleeping_recovery_retry_stops_when_drain_begins(
+        self,
+        monkeypatch,
+    ):
+        """A retry waking inside shutdown cannot touch the ledger or reopen."""
+
+        from gateway import run as gateway_run
+        from gateway.run import GatewayRunner
+
+        adapter = _adapter()
+        adapter.recover_pending_operations = AsyncMock(
+            side_effect=RuntimeError("transient storage fault")
+        )
+        adapter._accepting_webhooks = False
+        runner = object.__new__(GatewayRunner)
+        runner.config = GatewayConfig(multiplex_profiles=False)
+        runner.adapters = {Platform.WEBHOOK: adapter}
+        runner._background_tasks = set()
+        runner._webhook_recovery_retry_task = None
+        runner._webhook_recovery_retry_adapter = None
+        runner._startup_restore_in_progress = False
+        runner._draining = False
+        runner._external_drain_active = False
+        runner._running = True
+        runner._shutdown_event = asyncio.Event()
+        adapter.gateway_runner = runner
+
+        sleep_entered = asyncio.Event()
+        release_sleep = asyncio.Event()
+        real_sleep = asyncio.sleep
+
+        async def controlled_sleep(_delay):
+            sleep_entered.set()
+            await release_sleep.wait()
+
+        monkeypatch.setattr(gateway_run.asyncio, "sleep", controlled_sleep)
+
+        assert await runner._recover_webhook_operations(trigger="startup") == 0
+        retry_task = runner._webhook_recovery_retry_task
+        assert retry_task is not None
+        await asyncio.wait_for(sleep_entered.wait(), timeout=1)
+
+        runner._draining = True
+        runner._running = False
+        release_sleep.set()
+        await asyncio.wait_for(retry_task, timeout=1)
+        await real_sleep(0)
+
+        assert adapter.recover_pending_operations.await_count == 1
+        assert adapter._accepting_webhooks is False
+        assert runner._webhook_recovery_retry_task is None
+        assert runner._webhook_recovery_retry_adapter is None
+        assert runner._background_tasks == set()
+
+    @pytest.mark.asyncio
+    async def test_inflight_recovery_cannot_reopen_after_drain_begins(self):
+        """A recovery success that crosses the drain boundary stays fenced."""
+
+        from gateway.run import GatewayRunner
+
+        adapter = _adapter()
+        adapter._accepting_webhooks = False
+        recovery_entered = asyncio.Event()
+        release_recovery = asyncio.Event()
+
+        async def blocking_recovery(*, trigger):
+            assert trigger == "reconnect:webhook"
+            recovery_entered.set()
+            await release_recovery.wait()
+            return 0
+
+        adapter.recover_pending_operations = blocking_recovery
+        runner = object.__new__(GatewayRunner)
+        runner.config = GatewayConfig(multiplex_profiles=False)
+        runner.adapters = {Platform.WEBHOOK: adapter}
+        runner._background_tasks = set()
+        runner._webhook_recovery_retry_task = None
+        runner._webhook_recovery_retry_adapter = None
+        runner._startup_restore_in_progress = False
+        runner._draining = False
+        runner._external_drain_active = False
+        runner._running = True
+        runner._shutdown_event = asyncio.Event()
+        adapter.gateway_runner = runner
+
+        recovery = asyncio.create_task(
+            runner._recover_webhook_operations(trigger="reconnect:webhook")
+        )
+        await asyncio.wait_for(recovery_entered.wait(), timeout=1)
+        runner._draining = True
+        runner._running = False
+        release_recovery.set()
+
+        assert await asyncio.wait_for(recovery, timeout=1) == 0
+        assert adapter._accepting_webhooks is False
+        assert runner._webhook_recovery_retry_task is None
+        assert runner._background_tasks == set()
+
+    @pytest.mark.asyncio
+    async def test_replacement_adapter_replaces_stale_recovery_retry(
+        self,
+        monkeypatch,
+    ):
+        from gateway import run as gateway_run
+        from gateway.run import GatewayRunner
+
+        old_adapter = _adapter()
+        old_adapter.recover_pending_operations = AsyncMock(
+            side_effect=RuntimeError("old adapter storage fault")
+        )
+        replacement_adapter = _adapter()
+        replacement_adapter.recover_pending_operations = AsyncMock(
+            side_effect=[RuntimeError("replacement storage fault"), 0]
+        )
+        runner = object.__new__(GatewayRunner)
+        runner.config = GatewayConfig(multiplex_profiles=False)
+        runner.adapters = {Platform.WEBHOOK: old_adapter}
+        runner._background_tasks = set()
+        runner._webhook_recovery_retry_task = None
+        runner._webhook_recovery_retry_adapter = None
+        runner._startup_restore_in_progress = False
+        runner._draining = False
+        runner._external_drain_active = False
+        runner._running = True
+        runner._shutdown_event = asyncio.Event()
+        old_adapter.gateway_runner = runner
+        replacement_adapter.gateway_runner = runner
+
+        # Hold the old retry in its first sleep so replacement is
+        # deterministic rather than scheduler-timing dependent.
+        monkeypatch.setattr(
+            gateway_run,
+            "_WEBHOOK_RECOVERY_RETRY_INITIAL_SECONDS",
+            3600,
+        )
+        monkeypatch.setattr(
+            gateway_run,
+            "_WEBHOOK_RECOVERY_RETRY_MAX_SECONDS",
+            3600,
+        )
+        assert await runner._recover_webhook_operations(trigger="startup") == 0
+        old_retry = runner._webhook_recovery_retry_task
+        assert old_retry is not None
+        assert runner._webhook_recovery_retry_adapter is old_adapter
+        await asyncio.sleep(0)
+
+        runner.adapters[Platform.WEBHOOK] = replacement_adapter
+        monkeypatch.setattr(
+            gateway_run,
+            "_WEBHOOK_RECOVERY_RETRY_INITIAL_SECONDS",
+            0,
+        )
+        monkeypatch.setattr(
+            gateway_run,
+            "_WEBHOOK_RECOVERY_RETRY_MAX_SECONDS",
+            0,
+        )
+        assert (
+            await runner._recover_webhook_operations(trigger="reconnect:webhook") == 0
+        )
+        replacement_retry = runner._webhook_recovery_retry_task
+
+        assert replacement_retry is not None
+        assert replacement_retry is not old_retry
+        assert runner._webhook_recovery_retry_adapter is replacement_adapter
+
+        await replacement_retry
+        await asyncio.gather(old_retry, return_exceptions=True)
+        await asyncio.sleep(0)
+
+        assert old_retry.cancelled()
+        assert old_adapter.recover_pending_operations.await_count == 1
+        assert replacement_adapter.recover_pending_operations.await_count == 2
+        assert replacement_adapter._accepting_webhooks is True
+        assert runner._webhook_recovery_retry_task is None
+        assert runner._webhook_recovery_retry_adapter is None
+        assert runner._background_tasks == set()
+
+    @pytest.mark.asyncio
+    async def test_replacement_success_cancels_stale_adapter_retry(
+        self,
+        monkeypatch,
+    ):
+        from gateway import run as gateway_run
+        from gateway.run import GatewayRunner
+
+        old_adapter = _adapter()
+        old_adapter.recover_pending_operations = AsyncMock(
+            side_effect=RuntimeError("old adapter storage fault")
+        )
+        replacement_adapter = _adapter()
+        replacement_adapter.recover_pending_operations = AsyncMock(return_value=0)
+        runner = object.__new__(GatewayRunner)
+        runner.config = GatewayConfig(multiplex_profiles=False)
+        runner.adapters = {Platform.WEBHOOK: old_adapter}
+        runner._background_tasks = set()
+        runner._webhook_recovery_retry_task = None
+        runner._webhook_recovery_retry_adapter = None
+        runner._startup_restore_in_progress = False
+        runner._draining = False
+        runner._external_drain_active = False
+        runner._running = True
+        runner._shutdown_event = asyncio.Event()
+        old_adapter.gateway_runner = runner
+        replacement_adapter.gateway_runner = runner
+        monkeypatch.setattr(
+            gateway_run,
+            "_WEBHOOK_RECOVERY_RETRY_INITIAL_SECONDS",
+            3600,
+        )
+        monkeypatch.setattr(
+            gateway_run,
+            "_WEBHOOK_RECOVERY_RETRY_MAX_SECONDS",
+            3600,
+        )
+
+        assert await runner._recover_webhook_operations(trigger="startup") == 0
+        old_retry = runner._webhook_recovery_retry_task
+        assert old_retry is not None
+        await asyncio.sleep(0)
+
+        runner.adapters[Platform.WEBHOOK] = replacement_adapter
+        assert (
+            await runner._recover_webhook_operations(trigger="reconnect:webhook") == 0
+        )
+        await asyncio.gather(old_retry, return_exceptions=True)
+        await asyncio.sleep(0)
+
+        assert old_retry.cancelled()
+        assert replacement_adapter.recover_pending_operations.await_count == 1
+        assert replacement_adapter._accepting_webhooks is True
+        assert runner._webhook_recovery_retry_task is None
+        assert runner._webhook_recovery_retry_adapter is None
+        assert runner._background_tasks == set()
+
+    @pytest.mark.asyncio
+    async def test_startup_recovery_failure_releases_global_gate_but_health_stays_degraded(
+        self,
+    ):
+        from gateway.run import GatewayRunner
+
+        adapter = _adapter({
+            "events": {"secret": _INSECURE_NO_AUTH, "provider": "generic"}
+        })
+        adapter.handle_message = AsyncMock()
+        adapter.recover_pending_operations = AsyncMock(
+            side_effect=RuntimeError("injected startup recovery outage")
+        )
+        runner = object.__new__(GatewayRunner)
+        runner.adapters = {Platform.WEBHOOK: adapter}
+        runner._startup_restore_in_progress = True
+        runner._startup_restore_tasks = []
+        runner._startup_restore_queue = []
+        runner._drain_startup_restore_queue = AsyncMock(return_value=0)
+        runner._running = True
+        runner._update_platform_runtime_status = MagicMock()
+        adapter.gateway_runner = runner
+
+        await runner._finish_startup_with_webhook_recovery()
+
+        assert runner._startup_restore_in_progress is False
+        assert adapter._accepting_webhooks is False
+        async with TestClient(TestServer(_app(adapter))) as client:
+            health = await client.get("/health")
+            health_payload = await health.json()
+            response = await client.post("/webhooks/events", json={"value": 1})
+        assert health.status == 503
+        assert health_payload["status"] == "degraded"
+        assert response.status == 503
+        assert adapter._operation_ledger.count() == 0
+        adapter.handle_message.assert_not_awaited()
+        runner._update_platform_runtime_status.assert_called_once_with(
+            Platform.WEBHOOK.value,
+            platform_state="retrying",
+            error_code="webhook_recovery_failed",
+            error_message="Durable webhook recovery failed",
+        )
+
+    @pytest.mark.asyncio
+    async def test_startup_recovery_finishes_before_global_intake_gate_opens(self):
+        from gateway.run import GatewayRunner
+
+        adapter = _adapter({
+            "events": {"secret": _INSECURE_NO_AUTH, "provider": "generic"}
+        })
+        adapter.handle_message = AsyncMock()
+        recovery_entered = asyncio.Event()
+        release_recovery = asyncio.Event()
+
+        async def blocking_recovery(*, trigger):
+            assert trigger == "startup"
+            recovery_entered.set()
+            await release_recovery.wait()
+            return 0
+
+        adapter.recover_pending_operations = blocking_recovery
+        runner = object.__new__(GatewayRunner)
+        runner.adapters = {Platform.WEBHOOK: adapter}
+        runner._startup_restore_in_progress = True
+        runner._startup_restore_tasks = []
+        runner._startup_restore_queue = []
+        runner._drain_startup_restore_queue = AsyncMock(return_value=0)
+        adapter.gateway_runner = runner
+
+        finish = asyncio.create_task(runner._finish_startup_with_webhook_recovery())
+        await asyncio.wait_for(recovery_entered.wait(), timeout=1)
+        async with TestClient(TestServer(_app(adapter))) as client:
+            health = await client.get("/health")
+            health_payload = await health.json()
+            response = await client.post("/webhooks/events", json={"value": 1})
+        assert health.status == 503
+        assert health_payload["status"] == "degraded"
+        assert response.status == 503
+        assert adapter._operation_ledger.count() == 0
+        adapter.handle_message.assert_not_awaited()
+        assert runner._startup_restore_in_progress is True
+
+        release_recovery.set()
+        await asyncio.wait_for(finish, timeout=1)
+        assert runner._startup_restore_in_progress is False
+        assert adapter._accepting_webhooks is True
+        async with TestClient(TestServer(_app(adapter))) as client:
+            health = await client.get("/health")
+            health_payload = await health.json()
+        assert health.status == 200
+        assert health_payload == {
+            "status": "ok",
+            "platform": "webhook",
+            "accepting_webhooks": True,
+        }
+
+    @pytest.mark.asyncio
+    async def test_runner_owned_reconnect_listener_stays_closed_through_recovery(self):
+        from gateway.run import GatewayRunner
+
+        adapter = _adapter({
+            "events": {"secret": _INSECURE_NO_AUTH, "provider": "generic"}
+        })
+        adapter.handle_message = AsyncMock()
+        runner = object.__new__(GatewayRunner)
+        runner.adapters = {}
+        runner._startup_restore_in_progress = False
+        runner._running = True
+        adapter.gateway_runner = runner
+        recovery_entered = asyncio.Event()
+        release_recovery = asyncio.Event()
+
+        async def blocking_recovery(*, trigger):
+            assert trigger == "reconnect:webhook"
+            recovery_entered.set()
+            await release_recovery.wait()
+            return 0
+
+        adapter.recover_pending_operations = blocking_recovery
+        try:
+            assert await adapter.connect(is_reconnect=True)
+            assert adapter._accepting_webhooks is False
+            runner.adapters[Platform.WEBHOOK] = adapter
+
+            recovery = asyncio.create_task(
+                runner._recover_webhook_operations(trigger="reconnect:webhook")
+            )
+            await asyncio.wait_for(recovery_entered.wait(), timeout=1)
+            async with TestClient(TestServer(_app(adapter))) as client:
+                response = await client.post(
+                    "/webhooks/events",
+                    json={"value": 1},
+                )
+            assert response.status == 503
+            assert adapter._operation_ledger.count() == 0
+            adapter.handle_message.assert_not_awaited()
+
+            release_recovery.set()
+            assert await asyncio.wait_for(recovery, timeout=1) == 0
+            assert adapter._accepting_webhooks is True
+        finally:
+            release_recovery.set()
+            await adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_skill_resolution_runs_inside_the_routed_profile_scope(
+        self,
+        monkeypatch,
+    ):
+        adapter = _adapter({
+            "events": {
+                "secret": _INSECURE_NO_AUTH,
+                "provider": "generic",
+                "profile": "ops",
+                "prompt": "base prompt",
+                "skills": ["ops-skill"],
+                "deliver": "log",
+            }
+        })
+        adapter.gateway_runner = SimpleNamespace(
+            config=SimpleNamespace(
+                multiplex_profiles=True,
+                multiplex_profile_allowlist=None,
+            ),
+            adapters={Platform.WEBHOOK: adapter},
+        )
+        adapter._resolve_admitted_toolsets = lambda *_args: []
+        active_profile = {"name": None}
+        entered_profiles = []
+
+        @contextmanager
+        def profile_scope(source):
+            previous = active_profile["name"]
+            active_profile["name"] = source.profile
+            entered_profiles.append(source.profile)
+            try:
+                yield
+            finally:
+                active_profile["name"] = previous
+
+        adapter._profile_runtime_context = profile_scope
+        adapter.handle_message = AsyncMock()
+        monkeypatch.setattr(
+            "hermes_cli.profiles.profiles_to_serve",
+            lambda **_kwargs: [("ops", object())],
+        )
+
+        def get_skill_commands():
+            assert active_profile["name"] == "ops"
+            return {"/ops-skill": object()}
+
+        def build_skill_invocation_message(command, *, user_instruction):
+            assert active_profile["name"] == "ops"
+            assert command == "/ops-skill"
+            return f"ops:{user_instruction}"
+
+        monkeypatch.setattr(
+            "agent.skill_commands.get_skill_commands",
+            get_skill_commands,
+        )
+        monkeypatch.setattr(
+            "agent.skill_commands.build_skill_invocation_message",
+            build_skill_invocation_message,
+        )
+        app = web.Application(client_max_size=adapter._max_body_bytes)
+        app.router.add_post(
+            "/p/{profile}/webhooks/{route_name}",
+            adapter._handle_webhook,
+        )
+
+        async with TestClient(TestServer(app)) as client:
+            response = await client.post(
+                "/p/ops/webhooks/events",
+                json={"value": 1},
+            )
+            assert response.status == 202
+
+        pending = tuple(adapter._background_tasks)
+        if pending:
+            await asyncio.gather(*pending)
+        event = adapter.handle_message.await_args.args[0]
+        assert event.source.profile == "ops"
+        assert event.text == "ops:base prompt"
+        assert entered_profiles
+        assert set(entered_profiles) == {"ops"}
+
+    @pytest.mark.asyncio
+    async def test_replaced_adapter_cannot_admit_through_stale_handler(self):
+        adapter = _adapter({
+            "events": {"secret": _INSECURE_NO_AUTH, "provider": "generic"}
+        })
+        adapter.gateway_runner = SimpleNamespace(
+            adapters={Platform.WEBHOOK: object()},
+        )
+        adapter.handle_message = AsyncMock()
+
+        async with TestClient(TestServer(_app(adapter))) as client:
+            response = await client.post("/webhooks/events", json={"value": 1})
+
+        assert response.status == 503
+        adapter.handle_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_replacement_while_body_is_read_cannot_create_ledger_row(self):
+        adapter = _adapter({
+            "events": {"secret": _INSECURE_NO_AUTH, "provider": "generic"}
+        })
+        runner = SimpleNamespace(
+            config=SimpleNamespace(multiplex_profiles=False),
+            adapters={Platform.WEBHOOK: adapter},
+        )
+        adapter.gateway_runner = runner
+        adapter.handle_message = AsyncMock()
+        read_started = asyncio.Event()
+        release_read = asyncio.Event()
+
+        class BlockingRequest:
+            match_info = {"route_name": "events"}
+            headers = {"Content-Type": "application/json"}
+            content_length = len(b'{"value":1}')
+
+            async def read(self):
+                read_started.set()
+                await release_read.wait()
+                return b'{"value":1}'
+
+        task = asyncio.create_task(adapter._handle_webhook(BlockingRequest()))
+        await asyncio.wait_for(read_started.wait(), timeout=1)
+        runner.adapters[Platform.WEBHOOK] = object()
+        release_read.set()
+        response = await asyncio.wait_for(task, timeout=1)
+
+        assert response.status == 503
+        assert adapter._operation_ledger.count() == 0
+        adapter.handle_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_webhook_listener_cannot_be_its_own_delivery_target(self):
+        adapter = _adapter({
+            "events": {
+                "secret": _INSECURE_NO_AUTH,
+                "provider": "generic",
+                "deliver_only": True,
+                "deliver": "webhook",
+                "deliver_extra": {"chat_id": "recursive"},
+            }
+        })
+        adapter.gateway_runner = SimpleNamespace(
+            config=SimpleNamespace(multiplex_profiles=False),
+            adapters={Platform.WEBHOOK: adapter},
+        )
+
+        async with TestClient(TestServer(_app(adapter))) as client:
+            response = await client.post("/webhooks/events", json={"value": 1})
+
+        assert response.status == 503
+        assert adapter._operation_ledger.count() == 0
+
+    @pytest.mark.asyncio
+    async def test_agent_final_is_one_replayable_text_carrier(self, tmp_path):
+        attachment = tmp_path / "report.pdf"
+        attachment.write_bytes(b"report")
+        adapter = _adapter({
+            "events": {
+                "secret": _INSECURE_NO_AUTH,
+                "provider": "generic",
+                "prompt": "run",
+                "deliver": "log",
+            }
+        })
+        adapter.config.typing_indicator = False
+        adapter._message_handler = AsyncMock(
+            return_value=f"Finished.\nMEDIA:{attachment}"
+        )
+        original_send = adapter.send
+        adapter.send = AsyncMock(wraps=original_send)
+        adapter.send_image = AsyncMock()
+        adapter.send_document = AsyncMock()
+        adapter.send_file = AsyncMock()
+        adapter.send_multiple_images = AsyncMock()
+
+        async with TestClient(TestServer(_app(adapter))) as client:
+            response = await client.post("/webhooks/events", json={"value": 1})
+            assert response.status == 202
+
+        for _ in range(100):
+            if not adapter._background_tasks:
+                break
+            await asyncio.sleep(0.01)
+
+        adapter.send.assert_awaited_once()
+        sent_content = adapter.send.await_args.kwargs["content"]
+        assert adapter.send.await_args.kwargs["metadata"]["notify"] is True
+        assert sent_content == (
+            "Finished.\n\n⚠️ Local attachments were omitted from webhook delivery."
+        )
+        adapter.send_image.assert_not_awaited()
+        adapter.send_document.assert_not_awaited()
+        adapter.send_file.assert_not_awaited()
+        adapter.send_multiple_images.assert_not_awaited()
+
+        event = adapter._message_handler.await_args.args[0]
+        authority = adapter._operation_ledger.lookup_session(event.source.chat_id)
+        assert authority is not None
+        assert authority.state is OperationState.SETTLED
+        assert authority.target_state is TargetState.SUPPRESSED
+        assert authority.delivery is not None
+        assert authority.delivery.content == sent_content
+
+    @pytest.mark.asyncio
+    async def test_platform_final_uses_only_webhook_owned_delivery_ledger(self):
+        adapter = _adapter({
+            "events": {
+                "secret": _INSECURE_NO_AUTH,
+                "provider": "generic",
+                "prompt": "run",
+                "deliver": "telegram",
+                "deliver_extra": {"chat_id": "target-chat"},
+            }
+        })
+        adapter.config.typing_indicator = False
+        adapter._message_handler = AsyncMock(return_value="one final response")
+        target_adapter = SimpleNamespace(
+            send=AsyncMock(
+                return_value=SendResult(success=True, message_id="target-message")
+            )
+        )
+        runner = SimpleNamespace(
+            config=SimpleNamespace(multiplex_profiles=False),
+            adapters={
+                Platform.WEBHOOK: adapter,
+                Platform.TELEGRAM: target_adapter,
+            },
+            _authorization_adapter=lambda platform, profile: (
+                target_adapter
+                if platform is Platform.TELEGRAM and profile == "default"
+                else adapter
+                if platform is Platform.WEBHOOK and profile == "default"
+                else None
+            ),
+            _redeliver_failed_obligations_for_platform=AsyncMock(return_value=0),
+        )
+        adapter.gateway_runner = runner
+
+        with patch("gateway.delivery_ledger.record_obligation") as generic_record:
+            async with TestClient(TestServer(_app(adapter))) as client:
+                response = await client.post(
+                    "/webhooks/events",
+                    json={"value": 1},
+                )
+                assert response.status == 202
+
+            pending = tuple(adapter._background_tasks)
+            if pending:
+                await asyncio.gather(*pending)
+
+        target_adapter.send.assert_awaited_once_with(
+            "target-chat",
+            "one final response",
+            metadata=None,
+        )
+        generic_record.assert_not_called()
+        runner._redeliver_failed_obligations_for_platform.assert_not_awaited()
+        event = adapter._message_handler.await_args.args[0]
+        authority = adapter._operation_ledger.lookup_session(event.source.chat_id)
+        assert authority is not None
+        assert authority.state is OperationState.SETTLED
+        assert authority.target_state is TargetState.CONFIRMED
+
+    @pytest.mark.asyncio
+    async def test_real_base_pipeline_failure_becomes_indeterminate(self):
+        adapter = _adapter({
+            "events": {
+                "secret": _INSECURE_NO_AUTH,
+                "provider": "generic",
+                "prompt": "run",
+                "deliver": "log",
+            }
+        })
+        adapter.config.typing_indicator = False
+        adapter._message_handler = AsyncMock(side_effect=RuntimeError("agent failed"))
+
+        async with TestClient(TestServer(_app(adapter))) as client:
+            response = await client.post("/webhooks/events", json={"value": 1})
+            assert response.status == 202
+
+        pending = tuple(adapter._background_tasks)
+        if pending:
+            await asyncio.gather(*pending)
+
+        event = adapter._message_handler.await_args.args[0]
+        authority = adapter._operation_ledger.lookup_session(event.source.chat_id)
+        assert authority is not None
+        assert authority.state is OperationState.INDETERMINATE
+        assert authority.delivery is None
+
+    @pytest.mark.asyncio
+    async def test_primary_reconnect_replacement_recovers_staged_target_once(self):
+        """The primary watcher publishes B before one real durable recovery."""
+
+        old_adapter = _adapter()
+        replacement_adapter = _adapter()
+        replacement_adapter._accepting_webhooks = False
+        target_adapter = SimpleNamespace(
+            send=AsyncMock(
+                return_value=SendResult(success=True, message_id="recovered-once")
+            )
+        )
+        envelope = _stage_replay_safe_platform_delivery(
+            old_adapter,
+            trace_id="primary-a-to-b-success",
+        )
+        runner = _runner_for_primary_webhook_reconnect(
+            old_adapter,
+            replacement_adapter,
+            target_adapter,
+        )
+        real_recover = replacement_adapter.recover_pending_operations
+        replacement_adapter.recover_pending_operations = AsyncMock(wraps=real_recover)
+        real_sleep = asyncio.sleep
+        sleep_calls = 0
+
+        async def finish_after_one_pass(_delay):
+            nonlocal sleep_calls
+            sleep_calls += 1
+            if sleep_calls > 1:
+                runner._running = False
+            await real_sleep(0)
+
+        with (
+            patch.object(
+                runner,
+                "_create_adapter",
+                return_value=replacement_adapter,
+            ),
+            patch.object(
+                runner,
+                "_connect_adapter_with_timeout",
+                new=AsyncMock(return_value=True),
+            ),
+            patch(
+                "gateway.channel_directory.build_channel_directory",
+                new=AsyncMock(return_value={"platforms": {}}),
+            ),
+            patch("asyncio.sleep", side_effect=finish_after_one_pass),
+        ):
+            await asyncio.wait_for(
+                runner._platform_reconnect_watcher(),
+                timeout=2,
+            )
+
+        pending = tuple(replacement_adapter._background_tasks)
+        if pending:
+            await asyncio.gather(*pending)
+
+        assert runner.adapters[Platform.WEBHOOK] is replacement_adapter
+        replacement_adapter.recover_pending_operations.assert_awaited_once_with(
+            trigger="reconnect:webhook"
+        )
+        target_adapter.send.assert_awaited_once_with(
+            "recovery-chat",
+            "one reconnect recovery response",
+            metadata=None,
+        )
+        restored = replacement_adapter._operation_ledger.lookup_session(
+            envelope.session_key
+        )
+        assert restored is not None
+        assert restored.state is OperationState.SETTLED
+        assert restored.target_state is TargetState.CONFIRMED
+
+    @pytest.mark.asyncio
+    async def test_failed_disconnect_retirement_quarantines_exact_owner_until_recovery(
+        self,
+        tmp_path,
+    ):
+        """A same-process replacement fences A before opening B's intake."""
+
+        from gateway.run import GatewayRunner
+
+        routes = {
+            "events": {
+                "secret": _INSECURE_NO_AUTH,
+                "provider": "generic",
+                "deliver": "telegram",
+                "deliver_extra": {"chat_id": "recovery-chat"},
+            }
+        }
+        old_adapter = _adapter(routes)
+        replacement_adapter = _adapter(routes)
+        replacement_adapter._accepting_webhooks = False
+
+        ready_body = b'{"case":"ready"}'
+        ready_envelope, ready = _prepare_owned_direct_operation(
+            old_adapter,
+            raw_body=ready_body,
+            content="recover ready once",
+        )
+        _delivery_envelope, delivery_ready = _prepare_owned_direct_operation(
+            old_adapter,
+            raw_body=b'{"case":"delivery-ready"}',
+            content="recover delivery-ready once",
+        )
+        assert old_adapter._operation_ledger.mark_running(delivery_ready)
+        delivery_ready = old_adapter._stage_exact_delivery(
+            delivery_ready,
+            "recover delivery-ready once",
+            {"v": 1, "kind": "direct"},
+        )
+        _ambiguous_envelope, ambiguous = _prepare_owned_direct_operation(
+            old_adapter,
+            raw_body=b'{"case":"ambiguous"}',
+            content="must not replay",
+        )
+        assert old_adapter._operation_ledger.mark_running(ambiguous)
+
+        prior_owner = old_adapter._operation_ledger.instance_id
+        with patch.object(
+            old_adapter._operation_ledger,
+            "retire_instance",
+            side_effect=RuntimeError("injected retirement failure"),
+        ):
+            with pytest.raises(RuntimeError, match="injected retirement failure"):
+                await old_adapter.disconnect()
+
+        assert old_adapter._accepting_webhooks is False
+        assert old_adapter.has_fatal_error
+        assert old_adapter.fatal_error_code == "webhook_retirement_failed"
+
+        # A different profile/physical ledger must not inherit this marker,
+        # even though its replacement exists in the same Python process.
+        unrelated_adapter = _adapter(routes)
+        unrelated_adapter._operation_ledger = WebhookOperationLedger(
+            tmp_path / "unrelated-profile" / "state.db"
+        )
+        unrelated_adapter._accepting_webhooks = False
+        with patch.object(
+            unrelated_adapter._operation_ledger,
+            "retire_owner_instance",
+            wraps=unrelated_adapter._operation_ledger.retire_owner_instance,
+        ) as unrelated_retirement:
+            assert (
+                await unrelated_adapter.recover_pending_operations(
+                    trigger="unrelated-profile"
+                )
+                == 0
+            )
+        unrelated_retirement.assert_not_called()
+
+        sends_entered = 0
+        all_sends_entered = asyncio.Event()
+        release_sends = asyncio.Event()
+
+        async def blocked_send(*_args, **_kwargs):
+            nonlocal sends_entered
+            sends_entered += 1
+            if sends_entered == 2:
+                all_sends_entered.set()
+            await release_sends.wait()
+            return SendResult(success=True, message_id=f"recovered-{sends_entered}")
+
+        target_adapter = SimpleNamespace(send=AsyncMock(side_effect=blocked_send))
+        runner = object.__new__(GatewayRunner)
+        runner.config = GatewayConfig(multiplex_profiles=False)
+        runner.adapters = {
+            Platform.WEBHOOK: replacement_adapter,
+            Platform.TELEGRAM: target_adapter,
+        }
+        runner._startup_restore_in_progress = False
+        runner._draining = False
+        runner._external_drain_active = False
+        runner._running = True
+        runner._shutdown_event = asyncio.Event()
+        runner._background_tasks = set()
+        runner._webhook_recovery_retry_task = None
+        runner._webhook_recovery_retry_adapter = None
+        runner._schedule_webhook_recovery_retry = MagicMock()
+        replacement_adapter.gateway_runner = runner
+        # A production reconnect publishes the replacement's immutable route
+        # authority before intake can reopen.  Keep this composition fixture on
+        # that same boundary: strict toolset authority must come from the
+        # profile config, while the later ACTIVE retry remains an indexed
+        # ledger result and performs no live-policy revalidation.
+        (tmp_path / "config.yaml").write_text(
+            "platform_toolsets:\n  webhook: []\n",
+            encoding="utf-8",
+        )
+        replacement_adapter._bind_route_authentication_authorities(
+            replacement_adapter._routes
+        )
+
+        real_retire_owner = replacement_adapter._operation_ledger.retire_owner_instance
+        with patch.object(
+            replacement_adapter._operation_ledger,
+            "retire_owner_instance",
+            side_effect=RuntimeError("injected retry failure"),
+        ) as failed_retry:
+            assert (
+                await runner._recover_webhook_operations(trigger="reconnect:webhook")
+                == 0
+            )
+        failed_retry.assert_called_once_with(prior_owner)
+        assert replacement_adapter._accepting_webhooks is False
+        runner._schedule_webhook_recovery_retry.assert_called_once_with(
+            replacement_adapter
+        )
+
+        # The replacement listener exists for diagnostics, but no request can
+        # cross admission while the exact prior-owner retirement still fails.
+        before_count = replacement_adapter._operation_ledger.count()
+        async with TestClient(TestServer(_app(replacement_adapter))) as client:
+            health = await client.get("/health")
+            blocked = await client.post(
+                "/webhooks/events",
+                data=ready_body,
+                headers={"Content-Type": "application/json"},
+            )
+        assert health.status == 503
+        assert blocked.status == 503
+        assert replacement_adapter._operation_ledger.count() == before_count
+        target_adapter.send.assert_not_awaited()
+
+        with patch.object(
+            replacement_adapter._operation_ledger,
+            "retire_owner_instance",
+            wraps=real_retire_owner,
+        ) as successful_retry:
+            assert await runner._recover_webhook_operations(trigger="retry") == 2
+        successful_retry.assert_called_once_with(prior_owner)
+        assert replacement_adapter._accepting_webhooks is True
+
+        await asyncio.wait_for(all_sends_entered.wait(), timeout=1)
+        # Recovery has claimed both replay-safe carriers, so an exact transport
+        # retry may briefly observe in-progress, but it cannot start a second
+        # effect and it cannot remain a permanent 202 after settlement.
+        async with TestClient(TestServer(_app(replacement_adapter))) as client:
+            active_duplicate = await client.post(
+                "/webhooks/events",
+                data=ready_body,
+                headers={"Content-Type": "application/json"},
+            )
+        assert active_duplicate.status == 202
+
+        release_sends.set()
+        pending = tuple(replacement_adapter._background_tasks)
+        if pending:
+            await asyncio.gather(*pending)
+
+        async with TestClient(TestServer(_app(replacement_adapter))) as client:
+            settled_duplicate = await client.post(
+                "/webhooks/events",
+                data=ready_body,
+                headers={"Content-Type": "application/json"},
+            )
+            settled_payload = await settled_duplicate.json()
+        assert settled_duplicate.status == 200
+        assert settled_payload["status"] == "duplicate"
+        assert target_adapter.send.await_count == 2
+        assert {call.args[1] for call in target_adapter.send.await_args_list} == {
+            "recover ready once",
+            "recover delivery-ready once",
+        }
+
+        recovered_ready = replacement_adapter._operation_ledger.lookup_session(
+            ready_envelope.session_key
+        )
+        assert recovered_ready is not None
+        assert recovered_ready.state is OperationState.SETTLED
+        assert recovered_ready.target_state is TargetState.CONFIRMED
+        assert recovered_ready.generation == ready.generation + 1
+        recovered_delivery = replacement_adapter._operation_ledger.lookup_session(
+            delivery_ready.session_key
+        )
+        assert recovered_delivery is not None
+        assert recovered_delivery.state is OperationState.SETTLED
+        assert recovered_delivery.target_state is TargetState.CONFIRMED
+        assert recovered_delivery.generation == delivery_ready.generation + 1
+        preserved_ambiguous = replacement_adapter._operation_ledger.lookup_session(
+            ambiguous.session_key
+        )
+        assert preserved_ambiguous is not None
+        assert preserved_ambiguous.state is OperationState.INDETERMINATE
+
+        # The exact marker was cleared after its successful retry. Re-running
+        # recovery neither retires A again nor schedules a duplicate carrier.
+        with patch.object(
+            replacement_adapter._operation_ledger,
+            "retire_owner_instance",
+            wraps=real_retire_owner,
+        ) as no_second_retirement:
+            assert (
+                await replacement_adapter.recover_pending_operations(
+                    trigger="idempotent-check"
+                )
+                == 0
+            )
+        no_second_retirement.assert_not_called()
+        assert target_adapter.send.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_multiplex_replacement_uses_root_before_quarantine_recovery(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        """Profile A and B share one listener-owned root replay ledger."""
+
+        from gateway.run import GatewayRunner
+
+        root = tmp_path / "multiplex-root"
+        profile_a = root / "profiles" / "alpha"
+        profile_b = root / "profiles" / "beta"
+        profile_a.mkdir(parents=True)
+        profile_b.mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(profile_a))
+        root_state = root / "state.db"
+
+        runner = object.__new__(GatewayRunner)
+        runner.config = GatewayConfig(multiplex_profiles=True)
+        runner.adapters = {}
+        runner._startup_restore_in_progress = False
+        runner._draining = False
+        runner._external_drain_active = False
+        runner._running = True
+        runner._shutdown_event = asyncio.Event()
+        runner._background_tasks = set()
+        runner._webhook_recovery_retry_task = None
+        runner._webhook_recovery_retry_adapter = None
+        runner._schedule_webhook_recovery_retry = MagicMock()
+        runner._update_platform_runtime_status = MagicMock()
+        runner._resolve_profile_home_for_source = lambda source: (
+            root
+            if (source.profile or "default") == "default"
+            else root / "profiles" / str(source.profile)
+        )
+
+        old_adapter = _adapter()
+        prior_instance = old_adapter._operation_ledger.instance_id
+        assert old_adapter._operation_ledger.db_path == root_state
+        old_adapter.gateway_runner = runner
+        assert await old_adapter.connect()
+        assert old_adapter._operation_ledger.db_path == root_state
+        assert old_adapter._operation_ledger.instance_id == prior_instance
+        assert (
+            old_adapter._authentication_authority_ledger
+            is old_adapter._operation_ledger
+        )
+        runner.adapters[Platform.WEBHOOK] = old_adapter
+
+        ready_envelope, ready = _prepare_owned_direct_operation(
+            old_adapter,
+            raw_body=b'{"multiplex":"ready"}',
+            content="root ready",
+            target_snapshot={"v": 1, "kind": "log", "profile": "default"},
+        )
+        delivery_envelope, delivery_ready = _prepare_owned_direct_operation(
+            old_adapter,
+            raw_body=b'{"multiplex":"delivery-ready"}',
+            content="root delivery-ready",
+            target_snapshot={"v": 1, "kind": "log", "profile": "default"},
+        )
+        assert old_adapter._operation_ledger.mark_running(delivery_ready)
+        delivery_ready = old_adapter._stage_exact_delivery(
+            delivery_ready,
+            "root delivery-ready",
+            {"v": 1, "kind": "direct"},
+        )
+
+        with patch.object(
+            old_adapter._operation_ledger,
+            "retire_instance",
+            side_effect=RuntimeError("injected multiplex retirement failure"),
+        ):
+            with pytest.raises(
+                RuntimeError, match="injected multiplex retirement failure"
+            ):
+                await old_adapter.disconnect()
+
+        monkeypatch.setenv("HERMES_HOME", str(profile_b))
+        replacement = _adapter()
+        replacement_instance = replacement._operation_ledger.instance_id
+        assert replacement._operation_ledger.db_path == root_state
+        replacement.gateway_runner = runner
+        assert await replacement.connect(is_reconnect=True)
+        assert replacement._operation_ledger.db_path == root_state
+        assert replacement._operation_ledger.instance_id == replacement_instance
+        assert (
+            replacement._authentication_authority_ledger
+            is replacement._operation_ledger
+        )
+        runner.adapters[Platform.WEBHOOK] = replacement
+
+        real_retire_owner = replacement._operation_ledger.retire_owner_instance
+        with patch.object(
+            replacement._operation_ledger,
+            "retire_owner_instance",
+            wraps=real_retire_owner,
+        ) as retried_retirement:
+            assert (
+                await runner._recover_webhook_operations(trigger="reconnect:webhook")
+                == 2
+            )
+        retried_retirement.assert_called_once_with(prior_instance)
+        assert replacement._accepting_webhooks is True
+
+        pending = tuple(replacement._background_tasks)
+        if pending:
+            await asyncio.gather(*pending)
+
+        recovered_ready = replacement._operation_ledger.lookup_session(
+            ready_envelope.session_key
+        )
+        assert recovered_ready is not None
+        assert recovered_ready.state is OperationState.SETTLED
+        assert recovered_ready.target_state is TargetState.SUPPRESSED
+        assert recovered_ready.generation == ready.generation + 1
+        recovered_delivery = replacement._operation_ledger.lookup_session(
+            delivery_envelope.session_key
+        )
+        assert recovered_delivery is not None
+        assert recovered_delivery.state is OperationState.SETTLED
+        assert recovered_delivery.target_state is TargetState.SUPPRESSED
+        assert recovered_delivery.generation == delivery_ready.generation + 1
+
+        await replacement.disconnect()
+
+    @pytest.mark.parametrize(
+        ("first_multiplex", "second_multiplex"),
+        [(False, True), (True, False)],
+    )
+    def test_profile_mode_transition_preserves_signed_replay_proof(
+        self,
+        tmp_path,
+        monkeypatch,
+        first_multiplex,
+        second_multiplex,
+    ):
+        """Toggling multiplexing cannot reopen a settled provider delivery."""
+
+        root = tmp_path / "mode-root"
+        profile_home = root / "profiles" / "alpha"
+        profile_home.mkdir(parents=True)
+        (profile_home / "config.yaml").write_text("{}\n", encoding="utf-8")
+        root_state = root / "state.db"
+        secret = "stable-mode-transition-secret"
+        raw_body = b'{"event_type":"tick","value":1}'
+        signature = hmac.new(secret.encode(), raw_body, hashlib.sha256).hexdigest()
+        headers = CIMultiDict({
+            "Content-Type": "application/json",
+            "X-Webhook-Signature": signature,
+        })
+
+        def route_config(multiplex: bool) -> dict:
+            route = {
+                "secret": secret,
+                "provider": "generic",
+                "signature_mode": "generic_v1",
+            }
+            if multiplex:
+                route["profile"] = "alpha"
+            return route
+
+        def build_adapter(multiplex: bool) -> WebhookAdapter:
+            monkeypatch.setenv(
+                "HERMES_HOME",
+                str(root if multiplex else profile_home),
+            )
+            adapter = _adapter({"events": route_config(multiplex)})
+            adapter.gateway_runner = SimpleNamespace(
+                config=GatewayConfig(
+                    multiplex_profiles=multiplex,
+                    multiplex_profile_allowlist=["alpha"] if multiplex else None,
+                ),
+                _resolve_profile_home_for_source=lambda source: (
+                    profile_home if source.profile == "alpha" else root
+                ),
+            )
+            adapter._bind_route_authentication_authorities(adapter._routes)
+            return adapter
+
+        def signed_envelope(adapter: WebhookAdapter, multiplex: bool):
+            bound_route = WebhookRouteConfig.bind(
+                "events",
+                route_config(multiplex),
+                headers=headers,
+                request_profile="alpha" if multiplex else "default",
+            )
+            request = SimpleNamespace(
+                headers=headers,
+                match_info={"route_name": "events"},
+            )
+            receipt = adapter._verify_signature_receipt(
+                request,
+                raw_body,
+                secret,
+                bound_route,
+            )
+            assert receipt is not None
+            return WebhookEnvelope.from_receipt(
+                receipt,
+                raw_body=raw_body,
+                media_type="application/json",
+                authority_profile="alpha",
+            )
+
+        first = build_adapter(first_multiplex)
+        assert first._operation_ledger.db_path == root_state
+        envelope = signed_envelope(first, first_multiplex)
+        assert envelope.authority_profile == "alpha"
+        admitted = first._operation_ledger.admit(envelope)
+        assert admitted.disposition is AdmitDisposition.ACCEPTED
+        assert admitted.authority is not None
+        assert first._operation_ledger.settle_no_effect(
+            admitted.authority,
+            "mode transition proof",
+        )
+
+        second = build_adapter(second_multiplex)
+        assert second._operation_ledger.db_path == root_state
+        replay_envelope = signed_envelope(second, second_multiplex)
+        assert replay_envelope.authority_profile == "alpha"
+        replay = second._operation_ledger.admit(replay_envelope)
+
+        assert replay.disposition is AdmitDisposition.DUPLICATE
+        assert replay.authority is not None
+        assert replay.authority.state is OperationState.SETTLED
+        assert second._operation_ledger.count() == 1
+
+    @pytest.mark.asyncio
+    async def test_primary_reconnect_shutdown_discards_b_without_recovery_effect(self):
+        """If drain wins B's connect, A remains published and no target runs."""
+
+        old_adapter = _adapter()
+        replacement_adapter = _adapter()
+        replacement_adapter._accepting_webhooks = False
+        target_adapter = SimpleNamespace(
+            send=AsyncMock(
+                return_value=SendResult(success=True, message_id="must-not-send")
+            )
+        )
+        envelope = _stage_replay_safe_platform_delivery(
+            old_adapter,
+            trace_id="primary-a-to-b-shutdown",
+        )
+        runner = _runner_for_primary_webhook_reconnect(
+            old_adapter,
+            replacement_adapter,
+            target_adapter,
+        )
+        real_recover = replacement_adapter.recover_pending_operations
+        replacement_adapter.recover_pending_operations = AsyncMock(wraps=real_recover)
+        real_disconnect = replacement_adapter.disconnect
+        replacement_adapter.disconnect = AsyncMock(wraps=real_disconnect)
+        real_sleep = asyncio.sleep
+
+        async def connect_finishes_during_drain(*_args, **_kwargs):
+            runner._draining = True
+            return True
+
+        async def immediate_sleep(_delay):
+            await real_sleep(0)
+
+        with (
+            patch.object(
+                runner,
+                "_create_adapter",
+                return_value=replacement_adapter,
+            ),
+            patch.object(
+                runner,
+                "_connect_adapter_with_timeout",
+                new=AsyncMock(side_effect=connect_finishes_during_drain),
+            ),
+            patch("asyncio.sleep", side_effect=immediate_sleep),
+        ):
+            await asyncio.wait_for(
+                runner._platform_reconnect_watcher(),
+                timeout=2,
+            )
+
+        assert runner.adapters[Platform.WEBHOOK] is old_adapter
+        assert Platform.WEBHOOK in runner._failed_platforms
+        replacement_adapter.disconnect.assert_awaited_once_with()
+        replacement_adapter.recover_pending_operations.assert_not_awaited()
+        target_adapter.send.assert_not_awaited()
+        replayable = old_adapter._operation_ledger.lookup_session(envelope.session_key)
+        assert replayable is not None
+        assert replayable.state is OperationState.DELIVERY_READY
+        assert replayable.target_state is TargetState.PENDING
+
+    @pytest.mark.asyncio
+    async def test_overlapping_recovery_triggers_invoke_one_staged_target(self):
+        adapter = _adapter()
+        target_adapter = SimpleNamespace(
+            send=AsyncMock(return_value=SendResult(success=True, message_id="sent-1"))
+        )
+        adapter.gateway_runner = SimpleNamespace(
+            config=SimpleNamespace(multiplex_profiles=False),
+            adapters={
+                Platform.WEBHOOK: adapter,
+                Platform.TELEGRAM: target_adapter,
+            },
+            _authorization_adapter=lambda platform, profile: (
+                target_adapter
+                if platform is Platform.TELEGRAM and profile == "default"
+                else adapter
+                if platform is Platform.WEBHOOK and profile == "default"
+                else None
+            ),
+        )
+        raw_body = b'{"value":1}'
+        route = WebhookRouteConfig.bind(
+            "recover",
+            {"provider": "generic"},
+            headers={},
+            request_profile="default",
+        )
+        envelope = WebhookEnvelope.from_receipt(
+            WebhookLocalBypassReceipt._issue(route, raw_body, {}),
+            raw_body=raw_body,
+            media_type="application/json",
+            trace_id="recover-trace",
+        )
+        admitted = adapter._operation_ledger.admit(envelope)
+        assert admitted.authority is not None
+        source = adapter._source_for_envelope(envelope)
+        prepared = adapter._operation_ledger.prepare(
+            admitted.authority,
+            event_snapshot={
+                "v": 1,
+                "mode": "direct",
+                "text": "one durable response",
+                "payload": {"value": 1},
+                "message_id": envelope.delivery_id,
+                "source": source.to_dict(),
+            },
+            target_snapshot={
+                "v": 1,
+                "kind": "platform",
+                "profile": "default",
+                "platform": "telegram",
+                "chat_id": "chat-1",
+            },
+            grant_snapshot=_grant_snapshot(adapter, envelope),
+        )
+        assert adapter._operation_ledger.mark_running(prepared)
+        staged = adapter._stage_exact_delivery(
+            prepared,
+            "one durable response",
+            {"v": 1, "kind": "direct"},
+        )
+        assert staged.state is OperationState.DELIVERY_READY
+
+        scheduled = await asyncio.gather(
+            adapter.recover_pending_operations(trigger="startup"),
+            adapter.recover_pending_operations(trigger="reconnect:webhook"),
+        )
+        pending = tuple(adapter._background_tasks)
+        if pending:
+            await asyncio.gather(*pending)
+
+        assert scheduled == [1, 0]
+        target_adapter.send.assert_awaited_once_with(
+            "chat-1",
+            "one durable response",
+            metadata=None,
+        )
+        restored = adapter._operation_ledger.lookup_session(envelope.session_key)
+        assert restored is not None
+        assert restored.state is OperationState.SETTLED
+        assert restored.target_state is TargetState.CONFIRMED
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("delivery_ready", [False, True])
+    async def test_immediate_recovery_cancellation_relinquishes_replay_safe_work(
+        self,
+        delivery_ready,
+    ):
+        adapter = _adapter()
+        raw_body = b'{"value":1}'
+        route = WebhookRouteConfig.bind(
+            "cancel-recovery",
+            {"provider": "generic"},
+            headers={},
+            request_profile="default",
+        )
+        envelope = WebhookEnvelope.from_receipt(
+            WebhookLocalBypassReceipt._issue(route, raw_body, {}),
+            raw_body=raw_body,
+            media_type="application/json",
+            trace_id=f"cancel-recovery-{delivery_ready}",
+        )
+        admitted = adapter._operation_ledger.admit(envelope)
+        assert admitted.authority is not None
+        source = adapter._source_for_envelope(envelope)
+        authority = adapter._operation_ledger.prepare(
+            admitted.authority,
+            event_snapshot={
+                "v": 1,
+                "mode": "direct",
+                "text": "durable response",
+                "payload": {"value": 1},
+                "message_id": envelope.delivery_id,
+                "source": source.to_dict(),
+            },
+            target_snapshot={"v": 1, "kind": "log", "profile": "default"},
+            grant_snapshot=_grant_snapshot(adapter, envelope),
+        )
+        if delivery_ready:
+            assert adapter._operation_ledger.mark_running(authority)
+            authority = adapter._stage_exact_delivery(
+                authority,
+                "durable response",
+                {"v": 1, "kind": "direct"},
+            )
+
+        # Simulate the owner disappearing so this adapter must claim recovery.
+        assert adapter._operation_ledger.relinquish_recovery_claim(authority)
+        assert await adapter.recover_pending_operations(trigger="first") == 1
+        pending = tuple(adapter._background_tasks)
+        assert len(pending) == 1
+        pending[0].cancel()
+        await asyncio.gather(*pending, return_exceptions=True)
+
+        replayable = adapter._operation_ledger.lookup_session(envelope.session_key)
+        assert replayable is not None
+        assert replayable.state is (
+            OperationState.DELIVERY_READY if delivery_ready else OperationState.READY
+        )
+        assert replayable.owner_instance != adapter._operation_ledger.instance_id
+
+        assert await adapter.recover_pending_operations(trigger="second") == 1
+        pending = tuple(adapter._background_tasks)
+        assert len(pending) == 1
+        await asyncio.gather(*pending)
+
+        restored = adapter._operation_ledger.lookup_session(envelope.session_key)
+        assert restored is not None
+        assert restored.state is OperationState.SETTLED
+        assert restored.target_state is TargetState.SUPPRESSED
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("callback_transition", "durable_outcome"),
+        [
+            pytest.param(
+                "relinquish_recovery_claim",
+                "exception",
+                id="relinquish-exception",
+            ),
+            pytest.param(
+                "relinquish_recovery_claim",
+                "authority-loss",
+                id="relinquish-authority-loss",
+            ),
+            pytest.param(
+                "mark_indeterminate",
+                "exception",
+                id="indeterminate-exception",
+            ),
+            pytest.param(
+                "mark_indeterminate",
+                "authority-loss",
+                id="indeterminate-authority-loss",
+            ),
+        ],
+    )
+    async def test_recovery_callback_durable_failure_fences_exact_current_owner(
+        self,
+        callback_transition,
+        durable_outcome,
+    ):
+        adapter = _adapter()
+        _envelope, authority = _prepare_owned_direct_operation(
+            adapter,
+            raw_body=(
+                f'{{"transition":"{callback_transition}",'
+                f'"outcome":"{durable_outcome}"}}'
+            ).encode(),
+            content="recovery callback fence",
+            target_snapshot={"v": 1, "kind": "log", "profile": "default"},
+        )
+        owner = adapter._operation_ledger.instance_id
+        schedule_retry = MagicMock()
+        update_status = MagicMock()
+        adapter.gateway_runner = SimpleNamespace(
+            _schedule_webhook_recovery_retry=schedule_retry,
+            _update_platform_runtime_status=update_status,
+        )
+        assert adapter._accepting_webhooks is True
+        assert _quarantined_retirement_owners(adapter._operation_ledger) == ()
+
+        transition_effect = (
+            {"side_effect": RuntimeError("injected durable callback failure")}
+            if durable_outcome == "exception"
+            else {"return_value": False}
+        )
+
+        async def fail_after_start() -> None:
+            raise RuntimeError("injected recovery task failure")
+
+        async def wait_forever() -> None:
+            await asyncio.Event().wait()
+
+        try:
+            with patch.object(
+                adapter._operation_ledger,
+                callback_transition,
+                **transition_effect,
+            ) as durable_transition:
+                operation = (
+                    wait_forever
+                    if callback_transition == "relinquish_recovery_claim"
+                    else fail_after_start
+                )
+                assert adapter._schedule_recovery_task(
+                    authority,
+                    "event recovery",
+                    operation,
+                )
+                task = adapter._recovery_tasks_by_operation[authority.operation_id]
+                if callback_transition == "relinquish_recovery_claim":
+                    # Cancellation before the coroutine's first instruction
+                    # exercises the callback's claim-handoff branch.
+                    task.cancel()
+                await asyncio.gather(task, return_exceptions=True)
+                # asyncio schedules task done callbacks with call_soon().
+                await asyncio.sleep(0)
+
+            assert durable_transition.call_count == 1
+            assert durable_transition.call_args.args[0] == authority
+            assert adapter._accepting_webhooks is False
+            assert adapter._intake_is_authoritative("default") is False
+            assert adapter._recovery_backlog_pending is True
+            assert adapter._recovery_restart_dead_scan is True
+            assert _quarantined_retirement_owners(adapter._operation_ledger) == (owner,)
+            assert schedule_retry.call_count >= 1
+            assert all(
+                call.args == (adapter,) for call in schedule_retry.call_args_list
+            )
+            update_status.assert_called_once_with(
+                Platform.WEBHOOK.value,
+                platform_state="retrying",
+                error_code="webhook_transition_failed",
+                error_message="Durable webhook transition requires recovery",
+            )
+            assert authority.operation_id not in adapter._recovery_tasks_by_operation
+            assert task not in adapter._background_tasks
+        finally:
+            _clear_quarantined_retirement_owner(
+                adapter._operation_ledger,
+                owner,
+            )
+
+    @pytest.mark.asyncio
+    async def test_bounded_recovery_drains_multi_page_backlog_without_task_fanout(
+        self,
+    ):
+        from gateway.run import GatewayRunner
+
+        adapter = _adapter(max_entries=32)
+        runner = object.__new__(GatewayRunner)
+        runner.config = GatewayConfig(multiplex_profiles=False)
+        runner.adapters = {Platform.WEBHOOK: adapter}
+        runner._startup_restore_in_progress = False
+        runner._draining = False
+        runner._external_drain_active = False
+        runner._running = True
+        runner._shutdown_event = asyncio.Event()
+        runner._background_tasks = set()
+        runner._webhook_recovery_retry_task = None
+        runner._webhook_recovery_retry_adapter = None
+        runner._schedule_webhook_recovery_retry = MagicMock()
+        runner._update_platform_runtime_status = MagicMock()
+        adapter.gateway_runner = runner
+        adapter._accepting_webhooks = False
+
+        staged_authorities = []
+        for index in range(20):
+            raw_body = json.dumps({"index": index}).encode()
+            route = WebhookRouteConfig.bind(
+                "backlog",
+                {"provider": "generic"},
+                headers={},
+                request_profile="default",
+            )
+            envelope = WebhookEnvelope.from_receipt(
+                WebhookLocalBypassReceipt._issue(route, raw_body, {}),
+                raw_body=raw_body,
+                media_type="application/json",
+                trace_id=f"backlog-{index}",
+            )
+            admitted = adapter._operation_ledger.admit(envelope)
+            assert admitted.authority is not None
+            prepared = adapter._operation_ledger.prepare(
+                admitted.authority,
+                event_snapshot={
+                    "v": 1,
+                    "mode": "direct",
+                    "text": f"backlog {index}",
+                    "payload": {"index": index},
+                    "message_id": envelope.delivery_id,
+                    "source": adapter._source_for_envelope(envelope).to_dict(),
+                },
+                target_snapshot={
+                    "v": 1,
+                    "kind": "log",
+                    "profile": "default",
+                },
+                grant_snapshot=_grant_snapshot(adapter, envelope),
+            )
+            assert adapter._operation_ledger.mark_running(prepared)
+            staged = adapter._stage_exact_delivery(
+                prepared,
+                f"backlog {index}",
+                {"v": 1, "kind": "direct"},
+            )
+            assert adapter._operation_ledger.relinquish_recovery_claim(staged)
+            staged_authorities.append(staged)
+
+        real_invoke = adapter._invoke_staged_target
+        first_batch_release = asyncio.Event()
+        invocation_count = 0
+
+        async def blocked_first_batch(authority):
+            nonlocal invocation_count
+            invocation_count += 1
+            await first_batch_release.wait()
+            return await real_invoke(authority)
+
+        adapter._invoke_staged_target = blocked_first_batch
+        assert await runner._recover_webhook_operations(trigger="bounded-start") == 8
+        assert len(adapter._recovery_tasks_by_operation) == 8
+        assert adapter._accepting_webhooks is False
+        assert adapter._recovery_backlog_pending is True
+
+        first_batch_release.set()
+        await asyncio.gather(*tuple(adapter._background_tasks))
+
+        for turn in range(1, 10):
+            await runner._recover_webhook_operations(trigger=f"bounded-{turn}")
+            assert len(adapter._recovery_tasks_by_operation) <= 8
+            pending = tuple(adapter._background_tasks)
+            if pending:
+                await asyncio.gather(*pending)
+            if adapter._accepting_webhooks:
+                break
+
+        assert adapter._accepting_webhooks is True
+        assert adapter._recovery_backlog_pending is False
+        assert invocation_count == 20
+        for staged in staged_authorities:
+            restored = adapter._operation_ledger.lookup_session(staged.session_key)
+            assert restored is not None
+            assert restored.state is OperationState.SETTLED
+            assert restored.target_state is TargetState.SUPPRESSED

--- a/tests/gateway/test_webhook_auto_resume_suppression.py
+++ b/tests/gateway/test_webhook_auto_resume_suppression.py
@@ -1,0 +1,173 @@
+"""Gateway auto-resume must defer webhook sessions to their exact ledger."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.webhook import WebhookAdapter
+from gateway.platforms.webhook_auth import WebhookLocalBypassReceipt
+from gateway.platforms.webhook_contract import WebhookEnvelope, WebhookRouteConfig
+from gateway.session import SessionSource, SessionStore
+from tests.gateway.restart_test_helpers import RestartTestAdapter
+
+
+@pytest.mark.asyncio
+async def test_webhook_resume_pending_is_not_claimed_by_generic_auto_resume(
+    tmp_path, monkeypatch
+):
+    """Ledger-owned webhook recovery must not touch the generic breaker."""
+
+    from gateway import restart_loop_guard
+    from gateway.run import GatewayRunner
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config = GatewayConfig(sessions_dir=tmp_path / "sessions")
+    runner = object.__new__(GatewayRunner)
+    runner.config = config
+    runner.session_store = SessionStore(config.sessions_dir, config)
+    runner.adapters = {}
+    runner._profile_adapters = {}
+    runner._sessions = {}
+    runner._background_tasks = set()
+
+    adapter = WebhookAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={"host": "127.0.0.1", "port": 0, "routes": {}},
+        )
+    )
+    adapter.gateway_runner = runner
+    runner.adapters[Platform.WEBHOOK] = adapter
+
+    raw_body = b'{"event":"resume-proof"}'
+    route = WebhookRouteConfig.bind(
+        "resume-proof",
+        {"provider": "generic", "profile": "default"},
+        headers={},
+        request_profile="default",
+    )
+    envelope = WebhookEnvelope.from_receipt(
+        WebhookLocalBypassReceipt._issue(route, raw_body, {}),
+        raw_body=raw_body,
+        media_type="application/json",
+        trace_id="resume-proof-trace",
+    )
+    source = adapter._source_for_envelope(envelope)
+    entry = runner.session_store.get_or_create_session(source)
+    assert runner.session_store.mark_resume_pending(
+        entry.session_key,
+        reason="restart_interrupted",
+    )
+    assert entry.resume_pending is True
+    assert entry.origin is source
+    assert source.platform is Platform.WEBHOOK
+    assert adapter.allows_automatic_session_resume is False
+
+    handle_message = AsyncMock(
+        side_effect=AssertionError("generic auto-resume invoked webhook execution")
+    )
+    adapter.handle_message = handle_message
+    persist_active_agents = MagicMock()
+    runner._persist_active_agents = persist_active_agents
+    restart_check = MagicMock(return_value=False)
+    monkeypatch.setattr(restart_loop_guard, "check_and_record", restart_check)
+
+    scheduled = runner._schedule_resume_pending_sessions()
+    await asyncio.sleep(0)
+
+    assert scheduled == 0
+    assert runner._peek_session_state(entry.session_key) is None
+    assert runner._is_session_running(entry.session_key) is False
+    assert runner._background_tasks == set()
+    handle_message.assert_not_awaited()
+    persist_active_agents.assert_not_called()
+    restart_check.assert_not_called()
+    retained = runner.session_store._entries[entry.session_key]
+    assert retained.resume_pending is True
+    assert retained.resume_reason == "restart_interrupted"
+
+
+@pytest.mark.asyncio
+async def test_mixed_webhook_and_telegram_resume_checks_only_generic_work(
+    tmp_path, monkeypatch
+):
+    """A webhook marker cannot suppress or inflate an eligible Telegram pass."""
+
+    from gateway import restart_loop_guard
+    from gateway.run import GatewayRunner
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config = GatewayConfig(sessions_dir=tmp_path / "sessions")
+    runner = object.__new__(GatewayRunner)
+    runner.config = config
+    runner.session_store = SessionStore(config.sessions_dir, config)
+    runner.adapters = {}
+    runner._profile_adapters = {}
+    runner._sessions = {}
+    runner._background_tasks = set()
+    runner._is_user_authorized = lambda _source: True
+    runner._persist_active_agents = MagicMock()
+
+    webhook_adapter = WebhookAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={"host": "127.0.0.1", "port": 0, "routes": {}},
+        )
+    )
+    webhook_adapter.gateway_runner = runner
+    webhook_adapter.handle_message = AsyncMock(
+        side_effect=AssertionError("generic auto-resume invoked webhook execution")
+    )
+    runner.adapters[Platform.WEBHOOK] = webhook_adapter
+
+    raw_body = b'{"event":"mixed-resume-proof"}'
+    route = WebhookRouteConfig.bind(
+        "mixed-resume-proof",
+        {"provider": "generic", "profile": "default"},
+        headers={},
+        request_profile="default",
+    )
+    envelope = WebhookEnvelope.from_receipt(
+        WebhookLocalBypassReceipt._issue(route, raw_body, {}),
+        raw_body=raw_body,
+        media_type="application/json",
+        trace_id="mixed-resume-proof-trace",
+    )
+    webhook_source = webhook_adapter._source_for_envelope(envelope)
+    webhook_entry = runner.session_store.get_or_create_session(webhook_source)
+    assert runner.session_store.mark_resume_pending(
+        webhook_entry.session_key,
+        reason="restart_interrupted",
+    )
+
+    telegram_adapter = RestartTestAdapter()
+    telegram_adapter.handle_message = AsyncMock(return_value=None)
+    runner.adapters[Platform.TELEGRAM] = telegram_adapter
+    telegram_source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="mixed-telegram-chat",
+        user_id="telegram-owner",
+    )
+    telegram_entry = runner.session_store.get_or_create_session(telegram_source)
+    assert runner.session_store.mark_resume_pending(
+        telegram_entry.session_key,
+        reason="restart_interrupted",
+    )
+
+    restart_check = MagicMock(return_value=False)
+    monkeypatch.setattr(restart_loop_guard, "check_and_record", restart_check)
+
+    scheduled = runner._schedule_resume_pending_sessions()
+    await asyncio.sleep(0)
+
+    assert scheduled == 1
+    restart_check.assert_called_once()
+    webhook_adapter.handle_message.assert_not_awaited()
+    telegram_adapter.handle_message.assert_awaited_once()
+    resumed_event = telegram_adapter.handle_message.await_args.args[0]
+    assert resumed_event.source is telegram_source
+    retained = runner.session_store._entries[webhook_entry.session_key]
+    assert retained.resume_pending is True
+    assert retained.resume_reason == "restart_interrupted"

--- a/tests/gateway/test_webhook_auto_tts_authority.py
+++ b/tests/gateway/test_webhook_auto_tts_authority.py
@@ -1,0 +1,263 @@
+"""Auto-TTS must not widen a webhook's one durable final carrier."""
+
+import asyncio
+import json
+from datetime import datetime, timedelta
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+import gateway.run as gateway_run
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, SendResult
+from gateway.platforms.webhook import WebhookAdapter, _INSECURE_NO_AUTH
+from gateway.platforms.webhook_ledger import (
+    OperationState,
+    WebhookOperationLedger,
+)
+from gateway.session import SessionEntry, build_session_key
+
+
+def _webhook_adapter(tmp_path: Path) -> WebhookAdapter:
+    config = PlatformConfig(
+        enabled=True,
+        extra={
+            "host": "127.0.0.1",
+            "port": 0,
+            "routes": {
+                "alerts": {
+                    "secret": _INSECURE_NO_AUTH,
+                    "provider": "github",
+                    "prompt": "Handle: {message}",
+                    "deliver": "telegram",
+                    "deliver_extra": {"chat_id": "target-chat"},
+                }
+            },
+        },
+    )
+    adapter = WebhookAdapter(config)
+    adapter._operation_ledger = WebhookOperationLedger(
+        tmp_path / "webhook-authority.db"
+    )
+    return adapter
+
+
+def _gateway_runner(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    adapter: WebhookAdapter,
+    target: MagicMock,
+) -> gateway_run.GatewayRunner:
+    from hermes_constants import get_hermes_home
+
+    # Route publication freezes grants from the physical profile config. Keep
+    # this real-runner fixture on that production path instead of relying only
+    # on the in-process load_config double below.
+    (get_hermes_home() / "config.yaml").write_text(
+        "voice:\n  auto_tts: true\n",
+        encoding="utf-8",
+    )
+    config = GatewayConfig(
+        platforms={
+            Platform.WEBHOOK: adapter.config,
+            Platform.TELEGRAM: target.config,
+        },
+        sessions_dir=tmp_path / "sessions",
+    )
+    runner = gateway_run.GatewayRunner(config)
+    runner.adapters = {
+        Platform.WEBHOOK: adapter,
+        Platform.TELEGRAM: target,
+    }
+    runner._profile_adapters = {}
+    runner._voice_mode = {}
+    runner._running = True
+    runner._startup_restore_in_progress = False
+    runner._draining = False
+    runner._external_drain_active = False
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._turn_leases = None
+    runner._session_db = None
+    runner._recover_telegram_topic_thread_id = lambda _source: None
+    runner._cache_session_source = lambda _key, _source: None
+    runner._is_session_run_current = lambda _key, _generation: True
+    runner._reply_anchor_for_event = lambda event: event.message_id
+    runner._get_guild_id = lambda _event: None
+    runner._set_session_env = lambda _context: None
+    runner._clear_session_env = lambda _tokens: None
+    runner._clear_restart_failure_count = AsyncMock()
+    runner._refresh_agent_cache_message_count = AsyncMock()
+    runner._drain_watch_notifications = AsyncMock()
+    runner.hooks = MagicMock()
+    runner.hooks.emit = AsyncMock()
+
+    # Use the same GatewayRunner method that production uses to populate the
+    # adapter's global voice.auto_tts default.
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"voice": {"auto_tts": True}},
+    )
+    runner._sync_voice_mode_state_to_adapter(adapter)
+    assert adapter._auto_tts_default is True
+
+    return runner
+
+
+def _app(adapter: WebhookAdapter) -> web.Application:
+    app = web.Application()
+    app.router.add_post("/webhooks/{route_name}", adapter._handle_webhook)
+    return app
+
+
+@pytest.mark.asyncio
+async def test_global_auto_tts_cannot_claim_webhook_final_before_base_delivery(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    """Drive GatewayRunner's real finalization into Base's real send funnel."""
+
+    adapter = _webhook_adapter(tmp_path)
+    target = MagicMock()
+    target.platform = Platform.TELEGRAM
+    target.config = PlatformConfig(enabled=True, token="test-token")
+    target.send = AsyncMock(
+        return_value=SendResult(success=True, message_id="target-message")
+    )
+    runner = _gateway_runner(monkeypatch, tmp_path, adapter, target)
+    adapter.gateway_runner = runner
+
+    captured = []
+
+    async def capture(event):
+        captured.append(event)
+
+    # First cross the real HTTP admission/prepare boundary. Processing is
+    # deliberately captured so the remainder can be driven synchronously.
+    adapter.handle_message = capture
+    async with TestClient(TestServer(_app(adapter))) as client:
+        response = await client.post(
+            "/webhooks/alerts",
+            json={"message": "build the report"},
+            headers={"X-GitHub-Delivery": "auto-tts-authority"},
+        )
+        assert response.status == 202
+    await asyncio.sleep(0)
+    assert len(captured) == 1
+    event = captured[0]
+
+    now = datetime.now()
+    session_key = build_session_key(event.source)
+    session_entry = SessionEntry(
+        session_key=session_key,
+        session_id="webhook-auto-tts-session",
+        created_at=now - timedelta(minutes=1),
+        updated_at=now,
+        origin=event.source,
+        platform=Platform.WEBHOOK,
+        chat_type="webhook",
+    )
+    history = [
+        {"role": "user", "content": "earlier"},
+        {"role": "assistant", "content": "acknowledged"},
+    ]
+    runner.session_store = MagicMock()
+    runner.session_store.config = runner.config
+    runner.session_store.get_or_create_session.return_value = session_entry
+    runner.session_store.load_transcript.return_value = history
+    runner.session_store.has_any_sessions.return_value = True
+    runner.session_store.has_platform_message_id.return_value = False
+
+    raw_final = "**Exact durable final.**\n\nMEDIA:/tmp/webhook-auto-tts-attachment.mp3"
+    expected_final = (
+        "**Exact durable final.**\n\n"
+        "⚠️ Local attachments were omitted from webhook delivery."
+    )
+    prepare_trap = MagicMock(wraps=adapter.prepare_ledger_owned_final_content)
+    adapter.prepare_ledger_owned_final_content = prepare_trap
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": raw_final,
+            "messages": [
+                *history,
+                {"role": "user", "content": event.text},
+                {"role": "assistant", "content": raw_final},
+            ],
+            "history_offset": len(history),
+            "tools": [],
+            "last_prompt_tokens": 0,
+            "api_calls": 1,
+            "failed": False,
+            "agent_persisted": False,
+        }
+    )
+
+    # If either generic auto-TTS stage is reached, allow the historical bug
+    # to materialize: synthesis creates a file and Base's inherited voice
+    # fallback would try to send its audio-error notice through webhook.send.
+    def fake_tts(*, text: str, output_path: str) -> str:
+        Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+        Path(output_path).write_bytes(b"fake audio")
+        return json.dumps({"success": True, "file_path": output_path})
+
+    tts_trap = MagicMock(side_effect=fake_tts)
+    monkeypatch.setattr("tools.tts_tool.text_to_speech_tool", tts_trap)
+    voice_fallback_trap = AsyncMock(wraps=adapter.send_voice)
+    adapter.send_voice = voice_fallback_trap
+
+    async def gateway_handler(inbound_event):
+        return await runner._handle_message_with_agent(
+            inbound_event,
+            inbound_event.source,
+            session_key,
+            1,
+        )
+
+    adapter.set_message_handler(gateway_handler)
+    await adapter._process_message_background(event, session_key)
+
+    assert adapter._should_auto_tts_for_chat(event.source.chat_id) is True
+    assert runner._should_send_voice_reply(event, raw_final, []) is False
+    tts_trap.assert_not_called()
+    voice_fallback_trap.assert_not_awaited()
+    prepare_trap.assert_called_once_with(raw_final, session_key=session_key)
+    target.send.assert_awaited_once_with(
+        "target-chat",
+        expected_final,
+        metadata=None,
+    )
+
+    settled = adapter._operation_ledger.lookup_session(event.source.chat_id)
+    assert settled is not None
+    assert settled.state is OperationState.SETTLED
+    assert settled.delivery is not None
+    assert settled.delivery.content == expected_final
+    assert dict(settled.delivery.carrier) == {"v": 1, "kind": "agent_final"}
+
+
+@pytest.mark.asyncio
+async def test_ledger_owned_adapter_inherited_voice_fallback_never_sends_text(
+    tmp_path: Path,
+):
+    """Defense in depth: Base's fallback cannot mutate a ledger final."""
+
+    adapter = _webhook_adapter(tmp_path)
+    adapter.send = AsyncMock(
+        side_effect=AssertionError("voice fallback attempted a webhook text send")
+    )
+
+    result = await BasePlatformAdapter.send_voice(
+        adapter,
+        chat_id="webhook:authority",
+        audio_path="/tmp/undeliverable.mp3",
+        metadata={"notify": True},
+    )
+
+    assert result.success is False
+    assert result.error == "Voice delivery is unavailable for ledger-owned finals"
+    adapter.send.assert_not_awaited()

--- a/tests/gateway/test_webhook_callbacks.py
+++ b/tests/gateway/test_webhook_callbacks.py
@@ -1,0 +1,207 @@
+"""Callback SSRF-guard and envelope tests (Task 13, #4386/#73828)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+from gateway.platforms import webhook_callbacks as wc
+
+
+def _envelope() -> dict:
+    return wc.build_callback_envelope(
+        execution_id="e1",
+        event_id="ev1",
+        status="completed",
+        output="done",
+        error=None,
+        attempt=1,
+    )
+
+
+class TestValidateCallbackUrl:
+    def test_public_https_ok(self, monkeypatch):
+        monkeypatch.setattr(
+            wc.socket,
+            "getaddrinfo",
+            lambda *_args, **_kwargs: [
+                (
+                    wc.socket.AF_INET,
+                    wc.socket.SOCK_STREAM,
+                    wc.socket.IPPROTO_TCP,
+                    "",
+                    ("93.184.216.34", 443),
+                )
+            ],
+        )
+        ok, _ = wc.validate_callback_url("https://example.com/done")
+        assert ok is True
+
+    def test_private_host_blocked(self):
+        ok, reason = wc.validate_callback_url("http://10.0.0.5/cb")
+        assert ok is False
+        assert "SSRF" in reason
+
+    def test_loopback_blocked(self):
+        ok, reason = wc.validate_callback_url("http://127.0.0.1/cb")
+        assert ok is False
+        assert "SSRF" in reason
+
+    def test_metadata_blocked(self):
+        ok, _ = wc.validate_callback_url("http://169.254.169.254/latest/meta-data")
+        assert ok is False
+
+    def test_non_http_blocked(self):
+        ok, reason = wc.validate_callback_url("file:///etc/passwd")
+        assert ok is False
+        assert "http(s)" in reason
+
+    def test_missing_host_blocked(self):
+        ok, _ = wc.validate_callback_url("https://")
+        assert ok is False
+
+    def test_any_unsafe_dns_answer_fails_closed(self, monkeypatch):
+        monkeypatch.setattr(
+            wc.socket,
+            "getaddrinfo",
+            lambda *_args, **_kwargs: [
+                (
+                    wc.socket.AF_INET,
+                    wc.socket.SOCK_STREAM,
+                    wc.socket.IPPROTO_TCP,
+                    "",
+                    ("93.184.216.34", 443),
+                ),
+                (
+                    wc.socket.AF_INET,
+                    wc.socket.SOCK_STREAM,
+                    wc.socket.IPPROTO_TCP,
+                    "",
+                    ("127.0.0.1", 443),
+                ),
+            ],
+        )
+        ok, reason = wc.validate_callback_url("https://example.com/done")
+        assert ok is False
+        assert "SSRF" in reason
+
+
+class TestEnvelope:
+    def test_envelope_shape(self):
+        env = _envelope()
+        assert env["execution_id"] == "e1"
+        assert env["status"] == "completed"
+        assert env["attempt"] == 1
+        assert env["error"] is None
+
+    def test_envelope_serializes(self):
+        env = wc.build_callback_envelope(
+            execution_id="e1",
+            event_id="ev1",
+            status="failed",
+            output=None,
+            error="boom",
+            attempt=2,
+        )
+        json.dumps(env)  # must not raise
+
+    def test_malformed_envelope_rejected_before_dns(self, monkeypatch):
+        def should_not_resolve(*_args, **_kwargs):
+            raise AssertionError("DNS must not run for an invalid envelope")
+
+        monkeypatch.setattr(wc.socket, "getaddrinfo", should_not_resolve)
+        assert wc.deliver_callback("https://example.com/done", None, {}) is False
+
+
+class TestSigning:
+    def test_signature_is_sha256(self):
+        body = b'{"x":1}'
+        sig = wc._sign(body, "secret")
+        assert sig.startswith("sha256=")
+
+
+class TestPinnedDelivery:
+    def test_delivery_dials_the_validated_address_without_second_dns(self, monkeypatch):
+        calls = []
+
+        def resolve(*_args, **_kwargs):
+            calls.append("resolve")
+            return [
+                (
+                    wc.socket.AF_INET,
+                    wc.socket.SOCK_STREAM,
+                    wc.socket.IPPROTO_TCP,
+                    "",
+                    ("93.184.216.34", 443),
+                )
+            ]
+
+        opened = []
+
+        def open_pinned(destination, body, headers, *, timeout):
+            opened.append((destination, body, headers, timeout))
+            return 204
+
+        monkeypatch.setattr(wc.socket, "getaddrinfo", resolve)
+        monkeypatch.setattr(wc, "_open_pinned", open_pinned)
+
+        assert (
+            wc.deliver_callback("https://example.com/done?x=1", "secret", _envelope())
+            is True
+        )
+        assert calls == ["resolve"]
+        destination = opened[0][0]
+        assert destination.connect_host == "93.184.216.34"
+        assert destination.hostname == "example.com"
+        assert destination.request_target == "/done?x=1"
+        assert opened[0][2]["X-Hermes-Signature-256"].startswith("sha256=")
+
+    def test_redirect_is_terminal_and_not_retried(self, monkeypatch):
+        monkeypatch.setattr(
+            wc.socket,
+            "getaddrinfo",
+            lambda *_args, **_kwargs: [
+                (
+                    wc.socket.AF_INET,
+                    wc.socket.SOCK_STREAM,
+                    wc.socket.IPPROTO_TCP,
+                    "",
+                    ("93.184.216.34", 443),
+                )
+            ],
+        )
+        attempts = []
+
+        def redirected(*_args, **_kwargs):
+            attempts.append(1)
+            return 302
+
+        monkeypatch.setattr(wc, "_open_pinned", redirected)
+        assert (
+            wc.deliver_callback("https://example.com/done", None, _envelope()) is False
+        )
+        assert attempts == [1]
+
+    def test_async_wrapper_moves_sync_transport_to_thread(self, monkeypatch):
+        calls = []
+
+        def fake_deliver(url, secret, envelope, *, timeout):
+            calls.append((url, secret, envelope, timeout))
+            return True
+
+        monkeypatch.setattr(wc, "deliver_callback", fake_deliver)
+        result = asyncio.run(
+            wc.deliver_callback_async(
+                "https://example.com/done",
+                "secret",
+                _envelope(),
+                timeout=3,
+            )
+        )
+        assert result is True
+        assert calls[0][3] == 3
+
+
+class TestDeliverRefusesPrivate:
+    def test_deliver_refuses_private(self):
+        assert wc.deliver_callback("http://127.0.0.1:9/cb", None, _envelope()) is False

--- a/tests/gateway/test_webhook_contract.py
+++ b/tests/gateway/test_webhook_contract.py
@@ -1,0 +1,1048 @@
+"""Contracts for canonical webhook provider, identity, and envelope authority."""
+
+import base64
+import hashlib
+import hmac
+import json
+import time
+from datetime import datetime, timezone
+from types import MappingProxyType
+
+import pytest
+
+from gateway.platforms.webhook_auth import (
+    WebhookAuthMixin,
+    WebhookLocalBypassReceipt,
+    WebhookSignatureVerificationReceipt,
+    WebhookVerificationCoverage,
+)
+from gateway.platforms.webhook_contract import (
+    GITHUB_AUTHENTICATED_EVENTS,
+    MAX_EVENT_TYPE_UTF8_BYTES,
+    PROVIDER_REGISTRY,
+    WebhookContractError,
+    WebhookEnvelope,
+    WebhookPayloadContractError,
+    WebhookReplayIdentityKind,
+    WebhookRouteConfig,
+    WebhookRouteScopeError,
+    canonical_provider,
+    canonical_signature_mode,
+    resolve_delivery_identity,
+    resolve_event_type,
+    validate_authenticated_event_body,
+)
+
+
+class _Headers(dict):
+    def get(self, key, default=""):
+        for candidate, value in self.items():
+            if str(candidate).lower() == str(key).lower():
+                return value
+        return default
+
+
+class _Request:
+    def __init__(self, headers):
+        self.headers = _Headers(headers)
+        self.match_info = {"route_name": "events"}
+
+
+class _Verifier(WebhookAuthMixin):
+    pass
+
+
+def verified_envelope(route, raw_body, headers, secret="secret", trace_id=None):
+    receipt = _Verifier()._verify_signature_receipt(
+        _Request(headers),
+        raw_body,
+        secret,
+        route,
+    )
+    assert receipt is not None
+    return WebhookEnvelope.from_receipt(
+        receipt,
+        raw_body=raw_body,
+        media_type="application/json",
+        trace_id=trace_id,
+    )
+
+
+def _body_hmac(body, secret="secret", *, prefix="sha256="):
+    return prefix + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+
+
+def _github_pull_request_body(number=7):
+    return json.dumps(
+        {
+            "action": "opened",
+            "number": number,
+            "pull_request": {
+                "id": 701,
+                "number": number,
+                "state": "open",
+                "title": "Authenticated PR",
+            },
+            "repository": {"id": 801, "full_name": "org/repo"},
+            "sender": {"id": 901, "login": "octocat"},
+        },
+        separators=(",", ":"),
+    ).encode()
+
+
+def _svix_signature(body, secret, msg_id, timestamp):
+    signed = msg_id.encode() + b"." + timestamp.encode() + b"." + body
+    digest = hmac.new(secret.encode(), signed, hashlib.sha256).digest()
+    return "v1," + base64.b64encode(digest).decode()
+
+
+def bind(route=None, headers=None, *, profile=None):
+    return WebhookRouteConfig.bind(
+        "events",
+        {} if route is None else route,
+        headers=headers or {},
+        request_profile=profile,
+    )
+
+
+def make_envelope(
+    route,
+    raw_body,
+    *,
+    headers=None,
+    bypass=False,
+    trace_id=None,
+    media_type="application/json",
+):
+    receipt_type = (
+        WebhookLocalBypassReceipt if bypass else WebhookSignatureVerificationReceipt
+    )
+    receipt = receipt_type._issue(route, raw_body, headers or {})
+    return WebhookEnvelope.from_receipt(
+        receipt,
+        raw_body=raw_body,
+        media_type=media_type,
+        trace_id=trace_id,
+    )
+
+
+def test_registry_is_read_only_and_has_expected_namespaces():
+    assert isinstance(PROVIDER_REGISTRY, MappingProxyType)
+    assert {
+        "github",
+        "gitlab",
+        "svix",
+        "standard_webhooks",
+        "chatwoot",
+        "linear",
+        "hindsight",
+        "hermes",
+        "stripe",
+        "generic",
+    } <= set(PROVIDER_REGISTRY)
+    with pytest.raises(TypeError):
+        PROVIDER_REGISTRY["evil"] = PROVIDER_REGISTRY["generic"]  # type: ignore[index]
+
+
+@pytest.mark.parametrize(
+    ("configured", "expected"),
+    [
+        ("agentmail", "svix"),
+        ("github-hmac-sha256", "github"),
+        ("gitlab_token", "gitlab"),
+        ("gitlab-standard", "standard_webhooks"),
+        ("generic_v1", "generic"),
+        ("generic-v2", "generic"),
+        ("hindsight_hmac_sha256", "hindsight"),
+        ("hermes-agent", "hermes"),
+    ],
+)
+def test_provider_aliases_canonicalize(configured, expected):
+    assert canonical_provider(configured) == expected
+
+
+@pytest.mark.parametrize(
+    ("configured", "expected"),
+    [
+        ("github-hmac-sha256", "github"),
+        ("gitlab-token", "gitlab"),
+        ("generic-v2", "generic_v2"),
+        ("gitlab_standard", "standard_webhooks"),
+        ("hindsight_hmac_sha256", "hindsight"),
+        ("hermes-agent", "hermes"),
+    ],
+)
+def test_signature_aliases_normalize_to_executable_modes(configured, expected):
+    assert canonical_signature_mode(configured) == expected
+
+
+def test_unknown_explicit_provider_and_signature_fail_closed():
+    with pytest.raises(WebhookContractError, match="unsupported webhook provider"):
+        bind({"provider": "made-up"})
+    with pytest.raises(
+        WebhookContractError, match="unsupported webhook signature mode"
+    ):
+        bind({"signature_mode": "made-up"})
+
+
+def test_provider_and_verifier_mode_cannot_disagree():
+    with pytest.raises(WebhookContractError, match="does not allow signature mode"):
+        bind({"provider": "github", "signature_mode": "svix"})
+
+
+def test_provider_can_use_registered_generic_verifier():
+    route = bind({"provider": "chatwoot", "signature_mode": "generic_v2"})
+    assert (route.provider, route.signature_mode) == ("chatwoot", "generic_v2")
+
+
+def test_route_event_rejects_lone_unicode_surrogate_as_typed_configuration():
+    with pytest.raises(WebhookContractError, match="event is not valid Unicode"):
+        bind({"provider": "github", "events": ["\udcff"]})
+
+
+def test_explicit_provider_does_not_promote_uncovered_attacker_headers():
+    route = bind(
+        {"provider": "github"},
+        {
+            "svix-id": "msg_attacker",
+            "svix-signature": "v1,attacker",
+            "X-GitHub-Delivery": "gh_123",
+        },
+    )
+    identity = resolve_delivery_identity(
+        route,
+        {"svix-id": "msg_attacker", "X-GitHub-Delivery": "gh_123"},
+        {},
+    )
+    assert route.provider_declared is True
+    assert identity is None
+
+
+def test_explicit_generic_route_ignores_github_event_header():
+    route = bind({"provider": "generic"})
+    assert (
+        resolve_event_type(
+            route,
+            {"X-GitHub-Event": "push"},
+            {"event_type": "generic.tick"},
+        )
+        == "generic.tick"
+    )
+
+
+def test_authenticated_payload_event_type_has_exact_utf8_bound():
+    route = bind({"provider": "generic"})
+
+    assert (
+        resolve_event_type(
+            route,
+            {},
+            {"event_type": "e" * MAX_EVENT_TYPE_UTF8_BYTES},
+        )
+        == "e" * MAX_EVENT_TYPE_UTF8_BYTES
+    )
+    with pytest.raises(WebhookPayloadContractError, match="exceeds 1024"):
+        resolve_event_type(
+            route,
+            {},
+            {"event_type": "é" * (MAX_EVENT_TYPE_UTF8_BYTES // 2 + 1)},
+        )
+
+
+def test_authenticated_payload_rejects_lone_unicode_surrogates():
+    raw_body = b'{"type":"\\ud800"}'
+    with pytest.raises(WebhookPayloadContractError, match="invalid Unicode"):
+        make_envelope(bind({"provider": "generic"}), raw_body)
+
+
+@pytest.mark.parametrize(
+    "raw_body",
+    [
+        b'{"amount":1e9999}',
+        b'{"nested":[-1e9999]}',
+    ],
+)
+def test_authenticated_payload_rejects_finite_syntax_that_overflows(raw_body):
+    with pytest.raises(WebhookPayloadContractError, match="non-finite number"):
+        make_envelope(bind({"provider": "generic"}), raw_body)
+
+
+@pytest.mark.parametrize(
+    "name",
+    [" events", "events ", "Events", "events/path", "e" * 129, 7],
+)
+def test_route_name_must_already_be_one_canonical_url_slug(name):
+    with pytest.raises(WebhookContractError, match="canonical lowercase URL slug"):
+        WebhookRouteConfig.bind(
+            name,
+            {"provider": "generic"},
+            headers={},
+        )
+
+
+@pytest.mark.parametrize("profile", [" ops", "ops ", "Ops", "ops/path", "p" * 65])
+def test_route_profile_must_already_be_canonical(profile):
+    with pytest.raises(WebhookContractError, match="non-canonical profile"):
+        bind({"provider": "generic", "profile": profile}, profile=profile)
+
+
+def test_route_bound_event_type_has_exact_utf8_bound():
+    with pytest.raises(WebhookContractError, match="event exceeds 1024"):
+        bind({"provider": "generic", "events": ["é" * 513]})
+
+
+@pytest.mark.parametrize(
+    "headers",
+    [
+        {"svix-id": "msg_1", "svix-signature": "v1,attacker"},
+        {"X-Hub-Signature-256": "sha256=attacker"},
+        {"linear-signature": "attacker"},
+        {"X-Hermes-Signature-256": "sha256=attacker"},
+        {"Stripe-Signature": "t=1,v1=attacker"},
+        {"X-Webhook-Signature-V2": "attacker"},
+    ],
+)
+def test_request_headers_cannot_select_undeclared_provider_authority(headers):
+    with pytest.raises(WebhookContractError, match="requires an explicit"):
+        bind({}, headers)
+
+
+def test_explicit_generic_v1_cannot_be_upgraded_or_downgraded_by_headers():
+    route = bind(
+        {"signature_mode": "generic_v1"},
+        {
+            "X-Webhook-Signature-V2": "attacker-v2",
+            "X-Webhook-Signature": "configured-v1",
+            "X-Hub-Signature-256": "sha256=attacker",
+        },
+    )
+    assert (route.provider, route.signature_mode) == ("generic", "generic_v1")
+
+
+def test_explicit_generic_v2_cannot_be_relabelled_by_provider_headers():
+    route = bind(
+        {"signature_mode": "generic_v2"},
+        {
+            "X-Hub-Signature-256": "sha256=attacker",
+            "linear-signature": "attacker",
+            "X-Hindsight-Signature": "attacker",
+            "X-Webhook-Signature": "captured-v1",
+        },
+    )
+    assert (route.provider, route.signature_mode) == ("generic", "generic_v2")
+
+
+def test_provider_field_verifier_alias_preserves_declared_generic_v1():
+    route = bind({"provider": "generic_v1"}, {})
+    assert (route.provider, route.signature_mode, route.provider_declared) == (
+        "generic",
+        "generic_v1",
+        True,
+    )
+
+
+def test_signature_mode_can_bind_provider_namespace():
+    route = bind({"signature_mode": "generic_v2"})
+    assert (route.provider, route.signature_mode, route.provider_declared) == (
+        "generic",
+        "generic_v2",
+        True,
+    )
+
+
+def test_gitlab_transport_ids_are_not_delivery_authority():
+    identity = resolve_delivery_identity(
+        bind({"provider": "gitlab"}),
+        {
+            "Idempotency-Key": "fallback",
+            "X-Gitlab-Webhook-UUID": "webhook-uuid",
+            "X-Gitlab-Event-UUID": "event-uuid",
+        },
+        {},
+    )
+    assert identity is None
+
+
+def test_unbound_event_header_authority_is_route_fixed():
+    with pytest.raises(WebhookContractError, match="at most one route-bound event"):
+        bind({"provider": "github", "events": ["push", "pull_request"]})
+
+    unfiltered = bind({"provider": "github"})
+    assert (
+        resolve_event_type(
+            unfiltered,
+            {},
+            {},
+            observed_headers={"X-GitHub-Event": "push"},
+        )
+        == "unknown"
+    )
+
+    fixed = bind({"provider": "github", "events": ["pull_request"]})
+    with pytest.raises(WebhookContractError, match="missing the route-bound"):
+        resolve_event_type(fixed, {}, {}, observed_headers={})
+    assert (
+        resolve_event_type(
+            fixed,
+            {},
+            {},
+            observed_headers={"X-GitHub-Event": "pull_request"},
+        )
+        == "pull_request"
+    )
+    with pytest.raises(WebhookContractError, match="route-bound event authority"):
+        resolve_event_type(
+            fixed,
+            {},
+            {},
+            observed_headers={"X-GitHub-Event": "workflow_run"},
+        )
+
+
+def test_github_route_binding_accepts_only_body_classified_events():
+    assert GITHUB_AUTHENTICATED_EVENTS == {
+        "check_run",
+        "issues",
+        "ping",
+        "pull_request",
+        "push",
+    }
+    with pytest.raises(
+        WebhookContractError,
+        match="cannot authenticate event body shape for 'workflow_run'",
+    ):
+        bind({"provider": "github", "events": ["workflow_run"]})
+
+
+def test_github_supported_body_classifiers_are_mutually_exclusive():
+    repository = {"id": 801, "full_name": "org/repo"}
+    sender = {"id": 901, "login": "octocat"}
+    payloads = {
+        "check_run": {
+            "action": "completed",
+            "check_run": {
+                "id": 401,
+                "name": "tests",
+                "status": "completed",
+            },
+            "repository": repository,
+            "sender": sender,
+        },
+        "issues": {
+            "action": "opened",
+            "issue": {"id": 601, "number": 3},
+            "repository": repository,
+            "sender": sender,
+        },
+        "ping": {
+            "zen": "Keep it logically awesome.",
+            "hook_id": 501,
+            "hook": {"id": 501, "type": "Repository"},
+        },
+        "pull_request": json.loads(_github_pull_request_body()),
+        "push": {
+            "ref": "refs/heads/main",
+            "before": "0" * 40,
+            "after": "1" * 40,
+            "created": False,
+            "deleted": False,
+            "forced": False,
+            "commits": [],
+            "repository": repository,
+            "pusher": {"name": "octocat"},
+            "sender": sender,
+        },
+    }
+
+    for configured_event in GITHUB_AUTHENTICATED_EVENTS:
+        route = bind({"provider": "github", "events": [configured_event]})
+        for payload_event, payload in payloads.items():
+            if configured_event == payload_event:
+                validate_authenticated_event_body(route, configured_event, payload)
+            else:
+                with pytest.raises(WebhookContractError, match="payload shape"):
+                    validate_authenticated_event_body(
+                        route,
+                        configured_event,
+                        payload,
+                    )
+
+    # Even if a future body happened to satisfy two registered predicates,
+    # it cannot inherit either event authority.
+    ambiguous = dict(payloads["pull_request"])
+    ambiguous.update(payloads["issues"])
+    ambiguous["action"] = "edited"
+    with pytest.raises(WebhookContractError, match="payload shape"):
+        validate_authenticated_event_body(
+            bind({"provider": "github", "events": ["pull_request"]}),
+            "pull_request",
+            ambiguous,
+        )
+
+    deployment_status = {
+        "action": "created",
+        "check_run": {"id": 401, "name": "deploy", "status": "queued"},
+        "deployment": {"id": 301},
+        "deployment_status": {"id": 302, "state": "pending"},
+        "repository": repository,
+        "sender": sender,
+    }
+    with pytest.raises(WebhookContractError, match="payload shape"):
+        validate_authenticated_event_body(
+            bind({"provider": "github", "events": ["check_run"]}),
+            "check_run",
+            deployment_status,
+        )
+
+
+def test_github_uncovered_header_mutation_cannot_mint_replay_authority():
+    route = bind({"provider": "github", "events": ["pull_request"]})
+    body = _github_pull_request_body()
+    signature = _body_hmac(body)
+
+    first = verified_envelope(
+        route,
+        body,
+        {
+            "X-Hub-Signature-256": signature,
+            "X-GitHub-Delivery": "delivery-a",
+            "X-GitHub-Event": "pull_request",
+        },
+        trace_id="trace-a",
+    )
+    second = verified_envelope(
+        route,
+        body,
+        {
+            "X-Hub-Signature-256": signature,
+            "X-GitHub-Delivery": "delivery-b",
+            "X-GitHub-Event": "pull_request",
+        },
+        trace_id="trace-b",
+    )
+
+    assert first.delivery_identity is None
+    assert second.delivery_identity is None
+    assert (first.observed_delivery_id, second.observed_delivery_id) == (
+        "delivery-a",
+        "delivery-b",
+    )
+    assert first.replay_identity == second.replay_identity
+    assert (
+        first.replay_identity.kind
+        is WebhookReplayIdentityKind.AUTHENTICATED_BODY_SHA256
+    )
+
+    receipt = _Verifier()._verify_signature_receipt(
+        _Request({
+            "X-Hub-Signature-256": signature,
+            "X-GitHub-Delivery": "delivery-c",
+            "X-GitHub-Event": "workflow_run",
+        }),
+        body,
+        "secret",
+        route,
+    )
+    assert receipt is not None
+    with pytest.raises(WebhookContractError, match="route-bound event authority"):
+        WebhookEnvelope.from_receipt(
+            receipt,
+            raw_body=body,
+            media_type="application/json",
+        )
+
+
+def test_signed_github_ping_body_cannot_be_relabelled_as_pull_request():
+    route = bind({"provider": "github", "events": ["pull_request"]})
+    body = json.dumps(
+        {
+            "zen": "Keep it logically awesome.",
+            "hook_id": 12345,
+            "hook": {"id": 12345, "type": "Repository", "name": "web"},
+            "repository": {"id": 801, "full_name": "org/repo"},
+            "sender": {"id": 901, "login": "octocat"},
+        },
+        separators=(",", ":"),
+    ).encode()
+    receipt = _Verifier()._verify_signature_receipt(
+        _Request({
+            "X-Hub-Signature-256": _body_hmac(body),
+            # This unsigned header is the attempted privilege relabel.
+            "X-GitHub-Event": "pull_request",
+        }),
+        body,
+        "secret",
+        route,
+    )
+
+    assert receipt is not None
+    with pytest.raises(
+        WebhookContractError,
+        match="payload shape does not match route-bound event 'pull_request'",
+    ):
+        WebhookEnvelope.from_receipt(
+            receipt,
+            raw_body=body,
+            media_type="application/json",
+        )
+
+
+def test_gitlab_credential_receipt_uses_fixed_event_and_body_replay_fence():
+    route = bind({"provider": "gitlab", "events": ["Push Hook"]})
+    body = b'{"object_kind":"push","before":"abc"}'
+    first = verified_envelope(
+        route,
+        body,
+        {
+            "X-Gitlab-Token": "secret",
+            "X-Gitlab-Event-UUID": "event-a",
+            "X-GitLab-Event": "Push Hook",
+        },
+    )
+    second = verified_envelope(
+        route,
+        body,
+        {
+            "X-Gitlab-Token": "secret",
+            "X-Gitlab-Event-UUID": "event-b",
+            "X-GitLab-Event": "Push Hook",
+        },
+    )
+    assert first.auth.coverage == WebhookVerificationCoverage.CREDENTIAL_ONLY.value
+    assert first.delivery_identity is None
+    assert first.event_type == "Push Hook"
+    assert first.observed_event_type == "Push Hook"
+    assert first.replay_identity == second.replay_identity
+    assert (
+        first.replay_identity.kind
+        is WebhookReplayIdentityKind.CREDENTIAL_OBSERVED_BODY_SHA256
+    )
+
+
+def test_hermes_outbound_headers_resolve_event_and_delivery_identity():
+    payload = {
+        "delivery_id": "hermes-delivery-1",
+        "hook_event_name": "post_tool_call",
+        "timestamp": "2026-08-27T00:00:00Z",
+    }
+    route = bind(
+        {"provider": "hermes"},
+        {
+            "X-Hermes-Signature-256": "sha256=value",
+            "X-Hermes-Delivery": "hermes-delivery-1",
+            "X-Hermes-Event": "post_tool_call",
+        },
+    )
+    identity = resolve_delivery_identity(
+        route,
+        {"X-Hermes-Delivery": "hermes-delivery-1"},
+        payload,
+    )
+    assert (route.provider, route.signature_mode) == ("hermes", "hermes")
+    assert identity is not None
+    assert identity.value == "hermes-delivery-1"
+    assert (
+        resolve_event_type(route, {"X-Hermes-Event": "post_tool_call"}, payload)
+        == "post_tool_call"
+    )
+
+
+@pytest.mark.parametrize("route", [[], "", 0, False])
+def test_falsey_non_object_route_config_is_rejected(route):
+    with pytest.raises(WebhookContractError, match="must be an object"):
+        bind(route)
+
+
+def test_hermes_unsigned_headers_must_match_authenticated_payload():
+    route = bind({"provider": "hermes"})
+    payload = {
+        "delivery_id": "real-delivery",
+        "hook_event_name": "real-event",
+    }
+    with pytest.raises(WebhookContractError, match="delivery metadata"):
+        resolve_delivery_identity(
+            route,
+            {"X-Hermes-Delivery": "attacker-delivery"},
+            payload,
+        )
+    with pytest.raises(WebhookContractError, match="event metadata"):
+        resolve_event_type(
+            route,
+            {"X-Hermes-Event": "attacker-event"},
+            payload,
+        )
+
+
+@pytest.mark.parametrize(
+    ("provider", "id_header", "timestamp_header", "signature_header", "msg_id"),
+    [
+        ("svix", "svix-id", "svix-timestamp", "svix-signature", "msg_1"),
+        (
+            "standard_webhooks",
+            "webhook-id",
+            "webhook-timestamp",
+            "webhook-signature",
+            "wh_1",
+        ),
+    ],
+)
+def test_message_id_signature_promotes_exact_native_identity(
+    provider,
+    id_header,
+    timestamp_header,
+    signature_header,
+    msg_id,
+):
+    route = bind({"provider": provider})
+    body = b'{"type":"message.received"}'
+    timestamp = str(int(time.time()))
+    envelope = verified_envelope(
+        route,
+        body,
+        {
+            id_header: msg_id,
+            timestamp_header: timestamp,
+            signature_header: _svix_signature(body, "secret", msg_id, timestamp),
+        },
+    )
+    assert envelope.delivery_identity is not None
+    assert envelope.delivery_identity.value == msg_id
+    assert envelope.replay_identity.kind is (
+        WebhookReplayIdentityKind.AUTHENTICATED_DELIVERY
+    )
+    assert envelope.replay_identity.value == msg_id
+
+
+def test_chatwoot_uncovered_delivery_header_cannot_change_replay_identity():
+    route = bind({"provider": "chatwoot", "signature_mode": "generic_v2"})
+    body = b'{"event":"message_created","conversation":{"id":17}}'
+    timestamp = str(int(time.time()))
+    signature = hmac.new(
+        b"secret",
+        timestamp.encode() + b"." + body,
+        hashlib.sha256,
+    ).hexdigest()
+    base_headers = {
+        "X-Webhook-Timestamp": timestamp,
+        "X-Webhook-Signature-V2": signature,
+    }
+    first = verified_envelope(
+        route,
+        body,
+        {**base_headers, "X-Chatwoot-Delivery": "delivery-a"},
+    )
+    second = verified_envelope(
+        route,
+        body,
+        {**base_headers, "X-Chatwoot-Delivery": "delivery-b"},
+    )
+    assert first.delivery_identity is None
+    assert first.event_type == "message_created"
+    assert first.replay_identity == second.replay_identity
+    assert first.observed_delivery_id == "delivery-a"
+    assert second.observed_delivery_id == "delivery-b"
+
+
+def test_hermes_and_stripe_promote_authenticated_body_ids():
+    hermes_delivery = "hermes-1"
+    hermes_body = json.dumps({
+        "delivery_id": hermes_delivery,
+        "hook_event_name": "post_tool_call",
+        "timestamp": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+    }).encode()
+    hermes = verified_envelope(
+        bind({"provider": "hermes"}),
+        hermes_body,
+        {
+            "X-Hermes-Signature-256": _body_hmac(hermes_body),
+            "X-Hermes-Delivery": hermes_delivery,
+            "X-Hermes-Event": "post_tool_call",
+        },
+    )
+    assert hermes.delivery_identity is not None
+    assert hermes.delivery_identity.value == hermes_delivery
+    assert (
+        hermes.replay_identity.kind is WebhookReplayIdentityKind.AUTHENTICATED_DELIVERY
+    )
+
+    stripe_body = b'{"id":"evt_123","type":"invoice.paid"}'
+    stripe_timestamp = str(int(time.time()))
+    stripe_signature = hmac.new(
+        b"whsec_test",
+        stripe_timestamp.encode() + b"." + stripe_body,
+        hashlib.sha256,
+    ).hexdigest()
+    stripe = verified_envelope(
+        bind({"provider": "stripe"}),
+        stripe_body,
+        {"Stripe-Signature": f"t={stripe_timestamp},v1={stripe_signature}"},
+        secret="whsec_test",
+    )
+    assert stripe.delivery_identity is not None
+    assert stripe.delivery_identity.value == "evt_123"
+    assert stripe.event_type == "invoice.paid"
+    assert (
+        stripe.replay_identity.kind is WebhookReplayIdentityKind.AUTHENTICATED_DELIVERY
+    )
+
+
+def test_body_only_mode_uses_labeled_authenticated_body_replay_fence():
+    envelope = make_envelope(
+        bind({"provider": "generic", "signature_mode": "generic_v1"}),
+        b'{"type":"tick"}',
+        headers={"X-Webhook-Signature": "sig"},
+        trace_id="trace-1",
+    )
+    assert envelope.delivery_identity is None
+    assert (
+        envelope.replay_identity.kind
+        is WebhookReplayIdentityKind.AUTHENTICATED_BODY_SHA256
+    )
+    assert (
+        envelope.replay_identity.value == hashlib.sha256(b'{"type":"tick"}').hexdigest()
+    )
+    assert "authenticated_body_sha256" in envelope.idempotency_key
+    assert envelope.delivery_id == "trace-1"
+
+
+def test_timestamp_headers_are_never_delivery_identity():
+    body = b"{}"
+    timestamp = str(int(time.time()))
+    signature = hmac.new(
+        b"secret",
+        timestamp.encode() + b"." + body,
+        hashlib.sha256,
+    ).hexdigest()
+    envelope = verified_envelope(
+        bind({"provider": "generic"}),
+        body,
+        headers={
+            "X-Webhook-Timestamp": timestamp,
+            "X-Webhook-Signature-V2": signature,
+        },
+        trace_id="trace-2",
+    )
+    assert envelope.delivery_identity is None
+    expected = hashlib.sha256(
+        timestamp.encode() + b"." + hashlib.sha256(body).hexdigest().encode()
+    ).hexdigest()
+    assert (
+        envelope.replay_identity.kind
+        is WebhookReplayIdentityKind.AUTHENTICATED_TIMESTAMP_BODY_SHA256
+    )
+    assert envelope.replay_identity.value == expected
+    assert timestamp not in envelope.idempotency_key
+
+
+def test_fresh_signed_timestamps_distinguish_identical_authenticated_bodies():
+    body = b'{"type":"tick"}'
+    route = bind({"provider": "generic"})
+    now = int(time.time())
+
+    def envelope(timestamp: int):
+        timestamp_text = str(timestamp)
+        signature = hmac.new(
+            b"secret",
+            timestamp_text.encode() + b"." + body,
+            hashlib.sha256,
+        ).hexdigest()
+        return verified_envelope(
+            route,
+            body,
+            {
+                "X-Webhook-Timestamp": timestamp_text,
+                "X-Webhook-Signature-V2": signature,
+            },
+        )
+
+    first = envelope(now)
+    second = envelope(now + 1)
+
+    assert first.body_sha256 == second.body_sha256
+    assert first.replay_identity != second.replay_identity
+    assert (
+        first.replay_identity.kind
+        is WebhookReplayIdentityKind.AUTHENTICATED_TIMESTAMP_BODY_SHA256
+    )
+
+
+def test_payload_id_is_accepted_only_for_registered_explicit_provider():
+    explicit = bind({"provider": "stripe"})
+    identity = resolve_delivery_identity(explicit, {}, {"id": "evt_123"})
+    assert identity is not None
+    assert (identity.provider, identity.value) == ("stripe", "evt_123")
+
+
+def test_chatwoot_does_not_treat_payload_id_as_delivery_authority():
+    route = bind({"provider": "chatwoot", "signature_mode": "generic_v2"})
+    assert resolve_delivery_identity(route, {}, {"id": 17}) is None
+    assert resolve_event_type(route, {}, {"event": "message_created"}) == (
+        "message_created"
+    )
+
+
+def test_idempotency_scope_and_session_trace_are_qualified_and_distinct():
+    route = WebhookRouteConfig.bind(
+        "deploy",
+        {"profile": "ops", "provider": "github"},
+        headers={},
+        request_profile="ops",
+    )
+    envelope = make_envelope(
+        route,
+        b"{}",
+        headers={"X-GitHub-Delivery": "abc"},
+        trace_id="trace-3",
+    )
+    body_hash = hashlib.sha256(b"{}").hexdigest()
+    assert envelope.delivery_identity is None
+    assert envelope.observed_delivery_id == "abc"
+    assert envelope.idempotency_scope == (
+        "ops",
+        "deploy",
+        "github",
+        f"authenticated_body_sha256:{body_hash}",
+    )
+    assert envelope.session_key == "webhook:ops:deploy:github:trace-3"
+    assert "abc" not in envelope.session_key
+
+
+def test_route_profile_mismatch_and_malformed_boolean_fail_closed():
+    with pytest.raises(WebhookRouteScopeError, match="not bound to profile"):
+        WebhookRouteConfig.bind(
+            "deploy",
+            {"profile": "ops", "provider": "github"},
+            headers={},
+            request_profile="default",
+        )
+    with pytest.raises(WebhookContractError, match="enabled must be a boolean"):
+        bind({"provider": "github", "enabled": "false"})
+
+
+def test_envelope_captures_body_hash_and_auth_provenance():
+    raw_body = _github_pull_request_body()
+    envelope = make_envelope(
+        bind({
+            "provider": "github",
+            "signature_mode": "github",
+            "events": ["pull_request"],
+        }),
+        raw_body,
+        headers={
+            "X-GitHub-Delivery": "delivery-1",
+            "X-GitHub-Event": "pull_request",
+        },
+        trace_id="trace-4",
+    )
+    assert envelope.event_type == "pull_request"
+    assert envelope.auth.provider == "github"
+    assert envelope.auth.signature_mode == "github"
+    assert envelope.auth.coverage == WebhookVerificationCoverage.BODY_MAC.value
+    assert envelope.auth.compatibility_inferred is False
+    assert envelope.auth.verified is True
+    assert envelope.body_sha256 == hashlib.sha256(raw_body).hexdigest()
+
+
+def test_local_bypass_is_explicit_and_other_unverified_envelopes_refuse():
+    route = bind({"provider": "generic"})
+    envelope = make_envelope(
+        route,
+        b"{}",
+        bypass=True,
+    )
+    assert envelope.auth.verified is False
+    assert envelope.auth.bypass == "insecure_local_test"
+    assert envelope.auth.coverage == WebhookVerificationCoverage.LOCAL_BYPASS.value
+    assert envelope.delivery_identity is None
+    assert (
+        envelope.replay_identity.kind
+        is WebhookReplayIdentityKind.LOCAL_BYPASS_BODY_SHA256
+    )
+    assert envelope.replay_identity.value == hashlib.sha256(b"{}").hexdigest()
+    with pytest.raises(WebhookContractError, match="exact verification receipt"):
+        WebhookEnvelope.from_receipt(
+            True,
+            raw_body=b"{}",
+            media_type="application/json",
+        )
+
+
+def test_envelope_payload_is_recursive_snapshot_and_mutable_copy_is_detached():
+    envelope = make_envelope(
+        bind({"provider": "generic"}),
+        b'{"outer":{"items":[1,{"x":2}]}}',
+    )
+    with pytest.raises(TypeError):
+        envelope.payload["new"] = 1  # type: ignore[index]
+    with pytest.raises(TypeError):
+        envelope.payload["outer"]["new"] = 1  # type: ignore[index]
+    mutable = envelope.mutable_payload()
+    mutable["outer"]["items"][1]["x"] = 7
+    assert envelope.payload["outer"]["items"][1]["x"] == 2
+
+
+def test_envelope_rejects_bytes_not_covered_by_receipt():
+    route = bind({"provider": "generic"})
+    receipt = WebhookSignatureVerificationReceipt._issue(
+        route,
+        b'{"trusted":true}',
+        {},
+    )
+    with pytest.raises(WebhookContractError, match="does not cover"):
+        WebhookEnvelope.from_receipt(
+            receipt,
+            raw_body=b'{"trusted":false}',
+            media_type="application/json",
+        )
+
+
+def test_envelope_rejects_media_type_reinterpretation_of_signed_bytes():
+    with pytest.raises(WebhookContractError, match="JSON semantics"):
+        make_envelope(
+            bind({"provider": "generic"}),
+            b'{"amount":"1","admin":"true"}',
+            media_type="application/x-www-form-urlencoded",
+        )
+
+
+def test_hermes_authenticated_timestamp_must_be_fresh():
+    raw_body = (
+        b'{"delivery_id":"delivery-1","hook_event_name":"post_tool_call",'
+        b'"timestamp":"2026-08-27T00:00:00Z"}'
+    )
+    with pytest.raises(WebhookContractError, match="outside replay window"):
+        make_envelope(
+            bind({"provider": "hermes"}),
+            raw_body,
+            headers={
+                "X-Hermes-Delivery": "delivery-1",
+                "X-Hermes-Event": "post_tool_call",
+            },
+        )
+
+
+def test_envelope_cannot_be_constructed_outside_the_build_gate():
+    with pytest.raises(TypeError):
+        WebhookEnvelope(  # type: ignore[call-arg]
+            route=bind({"provider": "generic"}),
+            auth=None,
+            event_type="forged",
+            delivery_identity=None,
+            trace_id="forged",
+            body_sha256="forged",
+            payload={},
+        )
+
+
+def test_malformed_route_events_are_rejected():
+    with pytest.raises(WebhookContractError, match="events must be a sequence"):
+        bind({"provider": "github", "events": "push"})
+
+
+@pytest.mark.parametrize(
+    "events",
+    [None, "", [1], ["push", ""], {"push"}],
+)
+def test_route_event_authority_is_not_coerced_or_unordered(events):
+    with pytest.raises(WebhookContractError, match="events must"):
+        bind({"provider": "github", "events": events})

--- a/tests/gateway/test_webhook_custom_signature.py
+++ b/tests/gateway/test_webhook_custom_signature.py
@@ -1,0 +1,323 @@
+"""Frozen route-configurable webhook HMAC authority."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import time
+from dataclasses import FrozenInstanceError
+
+import pytest
+from aiohttp.test_utils import make_mocked_request
+from multidict import CIMultiDict
+
+from gateway.config import PlatformConfig
+from gateway.platforms.webhook import WebhookAdapter
+from gateway.platforms.webhook_auth import WebhookVerificationCoverage
+from gateway.platforms.webhook_common import _authentication_key_fingerprints
+from gateway.platforms.webhook_contract import (
+    WebhookContractError,
+    WebhookRouteConfig,
+)
+
+
+def _adapter() -> WebhookAdapter:
+    return WebhookAdapter(PlatformConfig(enabled=True, extra={"routes": {}}))
+
+
+def _route(signature: dict) -> WebhookRouteConfig:
+    return WebhookRouteConfig.bind(
+        "events",
+        {"provider": "custom", "signature": signature},
+        headers={},
+        request_profile="default",
+    )
+
+
+def _request(headers):
+    return make_mocked_request(
+        "POST",
+        "/webhooks/events",
+        headers=headers,
+        match_info={"route_name": "events"},
+    )
+
+
+def test_custom_signature_is_normalized_and_frozen_at_route_bind():
+    route = _route({
+        "header": "ElevenLabs-Signature",
+        "signature_part": "v0",
+        "timestamp_part": "t",
+        "template": "{timestamp}.{body}",
+        "algorithm": "HMAC-SHA256",
+        "encoding": "hex",
+        "timestamp_unit": "seconds",
+        "tolerance_seconds": 1800,
+    })
+
+    assert route.provider == "custom"
+    assert route.signature_mode == "custom_hmac"
+    assert route.custom_signature is not None
+    assert route.custom_signature.header == "elevenlabs-signature"
+    assert route.custom_signature.algorithm == "sha256"
+    assert route.custom_signature.timestamp_unit == "seconds"
+    with pytest.raises(FrozenInstanceError):
+        route.custom_signature.header = "x-other"  # type: ignore[misc]
+
+
+def test_labeled_timestamp_signature_accepts_one_matching_candidate():
+    adapter = _adapter()
+    body = b'{"event":"transcript"}'
+    secret = "eleven-secret"
+    timestamp = str(int(time.time()))
+    digest = hmac.new(
+        secret.encode(),
+        timestamp.encode() + b"." + body,
+        hashlib.sha256,
+    ).hexdigest()
+    route = _route({
+        "header": "ElevenLabs-Signature",
+        "signature_part": "v0",
+        "timestamp_part": "t",
+        "template": "{timestamp}.{body}",
+    })
+
+    receipt = adapter._verify_signature_receipt(
+        _request({"ElevenLabs-Signature": f"junk,t={timestamp},v0=bad,v0={digest}"}),
+        body,
+        secret,
+        route,
+    )
+
+    assert receipt is not None
+    assert receipt.coverage is WebhookVerificationCoverage.TIMESTAMP_BODY_MAC
+    assert receipt.signed_timestamp == timestamp
+
+
+def test_custom_mode_never_falls_back_to_a_valid_native_header():
+    adapter = _adapter()
+    body = b"body"
+    secret = "secret"
+    github = "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+    route = _route({"header": "X-Custom-Signature", "template": "{body}"})
+
+    assert (
+        adapter._verify_signature_receipt(
+            _request({"X-Hub-Signature-256": github}),
+            body,
+            secret,
+            route,
+        )
+        is None
+    )
+
+
+def test_conflicting_timestamps_and_duplicate_physical_headers_fail_closed():
+    adapter = _adapter()
+    body = b"body"
+    secret = "secret"
+    timestamp = str(int(time.time()))
+    digest = hmac.new(
+        secret.encode(), timestamp.encode() + b"." + body, hashlib.sha256
+    ).hexdigest()
+    route = _route({
+        "header": "X-Parts",
+        "signature_part": "v1",
+        "timestamp_part": "t",
+        "template": "{timestamp}.{body}",
+    })
+
+    assert (
+        adapter._verify_signature_receipt(
+            _request({"X-Parts": f"t={timestamp},t={int(timestamp) + 1},v1={digest}"}),
+            body,
+            secret,
+            route,
+        )
+        is None
+    )
+
+    headers = CIMultiDict()
+    headers.add("X-Parts", f"t={timestamp},v1={digest}")
+    headers.add("X-Parts", f"t={timestamp},v1={digest}")
+    assert (
+        adapter._verify_signature_receipt(
+            _request(headers),
+            body,
+            secret,
+            route,
+        )
+        is None
+    )
+
+
+@pytest.mark.parametrize("offset", [-360, 360])
+def test_custom_seconds_timestamp_window_is_symmetric(offset: int):
+    adapter = _adapter()
+    body = b"body"
+    secret = "secret"
+    timestamp = str(int(time.time()) + offset)
+    message = b"v0:" + timestamp.encode() + b":" + body
+    signature = hmac.new(secret.encode(), message, hashlib.sha256).hexdigest()
+    route = _route({
+        "header": "X-Slack-Signature",
+        "signature_prefix": "v0=",
+        "timestamp_header": "X-Slack-Request-Timestamp",
+        "template": "v0:{timestamp}:{body}",
+        "tolerance_seconds": 300,
+    })
+
+    assert (
+        adapter._verify_signature_receipt(
+            _request({
+                "X-Slack-Signature": f"v0={signature}",
+                "X-Slack-Request-Timestamp": timestamp,
+            }),
+            body,
+            secret,
+            route,
+        )
+        is None
+    )
+
+
+def test_sha512_base64_millisecond_signature_covers_raw_body():
+    adapter = _adapter()
+    body = b"\xff\x00raw-body"
+    secret = "secret"
+    timestamp = str(int(time.time() * 1000))
+    digest = hmac.new(
+        secret.encode(),
+        timestamp.encode() + b":" + body,
+        hashlib.sha512,
+    ).digest()
+    route = _route({
+        "header": "X-Custom-Signature",
+        "timestamp_header": "X-Custom-Timestamp",
+        "template": "{timestamp}:{body}",
+        "algorithm": "sha512",
+        "encoding": "base64",
+        "timestamp_unit": "milliseconds",
+    })
+
+    receipt = adapter._verify_signature_receipt(
+        _request({
+            "X-Custom-Signature": base64.b64encode(digest).decode("ascii"),
+            "X-Custom-Timestamp": timestamp,
+        }),
+        body,
+        secret,
+        route,
+    )
+    assert receipt is not None
+    assert receipt.coverage is WebhookVerificationCoverage.TIMESTAMP_BODY_MAC
+
+
+def test_body_only_sha1_alias_accepts_uppercase_hex_and_is_body_bound():
+    adapter = _adapter()
+    body = b"\xffbody"
+    secret = "legacy-provider-secret"
+    signature = hmac.new(secret.encode(), body, hashlib.sha1).hexdigest().upper()
+    route = _route({
+        "header": "X-Legacy-Signature",
+        "template": "{body}",
+        "algorithm": "hmac-sha1",
+    })
+
+    receipt = adapter._verify_signature_receipt(
+        _request({"X-Legacy-Signature": signature}),
+        body,
+        secret,
+        route,
+    )
+    assert receipt is not None
+    assert receipt.coverage is WebhookVerificationCoverage.BODY_MAC
+    assert (
+        adapter._verify_signature_receipt(
+            _request({"X-Legacy-Signature": signature}),
+            body + b"!",
+            secret,
+            route,
+        )
+        is None
+    )
+
+
+@pytest.mark.parametrize(
+    "signature",
+    [
+        {},
+        {"header": "Bad Header", "template": "{body}"},
+        {"header": "X-Sig", "template": "literal"},
+        {"header": "X-Sig", "template": "{body}{body}"},
+        {"header": "X-Sig", "template": "{body}{unknown}"},
+        {"header": "X-Sig", "template": "{body}{"},
+        {"header": "X-Sig", "timestamp_header": "X-Time", "template": "{body}"},
+        {"header": "X-Sig", "template": "{timestamp}.{body}"},
+        {
+            "header": "X-Sig",
+            "timestamp_header": "X-Time",
+            "timestamp_part": "t",
+            "template": "{timestamp}.{body}",
+        },
+        {
+            "header": "X-Sig",
+            "timestamp_header": "X-Sig",
+            "template": "{timestamp}.{body}",
+        },
+        {
+            "header": "X-Sig",
+            "signature_part": "v1",
+            "timestamp_part": "v1",
+            "template": "{timestamp}.{body}",
+        },
+        {"header": "X-Sig", "template": "{body}", "algorithm": "md5"},
+        {"header": "X-Sig", "template": "{body}", "encoding": "base64url"},
+        {"header": "X-Sig", "template": "{body}", "tolerance_seconds": 300},
+        {
+            "header": "X-Sig",
+            "timestamp_header": "X-Time",
+            "template": "{timestamp}.{body}",
+            "timestamp_unit": "minutes",
+        },
+        {
+            "header": "X-Sig",
+            "timestamp_header": "X-Time",
+            "template": "{timestamp}.{body}",
+            "tolerance_seconds": 86_401,
+        },
+        {"header": "X-Sig", "template": "{body}", "event_header": "X-Event"},
+    ],
+)
+def test_malformed_custom_signature_authority_is_rejected_at_bind(signature):
+    with pytest.raises(WebhookContractError):
+        _route(signature)
+
+
+def test_signature_block_is_exclusive_to_custom_hmac():
+    with pytest.raises(WebhookContractError):
+        WebhookRouteConfig.bind(
+            "events",
+            {
+                "provider": "github",
+                "signature": {"header": "X-Sig", "template": "{body}"},
+            },
+            headers={},
+        )
+    with pytest.raises(WebhookContractError):
+        WebhookRouteConfig.bind(
+            "events",
+            {"provider": "custom"},
+            headers={},
+        )
+
+
+def test_key_fingerprints_follow_selected_hmac_digest_and_token_exactness():
+    sha512_key = _authentication_key_fingerprints("key", "custom_hmac", "sha512")
+    sha512_padded = _authentication_key_fingerprints("key\0", "custom_hmac", "sha512")
+    assert sha512_key & sha512_padded
+
+    token = _authentication_key_fingerprints("key", "plain_token", None)
+    padded_token = _authentication_key_fingerprints("key\0", "plain_token", None)
+    assert not token & padded_token

--- a/tests/gateway/test_webhook_deliver_only.py
+++ b/tests/gateway/test_webhook_deliver_only.py
@@ -23,12 +23,18 @@ from aiohttp.test_utils import TestClient, TestServer
 
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import MessageEvent, SendResult
-from gateway.platforms.webhook import WebhookAdapter, _INSECURE_NO_AUTH
+from gateway.platforms.webhook import (
+    WebhookAdapter,
+    _INSECURE_NO_AUTH,
+    _PROFILE_AUTHORITY_INCARNATION_FILENAME,
+)
+from gateway.platforms.webhook_ledger import OperationState
 
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _make_adapter(routes, **extra_kw) -> WebhookAdapter:
     extra = {"host": "127.0.0.1", "port": 0, "routes": routes}
@@ -48,10 +54,15 @@ def _wire_mock_target(adapter: WebhookAdapter, platform_name: str = "telegram"):
     """Attach a gateway_runner with a mocked target adapter."""
     mock_target = AsyncMock()
     mock_target.send = AsyncMock(return_value=SendResult(success=True))
+    mock_target.config = PlatformConfig(enabled=True)
 
     mock_runner = MagicMock()
-    mock_runner.adapters = {Platform(platform_name): mock_target}
+    mock_runner.adapters = {
+        Platform.WEBHOOK: adapter,
+        Platform(platform_name): mock_target,
+    }
     mock_runner.config.get_home_channel.return_value = None
+    mock_runner._authorization_adapter = None
 
     adapter.gateway_runner = mock_runner
     return mock_target
@@ -61,6 +72,7 @@ def _wire_mock_target(adapter: WebhookAdapter, platform_name: str = "telegram"):
 # Core behaviour: agent bypass
 # ===================================================================
 
+
 class TestDeliverOnlyBypassesAgent:
     """The whole point of the feature — handle_message must not be called."""
 
@@ -69,6 +81,7 @@ class TestDeliverOnlyBypassesAgent:
         routes = {
             "match-alert": {
                 "secret": _INSECURE_NO_AUTH,
+                "provider": "github",
                 "deliver": "telegram",
                 "deliver_only": True,
                 "deliver_extra": {"chat_id": "12345"},
@@ -87,9 +100,7 @@ class TestDeliverOnlyBypassesAgent:
         adapter.handle_message = _capture
 
         app = _create_app(adapter)
-        body = json.dumps(
-            {"payload": {"user": "alice", "other": "bob"}}
-        ).encode()
+        body = json.dumps({"payload": {"user": "alice", "other": "bob"}}).encode()
 
         async with TestClient(TestServer(app)) as cli:
             resp = await cli.post(
@@ -104,7 +115,7 @@ class TestDeliverOnlyBypassesAgent:
             data = await resp.json()
             assert data["status"] == "delivered"
             assert data["route"] == "match-alert"
-            assert data["target"] == "telegram"
+            assert data["target"] == "platform"
 
         # Let any background tasks settle before asserting no agent call
         await asyncio.sleep(0.05)
@@ -124,14 +135,15 @@ class TestDeliverOnlyBypassesAgent:
 # HTTP status codes
 # ===================================================================
 
-class TestDeliverOnlyStatusCodes:
 
+class TestDeliverOnlyStatusCodes:
     @pytest.mark.asyncio
     async def test_delivery_failure_returns_502(self):
         """If the target adapter returns SendResult(success=False), 502."""
         routes = {
             "r": {
                 "secret": _INSECURE_NO_AUTH,
+                "provider": "github",
                 "deliver": "telegram",
                 "deliver_only": True,
                 "deliver_extra": {"chat_id": "c-1"},
@@ -154,7 +166,7 @@ class TestDeliverOnlyStatusCodes:
             assert resp.status == 502
             data = await resp.json()
             # Generic error — no adapter-level detail leaks
-            assert data["error"] == "Delivery failed"
+            assert data["error"] == "Webhook target outcome requires reconciliation"
             assert "rate limited" not in json.dumps(data)
 
 
@@ -162,15 +174,15 @@ class TestDeliverOnlyStatusCodes:
 # Startup validation
 # ===================================================================
 
+
 class TestDeliverOnlyStartupValidation:
-
-
     @pytest.mark.asyncio
     async def test_deliver_only_with_real_target_accepted(self):
         """Sanity check — a valid deliver_only config passes validation."""
         routes = {
             "good": {
                 "secret": _INSECURE_NO_AUTH,
+                "provider": "github",
                 "deliver": "telegram",
                 "deliver_only": True,
                 "deliver_extra": {"chat_id": "c-1"},
@@ -193,8 +205,8 @@ class TestDeliverOnlyStartupValidation:
 # Security + reliability invariants still hold
 # ===================================================================
 
-class TestDeliverOnlySecurityInvariants:
 
+class TestDeliverOnlySecurityInvariants:
     @pytest.mark.asyncio
     async def test_hmac_still_enforced(self):
         """deliver_only does NOT bypass HMAC validation."""
@@ -202,6 +214,7 @@ class TestDeliverOnlySecurityInvariants:
         routes = {
             "r": {
                 "secret": secret,
+                "provider": "github",
                 "deliver": "telegram",
                 "deliver_only": True,
                 "deliver_extra": {"chat_id": "c-1"},
@@ -226,25 +239,118 @@ class TestDeliverOnlySecurityInvariants:
 
 
 # ===================================================================
-# Unit: _direct_deliver dispatch
+# Durable GitHub target dispatch
 # ===================================================================
 
-class TestDirectDeliverUnit:
 
+class TestDirectDeliverUnit:
+    @pytest.mark.asyncio
+    async def test_profile_rotation_after_prepare_never_crosses_running_gate(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        adapter = _make_adapter({
+            "r": {
+                "secret": _INSECURE_NO_AUTH,
+                "provider": "github",
+                "deliver": "telegram",
+                "deliver_only": True,
+                "deliver_extra": {"chat_id": "c-1"},
+                "prompt": "must not deliver",
+            }
+        })
+        target = _wire_mock_target(adapter)
+        adapter._bind_route_authentication_authorities(adapter._routes)
+        token_path = tmp_path / _PROFILE_AUTHORITY_INCARNATION_FILENAME
+        prior_generation = adapter._authenticated_route_bundles["r"].profile_generation
+        original_prepare = adapter._operation_ledger.prepare
+        prepared_carriers = []
+
+        def rotate_after_prepare(*args, **kwargs):
+            prepared = original_prepare(*args, **kwargs)
+            prepared_carriers.append(prepared)
+            token_path.unlink()
+            return prepared
+
+        monkeypatch.setattr(
+            adapter._operation_ledger,
+            "prepare",
+            rotate_after_prepare,
+        )
+        mark_running = MagicMock(wraps=adapter._operation_ledger.mark_running)
+        monkeypatch.setattr(
+            adapter._operation_ledger,
+            "mark_running",
+            mark_running,
+        )
+
+        async with TestClient(TestServer(_create_app(adapter))) as cli:
+            response = await cli.post(
+                "/webhooks/r",
+                json={"event": "rotate-after-prepare"},
+                headers={"X-GitHub-Delivery": "direct-generation-seam"},
+            )
+
+            assert response.status == 409
+            assert (await response.json())["status"] == "indeterminate"
+
+        assert len(prepared_carriers) == 1
+        restored = adapter._operation_ledger.lookup_session(
+            prepared_carriers[0].session_key
+        )
+        assert restored is not None
+        assert restored.state is OperationState.INDETERMINATE
+        mark_running.assert_not_called()
+        target.send.assert_not_awaited()
+        assert token_path.read_text(encoding="ascii").strip() != prior_generation
 
     @pytest.mark.asyncio
     async def test_dispatches_to_github_comment(self):
-        adapter = _make_adapter({})
-        with patch.object(
-            adapter, "_deliver_github_comment",
-            new=AsyncMock(return_value=SendResult(success=True)),
-        ) as mock_gh:
-            result = await adapter._direct_deliver(
-                "review body",
-                {
-                    "deliver": "github_comment",
-                    "deliver_extra": {"repo": "org/r", "pr_number": "1"},
-                },
-            )
-            assert result.success is True
-            mock_gh.assert_awaited_once()
+        adapter = _make_adapter({
+            "review": {
+                "secret": _INSECURE_NO_AUTH,
+                "provider": "github",
+                "deliver": "github_comment",
+                "deliver_only": True,
+                "deliver_extra": {"repo": "org/r", "pr_number": "1"},
+                "prompt": "review body",
+            }
+        })
+        completed = MagicMock(returncode=0, stdout="posted", stderr="")
+        with (
+            patch(
+                "gateway.platforms.webhook_route_authority.shutil.which",
+                return_value="/usr/bin/gh",
+            ),
+            patch.object(
+                adapter,
+                "_run_github_comment",
+                return_value=completed,
+            ) as mock_gh,
+        ):
+            async with TestClient(TestServer(_create_app(adapter))) as cli:
+                response = await cli.post(
+                    "/webhooks/review",
+                    json={"number": 1},
+                    headers={"X-GitHub-Delivery": "direct-gh-1"},
+                )
+                assert response.status == 200
+                payload = await response.json()
+                assert payload["status"] == "delivered"
+                assert payload["settlement"] == "confirmed"
+
+        mock_gh.assert_called_once()
+        executable, target, content, environment = mock_gh.call_args.args
+        assert executable == "/usr/bin/gh"
+        assert target == {
+            "v": 1,
+            "kind": "github_comment",
+            "profile": "default",
+            "repo": "org/r",
+            "pr_number": 1,
+        }
+        assert content == "review body"
+        assert environment["GH_PROMPT_DISABLED"] == "1"
+        assert environment["GH_NO_UPDATE_NOTIFIER"] == "1"

--- a/tests/gateway/test_webhook_dynamic_routes.py
+++ b/tests/gateway/test_webhook_dynamic_routes.py
@@ -1,14 +1,20 @@
 """Tests for webhook adapter dynamic route loading."""
 
 import json
+import os
+from pathlib import Path
+
 import pytest
 
+import gateway.platforms.webhook_intake as webhook_intake_module
 from gateway.config import PlatformConfig
 from gateway.platforms.webhook import (
     WebhookAdapter,
     _DYNAMIC_ROUTES_FILENAME,
     _INSECURE_NO_AUTH,
 )
+from gateway.platforms.webhook_filters import BoundedRegularFileSnapshot
+from gateway.platforms.webhook_ledger import WebhookLedgerError
 
 
 def _make_adapter(routes=None, extra=None):
@@ -27,19 +33,57 @@ def _isolate(tmp_path, monkeypatch):
 
 class TestDynamicRouteLoading:
     def test_no_dynamic_file(self):
-        adapter = _make_adapter(routes={"static": {"secret": "s"}})
+        adapter = _make_adapter(
+            routes={"static": {"secret": "s", "provider": "generic"}}
+        )
         adapter._reload_dynamic_routes()
         assert "static" in adapter._routes
         assert len(adapter._dynamic_routes) == 0
 
     def test_loads_dynamic_routes(self, tmp_path):
-        subs = {"my-hook": {"secret": "dynamic-secret", "prompt": "test", "events": []}}
+        subs = {
+            "my-hook": {
+                "secret": "dynamic-secret",
+                "provider": "generic",
+                "prompt": "test",
+                "events": [],
+            }
+        }
         (tmp_path / _DYNAMIC_ROUTES_FILENAME).write_text(json.dumps(subs))
 
-        adapter = _make_adapter(routes={"static": {"secret": "s"}})
+        adapter = _make_adapter(
+            routes={"static": {"secret": "s", "provider": "generic"}}
+        )
         adapter._reload_dynamic_routes()
         assert "my-hook" in adapter._routes
         assert "static" in adapter._routes
+
+    def test_invalid_unicode_event_is_rejected_without_transient_retry(
+        self,
+        tmp_path,
+    ):
+        subscriptions = tmp_path / _DYNAMIC_ROUTES_FILENAME
+        subscriptions.write_text(
+            json.dumps({
+                "invalid-event": {
+                    "secret": "dynamic-secret",
+                    "provider": "github",
+                    "events": ["\udcff"],
+                }
+            }),
+            encoding="utf-8",
+        )
+        adapter = _make_adapter()
+
+        adapter._reload_dynamic_routes()
+
+        assert "invalid-event" not in adapter._routes
+        assert adapter._dynamic_routes_file_identity is not None
+        assert adapter._dynamic_routes_content_sha256 is not None
+        assert adapter._dynamic_routes_rejected_file_identity is None
+        assert adapter._dynamic_routes_rejected_content_sha256 is None
+        assert adapter._dynamic_routes_transient_file_identity is None
+        assert adapter._dynamic_routes_retry_after == 0.0
 
 
 class TestDynamicRouteSecretValidation:
@@ -57,7 +101,13 @@ class TestDynamicRouteSecretValidation:
         # Explicit empty-string secret must NOT fall back to the global
         # secret, and the route must be skipped entirely.
         (tmp_path / _DYNAMIC_ROUTES_FILENAME).write_text(
-            json.dumps({"evil": {"secret": "", "prompt": "rm -rf"}})
+            json.dumps({
+                "evil": {
+                    "secret": "",
+                    "provider": "generic",
+                    "prompt": "rm -rf",
+                }
+            })
         )
         adapter = _make_adapter()  # has global secret
         adapter._reload_dynamic_routes()
@@ -66,7 +116,7 @@ class TestDynamicRouteSecretValidation:
 
     def test_missing_secret_no_global_rejected(self, tmp_path):
         (tmp_path / _DYNAMIC_ROUTES_FILENAME).write_text(
-            json.dumps({"orphan": {"prompt": "test"}})
+            json.dumps({"orphan": {"provider": "generic", "prompt": "test"}})
         )
         # No global secret configured
         adapter = _make_adapter(extra={"secret": ""})
@@ -78,10 +128,416 @@ class TestDynamicRouteSecretValidation:
         # No per-route secret but a global one is set → route is kept,
         # the global secret protects it. Preserves existing fallback.
         (tmp_path / _DYNAMIC_ROUTES_FILENAME).write_text(
-            json.dumps({"valid": {"prompt": "ok"}})
+            json.dumps({"valid": {"provider": "generic", "prompt": "ok"}})
         )
         adapter = _make_adapter()  # global secret set
         adapter._reload_dynamic_routes()
         assert "valid" in adapter._routes
 
+    def test_dynamic_route_cannot_reuse_static_route_secret(self, tmp_path):
+        (tmp_path / _DYNAMIC_ROUTES_FILENAME).write_text(
+            json.dumps({
+                "dynamic": {
+                    "secret": "shared-secret",
+                    "provider": "generic",
+                }
+            })
+        )
+        adapter = _make_adapter(
+            routes={
+                "static": {
+                    "secret": "shared-secret",
+                    "provider": "github",
+                }
+            }
+        )
 
+        adapter._reload_dynamic_routes()
+
+        assert "dynamic" not in adapter._routes
+
+    def test_later_dynamic_route_cannot_reuse_sibling_secret(self, tmp_path):
+        subscriptions = tmp_path / _DYNAMIC_ROUTES_FILENAME
+        subscriptions.write_text(
+            json.dumps({
+                "first": {
+                    "secret": "dynamic-shared-secret",
+                    "provider": "generic",
+                }
+            })
+        )
+        adapter = _make_adapter()
+        adapter._reload_dynamic_routes()
+        assert set(adapter._dynamic_routes) == {"first"}
+
+        subscriptions.write_text(
+            json.dumps({
+                "first": {
+                    "secret": "dynamic-shared-secret",
+                    "provider": "generic",
+                },
+                "second": {
+                    "secret": "dynamic-shared-secret",
+                    "provider": "github",
+                },
+            })
+        )
+        adapter._reload_dynamic_routes()
+
+        assert set(adapter._dynamic_routes) == {"first"}
+
+    def test_conflicting_reordered_snapshot_keeps_last_known_good(self, tmp_path):
+        subscriptions = tmp_path / _DYNAMIC_ROUTES_FILENAME
+        subscriptions.write_text(
+            json.dumps({
+                "low": {
+                    "secret": "captured-shared-secret",
+                    "provider": "generic",
+                }
+            })
+        )
+        adapter = _make_adapter()
+        adapter._reload_dynamic_routes()
+        assert set(adapter._dynamic_routes) == {"low"}
+
+        subscriptions.write_text(
+            json.dumps({
+                "high": {
+                    "secret": "captured-shared-secret",
+                    "provider": "github",
+                    "toolsets": ["terminal"],
+                },
+                "low": {
+                    "secret": "captured-shared-secret",
+                    "provider": "generic",
+                },
+            })
+        )
+        adapter._reload_dynamic_routes()
+
+        assert set(adapter._dynamic_routes) == {"low"}
+        assert "high" not in adapter._routes
+
+    @pytest.mark.parametrize("mtime_delta_ns", [0, -2_000_000_000])
+    def test_content_change_loads_with_equal_or_older_mtime(
+        self,
+        tmp_path,
+        mtime_delta_ns,
+    ):
+        subscriptions = tmp_path / _DYNAMIC_ROUTES_FILENAME
+        subscriptions.write_text(
+            json.dumps({"hook": {"secret": "secret-one", "provider": "generic"}})
+        )
+        adapter = _make_adapter()
+        adapter._reload_dynamic_routes()
+        original = subscriptions.stat()
+
+        subscriptions.write_text(
+            json.dumps({"hook": {"secret": "secret-two", "provider": "generic"}})
+        )
+        os.utime(
+            subscriptions,
+            ns=(original.st_atime_ns, original.st_mtime_ns + mtime_delta_ns),
+        )
+        adapter._reload_dynamic_routes()
+
+        assert adapter._routes["hook"]["secret"] == "secret-two"
+
+    def test_unchanged_file_is_not_rehashed_within_integrity_interval(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        subscriptions = tmp_path / _DYNAMIC_ROUTES_FILENAME
+        subscriptions.write_text(
+            json.dumps({"hook": {"secret": "stable-secret", "provider": "generic"}})
+        )
+        adapter = _make_adapter()
+        real_snapshot = webhook_intake_module.read_bounded_regular_file_snapshot
+        reads = 0
+
+        def tracked_snapshot(path, *, max_bytes):
+            nonlocal reads
+            if path == subscriptions:
+                reads += 1
+            return real_snapshot(path, max_bytes=max_bytes)
+
+        monkeypatch.setattr(
+            webhook_intake_module,
+            "read_bounded_regular_file_snapshot",
+            tracked_snapshot,
+        )
+        adapter._reload_dynamic_routes()
+        adapter._reload_dynamic_routes()
+
+        assert reads == 1
+
+    def test_preserved_metadata_still_rehashes_changed_content(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        subscriptions = tmp_path / _DYNAMIC_ROUTES_FILENAME
+        first = json.dumps({
+            "hook": {"secret": "secret-one", "provider": "generic"}
+        }).encode()
+        second = json.dumps({
+            "hook": {"secret": "secret-two", "provider": "generic"}
+        }).encode()
+        assert len(first) == len(second)
+        subscriptions.write_bytes(first)
+        adapter = _make_adapter()
+        clock = [100.0]
+        monkeypatch.setattr(
+            webhook_intake_module.time,
+            "monotonic",
+            lambda: clock[0],
+        )
+        adapter._reload_dynamic_routes()
+        original_stat = subscriptions.stat()
+
+        subscriptions.write_bytes(second)
+        real_snapshot = webhook_intake_module.read_bounded_regular_file_snapshot
+        real_stat = Path.stat
+
+        def preserved_metadata(path, *args, **kwargs):
+            if path == subscriptions:
+                return original_stat
+            return real_stat(path, *args, **kwargs)
+
+        def preserved_snapshot(path, *, max_bytes):
+            snapshot = real_snapshot(path, max_bytes=max_bytes)
+            if path == subscriptions:
+                return BoundedRegularFileSnapshot(snapshot.content, original_stat)
+            return snapshot
+
+        monkeypatch.setattr(Path, "stat", preserved_metadata)
+        monkeypatch.setattr(
+            webhook_intake_module,
+            "read_bounded_regular_file_snapshot",
+            preserved_snapshot,
+        )
+
+        adapter._reload_dynamic_routes()
+        assert adapter._routes["hook"]["secret"] == "secret-one"
+
+        clock[0] += (
+            webhook_intake_module._DYNAMIC_ROUTES_CONTENT_RECHECK_SECONDS + 0.001
+        )
+        adapter._reload_dynamic_routes()
+
+        assert adapter._routes["hook"]["secret"] == "secret-two"
+
+    def test_malformed_replacement_withdraws_previous_dynamic_routes(
+        self,
+        tmp_path,
+    ):
+        subscriptions = tmp_path / _DYNAMIC_ROUTES_FILENAME
+        subscriptions.write_text(
+            json.dumps({"hook": {"secret": "revoked-secret", "provider": "generic"}})
+        )
+        adapter = _make_adapter()
+        adapter._reload_dynamic_routes()
+        assert "hook" in adapter._routes
+        profile = str(adapter._authenticated_route_bundles["hook"].authority[0])
+        assert adapter._record_rate_limit_hit("hook", 1.0, profile=profile)
+        assert (profile, "hook") in adapter._rate_counts
+
+        subscriptions.write_text('{"hook":')
+        adapter._reload_dynamic_routes()
+
+        assert adapter._dynamic_routes == {}
+        assert "hook" not in adapter._routes
+        assert (profile, "hook") not in adapter._rate_counts
+
+    def test_route_name_churn_does_not_retain_rate_limit_buckets(self, tmp_path):
+        subscriptions = tmp_path / _DYNAMIC_ROUTES_FILENAME
+        adapter = _make_adapter()
+
+        for index in range(24):
+            route_name = f"rotated-{index}"
+            subscriptions.write_text(
+                json.dumps({
+                    route_name: {
+                        "secret": f"route-secret-{index}",
+                        "provider": "generic",
+                    }
+                })
+            )
+            adapter._reload_dynamic_routes()
+            bundle = adapter._authenticated_route_bundles[route_name]
+            profile = str(bundle.authority[0])
+            assert adapter._record_rate_limit_hit(
+                route_name,
+                float(index),
+                profile=profile,
+            )
+            assert set(adapter._rate_counts) == {(profile, route_name)}
+
+        assert len(adapter._rate_counts) == 1
+
+    def test_deep_dynamic_json_is_a_deterministic_rejected_snapshot(self, tmp_path):
+        subscriptions = tmp_path / _DYNAMIC_ROUTES_FILENAME
+        subscriptions.write_text(
+            '{"hook":{"secret":"deep-secret","provider":"generic","filters":'
+            + '{"not":' * 1_200
+            + '{"field":"x","equals":1}'
+            + "}" * 1_200
+            + "}}",
+            encoding="utf-8",
+        )
+        adapter = _make_adapter()
+
+        adapter._reload_dynamic_routes()
+
+        assert adapter._dynamic_routes == {}
+        assert "hook" not in adapter._routes
+        assert adapter._dynamic_routes_rejected_file_identity is not None
+
+    def test_same_key_policy_change_withdraws_old_route(self, tmp_path):
+        subscriptions = tmp_path / _DYNAMIC_ROUTES_FILENAME
+        subscriptions.write_text(
+            json.dumps({
+                "hook": {
+                    "secret": "policy-secret",
+                    "provider": "generic",
+                    "enabled": True,
+                }
+            })
+        )
+        adapter = _make_adapter()
+        adapter._reload_dynamic_routes()
+        assert "hook" in adapter._routes
+        profile = str(adapter._authenticated_route_bundles["hook"].authority[0])
+        assert adapter._record_rate_limit_hit("hook", 1.0, profile=profile)
+
+        subscriptions.write_text(
+            json.dumps({
+                "hook": {
+                    "secret": "policy-secret",
+                    "provider": "generic",
+                    "enabled": False,
+                }
+            })
+        )
+        adapter._reload_dynamic_routes()
+
+        assert adapter._dynamic_routes == {}
+        assert "hook" not in adapter._routes
+        assert (profile, "hook") not in adapter._rate_counts
+
+    def test_file_deletion_revokes_dynamic_route_even_if_static_bind_fails(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        subscriptions = tmp_path / _DYNAMIC_ROUTES_FILENAME
+        subscriptions.write_text(
+            json.dumps({"hook": {"secret": "deleted-secret", "provider": "generic"}})
+        )
+        adapter = _make_adapter(
+            routes={"static": {"secret": "static-secret", "provider": "generic"}}
+        )
+        adapter._reload_dynamic_routes()
+        assert "hook" in adapter._routes
+        profile = str(adapter._authenticated_route_bundles["hook"].authority[0])
+        assert adapter._record_rate_limit_hit("hook", 1.0, profile=profile)
+        assert adapter._record_rate_limit_hit("static", 1.0, profile=profile)
+
+        subscriptions.unlink()
+
+        def fail_static_bind(_routes):
+            raise WebhookLedgerError("root authority store unavailable")
+
+        monkeypatch.setattr(
+            adapter,
+            "_bind_route_authentication_authorities",
+            fail_static_bind,
+        )
+        adapter._reload_dynamic_routes()
+
+        assert adapter._dynamic_routes == {}
+        assert set(adapter._routes) == {"static"}
+        assert adapter._dynamic_routes_file_present is False
+        assert (profile, "hook") not in adapter._rate_counts
+        assert (profile, "static") in adapter._rate_counts
+
+    def test_transient_bind_failure_withdraws_changed_dynamic_authority(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        subscriptions = tmp_path / _DYNAMIC_ROUTES_FILENAME
+        subscriptions.write_text(
+            json.dumps({"hook": {"secret": "old-secret", "provider": "generic"}})
+        )
+        adapter = _make_adapter()
+        adapter._reload_dynamic_routes()
+        assert adapter._routes["hook"]["secret"] == "old-secret"
+
+        subscriptions.write_text(
+            json.dumps({"hook": {"secret": "new-secret", "provider": "generic"}})
+        )
+
+        def fail_bind(_routes):
+            raise OSError("temporary authority store failure")
+
+        monkeypatch.setattr(
+            adapter,
+            "_bind_route_authentication_authorities",
+            fail_bind,
+        )
+        adapter._reload_dynamic_routes()
+
+        assert adapter._dynamic_routes == {}
+        assert "hook" not in adapter._routes
+        assert adapter._dynamic_routes_transient_file_identity is not None
+
+    def test_stat_race_after_exists_withdraws_old_dynamic_authority(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        subscriptions = tmp_path / _DYNAMIC_ROUTES_FILENAME
+        subscriptions.write_text(
+            json.dumps({"hook": {"secret": "old-secret", "provider": "generic"}})
+        )
+        adapter = _make_adapter()
+        adapter._reload_dynamic_routes()
+        assert "hook" in adapter._routes
+
+        real_stat = Path.stat
+        real_exists = Path.exists
+
+        def raced_exists(path):
+            if path == subscriptions:
+                return True
+            return real_exists(path)
+
+        def raced_stat(path, *args, **kwargs):
+            if path == subscriptions:
+                raise FileNotFoundError("removed after exists")
+            return real_stat(path, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "exists", raced_exists)
+        monkeypatch.setattr(Path, "stat", raced_stat)
+        adapter._reload_dynamic_routes()
+
+        assert adapter._dynamic_routes == {}
+        assert "hook" not in adapter._routes
+
+    @pytest.mark.parametrize("name", [" route", "route ", "Route", "r" * 129])
+    def test_dynamic_route_name_must_be_canonical(self, tmp_path, name):
+        (tmp_path / _DYNAMIC_ROUTES_FILENAME).write_text(
+            json.dumps({
+                name: {
+                    "secret": f"secret-{len(name)}-{name[:1]}",
+                    "provider": "generic",
+                }
+            })
+        )
+        adapter = _make_adapter()
+
+        adapter._reload_dynamic_routes()
+
+        assert name not in adapter._routes

--- a/tests/gateway/test_webhook_effective_authority_freeze.py
+++ b/tests/gateway/test_webhook_effective_authority_freeze.py
@@ -1,0 +1,970 @@
+"""Regressions for immutable webhook execution-authority publication."""
+
+import asyncio
+import concurrent.futures
+import hashlib
+import hmac
+import json
+import os
+import threading
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+import gateway.platforms.webhook_intake as webhook_intake_module
+from gateway.config import HomeChannel, Platform, PlatformConfig
+from gateway.platforms.webhook import (
+    WebhookAdapter,
+    _PROFILE_AUTHORITY_INCARNATION_FILENAME,
+    _clear_quarantined_retirement_owner,
+    _profile_incarnation_token,
+    _quarantined_retirement_owners,
+)
+from gateway.platforms.webhook_filters import (
+    WebhookScriptDisposition,
+    WebhookScriptResult,
+)
+from gateway.platforms.webhook_contract import WebhookContractError
+
+
+@pytest.fixture(autouse=True)
+def _isolated_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+
+def _adapter(route: dict, *, secret: str = "authority-secret") -> WebhookAdapter:
+    route = {
+        "secret": secret,
+        "signature_mode": "generic_v1",
+        **route,
+    }
+    return WebhookAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={
+                "host": "127.0.0.1",
+                "port": 0,
+                "routes": {"events": route},
+            },
+        )
+    )
+
+
+def _app(adapter: WebhookAdapter) -> web.Application:
+    app = web.Application(client_max_size=adapter._max_body_bytes)
+    app.router.add_post("/webhooks/{route_name}", adapter._handle_webhook)
+    return app
+
+
+def _signed(payload: dict, secret: str = "authority-secret"):
+    body = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode()
+    signature = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+    return body, {
+        "Content-Type": "application/json",
+        "X-Webhook-Signature": signature,
+    }
+
+
+def _request(body: bytes, headers: dict[str, str]):
+    async def read():
+        return body
+
+    return SimpleNamespace(
+        headers=headers,
+        content_length=len(body),
+        match_info={"route_name": "events"},
+        read=read,
+    )
+
+
+@pytest.mark.asyncio
+async def test_deep_authenticated_json_is_rejected_as_payload_contract_error():
+    adapter = _adapter({"prompt": "never-run"})
+    adapter.handle_message = AsyncMock()
+    adapter._bind_route_authentication_authorities(adapter._routes)
+    body = b'{"value":' + b"[" * 500 + b"0" + b"]" * 500 + b"}"
+    signature = hmac.new(
+        b"authority-secret",
+        body,
+        hashlib.sha256,
+    ).hexdigest()
+
+    response = await adapter._handle_webhook(
+        _request(
+            body,
+            {
+                "Content-Type": "application/json",
+                "X-Webhook-Signature": signature,
+            },
+        )
+    )
+
+    assert response.status == 400
+    assert b"Invalid authenticated webhook payload" in response.body
+    assert adapter._operation_ledger.count() == 0
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_filter_file_change_after_signature_cannot_widen_frozen_filter(
+    tmp_path,
+):
+    watchlist = tmp_path / "watchlist.json"
+    watchlist.write_text('["allowed"]', encoding="utf-8")
+    adapter = _adapter({
+        "filters": {
+            "field": "actor",
+            "in_file": "watchlist.json",
+        },
+        "prompt": "actor={actor}",
+    })
+    adapter.handle_message = AsyncMock()
+    adapter._bind_route_authentication_authorities(adapter._routes)
+
+    original = adapter._live_route_authority_matches
+    checked = threading.Event()
+    proceed = threading.Event()
+
+    def pause_after_live_check(route_name, bundle):
+        result = original(route_name, bundle)
+        checked.set()
+        assert proceed.wait(timeout=5)
+        return result
+
+    adapter._live_route_authority_matches = pause_after_live_check
+    body, headers = _signed({"actor": "newly-added"})
+    async with TestClient(TestServer(_app(adapter))) as client:
+        pending = asyncio.create_task(
+            client.post(
+                "/webhooks/events",
+                data=body,
+                headers=headers,
+            )
+        )
+        assert await asyncio.to_thread(checked.wait, 5)
+        watchlist.write_text('["allowed","newly-added"]', encoding="utf-8")
+        proceed.set()
+        response = await pending
+        payload = await response.json()
+
+    assert response.status == 200
+    assert payload["status"] == "ignored"
+    assert payload["reason"] == "filter"
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_filter_file_change_withdraws_route_and_releases_new_claim(tmp_path):
+    watchlist = tmp_path / "watchlist.json"
+    watchlist.write_text('["old"]', encoding="utf-8")
+    adapter = _adapter({
+        "filters": {"field": "actor", "in_file": "watchlist.json"},
+    })
+    adapter.handle_message = AsyncMock()
+    adapter._bind_route_authentication_authorities(adapter._routes)
+    watchlist.write_text('["old","widened"]', encoding="utf-8")
+    body, headers = _signed({"actor": "widened"})
+
+    async with TestClient(TestServer(_app(adapter))) as client:
+        response = await client.post(
+            "/webhooks/events",
+            data=body,
+            headers=headers,
+        )
+
+    assert response.status == 503
+    assert "events" not in adapter._routes
+    assert adapter._operation_ledger.count() == 0
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_literal_in_file_key_inside_equals_is_not_read_as_filter_file():
+    adapter = _adapter({
+        "filters": {
+            "field": "meta",
+            "equals": {"in_file": "literal-not-a-path"},
+        },
+        "prompt": "matched",
+    })
+    adapter.handle_message = AsyncMock()
+    body, headers = _signed({"meta": {"in_file": "literal-not-a-path"}})
+
+    async with TestClient(TestServer(_app(adapter))) as client:
+        response = await client.post(
+            "/webhooks/events",
+            data=body,
+            headers=headers,
+        )
+
+    assert response.status == 202
+    adapter.handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_skill_scaffold_is_frozen_across_post_signature_change(monkeypatch):
+    version = {"value": "v1"}
+
+    monkeypatch.setattr(
+        "agent.skill_commands.get_skill_commands",
+        lambda: {"/review": object()},
+    )
+
+    def build_skill(command, *, user_instruction):
+        assert command == "/review"
+        return f"skill-{version['value']}\n{user_instruction}"
+
+    monkeypatch.setattr(
+        "agent.skill_commands.build_skill_invocation_message",
+        build_skill,
+    )
+    adapter = _adapter({"skills": ["review"], "prompt": "payload={value}"})
+    adapter.handle_message = AsyncMock()
+    adapter._bind_route_authentication_authorities(adapter._routes)
+
+    original = adapter._live_route_authority_matches
+    checked = threading.Event()
+    proceed = threading.Event()
+
+    def pause_after_live_check(route_name, bundle):
+        result = original(route_name, bundle)
+        checked.set()
+        assert proceed.wait(timeout=5)
+        return result
+
+    adapter._live_route_authority_matches = pause_after_live_check
+    body, headers = _signed({"value": "one"})
+    async with TestClient(TestServer(_app(adapter))) as client:
+        pending = asyncio.create_task(
+            client.post(
+                "/webhooks/events",
+                data=body,
+                headers=headers,
+            )
+        )
+        assert await asyncio.to_thread(checked.wait, 5)
+        version["value"] = "v2"
+        proceed.set()
+        response = await pending
+
+    assert response.status == 202
+    event = adapter.handle_message.await_args.args[0]
+    assert event.text.startswith("skill-v1\n")
+    assert "skill-v2" not in event.text
+
+
+@pytest.mark.asyncio
+async def test_home_channel_change_requires_rotated_route_policy():
+    home_a = HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="chat-a",
+        name="home-a",
+        thread_id="1",
+    )
+    target_config = PlatformConfig(enabled=True, home_channel=home_a)
+    target = SimpleNamespace(config=target_config)
+    adapter = _adapter({
+        "deliver": "telegram",
+        "deliver_only": True,
+        "prompt": "notice",
+    })
+    runner = SimpleNamespace(
+        adapters={Platform.WEBHOOK: adapter, Platform.TELEGRAM: target},
+        config=SimpleNamespace(
+            multiplex_profiles=False, get_home_channel=lambda _p: None
+        ),
+        _active_profile_name=lambda: "default",
+    )
+    adapter.gateway_runner = runner
+    adapter._bind_route_authentication_authorities(adapter._routes)
+    target.config.home_channel = HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="chat-b",
+        name="home-b",
+        thread_id="2",
+    )
+    body, headers = _signed({"value": 1})
+
+    async with TestClient(TestServer(_app(adapter))) as client:
+        response = await client.post(
+            "/webhooks/events",
+            data=body,
+            headers=headers,
+        )
+
+    assert response.status == 503
+    assert "events" not in adapter._routes
+    assert adapter._operation_ledger.count() == 0
+
+
+@pytest.mark.asyncio
+async def test_old_key_request_cannot_rejoin_new_name_indexed_bundle():
+    adapter = _adapter({"prompt": "policy-a"}, secret="key-a")
+    adapter.handle_message = AsyncMock()
+    adapter._bind_route_authentication_authorities(adapter._routes)
+    original = adapter._live_route_authority_matches
+    checked = threading.Event()
+    proceed = threading.Event()
+
+    def pause_after_live_check(route_name, bundle):
+        result = original(route_name, bundle)
+        checked.set()
+        assert proceed.wait(timeout=5)
+        return result
+
+    adapter._live_route_authority_matches = pause_after_live_check
+    old_body, old_headers = _signed({"value": "old"}, "key-a")
+    async with TestClient(TestServer(_app(adapter))) as client:
+        stale = asyncio.create_task(
+            client.post(
+                "/webhooks/events",
+                data=old_body,
+                headers=old_headers,
+            )
+        )
+        assert await asyncio.to_thread(checked.wait, 5)
+        route_b = {
+            "events": {
+                "secret": "key-b",
+                "signature_mode": "generic_v1",
+                "prompt": "policy-b-elevated",
+                "toolsets": ["terminal"],
+            }
+        }
+        adapter._bind_route_authentication_authorities(route_b)
+        adapter._routes = route_b
+        proceed.set()
+        stale_response = await stale
+
+        adapter._live_route_authority_matches = original
+        new_body, new_headers = _signed({"value": "new"}, "key-b")
+        current_response = await client.post(
+            "/webhooks/events",
+            data=new_body,
+            headers=new_headers,
+        )
+
+    assert stale_response.status == 503
+    assert current_response.status == 202
+    assert adapter._routes["events"]["prompt"] == "policy-b-elevated"
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.text == "policy-b-elevated"
+
+
+@pytest.mark.asyncio
+async def test_filter_cancellation_retains_global_slot_across_replacement(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        webhook_intake_module,
+        "_route_worker_slots",
+        threading.BoundedSemaphore(1),
+    )
+    adapter = _adapter({"filters": [], "prompt": "retryable"})
+    adapter.handle_message = AsyncMock()
+    adapter._bind_route_authentication_authorities(adapter._routes)
+    entered = threading.Event()
+    proceed = threading.Event()
+    exited = threading.Event()
+    calls = 0
+    original = adapter._route_processor.route_filters_match
+
+    def blocking_filter(*_args):
+        nonlocal calls
+        calls += 1
+        try:
+            entered.set()
+            assert proceed.wait(timeout=5)
+            return True
+        finally:
+            exited.set()
+
+    adapter._route_processor.route_filters_match = blocking_filter
+    body, headers = _signed({"value": "cancel-filter"})
+    task = asyncio.create_task(adapter._handle_webhook(_request(body, headers)))
+    assert await asyncio.to_thread(entered.wait, 5)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert adapter._operation_ledger.count() == 0
+
+    replacement = _adapter({"filters": [], "prompt": "retryable"})
+    replacement.handle_message = AsyncMock()
+    replacement._bind_route_authentication_authorities(replacement._routes)
+
+    busy_body, busy_headers = _signed({"value": "busy-filter"})
+    busy = await replacement._handle_webhook(_request(busy_body, busy_headers))
+    assert busy.status == 503
+    assert busy.headers["Retry-After"] == "1"
+    assert calls == 1
+    assert replacement._operation_ledger.count() == 0
+
+    proceed.set()
+    assert await asyncio.to_thread(exited.wait, 5)
+    await asyncio.sleep(0)
+    adapter._route_processor.route_filters_match = original
+    retry = await replacement._handle_webhook(_request(body, headers))
+    assert retry.status == 202
+    pending = tuple(replacement._background_tasks)
+    if pending:
+        await asyncio.gather(*pending)
+    replacement.handle_message.assert_awaited_once()
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_global_route_worker_capacity_never_exceeds_four(monkeypatch):
+    monkeypatch.setattr(
+        webhook_intake_module,
+        "_route_worker_slots",
+        threading.BoundedSemaphore(4),
+    )
+    adapters = [
+        _adapter({"filters": [], "prompt": "bounded"}),
+        _adapter({"filters": [], "prompt": "bounded"}),
+    ]
+    for adapter in adapters:
+        adapter.handle_message = AsyncMock()
+        adapter._bind_route_authentication_authorities(adapter._routes)
+    lock = threading.Lock()
+    all_entered = threading.Event()
+    proceed = threading.Event()
+    active = 0
+    maximum_active = 0
+    calls = 0
+
+    def blocking_filter(*_args):
+        nonlocal active, maximum_active, calls
+        with lock:
+            calls += 1
+            active += 1
+            maximum_active = max(maximum_active, active)
+            if active == 4:
+                all_entered.set()
+        try:
+            assert proceed.wait(timeout=5)
+            return True
+        finally:
+            with lock:
+                active -= 1
+
+    for adapter in adapters:
+        adapter._route_processor.route_filters_match = blocking_filter
+    requests = []
+    for index in range(8):
+        body, headers = _signed({"value": f"bounded-{index}"})
+        adapter = adapters[index % len(adapters)]
+        requests.append(
+            asyncio.create_task(adapter._handle_webhook(_request(body, headers)))
+        )
+
+    assert await asyncio.to_thread(all_entered.wait, 5)
+    for _attempt in range(500):
+        if sum(request.done() for request in requests) == 4:
+            break
+        await asyncio.sleep(0.01)
+    assert sum(request.done() for request in requests) == 4
+    proceed.set()
+    responses = await asyncio.gather(*requests)
+    statuses = [response.status for response in responses]
+    assert statuses.count(202) == 4
+    assert statuses.count(503) == 4
+    assert calls == 4
+    assert maximum_active == 4
+    pending = tuple(task for adapter in adapters for task in adapter._background_tasks)
+    if pending:
+        await asyncio.gather(*pending)
+
+
+@pytest.mark.asyncio
+async def test_script_worker_saturation_releases_before_mark_started(
+    tmp_path,
+    monkeypatch,
+):
+    scripts = tmp_path / "scripts"
+    scripts.mkdir()
+    (scripts / "route.py").write_text(
+        "import json, sys\njson.dump(json.load(sys.stdin), sys.stdout)\n",
+        encoding="utf-8",
+    )
+    gate = threading.BoundedSemaphore(1)
+    monkeypatch.setattr(webhook_intake_module, "_route_worker_slots", gate)
+    adapter = _adapter({"script": "route.py", "prompt": "scripted"})
+    adapter.handle_message = AsyncMock()
+    adapter._bind_route_authentication_authorities(adapter._routes)
+    original_mark_started = adapter._operation_ledger.mark_script_started
+    mark_started = MagicMock(wraps=original_mark_started)
+    monkeypatch.setattr(
+        adapter._operation_ledger,
+        "mark_script_started",
+        mark_started,
+    )
+    original_worker = adapter._run_retained_route_worker
+    saturated = False
+
+    async def saturate_after_filter(operation, *args, **kwargs):
+        nonlocal saturated
+        result = await original_worker(operation, *args, **kwargs)
+        if not saturated:
+            assert gate.acquire(blocking=False)
+            saturated = True
+        return result
+
+    monkeypatch.setattr(
+        adapter,
+        "_run_retained_route_worker",
+        saturate_after_filter,
+    )
+    body, headers = _signed({"value": "busy-script"})
+
+    try:
+        response = await adapter._handle_webhook(_request(body, headers))
+    finally:
+        if saturated:
+            gate.release()
+
+    assert response.status == 503
+    assert response.headers["Retry-After"] == "1"
+    assert adapter._operation_ledger.count() == 0
+    mark_started.assert_not_called()
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_script_cancellation_waits_for_worker_then_marks_indeterminate(
+    tmp_path,
+    monkeypatch,
+):
+    scripts = tmp_path / "scripts"
+    scripts.mkdir()
+    (scripts / "route.py").write_text(
+        "import json, sys\njson.dump(json.load(sys.stdin), sys.stdout)\n",
+        encoding="utf-8",
+    )
+    gate = threading.BoundedSemaphore(1)
+    monkeypatch.setattr(webhook_intake_module, "_route_worker_slots", gate)
+    adapter = _adapter({"script": "route.py", "prompt": "scripted"})
+    adapter.handle_message = AsyncMock()
+    adapter._bind_route_authentication_authorities(adapter._routes)
+    entered = threading.Event()
+    exited = threading.Event()
+    original = adapter._route_processor.run_prepared_script
+    real_mark_indeterminate = adapter._operation_ledger.mark_indeterminate
+
+    def blocking_script(*_args, cancellation_event=None):
+        assert cancellation_event is not None
+        try:
+            entered.set()
+            assert cancellation_event.wait(timeout=5)
+            return WebhookScriptResult(
+                disposition=WebhookScriptDisposition.INDETERMINATE,
+                error="cancelled",
+            )
+        finally:
+            exited.set()
+
+    def mark_after_worker_exit(authority, reason):
+        assert exited.is_set()
+        return real_mark_indeterminate(authority, reason)
+
+    adapter._route_processor.run_prepared_script = blocking_script
+    monkeypatch.setattr(
+        adapter._operation_ledger,
+        "mark_indeterminate",
+        mark_after_worker_exit,
+    )
+    body, headers = _signed({"value": "cancel-script"})
+    task = asyncio.create_task(adapter._handle_webhook(_request(body, headers)))
+    assert await asyncio.to_thread(entered.wait, 5)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert exited.is_set()
+    assert gate.acquire(blocking=False)
+    assert not gate.acquire(blocking=False)
+    gate.release()
+
+    retry = await adapter._handle_webhook(_request(body, headers))
+    assert retry.status == 409
+    assert b"indeterminate" in retry.body
+    adapter._route_processor.run_prepared_script = original
+    next_body, next_headers = _signed({"value": "after-cancel"})
+    accepted = await adapter._handle_webhook(_request(next_body, next_headers))
+    assert accepted.status == 202
+    pending = tuple(adapter._background_tasks)
+    if pending:
+        await asyncio.gather(*pending)
+    adapter.handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_unexpected_post_start_script_failure_is_indeterminate(
+    tmp_path,
+    monkeypatch,
+):
+    scripts = tmp_path / "scripts"
+    scripts.mkdir()
+    (scripts / "route.py").write_text(
+        "import json, sys\njson.dump(json.load(sys.stdin), sys.stdout)\n",
+        encoding="utf-8",
+    )
+    adapter = _adapter({"script": "route.py", "prompt": "scripted"})
+    adapter.handle_message = AsyncMock()
+    adapter._bind_route_authentication_authorities(adapter._routes)
+    original_mark = adapter._operation_ledger.mark_indeterminate
+    mark_indeterminate = MagicMock(wraps=original_mark)
+    monkeypatch.setattr(
+        adapter._operation_ledger,
+        "mark_indeterminate",
+        mark_indeterminate,
+    )
+    monkeypatch.setattr(
+        adapter._route_processor,
+        "run_prepared_script",
+        MagicMock(side_effect=RecursionError("nested script output")),
+    )
+    body, headers = _signed({"value": "deep-script-output"})
+
+    response = await adapter._handle_webhook(_request(body, headers))
+
+    assert response.status == 500
+    assert b"indeterminate" in response.body
+    mark_indeterminate.assert_called_once()
+    authority = mark_indeterminate.call_args.args[0]
+    restored = adapter._operation_ledger.lookup_session(authority.session_key)
+    assert restored is not None
+    assert restored.state.value == "indeterminate"
+    retry = await adapter._handle_webhook(_request(body, headers))
+    assert retry.status == 409
+    adapter.handle_message.assert_not_awaited()
+
+
+def test_route_publication_rejects_profile_rotation_during_dependency_snapshot(
+    tmp_path,
+    monkeypatch,
+):
+    scripts = tmp_path / "scripts"
+    scripts.mkdir()
+    script_path = scripts / "route.py"
+    script_path.write_text("version = 'old'\n", encoding="utf-8")
+    adapter = _adapter({"script": "route.py", "prompt": "scripted"})
+    token_path = tmp_path / _PROFILE_AUTHORITY_INCARNATION_FILENAME
+    original_prepare = adapter._route_processor.prepare_route_script
+    prior_token = None
+
+    def rotate_after_script_snapshot(script):
+        nonlocal prior_token
+        prepared, error = original_prepare(script)
+        assert prepared is not None
+        assert error is None
+        prior_token = token_path.read_text(encoding="ascii")
+        script_path.write_text("version = 'new'\n", encoding="utf-8")
+        token_path.unlink()
+        return prepared, error
+
+    monkeypatch.setattr(
+        adapter._route_processor,
+        "prepare_route_script",
+        rotate_after_script_snapshot,
+    )
+
+    with pytest.raises(
+        WebhookContractError,
+        match="profile authority changed while execution dependencies were snapshotted",
+    ):
+        adapter._bind_route_authentication_authorities(adapter._routes)
+
+    assert prior_token is not None
+    assert token_path.read_text(encoding="ascii") != prior_token
+    assert adapter._authenticated_route_snapshot is None
+    assert dict(adapter._authenticated_route_bundles) == {}
+
+    monkeypatch.setattr(
+        adapter._route_processor,
+        "prepare_route_script",
+        original_prepare,
+    )
+    adapter._bind_route_authentication_authorities(adapter._routes)
+    prepared = adapter._authenticated_route_bundles["events"].prepared_script
+    assert prepared is not None
+    assert prepared.source == "version = 'new'\n"
+
+
+def test_route_set_publication_rejects_generation_rotation_between_routes(
+    tmp_path,
+    monkeypatch,
+):
+    routes = {
+        "a": {
+            "secret": "route-a-secret",
+            "signature_mode": "generic_v1",
+            "prompt": "route-a",
+        },
+        "b": {
+            "secret": "route-b-secret",
+            "signature_mode": "generic_v1",
+            "prompt": "route-b",
+        },
+    }
+    adapter = WebhookAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={
+                "host": "127.0.0.1",
+                "port": 0,
+                "routes": routes,
+            },
+        )
+    )
+    token_path = tmp_path / _PROFILE_AUTHORITY_INCARNATION_FILENAME
+    original_generation = adapter._profile_authority_generation
+    prior_token = None
+    rotated = False
+
+    def rotate_before_route_b(bound_route, *, authority_profile):
+        nonlocal prior_token, rotated
+        if bound_route.name == "b" and not rotated:
+            prior_token = token_path.read_text(encoding="ascii")
+            token_path.unlink()
+            rotated = True
+        return original_generation(
+            bound_route,
+            authority_profile=authority_profile,
+        )
+
+    monkeypatch.setattr(
+        adapter,
+        "_profile_authority_generation",
+        rotate_before_route_b,
+    )
+
+    with pytest.raises(
+        WebhookContractError,
+        match="authority changed while the route set was snapshotted",
+    ):
+        adapter._bind_route_authentication_authorities(adapter._routes)
+
+    assert rotated
+    assert prior_token is not None
+    assert token_path.read_text(encoding="ascii") != prior_token
+    assert adapter._authenticated_route_snapshot is None
+    assert dict(adapter._authenticated_route_bundles) == {}
+    assert dict(adapter._authenticated_route_profile_generations) == {}
+
+
+@pytest.mark.asyncio
+async def test_published_script_route_profile_rotation_fails_before_script_start(
+    tmp_path,
+    monkeypatch,
+):
+    scripts = tmp_path / "scripts"
+    scripts.mkdir()
+    (scripts / "route.py").write_text(
+        "import json, sys\njson.dump(json.load(sys.stdin), sys.stdout)\n",
+        encoding="utf-8",
+    )
+    adapter = _adapter({"script": "route.py", "prompt": "scripted"})
+    adapter.handle_message = AsyncMock()
+    adapter._bind_route_authentication_authorities(adapter._routes)
+    published_generation = adapter._authenticated_route_bundles[
+        "events"
+    ].profile_generation
+    mark_script_started = MagicMock(wraps=adapter._operation_ledger.mark_script_started)
+    run_prepared_script = MagicMock(wraps=adapter._route_processor.run_prepared_script)
+    monkeypatch.setattr(
+        adapter._operation_ledger,
+        "mark_script_started",
+        mark_script_started,
+    )
+    monkeypatch.setattr(
+        adapter._route_processor,
+        "run_prepared_script",
+        run_prepared_script,
+    )
+    (tmp_path / _PROFILE_AUTHORITY_INCARNATION_FILENAME).unlink()
+    body, headers = _signed({"value": "rotated-profile"})
+
+    response = await adapter._handle_webhook(_request(body, headers))
+
+    assert response.status == 503
+    assert adapter._operation_ledger.count() == 0
+    assert "events" not in adapter._routes
+    mark_script_started.assert_not_called()
+    run_prepared_script.assert_not_called()
+    adapter.handle_message.assert_not_awaited()
+    assert (
+        adapter._current_profile_authority_generation(
+            "default",
+            route_name="events",
+        )
+        != published_generation
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "failed_transition",
+    ["release_pre_effect", "settle_no_effect", "mark_script_started"],
+)
+async def test_live_transition_failure_fences_and_quarantines_exact_owner(
+    tmp_path,
+    monkeypatch,
+    failed_transition,
+):
+    route = {"prompt": "transition"}
+    if failed_transition == "settle_no_effect":
+        route["events"] = ["never-selected"]
+    elif failed_transition == "mark_script_started":
+        scripts = tmp_path / "scripts"
+        scripts.mkdir()
+        (scripts / "route.py").write_text(
+            "import json, sys\njson.dump(json.load(sys.stdin), sys.stdout)\n",
+            encoding="utf-8",
+        )
+        route["script"] = "route.py"
+
+    adapter = _adapter(route)
+    runner = SimpleNamespace(
+        config=SimpleNamespace(multiplex_profiles=False),
+        adapters={Platform.WEBHOOK: adapter},
+        _profile_adapters={},
+        _startup_restore_in_progress=False,
+        _draining=False,
+        _external_drain_active=False,
+        _running=True,
+        _shutdown_event=asyncio.Event(),
+        _schedule_webhook_recovery_retry=MagicMock(),
+        _update_platform_runtime_status=MagicMock(),
+    )
+    adapter.gateway_runner = runner
+    adapter.handle_message = AsyncMock()
+    adapter._bind_route_authentication_authorities(adapter._routes)
+    if failed_transition == "release_pre_effect":
+        monkeypatch.setattr(adapter, "_record_rate_limit_hit", lambda *_a, **_k: False)
+    monkeypatch.setattr(
+        adapter._operation_ledger,
+        failed_transition,
+        MagicMock(side_effect=RuntimeError("injected durable transition failure")),
+    )
+    body, headers = _signed({"event": "not-selected"})
+
+    try:
+        response = await adapter._handle_webhook(_request(body, headers))
+
+        assert response.status == 503
+        assert adapter._accepting_webhooks is False
+        assert _quarantined_retirement_owners(adapter._operation_ledger) == (
+            adapter._operation_ledger.instance_id,
+        )
+        runner._schedule_webhook_recovery_retry.assert_called_once_with(adapter)
+        runner._update_platform_runtime_status.assert_called_once()
+        assert (
+            runner._update_platform_runtime_status.call_args.kwargs["error_code"]
+            == "webhook_transition_failed"
+        )
+        adapter.handle_message.assert_not_awaited()
+    finally:
+        _clear_quarantined_retirement_owner(
+            adapter._operation_ledger,
+            adapter._operation_ledger.instance_id,
+        )
+
+
+def test_profile_incarnation_is_atomic_under_concurrent_first_use(tmp_path):
+    with concurrent.futures.ThreadPoolExecutor(max_workers=8) as executor:
+        tokens = list(
+            executor.map(
+                lambda _index: _profile_incarnation_token(tmp_path),
+                range(24),
+            )
+        )
+
+    assert len(set(tokens)) == 1
+    token_path = tmp_path / _PROFILE_AUTHORITY_INCARNATION_FILENAME
+    assert token_path.read_text(encoding="ascii") == f"{tokens[0]}\n"
+    if os.name == "posix":
+        assert token_path.stat().st_mode & 0o777 == 0o600
+    assert not list(tmp_path.glob("*.tmp"))
+
+
+@pytest.mark.parametrize("failed_call", ["write", "fsync"])
+def test_profile_incarnation_persist_failure_removes_temporary_file(
+    tmp_path,
+    monkeypatch,
+    failed_call,
+):
+    def fail(*_args, **_kwargs):
+        raise OSError(f"injected {failed_call} failure")
+
+    monkeypatch.setattr(f"gateway.platforms.webhook_common.os.{failed_call}", fail)
+
+    with pytest.raises(
+        WebhookContractError,
+        match="profile authority incarnation token cannot be persisted",
+    ):
+        _profile_incarnation_token(tmp_path)
+
+    assert not (tmp_path / _PROFILE_AUTHORITY_INCARNATION_FILENAME).exists()
+    assert not list(tmp_path.glob("*.tmp"))
+
+
+def test_profile_delete_recreate_gets_new_generation_even_with_inode_reuse(tmp_path):
+    profile = tmp_path / "profile"
+    profile.mkdir()
+    first = _profile_incarnation_token(profile)
+    token_path = profile / _PROFILE_AUTHORITY_INCARNATION_FILENAME
+    token_path.unlink()
+    profile.rmdir()
+    profile.mkdir()
+    second = _profile_incarnation_token(profile)
+
+    assert second != first
+
+
+@pytest.mark.asyncio
+async def test_unreachable_explicit_profile_does_not_consume_key(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "hermes_cli.profiles.profile_matches_home",
+        lambda _name: False,
+    )
+    invalid = _adapter({"profile": "not-this-process"}, secret="reusable-key")
+    assert await invalid.connect() is False
+    assert invalid._runner is None
+    assert invalid.fatal_error_code == "webhook_configuration_invalid"
+    assert invalid.fatal_error_retryable is False
+    assert "not this gateway's profile" in (invalid.fatal_error_message or "")
+
+    corrected = _adapter({}, secret="reusable-key")
+    corrected._bind_route_authentication_authorities(corrected._routes)
+    assert "events" in corrected._authenticated_route_bundles
+
+
+@pytest.mark.asyncio
+async def test_missing_durable_key_proof_withdraws_cached_route(monkeypatch):
+    adapter = _adapter({"prompt": "must not run from cache"})
+    adapter.handle_message = AsyncMock()
+    adapter._bind_route_authentication_authorities(adapter._routes)
+    monkeypatch.setattr(
+        adapter._authentication_authority_ledger,
+        "authentication_keys_match",
+        lambda _bindings: False,
+    )
+    body, headers = _signed({"value": "after-replacement"})
+
+    async with TestClient(TestServer(_app(adapter))) as client:
+        response = await client.post(
+            "/webhooks/events",
+            data=body,
+            headers=headers,
+        )
+
+    assert response.status == 503
+    assert "events" not in adapter._routes
+    assert adapter._operation_ledger.count() == 0
+    adapter.handle_message.assert_not_awaited()

--- a/tests/gateway/test_webhook_executions_joined.py
+++ b/tests/gateway/test_webhook_executions_joined.py
@@ -1,0 +1,451 @@
+"""Joined authority regressions for webhook status and cancellation."""
+
+from __future__ import annotations
+
+from dataclasses import fields
+import hashlib
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from gateway.platforms.webhook_executions import (
+    CancelDisposition,
+    CancellationState,
+    ExecutionPhase,
+    ExecutionStatus,
+    WebhookExecutionProjection,
+)
+from gateway.platforms.webhook_ledger import (
+    AdmitDisposition,
+    OperationState,
+    Settlement,
+    SettlementKind,
+    TargetAttemptDisposition,
+    TargetState,
+    WebhookLedgerCorruptionError,
+    WebhookOperationLedger,
+)
+from tests.gateway.test_webhook_ledger import _envelope, _snapshots
+
+
+def _admit(
+    ledger: WebhookOperationLedger,
+    *,
+    delivery_id: str = "execution-delivery",
+    profile: str = "default",
+    route: str = "events",
+):
+    result = ledger.admit(
+        _envelope(
+            delivery_id=delivery_id,
+            trace_id=f"{delivery_id}-trace",
+            profile=profile,
+            route_name=route,
+        )
+    )
+    assert result.disposition is AdmitDisposition.ACCEPTED
+    assert result.authority is not None
+    return result.authority
+
+
+def _issue(
+    tmp_path: Path,
+    *,
+    delivery_id: str = "execution-delivery",
+    profile: str = "default",
+    route: str = "events",
+    **projection_options,
+):
+    db_path = tmp_path / "state.db"
+    ledger = WebhookOperationLedger(db_path, instance_id="execution-owner")
+    authority = _admit(
+        ledger,
+        delivery_id=delivery_id,
+        profile=profile,
+        route=route,
+    )
+    projection = WebhookExecutionProjection(ledger, **projection_options)
+    issued = projection.issue(authority, now=100.0)
+    assert issued.access_token is not None
+    return db_path, ledger, authority, projection, issued
+
+
+def test_projection_schema_is_joined_idempotent_and_stores_only_token_hash(
+    tmp_path: Path,
+) -> None:
+    db_path, ledger, authority, projection, issued = _issue(tmp_path)
+    assert issued.created
+    assert issued.expires_at == 3700.0
+
+    repeated = projection.issue(authority, now=101.0)
+    assert repeated.execution_id == issued.execution_id
+    assert repeated.access_token is None
+    assert not repeated.created
+    assert repeated.expires_at == issued.expires_at
+
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        stored = conn.execute("SELECT * FROM webhook_execution_capabilities").fetchone()
+        assert stored is not None
+        assert stored["operation_id"] == authority.operation_id
+        assert stored["issued_generation"] == authority.generation
+        assert (
+            stored["token_hash"]
+            == hashlib.sha256(issued.access_token.encode("utf-8")).hexdigest()
+        )
+        assert issued.access_token not in tuple(str(value) for value in stored)
+        foreign_keys = conn.execute(
+            "PRAGMA foreign_key_list(webhook_execution_capabilities)"
+        ).fetchall()
+        assert any(
+            row[2] == "webhook_operations"
+            and row[3] == "operation_id"
+            and row[4] == "operation_id"
+            and row[6].upper() == "CASCADE"
+            for row in foreign_keys
+        )
+
+        with pytest.raises(
+            sqlite3.IntegrityError,
+            match="webhook_execution_capability_authority_immutable",
+        ):
+            conn.execute(
+                """UPDATE webhook_execution_capabilities
+                      SET token_hash=? WHERE execution_id=?""",
+                ("0" * 64, issued.execution_id),
+            )
+
+    # Extra joined tables do not shadow or invalidate the canonical ledger, and
+    # migration remains idempotent across independently constructed shards.
+    peer_ledger = WebhookOperationLedger(db_path, instance_id="peer-owner")
+    peer_projection = WebhookExecutionProjection(peer_ledger)
+    status = peer_projection.status(
+        issued.execution_id,
+        issued.access_token,
+        profile=authority.profile,
+        route=authority.route,
+        now=102.0,
+    )
+    assert status is not None
+    assert status.operation_state is OperationState.PREPARING
+
+
+def test_status_is_a_redacted_live_projection_of_operation_and_target(
+    tmp_path: Path,
+) -> None:
+    _, ledger, authority, projection, issued = _issue(tmp_path)
+    assert issued.access_token is not None
+
+    accepted = projection.status(
+        issued.execution_id,
+        issued.access_token,
+        profile=authority.profile,
+        route=authority.route,
+        now=101.0,
+    )
+    assert accepted is not None
+    assert accepted.phase is ExecutionPhase.ACCEPTED
+    assert accepted.operation_state is OperationState.PREPARING
+    assert accepted.target_state is None
+    assert accepted.can_cancel
+    assert not accepted.effects_possible
+    assert not accepted.needs_attention
+    assert {field.name for field in fields(ExecutionStatus)} == {
+        "execution_id",
+        "phase",
+        "operation_state",
+        "target_state",
+        "generation",
+        "cancellation",
+        "can_cancel",
+        "effects_possible",
+        "created_at",
+        "updated_at",
+        "settled_at",
+        "needs_attention",
+    }
+
+    prepared = ledger.prepare(authority, **_snapshots("projection"))
+    assert ledger.mark_running(prepared)
+    running = projection.status(
+        issued.execution_id,
+        issued.access_token,
+        profile=authority.profile,
+        route=authority.route,
+        now=102.0,
+    )
+    assert running is not None
+    assert running.phase is ExecutionPhase.RUNNING
+    assert running.operation_state is OperationState.RUNNING
+    assert running.target_state is TargetState.PENDING
+    assert running.effects_possible
+
+    staged = ledger.stage_delivery(
+        prepared,
+        content="durable response",
+        carrier_snapshot={"delivery_type": "log", "profile": "default"},
+    )
+    delivery = projection.status(
+        issued.execution_id,
+        issued.access_token,
+        profile=authority.profile,
+        route=authority.route,
+        now=103.0,
+    )
+    assert delivery is not None
+    assert delivery.phase is ExecutionPhase.DELIVERY
+    assert delivery.operation_state is OperationState.DELIVERY_READY
+    assert delivery.target_state is TargetState.PENDING
+
+    attempt = ledger.begin_target(staged)
+    assert attempt.disposition is TargetAttemptDisposition.STARTED
+    assert ledger.settle_target(
+        attempt,
+        Settlement(SettlementKind.CONFIRMED, external_id="delivered"),
+    )
+    settled = projection.status(
+        issued.execution_id,
+        issued.access_token,
+        profile=authority.profile,
+        route=authority.route,
+        now=104.0,
+    )
+    assert settled is not None
+    assert settled.phase is ExecutionPhase.SETTLED
+    assert settled.operation_state is OperationState.SETTLED
+    assert settled.target_state is TargetState.CONFIRMED
+    assert not settled.can_cancel
+    assert settled.settled_at is not None
+
+    assert (
+        projection.status(
+            issued.execution_id,
+            "wrong-token",
+            profile=authority.profile,
+            route=authority.route,
+            now=105.0,
+        )
+        is None
+    )
+    assert (
+        projection.status(
+            issued.execution_id,
+            issued.access_token,
+            profile="other-profile",
+            route=authority.route,
+            now=106.0,
+        )
+        is None
+    )
+
+
+def test_cancel_request_survives_restart_and_closes_pre_bind_race(
+    tmp_path: Path,
+) -> None:
+    db_path, _, authority, projection, issued = _issue(tmp_path)
+    assert issued.access_token is not None
+
+    requested = projection.request_cancel(
+        issued.execution_id,
+        issued.access_token,
+        profile=authority.profile,
+        route=authority.route,
+        now=101.0,
+    )
+    assert requested is not None
+    assert requested.disposition is CancelDisposition.REQUESTED
+    assert requested.status.cancellation is CancellationState.REQUESTED
+    assert requested.status.operation_state is OperationState.PREPARING
+    assert not projection.claim_cancel(
+        authority.operation_id,
+        authority.generation + 1,
+        now=102.0,
+    )
+
+    restarted_ledger = WebhookOperationLedger(db_path, instance_id="new-shard")
+    restarted = WebhookExecutionProjection(restarted_ledger)
+    assert restarted.claim_cancel(
+        authority.operation_id,
+        authority.generation,
+        now=103.0,
+    )
+    assert restarted.claim_cancel(
+        authority.operation_id,
+        authority.generation,
+        now=104.0,
+    )
+    observed = restarted.request_cancel(
+        issued.execution_id,
+        issued.access_token,
+        profile=authority.profile,
+        route=authority.route,
+        now=105.0,
+    )
+    assert observed is not None
+    assert observed.disposition is CancelDisposition.OBSERVED
+    assert observed.status.cancellation is CancellationState.OBSERVED
+
+
+def test_cancel_is_too_late_after_target_attempt_and_terminal_after_settlement(
+    tmp_path: Path,
+) -> None:
+    _, ledger, authority, projection, issued = _issue(tmp_path)
+    assert issued.access_token is not None
+    prepared = ledger.prepare(authority, **_snapshots("too-late"))
+    assert ledger.mark_running(prepared)
+    staged = ledger.stage_delivery(
+        prepared,
+        content="durable response",
+        carrier_snapshot={"delivery_type": "log", "profile": "default"},
+    )
+    attempt = ledger.begin_target(staged)
+    assert attempt.disposition is TargetAttemptDisposition.STARTED
+
+    too_late = projection.request_cancel(
+        issued.execution_id,
+        issued.access_token,
+        profile=authority.profile,
+        route=authority.route,
+        now=101.0,
+    )
+    assert too_late is not None
+    assert too_late.disposition is CancelDisposition.TOO_LATE
+    assert too_late.status.operation_state is OperationState.DELIVERING
+    assert too_late.status.cancellation is CancellationState.NONE
+    assert not too_late.status.can_cancel
+    assert not projection.claim_cancel(
+        authority.operation_id,
+        authority.generation,
+        now=102.0,
+    )
+
+    assert ledger.settle_target(
+        attempt,
+        Settlement(SettlementKind.CONFIRMED, external_id="delivered"),
+    )
+    terminal = projection.request_cancel(
+        issued.execution_id,
+        issued.access_token,
+        profile=authority.profile,
+        route=authority.route,
+        now=103.0,
+    )
+    assert terminal is not None
+    assert terminal.disposition is CancelDisposition.TERMINAL
+    assert terminal.status.phase is ExecutionPhase.SETTLED
+
+
+def test_auth_attempt_limit_is_durable_and_shared_by_status_and_cancel(
+    tmp_path: Path,
+) -> None:
+    db_path, _, authority, projection, issued = _issue(
+        tmp_path,
+        auth_window_seconds=10,
+        auth_max_attempts=2,
+    )
+    assert issued.access_token is not None
+
+    assert (
+        projection.status(
+            issued.execution_id,
+            "wrong-token",
+            profile=authority.profile,
+            route=authority.route,
+            now=101.0,
+        )
+        is None
+    )
+    assert (
+        projection.request_cancel(
+            issued.execution_id,
+            issued.access_token,
+            profile=authority.profile,
+            route="wrong-route",
+            now=102.0,
+        )
+        is None
+    )
+    assert (
+        projection.status(
+            issued.execution_id,
+            issued.access_token,
+            profile=authority.profile,
+            route=authority.route,
+            now=103.0,
+        )
+        is None
+    )
+
+    restarted = WebhookExecutionProjection(
+        WebhookOperationLedger(db_path, instance_id="rate-limit-peer"),
+        auth_window_seconds=10,
+        auth_max_attempts=2,
+    )
+    assert (
+        restarted.request_cancel(
+            issued.execution_id,
+            issued.access_token,
+            profile=authority.profile,
+            route=authority.route,
+            now=109.0,
+        )
+        is None
+    )
+    after_window = restarted.status(
+        issued.execution_id,
+        issued.access_token,
+        profile=authority.profile,
+        route=authority.route,
+        now=111.0,
+    )
+    assert after_window is not None
+
+
+def test_expiration_prunes_only_capability_and_never_canonical_operation(
+    tmp_path: Path,
+) -> None:
+    _, ledger, authority, projection, issued = _issue(
+        tmp_path,
+        capability_ttl_seconds=60,
+    )
+    assert issued.access_token is not None
+
+    assert projection.prune_expired(now=159.0) == 0
+    assert projection.prune_expired(now=160.0) == 1
+    assert (
+        projection.status(
+            issued.execution_id,
+            issued.access_token,
+            profile=authority.profile,
+            route=authority.route,
+            now=161.0,
+        )
+        is None
+    )
+    canonical = ledger.lookup_session(authority.session_key)
+    assert canonical is not None
+    assert canonical.operation_id == authority.operation_id
+
+
+def test_incomplete_projection_schema_fails_closed(tmp_path: Path) -> None:
+    db_path = tmp_path / "state.db"
+    ledger = WebhookOperationLedger(db_path)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """CREATE TABLE webhook_execution_projection_meta (
+                   schema_name TEXT PRIMARY KEY,
+                   schema_version INTEGER NOT NULL
+               )"""
+        )
+        conn.execute(
+            """INSERT INTO webhook_execution_projection_meta
+                   (schema_name, schema_version) VALUES (?, ?)""",
+            ("webhook_execution_projection", 1),
+        )
+
+    with pytest.raises(
+        WebhookLedgerCorruptionError,
+        match="projection schema is incomplete",
+    ):
+        WebhookExecutionProjection(ledger)

--- a/tests/gateway/test_webhook_file_snapshots.py
+++ b/tests/gateway/test_webhook_file_snapshots.py
@@ -1,0 +1,456 @@
+"""Adversarial regular-file snapshot tests for webhook authority inputs."""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import gateway.platforms.webhook_filters as webhook_filters
+from gateway.config import PlatformConfig
+from gateway.platforms.webhook import (
+    WebhookAdapter,
+    _DYNAMIC_ROUTES_FILENAME,
+)
+from gateway.platforms.webhook_contract import (
+    WebhookContractError,
+    WebhookRouteConfig,
+)
+from gateway.platforms.webhook_filters import (
+    MAX_SCRIPT_OUTPUT_COMBINED_BYTES,
+    MAX_SCRIPT_OUTPUT_STREAM_BYTES,
+    WebhookRouteProcessor,
+    WebhookScriptDisposition,
+)
+
+
+requires_fifo = pytest.mark.skipif(
+    not hasattr(os, "mkfifo"),
+    reason="FIFO authority regressions require os.mkfifo",
+)
+
+
+def _scripts_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    scripts = tmp_path / "scripts"
+    scripts.mkdir()
+    return scripts
+
+
+def _prepare_script(
+    scripts: Path,
+    *,
+    name: str,
+    source: str,
+    timeout: int = 10,
+):
+    (scripts / name).write_text(source, encoding="utf-8")
+    processor = WebhookRouteProcessor(script_timeout_seconds=timeout)
+    prepared, error = processor.prepare_route_script(name)
+    assert error is None
+    assert prepared is not None
+    return processor, prepared
+
+
+def _write_fifo_once(path: Path) -> None:
+    """Unblock a regressed blocking reader so the test fails instead of hangs."""
+
+    try:
+        fd = os.open(path, os.O_WRONLY | getattr(os, "O_NONBLOCK", 0))
+    except OSError:
+        return
+    try:
+        os.write(fd, b"\n")
+    finally:
+        os.close(fd)
+
+
+def _call_promptly_with_fifo_escape(
+    fifo_path: Path,
+    call: Callable[[], Any],
+) -> Any:
+    escape = threading.Timer(2.0, _write_fifo_once, args=(fifo_path,))
+    escape.daemon = True
+    escape.start()
+    started = time.monotonic()
+    try:
+        result = call()
+    finally:
+        escape.cancel()
+    assert time.monotonic() - started < 1.0
+    return result
+
+
+def _adapter(routes: dict[str, dict] | None = None) -> WebhookAdapter:
+    return WebhookAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={
+                "host": "127.0.0.1",
+                "port": 0,
+                "routes": routes or {},
+            },
+        )
+    )
+
+
+@requires_fifo
+def test_filter_authority_fifo_fails_promptly(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    fifo = tmp_path / "filter-values.fifo"
+    os.mkfifo(fifo)
+    adapter = _adapter({
+        "events": {
+            "provider": "generic",
+            "secret": "filter-fifo-secret",
+            "filters": {"field": "actor", "in_file": str(fifo)},
+        }
+    })
+
+    with pytest.raises(WebhookContractError, match="filter in_file is unavailable"):
+        _call_promptly_with_fifo_escape(
+            fifo,
+            lambda: adapter._bind_route_authentication_authorities(adapter._routes),
+        )
+
+
+@requires_fifo
+def test_gateway_config_authority_fifo_fails_promptly(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    fifo = tmp_path / "config.yaml"
+    os.mkfifo(fifo)
+
+    with pytest.raises(WebhookContractError, match="config is unavailable"):
+        _call_promptly_with_fifo_escape(
+            fifo,
+            WebhookAdapter._load_gateway_config_for_authority,
+        )
+
+
+@requires_fifo
+def test_dynamic_route_fifo_withdraws_promptly(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    fifo = tmp_path / _DYNAMIC_ROUTES_FILENAME
+    os.mkfifo(fifo)
+    adapter = _adapter()
+
+    _call_promptly_with_fifo_escape(fifo, adapter._reload_dynamic_routes)
+
+    assert adapter._dynamic_routes == {}
+    assert adapter._routes == {}
+
+
+def test_deep_filter_file_and_literal_authority_fail_as_contract_errors(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    values = tmp_path / "deep.json"
+    values.write_text("[" * 600 + "0" + "]" * 600, encoding="utf-8")
+    adapter = _adapter()
+    route = {
+        "provider": "generic",
+        "secret": "deep-filter-secret",
+        "filters": {"field": "actor", "in_file": str(values)},
+    }
+    bound = WebhookRouteConfig.bind(
+        "events",
+        route,
+        headers={},
+        request_profile="default",
+    )
+
+    with pytest.raises(WebhookContractError):
+        adapter._prepare_route_filter_authority(
+            route,
+            bound,
+            authority_profile="default",
+        )
+
+    nested: object = {"field": "actor", "equals": "value"}
+    for _ in range(600):
+        nested = {"not": nested}
+    literal_route = {**route, "filters": nested}
+    with pytest.raises(WebhookContractError):
+        adapter._prepare_route_filter_authority(
+            literal_route,
+            bound,
+            authority_profile="default",
+        )
+
+
+def test_filter_file_huge_integer_is_a_contract_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    values = tmp_path / "huge-integer.json"
+    values.write_text("[" + "9" * 5_000 + "]", encoding="utf-8")
+    adapter = _adapter()
+    route = {
+        "provider": "generic",
+        "secret": "huge-integer-secret",
+        "filters": {"field": "actor", "in_file": str(values)},
+    }
+    bound = WebhookRouteConfig.bind(
+        "events",
+        route,
+        headers={},
+        request_profile="default",
+    )
+
+    with pytest.raises(WebhookContractError, match="invalid JSON value"):
+        adapter._prepare_route_filter_authority(
+            route,
+            bound,
+            authority_profile="default",
+        )
+
+
+def test_filter_file_embedded_nul_is_a_contract_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    adapter = _adapter()
+    route = {
+        "provider": "generic",
+        "secret": "nul-path-secret",
+        "filters": {"field": "actor", "in_file": "bad\0path.json"},
+    }
+    bound = WebhookRouteConfig.bind(
+        "events",
+        route,
+        headers={},
+        request_profile="default",
+    )
+
+    with pytest.raises(WebhookContractError, match="filter in_file is unavailable"):
+        adapter._prepare_route_filter_authority(
+            route,
+            bound,
+            authority_profile="default",
+        )
+
+
+@requires_fifo
+def test_script_fifo_fails_promptly_without_opening_a_blocking_reader(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scripts = _scripts_home(tmp_path, monkeypatch)
+    fifo = scripts / "blocked.py"
+    os.mkfifo(fifo)
+
+    prepared, error = _call_promptly_with_fifo_escape(
+        fifo,
+        lambda: WebhookRouteProcessor().prepare_route_script("blocked.py"),
+    )
+
+    assert prepared is None
+    assert "not a file" in str(error)
+
+
+@requires_fifo
+def test_script_symlink_to_fifo_fails_promptly(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scripts = _scripts_home(tmp_path, monkeypatch)
+    fifo = scripts / "blocked-target.py"
+    os.mkfifo(fifo)
+    link = scripts / "blocked-link.py"
+    try:
+        link.symlink_to(fifo)
+    except OSError as exc:
+        pytest.skip(f"symlink creation is unavailable: {exc}")
+
+    prepared, error = _call_promptly_with_fifo_escape(
+        fifo,
+        lambda: WebhookRouteProcessor().prepare_route_script("blocked-link.py"),
+    )
+
+    assert prepared is None
+    assert "not a file" in str(error)
+
+
+@requires_fifo
+def test_script_regular_to_fifo_race_fails_promptly_after_resolution(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scripts = _scripts_home(tmp_path, monkeypatch)
+    script = scripts / "raced.py"
+    script.write_text("print('{}')\n", encoding="utf-8")
+    original_resolver = webhook_filters._resolve_script_path
+
+    def replace_after_resolution(value: Any):
+        resolved, error = original_resolver(value)
+        assert resolved == script
+        assert error is None
+        script.unlink()
+        os.mkfifo(script)
+        return resolved, None
+
+    monkeypatch.setattr(
+        webhook_filters,
+        "_resolve_script_path",
+        replace_after_resolution,
+    )
+
+    prepared, error = _call_promptly_with_fifo_escape(
+        script,
+        lambda: WebhookRouteProcessor().prepare_route_script("raced.py"),
+    )
+
+    assert prepared is None
+    assert "not a regular file" in str(error)
+
+
+def test_script_symlink_to_regular_file_remains_supported(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scripts = _scripts_home(tmp_path, monkeypatch)
+    target = scripts / "target.py"
+    target.write_text("print('{}')\n", encoding="utf-8")
+    link = scripts / "linked.py"
+    try:
+        link.symlink_to(target)
+    except OSError as exc:
+        pytest.skip(f"symlink creation is unavailable: {exc}")
+
+    prepared, error = WebhookRouteProcessor().prepare_route_script("linked.py")
+
+    assert error is None
+    assert prepared is not None
+    assert prepared.source == "print('{}')\n"
+
+
+@pytest.mark.live_system_guard_bypass
+def test_script_oversized_stdout_is_terminated_and_typed_indeterminate(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scripts = _scripts_home(tmp_path, monkeypatch)
+    processor, prepared = _prepare_script(
+        scripts,
+        name="stdout.py",
+        source=(
+            "import sys, time\n"
+            f"sys.stdout.write('x' * {MAX_SCRIPT_OUTPUT_STREAM_BYTES + 1})\n"
+            "sys.stdout.flush()\n"
+            "time.sleep(10)\n"
+        ),
+    )
+
+    started = time.monotonic()
+    result = processor.run_prepared_script(prepared, {})
+
+    assert time.monotonic() - started < 3.0
+    assert result.disposition is WebhookScriptDisposition.INDETERMINATE
+    assert "output exceeded" in str(result.error)
+
+
+@pytest.mark.live_system_guard_bypass
+def test_script_oversized_stderr_is_typed_indeterminate(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scripts = _scripts_home(tmp_path, monkeypatch)
+    processor, prepared = _prepare_script(
+        scripts,
+        name="stderr.py",
+        source=(
+            "import sys\n"
+            f"sys.stderr.write('x' * {MAX_SCRIPT_OUTPUT_STREAM_BYTES + 1})\n"
+        ),
+    )
+
+    result = processor.run_prepared_script(prepared, {})
+
+    assert result.disposition is WebhookScriptDisposition.INDETERMINATE
+    assert "output exceeded" in str(result.error)
+
+
+@pytest.mark.live_system_guard_bypass
+def test_script_combined_output_limit_is_enforced_across_both_pipes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scripts = _scripts_home(tmp_path, monkeypatch)
+    half_plus_one = MAX_SCRIPT_OUTPUT_COMBINED_BYTES // 2 + 1
+    processor, prepared = _prepare_script(
+        scripts,
+        name="combined.py",
+        source=(
+            "import sys\n"
+            f"sys.stdout.write('o' * {half_plus_one})\n"
+            "sys.stdout.flush()\n"
+            f"sys.stderr.write('e' * {half_plus_one})\n"
+        ),
+    )
+
+    result = processor.run_prepared_script(prepared, {})
+
+    assert result.disposition is WebhookScriptDisposition.INDETERMINATE
+    assert "output exceeded" in str(result.error)
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "print('[' * 2000 + '0' + ']' * 2000)\n",
+        "import sys\nsys.stdout.buffer.write(b'\\xff')\n",
+    ],
+)
+def test_script_pathological_json_or_unicode_output_returns_a_typed_result(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    source: str,
+) -> None:
+    scripts = _scripts_home(tmp_path, monkeypatch)
+    processor, prepared = _prepare_script(
+        scripts,
+        name="pathological.py",
+        source=source,
+    )
+
+    result = processor.run_prepared_script(prepared, {})
+
+    assert result.disposition is WebhookScriptDisposition.CONTINUE
+    assert isinstance(result.payload, dict)
+    assert isinstance(result.payload.get("script_output"), str)
+
+
+def test_recursive_script_payload_fails_before_process_start(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scripts = _scripts_home(tmp_path, monkeypatch)
+    processor, prepared = _prepare_script(
+        scripts,
+        name="unused.py",
+        source="print('{}')\n",
+    )
+    payload: dict[str, Any] = {}
+    payload["self"] = payload
+
+    result = processor.run_prepared_script(prepared, payload)
+
+    assert result.disposition is WebhookScriptDisposition.FAILED
+    assert "cannot be serialized" in str(result.error)

--- a/tests/gateway/test_webhook_integration.py
+++ b/tests/gateway/test_webhook_integration.py
@@ -30,9 +30,10 @@ from gateway.platforms.webhook import WebhookAdapter, _INSECURE_NO_AUTH
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _make_adapter(routes, **extra_kw) -> WebhookAdapter:
     """Create a WebhookAdapter with the given routes."""
-    extra = {"host": "0.0.0.0", "port": 0, "routes": routes}
+    extra = {"host": "127.0.0.1", "port": 0, "routes": routes}
     extra.update(extra_kw)
     config = PlatformConfig(enabled=True, extra=extra)
     return WebhookAdapter(config)
@@ -48,9 +49,7 @@ def _create_app(adapter: WebhookAdapter) -> web.Application:
 
 def _github_signature(body: bytes, secret: str) -> str:
     """Compute X-Hub-Signature-256 for *body* using *secret*."""
-    return "sha256=" + hmac.new(
-        secret.encode(), body, hashlib.sha256
-    ).hexdigest()
+    return "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
 
 
 # A realistic GitHub pull_request event payload (trimmed)
@@ -58,6 +57,9 @@ GITHUB_PR_PAYLOAD = {
     "action": "opened",
     "number": 42,
     "pull_request": {
+        "id": 701,
+        "number": 42,
+        "state": "open",
         "title": "Add webhook adapter",
         "body": "This PR adds a generic webhook platform adapter.",
         "html_url": "https://github.com/org/repo/pull/42",
@@ -77,8 +79,8 @@ GITHUB_PR_PAYLOAD = {
 # Test 1: GitHub PR webhook triggers agent
 # ===================================================================
 
-class TestGitHubPRWebhook:
 
+class TestGitHubPRWebhook:
     @pytest.mark.asyncio
     async def test_github_pr_webhook_triggers_agent(self):
         """POST with a realistic GitHub PR payload should:
@@ -91,6 +93,7 @@ class TestGitHubPRWebhook:
         routes = {
             "github-pr": {
                 "secret": secret,
+                "provider": "github",
                 "events": ["pull_request"],
                 "prompt": (
                     "Review PR #{number} by {sender.login}: "
@@ -128,7 +131,11 @@ class TestGitHubPRWebhook:
             assert data["status"] == "accepted"
             assert data["route"] == "github-pr"
             assert data["event"] == "pull_request"
-            assert data["delivery_id"] == "gh-delivery-001"
+            # GitHub's delivery header is not covered by the body MAC, so it
+            # remains diagnostic-only and cannot become execution authority.
+            delivery_id = data["delivery_id"]
+            assert delivery_id != "gh-delivery-001"
+            assert len(delivery_id) == 32
 
         # Let the asyncio.create_task fire
         await asyncio.sleep(0.05)
@@ -140,15 +147,15 @@ class TestGitHubPRWebhook:
         assert event.source.chat_type == "webhook"
         assert event.source.platform == Platform.WEBHOOK
         assert "github-pr" in event.source.chat_id
-        assert event.message_id == "gh-delivery-001"
+        assert event.message_id == delivery_id
 
 
 # ===================================================================
 # Test 2: Skills injected into prompt
 # ===================================================================
 
-class TestSkillsInjection:
 
+class TestSkillsInjection:
     @pytest.mark.asyncio
     async def test_skills_injected_into_prompt(self):
         """When a route has skills: [code-review], the adapter should
@@ -157,6 +164,7 @@ class TestSkillsInjection:
         routes = {
             "pr-review": {
                 "secret": _INSECURE_NO_AUTH,
+                "provider": "github",
                 "events": ["pull_request"],
                 "prompt": "Review this PR: {pull_request.title}",
                 "skills": ["code-review"],
@@ -177,12 +185,15 @@ class TestSkillsInjection:
         )
 
         # The imports are lazy (inside the handler), so patch the source module
-        with patch(
-            "agent.skill_commands.build_skill_invocation_message",
-            return_value=skill_content,
-        ) as mock_build, patch(
-            "agent.skill_commands.get_skill_commands",
-            return_value={"/code-review": {"name": "code-review"}},
+        with (
+            patch(
+                "agent.skill_commands.build_skill_invocation_message",
+                return_value=skill_content,
+            ) as mock_build,
+            patch(
+                "agent.skill_commands.get_skill_commands",
+                return_value={"/code-review": {"name": "code-review"}},
+            ),
         ):
             app = _create_app(adapter)
             async with TestClient(TestServer(app)) as cli:
@@ -209,8 +220,8 @@ class TestSkillsInjection:
 # Test 3: Cross-platform delivery (webhook → Telegram)
 # ===================================================================
 
-class TestCrossPlatformDelivery:
 
+class TestCrossPlatformDelivery:
     @pytest.mark.asyncio
     async def test_cross_platform_delivery(self):
         """When deliver='telegram', the response is routed to the
@@ -218,6 +229,7 @@ class TestCrossPlatformDelivery:
         routes = {
             "alerts": {
                 "secret": _INSECURE_NO_AUTH,
+                "provider": "github",
                 "prompt": "Alert: {message}",
                 "deliver": "telegram",
                 "deliver_extra": {"chat_id": "12345"},
@@ -229,15 +241,23 @@ class TestCrossPlatformDelivery:
         # Set up a mock gateway runner with a mock Telegram adapter
         mock_tg_adapter = AsyncMock()
         mock_tg_adapter.send = AsyncMock(return_value=SendResult(success=True))
+        mock_tg_adapter.config = PlatformConfig(enabled=True, token="fake")
 
         mock_runner = MagicMock()
-        mock_runner.adapters = {Platform.TELEGRAM: mock_tg_adapter}
+        mock_runner.adapters = {
+            Platform.WEBHOOK: adapter,
+            Platform.TELEGRAM: mock_tg_adapter,
+        }
         mock_runner.config = GatewayConfig(
             platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake")}
         )
+        mock_runner._authorization_adapter = None
+        # MagicMock otherwise fabricates a callable profile-config resolver,
+        # making this narrow delivery double look like a full GatewayRunner.
+        mock_runner._resolve_profile_home_for_source = None
         adapter.gateway_runner = mock_runner
 
-        # First, simulate a webhook POST to set up delivery_info
+        # First, admit and durably prepare the exact target authority.
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
             resp = await cli.post(
@@ -247,28 +267,45 @@ class TestCrossPlatformDelivery:
             )
             assert resp.status == 202
 
-        # The adapter should have stored delivery info
-        chat_id = "webhook:alerts:alert-001"
-        assert chat_id in adapter._delivery_info
+        # Delivery target lookup is keyed by the execution trace, not the
+        # provider-controlled retry ID.
+        await asyncio.sleep(0.05)
+        event = adapter.handle_message.await_args.args[0]
+        chat_id = event.source.chat_id
+        assert chat_id.startswith("webhook:default:alerts:github:")
+        assert "alert-001" not in chat_id
+        assert event.webhook_authority.target_snapshot == {
+            "v": 1,
+            "kind": "platform",
+            "profile": "default",
+            "platform": "telegram",
+            "chat_id": "12345",
+        }
 
         # Now call send() as if the agent has finished
-        result = await adapter.send(chat_id, "I've acknowledged the alert.")
+        await adapter.on_processing_start(event)
+        result = await adapter.send(
+            chat_id,
+            "I've acknowledged the alert.",
+            metadata={"notify": True},
+        )
 
         assert result.success is True
         mock_tg_adapter.send.assert_awaited_once_with(
             "12345", "I've acknowledged the alert.", metadata=None
         )
-        # Delivery info is retained after send() so interim status messages
-        # don't strand the final response (TTL-based cleanup happens on POST).
-        assert chat_id in adapter._delivery_info
+        settled = adapter._operation_ledger.lookup_session(chat_id)
+        assert settled is not None
+        assert settled.delivery is not None
+        assert settled.delivery.content == "I've acknowledged the alert."
 
 
 # ===================================================================
 # Test 4: GitHub comment delivery via gh CLI
 # ===================================================================
 
-class TestGitHubCommentDelivery:
 
+class TestGitHubCommentDelivery:
     @pytest.mark.asyncio
     async def test_github_comment_delivery(self):
         """When deliver='github_comment', the adapter invokes
@@ -276,6 +313,7 @@ class TestGitHubCommentDelivery:
         routes = {
             "pr-bot": {
                 "secret": _INSECURE_NO_AUTH,
+                "provider": "github",
                 "prompt": "Review: {pull_request.title}",
                 "deliver": "github_comment",
                 "deliver_extra": {
@@ -287,54 +325,73 @@ class TestGitHubCommentDelivery:
         adapter = _make_adapter(routes)
         adapter.handle_message = AsyncMock()
 
-        # POST a webhook to set up delivery info
-        app = _create_app(adapter)
-        async with TestClient(TestServer(app)) as cli:
-            resp = await cli.post(
-                "/webhooks/pr-bot",
-                json=GITHUB_PR_PAYLOAD,
-                headers={
-                    "X-GitHub-Event": "pull_request",
-                    "X-GitHub-Delivery": "gh-comment-001",
-                },
-            )
-            assert resp.status == 202
-
-        chat_id = "webhook:pr-bot:gh-comment-001"
-        assert chat_id in adapter._delivery_info
-
-        # Verify deliver_extra was rendered with payload data
-        delivery = adapter._delivery_info[chat_id]
-        assert delivery["deliver_extra"]["repo"] == "org/repo"
-        assert delivery["deliver_extra"]["pr_number"] == "42"
-
-        # Mock subprocess.run and call send()
+        # Mock the exact executable resolution and subprocess target mutation.
         mock_result = MagicMock()
         mock_result.returncode = 0
         mock_result.stdout = "Comment posted"
         mock_result.stderr = ""
 
-        with patch(
-            "gateway.platforms.webhook.subprocess.run",
-            return_value=mock_result,
-        ) as mock_run:
+        with (
+            patch(
+                "gateway.platforms.webhook_route_authority.shutil.which",
+                return_value="/usr/bin/gh",
+            ),
+            patch(
+                "gateway.platforms.webhook_delivery.subprocess.run",
+                return_value=mock_result,
+            ) as mock_run,
+        ):
+            app = _create_app(adapter)
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post(
+                    "/webhooks/pr-bot",
+                    json=GITHUB_PR_PAYLOAD,
+                    headers={
+                        "X-GitHub-Event": "pull_request",
+                        "X-GitHub-Delivery": "gh-comment-001",
+                    },
+                )
+                assert resp.status == 202
+
+            await asyncio.sleep(0.05)
+            event = adapter.handle_message.await_args.args[0]
+            chat_id = event.source.chat_id
+            assert chat_id.startswith("webhook:default:pr-bot:github:")
+            assert "gh-comment-001" not in chat_id
+            assert event.webhook_authority.target_snapshot == {
+                "v": 1,
+                "kind": "github_comment",
+                "profile": "default",
+                "repo": "org/repo",
+                "pr_number": 42,
+            }
+
+            await adapter.on_processing_start(event)
             result = await adapter.send(
-                chat_id, "LGTM! The code looks great."
+                chat_id,
+                "LGTM! The code looks great.",
+                metadata={"notify": True},
             )
 
         assert result.success is True
-        mock_run.assert_called_once_with(
-            [
-                "gh", "pr", "comment", "42",
-                "--repo", "org/repo",
-                "--body", "LGTM! The code looks great.",
-            ],
-            capture_output=True,
-            text=True,
-            encoding="utf-8",
-            errors="replace",
-            timeout=30,
-        )
-        # Delivery info is retained after send() so interim status messages
-        # don't strand the final response (TTL-based cleanup happens on POST).
-        assert chat_id in adapter._delivery_info
+        mock_run.assert_called_once()
+        command = mock_run.call_args.args[0]
+        assert command == [
+            "/usr/bin/gh",
+            "pr",
+            "comment",
+            "42",
+            "--repo",
+            "org/repo",
+            "--body",
+            "LGTM! The code looks great.",
+        ]
+        kwargs = mock_run.call_args.kwargs
+        assert kwargs["capture_output"] is True
+        assert kwargs["text"] is True
+        assert kwargs["timeout"] == 30
+        assert kwargs["check"] is False
+        assert kwargs["env"]["GH_PROMPT_DISABLED"] == "1"
+        settled = adapter._operation_ledger.lookup_session(chat_id)
+        assert settled is not None
+        assert settled.delivery is not None

--- a/tests/gateway/test_webhook_ledger.py
+++ b/tests/gateway/test_webhook_ledger.py
@@ -1,0 +1,1308 @@
+"""Focused durability and transition tests for the inbound webhook ledger."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from threading import Barrier
+from types import MappingProxyType
+
+import pytest
+
+import gateway.platforms.webhook_ledger as ledger_module
+from gateway.platforms.webhook_auth import (
+    WebhookLocalBypassReceipt,
+    WebhookSignatureVerificationReceipt,
+)
+from gateway.platforms.webhook_contract import WebhookEnvelope, WebhookRouteConfig
+from gateway.platforms.webhook_ledger import (
+    AdmitDisposition,
+    OperationState,
+    RecoveryBatch,
+    Settlement,
+    SettlementKind,
+    TargetAttemptDisposition,
+    TargetState,
+    WebhookLedgerCorruptionError,
+    WebhookLedgerError,
+    WebhookLedgerTransitionError,
+    WebhookOperationLedger,
+    content_sha256,
+)
+
+
+def _envelope(
+    *,
+    delivery_id: str | None = "delivery-1",
+    trace_id: str = "trace-1",
+    payload: dict | None = None,
+    profile: str = "default",
+    route_name: str = "events",
+    provider: str = "github",
+    local_bypass: bool = False,
+) -> WebhookEnvelope:
+    body_payload = (
+        payload
+        if payload is not None
+        else {"event_type": "push", "value": delivery_id or trace_id}
+    )
+    raw_body = json.dumps(
+        body_payload,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode()
+    headers = (
+        {
+            "X-GitHub-Event": "push",
+            **({"X-GitHub-Delivery": delivery_id} if delivery_id is not None else {}),
+        }
+        if provider == "github"
+        else {"svix-id": delivery_id}
+        if delivery_id is not None
+        else {}
+    )
+    route = WebhookRouteConfig.bind(
+        route_name,
+        {"provider": provider, "profile": profile},
+        headers=headers,
+        request_profile=profile,
+    )
+    receipt_type = (
+        WebhookLocalBypassReceipt
+        if local_bypass
+        else WebhookSignatureVerificationReceipt
+    )
+    receipt = receipt_type._issue(route, raw_body, headers)
+    return WebhookEnvelope.from_receipt(
+        receipt,
+        raw_body=raw_body,
+        media_type="application/json",
+        trace_id=trace_id,
+    )
+
+
+def _snapshots(label: str = "one") -> dict[str, dict]:
+    return {
+        "event_snapshot": {
+            "event_type": "push",
+            "payload": {"label": label, "items": [1, 2]},
+        },
+        "target_snapshot": {
+            "type": "slack",
+            "channel": "C123",
+            "template": "{label}",
+        },
+        "grant_snapshot": {"toolsets": ["webhook", "slack"]},
+    }
+
+
+def _admit_and_prepare(
+    ledger: WebhookOperationLedger,
+    *,
+    delivery_id: str,
+    trace_id: str,
+):
+    admitted = ledger.admit(_envelope(delivery_id=delivery_id, trace_id=trace_id))
+    assert admitted.disposition is AdmitDisposition.ACCEPTED
+    assert admitted.authority is not None
+    return ledger.prepare(admitted.authority, **_snapshots(delivery_id))
+
+
+def _stage(
+    ledger: WebhookOperationLedger,
+    authority,
+    *,
+    content: str = "agent response",
+    carrier: dict | None = None,
+):
+    assert ledger.mark_running(authority)
+    return ledger.stage_delivery(
+        authority,
+        content=content,
+        carrier_snapshot=carrier or {"delivery_type": "slack", "channel": "C123"},
+    )
+
+
+def test_running_gate_has_exactly_one_winner(tmp_path: Path):
+    db_path = tmp_path / "state.db"
+    first = WebhookOperationLedger(db_path, instance_id="running-owner")
+    second = WebhookOperationLedger(db_path, instance_id="running-owner")
+    authority = _admit_and_prepare(
+        first,
+        delivery_id="one-run",
+        trace_id="one-run-trace",
+    )
+    barrier = Barrier(2)
+
+    def start(handle: WebhookOperationLedger) -> bool:
+        barrier.wait(timeout=5)
+        return handle.mark_running(authority)
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(start, (first, second)))
+
+    assert sorted(results) == [False, True]
+    current = first.lookup_session(authority.session_key)
+    assert current is not None
+    assert current.state is OperationState.RUNNING
+
+
+def test_script_start_gate_has_exactly_one_winner(tmp_path: Path):
+    db_path = tmp_path / "state.db"
+    first = WebhookOperationLedger(db_path, instance_id="script-owner")
+    second = WebhookOperationLedger(db_path, instance_id="script-owner")
+    admitted = first.admit(
+        _envelope(delivery_id="one-script", trace_id="one-script-trace")
+    )
+    assert admitted.authority is not None
+    authority = admitted.authority
+
+    assert first.mark_script_started(authority)
+    assert not first.mark_script_started(authority)
+
+    other = first.admit(
+        _envelope(delivery_id="racing-script", trace_id="racing-script-trace")
+    )
+    assert other.authority is not None
+    barrier = Barrier(2)
+
+    def start(handle: WebhookOperationLedger) -> bool:
+        barrier.wait(timeout=5)
+        return handle.mark_script_started(other.authority)
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(start, (first, second)))
+
+    assert sorted(results) == [False, True]
+
+
+def test_atomic_stable_admission_across_connections(tmp_path: Path):
+    db_path = tmp_path / "state.db"
+    first = WebhookOperationLedger(db_path)
+    second = WebhookOperationLedger(db_path)
+    barrier = Barrier(2)
+    envelopes = (
+        _envelope(delivery_id="same-delivery", trace_id="trace-a"),
+        _envelope(delivery_id="same-delivery", trace_id="trace-b"),
+    )
+
+    def admit(index: int):
+        barrier.wait(timeout=5)
+        return (first, second)[index].admit(envelopes[index])
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(admit, range(2)))
+
+    assert {result.disposition for result in results} == {
+        AdmitDisposition.ACCEPTED,
+        AdmitDisposition.ACTIVE,
+    }
+    assert first.count() == 1
+    assert {
+        result.authority.operation_id
+        for result in results
+        if result.authority is not None
+    } == {results[0].authority.operation_id}
+
+
+def test_replay_identity_uses_authenticated_coverage_not_observed_headers(
+    tmp_path: Path,
+):
+    ledger = WebhookOperationLedger(tmp_path / "state.db")
+    native = ledger.admit(
+        _envelope(
+            delivery_id="provider-id",
+            trace_id="trace-a",
+            provider="svix",
+        )
+    )
+    native_conflict = ledger.admit(
+        _envelope(
+            delivery_id="provider-id",
+            trace_id="trace-b",
+            payload={"event_type": "push", "value": 2},
+            provider="svix",
+        )
+    )
+    shared_body = {"event_type": "push", "value": "same-authenticated-body"}
+    observed_a = ledger.admit(
+        _envelope(delivery_id="unsigned-a", trace_id="observed-a", payload=shared_body)
+    )
+    observed_b = ledger.admit(
+        _envelope(delivery_id="unsigned-b", trace_id="observed-b", payload=shared_body)
+    )
+    changed_body = ledger.admit(
+        _envelope(
+            delivery_id="unsigned-a",
+            trace_id="observed-c",
+            payload={"event_type": "push", "value": "different-body"},
+        )
+    )
+
+    assert native.disposition is AdmitDisposition.ACCEPTED
+    assert native_conflict.disposition is AdmitDisposition.CONFLICT
+    assert observed_a.disposition is AdmitDisposition.ACCEPTED
+    assert observed_b.disposition is AdmitDisposition.ACTIVE
+    assert changed_body.disposition is AdmitDisposition.ACCEPTED
+    assert ledger.count() == 3
+
+
+def test_prepare_persists_exact_frozen_session_authority_across_restart(
+    tmp_path: Path,
+):
+    db_path = tmp_path / "state.db"
+    ledger = WebhookOperationLedger(db_path)
+    accepted = ledger.admit(_envelope(delivery_id="restart", trace_id="restart-trace"))
+    assert accepted.authority is not None
+    prepared = ledger.prepare(accepted.authority, **_snapshots("restart"))
+
+    restarted = WebhookOperationLedger(db_path)
+    restored = restarted.lookup_session(prepared.session_key)
+
+    assert restored is not None
+    assert restored.state is OperationState.READY
+    assert restored.operation_id == prepared.operation_id
+    assert restored.target_state is TargetState.PENDING
+    assert restored.event_snapshot["event_type"] == "push"
+    assert restored.event_snapshot["payload"]["label"] == "restart"
+    assert restored.event_snapshot["payload"]["items"] == (1, 2)
+    assert restored.target_snapshot == _snapshots("restart")["target_snapshot"]
+    assert restored.grant_snapshot["toolsets"] == ("webhook", "slack")
+    assert isinstance(restored.event_snapshot, MappingProxyType)
+    with pytest.raises(TypeError):
+        restored.grant_snapshot["toolsets"] = []  # type: ignore[index]
+
+
+def test_prepare_is_idempotent_only_for_the_exact_snapshot(tmp_path: Path):
+    ledger = WebhookOperationLedger(tmp_path / "state.db")
+    accepted = ledger.admit(_envelope(delivery_id="prepare", trace_id="prepare-trace"))
+    assert accepted.authority is not None
+    prepared = ledger.prepare(accepted.authority, **_snapshots("same"))
+
+    repeated = ledger.prepare(accepted.authority, **_snapshots("same"))
+    assert repeated == prepared
+    with pytest.raises(WebhookLedgerTransitionError):
+        ledger.prepare(accepted.authority, **_snapshots("different"))
+
+
+def test_prepare_accepts_nested_immutable_json_projections(tmp_path: Path):
+    ledger = WebhookOperationLedger(tmp_path / "state.db")
+    accepted = ledger.admit(
+        _envelope(delivery_id="immutable", trace_id="immutable-trace")
+    )
+    assert accepted.authority is not None
+
+    prepared = ledger.prepare(
+        accepted.authority,
+        event_snapshot=MappingProxyType({
+            "payload": MappingProxyType({"items": ("a", "b")})
+        }),
+        target_snapshot=MappingProxyType({"deliver": "log"}),
+        grant_snapshot=MappingProxyType({"toolsets": ("webhook",)}),
+    )
+
+    assert prepared.event_snapshot["payload"]["items"] == ("a", "b")
+    assert prepared.grant_snapshot["toolsets"] == ("webhook",)
+
+
+def test_prepare_rolls_back_target_when_operation_commit_fails(tmp_path: Path):
+    db_path = tmp_path / "state.db"
+    ledger = WebhookOperationLedger(db_path)
+    accepted = ledger.admit(
+        _envelope(delivery_id="rollback", trace_id="rollback-trace")
+    )
+    assert accepted.authority is not None
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """CREATE TRIGGER reject_webhook_prepare
+               BEFORE UPDATE OF state ON webhook_operations
+               WHEN NEW.state='ready'
+               BEGIN SELECT RAISE(ABORT, 'injected prepare failure'); END"""
+        )
+
+    with pytest.raises(WebhookLedgerError, match="SQLITE_CONSTRAINT_TRIGGER"):
+        ledger.prepare(accepted.authority, **_snapshots("rollback"))
+
+    with sqlite3.connect(db_path) as conn:
+        state = conn.execute(
+            "SELECT state FROM webhook_operations WHERE operation_id=?",
+            (accepted.authority.operation_id,),
+        ).fetchone()[0]
+        target_count = conn.execute("SELECT COUNT(*) FROM webhook_targets").fetchone()[
+            0
+        ]
+    assert state == OperationState.PREPARING.value
+    assert target_count == 0
+
+
+def test_stage_delivery_rolls_back_target_when_operation_commit_fails(tmp_path: Path):
+    db_path = tmp_path / "state.db"
+    ledger = WebhookOperationLedger(db_path)
+    prepared = _admit_and_prepare(
+        ledger,
+        delivery_id="stage-rollback",
+        trace_id="stage-rollback-trace",
+    )
+    assert ledger.mark_running(prepared)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """CREATE TRIGGER reject_webhook_stage
+               BEFORE UPDATE OF state ON webhook_operations
+               WHEN NEW.state='delivery_ready'
+               BEGIN SELECT RAISE(ABORT, 'injected stage failure'); END"""
+        )
+
+    with pytest.raises(WebhookLedgerError, match="SQLITE_CONSTRAINT_TRIGGER"):
+        ledger.stage_delivery(
+            prepared,
+            content="response",
+            carrier_snapshot={"kind": "platform", "chat_id": "C123"},
+        )
+
+    restored = WebhookOperationLedger(db_path).lookup_session(prepared.session_key)
+    assert restored is not None
+    assert restored.state is OperationState.RUNNING
+    assert restored.target_state is TargetState.PENDING
+    assert restored.delivery is None
+
+
+def test_begin_target_rolls_back_attempt_when_operation_commit_fails(tmp_path: Path):
+    db_path = tmp_path / "state.db"
+    ledger = WebhookOperationLedger(db_path)
+    prepared = _admit_and_prepare(
+        ledger,
+        delivery_id="begin-rollback",
+        trace_id="begin-rollback-trace",
+    )
+    staged = _stage(ledger, prepared, content="response")
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """CREATE TRIGGER reject_webhook_begin
+               BEFORE UPDATE OF state ON webhook_operations
+               WHEN NEW.state='delivering'
+               BEGIN SELECT RAISE(ABORT, 'injected begin failure'); END"""
+        )
+
+    with pytest.raises(WebhookLedgerError, match="SQLITE_CONSTRAINT_TRIGGER"):
+        ledger.begin_target(staged)
+
+    restored = WebhookOperationLedger(db_path).lookup_session(prepared.session_key)
+    assert restored is not None
+    assert restored.state is OperationState.DELIVERY_READY
+    assert restored.target_state is TargetState.PENDING
+
+
+def test_settle_target_rolls_back_target_when_operation_commit_fails(tmp_path: Path):
+    db_path = tmp_path / "state.db"
+    ledger = WebhookOperationLedger(db_path)
+    prepared = _admit_and_prepare(
+        ledger,
+        delivery_id="settle-rollback",
+        trace_id="settle-rollback-trace",
+    )
+    staged = _stage(ledger, prepared, content="response")
+    attempt = ledger.begin_target(staged)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """CREATE TRIGGER reject_webhook_settle
+               BEFORE UPDATE OF state ON webhook_operations
+               WHEN NEW.state='settled'
+               BEGIN SELECT RAISE(ABORT, 'injected settle failure'); END"""
+        )
+
+    with pytest.raises(WebhookLedgerError, match="SQLITE_CONSTRAINT_TRIGGER"):
+        ledger.settle_target(
+            attempt,
+            Settlement(SettlementKind.CONFIRMED, external_id="message-1"),
+        )
+
+    restored = WebhookOperationLedger(db_path).lookup_session(prepared.session_key)
+    assert restored is not None
+    assert restored.state is OperationState.DELIVERING
+    assert restored.target_state is TargetState.ATTEMPTING
+
+
+def test_settle_no_effect_rolls_back_operation_when_target_commit_fails(
+    tmp_path: Path,
+):
+    db_path = tmp_path / "state.db"
+    ledger = WebhookOperationLedger(db_path)
+    prepared = _admit_and_prepare(
+        ledger,
+        delivery_id="no-effect-rollback",
+        trace_id="no-effect-rollback-trace",
+    )
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """CREATE TRIGGER reject_webhook_no_effect
+               BEFORE UPDATE OF state ON webhook_targets
+               WHEN NEW.state='suppressed'
+               BEGIN SELECT RAISE(ABORT, 'injected no-effect failure'); END"""
+        )
+
+    with pytest.raises(WebhookLedgerError, match="SQLITE_CONSTRAINT_TRIGGER"):
+        ledger.settle_no_effect(prepared, "ignored")
+
+    restored = WebhookOperationLedger(db_path).lookup_session(prepared.session_key)
+    assert restored is not None
+    assert restored.state is OperationState.READY
+    assert restored.target_state is TargetState.PENDING
+
+
+def test_target_attempt_is_fenced_settled_and_cached_after_restart(tmp_path: Path):
+    db_path = tmp_path / "state.db"
+    ledger = WebhookOperationLedger(db_path)
+    prepared = _admit_and_prepare(
+        ledger,
+        delivery_id="target-confirm",
+        trace_id="target-confirm-trace",
+    )
+    digest = content_sha256("agent response")
+    staged = _stage(ledger, prepared, content="agent response")
+
+    attempt = ledger.begin_target(staged, content_sha256=digest)
+    assert attempt.disposition is TargetAttemptDisposition.STARTED
+    assert attempt.delivery is not None
+    assert attempt.delivery.content == "agent response"
+    assert attempt.delivery.carrier["channel"] == "C123"
+    assert ledger.settle_target(
+        attempt,
+        Settlement(SettlementKind.CONFIRMED, external_id="message-123"),
+    )
+
+    restarted = WebhookOperationLedger(db_path)
+    restored = restarted.lookup_session(prepared.session_key)
+    assert restored is not None
+    assert restored.state is OperationState.SETTLED
+    assert restored.target_state is TargetState.CONFIRMED
+    cached = restarted.begin_target(restored, content_sha256=digest)
+    assert cached.disposition is TargetAttemptDisposition.CACHED
+    duplicate = restarted.admit(
+        _envelope(
+            delivery_id="target-confirm",
+            trace_id="provider-retry-gets-a-new-trace",
+        )
+    )
+    assert duplicate.disposition is AdmitDisposition.DUPLICATE
+
+
+def test_pre_effect_failure_reopens_target_but_stale_attempt_cannot_settle(
+    tmp_path: Path,
+):
+    ledger = WebhookOperationLedger(tmp_path / "state.db")
+    prepared = _admit_and_prepare(
+        ledger,
+        delivery_id="retry-target",
+        trace_id="retry-target-trace",
+    )
+    digest = content_sha256("same response")
+    staged = _stage(ledger, prepared, content="same response")
+
+    first = ledger.begin_target(staged, content_sha256=digest)
+    assert ledger.settle_target(
+        first,
+        Settlement(SettlementKind.PRE_EFFECT_FAILED, error="socket never opened"),
+    )
+    retryable = ledger.lookup_session(prepared.session_key)
+    assert retryable is not None
+    assert retryable.state is OperationState.DELIVERY_READY
+    assert retryable.target_state is TargetState.PENDING
+    assert retryable.delivery is not None
+    assert retryable.delivery.content == "same response"
+    second = ledger.begin_target(retryable, content_sha256=digest)
+
+    assert second.disposition is TargetAttemptDisposition.STARTED
+    assert second.attempt_token != first.attempt_token
+    assert not ledger.settle_target(
+        first,
+        Settlement(SettlementKind.CONFIRMED, external_id="stale"),
+    )
+    assert ledger.settle_target(
+        second,
+        Settlement(SettlementKind.SUPPRESSED, error="policy silence"),
+    )
+    restored = ledger.lookup_session(prepared.session_key)
+    assert restored is not None
+    assert restored.state is OperationState.SETTLED
+    assert restored.target_state is TargetState.SUPPRESSED
+
+
+def test_target_content_fence_rejects_mismatched_active_and_cached_attempts(
+    tmp_path: Path,
+):
+    ledger = WebhookOperationLedger(tmp_path / "state.db")
+    prepared = _admit_and_prepare(
+        ledger,
+        delivery_id="content-fence",
+        trace_id="content-fence-trace",
+    )
+    original_digest = content_sha256("original response")
+    different_digest = content_sha256("different response")
+    staged = _stage(ledger, prepared, content="original response")
+
+    attempt = ledger.begin_target(staged, content_sha256=original_digest)
+    with pytest.raises(WebhookLedgerTransitionError, match="durable staged delivery"):
+        ledger.begin_target(staged, content_sha256=different_digest)
+
+    assert ledger.settle_target(
+        attempt,
+        Settlement(SettlementKind.CONFIRMED, external_id="message-1"),
+    )
+    settled = ledger.lookup_session(prepared.session_key)
+    assert settled is not None
+    with pytest.raises(WebhookLedgerTransitionError, match="durable staged delivery"):
+        ledger.begin_target(settled, content_sha256=different_digest)
+    assert (
+        ledger.begin_target(settled, content_sha256=original_digest).disposition
+        is TargetAttemptDisposition.CACHED
+    )
+
+
+def test_staged_delivery_is_idempotent_only_for_exact_content_and_carrier(
+    tmp_path: Path,
+):
+    ledger = WebhookOperationLedger(tmp_path / "state.db")
+    prepared = _admit_and_prepare(
+        ledger,
+        delivery_id="restage",
+        trace_id="restage-trace",
+    )
+    assert ledger.mark_running(prepared)
+    carrier = {"kind": "platform", "chat_id": "C123"}
+    staged = ledger.stage_delivery(
+        prepared,
+        content="exact response",
+        carrier_snapshot=carrier,
+    )
+
+    assert (
+        ledger.stage_delivery(
+            staged,
+            content="exact response",
+            carrier_snapshot=carrier,
+        )
+        == staged
+    )
+    with pytest.raises(WebhookLedgerTransitionError, match="cannot be rebound"):
+        ledger.stage_delivery(
+            staged,
+            content="different response",
+            carrier_snapshot=carrier,
+        )
+    with pytest.raises(WebhookLedgerTransitionError, match="cannot be rebound"):
+        ledger.stage_delivery(
+            staged,
+            content="exact response",
+            carrier_snapshot={"kind": "platform", "chat_id": "C999"},
+        )
+
+
+def test_dead_owner_recovers_pre_effect_failure_as_delivery_only(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    ledger = WebhookOperationLedger(tmp_path / "state.db")
+    prepared = _admit_and_prepare(
+        ledger,
+        delivery_id="pre-effect-recovery",
+        trace_id="pre-effect-recovery-trace",
+    )
+    staged = _stage(ledger, prepared, content="response")
+    attempt = ledger.begin_target(
+        staged,
+        content_sha256=content_sha256("response"),
+    )
+    assert ledger.settle_target(
+        attempt,
+        Settlement(SettlementKind.PRE_EFFECT_FAILED, error="not invoked"),
+    )
+
+    monkeypatch.setattr(ledger_module, "_owner_alive", lambda *_: False)
+    recovered = ledger.recover_dead_owners(now=1000.0)
+
+    assert recovered.indeterminate == ()
+    assert recovered.event_ready == ()
+    assert [item.operation_id for item in recovered.delivery_ready] == [
+        prepared.operation_id
+    ]
+    replay = recovered.delivery_ready[0]
+    assert replay.generation == prepared.generation + 1
+    assert replay.target_state is TargetState.PENDING
+    assert replay.delivery is not None
+    assert replay.delivery.content == "response"
+    assert ledger.begin_target(replay).disposition is TargetAttemptDisposition.STARTED
+
+
+def test_current_delivery_ready_lists_only_this_instances_retryable_staged_work(
+    tmp_path: Path,
+):
+    db_path = tmp_path / "state.db"
+    owner = WebhookOperationLedger(db_path, instance_id="owner")
+    peer = WebhookOperationLedger(db_path, instance_id="peer")
+
+    event_ready = _admit_and_prepare(
+        owner,
+        delivery_id="event-ready",
+        trace_id="event-ready-trace",
+    )
+    first = _admit_and_prepare(
+        owner,
+        delivery_id="first-staged",
+        trace_id="first-staged-trace",
+    )
+    first = _stage(owner, first, content="first exact output")
+    retryable = _admit_and_prepare(
+        owner,
+        delivery_id="retryable-staged",
+        trace_id="retryable-staged-trace",
+    )
+    retryable = _stage(owner, retryable, content="retry exact output")
+    retry_attempt = owner.begin_target(retryable)
+    assert owner.settle_target(
+        retry_attempt,
+        Settlement(SettlementKind.PRE_EFFECT_FAILED, error="adapter unavailable"),
+    )
+    attempting = _admit_and_prepare(
+        owner,
+        delivery_id="attempting",
+        trace_id="attempting-trace",
+    )
+    attempting = _stage(owner, attempting, content="already attempting")
+    assert (
+        owner.begin_target(attempting).disposition is TargetAttemptDisposition.STARTED
+    )
+    peer_staged = _admit_and_prepare(
+        peer,
+        delivery_id="peer-staged",
+        trace_id="peer-staged-trace",
+    )
+    peer_staged = _stage(peer, peer_staged, content="peer exact output")
+
+    current = owner.current_delivery_ready()
+
+    assert {item.operation_id for item in current} == {
+        first.operation_id,
+        retryable.operation_id,
+    }
+    assert event_ready.operation_id not in {item.operation_id for item in current}
+    assert attempting.operation_id not in {item.operation_id for item in current}
+    assert peer_staged.operation_id not in {item.operation_id for item in current}
+    assert all(item.owner_instance == owner.instance_id for item in current)
+    assert {
+        item.operation_id: item.delivery.content if item.delivery is not None else None
+        for item in current
+    } == {
+        first.operation_id: "first exact output",
+        retryable.operation_id: "retry exact output",
+    }
+    assert [item.operation_id for item in peer.current_delivery_ready()] == [
+        peer_staged.operation_id
+    ]
+
+    assert owner.begin_target(first).disposition is TargetAttemptDisposition.STARTED
+    assert [item.operation_id for item in owner.current_delivery_ready()] == [
+        retryable.operation_id
+    ]
+
+
+def test_racing_current_delivery_recovery_triggers_cross_one_target_gate(
+    tmp_path: Path,
+):
+    db_path = tmp_path / "state.db"
+    first_handle = WebhookOperationLedger(db_path, instance_id="live-adapter")
+    second_handle = WebhookOperationLedger(db_path, instance_id="live-adapter")
+    prepared = _admit_and_prepare(
+        first_handle,
+        delivery_id="reconnect-race",
+        trace_id="reconnect-race-trace",
+    )
+    staged = _stage(first_handle, prepared, content="one durable output")
+    barrier = Barrier(2)
+
+    def begin(handle: WebhookOperationLedger):
+        authority = handle.current_delivery_ready()[0]
+        barrier.wait(timeout=5)
+        return handle.begin_target(authority)
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        attempts = list(pool.map(begin, (first_handle, second_handle)))
+
+    assert {attempt.disposition for attempt in attempts} == {
+        TargetAttemptDisposition.STARTED,
+        TargetAttemptDisposition.IN_PROGRESS,
+    }
+    assert (
+        sum(
+            attempt.attempt_token is not None
+            for attempt in attempts
+            if attempt.disposition is TargetAttemptDisposition.STARTED
+        )
+        == 1
+    )
+    assert first_handle.current_delivery_ready() == ()
+    assert second_handle.current_delivery_ready() == ()
+
+    started = next(
+        attempt
+        for attempt in attempts
+        if attempt.disposition is TargetAttemptDisposition.STARTED
+    )
+    assert first_handle.settle_target(
+        started,
+        Settlement(SettlementKind.CONFIRMED, external_id="message-1"),
+    )
+    restored = second_handle.lookup_session(staged.session_key)
+    assert restored is not None
+    assert restored.state is OperationState.SETTLED
+    assert restored.target_state is TargetState.CONFIRMED
+
+
+def test_indeterminate_target_never_retries(tmp_path: Path):
+    ledger = WebhookOperationLedger(tmp_path / "state.db")
+    prepared = _admit_and_prepare(
+        ledger,
+        delivery_id="unknown-target",
+        trace_id="unknown-target-trace",
+    )
+    digest = content_sha256("response")
+    staged = _stage(ledger, prepared, content="response")
+    attempt = ledger.begin_target(staged, content_sha256=digest)
+    assert not ledger.settle_no_effect(staged, "cannot bypass an active effect")
+    active = ledger.lookup_session(prepared.session_key)
+    assert active is not None
+    assert active.state is OperationState.DELIVERING
+    assert active.target_state is TargetState.ATTEMPTING
+    assert ledger.settle_target(
+        attempt,
+        Settlement(SettlementKind.INDETERMINATE, error="connection reset after write"),
+    )
+
+    restored = ledger.lookup_session(prepared.session_key)
+    assert restored is not None
+    assert restored.state is OperationState.INDETERMINATE
+    assert restored.target_state is TargetState.INDETERMINATE
+    retry = ledger.begin_target(restored, content_sha256=digest)
+    assert retry.disposition is TargetAttemptDisposition.INDETERMINATE
+
+
+def test_dead_owner_recovery_replays_only_committed_pre_effect_work(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    ledger = WebhookOperationLedger(tmp_path / "state.db")
+
+    safe_preparing = ledger.admit(
+        _envelope(delivery_id="pre-safe", trace_id="pre-safe-trace")
+    ).authority
+    script_preparing = ledger.admit(
+        _envelope(delivery_id="pre-script", trace_id="pre-script-trace")
+    ).authority
+    assert safe_preparing is not None
+    assert script_preparing is not None
+    assert ledger.mark_script_started(script_preparing)
+
+    ready = _admit_and_prepare(
+        ledger,
+        delivery_id="ready",
+        trace_id="ready-trace",
+    )
+    running = _admit_and_prepare(
+        ledger,
+        delivery_id="running",
+        trace_id="running-trace",
+    )
+    assert ledger.mark_running(running)
+    attempting = _admit_and_prepare(
+        ledger,
+        delivery_id="attempting",
+        trace_id="attempting-trace",
+    )
+    attempting = _stage(ledger, attempting, content="response")
+    attempt = ledger.begin_target(
+        attempting,
+        content_sha256=content_sha256("response"),
+    )
+    assert attempt.disposition is TargetAttemptDisposition.STARTED
+
+    monkeypatch.setattr(ledger_module, "_owner_alive", lambda *_: False)
+    recovered = ledger.recover_dead_owners(now=1000.0)
+
+    assert recovered.released == (safe_preparing.operation_id,)
+    assert {item.operation_id for item in recovered.event_ready} == {ready.operation_id}
+    assert recovered.delivery_ready == ()
+    assert set(recovered.indeterminate) == {
+        script_preparing.operation_id,
+        running.operation_id,
+        attempting.operation_id,
+    }
+    replay = recovered.event_ready[0]
+    assert replay.generation == ready.generation + 1
+    with pytest.raises(WebhookLedgerTransitionError):
+        ledger.stage_delivery(
+            ready,
+            content="stale",
+            carrier_snapshot={"delivery_type": "log"},
+        )
+    assert ledger.mark_running(replay)
+    replay = ledger.stage_delivery(
+        replay,
+        content="fresh",
+        carrier_snapshot={"delivery_type": "log"},
+    )
+    assert (
+        ledger.begin_target(replay, content_sha256=content_sha256("fresh")).disposition
+        is TargetAttemptDisposition.STARTED
+    )
+    attempted_state = ledger.lookup_session(attempting.session_key)
+    assert attempted_state is not None
+    assert attempted_state.state is OperationState.INDETERMINATE
+    assert attempted_state.target_state is TargetState.INDETERMINATE
+
+
+def test_same_pid_instance_retirement_fences_old_owner_without_stealing_peer(
+    tmp_path: Path,
+):
+    db_path = tmp_path / "state.db"
+    old = WebhookOperationLedger(db_path, instance_id="old-adapter")
+    peer = WebhookOperationLedger(db_path, instance_id="live-peer")
+    replacement = WebhookOperationLedger(db_path, instance_id="replacement")
+
+    event_ready = _admit_and_prepare(
+        old,
+        delivery_id="old-event-ready",
+        trace_id="old-event-ready-trace",
+    )
+    delivery_ready = _admit_and_prepare(
+        old,
+        delivery_id="old-delivery-ready",
+        trace_id="old-delivery-ready-trace",
+    )
+    delivery_ready = _stage(old, delivery_ready, content="persisted output")
+    running = _admit_and_prepare(
+        old,
+        delivery_id="old-running",
+        trace_id="old-running-trace",
+    )
+    assert old.mark_running(running)
+    peer_ready = _admit_and_prepare(
+        peer,
+        delivery_id="peer-ready",
+        trace_id="peer-ready-trace",
+    )
+
+    # A different object in the same live PID is not evidence of owner death.
+    assert replacement.recover_dead_owners().event_ready == ()
+    retired = old.retire_instance(now=500.0)
+    assert retired.indeterminate == (running.operation_id,)
+    assert not old.mark_running(event_ready)
+    with pytest.raises(
+        WebhookLedgerTransitionError, match="different adapter instance"
+    ):
+        old.begin_target(delivery_ready)
+
+    recovered = replacement.recover_dead_owners(now=501.0)
+    assert {item.operation_id for item in recovered.event_ready} == {
+        event_ready.operation_id
+    }
+    assert {item.operation_id for item in recovered.delivery_ready} == {
+        delivery_ready.operation_id
+    }
+    assert all(
+        item.owner_instance == replacement.instance_id
+        for item in (*recovered.event_ready, *recovered.delivery_ready)
+    )
+    still_peer_owned = peer.lookup_session(peer_ready.session_key)
+    assert still_peer_owned is not None
+    assert still_peer_owned.owner_instance == peer.instance_id
+    running_state = replacement.lookup_session(running.session_key)
+    assert running_state is not None
+    assert running_state.state is OperationState.INDETERMINATE
+
+
+def test_replacement_retries_exact_prior_owner_retirement_idempotently(
+    tmp_path: Path,
+):
+    db_path = tmp_path / "state.db"
+    old = WebhookOperationLedger(db_path, instance_id="quarantined-adapter")
+    peer = WebhookOperationLedger(db_path, instance_id="unrelated-live-peer")
+    replacement = WebhookOperationLedger(db_path, instance_id="replacement")
+
+    preparing = old.admit(
+        _envelope(
+            delivery_id="quarantined-preparing",
+            trace_id="quarantined-preparing-trace",
+        )
+    )
+    assert preparing.authority is not None
+    ready = _admit_and_prepare(
+        old,
+        delivery_id="quarantined-ready",
+        trace_id="quarantined-ready-trace",
+    )
+    running = _admit_and_prepare(
+        old,
+        delivery_id="quarantined-running",
+        trace_id="quarantined-running-trace",
+    )
+    assert old.mark_running(running)
+    peer_ready = _admit_and_prepare(
+        peer,
+        delivery_id="peer-stays-live",
+        trace_id="peer-stays-live-trace",
+    )
+
+    assert replacement.recover_dead_owners().event_ready == ()
+    retired = replacement.retire_owner_instance(
+        old.instance_id,
+        now=700.0,
+    )
+    assert retired.released == (preparing.authority.operation_id,)
+    assert retired.indeterminate == (running.operation_id,)
+    assert (
+        replacement.retire_owner_instance(
+            old.instance_id,
+            now=701.0,
+        )
+        == RecoveryBatch()
+    )
+
+    recovered = replacement.recover_dead_owners(now=702.0)
+    assert tuple(item.operation_id for item in recovered.event_ready) == (
+        ready.operation_id,
+    )
+    peer_state = replacement.lookup_session(peer_ready.session_key)
+    assert peer_state is not None
+    assert peer_state.owner_instance == peer.instance_id
+    running_state = replacement.lookup_session(running.session_key)
+    assert running_state is not None
+    assert running_state.state is OperationState.INDETERMINATE
+
+
+def test_capacity_compacts_heavy_rows_but_stable_identity_never_reopens(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    clock = {"now": 100.0}
+    monkeypatch.setattr(ledger_module.time, "time", lambda: clock["now"])
+    ledger = WebhookOperationLedger(
+        tmp_path / "state.db",
+        max_records=1,
+        terminal_retention_seconds=10,
+    )
+    accepted = ledger.admit(
+        _envelope(delivery_id="old", trace_id="old-trace", provider="svix")
+    )
+    assert accepted.authority is not None
+    assert ledger.settle_no_effect(accepted.authority, "filtered")
+
+    clock["now"] = 105.0
+    assert (
+        ledger.admit(
+            _envelope(delivery_id="new", trace_id="new-trace", provider="svix")
+        ).disposition
+        is AdmitDisposition.ACCEPTED
+    )
+    assert ledger.count() == 1
+    assert ledger.tombstone_count() == 1
+    ancient_retry = ledger.admit(
+        _envelope(delivery_id="old", trace_id="ancient-retry", provider="svix")
+    )
+    assert ancient_retry.disposition is AdmitDisposition.DUPLICATE
+    assert ancient_retry.authority is None
+    assert ancient_retry.tombstone is not None
+    assert ancient_retry.tombstone.operation_id == "old-trace"
+    ancient_conflict = ledger.admit(
+        _envelope(
+            delivery_id="old",
+            trace_id="ancient-conflict",
+            payload={"event_type": "push", "value": 999},
+            provider="svix",
+        )
+    )
+    assert ancient_conflict.disposition is AdmitDisposition.CONFLICT
+    assert ancient_conflict.tombstone == ancient_retry.tombstone
+
+
+def test_remote_body_only_settlement_replay_fence_never_reopens(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    clock = {"now": 100.0}
+    monkeypatch.setattr(ledger_module.time, "time", lambda: clock["now"])
+    ledger = WebhookOperationLedger(
+        tmp_path / "state.db",
+        local_bypass_replay_retention_seconds=10,
+        terminal_retention_seconds=1,
+    )
+    payload = {"event_type": "push", "value": "identical"}
+    first = ledger.admit(
+        _envelope(
+            delivery_id="observed-a",
+            trace_id="body-a",
+            payload=payload,
+            provider="github",
+        )
+    )
+    assert first.authority is not None
+    assert ledger.settle_no_effect(first.authority, "complete")
+
+    clock["now"] = 102.0
+    assert ledger.prune() == 1
+    assert ledger.count() == 0
+    assert ledger.tombstone_count() == 1
+
+    clock["now"] = 109.0
+    assert (
+        ledger.admit(
+            _envelope(
+                delivery_id="observed-b",
+                trace_id="body-b",
+                payload=payload,
+                provider="github",
+            )
+        ).disposition
+        is AdmitDisposition.DUPLICATE
+    )
+
+    clock["now"] = 110.0
+    permanent_retry = ledger.admit(
+        _envelope(
+            delivery_id="observed-c",
+            trace_id="body-c",
+            payload=payload,
+            provider="github",
+        )
+    )
+    assert permanent_retry.disposition is AdmitDisposition.DUPLICATE
+
+
+def test_local_bypass_settlement_replay_fence_expires_explicitly(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    clock = {"now": 100.0}
+    monkeypatch.setattr(ledger_module.time, "time", lambda: clock["now"])
+    ledger = WebhookOperationLedger(
+        tmp_path / "state.db",
+        local_bypass_replay_retention_seconds=10,
+        terminal_retention_seconds=1,
+    )
+    payload = {"event_type": "push", "value": "local-test"}
+    first = ledger.admit(
+        _envelope(
+            delivery_id="observed-a",
+            trace_id="local-a",
+            payload=payload,
+            local_bypass=True,
+        )
+    )
+    assert first.authority is not None
+    assert ledger.settle_no_effect(first.authority, "complete")
+
+    clock["now"] = 102.0
+    assert ledger.prune() == 1
+    assert ledger.count() == 0
+    assert ledger.tombstone_count() == 1
+
+    clock["now"] = 109.0
+    assert (
+        ledger.admit(
+            _envelope(
+                delivery_id="observed-b",
+                trace_id="local-b",
+                payload=payload,
+                local_bypass=True,
+            )
+        ).disposition
+        is AdmitDisposition.DUPLICATE
+    )
+
+    clock["now"] = 110.0
+    reopened = ledger.admit(
+        _envelope(
+            delivery_id="observed-c",
+            trace_id="local-c",
+            payload=payload,
+            local_bypass=True,
+        )
+    )
+    assert reopened.disposition is AdmitDisposition.ACCEPTED
+    assert reopened.authority is not None
+    assert reopened.authority.operation_id == "local-c"
+
+
+def test_one_route_cannot_consume_the_shared_capacity_reserve(tmp_path: Path):
+    ledger = WebhookOperationLedger(tmp_path / "state.db", max_records=4)
+    for index in range(3):
+        admitted = ledger.admit(
+            _envelope(
+                delivery_id=f"route-a-{index}",
+                trace_id=f"route-a-trace-{index}",
+                route_name="route-a",
+                provider="svix",
+            )
+        )
+        assert admitted.disposition is AdmitDisposition.ACCEPTED
+
+    assert (
+        ledger.admit(
+            _envelope(
+                delivery_id="route-a-overflow",
+                trace_id="route-a-overflow-trace",
+                route_name="route-a",
+                provider="svix",
+            )
+        ).disposition
+        is AdmitDisposition.SATURATED
+    )
+    assert (
+        ledger.admit(
+            _envelope(
+                delivery_id="route-b-reserved",
+                trace_id="route-b-reserved-trace",
+                route_name="route-b",
+                provider="svix",
+            )
+        ).disposition
+        is AdmitDisposition.ACCEPTED
+    )
+
+
+def test_indeterminate_authority_preserves_evidence_without_exhausting_live_capacity(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    clock = {"now": 100.0}
+    monkeypatch.setattr(ledger_module.time, "time", lambda: clock["now"])
+    ledger = WebhookOperationLedger(
+        tmp_path / "state.db",
+        max_records=1,
+        terminal_retention_seconds=1,
+    )
+    accepted = ledger.admit(_envelope(delivery_id="unknown", trace_id="unknown-trace"))
+    assert accepted.authority is not None
+    assert ledger.mark_indeterminate(accepted.authority, "unknown postcondition")
+
+    clock["now"] = 10_000.0
+    assert ledger.prune() == 0
+    assert (
+        ledger.admit(_envelope(delivery_id="later", trace_id="later-trace")).disposition
+        is AdmitDisposition.ACCEPTED
+    )
+    retained = ledger.lookup_session(accepted.authority.session_key)
+    assert retained is not None
+    assert retained.state is OperationState.INDETERMINATE
+    assert ledger.tombstone_count() == 0
+    assert (
+        ledger.admit(
+            _envelope(delivery_id="unknown", trace_id="retry-trace")
+        ).disposition
+        is AdmitDisposition.INDETERMINATE
+    )
+
+
+def test_sqlite_write_failure_propagates_without_in_memory_fallback(tmp_path: Path):
+    db_path = tmp_path / "state.db"
+    ledger = WebhookOperationLedger(db_path)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """CREATE TRIGGER reject_webhook_admit
+               BEFORE INSERT ON webhook_operations
+               BEGIN SELECT RAISE(ABORT, 'injected admission failure'); END"""
+        )
+
+    with pytest.raises(WebhookLedgerError, match="SQLITE_CONSTRAINT_TRIGGER"):
+        ledger.admit(_envelope(delivery_id="failure", trace_id="failure-trace"))
+    assert ledger.count() == 0
+
+
+@pytest.mark.parametrize(
+    "corrupt_json",
+    [
+        '{"toolsets":["safe"],"toolsets":["unsafe"]}',
+        '{"score":NaN}',
+        '{ "toolsets": ["webhook"] }',
+    ],
+)
+def test_corrupted_authority_json_fails_closed(tmp_path: Path, corrupt_json: str):
+    db_path = tmp_path / "state.db"
+    ledger = WebhookOperationLedger(db_path)
+    prepared = _admit_and_prepare(
+        ledger,
+        delivery_id="corrupt-json",
+        trace_id="corrupt-json-trace",
+    )
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "UPDATE webhook_operations SET grant_json=? WHERE operation_id=?",
+            (corrupt_json, prepared.operation_id),
+        )
+
+    with pytest.raises(WebhookLedgerCorruptionError):
+        ledger.lookup_session(prepared.session_key)
+
+
+def test_staged_delivery_digest_corruption_fails_closed(tmp_path: Path):
+    db_path = tmp_path / "state.db"
+    ledger = WebhookOperationLedger(db_path)
+    prepared = _admit_and_prepare(
+        ledger,
+        delivery_id="corrupt-delivery",
+        trace_id="corrupt-delivery-trace",
+    )
+    staged = _stage(ledger, prepared, content="original")
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """UPDATE webhook_targets SET delivery_json=?
+               WHERE operation_id=?""",
+            (
+                '{"carrier":{"channel":"C123","delivery_type":"slack"},'
+                '"content":"mutated"}',
+                staged.operation_id,
+            ),
+        )
+
+    with pytest.raises(WebhookLedgerCorruptionError, match="does not match"):
+        ledger.lookup_session(staged.session_key)
+
+
+def test_staged_delivery_carrier_digest_corruption_fails_closed(tmp_path: Path):
+    db_path = tmp_path / "state.db"
+    ledger = WebhookOperationLedger(db_path)
+    prepared = _admit_and_prepare(
+        ledger,
+        delivery_id="corrupt-carrier",
+        trace_id="corrupt-carrier-trace",
+    )
+    staged = _stage(ledger, prepared, content="original")
+    with sqlite3.connect(db_path) as conn:
+        original = conn.execute(
+            """SELECT delivery_json FROM webhook_targets
+               WHERE operation_id=?""",
+            (staged.operation_id,),
+        ).fetchone()[0]
+        decoded = json.loads(original)
+        decoded["carrier"]["channel"] = "C999"
+        mutated = json.dumps(decoded, separators=(",", ":"), sort_keys=True)
+        conn.execute(
+            """UPDATE webhook_targets SET delivery_json=?
+               WHERE operation_id=?""",
+            (mutated, staged.operation_id),
+        )
+
+    with pytest.raises(WebhookLedgerCorruptionError, match="carrier does not match"):
+        ledger.lookup_session(staged.session_key)
+
+
+def test_incompatible_uniqueness_schema_fails_closed(tmp_path: Path):
+    db_path = tmp_path / "state.db"
+    WebhookOperationLedger(db_path)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("DROP INDEX idx_webhook_operations_replay_identity")
+        conn.execute(
+            """CREATE INDEX idx_webhook_operations_replay_identity
+               ON webhook_operations(profile, route, provider, replay_id)"""
+        )
+
+    with pytest.raises(
+        WebhookLedgerCorruptionError,
+        match="replay-identity uniqueness is unavailable",
+    ):
+        WebhookOperationLedger(db_path)

--- a/tests/gateway/test_webhook_ledger_capacity_scope.py
+++ b/tests/gateway/test_webhook_ledger_capacity_scope.py
@@ -1,0 +1,176 @@
+"""Capacity isolation tests for durable webhook authority scopes."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import gateway.platforms.webhook_ledger as ledger_module
+from gateway.platforms.webhook_auth import WebhookSignatureVerificationReceipt
+from gateway.platforms.webhook_contract import WebhookEnvelope, WebhookRouteConfig
+from gateway.platforms.webhook_ledger import (
+    AdmitDisposition,
+    OperationState,
+    WebhookOperationLedger,
+)
+
+
+def _envelope(
+    identity: str,
+    *,
+    trace_id: str,
+    profile: str = "default",
+    route_name: str = "route-a",
+    provider: str = "svix",
+    body_value: str | None = None,
+) -> WebhookEnvelope:
+    raw_body = json.dumps(
+        {"event": "push", "value": body_value or identity},
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode()
+    if provider == "svix":
+        headers = {"svix-id": identity}
+    elif provider == "github":
+        headers = {
+            "X-GitHub-Delivery": identity,
+            "X-GitHub-Event": "push",
+        }
+    else:  # pragma: no cover - this fixture intentionally supports two providers
+        raise AssertionError(f"unsupported fixture provider: {provider}")
+    route = WebhookRouteConfig.bind(
+        route_name,
+        {"provider": provider, "profile": profile},
+        headers=headers,
+        request_profile=profile,
+    )
+    receipt = WebhookSignatureVerificationReceipt._issue(route, raw_body, headers)
+    return WebhookEnvelope.from_receipt(
+        receipt,
+        raw_body=raw_body,
+        media_type="application/json",
+        trace_id=trace_id,
+    )
+
+
+@pytest.mark.parametrize(
+    ("dimension", "entrant_scope"),
+    [
+        ("route", {"route_name": "route-b"}),
+        ("profile", {"profile": "tenant-b"}),
+        ("provider", {"provider": "github"}),
+    ],
+)
+def test_capacity_reserve_is_keyed_by_exact_scope_dimension(
+    tmp_path: Path,
+    dimension: str,
+    entrant_scope: dict[str, str],
+):
+    ledger = WebhookOperationLedger(tmp_path / "state.db", max_records=4)
+    base_scope = {
+        "profile": "default",
+        "route_name": "route-a",
+        "provider": "svix",
+    }
+
+    for index in range(3):
+        admitted = ledger.admit(
+            _envelope(
+                f"base-{index}",
+                trace_id=f"base-trace-{index}",
+                **base_scope,
+            )
+        )
+        assert admitted.disposition is AdmitDisposition.ACCEPTED
+
+    same_scope = ledger.admit(
+        _envelope("same-overflow", trace_id="same-overflow-trace", **base_scope)
+    )
+    assert same_scope.disposition is AdmitDisposition.SATURATED
+
+    distinct_scope = {**base_scope, **entrant_scope}
+    reserved = ledger.admit(
+        _envelope(
+            f"reserved-{dimension}",
+            trace_id=f"reserved-{dimension}-trace",
+            **distinct_scope,
+        )
+    )
+    assert reserved.disposition is AdmitDisposition.ACCEPTED
+    assert reserved.authority is not None
+    assert (
+        reserved.authority.profile,
+        reserved.authority.route,
+        reserved.authority.provider,
+    ) == (
+        distinct_scope["profile"],
+        distinct_scope["route_name"],
+        distinct_scope["provider"],
+    )
+
+    assert ledger.count() == 4
+    globally_full = ledger.admit(
+        _envelope(
+            f"global-overflow-{dimension}",
+            trace_id=f"global-overflow-{dimension}-trace",
+            profile="other-profile",
+            route_name="other-route",
+            provider="github",
+        )
+    )
+    assert globally_full.disposition is AdmitDisposition.SATURATED
+    assert ledger.count() == 4
+
+
+def test_indeterminate_evidence_is_retained_but_excluded_from_live_capacity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    clock = {"now": 100.0}
+    monkeypatch.setattr(ledger_module.time, "time", lambda: clock["now"])
+    ledger = WebhookOperationLedger(
+        tmp_path / "state.db",
+        max_records=1,
+        terminal_retention_seconds=1,
+    )
+    unknown_envelope = _envelope(
+        "unknown-effect",
+        trace_id="unknown-effect-trace",
+        body_value="same-authenticated-body",
+    )
+    unknown = ledger.admit(unknown_envelope)
+    assert unknown.disposition is AdmitDisposition.ACCEPTED
+    assert unknown.authority is not None
+    assert ledger.mark_indeterminate(unknown.authority, "effect outcome unknown")
+
+    clock["now"] = 10_000.0
+    assert ledger.prune() == 0
+    retained = ledger.lookup_session(unknown.authority.session_key)
+    assert retained is not None
+    assert retained.state is OperationState.INDETERMINATE
+    assert retained.operation_id == "unknown-effect-trace"
+    assert retained.body_sha256 == unknown_envelope.body_sha256
+
+    replay = ledger.admit(
+        _envelope(
+            "unknown-effect",
+            trace_id="unknown-effect-retry-trace",
+            body_value="same-authenticated-body",
+        )
+    )
+    assert replay.disposition is AdmitDisposition.INDETERMINATE
+    assert replay.authority is not None
+    assert replay.authority.operation_id == retained.operation_id
+
+    live = ledger.admit(_envelope("new-live", trace_id="new-live-trace"))
+    assert live.disposition is AdmitDisposition.ACCEPTED
+    assert live.authority is not None
+    assert ledger.count() == 2
+
+    full = ledger.admit(_envelope("another-live", trace_id="another-live-trace"))
+    assert full.disposition is AdmitDisposition.SATURATED
+    still_retained = ledger.lookup_session(unknown.authority.session_key)
+    assert still_retained is not None
+    assert still_retained.state is OperationState.INDETERMINATE

--- a/tests/gateway/test_webhook_ledger_recovery_batches.py
+++ b/tests/gateway/test_webhook_ledger_recovery_batches.py
@@ -1,0 +1,681 @@
+"""Bounded, indexed pagination regressions for webhook recovery authority."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+import gateway.platforms.webhook_ledger as ledger_module
+from gateway.platforms.webhook_ledger import (
+    DEFAULT_RECOVERY_BATCH_SIZE,
+    MAXIMUM_RECOVERY_BATCH_SIZE,
+    MAXIMUM_RECOVERY_PROFILES,
+    AdmitDisposition,
+    OperationState,
+    RecoveryCursor,
+    WebhookLedgerConfigurationError,
+    WebhookLedgerCorruptionError,
+    WebhookLedgerError,
+    WebhookOperationLedger,
+)
+from tests.gateway.test_webhook_ledger import (
+    _admit_and_prepare,
+    _envelope,
+    _snapshots,
+    _stage,
+)
+
+
+def _set_dead_owner(db_path: Path, owner_instance: str) -> None:
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """UPDATE webhook_operations
+                  SET owner_pid=NULL, owner_started_at=NULL
+                WHERE owner_instance=?""",
+            (owner_instance,),
+        )
+
+
+def _prepare_for_profile(
+    ledger: WebhookOperationLedger,
+    *,
+    profile: str,
+    operation_id: str,
+):
+    admitted = ledger.admit(
+        _envelope(
+            delivery_id=operation_id,
+            trace_id=operation_id,
+            profile=profile,
+        )
+    )
+    assert admitted.disposition is AdmitDisposition.ACCEPTED
+    assert admitted.authority is not None
+    return ledger.prepare(admitted.authority, **_snapshots(operation_id))
+
+
+def test_delivery_ready_pages_are_strictly_capped_and_cursor_complete(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = {"now": 1000.0}
+    monkeypatch.setattr(ledger_module.time, "time", lambda: clock["now"])
+    ledger = WebhookOperationLedger(
+        tmp_path / "state.db",
+        instance_id="delivery-owner",
+        max_records=64,
+    )
+    expected: list[str] = []
+    for index in range(DEFAULT_RECOVERY_BATCH_SIZE * 2 + 3):
+        clock["now"] = 1000.0 + index
+        authority = _admit_and_prepare(
+            ledger,
+            delivery_id=f"delivery-page-{index:03d}",
+            trace_id=f"delivery-page-{index:03d}",
+        )
+        expected.append(authority.operation_id)
+        _stage(ledger, authority, content=f"durable output {index}")
+
+    cursor = None
+    observed: list[str] = []
+    page_sizes: list[int] = []
+    while True:
+        page = ledger.list_delivery_ready(limit=3, after=cursor)
+        assert page.event_ready == ()
+        assert page.released == ()
+        assert page.indeterminate == ()
+        assert page.scanned_count == len(page.delivery_ready) <= 3
+        page_sizes.append(page.scanned_count)
+        observed.extend(item.operation_id for item in page.delivery_ready)
+        if not page.has_more:
+            assert page.next_cursor is None
+            break
+        assert page.next_cursor is not None
+        assert cursor is None or page.next_cursor > cursor
+        cursor = page.next_cursor
+
+    assert observed == expected
+    assert len(observed) == len(set(observed))
+    assert page_sizes == [3] * (len(expected) // 3) + [len(expected) % 3]
+    assert len(ledger.current_delivery_ready()) == DEFAULT_RECOVERY_BATCH_SIZE
+
+
+def test_dead_owner_scan_cursor_advances_past_live_head_without_starvation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = {"now": 100.0}
+    monkeypatch.setattr(ledger_module.time, "time", lambda: clock["now"])
+    db_path = tmp_path / "state.db"
+    live = WebhookOperationLedger(db_path, instance_id="live-owner", max_records=64)
+    dead = WebhookOperationLedger(db_path, instance_id="dead-owner", max_records=64)
+    replacement = WebhookOperationLedger(
+        db_path,
+        instance_id="replacement-owner",
+        max_records=64,
+    )
+
+    live_ids: list[str] = []
+    for index in range(3):
+        clock["now"] = 100.0 + index
+        live_ids.append(
+            _admit_and_prepare(
+                live,
+                delivery_id=f"live-{index}",
+                trace_id=f"live-{index}",
+            ).operation_id
+        )
+    dead_ids: list[str] = []
+    for index in range(5):
+        clock["now"] = 200.0 + index
+        dead_ids.append(
+            _admit_and_prepare(
+                dead,
+                delivery_id=f"dead-{index}",
+                trace_id=f"dead-{index}",
+            ).operation_id
+        )
+    _set_dead_owner(db_path, dead.instance_id)
+
+    first = replacement.recover_dead_owners_page(now=300.0, limit=3)
+    assert first.scanned_count == 3
+    assert first.event_ready == ()
+    assert first.delivery_ready == ()
+    assert first.has_more
+    assert first.next_cursor is not None
+
+    cursor = first.next_cursor
+    recovered: list[str] = []
+    scanned = first.scanned_count
+    while True:
+        page = replacement.recover_dead_owners_page(
+            now=300.0,
+            limit=3,
+            after=cursor,
+        )
+        assert page.scanned_count <= 3
+        assert (
+            len(page.event_ready)
+            + len(page.delivery_ready)
+            + len(page.released)
+            + len(page.indeterminate)
+            <= page.scanned_count
+        )
+        recovered.extend(item.operation_id for item in page.event_ready)
+        scanned += page.scanned_count
+        if not page.has_more:
+            assert page.next_cursor is None
+            break
+        assert page.next_cursor is not None
+        assert page.next_cursor > cursor
+        cursor = page.next_cursor
+
+    assert scanned == len(live_ids) + len(dead_ids)
+    assert recovered == dead_ids
+    assert len(recovered) == len(set(recovered))
+    with sqlite3.connect(db_path) as conn:
+        live_owners = dict(
+            conn.execute(
+                """SELECT operation_id, owner_instance
+                     FROM webhook_operations
+                    WHERE operation_id IN (?, ?, ?)""",
+                live_ids,
+            )
+        )
+    assert live_owners == dict.fromkeys(live_ids, live.instance_id)
+
+    rediscovered = replacement.list_current_recovery_ready(limit=3)
+    assert [item.operation_id for item in rediscovered.event_ready] == dead_ids[:3]
+    assert rediscovered.delivery_ready == ()
+    assert rediscovered.has_more
+    assert rediscovered.next_cursor is not None
+
+
+def test_retirement_pages_leave_selection_and_preserve_exact_owner_scope(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = {"now": 100.0}
+    monkeypatch.setattr(ledger_module.time, "time", lambda: clock["now"])
+    db_path = tmp_path / "state.db"
+    old = WebhookOperationLedger(db_path, instance_id="old-owner", max_records=64)
+    peer = WebhookOperationLedger(db_path, instance_id="peer-owner", max_records=64)
+    replacement = WebhookOperationLedger(
+        db_path,
+        instance_id="replacement-owner",
+        max_records=64,
+    )
+
+    old_ids: list[str] = []
+    for index in range(7):
+        clock["now"] = 100.0 + index
+        old_ids.append(
+            _admit_and_prepare(
+                old,
+                delivery_id=f"old-{index}",
+                trace_id=f"old-{index}",
+            ).operation_id
+        )
+    clock["now"] = 200.0
+    peer_authority = _admit_and_prepare(
+        peer,
+        delivery_id="peer-stays-owned",
+        trace_id="peer-stays-owned",
+    )
+
+    page_sizes: list[int] = []
+    while True:
+        page = replacement.retire_owner_instance_page(
+            old.instance_id,
+            now=300.0,
+            limit=3,
+        )
+        page_sizes.append(page.scanned_count)
+        # READY rows leave the exact owner selection without being returned as
+        # scheduled work. Exhaustion must use has_more, never tuple emptiness.
+        assert page.event_ready == page.delivery_ready == ()
+        assert page.released == page.indeterminate == ()
+        assert page.scanned_count <= 3
+        assert page.next_cursor is None
+        if not page.has_more:
+            break
+
+    assert page_sizes == [3, 3, 1]
+    with sqlite3.connect(db_path) as conn:
+        remaining = conn.execute(
+            """SELECT COUNT(*) FROM webhook_operations
+                WHERE owner_instance=? AND state IN (
+                    'preparing','ready','running','delivery_ready','delivering'
+                )""",
+            (old.instance_id,),
+        ).fetchone()
+    assert remaining == (0,)
+    peer_state = replacement.lookup_session(peer_authority.session_key)
+    assert peer_state is not None
+    assert peer_state.owner_instance == peer.instance_id
+
+    recovered: list[str] = []
+    cursor = None
+    while True:
+        page = replacement.recover_dead_owners_page(
+            now=301.0,
+            limit=3,
+            after=cursor,
+        )
+        recovered.extend(item.operation_id for item in page.event_ready)
+        if not page.has_more:
+            break
+        assert page.next_cursor is not None
+        cursor = page.next_cursor
+    assert recovered == old_ids
+
+
+def test_profile_filtered_recovery_skips_excluded_dead_front_without_starvation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = {"now": 100.0}
+    monkeypatch.setattr(ledger_module.time, "time", lambda: clock["now"])
+    db_path = tmp_path / "state.db"
+    excluded_owner = WebhookOperationLedger(
+        db_path,
+        instance_id="excluded-owner",
+        max_records=64,
+    )
+    included_owner = WebhookOperationLedger(
+        db_path,
+        instance_id="included-owner",
+        max_records=64,
+    )
+    replacement = WebhookOperationLedger(
+        db_path,
+        instance_id="replacement-owner",
+        max_records=64,
+    )
+
+    excluded_ids: list[str] = []
+    for index in range(5):
+        clock["now"] = 100.0 + index
+        excluded_ids.append(
+            _prepare_for_profile(
+                excluded_owner,
+                profile="excluded",
+                operation_id=f"excluded-{index}",
+            ).operation_id
+        )
+    included_ids: list[str] = []
+    for index in range(3):
+        clock["now"] = 200.0 + index
+        included_ids.append(
+            _prepare_for_profile(
+                included_owner,
+                profile="included",
+                operation_id=f"included-{index}",
+            ).operation_id
+        )
+    _set_dead_owner(db_path, excluded_owner.instance_id)
+    _set_dead_owner(db_path, included_owner.instance_id)
+
+    first = replacement.recover_dead_owners_page(
+        now=300.0,
+        limit=2,
+        profiles=("included",),
+    )
+    assert [item.operation_id for item in first.event_ready] == included_ids[:2]
+    assert first.scanned_count == 2
+    assert first.has_more
+    assert first.next_cursor is not None
+    second = replacement.recover_dead_owners_page(
+        now=300.0,
+        limit=2,
+        after=first.next_cursor,
+        profiles=("included",),
+    )
+    assert [item.operation_id for item in second.event_ready] == included_ids[2:]
+    assert second.scanned_count == 1
+    assert not second.has_more
+
+    with sqlite3.connect(db_path) as conn:
+        excluded_rows = conn.execute(
+            """SELECT operation_id, profile, generation, owner_instance
+                 FROM webhook_operations
+                WHERE profile='excluded'
+                ORDER BY created_at, operation_id"""
+        ).fetchall()
+    assert excluded_rows == [
+        (operation_id, "excluded", 1, excluded_owner.instance_id)
+        for operation_id in excluded_ids
+    ]
+
+    assert (
+        replacement.recover_dead_owners_page(profiles=())
+        == ledger_module.RecoveryBatch()
+    )
+
+
+def test_admission_persists_physical_authority_profile_not_route_alias(
+    tmp_path: Path,
+) -> None:
+    ledger = WebhookOperationLedger(tmp_path / "state.db")
+    envelope = _envelope(
+        delivery_id="physical-profile",
+        trace_id="physical-profile",
+        profile="default",
+    )
+    object.__setattr__(envelope, "authority_profile", "alpha")
+
+    admitted = ledger.admit(envelope)
+
+    assert admitted.disposition is AdmitDisposition.ACCEPTED
+    assert admitted.authority is not None
+    assert admitted.authority.profile == "alpha"
+    with sqlite3.connect(ledger.db_path) as conn:
+        persisted = conn.execute(
+            """SELECT profile FROM webhook_operations
+                WHERE operation_id='physical-profile'"""
+        ).fetchone()
+    assert persisted == ("alpha",)
+
+
+def test_current_owner_pages_filter_exact_physical_profiles_without_starvation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = {"now": 100.0}
+    monkeypatch.setattr(ledger_module.time, "time", lambda: clock["now"])
+    ledger = WebhookOperationLedger(
+        tmp_path / "state.db",
+        instance_id="shared-owner",
+        max_records=64,
+    )
+    excluded_ids: list[str] = []
+    for index in range(5):
+        clock["now"] = 100.0 + index
+        authority = _prepare_for_profile(
+            ledger,
+            profile="excluded",
+            operation_id=f"current-excluded-{index}",
+        )
+        excluded_ids.append(authority.operation_id)
+        _stage(ledger, authority)
+    included_ids: list[str] = []
+    for index in range(2):
+        clock["now"] = 200.0 + index
+        authority = _prepare_for_profile(
+            ledger,
+            profile="included",
+            operation_id=f"current-included-{index}",
+        )
+        included_ids.append(authority.operation_id)
+        _stage(ledger, authority)
+
+    first = ledger.list_delivery_ready(limit=1, profiles=("included",))
+    assert [item.operation_id for item in first.delivery_ready] == included_ids[:1]
+    assert first.has_more
+    assert first.next_cursor is not None
+    second = ledger.list_current_recovery_ready(
+        limit=1,
+        after=first.next_cursor,
+        profiles=("included",),
+    )
+    assert [item.operation_id for item in second.delivery_ready] == included_ids[1:]
+    assert not second.has_more
+    assert all(
+        item.operation_id not in excluded_ids
+        for item in (*first.delivery_ready, *second.delivery_ready)
+    )
+    assert (
+        ledger.list_current_recovery_ready(profiles=()) == ledger_module.RecoveryBatch()
+    )
+
+
+def test_recovery_queries_are_partial_indexed_and_never_unbounded(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "state.db"
+    ledger = WebhookOperationLedger(db_path, instance_id="query-owner")
+    staged = _admit_and_prepare(
+        ledger,
+        delivery_id="query-plan",
+        trace_id="query-plan",
+    )
+    _stage(ledger, staged)
+
+    statements: list[str] = []
+    original_connect = ledger._connect
+
+    def traced_connect() -> sqlite3.Connection:
+        conn = original_connect()
+        conn.set_trace_callback(statements.append)
+        return conn
+
+    ledger._connect = traced_connect  # type: ignore[method-assign]
+    ledger.list_delivery_ready(limit=1)
+    ledger.list_delivery_ready(limit=1, profiles=("default",))
+    ledger.list_current_recovery_ready(limit=1)
+    ledger.list_current_recovery_ready(limit=1, profiles=("default",))
+    ledger.recover_dead_owners_page(limit=1)
+    ledger.recover_dead_owners_page(limit=1, profiles=("default",))
+    ledger.retire_owner_instance_page("missing-owner", limit=1)
+
+    bounded_indexes = {
+        "idx_webhook_operations_owner_delivery_ready",
+        "idx_webhook_operations_owner_current_recovery",
+        "idx_webhook_operations_owner_profile_delivery_ready",
+        "idx_webhook_operations_owner_profile_current_recovery",
+        "idx_webhook_operations_recovery_order",
+        "idx_webhook_operations_owner_recovery_order",
+        "idx_webhook_operations_profile_recovery_order",
+    }
+    normalized_statements = [
+        " ".join(statement.lower().split()) for statement in statements
+    ]
+    for index_name in bounded_indexes:
+        matching = [
+            statement
+            for statement in normalized_statements
+            if f"indexed by {index_name}" in statement
+        ]
+        assert matching, index_name
+        assert all(" limit " in statement for statement in matching)
+        assert all(
+            "count(" not in statement and "sum(" not in statement
+            for statement in matching
+        )
+
+    with sqlite3.connect(db_path) as conn:
+        plans = {
+            "idx_webhook_operations_recovery_order": conn.execute(
+                """EXPLAIN QUERY PLAN
+                   SELECT operation_id, created_at
+                     FROM webhook_operations INDEXED BY
+                          idx_webhook_operations_recovery_order
+                    WHERE state IN (
+                        'preparing','ready','running','delivery_ready','delivering'
+                    )
+                    ORDER BY created_at, operation_id
+                    LIMIT 8"""
+            ).fetchall(),
+            "idx_webhook_operations_owner_recovery_order": conn.execute(
+                """EXPLAIN QUERY PLAN
+                   SELECT operation_id, created_at
+                     FROM webhook_operations INDEXED BY
+                          idx_webhook_operations_owner_recovery_order
+                    WHERE owner_instance=? AND state IN (
+                        'preparing','ready','running','delivery_ready','delivering'
+                    )
+                    ORDER BY created_at, operation_id
+                    LIMIT 8""",
+                (ledger.instance_id,),
+            ).fetchall(),
+            "idx_webhook_operations_owner_delivery_ready": conn.execute(
+                """EXPLAIN QUERY PLAN
+                   SELECT o.operation_id, o.created_at
+                     FROM webhook_operations AS o INDEXED BY
+                          idx_webhook_operations_owner_delivery_ready
+                     JOIN webhook_targets AS t ON t.operation_id=o.operation_id
+                    WHERE o.owner_instance=? AND o.state='delivery_ready'
+                      AND t.state='pending'
+                    ORDER BY o.created_at, o.operation_id
+                    LIMIT 8""",
+                (ledger.instance_id,),
+            ).fetchall(),
+            "idx_webhook_operations_profile_recovery_order": conn.execute(
+                """EXPLAIN QUERY PLAN
+                   SELECT operation_id, created_at
+                     FROM webhook_operations INDEXED BY
+                          idx_webhook_operations_profile_recovery_order
+                    WHERE profile=? AND state IN (
+                        'preparing','ready','running','delivery_ready','delivering'
+                    )
+                    ORDER BY created_at, operation_id
+                    LIMIT 8""",
+                ("default",),
+            ).fetchall(),
+        }
+    for index_name, plan in plans.items():
+        detail = " ".join(str(row[3]).lower() for row in plan)
+        assert index_name in detail
+        assert "temp b-tree" not in detail
+
+
+@pytest.mark.parametrize(
+    "invalid_limit", [0, -1, True, MAXIMUM_RECOVERY_BATCH_SIZE + 1]
+)
+def test_recovery_batch_limit_is_strict(
+    tmp_path: Path,
+    invalid_limit: int,
+) -> None:
+    ledger = WebhookOperationLedger(tmp_path / f"state-{invalid_limit}.db")
+    with pytest.raises(ValueError, match="recovery batch limit"):
+        ledger.recover_dead_owners_page(limit=invalid_limit)
+    with pytest.raises(ValueError, match="recovery batch limit"):
+        ledger.list_current_recovery_ready(limit=invalid_limit)
+    with pytest.raises(ValueError, match="recovery batch limit"):
+        ledger.list_delivery_ready(limit=invalid_limit)
+    with pytest.raises(ValueError, match="recovery batch limit"):
+        ledger.retire_instance_page(limit=invalid_limit)
+
+
+@pytest.mark.parametrize("invalid_now", [float("nan"), float("inf"), "not-a-time"])
+def test_dead_owner_recovery_rejects_nonfinite_time(
+    tmp_path: Path,
+    invalid_now: object,
+) -> None:
+    ledger = WebhookOperationLedger(tmp_path / "state.db")
+    with pytest.raises(WebhookLedgerError, match="timestamp must be finite"):
+        ledger.recover_dead_owners_page(now=invalid_now)
+
+
+def test_shadowed_recovery_index_fails_closed_on_open(tmp_path: Path) -> None:
+    db_path = tmp_path / "state.db"
+    WebhookOperationLedger(db_path)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("DROP INDEX idx_webhook_operations_recovery_order")
+        conn.execute(
+            """CREATE INDEX idx_webhook_operations_recovery_order
+                 ON webhook_operations(updated_at)
+               WHERE state='ready'"""
+        )
+
+    with pytest.raises(
+        WebhookLedgerCorruptionError,
+        match="bounded recovery indexes",
+    ):
+        WebhookOperationLedger(db_path)
+
+
+def test_persisted_limit_mismatch_has_deterministic_configuration_subtype(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "state.db"
+    WebhookOperationLedger(db_path, max_records=8)
+    with pytest.raises(
+        WebhookLedgerConfigurationError,
+        match="limits do not match persisted authority",
+    ):
+        WebhookOperationLedger(db_path, max_records=9)
+
+
+def test_recovery_cursor_rejects_noncanonical_or_nonfinite_values(
+    tmp_path: Path,
+) -> None:
+    ledger = WebhookOperationLedger(tmp_path / "state.db")
+    for cursor in (
+        RecoveryCursor(float("nan"), "operation"),
+        RecoveryCursor(1.0, " operation "),
+    ):
+        with pytest.raises(ValueError, match="recovery cursor"):
+            ledger.recover_dead_owners_page(after=cursor)
+    with pytest.raises(ValueError, match="RecoveryCursor"):
+        ledger.recover_dead_owners_page(after=(1.0, "operation"))  # type: ignore[arg-type]
+
+
+def test_recovery_profile_filter_is_canonical_and_capped(tmp_path: Path) -> None:
+    ledger = WebhookOperationLedger(tmp_path / "state.db")
+    with pytest.raises(ValueError, match="iterable of profile names"):
+        ledger.recover_dead_owners_page(profiles="default")
+    with pytest.raises(ValueError, match="profile-count limit"):
+        ledger.recover_dead_owners_page(
+            profiles=tuple(
+                f"profile-{index}" for index in range(MAXIMUM_RECOVERY_PROFILES + 1)
+            )
+        )
+    with pytest.raises(ValueError, match="recovery profile"):
+        ledger.recover_dead_owners_page(profiles=(" default ",))
+
+
+def test_default_batch_is_below_hard_recovery_cap() -> None:
+    assert 1 <= DEFAULT_RECOVERY_BATCH_SIZE < MAXIMUM_RECOVERY_BATCH_SIZE
+    assert MAXIMUM_RECOVERY_BATCH_SIZE <= 16
+
+
+def test_current_recovery_ready_excludes_ordinary_generation_one_event(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "state.db"
+    ordinary = WebhookOperationLedger(db_path, instance_id="ordinary-owner")
+    dead = WebhookOperationLedger(db_path, instance_id="dead-owner")
+    ledger = WebhookOperationLedger(db_path, instance_id="recovery-owner")
+    ordinary_ready = _admit_and_prepare(
+        ordinary,
+        delivery_id="ordinary-event-ready",
+        trace_id="ordinary-event-ready",
+    )
+    dead_ready = _admit_and_prepare(
+        dead,
+        delivery_id="recovered-event-ready",
+        trace_id="recovered-event-ready",
+    )
+    _set_dead_owner(db_path, dead.instance_id)
+    claimed = ledger.recover_dead_owners_page(limit=3)
+    assert [item.operation_id for item in claimed.event_ready] == [
+        dead_ready.operation_id
+    ]
+    event_ready = claimed.event_ready[0]
+    delivery_ready = _admit_and_prepare(
+        ledger,
+        delivery_id="delivery-ready",
+        trace_id="delivery-ready",
+    )
+    delivery_ready = _stage(ledger, delivery_ready)
+
+    page = ledger.list_current_recovery_ready(limit=3)
+
+    assert [item.operation_id for item in page.event_ready] == [
+        event_ready.operation_id
+    ]
+    assert [item.operation_id for item in page.delivery_ready] == [
+        delivery_ready.operation_id
+    ]
+    assert page.scanned_count == 2
+    assert not page.has_more
+    assert ordinary_ready.operation_id not in {
+        item.operation_id for item in (*page.event_ready, *page.delivery_ready)
+    }
+    assert all(
+        item.state in {OperationState.READY, OperationState.DELIVERY_READY}
+        for item in (*page.event_ready, *page.delivery_ready)
+    )

--- a/tests/gateway/test_webhook_ledger_storage_budget.py
+++ b/tests/gateway/test_webhook_ledger_storage_budget.py
@@ -1,0 +1,1948 @@
+"""Fail-closed total storage authority for the durable webhook ledger."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+import gateway.platforms.webhook_ledger as ledger_module
+from gateway.platforms.webhook_auth import (
+    WebhookLocalBypassReceipt,
+    WebhookSignatureVerificationReceipt,
+)
+from gateway.platforms.webhook_contract import WebhookEnvelope, WebhookRouteConfig
+from gateway.platforms.webhook_ledger import (
+    AdmitDisposition,
+    AdmitSaturationReason,
+    MAXIMUM_MAX_STORAGE_BYTES,
+    MINIMUM_MAX_STORAGE_BYTES,
+    OperationState,
+    Settlement,
+    SettlementKind,
+    TargetAttemptDisposition,
+    WebhookLedgerCapacityError,
+    WebhookLedgerConfigurationError,
+    WebhookLedgerCorruptionError,
+    WebhookLedgerError,
+    WebhookLedgerTransitionError,
+    WebhookOperationLedger,
+)
+
+
+def _envelope(
+    identity: str,
+    *,
+    trace_id: str,
+    route_name: str = "storage-budget",
+    body_identity: str | None = None,
+    local_bypass: bool = False,
+) -> WebhookEnvelope:
+    raw_body = json.dumps(
+        {"event": "push", "identity": body_identity or identity},
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode()
+    headers = {} if local_bypass else {"svix-id": identity}
+    route = WebhookRouteConfig.bind(
+        route_name,
+        {"provider": "generic" if local_bypass else "svix"},
+        headers=headers,
+        request_profile="default",
+    )
+    receipt = (
+        WebhookLocalBypassReceipt._issue(route, raw_body, headers)
+        if local_bypass
+        else WebhookSignatureVerificationReceipt._issue(route, raw_body, headers)
+    )
+    return WebhookEnvelope.from_receipt(
+        receipt,
+        raw_body=raw_body,
+        media_type="application/json",
+        trace_id=trace_id,
+    )
+
+
+def _create_populated_v4_ledger(
+    db_path: Path,
+    *,
+    corrupt_state: bool = False,
+    drop_replay_index: bool = False,
+    invalid_event_json: bool = False,
+    corrupt_body_digest: bool = False,
+    invalid_created_at: bool = False,
+    invalid_expiry: bool = False,
+    extra_trigger: bool = False,
+    weakened_operation_schema: bool = False,
+    profile: str = "alpha",
+) -> None:
+    """Create the canonical pre-budget v4 core used by migration tests."""
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("PRAGMA foreign_keys=ON")
+        conn.executescript(
+            """
+            CREATE TABLE webhook_operations (
+                operation_id TEXT PRIMARY KEY,
+                profile TEXT NOT NULL,
+                route TEXT NOT NULL,
+                provider TEXT NOT NULL,
+                replay_id TEXT NOT NULL,
+                body_sha256 TEXT NOT NULL,
+                event_type TEXT NOT NULL,
+                session_key TEXT NOT NULL UNIQUE,
+                state TEXT NOT NULL CHECK (
+                    state IN (
+                        'preparing','ready','running','delivery_ready',
+                        'delivering','settled','indeterminate'
+                    )
+                ),
+                generation INTEGER NOT NULL CHECK (generation >= 1),
+                owner_pid INTEGER,
+                owner_started_at INTEGER,
+                owner_instance TEXT NOT NULL,
+                event_json TEXT,
+                target_json TEXT,
+                grant_json TEXT,
+                script_started INTEGER NOT NULL DEFAULT 0 CHECK (
+                    script_started IN (0,1)
+                ),
+                created_at REAL NOT NULL,
+                updated_at REAL NOT NULL,
+                settled_at REAL,
+                last_error TEXT
+            );
+            CREATE UNIQUE INDEX idx_webhook_operations_replay_identity
+                ON webhook_operations(profile, route, provider, replay_id);
+            CREATE INDEX idx_webhook_operations_state_updated
+                ON webhook_operations(state, updated_at);
+            CREATE TABLE webhook_targets (
+                operation_id TEXT NOT NULL,
+                target_id TEXT NOT NULL,
+                state TEXT NOT NULL CHECK (
+                    state IN (
+                        'pending','attempting','confirmed','suppressed','indeterminate'
+                    )
+                ),
+                attempt_token TEXT,
+                content_sha256 TEXT,
+                delivery_json TEXT,
+                delivery_sha256 TEXT,
+                external_id TEXT,
+                owner_pid INTEGER,
+                owner_started_at INTEGER,
+                owner_instance TEXT,
+                started_at REAL,
+                settled_at REAL,
+                updated_at REAL NOT NULL,
+                last_error TEXT,
+                PRIMARY KEY(operation_id, target_id),
+                FOREIGN KEY(operation_id) REFERENCES webhook_operations(operation_id)
+                    ON DELETE CASCADE
+            );
+            CREATE TABLE webhook_delivery_tombstones (
+                profile TEXT NOT NULL,
+                route TEXT NOT NULL,
+                provider TEXT NOT NULL,
+                replay_id TEXT NOT NULL,
+                body_sha256 TEXT NOT NULL,
+                operation_id TEXT NOT NULL,
+                state TEXT NOT NULL CHECK (
+                    state IN ('settled','indeterminate')
+                ),
+                settled_at REAL NOT NULL,
+                expires_at REAL,
+                PRIMARY KEY(profile, route, provider, replay_id)
+            );
+            CREATE INDEX idx_webhook_tombstones_expires_at
+                ON webhook_delivery_tombstones(expires_at)
+                WHERE expires_at IS NOT NULL;
+            CREATE TABLE webhook_ledger_meta (
+                schema_name TEXT PRIMARY KEY CHECK (
+                    schema_name='webhook_operation_ledger'
+                ),
+                schema_version INTEGER NOT NULL CHECK (schema_version=4)
+            );
+            INSERT INTO webhook_ledger_meta VALUES (
+                'webhook_operation_ledger', 4
+            );
+            """
+        )
+        target_json = json.dumps(
+            {"kind": "log", "profile": profile, "v": 1},
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        target_id = hashlib.sha256(target_json.encode()).hexdigest()[:32]
+        if corrupt_state:
+            conn.execute("PRAGMA ignore_check_constraints=ON")
+        conn.execute(
+            """INSERT INTO webhook_operations (
+                   operation_id, profile, route, provider, replay_id,
+                   body_sha256, event_type, session_key, state, generation,
+                   owner_pid, owner_started_at, owner_instance, event_json,
+                   target_json, grant_json, script_started, created_at,
+                   updated_at, settled_at, last_error
+               ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 1, NULL, NULL, ?, ?, ?, ?,
+                         0, 100.0, 100.0, NULL, NULL)""",
+            (
+                "v4-operation",
+                profile,
+                "v4-route",
+                "svix",
+                "provider_id:v4-delivery",
+                "a" * 64,
+                "push",
+                "agent:main:webhook:v4",
+                "corrupt" if corrupt_state else "ready",
+                "v4-instance",
+                json.dumps(
+                    {"payload": {"v": 4}, "text": "v4", "v": 1},
+                    separators=(",", ":"),
+                    sort_keys=True,
+                ),
+                target_json,
+                json.dumps(
+                    {"toolsets": [], "v": 1},
+                    separators=(",", ":"),
+                    sort_keys=True,
+                ),
+            ),
+        )
+        if corrupt_state:
+            conn.execute("PRAGMA ignore_check_constraints=OFF")
+        if invalid_event_json:
+            conn.execute(
+                """UPDATE webhook_operations SET event_json='{'
+                    WHERE operation_id='v4-operation'"""
+            )
+        if corrupt_body_digest:
+            conn.execute(
+                """UPDATE webhook_operations SET body_sha256=?
+                    WHERE operation_id='v4-operation'""",
+                ("z" * 64,),
+            )
+        if invalid_created_at:
+            conn.execute(
+                """UPDATE webhook_operations SET created_at='NaN'
+                    WHERE operation_id='v4-operation'"""
+            )
+        conn.execute(
+            """INSERT INTO webhook_targets (
+                   operation_id, target_id, state, updated_at
+               ) VALUES (?, ?, 'pending', 100.0)""",
+            ("v4-operation", target_id),
+        )
+        conn.execute(
+            """INSERT INTO webhook_delivery_tombstones (
+                   profile, route, provider, replay_id, body_sha256,
+                   operation_id, state, settled_at, expires_at
+               ) VALUES (
+                   ?, 'v4-history', 'svix', 'provider_id:v4-old', ?,
+                   'v4-old-operation', 'settled', 90.0, NULL
+               )""",
+            (profile, "b" * 64),
+        )
+        if invalid_expiry:
+            conn.execute(
+                """UPDATE webhook_delivery_tombstones SET expires_at=100.0
+                    WHERE replay_id='provider_id:v4-old'"""
+            )
+        if drop_replay_index:
+            conn.execute("DROP INDEX idx_webhook_operations_replay_identity")
+        if extra_trigger:
+            conn.execute(
+                """CREATE TRIGGER unexpected_v4_operation_trigger
+                    AFTER UPDATE ON webhook_operations BEGIN SELECT 1; END"""
+            )
+        if weakened_operation_schema:
+            conn.execute("PRAGMA writable_schema=ON")
+            conn.execute(
+                """UPDATE sqlite_master
+                      SET sql=replace(
+                          sql,
+                          'generation INTEGER NOT NULL CHECK (generation >= 1)',
+                          'generation INTEGER NOT NULL'
+                      )
+                    WHERE type='table' AND name='webhook_operations'"""
+            )
+            conn.execute("PRAGMA writable_schema=OFF")
+
+
+def test_indeterminate_evidence_consumes_the_global_storage_budget(tmp_path: Path):
+    ledger = WebhookOperationLedger(
+        tmp_path / "state.db",
+        max_records=8,
+        max_storage_bytes=MINIMUM_MAX_STORAGE_BYTES,
+    )
+    envelope = _envelope("unknown", trace_id="unknown-trace")
+    admitted = ledger.admit(envelope)
+    assert admitted.disposition is AdmitDisposition.ACCEPTED
+    assert admitted.authority is not None
+    assert (
+        ledger.admit(_envelope("unknown", trace_id="unknown-active")).disposition
+        is AdmitDisposition.ACTIVE
+    )
+    assert (
+        ledger.admit(
+            _envelope(
+                "unknown",
+                trace_id="unknown-conflict",
+                body_identity="changed",
+            )
+        ).disposition
+        is AdmitDisposition.CONFLICT
+    )
+    assert ledger.mark_indeterminate(admitted.authority, "unknown postcondition")
+    assert ledger.storage_usage() == (
+        MINIMUM_MAX_STORAGE_BYTES,
+        1,
+        MINIMUM_MAX_STORAGE_BYTES,
+    )
+
+    saturated = ledger.admit(_envelope("new", trace_id="new-trace"))
+    assert saturated.disposition is AdmitDisposition.SATURATED
+    replay = ledger.admit(_envelope("unknown", trace_id="unknown-retry"))
+    assert replay.disposition is AdmitDisposition.INDETERMINATE
+    retained = ledger.lookup_session(admitted.authority.session_key)
+    assert retained is not None
+    assert retained.state is OperationState.INDETERMINATE
+
+
+def test_permanent_proofs_eventually_saturate_without_reopening_replays(
+    tmp_path: Path,
+):
+    tombstone_bytes = ledger_module._TOMBSTONE_STORAGE_RESERVATION_BYTES
+    storage_limit = MINIMUM_MAX_STORAGE_BYTES + 2 * tombstone_bytes
+    ledger = WebhookOperationLedger(
+        tmp_path / "state.db",
+        max_records=8,
+        max_storage_bytes=storage_limit,
+    )
+
+    for index in range(3):
+        envelope = _envelope(
+            f"settled-{index}",
+            trace_id=f"trace-{index}",
+            route_name=f"storage-budget-{index}",
+        )
+        admitted = ledger.admit(envelope)
+        assert admitted.disposition is AdmitDisposition.ACCEPTED
+        assert admitted.authority is not None
+        assert ledger.settle_no_effect(admitted.authority)
+
+    saturated = ledger.admit(
+        _envelope(
+            "overflow",
+            trace_id="overflow-trace",
+            route_name="storage-budget-overflow",
+        )
+    )
+    assert saturated.disposition is AdmitDisposition.SATURATED
+    assert ledger.count() == 0
+    assert ledger.tombstone_count() == 3
+    reserved, proofs, persisted_limit = ledger.storage_usage()
+    assert reserved == 3 * tombstone_bytes
+    assert proofs == 3
+    assert persisted_limit == storage_limit
+
+    duplicate = ledger.admit(
+        _envelope(
+            "settled-0",
+            trace_id="settled-0-retry",
+            route_name="storage-budget-0",
+        )
+    )
+    assert duplicate.disposition is AdmitDisposition.DUPLICATE
+
+
+def test_one_scope_cannot_consume_the_global_storage_reserve(tmp_path: Path):
+    tombstone_bytes = ledger_module._TOMBSTONE_STORAGE_RESERVATION_BYTES
+    storage_limit = MINIMUM_MAX_STORAGE_BYTES * 2
+    ledger = WebhookOperationLedger(
+        tmp_path / "state.db",
+        max_records=8,
+        max_storage_bytes=storage_limit,
+    )
+
+    first = ledger.admit(_envelope("scope-a-1", trace_id="scope-a-1-trace"))
+    assert first.authority is not None
+    assert ledger.settle_no_effect(first.authority)
+
+    # The first settled carrier compacts, but its permanent proof still owns
+    # bytes in scope A. It cannot consume the heavy-carrier reserve.
+    scope_full = ledger.admit(_envelope("scope-a-2", trace_id="scope-a-2-trace"))
+    assert scope_full.disposition is AdmitDisposition.SATURATED
+    assert scope_full.saturation is AdmitSaturationReason.SCOPE_STORAGE_LIMIT
+    assert (
+        ledger.admit(
+            _envelope(
+                "scope-b-1",
+                trace_id="scope-b-1-trace",
+                route_name="storage-budget-b",
+            )
+        ).disposition
+        is AdmitDisposition.ACCEPTED
+    )
+    assert ledger.storage_usage() == (
+        MINIMUM_MAX_STORAGE_BYTES + tombstone_bytes,
+        2,
+        storage_limit,
+    )
+
+    # Exact proof lookup remains available even while both the scope and
+    # global admission budgets refuse new unique work.
+    replay = ledger.admit(_envelope("scope-a-1", trace_id="scope-a-1-retry"))
+    assert replay.disposition is AdmitDisposition.DUPLICATE
+    globally_full = ledger.admit(
+        _envelope(
+            "scope-c-1",
+            trace_id="scope-c-1-trace",
+            route_name="storage-budget-c",
+        )
+    )
+    assert globally_full.disposition is AdmitDisposition.SATURATED
+    assert globally_full.saturation is AdmitSaturationReason.GLOBAL_STORAGE_LIMIT
+
+
+def test_concurrent_handles_cannot_both_claim_the_last_storage_slot(tmp_path: Path):
+    db_path = tmp_path / "state.db"
+    first = WebhookOperationLedger(
+        db_path,
+        max_records=8,
+        max_storage_bytes=MINIMUM_MAX_STORAGE_BYTES,
+        instance_id="first",
+    )
+    second = WebhookOperationLedger(
+        db_path,
+        max_records=8,
+        max_storage_bytes=MINIMUM_MAX_STORAGE_BYTES,
+        instance_id="second",
+    )
+
+    def admit(ledger: WebhookOperationLedger, identity: str, route: str):
+        return ledger.admit(
+            _envelope(identity, trace_id=f"{identity}-trace", route_name=route)
+        ).disposition
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        futures = (
+            pool.submit(admit, first, "concurrent-a", "concurrent-a"),
+            pool.submit(admit, second, "concurrent-b", "concurrent-b"),
+        )
+    assert sorted(result.result().value for result in futures) == [
+        AdmitDisposition.ACCEPTED.value,
+        AdmitDisposition.SATURATED.value,
+    ]
+    assert first.storage_usage() == (
+        MINIMUM_MAX_STORAGE_BYTES,
+        1,
+        MINIMUM_MAX_STORAGE_BYTES,
+    )
+
+
+def test_reserved_carrier_can_reach_full_size_and_settle_at_budget(tmp_path: Path):
+    ledger = WebhookOperationLedger(
+        tmp_path / "state.db",
+        max_records=8,
+        max_storage_bytes=MINIMUM_MAX_STORAGE_BYTES,
+    )
+    admitted = ledger.admit(_envelope("large", trace_id="large-trace"))
+    assert admitted.authority is not None
+
+    large_event_value = "e" * (ledger_module._MAX_EVENT_JSON_BYTES - 128)
+    prepared = ledger.prepare(
+        admitted.authority,
+        event_snapshot={"payload": large_event_value},
+        target_snapshot={"kind": "log", "profile": "default"},
+        grant_snapshot={"mode": "agent", "toolsets": []},
+    )
+    assert ledger.mark_running(prepared)
+    large_delivery = "d" * (ledger_module._MAX_EVENT_JSON_BYTES - 256)
+    staged = ledger.stage_delivery(
+        prepared,
+        content=large_delivery,
+        carrier_snapshot={"v": 1, "kind": "agent_final"},
+    )
+    attempt = ledger.begin_target(staged)
+    assert attempt.disposition is TargetAttemptDisposition.STARTED
+    assert ledger.settle_target(
+        attempt,
+        Settlement(SettlementKind.SUPPRESSED),
+    )
+    restored = ledger.lookup_session(staged.session_key)
+    assert restored is not None
+    assert restored.state is OperationState.SETTLED
+    assert ledger.storage_usage() == (
+        MINIMUM_MAX_STORAGE_BYTES,
+        1,
+        MINIMUM_MAX_STORAGE_BYTES,
+    )
+
+
+def test_persisted_limit_rejects_mismatched_process_configuration(tmp_path: Path):
+    db_path = tmp_path / "state.db"
+    higher_limit = MINIMUM_MAX_STORAGE_BYTES * 2
+    first = WebhookOperationLedger(db_path, max_storage_bytes=higher_limit)
+    with pytest.raises(WebhookLedgerError, match="limits do not match"):
+        WebhookOperationLedger(
+            db_path,
+            max_storage_bytes=MINIMUM_MAX_STORAGE_BYTES,
+        )
+    second = WebhookOperationLedger(db_path, max_storage_bytes=higher_limit)
+    assert first.storage_usage()[2] == higher_limit
+    assert second.storage_usage()[2] == higher_limit
+
+    assert (
+        first.admit(_envelope("one", trace_id="one-trace")).disposition
+        is AdmitDisposition.ACCEPTED
+    )
+    assert (
+        first.admit(
+            _envelope("two", trace_id="two-trace", route_name="other-scope")
+        ).disposition
+        is AdmitDisposition.ACCEPTED
+    )
+    assert (
+        first.admit(
+            _envelope("three", trace_id="three-trace", route_name="third-scope")
+        ).disposition
+        is AdmitDisposition.SATURATED
+    )
+
+
+def test_persisted_limit_cannot_be_silently_widened_by_a_later_handle(
+    tmp_path: Path,
+):
+    db_path = tmp_path / "state.db"
+    ledger = WebhookOperationLedger(
+        db_path,
+        max_storage_bytes=MINIMUM_MAX_STORAGE_BYTES,
+    )
+    with pytest.raises(WebhookLedgerError, match="limits do not match"):
+        WebhookOperationLedger(
+            db_path,
+            max_storage_bytes=MINIMUM_MAX_STORAGE_BYTES * 2,
+        )
+    assert ledger.storage_usage()[2] == MINIMUM_MAX_STORAGE_BYTES
+
+
+@pytest.mark.parametrize(("first_limit", "second_limit"), [(8, 7), (7, 8)])
+def test_persisted_record_limit_rejects_mismatched_handles(
+    tmp_path: Path,
+    first_limit: int,
+    second_limit: int,
+):
+    db_path = tmp_path / "state.db"
+    WebhookOperationLedger(db_path, max_records=first_limit)
+
+    with pytest.raises(WebhookLedgerError, match="limits do not match"):
+        WebhookOperationLedger(db_path, max_records=second_limit)
+
+    with sqlite3.connect(db_path) as conn:
+        persisted = conn.execute(
+            """SELECT max_records FROM webhook_ledger_usage
+                WHERE schema_name='webhook_operation_ledger'"""
+        ).fetchone()[0]
+    assert persisted == first_limit
+
+
+def test_auth_binding_handle_adopts_root_limits_across_named_profile_quotas(
+    tmp_path: Path,
+):
+    root_db = tmp_path / "root" / "state.db"
+    profile_db = tmp_path / "root" / "profiles" / "alpha" / "state.db"
+    root_ledger = WebhookOperationLedger(
+        root_db,
+        max_records=4096,
+        max_storage_bytes=MINIMUM_MAX_STORAGE_BYTES * 4,
+    )
+    profile_ledger = WebhookOperationLedger(
+        profile_db,
+        max_records=8,
+        max_storage_bytes=MINIMUM_MAX_STORAGE_BYTES * 2,
+    )
+    assert profile_ledger.max_records == 8
+
+    auth_ledger = WebhookOperationLedger.for_authentication_bindings(root_db)
+    assert auth_ledger.max_records == root_ledger.max_records == 4096
+    assert (
+        auth_ledger.max_storage_bytes
+        == root_ledger.max_storage_bytes
+        == MINIMUM_MAX_STORAGE_BYTES * 4
+    )
+    binding = (
+        hashlib.sha256(b"named-profile-key").hexdigest(),
+        "alpha",
+        "events",
+        "generic",
+        "generic_v2",
+        hashlib.sha256(b"named-profile-policy").hexdigest(),
+    )
+    auth_ledger.bind_authentication_keys([binding])
+
+    reopened_root = WebhookOperationLedger(
+        root_db,
+        max_records=4096,
+        max_storage_bytes=MINIMUM_MAX_STORAGE_BYTES * 4,
+    )
+    reopened_root.bind_authentication_keys([binding])
+    with sqlite3.connect(root_db) as conn:
+        persisted_limits = conn.execute(
+            """SELECT max_records, max_storage_bytes
+                 FROM webhook_ledger_usage"""
+        ).fetchone()
+        binding_count = conn.execute(
+            "SELECT COUNT(*) FROM webhook_auth_key_bindings"
+        ).fetchone()[0]
+    assert persisted_limits == (
+        4096,
+        MINIMUM_MAX_STORAGE_BYTES * 4,
+    )
+    assert binding_count == 1
+
+
+def test_alpha_first_auth_binding_bootstrap_allows_default_custom_quotas(
+    tmp_path: Path,
+):
+    root_db = tmp_path / "root" / "state.db"
+    auth_ledger = WebhookOperationLedger.for_authentication_bindings(root_db)
+    binding = (
+        hashlib.sha256(b"alpha-first-key").hexdigest(),
+        "alpha",
+        "events",
+        "generic",
+        "generic_v2",
+        hashlib.sha256(b"alpha-first-policy").hexdigest(),
+    )
+    auth_ledger.bind_authentication_keys([binding])
+
+    custom_records = 17
+    custom_storage = MINIMUM_MAX_STORAGE_BYTES * 3
+    default_ledger = WebhookOperationLedger(
+        root_db,
+        max_records=custom_records,
+        max_storage_bytes=custom_storage,
+    )
+    assert default_ledger.max_records == custom_records
+    assert default_ledger.max_storage_bytes == custom_storage
+    default_ledger.bind_authentication_keys([binding])
+
+    reopened_auth = WebhookOperationLedger.for_authentication_bindings(root_db)
+    assert reopened_auth.max_records == custom_records
+    assert reopened_auth.max_storage_bytes == custom_storage
+    with sqlite3.connect(root_db) as conn:
+        usage = conn.execute(
+            """SELECT max_records, max_storage_bytes,
+                      operation_limits_provisional, proof_count,
+                      auth_binding_count
+                 FROM webhook_ledger_usage"""
+        ).fetchone()
+    assert usage == (custom_records, custom_storage, 0, 0, 1)
+
+
+def test_provisional_limits_never_rewrite_existing_operation_evidence(
+    tmp_path: Path,
+):
+    root_db = tmp_path / "root" / "state.db"
+    auth_ledger = WebhookOperationLedger.for_authentication_bindings(root_db)
+    admitted = auth_ledger.admit(
+        _envelope("provisional-proof", trace_id="provisional-proof-trace")
+    )
+    assert admitted.disposition is AdmitDisposition.ACCEPTED
+    assert admitted.authority is not None
+
+    with pytest.raises(
+        WebhookLedgerError,
+        match="provisional webhook operation limits cannot change",
+    ):
+        WebhookOperationLedger(
+            root_db,
+            max_records=17,
+            max_storage_bytes=MINIMUM_MAX_STORAGE_BYTES * 3,
+        )
+
+    reopened = WebhookOperationLedger.for_authentication_bindings(root_db)
+    assert reopened.max_records == ledger_module.DEFAULT_MAX_RECORDS
+    assert reopened.max_storage_bytes == ledger_module.DEFAULT_MAX_STORAGE_BYTES
+    assert reopened.lookup_session(admitted.authority.session_key) is not None
+    with sqlite3.connect(root_db) as conn:
+        usage = conn.execute(
+            """SELECT max_records, max_storage_bytes,
+                      operation_limits_provisional, proof_count
+                 FROM webhook_ledger_usage"""
+        ).fetchone()
+    assert usage == (
+        ledger_module.DEFAULT_MAX_RECORDS,
+        ledger_module.DEFAULT_MAX_STORAGE_BYTES,
+        1,
+        1,
+    )
+
+
+def test_limit_cannot_be_lowered_below_reserved_evidence(tmp_path: Path):
+    db_path = tmp_path / "state.db"
+    higher_limit = MINIMUM_MAX_STORAGE_BYTES * 2
+    ledger = WebhookOperationLedger(db_path, max_storage_bytes=higher_limit)
+    for index in range(2):
+        admitted = ledger.admit(
+            _envelope(
+                f"live-{index}",
+                trace_id=f"live-{index}-trace",
+                route_name=f"live-scope-{index}",
+            )
+        )
+        assert admitted.disposition is AdmitDisposition.ACCEPTED
+
+    with pytest.raises(WebhookLedgerError, match="below reserved evidence"):
+        WebhookOperationLedger(
+            db_path,
+            max_storage_bytes=MINIMUM_MAX_STORAGE_BYTES,
+        )
+
+
+def test_authentication_binding_policy_is_permanent_across_reopen(tmp_path: Path):
+    db_path = tmp_path / "state.db"
+    fingerprint = hashlib.sha256(b"stable-key").hexdigest()
+    first_policy = hashlib.sha256(b"policy-one").hexdigest()
+    second_policy = hashlib.sha256(b"policy-two").hexdigest()
+    binding = (
+        fingerprint,
+        "default",
+        "events",
+        "generic",
+        "generic_v2",
+        first_policy,
+    )
+    ledger = WebhookOperationLedger(db_path)
+    ledger.bind_authentication_keys([binding])
+    ledger.bind_authentication_keys([binding])
+
+    reopened = WebhookOperationLedger(db_path)
+    reopened.bind_authentication_keys([binding])
+    with pytest.raises(
+        WebhookLedgerTransitionError,
+        match="permanently bound to another route policy authority",
+    ):
+        reopened.bind_authentication_keys([
+            (*binding[:-1], second_policy),
+        ])
+
+    with sqlite3.connect(db_path) as conn:
+        persisted = conn.execute(
+            """SELECT profile, route, provider, signature_mode, policy_sha256
+                 FROM webhook_auth_key_bindings
+                WHERE key_fingerprint=?""",
+            (fingerprint,),
+        ).fetchall()
+        usage = conn.execute(
+            """SELECT reserved_bytes, proof_count,
+                      auth_binding_reserved_bytes, auth_binding_count
+                 FROM webhook_ledger_usage
+                WHERE schema_name='webhook_operation_ledger'"""
+        ).fetchone()
+    assert persisted == [binding[1:]]
+    assert usage == (
+        0,
+        0,
+        ledger_module._AUTH_BINDING_STORAGE_RESERVATION_BYTES,
+        1,
+    )
+
+
+def test_authentication_bindings_are_globally_budgeted_and_atomic(
+    tmp_path: Path,
+):
+    db_path = tmp_path / "state.db"
+    ledger = WebhookOperationLedger(
+        db_path,
+        max_storage_bytes=MINIMUM_MAX_STORAGE_BYTES,
+    )
+    capacity = (
+        ledger_module._AUTH_BINDING_GLOBAL_LIMIT_BYTES
+        // ledger_module._AUTH_BINDING_STORAGE_RESERVATION_BYTES
+    )
+    policy_sha256 = hashlib.sha256(b"stable-policy").hexdigest()
+    bindings = [
+        (
+            hashlib.sha256(f"key-{index}".encode()).hexdigest(),
+            "default",
+            f"route-{index}",
+            "generic",
+            "generic_v2",
+            policy_sha256,
+        )
+        for index in range(capacity)
+    ]
+    overflow = (
+        hashlib.sha256(b"overflow-key").hexdigest(),
+        "default",
+        "overflow",
+        "generic",
+        "generic_v2",
+        policy_sha256,
+    )
+    ledger.bind_authentication_keys(bindings[:-1])
+    with pytest.raises(
+        WebhookLedgerCapacityError,
+        match="authentication binding capacity exhausted",
+    ):
+        ledger.bind_authentication_keys([bindings[-1], overflow])
+    with sqlite3.connect(db_path) as conn:
+        rolled_back_count = conn.execute(
+            "SELECT COUNT(*) FROM webhook_auth_key_bindings"
+        ).fetchone()[0]
+    assert rolled_back_count == capacity - 1
+
+    ledger.bind_authentication_keys([bindings[-1]])
+    ledger.bind_authentication_keys([bindings[0]])
+    with pytest.raises(
+        WebhookLedgerCapacityError,
+        match="authentication binding capacity exhausted",
+    ):
+        ledger.bind_authentication_keys([overflow])
+
+    with sqlite3.connect(db_path) as conn:
+        binding_count = conn.execute(
+            "SELECT COUNT(*) FROM webhook_auth_key_bindings"
+        ).fetchone()[0]
+        usage = conn.execute(
+            """SELECT reserved_bytes, proof_count,
+                      auth_binding_reserved_bytes, auth_binding_count
+                 FROM webhook_ledger_usage
+                WHERE schema_name='webhook_operation_ledger'"""
+        ).fetchone()
+    assert binding_count == capacity
+    assert usage == (
+        0,
+        0,
+        ledger_module._AUTH_BINDING_GLOBAL_LIMIT_BYTES,
+        capacity,
+    )
+    assert ledger.has_global_admission_capacity()
+
+
+def test_authentication_binding_counter_corruption_fails_closed_on_reopen(
+    tmp_path: Path,
+):
+    db_path = tmp_path / "state.db"
+    ledger = WebhookOperationLedger(db_path)
+    ledger.bind_authentication_keys([
+        (
+            hashlib.sha256(b"counter-key").hexdigest(),
+            "default",
+            "counter-route",
+            "generic",
+            "generic_v2",
+            hashlib.sha256(b"counter-policy").hexdigest(),
+        )
+    ])
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("PRAGMA ignore_check_constraints=ON")
+        conn.execute(
+            """UPDATE webhook_ledger_usage SET auth_binding_count=0
+                WHERE schema_name='webhook_operation_ledger'"""
+        )
+        conn.execute("PRAGMA ignore_check_constraints=OFF")
+
+    with pytest.raises(
+        WebhookLedgerCorruptionError,
+        match="usage counter is inconsistent",
+    ):
+        WebhookOperationLedger(db_path)
+
+
+def test_authentication_binding_content_corruption_fails_closed_on_reopen(
+    tmp_path: Path,
+):
+    db_path = tmp_path / "state.db"
+    ledger = WebhookOperationLedger(db_path)
+    ledger.bind_authentication_keys([
+        (
+            hashlib.sha256(b"timestamp-key").hexdigest(),
+            "default",
+            "timestamp-route",
+            "generic",
+            "generic_v2",
+            hashlib.sha256(b"timestamp-policy").hexdigest(),
+        )
+    ])
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("DROP TRIGGER trg_webhook_auth_bindings_immutable_update")
+        conn.execute("UPDATE webhook_auth_key_bindings SET bound_at='NaN'")
+
+    with pytest.raises(
+        WebhookLedgerCorruptionError,
+        match="authentication key binding is invalid",
+    ):
+        WebhookOperationLedger(db_path)
+
+
+def test_authentication_key_match_is_bounded_indexed_and_exact(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    ledger = WebhookOperationLedger(tmp_path / "state.db")
+    policy_sha256 = hashlib.sha256(b"match-policy").hexdigest()
+    bindings = [
+        (
+            hashlib.sha256(f"match-key-{index}".encode()).hexdigest(),
+            "default",
+            "match-route",
+            "generic",
+            "generic_v2",
+            policy_sha256,
+        )
+        for index in range(2)
+    ]
+    ledger.bind_authentication_keys(bindings)
+
+    statements: list[str] = []
+    original_connect = ledger._connect
+
+    def traced_connect():
+        conn = original_connect()
+        conn.set_trace_callback(statements.append)
+        return conn
+
+    monkeypatch.setattr(ledger, "_connect", traced_connect)
+    assert ledger.authentication_keys_match(bindings)
+    assert not ledger.authentication_keys_match([
+        (
+            *bindings[0][:-1],
+            hashlib.sha256(b"other-policy").hexdigest(),
+        )
+    ])
+    assert not ledger.authentication_keys_match([
+        (
+            hashlib.sha256(b"missing-key").hexdigest(),
+            *bindings[0][1:],
+        )
+    ])
+    with pytest.raises(
+        WebhookLedgerError,
+        match="exceeds its fingerprint bound",
+    ):
+        ledger.authentication_keys_match(bindings * 5)
+
+    binding_reads = [
+        statement.lower()
+        for statement in statements
+        if statement.lstrip().lower().startswith("select")
+        and "from webhook_auth_key_bindings" in statement.lower()
+    ]
+    assert binding_reads
+    assert all("where key_fingerprint=" in statement for statement in binding_reads)
+    assert all("count(" not in statement for statement in binding_reads)
+    assert all("sum(" not in statement for statement in binding_reads)
+    with sqlite3.connect(ledger.db_path) as conn:
+        plan = conn.execute(
+            """EXPLAIN QUERY PLAN
+                SELECT profile, route, provider, signature_mode, policy_sha256
+                  FROM webhook_auth_key_bindings
+                 WHERE key_fingerprint=?""",
+            (bindings[0][0],),
+        ).fetchall()
+    assert any(
+        "USING INDEX sqlite_autoindex_webhook_auth_key_bindings_1" in row[3]
+        for row in plan
+    )
+    assert not any("SCAN webhook_auth_key_bindings" in row[3] for row in plan)
+
+
+def test_authentication_key_match_detects_root_database_loss_and_replacement(
+    tmp_path: Path,
+):
+    db_path = tmp_path / "root" / "state.db"
+    ledger = WebhookOperationLedger(db_path)
+    fingerprint = hashlib.sha256(b"cached-alpha-key").hexdigest()
+    policy_sha256 = hashlib.sha256(b"cached-alpha-policy").hexdigest()
+    alpha_binding = (
+        fingerprint,
+        "alpha",
+        "events",
+        "generic",
+        "generic_v2",
+        policy_sha256,
+    )
+    ledger.bind_authentication_keys([alpha_binding])
+    assert ledger.authentication_keys_match([alpha_binding])
+
+    lost_backup = tmp_path / "lost-root-state.db"
+    db_path.replace(lost_backup)
+    with pytest.raises(WebhookLedgerError):
+        ledger.authentication_keys_match([alpha_binding])
+    lost_backup.replace(db_path)
+    assert ledger.authentication_keys_match([alpha_binding])
+
+    replacement_path = tmp_path / "replacement-state.db"
+    replacement = WebhookOperationLedger(replacement_path)
+    beta_binding = (
+        fingerprint,
+        "beta",
+        "events",
+        "generic",
+        "generic_v2",
+        hashlib.sha256(b"replacement-beta-policy").hexdigest(),
+    )
+    replacement.bind_authentication_keys([beta_binding])
+    with sqlite3.connect(replacement_path) as conn:
+        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+    displaced_path = tmp_path / "displaced-alpha-state.db"
+    db_path.replace(displaced_path)
+    replacement_path.replace(db_path)
+
+    assert not ledger.authentication_keys_match([alpha_binding])
+    assert ledger.authentication_keys_match([beta_binding])
+
+
+def test_one_route_cannot_consume_shared_capacity_with_key_rotations(
+    tmp_path: Path,
+):
+    storage_limit = MINIMUM_MAX_STORAGE_BYTES * 2
+    ledger = WebhookOperationLedger(
+        tmp_path / "state.db",
+        max_storage_bytes=storage_limit,
+    )
+    scope_capacity = (
+        ledger_module._AUTH_BINDING_SCOPE_LIMIT_BYTES
+        // ledger_module._AUTH_BINDING_STORAGE_RESERVATION_BYTES
+    )
+    policy_sha256 = hashlib.sha256(b"rotating-policy").hexdigest()
+    rotations = [
+        (
+            hashlib.sha256(f"rotation-{index}".encode()).hexdigest(),
+            "default",
+            "rotating-route",
+            "generic",
+            "generic_v2",
+            policy_sha256,
+        )
+        for index in range(scope_capacity + 1)
+    ]
+    ledger.bind_authentication_keys(rotations[:-1])
+    ledger.bind_authentication_keys([rotations[0]])
+
+    with pytest.raises(
+        WebhookLedgerCapacityError,
+        match="route-scope capacity exhausted",
+    ):
+        ledger.bind_authentication_keys([rotations[-1]])
+    assert ledger.has_global_admission_capacity()
+    reserved_operation = ledger.admit(
+        _envelope(
+            "reserved-operation",
+            trace_id="reserved-operation-trace",
+            route_name="other-route",
+        )
+    )
+    assert reserved_operation.disposition is AdmitDisposition.ACCEPTED
+    assert ledger.has_global_admission_capacity()
+    second_operation = ledger.admit(
+        _envelope(
+            "second-reserved-operation",
+            trace_id="second-reserved-operation-trace",
+            route_name="another-route",
+        )
+    )
+    assert second_operation.disposition is AdmitDisposition.ACCEPTED
+    assert not ledger.has_global_admission_capacity()
+
+
+def test_full_operation_budget_cannot_strand_authentication_rotation(
+    tmp_path: Path,
+):
+    ledger = WebhookOperationLedger(
+        tmp_path / "state.db",
+        max_storage_bytes=MINIMUM_MAX_STORAGE_BYTES,
+    )
+    admitted = ledger.admit(
+        _envelope("fills-operation-budget", trace_id="full-budget-trace")
+    )
+    assert admitted.disposition is AdmitDisposition.ACCEPTED
+    assert not ledger.has_global_admission_capacity()
+
+    policy_sha256 = hashlib.sha256(b"full-budget-policy").hexdigest()
+    old_binding = (
+        hashlib.sha256(b"old-key").hexdigest(),
+        "default",
+        "rotating-route",
+        "generic",
+        "generic_v2",
+        policy_sha256,
+    )
+    replacement_binding = (
+        hashlib.sha256(b"replacement-key").hexdigest(),
+        *old_binding[1:],
+    )
+    ledger.bind_authentication_keys([old_binding])
+    ledger.bind_authentication_keys([replacement_binding])
+    ledger.bind_authentication_keys([replacement_binding])
+
+    with sqlite3.connect(ledger.db_path) as conn:
+        usage = conn.execute(
+            """SELECT reserved_bytes, auth_binding_reserved_bytes,
+                      auth_binding_count
+                 FROM webhook_ledger_usage"""
+        ).fetchone()
+    assert usage == (
+        MINIMUM_MAX_STORAGE_BYTES,
+        2 * ledger_module._AUTH_BINDING_STORAGE_RESERVATION_BYTES,
+        2,
+    )
+
+
+def test_populated_v4_ledger_migrates_transactionally_to_v5(tmp_path: Path):
+    db_path = tmp_path / "state.db"
+    _create_populated_v4_ledger(db_path)
+    with sqlite3.connect(db_path) as conn:
+        before_rows = (
+            conn.execute(
+                "SELECT * FROM webhook_operations ORDER BY operation_id"
+            ).fetchall(),
+            conn.execute(
+                "SELECT * FROM webhook_targets ORDER BY operation_id, target_id"
+            ).fetchall(),
+            conn.execute(
+                """SELECT * FROM webhook_delivery_tombstones
+                    ORDER BY profile, route, provider, replay_id"""
+            ).fetchall(),
+        )
+
+    ledger = WebhookOperationLedger(db_path)
+
+    restored = ledger.lookup_session("agent:main:webhook:v4")
+    assert restored is not None
+    assert restored.operation_id == "v4-operation"
+    assert restored.state is OperationState.READY
+    assert restored.target_state is not None
+    assert ledger.count() == 1
+    assert ledger.tombstone_count() == 1
+    assert ledger.storage_usage() == (
+        ledger_module._OPERATION_STORAGE_RESERVATION_BYTES
+        + ledger_module._TOMBSTONE_STORAGE_RESERVATION_BYTES,
+        2,
+        ledger_module.DEFAULT_MAX_STORAGE_BYTES,
+    )
+    with sqlite3.connect(db_path) as conn:
+        version = conn.execute(
+            """SELECT schema_version FROM webhook_ledger_meta
+                WHERE schema_name='webhook_operation_ledger'"""
+        ).fetchone()[0]
+        target_pk = [
+            row[5] for row in conn.execute("PRAGMA table_info(webhook_targets)")
+        ]
+        usage = conn.execute(
+            """SELECT active_record_count, settled_operation_count,
+                      indeterminate_operation_count, auth_binding_count
+                 FROM webhook_ledger_usage"""
+        ).fetchone()
+        parked_tables = conn.execute(
+            """SELECT name FROM sqlite_master
+                WHERE type='table' AND name LIKE '%_v4'"""
+        ).fetchall()
+        after_rows = (
+            conn.execute(
+                "SELECT * FROM webhook_operations ORDER BY operation_id"
+            ).fetchall(),
+            conn.execute(
+                "SELECT * FROM webhook_targets ORDER BY operation_id, target_id"
+            ).fetchall(),
+            conn.execute(
+                """SELECT * FROM webhook_delivery_tombstones
+                    ORDER BY profile, route, provider, replay_id"""
+            ).fetchall(),
+        )
+    assert version == 5
+    assert target_pk == [1] + [0] * 14
+    assert usage == (1, 0, 0, 0)
+    assert parked_tables == []
+    assert after_rows == before_rows
+
+
+def test_v4_migration_validates_large_operations_in_bounded_batches(
+    tmp_path: Path,
+    monkeypatch,
+):
+    db_path = tmp_path / "state.db"
+    _create_populated_v4_ledger(db_path)
+    operation_count = 2 * ledger_module._V4_MIGRATION_VALIDATION_BATCH_SIZE + 2
+    large_event_json = json.dumps(
+        {
+            "padding": "x" * (64 * 1024),
+            "payload": {"v": 4},
+            "text": "v4",
+            "v": 1,
+        },
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "UPDATE webhook_operations SET event_json=? WHERE operation_id=?",
+            (large_event_json, "v4-operation"),
+        )
+        for index in range(1, operation_count):
+            operation_id = f"v4-operation-{index:03d}"
+            conn.execute(
+                """INSERT INTO webhook_operations (
+                       operation_id, profile, route, provider, replay_id,
+                       body_sha256, event_type, session_key, state, generation,
+                       owner_pid, owner_started_at, owner_instance, event_json,
+                       target_json, grant_json, script_started, created_at,
+                       updated_at, settled_at, last_error
+                   )
+                   SELECT ?, profile, route, provider, ?, body_sha256,
+                          event_type, ?, state, generation, owner_pid,
+                          owner_started_at, owner_instance, event_json,
+                          target_json, grant_json, script_started, created_at,
+                          updated_at, settled_at, last_error
+                     FROM webhook_operations
+                    WHERE operation_id='v4-operation'""",
+                (
+                    operation_id,
+                    f"provider_id:v4-delivery-{index:03d}",
+                    f"agent:main:webhook:v4:{index:03d}",
+                ),
+            )
+            conn.execute(
+                """INSERT INTO webhook_targets (
+                       operation_id, target_id, state, attempt_token,
+                       content_sha256, delivery_json, delivery_sha256,
+                       external_id, owner_pid, owner_started_at, owner_instance,
+                       started_at, settled_at, updated_at, last_error
+                   )
+                   SELECT ?, target_id, state, attempt_token, content_sha256,
+                          delivery_json, delivery_sha256, external_id, owner_pid,
+                          owner_started_at, owner_instance, started_at,
+                          settled_at, updated_at, last_error
+                     FROM webhook_targets
+                    WHERE operation_id='v4-operation'""",
+                (operation_id,),
+            )
+
+    fetch_sizes: list[int] = []
+
+    class TrackingCursor(sqlite3.Cursor):
+        _operation_scan = False
+
+        def execute(self, sql, parameters=()):
+            self._operation_scan = (
+                "SELECT * FROM webhook_operations ORDER BY operation_id"
+                in " ".join(str(sql).split())
+            )
+            return super().execute(sql, parameters)
+
+        def fetchmany(self, size=None):
+            if self._operation_scan:
+                fetch_sizes.append(size)
+            return super().fetchmany(size)
+
+        def fetchall(self):
+            if self._operation_scan:
+                raise AssertionError("v4 operation validation must not fetch all rows")
+            return super().fetchall()
+
+    class TrackingConnection(sqlite3.Connection):
+        def execute(self, sql, parameters=()):
+            return self.cursor(factory=TrackingCursor).execute(sql, parameters)
+
+    real_connect = sqlite3.connect
+
+    def tracking_connect(*args, **kwargs):
+        kwargs["factory"] = TrackingConnection
+        return real_connect(*args, **kwargs)
+
+    monkeypatch.setattr(ledger_module.sqlite3, "connect", tracking_connect)
+
+    ledger = WebhookOperationLedger(db_path)
+
+    assert ledger.count() == operation_count
+    assert len(fetch_sizes) >= 3
+    assert set(fetch_sizes) == {ledger_module._V4_MIGRATION_VALIDATION_BATCH_SIZE}
+
+
+@pytest.mark.parametrize(
+    "ambiguous_table",
+    ["webhook_operations", "webhook_delivery_tombstones"],
+)
+def test_v4_default_profile_ambiguity_fails_closed_and_rolls_back(
+    tmp_path: Path,
+    ambiguous_table: str,
+):
+    db_path = tmp_path / "state.db"
+    _create_populated_v4_ledger(db_path, profile="alpha")
+    with sqlite3.connect(db_path) as conn:
+        if ambiguous_table == "webhook_operations":
+            conn.execute("UPDATE webhook_operations SET profile='default'")
+        else:
+            conn.execute("UPDATE webhook_delivery_tombstones SET profile='default'")
+    with sqlite3.connect(db_path) as conn:
+        before = tuple(conn.iterdump())
+
+    with pytest.raises(
+        WebhookLedgerConfigurationError,
+        match="physical authority profile is ambiguous",
+    ):
+        WebhookOperationLedger(db_path)
+
+    with sqlite3.connect(db_path) as conn:
+        after = tuple(conn.iterdump())
+        version = conn.execute(
+            "SELECT schema_version FROM webhook_ledger_meta"
+        ).fetchone()
+        v5_usage = conn.execute(
+            """SELECT 1 FROM sqlite_master
+                WHERE type='table' AND name='webhook_ledger_usage'"""
+        ).fetchone()
+    assert after == before
+    assert version == (4,)
+    assert v5_usage is None
+
+
+def test_concurrent_constructors_migrate_v4_once_and_both_open_v5(
+    tmp_path: Path,
+):
+    db_path = tmp_path / "state.db"
+    _create_populated_v4_ledger(db_path)
+
+    def open_ledger(instance_id: str) -> tuple[int, int]:
+        ledger = WebhookOperationLedger(db_path, instance_id=instance_id)
+        return ledger.count(), ledger.tombstone_count()
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        opened = list(pool.map(open_ledger, ("migrator-a", "migrator-b")))
+
+    assert opened == [(1, 1), (1, 1)]
+    with sqlite3.connect(db_path) as conn:
+        assert conn.execute(
+            "SELECT schema_version FROM webhook_ledger_meta"
+        ).fetchone() == (5,)
+        assert conn.execute(
+            """SELECT active_record_count, settled_operation_count,
+                      indeterminate_operation_count, proof_count
+                 FROM webhook_ledger_usage"""
+        ).fetchone() == (1, 0, 0, 2)
+        assert conn.execute(
+            """SELECT COUNT(*) FROM sqlite_master
+                WHERE type='table' AND name LIKE '%_v4'"""
+        ).fetchone() == (0,)
+
+
+@pytest.mark.parametrize(
+    ("fixture_kwargs", "error_match"),
+    [
+        ({"drop_replay_index": True}, "v4 ledger indexes or triggers"),
+        ({"extra_trigger": True}, "v4 ledger indexes or triggers"),
+        ({"weakened_operation_schema": True}, "v4 ledger table definitions"),
+        ({"corrupt_state": True}, "invalid durable authority"),
+        ({"invalid_event_json": True}, "stored event snapshot is invalid JSON"),
+        ({"corrupt_body_digest": True}, "stored operation body_sha256 is invalid"),
+        ({"invalid_created_at": True}, "stored operation created_at is invalid"),
+        ({"invalid_expiry": True}, "invalid durable authority"),
+    ],
+)
+def test_v4_migration_corruption_rolls_back_original_ledger(
+    tmp_path: Path,
+    fixture_kwargs,
+    error_match,
+):
+    db_path = tmp_path / "state.db"
+    _create_populated_v4_ledger(db_path, **fixture_kwargs)
+
+    with pytest.raises(WebhookLedgerError, match=error_match):
+        WebhookOperationLedger(db_path)
+
+    with sqlite3.connect(db_path) as conn:
+        version = conn.execute(
+            "SELECT schema_version FROM webhook_ledger_meta"
+        ).fetchone()[0]
+        operation = conn.execute(
+            """SELECT operation_id, state FROM webhook_operations
+                WHERE operation_id='v4-operation'"""
+        ).fetchone()
+        target_count = conn.execute("SELECT COUNT(*) FROM webhook_targets").fetchone()[
+            0
+        ]
+        v5_usage_exists = conn.execute(
+            """SELECT 1 FROM sqlite_master
+                WHERE type='table' AND name='webhook_ledger_usage'"""
+        ).fetchone()
+    assert version == 4
+    assert operation == (
+        "v4-operation",
+        "corrupt" if fixture_kwargs.get("corrupt_state") else "ready",
+    )
+    assert target_count == 1
+    assert v5_usage_exists is None
+
+
+def test_over_capacity_v4_migration_is_actionable_and_rolls_back(tmp_path: Path):
+    db_path = tmp_path / "state.db"
+    _create_populated_v4_ledger(db_path)
+
+    with pytest.raises(
+        WebhookLedgerCapacityError,
+        match=(
+            "v4 migration exceeds the configured storage capacity; "
+            "increase idempotency_max_storage_bytes"
+        ),
+    ):
+        WebhookOperationLedger(
+            db_path,
+            max_storage_bytes=MINIMUM_MAX_STORAGE_BYTES,
+        )
+
+    with sqlite3.connect(db_path) as conn:
+        assert conn.execute(
+            "SELECT schema_version FROM webhook_ledger_meta"
+        ).fetchone() == (4,)
+        assert conn.execute("SELECT COUNT(*) FROM webhook_operations").fetchone() == (
+            1,
+        )
+        assert conn.execute(
+            "SELECT COUNT(*) FROM webhook_delivery_tombstones"
+        ).fetchone() == (1,)
+        assert (
+            conn.execute(
+                """SELECT 1 FROM sqlite_master
+                WHERE type='table' AND name='webhook_ledger_usage'"""
+            ).fetchone()
+            is None
+        )
+
+
+def test_usage_counter_corruption_fails_closed_on_reopen(tmp_path: Path):
+    db_path = tmp_path / "state.db"
+    ledger = WebhookOperationLedger(db_path)
+    assert (
+        ledger.admit(_envelope("proof", trace_id="proof-trace")).disposition
+        is AdmitDisposition.ACCEPTED
+    )
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """UPDATE webhook_ledger_usage SET reserved_bytes=0
+               WHERE schema_name='webhook_operation_ledger'"""
+        )
+
+    with pytest.raises(
+        WebhookLedgerCorruptionError,
+        match="usage counter is inconsistent",
+    ):
+        WebhookOperationLedger(db_path)
+
+
+def test_scope_usage_counter_corruption_fails_closed_on_reopen(tmp_path: Path):
+    db_path = tmp_path / "state.db"
+    ledger = WebhookOperationLedger(db_path)
+    assert (
+        ledger.admit(_envelope("scope-proof", trace_id="scope-proof-trace")).disposition
+        is AdmitDisposition.ACCEPTED
+    )
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """UPDATE webhook_ledger_scope_usage
+                  SET reserved_bytes=reserved_bytes+1
+                WHERE profile='default' AND route='storage-budget'
+                  AND provider='svix'"""
+        )
+
+    with pytest.raises(
+        WebhookLedgerCorruptionError,
+        match="scope usage counter is inconsistent",
+    ):
+        WebhookOperationLedger(db_path)
+
+
+def test_scope_active_counter_corruption_fails_closed_on_reopen(tmp_path: Path):
+    db_path = tmp_path / "state.db"
+    ledger = WebhookOperationLedger(db_path)
+    assert (
+        ledger.admit(
+            _envelope("scope-active", trace_id="scope-active-trace")
+        ).disposition
+        is AdmitDisposition.ACCEPTED
+    )
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """UPDATE webhook_ledger_scope_usage
+                  SET active_record_count=0
+                WHERE profile='default' AND route='storage-budget'
+                  AND provider='svix'"""
+        )
+
+    with pytest.raises(
+        WebhookLedgerCorruptionError,
+        match="scope usage counter is inconsistent",
+    ):
+        WebhookOperationLedger(db_path)
+
+
+def test_state_class_counters_follow_transitions_deletes_and_compaction(
+    tmp_path: Path,
+):
+    db_path = tmp_path / "state.db"
+    ledger = WebhookOperationLedger(db_path, terminal_retention_seconds=1)
+
+    def state_counts() -> tuple[int, int, int]:
+        with sqlite3.connect(db_path) as conn:
+            row = conn.execute(
+                """SELECT active_record_count, settled_operation_count,
+                          indeterminate_operation_count
+                     FROM webhook_ledger_usage
+                    WHERE schema_name='webhook_operation_ledger'"""
+            ).fetchone()
+        assert row is not None
+        return tuple(int(value) for value in row)
+
+    settled = ledger.admit(_envelope("settled", trace_id="settled-trace"))
+    assert settled.authority is not None
+    assert state_counts() == (1, 0, 0)
+    prepared = ledger.prepare(
+        settled.authority,
+        event_snapshot={"v": 1, "payload": {}},
+        target_snapshot={"v": 1, "kind": "log", "profile": "default"},
+        grant_snapshot={"v": 1, "toolsets": []},
+    )
+    assert state_counts() == (1, 0, 0)
+    assert ledger.settle_no_effect(prepared)
+    assert state_counts() == (0, 1, 0)
+
+    unknown = ledger.admit(
+        _envelope(
+            "unknown",
+            trace_id="unknown-trace",
+            route_name="unknown-scope",
+        )
+    )
+    assert unknown.authority is not None
+    assert state_counts() == (1, 1, 0)
+    assert ledger.mark_indeterminate(unknown.authority, "unknown outcome")
+    assert state_counts() == (0, 1, 1)
+
+    released = ledger.admit(
+        _envelope(
+            "released",
+            trace_id="released-trace",
+            route_name="released-scope",
+        )
+    )
+    assert released.authority is not None
+    assert state_counts() == (1, 1, 1)
+    assert ledger.release_pre_effect(released.authority)
+    assert state_counts() == (0, 1, 1)
+
+    assert ledger.prune(now=ledger_module.time.time() + 2) == 1
+    assert state_counts() == (0, 0, 1)
+    assert ledger.count() == 1
+    assert ledger.tombstone_count() == 1
+
+
+def test_state_counter_corruption_fails_closed_on_reopen(tmp_path: Path):
+    db_path = tmp_path / "state.db"
+    ledger = WebhookOperationLedger(db_path)
+    admitted = ledger.admit(_envelope("counter", trace_id="counter-trace"))
+    assert admitted.authority is not None
+
+    # Preserve the table-level total while assigning the proof to the wrong
+    # state class, so startup validation must compare counters to durable rows.
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """UPDATE webhook_ledger_usage
+                  SET active_record_count=0,
+                      indeterminate_operation_count=1
+                WHERE schema_name='webhook_operation_ledger'"""
+        )
+
+    with pytest.raises(
+        WebhookLedgerCorruptionError,
+        match="usage counter is inconsistent",
+    ):
+        WebhookOperationLedger(db_path)
+
+
+def test_missing_state_transition_trigger_is_detected_after_transition(
+    tmp_path: Path,
+):
+    db_path = tmp_path / "state.db"
+    ledger = WebhookOperationLedger(db_path)
+    admitted = ledger.admit(_envelope("trigger", trace_id="trigger-trace"))
+    assert admitted.authority is not None
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("DROP TRIGGER trg_webhook_operations_usage_state")
+
+    assert ledger.settle_no_effect(admitted.authority)
+    with pytest.raises(
+        WebhookLedgerCorruptionError,
+        match="usage counter is inconsistent",
+    ):
+        WebhookOperationLedger(db_path)
+
+
+def test_bounded_settlement_expiry_index_corruption_fails_closed_on_reopen(
+    tmp_path: Path,
+):
+    db_path = tmp_path / "state.db"
+    WebhookOperationLedger(db_path)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("DROP INDEX idx_webhook_operations_bounded_settled_expiry")
+        conn.execute(
+            """CREATE INDEX idx_webhook_operations_bounded_settled_expiry
+                   ON webhook_operations(updated_at)
+                 WHERE state='settled'"""
+        )
+
+    with pytest.raises(
+        WebhookLedgerCorruptionError,
+        match="bounded-settlement expiry index is unavailable",
+    ):
+        WebhookOperationLedger(db_path)
+
+
+def test_global_capacity_readiness_uses_counters_and_bounded_indexed_probes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    ledger = WebhookOperationLedger(tmp_path / "state.db")
+    statements: list[str] = []
+    original_connect = ledger._connect
+
+    def traced_connect():
+        conn = original_connect()
+        conn.set_trace_callback(statements.append)
+        return conn
+
+    monkeypatch.setattr(ledger, "_connect", traced_connect)
+    assert ledger.has_global_admission_capacity()
+
+    proof_reads = [
+        statement.lower()
+        for statement in statements
+        if statement.lstrip().lower().startswith("select")
+        and (
+            "from webhook_operations" in statement.lower()
+            or "from webhook_delivery_tombstones" in statement.lower()
+        )
+    ]
+    assert len(proof_reads) == 2
+    assert all("indexed by" in statement for statement in proof_reads)
+    assert all(
+        f"limit {ledger_module._MAX_PRUNE_BATCH}" in statement
+        for statement in proof_reads
+    )
+    assert all("count(" not in statement for statement in proof_reads)
+    assert all("sum(" not in statement for statement in proof_reads)
+
+    prefix = ledger_module._BOUNDED_REPLAY_PREFIXES[0]
+    with sqlite3.connect(ledger.db_path) as conn:
+        operation_plan = conn.execute(
+            f"""EXPLAIN QUERY PLAN
+                SELECT operation_id
+                  FROM webhook_operations INDEXED BY
+                       idx_webhook_operations_bounded_settled_expiry
+                 WHERE state='settled'
+                   AND substr(replay_id, 1, {len(prefix)})='{prefix}'
+                   AND COALESCE(settled_at, updated_at) <= ?
+                 ORDER BY COALESCE(settled_at, updated_at)
+                 LIMIT ?""",
+            (0.0, ledger_module._MAX_PRUNE_BATCH),
+        ).fetchall()
+        tombstone_plan = conn.execute(
+            """EXPLAIN QUERY PLAN
+                SELECT rowid
+                  FROM webhook_delivery_tombstones INDEXED BY
+                       idx_webhook_tombstones_expires_at
+                 WHERE expires_at IS NOT NULL AND expires_at <= ?
+                 ORDER BY expires_at, rowid
+                 LIMIT ?""",
+            (0.0, ledger_module._MAX_PRUNE_BATCH),
+        ).fetchall()
+    assert any(
+        "USING INDEX idx_webhook_operations_bounded_settled_expiry" in row[3]
+        for row in operation_plan
+    )
+    assert not any("SCAN webhook_operations" in row[3] for row in operation_plan)
+    assert any(
+        "USING COVERING INDEX idx_webhook_tombstones_expires_at" in row[3]
+        for row in tombstone_plan
+    )
+    assert not any(
+        "SCAN webhook_delivery_tombstones" in row[3] for row in tombstone_plan
+    )
+
+
+def test_populated_admission_uses_persisted_global_and_scope_counters(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    ledger = WebhookOperationLedger(
+        tmp_path / "state.db",
+        max_records=128,
+    )
+    for index in range(30):
+        admitted = ledger.admit(
+            _envelope(
+                f"populated-{index}",
+                trace_id=f"populated-trace-{index}",
+                route_name=f"route-{index % 10}",
+            )
+        )
+        assert admitted.authority is not None
+        if index % 3 == 0:
+            assert ledger.settle_no_effect(admitted.authority)
+        elif index % 3 == 1:
+            assert ledger.mark_indeterminate(
+                admitted.authority,
+                "mixed-state capacity proof",
+            )
+
+    statements: list[str] = []
+    original_connect = ledger._connect
+
+    def traced_connect():
+        conn = original_connect()
+        conn.set_trace_callback(statements.append)
+        return conn
+
+    monkeypatch.setattr(ledger, "_connect", traced_connect)
+    admitted = ledger.admit(
+        _envelope(
+            "counter-admission",
+            trace_id="counter-admission-trace",
+            route_name="fresh-counter-scope",
+        )
+    )
+    assert admitted.disposition is AdmitDisposition.ACCEPTED
+
+    selects = [
+        statement.lower()
+        for statement in statements
+        if statement.lstrip().lower().startswith("select")
+    ]
+    assert not any("count(" in statement for statement in selects)
+    assert not any("sum(" in statement for statement in selects)
+    assert any("from webhook_ledger_usage" in statement for statement in selects)
+    assert any("from webhook_ledger_scope_usage" in statement for statement in selects)
+    settled_probes = [
+        statement
+        for statement in selects
+        if "from webhook_operations" in statement and "state='settled'" in statement
+    ]
+    assert settled_probes
+    assert all("indexed by" in statement for statement in settled_probes)
+    assert all("limit" in statement for statement in settled_probes)
+
+    with sqlite3.connect(ledger.db_path) as conn:
+        global_plan = conn.execute(
+            """EXPLAIN QUERY PLAN
+                SELECT * FROM webhook_operations INDEXED BY
+                       idx_webhook_operations_state_updated
+                 WHERE state='settled'
+                 ORDER BY updated_at
+                 LIMIT ?""",
+            (ledger_module._MAX_PRUNE_BATCH,),
+        ).fetchall()
+        scope_plan = conn.execute(
+            """EXPLAIN QUERY PLAN
+                SELECT * FROM webhook_operations INDEXED BY
+                       idx_webhook_operations_scope_state_updated
+                 WHERE state='settled' AND profile=? AND route=? AND provider=?
+                 ORDER BY updated_at
+                 LIMIT ?""",
+            (
+                "default",
+                "route-0",
+                "svix",
+                ledger_module._MAX_PRUNE_BATCH,
+            ),
+        ).fetchall()
+    assert any(
+        "USING INDEX idx_webhook_operations_state_updated" in row[3]
+        for row in global_plan
+    )
+    assert not any("SCAN webhook_operations" in row[3] for row in global_plan)
+    assert any(
+        "USING INDEX idx_webhook_operations_scope_state_updated" in row[3]
+        for row in scope_plan
+    )
+    assert not any("SCAN webhook_operations" in row[3] for row in scope_plan)
+
+
+def test_mixed_states_keep_readiness_and_real_global_admission_in_lockstep(
+    tmp_path: Path,
+):
+    ledger = WebhookOperationLedger(
+        tmp_path / "state.db",
+        max_records=3,
+    )
+    active = ledger.admit(
+        _envelope("active", trace_id="active-trace", route_name="active-route")
+    )
+    settled = ledger.admit(
+        _envelope(
+            "settled-mixed",
+            trace_id="settled-mixed-trace",
+            route_name="settled-route",
+        )
+    )
+    indeterminate = ledger.admit(
+        _envelope(
+            "indeterminate-mixed",
+            trace_id="indeterminate-mixed-trace",
+            route_name="indeterminate-route",
+        )
+    )
+    assert active.authority is not None
+    assert settled.authority is not None
+    assert indeterminate.authority is not None
+    assert ledger.settle_no_effect(settled.authority)
+    assert ledger.mark_indeterminate(
+        indeterminate.authority,
+        "mixed-state unknown outcome",
+    )
+
+    assert ledger.has_global_admission_capacity()
+    second_active = ledger.admit(
+        _envelope(
+            "second-active",
+            trace_id="second-active-trace",
+            route_name="second-active-route",
+        )
+    )
+    assert second_active.disposition is AdmitDisposition.ACCEPTED
+    assert ledger.has_global_admission_capacity()
+    third_active = ledger.admit(
+        _envelope(
+            "third-active",
+            trace_id="third-active-trace",
+            route_name="third-active-route",
+        )
+    )
+    assert third_active.disposition is AdmitDisposition.ACCEPTED
+
+    assert not ledger.has_global_admission_capacity()
+    full = ledger.admit(
+        _envelope(
+            "globally-full",
+            trace_id="globally-full-trace",
+            route_name="globally-full-route",
+        )
+    )
+    assert full.disposition is AdmitDisposition.SATURATED
+    assert full.saturation is AdmitSaturationReason.GLOBAL_RECORD_LIMIT
+
+
+def test_max_record_one_repeatedly_compacts_one_settlement_before_admission(
+    tmp_path: Path,
+):
+    ledger = WebhookOperationLedger(
+        tmp_path / "state.db",
+        max_records=1,
+    )
+    for index in range(12):
+        assert ledger.has_global_admission_capacity()
+        admitted = ledger.admit(
+            _envelope(
+                f"record-edge-{index}",
+                trace_id=f"record-edge-trace-{index}",
+            )
+        )
+        assert admitted.disposition is AdmitDisposition.ACCEPTED
+        assert admitted.authority is not None
+        assert ledger.count() == 1
+        assert not ledger.has_global_admission_capacity()
+        assert ledger.settle_no_effect(admitted.authority)
+        assert ledger.has_global_admission_capacity()
+
+    final = ledger.admit(
+        _envelope("record-edge-final", trace_id="record-edge-final-trace")
+    )
+    assert final.disposition is AdmitDisposition.ACCEPTED
+    assert ledger.count() == 1
+    assert ledger.tombstone_count() == 12
+
+
+def test_pruning_is_bounded_and_an_expired_exact_identity_reopens(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    clock = {"now": 100.0}
+    monkeypatch.setattr(ledger_module.time, "time", lambda: clock["now"])
+    ledger = WebhookOperationLedger(
+        tmp_path / "state.db",
+        terminal_retention_seconds=1,
+        local_bypass_replay_retention_seconds=10,
+    )
+    for index in range(3):
+        admitted = ledger.admit(
+            _envelope(
+                f"expired-{index}",
+                trace_id=f"expired-{index}-trace",
+                route_name=f"expired-scope-{index}",
+                local_bypass=True,
+            )
+        )
+        assert admitted.authority is not None
+        assert ledger.settle_no_effect(admitted.authority)
+
+    clock["now"] = 102.0
+    monkeypatch.setattr(ledger_module, "_MAX_PRUNE_BATCH", 3)
+    assert ledger.prune() == 3
+    assert ledger.tombstone_count() == 3
+    clock["now"] = 111.0
+    monkeypatch.setattr(ledger_module, "_MAX_PRUNE_BATCH", 2)
+    assert ledger.prune() == 2
+    assert ledger.tombstone_count() == 1
+
+    reopened = ledger.admit(
+        _envelope(
+            "expired-2",
+            trace_id="expired-2-reopened",
+            route_name="expired-scope-2",
+            local_bypass=True,
+        )
+    )
+    assert reopened.disposition is AdmitDisposition.ACCEPTED
+    assert ledger.tombstone_count() == 0
+
+
+def test_remote_proof_with_expiry_is_rejected_as_corruption(tmp_path: Path):
+    db_path = tmp_path / "state.db"
+    ledger = WebhookOperationLedger(db_path, terminal_retention_seconds=1)
+    admitted = ledger.admit(_envelope("permanent", trace_id="permanent-trace"))
+    assert admitted.authority is not None
+    assert ledger.settle_no_effect(admitted.authority)
+    assert ledger.prune(now=ledger_module.time.time() + 10) == 1
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("PRAGMA ignore_check_constraints=ON")
+        conn.execute("UPDATE webhook_delivery_tombstones SET expires_at=20_000")
+
+    with pytest.raises(
+        WebhookLedgerCorruptionError,
+        match="tombstone expiry is invalid",
+    ):
+        WebhookOperationLedger(db_path)
+
+
+@pytest.mark.parametrize(
+    "invalid_limit",
+    [
+        MINIMUM_MAX_STORAGE_BYTES - 1,
+        MAXIMUM_MAX_STORAGE_BYTES + 1,
+        True,
+        float(MINIMUM_MAX_STORAGE_BYTES),
+        str(MINIMUM_MAX_STORAGE_BYTES),
+        None,
+    ],
+)
+def test_storage_limit_range_is_strict(tmp_path: Path, invalid_limit):
+    with pytest.raises(ValueError, match="supported storage range"):
+        WebhookOperationLedger(
+            tmp_path / f"invalid-{invalid_limit}.db",
+            max_storage_bytes=invalid_limit,
+        )

--- a/tests/gateway/test_webhook_lifecycle.py
+++ b/tests/gateway/test_webhook_lifecycle.py
@@ -1,0 +1,107 @@
+"""Public liveness/readiness contract for the sharded webhook adapter."""
+
+from __future__ import annotations
+
+import errno
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.config import PlatformConfig
+from gateway.platforms.webhook import WebhookAdapter
+
+
+def _adapter() -> WebhookAdapter:
+    return WebhookAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={
+                "host": "127.0.0.1",
+                "port": 0,
+                "routes": {
+                    "events": {
+                        "provider": "generic",
+                        "secret": "readiness-secret-must-not-leak",
+                    }
+                },
+            },
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_health_is_liveness_only_when_intake_is_fenced():
+    adapter = _adapter()
+    adapter._accepting_webhooks = False
+    adapter._operation_ledger.has_global_admission_capacity = MagicMock(
+        side_effect=AssertionError("liveness must not probe durable storage")
+    )
+    app = web.Application()
+    app.router.add_get("/health", adapter._handle_health)
+    async with TestClient(TestServer(app)) as client:
+        response = await client.get("/health")
+        assert response.status == 200
+        assert await response.json() == {
+            "status": "ok",
+            "platform": "webhook",
+        }
+
+
+@pytest.mark.asyncio
+async def test_ready_reports_fenced_intake_without_secret_or_route_policy():
+    adapter = _adapter()
+    adapter._accepting_webhooks = False
+    app = web.Application()
+    app.router.add_get("/ready", adapter._handle_ready)
+    async with TestClient(TestServer(app)) as client:
+        response = await client.get("/ready")
+        body = await response.text()
+    assert response.status == 503
+    assert "not_ready" in body
+    assert "readiness-secret-must-not-leak" not in body
+    assert "signature_mode" not in body
+
+
+@pytest.mark.asyncio
+async def test_ready_reports_only_bounded_operational_fields():
+    adapter = _adapter()
+    adapter._accepting_webhooks = True
+    adapter._bind_route_authentication_authorities(adapter._routes)
+    app = web.Application()
+    app.router.add_get("/ready", adapter._handle_ready)
+    async with TestClient(TestServer(app)) as client:
+        response = await client.get("/ready")
+        payload = await response.json()
+    assert response.status == 200
+    assert payload == {
+        "status": "ready",
+        "platform": "webhook",
+        "accepting_webhooks": True,
+        "host": "127.0.0.1",
+        "port": 0,
+        "routes": 1,
+    }
+
+
+@pytest.mark.asyncio
+async def test_port_conflict_is_fatal_and_nonretryable():
+    adapter = _adapter()
+    site = MagicMock()
+    site.start = AsyncMock(side_effect=OSError(errno.EADDRINUSE, "in use"))
+    with patch("gateway.platforms.webhook.web.TCPSite", return_value=site):
+        assert await adapter.connect() is False
+    assert adapter.fatal_error_code == "webhook_port_in_use"
+    assert adapter.fatal_error_retryable is False
+
+
+@pytest.mark.asyncio
+async def test_other_bind_failure_is_named_and_retryable():
+    adapter = _adapter()
+    site = MagicMock()
+    site.start = AsyncMock(side_effect=OSError(errno.EACCES, "denied"))
+    with patch("gateway.platforms.webhook.web.TCPSite", return_value=site):
+        assert await adapter.connect() is False
+    assert adapter.fatal_error_code == "webhook_bind_failed"
+    assert adapter.fatal_error_retryable is True

--- a/tests/gateway/test_webhook_limits.py
+++ b/tests/gateway/test_webhook_limits.py
@@ -1,0 +1,145 @@
+"""Fail-closed request and durable-carrier limits for webhook intake."""
+
+import hashlib
+import hmac
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.config import PlatformConfig
+from gateway.platforms.webhook import (
+    WebhookAdapter,
+    WebhookConfigurationError,
+    _MAX_BODY_BYTES_LIMIT,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_hermes_home(tmp_path, monkeypatch):
+    """Keep each test's durable ledger and key authority independent."""
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+
+def _adapter(*, max_body_bytes=_MAX_BODY_BYTES_LIMIT, routes=None, **extra):
+    return WebhookAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={
+                "host": "127.0.0.1",
+                "port": 0,
+                "max_body_bytes": max_body_bytes,
+                "routes": routes or {},
+                **extra,
+            },
+        )
+    )
+
+
+def _app(adapter):
+    app = web.Application(client_max_size=adapter._max_body_bytes)
+    app.router.add_get("/health", adapter._handle_health)
+    app.router.add_post("/webhooks/{route_name}", adapter._handle_webhook)
+    return app
+
+
+@pytest.mark.parametrize(
+    "configured",
+    [
+        True,
+        False,
+        1.0,
+        1.5,
+        _MAX_BODY_BYTES_LIMIT + 1,
+    ],
+)
+def test_max_body_bytes_rejects_non_integer_or_unsafe_configuration(configured):
+    with pytest.raises(WebhookConfigurationError, match="max_body_bytes"):
+        _adapter(max_body_bytes=configured)
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["rate_limit", "script_timeout_seconds"],
+)
+@pytest.mark.parametrize(
+    "configured",
+    [True, False, None, 0, -1, 1.5, "1.5"],
+)
+def test_execution_limits_reject_non_positive_or_non_integer_configuration(
+    field,
+    configured,
+):
+    with pytest.raises(WebhookConfigurationError, match=field):
+        _adapter(**{field: configured})
+
+
+@pytest.mark.parametrize(
+    ("field", "configured"),
+    [
+        ("port", -1),
+        ("port", 65_536),
+        ("rate_limit", 10_001),
+        ("script_timeout_seconds", 301),
+    ],
+)
+def test_execution_limits_reject_values_above_their_safe_bounds(
+    field,
+    configured,
+):
+    with pytest.raises(WebhookConfigurationError, match=field):
+        _adapter(**{field: configured})
+
+
+@pytest.mark.asyncio
+async def test_signed_template_expansion_is_rejected_before_effect_and_recovers():
+    secret = "carrier-limit-secret"
+    adapter = _adapter(
+        routes={
+            "events": {
+                "provider": "generic",
+                "signature_mode": "generic_v1",
+                "secret": secret,
+                "prompt": "{data}{data}",
+            }
+        }
+    )
+    adapter.handle_message = AsyncMock()
+
+    def signed(payload):
+        body = json.dumps(payload, separators=(",", ":")).encode()
+        signature = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+        return body, {
+            "Content-Type": "application/json",
+            "X-Webhook-Signature": signature,
+        }
+
+    oversized_body, oversized_headers = signed({"data": "x" * (300 * 1024)})
+    small_body, small_headers = signed({"data": "ok"})
+
+    async with TestClient(TestServer(_app(adapter))) as client:
+        rejected = await client.post(
+            "/webhooks/events",
+            data=oversized_body,
+            headers=oversized_headers,
+        )
+        rejected_payload = await rejected.json()
+        assert adapter._operation_ledger.count() == 0
+        healthy = await client.get("/health")
+        accepted = await client.post(
+            "/webhooks/events",
+            data=small_body,
+            headers=small_headers,
+        )
+
+    assert rejected.status == 413
+    assert rejected_payload == {
+        "error": "Payload expands beyond durable webhook limits"
+    }
+    assert healthy.status == 200
+    assert accepted.status == 202
+    assert adapter._operation_ledger.count() == 1
+    adapter.handle_message.assert_awaited_once()

--- a/tests/gateway/test_webhook_profile_authority_integration.py
+++ b/tests/gateway/test_webhook_profile_authority_integration.py
@@ -1,0 +1,781 @@
+"""Adversarial integration tests for durable webhook profile authority."""
+
+import asyncio
+import base64
+import hashlib
+import hmac
+import time
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from multidict import CIMultiDict
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import SendResult
+from gateway.platforms.webhook import (
+    WebhookAdapter,
+    WebhookTargetDeliveryDisposition,
+    _PROFILE_AUTHORITY_INCARNATION_FILENAME,
+)
+from gateway.platforms.webhook_auth import WebhookLocalBypassReceipt
+from gateway.platforms.webhook_contract import WebhookEnvelope, WebhookRouteConfig
+from gateway.platforms.webhook_ledger import (
+    OperationState,
+    TargetState,
+    WebhookLedgerError,
+    WebhookLedgerTransitionError,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_ledger_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+
+def _adapter() -> WebhookAdapter:
+    return WebhookAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={
+                "host": "127.0.0.1",
+                "port": 0,
+                "routes": {},
+                "idempotency_max_entries": 8,
+            },
+        )
+    )
+
+
+def _grant_snapshot(adapter: WebhookAdapter, envelope: WebhookEnvelope) -> dict:
+    try:
+        profile_generation = adapter._current_profile_authority_generation(
+            envelope.authority_profile,
+            route_name=envelope.route.name,
+        )
+    except Exception:
+        # Removed-profile tests construct the carrier after modeling removal;
+        # this stands in for the non-empty incarnation captured beforehand.
+        profile_generation = "test-prior-profile-incarnation"
+    return {
+        "v": 1,
+        "toolsets": [],
+        "profile_generation": profile_generation,
+    }
+
+
+def _stage_delivery(
+    adapter: WebhookAdapter,
+    *,
+    profile: str,
+    target: dict,
+    suffix: str,
+    relinquish: bool = False,
+):
+    raw_body = f'{{"delivery":"{suffix}"}}'.encode()
+    route = WebhookRouteConfig.bind(
+        f"profile-{suffix}",
+        {"provider": "generic", "profile": profile},
+        headers={},
+        request_profile=profile,
+    )
+    envelope = WebhookEnvelope.from_receipt(
+        WebhookLocalBypassReceipt._issue(route, raw_body, {}),
+        raw_body=raw_body,
+        media_type="application/json",
+        trace_id=f"trace-{suffix}",
+    )
+    admitted = adapter._operation_ledger.admit(envelope)
+    assert admitted.authority is not None
+    source = adapter._source_for_envelope(envelope)
+    prepared = adapter._operation_ledger.prepare(
+        admitted.authority,
+        event_snapshot={
+            "v": 1,
+            "mode": "direct",
+            "text": f"durable output {suffix}",
+            "payload": {"delivery": suffix},
+            "message_id": envelope.delivery_id,
+            "source": source.to_dict(),
+        },
+        target_snapshot=target,
+        grant_snapshot=_grant_snapshot(adapter, envelope),
+    )
+    assert adapter._operation_ledger.mark_running(prepared)
+    staged = adapter._stage_exact_delivery(
+        prepared,
+        f"durable output {suffix}",
+        {"v": 1, "kind": "direct"},
+    )
+    assert staged.state is OperationState.DELIVERY_READY
+    if relinquish:
+        assert adapter._operation_ledger.relinquish_recovery_claim(staged)
+    return staged
+
+
+def test_root_ledger_isolates_same_provider_delivery_id_by_physical_profile(
+    tmp_path,
+    monkeypatch,
+):
+    root = tmp_path / "shared-root"
+    alpha_home = root / "profiles" / "alpha"
+    beta_home = root / "profiles" / "beta"
+    alpha_home.mkdir(parents=True)
+    beta_home.mkdir(parents=True)
+    message_id = "same-provider-delivery"
+    timestamp = str(int(time.time()))
+
+    def build(profile: str, secret: str, body: bytes):
+        monkeypatch.setenv(
+            "HERMES_HOME",
+            str(root / "profiles" / profile),
+        )
+        adapter = WebhookAdapter(
+            PlatformConfig(
+                enabled=True,
+                extra={
+                    "host": "127.0.0.1",
+                    "port": 0,
+                    "routes": {
+                        "shared": {
+                            "provider": "standard_webhooks",
+                            "secret": secret,
+                        }
+                    },
+                },
+            )
+        )
+        adapter._bind_route_authentication_authorities(adapter._routes)
+        signed = f"{message_id}.{timestamp}.".encode() + body
+        signature = (
+            "v1,"
+            + base64.b64encode(
+                hmac.new(secret.encode(), signed, hashlib.sha256).digest()
+            ).decode()
+        )
+        headers = CIMultiDict({
+            "Content-Type": "application/json",
+            "webhook-id": message_id,
+            "webhook-timestamp": timestamp,
+            "webhook-signature": signature,
+        })
+        bound = WebhookRouteConfig.bind(
+            "shared",
+            adapter._routes["shared"],
+            headers=headers,
+            request_profile="default",
+        )
+        receipt = adapter._verify_signature_receipt(
+            SimpleNamespace(
+                headers=headers,
+                match_info={"route_name": "shared"},
+            ),
+            body,
+            secret,
+            bound,
+        )
+        assert receipt is not None
+        envelope = WebhookEnvelope.from_receipt(
+            receipt,
+            raw_body=body,
+            media_type="application/json",
+            authority_profile=str(
+                adapter._authenticated_route_bundles["shared"].authority[0]
+            ),
+        )
+        return adapter, envelope
+
+    alpha, alpha_envelope = build("alpha", "alpha-secret", b'{"owner":"alpha"}')
+    alpha_admission = alpha._operation_ledger.admit(alpha_envelope)
+    assert alpha_admission.authority is not None
+    beta, beta_envelope = build("beta", "beta-secret", b'{"owner":"beta"}')
+    beta_admission = beta._operation_ledger.admit(beta_envelope)
+    assert beta_admission.authority is not None
+
+    assert alpha_envelope.replay_id == beta_envelope.replay_id
+    assert alpha_envelope.authority_profile == "alpha"
+    assert beta_envelope.authority_profile == "beta"
+    assert (
+        alpha_admission.authority.operation_id != beta_admission.authority.operation_id
+    )
+    assert beta._operation_ledger.count() == 2
+    assert alpha._operation_ledger.settle_no_effect(
+        alpha_admission.authority,
+        "alpha complete",
+    )
+    assert beta._operation_ledger.settle_no_effect(
+        beta_admission.authority,
+        "beta complete",
+    )
+    assert alpha._operation_ledger.admit(alpha_envelope).authority.state is (
+        OperationState.SETTLED
+    )
+    assert beta._operation_ledger.admit(beta_envelope).authority.state is (
+        OperationState.SETTLED
+    )
+
+
+@pytest.mark.asyncio
+async def test_single_profile_recovery_switchback_claims_only_exact_physical_profile(
+    tmp_path,
+    monkeypatch,
+):
+    """A shared root never lets the active named profile borrow peer work."""
+
+    root = tmp_path / "shared-root"
+    alpha_home = root / "profiles" / "alpha"
+    beta_home = root / "profiles" / "beta"
+    alpha_home.mkdir(parents=True)
+    beta_home.mkdir(parents=True)
+
+    monkeypatch.setenv("HERMES_HOME", str(alpha_home))
+    alpha_predecessor = _adapter()
+    staged = _stage_delivery(
+        alpha_predecessor,
+        profile="alpha",
+        target={"v": 1, "kind": "log", "profile": "alpha"},
+        suffix="alpha-switchback",
+        relinquish=True,
+    )
+    initial = alpha_predecessor._operation_ledger.lookup_session(staged.session_key)
+    assert initial is not None
+    assert initial.state is OperationState.DELIVERY_READY
+    initial_owner = initial.owner_instance
+    initial_generation = initial.generation
+
+    monkeypatch.setenv("HERMES_HOME", str(beta_home))
+    beta = _adapter()
+    assert beta._operation_ledger.db_path == root / "state.db"
+    beta_invoke = AsyncMock(wraps=beta._invoke_staged_target)
+    monkeypatch.setattr(beta, "_invoke_staged_target", beta_invoke)
+
+    assert await beta.recover_pending_operations(trigger="beta-active") == 0
+    await asyncio.sleep(0)
+
+    untouched = beta._operation_ledger.lookup_session(staged.session_key)
+    assert untouched is not None
+    assert untouched.state is OperationState.DELIVERY_READY
+    assert untouched.owner_instance == initial_owner
+    assert untouched.generation == initial_generation
+    assert tuple(beta._background_tasks) == ()
+    beta_invoke.assert_not_awaited()
+
+    monkeypatch.setenv("HERMES_HOME", str(alpha_home))
+    alpha = _adapter()
+    assert alpha._operation_ledger.db_path == beta._operation_ledger.db_path
+    alpha_invoke = AsyncMock(wraps=alpha._invoke_staged_target)
+    monkeypatch.setattr(alpha, "_invoke_staged_target", alpha_invoke)
+
+    assert await alpha.recover_pending_operations(trigger="alpha-restored") == 1
+    pending = tuple(alpha._background_tasks)
+    if pending:
+        await asyncio.gather(*pending)
+    await asyncio.sleep(0)
+
+    settled = alpha._operation_ledger.lookup_session(staged.session_key)
+    assert settled is not None
+    assert settled.state is OperationState.SETTLED
+    assert settled.target_state is TargetState.SUPPRESSED
+    assert settled.generation == initial_generation + 1
+    alpha_invoke.assert_awaited_once()
+
+    assert await alpha.recover_pending_operations(trigger="alpha-repeat") == 0
+    await asyncio.sleep(0)
+    alpha_invoke.assert_awaited_once()
+    repeated = alpha._operation_ledger.lookup_session(staged.session_key)
+    assert repeated is not None
+    assert repeated.state is OperationState.SETTLED
+    assert repeated.generation == initial_generation + 1
+
+
+@pytest.mark.asyncio
+async def test_default_target_does_not_borrow_active_named_profile_adapter():
+    """Persisted ``default`` authority must select its exact adapter registry."""
+
+    from gateway.run import GatewayRunner
+
+    adapter = _adapter()
+    named_adapter = SimpleNamespace(
+        send=AsyncMock(return_value=SendResult(success=True, message_id="wrong"))
+    )
+    default_adapter = SimpleNamespace(
+        send=AsyncMock(return_value=SendResult(success=True, message_id="right"))
+    )
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(multiplex_profiles=True)
+    runner._active_profile_name = lambda: "dev"
+    runner.adapters = {
+        Platform.WEBHOOK: adapter,
+        Platform.TELEGRAM: named_adapter,
+    }
+    runner._profile_adapters = {
+        "default": {Platform.TELEGRAM: default_adapter},
+    }
+    adapter.gateway_runner = runner
+
+    staged = _stage_delivery(
+        adapter,
+        profile="default",
+        target={
+            "v": 1,
+            "kind": "platform",
+            "profile": "default",
+            "platform": "telegram",
+            "chat_id": "default-chat",
+        },
+        suffix="default-egress",
+    )
+
+    result = await adapter._invoke_staged_target(staged)
+
+    assert result.success is True
+    default_adapter.send.assert_awaited_once_with(
+        "default-chat",
+        "durable output default-egress",
+        metadata=None,
+    )
+    named_adapter.send.assert_not_awaited()
+    restored = adapter._operation_ledger.lookup_session(staged.session_key)
+    assert restored is not None
+    assert restored.state is OperationState.SETTLED
+    assert restored.target_state is TargetState.CONFIRMED
+
+
+@pytest.mark.asyncio
+async def test_failed_post_effect_settlement_invokes_target_once_and_fences_intake(
+    monkeypatch,
+):
+    """A failed confirmed-write becomes one durable unknown, never a retry."""
+
+    from gateway.run import GatewayRunner
+
+    adapter = _adapter()
+    target_adapter = SimpleNamespace(
+        send=AsyncMock(return_value=SendResult(success=True, message_id="sent-once"))
+    )
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(multiplex_profiles=False)
+    runner._active_profile_name = lambda: "default"
+    runner.adapters = {
+        Platform.WEBHOOK: adapter,
+        Platform.TELEGRAM: target_adapter,
+    }
+    runner._profile_adapters = {}
+    adapter.gateway_runner = runner
+    staged = _stage_delivery(
+        adapter,
+        profile="default",
+        target={
+            "v": 1,
+            "kind": "platform",
+            "profile": "default",
+            "platform": "telegram",
+            "chat_id": "target-chat",
+        },
+        suffix="settlement-write-failure",
+    )
+
+    real_settle = adapter._operation_ledger.settle_target
+    calls = {"count": 0}
+
+    def fail_first_settlement(attempt, settlement):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            raise WebhookLedgerError("injected post-effect settlement failure")
+        return real_settle(attempt, settlement)
+
+    monkeypatch.setattr(
+        adapter._operation_ledger,
+        "settle_target",
+        fail_first_settlement,
+    )
+    result = await adapter._invoke_staged_target(staged)
+
+    assert result.disposition is WebhookTargetDeliveryDisposition.INDETERMINATE
+    target_adapter.send.assert_awaited_once()
+    assert calls["count"] == 2
+    assert adapter._accepting_webhooks is False
+    restored = adapter._operation_ledger.lookup_session(staged.session_key)
+    assert restored is not None
+    assert restored.state is OperationState.INDETERMINATE
+    assert restored.target_state is TargetState.INDETERMINATE
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("carrier", ["platform", "github_comment"])
+async def test_removed_profile_recovery_never_borrows_live_authority(
+    carrier, monkeypatch
+):
+    """A removed durable profile is rejected before any recovered effect."""
+
+    from agent import secret_scope
+    from gateway.run import GatewayRunner
+    from gateway.platforms import webhook_route_authority
+
+    adapter = _adapter()
+    primary_adapter = SimpleNamespace(
+        send=AsyncMock(return_value=SendResult(success=True, message_id="primary"))
+    )
+    retired_adapter = SimpleNamespace(
+        send=AsyncMock(return_value=SendResult(success=True, message_id="retired"))
+    )
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(multiplex_profiles=True)
+    runner._active_profile_name = lambda: "dev"
+    runner.adapters = {
+        Platform.WEBHOOK: adapter,
+        Platform.TELEGRAM: primary_adapter,
+    }
+    # Model a removal race where the live registry has not yet discarded its
+    # old adapter. The real profile resolver must remain the final authority.
+    runner._profile_adapters = {
+        "retired": {Platform.TELEGRAM: retired_adapter},
+    }
+    adapter.gateway_runner = runner
+
+    token_lookup = MagicMock(
+        side_effect=AssertionError("removed profile borrowed a live token")
+    )
+    monkeypatch.setattr(secret_scope, "get_secret", token_lookup)
+    executable_lookup = MagicMock(
+        side_effect=AssertionError("removed profile resolved an external carrier")
+    )
+    monkeypatch.setattr(
+        webhook_route_authority.shutil,
+        "which",
+        executable_lookup,
+    )
+    external_carrier = MagicMock(
+        side_effect=AssertionError("removed profile invoked an external carrier")
+    )
+    monkeypatch.setattr(adapter, "_run_github_comment", external_carrier)
+
+    if carrier == "platform":
+        target = {
+            "v": 1,
+            "kind": "platform",
+            "profile": "retired",
+            "platform": "telegram",
+            "chat_id": "retired-chat",
+        }
+    else:
+        target = {
+            "v": 1,
+            "kind": "github_comment",
+            "profile": "retired",
+            "repo": "owner/repo",
+            "pr_number": 7,
+        }
+    staged = _stage_delivery(
+        adapter,
+        profile="retired",
+        target=target,
+        suffix=f"removed-{carrier}",
+        relinquish=True,
+    )
+
+    assert await adapter.recover_pending_operations(trigger="profile-removal") == 0
+    pending = tuple(adapter._background_tasks)
+    assert pending == ()
+
+    restored = adapter._operation_ledger.lookup_session(staged.session_key)
+    assert restored is not None
+    assert restored.state is OperationState.DELIVERY_READY
+    assert restored.owner_instance != adapter._operation_ledger.instance_id
+    primary_adapter.send.assert_not_awaited()
+    retired_adapter.send.assert_not_awaited()
+    token_lookup.assert_not_called()
+    executable_lookup.assert_not_called()
+    external_carrier.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_existing_but_unserved_profile_cannot_recover_agent_work(
+    tmp_path, monkeypatch
+):
+    """Allowlist revocation wins even while the profile directory remains."""
+
+    from gateway.run import GatewayRunner
+
+    adapter = _adapter()
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        multiplex_profiles=True,
+        multiplex_profile_allowlist=["dev"],
+    )
+    runner.adapters = {Platform.WEBHOOK: adapter}
+    runner._profile_adapters = {}
+    adapter.gateway_runner = runner
+    adapter.handle_message = AsyncMock(
+        side_effect=AssertionError("revoked profile reached agent dispatch")
+    )
+
+    ops_home = tmp_path / "profiles" / "ops"
+    ops_home.mkdir(parents=True)
+    monkeypatch.setattr(
+        "hermes_cli.profiles.profile_exists",
+        lambda name: name == "ops",
+    )
+    monkeypatch.setattr(
+        "hermes_cli.profiles.get_profile_dir",
+        lambda name: ops_home if name == "ops" else tmp_path / name,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.profiles.profiles_to_serve",
+        lambda **_kwargs: [("dev", tmp_path / "profiles" / "dev")],
+    )
+
+    raw_body = b'{"event":"revoked"}'
+    route = WebhookRouteConfig.bind(
+        "revoked-agent",
+        {"provider": "generic", "profile": "ops"},
+        headers={},
+        request_profile="ops",
+    )
+    envelope = WebhookEnvelope.from_receipt(
+        WebhookLocalBypassReceipt._issue(route, raw_body, {}),
+        raw_body=raw_body,
+        media_type="application/json",
+        trace_id="revoked-agent-trace",
+    )
+    admitted = adapter._operation_ledger.admit(envelope)
+    assert admitted.authority is not None
+    source = adapter._source_for_envelope(envelope)
+    prepared = adapter._operation_ledger.prepare(
+        admitted.authority,
+        event_snapshot={
+            "v": 1,
+            "mode": "agent",
+            "text": "do not run",
+            "payload": {"event": "revoked"},
+            "message_id": envelope.delivery_id,
+            "source": source.to_dict(),
+        },
+        target_snapshot={"v": 1, "kind": "log", "profile": "ops"},
+        grant_snapshot=_grant_snapshot(adapter, envelope),
+    )
+    assert adapter._operation_ledger.relinquish_recovery_claim(prepared)
+
+    assert await adapter.recover_pending_operations(trigger="allowlist-revocation") == 0
+    pending = tuple(adapter._background_tasks)
+    assert pending == ()
+
+    restored = adapter._operation_ledger.lookup_session(envelope.session_key)
+    assert restored is not None
+    assert restored.state is OperationState.READY
+    assert restored.owner_instance != adapter._operation_ledger.instance_id
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_recreated_same_name_profile_cannot_execute_prior_incarnation(
+    tmp_path,
+    monkeypatch,
+):
+    """A new physical profile incarnation never inherits old replay-safe work."""
+
+    profile_home = tmp_path / "profiles" / "ops"
+    profile_home.mkdir(parents=True)
+    runner = SimpleNamespace(
+        config=GatewayConfig(
+            multiplex_profiles=True,
+            multiplex_profile_allowlist=["ops"],
+        ),
+        adapters={},
+        _profile_adapters={},
+        _resolve_profile_home_for_source=lambda source: (
+            profile_home if source.profile == "ops" else tmp_path
+        ),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.profiles.profiles_to_serve",
+        lambda **_kwargs: [("default", tmp_path), ("ops", profile_home)],
+    )
+
+    prior = _adapter()
+    prior.gateway_runner = runner
+    raw_body = b'{"event":"prior-incarnation"}'
+    route = WebhookRouteConfig.bind(
+        "incarnation",
+        {"provider": "generic", "profile": "ops"},
+        headers={},
+        request_profile="ops",
+    )
+    envelope = WebhookEnvelope.from_receipt(
+        WebhookLocalBypassReceipt._issue(route, raw_body, {}),
+        raw_body=raw_body,
+        media_type="application/json",
+        trace_id="prior-incarnation",
+        authority_profile="ops",
+    )
+    admitted = prior._operation_ledger.admit(envelope)
+    assert admitted.authority is not None
+    authority = prior._operation_ledger.prepare(
+        admitted.authority,
+        event_snapshot={
+            "v": 1,
+            "mode": "direct",
+            "text": "must not run",
+            "payload": {"event": "prior-incarnation"},
+            "message_id": envelope.delivery_id,
+            "source": prior._source_for_envelope(envelope).to_dict(),
+        },
+        target_snapshot={"v": 1, "kind": "log", "profile": "ops"},
+        grant_snapshot=_grant_snapshot(prior, envelope),
+    )
+    assert prior._operation_ledger.relinquish_recovery_claim(authority)
+
+    token_path = profile_home / _PROFILE_AUTHORITY_INCARNATION_FILENAME
+    token_path.unlink()
+
+    replacement = _adapter()
+    replacement.gateway_runner = runner
+    runner.adapters[Platform.WEBHOOK] = replacement
+    assert (
+        await replacement.recover_pending_operations(trigger="same-name-recreated") == 0
+    )
+    assert tuple(replacement._background_tasks) == ()
+
+    restored = replacement._operation_ledger.lookup_session(envelope.session_key)
+    assert restored is not None
+    assert restored.state is OperationState.INDETERMINATE
+
+
+@pytest.mark.asyncio
+async def test_profile_generation_is_rechecked_at_agent_running_gate(tmp_path):
+    profile_home = tmp_path / "profiles" / "ops"
+    profile_home.mkdir(parents=True)
+    runner = SimpleNamespace(
+        config=GatewayConfig(multiplex_profiles=True),
+        _resolve_profile_home_for_source=lambda source: (
+            profile_home if source.profile == "ops" else tmp_path
+        ),
+    )
+    adapter = _adapter()
+    adapter.gateway_runner = runner
+    raw_body = b'{"event":"agent-gate"}'
+    route = WebhookRouteConfig.bind(
+        "agent-gate",
+        {"provider": "generic", "profile": "ops"},
+        headers={},
+        request_profile="ops",
+    )
+    envelope = WebhookEnvelope.from_receipt(
+        WebhookLocalBypassReceipt._issue(route, raw_body, {}),
+        raw_body=raw_body,
+        media_type="application/json",
+        trace_id="agent-gate",
+        authority_profile="ops",
+    )
+    admitted = adapter._operation_ledger.admit(envelope)
+    assert admitted.authority is not None
+    prepared = adapter._operation_ledger.prepare(
+        admitted.authority,
+        event_snapshot={
+            "v": 1,
+            "mode": "agent",
+            "text": "must not run",
+            "payload": {"event": "agent-gate"},
+            "message_id": envelope.delivery_id,
+            "source": adapter._source_for_envelope(envelope).to_dict(),
+        },
+        target_snapshot={"v": 1, "kind": "log", "profile": "ops"},
+        grant_snapshot=_grant_snapshot(adapter, envelope),
+    )
+    (profile_home / _PROFILE_AUTHORITY_INCARNATION_FILENAME).unlink()
+
+    with pytest.raises(
+        WebhookLedgerTransitionError,
+        match="profile authority changed",
+    ):
+        await adapter.on_processing_start(SimpleNamespace(webhook_authority=prepared))
+
+    restored = adapter._operation_ledger.lookup_session(prepared.session_key)
+    assert restored is not None
+    assert restored.state is OperationState.INDETERMINATE
+
+
+@pytest.mark.asyncio
+async def test_profile_generation_is_rechecked_at_recovered_direct_running_gate(
+    tmp_path,
+    monkeypatch,
+):
+    adapter = _adapter()
+    raw_body = b'{"event":"recovered-direct-gate"}'
+    route = WebhookRouteConfig.bind(
+        "recovered-direct-gate",
+        {"provider": "generic"},
+        headers={},
+        request_profile="default",
+    )
+    envelope = WebhookEnvelope.from_receipt(
+        WebhookLocalBypassReceipt._issue(route, raw_body, {}),
+        raw_body=raw_body,
+        media_type="application/json",
+        trace_id="recovered-direct-gate",
+    )
+    admitted = adapter._operation_ledger.admit(envelope)
+    assert admitted.authority is not None
+    prepared = adapter._operation_ledger.prepare(
+        admitted.authority,
+        event_snapshot={
+            "v": 1,
+            "mode": "direct",
+            "text": "must not deliver",
+            "payload": {"event": "recovered-direct-gate"},
+            "message_id": envelope.delivery_id,
+            "source": adapter._source_for_envelope(envelope).to_dict(),
+        },
+        target_snapshot={"v": 1, "kind": "log", "profile": "default"},
+        grant_snapshot=_grant_snapshot(adapter, envelope),
+    )
+    mark_running = MagicMock(wraps=adapter._operation_ledger.mark_running)
+    monkeypatch.setattr(adapter._operation_ledger, "mark_running", mark_running)
+    (tmp_path / _PROFILE_AUTHORITY_INCARNATION_FILENAME).unlink()
+
+    await adapter._recover_event_ready(prepared)
+
+    restored = adapter._operation_ledger.lookup_session(prepared.session_key)
+    assert restored is not None
+    assert restored.state is OperationState.INDETERMINATE
+    mark_running.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_profile_generation_is_rechecked_at_target_attempt_gate(tmp_path):
+    profile_home = tmp_path / "profiles" / "ops"
+    profile_home.mkdir(parents=True)
+    target_adapter = SimpleNamespace(
+        send=AsyncMock(return_value=SendResult(success=True, message_id="wrong"))
+    )
+    runner = SimpleNamespace(
+        config=GatewayConfig(multiplex_profiles=True),
+        adapters={},
+        _profile_adapters={"ops": {Platform.TELEGRAM: target_adapter}},
+        _resolve_profile_home_for_source=lambda source: (
+            profile_home if source.profile == "ops" else tmp_path
+        ),
+    )
+    adapter = _adapter()
+    adapter.gateway_runner = runner
+    staged = _stage_delivery(
+        adapter,
+        profile="ops",
+        target={
+            "v": 1,
+            "kind": "platform",
+            "profile": "ops",
+            "platform": "telegram",
+            "chat_id": "must-not-send",
+        },
+        suffix="target-generation-gate",
+    )
+    (profile_home / _PROFILE_AUTHORITY_INCARNATION_FILENAME).unlink()
+
+    result = await adapter._invoke_staged_target(staged)
+
+    assert result.disposition is WebhookTargetDeliveryDisposition.INDETERMINATE
+    target_adapter.send.assert_not_awaited()
+    restored = adapter._operation_ledger.lookup_session(staged.session_key)
+    assert restored is not None
+    assert restored.state is OperationState.INDETERMINATE

--- a/tests/gateway/test_webhook_provider_expansion.py
+++ b/tests/gateway/test_webhook_provider_expansion.py
@@ -1,0 +1,301 @@
+"""Explicit native-provider verifier coverage for the consolidated adapter."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import time
+
+import pytest
+from aiohttp.test_utils import make_mocked_request
+
+from gateway.config import PlatformConfig
+from gateway.platforms.webhook import WebhookAdapter
+from gateway.platforms.webhook_auth import WebhookVerificationCoverage
+from gateway.platforms.webhook_contract import WebhookRouteConfig
+from gateway.platforms.webhook_contract import resolve_event_type
+
+
+def _adapter() -> WebhookAdapter:
+    return WebhookAdapter(PlatformConfig(enabled=True, extra={"routes": {}}))
+
+
+def _route(provider: str, **extra) -> WebhookRouteConfig:
+    return WebhookRouteConfig.bind(
+        "events",
+        {"provider": provider, **extra},
+        headers={},
+        request_profile="default",
+    )
+
+
+def _request(headers: dict[str, str]):
+    return make_mocked_request(
+        "POST",
+        "/webhooks/events",
+        headers=headers,
+        match_info={"route_name": "events"},
+    )
+
+
+def _hex(secret: str, body: bytes, prefix: str = "") -> str:
+    return prefix + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+
+
+@pytest.mark.parametrize(
+    ("provider", "header", "prefix"),
+    [
+        ("sentry", "sentry-hook-signature", ""),
+        ("juniper_mist", "X-Mist-Signature-v2", ""),
+        ("fireflies", "X-Hub-Signature", "sha256="),
+        ("redmine", "X-Redmine-Signature-256", "sha256="),
+        ("gitea", "X-Gitea-Signature", ""),
+        ("forgejo", "X-Forgejo-Signature", ""),
+        ("asana", "X-Hook-Signature", ""),
+        ("attio", "Attio-Signature", ""),
+        ("notion", "X-Notion-Signature", "sha256="),
+        ("exit1", "X-Exit1-Signature", "sha256="),
+        ("jira", "X-Hub-Signature", "sha256="),
+    ],
+)
+def test_native_hex_body_modes_are_explicit_and_body_bound(
+    provider: str,
+    header: str,
+    prefix: str,
+):
+    adapter = _adapter()
+    body = b'{"type":"created","id":"evt_1"}'
+    secret = f"{provider}-secret"
+    route = _route(provider)
+    receipt = adapter._verify_signature_receipt(
+        _request({header: _hex(secret, body, prefix)}),
+        body,
+        secret,
+        route,
+    )
+    assert receipt is not None
+    assert receipt.coverage is WebhookVerificationCoverage.BODY_MAC
+    assert (
+        adapter._verify_signature_receipt(
+            _request({header: _hex(secret, body, prefix)}),
+            body + b" ",
+            secret,
+            route,
+        )
+        is None
+    )
+
+
+def test_todoist_base64_signature_is_body_bound():
+    adapter = _adapter()
+    body = b'{"event_name":"item:added"}'
+    secret = "todoist-secret"
+    signature = base64.b64encode(
+        hmac.new(secret.encode(), body, hashlib.sha256).digest()
+    ).decode("ascii")
+    receipt = adapter._verify_signature_receipt(
+        _request({"X-Todoist-Hmac-SHA256": signature}),
+        body,
+        secret,
+        _route("todoist"),
+    )
+    assert receipt is not None
+    assert receipt.coverage is WebhookVerificationCoverage.BODY_MAC
+
+
+def test_pocket_signature_binds_millisecond_timestamp_and_body():
+    adapter = _adapter()
+    body = b'{"event":"recording.ready"}'
+    secret = "pocket-secret"
+    timestamp = str(int(time.time() * 1000))
+    signature = hmac.new(
+        secret.encode(),
+        timestamp.encode() + b"." + body,
+        hashlib.sha256,
+    ).hexdigest()
+    route = _route("pocket")
+    receipt = adapter._verify_signature_receipt(
+        _request({
+            "X-HeyPocket-Signature": signature,
+            "X-HeyPocket-Timestamp": timestamp,
+        }),
+        body,
+        secret,
+        route,
+    )
+    assert receipt is not None
+    assert receipt.coverage is WebhookVerificationCoverage.TIMESTAMP_BODY_MAC
+    stale = str(int((time.time() - 301) * 1000))
+    stale_signature = hmac.new(
+        secret.encode(),
+        stale.encode() + b"." + body,
+        hashlib.sha256,
+    ).hexdigest()
+    assert (
+        adapter._verify_signature_receipt(
+            _request({
+                "X-HeyPocket-Signature": stale_signature,
+                "X-HeyPocket-Timestamp": stale,
+            }),
+            body,
+            secret,
+            route,
+        )
+        is None
+    )
+
+
+def test_linear_requires_fresh_signed_payload_timestamp():
+    adapter = _adapter()
+    secret = "linear-secret"
+    timestamp = int(time.time() * 1000)
+    body = json.dumps({"webhookTimestamp": timestamp, "type": "Issue"}).encode()
+    signature = _hex(secret, body)
+    route = _route("linear")
+    receipt = adapter._verify_signature_receipt(
+        _request({
+            "Linear-Signature": signature,
+            "Linear-Timestamp": str(timestamp),
+            "Linear-Delivery": "observed-not-signed",
+        }),
+        body,
+        secret,
+        route,
+    )
+    assert receipt is not None
+    assert receipt.coverage is WebhookVerificationCoverage.TIMESTAMP_BODY_MAC
+    assert receipt.verified_headers == {}
+    assert receipt.observed_headers == {
+        "Linear-Delivery": "observed-not-signed",
+    }
+
+    stale_body = json.dumps({
+        "webhookTimestamp": int((time.time() - 61) * 1000),
+        "type": "Issue",
+    }).encode()
+    assert (
+        adapter._verify_signature_receipt(
+            _request({"Linear-Signature": _hex(secret, stale_body)}),
+            stale_body,
+            secret,
+            route,
+        )
+        is None
+    )
+
+
+@pytest.mark.parametrize(
+    ("provider", "headers"),
+    [
+        ("plain_token", {"X-Webhook-Secret": "shared-secret"}),
+        ("bearer_token", {"Authorization": "Bearer shared-secret"}),
+    ],
+)
+def test_plain_tokens_use_explicit_credential_only_transports(provider, headers):
+    adapter = _adapter()
+    route = _route(provider)
+    receipt = adapter._verify_signature_receipt(
+        _request(headers),
+        b'{"untrusted":"body"}',
+        "shared-secret",
+        route,
+    )
+    assert receipt is not None
+    assert receipt.coverage is WebhookVerificationCoverage.CREDENTIAL_ONLY
+    assert (
+        adapter._verify_signature_receipt(
+            _request(headers),
+            b"{}",
+            "different-secret",
+            route,
+        )
+        is None
+    )
+
+
+def test_token_transports_and_attio_header_variants_never_fall_through():
+    adapter = _adapter()
+    body = b"{}"
+    secret = "shared-secret"
+    assert (
+        adapter._verify_signature_receipt(
+            _request({"Authorization": f"Bearer {secret}"}),
+            body,
+            secret,
+            _route("plain_token"),
+        )
+        is None
+    )
+
+    x_signature = _hex(secret, body)
+    assert (
+        adapter._verify_signature_receipt(
+            _request({
+                "Attio-Signature": "bad",
+                "X-Attio-Signature": x_signature,
+            }),
+            body,
+            secret,
+            _route("attio"),
+        )
+        is None
+    )
+    assert (
+        adapter._verify_signature_receipt(
+            _request({"X-Attio-Signature": x_signature}),
+            body,
+            secret,
+            _route("attio", signature_mode="attio_x"),
+        )
+        is not None
+    )
+
+
+def test_fireflies_event_authority_comes_from_signed_body_not_header():
+    route = _route("fireflies")
+    assert (
+        resolve_event_type(
+            route,
+            {},
+            {"event": "meeting.transcribed"},
+            observed_headers={"X-Untrusted-Event": "forged"},
+        )
+        == "meeting.transcribed"
+    )
+
+
+def test_trello_signature_binds_exact_registered_callback_url():
+    adapter = _adapter()
+    body = b'{"action":{"id":"a1","type":"commentCard"}}'
+    secret = "trello-secret"
+    callback_url = "https://hooks.example.test/webhooks/events"
+    signature = base64.b64encode(
+        hmac.new(
+            secret.encode(),
+            body + callback_url.encode(),
+            hashlib.sha1,
+        ).digest()
+    ).decode("ascii")
+    route = _route("trello", callback_url=callback_url)
+    receipt = adapter._verify_signature_receipt(
+        _request({"X-Trello-Webhook": signature}),
+        body,
+        secret,
+        route,
+    )
+    assert receipt is not None
+    wrong_route = _route(
+        "trello",
+        callback_url="https://hooks.example.test/webhooks/events/",
+    )
+    assert (
+        adapter._verify_signature_receipt(
+            _request({"X-Trello-Webhook": signature}),
+            body,
+            secret,
+            wrong_route,
+        )
+        is None
+    )

--- a/tests/gateway/test_webhook_real_path_e2e.py
+++ b/tests/gateway/test_webhook_real_path_e2e.py
@@ -1,0 +1,219 @@
+"""Real local-network integration proof for webhook execution authority."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import hmac
+import json
+import sqlite3
+import time
+
+import pytest
+from aiohttp import ClientSession
+
+from gateway.config import PlatformConfig
+from gateway.platforms.base import ProcessingOutcome
+from gateway.platforms.webhook import WebhookAdapter
+from gateway.platforms.webhook_ledger import OperationState, TargetState
+
+
+@pytest.mark.asyncio
+async def test_signed_loopback_request_runs_exact_route_and_deduplicates(
+    tmp_path, monkeypatch
+):
+    """Exercise the real listener, verifier, filter, script, and durable ledger."""
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    scripts = tmp_path / "scripts"
+    scripts.mkdir()
+    (scripts / "normalize.py").write_text(
+        "import json, sys\n"
+        "payload = json.load(sys.stdin)\n"
+        "payload['normalized_total'] = payload['amount'] * 2\n"
+        "payload['script_marker'] = 'executed'\n"
+        "print(json.dumps(payload, sort_keys=True))\n",
+        encoding="utf-8",
+    )
+
+    secret = "local-e2e-signing-secret"
+    adapter = WebhookAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={
+                "host": "127.0.0.1",
+                "port": 0,
+                "script_timeout_seconds": 5,
+                "routes": {
+                    "invoice": {
+                        "secret": secret,
+                        "provider": "generic",
+                        "signature_mode": "generic_v2",
+                        "events": ["invoice.created"],
+                        "filters": [
+                            {"field": "kind", "equals": "invoice"},
+                            {"field": "amount", "in": [21]},
+                        ],
+                        "script": "normalize.py",
+                        "prompt": (
+                            "Ready {customer} total={normalized_total} "
+                            "marker={script_marker}"
+                        ),
+                        "deliver": "log",
+                    }
+                },
+            },
+        )
+    )
+
+    completed = asyncio.Event()
+    events = []
+    send_results = []
+    consumer_errors: list[BaseException] = []
+
+    async def consume(event):
+        events.append(event)
+        try:
+            await adapter.on_processing_start(event)
+            send_results.append(
+                await adapter.send(
+                    event.source.chat_id,
+                    "ACK::" + event.text,
+                    metadata={"notify": True},
+                )
+            )
+            await adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
+        except BaseException as exc:
+            consumer_errors.append(exc)
+            raise
+        finally:
+            completed.set()
+
+    adapter.handle_message = consume
+    assert await adapter.connect() is True
+    try:
+        assert adapter._runner is not None
+        sockets = [
+            sock for site in adapter._runner.sites for sock in site._server.sockets
+        ]
+        assert sockets
+        port = sockets[0].getsockname()[1]
+        endpoint = f"http://127.0.0.1:{port}/webhooks/invoice"
+        timestamp = str(int(time.time()))
+
+        def signed(payload):
+            body = json.dumps(
+                payload,
+                separators=(",", ":"),
+                sort_keys=True,
+            ).encode()
+            signature = hmac.new(
+                secret.encode(),
+                timestamp.encode() + b"." + body,
+                hashlib.sha256,
+            ).hexdigest()
+            return body, {
+                "Content-Type": "application/json",
+                "X-Webhook-Timestamp": timestamp,
+                "X-Webhook-Signature-V2": signature,
+            }
+
+        matching_body, matching_headers = signed({
+            "event_type": "invoice.created",
+            "kind": "invoice",
+            "customer": "ACME",
+            "amount": 21,
+        })
+        filtered_body, filtered_headers = signed({
+            "event_type": "invoice.created",
+            "kind": "other",
+            "customer": "NO-DISPATCH",
+            "amount": 21,
+        })
+
+        async with ClientSession() as client:
+            invalid = await client.post(
+                endpoint,
+                data=matching_body,
+                headers={
+                    **matching_headers,
+                    "X-Webhook-Signature-V2": "0" * 64,
+                },
+            )
+            invalid_payload = await invalid.json()
+            assert invalid.status == 401
+            assert invalid_payload == {"error": "Invalid signature"}
+            assert adapter._operation_ledger.count() == 0
+
+            filtered = await client.post(
+                endpoint,
+                data=filtered_body,
+                headers=filtered_headers,
+            )
+            filtered_payload = await filtered.json()
+            assert filtered.status == 200
+            assert filtered_payload == {
+                "status": "ignored",
+                "reason": "filter",
+                "route": "invoice",
+            }
+            assert events == []
+
+            accepted = await client.post(
+                endpoint,
+                data=matching_body,
+                headers=matching_headers,
+            )
+            accepted_payload = await accepted.json()
+            assert accepted.status == 202
+            assert accepted_payload["status"] == "accepted"
+            assert (
+                accepted_payload["deduplication"]
+                == "authenticated_timestamp_body_sha256"
+            )
+            await asyncio.wait_for(completed.wait(), timeout=10)
+
+            duplicate = await client.post(
+                endpoint,
+                data=matching_body,
+                headers=matching_headers,
+            )
+            duplicate_payload = await duplicate.json()
+            assert duplicate.status == 200
+            assert duplicate_payload["status"] == "duplicate"
+
+        assert len(events) == 1
+        assert consumer_errors == []
+        assert events[0].text == "Ready ACME total=42 marker=executed"
+        assert events[0].raw_message["normalized_total"] == 42
+        assert events[0].raw_message["script_marker"] == "executed"
+        assert len(send_results) == 1
+        assert send_results[0].success is True
+        assert send_results[0].raw_response == {"webhook_settlement": "suppressed"}
+
+        authority = adapter._operation_ledger.lookup_session(events[0].source.chat_id)
+        assert authority is not None
+        assert authority.state is OperationState.SETTLED
+        assert authority.target_state is TargetState.SUPPRESSED
+        assert authority.delivery is not None
+        assert authority.delivery.content == "ACK::Ready ACME total=42 marker=executed"
+        assert authority.event_snapshot is not None
+        assert authority.event_snapshot["payload"]["script_marker"] == "executed"
+        assert authority.grant_snapshot is not None
+        assert authority.grant_snapshot["profile_generation"]
+        assert adapter._operation_ledger.db_path == tmp_path / "state.db"
+
+        with sqlite3.connect(tmp_path / "state.db") as connection:
+            operations = connection.execute(
+                "SELECT profile, route, state FROM webhook_operations"
+            ).fetchall()
+            bindings = connection.execute(
+                """SELECT profile, route, provider, signature_mode
+                   FROM webhook_auth_key_bindings"""
+            ).fetchall()
+        assert len(operations) == 2
+        assert set(operations) == {("default", "invoice", "settled")}
+        assert bindings
+        assert set(bindings) == {("default", "invoice", "generic", "generic_v2")}
+    finally:
+        await adapter.disconnect()

--- a/tests/gateway/test_webhook_route_store.py
+++ b/tests/gateway/test_webhook_route_store.py
@@ -1,0 +1,1106 @@
+"""Behavioral coverage for the profile-aware webhook route store."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import hmac
+import json
+import os
+import traceback
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import nullcontext
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+from pydantic import ValidationError
+
+import gateway.platforms.webhook_store as webhook_store_module
+from gateway.platforms.webhook_contract import WebhookContractError, WebhookRouteConfig
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.webhook import WebhookAdapter
+from gateway.platforms.webhook_models import (
+    WebhookRouteDocument,
+    from_persisted_route,
+    to_persisted_route,
+)
+from gateway.platforms.webhook_store import (
+    WebhookRouteStore,
+    WebhookRouteStoreCorruptError,
+    WebhookRouteStoreUnsafePathError,
+    stores_for_served_profiles,
+)
+
+
+def _route(name: str, *, profile: str = "default") -> WebhookRouteDocument:
+    return WebhookRouteDocument(
+        name=name,
+        profile=profile,
+        secret_ref=f"WEBHOOK_ROUTE_{name.upper().replace('-', '_')}",
+    )
+
+
+def test_document_delegates_security_binding_to_canonical_contract():
+    route = WebhookRouteDocument(
+        name="github-push",
+        profile="alpha",
+        provider="github",
+        signature_mode=None,
+        events=["push"],
+        secret_ref="WEBHOOK_ROUTE_GITHUB_PUSH",
+    )
+
+    assert isinstance(route.contract, WebhookRouteConfig)
+    assert route.contract.provider == "github"
+    assert route.contract.signature_mode == "github"
+    assert route.contract.profile == "alpha"
+
+
+def test_provider_specific_fields_reach_the_canonical_contract():
+    trello = WebhookRouteDocument(
+        name="trello-card",
+        provider="trello",
+        signature_mode=None,
+        callback_url="https://hooks.example.test/trello",
+        secret_ref="WEBHOOK_ROUTE_TRELLO_CARD",
+    )
+    assert trello.contract.signature_context == "https://hooks.example.test/trello"
+
+    with pytest.raises(ValidationError, match="callback_url"):
+        WebhookRouteDocument(
+            name="trello-card",
+            provider="trello",
+            signature_mode=None,
+            secret_ref="WEBHOOK_ROUTE_TRELLO_CARD",
+        )
+
+
+def test_historical_cli_route_uses_github_default_not_generic_default():
+    route = from_persisted_route(
+        "legacy",
+        {
+            "description": "Agent-created subscription: legacy",
+            "secret": "plaintext-until-migration",
+        },
+        profile="default",
+    )
+
+    assert route.contract.provider == "github"
+    assert route.contract.signature_mode == "github"
+    assert route.secret_ref is None
+    assert route.has_legacy_plaintext_secret is True
+    assert "plaintext-until-migration" not in repr(route)
+    assert "plaintext-until-migration" not in str(route.model_dump())
+    assert to_persisted_route(route)["secret"] == "plaintext-until-migration"
+
+
+def test_plaintext_is_never_reinterpreted_as_a_secret_reference():
+    route = from_persisted_route(
+        "legacy",
+        {
+            "provider": "generic",
+            "secret": "not-an-env-name",
+        },
+        profile="default",
+    )
+    assert route.secret_ref is None
+    assert route.legacy_secret == "not-an-env-name"
+
+    with pytest.raises(ValidationError, match="both secret_ref and plaintext"):
+        WebhookRouteDocument(
+            name="ambiguous",
+            secret_ref="WEBHOOK_ROUTE_AMBIGUOUS",
+            secret="plaintext",
+        )
+
+
+@pytest.mark.parametrize("reserved", ["legacy_secret", "legacy_secret_value"])
+def test_internal_secret_attribute_names_cannot_be_retained_as_extras(reserved):
+    with pytest.raises(ValidationError, match="reserved secret field"):
+        WebhookRouteDocument.model_validate({
+            "name": "ambiguous",
+            "provider": "generic",
+            "secret": "hidden-value",
+            reserved: "repr-visible-value",
+        })
+
+
+@pytest.mark.parametrize("name", ["../escape", "Bad", "-leading", "", "a/b"])
+def test_document_rejects_noncanonical_route_names(name: str):
+    with pytest.raises(ValidationError):
+        WebhookRouteDocument(name=name, secret_ref="WEBHOOK_ROUTE_TEST")
+
+
+def test_profile_paths_are_isolated_and_served_homes_are_exact(tmp_path):
+    alpha_home = tmp_path / "profiles" / "alpha"
+    beta_home = tmp_path / "profiles" / "beta"
+    stores = stores_for_served_profiles([("alpha", alpha_home), ("beta", beta_home)])
+    stores["alpha"].save({"alpha-route": _route("alpha-route", profile="alpha")})
+    stores["beta"].save({"beta-route": _route("beta-route", profile="beta")})
+
+    assert stores["alpha"].path == alpha_home / "webhook_subscriptions.json"
+    assert stores["beta"].path == beta_home / "webhook_subscriptions.json"
+    assert list(stores["alpha"].load()) == ["alpha-route"]
+    assert list(stores["beta"].load()) == ["beta-route"]
+
+
+def test_store_rejects_traversal_and_profile_home_mismatch(tmp_path):
+    with pytest.raises(WebhookRouteStoreUnsafePathError, match="traversal"):
+        WebhookRouteStore(tmp_path / "safe" / ".." / "escape")
+    with pytest.raises(WebhookRouteStoreUnsafePathError, match="does not match"):
+        WebhookRouteStore.for_profile_home("alpha", tmp_path / "profiles" / "beta")
+
+
+def test_store_rejects_embedded_null_root():
+    with pytest.raises(WebhookRouteStoreUnsafePathError, match="valid path"):
+        WebhookRouteStore("invalid\x00root")
+
+
+def test_windows_move_flags_are_write_through_platform_data():
+    assert webhook_store_module._windows_move_flags(replace_existing=True) == (
+        webhook_store_module._WINDOWS_MOVE_REPLACE_EXISTING
+        | webhook_store_module._WINDOWS_MOVE_WRITE_THROUGH
+    )
+    assert (
+        webhook_store_module._windows_move_flags(replace_existing=False)
+        == webhook_store_module._WINDOWS_MOVE_WRITE_THROUGH
+    )
+
+
+@pytest.mark.windows_only
+def test_windows_native_store_round_trip(tmp_path):
+    store = WebhookRouteStore(tmp_path, profile="alpha")
+    assert store.probe_identity() is None
+    store.lock_path.write_bytes(b"")
+    store.save({"route": _route("route", profile="alpha")})
+
+    assert store.lock_path.read_bytes() == b"0"
+    assert list(store.load()) == ["route"]
+    assert store.probe_identity() is not None
+
+
+def test_save_is_sorted_atomic_owner_only_and_temp_free(tmp_path):
+    store = WebhookRouteStore(tmp_path)
+    store.save({
+        "zulu": _route("zulu"),
+        "alpha": _route("alpha"),
+        "middle": _route("middle"),
+    })
+
+    data = json.loads(store.path.read_text(encoding="utf-8"))
+    assert list(data) == ["alpha", "middle", "zulu"]
+    assert list(store.load()) == ["alpha", "middle", "zulu"]
+    assert not list(tmp_path.glob(".*.tmp"))
+    if os.name == "posix":
+        assert store.path.stat().st_mode & 0o777 == 0o600
+
+
+def test_management_corruption_raises_without_changing_exact_bytes(tmp_path):
+    store = WebhookRouteStore(tmp_path)
+    store.profile_root.mkdir(parents=True, exist_ok=True)
+    corrupt = b'{"route":{"provider":"generic"},"route":{}}'
+    store.path.write_bytes(corrupt)
+
+    with pytest.raises(WebhookRouteStoreCorruptError):
+        store.load()
+
+    assert store.path.read_bytes() == corrupt
+    assert not list(tmp_path.glob("webhook_subscriptions.json.corrupt-*"))
+
+
+@pytest.mark.parametrize(
+    "corrupt",
+    [
+        b'{"route":{"provider":"generic","secret":"value","future":1e999}}',
+        b'{"route":{"provider":"generic","secret":"value","description":"\\ud800"}}',
+    ],
+)
+def test_management_rejects_noncanonical_json_values_without_mutation(
+    tmp_path,
+    corrupt,
+):
+    store = WebhookRouteStore(tmp_path)
+    store.profile_root.mkdir(parents=True, exist_ok=True)
+    store.path.write_bytes(corrupt)
+
+    with pytest.raises(WebhookRouteStoreCorruptError):
+        store.load()
+
+    assert store.path.read_bytes() == corrupt
+
+
+def test_corrupt_store_traceback_does_not_disclose_plaintext_secret(tmp_path):
+    store = WebhookRouteStore(tmp_path)
+    store.profile_root.mkdir(parents=True, exist_ok=True)
+    sentinel = "never-log-this-route-secret"
+    store.path.write_text(
+        json.dumps({
+            "route": {
+                "provider": "generic",
+                "secret": sentinel,
+                "response_mode": "callback",
+                "callback": {"url": "file:///invalid"},
+            }
+        }),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(WebhookRouteStoreCorruptError) as raised:
+        store.load()
+
+    rendered = "".join(traceback.format_exception(raised.value))
+    assert sentinel not in rendered
+
+
+def test_runtime_corruption_quarantines_exact_bytes_and_returns_revocation(tmp_path):
+    store = WebhookRouteStore(tmp_path)
+    store.profile_root.mkdir(parents=True, exist_ok=True)
+    corrupt = b"{not-json"
+    store.path.write_bytes(corrupt)
+
+    snapshot = store.load_runtime()
+
+    assert snapshot.routes == {}
+    assert snapshot.quarantined_path is not None
+    assert snapshot.quarantined_path.read_bytes() == corrupt
+    assert not store.path.exists()
+    assert snapshot.content_sha256 is not None
+
+
+def test_runtime_oversize_store_is_quarantined_without_unbounded_read(tmp_path):
+    store = WebhookRouteStore(tmp_path)
+    store.profile_root.mkdir(parents=True, exist_ok=True)
+    oversized = 4 * 1024 * 1024 + 1
+    with store.path.open("wb") as stream:
+        stream.truncate(oversized)
+
+    snapshot = store.load_runtime()
+
+    assert snapshot.routes == {}
+    assert snapshot.content_sha256 is None
+    assert snapshot.quarantined_path is not None
+    assert snapshot.quarantined_path.stat().st_size == oversized
+    assert not store.path.exists()
+
+
+def test_update_refuses_to_replace_a_corrupt_store(tmp_path):
+    store = WebhookRouteStore(tmp_path)
+    store.profile_root.mkdir(parents=True, exist_ok=True)
+    store.path.write_bytes(b"broken")
+
+    with pytest.raises(WebhookRouteStoreCorruptError):
+        store.update(lambda routes: {**routes, "new": _route("new")})
+
+    assert store.path.read_bytes() == b"broken"
+
+
+def test_store_rejects_symlink_file_and_parent(tmp_path):
+    target = tmp_path / "outside.json"
+    target.write_text("{}", encoding="utf-8")
+    linked_root = tmp_path / "linked-root"
+    try:
+        linked_root.symlink_to(tmp_path, target_is_directory=True)
+    except (NotImplementedError, OSError):
+        pytest.skip("symlinks are unavailable")
+
+    with pytest.raises(WebhookRouteStoreUnsafePathError, match="real directories"):
+        WebhookRouteStore(linked_root).load()
+
+    real_root = tmp_path / "real-root"
+    real_root.mkdir()
+    (real_root / "webhook_subscriptions.json").symlink_to(target)
+    with pytest.raises(WebhookRouteStoreUnsafePathError, match="must not be a link"):
+        WebhookRouteStore(real_root).load()
+    assert target.read_text(encoding="utf-8") == "{}"
+
+
+def test_store_rejects_profile_directory_writable_by_other_accounts(tmp_path):
+    if os.name != "posix":
+        pytest.skip("POSIX ownership and mode contract")
+    store_root = tmp_path / "shared-store"
+    store_root.mkdir(mode=0o700)
+    store_root.chmod(0o777)
+
+    with pytest.raises(
+        WebhookRouteStoreUnsafePathError,
+        match="group- or world-writable",
+    ):
+        WebhookRouteStore(store_root).save({"route": _route("route")})
+
+    assert not (store_root / "webhook_subscriptions.json").exists()
+
+
+def test_route_hardlink_is_rejected_before_mode_or_content_mutation(tmp_path):
+    store_root = tmp_path / "store"
+    store_root.mkdir()
+    outside = tmp_path / "outside.json"
+    content = b'{"route":{"provider":"generic","secret":"value"}}'
+    outside.write_bytes(content)
+    outside.chmod(0o644)
+    try:
+        os.link(outside, store_root / "webhook_subscriptions.json")
+    except OSError:
+        pytest.skip("hard links are unavailable")
+
+    with pytest.raises(WebhookRouteStoreUnsafePathError, match="one filesystem link"):
+        WebhookRouteStore(store_root).load()
+
+    assert outside.read_bytes() == content
+    if os.name == "posix":
+        assert outside.stat().st_mode & 0o777 == 0o644
+
+
+def test_lock_hardlink_is_rejected_before_mode_or_content_mutation(tmp_path):
+    store_root = tmp_path / "store"
+    store_root.mkdir()
+    outside = tmp_path / "outside.lock"
+    outside.write_bytes(b"sentinel")
+    outside.chmod(0o644)
+    try:
+        os.link(outside, store_root / ".webhook_subscriptions.lock")
+    except OSError:
+        pytest.skip("hard links are unavailable")
+
+    with pytest.raises(WebhookRouteStoreUnsafePathError, match="one filesystem link"):
+        WebhookRouteStore(store_root).save({"route": _route("route")})
+
+    assert outside.read_bytes() == b"sentinel"
+    if os.name == "posix":
+        assert outside.stat().st_mode & 0o777 == 0o644
+
+
+def test_lock_symlink_is_rejected_without_touching_target(tmp_path):
+    store_root = tmp_path / "store"
+    store_root.mkdir()
+    outside = tmp_path / "outside.lock"
+    outside.write_bytes(b"sentinel")
+    try:
+        (store_root / ".webhook_subscriptions.lock").symlink_to(outside)
+    except (NotImplementedError, OSError):
+        pytest.skip("symlinks are unavailable")
+
+    with pytest.raises(WebhookRouteStoreUnsafePathError, match="must not be a link"):
+        WebhookRouteStore(store_root).save({"route": _route("route")})
+
+    assert outside.read_bytes() == b"sentinel"
+
+
+def test_mutated_nested_document_is_deeply_revalidated_before_save(tmp_path):
+    store = WebhookRouteStore(tmp_path)
+    route = WebhookRouteDocument(
+        name="callback",
+        secret_ref="WEBHOOK_ROUTE_CALLBACK",
+        response_mode="callback",
+        callback={"url": "https://example.test/result"},
+    )
+    route.callback["url"] = "file:///not-authorized"
+
+    with pytest.raises(ValidationError, match="absolute HTTP"):
+        store.save({"callback": route})
+
+    assert not store.path.exists()
+
+
+def test_serialization_sorts_nested_unknown_policy_keys(tmp_path):
+    store = WebhookRouteStore(tmp_path)
+    route = _route("route")
+    route.future_policy = {"zulu": 1, "alpha": {"zulu": 2, "alpha": 3}}
+
+    store.save({"route": route})
+
+    raw = store.path.read_text(encoding="utf-8")
+    assert raw.index('"alpha"') < raw.index('"zulu"')
+    nested = json.loads(raw)["route"]["future_policy"]["alpha"]
+    assert list(nested) == ["alpha", "zulu"]
+
+
+def test_concurrent_updates_do_not_lose_independent_routes(tmp_path):
+    store = WebhookRouteStore(tmp_path)
+
+    def add(index: int) -> None:
+        name = f"route-{index:02d}"
+        store.update(lambda current: {**current, name: _route(name)})
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        list(pool.map(add, range(24)))
+
+    routes = store.load()
+    assert len(routes) == 24
+    assert list(routes) == sorted(routes)
+
+
+def test_store_rejects_cross_profile_documents(tmp_path):
+    store = WebhookRouteStore(tmp_path, profile="alpha")
+    with pytest.raises(ValueError, match="profile store"):
+        store.save({"route": _route("route", profile="beta")})
+
+
+def _write_runtime_routes(home, routes: dict) -> None:
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "webhook_subscriptions.json").write_text(
+        json.dumps(routes),
+        encoding="utf-8",
+    )
+
+
+def _multiplex_adapter(root, *, allowlist=None, static_routes=None) -> WebhookAdapter:
+    adapter = WebhookAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={
+                "secret": "listener-owner-secret",
+                "routes": static_routes or {},
+            },
+        )
+    )
+    runner = SimpleNamespace(
+        config=SimpleNamespace(
+            multiplex_profiles=True,
+            multiplex_profile_allowlist=allowlist,
+        ),
+        _resolve_profile_home_for_source=lambda source: (
+            root if source.profile == "default" else root / "profiles" / source.profile
+        ),
+    )
+    runner.adapters = {Platform.WEBHOOK: adapter}
+    adapter.gateway_runner = runner
+    # These integration tests exercise route-store publication. The production
+    # resolver/context and their own suites remain responsible for tool grants.
+    adapter._resolve_admitted_toolsets = lambda route, source, strict_config=False: []
+    adapter._profile_runtime_context = lambda source: nullcontext()
+    return adapter
+
+
+def test_multiplex_runtime_loads_only_exact_admitted_profile_stores(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    alpha = tmp_path / "profiles" / "alpha"
+    beta = tmp_path / "profiles" / "beta"
+    _write_runtime_routes(
+        tmp_path,
+        {"default-hook": {"provider": "generic", "secret": "default-secret"}},
+    )
+    _write_runtime_routes(
+        alpha,
+        {"alpha-hook": {"provider": "generic", "secret": "alpha-secret"}},
+    )
+    _write_runtime_routes(
+        beta,
+        {"beta-hook": {"provider": "generic", "secret": "beta-secret"}},
+    )
+    adapter = _multiplex_adapter(tmp_path, allowlist=["alpha"])
+
+    adapter._reload_dynamic_routes()
+
+    assert set(adapter._dynamic_routes) == {"default-hook", "alpha-hook"}
+    assert adapter._dynamic_routes["default-hook"]["profile"] == "default"
+    assert adapter._dynamic_routes["alpha-hook"]["profile"] == "alpha"
+    assert set(adapter._dynamic_profile_store_state) == {"default", "alpha"}
+
+
+def test_multiplex_runtime_quarantines_and_revokes_only_corrupt_profile(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    alpha = tmp_path / "profiles" / "alpha"
+    _write_runtime_routes(
+        tmp_path,
+        {"default-hook": {"provider": "generic", "secret": "default-secret"}},
+    )
+    _write_runtime_routes(
+        alpha,
+        {"alpha-hook": {"provider": "generic", "secret": "alpha-secret"}},
+    )
+    adapter = _multiplex_adapter(tmp_path, allowlist=["alpha"])
+    adapter._reload_dynamic_routes()
+    assert set(adapter._dynamic_routes) == {"default-hook", "alpha-hook"}
+
+    corrupt = b"{broken-profile-store"
+    alpha_store = alpha / "webhook_subscriptions.json"
+    alpha_store.write_bytes(corrupt)
+    adapter._dynamic_profile_reload_after = 0.0
+    adapter._reload_dynamic_routes()
+
+    assert set(adapter._dynamic_routes) == {"default-hook"}
+    quarantines = list(alpha.glob("webhook_subscriptions.json.corrupt-*"))
+    assert len(quarantines) == 1
+    assert quarantines[0].read_bytes() == corrupt
+    assert not alpha_store.exists()
+
+
+def test_multiplex_runtime_qualifies_same_route_name_by_public_profile(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    alpha = tmp_path / "profiles" / "alpha"
+    _write_runtime_routes(
+        tmp_path,
+        {"shared": {"provider": "generic", "secret": "default-secret"}},
+    )
+    _write_runtime_routes(
+        alpha,
+        {"shared": {"provider": "generic", "secret": "alpha-secret"}},
+    )
+    adapter = _multiplex_adapter(tmp_path, allowlist=["alpha"])
+
+    adapter._reload_dynamic_routes()
+
+    assert set(adapter._dynamic_routes_by_key) == {
+        ("default", "shared"),
+        ("alpha", "shared"),
+    }
+    assert set(adapter._authenticated_route_registry) == {
+        ("default", "shared"),
+        ("alpha", "shared"),
+    }
+    assert adapter._authenticated_route_registry[("default", "shared")].secret == (
+        "default-secret"
+    )
+    assert adapter._authenticated_route_registry[("alpha", "shared")].secret == (
+        "alpha-secret"
+    )
+    # The historical name-only facade cannot choose between siblings.
+    assert "shared" not in adapter._dynamic_routes
+    assert "shared" not in adapter._routes
+
+
+def test_qualified_route_key_must_match_embedded_public_profile(tmp_path):
+    adapter = _multiplex_adapter(tmp_path, allowlist=[])
+
+    with pytest.raises(WebhookContractError, match="carries profile 'beta'"):
+        adapter._qualified_route_candidates({
+            ("alpha", "shared"): {
+                "profile": "beta",
+                "provider": "generic",
+                "secret": "beta-secret",
+            }
+        })
+
+
+def test_static_and_dynamic_same_name_coexist_across_profiles(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    alpha = tmp_path / "profiles" / "alpha"
+    _write_runtime_routes(
+        alpha,
+        {"shared": {"provider": "generic", "secret": "alpha-secret"}},
+    )
+    adapter = _multiplex_adapter(
+        tmp_path,
+        allowlist=["alpha"],
+        static_routes={"shared": {"provider": "generic", "secret": "static-secret"}},
+    )
+
+    adapter._reload_dynamic_routes()
+
+    assert set(adapter._authenticated_route_registry) == {
+        ("default", "shared"),
+        ("alpha", "shared"),
+    }
+    assert adapter._authenticated_route_registry[("default", "shared")].secret == (
+        "static-secret"
+    )
+    assert adapter._authenticated_route_registry[("alpha", "shared")].secret == (
+        "alpha-secret"
+    )
+
+
+def test_disabling_same_name_sibling_revokes_only_its_qualified_authority(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    alpha = tmp_path / "profiles" / "alpha"
+    default_route = {"provider": "generic", "secret": "default-secret"}
+    alpha_route = {"provider": "generic", "secret": "alpha-secret"}
+    _write_runtime_routes(tmp_path, {"shared": default_route})
+    _write_runtime_routes(alpha, {"shared": alpha_route})
+    adapter = _multiplex_adapter(tmp_path, allowlist=["alpha"])
+    adapter._reload_dynamic_routes()
+    assert adapter._record_rate_limit_hit("shared", 1.0, profile="default")
+    assert adapter._record_rate_limit_hit("shared", 1.0, profile="alpha")
+
+    _write_runtime_routes(
+        alpha,
+        {"shared": {**alpha_route, "enabled": False}},
+    )
+    adapter._dynamic_profile_reload_after = 0.0
+    adapter._reload_dynamic_routes()
+
+    assert set(adapter._authenticated_route_registry) == {("default", "shared")}
+    assert adapter._authenticated_route_registry[("default", "shared")].secret == (
+        "default-secret"
+    )
+    assert ("default", "shared") in adapter._rate_counts
+    assert ("alpha", "shared") not in adapter._rate_counts
+
+
+@pytest.mark.asyncio
+async def test_same_name_profiles_route_to_exact_immutable_bundle(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    alpha = tmp_path / "profiles" / "alpha"
+    _write_runtime_routes(
+        tmp_path,
+        {
+            "shared": {
+                "signature_mode": "generic_v1",
+                "secret": "default-secret",
+            }
+        },
+    )
+    _write_runtime_routes(
+        alpha,
+        {
+            "shared": {
+                "signature_mode": "generic_v1",
+                "secret": "alpha-secret",
+            }
+        },
+    )
+    adapter = _multiplex_adapter(tmp_path, allowlist=["alpha"])
+    adapter.handle_message = AsyncMock()
+    adapter._reload_dynamic_routes()
+    app = web.Application(client_max_size=adapter._max_body_bytes)
+    app.router.add_post("/webhooks/{route_name}", adapter._handle_webhook)
+    app.router.add_post(
+        "/p/{profile}/webhooks/{route_name}",
+        adapter._handle_webhook,
+    )
+    body = b'{"value":1}'
+
+    def headers(secret: str) -> dict[str, str]:
+        signature = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+        return {
+            "Content-Type": "application/json",
+            "X-Webhook-Signature": signature,
+        }
+
+    async with TestClient(TestServer(app)) as client:
+        crossed_default = await client.post(
+            "/webhooks/shared",
+            data=body,
+            headers=headers("alpha-secret"),
+        )
+        crossed_alpha = await client.post(
+            "/p/alpha/webhooks/shared",
+            data=body,
+            headers=headers("default-secret"),
+        )
+        accepted_default = await client.post(
+            "/webhooks/shared",
+            data=body,
+            headers=headers("default-secret"),
+        )
+        accepted_alpha = await client.post(
+            "/p/alpha/webhooks/shared",
+            data=body,
+            headers=headers("alpha-secret"),
+        )
+
+    assert crossed_default.status == crossed_alpha.status == 401
+    assert accepted_default.status == accepted_alpha.status == 202
+    await asyncio.sleep(0.05)
+    assert [
+        call.args[0].source.profile for call in adapter.handle_message.await_args_list
+    ] == ["default", "alpha"]
+
+
+@pytest.mark.asyncio
+async def test_same_name_sibling_republish_preserves_only_unchanged_inflight_bundle(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    alpha = tmp_path / "profiles" / "alpha"
+    _write_runtime_routes(
+        tmp_path,
+        {
+            "shared": {
+                "signature_mode": "generic_v1",
+                "secret": "default-secret",
+            }
+        },
+    )
+    _write_runtime_routes(
+        alpha,
+        {
+            "shared": {
+                "signature_mode": "generic_v1",
+                "secret": "alpha-secret",
+            }
+        },
+    )
+    adapter = _multiplex_adapter(tmp_path, allowlist=["alpha"])
+    adapter.handle_message = AsyncMock()
+    adapter._reload_dynamic_routes()
+    prior_default = adapter._authenticated_route_registry[("default", "shared")]
+    prior_alpha = adapter._authenticated_route_registry[("alpha", "shared")]
+    body = b'{"value":"in-flight"}'
+
+    class BlockingRequest:
+        def __init__(self, profile: str, secret: str):
+            self.match_info = {
+                "route_name": "shared",
+                **({"profile": profile} if profile else {}),
+            }
+            signature = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+            self.headers = {
+                "Content-Type": "application/json",
+                "X-Webhook-Signature": signature,
+            }
+            self.content_length = len(body)
+            self.started = asyncio.Event()
+            self.release = asyncio.Event()
+
+        async def read(self) -> bytes:
+            self.started.set()
+            await self.release.wait()
+            return body
+
+    default_request = BlockingRequest("", "default-secret")
+    alpha_request = BlockingRequest("alpha", "alpha-secret")
+    default_task = asyncio.create_task(adapter._handle_webhook(default_request))
+    alpha_task = asyncio.create_task(adapter._handle_webhook(alpha_request))
+    await asyncio.gather(
+        default_request.started.wait(),
+        alpha_request.started.wait(),
+    )
+
+    _write_runtime_routes(
+        alpha,
+        {
+            "shared": {
+                "signature_mode": "generic_v1",
+                "secret": "rotated-alpha-secret",
+            }
+        },
+    )
+    adapter._dynamic_profile_reload_after = 0.0
+    adapter._reload_dynamic_routes()
+
+    assert adapter._authenticated_route_registry[("default", "shared")] is prior_default
+    assert adapter._authenticated_route_registry[("alpha", "shared")] is not prior_alpha
+    default_request.release.set()
+    alpha_request.release.set()
+    default_response, alpha_response = await asyncio.gather(
+        default_task,
+        alpha_task,
+    )
+
+    assert default_response.status == 202
+    assert alpha_response.status == 503
+    await asyncio.sleep(0)
+    assert len(adapter.handle_message.await_args_list) == 1
+    assert adapter.handle_message.await_args.args[0].source.profile == "default"
+
+
+@pytest.mark.asyncio
+async def test_same_name_profiles_have_independent_request_rate_buckets(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    alpha = tmp_path / "profiles" / "alpha"
+    _write_runtime_routes(
+        tmp_path,
+        {
+            "shared": {
+                "signature_mode": "generic_v1",
+                "secret": "default-secret",
+            }
+        },
+    )
+    _write_runtime_routes(
+        alpha,
+        {
+            "shared": {
+                "signature_mode": "generic_v1",
+                "secret": "alpha-secret",
+            }
+        },
+    )
+    adapter = _multiplex_adapter(tmp_path, allowlist=["alpha"])
+    adapter.handle_message = AsyncMock()
+    adapter._rate_limit = 1
+    adapter._reload_dynamic_routes()
+    app = web.Application(client_max_size=adapter._max_body_bytes)
+    app.router.add_post("/webhooks/{route_name}", adapter._handle_webhook)
+    app.router.add_post(
+        "/p/{profile}/webhooks/{route_name}",
+        adapter._handle_webhook,
+    )
+
+    def headers(secret: str, body: bytes) -> dict[str, str]:
+        signature = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+        return {
+            "Content-Type": "application/json",
+            "X-Webhook-Signature": signature,
+        }
+
+    first = b'{"value":1}'
+    second = b'{"value":2}'
+    async with TestClient(TestServer(app)) as client:
+        default_first = await client.post(
+            "/webhooks/shared",
+            data=first,
+            headers=headers("default-secret", first),
+        )
+        default_second = await client.post(
+            "/webhooks/shared",
+            data=second,
+            headers=headers("default-secret", second),
+        )
+        alpha_first = await client.post(
+            "/p/alpha/webhooks/shared",
+            data=first,
+            headers=headers("alpha-secret", first),
+        )
+        alpha_second = await client.post(
+            "/p/alpha/webhooks/shared",
+            data=second,
+            headers=headers("alpha-secret", second),
+        )
+
+    assert default_first.status == alpha_first.status == 202
+    assert default_second.status == alpha_second.status == 429
+    assert set(adapter._rate_counts) == {
+        ("default", "shared"),
+        ("alpha", "shared"),
+    }
+
+
+@pytest.mark.asyncio
+async def test_bare_path_never_falls_back_to_only_named_profile_route(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    alpha = tmp_path / "profiles" / "alpha"
+    _write_runtime_routes(
+        alpha,
+        {
+            "shared": {
+                "signature_mode": "generic_v1",
+                "secret": "alpha-secret",
+            }
+        },
+    )
+    adapter = _multiplex_adapter(tmp_path, allowlist=["alpha"])
+    adapter.handle_message = AsyncMock()
+    adapter._reload_dynamic_routes()
+    app = web.Application(client_max_size=adapter._max_body_bytes)
+    app.router.add_post("/webhooks/{route_name}", adapter._handle_webhook)
+    app.router.add_post(
+        "/p/{profile}/webhooks/{route_name}",
+        adapter._handle_webhook,
+    )
+    body = b'{"value":2}'
+    signature = hmac.new(b"alpha-secret", body, hashlib.sha256).hexdigest()
+    headers = {
+        "Content-Type": "application/json",
+        "X-Webhook-Signature": signature,
+    }
+
+    async with TestClient(TestServer(app)) as client:
+        bare = await client.post("/webhooks/shared", data=body, headers=headers)
+        named = await client.post(
+            "/p/alpha/webhooks/shared",
+            data=body,
+            headers=headers,
+        )
+
+    assert bare.status == 404
+    assert named.status == 202
+
+
+def test_multiplex_runtime_skips_disabled_and_never_borrows_owner_secret(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    alpha = tmp_path / "profiles" / "alpha"
+    _write_runtime_routes(
+        alpha,
+        {
+            "disabled": {
+                "provider": "generic",
+                "secret": "alpha-secret",
+                "enabled": False,
+            },
+            "missing-secret": {"provider": "generic"},
+            "unresolved-ref": {
+                "provider": "generic",
+                "secret_ref": "WEBHOOK_ROUTE_UNRESOLVED",
+            },
+        },
+    )
+    adapter = _multiplex_adapter(tmp_path, allowlist=["alpha"])
+
+    adapter._reload_dynamic_routes()
+
+    assert adapter._dynamic_routes == {}
+
+
+def test_multiplex_runtime_revokes_snapshot_if_profile_incarnation_changes(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    alpha = tmp_path / "profiles" / "alpha"
+    _write_runtime_routes(
+        tmp_path,
+        {"default-hook": {"provider": "generic", "secret": "default-secret"}},
+    )
+    _write_runtime_routes(
+        alpha,
+        {"alpha-hook": {"provider": "generic", "secret": "alpha-secret"}},
+    )
+    adapter = _multiplex_adapter(tmp_path, allowlist=["alpha"])
+    adapter._reload_dynamic_routes()
+    assert "alpha-hook" in adapter._dynamic_routes
+    real_generation = adapter._current_profile_authority_generation
+    alpha_calls = 0
+
+    def changing_generation(profile, *, route_name):
+        nonlocal alpha_calls
+        if profile == "alpha" and route_name == "profile-store":
+            alpha_calls += 1
+            return "a" * 64 if alpha_calls == 1 else "b" * 64
+        return real_generation(profile, route_name=route_name)
+
+    monkeypatch.setattr(
+        adapter,
+        "_current_profile_authority_generation",
+        changing_generation,
+    )
+    adapter._dynamic_profile_reload_after = 0.0
+    adapter._reload_dynamic_routes()
+
+    assert "default-hook" in adapter._dynamic_routes
+    assert "alpha-hook" not in adapter._dynamic_routes
+
+
+def test_multiplex_runtime_unchanged_fast_path_performs_no_store_io(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write_runtime_routes(
+        tmp_path,
+        {"hook": {"provider": "generic", "secret": "default-secret"}},
+    )
+    adapter = _multiplex_adapter(tmp_path, allowlist=[])
+    clock = [100.0]
+    monkeypatch.setattr(
+        "gateway.platforms.webhook_intake.time.monotonic",
+        lambda: clock[0],
+    )
+    real_load = WebhookRouteStore.load_runtime
+    calls = []
+
+    def counted_load(store):
+        calls.append(store.profile)
+        return real_load(store)
+
+    monkeypatch.setattr(WebhookRouteStore, "load_runtime", counted_load)
+    adapter._reload_dynamic_routes()
+    first_calls = list(calls)
+    bind_calls = []
+    real_bind = adapter._bind_route_authentication_authorities
+
+    def counted_bind(routes):
+        bind_calls.append(tuple(sorted(routes)))
+        return real_bind(routes)
+
+    monkeypatch.setattr(adapter, "_bind_route_authentication_authorities", counted_bind)
+
+    clock[0] = 100.5
+    adapter._reload_dynamic_routes()
+    assert calls == first_calls
+    assert bind_calls == []
+
+    clock[0] = 101.1
+    adapter._reload_dynamic_routes()
+    assert len(calls) > len(first_calls)
+    assert bind_calls == []
+
+
+def test_multiplex_integrity_rechecks_are_globally_staggered(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    for profile in ("alpha", "beta", "gamma"):
+        _write_runtime_routes(
+            tmp_path / "profiles" / profile,
+            {
+                f"{profile}-hook": {
+                    "provider": "generic",
+                    "secret": f"{profile}-secret",
+                }
+            },
+        )
+    adapter = _multiplex_adapter(
+        tmp_path,
+        allowlist=["alpha", "beta", "gamma"],
+    )
+    clock = [200.0]
+    monkeypatch.setattr(
+        "gateway.platforms.webhook_intake.time.monotonic",
+        lambda: clock[0],
+    )
+    adapter._reload_dynamic_routes()
+
+    real_load = WebhookRouteStore.load_runtime
+    calls = []
+
+    def counted_load(store):
+        calls.append(store.profile)
+        return real_load(store)
+
+    monkeypatch.setattr(WebhookRouteStore, "load_runtime", counted_load)
+    clock[0] = 201.1
+    adapter._reload_dynamic_routes()
+
+    # Four admitted profiles (default + three named), but only the single
+    # round-robin integrity slot gets a deep read when all identities match.
+    assert len(calls) == 1
+
+
+def test_multiplex_runtime_busy_writer_retains_prior_exact_snapshot(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    alpha = tmp_path / "profiles" / "alpha"
+    _write_runtime_routes(
+        alpha,
+        {"alpha-hook": {"provider": "generic", "secret": "alpha-secret"}},
+    )
+    adapter = _multiplex_adapter(tmp_path, allowlist=["alpha"])
+    adapter._reload_dynamic_routes()
+    prior = dict(adapter._dynamic_routes["alpha-hook"])
+    real_load = WebhookRouteStore.load_runtime
+
+    def busy_alpha(store):
+        if store.profile == "alpha":
+            raise TimeoutError("writer still owns atomic switch")
+        return real_load(store)
+
+    monkeypatch.setattr(WebhookRouteStore, "load_runtime", busy_alpha)
+    adapter._dynamic_profile_reload_after = 0.0
+    adapter._reload_dynamic_routes()
+
+    assert adapter._dynamic_routes["alpha-hook"] == prior

--- a/tests/gateway/test_webhook_route_toolsets.py
+++ b/tests/gateway/test_webhook_route_toolsets.py
@@ -1,137 +1,395 @@
-"""Per-route webhook toolset overrides (adapter.toolsets_for_source).
+"""Durable per-webhook-operation toolset authority.
 
-A webhook route config may carry a ``toolsets`` list that replaces the
-platform-level ``platform_toolsets.webhook`` resolution for runs triggered by
-that route only. The gateway validates the override through the same
-``_get_platform_tools`` path as platform config, so restricted/unknown names
-behave identically to a manually configured platform toolset list.
+Route toolsets are validated once, before dispatch, and persisted in the
+operation ledger. Agent execution consumes only that exact durable grant.
+Missing, malformed, or unreadable authority is an explicit deny-all result;
+mutable route or platform configuration is never consulted as a fallback.
 """
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
 
 from gateway.platforms.base import BasePlatformAdapter
 from gateway.platforms.webhook import WebhookAdapter
+from gateway.platforms.webhook_auth import WebhookLocalBypassReceipt
+from gateway.platforms.webhook_contract import (
+    WebhookContractError,
+    WebhookEnvelope,
+    WebhookRouteConfig,
+)
+from gateway.platforms.webhook_ledger import (
+    AdmitDisposition,
+    WebhookOperationLedger,
+)
 from gateway.run import GatewayRunner
 from hermes_cli.tools_config import _get_platform_tools
 
 
 class _Src:
-    def __init__(self, chat_id):
+    def __init__(self, chat_id: str):
         self.chat_id = chat_id
 
 
-def _make_adapter(routes):
-    wa = object.__new__(WebhookAdapter)
-    wa._routes = routes
-    return wa
+class _BrokenLedger:
+    def lookup_session(self, _session_key: str):
+        raise RuntimeError("injected ledger failure")
 
 
-def _make_runner(adapter):
-    gr = object.__new__(GatewayRunner)
-    gr._adapter_for_source = lambda source: adapter
-    return gr
+def _make_adapter(ledger, *, routes=None, runner=None) -> WebhookAdapter:
+    adapter = object.__new__(WebhookAdapter)
+    adapter._operation_ledger = ledger
+    adapter._routes = routes or {}
+    adapter.gateway_runner = runner
+    return adapter
+
+
+def _make_runner(adapter) -> GatewayRunner:
+    runner = object.__new__(GatewayRunner)
+    runner._adapter_for_source = lambda source: adapter
+    return runner
+
+
+def _prepared_authority(
+    tmp_path: Path,
+    grant_snapshot: dict,
+    *,
+    trace_id: str = "trace-1",
+):
+    ledger = WebhookOperationLedger(tmp_path / f"{trace_id}.db")
+    body = json.dumps(
+        {"event": "push", "trace": trace_id},
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode()
+    route = WebhookRouteConfig.bind(
+        "mon",
+        {"provider": "generic", "profile": "default"},
+        headers={},
+        request_profile="default",
+    )
+    receipt = WebhookLocalBypassReceipt._issue(route, body, {})
+    envelope = WebhookEnvelope.from_receipt(
+        receipt,
+        raw_body=body,
+        media_type="application/json",
+        trace_id=trace_id,
+    )
+    admitted = ledger.admit(envelope)
+    assert admitted.disposition is AdmitDisposition.ACCEPTED
+    assert admitted.authority is not None
+    prepared = ledger.prepare(
+        admitted.authority,
+        event_snapshot={"v": 1, "kind": "agent", "prompt": "inspect"},
+        target_snapshot={"v": 1, "kind": "log", "profile": "default"},
+        grant_snapshot=grant_snapshot,
+    )
+    return ledger, prepared
 
 
 BASE_CONFIG = {"platform_toolsets": {"webhook": ["web", "vision", "clarify"]}}
 
 
-class TestWebhookAdapterToolsetsForSource:
-    def test_route_with_toolsets_returns_list(self):
-        wa = _make_adapter({"mon": {"secret": "x", "toolsets": ["terminal", "file"]}})
-        assert wa.toolsets_for_source(_Src("webhook:mon:d1")) == ["terminal", "file"]
-
-    def test_route_without_toolsets_returns_none(self):
-        wa = _make_adapter({"plain": {"secret": "x"}})
-        assert wa.toolsets_for_source(_Src("webhook:plain:d1")) is None
-
-    def test_unknown_route_returns_none(self):
-        wa = _make_adapter({})
-        assert wa.toolsets_for_source(_Src("webhook:ghost:d1")) is None
-
-    def test_non_webhook_chat_id_returns_none(self):
-        wa = _make_adapter({"mon": {"secret": "x", "toolsets": ["terminal"]}})
-        assert wa.toolsets_for_source(_Src("telegram:123")) is None
-
-    def test_empty_or_non_list_toolsets_returns_none(self):
-        wa = _make_adapter(
-            {
-                "empty": {"secret": "x", "toolsets": []},
-                "str": {"secret": "x", "toolsets": "terminal"},
-                "blank": {"secret": "x", "toolsets": ["  ", ""]},
-            }
+class TestWebhookAdapterDurableGrant:
+    def test_returns_exact_persisted_grant(self, tmp_path: Path):
+        ledger, authority = _prepared_authority(
+            tmp_path,
+            {"v": 1, "toolsets": ["terminal", "file"]},
         )
-        assert wa.toolsets_for_source(_Src("webhook:empty:d")) is None
-        assert wa.toolsets_for_source(_Src("webhook:str:d")) is None
-        assert wa.toolsets_for_source(_Src("webhook:blank:d")) is None
+        adapter = _make_adapter(ledger)
+        source = _Src(authority.session_key)
 
-    def test_base_adapter_default_is_none(self):
-        # Non-webhook adapters inherit a None default: no override anywhere.
-        wa = _make_adapter({})
+        assert adapter.resolved_toolsets_for_source(source) == ["terminal", "file"]
+        assert adapter.toolsets_for_source(source) == ["terminal", "file"]
+
+    def test_mutable_route_cannot_replace_persisted_grant(self, tmp_path: Path):
+        ledger, authority = _prepared_authority(
+            tmp_path,
+            {"v": 1, "toolsets": ["web"]},
+        )
+        routes = {"mon": {"toolsets": ["terminal"]}}
+        adapter = _make_adapter(ledger, routes=routes)
+        source = _Src(authority.session_key)
+
+        assert adapter.resolved_toolsets_for_source(source) == ["web"]
+        routes["mon"]["toolsets"] = ["file", "terminal"]
+        assert adapter.resolved_toolsets_for_source(source) == ["web"]
+
+    def test_missing_authority_is_deny_all_even_when_route_is_wider(
+        self,
+        tmp_path: Path,
+    ):
+        ledger = WebhookOperationLedger(tmp_path / "state.db")
+        adapter = _make_adapter(
+            ledger,
+            routes={"mon": {"toolsets": ["terminal", "file"]}},
+        )
+
+        assert adapter.resolved_toolsets_for_source(_Src("webhook:missing")) == []
+        assert adapter.toolsets_for_source(_Src("webhook:missing")) == []
+
+    @pytest.mark.parametrize(
+        "grant_snapshot",
+        [
+            pytest.param({}, id="missing-version"),
+            pytest.param({"v": 2, "toolsets": ["terminal"]}, id="wrong-version"),
+            pytest.param({"v": 1}, id="missing-list"),
+            pytest.param({"v": 1, "toolsets": "terminal"}, id="string-list"),
+            pytest.param({"v": 1, "toolsets": ["terminal", ""]}, id="blank"),
+            pytest.param({"v": 1, "toolsets": ["terminal", 7]}, id="non-string"),
+        ],
+    )
+    def test_malformed_persisted_grant_is_deny_all(
+        self,
+        tmp_path: Path,
+        grant_snapshot: dict,
+    ):
+        ledger, authority = _prepared_authority(
+            tmp_path,
+            grant_snapshot,
+            trace_id=f"malformed-{abs(hash(repr(grant_snapshot)))}",
+        )
+        adapter = _make_adapter(ledger)
+
+        assert adapter.resolved_toolsets_for_source(_Src(authority.session_key)) == []
+
+    def test_ledger_failure_and_blank_source_are_deny_all(self):
+        adapter = _make_adapter(_BrokenLedger())
+
+        assert adapter.resolved_toolsets_for_source(_Src("webhook:mon:d")) == []
+        assert adapter.resolved_toolsets_for_source(_Src("")) == []
+
+    def test_base_adapter_has_no_exact_or_legacy_override(self):
+        adapter = object.__new__(WebhookAdapter)
+        source = _Src("webhook:mon:d")
+
+        assert BasePlatformAdapter.resolved_toolsets_for_source(adapter, source) is None
+        assert BasePlatformAdapter.toolsets_for_source(adapter, source) is None
+
+
+class TestAdmissionTimeResolution:
+    def test_declared_route_grant_is_normalized_and_validated_once(
+        self,
+        monkeypatch,
+    ):
+        runner = SimpleNamespace(config=SimpleNamespace(multiplex_profiles=False))
+        adapter = _make_adapter(None, runner=runner)
+        original_config = {
+            "platform_toolsets": {"webhook": ["vision"]},
+            "unrelated": {"preserved": True},
+        }
+        seen = []
+
+        monkeypatch.setattr(
+            "gateway.run._load_gateway_config",
+            lambda: original_config,
+        )
+
+        def resolve(config, platform_key):
+            seen.append((config, platform_key))
+            return {"terminal", "web"}
+
+        monkeypatch.setattr("hermes_cli.tools_config._get_platform_tools", resolve)
+
+        resolved = adapter._resolve_admitted_toolsets(
+            {"toolsets": [" terminal ", "web", "terminal"]},
+            _Src("webhook:default:mon:generic:trace"),
+        )
+
+        assert resolved == ["terminal", "web"]
+        assert len(seen) == 1
+        resolved_config, platform_key = seen[0]
+        assert platform_key == "webhook"
+        assert resolved_config["platform_toolsets"]["webhook"] == [
+            "terminal",
+            "web",
+        ]
+        assert original_config == {
+            "platform_toolsets": {"webhook": ["vision"]},
+            "unrelated": {"preserved": True},
+        }
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            pytest.param("terminal", id="not-list"),
+            pytest.param(["terminal", ""], id="blank"),
+            pytest.param(["terminal", 7], id="non-string"),
+        ],
+    )
+    def test_invalid_declared_route_grant_fails_before_dispatch(self, raw):
+        runner = SimpleNamespace(config=SimpleNamespace(multiplex_profiles=False))
+        adapter = _make_adapter(None, runner=runner)
+
+        with pytest.raises(WebhookContractError, match="toolset"):
+            adapter._resolve_admitted_toolsets(
+                {"toolsets": raw},
+                _Src("webhook:default:mon:generic:trace"),
+            )
+
+    def test_empty_declared_grant_is_explicit_deny_all(self, monkeypatch):
+        runner = SimpleNamespace(config=SimpleNamespace(multiplex_profiles=False))
+        adapter = _make_adapter(None, runner=runner)
+
+        monkeypatch.setattr(
+            "hermes_cli.tools_config._get_platform_tools",
+            lambda *_args: (_ for _ in ()).throw(
+                AssertionError("empty grant must not broaden through live config")
+            ),
+        )
+
         assert (
-            BasePlatformAdapter.toolsets_for_source(wa, _Src("webhook:mon:d")) is None
+            adapter._resolve_admitted_toolsets(
+                {"toolsets": []},
+                _Src("webhook:default:mon:generic:trace"),
+            )
+            == []
+        )
+
+    def test_missing_gateway_runner_is_deny_all(self):
+        adapter = _make_adapter(None, runner=None)
+
+        assert (
+            adapter._resolve_admitted_toolsets(
+                {"toolsets": ["terminal"]},
+                _Src("webhook:default:mon:generic:trace"),
+            )
+            == []
         )
 
 
-class TestGatewayResolveEnabledToolsetsForSource:
-    def test_override_replaces_platform_resolution(self):
-        wa = _make_adapter(
-            {"mon": {"secret": "x", "toolsets": ["terminal", "file", "web"]}}
+class TestGatewayConsumesExactGrant:
+    def test_exact_grant_bypasses_mutable_resolution(self, tmp_path, monkeypatch):
+        ledger, authority = _prepared_authority(
+            tmp_path,
+            {"v": 1, "toolsets": ["web", "terminal", "web"]},
         )
-        gr = _make_runner(wa)
-        res = GatewayRunner._resolve_enabled_toolsets_for_source(
-            gr, BASE_CONFIG, _Src("webhook:mon:d"), "webhook"
+        adapter = _make_adapter(
+            ledger,
+            routes={"mon": {"toolsets": ["file"]}},
         )
-        assert "terminal" in res and "file" in res and "web" in res
-        assert "vision" not in res  # platform list fully replaced, not merged
+        runner = _make_runner(adapter)
+        config = {"platform_toolsets": {"webhook": ["vision"]}}
 
-    def test_override_validated_like_platform_config(self):
-        # Contract: resolving with an override is byte-identical to resolving
-        # the same list configured as platform_toolsets.webhook.
-        override = ["terminal", "file", "web", "discord_admin"]
-        wa = _make_adapter({"mon": {"secret": "x", "toolsets": override}})
-        gr = _make_runner(wa)
-        res = GatewayRunner._resolve_enabled_toolsets_for_source(
-            gr, BASE_CONFIG, _Src("webhook:mon:d"), "webhook"
+        monkeypatch.setattr(
+            "hermes_cli.tools_config._get_platform_tools",
+            lambda *_args: (_ for _ in ()).throw(
+                AssertionError("durable grant must not be re-resolved")
+            ),
         )
-        expected = sorted(
-            _get_platform_tools(
-                {"platform_toolsets": {"webhook": list(override)}}, "webhook"
+
+        resolved, has_override, failed = (
+            GatewayRunner._resolve_toolset_authority_for_source(
+                runner,
+                config,
+                _Src(authority.session_key),
+                "webhook",
             )
         )
-        assert res == expected
-        # discord_admin is platform-restricted to discord — must be dropped.
-        assert "discord_admin" not in res
 
-    def test_no_override_uses_platform_resolution(self):
-        wa = _make_adapter({"plain": {"secret": "x"}})
-        gr = _make_runner(wa)
-        res = GatewayRunner._resolve_enabled_toolsets_for_source(
-            gr, BASE_CONFIG, _Src("webhook:plain:d"), "webhook"
-        )
-        assert res == sorted(_get_platform_tools(BASE_CONFIG, "webhook"))
-        assert "terminal" not in res
+        assert resolved == ["web", "terminal"]
+        assert has_override is True
+        assert failed is False
+        assert config == {"platform_toolsets": {"webhook": ["vision"]}}
 
-    def test_adapter_exception_falls_back_to_platform_resolution(self):
-        wa = _make_adapter({})
-        wa.toolsets_for_source = lambda source: (_ for _ in ()).throw(
-            RuntimeError("boom")
+    def test_exact_empty_grant_is_deny_all(self, tmp_path, monkeypatch):
+        ledger, authority = _prepared_authority(
+            tmp_path,
+            {"v": 1, "toolsets": []},
         )
-        gr = _make_runner(wa)
-        res = GatewayRunner._resolve_enabled_toolsets_for_source(
-            gr, BASE_CONFIG, _Src("webhook:mon:d"), "webhook"
-        )
-        assert res == sorted(_get_platform_tools(BASE_CONFIG, "webhook"))
+        adapter = _make_adapter(ledger)
+        runner = _make_runner(adapter)
 
-    def test_missing_adapter_falls_back_to_platform_resolution(self):
-        gr = _make_runner(None)
-        res = GatewayRunner._resolve_enabled_toolsets_for_source(
-            gr, BASE_CONFIG, _Src("webhook:mon:d"), "webhook"
+        monkeypatch.setattr(
+            "hermes_cli.tools_config._get_platform_tools",
+            lambda *_args: (_ for _ in ()).throw(
+                AssertionError("deny-all must not be re-resolved")
+            ),
         )
-        assert res == sorted(_get_platform_tools(BASE_CONFIG, "webhook"))
 
-    def test_original_config_not_mutated(self):
-        cfg = {"platform_toolsets": {"webhook": ["web"]}}
-        wa = _make_adapter({"mon": {"secret": "x", "toolsets": ["terminal"]}})
-        gr = _make_runner(wa)
-        GatewayRunner._resolve_enabled_toolsets_for_source(
-            gr, cfg, _Src("webhook:mon:d"), "webhook"
+        resolved, has_override, failed = (
+            GatewayRunner._resolve_toolset_authority_for_source(
+                runner,
+                BASE_CONFIG,
+                _Src(authority.session_key),
+                "webhook",
+            )
         )
-        assert cfg["platform_toolsets"]["webhook"] == ["web"]
+
+        assert resolved == []
+        assert has_override is True
+        assert failed is False
+
+    def test_missing_durable_authority_does_not_fall_back_to_platform_config(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        adapter = _make_adapter(
+            WebhookOperationLedger(tmp_path / "state.db"),
+            routes={"mon": {"toolsets": ["terminal"]}},
+        )
+        runner = _make_runner(adapter)
+
+        monkeypatch.setattr(
+            "hermes_cli.tools_config._get_platform_tools",
+            lambda *_args: (_ for _ in ()).throw(
+                AssertionError("missing authority must be deny-all")
+            ),
+        )
+
+        resolved, has_override, failed = (
+            GatewayRunner._resolve_toolset_authority_for_source(
+                runner,
+                BASE_CONFIG,
+                _Src("webhook:missing"),
+                "webhook",
+            )
+        )
+
+        assert resolved == []
+        assert has_override is True
+        assert failed is False
+
+    def test_unreadable_durable_authority_does_not_fall_back(self, monkeypatch):
+        runner = _make_runner(_make_adapter(_BrokenLedger()))
+
+        monkeypatch.setattr(
+            "hermes_cli.tools_config._get_platform_tools",
+            lambda *_args: (_ for _ in ()).throw(
+                AssertionError("ledger failure must be deny-all")
+            ),
+        )
+
+        resolved, has_override, failed = (
+            GatewayRunner._resolve_toolset_authority_for_source(
+                runner,
+                BASE_CONFIG,
+                _Src("webhook:mon:d"),
+                "webhook",
+            )
+        )
+
+        assert resolved == []
+        assert has_override is True
+        assert failed is False
+
+    def test_missing_webhook_adapter_fails_closed(self):
+        runner = _make_runner(None)
+
+        resolved, has_override, failed = (
+            GatewayRunner._resolve_toolset_authority_for_source(
+                runner,
+                BASE_CONFIG,
+                _Src("webhook:mon:d"),
+                "webhook",
+            )
+        )
+
+        assert resolved == []
+        assert has_override is True
+        assert failed is True

--- a/tests/gateway/test_webhook_runner_configuration_failures.py
+++ b/tests/gateway/test_webhook_runner_configuration_failures.py
@@ -1,0 +1,193 @@
+"""Runner handling for deterministic webhook constructor failures."""
+
+import asyncio
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.webhook import WebhookConfigurationError
+from gateway.platforms.webhook_ledger import WebhookLedgerConfigurationError
+from gateway.restart import GATEWAY_FATAL_CONFIG_EXIT_CODE
+from gateway.run import GatewayRunner
+
+
+def _webhook_config(tmp_path) -> GatewayConfig:
+    return GatewayConfig(
+        platforms={
+            Platform.WEBHOOK: PlatformConfig(
+                enabled=True,
+                extra={"host": "127.0.0.1", "port": 0, "routes": {}},
+            )
+        },
+        sessions_dir=tmp_path / "sessions",
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "failure",
+    [
+        WebhookConfigurationError("rate_limit must be a positive integer"),
+        WebhookLedgerConfigurationError(
+            "configured ledger limit conflicts with persisted authority"
+        ),
+    ],
+    ids=["typed-config", "persisted-ledger-config"],
+)
+async def test_primary_startup_parks_deterministic_webhook_constructor_failure(
+    monkeypatch,
+    tmp_path,
+    failure,
+):
+    """Immutable webhook constructor errors exit once instead of retrying."""
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    runner = GatewayRunner(_webhook_config(tmp_path))
+    status = MagicMock()
+    monkeypatch.setattr(runner, "_update_platform_runtime_status", status)
+
+    def fail_construction(_platform, _platform_config):
+        raise failure
+
+    monkeypatch.setattr(runner, "_create_adapter", fail_construction)
+
+    assert await runner.start() is True
+
+    assert runner.should_exit_cleanly is True
+    assert runner.exit_code == GATEWAY_FATAL_CONFIG_EXIT_CODE
+    assert Platform.WEBHOOK not in runner._failed_platforms
+    status.assert_called_once_with(
+        "webhook",
+        platform_state="fatal",
+        error_code="webhook_configuration_invalid",
+        error_message=str(failure),
+    )
+
+
+@pytest.mark.asyncio
+async def test_primary_startup_does_not_mask_untyped_constructor_failure(
+    monkeypatch,
+    tmp_path,
+):
+    """An unrelated constructor bug retains the startup fail-loud behavior."""
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    runner = GatewayRunner(_webhook_config(tmp_path))
+    status = MagicMock()
+    monkeypatch.setattr(runner, "_update_platform_runtime_status", status)
+
+    def fail_construction(_platform, _platform_config):
+        raise RuntimeError("unexpected webhook constructor bug")
+
+    monkeypatch.setattr(runner, "_create_adapter", fail_construction)
+
+    with pytest.raises(RuntimeError, match="unexpected webhook constructor bug"):
+        await runner.start()
+
+    assert Platform.WEBHOOK not in runner._failed_platforms
+    status.assert_not_called()
+
+
+def _reconnect_runner(tmp_path, failure):
+    runner = object.__new__(GatewayRunner)
+    config = _webhook_config(tmp_path)
+    runner.config = config
+    runner._running = True
+    runner._shutdown_event = asyncio.Event()
+    runner._draining = False
+    runner.adapters = {}
+    runner.delivery_router = MagicMock()
+    runner._failed_platforms = {
+        Platform.WEBHOOK: {
+            "config": config.platforms[Platform.WEBHOOK],
+            "attempts": 1,
+            "next_retry": time.monotonic() - 1,
+            "queued_at": time.monotonic(),
+        }
+    }
+    runner._create_adapter = MagicMock(side_effect=failure)
+    runner._update_platform_runtime_status = MagicMock()
+    return runner
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "failure",
+    [
+        WebhookConfigurationError("port must be an integer"),
+        WebhookLedgerConfigurationError(
+            "configured ledger limit conflicts with persisted authority"
+        ),
+    ],
+    ids=["typed-config", "persisted-ledger-config"],
+)
+async def test_reconnect_drops_deterministic_webhook_constructor_failure(
+    monkeypatch,
+    tmp_path,
+    failure,
+):
+    """Reconnect removes immutable config failures from its retry queue."""
+
+    runner = _reconnect_runner(tmp_path, failure)
+
+    def record_status(*args, **kwargs):
+        if kwargs.get("platform_state") == "fatal":
+            runner._running = False
+
+    runner._update_platform_runtime_status.side_effect = record_status
+
+    async def no_sleep(_delay):
+        return None
+
+    monkeypatch.setattr("gateway.run.asyncio.sleep", no_sleep)
+
+    await runner._platform_reconnect_watcher()
+
+    assert Platform.WEBHOOK not in runner._failed_platforms
+    assert Platform.WEBHOOK not in runner.adapters
+    runner._create_adapter.assert_called_once_with(
+        Platform.WEBHOOK,
+        runner.config.platforms[Platform.WEBHOOK],
+    )
+    runner._update_platform_runtime_status.assert_called_once_with(
+        "webhook",
+        platform_state="fatal",
+        error_code="webhook_configuration_invalid",
+        error_message=str(failure),
+    )
+
+
+@pytest.mark.asyncio
+async def test_reconnect_keeps_untyped_constructor_failure_retryable(
+    monkeypatch,
+    tmp_path,
+):
+    """Transient or unexpected exceptions retain the reconnect backoff path."""
+
+    failure = RuntimeError("temporary constructor dependency failure")
+    runner = _reconnect_runner(tmp_path, failure)
+
+    def record_status(*args, **kwargs):
+        if kwargs.get("platform_state") == "retrying":
+            runner._running = False
+
+    runner._update_platform_runtime_status.side_effect = record_status
+
+    async def no_sleep(_delay):
+        return None
+
+    monkeypatch.setattr("gateway.run.asyncio.sleep", no_sleep)
+
+    await runner._platform_reconnect_watcher()
+
+    queued = runner._failed_platforms[Platform.WEBHOOK]
+    assert queued["attempts"] == 2
+    assert queued["next_retry"] > time.monotonic()
+    runner._update_platform_runtime_status.assert_called_once_with(
+        "webhook",
+        platform_state="retrying",
+        error_code=None,
+        error_message=str(failure),
+    )

--- a/tests/gateway/test_webhook_script_execution_authority.py
+++ b/tests/gateway/test_webhook_script_execution_authority.py
@@ -368,13 +368,16 @@ def test_timeout_kills_descendant_that_ignores_sigterm(
             "from pathlib import Path\n"
             f"marker = Path({str(child_pid_file)!r})\n"
             f"subprocess.Popen([sys.executable, '-I', '-S', '-c', {child_source!r}])\n"
-            "deadline = time.monotonic() + 2\n"
+            "deadline = time.monotonic() + 4\n"
             "while not marker.exists() and time.monotonic() < deadline:\n"
             "    time.sleep(0.01)\n"
             "time.sleep(60)\n"
         ),
     )
-    processor.script_timeout_seconds = 1
+    # The canonical runner executes this process-heavy file beside many other
+    # subprocesses. Give the child enough time to install its SIGTERM handler
+    # and publish the PID before exercising the timeout kill path.
+    processor.script_timeout_seconds = 5
 
     started = time.monotonic()
     result = processor.run_prepared_script(prepared, {})

--- a/tests/gateway/test_webhook_script_execution_authority.py
+++ b/tests/gateway/test_webhook_script_execution_authority.py
@@ -1,0 +1,1772 @@
+"""Adversarial execution-authority tests for webhook filters and scripts."""
+
+from __future__ import annotations
+
+import json
+import mmap
+import os
+import shlex
+import signal
+import subprocess
+import sys
+import threading
+import time
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+import gateway.platforms.webhook_filters as webhook_filters
+from gateway.platforms.webhook_filters import (
+    BoundedFileSnapshotChanged,
+    MAX_FILTER_FILE_SNAPSHOT_BYTES,
+    MAX_SCRIPT_OUTPUT_STREAM_BYTES,
+    MAX_SCRIPT_SNAPSHOT_BYTES,
+    WebhookRouteProcessor,
+    WebhookScriptDisposition,
+    read_bounded_regular_file_snapshot,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+
+def _prepare(
+    tmp_path: Path,
+    *,
+    name: str,
+    source: str,
+) -> tuple[WebhookRouteProcessor, object, Path]:
+    scripts = tmp_path / "scripts"
+    scripts.mkdir(exist_ok=True)
+    script = scripts / name
+    script.write_text(source, encoding="utf-8")
+    processor = WebhookRouteProcessor(script_timeout_seconds=5)
+    prepared, error = processor.prepare_route_script(name)
+    if prepared is None and name.endswith((".sh", ".bash")):
+        pytest.skip(error or "bash is unavailable")
+    assert error is None
+    assert prepared is not None
+    return processor, prepared, script
+
+
+def test_python_script_never_rejoins_live_process_environment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for name in ("CUSTOM_WEBHOOK_SECRET", "BASH_ENV", "ENV", "PYTHONPATH"):
+        monkeypatch.setenv(name, f"before-{name}")
+    processor, prepared, _script = _prepare(
+        tmp_path,
+        name="environment.py",
+        source=(
+            "import json, os\n"
+            "names = ('CUSTOM_WEBHOOK_SECRET', 'BASH_ENV', 'ENV', 'PYTHONPATH')\n"
+            "result = {name: os.environ.get(name) for name in names}\n"
+            "result.update({\n"
+            "    'HOME': os.environ.get('HOME'),\n"
+            "    'HERMES_HOME': os.environ.get('HERMES_HOME'),\n"
+            "    'PATH': os.environ.get('PATH'),\n"
+            "    'cwd': os.getcwd(),\n"
+            "})\n"
+            "print(json.dumps(result))\n"
+        ),
+    )
+
+    for name in ("CUSTOM_WEBHOOK_SECRET", "BASH_ENV", "ENV", "PYTHONPATH"):
+        monkeypatch.setenv(name, f"after-{name}")
+    monkeypatch.setenv("PATH", str(tmp_path / "attacker-bin"))
+
+    result = processor.run_prepared_script(prepared, {})
+
+    assert result.disposition is WebhookScriptDisposition.CONTINUE
+    assert result.payload is not None
+    assert result.payload == {
+        "CUSTOM_WEBHOOK_SECRET": None,
+        "BASH_ENV": None,
+        "ENV": None,
+        "PYTHONPATH": None,
+        "HOME": result.payload["cwd"],
+        "HERMES_HOME": None,
+        "PATH": os.defpath,
+        "cwd": result.payload["cwd"],
+    }
+    assert not Path(result.payload["cwd"]).exists()
+
+
+def test_bash_script_ignores_late_startup_hooks_and_relative_helpers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    processor, prepared, script = _prepare(
+        tmp_path,
+        name="transform.sh",
+        source=(
+            "if [ -f ./helper.sh ]; then\n"
+            "  . ./helper.sh\n"
+            "else\n"
+            "  printf '%s\\n' '{\"shell\":\"clean\"}'\n"
+            "fi\n"
+        ),
+    )
+    marker = tmp_path / "startup-hook-ran"
+    hook = tmp_path / "injected-bash-env.sh"
+    hook.write_text(f"touch {shlex.quote(str(marker))}\n", encoding="utf-8")
+    (script.parent / "helper.sh").write_text(
+        "printf '%s\\n' '{\"shell\":\"helper-loaded\"}'\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("BASH_ENV", str(hook))
+    monkeypatch.setenv("ENV", str(hook))
+    monkeypatch.chdir(script.parent)
+
+    result = processor.run_prepared_script(prepared, {})
+
+    assert result.disposition is WebhookScriptDisposition.CONTINUE
+    assert result.payload == {"shell": "clean"}
+    assert not marker.exists()
+
+
+def test_python_script_ignores_replaced_cwd_helpers_and_pythonpath(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    helper_name = "webhook_mutated_helper_6f7c78"
+    processor, prepared, script = _prepare(
+        tmp_path,
+        name="isolated.py",
+        source=(
+            "import json, os\n"
+            "try:\n"
+            f"    __import__({helper_name!r})\n"
+            "except ModuleNotFoundError:\n"
+            "    helper = 'isolated'\n"
+            "else:\n"
+            "    helper = 'loaded'\n"
+            "print(json.dumps({\n"
+            "    'helper': helper,\n"
+            "    'cwd': os.getcwd(),\n"
+            "    'file': __file__,\n"
+            "}))\n"
+        ),
+    )
+
+    original_scripts = tmp_path / "scripts-original"
+    script.parent.rename(original_scripts)
+    replacement_scripts = tmp_path / "scripts"
+    replacement_scripts.mkdir()
+    (replacement_scripts / f"{helper_name}.py").write_text(
+        "raise RuntimeError('replacement cwd helper executed')\n",
+        encoding="utf-8",
+    )
+    attacker_path = tmp_path / "attacker-pythonpath"
+    attacker_path.mkdir()
+    (attacker_path / f"{helper_name}.py").write_text(
+        "raise RuntimeError('PYTHONPATH helper executed')\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("PYTHONPATH", str(attacker_path))
+    monkeypatch.chdir(replacement_scripts)
+
+    result = processor.run_prepared_script(prepared, {})
+
+    assert result.disposition is WebhookScriptDisposition.CONTINUE
+    assert result.payload is not None
+    assert result.payload["helper"] == "isolated"
+    assert result.payload["file"].startswith("hermes-webhook-script:")
+    assert str(script) not in result.payload["file"]
+    assert result.payload["cwd"] not in {
+        str(original_scripts),
+        str(replacement_scripts),
+        str(attacker_path),
+    }
+    assert not Path(result.payload["cwd"]).exists()
+
+
+def test_python_script_cannot_reopen_replaced_original_file(
+    tmp_path: Path,
+) -> None:
+    marker = tmp_path / "python-replacement-ran"
+    processor, prepared, script = _prepare(
+        tmp_path,
+        name="self-reopen.py",
+        source=(
+            "from pathlib import Path\n"
+            "try:\n"
+            "    replacement = Path(__file__).read_text(encoding='utf-8')\n"
+            "except OSError:\n"
+            "    print('{\"reopened\":false}')\n"
+            "else:\n"
+            "    exec(compile(replacement, __file__, 'exec'))\n"
+        ),
+    )
+    script.write_text(
+        "from pathlib import Path\n"
+        f"Path({str(marker)!r}).write_text('ran', encoding='utf-8')\n"
+        "print('{\"reopened\":true}')\n",
+        encoding="utf-8",
+    )
+
+    result = processor.run_prepared_script(prepared, {})
+
+    assert result.disposition is WebhookScriptDisposition.CONTINUE
+    assert result.payload == {"reopened": False}
+    assert not marker.exists()
+
+
+def test_python_snapshot_preserves_module_preamble_semantics(
+    tmp_path: Path,
+) -> None:
+    processor, prepared, _script = _prepare(
+        tmp_path,
+        name="future-import.py",
+        source=(
+            '"""frozen transform docstring"""\n'
+            "from __future__ import annotations\n"
+            "import json\n"
+            "def transform(value: MissingType) -> MissingResult:\n"
+            "    return value\n"
+            "print(json.dumps({\n"
+            "    'doc': __doc__,\n"
+            "    'annotation': transform.__annotations__['value'],\n"
+            "}))\n"
+        ),
+    )
+
+    result = processor.run_prepared_script(prepared, {})
+
+    assert result.disposition is WebhookScriptDisposition.CONTINUE
+    assert result.payload == {
+        "doc": "frozen transform docstring",
+        "annotation": "MissingType",
+    }
+
+
+def test_bash_script_cannot_source_replaced_original_file(
+    tmp_path: Path,
+) -> None:
+    marker = tmp_path / "bash-replacement-ran"
+    processor, prepared, script = _prepare(
+        tmp_path,
+        name="self-source.sh",
+        source=(
+            'if [ -r "$0" ]; then\n'
+            '  . "$0"\n'
+            "else\n"
+            "  printf '%s\\n' '{\"reopened\":false}'\n"
+            "fi\n"
+        ),
+    )
+    script.write_text(
+        f"touch {shlex.quote(str(marker))}\nprintf '%s\\n' '{{\"reopened\":true}}'\n",
+        encoding="utf-8",
+    )
+
+    result = processor.run_prepared_script(prepared, {})
+
+    assert result.disposition is WebhookScriptDisposition.CONTINUE
+    assert result.payload == {"reopened": False}
+    assert not marker.exists()
+
+
+def test_python_script_has_no_mutable_site_or_pythonpath_imports(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pythonpath_module = "webhook_pythonpath_helper_84ea23"
+    user_site_module = "webhook_user_site_helper_84ea23"
+    pythonpath = tmp_path / "late-pythonpath"
+    pythonpath.mkdir()
+    (pythonpath / f"{pythonpath_module}.py").write_text(
+        "raise RuntimeError('PYTHONPATH helper ran')\n",
+        encoding="utf-8",
+    )
+    user_site = (
+        tmp_path
+        / ".local"
+        / "lib"
+        / f"python{sys.version_info.major}.{sys.version_info.minor}"
+        / "site-packages"
+    )
+    user_site.mkdir(parents=True)
+    (user_site / f"{user_site_module}.py").write_text(
+        "raise RuntimeError('user-site helper ran')\n",
+        encoding="utf-8",
+    )
+    processor, prepared, _script = _prepare(
+        tmp_path,
+        name="site-isolated.py",
+        source=(
+            "import importlib, json, sys\n"
+            "def probe(name):\n"
+            "    try:\n"
+            "        importlib.import_module(name)\n"
+            "    except ModuleNotFoundError:\n"
+            "        return 'blocked'\n"
+            "    return 'loaded'\n"
+            f"names = ({pythonpath_module!r}, {user_site_module!r}, 'aiohttp')\n"
+            "print(json.dumps({\n"
+            "    'isolated': sys.flags.isolated,\n"
+            "    'no_site': sys.flags.no_site,\n"
+            "    'imports': {name: probe(name) for name in names},\n"
+            "}))\n"
+        ),
+    )
+    monkeypatch.setenv("PYTHONPATH", str(pythonpath))
+
+    result = processor.run_prepared_script(prepared, {})
+
+    assert result.disposition is WebhookScriptDisposition.CONTINUE
+    assert result.payload == {
+        "isolated": 1,
+        "no_site": 1,
+        "imports": {
+            pythonpath_module: "blocked",
+            user_site_module: "blocked",
+            "aiohttp": "blocked",
+        },
+    }
+
+
+def _pid_is_effectively_alive(pid: int) -> bool:
+    proc_stat = Path(f"/proc/{pid}/stat")
+    try:
+        fields = proc_stat.read_text(encoding="utf-8").split()
+    except OSError:
+        fields = []
+    if len(fields) >= 3 and fields[2] == "Z":
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+@pytest.mark.skipif(os.name != "posix", reason="process groups require POSIX")
+@pytest.mark.live_system_guard_bypass
+def test_timeout_kills_descendant_that_ignores_sigterm(
+    tmp_path: Path,
+) -> None:
+    child_pid_file = tmp_path / "sigterm-ignoring-child.pid"
+    child_source = (
+        "import os, signal, time\n"
+        "from pathlib import Path\n"
+        "signal.signal(signal.SIGTERM, signal.SIG_IGN)\n"
+        f"Path({str(child_pid_file)!r}).write_text(str(os.getpid()), encoding='utf-8')\n"
+        "time.sleep(60)\n"
+    )
+    processor, prepared, _script = _prepare(
+        tmp_path,
+        name="spawn-child.py",
+        source=(
+            "import subprocess, sys, time\n"
+            "from pathlib import Path\n"
+            f"marker = Path({str(child_pid_file)!r})\n"
+            f"subprocess.Popen([sys.executable, '-I', '-S', '-c', {child_source!r}])\n"
+            "deadline = time.monotonic() + 2\n"
+            "while not marker.exists() and time.monotonic() < deadline:\n"
+            "    time.sleep(0.01)\n"
+            "time.sleep(60)\n"
+        ),
+    )
+    processor.script_timeout_seconds = 1
+
+    started = time.monotonic()
+    result = processor.run_prepared_script(prepared, {})
+    elapsed = time.monotonic() - started
+
+    assert result.disposition is WebhookScriptDisposition.INDETERMINATE
+    assert "timed out" in str(result.error)
+    # The canonical runner executes this process-heavy file beside 17 other
+    # subprocesses.  Preserve a hard bound that catches the 60-second leak
+    # without treating scheduler contention as a product failure.
+    assert elapsed < 20
+    assert child_pid_file.exists()
+    child_pid = int(child_pid_file.read_text(encoding="utf-8"))
+    deadline = time.monotonic() + 2
+    try:
+        while _pid_is_effectively_alive(child_pid) and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert not _pid_is_effectively_alive(child_pid)
+    finally:
+        if _pid_is_effectively_alive(child_pid):
+            os.kill(child_pid, signal.SIGKILL)
+
+
+@pytest.mark.skipif(os.name != "posix", reason="process groups require POSIX")
+@pytest.mark.live_system_guard_bypass
+def test_normal_exit_kills_descendant_that_closed_output_pipes(
+    tmp_path: Path,
+) -> None:
+    child_pid_file = tmp_path / "normal-exit-child.pid"
+    child_source = (
+        "import os, signal, time\n"
+        "from pathlib import Path\n"
+        "signal.signal(signal.SIGTERM, signal.SIG_IGN)\n"
+        f"Path({str(child_pid_file)!r}).write_text(str(os.getpid()), encoding='utf-8')\n"
+        "time.sleep(60)\n"
+    )
+    processor, prepared, _script = _prepare(
+        tmp_path,
+        name="exit-after-child.py",
+        source=(
+            "import subprocess, sys, time\n"
+            "from pathlib import Path\n"
+            f"marker = Path({str(child_pid_file)!r})\n"
+            "subprocess.Popen(\n"
+            f"    [sys.executable, '-I', '-S', '-c', {child_source!r}],\n"
+            "    stdin=subprocess.DEVNULL,\n"
+            "    stdout=subprocess.DEVNULL,\n"
+            "    stderr=subprocess.DEVNULL,\n"
+            ")\n"
+            "deadline = time.monotonic() + 2\n"
+            "while not marker.exists() and time.monotonic() < deadline:\n"
+            "    time.sleep(0.01)\n"
+            "print('{}')\n"
+        ),
+    )
+
+    started = time.monotonic()
+    result = processor.run_prepared_script(prepared, {})
+    elapsed = time.monotonic() - started
+
+    assert result.disposition is WebhookScriptDisposition.CONTINUE
+    assert result.payload == {}
+    assert elapsed < 2
+    assert child_pid_file.exists()
+    child_pid = int(child_pid_file.read_text(encoding="utf-8"))
+    deadline = time.monotonic() + 2
+    try:
+        while _pid_is_effectively_alive(child_pid) and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert not _pid_is_effectively_alive(child_pid)
+    finally:
+        if _pid_is_effectively_alive(child_pid):
+            os.kill(child_pid, signal.SIGKILL)
+
+
+def test_prepared_interpreter_contract_cannot_be_substituted(
+    tmp_path: Path,
+) -> None:
+    marker = tmp_path / "substituted-interpreter-ran"
+    processor, prepared, _script = _prepare(
+        tmp_path,
+        name="exact.py",
+        source=(
+            "from pathlib import Path\n"
+            f"Path({str(marker)!r}).write_text('ran')\n"
+            "print('{}')\n"
+        ),
+    )
+
+    result = processor.run_prepared_script(
+        replace(prepared, interpreter_kind="bash"),
+        {},
+    )
+
+    assert result.disposition is WebhookScriptDisposition.FAILED
+    assert "snapshot digest" in str(result.error)
+    assert not marker.exists()
+
+
+def _write_fifo_once(path: Path) -> None:
+    try:
+        fd = os.open(path, os.O_WRONLY | getattr(os, "O_NONBLOCK", 0))
+    except OSError:
+        return
+    try:
+        os.write(fd, b"\n")
+    finally:
+        os.close(fd)
+
+
+@pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="FIFO requires os.mkfifo")
+def test_compatibility_filter_file_fifo_fails_promptly(
+    tmp_path: Path,
+) -> None:
+    fifo = tmp_path / "filter.fifo"
+    os.mkfifo(fifo)
+    escape = threading.Timer(2.0, _write_fifo_once, args=(fifo,))
+    escape.daemon = True
+    escape.start()
+    started = time.monotonic()
+    try:
+        values = webhook_filters._load_filter_file_values(str(fifo))
+    finally:
+        escape.cancel()
+
+    assert time.monotonic() - started < 1.0
+    assert values is None
+
+
+@pytest.mark.skipif(os.name != "posix", reason="device-file check is POSIX-only")
+def test_compatibility_filter_file_device_fails_closed() -> None:
+    assert webhook_filters._load_filter_file_values(os.devnull) is None
+
+
+def test_compatibility_filter_file_oversize_fails_closed(
+    tmp_path: Path,
+) -> None:
+    oversized = tmp_path / "oversized-filter.json"
+    oversized.write_bytes(b"x" * (MAX_FILTER_FILE_SNAPSHOT_BYTES + 1))
+
+    assert webhook_filters._load_filter_file_values(str(oversized)) is None
+
+
+def test_compatibility_filter_file_deep_json_fails_closed(
+    tmp_path: Path,
+) -> None:
+    deeply_nested = tmp_path / "deep-filter.json"
+    deeply_nested.write_text("[" * 2000 + "0" + "]" * 2000, encoding="utf-8")
+
+    assert webhook_filters._load_filter_file_values(str(deeply_nested)) is None
+
+
+def test_compatibility_filter_file_symlink_to_regular_remains_supported(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "filter-values.json"
+    target.write_text('["one", "two"]', encoding="utf-8")
+    link = tmp_path / "filter-link.json"
+    try:
+        link.symlink_to(target)
+    except OSError as exc:
+        pytest.skip(f"symlink creation is unavailable: {exc}")
+
+    assert webhook_filters._load_filter_file_values(str(link)) == ["one", "two"]
+
+
+def test_bounded_snapshot_rejects_file_changed_during_read(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target = tmp_path / "changing-filter.json"
+    target.write_bytes(b'["before"]')
+    real_read = webhook_filters.os.read
+    changed = False
+
+    def mutate_after_first_read(fd: int, size: int) -> bytes:
+        nonlocal changed
+        chunk = real_read(fd, size)
+        if chunk and not changed:
+            changed = True
+            with target.open("ab") as handle:
+                handle.write(b" ")
+                handle.flush()
+                os.fsync(handle.fileno())
+        return chunk
+
+    monkeypatch.setattr(webhook_filters.os, "read", mutate_after_first_read)
+
+    with pytest.raises(BoundedFileSnapshotChanged, match="changed while being read"):
+        read_bounded_regular_file_snapshot(target, max_bytes=1024)
+
+
+def test_bounded_snapshot_double_read_detects_metadata_invisible_rewrite(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target = tmp_path / "metadata-invisible.bin"
+    target.write_bytes(b"a" * (128 * 1024))
+    real_read = webhook_filters.os.read
+    changed = False
+
+    def rewrite_after_first_chunk(fd: int, size: int) -> bytes:
+        nonlocal changed
+        chunk = real_read(fd, size)
+        if chunk and not changed:
+            changed = True
+            target.write_bytes(b"b" * (128 * 1024))
+        return chunk
+
+    monkeypatch.setattr(webhook_filters.os, "read", rewrite_after_first_chunk)
+    monkeypatch.setattr(webhook_filters, "_stat_identity", lambda _value: (1,))
+
+    with pytest.raises(BoundedFileSnapshotChanged, match="changed while being read"):
+        read_bounded_regular_file_snapshot(target, max_bytes=128 * 1024)
+
+
+def test_bounded_snapshot_double_read_rejects_mmap_torn_content(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target = tmp_path / "mmap-changing.bin"
+    target.write_bytes(b"a" * (128 * 1024))
+    real_read = webhook_filters.os.read
+    changed = False
+
+    with target.open("r+b") as handle, mmap.mmap(handle.fileno(), 0) as mapping:
+        mapping[0:1] = b"a"
+
+        def mutate_after_first_chunk(fd: int, size: int) -> bytes:
+            nonlocal changed
+            chunk = real_read(fd, size)
+            if chunk and not changed:
+                changed = True
+                mapping[:] = b"b" * len(mapping)
+            return chunk
+
+        monkeypatch.setattr(webhook_filters.os, "read", mutate_after_first_chunk)
+        monkeypatch.setattr(webhook_filters, "_stat_identity", lambda _value: (1,))
+
+        with pytest.raises(
+            BoundedFileSnapshotChanged,
+            match="changed while being read",
+        ):
+            read_bounded_regular_file_snapshot(target, max_bytes=128 * 1024)
+
+
+def test_regex_worker_uses_isolated_minimal_environment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    real_popen = webhook_filters.subprocess.Popen
+
+    def capture_popen(argv: list[str], **kwargs: object):
+        captured["argv"] = argv
+        captured.update(kwargs)
+        return real_popen(argv, **kwargs)
+
+    monkeypatch.setenv("REGEX_WORKER_SECRET", "must-not-leak")
+    monkeypatch.setenv("LD_PRELOAD", str(tmp_path / "attacker.so"))
+    monkeypatch.setenv("PYTHONPATH", str(tmp_path / "attacker-pythonpath"))
+    monkeypatch.setattr(webhook_filters.subprocess, "Popen", capture_popen)
+
+    assert webhook_filters._bounded_regex_search("^safe$", "safe") is True
+
+    argv = captured["argv"]
+    assert isinstance(argv, list)
+    assert argv[1:6] == ["-I", "-S", "-X", "utf8", "-c"]
+    if os.name == "posix":
+        assert argv[0].startswith(("/proc/self/fd/", "/dev/fd/"))
+        pass_fds = captured["pass_fds"]
+        assert isinstance(pass_fds, tuple)
+        assert len(pass_fds) == 1
+        assert argv[0].endswith(f"/{pass_fds[0]}")
+    else:
+        assert "pass_fds" not in captured
+    environment = captured["env"]
+    assert isinstance(environment, dict)
+    assert "REGEX_WORKER_SECRET" not in environment
+    assert "LD_PRELOAD" not in environment
+    assert "PYTHONPATH" not in environment
+    cwd = captured["cwd"]
+    assert isinstance(cwd, str)
+    assert environment["HOME"] == cwd
+    assert not Path(cwd).exists()
+
+
+def test_script_resolution_race_cannot_follow_outside_root_symlink(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scripts = tmp_path / "scripts"
+    scripts.mkdir()
+    script = scripts / "route.py"
+    script.write_text('print(\'{"origin":"inside"}\')\n', encoding="utf-8")
+    outside = tmp_path / "outside.py"
+    outside.write_text('print(\'{"origin":"outside"}\')\n', encoding="utf-8")
+    original_resolver = webhook_filters._resolve_script_path
+
+    def replace_after_resolution(value: object):
+        resolved, error = original_resolver(value)
+        assert resolved == script
+        assert error is None
+        script.unlink()
+        try:
+            script.symlink_to(outside)
+        except OSError as exc:
+            pytest.skip(f"symlink creation is unavailable: {exc}")
+        return resolved, error
+
+    monkeypatch.setattr(
+        webhook_filters,
+        "_resolve_script_path",
+        replace_after_resolution,
+    )
+
+    prepared, error = WebhookRouteProcessor().prepare_route_script("route.py")
+
+    assert prepared is None
+    assert "cannot be read" in str(error)
+
+
+def test_script_root_symlink_loop_race_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scripts = tmp_path / "scripts"
+    scripts.mkdir()
+    script = scripts / "route.py"
+    script.write_text("print('{}')\n", encoding="utf-8")
+    original_resolver = webhook_filters._resolve_script_path
+
+    def loop_root_after_resolution(value: object):
+        resolved, error = original_resolver(value)
+        assert resolved == script
+        assert error is None
+        scripts.rename(tmp_path / "original-scripts")
+        try:
+            scripts.symlink_to("scripts", target_is_directory=True)
+        except OSError as exc:
+            pytest.skip(f"symlink creation is unavailable: {exc}")
+        return resolved, error
+
+    monkeypatch.setattr(
+        webhook_filters,
+        "_resolve_script_path",
+        loop_root_after_resolution,
+    )
+
+    prepared, error = WebhookRouteProcessor().prepare_route_script("route.py")
+
+    assert prepared is None
+    assert "root cannot be resolved" in str(error)
+
+
+def test_bash_resolution_ignores_mutable_process_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    default_bash = webhook_filters.shutil.which("bash", path=os.defpath)
+    if default_bash is None:
+        pytest.skip("bash is unavailable on the platform default path")
+    attacker_bin = tmp_path / "attacker-bin"
+    attacker_bin.mkdir()
+    attacker_bash = attacker_bin / "bash"
+    attacker_bash.write_text(
+        "#!/bin/sh\nprintf '%s\\n' '{\"interpreter\":\"attacker\"}'\n",
+        encoding="utf-8",
+    )
+    attacker_bash.chmod(0o700)
+    monkeypatch.setenv("PATH", str(attacker_bin))
+
+    processor, prepared, _script = _prepare(
+        tmp_path,
+        name="route.sh",
+        source="printf '%s\\n' '{\"interpreter\":\"default\"}'\n",
+    )
+
+    assert prepared.interpreter != str(attacker_bash)
+    result = processor.run_prepared_script(prepared, {})
+    assert result.disposition is WebhookScriptDisposition.CONTINUE
+    assert result.payload == {"interpreter": "default"}
+
+
+def test_bash_interpreter_symlink_loop_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    interpreter = tmp_path / "loop-bash"
+    try:
+        interpreter.symlink_to(interpreter.name)
+    except OSError as exc:
+        pytest.skip(f"symlink creation is unavailable: {exc}")
+    monkeypatch.setattr(
+        webhook_filters.shutil,
+        "which",
+        lambda _name, path=None: str(interpreter),
+    )
+    scripts = tmp_path / "scripts"
+    scripts.mkdir()
+    (scripts / "route.sh").write_text("printf '{}\\n'\n", encoding="utf-8")
+
+    prepared, error = WebhookRouteProcessor().prepare_route_script("route.sh")
+
+    assert prepared is None
+    assert "interpreter is unavailable" in str(error)
+
+
+@pytest.mark.skipif(os.name != "posix", reason="execute-by-fd requires POSIX")
+def test_interpreter_replacement_at_spawn_executes_verified_descriptor(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_bash = tmp_path / "frozen-bash"
+    fake_bash.write_text(
+        "#!/bin/sh\nprintf '%s\\n' '{\"interpreter\":\"v1\"}'\n",
+        encoding="utf-8",
+    )
+    fake_bash.chmod(0o700)
+    monkeypatch.setattr(
+        webhook_filters.shutil,
+        "which",
+        lambda _name, path=None: str(fake_bash),
+    )
+    processor, prepared, _script = _prepare(
+        tmp_path,
+        name="route.sh",
+        source="printf '%s\\n' '{\"source\":\"route\"}'\n",
+    )
+    real_popen = webhook_filters.subprocess.Popen
+    replaced = False
+
+    def replace_then_spawn(*args, **kwargs):
+        nonlocal replaced
+        if not replaced:
+            replacement = tmp_path / "replacement-bash"
+            replacement.write_text(
+                "#!/bin/sh\nprintf '%s\\n' '{\"interpreter\":\"v2\"}'\n",
+                encoding="utf-8",
+            )
+            replacement.chmod(0o700)
+            os.replace(replacement, fake_bash)
+            replaced = True
+        return real_popen(*args, **kwargs)
+
+    monkeypatch.setattr(webhook_filters.subprocess, "Popen", replace_then_spawn)
+
+    result = processor.run_prepared_script(prepared, {})
+
+    assert result.disposition is WebhookScriptDisposition.CONTINUE
+    assert result.payload == {"interpreter": "v1"}
+    rejected = processor.run_prepared_script(prepared, {})
+    assert rejected.disposition is WebhookScriptDisposition.FAILED
+    assert "interpreter content changed" in str(rejected.error)
+
+
+@pytest.mark.skipif(os.name != "posix", reason="execute-by-fd requires POSIX")
+def test_interpreter_in_place_overwrite_at_spawn_executes_sealed_snapshot(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_bash = tmp_path / "mutable-bash"
+    fake_bash.write_text(
+        "#!/bin/sh\nprintf '%s\\n' '{\"interpreter\":\"v1\"}'\n",
+        encoding="utf-8",
+    )
+    fake_bash.chmod(0o700)
+    monkeypatch.setattr(
+        webhook_filters.shutil,
+        "which",
+        lambda _name, path=None: str(fake_bash),
+    )
+    processor, prepared, _script = _prepare(
+        tmp_path,
+        name="route.sh",
+        source="printf '%s\\n' '{\"source\":\"route\"}'\n",
+    )
+    real_popen = webhook_filters.subprocess.Popen
+    overwritten = False
+
+    def overwrite_then_spawn(*args, **kwargs):
+        nonlocal overwritten
+        if not overwritten:
+            fake_bash.write_text(
+                "#!/bin/sh\nprintf '%s\\n' '{\"interpreter\":\"v2\"}'\n",
+                encoding="utf-8",
+            )
+            fake_bash.chmod(0o700)
+            overwritten = True
+        return real_popen(*args, **kwargs)
+
+    monkeypatch.setattr(webhook_filters.subprocess, "Popen", overwrite_then_spawn)
+
+    result = processor.run_prepared_script(prepared, {})
+
+    assert result.disposition is WebhookScriptDisposition.CONTINUE
+    assert result.payload == {"interpreter": "v1"}
+
+
+@pytest.mark.skipif(os.name != "posix", reason="execute-by-fd requires POSIX")
+def test_no_memfd_interpreter_snapshot_fallback_executes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    if not hasattr(webhook_filters.os, "memfd_create"):
+        pytest.skip("memfd fallback is already active")
+    monkeypatch.setattr(
+        webhook_filters.os,
+        "memfd_create",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("unsupported")),
+    )
+    processor, prepared, _script = _prepare(
+        tmp_path,
+        name="fallback.sh",
+        source="printf '%s\\n' '{\"fallback\":true}'\n",
+    )
+
+    result = processor.run_prepared_script(prepared, {})
+
+    assert result.disposition is WebhookScriptDisposition.CONTINUE
+    assert result.payload == {"fallback": True}
+
+
+def test_full_size_python_snapshot_executes_without_argv_expansion(
+    tmp_path: Path,
+) -> None:
+    tail = 'print(\'{"size":"accepted"}\')\n'
+    source = "\n" * (MAX_SCRIPT_SNAPSHOT_BYTES - len(tail)) + tail
+    assert len(source.encode("utf-8")) == MAX_SCRIPT_SNAPSHOT_BYTES
+    scripts = tmp_path / "scripts"
+    scripts.mkdir()
+    (scripts / "full-size.py").write_bytes(source.encode("utf-8"))
+    processor = WebhookRouteProcessor(script_timeout_seconds=5)
+    prepared, error = processor.prepare_route_script("full-size.py")
+    assert error is None
+    assert prepared is not None
+
+    result = processor.run_prepared_script(prepared, {})
+
+    assert result.disposition is WebhookScriptDisposition.CONTINUE
+    assert result.payload == {"size": "accepted"}
+
+
+@pytest.mark.live_system_guard_bypass
+def test_cancellation_event_kills_running_script_promptly(
+    tmp_path: Path,
+) -> None:
+    pid_file = tmp_path / "cancelled-script.pid"
+    processor, prepared, _script = _prepare(
+        tmp_path,
+        name="cancel.py",
+        source=(
+            "import os, time\n"
+            "from pathlib import Path\n"
+            f"Path({str(pid_file)!r}).write_text(str(os.getpid()), encoding='utf-8')\n"
+            "time.sleep(60)\n"
+        ),
+    )
+    cancellation_event = threading.Event()
+    observed: dict[str, object] = {}
+
+    def execute() -> None:
+        observed["result"] = processor.run_prepared_script(
+            prepared,
+            {},
+            cancellation_event=cancellation_event,
+        )
+
+    worker = threading.Thread(target=execute)
+    worker.start()
+    deadline = time.monotonic() + 5
+    pid_text = ""
+    while time.monotonic() < deadline:
+        try:
+            pid_text = pid_file.read_text(encoding="utf-8").strip()
+        except FileNotFoundError:
+            pass
+        if pid_text:
+            break
+        time.sleep(0.01)
+    assert pid_text
+    pid = int(pid_text)
+    cancellation_event.set()
+    worker.join(timeout=3)
+
+    assert not worker.is_alive()
+    result = observed["result"]
+    assert result.disposition is WebhookScriptDisposition.INDETERMINATE
+    assert "cancelled" in str(result.error)
+    assert not _pid_is_effectively_alive(pid)
+
+
+@pytest.mark.live_system_guard_bypass
+def test_cancellation_after_leader_exit_is_still_indeterminate(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    processor, prepared, _script = _prepare(
+        tmp_path,
+        name="fast-exit.py",
+        source="print('{}')\n",
+    )
+    cancellation_event = threading.Event()
+    reaped = threading.Event()
+    release = threading.Event()
+    observed: dict[str, object] = {}
+    real_reap = webhook_filters._reap_finished_script_process_group
+
+    def gate_after_reap(process) -> None:
+        real_reap(process)
+        reaped.set()
+        assert release.wait(timeout=3)
+
+    monkeypatch.setattr(
+        webhook_filters,
+        "_reap_finished_script_process_group",
+        gate_after_reap,
+    )
+
+    worker = threading.Thread(
+        target=lambda: observed.setdefault(
+            "result",
+            processor.run_prepared_script(
+                prepared,
+                {},
+                cancellation_event=cancellation_event,
+            ),
+        )
+    )
+    worker.start()
+    assert reaped.wait(timeout=3)
+    cancellation_event.set()
+    release.set()
+    worker.join(timeout=3)
+
+    assert not worker.is_alive()
+    result = observed["result"]
+    assert result.disposition is WebhookScriptDisposition.INDETERMINATE
+    assert "cancelled" in str(result.error)
+
+
+def test_cancellation_during_input_handoff_prevents_spawn(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    processor, prepared, _script = _prepare(
+        tmp_path,
+        name="cancel-before-spawn.py",
+        source="print('{}')\n",
+    )
+    cancellation_event = threading.Event()
+    handoff_started = threading.Event()
+    release = threading.Event()
+    observed: dict[str, object] = {}
+    real_write_all = webhook_filters._write_all_to_fd
+
+    def gated_write(fd: int, content: bytes) -> None:
+        handoff_started.set()
+        assert release.wait(timeout=3)
+        real_write_all(fd, content)
+
+    def unexpected_spawn(*_args, **_kwargs):
+        raise AssertionError("cancelled script was spawned")
+
+    monkeypatch.setattr(webhook_filters, "_write_all_to_fd", gated_write)
+    monkeypatch.setattr(webhook_filters.subprocess, "Popen", unexpected_spawn)
+    worker = threading.Thread(
+        target=lambda: observed.setdefault(
+            "result",
+            processor.run_prepared_script(
+                prepared,
+                {"content": "x" * 128_000},
+                cancellation_event=cancellation_event,
+            ),
+        )
+    )
+    worker.start()
+    assert handoff_started.wait(timeout=3)
+    cancellation_event.set()
+    release.set()
+    worker.join(timeout=3)
+
+    assert not worker.is_alive()
+    result = observed["result"]
+    assert result.disposition is WebhookScriptDisposition.INDETERMINATE
+    assert "cancelled" in str(result.error)
+
+
+@pytest.mark.parametrize(
+    ("pattern", "value"),
+    [("\ud800", "safe"), ("safe", "\ud800")],
+)
+def test_regex_lone_surrogate_fails_closed(pattern: str, value: str) -> None:
+    assert webhook_filters._bounded_regex_search(pattern, value) is None
+
+
+@pytest.mark.parametrize(
+    "value",
+    [["\ud800"], {"nested": "\ud800"}],
+)
+def test_regex_nested_lone_surrogate_fails_closed(value: object) -> None:
+    assert not WebhookRouteProcessor().filter_matches(
+        {"field": "value", "regex": r"ud800"},
+        {"value": value},
+        "push",
+        {},
+    )
+
+
+def test_regex_worker_preserves_non_ascii_unicode_semantics() -> None:
+    assert webhook_filters._bounded_regex_search(r"^\w+$", "é") is True
+
+
+@pytest.mark.skipif(os.name != "posix", reason="execute-by-fd requires POSIX")
+def test_regex_interpreter_replacement_at_spawn_uses_verified_descriptor(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    interpreter_link = tmp_path / "regex-python"
+    try:
+        interpreter_link.symlink_to(Path(sys.executable).resolve())
+    except OSError as exc:
+        pytest.skip(f"symlink creation is unavailable: {exc}")
+    marker = tmp_path / "replacement-interpreter-ran"
+    replacement = tmp_path / "replacement-python"
+    replacement.write_text(
+        f"#!/bin/sh\ntouch {shlex.quote(str(marker))}\nprintf 1\n",
+        encoding="utf-8",
+    )
+    replacement.chmod(0o700)
+    monkeypatch.setattr(
+        webhook_filters,
+        "_REGEX_INTERPRETER_PATH",
+        str(interpreter_link),
+    )
+    real_popen = webhook_filters.subprocess.Popen
+
+    def replace_then_popen(*args, **kwargs):
+        os.replace(replacement, interpreter_link)
+        return real_popen(*args, **kwargs)
+
+    monkeypatch.setattr(webhook_filters.subprocess, "Popen", replace_then_popen)
+
+    assert webhook_filters._bounded_regex_search("does-not-match", "safe") is False
+    assert not marker.exists()
+
+
+def test_regex_mutable_launch_path_is_not_reopened_before_call(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    marker = tmp_path / "precall-replacement-ran"
+    replacement = tmp_path / "replacement-python"
+    replacement.write_text(
+        f"#!/bin/sh\ntouch {shlex.quote(str(marker))}\nprintf 1\n",
+        encoding="utf-8",
+    )
+    replacement.chmod(0o700)
+    monkeypatch.setattr(
+        webhook_filters,
+        "_REGEX_INTERPRETER_PATH",
+        str(replacement),
+    )
+
+    assert webhook_filters._bounded_regex_search("does-not-match", "safe") is False
+    assert not marker.exists()
+
+
+def test_regex_retained_interpreter_failure_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def unexpected_spawn(*_args, **_kwargs):
+        raise AssertionError("regex worker spawned without interpreter authority")
+
+    monkeypatch.setattr(webhook_filters, "_REGEX_INTERPRETER_FD", -1)
+    monkeypatch.setattr(webhook_filters.subprocess, "Popen", unexpected_spawn)
+
+    assert webhook_filters._bounded_regex_search("safe", "safe") is None
+
+
+def test_regex_nodes_do_not_rehash_interpreter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def unexpected_rehash(*_args, **_kwargs):
+        raise AssertionError("regex node rehashed the retained interpreter")
+
+    monkeypatch.setattr(
+        webhook_filters,
+        "_open_stable_regular_file_digest",
+        unexpected_rehash,
+    )
+
+    assert webhook_filters._bounded_regex_search("safe", "safe") is True
+    assert webhook_filters._bounded_regex_search("other", "safe") is False
+
+
+def test_regex_worker_startup_delay_is_not_charged_to_match_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        webhook_filters,
+        "_REGEX_WORKER",
+        "import time\ntime.sleep(0.25)\n" + webhook_filters._REGEX_WORKER,
+    )
+
+    assert webhook_filters._bounded_regex_search(r"^safe$", "safe") is True
+
+
+def test_regex_worker_match_delay_exceeds_post_ready_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    input_line = "pattern, value = json.load(sys.stdin)\n"
+    assert input_line in webhook_filters._REGEX_WORKER
+    monkeypatch.setattr(
+        webhook_filters,
+        "_REGEX_WORKER",
+        webhook_filters._REGEX_WORKER.replace(
+            input_line,
+            input_line + "import time\ntime.sleep(0.25)\n",
+        ),
+    )
+    started = time.monotonic()
+
+    assert webhook_filters._bounded_regex_search(r"^safe$", "safe") is None
+    assert time.monotonic() - started < 1.0
+
+
+def test_regex_worker_startup_deadline_is_bounded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        webhook_filters,
+        "FILTER_REGEX_STARTUP_TIMEOUT_SECONDS",
+        0.05,
+    )
+    monkeypatch.setattr(
+        webhook_filters,
+        "_REGEX_WORKER",
+        "import time\ntime.sleep(0.25)\n" + webhook_filters._REGEX_WORKER,
+    )
+    started = time.monotonic()
+
+    assert webhook_filters._bounded_regex_search(r"^safe$", "safe") is None
+    assert time.monotonic() - started < 1.0
+
+
+def test_regex_timeout_reaps_worker_before_working_directory_cleanup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    input_line = "pattern, value = json.load(sys.stdin)\n"
+    monkeypatch.setattr(
+        webhook_filters,
+        "_REGEX_WORKER",
+        webhook_filters._REGEX_WORKER.replace(
+            input_line,
+            input_line + "import time\ntime.sleep(0.25)\n",
+        ),
+    )
+    real_popen = webhook_filters.subprocess.Popen
+    real_temporary_directory = webhook_filters.tempfile.TemporaryDirectory
+    spawned: dict[str, subprocess.Popen[bytes]] = {}
+    cleanup_calls = 0
+
+    def capture_popen(*args, **kwargs):
+        process = real_popen(*args, **kwargs)
+        spawned["process"] = process
+        return process
+
+    class ActiveCwdRejectingTemporaryDirectory:
+        def __init__(self, **kwargs: object) -> None:
+            self._inner = real_temporary_directory(**kwargs)
+            self.name = self._inner.name
+
+        def __enter__(self) -> str:
+            return self.name
+
+        def __exit__(self, *_args: object) -> None:
+            self.cleanup()
+
+        def cleanup(self) -> None:
+            nonlocal cleanup_calls
+            process = spawned["process"]
+            if process.poll() is None:
+                raise PermissionError("cannot remove a live process working directory")
+            cleanup_calls += 1
+            self._inner.cleanup()
+
+    monkeypatch.setattr(webhook_filters.subprocess, "Popen", capture_popen)
+    monkeypatch.setattr(
+        webhook_filters.tempfile,
+        "TemporaryDirectory",
+        ActiveCwdRejectingTemporaryDirectory,
+    )
+
+    assert webhook_filters._bounded_regex_search(r"^safe$", "safe") is None
+    assert cleanup_calls == 1
+    assert spawned["process"].poll() is not None
+
+
+def test_oversized_interpreter_is_rejected_before_reading(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    interpreter = tmp_path / "oversized-interpreter"
+    with interpreter.open("wb") as handle:
+        handle.truncate(webhook_filters.MAX_SCRIPT_INTERPRETER_SNAPSHOT_BYTES + 1)
+
+    def unexpected_read(_fd: int, _size: int) -> bytes:
+        raise AssertionError("oversized interpreter content was read")
+
+    monkeypatch.setattr(webhook_filters.os, "read", unexpected_read)
+
+    with pytest.raises(webhook_filters.BoundedFileSnapshotTooLarge):
+        webhook_filters._open_stable_regular_file_digest(interpreter)
+
+
+@pytest.mark.parametrize("kind", ["cycle", "deep"])
+def test_regex_unserializable_filter_value_fails_closed(kind: str) -> None:
+    value: list[object] = []
+    if kind == "cycle":
+        value.append(value)
+    else:
+        cursor = value
+        for _ in range(10_000):
+            nested: list[object] = []
+            cursor.append(nested)
+            cursor = nested
+
+    assert not WebhookRouteProcessor().filter_matches(
+        {"field": "value", "regex": "safe"},
+        {"value": value},
+        "push",
+        {},
+    )
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        b"\xff",
+        bytearray(b"\xff"),
+        memoryview(b"\xff"),
+        float("nan"),
+        float("inf"),
+        float("-inf"),
+        ("tuple",),
+        {"set"},
+    ],
+)
+def test_regex_non_json_scalar_or_container_fails_closed(value: object) -> None:
+    assert not WebhookRouteProcessor().filter_matches(
+        {"field": "value", "regex": ".*"},
+        {"value": value},
+        "push",
+        {},
+    )
+
+
+def test_regex_decimal_and_custom_object_fail_closed() -> None:
+    from decimal import Decimal
+
+    class MatchableObject:
+        def __str__(self) -> str:
+            return "matchable"
+
+    processor = WebhookRouteProcessor()
+    for value in (Decimal("1.25"), MatchableObject()):
+        assert not processor.filter_matches(
+            {"field": "value", "regex": ".*"},
+            {"value": value},
+            "push",
+            {},
+        )
+
+
+@pytest.mark.parametrize(
+    ("value", "pattern"),
+    [
+        (None, r"^None$"),
+        (True, r"^True$"),
+        (42, r"^42$"),
+        (1.25, r"^1\.25$"),
+        ("é", r"^é$"),
+    ],
+)
+def test_regex_json_scalar_stringification_is_preserved(
+    value: object,
+    pattern: str,
+) -> None:
+    assert WebhookRouteProcessor().filter_matches(
+        {"field": "value", "regex": pattern},
+        {"value": value},
+        "push",
+        {},
+    )
+
+
+def test_redaction_failure_after_silent_script_is_indeterminate(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    processor, prepared, _script = _prepare(
+        tmp_path,
+        name="silent.py",
+        source="print('[SILENT]')\n",
+    )
+
+    def fail_redaction(_text: str) -> str:
+        raise RuntimeError("injected redaction failure")
+
+    monkeypatch.setattr("agent.redact.redact_sensitive_text", fail_redaction)
+
+    result = processor.run_prepared_script(prepared, {"original": True})
+
+    assert result.disposition is WebhookScriptDisposition.INDETERMINATE
+    assert "redaction failed" in str(result.error)
+
+
+@pytest.mark.parametrize("invalid_result", [None, 0, b""])
+def test_redaction_non_text_result_after_execution_is_indeterminate(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    invalid_result: object,
+) -> None:
+    processor, prepared, _script = _prepare(
+        tmp_path,
+        name="redaction-contract.py",
+        source="print('[SILENT]')\n",
+    )
+    monkeypatch.setattr(
+        "agent.redact.redact_sensitive_text",
+        lambda _text: invalid_result,
+    )
+
+    result = processor.run_prepared_script(prepared, {})
+
+    assert result.disposition is WebhookScriptDisposition.INDETERMINATE
+    assert "redaction failed" in str(result.error)
+
+
+def test_compatibility_filter_file_oversized_integer_fails_closed(
+    tmp_path: Path,
+) -> None:
+    values = tmp_path / "oversized-integer.json"
+    values.write_text("9" * 5_000, encoding="utf-8")
+
+    assert webhook_filters._load_filter_file_values(str(values)) is None
+
+
+def test_embedded_nul_paths_fail_closed() -> None:
+    prepared, error = WebhookRouteProcessor().prepare_route_script("bad\0path.py")
+
+    assert prepared is None
+    assert "invalid" in str(error)
+    assert webhook_filters._load_filter_file_values("bad\0path") is None
+
+
+def test_expanduser_runtime_errors_fail_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    real_expanduser = Path.expanduser
+
+    def fail_unknown_user(path: Path) -> Path:
+        if str(path).startswith("~unknown_webhook_user"):
+            raise RuntimeError("unknown user")
+        return real_expanduser(path)
+
+    monkeypatch.setattr(Path, "expanduser", fail_unknown_user)
+
+    prepared, error = WebhookRouteProcessor().prepare_route_script(
+        "~unknown_webhook_user/route.py"
+    )
+    assert prepared is None
+    assert "invalid" in str(error)
+    assert (
+        webhook_filters._load_filter_file_values(
+            "~unknown_webhook_user/filter-values.json"
+        )
+        is None
+    )
+
+
+@pytest.mark.skipif(os.name != "posix", reason="setsid regression requires POSIX")
+@pytest.mark.live_system_guard_bypass
+def test_escaped_descendant_retaining_pipes_leaves_no_pipe_workers(
+    tmp_path: Path,
+) -> None:
+    child_pid_file = tmp_path / "escaped-pipe-child.pid"
+    child_source = (
+        "import os, time\n"
+        "from pathlib import Path\n"
+        f"Path({str(child_pid_file)!r}).write_text(str(os.getpid()), encoding='utf-8')\n"
+        "time.sleep(60)\n"
+    )
+    processor, prepared, _script = _prepare(
+        tmp_path,
+        name="escaped-pipes.py",
+        source=(
+            "import subprocess, sys, time\n"
+            "from pathlib import Path\n"
+            f"marker = Path({str(child_pid_file)!r})\n"
+            "subprocess.Popen(\n"
+            f"    [sys.executable, '-I', '-S', '-c', {child_source!r}],\n"
+            "    start_new_session=True,\n"
+            ")\n"
+            "deadline = time.monotonic() + 2\n"
+            "while not marker.exists() and time.monotonic() < deadline:\n"
+            "    time.sleep(0.01)\n"
+            "print('{}')\n"
+        ),
+    )
+
+    result = processor.run_prepared_script(prepared, {})
+    child_pid = int(child_pid_file.read_text(encoding="utf-8"))
+    try:
+        assert result.disposition is WebhookScriptDisposition.CONTINUE
+        assert not any(
+            thread.is_alive() and thread.name.startswith("webhook-script-")
+            for thread in threading.enumerate()
+        )
+    finally:
+        if _pid_is_effectively_alive(child_pid):
+            os.kill(child_pid, signal.SIGKILL)
+
+
+def test_delayed_output_accounting_preserves_output_limit_classification(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    processor, prepared, _script = _prepare(
+        tmp_path,
+        name="output-boundary.py",
+        source=(
+            "import sys\n"
+            f"sys.stdout.buffer.write(b'x' * {MAX_SCRIPT_OUTPUT_STREAM_BYTES + 1})\n"
+            "sys.stdout.flush()\n"
+        ),
+    )
+    real_read_available = webhook_filters._read_available_script_pipe
+    release = threading.Event()
+    observed_stdout = 0
+    gated = False
+
+    def delayed_read(pipe, *, nonblocking: bool):
+        nonlocal observed_stdout, gated
+        chunk = real_read_available(pipe, nonblocking=nonblocking)
+        if chunk:
+            observed_stdout += len(chunk)
+            if observed_stdout > MAX_SCRIPT_OUTPUT_STREAM_BYTES and not gated:
+                gated = True
+                assert release.wait(timeout=2)
+        return chunk
+
+    monkeypatch.setattr(
+        webhook_filters,
+        "_read_available_script_pipe",
+        delayed_read,
+    )
+    release_timer = threading.Timer(0.75, release.set)
+    release_timer.start()
+    try:
+        result = processor.run_prepared_script(prepared, {})
+    finally:
+        release.set()
+        release_timer.cancel()
+
+    assert gated
+    assert result.disposition is WebhookScriptDisposition.INDETERMINATE
+    assert "output exceeded" in str(result.error)
+    assert not any(
+        thread.is_alive() and thread.name.startswith("webhook-script-")
+        for thread in threading.enumerate()
+    )
+
+
+def test_unsupported_nonblocking_pipes_use_compatible_fallback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    processor, prepared, _script = _prepare(
+        tmp_path,
+        name="blocking-pipe-fallback.py",
+        source="print('{\"fallback\":true}')\n",
+    )
+
+    def unsupported_set_blocking(_fd: int, _blocking: bool) -> None:
+        raise OSError("anonymous pipe nonblocking mode is unsupported")
+
+    monkeypatch.setattr(webhook_filters.os, "set_blocking", unsupported_set_blocking)
+
+    result = processor.run_prepared_script(prepared, {})
+
+    assert result.disposition is WebhookScriptDisposition.CONTINUE
+    assert result.payload == {"fallback": True}
+    assert not any(
+        thread.is_alive() and thread.name.startswith("webhook-script-")
+        for thread in threading.enumerate()
+    )
+
+
+def test_unsupported_nonblocking_fallback_preserves_output_limit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    processor, prepared, _script = _prepare(
+        tmp_path,
+        name="blocking-output-limit.py",
+        source=(
+            "import sys\n"
+            f"sys.stdout.buffer.write(b'x' * {MAX_SCRIPT_OUTPUT_STREAM_BYTES + 1})\n"
+        ),
+    )
+    monkeypatch.setattr(
+        webhook_filters.os,
+        "set_blocking",
+        lambda *_args: (_ for _ in ()).throw(OSError("unsupported")),
+    )
+
+    result = processor.run_prepared_script(prepared, {})
+
+    assert result.disposition is WebhookScriptDisposition.INDETERMINATE
+    assert "output exceeded" in str(result.error)
+
+
+def test_large_payload_uses_nonblocking_stdin_handoff(tmp_path: Path) -> None:
+    processor, prepared, _script = _prepare(
+        tmp_path,
+        name="large-stdin.py",
+        source=(
+            "import json, sys\n"
+            "content = sys.stdin.buffer.read()\n"
+            "print(json.dumps({'bytes': len(content)}))\n"
+        ),
+    )
+    payload = {"content": "x" * (256 * 1024)}
+
+    result = processor.run_prepared_script(prepared, payload)
+
+    assert result.disposition is WebhookScriptDisposition.CONTINUE
+    assert result.payload == {"bytes": len(json.dumps(payload).encode())}
+
+
+def test_pipe_value_error_is_typed_and_retires_all_workers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    processor, prepared, _script = _prepare(
+        tmp_path,
+        name="pipe-close-race.py",
+        source="import time\ntime.sleep(60)\n",
+    )
+    injected = threading.Event()
+    real_read_available = webhook_filters._read_available_script_pipe
+
+    def concurrent_close_read(pipe, *, nonblocking: bool):
+        if not injected.is_set():
+            injected.set()
+            raise ValueError("I/O operation on closed file")
+        return real_read_available(pipe, nonblocking=nonblocking)
+
+    monkeypatch.setattr(
+        webhook_filters,
+        "_read_available_script_pipe",
+        concurrent_close_read,
+    )
+
+    result = processor.run_prepared_script(prepared, {})
+
+    assert injected.is_set()
+    assert result.disposition is WebhookScriptDisposition.INDETERMINATE
+    assert "pipe failed" in str(result.error)
+    assert not any(
+        thread.is_alive() and thread.name.startswith("webhook-script-")
+        for thread in threading.enumerate()
+    )
+
+
+def test_reaped_leader_is_not_targeted_by_process_group_cleanup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class ReapedProcess:
+        pid = 424242
+        returncode: int | None = None
+
+        def poll(self) -> int:
+            self.returncode = 0
+            return 0
+
+        def wait(self, *, timeout: float) -> int:
+            assert timeout == webhook_filters._SCRIPT_TERMINATE_GRACE_SECONDS
+            assert self.returncode == 0
+            return 0
+
+    process = ReapedProcess()
+    killpg_calls: list[tuple[int, int]] = []
+    monkeypatch.setattr(
+        webhook_filters,
+        "_can_observe_posix_exit_without_reaping",
+        lambda: False,
+    )
+    monkeypatch.setattr(
+        webhook_filters.os,
+        "killpg",
+        lambda pid, sig: killpg_calls.append((pid, sig)),
+        raising=False,
+    )
+
+    assert webhook_filters._script_process_has_exited(process)
+    webhook_filters._reap_finished_script_process_group(process)
+
+    assert process.returncode == 0
+    assert killpg_calls == []
+
+
+@pytest.mark.skipif(os.name != "posix", reason="simulates non-POSIX branch")
+def test_windows_final_interpreter_path_failure_is_typed_and_closes_fd(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    processor, prepared, _script = _prepare(
+        tmp_path,
+        name="windows-path-failure.py",
+        source="print('{}')\n",
+    )
+    interpreter_fd = os.open(sys.executable, os.O_RDONLY)
+    monkeypatch.setattr(webhook_filters.os, "name", "nt")
+    monkeypatch.setattr(webhook_filters, "Path", lambda value: value)
+    monkeypatch.setattr(
+        webhook_filters,
+        "_open_stable_regular_file_digest",
+        lambda _path: (interpreter_fd, prepared.interpreter_sha256),
+    )
+    monkeypatch.setattr(
+        webhook_filters,
+        "_windows_final_path_from_fd",
+        lambda _fd: (_ for _ in ()).throw(OSError("injected final-path failure")),
+    )
+
+    result = processor.run_prepared_script(prepared, {})
+
+    assert result.disposition is WebhookScriptDisposition.FAILED
+    assert "cannot be executed safely" in str(result.error)
+    with pytest.raises(OSError):
+        os.fstat(interpreter_fd)
+
+
+def test_regex_startup_capture_failure_closes_provisional_fd(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    interpreter_fd = os.open(sys.executable, os.O_RDONLY)
+    monkeypatch.setattr(
+        webhook_filters,
+        "_open_stable_regular_file_digest",
+        lambda _path: (interpreter_fd, "a" * 64),
+    )
+    monkeypatch.setattr(
+        webhook_filters,
+        "_windows_final_path_from_fd",
+        lambda _fd: (_ for _ in ()).throw(OSError("injected capture failure")),
+    )
+
+    with pytest.raises(OSError, match="injected capture failure"):
+        webhook_filters._capture_regex_interpreter_authority(platform_name="nt")
+
+    with pytest.raises(OSError):
+        os.fstat(interpreter_fd)
+
+
+@pytest.mark.windows_only
+def test_windows_locked_file_and_interpreter_spawn_contract(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "locked.exe"
+    target.write_bytes(b"original")
+    replacement = tmp_path / "replacement.exe"
+    replacement.write_bytes(b"replacement")
+    descriptor = webhook_filters._open_windows_read_locked(target)
+    try:
+        with pytest.raises(OSError):
+            os.replace(replacement, target)
+    finally:
+        os.close(descriptor)
+    os.replace(replacement, target)
+    assert target.read_bytes() == b"replacement"
+
+    assert webhook_filters._bounded_regex_search(r"^\w+$", "é") is True
+    processor, prepared, _script = _prepare(
+        tmp_path,
+        name="windows-spawn.py",
+        source="print('{\"windows\":true}')\n",
+    )
+    result = processor.run_prepared_script(prepared, {})
+    assert result.disposition is WebhookScriptDisposition.CONTINUE
+    assert result.payload == {"windows": True}

--- a/tests/gateway/test_webhook_session_close.py
+++ b/tests/gateway/test_webhook_session_close.py
@@ -1,8 +1,9 @@
 """Invariant test: a completed webhook delivery closes its session.
 
-Regression guard for the ghost-session leak.  Webhook deliveries create a
-unique one-shot session (``delivery_id`` baked into the session key), but the
-adapter historically fired ``handle_message`` without ever ending the session.
+Regression guard for the ghost-session leak. Webhook deliveries create a
+unique one-shot session from the admitted profile/route/provider and the
+server-generated operation trace (deliberately not the provider delivery ID),
+but the adapter historically fired ``handle_message`` without ever ending it.
 ``SessionDB.prune_sessions`` only reaps rows where ``ended_at IS NOT NULL``, so
 every webhook session stayed unprunable and state.db grew without bound (this
 was the primary driver of the SQLite lock-contention gateway outage).
@@ -23,8 +24,12 @@ masks exactly that bug (the first version of this fix shipped that way).
 """
 
 import asyncio
+import threading
+from pathlib import Path
 
 import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
 
 from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.platforms.base import MessageEvent, MessageType
@@ -37,6 +42,17 @@ def _make_adapter(routes, **extra_kw) -> WebhookAdapter:
     extra.update(extra_kw)
     config = PlatformConfig(enabled=True, extra=extra)
     return WebhookAdapter(config)
+
+
+def _create_app(adapter: WebhookAdapter, *, multiplex: bool = False) -> web.Application:
+    app = web.Application()
+    app.router.add_post("/webhooks/{route_name}", adapter._handle_webhook)
+    if multiplex:
+        app.router.add_post(
+            "/p/{profile}/webhooks/{route_name}",
+            adapter._handle_webhook,
+        )
+    return app
 
 
 class _FakeRunner:
@@ -56,11 +72,12 @@ class _FakeRunner:
         return self.session_store._generate_session_key(source)
 
 
-def _make_store(tmp_path) -> SessionStore:
+def _make_store(tmp_path, *, multiplex_profiles: bool = False) -> SessionStore:
     sessions_dir = tmp_path / "sessions"
     sessions_dir.mkdir()
     config = GatewayConfig(
-        platforms={Platform.WEBHOOK: PlatformConfig(enabled=True)}
+        multiplex_profiles=multiplex_profiles,
+        platforms={Platform.WEBHOOK: PlatformConfig(enabled=True)},
     )
     store = SessionStore(sessions_dir=sessions_dir, config=config)
     assert store._db is not None, "test requires a real SessionDB"
@@ -85,7 +102,9 @@ def _make_event(adapter: WebhookAdapter, delivery_id: str, text: str) -> Message
     )
 
 
-async def _drain_background_tasks(adapter: WebhookAdapter, timeout: float = 5.0) -> None:
+async def _drain_background_tasks(
+    adapter: WebhookAdapter, timeout: float = 5.0
+) -> None:
     """Wait for the adapter's spawned processing task(s) to finish."""
     deadline = asyncio.get_event_loop().time() + timeout
     while adapter._background_tasks and asyncio.get_event_loop().time() < deadline:
@@ -100,15 +119,15 @@ async def test_completed_webhook_delivery_closes_its_session(tmp_path):
     store = _make_store(tmp_path)
     runner = _FakeRunner(store)
 
-    adapter = _make_adapter(
-        {
-            "alerts": {
-                "secret": _INSECURE_NO_AUTH,
-                "prompt": "Alert: {message}",
-                "deliver": "log",
-            }
+    adapter = _make_adapter({
+        "alerts": {
+            "secret": _INSECURE_NO_AUTH,
+            "provider": "github",
+            "prompt": "Alert: {message}",
+            "deliver": "log",
         }
-    )
+    })
+    runner.adapters = {Platform.WEBHOOK: adapter}
     adapter.gateway_runner = runner
 
     # Stub the RUNNER-side handler (the seam the live gateway injects) — the
@@ -125,13 +144,19 @@ async def test_completed_webhook_delivery_closes_its_session(tmp_path):
 
     adapter._message_handler = _message_handler
 
-    event = _make_event(adapter, "alert-close-001", "Alert: server on fire")
-
-    # Exactly what _handle_webhook schedules.
-    await adapter.handle_message(event)
+    # Admit through the real HTTP boundary so the event carries the exact
+    # durable operation authority required by the processing hooks.
+    async with TestClient(TestServer(_create_app(adapter))) as cli:
+        response = await cli.post(
+            "/webhooks/alerts",
+            json={"message": "server on fire"},
+            headers={"X-GitHub-Delivery": "alert-close-001"},
+        )
+        assert response.status == 202
     # handle_message is fire-and-forget: the session must NOT be expected to
     # exist yet.  (Guards against reintroducing a close wrapped around
     # handle_message itself, which ran before the row existed and no-op'd.)
+    await asyncio.sleep(0.05)
     await _drain_background_tasks(adapter)
 
     session_id = created["session_id"]
@@ -151,3 +176,97 @@ async def test_completed_webhook_delivery_closes_its_session(tmp_path):
     store._db.close()
 
 
+@pytest.mark.asyncio
+async def test_multiplex_completion_closes_the_admitted_profile_db(
+    tmp_path, monkeypatch
+):
+    """The completion hook must resolve its DB inside the source profile scope."""
+    import hermes_state
+
+    from gateway.run import (
+        GatewayRunner,
+        _SESSION_DB_UNPINNED,
+        _profile_runtime_scope,
+    )
+    from gateway.session_db_recovery import RecoverableHandleCache
+
+    root = tmp_path / "hermes"
+    profile_home = root / "profiles" / "fitness"
+    root.mkdir()
+    profile_home.mkdir(parents=True)
+    # Route publication freezes grants from the admitted physical profile.
+    # A real multiplex runner therefore requires that profile's config file.
+    (profile_home / "config.yaml").write_text("{}\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    # The suite fixture deliberately pins DEFAULT_DB_PATH. This regression
+    # exercises production's context-local path resolution instead.
+    monkeypatch.setattr(
+        hermes_state, "DEFAULT_DB_PATH", hermes_state._IMPORT_DEFAULT_DB_PATH
+    )
+
+    store = _make_store(root, multiplex_profiles=True)
+    runner = object.__new__(GatewayRunner)
+    runner.config = store.config
+    runner.session_store = store
+    runner._session_db_pinned = _SESSION_DB_UNPINNED
+    runner._session_db_handles = {}
+    runner._session_db_handles_lock = threading.Lock()
+    runner._session_db_handle_cache = RecoverableHandleCache(
+        handles=runner._session_db_handles,
+        lock=runner._session_db_handles_lock,
+    )
+    runner._session_db_init_error = None
+
+    adapter = _make_adapter({
+        "alerts": {
+            "profile": "fitness",
+            "secret": _INSECURE_NO_AUTH,
+            "provider": "github",
+            "prompt": "Alert: {message}",
+            "deliver": "log",
+        }
+    })
+    runner.adapters = {Platform.WEBHOOK: adapter}
+    adapter.gateway_runner = runner
+
+    created = {}
+
+    async def _runner_handle_message(event: MessageEvent):
+        # The real primary-profile wrapper must have installed the admitted
+        # profile before any session state is created.
+        created["db_path"] = Path(store._db.db_path)
+        entry = store.get_or_create_session(event.source)
+        created["session_id"] = entry.session_id
+        return ""
+
+    runner._handle_message = _runner_handle_message
+    adapter._message_handler = runner._make_default_profile_message_handler()
+
+    try:
+        async with TestClient(TestServer(_create_app(adapter, multiplex=True))) as cli:
+            response = await cli.post(
+                "/p/fitness/webhooks/alerts",
+                json={"message": "Profile-scoped alert"},
+                headers={"X-GitHub-Delivery": "profile-close-001"},
+            )
+            assert response.status == 202
+        await asyncio.sleep(0.05)
+        await _drain_background_tasks(adapter)
+
+        session_id = created["session_id"]
+        assert created["db_path"] == profile_home / "state.db"
+
+        with _profile_runtime_scope(profile_home):
+            profile_row = store._db.get_session(session_id)
+        root_row = store._db.get_session(session_id)
+
+        assert profile_row is not None
+        assert profile_row["ended_at"] is not None, (
+            "completion resolved the root DB after the routed profile scope "
+            "exited, leaving the admitted profile's session open"
+        )
+        assert profile_row["end_reason"] == "webhook_complete"
+        assert root_row is None
+    finally:
+        store.close_all_db_handles()
+        runner.close_all_session_db_handles()

--- a/tests/gateway/test_webhook_signature_rate_limit.py
+++ b/tests/gateway/test_webhook_signature_rate_limit.py
@@ -9,8 +9,9 @@ with 429.
 The correct order is:
 1. Read body
 2. Validate HMAC signature (reject 401 if invalid)
-3. Rate limit check (reject 429 if over limit)
-4. Process the webhook
+3. Resolve durable replay identity
+4. Return duplicate/conflict without consuming execution quota
+5. Rate-limit only newly accepted work
 """
 
 import hashlib
@@ -53,7 +54,21 @@ def _github_signature(body: bytes, secret: str) -> str:
     ).hexdigest()
 
 
-SIMPLE_PAYLOAD = {"event": "test", "data": "hello"}
+SIMPLE_PAYLOAD = {
+    "ref": "refs/heads/main",
+    "before": "0" * 40,
+    "after": "1" * 40,
+    "created": False,
+    "deleted": False,
+    "forced": False,
+    "commits": [],
+    "head_commit": None,
+    "repository": {"id": 801, "full_name": "org/repo"},
+    "pusher": {"name": "octocat"},
+    "sender": {"id": 901, "login": "octocat"},
+    "event": "test",
+    "data": "hello",
+}
 
 
 class TestSignatureBeforeRateLimit:
@@ -75,6 +90,7 @@ class TestSignatureBeforeRateLimit:
         routes = {
             route_name: {
                 "secret": secret,
+                "provider": "github",
                 "events": ["push"],
                 "prompt": "Event: {event}",
                 "deliver": "log",
@@ -139,4 +155,64 @@ class TestSignatureBeforeRateLimit:
         # The valid event should have been captured
         assert len(captured_events) == 1
 
+    @pytest.mark.asyncio
+    async def test_valid_replay_flood_does_not_starve_fresh_delivery(self):
+        secret = "replay-safe-rate-secret"
+        route_name = "test-route"
+        adapter = _make_adapter(
+            {
+                route_name: {
+                    "secret": secret,
+                    "provider": "github",
+                    "events": ["push"],
+                    "prompt": "Event: {after}",
+                    "deliver": "log",
+                }
+            },
+            rate_limit=2,
+        )
+        async def handle_message(_event):
+            return None
 
+        adapter.handle_message = handle_message
+        app = _create_app(adapter)
+        first_payload = dict(SIMPLE_PAYLOAD, after="1" * 40)
+        first_body = json.dumps(first_payload).encode()
+        first_headers = {
+            "Content-Type": "application/json",
+            "X-GitHub-Event": "push",
+            "X-Hub-Signature-256": _github_signature(first_body, secret),
+        }
+
+        async with TestClient(TestServer(app)) as client:
+            first = await client.post(
+                f"/webhooks/{route_name}",
+                data=first_body,
+                headers=first_headers,
+            )
+            assert first.status == 202
+
+            for _ in range(10):
+                replay = await client.post(
+                    f"/webhooks/{route_name}",
+                    data=first_body,
+                    headers=first_headers,
+                )
+                assert replay.status in {200, 202}
+
+            fresh_payload = dict(SIMPLE_PAYLOAD, after="2" * 40)
+            fresh_body = json.dumps(fresh_payload).encode()
+            fresh = await client.post(
+                f"/webhooks/{route_name}",
+                data=fresh_body,
+                headers={
+                    "Content-Type": "application/json",
+                    "X-GitHub-Event": "push",
+                    "X-Hub-Signature-256": _github_signature(
+                        fresh_body,
+                        secret,
+                    ),
+                },
+            )
+
+        assert fresh.status == 202

--- a/tests/gateway/test_webhook_streaming_authority.py
+++ b/tests/gateway/test_webhook_streaming_authority.py
@@ -1,0 +1,287 @@
+"""Webhook turns must never create token-streaming side effects."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig, StreamingConfig
+from gateway.display_config import resolve_display_setting
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    SendResult,
+)
+from gateway.session import SessionSource
+from gateway.session import build_session_key
+from gateway.turn_context import TurnContext
+
+
+class _FinalAgent:
+    instances = []
+
+    def __init__(self, **kwargs):
+        self.model = kwargs["model"]
+        self.session_id = kwargs["session_id"]
+        self.tools = []
+        self.context_compressor = SimpleNamespace(
+            last_prompt_tokens=0,
+            context_length=200_000,
+        )
+        self.session_prompt_tokens = 0
+        self.session_completion_tokens = 0
+        self.callback_seen_during_run = object()
+        type(self).instances.append(self)
+
+    def run_conversation(self, _message, **_kwargs):
+        self.callback_seen_during_run = self.stream_delta_callback
+        return {
+            "final_response": "ordinary final",
+            "completed": True,
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+class _StreamConsumerSpy:
+    instances = []
+
+    def __init__(self, *args, **kwargs):
+        type(self).instances.append((args, kwargs))
+
+    def on_delta(self, _text):
+        pass
+
+    def finish(self, *_args):
+        pass
+
+
+class _LedgerOwnedWebhookProbe(BasePlatformAdapter):
+    """Concrete webhook-shaped adapter that records Base's final send."""
+
+    owns_final_delivery_ledger = True
+
+    def __init__(self):
+        config = PlatformConfig(enabled=True)
+        config.typing_indicator = False
+        super().__init__(config, Platform.WEBHOOK)
+        self.sent = []
+
+    async def connect(self, *, is_reconnect: bool = False):
+        return True
+
+    async def disconnect(self):
+        pass
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        self.sent.append({
+            "chat_id": chat_id,
+            "content": content,
+            "reply_to": reply_to,
+            "metadata": metadata,
+        })
+        return SendResult(success=True, message_id="webhook-final")
+
+    async def get_chat_info(self, chat_id):
+        return {"id": chat_id}
+
+
+class _ProxyResponse:
+    status = 200
+
+    def __init__(self):
+        self.content = self
+
+    async def iter_any(self):
+        yield b'data: {"choices":[{"delta":{"content":"proxy final"}}]}\n\n'
+        yield b"data: [DONE]\n\n"
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        pass
+
+
+class _ProxySession:
+    def __init__(self):
+        self.body = None
+
+    def post(self, _url, *, json, headers):
+        self.body = json
+        return _ProxyResponse()
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        pass
+
+
+def test_webhook_turn_forces_streaming_off_despite_both_enable_flags(monkeypatch):
+    from gateway.run import TurnRunner
+    import gateway.stream_consumer as stream_consumer_module
+
+    _FinalAgent.instances.clear()
+    _StreamConsumerSpy.instances.clear()
+    monkeypatch.setattr(
+        stream_consumer_module,
+        "GatewayStreamConsumer",
+        _StreamConsumerSpy,
+    )
+
+    user_config = {
+        "display": {
+            "platforms": {
+                "webhook": {"streaming": True},
+            },
+        },
+    }
+    assert resolve_display_setting(user_config, "webhook", "streaming") is True
+
+    gateway_runner = MagicMock()
+    gateway_runner.config = SimpleNamespace(
+        streaming=StreamingConfig(enabled=True, transport="edit")
+    )
+    gateway_runner._provider_routing = {}
+    gateway_runner._agent_cache_lock = None
+    gateway_runner._agent_cache = {}
+    gateway_runner._session_db = None
+    gateway_runner._prefill_messages = None
+    gateway_runner._pending_model_notes = {}
+    gateway_runner._pending_skills_reload_notes = {}
+    gateway_runner.session_store._entries = {}
+    gateway_runner._get_system_prompt_for_channel.return_value = None
+    gateway_runner._resolve_session_agent_runtime.return_value = ("test-model", {})
+    gateway_runner._resolve_session_reasoning_config.return_value = None
+    gateway_runner._resolve_session_service_tier.return_value = None
+    gateway_runner._resolve_turn_agent_config.return_value = {
+        "model": "test-model",
+        "runtime": {},
+    }
+    gateway_runner._agent_config_signature.return_value = ("test-signature",)
+    gateway_runner._extract_cache_busting_config.return_value = {}
+    gateway_runner._refresh_fallback_model.return_value = None
+    gateway_runner._consume_pending_native_image_paths.return_value = []
+    gateway_runner._consume_pending_turn_sidecar_notes.return_value = []
+    gateway_runner._is_telegram_topic_lane.return_value = False
+    gateway_runner._is_discord_auto_thread_lane.return_value = False
+    gateway_runner._is_relay_discord_channel_lane.return_value = False
+    gateway_runner._adapter_for_source.return_value = object()
+    gateway_runner._build_stream_consumer_config.return_value = (
+        SimpleNamespace(),
+        False,
+    )
+
+    source = SessionSource(
+        platform=Platform.WEBHOOK,
+        chat_id="authority-target",
+        user_id="webhook-source",
+    )
+    ctx = TurnContext(
+        source=source,
+        message="execute webhook operation",
+        history=[],
+        session_id="webhook-session",
+        session_key="webhook-session-key",
+        user_config=user_config,
+        AIAgent=_FinalAgent,
+        resolve_display_setting=resolve_display_setting,
+        _run_still_current=lambda: True,
+        _hooks_ref=SimpleNamespace(loaded_hooks=False),
+        interim_assistant_messages_enabled=False,
+    )
+
+    result = TurnRunner(gateway_runner, ctx).run_sync()
+
+    assert result["final_response"] == "ordinary final"
+    assert result["completed"] is True
+    assert len(_FinalAgent.instances) == 1
+    assert _FinalAgent.instances[0].callback_seen_during_run is None
+    assert _FinalAgent.instances[0].stream_delta_callback is None
+    assert ctx.stream_consumer_holder == [None]
+    assert _StreamConsumerSpy.instances == []
+    gateway_runner._build_stream_consumer_config.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_proxy_webhook_keeps_final_in_base_owned_delivery(monkeypatch):
+    """Defense in depth for a proxy path blocked by today's grant carrier."""
+
+    from gateway.run import GatewayRunner
+    import gateway.stream_consumer as stream_consumer_module
+
+    _StreamConsumerSpy.instances.clear()
+    monkeypatch.setattr(
+        stream_consumer_module,
+        "GatewayStreamConsumer",
+        _StreamConsumerSpy,
+    )
+    monkeypatch.delenv("GATEWAY_PROXY_KEY", raising=False)
+    monkeypatch.setattr(
+        "gateway.run._load_gateway_config",
+        lambda: {
+            "display": {
+                "platforms": {
+                    "webhook": {"streaming": True},
+                },
+            },
+        },
+    )
+
+    proxy_session = _ProxySession()
+    monkeypatch.setattr("aiohttp.ClientSession", lambda **_kwargs: proxy_session)
+    monkeypatch.setattr("aiohttp.ClientTimeout", lambda **_kwargs: object())
+
+    adapter = _LedgerOwnedWebhookProbe()
+    source = SessionSource(
+        platform=Platform.WEBHOOK,
+        chat_id="webhook:default:deploy:generic:proxy-proof",
+        chat_name="webhook/deploy",
+        chat_type="webhook",
+        user_id="webhook:deploy",
+        user_name="deploy",
+    )
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {Platform.WEBHOOK: adapter}
+    runner.config = SimpleNamespace(
+        streaming=StreamingConfig(enabled=True, transport="edit")
+    )
+    runner._get_proxy_url = lambda: "http://proxy.invalid:8642"
+    runner._adapter_for_source = lambda _source: adapter
+    runner._thread_metadata_for_source = lambda _source, _message_id: None
+    runner._build_stream_consumer_config = MagicMock(
+        side_effect=AssertionError("webhook proxy constructed a stream consumer")
+    )
+
+    observed_result = None
+
+    async def proxy_handler(_event):
+        nonlocal observed_result
+        observed_result = await runner._run_agent_via_proxy(
+            message="deploy",
+            context_prompt="",
+            history=[],
+            source=source,
+            session_id="proxy-session",
+        )
+        return observed_result["final_response"]
+
+    adapter.set_message_handler(proxy_handler)
+    event = MessageEvent(text="deploy", source=source, message_id="delivery-1")
+    await adapter._process_message_background(event, build_session_key(source))
+
+    assert proxy_session.body["stream"] is True
+    assert observed_result["final_response"] == "proxy final"
+    assert observed_result["response_previewed"] is False
+    assert "already_sent" not in observed_result
+    assert _StreamConsumerSpy.instances == []
+    runner._build_stream_consumer_config.assert_not_called()
+    assert adapter.sent == [
+        {
+            "chat_id": source.chat_id,
+            "content": "proxy final",
+            "reply_to": "delivery-1",
+            "metadata": {"notify": True},
+        }
+    ]

--- a/tests/gateway/test_webhook_target_authority_startup.py
+++ b/tests/gateway/test_webhook_target_authority_startup.py
@@ -1,0 +1,158 @@
+"""Startup composition regressions for immutable webhook target authority."""
+
+from pathlib import Path
+
+import pytest
+
+from gateway.config import GatewayConfig, PlatformConfig
+from gateway.platforms.webhook import WebhookAdapter
+from gateway.platforms.webhook_contract import WebhookContractError
+from gateway.run import GatewayRunner
+
+
+@pytest.fixture(autouse=True)
+def _isolated_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+
+def _runner(root: Path, named_home: Path) -> GatewayRunner:
+    """Build the real target-authorization registry shape before publication."""
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(multiplex_profiles=True)
+    runner.adapters = {}
+    runner._profile_adapters = {}
+    runner._active_profile_name = lambda: "default"
+    runner._resolve_profile_home_for_source = lambda source: (
+        named_home if source.profile == "ops" else root
+    )
+    return runner
+
+
+def _adapter(runner: GatewayRunner, route: dict) -> WebhookAdapter:
+    adapter = WebhookAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={
+                "host": "127.0.0.1",
+                "port": 0,
+                "routes": {
+                    "events": {
+                        "provider": "generic",
+                        "signature_mode": "generic_v1",
+                        "secret": "startup-target-authority-secret",
+                        "deliver_only": True,
+                        "prompt": "startup composition",
+                        **route,
+                    },
+                },
+                "idempotency_max_entries": 8,
+            },
+        )
+    )
+    adapter.gateway_runner = runner
+    return adapter
+
+
+def test_named_profile_home_is_frozen_before_secondary_adapter_publication(
+    tmp_path,
+    monkeypatch,
+):
+    root = tmp_path
+    ops_home = root / "profiles" / "ops"
+    ops_home.mkdir(parents=True)
+    (ops_home / "config.yaml").write_text(
+        """\
+platforms:
+  telegram:
+    enabled: true
+    home_channel:
+      platform: telegram
+      chat_id: ops-home-chat
+      name: Ops home
+      thread_id: ops-home-thread
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        "hermes_cli.profiles.profiles_to_serve",
+        lambda **_kwargs: [("default", root), ("ops", ops_home)],
+    )
+    runner = _runner(root, ops_home)
+    adapter = _adapter(
+        runner,
+        {
+            "profile": "ops",
+            "deliver": "telegram",
+        },
+    )
+
+    # Webhook publication precedes secondary adapter publication during
+    # multiplex startup. Target authority therefore has to come from the
+    # named profile's configured home, not a live adapter registry.
+    assert runner.adapters == {}
+    assert runner._profile_adapters == {}
+    adapter._bind_route_authentication_authorities(adapter._routes)
+
+    target = adapter._authenticated_route_bundles["events"].prepared_target
+    assert target.profile == "ops"
+    assert target.platform == "telegram"
+    assert target.home_chat_id == "ops-home-chat"
+    assert target.home_thread_id == "ops-home-thread"
+    assert runner.adapters == {}
+    assert runner._profile_adapters == {}
+
+
+def test_default_slack_static_chat_without_scope_fails_before_publication(
+    tmp_path,
+):
+    runner = _runner(tmp_path, tmp_path / "profiles" / "ops")
+    adapter = _adapter(
+        runner,
+        {
+            "deliver": "slack",
+            "deliver_extra": {"chat_id": "C_TARGET"},
+        },
+    )
+
+    # Repeating the preflight in the same adapter-free startup state proves
+    # this is the deterministic authority contract, not connection ordering.
+    for _ in range(2):
+        with pytest.raises(
+            WebhookContractError,
+            match="Slack target workspace scope cannot be established",
+        ):
+            adapter._bind_route_authentication_authorities(adapter._routes)
+
+    assert adapter._authenticated_route_bundles == {}
+    assert runner.adapters == {}
+    assert runner._profile_adapters == {}
+
+
+def test_default_slack_static_chat_and_scope_publish_without_live_adapter(
+    tmp_path,
+):
+    runner = _runner(tmp_path, tmp_path / "profiles" / "ops")
+    adapter = _adapter(
+        runner,
+        {
+            "deliver": "slack",
+            "deliver_extra": {
+                "chat_id": "C_TARGET",
+                "scope_id": "T_WORKSPACE",
+            },
+        },
+    )
+
+    assert runner.adapters == {}
+    assert runner._profile_adapters == {}
+    adapter._bind_route_authentication_authorities(adapter._routes)
+
+    target = adapter._authenticated_route_bundles["events"].prepared_target
+    assert target.profile == "default"
+    assert target.platform == "slack"
+    assert target.slack_static_chat_id == "C_TARGET"
+    assert target.slack_static_scope_id == "T_WORKSPACE"
+    assert target.slack_scope_locked is True
+    assert runner.adapters == {}
+    assert runner._profile_adapters == {}

--- a/tests/gateway/test_webhook_terminal_outcomes.py
+++ b/tests/gateway/test_webhook_terminal_outcomes.py
@@ -1,0 +1,128 @@
+"""Durable, redacted terminal outcomes for failed webhook agent runs."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import SendResult
+from gateway.platforms.webhook import WebhookAdapter, _INSECURE_NO_AUTH
+from gateway.platforms.webhook_ledger import OperationState, TargetState
+from gateway.platforms.webhook_terminal import (
+    WebhookTerminalOutcome,
+    terminal_outcome_carrier,
+    terminal_outcome_notice,
+)
+
+
+def _app(adapter: WebhookAdapter) -> web.Application:
+    app = web.Application(client_max_size=adapter._max_body_bytes)
+    app.router.add_post("/webhooks/{route_name}", adapter._handle_webhook)
+    return app
+
+
+async def _drain(adapter: WebhookAdapter) -> None:
+    deadline = asyncio.get_running_loop().time() + 5
+    while adapter._background_tasks and asyncio.get_running_loop().time() < deadline:
+        await asyncio.sleep(0.01)
+    await asyncio.sleep(0)
+    assert not adapter._background_tasks
+
+
+def test_terminal_error_contract_is_typed_and_privacy_bounded():
+    outcome = WebhookTerminalOutcome.ERROR
+
+    assert terminal_outcome_notice(outcome) == (
+        "Webhook processing failed before a final response was produced."
+    )
+    assert terminal_outcome_carrier(outcome) == {
+        "v": 1,
+        "kind": "terminal_outcome",
+        "outcome": "error",
+    }
+    with pytest.raises(TypeError):
+        terminal_outcome_notice("provider token=secret")  # type: ignore[arg-type]
+    with pytest.raises(TypeError):
+        terminal_outcome_carrier("error")  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_agent_exception_stages_redacted_error_before_reconciliation(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    adapter = WebhookAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={
+                "host": "127.0.0.1",
+                "port": 0,
+                "routes": {
+                    "events": {
+                        "provider": "github",
+                        "secret": _INSECURE_NO_AUTH,
+                        "deliver": "telegram",
+                        "deliver_extra": {"chat_id": "alert-channel"},
+                    }
+                },
+            },
+        )
+    )
+    target = SimpleNamespace(
+        send=AsyncMock(
+            return_value=SendResult(success=True, message_id="error-notice-1")
+        )
+    )
+    runner = SimpleNamespace(
+        adapters={Platform.WEBHOOK: adapter, Platform.TELEGRAM: target},
+        _profile_adapters={},
+        config=GatewayConfig(platforms={}, multiplex_profiles=False),
+        _running=True,
+    )
+    adapter.gateway_runner = runner
+    captured = []
+    sensitive_error = "provider failed with token=super-secret-value"
+
+    async def fail_agent(event):
+        captured.append(event)
+        raise RuntimeError(sensitive_error)
+
+    adapter._message_handler = fail_agent
+    body = {"action": "opened", "number": 42}
+    headers = {"X-GitHub-Delivery": "observed-error-delivery"}
+
+    async with TestClient(TestServer(_app(adapter))) as client:
+        accepted = await client.post("/webhooks/events", json=body, headers=headers)
+        await _drain(adapter)
+        duplicate = await client.post("/webhooks/events", json=body, headers=headers)
+        duplicate_payload = await duplicate.json()
+
+    assert accepted.status == 202
+    assert duplicate.status == 200
+    assert duplicate_payload["status"] == "duplicate"
+    assert len(captured) == 1
+    target.send.assert_awaited_once()
+    chat_id, content = target.send.await_args.args[:2]
+    assert chat_id == "alert-channel"
+    assert content == terminal_outcome_notice(WebhookTerminalOutcome.ERROR)
+    assert sensitive_error not in content
+
+    settled = adapter._operation_ledger.lookup_session(
+        captured[0].webhook_authority.session_key
+    )
+    assert settled is not None
+    assert settled.state is OperationState.SETTLED
+    assert settled.target_state is TargetState.CONFIRMED
+    assert settled.delivery is not None
+    assert dict(settled.delivery.carrier) == terminal_outcome_carrier(
+        WebhookTerminalOutcome.ERROR
+    )
+    assert sensitive_error not in settled.delivery.content
+    assert sensitive_error not in json.dumps(dict(settled.delivery.carrier))

--- a/tests/hermes_cli/test_dashboard_admin_endpoints.py
+++ b/tests/hermes_cli/test_dashboard_admin_endpoints.py
@@ -322,8 +322,7 @@ class TestWebhookEndpoints:
     def _setup(self, _isolate_hermes_home):
         self.client, _ = _client()
 
-
-    def test_create_webhook_persists_script(self):
+    def _enable_webhook_platform(self):
         from hermes_cli.config import load_config, save_config
 
         cfg = load_config()
@@ -332,6 +331,9 @@ class TestWebhookEndpoints:
             "extra": {"host": "0.0.0.0", "port": 8644},
         }
         save_config(cfg)
+
+    def test_create_webhook_persists_script(self):
+        self._enable_webhook_platform()
 
         r = self.client.post(
             "/api/webhooks",
@@ -346,6 +348,74 @@ class TestWebhookEndpoints:
 
         subs = self.client.get("/api/webhooks").json()["subscriptions"]
         assert subs[0]["script"] == "todoist_filter.py"
+
+    def test_create_and_list_project_exact_deliver_chat_id_without_list_secret(self):
+        import json
+
+        self._enable_webhook_platform()
+        create = self.client.post(
+            "/api/webhooks",
+            json={
+                "name": "callback-route",
+                "deliver": "discord",
+                "deliver_chat_id": "channel-123",
+            },
+        )
+
+        assert create.status_code == 200
+        created = create.json()
+        assert created["deliver_chat_id"] == "channel-123"
+        assert created["secret_set"] is True
+        assert isinstance(created.get("secret"), str)
+        assert "deliver_extra" not in created
+
+        listed = self.client.get("/api/webhooks").json()
+        route = listed["subscriptions"][0]
+        assert route["deliver_chat_id"] == "channel-123"
+        assert route["secret_set"] is True
+        assert "secret" not in route
+        assert "deliver_extra" not in route
+        assert created["secret"] not in json.dumps(listed)
+
+    def test_omitted_deliver_chat_id_does_not_invent_binding(self):
+        self._enable_webhook_platform()
+
+        create = self.client.post(
+            "/api/webhooks",
+            json={"name": "no-binding", "deliver": "log"},
+        )
+
+        assert create.status_code == 200
+        assert create.json()["deliver_chat_id"] is None
+        route = self.client.get("/api/webhooks").json()["subscriptions"][0]
+        assert route["deliver_chat_id"] is None
+        assert "deliver_extra" not in route
+
+    def test_malformed_deliver_extra_does_not_invent_binding(self):
+        from hermes_cli.web_server import _webhook_route_summary
+
+        malformed_routes = [
+            {},
+            {"deliver_extra": None},
+            {"deliver_extra": "not-an-object"},
+            {"deliver_extra": ["channel-123"]},
+            {"deliver_extra": {"chat_id": 123}},
+            {"deliver_extra": {"chat_id": True}},
+            {"deliver_extra": {"chat_id": {"nested": "channel-123"}}},
+            {"deliver_extra": {"other": "channel-123"}},
+        ]
+        for route in malformed_routes:
+            summary = _webhook_route_summary("probe", route, "http://localhost:8644")
+            assert summary["deliver_chat_id"] is None
+            assert "deliver_extra" not in summary
+
+        exact = _webhook_route_summary(
+            "probe",
+            {"deliver_extra": {"chat_id": "channel-123"}},
+            "http://localhost:8644",
+        )
+        assert exact["deliver_chat_id"] == "channel-123"
+        assert "deliver_extra" not in exact
 
     def test_enable_platform_starts_gateway_restart(self, monkeypatch):
         import hermes_cli.web_server as ws

--- a/tests/hermes_cli/test_webhook_cli.py
+++ b/tests/hermes_cli/test_webhook_cli.py
@@ -6,6 +6,7 @@ import pytest
 import stat
 from argparse import Namespace
 
+from gateway.platforms.webhook_store import WebhookRouteStoreCorruptError
 from hermes_cli.webhook import (
     webhook_command,
     _get_webhook_base_url,
@@ -98,13 +99,21 @@ class TestPersistence:
         path = _subscriptions_path()
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text("broken{{{")
-        assert _load_subscriptions() == {}
+        with pytest.raises(WebhookRouteStoreCorruptError):
+            _load_subscriptions()
+        assert path.read_text(encoding="utf-8") == "broken{{{"
 
     @pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits are platform-specific")
     def test_save_creates_secret_file_owner_only_under_permissive_umask(self):
         old_umask = os.umask(0o022)
         try:
-            _save_subscriptions({"demo": {"secret": "TOPSECRET", "prompt": "x"}})
+            _save_subscriptions({
+                "demo": {
+                    "provider": "generic",
+                    "secret": "TOPSECRET",
+                    "prompt": "x",
+                }
+            })
         finally:
             os.umask(old_umask)
 
@@ -120,7 +129,13 @@ class TestPersistence:
         path.write_text(json.dumps({"old": {"secret": "stale", "prompt": "x"}}))
         path.chmod(0o644)
 
-        _save_subscriptions({"demo": {"secret": "FRESH", "prompt": "x"}})
+        _save_subscriptions({
+            "demo": {
+                "provider": "generic",
+                "secret": "FRESH",
+                "prompt": "x",
+            }
+        })
 
         assert stat.S_IMODE(path.stat().st_mode) == 0o600
         assert "FRESH" in path.read_text(encoding="utf-8")
@@ -152,4 +167,3 @@ class TestWebhookEnabledGate:
         )
         import hermes_cli.webhook as wh_mod
         assert wh_mod._is_webhook_enabled() is False
-

--- a/tests/hermes_cli/test_webhook_cli_management.py
+++ b/tests/hermes_cli/test_webhook_cli_management.py
@@ -1,0 +1,293 @@
+"""Focused behavior contracts for sharded webhook CLI management."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from argparse import Namespace
+
+import pytest
+
+from hermes_cli.subcommands.webhook import build_webhook_parser
+from hermes_cli.webhook import (
+    ConcurrentWebhookUpdateError,
+    _load_subscriptions,
+    _save_subscriptions,
+    _subscriptions_path,
+    webhook_command,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr("hermes_cli.webhook._is_webhook_enabled", lambda: True)
+
+
+def _args(**overrides) -> Namespace:
+    values = {
+        "webhook_action": "subscribe",
+        "name": "events",
+        "prompt": "",
+        "events": "",
+        "provider": "generic",
+        "signature_mode": "generic_v2",
+        "route_profile": "",
+        "profile": "",
+        "description": "",
+        "skills": "",
+        "deliver": "log",
+        "deliver_chat_id": "",
+        "secret": "test-secret",
+        "secret_fd": None,
+        "deliver_only": False,
+        "script": "",
+        "replace": False,
+        "json": False,
+        "payload": "",
+    }
+    values.update(overrides)
+    return Namespace(**values)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="hermes")
+    build_webhook_parser(
+        parser.add_subparsers(dest="command"),
+        cmd_webhook=webhook_command,
+    )
+    return parser
+
+
+def test_parser_exposes_management_profile_json_replace_and_secret_fd():
+    parsed = _parser().parse_args([
+        "webhook",
+        "subscribe",
+        "events",
+        "--profile",
+        "ops",
+        "--replace",
+        "--json",
+        "--secret-fd",
+        "3",
+    ])
+
+    assert parsed.profile == "ops"
+    assert parsed.replace is True
+    assert parsed.json is True
+    assert parsed.secret_fd == 3
+
+
+def test_parser_rejects_secret_and_secret_fd_without_echoing_value(capsys):
+    sentinel = "never-echo-this-secret"
+    with pytest.raises(SystemExit):
+        _parser().parse_args([
+            "webhook",
+            "subscribe",
+            "events",
+            "--secret",
+            sentinel,
+            "--secret-fd",
+            "3",
+        ])
+
+    assert sentinel not in capsys.readouterr().err
+
+
+def test_subscribe_conflict_requires_replace_and_preserves_existing(capsys):
+    webhook_command(_args(secret="first-secret"))
+    capsys.readouterr()
+
+    webhook_command(_args(secret="second-secret"))
+
+    output = capsys.readouterr().out
+    assert "already exists" in output
+    assert "second-secret" not in output
+    assert _load_subscriptions()["events"]["secret"] == "first-secret"
+
+    webhook_command(_args(secret="second-secret", replace=True))
+    assert _load_subscriptions()["events"]["secret"] == "second-secret"
+
+
+def test_secret_fd_is_bounded_trimmed_left_open_and_never_echoed(tmp_path, capsys):
+    sentinel = "fd-secret-value"
+    path = tmp_path / "secret"
+    path.write_text(sentinel + "\n", encoding="utf-8")
+    with path.open("rb") as stream:
+        webhook_command(_args(name="fd-route", secret="", secret_fd=stream.fileno()))
+        os.fstat(stream.fileno())
+
+    output = capsys.readouterr().out
+    assert sentinel not in output
+    assert _load_subscriptions()["fd-route"]["secret"] == sentinel
+
+
+def test_secret_fd_accepts_4096_bytes_and_rejects_4097(tmp_path, capsys):
+    maximum = tmp_path / "maximum"
+    maximum.write_bytes(b"x" * 4096)
+    with maximum.open("rb") as stream:
+        webhook_command(_args(name="maximum", secret="", secret_fd=stream.fileno()))
+    assert len(_load_subscriptions()["maximum"]["secret"]) == 4096
+    assert "x" * 32 not in capsys.readouterr().out
+
+    oversize = tmp_path / "oversize"
+    oversize.write_bytes(b"y" * 4097)
+    with oversize.open("rb") as stream:
+        webhook_command(_args(name="oversize", secret="", secret_fd=stream.fileno()))
+    assert "oversize" not in _load_subscriptions()
+    assert "y" * 32 not in capsys.readouterr().out
+
+
+def test_subscribe_list_and_show_json_are_secret_safe(capsys):
+    sentinel = "json-secret-sentinel"
+    webhook_command(_args(secret=sentinel, json=True))
+    created = json.loads(capsys.readouterr().out)
+    assert created["name"] == "events"
+    assert created["secret_set"] is True
+    assert created["secret_masked"] == "***"
+    assert sentinel not in json.dumps(created)
+
+    webhook_command(_args(webhook_action="list", json=True))
+    listed = json.loads(capsys.readouterr().out)
+    assert listed[0]["name"] == "events"
+    assert sentinel not in json.dumps(listed)
+
+    webhook_command(_args(webhook_action="show", json=True))
+    shown = json.loads(capsys.readouterr().out)
+    assert shown["name"] == "events"
+    assert sentinel not in json.dumps(shown)
+
+
+def test_update_preserves_unknown_fields_and_canonical_delivery():
+    webhook_command(_args())
+    path = _subscriptions_path()
+    persisted = json.loads(path.read_text(encoding="utf-8"))
+    persisted["events"]["future_policy"] = {"mode": "strict"}
+    path.write_text(json.dumps(persisted), encoding="utf-8")
+
+    webhook_command(
+        _args(
+            webhook_action="update",
+            prompt="new prompt",
+            events="deploy,build",
+            deliver="slack",
+            deliver_chat_id="C123",
+        )
+    )
+
+    route = _load_subscriptions()["events"]
+    assert route["prompt"] == "new prompt"
+    assert route["events"] == ["deploy", "build"]
+    assert route["future_policy"] == {"mode": "strict"}
+    assert route["deliveries"][0] == {"target": "slack", "chat_id": "C123"}
+
+
+def test_enable_disable_rotate_show_and_remove_lifecycle(capsys):
+    webhook_command(_args(secret="old-secret"))
+    capsys.readouterr()
+
+    webhook_command(_args(webhook_action="disable"))
+    assert _load_subscriptions()["events"]["enabled"] is False
+    webhook_command(_args(webhook_action="enable"))
+    assert _load_subscriptions()["events"]["enabled"] is True
+
+    capsys.readouterr()
+    webhook_command(_args(webhook_action="rotate-secret"))
+    rotated_output = capsys.readouterr().out
+    new_secret = _load_subscriptions()["events"]["secret"]
+    assert new_secret != "old-secret"
+    assert new_secret in rotated_output
+
+    webhook_command(_args(webhook_action="show"))
+    shown = capsys.readouterr().out
+    assert new_secret not in shown
+    assert "Secret:   ***" in shown
+
+    webhook_command(_args(webhook_action="remove"))
+    assert "events" not in _load_subscriptions()
+
+
+def test_profile_selection_shards_storage_and_urls(capsys):
+    webhook_command(_args(profile="ops"))
+
+    output = capsys.readouterr().out
+    assert "/p/ops/webhooks/events" in output
+    assert "events" not in _load_subscriptions()
+    assert _load_subscriptions("ops")["events"]["profile"] == "ops"
+    assert _subscriptions_path("ops").parent.name == "ops"
+
+    webhook_command(_args(webhook_action="remove", profile="ops"))
+    assert "events" not in _load_subscriptions("ops")
+
+
+def test_corrupt_store_fails_closed_without_consuming_secret_fd(tmp_path, capsys):
+    corrupt = b"{broken-store"
+    path = _subscriptions_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(corrupt)
+    secret_path = tmp_path / "secret-input"
+    secret_path.write_text("unconsumed", encoding="utf-8")
+
+    with secret_path.open("rb") as stream:
+        webhook_command(_args(secret="", secret_fd=stream.fileno()))
+        assert stream.tell() == 0
+
+    output = capsys.readouterr().out
+    assert "No changes were made" in output
+    assert path.read_bytes() == corrupt
+
+
+def _compat_route(secret: str, *, prompt: str = "") -> dict:
+    return {
+        "profile": "default",
+        "provider": "generic",
+        "signature_mode": "generic_v2",
+        "secret": secret,
+        "prompt": prompt,
+        "deliver": "log",
+        "deliver_extra": {},
+    }
+
+
+def test_compat_snapshots_merge_independent_concurrent_additions():
+    first = _load_subscriptions()
+    second = _load_subscriptions()
+    first["alpha"] = _compat_route("alpha-secret")
+    second["beta"] = _compat_route("beta-secret")
+
+    _save_subscriptions(first)
+    _save_subscriptions(second)
+
+    assert set(_load_subscriptions()) == {"alpha", "beta"}
+
+
+def test_compat_snapshot_rejects_divergent_same_route_update():
+    initial = _load_subscriptions()
+    initial["shared"] = _compat_route("shared-secret", prompt="before")
+    _save_subscriptions(initial)
+    first = _load_subscriptions()
+    second = _load_subscriptions()
+    first["shared"]["prompt"] = "writer-one"
+    second["shared"]["prompt"] = "writer-two"
+
+    _save_subscriptions(first)
+    with pytest.raises(ConcurrentWebhookUpdateError, match="shared"):
+        _save_subscriptions(second)
+
+    assert _load_subscriptions()["shared"]["prompt"] == "writer-one"
+
+
+def test_compat_snapshot_delete_preserves_unrelated_concurrent_addition():
+    initial = _load_subscriptions()
+    initial["old"] = _compat_route("old-secret")
+    _save_subscriptions(initial)
+    deleter = _load_subscriptions()
+    adder = _load_subscriptions()
+    del deleter["old"]
+    adder["new"] = _compat_route("new-secret")
+
+    _save_subscriptions(adder)
+    _save_subscriptions(deleter)
+
+    assert set(_load_subscriptions()) == {"new"}

--- a/tests/hermes_cli/test_webhook_cli_provider_contract.py
+++ b/tests/hermes_cli/test_webhook_cli_provider_contract.py
@@ -19,6 +19,7 @@ from hermes_cli.webhook import (
     _default_test_payload,
     _load_subscriptions,
     _save_subscriptions,
+    _subscriptions_path,
     _test_headers,
     webhook_command,
 )
@@ -39,14 +40,18 @@ def _args(**overrides) -> Namespace:
         "provider": "github",
         "signature_mode": "",
         "route_profile": "default",
+        "profile": "",
         "description": "",
         "skills": "",
         "deliver": "log",
         "deliver_chat_id": "",
         "secret": "test-secret",
+        "secret_fd": None,
         "payload": "",
         "script": "",
         "deliver_only": False,
+        "replace": False,
+        "json": False,
     }
     values.update(overrides)
     return Namespace(**values)
@@ -110,12 +115,12 @@ def test_named_profile_subscription_persists_and_tests_the_prefixed_url(
 ):
     webhook_command(_args(route_profile="Ops"))
 
-    route = _load_subscriptions()["events"]
+    route = _load_subscriptions("ops")["events"]
     assert route["profile"] == "ops"
     assert "/p/ops/webhooks/events" in capsys.readouterr().out
 
     captured = _capture_urlopen(monkeypatch)
-    webhook_command(_args(webhook_action="test"))
+    webhook_command(_args(webhook_action="test", profile="ops"))
 
     assert captured["request"].full_url == "http://localhost:8644/p/ops/webhooks/events"
 
@@ -190,7 +195,7 @@ def test_real_entrypoint_preserves_route_profile_for_webhook_subcommand(
     assert os.environ["HERMES_HOME"] == original_home
     main_mod.main()
 
-    route = _load_subscriptions()["entrypoint-profile"]
+    route = _load_subscriptions("ops")["entrypoint-profile"]
     assert route["profile"] == "ops"
 
 
@@ -426,16 +431,21 @@ def test_generated_default_request_satisfies_selected_verifier(
     assert envelope.event_type == events[0]
 
 
-def test_test_command_rejects_unbound_manual_route_before_network(
+def test_test_command_rejects_corrupt_unbound_store_before_network(
     capsys,
     monkeypatch,
 ):
-    _save_subscriptions({
-        "events": {
-            "description": "manually created",
-            "secret": "test-secret",
-        }
-    })
+    path = _subscriptions_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps({
+            "events": {
+                "description": "manually created",
+                "secret": "test-secret",
+            }
+        }),
+        encoding="utf-8",
+    )
     called = False
 
     def _unexpected_urlopen(*_args, **_kwargs):
@@ -447,4 +457,6 @@ def test_test_command_rejects_unbound_manual_route_before_network(
     webhook_command(_args(webhook_action="test"))
 
     assert called is False
-    assert "requires an explicit provider or signature_mode" in capsys.readouterr().out
+    assert (
+        "Cannot safely access the webhook subscription store" in capsys.readouterr().out
+    )

--- a/tests/hermes_cli/test_webhook_cli_provider_contract.py
+++ b/tests/hermes_cli/test_webhook_cli_provider_contract.py
@@ -1,0 +1,450 @@
+"""Provider-contract coverage for ``hermes webhook subscribe/test``."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import hmac
+import json
+import os
+import sys
+from argparse import Namespace
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_cli.subcommands.webhook import build_webhook_parser
+from hermes_cli.webhook import (
+    _bind_subscription,
+    _default_test_payload,
+    _load_subscriptions,
+    _save_subscriptions,
+    _test_headers,
+    webhook_command,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr("hermes_cli.webhook._is_webhook_enabled", lambda: True)
+
+
+def _args(**overrides) -> Namespace:
+    values = {
+        "webhook_action": "subscribe",
+        "name": "events",
+        "prompt": "",
+        "events": "",
+        "provider": "github",
+        "signature_mode": "",
+        "route_profile": "default",
+        "description": "",
+        "skills": "",
+        "deliver": "log",
+        "deliver_chat_id": "",
+        "secret": "test-secret",
+        "payload": "",
+        "script": "",
+        "deliver_only": False,
+    }
+    values.update(overrides)
+    return Namespace(**values)
+
+
+def _capture_urlopen(monkeypatch):
+    captured = {}
+
+    class _Response:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        @staticmethod
+        def read():
+            return b'{"status":"accepted"}'
+
+    def _urlopen(request, timeout):
+        captured["request"] = request
+        captured["timeout"] = timeout
+        return _Response()
+
+    monkeypatch.setattr("urllib.request.urlopen", _urlopen)
+    return captured
+
+
+def _handler(_args):
+    return None
+
+
+def test_subscribe_parser_exposes_provider_contract_flags():
+    parser = argparse.ArgumentParser(prog="hermes")
+    subparsers = parser.add_subparsers(dest="command")
+    build_webhook_parser(subparsers, cmd_webhook=_handler)
+
+    parsed = parser.parse_args([
+        "webhook",
+        "subscribe",
+        "chatwoot",
+        "--provider",
+        "chatwoot",
+        "--signature-mode",
+        "generic_v2",
+        "--route-profile",
+        "ops",
+    ])
+
+    assert parsed.provider == "chatwoot"
+    assert parsed.signature_mode == "generic_v2"
+    assert parsed.route_profile == "ops"
+    assert parsed.func is _handler
+
+
+def test_named_profile_subscription_persists_and_tests_the_prefixed_url(
+    monkeypatch,
+    capsys,
+):
+    webhook_command(_args(route_profile="Ops"))
+
+    route = _load_subscriptions()["events"]
+    assert route["profile"] == "ops"
+    assert "/p/ops/webhooks/events" in capsys.readouterr().out
+
+    captured = _capture_urlopen(monkeypatch)
+    webhook_command(_args(webhook_action="test"))
+
+    assert captured["request"].full_url == "http://localhost:8644/p/ops/webhooks/events"
+
+
+def test_subscribe_wildcard_bind_labels_local_url_and_requires_https_proxy(
+    monkeypatch,
+    capsys,
+):
+    monkeypatch.setattr(
+        "hermes_cli.webhook._get_webhook_config",
+        lambda: {"enabled": True, "extra": {"host": "0.0.0.0", "port": 8644}},
+    )
+
+    webhook_command(_args(route_profile="ops"))
+
+    output = capsys.readouterr().out
+    assert "Local test URL: http://localhost:8644/p/ops/webhooks/events" in output
+    assert (
+        "External callback: a public HTTPS reverse proxy is required; use "
+        "https://<public-host>/p/ops/webhooks/events and preserve the exact path."
+        in output
+    )
+    assert "Do not configure an external service with the local test URL." in output
+    assert "Callback URL: http://localhost" not in output
+
+
+def test_subscribe_nonloopback_bind_labels_callback_url(monkeypatch, capsys):
+    monkeypatch.setattr(
+        "hermes_cli.webhook._get_webhook_config",
+        lambda: {
+            "enabled": True,
+            "extra": {"host": "hooks.internal.example", "port": 9443},
+        },
+    )
+
+    webhook_command(_args())
+
+    output = capsys.readouterr().out
+    assert "Callback URL: http://hooks.internal.example:9443/webhooks/events" in output
+    assert "Local test URL:" not in output
+    assert "public HTTPS reverse proxy is required" not in output
+
+
+def test_real_entrypoint_preserves_route_profile_for_webhook_subcommand(
+    monkeypatch,
+):
+    import hermes_cli.main as main_mod
+
+    original_home = os.environ["HERMES_HOME"]
+    argv = [
+        "hermes",
+        "webhook",
+        "subscribe",
+        "entrypoint-profile",
+        "--route-profile",
+        "ops",
+        "--provider",
+        "generic",
+        "--signature-mode",
+        "generic_v2",
+        "--secret",
+        "test-secret",
+    ]
+    monkeypatch.setenv("HERMES_S6_SUPERVISED_CHILD", "1")
+    monkeypatch.setattr(sys, "argv", argv.copy())
+
+    # Exercise the same pre-argparse scanner and full parser/dispatch path as
+    # the console entrypoint. The route flag must neither switch HERMES_HOME
+    # nor disappear before the webhook subparser sees it.
+    main_mod._apply_profile_override()
+    assert sys.argv == argv
+    assert os.environ["HERMES_HOME"] == original_home
+    main_mod.main()
+
+    route = _load_subscriptions()["entrypoint-profile"]
+    assert route["profile"] == "ops"
+
+
+def test_subscribe_rejects_route_name_over_contract_bound(capsys):
+    webhook_command(_args(name="r" * 129))
+
+    assert _load_subscriptions() == {}
+    assert "at most 128" in capsys.readouterr().out
+
+
+def test_subscribe_persists_canonical_explicit_provider_contract():
+    webhook_command(
+        _args(
+            provider="github_hmac_sha256",
+            events="pull_request, pull_request, ",
+        )
+    )
+
+    route = _load_subscriptions()["events"]
+    assert route["provider"] == "github"
+    assert route["signature_mode"] == "github"
+    assert route["events"] == ["pull_request"]
+
+
+def test_subscribe_rejects_multiple_github_events_without_persisting(capsys):
+    webhook_command(_args(events="push,pull_request"))
+
+    assert _load_subscriptions() == {}
+    output = capsys.readouterr().out
+    assert "at most one route-bound event" in output
+
+
+def test_subscribe_rejects_github_event_without_body_classifier(capsys):
+    webhook_command(_args(events="workflow_run"))
+
+    assert _load_subscriptions() == {}
+    assert (
+        "cannot authenticate event body shape for 'workflow_run'"
+        in capsys.readouterr().out
+    )
+
+
+def test_subscribe_allows_multiple_payload_authoritative_events():
+    webhook_command(_args(provider="generic", events="build,deploy"))
+
+    route = _load_subscriptions()["events"]
+    assert route["provider"] == "generic"
+    assert route["signature_mode"] == "generic_v2"
+    assert route["events"] == ["build", "deploy"]
+
+
+@pytest.mark.parametrize(
+    ("provider", "expected_hint"),
+    [
+        (
+            "github",
+            "Authentication: GitHub webhook secret (X-Hub-Signature-256 HMAC-SHA256).",
+        ),
+        (
+            "gitlab",
+            "Authentication: GitLab Secret token (X-Gitlab-Token exact string match).",
+        ),
+        (
+            "generic",
+            "Authentication: generic_v2 secret "
+            "(X-Webhook-Timestamp + X-Webhook-Signature-V2 HMAC-SHA256).",
+        ),
+    ],
+)
+def test_subscribe_success_reports_provider_authentication_contract(
+    provider,
+    expected_hint,
+    capsys,
+):
+    webhook_command(_args(provider=provider))
+
+    output = capsys.readouterr().out
+    assert expected_hint in output
+    assert "Use the secret for HMAC-SHA256 signature validation" not in output
+
+
+def test_github_test_uses_route_bound_event_and_exact_body_mac(monkeypatch):
+    _save_subscriptions({
+        "events": {
+            "description": "Agent-created subscription: events",
+            "provider": "github",
+            "signature_mode": "github",
+            "events": ["pull_request"],
+            "secret": "test-secret",
+        }
+    })
+    captured = _capture_urlopen(monkeypatch)
+
+    webhook_command(_args(webhook_action="test"))
+
+    request = captured["request"]
+    headers = {key.lower(): value for key, value in request.header_items()}
+    expected = hmac.new(b"test-secret", request.data, hashlib.sha256).hexdigest()
+    assert headers["x-github-event"] == "pull_request"
+    assert headers["x-hub-signature-256"] == f"sha256={expected}"
+    payload = json.loads(request.data)
+    assert payload["pull_request"]["number"] == payload["number"]
+    assert {"repository", "sender"} <= payload.keys()
+    assert captured["timeout"] == 10
+
+
+def test_generic_v2_test_uses_timestamp_body_mac_and_selected_event(
+    monkeypatch,
+):
+    _save_subscriptions({
+        "events": {
+            "description": "Agent-created subscription: events",
+            "provider": "generic",
+            "signature_mode": "generic_v2",
+            "events": ["deploy", "build"],
+            "secret": "test-secret",
+        }
+    })
+    monkeypatch.setattr("hermes_cli.webhook.time.time", lambda: 1_700_000_000)
+    captured = _capture_urlopen(monkeypatch)
+
+    webhook_command(_args(webhook_action="test"))
+
+    request = captured["request"]
+    headers = {key.lower(): value for key, value in request.header_items()}
+    signed = b"1700000000." + request.data
+    expected = hmac.new(b"test-secret", signed, hashlib.sha256).hexdigest()
+    assert headers["x-webhook-timestamp"] == "1700000000"
+    assert headers["x-webhook-signature-v2"] == expected
+    assert json.loads(request.data)["event_type"] == "deploy"
+
+
+@pytest.mark.parametrize(
+    ("provider", "signature_mode", "events"),
+    [
+        ("github", "github", ["check_run"]),
+        ("github", "github", ["issues"]),
+        ("github", "github", ["ping"]),
+        ("github", "github", ["pull_request"]),
+        ("github", "github", ["push"]),
+        ("gitlab", "gitlab", ["Push Hook"]),
+        ("hindsight", "hindsight", ["memory.created"]),
+        ("linear", "linear", ["Issue"]),
+        ("generic", "generic_v1", ["deploy"]),
+        ("generic", "generic_v2", ["deploy"]),
+        ("chatwoot", "generic_v2", ["message_created"]),
+    ],
+)
+def test_default_payloads_without_native_identity_have_fresh_body_test_ids(
+    provider,
+    signature_mode,
+    events,
+    monkeypatch,
+):
+    route = _bind_subscription(
+        "events",
+        {
+            "provider": provider,
+            "signature_mode": signature_mode,
+            "events": events,
+        },
+    )
+    tokens = iter(("11" * 12, "22" * 12))
+    monkeypatch.setattr(
+        "hermes_cli.webhook.secrets.token_hex",
+        lambda length: next(tokens) if length == 12 else "",
+    )
+
+    first = _default_test_payload(route)
+    second = _default_test_payload(route)
+
+    assert first["test_id"] == f"test_{'11' * 12}"
+    assert second["test_id"] == f"test_{'22' * 12}"
+    assert first != second
+
+
+@pytest.mark.parametrize(
+    ("provider", "signature_mode", "events"),
+    [
+        ("github", "github", ["check_run"]),
+        ("github", "github", ["issues"]),
+        ("github", "github", ["ping"]),
+        ("github", "github", ["pull_request"]),
+        ("github", "github", ["push"]),
+        ("gitlab", "gitlab", ["Push Hook"]),
+        ("svix", "svix", ["message.created"]),
+        ("standard_webhooks", "standard_webhooks", ["message.created"]),
+        ("hindsight", "hindsight", ["memory.created"]),
+        ("hermes", "hermes", ["post_tool_call"]),
+        ("linear", "linear", ["Issue"]),
+        ("stripe", "stripe", ["invoice.paid"]),
+        ("generic", "generic_v1", ["deploy"]),
+        ("generic", "generic_v2", ["deploy"]),
+        ("chatwoot", "generic_v2", ["message_created"]),
+    ],
+)
+def test_generated_default_request_satisfies_selected_verifier(
+    provider,
+    signature_mode,
+    events,
+):
+    from gateway.platforms.webhook_auth import WebhookAuthMixin
+    from gateway.platforms.webhook_contract import WebhookEnvelope
+
+    class _Verifier(WebhookAuthMixin):
+        pass
+
+    route = _bind_subscription(
+        "events",
+        {
+            "provider": provider,
+            "signature_mode": signature_mode,
+            "events": events,
+        },
+    )
+    payload_object = _default_test_payload(route)
+    payload = json.dumps(payload_object, ensure_ascii=False).encode()
+    headers = _test_headers(route, "test-secret", payload, payload_object)
+    request = SimpleNamespace(headers=headers, match_info={"route_name": "events"})
+
+    receipt = _Verifier()._verify_signature_receipt(
+        request,
+        payload,
+        "test-secret",
+        route,
+    )
+    assert receipt is not None
+    envelope = WebhookEnvelope.from_receipt(
+        receipt,
+        raw_body=payload,
+        media_type="application/json",
+    )
+    assert envelope.event_type == events[0]
+
+
+def test_test_command_rejects_unbound_manual_route_before_network(
+    capsys,
+    monkeypatch,
+):
+    _save_subscriptions({
+        "events": {
+            "description": "manually created",
+            "secret": "test-secret",
+        }
+    })
+    called = False
+
+    def _unexpected_urlopen(*_args, **_kwargs):
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr("urllib.request.urlopen", _unexpected_urlopen)
+
+    webhook_command(_args(webhook_action="test"))
+
+    assert called is False
+    assert "requires an explicit provider or signature_mode" in capsys.readouterr().out

--- a/website/docs/guides/automation-blueprints.md
+++ b/website/docs/guides/automation-blueprints.md
@@ -19,7 +19,7 @@ For parameterized blueprints with forms instead of cron syntax, see the [Automat
 | **GitHub Event** | Fires on PR opens, pushes, issues, CI results | Webhook platform (`hermes webhook subscribe`) |
 | **API Call** | External service POSTs JSON to your endpoint | Webhook platform (config.yaml routes or `hermes webhook subscribe`) |
 
-All three support delivery to Telegram, Discord, Slack, SMS, email, GitHub comments, or local files.
+Webhook routes can deliver to the gateway log, Telegram, Discord, Slack, Signal, SMS, or a fully bound GitHub PR comment target. Scheduled tasks have their own configured delivery choices.
 :::
 
 ---
@@ -51,14 +51,16 @@ Format as a clean digest. If no new issues, respond with [SILENT]." \
 
 ### Automatic PR Code Review
 
-Review every pull request automatically when it's opened. Posts a review comment directly on the PR.
+Review every pull request automatically when it's opened. The static route posts the final review directly on the PR; the constrained CLI alternative logs a metadata-only review checklist.
 
 **Trigger:** GitHub webhook
 
-**Option A — Dynamic subscription (CLI):**
+**Option A — Dynamic subscription (CLI, metadata-only review to the log):**
 
 ```bash
 hermes webhook subscribe github-pr-review \
+  --provider github \
+  --signature-mode github \
   --events "pull_request" \
   --prompt "Review this pull request:
 Repository: {repository.full_name}
@@ -67,18 +69,14 @@ Author: {pull_request.user.login}
 Action: {action}
 Diff URL: {pull_request.diff_url}
 
-Fetch the diff with: curl -sL {pull_request.diff_url}
-
-Review for:
-- Security issues (injection, auth bypass, secrets in code)
-- Performance concerns (N+1 queries, unbounded loops, memory leaks)
-- Code quality (naming, duplication, error handling)
-- Missing tests for new behavior
-
-Post a concise review. If the PR is a trivial docs/typo change, say so briefly." \
+Based only on the signed webhook metadata, identify the likely review focus and
+return a concise checklist for a human reviewer. Do not claim to have inspected
+the diff or post anything to GitHub." \
   --skills github-code-review \
-  --deliver github_comment
+  --deliver log
 ```
+
+The dynamic CLI does not expose per-route `toolsets` or the `repo` and `pr_number` authority required by `github_comment`. Use the static route below when the agent must fetch the diff and post the result to GitHub.
 
 **Option B — Static route (config.yaml):**
 
@@ -88,17 +86,24 @@ platforms:
     enabled: true
     extra:
       port: 8644
-      secret: "your-global-secret"
       routes:
         github-pr-review:
+          provider: github
+          signature_mode: github
           events: ["pull_request"]
           secret: "github-webhook-secret"
+          filters:
+            - field: "action"
+              in: ["opened", "synchronize", "reopened"]
+          toolsets: ["terminal"]
           prompt: |
             Review PR #{pull_request.number}: {pull_request.title}
             Repository: {repository.full_name}
             Author: {pull_request.user.login}
-            Diff URL: {pull_request.diff_url}
+            Fetch the diff with:
+            gh pr diff {pull_request.number} --repo {repository.full_name}
             Review for security, performance, and code quality.
+            Return only the review text; do not post it yourself.
           skills: ["github-code-review"]
           deliver: "github_comment"
           deliver_extra:
@@ -107,6 +112,8 @@ platforms:
 ```
 
 Then in GitHub: **Settings → Webhooks → Add webhook** → Payload URL: `http://your-server:8644/webhooks/github-pr-review`, Content type: `application/json`, Secret: `github-webhook-secret`, Events: **Pull requests**.
+
+The agent's `gh pr diff` command runs in the configured terminal backend, while the adapter's final `gh pr comment` delivery runs on the gateway host. Install and authenticate `gh` in both places when they are different machines or containers.
 
 ### Docs Drift Detection
 
@@ -168,8 +175,12 @@ Trigger smoke tests after every deployment. Your CI/CD pipeline POSTs to the web
 **Trigger:** API call (webhook)
 
 ```bash
+DEPLOY_WEBHOOK_SECRET="replace-with-a-random-secret"
 hermes webhook subscribe deploy-verify \
+  --provider generic \
+  --signature-mode generic_v2 \
   --events "deployment" \
+  --secret "$DEPLOY_WEBHOOK_SECRET" \
   --prompt "A deployment just completed:
 Service: {service}
 Environment: {environment}
@@ -177,11 +188,11 @@ Version: {version}
 Deployed by: {deployer}
 
 Run these verification steps:
-1. Check if the service is responding: curl -s -o /dev/null -w '%{http_code}' {health_url}
-2. Search recent logs for errors: check the deployment payload for any error indicators
-3. Verify the version matches: curl -s {health_url}/version
+1. Use web extraction to check whether {health_url} responds successfully
+2. Inspect the deployment payload's error summary: {errors}
+3. Use web extraction to verify that {version_url} reports version {version}
 
-Report: deployment status (healthy/degraded/failed), response time, any errors found.
+Report: deployment status (healthy/degraded/failed), observed versions, and any errors found.
 If healthy, keep it brief. If degraded or failed, provide detailed diagnostics." \
   --deliver telegram
 ```
@@ -189,20 +200,30 @@ If healthy, keep it brief. If degraded or failed, provide detailed diagnostics."
 Your CI/CD pipeline triggers it:
 
 ```bash
+BODY='{"event_type":"deployment","service":"api","environment":"prod","version":"2.1.0","deployer":"ci","health_url":"https://api.example.com/health","version_url":"https://api.example.com/version","errors":[]}'
+TIMESTAMP=$(date +%s)
+SIG=$(printf '%s.%s' "$TIMESTAMP" "$BODY" | openssl dgst -sha256 -hmac "$DEPLOY_WEBHOOK_SECRET" -hex | awk '{print $2}')
+
 curl -X POST http://your-server:8644/webhooks/deploy-verify \
   -H "Content-Type: application/json" \
-  -H "X-Hub-Signature-256: sha256=$(echo -n '{"service":"api","environment":"prod","version":"2.1.0","deployer":"ci","health_url":"https://api.example.com/health"}' | openssl dgst -sha256 -hmac 'your-secret' | cut -d' ' -f2)" \
-  -d '{"service":"api","environment":"prod","version":"2.1.0","deployer":"ci","health_url":"https://api.example.com/health"}'
+  -H "X-Webhook-Timestamp: $TIMESTAMP" \
+  -H "X-Webhook-Signature-V2: $SIG" \
+  -d "$BODY"
 ```
 
 ### Alert Triage
 
-Correlate monitoring alerts with recent changes to draft a response. Works with Datadog, PagerDuty, Grafana, or any alerting system that can POST JSON.
+Correlate monitoring alerts with recent changes to draft a response. This generic recipe works with any alerting system, or a trusted relay in front of it, that can send Hermes Generic V2 signatures.
 
 **Trigger:** API call (webhook)
 
 ```bash
+ALERT_WEBHOOK_SECRET="replace-with-a-random-secret"
 hermes webhook subscribe alert-triage \
+  --provider generic \
+  --signature-mode generic_v2 \
+  --events "alert" \
+  --secret "$ALERT_WEBHOOK_SECRET" \
   --prompt "Monitoring alert received:
 Alert: {alert.name}
 Severity: {alert.severity}
@@ -221,6 +242,8 @@ Investigate:
 Be concise. This goes to the on-call channel." \
   --deliver slack
 ```
+
+Send a top-level `"event_type": "alert"` in the signed JSON body and calculate `X-Webhook-Timestamp` and `X-Webhook-Signature-V2` exactly as in the deploy example above. Provider-specific headers never select a verifier automatically; use a provider-specific route instead when the sender has a supported native contract.
 
 ### Uptime Monitor
 
@@ -346,14 +369,16 @@ hermes cron create "0 8 * * *" \
 
 ## GitHub Event Automations
 
-### Issue Auto-Labeling
+### Issue Triage Drafts
 
-Automatically label and respond to new issues.
+Draft labels and an initial response for new issues, then log them for review.
 
 **Trigger:** GitHub webhook
 
 ```bash
 hermes webhook subscribe github-issues \
+  --provider github \
+  --signature-mode github \
   --events "issues" \
   --prompt "New GitHub issue received:
 Repository: {repository.full_name}
@@ -367,15 +392,17 @@ If this is a new issue (action=opened):
 1. Read the issue title and body carefully
 2. Suggest appropriate labels (bug, feature, docs, security, question)
 3. If it's a bug report, check if you can identify the affected component from the description
-4. Post a helpful initial response acknowledging the issue
+4. Draft a helpful initial response acknowledging the issue
 
 If this is a label or assignment change, respond with [SILENT]." \
-  --deliver github_comment
+  --deliver log
 ```
+
+This dynamic recipe logs label suggestions and a response draft. The CLI cannot bind the `repo` and `pr_number` fields required by `github_comment`; use a static route with an explicit `deliver_extra` target if the result must be posted to GitHub.
 
 ### CI Failure Analysis
 
-Analyze CI failures and post diagnostics on the PR.
+Analyze CI failures and log diagnostics. A check run can reference zero or multiple pull requests, so this recipe does not assume one fixed GitHub comment target.
 
 **Trigger:** GitHub webhook
 
@@ -387,54 +414,67 @@ platforms:
     extra:
       routes:
         ci-failure:
+          provider: github
+          signature_mode: github
           events: ["check_run"]
           secret: "ci-secret"
+          toolsets: ["web"]
           prompt: |
             CI check failed:
             Repository: {repository.full_name}
             Check: {check_run.name}
             Status: {check_run.conclusion}
-            PR: #{check_run.pull_requests.0.number}
+            Associated PRs: {check_run.pull_requests}
             Details URL: {check_run.details_url}
 
             If conclusion is "failure":
-            1. Fetch the log from the details URL if accessible
+            1. Use web extraction to inspect the details URL if it is publicly accessible
             2. Identify the likely cause of failure
             3. Suggest a fix
             If conclusion is "success", respond with [SILENT].
-          deliver: "github_comment"
-          deliver_extra:
-            repo: "{repository.full_name}"
-            pr_number: "{check_run.pull_requests.0.number}"
+          deliver: "log"
 ```
 
-### Auto-Port Changes Across Repos
+### Plan Cross-Repo Ports
 
-When a PR merges in one repo, automatically port the equivalent change to another.
+When a PR merges in one repo, inspect its diff and prepare a concrete porting plan for another repository.
 
 **Trigger:** GitHub webhook
 
-```bash
-hermes webhook subscribe auto-port \
-  --events "pull_request" \
-  --prompt "PR merged in the source repository:
-Repository: {repository.full_name}
-PR #{pull_request.number}: {pull_request.title}
-Author: {pull_request.user.login}
-Action: {action}
-Merge commit: {pull_request.merge_commit_sha}
+```yaml
+# config.yaml route
+platforms:
+  webhook:
+    enabled: true
+    extra:
+      routes:
+        auto-port-plan:
+          provider: github
+          signature_mode: github
+          events: ["pull_request"]
+          secret: "auto-port-secret"
+          filters:
+            - field: "action"
+              equals: "closed"
+            - field: "pull_request.merged"
+              equals: true
+          toolsets: ["terminal"]
+          prompt: |
+            A pull request merged in {repository.full_name}:
+            PR #{pull_request.number}: {pull_request.title}
+            Merge commit: {pull_request.merge_commit_sha}
 
-If action is 'closed' and pull_request.merged is true:
-1. Fetch the diff: curl -sL {pull_request.diff_url}
-2. Analyze what changed
-3. Determine if this change needs to be ported to the Go SDK equivalent
-4. If yes, create a branch, apply the equivalent changes, and open a PR on the target repo
-5. Reference the original PR in the new PR description
+            Run:
+            gh pr diff {pull_request.number} --repo {repository.full_name}
 
-If action is not 'closed' or not merged, respond with [SILENT]." \
-  --skills github-pr-workflow \
-  --deliver log
+            Analyze the diff and prepare a file-by-file porting plan for org/go-sdk.
+            Include a proposed PR title and body that reference the original PR.
+            Do not clone, edit, push, or open a PR; return the plan only.
+          skills: ["github-pr-workflow"]
+          deliver: log
 ```
+
+The `terminal` grant is explicit because dynamic subscriptions cannot add per-route toolsets. The `gh pr diff` command runs in the configured terminal backend, where `gh` must be installed and authenticated.
 
 ---
 
@@ -447,8 +487,12 @@ Track payment events and get summaries of failures.
 **Trigger:** API call (webhook)
 
 ```bash
+STRIPE_WEBHOOK_SECRET="whsec_replace_with_your_endpoint_secret"
 hermes webhook subscribe stripe-payments \
+  --provider stripe \
+  --signature-mode stripe \
   --events "payment_intent.succeeded,payment_intent.payment_failed,charge.dispute.created" \
+  --secret "$STRIPE_WEBHOOK_SECRET" \
   --prompt "Stripe event received:
 Event type: {type}
 Amount: {data.object.amount} cents ({data.object.currency})
@@ -581,7 +625,7 @@ Keep the outline to ~300 words. This is a starting point, not a finished post." 
 | `{issue.number}` | Issue number |
 | `{repository.full_name}` | `owner/repo` |
 | `{action}` | Event action (opened, closed, etc.) |
-| `{__raw__}` | Full JSON payload (truncated at 4000 chars) |
+| `{__raw__}` | Parseable raw-payload envelope bounded to 4,000 UTF-8 bytes, with explicit truncation metadata |
 | `{sender.login}` | GitHub user who triggered the event |
 
 ### The [SILENT] Pattern

--- a/website/docs/guides/webhook-github-pr-review.md
+++ b/website/docs/guides/webhook-github-pr-review.md
@@ -20,7 +20,7 @@ For the full webhook platform reference (all config options, delivery types, dyn
 :::
 
 :::warning Prompt injection risk
-Webhook payloads contain attacker-controlled data — PR titles, commit messages, and descriptions can contain malicious instructions. When your webhook endpoint is exposed to the internet, run the gateway in a sandboxed environment (Docker, SSH backend). See the [security section](#security-notes) below.
+Webhook payloads contain attacker-controlled data — PR titles, commit messages, and descriptions can contain malicious instructions. Hermes does not add an OS sandbox for a route's terminal grant. Isolate the configured terminal backend with Docker, a VM, or an SSH policy, and remember that final `github_comment` delivery runs separately on the gateway host. See the [security section](#security-notes) below.
 :::
 
 ---
@@ -28,7 +28,8 @@ Webhook payloads contain attacker-controlled data — PR titles, commit messages
 ## Prerequisites
 
 - Hermes Agent installed and running (`hermes gateway`)
-- [`gh` CLI](https://cli.github.com/) installed and authenticated on the gateway host (`gh auth login`)
+- [`gh` CLI](https://cli.github.com/) installed and authenticated in the configured terminal backend, where the agent runs `gh pr diff`
+- `gh` also installed and authenticated on the gateway host, where the `github_comment` delivery adapter runs `gh pr comment` (this can be the same installation for a local backend)
 - A publicly reachable URL for your Hermes instance (see [Local testing with ngrok](#local-testing-with-ngrok) if running locally)
 - Admin access to the GitHub repository (required to manage webhooks)
 
@@ -44,13 +45,16 @@ platforms:
     enabled: true
     extra:
       port: 8644          # default; change if another service occupies this port
-      rate_limit: 30      # max requests per minute per route (not a global cap)
+      rate_limit: 30      # new identities per profile/route per sliding 60 seconds
 
       routes:
         github-pr-review:
+          provider: github
+          signature_mode: github
           secret: "your-webhook-secret-here"   # must match the GitHub webhook secret exactly
           events:
             - pull_request
+          toolsets: ["terminal"]                 # explicit grant required for gh
 
           # The agent is instructed to fetch the actual diff before reviewing.
           # {number} and {repository.full_name} are resolved from the GitHub payload.
@@ -63,12 +67,13 @@ platforms:
             Description: {pull_request.body}
             URL: {pull_request.html_url}
 
-            If the action is "closed" or "labeled", stop here and do not post a comment.
+            If the action is "closed" or "labeled", respond with [SILENT].
 
             Otherwise:
             1. Run: gh pr diff {number} --repo {repository.full_name}
             2. Review the code changes for correctness, security issues, and clarity.
-            3. Write a concise, actionable review comment and post it.
+            3. Return a concise, actionable review comment. Do not post it yourself;
+               the configured github_comment target posts the final response.
 
           deliver: github_comment
           deliver_extra:
@@ -80,15 +85,18 @@ platforms:
 
 | Field | Description |
 |---|---|
-| `secret` (route-level) | HMAC secret for this route. Falls back to `extra.secret` global if omitted. |
-| `events` | List of `X-GitHub-Event` header values to accept. Empty list = accept all. |
+| `provider` | Binds this route to the GitHub verifier; request headers cannot select a provider. |
+| `signature_mode` | Explicitly binds GitHub's `X-Hub-Signature-256` verifier. |
+| `secret` (route-level) | HMAC secret for this route. A global `extra.secret` fallback is valid only when exactly one authenticated route uses it; otherwise every route needs unique key material. |
+| `events` | At most one authenticated GitHub event class. Supported values are `check_run`, `pull_request`, `push`, `issues`, and `ping`; the header and signed body shape must both match. Empty list accepts without event dispatch authority (`event=unknown`). |
+| `toolsets` | Replaces the constrained webhook defaults for this route. `terminal` is required for `gh pr diff`; remove it if you change the prompt to avoid shell access. |
 | `prompt` | Template; `{field}` and `{nested.field}` resolve from the GitHub payload. |
 | `deliver` | `github_comment` posts via `gh pr comment`. `log` just writes to the gateway log. |
 | `deliver_extra.repo` | Resolves to e.g. `org/repo` from the payload. |
 | `deliver_extra.pr_number` | Resolves to the PR number from the payload. |
 
 :::note The payload does not contain code
-The GitHub webhook payload includes PR metadata (title, description, branch names, URLs) but **not the diff**. The prompt above instructs the agent to run `gh pr diff` to fetch the actual changes. The default `hermes-webhook` toolset is deliberately constrained (web search/extract, vision, clarify — **no terminal**) because webhook payloads can carry untrusted content. To let this route run `gh`, add a per-route toolset grant: `toolsets: ["terminal", "web"]` on the route config — see [Per-route toolsets](/docs/user-guide/messaging/webhooks#per-route-toolsets).
+The GitHub webhook payload includes PR metadata (title, description, branch names, URLs) but **not the diff**. The prompt above instructs the agent to run `gh pr diff` to fetch the actual changes. The default `hermes-webhook` toolset is deliberately constrained (web search/extract, vision, clarify — **no terminal**) because webhook payloads can carry untrusted content. This route therefore grants exactly `toolsets: ["terminal"]`; that replaces the platform default for this route. See [Per-route toolsets](/docs/user-guide/messaging/webhooks#per-route-toolsets).
 :::
 
 ---
@@ -102,14 +110,14 @@ hermes gateway
 You should see:
 
 ```
-[webhook] Listening on 0.0.0.0:8644 — routes: github-pr-review
+[webhook] Listening on * (all interfaces, IPv4+IPv6):8644 — routes: github-pr-review
 ```
 
 Verify it's running:
 
 ```bash
 curl http://localhost:8644/health
-# {"status": "ok", "platform": "webhook"}
+# {"status":"ok","platform":"webhook","accepting_webhooks":true}
 ```
 
 ---
@@ -124,7 +132,7 @@ curl http://localhost:8644/health
    - **Which events?** → Select individual events → check **Pull requests**
 3. Click **Add webhook**
 
-GitHub will immediately send a `ping` event to confirm the connection. It is safely ignored — `ping` is not in your `events` list — and returns `{"status": "ignored", "event": "ping"}`. It is only logged at DEBUG level, so it won't appear in the console at the default log level.
+GitHub will immediately send a signed `ping` event to confirm the connection. Because this route binds exactly `pull_request`, that delivery is rejected with HTTP `401` (`Invalid authenticated webhook metadata`). Both the `X-GitHub-Event` value and the HMAC-covered JSON body shape must match, so relabeling the ping header cannot turn it into a pull-request event. This is expected; a later signed `pull_request` delivery is the functional test.
 
 ---
 
@@ -150,23 +158,36 @@ ngrok http 8644
 
 Copy the `https://...ngrok-free.app` URL and use it as your GitHub Payload URL. On the free ngrok tier the URL changes each time ngrok restarts — update your GitHub webhook each session. Paid ngrok accounts get a static domain.
 
-You can smoke-test a static route directly with `curl` — no GitHub account or real PR needed.
+You can smoke-test a static route directly with `curl` — no GitHub account or real PR needed. Add a separate log-only route with its own secret so testing does not mutate the key-bound policy of the production route:
 
-:::tip Use `deliver: log` when testing locally
-Change `deliver: github_comment` to `deliver: log` in your config while testing. Otherwise the agent will attempt to post a comment to the fake `org/repo#99` repo in the test payload, which will fail. Switch back to `deliver: github_comment` once you're satisfied with the prompt output.
+```yaml
+# Inside platforms.webhook.extra.routes:
+github-pr-review-smoke:
+  provider: github
+  signature_mode: github
+  events: [pull_request]
+  secret: "a-distinct-smoke-test-secret"
+  prompt: |
+    Summarize this test PR payload:
+    PR #{number}: {pull_request.title} in {repository.full_name}
+  deliver: log
+```
+
+:::tip Why use a second route?
+The secret is permanently bound to its route name, profile, verifier, prompt, tools, and delivery policy. Reusing the production secret after changing `deliver` from `github_comment` to `log` is rejected; a separate route keeps both authorities unambiguous.
 :::
 
 ```bash
-SECRET="your-webhook-secret-here"
-BODY='{"action":"opened","number":99,"pull_request":{"title":"Test PR","body":"Adds a feature.","user":{"login":"testuser"},"head":{"ref":"feat/x"},"base":{"ref":"main"},"html_url":"https://github.com/org/repo/pull/99"},"repository":{"full_name":"org/repo"}}'
+SECRET="a-distinct-smoke-test-secret"
+BODY='{"action":"opened","number":99,"pull_request":{"id":701,"number":99,"state":"open","title":"Test PR","body":"Adds a feature.","user":{"login":"testuser"},"head":{"ref":"feat/x"},"base":{"ref":"main"},"html_url":"https://github.com/org/repo/pull/99"},"repository":{"id":801,"full_name":"org/repo"},"sender":{"id":901,"login":"testuser"}}'
 SIG=$(printf '%s' "$BODY" | openssl dgst -sha256 -hmac "$SECRET" -hex | awk '{print "sha256="$2}')
 
-curl -s -X POST http://localhost:8644/webhooks/github-pr-review \
+curl -s -X POST http://localhost:8644/webhooks/github-pr-review-smoke \
   -H "Content-Type: application/json" \
   -H "X-GitHub-Event: pull_request" \
   -H "X-Hub-Signature-256: $SIG" \
   -d "$BODY"
-# Expected: {"status":"accepted","route":"github-pr-review","event":"pull_request","delivery_id":"..."}
+# HTTP 202: {"status":"accepted","route":"github-pr-review-smoke","event":"pull_request","delivery_id":"...","deduplication":"authenticated_body_sha256"}
 ```
 
 Then watch the agent run:
@@ -182,14 +203,15 @@ tail -f "${HERMES_HOME:-$HOME/.hermes}/logs/gateway.log"
 
 ## Filtering to specific actions
 
-GitHub sends `pull_request` events for many actions: `opened`, `synchronize`, `reopened`, `closed`, `labeled`, etc. The `events` list filters by the `X-GitHub-Event` header value, and route-level `filters` can narrow by payload fields such as `action`.
+GitHub sends `pull_request` events for many actions: `opened`, `synchronize`, `reopened`, `closed`, `labeled`, etc. The route binds both the `X-GitHub-Event` value and authenticated pull-request body class; route-level `filters` can then narrow by payload fields such as `action`.
 
-The prompt in Step 1 already handles this by instructing the agent to stop early for `closed` and `labeled` events.
+The prompt in Step 1 already handles this by returning `[SILENT]` for `closed` and `labeled` events.
 
 :::warning The agent still runs and consumes tokens
-The "stop here" instruction prevents a meaningful review, but the agent still runs to completion for every `pull_request` event regardless of action. Prefer filtering before the agent wakes:
+The `[SILENT]` instruction suppresses final delivery, but the agent still runs for every `pull_request` event regardless of action. Prefer filtering before the agent wakes. Because filters are part of the key-bound execution policy, set a **fresh route secret** and update the GitHub webhook secret at the same time; reusing the original secret with this edit is rejected.
 
 ```yaml
+secret: "fresh-secret-for-filtered-policy"
 filters:
   - field: "action"
     in: ["opened", "synchronize", "reopened"]
@@ -204,7 +226,7 @@ For high-volume repositories, you can still filter upstream with a GitHub Action
 
 ## Using a skill for consistent review style
 
-Load a [Hermes skill](/user-guide/features/skills) to give the agent a consistent review persona. Add `skills` to your route inside `platforms.webhook.extra.routes` in `config.yaml`:
+Load a [Hermes skill](/user-guide/features/skills) to give the agent a consistent review persona. A skill changes the key-bound execution policy, so use a fresh secret in both this route and the GitHub webhook rather than adding it under the old secret:
 
 ```yaml
 platforms:
@@ -213,19 +235,23 @@ platforms:
     extra:
       routes:
         github-pr-review:
-          secret: "your-webhook-secret-here"
+          provider: github
+          signature_mode: github
+          secret: "fresh-secret-for-skilled-policy"
           events: [pull_request]
+          toolsets: ["terminal"]
           prompt: |
             A pull request event was received (action: {action}).
             PR #{number}: {pull_request.title} by {pull_request.user.login}
             URL: {pull_request.html_url}
 
-            If the action is "closed" or "labeled", stop here and do not post a comment.
+            If the action is "closed" or "labeled", respond with [SILENT].
 
             Otherwise:
             1. Run: gh pr diff {number} --repo {repository.full_name}
             2. Review the diff using your review guidelines.
-            3. Write a concise, actionable review comment and post it.
+            3. Return a concise, actionable review comment. Do not post it yourself;
+               the configured github_comment target posts the final response.
           skills:
             - review
           deliver: github_comment
@@ -240,23 +266,30 @@ platforms:
 
 ## Sending responses to Slack or Discord instead
 
-Replace the `deliver` and `deliver_extra` fields inside your route with your target platform:
+Delivery kind and target fields are part of the key-bound execution policy. To switch an existing route, rotate to a fresh secret in both the route and GitHub, then replace `deliver` and `deliver_extra` with one of these targets:
+
+Slack:
 
 ```yaml
 # Inside platforms.webhook.extra.routes.<route-name>:
-
-# Slack
+secret: "fresh-secret-for-this-slack-policy"
 deliver: slack
 deliver_extra:
   chat_id: "C0123456789"   # Slack channel ID (omit to use the configured home channel)
+  scope_id: "T0123456789"  # Slack workspace/team ID for this channel
+```
 
-# Discord
+Discord:
+
+```yaml
+# Inside platforms.webhook.extra.routes.<route-name>:
+secret: "fresh-secret-for-this-discord-policy"
 deliver: discord
 deliver_extra:
   chat_id: "987654321012345678"  # Discord channel ID (omit to use home channel)
 ```
 
-The target platform must also be enabled and connected in the gateway. If `chat_id` is omitted, the response is sent to that platform's configured home channel.
+The target platform must also be enabled and connected in the gateway. If `chat_id` is omitted, the response is sent to that platform's configured home channel. A templated Slack `chat_id` requires an explicit route-bound `scope_id`; for a static channel, the adapter may establish that scope from the connected workspace, but specifying it removes ambiguity.
 
 Valid `deliver` values: `log` · `github_comment` · `telegram` · `discord` · `slack` · `signal` · `sms`
 
@@ -264,26 +297,35 @@ Valid `deliver` values: `log` · `github_comment` · `telegram` · `discord` · 
 
 ## GitLab support
 
-The same adapter works with GitLab. GitLab uses `X-Gitlab-Token` for authentication (plain string match, not HMAC) — Hermes handles both automatically.
+The same adapter works with GitLab, but the route must explicitly bind the GitLab verifier. Request headers never select or auto-detect a provider. GitLab uses `X-Gitlab-Token` for authentication (plain string match, not HMAC), so give it a separate route and secret from GitHub.
 
-For event filtering, GitLab sets `X-GitLab-Event` to values like `Merge Request Hook`, `Push Hook`, `Pipeline Hook`. Use the exact header value in `events`:
+For event filtering, GitLab sets `X-GitLab-Event` to values like `Merge Request Hook`, `Push Hook`, and `Pipeline Hook`. A GitLab route may bind at most one of these unsigned header values; use the exact value:
 
 ```yaml
-events:
-  - Merge Request Hook
+# Inside platforms.webhook.extra.routes:
+gitlab-mr-review:
+  provider: gitlab
+  signature_mode: gitlab
+  secret: "a-distinct-gitlab-token"
+  events:
+    - Merge Request Hook
+  prompt: |
+    Review GitLab MR !{object_attributes.iid}: {object_attributes.title}
+    Return a concise review based on the authenticated payload metadata.
+  deliver: log
 ```
 
-GitLab payload fields differ from GitHub's — e.g. `{object_attributes.title}` for the MR title and `{object_attributes.iid}` for the MR number. The easiest way to discover the full payload structure is GitLab's **Test** button in your webhook settings, combined with the **Recent Deliveries** log. Alternatively, omit `prompt` from your route config — Hermes will then pass the full payload as formatted JSON directly to the agent, and the agent's response (visible in the gateway log with `deliver: log`) will describe its structure.
+GitLab payload fields differ from GitHub's — e.g. `{object_attributes.title}` for the MR title and `{object_attributes.iid}` for the MR number. The easiest way to discover the full payload structure is GitLab's **Test** button in your webhook settings, combined with the **Recent Deliveries** log. Alternatively, omit `prompt` from your route config — Hermes then passes a parseable raw-payload envelope bounded to 4,000 UTF-8 bytes (with an explicit `truncated` marker) to the agent.
 
 ---
 
 ## Security notes
 
 - **Never use `INSECURE_NO_AUTH`** in production — it disables signature validation entirely. It is only for local development.
-- **Rotate your webhook secret** periodically and update it in both GitHub (webhook settings) and your `config.yaml`.
-- **Rate limiting** is 30 req/min per route by default (configurable via `extra.rate_limit`). Exceeding it returns `429`.
-- **Duplicate deliveries** (webhook retries) are deduplicated via a 1-hour idempotency cache. The cache key is `X-GitHub-Delivery` if present, then `X-Request-ID`, then a millisecond timestamp. When neither delivery ID header is set, retries are **not** deduplicated.
-- **Prompt injection:** PR titles, descriptions, and commit messages are attacker-controlled. Malicious PRs could attempt to manipulate the agent's actions. Run the gateway in a sandboxed environment (Docker, VM) when exposed to the public internet.
+- **Rotate your webhook secret** in both GitHub and `config.yaml` whenever the route name, profile, provider, signature mode, or execution policy changes. Key material is permanently bound across profiles to its original route policy and cannot be reassigned.
+- **Rate limiting** admits 30 new identities per profile/route in a sliding 60-second window by default (configurable via `extra.rate_limit`). Durable duplicates and already-active identities do not consume another slot; a new identity over quota returns `429`.
+- **Duplicate deliveries** are fenced by a durable replay proof derived from the authenticated request body. GitHub's body signature does not authenticate `X-GitHub-Delivery` or `X-Request-ID`, so those observed headers are diagnostic only and never control replay identity. The proof survives process restarts; it is not a one-hour memory cache.
+- **Prompt injection and tool authority:** PR titles, descriptions, and commit messages are attacker-controlled. `toolsets: ["terminal"]` grants trusted local-code capability; Hermes does not add an OS sandbox. Isolate the configured terminal backend with Docker, a VM, or SSH policy. That isolation does not cover `github_comment`: its final `gh pr comment` command runs on the gateway host under the adapter's fixed target authority.
 
 ---
 
@@ -293,12 +335,13 @@ GitLab payload fields differ from GitHub's — e.g. `{object_attributes.title}` 
 |---|---|
 | `401 Invalid signature` | Secret in config.yaml doesn't match GitHub webhook secret |
 | `404 Unknown route` | Route name in the URL doesn't match the key in `routes:` |
-| `429 Rate limit exceeded` | 30 req/min per route exceeded — common when re-delivering test events from GitHub's UI; wait a minute or raise `extra.rate_limit` |
-| No comment posted | `gh` not installed, not on PATH, or not authenticated (`gh auth login`) |
-| Agent runs but no comment | Check the gateway log — if the agent output was empty or just "SKIP", delivery is still attempted |
+| `429 Rate limit exceeded` | The sliding 60-second quota for new identities was exceeded; wait until the oldest admitted identity leaves the window or raise `extra.rate_limit` |
+| Agent cannot fetch the diff | Check `gh` installation and authentication in the configured terminal backend |
+| Review succeeds but no comment is posted | Check `gh` installation and authentication on the gateway host; `github_comment` delivery runs there |
+| Agent runs but no comment | An intentional autonomous silence response (`[SILENT]`, including that marker followed by explanatory prose) suppresses target delivery by design. If silence was unexpected, inspect the prompt and completed agent output in the gateway log. |
 | Port already in use | Change `extra.port` in config.yaml |
 | Agent runs but reviews only the PR description | The prompt isn't including the `gh pr diff` instruction — the diff is not in the webhook payload |
-| Can't see the ping event | Ignored events return `{"status":"ignored","event":"ping"}` at DEBUG log level only — check GitHub's delivery log (repo → Settings → Webhooks → your webhook → Recent Deliveries) |
+| GitHub marks the initial ping failed | Expected for an `events: [pull_request]` route: its header and authenticated body classify as `ping`, not `pull_request`, so the route returns `401`. Confirm a subsequent signed pull-request delivery instead. |
 
 **GitHub's Recent Deliveries tab** (repo → Settings → Webhooks → your webhook) shows the exact request headers, payload, HTTP status, and response body for every delivery. It is the fastest way to diagnose failures without touching your server logs.
 
@@ -311,17 +354,21 @@ platforms:
   webhook:
     enabled: true
     extra:
+      host: null                # default: all interfaces on IPv4 and IPv6
       port: 8644               # listen port (default: 8644)
-      secret: ""               # optional global fallback secret
-      rate_limit: 30           # requests per minute per route
-      max_body_bytes: 1048576  # payload size limit in bytes (default: 1 MB)
+      secret: ""               # fallback only when exactly one authenticated route uses it
+      rate_limit: 30           # new identities per profile/route per sliding 60 seconds
+      max_body_bytes: 1048576  # default and hard maximum: 1 MiB
 
       routes:
         <route-name>:
+          provider: github       # explicit provider/verifier binding
+          signature_mode: github
           secret: "required-per-route"
-          events: []            # [] = accept all; otherwise list X-GitHub-Event values
+          events: []            # [] = unfiltered/unknown; otherwise one supported event
           prompt: ""            # {field} / {nested.field} resolved from payload
           skills: []            # first matching skill is loaded (only one)
+          toolsets: []          # explicit per-route replacement; terminal is not a default
           deliver: "log"        # log | github_comment | telegram | discord | slack | signal | sms
           deliver_extra: {}     # repo + pr_number for github_comment; chat_id for others
 ```

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -783,7 +783,7 @@ Manage dynamic webhook subscriptions for event-driven agent activation. Requires
 
 | Subcommand | Description |
 |------------|-------------|
-| `subscribe` / `add` | Create a webhook route. Returns the URL and HMAC secret to configure on your service. |
+| `subscribe` / `add` | Create a webhook route. Prints its route URL, bound provider/signature mode, secret/token, and any available provider-specific header guidance. |
 | `list` / `ls` | Show all agent-created subscriptions. |
 | `remove` / `rm` | Delete a dynamic subscription. Static routes from config.yaml are not affected. |
 | `test` | Send a test POST to verify a subscription is working. |
@@ -797,16 +797,23 @@ hermes webhook subscribe <name> [options]
 | Option | Description |
 |--------|-------------|
 | `--prompt` | Prompt template with `{dot.notation}` payload references. |
-| `--events` | Comma-separated event types to accept (e.g. `issues,pull_request`). Empty = all. |
+| `--events` | Comma-separated event filters. GitHub permits one authenticated body class (`check_run`, `pull_request`, `push`, `issues`, or `ping`); GitLab permits one exact header value. Empty disables filtering: route-bound GitHub/GitLab requests resolve as `unknown`, while body-authoritative providers can still resolve an authenticated payload event. |
+| `--provider` | Explicit provider contract (default: `github`), such as `github`, `gitlab`, `svix`, `standard_webhooks`, `stripe`, `hermes`, or `generic`. |
+| `--signature-mode` | Explicit verifier override, including recommended `generic_v2` for generic senders. |
+| `--route-profile` | Gateway profile authorized to receive the route (default: `default`). Every explicit named profile uses `/p/<profile>/webhooks/<name>`, even in single-profile mode (where it must name that running profile); multiplex mode only permits several served names. The top-level `--profile` flag instead selects which local Hermes profile runs the CLI. |
 | `--description` | Human-readable description. |
 | `--skills` | Comma-separated skill names to load for the agent run. |
-| `--deliver` | Delivery target: `log` (default), `telegram`, `discord`, `slack`, `github_comment`. |
+| `--deliver` | Delivery target: `log` (default), `telegram`, `discord`, `slack`, `github_comment`. `github_comment` also requires route-bound `deliver_extra.repo` and positive `deliver_extra.pr_number`; the current CLI has no flags for those fields, so use a complete static route (or a carefully edited complete dynamic entry with fresh secret) for that target. |
 | `--deliver-chat-id` | Target chat/channel ID for cross-platform delivery. |
-| `--secret` | Custom HMAC secret. Auto-generated if omitted. |
+| `--secret` | Custom provider verification secret/token. Auto-generated if omitted. |
 | `--deliver-only` | Skip the agent — deliver the rendered `--prompt` as the literal message. Zero LLM cost, sub-second delivery. Requires `--deliver` to be a real target (not `log`). |
-| `--script` | Filter/transform script under `~/.hermes/scripts/`. The webhook payload is passed as JSON on stdin; JSON stdout replaces the payload, and empty stdout, `[SILENT]`, or a nonzero exit code ignores the webhook. See [Script Filters and Transforms](../user-guide/messaging/webhooks.md#script-filters-and-transforms). |
+| `--script` | Filter/transform script under the active profile's `$HERMES_HOME/scripts/` (normally `~/.hermes/scripts/`). The webhook payload is passed as JSON on stdin; JSON stdout replaces the payload, while empty stdout or `[SILENT]` suppresses delivery. Static script defects block listener startup; invalid dynamic candidates are skipped or withdrawn. A timeout or nonzero exit after execution starts returns HTTP 500 as indeterminate and durably fences retries for the same delivery identity. See [Script Filters and Transforms](../user-guide/messaging/webhooks.md#script-filters-and-transforms). |
 
-Subscriptions persist to `~/.hermes/webhook_subscriptions.json` and are hot-reloaded by the webhook adapter without a gateway restart.
+Subscriptions persist to the active profile's `$HERMES_HOME/webhook_subscriptions.json` (normally `~/.hermes/webhook_subscriptions.json`; named profiles normally use `~/.hermes/profiles/<name>/webhook_subscriptions.json`) and are hot-reloaded without a gateway restart. The adapter checks at connect time and before each incoming webhook: metadata changes load on that next check, while unchanged metadata receives a bounded SHA-256 content recheck at most about once per second.
+
+`subscribe` defaults to `--provider github`; that default is not provider auto-detection. Set `--provider` (and `--signature-mode` where applicable) for every non-GitHub sender. `hermes webhook test` generates a provider-shaped default body, but `--payload` sends exactly the JSON you supply: signing a custom body does not make it satisfy a GitHub event classifier or another provider's payload contract.
+
+When the webhook bind is omitted, loopback, or wildcard (`0.0.0.0` / `::`), `subscribe` prints a **Local test URL**. Do not give that URL to an external provider. Put the same route path behind a public HTTPS reverse proxy—for example, `/p/ops/webhooks/build` must remain `/p/ops/webhooks/build` on the public URL. A configured non-loopback bind is labeled **Callback URL** instead. `hermes webhook test` intentionally posts directly to the configured/local gateway address; it does not test your public reverse proxy.
 
 ## `hermes doctor`
 

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -522,7 +522,7 @@ These are set automatically by the Docker terminal backend when `proxy.enabled: 
 | `HASS_URL` | Home Assistant URL (default: `http://homeassistant.local:8123`) |
 | `WEBHOOK_ENABLED` | Enable the webhook platform adapter (`true`/`false`) |
 | `WEBHOOK_PORT` | HTTP server port for receiving webhooks (default: `8644`) |
-| `WEBHOOK_SECRET` | Global HMAC secret for webhook signature validation (used as fallback when routes don't specify their own) |
+| `WEBHOOK_SECRET` | Global HMAC fallback for exactly one authenticated webhook route; multiple routes require unique per-route secrets |
 | `API_SERVER_ENABLED` | Enable the OpenAI-compatible API server (`true`/`false`). Runs alongside other platforms. |
 | `API_SERVER_KEY` | Bearer token for API server authentication. Required whenever the API server is enabled. |
 | `API_SERVER_CORS_ORIGINS` | Comma-separated browser origins allowed to call the API server directly (for example `http://localhost:3000,http://127.0.0.1:3000`). Default: disabled. |

--- a/website/docs/user-guide/messaging/webhooks.md
+++ b/website/docs/user-guide/messaging/webhooks.md
@@ -28,7 +28,7 @@ The agent processes the event and can respond by posting comments on PRs, sendin
 
 1. Enable via `hermes gateway setup` or environment variables
 2. Define routes in `config.yaml` **or** create them dynamically with `hermes webhook subscribe`
-3. Point your service at `http://your-server:8644/webhooks/<route-name>`
+3. Point your service at `/webhooks/<route-name>` for a default-bound route. A route with an explicit named `profile` always uses `/p/<profile>/webhooks/<route-name>`, including on a single-profile gateway.
 
 ---
 
@@ -65,7 +65,7 @@ curl http://localhost:8644/health
 Expected response:
 
 ```json
-{"status": "ok", "platform": "webhook"}
+{"status": "ok", "platform": "webhook", "accepting_webhooks": true}
 ```
 
 ---
@@ -78,17 +78,21 @@ Routes define how different webhook sources are handled. Each route is a named e
 
 | Property | Required | Description |
 |----------|----------|-------------|
-| `events` | No | List of event types to accept (e.g. `["pull_request"]`). If empty, all events are accepted. Event type is read from `X-GitHub-Event`, `X-GitLab-Event`, or `event_type` in the payload. |
-| `secret` | **Yes** | HMAC secret for signature validation. Falls back to the global `secret` if not set on the route. Set to `"INSECURE_NO_AUTH"` for testing only (skips validation). |
-| `profile` | No | Profile authorized to execute this route when `gateway.multiplex_profiles` is enabled. Omit it for a default-profile-only route; set a profile name (for example `coder`) to bind the route and its secret to `/p/coder/webhooks/<route>`. |
-| `prompt` | No | Template string with dot-notation payload access (e.g. `{pull_request.title}`). If omitted, the full JSON payload is dumped into the prompt. Payload fields are untrusted — see [Authenticated does not mean trusted](#authenticated-does-not-mean-trusted). |
+| `provider` | **Yes*** | Explicit provider contract, such as `github`, `gitlab`, `svix`, `standard_webhooks`, `stripe`, `hermes`, or `generic`. A route must declare `provider` or `signature_mode`; Hermes never guesses from attacker-controlled headers. |
+| `signature_mode` | Sometimes | Explicit verifier mode. Usually inferred from `provider`; required when that provider has no safe default, and useful to select `generic_v1` versus recommended `generic_v2`. |
+| `events` | No | Event types admitted by this route. GitHub permits at most one of `check_run`, `pull_request`, `push`, `issues`, or `ping`; Hermes requires both the unsigned header and the HMAC-covered body shape to match. GitLab also permits at most one event and requires its unsigned header to equal the route-bound value. With no configured event, the request is unfiltered but its resolved event is `unknown`. Other providers may resolve an authenticated body event. |
+| `secret` | **Yes** | HMAC secret for signature validation. A global `secret` may supply the value only when exactly one authenticated route uses that fallback; configure unique per-route secrets otherwise. Set to `"INSECURE_NO_AUTH"` for loopback testing only (skips validation). |
+| `profile` | No | Profile authorized to execute this route. Omit it (or use `default`) for `/webhooks/<route>`; an explicit name such as `coder` always binds the route and secret to `/p/coder/webhooks/<route>`. In single-profile mode that name must be the running profile itself; `gateway.multiplex_profiles` only adds the ability to serve multiple allowed profiles from one gateway. |
+| `prompt` | No | Template string with dot-notation payload access (e.g. `{pull_request.title}`). If omitted, the prompt includes a parseable raw-payload envelope bounded to 4,000 UTF-8 bytes; it does not include an unbounded full dump. Payload fields are untrusted — see [Authenticated does not mean trusted](#authenticated-does-not-mean-trusted). |
 | `filters` | No | Declarative payload filters evaluated after auth/body/event filtering and before agent or direct delivery work. Non-matches return `{"status":"ignored","reason":"filter"}` with HTTP 200. |
-| `script` | No | Filter/transform script under `~/.hermes/scripts/`. The webhook payload is passed as JSON on stdin. JSON object stdout replaces the payload before templating; text stdout is exposed as `script_output`; empty stdout, `[SILENT]`, or a nonzero exit code ignores the webhook. |
+| `script` | No | Filter/transform script under the active profile's `$HERMES_HOME/scripts/` (normally `~/.hermes/scripts/`). The webhook payload is passed as JSON on stdin. JSON object stdout replaces the payload before templating; text stdout is exposed as `script_output`; empty stdout, `[SILENT]`, or `{"__hermes_ignore__": true}` suppresses delivery. A timeout or nonzero exit after execution starts returns HTTP 500 as indeterminate and durably fences retries for the same delivery identity. |
 | `skills` | No | List of skill names to load for the agent run. |
 | `toolsets` | No | List of toolset keys (e.g. `["terminal", "file", "web"]`) that **replaces** the platform-level webhook toolset for runs triggered by this route only. Manual config edit only — not settable via `hermes webhook subscribe`, so agent-created subscriptions cannot self-grant elevated tools. Names are validated the same way as `platform_toolsets` entries (unknown or platform-restricted names are dropped). See [Per-route toolsets](#per-route-toolsets). |
 | `deliver` | No | Where to send the response: `github_comment`, `telegram`, `discord`, `slack`, `signal`, `sms`, `whatsapp`, `matrix`, `mattermost`, `homeassistant`, `email`, `dingtalk`, `feishu`, `wecom`, `weixin`, `bluebubbles`, `qqbot`, or `log` (default). |
 | `deliver_extra` | No | Additional delivery config — keys depend on `deliver` type (e.g. `repo`, `pr_number`, `chat_id`). Values support the same `{dot.notation}` templates as `prompt`. |
 | `deliver_only` | No | If `true`, skip the agent entirely — the rendered `prompt` template becomes the literal message that gets delivered. Zero LLM cost, sub-second delivery. See [Direct Delivery Mode](#direct-delivery-mode) for use cases. Requires `deliver` to be a real target (not `log`). |
+
+\* Declare at least one of `provider` or `signature_mode`.
 
 ### Full example
 
@@ -101,6 +105,7 @@ platforms:
       secret: "global-fallback-secret"
       routes:
         github-pr:
+          provider: "github"
           events: ["pull_request"]
           secret: "github-webhook-secret"
           prompt: |
@@ -117,6 +122,7 @@ platforms:
             repo: "{repository.full_name}"
             pr_number: "{number}"
         deploy-notify:
+          provider: "github"
           events: ["push"]
           secret: "deploy-secret"
           prompt: "New push to {repository.full_name} branch {ref}: {head_commit.message}"
@@ -128,7 +134,7 @@ platforms:
 
 ### Payload Filters
 
-Use `filters` when a provider sends a broad event stream but only some payloads should wake the agent or trigger `deliver_only` delivery. Filters run after signature validation, body parsing, and `events`, but before prompt rendering, idempotency, agent dispatch, or direct delivery.
+Use `filters` when a provider sends a broad event stream but only some payloads should wake the agent or trigger `deliver_only` delivery. Filters run after signature validation, body parsing, event selection, and durable replay admission, but before scripts, prompt rendering, agent dispatch, or target delivery. An ignored authenticated identity therefore still leaves a permanent replay proof.
 
 ```yaml
 platforms:
@@ -136,6 +142,8 @@ platforms:
     extra:
       routes:
         todoist:
+          provider: "generic"
+          signature_mode: "generic_v2"
           events: ["item:updated"]
           secret: "todoist-secret"
           filters:
@@ -157,14 +165,20 @@ Supported operators:
 - `contains` for strings, lists, and dict keys
 - `in` for inline lists
 - `in_file` for JSON arrays, JSON objects (keys are used), or newline-delimited text files
-- `regex`
+- `regex` (evaluated off the HTTP event loop in an isolated worker; patterns over 4 KiB, inputs over 256 KiB, invalid expressions, or matches exceeding 100 ms fail closed)
+
+One route is limited to 64 filter nodes, eight levels of nesting, and eight regex operators. Routes that exceed any limit fail closed.
 - `all`, `any`, and `not` groups
 
-Field paths use dot notation. `payload.foo` reads from a top-level `payload` object when one exists, or from the root webhook body for flat payloads. `event` / `event_type` match the resolved event type, and `headers.<Name>` reads request headers.
+Field paths use dot notation. `payload.foo` reads from a top-level `payload` object when one exists, or from the root webhook body for flat payloads. `event` / `event_type` match the resolved authoritative event type. `headers.<Name>` exposes only headers cryptographically covered by the selected verifier; unsigned GitHub/GitLab event or delivery headers are diagnostics and are not filter inputs.
 
 ### Script Filters and Transforms
 
-Use `script` when declarative filters are not enough. Scripts must live under `~/.hermes/scripts/` for the active profile; relative paths resolve there, and path traversal outside that directory is blocked. `.sh` and `.bash` scripts run with bash, and all other extensions run with the current Python interpreter.
+Use `script` when declarative filters are not enough. Scripts must live under the active profile's `$HERMES_HOME/scripts/` (normally `~/.hermes/scripts/`); relative paths resolve there, and path traversal outside that directory is blocked. Hermes captures the exact script bytes when it publishes the route and executes only those captured bytes. `.sh` and `.bash` sources run with bash using `--noprofile --norc`; all other sources run with the current Python interpreter in isolated mode.
+
+Every invocation runs in a fresh, empty working directory with a captured minimal non-secret environment. It does not inherit `BASH_ENV`, `ENV`, `PYTHONPATH`, arbitrary custom variables, or credential variables from the gateway process. Consequently, relative imports, neighboring helper files, shell startup hooks, and ambient environment secrets are unavailable. Route scripts must be self-contained JSON transforms: read the supplied JSON from stdin and emit their result on stdout.
+
+Route scripts are trusted local code, not an operating-system sandbox. They run as the gateway user and can deliberately access anything that account can access or detach processes beyond Hermes' best-effort child cleanup. The frozen source/interpreter contract, empty working directory, minimal environment, timeout, and output limits prevent accidental authority drift; they do not contain a malicious script. Run the gateway itself in a container, VM, or restricted service account when route-script authors are not fully trusted.
 
 The route payload is sent to stdin as JSON:
 
@@ -187,7 +201,10 @@ Script outcomes:
 
 - JSON object stdout replaces the payload used by `prompt` and `deliver_extra`.
 - Non-JSON text stdout is added to the payload as `script_output`.
-- Empty stdout, exact `[SILENT]`, `{"__hermes_ignore__": true}`, timeout, missing script, or nonzero exit code returns HTTP 200 with `{"status":"ignored","reason":"script"}`.
+- Empty stdout, exact `[SILENT]`, or `{"__hermes_ignore__": true}` explicitly suppresses delivery and returns HTTP 200 with `{"status":"ignored","reason":"script"}`.
+- Script configuration is validated before the route is published. A missing, unreadable, or invalid script prevents a static webhook listener from starting; the same defect in a dynamic subscription causes that candidate to be skipped or an already-published dynamic route to be withdrawn. It is not normally accepted and rediscovered per request. A defensive request-time configuration inconsistency still fails before script execution with HTTP 500 and `status=failed`, so that delivery can be retried after the route is repaired and republished.
+- Once script execution is durably marked as started, a timeout, runtime failure, nonzero exit, or invalid output returns HTTP 500 with `status=indeterminate`. Hermes records an indeterminate outcome and fences the same delivery identity; a retry returns HTTP 409 with `status=indeterminate` instead of running the script again.
+- Script stdout and stderr are each bounded to 1 MiB, and their combined captured output is also bounded to 1 MiB. Crossing any output bound terminates the script and follows the started-script `indeterminate` path above.
 
 ### Prompt Templates
 
@@ -195,7 +212,7 @@ Prompts use dot-notation to access nested fields in the webhook payload:
 
 - `{pull_request.title}` resolves to `payload["pull_request"]["title"]`
 - `{repository.full_name}` resolves to `payload["repository"]["full_name"]`
-- `{__raw__}` — special token that dumps the **entire payload** as indented JSON (truncated at 4000 characters). Useful for monitoring alerts or generic webhooks where the agent needs the full context.
+- `{__raw__}` — a parseable JSON envelope with `payload`, `truncated`, and `original_bytes` fields. The complete envelope, including JSON escaping and metadata, is bounded to 4,000 UTF-8 bytes by default.
 - Missing keys are left as the literal `{key}` string (no error)
 - Nested dicts and lists are JSON-serialized and truncated at 2000 characters
 
@@ -205,7 +222,7 @@ You can mix `{__raw__}` with regular template variables:
 prompt: "PR #{pull_request.number} by {pull_request.user.login}: {__raw__}"
 ```
 
-If no `prompt` template is configured for a route, the entire payload is dumped as indented JSON (truncated at 4000 characters).
+If no `prompt` template is configured, Hermes places that same bounded 4,000-byte raw-payload envelope inside the generated prompt. Large payloads are explicitly marked `truncated`; an omitted template never creates an unbounded full JSON dump.
 
 The same dot-notation templates work in `deliver_extra` values.
 
@@ -214,18 +231,24 @@ The same dot-notation templates work in `deliver_extra` values.
 When delivering webhook responses to Telegram, you can target a specific forum topic by including `message_thread_id` (or `thread_id`) in `deliver_extra`:
 
 ```yaml
-webhooks:
-  routes:
-    alerts:
-      events: ["alert"]
-      prompt: "Alert: {__raw__}"
-      deliver: "telegram"
-      deliver_extra:
-        chat_id: "-1001234567890"
-        message_thread_id: "42"
+platforms:
+  webhook:
+    enabled: true
+    extra:
+      routes:
+        alerts:
+          provider: "generic"
+          signature_mode: "generic_v2"
+          secret: "your-generic-v2-secret"
+          events: ["alert"]
+          prompt: "Alert: {__raw__}"
+          deliver: "telegram"
+          deliver_extra:
+            chat_id: "-1001234567890"
+            message_thread_id: "42"
 ```
 
-If `chat_id` is not provided in `deliver_extra`, the delivery falls back to the home channel configured for the target platform.
+If `chat_id` is not provided in `deliver_extra`, the delivery falls back to the home channel configured for the target platform. For a named multiplexed route whose target adapter is not active during route publication, Hermes reads that home channel from the routed profile's configuration—not from the process default profile—and freezes it into the route authority.
 
 ---
 
@@ -281,7 +304,8 @@ platforms:
     extra:
       routes:
         gitlab-mr:
-          events: ["merge_request"]
+          provider: "gitlab"
+          events: ["Merge Request Hook"]
           secret: "your-gitlab-secret-token"
           prompt: |
             Review this merge request:
@@ -302,10 +326,10 @@ The `deliver` field controls where the agent's response goes after processing th
 | Deliver Type | Description |
 |-------------|-------------|
 | `log` | Logs the response to the gateway log output. This is the default and is useful for testing. |
-| `github_comment` | Posts the response as a PR/issue comment via the `gh` CLI. Requires `deliver_extra.repo` and `deliver_extra.pr_number`. The `gh` CLI must be installed and authenticated on the gateway host (`gh auth login`). |
+| `github_comment` | Posts the response as a pull-request comment via `gh pr comment`. Requires `deliver_extra.repo` and a positive `deliver_extra.pr_number`. The `gh` CLI must be installed and authenticated on the gateway host (`gh auth login`). |
 | `telegram` | Routes the response to Telegram. Uses the home channel, or specify `chat_id` in `deliver_extra`. |
 | `discord` | Routes the response to Discord. Uses the home channel, or specify `chat_id` in `deliver_extra`. |
-| `slack` | Routes the response to Slack. Uses the home channel, or specify `chat_id` in `deliver_extra`. |
+| `slack` | Routes the response to Slack. Uses the configured home channel, or specifies `chat_id` in `deliver_extra`. A templated `chat_id` requires an explicit route-bound workspace `scope_id`; for a static channel the connected adapter can establish the scope, though declaring it explicitly is clearer. |
 | `signal` | Routes the response to Signal. Uses the home channel, or specify `chat_id` in `deliver_extra`. |
 | `sms` | Routes the response to SMS via Twilio. Uses the home channel, or specify `chat_id` in `deliver_extra`. |
 | `whatsapp` | Routes the response to WhatsApp. Uses the home channel, or specify `chat_id` in `deliver_extra`. |
@@ -319,7 +343,7 @@ The `deliver` field controls where the agent's response goes after processing th
 | `weixin` | Routes the response to Weixin (WeChat). Uses the home channel, or specify `chat_id` in `deliver_extra`. |
 | `bluebubbles` | Routes the response to BlueBubbles (iMessage). Uses the home channel, or specify `chat_id` in `deliver_extra`. |
 
-For cross-platform delivery, the target platform must also be enabled and connected in the gateway. If no `chat_id` is provided in `deliver_extra`, the response is sent to that platform's configured home channel.
+For cross-platform delivery, the target platform must also be enabled and connected in the gateway. If no `chat_id` is provided in `deliver_extra`, the response is sent to that platform's configured home channel. A templated Slack `chat_id` requires a route-bound `scope_id` so a signed event cannot cross workspace authority. For a static Slack channel, Hermes may freeze the scope established by the connected adapter; specifying `scope_id` explicitly removes ambiguity.
 
 ---
 
@@ -341,7 +365,7 @@ Benefits:
 - **Zero LLM tokens** — the agent is never invoked
 - **Sub-second delivery** — a single adapter call, no reasoning loop
 - **Same security as agent mode** — HMAC auth, rate limits, idempotency, and body-size limits all still apply
-- **Synchronous response** — the POST returns `200 OK` once delivery succeeds, or `502` if the target rejects it, so your upstream service can retry intelligently
+- **Synchronous response** — the POST returns `200 OK` once delivery succeeds. A target failure known to occur before any effect returns `503` with `Retry-After: 5` and is retryable; `502` means the target outcome is indeterminate and requires reconciliation, not an automatic retry.
 
 ### Example: Telegram push from Supabase
 
@@ -354,6 +378,8 @@ platforms:
       secret: "global-secret"
       routes:
         antenna-matches:
+          provider: "generic"
+          signature_mode: "generic_v2"
           secret: "antenna-webhook-secret"
           deliver: "telegram"
           deliver_only: true
@@ -362,12 +388,14 @@ platforms:
             chat_id: "{match.telegram_chat_id}"
 ```
 
-Your Supabase edge function signs the payload with HMAC-SHA256 and POSTs to `https://your-server:8644/webhooks/antenna-matches`. The webhook adapter validates the signature, renders the template from the payload, delivers to Telegram, and returns `200 OK`.
+Your Supabase edge function must set `X-Webhook-Timestamp` to the current Unix timestamp, compute the lowercase HMAC-SHA256 hex digest of `<timestamp>.<exact request body>` with `antenna-webhook-secret`, and send that digest in `X-Webhook-Signature-V2` when it POSTs to `https://your-server:8644/webhooks/antenna-matches`. The timestamp must be within 300 seconds of the gateway clock. The adapter validates that explicit `generic_v2` contract, renders the template, delivers to Telegram, and returns `200 OK`.
 
 ### Example: Dynamic subscription via CLI
 
 ```bash
 hermes webhook subscribe antenna-matches \
+  --provider generic \
+  --signature-mode generic_v2 \
   --deliver telegram \
   --deliver-chat-id "123456789" \
   --deliver-only \
@@ -379,21 +407,26 @@ hermes webhook subscribe antenna-matches \
 
 | Status | Meaning |
 |--------|---------|
-| `200 OK` | Delivered successfully. Body: `{"status": "delivered", "route": "...", "target": "...", "delivery_id": "..."}` |
-| `200 OK` (status=duplicate) | Duplicate `X-GitHub-Delivery` ID within the idempotency TTL (1 hour). Not re-delivered. |
+| `200 OK` | Delivered successfully. The body includes `status`, `route`, `target`, `delivery_id`, and the durable target `settlement` (`confirmed` or `cached`). |
+| `200 OK` (status=suppressed) | An intentional autonomous silence response was settled without invoking the target; `settlement` is `suppressed`. |
+| `200 OK` (status=duplicate) | The authenticated replay identity already settled. Its permanent proof prevents re-delivery. |
+| `202 Accepted` (status=in_progress) | That replay identity is already running or owns a retryable staged carrier. |
+| `409 Conflict` | The authenticated replay identity conflicts with another body, or its prior outcome is indeterminate and requires reconciliation. |
 | `401 Unauthorized` | HMAC signature invalid or missing. |
 | `400 Bad Request` | Malformed JSON body. |
 | `404 Not Found` | Unknown route name. |
-| `413 Payload Too Large` | Body exceeded `max_body_bytes`. |
+| `413 Payload Too Large` | The request body exceeded `max_body_bytes`, or a pre-effect template expansion exceeded a durable carrier limit. |
 | `429 Too Many Requests` | Route rate limit exceeded. |
-| `502 Bad Gateway` | Target adapter rejected the message or raised. The error is logged server-side; the response body is a generic `Delivery failed` to avoid leaking adapter internals. |
+| `500 Internal Server Error` | A started route script failed or timed out; the outcome is durably fenced as indeterminate. |
+| `502 Bad Gateway` | The target attempt may already have taken effect, so its outcome is indeterminate and requires reconciliation. The replay identity is durably fenced; repeating that same identity returns `409` instead of invoking the target again. |
+| `503 Service Unavailable` | Intake/recovery authority, one of the four **process-global** bounded route workers shared by all webhook adapters/profiles, target preflight, or durable ledger capacity is unavailable. Route-worker saturation includes `Retry-After: 1`; a pre-effect target failure includes `Retry-After: 5`; capacity saturation has no automatic retry interval because permanent replay proofs are never evicted. |
 
 ### Configuration gotchas
 
 - `deliver_only: true` requires `deliver` to be a real target. `deliver: log` (or omitting `deliver`) is rejected at startup — the adapter refuses to start if it finds a misconfigured route.
 - The `skills` field is ignored in direct delivery mode (no agent runs, so there's nothing to inject skills into).
 - Template rendering uses the same `{dot.notation}` syntax as agent mode, including the `{__raw__}` token.
-- Idempotency uses the same `X-GitHub-Delivery` / `X-Request-ID` header — retries with the same ID return `status=duplicate` and do NOT re-deliver.
+- Replay fencing uses only authenticated identity material. Svix/Standard Webhooks bind their message ID into the signature; Stripe/Hermes can use an authenticated body ID. Body-only providers such as GitHub are fenced by the authenticated body digest, not by an unsigned transport ID.
 
 ---
 
@@ -405,6 +438,7 @@ In addition to static routes in `config.yaml`, you can create webhook subscripti
 
 ```bash
 hermes webhook subscribe github-issues \
+  --provider github \
   --events "issues" \
   --prompt "New issue #{issue.number}: {issue.title}\nBy: {issue.user.login}\n\n{issue.body}" \
   --deliver telegram \
@@ -430,13 +464,15 @@ hermes webhook remove github-issues
 
 ```bash
 hermes webhook test github-issues
-hermes webhook test github-issues --payload '{"issue": {"number": 42, "title": "Test"}}'
+hermes webhook test github-issues --payload '{"action":"opened","issue":{"number":42,"title":"Test"},"repository":{"id":1,"full_name":"owner/repo"},"sender":{"id":2,"login":"tester"}}'
 ```
+
+The first command generates a provider-valid body automatically. A custom GitHub payload must still prove the configured event class; for `issues`, that includes a supported `action` plus `issue`, `repository`, and `sender` objects. The CLI signs the exact custom bytes and sends the route-bound `X-GitHub-Event` header, but it does not repair an invalid provider payload for you.
 
 ### How dynamic subscriptions work
 
-- Subscriptions are stored in `~/.hermes/webhook_subscriptions.json`
-- The webhook adapter hot-reloads this file on each incoming request (mtime-gated, negligible overhead)
+- Subscriptions are stored in the active profile's `${HERMES_HOME:-$HOME/.hermes}/webhook_subscriptions.json` (for example, `~/.hermes/profiles/ops/webhook_subscriptions.json` for a named profile)
+- The webhook adapter checks the file at connect time and before each incoming webhook, so no restart is needed. File identity/metadata changes are loaded on that next check; when those values are unchanged, bounded rereads and SHA-256 content checks are rate-limited to about once per second to catch same-metadata edits without letting request floods amplify file reads.
 - Static routes from `config.yaml` always take precedence over dynamic ones with the same name
 - Dynamic subscriptions use the same route format and capabilities as static routes (events, prompt templates, skills, delivery)
 - No gateway restart required — subscribe and it's immediately live
@@ -460,21 +496,31 @@ platforms:
     extra:
       routes:
         oom-emergency:
+          provider: "generic"
+          signature_mode: "generic_v2"
           secret: "monitor-secret"
           prompt: "Memory emergency: {detail}. Diagnose with ps/free/py-spy and report."
           toolsets: ["terminal", "file", "code_execution", "web"]
           deliver: "telegram"
 ```
 
-For dynamic subscriptions, add the `toolsets` key by editing `~/.hermes/webhook_subscriptions.json` directly:
+For dynamic subscriptions, `hermes webhook subscribe` cannot grant toolsets. To grant them manually, edit the active profile's `${HERMES_HOME:-$HOME/.hermes}/webhook_subscriptions.json`, preserve the complete saved route entry, add `toolsets`, and replace its `secret` with fresh key material. Then update the sender to use that new secret. Toolsets are part of the key-bound execution policy, so reusing the old secret causes the candidate route to be rejected and an existing dynamic route to be withdrawn.
 
 ```json
 {
   "oom-emergency": {
-    "secret": "...",
-    "prompt": "...",
+    "description": "Trusted local memory monitor",
+    "profile": "default",
+    "provider": "generic",
+    "signature_mode": "generic_v2",
+    "events": [],
+    "secret": "NEW-UNUSED-SECRET",
+    "prompt": "Memory emergency: {detail}. Diagnose and report.",
+    "skills": [],
     "toolsets": ["terminal", "file", "web"],
-    "deliver": "telegram"
+    "deliver": "telegram",
+    "deliver_extra": {"chat_id": "123456789"},
+    "created_at": "2026-08-28T00:00:00Z"
   }
 }
 ```
@@ -483,7 +529,7 @@ Behavior and safety properties:
 
 - The route list **replaces** the platform-level webhook toolset resolution for that route's runs (it is not merged).
 - Names are validated through the same path as `platform_toolsets` config — unknown names and platform-restricted toolsets are dropped.
-- `hermes webhook subscribe` deliberately does **not** accept a toolsets flag. Granting elevated tools is a manual config-file edit, so an agent creating its own subscription at runtime cannot self-grant `terminal`.
+- `hermes webhook subscribe` deliberately does **not** accept a toolsets flag. Granting elevated tools requires a complete manual config-file edit and fresh secret, so an agent creating its own subscription at runtime cannot self-grant `terminal`.
 - Only grant elevated toolsets to routes whose senders you fully control, with a real HMAC secret. Anyone who can POST a validly-signed payload to that route is effectively running an agent with those tools.
 
 ---
@@ -499,48 +545,63 @@ The adapter validates incoming webhook signatures using the appropriate method f
 - **GitHub**: `X-Hub-Signature-256` header — HMAC-SHA256 hex digest prefixed with `sha256=`
 - **GitLab**: `X-Gitlab-Token` header — plain secret string match
 - **Generic (V2, recommended)**: `X-Webhook-Signature-V2` + `X-Webhook-Timestamp` headers — HMAC-SHA256 hex digest of `<timestamp>.<body>`. The timestamp (Unix seconds) must be within ±300 seconds of the server clock, which prevents captured requests from being replayed later.
-- **Generic (V1, legacy)**: `X-Webhook-Signature` header — raw HMAC-SHA256 hex digest of the body only. Still accepted for backward compatibility, but it has no replay protection (a captured request replays indefinitely); the gateway logs a deprecation warning once per route. Switch senders to V2.
+- **Generic (V1, legacy)**: `X-Webhook-Signature` header — raw HMAC-SHA256 hex digest of the body only. V1 has no signed timestamp or nonce, so a captured body can still be presented as fresh later. The durable ledger permanently fences a second execution of that identical authenticated body, which also means legitimate identical V1 payloads collapse into one identity. The gateway logs a deprecation warning once per route; switch senders to V2.
 
 If a secret is configured but no recognized signature header is present, the request is rejected.
 
 ### Secret is required
 
-Every route must have a secret — either set directly on the route or inherited from the global `secret`. Routes without a secret cause the adapter to fail at startup with an error. For development/testing only, you can set the secret to `"INSECURE_NO_AUTH"` to skip validation entirely.
+Every route must have a secret. The global `secret` is a convenience fallback for **exactly one authenticated route**; two authenticated routes that inherit it would reuse key material across authority scopes, so startup fails closed. Configure a unique secret on every route when more than one authenticated route exists. For development/testing only, you can set the secret to `"INSECURE_NO_AUTH"` to skip validation entirely.
 
-When multi-profile routing is enabled, the route's `profile` field also
-binds that secret to one execution target. A route without `profile` is
-default-profile-only. A request carrying a valid route signature is still
-rejected if its `/p/<profile>/` prefix does not match the route binding.
+Authentication key material is permanently bound in the root durable authority across all profiles. The binding covers the physical profile incarnation, route name, provider, signature mode, and the complete non-secret execution policy: the canonical route, resolved toolsets, complete captured script execution contract (source bytes, interpreter and isolated invocation, minimal environment, and empty-working-directory rule), snapshotted skill scaffold, captured `in_file` filter values, and frozen delivery target authority. A key cannot later be reassigned by renaming or moving a route, changing any dependency or verifier, deleting and recreating a profile, or starting another profile. Hermes withdraws a live route when a bound file, profile, grant, skill, or target no longer matches its published snapshot. Rotate to fresh secret material whenever any bound field or policy changes; the previous binding remains as replay evidence and is not reusable.
+
+The route's `profile` field binds its secret to one execution target in every
+gateway mode. A route without `profile` is default-profile-only; an explicit
+named profile always requires the matching `/p/<profile>/` prefix. A
+single-profile gateway accepts only its own name there, while
+`gateway.multiplex_profiles` permits one gateway to serve multiple allowed
+profiles. A request carrying a valid route signature is still rejected if its
+URL prefix does not match the route binding.
 
 `INSECURE_NO_AUTH` is only accepted when the gateway is bound to a loopback host (`127.0.0.1`, `localhost`, `::1`). If it is combined with a non-loopback bind such as `0.0.0.0` or a LAN IP, the adapter refuses to start — this prevents accidentally exposing an unauthenticated endpoint on a public interface.
 
 ### Rate limiting
 
-Each route is rate-limited to **30 requests per minute** by default (fixed-window). Configure this globally:
+Each profile/route scope admits at most **30 new identities in a sliding 60-second window** by default. Configure the quota globally:
 
 ```yaml
 platforms:
   webhook:
     extra:
-      rate_limit: 60  # requests per minute
+      rate_limit: 60  # new identities per sliding 60 seconds
 ```
 
-Requests exceeding the limit receive a `429 Too Many Requests` response.
+`rate_limit` must be an exact integer from 1 through 10,000. `script_timeout_seconds` is configured in the same `extra` block and must be an exact integer from 1 through 300 seconds. Invalid values make webhook startup fail as a configuration error rather than silently changing the limit.
+
+New identities beyond the quota receive `429 Too Many Requests`. Exact duplicates, conflicts, and already-active identities are resolved from durable replay evidence before this quota and do not consume another slot, so retry floods cannot starve fresh work.
 
 ### Idempotency
 
-Delivery IDs (from `X-GitHub-Delivery`, `X-Request-ID`, or a timestamp fallback) are cached for **1 hour**. Duplicate deliveries (e.g. webhook retries) are silently skipped with a `200` response, preventing duplicate agent runs.
+Authenticated provider delivery IDs become permanent replay identities. Providers without a signed delivery ID use the authenticated signed timestamp/body pair, or—under legacy body-only HMAC—the authenticated body digest. Settled and indeterminate evidence is durable across gateway restarts and is never evicted merely to admit new work. Only the explicit loopback test bypass has a bounded one-hour replay window.
+
+The replay ledger is the stable Hermes root's `state.db`, not a named profile's local database. In a normal layout that is `~/.hermes/state.db`; when active `HERMES_HOME` is `<root>/profiles/<name>`, Hermes resolves the ledger to `<root>/state.db`. The same evidence therefore remains authoritative when a gateway changes between multiplexed and non-multiplexed operation. Within that root ledger, operation and replay authority is partitioned by the effective physical profile that executes the route; a syntactic `default` route in a named single-profile process therefore belongs to that named physical profile, not to a separate default partition.
+
+Each physical profile home carries a durable random `.webhook-profile-incarnation` token. Hermes derives the route's profile generation from that resolved home and token, captures it in durable grants, and checks it again before script, agent, target, and recovery effects. Recreating or replacing a profile therefore cannot inherit stale work merely by reusing its name. Dead-owner recovery is scoped the same way: an adapter may reconcile only rows for physical profiles it currently serves and whose generation is still current; it leaves every other profile's rows untouched for an authorized adapter.
+
+The ledger reserves worst-case storage before a script, agent, or target effect can run. `idempotency_max_storage_bytes` defaults to 1 GiB and must be an exact integer from 5 MiB through 64 GiB; one profile/route/provider cannot consume the global reserve. `idempotency_max_entries` defaults to 4096 live operations. Both caps are persisted as ledger authority, so reopening the same ledger with different values fails startup instead of silently changing admission semantics. These limits bound the webhook ledger's logical allocation inside shared `state.db`, not the physical size of that database or its WAL. Once permanent evidence exhausts the configured budget, new unique identities fail closed with HTTP 503 while exact duplicate/conflict decisions remain available.
 
 ### Body size limits
 
-Payloads exceeding **1 MB** are rejected before the body is read. Configure this:
+`max_body_bytes` defaults to—and cannot exceed—**1 MiB (1,048,576 bytes)**. It must be an exact integer from 1 through 1,048,576; booleans, fractional values, and larger limits are rejected at startup. A declared `Content-Length` over the cap is rejected before reading. Chunked or otherwise lengthless bodies are aborted during the bounded read as soon as they cross the cap.
 
 ```yaml
 platforms:
   webhook:
     extra:
-      max_body_bytes: 2097152  # 2 MB
+      max_body_bytes: 1048576  # default and hard maximum: 1 MiB
 ```
+
+Post-authentication carriers are bounded separately: the rendered prompt is at most **512 KiB**, the complete durable event snapshot at most **2 MiB**, and each durable target or tool-grant authority snapshot at most **64 KiB**. A template expansion that exceeds a limit before any configured script or downstream effect returns HTTP 413 and releases its operation claim. If a started script produces an oversized carrier, Hermes instead records an indeterminate result and returns HTTP 500 rather than pretending it was safe to retry.
 
 ### Authenticated does not mean trusted
 
@@ -563,7 +624,7 @@ This is the same trust model that applies to everything the agent reads: web pag
 
 - Verify the port is exposed and accessible from the webhook source
 - Check firewall rules — port `8644` (or your configured port) must be open
-- Verify the URL path matches: `http://your-server:8644/webhooks/<route-name>`
+- Verify the URL path matches the route binding: `/webhooks/<route-name>` for default, or `/p/<profile>/webhooks/<route-name>` for every explicit named profile (single-profile and multiplex modes)
 - Use the `/health` endpoint to confirm the server is running
 
 ### Signature validation failing
@@ -573,12 +634,12 @@ This is the same trust model that applies to everything the agent reads: web pag
 - For GitLab, the secret is a plain token match — check `X-Gitlab-Token`
 - Check gateway logs for `Invalid signature` warnings
 
-### Event being ignored
+### Event rejected or ignored
 
-- Check that the event type is in your route's `events` list
-- GitHub events use values like `pull_request`, `push`, `issues` (the `X-GitHub-Event` header value)
-- GitLab events use values like `merge_request`, `push` (the `X-GitLab-Event` header value)
-- If `events` is empty or not set, all events are accepted
+- Check that the event type exactly matches your route's `events` entry. A mismatched route-bound GitHub/GitLab event is rejected with `401`, not ignored.
+- GitHub route binding supports `check_run`, `pull_request`, `push`, `issues`, and `ping`. The `X-GitHub-Event` value and the authenticated JSON body shape must both match; changing the unsigned header on a signed body is rejected with `401`.
+- GitLab events use exact `X-GitLab-Event` header values such as `Merge Request Hook` and `Push Hook`, not payload values such as `merge_request`
+- If `events` is empty or not set, requests are unfiltered. Route-bound GitHub/GitLab requests resolve as `event=unknown`; generic, Stripe, and other body-authoritative providers can still resolve an event from authenticated payload fields.
 
 ### Agent not responding
 
@@ -588,8 +649,8 @@ This is the same trust model that applies to everything the agent reads: web pag
 
 ### Duplicate responses
 
-- The idempotency cache should prevent this — check that the webhook source is sending a delivery ID header (`X-GitHub-Delivery` or `X-Request-ID`)
-- Delivery IDs are cached for 1 hour
+- Check that retries preserve the provider material actually covered by its signature: for example `svix-id`/`webhook-id`, an authenticated body ID, or the exact signed timestamp/body pair. Unsigned diagnostic headers do not control replay identity.
+- Inspect gateway logs for durable-ledger or settlement errors. Replay proofs are persistent; they are not a one-hour process-local cache.
 
 ### `gh` CLI errors (GitHub comment delivery)
 
@@ -605,4 +666,4 @@ This is the same trust model that applies to everything the agent reads: web pag
 |----------|-------------|---------|
 | `WEBHOOK_ENABLED` | Enable the webhook platform adapter | `false` |
 | `WEBHOOK_PORT` | HTTP server port for receiving webhooks | `8644` |
-| `WEBHOOK_SECRET` | Global HMAC secret (used as fallback when routes don't specify their own) | _(none)_ |
+| `WEBHOOK_SECRET` | Global HMAC fallback for exactly one authenticated route; use unique route secrets when multiple routes exist | _(none)_ |

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/automation-blueprints.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/automation-blueprints.md
@@ -51,33 +51,29 @@ Format as a clean digest. If no new issues, respond with [SILENT]." \
 
 ### 自动 PR 代码审查
 
-PR 开启时自动进行审查，并直接在 PR 上发布审查评论。
+静态路由会在 PR 开启或更新时获取 diff，并把最终审查直接发布到 PR；受限的 CLI 备选方案只把基于元数据的审查清单写入日志。
 
 **触发方式：** GitHub webhook
 
-**方式 A——动态订阅（CLI）：**
+**方式 A——动态订阅（CLI，仅元数据分类）：**
+
+动态 CLI 有意不能授予 `terminal` toolset，也不能设置 `github_comment` 所需的 `deliver_extra.repo` / `pr_number`。因此这个可直接运行的版本只根据已认证的 PR 元数据起草清单并写入日志。需要获取 diff 并评论 PR 时，请使用下方的完整静态路由。
 
 ```bash
 hermes webhook subscribe github-pr-review \
+  --provider github \
+  --signature-mode github \
   --events "pull_request" \
-  --prompt "Review this pull request:
+  --prompt "Triage this pull request from its metadata:
 Repository: {repository.full_name}
 PR #{pull_request.number}: {pull_request.title}
 Author: {pull_request.user.login}
 Action: {action}
-Diff URL: {pull_request.diff_url}
+Description: {pull_request.body}
 
-Fetch the diff with: curl -sL {pull_request.diff_url}
-
-Review for:
-- Security issues (injection, auth bypass, secrets in code)
-- Performance concerns (N+1 queries, unbounded loops, memory leaks)
-- Code quality (naming, duplication, error handling)
-- Missing tests for new behavior
-
-Post a concise review. If the PR is a trivial docs/typo change, say so briefly." \
-  --skill github-code-review \
-  --deliver github_comment
+Summarize the likely review areas and draft questions for a human reviewer. Do not claim to have inspected the diff." \
+  --skills github-code-review \
+  --deliver log
 ```
 
 **方式 B——静态路由（config.yaml）：**
@@ -91,20 +87,30 @@ platforms:
       secret: "your-global-secret"
       routes:
         github-pr-review:
+          provider: github
+          signature_mode: github
           events: ["pull_request"]
           secret: "github-webhook-secret"
+          filters:
+            - field: "action"
+              in: ["opened", "synchronize", "reopened"]
+          toolsets: ["terminal"]
           prompt: |
             Review PR #{pull_request.number}: {pull_request.title}
             Repository: {repository.full_name}
             Author: {pull_request.user.login}
-            Diff URL: {pull_request.diff_url}
-            Review for security, performance, and code quality.
+            Run: gh pr diff {pull_request.number} --repo {repository.full_name}
+            Review the diff for security, performance, and code quality.
+            Return only the concise review text. Do not post it yourself;
+            the github_comment delivery target below posts the final response.
           skills: ["github-code-review"]
           deliver: "github_comment"
           deliver_extra:
             repo: "{repository.full_name}"
             pr_number: "{pull_request.number}"
 ```
+
+这里的 `terminal` 命令在配置的 terminal 后端中运行；`github_comment` 投递使用的 `gh` 则在 gateway 主机上运行。因此，若 terminal 后端是 Docker 或 SSH，两处都必须具备各自所需的 `gh`/认证。该路由的 secret 会绑定 provider、toolset、prompt、skill 和投递目标；以后修改任一字段时必须换用全新 secret，并同步更新 GitHub webhook。
 
 然后在 GitHub 中：**Settings → Webhooks → Add webhook** → Payload URL：`http://your-server:8644/webhooks/github-pr-review`，Content type：`application/json`，Secret：`github-webhook-secret`，Events：**Pull requests**。
 
@@ -168,8 +174,12 @@ If no vulnerabilities, respond with [SILENT]." \
 **触发方式：** API 调用（webhook）
 
 ```bash
+DEPLOY_WEBHOOK_SECRET="replace-with-a-random-secret"
 hermes webhook subscribe deploy-verify \
+  --provider generic \
+  --signature-mode generic_v2 \
   --events "deployment" \
+  --secret "$DEPLOY_WEBHOOK_SECRET" \
   --prompt "A deployment just completed:
 Service: {service}
 Environment: {environment}
@@ -177,32 +187,44 @@ Version: {version}
 Deployed by: {deployer}
 
 Run these verification steps:
-1. Check if the service is responding: curl -s -o /dev/null -w '%{http_code}' {health_url}
-2. Search recent logs for errors: check the deployment payload for any error indicators
-3. Verify the version matches: curl -s {health_url}/version
+1. Use web extraction to check whether {health_url} responds successfully
+2. Inspect the deployment payload's error summary: {errors}
+3. Use web extraction to verify that {version_url} reports version {version}
 
-Report: deployment status (healthy/degraded/failed), response time, any errors found.
+Report: deployment status (healthy/degraded/failed), observed versions, and any errors found.
 If healthy, keep it brief. If degraded or failed, provide detailed diagnostics." \
   --deliver telegram
 ```
 
+在 CI 中使用同一个 `DEPLOY_WEBHOOK_SECRET`。此 prompt 只使用默认 webhook toolset 中的 web 提取能力，不要求动态订阅自行授予 terminal。
+
 你的 CI/CD 流水线触发方式：
 
 ```bash
+BODY='{"event_type":"deployment","service":"api","environment":"prod","version":"2.1.0","deployer":"ci","health_url":"https://api.example.com/health","version_url":"https://api.example.com/version","errors":[]}'
+TIMESTAMP=$(date +%s)
+SIG=$(printf '%s.%s' "$TIMESTAMP" "$BODY" | openssl dgst -sha256 -hmac "$DEPLOY_WEBHOOK_SECRET" -hex | awk '{print $2}')
+
 curl -X POST http://your-server:8644/webhooks/deploy-verify \
   -H "Content-Type: application/json" \
-  -H "X-Hub-Signature-256: sha256=$(echo -n '{"service":"api","environment":"prod","version":"2.1.0","deployer":"ci","health_url":"https://api.example.com/health"}' | openssl dgst -sha256 -hmac 'your-secret' | cut -d' ' -f2)" \
-  -d '{"service":"api","environment":"prod","version":"2.1.0","deployer":"ci","health_url":"https://api.example.com/health"}'
+  -H "X-Webhook-Timestamp: $TIMESTAMP" \
+  -H "X-Webhook-Signature-V2: $SIG" \
+  -d "$BODY"
 ```
 
 ### 告警分类
 
-将监控告警与近期变更关联，起草响应方案。适用于 Datadog、PagerDuty、Grafana 或任何能 POST JSON 的告警系统。
+将监控告警与近期变更关联，起草响应方案。这个通用蓝图适用于任何能发送 Hermes Generic V2 签名的告警系统，或位于原始告警系统前方的可信中继。
 
 **触发方式：** API 调用（webhook）
 
 ```bash
+ALERT_WEBHOOK_SECRET="replace-with-a-random-secret"
 hermes webhook subscribe alert-triage \
+  --provider generic \
+  --signature-mode generic_v2 \
+  --events "alert" \
+  --secret "$ALERT_WEBHOOK_SECRET" \
   --prompt "Monitoring alert received:
 Alert: {alert.name}
 Severity: {alert.severity}
@@ -221,6 +243,8 @@ Investigate:
 Be concise. This goes to the on-call channel." \
   --deliver slack
 ```
+
+在已签名 JSON 正文顶层加入 `"event_type": "alert"`，并严格按上一个部署示例计算 `X-Webhook-Timestamp` 与 `X-Webhook-Signature-V2`。服务商请求头不会自动选择验证器；若发送方已有 Hermes 支持的原生契约，应改用对应的 provider 路由。
 
 ### 可用性监控
 
@@ -346,14 +370,16 @@ hermes cron create "0 8 * * *" \
 
 ## GitHub 事件自动化
 
-### Issue 自动打标签
+### Issue 分类建议
 
-自动对新 issue 打标签并回复。
+自动为新 issue 起草标签和初始回复，并写入日志供人工审核。
 
 **触发方式：** GitHub webhook
 
 ```bash
 hermes webhook subscribe github-issues \
+  --provider github \
+  --signature-mode github \
   --events "issues" \
   --prompt "New GitHub issue received:
 Repository: {repository.full_name}
@@ -367,15 +393,17 @@ If this is a new issue (action=opened):
 1. Read the issue title and body carefully
 2. Suggest appropriate labels (bug, feature, docs, security, question)
 3. If it's a bug report, check if you can identify the affected component from the description
-4. Post a helpful initial response acknowledging the issue
+4. Draft a helpful initial response acknowledging the issue
 
 If this is a label or assignment change, respond with [SILENT]." \
-  --deliver github_comment
+  --deliver log
 ```
+
+此动态蓝图只记录标签建议与回复草稿。当前 CLI 不能绑定 `github_comment` 所需的 `repo` 和 `pr_number`；若结果必须发布到 GitHub，请使用带显式 `deliver_extra` 目标的完整静态 PR 路由。
 
 ### CI 失败分析
 
-分析 CI 失败原因并在 PR 上发布诊断信息。
+分析 CI 失败原因并把诊断信息写入日志。一个 check run 可能关联零个或多个 pull request，因此此蓝图不会假定单一 GitHub 评论目标。
 
 **触发方式：** GitHub webhook
 
@@ -387,54 +415,67 @@ platforms:
     extra:
       routes:
         ci-failure:
+          provider: github
+          signature_mode: github
           events: ["check_run"]
           secret: "ci-secret"
+          toolsets: ["web"]
           prompt: |
             CI check failed:
             Repository: {repository.full_name}
             Check: {check_run.name}
             Status: {check_run.conclusion}
-            PR: #{check_run.pull_requests.0.number}
+            Associated PRs: {check_run.pull_requests}
             Details URL: {check_run.details_url}
 
             If conclusion is "failure":
-            1. Fetch the log from the details URL if accessible
+            1. Use web extraction to inspect the details URL if it is publicly accessible
             2. Identify the likely cause of failure
             3. Suggest a fix
             If conclusion is "success", respond with [SILENT].
-          deliver: "github_comment"
-          deliver_extra:
-            repo: "{repository.full_name}"
-            pr_number: "{check_run.pull_requests.0.number}"
+          deliver: "log"
 ```
 
-### 跨仓库自动移植变更
+### 规划跨仓库移植
 
-某仓库 PR 合并后，自动将等效变更移植到另一个仓库。
+某仓库 PR 合并后，检查其 diff，并为另一个仓库准备具体移植计划。
 
 **触发方式：** GitHub webhook
 
-```bash
-hermes webhook subscribe auto-port \
-  --events "pull_request" \
-  --prompt "PR merged in the source repository:
-Repository: {repository.full_name}
-PR #{pull_request.number}: {pull_request.title}
-Author: {pull_request.user.login}
-Action: {action}
-Merge commit: {pull_request.merge_commit_sha}
+```yaml
+# config.yaml route
+platforms:
+  webhook:
+    enabled: true
+    extra:
+      routes:
+        auto-port-plan:
+          provider: github
+          signature_mode: github
+          events: ["pull_request"]
+          secret: "auto-port-secret"
+          filters:
+            - field: "action"
+              equals: "closed"
+            - field: "pull_request.merged"
+              equals: true
+          toolsets: ["terminal"]
+          prompt: |
+            A pull request merged in {repository.full_name}:
+            PR #{pull_request.number}: {pull_request.title}
+            Merge commit: {pull_request.merge_commit_sha}
 
-If action is 'closed' and pull_request.merged is true:
-1. Fetch the diff: curl -sL {pull_request.diff_url}
-2. Analyze what changed
-3. Determine if this change needs to be ported to the Go SDK equivalent
-4. If yes, create a branch, apply the equivalent changes, and open a PR on the target repo
-5. Reference the original PR in the new PR description
+            Run:
+            gh pr diff {pull_request.number} --repo {repository.full_name}
 
-If action is not 'closed' or not merged, respond with [SILENT]." \
-  --skill github-pr-workflow \
-  --deliver log
+            Analyze the diff and prepare a file-by-file porting plan for org/go-sdk.
+            Include a proposed PR title and body that reference the original PR.
+            Do not clone, edit, push, or open a PR; return the plan only.
+          skills: ["github-pr-workflow"]
+          deliver: log
 ```
+
+这里显式授予 `terminal`，因为动态订阅不能增加路由级 toolset。`gh pr diff` 在配置的 terminal 后端中运行；该环境必须安装并认证 `gh`。
 
 ---
 
@@ -447,7 +488,11 @@ If action is not 'closed' or not merged, respond with [SILENT]." \
 **触发方式：** API 调用（webhook）
 
 ```bash
+STRIPE_WEBHOOK_SECRET="whsec_replace_with_your_endpoint_secret"
 hermes webhook subscribe stripe-payments \
+  --provider stripe \
+  --signature-mode stripe \
+  --secret "$STRIPE_WEBHOOK_SECRET" \
   --events "payment_intent.succeeded,payment_intent.payment_failed,charge.dispute.created" \
   --prompt "Stripe event received:
 Event type: {type}
@@ -469,6 +514,8 @@ For payment_intent.succeeded:
 Keep responses concise for the ops channel." \
   --deliver slack
 ```
+
+`STRIPE_WEBHOOK_SECRET` 必须是 Stripe 为该 endpoint 提供的 `whsec_...` signing secret；不要使用任意生成的 HMAC secret。Stripe 的 `Stripe-Signature` 请求头和正文 `type` 提供认证契约与事件类型。
 
 ### 每日营收摘要
 
@@ -581,7 +628,7 @@ Keep the outline to ~300 words. This is a starting point, not a finished post." 
 | `{issue.number}` | Issue 编号 |
 | `{repository.full_name}` | `owner/repo` |
 | `{action}` | 事件动作（opened、closed 等） |
-| `{__raw__}` | 完整 JSON payload（截断至 4000 字符） |
+| `{__raw__}` | 最多 4,000 UTF-8 字节、带明确截断元数据的可解析原始 payload 信封 |
 | `{sender.login}` | 触发事件的 GitHub 用户 |
 
 ### [SILENT] 模式

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/webhook-github-pr-review.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/webhook-github-pr-review.md
@@ -28,7 +28,7 @@ Webhook payload 包含攻击者可控的数据——PR 标题、commit 消息和
 ## 前提条件
 
 - Hermes Agent 已安装并运行（`hermes gateway`）
-- [`gh` CLI](https://cli.github.com/) 已安装并在 gateway 主机上完成认证（`gh auth login`）
+- [`gh` CLI](https://cli.github.com/) 已安装并完成认证：`gh pr diff` 在配置的 terminal 后端中运行，而最终的 `github_comment` 投递在 gateway 主机上运行。使用 Docker 或 SSH terminal 后端时，两处环境都必须分别具备所需的 `gh` 与凭证。
 - 你的 Hermes 实例有一个可公网访问的 URL（如果在本地运行，请参阅[使用 ngrok 进行本地测试](#local-testing-with-ngrok)）
 - 对 GitHub 仓库的管理员权限（管理 webhook 所需）
 
@@ -44,13 +44,16 @@ platforms:
     enabled: true
     extra:
       port: 8644          # 默认值；如果该端口被其他服务占用，请修改
-      rate_limit: 30      # 每条路由每分钟最大请求数（非全局上限）
+      rate_limit: 30      # 每个 profile/路由滑动 60 秒内的新身份数
 
       routes:
         github-pr-review:
+          provider: github
+          signature_mode: github
           secret: "your-webhook-secret-here"   # 必须与 GitHub webhook secret 完全一致
           events:
             - pull_request
+          toolsets: ["terminal"]                 # 运行 gh 所需的显式授权
 
           # agent 被指示在审查前先获取实际的 diff。
           # {number} 和 {repository.full_name} 从 GitHub payload 中解析。
@@ -63,12 +66,13 @@ platforms:
             Description: {pull_request.body}
             URL: {pull_request.html_url}
 
-            If the action is "closed" or "labeled", stop here and do not post a comment.
+            If the action is "closed" or "labeled", respond with [SILENT].
 
             Otherwise:
             1. Run: gh pr diff {number} --repo {repository.full_name}
             2. Review the code changes for correctness, security issues, and clarity.
-            3. Write a concise, actionable review comment and post it.
+            3. Return only a concise, actionable review comment. Do not post it yourself;
+               the github_comment delivery target posts the final response exactly once.
 
           deliver: github_comment
           deliver_extra:
@@ -80,15 +84,17 @@ platforms:
 
 | 字段 | 说明 |
 |---|---|
-| `secret`（路由级别） | 该路由的 HMAC secret。如果省略，则回退到 `extra.secret` 全局配置。 |
-| `events` | 要接受的 `X-GitHub-Event` 请求头值列表。空列表 = 接受所有。 |
+| `provider` | 将此路由绑定到 GitHub 验证器；请求头不能选择 provider。 |
+| `secret`（路由级别） | 该路由的 HMAC secret。全局 `extra.secret` 回退值仅在恰好一条已认证路由使用时有效；否则每条路由都必须使用唯一密钥材料。 |
+| `events` | 最多配置一个已认证 GitHub 事件类别。支持 `check_run`、`pull_request`、`push`、`issues`、`ping`；请求头与已签名正文结构必须同时匹配。空列表不按事件过滤，但事件权限解析为 `unknown`。 |
+| `toolsets` | 替换此路由受限的 webhook 默认工具集。`gh pr diff` 需要 `terminal`；若 prompt 不再使用 shell，请移除此授权。 |
 | `prompt` | 模板；`{field}` 和 `{nested.field}` 从 GitHub payload 中解析。 |
 | `deliver` | `github_comment` 通过 `gh pr comment` 发布。`log` 仅写入 gateway 日志。 |
 | `deliver_extra.repo` | 从 payload 中解析为例如 `org/repo`。 |
 | `deliver_extra.pr_number` | 从 payload 中解析为 PR 编号。 |
 
 :::note Payload 中不包含代码
-GitHub webhook payload 包含 PR 元数据（标题、描述、分支名、URL），但**不包含 diff**。上方的 prompt 指示 agent 运行 `gh pr diff` 来获取实际变更。`terminal` 工具已包含在默认的 `hermes-webhook` 工具集中，无需额外配置。
+GitHub webhook payload 包含 PR 元数据（标题、描述、分支名、URL），但**不包含 diff**。上方的 prompt 指示 agent 在配置的 terminal 后端中运行 `gh pr diff` 来获取实际变更。默认 `hermes-webhook` 工具集出于安全考虑不包含 `terminal`；本路由因此显式授予 `toolsets: ["terminal"]`，并用它替换此路由的平台默认工具集。最终 `github_comment` 投递由 gateway 主机上的 `gh` 独立执行；prompt 只应返回评论文本，不能再次发布。
 :::
 
 ---
@@ -102,14 +108,14 @@ hermes gateway
 你应该看到：
 
 ```
-[webhook] Listening on 0.0.0.0:8644 — routes: github-pr-review
+[webhook] Listening on * (all interfaces, IPv4+IPv6):8644 — routes: github-pr-review
 ```
 
 验证其是否正在运行：
 
 ```bash
 curl http://localhost:8644/health
-# {"status": "ok", "platform": "webhook"}
+# {"status": "ok", "platform": "webhook", "accepting_webhooks": true}
 ```
 
 ---
@@ -124,7 +130,7 @@ curl http://localhost:8644/health
    - **Which events?** → 选择单个事件 → 勾选 **Pull requests**
 3. 点击 **Add webhook**
 
-GitHub 会立即发送一个 `ping` 事件以确认连接。该事件会被安全忽略——`ping` 不在你的 `events` 列表中——并返回 `{"status": "ignored", "event": "ping"}`。它仅在 DEBUG 级别记录日志，因此不会在默认日志级别的控制台中显示。
+GitHub 会立即发送一个已签名的 `ping` 事件以确认连接。此路由精确绑定 `pull_request`，因此该投递会返回 HTTP `401`（`Invalid authenticated webhook metadata`）。`X-GitHub-Event` 值与 HMAC 覆盖的 JSON 正文结构必须同时匹配，所以修改 ping 的请求头也不能把它变成 pull-request 事件。这是预期行为；之后已签名的 `pull_request` 投递才是功能测试。
 
 ---
 
@@ -150,23 +156,36 @@ ngrok http 8644
 
 复制 `https://...ngrok-free.app` URL 并将其用作你的 GitHub Payload URL。在 ngrok 免费版中，每次 ngrok 重启后 URL 都会变化——每次会话都需要更新你的 GitHub webhook。付费 ngrok 账户可获得静态域名。
 
-你可以直接用 `curl` 对静态路由进行冒烟测试——无需 GitHub 账户或真实 PR。
+你可以直接用 `curl` 对静态路由进行冒烟测试——无需 GitHub 账户或真实 PR。请添加一条使用独立 secret 的 log-only 路由，避免测试时修改生产路由已绑定到密钥的策略：
 
-:::tip 本地测试时使用 `deliver: log`
-在测试时，将配置中的 `deliver: github_comment` 改为 `deliver: log`。否则 agent 将尝试向测试 payload 中的假 `org/repo#99` 仓库发布评论，这将会失败。对 prompt 输出满意后，再切换回 `deliver: github_comment`。
+```yaml
+# 位于 platforms.webhook.extra.routes 内：
+github-pr-review-smoke:
+  provider: github
+  signature_mode: github
+  events: [pull_request]
+  secret: "a-distinct-smoke-test-secret"
+  prompt: |
+    Summarize this test PR payload:
+    PR #{number}: {pull_request.title} in {repository.full_name}
+  deliver: log
+```
+
+:::tip 为什么使用第二条路由？
+Secret 会永久绑定到路由名称、profile、验证器、prompt、toolset 和投递策略。把生产路由的 `deliver` 从 `github_comment` 改为 `log` 后继续复用原 secret 会被拒绝；独立路由能让两套权限保持明确。
 :::
 
 ```bash
-SECRET="your-webhook-secret-here"
-BODY='{"action":"opened","number":99,"pull_request":{"title":"Test PR","body":"Adds a feature.","user":{"login":"testuser"},"head":{"ref":"feat/x"},"base":{"ref":"main"},"html_url":"https://github.com/org/repo/pull/99"},"repository":{"full_name":"org/repo"}}'
+SECRET="a-distinct-smoke-test-secret"
+BODY='{"action":"opened","number":99,"pull_request":{"id":701,"number":99,"state":"open","title":"Test PR","body":"Adds a feature.","user":{"login":"testuser"},"head":{"ref":"feat/x"},"base":{"ref":"main"},"html_url":"https://github.com/org/repo/pull/99"},"repository":{"id":801,"full_name":"org/repo"},"sender":{"id":901,"login":"testuser"}}'
 SIG=$(printf '%s' "$BODY" | openssl dgst -sha256 -hmac "$SECRET" -hex | awk '{print "sha256="$2}')
 
-curl -s -X POST http://localhost:8644/webhooks/github-pr-review \
+curl -s -X POST http://localhost:8644/webhooks/github-pr-review-smoke \
   -H "Content-Type: application/json" \
   -H "X-GitHub-Event: pull_request" \
   -H "X-Hub-Signature-256: $SIG" \
   -d "$BODY"
-# Expected: {"status":"accepted","route":"github-pr-review","event":"pull_request","delivery_id":"..."}
+# HTTP 202: {"status":"accepted","route":"github-pr-review-smoke","event":"pull_request","delivery_id":"...","deduplication":"authenticated_body_sha256"}
 ```
 
 然后观察 agent 运行：
@@ -182,12 +201,21 @@ tail -f "${HERMES_HOME:-$HOME/.hermes}/logs/gateway.log"
 
 ## 过滤特定 action
 
-GitHub 会针对多种 action 发送 `pull_request` 事件：`opened`、`synchronize`、`reopened`、`closed`、`labeled` 等。`events` 列表仅按 `X-GitHub-Event` 请求头值过滤——无法在路由级别按 action 子类型过滤。
+GitHub 会针对多种 action 发送 `pull_request` 事件：`opened`、`synchronize`、`reopened`、`closed`、`labeled` 等。路由会同时绑定 `X-GitHub-Event` 值与已认证的 pull-request 正文类别；随后可用路由级 `filters` 按 `action` 等 payload 字段进一步筛选。
 
-第一步中的 prompt 已通过指示 agent 对 `closed` 和 `labeled` 事件提前停止来处理这一问题。
+第一步的 prompt 会为 `closed` 和 `labeled` action 返回 `[SILENT]`。
 
 :::warning Agent 仍会运行并消耗 token（令牌）
-"stop here" 指令会阻止有意义的审查，但无论 action 如何，agent 仍会对每个 `pull_request` 事件运行至完成。GitHub webhook 只能按事件类型（`pull_request`、`push`、`issues` 等）过滤——无法按 action 子类型（`opened`、`closed`、`labeled`）过滤。路由级别没有针对子 action 的过滤器。对于高流量仓库，请接受这一成本，或通过 GitHub Actions workflow 在上游进行过滤，有条件地调用你的 webhook URL。
+`[SILENT]` 会抑制最终投递，但每个 `pull_request` action 仍会运行 agent 并消耗 token。请在 agent 唤醒前使用路由级 `filters`。Filters 属于密钥绑定的执行策略，因此要同时在路由和 GitHub 中换用**全新 secret**；复用旧 secret 进行此编辑会被拒绝：
+
+```yaml
+secret: "NEW-FILTERED-WEBHOOK-SECRET"
+filters:
+  - field: "action"
+    in: ["opened", "synchronize", "reopened"]
+```
+
+对于高流量仓库，还可通过 GitHub Actions workflow 在上游按条件调用 webhook URL。
 :::
 
 > 不支持 Jinja2 或条件模板语法。`{field}` 和 `{nested.field}` 是唯一支持的替换方式。其他内容会原样传递给 agent。
@@ -205,19 +233,23 @@ platforms:
     extra:
       routes:
         github-pr-review:
-          secret: "your-webhook-secret-here"
+          provider: github
+          signature_mode: github
+          secret: "NEW-SKILL-BOUND-WEBHOOK-SECRET"
           events: [pull_request]
+          toolsets: ["terminal"]
           prompt: |
             A pull request event was received (action: {action}).
             PR #{number}: {pull_request.title} by {pull_request.user.login}
             URL: {pull_request.html_url}
 
-            If the action is "closed" or "labeled", stop here and do not post a comment.
+            If the action is "closed" or "labeled", respond with [SILENT].
 
             Otherwise:
             1. Run: gh pr diff {number} --repo {repository.full_name}
             2. Review the diff using your review guidelines.
-            3. Write a concise, actionable review comment and post it.
+            3. Return only a concise, actionable review comment. Do not post it yourself;
+               the github_comment target posts the final response exactly once.
           skills:
             - review
           deliver: github_comment
@@ -226,29 +258,38 @@ platforms:
             pr_number: "{number}"
 ```
 
+添加或修改 skill 会改变密钥绑定策略。请把示例中的值替换为从未使用过的新 secret，并同步更新 GitHub webhook；不能继续使用此前无 skill 路由的 secret。
+
 > **注意：** 列表中只有第一个找到的 skill 会被加载。Hermes 不会叠加多个 skill——后续条目会被忽略。
 
 ---
 
 ## 将响应发送到 Slack 或 Discord
 
-将路由中的 `deliver` 和 `deliver_extra` 字段替换为你的目标平台：
+改变 `deliver` 或 `deliver_extra` 会改变密钥绑定策略。请同时将 `secret` 换成从未使用过的新值，并在 GitHub webhook 设置中同步更新。以下是两个互斥的目标示例：
+
+Slack：
 
 ```yaml
 # 在 platforms.webhook.extra.routes.<route-name> 内部：
-
-# Slack
+secret: "NEW-SLACK-BOUND-WEBHOOK-SECRET"
 deliver: slack
 deliver_extra:
   chat_id: "C0123456789"   # Slack 频道 ID（省略则使用配置的默认频道）
+  scope_id: "T0123456789"  # 此频道所属的 Slack 工作区/团队 ID
+```
 
-# Discord
+Discord：
+
+```yaml
+# 在 platforms.webhook.extra.routes.<route-name> 内部：
+secret: "NEW-DISCORD-BOUND-WEBHOOK-SECRET"
 deliver: discord
 deliver_extra:
   chat_id: "987654321012345678"  # Discord 频道 ID（省略则使用默认频道）
 ```
 
-目标平台也必须在 gateway 中启用并连接。如果省略 `chat_id`，响应将发送到该平台配置的默认频道。
+目标平台也必须在 gateway 中启用并连接。如果省略 `chat_id`，响应将发送到该平台配置的默认频道。模板化的 Slack `chat_id` 必须显式绑定匹配的工作区/团队 `scope_id`；静态频道可由已连接的适配器确立 scope，但显式配置可消除歧义。
 
 有效的 `deliver` 值：`log` · `github_comment` · `telegram` · `discord` · `slack` · `signal` · `sms`
 
@@ -256,25 +297,28 @@ deliver_extra:
 
 ## GitLab 支持
 
-同一适配器也适用于 GitLab。GitLab 使用 `X-Gitlab-Token` 进行认证（纯字符串匹配，非 HMAC）——Hermes 会自动处理两者。
+同一适配器也适用于 GitLab。GitLab 使用 `X-Gitlab-Token` 进行认证（纯字符串匹配，非 HMAC），但 Hermes 不会从请求头自动猜测 provider；路由必须显式声明 `provider: gitlab`。
 
 对于事件过滤，GitLab 将 `X-GitLab-Event` 设置为 `Merge Request Hook`、`Push Hook`、`Pipeline Hook` 等值。在 `events` 中使用精确的请求头值：
 
 ```yaml
+provider: gitlab
+signature_mode: gitlab
+secret: "your-gitlab-secret-token"
 events:
   - Merge Request Hook
 ```
 
-GitLab 的 payload 字段与 GitHub 不同——例如，MR 标题使用 `{object_attributes.title}`，MR 编号使用 `{object_attributes.iid}`。发现完整 payload 结构最简单的方式是使用 GitLab webhook 设置中的 **Test** 按钮，结合 **Recent Deliveries** 日志。或者，在路由配置中省略 `prompt`——Hermes 将把完整 payload 作为格式化 JSON 直接传递给 agent，agent 的响应（在 gateway 日志中通过 `deliver: log` 可见）将描述其结构。
+GitLab 的 payload 字段与 GitHub 不同——例如，MR 标题使用 `{object_attributes.title}`，MR 编号使用 `{object_attributes.iid}`。发现完整 payload 结构最简单的方式是使用 GitLab webhook 设置中的 **Test** 按钮，结合 **Recent Deliveries** 日志。或者，在路由配置中省略 `prompt`——Hermes 会向 agent 传递一个最多 4,000 UTF-8 字节、可解析并带有明确 `truncated` 标记的原始 payload 信封。
 
 ---
 
 ## 安全说明
 
 - **永远不要在生产环境中使用 `INSECURE_NO_AUTH`**——它会完全禁用签名验证。仅用于本地开发。
-- **定期轮换你的 webhook secret**，并在 GitHub（webhook 设置）和你的 `config.yaml` 中同步更新。
-- **速率限制**默认为每条路由每分钟 30 次请求（可通过 `extra.rate_limit` 配置）。超出限制返回 `429`。
-- **重复投递**（webhook 重试）通过 1 小时的幂等性缓存进行去重。缓存键依次为 `X-GitHub-Delivery`（如果存在）、`X-Request-ID`、毫秒级时间戳。当两个投递 ID 请求头都未设置时，重试**不会**去重。
+- **路由名称、profile、provider、签名模式或执行策略发生变化时轮换 webhook secret**，并在 GitHub 与 `config.yaml` 中同步更新。密钥材料会跨 profile 永久绑定到原始路由策略，不能重新分配。
+- **速率限制**默认在每个 profile/路由的滑动 60 秒窗口内准入 30 个新身份（可通过 `extra.rate_limit` 配置）。持久化重复或已活动身份不会再次占用配额；新身份超限返回 `429`。
+- **重复投递**由基于已认证请求正文生成的持久重放凭证阻止。GitHub 的正文签名不认证 `X-GitHub-Delivery` 或 `X-Request-ID`，因此这些观察到的请求头仅用于诊断，绝不会控制重放身份。该凭证在进程重启后仍有效，并非一小时的内存缓存。
 - **Prompt 注入：** PR 标题、描述和 commit 消息均为攻击者可控内容。恶意 PR 可能尝试操纵 agent 的行为。当暴露在公网时，请在沙箱环境（Docker、VM）中运行 gateway。
 
 ---
@@ -285,12 +329,12 @@ GitLab 的 payload 字段与 GitHub 不同——例如，MR 标题使用 `{objec
 |---|---|
 | `401 Invalid signature` | config.yaml 中的 secret 与 GitHub webhook secret 不匹配 |
 | `404 Unknown route` | URL 中的路由名称与 `routes:` 中的键不匹配 |
-| `429 Rate limit exceeded` | 每条路由每分钟 30 次请求已超出——在 GitHub UI 中重新投递测试事件时常见；等待一分钟或提高 `extra.rate_limit` |
+| `429 Rate limit exceeded` | 新身份超过滑动 60 秒配额；等待最早准入身份离开窗口，或提高 `extra.rate_limit` |
 | 未发布评论 | `gh` 未安装、不在 PATH 中，或未完成认证（`gh auth login`） |
-| Agent 运行但无评论 | 检查 gateway 日志——如果 agent 输出为空或仅为"SKIP"，投递仍会被尝试 |
+| Agent 运行但无评论 | 有意的 autonomous silence 响应（`[SILENT]`，包括该标记后附带解释文字）会按设计抑制目标投递。若并非预期静默，请在 gateway 日志中检查 prompt 与完整 agent 输出。 |
 | 端口已被占用 | 在 config.yaml 中修改 `extra.port` |
 | Agent 运行但仅审查了 PR 描述 | prompt 中未包含 `gh pr diff` 指令——diff 不在 webhook payload 中 |
-| 看不到 ping 事件 | 被忽略的事件仅在 DEBUG 日志级别返回 `{"status":"ignored","event":"ping"}`——检查 GitHub 的投递日志（仓库 → Settings → Webhooks → 你的 webhook → Recent Deliveries） |
+| GitHub 将初始 ping 标记为失败 | 对 `events: [pull_request]` 路由来说这是预期行为：其请求头和已认证正文都属于 `ping` 而非 `pull_request`，因此返回 `401`。请改为确认之后已签名的 pull-request 投递。 |
 
 **GitHub 的 Recent Deliveries 标签页**（仓库 → Settings → Webhooks → 你的 webhook）显示每次投递的精确请求头、payload、HTTP 状态和响应体。这是无需查看服务器日志即可诊断故障的最快方式。
 
@@ -303,18 +347,21 @@ platforms:
   webhook:
     enabled: true
     extra:
-      host: "0.0.0.0"         # 绑定地址（默认：0.0.0.0）
+      # 默认省略 host，监听所有 IPv4 + IPv6 接口；如需限制请显式设置地址
       port: 8644               # 监听端口（默认：8644）
-      secret: ""               # 可选的全局回退 secret
-      rate_limit: 30           # 每条路由每分钟请求数
-      max_body_bytes: 1048576  # payload 大小限制，单位字节（默认：1 MB）
+      secret: ""               # 仅当恰好一条已认证路由使用时才可作为回退
+      rate_limit: 30           # 每个 profile/路由滑动 60 秒内的新身份数
+      max_body_bytes: 1048576  # 默认值及硬上限：1 MiB
 
       routes:
         <route-name>:
+          provider: github       # 显式 provider/验证器绑定
+          signature_mode: github
           secret: "required-per-route"
-          events: []            # [] = 接受所有；否则列出 X-GitHub-Event 值
+          events: []            # [] = 不过滤/unknown；否则配置一个受支持事件
           prompt: ""            # {field} / {nested.field} 从 payload 中解析
           skills: []            # 加载第一个匹配的 skill（仅一个）
+          toolsets: []          # 显式的每路由替换；terminal 不是默认工具
           deliver: "log"        # log | github_comment | telegram | discord | slack | signal | sms
           deliver_extra: {}     # github_comment 需要 repo + pr_number；其他平台需要 chat_id
 ```

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/cli-commands.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/cli-commands.md
@@ -456,7 +456,7 @@ hermes webhook <subscribe|list|remove|test>
 
 | 子命令 | 说明 |
 |------------|-------------|
-| `subscribe` / `add` | 创建 webhook 路由。返回要在你的服务上配置的 URL 和 HMAC 密钥。 |
+| `subscribe` / `add` | 创建 webhook 路由，并打印路由 URL、绑定的 provider/signature mode、secret/token，以及可用的服务商专用请求头提示。 |
 | `list` / `ls` | 显示所有 agent 创建的订阅。 |
 | `remove` / `rm` | 删除动态订阅。不影响 config.yaml 中的静态路由。 |
 | `test` | 发送测试 POST 以验证订阅是否正常工作。 |
@@ -470,16 +470,23 @@ hermes webhook subscribe <name> [options]
 | 选项 | 说明 |
 |--------|-------------|
 | `--prompt` | 带有 `{dot.notation}` payload 引用的 prompt 模板。 |
-| `--events` | 要接受的逗号分隔事件类型（如 `issues,pull_request`）。为空则接受所有。 |
+| `--events` | 以逗号分隔的事件过滤器。GitHub 允许一个已认证正文类别（`check_run`、`pull_request`、`push`、`issues` 或 `ping`）；GitLab 允许一个精确请求头值。为空时不进行过滤：路由绑定的 GitHub/GitLab 请求解析为 `unknown`，而以正文为权限来源的服务商仍可从已认证 payload 解析事件。 |
+| `--provider` | 显式服务商契约（默认：`github`），例如 `github`、`gitlab`、`svix`、`standard_webhooks`、`stripe`、`hermes` 或 `generic`。 |
+| `--signature-mode` | 显式验证器覆盖；通用发送方推荐使用 `generic_v2`。 |
+| `--route-profile` | 有权接收此路由的 gateway profile（默认：`default`）。任何显式命名 profile 即使在单 profile 模式下也使用 `/p/<profile>/webhooks/<name>`（此时名称必须是当前运行的 profile）；multiplex 模式只增加可同时服务多个名称的能力。顶层 `--profile` 标志用于选择运行 CLI 的本地 Hermes profile，两者含义不同。 |
 | `--description` | 人类可读的描述。 |
 | `--skills` | 为 agent 运行加载的逗号分隔 skill 名称。 |
-| `--deliver` | 投递目标：`log`（默认）、`telegram`、`discord`、`slack`、`github_comment`。 |
+| `--deliver` | 投递目标：`log`（默认）、`telegram`、`discord`、`slack`、`github_comment`。`github_comment` 还要求路由绑定的 `deliver_extra.repo` 和正整数 `deliver_extra.pr_number`；当前 CLI 没有设置这些字段的标志，因此该目标应使用完整静态路由（或谨慎编辑完整动态条目并换用全新 secret）。 |
 | `--deliver-chat-id` | 跨平台投递的目标聊天/频道 ID。 |
-| `--secret` | 自定义 HMAC 密钥。省略时自动生成。 |
+| `--secret` | 自定义服务商验证 secret/token。省略时自动生成。 |
 | `--deliver-only` | 跳过 agent——将渲染后的 `--prompt` 作为字面消息投递。零 LLM 成本，亚秒级投递。要求 `--deliver` 为真实目标（非 `log`）。 |
-| `--script` | 位于 `~/.hermes/scripts/` 下的过滤/转换脚本。webhook payload 以 JSON 形式通过 stdin 传入；JSON stdout 会替换 payload，空 stdout、`[SILENT]` 或非零退出码会忽略该 webhook。参见[脚本过滤与转换](../user-guide/messaging/webhooks.md#script-filters-and-transforms)。 |
+| `--script` | 位于活动 profile 的 `$HERMES_HOME/scripts/` 下（通常为 `~/.hermes/scripts/`）的过滤/转换脚本。webhook payload 以 JSON 形式通过 stdin 传入；JSON stdout 会替换 payload，空 stdout 或 `[SILENT]` 会抑制投递。静态脚本错误会阻止监听器启动；无效动态候选会被跳过或撤销。执行开始后的超时或非零退出会返回 HTTP 500，标记结果为不确定，并持久阻止同一投递身份重试。参见[脚本过滤与转换](../user-guide/messaging/webhooks.md#script-filters-and-transforms)。 |
 
-订阅持久化到 `~/.hermes/webhook_subscriptions.json`，webhook 适配器无需重启 gateway 即可热重载。
+订阅持久化到活动 profile 的 `$HERMES_HOME/webhook_subscriptions.json`（通常为 `~/.hermes/webhook_subscriptions.json`；命名 profile 通常使用 `~/.hermes/profiles/<name>/webhook_subscriptions.json`），webhook 适配器无需重启 gateway 即可热重载。适配器在连接时和每个传入 webhook 之前检查文件：元数据变化会在下一次检查中加载；元数据未变化时，受限的 SHA-256 内容复查最多大约每秒一次。
+
+`subscribe` 默认使用 `--provider github`；这不是服务商自动探测。所有非 GitHub 发送方都应显式设置 `--provider`，并在适用时设置 `--signature-mode`。`hermes webhook test` 会生成符合服务商结构的默认正文，但 `--payload` 会原样发送你提供的 JSON：为自定义正文签名，并不会让它自动满足 GitHub 事件分类器或其他服务商的 payload 契约。
+
+当 webhook 绑定地址省略、为 loopback，或为通配地址（`0.0.0.0` / `::`）时，`subscribe` 打印的是**本地测试 URL（Local test URL）**。不要把该 URL 配置给外部服务商；必须通过公网 HTTPS 反向代理暴露完全相同的路由路径。例如，本地的 `/p/ops/webhooks/build` 在公网 URL 中也必须保持为 `/p/ops/webhooks/build`。配置了非 loopback 绑定地址时，输出会改为标记 **Callback URL**。`hermes webhook test` 有意直接向配置的/本地 gateway 地址发送请求，不会测试公网反向代理。
 
 ## `hermes doctor`
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/environment-variables.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/environment-variables.md
@@ -407,7 +407,7 @@ description: "Hermes Agent 使用的所有环境变量完整参考"
 | `HASS_URL` | Home Assistant URL（默认：`http://homeassistant.local:8123`） |
 | `WEBHOOK_ENABLED` | 启用 webhook 平台适配器（`true`/`false`） |
 | `WEBHOOK_PORT` | 接收 webhook 的 HTTP 服务器端口（默认：`8644`） |
-| `WEBHOOK_SECRET` | webhook 签名验证的全局 HMAC 密钥（当路由未指定自己的密钥时作为回退） |
+| `WEBHOOK_SECRET` | 仅供恰好一条已认证 webhook 路由使用的全局 HMAC 回退值；多路由必须各用唯一密钥 |
 | `API_SERVER_ENABLED` | 启用 OpenAI 兼容 API 服务器（`true`/`false`）。与其他平台并行运行。 |
 | `API_SERVER_KEY` | API 服务器认证的 Bearer token。非回环绑定时强制执行。 |
 | `API_SERVER_CORS_ORIGINS` | 允许直接调用 API 服务器的逗号分隔浏览器来源（例如 `http://localhost:3000,http://127.0.0.1:3000`）。默认：禁用。 |

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/webhooks.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/webhooks.md
@@ -28,7 +28,7 @@ agent 处理事件后，可通过在 PR 上发布评论、向 Telegram/Discord �
 
 1. 通过 `hermes gateway setup` 或环境变量启用
 2. 在 `config.yaml` 中定义路由，**或**使用 `hermes webhook subscribe` 动态创建
-3. 将你的服务指向 `http://your-server:8644/webhooks/<route-name>`
+3. 默认绑定的路由使用 `/webhooks/<route-name>`。显式设置命名 `profile` 的路由始终使用 `/p/<profile>/webhooks/<route-name>`，即使 gateway 运行在单 profile 模式下也是如此。
 
 ---
 
@@ -65,7 +65,7 @@ curl http://localhost:8644/health
 预期响应：
 
 ```json
-{"status": "ok", "platform": "webhook"}
+{"status": "ok", "platform": "webhook", "accepting_webhooks": true}
 ```
 
 ---
@@ -78,15 +78,21 @@ curl http://localhost:8644/health
 
 | 属性 | 是否必填 | 描述 |
 |----------|----------|-------------|
-| `events` | 否 | 要接受的事件类型列表（例如 `["pull_request"]`）。若为空，则接受所有事件。事件类型从 `X-GitHub-Event`、`X-GitLab-Event` 或 payload 中的 `event_type` 读取。 |
-| `secret` | **是** | 用于签名验证的 HMAC secret。若路由未设置，则回退到全局 `secret`。仅用于测试时可设为 `"INSECURE_NO_AUTH"`（跳过验证）。 |
-| `prompt` | 否 | 使用点号表示法访问 payload 字段的模板字符串（例如 `{pull_request.title}`）。若省略，则将完整 JSON payload 转储到 prompt 中。 |
+| `provider` | **是*** | 显式服务商契约，例如 `github`、`gitlab`、`svix`、`standard_webhooks`、`stripe`、`hermes` 或 `generic`。路由必须声明 `provider` 或 `signature_mode`；Hermes 不会根据攻击者可控请求头猜测。 |
+| `signature_mode` | 有时 | 显式验证器模式。通常由 `provider` 推导；服务商没有安全默认值时必填，也可用于选择 `generic_v1` 或推荐的 `generic_v2`。 |
+| `events` | 否 | 此路由允许的事件类型。GitHub 最多配置 `check_run`、`pull_request`、`push`、`issues` 或 `ping` 中的一个；Hermes 同时要求未签名的请求头和 HMAC 覆盖的正文结构匹配。GitLab 同样最多配置一个事件，并要求其未签名请求头与路由绑定值完全一致。未配置时不按事件过滤，但解析事件为 `unknown`。其他服务商可从已认证正文解析事件。 |
+| `secret` | **是** | 用于签名验证的 HMAC secret。仅当恰好一条已认证路由使用回退值时，才可由全局 `secret` 提供；多条路由必须配置各自唯一的 secret。仅回环测试可设为 `"INSECURE_NO_AUTH"`（跳过验证）。 |
+| `profile` | 否 | 有权执行此路由的 profile。省略（或使用 `default`）时绑定 `/webhooks/<route>`；显式名称（例如 `coder`）始终将路由及 secret 绑定到 `/p/coder/webhooks/<route>`。单 profile 模式下，该名称必须是当前运行的 profile；`gateway.multiplex_profiles` 只增加由同一 gateway 服务多个允许 profile 的能力。 |
+| `prompt` | 否 | 使用点号表示法访问 payload 字段的模板字符串（例如 `{pull_request.title}`）。若省略，prompt 会包含一个最多 4,000 UTF-8 字节、可解析的原始 payload 信封，而不是无界的完整转储。 |
 | `filters` | 否 | 声明式 payload 过滤器，在认证/请求体/事件过滤之后、agent 或直接投递之前求值。不匹配时返回 `{"status":"ignored","reason":"filter"}`（HTTP 200）。 |
-| `script` | 否 | 位于 `~/.hermes/scripts/` 下的过滤/转换脚本。webhook payload 以 JSON 形式通过 stdin 传入。stdout 为 JSON 对象时会在模板渲染前替换 payload；文本 stdout 以 `script_output` 形式暴露；空 stdout、`[SILENT]` 或非零退出码会忽略该 webhook。 |
+| `script` | 否 | 位于活动 profile 的 `$HERMES_HOME/scripts/` 下（通常为 `~/.hermes/scripts/`）的过滤/转换脚本。webhook payload 以 JSON 形式通过 stdin 传入。stdout 为 JSON 对象时会在模板渲染前替换 payload；文本 stdout 以 `script_output` 形式暴露；空 stdout、`[SILENT]` 或 `{"__hermes_ignore__": true}` 会抑制投递。脚本执行开始后，超时或非零退出码会返回 HTTP 500 及 `status=indeterminate`，并持久阻止相同投递标识再次执行。 |
 | `skills` | 否 | agent 运行时加载的 skill 名称列表。 |
+| `toolsets` | 否 | 仅为此路由替换平台级 webhook toolset 的键列表。只能手动编辑配置，`hermes webhook subscribe` 不可设置，避免 agent 创建订阅时自行提升权限。参见[路由级 toolset](#per-route-toolsets)。 |
 | `deliver` | 否 | 响应发送目标：`github_comment`、`telegram`、`discord`、`slack`、`signal`、`sms`、`whatsapp`、`matrix`、`mattermost`、`homeassistant`、`email`、`dingtalk`、`feishu`、`wecom`、`weixin`、`bluebubbles`、`qqbot`，或 `log`（默认）。 |
 | `deliver_extra` | 否 | 额外的投递配置——键取决于 `deliver` 类型（例如 `repo`、`pr_number`、`chat_id`）。值支持与 `prompt` 相同的 `{dot.notation}` 模板语法。 |
 | `deliver_only` | 否 | 若为 `true`，完全跳过 agent——渲染后的 `prompt` 模板直接作为消息体投递。零 LLM token 消耗，亚秒级投递。参见[直接投递模式](#direct-delivery-mode)了解使用场景。要求 `deliver` 为真实目标（非 `log`）。 |
+
+\* `provider` 与 `signature_mode` 至少声明一个。
 
 ### 完整示例
 
@@ -99,6 +105,7 @@ platforms:
       secret: "global-fallback-secret"
       routes:
         github-pr:
+          provider: "github"
           events: ["pull_request"]
           secret: "github-webhook-secret"
           prompt: |
@@ -115,6 +122,7 @@ platforms:
             repo: "{repository.full_name}"
             pr_number: "{number}"
         deploy-notify:
+          provider: "github"
           events: ["push"]
           secret: "deploy-secret"
           prompt: "New push to {repository.full_name} branch {ref}: {head_commit.message}"
@@ -126,7 +134,7 @@ platforms:
 
 ### Payload 过滤器 {#payload-filters}
 
-当服务商发送宽泛的事件流、但只有部分 payload 应唤醒 agent 或触发 `deliver_only` 投递时，使用 `filters`。过滤器在签名验证、请求体解析和 `events` 之后运行，但在 prompt 渲染、幂等去重、agent 调度或直接投递之前运行。
+当服务商发送宽泛的事件流、但只有部分 payload 应唤醒 agent 或触发 `deliver_only` 投递时，使用 `filters`。过滤器在签名验证、请求体解析、事件选择和持久化重放准入之后运行，但在脚本、prompt 渲染、agent 调度或目标投递之前运行。因此，被忽略的已认证身份仍会留下永久重放凭证。
 
 ```yaml
 platforms:
@@ -134,6 +142,8 @@ platforms:
     extra:
       routes:
         todoist:
+          provider: "generic"
+          signature_mode: "generic_v2"
           events: ["item:updated"]
           secret: "todoist-secret"
           filters:
@@ -155,14 +165,20 @@ platforms:
 - `contains` — 适用于字符串、列表和 dict 键
 - `in` — 内联列表
 - `in_file` — JSON 数组、JSON 对象（使用其键）或按行分隔的文本文件
-- `regex`
+- `regex`（在 HTTP 事件循环之外的隔离 worker 中求值；超过 4 KiB 的表达式、超过 256 KiB 的输入、无效表达式或超过 100 ms 的匹配均失败关闭）
+
+每条路由最多包含 64 个过滤节点、八层嵌套和八个正则操作符；超过任一限制都会失败关闭。
 - `all`、`any` 和 `not` 分组
 
-字段路径使用点号表示法。当存在顶层 `payload` 对象时，`payload.foo` 从中读取；对扁平 payload 则从 webhook 请求体根部读取。`event` / `event_type` 匹配解析出的事件类型，`headers.<Name>` 读取请求头。
+字段路径使用点号表示法。当存在顶层 `payload` 对象时，`payload.foo` 从中读取；对扁平 payload 则从 webhook 请求体根部读取。`event` / `event_type` 匹配解析出的权威事件类型。`headers.<Name>` 只暴露所选验证器以密码学方式覆盖的请求头；未签名的 GitHub/GitLab 事件或投递请求头仅用于诊断，不能作为过滤输入。
 
 ### 脚本过滤与转换 {#script-filters-and-transforms}
 
-当声明式过滤器不够用时，使用 `script`。脚本必须位于当前 profile 的 `~/.hermes/scripts/` 目录下；相对路径在该目录内解析，且禁止路径穿越到目录之外。`.sh` 和 `.bash` 脚本用 bash 运行，其他扩展名用当前 Python 解释器运行。
+当声明式过滤器不够用时，使用 `script`。脚本必须位于活动 profile 的 `$HERMES_HOME/scripts/` 目录下（通常为 `~/.hermes/scripts/`）；相对路径在该目录内解析，且禁止路径穿越到目录之外。Hermes 会在发布路由时捕获精确的脚本字节，执行时只使用这些已捕获字节。`.sh` 和 `.bash` 源码通过带 `--noprofile --norc` 的 bash 运行；其他源码通过当前 Python 解释器的隔离模式运行。
+
+每次调用都在全新、空白的工作目录中运行，并使用已捕获的最小非 secret 环境。它不会从 gateway 进程继承 `BASH_ENV`、`ENV`、`PYTHONPATH`、任意自定义变量或凭据变量。因此，相对导入、相邻 helper 文件、shell 启动钩子和环境中的 secret 都不可用。路由脚本必须是自包含的 JSON 转换：从 stdin 读取所提供的 JSON，并把结果写到 stdout。
+
+路由脚本是受信任的本地代码，并不是操作系统级沙箱。它以 gateway 用户身份运行，能够主动访问该账户可访问的任何资源，也可以脱离 Hermes 对子进程的尽力清理。冻结源码/解释器契约、空白工作目录、最小环境、超时和输出上限用于防止意外的权限漂移，并不能约束恶意脚本。如果不能完全信任路由脚本作者，请把 gateway 本身运行在容器、虚拟机或受限服务账户中。
 
 路由 payload 以 JSON 形式发送到 stdin：
 
@@ -185,7 +201,10 @@ print(json.dumps(payload))
 
 - stdout 为 JSON 对象时，替换 `prompt` 和 `deliver_extra` 使用的 payload。
 - 非 JSON 文本 stdout 会以 `script_output` 字段加入 payload。
-- 空 stdout、精确的 `[SILENT]`、`{"__hermes_ignore__": true}`、超时、脚本缺失或非零退出码，均返回 HTTP 200 及 `{"status":"ignored","reason":"script"}`。
+- 空 stdout、精确的 `[SILENT]` 或 `{"__hermes_ignore__": true}` 会明确抑制投递，并返回 HTTP 200 及 `{"status":"ignored","reason":"script"}`。
+- Hermes 会在发布路由之前验证脚本配置。脚本缺失、无法读取或无效时，静态 webhook 监听器不会启动；动态订阅中的同类错误会使候选路由被跳过，或使已发布的动态路由被撤销。它通常不会等到请求到达后才被发现。若防御性检查仍在请求期间发现配置不一致，则会在脚本执行前返回 HTTP 500 及 `status=failed`；修复并重新发布路由后可以重试该投递。
+- 脚本执行被持久标记为已开始后，超时、运行时错误、非零退出码或无效输出会返回 HTTP 500 及 `status=indeterminate`。Hermes 会记录不确定结果并阻止相同投递标识再次执行；重试时返回 HTTP 409 及 `status=indeterminate`，而不会再次运行脚本。
+- 脚本 stdout 与 stderr 各自最多捕获 1 MiB，两者合计同样最多 1 MiB。超过任一输出上限都会终止脚本，并按上述“脚本已开始”的 `indeterminate` 路径处理。
 
 ### Prompt 模板
 
@@ -193,7 +212,7 @@ Prompt 使用点号表示法访问 webhook payload 中的嵌套字段：
 
 - `{pull_request.title}` 解析为 `payload["pull_request"]["title"]`
 - `{repository.full_name}` 解析为 `payload["repository"]["full_name"]`
-- `{__raw__}` — 特殊 token，将**整个 payload** 以缩进 JSON 格式转储（截断至 4000 个字符）。适用于监控告警或通用 webhook，agent 需要完整上下文时使用。
+- `{__raw__}` — 包含 `payload`、`truncated` 和 `original_bytes` 字段的可解析 JSON 信封。包括 JSON 转义和元数据在内，整个信封默认最多 4,000 UTF-8 字节。
 - 缺失的键保留为字面量 `{key}` 字符串（不报错）
 - 嵌套的 dict 和 list 会被 JSON 序列化并截断至 2000 个字符
 
@@ -203,7 +222,7 @@ Prompt 使用点号表示法访问 webhook payload 中的嵌套字段：
 prompt: "PR #{pull_request.number} by {pull_request.user.login}: {__raw__}"
 ```
 
-若路由未配置 `prompt` 模板，则将整个 payload 以缩进 JSON 格式转储（截断至 4000 个字符）。
+若路由未配置 `prompt` 模板，Hermes 会把同一个受限的 4,000 字节原始 payload 信封放进生成的 prompt。较大的 payload 会明确标记 `truncated`；省略模板不会产生无界的完整 JSON 转储。
 
 `deliver_extra` 的值中同样支持点号表示法模板。
 
@@ -212,18 +231,24 @@ prompt: "PR #{pull_request.number} by {pull_request.user.login}: {__raw__}"
 向 Telegram 投递 webhook 响应时，可通过在 `deliver_extra` 中包含 `message_thread_id`（或 `thread_id`）来指定特定论坛话题：
 
 ```yaml
-webhooks:
-  routes:
-    alerts:
-      events: ["alert"]
-      prompt: "Alert: {__raw__}"
-      deliver: "telegram"
-      deliver_extra:
-        chat_id: "-1001234567890"
-        message_thread_id: "42"
+platforms:
+  webhook:
+    enabled: true
+    extra:
+      routes:
+        alerts:
+          provider: "generic"
+          signature_mode: "generic_v2"
+          secret: "your-generic-v2-secret"
+          events: ["alert"]
+          prompt: "Alert: {__raw__}"
+          deliver: "telegram"
+          deliver_extra:
+            chat_id: "-1001234567890"
+            message_thread_id: "42"
 ```
 
-若 `deliver_extra` 中未提供 `chat_id`，则回退到目标平台配置的主频道。
+若 `deliver_extra` 中未提供 `chat_id`，则回退到目标平台配置的主频道。对于命名的 multiplex 路由，如果路由发布时目标适配器尚未活动，Hermes 会从该路由所指 profile 的配置读取主频道，而不是使用进程默认 profile，并将其冻结到路由权限中。
 
 ---
 
@@ -279,7 +304,8 @@ platforms:
     extra:
       routes:
         gitlab-mr:
-          events: ["merge_request"]
+          provider: "gitlab"
+          events: ["Merge Request Hook"]
           secret: "your-gitlab-secret-token"
           prompt: |
             Review this merge request:
@@ -300,10 +326,10 @@ platforms:
 | 投递类型 | 描述 |
 |-------------|-------------|
 | `log` | 将响应记录到 gateway 日志输出。这是默认值，适合测试使用。 |
-| `github_comment` | 通过 `gh` CLI 将响应作为 PR/issue 评论发布。需要 `deliver_extra.repo` 和 `deliver_extra.pr_number`。`gh` CLI 必须安装并在 gateway 主机上完成认证（`gh auth login`）。 |
+| `github_comment` | 通过 `gh pr comment` 将响应作为 pull request 评论发布。需要 `deliver_extra.repo` 和正整数 `deliver_extra.pr_number`。`gh` CLI 必须安装并在 gateway 主机上完成认证（`gh auth login`）。 |
 | `telegram` | 将响应路由到 Telegram。使用主频道，或在 `deliver_extra` 中指定 `chat_id`。 |
 | `discord` | 将响应路由到 Discord。使用主频道，或在 `deliver_extra` 中指定 `chat_id`。 |
-| `slack` | 将响应路由到 Slack。使用主频道，或在 `deliver_extra` 中指定 `chat_id`。 |
+| `slack` | 将响应路由到 Slack。使用已配置的主频道，或在 `deliver_extra` 中指定 `chat_id`。模板化的 `chat_id` 必须显式绑定工作区 `scope_id`；静态频道可由已连接的适配器确立 scope，但显式声明更清楚。 |
 | `signal` | 将响应路由到 Signal。使用主频道，或在 `deliver_extra` 中指定 `chat_id`。 |
 | `sms` | 通过 Twilio 将响应路由到 SMS。使用主频道，或在 `deliver_extra` 中指定 `chat_id`。 |
 | `whatsapp` | 将响应路由到 WhatsApp。使用主频道，或在 `deliver_extra` 中指定 `chat_id`。 |
@@ -317,7 +343,7 @@ platforms:
 | `weixin` | 将响应路由到 Weixin（微信）。使用主频道，或在 `deliver_extra` 中指定 `chat_id`。 |
 | `bluebubbles` | 将响应路由到 BlueBubbles（iMessage）。使用主频道，或在 `deliver_extra` 中指定 `chat_id`。 |
 
-跨平台投递时，目标平台也必须在 gateway 中启用并连接。若 `deliver_extra` 中未提供 `chat_id`，响应将发送到该平台配置的主频道。
+跨平台投递时，目标平台也必须在 gateway 中启用并连接。若 `deliver_extra` 中未提供 `chat_id`，响应将发送到该平台配置的主频道。模板化的 Slack `chat_id` 必须提供路由绑定的 `scope_id`，以防已签名事件跨越工作区权限边界。对于静态 Slack 频道，Hermes 可冻结已连接适配器确立的 scope；显式配置 `scope_id` 可消除歧义。
 
 ---
 
@@ -339,7 +365,7 @@ platforms:
 - **零 LLM token** — agent 从不被调用
 - **亚秒级投递** — 单次适配器调用，无推理循环
 - **与 agent 模式相同的安全性** — HMAC 认证、速率限制、幂等性和请求体大小限制均正常生效
-- **同步响应** — 投递成功后 POST 返回 `200 OK`，若目标拒绝则返回 `502`，便于上游服务智能重试
+- **同步响应** — 投递成功后 POST 返回 `200 OK`。若确定目标在任何副作用发生前失败，则返回带 `Retry-After: 5` 的 `503`，可以重试；`502` 表示目标结果不确定、需要人工核对，不能自动重试。
 
 ### 示例：从 Supabase 推送到 Telegram
 
@@ -352,6 +378,8 @@ platforms:
       secret: "global-secret"
       routes:
         antenna-matches:
+          provider: "generic"
+          signature_mode: "generic_v2"
           secret: "antenna-webhook-secret"
           deliver: "telegram"
           deliver_only: true
@@ -360,12 +388,14 @@ platforms:
             chat_id: "{match.telegram_chat_id}"
 ```
 
-你的 Supabase edge function 使用 HMAC-SHA256 对 payload 签名并 POST 到 `https://your-server:8644/webhooks/antenna-matches`。webhook 适配器验证签名、从 payload 渲染模板、投递到 Telegram，并返回 `200 OK`。
+Supabase edge function 必须把当前 Unix 时间戳放入 `X-Webhook-Timestamp`，用 `antenna-webhook-secret` 对 `<timestamp>.<原始请求正文>` 计算小写 HMAC-SHA256 十六进制摘要，并把摘要放入 `X-Webhook-Signature-V2`，再 POST 到 `https://your-server:8644/webhooks/antenna-matches`。时间戳必须在 gateway 时钟前后 300 秒内。适配器按显式 `generic_v2` 契约验证请求、渲染模板、投递到 Telegram，并返回 `200 OK`。
 
 ### 示例：通过 CLI 动态订阅
 
 ```bash
 hermes webhook subscribe antenna-matches \
+  --provider generic \
+  --signature-mode generic_v2 \
   --deliver telegram \
   --deliver-chat-id "123456789" \
   --deliver-only \
@@ -377,21 +407,26 @@ hermes webhook subscribe antenna-matches \
 
 | 状态码 | 含义 |
 |--------|---------|
-| `200 OK` | 投递成功。响应体：`{"status": "delivered", "route": "...", "target": "...", "delivery_id": "..."}` |
-| `200 OK`（status=duplicate） | 在幂等性 TTL（1 小时）内重复的 `X-GitHub-Delivery` ID。不重复投递。 |
+| `200 OK` | 投递成功。响应体包含 `status`、`route`、`target`、`delivery_id`，以及持久化目标 `settlement`（`confirmed` 或 `cached`）。 |
+| `200 OK`（status=suppressed） | 有意的 autonomous silence 响应在不调用目标的情况下完成结算；`settlement` 为 `suppressed`。 |
+| `200 OK`（status=duplicate） | 已认证的重放身份已经完成；永久凭证会阻止重复投递。 |
+| `202 Accepted`（status=in_progress） | 同一重放身份正在运行，或已拥有可恢复的暂存投递。 |
+| `409 Conflict` | 同一已认证重放身份对应不同正文，或先前结果不确定、需要人工核对。 |
 | `401 Unauthorized` | HMAC 签名无效或缺失。 |
 | `400 Bad Request` | JSON 请求体格式错误。 |
 | `404 Not Found` | 未知路由名称。 |
-| `413 Payload Too Large` | 请求体超过 `max_body_bytes`。 |
+| `413 Payload Too Large` | 请求体超过 `max_body_bytes`，或副作用开始前的模板扩展超过持久载体限制。 |
 | `429 Too Many Requests` | 路由速率限制已超出。 |
-| `502 Bad Gateway` | 目标适配器拒绝消息或抛出异常。错误记录在服务端日志中；响应体为通用的 `Delivery failed`，避免泄露适配器内部信息。 |
+| `500 Internal Server Error` | 已启动的路由脚本失败或超时；结果会被持久化标记为不确定并阻止重试。 |
+| `502 Bad Gateway` | 目标尝试可能已经产生副作用，因此结果不确定、需要核对。该重放身份会被持久阻止；再次提交同一身份会返回 `409`，不会重新调用目标。 |
+| `503 Service Unavailable` | 接收/恢复权限、由所有 webhook 适配器/profile 共享的四个**进程全局**受限路由 worker 之一、目标预检或持久化账本容量不可用。路由 worker 饱和时包含 `Retry-After: 1`；目标在副作用前失败时包含 `Retry-After: 5`；永久重放凭证不会自动淘汰，因此容量耗尽时不提供自动重试间隔。 |
 
 ### 配置注意事项
 
 - `deliver_only: true` 要求 `deliver` 为真实目标。`deliver: log`（或省略 `deliver`）在启动时会被拒绝——适配器发现路由配置错误时拒绝启动。
 - 直接投递模式下 `skills` 字段被忽略（不运行 agent，无处注入 skill）。
 - 模板渲染使用与 agent 模式相同的 `{dot.notation}` 语法，包括 `{__raw__}` token。
-- 幂等性使用相同的 `X-GitHub-Delivery` / `X-Request-ID` 请求头——携带相同 ID 的重试返回 `status=duplicate` 且**不**重复投递。
+- 重放防护只使用已认证的身份材料。Svix/Standard Webhooks 会把消息 ID 纳入签名；Stripe/Hermes 可使用已认证正文中的 ID。GitHub 等仅对正文签名的服务商按已认证正文摘要防护，而不是按未签名的传输 ID。
 
 ---
 
@@ -403,6 +438,7 @@ hermes webhook subscribe antenna-matches \
 
 ```bash
 hermes webhook subscribe github-issues \
+  --provider github \
   --events "issues" \
   --prompt "New issue #{issue.number}: {issue.title}\nBy: {issue.user.login}\n\n{issue.body}" \
   --deliver telegram \
@@ -428,13 +464,15 @@ hermes webhook remove github-issues
 
 ```bash
 hermes webhook test github-issues
-hermes webhook test github-issues --payload '{"issue": {"number": 42, "title": "Test"}}'
+hermes webhook test github-issues --payload '{"action":"opened","issue":{"number":42,"title":"Test"},"repository":{"id":1,"full_name":"owner/repo"},"sender":{"id":2,"login":"tester"}}'
 ```
+
+第一条命令会自动生成符合服务商契约的正文。自定义 GitHub payload 仍必须证明配置的事件类别；对于 `issues`，正文至少要包含受支持的 `action` 以及 `issue`、`repository`、`sender` 对象。CLI 会对自定义的精确字节签名并发送路由绑定的 `X-GitHub-Event` 请求头，但不会替你修复不合法的服务商 payload。
 
 ### 动态订阅的工作原理
 
-- 订阅存储在 `~/.hermes/webhook_subscriptions.json`
-- webhook 适配器在每次收到请求时热重载该文件（基于 mtime 检测，开销可忽略不计）
+- 订阅存储在活动 profile 的 `${HERMES_HOME:-$HOME/.hermes}/webhook_subscriptions.json`（例如命名 profile `ops` 使用 `~/.hermes/profiles/ops/webhook_subscriptions.json`）
+- webhook 适配器在连接时及处理每个传入 webhook 之前检查该文件，因此无需重启。文件身份或元数据变化时会在下一次检查中加载；若这些值没有变化，则受限重读和 SHA-256 内容检查最多大约每秒一次，既能发现元数据未变化的编辑，也避免请求洪泛放大文件读取。
 - `config.yaml` 中的静态路由始终优先于同名的动态订阅
 - 动态订阅与静态路由使用相同的格式和功能（events、prompt 模板、skills、delivery）
 - 无需重启 gateway——订阅后立即生效
@@ -442,6 +480,57 @@ hermes webhook test github-issues --payload '{"issue": {"number": 42, "title": "
 ### agent 驱动的订阅
 
 agent 可通过 terminal 工具在 `webhook-subscriptions` skill 的引导下创建订阅。向 agent 请求"为 GitHub issues 设置 webhook"，它将运行相应的 `hermes webhook subscribe` 命令。
+
+---
+
+## 路由级 toolset {#per-route-toolsets}
+
+Webhook agent 运行默认使用刻意收紧的 toolset（`web_search`、`web_extract`、`vision_analyze`、`clarify`），因为第三方可控的 webhook payload 可能包含 prompt 注入。公开 PR 标题或 issue 评论不应因此获得 terminal 权限。
+
+对于发送方完全受控的可信路由，例如本机监控守护进程或内部 CI，可以只为该路由配置更宽的 toolset，而不扩大其他 webhook 路由的权限：
+
+```yaml
+platforms:
+  webhook:
+    enabled: true
+    extra:
+      routes:
+        oom-emergency:
+          provider: "generic"
+          signature_mode: "generic_v2"
+          secret: "monitor-secret"
+          prompt: "Memory emergency: {detail}. Diagnose with ps/free/py-spy and report."
+          toolsets: ["terminal", "file", "code_execution", "web"]
+          deliver: "telegram"
+```
+
+`hermes webhook subscribe` 不能授予 toolset。若要手动授予，请编辑活动 profile 的 `${HERMES_HOME:-$HOME/.hermes}/webhook_subscriptions.json`：保留 CLI 已保存的完整路由条目，加入 `toolsets`，并把 `secret` 换成从未使用过的新密钥；随后同步更新发送方。Toolset 属于密钥绑定的执行策略，复用旧 secret 会使候选路由被拒绝，并撤销已有动态路由。
+
+```json
+{
+  "oom-emergency": {
+    "description": "Trusted local memory monitor",
+    "profile": "default",
+    "provider": "generic",
+    "signature_mode": "generic_v2",
+    "events": [],
+    "secret": "NEW-UNUSED-SECRET",
+    "prompt": "Memory emergency: {detail}. Diagnose and report.",
+    "skills": [],
+    "toolsets": ["terminal", "file", "web"],
+    "deliver": "telegram",
+    "deliver_extra": {"chat_id": "123456789"},
+    "created_at": "2026-08-28T00:00:00Z"
+  }
+}
+```
+
+行为与安全属性：
+
+- 路由列表会**替换**该路由运行时的平台级 webhook toolset 解析结果，而不是与之合并。
+- 名称通过与 `platform_toolsets` 相同的路径验证；未知或受平台限制的 toolset 会被移除。
+- `hermes webhook subscribe` 有意不提供 toolset 标志。提升权限必须完整地手动编辑配置并轮换新 secret，因此运行时自行创建订阅的 agent 不能自行授予 `terminal`。
+- 只应为发送方完全受控且使用真实 HMAC secret 的路由授予提升后的 toolset。任何能向该路由发送有效签名 payload 的主体，实际上都能让 agent 使用这些工具。
 
 ---
 
@@ -455,43 +544,58 @@ webhook 适配器包含多层安全机制：
 
 - **GitHub**：`X-Hub-Signature-256` 请求头——以 `sha256=` 为前缀的 HMAC-SHA256 十六进制摘要
 - **GitLab**：`X-Gitlab-Token` 请求头——明文 secret 字符串匹配
-- **通用**：`X-Webhook-Signature` 请求头——原始 HMAC-SHA256 十六进制摘要
+- **通用（V2，推荐）**：`X-Webhook-Signature-V2` 与 `X-Webhook-Timestamp` 请求头——对 `<timestamp>.<body>` 计算 HMAC-SHA256；时间戳必须在服务器时钟前后 300 秒内。
+- **通用（V1，旧版）**：`X-Webhook-Signature` 请求头——仅对正文计算 HMAC-SHA256，没有签名时间戳或 nonce。持久化账本会永久阻止同一已认证正文再次执行，但这也会把内容完全相同的合法 V1 请求合并为同一身份；请迁移到 V2。
 
 若已配置 secret 但请求中不存在已识别的签名请求头，则请求被拒绝。
 
 ### Secret 为必填项
 
-每个路由必须有 secret——直接设置在路由上或从全局 `secret` 继承。没有 secret 的路由会导致适配器在启动时报错退出。仅用于开发/测试时，可将 secret 设为 `"INSECURE_NO_AUTH"` 以完全跳过验证。
+每个路由都必须有 secret。全局 `secret` 只可作为**恰好一条已认证路由**的便利回退值；若两条已认证路由都继承它，就会跨权限域复用密钥材料，因此启动会失败关闭。存在多条已认证路由时，请为每条路由配置唯一 secret。仅用于开发/测试时，可将 secret 设为 `"INSECURE_NO_AUTH"` 以完全跳过验证。
+
+认证密钥材料会在根级持久权限中跨所有 profile 永久绑定。绑定范围包括物理 profile 实例、路由名称、provider、签名模式以及完整的非 secret 执行策略：规范化路由、解析后的 toolset、完整捕获的脚本执行契约（源码字节、解释器与隔离调用方式、最小环境及空白工作目录规则）、快照化的 skill 框架、已捕获的 `in_file` 过滤值，以及冻结的投递目标权限。重命名或移动路由、更换任一依赖或验证器、删除并重建 profile，或启动另一个 profile，都不能重新分配既有密钥。当绑定的文件、profile、授权、skill 或目标不再匹配已发布快照时，Hermes 会撤销该在线路由。任何绑定字段或策略发生变化时，都必须轮换为全新 secret；旧绑定会继续作为重放证据保存，不能复用。
+
+路由的 `profile` 字段在所有 gateway 模式下都会把 secret 绑定到一个执行目标。未设置 `profile` 的路由仅属于默认 profile；显式命名 profile 始终要求匹配的 `/p/<profile>/` 前缀。单 profile gateway 在该前缀中只接受自身名称，而 `gateway.multiplex_profiles` 允许一个 gateway 服务多个获准 profile。即使路由签名有效，URL 前缀与路由绑定不匹配时请求仍会被拒绝。
 
 `INSECURE_NO_AUTH` 仅在 gateway 绑定到回环地址（`127.0.0.1`、`localhost`、`::1`）时被接受。若与非回环绑定（如 `0.0.0.0` 或局域网 IP）组合使用，适配器拒绝启动——这可防止在公共接口上意外暴露未认证的端点。
 
 ### 速率限制
 
-每个路由默认限制为**每分钟 30 次请求**（固定窗口）。可全局配置：
+每个 profile/路由作用域默认在**滑动 60 秒窗口内最多准入 30 个新身份**。可全局配置该配额：
 
 ```yaml
 platforms:
   webhook:
     extra:
-      rate_limit: 60  # requests per minute
+      rate_limit: 60  # 每个滑动 60 秒窗口的新身份数
 ```
 
-超出限制的请求收到 `429 Too Many Requests` 响应。
+`rate_limit` 必须是 1 到 10,000 之间的精确整数。`script_timeout_seconds` 在同一个 `extra` 块中配置，必须是 1 到 300 秒之间的精确整数。无效值会使 webhook 以配置错误启动失败，而不会被静默改写。
+
+超过配额的新身份会收到 `429 Too Many Requests`。完全重复、冲突和已处于活动状态的身份会先由持久重放证据解析，不会再次消耗配额，因此重试洪泛无法挤占新任务。
 
 ### 幂等性
 
-投递 ID（来自 `X-GitHub-Delivery`、`X-Request-ID` 或时间戳回退）缓存 **1 小时**。重复投递（例如 webhook 重试）会被静默跳过并返回 `200` 响应，防止重复触发 agent 运行。
+已认证的服务商投递 ID 会成为永久重放身份。没有已签名投递 ID 的服务商使用已认证的“签名时间戳 + 正文”组合；旧版仅正文 HMAC 则使用已认证正文摘要。已完成和不确定结果的凭证会跨 gateway 重启持久保存，不会为了接收新任务而淘汰。只有显式的本机回环测试绕过具有一小时重放窗口。
+
+重放账本位于稳定 Hermes 根目录的 `state.db`，而不是命名 profile 的本地数据库。标准布局使用 `~/.hermes/state.db`；若活动 `HERMES_HOME` 为 `<root>/profiles/<name>`，Hermes 会把账本解析为 `<root>/state.db`。因此，gateway 在 multiplex 与非 multiplex 模式之间切换时，同一证据仍然有效。在这个根级账本内，操作与重放权限按实际执行路由的有效物理 profile 分区；所以命名单 profile 进程中的字面 `default` 路由属于该命名物理 profile，而不是单独的默认分区。
+
+每个物理 profile 主目录都包含一个持久化随机 `.webhook-profile-incarnation` token。Hermes 从解析后的主目录及该 token 派生路由的 profile generation，把它捕获到持久授权中，并在脚本、agent、目标和恢复副作用开始前再次检查。仅复用名称来重建或替换 profile，不能继承旧任务。失效 owner 恢复同样遵守该边界：适配器只能核对当前由它服务且 generation 仍然有效的物理 profile 行；其他 profile 的行保持不动，等待有权的适配器处理。
+
+账本会在脚本、agent 或目标副作用开始前预留最坏情况存储。`idempotency_max_storage_bytes` 默认为 1 GiB，必须是 5 MiB 至 64 GiB 范围内的精确整数；单个 profile/route/provider 无法占用全局预留空间。`idempotency_max_entries` 默认允许 4096 个活动操作。两个上限都会作为账本权限持久化；用不同值重新打开同一账本时启动失败，而不会静默改变准入语义。这些限制约束共享 `state.db` 内 webhook 账本的逻辑分配，并不限制整个数据库文件或 WAL 的物理大小。永久凭证耗尽预算后，新的唯一身份会以 HTTP 503 失败关闭，而既有身份仍可得到精确的重复/冲突判定。
 
 ### 请求体大小限制
 
-超过 **1 MB** 的 payload 在读取请求体之前即被拒绝。可配置：
+`max_body_bytes` 默认为且不能超过 **1 MiB（1,048,576 字节）**。它必须是 1 到 1,048,576 之间的精确整数；布尔值、小数和更大的上限都会在启动时被拒绝。声明的 `Content-Length` 超限会在读取前拒绝；分块传输或其他无长度请求体则会在受限读取过程中一旦越界立即中止。
 
 ```yaml
 platforms:
   webhook:
     extra:
-      max_body_bytes: 2097152  # 2 MB
+      max_body_bytes: 1048576  # 默认值及硬上限：1 MiB
 ```
+
+认证后的载体还有独立上限：渲染 prompt 最多 **512 KiB**，完整持久事件快照最多 **2 MiB**，每个持久目标或 tool grant 权限快照最多 **64 KiB**。若模板在任何已配置脚本或下游副作用开始前扩展超限，Hermes 会返回 HTTP 413 并释放操作声明。若已启动的脚本产生超限载体，Hermes 会改为记录不确定结果并返回 HTTP 500，而不会错误地认为可安全重试。
 
 ### Prompt 注入风险
 
@@ -507,7 +611,7 @@ Webhook payload 包含攻击者可控的数据——PR 标题、commit 消息、
 
 - 验证端口已暴露且可从 webhook 来源访问
 - 检查防火墙规则——端口 `8644`（或你配置的端口）必须开放
-- 验证 URL 路径是否匹配：`http://your-server:8644/webhooks/<route-name>`
+- 验证 URL 路径是否匹配路由绑定：默认路由使用 `/webhooks/<route-name>`；任何显式命名 profile 在单 profile 和 multiplex 模式下都使用 `/p/<profile>/webhooks/<route-name>`
 - 使用 `/health` 端点确认服务器正在运行
 
 ### 签名验证失败
@@ -517,12 +621,12 @@ Webhook payload 包含攻击者可控的数据——PR 标题、commit 消息、
 - 对于 GitLab，secret 为明文 token 匹配——检查 `X-Gitlab-Token`
 - 检查 gateway 日志中的 `Invalid signature` 警告
 
-### 事件被忽略
+### 事件被拒绝或忽略
 
-- 检查事件类型是否在路由的 `events` 列表中
-- GitHub 事件使用如 `pull_request`、`push`、`issues` 等值（`X-GitHub-Event` 请求头的值）
-- GitLab 事件使用如 `merge_request`、`push` 等值（`X-GitLab-Event` 请求头的值）
-- 若 `events` 为空或未设置，则接受所有事件
+- 检查事件类型是否与路由的 `events` 条目完全一致。路由绑定的 GitHub/GitLab 事件不匹配时会返回 `401`，而不是被忽略。
+- GitHub 路由绑定支持 `check_run`、`pull_request`、`push`、`issues` 和 `ping`。`X-GitHub-Event` 值与已认证 JSON 正文结构必须同时匹配；修改已签名正文旁边的未签名请求头会返回 `401`。
+- GitLab 事件使用精确的 `X-GitLab-Event` 请求头值，例如 `Merge Request Hook`、`Push Hook`，而不是 `merge_request` 等 payload 值
+- 若 `events` 为空或未设置，请求不按事件过滤。路由绑定的 GitHub/GitLab 请求解析为 `event=unknown`；generic、Stripe 等以已认证正文为准的服务商仍可从 payload 字段解析事件。
 
 ### Agent 未响应
 
@@ -532,8 +636,8 @@ Webhook payload 包含攻击者可控的数据——PR 标题、commit 消息、
 
 ### 重复响应
 
-- 幂等性缓存应能防止此问题——检查 webhook 来源是否发送了投递 ID 请求头（`X-GitHub-Delivery` 或 `X-Request-ID`）
-- 投递 ID 缓存 1 小时
+- 检查重试是否保持签名实际覆盖的服务商材料，例如 `svix-id`/`webhook-id`、已认证正文 ID，或完全相同的已签名“时间戳 + 正文”组合。未签名的诊断请求头不会控制重放身份。
+- 检查 gateway 日志中的持久化账本或结算错误。重放凭证会持久保存，并非一小时的进程内缓存。
 
 ### `gh` CLI 错误（GitHub 评论投递）
 
@@ -549,4 +653,4 @@ Webhook payload 包含攻击者可控的数据——PR 标题、commit 消息、
 |----------|-------------|---------|
 | `WEBHOOK_ENABLED` | 启用 webhook 平台适配器 | `false` |
 | `WEBHOOK_PORT` | 接收 webhook 的 HTTP 服务器端口 | `8644` |
-| `WEBHOOK_SECRET` | 全局 HMAC secret（路由未指定自身 secret 时作为回退） | _（无）_ |
+| `WEBHOOK_SECRET` | 仅供恰好一条已认证路由使用的全局 HMAC 回退值；多路由必须各用唯一 secret | _（无）_ |


### PR DESCRIPTION
## Current composition gate — 2026-08-30 09:43 CDT

- **Live #97083 head:** `b77c9125c87017714660aa6918beb642f1c8f1fe`, exactly **2 commits / 75 files**, open and non-draft. Both submitted commits have exact hosted green CI/Docker/Nix receipts below, so the *submitted train itself* is green.
- **Current upstream main:** `5cc1369fa298021f8c740de154ff8c37c30bdcc8`. Live compare from this PR head to main is **diverged** with merge base `c30ac90a92097058ddd6f9db3fa2e3182a7bfdcc`: main has advanced **399 commits** while this PR owns its 2 submitted commits. GitHub currently reports the PR **non-mergeable**. The old hosted green therefore certifies only `bd3fd0ed… → b77c9125…`; it does **not** certify a current-main composition.
- **Merged #97204** remains current-main ownership for webhook/event-loop liveness: `gateway/platforms/webhook.py::_deliver_github_comment` must remain off-loop, and the ASYNC lint ratchet is merged enforcement. #97083 must preserve that landed liveness contract while resolving the current-main graph.
- **#97218** (`fix(gateway): bind webhook replay identity to authenticated content`) is now a single-commit, three-file carrier at exact head `359bd692ee887fa0562e6d99fd3c0cedccc2ac02`. CI `33271699471`, Docker `33271698889`, and Nix `33271698947` all succeeded on that only surviving commit, so #97218 is both **head-green and train-green**. Its current-main landing edge was rechecked at `main@5cc1369f…`: the 150 main-only commits since its merge base are path-disjoint from its three submitted files, and GitHub currently reports it mergeable.
- **#97218's invariant remains a strict prerequisite** of this durable authority pipeline: caller-supplied request/delivery IDs cannot mint distinct replay identities for the same authenticated content, and legacy body-only signing cannot weaken authenticated replay identity.
- **Merge/composition order:** preserve merged #97204; land or otherwise consume the exact #97218 replay owner; then semantically recompose #97083 on current main, subtracting that replay implementation rather than carrying a parallel copy, and reacquire exact CI/Docker/Nix for every surviving #97083 commit. If #97218 changes before landing, re-pin its exact accepted object before composition rather than inheriting this receipt.

This is a semantic-owner rule, not only a file-conflict note: event-loop realization, authenticated replay identity, joined route authority, durable execution, and terminal settlement each have one current owner at their mutation boundary.

## What lands

This makes webhook execution a sharded, durable authority pipeline instead of one ambient adapter godfile.

The public import remains `gateway.platforms.webhook.WebhookAdapter`. The current head splits responsibility across the webhook facade plus dedicated authentication, contract, route-authority, intake, delivery, recovery, callback, execution, model, store, and terminal modules. The PR no longer embeds source-line counts here because the head has moved since the first construction receipt; exact source shape is verified from the submitted object, not transferred from an earlier commit.

## Invariants

- Coordinates select a candidate route; immutable proof objects authorize effects.
- The joined route authority freezes profile generation, authentication keys, toolsets, filters, skills, target, and runtime scope before work begins.
- One durable operation owns one exact final carrier and one typed settlement.
- Duplicate, stale-generation, contradictory, failed, timed-out, and indeterminate operations cannot widen authority or silently repeat effects.
- Dynamic-route replacement revokes stale authority before publishing the replacement.
- Recovery is bounded, profile-scoped, generation-checked, and fail-closed.
- Trusted script execution is bounded by regular-file snapshots, interpreter/executable authority, environment reduction, output caps, timeout, and descendant teardown.
- The shared listener remains the sole multiplex intake owner; profile routes cannot borrow sibling credentials, adapters, sessions, or tool grants.

## Operator surface

This also closes the CLI/config/docs side of the contract:

- provider-aware webhook subscription validation;
- durable ledger capacity and storage-budget controls;
- explicit raw-payload, body, prompt, filter, script, and recovery bounds;
- English and Simplified Chinese webhook/automation/reference documentation;
- real loopback listener proof covering signature verification, filtering, script execution, durable deduplication, delivery settlement, and disconnect.

## Exact evidence

- Construction base / live merge base: `c30ac90a92097058ddd6f9db3fa2e3182a7bfdcc`
- Commit 1: `bd3fd0ed75084994fd9662019385bc773c69e097` — tree `82d4764f3b4ac591a8ec0c5e70884c2e2ced6fc5`
- Commit 2 / current head: `b77c9125c87017714660aa6918beb642f1c8f1fe` — tree `b278d09eec288e28da743ac20c719d848e3fe103`
- Every surviving commit on the submitted object has exact hosted green CI/Docker/Nix:
  - `bd3fd0ed…`: CI `33166146507`, Docker `33166145895`, Nix `33166145918`
  - `b77c9125…`: CI `33171319783`, Docker `33171318964`, Nix `33171319049`
- Current-main cross-check: `5cc1369fa298021f8c740de154ff8c37c30bdcc8`; live compare reports 399 main commits beyond merge base and GitHub reports this PR non-mergeable. A fresh current-main composition is therefore mandatory before landing.
- First-commit local evidence at `bd3fd0ed…`: webhook suite **707 passed, 0 failed, 1 Windows-only skip**; multiplex/profile/reconnect/proxy authority suite **188 passed, 0 failed**; focused moved-boundary suite **71 passed, 0 failed**; Ruff, byte compilation, staged diff integrity, and real listener E2E passed.
- The first-commit remote tree and all 56 committed blob IDs were verified exact at `bd3fd0ed…`; that receipt is intentionally not transferred to the later head or to a future recomposition.

## Interlocks and merge order

This is the current architecture carrier for the earlier slices #90236, #90995, #90304, and #85638, but it is **not** a current-main landing object until recomposed and re-proven.

A live FILE-LIST scan also found overlap with the following open work. This is a merge-order declaration, not a false claim that every unique provider feature is semantically absorbed. Each unique remainder must be revalidated against the joined authority and durable-settlement contracts after this change:

- delivery/recovery: #96681 (Slechts), #96516 (webtoolbox), #90385 (ryanlatham), #95408 (saedol-lang), #80533 (chenwei791129);
- signatures/secrets/providers: #96621 (ronlg), #95068 (jr551), #94953 (misschloedupont), #79656 (Mourey), #92972 (menhguin), #92024 (teknium1), #47849 (HwangJohn), #89427 (Leowr997), #90479 (aviyashchin);
- profile/session/intake: #94130 (martwals), #92682 (chelsealong), #92511 (fangliquanflq), #91743 (IAvecilla), #92066 (teknium1), #90589 (jzOcb), #95203 (johanseg);
- event-source expansion: #95262 (teknium1).

No overlapping PR should be merged independently without first proving that it preserves the authority join, single-owner listener, exact carrier, and typed settlement boundaries above.