### PR TITLE
fix(gateway): bind webhook replay identity to authenticated content

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -25,8 +25,8 @@ Security:
   - Body size limits checked before reading payload
   - Generic HMAC supports a V2 signature (X-Webhook-Signature-V2) that
     binds a timestamp into the signed data for replay protection; the
-    legacy body-only V1 (X-Webhook-Signature) is deprecated but still
-    accepted with a warning, since it has no replay protection
+    legacy body-only V1 (X-Webhook-Signature) is rejected because it has
+    no replay protection
   - Set secret to "INSECURE_NO_AUTH" to skip validation (testing only)
 """
 
@@ -197,9 +197,6 @@ class WebhookAdapter(BasePlatformAdapter):
         self._dynamic_routes_mtime: float = 0.0
         self._routes: Dict[str, dict] = dict(self._static_routes)
         self._runner = None
-        # Routes already warned about legacy V1 body-only signatures
-        # (once-per-route so a busy sender doesn't spam the log).
-        self._v1_signature_warned: set[str] = set()
 
         # Delivery info keyed by session chat_id.
         #
@@ -450,6 +447,50 @@ class WebhookAdapter(BasePlatformAdapter):
         window.append(now)
         return True
 
+    def _authenticated_delivery_identity(
+        self, request: "web.Request", body: bytes
+    ) -> Optional[str]:
+        """Return the delivery identity covered by the accepted signature.
+
+        ``X-Request-ID`` and ``X-GitHub-Delivery`` are useful provider metadata,
+        but neither is covered by the corresponding signature in this adapter.
+        They therefore cannot be used as idempotency or session keys.  For
+        those schemes, derive the key from the bytes that were authenticated:
+        the V2 timestamp/body pair or the GitHub body.  Svix already signs its
+        message ID, so its existing identity remains unchanged.
+        """
+        def _header(name: str) -> str:
+            return (
+                request.headers.get(name, "")
+                or request.headers.get(name.lower(), "")
+                or request.headers.get(name.upper(), "")
+            )
+
+        # Keep the same precedence as _validate_signature().
+        svix_id = _header("svix-id")
+        svix_timestamp = _header("svix-timestamp")
+        svix_signature = _header("svix-signature")
+        if svix_id or svix_timestamp or svix_signature:
+            # _validate_svix_signature() has already authenticated svix_id.
+            return svix_id or None
+
+        if _header("X-Hub-Signature-256"):
+            digest = hashlib.sha256(body).hexdigest()
+            return f"github-body:{digest}"
+
+        if _header("X-Webhook-Signature-V2"):
+            timestamp = _header("X-Webhook-Timestamp")
+            if not timestamp:
+                return None
+            signed_content = timestamp.encode() + b"." + body
+            digest = hashlib.sha256(signed_content).hexdigest()
+            return f"generic-v2:{digest}"
+
+        # GitLab's token scheme and explicit local-test auth retain their
+        # historical delivery-id behavior for compatibility.  Body-only
+        # generic/Linear signatures are rejected before this method is called.
+        return None
+
     def _record_delivery_id(self, delivery_id: str, now: float) -> bool:
         """Return True when this delivery should be processed."""
         seen_at = self._seen_deliveries.get(delivery_id)
@@ -468,7 +509,7 @@ class WebhookAdapter(BasePlatformAdapter):
     def toolsets_for_source(self, source) -> Optional[List[str]]:
         """Per-route toolset override.
 
-        Webhook session chat_ids are ``webhook:{route}:{delivery_id}``.
+        Webhook session chat_ids are ``webhook:{route}:{replay_identity}``.
         When the matching route config carries a ``toolsets`` list, that list
         replaces the platform-level ``platform_toolsets.webhook`` resolution
         for this run only. Routes without the key keep the platform default
@@ -842,7 +883,10 @@ class WebhookAdapter(BasePlatformAdapter):
             except Exception as e:
                 logger.warning("[webhook] Skill loading failed: %s", e)
 
-        # Build a unique delivery ID
+        # Build a unique delivery ID.  Keep the provider/caller value for
+        # response and MessageEvent compatibility, but never use an unsigned
+        # value as the replay/session identity when a stronger authenticated
+        # identity is available.
         delivery_id = request.headers.get(
             "X-GitHub-Delivery",
             request.headers.get(
@@ -850,11 +894,17 @@ class WebhookAdapter(BasePlatformAdapter):
                 request.headers.get("X-Request-ID", str(int(time.time() * 1000))),
             ),
         )
+        authenticated_identity = self._authenticated_delivery_identity(
+            request, raw_body
+        )
+        replay_identity = authenticated_identity or delivery_id
 
         # ── Idempotency ─────────────────────────────────────────
-        # Skip duplicate deliveries (webhook retries).
+        # Skip duplicate deliveries (webhook retries).  For GitHub and V2,
+        # replay_identity is derived from the authenticated bytes rather than
+        # the caller-controlled delivery header.
         now = time.time()
-        if not self._record_delivery_id(delivery_id, now):
+        if not self._record_delivery_id(replay_identity, now):
             logger.info(
                 "[webhook] Skipping duplicate delivery %s", delivery_id
             )
@@ -921,9 +971,9 @@ class WebhookAdapter(BasePlatformAdapter):
                 status=502,
             )
 
-        # Use delivery_id in session key so concurrent webhooks on the
-        # same route get independent agent runs (not queued/interrupted).
-        session_chat_id = f"webhook:{route_name}:{delivery_id}"
+        # Use the authenticated replay identity in the session key so
+        # caller-controlled IDs cannot create a second concurrent agent run.
+        session_chat_id = f"webhook:{route_name}:{replay_identity}"
 
         # Store delivery info for send().  Read by every send() invocation
         # for this chat_id (interim status messages and the final response),
@@ -990,9 +1040,9 @@ class WebhookAdapter(BasePlatformAdapter):
     ) -> None:
         """Close the per-delivery webhook session once its run finishes.
 
-        A webhook delivery is one-shot: the ``delivery_id`` is baked into the
-        session key, so the session will never receive a second turn.  Mirror
-        the cron completion path (``cron/scheduler.py`` →
+        A webhook delivery is one-shot: the authenticated ``replay_identity``
+        is baked into the session key, so the session will never receive a
+        second turn.  Mirror the cron completion path (``cron/scheduler.py`` →
         ``end_session(..., "cron_complete")``) by marking the session ended
         when the run completes.  Without this, webhook sessions keep
         ``ended_at`` NULL forever; ``SessionDB.prune_sessions`` only reaps
@@ -1106,17 +1156,18 @@ class WebhookAdapter(BasePlatformAdapter):
                 signature_header=svix_signature,
             )
 
-        # Linear: linear-signature = <hex HMAC-SHA256 of the raw body, keyed
-        # by the webhook signing key>. Linear's documented scheme signs the
-        # body only (no timestamp binding), so this mirrors it exactly;
-        # without this branch every Linear delivery to a secret-configured
-        # route was rejected as unrecognized (#87348).
+        # Linear's documented ``linear-signature`` scheme signs the body only,
+        # so it cannot authenticate freshness or a provider-controlled delivery
+        # identity. Do not allow that legacy compatibility branch to authorize
+        # agent work or direct delivery. In particular, never turn a caller's
+        # X-Request-ID into an authenticated idempotency key for this scheme.
         linear_sig = _header("linear-signature")
         if linear_sig:
-            expected_linear = hmac.new(
-                secret.encode(), body, hashlib.sha256
-            ).hexdigest()
-            return _hmac_str_equal(linear_sig, expected_linear)
+            logger.warning(
+                "[webhook] Rejecting legacy Linear body-only signature; "
+                "a freshness-bound provider signature is required"
+            )
+            return False
 
         # GitHub: X-Hub-Signature-256 = sha256=<hex>
         gh_sig = request.headers.get("X-Hub-Signature-256", "")
@@ -1174,29 +1225,20 @@ class WebhookAdapter(BasePlatformAdapter):
             ).hexdigest()
             return _hmac_str_equal(v2_sig, expected_v2)
 
-        # Generic V1 (legacy): X-Webhook-Signature = <hex HMAC-SHA256 of body>
-        # (deprecated — no replay protection, since the signature only
-        # covers the body: a captured (body, signature) pair replays
-        # indefinitely with no timestamp binding it to a specific delivery.)
+        # Generic V1 (legacy): X-Webhook-Signature = <hex HMAC-SHA256 of body>.
+        # It has no replay protection because the signature only covers the
+        # body. Reject it rather than warning and accepting a captured pair;
+        # caller-controlled X-Request-ID and a receipt-time fallback are not
+        # authenticated delivery identities.
         # Only reachable when X-Webhook-Signature-V2 was not sent at all —
         # see the guard above.
         generic_sig = request.headers.get("X-Webhook-Signature", "")
         if generic_sig:
-            expected = hmac.new(
-                secret.encode(), body, hashlib.sha256
-            ).hexdigest()
-            route_name = request.match_info.get("route_name", "")
-            if route_name not in self._v1_signature_warned:
-                self._v1_signature_warned.add(route_name)
-                logger.warning(
-                    "[webhook] Route '%s' uses legacy body-only HMAC (no "
-                    "timestamp), which is vulnerable to replay attacks. Add "
-                    "an 'X-Webhook-Timestamp' header and switch to "
-                    "'X-Webhook-Signature-V2' (HMAC-SHA256 of "
-                    "'<timestamp>.<body>').",
-                    route_name,
-                )
-            return _hmac_str_equal(generic_sig, expected)
+            logger.warning(
+                "[webhook] Rejecting legacy generic body-only HMAC; "
+                "use X-Webhook-Signature-V2 with X-Webhook-Timestamp"
+            )
+            return False
 
         # No recognised signature header but secret is configured → reject
         logger.debug(

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -155,8 +155,8 @@ class TestValidateSignature:
             # Must return False, never raise.
             assert adapter._validate_signature(req, body, secret) is False
 
-    def test_linear_signature_valid_accepts(self):
-        """Linear signs the raw body (hex HMAC-SHA256) in linear-signature."""
+    def test_linear_signature_body_only_rejects(self):
+        """Linear's body-only compatibility signature cannot authorize work."""
         adapter = _make_adapter()
         body = b'{"type": "Issue", "data": {"id": "abc"}}'
         secret = "linear-webhook-key"
@@ -164,7 +164,7 @@ class TestValidateSignature:
 
         req = _mock_request(headers={"linear-signature": sig})
 
-        assert adapter._validate_signature(req, body, secret) is True
+        assert adapter._validate_signature(req, body, secret) is False
 
     def test_linear_signature_mismatch_rejects(self):
         """A well-formed linear-signature computed with the wrong key fails closed."""
@@ -263,24 +263,19 @@ class TestValidateSignature:
         })
         assert adapter._validate_signature(req, body, secret) is False
 
-    def test_v1_replay_attack_succeeds_demonstrating_the_hole_v2_closes(self):
-        """Regression/documentation test: a captured (body, signature) V1
-        pair replays successfully no matter how much time has passed,
-        because the V1 signature has no timestamp binding at all. This is
-        the exact vulnerability V2 fixes — it is not asserting desired
-        behavior, it is pinning the known, accepted-with-warning legacy
-        gap so a future change to V1's semantics doesn't silently alter it
-        without a deliberate decision."""
+    def test_v1_body_only_signature_rejects(self):
+        """A captured body/signature pair cannot authorize a legacy replay."""
         adapter = _make_adapter()
         body = b'{"event": "push"}'
         secret = "generic-secret"
         sig = _generic_signature(body, secret)
         original_request = _mock_request(headers={"X-Webhook-Signature": sig})
-        assert adapter._validate_signature(original_request, body, secret) is True
-        # "Time passes" — nothing about a V1 signature depends on time, so
-        # a captured pair replayed much later still validates.
-        replayed_request = _mock_request(headers={"X-Webhook-Signature": sig})
-        assert adapter._validate_signature(replayed_request, body, secret) is True
+        assert adapter._validate_signature(original_request, body, secret) is False
+        # A caller-controlled request ID must not change the result.
+        replayed_request = _mock_request(
+            headers={"X-Webhook-Signature": sig, "X-Request-ID": "fresh-id"}
+        )
+        assert adapter._validate_signature(replayed_request, body, secret) is False
 
 
     def test_validate_svix_signature_raw_secret_valid(self):

--- a/tests/gateway/test_webhook_legacy_freshness_contract.py
+++ b/tests/gateway/test_webhook_legacy_freshness_contract.py
@@ -1,0 +1,178 @@
+"""R4-SEC-002 regression tests for legacy webhook freshness."""
+
+import asyncio
+import hashlib
+import hmac
+import json
+import time
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.config import PlatformConfig
+from gateway.platforms.webhook import WebhookAdapter
+
+
+def _make_adapter(routes: dict) -> WebhookAdapter:
+    config = PlatformConfig(
+        enabled=True,
+        extra={"host": "0.0.0.0", "port": 0, "routes": routes},
+    )
+    return WebhookAdapter(config)
+
+
+def _create_app(adapter: WebhookAdapter) -> web.Application:
+    app = web.Application()
+    app.router.add_post("/webhooks/{route_name}", adapter._handle_webhook)
+    return app
+
+
+def _body_signature(body: bytes, secret: str) -> str:
+    return hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+
+
+def _generic_v2_signature(body: bytes, secret: str, timestamp: str) -> str:
+    signed_content = timestamp.encode() + b"." + body
+    return hmac.new(secret.encode(), signed_content, hashlib.sha256).hexdigest()
+
+
+def _github_signature(body: bytes, secret: str) -> str:
+    return "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+
+
+@pytest.mark.asyncio
+async def test_generic_body_hmac_replay_with_fresh_request_id_cannot_dispatch_twice():
+    """Caller-controlled request IDs cannot make body-only HMAC replayable."""
+    secret = "generic-freshness-secret"
+    adapter = _make_adapter({"generic": {"secret": secret}})
+    dispatched = []
+
+    async def capture(event):
+        dispatched.append(event)
+
+    adapter.handle_message = capture
+    body = json.dumps({"event_type": "ping", "value": 1}).encode()
+    signature = _body_signature(body, secret)
+
+    async with TestClient(TestServer(_create_app(adapter))) as client:
+        headers = {"X-Webhook-Signature": signature}
+        first = await client.post(
+            "/webhooks/generic",
+            data=body,
+            headers={**headers, "X-Request-ID": "caller-id-1"},
+        )
+        second = await client.post(
+            "/webhooks/generic",
+            data=body,
+            headers={**headers, "X-Request-ID": "caller-id-2"},
+        )
+
+    await asyncio.sleep(0.05)
+    assert first.status == 401
+    assert second.status == 401
+    assert dispatched == []
+
+
+@pytest.mark.asyncio
+async def test_generic_v2_replay_with_fresh_request_id_is_duplicate():
+    """V2 replay identity comes from the signed timestamp and body."""
+    secret = "generic-v2-replay-secret"
+    adapter = _make_adapter({"generic": {"secret": secret}})
+    dispatched = []
+
+    async def capture(event):
+        dispatched.append(event)
+
+    adapter.handle_message = capture
+    body = json.dumps({"event_type": "ping", "value": 1}).encode()
+    timestamp = str(int(time.time()))
+    signature = _generic_v2_signature(body, secret, timestamp)
+    signed_headers = {
+        "X-Webhook-Signature-V2": signature,
+        "X-Webhook-Timestamp": timestamp,
+    }
+
+    async with TestClient(TestServer(_create_app(adapter))) as client:
+        first = await client.post(
+            "/webhooks/generic",
+            data=body,
+            headers={**signed_headers, "X-Request-ID": "caller-one"},
+        )
+        second = await client.post(
+            "/webhooks/generic",
+            data=body,
+            headers={**signed_headers, "X-Request-ID": "caller-two"},
+        )
+        duplicate = await second.json()
+
+    await asyncio.sleep(0.05)
+    assert first.status == 202
+    assert second.status == 200
+    assert duplicate["status"] == "duplicate"
+    assert len(dispatched) == 1
+    assert dispatched[0].source.chat_id.startswith("webhook:generic:generic-v2:")
+    assert "caller-one" not in dispatched[0].source.chat_id
+
+
+@pytest.mark.asyncio
+async def test_github_replay_with_changed_delivery_id_is_duplicate():
+    """GitHub replay identity comes from the HMAC-authenticated body."""
+    secret = "github-replay-secret"
+    adapter = _make_adapter({"github": {"secret": secret}})
+    dispatched = []
+
+    async def capture(event):
+        dispatched.append(event)
+
+    adapter.handle_message = capture
+    body = json.dumps({"event": "push", "ref": "refs/heads/main"}).encode()
+    signature = _github_signature(body, secret)
+    signed_headers = {"X-Hub-Signature-256": signature}
+
+    async with TestClient(TestServer(_create_app(adapter))) as client:
+        first = await client.post(
+            "/webhooks/github",
+            data=body,
+            headers={**signed_headers, "X-GitHub-Delivery": "github-one"},
+        )
+        second = await client.post(
+            "/webhooks/github",
+            data=body,
+            headers={**signed_headers, "X-GitHub-Delivery": "github-two"},
+        )
+        duplicate = await second.json()
+
+    await asyncio.sleep(0.05)
+    assert first.status == 202
+    assert second.status == 200
+    assert duplicate["status"] == "duplicate"
+    assert len(dispatched) == 1
+    assert dispatched[0].source.chat_id.startswith("webhook:github:github-body:")
+    assert "github-one" not in dispatched[0].source.chat_id
+
+
+@pytest.mark.asyncio
+async def test_linear_body_hmac_without_freshness_is_rejected_by_default():
+    """Linear's body-only compatibility signature cannot authorize dispatch."""
+    secret = "linear-freshness-secret"
+    adapter = _make_adapter({"linear": {"secret": secret}})
+    dispatched = []
+
+    async def capture(event):
+        dispatched.append(event)
+
+    adapter.handle_message = capture
+    body = json.dumps({"type": "Issue", "id": "issue-1"}).encode()
+    signature = _body_signature(body, secret)
+
+    async with TestClient(TestServer(_create_app(adapter))) as client:
+        response = await client.post(
+            "/webhooks/linear",
+            data=body,
+            headers={"linear-signature": signature},
+        )
+
+    await asyncio.sleep(0.05)
+    assert response.status == 401
+    assert dispatched == []


### PR DESCRIPTION
## Current landing gate — 2026-08-30 09:40 CDT

- **Construction merge base:** upstream `main@4209d371aa1bb8840ce8447555bdd863a1a96c38`.
- **Current upstream main:** `5cc1369fa298021f8c740de154ff8c37c30bdcc8`.
- **Live head:** `359bd692ee887fa0562e6d99fd3c0cedccc2ac02`.
- **Submitted train:** exactly **1 commit / 3 files**; open, non-draft, and GitHub currently reports it mergeable.
- **Exact-head acceptance:** [CI 33271699471](https://github.com/NousResearch/hermes-agent/actions/runs/33271699471), [Docker 33271698889](https://github.com/NousResearch/hermes-agent/actions/runs/33271698889), and [Nix 33271698947](https://github.com/NousResearch/hermes-agent/actions/runs/33271698947) all succeeded on `359bd692…`.
- **Every-commit gate:** satisfied. There is one surviving commit and it has the complete hosted matrix above.
- **Landing-edge cross-check:** live compare from `359bd692…` to `main@5cc1369f…` has merge base `4209d371…`; main has advanced 150 commits, but that main-only changed-file set is path-disjoint from all three submitted paths (`gateway/platforms/webhook.py`, `tests/gateway/test_webhook_adapter.py`, `tests/gateway/test_webhook_legacy_freshness_contract.py`). No exact-head receipt is transferred to main; this only proves the present landing drift does not collide with the submitted FILE-LIST.
- **Construction proof:** the submitted commit rematerialized the reviewed product tree as one commit on `4209d371…` using tree `53c149f09fbb12f8e6158d35edfe2e21234bacb8`, preserving merged #97204's off-loop delivery owner while adding the replay repair.

This PR remains **head-green and train-green** on its exact submitted object, and the current landing edge is file-disjoint/mergeable. The remaining ordering boundary is architectural: #97083 must consume/subtract this replay owner rather than duplicate it, then reacquire proof for its own final composition.

## What does this PR do?

Binds webhook replay identity to authenticated request content. Legacy body-only generic and Linear signatures are rejected; V2, GitHub, and provider delivery identities derive or validate replay keys from authenticated material, so changing a caller-supplied `X-Request-ID` or delivery ID cannot turn one signed body into multiple side effects.

## Related Issue

No public issue was filed for this exact defect. **Interlock: #97083 is the broader Webhook Revolution architecture carrier.** Live FILE-LIST reconciliation proves physical overlap on `gateway/platforms/webhook.py` and `tests/gateway/test_webhook_adapter.py`; this PR owns the narrow authenticated replay-identity invariant, not the joined authority architecture.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests
- [ ] ♻️ Refactor
- [ ] 🎯 New skill

## Reproduction

1. Send one valid V2 or GitHub-signed webhook body through a configured route.
2. Replay the identical authenticated body/signature with a different caller-supplied `X-Request-ID` or delivery ID.
3. Without authenticated replay ownership, the second request can be admitted as new work. This branch derives the replay/session key from the authenticated material, so the replay cannot create a second side effect.

## Changes Made

- `gateway/platforms/webhook.py` — rejects body-only authorization and binds replay/idempotency identity to authenticated content while preserving #97204's off-loop delivery contract.
- `tests/gateway/test_webhook_legacy_freshness_contract.py` — proves generic and Linear legacy rejection plus replay behavior.
- `tests/gateway/test_webhook_adapter.py` — proves GitHub/V2/provider compatibility and authenticated delivery-identity binding.

## How to Test

```bash
python -m pytest -q \
  tests/gateway/test_webhook_adapter.py \
  tests/gateway/test_webhook_legacy_freshness_contract.py \
  tests/gateway/test_webhook_signature_rate_limit.py \
  tests/gateway/test_webhook_integration.py
python -m ruff check \
  gateway/platforms/webhook.py \
  tests/gateway/test_webhook_adapter.py \
  tests/gateway/test_webhook_legacy_freshness_contract.py
git diff --check
```

Repository-wide hosted acceptance is attached to the exact submitted head above.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits and includes DCO sign-off
- [x] I searched for existing work and reconciled the live overlap with #97083
- [x] My PR contains only changes related to this fix
- [x] Every submitted commit has exact CI/Docker/Nix acceptance
- [x] I've added adversarial tests for the bypass shape

### Documentation & Housekeeping

- [x] Public route configuration is unchanged
- [x] No config key changed
- [x] No tool schema changed
- [x] `gateway/platforms/webhook.py` remains below 2,000 lines
- [x] FILE-LIST is exactly three product files

## Verification

| Object | Exact receipt |
|---|---|
| Construction merge base | `4209d371aa1bb8840ce8447555bdd863a1a96c38` |
| Current main cross-check | `5cc1369fa298021f8c740de154ff8c37c30bdcc8` — 150 main-only commits since merge base; submitted FILE-LIST path-disjoint |
| Head | `359bd692ee887fa0562e6d99fd3c0cedccc2ac02` |
| Product tree | `53c149f09fbb12f8e6158d35edfe2e21234bacb8` |
| CI | [33271699471 — success](https://github.com/NousResearch/hermes-agent/actions/runs/33271699471) |
| Docker | [33271698889 — success](https://github.com/NousResearch/hermes-agent/actions/runs/33271698889) |
| Nix | [33271698947 — success](https://github.com/NousResearch/hermes-agent/actions/runs/33271698947) |

The earlier two-commit train (`92c7fc1…` → `f916bde…`) is not submitted and contributes no inherited acceptance. `359bd692…` rematerializes the reviewed product tree as one commit.

## Coordination / dedup

- **#97218 owns:** authenticated replay identity and rejection of body-only authorization.
- **Merged #97204 owns:** GitHub delivery liveness/off-loop execution.
- **#97083 owns:** the broader joined webhook authority, ledger, delivery, and recovery architecture.

Required order: land #97218, then make #97083 consume/subtract this exact owner while preserving #97204 and reacquire exact-head/every-commit proof. No composition may restore caller-controlled replay identity or duplicate this implementation under a second owner.

## Screenshots / Logs

```text
CI      33271699471  success
Docker  33271698889  success
Nix     33271698947  success
```