### PR TITLE
fix(agent): block shell re-entry in command-token helpers

### DIFF
--- a/agent/command_token_source.py
+++ b/agent/command_token_source.py
@@ -27,6 +27,12 @@ Output contract: print ONLY the token on stdout, either bare or as JSON with
 an ``access_token`` field (``expires_in`` is honoured when present) — the
 shape OAuth 2.0 token endpoints and the helpers above already emit.
 
+Command execution: ``key_cmd`` is an argv-style command line. Hermes parses it
+with ``shlex`` and invokes the resulting argument vector with shell execution
+disabled. Shell operators and expansion syntax are rejected rather than
+reinterpreted, so shell-only helpers must be migrated to an executable plus
+explicit arguments.
+
 Precedence: an explicit ``--api-key`` still wins (the one-off recovery escape
 hatch); otherwise ``key_cmd`` is preferred over a static ``api_key`` /
 ``key_env`` on the same entry.
@@ -36,6 +42,7 @@ from __future__ import annotations
 
 import json
 import logging
+import shlex
 import subprocess
 import threading
 import time
@@ -63,12 +70,53 @@ class CommandTokenError(RuntimeError):
     """A ``key_cmd`` failed to produce a usable token."""
 
 
+_SHELL_SYNTAX = frozenset(
+    (";", "&", "|", "<", ">", "$", "(", ")", "`", "\r", "\n")
+)
+
+
+def _parse_command_argv(command: str, label: str) -> list[str]:
+    """Parse an argv-style command without granting it shell semantics."""
+    in_single_quote = False
+    in_double_quote = False
+    escaped = False
+    for char in command:
+        if escaped:
+            escaped = False
+            continue
+        if char == "\\" and not in_single_quote:
+            escaped = True
+            continue
+        if char == "'" and not in_double_quote:
+            in_single_quote = not in_single_quote
+            continue
+        if char == '"' and not in_single_quote:
+            in_double_quote = not in_double_quote
+            continue
+        if not in_single_quote and not in_double_quote and char in _SHELL_SYNTAX:
+            raise CommandTokenError(
+                f"key_cmd for provider {label!r} contains unsupported shell syntax; "
+                "use an argv-style command without shell operators"
+            )
+
+    try:
+        argv = shlex.split(command, posix=True)
+    except ValueError as exc:
+        raise CommandTokenError(
+            f"key_cmd for provider {label!r} could not be parsed as argv"
+        ) from exc
+    if not argv:
+        raise CommandTokenError(f"key_cmd for provider {label!r} is empty")
+    return argv
+
+
 def _mint(command: str, label: str) -> tuple[str, Optional[float]]:
-    """Run *command*, returning ``(token, ttl_seconds_or_None)``."""
+    """Run *command* as argv, returning ``(token, ttl_seconds_or_None)``."""
+    argv = _parse_command_argv(command, label)
     try:
         completed = subprocess.run(
-            command,
-            shell=True,
+            argv,
+            shell=False,
             capture_output=True,
             text=True,
             timeout=_MINT_TIMEOUT_SECONDS,

--- a/agent/command_token_source.py
+++ b/agent/command_token_source.py
@@ -108,29 +108,31 @@ _SHELL_EXECUTABLES = frozenset(
 )
 
 
+_PROCESS_DISPATCH_WRAPPERS = frozenset({
+    "doas", "doas.exe", "env", "env.exe", "nice", "nice.exe",
+    "nohup", "nohup.exe", "runuser", "runuser.exe", "script", "script.exe",
+    "setsid", "setsid.exe", "sudo", "sudo.exe", "timeout", "timeout.exe",
+    "wsl", "wsl.exe", "xargs", "xargs.exe",
+})
+
+
 def _command_basename(value: str) -> str:
     return value.replace("\\", "/").rsplit("/", 1)[-1].casefold()
 
 
 def _reject_shell_launcher(argv: list[str], label: str) -> None:
-    """Keep a child shell from restoring shell semantics behind shell=False."""
+    """Keep child shells and dispatch wrappers behind the trusted boundary."""
     executable = _command_basename(argv[0])
+    if executable in _PROCESS_DISPATCH_WRAPPERS:
+        raise CommandTokenError(
+            f"key_cmd for provider {label!r} cannot launch a process wrapper; "
+            "use the credential executable directly"
+        )
     if executable in _SHELL_EXECUTABLES:
         raise CommandTokenError(
             f"key_cmd for provider {label!r} cannot launch a shell; "
             "use an executable plus explicit arguments"
         )
-    if executable == "env":
-        # ``env VAR=value bash -c ...`` is a common indirect shell launcher.
-        for argument in argv[1:]:
-            if argument.startswith("-") or "=" in argument:
-                continue
-            if _command_basename(argument) in _SHELL_EXECUTABLES:
-                raise CommandTokenError(
-                    f"key_cmd for provider {label!r} cannot launch a shell; "
-                    "use an executable plus explicit arguments"
-                )
-            break
 
 
 def _has_unquoted_shell_syntax_posix(command: str) -> bool:

--- a/agent/command_token_source.py
+++ b/agent/command_token_source.py
@@ -28,10 +28,12 @@ an ``access_token`` field (``expires_in`` is honoured when present) — the
 shape OAuth 2.0 token endpoints and the helpers above already emit.
 
 Command execution: ``key_cmd`` is an argv-style command line. Hermes parses it
-with ``shlex`` and invokes the resulting argument vector with shell execution
-disabled. Shell operators and expansion syntax are rejected rather than
-reinterpreted, so shell-only helpers must be migrated to an executable plus
-explicit arguments.
+with the platform's command-line rules and invokes the resulting argument vector
+with shell execution disabled. Shell operators and expansion syntax are rejected
+rather than reinterpreted, and shell interpreters/command-string modes are not
+valid helpers, so shell-only helpers must be migrated to an executable plus
+explicit arguments. On Windows, use native command-line quoting: backslashes
+are literal path separators except when they precede a double quote.
 
 Precedence: an explicit ``--api-key`` still wins (the one-off recovery escape
 hatch); otherwise ``key_cmd`` is preferred over a static ``api_key`` /
@@ -44,6 +46,7 @@ import json
 import logging
 import shlex
 import subprocess
+import sys
 import threading
 import time
 from typing import Callable, Optional
@@ -73,10 +76,64 @@ class CommandTokenError(RuntimeError):
 _SHELL_SYNTAX = frozenset(
     (";", "&", "|", "<", ">", "$", "(", ")", "`", "\r", "\n")
 )
+_SHELL_EXECUTABLES = frozenset(
+    {
+        "bash",
+        "bash.exe",
+        "busybox.exe",
+        "command.com",
+        "csh",
+        "csh.exe",
+        "dash",
+        "dash.exe",
+        "fish",
+        "fish.exe",
+        "ksh",
+        "ksh.exe",
+        "pwsh",
+        "pwsh.exe",
+        "pwsh-preview.exe",
+        "powershell",
+        "powershell.exe",
+        "powershell_ise.exe",
+        "sh",
+        "sh.exe",
+        "tcsh",
+        "tcsh.exe",
+        "zsh",
+        "zsh.exe",
+        "cmd",
+        "cmd.exe",
+    }
+)
 
 
-def _parse_command_argv(command: str, label: str) -> list[str]:
-    """Parse an argv-style command without granting it shell semantics."""
+def _command_basename(value: str) -> str:
+    return value.replace("\\", "/").rsplit("/", 1)[-1].casefold()
+
+
+def _reject_shell_launcher(argv: list[str], label: str) -> None:
+    """Keep a child shell from restoring shell semantics behind shell=False."""
+    executable = _command_basename(argv[0])
+    if executable in _SHELL_EXECUTABLES:
+        raise CommandTokenError(
+            f"key_cmd for provider {label!r} cannot launch a shell; "
+            "use an executable plus explicit arguments"
+        )
+    if executable == "env":
+        # ``env VAR=value bash -c ...`` is a common indirect shell launcher.
+        for argument in argv[1:]:
+            if argument.startswith("-") or "=" in argument:
+                continue
+            if _command_basename(argument) in _SHELL_EXECUTABLES:
+                raise CommandTokenError(
+                    f"key_cmd for provider {label!r} cannot launch a shell; "
+                    "use an executable plus explicit arguments"
+                )
+            break
+
+
+def _has_unquoted_shell_syntax_posix(command: str) -> bool:
     in_single_quote = False
     in_double_quote = False
     escaped = False
@@ -94,19 +151,76 @@ def _parse_command_argv(command: str, label: str) -> list[str]:
             in_double_quote = not in_double_quote
             continue
         if not in_single_quote and not in_double_quote and char in _SHELL_SYNTAX:
-            raise CommandTokenError(
-                f"key_cmd for provider {label!r} contains unsupported shell syntax; "
-                "use an argv-style command without shell operators"
-            )
+            return True
+    return False
 
+
+def _has_unquoted_shell_syntax_windows(command: str) -> bool:
+    """Check operators using the quote rules used by Windows argv parsing."""
+    in_double_quote = False
+    backslashes = 0
+    for char in command:
+        if char == "\\":
+            backslashes += 1
+            continue
+        if char == '"':
+            # An odd run of backslashes escapes the quote; an even run leaves
+            # half the backslashes and toggles the native quote state.
+            if backslashes % 2 == 0:
+                in_double_quote = not in_double_quote
+            backslashes = 0
+            continue
+        backslashes = 0
+        if not in_double_quote and char in _SHELL_SYNTAX:
+            return True
+    return False
+
+
+def _parse_windows_command_argv(command: str) -> list[str]:
+    """Parse *command* with Windows' ``CommandLineToArgvW`` contract."""
+    import ctypes
+
+    argc = ctypes.c_int()
+    command_line_to_argv = ctypes.windll.shell32.CommandLineToArgvW
+    command_line_to_argv.argtypes = [
+        ctypes.c_wchar_p,
+        ctypes.POINTER(ctypes.c_int),
+    ]
+    command_line_to_argv.restype = ctypes.POINTER(ctypes.c_wchar_p)
+    argv_pointer = command_line_to_argv(command, ctypes.byref(argc))
+    if not argv_pointer:
+        raise ValueError("CommandLineToArgvW failed")
     try:
-        argv = shlex.split(command, posix=True)
-    except ValueError as exc:
+        return [argv_pointer[index] for index in range(argc.value)]
+    finally:
+        ctypes.windll.kernel32.LocalFree(argv_pointer)
+
+
+def _parse_command_argv(command: str, label: str) -> list[str]:
+    """Parse an argv-style command without granting it shell semantics."""
+    if "\x00" in command:
+        raise CommandTokenError(
+            f"key_cmd for provider {label!r} could not be parsed as argv"
+        )
+    try:
+        if sys.platform == "win32":
+            has_shell_syntax = _has_unquoted_shell_syntax_windows(command)
+            argv = _parse_windows_command_argv(command)
+        else:
+            has_shell_syntax = _has_unquoted_shell_syntax_posix(command)
+            argv = shlex.split(command, posix=True)
+    except (OSError, ValueError) as exc:
         raise CommandTokenError(
             f"key_cmd for provider {label!r} could not be parsed as argv"
         ) from exc
+    if has_shell_syntax:
+        raise CommandTokenError(
+            f"key_cmd for provider {label!r} contains unsupported shell syntax; "
+            "use an argv-style command without shell operators"
+        )
     if not argv:
         raise CommandTokenError(f"key_cmd for provider {label!r} is empty")
+    _reject_shell_launcher(argv, label)
     return argv
 
 
@@ -125,6 +239,10 @@ def _mint(command: str, label: str) -> tuple[str, Optional[float]]:
         raise CommandTokenError(
             f"key_cmd for provider {label!r} timed out after "
             f"{_MINT_TIMEOUT_SECONDS}s"
+        ) from exc
+    except ValueError as exc:
+        raise CommandTokenError(
+            f"key_cmd for provider {label!r} could not be executed"
         ) from exc
     except OSError as exc:
         raise CommandTokenError(

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -150,10 +150,15 @@ model:
 # request (cached until shortly before expiry), so long sessions keep working
 # with no restart.
 #
-# Contract: print ONLY the token on stdout, either bare or as JSON with an
-# "access_token" field ("expires_in" is honoured). Same shape as OAuth 2.0
-# token endpoints, Claude Code's `apiKeyHelper`, `gcloud auth
-# print-access-token`, and `aws ecr get-login-password`.
+# Contract: key_cmd is argv-only and Hermes never invokes a shell. Print ONLY the
+# token on stdout, either bare or as JSON with an "access_token" field
+# ("expires_in" is honoured). Shell operators and launchers such as cmd.exe /c,
+# powershell -Command, pwsh -c, sh -c, and bash -c are rejected; use an
+# executable plus explicit arguments instead.
+#
+# On Windows, native command-line quoting is used: backslashes are preserved as
+# path separators unless they precede a double quote. Quote paths containing
+# spaces with double quotes; do not use POSIX single-quote syntax.
 #
 # Precedence: an explicit --api-key still wins; otherwise key_cmd is preferred
 # over inline api_key / key_env on that entry.

--- a/tests/agent/test_command_token_source.py
+++ b/tests/agent/test_command_token_source.py
@@ -14,6 +14,9 @@ behaviours that make the feature work:
 
 from __future__ import annotations
 
+import json
+import shlex
+import sys
 import time
 from types import SimpleNamespace
 
@@ -27,21 +30,64 @@ from agent.command_token_source import (
 )
 
 
+def _python_command(code: str) -> str:
+    return f"{shlex.quote(sys.executable)} -c {shlex.quote(code)}"
+
+
+def _python_print(value: str) -> str:
+    return _python_command(f"print({value!r}, end='')")
+
+
 class TestMinting:
+    def test_default_execution_uses_argv_without_shell(self, monkeypatch):
+        seen = {}
+
+        def fake_run(command, **kwargs):
+            seen["command"] = command
+            seen["shell"] = kwargs.get("shell")
+            return SimpleNamespace(returncode=0, stdout="tok-safe", stderr="")
+
+        monkeypatch.setattr("agent.command_token_source.subprocess.run", fake_run)
+
+        assert _mint("token-helper --profile prod", "dbx") == ("tok-safe", None)
+        assert seen == {
+            "command": ["token-helper", "--profile", "prod"],
+            "shell": False,
+        }
+
+    def test_shell_injection_marker_never_runs(self, tmp_path):
+        marker = tmp_path / "marker"
+        python = sys.executable.replace("\\", "/")
+        marker_path = marker.as_posix()
+        first = (
+            f'"{python}" -c "from pathlib import Path; '
+            f"Path(r'{marker_path}').write_text('pwned')\""
+        )
+        second = f'"{python}" -c "print(\'tok\')"'
+        separator = "&" if sys.platform == "win32" else ";"
+
+        with pytest.raises(CommandTokenError):
+            _mint(f"{first} {separator} {second}", "dbx")
+
+        assert not marker.exists(), "shell metacharacters must not run a second operation"
+
     def test_bare_token_stdout(self):
-        source = CommandTokenSource("printf 'tok-abc'", "dbx")
+        source = CommandTokenSource(_python_command("print('tok-abc', end='')"), "dbx")
         assert source() == "tok-abc"
 
     def test_json_access_token(self):
         """The OAuth 2.0 token-endpoint response shape."""
         source = CommandTokenSource(
-            """printf '{"access_token":"tok-json","expires_in":3600}'""", "dbx"
+            _python_command(
+                "print('{\"access_token\":\"tok-json\",\"expires_in\":3600}', end='')"
+            ),
+            "dbx",
         )
         assert source() == "tok-json"
 
     def test_trailing_newline_is_stripped(self):
         """A raw newline in the credential would corrupt the auth header."""
-        assert CommandTokenSource("echo tok-nl", "dbx")() == "tok-nl"
+        assert CommandTokenSource(_python_command("print('tok-nl')"), "dbx")() == "tok-nl"
 
     def test_multiline_output_is_rejected_not_guessed(self):
         """Only the token may land on stdout.
@@ -50,26 +96,30 @@ class TestMinting:
         warning, two tokens) into a corrupt-credential 401 that is much harder
         to diagnose than an explicit refusal.
         """
-        source = CommandTokenSource("printf 'banner\\ntok-real'", "dbx")
+        source = CommandTokenSource(
+            _python_command("print('banner\\ntok-real', end='')"), "dbx"
+        )
         with pytest.raises(CommandTokenError, match="multiple lines"):
             source()
 
     def test_json_without_access_token_is_an_error(self):
-        source = CommandTokenSource("""printf '{"nope":1}'""", "dbx")
+        source = CommandTokenSource(_python_command("print('{\"nope\":1}', end='')"), "dbx")
         with pytest.raises(CommandTokenError, match="access_token"):
             source()
 
     def test_empty_output_is_an_error(self):
         with pytest.raises(CommandTokenError, match="no output"):
-            CommandTokenSource("true", "dbx")()
+            CommandTokenSource(_python_command("pass"), "dbx")()
 
     def test_nonzero_exit_is_an_error(self):
         with pytest.raises(CommandTokenError, match="exited 3"):
-            CommandTokenSource("exit 3", "dbx")()
+            CommandTokenSource(_python_command("raise SystemExit(3)"), "dbx")()
 
     def test_failure_message_is_actionable_without_echoing_the_command(self):
         """Actionable, but never echoes the command (it may embed a secret)."""
-        secret_cmd = "print-token --client-secret=SENTINEL-SECRET; exit 1"
+        secret_cmd = _python_command(
+            "import sys; print('SENTINEL-SECRET', file=sys.stderr); raise SystemExit(1)"
+        )
         with pytest.raises(CommandTokenError) as excinfo:
             CommandTokenSource(secret_cmd, "dbx")()
         message = str(excinfo.value)
@@ -82,7 +132,10 @@ class TestNoCredentialLeak:
     def test_failure_message_excludes_command_output(self):
         """A failing auth helper may print a token — it must not be surfaced."""
         source = CommandTokenSource(
-            "printf 'SENTINEL-SECRET'; printf 'stderr-SENTINEL' >&2; exit 1",
+            _python_command(
+                "import sys; print('SENTINEL-SECRET', file=sys.stdout); "
+                "print('stderr-SENTINEL', file=sys.stderr); raise SystemExit(1)"
+            ),
             "dbx",
         )
         with pytest.raises(CommandTokenError) as excinfo:
@@ -94,14 +147,19 @@ class TestCaching:
     def test_token_is_cached_between_calls(self):
         """Without caching the command would run on every request."""
         # A command whose output changes each run: equal results prove caching.
-        source = CommandTokenSource("date +%s%N", "dbx")
+        source = CommandTokenSource(
+            _python_command("import time; print(time.time_ns(), end='')"), "dbx"
+        )
         assert source() == source()
 
     def test_expired_token_is_reminted(self):
-        # date +%s%N changes every run; $RANDOM would be bash-only (empty
-        # under dash, which is what /bin/sh is on Debian-family CI).
+        # time_ns changes every run and is available on every supported OS.
         source = CommandTokenSource(
-            """printf '{"access_token":"tok-%s","expires_in":3600}' "$(date +%s%N)" """,
+            _python_command(
+                "import json, time; print(json.dumps({"
+                "'access_token': f'tok-{time.time_ns()}', 'expires_in': 3600"
+                "}), end='')"
+            ),
             "dbx",
         )
         first = source()
@@ -119,7 +177,9 @@ class TestCaching:
         """
         from agent.command_token_source import _NO_TTL_REFRESH_SECONDS
 
-        source = CommandTokenSource("date +%s%N", "dbx")
+        source = CommandTokenSource(
+            _python_command("import time; print(time.time_ns(), end='')"), "dbx"
+        )
         first = source()
         assert 0 < source._expires_at - time.monotonic() <= _NO_TTL_REFRESH_SECONDS
         assert source() == first  # cached inside the window
@@ -128,7 +188,7 @@ class TestCaching:
 
     def test_advertised_ttl_sets_an_expiry(self):
         source = CommandTokenSource(
-            """printf '{"access_token":"tok","expires_in":3600}'""", "dbx"
+            _python_print('{"access_token":"tok","expires_in":3600}'), "dbx"
         )
         source()
         assert source._expires_at is not None
@@ -136,7 +196,7 @@ class TestCaching:
     def test_ttl_shorter_than_the_leeway_still_caches_briefly(self):
         """A leeway larger than the TTL must not disable caching entirely."""
         source = CommandTokenSource(
-            """printf '{"access_token":"tok","expires_in":1}'""", "dbx"
+            _python_print('{"access_token":"tok","expires_in":1}'), "dbx"
         )
         source()
         assert source._expires_at is not None
@@ -249,42 +309,44 @@ class TestAbsoluteExpiry:
 
     def test_iso_expiry_yields_a_ttl(self):
         deadline = self._iso(3600)
-        _, ttl = _mint(f"printf '%s' '{{\"access_token\":\"t\",\"expiry\":\"{deadline}\"}}'", "p")
+        payload = json.dumps({"access_token": "t", "expiry": deadline})
+        _, ttl = _mint(_python_print(payload), "p")
         assert ttl is not None, "an advertised deadline must produce a TTL"
         assert 3500 < ttl <= 3600
 
     def test_azure_expires_on_spelling(self):
         deadline = self._iso(1800)
-        _, ttl = _mint(f"printf '%s' '{{\"access_token\":\"t\",\"expiresOn\":\"{deadline}\"}}'", "p")
+        payload = json.dumps({"access_token": "t", "expiresOn": deadline})
+        _, ttl = _mint(_python_print(payload), "p")
         assert ttl is not None and 1700 < ttl <= 1800
 
     def test_expires_in_still_wins_when_both_present(self):
         """The RFC 6749 field is authoritative where a helper sends both."""
         deadline = self._iso(3600)
-        _, ttl = _mint(
-            f"printf '%s' '{{\"access_token\":\"t\",\"expires_in\":120,\"expiry\":\"{deadline}\"}}'",
-            "p",
+        payload = json.dumps(
+            {"access_token": "t", "expires_in": 120, "expiry": deadline}
         )
+        _, ttl = _mint(_python_print(payload), "p")
         assert ttl == 120.0
 
     def test_unparseable_expiry_is_not_a_ttl(self):
         """Junk must fall back to refresh-on-401, never to a guessed deadline."""
-        _, ttl = _mint('printf \'%s\' \'{"access_token":"t","expiry":"whenever"}\'', "p")
+        _, ttl = _mint(_python_print('{"access_token":"t","expiry":"whenever"}'), "p")
         assert ttl is None
 
     def test_already_past_expiry_is_not_a_ttl(self):
         """A stale deadline must not become a negative or zero TTL."""
-        _, ttl = _mint(
-            f"printf '%s' '{{\"access_token\":\"t\",\"expiry\":\"{self._iso(-60)}\"}}'", "p"
-        )
+        payload = json.dumps({"access_token": "t", "expiry": self._iso(-60)})
+        _, ttl = _mint(_python_print(payload), "p")
         assert ttl is None
 
     def test_the_token_actually_gets_re_minted(self, tmp_path):
         """The regression that mattered: a deadline must expire the cache."""
         counter = tmp_path / "calls"
-        cmd = (
-            f"printf x >> {counter}; "
-            f"printf '%s' '{{\"access_token\":\"t\",\"expiry\":\"{self._iso(1)}\"}}'"
+        cmd = _python_command(
+            "import json; from pathlib import Path; "
+            f"p=Path({str(counter)!r}); p.open('a').write('x'); "
+            f"print(json.dumps({{'access_token': 't', 'expiry': {self._iso(1)!r}}}), end='')"
         )
         src = CommandTokenSource(cmd, "p")
         src()

--- a/tests/agent/test_command_token_source.py
+++ b/tests/agent/test_command_token_source.py
@@ -106,6 +106,22 @@ class TestMinting:
         with pytest.raises(CommandTokenError, match="shell"):
             _mint(command, "dbx")
 
+    @pytest.mark.parametrize("command", [
+        'env -u SECRET bash -c "echo pwned"',
+        'env --split-string="bash -c echo"',
+        'nice bash -c "echo pwned"',
+        'nohup sh -c "echo pwned"',
+        'xargs -0 bash -c "echo pwned"',
+        'wsl sh -c "echo pwned"',
+    ])
+    def test_process_dispatch_wrappers_are_rejected(self, monkeypatch, command):
+        monkeypatch.setattr(
+            "agent.command_token_source.subprocess.run",
+            lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("must not spawn")),
+        )
+        with pytest.raises(CommandTokenError, match="process wrapper"):
+            _mint(command, "dbx")
+
     def test_nul_command_is_normalized_to_provider_error(self):
         with pytest.raises(CommandTokenError, match="could not be parsed") as excinfo:
             _mint("helper\x00--token", "dbx")

--- a/tests/agent/test_command_token_source.py
+++ b/tests/agent/test_command_token_source.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import json
 import shlex
+import subprocess
 import sys
 import time
 from types import SimpleNamespace
@@ -26,12 +27,18 @@ from agent.command_token_source import (
     CommandTokenError,
     CommandTokenSource,
     _mint,
+    _parse_command_argv,
     build_command_token_provider,
 )
 
 
 def _python_command(code: str) -> str:
-    return f"{shlex.quote(sys.executable)} -c {shlex.quote(code)}"
+    argv = [sys.executable, "-c", code]
+    if sys.platform == "win32":
+        # Force quoting for Python snippets containing shell-like punctuation;
+        # native Windows argv parsing otherwise leaves ``print(...)`` unquoted.
+        return subprocess.list2cmdline([sys.executable, "-c", f"{code} "])
+    return " ".join(shlex.quote(part) for part in argv)
 
 
 def _python_print(value: str) -> str:
@@ -54,6 +61,55 @@ class TestMinting:
             "command": ["token-helper", "--profile", "prod"],
             "shell": False,
         }
+
+    @pytest.mark.parametrize(
+        ("command", "expected"),
+        [
+            (
+                r"helper --config C:\Users\andre\config.json",
+                ["helper", "--config", r"C:\Users\andre\config.json"],
+            ),
+            (
+                r'"C:\Program Files\helper.exe" --path C:\tmp\token',
+                [
+                    r"C:\Program Files\helper.exe",
+                    "--path",
+                    r"C:\tmp\token",
+                ],
+            ),
+            (
+                "helper --path C:\\tmp\\",
+                ["helper", "--path", "C:\\tmp\\"],
+            ),
+        ],
+    )
+    def test_windows_parser_preserves_native_backslashes(self, command, expected):
+        if sys.platform != "win32":
+            pytest.skip("native backslash parsing is Windows-specific")
+        assert _parse_command_argv(command, "dbx") == expected
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            'cmd.exe /d /c "echo pwned > marker"',
+            'powershell -NoProfile -Command "Set-Content marker pwned"',
+            'pwsh -NoProfile -c "Set-Content marker pwned"',
+            'sh -c "echo pwned > marker"',
+            'bash -c "echo pwned > marker"',
+        ],
+    )
+    def test_shell_launchers_are_rejected_before_execution(self, monkeypatch, command):
+        def fail_if_called(*args, **kwargs):
+            raise AssertionError("shell launcher must be rejected before process creation")
+
+        monkeypatch.setattr("agent.command_token_source.subprocess.run", fail_if_called)
+        with pytest.raises(CommandTokenError, match="shell"):
+            _mint(command, "dbx")
+
+    def test_nul_command_is_normalized_to_provider_error(self):
+        with pytest.raises(CommandTokenError, match="could not be parsed") as excinfo:
+            _mint("helper\x00--token", "dbx")
+        assert "helper" not in str(excinfo.value)
 
     def test_shell_injection_marker_never_runs(self, tmp_path):
         marker = tmp_path / "marker"

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -1285,7 +1285,7 @@ Each entry accepts: `api` (the endpoint base URL — `base_url`/`url` are accept
 
 #### Command-minted credentials (`key_cmd`)
 
-Enterprise gateways often issue short-lived bearer tokens (SSO/OIDC brokers, cloud IAM, internal auth proxies) rather than static API keys, so a token copied into `.env` goes stale mid-session and requests start returning 401. `key_cmd` names a command that *prints* a token; Hermes runs it and caches the result until shortly before expiry, so long sessions keep working with no restart:
+Enterprise gateways often issue short-lived bearer tokens (SSO/OIDC brokers, cloud IAM, internal auth proxies) rather than static API keys, so a token copied into `.env` goes stale mid-session and requests start returning 401. `key_cmd` names an **argv-only executable command** that *prints* a token; Hermes runs it and caches the result until shortly before expiry, so long sessions keep working with no restart. Hermes never invokes a shell for `key_cmd`.
 
 ```yaml
 providers:
@@ -1295,7 +1295,9 @@ providers:
     key_cmd: "my-auth-cli print-token --profile prod"
 ```
 
-Works with any helper that prints a token — `databricks auth token`, `gcloud auth print-access-token`, `az account get-access-token`, `vault read`, or Claude Code-style `apiKeyHelper` scripts.
+Works with any executable helper that prints a token — `databricks auth token`, `gcloud auth print-access-token`, `az account get-access-token`, or `vault read`. Do not wrap a helper in `cmd.exe /c`, `powershell -Command`, `pwsh -c`, `sh -c`, or `bash -c`; shell launchers and shell operators are rejected. Replace shell syntax with explicit executable arguments instead.
+
+On Windows, `key_cmd` uses native command-line quoting. Backslashes are preserved as path separators unless they precede a double quote. Quote an executable or argument only when it contains spaces, for example: `"C:\Program Files\my-auth.exe" --config C:\Users\me\config.json`. Use double quotes (not POSIX single-quote syntax) for grouped arguments; escape embedded double quotes with the native backslash rules.
 
 The command must print **only** the token on stdout: either bare, or as JSON with an `access_token` field (`expires_in` is honored; absolute `expiry`/`expiresOn` ISO timestamps too). Multi-line output is rejected rather than guessed at. If no expiry is advertised, the token is re-minted on a bounded window.
 


### PR DESCRIPTION
## What does this PR do?

Removes implicit shell interpretation from `key_cmd` token helpers and blocks indirect shell re-entry through process-dispatch wrappers. Commands are parsed into native argv, execute with `shell=False`, preserve Windows backslashes/quoting, and reject direct shells plus `env`, `nice`, `nohup`, `xargs`, `sudo`, `wsl`, and equivalent launchers before process creation.

## Related Issue

No public issue was filed. Live dedup search returned no matching issue or open PR.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Reproduction

1. Configure a provider with `key_cmd: 'cmd.exe /c "echo token"'` or `key_cmd: 'env -u X bash -c "echo token"'`.
2. Invoke the command-token provider.
3. Current main grants shell semantics through the configured command path; this branch rejects direct shells and process-dispatch wrappers before creating a process while direct executable helpers remain valid.

## Changes Made

- `agent/command_token_source.py` — native argv parsing, shell/operator rejection, process-wrapper rejection, and normalized execution errors.
- `tests/agent/test_command_token_source.py` — Windows quoting/backslash, direct-shell, wrapper-chain, NUL, parser/cache/error, and real-helper tests.
- `cli-config.yaml.example` — documents argv-only helpers and Windows quoting.
- `website/docs/integrations/providers.md` — updates provider configuration guidance.

## How to Test

1. Run `python -m pytest -q tests/agent/test_command_token_source.py`.
2. Confirm `46 passed`.
3. Run `python -m ruff check agent/command_token_source.py tests/agent/test_command_token_source.py` and `git diff --check`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — repository baseline is non-green; exact affected tests are green
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — provider guide and module contract updated
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — argv-only contract documented; no new key
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — Windows native parsing and POSIX shlex paths are separate
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; this is provider configuration, not a model tool schema

## Why this matters to users

Short-lived enterprise credentials can still be minted by executable helpers, but configuration text can no longer silently regain shell semantics through direct or wrapper-launched interpreters. Existing token parsing, expiry, caching, and error redaction remain intact.

## Verification

- Candidate HEAD: `48556521dcf2fba18e4a1b890413d8e6e11c8c0d`
- Focused suite: `46 passed`
- Ruff and `git diff --check`: pass
- Production line census: 358 lines
- Independent correctness review: approve; authoritative adversarial review runs against the same head

## Campaign methodology

Source pin `f751a8c5467c41500e505d90cb0eb8b70929080f`; current-main base `d0351e32309bd68a1012c302157947b955323fca`. Five analysts → five blind witnesses → five adjudicators → TDD implementation/fix lanes → two exact-head reviewers. The wrapper-chain bypass was found by an adversarial reviewer and closed in a successor commit.

## Coordination / dedup

Related work searched live before push: no matching issue or open PR. Builds on: new class-specific implementation. Merge order: standalone.

## Screenshots / Logs

```text
46 passed
All checks passed!
git diff --check: clean
```
