### PR TITLE
fix(cron): resolve named Telegram DM topics

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3310,6 +3310,73 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         delivered = False
         target_errors = []
 
+        # Named Telegram private-DM topic target (``telegram:<positive_chat_id>:<topic_name>``):
+        # the topic name is a non-numeric label that must be resolved to a real
+        # thread id through the live adapter (ensure_dm_topic) before text or
+        # media delivery. This is the cron sibling of the live DeliveryRouter
+        # path in gateway/delivery.py. Fail closed when no live adapter is
+        # available — silently delivering into General would be worse than a
+        # visible error.
+        from gateway.delivery import (
+            _looks_like_int,
+            looks_like_telegram_private_chat_id,
+        )
+
+        if (
+            platform == Platform.TELEGRAM
+            and thread_id is not None
+            and not _looks_like_int(str(thread_id))
+            and looks_like_telegram_private_chat_id(str(chat_id))
+        ):
+            if not live_adapter_ready:
+                msg = (
+                    f"named Telegram private-DM topic target {platform_name}:{chat_id}:{thread_id} "
+                    "requires a live gateway adapter to resolve the topic name; "
+                    "no live adapter is available"
+                )
+                logger.warning("Job '%s': %s", job["id"], msg)
+                delivery_errors.append(msg)
+                continue
+            ensure_dm_topic = getattr(runtime_adapter, "ensure_dm_topic", None)
+            if ensure_dm_topic is None:
+                msg = (
+                    f"named Telegram private-DM topic target {platform_name}:{chat_id}:{thread_id} "
+                    "cannot be resolved: the live adapter has no ensure_dm_topic"
+                )
+                logger.warning("Job '%s': %s", job["id"], msg)
+                delivery_errors.append(msg)
+                continue
+            try:
+                from agent.async_utils import safe_schedule_threadsafe
+
+                future = safe_schedule_threadsafe(
+                    ensure_dm_topic(str(chat_id), str(thread_id)), loop,
+                )
+                if future is None:
+                    raise RuntimeError("gateway event loop scheduling failed")
+                resolved_thread_id = future.result(timeout=30)
+            except Exception as ex:
+                msg = (
+                    f"failed to resolve named Telegram private-DM topic "
+                    f"{platform_name}:{chat_id}:{thread_id}: {ex}"
+                )
+                logger.warning("Job '%s': %s", job["id"], msg)
+                delivery_errors.append(msg)
+                continue
+            if not resolved_thread_id:
+                msg = (
+                    f"failed to resolve named Telegram private-DM topic "
+                    f"{platform_name}:{chat_id}:{thread_id} (adapter returned no thread id)"
+                )
+                logger.warning("Job '%s': %s", job["id"], msg)
+                delivery_errors.append(msg)
+                continue
+            logger.info(
+                "Job '%s': resolved named Telegram private-DM topic %s:%s:%s -> thread_id=%s",
+                job["id"], platform_name, chat_id, thread_id, resolved_thread_id,
+            )
+            thread_id = str(resolved_thread_id)
+
         # Continuable cron surface (D1/D2/D6): resolve the delivery surface for
         # this platform generically from its config ``extra``. Default "thread"
         # (today's behaviour, byte-identical). "in_channel" delivers the brief

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -243,6 +243,115 @@ class TestResolveDeliveryTarget:
         }
 
 
+    def test_named_telegram_private_dm_topic_target_is_parsed(self):
+        """``telegram:<positive_chat_id>:<topic_name>`` splits into chat + topic name.
+
+        Regression for #80483: the topic name is a non-numeric label, not a
+        numeric thread id, so it must not be swallowed into the chat id.
+        """
+        job = {"deliver": "telegram:722341991:Debug"}
+        with patch(
+            "gateway.channel_directory.resolve_channel_name", return_value=None
+        ):
+            result = _resolve_delivery_target(job)
+        assert result == {
+            "platform": "telegram",
+            "chat_id": "722341991",
+            "thread_id": "Debug",
+            "_resolved_from": "explicit",
+        }
+
+
+class TestNamedTelegramTopicCronDelivery:
+    """Cron delivery of a named Telegram private-DM topic target (#80483).
+
+    ``telegram:<positive_chat_id>:<topic_name>`` must be resolved to a real
+    thread id through the live adapter (ensure_dm_topic) before text/media
+    delivery, and must fail closed when no live adapter is available.
+    """
+
+    def _telegram_cfg(self):
+        from gateway.config import Platform
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        pconfig.extra = {}
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+        return mock_cfg
+
+    def _run_delivery(self, adapter, *, loop_running=True, deliver="telegram:722341991:Debug"):
+        from gateway.config import Platform
+        from concurrent.futures import Future
+
+        mock_cfg = self._telegram_cfg()
+        loop = MagicMock()
+        loop.is_running.return_value = loop_running
+
+        def fake_run_coro(coro, _loop):
+            future = Future()
+            try:
+                import asyncio as _asyncio
+                future.set_result(_asyncio.run(coro))
+            except BaseException as _e:  # noqa: BLE001
+                future.set_exception(_e)
+            return future
+
+        job = {
+            "id": "named-topic-job",
+            "name": "Named Topic",
+            "deliver": deliver,
+        }
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("asyncio.run_coroutine_threadsafe", side_effect=fake_run_coro):
+            return _deliver_result(
+                job, "Here is the brief.",
+                adapters={Platform.TELEGRAM: adapter}, loop=loop,
+            )
+
+    def _telegram_adapter(self, resolved_thread_id: str | None = "38049"):
+        adapter = AsyncMock()
+        adapter.ensure_dm_topic = AsyncMock(return_value=resolved_thread_id)
+        adapter.send.return_value = MagicMock(
+            success=True, message_id="msg_1", raw_response=None,
+        )
+        return adapter
+
+    def test_named_topic_resolved_before_delivery(self):
+        """The topic name is resolved via ensure_dm_topic, then the resolved
+        thread id is used for the actual send."""
+        adapter = self._telegram_adapter()
+        err = self._run_delivery(adapter)
+
+        assert err is None
+        adapter.ensure_dm_topic.assert_awaited_once_with("722341991", "Debug")
+        # The send must carry the resolved thread id, not the raw topic name.
+        send_call = adapter.send.await_args
+        assert send_call is not None
+        assert send_call.args[0] == "722341991"
+        assert send_call.kwargs["metadata"]["thread_id"] == "38049"
+
+    def test_named_topic_fails_closed_without_live_adapter(self):
+        """No live adapter -> the named topic cannot be resolved -> fail closed
+        (no silent delivery into General)."""
+        adapter = self._telegram_adapter()
+        err = self._run_delivery(adapter, loop_running=False)
+
+        assert err is not None
+        assert "requires a live gateway adapter" in err
+        adapter.send.assert_not_awaited()
+
+    def test_named_topic_fails_closed_when_resolution_fails(self):
+        """ensure_dm_topic returning no thread id -> fail closed."""
+        adapter = self._telegram_adapter(resolved_thread_id=None)
+        err = self._run_delivery(adapter)
+
+        assert err is not None
+        assert "returned no thread id" in err
+        adapter.send.assert_not_awaited()
+
+
     def test_human_friendly_label_resolved_via_channel_directory(self):
         """deliver: 'whatsapp:Alice (dm)' resolves to the real JID."""
         job = {"deliver": "whatsapp:Alice (dm)"}

--- a/tests/tools/test_send_message_target_parse.py
+++ b/tests/tools/test_send_message_target_parse.py
@@ -25,6 +25,50 @@ def test_photon_e164_target_is_explicit() -> None:
     assert is_explicit is True
 
 
+def test_telegram_named_private_dm_topic_is_parsed() -> None:
+    """``telegram:<positive_chat_id>:<topic_name>`` splits into chat + topic name.
+
+    Regression for #80483: the topic name is a non-numeric label, not a numeric
+    thread id, so it must not be swallowed into the chat id.
+    """
+    chat_id, thread_id, is_explicit = _parse_target_ref("telegram", "722341991:Debug")
+
+    assert chat_id == "722341991"
+    assert thread_id == "Debug"
+    assert is_explicit is True
+
+
+def test_telegram_numeric_topic_still_parses_as_thread_id() -> None:
+    """Numeric Telegram topic targets keep their existing shape."""
+    chat_id, thread_id, is_explicit = _parse_target_ref("telegram", "722341991:17")
+
+    assert chat_id == "722341991"
+    assert thread_id == "17"
+    assert is_explicit is True
+
+
+def test_telegram_named_topic_requires_positive_private_chat_id() -> None:
+    """A named topic on a negative (group/supergroup) chat id is not a private
+    DM topic — it must not be misparsed as one."""
+    chat_id, thread_id, is_explicit = _parse_target_ref(
+        "telegram", "-1001234567890:Debug"
+    )
+
+    assert chat_id is None
+    assert thread_id is None
+    assert is_explicit is False
+
+
+def test_discord_named_topic_is_not_recognized() -> None:
+    """Discord threads are always numeric snowflakes; a named label must not
+    be parsed as a Discord thread id."""
+    chat_id, thread_id, is_explicit = _parse_target_ref("discord", "999888777:Debug")
+
+    assert chat_id is None
+    assert thread_id is None
+    assert is_explicit is False
+
+
 def test_e164_target_still_requires_phone_platform() -> None:
     assert _parse_target_ref("matrix", "+15551234567")[2] is False
 

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -19,6 +19,13 @@ from agent.secret_scope import get_secret
 logger = logging.getLogger(__name__)
 
 _TELEGRAM_TOPIC_TARGET_RE = re.compile(r"^\s*(-?\d+)(?::(\d+))?\s*$")
+# Named Telegram private-DM topic targets: ``<positive_chat_id>:<topic_name>``.
+# Telegram private chats use positive chat IDs; the topic name is a non-numeric
+# label the live adapter resolves to a thread id (ensure_dm_topic). Kept
+# separate from _TELEGRAM_TOPIC_TARGET_RE (which Discord reuses via
+# _NUMERIC_TOPIC_RE) so a named topic is only recognized for Telegram, never
+# for Discord threads (which are always numeric snowflakes).
+_TELEGRAM_NAMED_TOPIC_TARGET_RE = re.compile(r"^\s*(\d+):([^:\s][^:]*)\s*$")
 _FEISHU_TARGET_RE = re.compile(r"^\s*((?:oc|ou|on|chat|open)_[-A-Za-z0-9]+)(?::([-A-Za-z0-9_]+))?\s*$")
 # Slack conversation IDs: C (public channel), G (private/group channel), D (DM).
 # Must be uppercase alphanumeric, 9+ chars. User IDs (U...) are parsed as
@@ -534,6 +541,13 @@ def _parse_target_ref(platform_name: str, target_ref: str):
     """Parse a tool target into chat_id/thread_id and whether it is explicit."""
     if platform_name == "telegram":
         match = _TELEGRAM_TOPIC_TARGET_RE.fullmatch(target_ref)
+        if match:
+            return match.group(1), match.group(2), True
+        # Named private-DM topic: ``<positive_chat_id>:<topic_name>``. The
+        # topic name is a non-numeric label the live adapter resolves to a
+        # thread id (ensure_dm_topic); it is NOT a numeric thread id, so it
+        # must not be confused with a forum topic or a channel DM topic.
+        match = _TELEGRAM_NAMED_TOPIC_TARGET_RE.fullmatch(target_ref)
         if match:
             return match.group(1), match.group(2), True
         from plugins.platforms.telegram.telegram_ids import (


### PR DESCRIPTION
Fixes #80483.

Cron targets such as `telegram:<private-chat-id>:<topic-name>` are now parsed without swallowing the topic label, resolved through the live Telegram adapter before delivery, and fail closed when the adapter cannot resolve the topic. Numeric Telegram topics and Discord parsing retain their existing behaviour.

Tests:
- Focused named-topic/parser tests: 12 passed
- `python -m pytest -q tests/tools/test_send_message_target_parse.py tests/cron/test_scheduler.py`: 122 passed
- `ruff check` on all four changed files