### PR TITLE
fix(cli): register canonical sys.modules alias under runpy to stop profile re-scope

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -14782,4 +14782,19 @@ def main():
 
 
 if __name__ == "__main__":
+    # ``python -m hermes_cli.main`` (runpy) executes this module as
+    # ``__main__`` WITHOUT registering it under its canonical name in
+    # sys.modules. The first lazy ``from hermes_cli.main import ...`` in the
+    # process (gateway/code_skew.py's boot fingerprint is the first such
+    # import in a gateway process) would then re-execute the entire module —
+    # running _apply_profile_override() a second time against the
+    # already-stripped argv. With a sticky active_profile present, that
+    # re-resolves HERMES_HOME to the named profile and silently re-scopes a
+    # ``-p default`` gateway (the systemd unit's ExecStart) to that profile,
+    # losing the multiplexer's port-binding platforms (api_server 8642) after
+    # every in-process restart. Register the canonical alias so lazy imports
+    # resolve to this already-executed module instead of re-running it.
+    import sys as _sys
+
+    _sys.modules.setdefault("hermes_cli.main", _sys.modules["__main__"])
     main()

--- a/tests/hermes_cli/test_apply_profile_override.py
+++ b/tests/hermes_cli/test_apply_profile_override.py
@@ -12,7 +12,9 @@ active_profile (child-process inheritance contract).
 from __future__ import annotations
 
 import os
+import subprocess
 import sys
+import textwrap
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -163,4 +165,74 @@ class TestSupervisedChildIgnoresStickyProfile:
         result = os.environ.get("HERMES_HOME")
         assert result is not None
         assert result.endswith("coder")
+
+
+class TestRunpyModuleExecutionRegistersCanonicalAlias:
+    """``python -m hermes_cli.main`` must execute the module exactly once.
+
+    runpy runs the module as ``__main__`` WITHOUT registering it under its
+    canonical name in sys.modules. The first lazy
+    ``from hermes_cli.main import ...`` in the process (gateway/code_skew.py's
+    boot fingerprint is the first such import in a gateway process) then
+    re-executed the whole module, running _apply_profile_override() a second
+    time against the already-stripped argv. With a sticky active_profile
+    present, that re-resolved HERMES_HOME to the named profile and silently
+    re-scoped a ``-p default`` gateway (the systemd unit's ExecStart) to that
+    profile — losing the multiplexer's port-binding platforms (api_server
+    8642) after every in-process restart.
+    """
+
+    def test_lazy_import_does_not_rescope_launcher_profile(self, tmp_path):
+        hermes_root = tmp_path / ".hermes"
+        (hermes_root / "profiles" / "biz-assistant").mkdir(parents=True)
+        (hermes_root / "active_profile").write_text("biz-assistant")
+        script = textwrap.dedent(
+            f"""
+            import importlib.util
+            import os
+            import sys
+
+            os.environ["HERMES_HOME"] = {str(hermes_root)!r}
+            sys.argv = ["hermes_cli.main", "-p", "default", "gateway", "run"]
+
+            spec = importlib.util.find_spec("hermes_cli.main")
+            source = open(spec.origin, encoding="utf-8").read()
+            # Neutralize only the trailing main() call — this test exercises
+            # the module-level profile resolution, the way runpy does, while
+            # keeping the __main__ guard block (which registers the canonical
+            # sys.modules alias) intact.
+            source = source.rsplit("    main()", 1)[0] + "    pass\\n"
+            import __main__
+            globs = __main__.__dict__
+            globs.update(
+                __name__="__main__",
+                __spec__=spec,
+                __file__=spec.origin,
+                __loader__=spec.loader,
+                __package__="hermes_cli",
+            )
+            exec(compile(source, spec.origin, "exec"), globs)
+
+            # The lazy import that used to re-execute the module:
+            from hermes_cli.main import _read_git_revision_fingerprint  # noqa: F401
+            print("FINAL_HOME=" + os.environ["HERMES_HOME"])
+            """
+        )
+        env = dict(os.environ)
+        env.pop("INVOCATION_ID", None)
+        env.pop("HERMES_S6_SUPERVISED_CHILD", None)
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            timeout=180,
+            env=env,
+            cwd=str(Path(__file__).resolve().parents[2]),
+        )
+        assert result.returncode == 0, result.stderr
+        final_lines = [
+            line for line in result.stdout.splitlines() if line.startswith("FINAL_HOME=")
+        ]
+        assert final_lines, result.stdout
+        assert final_lines[-1] == f"FINAL_HOME={hermes_root}", result.stdout
 


### PR DESCRIPTION
## What does this PR do?

Fixes a silent profile re-scope bug when Hermes is launched via `python -m hermes_cli.main` (the systemd unit's `ExecStart`).

`runpy` executes the module as `__main__` **without** registering it under its canonical name in `sys.modules`. The first lazy `from hermes_cli.main import ...` in the process — `gateway/code_skew.py`'s boot fingerprint, the first such import in a gateway process — therefore re-executed the entire module, running `_apply_profile_override()` a second time against the already-stripped `argv`. With a sticky `active_profile` present, that re-resolved `HERMES_HOME` to the named profile and silently re-scoped a `-p default` gateway to that profile, dropping the multiplexer's port-binding platforms (`api_server` 8642) after every in-process restart.

The fix registers the canonical alias in the `__main__` guard so lazy imports resolve to the already-executed module instead of re-running it.

## Related Issue

N/A (no existing issue found for this symptom).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/main.py`: in the `if __name__ == "__main__":` guard, add `sys.modules.setdefault("hermes_cli.main", sys.modules["__main__"])` before `main()` (15 lines with explanatory comment).
- `tests/hermes_cli/test_apply_profile_override.py`: regression test `TestRunpyModuleExecutionRegistersCanonicalAlias` (72 lines) that reproduces runpy execution + lazy import.

## How to Test

1. Reproduce (before fix): run the module via runpy with a sticky `active_profile` set and a `-p default` argv, then trigger a lazy `from hermes_cli.main import ...` — `HERMES_HOME` gets re-resolved to the named profile (e.g. `<root>/profiles/<sticky>`).
2. With the fix, the lazy import resolves to the already-executed module and `HERMES_HOME` stays `<root>`.
3. Regression test: `pytest tests/hermes_cli/test_apply_profile_override.py -k RunpyModuleExecution` — fails without the fix (RED verified by reverting the guard), passes with it (GREEN).

Empirical before/after on a real gateway process: before the fix `Session storage: <root>/profiles/<sticky>/sessions` + `Active profile: <sticky>`; after the fix `Session storage: <root>/sessions` and no `Active profile` line.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Fedora 44 (Linux), Python 3.13

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
