### PR TITLE
fix(compression): apply the fast-lane cap/reasoning controls on the async path too

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5495,6 +5495,19 @@ async def _call_fallback_candidate_async(
         )
         effective_timeout = fb_timeout
     destination = _fallback_destination(task, fb_client, fb_model, fb_label)
+    task_config = _get_auxiliary_task_config(task) if task == "compression" else {}
+    fallback_entry = _fallback_chain_entry(task, fb_label) or {}
+    fallback_max_tokens, fallback_extra_body = _compression_fast_lane_controls(
+        task,
+        actual_provider=destination.provider,
+        actual_model=destination.model,
+        requested_provider=fallback_entry.get("provider"),
+        requested_model=fallback_entry.get("model"),
+        route_config=fallback_entry,
+        leak_guard_config=task_config,
+        max_tokens=max_tokens,
+        extra_body=effective_extra_body,
+    )
     fallback_messages, fallback_tools = _replan_synchronous_cache_sections(
         messages,
         tools,
@@ -5502,10 +5515,14 @@ async def _call_fallback_candidate_async(
     )
     fb_kwargs = _build_call_kwargs(
         destination.provider, destination.model, fallback_messages,
-        temperature=temperature, max_tokens=max_tokens,
+        temperature=temperature, max_tokens=fallback_max_tokens,
         tools=fallback_tools, timeout=effective_timeout,
-        extra_body=effective_extra_body, reasoning_config=reasoning_config,
+        extra_body=fallback_extra_body, reasoning_config=reasoning_config,
         base_url=destination.base_url, task=task)
+    if fallback_max_tokens is not None and max_tokens is None:
+        fb_kwargs.update(
+            auxiliary_max_tokens_param(fallback_max_tokens, model=destination.model)
+        )
     try:
         return _validate_llm_response(
             await _relay_async_completion(
@@ -5543,15 +5560,32 @@ async def _call_fallback_candidate_async(
                     tools,
                     destination=retry_destination,
                 )
+                retry_max_tokens, retry_extra_body = _compression_fast_lane_controls(
+                    task,
+                    actual_provider=retry_destination.provider,
+                    actual_model=retry_destination.model,
+                    requested_provider=fallback_entry.get("provider"),
+                    requested_model=fallback_entry.get("model"),
+                    route_config=fallback_entry,
+                    leak_guard_config=task_config,
+                    max_tokens=max_tokens,
+                    extra_body=effective_extra_body,
+                )
                 retry_kwargs = _build_call_kwargs(
                     retry_destination.provider,
                     retry_destination.model,
                     retry_messages,
-                    temperature=temperature, max_tokens=max_tokens,
+                    temperature=temperature, max_tokens=retry_max_tokens,
                     tools=retry_tools, timeout=effective_timeout,
-                    extra_body=effective_extra_body,
+                    extra_body=retry_extra_body,
                     reasoning_config=reasoning_config,
                     base_url=retry_destination.base_url, task=task)
+                if retry_max_tokens is not None and max_tokens is None:
+                    retry_kwargs.update(
+                        auxiliary_max_tokens_param(
+                            retry_max_tokens, model=retry_destination.model
+                        )
+                    )
                 try:
                     return _validate_llm_response(
                         await _relay_async_completion(
@@ -10694,6 +10728,20 @@ async def _async_call_llm_impl(
 
     effective_timeout = _effective_aux_timeout(task, timeout)
     request_provider = effective_provider or resolved_provider
+    compression_config = (
+        _get_auxiliary_task_config("compression") if task == "compression" else {}
+    )
+    fast_compression_cap, effective_extra_body = _compression_fast_lane_controls(
+        task,
+        actual_provider=request_provider,
+        actual_model=final_model,
+        requested_provider=provider,
+        requested_model=model,
+        route_config=compression_config,
+        leak_guard_config=compression_config,
+        max_tokens=max_tokens,
+        extra_body=effective_extra_body,
+    )
     _set_relay_auxiliary_route(
         request_provider,
         final_model,
@@ -10713,6 +10761,11 @@ async def _async_call_llm_impl(
         tools=tools, timeout=effective_timeout, extra_body=effective_extra_body,
         reasoning_config=reasoning_config,
         base_url=_client_base or resolved_base_url, task=task)
+    if fast_compression_cap is not None and max_tokens is None:
+        # Same narrow exception as the sync path (_call_llm_impl): the
+        # configured compression route is concrete and certified
+        # non-reasoning, so a bounded summary request is intentional.
+        kwargs.update(auxiliary_max_tokens_param(fast_compression_cap, model=final_model))
 
     # Convert image blocks for Anthropic-compatible endpoints (e.g. MiniMax)
     if _is_anthropic_compat_endpoint(request_provider, _client_base):

--- a/tests/agent/test_fast_compression_lane.py
+++ b/tests/agent/test_fast_compression_lane.py
@@ -2,7 +2,9 @@
 
 import time
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 
 def _resolve(config, *, provider="ollama", model="qwen3:8b", requested_model=None):
@@ -475,3 +477,135 @@ def test_explicit_caller_max_tokens_keeps_provider_quirk_handling():
     request = client.chat.completions.create.call_args.kwargs
     assert "max_tokens" not in request
     assert "max_completion_tokens" not in request
+
+
+class TestAsyncCompressionFastLaneParity:
+    """async_call_llm / _call_fallback_candidate_async must apply the same
+    certified fast-lane controls as their sync counterparts.
+
+    Before this fix, resolve_compression_fast_lane and
+    _compression_fast_lane_controls were only wired into the sync
+    call_llm/_call_fallback_candidate_sync paths — async_call_llm's own
+    docstring ("Same as call_llm() but async") was inaccurate: the async
+    path never certified a route or applied a cap/reasoning override.
+    """
+
+    @pytest.mark.asyncio
+    async def test_certified_fast_lane_sends_the_configured_cap_to_its_provider(self):
+        from agent.auxiliary_client import async_call_llm
+
+        config = {
+            "provider": "ollama",
+            "model": "qwen3:8b",
+            "reasoning_effort": "none",
+            "max_output_tokens": 1400,
+        }
+        client = MagicMock()
+        client.base_url = "http://127.0.0.1:11434/v1"
+        response = object()
+        client.chat.completions.create = AsyncMock(return_value=response)
+
+        with (
+            patch("agent.auxiliary_client._get_auxiliary_task_config", return_value=config),
+            patch("agent.auxiliary_client._get_cached_client", return_value=(client, "qwen3:8b")),
+            patch("agent.auxiliary_client._validate_llm_response", return_value=response),
+        ):
+            result = await async_call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "summary request"}],
+            )
+        assert result is response
+
+        request = client.chat.completions.create.call_args.kwargs
+        assert request["max_tokens"] == 1400
+        assert request["extra_body"]["reasoning"] == {"enabled": False}
+
+    @pytest.mark.asyncio
+    async def test_uncertified_effective_primary_route_does_not_receive_fast_cap(self):
+        from agent.auxiliary_client import async_call_llm
+
+        config = {
+            "provider": "ollama",
+            "model": "qwen3:8b",
+            "reasoning_effort": "none",
+            "max_output_tokens": 1400,
+        }
+        client = MagicMock()
+        client.base_url = "http://127.0.0.1:11434/v1"
+        response = object()
+        client.chat.completions.create = AsyncMock(return_value=response)
+
+        with (
+            patch("agent.auxiliary_client._get_auxiliary_task_config", return_value=config),
+            patch(
+                "agent.auxiliary_client._get_cached_client",
+                return_value=(client, "server-selected-model"),
+            ),
+            patch("agent.auxiliary_client._validate_llm_response", return_value=response),
+        ):
+            result = await async_call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "summary request"}],
+            )
+        assert result is response
+
+        request = client.chat.completions.create.call_args.kwargs
+        assert "max_tokens" not in request
+        assert "max_completion_tokens" not in request
+        assert "reasoning" not in request.get("extra_body", {})
+
+    @pytest.mark.asyncio
+    async def test_fallback_cap_requires_independent_route_certification(self):
+        from agent.auxiliary_client import _call_fallback_candidate_async
+
+        response = object()
+
+        async def _request_for(entry):
+            config = {
+                "fallback_chain": [entry],
+                "provider": "ollama",
+                "model": "qwen3:8b",
+                "reasoning_effort": "none",
+                "max_output_tokens": 1400,
+            }
+            client = MagicMock()
+            client.base_url = "http://127.0.0.1:11434/v1"
+            client.chat.completions.create = AsyncMock(return_value=response)
+            with (
+                patch("agent.auxiliary_client._get_auxiliary_task_config", return_value=config),
+                patch("agent.auxiliary_client._validate_llm_response", return_value=response),
+            ):
+                result = await _call_fallback_candidate_async(
+                    client,
+                    "qwen3:14b",
+                    "fallback_chain[0](ollama)",
+                    task="compression",
+                    messages=[{"role": "user", "content": "summary request"}],
+                    temperature=None,
+                    max_tokens=None,
+                    tools=None,
+                    effective_timeout=300,
+                    effective_extra_body={"reasoning": {"enabled": False, "effort": "none"}},
+                    reasoning_config=None,
+                )
+                assert result is response
+            return client.chat.completions.create.call_args.kwargs
+
+        uncertified = await _request_for({"provider": "ollama", "model": "qwen3:14b"})
+        certified = await _request_for(
+            {
+                "provider": "ollama",
+                "model": "qwen3:14b",
+                "reasoning_effort": "none",
+                "max_output_tokens": 900,
+            }
+        )
+
+        assert "max_tokens" not in uncertified
+        assert "max_completion_tokens" not in uncertified
+        assert "reasoning" not in uncertified.get("extra_body", {})
+        assert certified["max_tokens"] == 900
+        assert certified["extra_body"]["reasoning"] == {
+            "enabled": False,
+            "effort": "none",
+        }


### PR DESCRIPTION
## Summary

`resolve_compression_fast_lane` / `_compression_fast_lane_controls` (the opt-in compression fast-lane: caps `max_output_tokens` and disables reasoning when the operator has certified a concrete, non-reasoning auxiliary route) were only wired into the sync `call_llm` / `_call_fallback_candidate_sync` paths. `async_call_llm`'s own docstring says "Same as `call_llm()` but async," but `_async_call_llm_impl` and `_call_fallback_candidate_async` never certified a route or applied the cap/non-reasoning override — the docstring was inaccurate.

Reachability: no built-in caller uses the async compression path today (`context_compressor.py`/`conversation_compression.py` are fully synchronous), so this is latent rather than actively triggered — it's reachable via `agent.plugin_llm.PluginLlm.acomplete(task="compression")` when a plugin sets `plugins.entries.<id>.llm.allow_task_override: true` (an explicit operator opt-in), or by any future caller that routes compression through the async path. Checked both source PRs (#96945, #96963) for the fast-lane feature — neither's "deliberately skipped" scope notes mention async, so this looks like an oversight rather than an intentional deferral.

## Changes

- `agent/auxiliary_client.py`:
  - `_async_call_llm_impl`: resolves `compression_config` and calls `_compression_fast_lane_controls` right after `request_provider` is known (mirroring `_call_llm_impl` line for line), and applies the resulting cap via `auxiliary_max_tokens_param` after `kwargs` is built.
  - `_call_fallback_candidate_async`: same treatment at both the primary fallback call and its auth-retry, mirroring `_call_fallback_candidate_sync`.

## Testing

- Three new regression tests in `tests/agent/test_fast_compression_lane.py` (`TestAsyncCompressionFastLaneParity`), mirroring the existing sync fast-lane tests but exercising `async_call_llm` / `_call_fallback_candidate_async`:
  - `test_certified_fast_lane_sends_the_configured_cap_to_its_provider`
  - `test_uncertified_effective_primary_route_does_not_receive_fast_cap`
  - `test_fallback_cap_requires_independent_route_certification`
- Mutation-verified: all three fail against the pre-fix code.
- Full `tests/agent/test_fast_compression_lane.py` + `tests/agent/test_auxiliary_compression_timeout_floor.py` + `tests/agent/test_compression_attempt_ownership.py` (33 tests) pass.
- Broader regression: `tests/agent/ -k "auxiliary or compression or fallback"` (701 tests) — 4 pre-existing failures, confirmed independent of this change by running the identical selection against the pre-fix code (same 4 failures, same "the 'anthropic' package is not installed" root cause — a documented environment gap, not a regression).
- ruff clean.