### PR TITLE
fix(kanban): gate dependencies on exact parent results

### DIFF
--- a/contributors/emails/nunm1107@hotmail.com
+++ b/contributors/emails/nunm1107@hotmail.com
@@ -1,0 +1,2 @@
+MisterNunm
+# PR #97151 (Kanban exact parent-result gates)

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -22,7 +22,7 @@ import shlex
 import sys
 import time
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Iterable, Optional
 
 from hermes_cli import kanban_db as kb
 from hermes_cli import kanban_swarm as ks
@@ -333,6 +333,18 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_create.add_argument("--assignee", default=None, help="Profile name to assign")
     p_create.add_argument("--parent", action="append", default=[],
                           help="Parent task id (repeatable)")
+    p_create.add_argument(
+        "--require-parent-result",
+        action="append",
+        default=[],
+        dest="required_parent_results",
+        metavar="PARENT=RESULT",
+        help=(
+            "Require one parent edge to have an exact machine-readable result "
+            "while done (repeatable), e.g. "
+            "--require-parent-result t_qa=ready_to_deploy"
+        ),
+    )
     p_create.add_argument("--workspace", default="scratch",
                           help="scratch | worktree | worktree:<path> | dir:<path> "
                                "(default: scratch)")
@@ -550,6 +562,14 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_link = sub.add_parser("link", help="Add a parent->child dependency")
     p_link.add_argument("parent_id")
     p_link.add_argument("child_id")
+    p_link.add_argument(
+        "--required-parent-result",
+        default=None,
+        help=(
+            "Require the parent to be done with this exact machine-readable "
+            "result before releasing the child"
+        ),
+    )
     p_unlink = sub.add_parser("unlink", help="Remove a parent->child dependency")
     p_unlink.add_argument("parent_id")
     p_unlink.add_argument("child_id")
@@ -1539,6 +1559,21 @@ def _cmd_assignees(args: argparse.Namespace) -> int:
     return 0
 
 
+def _parse_required_parent_results(values: Iterable[str]) -> dict[str, str]:
+    """Parse repeatable ``PARENT=RESULT`` CLI values into an edge map."""
+    parsed: dict[str, str] = {}
+    for raw_value in values:
+        parent_id, separator, required_result = str(raw_value).partition("=")
+        parent_id = parent_id.strip()
+        required_result = required_result.strip()
+        if not separator or not parent_id or not required_result:
+            raise ValueError(
+                f"expected PARENT=RESULT, got {raw_value!r}"
+            )
+        parsed[parent_id] = required_result
+    return parsed
+
+
 def _cmd_create(args: argparse.Namespace) -> int:
     try:
         ws_kind, ws_path = _parse_workspace_flag(args.workspace)
@@ -1562,6 +1597,13 @@ def _cmd_create(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
         return 2
+    try:
+        required_parent_results = _parse_required_parent_results(
+            getattr(args, "required_parent_results", None) or []
+        )
+    except ValueError as exc:
+        print(f"kanban: --require-parent-result: {exc}", file=sys.stderr)
+        return 2
     with kb.connect_closing() as conn:
         task_id = kb.create_task(
             conn,
@@ -1576,6 +1618,7 @@ def _cmd_create(args: argparse.Namespace) -> int:
             tenant=args.tenant,
             priority=args.priority,
             parents=tuple(args.parent or ()),
+            required_parent_results=required_parent_results,
             triage=bool(getattr(args, "triage", False)),
             idempotency_key=getattr(args, "idempotency_key", None),
             max_runtime_seconds=max_runtime,
@@ -2068,7 +2111,14 @@ def _cmd_diagnostics(args: argparse.Namespace) -> int:
 
 def _cmd_link(args: argparse.Namespace) -> int:
     with kb.connect_closing() as conn:
-        kb.link_tasks(conn, args.parent_id, args.child_id)
+        kb.link_tasks(
+            conn,
+            args.parent_id,
+            args.child_id,
+            required_parent_result=getattr(
+                args, "required_parent_result", None
+            ),
+        )
     print(f"Linked {args.parent_id} -> {args.child_id}")
     return 0
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1426,8 +1426,11 @@ CREATE TABLE IF NOT EXISTS tasks (
 );
 
 CREATE TABLE IF NOT EXISTS task_links (
-    parent_id  TEXT NOT NULL,
-    child_id   TEXT NOT NULL,
+    parent_id              TEXT NOT NULL,
+    child_id               TEXT NOT NULL,
+    -- Optional exact machine-readable result required from this parent.
+    -- NULL preserves the legacy terminal-status-only dependency behavior.
+    required_parent_result TEXT,
     PRIMARY KEY (parent_id, child_id)
 );
 
@@ -2705,6 +2708,28 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         "CREATE INDEX IF NOT EXISTS idx_tasks_session_id ON tasks(session_id)"
     )
 
+    # Result-aware dependency edges are opt-in. Existing links receive NULL,
+    # preserving their historical done/archived terminal-status semantics.
+    task_links_exists = (
+        conn.execute(
+            "SELECT 1 FROM sqlite_master "
+            "WHERE type='table' AND name='task_links' LIMIT 1"
+        ).fetchone()
+        is not None
+    )
+    link_cols = (
+        {row["name"] for row in conn.execute("PRAGMA table_info(task_links)")}
+        if task_links_exists
+        else set()
+    )
+    if task_links_exists and "required_parent_result" not in link_cols:
+        _add_column_if_missing(
+            conn,
+            "task_links",
+            "required_parent_result",
+            "required_parent_result TEXT",
+        )
+
     # task_events gained a run_id column; back-fill it as NULL for
     # historical events (they predate runs and can't be attributed).
     ev_cols = {row["name"] for row in conn.execute("PRAGMA table_info(task_events)")}
@@ -3166,6 +3191,40 @@ def _canonical_assignee(assignee: Optional[str]) -> Optional[str]:
     return normalize_profile_name(assignee)
 
 
+def _normalize_required_parent_results(
+    parents: Iterable[str],
+    required_parent_results: Optional[Mapping[str, str]],
+) -> dict[str, str]:
+    """Validate and normalize per-parent result predicates for task creation."""
+    if required_parent_results is None:
+        return {}
+    if not isinstance(required_parent_results, Mapping):
+        raise ValueError("required_parent_results must map parent ids to results")
+    parent_ids = set(parents)
+    normalized: dict[str, str] = {}
+    for raw_parent_id, raw_result in required_parent_results.items():
+        parent_id = str(raw_parent_id).strip()
+        if parent_id not in parent_ids:
+            raise ValueError(
+                f"required parent {parent_id!r} is not present in parents"
+            )
+        if not isinstance(raw_result, str) or not raw_result.strip():
+            raise ValueError(
+                f"required result for parent {parent_id!r} must be a non-empty string"
+            )
+        normalized[parent_id] = raw_result.strip()
+    return normalized
+
+
+def _normalize_required_parent_result(value: Optional[str]) -> Optional[str]:
+    """Normalize one optional edge result predicate."""
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError("required_parent_result must be a non-empty string")
+    return value.strip()
+
+
 def create_task(
     conn: sqlite3.Connection,
     *,
@@ -3179,6 +3238,7 @@ def create_task(
     tenant: Optional[str] = None,
     priority: int = 0,
     parents: Iterable[str] = (),
+    required_parent_results: Optional[Mapping[str, str]] = None,
     triage: bool = False,
     idempotency_key: Optional[str] = None,
     max_runtime_seconds: Optional[int] = None,
@@ -3198,7 +3258,10 @@ def create_task(
     """Create a new task and optionally link it under parent tasks.
 
     Returns the new task id.  Status is ``ready`` when there are no
-    parents (or all parents already ``done``), otherwise ``todo``.
+    parents (or all parents satisfy their dependency edges), otherwise
+    ``todo``. ``required_parent_results`` optionally maps a parent id to the
+    exact ``tasks.result`` value that parent must record while in ``done``;
+    omitted parents retain legacy ``done``/``archived`` behavior.
     If ``triage=True``, status is forced to ``triage`` regardless of
     parents — a specifier/triager is expected to promote the task to
     ``todo`` once the spec is fleshed out.
@@ -3237,6 +3300,10 @@ def create_task(
     model_override = (model_override or "").strip() or None
     provider_override = (provider_override or "").strip() or None
     reasoning_effort = normalize_reasoning_effort(reasoning_effort)
+    parents = tuple(str(parent_id) for parent_id in parents)
+    required_parent_results = _normalize_required_parent_results(
+        parents, required_parent_results,
+    )
     if provider_override and not model_override:
         raise ValueError("provider_override requires a model_override")
     assignee = _canonical_assignee(assignee)
@@ -3466,13 +3533,22 @@ def create_task(
                         missing = _find_missing_parents(conn, parents)
                         if missing:
                             raise ValueError(f"unknown parent task(s): {', '.join(missing)}")
-                        # If any parent is not yet done, we're todo.
+                        # If any parent has not satisfied its edge, we're todo.
                         rows = conn.execute(
-                            "SELECT status FROM tasks WHERE id IN "
+                            "SELECT id, status, result FROM tasks WHERE id IN "
                             "(" + ",".join("?" * len(parents)) + ")",
                             parents,
                         ).fetchall()
-                        if any(r["status"] != "done" for r in rows):
+                        if any(
+                            not _parent_dependency_satisfied(
+                                parent_status=row["status"],
+                                parent_result=row["result"],
+                                required_parent_result=(
+                                    required_parent_results.get(row["id"])
+                                ),
+                            )
+                            for row in rows
+                        ):
                             task_status = "todo"
                 # Even in triage mode we still need to validate parent ids
                 # so the eventual link rows don't dangle.
@@ -3539,8 +3615,10 @@ def create_task(
                 )
                 for pid in parents:
                     conn.execute(
-                        "INSERT OR IGNORE INTO task_links (parent_id, child_id) VALUES (?, ?)",
-                        (pid, task_id),
+                        "INSERT OR IGNORE INTO task_links "
+                        "(parent_id, child_id, required_parent_result) "
+                        "VALUES (?, ?, ?)",
+                        (pid, task_id, required_parent_results.get(pid)),
                     )
                 # Notify-sub inheritance (ACK-edge: the originating channel
                 # still hears about a child that BLOCKs, not just the final
@@ -3554,6 +3632,7 @@ def create_task(
                         "assignee": assignee,
                         "status": task_status,
                         "parents": list(parents),
+                        "required_parent_results": required_parent_results or None,
                         "tenant": tenant,
                         "workspace_kind": workspace_kind,
                         "workspace_path": workspace_path,
@@ -3837,7 +3916,16 @@ def set_reasoning_effort(
 # Links
 # ---------------------------------------------------------------------------
 
-def link_tasks(conn: sqlite3.Connection, parent_id: str, child_id: str) -> None:
+def link_tasks(
+    conn: sqlite3.Connection,
+    parent_id: str,
+    child_id: str,
+    *,
+    required_parent_result: Optional[str] = None,
+) -> None:
+    required_parent_result = _normalize_required_parent_result(
+        required_parent_result
+    )
     if parent_id == child_id:
         raise ValueError("a task cannot depend on itself")
     with write_txn(conn):
@@ -3848,22 +3936,32 @@ def link_tasks(conn: sqlite3.Connection, parent_id: str, child_id: str) -> None:
             raise ValueError(
                 f"linking {parent_id} -> {child_id} would create a cycle"
             )
-        conn.execute(
-            "INSERT OR IGNORE INTO task_links (parent_id, child_id) VALUES (?, ?)",
-            (parent_id, child_id),
+        inserted = conn.execute(
+            "INSERT OR IGNORE INTO task_links "
+            "(parent_id, child_id, required_parent_result) VALUES (?, ?, ?)",
+            (parent_id, child_id, required_parent_result),
         )
-        # If child was ready but parent is not yet done, demote child to todo.
-        parent_status = conn.execute(
-            "SELECT status FROM tasks WHERE id = ?", (parent_id,)
-        ).fetchone()["status"]
-        if parent_status != "done":
+        # Re-linking remains idempotent when the optional predicate is omitted.
+        # Supplying one explicitly upgrades an existing legacy edge in place.
+        if inserted.rowcount == 0 and required_parent_result is not None:
+            conn.execute(
+                "UPDATE task_links SET required_parent_result = ? "
+                "WHERE parent_id = ? AND child_id = ?",
+                (required_parent_result, parent_id, child_id),
+            )
+        # If the newly linked edge is not satisfied, demote a ready child.
+        if not _parents_satisfied(conn, child_id):
             conn.execute(
                 "UPDATE tasks SET status = 'todo' WHERE id = ? AND status = 'ready'",
                 (child_id,),
             )
         _append_event(
             conn, child_id, "linked",
-            {"parent": parent_id, "child": child_id},
+            {
+                "parent": parent_id,
+                "child": child_id,
+                "required_parent_result": required_parent_result,
+            },
         )
         _inherit_notify_subs(conn, child_id, (parent_id,))
 
@@ -4451,6 +4549,55 @@ def _synthesize_ended_run(
 # Dependency resolution (todo -> ready)
 # ---------------------------------------------------------------------------
 
+def _parent_dependency_satisfied(
+    *,
+    parent_status: str,
+    parent_result: Optional[str],
+    required_parent_result: Optional[str],
+) -> bool:
+    """Return whether one parent row satisfies one dependency edge.
+
+    Legacy edges (NULL predicate) preserve the existing done/archived terminal
+    behavior. Result-gated edges fail closed: only ``done`` plus an exact
+    ``tasks.result`` match satisfies them; archived parents never do.
+    """
+    if required_parent_result is None:
+        return parent_status in {"done", "archived"}
+    return (
+        parent_status == "done"
+        and parent_result == required_parent_result
+    )
+
+
+def unsatisfied_parent_dependencies(
+    conn: sqlite3.Connection, task_id: str,
+) -> list[dict[str, Optional[str]]]:
+    """Return direct parent edges that do not satisfy their declared gate."""
+    rows = conn.execute(
+        "SELECT p.id, p.title, p.status, p.result, "
+        "       l.required_parent_result "
+        "FROM task_links l "
+        "JOIN tasks p ON p.id = l.parent_id "
+        "WHERE l.child_id = ? ORDER BY p.id",
+        (task_id,),
+    ).fetchall()
+    return [
+        {
+            "id": row["id"],
+            "title": row["title"],
+            "status": row["status"],
+            "result": row["result"],
+            "required_parent_result": row["required_parent_result"],
+        }
+        for row in rows
+        if not _parent_dependency_satisfied(
+            parent_status=row["status"],
+            parent_result=row["result"],
+            required_parent_result=row["required_parent_result"],
+        )
+    ]
+
+
 def _has_sticky_block(conn: sqlite3.Connection, task_id: str) -> bool:
     """Return True when ``task_id`` is sticky-blocked by an explicit
     worker/operator ``kanban_block`` call (#28712).
@@ -4521,7 +4668,7 @@ def _resume_status_from_events(conn: sqlite3.Connection, task_id: str) -> str:
 def recompute_ready(
     conn: sqlite3.Connection, failure_limit: int = None,
 ) -> int:
-    """Promote ``todo`` tasks to ``ready`` when all parents are ``done`` or ``archived``.
+    """Promote waiting tasks when every parent dependency edge is satisfied.
 
     Returns the number of tasks promoted.  Opens its own IMMEDIATE txn, so it
     MUST be called OUTSIDE any open write transaction (plain ``write_txn``
@@ -4567,13 +4714,7 @@ def recompute_ready(
                 # legitimate exit (it emits ``"unblocked"`` which flips
                 # this predicate back).
                 continue
-            parents = conn.execute(
-                "SELECT t.status FROM tasks t "
-                "JOIN task_links l ON l.parent_id = t.id "
-                "WHERE l.child_id = ?",
-                (task_id,),
-            ).fetchall()
-            if all(p["status"] in ("done", "archived") for p in parents):
+            if _parents_satisfied(conn, task_id):
                 resume_status = _resume_status_from_events(conn, task_id)
                 if cur_status == "blocked":
                     # Don't auto-recover tasks that have hit the
@@ -4615,14 +4756,8 @@ def recompute_ready(
 # ---------------------------------------------------------------------------
 
 def _parents_satisfied(conn: sqlite3.Connection, task_id: str) -> bool:
-    """Return whether every direct parent is terminal for dependency gating."""
-    return conn.execute(
-        "SELECT 1 FROM task_links l "
-        "JOIN tasks p ON p.id = l.parent_id "
-        "WHERE l.child_id = ? "
-        "AND p.status NOT IN ('done', 'archived') LIMIT 1",
-        (task_id,),
-    ).fetchone() is None
+    """Return whether every direct parent satisfies its dependency edge."""
+    return not unsatisfied_parent_dependencies(conn, task_id)
 
 
 def claim_task(
@@ -4642,20 +4777,14 @@ def claim_task(
     expires = now + _resolve_claim_ttl_seconds(ttl_seconds)
     with write_txn(conn):
         # Structural invariant: never transition ready -> running while any
-        # parent is not yet 'done'. This is the single enforcement point
+        # parent dependency is unsatisfied. This is the single enforcement point
         # regardless of which writer (create_task, link_tasks, unblock_task,
         # release_stale_claims, manual SQL) set status='ready'. If a racy
-        # writer promoted a task with undone parents, demote it back to
+        # writer promoted a task with unmet parent gates, demote it back to
         # 'todo' here — recompute_ready will re-promote when the parents
         # actually finish. See RCA at
         # kanban/boards/cookai/workspaces/t_a6acd07d/root-cause.md.
-        undone = conn.execute(
-            "SELECT 1 FROM task_links l "
-            "JOIN tasks p ON p.id = l.parent_id "
-            "WHERE l.child_id = ? AND p.status NOT IN ('done', 'archived') LIMIT 1",
-            (task_id,),
-        ).fetchone()
-        if undone:
+        if not _parents_satisfied(conn, task_id):
             conn.execute(
                 "UPDATE tasks SET status = 'todo' "
                 "WHERE id = ? AND status = 'ready'",
@@ -4663,7 +4792,7 @@ def claim_task(
             )
             _append_event(
                 conn, task_id, "claim_rejected",
-                {"reason": "parents_not_done"},
+                {"reason": "parent_requirements_not_met"},
             )
             return None
         # Defensive: if a prior run somehow leaked (invariant violation from
@@ -6792,8 +6921,9 @@ def promote_task(
 
     Mirrors the automatic promotion done by ``recompute_ready`` but
     drives it from a deliberate operator action with an audit-trail
-    entry. Refuses to promote if any parent dep is not in a terminal
-    state (`done`/`archived`) unless ``force=True``. Does NOT change
+    entry. Refuses unsatisfied result-gated edges unconditionally; legacy
+    status-only dependencies may still be overridden with ``force=True``.
+    Does NOT change
     assignee or claim state. Returns ``(True, None)`` on success and
     ``(False, reason)`` if refused. ``dry_run=True`` validates the
     promotion would succeed without mutating state.
@@ -6811,22 +6941,22 @@ def promote_task(
             f"'todo' or 'blocked'"
         )
 
-    if not force:
-        parents = conn.execute(
-            "SELECT t.id, t.status FROM tasks t "
-            "JOIN task_links l ON l.parent_id = t.id "
-            "WHERE l.child_id = ?",
-            (task_id,),
-        ).fetchall()
-        unsatisfied = [
-            p["id"] for p in parents
-            if p["status"] not in ("done", "archived")
-        ]
-        if unsatisfied:
-            return False, (
-                f"unsatisfied parent dependencies: "
-                f"{', '.join(unsatisfied)} (use --force to override)"
-            )
+    unsatisfied = unsatisfied_parent_dependencies(conn, task_id)
+    result_gated = [
+        parent for parent in unsatisfied
+        if parent["required_parent_result"] is not None
+    ]
+    if result_gated:
+        return False, (
+            "unsatisfied required parent results: "
+            + ", ".join(parent["id"] or "" for parent in result_gated)
+        )
+    if unsatisfied and not force:
+        return False, (
+            f"unsatisfied parent dependencies: "
+            f"{', '.join(parent['id'] or '' for parent in unsatisfied)} "
+            "(use --force to override)"
+        )
 
     if dry_run:
         return True, None
@@ -6878,7 +7008,7 @@ def _reclaim_dangling_run(
 
 
 def _landing_status_after_parents(conn: sqlite3.Connection, task_id: str) -> str:
-    """Return ``'todo'`` if any parent isn't ``done`` yet, else ``'ready'``.
+    """Return ``'todo'`` until every parent edge is satisfied, else ``'ready'``.
 
     The parent-completion re-gate shared by :func:`unblock_task` and
     :func:`reopen_review_task`: flipping straight to ``ready`` would bypass the
@@ -6888,14 +7018,7 @@ def _landing_status_after_parents(conn: sqlite3.Connection, task_id: str) -> str
     kanban/boards/cookai/workspaces/t_a6acd07d/root-cause.md. Kept in one place
     so the two transitions can't drift.
     """
-    undone_parents = conn.execute(
-        "SELECT 1 FROM task_links l "
-        "JOIN tasks p ON p.id = l.parent_id "
-        "WHERE l.child_id = ? "
-        "AND p.status NOT IN ('done', 'archived') LIMIT 1",
-        (task_id,),
-    ).fetchone()
-    return "todo" if undone_parents else "ready"
+    return "ready" if _parents_satisfied(conn, task_id) else "todo"
 
 
 def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3225,6 +3225,22 @@ def _normalize_required_parent_result(value: Optional[str]) -> Optional[str]:
     return value.strip()
 
 
+def _task_dependency_contract(
+    conn: sqlite3.Connection,
+    task_id: str,
+) -> dict[str, Optional[str]]:
+    """Return the exact parent/result predicate contract for one task."""
+    rows = conn.execute(
+        "SELECT parent_id, required_parent_result FROM task_links "
+        "WHERE child_id = ?",
+        (task_id,),
+    ).fetchall()
+    return {
+        row["parent_id"]: row["required_parent_result"]
+        for row in rows
+    }
+
+
 def create_task(
     conn: sqlite3.Connection,
     *,
@@ -3268,8 +3284,9 @@ def create_task(
 
     If ``idempotency_key`` is provided and a non-archived task with the
     same key already exists, returns the existing task's id instead of
-    creating a duplicate. Useful for retried webhooks / automation that
-    should not double-write.
+    creating a duplicate when its dependency contract is identical. A retry
+    with different parent ids or result predicates raises ``ValueError``.
+    Useful for retried webhooks / automation that should not double-write.
 
     ``max_runtime_seconds`` caps how long a worker may run before the
     dispatcher SIGTERMs (then SIGKILLs after a grace window) and
@@ -3484,6 +3501,16 @@ def create_task(
             (idempotency_key,),
         ).fetchone()
         if row:
+            requested_contract = {
+                parent_id: required_parent_results.get(parent_id)
+                for parent_id in set(parents)
+            }
+            existing_contract = _task_dependency_contract(conn, row["id"])
+            if existing_contract != requested_contract:
+                raise ValueError(
+                    f"idempotency_key {idempotency_key!r} belongs to task "
+                    f"{row['id']!r} with a different dependency contract"
+                )
             return row["id"]
 
     now = int(time.time())

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -605,6 +605,7 @@ class CreateTaskBody(BaseModel):
     workspace_kind: str = "scratch"
     workspace_path: Optional[str] = None
     parents: list[str] = Field(default_factory=list)
+    required_parent_results: dict[str, str] = Field(default_factory=dict)
     triage: bool = False
     idempotency_key: Optional[str] = None
     max_runtime_seconds: Optional[int] = None
@@ -637,6 +638,7 @@ def create_task(payload: CreateTaskBody, board: Optional[str] = Query(None)):
             tenant=payload.tenant,
             priority=payload.priority,
             parents=payload.parents,
+            required_parent_results=payload.required_parent_results,
             triage=payload.triage,
             idempotency_key=payload.idempotency_key,
             max_runtime_seconds=payload.max_runtime_seconds,
@@ -957,14 +959,24 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
                     blockers = _parents_blocking_ready(conn, task_id)
                     if blockers:
                         names = ", ".join(
-                            f"{p['title']!r} ({p['id']}, status={p['status']})"
+                            (
+                                f"{p['title']!r} ({p['id']}, "
+                                f"status={p['status']}, result={p['result']}, "
+                                "required_parent_result="
+                                f"{p['required_parent_result']})"
+                                if p["required_parent_result"] is not None
+                                else (
+                                    f"{p['title']!r} ({p['id']}, "
+                                    f"status={p['status']})"
+                                )
+                            )
                             for p in blockers
                         )
                         raise HTTPException(
                             status_code=409,
                             detail=(
-                                f"Cannot move to 'ready': blocked by parent(s) "
-                                f"not done — {names}"
+                                "Cannot move to 'ready': blocked by "
+                                f"unsatisfied parent dependency — {names}"
                             ),
                         )
                 raise HTTPException(
@@ -1076,24 +1088,14 @@ def delete_task(task_id: str, board: Optional[str] = Query(None)):
 def _parents_blocking_ready(
     conn: sqlite3.Connection, task_id: str,
 ) -> list:
-    """Return parent rows (``id``, ``title``, ``status``) that aren't ``done``
-    and therefore prevent ``task_id`` from being promoted to ``ready``.
+    """Return parent rows whose dependency edges are not satisfied.
 
     Used to enrich the 409 response from :func:`update_task` so the
     dashboard can show an actionable toast (#26744) instead of a silent
     no-op.  Returns ``[]`` when nothing blocks the transition (e.g. no
     parents, or all parents already done).
     """
-    rows = conn.execute(
-        "SELECT t.id, t.title, t.status FROM tasks t "
-        "JOIN task_links l ON l.parent_id = t.id "
-        "WHERE l.child_id = ? AND t.status != 'done'",
-        (task_id,),
-    ).fetchall()
-    return [
-        {"id": r["id"], "title": r["title"], "status": r["status"]}
-        for r in rows
-    ]
+    return kanban_db.unsatisfied_parent_dependencies(conn, task_id)
 
 
 def _invalidate_descendants_for_parent_reopen(
@@ -1158,15 +1160,7 @@ def _set_status_direct(
         # Prevents the dispatcher from spawning a child whose upstream work
         # hasn't completed (e.g. T4 dispatched while T3 is still blocked).
         if effective_status == "ready":
-            parent_statuses = conn.execute(
-                "SELECT t.status FROM tasks t "
-                "JOIN task_links l ON l.parent_id = t.id "
-                "WHERE l.child_id = ?",
-                (task_id,),
-            ).fetchall()
-            if parent_statuses and not all(
-                p["status"] in {"done", "archived"} for p in parent_statuses
-            ):
+            if not kanban_db._parents_satisfied(conn, task_id):
                 return False
 
         was_running = prev["status"] == "running"
@@ -1261,6 +1255,7 @@ def add_comment(task_id: str, payload: CommentBody, board: Optional[str] = Query
 class LinkBody(BaseModel):
     parent_id: str
     child_id: str
+    required_parent_result: Optional[str] = None
 
 
 @router.post("/links")
@@ -1268,7 +1263,12 @@ def add_link(payload: LinkBody, board: Optional[str] = Query(None)):
     board = _resolve_board(board)
     conn = _conn(board=board)
     try:
-        kanban_db.link_tasks(conn, payload.parent_id, payload.child_id)
+        kanban_db.link_tasks(
+            conn,
+            payload.parent_id,
+            payload.child_id,
+            required_parent_result=payload.required_parent_result,
+        )
         return {"ok": True}
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))

--- a/tests/hermes_cli/test_kanban_required_parent_result.py
+++ b/tests/hermes_cli/test_kanban_required_parent_result.py
@@ -1,0 +1,446 @@
+"""Result-aware Kanban dependency edge behavior.
+
+These tests protect the distinction between a parent's lifecycle state and
+its machine-readable outcome.  Legacy links stay terminal-status gated;
+opt-in links additionally require an exact successful result.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban as kb_cli
+
+
+@pytest.fixture
+def conn(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    with kb.connect_closing() as connection:
+        yield connection
+
+
+def _completed_parent(conn, *, result: str | None) -> str:
+    parent_id = kb.create_task(conn, title="qa", assignee="reviewer")
+    assert kb.complete_task(conn, parent_id, result=result)
+    return parent_id
+
+
+@pytest.mark.parametrize(
+    ("status", "result"),
+    [
+        ("done", "qa_failed"),
+        ("done", None),
+        ("done", "READY_TO_DEPLOY"),
+        ("archived", "ready_to_deploy"),
+    ],
+)
+def test_result_gated_creation_waits_for_exact_done_result(
+    conn, status: str, result: str | None,
+) -> None:
+    parent_id = _completed_parent(conn, result=result)
+    if status == "archived":
+        assert kb.archive_task(conn, parent_id)
+
+    child_id = kb.create_task(
+        conn,
+        title="deploy",
+        parents=[parent_id],
+        required_parent_results={parent_id: "ready_to_deploy"},
+    )
+
+    assert kb.get_task(conn, child_id).status == "todo"
+    assert not kb._parents_satisfied(conn, child_id)
+
+
+def test_result_gated_creation_accepts_exact_done_result(conn) -> None:
+    parent_id = _completed_parent(conn, result="ready_to_deploy")
+
+    child_id = kb.create_task(
+        conn,
+        title="deploy",
+        parents=[parent_id],
+        required_parent_results={parent_id: "ready_to_deploy"},
+    )
+
+    assert kb.get_task(conn, child_id).status == "ready"
+    assert kb._parents_satisfied(conn, child_id)
+
+
+def test_summary_or_metadata_claim_does_not_satisfy_result_gate(conn) -> None:
+    parent_id = kb.create_task(conn, title="qa", assignee="reviewer")
+    assert kb.complete_task(
+        conn,
+        parent_id,
+        result="qa_failed",
+        summary="ready_to_deploy",
+        metadata={"result": "ready_to_deploy"},
+    )
+
+    child_id = kb.create_task(
+        conn,
+        title="deploy",
+        parents=[parent_id],
+        required_parent_results={parent_id: "ready_to_deploy"},
+    )
+
+    assert kb.get_task(conn, child_id).status == "todo"
+
+
+@pytest.mark.parametrize("terminal_status", ["done", "archived"])
+def test_legacy_null_predicate_keeps_terminal_status_behavior(
+    conn, terminal_status: str,
+) -> None:
+    parent_id = _completed_parent(conn, result="anything")
+    if terminal_status == "archived":
+        assert kb.archive_task(conn, parent_id)
+
+    child_id = kb.create_task(conn, title="ordinary", parents=[parent_id])
+
+    assert kb.get_task(conn, child_id).status == "ready"
+    edge = conn.execute(
+        "SELECT required_parent_result FROM task_links "
+        "WHERE parent_id = ? AND child_id = ?",
+        (parent_id, child_id),
+    ).fetchone()
+    assert edge["required_parent_result"] is None
+
+
+def test_linking_unsatisfied_result_gate_demotes_ready_child(conn) -> None:
+    parent_id = _completed_parent(conn, result="qa_failed")
+    child_id = kb.create_task(conn, title="deploy")
+
+    kb.link_tasks(
+        conn,
+        parent_id,
+        child_id,
+        required_parent_result="ready_to_deploy",
+    )
+
+    assert kb.get_task(conn, child_id).status == "todo"
+    conn.execute(
+        "UPDATE tasks SET result = 'ready_to_deploy' WHERE id = ?",
+        (parent_id,),
+    )
+    assert kb.recompute_ready(conn) == 1
+    assert kb.get_task(conn, child_id).status == "ready"
+
+
+def test_claim_and_repeated_recompute_fail_closed(conn) -> None:
+    parent_id = _completed_parent(conn, result="qa_failed")
+    child_id = kb.create_task(
+        conn,
+        title="deploy",
+        assignee="deployer",
+        parents=[parent_id],
+        required_parent_results={parent_id: "ready_to_deploy"},
+    )
+
+    for _ in range(3):
+        assert kb.recompute_ready(conn) == 0
+        assert kb.get_task(conn, child_id).status == "todo"
+
+    conn.execute("UPDATE tasks SET status = 'ready' WHERE id = ?", (child_id,))
+    assert kb.claim_task(conn, child_id, claimer="dispatcher") is None
+    assert kb.get_task(conn, child_id).status == "todo"
+
+
+def test_manual_force_cannot_bypass_result_predicate(conn) -> None:
+    parent_id = _completed_parent(conn, result="qa_failed")
+    child_id = kb.create_task(
+        conn,
+        title="deploy",
+        parents=[parent_id],
+        required_parent_results={parent_id: "ready_to_deploy"},
+    )
+
+    ok, reason = kb.promote_task(
+        conn,
+        child_id,
+        actor="operator",
+        force=True,
+    )
+
+    assert not ok
+    assert "required parent results" in (reason or "")
+    assert kb.get_task(conn, child_id).status == "todo"
+
+
+def test_manual_force_still_bypasses_legacy_status_dependency(conn) -> None:
+    parent_id = kb.create_task(conn, title="ordinary parent")
+    child_id = kb.create_task(conn, title="ordinary child", parents=[parent_id])
+
+    ok, reason = kb.promote_task(
+        conn,
+        child_id,
+        actor="operator",
+        force=True,
+    )
+
+    assert ok
+    assert reason is None
+    assert kb.get_task(conn, child_id).status == "ready"
+
+
+def test_dispatch_ticks_never_spawn_unsatisfied_result_gate(
+    conn, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from hermes_cli import profiles
+
+    monkeypatch.setattr(profiles, "profile_exists", lambda _name: True)
+    parent_id = _completed_parent(conn, result="qa_failed")
+    child_id = kb.create_task(
+        conn,
+        title="deploy",
+        assignee="deployer",
+        parents=[parent_id],
+        required_parent_results={parent_id: "ready_to_deploy"},
+    )
+    spawned: list[str] = []
+
+    def fake_spawn(task, _workspace, board=None):
+        spawned.append(task.id)
+        return 4242
+
+    for _ in range(3):
+        result = kb.dispatch_once(
+            conn,
+            spawn_fn=fake_spawn,
+            reconcile_orphans=False,
+        )
+        assert result.promoted == 0
+        assert spawned == []
+        assert kb.get_task(conn, child_id).status == "todo"
+
+    conn.execute(
+        "UPDATE tasks SET result = 'ready_to_deploy' WHERE id = ?",
+        (parent_id,),
+    )
+    result = kb.dispatch_once(
+        conn,
+        spawn_fn=fake_spawn,
+        reconcile_orphans=False,
+    )
+    assert result.promoted == 1
+    assert spawned == [child_id]
+
+
+def test_creation_rejects_requirement_for_unlinked_parent(conn) -> None:
+    parent_id = kb.create_task(conn, title="qa")
+
+    with pytest.raises(ValueError, match="not present in parents"):
+        kb.create_task(
+            conn,
+            title="deploy",
+            required_parent_results={parent_id: "ready_to_deploy"},
+        )
+
+
+def test_legacy_task_links_schema_migrates_to_nullable_predicate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    db_path = home / "legacy.db"
+
+    with kb.connect_closing(db_path) as conn:
+        parent_id = _completed_parent(conn, result="ordinary")
+        child_id = kb.create_task(conn, title="ordinary", parents=[parent_id])
+        conn.execute("ALTER TABLE task_links RENAME TO task_links_current")
+        conn.execute(
+            "CREATE TABLE task_links ("
+            "parent_id TEXT NOT NULL, child_id TEXT NOT NULL, "
+            "PRIMARY KEY (parent_id, child_id))"
+        )
+        conn.execute(
+            "INSERT INTO task_links (parent_id, child_id) "
+            "SELECT parent_id, child_id FROM task_links_current"
+        )
+        conn.execute("DROP TABLE task_links_current")
+
+    kb.init_db(db_path)
+
+    with kb.connect_closing(db_path) as conn:
+        columns = {
+            row["name"] for row in conn.execute("PRAGMA table_info(task_links)")
+        }
+        assert "required_parent_result" in columns
+        edge = conn.execute(
+            "SELECT required_parent_result FROM task_links "
+            "WHERE parent_id = ? AND child_id = ?",
+            (parent_id, child_id),
+        ).fetchone()
+        assert edge["required_parent_result"] is None
+        assert kb._parents_satisfied(conn, child_id)
+
+
+def _create_namespace(**overrides) -> argparse.Namespace:
+    values = {
+        "title": "deploy",
+        "body": None,
+        "assignee": "deployer",
+        "created_by": "operator",
+        "workspace": "scratch",
+        "branch": None,
+        "project": None,
+        "tenant": None,
+        "priority": 0,
+        "parent": [],
+        "required_parent_results": [],
+        "triage": False,
+        "idempotency_key": None,
+        "max_runtime": None,
+        "skills": None,
+        "max_retries": None,
+        "model_override": None,
+        "provider_override": None,
+        "goal_mode": False,
+        "goal_max_turns": None,
+        "initial_status": "running",
+        "json": False,
+    }
+    values.update(overrides)
+    return argparse.Namespace(**values)
+
+
+def test_cli_create_parses_and_persists_parent_result_requirement(
+    conn, capsys,
+) -> None:
+    parent_id = _completed_parent(conn, result="qa_failed")
+
+    rc = kb_cli._cmd_create(
+        _create_namespace(
+            parent=[parent_id],
+            required_parent_results=[f"{parent_id}=ready_to_deploy"],
+        )
+    )
+
+    assert rc == 0, capsys.readouterr().err
+    child = conn.execute(
+        "SELECT id, status FROM tasks WHERE title = 'deploy' ORDER BY created_at DESC"
+    ).fetchone()
+    assert child["status"] == "todo"
+    edge = conn.execute(
+        "SELECT required_parent_result FROM task_links "
+        "WHERE parent_id = ? AND child_id = ?",
+        (parent_id, child["id"]),
+    ).fetchone()
+    assert edge["required_parent_result"] == "ready_to_deploy"
+
+
+def test_cli_link_persists_parent_result_requirement(conn, capsys) -> None:
+    parent_id = _completed_parent(conn, result="qa_failed")
+    child_id = kb.create_task(conn, title="child")
+
+    rc = kb_cli._cmd_link(
+        argparse.Namespace(
+            parent_id=parent_id,
+            child_id=child_id,
+            required_parent_result="ready_to_deploy",
+        )
+    )
+
+    assert rc == 0, capsys.readouterr().err
+    assert kb.get_task(conn, child_id).status == "todo"
+    edge = conn.execute(
+        "SELECT required_parent_result FROM task_links "
+        "WHERE parent_id = ? AND child_id = ?",
+        (parent_id, child_id),
+    ).fetchone()
+    assert edge["required_parent_result"] == "ready_to_deploy"
+
+
+def test_cli_parser_exposes_typed_result_gate_options() -> None:
+    root = argparse.ArgumentParser()
+    subparsers = root.add_subparsers(dest="command")
+    kb_cli.build_parser(subparsers)
+
+    create_args = root.parse_args(
+        [
+            "kanban",
+            "create",
+            "deploy",
+            "--parent",
+            "t_qa",
+            "--require-parent-result",
+            "t_qa=ready_to_deploy",
+        ]
+    )
+    link_args = root.parse_args(
+        [
+            "kanban",
+            "link",
+            "t_qa",
+            "t_deploy",
+            "--required-parent-result",
+            "ready_to_deploy",
+        ]
+    )
+
+    assert create_args.required_parent_results == ["t_qa=ready_to_deploy"]
+    assert link_args.required_parent_result == "ready_to_deploy"
+
+
+def test_worker_create_tool_persists_typed_result_gate(conn) -> None:
+    from tools import kanban_tools as kt
+
+    parent_id = _completed_parent(conn, result="qa_failed")
+    payload = kt._handle_create(
+        {
+            "title": "tool child",
+            "assignee": "deployer",
+            "parents": [parent_id],
+            "required_parent_results": {parent_id: "ready_to_deploy"},
+        }
+    )
+    result = __import__("json").loads(payload)
+
+    assert result["ok"] is True
+    assert kb.get_task(conn, result["task_id"]).status == "todo"
+    edge = conn.execute(
+        "SELECT required_parent_result FROM task_links "
+        "WHERE parent_id = ? AND child_id = ?",
+        (parent_id, result["task_id"]),
+    ).fetchone()
+    assert edge["required_parent_result"] == "ready_to_deploy"
+
+
+def test_worker_link_tool_persists_typed_result_gate(conn) -> None:
+    from tools import kanban_tools as kt
+
+    parent_id = _completed_parent(conn, result="qa_failed")
+    child_id = kb.create_task(conn, title="tool linked child")
+    payload = kt._handle_link(
+        {
+            "parent_id": parent_id,
+            "child_id": child_id,
+            "required_parent_result": "ready_to_deploy",
+        }
+    )
+    result = __import__("json").loads(payload)
+
+    assert result["ok"] is True
+    assert kb.get_task(conn, child_id).status == "todo"
+
+
+def test_worker_tool_schemas_type_result_gate_options() -> None:
+    from tools import kanban_tools as kt
+
+    create_prop = kt.KANBAN_CREATE_SCHEMA["parameters"]["properties"][
+        "required_parent_results"
+    ]
+    link_prop = kt.KANBAN_LINK_SCHEMA["parameters"]["properties"][
+        "required_parent_result"
+    ]
+
+    assert create_prop["type"] == "object"
+    assert create_prop["additionalProperties"] == {"type": "string"}
+    assert link_prop["type"] == "string"

--- a/tests/hermes_cli/test_kanban_required_parent_result.py
+++ b/tests/hermes_cli/test_kanban_required_parent_result.py
@@ -73,6 +73,103 @@ def test_result_gated_creation_accepts_exact_done_result(conn) -> None:
     assert kb._parents_satisfied(conn, child_id)
 
 
+def test_idempotent_create_reuses_exact_dependency_contract(conn) -> None:
+    parent_id = _completed_parent(conn, result="qa_failed")
+    expected_id = kb.create_task(
+        conn,
+        title="deploy",
+        parents=[parent_id],
+        required_parent_results={parent_id: "ready_to_deploy"},
+        idempotency_key="deploy-once",
+    )
+
+    actual_id = kb.create_task(
+        conn,
+        title="ignored on exact retry",
+        parents=[parent_id],
+        required_parent_results={parent_id: "ready_to_deploy"},
+        idempotency_key="deploy-once",
+    )
+
+    assert actual_id == expected_id
+
+
+@pytest.mark.parametrize(
+    ("original_required_result", "retry_required_result"),
+    [
+        pytest.param(None, "ready_to_deploy", id="legacy-to-strict"),
+        pytest.param(
+            "ready_to_deploy",
+            "qa_failed",
+            id="different-required-result",
+        ),
+    ],
+)
+def test_idempotent_create_rejects_different_dependency_contract(
+    conn,
+    original_required_result: str | None,
+    retry_required_result: str,
+) -> None:
+    parent_id = _completed_parent(conn, result="qa_failed")
+    original_requirements = (
+        {parent_id: original_required_result}
+        if original_required_result is not None
+        else None
+    )
+    existing_id = kb.create_task(
+        conn,
+        title="original deploy",
+        parents=[parent_id],
+        required_parent_results=original_requirements,
+        idempotency_key="deploy-once",
+    )
+
+    with pytest.raises(ValueError, match="different dependency contract"):
+        kb.create_task(
+            conn,
+            title="conflicting deploy retry",
+            parents=[parent_id],
+            required_parent_results={parent_id: retry_required_result},
+            idempotency_key="deploy-once",
+        )
+
+    tasks = conn.execute(
+        "SELECT id FROM tasks WHERE idempotency_key = ?",
+        ("deploy-once",),
+    ).fetchall()
+    assert [row["id"] for row in tasks] == [existing_id]
+
+
+def test_idempotent_create_rejects_different_parent_set(conn) -> None:
+    first_parent_id = _completed_parent(conn, result="ready_to_deploy")
+    second_parent_id = _completed_parent(conn, result="ready_to_deploy")
+    existing_id = kb.create_task(
+        conn,
+        title="original deploy",
+        parents=[first_parent_id],
+        required_parent_results={first_parent_id: "ready_to_deploy"},
+        idempotency_key="deploy-once",
+    )
+
+    with pytest.raises(ValueError, match="different dependency contract"):
+        kb.create_task(
+            conn,
+            title="conflicting deploy retry",
+            parents=[first_parent_id, second_parent_id],
+            required_parent_results={
+                first_parent_id: "ready_to_deploy",
+                second_parent_id: "ready_to_deploy",
+            },
+            idempotency_key="deploy-once",
+        )
+
+    tasks = conn.execute(
+        "SELECT id FROM tasks WHERE idempotency_key = ?",
+        ("deploy-once",),
+    ).fetchall()
+    assert [row["id"] for row in tasks] == [existing_id]
+
+
 def test_summary_or_metadata_claim_does_not_satisfy_result_gate(conn) -> None:
     parent_id = kb.create_task(conn, title="qa", assignee="reviewer")
     assert kb.complete_task(
@@ -149,6 +246,54 @@ def test_claim_and_repeated_recompute_fail_closed(conn) -> None:
     conn.execute("UPDATE tasks SET status = 'ready' WHERE id = ?", (child_id,))
     assert kb.claim_task(conn, child_id, claimer="dispatcher") is None
     assert kb.get_task(conn, child_id).status == "todo"
+
+
+def test_claim_holds_child_after_completed_parent_result_stops_matching(
+    conn,
+) -> None:
+    parent_id = _completed_parent(conn, result="ready_to_deploy")
+    child_id = kb.create_task(
+        conn,
+        title="deploy",
+        assignee="deployer",
+        parents=[parent_id],
+        required_parent_results={parent_id: "ready_to_deploy"},
+    )
+    assert kb.get_task(conn, child_id).status == "ready"
+
+    assert kb.edit_completed_task_result(
+        conn,
+        parent_id,
+        result="qa_failed",
+    )
+
+    assert kb.claim_task(conn, child_id, claimer="dispatcher") is None
+    assert kb.get_task(conn, child_id).status == "todo"
+
+
+def test_recompute_releases_child_after_completed_parent_result_starts_matching(
+    conn,
+) -> None:
+    parent_id = _completed_parent(conn, result="qa_failed")
+    child_id = kb.create_task(
+        conn,
+        title="deploy",
+        assignee="deployer",
+        parents=[parent_id],
+        required_parent_results={parent_id: "ready_to_deploy"},
+    )
+    assert kb.get_task(conn, child_id).status == "todo"
+
+    assert kb.edit_completed_task_result(
+        conn,
+        parent_id,
+        result="ready_to_deploy",
+    )
+
+    assert kb.recompute_ready(conn) == 1
+    claimed = kb.claim_task(conn, child_id, claimer="dispatcher")
+    assert claimed is not None
+    assert claimed.id == child_id
 
 
 def test_manual_force_cannot_bypass_result_predicate(conn) -> None:

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -1226,7 +1226,64 @@ def test_specify_happy_path(client, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# Final result visibility for Done cards
+# Result-aware dependency edges
 # ---------------------------------------------------------------------------
 
+
+def test_dashboard_create_and_manual_ready_share_result_gate(client):
+    with kb.connect_closing() as conn:
+        parent_id = kb.create_task(conn, title="QA", assignee="reviewer")
+        assert kb.complete_task(conn, parent_id, result="qa_failed")
+
+    response = client.post(
+        "/api/plugins/kanban/tasks",
+        json={
+            "title": "Deploy",
+            "parents": [parent_id],
+            "required_parent_results": {parent_id: "ready_to_deploy"},
+        },
+    )
+    assert response.status_code == 200, response.text
+    child = response.json()["task"]
+    assert child["status"] == "todo"
+
+    promote = client.patch(
+        f"/api/plugins/kanban/tasks/{child['id']}",
+        json={"status": "ready"},
+    )
+    assert promote.status_code == 409
+    detail = promote.json()["detail"]
+    assert "required_parent_result=ready_to_deploy" in detail
+    assert "result=qa_failed" in detail
+
+
+def test_dashboard_link_api_persists_result_gate(client):
+    with kb.connect_closing() as conn:
+        parent_id = kb.create_task(conn, title="QA", assignee="reviewer")
+        assert kb.complete_task(conn, parent_id, result="qa_failed")
+        child_id = kb.create_task(conn, title="Deploy")
+
+    response = client.post(
+        "/api/plugins/kanban/links",
+        json={
+            "parent_id": parent_id,
+            "child_id": child_id,
+            "required_parent_result": "ready_to_deploy",
+        },
+    )
+    assert response.status_code == 200, response.text
+
+    with kb.connect_closing() as conn:
+        assert kb.get_task(conn, child_id).status == "todo"
+        edge = conn.execute(
+            "SELECT required_parent_result FROM task_links "
+            "WHERE parent_id = ? AND child_id = ?",
+            (parent_id, child_id),
+        ).fetchone()
+        assert edge["required_parent_result"] == "ready_to_deploy"
+
+
+# ---------------------------------------------------------------------------
+# Final result visibility for Done cards
+# ---------------------------------------------------------------------------
 

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -1360,6 +1360,7 @@ def _handle_create(args: dict, **kw) -> str:
         )
     body = args.get("body")
     parents = args.get("parents") or []
+    required_parent_results = args.get("required_parent_results") or {}
     tenant = args.get("tenant") or os.environ.get("HERMES_TENANT")
     # Stamp the originating session id when the agent loop runs under
     # ACP (which sets HERMES_SESSION_ID before invoking tools). NULL on
@@ -1419,6 +1420,11 @@ def _handle_create(args: dict, **kw) -> str:
         return tool_error(
             f"parents must be a list of task ids, got {type(parents).__name__}"
         )
+    if not isinstance(required_parent_results, dict):
+        return tool_error(
+            "required_parent_results must be an object mapping parent ids "
+            "to exact result strings"
+        )
     board = args.get("board")
     try:
         kb, conn = _connect(board=board)
@@ -1439,6 +1445,7 @@ def _handle_create(args: dict, **kw) -> str:
                 body=body,
                 assignee=str(assignee),
                 parents=tuple(parents),
+                required_parent_results=required_parent_results,
                 tenant=tenant,
                 priority=int(priority) if priority is not None else 0,
                 workspace_kind=str(workspace_kind),
@@ -1648,13 +1655,19 @@ def _handle_link(args: dict, **kw) -> str:
         return delegated_err
     parent_id = args.get("parent_id")
     child_id = args.get("child_id")
+    required_parent_result = args.get("required_parent_result")
     if not parent_id or not child_id:
         return tool_error("both parent_id and child_id are required")
     board = args.get("board")
     try:
         kb, conn = _connect(board=board)
         try:
-            kb.link_tasks(conn, parent_id=parent_id, child_id=child_id)
+            kb.link_tasks(
+                conn,
+                parent_id=parent_id,
+                child_id=child_id,
+                required_parent_result=required_parent_result,
+            )
             return _ok(parent_id=parent_id, child_id=child_id)
         finally:
             conn.close()
@@ -2168,10 +2181,20 @@ KANBAN_CREATE_SCHEMA = {
                 "items": {"type": "string"},
                 "description": (
                     "Parent task ids. The new task stays in 'todo' "
-                    "until every parent reaches 'done'; then it "
+                    "until every parent dependency is satisfied; then it "
                     "auto-promotes to 'ready'. Typical fan-in: list "
                     "all the researcher task ids when creating a "
                     "synthesizer task."
+                ),
+            },
+            "required_parent_results": {
+                "type": "object",
+                "additionalProperties": {"type": "string"},
+                "description": (
+                    "Optional map of parent task id to the exact "
+                    "machine-readable tasks.result required while that "
+                    "parent is done. Omitted parents retain ordinary "
+                    "done/archived dependency behavior."
                 ),
             },
             "tenant": {
@@ -2334,14 +2357,21 @@ KANBAN_LINK_SCHEMA = {
     "name": "kanban_link",
     "description": (
         "Add a parent→child dependency edge after both tasks already "
-        "exist. The child won't promote to 'ready' until all parents "
-        "are 'done'. Cycles and self-links are rejected."
+        "exist. The child won't promote to 'ready' until all dependency "
+        "edges are satisfied. Cycles and self-links are rejected."
     ),
     "parameters": {
         "type": "object",
         "properties": {
             "parent_id": {"type": "string", "description": "Parent task id."},
             "child_id":  {"type": "string", "description": "Child task id."},
+            "required_parent_result": {
+                "type": "string",
+                "description": (
+                    "Optional exact machine-readable result required from "
+                    "the parent while it is done."
+                ),
+            },
             "board": _board_schema_prop(),
         },
         "required": ["parent_id", "child_id"],


### PR DESCRIPTION
## What does this PR do?

Kanban dependency release currently treats a terminal parent as successful even when the parent recorded a machine-readable failure result. That can release QA-gated deployment or release children after QA has completed with `qa_failed`.

This PR adds an opt-in, nullable edge-level `required_parent_result` predicate. A gated edge is satisfied only when the parent is exactly `done` and `tasks.result` exactly matches the declared value. Existing NULL edges keep their current `done`/`archived` behavior.

The predicate is explicit and generic: it does not infer approval from task titles, assignees, summaries, comments, or metadata prose. Idempotent create retries also compare the exact parent/result dependency contract and fail closed instead of silently returning a task with stale or weaker edges.

This supersedes the closed publication attempt #97141; the implementation is republished from the requested fork branch name.

## Related Issue and Semantic Ownership

Related to #67132.

This overlaps with #67156 and #68850 but uses a different contract:

- #67156 is approval-specific and reads structured terminal-run `approved: true` metadata.
- #68850 infers semantic gate verdicts from role and verdict conventions.
- This PR declares an exact required `tasks.result` on each selected edge, supporting contracts such as `ready_to_deploy` without changing ordinary dependencies.

Proposed landing graph:

- #97151 is the semantic owner for explicit, typed exact-result edge policy and the shared dependency evaluator.
- #67156 is complementary approval policy. If adopted, it should compose as another typed policy behind the same evaluator, preserving `peacockesq`'s credit.
- #68850 is a competing inference model and should not coexist as a parallel dependency-success authority. Any useful behavior should be translated into the typed evaluator or explicitly superseded, preserving `chahababa`'s credit.
- #97141 remains superseded publication history, not a second implementation.

This PR does not import code from the other active PRs. Consolidation should be coordinated with their authors before landing. The current implementation also still needs to be restacked with the accepted fracture owners in #79893, #79894, #79895, #79940, and #79982 rather than establishing new long-term authority in the monoliths.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/kanban_db.py`: add the nullable schema migration, shared dependency predicate, and enforcement across create/link/recompute/claim/reclaim/unblock/manual promotion paths.
- `hermes_cli/kanban_db.py`: make idempotent create retries compare exact parent IDs and result predicates before reusing an existing task.
- `hermes_cli/kanban.py`: add typed create/link CLI options.
- `tools/kanban_tools.py`: expose typed create/link tool schema fields and handlers.
- `plugins/kanban/dashboard/plugin_api.py`: accept the predicate and use the same blocker logic for manual/dashboard promotion.
- `tests/hermes_cli/test_kanban_required_parent_result.py`: cover exact success, failure/null/case mismatch, archived gated parents, legacy compatibility, dispatcher ticks, force behavior, migration, CLI/tool surfaces, exact and conflicting idempotent retries, and post-completion result edits.
- `tests/plugins/test_kanban_dashboard_plugin.py`: cover dashboard create/link persistence and manual ready rejection.
- `contributors/emails/nunm1107@hotmail.com`: map the commit email to `MisterNunm` without rewriting history.

## How to Test

1. Run the complete Kanban regression family:

   ```bash
   ./scripts/run_tests.sh tests/hermes_cli/test_kanban*.py tests/tools/test_kanban_tools.py tests/plugins/test_kanban_dashboard_plugin.py -q --file-retries 0
   ```

   Verified result on current head `ef4ac92a`: **394 passed, 0 failed, 1 Windows-only skipped** across 49 files.

2. Run the contributor mapping tests:

   ```bash
   ./scripts/run_tests.sh tests/scripts/test_contributor_map.py -q --file-retries 0
   ```

   Verified result: **7 passed, 0 failed**.

3. Run Ruff on the changed Python files. Verified result: `All checks passed!`.
4. Run `git diff --check origin/main...HEAD`. Verified clean.

The repository-wide suite was attempted but is not claimed green. A worktree-local optional-dependency environment allowed the Anthropic and ACP tests to pass, but unrelated tests then hit Linux Unix-socket path limits, desktop-environment assumptions, and live-runtime guards. Updater tests also replaced that local virtual environment during the parallel run, invalidating the remaining repository-wide receipt. The disposable environment was removed and the complete Kanban family was rerun cleanly through the canonical wrapper.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs and documented the overlap above
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — the complete 49-file Kanban scope passes; the repository-wide run was not a valid green receipt for the environment reasons documented above
- [x] I've added tests for my changes
- [x] I've tested on my platform: WSL2 Ubuntu, Python 3.11 test environment

### Documentation & Housekeeping

- [x] Relevant documentation is covered by code/tool descriptions and docstrings; no standalone guide change is required
- [x] `cli-config.yaml.example` — N/A; no configuration key was added
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A; no repository workflow convention changed
- [x] Cross-platform impact considered: implementation uses platform-neutral Python and SQLite; Windows-only tests remain on their CI lane
- [x] Tool descriptions and schemas were updated for the new typed create/link fields

## Screenshots / Logs

N/A — this is a database and dispatcher invariant with automated regression coverage.
