### PR TITLE
fix(tts): explain denied output paths and expose auto-TTS failures

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -6585,6 +6585,12 @@ class BasePlatformAdapter(ABC):
                                     if path and Path(path).exists()
                                 ]
                                 _tts_path = _tts_paths[0] if _tts_paths else None
+                            else:
+                                logger.warning(
+                                    "[%s] Auto-TTS failed: %s",
+                                    self.name,
+                                    tts_data.get("error") or "unknown tool error",
+                                )
                     except Exception as tts_err:
                         logger.warning("[%s] Auto-TTS failed: %s", self.name, tts_err)
 

--- a/tests/gateway/test_base_auto_tts_output_format.py
+++ b/tests/gateway/test_base_auto_tts_output_format.py
@@ -116,7 +116,7 @@ async def _run_auto_tts(adapter: _DummyAdapter, platform: Platform):
 
 
 @pytest.mark.asyncio
-async def test_base_auto_tts_skips_playback_when_tool_reports_failure():
+async def test_base_auto_tts_logs_and_skips_playback_when_tool_reports_failure(caplog):
     """A success=False tool result must not deliver a stale/partial file."""
     adapter = _DummyAdapter(Platform.TELEGRAM)
     adapter._keep_typing = _hold_typing()
@@ -139,5 +139,6 @@ async def test_base_auto_tts_skips_playback_when_tool_reports_failure():
         )
 
     adapter.play_tts.assert_not_awaited()
+    assert "[Telegram] Auto-TTS failed: backend exploded" in caplog.text
     # Text reply still goes out.
     assert adapter.sent and adapter.sent[0]["content"] == "reply text"

--- a/tests/tools/test_tts_path_traversal.py
+++ b/tests/tools/test_tts_path_traversal.py
@@ -48,7 +48,7 @@ def test_output_path_rejects_hermes_oauth_store(tmp_path, monkeypatch):
     ))
 
     assert result["success"] is False
-    assert "protected credential" in result["error"]
+    assert "protected system/credential file" in result["error"]
     assert not target.exists()
 
 
@@ -69,5 +69,5 @@ def test_output_path_rejects_mcp_token_directory(tmp_path, monkeypatch):
     ))
 
     assert result["success"] is False
-    assert "protected credential" in result["error"]
+    assert "protected system/credential file" in result["error"]
     assert not target.exists()

--- a/tests/tools/test_tts_write_safety.py
+++ b/tests/tools/test_tts_write_safety.py
@@ -1,0 +1,71 @@
+"""TTS output-path errors preserve the file-safety denial class."""
+
+import json
+from pathlib import Path
+
+from tools.tts_tool import _text_to_speech_single, text_to_speech_tool
+
+
+def _assert_safe_root_error(result: str, safe_root: Path) -> None:
+    data = json.loads(result)
+    assert data["success"] is False
+    assert "outside HERMES_WRITE_SAFE_ROOT" in data["error"]
+    assert str(safe_root) in data["error"]
+    assert "credential" not in data["error"]
+
+
+def test_single_tts_reports_safe_root_denial(tmp_path, monkeypatch):
+    safe_root = tmp_path / "allowed"
+    safe_root.mkdir()
+    monkeypatch.setenv("HERMES_WRITE_SAFE_ROOT", str(safe_root))
+
+    result = _text_to_speech_single(
+        "hello",
+        output_path=str(tmp_path / "outside.mp3"),
+        tts_config_override={"provider": "edge"},
+    )
+
+    _assert_safe_root_error(result, safe_root)
+
+
+def test_chunking_wrapper_reports_safe_root_denial(tmp_path, monkeypatch):
+    safe_root = tmp_path / "allowed"
+    safe_root.mkdir()
+    monkeypatch.setenv("HERMES_WRITE_SAFE_ROOT", str(safe_root))
+
+    result = text_to_speech_tool(
+        "hello",
+        output_path=str(tmp_path / "outside.mp3"),
+    )
+
+    _assert_safe_root_error(result, safe_root)
+
+
+def test_single_tts_keeps_credential_denial_distinct(monkeypatch):
+    monkeypatch.delenv("HERMES_WRITE_SAFE_ROOT", raising=False)
+
+    result = _text_to_speech_single(
+        "hello",
+        output_path=str(Path.home() / ".ssh" / "id_rsa"),
+        tts_config_override={"provider": "edge"},
+    )
+
+    data = json.loads(result)
+    assert data["success"] is False
+    assert "protected system/credential file" in data["error"]
+    assert "HERMES_WRITE_SAFE_ROOT" not in data["error"]
+
+
+def test_single_tts_reports_approval_required_path(monkeypatch):
+    monkeypatch.delenv("HERMES_WRITE_SAFE_ROOT", raising=False)
+
+    result = _text_to_speech_single(
+        "hello",
+        output_path=str(Path.home() / ".ssh" / "config"),
+        tts_config_override={"provider": "edge"},
+    )
+
+    data = json.loads(result)
+    assert data["success"] is False
+    assert "requires explicit approval" in data["error"]
+    assert "credential" not in data["error"]

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -3139,6 +3139,24 @@ def _generate_kittentts(text: str, output_path: str, tts_config: Dict[str, Any])
 # ===========================================================================
 # Main tool function
 # ===========================================================================
+def _get_tts_write_error(path: Path) -> Optional[str]:
+    """Return the classified fail-closed error for a TTS output path."""
+    from agent.file_safety import (
+        get_write_denied_error,
+        is_write_approval_required,
+    )
+
+    error = get_write_denied_error(str(path), verb="TTS write")
+    if error is not None:
+        return error
+    if is_write_approval_required(str(path)):
+        return (
+            f"TTS write denied: '{path}' requires explicit approval. "
+            "Choose a normal audio output location."
+        )
+    return None
+
+
 def _text_to_speech_single(
     text: str,
     output_path: Optional[str] = None,
@@ -3231,15 +3249,11 @@ def _text_to_speech_single(
             file_path = _configured_command_tts_output_path(
                 file_path, command_provider_config
             )
-        from agent.file_safety import is_write_approval_required, is_write_denied
-
-        if is_write_denied(str(file_path)) or is_write_approval_required(str(file_path)):
+        write_error = _get_tts_write_error(file_path)
+        if write_error is not None:
             return json.dumps({
                 "success": False,
-                "error": (
-                    f"output_path targets a protected credential or system path: "
-                    f"{file_path}. Choose a normal audio output location."
-                ),
+                "error": write_error,
             }, ensure_ascii=False)
     else:
         timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S_%f")
@@ -3590,14 +3604,11 @@ def text_to_speech_tool(
             base_path = _configured_command_tts_output_path(
                 base_path, command_provider_config,
             )
-        from agent.file_safety import is_write_approval_required, is_write_denied
-        if is_write_denied(str(base_path)) or is_write_approval_required(str(base_path)):
+        write_error = _get_tts_write_error(base_path)
+        if write_error is not None:
             return json.dumps({
                 "success": False,
-                "error": (
-                    f"output_path targets a protected credential or system path: "
-                    f"{base_path}. Choose a normal audio output location."
-                ),
+                "error": write_error,
             }, ensure_ascii=False)
     else:
         timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S_%f")


### PR DESCRIPTION
## What does this PR do?

TTS callers now receive the real write-safety denial reason instead of every rejected output path being labeled as a protected credential or system path. Gateway auto-TTS also logs tool-reported failures, so operators can diagnose missing voice replies while the text reply continues to be delivered.

### Symptom

An output path outside `HERMES_WRITE_SAFE_ROOT` was reported as a protected credential or system path. On the `BasePlatformAdapter` voice-reply path, the same `success: false` result suppressed audio without any warning log.

### Impact

Users can receive a text reply with no corresponding auto-TTS voice reply, while operators have neither an accurate error classification nor a gateway warning explaining the missing audio.

### Bug Cause

**Trigger:** `tools/tts_tool.py` explicit output-path guards and `gateway/platforms/base.py` auto-TTS result handling.

**Causal chain:**
1. A caller supplies a TTS output path rejected by write safety, including a path outside `HERMES_WRITE_SAFE_ROOT`.
2. Both TTS guards collapse every denial class into one credential/system-path message, and the base adapter only handles successful tool results or raised exceptions.
3. The caller sees a misleading denial, while returned JSON failures produce no audio and no gateway warning.

**Why it is wrong:** The shared file-safety layer already distinguishes safe-root, credential, and approval-required paths. The TTS tool discarded that classification, and the adapter treated a normal error result as an unremarkable empty path list.

**Working sibling / contrast:** `GatewayRunner._send_voice_reply` already warns when the TTS tool reports failure, and file tools already render `get_write_denied_error()` classifications.

**Ruled out:** PR #80398 relocates a default auto-TTS output directory but does not classify caller-supplied denied paths or log `BasePlatformAdapter` tool failures.

### Fix

Use the shared classified denial renderer at both TTS output-path guards, retain a distinct fail-closed message for approval-required paths, and warn when base-adapter auto-TTS receives `success: false`. Regression tests cover safe-root, credential, approval-required, logging, playback suppression, and continued text delivery behavior.

## Related Issue

Closes #97110

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/tts_tool.py` - preserve write-safety denial classes for single and chunked TTS paths.
- `gateway/platforms/base.py` - log tool-reported auto-TTS failures.
- `tests/tools/test_tts_write_safety.py` - exercise safe-root, credential, and approval-required errors.
- `tests/gateway/test_base_auto_tts_output_format.py` - verify warning logs, no stale playback, and continued text delivery.

## How to Test

1. Set `HERMES_WRITE_SAFE_ROOT` to one directory and request TTS output in a different directory; verify the error names the safe-root restriction.
2. Return `{"success": false, "error": "backend exploded"}` from base-adapter auto-TTS; verify a warning is logged, audio playback is skipped, and the text reply is sent.
3. Run:

```bash
scripts/run_tests.sh tests/tools/test_tts_write_safety.py tests/gateway/test_base_auto_tts_output_format.py -q
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant test entry and all targeted tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation update is not required for corrected runtime errors and logging
- [x] `cli-config.yaml.example` update is not required because no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are not required because no architecture or workflow changed
- [x] I've considered cross-platform impact; the shared path classifier retains platform-specific path handling
- [x] Tool schema updates are not required because parameters and response shape are unchanged
