### PR TITLE
fix(memory): coerce non-string memory tool results to JSON strings

### DIFF
--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -927,13 +927,26 @@ class MemoryManager:
         if provider is None:
             return tool_error(f"No memory provider handles tool '{tool_name}'")
         try:
-            return provider.handle_tool_call(tool_name, args, **kwargs)
+            result = provider.handle_tool_call(tool_name, args, **kwargs)
         except Exception as e:
             logger.error(
                 "Memory provider '%s' handle_tool_call(%s) failed: %s",
                 provider.name, tool_name, e,
             )
             return tool_error(f"Memory tool '{tool_name}' failed: {e}")
+        # Providers are documented (MemoryProvider.handle_tool_call) to return
+        # a JSON string. Enforce that here so a structured (dict/list) result
+        # can never be persisted and re-sent as non-string tool content --
+        # OpenAI-compatible providers reject that with a 400 that bricks the
+        # whole conversation and every retry through the fallback chain.
+        if isinstance(result, str):
+            return result
+        try:
+            return json.dumps(result, ensure_ascii=False)
+        except (TypeError, ValueError):
+            return tool_error(
+                f"Memory tool '{tool_name}' returned unserializable result"
+            )
 
     # -- Lifecycle hooks -----------------------------------------------------
 

--- a/tests/run_agent/test_memory_provider_init.py
+++ b/tests/run_agent/test_memory_provider_init.py
@@ -3,6 +3,8 @@
 from types import SimpleNamespace
 from unittest.mock import patch
 
+from agent.memory_provider import MemoryProvider
+
 
 class RecordingMemoryProvider:
     name = "recording"
@@ -168,5 +170,55 @@ def test_core_tool_names_rejected_from_memory_routing_table():
     assert "clarify" not in schema_names
     assert "delegate_task" not in schema_names
     assert "honcho_search" in schema_names
+
+
+class DictReturningProvider(MemoryProvider):
+    """Memory provider that violates the ABC contract by returning dicts."""
+
+    @property
+    def name(self) -> str:
+        return "dict-return"
+
+    def is_available(self) -> bool:
+        return True
+
+    def initialize(self, session_id: str, **kwargs) -> None:
+        pass
+
+    def get_tool_schemas(self):
+        return [
+            {
+                "name": "hybrid_mem_remember",
+                "description": "remember a fact",
+                "parameters": {"type": "object"},
+            }
+        ]
+
+    def handle_tool_call(self, tool_name, args, **kwargs):  # type: ignore[override]
+        # Deliberately violates "must return a JSON string" to exercise the
+        # manager's defensive coercion (see test below).
+        return {"memory_id": "abc123"}
+
+
+def test_memory_handle_tool_call_coerces_non_string_result_to_json():
+    """A provider returning a dict must never yield non-string tool content.
+
+    Regression for the session-bricking bug: a structured tool result was
+    persisted with the _CONTENT_JSON_PREFIX sentinel and then re-sent to
+    OpenAI-compatible providers as dict tool content, which they reject with
+    a 400 ("messages.N.content: Invalid input") that poisoned every retry
+    through the fallback chain.
+    """
+    import json
+
+    from agent.memory_manager import MemoryManager
+
+    mm = MemoryManager()
+    mm.add_provider(DictReturningProvider())
+    assert mm.has_tool("hybrid_mem_remember")
+
+    result = mm.handle_tool_call("hybrid_mem_remember", {"content": "x"})
+    assert isinstance(result, str)
+    assert json.loads(result) == {"memory_id": "abc123"}
 
 


### PR DESCRIPTION
## Problem

A single memory-provider tool result that is a structured `dict` (instead of the documented JSON string) silently bricks the entire conversation.

**Repro (live, session `20260828_061715_fe0d96`):** `hybrid_mem_remember` failed while fetching its embedder (transient HuggingFace 404). The `Turtle`/`hybrid-mem` provider's `handle_tool_call` returns a dict on every path — including its exception handler (`provider.py:286`, `{"error": "RemoteEntryNotFoundError: ..."}`). Hermes persisted that dict via `_encode_content` with the `\x00json:` storage sentinel (`hermes_state.py`). On the next API send the content decoded back to a **dict**, and OpenAI/DeepSeek-compatible providers require tool-message `content` to be a **string** → `HTTP 400 ... messages.65.content: Invalid input`. Every retry re-sends the same poisoned history, so the request fails against **every provider in the fallback chain** and the conversation is stuck.

## Root cause

`MemoryProvider.handle_tool_call` (`agent/memory_provider.py:241`) documents "Must return a JSON string," but `MemoryManager.handle_tool_call` (`agent/memory_manager.py:930`) returns the provider's result **verbatim** — no enforcement. A contract-violating provider's structured result flows straight into a tool message and then to the API.

## Fix

Enforce the contract at the manager boundary:

- `str` result → pass through unchanged (normal path, zero change).
- `dict`/`list`/`scalar` result → `json.dumps` into a JSON string.
- Unserializable → `tool_error(...)`.

This fixes the whole bug class (any memory provider that returns non-string results), not just the one that tripped today.

## Tests

Added `test_memory_handle_tool_call_coerces_non_string_result_to_json` in `tests/run_agent/test_memory_provider_init.py` — a provider that deliberately returns a dict, asserting the manager returns a parseable JSON string. 6/6 in that file, 41/41 across the memory-manager test set pass.