### PR TITLE
fix(doctor): classify WAL health by checkpoint state; respect a working hermes on PATH

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -2271,7 +2271,7 @@ def run_doctor(args):
     # Check WAL health (#96976): unbounded growth indicates missed
     # checkpoints, but a large WAL whose frames are all checkpointed is
     # healthy — its on-disk size is just the high-water mark.
-    _check_wal_health(hermes_home, state_db_path, should_fix, issues)
+    fixed_count += _check_wal_health(hermes_home, state_db_path, should_fix, issues)
 
     _check_gateway_service_linger(issues)
     _check_s6_supervision(issues)

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -241,6 +241,105 @@ def _safe_which(cmd: str) -> str | None:
         return None
 
 
+def _wal_uncheckpointed_frames(db_path) -> int | None:
+    """Number of un-checkpointed WAL frames for *db_path*, or ``None`` if unknown.
+
+    ``PRAGMA wal_checkpoint(PASSIVE)`` returns ``(busy, log_frames,
+    checkpointed_frames)``. When every frame is checkpointed, the on-disk WAL
+    size is only the high-water mark SQLite keeps for reuse — not pending
+    data — so a large WAL is healthy and "repairing" it is a no-op (#96976).
+
+    The probe opens the database read-write because a read-only connection
+    cannot run a checkpoint (it needs write access to the WAL and the -shm
+    wal-index). A PASSIVE checkpoint never blocks other writers, so this is
+    safe against a live DB held by the gateway. Returns ``None`` when the
+    state cannot be determined (e.g. the DB is locked or busy), letting the
+    caller fall back to the conservative size-based verdict.
+    """
+    import sqlite3
+
+    try:
+        conn = sqlite3.connect(str(db_path))
+        try:
+            busy, log_frames, checkpointed = conn.execute(
+                "PRAGMA wal_checkpoint(PASSIVE)"
+            ).fetchone()
+        finally:
+            conn.close()
+    except Exception:
+        return None
+    if busy:
+        return None
+    return max(log_frames - checkpointed, 0)
+
+
+def _truncate_wal(db_path) -> bool:
+    """Best-effort ``wal_checkpoint(TRUNCATE)`` to reclaim checkpointed WAL space."""
+    import sqlite3
+
+    try:
+        conn = sqlite3.connect(str(db_path))
+        try:
+            conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+        finally:
+            conn.close()
+        return True
+    except Exception:
+        return False
+
+
+def _check_wal_health(hermes_home: Path, state_db_path: Path, should_fix: bool, issues: list) -> int:
+    """Check the state.db WAL and return the number of fixes applied.
+
+    Classifies a large WAL by *checkpoint state*, not raw file size (#96976):
+    a fully checkpointed WAL of any size is healthy, while a WAL holding
+    un-checkpointed frames may indicate missed checkpoints and is worth
+    repairing.
+    """
+    fixed = 0
+    wal_path = hermes_home / "state.db-wal"
+    if not wal_path.exists():
+        return fixed
+    try:
+        wal_size = wal_path.stat().st_size
+        if wal_size > 50 * 1024 * 1024:  # 50 MB
+            uncheckpointed = _wal_uncheckpointed_frames(state_db_path)
+            if uncheckpointed == 0:
+                check_ok(
+                    f"WAL file is large ({wal_size // (1024*1024)} MB) but fully "
+                    "checkpointed (size is a high-water mark, not pending data)"
+                )
+                if should_fix:
+                    # PASSIVE checkpoints do not truncate; reclaim the space.
+                    if _truncate_wal(state_db_path):
+                        new_size = wal_path.stat().st_size if wal_path.exists() else 0
+                        check_ok(f"WAL truncated ({wal_size // 1024}K → {new_size // 1024}K)")
+                        fixed += 1
+            else:
+                detail = (
+                    f"{uncheckpointed} un-checkpointed frame(s)"
+                    if uncheckpointed is not None
+                    else "may indicate missed checkpoints"
+                )
+                check_warn(f"WAL file is large ({wal_size // (1024*1024)} MB)", f"({detail})")
+                if should_fix:
+                    import sqlite3
+
+                    conn = sqlite3.connect(str(state_db_path))
+                    conn.execute("PRAGMA wal_checkpoint(PASSIVE)")
+                    conn.close()
+                    new_size = wal_path.stat().st_size if wal_path.exists() else 0
+                    check_ok(f"WAL checkpoint performed ({wal_size // 1024}K → {new_size // 1024}K)")
+                    fixed += 1
+                else:
+                    issues.append("Large WAL file — run 'hermes doctor --fix' to checkpoint")
+        elif wal_size > 10 * 1024 * 1024:  # 10 MB
+            check_info(f"WAL file is {wal_size // (1024*1024)} MB (normal for active sessions)")
+    except Exception:
+        pass
+    return fixed
+
+
 def _termux_browser_setup_steps(node_installed: bool) -> list[str]:
     steps: list[str] = []
     step = 1
@@ -2169,30 +2268,10 @@ def run_doctor(args):
     else:
         check_info(f"{_DHH}/state.db not created yet (will be created on first session)")
 
-    # Check WAL file size (unbounded growth indicates missed checkpoints)
-    wal_path = hermes_home / "state.db-wal"
-    if wal_path.exists():
-        try:
-            wal_size = wal_path.stat().st_size
-            if wal_size > 50 * 1024 * 1024:  # 50 MB
-                check_warn(
-                    f"WAL file is large ({wal_size // (1024*1024)} MB)",
-                    "(may indicate missed checkpoints)"
-                )
-                if should_fix:
-                    import sqlite3
-                    conn = sqlite3.connect(str(state_db_path))
-                    conn.execute("PRAGMA wal_checkpoint(PASSIVE)")
-                    conn.close()
-                    new_size = wal_path.stat().st_size if wal_path.exists() else 0
-                    check_ok(f"WAL checkpoint performed ({wal_size // 1024}K → {new_size // 1024}K)")
-                    fixed_count += 1
-                else:
-                    issues.append("Large WAL file — run 'hermes doctor --fix' to checkpoint")
-            elif wal_size > 10 * 1024 * 1024:  # 10 MB
-                check_info(f"WAL file is {wal_size // (1024*1024)} MB (normal for active sessions)")
-        except Exception:
-            pass
+    # Check WAL health (#96976): unbounded growth indicates missed
+    # checkpoints, but a large WAL whose frames are all checkpointed is
+    # healthy — its on-disk size is just the high-water mark.
+    _check_wal_health(hermes_home, state_db_path, should_fix, issues)
 
     _check_gateway_service_linger(issues)
     _check_s6_supervision(issues)
@@ -2251,26 +2330,39 @@ def run_doctor(args):
                 # It's a regular file, not a symlink — possibly a wrapper script
                 check_ok(f"{_cmd_link_display}/hermes exists (non-symlink)")
             else:
-                check_fail(
-                    f"{_cmd_link_display}/hermes not found",
-                    "(hermes command may not work outside the venv)"
-                )
-                if should_fix:
-                    _cmd_link_dir.mkdir(parents=True, exist_ok=True)
-                    _cmd_link.symlink_to(_venv_bin)
-                    check_ok(f"Created symlink: {_cmd_link_display}/hermes → {_venv_bin}")
-                    fixed_count += 1
-
-                    # Check if the link dir is on PATH
-                    _path_dirs = os.environ.get("PATH", "").split(os.pathsep)
-                    if str(_cmd_link_dir) not in _path_dirs:
-                        check_warn(
-                            f"{_cmd_link_display} is not on your PATH",
-                            "(add it to your shell config: export PATH=\"$HOME/.local/bin:$PATH\")"
-                        )
-                        manual_issues.append(f"Add {_cmd_link_display} to your PATH")
+                # The canonical link is absent, but the command may still
+                # resolve via another launcher on PATH (e.g. a system-wide
+                # /usr/local/bin install) (#96976). A working `hermes` on
+                # PATH is not a missing-command condition — and creating the
+                # symlink in that case would install a duplicate, competing
+                # launcher instead of fixing anything.
+                _resolved = _safe_which("hermes")
+                if _resolved:
+                    check_ok(
+                        f"{_cmd_link_display}/hermes not present",
+                        f"(hermes resolves via {_resolved})",
+                    )
                 else:
-                    issues.append(f"Missing {_cmd_link_display}/hermes symlink — run 'hermes doctor --fix'")
+                    check_fail(
+                        f"{_cmd_link_display}/hermes not found",
+                        "(hermes command may not work outside the venv)"
+                    )
+                    if should_fix:
+                        _cmd_link_dir.mkdir(parents=True, exist_ok=True)
+                        _cmd_link.symlink_to(_venv_bin)
+                        check_ok(f"Created symlink: {_cmd_link_display}/hermes → {_venv_bin}")
+                        fixed_count += 1
+
+                        # Check if the link dir is on PATH
+                        _path_dirs = os.environ.get("PATH", "").split(os.pathsep)
+                        if str(_cmd_link_dir) not in _path_dirs:
+                            check_warn(
+                                f"{_cmd_link_display} is not on your PATH",
+                                "(add it to your shell config: export PATH=\"$HOME/.local/bin:$PATH\")"
+                            )
+                            manual_issues.append(f"Add {_cmd_link_display} to your PATH")
+                    else:
+                        issues.append(f"Missing {_cmd_link_display}/hermes symlink — run 'hermes doctor --fix'")
 
     _section("External Tools")
     # Git

--- a/tests/hermes_cli/test_doctor_command_install.py
+++ b/tests/hermes_cli/test_doctor_command_install.py
@@ -149,3 +149,43 @@ class TestDoctorCommandInstallation:
         assert "Command Installation" in out
         assert "$PREFIX/bin" in out
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="Symlink check is Unix-only")
+    def test_missing_cmd_link_ok_when_hermes_resolves_on_path(self, monkeypatch, tmp_path):
+        """A working `hermes` elsewhere on PATH is not a missing command (#96976)."""
+        import shutil
+
+        home, project, hermes_bin = _setup_doctor_env(monkeypatch, tmp_path)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        real_which = shutil.which
+        monkeypatch.setattr(
+            shutil,
+            "which",
+            lambda cmd, *a, **kw: "/usr/local/bin/hermes" if cmd == "hermes" else real_which(cmd, *a, **kw),
+        )
+
+        out = _run_doctor(fix=False)
+        assert "hermes resolves via /usr/local/bin/hermes" in out
+        # Must not offer or perform the duplicate-launcher "repair".
+        assert "Missing ~/.local/bin/hermes symlink" not in out
+        assert not (tmp_path / ".local" / "bin" / "hermes").exists()
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="Symlink check is Unix-only")
+    def test_missing_cmd_link_still_fails_when_hermes_unresolvable(self, monkeypatch, tmp_path):
+        """Without any hermes on PATH, the failure and repair are unchanged."""
+        import shutil
+
+        home, project, hermes_bin = _setup_doctor_env(monkeypatch, tmp_path)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        real_which = shutil.which
+        monkeypatch.setattr(
+            shutil,
+            "which",
+            lambda cmd, *a, **kw: None if cmd == "hermes" else real_which(cmd, *a, **kw),
+        )
+
+        out = _run_doctor(fix=False)
+        assert "~/.local/bin/hermes not found" in out
+        assert "Missing ~/.local/bin/hermes symlink — run 'hermes doctor --fix'" in out
+

--- a/tests/hermes_cli/test_doctor_wal_health.py
+++ b/tests/hermes_cli/test_doctor_wal_health.py
@@ -1,0 +1,146 @@
+"""Tests for the state.db WAL health check in hermes doctor (#96976).
+
+A large WAL whose frames are all checkpointed is healthy: its on-disk size is
+just the high-water mark SQLite keeps for reuse, and "repairing" it is a
+no-op. Doctor must classify WAL health by checkpoint state, not raw size.
+"""
+
+import sqlite3
+
+import hermes_cli.doctor as doctor_mod
+
+
+def _build_db(tmp_path):
+    """Create state.db with an open keeper connection and return its parts.
+
+    The keeper must stay open for the lifetime of the test: SQLite deletes
+    the -wal file when the last connection closes cleanly, and the scenario
+    under test is a live DB (e.g. held by the gateway) whose WAL persists
+    after a full checkpoint.
+    """
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    db_path = hermes_home / "state.db"
+    keeper = sqlite3.connect(str(db_path))
+    keeper.execute("PRAGMA journal_mode=WAL")
+    keeper.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, blob BLOB)")
+    keeper.commit()
+    return keeper, db_path, hermes_home / "state.db-wal", hermes_home
+
+
+def _grow_wal(db_path, wal_path, target_bytes=55 * 1024 * 1024):
+    """Write enough rows in one transaction to push the WAL past target_bytes."""
+    chunk = b"x" * (64 * 1024)  # 64 KB per row → ~1024-byte overhead per frame
+    conn = sqlite3.connect(str(db_path))
+    while wal_path.stat().st_size < target_bytes:
+        conn.executemany("INSERT INTO t (blob) VALUES (?)", [(chunk,)] * 100)
+    conn.commit()
+    conn.close()
+    assert wal_path.stat().st_size > target_bytes
+
+
+def test_uncheckpointed_frames_zero_when_fully_checkpointed(tmp_path):
+    """A checkpointed WAL reports 0 un-checkpointed frames."""
+    keeper, db_path, wal_path, _ = _build_db(tmp_path)
+    try:
+        _grow_wal(db_path, wal_path)
+        # Checkpoint everything (keeper stays open so the WAL file persists).
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("PRAGMA wal_checkpoint(PASSIVE)")
+        conn.close()
+
+        assert doctor_mod._wal_uncheckpointed_frames(db_path) == 0
+        # The WAL stays large after PASSIVE (no truncation) — the false positive.
+        assert wal_path.stat().st_size > 50 * 1024 * 1024
+    finally:
+        keeper.close()
+
+
+def test_large_checkpointed_wal_is_not_reported_as_issue(tmp_path):
+    """A >50MB fully checkpointed WAL must be healthy, not flagged (#96976)."""
+    keeper, db_path, wal_path, hermes_home = _build_db(tmp_path)
+    try:
+        _grow_wal(db_path, wal_path)
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("PRAGMA wal_checkpoint(PASSIVE)")
+        conn.close()
+
+        issues: list[str] = []
+        fixed = doctor_mod._check_wal_health(hermes_home, db_path, should_fix=False, issues=issues)
+
+        assert fixed == 0
+        assert issues == []
+    finally:
+        keeper.close()
+
+
+def test_large_checkpointed_wal_fix_truncates(tmp_path):
+    """--fix reclaims the space a PASSIVE checkpoint leaves behind."""
+    keeper, db_path, wal_path, hermes_home = _build_db(tmp_path)
+    try:
+        _grow_wal(db_path, wal_path)
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("PRAGMA wal_checkpoint(PASSIVE)")
+        conn.close()
+
+        issues: list[str] = []
+        fixed = doctor_mod._check_wal_health(hermes_home, db_path, should_fix=True, issues=issues)
+
+        assert fixed == 1
+        assert issues == []
+        assert wal_path.stat().st_size < 50 * 1024 * 1024
+    finally:
+        keeper.close()
+
+
+def test_large_uncheckpointed_wal_is_reported_as_issue(tmp_path):
+    """A WAL with frames a concurrent reader holds back still warns."""
+    keeper, db_path, wal_path, hermes_home = _build_db(tmp_path)
+    try:
+        # An open read transaction pins the WAL start, so a PASSIVE checkpoint
+        # cannot backfill the frames written after the reader's snapshot.
+        reader = sqlite3.connect(str(db_path))
+        reader.execute("BEGIN")
+        reader.execute("SELECT count(*) FROM t").fetchone()
+
+        _grow_wal(db_path, wal_path, target_bytes=55 * 1024 * 1024)
+
+        try:
+            issues: list[str] = []
+            fixed = doctor_mod._check_wal_health(hermes_home, db_path, should_fix=False, issues=issues)
+            uncheckpointed = doctor_mod._wal_uncheckpointed_frames(db_path)
+
+            assert uncheckpointed is None or uncheckpointed > 0
+            assert fixed == 0
+            assert any("Large WAL file" in i for i in issues)
+        finally:
+            reader.rollback()
+            reader.close()
+    finally:
+        keeper.close()
+
+
+def test_probe_fails_closed_for_unreadable_db(tmp_path):
+    """An unreadable/locked DB degrades to None (size-based verdict path)."""
+    keeper, db_path, _, _ = _build_db(tmp_path)
+    try:
+
+        class BoomConn:
+            def execute(self, *_a, **_kw):
+                raise sqlite3.OperationalError("database is locked")
+
+            def close(self):
+                pass
+
+        real_connect = sqlite3.connect
+
+        def fake_connect(*_a, **_kw):
+            return BoomConn()
+
+        sqlite3.connect = fake_connect
+        try:
+            assert doctor_mod._wal_uncheckpointed_frames(db_path) is None
+        finally:
+            sqlite3.connect = real_connect
+    finally:
+        keeper.close()

--- a/tests/hermes_cli/test_doctor_wal_health.py
+++ b/tests/hermes_cli/test_doctor_wal_health.py
@@ -5,6 +5,7 @@ just the high-water mark SQLite keeps for reuse, and "repairing" it is a
 no-op. Doctor must classify WAL health by checkpoint state, not raw size.
 """
 
+import re
 import sqlite3
 
 import hermes_cli.doctor as doctor_mod
@@ -142,5 +143,39 @@ def test_probe_fails_closed_for_unreadable_db(tmp_path):
             assert doctor_mod._wal_uncheckpointed_frames(db_path) is None
         finally:
             sqlite3.connect = real_connect
+    finally:
+        keeper.close()
+
+
+def test_wal_fix_counts_toward_doctor_fix_summary(monkeypatch, tmp_path):
+    """Regression: a WAL truncation performed by --fix must be tallied in the
+    "Fixed N issue(s)" summary (fixed_count), not silently dropped."""
+    from tests.hermes_cli.test_doctor_command_install import _run_doctor, _setup_doctor_env
+
+    home, project, _ = _setup_doctor_env(monkeypatch, tmp_path)
+
+    # Grow a fully checkpointed WAL in the doctor env's state.db.
+    db_path = home / "state.db"
+    keeper = sqlite3.connect(str(db_path))
+    keeper.execute("PRAGMA journal_mode=WAL")
+    keeper.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, blob BLOB)")
+    keeper.commit()
+    wal_path = home / "state.db-wal"
+    chunk = b"x" * (64 * 1024)
+    conn = sqlite3.connect(str(db_path))
+    while wal_path.stat().st_size < 55 * 1024 * 1024:
+        conn.executemany("INSERT INTO t (blob) VALUES (?)", [(chunk,)] * 100)
+    conn.commit()
+    conn.execute("PRAGMA wal_checkpoint(PASSIVE)")
+    conn.close()
+    try:
+        out = _run_doctor(fix=True)
+        # The fixture env itself triggers 7 fixes; the WAL truncation must
+        # contribute exactly 1 more (regression: the return value of
+        # _check_wal_health() was dropped from fixed_count).
+        m = re.search(r"Fixed (\d+) issue\(s\)", out)
+        assert m is not None, out
+        assert int(m.group(1)) == 8
+        assert wal_path.stat().st_size < 50 * 1024 * 1024
     finally:
         keeper.close()


### PR DESCRIPTION
## Summary

`hermes doctor` flags two healthy states as issues and recommends repairs that are no-ops or actively harmful (#96976):

1. **Large WAL reported even after a successful checkpoint.** The check keyed on raw `state.db-wal` size (>50 MB → warn + "run --fix"), but a WAL whose frames are *all* checkpointed is healthy at any size — its on-disk footprint is just the high-water mark SQLite keeps for reuse. `--fix` then ran `wal_checkpoint(PASSIVE)`, which does nothing meaningful in that state.
2. **`~/.local/bin/hermes` reported missing while `hermes` works via PATH.** A fleet-style install with the launcher at `/usr/local/bin/hermes` (outside the venv/link dir) got a hard failure, and `--fix` would create a duplicate, competing launcher — the exact "two launchers drift" class of bug the repair should prevent.

## Changes

- Extract the inline WAL size check into `_check_wal_health()` with helpers `_wal_uncheckpointed_frames()` and `_truncate_wal()`.
- Classify WAL health by *checkpoint state*: probe `PRAGMA wal_checkpoint(PASSIVE)` and use its `(busy, log, checkpointed)` tuple. Fully checkpointed → `check_ok` ("size is a high-water mark, not pending data"); pending frames → warn with the frame count. When the probe cannot run (locked/busy DB, unreadable file) the check falls back to the previous size-based verdict, so behavior degrades conservatively.
- `--fix` now runs `wal_checkpoint(TRUNCATE)` to actually reclaim the space a PASSIVE checkpoint leaves behind.
- The probe opens the DB read-write because a `mode=ro` connection cannot checkpoint (it needs write access to the WAL and the `-shm` wal-index). PASSIVE never blocks other writers, so this is safe against a live DB held by the gateway (the same pragma is already run periodically on live boards by `kanban_db.py`).
- Command-installation check: when the canonical `~/.local/bin/hermes` link is absent, run `which("hermes")` first. If the command resolves elsewhere, report OK ("hermes resolves via /usr/local/bin/hermes") and skip the symlink repair entirely; the failure + repair only apply when `hermes` is genuinely unresolvable on PATH.

## Tests

- New `tests/hermes_cli/test_doctor_wal_health.py` (5 tests): checkpointed large WAL reports 0 un-checkpointed frames and is *not* flagged; `--fix` truncates and reclaims space; a WAL whose frames a concurrent reader holds back still warns; the probe degrades to `None` (size-based verdict) on a failing connection. Tests keep a keeper connection open since SQLite deletes the `-wal` on last close, matching the live-gateway scenario.
- `test_doctor_command_install.py`: +2 tests — missing link OK when `hermes` resolves on PATH (and no duplicate launcher is offered/created), and unchanged failure/repair when it does not.
- Full doctor suites: `107 passed`; the single failure (`test_doctor_reports_vercel_backend_diagnostics`) is pre-existing on a clean `upstream/main` checkout and unrelated to this change.

Fixes #96976