### PR TITLE
feat(commands): converge Discord native and relay projection

### DIFF
--- a/gateway/discord_command_projection.py
+++ b/gateway/discord_command_projection.py
@@ -1,0 +1,27 @@
+"""Compatibility import for the shared Discord command projection package."""
+
+from gateway.discord_projection import (
+    DiscordCommandProjection,
+    DiscordProjectedCommand,
+    DiscordProjectionError,
+    DiscordProjectionMismatch,
+    build_relay_discord_manifest,
+    build_relay_discord_projection,
+    canonicalize_discord_command,
+    canonicalize_discord_option,
+    project_discord_commands,
+    verify_discord_projection_readback,
+)
+
+__all__ = [
+    "DiscordCommandProjection",
+    "DiscordProjectedCommand",
+    "DiscordProjectionError",
+    "DiscordProjectionMismatch",
+    "build_relay_discord_manifest",
+    "build_relay_discord_projection",
+    "canonicalize_discord_command",
+    "canonicalize_discord_option",
+    "project_discord_commands",
+    "verify_discord_projection_readback",
+]

--- a/gateway/discord_projection/__init__.py
+++ b/gateway/discord_projection/__init__.py
@@ -1,0 +1,28 @@
+"""Shared Discord command projection API."""
+
+from .core import (
+    DiscordProjectionError,
+    DiscordProjectionMismatch,
+    canonicalize_discord_command,
+    canonicalize_discord_option,
+)
+from .model import (
+    DiscordCommandProjection,
+    DiscordProjectedCommand,
+    project_discord_commands,
+    verify_discord_projection_readback,
+)
+from .relay import build_relay_discord_manifest, build_relay_discord_projection
+
+__all__ = [
+    "DiscordCommandProjection",
+    "DiscordProjectedCommand",
+    "DiscordProjectionError",
+    "DiscordProjectionMismatch",
+    "build_relay_discord_manifest",
+    "build_relay_discord_projection",
+    "canonicalize_discord_command",
+    "canonicalize_discord_option",
+    "project_discord_commands",
+    "verify_discord_projection_readback",
+]

--- a/gateway/discord_projection/core.py
+++ b/gateway/discord_projection/core.py
@@ -1,0 +1,110 @@
+"""Canonical Discord wire normalization and typed mismatch errors."""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+DISCORD_COMMAND_NAME_RE = re.compile(r"^[a-z0-9_-]{1,32}$")
+STRING_OPTION = 3
+CommandKey = tuple[int, str]
+
+
+class DiscordProjectionError(ValueError):
+    """Base failure for invalid or contradictory Discord projections."""
+
+
+class DiscordProjectionMismatch(DiscordProjectionError):
+    """Remote read-back did not settle to the desired projection."""
+
+    def __init__(
+        self,
+        *,
+        missing: Sequence[CommandKey] = (),
+        unexpected: Sequence[CommandKey] = (),
+        changed: Sequence[CommandKey] = (),
+    ) -> None:
+        self.missing = tuple(missing)
+        self.unexpected = tuple(unexpected)
+        self.changed = tuple(changed)
+        parts: list[str] = []
+        if self.missing:
+            parts.append(f"missing={list(self.missing)!r}")
+        if self.unexpected:
+            parts.append(f"unexpected={list(self.unexpected)!r}")
+        if self.changed:
+            parts.append(f"changed={list(self.changed)!r}")
+        detail = ", ".join(parts) if parts else "unknown mismatch"
+        super().__init__(f"Discord command read-back mismatch: {detail}")
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+
+def deep_copy_json(value: Any) -> Any:
+    return json.loads(canonical_json(value))
+
+
+def canonicalize_discord_option(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Reduce one Discord option to semantic fields Hermes manages."""
+    return {
+        "type": int(payload.get("type", 0) or 0),
+        "name": str(payload.get("name", "") or ""),
+        "description": str(payload.get("description", "") or ""),
+        "required": bool(payload.get("required", False)),
+        "autocomplete": bool(payload.get("autocomplete", False)),
+        "choices": [
+            {
+                "name": str(choice.get("name", "") or ""),
+                "value": choice.get("value"),
+            }
+            for choice in payload.get("choices", []) or []
+            if isinstance(choice, Mapping)
+        ],
+        "channel_types": list(payload.get("channel_types", []) or []),
+        "min_value": payload.get("min_value"),
+        "max_value": payload.get("max_value"),
+        "min_length": payload.get("min_length"),
+        "max_length": payload.get("max_length"),
+        "options": [
+            canonicalize_discord_option(item)
+            for item in payload.get("options", []) or []
+            if isinstance(item, Mapping)
+        ],
+    }
+
+
+def canonicalize_discord_command(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Reduce one command payload to semantic fields Hermes manages."""
+    contexts = payload.get("contexts")
+    integration_types = payload.get("integration_types")
+    permissions = payload.get("default_member_permissions")
+    return {
+        "type": int(payload.get("type", 1) or 1),
+        "name": str(payload.get("name", "") or ""),
+        "description": str(payload.get("description", "") or ""),
+        "default_member_permissions": (
+            None if permissions is None else str(permissions)
+        ),
+        "dm_permission": bool(payload.get("dm_permission", True)),
+        "nsfw": bool(payload.get("nsfw", False)),
+        "contexts": sorted(int(value) for value in contexts) if contexts else None,
+        "integration_types": (
+            sorted(int(value) for value in integration_types)
+            if integration_types
+            else None
+        ),
+        "options": [
+            canonicalize_discord_option(item)
+            for item in payload.get("options", []) or []
+            if isinstance(item, Mapping)
+        ],
+    }

--- a/gateway/discord_projection/identity.py
+++ b/gateway/discord_projection/identity.py
@@ -1,0 +1,44 @@
+"""Canonical slash-command identity resolution for Discord projections."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+
+from hermes_cli.commands import resolve_command
+
+
+@lru_cache(maxsize=1)
+def versioned_catalog_resolver():
+    """Return PR-1's catalog resolver when that prerequisite is present."""
+    try:
+        from hermes_cli.command_catalog import (
+            build_command_catalog,
+            resolve_catalog_command,
+        )
+    except ModuleNotFoundError as exc:
+        if exc.name != "hermes_cli.command_catalog":
+            raise
+        return None
+    catalog = build_command_catalog()
+    return catalog, resolve_catalog_command
+
+
+def semantic_identity(name: str, command_type: int) -> tuple[str, str]:
+    """Resolve an entered Discord name to stable identity and canonical name."""
+    versioned = versioned_catalog_resolver()
+    if versioned is not None:
+        catalog, resolver = versioned
+        spec = resolver(catalog, name)
+        if spec is not None:
+            return spec.command_id, spec.name
+
+    command = resolve_command(name)
+    if command is None:
+        return f"discord.{command_type}.{name}", name
+    value = getattr(command, "command_id", None)
+    command_id = (
+        value.strip()
+        if isinstance(value, str) and value.strip()
+        else command.name
+    )
+    return command_id, command.name

--- a/gateway/discord_projection/model.py
+++ b/gateway/discord_projection/model.py
@@ -1,0 +1,144 @@
+"""Immutable Discord command projection, fingerprint, and read-back proof."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from .core import (
+    DISCORD_COMMAND_NAME_RE,
+    CommandKey,
+    DiscordProjectionError,
+    DiscordProjectionMismatch,
+    canonical_json,
+    canonicalize_discord_command,
+    deep_copy_json,
+)
+from .identity import semantic_identity
+
+
+@dataclass(frozen=True, slots=True)
+class DiscordProjectedCommand:
+    """One immutable command projection with wire and semantic identities."""
+
+    command_id: str
+    canonical_name: str
+    entered_name: str
+    command_type: int
+    wire_json: str
+    canonical_json: str
+
+    @property
+    def key(self) -> CommandKey:
+        return self.command_type, self.entered_name.casefold()
+
+    def wire_payload(self) -> dict[str, Any]:
+        return json.loads(self.wire_json)
+
+    def canonical_payload(self) -> dict[str, Any]:
+        return json.loads(self.canonical_json)
+
+
+@dataclass(frozen=True, slots=True)
+class DiscordCommandProjection:
+    """Immutable ordered projection plus deterministic semantic revision."""
+
+    entries: tuple[DiscordProjectedCommand, ...]
+    revision: str
+
+    def wire_commands(self) -> list[dict[str, Any]]:
+        return [entry.wire_payload() for entry in self.entries]
+
+    def canonical_by_key(self) -> dict[CommandKey, dict[str, Any]]:
+        return {entry.key: entry.canonical_payload() for entry in self.entries}
+
+    def semantic_by_key(self) -> dict[CommandKey, tuple[str, str]]:
+        return {
+            entry.key: (entry.command_id, entry.canonical_name)
+            for entry in self.entries
+        }
+
+
+def project_discord_commands(
+    payloads: Iterable[Mapping[str, Any]],
+) -> DiscordCommandProjection:
+    """Build a fail-closed, deterministic projection from Discord wire rows."""
+    entries: list[DiscordProjectedCommand] = []
+    seen_keys: set[CommandKey] = set()
+
+    for raw in payloads:
+        if not isinstance(raw, Mapping):
+            raise DiscordProjectionError(
+                f"Discord command payload must be a mapping, got {type(raw).__name__}"
+            )
+        wire = deep_copy_json(dict(raw))
+        canonical = canonicalize_discord_command(wire)
+        name = canonical["name"]
+        command_type = canonical["type"]
+        if not DISCORD_COMMAND_NAME_RE.fullmatch(name):
+            raise DiscordProjectionError(f"invalid Discord command name: {name!r}")
+        key = command_type, name.casefold()
+        if key in seen_keys:
+            raise DiscordProjectionError(
+                f"duplicate Discord command projection: type={command_type} name={name!r}"
+            )
+        seen_keys.add(key)
+        command_id, canonical_name = semantic_identity(name, command_type)
+        entries.append(
+            DiscordProjectedCommand(
+                command_id=command_id,
+                canonical_name=canonical_name,
+                entered_name=name,
+                command_type=command_type,
+                wire_json=canonical_json(wire),
+                canonical_json=canonical_json(canonical),
+            )
+        )
+
+    revision_rows = [
+        {
+            "command_id": entry.command_id,
+            "canonical_name": entry.canonical_name,
+            "entered_name": entry.entered_name,
+            "type": entry.command_type,
+            "payload": entry.canonical_payload(),
+        }
+        for entry in sorted(entries, key=lambda item: item.key)
+    ]
+    revision = hashlib.sha256(
+        canonical_json(revision_rows).encode("utf-8")
+    ).hexdigest()
+    return DiscordCommandProjection(entries=tuple(entries), revision=revision)
+
+
+def verify_discord_projection_readback(
+    expected: DiscordCommandProjection,
+    remote_payloads: Iterable[Mapping[str, Any]],
+) -> DiscordCommandProjection:
+    """Verify exact remote settlement and return the observed projection."""
+    observed = project_discord_commands(remote_payloads)
+    desired_by_key = expected.canonical_by_key()
+    observed_by_key = observed.canonical_by_key()
+
+    desired_keys = set(desired_by_key)
+    observed_keys = set(observed_by_key)
+    missing = sorted(desired_keys - observed_keys)
+    unexpected = sorted(observed_keys - desired_keys)
+    changed = sorted(
+        key
+        for key in desired_keys & observed_keys
+        if desired_by_key[key] != observed_by_key[key]
+        or expected.semantic_by_key()[key] != observed.semantic_by_key()[key]
+    )
+    if missing or unexpected or changed:
+        raise DiscordProjectionMismatch(
+            missing=missing,
+            unexpected=unexpected,
+            changed=changed,
+        )
+    if observed.revision != expected.revision:
+        raise DiscordProjectionMismatch(changed=sorted(desired_keys))
+    return observed

--- a/gateway/discord_projection/relay.py
+++ b/gateway/discord_projection/relay.py
@@ -1,0 +1,148 @@
+"""Current-main Discord relay compatibility projection."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+from .core import STRING_OPTION
+from .model import DiscordCommandProjection, project_discord_commands
+
+
+def _opt(
+    name: str,
+    description: str,
+    *,
+    choices: Sequence[str] | None = None,
+) -> dict[str, Any]:
+    row: dict[str, Any] = {
+        "type": STRING_OPTION,
+        "name": name,
+        "description": description,
+        "required": False,
+    }
+    if choices:
+        row["choices"] = [
+            {"name": choice, "value": choice}
+            for choice in choices
+        ]
+    return row
+
+
+def _relay_compatibility_payloads() -> list[dict[str, Any]]:
+    """Return the accepted relay/native compatibility surface on current main."""
+    return [
+        {"name": "new", "description": "Start a new conversation"},
+        {"name": "reset", "description": "Reset your Hermes session"},
+        {
+            "name": "model",
+            "description": "Show or change the model",
+            "options": [_opt("name", "Model name. Leave empty to see current.")],
+        },
+        {
+            "name": "reasoning",
+            "description": "Show/change reasoning effort, or toggle showing it",
+            "options": [
+                _opt(
+                    "effort",
+                    "Level, reset, or show/hide. Leave empty to see current.",
+                    choices=[
+                        "none",
+                        "minimal",
+                        "low",
+                        "medium",
+                        "high",
+                        "xhigh",
+                        "max",
+                        "ultra",
+                        "reset",
+                        "show",
+                        "hide",
+                    ],
+                )
+            ],
+        },
+        {
+            "name": "personality",
+            "description": "Set a personality",
+            "options": [_opt("name", "Personality name. Leave empty to list.")],
+        },
+        {"name": "retry", "description": "Retry your last message"},
+        {"name": "undo", "description": "Remove the last exchange"},
+        {"name": "status", "description": "Show Hermes session status"},
+        {"name": "sethome", "description": "Set this chat as the home channel"},
+        {"name": "stop", "description": "Stop the running Hermes agent"},
+        {
+            "name": "steer",
+            "description": "Inject a message after the next tool call (no interrupt)",
+            "options": [_opt("text", "What to tell the agent")],
+        },
+        {"name": "compress", "description": "Compress conversation context"},
+        {
+            "name": "title",
+            "description": "Set or show the session title",
+            "options": [_opt("text", "New title. Leave empty to show.")],
+        },
+        {
+            "name": "resume",
+            "description": "Resume a previously-named session",
+            "options": [_opt("name", "Session title or id")],
+        },
+        {"name": "usage", "description": "Show token usage for this session"},
+        {"name": "help", "description": "Show available commands"},
+        {"name": "insights", "description": "Show usage insights and analytics"},
+        {"name": "reload-mcp", "description": "Reload MCP servers from config"},
+        {
+            "name": "reload-skills",
+            "description": "Re-scan skills for new or removed entries",
+        },
+        {"name": "voice", "description": "Toggle voice reply mode"},
+        {"name": "update", "description": "Update Hermes Agent to the latest version"},
+        {"name": "restart", "description": "Gracefully restart the Hermes gateway"},
+        {
+            "name": "approve",
+            "description": "Approve a pending dangerous command",
+            "options": [
+                _opt(
+                    "scope",
+                    "Approval scope",
+                    choices=["once", "session", "always", "all"],
+                )
+            ],
+        },
+        {
+            "name": "deny",
+            "description": "Deny a pending dangerous command",
+            "options": [_opt("reason", "Why (relayed to the agent)")],
+        },
+        {
+            "name": "thread",
+            "description": "Create a new thread and start a Hermes session in it",
+            "options": [_opt("name", "Thread name")],
+        },
+        {
+            "name": "queue",
+            "description": "Queue a prompt for the next turn (doesn't interrupt)",
+            "options": [_opt("text", "The prompt to queue")],
+        },
+        {
+            "name": "bg",
+            "description": "Run a prompt in a separate background session",
+            "options": [_opt("text", "The prompt to run")],
+        },
+        {
+            "name": "btw",
+            "description": "Ask a side question about the current conversation",
+            "options": [_opt("text", "The question to answer")],
+        },
+    ]
+
+
+def build_relay_discord_projection() -> DiscordCommandProjection:
+    """Build the relay lane's immutable Discord command projection."""
+    return project_discord_commands(_relay_compatibility_payloads())
+
+
+def build_relay_discord_manifest() -> list[dict[str, Any]]:
+    """Compatibility export used by the relay hello frame."""
+    return build_relay_discord_projection().wire_commands()

--- a/gateway/relay/command_manifest.py
+++ b/gateway/relay/command_manifest.py
@@ -1,150 +1,17 @@
-"""Gateway-declared slash-command manifest for the relay lane (Phase 4).
+"""Relay-lane compatibility export for the shared Discord projection.
 
-The native Discord adapter registers its slash commands directly on the
-Discord command tree (`_register_slash_commands`,
-plugins/platforms/discord/adapter.py) — it holds the bot token. Over the
-relay the CONNECTOR holds the token, so the gateway DECLARES the same
-command set on its `hello` frame (`command_manifest`) and the connector
-reconciles Discord's global application-command registration against it
-(gateway-gateway `DiscordCommandRegistrar`: GET → diff → bulk PUT,
-idempotent, best-effort).
-
-This module is that declaration: the single source of truth for what the
-relay lane advertises. It MIRRORS the native tree — same names, same
-descriptions — so a user moving between a native-Discord deployment and a
-hosted/relay one sees the same command palette. Interactions come back over
-the passthrough plane and are normalized by
-RelayAdapter._discord_interaction_to_event into the same "/name args"
-COMMAND events the dispatcher already routes, so declaring a command here
-requires NO new handler — the dispatcher's existing slash surface is the
-handler.
-
-Wire shape (per entry): {name, description, options?} where options rows are
-Discord option objects passed through verbatim. Names must satisfy
-Discord's CHAT_INPUT rules ([a-z0-9_-]{1,32}); the connector drops invalid
-entries (fail-open per entry, never the whole manifest).
+The source of truth moved to :mod:`gateway.discord_command_projection` so the
+native adapter's sync proof and the relay hello manifest use one canonical
+normalization, fingerprint, alias identity, and read-back contract.
 """
 
 from __future__ import annotations
 
 from typing import Any, Dict, List
 
-# Discord option type 3 = STRING.
-_STR = 3
-
-
-def _opt(name: str, description: str, *, choices: List[str] | None = None) -> Dict[str, Any]:
-    row: Dict[str, Any] = {
-        "type": _STR,
-        "name": name,
-        "description": description,
-        "required": False,
-    }
-    if choices:
-        row["choices"] = [{"name": c, "value": c} for c in choices]
-    return row
+from gateway.discord_command_projection import build_relay_discord_manifest
 
 
 def build_relay_command_manifest() -> List[Dict[str, Any]]:
-    """The relay lane's Discord slash-command manifest (native-tree mirror)."""
-    return [
-        {"name": "new", "description": "Start a new conversation"},
-        {"name": "reset", "description": "Reset your Hermes session"},
-        {
-            "name": "model",
-            "description": "Show or change the model",
-            "options": [_opt("name", "Model name. Leave empty to see current.")],
-        },
-        {
-            "name": "reasoning",
-            "description": "Show/change reasoning effort, or toggle showing it",
-            "options": [
-                _opt(
-                    "effort",
-                    "Level, reset, or show/hide. Leave empty to see current.",
-                    choices=[
-                        "none",
-                        "minimal",
-                        "low",
-                        "medium",
-                        "high",
-                        "xhigh",
-                        "max",
-                        "ultra",
-                        "reset",
-                        "show",
-                        "hide",
-                    ],
-                )
-            ],
-        },
-        {
-            "name": "personality",
-            "description": "Set a personality",
-            "options": [_opt("name", "Personality name. Leave empty to list.")],
-        },
-        {"name": "retry", "description": "Retry your last message"},
-        {"name": "undo", "description": "Remove the last exchange"},
-        {"name": "status", "description": "Show Hermes session status"},
-        {"name": "sethome", "description": "Set this chat as the home channel"},
-        {"name": "stop", "description": "Stop the running Hermes agent"},
-        {
-            "name": "steer",
-            "description": "Inject a message after the next tool call (no interrupt)",
-            "options": [_opt("text", "What to tell the agent")],
-        },
-        {"name": "compress", "description": "Compress conversation context"},
-        {
-            "name": "title",
-            "description": "Set or show the session title",
-            "options": [_opt("text", "New title. Leave empty to show.")],
-        },
-        {
-            "name": "resume",
-            "description": "Resume a previously-named session",
-            "options": [_opt("name", "Session title or id")],
-        },
-        {"name": "usage", "description": "Show token usage for this session"},
-        {"name": "help", "description": "Show available commands"},
-        {"name": "insights", "description": "Show usage insights and analytics"},
-        {"name": "reload-mcp", "description": "Reload MCP servers from config"},
-        {
-            "name": "reload-skills",
-            "description": "Re-scan skills for new or removed entries",
-        },
-        {"name": "voice", "description": "Toggle voice reply mode"},
-        {"name": "update", "description": "Update Hermes Agent to the latest version"},
-        {"name": "restart", "description": "Gracefully restart the Hermes gateway"},
-        {
-            "name": "approve",
-            "description": "Approve a pending dangerous command",
-            "options": [
-                _opt("scope", "Approval scope", choices=["once", "session", "always", "all"])
-            ],
-        },
-        {
-            "name": "deny",
-            "description": "Deny a pending dangerous command",
-            "options": [_opt("reason", "Why (relayed to the agent)")],
-        },
-        {
-            "name": "thread",
-            "description": "Create a new thread and start a Hermes session in it",
-            "options": [_opt("name", "Thread name")],
-        },
-        {
-            "name": "queue",
-            "description": "Queue a prompt for the next turn (doesn't interrupt)",
-            "options": [_opt("text", "The prompt to queue")],
-        },
-        {
-            "name": "bg",
-            "description": "Run a prompt in a separate background session",
-            "options": [_opt("text", "The prompt to run")],
-        },
-        {
-            "name": "btw",
-            "description": "Ask a side question about the current conversation",
-            "options": [_opt("text", "The question to answer")],
-        },
-    ]
+    """Return the relay lane's Discord command manifest."""
+    return build_relay_discord_manifest()

--- a/plugins/platforms/discord/__init__.py
+++ b/plugins/platforms/discord/__init__.py
@@ -1,3 +1,3 @@
-from .adapter import register
+from .projected_adapter import register
 
 __all__ = ["register"]

--- a/plugins/platforms/discord/projected_adapter.py
+++ b/plugins/platforms/discord/projected_adapter.py
@@ -1,0 +1,132 @@
+"""Discord adapter entry point with shared projection settlement.
+
+The legacy adapter keeps the accepted interaction callbacks and command-tree
+construction.  This bounded subclass changes only the registration factory and
+the post-sync proof: desired native commands are fingerprinted through the same
+projection contract as relay commands, then Discord is read back and compared
+before sync is reported as settled.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from gateway.discord_command_projection import (
+    DiscordCommandProjection,
+    DiscordProjectionMismatch,
+    project_discord_commands,
+    verify_discord_projection_readback,
+)
+
+from . import adapter as _adapter
+
+
+class ProjectedDiscordAdapter(_adapter.DiscordAdapter):
+    """DiscordAdapter with deterministic projection and exact remote read-back."""
+
+    _READBACK_ATTEMPTS = 3
+    _SAME_FINGERPRINT_SKIP = "same slash-command fingerprint already synced"
+
+    _discord_command_projection_revision: str | None = None
+    _discord_command_projection_verified_revision: str | None = None
+
+    def _desired_command_projection(self) -> DiscordCommandProjection:
+        if not self._client:
+            return project_discord_commands(())
+        tree = self._client.tree
+        return project_discord_commands(
+            command.to_dict(tree)
+            for command in tree.get_commands()
+        )
+
+    def _remote_command_payload(self, command: Any) -> dict[str, Any]:
+        return self._existing_command_to_payload(command)
+
+    def _desired_command_sync_fingerprint(self) -> str:
+        """Persist the shared canonical projection revision as sync identity."""
+        return self._desired_command_projection().revision
+
+    def _command_sync_skip_reason(
+        self, app_id: Any, fingerprint: str
+    ) -> str | None:
+        """Retain rate-limit backoff, but re-read Discord on every startup.
+
+        A local fingerprint proves only what this process intended last time.
+        It cannot prove that Discord still holds that object after an external
+        edit or partial remote mutation.  The normal safe reconciler is cheap
+        when nothing changed, so the same-fingerprint shortcut is converted
+        into an exact remote read-back instead of a completion claim.
+        """
+        reason = super()._command_sync_skip_reason(app_id, fingerprint)
+        if reason == self._SAME_FINGERPRINT_SKIP:
+            return None
+        return reason
+
+    async def _verify_remote_projection(
+        self,
+        desired: DiscordCommandProjection,
+    ) -> DiscordCommandProjection:
+        """Read Discord back with a bounded propagation retry."""
+        if not self._client:
+            return project_discord_commands(())
+
+        last_mismatch = None
+        for attempt in range(self._READBACK_ATTEMPTS):
+            remote_commands = await self._client.tree.fetch_commands()
+            try:
+                return verify_discord_projection_readback(
+                    desired,
+                    (
+                        self._remote_command_payload(command)
+                        for command in remote_commands
+                    ),
+                )
+            except DiscordProjectionMismatch as exc:
+                last_mismatch = exc
+                if attempt + 1 >= self._READBACK_ATTEMPTS:
+                    raise
+                await self._sleep_between_command_sync_mutations()
+
+        if last_mismatch is None:
+            raise RuntimeError("Discord read-back ended without a projection result")
+        raise last_mismatch
+
+    async def _safe_sync_slash_commands(self) -> dict[str, int]:
+        """Run the existing minimal diff, then prove exact remote settlement."""
+        desired = self._desired_command_projection()
+        result = await super()._safe_sync_slash_commands()
+        if not self._client:
+            return result
+
+        observed = await self._verify_remote_projection(desired)
+        self._discord_command_projection_revision = desired.revision
+        self._discord_command_projection_verified_revision = observed.revision
+        return result
+
+
+def _build_projected_adapter(config):
+    return ProjectedDiscordAdapter(config)
+
+
+class _ProjectedRegistrationContext:
+    """Narrow proxy that swaps only Discord's adapter factory."""
+
+    def __init__(self, target: Any) -> None:
+        self._target = target
+
+    def register_platform(self, *args: Any, **kwargs: Any):
+        forwarded = dict(kwargs)
+        if forwarded.get("name") == "discord":
+            forwarded["adapter_factory"] = _build_projected_adapter
+        return self._target.register_platform(*args, **forwarded)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._target, name)
+
+
+def register(ctx) -> None:
+    """Register Discord without copying the adapter's plugin metadata."""
+    _adapter.register(_ProjectedRegistrationContext(ctx))
+
+
+__all__ = ["ProjectedDiscordAdapter", "register"]

--- a/tests/gateway/test_discord_command_projection.py
+++ b/tests/gateway/test_discord_command_projection.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+
+from gateway.discord_command_projection import (
+    DiscordProjectionError,
+    DiscordProjectionMismatch,
+    build_relay_discord_projection,
+    project_discord_commands,
+    verify_discord_projection_readback,
+)
+from gateway.relay.command_manifest import build_relay_command_manifest
+
+
+def test_relay_manifest_is_the_shared_projection_wire_output() -> None:
+    projection = build_relay_discord_projection()
+
+    assert build_relay_command_manifest() == projection.wire_commands()
+    assert [row["name"] for row in projection.wire_commands()] == [
+        "new",
+        "reset",
+        "model",
+        "reasoning",
+        "personality",
+        "retry",
+        "undo",
+        "status",
+        "sethome",
+        "stop",
+        "steer",
+        "compress",
+        "title",
+        "resume",
+        "usage",
+        "help",
+        "insights",
+        "reload-mcp",
+        "reload-skills",
+        "voice",
+        "update",
+        "restart",
+        "approve",
+        "deny",
+        "thread",
+        "queue",
+        "bg",
+        "btw",
+    ]
+
+
+def test_alias_projection_preserves_one_semantic_identity() -> None:
+    projection = build_relay_discord_projection()
+    by_name = {entry.entered_name: entry for entry in projection.entries}
+
+    assert by_name["new"].command_id == by_name["reset"].command_id
+    assert by_name["new"].canonical_name == "new"
+    assert by_name["reset"].canonical_name == "new"
+
+
+def test_projection_revision_is_independent_of_command_order() -> None:
+    rows = build_relay_command_manifest()
+
+    forward = project_discord_commands(rows)
+    reverse = project_discord_commands(reversed(rows))
+
+    assert forward.revision == reverse.revision
+    assert forward.canonical_by_key() == reverse.canonical_by_key()
+
+
+def test_readback_accepts_remote_defaults_and_order_changes() -> None:
+    desired = build_relay_discord_projection()
+    remote = list(reversed(deepcopy(desired.wire_commands())))
+    for row in remote:
+        row["type"] = 1
+        row["dm_permission"] = True
+        row["nsfw"] = False
+        row["default_member_permissions"] = None
+
+    observed = verify_discord_projection_readback(desired, remote)
+
+    assert observed.revision == desired.revision
+
+
+def test_readback_fails_closed_on_changed_remote_shape() -> None:
+    desired = build_relay_discord_projection()
+    remote = deepcopy(desired.wire_commands())
+    remote[0]["description"] = "drifted"
+
+    with pytest.raises(DiscordProjectionMismatch) as exc_info:
+        verify_discord_projection_readback(desired, remote)
+
+    assert exc_info.value.changed == ((1, "new"),)
+
+
+def test_readback_fails_closed_on_missing_and_unexpected_commands() -> None:
+    desired = project_discord_commands(
+        [{"name": "new", "description": "Start a new conversation"}]
+    )
+    remote = [{"name": "foreign", "description": "Not Hermes"}]
+
+    with pytest.raises(DiscordProjectionMismatch) as exc_info:
+        verify_discord_projection_readback(desired, remote)
+
+    assert exc_info.value.missing == ((1, "new"),)
+    assert exc_info.value.unexpected == ((1, "foreign"),)
+
+
+@pytest.mark.parametrize("name", ["UPPER", "has space", "", "x" * 33])
+def test_invalid_discord_names_fail_projection(name: str) -> None:
+    with pytest.raises(DiscordProjectionError, match="invalid Discord command name"):
+        project_discord_commands([{"name": name, "description": "invalid"}])
+
+
+def test_duplicate_wire_identity_fails_projection() -> None:
+    with pytest.raises(DiscordProjectionError, match="duplicate Discord command"):
+        project_discord_commands(
+            [
+                {"name": "status", "description": "one"},
+                {"name": "status", "description": "two"},
+            ]
+        )
+
+
+def test_projection_consumes_versioned_catalog_identity_when_available(
+    monkeypatch,
+) -> None:
+    catalog = object()
+    spec = type("Spec", (), {"command_id": "command.new", "name": "new"})()
+
+    def resolver(actual_catalog, token):
+        assert actual_catalog is catalog
+        return spec if str(token).lstrip("/") in {"new", "reset"} else None
+
+    monkeypatch.setattr(
+        "gateway.discord_projection.identity.versioned_catalog_resolver",
+        lambda: (catalog, resolver),
+    )
+
+    projection = project_discord_commands(
+        [
+            {"name": "new", "description": "Start a new conversation"},
+            {"name": "reset", "description": "Reset your Hermes session"},
+        ]
+    )
+
+    assert {entry.command_id for entry in projection.entries} == {"command.new"}
+    assert {entry.canonical_name for entry in projection.entries} == {"new"}

--- a/tests/plugins/platforms/test_discord_projected_adapter.py
+++ b/tests/plugins/platforms/test_discord_projected_adapter.py
@@ -1,0 +1,221 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.discord_command_projection import DiscordProjectionMismatch
+from plugins.platforms.discord import projected_adapter
+
+
+class _RegistrationContext:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    def register_platform(self, **kwargs):
+        self.calls.append(kwargs)
+
+
+class _LocalCommand:
+    def __init__(self, payload: dict) -> None:
+        self.payload = payload
+
+    def to_dict(self, _tree) -> dict:
+        return deepcopy(self.payload)
+
+
+class _RemoteCommand:
+    def __init__(self, payload: dict) -> None:
+        self.payload = payload
+
+    def to_dict(self) -> dict:
+        return deepcopy(self.payload)
+
+
+class _Tree:
+    def __init__(self, local: list[dict], remote: list[dict]) -> None:
+        self._local = [_LocalCommand(row) for row in local]
+        self._remote = [_RemoteCommand(row) for row in remote]
+        self.fetch_commands = AsyncMock(return_value=self._remote)
+
+    def get_commands(self):
+        return list(self._local)
+
+
+def test_registration_reuses_adapter_metadata_and_swaps_only_factory() -> None:
+    ctx = _RegistrationContext()
+
+    projected_adapter.register(ctx)
+
+    assert len(ctx.calls) == 1
+    call = ctx.calls[0]
+    assert call["name"] == "discord"
+    assert call["label"] == "Discord"
+    assert call["adapter_factory"] is projected_adapter._build_projected_adapter
+    assert call["standalone_sender_fn"] is not None
+    assert call["required_env"] == ["DISCORD_BOT_TOKEN"]
+
+
+def test_projected_factory_returns_the_bounded_subclass(monkeypatch) -> None:
+    monkeypatch.setattr(
+        projected_adapter.ProjectedDiscordAdapter,
+        "__init__",
+        lambda self, config: None,
+    )
+
+    created = projected_adapter._build_projected_adapter(object())
+
+    assert isinstance(created, projected_adapter.ProjectedDiscordAdapter)
+
+
+@pytest.mark.asyncio
+async def test_native_sync_reads_back_the_exact_projection(monkeypatch) -> None:
+    payloads = [
+        {"name": "new", "description": "Start a new conversation"},
+        {
+            "name": "model",
+            "description": "Show or change the model",
+            "options": [
+                {
+                    "type": 3,
+                    "name": "name",
+                    "description": "Model name",
+                    "required": False,
+                }
+            ],
+        },
+    ]
+    tree = _Tree(payloads, list(reversed(payloads)))
+    adapter = object.__new__(projected_adapter.ProjectedDiscordAdapter)
+    adapter._client = SimpleNamespace(tree=tree)
+    adapter._existing_command_to_payload = lambda command: command.to_dict()
+    adapter._READBACK_ATTEMPTS = 1
+
+    async def base_sync(_self):
+        return {
+            "total": 2,
+            "unchanged": 2,
+            "updated": 0,
+            "recreated": 0,
+            "created": 0,
+            "deleted": 0,
+        }
+
+    monkeypatch.setattr(
+        projected_adapter._adapter.DiscordAdapter,
+        "_safe_sync_slash_commands",
+        base_sync,
+    )
+
+    result = await adapter._safe_sync_slash_commands()
+
+    assert result["total"] == 2
+    assert tree.fetch_commands.await_count == 1
+    assert adapter._discord_command_projection_revision
+    assert (
+        adapter._discord_command_projection_verified_revision
+        == adapter._discord_command_projection_revision
+    )
+
+
+@pytest.mark.asyncio
+async def test_native_sync_refuses_false_completion_after_remote_drift(
+    monkeypatch,
+) -> None:
+    local = [{"name": "new", "description": "Start a new conversation"}]
+    remote = [{"name": "new", "description": "drifted"}]
+    tree = _Tree(local, remote)
+    adapter = object.__new__(projected_adapter.ProjectedDiscordAdapter)
+    adapter._client = SimpleNamespace(tree=tree)
+    adapter._existing_command_to_payload = lambda command: command.to_dict()
+    adapter._READBACK_ATTEMPTS = 1
+
+    async def base_sync(_self):
+        return {
+            "total": 1,
+            "unchanged": 0,
+            "updated": 1,
+            "recreated": 0,
+            "created": 0,
+            "deleted": 0,
+        }
+
+    monkeypatch.setattr(
+        projected_adapter._adapter.DiscordAdapter,
+        "_safe_sync_slash_commands",
+        base_sync,
+    )
+
+    with pytest.raises(DiscordProjectionMismatch):
+        await adapter._safe_sync_slash_commands()
+
+
+def test_native_sync_uses_the_shared_projection_revision() -> None:
+    payloads = [{"name": "new", "description": "Start a new conversation"}]
+    tree = _Tree(payloads, payloads)
+    adapter = object.__new__(projected_adapter.ProjectedDiscordAdapter)
+    adapter._client = SimpleNamespace(tree=tree)
+
+    assert (
+        adapter._desired_command_sync_fingerprint()
+        == adapter._desired_command_projection().revision
+    )
+
+
+def test_same_local_fingerprint_does_not_bypass_remote_readback(monkeypatch) -> None:
+    adapter = object.__new__(projected_adapter.ProjectedDiscordAdapter)
+
+    monkeypatch.setattr(
+        projected_adapter._adapter.DiscordAdapter,
+        "_command_sync_skip_reason",
+        lambda _self, _app_id, _fingerprint: (
+            "same slash-command fingerprint already synced"
+        ),
+    )
+
+    assert adapter._command_sync_skip_reason("app", "revision") is None
+
+
+def test_rate_limit_backoff_still_skips_reconciliation(monkeypatch) -> None:
+    adapter = object.__new__(projected_adapter.ProjectedDiscordAdapter)
+
+    monkeypatch.setattr(
+        projected_adapter._adapter.DiscordAdapter,
+        "_command_sync_skip_reason",
+        lambda _self, _app_id, _fingerprint: "retry after 12.0s",
+    )
+
+    assert (
+        adapter._command_sync_skip_reason("app", "revision")
+        == "retry after 12.0s"
+    )
+
+
+@pytest.mark.asyncio
+async def test_native_readback_retries_bounded_remote_propagation() -> None:
+    desired_rows = [
+        {"name": "new", "description": "Start a new conversation"}
+    ]
+    drifted_rows = [{"name": "new", "description": "stale"}]
+    tree = _Tree(desired_rows, drifted_rows)
+    tree.fetch_commands = AsyncMock(
+        side_effect=[
+            [_RemoteCommand(row) for row in drifted_rows],
+            [_RemoteCommand(row) for row in desired_rows],
+        ]
+    )
+    adapter = object.__new__(projected_adapter.ProjectedDiscordAdapter)
+    adapter._client = SimpleNamespace(tree=tree)
+    adapter._existing_command_to_payload = lambda command: command.to_dict()
+    adapter._READBACK_ATTEMPTS = 2
+    adapter._sleep_between_command_sync_mutations = AsyncMock()
+
+    observed = await adapter._verify_remote_projection(
+        adapter._desired_command_projection()
+    )
+
+    assert observed.revision == adapter._desired_command_projection().revision
+    assert tree.fetch_commands.await_count == 2
+    adapter._sleep_between_command_sync_mutations.assert_awaited_once()


### PR DESCRIPTION
## What does this PR do?

Implements **PR 7 — Discord native/relay convergence** under #96692 as one exact current-main commit, without writing into the active Discord adapter or relay WebSocket transport owners.

Hermes has two Discord command presentations with different transports:

- the native Discord application-command tree owned by `plugins/platforms/discord/adapter.py`; and
- the hosted relay manifest exported through `gateway/relay/command_manifest.py`.

Those lanes may differ in transport and presentation, but they must not independently define command identity, canonical wire semantics, revision identity, or what counts as successful remote settlement.

### Invariant

> Native Discord and relay may differ in transport and presentation. They may not become separate semantic owners for the same command plane.

This PR establishes one transport-neutral Discord projection boundary that:

- canonicalizes the Discord command/option fields Hermes actually manages;
- preserves command type as part of wire identity;
- validates names and refuses duplicate wire identities;
- resolves aliases through Hermes' canonical command owner, so `/new` and `/reset` remain separate presentation rows while sharing one semantic identity;
- adopts the versioned catalog's stable `command_id` automatically when that catalog is available, without vendoring or duplicating it here;
- produces an immutable, order-independent SHA-256 projection revision;
- compares desired and remote command sets with typed `missing`, `unexpected`, and `changed` evidence;
- makes the relay manifest a compatibility export of the shared projection instead of a second semantic table;
- installs a bounded Discord adapter subclass through the existing plugin registration contract, preserving the current callback/interaction implementation in `adapter.py`;
- preserves minimal-diff and rate-limit behavior while removing the unsafe inference that a matching local fingerprint proves current remote state;
- performs bounded remote read-back after reconciliation and records success only after the exact canonical projection settles.

## Current-main rematerialization

The prior PR7 object predated command-plane changes now present on `main`: the relay surface uses `/bg` rather than the older `/background` row and includes `/btw`. Blindly rebasing the old projection package would therefore have reintroduced stale command semantics.

This submitted object was rebuilt directly from current `main` and the shared relay projection now carries the live `/bg` and `/btw` surface. The projection regression test asserts the same 28-row command order exported by the relay compatibility manifest.

## Exact submitted object

- Base / current `main`: `66666f6e2eca0ae883195a34c66131985ea7dd06`
- Head: `8ea55b1d72c9a4bf53c6f93df22108fbc7a48cad`
- Tree: `7cecb2602370179ef228285e90090093c9c9745f`
- Shape: **1 commit / 11 files / +1011 / -141**
- Topology: **1 ahead / 0 behind**
- `plugins/platforms/discord/adapter.py` edits: **0**
- `gateway/relay/ws_transport.py` edits: **0**
- Every changed file remains below the repository's **2,000-line** ceiling
- PR state after exact-head acceptance: **open / non-draft / mergeable**
- Inline review threads: **none**

## Changes Made

### Shared projection package

- `gateway/discord_projection/core.py`
  - canonical Discord command/option normalization;
  - JSON-safe canonical serialization;
  - command-name validation;
  - typed projection and mismatch errors.
- `gateway/discord_projection/identity.py`
  - canonical alias resolution through Hermes command ownership;
  - optional adoption of stable catalog identity;
  - explicit fallback identity for Discord-native commands outside the current core registry.
- `gateway/discord_projection/model.py`
  - immutable projected-command and projection objects;
  - duplicate wire-identity refusal;
  - order-independent revision generation;
  - canonical/semantic lookup maps;
  - exact desired-versus-remote read-back verification.
- `gateway/discord_projection/relay.py`
  - current relay/native compatibility schema, including `/bg` and `/btw`;
  - relay projection construction through the shared canonical contract.
- `gateway/discord_projection/__init__.py` and `gateway/discord_command_projection.py`
  - bounded public API and compatibility import path.

### Native Discord settlement

- `plugins/platforms/discord/projected_adapter.py`
  - bounded subclass of the existing Discord adapter;
  - desired projection built from the actual native command tree;
  - shared semantic projection revision as sync identity;
  - matching local fingerprint converted from a false-completion shortcut into a remote read-back obligation;
  - existing rate-limit backoff and minimal reconciliation preserved;
  - bounded remote propagation read-back;
  - local success state recorded only after exact settlement.
- `plugins/platforms/discord/__init__.py`
  - routes plugin registration through the bounded projected adapter entry point.

### Relay convergence

- `gateway/relay/command_manifest.py`
  - becomes a narrow compatibility export of the shared projection;
  - preserves the public `build_relay_command_manifest()` call shape;
  - no relay WebSocket transport ownership moves into this PR.

### Verification witnesses

- `tests/gateway/test_discord_command_projection.py`
  - relay manifest parity including `/bg` and `/btw`;
  - alias-to-canonical semantic identity;
  - deterministic order-independent revision;
  - remote-default/order normalization;
  - changed/missing/unexpected read-back refusal;
  - invalid/duplicate command refusal;
  - optional stable-catalog identity adoption.
- `tests/plugins/platforms/test_discord_projected_adapter.py`
  - registration metadata/factory preservation;
  - exact native read-back success;
  - remote-drift refusal;
  - shared projection revision as sync identity;
  - same-local-fingerprint remote verification;
  - rate-limit backoff preservation;
  - bounded propagation retry.

## FILE-LIST / ownership disposition

A fresh FILE-LIST scan was performed before the current-main rematerialization.

- The submitted projection paths and relay manifest have no conflicting active implementation owner found in the scan.
- Open Discord extraction work such as #82496 is disjoint from this object: it owns `plugins/platforms/discord/adapter.py` / `command_sync.py` and its extraction witness, while this PR deliberately leaves `adapter.py` untouched.
- The branch also deliberately leaves `gateway/relay/ws_transport.py` untouched.
- No submitted file exceeds 2,000 lines.

## Related Issue / provenance

Part of #96692 — **Unified slash-command registry and execution contract across every Hermes surface**.

This PR intentionally does **not** use `Fixes` or `Closes`; #96692 remains open until the broader catalog, invocation/result ABI, contributor assembly, remaining surface migrations, compatibility deletion, and cross-surface conformance work are complete.

Relevant lineage:

- #97102 owns the executable command-plane inventory/characterization baseline.
- #96791 by OutThisLife is merged ownership for registry-backed Desktop metadata and the existing backend catalog projection; this PR composes with that work rather than duplicating it.
- #97143 is the versioned semantic-catalog proposal; this projection can consume its stable identity when available without vendoring that implementation.
- #97153 owns the typed invocation/result/dispatcher ABI; this PR does not reconstruct it.
- #93338 is Discord alias-projection lineage; aliases remain presentation rows bound to canonical semantic identity here.
- #96705 remains historical stable-identity/revision design provenance, not a landing receipt.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## How to Test

Focused projection and adapter settlement:

```bash
scripts/run_tests.sh \
  tests/gateway/test_discord_command_projection.py \
  tests/plugins/platforms/test_discord_projected_adapter.py -q
```

Adjacent Discord/relay behavior:

```bash
scripts/run_tests.sh \
  tests/gateway/test_discord_slash_commands.py \
  tests/gateway/relay/test_relay_interactive.py -q
```

Repository hygiene:

```bash
git diff --check 66666f6e2eca0ae883195a34c66131985ea7dd06..8ea55b1d72c9a4bf53c6f93df22108fbc7a48cad
python scripts/check-windows-footguns.py \
  gateway/discord_command_projection.py \
  gateway/discord_projection \
  plugins/platforms/discord/projected_adapter.py
```

## Hosted exact-head acceptance

Every surviving commit is green; there is exactly one.

- CI: **33314944607 — success**
  - `Python tests / Run tests` — success
  - Windows-only tests — success
  - macOS-only tests — success
  - Python e2e — success
  - `ruff + ty diff` — success
  - blocking Ruff enforcement — success
  - blocking Windows footgun gate — success
  - contributor attribution — success
  - supply-chain aggregate — success
  - **All required checks pass: job 99267001711 — success**
- Docker: **33314944391 — success**
- Nix: **33314944324 — success**

The exact head/tree above are the objects exercised by those hosted runs. Current `main` remained the submitted commit's direct parent after the matrix settled, so no historical/sibling green was transferred.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] Commit message follows Conventional Commits
- [x] Exact FILE-LIST scan completed before writing
- [x] PR contains only Discord native/relay projection convergence and settlement work
- [x] Every surviving commit is exact-head green
- [x] Tests cover the new projection and settlement boundaries
- [x] Cross-platform hosted acceptance passed

### Documentation & Housekeeping

- [x] No user-facing command syntax or configuration contract is newly invented here; the rematerialization preserves current-main `/bg` and `/btw`
- [x] No config key changed
- [x] No contributor workflow or agent instruction contract changed
- [x] Cross-platform impact covered by hosted Windows/macOS lanes
- [x] No Hermes tool schema or model-facing tool behavior changed

## Exact-object state

- Materialization: **submitted on exact current-main parent**
- Integrity: **green on exact CI/Docker/Nix object**
- Governance: **no producer-authored review claimed**
- Integration: **open / non-draft / mergeable**
- Operation: **hosted repository acceptance passed; no live Discord production deployment claimed**
- Lineage: **active PR7 carrier under #96692**