### PR TITLE
fix(file_tools): include output mode and context in repeat guard key

### DIFF
--- a/tests/tools/test_read_loop_detection.py
+++ b/tests/tools/test_read_loop_detection.py
@@ -194,6 +194,42 @@ class TestSearchLoopDetection(unittest.TestCase):
             self.assertNotIn("_warning", result)
             self.assertNotIn("error", result)
 
+    @patch("tools.file_tools._get_file_ops")
+    def test_context_change_does_not_count_as_repeat(self, mock_ops):
+        """Changing only context starts a new search sequence."""
+        fake = _make_fake_file_ops()
+        dispatches = []
+        fake.search = lambda **kw: (dispatches.append(kw) or _FakeSearchResult())
+        mock_ops.return_value = fake
+
+        for _ in range(3):
+            search_tool("def main", task_id="t1")
+        result = json.loads(search_tool("def main", context=1, task_id="t1"))
+
+        self.assertNotIn("_warning", result)
+        self.assertNotIn("error", result)
+        self.assertEqual(len(dispatches), 4)
+        self.assertEqual(dispatches[-1]["context"], 1)
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_output_mode_change_does_not_count_as_repeat(self, mock_ops):
+        """Changing only output_mode starts a new search sequence."""
+        fake = _make_fake_file_ops()
+        dispatches = []
+        fake.search = lambda **kw: (dispatches.append(kw) or _FakeSearchResult())
+        mock_ops.return_value = fake
+
+        for _ in range(3):
+            search_tool("def main", task_id="t1")
+        result = json.loads(
+            search_tool("def main", output_mode="count", task_id="t1")
+        )
+
+        self.assertNotIn("_warning", result)
+        self.assertNotIn("error", result)
+        self.assertEqual(len(dispatches), 4)
+        self.assertEqual(dispatches[-1]["output_mode"], "count")
+
     @patch("tools.file_tools._get_file_ops", return_value=_make_fake_file_ops())
     def test_read_between_searches_resets_consecutive(self, _mock_ops):
         """A read_file call between searches resets search consecutive counter."""

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -885,9 +885,12 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
     try:
         offset, limit = normalize_search_pagination(offset, limit)
 
-        # Pagination args (and order) are part of the key so paging through truncated
-        # results doesn't trip the repeated-search guard.
-        search_key = ("search", pattern, target, str(path), file_glob or "", limit, offset, order)
+        # Pagination, output shape, context, and order are part of the key so
+        # changing the requested search does not trip the repeat guard.
+        search_key = (
+            "search", pattern, target, str(path), file_glob or "",
+            limit, offset, output_mode, context, order,
+        )
         with _read_tracker_lock:
             task_data = _read_tracker.setdefault(task_id, {
                 "last_key": None, "consecutive": 0, "read_history": set()})


### PR DESCRIPTION
## Summary

The search repeat guard treated calls with different `output_mode` or `context` values as identical. This was reproduced on the pre-fix clean base: after three identical searches, changing only `context` or only `output_mode` still returned the repeated-search block, and the changed call was not dispatched to the search backend.

## Changes

- Include `output_mode` and `context` in the search repeat-guard key.
- Preserve the existing query, pagination, warning, and blocking behavior for truly identical consecutive calls.
- Add behavioral regression coverage for changing each newly tracked argument.

## Validation

### Observed failure on the pre-fix base

Sanitized runtime reproduction from the clean pre-fix base:

```text
three identical searches       backend dispatches: 3
fourth search: context 0 -> 1  backend dispatches: 3
response: BLOCKED: You have run this exact search 4 times in a row
```

The `context`-changed call was classified as a repeat and never reached the backend. Repeating the same sequence with `output_mode` changed from `content` to `count` produced the same false block.

### Reproduction

1. Run the same search three times with identical arguments.
2. Run it a fourth time, changing only `context` from `0` to `1`.
3. Record the response and count backend dispatches.
4. Repeat steps 1-3 with only `output_mode` changed from `content` to `count`.
5. On the pre-fix base, each changed call is blocked and dispatch count remains `3`. With this change, each changed call starts a distinct sequence, is dispatched, and returns without a repeat warning or block.

### Automated checks

- Targeted `test runner`: **63 passed, 0 failed, 2 skipped**.
- The skipped tests are Windows-only and were not applicable on the Linux runner.
- The regression tests verify backend dispatch for both `context` and `output_mode` changes, while the existing tests retain the fourth-identical-search block.
- Independent review confirmed the key identity change, retained repeat protection, and no security concerns.

## Infographic

![Search repeat guard before and after](https://v3b.fal.media/files/b/0aa8255f/R_GrIo68NAluvQB3fkSRa_kXroIYGc.png)
