### PR TITLE
fix(agent): harden forced file-content redaction

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -825,10 +825,8 @@ def redact_sensitive_text(
     if not (force or _REDACT_ENABLED):
         return text
 
-    # file_read content shouldn't hit the source-code ENV/JSON false-positive
-    # paths either (it's config/data, not log lines).
-    if file_read:
-        code_file = True
+    # File content must also run the structured assignment/JSON/YAML passes;
+    # source-code callers keep the explicit code_file opt-out.
 
     # Known prefixes (sk-, ghp_, etc.) — gate on substring presence
     if _has_known_prefix_substring(text):
@@ -842,8 +840,16 @@ def redact_sensitive_text(
         text = _mask_control_split_tokens(text, _prefix_sub)
         text = _PREFIX_RE.sub(lambda m: _prefix_sub(m.group(1)), text)
 
-    # ENV assignments: OPENAI_API_KEY=***  (skip for code files — false positives)
-    if not code_file:
+    # ENV assignments: OPENAI_API_KEY=*** (skip only for non-file source code)
+    # File content must also run the structured assignment/JSON/YAML passes.
+    if file_read or not code_file:
+        def _mask_structured_value(value):
+            # The prefix pass already produced a safe file-content sentinel;
+            # keep it intact instead of replacing it with a reusable mask.
+            if file_read and value.startswith("«redacted:") and value.endswith("»"):
+                return value
+            return _mask_token_nonreusable(value) if file_read else _mask_token(value)
+
         if "=" in text:
             def _redact_env(m):
                 name, quote, value = m.group(1), m.group(2), m.group(3)
@@ -859,7 +865,7 @@ def redact_sensitive_text(
                 # embedded matching inside the helper.
                 if not _key_has_secret_keyword(name):
                     return m.group(0)
-                return f"{name}={quote}{_mask_token(value)}{quote}"
+                return f"{name}={quote}{_mask_structured_value(value)}{quote}"
             text = _ENV_ASSIGN_RE.sub(_redact_env, text)
             # Lowercase env names (``openai_key=…``). Skip URLs — the query
             # string may contain ``token=``/``key=`` params that are
@@ -894,7 +900,7 @@ def redact_sensitive_text(
                 # not a leaked secret value.
                 if _ENV_LOOKUP_VALUE_RE.match(value):
                     return m.group(0)
-                return f'{key}: "{_mask_token(value)}"'
+                return f'{key}: "{_mask_structured_value(value)}"'
             text = _JSON_FIELD_RE.sub(_redact_json, text)
 
         # Unquoted YAML / colon config: password: ***  (after JSON so quoted
@@ -913,7 +919,7 @@ def redact_sensitive_text(
                 # document text, not credentials (nearai/ironclaw#6129).
                 if not _key_has_secret_keyword(key):
                     return m.group(0)
-                return f"{key}{sep}{_mask_token(value)}"
+                return f"{key}{sep}{_mask_structured_value(value)}"
             text = _YAML_ASSIGN_RE.sub(_redact_yaml, text)
 
     # Authorization headers — _AUTH_HEADER_RE matches any scheme after

--- a/agent/redact.py
+++ b/agent/redact.py
@@ -902,6 +902,8 @@ def redact_sensitive_text(
             # keep it intact instead of replacing it with a reusable mask.
             if value.startswith("«redacted:") and value.endswith("»"):
                 return value
+            if re.fullmatch(r"[A-Za-z0-9_:-]{1,8}\.\.\.[A-Za-z0-9_-]{0,4}", value):
+                return value
             if code_file and not file_read and not _should_redact_code_structured_value(key, value):
                 return value
             return _mask_token_nonreusable(value) if file_read else _mask_token(value)

--- a/agent/redact.py
+++ b/agent/redact.py
@@ -902,7 +902,7 @@ def redact_sensitive_text(
             # keep it intact instead of replacing it with a reusable mask.
             if value.startswith("«redacted:") and value.endswith("»"):
                 return value
-            if re.fullmatch(r"[A-Za-z0-9_:-]{1,8}\.\.\.[A-Za-z0-9_-]{0,4}", value):
+            if code_file and re.fullmatch(r"[A-Za-z0-9_:-]{1,8}\.\.\.[A-Za-z0-9_-]{0,4}", value):
                 return value
             if code_file and not file_read and not _should_redact_code_structured_value(key, value):
                 return value

--- a/agent/redact.py
+++ b/agent/redact.py
@@ -155,11 +155,23 @@ _SECRET_ENV_NAMES = r"(?:API_?KEY|KEY|TOKEN|SECRET|PASSWORD|PASSWD|PASS|PW|CREDE
 _ENV_ASSIGN_RE = re.compile(
     rf"([A-Z0-9_]{{0,50}}{_SECRET_ENV_NAMES}[A-Z0-9_]{{0,50}})\s*=\s*(['\"]?)(\S+)\2",
 )
+# Quoted assignments need their own grammar: ``\S+`` stops at the first space
+# and also leaves an escaped quote's suffix exposed.  The escaped-character
+# branch consumes ``\\\"``/``\\'`` as one value character.
+_ENV_ASSIGN_QUOTED_RE = re.compile(
+    rf"([A-Z0-9_]{{0,50}}{_SECRET_ENV_NAMES}[A-Z0-9_]{{0,50}})\s*=\s*"
+    r"(['\"])((?:\\.|(?!\2)[^\r\n])*)\2",
+)
 # Lowercase env names: only underscore-boundary forms (``openai_key=…``,
 # ``FAL_KEY=…``, ``db_pw=…``) — NOT bare ``password=``/``token=``/``secret=``,
 # which appear in prose, URLs, and form bodies (issue #77484).
 _ENV_ASSIGN_LOWER_RE = re.compile(
     rf"([a-z0-9_]+(?:_|^)(?:key|pass|pw|token|secret|password|passwd|credential|auth)(?=[^a-z0-9_]|$))\s*=\s*(['\"]?)(\S+)\2",
+    re.IGNORECASE,
+)
+_ENV_ASSIGN_LOWER_QUOTED_RE = re.compile(
+    rf"([a-z0-9_]+(?:_|^)(?:key|pass|pw|token|secret|password|passwd|credential|auth)(?=[^a-z0-9_]|$))\s*=\s*"
+    r"(['\"])((?:\\.|(?!\2)[^\r\n])*)\2",
     re.IGNORECASE,
 )
 
@@ -225,6 +237,11 @@ _YAML_CFG_NAMES = r"(?:api[ _.\-]?key|token|secret|passwd|password|credential)"
 # leading ``[A-Za-z0-9_.\-]*`` stays backtrackable (see _CFG_DOTTED_RE note).
 _YAML_ASSIGN_RE = re.compile(
     rf"(^[ \t]*+[A-Za-z0-9_.\-]*{_YAML_CFG_NAMES}[A-Za-z0-9_.\-]*+)(:[ \t]*+)(?!['\"])([^\s&]++)",
+    re.IGNORECASE | re.MULTILINE,
+)
+_YAML_QUOTED_ASSIGN_RE = re.compile(
+    rf"(^[ \t]*+[A-Za-z0-9_.\-]*{_YAML_CFG_NAMES}[A-Za-z0-9_.\-]*+)(:[ \t]*+)"
+    r"(['\"])((?:\\.|(?!\3)[^\r\n])*)\3",
     re.IGNORECASE | re.MULTILINE,
 )
 
@@ -318,7 +335,7 @@ def _key_has_secret_keyword(key: str) -> bool:
 # JSON field patterns: "apiKey": "value", "token": "value", etc.
 _JSON_KEY_NAMES = r"(?:api_?[Kk]ey|token|secret|password|access_token|refresh_token|auth_token|bearer|secret_value|raw_secret|secret_input|key_material)"
 _JSON_FIELD_RE = re.compile(
-    rf'("{_JSON_KEY_NAMES}")\s*:\s*"([^"]+)"',
+    rf'("{_JSON_KEY_NAMES}")\s*:\s*"((?:\\.|[^"\\\r\n])+)"',
     re.IGNORECASE,
 )
 
@@ -470,7 +487,9 @@ _FORM_BODY_RE = re.compile(
 # smuggled as ``sk-abc\x1bdef…`` or ``ghp_abc\n123…`` escapes the contiguous
 # prefix regexes (issue #77484). Used by _mask_control_split_tokens.
 _CONTROL_CHARS_RE = re.compile(
-    r"[\x00-\x1f\x7f\u200b-\u200f\u2028-\u202f\u2060\ufeff]"
+    r"[\x00-\x1f\x7f-\x9f\u00ad\u061c\u180e\u200b-\u200f"
+    r"\u2028-\u202f\u2060-\u206f\ufeff\ufff9-\ufffb"
+    r"\U000e0001\U000e0020-\U000e007f]"
 )
 
 # Union of every _PREFIX_PATTERNS body class — a control-stripped match may
@@ -509,22 +528,17 @@ def _mask_control_split_tokens(text: str, mask_fn) -> str:
         body = m.group(1)
         start_orig = orig_idx[m.start(1)]
         end_orig = orig_idx[m.end(1) - 1] + 1
-        # If a fragment inside the span already matches _PREFIX_RE on its
-        # own AND the span crosses a LINE boundary (\n / \r), do NOT join.
-        # A complete token at end-of-line followed by a word line
-        # (``ghp_<token>\nbutton [ref=e3]``) joins into one stripped-copy
-        # match and the mask eats ``button``. Line structure is legitimate;
-        # the self-matching fragment is handled by the ordinary prefix pass
-        # (any remainder past the newline is left unmasked — accepted
-        # residual to preserve line structure).
-        # For NON-newline controls (ESC, ZWSP, ...) the join proceeds even
-        # when a fragment self-matches: those bytes never legitimately sit
-        # between a token and adjacent prose, and skipping there let the
-        # non-matching remainder of a split token leak
-        # (``sk-<head>\x1b<tail>`` masked only the head).
         span = text[start_orig:end_orig]
+        # A complete token followed by a new line of ordinary text must not
+        # be swallowed as one credential.  A split token, however, can have a
+        # self-matching prefix fragment before LF/CR; only join that case when
+        # the post-boundary fragment is long enough to be a token body.  This
+        # preserves UI/source lines such as ``token\nbutton [ref=e3]`` while
+        # closing the suffix-leak path for long split credentials.
         if ("\n" in span or "\r" in span) and _PREFIX_RE.search(span):
-            continue
+            after_boundary = re.split(r"[\n\r]", span, maxsplit=1)[1]
+            if len(after_boundary) < 10:
+                continue
         # Reject matches whose original span crosses a non-token char
         # (e.g. ``sk_abc…\nTAVILY_API_KEY=…`` — the ``=`` is not part of a
         # token body, so the regex matched across unrelated lines). Also
@@ -771,6 +785,41 @@ def _mask_token_nonreusable(token: str) -> str:
     return f"«redacted:{label}…»" if label else "«redacted-secret»"
 
 
+_SOURCE_SAFE_VALUE_RE = re.compile(
+    r"^(?:true|false|null|none|undefined|[+-]?\d+(?:\.\d+)?)$",
+    re.IGNORECASE,
+)
+_SOURCE_PLACEHOLDER_RE = re.compile(
+    r"(?:placeholder|example|dummy|fixture|test)",
+    re.IGNORECASE,
+)
+
+
+def _should_redact_code_structured_value(key: str, value: str) -> bool:
+    """Keep low-confidence source literals while masking real credentials.
+
+    ``code_file`` is a narrow false-positive control, not a secret-safety
+    bypass.  Numeric/boolean constants and explicit fixture placeholders are
+    ordinary source content; credential-shaped keys or opaque values remain
+    redacted even when the caller identifies the surrounding text as source.
+    """
+    normalized_key = re.sub(r"[^a-z0-9]", "", key.lower())
+    normalized_value = value.strip()
+    if _SOURCE_SAFE_VALUE_RE.fullmatch(normalized_value):
+        return False
+    if _SOURCE_PLACEHOLDER_RE.search(normalized_value) and len(value) < 80:
+        return False
+    strong_key = any(
+        marker in normalized_key
+        for marker in (
+            "apikey", "secret", "password", "passwd", "credential",
+            "privatekey", "accesstoken", "refreshtoken", "authtoken",
+            "bearer", "jwt", "clientsecret",
+        )
+    )
+    return strong_key or len(value) >= 12
+
+
 def redact_sensitive_text(
     text: str,
     *,
@@ -822,7 +871,9 @@ def redact_sensitive_text(
         text = str(text)
     if not text:
         return text
-    if not (force or _REDACT_ENABLED):
+    # File content is an agent-visible safety boundary.  It is always
+    # redacted, even when ordinary logging redaction was disabled globally.
+    if not (force or file_read or _REDACT_ENABLED):
         return text
 
     # File content must also run the structured assignment/JSON/YAML passes;
@@ -842,11 +893,16 @@ def redact_sensitive_text(
 
     # ENV assignments: OPENAI_API_KEY=*** (skip only for non-file source code)
     # File content must also run the structured assignment/JSON/YAML passes.
-    if file_read or not code_file:
-        def _mask_structured_value(value):
+    # Structured values are always inspected.  ``code_file`` only narrows the
+    # low-confidence values through _should_redact_code_structured_value; it
+    # never disables credential-shaped assignments or fields.
+    if text:
+        def _mask_structured_value(value, key=""):
             # The prefix pass already produced a safe file-content sentinel;
             # keep it intact instead of replacing it with a reusable mask.
-            if file_read and value.startswith("«redacted:") and value.endswith("»"):
+            if value.startswith("«redacted:") and value.endswith("»"):
+                return value
+            if code_file and not file_read and not _should_redact_code_structured_value(key, value):
                 return value
             return _mask_token_nonreusable(value) if file_read else _mask_token(value)
 
@@ -865,7 +921,13 @@ def redact_sensitive_text(
                 # embedded matching inside the helper.
                 if not _key_has_secret_keyword(name):
                     return m.group(0)
-                return f"{name}={quote}{_mask_structured_value(value)}{quote}"
+                return f"{name}={quote}{_mask_structured_value(value, name)}{quote}"
+            def _redact_env_quoted(m):
+                name, quote, value = m.group(1), m.group(2), m.group(3)
+                if _ENV_LOOKUP_VALUE_RE.match(value) or not _key_has_secret_keyword(name):
+                    return m.group(0)
+                return f"{name}={quote}{_mask_structured_value(value, name)}{quote}"
+            text = _ENV_ASSIGN_QUOTED_RE.sub(_redact_env_quoted, text)
             text = _ENV_ASSIGN_RE.sub(_redact_env, text)
             # Lowercase env names (``openai_key=…``). Skip URLs — the query
             # string may contain ``token=``/``key=`` params that are
@@ -874,6 +936,7 @@ def redact_sensitive_text(
             # case). The uppercase regex above is all-caps-only, so it never
             # matches URL params; the lowercase one would (issue #77484).
             if "://" not in text:
+                text = _ENV_ASSIGN_LOWER_QUOTED_RE.sub(_redact_env_quoted, text)
                 text = _ENV_ASSIGN_LOWER_RE.sub(_redact_env, text)
             # Lowercase/dotted config keys (issue #16413). Skip URLs entirely —
             # web-URL query params are intentionally passed through (see note
@@ -900,7 +963,7 @@ def redact_sensitive_text(
                 # not a leaked secret value.
                 if _ENV_LOOKUP_VALUE_RE.match(value):
                     return m.group(0)
-                return f'{key}: "{_mask_structured_value(value)}"'
+                return f'{key}: "{_mask_structured_value(value, key)}"'
             text = _JSON_FIELD_RE.sub(_redact_json, text)
 
         # Unquoted YAML / colon config: password: ***  (after JSON so quoted
@@ -919,7 +982,13 @@ def redact_sensitive_text(
                 # document text, not credentials (nearai/ironclaw#6129).
                 if not _key_has_secret_keyword(key):
                     return m.group(0)
-                return f"{key}{sep}{_mask_structured_value(value)}"
+                return f"{key}{sep}{_mask_structured_value(value, key)}"
+            def _redact_yaml_quoted(m):
+                key, sep, quote, value = m.groups()
+                if _ENV_LOOKUP_VALUE_RE.match(value) or not _key_has_secret_keyword(key):
+                    return m.group(0)
+                return f"{key}{sep}{quote}{_mask_structured_value(value, key)}{quote}"
+            text = _YAML_QUOTED_ASSIGN_RE.sub(_redact_yaml_quoted, text)
             text = _YAML_ASSIGN_RE.sub(_redact_yaml, text)
 
     # Authorization headers — _AUTH_HEADER_RE matches any scheme after

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -1051,3 +1051,20 @@ class TestMaskSecretControlStripping:
     def test_all_control_value_returns_empty_fallback(self):
         assert mask_secret("\n\x85\u200b") == ""
         assert mask_secret("\n\x85\u200b", empty="(not set)") == "(not set)"
+
+
+class TestForcedFileContentRedaction:
+    """File-content mode must cover opaque structured credential values."""
+
+    def test_file_read_redacts_opaque_assignment_and_nested_json(self):
+        assignment = "opaqueassignment123456789"
+        nested_json = "nestedjsonsecret987654321"
+        content = (
+            f"SERVICE_API_KEY={assignment}\n"
+            f'{{"credentials": {{"apiKey": "{nested_json}"}}}}'
+        )
+
+        result = redact_sensitive_text(content, force=True, file_read=True)
+
+        assert assignment not in result
+        assert nested_json not in result

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -1068,3 +1068,70 @@ class TestForcedFileContentRedaction:
 
         assert assignment not in result
         assert nested_json not in result
+
+    def test_file_read_forces_redaction_when_global_opt_out_is_set(self, monkeypatch):
+        monkeypatch.setattr("agent.redact._REDACT_ENABLED", False)
+        secret = "opaque-file-secret-123456789"
+
+        result = redact_sensitive_text(
+            f"SERVICE_API_KEY={secret}", file_read=True
+        )
+
+        assert secret not in result
+
+    def test_code_file_only_skips_source_like_values(self):
+        secret = "opaque-structured-secret-123456789"
+        content = (
+            "MAX_TOKENS=100\n"
+            f"SERVICE_API_KEY={secret}\n"
+            '{"apiKey": "test"}'
+        )
+
+        result = redact_sensitive_text(content, force=True, code_file=True)
+
+        assert "MAX_TOKENS=100" in result
+        assert secret not in result
+        assert '"apiKey": "test"' in result
+
+    def test_terminal_output_redacts_structured_values_for_unknown_commands(self):
+        from agent.redact import redact_terminal_output
+
+        assignment = "opaque-terminal-secret-123456789"
+        nested = "opaque-json-secret-987654321"
+        output = (
+            f"SERVICE_API_KEY={assignment}\n"
+            f"password: {nested}\n"
+            f'{{"apiKey": "{nested}"}}'
+        )
+
+        result = redact_terminal_output(output, "python app.py", force=True)
+
+        assert assignment not in result
+        assert nested not in result
+
+    def test_control_and_format_characters_cannot_split_prefix_tokens(self):
+        from agent.redact import redact_sensitive_text
+
+        token = "sk-" + "a" * 30
+        for separator in ("\n", "\r", "\x85", "\u2061", "\u2064"):
+            split = token[:15] + separator + token[15:]
+            result = redact_sensitive_text(split, force=True, file_read=True)
+            assert "a" * 15 not in result, repr(separator)
+
+    def test_quoted_yaml_env_and_escaped_json_values_are_redacted(self):
+        import json
+
+        yaml_secret = "quoted-yaml-secret-123456789"
+        env_secret = "quoted env secret 123456789"
+        json_secret = 'escaped"json-secret-987654321'
+        content = (
+            f'password: "{yaml_secret}"\n'
+            f'SERVICE_API_KEY="{env_secret}"\n'
+            + json.dumps({"credentials": {"apiKey": json_secret}})
+        )
+
+        result = redact_sensitive_text(content, force=True, file_read=True)
+
+        assert yaml_secret not in result
+        assert env_secret not in result
+        assert json_secret not in result

--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -1033,3 +1033,37 @@ class TestSSHConfigWriteGateSingleQuery:
             f"required kwargs {missing}; it would raise TypeError instead "
             f"of showing an approval prompt"
         )
+
+
+class TestForcedFileContentRedaction:
+    """All file-reader content must use the forced structured redaction path."""
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_unrecognized_reader_content_is_redacted_as_file_content(self, mock_get):
+        assignment = "opaqueassignment123456789"
+        nested_json = "nestedjsonsecret987654321"
+        split_prefix = "sk-" + "a" * 8 + "\x1b" + "b" * 24
+        content = (
+            f" 1|SERVICE_API_KEY={assignment}\n"
+            f' 2|{{"credentials": {{"apiKey": "{nested_json}"}}}}\n'
+            f" 3|CONTROL_TOKEN={split_prefix}\n"
+        )
+        mock_ops = MagicMock()
+        result_obj = MagicMock()
+        result_obj.content = content
+        result_obj.to_dict.return_value = {
+            "content": content,
+            "total_lines": 3,
+            "file_size": len(content),
+        }
+        mock_ops.read_file.return_value = result_obj
+        mock_get.return_value = mock_ops
+
+        from tools.file_tools import read_file_tool
+
+        result = json.loads(read_file_tool("/tmp/indirect-reader-output.txt"))
+        returned = result["content"]
+
+        assert assignment not in returned
+        assert nested_json not in returned
+        assert "b" * 24 not in returned


### PR DESCRIPTION
## What does this PR do?

Hardens forced file-content redaction without changing ordinary source-code literals. File reads retain the safety boundary even when general log redaction is disabled, redact quoted ENV/YAML and escaped JSON credential fields, and reject control/format-character token splitting. Canonical already-masked token markers remain stable instead of being degraded to an uninformative `***` value.

## Related work and ownership

No public issue was filed for the full forced-file boundary class.

This branch overlaps two earlier implementation PRs in narrower parser seams:

- #53741 (`r266-tech`) identified and implemented quote-aware YAML scalar redaction, including single-quote doubling, unterminated values, and CRLF line bounds.
- #69196 (`fangliquanflq`) identified and implemented escape-aware JSON credential-field redaction.

Those findings predate this PR and must retain explicit credit in any final restack/landing commit. #97215's distinct ownership is the fail-closed `file_read` boundary, structured-value policy across file and terminal output, canonical non-reusable sentinel preservation, and the broader control/format-split defense.

Complementary work, not superseded here:

- #81121: ANSI CSI and same-line control-split handling.
- #96615: ordinary-value preservation for ambiguous token/key labels.
- #31003: write-side rejection of redacted placeholders.
- #72807: configured literal-secret redaction.
- #80923: bare WhatsApp identifier redaction.
- #66403: literal-star configuration documentation.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests
- [ ] ♻️ Refactor
- [ ] 🎯 New skill

## Reproduction

1. Set `agent.redact._REDACT_ENABLED = False` in an isolated test.
2. Call `redact_sensitive_text("SERVICE_API_KEY=opaque-file-secret-123456789", file_read=True)`.
3. Before this patch the opaque value can remain in agent-visible file output; after this patch the value is replaced by a non-reusable redaction marker. The regression also covers quoted ENV/YAML, escaped JSON, and control/format-character splits.

## Changes Made

- `agent/redact.py` — forces the file-read boundary, handles structured quoted values and control-split tokens, narrows `code_file` exemptions, and preserves canonical masked values.
- `tests/agent/test_redact.py` — adds behavioral coverage for global opt-out, structured formats, terminal output, control/format separators, and source-like negative controls.
- `tests/tools/test_file_tools.py` — exercises the public file-read integration boundary.

## How to Test

```bash
scripts/run_tests.sh \
  tests/agent/test_redact.py \
  tests/tools/test_file_tools.py \
  tests/tools/test_terminal_output_transform_hook.py \
  -q

python -m ruff check \
  agent/redact.py \
  tests/agent/test_redact.py \
  tests/tools/test_file_tools.py

git diff --check
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs and recorded the overlapping/complementary work above
- [x] My PR contains only changes related to this security class
- [ ] I've run the full repository suite — the historical exact-head focused matrix and hosted workflows are recorded below; a current-main restack still requires fresh proof
- [x] I've added tests
- [x] I've tested on Windows 11 / Python 3.11.15

### Documentation & Housekeeping

- [x] User documentation: N/A; no public command or configuration change
- [x] `cli-config.yaml.example`: N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A
- [x] Cross-platform impact considered; the changed logic is platform-independent string/regex handling
- [x] Tool schemas: N/A

## Verification

Historical candidate head: `8fae61503233fb9cc2239408fe5a20fb49124a0a`

- Focused local matrix: `110 passed`
- Ruff: pass
- `git diff --check`: pass
- Hosted CI: https://github.com/NousResearch/hermes-agent/actions/runs/33180666779 — success
- Docker: https://github.com/NousResearch/hermes-agent/actions/runs/33180666087 — success
- Nix: https://github.com/NousResearch/hermes-agent/actions/runs/33180666246 — success
- Production line census: `agent/redact.py` 1,504 lines, below the 2,000-line ceiling

These receipts prove the historical head only. Current `main` has moved substantially; GitHub presently reports the branch mergeable, but no fresh current-base CI/Docker/Nix matrix has run, so the old receipts are not being represented as current-main acceptance.

## Publication gate

Before merge, rematerialize the scoped change as one commit directly on current `main` with author `Axl Ibiza, MBA <andrexibiza@gmail.com>`, preserve explicit credit for #53741 and #69196, then reacquire fresh exact-head CI, Docker, and Nix success. No public readiness or supersession claim should be made before that proof exists.

## Campaign methodology

Source pin `f751a8c5467c41500e505d90cb0eb8b70929080f`; historical remediation base `d0351e32309bd68a1012c302157947b955323fca`. The class passed five analyst lanes, five mutually blind witness lanes, five adjudicators, TDD implementation/fix lanes, and exact-head review. Machine evidence is preserved in the campaign manifest and patch SHA receipts.

## Screenshots / Logs

```text
110 passed
All checks passed!
git diff --check: clean
```
