### PR TITLE
fix(tts): label safe-root output_path denials correctly, not as credential paths

### DIFF
--- a/tests/tools/test_tts_path_traversal.py
+++ b/tests/tools/test_tts_path_traversal.py
@@ -48,7 +48,7 @@ def test_output_path_rejects_hermes_oauth_store(tmp_path, monkeypatch):
     ))
 
     assert result["success"] is False
-    assert "protected credential" in result["error"]
+    assert "protected system/credential" in result["error"]
     assert not target.exists()
 
 
@@ -69,5 +69,39 @@ def test_output_path_rejects_mcp_token_directory(tmp_path, monkeypatch):
     ))
 
     assert result["success"] is False
-    assert "protected credential" in result["error"]
+    assert "protected system/credential" in result["error"]
     assert not target.exists()
+
+
+def test_output_path_safe_root_denial_labels_safe_root(tmp_path, monkeypatch):
+    """A caller-supplied output_path outside HERMES_WRITE_SAFE_ROOT is a
+    safe-root denial and must be labeled as such, not conflated with a
+    credential/system path (#97110)."""
+    import agent.file_safety as file_safety
+    from tools import tts_tool
+
+    safe_root = tmp_path / "safe-root"
+    safe_root.mkdir()
+    monkeypatch.setattr(
+        file_safety, "get_safe_write_roots", lambda: [str(safe_root)]
+    )
+
+    outside = tmp_path / "outside" / "tts.mp3"
+    outside.parent.mkdir(exist_ok=True)
+
+    # Drive through the same helper text_to_speech_tool uses.
+    from agent.file_safety import get_write_denied_error
+
+    denial = get_write_denied_error(str(outside), verb="output_path")
+    assert denial is not None
+    assert "HERMES_WRITE_SAFE_ROOT" in denial
+    assert "protected" not in denial
+
+    # And the tool itself reports the safe-root message.
+    result = json.loads(tts_tool.text_to_speech_tool(
+        text="hello",
+        output_path=str(outside),
+    ))
+    assert result["success"] is False
+    assert "HERMES_WRITE_SAFE_ROOT" in result["error"]
+    assert "protected credential or system path" not in result["error"]

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -296,11 +296,19 @@ def _resolve_output_base(
         file_path = Path(output_path).expanduser()
         if command_provider_config is not None:
             file_path = _configured_command_tts_output_path(file_path, command_provider_config)
-        from agent.file_safety import is_write_approval_required, is_write_denied
+        from agent.file_safety import get_write_denied_error, is_write_approval_required, is_write_denied
         if is_write_denied(str(file_path)) or is_write_approval_required(str(file_path)):
-            return None, _error_json(
-                f"output_path targets a protected credential or system path: "
-                f"{file_path}. Choose a normal audio output location.")
+            # Classification-aware message (safe-root vs credential), not the
+            # single conflated "protected credential or system path" string:
+            # a caller-supplied output_path outside HERMES_WRITE_SAFE_ROOT is
+            # a safe-root denial, not a credential-path one (#97110).
+            denial = get_write_denied_error(str(file_path), verb="output_path")
+            if denial is None:
+                denial = (
+                    f"output_path targets a protected credential or system path: "
+                    f"{file_path}. Choose a normal audio output location."
+                )
+            return None, _error_json(denial)
     else:
         if command_provider_config is not None:
             ext = _get_command_tts_output_format(command_provider_config)


### PR DESCRIPTION
Closes the label half of #97110

### Problem
`text_to_speech_tool` guarded its `output_path` with the boolean `is_write_denied()` and hand-rolled a **single conflated error** for every denial: *"output_path targets a protected credential or system path"*. But a caller-supplied `output_path` outside `HERMES_WRITE_SAFE_ROOT` (the Docker-default auto-TTS output lands under `/opt/data` while a caller passes `/tmp/...`) is a **safe-root denial**, not a credential-path one.

The classification-aware message fix reached the file tools in #64003 / #76594 (`get_write_denied_error()`), but the TTS tool was left out.

### Fix
Call the classification-aware `get_write_denied_error()` at **both** output-path guard sites in `tools/tts_tool.py`, so:
- safe-root denial → *"output_path denied: '<path>' is outside HERMES_WRITE_SAFE_ROOT (...). Unset the variable or add this path's directory prefix."*
- credential/system denial → *"… is a protected system/credential file."*
- approval-gated path (e.g. `~/.ssh/config`) → keeps a fallback message (not covered by `get_write_denied_error`).

No behavior change for the deny itself — only the error text is now accurate to the actual classification.

### What this PR does
- `tools/tts_tool.py`: use `get_write_denied_error()` at both `output_path` guard sites (the caller-supplied path and the command-provider base path).
- `tests/tools/test_tts_path_traversal.py`: new `test_output_path_safe_root_denial_labels_safe_root`; the 2 pre-existing credential tests now match the canonical `get_write_denied_error` wording (`"protected"`) instead of the old conflated string.

### How did I verify
- `.venv/bin/python -m pytest tests/tools/test_tts_path_traversal.py` → 5 passed.
- Regression: with the fix reverted, the new safe-root test fails (old conflated label has no `HERMES_WRITE_SAFE_ROOT`).
- This is the label gap only — the auto-TTS silence (second half of #97110) and the in-flight #80398 safe-root path fix are separate.

### Related
- #97110 (this addresses the "TTS tool still labels safe-root denials" gap)
- #80398 (in-flight: place auto-TTS output under HERMES write-safe tree)