### PR TITLE
fix(macos): make the libpython refresh write atomic

### DIFF
--- a/hermes_cli/macos_tcc_anchor.py
+++ b/hermes_cli/macos_tcc_anchor.py
@@ -190,6 +190,13 @@ def _provision_libpython(
 
     Provision-if-present: a surplus hardlink on a statically-linked build is
     free; a missed detection is the only way #95425 returns.
+
+    Staged into a unique temp name and swapped in with ``os.replace`` — the
+    same atomic pattern ``_copy_alias``/``_write_marker`` use. An existing
+    ``dst`` on the refresh path is never unlinked before a replacement is
+    ready, so a hardlink/copy failure mid-refresh cannot leave the
+    interpreter without its libpython (the #95425 crash shape, for an
+    already-installed anchor rather than a fresh one).
     """
     src_lib = _store_root(source_file) / "lib"
     if not src_lib.is_dir():
@@ -201,20 +208,28 @@ def _provision_libpython(
             if not src.is_file():
                 continue
             dst = dst_lib / src.name
-            if dst.exists() or dst.is_symlink():
-                if not refresh:
-                    continue
-                try:
-                    dst.unlink()
-                except OSError:
-                    continue
+            if (dst.exists() or dst.is_symlink()) and not refresh:
+                continue
+            tmp_path: Path | None = None
             try:
-                os.link(src, dst)
-            except OSError:
+                fd, tmp_name = tempfile.mkstemp(prefix=f".{src.name}.tcc-", dir=str(dst_lib))
+                os.close(fd)
+                tmp_path = Path(tmp_name)
+                tmp_path.unlink()  # free the reserved name for os.link
                 try:
-                    shutil.copy2(src, dst)
+                    os.link(src, tmp_path)
                 except OSError:
-                    logger.debug("libpython provision failed for %s", src, exc_info=True)
+                    shutil.copy2(src, tmp_path)
+                os.replace(tmp_path, dst)
+                tmp_path = None
+            except OSError:
+                logger.debug("libpython provision failed for %s", src, exc_info=True)
+            finally:
+                if tmp_path is not None:
+                    try:
+                        tmp_path.unlink(missing_ok=True)
+                    except OSError:
+                        pass
     except OSError:
         logger.debug("libpython provision skipped", exc_info=True)
 

--- a/tests/hermes_cli/test_macos_tcc_anchor.py
+++ b/tests/hermes_cli/test_macos_tcc_anchor.py
@@ -359,6 +359,50 @@ class TestEnsureTccAnchor:
         assert marker.read_text(encoding="utf-8") == tcc._marker_value(source)
         assert not list(venv_bin.glob(".tcc-anchor-source.*"))
 
+    def test_libpython_refresh_failure_leaves_existing_dylib_intact(self, tmp_path, monkeypatch):
+        # If a refresh's hardlink AND copy fallback both fail (disk
+        # full/EPERM/interrupted), the venv's EXISTING libpython must
+        # survive untouched — the same atomic-write guarantee
+        # _copy_alias/_write_marker already give the alias and marker
+        # writes. Losing it here reintroduces the #95425 dyld crash for an
+        # already-installed anchor, not just a fresh one.
+        store_bin = _build_store(tmp_path, with_libpython=True)
+        venv_dir = tmp_path / "venv"
+        dst_lib = venv_dir / "lib"
+        dst_lib.mkdir(parents=True)
+        dst = dst_lib / "libpython3.11.dylib"
+        dst.write_bytes(b"existing working dylib")
+
+        monkeypatch.setattr(
+            tcc.os, "link",
+            lambda *a, **k: (_ for _ in ()).throw(OSError("no hardlinks across this fs")),
+        )
+        monkeypatch.setattr(
+            tcc.shutil, "copy2",
+            lambda *a, **k: (_ for _ in ()).throw(OSError("disk full")),
+        )
+
+        tcc._provision_libpython(venv_dir, store_bin / "python3.11", refresh=True)
+
+        assert dst.is_file()
+        assert dst.read_bytes() == b"existing working dylib"
+        # No leftover staging file either.
+        assert not list(dst_lib.glob(".libpython3.11.dylib.tcc-*"))
+
+    def test_libpython_refresh_success_atomically_replaces_dylib(self, tmp_path, monkeypatch):
+        store_bin = _build_store(tmp_path, with_libpython=True)
+        src_dylib = store_bin.parent / "lib" / "libpython3.11.dylib"
+        venv_dir = tmp_path / "venv"
+        dst_lib = venv_dir / "lib"
+        dst_lib.mkdir(parents=True)
+        dst = dst_lib / "libpython3.11.dylib"
+        dst.write_bytes(b"stale dylib")
+
+        tcc._provision_libpython(venv_dir, store_bin / "python3.11", refresh=True)
+
+        assert dst.read_bytes() == src_dylib.read_bytes()
+        assert not list(dst_lib.glob(".libpython3.11.dylib.tcc-*"))
+
     def test_store_root_marker_tracks_managed_uv_constant(self):
         # The repair-generation store marker must stay derived from
         # managed_uv's directory constant, not drift as a hardcoded string.


### PR DESCRIPTION
## Summary

`_provision_libpython`'s refresh path unlinked an existing `venv/lib/libpython*.dylib` before attempting a hardlink (falling back to `copy2`) at the same destination. If both the hardlink and the copy fallback fail (disk full, EPERM, an immutable flag, or the process is interrupted between the unlink and the replacement), the destination is left permanently missing — only logged at `debug` — because nothing ever recreates it.

Every other multi-step write in this module (`_write_marker`, `_copy_alias`, and the boot-verified binary anchor copy) already stages into a unique temp name and swaps it in with `os.replace` so a mid-write failure can never leave a torn or missing artifact; `_provision_libpython`'s refresh path was the one write site that still unlinked the live target first. This is the exact #95425 dyld crash this whole feature exists to prevent — reintroduced here for an already-installed anchor on refresh (source interpreter change, patch bump, CVE-repair rotation) rather than a fresh install.

`refresh=True` is not a rare/theoretical branch: it's called unconditionally from `_install_anchor()` on every anchor reinstall.

## Changes

- `hermes_cli/macos_tcc_anchor.py`: `_provision_libpython` now stages into `venv/lib/` via `tempfile.mkstemp`, attempts hardlink then `copy2` against the temp path, and `os.replace()`s it onto the destination — `dst` is never touched until a working replacement exists on both the fresh-install and refresh paths.

## Testing

- Two new regression tests in `tests/hermes_cli/test_macos_tcc_anchor.py`:
  - `test_libpython_refresh_failure_leaves_existing_dylib_intact` — with both `os.link` and `shutil.copy2` mocked to fail, an existing dylib survives a refresh attempt untouched, and no staging file is left behind.
  - `test_libpython_refresh_success_atomically_replaces_dylib` — a normal refresh still replaces the dylib with the store's current content.
- Mutation-verified: the failure-path test fails against the pre-fix code (`assert dst.is_file()` → `False`, i.e. the dylib is gone).
- Full `tests/hermes_cli/test_macos_tcc_anchor.py` (41 tests) passes.
- ruff clean.

Not empirically reproduced against a real disk-full/EPERM condition (out of scope without a real macOS filesystem fault-injection harness) — verified via the mocked hardlink/copy failure above, which exercises the exact code path a real fault would hit.