### PR TITLE
fix(agent): tool-pair sanitizers — whitespace ids pair, stale empty tool_calls drop, orphan logic unified (salvage #55845 + #78063 + #59434)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3741,6 +3741,109 @@ def repair_empty_non_final_messages(
     return messages
 
 
+def _classify_tool_call_orphans(
+    messages: List[Dict[str, Any]],
+) -> tuple:
+    """Return (surviving_call_ids, result_call_ids, orphaned_results, missing_results).
+
+    Collects tool-call IDs from both assistant ``tool_calls`` (using the
+    ``call_id || id`` resolution that ``_get_tool_call_id_static`` uses)
+    and from ``tool`` messages, then classifies orphans:
+
+    - ``orphaned_results``: tool messages whose ``tool_call_id`` has no
+      matching assistant tool_call in the window.
+    - ``missing_results``: assistant tool_calls whose results were dropped
+      (no matching ``tool`` message found).
+
+    This is the single source of truth for orphan detection. The caller
+    decides whether to insert stubs (pre-API sanitizer) or strip orphans
+    (context compressor) — but the *detection* logic is shared so dedup
+    and id-resolution rules never drift between the two sites (#58357).
+    """
+    surviving_call_ids: set = set()
+    for msg in messages:
+        if msg.get("role") == "assistant":
+            for tc in msg.get("tool_calls") or []:
+                cid = _ra().AIAgent._get_tool_call_id_static(tc)
+                if cid:
+                    surviving_call_ids.add(cid)
+
+    result_call_ids: set = set()
+    for msg in messages:
+        if msg.get("role") == "tool":
+            cid = (msg.get("tool_call_id") or "").strip()
+            if cid:
+                result_call_ids.add(cid)
+
+    orphaned_results = result_call_ids - surviving_call_ids
+    missing_results = surviving_call_ids - result_call_ids
+    return surviving_call_ids, result_call_ids, orphaned_results, missing_results
+
+
+
+def _classify_tool_call_orphans(messages: List[Dict[str, Any]]):
+    """Classify orphaned tool-call / tool-result pairs in *messages*.
+
+    Returns a 4-tuple ``(surviving_call_ids, result_call_ids,
+    orphaned_results, missing_tool_calls)``:
+
+    - ``surviving_call_ids``: every id variant carried by any assistant
+      ``tool_calls`` entry. A tool_call may carry SEVERAL equivalent id
+      spellings (``id`` fc_..., ``call_id`` call_..., ``response_item_id``,
+      or a composite ``call|item`` bridge id) — register EVERY variant so a
+      result matching any of them survives (#55626, #63000).
+    - ``result_call_ids``: every id variant referenced by a ``tool`` result.
+    - ``orphaned_results``: the actual ``tool`` message dicts whose complete
+      alias set matches no assistant call (compare by identity — ``id(msg)``
+      — when filtering, since dicts are unhashable).
+    - ``missing_tool_calls``: the actual tool_call entries with no matching
+      result on ANY alias (after orphaned results are excluded).
+
+    This is the single source of truth for orphan *detection*. Callers keep
+    their divergent remediation strategies — ``sanitize_api_messages``
+    inserts stubs, the context compressor strips orphans — but the
+    id-resolution and variant-expansion rules can never drift between the
+    two sites again (#58357).
+    """
+    assistant_call_variants: List[tuple[Any, frozenset[str]]] = []
+    surviving_call_ids: set[str] = set()
+    for msg in messages:
+        if msg.get("role") != "assistant":
+            continue
+        for tc in msg.get("tool_calls") or []:
+            variants = tool_call_id_variants(tc)
+            if variants:
+                assistant_call_variants.append((tc, variants))
+                surviving_call_ids.update(variants)
+
+    result_entries = [
+        (msg, tool_result_id_variants(msg.get("tool_call_id")))
+        for msg in messages
+        if msg.get("role") == "tool"
+    ]
+    result_call_ids: set[str] = set()
+    for _, variants in result_entries:
+        result_call_ids.update(variants)
+
+    orphaned_results = [
+        msg
+        for msg, variants in result_entries
+        if variants and not (variants & surviving_call_ids)
+    ]
+    orphaned_ids = {id(msg) for msg in orphaned_results}
+    surviving_result_variants = [
+        variants
+        for msg, variants in result_entries
+        if variants and id(msg) not in orphaned_ids
+    ]
+    missing_tool_calls = [
+        tc
+        for tc, variants in assistant_call_variants
+        if not any(variants & rv for rv in surviving_result_variants)
+    ]
+    return surviving_call_ids, result_call_ids, orphaned_results, missing_tool_calls
+
+
 def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """Fix orphaned tool_call / tool_result pairs before every LLM call.
 
@@ -3878,58 +3981,23 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
             _pre_id_filter_count - len(messages),
         )
 
-    assistant_call_variants: List[tuple[Any, frozenset[str]]] = []
-    surviving_call_ids: set[str] = set()
-    for msg in messages:
-        if msg.get("role") != "assistant":
-            continue
-        for tc in msg.get("tool_calls") or []:
-            # A tool_call may carry SEVERAL equivalent id spellings (``id``
-            # fc_..., ``call_id`` call_..., ``response_item_id``, or a
-            # composite ``call|item`` bridge id). ``_get_tool_call_id_static``
-            # returns only the preferred one, but a tool result keyed on any
-            # OTHER spelling would then look orphaned and get dropped +
-            # replaced with a bogus "[Result unavailable]" stub — silently
-            # eating a perfectly valid tool result (#55626, #63000). Register
-            # EVERY variant so a result matching any of them survives.
-            variants = tool_call_id_variants(tc)
-            if variants:
-                assistant_call_variants.append((tc, variants))
-                surviving_call_ids.update(variants)
-
-    result_entries = [
-        (msg, tool_result_id_variants(msg.get("tool_call_id")))
-        for msg in messages
-        if msg.get("role") == "tool"
-    ]
+    (
+        surviving_call_ids,
+        result_call_ids,
+        orphaned_results,
+        missing_tool_calls,
+    ) = _classify_tool_call_orphans(messages)
 
     # 1. Drop tool results whose complete alias set matches no assistant call.
-    orphaned_result_objects = {
-        id(msg)
-        for msg, variants in result_entries
-        if variants and not (variants & surviving_call_ids)
-    }
+    orphaned_result_objects = {id(msg) for msg in orphaned_results}
     if orphaned_result_objects:
         messages = [m for m in messages if id(m) not in orphaned_result_objects]
-        result_entries = [
-            (msg, variants)
-            for msg, variants in result_entries
-            if id(msg) not in orphaned_result_objects
-        ]
         _ra().logger.debug(
             "Pre-call sanitizer: removed %d orphaned tool result(s)",
             len(orphaned_result_objects),
         )
 
     # 2. Inject one stub per assistant call with no result on ANY alias.
-    surviving_result_variants = [
-        variants for _, variants in result_entries if variants
-    ]
-    missing_tool_calls = [
-        tc
-        for tc, variants in assistant_call_variants
-        if not any(variants & result_variants for result_variants in surviving_result_variants)
-    ]
     if missing_tool_calls:
         missing_tool_call_objects = {id(tc) for tc in missing_tool_calls}
         patched: List[Dict[str, Any]] = []

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3741,46 +3741,6 @@ def repair_empty_non_final_messages(
     return messages
 
 
-def _classify_tool_call_orphans(
-    messages: List[Dict[str, Any]],
-) -> tuple:
-    """Return (surviving_call_ids, result_call_ids, orphaned_results, missing_results).
-
-    Collects tool-call IDs from both assistant ``tool_calls`` (using the
-    ``call_id || id`` resolution that ``_get_tool_call_id_static`` uses)
-    and from ``tool`` messages, then classifies orphans:
-
-    - ``orphaned_results``: tool messages whose ``tool_call_id`` has no
-      matching assistant tool_call in the window.
-    - ``missing_results``: assistant tool_calls whose results were dropped
-      (no matching ``tool`` message found).
-
-    This is the single source of truth for orphan detection. The caller
-    decides whether to insert stubs (pre-API sanitizer) or strip orphans
-    (context compressor) — but the *detection* logic is shared so dedup
-    and id-resolution rules never drift between the two sites (#58357).
-    """
-    surviving_call_ids: set = set()
-    for msg in messages:
-        if msg.get("role") == "assistant":
-            for tc in msg.get("tool_calls") or []:
-                cid = _ra().AIAgent._get_tool_call_id_static(tc)
-                if cid:
-                    surviving_call_ids.add(cid)
-
-    result_call_ids: set = set()
-    for msg in messages:
-        if msg.get("role") == "tool":
-            cid = (msg.get("tool_call_id") or "").strip()
-            if cid:
-                result_call_ids.add(cid)
-
-    orphaned_results = result_call_ids - surviving_call_ids
-    missing_results = surviving_call_ids - result_call_ids
-    return surviving_call_ids, result_call_ids, orphaned_results, missing_results
-
-
-
 def _classify_tool_call_orphans(messages: List[Dict[str, Any]]):
     """Classify orphaned tool-call / tool-result pairs in *messages*.
 

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -683,19 +683,46 @@ def repair_message_sequence(agent, messages: List[Dict]) -> int:
             # blocks — fall back to keeping the existing content.
             prev_content = prev.get("content")
             new_content = msg.get("content")
+            content_rewritten = False
             if isinstance(prev_content, str) and isinstance(new_content, str):
                 joined = "\n".join(
                     p for p in (prev_content.strip(), new_content.strip()) if p
                 )
                 prev["content"] = joined
+                # A falsy ``new_content`` (e.g. "") strips to nothing and
+                # ``joined`` collapses back to ``prev_content`` unchanged --
+                # that must NOT count as a rewrite (wz-heng, #78063 review).
+                content_rewritten = joined != prev_content
             elif not prev_content and new_content is not None:
                 prev["content"] = new_content
+                content_rewritten = new_content != prev_content
             # Carry reasoning_content from the later turn only if the
             # earlier turn lacks it (strict thinking providers require a
             # reasoning_content on the merged tool-call turn; the first
             # non-empty one suffices).
             if not prev.get("reasoning_content") and msg.get("reasoning_content"):
                 prev["reasoning_content"] = msg["reasoning_content"]
+            # ``prev`` may carry an ``api_content`` sidecar (the exact bytes
+            # previously sent to the API, e.g. a sanitize-divergence stamp —
+            # see ``_flush_messages_to_session_db``) from BEFORE this merge.
+            # The sidecar takes priority over ``content`` at API-build time
+            # (``conversation_loop``'s ``api_messages`` build substitutes it
+            # back in for role ``assistant``), so leaving it in place while
+            # ``prev["content"]`` changes would silently replay the pre-merge
+            # bytes and discard everything this merge just concatenated on —
+            # the same stale-field-survives-the-merge shape as the
+            # ``tool_calls`` gap above, just for a different field. Only drop
+            # it when the merge actually changed the resulting value (e.g.
+            # the later turn's content is ``None``, or either side is
+            # multimodal/list — both branches skip the reassignment and
+            # ``prev["content"]`` is untouched; a falsy ``new_content`` that
+            # strips to nothing also leaves ``joined`` equal to the original
+            # ``prev_content``): in those cases the sidecar is still the
+            # exact bytes previously sent for the UNCHANGED content, and
+            # dropping it would break the prompt-cache replay invariant for
+            # no reason (wz-heng, #78063 review).
+            if content_rewritten:
+                drop_stale_api_content(prev)
             repairs += 1
             continue
         collapsed.append(msg)
@@ -3825,6 +3852,31 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
                     pass
             elif isinstance(tc, dict):
                 tc["function"] = {"name": _EMPTY_NAME_SENTINEL, "arguments": "{}"}
+
+    # --- Drop tool results with a missing/empty tool_call_id ---
+    # The orphan-sweep below only ever adds a TRUTHY ``tool_call_id`` to
+    # ``result_call_ids``, so a message with a missing/empty id is never
+    # added to that set and can therefore never land in ``orphaned_results``
+    # (a set-difference against ``surviving_call_ids``) either — it silently
+    # passes through this chokepoint untouched and can reach the provider
+    # with no ``tool_call_id`` at all, which strict OpenAI-compatible
+    # providers reject as a schema violation. ``repair_message_sequence``'s
+    # Pass 1 already drops this shape (`if tc_id and tc_id in
+    # known_tool_ids`) when it runs first on the same list, but any caller
+    # that reaches this function without going through
+    # ``repair_message_sequence`` first has no such guard. Drop explicitly
+    # here so this "final chokepoint" claim (see module docstring) actually
+    # holds regardless of caller (#78071).
+    _pre_id_filter_count = len(messages)
+    messages = [
+        m for m in messages
+        if not (m.get("role") == "tool" and not (m.get("tool_call_id") or "").strip())
+    ]
+    if len(messages) != _pre_id_filter_count:
+        _ra().logger.debug(
+            "Pre-call sanitizer: dropped %d tool result(s) with missing/empty tool_call_id",
+            _pre_id_filter_count - len(messages),
+        )
 
     assistant_call_variants: List[tuple[Any, frozenset[str]]] = []
     surviving_call_ids: set[str] = set()

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -5999,33 +5999,19 @@ This compaction should PRIORITISE preserving all information related to the focu
         silently dropped by the repair pass, re-exposing the original orphans.
         Stripping at the source avoids this entire class of mismatch.
         """
-        surviving_call_ids: set = set()
-        for msg in messages:
-            if msg.get("role") == "assistant":
-                for tc in msg.get("tool_calls") or []:
-                    surviving_call_ids |= self._tool_call_id_variants(tc)
+        from agent.agent_runtime_helpers import _classify_tool_call_orphans
 
-        result_call_ids: set = set()
-        for msg in messages:
-            if msg.get("role") == "tool":
-                cid = (msg.get("tool_call_id") or "").strip()
-                if cid:
-                    # Expand alias spellings on the RESULT side too — a
-                    # composite ``call|item`` tool_call_id must match a
-                    # tool_call registered under either half (#63000).
-                    result_call_ids |= tool_result_id_variants(cid)
+        (
+            surviving_call_ids,
+            result_call_ids,
+            orphaned_result_msgs,
+            missing_tool_calls,
+        ) = _classify_tool_call_orphans(messages)
+        orphaned_results = {id(m) for m in orphaned_result_msgs}
 
         # 1. Remove tool results whose call_id has no matching assistant tool_call
-        orphaned_results = result_call_ids - surviving_call_ids
         if orphaned_results:
-            messages = [
-                m for m in messages
-                if not (
-                    m.get("role") == "tool"
-                    and (rv := tool_result_id_variants(m.get("tool_call_id")))
-                    and not (rv & surviving_call_ids)
-                )
-            ]
+            messages = [m for m in messages if id(m) not in orphaned_results]
             if not self.quiet_mode:
                 logger.info("Compression sanitizer: removed %d orphaned tool result(s)", len(orphaned_results))
 
@@ -6037,7 +6023,7 @@ This compaction should PRIORITISE preserving all information related to the focu
         #    matching result — checking only one variant per side is exactly
         #    the mismatch this method exists to avoid.
         stripped_count = 0
-        if surviving_call_ids - result_call_ids:
+        if missing_tool_calls:
             # --- In-flight tool chain protection (issue #79278) -------------
             # A strip here must distinguish a *pending* tool_call (the model's
             # live request whose result the executor has not yet appended) from

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -5961,8 +5961,8 @@ This compaction should PRIORITISE preserving all information related to the focu
         SimpleNamespace), for logging/display only. Matching logic must use
         :meth:`_tool_call_id_variants` instead — see its docstring."""
         if isinstance(tc, dict):
-            return tc.get("call_id", "") or tc.get("id", "") or ""
-        return getattr(tc, "call_id", "") or getattr(tc, "id", "") or ""
+            return (tc.get("call_id", "") or tc.get("id", "") or "").strip()
+        return (getattr(tc, "call_id", "") or getattr(tc, "id", "") or "").strip()
 
     @staticmethod
     def _tool_call_id_variants(tc) -> set:
@@ -6008,7 +6008,7 @@ This compaction should PRIORITISE preserving all information related to the focu
         result_call_ids: set = set()
         for msg in messages:
             if msg.get("role") == "tool":
-                cid = msg.get("tool_call_id")
+                cid = (msg.get("tool_call_id") or "").strip()
                 if cid:
                     # Expand alias spellings on the RESULT side too — a
                     # composite ``call|item`` tool_call_id must match a

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -3619,3 +3619,60 @@ class TestPreLlmFeasibilityCheck:
             feasibility_skip=compressor._last_feasibility_skip,
         )
         assert compressor._fallback_compression_streak == 1
+
+
+class TestSanitizeToolPairsWhitespace:
+    """_sanitize_tool_pairs must strip whitespace from tool_call_id before
+    comparing, matching the fix applied to agent_runtime_helpers.py in
+    commit fa3ab2ffd.  Without stripping, a valid tool result whose
+    tool_call_id has surrounding whitespace is misclassified as orphaned
+    and silently replaced with a [Result unavailable] stub.
+    """
+
+    def _make(self):
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            return ContextCompressor(model="test/model", quiet_mode=True,
+                                     protect_first_n=2, protect_last_n=2)
+
+    def _assistant(self, call_id):
+        return {
+            "role": "assistant", "content": "",
+            "tool_calls": [{"id": call_id, "type": "function",
+                             "function": {"name": "f", "arguments": "{}"}}],
+        }
+
+    def test_leading_whitespace_on_result_id_preserved(self):
+        c = self._make()
+        msgs = [
+            self._assistant("call_abc"),
+            {"role": "tool", "tool_call_id": " call_abc", "content": "ok"},
+        ]
+        out = c._sanitize_tool_pairs(msgs)
+        tool_msgs = [m for m in out if m.get("role") == "tool"]
+        assert len(tool_msgs) == 1
+        assert tool_msgs[0]["content"] == "ok", "valid result must not be treated as orphaned"
+
+    def test_trailing_whitespace_on_result_id_preserved(self):
+        c = self._make()
+        msgs = [
+            self._assistant("call_xyz"),
+            {"role": "tool", "tool_call_id": "call_xyz  ", "content": "data"},
+        ]
+        out = c._sanitize_tool_pairs(msgs)
+        tool_msgs = [m for m in out if m.get("role") == "tool"]
+        assert len(tool_msgs) == 1
+        assert tool_msgs[0]["content"] == "data"
+
+    def test_truly_orphaned_still_removed(self):
+        """Whitespace-trimmed ID that still has no match must be removed.
+        The assistant's call_real has no matching result, so a stub is
+        inserted in its place — the original orphaned entry must be gone."""
+        c = self._make()
+        msgs = [
+            self._assistant("call_real"),
+            {"role": "tool", "tool_call_id": " call_orphan ", "content": "stale"},
+        ]
+        out = c._sanitize_tool_pairs(msgs)
+        tool_call_ids = [m.get("tool_call_id") for m in out if m.get("role") == "tool"]
+        assert "call_orphan" not in tool_call_ids, "genuinely orphaned result must be removed"
+        assert " call_orphan " not in tool_call_ids, "original whitespace form must also be gone"

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -288,6 +288,106 @@ def test_repair_keeps_two_parallel_calls_answered_by_mixed_variants():
     ]
 
 
+def test_repair_merge_drops_stale_api_content_sidecar_on_surviving_turn():
+    """A pre-existing ``api_content`` sidecar on the surviving (first)
+    assistant turn must be dropped when the merge rewrites ``content`` —
+    otherwise the sidecar (which takes priority over ``content`` at
+    API-build time, see ``conversation_loop``'s ``api_messages`` build)
+    replays the STALE pre-merge bytes on the next call, silently discarding
+    everything the merge just concatenated on. Same stale-field-survives-
+    the-merge shape as the ``tool_calls`` gap above (#77921), for the
+    ``api_content`` field instead.
+    """
+    agent = _bare_agent()
+    messages = [
+        {"role": "user", "content": "Q1"},
+        {
+            "role": "assistant",
+            "content": "first reply",
+            "api_content": "first reply (stale pre-merge bytes)",
+        },
+        {"role": "assistant", "content": "second reply"},
+    ]
+
+    repairs = AIAgent._repair_message_sequence(agent, messages)
+
+    assert repairs == 1
+    assert len(messages) == 2
+    assert "api_content" not in messages[1]
+    assert messages[1]["content"] == "first reply\nsecond reply"
+
+
+def test_repair_merge_preserves_api_content_sidecar_when_content_unchanged():
+    """Negative control (#78063 review): ``api_content`` must NOT be dropped
+    when the merge does not actually rewrite ``prev["content"]``.
+
+    When the later assistant turn's content is ``None``, neither the
+    both-str branch nor the ``not prev_content`` branch fires (``prev_content``
+    is a truthy string, so ``not prev_content`` is False) -- ``prev["content"]``
+    is left completely untouched. The sidecar is still the exact bytes
+    previously sent for that UNCHANGED content, so dropping it here would
+    diverge replay bytes and break the prompt-cache invariant for no reason.
+    """
+    agent = _bare_agent()
+    messages = [
+        {"role": "user", "content": "Q1"},
+        {"role": "assistant", "content": "clean", "api_content": "wire bytes"},
+        {"role": "assistant", "content": None},
+    ]
+
+    repairs = AIAgent._repair_message_sequence(agent, messages)
+
+    assert repairs == 1
+    assert len(messages) == 2
+    assert messages[1]["content"] == "clean"
+    assert messages[1]["api_content"] == "wire bytes"
+
+
+def test_repair_merge_preserves_api_content_sidecar_when_content_unchanged_by_empty_string():
+    """Negative control (wz-heng, #78063 review): ``content_rewritten`` must
+    mean "the value changed", not "entered the assignment branch".
+
+    Later turn's content is ``""`` -- the both-str branch fires and
+    ``prev["content"]`` IS reassigned, but ``joined`` strips the falsy
+    empty string away and collapses back to the original ``prev_content``
+    unchanged. The sidecar must survive because no byte of ``content``
+    actually moved.
+    """
+    agent = _bare_agent()
+    messages = [
+        {"role": "user", "content": "Q1"},
+        {"role": "assistant", "content": "clean", "api_content": "wire bytes"},
+        {"role": "assistant", "content": ""},
+    ]
+
+    repairs = AIAgent._repair_message_sequence(agent, messages)
+
+    assert repairs == 1
+    assert len(messages) == 2
+    assert messages[1]["content"] == "clean"
+    assert messages[1]["api_content"] == "wire bytes"
+
+
+def test_repair_merge_preserves_api_content_sidecar_with_multimodal_content():
+    """Same negative control, multimodal (list) content on the later turn --
+    the merge intentionally leaves list content alone (see the merge's
+    docstring), so ``prev["content"]`` is untouched and the sidecar must
+    survive."""
+    agent = _bare_agent()
+    messages = [
+        {"role": "user", "content": "Q1"},
+        {"role": "assistant", "content": "clean", "api_content": "wire bytes"},
+        {"role": "assistant", "content": [{"type": "text", "text": "img context"}]},
+    ]
+
+    AIAgent._repair_message_sequence(agent, messages)
+
+    assert len(messages) == 2
+    assert messages[1]["content"] == "clean"
+    assert messages[1]["api_content"] == "wire bytes"
+
+
+
 def test_sanitize_consumes_all_responses_id_variants_for_duplicate_result():
     """A sibling-id replay must not replace the first real result."""
     from agent.agent_runtime_helpers import sanitize_api_messages
@@ -494,6 +594,34 @@ def test_sanitize_preserves_distinct_tool_call_ids():
     assistant = [m for m in out if m.get("role") == "assistant"][0]
     assert [tc["id"] for tc in assistant["tool_calls"]] == ["call_A", "call_B"]
     assert sorted(m["tool_call_id"] for m in out if m.get("role") == "tool") == ["call_A", "call_B"]
+
+
+def test_sanitize_drops_tool_result_with_missing_tool_call_id():
+    """A tool message with NO ``tool_call_id`` must be dropped, not silently
+    passed through.
+
+    Before the fix: ``result_call_ids`` only ever collects TRUTHY ids, so a
+    missing/empty id is never added to that set and can therefore never land
+    in ``orphaned_results`` (a set-difference against ``surviving_call_ids``)
+    either -- the message survives sanitize_api_messages untouched and can
+    reach the provider with no ``tool_call_id`` at all, a schema violation
+    on strict OpenAI-compatible providers (#78071).
+    """
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    messages = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "", "tool_calls": [
+            {"id": "call_Z", "type": "function",
+             "function": {"name": "f", "arguments": "{}"}},
+        ]},
+        {"role": "tool", "tool_call_id": "call_Z", "content": "real result"},
+        {"role": "tool", "tool_call_id": "", "content": "no id"},
+        {"role": "tool", "content": "id key entirely absent"},
+    ]
+    out = sanitize_api_messages(list(messages))
+    tool_ids = [m.get("tool_call_id") for m in out if m.get("role") == "tool"]
+    assert tool_ids == ["call_Z"]  # only the properly-paired result survives
 
 
 # ── tool_call_id reuse by local servers (#70724) ────────────────────────────

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -1084,3 +1084,64 @@ def test_compressor_sanitize_keeps_composite_keyed_pair():
     ]
     out = cc._sanitize_tool_pairs(msgs)
     assert not any(m.get("role") == "tool" for m in out)
+
+
+# ── _classify_tool_call_orphans ─────────────────────────────────────────
+
+def test_classify_orphans_empty():
+    from agent.agent_runtime_helpers import _classify_tool_call_orphans
+    sv, rs, orphaned, missing = _classify_tool_call_orphans([])
+    assert sv == set()
+    assert rs == set()
+    assert orphaned == []
+    assert missing == []
+
+
+def test_classify_orphans_clean_pair():
+    from agent.agent_runtime_helpers import _classify_tool_call_orphans
+    messages = [
+        {"role": "assistant", "tool_calls": [{"id": "call_1", "type": "function", "function": {"name": "f", "arguments": "{}"}}]},
+        {"role": "tool", "tool_call_id": "call_1", "content": "ok"},
+    ]
+    sv, rs, orphaned, missing = _classify_tool_call_orphans(messages)
+    assert sv == {"call_1"}
+    assert rs == {"call_1"}
+    assert orphaned == []
+    assert missing == []
+
+
+def test_classify_orphans_detects_orphaned_result():
+    from agent.agent_runtime_helpers import _classify_tool_call_orphans
+    messages = [
+        {"role": "tool", "tool_call_id": "orphan_1", "content": "no matching call"},
+    ]
+    sv, rs, orphaned, missing = _classify_tool_call_orphans(messages)
+    assert [m["tool_call_id"] for m in orphaned] == ["orphan_1"]
+    assert missing == []
+
+
+def test_classify_orphans_detects_missing_result():
+    from agent.agent_runtime_helpers import _classify_tool_call_orphans
+    messages = [
+        {"role": "assistant", "tool_calls": [{"id": "call_1", "type": "function", "function": {"name": "f", "arguments": "{}"}}]},
+    ]
+    sv, rs, orphaned, missing = _classify_tool_call_orphans(messages)
+    assert orphaned == []
+    assert [tc["id"] for tc in missing] == ["call_1"]
+
+
+def test_classify_orphans_mixed():
+    from agent.agent_runtime_helpers import _classify_tool_call_orphans
+    messages = [
+        {"role": "assistant", "tool_calls": [
+            {"id": "call_A", "type": "function", "function": {"name": "f", "arguments": "{}"}},
+            {"id": "call_B", "type": "function", "function": {"name": "g", "arguments": "{}"}},
+        ]},
+        {"role": "tool", "tool_call_id": "call_A", "content": "ok"},
+        {"role": "tool", "tool_call_id": "call_C", "content": "orphan"},
+    ]
+    sv, rs, orphaned, missing = _classify_tool_call_orphans(messages)
+    assert sv == {"call_A", "call_B"}
+    assert rs == {"call_A", "call_C"}
+    assert [m["tool_call_id"] for m in orphaned] == ["call_C"]
+    assert [tc["id"] for tc in missing] == ["call_B"]


### PR DESCRIPTION
## Summary

Combined salvage of three community tool-pair sanitizer PRs, applied fixes-first so the final refactor deduplicates the already-fixed logic:

1. **#55845** by @srojk34 — strip whitespace from `tool_call_id` in `ContextCompressor._sanitize_tool_pairs`, closing the sibling gap of `fa3ab2ffd`: IDs differing only by stray whitespace were misclassified as orphaned and replaced with `[Result unavailable]` stubs on every compression cycle.
2. **#78063** by @JoaoMarcos44 — fix three stale-field bugs in `agent/agent_runtime_helpers.py`: drop stale empty `tool_calls` surviving the consecutive-assistant merge (fixes #77921), drop the stale `api_content` sidecar when the merge rewrites `content` (with the wz-heng review's negative controls), and drop tool results with a missing/empty `tool_call_id` at the pre-API chokepoint (#78071).
3. **#59434** by @isheng-eqi — extract a shared `_classify_tool_call_orphans(messages)` used by both `sanitize_api_messages` and `_sanitize_tool_pairs`, so orphan-detection/id-resolution rules can never drift between the two copies again (#58357).

All three authors' commits are cherry-picked so authorship is preserved; conflict-resolution glue is in a separate commit.

Fixes #77921. Closes #58357. Closes #78071 (chokepoint half).

## Changes

**#55845 (whitespace ids)** — `agent/context_compressor.py`, `tests/agent/test_context_compressor.py` (+3 tests)
- Main has since adopted variant-set matching (`tool_call_id_variants` / `tool_result_id_variants` from `agent/message_sanitization.py`, #63000/#97075 churn), whose `_expand_tool_id_variants` already `.strip()`s — so the *behavioral* whitespace fix was partially superseded. Salvaged: the `.strip()` on `_get_tool_call_id` (still raw on main) and the author's 3 regression tests, which now pin the whitespace-pairing contract against future drift.

**#78063 (stale fields on merge)** — `agent/agent_runtime_helpers.py`, `tests/run_agent/test_message_sequence_repair.py` (+7 tests)
- Fix 1 (empty `tool_calls` dropped in `repair_message_sequence` merge) landed on main independently as `f316f7d086` — redundant, not re-applied.
- Fix 2 salvaged: `content_rewritten` tracking in the consecutive-assistant merge; drop the `api_content` sidecar only when the merged `content` value actually changed, so prompt-cache replay bytes stay stable when nothing moved (empty-string / `None` / multimodal negative controls included).
- Fix 3 salvaged: explicit pre-filter in `sanitize_api_messages` dropping `role=tool` messages with a missing/empty `tool_call_id`, which previously slipped through the orphan sweep (truthy-only set membership) and reached strict providers as a schema violation.

**#59434 (dedup refactor)** — `agent/agent_runtime_helpers.py`, `agent/context_compressor.py`, `tests/run_agent/test_message_sequence_repair.py` (+5 tests)
- New `_classify_tool_call_orphans(messages)` in `agent_runtime_helpers.py` is the single owner of orphan *detection*; both call sites delegate to it while keeping their divergent remediation (insert-stubs vs strip-orphans, incl. the #79278 in-flight-chain protection).
- Reconciled with main's post-PR variant-set semantics: the classifier registers EVERY id alias (`id`/`call_id`/`response_item_id`/composite `call|item`, #55626/#63000) and returns orphaned *message objects* / missing *tool_call entries* (identity-matched), so the refactor is behavior-preserving against today's alias-aware code rather than regressing to single-id matching. The author's 5 classifier unit tests were adapted to the alias-aware return shape.

## Validation

Live A/B on the real modules (`.venv` python + worktree sys.path), BEFORE = current `main`, AFTER = this branch:

| Probe | BEFORE (main) | AFTER |
|---|---|---|
| #55845: `tool_calls id 'call_x'` + result `'call_x '` (trailing space) through `_sanitize_tool_pairs` | paired ✅ (superseded by variant-strip on main; tests salvaged to pin it) | paired & preserved ✅, deterministic ✅ |
| #78063a: `#77921` shape — merge leaves stale `tool_calls: []` | already dropped ✅ (`f316f7d086`) | dropped ✅ |
| #78063b: stale `api_content` sidecar after merge rewrites content | **survives ❌** (stale bytes would replay) | dropped ✅; preserved when content unchanged ✅ |
| #78063c: tool results with `tool_call_id: ""` / key absent through `sanitize_api_messages` | **reach the wire ❌** (`['call_Z', '', None]`) | dropped ✅ (`['call_Z']`) |
| #59434: shared `_classify_tool_call_orphans` imported by both call sites | **absent ❌** (two drifting copies) | present ✅ (grep: both `agent_runtime_helpers.py` + `context_compressor.py` delegate); both suites pass pre/post refactor proving identical behavior |

Invariants held in every probe: role alternation preserved, no orphaned tool results, deterministic output.

**Live repro:** BEFORE on main — `api_content` sidecar survives the assistant merge (stale bytes win at API-build time) and id-less tool results pass `sanitize_api_messages` untouched (`tool ids on wire: ['call_Z', '', None]`); AFTER — sidecar dropped exactly when content changed, wire ids `['call_Z']`, and both sanitizers classify orphans through the one shared function.

Tests: `tests/run_agent/test_message_sequence_repair.py` + `tests/agent/test_context_compressor.py` → **194 passed** (memory-capped run), including the 15 new tests from the three PRs. `ruff check` clean on all touched files.

Note on #59434's `scripts/release.py` hunk: it appended to the frozen `AUTHOR_MAP` — dropped per current attribution policy (contributor mapping lives in `contributors/emails/`; `ishengeqi@163.com`, `joaomarcosdias444@gmail.com`, and `srojk34` noreply are all already mapped — `scripts/audit_pr_attribution.py --fix` reports clean).

## Infographic

![infographic](https://v3b.fal.media/files/b/0aa82735/mlSqTc6BKKiNQC05CUAcd_A8SAYtaJ.png)

