### PR TITLE
fix(kanban): share dispatch admission with health

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -1629,23 +1629,17 @@ class GatewayKanbanWatchersMixin:
             return out
 
         def _ready_nonempty() -> bool:
-            """Cheap probe: is there at least one ready+assigned+unclaimed
-            task on ANY board whose assignee maps to a real Hermes profile
-            (i.e. one the dispatcher would actually spawn for)?
+            """Return whether any board has work admitted by this tick's gates.
 
-            Tasks assigned to control-plane lanes (e.g. ``orion-cc``,
-            ``orion-research``) are pulled by terminals via
-            ``claim_task`` directly and never spawnable, so a queue full
-            of those is "correctly idle", not "stuck". Filtering them out
-            here keeps the stuck-warn fire only on real failures (broken
-            PATH, missing venv, credential loss for a real Hermes profile).
+            The health probe receives the same routing, capacity, memory, and
+            review settings used by ``dispatch_once`` above. In particular,
+            unassigned rows are admitted when ``default_assignee`` resolves,
+            while dependency-blocked, capped, guarded, and invalid rows are
+            intentionally idle for this tick.
             """
             # Only probe the review column when autonomous review dispatch is
-            # actually on. With ``review_dispatch`` off (the default — no
-            # sdlc-review agent), a task parked in 'review' is "correctly idle"
-            # waiting for a human, not a stuck dispatcher; probing it here would
-            # fire a false "dispatcher stuck" warning that never clears. Shares
-            # the exact gate the dispatcher uses so the two can't drift.
+            # actually on. With ``review_dispatch`` off, a task parked in
+            # 'review' is correctly idle waiting for a human.
             _review_probe = _kb.review_dispatch_enabled()
             try:
                 boards = _kb.list_boards(include_archived=False)
@@ -1656,9 +1650,22 @@ class GatewayKanbanWatchersMixin:
                 conn = None
                 try:
                     conn = _kb.connect(board=slug)
-                    if _kb.has_spawnable_ready(conn):
+                    health_context = {
+                        "default_assignee": default_assignee,
+                        "max_spawn": max_spawn,
+                        "max_in_progress": max_in_progress,
+                        "max_in_progress_per_profile": max_in_progress_per_profile,
+                        "board": slug,
+                        # Use one sample for both lanes so this probe describes
+                        # one dispatcher tick rather than two drifting reads.
+                        "memory_pressure": _kb._memory_pressure_level(),
+                        "review_dispatch": _review_probe,
+                    }
+                    if _kb.has_spawnable_ready(conn, **health_context):
                         return True
-                    if _review_probe and _kb.has_spawnable_review(conn):
+                    if _review_probe and _kb.has_spawnable_review(
+                        conn, **health_context
+                    ):
                         return True
                 except Exception:
                     continue

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2836,18 +2836,29 @@ def _cmd_daemon(args: argparse.Namespace) -> int:
             )
 
     def _ready_queue_nonempty() -> bool:
-        """Cheap probe — is there at least one ready+assigned+unclaimed
-        task whose assignee maps to a real Hermes profile (i.e. one the
-        dispatcher would actually try to spawn for)?
+        """Return whether this tick has ready or review work to spawn.
 
-        Filters out tasks assigned to control-plane lanes
-        (e.g. ``orion-cc``, ``orion-research``) that are pulled by
-        terminals via ``claim_task`` directly — those are correctly idle
-        from the dispatcher's perspective, not stuck.
+        The health probe resolves the same routing, capacity, memory, and
+        review settings as ``run_daemon``/``dispatch_once``. A queue row that
+        is dependency-blocked, capped, guarded, or otherwise non-admissible is
+        correctly idle rather than evidence of a stuck dispatcher.
         """
         try:
             with kb.connect_closing() as conn:
-                return kb.has_spawnable_ready(conn)
+                health_context = kb._resolve_dispatch_health_context(
+                    max_spawn=(
+                        args.max
+                        if getattr(args, "max", None) is not None
+                        else kb._DISPATCH_CONTEXT_UNSET
+                    ),
+                    memory_pressure=kb._memory_pressure_level(),
+                )
+                if kb.has_spawnable_ready(conn, **health_context):
+                    return True
+                return bool(
+                    health_context["review_dispatch"]
+                    and kb.has_spawnable_review(conn, **health_context)
+                )
         except Exception:
             return False
 

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2796,7 +2796,7 @@ def _cmd_daemon(args: argparse.Namespace) -> int:
     health_state = {"bad_ticks": 0, "last_warn_at": 0}
 
     def _on_tick(res):
-        ready_pending = bool(res.skipped_unassigned) or _ready_queue_nonempty()
+        ready_pending = _ready_queue_nonempty()
         spawned_any = bool(res.spawned)
         if ready_pending and not spawned_any:
             health_state["bad_ticks"] += 1

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -9548,61 +9548,91 @@ def check_respawn_guard(
     return None
 
 
-def has_spawnable_ready(conn: sqlite3.Connection) -> bool:
-    """Return True iff there is at least one ready+assigned+unclaimed task
-    whose assignee maps to a real Hermes profile.
+def _profile_spawnability(assignee: Optional[str]) -> Optional[bool]:
+    """Return whether *assignee* can be dispatched as a Hermes profile.
 
-    Used by the gateway- and CLI-embedded dispatchers' health telemetry to
-    decide whether ``0 spawned`` is a "stuck" condition (real spawnable
-    work waiting) or a "correctly idle" condition (only control-plane
-    lanes like ``orion-cc`` / ``orion-research`` waiting on terminals
-    that pull tasks via ``claim_task`` directly).
-
-    Falls back to "any ready+assigned" if ``profile_exists`` is not
-    importable (e.g. partial install) — preserves the old behavior so
-    the warning still fires in degraded environments.
+    ``True`` and ``False`` are definitive answers. ``None`` means profile
+    introspection was unavailable; callers should retain the dispatcher's
+    existing conservative behavior and treat the row as potentially
+    spawnable. Validation is deliberately performed here instead of relying
+    only on ``profile_exists``: a synthetic database row such as ``..`` must
+    not resolve through a parent directory and look like a valid profile.
     """
-    rows = conn.execute(
-        "SELECT DISTINCT assignee FROM tasks "
-        "WHERE status = 'ready' AND assignee IS NOT NULL "
-        "    AND claim_lock IS NULL"
-    ).fetchall()
-    if not rows:
+    if not assignee:
         return False
     try:
-        from hermes_cli.profiles import profile_exists  # local import: avoids cycle
+        from hermes_cli.profiles import (
+            normalize_profile_name,
+            profile_exists,
+            validate_profile_name,
+        )
     except Exception:
-        # Can't introspect — assume spawnable, preserve legacy behavior.
-        return True
+        # Preserve the pre-existing degraded-install behavior: without the
+        # profiles module the dispatcher still surfaces possible stuck work.
+        return None
+    try:
+        canonical = normalize_profile_name(assignee)
+        validate_profile_name(canonical)
+    except (TypeError, ValueError):
+        return False
+    try:
+        return bool(profile_exists(canonical))
+    except Exception:
+        # A filesystem/profile-store failure is not proof that the row is
+        # intentionally idle. Keep health telemetry conservative and allow
+        # the normal dispatcher path to retain its existing fallback.
+        return None
+
+
+def _has_spawnable_tasks(
+    conn: sqlite3.Connection,
+    *,
+    status: str,
+    lane: str,
+) -> bool:
+    """Return whether a task in *status* would pass dispatch admission.
+
+    The health probe must use the same respawn guard as ``dispatch_once``;
+    otherwise a task intentionally deferred by the active-PR, recent-success,
+    quota, or auth guard is misreported as stuck. Guard-probe failures remain
+    conservative: they report possible work rather than hiding a real stuck
+    dispatcher. ``lane`` is passed through so the review lane retains its
+    intentional active-PR/recent-success bypass.
+    """
+    rows = conn.execute(
+        "SELECT id, assignee FROM tasks "
+        "WHERE status = ? AND assignee IS NOT NULL "
+        "    AND claim_lock IS NULL",
+        (status,),
+    ).fetchall()
     for row in rows:
-        if profile_exists(row["assignee"]):
+        spawnability = _profile_spawnability(row["assignee"])
+        if spawnability is False:
+            continue
+        try:
+            guard_reason = check_respawn_guard(conn, row["id"], lane=lane)
+        except Exception:
+            # Do not suppress the warning when the guard itself is unavailable.
+            return True
+        if guard_reason is None:
             return True
     return False
+
+
+def has_spawnable_ready(conn: sqlite3.Connection) -> bool:
+    """Return True iff a ready task would pass dispatch admission.
+
+    Used by the gateway- and CLI-embedded dispatchers' health telemetry to
+    distinguish genuinely stuck spawnable work from intentionally idle rows
+    (control-plane lanes, malformed synthetic assignees, active-PR/recent-
+    success guards, or already-claimed tasks).
+    """
+    return _has_spawnable_tasks(conn, status="ready", lane="ready")
 
 
 def has_spawnable_review(conn: sqlite3.Connection) -> bool:
-    """Return True iff there is at least one review+assigned+unclaimed task
-    whose assignee maps to a real Hermes profile.
-
-    Mirror of :func:`has_spawnable_ready` for the review column —
-    used by the health telemetry to decide whether the dispatcher
-    should have spawned a review agent.
-    """
-    rows = conn.execute(
-        "SELECT DISTINCT assignee FROM tasks "
-        "WHERE status = 'review' AND assignee IS NOT NULL "
-        "    AND claim_lock IS NULL"
-    ).fetchall()
-    if not rows:
-        return False
-    try:
-        from hermes_cli.profiles import profile_exists  # local import: avoids cycle
-    except Exception:
-        return True
-    for row in rows:
-        if profile_exists(row["assignee"]):
-            return True
-    return False
+    """Return True iff a review task would pass review dispatch admission."""
+    return _has_spawnable_tasks(conn, status="review", lane="review")
 
 
 def review_dispatch_enabled() -> bool:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -9548,18 +9548,42 @@ def check_respawn_guard(
     return None
 
 
-def _profile_spawnability(assignee: Optional[str]) -> Optional[bool]:
-    """Return whether *assignee* can be dispatched as a Hermes profile.
+@dataclass(frozen=True)
+class _ProfileAdmission:
+    """Validated profile resolution used by both dispatch and health probes."""
 
-    ``True`` and ``False`` are definitive answers. ``None`` means profile
-    introspection was unavailable; callers should retain the dispatcher's
-    existing conservative behavior and treat the row as potentially
-    spawnable. Validation is deliberately performed here instead of relying
-    only on ``profile_exists``: a synthetic database row such as ``..`` must
-    not resolve through a parent directory and look like a valid profile.
+    canonical: Optional[str]
+    spawnable: Optional[bool]
+
+
+@dataclass(frozen=True)
+class _DispatchAdmission:
+    """Result of the non-mutating portion of one dispatch admission check."""
+
+    assignee: Optional[str] = None
+    canonical_assignee: Optional[str] = None
+    reason: Optional[str] = None
+    guard_reason: Optional[str] = None
+    current_running: int = 0
+    auto_assigned_default: bool = False
+
+
+# ``None`` is a meaningful explicit value for the optional caps, so the health
+# API uses a sentinel to distinguish "caller supplied no context" from
+# "caller supplied an uncapped setting".
+_DISPATCH_CONTEXT_UNSET = object()
+
+
+def _profile_admission(assignee: Optional[str]) -> _ProfileAdmission:
+    """Resolve and validate *assignee* without allowing path traversal.
+
+    ``spawnable=None`` means profile introspection was unavailable. That keeps
+    the historical conservative health behavior for a degraded installation;
+    a syntactically invalid name is still a definitive ``False`` whenever the
+    profiles module is available (which is the normal dispatcher path).
     """
     if not assignee:
-        return False
+        return _ProfileAdmission(None, False)
     try:
         from hermes_cli.profiles import (
             normalize_profile_name,
@@ -9567,21 +9591,292 @@ def _profile_spawnability(assignee: Optional[str]) -> Optional[bool]:
             validate_profile_name,
         )
     except Exception:
-        # Preserve the pre-existing degraded-install behavior: without the
-        # profiles module the dispatcher still surfaces possible stuck work.
-        return None
+        # A partial install cannot prove that an otherwise opaque assignee is
+        # a control-plane lane. Preserve the pre-existing fail-open telemetry
+        # behavior rather than hiding a possible stuck task.
+        return _ProfileAdmission(assignee, None)
     try:
         canonical = normalize_profile_name(assignee)
         validate_profile_name(canonical)
-    except (TypeError, ValueError):
-        return False
+    except (AttributeError, TypeError, ValueError):
+        # Validation must happen before profile_exists: profile_exists resolves
+        # its path and a value such as ``..`` could otherwise escape profiles/.
+        return _ProfileAdmission(None, False)
     try:
-        return bool(profile_exists(canonical))
+        return _ProfileAdmission(canonical, bool(profile_exists(canonical)))
     except Exception:
-        # A filesystem/profile-store failure is not proof that the row is
-        # intentionally idle. Keep health telemetry conservative and allow
-        # the normal dispatcher path to retain its existing fallback.
+        # A profile-store read failure is not proof that this is an intentional
+        # human lane. Keep the existing conservative fallback for health and
+        # let the normal dispatch path retain its previous behavior.
+        return _ProfileAdmission(canonical, None)
+
+
+def _profile_spawnability(assignee: Optional[str]) -> Optional[bool]:
+    """Return the validated profile spawnability for *assignee*."""
+    return _profile_admission(assignee).spawnable
+
+
+def _dispatch_admission(
+    conn: sqlite3.Connection,
+    row: Mapping[str, Any],
+    *,
+    lane: str,
+    default_assignee: Optional[str] = None,
+    per_profile_cap: Optional[int] = None,
+    per_profile_running: Optional[Mapping[str, int]] = None,
+    check_dependencies: bool = True,
+) -> _DispatchAdmission:
+    """Apply the shared, read-only dispatch admission predicate.
+
+    ``claim_task`` / ``claim_review_task`` remain the final atomic gates. The
+    real dispatcher passes ``check_dependencies=False`` so those functions can
+    demote a raced row exactly as before; dry-run and health callers set it to
+    true so a row with unfinished parents is never reported as spawnable.
+    """
+    row_assignee = row["assignee"]
+    auto_assigned_default = False
+    if not row_assignee:
+        if lane != "ready" or not default_assignee:
+            return _DispatchAdmission(reason="unassigned")
+        default_profile = _profile_admission(default_assignee)
+        if default_profile.spawnable is False:
+            # The dispatcher reports an unusable fallback in the same bucket
+            # as an unassigned row; there is no profile it can safely spawn.
+            return _DispatchAdmission(reason="unassigned")
+        row_assignee = default_assignee
+        auto_assigned_default = True
+
+    profile = _profile_admission(row_assignee)
+    if profile.spawnable is False:
+        return _DispatchAdmission(
+            assignee=row_assignee,
+            canonical_assignee=profile.canonical,
+            reason="nonspawnable",
+        )
+
+    current_running = 0
+    if per_profile_cap is not None and per_profile_cap > 0:
+        current_running = int((per_profile_running or {}).get(row_assignee, 0))
+        if current_running >= per_profile_cap:
+            return _DispatchAdmission(
+                assignee=row_assignee,
+                canonical_assignee=profile.canonical,
+                reason="per_profile_capped",
+                current_running=current_running,
+                auto_assigned_default=auto_assigned_default,
+            )
+
+    # Keep the guard before the dependency claim, matching dispatch_once's
+    # existing order and preserving its active-PR/review-lane semantics.
+    guard_reason = check_respawn_guard(conn, row["id"], lane=lane)
+    if guard_reason is not None:
+        return _DispatchAdmission(
+            assignee=row_assignee,
+            canonical_assignee=profile.canonical,
+            reason="guard",
+            guard_reason=guard_reason,
+            auto_assigned_default=auto_assigned_default,
+        )
+
+    if check_dependencies and not _parents_satisfied(conn, row["id"]):
+        return _DispatchAdmission(
+            assignee=row_assignee,
+            canonical_assignee=profile.canonical,
+            reason="dependency",
+            auto_assigned_default=auto_assigned_default,
+        )
+
+    return _DispatchAdmission(
+        assignee=row_assignee,
+        canonical_assignee=profile.canonical,
+        current_running=current_running,
+        auto_assigned_default=auto_assigned_default,
+    )
+
+
+def _positive_dispatch_cap(value: Any, *, allow_zero: bool = False) -> Optional[int]:
+    """Parse an optional dispatcher cap without applying a default."""
+    if value is None:
         return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    if parsed < 0 or (parsed == 0 and not allow_zero):
+        return None
+    return parsed
+
+
+def _resolve_dispatch_health_context(
+    *,
+    default_assignee: Any = _DISPATCH_CONTEXT_UNSET,
+    max_spawn: Any = _DISPATCH_CONTEXT_UNSET,
+    max_in_progress: Any = _DISPATCH_CONTEXT_UNSET,
+    max_in_progress_per_profile: Any = _DISPATCH_CONTEXT_UNSET,
+    board: Optional[str] = None,
+    memory_pressure: Any = _DISPATCH_CONTEXT_UNSET,
+    review_dispatch: Any = _DISPATCH_CONTEXT_UNSET,
+) -> dict[str, Any]:
+    """Resolve the exact settings needed by the health admission probe.
+
+    Gateway and standalone callers pass their already-resolved values. Direct
+    callers that omit context get the same read-only config/memory defaults as
+    the dispatcher, which keeps the public compatibility helper truthful too.
+    """
+    kanban_cfg: Mapping[str, Any] = {}
+    if any(
+        value is _DISPATCH_CONTEXT_UNSET
+        for value in (
+            default_assignee,
+            max_spawn,
+            max_in_progress,
+            max_in_progress_per_profile,
+            memory_pressure,
+            review_dispatch,
+        )
+    ):
+        try:
+            from hermes_cli.config import load_config
+            loaded = load_config()
+            candidate = loaded.get("kanban", {}) if isinstance(loaded, dict) else {}
+            kanban_cfg = candidate if isinstance(candidate, dict) else {}
+        except Exception:
+            kanban_cfg = {}
+
+    if default_assignee is _DISPATCH_CONTEXT_UNSET:
+        default_assignee = (kanban_cfg.get("default_assignee") or "").strip() or None
+    elif default_assignee is not None:
+        default_assignee = str(default_assignee).strip() or None
+
+    if max_spawn is _DISPATCH_CONTEXT_UNSET:
+        max_spawn = _positive_dispatch_cap(
+            kanban_cfg.get("max_spawn"), allow_zero=True
+        )
+    else:
+        max_spawn = _positive_dispatch_cap(max_spawn, allow_zero=True)
+
+    if max_in_progress is _DISPATCH_CONTEXT_UNSET:
+        configured = _positive_dispatch_cap(kanban_cfg.get("max_in_progress"))
+        max_in_progress = resolve_max_in_progress(configured)
+    elif max_in_progress is not None:
+        max_in_progress = _positive_dispatch_cap(max_in_progress, allow_zero=True)
+
+    if max_in_progress_per_profile is _DISPATCH_CONTEXT_UNSET:
+        max_in_progress_per_profile = _positive_dispatch_cap(
+            kanban_cfg.get("max_in_progress_per_profile")
+        )
+    else:
+        max_in_progress_per_profile = _positive_dispatch_cap(
+            max_in_progress_per_profile
+        )
+
+    if memory_pressure is _DISPATCH_CONTEXT_UNSET:
+        memory_pressure = _memory_pressure_level()
+
+    if review_dispatch is _DISPATCH_CONTEXT_UNSET:
+        review_dispatch = bool(kanban_cfg.get("review_dispatch", True))
+    else:
+        review_dispatch = bool(review_dispatch)
+
+    return {
+        "default_assignee": default_assignee,
+        "max_spawn": max_spawn,
+        "max_in_progress": max_in_progress,
+        "max_in_progress_per_profile": max_in_progress_per_profile,
+        "board": board,
+        "memory_pressure": memory_pressure,
+        "review_dispatch": review_dispatch,
+    }
+
+
+def _health_spawn_budget(
+    conn: sqlite3.Connection, context: Mapping[str, Any]
+) -> Optional[int]:
+    """Return this tick's remaining spawn budget, or None when uncapped."""
+    max_spawn = context["max_spawn"]
+    max_in_progress = context["max_in_progress"]
+    running_count = 0
+    if max_spawn is not None or max_in_progress is not None:
+        running_count = count_running_tasks(conn)
+
+    budget: Optional[int] = None
+    if max_spawn is not None:
+        if running_count >= max_spawn:
+            return 0
+        budget = max_spawn - running_count
+
+    if max_in_progress is not None:
+        try:
+            other_running = count_running_tasks_other_boards(context["board"])
+        except Exception:
+            # A broken peer-board probe aborts the live tick; keep the health
+            # probe conservative rather than hiding potentially spawnable work.
+            other_running = 0
+        total_running = running_count + other_running
+        if total_running >= max_in_progress:
+            return 0
+        remaining = max_in_progress - total_running
+        if budget is None or budget > remaining:
+            budget = remaining
+
+    pressure = context["memory_pressure"]
+    if pressure == "critical":
+        return 0
+    if pressure == "elevated":
+        if budget is None:
+            return 1
+        return min(budget, 1)
+    return budget
+
+
+def _running_counts_by_profile(
+    conn: sqlite3.Connection, per_profile_cap: Optional[int]
+) -> dict[str, int]:
+    if per_profile_cap is None or per_profile_cap <= 0:
+        return {}
+    try:
+        return {
+            row["assignee"]: int(row["n"])
+            for row in conn.execute(
+                "SELECT assignee, COUNT(*) AS n FROM tasks "
+                "WHERE status = 'running' AND assignee IS NOT NULL "
+                "GROUP BY assignee"
+            )
+        }
+    except Exception:
+        # The dispatch loop's query normally succeeds; if it does not, do not
+        # hide potentially spawnable work from a health warning.
+        return {}
+
+
+def _has_admissible_rows(
+    conn: sqlite3.Connection,
+    rows: Iterable[Mapping[str, Any]],
+    *,
+    lane: str,
+    default_assignee: Optional[str],
+    per_profile_cap: Optional[int],
+    per_profile_running: Mapping[str, int],
+) -> bool:
+    """Return whether any row passes the shared non-mutating predicate."""
+    for row in rows:
+        try:
+            admission = _dispatch_admission(
+                conn,
+                row,
+                lane=lane,
+                default_assignee=default_assignee,
+                per_profile_cap=per_profile_cap,
+                per_profile_running=per_profile_running,
+                check_dependencies=True,
+            )
+        except Exception:
+            # A guard/read failure must remain conservative: the dispatcher
+            # may still be able to spawn once the transient error clears.
+            return True
+        if admission.reason is None:
+            return True
+    return False
 
 
 def _has_spawnable_tasks(
@@ -9589,50 +9884,131 @@ def _has_spawnable_tasks(
     *,
     status: str,
     lane: str,
+    default_assignee: Any = _DISPATCH_CONTEXT_UNSET,
+    max_spawn: Any = _DISPATCH_CONTEXT_UNSET,
+    max_in_progress: Any = _DISPATCH_CONTEXT_UNSET,
+    max_in_progress_per_profile: Any = _DISPATCH_CONTEXT_UNSET,
+    board: Optional[str] = None,
+    memory_pressure: Any = _DISPATCH_CONTEXT_UNSET,
+    review_dispatch: Any = _DISPATCH_CONTEXT_UNSET,
 ) -> bool:
-    """Return whether a task in *status* would pass dispatch admission.
+    """Return whether the current dispatcher tick could spawn a row.
 
-    The health probe must use the same respawn guard as ``dispatch_once``;
-    otherwise a task intentionally deferred by the active-PR, recent-success,
-    quota, or auth guard is misreported as stuck. Guard-probe failures remain
-    conservative: they report possible work rather than hiding a real stuck
-    dispatcher. ``lane`` is passed through so the review lane retains its
-    intentional active-PR/recent-success bypass.
+    This mirrors the actual dispatcher admission gates: dependency state,
+    validated/default profile routing, both concurrency caps, memory pressure,
+    per-profile capacity, and the lane-specific respawn guard. A raw ready row
+    is intentionally not enough to trigger a stuck warning.
     """
+    context = _resolve_dispatch_health_context(
+        default_assignee=default_assignee,
+        max_spawn=max_spawn,
+        max_in_progress=max_in_progress,
+        max_in_progress_per_profile=max_in_progress_per_profile,
+        board=board,
+        memory_pressure=memory_pressure,
+        review_dispatch=review_dispatch,
+    )
+    if status == "review" and not context["review_dispatch"]:
+        return False
+    budget = _health_spawn_budget(conn, context)
+    if budget == 0:
+        return False
+
+    per_profile_cap = context["max_in_progress_per_profile"]
+    per_profile_running = _running_counts_by_profile(conn, per_profile_cap)
     rows = conn.execute(
         "SELECT id, assignee FROM tasks "
-        "WHERE status = ? AND assignee IS NOT NULL "
-        "    AND claim_lock IS NULL",
+        "WHERE status = ? AND claim_lock IS NULL "
+        "ORDER BY priority DESC, created_at ASC",
         (status,),
     ).fetchall()
-    for row in rows:
-        spawnability = _profile_spawnability(row["assignee"])
-        if spawnability is False:
-            continue
-        try:
-            guard_reason = check_respawn_guard(conn, row["id"], lane=lane)
-        except Exception:
-            # Do not suppress the warning when the guard itself is unavailable.
-            return True
-        if guard_reason is None:
-            return True
-    return False
+
+    if status == "ready":
+        ready_budget = budget
+        if budget is not None and budget > 0 and context["review_dispatch"]:
+            review_rows = conn.execute(
+                "SELECT id, assignee FROM tasks "
+                "WHERE status = 'review' AND claim_lock IS NULL "
+                "ORDER BY priority DESC, created_at ASC"
+            ).fetchall()
+            review_spawnable = _has_admissible_rows(
+                conn,
+                review_rows,
+                lane="review",
+                default_assignee=None,
+                per_profile_cap=per_profile_cap,
+                per_profile_running=per_profile_running,
+            )
+            if review_spawnable:
+                ready_budget = max(budget - 1, 0)
+        if ready_budget == 0:
+            return False
+    else:
+        ready_budget = budget
+
+    # A finite budget is already checked for zero above. The predicate only
+    # needs to find one admissible row; the actual dispatcher consumes the
+    # budget as it iterates and claims rows.
+    return _has_admissible_rows(
+        conn,
+        rows,
+        lane=lane,
+        default_assignee=(context["default_assignee"] if lane == "ready" else None),
+        per_profile_cap=per_profile_cap,
+        per_profile_running=per_profile_running,
+    )
 
 
-def has_spawnable_ready(conn: sqlite3.Connection) -> bool:
-    """Return True iff a ready task would pass dispatch admission.
+def has_spawnable_ready(
+    conn: sqlite3.Connection,
+    *,
+    default_assignee: Any = _DISPATCH_CONTEXT_UNSET,
+    max_spawn: Any = _DISPATCH_CONTEXT_UNSET,
+    max_in_progress: Any = _DISPATCH_CONTEXT_UNSET,
+    max_in_progress_per_profile: Any = _DISPATCH_CONTEXT_UNSET,
+    board: Optional[str] = None,
+    memory_pressure: Any = _DISPATCH_CONTEXT_UNSET,
+    review_dispatch: Any = _DISPATCH_CONTEXT_UNSET,
+) -> bool:
+    """Return True iff a ready task would pass this dispatch tick's gates."""
+    return _has_spawnable_tasks(
+        conn,
+        status="ready",
+        lane="ready",
+        default_assignee=default_assignee,
+        max_spawn=max_spawn,
+        max_in_progress=max_in_progress,
+        max_in_progress_per_profile=max_in_progress_per_profile,
+        board=board,
+        memory_pressure=memory_pressure,
+        review_dispatch=review_dispatch,
+    )
 
-    Used by the gateway- and CLI-embedded dispatchers' health telemetry to
-    distinguish genuinely stuck spawnable work from intentionally idle rows
-    (control-plane lanes, malformed synthetic assignees, active-PR/recent-
-    success guards, or already-claimed tasks).
-    """
-    return _has_spawnable_tasks(conn, status="ready", lane="ready")
 
-
-def has_spawnable_review(conn: sqlite3.Connection) -> bool:
+def has_spawnable_review(
+    conn: sqlite3.Connection,
+    *,
+    default_assignee: Any = _DISPATCH_CONTEXT_UNSET,
+    max_spawn: Any = _DISPATCH_CONTEXT_UNSET,
+    max_in_progress: Any = _DISPATCH_CONTEXT_UNSET,
+    max_in_progress_per_profile: Any = _DISPATCH_CONTEXT_UNSET,
+    board: Optional[str] = None,
+    memory_pressure: Any = _DISPATCH_CONTEXT_UNSET,
+    review_dispatch: Any = _DISPATCH_CONTEXT_UNSET,
+) -> bool:
     """Return True iff a review task would pass review dispatch admission."""
-    return _has_spawnable_tasks(conn, status="review", lane="review")
+    return _has_spawnable_tasks(
+        conn,
+        status="review",
+        lane="review",
+        default_assignee=default_assignee,
+        max_spawn=max_spawn,
+        max_in_progress=max_in_progress,
+        max_in_progress_per_profile=max_in_progress_per_profile,
+        board=board,
+        memory_pressure=memory_pressure,
+        review_dispatch=review_dispatch,
+    )
 
 
 def review_dispatch_enabled() -> bool:
@@ -10096,25 +10472,20 @@ def _dispatch_once_locked(
     # from the ready loop so the review lane always gets a spawn
     # opportunity. The reservation is per-tick and self-releasing: with no
     # spawnable review work (or no cap at all) the ready loop keeps the
-    # full budget. "Spawnable" mirrors the review loop's own gate
-    # (assigned + real profile) so a review column full of human-pulled
-    # control-plane lanes doesn't permanently tax ready throughput.
+    # full budget. "Spawnable" uses the same validated profile, dependency,
+    # per-profile, and respawn gates as the review loop.
     def _any_spawnable_review() -> bool:
         if not review_rows:
             return False
-        try:
-            from hermes_cli.profiles import profile_exists as _rpe
-        except Exception:
-            # Profiles module unavailable (test stubs, exotic envs) —
-            # assume spawnable, matching the review loop's own fallback.
-            return any(row["assignee"] for row in review_rows)
-        return any(
-            row["assignee"] and _rpe(row["assignee"]) for row in review_rows
+        return _has_admissible_rows(
+            conn,
+            review_rows,
+            lane="review",
+            default_assignee=None,
+            per_profile_cap=_per_profile_cap,
+            per_profile_running=_per_profile_running,
         )
 
-    ready_budget = spawn_budget
-    if spawn_budget is not None and spawn_budget > 0 and _any_spawnable_review():
-        ready_budget = max(spawn_budget - 1, 0)
     spawned = 0
     # Per-profile concurrency cap (#21582): when set, track how many
     # workers each assignee already has in flight, and refuse to spawn
@@ -10138,123 +10509,90 @@ def _dispatch_once_locked(
             _per_profile_running[prow["assignee"]] = int(prow["n"])
     # Normalize default_assignee once: empty/whitespace string → None so the
     # rest of the loop can use ``if default_assignee:`` as a single check.
-    # We also resolve profile_exists once here for the same reason.
+    # Profile validation and existence are performed by _dispatch_admission,
+    # which is also used by the health probe. This prevents a path-shaped
+    # synthetic assignee from being accepted by profile_exists directly.
     _default_assignee = (default_assignee or "").strip() or None
-    _default_assignee_resolved = False
-    if _default_assignee:
-        try:
-            from hermes_cli.profiles import profile_exists as _pe
-            _default_assignee_resolved = bool(_pe(_default_assignee))
-        except Exception:
-            # Profiles module not importable (test stubs, exotic envs).
-            # Trust the operator's config and try the assignment; the
-            # downstream profile_exists check on the assigned row will
-            # bucket it as nonspawnable if the profile genuinely isn't
-            # there, with the existing diagnostic.
-            _default_assignee_resolved = True
+    ready_budget = spawn_budget
+    if spawn_budget is not None and spawn_budget > 0 and _any_spawnable_review():
+        ready_budget = max(spawn_budget - 1, 0)
     for row in ready_rows:
         if ready_budget is not None and spawned >= ready_budget:
             break
-        row_assignee = row["assignee"]
-        if not row_assignee:
-            # Honour kanban.default_assignee: when the dispatcher hits an
-            # unassigned ready task and an operator-configured fallback
-            # exists, persist the assignment and proceed. This removes the
-            # dashboard footgun where a task created without an assignee
-            # parks in 'ready' forever even though the operator's intent
-            # ("default") was perfectly clear (#27145). Mutating the row
-            # (not just the in-memory view) keeps diagnostics and the
-            # board state consistent: the task is now legitimately owned
-            # by ``kanban.default_assignee``, not "unassigned but secretly
-            # routed".
-            if _default_assignee and _default_assignee_resolved:
-                # Dry-run: show what WOULD happen (auto-assign + spawn) without
-                # mutating the DB. Real run: mutate the row + emit the
-                # 'assigned' event so the board state matches what just happened.
-                if not dry_run:
-                    try:
-                        with write_txn(conn):
-                            conn.execute(
-                                "UPDATE tasks SET assignee = ? WHERE id = ? "
-                                "AND (assignee IS NULL OR assignee = '')",
-                                (_default_assignee, row["id"]),
-                            )
-                            _append_event(
-                                conn, row["id"], "assigned",
-                                {
-                                    "assignee": _default_assignee,
-                                    "source": "kanban.default_assignee",
-                                },
-                            )
-                    except Exception:
-                        _log.debug(
-                            "kanban dispatch: failed to apply default_assignee=%r "
-                            "to task %s",
-                            _default_assignee, row["id"], exc_info=True,
+        admission = _dispatch_admission(
+            conn,
+            row,
+            lane="ready",
+            default_assignee=_default_assignee,
+            per_profile_cap=_per_profile_cap,
+            per_profile_running=_per_profile_running,
+            # The atomic claim remains the final dependency gate on a real
+            # tick. Dry-run must still report parent-blocked rows accurately.
+            check_dependencies=dry_run,
+        )
+        row_assignee = admission.assignee or ""
+        if admission.auto_assigned_default:
+            # Dry-run: show what WOULD happen (auto-assign + spawn) without
+            # mutating the DB. Real run: mutate the row + emit the 'assigned'
+            # event so the board state matches what just happened.
+            if not dry_run:
+                try:
+                    with write_txn(conn):
+                        conn.execute(
+                            "UPDATE tasks SET assignee = ? WHERE id = ? "
+                            "AND (assignee IS NULL OR assignee = '')",
+                            (_default_assignee, row["id"]),
                         )
-                        result.skipped_unassigned.append(row["id"])
-                        continue
-                row_assignee = _default_assignee
-                result.auto_assigned_default.append(row["id"])
-            else:
-                result.skipped_unassigned.append(row["id"])
-                continue
-        # Skip ready tasks whose assignee is not a real Hermes profile.
-        # `_default_spawn` invokes ``hermes -p <assignee>`` which fails
-        # with "Profile 'X' does not exist" when the assignee names a
-        # control-plane lane (e.g. an interactive Claude Code terminal
-        # like ``orion-cc`` / ``orion-research``) rather than a Hermes
-        # profile. Those task lanes are pulled by terminals via
-        # ``claim_task`` directly and should NEVER auto-spawn — the
-        # subprocess would crash on startup, get reaped as a zombie,
-        # the task would loop back to ``ready`` on next tick, and we'd
-        # burn CPU forever (#kanban-dispatcher-crash-loop 2026-05-05).
-        try:
-            from hermes_cli.profiles import profile_exists  # local import: avoids cycle
-        except Exception:
-            profile_exists = None  # type: ignore[assignment]
-        if profile_exists is not None and not profile_exists(row_assignee):
-            # Bucket separately from skipped_unassigned: the operator
-            # cannot fix this by assigning a profile (the assignee IS the
-            # intended owner — a terminal lane). Health telemetry uses
-            # this distinction to suppress spurious "stuck" warnings on
-            # multi-lane setups where the ready queue is steadily full
-            # of human-pulled work.
+                        _append_event(
+                            conn,
+                            row["id"],
+                            "assigned",
+                            {
+                                "assignee": _default_assignee,
+                                "source": "kanban.default_assignee",
+                            },
+                        )
+                except Exception:
+                    _log.debug(
+                        "kanban dispatch: failed to apply default_assignee=%r "
+                        "to task %s",
+                        _default_assignee,
+                        row["id"],
+                        exc_info=True,
+                    )
+                    result.skipped_unassigned.append(row["id"])
+                    continue
+            result.auto_assigned_default.append(row["id"])
+        if admission.reason == "unassigned":
+            result.skipped_unassigned.append(row["id"])
+            continue
+        if admission.reason == "nonspawnable":
+            # `_default_spawn` invokes ``hermes -p <assignee>``. Control-plane
+            # lanes and malformed synthetic names are pulled by terminals and
+            # must never reach a subprocess spawn path.
             result.skipped_nonspawnable.append(row["id"])
             continue
-        # Per-profile concurrency cap (#21582): even if there's global
-        # headroom, refuse to spawn for an assignee that's already at
-        # its in-flight cap. Prevents one profile's local model / API
-        # quota / browser pool from being overwhelmed by a fan-out
-        # while the global max_in_progress / max_spawn caps still allow
-        # work on OTHER profiles.
-        if _per_profile_cap is not None:
-            current = _per_profile_running.get(row_assignee, 0)
-            if current >= _per_profile_cap:
-                result.skipped_per_profile_capped.append(
-                    (row["id"], row_assignee, current)
-                )
-                continue
-        # Respawn guard: refuse to re-spawn when useful work is already
-        # in-flight/recent, or when the last failure is a deterministic
-        # blocker (quota / auth). The guard defers the spawn this tick so
-        # the task gets a chance to clear (rate limits often reset in
-        # seconds-to-minutes); the existing consecutive_failures counter
-        # still trips the auto-block circuit breaker after failure_limit
-        # consecutive failures, so a persistent auth error eventually
-        # blocks via the normal path rather than on first occurrence.
-        guard_reason = check_respawn_guard(conn, row["id"])
-        if guard_reason is not None:
-            result.respawn_guarded.append((row["id"], guard_reason))
-            # Emit an event so operators can see why the task was
-            # skipped when reading `hermes kanban tail` — without
-            # this the task appears stuck in ready with no diagnosis.
+        if admission.reason == "per_profile_capped":
+            result.skipped_per_profile_capped.append(
+                (row["id"], row_assignee, admission.current_running)
+            )
+            continue
+        if admission.reason == "guard":
+            guard_reason = admission.guard_reason
+            result.respawn_guarded.append((row["id"], guard_reason or "unknown"))
+            # Emit an event so operators can see why the task was skipped when
+            # reading `hermes kanban tail` — without this the task appears
+            # stuck in ready with no diagnosis.
             if not dry_run:
                 with write_txn(conn):
                     _append_event(
-                        conn, row["id"], "respawn_guarded",
+                        conn,
+                        row["id"],
+                        "respawn_guarded",
                         {"reason": guard_reason},
                     )
+            continue
+        if admission.reason == "dependency":
             continue
         if dry_run:
             result.spawned.append((row["id"], row_assignee, ""))
@@ -10360,39 +10698,46 @@ def _dispatch_once_locked(
     for row in review_rows:
         if spawn_budget is not None and spawned >= spawn_budget:
             break
-        if not row["assignee"]:
+        admission = _dispatch_admission(
+            conn,
+            row,
+            lane="review",
+            per_profile_cap=_per_profile_cap,
+            per_profile_running=_per_profile_running,
+            check_dependencies=dry_run,
+        )
+        row_assignee = admission.assignee or ""
+        if admission.reason == "unassigned":
             result.skipped_unassigned.append(row["id"])
             continue
-        try:
-            from hermes_cli.profiles import profile_exists
-        except Exception:
-            profile_exists = None  # type: ignore[assignment]
-        if profile_exists is not None and not profile_exists(row["assignee"]):
+        if admission.reason == "nonspawnable":
             result.skipped_nonspawnable.append(row["id"])
             continue
-        if _per_profile_cap is not None:
-            current = _per_profile_running.get(row["assignee"], 0)
-            if current >= _per_profile_cap:
-                result.skipped_per_profile_capped.append(
-                    (row["id"], row["assignee"], current)
-                )
-                continue
-        guard_reason = check_respawn_guard(conn, row["id"], lane="review")
-        if guard_reason is not None:
-            result.respawn_guarded.append((row["id"], guard_reason))
+        if admission.reason == "per_profile_capped":
+            result.skipped_per_profile_capped.append(
+                (row["id"], row_assignee, admission.current_running)
+            )
+            continue
+        if admission.reason == "guard":
+            guard_reason = admission.guard_reason
+            result.respawn_guarded.append((row["id"], guard_reason or "unknown"))
             if not dry_run:
                 with write_txn(conn):
                     _append_event(
-                        conn, row["id"], "respawn_guarded",
+                        conn,
+                        row["id"],
+                        "respawn_guarded",
                         {"reason": guard_reason},
                     )
             continue
+        if admission.reason == "dependency":
+            continue
         if dry_run:
-            result.spawned.append((row["id"], row["assignee"], ""))
+            result.spawned.append((row["id"], row_assignee, ""))
             spawned += 1
-            if _per_profile_cap is not None:
-                _per_profile_running[row["assignee"]] = (
-                    _per_profile_running.get(row["assignee"], 0) + 1
+            if _per_profile_cap is not None and row_assignee:
+                _per_profile_running[row_assignee] = (
+                    _per_profile_running.get(row_assignee, 0) + 1
                 )
             continue
         claimed = claim_review_task(conn, row["id"], ttl_seconds=ttl_seconds)
@@ -11016,15 +11361,28 @@ def run_daemon(
             # entire backlog in one tick even with the derived default in
             # place everywhere else. Re-resolved every tick (config load is
             # mtime-cached) so operator edits apply without a restart.
-            max_in_progress = resolve_max_in_progress(
-                configured_max_in_progress()
+            # Resolve the remaining admission settings here as well so the
+            # standalone path and its health probe agree on default routing,
+            # per-profile capacity, and the configured max_spawn override.
+            configured_max = configured_max_in_progress()
+            dispatch_context = _resolve_dispatch_health_context(
+                max_spawn=(
+                    max_spawn
+                    if max_spawn is not None
+                    else _DISPATCH_CONTEXT_UNSET
+                ),
+                max_in_progress=resolve_max_in_progress(configured_max),
             )
             with contextlib.closing(connect()) as conn:
                 res = dispatch_once(
                     conn,
-                    max_spawn=max_spawn,
-                    max_in_progress=max_in_progress,
+                    max_spawn=dispatch_context["max_spawn"],
+                    max_in_progress=dispatch_context["max_in_progress"],
                     failure_limit=failure_limit,
+                    default_assignee=dispatch_context["default_assignee"],
+                    max_in_progress_per_profile=dispatch_context[
+                        "max_in_progress_per_profile"
+                    ],
                 )
             if on_tick is not None:
                 try:

--- a/tests/hermes_cli/test_kanban_stuck_ready_guard.py
+++ b/tests/hermes_cli/test_kanban_stuck_ready_guard.py
@@ -1,0 +1,247 @@
+"""Regression coverage for dispatcher's spawnability health predicate.
+
+The stuck warning is only actionable when a ready task would pass the same
+admission gates as ``dispatch_once``.  Guarded, malformed, unassigned, and
+already-claimed rows are intentionally idle/non-admissible and must not keep
+incrementing the zero-spawn window.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import time
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+@pytest.fixture
+def all_profiles_real(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make the profile admission gate deterministic without creating profiles."""
+    import hermes_cli.profiles as profiles
+
+    monkeypatch.setattr(profiles, "profile_exists", lambda _name: True)
+
+
+def _seed_active_pr(conn, task_id: str) -> None:
+    kb.add_comment(
+        conn,
+        task_id,
+        author="worker",
+        body="Opened https://github.com/example/repo/pull/123.",
+    )
+
+
+def _run_daemon_ticks(
+    monkeypatch: pytest.MonkeyPatch,
+    ticks: int,
+    result: kb.DispatchResult,
+) -> int:
+    """Run the legacy --force daemon callback without sleeping."""
+    import hermes_cli.kanban as kanban_cli
+
+    def fake_run_daemon(**kwargs):
+        on_tick = kwargs["on_tick"]
+        for _ in range(ticks):
+            on_tick(result)
+
+    monkeypatch.setattr(kb, "run_daemon", fake_run_daemon)
+    args = argparse.Namespace(
+        force=True,
+        pidfile=None,
+        verbose=False,
+        interval=5,
+        max=None,
+    )
+    return kanban_cli._cmd_daemon(args)
+
+
+def test_active_pr_ready_card_is_not_spawnable_or_stuck(
+    kanban_home: Path,
+    all_profiles_real: None,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="already has a PR", assignee="worker")
+        _seed_active_pr(conn, task_id)
+        assert kb.check_respawn_guard(conn, task_id) == "active_pr"
+        assert kb.has_spawnable_ready(conn) is False
+
+    assert _run_daemon_ticks(monkeypatch, 8, kb.DispatchResult()) == 0
+    assert "dispatcher stuck" not in capsys.readouterr().err
+
+
+def test_invalid_or_unassigned_ready_card_is_not_spawnable_or_stuck(
+    kanban_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Malformed synthetic rows must fail closed instead of looking spawnable."""
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="synthetic malformed row")
+        # Bypass the public normalizer to model a stale/synthetic DB row.  ``..``
+        # must never be accepted as a profile path, even if its parent exists.
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET assignee = ? WHERE id = ?",
+                ("..", task_id),
+            )
+        assert kb.has_spawnable_ready(conn) is False
+
+    # The result also carries the legacy unassigned bucket: health must use the
+    # admission probe, not any raw skipped-row signal, for the stuck predicate.
+    result = kb.DispatchResult(skipped_unassigned=[task_id])
+    assert _run_daemon_ticks(monkeypatch, 8, result) == 0
+    assert "dispatcher stuck" not in capsys.readouterr().err
+
+
+def test_genuinely_dispatchable_ready_card_still_warns_after_threshold(
+    kanban_home: Path,
+    all_profiles_real: None,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with kb.connect() as conn:
+        kb.create_task(conn, title="real work", assignee="worker")
+        assert kb.has_spawnable_ready(conn) is True
+
+    assert _run_daemon_ticks(monkeypatch, 5, kb.DispatchResult()) == 0
+    assert "dispatcher stuck" not in capsys.readouterr().err
+
+    # The sixth consecutive zero-spawn tick is the configured warning threshold.
+    assert _run_daemon_ticks(monkeypatch, 6, kb.DispatchResult()) == 0
+    warnings = [
+        line for line in capsys.readouterr().err.splitlines()
+        if "dispatcher stuck" in line
+    ]
+    assert len(warnings) == 1
+
+
+def test_live_claim_and_empty_ready_queue_do_not_warn(
+    kanban_home: Path,
+    all_profiles_real: None,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="claimed work", assignee="worker")
+        assert kb.claim_task(conn, task_id) is not None
+        assert kb.has_spawnable_ready(conn) is False
+
+    assert _run_daemon_ticks(monkeypatch, 8, kb.DispatchResult()) == 0
+    assert "dispatcher stuck" not in capsys.readouterr().err
+
+    # A fresh daemon callback with no ready row remains idle as before.
+    assert _run_daemon_ticks(monkeypatch, 8, kb.DispatchResult()) == 0
+    assert "dispatcher stuck" not in capsys.readouterr().err
+
+
+def test_review_lane_keeps_active_pr_bypass(
+    kanban_home: Path,
+    all_profiles_real: None,
+) -> None:
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="review existing PR", assignee="reviewer")
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET status = 'review' WHERE id = ?", (task_id,))
+        _seed_active_pr(conn, task_id)
+
+        assert kb.check_respawn_guard(conn, task_id, lane="review") is None
+        assert kb.has_spawnable_review(conn) is True
+
+
+def test_guard_probe_error_keeps_warning_conservative(
+    kanban_home: Path,
+    all_profiles_real: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with kb.connect() as conn:
+        kb.create_task(conn, title="guard unavailable", assignee="worker")
+        monkeypatch.setattr(
+            kb,
+            "check_respawn_guard",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("probe failed")),
+        )
+        # A failed guard probe must not silently hide a real stuck condition.
+        assert kb.has_spawnable_ready(conn) is True
+
+
+def _gateway_ticks(
+    monkeypatch: pytest.MonkeyPatch,
+    runner: object,
+    min_ticks: int,
+) -> None:
+    """Run the embedded watcher inline for a bounded number of ticks."""
+    import hermes_cli.kanban_db as _kb
+
+    ticks = {"n": 0}
+
+    async def fake_to_thread(fn, *args, **kwargs):
+        result = fn(*args, **kwargs)
+        target = args[0] if getattr(fn, "__name__", "") == "_run_in_fresh_context" else fn
+        if getattr(target, "__name__", "") == "reap_worker_zombies":
+            ticks["n"] += 1
+            if ticks["n"] >= min_ticks:
+                runner._running = False
+        return result
+
+    async def fake_sleep(_delay):
+        return None
+
+    monkeypatch.setattr("asyncio.to_thread", fake_to_thread)
+    monkeypatch.setattr("asyncio.sleep", fake_sleep)
+    monkeypatch.setattr(
+        _kb,
+        "list_boards",
+        lambda include_archived=False: [{"slug": _kb.DEFAULT_BOARD}],
+    )
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {
+            "kanban": {
+                "dispatch_in_gateway": True,
+                "dispatch_interval_seconds": 1,
+                "auto_decompose": False,
+            }
+        },
+    )
+
+    asyncio.run(asyncio.wait_for(runner._kanban_dispatcher_watcher(), timeout=10.0))
+
+
+def test_gateway_watcher_uses_same_guarded_ready_predicate(
+    kanban_home: Path,
+    all_profiles_real: None,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    from gateway.run import GatewayRunner
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="gateway guarded", assignee="worker")
+        _seed_active_pr(conn, task_id)
+
+    runner = object.__new__(GatewayRunner)
+    runner._running = True
+    with caplog.at_level(logging.WARNING, logger="gateway.run"):
+        _gateway_ticks(monkeypatch, runner, 8)
+
+    assert [
+        record for record in caplog.records
+        if "kanban dispatcher stuck" in record.getMessage()
+    ] == []

--- a/tests/hermes_cli/test_kanban_stuck_ready_guard.py
+++ b/tests/hermes_cli/test_kanban_stuck_ready_guard.py
@@ -13,6 +13,7 @@ import asyncio
 import logging
 import time
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -44,6 +45,21 @@ def _seed_active_pr(conn, task_id: str) -> None:
         author="worker",
         body="Opened https://github.com/example/repo/pull/123.",
     )
+
+
+def _health_context(**overrides: object) -> dict[str, Any]:
+    """Pin admission inputs so tests exercise one deterministic dispatcher tick."""
+    context: dict[str, object] = {
+        "default_assignee": None,
+        "max_spawn": None,
+        "max_in_progress": None,
+        "max_in_progress_per_profile": None,
+        "board": None,
+        "memory_pressure": "unknown",
+        "review_dispatch": False,
+    }
+    context.update(overrides)
+    return context
 
 
 def _run_daemon_ticks(
@@ -91,23 +107,160 @@ def test_invalid_or_unassigned_ready_card_is_not_spawnable_or_stuck(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """Malformed synthetic rows must fail closed instead of looking spawnable."""
+    """Malformed synthetic rows must fail closed in health and dispatch."""
+    # ``profile_exists('..')`` used to return true when the profile-store
+    # directory existed. Keep the real directory shape so this is a causal
+    # regression rather than a test-only mock of the old false positive.
+    (kanban_home / "profiles").mkdir()
+    monkeypatch.setattr(kb, "_memory_pressure_level", lambda: "unknown")
+    spawned: list[tuple[object, ...]] = []
+
+    def fake_spawn(*args: object, **kwargs: object) -> int:
+        spawned.append(args)
+        return 123
+
     with kb.connect() as conn:
         task_id = kb.create_task(conn, title="synthetic malformed row")
-        # Bypass the public normalizer to model a stale/synthetic DB row.  ``..``
+        # Bypass the public normalizer to model a stale/synthetic DB row. ``..``
         # must never be accepted as a profile path, even if its parent exists.
         with kb.write_txn(conn):
             conn.execute(
                 "UPDATE tasks SET assignee = ? WHERE id = ?",
                 ("..", task_id),
             )
-        assert kb.has_spawnable_ready(conn) is False
+        assert (
+            kb.has_spawnable_ready(conn, **_health_context(memory_pressure="unknown"))
+            is False
+        )
+        result = kb.dispatch_once(
+            conn,
+            spawn_fn=fake_spawn,
+            dry_run=False,
+            max_spawn=None,
+            max_in_progress=None,
+            max_in_progress_per_profile=None,
+        )
+        assert task_id in result.skipped_nonspawnable
 
-    # The result also carries the legacy unassigned bucket: health must use the
-    # admission probe, not any raw skipped-row signal, for the stuck predicate.
-    result = kb.DispatchResult(skipped_unassigned=[task_id])
-    assert _run_daemon_ticks(monkeypatch, 8, result) == 0
+    assert spawned == []
+    assert _run_daemon_ticks(monkeypatch, 8, kb.DispatchResult()) == 0
     assert "dispatcher stuck" not in capsys.readouterr().err
+
+
+def test_unassigned_ready_card_uses_default_assignee_in_health_and_dispatch(
+    kanban_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    (kanban_home / "profiles" / "worker").mkdir(parents=True)
+    monkeypatch.setattr(kb, "_memory_pressure_level", lambda: "unknown")
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="default-routed work")
+        context = _health_context(default_assignee="worker")
+        assert kb.has_spawnable_ready(conn, **context) is True
+
+        result = kb.dispatch_once(
+            conn,
+            dry_run=True,
+            default_assignee="worker",
+            max_spawn=None,
+            max_in_progress=None,
+            max_in_progress_per_profile=None,
+        )
+        assert task_id in result.auto_assigned_default
+        assert task_id in [task[0] for task in result.spawned]
+
+
+def test_undone_parent_is_not_spawnable_in_health_or_dispatch(
+    kanban_home: Path,
+    all_profiles_real: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(kb, "_memory_pressure_level", lambda: "unknown")
+
+    with kb.connect() as conn:
+        parent_id = kb.create_task(conn, title="parent", assignee="worker")
+        assert kb.claim_task(conn, parent_id) is not None
+        child_id = kb.create_task(conn, title="child", assignee="worker")
+        kb.link_tasks(conn, parent_id, child_id)
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET status = 'ready' WHERE id = ?", (child_id,))
+
+        assert kb.has_spawnable_ready(conn, **_health_context()) is False
+        result = kb.dispatch_once(
+            conn,
+            dry_run=True,
+            max_spawn=None,
+            max_in_progress=None,
+            max_in_progress_per_profile=None,
+        )
+        assert child_id not in [task[0] for task in result.spawned]
+
+
+def test_full_global_cap_is_not_spawnable_in_health_or_dispatch(
+    kanban_home: Path,
+    all_profiles_real: None,
+) -> None:
+    with kb.connect() as conn:
+        running_id = kb.create_task(conn, title="running", assignee="worker")
+        assert kb.claim_task(conn, running_id) is not None
+        ready_id = kb.create_task(conn, title="at global cap", assignee="worker")
+
+        context = _health_context(max_in_progress=1)
+        assert kb.has_spawnable_ready(conn, **context) is False
+        result = kb.dispatch_once(
+            conn,
+            dry_run=True,
+            max_spawn=None,
+            max_in_progress=1,
+            max_in_progress_per_profile=None,
+        )
+        assert ready_id not in [task[0] for task in result.spawned]
+
+
+def test_full_profile_cap_is_not_spawnable_in_health_or_dispatch(
+    kanban_home: Path,
+    all_profiles_real: None,
+) -> None:
+    with kb.connect() as conn:
+        running_id = kb.create_task(conn, title="running", assignee="worker")
+        assert kb.claim_task(conn, running_id) is not None
+        ready_id = kb.create_task(conn, title="at profile cap", assignee="worker")
+
+        context = _health_context(max_in_progress_per_profile=1)
+        assert kb.has_spawnable_ready(conn, **context) is False
+        result = kb.dispatch_once(
+            conn,
+            dry_run=True,
+            max_spawn=None,
+            max_in_progress=None,
+            max_in_progress_per_profile=1,
+        )
+        assert ready_id in [task[0] for task in result.skipped_per_profile_capped]
+
+
+def test_critical_memory_pressure_is_not_spawnable_in_health_or_dispatch(
+    kanban_home: Path,
+    all_profiles_real: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(kb, "_memory_pressure_level", lambda: "critical")
+
+    with kb.connect() as conn:
+        ready_id = kb.create_task(conn, title="memory constrained", assignee="worker")
+        assert (
+            kb.has_spawnable_ready(conn, **_health_context(memory_pressure="critical"))
+            is False
+        )
+        result = kb.dispatch_once(
+            conn,
+            dry_run=True,
+            max_spawn=None,
+            max_in_progress=None,
+            max_in_progress_per_profile=None,
+        )
+        assert ready_id not in [task[0] for task in result.spawned]
+        assert result.memory_pressure == "critical"
 
 
 def test_genuinely_dispatchable_ready_card_still_warns_after_threshold(
@@ -126,7 +279,8 @@ def test_genuinely_dispatchable_ready_card_still_warns_after_threshold(
     # The sixth consecutive zero-spawn tick is the configured warning threshold.
     assert _run_daemon_ticks(monkeypatch, 6, kb.DispatchResult()) == 0
     warnings = [
-        line for line in capsys.readouterr().err.splitlines()
+        line
+        for line in capsys.readouterr().err.splitlines()
         if "dispatcher stuck" in line
     ]
     assert len(warnings) == 1
@@ -175,7 +329,9 @@ def test_guard_probe_error_keeps_warning_conservative(
         monkeypatch.setattr(
             kb,
             "check_respawn_guard",
-            lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("probe failed")),
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                RuntimeError("probe failed")
+            ),
         )
         # A failed guard probe must not silently hide a real stuck condition.
         assert kb.has_spawnable_ready(conn) is True
@@ -193,7 +349,9 @@ def _gateway_ticks(
 
     async def fake_to_thread(fn, *args, **kwargs):
         result = fn(*args, **kwargs)
-        target = args[0] if getattr(fn, "__name__", "") == "_run_in_fresh_context" else fn
+        target = (
+            args[0] if getattr(fn, "__name__", "") == "_run_in_fresh_context" else fn
+        )
         if getattr(target, "__name__", "") == "reap_worker_zombies":
             ticks["n"] += 1
             if ticks["n"] >= min_ticks:
@@ -242,6 +400,7 @@ def test_gateway_watcher_uses_same_guarded_ready_predicate(
         _gateway_ticks(monkeypatch, runner, 8)
 
     assert [
-        record for record in caplog.records
+        record
+        for record in caplog.records
         if "kanban dispatcher stuck" in record.getMessage()
     ] == []


### PR DESCRIPTION
## What does this PR do?

This fixes upstream issue #80513, where dispatcher “stuck” telemetry can false-alarm for tasks deferred by respawn/admission guards. The change shares the dispatch admission predicate with the health path so both paths apply the same routing, dependency, active-work, capacity, memory, and lane-specific respawn safeguards.

Tracking: Kanban task `t_46ae4030`; approved review handoff: parent task `t_8d807c21`.

## Related Issue

Fixes #80513

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Reuse the shared admission predicate across dispatcher and health paths.
- Preserve validated profile/default routing and unfinished-dependency guards.
- Preserve active-PR/lane, global-cap, per-profile-cap, and memory-pressure guards.
- Preserve lane-specific respawn guards and their corresponding telemetry behavior.
- Update the focused RED/regression coverage for the stuck-ready guard.

## How to Test

The exact reviewed head is `c715f5ada6ff5cf6395133bc7375408a6af3c13d`.

Focused and adjacent suites passed during independent exact-head review:

1. `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m pytest -p no:cacheprovider -q tests/hermes_cli/test_kanban_stuck_ready_guard.py tests/hermes_cli/test_kanban_memory_guard.py tests/hermes_cli/test_kanban_db.py tests/gateway/test_kanban_watchers_mixin.py tests/gateway/test_kanban_notifier_watcher_dispatch_gate.py tests/gateway/test_kanban_notifier_zero_sub_gate.py tests/gateway/test_stuck_loop.py` — **63 passed, 1 skipped**.
2. `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m pytest -p no:cacheprovider -q tests/hermes_cli/test_kanban_host_cap.py tests/hermes_cli/test_kanban_per_profile_cap.py tests/hermes_cli/test_kanban_review_lifecycle.py` — **32 passed**.
3. `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m pytest -p no:cacheprovider -q tests/hermes_cli/test_kanban_default_assignee.py tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py` — **4 passed**.
4. `.venv/bin/ruff check hermes_cli/kanban.py hermes_cli/kanban_db.py gateway/kanban_watchers.py tests/hermes_cli/test_kanban_stuck_ready_guard.py` — **All checks passed**.
5. `.venv/bin/ruff format --check tests/hermes_cli/test_kanban_stuck_ready_guard.py` — **1 file already formatted**.
6. `git diff --check 3f315e46fe HEAD` — **passed**.

## Review Evidence and Known Limitations

- Independent exact-head functional/security review approved the change and verified the remote fork ref resolves to the exact head above.
- The optional broad gateway test glob could not collect one module because `aiohttp` is absent in the existing `.venv`; no dependency installation was attempted.
- The broad `hermes_cli` Kanban test glob exceeded the bounded command timeout; the focused and adjacent dispatcher/health suites above passed.
- Repository-wide `ruff format --check` still reports pre-existing drift in three source files; the changed RED test is formatted. No formatter or source edits were performed during review.
- This PR is intentionally not merged, deployed, or used to close the separate blocked native-dispatch reconciliation card `t_b1652653`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — focused/adjacent suites are listed above; broad coverage has the documented limitations
- [x] I've added tests for this bug fix
- [x] I've tested on my platform: Linux CI/runtime

### Documentation & Housekeeping

- [ ] I've updated relevant documentation — N/A for this internal dispatcher guard
- [ ] I've updated `cli-config.yaml.example` — N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — guard logic is shared and covered by focused tests
- [ ] I've updated tool descriptions/schemas — N/A

## Screenshots / Logs

No screenshots. The review evidence and known test limitations are recorded above.
