### PR TITLE
fix(agent): drop the api_content sidecar when stripping images from history (salvage #68811)

### DIFF
--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -416,8 +416,16 @@ def _strip_images_from_messages(messages: list) -> bool:
         practice this only hits synthetic image-only user messages appended
         for attachment delivery; real user turns always include text.
 
+    This runs on the persistent history as well as the per-call copy, so any
+    message it rewrites must also lose its ``api_content`` sidecar: the sidecar
+    carries the exact bytes previously sent — here, the images this strip
+    exists to remove — and the next turn substitutes it back into ``content``,
+    undoing the strip on the wire.
+
     Returns True if any image parts were removed.
     """
+    from agent.turn_context import drop_stale_api_content
+
     found = False
     to_delete = []
     for i, msg in enumerate(messages):
@@ -443,6 +451,8 @@ def _strip_images_from_messages(messages: list) -> bool:
                 # Synthetic image-only user/assistant message with no text;
                 # safe to drop.
                 to_delete.append(i)
+            # Content was rewritten — the pre-strip sidecar is now stale.
+            drop_stale_api_content(msg)
     for i in reversed(to_delete):
         del messages[i]
     return found

--- a/tests/run_agent/test_image_rejection_fallback.py
+++ b/tests/run_agent/test_image_rejection_fallback.py
@@ -173,3 +173,80 @@ class TestImageRejectionPhraseIsolation:
             assert self._matches(body) is True, f"false negative on: {body}"
 
 
+class TestStripImagesDropsStaleApiContent:
+    """The strip runs on the persistent history, not just the per-call copy.
+
+    ``api_content`` is the byte-stability sidecar: it holds the exact bytes
+    previously sent for a message, and the next turn substitutes it back into
+    ``content``. Leaving it in place on a message this function rewrote would
+    replay the images the strip just removed — and the recovery cannot re-fire,
+    because it sets ``_vision_supported = False`` and gates itself on that. The
+    session would then send rejected images on every subsequent turn.
+
+    Same contract the other content-rewrite paths follow (stale-confirmation
+    redaction in ``replay_cleanup``, compression rewrites, merge-into-tail):
+    "the cost is one cache boundary miss, never wrong content".
+    """
+
+    @staticmethod
+    def _wire(msg):
+        """What the next turn actually sends for this history message."""
+        from agent.turn_context import substitute_api_content
+
+        api_msg = msg.copy()
+        substitute_api_content(api_msg)
+        return api_msg["content"]
+
+    def _image_msg(self, sidecar="look<IMAGE BYTES SENT LAST TURN>"):
+        return {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "look"},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+            ],
+            "api_content": sidecar,
+        }
+
+    def test_stripped_message_loses_its_sidecar(self):
+        msgs = [self._image_msg()]
+        assert _strip_images_from_messages(msgs) is True
+        assert "api_content" not in msgs[0]
+
+    def test_next_turn_does_not_resend_the_stripped_images(self):
+        msgs = [self._image_msg()]
+        _strip_images_from_messages(msgs)
+
+        wire = self._wire(msgs[0])
+        assert "IMAGE BYTES" not in str(wire), (
+            "the stale sidecar replayed the images the strip removed"
+        )
+        assert wire == [{"type": "text", "text": "look"}]
+
+    def test_tool_placeholder_message_also_loses_its_sidecar(self):
+        """An image-only tool result becomes a placeholder — same rewrite."""
+        msgs = [
+            {
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "content": [{"type": "image_url", "image_url": {"url": "x"}}],
+                "api_content": "<SCREENSHOT BYTES>",
+            }
+        ]
+        assert _strip_images_from_messages(msgs) is True
+        assert "api_content" not in msgs[0]
+        assert "image content removed" in msgs[0]["content"]
+
+    def test_untouched_messages_keep_their_sidecar(self):
+        """Only rewritten messages pay the cache boundary — not the whole prefix."""
+        msgs = [
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": "no images here"}],
+                "api_content": "no images here<injected ctx>",
+            },
+            self._image_msg(),
+        ]
+        _strip_images_from_messages(msgs)
+
+        assert msgs[0]["api_content"] == "no images here<injected ctx>"
+        assert "api_content" not in msgs[1]


### PR DESCRIPTION
## Summary

Salvage of #68811 by @Frowtek — full credit to them for the diagnosis, fix, and tests.

`api_content` is the byte-stability sidecar (#67274): it holds the exact bytes previously sent for a message, and every turn substitutes it back into `content` when building `api_messages`. `_strip_images_from_messages` rewrites `content` on the **persistent history** (image-rejection recovery at `conversation_loop.py:4657`) but never dropped the sidecar, so the next turn's substitution replayed the very image bytes the strip removed. Worse, the recovery is gated on `_vision_supported`, which it just set `False` — it can never re-fire, so the session stays wedged on a 4xx it already knew how to fix.

Fix (contributor's, unchanged): call `drop_stale_api_content(msg)` on each message the strip rewrites, inside the function so every caller is covered — including today's copy-on-write image-corrupt path (`conversation_loop.py:4858`), where dropping the sidecar on the per-call copy is harmless and canonical history keeps both its images and its sidecar. Untouched messages keep their sidecar, so only rewritten messages pay a cache boundary miss.

## Changes

- `agent/message_sanitization.py`: `_strip_images_from_messages` now drops the stale `api_content` sidecar on every message whose content it rewrites (image-part removal and tool-placeholder replacement), per the `drop_stale_api_content` contract.
- `tests/run_agent/test_image_rejection_fallback.py`: new `TestStripImagesDropsStaleApiContent` (4 tests) — rewritten message loses its sidecar, next turn does not resend stripped images, tool-placeholder rewrite covered, untouched messages keep theirs.

## Validation

| Check | Result |
|---|---|
| `tests/run_agent/test_image_rejection_fallback.py` (incl. 4 new tests) | ✅ pass |
| `tests/run_agent/test_69078_image_corrupt_recovery.py` (pins copy-on-write contract) | ✅ 28 passed total, 2.36s |
| Live A/B repro (real functions, venv python) | ✅ before: sidecar retained → images resent; after: sidecar dropped |
| Stale-base gate (`git rev-list --count HEAD..origin/main`) | ✅ 0 |
| Attribution audit (`scripts/audit_pr_attribution.py --fix`) | ✅ all mapped (Frowtek) |

**Live repro:** on origin/main, after `_strip_images_from_messages` the history message keeps `api_content` and `substitute_api_content` sends `'look<IMAGE BYTES SENT LAST TURN>'` on the next turn; with this fix the sidecar is dropped and the next turn sends `[{'type': 'text', 'text': 'look'}]`.

## Infographic

![infographic](https://v3b.fal.media/files/b/0aa825dd/0Hb_4sNvN6PPK52SCCfsB_4nyQd76c.png)

