### PR TITLE
docs(slack): MPIM ids are C-prefixed in modern workspaces — drop the 'starts with G' claim

### DIFF
--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -656,7 +656,7 @@ Slack supports both patterns: `@mention` required to start a conversation by def
 :::
 
 :::caution Group DMs (MPIMs) are shared surfaces, not 1:1 DMs
-A **1:1 direct message** is a private conversation with one person, so it is mention-exempt. A **group DM (MPIM / multi-person DM)** is a *shared surface* — multiple people can see and trigger the bot — so it obeys the same operator controls as a channel: `require_mention`, `strict_mention`, `free_response_channels`, and `allowed_channels` all apply, and the bot only adds `:eyes:`/`:white_check_mark:` reactions when it is actually `@mentioned`. To let the bot respond freely in a specific group DM, add its channel ID (starts with `G`) to `free_response_channels`.
+A **1:1 direct message** is a private conversation with one person, so it is mention-exempt. A **group DM (MPIM / multi-person DM)** is a *shared surface* — multiple people can see and trigger the bot — so it obeys the same operator controls as a channel: `require_mention`, `strict_mention`, `free_response_channels`, and `allowed_channels` all apply, and the bot only adds `:eyes:`/`:white_check_mark:` reactions when it is actually `@mentioned`. To let the bot respond freely in a specific group DM, add its channel ID to `free_response_channels`. (Copy the real ID rather than assuming a prefix: modern workspaces mint MPIM IDs starting with `C`, same as regular channels; only legacy workspaces use `G`.)
 :::
 
 #### Which mention option do I want?
@@ -778,7 +778,7 @@ If this target passes but a live workspace still misroutes messages, investigate
 
 Restrict the bot to a fixed set of Slack channels — useful when the bot is invited to many channels but should only respond in a few. When set, messages from channels NOT in this list are **silently ignored**, even if the bot is `@mentioned`.
 
-**1:1 DMs are exempt** from this filter, so authorized users can always reach the bot in a direct message. **Group DMs (MPIMs) are not exempt** — like channels, an MPIM must be on the allowlist (its ID starts with `G`) or its messages are dropped.
+**1:1 DMs are exempt** from this filter, so authorized users can always reach the bot in a direct message. **Group DMs (MPIMs) are not exempt** — like channels, an MPIM must be on the allowlist or its messages are dropped. (Modern workspaces mint MPIM IDs starting with `C`, same as regular channels; only legacy workspaces use `G` — copy the actual ID.)
 
 ```yaml
 slack:


### PR DESCRIPTION
## What does this PR do?

Corrects a stale claim in the Slack messaging docs. `website/docs/user-guide/messaging/slack.md` states twice (the group-DM paragraph in the mention-gating section, and the allowlist section) that a group DM's (MPIM's) channel ID "starts with `G`". That was true of legacy Slack workspaces; modern workspaces mint MPIM conversation IDs starting with `C`, the same prefix as regular channels. The stale claim isn't harmless filler: an operator configuring `allowed_channels` / `free_response_channels` copies the MPIM's real `C…` ID, and the doc actively confirms the wrong conclusion ("this must not be the group DM's ID"). Observed on a production Slack gateway (v0.20.x), where a `C`-prefixed MPIM plus this doc line produced a real allowlist misconfiguration before the ID was traced.

The Slack adapter code is prefix-agnostic (no `startswith("G")` routing at `v2026.8.27`), so this is a docs-only change. The zh-Hans translation does not contain the prefix claim, so no translation update is needed.

## Related Issue

None — docs-only correction, filed directly per CONTRIBUTING's documentation priority. Happy to open a tracking issue if preferred.

## Type of Change

- [x] 📝 Documentation update

## Changes Made

- `website/docs/user-guide/messaging/slack.md` — two sentences: drop the "starts with `G`" assertion, tell operators to copy the actual ID, and note that modern workspaces use `C`-prefixed MPIM IDs (legacy: `G`).

## Testing

- Docs-only; verified the two edited sentences render as plain Markdown and no other occurrence of the claim remains in `website/docs/` (`grep -rn "starts with \`G\`" website/docs/` → none).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012XHcYB39VoUXkz5x5TgTrQ
