### PR TITLE
fix: strict positional providers no longer 400 on histories with displaced or replayed tool results — enforce tool_call/tool_result adjacency at both repair layers

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -817,8 +817,10 @@ def repair_message_sequence(agent, messages: List[Dict]) -> int:
     # displaced-but-present result masks (see sanitize_api_messages) —
     # so the durable history must not keep replaying the poisoned turn
     # either. Enforce the positional invariant here: a tool_call is only
-    # legitimate when a result for ANY of its ids (``id`` / ``call_id``,
-    # same superset as Pass 1) appears in the run of tool messages
+    # legitimate when a result for ANY of its id variants (``id`` /
+    # ``call_id`` / ``response_item_id`` / composite bridge — the same
+    # unified alias policy as Pass 1, via ``tool_call_id_variants`` /
+    # ``tool_result_id_variants``) appears in the run of tool messages
     # IMMEDIATELY following the declaring assistant message — before any
     # user turn or further assistant turn. Unanswered calls are pruned;
     # if the message then carries no other payload (no content,
@@ -850,15 +852,13 @@ def repair_message_sequence(agent, messages: List[Dict]) -> int:
         ):
             tid = (filtered[j].get("tool_call_id") or "").strip()
             if tid:
-                answered.add(tid)
+                answered.update(tool_result_id_variants(tid))
             j += 1
         kept_calls: List[Dict] = []
         dropped_calls = 0
         for tc in msg.get("tool_calls") or []:
-            tc_ids = []
-            if isinstance(tc, dict):
-                tc_ids = [x for x in (tc.get("id"), tc.get("call_id")) if x]
-            if tc_ids and any(x in answered for x in tc_ids):
+            variants = tool_call_id_variants(tc)
+            if variants and (variants & answered):
                 kept_calls.append(tc)
             else:
                 dropped_calls += 1

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3852,11 +3852,20 @@ def _classify_tool_call_orphans(messages: List[Dict[str, Any]]):
     - ``missing_tool_calls``: the actual tool_call entries with no matching
       result on ANY alias (after orphaned results are excluded).
 
-    This is the single source of truth for orphan *detection*. Callers keep
-    their divergent remediation strategies — ``sanitize_api_messages``
-    inserts stubs, the context compressor strips orphans — but the
-    id-resolution and variant-expansion rules can never drift between the
-    two sites again (#58357).
+    This is the single source of truth for GLOBAL orphan *detection* (does
+    a matching id exist anywhere in the transcript). Its remaining consumer
+    is the context compressor's ``_sanitize_tool_pairs`` (strip orphans from
+    the durable history); the id-resolution and variant-expansion rules live
+    here so they can never drift between call sites again (#58357).
+
+    ``sanitize_api_messages`` no longer uses the global check: strict
+    positional providers (DeepSeek v4, Kimi) reject a call whose result is
+    not in the IMMEDIATELY-following tool run even when a matching id exists
+    elsewhere, so its pairing pass walks the transcript positionally instead
+    (#94704) — a strictly stronger invariant that subsumes the global one at
+    that site. Both share the same ``tool_call_id_variants`` /
+    ``tool_result_id_variants`` alias policy, which is the part that must
+    not fork.
     """
     assistant_call_variants: List[tuple[Any, frozenset[str]]] = []
     surviving_call_ids: set[str] = set()
@@ -4010,13 +4019,13 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
                 tc["function"] = {"name": _EMPTY_NAME_SENTINEL, "arguments": "{}"}
 
     # --- Drop tool results with a missing/empty tool_call_id ---
-    # The orphan-sweep below only ever adds a TRUTHY ``tool_call_id`` to
-    # ``result_call_ids``, so a message with a missing/empty id is never
-    # added to that set and can therefore never land in ``orphaned_results``
-    # (a set-difference against ``surviving_call_ids``) either — it silently
-    # passes through this chokepoint untouched and can reach the provider
-    # with no ``tool_call_id`` at all, which strict OpenAI-compatible
-    # providers reject as a schema violation. ``repair_message_sequence``'s
+    # The positional pairing walk below also catches this shape (an id-less
+    # result expands to zero variants, matches no declared call, and is
+    # dropped as a positional orphan), but keep the explicit early filter so
+    # the distinct failure mode keeps its own log line and the guarantee
+    # doesn't silently depend on the walk's internals: a result with no
+    # ``tool_call_id`` at all is a schema violation strict OpenAI-compatible
+    # providers reject outright. ``repair_message_sequence``'s
     # Pass 1 already drops this shape (`if tc_id and tc_id in
     # known_tool_ids`) when it runs first on the same list, but any caller
     # that reaches this function without going through

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -589,7 +589,11 @@ def repair_message_sequence(agent, messages: List[Dict]) -> int:
          resumed histories. Refs #29148, #49147.
       1. Stray ``tool`` messages whose ``tool_call_id`` doesn't match
          any preceding assistant tool_call — dropped.
-      2. Consecutive ``user`` messages — merged with newline separator
+      2. ``tool_calls`` on an assistant message that no immediately
+         following ``tool`` result answers are pruned — and the turn is
+         dropped entirely if that leaves it payload-empty (an empty
+         non-final assistant message is itself a 400 on most providers).
+      3. Consecutive ``user`` messages — merged with newline separator
          so no user input is lost.
 
     Deliberately does NOT rewind orphan ``assistant(tool_calls)+tool``
@@ -598,6 +602,19 @@ def repair_message_sequence(agent, messages: List[Dict]) -> int:
     before the model got a continuation turn (the ongoing dialog
     pattern). The empty-response scaffolding stripper handles the
     genuinely-broken variant via its flag-gated rewind.
+
+    Pass 2 (prune unanswered ``tool_calls``) answers the complement of
+    Pass 1: Pass 1 removes the stray result, Pass 2 removes the orphaned
+    call it was displaced from. Context compression can move a tool
+    result past a user turn; without this pass the declaring assistant
+    message would keep replaying an unanswered ``tool_call`` and strict
+    providers (DeepSeek v4) reject that with HTTP 400 "An assistant
+    message with 'tool_calls' must be followed by tool messages
+    responding to each 'tool_call_id'". A call counts as answered when
+    the run of ``tool`` messages immediately following its assistant
+    message contains a result keyed to ANY of the call's ids (``id`` or
+    ``call_id`` — the same superset rule Pass 1 registers). Codex
+    interim turns are exempt, as in Pass 0.
 
     Returns the number of repairs made (for logging/telemetry).
     """
@@ -786,10 +803,86 @@ def repair_message_sequence(agent, messages: List[Dict]) -> int:
                 matched_tool_groups = set()
             filtered.append(msg)
 
-    # Pass 2: merge consecutive user messages. Preserves all user input
+    # Pass 2: prune tool_calls that were never answered positionally.
+    #
+    # Pass 1 dropped the stray/displaced tool RESULT — but a tool_call
+    # whose result was displaced far beyond the following turn (context
+    # compression can move it past a user turn) leaves its declaring
+    # assistant message carrying an UNANSWERED tool_call, and strict
+    # OpenAI-compatible providers (DeepSeek v4) reject the payload with
+    # HTTP 400 "An assistant message with 'tool_calls' must be followed
+    # by tool messages responding to each 'tool_call_id' (insufficient
+    # tool messages following tool_calls message)". The per-call
+    # sanitizer's stub pass is keyed on GLOBAL id presence, which a
+    # displaced-but-present result masks (see sanitize_api_messages) —
+    # so the durable history must not keep replaying the poisoned turn
+    # either. Enforce the positional invariant here: a tool_call is only
+    # legitimate when a result for ANY of its ids (``id`` / ``call_id``,
+    # same superset as Pass 1) appears in the run of tool messages
+    # IMMEDIATELY following the declaring assistant message — before any
+    # user turn or further assistant turn. Unanswered calls are pruned;
+    # if the message then carries no other payload (no content,
+    # reasoning, codex items), the whole turn is dropped — an empty
+    # non-final assistant message is itself rejected by providers.
+    # Codex interim turns are exempt, as in Pass 0: their calls are
+    # replayed through the Responses-items chain, not the tool-result
+    # run.
+    pruned: List[Dict] = []
+    i = 0
+    n = len(filtered)
+    while i < n:
+        msg = filtered[i]
+        if not (
+            isinstance(msg, dict)
+            and msg.get("role") == "assistant"
+            and msg.get("tool_calls")
+            and not _is_codex_interim(msg)
+        ):
+            pruned.append(msg)
+            i += 1
+            continue
+        answered: set = set()
+        j = i + 1
+        while (
+            j < n
+            and isinstance(filtered[j], dict)
+            and filtered[j].get("role") == "tool"
+        ):
+            tid = (filtered[j].get("tool_call_id") or "").strip()
+            if tid:
+                answered.add(tid)
+            j += 1
+        kept_calls: List[Dict] = []
+        dropped_calls = 0
+        for tc in msg.get("tool_calls") or []:
+            tc_ids = []
+            if isinstance(tc, dict):
+                tc_ids = [x for x in (tc.get("id"), tc.get("call_id")) if x]
+            if tc_ids and any(x in answered for x in tc_ids):
+                kept_calls.append(tc)
+            else:
+                dropped_calls += 1
+        if dropped_calls:
+            repairs += 1
+            if not kept_calls and not _msg_has_payload(
+                {k: v for k, v in msg.items() if k != "tool_calls"}
+            ):
+                # The pruned call(s) were the message's only payload —
+                # dropping the whole turn beats sending an empty
+                # assistant message (which most providers 400).
+                i += 1
+                continue
+            if kept_calls:
+                msg["tool_calls"] = kept_calls
+            else:
+                msg.pop("tool_calls", None)
+        pruned.append(msg)
+        i += 1
+
+    # Pass 3: merge consecutive user messages. Preserves all user input
     # so nothing the user typed is lost.
     merged: List[Dict] = []
-    for msg in filtered:
+    for msg in pruned:
         if (
             merged
             and isinstance(msg, dict)
@@ -3941,48 +4034,105 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
             _pre_id_filter_count - len(messages),
         )
 
-    (
-        surviving_call_ids,
-        result_call_ids,
-        orphaned_results,
-        missing_tool_calls,
-    ) = _classify_tool_call_orphans(messages)
+    # --- Positional tool_call <-> tool_result pairing ---
+    # Strict OpenAI-compatible providers (DeepSeek v4, Kimi) enforce the
+    # POSITIONAL invariant: an assistant message carrying tool_calls must
+    # be IMMEDIATELY followed by tool messages covering every
+    # tool_call_id. The previous implementation compared global id sets,
+    # which misses the failure mode where a result exists somewhere in
+    # the transcript but not in the run right after its call — an
+    # interrupted turn or a compression window can displace a result
+    # past a user turn. The id then survives in the global result set,
+    # so the call looks answered, no stub is injected, and the provider
+    # rejects the payload with HTTP 400 "An assistant message with
+    # 'tool_calls' must be followed by tool messages responding to each
+    # 'tool_call_id' (insufficient tool messages following tool_calls
+    # message)". Rewritten as a single rolling walk on the per-call
+    # copy (#94704):
+    #   (a) tool results that do not immediately follow an assistant
+    #       message declaring their id are dropped (positional orphans —
+    #       includes results appearing BEFORE their call, which strict
+    #       providers also reject);
+    #   (b) declared ids not covered by the immediately-following tool
+    #       run get a stub result injected at the end of that run, even
+    #       when a mispositioned result exists elsewhere.
+    # Matching is variant-aware (``tool_call_id_variants`` /
+    # ``tool_result_id_variants``): a result keyed on ANY alias spelling
+    # (``id`` / ``call_id`` / ``response_item_id`` / composite bridge)
+    # answers the call, preserving the unified alias policy from
+    # #55626/#63000/#93251.
+    paired: List[Dict[str, Any]] = []
+    declared_calls: Dict[str, tuple] = {}
+    dropped_positional_orphans = 0
+    added_stubs = 0
 
-    # 1. Drop tool results whose complete alias set matches no assistant call.
-    orphaned_result_objects = {id(msg) for msg in orphaned_results}
-    if orphaned_result_objects:
-        messages = [m for m in messages if id(m) not in orphaned_result_objects]
+    def _flush_unanswered_stubs() -> None:
+        nonlocal added_stubs
+        for key in sorted(declared_calls):
+            tc, _variants = declared_calls[key]
+            cid = coalesce_tool_call_id(tc) or key
+            paired.append({
+                "role": "tool",
+                "name": _ra().AIAgent._get_tool_call_name_static(tc),
+                "content": "[Result unavailable — see context summary above]",
+                "tool_call_id": cid,
+            })
+            added_stubs += 1
+        declared_calls.clear()
+
+    for msg in messages:
+        role = msg.get("role")
+        if role == "assistant":
+            # A new assistant turn closes the previous tool-result run:
+            # anything still pending was never answered positionally.
+            _flush_unanswered_stubs()
+            declared_calls = {}
+            for tc in msg.get("tool_calls") or []:
+                variants = tool_call_id_variants(tc)
+                if variants:
+                    # Key on a stable representative of the alias group so
+                    # a result matching ANY spelling can consume the call.
+                    declared_calls[sorted(variants)[0]] = (tc, variants)
+            paired.append(msg)
+        elif role == "tool":
+            result_variants = tool_result_id_variants(msg.get("tool_call_id"))
+            matched = next(
+                (
+                    key
+                    for key, (_tc, variants) in declared_calls.items()
+                    if variants & result_variants
+                ),
+                None,
+            )
+            if matched is not None:
+                paired.append(msg)
+                # Consume so a duplicate result reusing the id falls into
+                # the drop branch (same semantics as the old global
+                # dedup; strict providers reject duplicate tool_call_id).
+                declared_calls.pop(matched, None)
+            else:
+                dropped_positional_orphans += 1
+        else:
+            if role == "user":
+                # A user turn closes the tool-result run; subsequent
+                # tool messages without a fresh declaring assistant
+                # turn are orphans.
+                _flush_unanswered_stubs()
+            paired.append(msg)
+    # The transcript may end right after an unanswered assistant turn.
+    _flush_unanswered_stubs()
+    if dropped_positional_orphans or added_stubs:
+        messages = paired
+    if dropped_positional_orphans:
         _ra().logger.debug(
-            "Pre-call sanitizer: removed %d orphaned tool result(s)",
-            len(orphaned_result_objects),
+            "Pre-call sanitizer: removed %d positionally orphaned tool result(s)",
+            dropped_positional_orphans,
         )
-
-    # 2. Inject one stub per assistant call with no result on ANY alias.
-    if missing_tool_calls:
-        missing_tool_call_objects = {id(tc) for tc in missing_tool_calls}
-        patched: List[Dict[str, Any]] = []
-        for msg in messages:
-            patched.append(msg)
-            if msg.get("role") == "assistant":
-                for tc in msg.get("tool_calls") or []:
-                    if id(tc) not in missing_tool_call_objects:
-                        continue
-                    cid = coalesce_tool_call_id(tc)
-                    if not cid:
-                        variants = tool_call_id_variants(tc)
-                        cid = sorted(variants)[0] if variants else ""
-                    if not cid:
-                        continue
-                    patched.append({
-                        "role": "tool",
-                        "name": _ra().AIAgent._get_tool_call_name_static(tc),
-                        "content": "[Result unavailable — see context summary above]",
-                        "tool_call_id": cid,
-                    })
-        messages = patched
+    if added_stubs:
         _ra().logger.debug(
-            "Pre-call sanitizer: added %d stub tool result(s)",
-            len(missing_tool_calls),
+            "Pre-call sanitizer: added %d stub tool result(s) for "
+            "positionally unanswered tool call(s)",
+            added_stubs,
         )
 
     # 3. Deduplicate tool_call_ids. Strict providers (DeepSeek) reject a

--- a/contributors/emails/fedeb703@gmail.com
+++ b/contributors/emails/fedeb703@gmail.com
@@ -1,0 +1,1 @@
+fedebyes

--- a/contributors/emails/tiberiud99@gmail.com
+++ b/contributors/emails/tiberiud99@gmail.com
@@ -1,0 +1,1 @@
+TiberiuD

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -832,32 +832,28 @@ def test_repair_keeps_tool_result_when_tool_calls_are_sdk_objects():
 # such turns on the per-call copy so the session recovers itself in memory.
 
 
-def test_sanitize_dedup_drops_tool_calls_key_when_all_removed():
-    """When dedup removes ALL tool_calls from an assistant message,
-    the key is dropped instead of writing tool_calls: [].
+def test_sanitize_interrupted_call_stubbed_and_replay_kept():
+    """A crash/resume glitch replays the SAME assistant call while the first
+    occurrence is still positionally unanswered.
 
-    DeepSeek v4 and newer OpenAI reject empty tool_calls with HTTP 400.
-    The dedup pass introduced by #58327 can produce this state when
-    all tool_call_ids are duplicates of earlier messages in a long
-    history. The fix (#64335) drops the key entirely rather than
-    writing an empty array.
+    With the positional pairing pass (#94704), the interrupted first call is
+    no longer a dedup candidate: it gets a synthetic unavailable-result stub
+    at the end of its (empty) tool run, and the replayed call — now with its
+    own immediate result — is a legitimate new round. This supersedes the
+    pre-positional shape where the dedup pass removed the replay's tool_calls
+    (the #64335 empty-key guard is still exercised by
+    ``test_sanitize_drops_empty_tool_calls_array``).
     """
     from agent.agent_runtime_helpers import sanitize_api_messages
 
-    # Simulate a crash/resume glitch or compression-window re-emission that
-    # replays the SAME assistant call while the first is still outstanding
-    # (no tool result has answered it yet). That is a true duplicate: the
-    # first occurrence is kept, the replay is removed. NOTE: a reuse AFTER
-    # the call was answered is NOT a duplicate — servers with per-turn or
-    # constant ids (llama.cpp, Kimi K3) legitimately re-issue ids across
-    # turns (#70724), which outstanding-call semantics now preserve.
+    # Simulate a crash/resume glitch that replays the SAME assistant call
+    # while the first is still outstanding (no tool result has answered it
+    # yet, and a second assistant turn interrupts the run).
     messages = [
         {"role": "user", "content": "step 1"},
         {"role": "assistant", "content": "running",
          "tool_calls": [{"id": "call_A", "type": "function",
                          "function": {"name": "foo", "arguments": "{}"}}]},
-        # Replayed assistant call BEFORE the result answers call_A —
-        # a duplicate of a still-outstanding call, so it must be removed.
         {"role": "assistant", "content": "retrying",
          "tool_calls": [{"id": "call_A", "type": "function",
                          "function": {"name": "foo", "arguments": "{}"}}]},
@@ -866,18 +862,18 @@ def test_sanitize_dedup_drops_tool_calls_key_when_all_removed():
 
     out = sanitize_api_messages(list(messages))
 
-    # First assistant should keep tool_calls (first occurrence)
-    assistant1 = [m for m in out if m.get("role") == "assistant"][0]
-    assert "tool_calls" in assistant1
-    assert len(assistant1["tool_calls"]) == 1
-    assert assistant1["tool_calls"][0]["id"] == "call_A"
-
-    # Second assistant should have tool_calls key DROPPED
-    # (all tool_calls were deduped as duplicates of call_A)
-    assistant2 = [m for m in out if m.get("role") == "assistant"][1]
-    assert "tool_calls" not in assistant2
-    # Content should be preserved
-    assert assistant2["content"] == "retrying"
+    # Both assistant turns survive; the interrupted one is answered by a
+    # stub inserted before the replay, the replay by its real result.
+    assert [m["role"] for m in out] == [
+        "user", "assistant", "tool", "assistant", "tool",
+    ]
+    assert out[2]["role"] == "tool"
+    assert out[2]["tool_call_id"] == "call_A"
+    assert "Result unavailable" in out[2]["content"]
+    assistants = [m for m in out if m.get("role") == "assistant"]
+    assert all("tool_calls" in a for a in assistants)
+    assert [a["tool_calls"][0]["id"] for a in assistants] == ["call_A", "call_A"]
+    assert out[4]["content"] == "result 1"
 
 
 def test_repair_drops_duplicate_tool_result_keyed_on_sibling_id():
@@ -1301,4 +1297,94 @@ def test_sanitize_positional_pairing_untouched_valid_transcript():
         "user", "assistant", "tool", "assistant", "tool", "assistant",
     ]
     assert all("Result unavailable" not in str(m.get("content", "")) for m in out)
+
+
+def test_sanitize_stubs_replayed_call_masked_by_historical_result():
+    """Issue #94704 acceptance shape: a historical result masks a later
+    replayed call with no immediate result.
+
+    ```text
+    user
+    assistant(tool_calls=[call_old])                # first declaration, answered
+    tool(call_old)                                  # historical completed call
+    user
+    assistant(tool_calls=[call_old, call_new])      # call_old REPLAYED
+      tool(call_new)                                # call_old unanswered here
+    ```
+
+    The global presence check sees ``call_old`` answered somewhere and
+    injects no stub; DeepSeek v4 rejects the payload because the second
+    declaration's contiguous tool run covers only ``call_new``. The
+    positional pass must stub ``call_old`` at the end of the second run
+    while keeping the historical result and the fresh result intact.
+    """
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    messages = [
+        {"role": "user", "content": "step 1"},
+        _assistant_with_call("call_old", content=""),
+        _tool_result("call_old", content="historical result"),
+        {"role": "user", "content": "step 2"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"id": "call_old", "type": "function",
+                 "function": {"name": "f", "arguments": "{}"}},
+                {"id": "call_new", "type": "function",
+                 "function": {"name": "g", "arguments": "{}"}},
+            ],
+        },
+        _tool_result("call_new", content="fresh result"),
+    ]
+
+    out = sanitize_api_messages(list(messages))
+
+    # The second run ends with a stub for the replayed call_old, inserted
+    # right after the fresh result and BEFORE any user turn.
+    roles = [m["role"] for m in out]
+    assert roles == ["user", "assistant", "tool", "user", "assistant",
+                     "tool", "tool"]
+    second_run = out[4:]
+    assert [m["tool_call_id"] for m in second_run if m["role"] == "tool"] == [
+        "call_new", "call_old",
+    ]
+    stub = second_run[2]
+    assert stub["role"] == "tool"
+    assert stub["tool_call_id"] == "call_old"
+    assert "Result unavailable" in stub["content"]
+    # Historical + fresh results both survive untouched.
+    contents = [m.get("content", "") for m in out]
+    assert "historical result" in contents
+    assert "fresh result" in contents
+
+
+def test_sanitize_stubs_interrupted_first_occurrence_keeps_replay_pair():
+    """Production shape (session 7d57a602b83d): an interrupted turn persists
+    an assistant tool_call with NO result (next message is user); on resume
+    the SAME call is re-issued and persisted again WITH its result. Each id
+    therefore exists twice — the first occurrence must be stubbed so the
+    positional invariant holds, while the replayed pair stays untouched.
+    """
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    messages = [
+        {"role": "user", "content": "do it"},
+        _assistant_with_call("call_A", content=""),   # interrupted: no result
+        {"role": "user", "content": "resumed"},
+        _assistant_with_call("call_A", content=""),   # replay: paired
+        _tool_result("call_A", content="real result"),
+    ]
+
+    out = sanitize_api_messages(list(messages))
+
+    roles = [m["role"] for m in out]
+    assert roles == ["user", "assistant", "tool", "user", "assistant", "tool"]
+    # Stub inserted for the interrupted first occurrence, before the user turn.
+    assert out[2]["role"] == "tool"
+    assert out[2]["tool_call_id"] == "call_A"
+    assert "Result unavailable" in out[2]["content"]
+    # Replayed pair keeps the REAL result, not a stub.
+    assert out[5]["content"] == "real result"
+
 

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -429,6 +429,7 @@ def test_tool_executor_uses_canonical_responses_pairing_id():
     ) == "call_ABC"
 
 
+
 # ── repair_message_sequence_with_cursor (#44837) ───────────────────────────
 
 from agent.agent_runtime_helpers import repair_message_sequence_with_cursor
@@ -475,7 +476,6 @@ def test_cursor_rewinds_when_compaction_happens_before_cursor():
 
 
 
-
 def test_flush_guard_clamps_overshooting_cursor():
     """_flush_messages_to_session_db safety net: an overshooting cursor must
     not produce a negative-start slice that skips everything (#44837)."""
@@ -510,15 +510,6 @@ def test_flush_guard_clamps_overshooting_cursor():
 
 
 # ── Pass 0: merge consecutive assistant messages (issue #29148, #49147) ─────
-
-
-
-
-
-
-
-
-
 
 
 
@@ -827,8 +818,6 @@ def test_repair_keeps_tool_result_when_tool_calls_are_sdk_objects():
     assert "tool" in roles, "legitimate tool result was dropped as a false orphan"
     tool_msg = next(m for m in messages if m.get("role") == "tool")
     assert tool_msg["content"] == "file contents"
-
-
 
 
 
@@ -1145,3 +1134,171 @@ def test_classify_orphans_mixed():
     assert rs == {"call_A", "call_C"}
     assert [m["tool_call_id"] for m in orphaned] == ["call_C"]
     assert [tc["id"] for tc in missing] == ["call_B"]
+
+
+# ── Positional tool_call <-> tool_result pairing ───────────────────────────
+# Production incident (session 4d8727cbcf04): context compression displaced
+# a tool result ~110 messages past its declaring assistant turn (across a
+# user turn). repair_message_sequence Pass 1 dropped the displaced result as
+# stray but left the declaring assistant carrying an UNANSWERED tool_call
+# with empty content; sanitize_api_messages' global-set stub pass saw the
+# displaced result still present, considered the call answered, and injected
+# no stub — DeepSeek v4 then 400'd the payload: "An assistant message with
+# 'tool_calls' must be followed by tool messages responding to each
+# 'tool_call_id' (insufficient tool messages following tool_calls message)".
+
+
+def _assistant_with_call(call_id, content=""):
+    return {
+        "role": "assistant",
+        "content": content,
+        "tool_calls": [{
+            "id": call_id, "type": "function",
+            "function": {"name": "f", "arguments": "{}"},
+        }],
+    }
+
+
+def _tool_result(call_id, content="out"):
+    return {"role": "tool", "tool_call_id": call_id, "content": content}
+
+
+def test_repair_prunes_tool_call_whose_result_was_displaced():
+    """Pass 2: a tool_call with no result in the immediately-following run is
+    pruned, even when its result exists far later (post-compression shape).
+    The assistant turn keeps its plain content once the calls are pruned.
+    """
+    agent = _bare_agent()
+    messages = [
+        {"role": "user", "content": "do it"},
+        _assistant_with_call("call_A", content=""),          # declares A, never answered here
+        _assistant_with_call("call_B", content="second"),    # merged into the above (Pass 0)
+        _tool_result("call_B"),
+        {"role": "user", "content": "meanwhile"},            # user redirect
+        _tool_result("call_A", content="late result"),       # displaced: dropped by Pass 1
+    ]
+
+    repairs = AIAgent._repair_message_sequence(agent, messages)
+
+    assert repairs >= 1
+    assistants = [m for m in messages if m.get("role") == "assistant"]
+    assert len(assistants) == 1
+    ids = [tc["id"] for tc in assistants[0]["tool_calls"]]
+    assert ids == ["call_B"]          # unanswered call_A pruned
+    assert assistants[0]["content"] == "second"
+    # The legitimate call_B result survives; only the displaced late
+    # call_A result was dropped.
+    tools = [m for m in messages if m.get("role") == "tool"]
+    assert len(tools) == 1
+    assert tools[0]["tool_call_id"] == "call_B"
+
+
+def test_repair_drops_turn_when_pruned_calls_were_only_payload():
+    """Pass 2: when pruning empties the merged assistant turn (no content,
+    no reasoning), the whole turn is dropped instead of sending an empty
+    non-final assistant message (itself a 400 on most providers).
+    """
+    agent = _bare_agent()
+    messages = [
+        {"role": "user", "content": "do it"},
+        _assistant_with_call("call_A"),                    # empty content
+        {"role": "assistant", "content": ""},              # merged in (Pass 0)
+        {"role": "user", "content": "redirected"},
+        _tool_result("call_A", content="late"),            # displaced: dropped
+    ]
+
+    repairs = AIAgent._repair_message_sequence(agent, messages)
+
+    assert repairs >= 2
+    assert all(m.get("role") != "assistant" for m in messages)
+    # The two user turns merge (Pass 3); nothing was lost.
+    users = [m for m in messages if m.get("role") == "user"]
+    assert len(users) == 1
+    assert "do it" in users[0]["content"] and "redirected" in users[0]["content"]
+
+
+def test_repair_keeps_calls_answered_within_following_run():
+    """Negative control: a legitimate assistant(tool_calls)+tool run must
+    survive Pass 2 untouched (the ongoing dialog pattern)."""
+    agent = _bare_agent()
+    messages = [
+        {"role": "user", "content": "Q1"},
+        _assistant_with_call("t1", content=""),
+        _tool_result("t1"),
+        {"role": "user", "content": "Q2"},
+    ]
+    original = [dict(m) for m in messages]
+
+    repairs = AIAgent._repair_message_sequence(agent, messages)
+
+    assert repairs == 0
+    assert messages == original
+
+
+def test_sanitize_stubs_call_unanswered_positionally_even_if_result_exists_elsewhere():
+    """sanitize_api_messages must inject a stub right after the declaring
+    assistant message when no result follows it, EVEN IF a (displaced)
+    result exists later in the transcript — the global-set check missed
+    this exact shape (production 400, session 4d8727cbcf04)."""
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    messages = [
+        {"role": "user", "content": "do it"},
+        _assistant_with_call("call_A", content=""),
+        {"role": "user", "content": "meanwhile"},
+        _tool_result("call_A", content="late result"),
+    ]
+
+    out = sanitize_api_messages(list(messages))
+
+    roles = [m["role"] for m in out]
+    assert roles == ["user", "assistant", "tool", "user"]
+    stub = out[2]
+    assert stub["tool_call_id"] == "call_A"
+    assert "Result unavailable" in stub["content"]
+    # The displaced late result is dropped (positional orphan).
+    assert "late result" not in [m.get("content", "") for m in out]
+
+
+def test_sanitize_drops_result_appearing_before_its_call():
+    """A tool result that precedes its declaring assistant message is a
+    positional orphan — strict providers reject 'role=tool' messages that
+    don't follow a tool_calls message."""
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    messages = [
+        {"role": "user", "content": "do it"},
+        _tool_result("call_A"),                    # before its call
+        _assistant_with_call("call_A", content=""),
+        _tool_result("call_A"),
+    ]
+
+    out = sanitize_api_messages(list(messages))
+
+    tools = [m for m in out if m.get("role") == "tool"]
+    assert len(tools) == 1                          # only the valid one survives
+    assert tools[0]["tool_call_id"] == "call_A"
+
+
+def test_sanitize_positional_pairing_untouched_valid_transcript():
+    """Negative control: a fully paired transcript (each tool-calling
+    assistant immediately followed by its results) gets no stubs and loses
+    no results."""
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    messages = [
+        {"role": "user", "content": "do it"},
+        _assistant_with_call("call_A", content=""),
+        _tool_result("call_A"),
+        _assistant_with_call("call_B", content=""),
+        _tool_result("call_B"),
+        {"role": "assistant", "content": "done"},
+    ]
+
+    out = sanitize_api_messages(list(messages))
+
+    assert [m["role"] for m in out] == [
+        "user", "assistant", "tool", "assistant", "tool", "assistant",
+    ]
+    assert all("Result unavailable" not in str(m.get("content", "")) for m in out)
+


### PR DESCRIPTION
## Summary

Fixes #94704 — strict positional providers (DeepSeek v4, Kimi) reject a payload where an assistant `tool_calls` message is not IMMEDIATELY followed by tool results covering every declared id:

```
HTTP 400: An assistant message with 'tool_calls' must be followed by tool messages
responding to each 'tool_call_id'. (insufficient tool messages following tool_calls message)
```

Our sanitizers verified that every tool_call had a matching result *somewhere* (global set difference), but not *positionally*. A displaced result (compression window, interrupted turn, replayed id) masked the unanswered call: `surviving_call_ids == result_call_ids → missing = []` → no stub, and the provider 400'd every subsequent turn of the session.

Combined salvage of two PRs fixing the same issue, credit to **@TiberiuD** (#84481, first submitter — original implementation, cherry-picked with authorship preserved) and **@fedebyes** (#95751 — rebased continuation making the prune variant-aware and adding the #94704 acceptance-shape regression tests, cherry-picked with authorship preserved). #95751 was an explicit successor to #84481 (it carried Tiberiu's commit forward); this PR lands that lineage on current main, reconciled with the shared `_classify_tool_call_orphans` classifier from #97167 which landed after both.

This general fix also **subsumes the Kimi-specific #24330** ("strict tool-message adjacency check for Moonshot AI / Kimi", fixes #24328): that PR replaces the same global set check with a forward positional pass, but only in provider-specific paths. The positional walk here runs unconditionally at the final pre-API chokepoint, covering the Kimi case for all providers.

## Changes

**`repair_message_sequence` — new Pass 2 (durable history)**
- Prunes `tool_calls` with no result in the immediately-following run of `tool` messages; drops the whole turn if pruning leaves it payload-empty (an empty non-final assistant message is itself a 400). Codex interim turns exempt, as in Pass 0.
- Matching uses the full alias set (`tool_call_id_variants` / `tool_result_id_variants`: `id`, `call_id`, `response_item_id`, composite bridge ids) so calls answered through Responses-API variants are never wrongly pruned (#55626/#63000/#93251).

**`sanitize_api_messages` — positional pairing pass (per-call copy)**
- Replaces the global-set orphan/stub logic with a single rolling walk: (a) tool results not immediately following an assistant message declaring their id are dropped (including results appearing *before* their call); (b) declared ids not covered by the immediately-following tool run get a `[Result unavailable]` stub, even when a mispositioned result exists elsewhere.
- Variant-aware matching; composes with the existing outstanding-call dedup pass so legitimately replayed ids (crash/resume) re-arm and survive with their own result.

**Integration with #97167's shared classifier** — `_classify_tool_call_orphans` stays the single source of truth for GLOBAL orphan detection; its remaining consumer is the context compressor's `_sanitize_tool_pairs`. The sanitizer's positional walk is a strictly stronger invariant that subsumes the global check at that one site; both share the same variant-alias policy (the part that must not fork). Docstrings updated to reflect the split; the classifier's own tests (added in #97167) still pass unchanged.

## Validation

**Live repro:** built the #94704 acceptance shape (assistant `tool_calls` for `call_X` followed by a user turn, then a replay of `call_X` properly paired) and ran the real `repair_message_sequence → sanitize_api_messages` pipeline.

- **BEFORE (current main `eff97a8a05`):** `repairs: 0`, positional violations in outgoing payload: `[(1, 'call_X')]` — the poisoned turn reaches the wire.
- **AFTER (this branch):** `repairs: 2`, positional violations: `[]` — the orphaned first occurrence is pruned, the replay pair survives.
- **Clean-history passthrough (determinism / cache safety):** a valid transcript (parallel `call_A`+`call_B` batch, paired results, alternating roles) runs through both passes **byte-identical** (`json.dumps(out) == json.dumps(input)`, repairs = 0) before AND after — the sanitizer only fires on genuinely broken histories.

**Tests**
- `tests/run_agent/test_message_sequence_repair.py`: **53 passed** (includes both PRs' new tests: displaced-across-user-turn prune, whole-turn drop, replayed-call-masked-by-historical-result stub, result-before-its-call drop, interrupted-first-occurrence + replay-pair, and negative controls asserting valid transcripts are untouched — plus the #97167 classifier tests, unchanged).
- `tests/agent/test_context_compressor.py`: **149 passed** (compressor's `_sanitize_tool_pairs` continues to use the shared classifier unchanged).
- `tests/hermes_state/test_restore_alternation_repair.py` + `tests/agent/test_micro_compaction.py`: **39 passed**.
- `ruff check` clean on both changed files.

## Infographic

![infographic](https://v3b.fal.media/files/b/0aa8288a/JqgHfgndBml6WCBzIf7xt_l3YNmXiI.png)

