### PR TITLE
feat(telegram): read groups.<chatId>.allow_from for per-chat sender authorization

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -1421,10 +1421,18 @@ class TelegramAdapter(BasePlatformAdapter):
 
         # Per-chat sender allowlist: groups.<chatId>.allow_from (#992a463a).
         # Mirrors WeCom's groups.<id>.allow_from (_resolve_group_cfg /
-        # _is_group_allowed). This is an ADDITIONAL, independent gate on top
-        # of the flat group_allow_from / chat-level allowlist above — chat-
-        # level allowlisting (allowed_chats/group_allowed_chats) is unchanged;
-        # when groups.<chatId> is present for this chat, the sender must ALSO
+        # _is_group_allowed) — including WeCom's ORDERING: _is_group_allowed
+        # resolves chat-level policy FIRST and returns False immediately if
+        # the chat itself isn't allowed, THEN applies the per-chat sender
+        # filter as an additional, sequential AND. Replicate that here: this
+        # gate must never be able to independently satisfy `authorized`
+        # before chat-level allowlisting (allowed_chats/group_allowed_chats /
+        # TELEGRAM_ALLOWED_CHATS / TELEGRAM_GROUP_ALLOWED_CHATS) has actually
+        # run — otherwise a sender who matches groups.<chatId>.allow_from for
+        # a chat that was never allowlisted at the chat level bypasses that
+        # gate entirely (t_450b1946 / uss-platform #2353 §17 slice 4/6 fix).
+        #
+        # When groups.<chatId> is present for this chat, the sender must ALSO
         # be listed in its allow_from. An entry present with allow_from: []
         # fails closed for that chat (blocks everyone), not "ignore this key".
         # When groups.<chatId> is absent for the chat, this gate is a no-op
@@ -1436,10 +1444,35 @@ class TelegramAdapter(BasePlatformAdapter):
                     group_cfg.get("allow_from") if isinstance(group_cfg, dict) else None
                 )
                 per_chat_authorized = user_id in per_chat_allow or "*" in per_chat_allow
-                if authorized is None:
-                    authorized = per_chat_authorized
+
+                # Resolve chat-level authorization FIRST (WeCom ordering).
+                # `chat_level_authorized` is None when no chat-level
+                # allowlist is configured at all (unrestricted — the runner
+                # fallback below still applies normally); False when a
+                # configured allowlist excludes this chat (hard reject,
+                # independent of any per-chat sender match); True when a
+                # configured allowlist explicitly includes this chat.
+                chat_level_authorized = self._telegram_chat_level_authorized(source.chat_id)
+
+                if chat_level_authorized is False:
+                    # Chat itself never passed the chat-level gate — no
+                    # sender can be authorized here via the per-chat gate,
+                    # regardless of groupAccess/allow_from matches.
+                    authorized = False
+                elif chat_level_authorized is True:
+                    # Chat-level gate explicitly passed; per-chat sender
+                    # filter is now a sequential AND on top of it.
+                    authorized = per_chat_authorized and (
+                        authorized if authorized is not None else True
+                    )
                 else:
-                    authorized = authorized and per_chat_authorized
+                    # No chat-level allowlist configured at all — preserve
+                    # prior behavior (this gate ANDs with any flat
+                    # group_allow_from decision, or stands alone).
+                    if authorized is None:
+                        authorized = per_chat_authorized
+                    else:
+                        authorized = authorized and per_chat_authorized
 
         # Test/custom injection only. The class method named
         # _is_callback_user_authorized is for inline button callbacks and must
@@ -8620,6 +8653,41 @@ class TelegramAdapter(BasePlatformAdapter):
         if isinstance(raw, list):
             return {str(part).strip() for part in raw if str(part).strip()}
         return {part.strip() for part in str(raw).split(",") if part.strip()}
+
+    def _telegram_chat_level_authorized(self, chat_id: Optional[str]) -> Optional[bool]:
+        """Resolve chat-level group authorization for ``chat_id``.
+
+        Mirrors WeCom's ``_is_group_allowed`` chat-scope check so the
+        per-chat ``groups.<chatId>.allow_from`` sender gate
+        (``_is_user_authorized_from_message``) can consult it BEFORE
+        applying the sender filter, instead of being able to independently
+        decide ``authorized`` and skip chat-level allowlisting entirely
+        (t_450b1946 / uss-platform #2353 §17 slice 4/6).
+
+        Consults both chat-scope allowlists the codebase recognizes for
+        Telegram groups — ``group_allowed_chats``/``TELEGRAM_GROUP_ALLOWED_CHATS``
+        (the runner's own authorization gate, see
+        ``gateway/authz_mixin.py::_is_user_authorized``) and
+        ``allowed_chats``/``TELEGRAM_ALLOWED_CHATS`` (the response gate) —
+        with the same AND semantics as ``_telegram_observe_allowed_chats``:
+        when both are configured, the chat must satisfy both.
+
+        Returns:
+            ``None`` when neither allowlist is configured (unrestricted —
+            the caller falls through to its normal, unrestricted decision
+            chain unchanged). ``True``/``False`` when at least one allowlist
+            is configured and the chat passes/fails it.
+        """
+        normalized_chat_id = str(chat_id or "").strip()
+        group_allowed = self._telegram_group_allowed_chats()
+        response_allowed = self._telegram_allowed_chats()
+        if not group_allowed and not response_allowed:
+            return None
+        if group_allowed and normalized_chat_id not in group_allowed:
+            return False
+        if response_allowed and normalized_chat_id not in response_allowed:
+            return False
+        return True
 
     def _telegram_observe_allowed_chats(self) -> set[str]:
         """Chats where observed group context may use a shared source.

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -1419,6 +1419,28 @@ class TelegramAdapter(BasePlatformAdapter):
             allowed = _coerce_allow_set(adapter_allow_from)
             authorized = user_id in allowed or "*" in allowed
 
+        # Per-chat sender allowlist: groups.<chatId>.allow_from (#992a463a).
+        # Mirrors WeCom's groups.<id>.allow_from (_resolve_group_cfg /
+        # _is_group_allowed). This is an ADDITIONAL, independent gate on top
+        # of the flat group_allow_from / chat-level allowlist above — chat-
+        # level allowlisting (allowed_chats/group_allowed_chats) is unchanged;
+        # when groups.<chatId> is present for this chat, the sender must ALSO
+        # be listed in its allow_from. An entry present with allow_from: []
+        # fails closed for that chat (blocks everyone), not "ignore this key".
+        # When groups.<chatId> is absent for the chat, this gate is a no-op
+        # and the decision above (or the fallback chain below) stands.
+        if chat_type in ("group", "forum", "channel"):
+            group_cfg = self._resolve_group_cfg(source.chat_id)
+            if group_cfg is not None:
+                per_chat_allow = _coerce_allow_set(
+                    group_cfg.get("allow_from") if isinstance(group_cfg, dict) else None
+                )
+                per_chat_authorized = user_id in per_chat_allow or "*" in per_chat_allow
+                if authorized is None:
+                    authorized = per_chat_authorized
+                else:
+                    authorized = authorized and per_chat_authorized
+
         # Test/custom injection only. The class method named
         # _is_callback_user_authorized is for inline button callbacks and must
         # not be treated as a user-id-only shortcut for real messages — only
@@ -1490,6 +1512,30 @@ class TelegramAdapter(BasePlatformAdapter):
             return True
         # Unauthorized DM that the gateway would pair: forward so pairing can run.
         return self._should_pass_unauthorized_dm_for_pairing(source)
+
+    def _resolve_group_cfg(self, chat_id: Optional[str]) -> Optional[Dict[str, Any]]:
+        """Resolve ``extra.groups.<chat_id>`` config for a chat.
+
+        Mirrors WeCom's ``WeComAdapter._resolve_group_cfg``: reads
+        ``config.extra["groups"]`` as ``Dict[chatId, {"allow_from": [...]}]``
+        (see #992a463a / uss-platform #2353 §17 slice 4/6). Returns ``None``
+        when ``groups`` is absent/not a dict or the chat has no entry — the
+        caller treats ``None`` as "no additional gate applies", distinct from
+        an explicit ``{}``/``{"allow_from": []}`` entry which fails closed.
+        """
+        groups = self.config.extra.get("groups")
+        if not isinstance(groups, dict):
+            return None
+        normalized_chat_id = str(chat_id or "").strip()
+        if not normalized_chat_id:
+            return None
+        if normalized_chat_id in groups and isinstance(groups[normalized_chat_id], dict):
+            return groups[normalized_chat_id]
+        lowered = normalized_chat_id.lower()
+        for key, value in groups.items():
+            if isinstance(key, str) and key.lower() == lowered and isinstance(value, dict):
+                return value
+        return None
 
     @classmethod
     def _metadata_thread_id(cls, metadata: Optional[Dict[str, Any]]) -> Optional[str]:

--- a/tests/gateway/test_telegram_auth_check.py
+++ b/tests/gateway/test_telegram_auth_check.py
@@ -460,3 +460,80 @@ def test_per_chat_groups_allow_from_does_not_apply_to_dms():
 
     msg = _make_message(from_user_id=111, chat_id=111, chat_type="dm")
     assert adapter._is_user_authorized_from_message(msg) is True
+
+
+# ---------------------------------------------------------------------------
+# Regression: groups.<chatId>.allow_from must never bypass the chat-level
+# allowed_chats/group_allowed_chats gate (t_450b1946 / uss-platform #2353
+# §17 slice 4/6 follow-up). Confirmed bug: PR-97104 let the per-chat sender
+# gate independently decide `authorized` before the chat-level allowlist
+# was consulted, so a sender listed in groups.<chatId>.allow_from could
+# speak in a chat that was never allowlisted at the chat level at all.
+# Mirrors WeCom's _is_group_allowed ordering: chat-level resolves FIRST,
+# per-chat sender filter applies only as an additional AND on top of it.
+# ---------------------------------------------------------------------------
+
+
+def test_per_chat_allow_from_does_not_bypass_chat_level_allowed_chats():
+    """Sender matches groups.<chatId>.allow_from but the chat itself is not
+    in allowed_chats -> must be REJECTED, not authorized.
+
+    Exact repro from the task: allowed_chats excludes -100999, but
+    groups.-100999.allow_from lists sender 222 -- 222 must still be
+    rejected because the chat never passed the chat-level gate.
+    """
+    adapter = _make_adapter(
+        allowed_chats=["-100111"],
+        groups={"-100999": {"allow_from": ["222"]}},
+    )
+
+    msg = _make_message(from_user_id=222, chat_id=-100999, chat_type="group")
+    assert adapter._is_user_authorized_from_message(msg) is False
+
+
+def test_per_chat_allow_from_does_not_bypass_group_allowed_chats():
+    """Same bypass, but via the runner-facing group_allowed_chats gate
+    instead of the response-facing allowed_chats gate.
+    """
+    adapter = _make_adapter(
+        group_allowed_chats=["-100111"],
+        groups={"-100999": {"allow_from": ["222"]}},
+    )
+
+    msg = _make_message(from_user_id=222, chat_id=-100999, chat_type="group")
+    assert adapter._is_user_authorized_from_message(msg) is False
+
+
+def test_chat_level_allowed_sender_level_rejected_is_still_rejected():
+    """Inverse: chat-level allowlist accepts the chat, but the sender fails
+    the per-chat groups.<chatId>.allow_from filter -> must be REJECTED.
+
+    Exercises the real chat-level path (not a stub runner that never gets
+    called): allowed_chats explicitly includes -100123, so chat-level
+    resolves True, but sender 111 is not in groups.-100123.allow_from.
+    """
+    adapter = _make_adapter(
+        allowed_chats=["-100123"],
+        groups={"-100123": {"allow_from": ["222"]}},
+    )
+
+    msg = _make_message(from_user_id=111, chat_id=-100123, chat_type="group")
+    assert adapter._is_user_authorized_from_message(msg) is False
+
+    # Listed sender in the allowed chat is still authorized.
+    msg_ok = _make_message(from_user_id=222, chat_id=-100123, chat_type="group")
+    assert adapter._is_user_authorized_from_message(msg_ok) is True
+
+
+def test_per_chat_allow_from_bypass_blocked_even_with_flat_group_allow_from_matching():
+    """Belt-and-suspenders: even when the flat group_allow_from gate would
+    have separately authorized the sender, an excluded chat still rejects.
+    """
+    adapter = _make_adapter(
+        allowed_chats=["-100111"],
+        group_allow_from=["222"],
+        groups={"-100999": {"allow_from": ["222"]}},
+    )
+
+    msg = _make_message(from_user_id=222, chat_id=-100999, chat_type="group")
+    assert adapter._is_user_authorized_from_message(msg) is False

--- a/tests/gateway/test_telegram_auth_check.py
+++ b/tests/gateway/test_telegram_auth_check.py
@@ -370,3 +370,93 @@ def test_multiplex_closure_handler_without_callback_falls_back_to_env(monkeypatc
     assert adapter._is_user_authorized_from_message(
         _make_message(from_user_id=555, chat_id=-100123, chat_type="group")
     ) is False
+
+
+# ---------------------------------------------------------------------------
+# groups.<chatId>.allow_from (#992a463a / uss-platform #2353 §17 slice 4/6)
+#
+# Mirrors WeCom's groups.<id>.allow_from (_resolve_group_cfg / _is_group_allowed,
+# see tests/gateway/test_config_driven_access_policy.py::
+# test_wecom_open_group_with_per_group_sender_allowlist_is_authorized).
+# This is an ADDITIONAL, independent gate on top of chat-level policy /
+# group_allow_from — not a replacement for it.
+# ---------------------------------------------------------------------------
+
+
+def test_per_chat_groups_allow_from_rejects_unlisted_sender():
+    """A chat with groups.<chatId>.allow_from set rejects a sender not in it."""
+    adapter = _make_adapter(groups={"-100123": {"allow_from": ["222"]}})
+
+    msg = _make_message(from_user_id=111, chat_id=-100123, chat_type="group")
+    assert adapter._is_user_authorized_from_message(msg) is False
+
+
+def test_per_chat_groups_allow_from_accepts_listed_sender():
+    """A chat with groups.<chatId>.allow_from set accepts a sender in it."""
+    adapter = _make_adapter(groups={"-100123": {"allow_from": ["222"]}})
+
+    msg = _make_message(from_user_id=222, chat_id=-100123, chat_type="group")
+    assert adapter._is_user_authorized_from_message(msg) is True
+
+
+def test_chat_with_no_groups_entry_is_unaffected():
+    """A chat absent from extra.groups is unaffected by this gate.
+
+    No group_allow_from / chat allowlist configured either, so the message
+    passes through the normal env-only fallback (no allowlist configured ->
+    default allow), proving the new key is a true no-op when absent.
+    """
+    adapter = _make_adapter(groups={"-100123": {"allow_from": ["222"]}})
+
+    # Different chat id -> no groups.<chatId> entry for it.
+    msg = _make_message(from_user_id=999, chat_id=-100999, chat_type="group")
+    assert adapter._is_user_authorized_from_message(msg) is True
+
+
+def test_per_chat_groups_allow_from_empty_list_blocks_everyone_in_that_chat():
+    """allow_from: [] fails closed for that specific chat (blocks everyone)."""
+    adapter = _make_adapter(groups={"-100123": {"allow_from": []}})
+
+    assert adapter._is_user_authorized_from_message(
+        _make_message(from_user_id=111, chat_id=-100123, chat_type="group")
+    ) is False
+    assert adapter._is_user_authorized_from_message(
+        _make_message(from_user_id=222, chat_id=-100123, chat_type="group")
+    ) is False
+
+    # A different, unconfigured chat is not affected by the fail-closed entry.
+    assert adapter._is_user_authorized_from_message(
+        _make_message(from_user_id=333, chat_id=-100999, chat_type="group")
+    ) is True
+
+
+def test_per_chat_groups_allow_from_is_additional_to_flat_group_allow_from():
+    """groups.<chatId>.allow_from ANDs with the flat group_allow_from gate.
+
+    Sender must pass BOTH: present in group_allow_from AND (when the chat has
+    a groups.<chatId> entry) present in that chat's allow_from.
+    """
+    adapter = _make_adapter(
+        group_allow_from=["111", "222"],
+        groups={"-100123": {"allow_from": ["222"]}},
+    )
+
+    # In group_allow_from but not in the per-chat allow_from -> rejected.
+    assert adapter._is_user_authorized_from_message(
+        _make_message(from_user_id=111, chat_id=-100123, chat_type="group")
+    ) is False
+    # In both -> authorized.
+    assert adapter._is_user_authorized_from_message(
+        _make_message(from_user_id=222, chat_id=-100123, chat_type="group")
+    ) is True
+
+
+def test_per_chat_groups_allow_from_does_not_apply_to_dms():
+    """The groups.<chatId> gate only applies to group/forum/channel chats."""
+    adapter = _make_adapter(
+        allow_from=["111"],
+        groups={"111": {"allow_from": ["222"]}},  # keyed by chat id, irrelevant to DM auth
+    )
+
+    msg = _make_message(from_user_id=111, chat_id=111, chat_type="dm")
+    assert adapter._is_user_authorized_from_message(msg) is True


### PR DESCRIPTION
## Context

Follow-up from uss-platform #2353 §17 slice 4/6 (kanban t_80c03fc9, operatord PR-460 on `uss-ai-agents`).

USS emits `groupAccess.telegram[chatId].allowedUserIds` on the desired-state document. operatord (PR-460) parses this and renders it into the Hermes-managed `config.yaml` as:

```yaml
platforms:
  telegram:
    extra:
      groups:
        "-100123456":
          allow_from: ["111", "222"]
```

This is the exact shape the WeCom adapter already reads via `groups.<id>.allow_from` (`plugins/platforms/wecom/adapter.py`).

## The gap

Telegram's adapter had no equivalent — `extra.groups` was never read, so operatord's rendered config was inert on disk for Telegram.

## What changed

- `plugins/platforms/telegram/adapter.py`: added `TelegramAdapter._resolve_group_cfg(chat_id)` mirroring WeCom's helper (exact match by chat id, then case-insensitive fallback).
- `_is_user_authorized_from_message`: for `chat_type in ("group", "forum", "channel")`, additionally gates on `groups.<chatId>.allow_from` when present for that chat — independent of and in addition to the existing flat `group_allow_from`. `allow_from: []` fails closed for that specific chat (blocks everyone there); an absent `groups.<chatId>` entry is a no-op (existing behavior unchanged).

## Out of scope

- No changes to `uss-ai-agents`/operatord (already shipped in PR-460) or uss-platform (already shipped, slice 4/6).
- No change to WeCom's own implementation — only mirroring its pattern for Telegram.

## Verification

Real pytest run (`/opt/hermes/venv`):

```
tests/gateway/test_telegram_auth_check.py .................... 19 passed (6 new)
tests/gateway/test_telegram_group_gating.py ..................  unmodified, still passing
tests/gateway/test_config_driven_access_policy.py .............  unmodified, still passing
=> 95 passed

tests/gateway -k telegram => 679 passed, 1 pre-existing skip
```

New tests cover: unauthorized sender in a chat with `groups.<chatId>.allow_from` rejected; authorized sender accepted; chat with no `groups.<chatId>` entry unaffected; `allow_from: []` blocks everyone in that specific chat without affecting other chats; AND-composition with the flat `group_allow_from` gate; DM chats unaffected by the per-chat groups key.