### PR TITLE
fix(whatsapp): contain late media stream errors

### DIFF
--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -40,6 +40,7 @@ import {
   buildLocationPayload,
   buildTextSendPayload,
   createBoundedMessageStore,
+  downloadMediaToBuffer,
   extractBridgeEvent,
   inboundReadReceiptKeys,
   inferMediaType,
@@ -419,6 +420,12 @@ async function startSocket() {
     },
   });
 
+  const downloadInboundMedia = downloadMediaToBuffer(
+    downloadMediaMessage,
+    { logger, reuploadRequest: sock.updateMediaMessage },
+    (err) => console.warn('[bridge] late inbound media stream error:', err?.message || err),
+  );
+
   sock.ev.on('creds.update', () => { saveCreds(); lidToPhone = buildLidMap(); });
 
   sock.ev.on('connection.update', (update) => {
@@ -726,7 +733,7 @@ async function startSocket() {
         senderNumber,
         botIds,
         isGroup,
-        downloadMedia: async (mediaMsg) => downloadMediaMessage(mediaMsg, 'buffer', {}, { logger, reuploadRequest: sock.updateMediaMessage }),
+        downloadMedia: downloadInboundMedia,
         cacheDirs: {
           image: IMAGE_CACHE_DIR,
           document: DOCUMENT_CACHE_DIR,

--- a/scripts/whatsapp-bridge/bridge.native.test.mjs
+++ b/scripts/whatsapp-bridge/bridge.native.test.mjs
@@ -10,6 +10,7 @@ import { createHash } from 'node:crypto';
 import { mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
+import { PassThrough } from 'node:stream';
 import { getAggregateVotesInPollMessage } from '@whiskeysockets/baileys';
 
 import {
@@ -17,12 +18,67 @@ import {
   buildTextSendPayload,
   createBoundedMessageStore,
   appendMediaFailureNote,
+  downloadMediaToBuffer,
   extractBridgeEvent,
   inboundReadReceiptKeys,
   mediaPayloadForFile,
   pollCreationMessageFromPayload,
   pollUpdateForAggregation,
 } from './bridge_helpers.js';
+
+// -- inbound media stream containment ------------------------------------
+{
+  const stream = new PassThrough();
+  const requestedTypes = [];
+  const download = downloadMediaToBuffer(async (_msg, type) => {
+    requestedTypes.push(type);
+    queueMicrotask(() => {
+      stream.write(Buffer.from('media'));
+      stream.end();
+    });
+    return stream;
+  });
+
+  assert.equal((await download({ key: { id: 'media-ok' } })).toString(), 'media');
+  assert.deepEqual(requestedTypes, ['stream']);
+  console.log('  ✓ inbound media is explicitly consumed as a stream');
+}
+
+{
+  const stream = new PassThrough();
+  const download = downloadMediaToBuffer(async () => {
+    queueMicrotask(() => stream.destroy(new Error('HTTP/2 stream reset')));
+    return stream;
+  });
+
+  await assert.rejects(() => download({ key: { id: 'media-fail' } }), /HTTP\/2 stream reset/);
+  console.log('  ✓ active media stream errors reject into the message boundary');
+}
+
+{
+  const stream = new PassThrough();
+  const lateErrors = [];
+  const download = downloadMediaToBuffer(
+    async () => {
+      queueMicrotask(() => stream.end(Buffer.from('complete')));
+      return stream;
+    },
+    {},
+    (err) => lateErrors.push(err.message),
+  );
+
+  assert.equal((await download({ key: { id: 'media-late' } })).toString(), 'complete');
+  stream.emit('error', new Error('late HTTP/2 reset'));
+  assert.deepEqual(lateErrors, ['late HTTP/2 reset']);
+
+  const next = new PassThrough();
+  const nextDownload = downloadMediaToBuffer(async () => {
+    queueMicrotask(() => next.end(Buffer.from('next')));
+    return next;
+  });
+  assert.equal((await nextDownload({ key: { id: 'media-next' } })).toString(), 'next');
+  console.log('  ✓ late media stream errors stay contained and later downloads continue');
+}
 
 // -- inbound read receipts ------------------------------------------------
 {

--- a/scripts/whatsapp-bridge/bridge_helpers.js
+++ b/scripts/whatsapp-bridge/bridge_helpers.js
@@ -296,6 +296,53 @@ export function appendMediaFailureNote(content, failures) {
   return content ? `${content}\n${note}` : note;
 }
 
+export function downloadMediaToBuffer(downloadMediaMessage, options = {}, onLateError) {
+  return async (mediaMsg) => {
+    const stream = await downloadMediaMessage(mediaMsg, 'stream', {}, options);
+    if (!stream || typeof stream.on !== 'function') {
+      throw new TypeError('media download did not return a readable stream');
+    }
+
+    return new Promise((resolve, reject) => {
+      const chunks = [];
+      let settled = false;
+
+      const cleanup = () => {
+        stream.removeListener('data', onData);
+        stream.removeListener('end', onEnd);
+        stream.removeListener('close', onClose);
+      };
+      const finish = (fn, value) => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        fn(value);
+      };
+      const onData = (chunk) => chunks.push(Buffer.from(chunk));
+      const onEnd = () => finish(resolve, Buffer.concat(chunks));
+      const onClose = () => finish(reject, new Error('media stream closed before completing'));
+      const onError = (err) => {
+        if (!settled) {
+          finish(reject, err);
+          return;
+        }
+        try {
+          onLateError?.(err);
+        } catch {}
+      };
+
+      // Keep the error listener after settlement. Some HTTP/2-backed Baileys
+      // streams emit a transport error on a later tick after their consumer
+      // has completed; removing this listener would turn that into an
+      // uncaught exception and terminate the bridge.
+      stream.on('error', onError);
+      stream.on('data', onData);
+      stream.once('end', onEnd);
+      stream.once('close', onClose);
+    });
+  };
+}
+
 export async function extractBridgeEvent({
   msg,
   chatId,


### PR DESCRIPTION
## Summary

- request inbound Baileys media as a readable stream instead of relying on its internal buffer consumer
- consume the stream behind a local error boundary so transfer failures reach the existing media-failure note path
- retain the stream error listener after completion to contain late HTTP/2 transport errors without terminating the bridge

## Root Cause

`downloadMediaMessage(..., "buffer")` owns the stream consumer internally. A transport `error` emitted after that consumer detached can escape the awaited promise and become an uncaught EventEmitter error. The bridge then exits and loses its in-memory inbound queue. Requesting the stream explicitly gives the bridge ownership of the error listener for the stream's full lifetime.

## Testing

- `node --check scripts/whatsapp-bridge/bridge.js`
- `node --check scripts/whatsapp-bridge/bridge_helpers.js`
- all six `scripts/whatsapp-bridge/*.test.mjs` files
- regression cases cover successful buffering, active HTTP/2 stream failure, late post-completion error containment, and a subsequent successful download

## Related Issue

N/A
