### PR TITLE
fix(gateway): keep concurrent search timeouts from stalling gateway cleanup

### DIFF
--- a/tests/tools/test_local_setsid_descendant_sweep.py
+++ b/tests/tools/test_local_setsid_descendant_sweep.py
@@ -1,23 +1,27 @@
 """Regression tests for #85125 Phase 4b (terminal flavor of the #71148 class).
 
 LocalEnvironment._kill_process kills the process GROUP (SIGTERM -> wait ->
-SIGKILL).  A descendant that called ``setsid`` escapes the group and survives
-the group-kill — the local sibling of issue #84967.  The fix snapshots the
-descendant set via psutil BEFORE the first signal (children reparent to init
-after the parent dies, so a later parent walk finds nothing — same rationale
-as agent/deadline.py kill_process_tree) and sweeps any snapshotted survivor
-outside the (now-dead) group with SIGKILL afterwards.
+SIGKILL). A descendant that called ``setsid`` escapes the group and survives
+the group-kill — the local sibling of issue #84967. Descendants are therefore
+snapshotted before the first signal, but that process-table walk is independently
+bounded and single-flight so slow ``/proc`` implementations cannot wedge every
+concurrent timeout-cleanup worker.
 """
 
 import os
 import signal
 import textwrap
+import threading
 import time
 from types import SimpleNamespace
 
 import pytest
 
-from tools.environments.local import LocalEnvironment
+from tools.environments.local import (
+    LocalEnvironment,
+    _DESCENDANT_SNAPSHOT_LOCK,
+    _bounded_descendant_snapshot,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -46,6 +50,7 @@ def _wait_for_pid_exit(pid: int, timeout: float = 10.0) -> bool:
 
 
 @pytest.mark.live_system_guard_bypass
+@pytest.mark.linux_only
 def test_timeout_kill_reaps_setsid_grandchild(tmp_path):
     """A grandchild that setsid's out of the group must not survive the
     timeout kill path."""
@@ -110,6 +115,7 @@ def _sh_quote(s: str) -> str:
     return shlex.quote(s)
 
 
+@pytest.mark.linux_only
 def test_kill_process_survives_psutil_snapshot_failure(monkeypatch):
     """A broken psutil snapshot must never break the kill path — the
     group-kill escalation still runs to completion."""
@@ -146,3 +152,72 @@ def test_kill_process_survives_psutil_snapshot_failure(monkeypatch):
     # escalation path completed despite the snapshot failure.
     assert killpg_calls[0] == (67890, signal.SIGTERM)
     assert (67890, 0) in killpg_calls
+
+
+def test_descendant_snapshot_has_independent_deadline_and_single_flight(monkeypatch):
+    """A slow process-table walk must not multiply across timeout cleanup."""
+    psutil = pytest.importorskip("psutil")
+    entered = threading.Event()
+    release = threading.Event()
+    finished = threading.Event()
+    late_result = threading.Event()
+    late_children = []
+    calls = []
+
+    class SlowProcess:
+        def __init__(self, pid):
+            calls.append(pid)
+
+        def children(self, *, recursive):
+            assert recursive is True
+            entered.set()
+            release.wait(timeout=2)
+            finished.set()
+            return ["late-child"]
+
+    monkeypatch.setattr(psutil, "Process", SlowProcess)
+
+    def capture_late(children):
+        late_children.extend(children)
+        late_result.set()
+
+    started = time.monotonic()
+    first = _bounded_descendant_snapshot(
+        111,
+        timeout_s=0.02,
+        on_late_result=capture_late,
+    )
+    elapsed = time.monotonic() - started
+    assert entered.is_set()
+    assert first == []
+    assert elapsed < 0.2
+
+    # While the abandoned scan is still alive, another cleanup must skip the
+    # process-table walk rather than starting a second expensive enumeration.
+    second = _bounded_descendant_snapshot(222, timeout_s=0.02)
+    assert second == []
+    assert calls == [111]
+
+    release.set()
+    assert finished.wait(timeout=1)
+    assert late_result.wait(timeout=1)
+    assert late_children == ["late-child"]
+    assert _DESCENDANT_SNAPSHOT_LOCK.acquire(timeout=1)
+    _DESCENDANT_SNAPSHOT_LOCK.release()
+
+
+def test_fast_descendant_snapshot_preserves_setsid_sweep(monkeypatch):
+    psutil = pytest.importorskip("psutil")
+    children = [object(), object()]
+
+    class FastProcess:
+        def __init__(self, pid):
+            assert pid == 333
+
+        def children(self, *, recursive):
+            assert recursive is True
+            return children
+
+    monkeypatch.setattr(psutil, "Process", FastProcess)
+
+    assert _bounded_descendant_snapshot(333, timeout_s=0.2) == children

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -10,8 +10,9 @@ import signal
 import subprocess
 import sys
 import tempfile
+import threading
 import time
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from pathlib import Path
 
 from hermes_constants import get_process_hermes_home
@@ -21,6 +22,93 @@ from hermes_cli._subprocess_compat import windows_hide_flags
 _IS_WINDOWS = platform.system() == "Windows"
 
 logger = logging.getLogger(__name__)
+
+_DESCENDANT_SNAPSHOT_BUDGET_S = 0.25
+_DESCENDANT_SNAPSHOT_LOCK = threading.Lock()
+
+
+def _sweep_escaped_descendants(descendants: list, pgid: int) -> None:
+    """SIGKILL identity-checked descendants outside ``pgid``."""
+    for child in descendants:
+        try:
+            if not child.is_running():
+                continue
+            try:
+                if os.getpgid(child.pid) == pgid:
+                    continue
+            except (ProcessLookupError, PermissionError, OSError):
+                pass
+            child.kill()
+        except Exception:
+            continue
+
+
+def _bounded_descendant_snapshot(
+    pid: int,
+    *,
+    timeout_s: float,
+    on_late_result: Callable[[list], None] | None = None,
+) -> list:
+    """Best-effort psutil descendant snapshot with a hard caller deadline.
+
+    Process-table enumeration can take minutes under PRoot and similarly slow
+    ``/proc`` implementations. Keep at most one abandoned scan in flight and
+    let timeout cleanup continue with its process-group boundary when the scan
+    misses its independent budget. A late result is handed to the optional
+    callback so escaped descendants are still reaped eventually.
+    """
+    if not _DESCENDANT_SNAPSHOT_LOCK.acquire(blocking=False):
+        return []
+
+    done = threading.Event()
+    state_lock = threading.Lock()
+    state = {"timed_out": False}
+    result: list = []
+
+    def _scan() -> None:
+        try:
+            try:
+                import psutil
+
+                descendants = psutil.Process(pid).children(recursive=True)
+            except Exception:
+                descendants = []
+            with state_lock:
+                late = state["timed_out"]
+                if not late:
+                    result.extend(descendants)
+                done.set()
+            if late and on_late_result is not None:
+                try:
+                    on_late_result(descendants)
+                except Exception:
+                    pass
+        finally:
+            _DESCENDANT_SNAPSHOT_LOCK.release()
+
+    try:
+        threading.Thread(
+            target=_scan,
+            daemon=True,
+            name=f"descendant-snapshot-{pid}",
+        ).start()
+    except Exception:
+        _DESCENDANT_SNAPSHOT_LOCK.release()
+        return []
+
+    if not done.wait(max(0.0, timeout_s)):
+        with state_lock:
+            if done.is_set():
+                return result
+            state["timed_out"] = True
+        logger.warning(
+            "Process-tree snapshot for pid %s exceeded %.2fs; "
+            "continuing with process-group cleanup",
+            pid,
+            timeout_s,
+        )
+        return []
+    return result
 
 
 def _msys_to_windows_path(cwd: str) -> str:
@@ -1943,63 +2031,40 @@ class LocalEnvironment(BaseEnvironment):
                 # (issue #84967's local sibling).  The snapshot must never
                 # break the kill path, so any failure just yields an empty
                 # sweep set.
-                descendants: list = []
-                try:
-                    import psutil
-
-                    descendants = psutil.Process(proc.pid).children(recursive=True)
-                except Exception:
-                    descendants = []
-
-                def _sweep_escaped_descendants() -> None:
-                    """SIGKILL snapshotted survivors outside the (dead) group.
-
-                    Runs after the TERM→KILL group escalation so in-group
-                    members keep their SIGTERM grace window; only escapees
-                    (own setsid sessions) are force-killed.  psutil's
-                    identity-aware Process means recycled PIDs are skipped.
-
-                    POSIX-only: reached solely from the non-_IS_WINDOWS
-                    branch above (the win32 path returns earlier).
-                    """
-                    for child in descendants:
-                        try:
-                            if not child.is_running():
-                                continue
-                            try:
-                                if os.getpgid(child.pid) == pgid:
-                                    continue  # group-kill already covers it
-                            except (ProcessLookupError, PermissionError, OSError):
-                                pass
-                            child.kill()
-                        except Exception:
-                            continue
+                descendants = _bounded_descendant_snapshot(
+                    proc.pid,
+                    timeout_s=_DESCENDANT_SNAPSHOT_BUDGET_S,
+                    on_late_result=lambda late: _sweep_escaped_descendants(
+                        late,
+                        pgid,
+                    ),
+                )
 
                 try:
                     os.killpg(pgid, signal.SIGTERM)  # windows-footgun: ok — POSIX process-group SIGTERM (guarded by _IS_WINDOWS above)
                 except ProcessLookupError:
-                    _sweep_escaped_descendants()
+                    _sweep_escaped_descendants(descendants, pgid)
                     return
 
                 # Wait on the process group, not just the shell wrapper. Under
                 # load the wrapper can exit before grandchildren do; returning
                 # at that point leaves orphaned process-group members behind.
                 if _wait_for_group_exit(pgid, 1.0):
-                    _sweep_escaped_descendants()
+                    _sweep_escaped_descendants(descendants, pgid)
                     return
 
                 try:
                     # POSIX-only: _IS_WINDOWS is handled by the outer branch.
                     os.killpg(pgid, signal.SIGKILL)  # windows-footgun: ok — POSIX process-group SIGKILL
                 except ProcessLookupError:
-                    _sweep_escaped_descendants()
+                    _sweep_escaped_descendants(descendants, pgid)
                     return
                 _wait_for_group_exit(pgid, 2.0)
                 try:
                     proc.wait(timeout=0.2)
                 except (subprocess.TimeoutExpired, OSError):
                     pass
-                _sweep_escaped_descendants()
+                _sweep_escaped_descendants(descendants, pgid)
         except (ProcessLookupError, PermissionError, OSError):
             try:
                 proc.kill()


### PR DESCRIPTION
## What does this PR do?

Keeps concurrent local command timeouts, including `search_files` ripgrep calls, from multiplying expensive process-table scans during cleanup. On metadata-slow POSIX environments, cleanup now continues through the existing process-group termination path after an independent 250 ms snapshot budget while one daemon scan retains best-effort escaped-descendant cleanup.

### Symptom

Several concurrent `search_files` calls can all enter `LocalEnvironment._kill_process()` after timing out and simultaneously call `psutil.Process.children(recursive=True)`. Under PRoot, those process-table walks can remain active long enough for the multiplex gateway to miss liveness probes and exit.

### Impact

A filesystem-heavy turn can disconnect every profile and platform session hosted by the affected multiplex gateway instead of failing only the timed-out searches.

### Bug Cause

**Trigger:** `tools/environments/local.py` / `LocalEnvironment._kill_process()` after a local subprocess timeout.

**Causal chain:**
1. Concurrent local searches exceed their command deadline.
2. Every cleanup worker synchronously enumerates the full process table before delivering the process-group signal.
3. Slow `/proc` enumeration holds all cleanup workers in metadata-heavy work and amplifies gateway scheduling pressure.

**Why it is wrong:** The command deadline did not independently bound descendant discovery, so cleanup could take arbitrarily longer than the operation it was meant to terminate.

**Working sibling / contrast:** The process-group TERM/KILL path is bounded and covers the normal command session without a process-table traversal. Recursive discovery is needed only as a best-effort supplement for descendants that created a separate session.

**Ruled out:** The captured workers were executing inside process cleanup and post-search path resolution, not waiting at a SessionDB dispatch boundary. The available evidence does not prove SQLite/WAL corruption as the cause of this incident.

### Fix

- Bound descendant discovery to 250 ms from the cleanup caller.
- Serialize discovery globally so concurrent timeouts cannot start multiple full process-table scans.
- Continue process-group TERM/KILL escalation when discovery is slow.
- Preserve escaped-descendant cleanup by sweeping identity-aware late results asynchronously when the single scan eventually completes.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/environments/local.py` - add bounded, single-flight descendant discovery and late-result sweeping.
- `tests/tools/test_local_setsid_descendant_sweep.py` - cover the deadline, single-flight behavior, late cleanup, fast-path preservation, and native OS markers.

## How to Test

1. Run the targeted local cleanup and Windows compatibility tests.
2. Confirm the simulated blocked process-table scan returns to its caller within the independent budget and a concurrent request does not start another scan.
3. Confirm a fast snapshot still returns descendants for the existing escaped-session sweep.

```bash
scripts/run_tests.sh tests/tools/test_local_setsid_descendant_sweep.py tests/tools/test_local_env_windows_msys.py -q
```

Result on Windows 11: 18 passed, 6 Linux-only tests skipped for their native CI lane.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A; behavior is documented in code docstrings
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility); the Windows cleanup branch is unchanged
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

N/A; this change is covered by deterministic regression tests.