### PR TITLE
test(desktop): pick platform-appropriate /bin/true stub in managed-ssh-update test (#96975)

### DIFF
--- a/apps/desktop/electron/managed-ssh-update.test.ts
+++ b/apps/desktop/electron/managed-ssh-update.test.ts
@@ -283,12 +283,17 @@ test('POSIX managed launcher is detached, correlation-scoped, and never publishe
 test('POSIX managed launcher executes the updater command and atomically publishes its status', async () => {
   const home = await mkdtemp(path.join(os.tmpdir(), 'hermes-managed-launch-'))
 
+  // `/bin/true` exists on Linux but not on macOS (its `true` lives at
+  // `/usr/bin/true`), so a hard-coded `/bin/true` stub makes the generated
+  // launcher exit with rc=127 under `/bin/sh` on macOS. Pick per platform.
+  const trueBin = process.platform === 'darwin' ? '/usr/bin/true' : '/bin/true'
+
   try {
     const command = buildPosixManagedUpdateLaunch(
       {
         ssh: { exec: async () => '' },
         platform: 'Linux',
-        hermesPath: '/bin/true',
+        hermesPath: trueBin,
         hermesHome: home
       },
       CORRELATION


### PR DESCRIPTION
## Summary

Closes #96975.

\`electron/managed-ssh-update.test.ts::POSIX managed launcher executes the updater command and atomically publishes its status\` stubs the remote hermes binary with \`hermesPath: '/bin/true'\`. That file exists on Linux but not on macOS — the \`true\` binary lives at \`/usr/bin/true\` there, and \`/bin/true\` does not exist. The generated launcher runs \`/bin/true update --yes\` under \`/bin/sh\`, gets \`rc=127\`, publishes \`127\` into the status file, and \`assert.equal(status, '0')\` fails with \`AssertionError: '127' !== '0'\`. Linux CI is unaffected which is why this was not caught.

Pick the stub path per platform (\`/usr/bin/true\` on \`darwin\`, \`/bin/true\` elsewhere). Keeps the test's intent — a launcher binary that exits 0 — intact.

## Test plan

- [ ] On macOS: \`cd apps/desktop && npx vitest run --project electron electron/managed-ssh-update.test.ts\` — the previously-failing case now passes (status file contains \`0\`).
- [ ] On Linux: the same command still passes (Linux path unchanged).
- [ ] No other tests reference \`hermesPath\` in this file, so no cross-test impact.