### PR TITLE
feat(stt): honor stt.mistral.base_url, completing endpoint parity

### DIFF
--- a/contributors/emails/25252086+meltforce@users.noreply.github.com
+++ b/contributors/emails/25252086+meltforce@users.noreply.github.com
@@ -1,0 +1,2 @@
+# stt.mistral.base_url endpoint parity
+meltforce

--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -625,6 +625,80 @@ class TestTranscribeMistral:
         assert "RuntimeError" in result["error"]
         assert "secret-key-leaked" not in result["error"]
 
+    def test_config_base_url_becomes_server_url(
+        self, monkeypatch, sample_ogg, mock_mistral_module
+    ):
+        """stt.mistral.base_url reaches the SDK as server_url.
+
+        Endpoint parity with tts.mistral.base_url and with every other STT
+        provider (openai, xai, elevenlabs, deepinfra), which all read
+        base_url from their own config block.
+        """
+        monkeypatch.setenv("MISTRAL_API_KEY", "test-key")
+        mock_result = MagicMock()
+        mock_result.text = "routed"
+        mock_mistral_module.audio.transcriptions.complete.return_value = mock_result
+
+        from tools import transcription_tools
+        config = {"mistral": {"base_url": "http://localhost:4004/v1/proxy/"}}
+        with patch.object(transcription_tools, "_load_stt_config", return_value=config):
+            result = transcription_tools._transcribe_mistral(
+                sample_ogg, "voxtral-mini-latest"
+            )
+
+        assert result["success"] is True
+        import sys
+        kwargs = sys.modules["mistralai.client"].Mistral.call_args.kwargs
+        # Trailing slash stripped, same normalization the other providers apply.
+        assert kwargs["server_url"] == "http://localhost:4004/v1/proxy"
+        assert kwargs["api_key"] == "test-key"
+
+    def test_no_base_url_keeps_sdk_default(
+        self, monkeypatch, sample_ogg, mock_mistral_module
+    ):
+        """Unconfigured, no server_url is passed at all.
+
+        The SDK then keeps its own endpoint, so an install that never sets
+        base_url behaves exactly as it did before.
+        """
+        monkeypatch.setenv("MISTRAL_API_KEY", "test-key")
+        monkeypatch.delenv("STT_MISTRAL_BASE_URL", raising=False)
+        mock_result = MagicMock()
+        mock_result.text = "default"
+        mock_mistral_module.audio.transcriptions.complete.return_value = mock_result
+
+        from tools import transcription_tools
+        with patch.object(transcription_tools, "_load_stt_config", return_value={}), \
+             patch.object(transcription_tools, "MISTRAL_STT_BASE_URL", ""):
+            result = transcription_tools._transcribe_mistral(
+                sample_ogg, "voxtral-mini-latest"
+            )
+
+        assert result["success"] is True
+        import sys
+        assert "server_url" not in sys.modules["mistralai.client"].Mistral.call_args.kwargs
+
+    def test_env_base_url_used_when_config_is_silent(
+        self, monkeypatch, sample_ogg, mock_mistral_module
+    ):
+        """STT_MISTRAL_BASE_URL applies when the config block sets nothing."""
+        monkeypatch.setenv("MISTRAL_API_KEY", "test-key")
+        monkeypatch.setenv("STT_MISTRAL_BASE_URL", "http://gateway.internal/v1")
+        mock_result = MagicMock()
+        mock_result.text = "from env"
+        mock_mistral_module.audio.transcriptions.complete.return_value = mock_result
+
+        from tools import transcription_tools
+        with patch.object(transcription_tools, "_load_stt_config", return_value={}):
+            result = transcription_tools._transcribe_mistral(
+                sample_ogg, "voxtral-mini-latest"
+            )
+
+        assert result["success"] is True
+        import sys
+        kwargs = sys.modules["mistralai.client"].Mistral.call_args.kwargs
+        assert kwargs["server_url"] == "http://gateway.internal/v1"
+
 # ============================================================================
 # _get_provider — Mistral
 # ============================================================================

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -120,6 +120,9 @@ COMMON_LOCAL_BIN_DIRS = ("/opt/homebrew/bin", "/usr/local/bin")
 GROQ_BASE_URL = os.getenv("GROQ_BASE_URL", "https://api.groq.com/openai/v1")
 OPENAI_BASE_URL = os.getenv("STT_OPENAI_BASE_URL", "https://api.openai.com/v1")
 XAI_STT_BASE_URL = os.getenv("XAI_STT_BASE_URL", "https://api.x.ai/v1")
+# Empty by default: unset, the mistralai SDK keeps its own endpoint, so an
+# absent override behaves exactly as before.
+MISTRAL_STT_BASE_URL = os.getenv("STT_MISTRAL_BASE_URL", "")
 ELEVENLABS_STT_BASE_URL = os.getenv("ELEVENLABS_STT_BASE_URL", "https://api.elevenlabs.io/v1")
 # DeepInfra STT base URL now resolved via hermes_cli.models.deepinfra_base_url (shared).
 
@@ -2391,6 +2394,17 @@ def _transcribe_mistral(
     if not api_key:
         return {"success": False, "transcript": "", "error": "MISTRAL_API_KEY not set"}
 
+    # Endpoint parity with every other STT provider and with tts.mistral: the
+    # Mistral SDK calls it server_url. Left unset the SDK keeps its own
+    # default, so this changes nothing for an install that does not configure
+    # it.
+    mistral_config = _load_stt_config().get("mistral") or {}
+    base_url = str(
+        mistral_config.get("base_url")
+        or get_env_value("STT_MISTRAL_BASE_URL")
+        or MISTRAL_STT_BASE_URL
+    ).strip().rstrip("/")
+
     try:
         try:
             from tools.lazy_deps import ensure as _lazy_ensure
@@ -2399,7 +2413,11 @@ def _transcribe_mistral(
             pass
         from mistralai.client import Mistral
 
-        with Mistral(api_key=api_key) as client:
+        client_kwargs: Dict[str, Any] = {"api_key": api_key}
+        if base_url:
+            client_kwargs["server_url"] = base_url
+
+        with Mistral(**client_kwargs) as client:
             with open(file_path, "rb") as audio_file:
                 complete_kwargs: Dict[str, Any] = {
                     "model": model_name,

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -167,6 +167,7 @@ For native Anthropic auth, Hermes prefers Claude Code's own credential files whe
 | `GROQ_BASE_URL` | Override the Groq OpenAI-compatible STT endpoint |
 | `STT_OPENAI_MODEL` | Override the OpenAI STT model (default: `whisper-1`) |
 | `STT_OPENAI_BASE_URL` | Override the OpenAI-compatible STT endpoint |
+| `STT_MISTRAL_BASE_URL` | Override the Mistral STT endpoint (`stt.mistral.base_url` takes precedence) |
 | `GITHUB_TOKEN` | GitHub token for Skills Hub (higher API rate limits, skill publish) |
 | `HONCHO_API_KEY` | Cross-session user modeling ([honcho.dev](https://honcho.dev/)) |
 | `HONCHO_BASE_URL` | Base URL for self-hosted Honcho instances (default: Honcho cloud). No API key required for local instances |

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -470,6 +470,7 @@ stt:
     model: "whisper-1"        # whisper-1, gpt-4o-mini-transcribe, gpt-4o-transcribe, gpt-transcribe
   mistral:
     model: "voxtral-mini-latest"  # voxtral-mini-latest, voxtral-mini-2602
+    # base_url: "https://gateway.example/v1"  # Override the Mistral endpoint (sent as the SDK's server_url)
   xai:
     model: "grok-stt"         # xAI Grok STT
     language: ""              # optional ISO-639-1 hint; blank = use HERMES_LOCAL_STT_LANGUAGE if set, else "en"
@@ -491,7 +492,7 @@ stt:
 
 **OpenAI API** — Accepts `VOICE_TOOLS_OPENAI_KEY` first and falls back to `OPENAI_API_KEY`. Supports `whisper-1`, `gpt-4o-mini-transcribe`, `gpt-4o-transcribe`, and `gpt-transcribe`.
 
-**Mistral API (Voxtral Transcribe)** — Requires `MISTRAL_API_KEY`. Uses Mistral's [Voxtral Transcribe](https://docs.mistral.ai/capabilities/audio/speech_to_text/) models. Supports 13 languages, speaker diarization, and word-level timestamps. Install with `cd ~/.hermes/hermes-agent && uv pip install -e ".[mistral]"`.
+**Mistral API (Voxtral Transcribe)** — Requires `MISTRAL_API_KEY`. Uses Mistral's [Voxtral Transcribe](https://docs.mistral.ai/capabilities/audio/speech_to_text/) models. Supports 13 languages, speaker diarization, and word-level timestamps. Install with `cd ~/.hermes/hermes-agent && uv pip install -e ".[mistral]"`. Set `stt.mistral.base_url` (or `STT_MISTRAL_BASE_URL`) to send transcription through an OpenAI-style gateway or reverse proxy in front of Mistral; unset, the SDK keeps its own endpoint.
 
 **xAI Grok STT** — Requires `XAI_API_KEY`. Posts to `https://api.x.ai/v1/stt` as multipart/form-data. Good choice if you're already using xAI for chat or TTS and want one API key for everything. Auto-detection order puts it after Groq — explicitly set `stt.provider: xai` to force it.
 


### PR DESCRIPTION
## What does this PR do?

`stt.provider: mistral` can only ever address `api.mistral.ai`. `_transcribe_mistral` builds its client as `Mistral(api_key=api_key)` with no `server_url`, so no configuration reaches the endpoint.

Every other STT provider already honors a base URL from its own config block — `openai` (`_resolve_openai_stt_client_config`), `xai`, `elevenlabs` and `deepinfra`. Mistral is the exception.

The TTS half is not: #73512 introduced what its description calls *class-level `base_url` parity* for TTS providers, and `_generate_mistral_tts` has read `tts.mistral.base_url` into the SDK's `server_url` since. This is the same change for the transcription side, in the shape `_transcribe_elevenlabs` uses — config block, then env, then module constant.

Unset, no `server_url` is passed at all and the SDK keeps its own endpoint, so an install that does not configure this behaves exactly as before.

**Why it matters.** A self-hosted gateway or authenticating reverse proxy in front of Mistral is reachable for synthesis and unreachable for transcription, which makes the provider pair unusable in that deployment — with nothing in the configuration to indicate why. Concretely, this came up routing both directions through Tailscale Aperture, whose HTTP connector answers `/v1/audio/speech` and `/v1/audio/transcriptions` identically; TTS could be pointed at it, STT could not.

## Related Issue

None open that I could find — searched `stt base_url`, `voxtral`, and `voxtral endpoint` across issues and PRs per CONTRIBUTING § *Search First*. The closest prior art is #73512 (merged), which this continues.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `tools/transcription_tools.py` — `_transcribe_mistral` resolves `stt.mistral.base_url` → `STT_MISTRAL_BASE_URL` → `MISTRAL_STT_BASE_URL` (new module constant, empty by default) and passes it to the SDK as `server_url` only when set.
- `tests/tools/test_transcription_tools.py` — three cases in `TestTranscribeMistral`: config `base_url` becomes `server_url` (with trailing-slash normalization), an unconfigured provider passes no `server_url` at all, and the env variable applies when the config block is silent.
- `website/docs/user-guide/features/tts.md` — the key in the STT config block, and a sentence in the Mistral provider detail.
- `website/docs/reference/environment-variables.md` — `STT_MISTRAL_BASE_URL`.

## How to Test

1. `python -m pytest tests/tools/test_transcription_tools.py -k "Mistral or mistral"` — 9 passed.
2. Regression across the transcription suite: `python -m pytest tests/tools/test_transcription_tools.py tests/tools/test_pre_transcription_hook.py tests/tools/test_transcription.py tests/tools/test_stt_language_resolution.py` — 101 passed.
3. End to end against a real proxy: set

   ```yaml
   stt:
     provider: mistral
     mistral:
       model: voxtral-mini-latest
       base_url: "https://<your-gateway>/v1/connectors/Mistral"
   ```

   and send a voice message. Verified this way on agent v0.20.6 against a Tailscale Aperture HTTP connector, which returned the correct transcript; without the change the same configuration reaches api.mistral.ai and the `base_url` value is ignored.
