### PR TITLE
fix(gateway): don't delete a live lock file on PermissionError in a read-only query

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -1013,15 +1013,19 @@ def is_gateway_runtime_lock_active(lock_path: Optional[Path] = None) -> bool:
     try:
         handle = open(resolved_lock_path, "a+", encoding="utf-8")
     except PermissionError:
-        # Stale root-owned lock file from a previous launchd Background
-        # session that ran as root.  The parent directory owner can unlink
-        # files even when they don't own them, so remove the stale lock
-        # and report inactive — the new process will create a fresh one.
-        try:
-            resolved_lock_path.unlink()
-        except OSError:
-            pass
-        return False
+        # This is a read-only query -- both actual callers (cron.py's
+        # gateway liveness check, gateway_windows.py's status display) only
+        # inspect, never acquire. A PermissionError here means some OTHER
+        # process (possibly root, e.g. a systemd --system-managed gateway)
+        # holds a lock file we cannot even open -- not proof it's stale.
+        # Unlinking it would delete a live gateway's lock and misreport it
+        # as not running (issue #96639). The one legitimate stale-lock case
+        # this used to unlink (a leftover root-owned file from a prior
+        # macOS launchd Background session) is still handled correctly and
+        # independently by acquire_gateway_runtime_lock()'s own
+        # unlink-and-retry, which runs when the gateway itself is the one
+        # actually trying to start and take ownership.
+        return True
     try:
         if _try_acquire_file_lock(handle):
             _release_file_lock(handle)

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -1150,15 +1150,29 @@ class TestLaunchdPlistRespawnGovernance:
 
 
 class TestPermissionErrorOnLockFile:
-    """Stale root-owned lock files from launchd Background sessions must not
-    crash the gateway on restart (issue #42685)."""
+    """is_gateway_runtime_lock_active() is a read-only status query -- both
+    of its actual callers (cron.py's gateway liveness check,
+    gateway_windows.py's diagnostic status display) only inspect, never
+    intend to acquire the lock. A PermissionError here must report the
+    lock as held and must never delete the file: it means some OTHER
+    process (root, e.g. a systemd --system-managed gateway) holds a lock
+    we cannot even open, not proof it's stale (issue #96639 -- a non-root
+    caller querying a live systemd-managed gateway's root-owned lock
+    previously deleted that lock and reported the gateway as not running).
+    The original stale-root-owned-lock-from-launchd scenario (#42685) is
+    still handled correctly and independently by
+    acquire_gateway_runtime_lock()'s own unlink-and-retry, covered by the
+    third test below -- that function IS the one legitimately trying to
+    acquire/take over the lock."""
 
-    def test_permission_error_on_lock_file_returns_false_and_removes(self, tmp_path, monkeypatch):
-        """When the lock file is not writable (root-owned), the function should
-        remove the stale file and report the lock as inactive."""
+    def test_permission_error_on_lock_file_reports_held_and_does_not_remove(self, tmp_path, monkeypatch):
+        """Regression for issue #96639: a PermissionError must report the
+        lock as active and must NOT delete the file -- it may belong to a
+        demonstrably live, root-owned process (e.g. a systemd --system
+        service) that this read-only query has no business touching."""
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         lock_path = tmp_path / "gateway.lock"
-        lock_path.write_text("stale", encoding="utf-8")
+        lock_path.write_text("held by another process", encoding="utf-8")
 
         real_open = open
 
@@ -1170,15 +1184,16 @@ class TestPermissionErrorOnLockFile:
         monkeypatch.setattr("builtins.open", deny_write)
 
         result = status.is_gateway_runtime_lock_active(lock_path)
-        assert result is False
-        assert not lock_path.exists(), "stale root-owned lock file should be removed"
+        assert result is True
+        assert lock_path.exists(), "an inaccessible lock file must never be deleted by a read-only query"
+        assert lock_path.read_text(encoding="utf-8") == "held by another process"
 
-    def test_permission_error_unlink_failure_still_returns_false(self, tmp_path, monkeypatch):
-        """Even if unlinking the stale lock file fails (e.g. directory not writable),
-        the function should still return False to allow startup."""
+    def test_permission_error_does_not_attempt_to_unlink_at_all(self, tmp_path, monkeypatch):
+        """Sanity: unlink() must not even be attempted -- the corrected
+        behavior removed that call entirely, not just made it non-fatal."""
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         lock_path = tmp_path / "gateway.lock"
-        lock_path.write_text("stale", encoding="utf-8")
+        lock_path.write_text("held by another process", encoding="utf-8")
 
         real_open = open
 
@@ -1187,22 +1202,26 @@ class TestPermissionErrorOnLockFile:
                 raise PermissionError(13, "Permission denied", str(path))
             return real_open(path, *args, **kwargs)
 
+        unlink_calls = []
         real_unlink = Path.unlink
 
-        def deny_unlink(self, *args, **kwargs):
+        def tracking_unlink(self, *args, **kwargs):
             if str(self) == str(lock_path):
-                raise OSError(13, "Permission denied", str(self))
+                unlink_calls.append(str(self))
             return real_unlink(self, *args, **kwargs)
 
         monkeypatch.setattr("builtins.open", deny_write)
-        monkeypatch.setattr(Path, "unlink", deny_unlink)
+        monkeypatch.setattr(Path, "unlink", tracking_unlink)
 
-        result = status.is_gateway_runtime_lock_active(lock_path)
-        assert result is False
+        status.is_gateway_runtime_lock_active(lock_path)
+        assert unlink_calls == []
 
     def test_acquire_gateway_runtime_lock_recovers_from_permission_error(self, tmp_path, monkeypatch):
         """acquire_gateway_runtime_lock must survive a stale root-owned lock
-        file: unlink it and retry with a fresh file instead of crashing."""
+        file: unlink it and retry with a fresh file instead of crashing.
+        Unaffected by the is_gateway_runtime_lock_active fix above -- this
+        exercises a separate function that legitimately IS trying to
+        acquire the lock, where the #42685 stale-lock cleanup still applies."""
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         lock_path = status._get_gateway_lock_path()
         lock_path.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Fixes #96639.

## Root cause

`is_gateway_runtime_lock_active()` unlinked the gateway lock file and reported `False` whenever `open()` raised `PermissionError`, on the assumption (from #42685) that this always meant a stale root-owned lock from a prior macOS launchd Background session.

That assumption doesn't hold for this function's actual callers. Traced both call sites -- `hermes_cli/cron.py`'s `_builtin_gateway_liveness()` (used by the `cronjob` tool's `gateway_running` notice) and `hermes_cli/gateway_windows.py`'s diagnostic status display -- both are pure read-only queries that never intend to acquire the lock. The gateway's own boot sequence goes through the separate `acquire_gateway_runtime_lock()`, which independently gained the identical stale-lock-cleanup logic in a follow-up commit for the case where the caller genuinely IS trying to take over the lock.

So when a genuinely live, root-owned gateway (e.g. a systemd `--system` unit, matching the reported repro exactly) is queried by a non-root caller, `PermissionError` doesn't mean stale -- it means "someone else holds a lock we can't even open." The query was deleting that live gateway's lock file and reporting it as not running. Beyond the reported false-negative, this was an undocumented destructive side effect on a status check that could also let a second gateway instance start and conflict with the running one.

## Fix

Removed the `unlink()` and changed the return value to `True`: we cannot open the file, so we cannot prove no one holds it. The original macOS launchd scenario is still handled correctly and independently by `acquire_gateway_runtime_lock()`'s own unlink-and-retry, unaffected by this change.

## Verification

Verified directly: monkeypatched `open()` to raise `PermissionError`, confirmed the fixed function returns `True` and the file survives untouched. Reverted just the fix and confirmed the exact reported symptom -- `False` returned AND the lock file deleted.

Updated the two existing tests that had encoded the buggy behavior as expected, added a third confirming `unlink()` is never attempted. Left the `acquire_gateway_runtime_lock()` recovery test unchanged.

72/72 pass across the full test file; 14/14 in the related cron liveness test file (no regression).