### PR TITLE
feat(commands): establish typed invocation and dispatcher ABI

### DIFF
--- a/hermes_cli/command_dispatcher.py
+++ b/hermes_cli/command_dispatcher.py
@@ -1,0 +1,695 @@
+"""Typed command invocation, policy, binding, and settlement contracts.
+
+This module is transport-free.  It is the bounded PR-2 narrow waist between a
+versioned command catalog and every surface-specific renderer.  Catalog
+construction remains a separate authority; this module accepts one immutable
+snapshot, enforces its revision and policy settlement, invokes exactly one
+binding, and returns one structured result.
+
+The catalog adapter is deliberately duck-typed so the PR-1 schema can land
+independently.  A snapshot must expose ``revision`` plus either
+``resolve_command_id(command_id)`` or a ``commands`` collection.  A command
+row must expose ``command_id`` and may expose ``execution_owner`` and
+``handler_id`` for binding-attestation checks.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import threading
+from collections.abc import Callable, Iterable, Mapping
+from dataclasses import dataclass, field, replace
+from types import MappingProxyType
+from typing import Any, Protocol, TypeAlias
+
+JSONScalar: TypeAlias = str | int | float | bool | None
+JSONValue: TypeAlias = JSONScalar | list["JSONValue"] | dict[str, "JSONValue"]
+
+COMMAND_RESULT_STATUSES = frozenset(
+    {
+        "ok",
+        "error",
+        "unknown_command",
+        "unavailable",
+        "confirmation_required",
+        "deferred",
+        "catalog_stale",
+        "indeterminate",
+        "send_to_agent",
+        "client_action",
+    }
+)
+
+
+def _require_text(value: Any, field_name: str) -> str:
+    text = str(value or "").strip()
+    if not text:
+        raise ValueError(f"{field_name} must not be blank")
+    return text
+
+
+def _json_copy(value: Any, field_name: str) -> Any:
+    """Return a detached JSON-compatible copy or fail the contract."""
+    try:
+        encoded = json.dumps(value, ensure_ascii=False, sort_keys=True)
+        return json.loads(encoded)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{field_name} must be JSON-serializable") from exc
+
+
+def _freeze_json(value: Any) -> Any:
+    if isinstance(value, dict):
+        return MappingProxyType({str(key): _freeze_json(item) for key, item in value.items()})
+    if isinstance(value, list):
+        return tuple(_freeze_json(item) for item in value)
+    return value
+
+
+def _thaw_json(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {str(key): _thaw_json(item) for key, item in value.items()}
+    if isinstance(value, tuple):
+        return [_thaw_json(item) for item in value]
+    return value
+
+
+def _freeze_mapping(value: Mapping[str, Any] | None, field_name: str) -> Mapping[str, Any]:
+    copied = _json_copy(dict(value or {}), field_name)
+    return _freeze_json(copied)
+
+
+def _freeze_mapping_sequence(
+    value: Iterable[Mapping[str, Any]] | None,
+    field_name: str,
+) -> tuple[Mapping[str, Any], ...]:
+    return tuple(_freeze_mapping(item, field_name) for item in (value or ()))
+
+
+@dataclass(frozen=True, slots=True)
+class CommandInvocation:
+    """One normalized command attempt bound to an exact catalog revision."""
+
+    request_id: str
+    catalog_revision: str
+    command_id: str
+    entered_name: str
+    raw_input: str
+    raw_arguments: str = ""
+    parsed_arguments: Mapping[str, Any] = field(default_factory=dict)
+    surface: str = ""
+    platform: str = ""
+    actor: Mapping[str, Any] = field(default_factory=dict)
+    profile_home: str = ""
+    cwd: str = ""
+    session_id: str = ""
+    chat_id: str = ""
+    channel_id: str = ""
+    thread_id: str = ""
+    source_id: str = ""
+    locale: str = ""
+    attachments: tuple[Mapping[str, Any], ...] = ()
+    capabilities: Mapping[str, Any] = field(default_factory=dict)
+    idempotency_key: str = ""
+    retry_of: str = ""
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "request_id", _require_text(self.request_id, "request_id"))
+        object.__setattr__(
+            self,
+            "catalog_revision",
+            _require_text(self.catalog_revision, "catalog_revision"),
+        )
+        object.__setattr__(self, "command_id", _require_text(self.command_id, "command_id"))
+        object.__setattr__(self, "entered_name", _require_text(self.entered_name, "entered_name"))
+        object.__setattr__(self, "surface", _require_text(self.surface, "surface"))
+        object.__setattr__(
+            self,
+            "parsed_arguments",
+            _freeze_mapping(self.parsed_arguments, "parsed_arguments"),
+        )
+        object.__setattr__(self, "actor", _freeze_mapping(self.actor, "actor"))
+        object.__setattr__(
+            self,
+            "attachments",
+            _freeze_mapping_sequence(self.attachments, "attachments"),
+        )
+        object.__setattr__(
+            self,
+            "capabilities",
+            _freeze_mapping(self.capabilities, "capabilities"),
+        )
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, Any]) -> "CommandInvocation":
+        if not isinstance(value, Mapping):
+            raise ValueError("invocation must be a mapping")
+        return cls(
+            request_id=value.get("request_id", ""),
+            catalog_revision=value.get("catalog_revision", ""),
+            command_id=value.get("command_id", ""),
+            entered_name=value.get("entered_name", ""),
+            raw_input=str(value.get("raw_input") or ""),
+            raw_arguments=str(value.get("raw_arguments") or ""),
+            parsed_arguments=value.get("parsed_arguments") or {},
+            surface=value.get("surface", ""),
+            platform=str(value.get("platform") or ""),
+            actor=value.get("actor") or {},
+            profile_home=str(value.get("profile_home") or ""),
+            cwd=str(value.get("cwd") or ""),
+            session_id=str(value.get("session_id") or ""),
+            chat_id=str(value.get("chat_id") or ""),
+            channel_id=str(value.get("channel_id") or ""),
+            thread_id=str(value.get("thread_id") or ""),
+            source_id=str(value.get("source_id") or ""),
+            locale=str(value.get("locale") or ""),
+            attachments=tuple(value.get("attachments") or ()),
+            capabilities=value.get("capabilities") or {},
+            idempotency_key=str(value.get("idempotency_key") or ""),
+            retry_of=str(value.get("retry_of") or ""),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "request_id": self.request_id,
+            "catalog_revision": self.catalog_revision,
+            "command_id": self.command_id,
+            "entered_name": self.entered_name,
+            "raw_input": self.raw_input,
+            "raw_arguments": self.raw_arguments,
+            "parsed_arguments": _thaw_json(self.parsed_arguments),
+            "surface": self.surface,
+            "platform": self.platform,
+            "actor": _thaw_json(self.actor),
+            "profile_home": self.profile_home,
+            "cwd": self.cwd,
+            "session_id": self.session_id,
+            "chat_id": self.chat_id,
+            "channel_id": self.channel_id,
+            "thread_id": self.thread_id,
+            "source_id": self.source_id,
+            "locale": self.locale,
+            "attachments": [_thaw_json(item) for item in self.attachments],
+            "capabilities": _thaw_json(self.capabilities),
+            "idempotency_key": self.idempotency_key,
+            "retry_of": self.retry_of,
+        }
+
+    def effect_fingerprint(self) -> str:
+        """Bind an idempotency key to the effect, not the transport request id."""
+        payload = self.to_dict()
+        payload.pop("request_id", None)
+        payload.pop("idempotency_key", None)
+        encoded = json.dumps(
+            payload,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        return hashlib.sha256(encoded).hexdigest()
+
+
+@dataclass(frozen=True, slots=True)
+class CommandResult:
+    """Typed terminal or continuation settlement returned by a command binding."""
+
+    status: str
+    command_id: str
+    content: tuple[Mapping[str, Any], ...] = ()
+    error: Mapping[str, Any] | None = None
+    unavailable_reason: str = ""
+    client_action: Mapping[str, Any] | None = None
+    session_mutations: Mapping[str, Any] = field(default_factory=dict)
+    receipts: tuple[Mapping[str, Any], ...] = ()
+    catalog_revision: str = ""
+    current_catalog_revision: str = ""
+    catalog_invalidation: bool = False
+    ephemeral: bool | None = None
+    visibility: str = ""
+
+    def __post_init__(self) -> None:
+        status = _require_text(self.status, "status")
+        if status not in COMMAND_RESULT_STATUSES:
+            raise ValueError(f"unsupported command result status: {status}")
+        object.__setattr__(self, "status", status)
+        object.__setattr__(self, "command_id", _require_text(self.command_id, "command_id"))
+        object.__setattr__(self, "content", _freeze_mapping_sequence(self.content, "content"))
+        object.__setattr__(
+            self,
+            "error",
+            None if self.error is None else _freeze_mapping(self.error, "error"),
+        )
+        object.__setattr__(
+            self,
+            "client_action",
+            None
+            if self.client_action is None
+            else _freeze_mapping(self.client_action, "client_action"),
+        )
+        object.__setattr__(
+            self,
+            "session_mutations",
+            _freeze_mapping(self.session_mutations, "session_mutations"),
+        )
+        object.__setattr__(
+            self,
+            "receipts",
+            _freeze_mapping_sequence(self.receipts, "receipts"),
+        )
+
+    @classmethod
+    def error_result(
+        cls,
+        command_id: str,
+        code: str,
+        message: str,
+        *,
+        status: str = "error",
+        catalog_revision: str = "",
+    ) -> "CommandResult":
+        return cls(
+            status=status,
+            command_id=command_id,
+            error={"code": code, "message": message},
+            catalog_revision=catalog_revision,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "command_id": self.command_id,
+            "content": [_thaw_json(item) for item in self.content],
+            "error": None if self.error is None else _thaw_json(self.error),
+            "unavailable_reason": self.unavailable_reason or None,
+            "client_action": (
+                None
+                if self.client_action is None
+                else _thaw_json(self.client_action)
+            ),
+            "session_mutations": _thaw_json(self.session_mutations),
+            "receipts": [_thaw_json(item) for item in self.receipts],
+            "catalog_revision": self.catalog_revision or None,
+            "current_catalog_revision": self.current_catalog_revision or None,
+            "catalog_invalidation": self.catalog_invalidation,
+            "ephemeral": self.ephemeral,
+            "visibility": self.visibility or None,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class CommandBinding:
+    """One executable owner for one stable command identity."""
+
+    command_id: str
+    execution_owner: str
+    handler_id: str
+    handler: Callable[[CommandInvocation, Any], CommandResult]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "command_id", _require_text(self.command_id, "command_id"))
+        object.__setattr__(
+            self,
+            "execution_owner",
+            _require_text(self.execution_owner, "execution_owner"),
+        )
+        object.__setattr__(self, "handler_id", _require_text(self.handler_id, "handler_id"))
+        if not callable(self.handler):
+            raise ValueError("handler must be callable")
+
+
+@dataclass(frozen=True, slots=True)
+class CommandPolicyState:
+    """Fully resolved policy facts enforced in one deterministic order."""
+
+    available: bool = True
+    unavailable_reason: str = ""
+    authorized: bool = True
+    authorization_reason: str = ""
+    confirmation_required: bool = False
+    confirmation: Mapping[str, Any] = field(default_factory=dict)
+    mutation_allowed: bool = True
+    mutation_reason: str = ""
+    busy_allowed: bool = True
+    busy_reason: str = ""
+    live_session_satisfied: bool = True
+    live_session_reason: str = ""
+    idempotency_allowed: bool = True
+    idempotency_reason: str = ""
+    retry_allowed: bool = True
+    retry_reason: str = ""
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "confirmation",
+            _freeze_mapping(self.confirmation, "confirmation"),
+        )
+
+
+class CatalogSnapshot(Protocol):
+    revision: str
+
+
+CatalogProvider: TypeAlias = Callable[[CommandInvocation], CatalogSnapshot]
+PolicyResolver: TypeAlias = Callable[[CommandInvocation, Any], CommandPolicyState]
+
+
+def catalog_revision(snapshot: Any) -> str:
+    return _require_text(getattr(snapshot, "revision", ""), "catalog revision")
+
+
+def catalog_to_dict(snapshot: Any) -> dict[str, Any]:
+    to_dict = getattr(snapshot, "to_dict", None)
+    if not callable(to_dict):
+        raise ValueError("catalog snapshot must expose to_dict()")
+    value = to_dict()
+    if not isinstance(value, Mapping):
+        raise ValueError("catalog to_dict() must return a mapping")
+    return _json_copy(dict(value), "catalog")
+
+
+def _row_value(row: Any, name: str, default: Any = None) -> Any:
+    if isinstance(row, Mapping):
+        return row.get(name, default)
+    return getattr(row, name, default)
+
+
+def resolve_catalog_command_id(snapshot: Any, command_id: str) -> Any | None:
+    resolver = getattr(snapshot, "resolve_command_id", None)
+    if callable(resolver):
+        return resolver(command_id)
+
+    commands = getattr(snapshot, "commands", ())
+    if isinstance(commands, Mapping):
+        direct = commands.get(command_id)
+        if direct is not None:
+            return direct
+        for key, row in commands.items():
+            if str(key).casefold() == command_id.casefold():
+                return row
+        return None
+
+    for row in commands or ():
+        value = str(_row_value(row, "command_id", "") or "")
+        if value.casefold() == command_id.casefold():
+            return row
+    return None
+
+
+class CommandReceiptStore(Protocol):
+    def begin(
+        self,
+        key: str,
+        fingerprint: str,
+    ) -> tuple[str, CommandResult | None]: ...
+
+    def settle(self, key: str, fingerprint: str, result: CommandResult) -> None: ...
+
+
+@dataclass(slots=True)
+class _ReceiptRecord:
+    fingerprint: str
+    result: CommandResult | None = None
+
+
+class InMemoryCommandReceiptStore:
+    """Process-local idempotency fence with typed replay/conflict outcomes."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._records: dict[str, _ReceiptRecord] = {}
+
+    def begin(
+        self,
+        key: str,
+        fingerprint: str,
+    ) -> tuple[str, CommandResult | None]:
+        normalized = _require_text(key, "idempotency_key")
+        with self._lock:
+            record = self._records.get(normalized)
+            if record is None:
+                self._records[normalized] = _ReceiptRecord(fingerprint=fingerprint)
+                return "new", None
+            if record.fingerprint != fingerprint:
+                return "conflict", None
+            if record.result is None:
+                return "pending", None
+            return "replay", record.result
+
+    def settle(self, key: str, fingerprint: str, result: CommandResult) -> None:
+        with self._lock:
+            record = self._records.get(key)
+            if record is None or record.fingerprint != fingerprint:
+                raise RuntimeError("idempotency reservation changed before settlement")
+            record.result = result
+
+
+class CommandDispatcher:
+    """Resolve, gate, invoke, and settle one command attempt."""
+
+    def __init__(
+        self,
+        *,
+        catalog_provider: CatalogProvider,
+        policy_resolver: PolicyResolver,
+        bindings: Iterable[CommandBinding],
+        receipt_store: CommandReceiptStore | None = None,
+    ) -> None:
+        if not callable(catalog_provider):
+            raise ValueError("catalog_provider must be callable")
+        if not callable(policy_resolver):
+            raise ValueError("policy_resolver must be callable")
+        self._catalog_provider = catalog_provider
+        self._policy_resolver = policy_resolver
+        self._receipt_store = receipt_store
+        self._bindings: dict[str, CommandBinding] = {}
+        for binding in bindings:
+            key = binding.command_id.casefold()
+            if key in self._bindings:
+                raise ValueError(f"duplicate command binding: {binding.command_id}")
+            self._bindings[key] = binding
+
+    def dispatch(self, invocation: CommandInvocation) -> CommandResult:
+        try:
+            snapshot = self._catalog_provider(invocation)
+            current_revision = catalog_revision(snapshot)
+        except Exception as exc:
+            return CommandResult.error_result(
+                invocation.command_id,
+                "catalog_unavailable",
+                str(exc)[:500] or type(exc).__name__,
+            )
+
+        if invocation.catalog_revision != current_revision:
+            return CommandResult(
+                status="catalog_stale",
+                command_id=invocation.command_id,
+                catalog_revision=invocation.catalog_revision,
+                current_catalog_revision=current_revision,
+                catalog_invalidation=True,
+            )
+
+        command = resolve_catalog_command_id(snapshot, invocation.command_id)
+        if command is None:
+            return CommandResult(
+                status="unknown_command",
+                command_id=invocation.command_id,
+                catalog_revision=current_revision,
+            )
+
+        resolved_id = str(_row_value(command, "command_id", "") or "").strip()
+        if not resolved_id or resolved_id.casefold() != invocation.command_id.casefold():
+            return CommandResult.error_result(
+                invocation.command_id,
+                "catalog_identity_mismatch",
+                "catalog resolved a different command identity",
+                catalog_revision=current_revision,
+            )
+
+        try:
+            policy = self._policy_resolver(invocation, command)
+        except Exception as exc:
+            return CommandResult.error_result(
+                invocation.command_id,
+                "policy_resolution_failed",
+                str(exc)[:500] or type(exc).__name__,
+                catalog_revision=current_revision,
+            )
+        if not isinstance(policy, CommandPolicyState):
+            return CommandResult.error_result(
+                invocation.command_id,
+                "invalid_policy_state",
+                "policy resolver must return CommandPolicyState",
+                catalog_revision=current_revision,
+            )
+
+        refusal = self._enforce_policy(invocation, policy, current_revision)
+        if refusal is not None:
+            return refusal
+
+        binding = self._bindings.get(invocation.command_id.casefold())
+        if binding is None:
+            return CommandResult(
+                status="unavailable",
+                command_id=invocation.command_id,
+                unavailable_reason="binding_unavailable",
+                catalog_revision=current_revision,
+            )
+
+        owner = str(_row_value(command, "execution_owner", "") or "").strip()
+        handler_id = str(_row_value(command, "handler_id", "") or "").strip()
+        if owner and owner != binding.execution_owner:
+            return CommandResult.error_result(
+                invocation.command_id,
+                "execution_owner_mismatch",
+                "catalog and binding execution owners differ",
+                catalog_revision=current_revision,
+            )
+        if handler_id and handler_id != binding.handler_id:
+            return CommandResult.error_result(
+                invocation.command_id,
+                "handler_binding_mismatch",
+                "catalog and binding handler ids differ",
+                catalog_revision=current_revision,
+            )
+
+        reservation: tuple[str, str] | None = None
+        if invocation.idempotency_key:
+            if self._receipt_store is None:
+                return CommandResult.error_result(
+                    invocation.command_id,
+                    "idempotency_store_unavailable",
+                    "idempotent invocation cannot execute without a receipt store",
+                    catalog_revision=current_revision,
+                )
+            fingerprint = invocation.effect_fingerprint()
+            verdict, prior = self._receipt_store.begin(
+                invocation.idempotency_key,
+                fingerprint,
+            )
+            if verdict == "conflict":
+                return CommandResult.error_result(
+                    invocation.command_id,
+                    "idempotency_conflict",
+                    "idempotency key is already bound to a different effect",
+                    catalog_revision=current_revision,
+                )
+            if verdict == "pending":
+                return CommandResult(
+                    status="deferred",
+                    command_id=invocation.command_id,
+                    error={
+                        "code": "idempotency_pending",
+                        "message": "an equivalent invocation is still executing",
+                    },
+                    catalog_revision=current_revision,
+                )
+            if verdict == "replay" and prior is not None:
+                return prior
+            reservation = (invocation.idempotency_key, fingerprint)
+
+        try:
+            result = binding.handler(invocation, command)
+        except Exception as exc:
+            result = CommandResult.error_result(
+                invocation.command_id,
+                "handler_error",
+                str(exc)[:500] or type(exc).__name__,
+                catalog_revision=current_revision,
+            )
+
+        if not isinstance(result, CommandResult):
+            result = CommandResult.error_result(
+                invocation.command_id,
+                "invalid_handler_result",
+                "command handlers must return CommandResult",
+                catalog_revision=current_revision,
+            )
+        elif result.command_id.casefold() != invocation.command_id.casefold():
+            result = CommandResult.error_result(
+                invocation.command_id,
+                "result_identity_mismatch",
+                "handler settled a different command identity",
+                catalog_revision=current_revision,
+            )
+        elif not result.catalog_revision:
+            result = replace(result, catalog_revision=current_revision)
+
+        if reservation is not None and self._receipt_store is not None:
+            try:
+                self._receipt_store.settle(*reservation, result)
+            except Exception as exc:
+                return CommandResult.error_result(
+                    invocation.command_id,
+                    "receipt_settlement_failed",
+                    str(exc)[:500] or type(exc).__name__,
+                    status="indeterminate",
+                    catalog_revision=current_revision,
+                )
+        return result
+
+    @staticmethod
+    def _enforce_policy(
+        invocation: CommandInvocation,
+        policy: CommandPolicyState,
+        revision: str,
+    ) -> CommandResult | None:
+        if not policy.available:
+            return CommandResult(
+                status="unavailable",
+                command_id=invocation.command_id,
+                unavailable_reason=policy.unavailable_reason or "unavailable",
+                catalog_revision=revision,
+            )
+        if not policy.authorized:
+            return CommandResult.error_result(
+                invocation.command_id,
+                "unauthorized",
+                policy.authorization_reason or "command is not authorized",
+                catalog_revision=revision,
+            )
+        if policy.confirmation_required:
+            return CommandResult(
+                status="confirmation_required",
+                command_id=invocation.command_id,
+                client_action=dict(policy.confirmation),
+                catalog_revision=revision,
+            )
+        if not policy.mutation_allowed:
+            return CommandResult.error_result(
+                invocation.command_id,
+                "mutation_refused",
+                policy.mutation_reason or "command mutation is not authorized",
+                catalog_revision=revision,
+            )
+        if not policy.busy_allowed:
+            return CommandResult(
+                status="unavailable",
+                command_id=invocation.command_id,
+                unavailable_reason=policy.busy_reason or "session_busy",
+                catalog_revision=revision,
+            )
+        if not policy.live_session_satisfied:
+            return CommandResult(
+                status="unavailable",
+                command_id=invocation.command_id,
+                unavailable_reason=(
+                    policy.live_session_reason or "live_session_required"
+                ),
+                catalog_revision=revision,
+            )
+        if not policy.idempotency_allowed:
+            return CommandResult.error_result(
+                invocation.command_id,
+                "idempotency_refused",
+                policy.idempotency_reason or "idempotency policy refused invocation",
+                catalog_revision=revision,
+            )
+        if invocation.retry_of and not policy.retry_allowed:
+            return CommandResult.error_result(
+                invocation.command_id,
+                "retry_refused",
+                policy.retry_reason or "command is not retry-safe",
+                catalog_revision=revision,
+            )
+        return None

--- a/tests/hermes_cli/test_command_dispatcher.py
+++ b/tests/hermes_cli/test_command_dispatcher.py
@@ -1,0 +1,292 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from hermes_cli.command_dispatcher import (
+    CommandBinding,
+    CommandDispatcher,
+    CommandInvocation,
+    CommandPolicyState,
+    CommandResult,
+    InMemoryCommandReceiptStore,
+)
+
+
+@dataclass(frozen=True)
+class FakeCommand:
+    command_id: str
+    name: str = "new"
+    aliases: tuple[str, ...] = ("reset",)
+    execution_owner: str = "server"
+    handler_id: str = "session.new"
+
+
+@dataclass(frozen=True)
+class FakeCatalog:
+    revision: str
+    commands: tuple[FakeCommand, ...]
+
+    def resolve_command_id(self, command_id: str):
+        return next(
+            (
+                command
+                for command in self.commands
+                if command.command_id.casefold() == command_id.casefold()
+            ),
+            None,
+        )
+
+    def to_dict(self):
+        return {
+            "schema_version": 2,
+            "revision": self.revision,
+            "commands": [command.__dict__ for command in self.commands],
+        }
+
+
+def invocation(**overrides) -> CommandInvocation:
+    values = {
+        "request_id": "request-1",
+        "catalog_revision": "rev-1",
+        "command_id": "session.new",
+        "entered_name": "reset",
+        "raw_input": "/reset now",
+        "raw_arguments": "now",
+        "parsed_arguments": {"name": "now"},
+        "surface": "desktop",
+        "platform": "desktop",
+        "actor": {"id": "user-1"},
+        "session_id": "session-1",
+        "attachments": ({"id": "attachment-1"},),
+        "capabilities": {"live_session": True},
+    }
+    values.update(overrides)
+    return CommandInvocation(**values)
+
+
+def dispatcher(
+    *,
+    catalog: FakeCatalog | None = None,
+    policy: CommandPolicyState | None = None,
+    handler=None,
+    receipt_store=None,
+) -> CommandDispatcher:
+    catalog = catalog or FakeCatalog("rev-1", (FakeCommand("session.new"),))
+    policy = policy or CommandPolicyState()
+    handler = handler or (
+        lambda inv, _command: CommandResult(
+            status="ok",
+            command_id=inv.command_id,
+            content=({"type": "text", "text": "created"},),
+        )
+    )
+    return CommandDispatcher(
+        catalog_provider=lambda _inv: catalog,
+        policy_resolver=lambda _inv, _command: policy,
+        bindings=(
+            CommandBinding(
+                command_id="session.new",
+                execution_owner="server",
+                handler_id="session.new",
+                handler=handler,
+            ),
+        ),
+        receipt_store=receipt_store,
+    )
+
+
+def test_invocation_is_detached_and_effect_fingerprint_ignores_request_id():
+    parsed = {"nested": ["one"]}
+    first = invocation(parsed_arguments=parsed)
+    parsed["nested"].append("two")
+
+    assert first.to_dict()["parsed_arguments"] == {"nested": ["one"]}
+    with pytest.raises(AttributeError):
+        first.parsed_arguments["nested"].append("blocked")
+    assert first.effect_fingerprint() == invocation(
+        request_id="request-2", parsed_arguments={"nested": ["one"]}
+    ).effect_fingerprint()
+
+
+def test_stale_catalog_refuses_before_policy_or_handler():
+    called = []
+    runtime = CommandDispatcher(
+        catalog_provider=lambda _inv: FakeCatalog(
+            "rev-2", (FakeCommand("session.new"),)
+        ),
+        policy_resolver=lambda *_args: called.append("policy"),
+        bindings=(),
+    )
+
+    result = runtime.dispatch(invocation())
+
+    assert result.status == "catalog_stale"
+    assert result.current_catalog_revision == "rev-2"
+    assert result.catalog_invalidation is True
+    assert called == []
+
+
+def test_unknown_command_is_typed_and_never_falls_through():
+    result = dispatcher().dispatch(invocation(command_id="missing.command"))
+
+    assert result.status == "unknown_command"
+    assert result.command_id == "missing.command"
+
+
+@pytest.mark.parametrize(
+    ("policy", "status", "reason_or_code"),
+    [
+        (
+            CommandPolicyState(available=False, unavailable_reason="unsupported"),
+            "unavailable",
+            "unsupported",
+        ),
+        (
+            CommandPolicyState(authorized=False, authorization_reason="denied"),
+            "error",
+            "unauthorized",
+        ),
+        (
+            CommandPolicyState(
+                confirmation_required=True,
+                confirmation={"kind": "confirm"},
+            ),
+            "confirmation_required",
+            None,
+        ),
+        (
+            CommandPolicyState(mutation_allowed=False, mutation_reason="read-only"),
+            "error",
+            "mutation_refused",
+        ),
+        (
+            CommandPolicyState(busy_allowed=False, busy_reason="session_busy"),
+            "unavailable",
+            "session_busy",
+        ),
+        (
+            CommandPolicyState(live_session_satisfied=False),
+            "unavailable",
+            "live_session_required",
+        ),
+        (
+            CommandPolicyState(idempotency_allowed=False),
+            "error",
+            "idempotency_refused",
+        ),
+    ],
+)
+def test_policy_refusals_settle_before_execution(policy, status, reason_or_code):
+    called = []
+    result = dispatcher(policy=policy, handler=lambda *_args: called.append(True)).dispatch(
+        invocation()
+    )
+
+    assert result.status == status
+    if status == "unavailable":
+        assert result.unavailable_reason == reason_or_code
+    elif reason_or_code is not None:
+        assert result.error["code"] == reason_or_code
+    assert called == []
+
+
+def test_retry_policy_applies_only_to_retry_attempts():
+    policy = CommandPolicyState(retry_allowed=False, retry_reason="not safe")
+
+    assert dispatcher(policy=policy).dispatch(invocation()).status == "ok"
+    retried = dispatcher(policy=policy).dispatch(invocation(retry_of="request-0"))
+    assert retried.status == "error"
+    assert retried.error["code"] == "retry_refused"
+
+
+def test_binding_owner_and_handler_are_attested_to_catalog():
+    catalog = FakeCatalog(
+        "rev-1",
+        (FakeCommand("session.new", execution_owner="client"),),
+    )
+    result = dispatcher(catalog=catalog).dispatch(invocation())
+
+    assert result.status == "error"
+    assert result.error["code"] == "execution_owner_mismatch"
+
+
+def test_handler_must_return_typed_result_for_same_command():
+    invalid = dispatcher(handler=lambda *_args: {"status": "ok"}).dispatch(invocation())
+    wrong = dispatcher(
+        handler=lambda *_args: CommandResult(status="ok", command_id="session.stop")
+    ).dispatch(invocation())
+
+    assert invalid.error["code"] == "invalid_handler_result"
+    assert wrong.error["code"] == "result_identity_mismatch"
+
+
+def test_handler_exception_becomes_typed_error_without_escaping():
+    def broken(*_args):
+        raise RuntimeError("boom")
+
+    result = dispatcher(handler=broken).dispatch(invocation())
+
+    assert result.status == "error"
+    assert result.error == {"code": "handler_error", "message": "boom"}
+
+
+def test_idempotency_replays_same_effect_and_rejects_key_rebinding():
+    calls = []
+    store = InMemoryCommandReceiptStore()
+
+    def handler(inv, _command):
+        calls.append(inv.raw_arguments)
+        return CommandResult(status="ok", command_id=inv.command_id)
+
+    runtime = dispatcher(handler=handler, receipt_store=store)
+    first = runtime.dispatch(invocation(idempotency_key="idem-1"))
+    replay = runtime.dispatch(
+        invocation(request_id="request-2", idempotency_key="idem-1")
+    )
+    conflict = runtime.dispatch(
+        invocation(raw_arguments="different", idempotency_key="idem-1")
+    )
+
+    assert first is replay
+    assert calls == ["now"]
+    assert conflict.error["code"] == "idempotency_conflict"
+
+
+def test_receipt_settlement_failure_is_indeterminate_after_the_effect():
+    class BrokenStore:
+        def begin(self, _key, _fingerprint):
+            return "new", None
+
+        def settle(self, _key, _fingerprint, _result):
+            raise RuntimeError("receipt sink unavailable")
+
+    result = dispatcher(receipt_store=BrokenStore()).dispatch(
+        invocation(idempotency_key="idem-1")
+    )
+
+    assert result.status == "indeterminate"
+    assert result.error["code"] == "receipt_settlement_failed"
+
+
+def test_idempotent_attempt_fails_closed_without_receipt_store():
+    result = dispatcher().dispatch(invocation(idempotency_key="idem-1"))
+
+    assert result.error["code"] == "idempotency_store_unavailable"
+
+
+def test_duplicate_bindings_fail_catalog_construction():
+    binding = CommandBinding(
+        command_id="session.new",
+        execution_owner="server",
+        handler_id="session.new",
+        handler=lambda *_args: CommandResult(status="ok", command_id="session.new"),
+    )
+
+    with pytest.raises(ValueError, match="duplicate command binding"):
+        CommandDispatcher(
+            catalog_provider=lambda _inv: FakeCatalog("rev-1", ()),
+            policy_resolver=lambda *_args: CommandPolicyState(),
+            bindings=(binding, binding),
+        )

--- a/tests/tui_gateway/test_command_rpc_v2.py
+++ b/tests/tui_gateway/test_command_rpc_v2.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from hermes_cli.command_dispatcher import (
+    CommandBinding,
+    CommandDispatcher,
+    CommandPolicyState,
+    CommandResult,
+)
+from tui_gateway.command_rpc_v2 import (
+    CATALOG_V2_METHOD,
+    INVOKE_METHOD,
+    LEGACY_CATALOG_METHOD,
+    LEGACY_DISPATCH_METHOD,
+    LEGACY_SLASH_EXEC_METHOD,
+    CommandRPCV2,
+)
+
+
+@dataclass(frozen=True)
+class Command:
+    command_id: str = "session.new"
+    name: str = "new"
+    aliases: tuple[str, ...] = ("reset",)
+    execution_owner: str = "server"
+    handler_id: str = "session.new"
+
+
+@dataclass(frozen=True)
+class Catalog:
+    revision: str = "rev-1"
+    commands: tuple[Command, ...] = (Command(),)
+
+    def resolve_command_id(self, command_id: str):
+        return next(
+            (row for row in self.commands if row.command_id == command_id),
+            None,
+        )
+
+    def resolve(self, token: str):
+        normalized = token.casefold()
+        return next(
+            (
+                row
+                for row in self.commands
+                if row.name == normalized or normalized in row.aliases
+            ),
+            None,
+        )
+
+    def to_dict(self):
+        return {
+            "schema_version": 2,
+            "revision": self.revision,
+            "commands": [
+                {
+                    "command_id": row.command_id,
+                    "name": row.name,
+                    "aliases": list(row.aliases),
+                }
+                for row in self.commands
+            ],
+        }
+
+
+def ok(rid, payload):
+    return {"id": rid, "result": dict(payload)}
+
+
+def err(rid, code, message):
+    return {"id": rid, "error": {"code": code, "message": message}}
+
+
+def build_rpc(calls=None, *, legacy=True):
+    calls = calls if calls is not None else []
+    catalog = Catalog()
+
+    def handler(invocation, _command):
+        calls.append(invocation)
+        return CommandResult(
+            status="ok",
+            command_id=invocation.command_id,
+            content=({"type": "text", "text": "created"},),
+        )
+
+    runtime = CommandDispatcher(
+        catalog_provider=lambda _inv: catalog,
+        policy_resolver=lambda *_args: CommandPolicyState(),
+        bindings=(
+            CommandBinding(
+                command_id="session.new",
+                execution_owner="server",
+                handler_id="session.new",
+                handler=handler,
+            ),
+        ),
+    )
+    return CommandRPCV2(
+        catalog_provider=lambda _params: catalog,
+        dispatcher=runtime,
+        ok=ok,
+        err=err,
+        legacy_catalog_projector=(
+            (lambda snapshot: {"revision": snapshot.revision, "pairs": [["/new", "New"]]})
+            if legacy
+            else None
+        ),
+        legacy_result_projector=(
+            (lambda result: {"type": "exec", "output": result["content"][0]["text"]})
+            if legacy
+            else None
+        ),
+    )
+
+
+def v2_params():
+    return {
+        "request_id": "request-1",
+        "catalog_revision": "rev-1",
+        "command_id": "session.new",
+        "entered_name": "reset",
+        "raw_input": "/reset now",
+        "raw_arguments": "now",
+        "parsed_arguments": {"name": "now"},
+        "surface": "desktop",
+    }
+
+
+def test_v2_handlers_use_exact_public_method_names():
+    handlers = build_rpc().handlers()
+
+    assert tuple(handlers) == (CATALOG_V2_METHOD, INVOKE_METHOD)
+    with pytest.raises(TypeError):
+        handlers["other"] = lambda: None
+
+
+def test_catalog_v2_returns_client_safe_snapshot():
+    response = build_rpc().catalog_v2("rpc-1", {"surface": "desktop"})
+
+    assert response["result"]["schema_version"] == 2
+    assert response["result"]["revision"] == "rev-1"
+    assert response["result"]["commands"][0]["command_id"] == "session.new"
+
+
+def test_commands_invoke_parses_and_dispatches_typed_invocation():
+    calls = []
+    response = build_rpc(calls).invoke("rpc-1", {"invocation": v2_params()})
+
+    assert response["result"]["status"] == "ok"
+    assert response["result"]["catalog_revision"] == "rev-1"
+    assert calls[0].entered_name == "reset"
+    assert calls[0].raw_arguments == "now"
+
+
+def test_commands_invoke_rejects_malformed_input_as_rpc_error():
+    response = build_rpc().invoke("rpc-1", {"invocation": {"command_id": "x"}})
+
+    assert response["error"]["code"] == 4003
+    assert "request_id" in response["error"]["message"]
+
+
+def test_legacy_command_dispatch_is_a_v2_invocation_shim():
+    calls = []
+    response = build_rpc(calls).legacy_dispatch(
+        "rpc-1",
+        {
+            "name": "/reset",
+            "arg": "now",
+            "session_id": "session-1",
+            "platform": "tui",
+        },
+    )
+
+    invocation = calls[0]
+    assert invocation.command_id == "session.new"
+    assert invocation.entered_name == "reset"
+    assert invocation.raw_input == "/reset now"
+    assert invocation.catalog_revision == "rev-1"
+    assert response["result"] == {"type": "exec", "output": "created"}
+
+
+def test_legacy_slash_exec_is_the_same_canonical_shim():
+    calls = []
+    response = build_rpc(calls).legacy_slash_exec(
+        "rpc-1",
+        {"command": "/reset now", "session_id": "session-1"},
+    )
+
+    assert calls[0].command_id == "session.new"
+    assert calls[0].raw_arguments == "now"
+    assert response["result"]["output"] == "created"
+
+
+def test_legacy_shims_fail_closed_without_explicit_projectors():
+    rpc = build_rpc(legacy=False)
+
+    assert rpc.legacy_catalog("rpc-1", {})["error"]["code"] == 5018
+    assert (
+        rpc.legacy_dispatch("rpc-1", {"name": "new"})["error"]["code"]
+        == 5018
+    )
+
+
+def test_include_legacy_exports_all_three_compatibility_methods():
+    handlers = build_rpc().handlers(include_legacy=True)
+
+    assert set(handlers) == {
+        CATALOG_V2_METHOD,
+        INVOKE_METHOD,
+        LEGACY_CATALOG_METHOD,
+        LEGACY_DISPATCH_METHOD,
+        LEGACY_SLASH_EXEC_METHOD,
+    }
+
+
+def test_install_refuses_method_collisions_unless_explicitly_replacing():
+    rpc = build_rpc()
+    methods = {CATALOG_V2_METHOD: object()}
+
+    with pytest.raises(ValueError, match="command RPC method collision"):
+        rpc.install(methods)
+
+    rpc.install(methods, replace_existing=True)
+    assert methods[CATALOG_V2_METHOD] == rpc.catalog_v2
+    assert methods[INVOKE_METHOD] == rpc.invoke

--- a/tui_gateway/command_rpc_v2.py
+++ b/tui_gateway/command_rpc_v2.py
@@ -1,0 +1,234 @@
+"""Versioned command RPC handlers and legacy compatibility shims.
+
+The owning gateway module is intentionally not imported here.  Callers provide
+its ``_ok``/``_err`` envelope functions and install the returned bounded
+handlers into the method registry.  This keeps the v2 ABI testable without
+adding another command table or growing an existing godfile.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Callable, Mapping, MutableMapping
+from types import MappingProxyType
+from typing import Any
+
+from hermes_cli.command_dispatcher import (
+    CommandDispatcher,
+    CommandInvocation,
+    catalog_revision,
+    catalog_to_dict,
+)
+
+CATALOG_V2_METHOD = "commands.catalog.v2"
+INVOKE_METHOD = "commands.invoke"
+LEGACY_CATALOG_METHOD = "commands.catalog"
+LEGACY_DISPATCH_METHOD = "command.dispatch"
+LEGACY_SLASH_EXEC_METHOD = "slash.exec"
+
+
+def _row_value(row: Any, name: str, default: Any = None) -> Any:
+    if isinstance(row, Mapping):
+        return row.get(name, default)
+    return getattr(row, name, default)
+
+
+def _resolve_catalog_token(snapshot: Any, token: str) -> Any | None:
+    normalized = str(token or "").strip().lstrip("/").casefold()
+    if not normalized:
+        return None
+
+    resolver = getattr(snapshot, "resolve_command", None)
+    if callable(resolver):
+        return resolver(normalized)
+    resolver = getattr(snapshot, "resolve", None)
+    if callable(resolver):
+        return resolver(normalized)
+
+    commands = getattr(snapshot, "commands", ())
+    rows = commands.values() if isinstance(commands, Mapping) else commands
+    for row in rows or ():
+        name = str(_row_value(row, "name", "") or "").casefold()
+        aliases = tuple(_row_value(row, "aliases", ()) or ())
+        if name == normalized or any(str(alias).casefold() == normalized for alias in aliases):
+            return row
+    return None
+
+
+def _command_id(row: Any) -> str:
+    return str(_row_value(row, "command_id", "") or "").strip()
+
+
+def _legacy_invocation(
+    *,
+    snapshot: Any,
+    token: str,
+    raw_arguments: str,
+    raw_input: str,
+    params: Mapping[str, Any],
+    source_method: str,
+) -> CommandInvocation:
+    row = _resolve_catalog_token(snapshot, token)
+    command_id = _command_id(row) if row is not None else f"unknown.{token.lstrip('/')}"
+    return CommandInvocation(
+        request_id=str(params.get("request_id") or f"{source_method}:{uuid.uuid4()}"),
+        catalog_revision=catalog_revision(snapshot),
+        command_id=command_id,
+        entered_name=str(token or "").lstrip("/"),
+        raw_input=raw_input,
+        raw_arguments=raw_arguments,
+        parsed_arguments={"legacy_raw": raw_arguments},
+        surface=str(params.get("surface") or "legacy-rpc"),
+        platform=str(params.get("platform") or "tui"),
+        actor=params.get("actor") or {},
+        profile_home=str(params.get("profile_home") or ""),
+        cwd=str(params.get("cwd") or ""),
+        session_id=str(params.get("session_id") or ""),
+        chat_id=str(params.get("chat_id") or ""),
+        channel_id=str(params.get("channel_id") or ""),
+        thread_id=str(params.get("thread_id") or ""),
+        source_id=str(params.get("source_id") or ""),
+        locale=str(params.get("locale") or ""),
+        attachments=tuple(params.get("attachments") or ()),
+        capabilities=params.get("capabilities") or {},
+        idempotency_key=str(params.get("idempotency_key") or ""),
+        retry_of=str(params.get("retry_of") or ""),
+    )
+
+
+class CommandRPCV2:
+    """JSON-RPC-compatible adapter around one canonical dispatcher."""
+
+    def __init__(
+        self,
+        *,
+        catalog_provider: Callable[[Mapping[str, Any]], Any],
+        dispatcher: CommandDispatcher,
+        ok: Callable[[Any, Mapping[str, Any]], dict[str, Any]],
+        err: Callable[[Any, int, str], dict[str, Any]],
+        legacy_catalog_projector: Callable[[Any], Mapping[str, Any]] | None = None,
+        legacy_result_projector: Callable[[Mapping[str, Any]], Mapping[str, Any]] | None = None,
+    ) -> None:
+        self._catalog_provider = catalog_provider
+        self._dispatcher = dispatcher
+        self._ok = ok
+        self._err = err
+        self._legacy_catalog_projector = legacy_catalog_projector
+        self._legacy_result_projector = legacy_result_projector
+
+    def catalog_v2(self, rid: Any, params: Mapping[str, Any]) -> dict[str, Any]:
+        try:
+            snapshot = self._catalog_provider(params)
+            return self._ok(rid, catalog_to_dict(snapshot))
+        except (TypeError, ValueError) as exc:
+            return self._err(rid, 4003, str(exc))
+        except Exception as exc:
+            return self._err(rid, 5020, str(exc))
+
+    def invoke(self, rid: Any, params: Mapping[str, Any]) -> dict[str, Any]:
+        try:
+            raw = params.get("invocation", params)
+            invocation = CommandInvocation.from_mapping(raw)
+        except (TypeError, ValueError) as exc:
+            return self._err(rid, 4003, str(exc))
+        return self._ok(rid, self._dispatcher.dispatch(invocation).to_dict())
+
+    def legacy_catalog(self, rid: Any, params: Mapping[str, Any]) -> dict[str, Any]:
+        if self._legacy_catalog_projector is None:
+            return self._err(rid, 5018, "legacy catalog projector is not installed")
+        try:
+            snapshot = self._catalog_provider(params)
+            projected = self._legacy_catalog_projector(snapshot)
+            return self._ok(rid, dict(projected))
+        except Exception as exc:
+            return self._err(rid, 5020, str(exc))
+
+    def legacy_dispatch(self, rid: Any, params: Mapping[str, Any]) -> dict[str, Any]:
+        token = str(params.get("name") or "").strip().lstrip("/")
+        raw_arguments = str(params.get("arg") or "")
+        if not token:
+            return self._err(rid, 4004, "empty command")
+        raw_input = f"/{token}" + (f" {raw_arguments}" if raw_arguments else "")
+        return self._run_legacy(
+            rid,
+            params,
+            token=token,
+            raw_arguments=raw_arguments,
+            raw_input=raw_input,
+            source_method=LEGACY_DISPATCH_METHOD,
+        )
+
+    def legacy_slash_exec(self, rid: Any, params: Mapping[str, Any]) -> dict[str, Any]:
+        raw_input = str(params.get("command") or "").strip()
+        if not raw_input:
+            return self._err(rid, 4004, "empty command")
+        text = raw_input[1:] if raw_input.startswith("/") else raw_input
+        token, _, raw_arguments = text.partition(" ")
+        if not token or "/" in token:
+            return self._err(rid, 4004, "invalid command")
+        return self._run_legacy(
+            rid,
+            params,
+            token=token,
+            raw_arguments=raw_arguments,
+            raw_input=raw_input,
+            source_method=LEGACY_SLASH_EXEC_METHOD,
+        )
+
+    def _run_legacy(
+        self,
+        rid: Any,
+        params: Mapping[str, Any],
+        *,
+        token: str,
+        raw_arguments: str,
+        raw_input: str,
+        source_method: str,
+    ) -> dict[str, Any]:
+        if self._legacy_result_projector is None:
+            return self._err(rid, 5018, "legacy result projector is not installed")
+        try:
+            snapshot = self._catalog_provider(params)
+            invocation = _legacy_invocation(
+                snapshot=snapshot,
+                token=token,
+                raw_arguments=raw_arguments,
+                raw_input=raw_input,
+                params=params,
+                source_method=source_method,
+            )
+            result = self._dispatcher.dispatch(invocation).to_dict()
+            return self._ok(rid, dict(self._legacy_result_projector(result)))
+        except (TypeError, ValueError) as exc:
+            return self._err(rid, 4003, str(exc))
+        except Exception as exc:
+            return self._err(rid, 5020, str(exc))
+
+    def handlers(self, *, include_legacy: bool = False) -> Mapping[str, Callable]:
+        handlers: dict[str, Callable] = {
+            CATALOG_V2_METHOD: self.catalog_v2,
+            INVOKE_METHOD: self.invoke,
+        }
+        if include_legacy:
+            handlers.update(
+                {
+                    LEGACY_CATALOG_METHOD: self.legacy_catalog,
+                    LEGACY_DISPATCH_METHOD: self.legacy_dispatch,
+                    LEGACY_SLASH_EXEC_METHOD: self.legacy_slash_exec,
+                }
+            )
+        return MappingProxyType(handlers)
+
+    def install(
+        self,
+        methods: MutableMapping[str, Callable],
+        *,
+        include_legacy: bool = False,
+        replace_existing: bool = False,
+    ) -> None:
+        handlers = self.handlers(include_legacy=include_legacy)
+        collisions = sorted(name for name in handlers if name in methods)
+        if collisions and not replace_existing:
+            joined = ", ".join(collisions)
+            raise ValueError(f"command RPC method collision: {joined}")
+        methods.update(handlers)


### PR DESCRIPTION
## What does this PR do?

This is PR 2 of #96692. It establishes the transport-free execution contract that the versioned command catalog and every Hermes command surface can compose through without creating another semantic registry.

The change adds one immutable `CommandInvocation`, one typed `CommandResult`, one `CommandBinding` per stable command identity, one deterministic dispatcher policy sequence, one idempotency/receipt settlement boundary, and bounded RPC handlers for `commands.catalog.v2` and `commands.invoke`.

Unknown commands and missing bindings fail closed. A typed command attempt cannot fall through into an agent prompt. Catalog revision mismatch is rejected before policy or execution. Executable bindings are separately attested against catalog `execution_owner` and `handler_id`, so client-safe catalog metadata never becomes executable authority by itself.

Legacy `commands.catalog`, `command.dispatch`, and `slash.exec` are represented only as explicit compatibility shims. They normalize into the same revision-bound invocation and require caller-supplied result/catalog projectors; absent projectors fail closed. This PR does not register a second production owner in `tui_gateway/server.py` or `tui_gateway/methods_tools.py`.

Exact submitted object:

- base: `35328345d5e3b5badc47271bdb8828e1fd2d25f4`
- head: `02d761558eefc5faa69e821f97f6d8c54df65e01`
- tree: `82dde8027396f6f8532b9674d092444a94b0d012`
- shape: one commit, four added files, `+1449/-0`
- all modified files remain below 2,000 lines

Prior work and composition are explicit: #97102 is the executable PR-0 characterization baseline; #96791 by OutThisLife remains the merged owner of registry-backed Desktop metadata and the current `commands.catalog` projection; closed #96705 remains stable-identity/revision design provenance only. #95028/#95101 remain separate authority-policy interlocks and are not reconstructed here. The Classic CLI, gateway, Desktop, and Ink binding seams tracked by #97138, #97114, #97124, and #97129 can compose onto this ABI rather than creating parallel execution contracts.

## Related Issue

Part of #96692.

This PR intentionally does not use `Fixes`/`Closes`: #96692 remains open until the unified catalog, resolver, dispatcher, surface migrations, native registration, compatibility removal, and conformance matrix are complete.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `hermes_cli/command_dispatcher.py`:
  - immutable, JSON-safe `CommandInvocation` carrying exact catalog revision, stable `command_id`, entered alias, raw/parsed arguments, actor/context identities, attachments, capabilities, idempotency key, and retry provenance;
  - typed `CommandResult` covering `ok`, `error`, `unknown_command`, `unavailable`, `confirmation_required`, `deferred`, `catalog_stale`, `indeterminate`, `send_to_agent`, and `client_action` settlements;
  - explicit `CommandBinding` with stable command identity, execution owner, handler ID, and callable separated from catalog metadata;
  - deterministic policy enforcement order: availability → authorization → confirmation → mutation → busy → live-session → idempotency → retry;
  - execution-owner/handler attestation, result-identity validation, typed handler failures, and fail-closed missing bindings;
  - process-local receipt store supporting new/replay/pending/conflict outcomes and `indeterminate` settlement when post-effect receipt persistence fails.
- Added `tui_gateway/command_rpc_v2.py`:
  - exact public v2 methods `commands.catalog.v2` and `commands.invoke`;
  - explicit compatibility shims for `commands.catalog`, `command.dispatch`, and `slash.exec`;
  - collision-refusing method installation unless replacement is explicitly authorized;
  - gateway envelope injection through existing `_ok`/`_err` contracts without importing or growing the gateway godfiles.
- Added `tests/hermes_cli/test_command_dispatcher.py` covering immutable invocation data, effect fingerprints, stale revisions, unknown commands, policy refusal precedence, retry rules, binding attestation, typed result enforcement, handler failures, receipt replay/conflict/indeterminacy, and duplicate binding refusal.
- Added `tests/tui_gateway/test_command_rpc_v2.py` covering exact method names, v2 catalog/invocation behavior, malformed invocation refusal, legacy normalization into canonical invocation, explicit projector requirements, compatibility method export, and method-collision refusal.
- Performed a live FILE-LIST search before publication; no existing open PR was found touching these four paths.

## How to Test

1. Run the focused dispatcher/RPC contract suite:
   ```bash
   python -m pytest -q \
     tests/hermes_cli/test_command_dispatcher.py \
     tests/tui_gateway/test_command_rpc_v2.py
   ```
   Expected: `27 passed`.
2. Compile the two production modules and two test modules with `py_compile`; expected: no syntax errors.
3. Verify exact submitted head `02d761558eefc5faa69e821f97f6d8c54df65e01` in hosted workflows:
   - CI `33172339782` — success
   - Docker `33172339245` — success
   - Nix `33172339336` — success
4. Verify the published blob identities:
   ```text
   69f88996d02d8ecf798eb25b69a06f06966b8994  hermes_cli/command_dispatcher.py
   d5991002aa1442efa6715fa9fd1c59193b4de442  tui_gateway/command_rpc_v2.py
   b0ed54971ab65fe46a507b742cf17979a39c6710  tests/hermes_cli/test_command_dispatcher.py
   177db686cf6a5b199ef145eb0ea987b576bcd073  tests/tui_gateway/test_command_rpc_v2.py
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the applicable focused pytest suites and all tests pass — `27 passed`; exact-head hosted CI also passed the repository test matrix
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: focused Python contract suite plus exact-head hosted Linux/Windows/macOS CI coverage

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; the new bounded modules carry their contract documentation and #96692 remains the architecture spec
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; no contributor/workflow contract changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the ABI is platform-neutral and exact-head hosted Windows/macOS lanes passed
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no tool schema changed

## Screenshots / Logs

No UI screenshots apply.

Exact-head hosted receipts for `02d761558eefc5faa69e821f97f6d8c54df65e01`:

- CI `33172339782` — **success**
- Docker Build, Test, and Publish `33172339245` — **success**
- Nix flake check `33172339336` — **success**

Focused contract execution: **27 passed**.

The exact-head matrix is the acceptance evidence for this submitted object; no predecessor, sibling, or local result is substituted for hosted proof.