### PR TITLE
feat(commands): establish classic CLI command bindings

### DIFF
--- a/hermes_cli/classic_cli_command_bindings.py
+++ b/hermes_cli/classic_cli_command_bindings.py
@@ -1,0 +1,210 @@
+"""Canonical classic-CLI slash-command bindings and invocation normalization.
+
+This module is the bounded PR-3 seam between the central command definition
+owner and the legacy :meth:`cli.HermesCLI.process_command` dispatcher.  It does
+not own command spelling, aliases, help text, argument semantics, policy, or
+result rendering.  Those remain registry/dispatcher concerns.
+
+Current main does not yet expose the versioned ``command_id`` field declared by
+#96692.  Bindings therefore use it when present and otherwise fall back to the
+canonical command name.  That compatibility rule lets the classic CLI adopt the
+stable identity automatically when the schema slice lands, without creating a
+second registry in the meantime.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+
+from hermes_cli.commands import COMMAND_REGISTRY, CommandDef, resolve_command
+
+
+_COMMAND_LINE_RE = re.compile(r"^/(?P<entered>[^\s/]+)(?P<tail>\s.*)?$", re.DOTALL)
+
+
+def _command_id(command: CommandDef) -> str:
+    """Return the stable identity available on this source tree."""
+    value = getattr(command, "command_id", None)
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return command.name
+
+
+def _classic_cli_candidate(command: CommandDef) -> bool:
+    """Return whether a command can be invoked from the classic CLI."""
+    return not command.gateway_only
+
+
+@dataclass(frozen=True, slots=True)
+class ClassicCLICommandBinding:
+    """One classic-CLI execution binding for one canonical command identity."""
+
+    command_id: str
+    canonical_name: str
+    dispatch_method: str
+    shared_execute: str | None
+
+    @classmethod
+    def from_command(cls, command: CommandDef) -> "ClassicCLICommandBinding":
+        return cls(
+            command_id=_command_id(command),
+            canonical_name=command.name,
+            dispatch_method="process_command",
+            shared_execute=getattr(command, "execute", None),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ClassicCLIInvocation:
+    """Normalized classic-CLI command attempt bound to canonical identity."""
+
+    binding: ClassicCLICommandBinding
+    entered_name: str
+    raw_arguments: str
+    canonical_input: str
+
+
+def build_classic_cli_bindings(
+    commands: Iterable[CommandDef] = COMMAND_REGISTRY,
+) -> tuple[ClassicCLICommandBinding, ...]:
+    """Build the immutable classic-CLI binding projection.
+
+    Duplicate semantic identities or canonical names fail closed.  Aliases do
+    not create additional bindings; they resolve to the canonical ``CommandDef``
+    before invocation settlement.
+    """
+    bindings: list[ClassicCLICommandBinding] = []
+    seen_ids: set[str] = set()
+    seen_names: set[str] = set()
+
+    for command in commands:
+        if not _classic_cli_candidate(command):
+            continue
+        binding = ClassicCLICommandBinding.from_command(command)
+        command_id = binding.command_id.strip()
+        canonical_name = binding.canonical_name.strip()
+        if not command_id:
+            raise ValueError("classic CLI command identity must not be blank")
+        if not canonical_name:
+            raise ValueError("classic CLI canonical command name must not be blank")
+
+        id_key = command_id.casefold()
+        name_key = canonical_name.casefold()
+        if id_key in seen_ids:
+            raise ValueError(f"duplicate classic CLI command identity: {command_id}")
+        if name_key in seen_names:
+            raise ValueError(
+                f"duplicate classic CLI canonical command name: {canonical_name}"
+            )
+        seen_ids.add(id_key)
+        seen_names.add(name_key)
+        bindings.append(binding)
+
+    return tuple(bindings)
+
+
+CLASSIC_CLI_COMMAND_BINDINGS: tuple[ClassicCLICommandBinding, ...] = (
+    build_classic_cli_bindings()
+)
+_BINDINGS_BY_ID = {
+    binding.command_id.casefold(): binding for binding in CLASSIC_CLI_COMMAND_BINDINGS
+}
+_BINDINGS_BY_NAME = {
+    binding.canonical_name.casefold(): binding
+    for binding in CLASSIC_CLI_COMMAND_BINDINGS
+}
+
+
+def _typed_token(value: str) -> str:
+    normalized = str(value or "").strip()
+    if normalized.startswith("/"):
+        normalized = normalized[1:]
+    return normalized.split(None, 1)[0].casefold() if normalized else ""
+
+
+def resolve_classic_cli_command_binding(
+    token: str,
+) -> ClassicCLICommandBinding | None:
+    """Resolve a typed name or alias to exactly one classic-CLI binding."""
+    typed = _typed_token(token)
+    if not typed:
+        return None
+    command = resolve_command(typed)
+    if command is None or not _classic_cli_candidate(command):
+        return None
+
+    binding = _BINDINGS_BY_ID.get(_command_id(command).casefold())
+    if binding is not None:
+        return binding
+    # Mixed-version compatibility: a process may gain stable ids after this
+    # immutable module snapshot was built.  Resolve only the same canonical
+    # owner; never guess across aliases or catalog order.
+    return _BINDINGS_BY_NAME.get(command.name.casefold())
+
+
+def normalize_classic_cli_invocation(
+    command_line: str,
+) -> ClassicCLIInvocation | None:
+    """Normalize one slash-shaped CLI input without changing its arguments.
+
+    Unknown commands, gateway-only commands, and ordinary prompt text return
+    ``None``.  The entered alias is retained for provenance while execution is
+    routed with the canonical name.  Argument spelling and case are preserved;
+    only the separator between the command token and arguments is normalized to
+    the exact text accepted by the legacy dispatcher.
+    """
+    if not isinstance(command_line, str):
+        return None
+    text = command_line.strip()
+    match = _COMMAND_LINE_RE.fullmatch(text)
+    if match is None:
+        return None
+
+    entered_name = match.group("entered")
+    binding = resolve_classic_cli_command_binding(entered_name)
+    if binding is None:
+        return None
+
+    tail = match.group("tail") or ""
+    raw_arguments = tail.lstrip()
+    canonical_input = f"/{binding.canonical_name}"
+    if raw_arguments:
+        canonical_input = f"{canonical_input} {raw_arguments}"
+
+    return ClassicCLIInvocation(
+        binding=binding,
+        entered_name=entered_name,
+        raw_arguments=raw_arguments,
+        canonical_input=canonical_input,
+    )
+
+
+def bind_classic_cli_dispatch(
+    cli: object,
+    token: str,
+) -> Callable[[str], bool] | None:
+    """Return the legacy dispatcher callable for a canonical CLI command."""
+    binding = resolve_classic_cli_command_binding(token)
+    if binding is None:
+        return None
+    dispatcher = getattr(cli, binding.dispatch_method, None)
+    return dispatcher if callable(dispatcher) else None
+
+
+def dispatch_classic_cli_command(cli: object, command_line: str) -> bool | None:
+    """Dispatch through the canonical binding while preserving legacy output.
+
+    The legacy ``process_command`` method remains the current execution owner;
+    this seam canonicalizes identity and alias routing only.  ``None`` means the
+    attempt was not admitted or no callable owner exists.  A future shared
+    dispatcher can replace the callable without changing the binding contract.
+    """
+    invocation = normalize_classic_cli_invocation(command_line)
+    if invocation is None:
+        return None
+    dispatcher = getattr(cli, invocation.binding.dispatch_method, None)
+    if not callable(dispatcher):
+        return None
+    return dispatcher(invocation.canonical_input)

--- a/tests/hermes_cli/test_classic_cli_command_bindings.py
+++ b/tests/hermes_cli/test_classic_cli_command_bindings.py
@@ -1,0 +1,128 @@
+"""Characterization for the classic-CLI command binding seam."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_cli.classic_cli_command_bindings import (
+    CLASSIC_CLI_COMMAND_BINDINGS,
+    bind_classic_cli_dispatch,
+    build_classic_cli_bindings,
+    dispatch_classic_cli_command,
+    normalize_classic_cli_invocation,
+    resolve_classic_cli_command_binding,
+)
+from hermes_cli.commands import COMMAND_REGISTRY, CommandDef, resolve_command
+
+
+def test_projection_is_immutable_unique_and_excludes_gateway_only_commands():
+    assert isinstance(CLASSIC_CLI_COMMAND_BINDINGS, tuple)
+    assert CLASSIC_CLI_COMMAND_BINDINGS
+
+    ids = [binding.command_id.casefold() for binding in CLASSIC_CLI_COMMAND_BINDINGS]
+    names = [
+        binding.canonical_name.casefold()
+        for binding in CLASSIC_CLI_COMMAND_BINDINGS
+    ]
+    assert len(ids) == len(set(ids))
+    assert len(names) == len(set(names))
+
+    projected = set(names)
+    expected = {
+        command.name.casefold()
+        for command in COMMAND_REGISTRY
+        if not command.gateway_only
+    }
+    assert projected == expected
+
+
+def test_alias_and_canonical_name_resolve_to_the_same_binding():
+    canonical = resolve_classic_cli_command_binding("branch")
+    alias = resolve_classic_cli_command_binding("/fork")
+
+    assert canonical is not None
+    assert alias is canonical
+    assert resolve_command("fork") is resolve_command("branch")
+
+
+def test_invocation_preserves_entered_alias_and_argument_text():
+    invocation = normalize_classic_cli_invocation("  /FoRk Mixed CASE --Flag  ")
+
+    assert invocation is not None
+    assert invocation.binding.canonical_name == "branch"
+    assert invocation.entered_name == "FoRk"
+    assert invocation.raw_arguments == "Mixed CASE --Flag"
+    assert invocation.canonical_input == "/branch Mixed CASE --Flag"
+
+
+def test_unknown_gateway_only_and_non_command_inputs_fail_closed():
+    assert normalize_classic_cli_invocation("plain prompt text") is None
+    assert normalize_classic_cli_invocation("/definitely-not-a-command") is None
+    assert normalize_classic_cli_invocation("/approve session") is None
+    assert resolve_classic_cli_command_binding("approve") is None
+
+
+def test_duplicate_fallback_identity_fails_closed():
+    first = CommandDef("duplicate", "first", "Test")
+    second = CommandDef("duplicate", "second", "Test")
+
+    with pytest.raises(ValueError, match="duplicate classic CLI command identity"):
+        build_classic_cli_bindings((first, second))
+
+
+def test_future_stable_identity_is_adopted_without_another_registry():
+    command = SimpleNamespace(
+        name="future-command",
+        command_id="session.future",
+        gateway_only=False,
+        execute=None,
+    )
+
+    bindings = build_classic_cli_bindings((command,))  # type: ignore[arg-type]
+
+    assert bindings[0].command_id == "session.future"
+    assert bindings[0].canonical_name == "future-command"
+
+
+def test_blank_future_identity_falls_back_to_canonical_name():
+    command = SimpleNamespace(
+        name="fallback-command",
+        command_id="   ",
+        gateway_only=False,
+        execute=None,
+    )
+
+    bindings = build_classic_cli_bindings((command,))  # type: ignore[arg-type]
+
+    assert bindings[0].command_id == "fallback-command"
+
+
+def test_dispatch_uses_canonical_input_and_preserves_legacy_result():
+    class StubCLI:
+        seen: str | None = None
+
+        def process_command(self, command: str) -> bool:
+            self.seen = command
+            return False
+
+    cli = StubCLI()
+
+    assert dispatch_classic_cli_command(cli, "/fork Mixed CASE") is False
+    assert cli.seen == "/branch Mixed CASE"
+
+
+def test_binding_returns_the_existing_process_command_owner():
+    class StubCLI:
+        def process_command(self, command: str) -> bool:
+            return command == "/version"
+
+    cli = StubCLI()
+    dispatcher = bind_classic_cli_dispatch(cli, "version")
+
+    assert dispatcher is not None
+    assert dispatcher("/version") is True
+
+
+def test_missing_dispatch_owner_fails_closed():
+    assert bind_classic_cli_dispatch(object(), "version") is None
+    assert dispatch_classic_cli_command(object(), "/version") is None


### PR DESCRIPTION
## What does this PR do?

Implements the **Classic CLI slice (PR 3)** of #96692 without inventing a second command registry or speculating about the not-yet-landed v2 invocation ABI.

The current repository already has a partial semantic center in `hermes_cli.commands.COMMAND_REGISTRY` and `resolve_command()`, while Classic CLI execution still terminates in the legacy `HermesCLI.process_command` owner. The prerequisite PR1/PR2 contracts named by #96692 — stable `command_id`, `CommandInvocation`, `CommandResult`, `commands.catalog.v2`, and `commands.invoke` — are not on `main` yet. Rewriting the large CLI dispatcher before those contracts exist would create the exact split-authority failure class #96692 is meant to eliminate.

This PR therefore adds the smallest independently landable **Classic CLI binding + invocation-normalization seam** on current repository truth. It does **not** change production call sites or terminal UX yet.

### Invariant

> Classic CLI may own presentation and interaction UX, but it may not independently reconstruct command identity, alias meaning, or execution ownership.

The seam enforces that invariant by:

- projecting one immutable `ClassicCLICommandBinding` for each non-gateway-only canonical `CommandDef`;
- resolving aliases through the existing canonical `resolve_command()` owner rather than creating another alias table;
- adopting `CommandDef.command_id` automatically when that stable field exists, with canonical name as the explicit current-v1 compatibility identity;
- preserving the user's entered alias and exact argument text while settling dispatch on canonical identity;
- routing canonicalized execution into the existing `HermesCLI.process_command` owner and preserving its current boolean/output contract;
- failing closed for unknown commands, ordinary prompt text, gateway-only commands, blank identities, duplicate stable IDs, duplicate canonical projections, and missing dispatcher owners;
- never falling back from a slash-shaped command attempt into prompt text.

### Exact submitted object

- Base: [`911a41ec971095ef211b07fe22b7c2dd4d3e255b`](https://github.com/NousResearch/hermes-agent/commit/911a41ec971095ef211b07fe22b7c2dd4d3e255b)
- Head: [`92cc1ee77971c15441031bce5308d03dd3854fef`](https://github.com/andrexibiza/hermes-agent/commit/92cc1ee77971c15441031bce5308d03dd3854fef)
- Tree: `1f07aedbd344acd1de593fd0720d2b3e699f64fd`
- Shape: **1 commit, 2 files, +338 / -0**
- Production call-site rewrites: **0**
- Current terminal behavior/output: **unchanged**

### Why this shape is correct now

This is not represented as the completed end-state of PR3. The full migration still requires the PR1/PR2 ABI named by #96692 so Classic CLI parsing, help, completion, policy admission, execution, and typed results can all consume the same catalog revision and dispatcher. Until those contracts exist, this PR establishes only the dependency-free boundary that can consume them later without manufacturing a competing semantic owner.

The intended progression is:

```text
current
CLI input
  -> command grammar
  -> canonical resolve_command()
  -> ClassicCLIInvocation
  -> ClassicCLICommandBinding
  -> current process_command owner

future after PR1/PR2
CLI input
  -> commands.catalog.v2 revision
  -> CommandInvocation
  -> central policy / dispatcher
  -> CommandResult
```

No compatibility code in this PR is allowed to become a second source of command truth.

## Related Issue

Part of #96692 — **Unified slash-command registry and execution contract across every Hermes surface**.

This PR does **not** close #96692; it is the PR3 Classic CLI migration slice in that issue's ordered plan.

### Prior work / provenance

- #96791 by **OutThisLife** is merged prior work that moved Hermes toward registry-backed command metadata and catalog projection. This PR composes with that ownership and does not duplicate it: https://github.com/NousResearch/hermes-agent/pull/96791
- #96705 is historical stable-ID/versioned-catalog design provenance only; it is not treated as the current landing object: https://github.com/NousResearch/hermes-agent/pull/96705
- #97102 is PR0 and owns the executable inventory/characterization baseline: https://github.com/NousResearch/hermes-agent/pull/97102
- #97114 owns the gateway command-binding seam: https://github.com/NousResearch/hermes-agent/pull/97114
- #97124 owns the Desktop command-binding seam: https://github.com/NousResearch/hermes-agent/pull/97124
- #97129 owns the Ink TUI command-binding seam: https://github.com/NousResearch/hermes-agent/pull/97129

Prior work by **OutThisLife in #96791** shaped this implementation and is also credited in the submitted commit.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `hermes_cli/classic_cli_command_bindings.py` (**210 lines**)
  - immutable Classic CLI binding projection from canonical `CommandDef` objects;
  - stable semantic identity selection (`command_id` when available, canonical v1 name otherwise);
  - canonical alias settlement through `resolve_command()`;
  - slash-attempt normalization that preserves entered-name and argument provenance;
  - explicit duplicate identity / duplicate projection rejection;
  - fail-closed execution binding to the current `HermesCLI.process_command` owner.
- Added `tests/hermes_cli/test_classic_cli_command_bindings.py` (**128 lines**)
  - exact current registry projection;
  - immutable and case-insensitively unique binding identities;
  - canonical-name / alias object identity;
  - entered-alias and argument preservation;
  - ordinary-text, unknown-command, and gateway-only refusal;
  - duplicate identity refusal;
  - future stable-ID adoption with explicit current-v1 fallback;
  - dispatch into the existing execution owner with return preservation;
  - missing-owner refusal.
- Kept both new files below the repository's **2,000-line** limit.
- Did **not** edit `hermes_cli/commands.py`, `cli.py`, `hermes_cli/cli_commands_mixin.py`, `gateway/slash_commands.py`, `tui_gateway/methods_tools.py`, Desktop command projection files, or Ink TUI command owners.

### FILE-LIST / collision check

The two changed paths were new at publication and had no open-PR owner. Sibling slash-command slices are path-disjoint.

`main` subsequently advanced from the publication base. The latest checked main during this body reconciliation was [`9978706e9303dbf990d90e744b131361449d73b9`](https://github.com/NousResearch/hermes-agent/commit/9978706e9303dbf990d90e744b131361449d73b9). Base→main was **5 commits ahead / 0 behind**, changing 12 paths; neither PR3 path was among them. GitHub continued to report #97138 mergeable. No churn-only restack was performed because there is no landing-edge path collision.

## How to Test

1. Run the focused Classic CLI binding characterization:

   ```bash
   scripts/run_tests.sh tests/hermes_cli/test_classic_cli_command_bindings.py -q
   ```

2. Verify the ten intended semantic edges: projection parity, immutable identity, alias settlement, entered-name provenance, argument preservation, fail-closed unknown/gateway/text handling, duplicate rejection, stable-ID compatibility, existing-owner dispatch, and missing-owner refusal.

3. Verify the exact submitted head `92cc1ee77971c15441031bce5308d03dd3854fef` against the hosted acceptance receipts:

   - [CI `33170917375`](https://github.com/NousResearch/hermes-agent/actions/runs/33170917375) — **SUCCESS**
   - [Docker `33170916781`](https://github.com/NousResearch/hermes-agent/actions/runs/33170916781) — **SUCCESS** on amd64 and arm64, including integration tests
   - [Nix `33170916754`](https://github.com/NousResearch/hermes-agent/actions/runs/33170916754) — **SUCCESS**
   - [Exact-head closure receipt](https://github.com/NousResearch/hermes-agent/pull/97138#issuecomment-5452519093)

Before publication, both changed files also passed Python byte-compilation and the dependency-isolated focused contract run passed **10/10** cases. Hosted exact-head CI above is the authoritative repository-level acceptance evidence.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — repository full Python test execution is green on the exact submitted head in [CI `33170917375`](https://github.com/NousResearch/hermes-agent/actions/runs/33170917375)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: exact-head CI executed the applicable Linux, macOS, and Windows lanes; Docker also passed on amd64 and arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — **N/A: no user-facing command behavior, help text, or public API is changed in this seam**
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — **N/A: no config keys changed**
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — **N/A: no contributor workflow or agent instruction contract changed; the command-plane architecture is already specified by #96692**
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — exact-head Linux/macOS/Windows lanes are green
- [x] I've updated tool descriptions/schemas if I changed tool behavior — **N/A: no tool schema or tool behavior changed**

## Screenshots / Logs

No screenshots are applicable: this PR intentionally changes no terminal rendering or user-visible command output.

### Exact-object verification state

- Materialization: **target_present** — https://github.com/NousResearch/hermes-agent/pull/97138
- Integrity: **exact_object_verified** — CI/Docker/Nix receipts above bind to head `92cc1ee77971c15441031bce5308d03dd3854fef`
- Governance: **unreviewed** — no producer-authored review has been submitted and no independent acceptance is claimed
- Integration: **open** — the PR is open, not merged
- Operation: **hermetic_verified** — repository tests execute the submitted code; no stronger production/operational claim is made
- Lineage: **active** — no superseding PR is claimed for this exact PR3 slice

The completion claim is intentionally limited to **submitted + exact-object verified**. Exact-head green does not imply maintainer acceptance, merge, release, or production operation.
