### PR TITLE
feat(commands): establish Ink TUI client command bindings

### DIFF
--- a/ui-tui/src/app/slash/ink-command-bindings.test.ts
+++ b/ui-tui/src/app/slash/ink-command-bindings.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  projectInkClientCommandBindings,
+  resolveInkClientCommandBinding
+} from './ink-command-bindings.js'
+import { SLASH_COMMANDS } from './registry.js'
+
+describe('Ink client command bindings', () => {
+  it('projects the complete current static handler surface for v1 mixed-version peers', () => {
+    const bindings = projectInkClientCommandBindings(SLASH_COMMANDS.map(command => ({ name: `/${command.name}` })))
+
+    expect(bindings).toHaveLength(SLASH_COMMANDS.length)
+    expect(new Set(bindings.map(binding => binding.canonicalName)).size).toBe(bindings.length)
+  })
+
+  it('uses command_id from v2 catalogs and the canonical name for mixed-version fallback', () => {
+    expect(
+      resolveInkClientCommandBinding({
+        command_id: 'ink.fortune',
+        execution_owner: 'client',
+        name: '/fortune'
+      })
+    ).toMatchObject({ canonicalName: '/fortune', commandId: 'ink.fortune' })
+    expect(resolveInkClientCommandBinding({ name: '/fortune' })).toMatchObject({
+      canonicalName: '/fortune',
+      commandId: '/fortune'
+    })
+  })
+
+  it('canonicalizes aliases through the existing registry instead of owning another alias table', () => {
+    const mouse = resolveInkClientCommandBinding({
+      command_id: 'ink.mouse',
+      execution_owner: 'client',
+      name: '/mouse'
+    })
+    const scroll = resolveInkClientCommandBinding({
+      command_id: 'ink.mouse',
+      execution_owner: 'client',
+      name: '/scroll'
+    })
+
+    expect(scroll).toMatchObject({ canonicalName: '/mouse', commandId: 'ink.mouse' })
+    expect(scroll?.run).toBe(mouse?.run)
+  })
+
+  it('does not claim explicitly server-, plugin-, skill-, or agent-owned commands', () => {
+    for (const execution_owner of ['server', 'plugin', 'skill', 'agent_turn']) {
+      expect(resolveInkClientCommandBinding({ execution_owner, name: '/fortune' })).toBeNull()
+    }
+  })
+
+  it('does not invent bindings for unknown catalog rows', () => {
+    expect(resolveInkClientCommandBinding({ execution_owner: 'client', name: '/does-not-exist' })).toBeNull()
+    expect(resolveInkClientCommandBinding({ execution_owner: 'client', name: '   ' })).toBeNull()
+  })
+
+  it('returns immutable bindings and projections', () => {
+    const binding = resolveInkClientCommandBinding({ execution_owner: 'client', name: '/fortune' })
+    const bindings = projectInkClientCommandBindings([{ execution_owner: 'client', name: '/fortune' }])
+
+    expect(Object.isFrozen(binding)).toBe(true)
+    expect(Object.isFrozen(bindings)).toBe(true)
+  })
+
+  it('fails closed on duplicate stable identities, including case-only variants', () => {
+    expect(() =>
+      projectInkClientCommandBindings([
+        { command_id: 'ink.shared', execution_owner: 'client', name: '/fortune' },
+        { command_id: 'INK.SHARED', execution_owner: 'client', name: '/mouse' }
+      ])
+    ).toThrow('Ink command_id collision')
+  })
+
+  it('fails closed when aliases project the same canonical command twice', () => {
+    expect(() =>
+      projectInkClientCommandBindings([
+        { command_id: 'ink.mouse', execution_owner: 'client', name: '/mouse' },
+        { command_id: 'ink.scroll', execution_owner: 'client', name: '/scroll' }
+      ])
+    ).toThrow('Ink canonical command collision')
+  })
+
+  it('rejects blank explicit command ids and ownership instead of guessing', () => {
+    expect(() =>
+      resolveInkClientCommandBinding({ command_id: '   ', execution_owner: 'client', name: '/fortune' })
+    ).toThrow('empty command_id')
+    expect(() => resolveInkClientCommandBinding({ execution_owner: '   ', name: '/fortune' })).toThrow(
+      'empty execution_owner'
+    )
+  })
+})

--- a/ui-tui/src/app/slash/ink-command-bindings.ts
+++ b/ui-tui/src/app/slash/ink-command-bindings.ts
@@ -1,0 +1,136 @@
+import { findSlashCommand } from './registry.js'
+import type { SlashCommand } from './types.js'
+
+/**
+ * Stable catalog identity consumed by the Ink client projection.
+ *
+ * `command_id` and `execution_owner` are present on commands.catalog.v2.
+ * Older gateway peers expose only `name`, so the canonical slash name and
+ * current static-handler ownership remain the explicit mixed-version fallback.
+ */
+export interface InkCatalogCommandIdentity {
+  command_id?: null | string
+  execution_owner?: null | string
+  name: string
+}
+
+/** Execution-only binding contributed by the Ink TUI client. */
+export interface InkClientCommandBinding {
+  readonly canonicalName: string
+  readonly commandId: string
+  readonly run: SlashCommand['run']
+}
+
+function normalizedCommandName(name: string): string {
+  return name.trim().replace(/^\/+/, '').toLowerCase()
+}
+
+function stableCommandId(identity: InkCatalogCommandIdentity, canonicalName: string): string {
+  if (identity.command_id == null) {
+    return canonicalName
+  }
+
+  const commandId = identity.command_id.trim()
+
+  if (!commandId) {
+    throw new Error(`Ink command binding for "${canonicalName}" has an empty command_id`)
+  }
+
+  return commandId
+}
+
+function isClientOwned(identity: InkCatalogCommandIdentity): boolean {
+  if (identity.execution_owner == null) {
+    return true
+  }
+
+  const owner = identity.execution_owner.trim().toLowerCase()
+
+  if (!owner) {
+    throw new Error(`Ink command binding for "${identity.name}" has an empty execution_owner`)
+  }
+
+  return owner === 'client'
+}
+
+/**
+ * Resolve one catalog row into an Ink-owned client binding.
+ *
+ * Explicit v2 server/plugin/skill/agent-turn ownership refuses a local binding;
+ * those commands must settle through commands.invoke. A missing owner is the
+ * compatibility contract for the current v1 catalog and preserves the existing
+ * local Ink handler while mixed-version peers remain supported.
+ */
+export function resolveInkClientCommandBinding(
+  identity: InkCatalogCommandIdentity
+): InkClientCommandBinding | null {
+  if (!isClientOwned(identity)) {
+    return null
+  }
+
+  const enteredName = normalizedCommandName(identity.name)
+
+  if (!enteredName) {
+    return null
+  }
+
+  const command = findSlashCommand(enteredName)
+
+  if (!command) {
+    return null
+  }
+
+  const canonicalName = `/${command.name.toLowerCase()}`
+
+  return Object.freeze({
+    canonicalName,
+    commandId: stableCommandId(identity, canonicalName),
+    run: command.run
+  })
+}
+
+/**
+ * Project a catalog into immutable Ink client bindings.
+ *
+ * Duplicate stable ids or duplicate canonical commands are authority
+ * collisions and fail closed rather than allowing catalog order or aliases to
+ * choose an execution owner.
+ */
+export function projectInkClientCommandBindings(
+  identities: readonly InkCatalogCommandIdentity[]
+): readonly InkClientCommandBinding[] {
+  const bindings: InkClientCommandBinding[] = []
+  const byCommandId = new Map<string, string>()
+  const byCanonicalName = new Map<string, string>()
+
+  for (const identity of identities) {
+    const binding = resolveInkClientCommandBinding(identity)
+
+    if (!binding) {
+      continue
+    }
+
+    const idKey = binding.commandId.toLowerCase()
+    const idOwner = byCommandId.get(idKey)
+
+    if (idOwner) {
+      throw new Error(
+        `Ink command_id collision: "${binding.commandId}" is bound by both "${idOwner}" and "${binding.canonicalName}"`
+      )
+    }
+
+    const canonicalOwner = byCanonicalName.get(binding.canonicalName)
+
+    if (canonicalOwner) {
+      throw new Error(
+        `Ink canonical command collision: "${binding.canonicalName}" is projected by both "${canonicalOwner}" and "${identity.name}"`
+      )
+    }
+
+    byCommandId.set(idKey, binding.canonicalName)
+    byCanonicalName.set(binding.canonicalName, identity.name)
+    bindings.push(binding)
+  }
+
+  return Object.freeze(bindings)
+}


### PR DESCRIPTION
## What does this PR do?

Establishes the Ink TUI **execution-binding seam** for the unified slash-command architecture tracked in #96692.

The change deliberately does **not** create another semantic command registry in TypeScript. It adds a bounded projection that can consume stable catalog identity (`command_id`, `execution_owner`) and bind only commands that the catalog authorizes the Ink client to execute locally.

The invariant is:

> Catalog identity selects the command; explicit execution ownership authorizes the local effect. Ink may bind only client-owned commands, and ambiguity fails closed.

This PR therefore:

- accepts `command_id` and `execution_owner` from the planned `commands.catalog.v2` contract;
- refuses local binding for explicit `server`, `plugin`, `skill`, and `agent_turn` ownership;
- preserves current v1 mixed-version behavior only when ownership is absent, using the canonical slash name plus the existing static Ink handler as the compatibility fallback;
- resolves aliases through the existing registry rather than introducing a second alias table;
- returns immutable execution-only bindings (`commandId`, `canonicalName`, `run`);
- refuses unknown commands rather than converting them into prompt text;
- fails closed on duplicate stable IDs, case-only ID collisions, and duplicate canonical projections.

This is intentionally an independently landable PR6 slice. The full Ink migration still depends on the shared v2 catalog/invocation ABI: catalog-driven completion/help/argument hints, contributor registration, routing non-client commands through `commands.invoke`, and removal of the legacy static semantic overlay/backend compatibility rows belong after those shared contracts exist. This PR does not guess or duplicate those contracts ahead of their landing objects.

### Exact object and scope

- Construction parent: `a5c7eed5f395ed9386753bd6bafa7cc144097416`
- Recorded PR base: `7d1c9aeab739842fa42112c95d086a9897f2d513`
- Current live `main` at final read-back: `62e8126c6929d1a5d9fd650317214ef240767d4e`
- Submitted head: `2b329821a73f196103820b59b820d03d0969a0a3`
- Tree: `e94c74b61afa905ef67bcd1a24d1d0dcd9e05721`
- Commits: **1**
- Changed files: **2**
- Additions/deletions: **+228 / -0**
- GitHub currently reports the PR **open, non-draft, mergeable, and clean**.
- The 47-commit `7d1c9aea… → 62e8126c…` live-main interval is path-disjoint from both submitted Ink binding paths.
- Production dispatch behavior is unchanged until the shared catalog/invocation path consumes this seam.

The branch was rematerialized as one DCO-signed commit after repairing the only exact CI failure. The repaired two-commit intermediate head `7be4d89caed3e94a6b5523261040641ed46924e1` was fully green, but it retained the earlier red commit in history. Because the repository completion contract requires every submitted commit to be green, the final submitted object is the one-commit tree above. Its own exact CI, Docker, and Nix workflows are now all green, so the every-surviving-commit execution gate is satisfied for this producer object.

### Ownership / interlocks

- #96791 remains the merged current-main owner of registry-backed catalog metadata and Desktop projection. This PR composes with it and does not edit `registry.ts`, `createSlashHandler.ts`, `useCompletion.ts`, `commands.catalog`, the Python command registry, or the gateway dispatcher.
- #97102 owns command-plane characterization.
- #97143 owns the versioned semantic catalog.
- #97153 owns the typed invocation/result/dispatcher ABI and must compose with #95101's Authority Policy ABI rather than becoming a second policy compiler.
- #96990 owns the live `tui_gateway/methods_tools.py` skill-canonicalization repair. This PR does not touch that path or supersede its exact-match behavior.
- #97124's Desktop binding slice is path-disjoint.
- An open-PR search for the exact `ink-command-bindings` token resolves only this PR.
- The two paths in this PR remain the Ink execution projection; they do not become alternate semantic owners.

## Related Issue

Part of #96692 — this PR is PR6's Ink client-binding slice and **does not close the parent issue by itself**.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `ui-tui/src/app/slash/ink-command-bindings.ts`.
  - Defines the catalog identity accepted by the Ink projection.
  - Defines the immutable execution-only binding returned to the client.
  - Canonicalizes command names through the existing slash registry.
  - Uses explicit `command_id` when present and canonical-name fallback only for mixed-version peers.
  - Refuses explicitly non-client execution owners.
  - Rejects blank explicit identity/ownership fields instead of guessing.
  - Rejects duplicate stable IDs and duplicate canonical command projections.
- Added `ui-tui/src/app/slash/ink-command-bindings.test.ts`.
  - Covers the complete current static handler surface under v1 compatibility.
  - Covers v2 `command_id` identity and v1 fallback identity.
  - Proves alias canonicalization reuses the existing handler (`/scroll` → `/mouse`).
  - Proves server/plugin/skill/agent-turn ownership cannot be claimed locally.
  - Proves unknown rows do not create bindings.
  - Proves returned bindings/projections are frozen.
  - Proves case-insensitive duplicate stable IDs fail closed.
  - Proves duplicate canonical projections fail closed.
  - Proves blank explicit IDs/owners fail closed.
- CI repair: reordered the two sibling imports in the new test to satisfy the repository's shared `perfectionist/sort-imports` natural-order rule. No runtime or test semantics changed.

## How to Test

From the repository root with workspace dependencies installed:

1. Run the focused PR6 test:
   ```bash
   cd ui-tui
   npm test -- src/app/slash/ink-command-bindings.test.ts
   ```
2. Run the Ink TUI package checks:
   ```bash
   npm run check
   ```
3. Verify the authority boundary in the focused suite:
   - a catalog row with `execution_owner: "client"` binds the existing local handler;
   - `server`, `plugin`, `skill`, and `agent_turn` rows return no local binding;
   - `/scroll` canonicalizes to `/mouse` without a second alias table;
   - duplicate `command_id` or canonical-command ownership throws rather than selecting by catalog order.
4. Verify the **final one-commit head** `2b329821a73f196103820b59b820d03d0969a0a3` only. Exact hosted receipts:
   - [CI 33202667310](https://github.com/NousResearch/hermes-agent/actions/runs/33202667310): **success**.
   - [Docker Build, Test, and Publish 33202666571](https://github.com/NousResearch/hermes-agent/actions/runs/33202666571): **success**.
   - [Nix flake check 33202666566](https://github.com/NousResearch/hermes-agent/actions/runs/33202666566): **success**.

### CI repair provenance

- Original submitted head `1e87799adad9e069af3e9ade4ed7fa8e156efab5`: Docker/Nix green, CI `33170406524` red in `JS & TS checks / JS & TS checks` → `Run all workspace checks`.
- Source-grounded cause: the shared ESLint configuration makes `perfectionist/sort-imports` an error with natural ordering; the new test imported `./registry.js` before `./ink-command-bindings.js`.
- Minimal repair only: reordered those two sibling imports.
- Repaired intermediate head `7be4d89caed3e94a6b5523261040641ed46924e1`: CI `33202194703`, Docker `33202194182`, Nix `33202194202` all succeeded.
- Final history cleanup: the same green tree was rematerialized as one DCO-signed commit `2b329821a73f196103820b59b820d03d0969a0a3`, so the submitted PR no longer contains the red predecessor commit. The final exact matrix above is green on the only surviving commit.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A to this pure Ink TypeScript slice; the authoritative integrated gates are recorded above
- [x] I've added tests for my changes
- [x] I've tested on my platform — the authoritative final GitHub Actions matrix is green on the exact submitted object

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A: **N/A; the new execution seam is documented in code and this PR, with no user-facing behavior enabled yet**
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A: **N/A; no configuration keys changed**
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A: **N/A; no contributor workflow changed, and the shared command-plane architecture remains owned by #96692**
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A: **N/A for platform-specific I/O; this is a pure TypeScript identity/dispatch projection with no filesystem, process, path, shell, or OS API behavior**
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A: **N/A; no Hermes tool behavior or schema changed**

## Screenshots / Logs

No visual surface changes; screenshots are not applicable.

Final submitted object: `2b329821a73f196103820b59b820d03d0969a0a3`, one commit / two paths. CI, Docker, and Nix are all green; the PR is clean and mergeable against the current landing edge. This is producer-side exact-object evidence, not self-review or independent acceptance.