### PR TITLE
fix(discord): preserve native thread rename contract

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -23644,13 +23644,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             thread_name,
         )
         try:
-            renamed = await rename_thread(
-                target_thread_id,
-                thread_name,
-                prefer_connector_created=use_connector_guard,
-                only_if_current_name=guard_name,
-                parent_chat_id=parent_chat_id,
-            )
+            if use_connector_guard:
+                renamed = await rename_thread(
+                    target_thread_id,
+                    thread_name,
+                    prefer_connector_created=True,
+                    only_if_current_name=None,
+                    parent_chat_id=parent_chat_id,
+                )
+            else:
+                renamed = await rename_thread(
+                    target_thread_id,
+                    thread_name,
+                    only_if_current_name=guard_name,
+                )
             logger.info(
                 "discord auto-thread rename result: thread=%s applied=%s",
                 target_thread_id,

--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -449,6 +449,52 @@ async def test_rename_thread_edits_only_when_current_name_matches(adapter):
     )
 
 
+@pytest.mark.asyncio
+async def test_native_auto_thread_title_rename_uses_native_adapter_contract(adapter):
+    """Relay-only kwargs must not leak into the native Discord adapter call."""
+    from gateway.config import Platform
+    from gateway.run import GatewayRunner
+    from gateway.session import SessionSource
+
+    thread = SimpleNamespace(id=999, name="Hermes", edit=AsyncMock())
+    adapter._client.get_channel = lambda _id: thread
+
+    class _Runner:
+        _is_discord_auto_thread_lane = GatewayRunner._is_discord_auto_thread_lane
+        _is_relay_discord_channel_lane = GatewayRunner._is_relay_discord_channel_lane
+        _sanitize_discord_thread_title = GatewayRunner._sanitize_discord_thread_title
+        _rename_discord_auto_thread_for_session_title = (
+            GatewayRunner._rename_discord_auto_thread_for_session_title
+        )
+
+        def __init__(self):
+            self.adapters = {Platform.DISCORD: adapter}
+
+        def _adapter_for_source(self, _source):
+            return adapter
+
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="999",
+        chat_type="thread",
+        thread_id="999",
+        delivered_via_upstream_relay=False,
+        auto_thread_created=True,
+        auto_thread_initial_name="Hermes",
+    )
+
+    await _Runner()._rename_discord_auto_thread_for_session_title(
+        source,
+        "session-1",
+        "Semantic Session Title",
+    )
+
+    thread.edit.assert_awaited_once_with(
+        name="Semantic Session Title",
+        reason="Hermes semantic session title",
+    )
+
+
 # ------------------------------------------------------------------
 # Auto-thread integration in _handle_message
 # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- keep relay-only thread rename arguments on the relay adapter path
- call the native Discord adapter with only its supported no-clobber guard
- add a regression test that exercises the gateway rename lane with the real native adapter contract

## Problem
Native Discord auto-threads received a generated session title in the session database but stayed at their placeholder name in Discord. The shared rename lane passed `prefer_connector_created` and `parent_chat_id` to the native adapter, whose `rename_thread` method does not accept those relay-only keywords. The resulting `TypeError` was swallowed by the best-effort rename path.

## Tests
- `python -m pytest tests/gateway/test_discord_slash_commands.py tests/gateway/relay/test_relay_threads.py -q`
- 32 passed