### PR TITLE
fix(web): preserve provider clean extract content

### DIFF
--- a/tests/tools/test_web_tools_truncate.py
+++ b/tests/tools/test_web_tools_truncate.py
@@ -67,6 +67,39 @@ class TestCharLimitConfig:
 
 
 class TestEndToEnd:
+    def test_web_extract_returns_provider_clean_content(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+
+        class FakeProvider:
+            name = "fake"
+            display_name = "Fake"
+
+            def supports_extract(self):
+                return True
+
+            async def extract(self, urls, **kwargs):
+                return [{
+                    "url": urls[0],
+                    "title": "Page",
+                    "content": "clean provider content",
+                    "raw_content": "raw provider content",
+                }]
+
+        with patch("tools.web_tools._ensure_web_plugins_loaded"), \
+             patch("tools.web_tools._get_extract_backend", return_value="fake"), \
+             patch("tools.web_tools.async_is_safe_url", new=_AsyncTrue()), \
+             patch("agent.web_search_registry.get_provider", return_value=FakeProvider()):
+            serialized_result = asyncio.new_event_loop().run_until_complete(
+                wt.web_extract_tool(["https://example.com/clean"])
+            )
+
+        result = json.loads(serialized_result)
+
+        assert result["results"][0]["content"] == "clean provider content"
+        assert "raw_content" not in result["results"][0]
+        assert "raw_content" not in serialized_result
+        assert "raw provider content" not in serialized_result
+
     def test_web_extract_truncates_large_page_no_llm(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
         big = "\n".join(f"para {i} " + "y" * 80 for i in range(3000))

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -1354,9 +1354,7 @@ async def web_extract_tool(
                             break
                         if fetched.get("error"):
                             continue
-                        _content = (
-                            fetched.get("raw_content", "") or fetched.get("content", "")
-                        )
+                        _content = fetched.get("content", "")
                         if _content:
                             _extract_cache_put(
                                 fetch_urls[fetched_pos],
@@ -1428,10 +1426,10 @@ async def web_extract_tool(
             if result.get("error"):
                 continue
             url = result.get("url", "")
-            raw_content = result.get("raw_content", "") or result.get("content", "")
-            if not raw_content:
+            content = result.get("content", "")
+            if not content:
                 continue
-            clean = convert_base64_images_to_links(raw_content)
+            clean = convert_base64_images_to_links(content)
             model_text, truncated = _truncate_with_footer(clean, url, effective_char_limit)
             result["content"] = model_text
             if truncated:


### PR DESCRIPTION
## Summary
- preserve provider-supplied clean `content` in `web_extract`
- keep `raw_content` limited to provider-internal processing
- add regression coverage with distinct clean and raw values

## Verification
- `pytest -q tests/tools/test_web_tools_truncate.py` (8 passed)
- `pytest -q tests/tools/test_web_providers.py` (12 passed)
- `python -m py_compile tools/web_tools.py tests/tools/test_web_tools_truncate.py`
- `git diff --check`

This is a review-only PR. No providers, config, credentials, deployment, or services were changed.