### PR TITLE
fix(cron): forward the dashboard's relay-fronted "Run Now" trigger to the gateway

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -13355,6 +13355,15 @@ def _trigger_cron_job_sync(job_id: str, profile: Optional[str] = None):
     job = _call_cron_for_profile(selected, "resolve_job_ref", job_id)
     if not job:
         raise HTTPException(status_code=404, detail="Job not found")
+    # Relay-fronted delivery (Discord/Telegram/etc. behind the gateway's relay
+    # connector) and E2EE rooms have no standalone sender in THIS (dashboard)
+    # process — only the gateway's live adapter can deliver. Forward there
+    # before claiming the run in-process, mirroring the CLI's own
+    # `hermes cron run` forward (tools.cronjob_tools._forward_relay_fronted_run)
+    # and the Chronos fire webhook's gateway forward just above.
+    _, home = _cron_profile_home(selected)
+    if _relay_fronted_run_platforms_for_profile(selected, home, job):
+        return _forward_relay_fronted_trigger(selected, home, job["id"])
     # Do not expose the job as due before claiming it: the built-in ticker and
     # external/manual fire paths share the same durable claim, so only one can
     # execute this selected run even if they race across processes. Active jobs
@@ -13469,8 +13478,8 @@ def _profile_env_value(home: Path, key: str) -> str:
     return ""
 
 
-def _gateway_fire_endpoint(profile: str, home: Path) -> str:
-    """Resolve the loopback URL of the gateway api_server's cron-fire route.
+def _gateway_fire_endpoint(profile: str, home: Path, *, route: str = "/api/cron/fire") -> str:
+    """Resolve the loopback URL of a gateway api_server route for TARGET profile.
 
     Port resolution mirrors gateway/config.py's api_server load order for the
     TARGET profile: ``platforms.api_server.extra.port`` in the profile's
@@ -13485,6 +13494,10 @@ def _gateway_fire_endpoint(profile: str, home: Path) -> str:
     the default gateway's port with that prefix; per-profile-gateway mode
     (each profile its own process/port) uses the bare path on the profile's
     own port.
+
+    ``route`` defaults to the Chronos fire webhook's path; pass a different
+    absolute path (e.g. an ``/api/jobs/{id}/run`` manual-trigger forward) to
+    resolve the same port/multiplex logic for another gateway route.
     """
     import os as _os
 
@@ -13539,8 +13552,89 @@ def _gateway_fire_endpoint(profile: str, home: Path) -> str:
         pass
 
     if multiplex and profile != "default":
-        return f"http://127.0.0.1:{port}/p/{profile}/api/cron/fire"
-    return f"http://127.0.0.1:{port}/api/cron/fire"
+        return f"http://127.0.0.1:{port}/p/{profile}{route}"
+    return f"http://127.0.0.1:{port}{route}"
+
+
+def _relay_fronted_run_platforms_for_profile(
+    profile: str, home: Path, job: Dict[str, Any]
+) -> set:
+    """Relay-fronted delivery platforms for ``job``, resolved under the
+    TARGET profile's config rather than the dashboard process's own active
+    profile — the profile-scoped analogue of
+    :func:`tools.cronjob_tools._relay_fronted_delivery_platforms`, needed
+    because the dashboard triggers jobs across every profile it manages, not
+    just the one it happens to be running under.
+    """
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    token = set_hermes_home_override(str(home))
+    try:
+        from tools.cronjob_tools import _relay_fronted_delivery_platforms
+
+        return _relay_fronted_delivery_platforms(job)
+    except Exception:
+        return set()
+    finally:
+        reset_hermes_home_override(token)
+
+
+def _forward_relay_fronted_trigger(profile: str, home: Path, job_id: str) -> Dict[str, Any]:
+    """Forward a dashboard "Run Now" trigger to the TARGET profile's gateway.
+
+    A relay-fronted platform's only sender is the gateway's live relay
+    adapter — no standalone credential exists in the dashboard process — so
+    this process cannot deliver the run itself (the same constraint
+    :func:`_fire_cron_job_for_profile` documents). This is the dashboard
+    analogue of the CLI's own forward
+    (``tools.cronjob_tools._forward_relay_fronted_run``): it hits the
+    gateway api_server's ``POST /api/jobs/{id}/run`` (API_SERVER_KEY bearer,
+    a manual trigger — NOT the Chronos-JWT-gated ``/api/cron/fire``), which
+    marks the job due for the gateway's own ticker to fire with the live
+    adapter.
+
+    Raises ``HTTPException`` (503) when the gateway is unreachable or
+    rejects the forward, so a relay-fronted trigger fails loudly instead of
+    silently claiming the run and never delivering it.
+    """
+    url = _gateway_fire_endpoint(profile, home, route=f"/api/jobs/{job_id}/run")
+
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    token = set_hermes_home_override(str(home))
+    try:
+        from agent.secret_scope import get_secret
+
+        key = get_secret("API_SERVER_KEY", "") or ""
+    finally:
+        reset_hermes_home_override(token)
+
+    import httpx
+
+    try:
+        resp = httpx.post(
+            url,
+            headers={"Authorization": f"Bearer {key}"},
+            json={},
+            timeout=10.0,
+        )
+    except Exception as exc:
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                "This job delivers through a relay-fronted platform, which "
+                "only the running gateway can reach, and the gateway is "
+                f"unreachable ({exc}). Start the profile's gateway and try "
+                "again."
+            ),
+        ) from exc
+    if resp.status_code >= 400:
+        raise HTTPException(
+            status_code=resp.status_code,
+            detail=f"Gateway rejected the forwarded run: {(resp.text or '')[:300]}",
+        )
+    refreshed = _call_cron_for_profile(profile, "get_job", job_id)
+    return refreshed or {"job_id": job_id, "forwarded_to_gateway": True}
 
 
 async def _forward_cron_fire_to_gateway(

--- a/tests/hermes_cli/test_web_server_cron_profiles.py
+++ b/tests/hermes_cli/test_web_server_cron_profiles.py
@@ -653,6 +653,128 @@ async def test_trigger_cron_job_forces_paused_job_atomically(
 
 
 @pytest.mark.asyncio
+async def test_trigger_cron_job_forwards_relay_fronted_job_to_gateway(
+    isolated_profiles,
+    monkeypatch,
+):
+    """A relay-fronted job's dashboard "Run Now" must forward to the TARGET
+    profile's gateway api_server (POST /api/jobs/{id}/run, API_SERVER_KEY
+    bearer) instead of firing in-process — this process has no standalone
+    sender for a relay-fronted platform, only the gateway's live adapter
+    does (mirrors the CLI's own `hermes cron run` forward)."""
+    from hermes_cli import web_server
+
+    job = web_server._call_cron_for_profile(
+        "worker_alpha",
+        "create_job",
+        prompt="deliver via relay",
+        schedule="every 1h",
+        name="relay-fronted-trigger-job",
+        deliver="discord",
+    )
+
+    monkeypatch.setattr(
+        "gateway.relay.relay_fronted_platforms", lambda: {"discord"}
+    )
+    monkeypatch.setattr(
+        "cron.scheduler._resolve_delivery_targets",
+        lambda job: [{"platform": "discord", "chat_id": "123"}],
+    )
+
+    def fire_due_must_not_run(self, *a, **kw):
+        raise AssertionError(
+            "relay-fronted trigger must forward to the gateway, not fire in-process"
+        )
+
+    monkeypatch.setattr(
+        "cron.scheduler_provider.resolve_cron_scheduler",
+        lambda: (_ for _ in ()).throw(
+            AssertionError("relay-fronted trigger must not resolve a local scheduler")
+        ),
+    )
+
+    posted = {}
+
+    class _Resp:
+        status_code = 200
+        text = ""
+
+    def fake_post(url, *, headers=None, json=None, timeout=None):
+        posted["url"] = url
+        posted["headers"] = headers
+        return _Resp()
+
+    monkeypatch.setattr("httpx.post", fake_post)
+    monkeypatch.setattr(
+        "agent.secret_scope.get_secret", lambda *a, **kw: "gw-secret-key"
+    )
+
+    triggered = await web_server.trigger_cron_job(
+        job["id"],
+        profile="worker_alpha",
+    )
+
+    assert posted["url"] == f"http://127.0.0.1:8642/api/jobs/{job['id']}/run"
+    assert posted["headers"]["Authorization"] == "Bearer gw-secret-key"
+    # Forwarded, not fired in-process: no local run was ever claimed.
+    assert triggered["last_run_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_trigger_cron_job_relay_fronted_gateway_unreachable_is_503(
+    isolated_profiles,
+    monkeypatch,
+):
+    """Gateway unreachable for a relay-fronted job must fail loudly (503),
+    never silently fall back to the in-process path that cannot deliver."""
+    from fastapi import HTTPException
+    from hermes_cli import web_server
+
+    job = web_server._call_cron_for_profile(
+        "worker_alpha",
+        "create_job",
+        prompt="deliver via relay",
+        schedule="every 1h",
+        name="relay-fronted-unreachable-job",
+        deliver="discord",
+    )
+
+    monkeypatch.setattr(
+        "gateway.relay.relay_fronted_platforms", lambda: {"discord"}
+    )
+    monkeypatch.setattr(
+        "cron.scheduler._resolve_delivery_targets",
+        lambda job: [{"platform": "discord", "chat_id": "123"}],
+    )
+    monkeypatch.setattr(
+        "cron.scheduler_provider.resolve_cron_scheduler",
+        lambda: (_ for _ in ()).throw(
+            AssertionError("relay-fronted trigger must not resolve a local scheduler")
+        ),
+    )
+
+    def fake_post(url, *, headers=None, json=None, timeout=None):
+        raise ConnectionError("gateway down")
+
+    monkeypatch.setattr("httpx.post", fake_post)
+    monkeypatch.setattr(
+        "agent.secret_scope.get_secret", lambda *a, **kw: "gw-secret-key"
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await web_server.trigger_cron_job(job["id"], profile="worker_alpha")
+
+    assert exc.value.status_code == 503
+    assert "relay-fronted" in exc.value.detail.lower()
+    persisted = web_server._call_cron_for_profile(
+        "worker_alpha",
+        "get_job",
+        job["id"],
+    )
+    assert persisted["last_run_at"] is None
+
+
+@pytest.mark.asyncio
 async def test_trigger_paused_job_rejects_legacy_provider_without_mutating_job(
     isolated_profiles,
     monkeypatch,


### PR DESCRIPTION
## Summary

The dashboard's manual trigger route (`POST /api/cron/jobs/{id}/trigger`, the "Run Now" button) still fires jobs in-process via the deprecated `_fire_cron_job_for_profile`, whose own docstring says it "cannot serve relay-fronted logical platforms ... or E2EE rooms" and "do not add new uses." The sibling Chronos fire webhook (`/api/cron/fire`) and the CLI's own `hermes cron run` (`tools.cronjob_tools._forward_relay_fronted_run`) were both already fixed to forward relay-fronted runs to the gateway's live adapter — the dashboard trigger route was the one caller left on the old path.

Concretely: clicking "Run Now" on a job that delivers through a relay-fronted platform (Discord/Telegram/etc. behind the gateway's relay connector) claims the run via CAS and then never delivers it.

## Changes

- `hermes_cli/web_server.py`:
  - `_trigger_cron_job_sync` now checks whether the job's resolved delivery targets include a relay-fronted platform (profile-scoped, since the dashboard triggers jobs across every profile it manages) and, if so, forwards to that profile's gateway instead of falling through to the in-process path.
  - New `_forward_relay_fronted_trigger`: hits the gateway api_server's `POST /api/jobs/{id}/run` (API_SERVER_KEY bearer — a manual trigger, not the JWT-gated Chronos fire route) — the dashboard analogue of the CLI's own forward. Gateway-unreachable now fails loudly with a 503 instead of silently dropping the run.
  - New `_relay_fronted_run_platforms_for_profile`: profile-scoped wrapper around `tools.cronjob_tools._relay_fronted_delivery_platforms`.
  - `_gateway_fire_endpoint` gained an optional `route` kwarg (default unchanged, `/api/cron/fire`) so both forwarders share the same profile-aware port/multiplex resolution logic instead of duplicating it.

## Testing

- Two new regression tests in `tests/hermes_cli/test_web_server_cron_profiles.py`:
  - `test_trigger_cron_job_forwards_relay_fronted_job_to_gateway` — a relay-fronted job's manual trigger forwards to the gateway (`POST /api/jobs/{id}/run` with the correct bearer) instead of firing in-process.
  - `test_trigger_cron_job_relay_fronted_gateway_unreachable_is_503` — gateway unreachable surfaces a 503 rather than silently claiming/dropping the run.
- Mutation-verified: both tests fail against the pre-fix code.
- Full `tests/hermes_cli/test_web_server_cron_profiles.py` + `tests/hermes_cli/test_cron_fire_dashboard.py` (56 tests) pass.
- Full `tests/cron/` (1033 tests) passes.
- ruff clean on touched files.

## Notes

Checked the open "Fix cron dashboard trigger-now execution" PR (#46956) — it targets a since-superseded implementation of `trigger_cron_job` (pre-CAS-claim rewrite) and fixes an unrelated immediate-tick-vs-deferred issue, not relay forwarding.