### PR TITLE
fix(compressor): compaction now actually frees historical image bytes — 413 recovery recovers (#89938, salvage #90001)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1863,9 +1863,15 @@ def _strip_historical_media(messages: List[Dict[str, Any]]) -> List[Dict[str, An
     placeholder so the outgoing request stops re-shipping the same multi-MB
     base-64 image blobs on every turn.
 
-    If no user message carries images, the list is returned unchanged.
-    If the only user message with images is the very first one (nothing
-    earlier to strip), the list is returned unchanged.
+    Tool results carry their own images (``vision_analyze`` and friends) and
+    are aged out on their own timeline: every image-bearing tool message
+    except the newest one is stripped, wherever it sits. Without that, a
+    session whose images arrive from tools rather than attachments has no
+    anchor to be "before" and keeps every blob forever (#89938).
+
+    If no message carries images at all, the list is returned unchanged. So
+    is a list whose only image-bearing user message is the very first one and
+    which has no tool-result images (nothing to strip in either rule).
 
     Shallow copies of touched messages only; input is never mutated.
     Port of Kilo-Org/kilocode#9434 (adapted for the OpenAI-style message
@@ -1889,15 +1895,48 @@ def _strip_historical_media(messages: List[Dict[str, Any]]) -> List[Dict[str, An
             anchor = i
             break
 
-    if anchor <= 0:
-        # No image-bearing user message, or it's the very first message —
-        # nothing before it to strip.
+    # Newest tool message carrying an image. Tool-result images
+    # (``vision_analyze``, screenshot-returning tools) accumulate on their own
+    # timeline and the user anchor never protects the stale ones: a session
+    # whose only image-bearing user message is the FIRST one leaves
+    # ``anchor <= 0`` and strips nothing at all, so twenty tool results keep
+    # multi-MB of base64 in every request body until the provider answers 413
+    # -- and the 413 handler's recovery compaction lands right back here and
+    # frees nothing, which is the wedge in #89938. Keep the newest tool image,
+    # since that is the one the model is reasoning about, and drop every older
+    # one wherever it sits.
+    tool_anchor = -1
+    for i in range(len(messages) - 1, -1, -1):
+        msg = messages[i]
+        if not isinstance(msg, dict):
+            continue
+        if msg.get("role") != "tool":
+            continue
+        if _content_has_images(msg.get("content")):
+            tool_anchor = i
+            break
+
+    if anchor <= 0 and tool_anchor < 0:
+        # No image-bearing user message (or it is the very first, with nothing
+        # earlier to strip), and no tool-result images to age out either.
         return messages
+
+    def _is_stale(index: int, message: Dict[str, Any]) -> bool:
+        # Rule 1 (unchanged): everything before the newest image-bearing user
+        # message. Checked first so a tool result that is the newest of its
+        # kind but still sits before that anchor keeps today's behaviour.
+        if 0 < anchor and index < anchor:
+            return True
+        # Rule 2: a tool result whose image has been superseded by a newer
+        # one. Applies inside the protected tail as well -- the tail exists to
+        # preserve conversational continuity, not to pin bytes the model has
+        # already moved past.
+        return message.get("role") == "tool" and index != tool_anchor
 
     changed = False
     result: List[Dict[str, Any]] = []
     for i, msg in enumerate(messages):
-        if i >= anchor or not isinstance(msg, dict):
+        if not isinstance(msg, dict) or not _is_stale(i, msg):
             result.append(msg)
             continue
         content = msg.get("content")

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1869,9 +1869,19 @@ def _strip_historical_media(messages: List[Dict[str, Any]]) -> List[Dict[str, An
     session whose images arrive from tools rather than attachments has no
     anchor to be "before" and keeps every blob forever (#89938).
 
+    The opening attachment gets the same keep-newest treatment: when the only
+    image-bearing user message is the very first one and a newer tool-result
+    image exists, the first message's images are replaced too (rule 1b) —
+    otherwise a session that opens with an attachment re-ships it forever.
+
+    Tool results are matched in both shapes: OpenAI-style content-part lists
+    and the native ``{_multimodal: True, content: [...]}`` dict envelope.
+    Image parts of all three wire shapes (Chat Completions ``image_url``,
+    Responses ``input_image``, Anthropic-native ``image``) are recognized.
+
     If no message carries images at all, the list is returned unchanged. So
     is a list whose only image-bearing user message is the very first one and
-    which has no tool-result images (nothing to strip in either rule).
+    which has no tool-result images (nothing to strip in any rule).
 
     Shallow copies of touched messages only; input is never mutated.
     Port of Kilo-Org/kilocode#9434 (adapted for the OpenAI-style message
@@ -1912,7 +1922,12 @@ def _strip_historical_media(messages: List[Dict[str, Any]]) -> List[Dict[str, An
             continue
         if msg.get("role") != "tool":
             continue
-        if _content_has_images(msg.get("content")):
+        # ``_tool_content_has_images`` (not the bare list matcher) so the
+        # native ``{_multimodal: True, content: [...]}`` dict envelope that
+        # vision_analyze can leave in the live list anchors here too —
+        # otherwise the newest envelope-shaped result is invisible to the
+        # scan and rule 2 strips it as if it were stale (#89938/#89965 gap).
+        if _tool_content_has_images(msg.get("content")):
             tool_anchor = i
             break
 
@@ -1927,6 +1942,18 @@ def _strip_historical_media(messages: List[Dict[str, Any]]) -> List[Dict[str, An
         # kind but still sits before that anchor keeps today's behaviour.
         if 0 < anchor and index < anchor:
             return True
+        # Rule 1b: the opening attachment ages out once something newer
+        # supersedes it. When the ONLY image-bearing user message is the very
+        # first one (``anchor == 0``) and newer tool-result images exist, the
+        # model has moved on — but the opening base64 blob used to survive
+        # every compaction forever, which is half the wedge in #89938 (the
+        # reported session opened with a ~200KB poster). The strip replaces
+        # the image with a text placeholder, so the row keeps non-empty
+        # user-role text and the zero-user-turn guard (#58753) is satisfied.
+        # When nothing newer exists the opening image IS the newest image and
+        # is kept, consistent with keep-newest everywhere else.
+        if anchor == 0 and index == 0 and tool_anchor > 0:
+            return True
         # Rule 2: a tool result whose image has been superseded by a newer
         # one. Applies inside the protected tail as well -- the tail exists to
         # preserve conversational continuity, not to pin bytes the model has
@@ -1940,6 +1967,24 @@ def _strip_historical_media(messages: List[Dict[str, Any]]) -> List[Dict[str, An
             result.append(msg)
             continue
         content = msg.get("content")
+        # Native multimodal dict envelope ({_multimodal: True, content: [...]})
+        # — the shape vision_analyze hands back before adapters unwrap it.
+        # ``_strip_images_from_content`` only understands part lists, so route
+        # this through the tool-message stripper, which collapses the envelope
+        # to its text summary and drops the stale api_content sidecar.
+        if (
+            msg.get("role") == "tool"
+            and isinstance(content, dict)
+            and content.get("_multimodal")
+            and _tool_content_has_images(content)
+        ):
+            new_msg = _strip_images_from_tool_msg(msg)
+            if new_msg is None:
+                result.append(msg)
+                continue
+            result.append(new_msg)
+            changed = True
+            continue
         if not _content_has_images(content):
             result.append(msg)
             continue

--- a/tests/agent/test_compressor_historical_media.py
+++ b/tests/agent/test_compressor_historical_media.py
@@ -107,6 +107,114 @@ class TestStripHistoricalMedia:
         # Second pass is a no-op — no images left before the anchor.
         assert second is first
 
+    def test_strips_stale_tool_result_images_when_no_user_image_exists(self):
+        """#89938: vision_analyze results are the only images in the session.
+
+        Before this rule the anchor stayed at -1 and the list came back
+        untouched, so every base64 blob rode along on every request.
+        """
+        msgs = [
+            {"role": "user", "content": "look at these"},
+            {"role": "tool", "tool_call_id": "a", "content": [TEXT, IMG_URL]},
+            {"role": "tool", "tool_call_id": "b", "content": [TEXT, IMG_URL]},
+            {"role": "tool", "tool_call_id": "c", "content": [TEXT, IMG_URL]},
+        ]
+        out = _strip_historical_media(msgs)
+
+        assert not _content_has_images(out[1]["content"])
+        assert not _content_has_images(out[2]["content"])
+        # The newest tool image is what the model is reasoning about.
+        assert _content_has_images(out[3]["content"])
+
+    def test_first_message_user_image_no_longer_blocks_tool_stripping(self):
+        """#89938's other half: ``anchor <= 0`` used to return early.
+
+        One attachment on the opening message plus a run of vision tool calls
+        is the exact reproduction in the report - and the old early return
+        meant the 413 recovery compaction freed nothing.
+        """
+        msgs = [
+            {"role": "user", "content": [TEXT, IMG_URL]},
+            {"role": "tool", "tool_call_id": "a", "content": [TEXT, IMG_URL]},
+            {"role": "tool", "tool_call_id": "b", "content": [TEXT, IMG_URL]},
+        ]
+        out = _strip_historical_media(msgs)
+
+        # The opening attachment keeps today's treatment: nothing precedes it.
+        assert _content_has_images(out[0]["content"])
+        assert not _content_has_images(out[1]["content"])
+        assert _content_has_images(out[2]["content"])
+
+    def test_newest_tool_image_survives_inside_the_protected_tail(self):
+        msgs = [
+            {"role": "user", "content": "hi"},
+            {"role": "user", "content": [TEXT, IMG_URL]},
+            {"role": "tool", "tool_call_id": "a", "content": [TEXT, IMG_URL]},
+            {"role": "tool", "tool_call_id": "b", "content": [TEXT, IMG_URL]},
+        ]
+        out = _strip_historical_media(msgs)
+
+        # The user anchor is index 1, so nothing before it changes and the
+        # anchor itself is kept byte-for-byte (test_compressor_zero_user_guard
+        # depends on that).
+        assert out[1] is msgs[1]
+        assert not _content_has_images(out[2]["content"])
+        assert _content_has_images(out[3]["content"])
+
+    def test_tool_image_before_the_user_anchor_is_still_stripped(self):
+        """Rule 1 keeps precedence over rule 2 where the two disagree."""
+        msgs = [
+            {"role": "tool", "tool_call_id": "a", "content": [TEXT, IMG_URL]},
+            {"role": "assistant", "content": "ok"},
+            {"role": "user", "content": [TEXT, IMG_URL]},
+        ]
+        out = _strip_historical_media(msgs)
+
+        # Index 0 is the newest *tool* image, but it sits before the user
+        # anchor, which has always stripped it. That must not regress.
+        assert not _content_has_images(out[0]["content"])
+        assert _content_has_images(out[2]["content"])
+
+    def test_unchanged_when_nothing_carries_images(self):
+        msgs = [
+            {"role": "user", "content": [TEXT]},
+            {"role": "tool", "tool_call_id": "a", "content": [TEXT]},
+        ]
+        assert _strip_historical_media(msgs) is msgs
+
+    def test_single_tool_image_is_left_alone(self):
+        msgs = [
+            {"role": "user", "content": "look"},
+            {"role": "tool", "tool_call_id": "a", "content": [TEXT, IMG_URL]},
+        ]
+        assert _strip_historical_media(msgs) is msgs
+
+    def test_idempotent_over_tool_images(self):
+        msgs = [
+            {"role": "tool", "tool_call_id": "a", "content": [TEXT, IMG_URL]},
+            {"role": "tool", "tool_call_id": "b", "content": [TEXT, IMG_URL]},
+        ]
+        first = _strip_historical_media(msgs)
+        assert first is not msgs
+        assert _strip_historical_media(first) is first
+
+    def test_stripped_tool_message_drops_its_api_content_sidecar(self):
+        """Replaying the sidecar would resend the bytes the strip removed."""
+        msgs = [
+            {
+                "role": "tool",
+                "tool_call_id": "a",
+                "content": [TEXT, IMG_URL],
+                "api_content": "the exact multimodal bytes sent last turn",
+            },
+            {"role": "tool", "tool_call_id": "b", "content": [TEXT, IMG_URL]},
+        ]
+        out = _strip_historical_media(msgs)
+
+        assert "api_content" not in out[0]
+        # The input list is never mutated.
+        assert "api_content" in msgs[0]
+
     def test_non_dict_messages_pass_through(self):
         msgs = [
             "not-a-dict",  # shouldn't crash
@@ -166,3 +274,56 @@ class TestCompressIntegration:
             assert not _content_has_images(m.get("content")), (
                 f"Stale image in {m.get('role')!r} message after compression"
             )
+
+    def test_compress_frees_stale_vision_tool_results(self, compressor):
+        """#89938 end to end: the 413 recovery compaction must free bytes.
+
+        The reported session had one attachment on the opening message and a
+        run of ``vision_analyze`` results after it. ``anchor <= 0`` made this
+        pass a no-op, so every recovery compaction returned a body that was
+        still multi-MB and the provider answered 413 again - seven times in
+        thirteen minutes.
+        """
+
+        def call(idx: str):
+            return [
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": idx,
+                            "type": "function",
+                            "function": {"name": "vision_analyze", "arguments": "{}"},
+                        }
+                    ],
+                },
+                {"role": "tool", "tool_call_id": idx, "content": [TEXT, IMG_URL]},
+            ]
+
+        msgs = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": [TEXT, IMG_URL]},  # the ONLY user image, first
+            *call("a"),
+            *call("b"),
+            {"role": "user", "content": "and this one?"},
+            *call("c"),
+        ]
+        with patch.object(compressor, "_generate_summary", return_value="SUMMARY TEXT"):
+            out = compressor.compress(msgs, current_tokens=60_000)
+
+        with_images = [m for m in out if isinstance(m, dict) and _content_has_images(m.get("content"))]
+        # Exactly one survivor: the newest vision result. The opening
+        # attachment is protect_first_n material and may or may not survive
+        # the summary window, so assert on what must NOT be there instead.
+        assert len(with_images) <= 2
+        stale_tool_images = [
+            m for m in out
+            if isinstance(m, dict)
+            and m.get("role") == "tool"
+            and _content_has_images(m.get("content"))
+            and m.get("tool_call_id") != "c"
+        ]
+        assert stale_tool_images == [], (
+            "vision_analyze results a, b still carry base64 after compression"
+        )

--- a/tests/agent/test_compressor_historical_media.py
+++ b/tests/agent/test_compressor_historical_media.py
@@ -140,10 +140,73 @@ class TestStripHistoricalMedia:
         ]
         out = _strip_historical_media(msgs)
 
-        # The opening attachment keeps today's treatment: nothing precedes it.
-        assert _content_has_images(out[0]["content"])
+        # Rule 1b: newer tool images supersede the opening attachment, so
+        # its bytes age out too — the row survives with a text placeholder.
+        assert not _content_has_images(out[0]["content"])
+        assert out[0]["role"] == "user"
         assert not _content_has_images(out[1]["content"])
         assert _content_has_images(out[2]["content"])
+
+    def test_first_message_image_kept_when_it_is_the_only_image(self):
+        """Rule 1b only fires when something newer supersedes the opener."""
+        msgs = [
+            {"role": "user", "content": [TEXT, IMG_URL]},
+            {"role": "assistant", "content": "looked"},
+            {"role": "tool", "tool_call_id": "a", "content": [TEXT]},
+        ]
+        assert _strip_historical_media(msgs) is msgs
+
+    def test_multimodal_envelope_tool_results_age_out(self):
+        """The native ``{_multimodal: True}`` dict envelope must strip too.
+
+        vision_analyze hands back this shape before adapters unwrap it; the
+        bare list matcher never saw it, so envelope-shaped results kept their
+        base64 through every compaction (#89965's shape-coverage gap).
+        """
+        env = {
+            "_multimodal": True,
+            "text_summary": "a poster",
+            "content": [TEXT, IMG_URL],
+        }
+        msgs = [
+            {"role": "user", "content": "look"},
+            {"role": "tool", "tool_call_id": "a", "content": dict(env), "api_content": "stale"},
+            {"role": "tool", "tool_call_id": "b", "content": dict(env)},
+        ]
+        out = _strip_historical_media(msgs)
+
+        # Older envelope collapses to its text summary; sidecar dropped.
+        assert isinstance(out[1]["content"], str)
+        assert "a poster" in out[1]["content"]
+        assert "api_content" not in out[1]
+        assert out[1]["tool_call_id"] == "a"
+        # Newest envelope is the anchor and survives byte-for-byte.
+        assert out[2] is msgs[2]
+
+    def test_all_three_wire_shapes_strip_in_tool_results(self):
+        """Chat Completions, Responses, and Anthropic-native parts all age."""
+        for img in (IMG_URL, INPUT_IMG, ANTHROPIC_IMG):
+            msgs = [
+                {"role": "tool", "tool_call_id": "a", "content": [TEXT, dict(img)]},
+                {"role": "tool", "tool_call_id": "b", "content": [TEXT, dict(img)]},
+            ]
+            out = _strip_historical_media(msgs)
+            assert not _content_has_images(out[0]["content"]), img["type"]
+            assert _content_has_images(out[1]["content"]), img["type"]
+
+    def test_deterministic_double_run(self):
+        """Running the strip twice yields byte-identical output."""
+        import json
+
+        msgs = [
+            {"role": "user", "content": [TEXT, IMG_URL]},
+            {"role": "tool", "tool_call_id": "a", "content": [TEXT, IMG_URL]},
+            {"role": "tool", "tool_call_id": "b", "content": [TEXT, INPUT_IMG]},
+        ]
+        first = _strip_historical_media(msgs)
+        second = _strip_historical_media(first)
+        assert json.dumps(first, sort_keys=True) == json.dumps(second, sort_keys=True)
+        assert second is first  # second pass is a no-op
 
     def test_newest_tool_image_survives_inside_the_protected_tail(self):
         msgs = [


### PR DESCRIPTION
## Summary

Fixes #89938 — the HTTP 413 wedge where base64 images in tool results re-ship on every turn and the 413 handler's recovery compaction frees nothing (7 compactions in 13 minutes, all below 200K tokens, all answered 413).

This is a **salvage of #90001 by @jackulau**, cherry-picked with authorship preserved. Jack's commit fixes the exact anchor bug: `_strip_historical_media` anchored only on the newest image-bearing *user* message and returned untouched when `anchor <= 0`, so a session whose images arrive from `vision_analyze` (plus one opening attachment) never stripped anything. His fix ages tool-result images on their own timeline — keep the newest, strip every older one wherever it sits, including inside the protected tail.

Credit also to **@Kewe63 (#89965)** for the sharpest gap analysis of this bug: first-message user images, all three image part shapes, `api_content` sidecar staleness, and determinism requirements. Those gaps are all covered here — but at **compaction time only**. The request-time half of #89965 was rejected on the cache invariant (rewriting per-request payloads mid-conversation changes the request prefix and breaks prompt caching), not on correctness; the analysis itself was excellent and directly shaped the follow-up commits.

## Changes

**Cherry-picked from #90001 (author: @jackulau)** — `8d62295e91`
- `_strip_historical_media` gains a `tool_anchor` (newest image-bearing tool message). Rule 2: any image-bearing tool result that isn't the newest is stripped, wherever it sits. Rule 1 (user anchor) keeps precedence. Early return now fires only when neither rule can act.
- 9 new tests in `tests/agent/test_compressor_historical_media.py`.

**Widening (this salvage)** — `e8069afd57`
- **Rule 1b — first-message user image ages out**: when the only image-bearing user message is the very first one (`anchor == 0`) and a newer tool-result image exists, the opening attachment's images are replaced with a text placeholder too. The row keeps non-empty user-role text, so the zero-user-turn guard (#58753) and role alternation are untouched. When nothing newer exists the opening image *is* the newest image and is kept.
- **Native `{_multimodal: True, content: [...]}` envelopes** now both anchor (newest is kept) and strip (older collapse to their `text_summary` via `_strip_images_from_tool_msg`). Previously the bare list matcher never saw this shape, so envelope-shaped results kept their base64 through every compaction.
- **All three wire shapes** — Chat Completions `image_url`, Responses `input_image`, Anthropic-native `image` — were already matched by `_IMAGE_PART_TYPES`; tests now pin each shape explicitly.
- **Stale `api_content` sidecars** are dropped from every compaction-rewritten message (reuses `drop_stale_api_content` from `agent/turn_context.py`, consistent with #97125), so replay cannot resend pre-rewrite bytes.
- **Determinism** pinned by test: running the strip twice returns the same object (no-op) with byte-identical JSON.

## Cache safety

Per the design ruling: **images are never removed or rewritten in live chat history or per-request payloads mid-conversation.** This strip runs ONLY inside `compress_context` → `ContextCompressor.compress()` (`_strip_historical_media` is called once, after `_sanitize_tool_pairs`, on the compacted list). Context compression is the one sanctioned cache break — it already invalidates the prompt-cache prefix — so this change introduces **no new cache invalidation**. Nothing here touches `api_messages` at request-build time; #89965's request-time eviction was deliberately not cherry-picked for exactly this reason.

## 413 → compaction routing

The 413 handler does route into this code: `agent/error_classifier.py:1352` classifies `status_code == 413` as `FailoverReason.payload_too_large`; `agent/conversation_loop.py` (~5639) then calls `agent._compress_context(...)` → `agent/conversation_compression.py:compress_context` → `agent.context_compressor.compress` (line 3492) → `_strip_historical_media` on the compacted output. Before this PR that terminal step was a no-op for the reported session shape, which is why recovery never freed bytes; now it does.

## Validation

| Check | Result |
|---|---|
| `tests/agent/test_compressor_historical_media.py` (incl. 5 new widening tests) | ✅ pass |
| `tests/agent/test_context_compressor.py` | ✅ pass |
| `tests/agent/test_compressor_zero_user_guard.py` | ✅ pass |
| `tests/run_agent/test_69078_image_corrupt_recovery.py` | ✅ pass |
| Combined (memory-capped `MemoryMax=8G`, `-o addopts=`) | ✅ 192 passed |
| `ruff check` on touched files | ✅ clean |
| Live A/B (below) | ✅ all assertions pass |
| Attribution audit (`scripts/audit_pr_attribution.py`) | ✅ all emails mapped |

**Live repro:** built the issue's exact shape (first user message with a real base64 PNG attachment + 6 `vision_analyze` tool results across all three image part shapes + text turns) and called the real `_strip_historical_media`. **BEFORE** (origin/main copy): returns the identical list object — 563,219 B in, 563,219 B out, nothing freed (the wedge). **AFTER** (this branch): 563,219 B → 82,379 B (**−85.4%**); the sole surviving image is the newest tool result; the first-message image is a text placeholder on an intact user row; role sequence and `tool_call_id` pairing byte-identical to input; `api_content` sidecars gone from every rewritten row; double-run is a byte-identical no-op. Envelope-shaped results: 160,721 B → 80,448 B on this branch vs untouched on main.

## Infographic

![infographic](https://v3b.fal.media/files/b/0aa82735/60fuhtyKgSWRnDia76ERb_p1kQkuvl.png)

