### PR TITLE
fix(tui): set gateway process title to hermes

### DIFF
--- a/hermes_cli/_startup_fast.py
+++ b/hermes_cli/_startup_fast.py
@@ -31,6 +31,7 @@ import sys
 __all__ = [
     "project_root_str",
     "ensure_project_root_on_path",
+    "set_process_title",
     "is_termux_env",
     "is_termux_fast_version_argv",
     "is_global_fast_version_argv",
@@ -60,6 +61,47 @@ def ensure_project_root_on_path() -> None:
         or os.path.normcase(os.path.realpath(entry)) != normalized_root
     ]
     sys.path.insert(0, project_root)
+
+
+def set_process_title() -> None:
+    """Set the process title to 'hermes' so tools like 'ps', 'top', and
+    'htop' show the app name instead of 'python3.xx'.
+
+    Purely cosmetic — non-fatal on any platform.
+
+    Strategy (try in order):
+      1. ``setproctitle`` (opt-in dep — installed via ``hermes tools`` or
+         ``pip install setproctitle``, or bundled in a future release).
+      2. ctypes ``prctl(PR_SET_NAME)`` (Linux only, 15-char limit).
+      3. ctypes ``pthread_setname_np`` (macOS only, kernel thread name —
+         changes lldb/top but not ``ps aux``).
+      4. No-op on Windows (the .exe name is already ``hermes.exe``).
+    """
+    # Strategy 1: setproctitle (best — works on macOS, Linux, BSD)
+    try:
+        import setproctitle  # type: ignore[import-untyped]
+
+        setproctitle.setproctitle("hermes")
+        return
+    except ImportError:
+        pass
+
+    # Strategy 2/3: platform-specific ctypes fallback. Keep the imports inside
+    # the guard because some Python builds do not include the _ctypes module.
+    try:
+        import ctypes
+        import platform
+
+        system = platform.system()
+        if system == "Linux":
+            libc = ctypes.CDLL("libc.so.6", use_errno=True)
+            libc.prctl(15, b"hermes", 0, 0, 0)  # PR_SET_NAME = 15
+        elif system == "Darwin":
+            libc = ctypes.CDLL("libc.dylib", use_errno=True)
+            libc.pthread_setname_np(b"hermes")
+        # Windows: the .exe name is already ``hermes.exe`` — nothing to do.
+    except Exception:
+        pass
 
 
 def is_termux_env() -> bool:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -233,43 +233,8 @@ def _ensure_project_root_on_path_fast() -> None:
 
 
 def _set_process_title() -> None:
-    """Set the process title to 'hermes' so tools like 'ps', 'top', and
-    'htop' show the app name instead of 'python3.xx'.
-
-    Purely cosmetic — non-fatal on any platform.
-
-    Strategy (try in order):
-      1. ``setproctitle`` (opt-in dep — installed via ``hermes tools`` or
-         ``pip install setproctitle``, or bundled in a future release).
-      2. ctypes ``prctl(PR_SET_NAME)`` (Linux only, 15-char limit).
-      3. ctypes ``pthread_setname_np`` (macOS only, kernel thread name —
-         changes lldb/top but not ``ps aux``).
-      4. No-op on Windows (the .exe name is already ``hermes.exe``).
-    """
-    # Strategy 1: setproctitle (best — works on macOS, Linux, BSD)
-    try:
-        import setproctitle  # type: ignore[import-untyped]
-
-        setproctitle.setproctitle("hermes")
-        return
-    except ImportError:
-        pass
-
-    # Strategy 2/3: platform-specific ctypes fallback
-    import ctypes
-    import platform
-
-    try:
-        system = platform.system()
-        if system == "Linux":
-            libc = ctypes.CDLL("libc.so.6", use_errno=True)
-            libc.prctl(15, b"hermes", 0, 0, 0)  # PR_SET_NAME = 15
-        elif system == "Darwin":
-            libc = ctypes.CDLL("libc.dylib", use_errno=True)
-            libc.pthread_setname_np(b"hermes")
-        # Windows: the .exe name is already ``hermes.exe`` — nothing to do.
-    except Exception:
-        pass
+    """Backward-compatible wrapper for the shared startup helper."""
+    _startup_fast.set_process_title()
 
 
 # Cheap, dependency-free read of `display.interface` from config.yaml for the

--- a/tests/hermes_cli/test_startup_fast_guards.py
+++ b/tests/hermes_cli/test_startup_fast_guards.py
@@ -16,11 +16,14 @@ Two invariants, each of which has been broken before:
    NameError-ing the Termux fast path in production for weeks.
 """
 
+import builtins
 import json
 import os
 import subprocess
 import sys
 from pathlib import Path
+
+from hermes_cli import _startup_fast
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
@@ -37,6 +40,20 @@ _FORBIDDEN_MODULES = (
     "httpx",
     "openai",
 )
+
+
+def test_set_process_title_is_non_fatal_without_ctypes(monkeypatch):
+    """A cosmetic title must not abort startup on Python builds without _ctypes."""
+    real_import = builtins.__import__
+
+    def import_without_title_dependencies(name, *args, **kwargs):
+        if name in {"ctypes", "setproctitle"}:
+            raise ImportError(f"simulated missing {name}")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", import_without_title_dependencies)
+
+    _startup_fast.set_process_title()
 
 
 def test_startup_fast_import_weight():

--- a/tests/tui_gateway/test_entry_picker_prewarm.py
+++ b/tests/tui_gateway/test_entry_picker_prewarm.py
@@ -36,6 +36,9 @@ def _run_main(monkeypatch, events, *, prewarm=None):
     ``events`` receives ``("write", <event type>)`` for every write_json call
     and ``("prewarm",)`` when the spy fires, in call order.
     """
+    monkeypatch.setattr(
+        entry._startup_fast, "set_process_title", lambda: events.append(("title",))
+    )
     monkeypatch.setattr(entry, "_install_sidecar_publisher", lambda: None)
     monkeypatch.setattr(entry, "ensure_mcp_discovery_started", lambda: None)
     monkeypatch.setattr(entry, "resolve_skin", lambda: "default")
@@ -80,6 +83,8 @@ def test_main_prewarms_picker_cache_after_gateway_ready(monkeypatch):
 
     ready_idx = events.index(("write", "gateway.ready"))
     prewarm_idx = events.index(("prewarm",))
+    title_idx = events.index(("title",))
+    assert title_idx < ready_idx
     assert ready_idx < prewarm_idx, (
         "prewarm must fire AFTER the gateway.ready write (idle window, "
         f"banner already shown); order was {events!r}"

--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -10,6 +10,8 @@ import hermes_bootstrap
 
 hermes_bootstrap.harden_import_path()
 
+from hermes_cli import _startup_fast
+
 import json
 import logging
 import signal
@@ -420,6 +422,7 @@ def ensure_mcp_discovery_started() -> None:
 
 
 def main():
+    _startup_fast.set_process_title()
     _install_sidecar_publisher()
 
     # Cross-backend liveness (#94895): register a heartbeat row so the


### PR DESCRIPTION
## Summary

- reuse the process-title helper from #35143 in the TUI gateway
- keep the optional `ctypes` fallback non-fatal

Fixes #97157
Refs #42080

## Tests

- targeted pytest: 8 passed
- Ruff and compile checks
- live Linux check: gateway reaches `gateway.ready` as `hermes`
