### PR TITLE
test(skills): add contract and workflow test suites for github skills

### DIFF
--- a/tests/skills/_skill_test_utils.py
+++ b/tests/skills/_skill_test_utils.py
@@ -1,0 +1,33 @@
+"""Shared helper utilities for skill contract and discipline tests."""
+
+import re
+from pathlib import Path
+from typing import Any
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def parse_frontmatter_and_body(skill_path: Path) -> tuple[dict[str, Any], str]:
+    """Extract YAML frontmatter and body from a SKILL.md file."""
+    content = skill_path.read_text(encoding="utf-8")
+    assert content.startswith("---"), f"{skill_path}: SKILL.md must start with ---"
+    m = re.search(r"\n---\s*\n", content[3:])
+    assert m, f"{skill_path}: unclosed frontmatter"
+    fm = yaml.safe_load(content[3 : m.start() + 3])
+    assert isinstance(fm, dict), f"{skill_path}: frontmatter must be a YAML mapping"
+    body = content[m.end() + 3 :]
+    return fm, body
+
+
+def resolve_related_skills_in_repo(names: list[str]) -> list[str]:
+    """Check that each related skill name exists in skills/ or optional-skills/."""
+    missing = []
+    for name in names:
+        hits = (
+            list(REPO_ROOT.glob(f"skills/**/{name}/SKILL.md"))
+            + list(REPO_ROOT.glob(f"optional-skills/**/{name}/SKILL.md"))
+        )
+        if not hits:
+            missing.append(name)
+    return missing

--- a/tests/skills/_skill_test_utils.py
+++ b/tests/skills/_skill_test_utils.py
@@ -10,7 +10,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 
 def parse_frontmatter_and_body(skill_path: Path) -> tuple[dict[str, Any], str]:
     """Extract YAML frontmatter and body from a SKILL.md file."""
-    content = skill_path.read_text(encoding="utf-8")
+    content = skill_path.read_text(encoding="utf-8").lstrip("\ufeff\r\n\t ")
     assert content.startswith("---"), f"{skill_path}: SKILL.md must start with ---"
     m = re.search(r"\n---\s*\n", content[3:])
     assert m, f"{skill_path}: unclosed frontmatter"

--- a/tests/skills/test_github_code_review_skill.py
+++ b/tests/skills/test_github_code_review_skill.py
@@ -1,0 +1,103 @@
+"""Contract and methodology tests for the github-code-review skill."""
+
+import re
+from pathlib import Path
+import pytest
+
+from tests.skills._skill_test_utils import parse_frontmatter_and_body, resolve_related_skills_in_repo
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILL_MD = REPO_ROOT / "skills" / "github" / "github-code-review" / "SKILL.md"
+
+REQUIRED_SECTIONS = [
+    "## Prerequisites",
+    "## 1. Reviewing Local Changes (Pre-Push)",
+    "## 2. Reviewing a Pull Request on GitHub",
+    "## 3. Review Checklist",
+    "## 4. Pre-Push Review Workflow",
+    "## 5. PR Review Workflow (End-to-End)",
+]
+
+CHECKLIST_CATEGORIES = [
+    "### Correctness",
+    "### Security",
+    "### Code Quality",
+    "### Testing",
+    "### Performance",
+    "### Documentation",
+]
+
+REVIEW_OUTPUT_SECTIONS = [
+    "### Critical",
+    "### Warnings",
+    "### Suggestions",
+    "### Looks Good",
+]
+
+
+class TestGithubCodeReviewContract:
+    """Test that github-code-review adheres to the project hardline standards."""
+
+    def test_skill_file_exists(self):
+        assert SKILL_MD.is_file()
+
+    def test_frontmatter_required_fields(self):
+        fm, _ = parse_frontmatter_and_body(SKILL_MD)
+        for field in ("name", "description", "version", "author", "license", "platforms"):
+            assert field in fm, f"missing frontmatter field: {field}"
+        assert fm["name"] == "github-code-review"
+        hermes = fm["metadata"]["hermes"]
+        assert hermes["tags"]
+        assert "related_skills" in hermes
+
+    def test_description_hardline(self):
+        fm, _ = parse_frontmatter_and_body(SKILL_MD)
+        desc = fm["description"]
+        assert len(desc) <= 60, f"description is {len(desc)} chars; max allowed is 60"
+        assert desc.endswith("."), "description must end with a period"
+        assert not re.search(
+            r"\b(powerful|comprehensive|seamless|revolutionary|cutting-edge|state-of-the-art)\b",
+            desc,
+            re.I,
+        )
+
+    def test_related_skills_resolve_in_repo(self):
+        fm, _ = parse_frontmatter_and_body(SKILL_MD)
+        missing = resolve_related_skills_in_repo(fm["metadata"]["hermes"]["related_skills"])
+        assert not missing, f"related_skills entries do not resolve in repo: {missing}"
+
+    def test_no_machine_local_paths(self):
+        content = SKILL_MD.read_text(encoding="utf-8")
+        assert "/home/" not in content
+        assert not re.search(r"[A-Z]:\\\\Users", content)
+
+
+class TestGithubCodeReviewContentAndStructure:
+    """Test review workflows, checklist categories, and output standards."""
+
+    def test_required_sections_present_and_ordered(self):
+        _, body = parse_frontmatter_and_body(SKILL_MD)
+        positions = [body.index(section) for section in REQUIRED_SECTIONS]
+        assert positions == sorted(positions), "sections must follow structured workflow order"
+
+    def test_review_checklist_comprehensive(self):
+        _, body = parse_frontmatter_and_body(SKILL_MD)
+        for category in CHECKLIST_CATEGORIES:
+            assert category in body, f"checklist category {category} must be present"
+
+    def test_structured_output_format(self):
+        _, body = parse_frontmatter_and_body(SKILL_MD)
+        for section in REVIEW_OUTPUT_SECTIONS:
+            assert section in body, f"review output section {section} must be defined"
+
+    def test_formal_review_events_documented(self):
+        _, body = parse_frontmatter_and_body(SKILL_MD)
+        assert "APPROVE" in body
+        assert "REQUEST_CHANGES" in body
+        assert "COMMENT" in body
+
+    def test_local_git_diff_inspection_commands(self):
+        _, body = parse_frontmatter_and_body(SKILL_MD)
+        assert "git diff --staged" in body
+        assert "git diff main...HEAD" in body
+        assert "git diff main...HEAD --stat" in body

--- a/tests/skills/test_github_issues_skill.py
+++ b/tests/skills/test_github_issues_skill.py
@@ -1,0 +1,98 @@
+"""Contract and workflow tests for the github-issues skill."""
+
+import re
+from pathlib import Path
+import pytest
+
+from tests.skills._skill_test_utils import parse_frontmatter_and_body, resolve_related_skills_in_repo
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILL_MD = REPO_ROOT / "skills" / "github" / "github-issues" / "SKILL.md"
+
+REQUIRED_SECTIONS = [
+    "## Prerequisites",
+    "## 1. Viewing Issues",
+    "## 2. Creating Issues",
+    "## 3. Managing Issues",
+    "## 4. Issue Triage Workflow",
+    "## 5. Bulk Operations",
+    "## Quick Reference Table",
+]
+
+LINKING_KEYWORDS = ["Closes #", "Fixes #", "Resolves #"]
+
+
+class TestGithubIssuesContract:
+    """Test that github-issues adheres to the project hardline standards."""
+
+    def test_skill_file_exists(self):
+        assert SKILL_MD.is_file()
+
+    def test_frontmatter_required_fields(self):
+        fm, _ = parse_frontmatter_and_body(SKILL_MD)
+        for field in ("name", "description", "version", "author", "license", "platforms"):
+            assert field in fm, f"missing frontmatter field: {field}"
+        assert fm["name"] == "github-issues"
+        hermes = fm["metadata"]["hermes"]
+        assert hermes["tags"]
+        assert "related_skills" in hermes
+
+    def test_description_hardline(self):
+        fm, _ = parse_frontmatter_and_body(SKILL_MD)
+        desc = fm["description"]
+        assert len(desc) <= 60, f"description is {len(desc)} chars; max allowed is 60"
+        assert desc.endswith("."), "description must end with a period"
+        assert not re.search(
+            r"\b(powerful|comprehensive|seamless|revolutionary|cutting-edge|state-of-the-art)\b",
+            desc,
+            re.I,
+        )
+
+    def test_related_skills_resolve_in_repo(self):
+        fm, _ = parse_frontmatter_and_body(SKILL_MD)
+        missing = resolve_related_skills_in_repo(fm["metadata"]["hermes"]["related_skills"])
+        assert not missing, f"related_skills entries do not resolve in repo: {missing}"
+
+    def test_no_machine_local_paths(self):
+        content = SKILL_MD.read_text(encoding="utf-8")
+        assert "/home/" not in content
+        assert not re.search(r"[A-Z]:\\\\Users", content)
+
+
+class TestGithubIssuesContentAndStructure:
+    """Test issue management workflows and templates in github-issues."""
+
+    def test_required_sections_present_and_ordered(self):
+        _, body = parse_frontmatter_and_body(SKILL_MD)
+        positions = [body.index(section) for section in REQUIRED_SECTIONS]
+        assert positions == sorted(positions), "sections must follow structured workflow order"
+
+    def test_dual_mode_commands_documented(self):
+        _, body = parse_frontmatter_and_body(SKILL_MD)
+        assert "gh issue list" in body
+        assert "gh issue create" in body
+        assert "gh issue edit" in body
+        assert "gh issue comment" in body
+        assert "gh issue close" in body
+        assert "api.github.com/repos" in body
+
+    def test_issue_templates_included(self):
+        _, body = parse_frontmatter_and_body(SKILL_MD)
+        # Bug report template
+        assert "## Bug Description" in body
+        assert "## Steps to Reproduce" in body
+        assert "## Expected Behavior" in body
+        # Feature request template
+        assert "## Feature Description" in body
+        assert "## Motivation" in body
+        assert "## Proposed Solution" in body
+
+    def test_pr_linking_keywords_documented(self):
+        _, body = parse_frontmatter_and_body(SKILL_MD)
+        for kw in LINKING_KEYWORDS:
+            assert kw in body, f"keyword {kw} must be documented for issue linking"
+
+    def test_triage_workflow_steps(self):
+        _, body = parse_frontmatter_and_body(SKILL_MD)
+        assert "Issue Triage Workflow" in body
+        assert "needs-triage" in body

--- a/tests/skills/test_github_pr_workflow_skill.py
+++ b/tests/skills/test_github_pr_workflow_skill.py
@@ -1,0 +1,105 @@
+"""Contract and workflow discipline tests for the github-pr-workflow skill."""
+
+import re
+from pathlib import Path
+import pytest
+
+from tests.skills._skill_test_utils import parse_frontmatter_and_body, resolve_related_skills_in_repo
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILL_MD = REPO_ROOT / "skills" / "github" / "github-pr-workflow" / "SKILL.md"
+
+REQUIRED_SECTIONS = [
+    "## Prerequisites",
+    "## 1. Branch Creation",
+    "## 2. Making Commits",
+    "## 3. Pushing and Creating a PR",
+    "## 4. Monitoring CI Status",
+    "## 5. Auto-Fixing CI Failures",
+    "## 6. Merging",
+    "## 7. Complete Workflow Example",
+    "## Useful PR Commands Reference",
+]
+
+CONVENTIONAL_COMMIT_TYPES = [
+    "feat",
+    "fix",
+    "refactor",
+    "docs",
+    "test",
+    "ci",
+    "chore",
+    "perf",
+]
+
+
+class TestGithubPrWorkflowContract:
+    """Test that github-pr-workflow adheres to the project hardline standards."""
+
+    def test_skill_file_exists(self):
+        assert SKILL_MD.is_file()
+
+    def test_frontmatter_required_fields(self):
+        fm, _ = parse_frontmatter_and_body(SKILL_MD)
+        for field in ("name", "description", "version", "author", "license", "platforms"):
+            assert field in fm, f"missing frontmatter field: {field}"
+        assert fm["name"] == "github-pr-workflow"
+        hermes = fm["metadata"]["hermes"]
+        assert hermes["tags"]
+        assert "related_skills" in hermes
+
+    def test_description_hardline(self):
+        fm, _ = parse_frontmatter_and_body(SKILL_MD)
+        desc = fm["description"]
+        assert len(desc) <= 60, f"description is {len(desc)} chars; max allowed is 60"
+        assert desc.endswith("."), "description must end with a period"
+        assert not re.search(
+            r"\b(powerful|comprehensive|seamless|revolutionary|cutting-edge|state-of-the-art)\b",
+            desc,
+            re.I,
+        )
+
+    def test_related_skills_resolve_in_repo(self):
+        fm, _ = parse_frontmatter_and_body(SKILL_MD)
+        missing = resolve_related_skills_in_repo(fm["metadata"]["hermes"]["related_skills"])
+        assert not missing, f"related_skills entries do not resolve in repo: {missing}"
+
+    def test_no_machine_local_paths(self):
+        content = SKILL_MD.read_text(encoding="utf-8")
+        assert "/home/" not in content
+        assert not re.search(r"[A-Z]:\\\\Users", content)
+
+
+class TestGithubPrWorkflowContentAndStructure:
+    """Test workflow instructions and dual-mode tooling in github-pr-workflow."""
+
+    def test_required_sections_present_and_ordered(self):
+        _, body = parse_frontmatter_and_body(SKILL_MD)
+        positions = [body.index(section) for section in REQUIRED_SECTIONS]
+        assert positions == sorted(positions), "sections must follow chronological PR lifecycle order"
+
+    def test_dual_mode_tooling_documented(self):
+        _, body = parse_frontmatter_and_body(SKILL_MD)
+        # CLI tool gh
+        assert "gh pr create" in body
+        assert "gh pr checks" in body
+        assert "gh pr merge" in body
+        # REST API / curl fallback
+        assert "api.github.com/repos" in body
+        assert "GITHUB_TOKEN" in body
+
+    def test_conventional_commits_documented(self):
+        _, body = parse_frontmatter_and_body(SKILL_MD)
+        assert "Conventional Commits" in body
+        for commit_type in CONVENTIONAL_COMMIT_TYPES:
+            assert f"`{commit_type}`" in body, f"commit type {commit_type} must be listed"
+
+    def test_ci_auto_fix_loop_discipline(self):
+        _, body = parse_frontmatter_and_body(SKILL_MD)
+        assert "Auto-Fix Loop Pattern" in body
+        assert "3 attempts" in body or "up to 3" in body.lower()
+
+    def test_merge_methods_documented(self):
+        _, body = parse_frontmatter_and_body(SKILL_MD)
+        assert "--squash" in body or '"squash"' in body
+        assert "--delete-branch" in body or "git push origin --delete" in body


### PR DESCRIPTION
### Summary of changes
- Adds dedicated hermetic contract and workflow discipline test suites for the core GitHub bundled skills:
  - `github-pr-workflow` (`tests/skills/test_github_pr_workflow_skill.py`): 10 tests covering PR lifecycle order, `gh` vs `curl` dual-mode tooling, Conventional Commits format, CI auto-fix loop pattern, and merge methods.
  - `github-issues` (`tests/skills/test_github_issues_skill.py`): 10 tests covering issue lifecycle, dual-mode commands, bug & feature request templates, PR linking keywords, and triage workflow.
  - `github-code-review` (`tests/skills/test_github_code_review_skill.py`): 10 tests covering pre-push review diffs, 6-category review checklist, structured output format (Critical/Warnings/Suggestions/Looks Good), and formal review events.
- Extracts shared skill testing utilities in `tests/skills/_skill_test_utils.py`.

### How to test
```bash
pytest tests/skills/test_github_pr_workflow_skill.py tests/skills/test_github_issues_skill.py tests/skills/test_github_code_review_skill.py -v
# Expected: 30 passed in ~0.5s

python scripts/check-windows-footguns.py tests/skills/_skill_test_utils.py tests/skills/test_github_pr_workflow_skill.py tests/skills/test_github_issues_skill.py tests/skills/test_github_code_review_skill.py
# Expected: 0 footguns found
```

### Platforms tested
- macOS (Darwin aarch64, Python 3.11)