### PR TITLE
test(skills): add contract and workflow test suites for productivity and research skills

### DIFF
--- a/tests/skills/_skill_test_utils.py
+++ b/tests/skills/_skill_test_utils.py
@@ -1,0 +1,33 @@
+"""Shared helper utilities for skill contract and discipline tests."""
+
+import re
+from pathlib import Path
+from typing import Any
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def parse_frontmatter_and_body(skill_path: Path) -> tuple[dict[str, Any], str]:
+    """Extract YAML frontmatter and body from a SKILL.md file."""
+    content = skill_path.read_text(encoding="utf-8")
+    assert content.startswith("---"), f"{skill_path}: SKILL.md must start with ---"
+    m = re.search(r"\n---\s*\n", content[3:])
+    assert m, f"{skill_path}: unclosed frontmatter"
+    fm = yaml.safe_load(content[3 : m.start() + 3])
+    assert isinstance(fm, dict), f"{skill_path}: frontmatter must be a YAML mapping"
+    body = content[m.end() + 3 :]
+    return fm, body
+
+
+def resolve_related_skills_in_repo(names: list[str]) -> list[str]:
+    """Check that each related skill name exists in skills/ or optional-skills/."""
+    missing = []
+    for name in names:
+        hits = (
+            list(REPO_ROOT.glob(f"skills/**/{name}/SKILL.md"))
+            + list(REPO_ROOT.glob(f"optional-skills/**/{name}/SKILL.md"))
+        )
+        if not hits:
+            missing.append(name)
+    return missing

--- a/tests/skills/_skill_test_utils.py
+++ b/tests/skills/_skill_test_utils.py
@@ -10,7 +10,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 
 def parse_frontmatter_and_body(skill_path: Path) -> tuple[dict[str, Any], str]:
     """Extract YAML frontmatter and body from a SKILL.md file."""
-    content = skill_path.read_text(encoding="utf-8")
+    content = skill_path.read_text(encoding="utf-8").lstrip("\ufeff\r\n\t ")
     assert content.startswith("---"), f"{skill_path}: SKILL.md must start with ---"
     m = re.search(r"\n---\s*\n", content[3:])
     assert m, f"{skill_path}: unclosed frontmatter"

--- a/tests/skills/test_docx_skill.py
+++ b/tests/skills/test_docx_skill.py
@@ -1,0 +1,82 @@
+"""Contract and CLI tool tests for the docx productivity skill."""
+
+import re
+from pathlib import Path
+import pytest
+
+from tests.skills._skill_test_utils import parse_frontmatter_and_body, resolve_related_skills_in_repo
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILL_MD = REPO_ROOT / "skills" / "productivity" / "docx" / "SKILL.md"
+
+REQUIRED_SECTIONS = [
+    "## When to Use",
+    "## Prerequisites",
+    "## How to Run",
+    "## Quick Reference",
+]
+
+DOCX_SCRIPTS = [
+    "docx_create.py",
+    "docx_read.py",
+    "docx_edit.py",
+    "docx_template.py",
+    "docx_revisions.py",
+    "docx_comments.py",
+    "docx_validate.py",
+]
+
+
+class TestDocxContract:
+    """Test that docx skill adheres to the project hardline standards."""
+
+    def test_skill_file_exists(self):
+        assert SKILL_MD.is_file()
+
+    def test_frontmatter_required_fields(self):
+        fm, _ = parse_frontmatter_and_body(SKILL_MD)
+        for field in ("name", "description", "version", "author", "license", "platforms"):
+            assert field in fm, f"missing frontmatter field: {field}"
+        assert fm["name"] == "docx"
+        hermes = fm["metadata"]["hermes"]
+        assert hermes["tags"]
+        assert "related_skills" in hermes
+
+    def test_description_hardline(self):
+        fm, _ = parse_frontmatter_and_body(SKILL_MD)
+        desc = fm["description"]
+        assert len(desc) <= 60, f"description is {len(desc)} chars; max allowed is 60"
+        assert desc.endswith("."), "description must end with a period"
+        assert not re.search(
+            r"\b(powerful|comprehensive|seamless|revolutionary|cutting-edge|state-of-the-art)\b",
+            desc,
+            re.I,
+        )
+
+    def test_related_skills_resolve_in_repo(self):
+        fm, _ = parse_frontmatter_and_body(SKILL_MD)
+        missing = resolve_related_skills_in_repo(fm["metadata"]["hermes"]["related_skills"])
+        assert not missing, f"related_skills entries do not resolve in repo: {missing}"
+
+    def test_no_machine_local_paths(self):
+        content = SKILL_MD.read_text(encoding="utf-8")
+        assert "/home/" not in content
+        assert not re.search(r"[A-Z]:\\\\Users", content)
+
+
+class TestDocxContentAndStructure:
+    """Test docx document operations, prerequisites, and CLI helper scripts."""
+
+    def test_required_sections_present(self):
+        _, body = parse_frontmatter_and_body(SKILL_MD)
+        for section in REQUIRED_SECTIONS:
+            assert section in body, f"section {section} must be present"
+
+    def test_python_docx_dependency_documented(self):
+        _, body = parse_frontmatter_and_body(SKILL_MD)
+        assert "python-docx" in body, "must document python-docx requirement"
+
+    def test_helper_scripts_documented(self):
+        _, body = parse_frontmatter_and_body(SKILL_MD)
+        for script in DOCX_SCRIPTS:
+            assert script in body, f"helper script {script} must be documented"

--- a/tests/skills/test_research_paper_writing_skill.py
+++ b/tests/skills/test_research_paper_writing_skill.py
@@ -1,0 +1,88 @@
+"""Contract and methodology tests for the research-paper-writing skill."""
+
+import re
+from pathlib import Path
+import pytest
+
+from tests.skills._skill_test_utils import parse_frontmatter_and_body, resolve_related_skills_in_repo
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILL_MD = REPO_ROOT / "skills" / "research" / "research-paper-writing" / "SKILL.md"
+
+PIPELINE_PHASES = [
+    "## Phase 0: Project Setup",
+    "## Phase 1: Literature Review",
+    "## Phase 2: Experiment Design",
+    "## Phase 3: Experiment Execution & Monitoring",
+    "## Phase 4: Result Analysis",
+    "## Phase 5: Paper Drafting",
+    "## Phase 6: Self-Review & Revision",
+    "## Phase 7: Submission Preparation",
+    "## Phase 8: Post-Acceptance Deliverables",
+]
+
+TARGET_VENUES = ["NeurIPS", "ICML", "ICLR", "ACL", "AAAI", "COLM"]
+
+
+class TestResearchPaperWritingContract:
+    """Test that research-paper-writing adheres to the project hardline standards."""
+
+    def test_skill_file_exists(self):
+        assert SKILL_MD.is_file()
+
+    def test_frontmatter_required_fields(self):
+        fm, _ = parse_frontmatter_and_body(SKILL_MD)
+        for field in ("name", "description", "version", "author", "license", "platforms"):
+            assert field in fm, f"missing frontmatter field: {field}"
+        assert fm["name"] == "research-paper-writing"
+        assert fm.get("dependencies")
+        hermes = fm["metadata"]["hermes"]
+        assert hermes["tags"]
+        assert "related_skills" in hermes
+
+    def test_description_hardline(self):
+        fm, _ = parse_frontmatter_and_body(SKILL_MD)
+        desc = fm["description"]
+        assert len(desc) <= 60, f"description is {len(desc)} chars; max allowed is 60"
+        assert desc.endswith("."), "description must end with a period"
+        assert not re.search(
+            r"\b(powerful|comprehensive|seamless|revolutionary|cutting-edge|state-of-the-art)\b",
+            desc,
+            re.I,
+        )
+
+    def test_related_skills_resolve_in_repo(self):
+        fm, _ = parse_frontmatter_and_body(SKILL_MD)
+        missing = resolve_related_skills_in_repo(fm["metadata"]["hermes"]["related_skills"])
+        assert not missing, f"related_skills entries do not resolve in repo: {missing}"
+
+    def test_no_machine_local_paths(self):
+        content = SKILL_MD.read_text(encoding="utf-8")
+        assert "/home/" not in content
+        assert not re.search(r"[A-Z]:\\\\Users", content)
+
+
+class TestResearchPaperWritingContentAndStructure:
+    """Test research paper writing pipeline phases, core philosophy, and conference venues."""
+
+    def test_pipeline_phases_present_and_ordered(self):
+        _, body = parse_frontmatter_and_body(SKILL_MD)
+        positions = [body.index(phase) for phase in PIPELINE_PHASES]
+        assert positions == sorted(positions), "phases must follow 0-8 research lifecycle order"
+
+    def test_target_venues_documented(self):
+        _, body = parse_frontmatter_and_body(SKILL_MD)
+        for venue in TARGET_VENUES:
+            assert venue in body, f"target venue {venue} must be covered in the paper pipeline"
+
+    def test_core_philosophy_rules_present(self):
+        _, body = parse_frontmatter_and_body(SKILL_MD)
+        assert "Never hallucinate citations" in body
+        assert "Paper is a story" in body
+        assert "Experiments serve claims" in body
+        assert "Commit early, commit often" in body
+
+    def test_proactivity_and_collaboration_matrix(self):
+        _, body = parse_frontmatter_and_body(SKILL_MD)
+        assert "Proactivity and Collaboration" in body
+        assert "Draft first, ask with the draft" in body

--- a/tests/skills/test_session_librarian_skill.py
+++ b/tests/skills/test_session_librarian_skill.py
@@ -1,0 +1,89 @@
+"""Contract and workflow discipline tests for the session-librarian skill."""
+
+import re
+from pathlib import Path
+import pytest
+
+from tests.skills._skill_test_utils import parse_frontmatter_and_body, resolve_related_skills_in_repo
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILL_MD = REPO_ROOT / "skills" / "productivity" / "session-librarian" / "SKILL.md"
+
+REQUIRED_SECTIONS = [
+    "## When to Use",
+    "## The Two Surfaces",
+    "## Procedure",
+    "## Parallel Workstreams",
+    "## Pitfalls",
+    "## Verification",
+]
+
+PROCEDURE_STEPS = [
+    "① **Discover.**",
+    "② **Summarize per session.**",
+    "③ **Plan before acting",
+    "④ **Act with the safest primitive.**",
+    "⑤ **Report.**",
+]
+
+
+class TestSessionLibrarianContract:
+    """Test that session-librarian adheres to the project hardline standards."""
+
+    def test_skill_file_exists(self):
+        assert SKILL_MD.is_file()
+
+    def test_frontmatter_required_fields(self):
+        fm, _ = parse_frontmatter_and_body(SKILL_MD)
+        for field in ("name", "description", "version", "author", "license", "platforms"):
+            assert field in fm, f"missing frontmatter field: {field}"
+        assert fm["name"] == "session-librarian"
+        hermes = fm["metadata"]["hermes"]
+        assert hermes["tags"]
+        assert "related_skills" in hermes
+
+    def test_description_hardline(self):
+        fm, _ = parse_frontmatter_and_body(SKILL_MD)
+        desc = fm["description"]
+        assert len(desc) <= 60, f"description is {len(desc)} chars; max allowed is 60"
+        assert desc.endswith("."), "description must end with a period"
+        assert not re.search(
+            r"\b(powerful|comprehensive|seamless|revolutionary|cutting-edge|state-of-the-art)\b",
+            desc,
+            re.I,
+        )
+
+    def test_related_skills_resolve_in_repo(self):
+        fm, _ = parse_frontmatter_and_body(SKILL_MD)
+        missing = resolve_related_skills_in_repo(fm["metadata"]["hermes"]["related_skills"])
+        assert not missing, f"related_skills entries do not resolve in repo: {missing}"
+
+    def test_no_machine_local_paths(self):
+        content = SKILL_MD.read_text(encoding="utf-8")
+        assert "/home/" not in content
+        assert not re.search(r"[A-Z]:\\\\Users", content)
+
+
+class TestSessionLibrarianContentAndStructure:
+    """Test session librarian procedures, safety gates, and dry-run rules."""
+
+    def test_required_sections_present_and_ordered(self):
+        _, body = parse_frontmatter_and_body(SKILL_MD)
+        positions = [body.index(section) for section in REQUIRED_SECTIONS]
+        assert positions == sorted(positions), "sections must follow structured order"
+
+    def test_procedure_steps_present_and_ordered(self):
+        _, body = parse_frontmatter_and_body(SKILL_MD)
+        positions = [body.index(step) for step in PROCEDURE_STEPS]
+        assert positions == sorted(positions), "procedure steps must follow 1-5 sequence"
+
+    def test_safety_and_dry_run_disciplines(self):
+        _, body = parse_frontmatter_and_body(SKILL_MD)
+        assert "--dry-run" in body, "must require --dry-run before destructive mutation"
+        assert "--yes" in body, "must document --yes for confirmed deletion"
+        assert "export" in body, "must offer session export backup before pruning"
+        assert "archive" in body, "must prefer reversible archive over hard delete"
+
+    def test_parallel_workstreams_uses_delegation(self):
+        _, body = parse_frontmatter_and_body(SKILL_MD)
+        assert "delegate_task" in body, "must use delegate_task for parallel workstreams"


### PR DESCRIPTION
### Summary of changes
- Adds dedicated hermetic contract and workflow discipline test suites for productivity and research skills:
  - `session-librarian` (`tests/skills/test_session_librarian_skill.py`): 9 tests covering 5-step session management procedure, `--dry-run` and `--yes` safety gates, export backups, and `delegate_task` parallel workstreams.
  - `research-paper-writing` (`tests/skills/test_research_paper_writing_skill.py`): 9 tests covering 9-phase ML research lifecycle (Phases 0-8), target venues (NeurIPS, ICML, ICLR, ACL, AAAI, COLM), citation veracity discipline, and proactivity matrix.
  - `docx` (`tests/skills/test_docx_skill.py`): 8 tests covering `python-docx` dependencies, document manipulation capabilities, and the 7 helper scripts in `scripts/`.
- Extracts shared skill testing utilities in `tests/skills/_skill_test_utils.py`.

### How to test
```bash
pytest tests/skills/test_session_librarian_skill.py tests/skills/test_research_paper_writing_skill.py tests/skills/test_docx_skill.py -v
# Expected: 26 passed in ~0.3s

python scripts/check-windows-footguns.py tests/skills/_skill_test_utils.py tests/skills/test_session_librarian_skill.py tests/skills/test_research_paper_writing_skill.py tests/skills/test_docx_skill.py
# Expected: 0 footguns found
```

### Platforms tested
- macOS (Darwin aarch64, Python 3.11)