### PR TITLE
test(skills): add contract and workflow test suites for apple ecosystem skills

### DIFF
--- a/tests/skills/_skill_test_utils.py
+++ b/tests/skills/_skill_test_utils.py
@@ -1,0 +1,33 @@
+"""Shared helper utilities for skill contract and discipline tests."""
+
+import re
+from pathlib import Path
+from typing import Any
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def parse_frontmatter_and_body(skill_path: Path) -> tuple[dict[str, Any], str]:
+    """Extract YAML frontmatter and body from a SKILL.md file."""
+    content = skill_path.read_text(encoding="utf-8")
+    assert content.startswith("---"), f"{skill_path}: SKILL.md must start with ---"
+    m = re.search(r"\n---\s*\n", content[3:])
+    assert m, f"{skill_path}: unclosed frontmatter"
+    fm = yaml.safe_load(content[3 : m.start() + 3])
+    assert isinstance(fm, dict), f"{skill_path}: frontmatter must be a YAML mapping"
+    body = content[m.end() + 3 :]
+    return fm, body
+
+
+def resolve_related_skills_in_repo(names: list[str]) -> list[str]:
+    """Check that each related skill name exists in skills/ or optional-skills/."""
+    missing = []
+    for name in names:
+        hits = (
+            list(REPO_ROOT.glob(f"skills/**/{name}/SKILL.md"))
+            + list(REPO_ROOT.glob(f"optional-skills/**/{name}/SKILL.md"))
+        )
+        if not hits:
+            missing.append(name)
+    return missing

--- a/tests/skills/test_apple_notes_skill.py
+++ b/tests/skills/test_apple_notes_skill.py
@@ -1,0 +1,96 @@
+"""Contract and workflow tests for the apple-notes skill."""
+
+import re
+from pathlib import Path
+import pytest
+
+from tests.skills._skill_test_utils import parse_frontmatter_and_body, resolve_related_skills_in_repo
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILL_MD = REPO_ROOT / "skills" / "apple" / "apple-notes" / "SKILL.md"
+
+REQUIRED_SECTIONS = [
+    "## Prerequisites",
+    "## When to Use",
+    "## When NOT to Use",
+    "## Quick Reference",
+    "## Limitations",
+    "## Rules",
+]
+
+MEMO_COMMANDS = [
+    "memo notes",
+    "memo notes -f",
+    "memo notes -s",
+    "memo notes -a",
+    "memo notes -e",
+    "memo notes -d",
+    "memo notes -m",
+    "memo notes -ex",
+]
+
+
+class TestAppleNotesContract:
+    """Test that apple-notes adheres to the project hardline standards."""
+
+    def test_skill_file_exists(self):
+        assert SKILL_MD.is_file()
+
+    def test_frontmatter_required_fields(self):
+        fm, _ = parse_frontmatter_and_body(SKILL_MD)
+        for field in ("name", "description", "version", "author", "license", "platforms"):
+            assert field in fm, f"missing frontmatter field: {field}"
+        assert fm["name"] == "apple-notes"
+        assert fm["platforms"] == ["macos"], "skill is macOS-specific"
+        hermes = fm["metadata"]["hermes"]
+        assert hermes["tags"]
+        assert "related_skills" in hermes
+
+    def test_prerequisites_commands(self):
+        fm, _ = parse_frontmatter_and_body(SKILL_MD)
+        assert fm.get("prerequisites", {}).get("commands") == ["memo"]
+
+    def test_description_hardline(self):
+        fm, _ = parse_frontmatter_and_body(SKILL_MD)
+        desc = fm["description"]
+        assert len(desc) <= 60, f"description is {len(desc)} chars; max allowed is 60"
+        assert desc.endswith("."), "description must end with a period"
+        assert not re.search(
+            r"\b(powerful|comprehensive|seamless|revolutionary|cutting-edge|state-of-the-art)\b",
+            desc,
+            re.I,
+        )
+
+    def test_related_skills_resolve_in_repo(self):
+        fm, _ = parse_frontmatter_and_body(SKILL_MD)
+        missing = resolve_related_skills_in_repo(fm["metadata"]["hermes"]["related_skills"])
+        assert not missing, f"related_skills entries do not resolve in repo: {missing}"
+
+    def test_no_machine_local_paths(self):
+        content = SKILL_MD.read_text(encoding="utf-8")
+        assert "/home/" not in content
+        assert not re.search(r"[A-Z]:\\\\Users", content)
+
+
+class TestAppleNotesContentAndStructure:
+    """Test documentation structure, CLI commands, and limitations in apple-notes."""
+
+    def test_required_sections_present_and_ordered(self):
+        _, body = parse_frontmatter_and_body(SKILL_MD)
+        positions = [body.index(section) for section in REQUIRED_SECTIONS]
+        assert positions == sorted(positions), "sections must follow structured order"
+
+    def test_memo_subcommands_documented(self):
+        _, body = parse_frontmatter_and_body(SKILL_MD)
+        for cmd in MEMO_COMMANDS:
+            assert cmd in body, f"command {cmd} must be documented"
+
+    def test_editor_environment_discipline(self):
+        _, body = parse_frontmatter_and_body(SKILL_MD)
+        assert "$EDITOR" in body, "must document $EDITOR environment variable requirement for -a"
+
+    def test_limitations_and_boundary_rules(self):
+        _, body = parse_frontmatter_and_body(SKILL_MD)
+        assert "Limitations" in body
+        assert "memory" in body, "must document contrast with internal memory tool"
+        assert "obsidian" in body, "must document contrast with obsidian skill"

--- a/tests/skills/test_apple_reminders_skill.py
+++ b/tests/skills/test_apple_reminders_skill.py
@@ -1,0 +1,99 @@
+"""Contract and workflow tests for the apple-reminders skill."""
+
+import re
+from pathlib import Path
+import pytest
+
+from tests.skills._skill_test_utils import parse_frontmatter_and_body, resolve_related_skills_in_repo
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILL_MD = REPO_ROOT / "skills" / "apple" / "apple-reminders" / "SKILL.md"
+
+REQUIRED_SECTIONS = [
+    "## Prerequisites",
+    "## When to Use",
+    "## When NOT to Use",
+    "## Quick Reference",
+    "## Due Time vs Alarm / Early Nudge",
+    "## Date Formats",
+    "## Rules",
+]
+
+REMINDCTL_COMMANDS = [
+    "remindctl today",
+    "remindctl tomorrow",
+    "remindctl week",
+    "remindctl overdue",
+    "remindctl all",
+    "remindctl list",
+    "remindctl add",
+    "remindctl complete",
+    "remindctl delete",
+]
+
+
+class TestAppleRemindersContract:
+    """Test that apple-reminders adheres to the project hardline standards."""
+
+    def test_skill_file_exists(self):
+        assert SKILL_MD.is_file()
+
+    def test_frontmatter_required_fields(self):
+        fm, _ = parse_frontmatter_and_body(SKILL_MD)
+        for field in ("name", "description", "version", "author", "license", "platforms"):
+            assert field in fm, f"missing frontmatter field: {field}"
+        assert fm["name"] == "apple-reminders"
+        assert fm["platforms"] == ["macos"], "skill is macOS-specific"
+        hermes = fm["metadata"]["hermes"]
+        assert hermes["tags"]
+
+    def test_prerequisites_commands(self):
+        fm, _ = parse_frontmatter_and_body(SKILL_MD)
+        assert fm.get("prerequisites", {}).get("commands") == ["remindctl"]
+
+    def test_description_hardline(self):
+        fm, _ = parse_frontmatter_and_body(SKILL_MD)
+        desc = fm["description"]
+        assert len(desc) <= 60, f"description is {len(desc)} chars; max allowed is 60"
+        assert desc.endswith("."), "description must end with a period"
+        assert not re.search(
+            r"\b(powerful|comprehensive|seamless|revolutionary|cutting-edge|state-of-the-art)\b",
+            desc,
+            re.I,
+        )
+
+    def test_no_machine_local_paths(self):
+        content = SKILL_MD.read_text(encoding="utf-8")
+        assert "/home/" not in content
+        assert not re.search(r"[A-Z]:\\\\Users", content)
+
+
+class TestAppleRemindersContentAndStructure:
+    """Test documentation structure, due vs alarm distinction, and output formats."""
+
+    def test_required_sections_present_and_ordered(self):
+        _, body = parse_frontmatter_and_body(SKILL_MD)
+        positions = [body.index(section) for section in REQUIRED_SECTIONS]
+        assert positions == sorted(positions), "sections must follow structured order"
+
+    def test_remindctl_commands_documented(self):
+        _, body = parse_frontmatter_and_body(SKILL_MD)
+        for cmd in REMINDCTL_COMMANDS:
+            assert cmd in body, f"command {cmd} must be documented"
+
+    def test_due_vs_alarm_early_nudge_distinction(self):
+        _, body = parse_frontmatter_and_body(SKILL_MD)
+        assert "--due" in body
+        assert "--alarm" in body
+        assert "dueDate" in body
+        assert "alarmDate" in body
+
+    def test_output_formats_documented(self):
+        _, body = parse_frontmatter_and_body(SKILL_MD)
+        assert "--json" in body
+        assert "--plain" in body
+        assert "--quiet" in body
+
+    def test_rules_clarify_agent_cronjob_vs_reminders(self):
+        _, body = parse_frontmatter_and_body(SKILL_MD)
+        assert "cronjob" in body.lower(), "must clarify agent cronjob vs Apple Reminders"

--- a/tests/skills/test_findmy_skill.py
+++ b/tests/skills/test_findmy_skill.py
@@ -1,0 +1,80 @@
+"""Contract and workflow tests for the findmy skill."""
+
+import re
+from pathlib import Path
+import pytest
+
+from tests.skills._skill_test_utils import parse_frontmatter_and_body, resolve_related_skills_in_repo
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILL_MD = REPO_ROOT / "skills" / "apple" / "findmy" / "SKILL.md"
+
+REQUIRED_SECTIONS = [
+    "## Prerequisites",
+    "## When to Use",
+    "## Method 1: AppleScript + Screenshot (Basic)",
+    "## Method 2: Peekaboo UI Automation (Recommended)",
+    "## Workflow: Track AirTag Location Over Time",
+    "## Limitations",
+    "## Rules",
+]
+
+
+class TestFindMyContract:
+    """Test that findmy adheres to the project hardline standards."""
+
+    def test_skill_file_exists(self):
+        assert SKILL_MD.is_file()
+
+    def test_frontmatter_required_fields(self):
+        fm, _ = parse_frontmatter_and_body(SKILL_MD)
+        for field in ("name", "description", "version", "author", "license", "platforms"):
+            assert field in fm, f"missing frontmatter field: {field}"
+        assert fm["name"] == "findmy"
+        assert fm["platforms"] == ["macos"], "skill is macOS-specific"
+        hermes = fm["metadata"]["hermes"]
+        assert hermes["tags"]
+
+    def test_description_hardline(self):
+        fm, _ = parse_frontmatter_and_body(SKILL_MD)
+        desc = fm["description"]
+        assert len(desc) <= 60, f"description is {len(desc)} chars; max allowed is 60"
+        assert desc.endswith("."), "description must end with a period"
+        assert not re.search(
+            r"\b(powerful|comprehensive|seamless|revolutionary|cutting-edge|state-of-the-art)\b",
+            desc,
+            re.I,
+        )
+
+    def test_no_machine_local_paths(self):
+        content = SKILL_MD.read_text(encoding="utf-8")
+        assert "/home/" not in content
+        assert not re.search(r"[A-Z]:\\\\Users", content)
+
+
+class TestFindMyContentAndStructure:
+    """Test UI automation methods, AirTag tracking loop, and privacy rules in findmy."""
+
+    def test_required_sections_present_and_ordered(self):
+        _, body = parse_frontmatter_and_body(SKILL_MD)
+        positions = [body.index(section) for section in REQUIRED_SECTIONS]
+        assert positions == sorted(positions), "sections must follow structured order"
+
+    def test_both_automation_methods_documented(self):
+        _, body = parse_frontmatter_and_body(SKILL_MD)
+        # Method 1
+        assert "osascript" in body
+        assert "screencapture" in body
+        assert "vision_analyze" in body
+        # Method 2
+        assert "peekaboo" in body
+
+    def test_airtag_foreground_tracking_discipline(self):
+        _, body = parse_frontmatter_and_body(SKILL_MD)
+        assert "AirTags only update" in body or "AirTag only updates" in body
+        assert "foreground" in body
+
+    def test_privacy_rules_documented(self):
+        _, body = parse_frontmatter_and_body(SKILL_MD)
+        assert "Respect privacy" in body
+        assert "only track devices/items the user owns" in body

--- a/tests/skills/test_imessage_skill.py
+++ b/tests/skills/test_imessage_skill.py
@@ -1,0 +1,98 @@
+"""Contract and workflow tests for the imessage skill."""
+
+import re
+from pathlib import Path
+import pytest
+
+from tests.skills._skill_test_utils import parse_frontmatter_and_body, resolve_related_skills_in_repo
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILL_MD = REPO_ROOT / "skills" / "apple" / "imessage" / "SKILL.md"
+
+REQUIRED_SECTIONS = [
+    "## Prerequisites",
+    "## When to Use",
+    "## When NOT to Use",
+    "## Quick Reference",
+    "## Service Options",
+    "## Rules",
+    "## Example Workflow",
+]
+
+IMSG_COMMANDS = [
+    "imsg chats",
+    "imsg history",
+    "imsg send",
+    "imsg watch",
+]
+
+SERVICE_OPTIONS = [
+    "--service imessage",
+    "--service sms",
+    "--service auto",
+]
+
+
+class TestIMessageContract:
+    """Test that imessage adheres to the project hardline standards."""
+
+    def test_skill_file_exists(self):
+        assert SKILL_MD.is_file()
+
+    def test_frontmatter_required_fields(self):
+        fm, _ = parse_frontmatter_and_body(SKILL_MD)
+        for field in ("name", "description", "version", "author", "license", "platforms"):
+            assert field in fm, f"missing frontmatter field: {field}"
+        assert fm["name"] == "imessage"
+        assert fm["platforms"] == ["macos"], "skill is macOS-specific"
+        hermes = fm["metadata"]["hermes"]
+        assert hermes["tags"]
+
+    def test_prerequisites_commands(self):
+        fm, _ = parse_frontmatter_and_body(SKILL_MD)
+        assert fm.get("prerequisites", {}).get("commands") == ["imsg"]
+
+    def test_description_hardline(self):
+        fm, _ = parse_frontmatter_and_body(SKILL_MD)
+        desc = fm["description"]
+        assert len(desc) <= 60, f"description is {len(desc)} chars; max allowed is 60"
+        assert desc.endswith("."), "description must end with a period"
+        assert not re.search(
+            r"\b(powerful|comprehensive|seamless|revolutionary|cutting-edge|state-of-the-art)\b",
+            desc,
+            re.I,
+        )
+
+    def test_no_machine_local_paths(self):
+        content = SKILL_MD.read_text(encoding="utf-8")
+        assert "/home/" not in content
+        assert not re.search(r"[A-Z]:\\\\Users", content)
+
+
+class TestIMessageContentAndStructure:
+    """Test messaging commands, service options, and safety rules in imessage."""
+
+    def test_required_sections_present_and_ordered(self):
+        _, body = parse_frontmatter_and_body(SKILL_MD)
+        positions = [body.index(section) for section in REQUIRED_SECTIONS]
+        assert positions == sorted(positions), "sections must follow structured order"
+
+    def test_imsg_commands_documented(self):
+        _, body = parse_frontmatter_and_body(SKILL_MD)
+        for cmd in IMSG_COMMANDS:
+            assert cmd in body, f"command {cmd} must be documented"
+
+    def test_service_options_documented(self):
+        _, body = parse_frontmatter_and_body(SKILL_MD)
+        for opt in SERVICE_OPTIONS:
+            assert opt in body, f"service option {opt} must be documented"
+
+    def test_safety_and_confirmation_rules(self):
+        _, body = parse_frontmatter_and_body(SKILL_MD)
+        assert "Always confirm recipient and message content" in body
+        assert "Never send to unknown numbers" in body
+
+    def test_workflow_has_confirmation_step(self):
+        _, body = parse_frontmatter_and_body(SKILL_MD)
+        assert "Confirm with user" in body
+        assert "Send after confirmation" in body


### PR DESCRIPTION
### Summary of changes
- Adds dedicated hermetic contract and workflow discipline test suites for the 4 macOS-specific Apple ecosystem skills:
  - `apple-notes` (`tests/skills/test_apple_notes_skill.py`): 10 tests covering macOS platform gating, `memo` CLI commands, `$EDITOR` environment handling, boundaries with memory/obsidian tools, and frontmatter standards.
  - `apple-reminders` (`tests/skills/test_apple_reminders_skill.py`): 10 tests covering `remindctl` commands, `--due` vs `--alarm` early nudge distinction, JSON/plain/quiet output formats, and cronjob vs reminder distinction.
  - `imessage` (`tests/skills/test_imessage_skill.py`): 10 tests covering `imsg` CLI commands, service options (`--service imessage/sms/auto`), explicit recipient confirmation rules, and step-by-step workflow.
  - `findmy` (`tests/skills/test_findmy_skill.py`): 8 tests covering AppleScript (`osascript` + `screencapture`) vs Peekaboo UI automation methods, AirTag foreground tracking discipline, and privacy rules.
- Extracts shared skill testing utilities in `tests/skills/_skill_test_utils.py`.

### How to test
```bash
pytest tests/skills/test_apple_notes_skill.py tests/skills/test_apple_reminders_skill.py tests/skills/test_imessage_skill.py tests/skills/test_findmy_skill.py -v
# Expected: 38 passed in ~0.5s

python scripts/check-windows-footguns.py tests/skills/_skill_test_utils.py tests/skills/test_apple_notes_skill.py tests/skills/test_apple_reminders_skill.py tests/skills/test_imessage_skill.py tests/skills/test_findmy_skill.py
# Expected: 0 footguns found
```

### Platforms tested
- macOS (Darwin aarch64, Python 3.11)