### PR TITLE
fix(desktop): a malformed mcp_servers entry no longer blanks the whole workspace (salvage #94338)

### DIFF
--- a/apps/desktop/src/app/command-palette/index.tsx
+++ b/apps/desktop/src/app/command-palette/index.tsx
@@ -56,6 +56,7 @@ import {
   Wrench,
   Zap
 } from '@/lib/icons'
+import { getServers } from '@/lib/mcp-servers'
 import { normalize } from '@/lib/text'
 import { cn } from '@/lib/utils'
 import { resolveVersionStatus } from '@/lib/version-status'
@@ -659,13 +660,9 @@ function CommandPaletteBody({ onExited }: { onExited: () => void }) {
     queryFn: () => listAllProfileSessions(200, 0, 'only')
   })
 
-  const mcpServers = useMemo(() => {
-    const raw = configQuery.data?.mcp_servers
-
-    return raw && typeof raw === 'object' && !Array.isArray(raw)
-      ? Object.keys(raw as Record<string, unknown>).sort()
-      : []
-  }, [configQuery.data])
+  // getServers is the shared choke point that also drops malformed (null/
+  // scalar) entries, so the palette never lists a server the MCP tab dropped.
+  const mcpServers = useMemo(() => Object.keys(getServers(configQuery.data ?? null)).sort(), [configQuery.data])
 
   const sessions = useMemo(() => (sessionsQuery.data?.sessions ?? []).map(toSessionEntry), [sessionsQuery.data])
   const archivedSessions = useMemo(() => (archivedQuery.data?.sessions ?? []).map(toSessionEntry), [archivedQuery.data])

--- a/apps/desktop/src/lib/mcp-servers.test.ts
+++ b/apps/desktop/src/lib/mcp-servers.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+
+import { getServers } from './mcp-servers'
+
+describe('getServers', () => {
+  it('returns empty when the map is absent or not a map', () => {
+    expect(getServers(null)).toEqual({})
+    expect(getServers({})).toEqual({})
+    expect(getServers({ mcp_servers: null })).toEqual({})
+    expect(getServers({ mcp_servers: ['files'] })).toEqual({})
+    expect(getServers({ mcp_servers: 'files' })).toEqual({})
+  })
+
+  it('passes object entries through untouched', () => {
+    const servers = { docs: { url: 'https://example.com/mcp' }, files: { args: ['-y', 'pkg'], command: 'npx' } }
+
+    expect(getServers({ mcp_servers: servers })).toEqual(servers)
+  })
+
+  // A key left without a value in config.yaml parses as `null`, and every
+  // reader (the `enabled` gate, the transport label, the probe) reaches
+  // straight into the entry — so one of these used to take the pane down.
+  it('drops non-object entries and keeps their siblings', () => {
+    const servers = { broken: null, list: ['a'], scalar: 3, working: { command: 'npx' } }
+
+    expect(getServers({ mcp_servers: servers })).toEqual({ working: { command: 'npx' } })
+  })
+})

--- a/apps/desktop/src/lib/mcp-servers.test.ts
+++ b/apps/desktop/src/lib/mcp-servers.test.ts
@@ -17,6 +17,15 @@ describe('getServers', () => {
     expect(getServers({ mcp_servers: servers })).toEqual(servers)
   })
 
+  // Field-level junk is the readers' problem, not this filter's — they coerce
+  // and tolerate. Pinned so a later tightening of `isEntry` can't start
+  // dropping entries that merely carry a bad field.
+  it('keeps entries whose fields are junk', () => {
+    const servers = { files: { command: 42, enabled: 'yes' } }
+
+    expect(getServers({ mcp_servers: servers })).toEqual(servers)
+  })
+
   // A key left without a value in config.yaml parses as `null`, and every
   // reader (the `enabled` gate, the transport label, the probe) reaches
   // straight into the entry — so one of these used to take the pane down.

--- a/apps/desktop/src/lib/mcp-servers.ts
+++ b/apps/desktop/src/lib/mcp-servers.ts
@@ -21,9 +21,28 @@ export function normalizeEntry(entry: Record<string, unknown>): Record<string, u
   return entry
 }
 
-/** The `mcp_servers` map out of a config record, or `{}` when absent/malformed. */
+/** A value a reader can reach into: an object, not `null`, an array or a scalar. */
+const isEntry = (value: unknown): value is Record<string, unknown> =>
+  !!value && typeof value === 'object' && !Array.isArray(value)
+
+/** The `mcp_servers` map out of a config record, or `{}` when absent/malformed.
+ *
+ *  Entries that aren't objects are dropped rather than handed on. Every reader
+ *  takes properties straight off the value — `enabled` for the runtime gate,
+ *  `command`/`url` for the transport, `tools` for the filter — so one bad entry
+ *  throws on the first property read and, with nothing between it and the pane,
+ *  takes the whole Capabilities workspace down with it. A `name:` left without
+ *  a value in `config.yaml` parses as `null` and does exactly that. The backend
+ *  already refuses to *write* a non-object entry (`_replace_mcp_servers`), so
+ *  this only has to survive a config edited by hand or by another tool. */
 export function getServers(config: { mcp_servers?: unknown } | null): McpServers {
   const raw = config?.mcp_servers
 
-  return raw && typeof raw === 'object' && !Array.isArray(raw) ? (raw as McpServers) : {}
+  if (!isEntry(raw)) {
+    return {}
+  }
+
+  return Object.fromEntries(
+    Object.entries(raw).filter((entry): entry is [string, Record<string, unknown>] => isEntry(entry[1]))
+  )
 }

--- a/apps/desktop/src/store/mcp-health.ts
+++ b/apps/desktop/src/store/mcp-health.ts
@@ -15,6 +15,7 @@
 import { getHermesConfigRecord, type McpTestResult, testMcpServer } from '@/hermes'
 import { translateNow } from '@/i18n'
 import { classifyProbe, freshProbe, probeCache, probeKey } from '@/lib/mcp-probe-cache'
+import { getServers } from '@/lib/mcp-servers'
 import { notify } from '@/store/notifications'
 import { $activeGatewayProfile, normalizeProfileKey } from '@/store/profile'
 import { $gatewayState } from '@/store/session'
@@ -106,10 +107,9 @@ async function sweep(): Promise<void> {
     return
   }
 
-  const raw = config.mcp_servers
-
-  const servers =
-    raw && typeof raw === 'object' && !Array.isArray(raw) ? (raw as Record<string, Record<string, unknown>>) : {}
+  // getServers drops non-object entries (a bare `name:` in config.yaml parses
+  // as `null`), so isUrlServer below never reads `.url` off a null entry.
+  const servers = getServers(config)
 
   for (const [name, server] of Object.entries(servers)) {
     if (!isUrlServer(server)) {

--- a/contributors/emails/ignaciogabrielchiappero@gmail.com
+++ b/contributors/emails/ignaciogabrielchiappero@gmail.com
@@ -1,0 +1,1 @@
+ignaciochiappero


### PR DESCRIPTION
## Summary

The Desktop MCP tab no longer crashes the whole workspace when config.yaml contains a null/scalar `mcp_servers` entry (salvage of #94338).

## Changes

- `apps/desktop/src/lib/mcp-servers.ts`: `getServers()` now drops non-object entries (null / array / scalar) instead of passing them through — a bare `name:` key in config.yaml parses as `null` and previously threw in `serverEnabled()` (`Cannot read properties of null (reading 'enabled')`), taking down the entire Capabilities workspace with the error card.
- `apps/desktop/src/lib/mcp-servers.test.ts` (new): vitest coverage for absent/non-map values, pass-through of valid entries, field-level junk survival, and dropping null/array/scalar entries while keeping siblings.
- Follow-up (ours): routed two sibling readers of raw `config.mcp_servers` through `getServers()` — `store/mcp-health.ts` (its sweep guarded the map but still passed null entries to `isUrlServer`, which reads `.url` → same crash class) and `app/command-palette/index.tsx` (duplicated inline map check; now lists exactly what the MCP tab shows).

## Validation

| Check | Before | After |
| --- | --- | --- |
| MCP tab with `broken:` (null) entry in `mcp_servers` | Error card replaces the entire workspace | Entry dropped; healthy servers render |
| MCP health sweep over a null entry | `TypeError` reading `.url` in `isUrlServer` | Entry filtered by `getServers()` |
| Command palette MCP group | Inline shape check, listed malformed keys | Same `getServers()` choke point as the tab |
| `npx vitest run src/lib/mcp-servers.test.ts` | n/a (new file) | 4/4 passed |
| `npx tsc --noEmit -p apps/desktop` | — | clean |

Sibling audit: `suggestion-providers/mcp.ts` (names via backend list, not raw config), `mcp-import.ts` and `mcp-tab.tsx` `parseServersDoc` (parse user-typed JSON with their own `isRecord`/shape guards), and `api/mcp.ts` (writes only) confirmed safe.

## Credit

Cherry-picked from #94338 by @ignaciochiappero — both original commits preserved with contributor authorship.

## Infographic

![infographic](https://v3b.fal.media/files/b/0aa825f1/LYxZRRQkp63lt_0qNOQ9P_5jwiUkjc.png)
