### PR TITLE
fix(desktop): preserve two-space hard breaks in preprocessMarkdown

### DIFF
--- a/apps/desktop/src/components/assistant-ui/markdown-text.test.ts
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.test.ts
@@ -102,6 +102,29 @@ describe('preprocessMarkdown', () => {
     expect(output).toContain('`items[0]`')
   })
 
+  it('preserves two-space hard breaks through preprocessing', () => {
+    // Two trailing spaces before a newline are a CommonMark hard break —
+    // Streamdown renders them as <br>. Preprocessing must be byte-identical
+    // here or the break silently disappears and both lines fuse into one.
+    const input = 'First line  \nSecond line'
+
+    expect(preprocessMarkdown(input)).toBe(input)
+  })
+
+  it('keeps hard breaks between source-list entries', () => {
+    const input = ['[1] First source  ', '[2] Second source  ', '[3] Third source'].join('\n')
+
+    const output = preprocessMarkdown(input)
+
+    expect(output).toContain('First source  \n[2]')
+  })
+
+  it('still strips a single trailing space before a newline', () => {
+    // Incidental trailing whitespace is not a hard break — the cleanup
+    // this pass was written for must keep working.
+    expect(preprocessMarkdown('First line \nSecond line')).toBe('First line\nSecond line')
+  })
+
   it('demotes title/url blocks wrapped in malformed inline fences', () => {
     const input = [
       '**🚢 TOMORROW (Fajardo, crystal clear cays, pickup avail):**',

--- a/apps/desktop/src/lib/markdown-preprocess.ts
+++ b/apps/desktop/src/lib/markdown-preprocess.ts
@@ -664,7 +664,17 @@ export function preprocessMarkdown(text: string): string {
       return leading + transformed + trailing
     })
     .join('')
-    .replace(/[ \t]+\n/g, '\n')
+    // Trailing-whitespace cleanup, Markdown-aware: two or more spaces
+    // directly before a newline are a CommonMark hard break — Streamdown
+    // renders them as <br>, so that run must reach it byte-identical or
+    // two lines fuse into one paragraph. Everything else at end-of-line
+    // (a lone space, any tab, or junk ahead of a hard-break run) is
+    // incidental trailing whitespace and still collapses exactly as this
+    // pass always did. A newline with no trailing whitespace never matches,
+    // so single newlines keep their soft-break meaning.
+    .replace(/[ \t]*(  +)\n|[ \t]+\n/g, (_match: string, hardBreak: string | undefined) =>
+      hardBreak ? `${hardBreak}\n` : '\n'
+    )
 }
 
 /**

--- a/apps/desktop/src/lib/preview-targets.ts
+++ b/apps/desktop/src/lib/preview-targets.ts
@@ -3,7 +3,14 @@ const PREVIEW_MARKDOWN_RE = /\[Preview:[^\]]+\]\((?<href>#preview[:/][^)]+)\)/gi
 export function stripPreviewTargets(text: string): string {
   return text
     .replace(PREVIEW_MARKDOWN_RE, '')
-    .replace(/[ \t]+\n/g, '\n')
+    // Trailing-whitespace cleanup, Markdown-aware: two or more spaces
+    // directly before a newline are a CommonMark hard break and must reach
+    // Streamdown byte-identical or two lines fuse into one paragraph. A
+    // lone space, any tab, or junk ahead of a hard-break run is incidental
+    // trailing whitespace and still collapses as this pass always did.
+    .replace(/[ \t]*(  +)\n|[ \t]+\n/g, (_match: string, hardBreak: string | undefined) =>
+      hardBreak ? `${hardBreak}\n` : '\n'
+    )
     .replace(/\n{3,}/g, '\n\n')
     .trim()
 }


### PR DESCRIPTION
## Summary

Hermes Desktop destroyed CommonMark two-space hard breaks before the text reached Streamdown: the trailing-whitespace cleanup ran `/[ \t]+\n/ → '\n'` in two places inside the rendering pipeline, so `"First line  \nSecond line"` rendered as one paragraph (`First line Second line`) while TUI and classic CLI rendered it correctly.

Both sites are now Markdown-aware: a run of **two or more spaces** directly before a newline survives byte-identical (that run *is* the hard break), while a lone trailing space, any tab, or junk ahead of a hard-break run still collapses exactly as before. A newline with no trailing whitespace never matches, so ordinary soft breaks keep their normal semantics — no change to single-newline behavior.

Empirically confirmed against Streamdown's own remark stack (remark-parse 11 / micromark): raw two-space input parses to `breakCount: 1`; the old preprocessor's output parses to `breakCount: 0` (fused into one text run); the fixed output restores `breakCount: 1`.

## Changes

- `apps/desktop/src/lib/markdown-preprocess.ts` — the final `.replace(/[ \t]+\n/g, '\n')` of `preprocessMarkdown()` is replaced with a Markdown-aware pass: `/[ \t]*(  +)\n|[ \t]+\n/g` keeps a 2+ space run before `\n` byte-identical and still collapses everything else at end-of-line exactly as before.
- `apps/desktop/src/lib/preview-targets.ts` — `stripPreviewTargets()` had the *same* strip and runs **inside** `preprocessMarkdown()` on every prose segment; without the same fix there, hard breaks still vanished (found by the regression tests failing after fixing only the final pass). It has exactly one production caller: `preprocessMarkdown`.
- `apps/desktop/src/components/assistant-ui/markdown-text.test.ts` — three focused regression tests: two-space hard break passes through byte-identical; hard breaks survive between source-list entries (`[1] …  \n[2] …`); a single trailing space is still stripped (original cleanup behavior kept).

## Tests

- Regression tests **fail against the old code** (2 failed | 48 passed — verified by temporarily restoring the old regexes at both sites) and **pass with the fix** (50/50).
- Full desktop ui suite: **618 files / 6131 tests pass**; `npm run typecheck` clean across all three tsconfig projects; `preview-targets.test.ts` passes unchanged.
- Focused: `vitest run --project ui src/components/assistant-ui/markdown-text.test.ts src/lib/preview-targets.test.ts` — all pass.

Closes #97117

## Notes

Three *conditional* message-ingestion normalizers (`renderMediaTags`, `normalizeCleanedText` in embedded-images, `stripGeneratedImageEchoes`) also collapse trailing whitespace, but they sanitize stored content on specific content triggers (MEDIA tags, data-image payloads, generated-image echoes) with different normalization semantics — deliberately left untouched here; happy to follow up if maintainers want the same treatment there.