### PR TITLE
fix(browser): use Browser Use API v4

### DIFF
--- a/plugins/browser/browser_use/provider.py
+++ b/plugins/browser/browser_use/provider.py
@@ -48,7 +48,7 @@ logger = logging.getLogger(__name__)
 _pending_create_keys: Dict[str, str] = {}
 _pending_create_keys_lock = threading.Lock()
 
-_BASE_URL = "https://api.browser-use.com/api/v3"
+_BASE_URL = "https://api.browser-use.com/api/v4"
 _DEFAULT_MANAGED_TIMEOUT_MINUTES = 5
 _DEFAULT_MANAGED_PROXY_COUNTRY_CODE = "us"
 

--- a/tests/tools/test_strict_provider_selection.py
+++ b/tests/tools/test_strict_provider_selection.py
@@ -278,6 +278,7 @@ class TestBrowserUseStrictSelection:
             config = provider._get_config_or_none()
         assert config["managed_mode"] is False
         assert config["api_key"] == "bu-key"
+        assert config["base_url"] == "https://api.browser-use.com/api/v4"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

- Point direct Browser Use cloud browser lifecycle calls at the current V4 API.
- Cover the direct-provider base URL in the existing selection test.

## Why

The direct Browser Use provider still targeted /api/v3. Browser Use now documents /api/v4 as the current API and keeps the same direct browser control contract: POST /browsers returns id and cdpUrl, and PATCH /browsers/{id} with {"action":"stop"} stops it. The managed Nous gateway path is unchanged.

## Tests

- 59 focused tests passed through scripts/run_tests.sh.
- Ruff passed for both changed files.
- The Windows-footgun scan passed for both changed files.
- git diff --check passed.