### PR TITLE
fix(gateway): dispatch plugin setup/connect by signature

### DIFF
--- a/gateway/plugin_dispatch.py
+++ b/gateway/plugin_dispatch.py
@@ -1,0 +1,58 @@
+"""Signature-tolerant dispatch for third-party platform plugins.
+
+Bundled adapters register zero-arg ``setup_fn`` and accept
+``connect(*, is_reconnect=False)``. External plugins (Keet, older forks)
+still declare ``setup_fn(config)`` or ``connect(self)`` without the keyword.
+Calling them with the current Hermes contract raises TypeError and aborts
+``hermes gateway setup`` / gateway start (#97065).
+
+Inspect the callable and pass only the parameters it actually accepts.
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any, Callable
+
+
+def invoke_setup_fn(setup_fn: Callable[..., Any], config: Any = None) -> Any:
+    """Call a platform ``setup_fn``, supplying ``config`` only if required."""
+    if setup_fn is None:
+        return None
+    try:
+        signature = inspect.signature(setup_fn)
+    except (TypeError, ValueError):
+        return setup_fn()
+
+    required = [
+        parameter
+        for parameter in signature.parameters.values()
+        if parameter.kind
+        in (
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            inspect.Parameter.KEYWORD_ONLY,
+        )
+        and parameter.default is inspect.Parameter.empty
+        and parameter.name != "self"
+    ]
+    if not required:
+        return setup_fn()
+
+    target = required[0]
+    if target.kind == inspect.Parameter.KEYWORD_ONLY:
+        return setup_fn(**{target.name: config})
+    return setup_fn(config)
+
+
+def connect_adapter(adapter: Any, *, is_reconnect: bool = False) -> Any:
+    """Call ``adapter.connect``, omitting ``is_reconnect`` when unsupported."""
+    connect = adapter.connect
+    try:
+        signature = inspect.signature(connect)
+        accepts_reconnect = "is_reconnect" in signature.parameters
+    except (TypeError, ValueError):
+        accepts_reconnect = False
+    if accepts_reconnect:
+        return connect(is_reconnect=is_reconnect)
+    return connect()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7866,17 +7866,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         ``running`` (#85993 — Telegram's 180s).
         """
         timeout = self._platform_connect_timeout_secs(platform, initial=initial)
+        from gateway.plugin_dispatch import connect_adapter
+
         if timeout <= 0:
-            return await adapter.connect(is_reconnect=is_reconnect)
+            result = connect_adapter(adapter, is_reconnect=is_reconnect)
+            if inspect.isawaitable(result):
+                return await result
+            return bool(result)
         # Use the detach-on-timeout pattern instead of plain asyncio.wait_for:
         # asyncio.wait_for cancels the overdue task but then waits for it to
         # exit. An adapter connect() that catches CancelledError can therefore
         # block recovery forever (the watcher never reaches the next retry).
         # Keep ownership of the old task through its done callback, but
         # release the runner at the deadline (#70344).
-        task = asyncio.ensure_future(
-            adapter.connect(is_reconnect=is_reconnect)
-        )
+        connected = connect_adapter(adapter, is_reconnect=is_reconnect)
+        if not inspect.isawaitable(connected):
+            return bool(connected)
+        task = asyncio.ensure_future(connected)
         try:
             done, _pending = await asyncio.wait({task}, timeout=timeout)
         except asyncio.CancelledError:

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -7680,7 +7680,9 @@ def _configure_platform(platform: dict) -> None:
     entry = platform.get("_registry_entry")
 
     if entry is not None and entry.setup_fn is not None:
-        entry.setup_fn()
+        from gateway.plugin_dispatch import invoke_setup_fn
+
+        invoke_setup_fn(entry.setup_fn, config=platform)
         return
 
     fn = _builtin_setup_fn(platform["key"])

--- a/tests/gateway/test_plugin_dispatch.py
+++ b/tests/gateway/test_plugin_dispatch.py
@@ -1,0 +1,77 @@
+"""Signature-tolerant plugin setup/connect dispatch (#97065)."""
+
+import inspect
+
+from gateway.plugin_dispatch import connect_adapter, invoke_setup_fn
+
+
+def test_zero_arg_setup_fn_is_called_without_config():
+    calls = []
+
+    def setup():
+        calls.append("zero")
+
+    invoke_setup_fn(setup, config={"key": "keet"})
+    assert calls == ["zero"]
+
+
+def test_config_arg_setup_fn_receives_platform_dict():
+    seen = []
+
+    def setup(config):
+        seen.append(config)
+
+    platform = {"key": "keet", "label": "Keet"}
+    invoke_setup_fn(setup, config=platform)
+    assert seen == [platform]
+
+
+def test_keyword_only_config_setup_fn():
+    seen = []
+
+    def setup(*, config):
+        seen.append(config)
+
+    invoke_setup_fn(setup, config="cfg")
+    assert seen == ["cfg"]
+
+
+class _ReconnectAdapter:
+    def __init__(self):
+        self.calls = []
+
+    async def connect(self, *, is_reconnect: bool = False):
+        self.calls.append(is_reconnect)
+        return True
+
+
+class _LegacyAdapter:
+    def __init__(self):
+        self.calls = []
+
+    async def connect(self):
+        self.calls.append("bare")
+        return True
+
+
+def test_connect_forwards_is_reconnect_when_accepted():
+    adapter = _ReconnectAdapter()
+    result = connect_adapter(adapter, is_reconnect=True)
+    assert inspect.iscoroutine(result)
+
+    async def _run():
+        return await result
+
+    import asyncio
+
+    assert asyncio.run(_run()) is True
+    assert adapter.calls == [True]
+
+
+def test_connect_omits_is_reconnect_for_legacy_signature():
+    adapter = _LegacyAdapter()
+    result = connect_adapter(adapter, is_reconnect=True)
+    import asyncio
+
+    assert asyncio.run(result) is True
+    assert adapter.calls == ["bare"]

--- a/tests/hermes_cli/test_setup_irc.py
+++ b/tests/hermes_cli/test_setup_irc.py
@@ -121,6 +121,25 @@ class TestIRCInteractiveSetup:
         out = capsys.readouterr().out
         assert "IRC setup complete!" in out
 
+    def test_configure_platform_passes_config_when_setup_fn_requires_it(self, monkeypatch, capsys):
+        """Third-party plugins (Keet) still declare setup_fn(config)."""
+        import hermes_cli.gateway as gateway_mod
+
+        seen = []
+
+        def fake_setup(config):
+            seen.append(config)
+            print("legacy setup complete")
+
+        plat = _register_irc_platform(setup_fn=fake_setup)
+        try:
+            gateway_mod._configure_platform(plat)
+        finally:
+            _unregister_irc_platform()
+
+        assert seen == [plat]
+        assert "legacy setup complete" in capsys.readouterr().out
+
 
     def test_configure_platform_fallback_when_no_setup_fn(self, monkeypatch, capsys):
         """A plugin with no setup_fn falls back to env-var instructions."""


### PR DESCRIPTION
## What does this PR do?

`hermes gateway setup` → Keet crashes with `TypeError: _setup_fn() missing 1 required positional argument: 'config'`. Hermes calls plugin `setup_fn()` with zero arguments and `adapter.connect(is_reconnect=...)`. Bundled adapters match that contract; third-party ones (Keet) still declare `setup_fn(config)` and a bare `connect(self)`.

Dispatch now inspects the callable and only passes parameters it accepts. Keet's setup function does not even use `config`; it just needs the argument present. The same helper omits `is_reconnect` when `connect()` does not take it, which is the second error in the issue.

## Related Issue

Fixes #97065

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `gateway/plugin_dispatch.py`: `invoke_setup_fn`, `connect_adapter`
- `hermes_cli/gateway.py`: `_configure_platform` uses signature-tolerant setup
- `gateway/run.py`: `_connect_adapter_with_timeout` uses signature-tolerant connect
- tests for zero-arg, config-arg, keyword-only setup, and both connect shapes

## How to Test

```text
cd /tmp/hermes-97065
uv run pytest tests/gateway/test_plugin_dispatch.py tests/hermes_cli/test_setup_irc.py -q
# 12 passed
```

Not runtime-tested against a live Keet plugin install.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the targeted pytest files above
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A
