### PR TITLE
feat: session temp files land on real storage, not tmpfs /tmp (salvage #97182)

### DIFF
--- a/contributors/emails/rahlquist@users.noreply.github.com
+++ b/contributors/emails/rahlquist@users.noreply.github.com
@@ -1,0 +1,1 @@
+rahlquist

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -30736,6 +30736,7 @@ def _start_gateway_housekeeping(stop_event: threading.Event, adapters=None, loop
         cleanup_video_cache,
     )
     from tools.tool_result_storage import cleanup_spillover_cache
+    from tools.environments.local import cleanup_terminal_temp_cache
     from tools.bot_mode_dm import cleanup_bot_dm_cache
     from tools.bot_relay import cleanup_bot_relay_artifacts
     from hermes_cli.debug import _sweep_expired_pastes
@@ -30757,6 +30758,7 @@ def _start_gateway_housekeeping(stop_event: threading.Event, adapters=None, loop
         ("Video", cleanup_video_cache),
         ("Screenshot", cleanup_screenshot_cache),
         ("Spillover", cleanup_spillover_cache),
+        ("Terminal temp", cleanup_terminal_temp_cache),
         ("Bot DM", cleanup_bot_dm_cache),
         ("Bot relay", cleanup_bot_relay_artifacts),
     )

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3640,6 +3640,7 @@ TERMINAL_CONFIG_ENV_MAP = {
     "modal_mode": "TERMINAL_MODAL_MODE",
     "degraded_mode": "TERMINAL_DEGRADED_MODE",
     "cwd": "TERMINAL_CWD",
+    "temp_dir": "TERMINAL_TEMP_DIR",
     "timeout": "TERMINAL_TIMEOUT",
     "lifetime_seconds": "TERMINAL_LIFETIME_SECONDS",
     "docker_image": "TERMINAL_DOCKER_IMAGE",

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -383,11 +383,13 @@ DEFAULT_CONFIG = {
         "degraded_mode": "warn",
         "cwd": ".",  # Use current directory
         # Root directory for Hermes' terminal session temp files (background
-        # logs/pid/exit files, code-execution sandboxes, etc.). Defaults to the
-        # OS temp root. Set this to a path on real storage when /tmp is a small
-        # tmpfs and Hermes runs out of space — e.g. on RAM-based tmpfs setups
-        # common to some Arch-based distros. Must be an absolute POSIX path;
-        # relative or empty values fall back to the default temp resolution.
+        # logs/pid/exit files, code-execution sandboxes, etc.). When empty,
+        # Hermes uses TMPDIR/TMP/TEMP if set, otherwise a managed dir on real
+        # storage at HERMES_HOME/cache/terminal (auto-pruned after 72h) — NOT
+        # tmpfs /tmp, which is RAM-capped and small on many distros (e.g.
+        # Arch-based setups) and fills up under load. Set this to redirect
+        # session temp anywhere else; must be an absolute POSIX path that
+        # exists. User-set paths are never auto-pruned.
         "temp_dir": "",
         # Terminal font family for the desktop app's embedded xterm.js terminal.
         # When set (e.g. "'CaskaydiaCoveNerdFont', 'JetBrains Mono', monospace"),

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -382,6 +382,13 @@ DEFAULT_CONFIG = {
         # preserves the historical error + traceback behavior.
         "degraded_mode": "warn",
         "cwd": ".",  # Use current directory
+        # Root directory for Hermes' terminal session temp files (background
+        # logs/pid/exit files, code-execution sandboxes, etc.). Defaults to the
+        # OS temp root. Set this to a path on real storage when /tmp is a small
+        # tmpfs and Hermes runs out of space — e.g. on RAM-based tmpfs setups
+        # common to some Arch-based distros. Must be an absolute POSIX path;
+        # relative or empty values fall back to the default temp resolution.
+        "temp_dir": "",
         # Terminal font family for the desktop app's embedded xterm.js terminal.
         # When set (e.g. "'CaskaydiaCoveNerdFont', 'JetBrains Mono', monospace"),
         # the desktop terminal uses this as the CSS font-family value, with the

--- a/tests/tools/test_local_temp_dir.py
+++ b/tests/tools/test_local_temp_dir.py
@@ -56,5 +56,71 @@ def test_temp_dir_empty_falls_through(tmp_path, monkeypatch):
     assert env.get_temp_dir() == str(tmp_path)
 
 
+def test_default_is_hermes_cache_not_tmp(tmp_path, monkeypatch):
+    """With no overrides at all, the default temp root is real storage under
+    HERMES_HOME (cache/terminal), NOT tmpfs /tmp."""
+    import hermes_constants  # noqa: F401 — resolves HERMES_HOME per call
+
+    for var in ("TERMINAL_TEMP_DIR", "TMPDIR", "TMP", "TEMP"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    env = _make_local_env({})
+    result = env.get_temp_dir()
+    assert result == str(tmp_path / ".hermes" / "cache" / "terminal")
+    assert os.path.isdir(result)
+
+
+def test_tmpdir_still_beats_default(tmp_path, monkeypatch):
+    """An explicit TMPDIR keeps winning over the managed default."""
+    monkeypatch.delenv("TERMINAL_TEMP_DIR", raising=False)
+    monkeypatch.setenv("TMPDIR", str(tmp_path))
+    env = _make_local_env({})
+    assert env.get_temp_dir() == str(tmp_path)
+
+
+def test_cleanup_terminal_temp_cache(tmp_path, monkeypatch):
+    """Old artifacts are pruned; fresh ones and live bg groups survive."""
+    import time
+
+    from tools.environments import local as local_mod
+
+    root = tmp_path / "cache" / "terminal"
+    root.mkdir(parents=True)
+    monkeypatch.setattr(local_mod, "_default_terminal_temp_dir", lambda: root)
+
+    old = time.time() - 100 * 3600
+    fresh = time.time()
+
+    # Stale loose artifact — pruned.
+    stale = root / "hermes-snap-deadbeef.sh"
+    stale.write_text("x")
+    os.utime(stale, (old, old))
+
+    # Fresh artifact — kept.
+    keep = root / "hermes-snap-cafef00d.sh"
+    keep.write_text("x")
+
+    # Live bg group: stale .pid but fresh .log — WHOLE group kept.
+    live_pid = root / "hermes_bg_live1.pid"
+    live_pid.write_text("123")
+    os.utime(live_pid, (old, old))
+    live_log = root / "hermes_bg_live1.log"
+    live_log.write_text("running")
+    os.utime(live_log, (fresh, fresh))
+
+    # Dead bg group: everything stale — pruned.
+    for suffix in ("log", "pid", "exit"):
+        f = root / f"hermes_bg_dead1.{suffix}"
+        f.write_text("x")
+        os.utime(f, (old, old))
+
+    removed = local_mod.cleanup_terminal_temp_cache(max_age_hours=72)
+    assert removed == 4  # stale snap + 3 dead-group files
+    assert keep.exists()
+    assert live_pid.exists() and live_log.exists()
+    assert not stale.exists()
+    assert not (root / "hermes_bg_dead1.log").exists()
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-q"]))

--- a/tests/tools/test_local_temp_dir.py
+++ b/tests/tools/test_local_temp_dir.py
@@ -1,0 +1,60 @@
+"""Tests for ``LocalEnvironment.get_temp_dir`` temp-dir redirect.
+
+Hermes exposes ``terminal.temp_dir`` (mirrored to ``TERMINAL_TEMP_DIR``) so
+users on RAM-based tmpfs ``/tmp`` can point session temp files (background
+logs/pid/exit files, code-execution sandboxes) at real storage.
+"""
+
+import os
+import sys
+
+import pytest
+
+from tools.environments.local import LocalEnvironment
+
+
+def _make_local_env(env: dict) -> LocalEnvironment:
+    """Construct a LocalEnvironment without running init_session (no bash)."""
+    obj = LocalEnvironment.__new__(LocalEnvironment)
+    obj.env = dict(env)
+    return obj
+
+
+def test_temp_dir_override_honored(tmp_path):
+    target = str(tmp_path)
+    env = _make_local_env({"TERMINAL_TEMP_DIR": target})
+    assert env.get_temp_dir() == target
+
+
+def test_temp_dir_from_process_env(tmp_path):
+    target = str(tmp_path)
+    env = _make_local_env({})
+    prev = os.environ.get("TERMINAL_TEMP_DIR")
+    os.environ["TERMINAL_TEMP_DIR"] = target
+    try:
+        assert env.get_temp_dir() == target
+    finally:
+        if prev is None:
+            os.environ.pop("TERMINAL_TEMP_DIR", None)
+        else:
+            os.environ["TERMINAL_TEMP_DIR"] = prev
+
+
+def test_temp_dir_non_existent_falls_through(tmp_path):
+    """A configured path that does not exist must not be used."""
+    missing = str(tmp_path / "does-not-exist")
+    env = _make_local_env({"TERMINAL_TEMP_DIR": missing})
+    # Should fall through to the standard TMPDIR//tmp//gettempdir chain, not
+    # return the missing path.
+    assert env.get_temp_dir() != missing
+
+
+def test_temp_dir_empty_falls_through(tmp_path, monkeypatch):
+    """An empty/relative terminal.temp_dir must not redirect."""
+    monkeypatch.setenv("TMPDIR", str(tmp_path))
+    env = _make_local_env({"TERMINAL_TEMP_DIR": ""})
+    assert env.get_temp_dir() == str(tmp_path)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-q"]))

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -1789,6 +1789,13 @@ class LocalEnvironment(BaseEnvironment):
             # Force forward slashes so the same string serves both contexts.
             return str(cache_dir).replace("\\", "/")
 
+        # Explicit temp-dir override from terminal.temp_dir (TERMINAL_TEMP_DIR).
+        # Honored ahead of the generic TMPDIR so users can redirect Hermes' temp
+        # root to real storage when /tmp is a small tmpfs.
+        configured = self.env.get("TERMINAL_TEMP_DIR") or os.environ.get("TERMINAL_TEMP_DIR")
+        if configured and configured.startswith("/") and os.path.isdir(configured):
+            return configured.rstrip("/") or "/"
+
         for env_var in ("TMPDIR", "TMP", "TEMP"):
             candidate = self.env.get(env_var) or os.environ.get(env_var)
             if candidate and candidate.startswith("/"):

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -10,6 +10,7 @@ import signal
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 from collections.abc import Mapping
 from pathlib import Path
@@ -21,6 +22,105 @@ from hermes_cli._subprocess_compat import windows_hide_flags
 _IS_WINDOWS = platform.system() == "Windows"
 
 logger = logging.getLogger(__name__)
+
+# --- Terminal temp-cache pruning -------------------------------------------
+#
+# get_temp_dir() now defaults to HERMES_HOME/cache/terminal (real storage)
+# instead of tmpfs /tmp, so stale session artifacts no longer disappear on
+# reboot for free. Prune them ourselves: the gateway housekeeping loop calls
+# cleanup_terminal_temp_cache() hourly (same contract as the other
+# cleanup_*_cache helpers), and a once-per-process best-effort sweep covers
+# CLI-only installs that never run the gateway.
+#
+# Background-process artifacts come in triplets (hermes_bg_<id>.log/.pid/
+# .exit). A long-running server's .pid file never changes mtime while its
+# .log keeps updating — so age is judged per GROUP (newest mtime among files
+# sharing a stem) to avoid yanking the pid/exit files out from under a
+# still-live background session.
+TERMINAL_TEMP_MAX_AGE_HOURS = 72
+
+_terminal_temp_prune_lock = threading.Lock()
+_terminal_temp_pruned_once = False
+
+_BG_GROUP_RE = re.compile(r"^(hermes_bg_[A-Za-z0-9_-]+)\.(log|pid|exit)$")
+
+
+def _default_terminal_temp_dir() -> "Path | None":
+    """Return HERMES_HOME/cache/terminal, or None if unresolvable."""
+    try:
+        from hermes_constants import get_hermes_home
+        return get_hermes_home() / "cache" / "terminal"
+    except Exception:
+        return None
+
+
+def cleanup_terminal_temp_cache(
+    max_age_hours: int = TERMINAL_TEMP_MAX_AGE_HOURS,
+) -> int:
+    """Delete session temp artifacts older than *max_age_hours*.
+
+    Same contract as the ``cleanup_*_cache`` helpers in
+    ``gateway.platforms.base`` — returns the number of entries removed — so
+    the gateway housekeeping loop can prune this dir on its hourly cadence.
+
+    Only prunes the managed default dir (``HERMES_HOME/cache/terminal``).
+    User-pointed ``terminal.temp_dir`` locations are the user's to manage —
+    we never bulk-delete inside a directory we don't own.
+    """
+    root = _default_terminal_temp_dir()
+    if root is None:
+        return 0
+    cutoff = time.time() - (max_age_hours * 3600)
+    removed = 0
+    try:
+        entries = list(root.iterdir())
+    except OSError:
+        return 0
+
+    # Newest mtime per hermes_bg_<id> group, so a live server's fresh .log
+    # protects its stale-looking .pid/.exit siblings.
+    group_newest: dict[str, float] = {}
+    for f in entries:
+        m = _BG_GROUP_RE.match(f.name)
+        if m:
+            try:
+                mt = f.stat().st_mtime
+            except OSError:
+                continue
+            key = m.group(1)
+            group_newest[key] = max(group_newest.get(key, 0.0), mt)
+
+    for f in entries:
+        try:
+            mt = f.stat().st_mtime
+        except OSError:
+            continue
+        m = _BG_GROUP_RE.match(f.name)
+        effective = group_newest.get(m.group(1), mt) if m else mt
+        if effective >= cutoff:
+            continue
+        try:
+            if f.is_dir():
+                shutil.rmtree(f, ignore_errors=True)
+            else:
+                f.unlink()
+            removed += 1
+        except OSError:
+            continue
+    return removed
+
+
+def _prune_terminal_temp_once() -> None:
+    """Best-effort prune, at most once per process (CLI-only installs)."""
+    global _terminal_temp_pruned_once
+    with _terminal_temp_prune_lock:
+        if _terminal_temp_pruned_once:
+            return
+        _terminal_temp_pruned_once = True
+    try:
+        cleanup_terminal_temp_cache()
+    except Exception as exc:
+        logger.debug("Terminal temp prune failed: %s", exc)
 
 
 def _msys_to_windows_path(cwd: str) -> str:
@@ -1764,8 +1864,19 @@ class LocalEnvironment(BaseEnvironment):
         resolves to a POSIX path.
 
         Check the environment configured for this backend first so callers can
-        override the temp root explicitly (for example via terminal.env or a
-        custom TMPDIR), then fall back to the host process environment.
+        override the temp root explicitly (for example via terminal.temp_dir,
+        terminal.env, or a custom TMPDIR), then fall back to the host process
+        environment.
+
+        **Default (no override set):** a dedicated cache dir under
+        ``HERMES_HOME`` (``~/.hermes/cache/terminal``) rather than ``/tmp``.
+        On several distros (Arch and friends) ``/tmp`` is a small RAM-backed
+        tmpfs, and Hermes session artifacts — background-process logs,
+        code-execution sandboxes, spilled tool results — can fill it under
+        load. Real storage is the safer default; stale artifacts are pruned
+        by ``cleanup_terminal_temp_cache`` (gateway housekeeping + a
+        once-per-process best-effort sweep) since we no longer get tmpfs
+        reboot wipes for free.
 
         **Windows:** hardcoded ``/tmp`` is wrong in two ways — native Python
         can't open the path, and the Windows default temp (``%TEMP%``) often
@@ -1786,6 +1897,7 @@ class LocalEnvironment(BaseEnvironment):
             except Exception:
                 cache_dir = Path(tempfile.gettempdir()) / "hermes_terminal"
             cache_dir.mkdir(parents=True, exist_ok=True)
+            _prune_terminal_temp_once()
             # Force forward slashes so the same string serves both contexts.
             return str(cache_dir).replace("\\", "/")
 
@@ -1800,6 +1912,20 @@ class LocalEnvironment(BaseEnvironment):
             candidate = self.env.get(env_var) or os.environ.get(env_var)
             if candidate and candidate.startswith("/"):
                 return candidate.rstrip("/") or "/"
+
+        # Default: HERMES_HOME/cache/terminal — real storage, mirroring the
+        # Windows branch above. /tmp is only a last-resort fallback now
+        # because RAM-backed tmpfs /tmp fills up under Hermes load.
+        try:
+            from hermes_constants import get_hermes_home
+            cache_dir = get_hermes_home() / "cache" / "terminal"
+            cache_dir.mkdir(parents=True, exist_ok=True)
+            resolved = str(cache_dir)
+            if resolved.startswith("/") and os.access(resolved, os.W_OK | os.X_OK):
+                _prune_terminal_temp_once()
+                return resolved.rstrip("/") or "/"
+        except Exception:
+            pass
 
         if os.path.isdir("/tmp") and os.access("/tmp", os.W_OK | os.X_OK):
             return "/tmp"

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -174,6 +174,7 @@ Hermes supports seven terminal backends. Each determines where the agent's shell
 terminal:
   backend: local    # local | docker | ssh | modal | daytona | vercel_sandbox | singularity
   cwd: "."          # Gateway/cron working directory (CLI always uses launch dir)
+  temp_dir: ""      # Session temp root; empty = TMPDIR, else ~/.hermes/cache/terminal
   font_family: ""   # Desktop terminal font; e.g. "MesloLGS NF"
   timeout: 180      # Per-command timeout in seconds
   home_mode: auto   # auto | real | profile — subprocess HOME policy
@@ -182,6 +183,18 @@ terminal:
   modal_image: "nikolaik/python-nodejs:python3.11-nodejs20"                 # Container image for Modal backend
   daytona_image: "nikolaik/python-nodejs:python3.11-nodejs20"               # Container image for Daytona backend
 ```
+
+`terminal.temp_dir` controls where Hermes puts session temp artifacts on the
+local backend — background-process logs/pid/exit files, code-execution
+sandboxes, and spilled tool results. When it's empty (the default), Hermes
+honors an explicit `TMPDIR`/`TMP`/`TEMP` from the environment and otherwise
+uses a managed directory on real storage at `~/.hermes/cache/terminal`
+instead of `/tmp` — on many distros (Arch-based setups in particular) `/tmp`
+is a small RAM-backed tmpfs that Hermes session artifacts can fill under
+load. The managed directory is auto-pruned: artifacts older than 72 hours are
+swept hourly by gateway housekeeping and once per process on CLI-only
+installs. Set `temp_dir` to an existing absolute path to redirect session
+temp anywhere else; user-set paths are never auto-pruned.
 
 `terminal.font_family` controls the embedded terminal in Hermes Desktop. It accepts either one locally installed family name (for example, `MesloLGS NF`) or a CSS font stack. Hermes appends its bundled JetBrains Mono stack as a fallback, and an empty value keeps the default. You can edit the same profile-scoped setting in **Settings → Appearance → Terminal Font**; no Google Fonts download or system-font permission is required.
 
@@ -371,6 +384,7 @@ Every key under `terminal:` has an env-var override of the form `TERMINAL_<KEY_U
 | `TERMINAL_CONTAINER_DISK` | `container_disk` | MB |
 | `TERMINAL_CONTAINER_PERSISTENT` | `container_persistent` | `true` / `false` — controls the bind-mount workspace dirs, distinct from `docker_persist_across_processes` |
 | `TERMINAL_LIFETIME_SECONDS` | `lifetime_seconds` | Idle reaper window |
+| `TERMINAL_TEMP_DIR` | `temp_dir` | Session temp root (local backend) |
 | `TERMINAL_TIMEOUT` | `timeout` | Per-command timeout |
 | `HERMES_DOCKER_BINARY` | _none_ | Force a specific docker/podman binary path |
 


### PR DESCRIPTION
## Summary
Hermes session temp artifacts (background-process log/pid/exit files, code-execution sandboxes, spilled tool results) no longer default to tmpfs `/tmp` — the local backend now uses real storage at `~/.hermes/cache/terminal`, auto-pruned after 72h. Root cause: many distros (Arch-based setups, and our own machines) mount `/tmp` as a small RAM-backed tmpfs, and Hermes fills it under load.

Salvages #97182 by @rahlquist (cherry-picked with authorship preserved) — the `terminal.temp_dir` config knob for pointing session temp anywhere explicitly — and builds the default change on top per maintainer direction.

## Changes
- `hermes_cli/config_defaults.py` + `hermes_cli/config.py`: new `terminal.temp_dir` key, bridged to `TERMINAL_TEMP_DIR` like `cwd` (@rahlquist)
- `tools/environments/local.py`: `get_temp_dir()` resolution is now `terminal.temp_dir` → `TMPDIR`/`TMP`/`TEMP` → **`HERMES_HOME/cache/terminal` (new default)** → `/tmp` last resort; mirrors the existing Windows branch
- `tools/environments/local.py`: `cleanup_terminal_temp_cache()` — 72h pruner with `hermes_bg_*` triplets aged as a group (a live server's fresh `.log` protects its stale-looking `.pid`/`.exit`); only the managed dir is ever pruned, user-set `temp_dir` paths are left alone
- `gateway/run.py`: pruner joins the hourly housekeeping cache loop; a once-per-process best-effort sweep covers CLI-only installs (same pattern as spillover)
- `website/docs/user-guide/configuration.md`: `temp_dir` documented in the terminal block + env var table
- Tests: 7 cases in `tests/tools/test_local_temp_dir.py` (override, env, fallthrough, new default, TMPDIR precedence, group-aware pruning)

## Validation
| | Before (main) | After |
|---|---|---|
| Default temp root (no env) | `/tmp` (tmpfs) | `~/.hermes/cache/terminal` |
| `TMPDIR` set | honored | honored (unchanged) |
| `terminal.temp_dir` set | n/a | wins over everything |
| Stale artifacts | accumulate until reboot | pruned at 72h, live bg groups kept |

**Live repro:** A/B against origin/main with isolated `HERMES_HOME` and real bash sessions — main resolves `/tmp`; this branch resolves `$HERMES_HOME/cache/terminal`, session snapshot lands there, env persists across execute() calls, `execute_code`/`tool_result_storage` follow, and the pruner removed exactly the 4 stale artifacts while keeping fresh files and a live bg group. Targeted tests: 36 passed.

## Infographic

![Session temp off tmpfs mission patch](https://v3b.fal.media/files/b/0aa82846/U1jhCOd3Rp3GMPIo5PM6x_sI8mdv8A.png)
