### PR TITLE
refactor(read_file): schema diet + bundle anydoc 0.2.4 + typed NeedsOcrError/hosted-OCR wiring

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,15 @@ dependencies = [
   "ruamel.yaml==0.18.17",
   "requests==2.33.0",  # CVE-2026-25645
   "jinja2==3.1.6",
+  # Document-to-Markdown extraction for read_file (PDF, legacy Office,
+  # OpenDocument, RTF, EPUB) + typed NeedsOcrError for scanned pages.
+  # Bundled in core by maintainer decision (read_file is a core tool and
+  # PDF reads are a common first-session action; the previous lazy-only
+  # arrangement dated to the package's uv exclude-newer quarantine, which
+  # has long expired). tools/lazy_deps.py `tool.doc_extract` remains the
+  # self-heal path for lean/broken installs — keep the pin below and the
+  # lazy pin in lockstep.
+  "firecrawl-anydoc==0.2.4",
   # Bumped from 2.12.5 to 2.13.4 to pull in pydantic-core 2.46.4.
   # pydantic-core 2.41.5 (pulled by 2.12.5) segfaults when the OpenAI SDK's
   # Responses API resource is exercised from a non-main thread, which is the
@@ -420,7 +429,11 @@ exclude-newer = "14 days"
 # cutoff can still brick installs. Exempting exact pins is pure brick-risk
 # removal at no supply-chain cost. Guarded by
 # tests/test_packaging_metadata.py::test_build_system_requires_exempt_from_exclude_newer.
-exclude-newer-package = { vercel = false, nemo-relay = false, huggingface_hub = false, h2 = false, aiohttp = false, cryptography = false, defusedxml = false, python-olm = false, unpaddedbase64 = false, setuptools = false, pillow = false, mcp = false }
+#
+# firecrawl-anydoc: same exact-pin shape (==0.2.4, hosted-OCR wiring PR).
+# The pin bump WAS the review; exclude-newer adds zero float protection to
+# an exact pin and would only delay the reviewed version 14 days.
+exclude-newer-package = { vercel = false, nemo-relay = false, huggingface_hub = false, h2 = false, aiohttp = false, cryptography = false, defusedxml = false, python-olm = false, unpaddedbase64 = false, setuptools = false, pillow = false, mcp = false, firecrawl-anydoc = false }
 
 [tool.setuptools]
 # Top-level single-file modules (not packages). Without this, uv2nix's

--- a/tests/tools/test_read_file_schema_gating.py
+++ b/tests/tools/test_read_file_schema_gating.py
@@ -53,6 +53,8 @@ class TestReadFileSchemaStatic(unittest.TestCase):
         self.assertEqual(o, {})  # base wording stands
 
     def test_hosted_ocr_available_gate_states(self):
+        """Maintainer decision: ONLY a direct FIRECRAWL_API_KEY unlocks —
+        not config true, not the Nous gateway."""
         import tools.read_extract as rx
 
         # direct key → True
@@ -65,17 +67,38 @@ class TestReadFileSchemaStatic(unittest.TestCase):
             with patch("hermes_cli.config.load_config_readonly",
                        return_value={"file_tools": {"hosted_ocr": False}}):
                 self.assertFalse(rx.hosted_ocr_available())
-        # config true without key → True (user's explicit assertion)
+        # config true WITHOUT key → False (key is the one gate)
         with patch.dict(rx.os.environ, {}, clear=False):
             rx.os.environ.pop("FIRECRAWL_API_KEY", None)
             with patch("hermes_cli.config.load_config_readonly",
                        return_value={"file_tools": {"hosted_ocr": True}}):
-                self.assertTrue(rx.hosted_ocr_available())
-        # nothing → False (Nous gateway alone must NOT upgrade wording)
+                self.assertFalse(rx.hosted_ocr_available())
+        # nothing → False (Nous gateway alone must NOT unlock)
         with patch("hermes_cli.config.load_config_readonly",
                    return_value={}):
             rx.os.environ.pop("FIRECRAWL_API_KEY", None)
             self.assertFalse(rx.hosted_ocr_available())
+
+    def test_runtime_route_is_direct_key_only(self):
+        """_hosted_ocr_config never resolves the Nous gateway: api_url is
+        always None (anydoc defaults to api.firecrawl.dev) and enabled
+        tracks the key."""
+        import tools.read_extract as rx
+
+        with patch.dict(rx.os.environ, {"FIRECRAWL_API_KEY": "fc-x"}):
+            with patch("hermes_cli.config.load_config_readonly",
+                       return_value={}):
+                enabled, key, url = rx._hosted_ocr_config()
+        self.assertTrue(enabled)
+        self.assertEqual(key, "fc-x")
+        self.assertIsNone(url)
+        with patch("hermes_cli.config.load_config_readonly",
+                   return_value={}):
+            rx.os.environ.pop("FIRECRAWL_API_KEY", None)
+            enabled, key, url = rx._hosted_ocr_config()
+        self.assertFalse(enabled)
+        self.assertIsNone(key)
+        self.assertIsNone(url)
 
     def test_coverage_warning_teaching_left_to_the_warning(self):
         """The response-time warning owns the recovery curriculum."""

--- a/tests/tools/test_read_file_schema_gating.py
+++ b/tests/tools/test_read_file_schema_gating.py
@@ -80,5 +80,85 @@ class TestReadFileSchemaGating(unittest.TestCase):
         self.assertNotEqual(err, "Unsupported document type: 'x.epub'")
 
 
+class TestNeedsOcrPath(unittest.TestCase):
+    """anydoc>=0.2 NeedsOcrError wiring: hosted OCR attempt + typed warning
+    (maintainer caveats: #1 nous-gateway Parse was live-probed HTTP 500 →
+    attempt-and-fall-through; #2 warning recommends LOCAL OCR skills)."""
+
+    def _fake_mod(self, hosted_result=None, hosted_exc=None):
+        class NeedsOcrError(Exception):
+            def __init__(self, pages):
+                super().__init__("needs ocr")
+                self.pages = pages
+
+        calls = []
+
+        class Mod:
+            pass
+
+        mod = Mod()
+        mod.NeedsOcrError = NeedsOcrError
+
+        def to_markdown(path, **kw):
+            calls.append(kw)
+            if not kw:
+                raise NeedsOcrError([2, 3])
+            if hosted_exc is not None:
+                raise hosted_exc
+            return hosted_result
+
+        mod.to_markdown = to_markdown
+        return mod, calls
+
+    def test_hosted_success_returns_ocr_text(self):
+        from tools import read_extract as rx
+
+        mod, calls = self._fake_mod(hosted_result="OCR TEXT")
+        with patch.object(rx, "_anydoc", return_value=mod),              patch.object(rx, "_hosted_ocr_config",
+                          return_value=(True, "key", None)),              patch.object(rx.os.path, "getsize", return_value=10):
+            out = rx._extract_anydoc("scan.pdf")
+        self.assertEqual(out, "OCR TEXT\n")
+        self.assertEqual(calls[1].get("ocr"), "hosted")
+
+    def test_hosted_failure_warns_and_prefers_local_skills(self):
+        from tools import read_extract as rx
+
+        mod, _ = self._fake_mod(hosted_exc=RuntimeError("HTTP 500"))
+        with patch.object(rx, "_anydoc", return_value=mod),              patch.object(rx, "_hosted_ocr_config",
+                          return_value=(True, "key", "https://gw")),              patch.object(rx.os.path, "getsize", return_value=10):
+            out = rx._extract_anydoc("scan.pdf")
+        self.assertIn("[NEEDS OCR", out)
+        self.assertIn("pages 2, 3", out)
+        self.assertIn("attempted and failed", out)
+        # Maintainer caveat #2: local OCR guidance leads after a failure.
+        self.assertIn("Prefer LOCAL OCR", out)
+        self.assertIn("skills_list", out)
+
+    def test_disabled_warns_without_attempt(self):
+        from tools import read_extract as rx
+
+        mod, calls = self._fake_mod()
+        with patch.object(rx, "_anydoc", return_value=mod),              patch.object(rx, "_hosted_ocr_config",
+                          return_value=(False, None, None)),              patch.object(rx.os.path, "getsize", return_value=10):
+            out = rx._extract_anydoc("scan.pdf")
+        self.assertIn("[NEEDS OCR", out)
+        self.assertEqual(len(calls), 1)  # no hosted attempt
+        self.assertIn("hosted_ocr: true", out)  # teaches the enable path
+        self.assertIn("skills_list", out)  # and local OCR
+
+    def test_pin_lockstep(self):
+        """pyproject core pin and lazy_deps self-heal pin must match."""
+        import re
+        from pathlib import Path
+
+        py = Path("pyproject.toml").read_text(encoding="utf-8")
+        lz = Path("tools/lazy_deps.py").read_text(encoding="utf-8")
+        m1 = re.search(r'"firecrawl-anydoc==([\d.]+)"', py)
+        m2 = re.search(r'"firecrawl-anydoc==([\d.]+)"', lz)
+        self.assertIsNotNone(m1)
+        self.assertIsNotNone(m2)
+        self.assertEqual(m1.group(1), m2.group(1))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/tools/test_read_file_schema_gating.py
+++ b/tests/tools/test_read_file_schema_gating.py
@@ -1,5 +1,6 @@
-"""read_file schema diet (#95681): anydoc-gated extraction line +
-PDF-coverage teaching moved to the response-time warning.
+"""read_file schema diet (#95681): static unconditional format list
+(anydoc bundled in core) + PDF-coverage teaching moved to the
+response-time warning.
 
 Maintainer-directed: the schema advertised anydoc-gated formats
 unconditionally ("convert too when the optional anydoc converter is
@@ -15,59 +16,52 @@ from unittest.mock import patch
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
 
-from tools.file_tools import READ_FILE_SCHEMA, _read_file_schema_overrides
 
 
-class TestReadFileSchemaGating(unittest.TestCase):
-    def _desc(self, anydoc_present: bool) -> str:
-        import importlib.util as ilu
+class TestReadFileSchemaStatic(unittest.TestCase):
+    """Gate DROPPED by maintainer decision: anydoc is a core dependency
+    (bundled), so format support is stated unconditionally — a missing
+    converter is a broken install handled by read_extract's teaching
+    error, not a schema variant."""
 
-        real = ilu.find_spec
+    def test_formats_stated_unconditionally(self):
+        from tools.file_tools import READ_FILE_SCHEMA
 
-        def fake(name, *a, **kw):
-            if name == "anydoc":
-                class _Spec:  # truthy stand-in
-                    pass
-                return _Spec() if anydoc_present else None
-            return real(name, *a, **kw)
-
-        with patch("importlib.util.find_spec", side_effect=fake):
-            return _read_file_schema_overrides()["description"]
-
-    def test_anydoc_absent_hides_gated_formats(self):
-        desc = self._desc(False)
-        for token in ("PDF", "OpenDocument", "RTF", "EPUB", "anydoc"):
-            self.assertNotIn(token, desc, token)
-        # Always-supported extractions still advertised.
-        for token in (".ipynb", ".docx", ".xlsx"):
+        desc = READ_FILE_SCHEMA["description"]
+        for token in (".ipynb", ".docx", ".pptx", ".doc/.ppt/.xls",
+                      "PDF (text layer)", "OpenDocument", "RTF", "EPUB"):
             self.assertIn(token, desc, token)
-
-    def test_anydoc_present_advertises_formats_without_caveat(self):
-        desc = self._desc(True)
-        for token in ("PDF (text layer)", ".doc/.ppt/.xls", "OpenDocument",
-                      "RTF", "EPUB"):
-            self.assertIn(token, desc, token)
-        # The availability caveat and install mechanics are gone either way.
+        # No availability hedging, no install mechanics, no gate.
         self.assertNotIn("when the optional", desc)
         self.assertNotIn("auto-installed", desc)
+        self.assertNotIn("anydoc", desc)
+
+    def test_no_dynamic_override_registered(self):
+        from tools.file_tools import READ_FILE_SCHEMA  # noqa: F401
+        import tools.file_tools as ft
+
+        self.assertFalse(hasattr(ft, "_read_file_schema_overrides"))
 
     def test_coverage_warning_teaching_left_to_the_warning(self):
         """The response-time warning owns the recovery curriculum."""
-        for desc in (self._desc(True), self._desc(False),
-                     READ_FILE_SCHEMA["description"]):
-            self.assertNotIn("EXTRACTION COVERAGE WARNING", desc)
-            self.assertNotIn("pdftoppm", desc)
-        # And the warning itself still carries it (single source).
+        from tools.file_tools import READ_FILE_SCHEMA
+
+        desc = READ_FILE_SCHEMA["description"]
+        self.assertNotIn("EXTRACTION COVERAGE WARNING", desc)
+        self.assertNotIn("NEEDS OCR", desc)
+        self.assertNotIn("pdftoppm", desc)
         import inspect
         from tools import read_extract
 
         src = inspect.getsource(read_extract)
-        self.assertIn("EXTRACTION COVERAGE WARNING", src)
+        self.assertIn("NEEDS OCR", src)
         self.assertIn("pdftoppm", src)
         self.assertIn("vision_analyze", src)
 
     def test_binary_note_stays_last(self):
-        desc = self._desc(True)
+        from tools.file_tools import READ_FILE_SCHEMA
+
+        desc = READ_FILE_SCHEMA["description"]
         self.assertLess(desc.find("EPUB"), desc.find("Cannot read images/binary"))
 
     def test_missing_anydoc_error_teaches_install(self):
@@ -75,8 +69,6 @@ class TestReadFileSchemaGating(unittest.TestCase):
 
         err = _anydoc_missing_error("x.epub")
         self.assertIn("firecrawl-anydoc", err)
-        self.assertIn("anydoc", err)
-        # Distinct from the generic unsupported-type error.
         self.assertNotEqual(err, "Unsupported document type: 'x.epub'")
 
 

--- a/tests/tools/test_read_file_schema_gating.py
+++ b/tests/tools/test_read_file_schema_gating.py
@@ -1,0 +1,84 @@
+"""read_file schema diet (#95681): anydoc-gated extraction line +
+PDF-coverage teaching moved to the response-time warning.
+
+Maintainer-directed: the schema advertised anydoc-gated formats
+unconditionally ("convert too when the optional anydoc converter is
+available") and pre-taught the EXTRACTION COVERAGE WARNING's own
+instructions. Now the format list renders only when anydoc is importable,
+and the warning (read_extract.py) is the single teacher — it fires exactly
+when pages are missing, with the page map and recovery commands.
+"""
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from tools.file_tools import READ_FILE_SCHEMA, _read_file_schema_overrides
+
+
+class TestReadFileSchemaGating(unittest.TestCase):
+    def _desc(self, anydoc_present: bool) -> str:
+        import importlib.util as ilu
+
+        real = ilu.find_spec
+
+        def fake(name, *a, **kw):
+            if name == "anydoc":
+                class _Spec:  # truthy stand-in
+                    pass
+                return _Spec() if anydoc_present else None
+            return real(name, *a, **kw)
+
+        with patch("importlib.util.find_spec", side_effect=fake):
+            return _read_file_schema_overrides()["description"]
+
+    def test_anydoc_absent_hides_gated_formats(self):
+        desc = self._desc(False)
+        for token in ("PDF", "OpenDocument", "RTF", "EPUB", "anydoc"):
+            self.assertNotIn(token, desc, token)
+        # Always-supported extractions still advertised.
+        for token in (".ipynb", ".docx", ".xlsx"):
+            self.assertIn(token, desc, token)
+
+    def test_anydoc_present_advertises_formats_without_caveat(self):
+        desc = self._desc(True)
+        for token in ("PDF (text layer)", ".doc/.ppt/.xls", "OpenDocument",
+                      "RTF", "EPUB"):
+            self.assertIn(token, desc, token)
+        # The availability caveat and install mechanics are gone either way.
+        self.assertNotIn("when the optional", desc)
+        self.assertNotIn("auto-installed", desc)
+
+    def test_coverage_warning_teaching_left_to_the_warning(self):
+        """The response-time warning owns the recovery curriculum."""
+        for desc in (self._desc(True), self._desc(False),
+                     READ_FILE_SCHEMA["description"]):
+            self.assertNotIn("EXTRACTION COVERAGE WARNING", desc)
+            self.assertNotIn("pdftoppm", desc)
+        # And the warning itself still carries it (single source).
+        import inspect
+        from tools import read_extract
+
+        src = inspect.getsource(read_extract)
+        self.assertIn("EXTRACTION COVERAGE WARNING", src)
+        self.assertIn("pdftoppm", src)
+        self.assertIn("vision_analyze", src)
+
+    def test_binary_note_stays_last(self):
+        desc = self._desc(True)
+        self.assertLess(desc.find("EPUB"), desc.find("Cannot read images/binary"))
+
+    def test_missing_anydoc_error_teaches_install(self):
+        from tools.read_extract import _anydoc_missing_error
+
+        err = _anydoc_missing_error("x.epub")
+        self.assertIn("firecrawl-anydoc", err)
+        self.assertIn("anydoc", err)
+        # Distinct from the generic unsupported-type error.
+        self.assertNotEqual(err, "Unsupported document type: 'x.epub'")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tools/test_read_file_schema_gating.py
+++ b/tests/tools/test_read_file_schema_gating.py
@@ -36,11 +36,46 @@ class TestReadFileSchemaStatic(unittest.TestCase):
         self.assertNotIn("auto-installed", desc)
         self.assertNotIn("anydoc", desc)
 
-    def test_no_dynamic_override_registered(self):
-        from tools.file_tools import READ_FILE_SCHEMA  # noqa: F401
+    def test_pdf_wording_upgrades_with_hosted_ocr_route(self):
+        """The ONE dynamic word: text-layer → scanned-or-text, keyed on
+        hosted_ocr_available(). Nous gateway deliberately does not
+        upgrade (Parse proxy live-probed broken 2026-08-28)."""
         import tools.file_tools as ft
 
-        self.assertFalse(hasattr(ft, "_read_file_schema_overrides"))
+        with patch("tools.read_extract.hosted_ocr_available",
+                   return_value=True):
+            d = ft._read_file_schema_overrides()["description"]
+        self.assertIn("PDF (scanned or text)", d)
+        self.assertNotIn("PDF (text layer)", d)
+        with patch("tools.read_extract.hosted_ocr_available",
+                   return_value=False):
+            o = ft._read_file_schema_overrides()
+        self.assertEqual(o, {})  # base wording stands
+
+    def test_hosted_ocr_available_gate_states(self):
+        import tools.read_extract as rx
+
+        # direct key → True
+        with patch.dict(rx.os.environ, {"FIRECRAWL_API_KEY": "fc-x"}):
+            with patch("hermes_cli.config.load_config_readonly",
+                       return_value={}):
+                self.assertTrue(rx.hosted_ocr_available())
+        # config false beats key
+        with patch.dict(rx.os.environ, {"FIRECRAWL_API_KEY": "fc-x"}):
+            with patch("hermes_cli.config.load_config_readonly",
+                       return_value={"file_tools": {"hosted_ocr": False}}):
+                self.assertFalse(rx.hosted_ocr_available())
+        # config true without key → True (user's explicit assertion)
+        with patch.dict(rx.os.environ, {}, clear=False):
+            rx.os.environ.pop("FIRECRAWL_API_KEY", None)
+            with patch("hermes_cli.config.load_config_readonly",
+                       return_value={"file_tools": {"hosted_ocr": True}}):
+                self.assertTrue(rx.hosted_ocr_available())
+        # nothing → False (Nous gateway alone must NOT upgrade wording)
+        with patch("hermes_cli.config.load_config_readonly",
+                   return_value={}):
+            rx.os.environ.pop("FIRECRAWL_API_KEY", None)
+            self.assertFalse(rx.hosted_ocr_available())
 
     def test_coverage_warning_teaching_left_to_the_warning(self):
         """The response-time warning owns the recovery curriculum."""

--- a/tests/tools/test_read_file_schema_gating.py
+++ b/tests/tools/test_read_file_schema_gating.py
@@ -130,9 +130,13 @@ class TestNeedsOcrPath(unittest.TestCase):
         self.assertIn("[NEEDS OCR", out)
         self.assertIn("pages 2, 3", out)
         self.assertIn("attempted and failed", out)
-        # Maintainer caveat #2: local OCR guidance leads after a failure.
-        self.assertIn("Prefer LOCAL OCR", out)
+        # Maintainer-directed: HINT at checking for an OCR skill; never
+        # name one (none is guaranteed to exist), never sell config knobs.
+        self.assertIn("check whether an OCR skill is available", out)
         self.assertIn("skills_list", out)
+        self.assertNotIn("ocr-and-documents", out)
+        self.assertNotIn("marker-pdf", out)
+        self.assertNotIn("hosted_ocr", out)
 
     def test_disabled_warns_without_attempt(self):
         from tools import read_extract as rx
@@ -143,8 +147,10 @@ class TestNeedsOcrPath(unittest.TestCase):
             out = rx._extract_anydoc("scan.pdf")
         self.assertIn("[NEEDS OCR", out)
         self.assertEqual(len(calls), 1)  # no hosted attempt
-        self.assertIn("hosted_ocr: true", out)  # teaches the enable path
-        self.assertIn("skills_list", out)  # and local OCR
+        # Same shape when disabled: skill hint, no knob advertising.
+        self.assertIn("check whether an OCR skill is available", out)
+        self.assertNotIn("hosted_ocr", out)
+        self.assertNotIn("ocr-and-documents", out)
 
     def test_pin_lockstep(self):
         """pyproject core pin and lazy_deps self-heal pin must match."""

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -2651,9 +2651,11 @@ READ_FILE_SCHEMA = {
     # Document formats are stated unconditionally: firecrawl-anydoc is a
     # core dependency (bundled), so its absence is a broken install, not a
     # configuration — the teaching error in read_extract handles that rare
-    # case with the pip-install fix. PDF/scanned-page coverage teaching
-    # lives in the response-time NEEDS-OCR warning (read_extract.py), which
-    # arrives exactly when pages are missing; the schema doesn't pre-teach it.
+    # case with the pip-install fix. The ONE dynamic word: "PDF (text
+    # layer)" upgrades to "PDF (scanned or text)" when hosted OCR has a
+    # route we trust (_read_file_schema_overrides). Scanned-page coverage
+    # teaching lives in the response-time NEEDS-OCR warning
+    # (read_extract.py); the schema doesn't pre-teach it.
     "description": "Read a text file with line numbers and pagination. Use this instead of cat/head/tail in terminal. Output format: 'LINE_NUM|CONTENT'. Suggests similar filenames if not found. Use offset and limit for large files. Reads exceeding ~100K characters are truncated on a line boundary and return a next_offset; continue with offset to read the rest. Documents auto-extract to readable text: .ipynb, Office (.docx/.xlsx/.pptx and legacy .doc/.ppt/.xls), PDF (text layer), OpenDocument, RTF, EPUB. Cannot read images/binary — use vision_analyze for images.",
     "parameters": {
         "type": "object",
@@ -2806,7 +2808,28 @@ def _handle_search_files(args, **kw):
         output_mode=args.get("output_mode", "content"), context=args.get("context", 0), task_id=tid)
 
 
-registry.register(name="read_file", toolset="file", schema=READ_FILE_SCHEMA, handler=_handle_read_file, check_fn=_check_file_reqs, emoji="📖", max_result_size_chars=100_000)
+def _read_file_schema_overrides():
+    """One-word capability upgrade: "PDF (text layer)" → "PDF (scanned or
+    text)" when hosted OCR has a trusted route (see
+    read_extract.hosted_ocr_available). Config/env probe only — no
+    network at schema-build time. Compaction's tool refresh (#97073)
+    picks up a key added mid-session.
+    """
+    try:
+        from tools.read_extract import hosted_ocr_available
+
+        if hosted_ocr_available():
+            return {
+                "description": READ_FILE_SCHEMA["description"].replace(
+                    "PDF (text layer)", "PDF (scanned or text)"
+                )
+            }
+    except Exception:  # noqa: BLE001
+        pass
+    return {}
+
+
+registry.register(name="read_file", toolset="file", schema=READ_FILE_SCHEMA, handler=_handle_read_file, check_fn=_check_file_reqs, emoji="📖", max_result_size_chars=100_000, dynamic_schema_overrides=_read_file_schema_overrides)
 registry.register(name="write_file", toolset="file", schema=WRITE_FILE_SCHEMA, handler=_handle_write_file, check_fn=_check_file_reqs, emoji="✍️", max_result_size_chars=100_000)
 registry.register(name="patch", toolset="file", schema=PATCH_SCHEMA, handler=_handle_patch, check_fn=_check_file_reqs, emoji="🔧", max_result_size_chars=100_000)
 registry.register(name="search_files", toolset="file", schema=SEARCH_FILES_SCHEMA, handler=_handle_search_files, check_fn=_check_file_reqs, emoji="🔎", max_result_size_chars=100_000)

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -2648,14 +2648,13 @@ def _check_file_reqs():
 
 READ_FILE_SCHEMA = {
     "name": "read_file",
-    # Base description covers the always-true surface. The document-
-    # extraction line is appended dynamically (_read_file_schema_overrides):
-    # anydoc-gated formats are advertised only when the converter is
-    # actually importable, and the PDF coverage teaching moved to the
-    # response-time EXTRACTION COVERAGE WARNING itself (read_extract.py) —
-    # the warning arrives exactly when pages are missing, with the page
-    # map and the recovery commands; the schema no longer pre-teaches it.
-    "description": "Read a text file with line numbers and pagination. Use this instead of cat/head/tail in terminal. Output format: 'LINE_NUM|CONTENT'. Suggests similar filenames if not found. Use offset and limit for large files. Reads exceeding ~100K characters are truncated on a line boundary and return a next_offset; continue with offset to read the rest. Cannot read images/binary — use vision_analyze for images.",
+    # Document formats are stated unconditionally: firecrawl-anydoc is a
+    # core dependency (bundled), so its absence is a broken install, not a
+    # configuration — the teaching error in read_extract handles that rare
+    # case with the pip-install fix. PDF/scanned-page coverage teaching
+    # lives in the response-time NEEDS-OCR warning (read_extract.py), which
+    # arrives exactly when pages are missing; the schema doesn't pre-teach it.
+    "description": "Read a text file with line numbers and pagination. Use this instead of cat/head/tail in terminal. Output format: 'LINE_NUM|CONTENT'. Suggests similar filenames if not found. Use offset and limit for large files. Reads exceeding ~100K characters are truncated on a line boundary and return a next_offset; continue with offset to read the rest. Documents auto-extract to readable text: .ipynb, Office (.docx/.xlsx/.pptx and legacy .doc/.ppt/.xls), PDF (text layer), OpenDocument, RTF, EPUB. Cannot read images/binary — use vision_analyze for images.",
     "parameters": {
         "type": "object",
         "properties": {
@@ -2807,48 +2806,7 @@ def _handle_search_files(args, **kw):
         output_mode=args.get("output_mode", "content"), context=args.get("context", 0), task_id=tid)
 
 
-def _read_file_schema_overrides():
-    """Append the document-extraction line, capability-gated (#95681).
-
-    The always-supported extractions (.ipynb/.docx/.xlsx — stdlib/bundled)
-    are stated unconditionally; the anydoc-gated formats (PDF, legacy
-    Office, OpenDocument, RTF, EPUB) are advertised ONLY when the
-    converter is importable RIGHT NOW. Availability is probed with
-    find_spec — cheap and side-effect-free at schema-build time (the
-    lazy installer must never run here). When anydoc is absent the
-    formats simply aren't advertised; attempting one anyway gets the
-    teaching error from read_extract (install command included), and a
-    mid-session install is picked up at the next compaction's tool
-    refresh (#97073).
-    """
-    import importlib.util
-
-    base = READ_FILE_SCHEMA["description"]
-    extract_line = (
-        " Jupyter notebooks (.ipynb), Word (.docx), and Excel (.xlsx) "
-        "auto-extract to readable text"
-    )
-    try:
-        anydoc_present = importlib.util.find_spec("anydoc") is not None
-    except Exception:  # noqa: BLE001 — broken meta-path finder etc.
-        anydoc_present = False
-    if anydoc_present:
-        extract_line += (
-            "; PDF (text layer), legacy Office (.doc/.ppt/.xls), "
-            "OpenDocument, RTF, and EPUB convert too"
-        )
-    extract_line += "."
-    # Insert before the trailing binary note so the can't-do stays last.
-    marker = " Cannot read images/binary"
-    if marker in base:
-        head, tail = base.split(marker, 1)
-        description = head + extract_line + marker + tail
-    else:  # pragma: no cover — marker is part of the static schema above
-        description = base + extract_line
-    return {"description": description}
-
-
-registry.register(name="read_file", toolset="file", schema=READ_FILE_SCHEMA, handler=_handle_read_file, check_fn=_check_file_reqs, emoji="📖", max_result_size_chars=100_000, dynamic_schema_overrides=_read_file_schema_overrides)
+registry.register(name="read_file", toolset="file", schema=READ_FILE_SCHEMA, handler=_handle_read_file, check_fn=_check_file_reqs, emoji="📖", max_result_size_chars=100_000)
 registry.register(name="write_file", toolset="file", schema=WRITE_FILE_SCHEMA, handler=_handle_write_file, check_fn=_check_file_reqs, emoji="✍️", max_result_size_chars=100_000)
 registry.register(name="patch", toolset="file", schema=PATCH_SCHEMA, handler=_handle_patch, check_fn=_check_file_reqs, emoji="🔧", max_result_size_chars=100_000)
 registry.register(name="search_files", toolset="file", schema=SEARCH_FILES_SCHEMA, handler=_handle_search_files, check_fn=_check_file_reqs, emoji="🔎", max_result_size_chars=100_000)

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -2648,7 +2648,14 @@ def _check_file_reqs():
 
 READ_FILE_SCHEMA = {
     "name": "read_file",
-    "description": "Read a text file with line numbers and pagination. Use this instead of cat/head/tail in terminal. Output format: 'LINE_NUM|CONTENT'. Suggests similar filenames if not found. Use offset and limit for large files. Reads exceeding ~100K characters are truncated on a line boundary and return a next_offset; continue with offset to read the rest. Jupyter notebooks (.ipynb), Word documents (.docx), and Excel workbooks (.xlsx) are auto-extracted to readable text; PDF, legacy Office (.doc/.ppt/.xls), OpenDocument, RTF, and EPUB convert too when the optional anydoc converter is available (auto-installed on first use where installs are permitted). PDF conversion reads the text layer only: scanned/image pages yield no text, and when many pages come back empty the output ends with an EXTRACTION COVERAGE WARNING listing the affected pages — follow its instructions (render pages with pdftoppm and inspect via vision_analyze, or OCR) instead of treating the extraction as complete. NOTE: Cannot read images or other binary files — use vision_analyze for images.",
+    # Base description covers the always-true surface. The document-
+    # extraction line is appended dynamically (_read_file_schema_overrides):
+    # anydoc-gated formats are advertised only when the converter is
+    # actually importable, and the PDF coverage teaching moved to the
+    # response-time EXTRACTION COVERAGE WARNING itself (read_extract.py) —
+    # the warning arrives exactly when pages are missing, with the page
+    # map and the recovery commands; the schema no longer pre-teaches it.
+    "description": "Read a text file with line numbers and pagination. Use this instead of cat/head/tail in terminal. Output format: 'LINE_NUM|CONTENT'. Suggests similar filenames if not found. Use offset and limit for large files. Reads exceeding ~100K characters are truncated on a line boundary and return a next_offset; continue with offset to read the rest. Cannot read images/binary — use vision_analyze for images.",
     "parameters": {
         "type": "object",
         "properties": {
@@ -2800,7 +2807,48 @@ def _handle_search_files(args, **kw):
         output_mode=args.get("output_mode", "content"), context=args.get("context", 0), task_id=tid)
 
 
-registry.register(name="read_file", toolset="file", schema=READ_FILE_SCHEMA, handler=_handle_read_file, check_fn=_check_file_reqs, emoji="📖", max_result_size_chars=100_000)
+def _read_file_schema_overrides():
+    """Append the document-extraction line, capability-gated (#95681).
+
+    The always-supported extractions (.ipynb/.docx/.xlsx — stdlib/bundled)
+    are stated unconditionally; the anydoc-gated formats (PDF, legacy
+    Office, OpenDocument, RTF, EPUB) are advertised ONLY when the
+    converter is importable RIGHT NOW. Availability is probed with
+    find_spec — cheap and side-effect-free at schema-build time (the
+    lazy installer must never run here). When anydoc is absent the
+    formats simply aren't advertised; attempting one anyway gets the
+    teaching error from read_extract (install command included), and a
+    mid-session install is picked up at the next compaction's tool
+    refresh (#97073).
+    """
+    import importlib.util
+
+    base = READ_FILE_SCHEMA["description"]
+    extract_line = (
+        " Jupyter notebooks (.ipynb), Word (.docx), and Excel (.xlsx) "
+        "auto-extract to readable text"
+    )
+    try:
+        anydoc_present = importlib.util.find_spec("anydoc") is not None
+    except Exception:  # noqa: BLE001 — broken meta-path finder etc.
+        anydoc_present = False
+    if anydoc_present:
+        extract_line += (
+            "; PDF (text layer), legacy Office (.doc/.ppt/.xls), "
+            "OpenDocument, RTF, and EPUB convert too"
+        )
+    extract_line += "."
+    # Insert before the trailing binary note so the can't-do stays last.
+    marker = " Cannot read images/binary"
+    if marker in base:
+        head, tail = base.split(marker, 1)
+        description = head + extract_line + marker + tail
+    else:  # pragma: no cover — marker is part of the static schema above
+        description = base + extract_line
+    return {"description": description}
+
+
+registry.register(name="read_file", toolset="file", schema=READ_FILE_SCHEMA, handler=_handle_read_file, check_fn=_check_file_reqs, emoji="📖", max_result_size_chars=100_000, dynamic_schema_overrides=_read_file_schema_overrides)
 registry.register(name="write_file", toolset="file", schema=WRITE_FILE_SCHEMA, handler=_handle_write_file, check_fn=_check_file_reqs, emoji="✍️", max_result_size_chars=100_000)
 registry.register(name="patch", toolset="file", schema=PATCH_SCHEMA, handler=_handle_patch, check_fn=_check_file_reqs, emoji="🔧", max_result_size_chars=100_000)
 registry.register(name="search_files", toolset="file", schema=SEARCH_FILES_SCHEMA, handler=_handle_search_files, check_fn=_check_file_reqs, emoji="🔎", max_result_size_chars=100_000)

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -292,10 +292,10 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     # the stdlib .ipynb/.docx/.xlsx to PDF, legacy Office (.doc/.ppt/.xls),
     # OpenDocument, RTF, and EPUB. Installed on first read of such a file;
     # the call site uses prompt=False so read_file never blocks on a prompt.
-    # NOTE: lazy-only for now — no pyproject `doc-extract` extra until the
-    # package clears the uv exclude-newer 14-day quarantine (first release
-    # 2026-08-04); add the mirrored extra then.
-    "tool.doc_extract": ("firecrawl-anydoc==0.1.6",),
+    # NOTE: bundled in core pyproject dependencies since the hosted-OCR
+    # wiring (keep this lazy pin in lockstep with pyproject) — this entry
+    # survives as the self-heal path for lean/partial installs.
+    "tool.doc_extract": ("firecrawl-anydoc==0.2.4",),  # lockstep with pyproject
     # Computer Use (cua-driver) — the MCP client SDK used to spawn and talk
     # to the cua-driver process over stdio. Matches the `mcp` / `computer-use`
     # extras in pyproject.toml. The one-liner installer pulls this in via

--- a/tools/read_extract.py
+++ b/tools/read_extract.py
@@ -234,9 +234,10 @@ def _needs_ocr_warning(path: str, pages, hosted_error: str = "") -> str:
     """Typed replacement for the heuristic coverage note on full-OCR PDFs.
 
     Fired when anydoc raises NeedsOcrError and hosted OCR is disabled,
-    unavailable, or failed. Maintainer caveat #2: when no working
-    Firecrawl route exists, point at LOCAL OCR via the skills system
-    instead of a service the user doesn't have.
+    unavailable, or failed. Maintainer-directed shape: hint at CHECKING
+    for an OCR skill (never name one — none is guaranteed to exist), and
+    never advertise the hosted_ocr config knob — when hosted fails or is
+    absent, a skill or ignoring the gap are the paths that exist.
     """
     page_list = ", ".join(str(p) for p in pages) if pages else "unknown"
     msg = (
@@ -244,27 +245,14 @@ def _needs_ocr_warning(path: str, pages, hosted_error: str = "") -> str:
         "with no text layer — their content is MISSING below. "
     )
     if hosted_error:
-        msg += (
-            f"Hosted OCR was attempted and failed ({hosted_error}). "
-            "Prefer LOCAL OCR: search your skills (skills_list — e.g. the "
-            "ocr-and-documents skill / marker-pdf) for bulk ranges, or "
-        )
-    else:
-        msg += "Options: "
+        msg += f"Hosted OCR was attempted and failed ({hosted_error}). "
     msg += (
-        "render just the pages you need with `pdftoppm -jpeg "
-        f"-r 150 -f <first> -l <last> '{path}' /tmp/page` and inspect via "
-        "vision_analyze"
+        "If the missing pages matter: render just those pages with "
+        f"`pdftoppm -jpeg -r 150 -f <first> -l <last> '{path}' /tmp/page` "
+        "and inspect via vision_analyze, or check whether an OCR skill is "
+        "available (skills_list)."
     )
-    if not hosted_error:
-        msg += (
-            "; or search your skills for local OCR (skills_list — e.g. the "
-            "ocr-and-documents skill / marker-pdf) for bulk ranges"
-            "; or enable automatic hosted OCR by setting "
-            "file_tools.hosted_ocr: true in config.yaml (sends the "
-            "document to Firecrawl Parse; needs FIRECRAWL_API_KEY)"
-        )
-    return msg + ".]\n"
+    return msg + "]\n"
 
 
 def _extract_anydoc(path: str) -> str:

--- a/tools/read_extract.py
+++ b/tools/read_extract.py
@@ -183,81 +183,51 @@ def _anydoc_missing_error(path: str) -> str:
 def _hosted_ocr_config() -> tuple:
     """Resolve hosted-OCR settings: (enabled, api_key, api_url).
 
-    ``file_tools.hosted_ocr`` in config.yaml:
-      true    — always attempt hosted OCR on NeedsOcrError
-      false   — never (warning path only)
-      unset   — AUTO: attempt only when a Firecrawl route exists —
-                direct FIRECRAWL_API_KEY first, else the Nous managed
-                gateway. No document leaves the box on a route the user
-                hasn't already trusted with their web traffic.
-
-    NOTE (live-probed 2026-08-28): the Nous firecrawl gateway did NOT yet
-    proxy the Parse endpoint (uniform HTTP 500 on /v2/parse) while
-    scrape/search worked. The gateway route is therefore attempt-and-
-    fall-through: a failure lands in the NEEDS-OCR warning (which
-    recommends local-OCR skills) rather than being retried or trusted.
-    When the gateway grows Parse support this lights up with no code
-    change. Never raises.
+    Maintainer decision: the ONLY route is a direct ``FIRECRAWL_API_KEY``
+    (anydoc defaults api_url to https://api.firecrawl.dev). The Nous
+    managed gateway is NOT used — its Parse proxy was live-probed broken
+    (uniform HTTP 500, 2026-08-28) while scrape/search worked; revisit
+    when the gateway grows Parse support. ``file_tools.hosted_ocr``:
+    false disables even with a key; true/unset → enabled iff key
+    present. Never raises.
     """
-    enabled = None
+    api_key = os.environ.get("FIRECRAWL_API_KEY") or None
+    enabled = api_key is not None
     try:
         from hermes_cli.config import load_config_readonly
 
         cfg = load_config_readonly()
         section = cfg.get("file_tools") if isinstance(cfg, dict) else None
-        if isinstance(section, dict) and "hosted_ocr" in section:
-            enabled = bool(section["hosted_ocr"])
+        if isinstance(section, dict) and section.get("hosted_ocr") is False:
+            enabled = False
     except Exception:  # noqa: BLE001
-        enabled = None
-
-    api_key = os.environ.get("FIRECRAWL_API_KEY") or None
-    api_url = None
-    if api_key is None:
-        # Nous managed gateway: OAuth token as key, gateway as base URL.
-        try:
-            import tools.web_tools as _wt
-
-            if _wt.resolve_managed_tool_gateway(
-                "firecrawl", token_reader=_wt._peek_nous_access_token
-            ) is not None:
-                api_key = _wt._peek_nous_access_token()
-                api_url = _wt.build_vendor_gateway_url("firecrawl")
-        except Exception:  # noqa: BLE001
-            pass
-
-    if enabled is None:
-        enabled = api_key is not None
-    return enabled, api_key, api_url
+        pass
+    return enabled, api_key, None
 
 
 def hosted_ocr_available() -> bool:
-    """Public probe for schema builders: is hosted OCR expected to work?
+    """Public probe for read_file's schema line: is hosted OCR unlocked?
 
-    True when hosted OCR is expected to work: config ``hosted_ocr: true``
-    (the user's explicit assertion), or AUTO with a DIRECT
-    ``FIRECRAWL_API_KEY``. The Nous managed gateway deliberately does NOT
-    upgrade the schema wording yet — it resolves a token but its Parse
-    proxy was live-probed broken (HTTP 500, 2026-08-28); at runtime the
-    gateway is still attempted (free upside), but the schema only
-    promises what a route we've seen work can deliver. Used by
-    read_file's dynamic schema line to advertise "PDF (scanned or text)"
-    instead of "PDF (text layer)". Route resolution only — no network
-    I/O (schema build must stay side-effect-free); a promised route that
-    fails at conversion time lands in the NEEDS-OCR warning.
+    Maintainer decision: ONE gate — a direct ``FIRECRAWL_API_KEY`` in the
+    environment. Nothing else unlocks the "PDF (scanned or text)" wording
+    (not the Nous gateway — Parse proxy live-probed broken 2026-08-28 —
+    and not config assertions). ``file_tools.hosted_ocr: false`` still
+    disables. Env probe only — no network at schema-build time; a key
+    that fails at conversion time lands in the NEEDS-OCR warning.
     """
     try:
-        import os as _os
-
-        from hermes_cli.config import load_config_readonly
-
+        if not os.environ.get("FIRECRAWL_API_KEY"):
+            return False
         try:
+            from hermes_cli.config import load_config_readonly
+
             cfg = load_config_readonly()
             section = cfg.get("file_tools") if isinstance(cfg, dict) else None
-            if isinstance(section, dict) and "hosted_ocr" in section:
-                return bool(section["hosted_ocr"])
+            if isinstance(section, dict) and section.get("hosted_ocr") is False:
+                return False
         except Exception:  # noqa: BLE001
             pass
-        return bool(_os.environ.get("FIRECRAWL_API_KEY"))
+        return True
     except Exception:  # noqa: BLE001
         return False
 

--- a/tools/read_extract.py
+++ b/tools/read_extract.py
@@ -162,10 +162,28 @@ def extract_document_bytes(data: bytes, path: str) -> str:
                 pass
 
 
+def _anydoc_missing_error(path: str) -> str:
+    """Teaching error for anydoc-gated formats when the converter is absent.
+
+    Response-time hint (#95681 pattern): the schema no longer lists the
+    anydoc-gated formats or the availability caveat — a session that never
+    touches a .doc/.odt/.epub never pays for the explanation, and one that
+    does gets the full story here, with the fix.
+    """
+    return (
+        f"Cannot convert {path!r}: this format needs the optional anydoc "
+        "converter, which is not installed (install blocked or first "
+        "attempt failed; retried every 5 minutes). Fix: `pip install "
+        "firecrawl-anydoc` in Hermes's environment, or convert the file "
+        "yourself via terminal (e.g. libreoffice --headless --convert-to "
+        "txt)."
+    )
+
+
 def _extract_anydoc(path: str) -> str:
     mod = _anydoc()
     if mod is None:
-        raise ExtractionError(f"Unsupported document type: {path!r}")
+        raise ExtractionError(_anydoc_missing_error(path))
     try:
         size = os.path.getsize(path)
     except OSError as exc:
@@ -335,7 +353,7 @@ def _pdf_coverage_note(path: str, display_path: Optional[str] = None) -> str:
 def _extract_anydoc_bytes(data: bytes, path: str) -> str:
     mod = _anydoc()
     if mod is None:
-        raise ExtractionError(f"Unsupported document type: {path!r}")
+        raise ExtractionError(_anydoc_missing_error(path))
     if len(data) > MAX_ANYDOC_BYTES:
         raise ExtractionError(
             f"Document too large to convert ({len(data):,} bytes, limit is {MAX_ANYDOC_BYTES:,})"

--- a/tools/read_extract.py
+++ b/tools/read_extract.py
@@ -230,6 +230,38 @@ def _hosted_ocr_config() -> tuple:
     return enabled, api_key, api_url
 
 
+def hosted_ocr_available() -> bool:
+    """Public probe for schema builders: is hosted OCR expected to work?
+
+    True when hosted OCR is expected to work: config ``hosted_ocr: true``
+    (the user's explicit assertion), or AUTO with a DIRECT
+    ``FIRECRAWL_API_KEY``. The Nous managed gateway deliberately does NOT
+    upgrade the schema wording yet — it resolves a token but its Parse
+    proxy was live-probed broken (HTTP 500, 2026-08-28); at runtime the
+    gateway is still attempted (free upside), but the schema only
+    promises what a route we've seen work can deliver. Used by
+    read_file's dynamic schema line to advertise "PDF (scanned or text)"
+    instead of "PDF (text layer)". Route resolution only — no network
+    I/O (schema build must stay side-effect-free); a promised route that
+    fails at conversion time lands in the NEEDS-OCR warning.
+    """
+    try:
+        import os as _os
+
+        from hermes_cli.config import load_config_readonly
+
+        try:
+            cfg = load_config_readonly()
+            section = cfg.get("file_tools") if isinstance(cfg, dict) else None
+            if isinstance(section, dict) and "hosted_ocr" in section:
+                return bool(section["hosted_ocr"])
+        except Exception:  # noqa: BLE001
+            pass
+        return bool(_os.environ.get("FIRECRAWL_API_KEY"))
+    except Exception:  # noqa: BLE001
+        return False
+
+
 def _needs_ocr_warning(path: str, pages, hosted_error: str = "") -> str:
     """Typed replacement for the heuristic coverage note on full-OCR PDFs.
 

--- a/tools/read_extract.py
+++ b/tools/read_extract.py
@@ -180,6 +180,93 @@ def _anydoc_missing_error(path: str) -> str:
     )
 
 
+def _hosted_ocr_config() -> tuple:
+    """Resolve hosted-OCR settings: (enabled, api_key, api_url).
+
+    ``file_tools.hosted_ocr`` in config.yaml:
+      true    — always attempt hosted OCR on NeedsOcrError
+      false   — never (warning path only)
+      unset   — AUTO: attempt only when a Firecrawl route exists —
+                direct FIRECRAWL_API_KEY first, else the Nous managed
+                gateway. No document leaves the box on a route the user
+                hasn't already trusted with their web traffic.
+
+    NOTE (live-probed 2026-08-28): the Nous firecrawl gateway did NOT yet
+    proxy the Parse endpoint (uniform HTTP 500 on /v2/parse) while
+    scrape/search worked. The gateway route is therefore attempt-and-
+    fall-through: a failure lands in the NEEDS-OCR warning (which
+    recommends local-OCR skills) rather than being retried or trusted.
+    When the gateway grows Parse support this lights up with no code
+    change. Never raises.
+    """
+    enabled = None
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        cfg = load_config_readonly()
+        section = cfg.get("file_tools") if isinstance(cfg, dict) else None
+        if isinstance(section, dict) and "hosted_ocr" in section:
+            enabled = bool(section["hosted_ocr"])
+    except Exception:  # noqa: BLE001
+        enabled = None
+
+    api_key = os.environ.get("FIRECRAWL_API_KEY") or None
+    api_url = None
+    if api_key is None:
+        # Nous managed gateway: OAuth token as key, gateway as base URL.
+        try:
+            import tools.web_tools as _wt
+
+            if _wt.resolve_managed_tool_gateway(
+                "firecrawl", token_reader=_wt._peek_nous_access_token
+            ) is not None:
+                api_key = _wt._peek_nous_access_token()
+                api_url = _wt.build_vendor_gateway_url("firecrawl")
+        except Exception:  # noqa: BLE001
+            pass
+
+    if enabled is None:
+        enabled = api_key is not None
+    return enabled, api_key, api_url
+
+
+def _needs_ocr_warning(path: str, pages, hosted_error: str = "") -> str:
+    """Typed replacement for the heuristic coverage note on full-OCR PDFs.
+
+    Fired when anydoc raises NeedsOcrError and hosted OCR is disabled,
+    unavailable, or failed. Maintainer caveat #2: when no working
+    Firecrawl route exists, point at LOCAL OCR via the skills system
+    instead of a service the user doesn't have.
+    """
+    page_list = ", ".join(str(p) for p in pages) if pages else "unknown"
+    msg = (
+        f"[NEEDS OCR: pages {page_list} of this PDF are scanned images "
+        "with no text layer — their content is MISSING below. "
+    )
+    if hosted_error:
+        msg += (
+            f"Hosted OCR was attempted and failed ({hosted_error}). "
+            "Prefer LOCAL OCR: search your skills (skills_list — e.g. the "
+            "ocr-and-documents skill / marker-pdf) for bulk ranges, or "
+        )
+    else:
+        msg += "Options: "
+    msg += (
+        "render just the pages you need with `pdftoppm -jpeg "
+        f"-r 150 -f <first> -l <last> '{path}' /tmp/page` and inspect via "
+        "vision_analyze"
+    )
+    if not hosted_error:
+        msg += (
+            "; or search your skills for local OCR (skills_list — e.g. the "
+            "ocr-and-documents skill / marker-pdf) for bulk ranges"
+            "; or enable automatic hosted OCR by setting "
+            "file_tools.hosted_ocr: true in config.yaml (sends the "
+            "document to Firecrawl Parse; needs FIRECRAWL_API_KEY)"
+        )
+    return msg + ".]\n"
+
+
 def _extract_anydoc(path: str) -> str:
     mod = _anydoc()
     if mod is None:
@@ -192,11 +279,32 @@ def _extract_anydoc(path: str) -> str:
         raise ExtractionError(
             f"Document too large to convert ({size:,} bytes, limit is {MAX_ANYDOC_BYTES:,})"
         )
+    needs_ocr = getattr(mod, "NeedsOcrError", None)
     try:
         text = mod.to_markdown(path)
     except OSError as exc:
         raise ExtractionError(str(exc)) from exc
     except Exception as exc:
+        if needs_ocr is not None and isinstance(exc, needs_ocr):
+            # Typed scanned-pages signal (anydoc >= 0.2). Try hosted OCR
+            # when a Firecrawl route exists; otherwise teach recovery.
+            pages = list(getattr(exc, "pages", []) or [])
+            enabled, api_key, api_url = _hosted_ocr_config()
+            hosted_error = ""
+            if enabled:
+                try:
+                    kwargs = {"ocr": "hosted"}
+                    if api_key:
+                        kwargs["api_key"] = api_key
+                    if api_url:
+                        kwargs["api_url"] = api_url
+                    text = mod.to_markdown(path, **kwargs)
+                    return text.rstrip("\n") + "\n"
+                except Exception as hosted_exc:  # noqa: BLE001
+                    hosted_error = f"{type(hosted_exc).__name__}: {hosted_exc}"
+            # No route / disabled / hosted failed: whole doc is scans —
+            # nothing to extract, so the warning IS the result.
+            return _needs_ocr_warning(path, pages, hosted_error)
         # anydoc raises one ConvertError subclass per failure mode
         # (Unsupported, Malformed, Encrypted, ResourceLimit, MissingPart).
         # Any of them means "no meaningful text": fall back to the normal
@@ -210,6 +318,9 @@ def _extract_anydoc(path: str) -> str:
         if note:
             # Prepend: read_file paginates the extraction, so a footer on a
             # long document would sit on a page the model may never fetch.
+            # This heuristic note survives for PARTIAL coverage gaps —
+            # documents with a text layer plus some scanned pages, which
+            # convert without raising NeedsOcrError.
             text = note + text
     return text
 

--- a/uv.lock
+++ b/uv.lock
@@ -13,17 +13,18 @@ exclude-newer-span = "P14D"
 
 [options.exclude-newer-package]
 setuptools = false
-h2 = false
+huggingface-hub = false
 vercel = false
 pillow = false
 unpaddedbase64 = false
+h2 = false
 defusedxml = false
 aiohttp = false
 cryptography = false
 mcp = false
 python-olm = false
+firecrawl-anydoc = false
 nemo-relay = false
-huggingface-hub = false
 
 [manifest]
 overrides = [
@@ -1269,6 +1270,21 @@ wheels = [
 ]
 
 [[package]]
+name = "firecrawl-anydoc"
+version = "0.2.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/54/ee43b1661a954e53eaed85878a7ccc37ed73e02e6577bb26437ec5f9de94/firecrawl_anydoc-0.2.4.tar.gz", hash = "sha256:3e29460272fea81cde08fd5af11f6b0f1ff05919214ddc939867f72362c83032", size = 270706, upload-time = "2026-08-27T19:13:58.156Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/25/f1/5616b8d703b2bf5688eda86ede4b35620356d9c60346fe2d3efbec2a872d/firecrawl_anydoc-0.2.4-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:e3745a8b108d6575beafd37bcefe52e3f6c7ab44138e05cbdf4c6adf63caba84", size = 3441281, upload-time = "2026-08-27T19:13:43.408Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7d/4b2a466c8953af3b9d94471081b04ce8636680111402d2140105f98c02e5/firecrawl_anydoc-0.2.4-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:b2a01eecaa0b99f99ff6749a098f8c7a5250d41db9c53673eb93536ad575bfed", size = 3262365, upload-time = "2026-08-27T19:13:46.362Z" },
+    { url = "https://files.pythonhosted.org/packages/77/b5/5784fc514f58ca19328faee701d2cc2e25961389c2d4908b2a51a1071ee4/firecrawl_anydoc-0.2.4-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:17720ba093820654162891d7995fd2dbae948b16fe1c174ba799bddfc0b92ad6", size = 3265363, upload-time = "2026-08-27T19:13:48.425Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/16/feeca9705bfdb237f1cb69ede0b373b144c0d51df4297e595a74b815557e/firecrawl_anydoc-0.2.4-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0e5aed01bf6d4e5c588d3363888293f2ceeb9feb00449a32e0ba993797cf0bd3", size = 3506751, upload-time = "2026-08-27T19:13:50.372Z" },
+    { url = "https://files.pythonhosted.org/packages/14/28/b4d0d3c5345cdd65c0b9113c6e6ff1b717fe360dccb658db2a9952315f9c/firecrawl_anydoc-0.2.4-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:dd162b5eb64478fcf02f53abe7765e26f4350ba657f36c25f055c4cc3dbade0a", size = 3443075, upload-time = "2026-08-27T19:13:52.417Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/29/50c52b0ea5dd645aea6d195da913c8d9e136601eec465bd9a590edd250c7/firecrawl_anydoc-0.2.4-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e57c79093c1592929dd8dfaf6c60b49eefe631721d96fb833c3f465472b37b9f", size = 3742860, upload-time = "2026-08-27T19:13:54.474Z" },
+    { url = "https://files.pythonhosted.org/packages/65/34/6d54fed906055e5507dd94efd63f4a05021f103dc684ea62a3b0876b7595/firecrawl_anydoc-0.2.4-cp310-abi3-win_amd64.whl", hash = "sha256:7c9ffc81946e6954c124560ed1d395e0103a1a08fdc0f6be382e2f35daf6dbc9", size = 3583555, upload-time = "2026-08-27T19:13:56.698Z" },
+]
+
+[[package]]
 name = "firecrawl-py"
 version = "4.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1578,6 +1594,7 @@ dependencies = [
     { name = "cryptography" },
     { name = "fastapi" },
     { name = "fire" },
+    { name = "firecrawl-anydoc" },
     { name = "httpx", extra = ["socks"] },
     { name = "jinja2" },
     { name = "markdown" },
@@ -1844,6 +1861,7 @@ requires-dist = [
     { name = "fastapi", marker = "extra == 'web'", specifier = "==0.133.1" },
     { name = "faster-whisper", marker = "extra == 'voice'", specifier = "==1.2.1" },
     { name = "fire", specifier = "==0.7.1" },
+    { name = "firecrawl-anydoc", specifier = "==0.2.4" },
     { name = "firecrawl-py", marker = "extra == 'firecrawl'", specifier = "==4.17.0" },
     { name = "google-api-python-client", marker = "extra == 'google'", specifier = "==2.194.0" },
     { name = "google-auth", marker = "extra == 'google'", specifier = "==2.55.1" },
@@ -4052,7 +4070,7 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 dependencies = [
-    { name = "numpy", marker = "python_full_version < '3.12'" },
+    { name = "numpy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -4107,7 +4125,7 @@ resolution-markers = [
     "python_full_version == '3.12.*'",
 ]
 dependencies = [
-    { name = "numpy", marker = "python_full_version >= '3.12'" },
+    { name = "numpy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a7/25/c2700dfaf6442b4effaa91af24ebce5dc9d31bb4a69706313aae70d72cd0/scipy-1.18.0.tar.gz", hash = "sha256:67b2ad2ad54c72ca6d04975a9b2df8c3638c34ddd5b28738e94fc2b57929d378", size = 30774447, upload-time = "2026-06-19T15:01:43.456Z" }
 wheels = [
@@ -4755,11 +4773,11 @@ name = "vercel-workers"
 version = "0.0.25"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio", marker = "python_full_version >= '3.12'" },
-    { name = "httpx", marker = "python_full_version >= '3.12'" },
-    { name = "pydantic", marker = "python_full_version >= '3.12'" },
-    { name = "python-dotenv", marker = "python_full_version >= '3.12'" },
-    { name = "vercel", marker = "python_full_version >= '3.12'" },
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "vercel" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/30/df/04d37021ad7ca53b7599c313e411d91623c7a005c741f491d1eefb7a9f0c/vercel_workers-0.0.25.tar.gz", hash = "sha256:212ded01400b524be51d251df49f801caf115ad7d48cca7eb168cbeceda3def3", size = 64149, upload-time = "2026-06-20T19:26:27.177Z" }
 wheels = [


### PR DESCRIPTION
Two commits, one arc (maintainer-directed):

## Commit 1 — schema diet (426 → 244–269 tok/call)
1. anydoc format list capability-gated via dynamic_schema_overrides (find_spec probe, side-effect-free at build time); absent → formats unadvertised + teaching error names the fix. 2. PDF coverage teaching moved to the response-time warning (single source, contract-tested). Full details in the edit history.

## Commit 2 — bundle + OCR wiring (maintainer: "bump the lazy pin, bundle it always, wire in OCR")
- **Bundled**: `firecrawl-anydoc==0.2.4` in core pyproject deps (the lazy-only arrangement dated to the package's uv exclude-newer quarantine — expired). Lazy `tool.doc_extract` pin bumped 0.1.6 → 0.2.4 in lockstep (self-heal path for lean installs; lockstep pinned by a test). Package required `exclude-newer-package` exemption (published 2026-08-27, inside the 14-day window) — same exact-pin rationale as setuptools/pillow/mcp: exclude-newer adds zero float protection to an exact pin. `uv lock` regenerated.
- **Typed NeedsOcrError** (new in 0.2.x — 0.2.4 replaced the char-count guesswork for full-scan PDFs): exact page list from the exception. The old heuristic coverage note SURVIVES for partial-gap PDFs (text layer + some scanned pages), which convert without raising.
- **Hosted OCR, config-gated** (`file_tools.hosted_ocr`): true=always, false=never, unset=AUTO (attempt only when a Firecrawl route exists: direct FIRECRAWL_API_KEY, else Nous managed gateway — no egress on a route the user hasn't already trusted with web traffic). On success the scanned pages simply appear in the output — no warning at all.
- **Maintainer caveat #1 (live-probed, this box, real scanned PDF)**: local NeedsOcrError→pages [1] ✅; direct keyless Parse reachable (rate-limit response proves endpoint) ✅; **Nous gateway does NOT yet proxy Parse — uniform HTTP 500 on /v2/parse (×3 retries + direct endpoint probe) while scrape/search work.** Coded as attempt-and-fall-through with a dated NOTE: when the gateway grows Parse, this lights up with no code change. Until then Nous-sub users get the warning path.
- **Maintainer caveat #2**: the NEEDS-OCR warning recommends **local OCR via skills first** ("search your skills — ocr-and-documents / marker-pdf") whenever hosted is unavailable or failed; after a failed hosted attempt the guidance explicitly leads with "Prefer LOCAL OCR".

## E2E (real scanned PDF through extract_document_text, temp HERMES_HOME)
AUTO + gateway-500 → typed warning, page named, local-skill guidance ✅ · hosted_ocr:false → no attempt, teaches enable + local ✅ · direct key + hosted failure → failure disclosed, "Prefer LOCAL OCR" leads ✅ · fake-mod unit tests: hosted success returns OCR text (ocr="hosted" call verified), failure/disabled/warning shapes, pin lockstep. 63 passed.