### PR TITLE
fix(desktop): per-stream buffers for HERMES_BACKEND_READY watcher

### DIFF
--- a/apps/desktop/electron/backend-ready.ts
+++ b/apps/desktop/electron/backend-ready.ts
@@ -35,8 +35,9 @@ function resolvePortAnnounceTimeoutMs(env = process.env) {
 }
 
 /**
- * Watch a child process's stdout for the `HERMES_(BACKEND|DASHBOARD)_READY
+ * Watch a child process's stdout (and stderr) for the `HERMES_(BACKEND|DASHBOARD)_READY
  * port=<N>` line that web_server.py prints after uvicorn binds its socket.
+ * (Both streams are watched: `hermes serve` can announce on stderr.)
  *
  * Returns the parsed port. Rejects if:
  *   - the child exits before emitting the line
@@ -53,7 +54,9 @@ function resolvePortAnnounceTimeoutMs(env = process.env) {
  */
 function waitForDashboardPort(child, timeoutMs = resolvePortAnnounceTimeoutMs(), describeOutputTail = () => '') {
   return new Promise((resolve, reject) => {
-    let buf = ''
+    // Per-stream buffers: a partial line on one pipe must NOT be spliced onto
+    // a line on the other (it corrupts the ^-anchored _READY_RE match and makes
+    // boot hang to the 90s timeout). See #96282 / PR #96325.
     let done = false
 
     function cleanup() {
@@ -63,28 +66,39 @@ function waitForDashboardPort(child, timeoutMs = resolvePortAnnounceTimeoutMs(),
 
       done = true
       clearTimeout(timer)
-      child.stdout.off('data', onData)
+      child.stdout.off('data', onStdout)
+      child.stderr.off('data', onStderr)
       child.off('exit', onExit)
       child.off('error', onError)
     }
 
-    function onData(chunk) {
-      buf += chunk.toString()
-      let nl
+    function onStreamData(bufRef: { v: string }) {
+      return (chunk: Buffer | string) => {
+        let buf = bufRef.v
+        buf += chunk.toString()
+        let nl
 
-      while ((nl = buf.indexOf('\n')) !== -1) {
-        const line = buf.slice(0, nl)
-        buf = buf.slice(nl + 1)
-        const m = line.match(_READY_RE)
+        while ((nl = buf.indexOf('\n')) !== -1) {
+          const line = buf.slice(0, nl)
+          buf = buf.slice(nl + 1)
+          const m = line.match(_READY_RE)
 
-        if (m) {
-          cleanup()
-          resolve(parseInt(m[1], 10))
+          if (m) {
+            cleanup()
+            resolve(parseInt(m[1], 10))
 
-          return
+            return
+          }
         }
+
+        bufRef.v = buf
       }
     }
+
+    const stdoutRef = { v: '' }
+    const stderrRef = { v: '' }
+    const onStdout = onStreamData(stdoutRef)
+    const onStderr = onStreamData(stderrRef)
 
     function onExit(code, signal) {
       cleanup()
@@ -101,7 +115,8 @@ function waitForDashboardPort(child, timeoutMs = resolvePortAnnounceTimeoutMs(),
       reject(new Error(`Timed out waiting for Hermes backend port announcement (${timeoutMs}ms)`))
     }, timeoutMs)
 
-    child.stdout.on('data', onData)
+    child.stdout.on('data', onStdout)
+    child.stderr.on('data', onStderr)
     child.on('exit', onExit)
     child.on('error', onError)
   })


### PR DESCRIPTION
Fixes #96344 (dup #96294) — 90s boot timeout even though backend announced HERMES_BACKEND_READY.

**Root cause:** `waitForDashboardPort` in `apps/desktop/electron/backend-ready.ts` used one shared `buf` for both stdout+stderr. `hermes serve` prints the sentinel to stderr (tui_gateway stdout->stderr redirect), and a partial stderr line splices onto the READY line so the ^-anchored _READY_RE never matches -> 90s timeout against a healthy backend.

**Fix:** Per-stream buffers (onStdout/onStderr, #96325/#96347). Each stream gets its own buffer, both watched, cleanup detaches both. Verified: built asar shows `const onStderr = onStreamData(stderrRef)` and boots without timeout.

Closes #96344
Related #96294 #96325 #96347 #96390

Test: `hermes desktop` boots, desktop.log shows HERMES_BACKEND_READY -> finalizing without 90s wait. Built asar 8.5M compressed verified.