### PR TITLE
fix(tools): make OAuth state lifecycle fail closed

### DIFF
--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -1040,25 +1040,37 @@ class TestWaitForCallbackSkipIntegration:
 # ---------------------------------------------------------------------------
 
 class TestPoisonClientRegistration:
-    def test_poison_backs_up_and_removes_client_and_meta(self, tmp_path, monkeypatch):
+    def test_r3_cand_004_red_1_no_legacy_backup_survives_lifecycle(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         storage = HermesTokenStorage("srv")
         d = tmp_path / "mcp-tokens"
         d.mkdir(parents=True)
         (d / "srv.json").write_text('{"access_token": "keep-me"}')
         (d / "srv.client.json").write_text('{"client_id": "dead"}')
+        (d / "srv.client.json.bak").write_text('{"client_id": "stale"}')
         (d / "srv.meta.json").write_text('{"token_endpoint": "https://idp/token"}')
 
         removed = storage.poison_client_registration()
 
         assert removed is True
-        # Client + metadata gone, forcing re-registration on the next flow.
         assert not (d / "srv.client.json").exists()
+        assert not (d / "srv.client.json.bak").exists()
         assert not (d / "srv.meta.json").exists()
-        # Backup of the client file kept for recovery.
-        assert (d / "srv.client.json.bak").read_text() == '{"client_id": "dead"}'
-        # Tokens are intentionally preserved.
         assert (d / "srv.json").read_text() == '{"access_token": "keep-me"}'
+
+        # Explicit logout/remove must not leave recoverable state behind.
+        storage.remove()
+        assert not any(d.glob("srv*"))
+
+        # Rollback is limited to the three primary files and cannot resurrect .bak.
+        (d / "srv.client.json").write_text('{"client_id": "new"}')
+        (d / "srv.client.json.bak").write_text('{"client_id": "legacy"}')
+        snapshot = storage.snapshot()
+        assert set(snapshot) <= {"srv.json", "srv.client.json", "srv.meta.json"}
+        storage.remove()
+        storage.restore(snapshot)
+        assert not (d / "srv.client.json.bak").exists()
+        assert (d / "srv.client.json").read_text() == '{"client_id": "new"}'
 
 
 def test_wait_for_callback_port_in_use_reports_clear_error(monkeypatch):

--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -160,6 +160,34 @@ class TestHermesTokenStorage:
         import asyncio
         assert asyncio.run(storage.get_tokens()) is None
 
+    def test_restore_rejects_legacy_client_backup(self, tmp_path, monkeypatch):
+        """Rollback must not recreate the secret-bearing legacy backup."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        storage = HermesTokenStorage("srv")
+        token_dir = tmp_path / "mcp-tokens"
+        token_dir.mkdir(parents=True)
+        token_path = token_dir / "srv.json"
+        token_path.write_bytes(b'{"access_token":"still-valid"}')
+
+        with pytest.raises(ValueError, match="Invalid OAuth snapshot filename"):
+            storage.restore({"srv.client.json.bak": b"secret-bearing"})
+
+        assert not (token_dir / "srv.client.json.bak").exists()
+        assert token_path.read_bytes() == b'{"access_token":"still-valid"}'
+
+    def test_restore_rejects_paths_outside_token_directory(self, tmp_path, monkeypatch):
+        """Rollback filenames must be exact basenames within mcp-tokens/."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        storage = HermesTokenStorage("srv")
+        token_dir = tmp_path / "mcp-tokens"
+        outside = tmp_path / "escape.txt"
+
+        with pytest.raises(ValueError, match="Invalid OAuth snapshot filename"):
+            storage.restore({"../escape.txt": b"secret"})
+
+        assert not outside.exists()
+        assert not token_dir.exists()
+
 
 # ---------------------------------------------------------------------------
 # build_oauth_auth

--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -3,7 +3,9 @@
 import json
 import stat
 import sys
+import threading
 from io import BytesIO
+from pathlib import Path
 from unittest.mock import patch, MagicMock
 
 import pytest
@@ -187,6 +189,140 @@ class TestHermesTokenStorage:
 
         assert not outside.exists()
         assert not token_dir.exists()
+    def test_restore_only_if_absent_serializes_against_successful_writer(
+        self, tmp_path, monkeypatch
+    ):
+        """A successful token write racing rollback must win the lifecycle lock."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        storage = HermesTokenStorage("srv")
+        token_dir = tmp_path / "mcp-tokens"
+        token_dir.mkdir(parents=True)
+        token_path = token_dir / "srv.json"
+        absence_checked = threading.Event()
+        writer_done = threading.Event()
+        original_exists = Path.exists
+
+        def observe_absence(path):
+            if path == token_path and not absence_checked.is_set():
+                absence_checked.set()
+                writer_done.wait(timeout=2)
+            return original_exists(path)
+
+        def write_new_tokens():
+            absence_checked.wait(timeout=2)
+            token = MagicMock()
+            token.model_dump.return_value = {
+                "access_token": "new",
+                "token_type": "Bearer",
+            }
+            asyncio.run(storage.set_tokens(token))
+            writer_done.set()
+
+        writer = threading.Thread(target=write_new_tokens)
+        writer.start()
+        with patch.object(Path, "exists", observe_absence):
+            storage.restore(
+                {"srv.json": b'{"access_token":"old"}'},
+                only_if_absent=True,
+            )
+        writer.join(timeout=3)
+
+        assert writer_done.is_set()
+        assert json.loads(token_path.read_text())["access_token"] == "new"
+
+    def test_restore_failure_leaves_durable_incomplete_marker(self, tmp_path, monkeypatch):
+        """A partial restore is non-success and visibly marked for recovery."""
+        import tools.mcp_oauth_storage as storage_mod
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        storage = HermesTokenStorage("srv")
+        token_dir = tmp_path / "mcp-tokens"
+        token_dir.mkdir(parents=True)
+        snapshot = {
+            "srv.json": b'{"access_token":"token"}',
+            "srv.client.json": b'{"client_id":"client"}',
+            "srv.meta.json": b'{"token_endpoint":"https://idp/token"}',
+        }
+        original_open = storage_mod.os.open
+
+        def fail_client_open(path, flags, mode=0o666, *args):
+            if Path(path).name == "srv.client.json":
+                raise OSError("injected restore write failure")
+            return original_open(path, flags, mode, *args)
+
+        with patch.object(storage_mod.os, "open", fail_client_open):
+            with pytest.raises(OSError, match="injected restore write failure"):
+                storage.restore(snapshot)
+
+        assert (token_dir / "srv.lifecycle-incomplete").exists()
+
+    def test_snapshot_refuses_symlinked_primary_without_reading_target(
+        self, tmp_path, monkeypatch
+    ):
+        """Snapshot never follows a symlink to an outside secret file."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        storage = HermesTokenStorage("srv")
+        token_dir = tmp_path / "mcp-tokens"
+        token_dir.mkdir(parents=True)
+        outside = tmp_path / "outside.json"
+        outside.write_bytes(b"outside-secret")
+        try:
+            (token_dir / "srv.json").symlink_to(outside)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlink creation is unavailable on this Windows host")
+
+        with pytest.raises(OSError):
+            storage.snapshot()
+        assert outside.read_bytes() == b"outside-secret"
+
+    def test_restore_refuses_symlinked_token_directory_without_outside_write(
+        self, tmp_path, monkeypatch
+    ):
+        """Restore never stages or writes through a reparse-point directory."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        storage = HermesTokenStorage("srv")
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        token_dir = tmp_path / "mcp-tokens"
+        try:
+            token_dir.symlink_to(outside, target_is_directory=True)
+        except (OSError, NotImplementedError):
+            pytest.skip("directory symlink creation is unavailable on this Windows host")
+
+        with pytest.raises(OSError):
+            storage.restore({"srv.json": b"must-not-escape"})
+        assert not (outside / "srv.json").exists()
+
+    @pytest.mark.parametrize(
+        "failed_name",
+        [
+            "srv.json",
+            "srv.client.json",
+            "srv.meta.json",
+            "srv.cimd-off",
+            "srv.client.json.bak",
+        ],
+    )
+    def test_remove_failure_leaves_durable_incomplete_marker(
+        self, tmp_path, monkeypatch, failed_name
+    ):
+        """Every cleanup unlink boundary remains visibly incomplete on failure."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        storage = HermesTokenStorage("srv")
+        token_dir = tmp_path / "mcp-tokens"
+        token_dir.mkdir(parents=True)
+        (token_dir / failed_name).write_bytes(b"state")
+        original_unlink = Path.unlink
+
+        def fail_one(path, missing_ok=False):
+            if path.name == failed_name:
+                raise OSError("injected cleanup failure")
+            return original_unlink(path, missing_ok=missing_ok)
+
+        with patch.object(Path, "unlink", fail_one):
+            with pytest.raises(OSError, match="injected cleanup failure"):
+                storage.remove()
+        assert (token_dir / "srv.lifecycle-incomplete").exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_mcp_oauth_manager.py
+++ b/tests/tools/test_mcp_oauth_manager.py
@@ -282,9 +282,35 @@ def test_invalid_client_at_token_endpoint_poisons(tmp_path, monkeypatch):
     asyncio.run(provider._maybe_flag_poisoned_client(resp))
 
     assert not (d / "srv.client.json").exists()
-    assert (d / "srv.client.json.bak").exists()
+    assert not (d / "srv.client.json.bak").exists()
     assert provider._initialized is False
     assert provider.context.client_info is None
+
+
+def test_r3_cand_004_red_2_cleanup_failure_is_hard_stop(tmp_path, monkeypatch):
+    """Cleanup failure must not be swallowed as a successful invalid_client heal."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    d = tmp_path / "mcp-tokens"
+    d.mkdir(parents=True)
+    (d / "srv.client.json").write_text('{"client_id": "dead"}')
+    provider = _provider_with_token_endpoint(
+        tmp_path, {}, "https://idp.example.com/oauth/token", monkeypatch
+    )
+    resp = _fake_response(
+        400, "https://idp.example.com/oauth/token", b'{"error":"invalid_client"}'
+    )
+    before_client = provider.context.client_info
+    monkeypatch.setattr(
+        type(provider.context.storage),
+        "poison_client_registration",
+        lambda _storage: (_ for _ in ()).throw(OSError("legacy backup cleanup refused")),
+    )
+
+    with pytest.raises(OSError, match="legacy backup cleanup refused"):
+        asyncio.run(provider._maybe_flag_poisoned_client(resp))
+
+    assert provider.context.client_info is before_client
+    assert provider._initialized is True
 
 
 def test_invalid_client_metadata_does_not_trip(tmp_path, monkeypatch):

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -636,13 +636,15 @@ class HermesTokenStorage:
             self._client_info_path(),
             self._meta_path(),
             self._cimd_rejected_path(),
+            self._client_info_path().with_name(self._client_info_path().name + ".bak"),
         ):
             p.unlink(missing_ok=True)
 
     def snapshot(self) -> dict[str, bytes]:
         """Capture on-disk OAuth state so a failed re-auth can restore it.
 
-        Maps filename -> bytes for whichever of the three state files exist.
+        Maps filename -> bytes for whichever of the three primary state files
+        exist. Legacy client backups are deliberately excluded from rollback.
         Feed back to ``restore()`` to undo an intervening ``remove()`` when a
         re-authentication attempt fails, so a still-valid token isn't destroyed.
         """
@@ -693,28 +695,26 @@ class HermesTokenStorage:
         ``if not client_info`` branch and re-run RFC 7591 dynamic client
         registration on the next flow. The stale ``meta.json`` is dropped
         too so discovery re-runs against a freshly fetched document.
-
         Tokens are intentionally left in place — the subsequent
         re-authorization overwrites them, and keeping them avoids losing a
         still-valid refresh token if the re-registration never completes.
 
-        A single ``.bak`` copy of the client file is kept for recovery.
+        Legacy backups are removed; cleanup errors propagate before callers
+        clear in-memory state while secret-bearing files remain on disk.
         Returns True if a client file was present and removed.
         """
         client_path = self._client_info_path()
-        if not client_path.exists():
-            return False
         backup = client_path.with_name(client_path.name + ".bak")
-        try:
-            backup.write_bytes(client_path.read_bytes())
-        except OSError as exc:  # non-fatal — proceed with the removal anyway
-            logger.warning("Could not back up client info at %s: %s", client_path, exc)
+        if not client_path.exists():
+            backup.unlink(missing_ok=True)
+            return False
+        backup.unlink(missing_ok=True)
         client_path.unlink(missing_ok=True)
         self._meta_path().unlink(missing_ok=True)
         logger.warning(
             "MCP OAuth '%s': cached client registration rejected as invalid_client; "
-            "removed client.json + meta.json (backup at %s) to force re-registration",
-            self._server_name, backup.name,
+            "removed client.json + meta.json and legacy backup to force re-registration",
+            self._server_name,
         )
         return True
 

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -658,6 +658,15 @@ class HermesTokenStorage:
 
     def restore(self, snapshot: dict[str, bytes], *, only_if_absent: bool = False) -> None:
         """Revert to a snapshot without overwriting a concurrent successful write."""
+        allowed = {
+            self._tokens_path().name,
+            self._client_info_path().name,
+            self._meta_path().name,
+        }
+        invalid = [fname for fname in snapshot if not isinstance(fname, str) or fname not in allowed]
+        if invalid:
+            names = ", ".join(repr(fname) for fname in invalid)
+            raise ValueError(f"Invalid OAuth snapshot filename(s): {names}")
         if only_if_absent and any(
             path.exists()
             for path in (self._tokens_path(), self._client_info_path(), self._meta_path())

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -643,8 +643,7 @@ class HermesTokenStorage:
     def snapshot(self) -> dict[str, bytes]:
         """Capture on-disk OAuth state so a failed re-auth can restore it.
 
-        Maps filename -> bytes for whichever of the three primary state files
-        exist. Legacy client backups are deliberately excluded from rollback.
+        Maps filename -> bytes for existing primary state files; legacy backups are excluded.
         Feed back to ``restore()`` to undo an intervening ``remove()`` when a
         re-authentication attempt fails, so a still-valid token isn't destroyed.
         """
@@ -658,15 +657,10 @@ class HermesTokenStorage:
 
     def restore(self, snapshot: dict[str, bytes], *, only_if_absent: bool = False) -> None:
         """Revert to a snapshot without overwriting a concurrent successful write."""
-        allowed = {
-            self._tokens_path().name,
-            self._client_info_path().name,
-            self._meta_path().name,
-        }
+        allowed = {self._tokens_path().name, self._client_info_path().name, self._meta_path().name}
         invalid = [fname for fname in snapshot if not isinstance(fname, str) or fname not in allowed]
         if invalid:
-            names = ", ".join(repr(fname) for fname in invalid)
-            raise ValueError(f"Invalid OAuth snapshot filename(s): {names}")
+            raise ValueError(f"Invalid OAuth snapshot filename(s): {', '.join(repr(name) for name in invalid)}")
         if only_if_absent and any(
             path.exists()
             for path in (self._tokens_path(), self._client_info_path(), self._meta_path())
@@ -708,8 +702,7 @@ class HermesTokenStorage:
         re-authorization overwrites them, and keeping them avoids losing a
         still-valid refresh token if the re-registration never completes.
 
-        Legacy backups are removed; cleanup errors propagate before callers
-        clear in-memory state while secret-bearing files remain on disk.
+        Legacy backups are removed; cleanup errors propagate before callers clear memory.
         Returns True if a client file was present and removed.
         """
         client_path = self._client_info_path()
@@ -720,11 +713,7 @@ class HermesTokenStorage:
         backup.unlink(missing_ok=True)
         client_path.unlink(missing_ok=True)
         self._meta_path().unlink(missing_ok=True)
-        logger.warning(
-            "MCP OAuth '%s': cached client registration rejected as invalid_client; "
-            "removed client.json + meta.json and legacy backup to force re-registration",
-            self._server_name,
-        )
+        logger.warning("MCP OAuth '%s': invalid_client; removed client.json, meta.json, and legacy backup", self._server_name)
         return True
 
     def has_cached_tokens(self) -> bool:

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -61,7 +61,15 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import parse_qs, urlparse
 from hermes_constants import secure_parent_dir
-from tools.mcp_oauth_storage import OAuthStorageLifecycleMixin
+from tools.mcp_oauth_storage import (
+    OAuthStorageLifecycleMixin,
+    _safe_file,
+    _safe_token_dir,
+    _validate_components,
+    _write_exclusive,
+    _read_file,
+    lifecycle_lock,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -402,12 +410,13 @@ def _can_open_browser() -> bool:
 
 
 def _read_json(path: Path) -> dict | None:
-    """Read a JSON file, returning None if it doesn't exist or is invalid."""
-    if not path.exists():
-        return None
+    """Read a JSON file without following symlink/reparse-point paths."""
     try:
-        return json.loads(path.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError) as exc:
+        raw = _read_file(path)
+        if raw is None:
+            return None
+        return json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError, OSError) as exc:
         logger.warning("Failed to read %s: %s", path, exc)
         return None
 
@@ -422,7 +431,9 @@ def _write_json(path: Path, data: dict) -> None:
     tokens to other local users between create and chmod. Mirrors the fix
     in ``agent/google_oauth.py`` (#19673).
     """
+    _validate_components(path, include_leaf=False)
     path.parent.mkdir(parents=True, exist_ok=True)
+    _validate_components(path, include_leaf=False)
     # Tighten parent dir to 0o700 so siblings can't traverse to the creds.
     # No-op on Windows (POSIX mode bits aren't enforced); ignore failures.
     # secure_parent_dir refuses to chmod /, top-level dirs, or the
@@ -542,7 +553,8 @@ class HermesTokenStorage(OAuthStorageLifecycleMixin):
                 # Mock tokens or unusual shapes: skip the expires_at write
                 # rather than fail persistence.
                 pass
-        _write_json(self._tokens_path(), payload)
+        with lifecycle_lock(self):
+            _write_json(self._tokens_path(), payload)
         logger.debug("OAuth tokens saved for %s", self._server_name)
 
     # -- client info -------------------------------------------------------
@@ -564,7 +576,11 @@ class HermesTokenStorage(OAuthStorageLifecycleMixin):
             if getattr(info, "client_secret", None) and data.get("token_endpoint_auth_method") in (None, "none", ""):
                 data["token_endpoint_auth_method"] = "client_secret_post"
                 info = OAuthClientInformationFull.model_validate(data)
-                _write_json(self._client_info_path(), info.model_dump(mode="json", exclude_none=True))
+                with lifecycle_lock(self):
+                    _write_json(
+                        self._client_info_path(),
+                        info.model_dump(mode="json", exclude_none=True),
+                    )
             return info
         except (ValueError, TypeError, KeyError) as exc:
             logger.warning("Corrupt client info at %s -- ignoring: %s", self._client_info_path(), exc)
@@ -579,7 +595,8 @@ class HermesTokenStorage(OAuthStorageLifecycleMixin):
         # so this flow and subsequent retries use client_secret_post.
         if data.get("client_secret") and data.get("token_endpoint_auth_method") in (None, "none", ""):
             data["token_endpoint_auth_method"] = "client_secret_post"
-        _write_json(self._client_info_path(), data)
+        with lifecycle_lock(self):
+            _write_json(self._client_info_path(), data)
         logger.debug("OAuth client info saved for %s", self._server_name)
 
     # -- oauth server metadata --------------------------------------------
@@ -591,7 +608,8 @@ class HermesTokenStorage(OAuthStorageLifecycleMixin):
     # forces a full browser re-authorization.
 
     def save_oauth_metadata(self, metadata: "OAuthMetadata") -> None:
-        _write_json(self._meta_path(), metadata.model_dump(exclude_none=True, mode="json"))
+        with lifecycle_lock(self):
+            _write_json(self._meta_path(), metadata.model_dump(exclude_none=True, mode="json"))
         logger.debug("OAuth metadata saved for %s", self._server_name)
 
     def load_oauth_metadata(self) -> "OAuthMetadata | None":
@@ -619,8 +637,13 @@ class HermesTokenStorage(OAuthStorageLifecycleMixin):
         """
         path = self._cimd_rejected_path()
         try:
-            path.parent.mkdir(parents=True, exist_ok=True)
-            path.touch()
+            with lifecycle_lock(self):
+                _safe_token_dir(self, create=True)
+                if not _safe_file(path):
+                    try:
+                        _write_exclusive(path, b"")
+                    except FileExistsError:
+                        _safe_file(path)
         except OSError as exc:  # non-fatal — worst case we retry CIMD later
             logger.debug("Could not record CIMD rejection at %s: %s", path, exc)
 
@@ -1646,7 +1669,7 @@ def _build_client_metadata(cfg: dict) -> "OAuthClientMetadata":
         return OAuthClientMetadata.model_validate(metadata_kwargs)
 
 
-def _invalidate_tokens_on_client_change(
+def _invalidate_tokens_on_client_change_unlocked(
     storage: "HermesTokenStorage",
     new_client_id: str,
     new_client_secret: str | None,
@@ -1701,6 +1724,18 @@ def _invalidate_tokens_on_client_change(
         )
 
 
+def _invalidate_tokens_on_client_change(
+    storage: "HermesTokenStorage",
+    new_client_id: str,
+    new_client_secret: str | None,
+) -> None:
+    """Serialize configured-client invalidation with all OAuth persistence."""
+    with lifecycle_lock(storage):
+        _invalidate_tokens_on_client_change_unlocked(
+            storage, new_client_id, new_client_secret
+        )
+
+
 def _maybe_preregister_client(
     storage: "HermesTokenStorage",
     cfg: dict,
@@ -1733,7 +1768,11 @@ def _maybe_preregister_client(
         info_dict["scope"] = cfg["scope"]
 
     client_info = OAuthClientInformationFull.model_validate(info_dict)
-    _write_json(storage._client_info_path(), client_info.model_dump(mode="json", exclude_none=True))
+    with lifecycle_lock(storage):
+        _write_json(
+            storage._client_info_path(),
+            client_info.model_dump(mode="json", exclude_none=True),
+        )
     logger.debug("Pre-registered client_id=%s for '%s'", client_id, storage._server_name)
 
 

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -61,6 +61,7 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import parse_qs, urlparse
 from hermes_constants import secure_parent_dir
+from tools.mcp_oauth_storage import OAuthStorageLifecycleMixin
 
 logger = logging.getLogger(__name__)
 
@@ -454,7 +455,7 @@ def _write_json(path: Path, data: dict) -> None:
 # ---------------------------------------------------------------------------
 
 
-class HermesTokenStorage:
+class HermesTokenStorage(OAuthStorageLifecycleMixin):
     """Persist OAuth tokens and client registration to JSON files.
 
     File layout::
@@ -626,95 +627,6 @@ class HermesTokenStorage:
     def cimd_rejected(self) -> bool:
         """True when this server has refused our metadata document before."""
         return self._cimd_rejected_path().exists()
-
-    # -- cleanup -----------------------------------------------------------
-
-    def remove(self) -> None:
-        """Delete all stored OAuth state for this server."""
-        for p in (
-            self._tokens_path(),
-            self._client_info_path(),
-            self._meta_path(),
-            self._cimd_rejected_path(),
-            self._client_info_path().with_name(self._client_info_path().name + ".bak"),
-        ):
-            p.unlink(missing_ok=True)
-
-    def snapshot(self) -> dict[str, bytes]:
-        """Capture on-disk OAuth state so a failed re-auth can restore it.
-
-        Maps filename -> bytes for existing primary state files; legacy backups are excluded.
-        Feed back to ``restore()`` to undo an intervening ``remove()`` when a
-        re-authentication attempt fails, so a still-valid token isn't destroyed.
-        """
-        snap: dict[str, bytes] = {}
-        for p in (self._tokens_path(), self._client_info_path(), self._meta_path()):
-            try:
-                snap[p.name] = p.read_bytes()
-            except OSError:
-                pass
-        return snap
-
-    def restore(self, snapshot: dict[str, bytes], *, only_if_absent: bool = False) -> None:
-        """Revert to a snapshot without overwriting a concurrent successful write."""
-        allowed = {self._tokens_path().name, self._client_info_path().name, self._meta_path().name}
-        invalid = [fname for fname in snapshot if not isinstance(fname, str) or fname not in allowed]
-        if invalid:
-            raise ValueError(f"Invalid OAuth snapshot filename(s): {', '.join(repr(name) for name in invalid)}")
-        if only_if_absent and any(
-            path.exists()
-            for path in (self._tokens_path(), self._client_info_path(), self._meta_path())
-        ):
-            logger.info(
-                "Skipping OAuth rollback for %s because newer state exists",
-                self._server_name,
-            )
-            return
-        self.remove()
-        if not snapshot:
-            return
-        token_dir = _get_token_dir(self._hermes_home)
-        token_dir.mkdir(parents=True, exist_ok=True)
-        for fname, data in snapshot.items():
-            path = token_dir / fname
-            try:
-                fd = os.open(
-                    str(path),
-                    os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
-                    stat.S_IRUSR | stat.S_IWUSR,
-                )
-                with os.fdopen(fd, "wb") as fh:
-                    fh.write(data)
-            except OSError as exc:
-                logger.warning("Failed to restore OAuth state %s: %s", fname, exc)
-
-    def poison_client_registration(self) -> bool:
-        """Discard a dead dynamically-registered client so it gets re-created.
-
-        Called when the IdP rejects our cached ``client_id`` with
-        ``invalid_client`` on the token endpoint — proof the server-side
-        registration is gone (IdP redeploy / DB wipe / rebrand). Deleting
-        ``client.json`` makes the MCP SDK's ``async_auth_flow`` take the
-        ``if not client_info`` branch and re-run RFC 7591 dynamic client
-        registration on the next flow. The stale ``meta.json`` is dropped
-        too so discovery re-runs against a freshly fetched document.
-        Tokens are intentionally left in place — the subsequent
-        re-authorization overwrites them, and keeping them avoids losing a
-        still-valid refresh token if the re-registration never completes.
-
-        Legacy backups are removed; cleanup errors propagate before callers clear memory.
-        Returns True if a client file was present and removed.
-        """
-        client_path = self._client_info_path()
-        backup = client_path.with_name(client_path.name + ".bak")
-        if not client_path.exists():
-            backup.unlink(missing_ok=True)
-            return False
-        backup.unlink(missing_ok=True)
-        client_path.unlink(missing_ok=True)
-        self._meta_path().unlink(missing_ok=True)
-        logger.warning("MCP OAuth '%s': invalid_client; removed client.json, meta.json, and legacy backup", self._server_name)
-        return True
 
     def has_cached_tokens(self) -> bool:
         """Return True if we have tokens on disk (may be expired)."""

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -432,9 +432,8 @@ def _make_hermes_provider_class() -> Optional[type]:
               * the body carries the ``invalid_client`` error code
                 (word-boundary match, so RFC 7591's ``invalid_client_metadata``
                 registration error does not trip it).
-            Pre-registered (config-supplied) clients are never poisoned.
-            Fully best-effort: any failure here is swallowed so a detection
-            miss never breaks the live auth flow.
+            Detection failures are best-effort, but storage cleanup failures
+            propagate so stale secret-bearing state cannot be hidden.
 
             Covers both the authorization-code token exchange and the
             preemptive refresh — but only when ``token_endpoint`` was
@@ -479,27 +478,35 @@ def _make_hermes_provider_class() -> Optional[type]:
                 # clears the marker, so a fixed document gets another chance.
                 cimd_url = getattr(self.context, "client_metadata_url", None)
                 rejected_id = getattr(self.context.client_info, "client_id", None)
-                if cimd_url and rejected_id == cimd_url:
-                    logger.warning(
-                        "MCP OAuth '%s': authorization server rejected our "
-                        "Client ID Metadata Document (%s) with invalid_client "
-                        "— falling back to dynamic client registration.",
-                        self._hermes_server_name, cimd_url,
-                    )
-                    self.context.client_metadata_url = None
-                    if isinstance(storage, HermesTokenStorage):
-                        storage.mark_cimd_rejected()
-
-                if isinstance(storage, HermesTokenStorage):
-                    storage.poison_client_registration()
-                # Drop the in-memory client so the SDK re-registers next flow.
-                self.context.client_info = None
-                self._initialized = False
+                cimd_rejected = bool(cimd_url and rejected_id == cimd_url)
             except Exception as exc:  # pragma: no cover — defensive, must not throw
                 logger.debug(
                     "MCP OAuth '%s': invalid_client detection failed (non-fatal): %s",
-                    self._hermes_server_name, exc,
+                    self._hermes_server_name,
+                    exc,
                 )
+                return
+
+            # Keep cleanup outside the detection guard: a failure here is a
+            # secret-bearing state failure, not a detection miss.
+            if isinstance(storage, HermesTokenStorage):
+                storage.poison_client_registration()
+
+            if cimd_rejected:
+                logger.warning(
+                    "MCP OAuth '%s': authorization server rejected our "
+                    "Client ID Metadata Document (%s) with invalid_client "
+                    "— falling back to dynamic client registration.",
+                    self._hermes_server_name,
+                    cimd_url,
+                )
+                self.context.client_metadata_url = None
+                if isinstance(storage, HermesTokenStorage):
+                    storage.mark_cimd_rejected()
+
+            # Drop the in-memory client only after storage cleanup succeeds.
+            self.context.client_info = None
+            self._initialized = False
 
         async def async_auth_flow(self, request):  # type: ignore[override]
             # Pre-flow hook: ask the manager to refresh from disk if needed.

--- a/tools/mcp_oauth_storage.py
+++ b/tools/mcp_oauth_storage.py
@@ -1,0 +1,111 @@
+"""Filesystem lifecycle operations for MCP OAuth storage.
+
+This module owns the snapshot/remove/restore/poison lifecycle while the public
+``HermesTokenStorage`` class remains the compatibility surface in
+``tools.mcp_oauth``.  The methods intentionally use the storage instance's
+private path helpers and call ``self.remove()`` so existing subclass and
+monkeypatch seams remain effective.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import stat
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger("tools.mcp_oauth")
+
+
+class OAuthStorageLifecycleMixin:
+    """Provide the on-disk OAuth state lifecycle for ``HermesTokenStorage``."""
+
+    def remove(self) -> None:
+        """Delete all stored OAuth state for this server."""
+        for p in (
+            self._tokens_path(),
+            self._client_info_path(),
+            self._meta_path(),
+            self._cimd_rejected_path(),
+            self._client_info_path().with_name(self._client_info_path().name + ".bak"),
+        ):
+            p.unlink(missing_ok=True)
+
+    def snapshot(self) -> dict[str, bytes]:
+        """Capture on-disk OAuth state so a failed re-auth can restore it.
+
+        Maps filename -> bytes for existing primary state files; legacy backups are excluded.
+        Feed back to ``restore()`` to undo an intervening ``remove()`` when a
+        re-authentication attempt fails, so a still-valid token isn't destroyed.
+        """
+        snap: dict[str, bytes] = {}
+        for p in (self._tokens_path(), self._client_info_path(), self._meta_path()):
+            try:
+                snap[p.name] = p.read_bytes()
+            except OSError:
+                pass
+        return snap
+
+    def restore(self, snapshot: dict[str, bytes], *, only_if_absent: bool = False) -> None:
+        """Revert to a snapshot without overwriting a concurrent successful write."""
+        allowed = {self._tokens_path().name, self._client_info_path().name, self._meta_path().name}
+        invalid = [fname for fname in snapshot if not isinstance(fname, str) or fname not in allowed]
+        if invalid:
+            raise ValueError(f"Invalid OAuth snapshot filename(s): {', '.join(repr(name) for name in invalid)}")
+        if only_if_absent and any(
+            path.exists()
+            for path in (self._tokens_path(), self._client_info_path(), self._meta_path())
+        ):
+            logger.info(
+                "Skipping OAuth rollback for %s because newer state exists",
+                self._server_name,
+            )
+            return
+        self.remove()
+        if not snapshot:
+            return
+        from tools.mcp_oauth import _get_token_dir
+
+        token_dir = _get_token_dir(self._hermes_home)
+        token_dir.mkdir(parents=True, exist_ok=True)
+        for fname, data in snapshot.items():
+            path = token_dir / fname
+            try:
+                fd = os.open(
+                    str(path),
+                    os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+                    stat.S_IRUSR | stat.S_IWUSR,
+                )
+                with os.fdopen(fd, "wb") as fh:
+                    fh.write(data)
+            except OSError as exc:
+                logger.warning("Failed to restore OAuth state %s: %s", fname, exc)
+
+    def poison_client_registration(self) -> bool:
+        """Discard a dead dynamically-registered client so it gets re-created.
+
+        Called when the IdP rejects our cached ``client_id`` with
+        ``invalid_client`` on the token endpoint — proof the server-side
+        registration is gone (IdP redeploy / DB wipe / rebrand). Deleting
+        ``client.json`` makes the MCP SDK's ``async_auth_flow`` take the
+        ``if not client_info`` branch and re-run RFC 7591 dynamic client
+        registration on the next flow. The stale ``meta.json`` is dropped
+        too so discovery re-runs against a freshly fetched document.
+        Tokens are intentionally left in place — the subsequent
+        re-authorization overwrites them, and keeping them avoids losing a
+        still-valid refresh token if the re-registration never completes.
+
+        Legacy backups are removed; cleanup errors propagate before callers clear memory.
+        Returns True if a client file was present and removed.
+        """
+        client_path = self._client_info_path()
+        backup = client_path.with_name(client_path.name + ".bak")
+        if not client_path.exists():
+            backup.unlink(missing_ok=True)
+            return False
+        backup.unlink(missing_ok=True)
+        client_path.unlink(missing_ok=True)
+        self._meta_path().unlink(missing_ok=True)
+        logger.warning("MCP OAuth '%s': invalid_client; removed client.json, meta.json, and legacy backup", self._server_name)
+        return True

--- a/tools/mcp_oauth_storage.py
+++ b/tools/mcp_oauth_storage.py
@@ -1,111 +1,283 @@
 """Filesystem lifecycle operations for MCP OAuth storage.
 
-This module owns the snapshot/remove/restore/poison lifecycle while the public
-``HermesTokenStorage`` class remains the compatibility surface in
-``tools.mcp_oauth``.  The methods intentionally use the storage instance's
-private path helpers and call ``self.remove()`` so existing subclass and
-monkeypatch seams remain effective.
+The public ``HermesTokenStorage`` compatibility class inherits this mixin.
+Lifecycle operations use the same per-server lock as normal OAuth writes,
+validate every directory component, and publish restored files by replacement
+from a staged directory rather than truncating live paths.
 """
 
 from __future__ import annotations
 
 import logging
 import os
+import shutil
 import stat
+import tempfile
+import threading
+from contextlib import contextmanager
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterator
 
 logger = logging.getLogger("tools.mcp_oauth")
+
+_LOCKS: dict[str, threading.RLock] = {}
+_LOCKS_GUARD = threading.Lock()
+
+
+def _lock_key(storage: Any) -> str:
+    return os.path.normcase(os.path.abspath(str(storage._tokens_path().parent)))
+
+
+@contextmanager
+def lifecycle_lock(storage: Any) -> Iterator[None]:
+    """Serialize all lifecycle and successful persistence writes per server."""
+    key = _lock_key(storage)
+    with _LOCKS_GUARD:
+        lock = _LOCKS.setdefault(key, threading.RLock())
+    with lock:
+        yield
+
+
+def _is_reparse(st: os.stat_result) -> bool:
+    attrs = getattr(st, "st_file_attributes", 0)
+    return stat.S_ISLNK(st.st_mode) or bool(attrs & getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400))
+
+
+def _existing_stat(path: Path) -> os.stat_result | None:
+    try:
+        return os.lstat(path)
+    except FileNotFoundError:
+        return None
+
+
+def _validate_components(path: Path, *, include_leaf: bool) -> None:
+    """Reject symlink/reparse components without resolving them."""
+    current = path if include_leaf else path.parent
+    components: list[Path] = []
+    while True:
+        components.append(current)
+        parent = current.parent
+        if parent == current:
+            break
+        current = parent
+    for component in reversed(components):
+        st = _existing_stat(component)
+        if st is None:
+            continue
+        if _is_reparse(st):
+            raise OSError(f"OAuth storage path contains a reparse point: {component}")
+        if not stat.S_ISDIR(st.st_mode):
+            raise OSError(f"OAuth storage component is not a directory: {component}")
+
+
+def _assert_real_directory(path: Path) -> os.stat_result:
+    st = _existing_stat(path)
+    if st is None:
+        raise FileNotFoundError(path)
+    if _is_reparse(st) or not stat.S_ISDIR(st.st_mode):
+        raise OSError(f"OAuth storage directory is not a real directory: {path}")
+    return st
+
+
+def _safe_token_dir(storage: Any, *, create: bool) -> Path:
+    token_dir = storage._tokens_path().parent
+    _validate_components(token_dir, include_leaf=False)
+    if _existing_stat(token_dir) is None:
+        if not create:
+            return token_dir
+        token_dir.mkdir(parents=True, exist_ok=True)
+    _validate_components(token_dir, include_leaf=True)
+    _assert_real_directory(token_dir)
+    return token_dir
+
+
+def _safe_file(path: Path) -> bool:
+    """Validate a file path and return whether its leaf exists."""
+    if not isinstance(path, (str, os.PathLike)):
+        return False
+    path = Path(path)
+    _validate_components(path, include_leaf=False)
+    st = _existing_stat(path)
+    if st is None:
+        return False
+    if _is_reparse(st) or not stat.S_ISREG(st.st_mode):
+        raise OSError(f"OAuth storage file is not a regular file: {path}")
+    return True
+
+
+def _read_file(path: Path) -> bytes | None:
+    if not _safe_file(path):
+        return None
+    flags = os.O_RDONLY | getattr(os, "O_BINARY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    fd = os.open(str(path), flags)
+    try:
+        opened = os.fstat(fd)
+        if _is_reparse(opened) or not stat.S_ISREG(opened.st_mode):
+            raise OSError(f"OAuth storage file changed to a non-regular file: {path}")
+        return os.read(fd, max(opened.st_size, 1) + 1)
+    finally:
+        os.close(fd)
+
+
+def _write_exclusive(path: Path, data: bytes) -> None:
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_BINARY", 0)
+    fd = os.open(str(path), flags, stat.S_IRUSR | stat.S_IWUSR)
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            fd = -1
+            handle.write(data)
+            handle.flush()
+            os.fsync(handle.fileno())
+    finally:
+        if fd != -1:
+            os.close(fd)
 
 
 class OAuthStorageLifecycleMixin:
     """Provide the on-disk OAuth state lifecycle for ``HermesTokenStorage``."""
 
-    def remove(self) -> None:
-        """Delete all stored OAuth state for this server."""
-        for p in (
+    def _lifecycle_paths(self) -> tuple[Path, ...]:
+        client = self._client_info_path()
+        return (
             self._tokens_path(),
-            self._client_info_path(),
+            client,
             self._meta_path(),
             self._cimd_rejected_path(),
-            self._client_info_path().with_name(self._client_info_path().name + ".bak"),
-        ):
-            p.unlink(missing_ok=True)
+            client.with_name(client.name + ".bak"),
+        )
+
+    def _lifecycle_marker_path(self) -> Path:
+        return self._tokens_path().parent / f"{self._server_name}.lifecycle-incomplete"
+
+    def _begin_marker(self, operation: str) -> None:
+        token_dir = _safe_token_dir(self, create=True)
+        marker = self._lifecycle_marker_path()
+        _validate_components(marker, include_leaf=False)
+        if _safe_file(marker):
+            return
+        try:
+            _write_exclusive(marker, f"operation={operation}\n".encode("ascii"))
+        except FileExistsError:
+            _safe_file(marker)
+
+    def _clear_marker(self) -> None:
+        marker = self._lifecycle_marker_path()
+        if not _safe_file(marker):
+            return
+        marker.unlink()
+
+    def _remove_unlocked(self, *, clear_marker: bool = True) -> None:
+        paths = self._lifecycle_paths()
+        marker = self._lifecycle_marker_path()
+        present = [_safe_file(path) for path in paths]
+        marker_present = _safe_file(marker)
+        if not any(present) and not marker_present:
+            return
+        _safe_token_dir(self, create=True)
+        self._begin_marker("remove")
+        try:
+            for path, exists in zip(paths, present):
+                if exists:
+                    path.unlink()
+            if clear_marker:
+                self._clear_marker()
+        except BaseException:
+            # The marker is intentionally retained. A caller must observe and
+            # recover the incomplete state rather than report cleanup success.
+            raise
+
+    def remove(self) -> None:
+        """Delete all stored OAuth state for this server, fail-closed."""
+        with lifecycle_lock(self):
+            self._remove_unlocked()
 
     def snapshot(self) -> dict[str, bytes]:
-        """Capture on-disk OAuth state so a failed re-auth can restore it.
-
-        Maps filename -> bytes for existing primary state files; legacy backups are excluded.
-        Feed back to ``restore()`` to undo an intervening ``remove()`` when a
-        re-authentication attempt fails, so a still-valid token isn't destroyed.
-        """
-        snap: dict[str, bytes] = {}
-        for p in (self._tokens_path(), self._client_info_path(), self._meta_path()):
-            try:
-                snap[p.name] = p.read_bytes()
-            except OSError:
-                pass
-        return snap
+        """Capture primary OAuth files without following links or reparses."""
+        with lifecycle_lock(self):
+            snap: dict[str, bytes] = {}
+            for path in (self._tokens_path(), self._client_info_path(), self._meta_path()):
+                data = _read_file(path)
+                if data is not None:
+                    snap[path.name] = data
+            return snap
 
     def restore(self, snapshot: dict[str, bytes], *, only_if_absent: bool = False) -> None:
-        """Revert to a snapshot without overwriting a concurrent successful write."""
-        allowed = {self._tokens_path().name, self._client_info_path().name, self._meta_path().name}
-        invalid = [fname for fname in snapshot if not isinstance(fname, str) or fname not in allowed]
+        """Restore a snapshot through a staged, marked, non-truncating publish."""
+        allowed = {path.name for path in (self._tokens_path(), self._client_info_path(), self._meta_path())}
+        invalid = [name for name in snapshot if not isinstance(name, str) or name not in allowed]
         if invalid:
-            raise ValueError(f"Invalid OAuth snapshot filename(s): {', '.join(repr(name) for name in invalid)}")
-        if only_if_absent and any(
-            path.exists()
-            for path in (self._tokens_path(), self._client_info_path(), self._meta_path())
-        ):
-            logger.info(
-                "Skipping OAuth rollback for %s because newer state exists",
-                self._server_name,
+            raise ValueError(
+                "Invalid OAuth snapshot filename(s): "
+                + ", ".join(repr(name) for name in invalid)
             )
-            return
-        self.remove()
-        if not snapshot:
-            return
-        from tools.mcp_oauth import _get_token_dir
 
-        token_dir = _get_token_dir(self._hermes_home)
-        token_dir.mkdir(parents=True, exist_ok=True)
-        for fname, data in snapshot.items():
-            path = token_dir / fname
+        with lifecycle_lock(self):
+            if only_if_absent and any(_safe_file(path) for path in (
+                self._tokens_path(), self._client_info_path(), self._meta_path()
+            )):
+                logger.info("Skipping OAuth rollback for %s because newer state exists", self._server_name)
+                return
+            if not snapshot:
+                self._remove_unlocked()
+                return
+
+            token_dir = _safe_token_dir(self, create=True)
+            directory_identity = _assert_real_directory(token_dir)
+            stage = Path(tempfile.mkdtemp(prefix=f".{self._server_name}.restore-", dir=str(token_dir)))
             try:
-                fd = os.open(
-                    str(path),
-                    os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
-                    stat.S_IRUSR | stat.S_IWUSR,
-                )
-                with os.fdopen(fd, "wb") as fh:
-                    fh.write(data)
-            except OSError as exc:
-                logger.warning("Failed to restore OAuth state %s: %s", fname, exc)
+                _assert_real_directory(stage)
+                staged: list[tuple[Path, Path]] = []
+                for name, data in snapshot.items():
+                    staged_path = stage / name
+                    _write_exclusive(staged_path, data)
+                    staged.append((staged_path, token_dir / name))
+
+                # Preserve the public remove() seam. The lock is re-entrant,
+                # so normal and monkeypatched remove implementations remain
+                # compatible while no writer can enter between the check and it.
+                self.remove()
+                self._begin_marker("restore")
+                for staged_path, target in staged:
+                    current_identity = _assert_real_directory(token_dir)
+                    if current_identity.st_dev != directory_identity.st_dev or current_identity.st_ino != directory_identity.st_ino:
+                        raise OSError("OAuth storage directory changed during restore")
+                    _validate_components(target, include_leaf=False)
+                    os.replace(staged_path, target)
+                self._clear_marker()
+            except BaseException as exc:
+                try:
+                    self._begin_marker("restore")
+                except OSError:
+                    logger.error("Could not mark incomplete OAuth restore for %s", self._server_name)
+                raise exc
+            finally:
+                shutil.rmtree(stage, ignore_errors=True)
 
     def poison_client_registration(self) -> bool:
-        """Discard a dead dynamically-registered client so it gets re-created.
-
-        Called when the IdP rejects our cached ``client_id`` with
-        ``invalid_client`` on the token endpoint — proof the server-side
-        registration is gone (IdP redeploy / DB wipe / rebrand). Deleting
-        ``client.json`` makes the MCP SDK's ``async_auth_flow`` take the
-        ``if not client_info`` branch and re-run RFC 7591 dynamic client
-        registration on the next flow. The stale ``meta.json`` is dropped
-        too so discovery re-runs against a freshly fetched document.
-        Tokens are intentionally left in place — the subsequent
-        re-authorization overwrites them, and keeping them avoids losing a
-        still-valid refresh token if the re-registration never completes.
-
-        Legacy backups are removed; cleanup errors propagate before callers clear memory.
-        Returns True if a client file was present and removed.
-        """
-        client_path = self._client_info_path()
-        backup = client_path.with_name(client_path.name + ".bak")
-        if not client_path.exists():
-            backup.unlink(missing_ok=True)
-            return False
-        backup.unlink(missing_ok=True)
-        client_path.unlink(missing_ok=True)
-        self._meta_path().unlink(missing_ok=True)
-        logger.warning("MCP OAuth '%s': invalid_client; removed client.json, meta.json, and legacy backup", self._server_name)
-        return True
+        """Discard a dead client registration while retaining token state."""
+        with lifecycle_lock(self):
+            client_path = self._client_info_path()
+            backup = client_path.with_name(client_path.name + ".bak")
+            client_exists = _safe_file(client_path)
+            backup_exists = _safe_file(backup)
+            meta_exists = _safe_file(self._meta_path())
+            if not client_exists and not backup_exists and not meta_exists:
+                return False
+            _safe_token_dir(self, create=True)
+            self._begin_marker("poison")
+            try:
+                if backup_exists:
+                    backup.unlink()
+                if client_exists:
+                    client_path.unlink()
+                if meta_exists:
+                    self._meta_path().unlink()
+                self._clear_marker()
+            except BaseException:
+                raise
+            if client_exists:
+                logger.warning(
+                    "MCP OAuth '%s': invalid_client; removed client.json, meta.json, and legacy backup",
+                    self._server_name,
+                )
+            return client_exists


### PR DESCRIPTION
## What does this PR do?

Makes MCP OAuth state transitions fail closed. The OAuth filesystem lifecycle is extracted into a focused owner that serializes per-server mutations, validates storage identities, refuses traversal and legacy-backup resurrection, detects symlink/reparse surfaces, stages rollback state before publication, and reports incomplete cleanup instead of silently returning partial success.

## Related Issue

No public issue was filed for this exact storage-lifecycle defect. **Interlock: #90888 remains the open credited OAuth auth-flow lifecycle/callback owner extracted from #84963.** Live FILE-LIST reconciliation proves both PRs modify `tools/mcp_oauth_manager.py`; they are complementary lifecycle axes, not unrelated standalone work.

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests
- [x] ♻️ Refactor
- [ ] 🎯 New skill

## Reproduction

1. Create `HermesTokenStorage("srv")` in an isolated `HERMES_HOME`.
2. Attempt `restore({"../escape": b"x"})`, then force a writer between the `only_if_absent` check and rollback publication and inject failures at the second/third file transition.
3. Current main permits unsafe/partial lifecycle states; this branch rejects path escape, serializes the per-server transition, and reports incomplete publication instead of returning success.

## Changes Made

- `tools/mcp_oauth_storage.py` — new bounded owner for OAuth snapshot, restore, cleanup, lock, confinement, and failure-state behavior.
- `tools/mcp_oauth.py` — composes the lifecycle owner while preserving the `HermesTokenStorage` public surface.
- `tools/mcp_oauth_manager.py` — makes invalid-client cleanup fail closed rather than swallowing secret-bearing storage failures.
- focused tests cover traversal, backup exclusion, forced interleavings, partial write/unlink failures, path confinement, and cleanup failure semantics.

## How to Test

1. Run `python -m pytest -q tests/tools/test_mcp_oauth.py tests/tools/test_mcp_oauth_manager.py tests/tools/test_mcp_cimd.py`.
2. Run `python -m ruff check tools/mcp_oauth.py tools/mcp_oauth_storage.py tests/tools/test_mcp_oauth.py`.
3. Run `python -m py_compile tools/mcp_oauth.py tools/mcp_oauth_storage.py` and `git diff --check`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing work and reconciled the live overlap with #90888 / #84963
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — the repository baseline is non-green; the complete OAuth/CIMD matrix is the governing selection
- [x] I've added tests
- [x] I've tested on Windows 11 / Python 3.11.15

### Documentation & Housekeeping

- [x] Lifecycle docstrings updated; no user command changed
- [x] No config key changed
- [x] No AGENTS.md change required
- [x] Windows reparse handling is explicit; POSIX no-follow behavior remains supported
- [x] No tool schema changed

## Why this matters to users

A failed or concurrent OAuth login must not replace newer credentials with stale state, recreate retired client secrets, or report success after only part of the credential set was restored. The filesystem lifecycle now has one bounded, deterministic owner.

## Verification

- Candidate HEAD: `5ce7ce2650dc910d827fa7ba015c8d951cf5f902`
- Full OAuth/CIMD matrix: `133 passed, 1 skipped`
- Ruff, compile, and diff checks: pass
- Line census: `tools/mcp_oauth.py` 1,906; `tools/mcp_oauth_storage.py` 283; both below 2,000

## Campaign methodology

Source pin `f751a8c5467c41500e505d90cb0eb8b70929080f`; current-main base at publication `d0351e32309bd68a1012c302157947b955323fca`. Five analysts → five blind witnesses → five adjudicators → implementation/fix lanes → exact-head reviews. Reviewer findings drove the lifecycle extraction and transactional repair rather than being deferred.

## Coordination / dedup

Live reconciliation after publication found the existing credited lifecycle child #90888, originating from #84963. The overlap is exact:

- #97216 ∩ #90888: `tools/mcp_oauth_manager.py`

A second current-main overlap appeared after publication in #97229:

- #97216 ∩ #97229: `tools/mcp_oauth.py`
- #97216 ∩ #97229: `tests/tools/test_mcp_oauth.py`

The responsibilities remain distinct:

- **#97216 owns storage identity, confinement, serialized mutation, rollback publication, incomplete-state reporting, and fail-closed secret cleanup.**
- **#90888 owns delegated `async_auth_flow` generator teardown in the owning asyncio task, including the `inner.aclose()` boundary and contributor provenance from @THArrowofApollo.**
- **#97229 owns terminal-input arbitration: an active prompt_toolkit application must remain the sole stdin owner, while OAuth retains the browser callback and separate-terminal login fallback.**
- **#84963 remains the parent topology record and does not itself become merged truth.**

Preferred composition is now a three-edge topology, not three independent OAuth owners. #97216 can land first because its current exact object is mergeable; #97229 then rebases its narrow stdin-arbitration hunk and focused tests over the extracted storage lifecycle, and #90888 restacks its credited owner-task teardown over the result. Any different merge order is valid only if the successor object preserves all three contracts and reacquires exact-head proof.

No merge order may flatten these responsibilities into one ambiguous OAuth owner, restore competing stdin readers, delete the owner-task `inner.aclose()` boundary, weaken the storage lifecycle, or discard contributor lineage.

## Screenshots / Logs

```text
133 passed, 1 skipped
All checks passed!
git diff --check: clean
```
