### PR TITLE
feat(commands): establish desktop client command bindings

### DIFF
--- a/apps/desktop/src/lib/desktop-command-bindings.test.ts
+++ b/apps/desktop/src/lib/desktop-command-bindings.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  projectDesktopClientCommandBindings,
+  resolveDesktopClientCommandBinding
+} from './desktop-command-bindings'
+
+const LOCAL_COMMANDS = [
+  '/new',
+  '/branch',
+  '/yolo',
+  '/wake',
+  '/handoff',
+  '/profile',
+  '/skin',
+  '/title',
+  '/help',
+  '/browser',
+  '/journey',
+  '/model',
+  '/resume',
+  '/compress',
+  '/pet',
+  '/hatch',
+  '/save',
+  '/status'
+] as const
+
+describe('desktop client command bindings', () => {
+  it('projects only genuinely client-owned action, picker, and RPC surfaces', () => {
+    const bindings = projectDesktopClientCommandBindings(LOCAL_COMMANDS.map(name => ({ name })))
+
+    expect(bindings).toHaveLength(18)
+    expect(bindings.filter(binding => binding.surface.kind === 'action')).toHaveLength(14)
+    expect(bindings.filter(binding => binding.surface.kind === 'picker')).toHaveLength(2)
+    expect(bindings.filter(binding => binding.surface.kind === 'rpc')).toHaveLength(2)
+  })
+
+  it('uses command_id from v2 catalogs and the canonical name for mixed-version fallback', () => {
+    expect(resolveDesktopClientCommandBinding({ command_id: 'session.new', name: '/new' })).toMatchObject({
+      canonicalName: '/new',
+      commandId: 'session.new'
+    })
+    expect(resolveDesktopClientCommandBinding({ name: '/new' })).toMatchObject({
+      canonicalName: '/new',
+      commandId: '/new'
+    })
+  })
+
+  it('canonicalizes aliases through the existing resolver instead of owning another alias table', () => {
+    expect(resolveDesktopClientCommandBinding({ command_id: 'session.new', name: '/reset' })).toMatchObject({
+      canonicalName: '/new',
+      commandId: 'session.new',
+      surface: { action: 'new', kind: 'action' }
+    })
+    expect(resolveDesktopClientCommandBinding({ name: '/commands' })).toMatchObject({
+      canonicalName: '/help',
+      surface: { action: 'help', kind: 'action' }
+    })
+  })
+
+  it('does not claim server-executed, unavailable, or unknown commands', () => {
+    expect(resolveDesktopClientCommandBinding({ name: '/usage' })).toBeNull()
+    expect(resolveDesktopClientCommandBinding({ name: '/clear' })).toBeNull()
+    expect(resolveDesktopClientCommandBinding({ name: '/does-not-exist' })).toBeNull()
+  })
+
+  it('preserves dedicated RPC execution without copying catalog semantics', () => {
+    const binding = resolveDesktopClientCommandBinding({ command_id: 'session.save', name: '/save' })
+
+    expect(binding).not.toBeNull()
+    expect(binding && Object.keys(binding).sort()).toEqual(['canonicalName', 'commandId', 'surface'])
+    expect(binding?.surface.kind).toBe('rpc')
+
+    if (binding?.surface.kind !== 'rpc') {
+      return
+    }
+
+    expect(binding.surface.rpc).toBe('session.save')
+    expect(binding.surface.buildParams({ arg: '', command: '/save', name: 'save', sessionId: 's-1' })).toEqual({
+      session_id: 's-1'
+    })
+  })
+
+  it('returns immutable bindings, surfaces, and projections', () => {
+    const binding = resolveDesktopClientCommandBinding({ name: '/model' })
+    const bindings = projectDesktopClientCommandBindings([{ name: '/new' }, { name: '/model' }])
+
+    expect(Object.isFrozen(binding)).toBe(true)
+    expect(Object.isFrozen(binding?.surface)).toBe(true)
+    expect(Object.isFrozen(bindings)).toBe(true)
+  })
+
+  it('fails closed on duplicate stable identities', () => {
+    expect(() =>
+      projectDesktopClientCommandBindings([
+        { command_id: 'desktop.shared', name: '/new' },
+        { command_id: 'desktop.shared', name: '/model' }
+      ])
+    ).toThrow('Desktop command_id collision')
+  })
+
+  it('fails closed when aliases project the same canonical command twice', () => {
+    expect(() =>
+      projectDesktopClientCommandBindings([
+        { command_id: 'session.new', name: '/new' },
+        { command_id: 'session.reset', name: '/reset' }
+      ])
+    ).toThrow('Desktop canonical command collision')
+  })
+
+  it('rejects blank explicit command ids instead of silently falling back', () => {
+    expect(() => resolveDesktopClientCommandBinding({ command_id: '   ', name: '/new' })).toThrow('empty command_id')
+  })
+})

--- a/apps/desktop/src/lib/desktop-command-bindings.ts
+++ b/apps/desktop/src/lib/desktop-command-bindings.ts
@@ -1,0 +1,147 @@
+import {
+  canonicalDesktopSlashCommand,
+  type DesktopActionId,
+  type DesktopPickerId,
+  resolveDesktopCommand,
+  type SlashCommandBuildCtx
+} from './desktop-slash-commands'
+
+/**
+ * Stable catalog identity consumed by the desktop client projection.
+ *
+ * `command_id` is present on commands.catalog.v2. Older backends only expose
+ * `name`; the canonical slash name is therefore the mixed-version fallback.
+ */
+export interface DesktopCatalogCommandIdentity {
+  command_id?: string | null
+  name: string
+}
+
+/** Execution-only binding contributed by the desktop client. */
+export type DesktopClientCommandSurface =
+  | Readonly<{ action: DesktopActionId; kind: 'action' }>
+  | Readonly<{ kind: 'picker'; picker: DesktopPickerId }>
+  | Readonly<{
+      buildParams: (ctx: SlashCommandBuildCtx) => Record<string, unknown>
+      kind: 'rpc'
+      rpc: string
+      timeoutMs?: number
+    }>
+
+/**
+ * A client-owned execution binding. Catalog semantics and presentation stay
+ * with the server catalog; this object says only how Desktop fulfils the id.
+ */
+export interface DesktopClientCommandBinding {
+  readonly canonicalName: string
+  readonly commandId: string
+  readonly surface: DesktopClientCommandSurface
+}
+
+function projectClientSurface(command: string): DesktopClientCommandSurface | null {
+  const surface = resolveDesktopCommand(command)?.surface
+
+  switch (surface?.kind) {
+    case 'action':
+      return Object.freeze({ action: surface.action, kind: 'action' })
+    case 'picker':
+      return Object.freeze({ kind: 'picker', picker: surface.picker })
+    case 'rpc': {
+      const binding = {
+        buildParams: surface.buildParams,
+        kind: 'rpc' as const,
+        rpc: surface.rpc,
+        ...(surface.timeoutMs === undefined ? {} : { timeoutMs: surface.timeoutMs })
+      }
+
+      return Object.freeze(binding)
+    }
+    case 'exec':
+    case 'unavailable':
+    case undefined:
+      return null
+  }
+}
+
+function stableCommandId(identity: DesktopCatalogCommandIdentity, canonicalName: string): string {
+  if (identity.command_id == null) {
+    return canonicalName
+  }
+
+  const commandId = identity.command_id.trim()
+
+  if (!commandId) {
+    throw new Error(`Desktop command binding for "${canonicalName}" has an empty command_id`)
+  }
+
+  return commandId
+}
+
+/**
+ * Resolve one catalog row into a Desktop-owned client binding.
+ *
+ * Server-executed, unavailable, and unknown commands deliberately return null:
+ * they must settle through the shared command invocation path instead of being
+ * re-owned by this client projection.
+ */
+export function resolveDesktopClientCommandBinding(
+  identity: DesktopCatalogCommandIdentity
+): DesktopClientCommandBinding | null {
+  const canonicalName = canonicalDesktopSlashCommand(identity.name)
+  const surface = projectClientSurface(canonicalName)
+
+  if (!surface) {
+    return null
+  }
+
+  return Object.freeze({
+    canonicalName,
+    commandId: stableCommandId(identity, canonicalName),
+    surface
+  })
+}
+
+/**
+ * Project a catalog into immutable Desktop client bindings.
+ *
+ * Duplicate stable ids or duplicate canonical commands are authority
+ * collisions and fail closed rather than allowing array order to choose an
+ * execution owner.
+ */
+export function projectDesktopClientCommandBindings(
+  identities: readonly DesktopCatalogCommandIdentity[]
+): readonly DesktopClientCommandBinding[] {
+  const bindings: DesktopClientCommandBinding[] = []
+  const byCommandId = new Map<string, string>()
+  const byCanonicalName = new Map<string, string>()
+
+  for (const identity of identities) {
+    const binding = resolveDesktopClientCommandBinding(identity)
+
+    if (!binding) {
+      continue
+    }
+
+    const idOwner = byCommandId.get(binding.commandId)
+
+    if (idOwner) {
+      throw new Error(
+        `Desktop command_id collision: "${binding.commandId}" is bound by both "${idOwner}" and "${binding.canonicalName}"`
+      )
+    }
+
+    const canonicalOwner = byCanonicalName.get(binding.canonicalName)
+
+    if (canonicalOwner) {
+      throw new Error(
+        `Desktop canonical command collision: "${binding.canonicalName}" is projected by both "${canonicalOwner}" and "${identity.name}"`
+      )
+    }
+
+    byCommandId.set(binding.commandId, binding.canonicalName)
+    byCanonicalName.set(binding.canonicalName, identity.name)
+    bindings.push(binding)
+  }
+
+  return Object.freeze(bindings)
+}


### PR DESCRIPTION
## PR 5 — Desktop client binding seam

This is the independently landable Desktop slice under #96692. It introduces the execution-only projection that lets Desktop contribute genuinely client-owned actions, pickers, and dedicated RPC bindings without becoming another semantic command registry.

### Exact object

- Base/current-main parent: `4209d371aa1bb8840ce8447555bdd863a1a96c38`
- Head: `9a23b4951d6bfae7a57d59a99e1643dcf16e7293`
- Tree: `9db5fe6e45d1628522e9d2d1ee9bef71d6df4eef`
- One surviving commit; two added files; current main is the direct parent
- DCO trailer: `Signed-off-by: Axl Ibiza, MBA <andrexibiza@gmail.com>`
- CI `33269223135` — SUCCESS
- Docker `33269222838` — SUCCESS
- Nix `33269222850` — SUCCESS

### Changed paths

- `apps/desktop/src/lib/desktop-command-bindings.ts`
- `apps/desktop/src/lib/desktop-command-bindings.test.ts`

### Contract

- Projects only Desktop-owned `action`, `picker`, and dedicated `rpc` surfaces.
- Server-executed, unavailable, and unknown commands produce no client binding and therefore cannot be silently re-owned by Desktop.
- Accepts stable `command_id` from `commands.catalog.v2`.
- Uses the canonical slash name only as the explicit mixed-version fallback for older catalog peers.
- Resolves aliases through the existing canonical Desktop resolver; no second alias table is introduced.
- Binding objects contain execution ownership only: `commandId`, `canonicalName`, and `surface`. Catalog description, aliases, argument semantics, visibility, availability, and policy remain server-owned.
- Duplicate stable ids and duplicate canonical projections fail closed instead of allowing row order to choose an execution owner.
- Bindings, surfaces, and projected collections are immutable.

### Repair / release-object reconciliation

The original submitted head `601ac5f54238b4d42e5be153872114393ba5270b` was red in the JS/TS workspace checks. The defect was the named-import order in the new Desktop binding module under the repository's `perfectionist/sort-named-imports` rule. Rather than stack a green fix on a surviving red commit, this PR was rematerialized as the single current-main commit above with the import ordering corrected and product behavior unchanged. Exact-head JS/TS checks are now green inside CI `33269223135`.

### Collision / provenance scan

#96791 remains the merged current-main owner of registry-backed Desktop catalog metadata and dynamic command projection. This PR composes with that work and does not edit `desktop-slash-commands.ts`, the composer dispatcher, the Python registry, or the gateway dispatcher. The two submitted paths are disjoint from sibling command slices #97129 and #97143.

### Focused characterization

The test suite covers the complete current Desktop-local surface (14 actions, 2 pickers, 2 RPCs), stable-id and v1 fallback behavior, alias canonicalization, server/unavailable refusal, RPC parameter preservation, immutable settlement, blank-id rejection, duplicate-id rejection, and duplicate-canonical rejection.

Refs #96692