### PR TITLE
feat(commands): add versioned semantic catalog contract

### DIFF
--- a/hermes_cli/command_catalog.py
+++ b/hermes_cli/command_catalog.py
@@ -1,0 +1,206 @@
+"""Versioned semantic projection of the canonical Hermes slash-command registry.
+
+PR 1 of the unified command-plane migration.  The existing
+``hermes_cli.commands.COMMAND_REGISTRY`` remains the semantic owner; this
+module gives that owner a client-safe, immutable schema with canonical IDs,
+alias-preserving resolution, deterministic fingerprints, and a fail-closed
+collision boundary for later contributors.
+
+No surface dispatches through this module yet.  Adoption belongs to later
+migration slices after the compatibility boundary is proved.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any, Iterable, Mapping, Sequence
+
+from hermes_cli.commands import COMMAND_REGISTRY, CommandDef, command_desktop_meta
+
+SCHEMA_VERSION = 2
+
+
+@dataclass(frozen=True)
+class CommandSpec:
+    """JSON-safe semantic projection of one command definition."""
+
+    schema_version: int
+    command_id: str
+    name: str
+    aliases: tuple[str, ...]
+    description_fallback: str
+    category: str
+    args_hint: str
+    subcommands: tuple[str, ...]
+    origin: str
+    legacy: Mapping[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "command_id": self.command_id,
+            "name": self.name,
+            "aliases": list(self.aliases),
+            "description_fallback": self.description_fallback,
+            "category": self.category,
+            "argument_schema": {
+                "kind": "legacy",
+                "hint": self.args_hint,
+                "subcommands": list(self.subcommands),
+            },
+            "origin": self.origin,
+            "legacy": dict(self.legacy),
+        }
+
+
+@dataclass(frozen=True)
+class CommandCatalog:
+    """Immutable command snapshot addressed by deterministic revision."""
+
+    schema_version: int
+    revision: str
+    commands: tuple[CommandSpec, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "revision": self.revision,
+            "commands": [command.to_dict() for command in self.commands],
+        }
+
+
+def _command_id(name: str) -> str:
+    """Seed the stable core ID namespace from the current canonical owner.
+
+    The ID is intentionally distinct from entered spelling: aliases always
+    resolve to this one identity.  A future canonical-name migration must
+    preserve the seeded ID explicitly rather than minting a new semantic
+    command; PR 1 pins the initial namespace and later slices consume it.
+    """
+
+    return "command." + name.replace("_", "-")
+
+
+def _legacy_spec(command: CommandDef) -> CommandSpec:
+    desktop_meta = command_desktop_meta(command)
+    return CommandSpec(
+        schema_version=SCHEMA_VERSION,
+        command_id=_command_id(command.name),
+        name=command.name,
+        aliases=tuple(command.aliases),
+        description_fallback=command.description,
+        category=command.category,
+        args_hint=command.args_hint,
+        subcommands=tuple(command.subcommands),
+        origin="core",
+        legacy={
+            "cli_only": command.cli_only,
+            "gateway_only": command.gateway_only,
+            "gateway_config_gate": command.gateway_config_gate,
+            "busy_policy": command.busy_policy,
+            "busy_handler": command.busy_handler,
+            "execute": command.execute,
+            "argument_mode": desktop_meta["argument_mode"],
+            "desktop": desktop_meta["desktop"],
+        },
+    )
+
+
+def _normalize_external_spec(value: Mapping[str, Any], origin: str) -> CommandSpec:
+    """Normalize a later contributor without granting it mutation authority."""
+
+    name = str(value.get("name") or "").lstrip("/").strip()
+    if not name:
+        raise ValueError(f"{origin} command contribution missing name")
+
+    command_id = str(value.get("command_id") or "").strip()
+    if not command_id:
+        raise ValueError(f"{origin} command contribution missing command_id")
+
+    aliases = tuple(str(item).lstrip("/") for item in value.get("aliases", ()) or ())
+    subcommands = tuple(str(item) for item in value.get("subcommands", ()) or ())
+    legacy = value.get("legacy") or {}
+    if not isinstance(legacy, Mapping):
+        raise ValueError(f"{command_id}: legacy metadata must be a mapping")
+
+    return CommandSpec(
+        schema_version=SCHEMA_VERSION,
+        command_id=command_id,
+        name=name,
+        aliases=aliases,
+        description_fallback=str(
+            value.get("description_fallback") or value.get("description") or ""
+        ),
+        category=str(value.get("category") or "Extensions"),
+        args_hint=str(value.get("args_hint") or ""),
+        subcommands=subcommands,
+        origin=origin,
+        legacy=dict(legacy),
+    )
+
+
+def validate_command_specs(specs: Sequence[CommandSpec]) -> None:
+    """Fail closed on duplicate semantic IDs or entered command tokens."""
+
+    ids: dict[str, str] = {}
+    tokens: dict[str, str] = {}
+
+    for spec in specs:
+        previous = ids.setdefault(spec.command_id, spec.origin)
+        if previous != spec.origin:
+            raise ValueError(
+                f"duplicate command_id {spec.command_id!r}: {previous} vs {spec.origin}"
+            )
+
+        for token in (spec.name, *spec.aliases):
+            key = token.casefold()
+            owner = tokens.setdefault(key, spec.command_id)
+            if owner != spec.command_id:
+                raise ValueError(
+                    f"command token {token!r} collides: {owner} vs {spec.command_id}"
+                )
+
+
+def _fingerprint(specs: Sequence[CommandSpec]) -> str:
+    payload = json.dumps(
+        [spec.to_dict() for spec in specs],
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def build_command_catalog(
+    *,
+    contributions: Iterable[tuple[str, Mapping[str, Any]]] = (),
+) -> CommandCatalog:
+    """Project the canonical registry plus explicit contributions.
+
+    PR 1 exposes contributor validation but does not perform runtime discovery;
+    context-scoped assembly is the next migration slice.
+    """
+
+    specs = [_legacy_spec(command) for command in COMMAND_REGISTRY]
+    specs.extend(_normalize_external_spec(value, origin) for origin, value in contributions)
+    specs.sort(key=lambda item: (item.category.casefold(), item.name.casefold(), item.command_id))
+    validate_command_specs(specs)
+    return CommandCatalog(
+        schema_version=SCHEMA_VERSION,
+        revision=_fingerprint(specs),
+        commands=tuple(specs),
+    )
+
+
+def resolve_catalog_command(catalog: CommandCatalog, token: str) -> CommandSpec | None:
+    normalized = str(token or "").lstrip("/").casefold()
+    if not normalized:
+        return None
+    for spec in catalog.commands:
+        if spec.name.casefold() == normalized:
+            return spec
+        if any(alias.casefold() == normalized for alias in spec.aliases):
+            return spec
+    return None

--- a/tests/hermes_cli/test_command_catalog.py
+++ b/tests/hermes_cli/test_command_catalog.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from hermes_cli.command_catalog import (
+    SCHEMA_VERSION,
+    build_command_catalog,
+    resolve_catalog_command,
+)
+from hermes_cli.commands import COMMAND_REGISTRY, command_desktop_meta
+
+
+def test_catalog_is_deterministic_and_aliases_preserve_identity():
+    first = build_command_catalog()
+    second = build_command_catalog()
+
+    assert first.schema_version == SCHEMA_VERSION
+    assert first.revision == second.revision
+    assert first.to_dict() == second.to_dict()
+    assert len(first.revision) == 64
+
+    new = resolve_catalog_command(first, "/new")
+    reset = resolve_catalog_command(first, "/reset")
+    assert new is not None
+    assert reset is not None
+    assert new is reset
+    assert new.command_id == "command.new"
+
+
+def test_catalog_is_json_serializable_and_projects_current_registry():
+    catalog = build_command_catalog()
+    payload = catalog.to_dict()
+
+    json.dumps(payload, sort_keys=True)
+    assert len(catalog.commands) == len(COMMAND_REGISTRY)
+
+    by_name = {spec.name: spec for spec in catalog.commands}
+    for command in COMMAND_REGISTRY:
+        spec = by_name[command.name]
+        assert spec.aliases == command.aliases
+        assert spec.description_fallback == command.description
+        assert spec.category == command.category
+        assert spec.args_hint == command.args_hint
+        assert spec.subcommands == command.subcommands
+        assert spec.legacy["busy_policy"] == command.busy_policy
+        assert spec.legacy["execute"] == command.execute
+        assert {
+            "argument_mode": spec.legacy["argument_mode"],
+            "desktop": spec.legacy["desktop"],
+        } == command_desktop_meta(command)
+
+
+def test_dynamic_contributions_require_explicit_identity_and_change_revision():
+    baseline = build_command_catalog()
+    catalog = build_command_catalog(
+        contributions=(
+            (
+                "plugin.example",
+                {
+                    "command_id": "plugin.example.deploy",
+                    "name": "deploy",
+                    "aliases": ["ship"],
+                    "description": "Deploy the current project",
+                    "category": "Plugins",
+                },
+            ),
+        )
+    )
+
+    deployed = resolve_catalog_command(catalog, "ship")
+    assert deployed is not None
+    assert deployed.command_id == "plugin.example.deploy"
+    assert deployed.origin == "plugin.example"
+    assert catalog.revision != baseline.revision
+
+    with pytest.raises(ValueError, match="missing command_id"):
+        build_command_catalog(
+            contributions=(("plugin.example", {"name": "anonymous"}),)
+        )
+
+
+def test_duplicate_alias_and_duplicate_id_fail_closed():
+    with pytest.raises(ValueError, match="collides"):
+        build_command_catalog(
+            contributions=(
+                (
+                    "plugin.example",
+                    {
+                        "command_id": "plugin.example.not-new",
+                        "name": "not-new",
+                        "aliases": ["new"],
+                    },
+                ),
+            )
+        )
+
+    with pytest.raises(ValueError, match="duplicate command_id"):
+        build_command_catalog(
+            contributions=(
+                (
+                    "plugin.one",
+                    {"command_id": "extension.same", "name": "one"},
+                ),
+                (
+                    "plugin.two",
+                    {"command_id": "extension.same", "name": "two"},
+                ),
+            )
+        )


### PR DESCRIPTION
## What does this PR do?

Implements **PR 1 — the versioned semantic catalog contract** under #96692 without creating a second executable slash-command registry.

`hermes_cli.commands.COMMAND_REGISTRY` remains the canonical owner of core names, aliases, descriptions, availability, busy policy, execution keys, and Desktop projection metadata. This slice projects that owner into one immutable, JSON-safe semantic object with canonical command identity, alias-preserving resolution, deterministic catalog revision, and fail-closed collision validation. It changes no production dispatch path and grants no new execution authority.

### Invariant

> Entered names and aliases may locate a command, but they do not own its meaning. Every later projection must carry one canonical semantic identity and the revision of the immutable catalog that defined it.

## Related Issue

Part of #96692 — **Unified slash-command registry and execution contract across every Hermes surface**.

This PR does **not** close #96692; it is the first production-code primitive in that ordered migration.

## Prior work / provenance

- #97102 is PR 0 and owns the current-topology inventory plus executable characterization baseline. This PR consumes that finding rather than duplicating it.
- #96791 by **OutThisLife** is merged current ownership for registry-backed Desktop metadata and catalog projection. This PR preserves that ownership by deriving Desktop metadata through `command_desktop_meta()`.
- #96705 is historical stable-ID/revision design provenance only; #96791 materially changed the landing topology after that branch was created.
- #50054 remains the explicit override-authority interlock. This PR fails closed instead of inventing last-writer-wins or import-order precedence.
- #95028 / #95101 remain the later Authority Policy ABI interlock. This PR does not reconstruct authorization, confirmation, mutation, busy-state, retry, or idempotency policy.
- #97114, #97124, #97129, and #97138 own path-disjoint gateway, Desktop, Ink TUI, and Classic CLI binding seams.

## Exact submitted object

- Construction parent: [`00bbfc690060d1323ddb2f065297c7425cb71c26`](https://github.com/NousResearch/hermes-agent/commit/00bbfc690060d1323ddb2f065297c7425cb71c26)
- Head: [`51e9e866d42723870613b22c3c443f2569b0a894`](https://github.com/NousResearch/hermes-agent/commit/51e9e866d42723870613b22c3c443f2569b0a894)
- Tree: `3d08d4acf6b8aa308805423412676d0cef51d6ef`
- Shape: **1 commit, 2 added files, +317 / -0**
- Production call-site rewrites: **0**
- Existing command execution/routing/help/completion behavior: **unchanged**

### Current-main reconciliation

Live `main` at this reconciliation is [`3f36c87e1ebdfbf7d14a88229dc9be222c12ea89`](https://github.com/NousResearch/hermes-agent/commit/3f36c87e1ebdfbf7d14a88229dc9be222c12ea89), **169 commits** beyond the construction parent. The complete main-only interval remains path-disjoint from both submitted paths (`hermes_cli/command_catalog.py`, `tests/hermes_cli/test_command_catalog.py`). GitHub's live PR object reports `mergeable=true`, `rebaseable=true`, `mergeable_state=clean`; no churn-only restack is required by the current landing edge.

## Changes Made

- Added `hermes_cli/command_catalog.py` (206 lines): immutable `CommandSpec` / `CommandCatalog`, schema version 2, deterministic SHA-256 revision, canonical core IDs, alias-preserving resolution, explicit future-contribution normalization, and fail-closed duplicate-ID/token collision validation.
- Added `tests/hermes_cli/test_command_catalog.py` (111 lines): deterministic serialization/revision, alias identity, one projection per canonical registry entry, JSON safety, preservation of busy/execution/argument-mode/Desktop metadata, revision change on valid contribution, and refusal of missing identity / duplicate IDs / name-alias collisions.
- Both files remain below the repository 2,000-line ceiling.

### Deliberate scope boundary

This PR does **not** replace `commands.catalog`, add a new transport, add normalized invocation/result types, perform context-scoped runtime discovery, define override authority, migrate any client/platform surface, or delete compatibility paths. Those are later slices after this identity/generation boundary is accepted.

## Verification

Current exact-head hosted acceptance for `51e9e866d42723870613b22c3c443f2569b0a894`:

- [CI `33196230005`](https://github.com/NousResearch/hermes-agent/actions/runs/33196230005) — **SUCCESS**
- [Docker `33196229237`](https://github.com/NousResearch/hermes-agent/actions/runs/33196229237) — **SUCCESS**
- [Nix `33196229259`](https://github.com/NousResearch/hermes-agent/actions/runs/33196229259) — **SUCCESS**

There is exactly one surviving submitted commit, so the every-commit execution gate is satisfied for the current object. No producer-authored review or independent acceptance is claimed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] Commit follows the repository's conventional-commit shape
- [x] Existing related PRs were checked; the submitted two-file surface is path-disjoint from the listed sibling carriers
- [x] PR contains only the semantic-catalog primitive and its focused tests
- [x] Exact-head CI is green
- [x] Tests for the new contract are included

### Documentation & Housekeeping

- [x] No user-facing documentation change is required because no operator/runtime behavior changes
- [x] No config keys changed
- [x] No tool schema changed
- [x] No file exceeds the 2,000-line ceiling

## Acceptance state

- Materialization: **target present** — https://github.com/NousResearch/hermes-agent/pull/97143
- Integrity: **exact-head green** — CI/Docker/Nix all succeeded on the one submitted commit
- Governance: **independent acceptance not yet claimed**
- Integration: **open + clean/mergeable**; the 169-commit current-main landing interval is path-disjoint from the submitted files
- Operation: **not claimed** — no production path consumes this catalog yet
- Lineage: **active** — no superseding landing object is claimed for this PR 1 slice

The old `b9642e…` failed-CI state is superseded by the current one-commit object above and must not be used as the acceptance state for this PR.