### PR TITLE
fix(paths): display_hermes_home renders POSIX separators on Windows (kills ~/AppData\Local\hermes chimeras)

### DIFF
--- a/agent/subdirectory_hints.py
+++ b/agent/subdirectory_hints.py
@@ -314,8 +314,9 @@ class SubdirectoryHintTracker:
                     rel_path = str(hint_path.relative_to(self.working_dir))
                 except (ValueError, RuntimeError):
                     try:
-                        rel_path = str(hint_path.relative_to(Path.home()))
-                        rel_path = "~/" + rel_path
+                        # as_posix: "~/" shorthand implies POSIX rendering
+                        # (avoids ~/AppData\Local\... chimeras on Windows).
+                        rel_path = "~/" + hint_path.relative_to(Path.home()).as_posix()
                     except (ValueError, RuntimeError):
                         pass  # keep absolute
                 found_hints.append((rel_path, content))

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11166,7 +11166,7 @@ def cmd_profile(args):
 
             # Profile dir for display
             try:
-                profile_dir_display = "~/" + str(profile_dir.relative_to(Path.home()))
+                profile_dir_display = "~/" + profile_dir.relative_to(Path.home()).as_posix()
             except ValueError:
                 profile_dir_display = str(profile_dir)
 

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -1009,7 +1009,13 @@ def display_hermes_home() -> str:
     """
     home = get_hermes_home()
     try:
-        return "~/" + str(home.relative_to(Path.home()))
+        # as_posix(): on Windows, str() of a relative Path renders
+        # backslashes, producing mixed-separator chimeras like
+        # ``~/AppData\Local\hermes/skills/`` once callers append
+        # sub-paths. ``~/`` shorthand implies POSIX rendering; keep the
+        # whole string consistent (forward slashes work everywhere,
+        # including Windows shells and Python APIs).
+        return "~/" + home.relative_to(Path.home()).as_posix()
     except ValueError:
         return str(home)
 

--- a/plugins/platforms/google_chat/oauth.py
+++ b/plugins/platforms/google_chat/oauth.py
@@ -90,7 +90,7 @@ except (ModuleNotFoundError, ImportError):
     def display_hermes_home() -> str:
         home = get_hermes_home()
         try:
-            return "~/" + str(home.relative_to(Path.home()))
+            return "~/" + home.relative_to(Path.home()).as_posix()
         except ValueError:
             return str(home)
 

--- a/skills/productivity/google-workspace/scripts/_hermes_home.py
+++ b/skills/productivity/google-workspace/scripts/_hermes_home.py
@@ -37,6 +37,6 @@ except (ModuleNotFoundError, ImportError):
         Mirrors ``hermes_constants.display_hermes_home()``."""
         home = get_hermes_home()
         try:
-            return "~/" + str(home.relative_to(Path.home()))
+            return "~/" + home.relative_to(Path.home()).as_posix()
         except ValueError:
             return str(home)

--- a/tests/test_display_hermes_home.py
+++ b/tests/test_display_hermes_home.py
@@ -1,0 +1,73 @@
+"""display_hermes_home() renders POSIX separators on every platform.
+
+Maintainer catch (#95681 arc): on Windows with a custom HERMES_HOME under
+the user profile (e.g. AppData/Local/hermes), ``"~/" +
+str(home.relative_to(Path.home()))`` produced the mixed-separator chimera
+``~/AppData\\Local\\hermes`` — which then leaked into every consumer that
+appends sub-paths (the skill_manage schema showed the agent
+``~/AppData\\Local\\hermes/skills/``). The ``~/`` shorthand implies POSIX
+rendering; the whole string must be consistent.
+"""
+import os
+import sys
+import unittest
+from pathlib import Path, PureWindowsPath
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+class TestDisplayHermesHomePosix(unittest.TestCase):
+    def test_nested_home_renders_forward_slashes(self):
+        """Simulate the Windows shape portably: home nested several levels
+        under the user profile must render with forward slashes only."""
+        import hermes_constants as hc
+
+        fake_userhome = Path.home()
+        nested = fake_userhome / "AppData" / "Local" / "hermes"
+        with patch.object(hc, "get_hermes_home", return_value=nested):
+            out = hc.display_hermes_home()
+        self.assertEqual(out, "~/AppData/Local/hermes")
+        self.assertNotIn("\\", out)
+
+    def test_default_home_unchanged(self):
+        import hermes_constants as hc
+
+        with patch.object(hc, "get_hermes_home",
+                          return_value=Path.home() / ".hermes"):
+            out = hc.display_hermes_home()
+        self.assertEqual(out, "~/.hermes")
+
+    def test_outside_home_falls_back_to_absolute(self):
+        import hermes_constants as hc
+
+        outside = Path("/opt/hermes-custom") if os.name != "nt" else Path("C:/opt/hermes-custom")
+        with patch.object(hc, "get_hermes_home", return_value=outside):
+            out = hc.display_hermes_home()
+        self.assertEqual(out, str(outside))
+
+    def test_no_serving_schema_carries_tilde_backslash_chimera(self):
+        """Fleet guard: no served tool schema string may combine '~/' with
+        a backslash — the class of bug, not the one site."""
+        from model_tools import get_tool_definitions
+
+        offenders = []
+
+        def walk(o, tool):
+            if isinstance(o, str):
+                if "~/" in o and "\\" in o:
+                    offenders.append((tool, o[:80]))
+            elif isinstance(o, dict):
+                for v in o.values():
+                    walk(v, tool)
+            elif isinstance(o, list):
+                for v in o:
+                    walk(v, tool)
+
+        for t in get_tool_definitions(quiet_mode=True):
+            walk(t, t["function"]["name"])
+        self.assertEqual(offenders, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Maintainer catch: on Windows with HERMES_HOME under the user profile, the skill_manage schema taught the agent that new skills land in `~/AppData\Local\hermes/skills/` — a POSIX `~/` prefix, Windows backslashes in the middle, forward slashes at the end.

## Root cause
`display_hermes_home()` (hermes_constants.py) built the display string as `"~/" + str(home.relative_to(Path.home()))`. On POSIX `str()` of a relative path gives forward slashes; on Windows it gives backslashes, and the `~/` prefix + any appended sub-path (`.../skills/`) complete the chimera. 57 call sites consume this helper (schemas, CLI messages, gateway delivery notes, setup prompts), so the bug surfaced everywhere HERMES_HOME wasn't literally `~/.hermes` (a single-segment relative path renders identically either way — which is why non-Windows and default-home installs never saw it).

## Fix — whole class, not the one site
- `display_hermes_home()`: `str(...)` → `.as_posix()` (the `~/` shorthand implies POSIX rendering; forward slashes work everywhere including Windows shells and Python APIs). All 57 consumers inherit the fix.
- Same hand-rolled pattern fixed at its 3 other sites: `agent/subdirectory_hints.py` (AGENTS.md hint paths), `hermes_cli/main.py` (profile dir display), `plugins/platforms/google_chat/oauth.py` + the google-workspace skill's vendored `_hermes_home.py` (both mirror the helper).

## Verified live (this Windows box, HERMES_HOME=AppData/Local/hermes — the repro config)
- before: `~/AppData\Local\hermes` · after: `~/AppData/Local/hermes`
- walked every string in every served tool schema: zero `~/`+backslash chimeras remain (skill_manage now teaches `~/AppData/Local/hermes/skills/`)

## Tests (4 new, all platform-portable — no Windows runner needed)
nested-home renders forward-slashes-only · default `~/.hermes` unchanged · outside-home falls back to absolute (unchanged) · **fleet guard**: no served schema string may ever combine `~/` with a backslash (pins the class).

Zero token delta — path bytes swap like-for-like (default homes literally unchanged).