### PR TITLE
fix(browser): rebase sibling-container CDP websocket URLs

### DIFF
--- a/tests/tools/test_browser_cdp_override.py
+++ b/tests/tools/test_browser_cdp_override.py
@@ -14,6 +14,99 @@ class TestResolveCdpOverride:
 
         assert _resolve_cdp_override(WS_URL) == WS_URL
 
+    def test_resolves_http_discovery_endpoint_to_websocket(self):
+        from tools.browser_tool import _resolve_cdp_override
+
+        response = Mock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = {"webSocketDebuggerUrl": WS_URL}
+
+        with patch("tools.browser_tool.requests.get", return_value=response) as mock_get:
+            resolved = _resolve_cdp_override(HTTP_URL)
+
+        assert resolved == WS_URL
+        mock_get.assert_called_once_with(VERSION_URL, timeout=10)
+
+    def test_rebases_container_loopback_websocket_to_remote_discovery_authority(self):
+        from tools.browser_tool import _resolve_cdp_override
+
+        remote_http_url = "http://remote-browser.example:9222"
+        advertised_ws_url = "ws://127.0.0.1/devtools/browser/abc123?token=opaque"
+        expected_ws_url = (
+            "ws://remote-browser.example:9222/"
+            "devtools/browser/abc123?token=opaque"
+        )
+        response = Mock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = {"webSocketDebuggerUrl": advertised_ws_url}
+
+        with patch("tools.browser_tool.requests.get", return_value=response) as mock_get:
+            resolved = _resolve_cdp_override(remote_http_url)
+
+        assert resolved == expected_ws_url
+        mock_get.assert_called_once_with(f"{remote_http_url}/json/version", timeout=10)
+
+    def test_keeps_loopback_websocket_for_loopback_discovery_authority(self):
+        from tools.browser_tool import _resolve_cdp_override
+
+        local_http_url = "http://127.0.0.1:9222"
+        advertised_ws_url = "ws://127.0.0.1/devtools/browser/abc123"
+        response = Mock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = {"webSocketDebuggerUrl": advertised_ws_url}
+
+        with patch("tools.browser_tool.requests.get", return_value=response):
+            resolved = _resolve_cdp_override(local_http_url)
+
+        assert resolved == advertised_ws_url
+
+    def test_keeps_non_loopback_advertised_websocket_unchanged(self):
+        from tools.browser_tool import _resolve_cdp_override
+
+        remote_http_url = "http://discovery-browser.example:9222"
+        advertised_ws_url = "ws://advertised-browser.example:9222/devtools/browser/abc123"
+        response = Mock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = {"webSocketDebuggerUrl": advertised_ws_url}
+
+        with patch("tools.browser_tool.requests.get", return_value=response):
+            resolved = _resolve_cdp_override(remote_http_url)
+
+        assert resolved == advertised_ws_url
+
+    def test_resolves_bare_ws_hostport_to_discovery_websocket(self):
+        from tools.browser_tool import _resolve_cdp_override
+
+        response = Mock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = {"webSocketDebuggerUrl": WS_URL}
+
+        with patch("tools.browser_tool.requests.get", return_value=response) as mock_get:
+            resolved = _resolve_cdp_override(f"ws://{HOST}:{PORT}")
+
+        assert resolved == WS_URL
+        mock_get.assert_called_once_with(VERSION_URL, timeout=10)
+
+    def test_uses_wss_for_https_discovery_when_rebasing_loopback(self):
+        from tools.browser_tool import _resolve_cdp_override
+
+        remote_https_url = "https://remote-browser.example:9443/json/version"
+        advertised_ws_url = "ws://localhost/devtools/browser/abc123"
+        expected_ws_url = "wss://remote-browser.example:9443/devtools/browser/abc123"
+        response = Mock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = {"webSocketDebuggerUrl": advertised_ws_url}
+
+        with patch("tools.browser_tool.requests.get", return_value=response):
+            resolved = _resolve_cdp_override(remote_https_url)
+
+        assert resolved == expected_ws_url
+
+    def test_falls_back_to_raw_url_when_discovery_fails(self):
+        from tools.browser_tool import _resolve_cdp_override
+
+        with patch("tools.browser_tool.requests.get", side_effect=RuntimeError("boom")):
+            assert _resolve_cdp_override(HTTP_URL) == HTTP_URL
 
     def test_redacts_secret_query_params_in_success_log(self):
         from tools.browser_tool import _resolve_cdp_override

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -528,6 +528,47 @@ def _resolve_cdp_override(cdp_url: str) -> str:
 
     ws_url = str(payload.get("webSocketDebuggerUrl") or "").strip()
     if ws_url:
+        # Chromium in a sibling container can advertise a debugger URL using
+        # its own loopback authority (for example, ws://127.0.0.1/...). That
+        # authority points at Hermes when the resolver runs in another
+        # container. Rebase only that authority to the configured discovery
+        # service, preserving Chromium's dynamic path and query string.
+        try:
+            from urllib.parse import urlsplit, urlunsplit
+
+            advertised = urlsplit(ws_url)
+            discovery = urlsplit(discovery_url)
+            advertised_host = (advertised.hostname or "").lower().rstrip(".")
+            discovery_host = (discovery.hostname or "").lower().rstrip(".")
+
+            def is_loopback_host(host: str) -> bool:
+                return (
+                    host in {"localhost", "0.0.0.0", "::", "::1"}
+                    or host.startswith("127.")
+                    or host.endswith(".localhost")
+                )
+
+            if (
+                advertised_host
+                and discovery_host
+                and is_loopback_host(advertised_host)
+                and not is_loopback_host(discovery_host)
+                and discovery.netloc
+            ):
+                scheme = "wss" if discovery.scheme in {"https", "wss"} else "ws"
+                ws_url = urlunsplit(
+                    (
+                        scheme,
+                        discovery.netloc,
+                        advertised.path,
+                        advertised.query,
+                        advertised.fragment,
+                    )
+                )
+        except ValueError:
+            # Preserve the existing actionable connection error for malformed
+            # advertised URLs instead of guessing an endpoint here.
+            pass
         logger.info(
             "Resolved CDP endpoint %s -> %s",
             _sanitize_url_for_logs(raw),


### PR DESCRIPTION
## Summary

Chromium in a sibling container can return a `webSocketDebuggerUrl` with a container-local loopback authority such as `ws://127.0.0.1/devtools/browser/<id>`. Hermes then tries to connect to its own loopback interface instead of the configured remote browser service.

This change rebases only a loopback advertised authority to the configured non-loopback discovery authority, preserving the dynamic DevTools path, query, and fragment. Loopback discovery endpoints and non-loopback advertised websocket URLs remain unchanged.

## Verification

- Reproduced against a live sibling-container CDP service: discovery succeeds, current resolver returned `ws://127.0.0.1/...`, and `browser_navigate` failed with connection refused.
- Direct rebased CDP `Browser.getVersion` succeeds against the live service.
- Real high-level `browser_navigate("https://example.com")` succeeds with the patched source and returns title plus accessibility snapshot.
- `ruff check tools/browser_tool.py tests/tools/test_browser_cdp_override.py`
- `scripts/run_tests.sh tests/tools/test_browser_cdp_override.py -q` (22 passed)
- `pytest tests/tools/test_browser_*.py -q` (514 passed, 22 deselected)

## Scope

No browser default, credentials, network exposure, session lifecycle, or data ownership changes.
