### PR TITLE
fix(desktop-update): resolve the posix hand-off interpreter instead of hardcoding /usr/bin/python3

### DIFF
--- a/scripts/desktop-update/posix.sh
+++ b/scripts/desktop-update/posix.sh
@@ -506,7 +506,21 @@ if [ "$HANDOFF_DAEMONIZED" -ne 1 ]; then
   # as a flag. Appending here previously left HANDOFF_DAEMONIZED unset on
   # every re-exec, causing this block to re-fire forever (self-exec loop,
   # unbounded argv growth) whenever relaunch args were present.
-  /usr/bin/nohup /usr/bin/python3 -c '
+  # Resolve the interpreter rather than hardcoding /usr/bin/python3: on macOS
+  # without Xcode Command Line Tools installed that path is a stub shim which
+  # pops a blocking "The python3 command requires the command line developer
+  # tools" GUI dialog instead of executing, so the hand-off never happens and
+  # the Desktop update button dead-ends. PATH cannot redirect an absolute path,
+  # so the install's own venv interpreter is preferred (same resolution order
+  # as start_ui above), with /usr/bin/python3 kept as the final fallback.
+  HANDOFF_PY=""
+  for _cand in "${INSTALL_ROOT:+$INSTALL_ROOT/venv/bin/python3}" \
+               "/opt/homebrew/bin/python3" "/usr/local/bin/python3" \
+               "$(command -v python3 2>/dev/null)" "/usr/bin/python3"; do
+    if [ -n "$_cand" ] && [ -x "$_cand" ]; then HANDOFF_PY="$_cand"; break; fi
+  done
+  log "hand-off interpreter: ${HANDOFF_PY:-<none found>}"
+  /usr/bin/nohup "$HANDOFF_PY" -c '
 import os, sys
 env = os.environ.copy()
 os.setsid()

--- a/tests/test_desktop_update_shim_progress.py
+++ b/tests/test_desktop_update_shim_progress.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import subprocess
 import sys
 import time
@@ -22,10 +23,14 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 SHIM_DIR = REPO_ROOT / "scripts" / "desktop-update"
 
 # posix.sh re-execs itself through these to detach from Electron's process
-# group; without them the hand-off never reaches its own main flow.
+# group; without them the hand-off never reaches its own main flow. The
+# interpreter is resolved, not hardcoded, so any python3 on PATH satisfies it.
 requires_posix_handoff = pytest.mark.skipif(
-    not (os.path.exists("/bin/bash") and os.path.exists("/usr/bin/python3")),
-    reason="posix.sh detaches through /bin/bash and /usr/bin/python3",
+    not (
+        os.path.exists("/bin/bash")
+        and (shutil.which("python3") or os.path.exists("/usr/bin/python3"))
+    ),
+    reason="posix.sh detaches through /bin/bash and a python3 interpreter",
 )
 
 


### PR DESCRIPTION
## What

`scripts/desktop-update/posix.sh` re-execs itself through a hardcoded `/usr/bin/python3` to obtain `os.setsid()` before handing off to the daemonized orchestrator. This changes that one call to resolve a real interpreter first, keeping `/usr/bin/python3` as the final fallback.

## Why

On macOS **without Xcode Command Line Tools installed**, `/usr/bin/python3` is not an interpreter — it's a ~119 KB stub shim. Invoking it pops a blocking GUI dialog:

> The "python3" command requires the command line developer tools. Would you like to install the tools now?

…instead of executing. So the hand-off at line 509 never happens and the Desktop update button dead-ends. Because the path is **absolute**, no user-side `PATH` fix can redirect it — not `.zshrc`, not `sudo launchctl config user path`.

This is not hypothetical on current betas: on macOS 27.0 (build `26A5421a`) the CLT package is absent from Apple's Software Update catalog, so the dialog's own Install button fails with *"Can't install the software because it is not currently available from the Software Update server"*. An affected user has no route back to a working Desktop updater.

`start_ui()` a few hundred lines above already does this correctly (lines 237-238, preferring `$INSTALL_ROOT/venv/bin/python3`), which is why the UI window works on the same machine where the hand-off does not — so this looks like an oversight rather than a deliberate choice.

## How to test

The two existing `@requires_posix_handoff` tests already cover this path and reproduce the bug on an affected machine:

```
# baseline, upstream main, on a Mac with no CLT:
tests/test_desktop_update_shim_progress.py
  FAILED test_update_gate_publishes_its_stage_before_running
  FAILED test_retry_gate_publishes_a_distinct_stage
  2 failed, 3 passed in 91.64s        <- hangs waiting on a hand-off that never fires

# same machine, with this patch:
  5 passed in 3.96s
```

Manual: `bash -n scripts/desktop-update/posix.sh` is clean, and under the restricted PATH that GUI/launchd children actually inherit (`env -i PATH=/usr/bin:/bin:/usr/sbin:/sbin`) the resolver selects `$INSTALL_ROOT/venv/bin/python3`; with `INSTALL_ROOT` unset it selects `/opt/homebrew/bin/python3`. A direct smoke test of the `setsid`+`execve` snippet with the resolved interpreter re-parents to `PPID 1` as the surrounding comment intends.

The test skip guard is widened to accept any `python3` (`shutil.which`), since the hand-off no longer depends on `/usr/bin/python3` specifically. Previously the guard would have *skipped* these tests on a CLT-less machine had the file merely been missing — but the stub exists, so they ran and hung instead.

## Platforms tested

- macOS 27.0 (`26A5421a`), Apple Silicon (M4 Max), no Xcode CLT installed — reproduces the bug and verifies the fix
- Behaviour where CLT *is* present is unchanged by construction: `/usr/bin/python3` remains the last fallback, and it is reached whenever nothing earlier in the list is executable
- Not tested on Linux/WSL2; the resolution list is additive and falls through to the previous behaviour, and `/opt/homebrew` simply won't exist there

## Related

No existing issue found for this (searched issues/PRs for the CLT dialog and `/usr/bin/python3`).
