### PR TITLE
fix(bot-mode): Bot Chat CLI resume follows profile model config

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8771,7 +8771,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
         Skips when the session has no model recorded or when the CLI was
         launched with an explicit ``-m`` override (user intent wins).
+        Bot-Mode Bot Chat sessions (and rows marked ``follow_profile_config``)
+        always use the profile's current config — same contract as the TUI
+        gateway's ``_stored_session_runtime_overrides`` (#89497, #97035).
         """
+        from hermes_state import SessionDB as _SessionDB
+
+        if _SessionDB.session_follows_profile_config(session_meta):
+            return
         stored_model = (session_meta or {}).get("model")
         if not stored_model:
             return
@@ -8781,7 +8788,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # Stored provider/endpoint via the canonical row-level reader
         # (prefers model_config.gateway_runtime, falls back to the TUI
         # gateway's top-level keys).
-        from hermes_state import SessionDB as _SessionDB
         _stored_runtime = _SessionDB.session_gateway_runtime(session_meta)
         stored_provider = _stored_runtime.get("provider") or None
         stored_base_url = _stored_runtime.get("base_url") or None
@@ -9960,15 +9966,20 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
             if self._session_db:
                 try:
+                    from hermes_state import SessionDB
+
                     self.agent._session_db_created = False
+                    _new_model_config = {
+                        "max_iterations": self.max_turns,
+                        "reasoning_config": self.reasoning_config,
+                    }
+                    if title == SessionDB.CANONICAL_BOT_CHAT_TITLE:
+                        _new_model_config["follow_profile_config"] = True
                     self._session_db.create_session(
                         session_id=self.session_id,
                         source=os.environ.get("HERMES_SESSION_SOURCE", "cli"),
                         model=self.model,
-                        model_config={
-                            "max_iterations": self.max_turns,
-                            "reasoning_config": self.reasoning_config,
-                        },
+                        model_config=_new_model_config,
                     )
                     self.agent._session_db_created = True
                 except Exception:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1822,7 +1822,10 @@ def _create_titled_session(title: str) -> Optional[str]:
         new_session_id = f"{timestamp_str}_{short_uuid}"
 
         db = SessionDB()
-        db.create_session(new_session_id, source="cli")
+        model_config = None
+        if title == SessionDB.CANONICAL_BOT_CHAT_TITLE:
+            model_config = {"follow_profile_config": True}
+        db.create_session(new_session_id, source="cli", model_config=model_config)
         db.set_session_title(new_session_id, title)
         return new_session_id
     except Exception:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -8504,6 +8504,33 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         return bool(raw.get("yolo_mode"))
 
     @staticmethod
+    def session_follows_profile_config(
+        session_meta: Optional[Dict[str, Any]],
+    ) -> bool:
+        """True when resume must use the profile's CURRENT config, not stored pins.
+
+        Bot-Mode canonical Bot Chat sessions (plugin-owned forever DMs) and
+        rows explicitly marked ``follow_profile_config`` must always rebuild
+        from the active profile config — restoring stored model/provider is
+        what left bot DMs on stale providers after ``/model`` or config.yaml
+        changes (#89497, #97035). Normal 1:1 user chats return False.
+        """
+        if not session_meta:
+            return False
+        raw = session_meta.get("model_config")
+        if isinstance(raw, str):
+            try:
+                raw = json.loads(raw)
+            except Exception:
+                raw = {}
+        if not isinstance(raw, dict):
+            raw = {}
+        if raw.get("follow_profile_config"):
+            return True
+        title = str(session_meta.get("title") or "").strip()
+        return title == SessionDB.CANONICAL_BOT_CHAT_TITLE
+
+    @staticmethod
     def session_gateway_runtime(session_meta: Optional[Dict[str, Any]]) -> Dict[str, Any]:
         """Read the persisted runtime route off a session row dict.
 

--- a/tests/cli/test_resume_model_restore.py
+++ b/tests/cli/test_resume_model_restore.py
@@ -118,6 +118,45 @@ def test_restore_session_model_swaps_running_agent_in_place():
     assert calls["new_model"] == "glm-4.7"
 
 
+def test_restore_session_model_skips_bot_chat_title():
+    """Bot Chat DMs must use the profile's current config (#97035)."""
+    stub = _make_stub()
+    stub._restore_session_model({
+        "title": SessionDB.CANONICAL_BOT_CHAT_TITLE,
+        "model": "stale-model",
+        "model_config": json.dumps(
+            {"provider": "nous", "gateway_runtime": {"provider": "nous"}}
+        ),
+    })
+    assert stub.model == "ambient-model"
+    assert stub.provider == "openrouter"
+
+
+def test_restore_session_model_skips_follow_profile_config_marker():
+    stub = _make_stub()
+    stub._restore_session_model(_row(model_config={
+        "follow_profile_config": True,
+        "gateway_runtime": {"provider": "nous"},
+    }))
+    assert stub.model == "ambient-model"
+    assert stub.provider == "openrouter"
+
+
+def test_session_follows_profile_config_legacy_title_only():
+    row = {
+        "title": SessionDB.CANONICAL_BOT_CHAT_TITLE,
+        "model": "openai/gpt-5.6-luna-pro",
+        "model_config": json.dumps({"provider": "nous"}),
+    }
+    assert SessionDB.session_follows_profile_config(row) is True
+
+
+def test_session_follows_profile_config_normal_chat_is_false():
+    row = _row(model_config={"provider": "nous"})
+    row["title"] = "Project planning"
+    assert SessionDB.session_follows_profile_config(row) is False
+
+
 # ── _persist_model_switch_to_session ────────────────────────────────
 
 

--- a/tests/hermes_cli/test_chat_c_fail_loudly.py
+++ b/tests/hermes_cli/test_chat_c_fail_loudly.py
@@ -15,6 +15,8 @@ Two behaviors are fixed here:
    deterministic "send to this named thread, making it if needed" primitive.
 """
 
+import json
+
 import pytest
 
 
@@ -155,5 +157,10 @@ class TestChatCFailLoudlyOnStderr:
         db = SessionDB()
         try:
             assert db.get_session_title(args.resume) == "Bot Chat"
+            sess = db.get_session(args.resume)
+            raw_cfg = sess.get("model_config")
+            if isinstance(raw_cfg, str):
+                raw_cfg = json.loads(raw_cfg)
+            assert raw_cfg.get("follow_profile_config") is True
         finally:
             db.close()


### PR DESCRIPTION
Adds SessionDB.session_follows_profile_config() — shared contract for rows that must always rebuild from the active profile config
Skips _restore_session_model for those rows on CLI resume
Stamps follow_profile_config: true when creating new Bot Chat sessions via --create-if-missing or /new