### PR TITLE
fix(profiles): tolerate unreadable skill trees

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -33,7 +33,7 @@ from dataclasses import dataclass
 from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Dict, List, Optional, Tuple
 
-from agent.skill_utils import is_excluded_skill_path
+from agent.skill_utils import iter_skill_index_files
 from hermes_constants import (
     clear_named_profile_deleted,
     mark_named_profile_deleted,
@@ -839,7 +839,11 @@ def _skills_dir_signature(skills_dir: Path) -> float:
 def _count_skills(profile_dir: Path) -> int:
     """Count installed skills in a profile (cached by skills-dir signature)."""
     skills_dir = profile_dir / "skills"
-    if not skills_dir.is_dir():
+    try:
+        skills_dir_exists = skills_dir.is_dir()
+    except OSError:
+        return 0
+    if not skills_dir_exists:
         return 0
 
     key = str(skills_dir)
@@ -853,11 +857,10 @@ def _count_skills(profile_dir: Path) -> int:
     ):
         return cached[2]
 
-    count = 0
-    for md in skills_dir.rglob("SKILL.md"):
-        if is_excluded_skill_path(md):
-            continue
-        count += 1
+    try:
+        count = sum(1 for _ in iter_skill_index_files(skills_dir, "SKILL.md"))
+    except OSError:
+        count = 0
     _SKILL_COUNT_CACHE[key] = (signature, now, count)
     return count
 

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -489,6 +489,30 @@ class TestListProfiles:
         assert "alpha" in names
         assert "beta" in names
 
+    def test_unreadable_skill_tree_does_not_hide_profile(
+        self, profile_env, monkeypatch,
+    ):
+        create_profile("blocked", no_alias=True)
+        skills_dir = get_profile_dir("blocked") / "skills"
+        readable_skill = skills_dir / "readable"
+        readable_skill.mkdir()
+        (readable_skill / "SKILL.md").write_text("# Readable", encoding="utf-8")
+        blocked_tree = skills_dir / "blocked-junction"
+        blocked_tree.mkdir()
+
+        real_scandir = os.scandir
+
+        def scandir_with_blocked_tree(path):
+            if os.fspath(path) == os.fspath(blocked_tree):
+                raise OSError(448, "untrusted mount point", str(path))
+            return real_scandir(path)
+
+        monkeypatch.setattr(os, "scandir", scandir_with_blocked_tree)
+
+        listed = {profile.name: profile for profile in list_profiles()}
+        assert "blocked" in listed
+        assert listed["blocked"].skill_count == 1
+
 
 # ===================================================================
 # TestActiveProfile


### PR DESCRIPTION
## What does this PR do?

Keeps profile enumeration available when skill-counting encounters an unreadable Windows junction, reparse point, or other inaccessible subtree.

`skill_count` is presentation metadata, so an inaccessible subtree should not make `list_profiles()` hide otherwise healthy profiles. The fix reuses the canonical `iter_skill_index_files()` walker used by skill discovery and guards unexpected `OSError`s while preserving the existing count cache.

## Related Issue

Fixes #97173

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/profiles.py`
  - use `agent.skill_utils.iter_skill_index_files()` instead of direct `Path.rglob()` for profile skill counts
  - return a degraded count instead of aborting the roster when root/scan operations raise `OSError`
  - preserve the existing signature/TTL cache
- `tests/hermes_cli/test_profiles.py`
  - add a regression test that raises `OSError(448, ...)` from `os.scandir()` for one child subtree
  - prove the profile remains visible and its readable skill is still counted

## How to Test

1. Run the targeted profile-list tests:
   ```bash
   scripts/run_tests.sh tests/hermes_cli/test_profiles.py -k TestListProfiles -q
   ```
   Result: **3 passed**.
2. Run the canonical walker tests:
   ```bash
   pytest tests/agent/test_skill_utils.py -q
   ```
   Result: **22 passed, 1 skipped**.
3. Run lint and syntax checks:
   ```bash
   ruff check hermes_cli/profiles.py tests/hermes_cli/test_profiles.py
   python -m py_compile hermes_cli/profiles.py tests/hermes_cli/test_profiles.py
   git diff --check
   ```
   Result: **passed**.
4. Regression-test sabotage check: restoring the exact `origin/main` `_count_skills()` implementation makes the new test fail with `OSError: [Errno 448] untrusted mount point`; restoring this fix makes it pass.

Windows baseline note: `tests/hermes_cli/test_profiles.py` has the same 6 pre-existing POSIX-assumption failures on both current `origin/main` and this branch. The branch adds one passing test (`51 passed, 6 failed`) versus the baseline (`50 passed, 6 failed`); no new failure was introduced.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; behavior-only bug fix with regression coverage
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Pre-fix regression failure excerpt:

```text
OSError: [Errno 448] untrusted mount point: '.../skills/blocked-junction'
hermes_cli/profiles.py:857: in _count_skills
    for md in skills_dir.rglob("SKILL.md"):
```

Post-fix targeted result:

```text
3 tests passed, 0 failed
```
