### PR TITLE
fix(windows): skip unreadable Node candidates instead of crashing hermes update (#97196)

### DIFF
--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -804,6 +804,25 @@ def _managed_node_tree_outdated(home: Path | None = None) -> bool:
     return False
 
 
+def _safe_is_file(candidate: Path) -> bool:
+    """``Path.is_file()`` that treats an unreadable candidate as "not a match".
+
+    ``Path.is_file()`` calls ``os.stat()``, which raises ``PermissionError``
+    (``WinError 5``) on Windows when the current user is denied ACL access to
+    the candidate — e.g. ``%LOCALAPPDATA%\\hermes\\node`` populated by an
+    elevated install. An unguarded probe there aborts ``hermes update``
+    before the managed-Node self-heal can run and before the PATH fallback
+    is tried. Skip an unreadable candidate instead of raising, consistent
+    with how :func:`node_tool_runnable` already treats ``OSError``.
+    ``FileNotFoundError`` maps to ``False`` for free (it is an ``OSError``
+    subclass and also what ``is_file`` returns natively for a missing path).
+    """
+    try:
+        return candidate.is_file()
+    except OSError:
+        return False
+
+
 def find_hermes_node_executable(command: str) -> str | None:
     """Return a Hermes-managed Node/npm executable path, healing broken trees.
 
@@ -820,7 +839,7 @@ def find_hermes_node_executable(command: str) -> str | None:
         for directory in iter_hermes_node_dirs():
             for name in names:
                 candidate = directory / name
-                if candidate.is_file() and (
+                if _safe_is_file(candidate) and (
                     sys.platform == "win32" or os.access(candidate, os.X_OK)
                 ):
                     resolved = str(candidate)
@@ -856,14 +875,18 @@ def find_node_executable_on_path(command: str) -> str | None:
         sep and sep in command_str for sep in (os.sep, os.altsep, "/", "\\")
     )
     if has_path_separator:
-        return command_str if Path(command_str).is_file() else None
+        return command_str if _safe_is_file(Path(command_str)) else None
 
     for name in _candidate_node_command_names(command_str):
         for directory in os.environ.get("PATH", "").split(os.pathsep):
             if not directory:
                 continue
             candidate = Path(directory) / name
-            if candidate.is_file():
+            # The installer puts %LOCALAPPDATA%\hermes\node on PATH, so this
+            # walk hits the same tree as find_hermes_node_executable(). An
+            # unguarded is_file() there would let an ACL-denied managed tree
+            # take out the PATH fallback too, leaving no resolution path.
+            if _safe_is_file(candidate):
                 return str(candidate)
     return None
 


### PR DESCRIPTION
## Summary

Closes #97196.

On Windows, if the managed Node tree at \`%LOCALAPPDATA%\hermes\node\` becomes **unreadable** by the current user (an ACL that denies the user, as opposed to a file lock), \`hermes update\` dies with an uncaught \`PermissionError\` before the managed-Node self-heal can run:

\`\`\`
PermissionError: [WinError 5] Access is denied:
  'C:\...\AppData\Local\hermes\node\npm.cmd'
    hermes_constants.py, in find_hermes_node_executable._first_runnable
      if candidate.is_file() and (
\`\`\`

Distinct from #80926 (a *file lock* held by a running \`node.exe\`, fixed in #86663 by staging the heal to a sibling dir). That fix makes the **heal** Windows-safe, but the **probe** that decides whether to heal is still unguarded, so an ACL-denied tree never reaches the healing path at all.

The installer also puts \`%LOCALAPPDATA%\hermes\node\` on \`PATH\`, so \`find_node_executable_on_path\` walks the same poisoned tree and dies the same way — knocking out the last fallback.

## Fix

Introduce \`_safe_is_file(candidate)\` — returns \`False\` on any \`OSError\` (\`PermissionError\` is a subclass), consistent with how \`node_tool_runnable\` already treats \`OSError\`. Apply it at:

- \`find_hermes_node_executable._first_runnable\` — lets the existing \`needs_heal\` / \`heal_hermes_managed_node\` path do its job.
- \`find_node_executable_on_path\` (both the has-separator fast path and the PATH walk) — restores PATH as a genuine fallback when the managed tree is unreadable.

\`FileNotFoundError\` maps to \`False\` for free (it's an \`OSError\` subclass and also what \`is_file()\` returns natively for a missing path), so behavior for the common \"tree not present\" case is unchanged.

## Test plan

- [ ] On Windows: reproduce per the issue (deny the current user read access to \`%LOCALAPPDATA%\hermes\node\`) and run \`hermes update\`. Verify no \`PermissionError\` traceback; the self-heal path fires and the update proceeds.
- [ ] On Windows with a healthy managed tree: \`hermes update\` still resolves the managed \`npm.cmd\` (no regression).
- [ ] On POSIX: unchanged — \`os.access(candidate, os.X_OK)\` still gates execution and \`is_file()\` never raises for a missing path.
- [ ] Sanity: \`_safe_is_file\` returns \`False\` for non-existent paths, \`False\` when \`is_file()\` raises \`PermissionError\`, and \`True\` for a regular file.