### PR TITLE
feat(plugins): add fail-closed model call policy

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -168,6 +168,11 @@ from agent.model_metadata import (
 )
 from hermes_cli.config import get_hermes_home
 from hermes_constants import OPENROUTER_BASE_URL
+from hermes_cli.model_call_policy import (
+    ModelCallPolicyDenied,
+    ModelCallPolicyHalt,
+    enforce_pre_model_call_policy,
+)
 from utils import base_url_host_matches, base_url_hostname, env_float, is_truthy_value, model_forces_max_completion_tokens, normalize_proxy_env_vars
 
 logger = logging.getLogger(__name__)
@@ -3547,6 +3552,44 @@ def _relay_auxiliary_metadata(
     }
 
 
+def _enforce_auxiliary_model_call_policy(
+    client: Any,
+    request: dict[str, Any],
+    *,
+    provider: str | None,
+    api_mode: str | None,
+) -> None:
+    """Authorize one final auxiliary provider attempt."""
+    context = _RELAY_AUX_CALL_CONTEXT.get() or {}
+    attempt_count = max(1, int(context.get("attempt_count") or 0))
+    session_id = ""
+    try:
+        from agent.aux_accounting import get_accounting_context
+
+        accounting = get_accounting_context()
+        if accounting is not None:
+            session_id = str(accounting[1] or "")
+    except Exception:
+        pass
+
+    enforce_pre_model_call_policy(
+        request,
+        call_kind="auxiliary",
+        task_id=os.environ.get("HERMES_KANBAN_TASK", ""),
+        mission_id=os.environ.get("HERMES_KANBAN_MISSION", ""),
+        auxiliary_task=str(context.get("task") or "unknown"),
+        profile=os.environ.get("HERMES_PROFILE", ""),
+        session_id=session_id,
+        api_request_id=str(context.get("request_id") or ""),
+        call_seq=attempt_count,
+        request_attempt=attempt_count - 1,
+        model=str(request.get("model") or context.get("model") or ""),
+        provider=str(provider or context.get("provider") or "auxiliary"),
+        base_url=str(getattr(client, "base_url", "") or ""),
+        api_mode=str(api_mode or context.get("api_mode") or "chat_completions"),
+    )
+
+
 def _relay_sync_completion(
     client: Any,
     kwargs: dict[str, Any],
@@ -3557,17 +3600,27 @@ def _relay_sync_completion(
 ) -> Any:
     callback = create or (lambda request: client.chat.completions.create(**request))
     route = _relay_auxiliary_metadata(provider=provider, api_mode=api_mode)
+
+    def authorized(request: dict[str, Any]) -> Any:
+        _enforce_auxiliary_model_call_policy(
+            client,
+            request,
+            provider=provider,
+            api_mode=api_mode,
+        )
+        return _run_protected_sync_provider_call(callback, request)
+
     # Protected compression calls isolate only the provider callback and stream
     # aggregation.  The owning thread remains free to unwind its lease/DB
     # transaction on hard cancel without touching the process-shared client.
     if route is None:
-        return _run_protected_sync_provider_call(callback, kwargs)
+        return authorized(kwargs)
     provider_name, fallback_model, metadata = route
     from agent import relay_llm
 
     return relay_llm.execute_current(
         kwargs,
-        lambda request: _run_protected_sync_provider_call(callback, request),
+        authorized,
         name=provider_name,
         model_name=str(kwargs.get("model") or fallback_model),
         metadata=metadata,
@@ -3585,14 +3638,24 @@ async def _relay_async_completion(
 ) -> Any:
     callback = create or (lambda request: client.chat.completions.create(**request))
     route = _relay_auxiliary_metadata(provider=provider, api_mode=api_mode)
+
+    async def authorized(request: dict[str, Any]) -> Any:
+        _enforce_auxiliary_model_call_policy(
+            client,
+            request,
+            provider=provider,
+            api_mode=api_mode,
+        )
+        return await callback(request)
+
     if route is None:
-        return await callback(kwargs)
+        return await authorized(kwargs)
     provider_name, fallback_model, metadata = route
     from agent import relay_llm
 
     return await relay_llm.execute_current_async(
         kwargs,
-        callback,
+        authorized,
         name=provider_name,
         model_name=str(kwargs.get("model") or fallback_model),
         metadata=metadata,
@@ -3608,14 +3671,24 @@ def _relay_sync_stream(
     api_mode: str | None = None,
 ) -> Any:
     route = _relay_auxiliary_metadata(provider=provider, api_mode=api_mode)
+
+    def authorized(request: dict[str, Any]) -> Any:
+        _enforce_auxiliary_model_call_policy(
+            client,
+            request,
+            provider=provider,
+            api_mode=api_mode,
+        )
+        return client.chat.completions.create(**request)
+
     if route is None:
-        return client.chat.completions.create(**kwargs)
+        return authorized(kwargs)
     provider_name, fallback_model, metadata = route
     from agent import relay_llm
 
     return relay_llm.stream_current(
         kwargs,
-        lambda request: client.chat.completions.create(**request),
+        authorized,
         name=provider_name,
         model_name=str(kwargs.get("model") or fallback_model),
         finalizer=dict,
@@ -9769,6 +9842,11 @@ def call_llm(
             semaphore = None
             return _release_sync_semaphore_after_stream(response, stream_semaphore)
         return response
+    except ModelCallPolicyHalt as policy_halt:
+        raise ModelCallPolicyDenied(
+            policy_halt.action,
+            policy_halt.message,
+        ) from None
     finally:
         if latency_info is not None:
             latency_info["summary_generation_ms"] = max(
@@ -10024,6 +10102,12 @@ def _call_llm_impl(
             # Return the provider call directly; the MoA facade converts a
             # completed response into a one-chunk delta iterator at its
             # boundary.
+            _enforce_auxiliary_model_call_policy(
+                client,
+                kwargs,
+                provider=request_provider,
+                api_mode=resolved_api_mode,
+            )
             return client.chat.completions.create(**kwargs)
         return _relay_sync_stream(
             client,
@@ -10661,22 +10745,28 @@ async def async_call_llm(
     if semaphore is not None:
         await semaphore.acquire()
     try:
-        return await _async_call_llm_impl(
-            task=task,
-            provider=provider,
-            model=model,
-            base_url=base_url,
-            api_key=api_key,
-            main_runtime=main_runtime,
-            messages=messages,
-            temperature=temperature,
-            max_tokens=max_tokens,
-            tools=tools,
-            timeout=timeout,
-            extra_body=extra_body,
-            reasoning_config=reasoning_config,
-            route_info=route_info,
-        )
+        try:
+            return await _async_call_llm_impl(
+                task=task,
+                provider=provider,
+                model=model,
+                base_url=base_url,
+                api_key=api_key,
+                main_runtime=main_runtime,
+                messages=messages,
+                temperature=temperature,
+                max_tokens=max_tokens,
+                tools=tools,
+                timeout=timeout,
+                extra_body=extra_body,
+                reasoning_config=reasoning_config,
+                route_info=route_info,
+            )
+        except ModelCallPolicyHalt as policy_halt:
+            raise ModelCallPolicyDenied(
+                policy_halt.action,
+                policy_halt.message,
+            ) from None
     finally:
         if semaphore is not None:
             semaphore.release()

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2966,6 +2966,7 @@ def run_conversation(
         finish_reason = "stop"
         response = None  # Guard against UnboundLocalError if all retries fail
         api_kwargs = None  # Guard against UnboundLocalError in except handler
+        model_policy_stop = None
         api_request_id = f"{turn_id}:api:{api_call_count}"
         agent._current_api_request_id = api_request_id
 
@@ -3264,6 +3265,32 @@ def run_conversation(
                             is_github_responses=agent._is_copilot_url(),
                             sanitize_harmony_tokens=agent._is_codex_backend(),
                         )
+                    # Final provider-attempt authority boundary: execution
+                    # middleware and provider preflight have already produced
+                    # the exact request this callback would send.
+                    from hermes_cli.model_call_policy import (
+                        enforce_pre_model_call_policy,
+                    )
+
+                    enforce_pre_model_call_policy(
+                        next_api_kwargs,
+                        call_kind="conversation",
+                        task_id=effective_task_id,
+                        mission_id=os.environ.get("HERMES_KANBAN_MISSION", ""),
+                        profile=os.environ.get("HERMES_PROFILE", ""),
+                        session_id=agent.session_id or "",
+                        turn_id=turn_id,
+                        api_request_id=api_request_id,
+                        call_seq=api_call_count,
+                        request_attempt=retry_count,
+                        platform=agent.platform or "",
+                        model=agent.model,
+                        provider=agent.provider,
+                        base_url=agent.base_url,
+                        api_mode=agent.api_mode,
+                        approx_input_tokens=request_pressure_tokens,
+                        middleware_trace=list(_llm_middleware_trace),
+                    )
                     if _use_streaming:
                         return agent._interruptible_streaming_api_call(
                             next_api_kwargs, on_first_delta=_stop_spinner
@@ -3292,6 +3319,7 @@ def run_conversation(
                     )
 
                 from hermes_cli.middleware import run_llm_execution_middleware
+                from hermes_cli.model_call_policy import ModelCallPolicyHalt
 
                 _model_request_active = getattr(agent, "_model_request_active", None)
                 _redirect_lock = getattr(agent, "_pending_redirect_lock", None)
@@ -3319,6 +3347,11 @@ def run_conversation(
                         api_call_count=api_call_count,
                         middleware_trace=list(_llm_middleware_trace),
                     )
+                except ModelCallPolicyHalt as policy_halt:
+                    model_policy_stop = {
+                        "action": policy_halt.action,
+                        "message": policy_halt.message,
+                    }
                 finally:
                     if _redirect_lock is not None:
                         with _redirect_lock:
@@ -3331,6 +3364,8 @@ def run_conversation(
                         if _model_request_active is not None:
                             _model_request_active.clear()
                         _redirect_crossed_response = agent._has_pending_redirect()
+                if model_policy_stop is not None:
+                    break
                 if _redirect_crossed_response:
                     # The response and redirect can cross on different threads:
                     # redirect() observed the request as active just before this
@@ -6780,6 +6815,31 @@ def run_conversation(
                     # stale request.
                     break
         
+        if model_policy_stop is not None:
+            # The request never reached the provider, so it must not consume a
+            # model-call iteration. The policy decision itself is the terminal
+            # result for this turn and is persisted by finalize_turn.
+            api_call_count -= 1
+            agent._api_call_count = api_call_count
+            try:
+                agent.iteration_budget.refund()
+            except Exception:
+                pass
+            if thinking_spinner:
+                thinking_spinner.stop("")
+                thinking_spinner = None
+            if agent.thinking_callback:
+                agent.thinking_callback("")
+            action = str(model_policy_stop.get("action") or "deny")
+            final_response = str(
+                model_policy_stop.get("message")
+                or "Model request denied by policy."
+            )
+            failed = True
+            _turn_exit_reason = f"model_policy_{action}"
+            agent._emit_status(f"⛔ {final_response}")
+            break
+
         if _retry.restart_with_redirected_messages:
             # The cancelled request produced no valid assistant item. Reuse the
             # same logical iteration after the outer loop appends the displayed

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -643,26 +643,25 @@ def _run_agent_tool_execution_middleware(
 
             def _resolve_pre_tool_block():
                 nonlocal final_args
-                try:
-                    from hermes_cli.plugins import _dispatch_pre_tool_call_hooks
+                from hermes_cli.model_call_policy import (
+                    dispatch_pre_tool_call_fail_closed,
+                )
 
-                    block_msg, modified_args = _dispatch_pre_tool_call_hooks(
-                        function_name,
-                        final_args,
-                        task_id=effective_task_id or "",
-                        session_id=getattr(agent, "session_id", "") or "",
-                        tool_call_id=tool_call_id or "",
-                        turn_id=getattr(agent, "_current_turn_id", "") or "",
-                        api_request_id=getattr(agent, "_current_api_request_id", "")
-                        or "",
-                        middleware_trace=list(state["middleware_trace"]),
-                    )
-                    if modified_args is not None:
-                        final_args = modified_args
-                        state["args"] = modified_args
-                    return block_msg
-                except Exception:
-                    return None
+                block_msg, modified_args = dispatch_pre_tool_call_fail_closed(
+                    function_name,
+                    final_args,
+                    task_id=effective_task_id or "",
+                    session_id=getattr(agent, "session_id", "") or "",
+                    tool_call_id=tool_call_id or "",
+                    turn_id=getattr(agent, "_current_turn_id", "") or "",
+                    api_request_id=getattr(agent, "_current_api_request_id", "")
+                    or "",
+                    middleware_trace=list(state["middleware_trace"]),
+                )
+                if modified_args is not None:
+                    final_args = modified_args
+                    state["args"] = modified_args
+                return block_msg
 
             block_message = (
                 _resolve_pre_tool_block()

--- a/contributors/emails/tommi.k.karlsson@gmail.com
+++ b/contributors/emails/tommi.k.karlsson@gmail.com
@@ -1,0 +1,1 @@
+tommikkarlsson-a11y

--- a/hermes_cli/model_call_policy.py
+++ b/hermes_cli/model_call_policy.py
@@ -1,0 +1,248 @@
+"""Fail-closed plugin policy for concrete model-provider attempts.
+
+The agent loop and the auxiliary client both call this module at their final
+provider callback.  Keeping resolution and payload shaping here gives policy
+plugins one contract without making either execution loop own plugin-policy
+semantics.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Dict, Iterable, Mapping
+from urllib.parse import urlsplit
+
+logger = logging.getLogger(__name__)
+
+PRE_TOOL_CALL_POLICY_FAILURE_MESSAGE = (
+    "pre_tool_call policy could not be evaluated safely"
+)
+PRE_MODEL_CALL_POLICY_FAILURE_MESSAGE = (
+    "Model request denied because a pre-model policy did not complete safely."
+)
+
+_ACTION_RANK = {"allow": 0, "pause": 1, "deny": 2}
+_RESULT_FIELDS = frozenset({"action", "message"})
+
+
+class ModelCallPolicyHalt(BaseException):
+    """Internal control flow that bypasses provider retry/fallback handlers."""
+
+    def __init__(self, action: str, message: str) -> None:
+        self.action = action
+        self.message = message
+        super().__init__(message)
+
+
+class ModelCallPolicyDenied(RuntimeError):
+    """Public auxiliary-call error produced by a policy pause or denial."""
+
+    def __init__(self, action: str, message: str) -> None:
+        self.action = action
+        self.message = message
+        super().__init__(message)
+
+
+def fail_closed_hook_result(hook_name: str) -> Dict[str, str]:
+    """Return the hook-specific directive for an unsafe policy failure."""
+    if hook_name == "pre_model_call_policy":
+        return {
+            "action": "deny",
+            "message": PRE_MODEL_CALL_POLICY_FAILURE_MESSAGE,
+        }
+    return {
+        "action": "block",
+        "message": "pre_tool_call plugin callback timed out or is still running",
+    }
+
+
+def resolve_pre_model_call_policy(**payload: Any) -> Dict[str, str]:
+    """Resolve all registered policy callbacks for one provider attempt.
+
+    ``None`` is no opinion.  Every non-``None`` result is validated completely
+    before precedence is applied, so a malformed low-priority result cannot be
+    hidden by an earlier valid pause or denial.
+    """
+    try:
+        from hermes_cli import lifecycle
+
+        if not lifecycle.has_hook("pre_model_call_policy"):
+            return {"action": "allow", "message": ""}
+        results = lifecycle.invoke_hook("pre_model_call_policy", **payload)
+    except Exception:
+        logger.warning("pre_model_call_policy dispatch failed", exc_info=True)
+        return fail_closed_hook_result("pre_model_call_policy")
+
+    return _resolve_policy_results(results)
+
+
+def _resolve_policy_results(results: Iterable[Any]) -> Dict[str, str]:
+    validated: list[Dict[str, str]] = []
+    for result in results:
+        if result is None:
+            continue
+        if not isinstance(result, dict) or not set(result).issubset(_RESULT_FIELDS):
+            return fail_closed_hook_result("pre_model_call_policy")
+
+        raw_action = result.get("action")
+        if not isinstance(raw_action, str):
+            return fail_closed_hook_result("pre_model_call_policy")
+        action = raw_action.strip().lower()
+        if action not in _ACTION_RANK:
+            return fail_closed_hook_result("pre_model_call_policy")
+
+        raw_message = result.get("message")
+        if raw_message is not None and not isinstance(raw_message, str):
+            return fail_closed_hook_result("pre_model_call_policy")
+        validated.append(
+            {
+                "action": action,
+                "message": (raw_message or "").strip()[:500],
+            }
+        )
+
+    decision = {"action": "allow", "message": ""}
+    for result in validated:
+        if _ACTION_RANK[result["action"]] > _ACTION_RANK[decision["action"]]:
+            decision = result
+
+    if decision["action"] != "allow" and not decision["message"]:
+        decision["message"] = (
+            "Model request paused by policy."
+            if decision["action"] == "pause"
+            else "Model request denied by policy."
+        )
+    return decision
+
+
+def enforce_pre_model_call_policy(
+    request: Mapping[str, Any],
+    **context: Any,
+) -> Dict[str, str]:
+    """Authorize one final request or halt before provider I/O."""
+    try:
+        from hermes_cli import lifecycle
+
+        has_policy = lifecycle.has_hook("pre_model_call_policy")
+    except Exception:
+        logger.warning("Unable to inspect pre_model_call_policy", exc_info=True)
+        decision = fail_closed_hook_result("pre_model_call_policy")
+        raise ModelCallPolicyHalt(
+            decision["action"], decision["message"]
+        ) from None
+
+    if not has_policy:
+        return {"action": "allow", "message": ""}
+
+    payload = _policy_payload(request, **context)
+    try:
+        results = lifecycle.invoke_hook("pre_model_call_policy", **payload)
+    except Exception:
+        logger.warning("pre_model_call_policy dispatch failed", exc_info=True)
+        decision = fail_closed_hook_result("pre_model_call_policy")
+    else:
+        decision = _resolve_policy_results(results)
+
+    if decision["action"] != "allow":
+        raise ModelCallPolicyHalt(
+            decision["action"], decision["message"]
+        ) from None
+    return decision
+
+
+def _policy_payload(
+    request: Mapping[str, Any],
+    **context: Any,
+) -> Dict[str, Any]:
+    messages = request.get("messages")
+    if not isinstance(messages, list):
+        messages = request.get("input")
+    if not isinstance(messages, list):
+        messages = []
+
+    try:
+        message_utf8_bytes = len(
+            json.dumps(
+                messages,
+                ensure_ascii=False,
+                separators=(",", ":"),
+                default=str,
+            ).encode("utf-8")
+        )
+    except Exception:
+        message_utf8_bytes = -1
+
+    approx_input_tokens = context.pop("approx_input_tokens", None)
+    if not isinstance(approx_input_tokens, int) or isinstance(
+        approx_input_tokens, bool
+    ):
+        approx_input_tokens = -1
+
+    max_output_tokens = _request_output_cap(request)
+    payload: Dict[str, Any] = {
+        "policy_schema_version": 1,
+        "call_kind": str(context.pop("call_kind", "conversation") or "conversation"),
+        "task_id": str(context.pop("task_id", "") or ""),
+        "mission_id": str(context.pop("mission_id", "") or ""),
+        "auxiliary_task": str(context.pop("auxiliary_task", "") or ""),
+        "profile": str(context.pop("profile", "") or ""),
+        "session_id": str(context.pop("session_id", "") or ""),
+        "turn_id": str(context.pop("turn_id", "") or ""),
+        "api_request_id": str(context.pop("api_request_id", "") or ""),
+        "call_seq": _non_negative_int(context.pop("call_seq", 0)),
+        "request_attempt": _non_negative_int(
+            context.pop("request_attempt", 0)
+        ),
+        "platform": str(context.pop("platform", "") or ""),
+        "model": str(
+            request.get("model") or context.pop("model", "") or ""
+        ),
+        "provider": str(context.pop("provider", "") or ""),
+        "base_url_host": _base_url_host(context.pop("base_url", "")),
+        "api_mode": str(context.pop("api_mode", "") or ""),
+        "message_count": len(messages),
+        "message_utf8_bytes": message_utf8_bytes,
+        "approx_input_tokens": approx_input_tokens,
+        "max_output_tokens": max_output_tokens,
+        "middleware_trace": list(context.pop("middleware_trace", []) or []),
+    }
+    return payload
+
+
+def _request_output_cap(request: Mapping[str, Any]) -> int:
+    for key in ("max_output_tokens", "max_completion_tokens", "max_tokens"):
+        value = request.get(key)
+        if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
+            return value
+    return -1
+
+
+def _non_negative_int(value: Any) -> int:
+    if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
+        return value
+    return 0
+
+
+def _base_url_host(value: Any) -> str:
+    raw = str(value or "").strip()
+    if not raw:
+        return ""
+    try:
+        return str(urlsplit(raw).hostname or "")
+    except Exception:
+        return ""
+
+
+def dispatch_pre_tool_call_fail_closed(
+    *args: Any,
+    **kwargs: Any,
+) -> tuple[str | None, Dict[str, Any] | None]:
+    """Dispatch the existing tool policy and block on dispatcher failure."""
+    try:
+        from hermes_cli.plugins import _dispatch_pre_tool_call_hooks
+
+        return _dispatch_pre_tool_call_hooks(*args, **kwargs)
+    except Exception:
+        logger.warning("pre_tool_call policy dispatch failed closed", exc_info=True)
+        return PRE_TOOL_CALL_POLICY_FAILURE_MESSAGE, None

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -65,6 +65,7 @@ from registration_lifecycle import replacement_coordinator
 from utils import env_var_enabled, fast_safe_load
 from hermes_cli.config import cfg_get, load_config_readonly
 from hermes_cli.middleware import OBSERVER_SCHEMA_VERSION, VALID_MIDDLEWARE
+from hermes_cli.model_call_policy import fail_closed_hook_result
 from hermes_cli.plugin_capabilities import (  # noqa: F401 — re-exported
     CAPABILITY_REGISTRY,
     VALID_CAPABILITY_IDS,
@@ -170,6 +171,10 @@ VALID_HOOKS: Set[str] = {
     # First non-None string wins. Useful for vocabulary/personality transformation.
     "transform_llm_output",
     "pre_llm_call",
+    # Synchronous fail-closed policy gate for the fully assembled provider
+    # request. Unlike pre_llm_call (an additive, fail-open context hook), this
+    # hook may stop a model request by returning allow|pause|deny.
+    "pre_model_call_policy",
     "post_llm_call",
     # Streaming LLM output observer hooks. Fired asynchronously off the token
     # path by agent.plugin_stream_hooks; callbacks observe immutable normalized
@@ -395,6 +400,7 @@ VALID_HOOKS: Set[str] = {
 # have its output silently ignored — registration is refused loudly instead.
 # Support for a shell response shape can lift an event out of this set.
 SHELL_UNSUPPORTED_HOOKS: Set[str] = {
+    "pre_model_call_policy",
     "transform_api_error_classification",
 }
 
@@ -438,9 +444,12 @@ _HOOK_TIMEOUT_BOUNDED_HOOKS: Set[str] = {
     "on_session_end",
 }
 
-# Policy hooks: timeout / still-running must fail closed (block the tool).
-# Skipping would let the tool run without a completed policy decision.
-_HOOK_TIMEOUT_FAIL_CLOSED_HOOKS: Set[str] = {"pre_tool_call"}
+# Policy hooks: timeout / still-running must fail closed. Skipping would let a
+# tool or provider request run without a completed policy decision.
+_HOOK_TIMEOUT_FAIL_CLOSED_HOOKS: Set[str] = {
+    "pre_tool_call",
+    "pre_model_call_policy",
+}
 
 # Documented parent-thread serialization contract — never move the callback
 # body onto a timeout worker (see website/docs/user-guide/features/hooks.md).
@@ -5629,7 +5638,7 @@ class PluginManager:
                                 callback_name,
                             )
                             if fail_closed:
-                                results.append(_pre_tool_call_timeout_block())
+                                results.append(fail_closed_hook_result(hook_name))
                             continue
                         if suppressed_until is not None:
                             self._hook_timeout_suppressed_until.pop(callback_key, None)
@@ -5680,7 +5689,7 @@ class PluginManager:
                             timeout,
                         )
                         if fail_closed:
-                            results.append(_pre_tool_call_timeout_block())
+                            results.append(fail_closed_hook_result(hook_name))
                         continue
                     if "exc" in failure:
                         raise failure["exc"]
@@ -5696,6 +5705,8 @@ class PluginManager:
                     callback_name,
                     exc,
                 )
+                if fail_closed:
+                    results.append(fail_closed_hook_result(hook_name))
         return results
 
     def _subscribe_event(

--- a/model_tools.py
+++ b/model_tools.py
@@ -1430,23 +1430,22 @@ def handle_function_call(
         # the hook on that same pass. When skip=True, the caller already
         # fired it — do nothing here.
         if not skip_pre_tool_call_hook:
-            block_message: Optional[str] = None
-            try:
-                from hermes_cli.plugins import _dispatch_pre_tool_call_hooks
-                block_message, modified_args = _dispatch_pre_tool_call_hooks(
-                    function_name,
-                    function_args,
-                    task_id=task_id or "",
-                    session_id=session_id or "",
-                    tool_call_id=tool_call_id or "",
-                    turn_id=turn_id or "",
-                    api_request_id=api_request_id or "",
-                    middleware_trace=list(_tool_middleware_trace),
-                )
-                if modified_args is not None:
-                    function_args = modified_args
-            except Exception as _hook_err:
-                logger.debug("pre_tool_call hook error: %s", _hook_err)
+            from hermes_cli.model_call_policy import (
+                dispatch_pre_tool_call_fail_closed,
+            )
+
+            block_message, modified_args = dispatch_pre_tool_call_fail_closed(
+                function_name,
+                function_args,
+                task_id=task_id or "",
+                session_id=session_id or "",
+                tool_call_id=tool_call_id or "",
+                turn_id=turn_id or "",
+                api_request_id=api_request_id or "",
+                middleware_trace=list(_tool_middleware_trace),
+            )
+            if modified_args is not None:
+                function_args = modified_args
 
             if block_message is not None:
                 result = tool_error(block_message)

--- a/tests/agent/test_auxiliary_model_call_policy.py
+++ b/tests/agent/test_auxiliary_model_call_policy.py
@@ -1,0 +1,109 @@
+"""Auxiliary model calls share the fail-closed provider-attempt gate."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from agent.auxiliary_client import call_llm
+from hermes_cli.model_call_policy import ModelCallPolicyDenied
+
+
+def test_auxiliary_deny_makes_zero_provider_calls(monkeypatch):
+    create = MagicMock(name="provider_create")
+    client = SimpleNamespace(
+        base_url="https://provider.example/v1?credential=hidden",
+        chat=SimpleNamespace(completions=SimpleNamespace(create=create)),
+    )
+    policy_payload = {}
+
+    monkeypatch.setattr(
+        "agent.auxiliary_client._resolve_task_provider_model",
+        lambda *_args, **_kwargs: (
+            "custom",
+            "configured-model",
+            "https://provider.example/v1",
+            "secret",
+            "chat_completions",
+        ),
+    )
+    monkeypatch.setattr(
+        "agent.auxiliary_client._get_cached_client",
+        lambda *_args, **_kwargs: (client, "configured-model"),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.lifecycle.has_hook",
+        lambda name: name == "pre_model_call_policy",
+    )
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "slice-1")
+    monkeypatch.setenv("HERMES_KANBAN_MISSION", "mission-root")
+
+    def deny(_name, **payload):
+        policy_payload.update(payload)
+        return [{"action": "deny", "message": "mission budget exhausted"}]
+
+    monkeypatch.setattr("hermes_cli.lifecycle.invoke_hook", deny)
+
+    with pytest.raises(ModelCallPolicyDenied, match="mission budget exhausted"):
+        call_llm(
+            task="title_generation",
+            provider="custom",
+            model="configured-model",
+            messages=[{"role": "user", "content": "title this"}],
+        )
+
+    create.assert_not_called()
+    assert policy_payload["call_kind"] == "auxiliary"
+    assert policy_payload["task_id"] == "slice-1"
+    assert policy_payload["mission_id"] == "mission-root"
+    assert policy_payload["auxiliary_task"] == "title_generation"
+    assert policy_payload["provider"] == "custom"
+    assert policy_payload["model"] == "configured-model"
+    assert policy_payload["base_url_host"] == "provider.example"
+    assert "credential" not in str(policy_payload)
+
+
+@pytest.mark.asyncio
+async def test_async_auxiliary_deny_makes_zero_provider_calls(monkeypatch):
+    create = AsyncMock(name="provider_create")
+    client = SimpleNamespace(
+        base_url="https://async-provider.example/v1",
+        chat=SimpleNamespace(completions=SimpleNamespace(create=create)),
+    )
+
+    monkeypatch.setattr(
+        "agent.auxiliary_client._resolve_task_provider_model",
+        lambda *_args, **_kwargs: (
+            "custom",
+            "async-model",
+            "https://async-provider.example/v1",
+            "secret",
+            "chat_completions",
+        ),
+    )
+    monkeypatch.setattr(
+        "agent.auxiliary_client._get_cached_client",
+        lambda *_args, **_kwargs: (client, "async-model"),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.lifecycle.has_hook",
+        lambda name: name == "pre_model_call_policy",
+    )
+    monkeypatch.setattr(
+        "hermes_cli.lifecycle.invoke_hook",
+        lambda _name, **_payload: [
+            {"action": "deny", "message": "async budget exhausted"}
+        ],
+    )
+
+    from agent.auxiliary_client import async_call_llm
+
+    with pytest.raises(ModelCallPolicyDenied, match="async budget exhausted"):
+        await async_call_llm(
+            task="compression",
+            provider="custom",
+            model="async-model",
+            messages=[{"role": "user", "content": "compress"}],
+        )
+
+    create.assert_not_awaited()

--- a/tests/hermes_cli/test_model_call_policy.py
+++ b/tests/hermes_cli/test_model_call_policy.py
@@ -1,0 +1,125 @@
+"""Behavioral contracts for the fail-closed model-call policy."""
+
+import threading
+
+import pytest
+
+from hermes_cli.model_call_policy import (
+    PRE_MODEL_CALL_POLICY_FAILURE_MESSAGE,
+    resolve_pre_model_call_policy,
+)
+from hermes_cli.plugins import PluginManager
+
+
+def test_no_listener_allows(monkeypatch):
+    monkeypatch.setattr("hermes_cli.lifecycle.has_hook", lambda _name: False)
+
+    assert resolve_pre_model_call_policy(session_id="s1") == {
+        "action": "allow",
+        "message": "",
+    }
+
+
+def test_none_is_no_opinion(monkeypatch):
+    monkeypatch.setattr("hermes_cli.lifecycle.has_hook", lambda _name: True)
+    monkeypatch.setattr(
+        "hermes_cli.lifecycle.invoke_hook",
+        lambda _name, **_payload: [None, {"action": "allow"}],
+    )
+
+    assert resolve_pre_model_call_policy(session_id="s1") == {
+        "action": "allow",
+        "message": "",
+    }
+
+
+@pytest.mark.parametrize(
+    "results",
+    [
+        [
+            {"action": "pause", "message": "wait"},
+            {"action": "allow"},
+            {"action": "deny", "message": "budget exhausted"},
+        ],
+        [
+            {"action": "deny", "message": "budget exhausted"},
+            {"action": "allow"},
+            {"action": "pause", "message": "wait"},
+        ],
+    ],
+)
+def test_deny_wins_independent_of_registration_order(monkeypatch, results):
+    monkeypatch.setattr("hermes_cli.lifecycle.has_hook", lambda _name: True)
+    monkeypatch.setattr(
+        "hermes_cli.lifecycle.invoke_hook",
+        lambda _name, **_payload: results,
+    )
+
+    assert resolve_pre_model_call_policy(session_id="s1") == {
+        "action": "deny",
+        "message": "budget exhausted",
+    }
+
+
+@pytest.mark.parametrize(
+    "results",
+    [
+        [{"action": "allow", "message": object()}],
+        [{"action": "allow", "unknown": True}],
+        [
+            {"action": "deny", "message": "valid first"},
+            {"action": "allow", "message": object()},
+        ],
+        [
+            {"action": "pause", "message": "valid first"},
+            {"action": "allow", "message": object()},
+        ],
+        [
+            {"action": "allow", "message": object()},
+            {"action": "deny", "message": "valid second"},
+        ],
+    ],
+)
+def test_every_non_none_result_is_validated_before_precedence(
+    monkeypatch, results
+):
+    monkeypatch.setattr("hermes_cli.lifecycle.has_hook", lambda _name: True)
+    monkeypatch.setattr(
+        "hermes_cli.lifecycle.invoke_hook",
+        lambda _name, **_payload: results,
+    )
+
+    assert resolve_pre_model_call_policy(session_id="s1") == {
+        "action": "deny",
+        "message": PRE_MODEL_CALL_POLICY_FAILURE_MESSAGE,
+    }
+
+
+def test_callback_exception_and_timeout_deny(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.plugins._resolve_hook_callback_timeout", lambda: 0.05
+    )
+
+    def boom(**_kwargs):
+        raise RuntimeError("broken policy")
+
+    manager = PluginManager()
+    manager._hooks["pre_model_call_policy"] = [boom]
+    monkeypatch.setattr("hermes_cli.plugins._plugin_manager", manager)
+
+    assert resolve_pre_model_call_policy(session_id="s1") == {
+        "action": "deny",
+        "message": PRE_MODEL_CALL_POLICY_FAILURE_MESSAGE,
+    }
+
+    hold = threading.Event()
+    manager._hooks["pre_model_call_policy"] = [
+        lambda **_kwargs: hold.wait(timeout=10.0)
+    ]
+    decision = resolve_pre_model_call_policy(session_id="s2")
+    hold.set()
+
+    assert decision == {
+        "action": "deny",
+        "message": PRE_MODEL_CALL_POLICY_FAILURE_MESSAGE,
+    }

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -1219,6 +1219,36 @@ class TestForceReloadSymmetry:
         assert _PRE_TOOL_CALL_TIMEOUT_BLOCK_MESSAGE in result
         hold.set()
 
+    def test_pre_tool_call_dispatch_exception_does_not_reach_tool_handler(
+        self, monkeypatch
+    ):
+        """A policy-dispatch defect must block instead of running the tool."""
+        import json
+
+        from hermes_cli.model_call_policy import (
+            PRE_TOOL_CALL_POLICY_FAILURE_MESSAGE,
+        )
+
+        monkeypatch.setattr(
+            "hermes_cli.plugins._dispatch_pre_tool_call_hooks",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("boom")),
+        )
+        mock_registry = MagicMock()
+        mock_registry.dispatch.return_value = json.dumps({"ok": True})
+
+        with patch("model_tools.registry", mock_registry):
+            from model_tools import handle_function_call
+
+            result = handle_function_call(
+                "web_search",
+                {"query": "test"},
+                task_id="t1",
+                session_id="s1",
+            )
+
+        mock_registry.dispatch.assert_not_called()
+        assert PRE_TOOL_CALL_POLICY_FAILURE_MESSAGE in result
+
 
 class TestPreToolCallBlocking:
     """Tests for the pre_tool_call block directive helper."""

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2370,6 +2370,35 @@ class TestConcurrentToolExecution:
         assert json.loads(result) == {"error": "Blocked"}
         assert agent._turns_since_memory == 5
 
+    def test_agent_tool_dispatch_exception_fails_closed(
+        self, agent, monkeypatch
+    ):
+        from agent import tool_executor
+        from hermes_cli.model_call_policy import (
+            PRE_TOOL_CALL_POLICY_FAILURE_MESSAGE,
+        )
+
+        monkeypatch.setattr(
+            "hermes_cli.plugins._dispatch_pre_tool_call_hooks",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                RuntimeError("broken dispatcher")
+            ),
+        )
+        dispatched = []
+
+        outcome = tool_executor._run_agent_tool_execution_middleware(
+            agent,
+            function_name="terminal",
+            function_args={"command": "true"},
+            effective_task_id="task-1",
+            tool_call_id="call-1",
+            execute=lambda args: dispatched.append(args) or "ok",
+        )
+
+        assert dispatched == []
+        assert outcome.blocked is True
+        assert PRE_TOOL_CALL_POLICY_FAILURE_MESSAGE in outcome.result
+
 
 
 
@@ -3087,6 +3116,53 @@ class TestRunConversation:
             result = agent.run_conversation("hello")
         assert result["final_response"] == "Final answer"
         assert result["completed"] is True
+
+    def test_pre_model_call_policy_denies_before_provider(self, agent, monkeypatch):
+        self._setup_agent(agent)
+        policy_payload = {}
+        policy_payloads = []
+
+        def _has_hook(name):
+            return name == "pre_model_call_policy"
+
+        def _deny(_name, **payload):
+            if _name != "pre_model_call_policy":
+                return []
+            policy_payload.update(payload)
+            policy_payloads.append(dict(payload))
+            return [{"action": "deny", "message": "mission budget exhausted"}]
+
+        def _rewrite_then_call(request, next_call, **_context):
+            realized_request = dict(request)
+            realized_request["model"] = "middleware-selected-model"
+            return next_call(realized_request)
+
+        monkeypatch.setattr("hermes_cli.lifecycle.has_hook", _has_hook)
+        monkeypatch.setattr("hermes_cli.lifecycle.invoke_hook", _deny)
+        monkeypatch.setattr(
+            "hermes_cli.middleware.run_llm_execution_middleware",
+            _rewrite_then_call,
+        )
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello", task_id="slice-1")
+
+        agent.client.chat.completions.create.assert_not_called()
+        assert result["final_response"] == "mission budget exhausted"
+        assert result["completed"] is False
+        assert result["failed"] is True
+        assert result["api_calls"] == 0
+        assert result["turn_exit_reason"] == "model_policy_deny"
+        assert policy_payload["policy_schema_version"] == 1
+        assert policy_payload["task_id"] == "slice-1"
+        assert policy_payload["call_seq"] == 1
+        assert policy_payload["request_attempt"] == 0
+        assert policy_payload["message_utf8_bytes"] > 0
+        assert policy_payload["model"] == "middleware-selected-model", policy_payloads
 
     def test_prompt_cache_marks_static_system_prefix_on_wire(self, agent):
         self._setup_agent(agent)

--- a/website/docs/developer-guide/plugins/index.md
+++ b/website/docs/developer-guide/plugins/index.md
@@ -926,6 +926,7 @@ Each hook is documented in full on the **[Event Hooks reference](/user-guide/fea
 | Hook | Fires when | Callback signature | Returns |
 |------|-----------|-------------------|---------|
 | [`pre_tool_call`](/user-guide/features/hooks#pre_tool_call) | Before any tool executes | `tool_name: str, args: dict, task_id: str` | optional directive: `{"action": "block", "message": ...}` vetoes the call; `{"action": "approve", "message": ...}` escalates to the human-approval gate |
+| [`pre_model_call_policy`](/user-guide/features/hooks#pre_model_call_policy) | Final provider callback for primary conversation and centralized auxiliary calls | request identity, sanitized route, and size metadata | fail-closed `allow`, `pause`, or `deny` directive |
 | [`post_tool_call`](/user-guide/features/hooks#post_tool_call) | After any tool returns | `tool_name: str, args: dict, result: str, task_id: str, duration_ms: int` | ignored |
 | [`pre_llm_call`](/user-guide/features/hooks#pre_llm_call) | Once per turn, before the tool-calling loop | `session_id: str, user_message: str, conversation_history: list, is_first_turn: bool, model: str, platform: str` | [context injection](#pre_llm_call-context-injection) |
 | [`post_llm_call`](/user-guide/features/hooks#post_llm_call) | Once per turn, after the tool-calling loop (successful turns only) | `session_id: str, user_message: str, assistant_response: str, conversation_history: list, model: str, platform: str` | ignored |
@@ -941,7 +942,7 @@ Each hook is documented in full on the **[Event Hooks reference](/user-guide/fea
 | `kanban_task_completed` | A kanban task completes (worker process) | `task_id, board, assignee, run_id, profile_name, summary: str \| None` | ignored |
 | `kanban_task_blocked` | A kanban task is blocked (worker process) | `task_id, board, assignee, run_id, profile_name, reason: str \| None` | ignored |
 
-Most hooks are fire-and-forget observers — their return values are ignored. The exceptions are `pre_llm_call`, which can inject context into the conversation, and `pre_tool_call`, which can return a block/approve directive.
+Most hooks are fire-and-forget observers — their return values are ignored. The exceptions are `pre_llm_call`, which can inject context into the conversation; `pre_tool_call`, which can return a block/approve directive; and the Python-only `pre_model_call_policy`, which fail-closes a provider request unless its callbacks resolve to `allow`.
 
 All callbacks should accept `**kwargs` for forward compatibility. If a hook callback crashes, it's logged and skipped. Other hooks and the agent continue normally.
 

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -383,7 +383,7 @@ def register(ctx):
 
 - Callbacks receive **keyword arguments**. Always accept `**kwargs` for forward compatibility.
 - Callback exceptions are logged and skipped; later callbacks continue.
-- If a Python plugin callback on a **timeout-bounded** hook (hot-path observers such as `post_tool_call` / `pre_llm_call`, plus the policy hook `pre_tool_call`) **blocks** longer than `plugins.hook_callback_timeout` (default 30s, set `0` to disable, max 600), it is abandoned without joining the worker so the agent loop continues. Timed-out or still-running `pre_tool_call` callbacks **fail closed** (block the tool); other bounded hooks fail open (skip). Hooks with a documented caller-thread contract (`subagent_stop`) are never moved onto a timeout worker. Shell hooks keep their own per-entry `timeout`.
+- If a Python plugin callback on a **timeout-bounded** hook (hot-path observers such as `post_tool_call` / `pre_llm_call`, plus the policy hooks `pre_tool_call` and `pre_model_call_policy`) **blocks** longer than `plugins.hook_callback_timeout` (default 30s, set `0` to disable, max 600), it is abandoned without joining the worker so the agent loop continues. Timed-out, still-running, or raised policy callbacks **fail closed** (`pre_tool_call` blocks the tool; `pre_model_call_policy` denies the provider request); other bounded hooks fail open (skip). Hooks with a documented caller-thread contract (`subagent_stop`) are never moved onto a timeout worker. Shell hooks keep their own per-entry `timeout`.
 - The catalog below is descriptive: **observers** ignore returns, **transforms** accept the first valid string replacement, and **directive/control** hooks consume documented return shapes. Plugin middleware is a separate registry and surface, not another hook category.
 - Correlation fields such as `turn_id`, `api_request_id`, `task_id`, `session_id`, and `api_call_count` are hook-specific and may be absent. Treat IDs as opaque.
 - Runtime event-name validity comes from `hermes_cli.plugins.VALID_HOOKS`. `hermes hooks list` lists configured shell/outbound hooks, not every available event; `hermes hooks test <event>` reports the valid set only when an invalid event is supplied.
@@ -439,6 +439,7 @@ Payload fields below are the exact event-specific fields supplied by each call s
 | Hook | Category | Exact timing and return behavior | Explicit payload fields | Privacy / sensitivity |
 |---|---|---|---|---|
 | [`pre_tool_call`](#pre_tool_call) | Directive/control | Once before execution; first valid `block` or `approve` directive wins, and `modify` returns are shallow-merged into the tool arguments. | `tool_name`, `args`, `task_id`, `session_id`, `tool_call_id`, `turn_id`, `api_request_id`, `middleware_trace` | Raw arguments may contain user content, paths, commands, or secrets. |
+| [`pre_model_call_policy`](#pre_model_call_policy) | Fail-closed directive/control | At the final provider callback for primary conversation-loop and centralized auxiliary calls, after request/execution middleware and final preflight; `deny` wins over `pause`, which wins over `allow`. | `policy_schema_version`, `call_kind`, `task_id`, `mission_id`, `auxiliary_task`, `profile`, `session_id`, `turn_id`, `api_request_id`, `call_seq`, `request_attempt`, `platform`, `model`, `provider`, `base_url_host`, `api_mode`, `message_count`, `message_utf8_bytes`, `approx_input_tokens`, `max_output_tokens`, `middleware_trace` | Carries request identity, sanitized route metadata, and size metadata, not prompt content. Python plugins only. |
 | `post_tool_call` | Observer | After blocked, error, or successful result; return ignored. | `tool_name`, `args`, `result`, `task_id`, `session_id`, `tool_call_id`, `turn_id`, `api_request_id`, `duration_ms`, `status`, `error_type`, `error_message`, `middleware_trace` | Result/error text may contain arbitrary tool or user content and secrets. |
 | `transform_tool_result` | Transform | After `post_tool_call`, before conversation append; first string replaces the result. | `tool_name`, `args`, `result`, `task_id`, `session_id`, `tool_call_id`, `turn_id`, `api_request_id`, `duration_ms`, `status`, `error_type`, `error_message` | Exposes the full model-bound result and arguments. |
 | `transform_terminal_output` | Transform | After bounded foreground process capture, before final output limiting; first string replaces output. | `command`, `output`, `returncode`, `task_id`, `env_type` | Command/output may contain credentials. |
@@ -653,6 +654,27 @@ def track_metrics(tool_name, result, duration_ms=0, **kwargs):
 def register(ctx):
     ctx.register_hook("post_tool_call", track_metrics)
 ```
+
+---
+
+### `pre_model_call_policy`
+
+Fires at the final provider callback for each primary conversation-loop request and each centralized `call_llm` / `async_call_llm` auxiliary attempt. Request middleware, execution middleware, route selection, and final provider preflight have already produced the request that would be sent. It is a Python-plugin-only, fail-closed policy gate; use `pre_api_request` for passive request telemetry and `pre_llm_call` for context injection. Standalone SDK clients created outside those two host-owned execution paths are deliberately outside this contract.
+
+```python
+def enforce_budget(session_id, call_seq, approx_input_tokens,
+                   max_output_tokens, **kwargs):
+    if would_exceed_budget(session_id, approx_input_tokens, max_output_tokens):
+        return {"action": "deny", "message": "Model budget exhausted"}
+    return {"action": "allow"}
+
+def register(ctx):
+    ctx.register_hook("pre_model_call_policy", enforce_budget)
+```
+
+Callbacks may return `allow`, `pause`, or `deny`. All registered callbacks run; `deny` wins over `pause`, and `pause` wins over `allow`. `None` means the callback is not applicable. Every non-`None` result is fully validated before precedence is applied. A timeout, exception, still-running callback, malformed non-`None` result, or dispatcher failure becomes `deny`, and the provider is not called. For a conversation request, `pause` or `deny` ends the turn with `completed=false`, `failed=true`, and `turn_exit_reason=model_policy_<action>` without consuming a model-call iteration. For an auxiliary request, it raises `ModelCallPolicyDenied` directly to the owning caller without provider retry or fallback.
+
+The payload contains stable request identity, sanitized route metadata, and bounded size metadata rather than prompt content. `policy_schema_version` is `1`; `call_kind` is `conversation` or `auxiliary`; `request_attempt` identifies retries of a logical request. `message_utf8_bytes=-1`, `approx_input_tokens=-1`, or `max_output_tokens=-1` means that measurement is unavailable and lets strict policies deny. `base_url_host` contains only the parsed hostname. Dispatcher-launched work maps `task_id` and `mission_id` from `HERMES_KANBAN_TASK` and `HERMES_KANBAN_MISSION`; callers that do not own a mission leave them empty. `profile` is populated from the existing `HERMES_PROFILE` runtime identity when present; auxiliary calls additionally expose their configured task as `auxiliary_task`.
 
 ---
 

--- a/website/docs/user-guide/features/plugins.md
+++ b/website/docs/user-guide/features/plugins.md
@@ -268,11 +268,11 @@ When you upgrade to a version of Hermes that has opt-in plugins (config schema v
 
 ## Available hooks
 
-Plugins can register the 26 lifecycle events currently accepted by `hermes_cli.plugins.VALID_HOOKS`. The **[Event Hooks catalog](/user-guide/features/hooks#shipped-plugin-hook-catalog)** is canonical for exact timing, return handling, payload fields, and privacy notes.
+Plugins can register the lifecycle events currently accepted by `hermes_cli.plugins.VALID_HOOKS`. The **[Event Hooks catalog](/user-guide/features/hooks#shipped-plugin-hook-catalog)** is canonical for exact timing, return handling, payload fields, and privacy notes.
 
 | Descriptive category | Shipped hooks |
 |---|---|
-| **Directive/control** | `pre_tool_call`, `pre_llm_call`, `pre_verify`, `pre_gateway_dispatch` |
+| **Directive/control** | `pre_tool_call`, `pre_model_call_policy`, `pre_llm_call`, `pre_verify`, `pre_gateway_dispatch` |
 | **Transform** | `transform_tool_result`, `transform_terminal_output`, `transform_llm_output`, `pre_transcription` |
 | **Observer** | `post_tool_call`, `post_llm_call`, `pre_api_request`, `post_api_request`, `api_request_error`, `on_stream_start`, `on_stream_delta`, `on_stream_end`, `on_interim_message`, `on_session_start`, `on_session_end`, `on_session_finalize`, `on_session_reset`, `on_skill_lifecycle`, `subagent_start`, `subagent_stop`, `pre_approval_request`, `post_approval_response`, `pre_command`, `kanban_task_claimed`, `kanban_task_completed`, `kanban_task_blocked` |
 


### PR DESCRIPTION
## Summary

- add a Python-only `pre_model_call_policy` hook at the final provider callback
- use one bounded policy owner for both the primary conversation loop and centralized sync/async auxiliary model calls
- resolve `allow`, `pause`, and `deny` fail closed on timeout, callback error, dispatcher error, or any malformed non-`None` output
- make existing pre-tool policy dispatch exceptions fail closed on both execution paths
- preserve Tommi Karlsson / `tommikkarlsson-a11y` attribution with the normal contributor mapping

## Contract

The policy observes the realized request after request/execution middleware, route selection, and final provider preflight, immediately before provider I/O. A deny or pause makes zero provider calls. Auxiliary denial surfaces directly as `ModelCallPolicyDenied`, bypassing provider retry and fallback.

`None` means no opinion. Every non-`None` result is fully validated before precedence is applied, so malformed allow or lower-priority results cannot bypass fail-closed behavior. The payload carries bounded request identity, exact optional task/mission attribution, sanitized route metadata, and size metadata without prompt content.

The contract covers the host-owned primary conversation path and centralized `call_llm` / `async_call_llm` auxiliary path. Standalone SDK clients outside those paths are explicitly out of scope. Issue #93592 is complementary evidence for the two-path model-I/O architecture.

## Review blockers resolved

- auxiliary sync and async deny witnesses prove zero provider calls
- documented `None` behavior has a direct regression
- malformed allow, malformed lower-priority results, and registration-order permutations all deny
- policy resolution and tool fail-closed dispatch live behind `hermes_cli/model_call_policy.py` instead of regrowing policy semantics in the active godfiles
- branch is restacked onto current upstream `main@dce2ecb8a9428aedf69e959bd15d7a9fa15eae01`
- contributor email mapping is included

## Validation on exact head

- policy/plugin suite: 87 passed
- `tests/run_agent/test_run_agent.py` excluding one environment-dependent Anthropic test: 282 passed
- targeted conversation and tool fail-closed witnesses: 2 passed
- Ruff: passed
- `git diff --check`: passed

The excluded Anthropic test cannot construct its optional client in this local runtime because the `anthropic` package is not installed; the changed policy paths pass on the exact submitted head.
