### PR TITLE
fix(tui-gateway): stop using os.kill(pid, 0) as liveness probe on Windows (#97019)

### DIFF
--- a/tui_gateway/host_supervisor.py
+++ b/tui_gateway/host_supervisor.py
@@ -20,7 +20,7 @@ import time
 import uuid
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional
 
 from hermes_constants import get_hermes_home
 from tools.environments.local import hermes_subprocess_env
@@ -85,37 +85,49 @@ def _default_registry_path() -> Path:
     return get_hermes_home() / "state" / _REGISTRY_NAME
 
 
-def _pid_alive(pid: int) -> bool:
-    # Never call os.kill(pid, 0) directly: on Windows CPython maps sig=0 to
-    # CTRL_C_EVENT (they collide at the C level) and routes it through
-    # GenerateConsoleCtrlEvent(0, pid), broadcasting Ctrl+C to the entire
-    # console process group containing the target PID. A read-only status
-    # check would then kill the process it inspects — and sibling processes
-    # sharing its console. See bpo-14484 and CONTRIBUTING.md rule 1.
-    # gateway.status._pid_exists is the canonical psutil-backed probe (with
-    # a ctypes OpenProcess/WaitForSingleObject fallback on Windows) and also
-    # handles zombie processes (issue #42126).
+_pid_probe_unavailable_logged = False
+
+
+def _pid_alive(pid: int) -> Optional[bool]:
+    """Return True if ``pid`` is alive, False if definitely dead, None if unknown.
+
+    Callers must treat ``None`` as "probe unavailable" and fail toward the
+    safer choice for their context — e.g. ``reconcile_startup_orphan`` must
+    not remove the registry on ``None`` or it can spawn a duplicate compute
+    host next to the live one.
+
+    Never call ``os.kill(pid, 0)`` directly: on Windows CPython maps sig=0 to
+    CTRL_C_EVENT (they collide at the C level) and routes it through
+    ``GenerateConsoleCtrlEvent(0, pid)``, broadcasting Ctrl+C to the entire
+    console process group containing the target PID. A read-only status
+    check would then kill the process it inspects — and sibling processes
+    sharing its console. See bpo-14484 and CONTRIBUTING.md rule 1.
+    ``gateway.status._pid_exists`` is the canonical psutil-backed probe
+    (with a ctypes ``OpenProcess``/``WaitForSingleObject`` fallback on
+    Windows) and also handles zombie processes (issue #42126).
+    """
+    global _pid_probe_unavailable_logged
     if pid <= 0:
         return False
     try:
         from gateway.status import _pid_exists
     except Exception:
-        # Log louder than debug so a missing probe (import-time failure of a
-        # transitive dep) is not silently indistinguishable from "process
-        # dead" — otherwise reconcile_startup_orphan concludes the old host
-        # died, removes the registry, and can spawn a second compute host
-        # alongside the live one.
-        logger.warning(
-            "gateway.status._pid_exists unavailable — treating pid=%s as gone",
-            pid,
-            exc_info=True,
-        )
-        return False
+        # Log once (not per-call): _pid_alive is invoked in a 50ms polling
+        # loop inside _terminate_pid, so a per-call warning with exc_info
+        # would emit a stack trace every 50ms if the import stays broken.
+        if not _pid_probe_unavailable_logged:
+            _pid_probe_unavailable_logged = True
+            logger.warning(
+                "gateway.status._pid_exists unavailable — pid liveness probe "
+                "will return unknown; callers must not treat as dead",
+                exc_info=True,
+            )
+        return None
     try:
         return bool(_pid_exists(int(pid)))
     except Exception:
         logger.debug("pid liveness probe failed for pid=%s", pid, exc_info=True)
-        return False
+        return None
 
 
 def _pid_command(pid: int) -> str:
@@ -242,9 +254,17 @@ class HostSupervisor:
             pid = int(data.get("host_pid") or 0)
         except Exception:
             pid = 0
-        if pid <= 0 or not _pid_alive(pid):
+        if pid <= 0:
             self._remove_registry()
             return "not-running"
+        alive = _pid_alive(pid)
+        if alive is False:
+            self._remove_registry()
+            return "not-running"
+        if alive is None:
+            # Probe unavailable: do NOT remove the registry, or we could
+            # spawn a second compute host alongside the still-live one.
+            return "probe-unavailable"
         if not self._pid_matches_compute_host(pid):
             # PID was reused by another process. Never signal it.
             self._remove_registry()
@@ -572,7 +592,7 @@ class HostSupervisor:
                 return
             deadline = time.monotonic() + timeout
             while time.monotonic() < deadline:
-                if not _pid_alive(pid):
+                if _pid_alive(pid) is False:
                     return
                 time.sleep(0.05)
             try:
@@ -583,6 +603,16 @@ class HostSupervisor:
                 logger.debug("failed to force-kill compute host pid=%s", pid, exc_info=True)
             return
         # Fallback path (should not fire in practice): use os.kill directly.
+        # On Windows this degrades — signal.SIGKILL does not exist so the
+        # "force" escalation becomes another SIGTERM that will not cascade
+        # to child processes. Surface that loudly so a missing gateway.status
+        # dependency does not silently break shutdown on Windows.
+        if sys.platform == "win32":
+            logger.warning(
+                "gateway.status.terminate_pid unavailable on Windows — "
+                "force-kill will not cascade to child processes for pid=%s",
+                pid,
+            )
         try:
             os.kill(pid, signal.SIGTERM)
         except ProcessLookupError:
@@ -592,7 +622,7 @@ class HostSupervisor:
             return
         deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
-            if not _pid_alive(pid):
+            if _pid_alive(pid) is False:
                 return
             time.sleep(0.05)
         sigkill = getattr(signal, "SIGKILL", signal.SIGTERM)

--- a/tui_gateway/host_supervisor.py
+++ b/tui_gateway/host_supervisor.py
@@ -86,16 +86,35 @@ def _default_registry_path() -> Path:
 
 
 def _pid_alive(pid: int) -> bool:
+    # Never call os.kill(pid, 0) directly: on Windows CPython maps sig=0 to
+    # CTRL_C_EVENT (they collide at the C level) and routes it through
+    # GenerateConsoleCtrlEvent(0, pid), broadcasting Ctrl+C to the entire
+    # console process group containing the target PID. A read-only status
+    # check would then kill the process it inspects — and sibling processes
+    # sharing its console. See bpo-14484 and CONTRIBUTING.md rule 1.
+    # gateway.status._pid_exists is the canonical psutil-backed probe (with
+    # a ctypes OpenProcess/WaitForSingleObject fallback on Windows) and also
+    # handles zombie processes (issue #42126).
     if pid <= 0:
         return False
     try:
-        os.kill(pid, 0)
-        return True
-    except ProcessLookupError:
-        return False
-    except PermissionError:
-        return True
+        from gateway.status import _pid_exists
     except Exception:
+        # Log louder than debug so a missing probe (import-time failure of a
+        # transitive dep) is not silently indistinguishable from "process
+        # dead" — otherwise reconcile_startup_orphan concludes the old host
+        # died, removes the registry, and can spawn a second compute host
+        # alongside the live one.
+        logger.warning(
+            "gateway.status._pid_exists unavailable — treating pid=%s as gone",
+            pid,
+            exc_info=True,
+        )
+        return False
+    try:
+        return bool(_pid_exists(int(pid)))
+    except Exception:
+        logger.debug("pid liveness probe failed for pid=%s", pid, exc_info=True)
         return False
 
 
@@ -531,6 +550,39 @@ class HostSupervisor:
         return is_compute_host_identity(pid)
 
     def _terminate_pid(self, pid: int, *, timeout: float = _SHUTDOWN_TIMEOUT_SECS) -> None:
+        # Route through gateway.status.terminate_pid so the escalation path
+        # works on Windows too. signal.SIGKILL does not exist on Windows and
+        # a bare SIGTERM there does not cascade to child processes;
+        # terminate_pid(..., force=True) uses `taskkill /T /F` instead.
+        try:
+            from gateway.status import terminate_pid
+        except Exception:
+            logger.debug(
+                "gateway.status.terminate_pid unavailable; falling back to os.kill",
+                exc_info=True,
+            )
+            terminate_pid = None
+        if terminate_pid is not None:
+            try:
+                terminate_pid(pid)
+            except ProcessLookupError:
+                return
+            except Exception:
+                logger.debug("failed to SIGTERM compute host pid=%s", pid, exc_info=True)
+                return
+            deadline = time.monotonic() + timeout
+            while time.monotonic() < deadline:
+                if not _pid_alive(pid):
+                    return
+                time.sleep(0.05)
+            try:
+                terminate_pid(pid, force=True)
+            except ProcessLookupError:
+                return
+            except Exception:
+                logger.debug("failed to force-kill compute host pid=%s", pid, exc_info=True)
+            return
+        # Fallback path (should not fire in practice): use os.kill directly.
         try:
             os.kill(pid, signal.SIGTERM)
         except ProcessLookupError:
@@ -543,12 +595,13 @@ class HostSupervisor:
             if not _pid_alive(pid):
                 return
             time.sleep(0.05)
+        sigkill = getattr(signal, "SIGKILL", signal.SIGTERM)
         try:
-            os.kill(pid, signal.SIGKILL)
+            os.kill(pid, sigkill)
         except ProcessLookupError:
             return
         except Exception:
-            logger.debug("failed to SIGKILL compute host pid=%s", pid, exc_info=True)
+            logger.debug("failed to force-kill compute host pid=%s", pid, exc_info=True)
 
     def _terminate_process(self, proc: subprocess.Popen[str]) -> None:
         if proc.poll() is not None:


### PR DESCRIPTION
## Summary

Closes #97019.

\`tui_gateway/host_supervisor._pid_alive\` used \`os.kill(pid, 0)\` as a read-only liveness probe. On Windows this is **not** a no-op — CPython maps \`sig=0\` to \`CTRL_C_EVENT\` (they collide at the integer value 0) and routes it through \`GenerateConsoleCtrlEvent(0, pid)\`, broadcasting Ctrl+C to the entire console process group containing the target PID. So a read-only status check from \`reconcile_startup_orphan\` could kill the compute host it was inspecting — and unrelated sibling processes sharing its console. This is the exact pattern \`CONTRIBUTING.md\` rule 1 forbids and that \`scripts/check-windows-footguns.py\` scans for (bpo-14484).

The repo already has the correct probe at \`gateway/status._pid_exists\` (psutil-backed with a ctypes \`OpenProcess\` / \`WaitForSingleObject\` fallback, also handles zombie processes per issue #42126). This PR routes \`_pid_alive\` through it.

While in the file: \`_terminate_pid\` had the sibling bug — it called \`os.kill(pid, signal.SIGKILL)\` on the escalation path. \`signal.SIGKILL\` does not exist on Windows and a bare \`SIGTERM\` there does not cascade to child processes. Now routes through \`gateway.status.terminate_pid(pid, force=True)\` which uses \`taskkill /T /F\`.

Also addressed the caveat from the issue: if the \`gateway.status\` import fails (e.g. a missing transitive dep), the probe now logs a warning instead of silently returning \`False\`, so \"probe unavailable\" is not indistinguishable from \"process dead\" — otherwise \`reconcile_startup_orphan\` could remove the registry entry and spawn a second compute host next to the live one.

## Test plan

- [ ] On Windows: start Hermes with \`dashboard.turn_isolation\` enabled, kill the dashboard uncleanly, restart Hermes. Verify \`reconcile_startup_orphan\` correctly detects the still-live compute host and does not send Ctrl+C to its console group.
- [ ] On Windows: force the shutdown escalation path (\`_terminate_pid\` with an unresponsive child). Verify \`taskkill /T /F\` fires and the process tree exits, without \`AttributeError: SIGKILL\`.
- [ ] On POSIX: existing behaviour unchanged — \`_pid_exists\` uses psutil / \`os.kill(pid, 0)\` internally, and \`terminate_pid\` uses SIGTERM/SIGKILL.
- [ ] Confirm existing host_supervisor tests still pass.