### PR TITLE
fix(xai): restore runtime OAuth fallback for direct tools

### DIFF
--- a/tests/tools/test_xai_http_credentials.py
+++ b/tests/tools/test_xai_http_credentials.py
@@ -88,6 +88,84 @@ def _install_fake_oauth_pool(monkeypatch, oauth_token: str) -> None:
     monkeypatch.setattr("agent.credential_pool.load_pool", _fake_load_pool)
 
 
+def _install_empty_oauth_pool(monkeypatch) -> None:
+    class _EmptyPool:
+        def select(self):
+            return None
+
+        def try_refresh_matching(self, _hint):
+            return None
+
+    monkeypatch.setattr(
+        "agent.credential_pool.load_pool", lambda _provider_id: _EmptyPool()
+    )
+
+
+def test_default_oauth_uses_runtime_singleton_when_pool_has_no_selectable_entry(
+    monkeypatch,
+):
+    from tools.xai_http import resolve_xai_http_credentials
+
+    monkeypatch.delenv("XAI_API_KEY", raising=False)
+    monkeypatch.setattr(
+        "tools.xai_http.get_env_value", lambda name, default=None: default
+    )
+    _install_empty_oauth_pool(monkeypatch)
+    monkeypatch.setattr(
+        "hermes_cli.auth.resolve_xai_oauth_runtime_credentials",
+        lambda **_: {
+            "provider": "xai-oauth",
+            "api_key": "singleton-oauth-token",
+            "base_url": "https://api.x.ai/v1",
+        },
+    )
+
+    creds = resolve_xai_http_credentials()
+
+    assert creds == {
+        "provider": "xai-oauth",
+        "api_key": "singleton-oauth-token",
+        "base_url": "https://api.x.ai/v1",
+    }
+
+
+def test_force_refresh_does_not_resurrect_runtime_singleton(monkeypatch):
+    from tools.xai_http import resolve_xai_http_credentials
+
+    monkeypatch.delenv("XAI_API_KEY", raising=False)
+    monkeypatch.setattr(
+        "tools.xai_http.get_env_value", lambda name, default=None: default
+    )
+    monkeypatch.setattr(
+        "tools.tool_backend_helpers.resolve_provider_secret",
+        lambda *_args, **_kwargs: "",
+    )
+    _install_empty_oauth_pool(monkeypatch)
+    singleton_calls = []
+
+    def _record_singleton_call(**kwargs):
+        singleton_calls.append(kwargs)
+        return {
+            "provider": "xai-oauth",
+            "api_key": "rejected-token",
+            "base_url": "https://api.x.ai/v1",
+        }
+
+    monkeypatch.setattr(
+        "hermes_cli.auth.resolve_xai_oauth_runtime_credentials",
+        _record_singleton_call,
+    )
+
+    creds = resolve_xai_http_credentials(
+        force_refresh=True,
+        api_key_hint="rejected-token",
+    )
+
+    assert creds["provider"] == "xai"
+    assert creds["api_key"] == ""
+    assert singleton_calls == []
+
+
 def test_prefer_api_key_wins_over_available_oauth(monkeypatch):
     from tools.xai_http import resolve_xai_http_credentials
 

--- a/tools/xai_http.py
+++ b/tools/xai_http.py
@@ -375,6 +375,29 @@ def resolve_xai_http_credentials(
     except Exception:
         pass
 
+    # Keep ordinary direct-tool resolution aligned with the main runtime's
+    # profile-aware singleton fallback.  Never take this path after a reactive
+    # refresh: the pool may have quarantined the bearer rejected by the server.
+    if not force_refresh:
+        try:
+            import hermes_cli.auth as auth_mod
+
+            singleton = auth_mod.resolve_xai_oauth_runtime_credentials(
+                force_refresh=False,
+            )
+            access_token = str(singleton.get("api_key") or "").strip()
+            if access_token:
+                return {
+                    "provider": "xai-oauth",
+                    "api_key": access_token,
+                    "base_url": str(
+                        singleton.get("base_url")
+                        or auth_mod.DEFAULT_XAI_OAUTH_BASE_URL
+                    ).strip().rstrip("/"),
+                }
+        except Exception:
+            pass
+
     try:
         from tools.tool_backend_helpers import resolve_provider_secret
 


### PR DESCRIPTION
## What does this PR do?

Direct xAI tools resolve OAuth through the credential pool before falling back to an API key. If `pool.select()` has no selectable entry, the resolver currently skips the profile-aware singleton path used by the main Grok runtime. This can hide `x_search` even while Grok inference works with the same profile.

Fall back to `resolve_xai_oauth_runtime_credentials()` during ordinary credential resolution. The fallback is deliberately disabled for `force_refresh=True`: after an endpoint rejects a bearer, the pool may quarantine it, and the singleton must not resurrect that rejected credential.

This is a narrower, profile-isolated follow-up to the credential-pool/singleton mismatch discussed in #43513 and fixed earlier at the auth-store chokepoint by #46614. A later multi-account change (`34837597d2`) made direct xAI tools select the pool directly, reintroducing the no-selectable-entry gap at this call site.

## Related Issue

Related: #43513, #46614

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/xai_http.py`: use the active profile's runtime OAuth singleton when normal pool selection yields no bearer.
- `tools/xai_http.py`: preserve quarantine semantics by never taking that fallback after `force_refresh=True`.
- `tests/tools/test_xai_http_credentials.py`: cover both the recovery path and the no-resurrection invariant.

## How to Test

1. Run `scripts/run_tests.sh tests/tools/test_xai_http_credentials.py`.
2. Run `scripts/run_tests.sh tests/tools/test_x_search_tool.py`.
3. With a profile where Grok inference works but the pool has no selectable entry, start Hermes with `HERMES_SAFE_MODE=1`, enable only `x_search`, and verify a read-only query returns `credential_source: xai-oauth`, the configured model, and a direct X status URL.

Local verification:

- Regression test demonstrated RED before the implementation: 1 failed, 1 passed.
- Credential resolver tests: 8 passed.
- x_search tool tests: 11 passed.
- `uvx ruff check .`: passed.
- `uvx ty check --output-format concise tools/xai_http.py`: passed.
- `python scripts/check-windows-footguns.py --all`: passed (1,022 files scanned).
- Live read-only x_search with user plugins disabled (`HERMES_SAFE_MODE=1`): succeeded with `credential_source=xai-oauth` and `model=grok-build-0.1`.
- Full local `scripts/run_tests.sh`: 83 failures in 18 unrelated files. Re-running exactly those 18 files on a clean `origin/main` worktree produced the identical 83 failures; this diff introduced no additional failing file or test. CI remains authoritative on a clean runner.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — full local suite has the baseline failures documented above; targeted tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Arch Linux, Python 3.11.15

### Documentation & Housekeeping

- [x] Documentation update: N/A — no user-facing behavior or configuration changes
- [x] `cli-config.yaml.example`: N/A — no config changes
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A — no architecture or workflow changes
- [x] Cross-platform impact considered — pure credential-selection logic; Windows footgun checker passes
- [x] Tool descriptions/schemas: N/A — schema and intended x_search behavior are unchanged

## Screenshots / Logs

Not applicable. Verification results are included above; no credentials or token material are logged.
