### PR TITLE
fix(web): rescue partial keyless extraction throttles per URL

### DIFF
--- a/plugins/web/keyless_mcp.py
+++ b/plugins/web/keyless_mcp.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import json
 import logging
 import uuid
+from collections.abc import Mapping
 from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
@@ -860,20 +861,30 @@ def extract_with_failover(name: str, urls: List[str]) -> List[Dict[str, Any]]:
     if not urls:
         return []
 
-    pending = list(urls)
-    merged: Dict[str, Dict[str, Any]] = {}
+    pending = list(range(len(urls)))
+    merged: List[Optional[Dict[str, Any]]] = []
+    for _ in urls:
+        merged.append(None)
     for i, vendor in enumerate(order):
         if not pending:
             break
-        results = _KEYLESS_EXTRACTORS[vendor](list(pending))
-        by_url = {
-            str(row.get("url") or ""): row
-            for row in results
-            if isinstance(row, dict) and row.get("url") in pending
-        }
-        retry: List[str] = []
-        for url in pending:
-            row = by_url.get(url)
+        requested_urls = [urls[index] for index in pending]
+        results = _KEYLESS_EXTRACTORS[vendor](requested_urls)
+        rows_by_url: Dict[str, List[Dict[str, Any]]] = {}
+        for row in results:
+            if not isinstance(row, dict):
+                continue
+            result_url = str(row.get("url") or "")
+            if result_url in requested_urls:
+                rows_by_url.setdefault(result_url, []).append(row)
+        row_offsets: Dict[str, int] = {}
+        retry: List[int] = []
+        for input_index in pending:
+            url = urls[input_index]
+            offset = row_offsets.get(url, 0)
+            candidates = rows_by_url.get(url, [])
+            row = candidates[offset] if offset < len(candidates) else None
+            row_offsets[url] = offset + 1
             if row is None:
                 row = {
                     "url": url,
@@ -883,14 +894,17 @@ def extract_with_failover(name: str, urls: List[str]) -> List[Dict[str, Any]]:
                 }
             elif vendor != name:
                 row = dict(row)
-                metadata = dict(row.get("metadata") or {})
+                raw_metadata = row.get("metadata")
+                metadata = (
+                    dict(raw_metadata) if isinstance(raw_metadata, Mapping) else {}
+                )
                 metadata.setdefault("sourceURL", url)
                 metadata["served_by"] = vendor
                 row["metadata"] = metadata
-            merged[url] = row
+            merged[input_index] = row
             error = str(row.get("error") or "")
             if error and _is_rate_limitish(error) and i + 1 < len(order):
-                retry.append(url)
+                retry.append(input_index)
 
         nxt = order[i + 1] if retry and i + 1 < len(order) else None
         if nxt:
@@ -903,4 +917,14 @@ def extract_with_failover(name: str, urls: List[str]) -> List[Dict[str, Any]]:
             )
         pending = retry
 
-    return [merged[url] for url in urls]
+    return [
+        row
+        if row is not None
+        else {
+            "url": urls[index],
+            "title": "",
+            "content": "",
+            "error": "Keyless extract returned no result",
+        }
+        for index, row in enumerate(merged)
+    ]

--- a/plugins/web/keyless_mcp.py
+++ b/plugins/web/keyless_mcp.py
@@ -840,32 +840,67 @@ def search_with_failover(name: str, query: str, limit: int = 5) -> Dict[str, Any
 
 
 def extract_with_failover(name: str, urls: List[str]) -> List[Dict[str, Any]]:
-    """Keyless extract across the vendor ring, failing over per-batch.
+    """Keyless extract across the vendor ring with per-URL throttle rescue.
 
-    Advances to the next ring vendor only when EVERY url in a batch comes
-    back with a rate-limit-shaped error — partial failures are page
-    problems, not throttling, and return as-is.
+    Successful and non-throttle rows are final. Only rows with a
+    rate-limit-shaped error advance to the next vendor. Results are merged
+    back to exactly one row per input URL in the caller's original order.
     """
     order = _ring_order(name)
     if not order:
         return [
-            {"url": u, "title": "", "content": "",
-             "error": "All keyless web providers are pinned to paid tiers."}
+            {
+                "url": u,
+                "title": "",
+                "content": "",
+                "error": "All keyless web providers are pinned to paid tiers.",
+            }
             for u in urls
         ]
-    last: List[Dict[str, Any]] = []
+    if not urls:
+        return []
+
+    pending = list(urls)
+    merged: Dict[str, Dict[str, Any]] = {}
     for i, vendor in enumerate(order):
-        results = _KEYLESS_EXTRACTORS[vendor](list(urls))
-        errors = [r.get("error", "") for r in results]
-        all_throttled = bool(results) and all(
-            e and _is_rate_limitish(e) for e in errors
-        )
-        if not all_throttled:
-            return results
-        last = results
-        nxt = order[i + 1] if i + 1 < len(order) else None
+        if not pending:
+            break
+        results = _KEYLESS_EXTRACTORS[vendor](list(pending))
+        by_url = {
+            str(row.get("url") or ""): row
+            for row in results
+            if isinstance(row, dict) and row.get("url") in pending
+        }
+        retry: List[str] = []
+        for url in pending:
+            row = by_url.get(url)
+            if row is None:
+                row = {
+                    "url": url,
+                    "title": "",
+                    "content": "",
+                    "error": f"Keyless {vendor} extract returned no result",
+                }
+            elif vendor != name:
+                row = dict(row)
+                metadata = dict(row.get("metadata") or {})
+                metadata.setdefault("sourceURL", url)
+                metadata["served_by"] = vendor
+                row["metadata"] = metadata
+            merged[url] = row
+            error = str(row.get("error") or "")
+            if error and _is_rate_limitish(error) and i + 1 < len(order):
+                retry.append(url)
+
+        nxt = order[i + 1] if retry and i + 1 < len(order) else None
         if nxt:
             logger.info(
-                "keyless %s extract throttled; failing over to %s", vendor, nxt
+                "keyless %s extract throttled for %d/%d URL(s); failing over to %s",
+                vendor,
+                len(retry),
+                len(pending),
+                nxt,
             )
-    return last
+        pending = retry
+
+    return [merged[url] for url in urls]

--- a/tests/tools/test_web_keyless_fallback.py
+++ b/tests/tools/test_web_keyless_fallback.py
@@ -517,29 +517,194 @@ class TestKeylessFailover:
         self._pin(monkeypatch, "exa")
         throttled = [
             {"url": "https://a", "title": "", "content": "", "error": "rate limit hit"},
-            {"url": "https://b", "title": "", "content": "", "error": "429 too many requests"},
+            {
+                "url": "https://b",
+                "title": "",
+                "content": "",
+                "error": "429 too many requests",
+            },
         ]
         good = [
             {"url": "https://a", "title": "A", "content": "x"},
             {"url": "https://b", "title": "B", "content": "y"},
         ]
-        monkeypatch.setitem(keyless_mcp._KEYLESS_EXTRACTORS, "exa", lambda urls: throttled)
-        monkeypatch.setitem(keyless_mcp._KEYLESS_EXTRACTORS, "parallel", lambda urls: good)
-        out = keyless_mcp.extract_with_failover("exa", ["https://a", "https://b"])
-        assert out == good
-
-    def test_extract_partial_failure_stays_on_primary(self, monkeypatch):
-        self._pin(monkeypatch, "exa")
-        partial = [
-            {"url": "https://a", "title": "A", "content": "x"},
-            {"url": "https://b", "title": "", "content": "", "error": "rate limit"},
-        ]
-        called = []
-        monkeypatch.setitem(keyless_mcp._KEYLESS_EXTRACTORS, "exa", lambda urls: partial)
         monkeypatch.setitem(
-            keyless_mcp._KEYLESS_EXTRACTORS, "parallel",
-            lambda urls: called.append(1) or [],
+            keyless_mcp._KEYLESS_EXTRACTORS, "exa", lambda urls: throttled
+        )
+        monkeypatch.setitem(
+            keyless_mcp._KEYLESS_EXTRACTORS, "parallel", lambda urls: good
         )
         out = keyless_mcp.extract_with_failover("exa", ["https://a", "https://b"])
-        assert out == partial
-        assert not called
+        assert [row["content"] for row in out] == ["x", "y"]
+        assert all(row["metadata"]["served_by"] == "parallel" for row in out)
+        assert [row["metadata"]["sourceURL"] for row in out] == [
+            "https://a",
+            "https://b",
+        ]
+
+    def test_extract_retries_only_throttled_rows_and_restores_input_order(
+        self, monkeypatch
+    ):
+        self._pin(monkeypatch, "exa")
+        urls = [
+            "https://www.anthropic.com/engineering/building-effective-agents",
+            "https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents",
+            "https://www.anthropic.com/engineering/multi-agent-research-system",
+            "https://www.anthropic.com/engineering/demystifying-evals-for-ai-agents",
+            "https://developers.openai.com/api/docs/guides/agent-evals.md",
+        ]
+        primary = [
+            {
+                "url": urls[0],
+                "title": "A",
+                "content": "primary-a",
+                "metadata": {"sourceURL": urls[0], "trace": "keep-a"},
+            },
+            {
+                "url": urls[1],
+                "title": "",
+                "content": "",
+                "error": "HTTP 429 rate limit",
+            },
+            {
+                "url": urls[2],
+                "title": "C",
+                "content": "primary-c",
+                "metadata": {"sourceURL": urls[2], "trace": "keep-c"},
+            },
+            {"url": urls[3], "title": "", "content": "", "error": "too many requests"},
+            {
+                "url": urls[4],
+                "title": "E",
+                "content": "primary-e",
+                "metadata": {"sourceURL": urls[4], "trace": "keep-e"},
+            },
+        ]
+        rescue_calls = []
+
+        def rescue(requested):
+            rescue_calls.append(list(requested))
+            # Deliberately reversed: the merge must restore original input order.
+            return [
+                {
+                    "url": urls[3],
+                    "title": "D",
+                    "content": "rescued-d",
+                    "metadata": {"sourceURL": urls[3], "trace": "keep-d"},
+                },
+                {
+                    "url": urls[1],
+                    "title": "B",
+                    "content": "rescued-b",
+                    "metadata": {"sourceURL": urls[1], "trace": "keep-b"},
+                },
+            ]
+
+        monkeypatch.setitem(
+            keyless_mcp._KEYLESS_EXTRACTORS, "exa", lambda requested: primary
+        )
+        monkeypatch.setitem(keyless_mcp._KEYLESS_EXTRACTORS, "parallel", rescue)
+
+        out = keyless_mcp.extract_with_failover("exa", urls)
+
+        assert rescue_calls == [[urls[1], urls[3]]]
+        assert [row["url"] for row in out] == urls
+        assert [row.get("content") for row in out] == [
+            "primary-a",
+            "rescued-b",
+            "primary-c",
+            "rescued-d",
+            "primary-e",
+        ]
+        assert out[0]["metadata"] == {"sourceURL": urls[0], "trace": "keep-a"}
+        assert out[1]["metadata"] == {
+            "sourceURL": urls[1],
+            "trace": "keep-b",
+            "served_by": "parallel",
+        }
+
+    def test_extract_saved_case_b_rescues_only_its_two_throttled_rows(
+        self, monkeypatch
+    ):
+        self._pin(monkeypatch, "exa")
+        urls = [
+            "https://developers.openai.com/api/docs/guides/trace-grading.md",
+            "https://developers.openai.com/api/docs/guides/evaluation-best-practices.md",
+            "https://cloud.google.com/blog/products/ai-machine-learning/a-devs-guide-to-production-ready-ai-agents/",
+            "https://docs.cloud.google.com/gemini-enterprise-agent-platform/scale/memory-bank",
+            "https://developers.openai.com/api/docs/guides/agent-builder-safety",
+        ]
+        primary = [
+            {"url": urls[0], "title": "A", "content": "primary-a"},
+            {"url": urls[1], "title": "B", "content": "primary-b"},
+            {"url": urls[2], "title": "", "content": "", "error": "HTTP 429"},
+            {"url": urls[3], "title": "D", "content": "primary-d"},
+            {
+                "url": urls[4],
+                "title": "",
+                "content": "",
+                "error": "free MCP rate limit",
+            },
+        ]
+        calls = []
+
+        def rescue(requested):
+            calls.append(list(requested))
+            return [
+                {"url": url, "title": "rescued", "content": f"rescued-{i}"}
+                for i, url in enumerate(requested)
+            ]
+
+        monkeypatch.setitem(
+            keyless_mcp._KEYLESS_EXTRACTORS, "exa", lambda requested: primary
+        )
+        monkeypatch.setitem(keyless_mcp._KEYLESS_EXTRACTORS, "parallel", rescue)
+
+        out = keyless_mcp.extract_with_failover("exa", urls)
+
+        assert calls == [[urls[2], urls[4]]]
+        assert [row["url"] for row in out] == urls
+        assert sum(not row.get("error") for row in out) == 5
+        assert out[0]["content"] == "primary-a"
+        assert out[2]["metadata"]["served_by"] == "parallel"
+        assert out[4]["metadata"]["sourceURL"] == urls[4]
+
+    def test_extract_never_retries_non_throttle_errors(self, monkeypatch):
+        self._pin(monkeypatch, "exa")
+        urls = ["https://ok", "https://not-found", "https://throttled"]
+        primary = [
+            {"url": urls[0], "title": "OK", "content": "primary"},
+            {"url": urls[1], "title": "", "content": "", "error": "HTTP 404"},
+            {"url": urls[2], "title": "", "content": "", "error": "HTTP 429"},
+        ]
+        rescue_calls = []
+        later_calls = []
+
+        def rescue(requested):
+            rescue_calls.append(list(requested))
+            return [
+                {
+                    "url": urls[2],
+                    "title": "",
+                    "content": "",
+                    "error": "HTTP 403 blocked",
+                }
+            ]
+
+        monkeypatch.setitem(
+            keyless_mcp._KEYLESS_EXTRACTORS, "exa", lambda requested: primary
+        )
+        monkeypatch.setitem(keyless_mcp._KEYLESS_EXTRACTORS, "parallel", rescue)
+        monkeypatch.setitem(
+            keyless_mcp._KEYLESS_EXTRACTORS,
+            "tavily",
+            lambda requested: later_calls.append(list(requested)) or [],
+        )
+
+        out = keyless_mcp.extract_with_failover("exa", urls)
+
+        assert rescue_calls == [[urls[2]]]
+        assert later_calls == []
+        assert out[1]["error"] == "HTTP 404"
+        assert out[2]["error"] == "HTTP 403 blocked"
+        assert out[2]["metadata"]["served_by"] == "parallel"

--- a/tests/tools/test_web_keyless_fallback.py
+++ b/tests/tools/test_web_keyless_fallback.py
@@ -708,3 +708,61 @@ class TestKeylessFailover:
         assert out[1]["error"] == "HTTP 404"
         assert out[2]["error"] == "HTTP 403 blocked"
         assert out[2]["metadata"]["served_by"] == "parallel"
+
+    def test_extract_tracks_duplicate_url_occurrences_independently(self, monkeypatch):
+        self._pin(monkeypatch, "exa")
+        url = "https://duplicate"
+        primary = [
+            {"url": url, "title": "first", "content": "primary-success"},
+            {"url": url, "title": "", "content": "", "error": "HTTP 429"},
+        ]
+        rescue_calls = []
+
+        def rescue(requested):
+            rescue_calls.append(list(requested))
+            return [{"url": url, "title": "second", "content": "rescued-success"}]
+
+        monkeypatch.setitem(
+            keyless_mcp._KEYLESS_EXTRACTORS, "exa", lambda requested: primary
+        )
+        monkeypatch.setitem(keyless_mcp._KEYLESS_EXTRACTORS, "parallel", rescue)
+
+        out = keyless_mcp.extract_with_failover("exa", [url, url])
+
+        assert rescue_calls == [[url]]
+        assert [row["content"] for row in out] == [
+            "primary-success",
+            "rescued-success",
+        ]
+        assert out[0] is not out[1]
+        assert out[1]["metadata"] == {
+            "sourceURL": url,
+            "served_by": "parallel",
+        }
+
+    def test_extract_normalizes_malformed_rescue_metadata(self, monkeypatch):
+        self._pin(monkeypatch, "exa")
+        url = "https://malformed-metadata"
+        primary = [{"url": url, "title": "", "content": "", "error": "HTTP 429"}]
+        rescued = [
+            {
+                "url": url,
+                "title": "rescued",
+                "content": "ok",
+                "metadata": "broken",
+            }
+        ]
+        monkeypatch.setitem(
+            keyless_mcp._KEYLESS_EXTRACTORS, "exa", lambda requested: primary
+        )
+        monkeypatch.setitem(
+            keyless_mcp._KEYLESS_EXTRACTORS, "parallel", lambda requested: rescued
+        )
+
+        out = keyless_mcp.extract_with_failover("exa", [url])
+
+        assert out[0]["content"] == "ok"
+        assert out[0]["metadata"] == {
+            "sourceURL": url,
+            "served_by": "parallel",
+        }


### PR DESCRIPTION
## Summary

- rescue only input URL occurrences that return a rate-limit-shaped error from a keyless extractor
- preserve successful and non-throttle rows without repeating their network work
- preserve input order, cardinality, and duplicate URL occurrence identity across fallback vendors
- normalize malformed rescue metadata while recording `sourceURL` and `served_by` provenance

## Problem

`extract_with_failover()` previously advanced to the next keyless vendor only when every row in a batch was throttled. A mixed batch such as three successful rows plus two HTTP 429 rows returned the throttled rows as failures even though another keyless vendor could rescue them. Retrying the whole batch would repeat already successful extraction work.

## Implementation

Failover state is tracked by input occurrence index rather than URL string. Each vendor receives only still-throttled occurrences. Provider rows are matched back to those occurrences in order, so duplicate URLs remain independent. Successes and non-throttle errors become terminal for their occurrence; after the ring is exhausted, the last honest provider result is retained.

No paid fallback path is added or invoked.

## Test plan

- [x] `scripts/run_tests.sh tests/tools/test_web_keyless_fallback.py tests/tools/test_web_keyless_rescue.py` — 59 passed
- [x] mixed `3 success + 2 HTTP 429` cases retry only the two throttled occurrences
- [x] `403`, `404`, and other non-throttle errors do not advance to another vendor
- [x] duplicate URL occurrences remain independent
- [x] malformed rescue metadata is normalized without crashing
- [x] input order, cardinality, provenance, bounded ring behavior, and honest final errors are covered
- [x] blocking `ruff check .`, focused `ty check`, compileall, `git diff --check`, Windows-footgun, conflict-marker, and added-line secret scans pass

## Scope

Two files only:

- `plugins/web/keyless_mcp.py`
- `tests/tools/test_web_keyless_fallback.py`
