### PR TITLE
feat(plugins): index herdr-auto-reconcile

### DIFF
--- a/hermes_cli/data/plugin_index.json
+++ b/hermes_cli/data/plugin_index.json
@@ -63,6 +63,18 @@
       "capabilities": ["tools"],
       "api_version": 1,
       "added_at": "2026-08-12"
+    },
+    {
+      "name": "herdr-auto-reconcile",
+      "description": "Wake Hermes when allowlisted Herdr panes need reconciliation, without routing or controlling pane work.",
+      "author": "Chris Yau",
+      "tags": ["herdr", "gateway", "automation", "multi-agent", "liveness"],
+      "repo": "chris-yyau/hermes-herdr-auto-reconcile",
+      "ref": "7a01878039c217f7b3a5500a3086dd62a077d100",
+      "homepage": "https://github.com/chris-yyau/hermes-herdr-auto-reconcile",
+      "capabilities": ["gateway"],
+      "api_version": 1,
+      "added_at": "2026-08-28"
     }
   ]
 }


### PR DESCRIPTION
## What does this PR do?

Adds `herdr-auto-reconcile` to the bundled community plugin index seed, pinned to the immutable `v1.1.0` commit.

The plugin watches only explicitly allowlisted Herdr panes and wakes an existing Hermes gateway session when reconciliation is needed. It detects and wakes only: it does not route work, prompt or control panes, run shell commands, write repositories, approve actions, or select issues.

`NousResearch/hermes-plugin-index` is still unpublished (#87565), so the bundled seed is currently the only official index source available to `hermes plugins search` when the remote falls back. This follows the existing seed-entry precedent without adding plugin runtime code to core.

Indexed ≠ audited. This PR adds discovery metadata only; normal install scanning, explicit enablement, and the plugin's separate gateway-injection grant remain required.

## Related Issue

Related to #87565.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `hermes_cli/data/plugin_index.json` — append one entry for `chris-yyau/hermes-herdr-auto-reconcile`, pinned to `7a01878039c217f7b3a5500a3086dd62a077d100` (`v1.1.0`).

## How to Test

1. Parse the seed with `python3 -m json.tool hermes_cli/data/plugin_index.json`.
2. Load it through `hermes_cli.plugin_index`, then verify `search_index(..., "herdr")` and `resolve_name(..., "herdr-auto-reconcile")` return the pinned entry.
3. Run `pytest --import-mode=importlib -q tests/hermes_cli/test_plugin_index_search.py tests/hermes_cli/test_plugin_packs.py` — 74 passed.

The pinned source commit and root `plugin.yaml` were also verified through the GitHub API. The standalone plugin's own Python 3.11/3.13 CI, Plugin Doctor, and GitHub install/action E2E are green at that commit.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched open PRs and issues for duplicates
- [x] The PR contains only the one metadata entry
- [ ] Full `pytest tests/ -q` — not run for this data-only seed entry; the two focused index suites passed (74 tests)
- [x] Tests for this format already exist in the focused index suites
- [x] Tested on macOS

### Documentation & Housekeeping

- [x] Documentation update — N/A; plugin documentation lives in the standalone repo
- [x] `cli-config.yaml.example` — N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A; no workflow or architecture change
- [x] Cross-platform impact considered — JSON metadata only
- [x] Tool descriptions/schemas — N/A; no tool behavior changed
