### PR TITLE
fix(browser): include managed Node in subprocess PATH

### DIFF
--- a/tests/tools/test_browser_real_profile.py
+++ b/tests/tools/test_browser_real_profile.py
@@ -167,6 +167,40 @@ class TestRealProfileCdpLaunch:
         assert cdp == "http://127.0.0.1:41000"
         self._reset()
 
+    def test_launch_env_includes_managed_node_dir(self, tmp_path):
+        import tools.browser_tool as bt
+        self._reset()
+        proc = Mock(returncode=0, stdout="", stderr="")
+        base_path = r"C:\Windows\System32"
+        managed_path = os.pathsep.join(
+            [r"C:\Users\test\AppData\Local\hermes\node", base_path]
+        )
+        captured = {}
+
+        def fake_run(_argv, **kwargs):
+            captured.update(kwargs)
+            return proc
+
+        with patch.object(bt, "_use_real_profile", return_value=True), \
+             patch("hermes_cli.browser_connect.detect_default_chromium", return_value="chrome"), \
+             patch("hermes_cli.browser_connect.snapshot_real_profile", return_value=(str(tmp_path), None)), \
+             patch.object(bt, "_agent_browser_get_cdp",
+                          side_effect=[None, "http://127.0.0.1:41000"]), \
+             patch.object(bt, "_find_agent_browser", return_value=r"C:\hermes\node\npx.CMD"), \
+             patch("tools.environments.local.hermes_subprocess_env",
+                   return_value={"PATH": base_path, "SCRUBBED": "1"}), \
+             patch.object(bt, "_merge_browser_path", return_value=managed_path) as merge_path, \
+             patch.object(bt.subprocess, "run", side_effect=fake_run), \
+             patch.object(bt, "_is_headed_mode", return_value=False):
+            cdp, err = bt._real_profile_cdp()
+
+        assert err is None
+        assert cdp == "http://127.0.0.1:41000"
+        merge_path.assert_called_once_with(base_path)
+        assert captured["env"]["PATH"] == managed_path
+        assert captured["env"]["SCRUBBED"] == "1"
+        self._reset()
+
     def test_launch_never_passes_headless(self, tmp_path):
         """--headless would use a separate cookie store → 0 real cookies."""
         import tools.browser_tool as bt

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -140,6 +140,7 @@ def _build_browser_env() -> dict:
     for _key in _BROWSER_PASSTHROUGH_KEYS:
         if _key in os.environ:
             env[_key] = os.environ[_key]
+    env["PATH"] = _merge_browser_path(env.get("PATH", ""))
     return env
 
 try:


### PR DESCRIPTION
## Summary

- Add Hermes-managed Node directories to the credential-scrubbed environment used by every browser subprocess.
- Restore Windows real-profile launch when `npx.CMD` cannot resolve its sibling `node.exe`.
- Keep the existing browser credential allowlist and secret stripping unchanged.

Fixes #97186

## Tests

- `scripts/run_tests.sh tests/tools/test_browser_real_profile.py tests/tools/test_browser_homebrew_paths.py tests/tools/test_browser_npx_warmup.py tests/tools/test_browser_use_cli.py -q` (218 passed)
- `ruff check tools/browser_tool.py tests/tools/test_browser_real_profile.py`
- `git diff --check`