### PR TITLE
fix(toolsets): fail loud when a toolset-deny declaration is silently ignored

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -596,6 +596,39 @@ def _get_platform_tools(config: dict, platform: str, *, include_default_mcp_serv
         disabled_names = [name.strip() for name in parse_config_string_list(disabled_toolsets) if name.strip()]
         enabled_toolsets = _prune_toolsets_stripped_by_disabled(enabled_toolsets, disabled_names)
 
+        # A deny list is security posture: an unrecognized name silently
+        # keeps the toolset enabled. Surface it here, where the subtraction
+        # happens, so a hand-edited/typo'd agent.disabled_toolsets is caught
+        # at runtime (#97111). _LEGACY_TOOLSET_MAP misspellings are resolved by
+        # validate_toolset; anything else that fails validation is dead.
+        from toolsets import validate_toolset
+
+        for name in sorted(disabled_names):
+            if not validate_toolset(name):
+                logger.warning(
+                    "agent.disabled_toolsets entry '%s' is not a known toolset — "
+                    "the deny is ignored (typo or renamed toolset). Fix config.yaml.",
+                    name,
+                )
+
+    # Fail-loud for the two silent deny-declaration shapes that do nothing.
+    # An operator hardening a container writes HERMES_DISABLED_TOOLSETS or a
+    # root-level disabled_toolsets: (beside toolsets:) — either is a plausible
+    # spelling that nothing reads, so capability silently stays on. Warn once
+    # here so the misdeclaration is noticed (#97111).
+    env_deny = os.environ.get("HERMES_DISABLED_TOOLSETS", "").strip()
+    if env_deny:
+        logger.warning(
+            "HERMES_DISABLED_TOOLSETS env var is set but is not consulted — "
+            "use agent.disabled_toolsets in config.yaml to deny toolsets."
+        )
+    root_deny = config.get("disabled_toolsets")
+    if root_deny:
+        logger.warning(
+            "root-level disabled_toolsets: in config.yaml is not read — put it "
+            "under agent: (agent.disabled_toolsets) for it to take effect."
+        )
+
     if explicitly_configured and toolset_names:
         _warn_all_invalid_platform_toolsets(platform, platform_toolsets[platform])
     return enabled_toolsets

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -1323,3 +1323,75 @@ class TestLightpandaPostSetup:
         # Not in the forced-setup gate: a missing binary must not nag every
         # user who toggles the browser toolset.
         assert "lightpanda" not in _POST_SETUP_INSTALLED
+
+
+# ---------------------------------------------------------------------------
+# #97111 — deny declarations that nothing reads must fail loud
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_agent_disabled_toolsets_entry_warns(caplog):
+    """An unrecognized name in agent.disabled_toolsets must warn, not silently
+    leave the toolset enabled (a deny list is security posture)."""
+    from hermes_cli.tools_config import _get_platform_tools
+
+    config = {
+        "platform_toolsets": {"cli": ["hermes-cli"]},
+        "agent": {"disabled_toolsets": ["hermes-cli", "definitely-not-a-toolset"]},
+    }
+
+    with caplog.at_level(logging.WARNING, logger="hermes_cli.tools_config"):
+        enabled = _get_platform_tools(config, "cli")
+
+    warnings = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+    assert any("definitely-not-a-toolset" in m and "not a known toolset" in m for m in warnings), warnings
+    # the valid deny still applies
+    assert "hermes-cli" not in enabled
+
+
+def test_env_deny_var_warns_that_it_is_ignored(caplog, monkeypatch):
+    """HERMES_DISABLED_TOOLSETS env var is set but nothing reads it — warn."""
+    from hermes_cli.tools_config import _get_platform_tools
+
+    monkeypatch.setenv("HERMES_DISABLED_TOOLSETS", "terminal,memory")
+    config = {"platform_toolsets": {"cli": ["hermes-cli"]}}
+
+    with caplog.at_level(logging.WARNING, logger="hermes_cli.tools_config"):
+        _get_platform_tools(config, "cli")
+
+    warnings = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+    assert any("HERMES_DISABLED_TOOLSETS" in m and "not consulted" in m for m in warnings), warnings
+
+
+def test_root_level_disabled_toolsets_warns_that_it_is_ignored(caplog):
+    """A root-level disabled_toolsets: (beside toolsets:) is not read — warn."""
+    from hermes_cli.tools_config import _get_platform_tools
+
+    config = {
+        "platform_toolsets": {"cli": ["hermes-cli"]},
+        "disabled_toolsets": ["memory"],  # root, not agent.
+    }
+
+    with caplog.at_level(logging.WARNING, logger="hermes_cli.tools_config"):
+        enabled = _get_platform_tools(config, "cli")
+
+    warnings = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+    assert any("root-level disabled_toolsets" in m and "not read" in m for m in warnings), warnings
+    # the root deny is ignored -> memory still not explicitly affected here
+    # (just assert resolution did not crash and the warn fired)
+    assert isinstance(enabled, set)
+
+
+def test_valid_disabled_toolsets_no_warning(caplog):
+    """A well-formed agent.disabled_toolsets emits none of the #97111 warnings."""
+    from hermes_cli.tools_config import _get_platform_tools
+
+    config = {
+        "platform_toolsets": {"cli": ["hermes-cli"]},
+        "agent": {"disabled_toolsets": []},
+    }
+    with caplog.at_level(logging.WARNING, logger="hermes_cli.tools_config"):
+        _get_platform_tools(config, "cli")
+
+    messages = [r.getMessage() for r in caplog.records]
+    assert not any("not a known toolset" in m or "not consulted" in m or "not read" in m for m in messages)


### PR DESCRIPTION
Addresses #97111

### Problem
Toolset denial is security posture — a deny list must actually remove capability. Three declaration shapes did **nothing**, with no warning, so an operator hardening a deployment believed tools were off when they were still on ("no terminal access in a shared environment"):

1. **`HERMES_DISABLED_TOOLSETS` env var** — zero references anywhere in the repo; accepted and inert.
2. **Root-level `disabled_toolsets:`** (beside `toolsets:`) — the schema default lives at the root (`config_defaults.py`), but every consumer reads only `agent.disabled_toolsets`, so a root key is silently dead.
3. **An unrecognized name inside `agent.disabled_toolsets`** — dropped silently in the subtraction loop.

### Fix
At `_get_platform_tools` — the point where the deny is applied and tools resolve for a session — make all three fail **loud**:
- When `HERMES_DISABLED_TOOLSETS` is set, log a warning telling the operator to use `agent.disabled_toolsets`.
- When a root-level `disabled_toolsets:` is present, log a warning telling them to move it under `agent:`.
- Validate each `agent.disabled_toolsets` entry via `validate_toolset()` and warn on any unrecognized name (typo / renamed toolset), while still applying the valid denies.

No deny behavior changes — only previously-silent misdeclarations are now surfaced.

### What this PR does
- `hermes_cli/tools_config.py`: three fail-loud warnings in `_get_platform_tools`.
- `tests/hermes_cli/test_tools_config.py`: unknown entry warns + valid deny still applies; env var warns it's not consulted; root key warns it's not read; well-formed config emits none of the new warnings.

### How did I verify
- `pytest tests/hermes_cli/test_tools_config.py` → 49 passed, 6 skipped.
- Regression: with the code fix reverted, `test_unknown_agent_disabled_toolsets_entry_warns` and `test_root_level_disabled_toolsets_warns_that_it_is_ignored` fail (2 failed) and pass with it.

### Out of scope
- Actually wiring a root-level `disabled_toolsets:` / `HERMES_DISABLED_TOOLSETS` to deny (a behavior change): this PR makes the silent misdeclaration visible first. If the project wants those honored, that's a separate deliberate-config change.
- `-z` oneshot reads (#61184/#97101) and the eager-reconcile surfaces are separate.