### PR TITLE
fix(sanitize): preserve assistant messages with tool_calls when stripping images (salvage #66714)

### DIFF
--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -412,9 +412,11 @@ def _strip_images_from_messages(messages: list) -> bool:
         with a plaintext placeholder, NOT deleted — deleting them would leave
         the paired ``tool_call_id`` on the prior assistant message unmatched,
         which providers reject with HTTP 400.
-      * Non-tool messages whose content becomes empty are dropped.  In
-        practice this only hits synthetic image-only user messages appended
-        for attachment delivery; real user turns always include text.
+      * Assistant messages carrying ``tool_calls`` are likewise replaced, not
+        deleted — dropping them would orphan their tool responses.
+      * Other messages whose content becomes empty are dropped.  In practice
+        this only hits synthetic image-only user messages appended for
+        attachment delivery; real user turns always include text.
 
     Returns True if any image parts were removed.
     """
@@ -435,13 +437,15 @@ def _strip_images_from_messages(messages: list) -> bool:
         if len(new_parts) < len(content):
             if new_parts:
                 msg["content"] = new_parts
-            elif msg.get("role") == "tool":
-                # Preserve tool_call_id linkage — providers require every
-                # assistant tool_call to have a matching tool response.
+            elif msg.get("role") == "tool" or msg.get("tool_calls"):
+                # Preserve message linkage — providers require every assistant
+                # tool_call to have a matching tool response, and an assistant
+                # message carrying tool_calls must survive even if its content
+                # was entirely images.
                 msg["content"] = "[image content removed — server does not support images]"
             else:
-                # Synthetic image-only user/assistant message with no text;
-                # safe to drop.
+                # Synthetic image-only user/assistant message with no text and
+                # no tool_calls; safe to drop.
                 to_delete.append(i)
     for i in reversed(to_delete):
         del messages[i]

--- a/contributors/emails/hakan.baysal@trmix.com
+++ b/contributors/emails/hakan.baysal@trmix.com
@@ -1,0 +1,1 @@
+hakanbaysal

--- a/tests/run_agent/test_image_rejection_fallback.py
+++ b/tests/run_agent/test_image_rejection_fallback.py
@@ -83,6 +83,53 @@ class TestStripImagesPreservesAlternation:
         assert msgs[2]["content"] == [{"type": "text", "text": "Captured 1024x768"}]
         assert msgs[2]["tool_call_id"] == "call_1"
 
+    def test_assistant_with_tool_calls_and_image_only_content_preserved(self):
+        """Assistant messages carrying tool_calls must NEVER be deleted —
+        dropping them would orphan the paired tool responses, which providers
+        reject with unmatched tool_call_id errors.
+        """
+        msgs = [
+            {"role": "user", "content": "annotate this screenshot"},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "image_url", "image_url": {"url": "data:image/png;base64,..."}},
+                ],
+                "tool_calls": [{
+                    "id": "call_xyz",
+                    "type": "function",
+                    "function": {"name": "annotate", "arguments": "{}"},
+                }],
+            },
+            {"role": "tool", "tool_call_id": "call_xyz", "content": "done"},
+        ]
+        changed = _strip_images_from_messages(msgs)
+        assert changed is True
+        # Length preserved — assistant message with tool_calls NOT deleted
+        assert len(msgs) == 3
+        assert msgs[1]["tool_calls"][0]["id"] == "call_xyz"
+        # Content replaced with text placeholder (now a string, not a list)
+        assert isinstance(msgs[1]["content"], str)
+        assert "image content removed" in msgs[1]["content"].lower()
+        # Paired tool response still matches
+        assert msgs[2]["tool_call_id"] == "call_xyz"
+
+    def test_image_only_user_message_dropped(self):
+        """Synthetic image-only user messages (gateway injection pattern) are
+        safe to drop — no tool_call_id linkage to preserve."""
+        msgs = [
+            {"role": "user", "content": "what's in this?"},
+            {"role": "assistant", "content": "I'll check."},
+            {
+                "role": "user",
+                "content": [{"type": "image_url", "image_url": {"url": "data:..."}}],
+            },
+        ]
+        changed = _strip_images_from_messages(msgs)
+        assert changed is True
+        # Synthetic image-only user message dropped
+        assert len(msgs) == 2
+        assert msgs[-1]["role"] == "assistant"
 
     def test_multiple_tool_messages_all_preserved(self):
         """Parallel tool calls: each tool_call_id must retain a paired message."""


### PR DESCRIPTION
## Summary
Salvage of #66714 by @hakanbaysal (credit preserved via cherry-pick): `_strip_images_from_messages()` deleted any non-tool message whose content became empty after image removal. An assistant message whose content was entirely images but which carries `tool_calls` was therefore dropped, orphaning its paired tool responses — the next request fails with unmatched `tool_call_id` errors (HTTP 400).

Such assistant messages are now replaced with the existing plaintext placeholder (tool_calls intact), exactly like tool-role messages, preserving the strict role-alternation / tool_call_id pairing invariant.

## Changes
- `agent/message_sanitization.py`: the empty-after-strip branch now keeps any message with `role == "tool"` **or** a truthy `tool_calls`, replacing content with `"[image content removed — server does not support images]"` instead of deleting; docstring updated.
- `tests/run_agent/test_image_rejection_fallback.py`: new regression tests `test_assistant_with_tool_calls_and_image_only_content_preserved` and `test_image_only_user_message_dropped`.
- Sibling audit: compression-path strippers (`agent/context_compressor.py` `_strip_images_from_tool_msg` / `_strip_images_from_content`) already replace with placeholders and never delete messages — no widening needed.

## Validation
- `pytest tests/run_agent/test_image_rejection_fallback.py tests/run_agent/test_69078_image_corrupt_recovery.py` — **26 passed**
- `ruff check` clean; rebased onto current `origin/main` (902cd05147) — base fresh, tests re-run green post-rebase.

**Live repro:** history `[user, assistant(tool_calls + image-only content), tool(result), assistant(text)]` run through the real `_strip_images_from_messages`:
- **BEFORE (origin/main):** `len: 3` — the assistant tool_calls message was deleted; sequence became `user → tool → assistant`, `orphaned tool result: True` (no preceding assistant carries `call_xyz`).
- **AFTER (this fix):** `len: 4` — assistant survives with `tool_calls: True`, content `"[image content removed — server does not support images]"`; `orphaned tool result: False`, `two same-role in a row: False`.

## Infographic
![infographic](https://v3b.fal.media/files/b/0aa825e8/G6ZJI6s-1_qOJAmjteHKz_XXI6iQ1h.png)

