### PR TITLE
fix(profiles): deleted named profiles stay deleted — tombstones block logging resurrection (#89438, salvage #90141)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -958,17 +958,13 @@ def ensure_hermes_home():
     home = get_hermes_home()
     key = str(home)
 
+    # Named profiles must be created explicitly (e.g. ``hermes profile create``).
+    # Check tombstones before the memo so a stale empty shell cannot skip
+    # the deleted-profile guard.
+    from hermes_constants import assert_named_profile_home_live
+    assert_named_profile_home_live(home)
     if key in _HERMES_HOME_ENSURED and home.is_dir():
         return
-    # Named profiles must be created explicitly (e.g. ``hermes profile create``).
-    # If a stale process keeps running after the profile was renamed/deleted,
-    # silently mkdir-ing the old HERMES_HOME would resurrect an empty skeleton
-    # and make the deleted profile reappear in Desktop/profile lists.
-    if home.parent.name == "profiles" and not home.exists():
-        raise FileNotFoundError(
-            f"Named profile home does not exist: {home}. "
-            "Create the profile explicitly before using it."
-        )
     if is_managed():
         old_umask = os.umask(0o007)
         try:

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -34,6 +34,11 @@ from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Dict, List, Optional, Tuple
 
 from agent.skill_utils import is_excluded_skill_path
+from hermes_constants import (
+    clear_named_profile_deleted,
+    mark_named_profile_deleted,
+    named_profile_is_deleted,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -1022,6 +1027,8 @@ def list_profiles() -> List[ProfileInfo]:
                 continue  # already added as the built-in default above
             if not _PROFILE_ID_RE.match(name):
                 continue
+            if named_profile_is_deleted(entry):
+                continue
             model, provider = _read_config_model(entry)
             alias_name = alias_map.get(normalize_profile_name(name))
             if alias_name:
@@ -1107,6 +1114,8 @@ def profiles_to_serve(
                 continue  # default is the built-in entry already added above
             if not _PROFILE_ID_RE.match(name):
                 continue
+            if named_profile_is_deleted(entry):
+                continue
             if allowed is not None and name not in allowed:
                 continue
             serve.append((name, entry))
@@ -1173,8 +1182,11 @@ def create_profile(
         )
 
     profile_dir = get_profile_dir(canon)
+    if profile_dir.exists() and named_profile_is_deleted(profile_dir):
+        shutil.rmtree(profile_dir)
     if profile_dir.exists():
         raise FileExistsError(f"Profile '{canon}' already exists at {profile_dir}")
+    clear_named_profile_deleted(profile_dir)
 
     # Resolve clone source
     source_dir = None
@@ -1702,6 +1714,10 @@ def delete_profile(name: str, yes: bool = False) -> Path:
     # the rmtree below fail with ENOTEMPTY and — before the ensure_hermes_home
     # guard — resurrected the deleted tree.
     _stop_profile_backends(canon, profile_dir)
+
+    # Tombstone before rmtree so a stale serve/logging mkdir cannot relist
+    # this name as a live profile.
+    mark_named_profile_deleted(profile_dir)
 
     # 2c. Release this process's holographic memory-store connections into
     # the profile. The Desktop's *main* serve process opens memory_store.db

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -385,11 +385,12 @@ def get_profile_dir(name: str) -> Path:
 
 
 def profile_exists(name: str) -> bool:
-    """Check whether a profile directory exists."""
+    """Check whether a live (non-tombstoned) profile directory exists."""
     canon = normalize_profile_name(name)
     if canon == "default":
         return True
-    return get_profile_dir(canon).is_dir()
+    profile_dir = get_profile_dir(canon)
+    return profile_dir.is_dir() and not named_profile_is_deleted(profile_dir)
 
 
 def profile_matches_home(name: str, home: "Path | None" = None) -> bool:
@@ -1183,6 +1184,10 @@ def create_profile(
 
     profile_dir = get_profile_dir(canon)
     if profile_dir.exists() and named_profile_is_deleted(profile_dir):
+        # Empty shells left by post-delete mkdir may be replaced. Identity
+        # files mean the leftover is not a shell — fail closed, no rmtree.
+        if (profile_dir / "config.yaml").exists() or (profile_dir / ".env").exists():
+            raise FileExistsError(f"Profile '{canon}' already exists at {profile_dir}")
         shutil.rmtree(profile_dir)
     if profile_dir.exists():
         raise FileExistsError(f"Profile '{canon}' already exists at {profile_dir}")
@@ -1396,6 +1401,8 @@ def backfill_profile_envs(quiet: bool = False) -> List[str]:
         if not entry.is_dir() or not _PROFILE_ID_RE.match(entry.name):
             continue
         if entry.name == "default":
+            continue
+        if named_profile_is_deleted(entry):
             continue
         env_path = entry / ".env"
         if env_path.exists():
@@ -2544,7 +2551,7 @@ def resolve_profile_env(profile_name: str) -> str:
         return str(root)
     profile_dir = root / "profiles" / canon
 
-    if not profile_dir.is_dir():
+    if not profile_dir.is_dir() or named_profile_is_deleted(profile_dir):
         raise FileNotFoundError(
             f"Profile '{canon}' does not exist. "
             f"Create it with: hermes profile create {canon}"

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -227,6 +227,62 @@ def get_default_hermes_root() -> Path:
     return result
 
 
+# Named-profile deletion must survive stale mkdir from live serve/logging.
+# The marker lives beside the profile dir, not inside it, so rmtree cannot
+# erase the fact that the profile was deleted.
+_DELETED_PROFILES_DIR = ".deleted"
+
+
+def named_profile_home(path: str | Path) -> Path | None:
+    """Return ``<root>/profiles/<name>`` when *path* is that home or under it."""
+    current = Path(path)
+    for candidate in (current, *current.parents):
+        if candidate.parent.name == "profiles" and not candidate.name.startswith("."):
+            return candidate
+    return None
+
+
+def profile_tombstone_path(profile_home: Path) -> Path:
+    return profile_home.parent / _DELETED_PROFILES_DIR / profile_home.name
+
+
+def named_profile_is_deleted(profile_home: str | Path) -> bool:
+    return profile_tombstone_path(Path(profile_home)).exists()
+
+
+def mark_named_profile_deleted(profile_home: str | Path) -> None:
+    marker = profile_tombstone_path(Path(profile_home))
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.write_text("deleted\n", encoding="utf-8")
+
+
+def clear_named_profile_deleted(profile_home: str | Path) -> None:
+    profile_tombstone_path(Path(profile_home)).unlink(missing_ok=True)
+
+
+def assert_named_profile_home_live(path: str | Path) -> None:
+    """Refuse missing or tombstoned named profile homes.
+
+    Default ``HERMES_HOME`` (not under ``profiles/``) is unchanged.
+    """
+    home = named_profile_home(path)
+    if home is None:
+        return
+    if named_profile_is_deleted(home) or not home.exists():
+        raise FileNotFoundError(
+            f"Named profile home does not exist: {home}. "
+            "Create the profile explicitly before using it."
+        )
+
+
+def mkdir_under_hermes_home(path: str | Path) -> Path:
+    """Create *path*, but never materialize a deleted/missing named profile."""
+    target = Path(path)
+    assert_named_profile_home_live(target)
+    target.mkdir(parents=True, exist_ok=True)
+    return target
+
+
 def get_optional_skills_dir(default: Path | None = None) -> Path:
     """Return the optional-skills directory, honoring package-manager wrappers.
 

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -234,11 +234,22 @@ _DELETED_PROFILES_DIR = ".deleted"
 
 
 def named_profile_home(path: str | Path) -> Path | None:
-    """Return ``<root>/profiles/<name>`` when *path* is that home or under it."""
+    """Return ``<root>/profiles/<name>`` when *path* is that home or under it.
+
+    A named profile home is only ``.../profiles/<id>`` where ``<id>`` does
+    not start with ``.``. A default Hermes home whose path merely contains a
+    ``profiles`` segment (e.g. ``/tmp/foo/profiles/notahome/.hermes``) is not
+    a named profile. ``.../profiles/worker/logs`` still resolves to
+    ``.../profiles/worker``.
+    """
     current = Path(path)
     for candidate in (current, *current.parents):
         if candidate.parent.name == "profiles" and not candidate.name.startswith("."):
             return candidate
+        # Stop at a default Hermes home so a coincidental ``profiles/``
+        # ancestor is not treated as a named-profile root.
+        if candidate.name == ".hermes":
+            return None
     return None
 
 

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -232,19 +232,60 @@ def get_default_hermes_root() -> Path:
 # erase the fact that the profile was deleted.
 _DELETED_PROFILES_DIR = ".deleted"
 
+# Files whose presence marks a directory as a real Hermes home. A fresh home
+# always gains at least one of these on first use (config save, env backfill,
+# session DB), while arbitrary directories that merely contain a ``profiles``
+# path segment (e.g. ``/srv/profiles/buildcache``) do not.
+_HERMES_HOME_MARKERS = ("config.yaml", ".env", "state.db")
+
+
+def _is_hermes_profiles_root(profiles_dir: Path) -> bool:
+    """Return True when *profiles_dir* is a canonical ``<hermes-home>/profiles``.
+
+    Anchors named-profile recognition so it only fires for directories that
+    provably live under a Hermes home: the classic ``~/.hermes`` layout, a
+    root carrying Hermes-home marker files (Docker/custom ``HERMES_HOME``
+    like ``/opt/data``), a ``profiles/.deleted`` tombstone directory (only
+    ever created by ``hermes profile delete``), or the process's resolved
+    default Hermes root.
+    """
+    root = profiles_dir.parent
+    if root.name == ".hermes":
+        return True
+    try:
+        if (profiles_dir / _DELETED_PROFILES_DIR).is_dir():
+            return True
+        if any((root / marker).exists() for marker in _HERMES_HOME_MARKERS):
+            return True
+    except OSError:
+        pass
+    try:
+        return root.resolve(strict=False) == get_default_hermes_root().resolve(
+            strict=False
+        )
+    except OSError:
+        return False
+
 
 def named_profile_home(path: str | Path) -> Path | None:
     """Return ``<root>/profiles/<name>`` when *path* is that home or under it.
 
     A named profile home is only ``.../profiles/<id>`` where ``<id>`` does
-    not start with ``.``. A default Hermes home whose path merely contains a
-    ``profiles`` segment (e.g. ``/tmp/foo/profiles/notahome/.hermes``) is not
-    a named profile. ``.../profiles/worker/logs`` still resolves to
-    ``.../profiles/worker``.
+    not start with ``.`` AND the ``profiles`` directory's parent is a real
+    Hermes home (see :func:`_is_hermes_profiles_root`). A default Hermes home
+    whose path merely contains a ``profiles`` segment
+    (e.g. ``/tmp/foo/profiles/notahome/.hermes``) is not a named profile,
+    and neither is an unrelated custom home like
+    ``/srv/profiles/buildcache`` — those must keep mkdir-ing normally.
+    ``.../profiles/worker/logs`` still resolves to ``.../profiles/worker``.
     """
     current = Path(path)
     for candidate in (current, *current.parents):
-        if candidate.parent.name == "profiles" and not candidate.name.startswith("."):
+        if (
+            candidate.parent.name == "profiles"
+            and not candidate.name.startswith(".")
+            and _is_hermes_profiles_root(candidate.parent)
+        ):
             return candidate
         # Stop at a default Hermes home so a coincidental ``profiles/``
         # ancestor is not treated as a named-profile root.

--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -301,8 +301,8 @@ def setup_logging(
     """
     global _logging_initialized
     home = hermes_home or get_hermes_home()
-    log_dir = home / "logs"
-    log_dir.mkdir(parents=True, exist_ok=True)
+    from hermes_constants import mkdir_under_hermes_home
+    log_dir = mkdir_under_hermes_home(home / "logs")
 
     # Read config defaults (best-effort — config may not be loaded yet).
     cfg_level, cfg_max_size, cfg_backup = _read_logging_config()
@@ -745,7 +745,8 @@ def _add_rotating_handler(
         ):
             return  # already attached
 
-    path.parent.mkdir(parents=True, exist_ok=True)
+    from hermes_constants import mkdir_under_hermes_home
+    mkdir_under_hermes_home(path.parent)
     handler = _ManagedRotatingFileHandler(
         str(path), maxBytes=max_bytes, backupCount=backup_count,
         encoding="utf-8",

--- a/tests/hermes_cli/test_deleted_profile_tombstone.py
+++ b/tests/hermes_cli/test_deleted_profile_tombstone.py
@@ -1,0 +1,95 @@
+"""Deleted named profiles must stay gone until explicitly recreated.
+
+A live serve/logging process can mkdir ``profiles/<name>/logs`` after
+``hermes profile delete`` removes the tree. That empty shell then
+reappears in ``hermes profile list`` and Desktop Bot Mode. These tests
+lock the tombstone + no-mkdir contract without depending on Desktop.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli.config import ensure_hermes_home
+from hermes_cli.profiles import (
+    create_profile,
+    delete_profile,
+    list_profiles,
+    profiles_to_serve,
+)
+from hermes_logging import setup_logging
+
+
+@pytest.fixture()
+def profile_env(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    default_home = tmp_path / ".hermes"
+    default_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(default_home))
+    return tmp_path
+
+
+def _named_homes(tmp_path: Path) -> list[str]:
+    return [info.name for info in list_profiles() if not info.is_default]
+
+
+class TestDeletedProfileTombstone:
+    def test_delete_then_logging_setup_does_not_recreate_home(self, profile_env, monkeypatch):
+        profile_dir = create_profile("worker", no_alias=True, no_skills=True)
+        with patch("hermes_cli.profiles._cleanup_gateway_service"), patch(
+            "hermes_cli.profiles._stop_profile_backends"
+        ):
+            delete_profile("worker", yes=True)
+
+        assert not profile_dir.exists()
+        assert "worker" not in _named_homes(profile_env)
+
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        with pytest.raises(FileNotFoundError, match="Named profile home does not exist"):
+            setup_logging(hermes_home=profile_dir, force=True)
+
+        assert not profile_dir.exists()
+        monkeypatch.setenv("HERMES_HOME", str(profile_env / ".hermes"))
+        assert "worker" not in _named_homes(profile_env)
+
+    def test_empty_shell_after_delete_is_not_listed_or_served(self, profile_env):
+        profile_dir = create_profile("worker", no_alias=True, no_skills=True)
+        with patch("hermes_cli.profiles._cleanup_gateway_service"), patch(
+            "hermes_cli.profiles._stop_profile_backends"
+        ):
+            delete_profile("worker", yes=True)
+
+        # Simulate a stale mkdir that only rebuilds the directory itself.
+        profile_dir.mkdir(parents=True)
+        (profile_dir / "state.db").write_bytes(b"")
+
+        assert "worker" not in _named_homes(profile_env)
+        served = [name for name, _ in profiles_to_serve(True)]
+        assert "worker" not in served
+
+    def test_tombstoned_home_is_not_bootstrapped(self, profile_env, monkeypatch):
+        profile_dir = create_profile("worker", no_alias=True, no_skills=True)
+        with patch("hermes_cli.profiles._cleanup_gateway_service"), patch(
+            "hermes_cli.profiles._stop_profile_backends"
+        ):
+            delete_profile("worker", yes=True)
+        profile_dir.mkdir(parents=True)
+
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        with pytest.raises(FileNotFoundError, match="Named profile home does not exist"):
+            ensure_hermes_home()
+        assert not (profile_dir / "sessions").exists()
+
+    def test_create_after_delete_clears_tombstone(self, profile_env):
+        create_profile("worker", no_alias=True, no_skills=True)
+        with patch("hermes_cli.profiles._cleanup_gateway_service"), patch(
+            "hermes_cli.profiles._stop_profile_backends"
+        ):
+            delete_profile("worker", yes=True)
+
+        recreated = create_profile("worker", no_alias=True, no_skills=True)
+        assert recreated.is_dir()
+        assert "worker" in _named_homes(profile_env)

--- a/tests/hermes_cli/test_deleted_profile_tombstone.py
+++ b/tests/hermes_cli/test_deleted_profile_tombstone.py
@@ -15,11 +15,16 @@ import pytest
 
 from hermes_cli.config import ensure_hermes_home
 from hermes_cli.profiles import (
+    backfill_profile_envs,
     create_profile,
     delete_profile,
     list_profiles,
+    profile_exists,
     profiles_to_serve,
+    resolve_profile_env,
+    set_active_profile,
 )
+from hermes_constants import named_profile_home
 from hermes_logging import setup_logging
 
 
@@ -34,6 +39,13 @@ def profile_env(tmp_path, monkeypatch):
 
 def _named_homes(tmp_path: Path) -> list[str]:
     return [info.name for info in list_profiles() if not info.is_default]
+
+
+def _delete(name: str) -> None:
+    with patch("hermes_cli.profiles._cleanup_gateway_service"), patch(
+        "hermes_cli.profiles._stop_profile_backends"
+    ):
+        delete_profile(name, yes=True)
 
 
 class TestDeletedProfileTombstone:
@@ -93,3 +105,64 @@ class TestDeletedProfileTombstone:
         recreated = create_profile("worker", no_alias=True, no_skills=True)
         assert recreated.is_dir()
         assert "worker" in _named_homes(profile_env)
+
+    def test_profile_exists_is_false_for_tombstoned_shell(self, profile_env):
+        profile_dir = create_profile("worker", no_alias=True, no_skills=True)
+        assert profile_exists("worker") is True
+        _delete("worker")
+        profile_dir.mkdir(parents=True)
+
+        assert profile_exists("worker") is False
+        with pytest.raises(FileNotFoundError, match="does not exist"):
+            set_active_profile("worker")
+        with pytest.raises(FileNotFoundError, match="does not exist"):
+            resolve_profile_env("worker")
+
+    def test_backfill_skips_tombstoned_directory(self, profile_env):
+        profile_dir = create_profile("worker", no_alias=True, no_skills=True)
+        _delete("worker")
+        profile_dir.mkdir(parents=True)
+        (profile_env / ".hermes" / ".env").write_text("OPENROUTER_API_KEY=root-key\n")
+
+        backfilled = backfill_profile_envs(quiet=True)
+
+        assert "worker" not in backfilled
+        assert not (profile_dir / ".env").exists()
+
+    def test_create_after_delete_replaces_empty_shell(self, profile_env):
+        profile_dir = create_profile("worker", no_alias=True, no_skills=True)
+        _delete("worker")
+        profile_dir.mkdir(parents=True)
+        (profile_dir / "logs").mkdir()
+
+        recreated = create_profile("worker", no_alias=True, no_skills=True)
+        assert recreated.is_dir()
+        assert "worker" in _named_homes(profile_env)
+
+    @pytest.mark.parametrize("leftover", ["config.yaml", ".env"])
+    def test_create_after_delete_refuses_when_identity_files_remain(
+        self, profile_env, leftover
+    ):
+        profile_dir = create_profile("worker", no_alias=True, no_skills=True)
+        _delete("worker")
+        profile_dir.mkdir(parents=True)
+        leftover_path = profile_dir / leftover
+        leftover_path.write_text("keep-me\n", encoding="utf-8")
+
+        with pytest.raises(FileExistsError, match="already exists"):
+            create_profile("worker", no_alias=True, no_skills=True)
+
+        assert leftover_path.read_text(encoding="utf-8") == "keep-me\n"
+        assert leftover_path.exists()
+
+
+class TestNamedProfileHome:
+    def test_logs_under_named_profile_resolve_to_profile_home(self, tmp_path):
+        worker = tmp_path / "profiles" / "worker"
+        assert named_profile_home(worker / "logs") == worker
+        assert named_profile_home(worker) == worker
+
+    def test_default_home_with_profiles_in_path_is_not_named(self, tmp_path):
+        default_home = tmp_path / "foo" / "profiles" / "notahome" / ".hermes"
+        assert named_profile_home(default_home) is None
+        assert named_profile_home(default_home / "logs") is None

--- a/tests/hermes_cli/test_deleted_profile_tombstone.py
+++ b/tests/hermes_cli/test_deleted_profile_tombstone.py
@@ -122,7 +122,9 @@ class TestDeletedProfileTombstone:
         profile_dir = create_profile("worker", no_alias=True, no_skills=True)
         _delete("worker")
         profile_dir.mkdir(parents=True)
-        (profile_env / ".hermes" / ".env").write_text("OPENROUTER_API_KEY=root-key\n")
+        (profile_env / ".hermes" / ".env").write_text(
+            "OPENROUTER_API_KEY=root-key\n", encoding="utf-8"
+        )
 
         backfilled = backfill_profile_envs(quiet=True)
 
@@ -158,7 +160,15 @@ class TestDeletedProfileTombstone:
 
 class TestNamedProfileHome:
     def test_logs_under_named_profile_resolve_to_profile_home(self, tmp_path):
+        # tmp_path acts as a real Hermes home (Docker/custom layout): it
+        # carries a home marker file, so profiles/ under it is canonical.
+        (tmp_path / "config.yaml").write_text("{}\n", encoding="utf-8")
         worker = tmp_path / "profiles" / "worker"
+        assert named_profile_home(worker / "logs") == worker
+        assert named_profile_home(worker) == worker
+
+    def test_dot_hermes_layout_resolves_without_markers(self, tmp_path):
+        worker = tmp_path / ".hermes" / "profiles" / "worker"
         assert named_profile_home(worker / "logs") == worker
         assert named_profile_home(worker) == worker
 
@@ -166,3 +176,37 @@ class TestNamedProfileHome:
         default_home = tmp_path / "foo" / "profiles" / "notahome" / ".hermes"
         assert named_profile_home(default_home) is None
         assert named_profile_home(default_home / "logs") is None
+
+    def test_unrelated_profiles_dir_is_not_named(self, tmp_path):
+        # Review point 1 regression: a custom home like
+        # /srv/profiles/buildcache must NOT be treated as a named profile —
+        # its parent is not a Hermes home, so logging must keep mkdir-ing.
+        custom_home = tmp_path / "srv" / "profiles" / "buildcache"
+        assert named_profile_home(custom_home) is None
+        assert named_profile_home(custom_home / "logs") is None
+
+    def test_unrelated_profiles_dir_still_mkdirs(self, tmp_path):
+        from hermes_constants import mkdir_under_hermes_home
+
+        custom_home = tmp_path / "srv" / "profiles" / "buildcache"
+        log_dir = mkdir_under_hermes_home(custom_home / "logs")
+        assert log_dir.is_dir()
+
+    def test_setup_logging_under_unrelated_profiles_dir_succeeds(self, tmp_path):
+        # End-to-end shape of the point-1 regression: setup_logging on a
+        # non-profile custom home whose path contains a 'profiles' segment
+        # must create the log dir instead of raising FileNotFoundError.
+        custom_home = tmp_path / "srv" / "profiles" / "buildcache"
+        custom_home.mkdir(parents=True)
+        log_dir = setup_logging(hermes_home=custom_home, force=True)
+        assert log_dir == custom_home / "logs"
+        assert log_dir.is_dir()
+
+    def test_tombstone_dir_marks_profiles_root(self, tmp_path):
+        # A profiles/.deleted directory is only ever created by
+        # `hermes profile delete` — its presence alone anchors recognition,
+        # so tombstones are honored even when root markers are missing.
+        profiles_dir = tmp_path / "opt" / "profiles"
+        (profiles_dir / ".deleted").mkdir(parents=True)
+        worker = profiles_dir / "worker"
+        assert named_profile_home(worker / "logs") == worker


### PR DESCRIPTION
Deleted named profiles now stay deleted: `hermes profile delete` writes a sibling tombstone at `profiles/.deleted/<name>` before rmtree, so a still-running serve/logging process can no longer resurrect the profile in `hermes profile list` or Desktop Bot Mode. Salvage of #90141 by @EndeavorYen onto current main, plus a follow-up fix for review point 1.

## Changes

**Salvaged from #90141 (authorship preserved, @EndeavorYen):**
- `delete_profile` writes the tombstone marker (`profiles/.deleted/<name>`) BEFORE removing the tree, so no window exists where a stale writer's mkdir wins.
- `ensure_hermes_home` / `setup_logging` / `_add_rotating_handler` refuse to mkdir or bootstrap a missing or tombstoned named profile home (`assert_named_profile_home_live`, `mkdir_under_hermes_home`).
- `list_profiles`, `profiles_to_serve`, `profile_exists`, `backfill_profile_envs`, and `resolve_profile_env` skip tombstoned names — an empty shell recreated by a stale mkdir no longer lists or serves.
- `create_profile` clears the tombstone (and replaces an empty post-delete shell; refuses when identity files like `config.yaml`/`.env` remain).
- New test file `tests/hermes_cli/test_deleted_profile_tombstone.py`.

**Follow-up (ours) — review point 1 fix:**
- The salvaged `named_profile_home()` heuristic treated ANY path whose ancestor sat under a directory literally named `profiles` as a named profile — so an unrelated custom home like `/srv/profiles/buildcache` would have made `setup_logging` raise `FileNotFoundError` instead of creating `logs/`. Recognition is now anchored: the `profiles` dir's parent must BE a Hermes home (`~/.hermes` layout, home marker files `config.yaml`/`.env`/`state.db` for Docker/custom roots, a `profiles/.deleted` tombstone dir, or the resolved default Hermes root).
- Regression tests added for the `/srv/profiles/<x>` false-positive shape (resolution returns `None`; `mkdir_under_hermes_home` and `setup_logging` still create dirs) plus the tombstone-dir and `~/.hermes` anchors.

Review points 2–4 from the PR's AI review (marker accumulation, `create_profile` TOCTOU, existing-test notes) are accepted as-is — no extra machinery.

## Validation

| Check | Result |
|---|---|
| Premise on current main | No tombstone/`.deleted` mechanism in `profiles.py`/`hermes_constants.py`; `setup_logging` blindly `mkdir -p`s `home/logs` |
| Sabotage A (guards neutered, tests kept) | 6 failed / 10 passed — tests genuinely exercise the guards |
| Sabotage B (restored, marker verified) | 16/16 pass in `test_deleted_profile_tombstone.py` |
| Targeted suites | `test_deleted_profile_tombstone.py` + `test_profiles.py`: 70 passed, 2 skipped; `test_hermes_constants.py` + `tests/gateway/test_status.py`: 135 passed, 7 skipped |
| Live E2E (isolated `HERMES_HOME`) | create → delete → stale `mkdir logs` + `setup_logging` refused (`FileNotFoundError`) → list/serve stay clean → recreate succeeds, tombstone cleared |
| Point-1 regression (live) | `setup_logging(hermes_home=/…/srv/profiles/buildcache)` creates `logs/` normally |
| ruff / Windows footguns | All checks passed (one bare `write_text` in the salvaged test given `encoding=`) |

## Credit

Salvaged from #90141 by @EndeavorYen — cherry-picked with authorship preserved. Together with #97069 (Desktop persisted-tile half, merged today) this completes #94235's chain; also addresses #89438 and #52279.

## Infographic

![PR infographic](https://v3b.fal.media/files/b/0aa825f0/A498G4Uz87otD-dZicb3e_CSpwXgNg.png)
