### PR TITLE
feat(gateway): configure public-facing replies

### DIFF
--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -58,6 +58,13 @@ _GLOBAL_DEFAULTS: dict[str, Any] = {
     # live, just cleaned up after success so the chat doesn't fill up with
     # stale breadcrumbs. Failed runs leave bubbles in place as breadcrumbs.
     "cleanup_progress": False,
+    # Customer-facing gateways can replace operator-oriented provider failure
+    # copy and keep /new confirmations free of runtime metadata. None preserves
+    # the built-in reply; details=True preserves model/provider/
+    # context information and the random tip.
+    "provider_error_reply": None,
+    "session_reset_reply": None,
+    "session_reset_details": True,
     # Live working-state status on platforms whose typing indicator renders
     # text (Slack's assistant status line). Values:
     #   "full" / true  -> verb + argument preview ("is running pytest…")
@@ -279,6 +286,7 @@ def _normalise(setting: str, value: Any) -> Any:
         "busy_ack_detail",
         "busy_steer_ack_enabled",
         "thinking_progress",
+        "session_reset_details",
     }:
         if isinstance(value, str):
             val = value.strip().lower()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -733,8 +733,36 @@ def _format_exec_approval_fallback(
         + ", ".join(choices[:-1]) + f", or {choices[-1]}."
     )
 
-def _gateway_provider_error_reply(text: str) -> str:
-    """Map raw provider/API errors to a short user-safe Telegram reply."""
+def _sanitize_gateway_configured_reply(value: Any) -> str:
+    """Make configured user-facing copy safe for gateway delivery."""
+    normalized = str(value).strip()
+    if not normalized:
+        return ""
+    try:
+        from agent.message_sanitization import _sanitize_surrogates
+
+        normalized = _sanitize_surrogates(normalized)
+    except Exception:
+        return ""
+    try:
+        from agent.redact import redact_sensitive_text
+
+        normalized = redact_sensitive_text(
+            normalized,
+            force=True,
+            redact_url_credentials=True,
+        )
+    except Exception:
+        return ""
+    return _redact_gateway_user_facing_secrets(normalized)
+
+
+def _gateway_provider_error_reply(text: str, custom_reply: Any = None) -> str:
+    """Map raw provider/API errors to a short user-safe gateway reply."""
+    if custom_reply is not None:
+        normalized = _sanitize_gateway_configured_reply(custom_reply)
+        if normalized:
+            return normalized
     if _GATEWAY_AUTH_ERROR_RE.search(text):
         return (
             "⚠️ Provider authentication failed. Check the configured credentials; "
@@ -798,6 +826,11 @@ def _looks_like_gateway_provider_error(text: str) -> bool:
     if not text:
         return False
     body = str(text).strip()
+    # _normalize_empty_agent_response wraps provider failures with this
+    # user-facing prefix. Classify the wrapped inner envelope rather than
+    # letting the wrapper bypass the provider-error sanitizer.
+    if body.lower().startswith("the request failed:"):
+        body = body.partition(":")[2].lstrip()
     # Provider failure envelopes are short. Assistant answers that happen
     # to mention HTTP status codes ("HTTP 404 means...") tend to be longer.
     if len(body) > 400 or body.count("\n") > 4:
@@ -840,7 +873,10 @@ def _sanitize_gateway_final_response(platform: Any, text: str) -> str:
 
     redacted = _redact_gateway_user_facing_secrets(str(text))
     if _looks_like_gateway_provider_error(redacted):
-        return _gateway_provider_error_reply(redacted)
+        return _gateway_provider_error_reply(
+            redacted,
+            _gateway_display_setting(platform, "provider_error_reply"),
+        )
     return redacted
 
 
@@ -870,7 +906,10 @@ def _prepare_gateway_status_message(platform: Any, event_type: str, message: str
         ):
             return None
     if _looks_like_gateway_provider_error(text):
-        return _gateway_provider_error_reply(text)
+        return _gateway_provider_error_reply(
+            text,
+            _gateway_display_setting(platform, "provider_error_reply"),
+        )
     return text
 
 
@@ -3629,6 +3668,25 @@ def _check_unavailable_skill(command_name: str) -> str | None:
 def _platform_config_key(platform: "Platform") -> str:
     """Map a Platform enum to its config.yaml key (LOCAL→"cli", rest→enum value)."""
     return "cli" if platform == Platform.LOCAL else platform.value
+
+
+def _gateway_display_setting(platform: Any, setting: str, fallback: Any = None) -> Any:
+    """Resolve a profile-scoped display setting for a gateway surface."""
+    try:
+        from gateway.display_config import resolve_display_setting
+
+        if isinstance(platform, str):
+            platform_key = platform.strip().lower()
+        else:
+            platform_key = _platform_config_key(platform)
+        return resolve_display_setting(
+            _load_gateway_config(),
+            platform_key,
+            setting,
+            fallback,
+        )
+    except Exception:
+        return fallback
 
 
 def _teams_pipeline_plugin_enabled() -> bool:

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -313,6 +313,43 @@ class GatewaySlashCommandsMixin:
             elif not _title_note:
                 # sanitize_title returned empty (whitespace-only / unprintable)
                 _title_note = t("gateway.reset.title_empty_untitled")
+        # Public/customer-facing chats can keep the reset confirmation while
+        # omitting operator-only model/provider/context metadata and the random
+        # tip. Resolution is profile-scoped, so multiplex routes honor the
+        # serving profile's config rather than the gateway root.
+        _show_reset_details = True
+        try:
+            from gateway.run import (
+                _gateway_display_setting,
+                _profile_runtime_scope,
+                _sanitize_gateway_configured_reply,
+            )
+
+            def _resolve_reset_display_settings():
+                return (
+                    _gateway_display_setting(source.platform, "session_reset_reply"),
+                    bool(
+                        _gateway_display_setting(
+                            source.platform, "session_reset_details", True
+                        )
+                    ),
+                )
+
+            if getattr(getattr(self, "config", None), "multiplex_profiles", False):
+                with _profile_runtime_scope(
+                    getattr(self, "_resolve_profile_home_for_source")(source)
+                ):
+                    _custom_reset_reply, _show_reset_details = (
+                        _resolve_reset_display_settings()
+                    )
+            else:
+                _custom_reset_reply, _show_reset_details = (
+                    _resolve_reset_display_settings()
+                )
+            if _custom_reset_reply is not None:
+                header = _sanitize_gateway_configured_reply(_custom_reset_reply)
+        except Exception:
+            pass
         header = header + _title_note
 
         # When /new runs inside a Telegram DM topic lane, rewrite the
@@ -342,10 +379,14 @@ class GatewaySlashCommandsMixin:
             pass
 
         # Append a random tip to the reset message
-        try:
-            from hermes_cli.tips import get_random_tip
-            _tip_line = t("gateway.reset.tip", tip=get_random_tip())
-        except Exception:
+        if _show_reset_details:
+            try:
+                from hermes_cli.tips import get_random_tip
+                _tip_line = t("gateway.reset.tip", tip=get_random_tip())
+            except Exception:
+                _tip_line = ""
+        else:
+            session_info = ""
             _tip_line = ""
 
         if session_info:

--- a/tests/gateway/test_session_model_reset.py
+++ b/tests/gateway/test_session_model_reset.py
@@ -100,3 +100,145 @@ async def test_new_command_only_clears_own_session():
     assert other_key in runner._session_reasoning_overrides
     assert session_key not in runner._pending_model_notes
     assert other_key in runner._pending_model_notes
+
+
+@pytest.mark.asyncio
+async def test_reset_reply_can_hide_operator_details_and_use_custom_text(monkeypatch):
+    """Public chats can confirm reset without model/provider/context metadata."""
+    import gateway.run as gateway_run
+
+    runner = _make_runner()
+    runner._reset_notice_session_info = lambda source: "Model: secret-model\nProvider: secret-provider\n"
+    runner._telegram_topic_new_header = lambda source: ""
+    runner._is_telegram_topic_lane = lambda source: False
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {
+            "display": {
+                "platforms": {
+                    "telegram": {
+                        "session_reset_reply": "New session started.",
+                        "session_reset_details": False,
+                    }
+                }
+            }
+        },
+    )
+
+    reply = str(await runner._handle_reset_command(_make_event("/new")))
+
+    assert reply == "New session started."
+    assert "secret-model" not in reply
+    assert "secret-provider" not in reply
+
+
+@pytest.mark.asyncio
+async def test_reset_reply_can_be_silent(monkeypatch):
+    """An explicit empty reset reply suppresses the confirmation banner."""
+    import gateway.run as gateway_run
+
+    runner = _make_runner()
+    runner._reset_notice_session_info = lambda source: "Model: secret-model\n"
+    runner._telegram_topic_new_header = lambda source: ""
+    runner._is_telegram_topic_lane = lambda source: False
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {
+            "display": {
+                "session_reset_reply": "",
+                "session_reset_details": False,
+            }
+        },
+    )
+
+    reply = str(await runner._handle_reset_command(_make_event("/reset")))
+
+    assert reply == ""
+
+
+@pytest.mark.asyncio
+async def test_reset_reply_uses_routed_profile_config_outside_outer_scope(tmp_path):
+    """Busy-path resets still resolve display settings from the routed profile."""
+    runner = _make_runner()
+    runner.config.multiplex_profiles = True
+    runner._resolve_profile_home_for_source = lambda source: tmp_path
+    runner._reset_notice_session_info = lambda source: "Model: secret-model\n"
+    runner._telegram_topic_new_header = lambda source: ""
+    runner._is_telegram_topic_lane = lambda source: False
+    (tmp_path / "config.yaml").write_text(
+        "display:\n"
+        "  platforms:\n"
+        "    telegram:\n"
+        "      session_reset_reply: Routed reset.\n"
+        "      session_reset_details: false\n",
+        encoding="utf-8",
+    )
+
+    reply = str(await runner._handle_reset_command(_make_event("/reset")))
+
+    assert reply == "Routed reset."
+    assert "secret-model" not in reply
+
+
+@pytest.mark.asyncio
+async def test_silent_reset_preserves_title_rejection_warning(monkeypatch):
+    """Title validation warnings survive when ordinary reset copy is hidden."""
+    import gateway.run as gateway_run
+
+    runner = _make_runner()
+    runner._session_db = SimpleNamespace(set_session_title=AsyncMock())
+    runner._reset_notice_session_info = lambda source: "Model: secret-model\n"
+    runner._telegram_topic_new_header = lambda source: ""
+    runner._is_telegram_topic_lane = lambda source: False
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {
+            "display": {
+                "session_reset_reply": "",
+                "session_reset_details": False,
+            }
+        },
+    )
+
+    reply = str(
+        await runner._handle_reset_command(_make_event("/new " + ("x" * 300)))
+    )
+
+    assert "title rejected" in reply.lower()
+    assert "secret-model" not in reply
+
+
+@pytest.mark.asyncio
+async def test_custom_reset_reply_is_safely_sanitized(monkeypatch):
+    """Configured reset copy cannot leak URL credentials or invalid surrogates."""
+    import gateway.run as gateway_run
+
+    credential = "abcdefghijklmnopqrstuvwxyz1234567890"
+    custom_reply = (
+        f"Reset https://user:{credential}@example.test/"
+        f"?token={credential} \ud800"
+    )
+    runner = _make_runner()
+    runner._reset_notice_session_info = lambda source: "Model: secret-model\n"
+    runner._telegram_topic_new_header = lambda source: ""
+    runner._is_telegram_topic_lane = lambda source: False
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {
+            "display": {
+                "session_reset_reply": custom_reply,
+                "session_reset_details": False,
+            }
+        },
+    )
+
+    reply = str(await runner._handle_reset_command(_make_event("/reset")))
+
+    assert reply.startswith("Reset ")
+    assert credential not in reply
+    assert "\ud800" not in reply
+    reply.encode("utf-8")

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -300,6 +300,179 @@ def test_telegram_final_response_redacts_auth_secrets():
     assert "sk-live" not in sanitized
 
 
+def test_provider_error_reply_uses_platform_display_override(monkeypatch):
+    """Customer-facing gateways can replace the safe technical fallback."""
+    import gateway.run as gateway_run
+
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {
+            "display": {
+                "platforms": {
+                    "telegram": {
+                        "provider_error_reply": "Please try again in a minute."
+                    }
+                }
+            }
+        },
+    )
+    raw = "API call failed after 3 retries: HTTP 401 Authorization: Bearer secret"
+
+    assert (
+        _sanitize_gateway_final_response(Platform.TELEGRAM, raw)
+        == "Please try again in a minute."
+    )
+
+
+def test_provider_error_reply_reads_active_profile_config(tmp_path):
+    """The real config path follows the active multiplex profile scope."""
+    from gateway.run import _profile_runtime_scope
+
+    (tmp_path / "config.yaml").write_text(
+        "display:\n"
+        "  platforms:\n"
+        "    telegram:\n"
+        "      provider_error_reply: Routed failure.\n",
+        encoding="utf-8",
+    )
+
+    with _profile_runtime_scope(tmp_path):
+        final_reply = _sanitize_gateway_final_response(
+            Platform.TELEGRAM,
+            "API call failed after 3 retries: HTTP 500",
+        )
+        status_reply = _prepare_gateway_status_message(
+            Platform.TELEGRAM,
+            "warn",
+            "API call failed after 3 retries: HTTP 500",
+        )
+
+    assert final_reply == "Routed failure."
+    assert status_reply == "Routed failure."
+
+
+def test_whitespace_provider_error_reply_uses_safe_builtin(monkeypatch):
+    """Whitespace-only overrides cannot erase the safe provider fallback."""
+    import gateway.run as gateway_run
+
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {"display": {"provider_error_reply": "   "}},
+    )
+
+    reply = _sanitize_gateway_final_response(
+        Platform.TELEGRAM,
+        "API call failed after 3 retries: HTTP 500",
+    )
+
+    assert "provider failed after retries" in reply.lower()
+
+
+def test_custom_provider_error_reply_is_safely_sanitized(monkeypatch):
+    """Configured copy cannot leak URL credentials or invalid surrogates."""
+    import gateway.run as gateway_run
+
+    credential = "abcdefghijklmnopqrstuvwxyz1234567890"
+    custom_reply = (
+        f"Try https://user:{credential}@example.test/"
+        f"?token={credential} later \ud800"
+    )
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {"display": {"provider_error_reply": custom_reply}},
+    )
+
+    reply = _sanitize_gateway_final_response(
+        Platform.TELEGRAM,
+        "API call failed after 3 retries: HTTP 500",
+    )
+
+    assert "Try " in reply
+    assert credential not in reply
+    assert "\ud800" not in reply
+    reply.encode("utf-8")
+
+
+def test_provider_error_reply_override_applies_to_status_messages(monkeypatch):
+    """Status callbacks use the same customer-facing provider failure reply."""
+    import gateway.run as gateway_run
+
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {"display": {"provider_error_reply": "Temporary failure."}},
+    )
+
+    assert (
+        _prepare_gateway_status_message(
+            Platform.TELEGRAM,
+            "warn",
+            "API call failed after 3 retries: HTTP 500",
+        )
+        == "Temporary failure."
+    )
+
+
+def test_provider_error_reply_override_handles_failed_agent_wrapper(monkeypatch):
+    """The empty-response failure wrapper must not bypass the configured reply."""
+    import gateway.run as gateway_run
+
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {"display": {"provider_error_reply": "Temporary failure."}},
+    )
+    wrapped = (
+        "The request failed: API call failed after 3 retries: HTTP 401 secret\n"
+        "Try again or use /reset to start a fresh session."
+    )
+
+    assert (
+        _sanitize_gateway_final_response(Platform.TELEGRAM, wrapped)
+        == "Temporary failure."
+    )
+
+
+@pytest.mark.parametrize("platform", ["slack", "matrix", "whatsapp"])
+def test_provider_error_reply_override_supports_string_platform_keys(monkeypatch, platform):
+    """Plugin and shared delivery paths may identify a platform by string."""
+    import gateway.run as gateway_run
+
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {
+            "display": {
+                "platforms": {platform: {"provider_error_reply": "Temporary failure."}}
+            }
+        },
+    )
+
+    assert (
+        _sanitize_gateway_final_response(platform, "API call failed: HTTP 500")
+        == "Temporary failure."
+    )
+
+
+def test_provider_error_reply_override_does_not_replace_normal_answers(monkeypatch):
+    """The override applies only to classified provider failures."""
+    import gateway.run as gateway_run
+
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {"display": {"provider_error_reply": "Temporary failure."}},
+    )
+
+    assert (
+        _sanitize_gateway_final_response(Platform.TELEGRAM, "Normal answer")
+        == "Normal answer"
+    )
+
+
 def test_telegram_final_response_keeps_normal_answers():
     """Normal assistant content should not be rewritten."""
     answer = "Here is the clean summary you asked for."

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2007,6 +2007,35 @@ Signal is listed as a valid platform key because the setting can be saved per pl
 
 `show_commentary` (default `true`) controls Codex Responses models' commentary channel — the polished progress narration these models produce alongside their private reasoning. When enabled, each completed commentary message is delivered as a visible mid-turn update (on the gateway this also requires `interim_assistant_messages`). Set it to `false` if the extra narration annoys you: commentary then falls back to the reasoning channel and is only shown when `show_reasoning` is enabled.
 
+### Public-facing gateway replies
+
+Gateways used in customer, student, or community chats can replace
+operator-oriented provider failure text and simplify `/new` / `/reset`
+confirmations without patching Hermes source code:
+
+```yaml
+display:
+  platforms:
+    telegram:
+      provider_error_reply: "I couldn't answer just now. Please try again in a minute."
+      session_reset_reply: "New session started."
+      session_reset_details: false
+```
+
+`provider_error_reply` is used only after Hermes has classified and redacted a
+provider failure; normal assistant answers are unchanged. Configured reply text is
+also surrogate-sanitized and passed through Hermes' existing secret redactor before
+delivery. Empty or whitespace-only
+values fall back to Hermes' safe built-in provider error message.
+
+`session_reset_reply` replaces the standard reset header and passes through the same
+surrogate sanitizer and URL-aware secret redactor. For a silent reset, set it to an
+empty string **and** set `session_reset_details: false`; title-validation warnings
+can still produce a reply. `session_reset_details: false` hides the model,
+provider, context information, and random tip while preserving those warnings.
+All three settings may also be placed directly under `display` as global defaults;
+`display.platforms.<platform>` overrides them per platform.
+
 ## Privacy
 
 ```yaml


### PR DESCRIPTION
## Summary

- add `display.provider_error_reply` with per-platform overrides for customer-facing gateway failures
- add `display.session_reset_reply` and `display.session_reset_details` to simplify `/new` and `/reset` confirmations
- preserve existing behavior unless an operator explicitly configures the new settings
- resolve settings from the active profile so multiplex gateways can use different copy per routed profile

## Motivation

Hermes already redacts raw provider failures before sending them to chat, but the built-in fallback is operator-oriented (for example, it directs the reader to gateway logs). Customer, student, and community gateways need a short audience-appropriate reply without patching Hermes source.

The standard `/new` and `/reset` response also includes model/provider/context metadata and a random tip. Those details are useful for an owner-operated gateway but noisy or inappropriate in public-facing chats.

## Configuration

```yaml
display:
  platforms:
    telegram:
      provider_error_reply: "I couldn't answer just now. Please try again in a minute."
      session_reset_reply: "New session started."
      session_reset_details: false
```

The same keys may be placed directly under `display` as global defaults. Platform-specific settings take precedence.

## Behavior and compatibility

- defaults remain unchanged: built-in safe provider replies and the full reset banner are preserved
- custom provider copy is used only after existing provider-error classification; normal assistant answers are untouched
- custom provider and reset copy pass through the existing surrogate sanitizer and URL-aware secret redactor before delivery
- both final responses and status callback paths use the configured provider reply
- wrapped failed-agent responses are classified without exposing their inner provider error
- empty/whitespace-only `provider_error_reply` falls back to the built-in safe reply
- an empty `session_reset_reply` combined with `session_reset_details: false` supports a silent reset; title-validation warnings may still produce a reply
- `session_reset_details: false` hides model/provider/context details and the random tip while preserving title-validation warnings
- enum and string platform identifiers are supported
- config loading follows the active profile scope used by multiplex gateways

## Test plan

- [x] `scripts/run_tests.sh tests/gateway/test_session_model_reset.py tests/gateway/test_telegram_noise_filter.py tests/gateway/test_display_config.py tests/gateway/test_multiplex_session_db_profile_scope.py tests/gateway/test_multiplex_adapter_registry.py tests/gateway/test_title_command.py tests/gateway/test_64674_multiplex_primary_token_scope.py -q` — 221 passed, including routed-profile scope and title-warning coverage
- [x] Ruff on all changed Python files — passed
- [x] `git diff --check` — passed
- [x] static added-line security scan — no findings

The full gateway suite also surfaced three macOS-only baseline failures unrelated to this change: two AF_UNIX path-length failures in `test_scale_to_zero.py` and one Linux abstract-socket test in `test_systemd_notify.py`. The same failures reproduce on a clean `origin/main` worktree.
