### PR TITLE
fix(execute-code): enforce UTF-8 spill byte cap

### DIFF
--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -18,7 +18,9 @@ import pytest
 import json
 import os
 import socket
+import tempfile
 import time
+from pathlib import Path
 
 os.environ["TERMINAL_ENV"] = "local"
 
@@ -760,6 +762,39 @@ class TestInterruptHandling(unittest.TestCase):
 
 class TestHeadTailTruncation(unittest.TestCase):
     """Tests for head+tail truncation of large stdout in execute_code."""
+
+    def test_spill_cap_counts_utf8_bytes_without_invalid_text(self):
+        """A multibyte spill remains within the documented byte ceiling."""
+        from tools import code_execution_tool as cet
+
+        with tempfile.TemporaryDirectory() as tmpdir, patch(
+            "hermes_constants.get_hermes_dir", return_value=Path(tmpdir)
+        ):
+            spill_path = cet._spill_full_stdout("😀" * (cet.MAX_SPILLED_STDOUT_BYTES + 1))
+
+            assert spill_path is not None
+            raw = Path(spill_path).read_bytes()
+        assert len(raw) <= cet.MAX_SPILLED_STDOUT_BYTES
+        assert raw.decode("utf-8").endswith("[... spill capped at 5,000,000 bytes ...]")
+
+    def test_kernel_spill_cap_counts_utf8_bytes_without_invalid_text(self):
+        """The generated session-kernel runner applies the same byte ceiling."""
+        from tools import code_kernel
+
+        with tempfile.TemporaryDirectory() as tmpdir, patch.dict(os.environ, {
+            "HERMES_KERNEL_SENTINEL": "test-sentinel",
+            "HERMES_KERNEL_SPILL_DIR": tmpdir,
+        }, clear=False):
+            namespace = {}
+            exec(code_kernel.KERNEL_RUNNER_SOURCE.split("def _reply")[0], namespace)
+            _clipped, clipped, spill_path = namespace["_bounded"](
+                "😀" * 5_000_001, "cell_stdout.txt"
+            )
+            raw = Path(spill_path).read_bytes()
+
+        assert clipped
+        assert len(raw) <= 5_000_000
+        assert raw.decode("utf-8").endswith("[... spill capped ...]")
 
     def _run(self, code):
         with patch("model_tools.handle_function_call", side_effect=_mock_handle_function_call):

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -156,6 +156,19 @@ def _truncate_stdout_text(stdout_text: str) -> Tuple[str, Dict[str, Any]]:
 MAX_SPILLED_STDOUT_BYTES = 5_000_000
 
 
+def _cap_spill_text(stdout_text: str) -> str:
+    """Return a UTF-8-valid spill payload within the byte ceiling."""
+    stdout_bytes = stdout_text.encode("utf-8", errors="replace")
+    if len(stdout_bytes) <= MAX_SPILLED_STDOUT_BYTES:
+        return stdout_text
+
+    marker = f"\n\n[... spill capped at {MAX_SPILLED_STDOUT_BYTES:,} bytes ...]"
+    marker_bytes = marker.encode("utf-8")
+    prefix_limit = MAX_SPILLED_STDOUT_BYTES - len(marker_bytes)
+    prefix = stdout_bytes[:prefix_limit].decode("utf-8", errors="ignore")
+    return prefix + marker
+
+
 def _spill_full_stdout(stdout_text: str) -> Optional[str]:
     """Write full stdout to cache/exec; return its path (None on failure).
 
@@ -168,11 +181,7 @@ def _spill_full_stdout(stdout_text: str) -> Optional[str]:
         import hashlib
         from hermes_constants import get_hermes_dir
 
-        if len(stdout_text) > MAX_SPILLED_STDOUT_BYTES:
-            stdout_text = (
-                stdout_text[:MAX_SPILLED_STDOUT_BYTES]
-                + f"\n\n[... spill capped at {MAX_SPILLED_STDOUT_BYTES:,} bytes ...]"
-            )
+        stdout_text = _cap_spill_text(stdout_text)
         cache_dir = get_hermes_dir("cache/exec", "exec_spill")
         cache_dir.mkdir(parents=True, exist_ok=True)
         digest = hashlib.sha256(

--- a/tools/code_kernel.py
+++ b/tools/code_kernel.py
@@ -92,6 +92,17 @@ GLOBALS = {{"__name__": "__main__", "__builtins__": __builtins__}}
 _real_stdout = sys.stdout
 
 
+def _spill_payload(text):
+    """Cap a spill by UTF-8 bytes without splitting a code point."""
+    encoded = text.encode("utf-8", errors="replace")
+    if len(encoded) <= _SPILL_CAP:
+        return text
+    marker = "\\n\\n[... spill capped ...]"
+    marker_bytes = marker.encode("utf-8")
+    prefix = encoded[: _SPILL_CAP - len(marker_bytes)].decode("utf-8", errors="ignore")
+    return prefix + marker
+
+
 def _bounded(text, spill_name=None):
     """Clip to the inline cap; spill the FULL text to disk when clipping.
 
@@ -105,9 +116,7 @@ def _bounded(text, spill_name=None):
         try:
             spill_path = os.path.join(_SPILL_DIR, spill_name)
             with open(spill_path, "w", encoding="utf-8", errors="replace") as f:
-                f.write(text[:_SPILL_CAP])
-                if len(text) > _SPILL_CAP:
-                    f.write("\\n\\n[... spill capped ...]")
+                f.write(_spill_payload(text))
         except Exception:
             spill_path = ""
     return text[: _CAPTURE_LIMIT], True, spill_path


### PR DESCRIPTION
## Summary
- enforce the 5 MB stdout spill ceiling by UTF-8 bytes rather than Python character count
- preserve valid UTF-8 by omitting a partial trailing code point and reserving bytes for the cap marker
- apply the same bound to host and persistent session-kernel spill paths

## Validation
- `scripts/run_tests.sh tests/tools/test_code_execution.py -q` (46 passed)
- `uv run python -m py_compile tools/code_execution_tool.py tools/code_kernel.py`
- `git diff --check`
- independent diff review: PASS

No issue is linked: this was reproduced directly on current main and exact open/closed/merged PR searches found no equivalent repair.