### PR TITLE
fix(code-execution): reap idle and cap remote session kernels

### DIFF
--- a/tests/tools/test_code_kernel_remote.py
+++ b/tests/tools/test_code_kernel_remote.py
@@ -200,6 +200,51 @@ class TestOwnershipIsolation(RemoteKernelBase):
         self.assertEqual(remaining_owner, "owner-b")
 
 
+class TestIdleReapAndCapEviction(RemoteKernelBase):
+    """Unlike local session kernels, remote kernels had no idle-reap or
+    process-wide cap: _REMOTE_KERNELS grew one entry per distinct
+    (owner, env_type, task_env_id) that was never revisited, for the life
+    of the gateway process."""
+
+    def test_idle_expired_kernel_is_reaped_on_next_call(self):
+        env = ScriptedEnv(_spawn_ok_handlers([_cell(), _cell()]))
+        execute_in_remote_kernel(
+            "print(1)", env=env, env_type="ssh", task_env_id="stale",
+            sandbox_tools=frozenset(), timeout=10, max_tool_calls=5,
+            reset=False, idle_exit=1800,
+        )
+        self.assertEqual(len(_REMOTE_KERNELS), 1)
+        # Backdate the kernel's last_used past the idle window — simulates
+        # a key that is never revisited again.
+        for kernel in _REMOTE_KERNELS.values():
+            kernel.last_used -= 2000
+        # A call for a DIFFERENT key must reap the stale entry on entry,
+        # without ever touching or reviving it.
+        execute_in_remote_kernel(
+            "print(1)", env=env, env_type="ssh", task_env_id="fresh",
+            sandbox_tools=frozenset(), timeout=10, max_tool_calls=5,
+            reset=False, idle_exit=1800,
+        )
+        owners = {key[0] for key in _REMOTE_KERNELS}
+        self.assertNotIn("stale", owners)
+        self.assertIn("fresh", owners)
+
+    def test_over_cap_evicts_least_recently_used(self):
+        with patch("tools.code_kernel._lifecycle_limits", return_value=(2, 1800)):
+            env = ScriptedEnv(_spawn_ok_handlers([_cell() for _ in range(10)]))
+            for i in range(3):
+                execute_in_remote_kernel(
+                    "print(1)", env=env, env_type="ssh", task_env_id=f"owner-{i}",
+                    sandbox_tools=frozenset(), timeout=10, max_tool_calls=5,
+                    reset=False, idle_exit=1800,
+                )
+            self.assertEqual(len(_REMOTE_KERNELS), 2)
+            owners = {key[0] for key in _REMOTE_KERNELS}
+            self.assertNotIn("owner-0", owners)
+            self.assertIn("owner-1", owners)
+            self.assertIn("owner-2", owners)
+
+
 class TestDispatchIntegration(unittest.TestCase):
     """_execute_remote prefers the kernel and falls open to per-call."""
 

--- a/tools/code_kernel_remote.py
+++ b/tools/code_kernel_remote.py
@@ -219,6 +219,44 @@ def shutdown_remote_kernels_for_owner(owner: str) -> None:
         _kill(kernel)
 
 
+def _reap_unlocked(idle_timeout: int) -> List["RemoteKernel"]:
+    """Pop idle-expired remote kernels; caller tears them down outside the lock.
+
+    Mirrors tools.code_kernel._reap_unlocked. The remote runner itself
+    self-exits after the same idle window (REMOTE_KERNEL_RUNNER_SOURCE's
+    IDLE_EXIT_SECONDS), so this only needs to clear the HOST-side
+    bookkeeping entry — without it, _REMOTE_KERNELS grows one entry per
+    distinct (owner, env_type, task_env_id) that is never revisited, for
+    the life of the gateway process.
+    """
+    now = time.monotonic()
+    doomed = [
+        key
+        for key, kernel in _REMOTE_KERNELS.items()
+        if now - kernel.last_used > idle_timeout
+    ]
+    return [_REMOTE_KERNELS.pop(key) for key in doomed]
+
+
+def _evict_over_cap_unlocked(keep: Tuple) -> List["RemoteKernel"]:
+    """Pop least-recently-used remote kernels beyond the process-wide cap.
+
+    Mirrors tools.code_kernel._evict_over_cap_unlocked, reusing the same
+    max_session_kernels config as an independent bound on _REMOTE_KERNELS.
+    """
+    from tools.code_kernel import _lifecycle_limits
+
+    cap, _ = _lifecycle_limits()
+    if len(_REMOTE_KERNELS) <= cap:
+        return []
+    by_age = sorted(
+        (key for key in _REMOTE_KERNELS if key != keep),
+        key=lambda key: _REMOTE_KERNELS[key].last_used,
+    )
+    doomed = by_age[: len(_REMOTE_KERNELS) - cap]
+    return [_REMOTE_KERNELS.pop(key) for key in doomed]
+
+
 atexit.register(shutdown_all_remote_kernels)
 
 
@@ -329,7 +367,10 @@ def execute_in_remote_kernel(
     state_reset = False
 
     with _REMOTE_KERNELS_LOCK:
+        expired = _reap_unlocked(idle_exit)
         kernel = _REMOTE_KERNELS.get(key)
+    for doomed in expired:
+        _kill(doomed)
 
     if kernel is not None and reset:
         with _REMOTE_KERNELS_LOCK:
@@ -359,6 +400,10 @@ def execute_in_remote_kernel(
             _REMOTE_KERNELS[key] = kernel
 
     kernel.last_used = time.monotonic()
+    with _REMOTE_KERNELS_LOCK:
+        evicted = _evict_over_cap_unlocked(keep=key)
+    for doomed in evicted:
+        _kill(doomed)
     kernel.cell_seq += 1
     seq = f"{kernel.cell_seq:06d}"
     q_cells = shlex.quote(f"{kernel.kernel_dir}/cells")


### PR DESCRIPTION
## Summary

Local session kernels (`tools/code_kernel.py`) sweep idle-expired entries and enforce a process-wide cap (`DEFAULT_MAX_SESSION_KERNELS`) on every call via `_reap_unlocked`/`_evict_over_cap_unlocked`. The new remote kernel host (#96991) never got the same treatment: `_REMOTE_KERNELS` only shrinks lazily when a specific key is revisited and found dead/reset/exited — so an owner that opens kernels for several distinct `(env_type, task_env_id)` combinations (or delegated children) and never revisits some of them accumulates host-side bookkeeping entries for the life of the gateway process.

**Scope note on severity:** this is narrower than it might look. The remote runner already self-reaps on its own idle timeout (`IDLE_EXIT_SECONDS` in the generated runner script), and the underlying transport connections are independently bounded — SSH via `ControlPersist=300`, Docker containers via `terminal_tool.py`'s own session-scoped idle-timeout. So nothing here leaks a live remote connection or process; what's missing is purely the host-side dict/cap bookkeeping symmetry with local kernels (unbounded small-object growth over a long gateway uptime, not a resource-exhaustion vector).

## Changes

- `tools/code_kernel_remote.py`: adds `_reap_unlocked(idle_timeout)` and `_evict_over_cap_unlocked(keep)`, mirroring `tools/code_kernel.py`'s implementations (same shape: pop-under-lock, teardown outside the lock). Reuses the existing `max_session_kernels` config (via `tools.code_kernel._lifecycle_limits`) as an independent cap on `_REMOTE_KERNELS`. Wired into `execute_in_remote_kernel`: reap runs on every call before key lookup; cap eviction runs on every call after `last_used` is updated (both reused and freshly-spawned paths), matching local's unconditional-per-call pattern.

## Testing

- Two new regression tests in `tests/tools/test_code_kernel_remote.py` (`TestIdleReapAndCapEviction`):
  - `test_idle_expired_kernel_is_reaped_on_next_call` — a kernel backdated past its idle window is reaped (and never revived) by a call for a different key.
  - `test_over_cap_evicts_least_recently_used` — spawning more distinct kernels than the configured cap evicts the least-recently-used ones.
- Mutation-verified: both fail against the pre-fix code.
- Full `tests/tools/test_code_kernel_remote.py` + `tests/tools/test_code_kernel.py` + `tests/tools/test_code_execution.py` (77 tests) pass.
- ruff clean.