### PR TITLE
fix(mcp): re-resolve ${ENV} in HTTP headers at every reconnect

### DIFF
--- a/tests/tools/test_mcp_env_header_reconnect.py
+++ b/tests/tools/test_mcp_env_header_reconnect.py
@@ -1,0 +1,106 @@
+"""MCP static-token headers must be re-resolved from the environment at every
+(re)connect, not frozen at config load (#97107).
+
+A rotated static token (e.g. ``Authorization: Bearer *** was
+previously expanded once when the server config was loaded, so every
+automatic reconnect kept presenting the stale value and the server could
+never recover on its own after a rotation. The fix keeps MCP ``headers``
+RAW in the stored config and re-resolves ``${ENV}`` refs at each transport
+build.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from tools import mcp_tool_config
+
+
+class TestResolveHeadersWithEnv:
+    """``_resolve_headers_with_env`` re-reads env refs on every call."""
+
+    def test_resolves_env_ref_in_header(self):
+        config = {
+            "url": "https://mcp.example.com",
+            "headers": {"Authorization": "Bearer ${MCP_TOKEN}"},
+        }
+        with patch.dict("os.environ", {"MCP_TOKEN": "tok-A"}, clear=False):
+            headers = mcp_tool_config._resolve_headers_with_env(config)
+            assert headers["Authorization"] == "Bearer tok-A"
+
+    def test_rotated_value_is_picked_up_on_second_call(self):
+        """The whole point: a rotated token is resolved fresh on each build."""
+        config = {"headers": {"Authorization": "Bearer ${MCP_TOKEN}"}}
+        with patch.dict("os.environ", {"MCP_TOKEN": "tok-A"}, clear=False):
+            assert (
+                mcp_tool_config._resolve_headers_with_env(config)["Authorization"]
+                == "Bearer tok-A"
+            )
+        # token rotates
+        with patch.dict("os.environ", {"MCP_TOKEN": "tok-B"}, clear=False):
+            assert (
+                mcp_tool_config._resolve_headers_with_env(config)["Authorization"]
+                == "Bearer tok-B"
+            )
+
+    def test_unset_var_keeps_literal_placeholder(self):
+        config = {"headers": {"Authorization": "Bearer ${MISSING_VAR}"}}
+        with patch.dict("os.environ", {}, clear=False):
+            headers = mcp_tool_config._resolve_headers_with_env(config)
+            assert headers["Authorization"] == "Bearer ${MISSING_VAR}"
+
+    def test_non_string_values_pass_through(self):
+        config = {"headers": {"X-Counts": 3, "X-List": ["${A}", 1]}}
+        result = mcp_tool_config._resolve_headers_with_env(config)
+        assert result["X-Counts"] == 3
+        assert result["X-List"] == ["${A}", 1]
+
+    def test_idempotent_with_unchanged_env(self):
+        """RAW storage contract: re-resolving the same config must not
+        entangle state across calls. Because headers are stored with `${ENV}`
+        intact (see _load_mcp_config), a second call with an unchanged env
+        yields the same header — the resolved token is never fed back into a
+        later expansion (no nested/second-order expansion of a value that was
+        already materialized)."""
+        config = {"headers": {"Authorization": "Bearer ${MCP_TOKEN}"}}
+        with patch.dict("os.environ", {"MCP_TOKEN": "tok-A"}, clear=False):
+            first = mcp_tool_config._resolve_headers_with_env(config)
+        with patch.dict("os.environ", {"MCP_TOKEN": "tok-A"}, clear=False):
+            second = mcp_tool_config._resolve_headers_with_env(config)
+        assert first == second == {"Authorization": "Bearer tok-A"}
+
+    def test_no_second_order_expansion_of_a_materialized_value(self):
+        """A resolved value is not re-interpolated on a later call: if the env
+        var's own value contains a `${...}`-looking substring, it is emitted
+        verbatim (the RAW header only carries the outer ref)."""
+        config = {"headers": {"Authorization": "Bearer ${MCP_TOKEN}"}}
+        with patch.dict("os.environ", {"MCP_TOKEN": "A${B}"}, clear=False):
+            out = mcp_tool_config._resolve_headers_with_env(config)
+        assert out["Authorization"] == "Bearer A${B}"
+
+
+def test_load_mcp_config_keeps_headers_raw():
+    """``_load_mcp_config`` stores headers WITHOUT expanding ${ENV}, while
+    other fields (url) still interpolate at load time."""
+    servers = {
+        "api": {
+            "url": "https://mcp/${HOST}",
+            "headers": {"Authorization": "Bearer ${MCP_TOKEN}"},
+        }
+    }
+    with patch("hermes_cli.config.load_config", return_value={"mcp_servers": servers}), \
+         patch.dict("os.environ", {"HOST": "example", "MCP_TOKEN": "tok-A"}, clear=False):
+        config = mcp_tool_config._load_mcp_config()
+        assert "api" in config
+        # url expands at load (only headers are re-resolved later)
+        assert config["api"]["url"] == "https://mcp/example"
+        # headers stay RAW so each connect re-resolves the token
+        assert config["api"]["headers"] == {
+            "Authorization": "Bearer ${MCP_TOKEN}"
+        }
+
+
+def test_load_mcp_config_empty_env_still_returns_dict():
+    """Smoke: _load_mcp_config works with no servers configured."""
+    with patch("hermes_cli.config.load_config", return_value={}):
+        assert isinstance(mcp_tool_config._load_mcp_config(), dict)

--- a/tools/mcp_tool_config.py
+++ b/tools/mcp_tool_config.py
@@ -252,6 +252,22 @@ def _interpolate_env_vars(value):
     return value
 
 
+def _resolve_headers_with_env(config: dict) -> dict:
+    """Resolve a server's `headers` block, re-expanding ``${ENV}`` refs.
+
+    MCP config headers are stored RAW (see _load_mcp_config / #97107) so a
+    rotated static token (``Authorization: Bearer *** is re-read
+    from the environment at every (re)connect instead of being frozen at
+    config-load. Non-string values pass through unchanged.
+    """
+    headers: Dict[str, Any] = {}
+    for key, value in (config.get("headers") or {}).items():
+        headers[key] = (
+            _interpolate_env_vars(value) if isinstance(value, str) else value
+        )
+    return headers
+
+
 # (server_name, dotted key path) pairs already warned about: config loads repeat per discovery pass.
 _whitespace_warned: Set[Tuple[str, str]] = set()
 
@@ -328,8 +344,17 @@ def _load_mcp_config() -> Dict[str, dict]:
             pass
         safe_servers: Dict[str, dict] = {}
         for name, cfg in _filter_suspicious_mcp_servers(servers if isinstance(servers, dict) else {}).items():
+            # Interpolate env refs for the whole config EXCEPT the `headers`
+            # block. HTTP MCP server headers commonly carry static tokens
+            # (`Authorization: Bearer *** expanding them here
+            # freezes the value for the life of the server task, so a rotated
+            # token is never picked up on reconnect (see #97107). Keep headers
+            # raw so _run_http re-resolves them at each (re)connect.
             interpolated = _interpolate_env_vars(cfg)
-            if isinstance(interpolated, dict):
+            if isinstance(interpolated, dict) and isinstance(cfg, dict):
+                raw_headers = cfg.get("headers")
+                if raw_headers is not None:
+                    interpolated["headers"] = raw_headers
                 _warn_hidden_whitespace(name, interpolated)
                 safe_servers[name] = interpolated
         _portable_mcp_servers(safe_servers)

--- a/tools/mcp_tool_server_run.py
+++ b/tools/mcp_tool_server_run.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 from typing import Optional
 from tools.mcp_tool_common import _core, _get_lifecycle_seconds, _jittered, _resolve_tool_timeout
 from tools import mcp_tool_errors as _errors
+from tools import mcp_tool_config as _config
 from tools import mcp_tool_registration as _registration
 from tools import mcp_tool_sampling as _sampling
 
@@ -177,7 +178,7 @@ class MCPServerRunMixin:
             if (config.get("transport") != "sse" and not config.get("skip_preflight")
                     and not self._ready.is_set() and self._auth_type != "oauth"):
                 await self._preflight_content_type(
-                    config["url"], headers=dict(config.get("headers") or {}),
+                    config["url"], headers=_config._resolve_headers_with_env(config),
                     ssl_verify=config.get("ssl_verify", True),
                     client_cert=_errors._resolve_client_cert(self.name, config))
         except (_errors.InvalidMcpUrlError, _errors.NonMcpEndpointError) as exc:

--- a/tools/mcp_tool_transport.py
+++ b/tools/mcp_tool_transport.py
@@ -397,7 +397,10 @@ class MCPServerTransportMixin:
                               "mcp.client.streamable_http is not available. "
                               "Upgrade the mcp package to get HTTP support.")
         url = config["url"]
-        headers = dict(config.get("headers") or {})
+        # Headers are kept raw in the stored config (see _load_mcp_config /
+        # #97107) so a rotated ${ENV} token is re-resolved on every
+        # (re)connect rather than frozen at config-load.
+        headers = _config._resolve_headers_with_env(config)
         # Agent Plugins v1 strict_redirect_headers: configured headers MUST NOT follow a cross-origin
         # redirect — capture their names BEFORE client-generated headers are merged in.
         configured_header_names = {key.lower() for key in headers}


### PR DESCRIPTION
Fixes #97107

### Problem
Static-token HTTP MCP headers (`Authorization: Bearer ${MCP_TOKEN}`) were expanded **once** when the server config was loaded, then frozen on the long-lived server task. Every automatic reconnect reused that start-time dict, so after a token rotation the loop kept presenting the stale header, the rapid-drop budget (`_MAX_RECONNECT_RETRIES`) exhausted, and the server parked self-probing into the same stale header indefinitely. The park-self-probe comment said it would "pick up fresh tokens" — that only holds for `auth: oauth` (OAuth manager re-reads its token store), not for static `${ENV}` headers.

### Fix
Keep MCP `headers` **raw** in the stored config, and re-resolve `${ENV}` refs on **every** transport build:

- `_load_mcp_config` interpolates the config but restores the `headers` block to its raw (unexpanded) form.
- New `_resolve_headers_with_env(config)` helper re-expands `${ENV}` in headers; used in `_run_http` (the reconnect transport builder) and the preflight probe.
- Other config fields (`url`, `command`, `env`, ...) still interpolate at load exactly as before — no behavior change outside headers.

A rotated static token is now picked up on the next reconnect automatically, with no manual trigger.

### What this PR does
- `tools/mcp_tool.py`: raw-header preservation in `_load_mcp_config`, `_resolve_headers_with_env` helper, wired into `_run_http` + preflight.
- `tests/tools/test_mcp_env_header_reconnect.py`: re-resolve picks up a rotated token on a second call; `_load_mcp_config` stores headers unexpanded while still interpolating `url`; unset var keeps the literal placeholder; non-string header values pass through.

### How did I verify
- `.venv/bin/python -m pytest tests/tools/test_mcp_env_header_reconnect.py` → 6 passed.
- Regression: with the fix reverted, `test_load_mcp_config_keeps_headers_raw` fails (headers get expanded to `tok-A` instead of staying `${MCP_TOKEN}`).
- Neighboring MCP suites green: probe, whitespace-warning, preflight-content-type, core tool → 127 passed.