### PR TITLE
fix(desktop): scope every session mutation to its owning profile

### DIFF
--- a/apps/desktop/src/api/sessions.test.ts
+++ b/apps/desktop/src/api/sessions.test.ts
@@ -10,13 +10,146 @@ vi.mock('./client', () => ({
 }))
 
 const client = await import('./client')
-const { listSidebarSessions } = await import('./sessions')
+
+const { deleteSession, setSessionArchived, setSessionPinnedRemote, setSessionUnreadRemote, listSidebarSessions } =
+  await import('./sessions')
 
 const hermesApi = vi.mocked(client.hermesApi)
 
 beforeEach(() => {
   vi.clearAllMocks()
   vi.mocked(client.getApiRequestConnection).mockReturnValue('prometheus')
+})
+
+describe('deleteSession profile scoping', () => {
+  it('scopes the DELETE to the owning profile in the URL (object owner)', async () => {
+    // Regression: the sidebar "All Profiles" delete sent the profile only via
+    // request.profile, not in the URL. On a remote gateway with no remoteProfile
+    // alias the main-process path rewrite left the URL unscoped, so the backend
+    // opened its own default state.db, missed the row, and returned
+    // {ok:true, already_absent:true} — the row vanished optimistically but was
+    // never deleted and came back on refresh. The URL must carry ?profile=.
+    hermesApi.mockResolvedValue({ ok: true } as never)
+    // Mirrors the real capabilityScoped for an object owner (remote-stamped row).
+    vi.mocked(client.capabilityScoped).mockReturnValue({ profile: 'tommy', connectionId: 'hermes-pi' })
+
+    await deleteSession('sess-1', { connectionId: 'hermes-pi', profile: 'tommy' })
+
+    expect(hermesApi.mock.calls[0][0]).toMatchObject({
+      method: 'DELETE',
+      path: '/api/sessions/sess-1?profile=tommy',
+      connectionId: 'hermes-pi',
+      profile: 'tommy'
+    })
+  })
+
+  it('scopes the DELETE to the owning profile in the URL (bare string owner)', async () => {
+    hermesApi.mockResolvedValue({ ok: true } as never)
+    // Bare-string owner: capabilityScoped resolves it to a profile scope.
+    vi.mocked(client.capabilityScoped).mockReturnValue({ profile: 'tommy' })
+
+    await deleteSession('sess-2', 'tommy')
+
+    expect(hermesApi.mock.calls[0][0]).toMatchObject({
+      method: 'DELETE',
+      path: '/api/sessions/sess-2?profile=tommy'
+    })
+  })
+
+  it('omits the profile query when no owner is known', async () => {
+    hermesApi.mockResolvedValue({ ok: true } as never)
+
+    await deleteSession('sess-3')
+
+    expect(hermesApi.mock.calls[0][0]).toMatchObject({
+      method: 'DELETE',
+      path: '/api/sessions/sess-3'
+    })
+    expect((hermesApi.mock.calls[0][0] as { path: string }).path).not.toContain('profile=')
+  })
+
+  it('keeps an explicit local pin routed to the local pool', async () => {
+    hermesApi.mockResolvedValue({ ok: true } as never)
+    // capabilityScoped drops a 'local' connection id by design; sessionScoped
+    // must re-add it so the request stays pinned to this device.
+    vi.mocked(client.capabilityScoped).mockReturnValue({ profile: 'tommy' })
+
+    await deleteSession('sess-4', { connectionId: 'local', profile: 'tommy' })
+
+    expect(hermesApi.mock.calls[0][0]).toMatchObject({
+      method: 'DELETE',
+      path: '/api/sessions/sess-4?profile=tommy',
+      connectionId: 'local',
+      profile: 'tommy'
+    })
+  })
+})
+
+describe('setSessionArchived profile scoping', () => {
+  it('carries the owning profile in the PATCH body', async () => {
+    // Same class as the unscoped DELETE: the PATCH handler reads its target DB
+    // from body.profile, so archiving a foreign-profile session must send it in
+    // the body, not only as request.profile (Electron routing), or on a remote
+    // gateway the archive lands on the wrong state.db and silently no-ops.
+    hermesApi.mockResolvedValue({ ok: true } as never)
+
+    await setSessionArchived('sess-a', true, 'tommy')
+
+    expect(hermesApi.mock.calls[0][0]).toMatchObject({
+      method: 'PATCH',
+      path: '/api/sessions/sess-a',
+      profile: 'tommy',
+      body: { archived: true, profile: 'tommy' }
+    })
+  })
+
+  it('omits the profile from the body when none is given', async () => {
+    hermesApi.mockResolvedValue({ ok: true } as never)
+
+    await setSessionArchived('sess-b', false)
+
+    const req = hermesApi.mock.calls[0][0] as { body: Record<string, unknown> }
+    expect(req).toMatchObject({ method: 'PATCH', body: { archived: false } })
+    expect(req.body).not.toHaveProperty('profile')
+  })
+})
+
+describe('setSessionPinnedRemote / setSessionUnreadRemote profile scoping', () => {
+  it('carries the owning profile in the pin PATCH body', async () => {
+    hermesApi.mockResolvedValue({ ok: true } as never)
+
+    await setSessionPinnedRemote('sess-p', true, 'tommy')
+
+    expect(hermesApi.mock.calls[0][0]).toMatchObject({
+      method: 'PATCH',
+      path: '/api/sessions/sess-p',
+      profile: 'tommy',
+      body: { pinned: true, profile: 'tommy' }
+    })
+  })
+
+  it('carries the owning profile in the unread PATCH body', async () => {
+    hermesApi.mockResolvedValue({ ok: true } as never)
+
+    await setSessionUnreadRemote('sess-u', true, 'tommy')
+
+    expect(hermesApi.mock.calls[0][0]).toMatchObject({
+      method: 'PATCH',
+      path: '/api/sessions/sess-u',
+      profile: 'tommy',
+      body: { unread: true, profile: 'tommy' }
+    })
+  })
+
+  it('omits the profile from the body when none is given', async () => {
+    hermesApi.mockResolvedValue({ ok: true } as never)
+
+    await setSessionPinnedRemote('sess-p2', false)
+
+    const req = hermesApi.mock.calls[0][0] as { body: Record<string, unknown> }
+    expect(req).toMatchObject({ method: 'PATCH', body: { pinned: false } })
+    expect(req.body).not.toHaveProperty('profile')
+  })
 })
 
 describe('listSidebarSessions remote ownership', () => {

--- a/apps/desktop/src/api/sessions.ts
+++ b/apps/desktop/src/api/sessions.ts
@@ -298,11 +298,17 @@ export async function listSidebarSessions(req: SidebarSessionsRequest): Promise<
 // Mutations take the owning `profile` so Electron can route them to the correct
 // remote backend or local profile scope. Omit for the current/default profile.
 export function setSessionArchived(id: string, archived: boolean, profile?: string | null): Promise<{ ok: boolean }> {
+  // Carry the owning profile IN THE PATCH BODY, mirroring renameSession — the
+  // backend reads its target DB from body.profile (_open_session_db_for_profile).
+  // Passing it only as request.profile (Electron routing) is not enough on a
+  // remote gateway with no remoteProfile alias: the archive lands on the wrong
+  // (default) state.db, no-ops on a missing row, and the archived/unarchived
+  // state silently fails to stick — the same class as the unscoped DELETE.
   return hermesApi<{ ok: boolean }>({
     ...(profile ? { profile } : {}),
     path: `/api/sessions/${encodeURIComponent(id)}`,
     method: 'PATCH',
-    body: { archived }
+    body: { archived, ...(profile ? { profile } : {}) }
   })
 }
 
@@ -311,11 +317,14 @@ export function setSessionArchived(id: string, archived: boolean, profile?: stri
 // pinned chat. Best-effort: the sidebar stays localStorage-driven for its own
 // display; this only feeds the backend policy.
 export function setSessionPinnedRemote(id: string, pinned: boolean, profile?: string | null): Promise<{ ok: boolean }> {
+  // Owning profile in the PATCH body (see setSessionArchived / renameSession):
+  // the handler reads its target DB from body.profile, so a remote/foreign
+  // profile's pin must travel in the body or it no-ops on the wrong state.db.
   return hermesApi<{ ok: boolean }>({
     ...(profile ? { profile } : {}),
     path: `/api/sessions/${encodeURIComponent(id)}`,
     method: 'PATCH',
-    body: { pinned }
+    body: { pinned, ...(profile ? { profile } : {}) }
   })
 }
 
@@ -324,11 +333,15 @@ export function setSessionPinnedRemote(id: string, pinned: boolean, profile?: st
 // routing as the other session mutations: a remote session's row lives only
 // on its remote host, so the owning profile must travel with the request.
 export function setSessionUnreadRemote(id: string, unread: boolean, profile?: string | null): Promise<{ ok: boolean }> {
+  // Owning profile in the PATCH body (see setSessionArchived / renameSession):
+  // the handler reads its target DB from body.profile, so a remote/foreign
+  // profile's unread toggle must travel in the body or it no-ops on the wrong
+  // state.db.
   return hermesApi<{ ok: boolean }>({
     ...(profile ? { profile } : {}),
     path: `/api/sessions/${encodeURIComponent(id)}`,
     method: 'PATCH',
-    body: { unread }
+    body: { unread, ...(profile ? { profile } : {}) }
   })
 }
 
@@ -526,9 +539,23 @@ export async function getAllSessionMessages(
 }
 
 export function deleteSession(id: string, profile?: ProfileScope): Promise<{ ok: boolean }> {
+  // Scope the DELETE to the owning profile IN THE URL, mirroring getSession /
+  // getSessionMessages. Passing the profile only via request.profile (which the
+  // Electron main process consumes for backend routing) is NOT enough: on a
+  // remote gateway whose connection has no remoteProfile alias, the main-process
+  // path rewrite leaves the URL unscoped, so the backend opens its OWN (default)
+  // state.db, fails to find another profile's session, and returns
+  // {ok:true, already_absent:true}. The row then vanishes optimistically but was
+  // never deleted and reappears on the next sidebar refresh — the "All Profiles
+  // delete doesn't stick" report. The endpoint already honours ?profile=
+  // (get/rename/messages all send it); DELETE was the one mutation that dropped
+  // it after the api/ split. request.profile stays on for per-profile remote
+  // override + global-remote routing (both re-read/re-append the param).
+  const suffix = sessionScopeQuery(profile)
+
   return hermesApi<{ ok: boolean }>({
     ...sessionScoped(profile),
-    path: `/api/sessions/${encodeURIComponent(id)}`,
+    path: `/api/sessions/${encodeURIComponent(id)}${suffix}`,
     method: 'DELETE'
   })
 }


### PR DESCRIPTION
## What does this PR do?

Fixes a class of desktop bug where **session mutations don't stick** — deleting, archiving, pinning, or marking-unread a session from the sidebar appears to succeed (the row disappears optimistically) but silently no-ops, and the row reappears on the next list refresh.

The problem only shows up when the mutated session is **not** owned by the profile currently serving the desktop's backend — most visibly in the **"All Profiles"** view, and on a **remote-primary** desktop (a registered remote gateway is the primary and every profile is served from it).

Root cause: the four mutation helpers in `apps/desktop/src/api/sessions.ts` passed the owning profile **only** as `request.profile`. That field drives Electron's backend **routing**, but it is not the scope the backend reads to pick its target DB — the backend selects the DB from `?profile=` (DELETE) or `body.profile` (PATCH). Reads (`getSession`, `getSessionMessages`) and `renameSession` already scope correctly; the four mutations did not:

- `deleteSession` — no `?profile=` in the URL
- `setSessionArchived` — no `profile` in the PATCH body
- `setSessionPinnedRemote` — no `profile` in the PATCH body
- `setSessionUnreadRemote` — no `profile` in the PATCH body

On a remote gateway whose connection has no `remoteProfile` alias, the main process leaves such requests unscoped, so the backend opens its own (default) `state.db`, finds no matching row, and returns `{ok:true, already_absent:true}` (DELETE) or a silent no-op (PATCH) — a fake success the UI treats as done. `deleteSession` specifically lost its `?profile=` scope in the `src/hermes.ts` → `src/api/` module split (it was present via PR #44138 / the pre-split path).

The fix scopes all four mutations the same way the already-working endpoints do — the minimal, consistent approach that requires no backend or routing changes and leaves single-profile / selected-profile users byte-identical.

## Related Issue

Fixes #78836

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/api/sessions.ts`
  - `deleteSession` — append `sessionScopeQuery(profile)` to the URL so the DELETE carries `?profile=<owner>` (mirrors `getSession` / `getSessionMessages`).
  - `setSessionArchived` — include `profile` in the PATCH body (mirrors `renameSession`).
  - `setSessionPinnedRemote` — include `profile` in the PATCH body.
  - `setSessionUnreadRemote` — include `profile` in the PATCH body.
  - `request.profile` is left in place on every mutation so per-profile remote-override and global-remote routing still resolve the correct backend.
- `apps/desktop/src/api/sessions.test.ts`
  - New coverage: `deleteSession` scopes `?profile=` in the URL for object and bare-string owners and omits it when no owner is known; `setSessionArchived` / `setSessionPinnedRemote` / `setSessionUnreadRemote` carry `body.profile` when owned and omit it otherwise.

Audited but unchanged (already correctly scoped or N/A): `listSessions`, `listAllProfileSessions`, `listSidebarSessions`, `getSession`, `getSessionMessages` (+ `getLatest`/`getOlder`/`getAll`), `renameSession`, `searchSessions`. The desktop frontend does not call the backend `bulk-delete` / `prune` / `empty` session endpoints, so those need no client change here.

## How to Test

Requires a multi-profile setup where the mutated session is owned by a **non-serving** profile — e.g. a remote-primary desktop (a registered remote gateway as primary), or the "All Profiles" view with sessions across profiles.

1. In the desktop sidebar, switch to the **"All Profiles on this Gateway"** view.
2. Delete a session that belongs to a non-primary profile (e.g. a `tommy` session while the serving/primary profile is `default`).
3. Switch profiles back and forth. **Before:** the row reappears (never deleted). **After:** the row stays gone. Repeat for archive, pin, and mark-unread — each now sticks.

Proof the fix reaches the right backend (remote-primary setup, gateway HTTPS access log):

```
# Before — no profile scope, backend hits the wrong (default) state.db:
"DELETE /api/sessions/<id> HTTP/1.1" 200 33      # {"ok":true,"already_absent":true}

# After — scoped to the owning profile, row actually removed:
"DELETE /api/sessions/<id>?profile=<owner> HTTP/1.1" 200 ...
```

Server-side confirmation: before the fix the "deleted" row was still present in the owning profile's `state.db`; after the fix it is gone.

Automated (from `apps/desktop`):

```
npx vitest run src/api/sessions.test.ts     # 10 passed
npx eslint src/api/sessions.ts src/api/sessions.test.ts   # clean
npx tsc -p . --noEmit                        # no new errors
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A: desktop-only TypeScript change with no Python surface. Verified with the desktop suite instead: `vitest run src/api/sessions.test.ts` (10 passed), `eslint` clean, `tsc -p . --noEmit` clean.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu (X11), Electron 40 desktop build against a remote-primary Hermes gateway

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (internal API-helper scoping only; no doc-facing behavior change)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A (no architecture change)
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (platform-agnostic URL/body scoping; no OS-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A (no tool behavior change)

## Screenshots / Logs

Gateway HTTPS reverse-proxy access log during the repro (remote-primary desktop):

```
Before (row silently survives):
[28/Aug/2026:13:01:55 +0000] "DELETE /api/sessions/20260828_082655_c8709d HTTP/1.1" 200 33 "Hermes/… Electron/40 …"

After (scoped, row deleted):
[.../…] "DELETE /api/sessions/20260828_082655_c8709d?profile=tommy HTTP/1.1" 200 …
```

The 33-byte body before the fix is `{"ok":true,"already_absent":true}` — the backend never found the row because it opened the wrong profile's `state.db`.
