### PR TITLE
fix(bot-mode): pin DM delivery to the target profile model

### DIFF
--- a/tests/tools/test_bot_mode_dm.py
+++ b/tests/tools/test_bot_mode_dm.py
@@ -268,6 +268,42 @@ def test_local_delivery_command_and_ack(tmp_path, monkeypatch):
     assert '$(and this is not shell)' in content
 
 
+def test_local_delivery_pins_target_profile_model(tmp_path, monkeypatch):
+    """Bot Chat resume must not keep the process-default model (#97035)."""
+    from tools.bot_relay import profile_model_cli_args
+
+    calls = _capture_spawn(monkeypatch)
+    home = _managed_home(tmp_path, teammates=("researcher",))
+    (home / "profiles" / "researcher" / "config.yaml").write_text(
+        "model:\n  default: stepfun/step-3.7-flash:free\n  provider: nous\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    assert profile_model_cli_args("researcher") == [
+        "--provider",
+        "nous",
+        "-m",
+        "stepfun/step-3.7-flash:free",
+    ]
+
+    agent = _FakeAgent(home, title="Bot Chat")
+    result = json.loads(
+        bot_mode_dm.message_agent_tool(
+            target="@researcher",
+            message="ping",
+            agent=agent,
+        )
+    )
+    assert result["status"] == "sent"
+    _mode, _dm_file, transport_argv = _runner_parts(calls[0]["command"])
+    assert transport_argv[-4:] == [
+        "--provider",
+        "nous",
+        "-m",
+        "stepfun/step-3.7-flash:free",
+    ]
+
+
 def test_peer_delivery_command_pins_registry_profile_for_secondary_bots(
     tmp_path, monkeypatch
 ):

--- a/tools/bot_mode_dm.py
+++ b/tools/bot_mode_dm.py
@@ -359,6 +359,8 @@ def message_agent_tool(
             return relayed
         return _err("You can't message yourself. Pick a teammate from the roster.")
 
+    from tools.bot_relay import profile_model_cli_args
+
     return _start_delivery(
         [
             "hermes",
@@ -371,6 +373,7 @@ def message_agent_tool(
             "Bot Chat",
             "--create-if-missing",
             "-Q",
+            *profile_model_cli_args(resolved),
         ],
         prefix + body,
         f"@{_handle(resolved)}",

--- a/tools/bot_relay.py
+++ b/tools/bot_relay.py
@@ -558,6 +558,44 @@ def _hermes_cli() -> str:
     return "hermes"
 
 
+def profile_model_cli_args(profile: str) -> list[str]:
+    """``--provider`` / ``-m`` flags from the *target* profile's config.yaml.
+
+    ``hermes -p <profile> chat`` sets HERMES_HOME, but a resumed Bot Chat
+    session restores the model stored on the session row. Under
+    ``gateway.multiplex_profiles`` that row can still carry the process-default
+    model from when the chat was first created, so the turn ignores the
+    target profile's ``model.default`` (#97035). Passing explicit CLI flags
+    sets ``_explicit_model_override`` and skips that restore.
+    """
+    from hermes_cli.config import read_user_config_raw, split_model_config_default
+    from hermes_cli.profiles import resolve_profile_env
+
+    try:
+        home = Path(resolve_profile_env(profile))
+    except (FileNotFoundError, ValueError, OSError):
+        return []
+    cfg = read_user_config_raw(home / "config.yaml")
+    if not isinstance(cfg, dict):
+        return []
+    model_cfg = cfg.get("model")
+    model = ""
+    provider = ""
+    if isinstance(model_cfg, str):
+        model = model_cfg.strip()
+    elif isinstance(model_cfg, dict):
+        raw_default = model_cfg.get("default") or model_cfg.get("model") or ""
+        model, nested_provider = split_model_config_default(raw_default)
+        provider = (nested_provider or str(model_cfg.get("provider") or "")).strip()
+        model = (model or "").strip()
+    args: list[str] = []
+    if provider and provider.lower() not in {"auto", ""}:
+        args.extend(["--provider", provider])
+    if model:
+        args.extend(["-m", model])
+    return args
+
+
 def local_delivery_command(profile: str, query_file: str) -> list[str]:
     """argv that delivers a DM into ``profile``'s Bot Chat on THIS gateway."""
     return [
@@ -571,6 +609,7 @@ def local_delivery_command(profile: str, query_file: str) -> list[str]:
         "Bot Chat",
         "--create-if-missing",
         "-Q",
+        *profile_model_cli_args(profile),
         "--query-file",
         query_file,
     ]


### PR DESCRIPTION
## What does this PR do?

Under `gateway.multiplex_profiles`, `message_agent` delivers into `@weekly-report` via `hermes -p weekly-report chat -c "Bot Chat"`. The child sets HERMES_HOME correctly (logs land in that profile) but resume restores the **session row's stored model**, which was the process-default (`openrouter` / `stealth/ox-alpha`) from when the Bot Chat was first created. Slash `/model` already reads the routed profile's `config.yaml` (faaf2ae); the DM transport did not.

Local delivery argv now includes `--provider` / `-m` taken from the **target** profile's `config.yaml`. That sets the CLI's `_explicit_model_override` so resume will not clobber it with the stale session model.

## Related Issue

Fixes #97035

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `tools/bot_relay.py`: `profile_model_cli_args()`; `local_delivery_command` appends them
- `tools/bot_mode_dm.py`: same flags on the local teammate spawn
- `tests/tools/test_bot_mode_dm.py`: researcher profile with nous + stepfun is pinned on the argv

## How to Test

```text
cd /tmp/hermes-97035
uv run pytest tests/tools/test_bot_mode_dm.py -q
# 40 passed, 1 skipped
```

Not runtime-tested on a live multiplexed Desktop with two model configs.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the targeted pytest file above
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A
