### PR TITLE
fix: allow HEIC/HEIF/AVIF image attachments end-to-end (desktop picker + gateway attach)

### DIFF
--- a/apps/desktop/src/app/chat/hooks/use-composer-actions.ts
+++ b/apps/desktop/src/app/chat/hooks/use-composer-actions.ts
@@ -23,11 +23,14 @@ import { notify, notifyError } from '@/store/notifications'
 
 import type { ImageDetachResponse } from '../../types'
 
-const IMAGE_EXTENSION_PATTERN = /\.(png|jpe?g|gif|webp|bmp|tiff?|svg|ico)$/i
+const IMAGE_EXTENSION_PATTERN = /\.(png|jpe?g|gif|webp|bmp|tiff?|svg|ico|heic|heif|avif)$/i
 
 const BLOB_MIME_EXTENSION: Record<string, string> = {
   'image/bmp': '.bmp',
   'image/gif': '.gif',
+  'image/heic': '.heic',
+  'image/heif': '.heif',
+  'image/avif': '.avif',
   'image/jpeg': '.jpg',
   'image/png': '.png',
   'image/svg+xml': '.svg',
@@ -543,7 +546,7 @@ export function useComposerActions({
       filters: [
         {
           name: t.composer.images,
-          extensions: ['png', 'jpg', 'jpeg', 'gif', 'webp', 'bmp', 'tiff']
+          extensions: ['png', 'jpg', 'jpeg', 'gif', 'webp', 'bmp', 'tiff', 'heic', 'heif', 'avif']
         }
       ]
     })

--- a/cli.py
+++ b/cli.py
@@ -3802,6 +3802,7 @@ def _cli_visible_print(text: str = "") -> None:
 _IMAGE_EXTENSIONS = frozenset({
     '.png', '.jpg', '.jpeg', '.gif', '.webp',
     '.bmp', '.tiff', '.tif', '.svg', '.ico',
+    '.heic', '.heif', '.avif',
 })
 
 


### PR DESCRIPTION
# PR: Support HEIC/HEIF/AVIF image attachments end-to-end (desktop picker, gateway attach, agent routing)

## Summary

Attaching an iPhone `.HEIC` photo to a Hermes Desktop chat fails at **three independent
extension whitelists**, even though the backend already contains a full HEIC transcode
pipeline (Pillow + pillow-heif → PNG) in `agent/image_routing.py::_transcode_to_png`.
This PR adds `heic/heif/avif` to the two lists that were missing them, so the existing
transcode path actually becomes reachable.

## Symptom (reproduced)

1. Desktop "+" image picker: HEIC files greyed out — the Electron `dialog.showOpenDialog`
   filter omits `heic`.
2. Even when the file is selected (e.g. drag-drop), the gateway RPC rejects it:
   `image.attach` → error 4016 `unsupported image: IMG_8196.HEIC`
   (from `tui_gateway/methods_prompt.py`, which validates against
   `cli.py::_IMAGE_EXTENSIONS` — no `.heic`).
3. `agent/image_routing.py` meanwhile *already* accepts `.heic` in `_IMAGE_EXTS` and
   transcodes to PNG via pillow-heif (optional plugin, registered on demand). So the
   routing layer was ready; the two upstream gates were not.

The result is a confusing half-feature: the transcoder, the routing docstrings, and
`_sniff_mime_from_bytes` (which even has HEIC magic-byte brands) all advertise HEIC
support that can never be reached from the desktop UI.

## Changes

**`apps/desktop/src/app/chat/hooks/use-composer-actions.ts`**
- `pickImages()` dialog filter: add `heic`, `heif`, `avif`
- `IMAGE_EXTENSION_PATTERN`: add `heic|heif|avif` (drag-drop / path classification)
- `BLOB_MIME_EXTENSION`: add `image/heic`, `image/heif`, `image/avif`

**`cli.py`**
- `_IMAGE_EXTENSIONS`: add `.heic`, `.heif`, `.avif` (used by the `image.attach`
  gateway method for its extension validation)

## Not changed (already correct)

- `agent/image_routing.py` — `_IMAGE_EXTS` already includes `.heic`; transcode to PNG
  already implemented with optional pillow-heif registration.
- `_sniff_mime_from_bytes` already recognizes HEIC/AVIF brands (`ftyp` + `heic`/`avif`).

## Notes

- The transcode path degrades gracefully: if pillow-heif isn't installed, the image is
  skipped with a log line rather than failing the turn (pre-existing behavior).
- AVIF is included in the same spirit: `pillow-avif-plugin` is already attempted in
  `_transcode_to_png`'s optional-plugin registration.

## Testing

- macOS desktop: "+" picker now offers HEIC; `image.attach` accepts `.heic`; session
  on a vision-capable model receives a transcoded PNG `image_url` part and describes
  the photo correctly.
- Verified the routing layer builds `['text', 'image_url']` parts from a real
  4032×3024 HEIC with no skipped paths.
