### PR TITLE
fix(config): warn when disabled toolset policy has no effect

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2489,16 +2489,18 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
     try:
         from toolsets import validate_toolset
         from hermes_cli.toolset_validation import (
+            effective_toolset_validator,
             validate_disabled_toolset_declarations,
             validate_platform_toolsets,
         )
 
         raw_config = read_raw_config()
+        is_valid_toolset = effective_toolset_validator(raw_config, validate_toolset)
         platform_warnings = validate_platform_toolsets(
-            raw_config.get("platform_toolsets"), validate_toolset
+            raw_config.get("platform_toolsets"), is_valid_toolset
         )
         deny_warnings = validate_disabled_toolset_declarations(
-            raw_config, validate_toolset, environ=os.environ
+            raw_config, is_valid_toolset, environ=os.environ
         )
         for w in platform_warnings:
             results["warnings"].append(w)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2481,25 +2481,37 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
                 config["mcp_servers"] = raw_mcp_servers
                 _persist_migration(config)
 
-    # ── Always: validate platform_toolsets after migration ──
+    # ── Always: validate toolset declarations after migration ──
     # A migration (or hand-edit) that leaves an invalid toolset name in
     # platform_toolsets silently disables the affected tools — resolve_toolset()
     # returns [] for an unknown name, so the agent quietly loses tools with no
     # error or warning. Surface it loudly instead. See #38798.
     try:
         from toolsets import validate_toolset
-        from hermes_cli.toolset_validation import validate_platform_toolsets
-
-        ts_warnings = validate_platform_toolsets(
-            read_raw_config().get("platform_toolsets"), validate_toolset
+        from hermes_cli.toolset_validation import (
+            validate_disabled_toolset_declarations,
+            validate_platform_toolsets,
         )
-        for w in ts_warnings:
+
+        raw_config = read_raw_config()
+        platform_warnings = validate_platform_toolsets(
+            raw_config.get("platform_toolsets"), validate_toolset
+        )
+        deny_warnings = validate_disabled_toolset_declarations(
+            raw_config, validate_toolset, environ=os.environ
+        )
+        for w in platform_warnings:
             results["warnings"].append(w)
+            if not quiet:
+                print(f"  ⚠ {w}")
+        for w in deny_warnings:
+            results["warnings"].append(w)
+            logger.warning("Toolset configuration: %s", w)
             if not quiet:
                 print(f"  ⚠ {w}")
     except Exception as _ts_val_err:
         # best-effort; never block migration on validation
-        logger.debug("platform_toolsets validation skipped: %s", _ts_val_err)
+        logger.debug("toolset configuration validation skipped: %s", _ts_val_err)
 
     if current_ver < latest_ver and not quiet and not floor_refused:
         print(f"Config version: {current_ver} → {latest_ver}")

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1779,6 +1779,27 @@ def run_doctor(args):
         except Exception:
             pass
 
+        # Deny declarations are policy, so inert spellings must never look
+        # healthy. Inspect raw config plus environment key names only; values
+        # are deliberately excluded from diagnostics.
+        try:
+            from hermes_cli.config import load_env, read_user_config_raw
+            from hermes_cli.toolset_validation import validate_disabled_toolset_declarations
+            from toolsets import validate_toolset
+
+            raw_config = read_user_config_raw(config_path)
+            env_names = set(os.environ) | set(load_env())
+            deny_warnings = validate_disabled_toolset_declarations(
+                raw_config,
+                validate_toolset,
+                environ={name: "" for name in env_names},
+            )
+            for warning in deny_warnings:
+                check_warn(warning)
+                issues.append(warning)
+        except Exception:
+            pass
+
         # Detect stale HERMES_MAX_ITERATIONS ghost in .env shadowing
         # agent.max_turns in config.yaml (issue #17534). The setup wizard
         # used to dual-write the iteration budget to both stores; users who

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1784,14 +1784,18 @@ def run_doctor(args):
         # are deliberately excluded from diagnostics.
         try:
             from hermes_cli.config import load_env, read_user_config_raw
-            from hermes_cli.toolset_validation import validate_disabled_toolset_declarations
+            from hermes_cli.toolset_validation import (
+                effective_toolset_validator,
+                validate_disabled_toolset_declarations,
+            )
             from toolsets import validate_toolset
 
             raw_config = read_user_config_raw(config_path)
             env_names = set(os.environ) | set(load_env())
+            is_valid_toolset = effective_toolset_validator(raw_config, validate_toolset)
             deny_warnings = validate_disabled_toolset_declarations(
                 raw_config,
-                validate_toolset,
+                is_valid_toolset,
                 environ={name: "" for name in env_names},
             )
             for warning in deny_warnings:

--- a/hermes_cli/toolset_validation.py
+++ b/hermes_cli/toolset_validation.py
@@ -1,4 +1,4 @@
-"""Validation for the ``platform_toolsets`` config section.
+"""Validation for toolset-related config declarations.
 
 Pure, side-effect-free helpers so the logic is unit-testable without importing
 the tool registry or launching Hermes (mirrors the decoupled-helper pattern used
@@ -12,7 +12,23 @@ significant debugging to find. Surfacing invalid toolset names (and the
 zero-tools end state) loudly turns that silent failure into an actionable one.
 """
 
-from typing import Callable, List
+from collections.abc import Mapping
+from typing import Callable, Collection, List, Optional
+
+from agent.skill_utils import parse_config_string_list
+
+
+LEGACY_TOOLSET_NAMES = frozenset({
+    "web_tools",
+    "terminal_tools",
+    "vision_tools",
+    "image_tools",
+    "skills_tools",
+    "browser_tools",
+    "cronjob_tools",
+    "file_tools",
+    "tts_tools",
+})
 
 
 def validate_platform_toolsets(
@@ -70,5 +86,49 @@ def validate_platform_toolsets(
         warnings.append(
             "platform_toolsets resolves to zero valid toolsets — the agent will "
             "have no tools. Run `hermes tools` to reconfigure."
+        )
+    return warnings
+
+
+def validate_disabled_toolset_declarations(
+    config: object,
+    is_valid_toolset: Callable[[str], bool],
+    *,
+    environ: Optional[Mapping[str, str]] = None,
+    legacy_names: Collection[str] = LEGACY_TOOLSET_NAMES,
+) -> List[str]:
+    """Report deny declarations that cannot affect the active tool surface.
+
+    Values are only named when they are toolset identifiers; arbitrary config
+    and environment values are never included in diagnostics.
+    """
+    warnings: List[str] = []
+    if environ is not None and "HERMES_DISABLED_TOOLSETS" in environ:
+        warnings.append(
+            "HERMES_DISABLED_TOOLSETS is not supported and has no effect; "
+            "configure agent.disabled_toolsets in config.yaml instead"
+        )
+
+    if not isinstance(config, dict):
+        return warnings
+
+    if "disabled_toolsets" in config:
+        warnings.append(
+            "root-level 'disabled_toolsets' has no effect; move it under "
+            "agent.disabled_toolsets"
+        )
+
+    agent_config = config.get("agent")
+    if not isinstance(agent_config, dict):
+        return warnings
+
+    for raw_name in parse_config_string_list(agent_config.get("disabled_toolsets")):
+        name = raw_name.strip()
+        if not name or is_valid_toolset(name) or name in legacy_names:
+            continue
+        warnings.append(
+            f"agent.disabled_toolsets references unknown toolset '{name}'; "
+            "this entry has no effect. Run `hermes tools list` to see valid "
+            "toolset names"
         )
     return warnings

--- a/hermes_cli/toolset_validation.py
+++ b/hermes_cli/toolset_validation.py
@@ -31,6 +31,41 @@ LEGACY_TOOLSET_NAMES = frozenset({
 })
 
 
+def effective_toolset_validator(
+    config: object,
+    is_valid_toolset: Callable[[str], bool],
+) -> Callable[[str], bool]:
+    """Include configured extension toolsets in a validity predicate.
+
+    Plugin and MCP aliases are registered dynamically, after some config
+    diagnostics run.  Discover their declared names through the same cached
+    APIs used by the toolset picker so an early doctor or migration pass does
+    not mislabel a valid extension deny as inert.
+    """
+    dynamic_names = set()
+    if isinstance(config, dict):
+        mcp_servers = config.get("mcp_servers")
+        if isinstance(mcp_servers, Mapping):
+            dynamic_names.update(
+                name for name in mcp_servers if isinstance(name, str) and name
+            )
+
+    try:
+        from hermes_cli.plugins import (
+            get_plugin_toolset_keys_nowait,
+            get_portable_mcp_server_names_nowait,
+        )
+
+        dynamic_names.update(get_plugin_toolset_keys_nowait())
+        dynamic_names.update(get_portable_mcp_server_names_nowait())
+    except Exception:
+        # Diagnostics remain best-effort. Runtime validation after discovery is
+        # authoritative and will still warn about genuinely unknown names.
+        pass
+
+    return lambda name: is_valid_toolset(name) or name in dynamic_names
+
+
 def validate_platform_toolsets(
     platform_toolsets: object,
     is_valid_toolset: Callable[[str], bool],

--- a/model_tools.py
+++ b/model_tools.py
@@ -59,6 +59,7 @@ def suppress_post_tool_call_hook():
 # Tracks platform-bundle names already flagged in disabled_toolsets so the
 # advisory (#33924) is logged once per name, not on every tool recompute.
 _WARNED_DISABLED_BUNDLES: set = set()
+_WARNED_UNKNOWN_DISABLED_TOOLSETS: set = set()
 
 
 def _is_delegated_child_context() -> bool:
@@ -475,10 +476,10 @@ def _compute_tool_definitions(
                     to_remove = bundle_non_core_tools(toolset_name)
                     tools_to_include.difference_update(to_remove)
                     resolved = sorted(to_remove)
-                    if (not quiet_mode and toolset_name.startswith("hermes-")
+                    if (toolset_name.startswith("hermes-")
                             and toolset_name not in _WARNED_DISABLED_BUNDLES):
                         _WARNED_DISABLED_BUNDLES.add(toolset_name)
-                        logger.info(
+                        logger.warning(
                             "agent.disabled_toolsets contains platform-bundle "
                             "name '%s'; core tools are preserved and only its "
                             "platform-specific tools (%s) are removed. Bundle "
@@ -497,8 +498,15 @@ def _compute_tool_definitions(
                 tools_to_include.difference_update(legacy_tools)
                 if not quiet_mode:
                     print(f"🚫 Disabled legacy toolset '{toolset_name}': {', '.join(legacy_tools)}")
-            elif not quiet_mode:
-                print(f"⚠️  Unknown toolset: {toolset_name}")
+            else:
+                if toolset_name not in _WARNED_UNKNOWN_DISABLED_TOOLSETS:
+                    _WARNED_UNKNOWN_DISABLED_TOOLSETS.add(toolset_name)
+                    logger.warning(
+                        "agent.disabled_toolsets references unknown toolset "
+                        "'%s'; this entry has no effect. Run `hermes tools "
+                        "list` to see valid toolset names.",
+                        toolset_name,
+                    )
 
     # Plugin-registered tools are now resolved through the normal toolset
     # path — validate_toolset() / resolve_toolset() / get_all_toolsets()

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -564,6 +564,41 @@ class TestSanitizeEnvLines:
             "  ✓ Normalized .env line formatting (2 line(s) changed)\n"
         )
 
+    def test_migrate_reports_inert_disabled_toolset_declarations(
+        self, caplog, tmp_path
+    ):
+        latest_version = DEFAULT_CONFIG["_config_version"]
+        raw_config = {
+            "disabled_toolsets": ["terminal"],
+            "agent": {"disabled_toolsets": ["execute_code"]},
+        }
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "HERMES_DISABLED_TOOLSETS": "do-not-log-this-value",
+                    "HERMES_HOME": str(tmp_path),
+                },
+                clear=True,
+            ),
+            patch("hermes_cli.config.sanitize_env_file", return_value=0),
+            patch(
+                "hermes_cli.config.check_config_version",
+                return_value=(latest_version, latest_version),
+            ),
+            patch("hermes_cli.config.read_raw_config", return_value=raw_config),
+            patch("hermes_cli.config.get_missing_env_vars", return_value=[]),
+            patch("hermes_cli.config.get_missing_config_fields", return_value=[]),
+            patch("hermes_cli.config.get_missing_skill_config_vars", return_value=[]),
+        ):
+            results = migrate_config(interactive=False, quiet=True)
+
+        assert len(results["warnings"]) == 3
+        assert "HERMES_DISABLED_TOOLSETS" in caplog.text
+        assert "root-level 'disabled_toolsets'" in caplog.text
+        assert "unknown toolset 'execute_code'" in caplog.text
+        assert "do-not-log-this-value" not in caplog.text
+
 
 
 

--- a/tests/hermes_cli/test_toolset_validation.py
+++ b/tests/hermes_cli/test_toolset_validation.py
@@ -6,7 +6,10 @@ tool registry nor a running Hermes.
 
 import pytest
 
-from hermes_cli.toolset_validation import validate_platform_toolsets
+from hermes_cli.toolset_validation import (
+    validate_disabled_toolset_declarations,
+    validate_platform_toolsets,
+)
 
 # A representative set of real toolset names. `hermes` is deliberately absent —
 # that is the corruption #38798 reported (`hermes-cli` rewritten to `hermes`).
@@ -44,6 +47,43 @@ def test_mixed_valid_and_invalid_flags_only_the_invalid():
     assert len(warnings) == 1
     assert "platform 'discord'" in warnings[0]
     assert "unknown toolset 'bogus'" in warnings[0]
+
+
+def test_disabled_toolset_validation_reports_every_inert_declaration():
+    warnings = validate_disabled_toolset_declarations(
+        {
+            "disabled_toolsets": ["terminal"],
+            "agent": {"disabled_toolsets": ["terminal", "execute_code"]},
+        },
+        _is_valid,
+        environ={"HERMES_DISABLED_TOOLSETS": "code_execution"},
+    )
+
+    assert len(warnings) == 3
+    assert any("HERMES_DISABLED_TOOLSETS" in warning for warning in warnings)
+    assert any("root-level 'disabled_toolsets'" in warning for warning in warnings)
+    assert any("unknown toolset 'execute_code'" in warning for warning in warnings)
+    assert all("agent.disabled_toolsets" in warning for warning in warnings)
+
+
+def test_disabled_toolset_validation_accepts_effective_legacy_names():
+    warnings = validate_disabled_toolset_declarations(
+        {"agent": {"disabled_toolsets": ["terminal_tools"]}},
+        _is_valid,
+        legacy_names={"terminal_tools"},
+    )
+
+    assert warnings == []
+
+
+def test_disabled_toolset_validation_parses_list_shaped_strings():
+    warnings = validate_disabled_toolset_declarations(
+        {"agent": {"disabled_toolsets": "['terminal', 'execute_code']"}},
+        _is_valid,
+    )
+
+    assert len(warnings) == 1
+    assert "unknown toolset 'execute_code'" in warnings[0]
 
 
 

--- a/tests/hermes_cli/test_toolset_validation.py
+++ b/tests/hermes_cli/test_toolset_validation.py
@@ -7,6 +7,7 @@ tool registry nor a running Hermes.
 import pytest
 
 from hermes_cli.toolset_validation import (
+    effective_toolset_validator,
     validate_disabled_toolset_declarations,
     validate_platform_toolsets,
 )
@@ -84,6 +85,34 @@ def test_disabled_toolset_validation_parses_list_shaped_strings():
 
     assert len(warnings) == 1
     assert "unknown toolset 'execute_code'" in warnings[0]
+
+
+def test_dynamic_extension_toolsets_are_valid_before_registry_discovery(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.plugins.get_plugin_toolset_keys_nowait",
+        lambda: {"plugin_bundle"},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.plugins.get_portable_mcp_server_names_nowait",
+        lambda: {"portable_server"},
+    )
+    config = {
+        "mcp_servers": {"native_server": {"enabled": True}},
+        "agent": {
+            "disabled_toolsets": [
+                "plugin_bundle",
+                "portable_server",
+                "native_server",
+                "bogus",
+            ]
+        },
+    }
+
+    is_valid = effective_toolset_validator(config, _is_valid)
+    warnings = validate_disabled_toolset_declarations(config, is_valid)
+
+    assert len(warnings) == 1
+    assert "unknown toolset 'bogus'" in warnings[0]
 
 
 

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -450,6 +450,19 @@ class TestDisabledToolsetsPlatformBundle:
         names = {t["function"]["name"] for t in tools}
         assert "discord" not in names
 
+    def test_unknown_disabled_toolset_warns_in_quiet_mode(self, caplog):
+        from model_tools import _compute_tool_definitions
+
+        _compute_tool_definitions(
+            enabled_toolsets=["terminal"],
+            disabled_toolsets=["execute_code"],
+            quiet_mode=True,
+        )
+
+        assert "agent.disabled_toolsets" in caplog.text
+        assert "execute_code" in caplog.text
+        assert "has no effect" in caplog.text
+
 
 
 

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -463,6 +463,41 @@ class TestDisabledToolsetsPlatformBundle:
         assert "execute_code" in caplog.text
         assert "has no effect" in caplog.text
 
+    def test_registry_owned_toolset_is_removed_when_disabled(self, monkeypatch):
+        from model_tools import _compute_tool_definitions
+        from tools.registry import ToolRegistry
+
+        reg = ToolRegistry()
+        reg.register(
+            name="dynamic_probe",
+            toolset="plugin_bundle",
+            schema={
+                "name": "dynamic_probe",
+                "description": "Probe",
+                "parameters": {"type": "object", "properties": {}},
+            },
+            handler=lambda args, **kwargs: "{}",
+        )
+        monkeypatch.setattr("tools.registry.registry", reg)
+        monkeypatch.setattr("model_tools.registry", reg)
+
+        enabled = _compute_tool_definitions(
+            enabled_toolsets=["plugin_bundle"],
+            quiet_mode=True,
+            skip_tool_search_assembly=True,
+        )
+        disabled = _compute_tool_definitions(
+            enabled_toolsets=["plugin_bundle"],
+            disabled_toolsets=["plugin_bundle"],
+            quiet_mode=True,
+            skip_tool_search_assembly=True,
+        )
+
+        assert "dynamic_probe" in {tool["function"]["name"] for tool in enabled}
+        assert "dynamic_probe" not in {
+            tool["function"]["name"] for tool in disabled
+        }
+
 
 
 


### PR DESCRIPTION
## What does this PR do?

Warns operators when a disabled-toolset policy cannot take effect, instead of silently leaving terminal or code-execution capabilities available. The diagnostics cover the unsupported `HERMES_DISABLED_TOOLSETS` environment variable, a misplaced root-level `disabled_toolsets` key, and unknown names under `agent.disabled_toolsets` without logging arbitrary configuration values.

### Symptom

A gateway or cron agent can start normally and retain tools that an operator intended to disable. In quiet mode, an unknown deny entry such as `execute_code` produced no warning, while `hermes doctor` did not report the unsupported environment variable or misplaced root key.

### Impact

Operators can believe a capability restriction is active when the model still receives and can call the corresponding tools. The affected deployment count is unknown.

### Bug Cause

**Trigger:** `model_tools.py:_compute_tool_definitions` and `hermes_cli/doctor.py:run_doctor`

**Causal chain:**
1. An operator configures an unsupported environment variable, places `disabled_toolsets` at the config root, or uses a tool name instead of a toolset name.
2. The config readers ignore the first two shapes, while the runtime unknown-name branch only printed when `quiet_mode` was false.
3. Gateway and cron agents use quiet mode, so the ineffective deny declaration leaves the tool surface unchanged with no actionable diagnostic.

**Why it is wrong:** deny declarations express capability policy. Treating an invalid declaration as an unobservable no-op makes the configured policy differ from the actual model tool surface.

**Working sibling / contrast:** valid names under `agent.disabled_toolsets`, such as `code_execution`, already reach the final subtraction step and remove their tools. Legacy accepted names remain valid for compatibility.

**Ruled out:** adopting `HERMES_DISABLED_TOOLSETS` as a new behavior channel was rejected because non-secret behavioral settings belong in `config.yaml`; the supported replacement is `agent.disabled_toolsets`.

### Fix

- Add shared validation for unsupported, misplaced, and unknown disabled-toolset declarations, including list-shaped string parsing and legacy-name compatibility.
- Run the validation during config migration and in `hermes doctor`, with messages that name only declaration/toolset identifiers and never environment values.
- Promote unknown disabled-toolset and platform-bundle advisories to once-per-process warnings that remain visible in quiet gateway and cron paths.

## Related Issue

Closes #97111

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `hermes_cli/toolset_validation.py` - validate all inert disabled-toolset declaration shapes.
- `hermes_cli/config.py` - report deny validation findings during migration, including quiet startup logs.
- `hermes_cli/doctor.py` - diagnose unsupported environment, misplaced root key, and unknown deny entries.
- `model_tools.py` - log unknown disabled names and bundle misuse even in quiet mode.
- `tests/hermes_cli/test_toolset_validation.py`, `tests/hermes_cli/test_config.py`, `tests/test_model_tools.py` - cover validation, non-disclosure, and quiet-mode runtime warnings.

## How to Test

1. Set `HERMES_DISABLED_TOOLSETS`, add root-level `disabled_toolsets`, and add an unknown name under `agent.disabled_toolsets`.
2. Run `hermes doctor` and verify all three actionable warnings appear while the environment variable value does not.
3. Run the focused automated suite:

```bash
scripts/run_tests.sh tests/hermes_cli/test_toolset_validation.py tests/test_model_tools.py tests/hermes_cli/test_config.py tests/hermes_cli/test_doctor.py tests/cron/test_agent_scheduling_gate.py tests/gateway/test_config.py tests/gateway/test_mcp_reload_refreshes_cached_agents.py -q
```

Observed: 290 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11, Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A, diagnostics describe the supported key directly
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A, no config key was added or changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - platform-independent Python config validation
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A, tool schemas are unchanged

## Screenshots / Logs

`hermes doctor` was exercised against a temporary config containing all three inert declaration shapes. It reported each warning and did not print the configured environment value.
