### PR TITLE
feat(commands): establish canonical gateway command bindings

### DIFF
--- a/gateway/command_bindings.py
+++ b/gateway/command_bindings.py
@@ -1,0 +1,138 @@
+"""Canonical gateway slash-command handler bindings.
+
+This module is deliberately smaller than the legacy gateway command owner.  It
+owns the *binding* from canonical command identity to the gateway callable name;
+it does not own command spelling, aliases, help text, or busy policy.  Those
+remain in :mod:`hermes_cli.commands` until the versioned command contract lands.
+
+The compatibility fallback from ``command_id`` to ``CommandDef.name`` is
+intentional: current main does not yet expose the PR-1 stable-id field.  Once
+that field exists, the same binding objects automatically key themselves by the
+stable identity without another gateway table.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+from hermes_cli.commands import COMMAND_REGISTRY, CommandDef, resolve_command
+
+
+# Handler names that cannot be derived mechanically from the canonical command
+# spelling.  Keep this map tiny: every ordinary command binds by convention.
+_HANDLER_NAME_OVERRIDES: dict[str, str] = {
+    "new": "_handle_reset_command",
+    "sethome": "_handle_set_home_command",
+}
+
+
+def _handler_name(command: CommandDef) -> str:
+    return _HANDLER_NAME_OVERRIDES.get(
+        command.name,
+        f"_handle_{command.name.replace('-', '_')}_command",
+    )
+
+
+def _command_id(command: CommandDef) -> str:
+    """Return the canonical semantic identity available on this source tree."""
+    value = getattr(command, "command_id", None)
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return command.name
+
+
+@dataclass(frozen=True, slots=True)
+class GatewayCommandBinding:
+    """One gateway execution binding for one canonical command identity."""
+
+    command_id: str
+    canonical_name: str
+    handler_name: str
+    busy_handler_name: str | None
+    shared_execute: str | None
+
+    @classmethod
+    def from_command(cls, command: CommandDef) -> "GatewayCommandBinding":
+        busy_handler = command.busy_handler
+        return cls(
+            command_id=_command_id(command),
+            canonical_name=command.name,
+            handler_name=_handler_name(command),
+            busy_handler_name=(
+                f"_busy_{busy_handler.replace('-', '_')}_command"
+                if busy_handler
+                else None
+            ),
+            shared_execute=command.execute,
+        )
+
+
+def _gateway_candidate(command: CommandDef) -> bool:
+    """Return whether a core command can be projected to a gateway context.
+
+    ``gateway_config_gate`` is a conditional gateway projection even when the
+    command is otherwise marked CLI-only, so it remains part of the candidate
+    binding set.  Runtime availability still belongs to policy, not this table.
+    """
+    return not command.cli_only or command.gateway_only or bool(command.gateway_config_gate)
+
+
+def build_gateway_bindings(
+    commands: Iterable[CommandDef] = COMMAND_REGISTRY,
+) -> tuple[GatewayCommandBinding, ...]:
+    """Build the immutable canonical gateway binding projection.
+
+    Duplicate semantic identities fail closed.  Alias tokens never create new
+    bindings because aliases resolve through ``resolve_command`` to the same
+    canonical ``CommandDef`` first.
+    """
+    bindings: list[GatewayCommandBinding] = []
+    seen: set[str] = set()
+    for command in commands:
+        if not _gateway_candidate(command):
+            continue
+        binding = GatewayCommandBinding.from_command(command)
+        key = binding.command_id.casefold()
+        if key in seen:
+            raise ValueError(f"duplicate gateway command identity: {binding.command_id}")
+        seen.add(key)
+        bindings.append(binding)
+    return tuple(bindings)
+
+
+GATEWAY_COMMAND_BINDINGS: tuple[GatewayCommandBinding, ...] = build_gateway_bindings()
+_BINDINGS_BY_ID = {binding.command_id.casefold(): binding for binding in GATEWAY_COMMAND_BINDINGS}
+_BINDINGS_BY_NAME = {
+    binding.canonical_name.casefold(): binding for binding in GATEWAY_COMMAND_BINDINGS
+}
+
+
+def resolve_gateway_command_binding(token: str) -> GatewayCommandBinding | None:
+    """Resolve a typed name/alias to exactly one canonical gateway binding."""
+    command = resolve_command(token)
+    if command is None or not _gateway_candidate(command):
+        return None
+    command_id = _command_id(command).casefold()
+    binding = _BINDINGS_BY_ID.get(command_id)
+    if binding is not None:
+        return binding
+    # Defensive compatibility for a partially upgraded process in which the
+    # registry object gained an id after this module's immutable snapshot was
+    # created.  Never guess across canonical names: resolve only the same owner.
+    return _BINDINGS_BY_NAME.get(command.name.casefold())
+
+
+def bind_gateway_handler(runner: object, token: str):
+    """Return the runner callable for a canonical gateway command, or ``None``.
+
+    Shared ``execute`` commands are intentionally not synthesized here.  Their
+    execution owner is the shared executor/dispatcher; this function only binds
+    gateway-owned handlers.  Missing attributes fail closed rather than falling
+    through to prompt text.
+    """
+    binding = resolve_gateway_command_binding(token)
+    if binding is None:
+        return None
+    handler = getattr(runner, binding.handler_name, None)
+    return handler if callable(handler) else None

--- a/tests/gateway/test_command_bindings.py
+++ b/tests/gateway/test_command_bindings.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from gateway.command_bindings import (
+    GATEWAY_COMMAND_BINDINGS,
+    bind_gateway_handler,
+    build_gateway_bindings,
+    resolve_gateway_command_binding,
+)
+from gateway.slash_commands import GatewaySlashCommandsMixin
+from hermes_cli.commands import COMMAND_REGISTRY, resolve_command
+
+
+def test_aliases_resolve_to_the_same_gateway_binding() -> None:
+    for command in COMMAND_REGISTRY:
+        canonical = resolve_gateway_command_binding(command.name)
+        if canonical is None:
+            continue
+        for alias in command.aliases:
+            assert resolve_gateway_command_binding(alias) is canonical
+            assert resolve_gateway_command_binding(f"/{alias}") is canonical
+            assert resolve_gateway_command_binding(alias.upper()) is canonical
+
+
+def test_cli_only_commands_do_not_gain_gateway_bindings() -> None:
+    assert resolve_gateway_command_binding("clear") is None
+    assert resolve_gateway_command_binding("/history") is None
+
+
+def test_irregular_gateway_handler_names_are_explicit() -> None:
+    new = resolve_gateway_command_binding("new")
+    reset = resolve_gateway_command_binding("reset")
+    sethome = resolve_gateway_command_binding("sethome")
+
+    assert new is not None
+    assert reset is new
+    assert new.handler_name == "_handle_reset_command"
+    assert sethome is not None
+    assert sethome.handler_name == "_handle_set_home_command"
+
+
+def test_ordinary_handler_names_are_derived_from_canonical_name() -> None:
+    usage = resolve_gateway_command_binding("usage")
+    reload_mcp = resolve_gateway_command_binding("reload-mcp")
+
+    assert usage is not None
+    assert usage.handler_name == "_handle_usage_command"
+    assert reload_mcp is not None
+    assert reload_mcp.handler_name == "_handle_reload_mcp_command"
+
+
+def test_binding_projection_has_one_casefolded_semantic_identity() -> None:
+    identities = [binding.command_id.casefold() for binding in GATEWAY_COMMAND_BINDINGS]
+    assert len(identities) == len(set(identities))
+
+
+def test_duplicate_semantic_identity_fails_closed() -> None:
+    source = resolve_command("usage")
+    assert source is not None
+    duplicate = replace(source, name="USAGE")
+
+    with pytest.raises(ValueError, match="duplicate gateway command identity"):
+        build_gateway_bindings((source, duplicate))
+
+
+def test_gateway_binding_resolves_real_mixin_handlers_without_prompt_fallback() -> None:
+    runner = object.__new__(GatewaySlashCommandsMixin)
+
+    for token in ("new", "reset", "usage", "status", "reload-mcp", "sethome"):
+        binding = resolve_gateway_command_binding(token)
+        assert binding is not None
+        handler = bind_gateway_handler(runner, token)
+        assert callable(handler), (token, binding.handler_name)
+
+    assert bind_gateway_handler(runner, "definitely-not-a-command") is None
+
+
+def test_shared_executor_metadata_stays_attached_to_the_canonical_binding() -> None:
+    shared = [command for command in COMMAND_REGISTRY if command.execute]
+    assert shared, "expected current main to expose at least one shared command executor"
+
+    for command in shared:
+        binding = resolve_gateway_command_binding(command.name)
+        if binding is not None:
+            assert binding.shared_execute == command.execute


### PR DESCRIPTION
## What does this PR do?

Establishes the first canonical **gateway execution-binding seam** for the unified slash-command architecture in #96692.

Hermes already has a central `CommandDef` registry, but gateway execution is still reconstructed from typed spellings and local handler-name conventions. This PR turns that reconstruction into one bounded, immutable projection:

```text
typed name or alias
  → central CommandDef resolution
  → canonical gateway binding
  → exact GatewayRunner handler
```

The change is deliberately narrow and independently landable on current `main`. It does not create a second command registry, does not alter command behavior, and does not modify the active gateway godfiles while many open PRs still own narrow fixes in them.

The new binding contract:

- creates exactly one `GatewayCommandBinding` for each gateway-capable canonical `CommandDef`;
- resolves aliases through `hermes_cli.commands.resolve_command()` before binding, so `/new` and `/reset` settle on the same object;
- derives ordinary handler names mechanically and keeps only genuinely irregular mappings explicit;
- fails closed on duplicate semantic identities;
- returns `None` for unknown commands or missing handlers instead of allowing a prompt-text fallback;
- preserves any existing shared `CommandDef.execute` owner rather than reimplementing it in the gateway; and
- automatically adopts `CommandDef.command_id` when the versioned-schema PR lands, while using the canonical name as the current-main compatibility identity.

This is the dependency-free portion of PR4 that is truthful on current `main`. The remaining gateway migration—typed `CommandInvocation`, policy/dispatcher settlement, stable-ID activation, and physical decomposition of `gateway/slash_commands.py`—must compose onto the prerequisite PR1/PR2 ABIs rather than inventing parallel placeholders here.

### Exact submitted object

- **Base:** `c30ac90a92097058ddd6f9db3fa2e3182a7bfdcc`
- **Head:** `7d04b98f0c2c3d2201b4d96dc20d7f757a4995c1`
- **Tree:** `5184828476f42d81355ab66188c02396cea1eaac`
- **Shape:** one commit, two added files, one ahead / zero behind
- **Production call-site rewrites:** zero
- **Review threads:** zero unresolved
- **GitHub state:** open, non-draft, mergeable

## Related Issue

Part of #96692.

Architecture and provenance interlocks:

- #97102 — PR0 inventory and executable characterization.
- #96791 by `OutThisLife` — merged current-main owner of registry-backed Desktop metadata and `commands.catalog`; this PR composes with that ownership and does not duplicate it.
- #96705 — closed design-provenance object for stable IDs and catalog fingerprints; not reused as a landing object.
- #95028 / #95101 — Authority Policy ABI interlock for later command-policy composition; not reconstructed here.

The live FILE-LIST and semantic scan included #96955, #96882, #96851, #96236, #96412, #85355, #96031, #84078, #94036, #95267, #54688, #94584, #94667, #94312, #94571, #42577, #93774, #92187, #92197, #89909, #84925, and #92530. None modifies either new path in this PR. This PR intentionally does not touch `gateway/slash_commands.py`, `gateway/run.py`, or `hermes_cli/commands.py`, preserving every active narrow owner and its provenance.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes a defect)
- [x] ✨ New feature (non-breaking architectural capability)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (new executable contract coverage)
- [x] ♻️ Refactor (no user-visible behavior change)
- [ ] 🎯 New skill

## Changes Made

- `gateway/command_bindings.py`
  - adds immutable `GatewayCommandBinding` records;
  - builds one canonical gateway projection from `COMMAND_REGISTRY`;
  - resolves aliases through the central resolver;
  - derives ordinary `_handle_<name>_command` ownership mechanically;
  - explicitly maps only `new → _handle_reset_command` and `sethome → _handle_set_home_command`;
  - carries `busy_handler` and shared-executor metadata without creating another semantic table;
  - fails closed on duplicate semantic identity; and
  - binds an exact callable from the live gateway runner without prompt fallback.
- `tests/gateway/test_command_bindings.py`
  - proves alias/object identity;
  - proves CLI-only commands do not acquire gateway bindings;
  - proves irregular and mechanically derived handler names;
  - proves case-folded semantic uniqueness and duplicate refusal;
  - proves bindings resolve against the real `GatewaySlashCommandsMixin`; and
  - proves shared-executor ownership remains attached to the canonical binding.

Both changed files are below the 2,000-line ceiling:

| Path | Lines |
|---|---:|
| `gateway/command_bindings.py` | 138 |
| `tests/gateway/test_command_bindings.py` | 88 |

## How to Test

Run the focused executable contract:

```bash
scripts/run_tests.sh tests/gateway/test_command_bindings.py -q
```

Run the repository-required Python checks covering this exact change:

```bash
ruff check gateway/command_bindings.py tests/gateway/test_command_bindings.py
python scripts/check-windows-footguns.py \
  gateway/command_bindings.py \
  tests/gateway/test_command_bindings.py
git diff --check c30ac90a92097058ddd6f9db3fa2e3182a7bfdcc...7d04b98f0c2c3d2201b4d96dc20d7f757a4995c1
```

Exact-head hosted acceptance on `7d04b98f0c2c3d2201b4d96dc20d7f757a4995c1`:

- [CI `33168799275`](https://github.com/NousResearch/hermes-agent/actions/runs/33168799275) — **SUCCESS**. Python tests, e2e, Windows-only, macOS-only, blocking Ruff, Ruff+ty diff, Windows footguns, attribution, common-ancestor integrity, OSV, supply-chain checks, and the required aggregate completed successfully; unrelated lanes skipped as expected.
- [Docker `33168798802`](https://github.com/NousResearch/hermes-agent/actions/runs/33168798802) — **SUCCESS**, including amd64 and arm64 image builds and integration tests.
- [Nix `33168798808`](https://github.com/NousResearch/hermes-agent/actions/runs/33168798808) — **SUCCESS**.

Current-main read-back remains the exact direct parent, `c30ac90a92097058ddd6f9db3fa2e3182a7bfdcc`. No historical, synthetic-merge, sibling-branch, or adjacent-object result is transferred to this head. The automatically triggered Label rerun workflow produced only skipped/cancelled bookkeeping objects; it is not a product execution gate and does not weaken the exact-head matrix above.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md).
- [x] My commit message follows [Conventional Commits](https://www.conventionalcommits.org/).
- [x] I searched the live PR/issue graph and performed a FILE-LIST scan before writing.
- [x] This PR contains only the gateway binding seam and its executable contract.
- [x] The focused test and full exact-head hosted Python matrix pass.
- [x] Tests cover every material behavior introduced by the change.
- [x] Linux, macOS, and Windows execution are represented in exact-head CI.
- [x] Every submitted commit is green; this PR contains one submitted commit.
- [x] Attribution and existing contributor provenance are preserved.
- [x] No modified or added file exceeds 2,000 lines.
- [x] There are zero unresolved review threads.

### Documentation & Housekeeping

- [x] User documentation is N/A; this introduces an internal binding ABI with no user-visible command change.
- [x] `cli-config.yaml.example` is N/A; no configuration key changes.
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A; no contributor workflow changes.
- [x] Cross-platform impact is covered by the exact-head Linux/macOS/Windows matrix.
- [x] Tool descriptions and schemas are N/A; no model-facing tool contract changes.
- [x] PR↔issue interlock is complete through #96692.

## Screenshots / Logs

No UI surface changes; screenshots are not applicable.

Exact publication object:

```text
base   c30ac90a92097058ddd6f9db3fa2e3182a7bfdcc
head   7d04b98f0c2c3d2201b4d96dc20d7f757a4995c1
tree   5184828476f42d81355ab66188c02396cea1eaac
shape  1 commit · 2 files · +226/-0 · 1 ahead/0 behind
CI     33168799275 SUCCESS
Docker 33168798802 SUCCESS
Nix    33168798808 SUCCESS
```