### PR TITLE
fix(gateway): route approvals.mode startup check through canonical resolver (#97016)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7247,10 +7247,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # for unattended gateways.
         try:
             from hermes_cli.config import load_config as _load_full_config
+            from tools.approval import _normalize_approval_mode
             _appr_cfg = _load_full_config()
-            _appr_mode = str(
-                cfg_get(_appr_cfg, "approvals", "mode", default="manual") or "manual"
-            ).strip().lower()
+            # Route through the canonical resolver so YAML 1.1's bare `off`
+            # (parsed as False) is treated as "off" here just like the runtime
+            # approval gate does — otherwise `False or "manual"` collapses to
+            # "manual" and this warning contradicts the effective policy.
+            _appr_mode = _normalize_approval_mode(
+                cfg_get(_appr_cfg, "approvals", "mode", default="manual")
+            )
             _tirith_on = bool(cfg_get(_appr_cfg, "security", "tirith_enabled", default=True))
             _aux_approval = cfg_get(_appr_cfg, "auxiliary", "approval", default=None)
             if _appr_mode == "manual" and not _tirith_on and not _aux_approval:


### PR DESCRIPTION
## Summary

Closes #97016.

YAML 1.1 parses bare `off` as boolean `False`. The runtime approval gate already handles this — `tools/approval._normalize_approval_mode` maps `False` → `\"off\"` (and its own docstring documents exactly this footgun). But the gateway startup heads-up in `gateway/run.py` used a plain `str(...).lower()` pipeline, so for `approvals: { mode: off }` (unquoted) `False or \"manual\"` collapsed to `\"manual\"`. With `security.tirith_enabled: false` and no `auxiliary.approval`, the gateway then logged:

> Gateway approvals.mode=manual with no automated risk assessor … dangerous commands and execute_code scripts will BLOCK until a human approves them

— for an operator who had explicitly turned approvals **off**, and whose sessions do in fact bypass approvals at runtime.

This routes the startup check through `_normalize_approval_mode` so it agrees with the runtime gate. Cosmetic, but it's a security-posture message and shouldn't lie.

## Test plan

- [ ] Set `~/.hermes/config.yaml` to `approvals: { mode: off }` (unquoted), `security: { tirith_enabled: false }`, no `auxiliary.approval`. Start any gateway. Verify the `approvals.mode=manual … BLOCK` warning no longer fires.
- [ ] Set `approvals: { mode: manual }` with the same tirith/auxiliary state. Verify the warning still fires (regression guard for the true-manual case).
- [ ] Set `approvals: { mode: \"off\" }` (quoted) — behavior unchanged, no warning.