### PR TITLE
fix(desktop): retry context-breakdown fetch until gateway hydration completes

### DIFF
--- a/apps/desktop/src/app/shell/hooks/use-context-breakdown.test.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-context-breakdown.test.tsx
@@ -1,0 +1,174 @@
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ContextBreakdown } from '@/types/hermes'
+
+import { deferred } from '../../../test/deferred'
+
+import { useContextBreakdown } from './use-context-breakdown'
+
+type GatewayRequester = <T = unknown>(method: string, params?: Record<string, unknown>) => Promise<T>
+
+function breakdownOf(contextMax: number): ContextBreakdown {
+  return {
+    categories: [{ color: 'teal', id: 'conversation', label: 'Conversation', tokens: 24_100 }],
+    context_max: contextMax,
+    context_percent: 9,
+    context_used: 24_100,
+    estimated_total: 25_400,
+    model: 'test-model'
+  }
+}
+
+async function flushAsync() {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(0)
+  })
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+})
+
+describe('useContextBreakdown retry', () => {
+  it('recovers from a session-not-found rejection once the gateway registers the session', async () => {
+    // The gateway 4001s until its runtime registry knows the session — the
+    // restart race. One failed fetch, then a real answer.
+    const requestGateway = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('session not found'))
+      .mockResolvedValue(breakdownOf(123_000))
+
+    const { result } = renderHook(() =>
+      useContextBreakdown({ busy: false, enabled: true, requestGateway, sessionId: 'runtime-1' })
+    )
+
+    await flushAsync()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000)
+    })
+
+    expect(requestGateway).toHaveBeenCalledTimes(2)
+    expect(result.current.breakdown?.context_max).toBe(123_000)
+    expect(result.current.loading).toBe(false)
+  })
+
+  it('refetches when the first answer has no hydration data instead of painting an empty gauge', async () => {
+    // The session is registered but the agent is not hydrated yet: the RPC
+    // SUCCEEDS with context_max 0. Accepting that answer would strand the
+    // gauge at zero until something else changes.
+    const requestGateway = vi.fn().mockResolvedValueOnce(breakdownOf(0)).mockResolvedValue(breakdownOf(999_000))
+
+    const { result } = renderHook(() =>
+      useContextBreakdown({ busy: false, enabled: true, requestGateway, sessionId: 'runtime-1' })
+    )
+
+    await flushAsync()
+    expect(result.current.breakdown).toBeNull()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000)
+    })
+
+    expect(requestGateway).toHaveBeenCalledTimes(2)
+    expect(result.current.breakdown?.context_max).toBe(999_000)
+    expect(result.current.loading).toBe(false)
+  })
+
+  it('stops after a bounded number of attempts instead of retrying forever', async () => {
+    const requestGateway = vi.fn(async (_method: string) => {
+      throw new Error('session not found')
+    })
+
+    const { result } = renderHook(() =>
+      useContextBreakdown({ busy: false, enabled: true, requestGateway, sessionId: 'runtime-1' })
+    )
+
+    await flushAsync()
+    expect(requestGateway).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000)
+    })
+
+    // RETRY_LIMIT is 4 retries: 1 initial fetch + 4 retries — then the hook
+    // gives up and never schedules another attempt, however long it waits.
+    expect(requestGateway).toHaveBeenCalledTimes(5)
+    expect(result.current.breakdown).toBeNull()
+    expect(result.current.loading).toBe(false)
+  })
+
+  it('does not report session A numbers once the focused session is B', async () => {
+    const sessionA = deferred<ContextBreakdown>()
+
+    const requestGateway = vi.fn((method: string, params?: Record<string, unknown>) => {
+      if (params?.session_id === 'runtime-2') {
+        return new Promise<ContextBreakdown>(() => undefined)
+      }
+
+      return sessionA.promise
+    }) as unknown as GatewayRequester
+
+    const { rerender, result } = renderHook(
+      ({ sessionId }) => useContextBreakdown({ busy: false, enabled: true, requestGateway, sessionId }),
+      { initialProps: { sessionId: 'runtime-1' } }
+    )
+
+    rerender({ sessionId: 'runtime-2' })
+    await flushAsync()
+
+    // A's fetch finally lands after the switch; it must not paint under B.
+    await act(async () => {
+      sessionA.resolve(breakdownOf(123_000))
+      await vi.advanceTimersByTimeAsync(0)
+    })
+
+    expect(result.current.breakdown).toBeNull()
+  })
+
+  it('starts a fresh retry budget after a dependency change mid-retry', async () => {
+    let rejectNext = true
+
+    const requestGateway = vi.fn(async (method: string): Promise<unknown> => {
+      if (rejectNext) {
+        throw new Error('session not found')
+      }
+
+      return breakdownOf(123_000)
+    }) as unknown as GatewayRequester
+
+    const { rerender, result } = renderHook(
+      ({ busy }) => useContextBreakdown({ busy, enabled: true, requestGateway, sessionId: 'runtime-1' }),
+      { initialProps: { busy: false } }
+    )
+
+    // First run: the attempt burns itself on a failure...
+    await flushAsync()
+    expect(requestGateway).toHaveBeenCalledTimes(1)
+
+    // ...mid-retry (before the scheduled retry fires) a turn boundary flips
+    // `busy` and remounts the effect.
+    rerender({ busy: true })
+    rerender({ busy: false })
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000)
+    })
+
+    // The old run's retry timer was cancelled on cleanup; the new run began
+    // from attempt 0, so the very next fetch is one it accepts.
+    rejectNext = false
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000)
+    })
+
+    expect(result.current.breakdown?.context_max).toBe(123_000)
+  })
+})

--- a/apps/desktop/src/app/shell/hooks/use-context-breakdown.ts
+++ b/apps/desktop/src/app/shell/hooks/use-context-breakdown.ts
@@ -9,6 +9,27 @@ interface ContextBreakdownOptions {
   sessionId: null | string
 }
 
+// Early in a session's life the gateway may not have the session registered yet
+// (the RPC errors) or may have it registered without a hydrated agent (the RPC
+// answers `context_max: 0`). Both are racing the gateway's own startup, not
+// real answers — so retry a few times with a short gap before giving up.
+// Without this the gauge stays blank until a toggle or a sent message changes
+// an effect dependency and triggers the fetch again.
+const RETRY_LIMIT = 4
+const RETRY_DELAY_MS = 1_500
+
+function isUsable(breakdown: ContextBreakdown | undefined) {
+  // A zero ceiling means the backend has no hydration data yet, not an empty
+  // context — a session always has at least the system prompt below it.
+  return Boolean(breakdown && breakdown.context_max > 0)
+}
+
+function wait(ms: number) {
+  return new Promise<void>(resolve => {
+    setTimeout(resolve, ms)
+  })
+}
+
 /** The focused session's context breakdown, fetched as soon as the statusbar
  *  gauge is on screen rather than when its popover opens.
  *
@@ -38,18 +59,44 @@ export function useContextBreakdown({ busy, enabled, requestGateway, sessionId }
     let cancelled = false
     setLoading(true)
 
-    void requestGateway<ContextBreakdown>('session.context_breakdown', { session_id: sessionId })
-      .then(breakdown => {
-        if (!cancelled && breakdown) {
+    // Attempt is per effect run, so a dependency change (session switch,
+    // toggle, turn boundary) starts a fresh retry budget.
+    const fetchOnce = async (attempt: number): Promise<void> => {
+      try {
+        const breakdown = await requestGateway<ContextBreakdown>('session.context_breakdown', {
+          session_id: sessionId
+        })
+
+        if (!cancelled && isUsable(breakdown)) {
           setFetched({ breakdown, sessionId })
+
+          return
         }
-      })
-      .catch(() => undefined)
-      .finally(() => {
-        if (!cancelled) {
-          setLoading(false)
-        }
-      })
+      } catch {
+        // The gateway can answer "session not found" before registration —
+        // transient, same as an empty success. Fall through to the retry.
+      }
+
+      // Exhausted the budget (or got through): the caller's finally clears
+      // loading; retrying further would only spam the gateway.
+      if (cancelled || attempt >= RETRY_LIMIT) {
+        return
+      }
+
+      await wait(RETRY_DELAY_MS)
+
+      if (cancelled) {
+        return
+      }
+
+      await fetchOnce(attempt + 1)
+    }
+
+    void fetchOnce(0).finally(() => {
+      if (!cancelled) {
+        setLoading(false)
+      }
+    })
 
     return () => {
       cancelled = true


### PR DESCRIPTION
Closes #97163

## Summary

After a desktop-app restart, the "Context usage" statusbar meter stays hidden until the user toggles the item or sends a message. The eager `session.context_breakdown` fetch in `useContextBreakdown` is one-shot per effect run and loses two different races against gateway hydration:

1. **RPC before the session is registered** → gateway answers error `4001 "session not found"` (`tui_gateway/server.py` `_sess_nowait`). The client swallowed it via `.catch(() => undefined)`.
2. **RPC while the session exists but the agent is not yet hydrated** → the handler's `agent is None` branch (`tui_gateway/methods_session.py:1707-1720`) returns a *successful* payload with `context_max: 0`. The client accepted it and stopped.

In both cases `context_max` stays falsy → `usageContextLabel()` returns `''` → the item hides itself. While the app sits idle, no effect dependency ever changes, so there is no retry and the meter stays hidden for the whole session. Toggling the item (`enabled` flip) or sending a message (`busy` flip) re-runs the effect — which is exactly the reported workaround behavior.

## Changes

In `apps/desktop/src/app/shell/hooks/use-context-breakdown.ts` (client-side only):

- Treat "no usable data yet" as transient: `isUsable()` requires `context_max > 0` (a zero ceiling means the backend has no hydration data yet, not an empty context — a session always has at least a system prompt below it).
- Bounded retry on **both** failure modes: rejection and success-with-unusable-data. `RETRY_LIMIT = 4` retries at `RETRY_DELAY_MS = 1500` (max 5 RPCs over ~6s, then gives up — no infinite polling).
- Retry budget is per effect run: the attempt counter lives in the effect closure, so a dependency change (session switch, toggle, turn boundary) grants a fresh budget, matching the hook's existing re-fetch semantics.
- Discipline preserved: `cancelled` checked after every await and before every setState; `loading` start/finish via `.finally`; return shape and keyed-by-sessionId semantics unchanged; public signature identical.

## Tests

New `use-context-breakdown.test.tsx` (5 tests, fake timers, ~1.4s):

- **4001 recovery**: rejection once, then success → hook ends with `context_max` set. Fails on the old code.
- **empty-success recovery**: first success with `context_max: 0`, then real data → hook retries instead of painting an empty gauge. Fails on the old code.
- **bounded**: always rejects → exactly 5 calls, then silence (verified over a 60s timer advance), `loading` false.
- **no cross-session leak**: deferred session-A answer landing after a switch to B never paints under B.
- **fresh budget after dep change**: `busy` flip mid-retry cancels the old timer (cleanup) and the new run accepts its first success.

Revert-to-buggy proof: with the fix stashed and only the test file present, 4/5 tests fail (the fifth asserts the unchanged keyed-session behavior). Restored, all 5 pass.

- `npx vitest run --project ui src/app/shell/hooks/use-context-breakdown.test.tsx` → 5/5 pass
- `npx tsc --noEmit` → clean
- `npx eslint` on both touched files → clean; prettier --check clean
- Sibling suites still green: `context-usage-panel.test.tsx` + `use-status-snapshot.test.ts` (14 passed), `statusbar-visibility.test.tsx` + `statusbar-context-menu.test.tsx` (12 passed)

## Coordination with related open PRs

- **#79175** (targets the older #78936 Catch-22) does **not** fix this race: it adds a separate `useContextUsageSeed` hook that fails open on fetch errors and publishes `context_max` unconditionally (including `0`), and it does not touch `use-context-breakdown.ts`. This PR is complementary — it fixes the fetch inside `useContextBreakdown` itself.
- Three open PRs (#79175, #87925, #89839) touch the same hook area, so merge conflicts are possible; happy to rebase.
- The issue also suggested gateway-readiness gating and refetch-on-busy-transition as alternatives. The bounded retry was chosen because it covers both failure modes client-side with no backend changes and no new state coupling; the existing `busy` dep already provides the refetch-on-turn boundary.