### PR TITLE
feat: add Discord channel CRUD actions

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2300,7 +2300,8 @@ DEFAULT_CONFIG = {
         # or YAML list. Unknown names are dropped with a warning at load time.
         # Actions: list_guilds, server_info, list_channels, channel_info,
         # list_roles, member_info, search_members, fetch_messages, list_pins,
-        # pin_message, unpin_message, create_thread, add_role, remove_role.
+        # pin_message, unpin_message, create_thread, create_channel,
+        # edit_channel, delete_channel, add_role, remove_role.
         "server_actions": "",
         # DEPRECATED / no-op. Any uploaded file is now always cached and
         # surfaced to the agent regardless of file type — authorization to

--- a/tests/tools/test_discord_channel_crud.py
+++ b/tests/tools/test_discord_channel_crud.py
@@ -1,0 +1,162 @@
+"""Behavior tests for Discord channel CRUD actions."""
+
+import json
+from unittest.mock import patch
+
+from tools.discord_tool import discord_admin_handler, get_dynamic_schema_admin
+
+
+class TestCreateChannel:
+    @patch("tools.discord_tool._discord_request")
+    def test_creates_text_channel_with_explicit_fields(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"discord": {"server_actions": ""}},
+        )
+        mock_req.return_value = {
+            "id": "44", "guild_id": "111", "name": "x-content",
+            "type": 0, "parent_id": "22", "topic": "Discuss X strategy",
+            "position": 3, "nsfw": False,
+        }
+        result = json.loads(discord_admin_handler(
+            action="create_channel", guild_id="111", name="x-content",
+            channel_type="text", parent_id="22", topic="Discuss X strategy",
+            nsfw=False, rate_limit_per_user=5,
+        ))
+        assert result == {
+            "success": True,
+            "channel": {
+                "id": "44", "guild_id": "111", "name": "x-content",
+                "type": "text", "parent_id": "22", "topic": "Discuss X strategy",
+                "position": 3, "nsfw": False,
+            },
+        }
+        mock_req.assert_called_once_with(
+            "POST", "/guilds/111/channels", "test-token",
+            body={
+                "name": "x-content", "type": 0, "parent_id": "22",
+                "topic": "Discuss X strategy", "nsfw": False,
+                "rate_limit_per_user": 5,
+            },
+        )
+
+    @patch("tools.discord_tool._discord_request")
+    def test_rejects_unsupported_channel_type_before_api_call(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        result = json.loads(discord_admin_handler(
+            action="create_channel", guild_id="111", name="bad", channel_type="stage",
+        ))
+        assert "error" in result
+        assert "channel_type" in result["error"]
+        mock_req.assert_not_called()
+
+    @patch("tools.discord_tool._discord_request")
+    def test_creates_category_without_text_only_fields(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.return_value = {
+            "id": "22", "guild_id": "111", "name": "Content", "type": 4,
+            "parent_id": None, "position": 1,
+        }
+        result = json.loads(discord_admin_handler(
+            action="create_channel", guild_id="111", name="Content",
+            channel_type="category",
+        ))
+        assert result["channel"]["type"] == "category"
+        mock_req.assert_called_once_with(
+            "POST", "/guilds/111/channels", "test-token",
+            body={"name": "Content", "type": 4},
+        )
+
+    @patch("tools.discord_tool._discord_request")
+    def test_rejects_text_only_fields_for_category(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        result = json.loads(discord_admin_handler(
+            action="create_channel", guild_id="111", name="Content",
+            channel_type="category", topic="not valid for a category",
+        ))
+        assert "error" in result
+        assert "category" in result["error"]
+        mock_req.assert_not_called()
+
+    @patch("tools.discord_tool._discord_request")
+    def test_rejects_out_of_range_slowmode(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        result = json.loads(discord_admin_handler(
+            action="create_channel", guild_id="111", name="chat",
+            rate_limit_per_user=21601,
+        ))
+        assert "error" in result
+        assert "rate_limit_per_user" in result["error"]
+        mock_req.assert_not_called()
+
+
+class TestEditChannel:
+    @patch("tools.discord_tool._discord_request")
+    def test_updates_only_explicit_fields(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.return_value = {
+            "id": "44", "guild_id": "111", "name": "x-strategy",
+            "type": 0, "parent_id": None, "topic": "New topic",
+            "position": 2, "nsfw": False,
+        }
+        result = json.loads(discord_admin_handler(
+            action="edit_channel", channel_id="44", name="x-strategy",
+            topic="New topic", parent_id="null", position=2,
+        ))
+        assert result["success"] is True
+        mock_req.assert_called_once_with(
+            "PATCH", "/channels/44", "test-token",
+            body={"name": "x-strategy", "topic": "New topic", "parent_id": None, "position": 2},
+        )
+
+    @patch("tools.discord_tool._discord_request")
+    def test_requires_at_least_one_edit_field(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        result = json.loads(discord_admin_handler(action="edit_channel", channel_id="44"))
+        assert "error" in result
+        assert "at least one" in result["error"]
+        mock_req.assert_not_called()
+
+    @patch("tools.discord_tool._discord_request")
+    def test_allows_clearing_topic(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.return_value = {"id": "44", "name": "chat", "type": 0, "topic": None}
+        result = json.loads(discord_admin_handler(
+            action="edit_channel", channel_id="44", topic="",
+        ))
+        assert result["success"] is True
+        mock_req.assert_called_once_with(
+            "PATCH", "/channels/44", "test-token", body={"topic": ""},
+        )
+
+
+class TestDeleteChannel:
+    @patch("tools.discord_tool._discord_request")
+    def test_deletes_channel(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.return_value = {"id": "44", "name": "old-channel", "type": 0}
+        result = json.loads(discord_admin_handler(action="delete_channel", channel_id="44"))
+        assert result == {
+            "success": True,
+            "deleted_channel": {"id": "44", "name": "old-channel", "type": "text"},
+        }
+        mock_req.assert_called_once_with("DELETE", "/channels/44", "test-token")
+
+
+def test_admin_schema_exposes_channel_crud(monkeypatch):
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"discord": {"server_actions": ""}},
+    )
+    schema = get_dynamic_schema_admin()
+    actions = schema["parameters"]["properties"]["action"]["enum"]
+    assert "create_channel" in actions
+    assert "edit_channel" in actions
+    assert "delete_channel" in actions
+    props = schema["parameters"]["properties"]
+    assert props["channel_type"]["enum"] == ["text", "category"]
+    assert "parent_id" in props
+    assert "topic" in props
+    assert "position" in props

--- a/tools/discord_tool.py
+++ b/tools/discord_tool.py
@@ -450,6 +450,113 @@ def _channel_info(token: str, channel_id: str, **_kwargs: Any) -> str:
     })
 
 
+_CREATABLE_CHANNEL_TYPES = {
+    "text": 0,
+    "category": 4,
+}
+
+
+def _channel_summary(channel: Dict[str, Any]) -> Dict[str, Any]:
+    """Return the stable fields callers need after a channel mutation."""
+    return {
+        "id": channel["id"],
+        "guild_id": channel.get("guild_id"),
+        "name": channel.get("name"),
+        "type": _channel_type_name(channel["type"]),
+        "parent_id": channel.get("parent_id"),
+        "topic": channel.get("topic"),
+        "position": channel.get("position"),
+        "nsfw": channel.get("nsfw", False),
+    }
+
+
+def _create_channel(
+    token: str,
+    guild_id: str,
+    name: str,
+    channel_type: str = "text",
+    parent_id: str = "",
+    topic: Optional[str] = None,
+    nsfw: Optional[bool] = None,
+    rate_limit_per_user: Optional[int] = None,
+    **_kwargs: Any,
+) -> str:
+    """Create a guild text channel or category."""
+    type_id = _CREATABLE_CHANNEL_TYPES.get(channel_type)
+    if type_id is None:
+        return tool_error(
+            "Unsupported channel_type. Use one of: text, category."
+        )
+    if channel_type == "category" and (
+        topic is not None or nsfw is not None or rate_limit_per_user is not None
+    ):
+        return tool_error(
+            "category creation does not accept topic, nsfw, or rate_limit_per_user."
+        )
+    if rate_limit_per_user is not None and not 0 <= rate_limit_per_user <= 21600:
+        return tool_error("rate_limit_per_user must be between 0 and 21600 seconds.")
+    body: Dict[str, Any] = {"name": name, "type": type_id}
+    if parent_id:
+        body["parent_id"] = parent_id
+    if topic is not None:
+        body["topic"] = topic
+    if nsfw is not None:
+        body["nsfw"] = nsfw
+    if rate_limit_per_user is not None:
+        body["rate_limit_per_user"] = rate_limit_per_user
+    channel = _discord_request("POST", f"/guilds/{guild_id}/channels", token, body=body)
+    return json.dumps({"success": True, "channel": _channel_summary(channel)})
+
+
+def _edit_channel(
+    token: str,
+    channel_id: str,
+    name: str = "",
+    parent_id: str = "",
+    topic: Optional[str] = None,
+    position: Optional[int] = None,
+    nsfw: Optional[bool] = None,
+    rate_limit_per_user: Optional[int] = None,
+    **_kwargs: Any,
+) -> str:
+    """Edit explicit fields on a guild channel or category."""
+    body: Dict[str, Any] = {}
+    if name:
+        body["name"] = name
+    if parent_id:
+        body["parent_id"] = None if parent_id.lower() == "null" else parent_id
+    if topic is not None:
+        body["topic"] = topic
+    if position is not None:
+        body["position"] = position
+    if nsfw is not None:
+        body["nsfw"] = nsfw
+    if rate_limit_per_user is not None:
+        if not 0 <= rate_limit_per_user <= 21600:
+            return tool_error("rate_limit_per_user must be between 0 and 21600 seconds.")
+        body["rate_limit_per_user"] = rate_limit_per_user
+    if not body:
+        return tool_error(
+            "edit_channel requires at least one explicit edit field: name, parent_id, "
+            "topic, position, nsfw, or rate_limit_per_user."
+        )
+    channel = _discord_request("PATCH", f"/channels/{channel_id}", token, body=body)
+    return json.dumps({"success": True, "channel": _channel_summary(channel)})
+
+
+def _delete_channel(token: str, channel_id: str, **_kwargs: Any) -> str:
+    """Delete a guild channel or category."""
+    channel = _discord_request("DELETE", f"/channels/{channel_id}", token)
+    return json.dumps({
+        "success": True,
+        "deleted_channel": {
+            "id": channel["id"],
+            "name": channel.get("name"),
+            "type": _channel_type_name(channel["type"]),
+        },
+    })
+
+
 def _list_roles(token: str, guild_id: str, **_kwargs: Any) -> str:
     """List all roles in a guild."""
     roles = _discord_request("GET", f"/guilds/{guild_id}/roles", token)
@@ -643,6 +750,9 @@ _ACTIONS = {
     "unpin_message": _unpin_message,
     "delete_message": _delete_message,
     "create_thread": _create_thread,
+    "create_channel": _create_channel,
+    "edit_channel": _edit_channel,
+    "delete_channel": _delete_channel,
     "add_role": _add_role,
     "remove_role": _remove_role,
 }
@@ -670,6 +780,9 @@ _ACTION_MANIFEST: List[Tuple[str, str, str]] = [
     ("unpin_message", "(channel_id, message_id)", "unpin a message"),
     ("delete_message", "(channel_id, message_id)", "delete a message"),
     ("create_thread", "(channel_id, name)", "create a public thread; optional message_id anchor"),
+    ("create_channel", "(guild_id, name)", "create a guild text channel or category"),
+    ("edit_channel", "(channel_id)", "rename, move, or edit a guild channel/category"),
+    ("delete_channel", "(channel_id)", "delete a guild channel or category"),
     ("add_role", "(guild_id, user_id, role_id)", "assign a role"),
     ("remove_role", "(guild_id, user_id, role_id)", "remove a role"),
 ]
@@ -691,6 +804,9 @@ _REQUIRED_PARAMS: Dict[str, List[str]] = {
     "unpin_message": ["channel_id", "message_id"],
     "delete_message": ["channel_id", "message_id"],
     "create_thread": ["channel_id", "name"],
+    "create_channel": ["guild_id", "name"],
+    "edit_channel": ["channel_id"],
+    "delete_channel": ["channel_id"],
     "add_role": ["guild_id", "user_id", "role_id"],
     "remove_role": ["guild_id", "user_id", "role_id"],
 }
@@ -850,7 +966,35 @@ def _build_schema(
         },
         "name": {
             "type": "string",
-            "description": "New thread name (create_thread).",
+            "description": "Thread or channel name (create_thread, create_channel, edit_channel).",
+        },
+        "channel_type": {
+            "type": "string",
+            "enum": ["text", "category"],
+            "description": "Guild channel type (create_channel; default text).",
+        },
+        "parent_id": {
+            "type": "string",
+            "description": "Parent category ID. Pass the literal string 'null' to remove it (edit_channel).",
+        },
+        "topic": {
+            "type": "string",
+            "description": "Channel topic. Pass an empty string to clear it (create_channel, edit_channel).",
+        },
+        "position": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Channel sorting position (edit_channel).",
+        },
+        "nsfw": {
+            "type": "boolean",
+            "description": "Whether the channel is age-restricted (create_channel, edit_channel).",
+        },
+        "rate_limit_per_user": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 21600,
+            "description": "Slowmode seconds for a text channel (create_channel, edit_channel).",
         },
         "limit": {
             "type": "integer",
@@ -932,6 +1076,15 @@ _ACTION_403_HINT = {
     "create_thread": (
         "Bot lacks CREATE_PUBLIC_THREADS in this channel, or cannot view it."
     ),
+    "create_channel": (
+        "Bot lacks MANAGE_CHANNELS in this server. Ask the server admin to grant it."
+    ),
+    "edit_channel": (
+        "Bot lacks MANAGE_CHANNELS for this channel or category."
+    ),
+    "delete_channel": (
+        "Bot lacks MANAGE_CHANNELS for this channel or category."
+    ),
     "add_role": (
         "Either the bot lacks MANAGE_ROLES, or the target role sits higher "
         "than the bot's highest role. Roles can only be assigned below the "
@@ -998,6 +1151,12 @@ def _run_discord_action(
     before: str = "",
     after: str = "",
     auto_archive_duration: int = 1440,
+    channel_type: str = "text",
+    parent_id: str = "",
+    topic: Optional[str] = None,
+    position: Optional[int] = None,
+    nsfw: Optional[bool] = None,
+    rate_limit_per_user: Optional[int] = None,
 ) -> str:
     """Shared handler logic for both discord tools."""
     token = _get_bot_token()
@@ -1029,6 +1188,12 @@ def _run_discord_action(
         "message_id": message_id,
         "query": query,
         "name": name,
+        "channel_type": channel_type,
+        "parent_id": parent_id,
+        "topic": topic,
+        "position": position,
+        "nsfw": nsfw,
+        "rate_limit_per_user": rate_limit_per_user,
     }
 
     missing = [p for p in _REQUIRED_PARAMS.get(action, []) if not local_vars.get(p)]
@@ -1051,6 +1216,12 @@ def _run_discord_action(
             before=before,
             after=after,
             auto_archive_duration=auto_archive_duration,
+            channel_type=channel_type,
+            parent_id=parent_id,
+            topic=topic,
+            position=position,
+            nsfw=nsfw,
+            rate_limit_per_user=rate_limit_per_user,
         )
     except DiscordAPIError as e:
         logger.warning("Discord API error in %s action '%s': %s", tool_label, action, e)
@@ -1080,6 +1251,8 @@ _HANDLER_DEFAULTS = {
     "action": "", "guild_id": "", "channel_id": "", "user_id": "",
     "role_id": "", "message_id": "", "query": "", "name": "",
     "limit": 50, "before": "", "after": "", "auto_archive_duration": 1440,
+    "channel_type": "text", "parent_id": "", "topic": None,
+    "position": None, "nsfw": None, "rate_limit_per_user": None,
 }
 
 


### PR DESCRIPTION
## Summary
- add create_channel for guild text channels and categories
- add edit_channel for names, parent categories, topics, positions, NSFW, and slowmode
- add delete_channel with MANAGE_CHANNELS-specific error guidance
- expose all new fields through the dynamic discord_admin schema

## Verification
- uv run --with pytest pytest -q tests/tools/test_discord_channel_crud.py tests/tools/test_discord_tool.py
  - 55 passed
- uv run --with pytest --with pytest-asyncio pytest -q tests/tools/test_discord_channel_crud.py tests/tools/test_discord_tool.py tests/gateway/test_discord_channel_controls.py tests/gateway/test_discord_connect.py
  - 74 passed
- git diff --check

## Scope
No gateway restart and no Discord channel mutation were performed from this branch.