### PR TITLE
refactor(skill_manage): schema diet, second pass (517 → 427 tok/call, −17%)

### DIFF
--- a/tests/tools/test_skill_manage_schema_diet.py
+++ b/tests/tools/test_skill_manage_schema_diet.py
@@ -1,0 +1,57 @@
+"""skill_manage schema diet contract (#95681, second pass).
+
+Pins the deduped surface: patch args defer to the `patch` tool's matching
+semantics instead of re-teaching them; file_path states its skill-dir-
+relative shape; no authoring curriculum or confirm-with-user coaching in
+the description (maintainer-directed cuts).
+"""
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from tools.skill_manager_tool import SKILL_MANAGE_SCHEMA
+
+
+class TestSkillManageSchemaDiet(unittest.TestCase):
+    def test_patch_args_defer_to_patch_tool(self):
+        props = SKILL_MANAGE_SCHEMA["parameters"]["properties"]
+        self.assertIn("patch tool", props["old_string"]["description"])
+        # The uniqueness/context curriculum lives in the patch tool's schema,
+        # not here.
+        self.assertNotIn("unique", props["old_string"]["description"])
+        self.assertNotIn("surrounding context", props["old_string"]["description"])
+
+    def test_file_path_states_relative_shape(self):
+        desc = SKILL_MANAGE_SCHEMA["parameters"]["properties"]["file_path"]["description"]
+        self.assertIn("RELATIVE", desc)
+        self.assertIn("references/api.md", desc)
+        self.assertIn("never absolute", desc)
+        # The subdirectory whitelist is a real contract — must stay.
+        for sub in ("references/", "templates/", "scripts/", "assets/"):
+            self.assertIn(sub, desc)
+
+    def test_description_cuts_hold(self):
+        desc = SKILL_MANAGE_SCHEMA["description"]
+        # Maintainer-directed: no confirm-with-user coaching.
+        self.assertNotIn("Confirm with the user", desc)
+        # Authoring curriculum compressed to the 57-char trigger rule +
+        # skill_view pointer; the numbered-steps/pitfalls list is gone.
+        self.assertIn("57 chars", desc)
+        self.assertIn("skill_view()", desc)
+        self.assertNotIn("numbered steps", desc)
+        # Stale action vocabulary must not return.
+        self.assertNotIn("edit", SKILL_MANAGE_SCHEMA["parameters"]["properties"]["name"]["description"])
+
+    def test_content_keeps_pre_irreversibility_warning(self):
+        """The REPLACES-whole-file warning is pre-irreversibility guidance:
+        an error can't teach after a successful full rewrite, so it must
+        stay schema-side (maintainer call)."""
+        desc = SKILL_MANAGE_SCHEMA["parameters"]["properties"]["content"]["description"]
+        self.assertIn("REPLACES", desc)
+        self.assertIn("skill_view()", desc)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -1763,16 +1763,12 @@ SKILL_MANAGE_SCHEMA = {
     "name": "skill_manage",
     "description": (
         "Create, update, or delete skills — your procedural memory for "
-        "recurring task types. Actions: create (full SKILL.md + optional "
-        f"category; lands in {display_hermes_home()}/skills/), patch "
-        "(old_string/new_string for a targeted fix — preferred; OR content "
-        "alone for a full SKILL.md rewrite), delete, write_file/remove_file "
-        "(supporting files). Existing skills are modified wherever they "
-        "live. Good skills: a self-contained trigger in the description's "
-        "first 57 chars ('Use when <trigger>. <one-line behavior>.'), "
-        "numbered steps with exact commands, pitfalls, verification (see "
-        "skill_view() for format). Confirm with the user before "
-        "create/delete."
+        f"recurring task types. Actions: create (lands in {display_hermes_home()}/skills/), "
+        "patch (targeted old_string/new_string fix — preferred), delete, "
+        "write_file/remove_file (supporting files). Existing skills are "
+        "modified wherever they live. Keep the description's first 57 chars "
+        "a self-contained trigger: 'Use when <trigger>. <one-line "
+        "behavior>.' — skill_view() shows full format conventions."
     ),
     "parameters": {
         "type": "object",
@@ -1785,58 +1781,61 @@ SKILL_MANAGE_SCHEMA = {
             "name": {
                 "type": "string",
                 "description": (
-                    "Skill name (lowercase, hyphens/underscores, max 64 chars). "
-                    "Must match an existing skill for patch/edit/delete/write_file/remove_file."
+                    "Skill name (lowercase, hyphens/underscores, max 64 "
+                    "chars); an existing skill's name for every action "
+                    "except create."
                 )
             },
             "content": {
                 "type": "string",
                 "description": (
-                    "Full SKILL.md content (YAML frontmatter + markdown body). "
-                    "Required for 'create'; on 'patch' it performs a full "
-                    "rewrite (major overhauls only — read the skill first with "
-                    "skill_view(), and don't combine with old_string)."
+                    "Full SKILL.md content (YAML frontmatter + markdown "
+                    "body). Required for 'create'. On 'patch' (without "
+                    "old_string) it REPLACES the whole file — read it via "
+                    "skill_view() first."
                 )
             },
+            # patch args: same fuzzy-matching semantics as the `patch` tool
+            # (uniqueness unless replace_all, context-for-uniqueness advice
+            # lives there) — teach only the skill-specific facts here.
             "old_string": {
                 "type": "string",
                 "description": (
-                    "Text to find in the file (required for 'patch'). Must be unique "
-                    "unless replace_all=true. Include enough surrounding context to "
-                    "ensure uniqueness."
+                    "Text to find (for 'patch'; same matching semantics as "
+                    "the patch tool)."
                 )
             },
             "new_string": {
                 "type": "string",
                 "description": (
-                    "Replacement text (required for 'patch'); must differ from "
-                    "old_string. Can be empty string to delete the matched text."
+                    "Replacement text (for 'patch'); empty string deletes "
+                    "the match."
                 )
             },
             "replace_all": {
                 "type": "boolean",
-                "description": "For 'patch': replace all occurrences instead of requiring a unique match (default: false)."
+                "description": "For 'patch': replace all occurrences (default: false)."
             },
             "category": {
                 "type": "string",
                 "description": (
-                    "Optional category/domain for organizing the skill (e.g., 'devops', "
-                    "'data-science', 'mlops'). Creates a subdirectory grouping. "
-                    "Only used with 'create'."
+                    "Optional category subdirectory for 'create' (e.g. "
+                    "'devops', 'mlops')."
                 )
             },
             "file_path": {
                 "type": "string",
                 "description": (
-                    "Path to a supporting file within the skill directory. "
-                    "For 'write_file'/'remove_file': required, must be under references/, "
-                    "templates/, scripts/, or assets/. "
-                    "For 'patch': optional, defaults to SKILL.md if omitted."
+                    "Path RELATIVE to the skill's own directory, e.g. "
+                    "'references/api.md' — no leading slash, never absolute. "
+                    "write_file/remove_file: required; first segment must be "
+                    "references/, templates/, scripts/, or assets/. patch: "
+                    "optional (default SKILL.md)."
                 )
             },
             "file_content": {
                 "type": "string",
-                "description": "Content for the file. Required for 'write_file'."
+                "description": "Content for write_file."
             },
             # NOTE: the handler also accepts `absorbed_into` on delete — the
             # curator's consolidation pass declares merge-vs-prune intent with


### PR DESCRIPTION
Campaign entry (#95681), maintainer-directed. Second pass over skill_manage (first: #95697), driven by the observation that its patch machinery re-teaches what the always-present `patch` tool already taught.

## Moves
1. **Cross-tool dedup (biggest cut):** old_string/new_string/replace_all use the SAME `fuzzy_find_and_replace` as the `patch` tool (413 tok, always served) — uniqueness-unless-replace_all, context-for-uniqueness, must-differ semantics now taught ONCE, there. skill_manage says "same matching semantics as the patch tool" + the one skill-specific fact each (empty new_string deletes). NOTE comment marks the dedup so a future edit doesn't re-inflate.
2. **file_path ambiguity fixed (maintainer catch):** was "path to a supporting file within the skill directory" — ambiguous between absolute/skills-dir-rooted/skill-dir-relative. Handler verified (`skill_dir / file_path`, traversal-guarded): now reads "Path RELATIVE to the skill's own directory, e.g. 'references/api.md' — no leading slash, never absolute." Whitelist stays (real contract).
3. **Pre-irreversibility guidance KEPT schema-side (maintainer correction of my own plan):** content-on-patch performs a destructive full rewrite on SUCCESS — an error can't teach after the old file is gone, so "REPLACES the whole file — read it via skill_view() first" stays in the schema, compressed not migrated. Only true reject-before-effect hedges were trimmed.
4. **Description cuts:** authoring curriculum compressed to the 57-char trigger rule + skill_view() pointer (curriculum lives there); "Confirm with the user before create/delete" removed (maintainer call); stale `edit` action vocabulary removed from `name`.

## Numbers
517 → **427 as served** (−90, −17%; cumulative with #95697: ~920 → 427). Zero interface change — params, actions, handler all untouched.

4 new contract tests pin the dedup, the relative-path phrasing, the description cuts, and (explicitly) the kept destructive-rewrite warning. Suites: 45 passed, 1 pre-existing failure (symlink rmtree guard, fails on clean main on Windows).

Sets up the follow-up `operations[]` batch interface (memory-tool pattern: create + N reference files atomically in one call) on a clean base.