### PR TITLE
fix(tools): scope the tools summary to the configurable toolset universe

### DIFF
--- a/contributors/emails/salch-cred@users.noreply.github.com
+++ b/contributors/emails/salch-cred@users.noreply.github.com
@@ -1,0 +1,1 @@
+salch-cred

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -2486,7 +2486,17 @@ def _platform_toolset_summary(config: dict, platforms: Optional[List[str]] = Non
 
     summary: Dict[str, Set[str]] = {}
     for pkey in platforms:
-        summary[pkey] = _get_platform_tools(config, pkey)
+        # Scope the summary to the configurable-toolset universe for this
+        # platform. The ``--summary`` denominator is
+        # ``_get_effective_configurable_toolsets()``, but the raw
+        # ``_get_platform_tools`` set also contains MCP server names and
+        # non-configurable recovered toolsets (e.g. ``kanban``), so ``count``
+        # could exceed ``total`` (``28/25``) and render ``✓ <mcp-server>`` /
+        # ``✓ kanban`` rows. Match the interactive checklist's scope
+        # (``_checklist_toolset_keys``) so the two CLI surfaces agree (#97015).
+        enabled = _get_platform_tools(config, pkey, include_default_mcp_servers=False)
+        universe = _checklist_toolset_keys(pkey)
+        summary[pkey] = enabled & universe
     return summary
 
 

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -19,6 +19,7 @@ from hermes_cli.tools_config import (
     _reconfigure_provider,
     _get_platform_tools,
     _platform_toolset_summary,
+    _get_effective_configurable_toolsets,
     _reconfigure_tool,
     _run_post_setup,
     _save_platform_tools,
@@ -1219,3 +1220,28 @@ def test_explicit_plugin_toolset_admitted_against_real_a2a_plugin(monkeypatch):
         f"plugin-provided 'a2a' toolset dropped by _get_platform_tools "
         f"(Layer 2 of #81163); enabled={sorted(enabled)}"
     )
+
+
+def test_toolset_summary_matches_configurable_universe():
+    """`hermes tools --summary` must not count MCP server names or
+    non-configurable recovered toolsets (e.g. ``kanban``), or it would print
+    ``count > total`` (e.g. ``28/25``) against the configurable-toolset
+    denominator and render ``✓ <mcp-server>`` / ``✓ kanban`` rows.
+    Regression for #97015.
+    """
+    config = {
+        "platform_toolsets": {"cli": ["hermes-cli"]},
+        "mcp_servers": {"mcp-chrome": {"command": "npx", "args": ["x"]}},
+    }
+
+    summary = _platform_toolset_summary(config, platforms=["cli"])
+    enabled = summary["cli"]
+
+    # MCP server names and non-configurable recovered toolsets must not
+    # inflate the summary's count.
+    assert "mcp-chrome" not in enabled
+    assert "kanban" not in enabled
+
+    # Every counted key is one the configurable-toolset universe can label.
+    universe = {k for k, _, _ in _get_effective_configurable_toolsets()}
+    assert all(k in universe for k in enabled)


### PR DESCRIPTION
Fixes #97015 — `hermes tools --summary` counts MCP server names and non-configurable recovered toolsets against a configurable-only denominator, and disagrees with the interactive checklist.

## Root cause

`_platform_toolset_summary()` built each platform's set from `_get_platform_tools(config, pkey)` with the **default** `include_default_mcp_servers=True`. That set contains MCP server names and non-configurable recovered toolsets (e.g. `kanban`). But `--summary` prints `count = len(enabled)` against `total = len(_get_effective_configurable_toolsets())` — so:

- `count` can exceed `total` (a user-visible `28/25`), and
- the summary renders `✓ <mcp-server>` / `✓ kanban` rows that are never offered as toggles.

Separately, `--summary` used the MCP-inclusive default while the interactive checklist uses `include_default_mcp_servers=False` (`tools_config.py:5439`), so the same config reports different counts in the two CLI surfaces.

## Fix

Scope `_platform_toolset_summary` to the platform's configurable-toolset universe (`_checklist_toolset_keys`), the same boundary the interactive checklist uses. The summary now only counts keys the configurable-toolset universe can label, so `count ≤ total` always and no MCP/`kanban` rows leak through. The two CLI surfaces agree.

## Validation

- New regression `test_toolset_summary_matches_configurable_universe`: a config with an MCP server name and `hermes-cli` enabled must not surface `mcp-chrome` or `kanban`, and every counted key must be in the configurable universe.
- Verified the fix output (no MCP/kanban, all keys configurable).
