### PR TITLE
fix(desktop): keep the opening user message on Show earlier

### DIFF
--- a/apps/desktop/src/app/chat/transcript-backfill.test.ts
+++ b/apps/desktop/src/app/chat/transcript-backfill.test.ts
@@ -8,14 +8,16 @@ import {
   backfillOlderTranscriptPage,
   graftRefreshedTailOntoBackfill,
   mergeOlderTranscriptPage,
-  transcriptBackfillAvailable
+  transcriptBackfillAvailable,
+  unhideOpeningUserRows
 } from './transcript-backfill'
 
 vi.mock('@/hermes', () => ({
-  getOlderSessionMessages: vi.fn()
+  getOlderSessionMessages: vi.fn(),
+  getSessionMessages: vi.fn()
 }))
 
-const { getOlderSessionMessages } = await import('@/hermes')
+const { getOlderSessionMessages, getSessionMessages } = await import('@/hermes')
 
 const chat = (id: string, rowId?: number): ChatMessage => ({
   id,
@@ -164,6 +166,11 @@ describe('backfillOlderTranscriptPage', () => {
     $transcriptTailBySessionId.set({})
     _resetTranscriptBackfillForTests()
     vi.mocked(getOlderSessionMessages).mockReset()
+    vi.mocked(getSessionMessages).mockReset()
+    vi.mocked(getSessionMessages).mockResolvedValue({
+      messages: [],
+      session_id: 'stored-1'
+    } as never)
   })
 
   afterEach(() => {
@@ -195,7 +202,6 @@ describe('backfillOlderTranscriptPage', () => {
 
     expect(applied).toBe(true)
     expect(getOlderSessionMessages).toHaveBeenCalledWith('stored-1', undefined, 120)
-    expect(applyOlderPage).toHaveBeenCalledTimes(1)
     expect(applyOlderPage.mock.calls[0][0].map((m: ChatMessage) => m.rowId)).toEqual([1, 2])
     // A short older page means the transcript is now fully loaded.
     expect(transcriptBackfillAvailable('stored-1')).toBe(false)
@@ -352,5 +358,66 @@ describe('backfillOlderTranscriptPage', () => {
 
     expect(applied).toBe(false)
     expect(transcriptBackfillAvailable('stored-1')).toBe(true)
+  })
+
+  it('prepends the opening user from the oldest page once paging is exhausted', async () => {
+    truncatedTail()
+    vi.mocked(getOlderSessionMessages).mockResolvedValue({
+      messages: [row(10, 'first-assistant-visible')],
+      pagination: { limit: 120, offset: 120, order: 'latest', returned: 1 },
+      session_id: 'stored-1'
+    } as never)
+    vi.mocked(getSessionMessages).mockResolvedValue({
+      messages: [
+        {
+          id: 1,
+          role: 'user',
+          content: '你感觉我们的 Hermes Relay Manager 怎么样？',
+          display_kind: 'hidden',
+          timestamp: 1
+        },
+        row(10, 'first-assistant-visible')
+      ],
+      pagination: { limit: 20, offset: 0, order: 'oldest', returned: 2 },
+      session_id: 'stored-1'
+    } as never)
+
+    const applyOlderPage = vi.fn()
+
+    await backfillOlderTranscriptPage({
+      storedSessionId: 'stored-1',
+      isCurrent: () => true,
+      applyOlderPage
+    })
+
+    expect(getSessionMessages).toHaveBeenCalledWith('stored-1', undefined, {
+      includeCompacted: true,
+      limit: 20,
+      offset: 0,
+      order: 'oldest'
+    })
+    const originPage = applyOlderPage.mock.calls[1][0] as ChatMessage[]
+    expect(originPage[0].role).toBe('user')
+    expect(originPage[0].parts[0]).toMatchObject({
+      type: 'text',
+      text: '你感觉我们的 Hermes Relay Manager 怎么样？'
+    })
+  })
+})
+
+describe('unhideOpeningUserRows', () => {
+  it('clears hidden on the first user so toChatMessages keeps the greeting', () => {
+    const messages = unhideOpeningUserRows([
+      {
+        id: 1,
+        role: 'user',
+        content: 'hello there',
+        display_kind: 'hidden',
+        timestamp: 1
+      }
+    ])
+
+    expect(messages[0].display_kind).toBeUndefined()
+    expect(messages[0].display_content).toBe('hello there')
   })
 })

--- a/apps/desktop/src/app/chat/transcript-backfill.ts
+++ b/apps/desktop/src/app/chat/transcript-backfill.ts
@@ -15,9 +15,44 @@
  * drift on the next page.
  */
 
-import { getOlderSessionMessages } from '@/hermes'
+import { getOlderSessionMessages, getSessionMessages } from '@/hermes'
 import { type ChatMessage, toChatMessages } from '@/lib/chat-messages'
+import type { SessionMessage } from '@/types/hermes'
 import { recordTranscriptBackfillPage, type TranscriptProfileScope, transcriptTailState } from '@/store/transcript-tail'
+
+/** Compaction projection can stamp the session's opening user as hidden. */
+export function unhideOpeningUserRows(messages: SessionMessage[]): SessionMessage[] {
+  const openingIndex = messages.findIndex(message => message.role === 'user')
+
+  if (openingIndex < 0) {
+    return messages
+  }
+
+  const opening = messages[openingIndex]
+
+  if (opening.display_kind !== 'hidden') {
+    return messages
+  }
+
+  const content = opening.display_content ?? opening.content
+
+  if (content == null || content === '') {
+    return messages
+  }
+
+  return messages.map((message, index) => {
+    if (index !== openingIndex) {
+      return message
+    }
+
+    const { display_kind: _hidden, ...rest } = message
+
+    return {
+      ...rest,
+      display_content: typeof content === 'string' ? content : String(content)
+    }
+  })
+}
 
 /** Older rows likely exist beyond what the in-memory store holds. */
 export function transcriptBackfillAvailable(
@@ -159,7 +194,29 @@ export function backfillOlderTranscriptPage(request: BackfillRequest): Promise<b
     // below prepends whatever prefix the store is missing, and the recorded
     // state marks the session fully loaded so the REST action retires.
     recordTranscriptBackfillPage(storedSessionId, page, profile)
-    request.applyOlderPage(toChatMessages(page.messages))
+    request.applyOlderPage(toChatMessages(unhideOpeningUserRows(page.messages)))
+
+    // #96875: paging can reach the top while the opening USER turn is still
+    // missing — compaction projection hides it (`display_kind: hidden`) or
+    // the last `latest` page starts at the first assistant. Fetch the
+    // oldest display rows once the tail is exhausted and prepend any user
+    // turn that is not already in the store.
+    const exhausted = !transcriptTailState(storedSessionId, profile)?.possiblyTruncated
+    if (exhausted) {
+      try {
+        const origin = await getSessionMessages(storedSessionId, tail.profile, {
+          includeCompacted: true,
+          limit: 20,
+          offset: 0,
+          order: 'oldest'
+        })
+        if (request.isCurrent()) {
+          request.applyOlderPage(toChatMessages(unhideOpeningUserRows(origin.messages)))
+        }
+      } catch {
+        // Origin fetch is best-effort; the already-applied older page stays.
+      }
+    }
 
     return true
   })().finally(() => {

--- a/apps/desktop/src/app/chat/transcript-backfill.ts
+++ b/apps/desktop/src/app/chat/transcript-backfill.ts
@@ -17,8 +17,8 @@
 
 import { getOlderSessionMessages, getSessionMessages } from '@/hermes'
 import { type ChatMessage, toChatMessages } from '@/lib/chat-messages'
-import type { SessionMessage } from '@/types/hermes'
 import { recordTranscriptBackfillPage, type TranscriptProfileScope, transcriptTailState } from '@/store/transcript-tail'
+import type { SessionMessage } from '@/types/hermes'
 
 /** Compaction projection can stamp the session's opening user as hidden. */
 export function unhideOpeningUserRows(messages: SessionMessage[]): SessionMessage[] {


### PR DESCRIPTION
## What does this PR do?

After #96606, "Show earlier" can reach the top of a long Desktop transcript, but the **opening user message** is still missing — the first visible row is the first assistant reply. `session_search` still finds the greeting in the durable store. Compaction projection can stamp that opening user as `display_kind: hidden`, which `toChatMessages` then drops.

When REST backfill exhausts the `latest` pages, Desktop now fetches the oldest display page (`order=oldest`, `include_compacted=true`), unhides a hidden opening user turn, and prepends it if it is not already in the store.

## Related Issue

Fixes #96875

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/chat/transcript-backfill.ts`: `unhideOpeningUserRows`, origin fetch after paging is exhausted
- `apps/desktop/src/app/chat/transcript-backfill.test.ts`: origin-user prepend + unhide unit

## How to Test

```text
cd apps/desktop
npx vitest run src/app/chat/transcript-backfill.test.ts
# 22 passed
```

Not runtime-tested against the reporter's 142-message session.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the targeted vitest file above
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A
