### PR TITLE
fix(delegation): resolve reliable worktree repo anchors

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2062,6 +2062,9 @@ DEFAULT_CONFIG = {
                                        # delegation units. New async dispatches beyond the cap
                                        # fall back to synchronous execution. Floor of 1, no ceiling.
                                        # (Replaces the deprecated max_async_children.)
+        "worktree_isolation": False,  # opt-in local git worktree per child
+        "worktree_repo_root": "",  # optional absolute checkout anchor; useful for
+                                    # persistent sessions whose recorded cwd is stale
         # Orchestrator role controls (see tools/delegate_tool.py:_get_max_spawn_depth
         # and _get_orchestrator_enabled).  Floored at 1, no upper ceiling —
         # raise deliberately, each level multiplies API cost.

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -517,6 +517,46 @@ class TestToolNamePreservation(unittest.TestCase):
 class TestDelegateObservability(unittest.TestCase):
     """Tests for enriched metadata returned by _run_single_child."""
 
+    def test_worktree_degradation_is_visible_to_child_and_parent(self):
+        parent = _make_mock_parent(depth=0)
+        captured = {}
+
+        with (
+            patch("run_agent.AIAgent") as MockAgent,
+            patch("tools.delegate_tool._get_worktree_isolation", return_value=True),
+            patch("tools.subagent_worktree.local_backend_active", return_value=True),
+            patch(
+                "tools.subagent_worktree.resolve_worktree_anchor",
+                return_value=(None, "no usable repository; using shared workspace"),
+            ),
+        ):
+            mock_child = MagicMock()
+            mock_child.model = "claude-sonnet-4-6"
+            mock_child.session_prompt_tokens = 0
+            mock_child.session_completion_tokens = 0
+
+            def run_child(user_message, **_kwargs):
+                captured["message"] = user_message
+                return {
+                    "final_response": "done",
+                    "completed": True,
+                    "interrupted": False,
+                    "api_calls": 1,
+                    "messages": [],
+                }
+
+            mock_child.run_conversation.side_effect = run_child
+            MockAgent.return_value = mock_child
+
+            result = json.loads(
+                delegate_task(goal="Test warning visibility", parent_agent=parent)
+            )
+
+        entry = result["results"][0]
+        self.assertIn("shared workspace", entry["worktree_warning"])
+        self.assertIn("[WORKTREE ISOLATION WARNING]", captured["message"])
+        self.assertIn(entry["worktree_warning"], captured["message"])
+
     def test_observability_fields_present(self):
         """Completed child should return tool_trace, tokens, model, exit_reason."""
         parent = _make_mock_parent(depth=0)

--- a/tests/tools/test_subagent_worktree.py
+++ b/tests/tools/test_subagent_worktree.py
@@ -11,6 +11,7 @@ import tempfile
 import shutil
 import unittest
 from pathlib import Path
+from types import SimpleNamespace
 from unittest import mock
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
@@ -26,7 +27,7 @@ def _git(args, cwd, check=True):
 
 def _make_repo(root: Path) -> Path:
     repo = root / "repo"
-    repo.mkdir()
+    repo.mkdir(parents=True)
     _git(["init", "-q"], repo)
     _git(["config", "user.email", "test@test"], repo)
     _git(["config", "user.name", "Test"], repo)
@@ -67,6 +68,70 @@ class SubagentWorktreeTests(unittest.TestCase):
     def test_resolve_repo_root_none_and_missing(self):
         self.assertIsNone(sw.resolve_repo_root(None))
         self.assertIsNone(sw.resolve_repo_root(str(self.tmp / "nope")))
+
+    def test_resolve_anchor_prefers_configured_repo_over_recorded_cwd(self):
+        configured = _make_repo(self.tmp / "configured-parent")
+        recorded = _make_repo(self.tmp / "recorded-parent")
+
+        root, warning = sw.resolve_worktree_anchor(
+            str(configured), str(recorded), None
+        )
+
+        self.assertEqual(Path(root).resolve(), configured.resolve())
+        self.assertIsNone(warning)
+
+    def test_resolve_anchor_falls_back_from_stale_recorded_cwd(self):
+        recorded = self.tmp / "owner-home"
+        recorded.mkdir()
+        workspace = _make_repo(self.tmp / "workspace-parent")
+
+        root, warning = sw.resolve_worktree_anchor(
+            None, str(recorded), str(workspace)
+        )
+
+        self.assertEqual(Path(root).resolve(), workspace.resolve())
+        self.assertIsNone(warning)
+
+    def test_resolve_anchor_warns_when_no_candidate_is_a_repo(self):
+        recorded = self.tmp / "owner-home"
+        recorded.mkdir()
+
+        root, warning = sw.resolve_worktree_anchor(None, str(recorded), None)
+
+        self.assertIsNone(root)
+        self.assertIn("shared workspace", warning)
+        self.assertIn("delegation.worktree_repo_root", warning)
+
+    def test_invalid_configured_anchor_warns_and_uses_workspace_repo(self):
+        configured = self.tmp / "not-a-repo"
+        configured.mkdir()
+        workspace = _make_repo(self.tmp / "workspace-parent")
+
+        root, warning = sw.resolve_worktree_anchor(
+            str(configured), None, str(workspace)
+        )
+
+        self.assertEqual(Path(root).resolve(), workspace.resolve())
+        self.assertIn(str(configured), warning)
+        self.assertIn("using parent workspace", warning)
+
+    def test_resolve_anchor_checks_all_workspace_hints(self):
+        stale = self.tmp / "stale-terminal-cwd"
+        stale.mkdir()
+        workspace = _make_repo(self.tmp / "agent-cwd")
+
+        root, warning = sw.resolve_worktree_anchor(
+            None, None, [str(stale), str(workspace)]
+        )
+
+        self.assertEqual(Path(root).resolve(), workspace.resolve())
+        self.assertIsNone(warning)
+
+    def test_relative_configured_anchor_is_rejected_with_warning(self):
+        root, warning = sw.resolve_worktree_anchor("relative/repo", None, None)
+
+        self.assertIsNone(root)
+        self.assertIn("absolute checkout path", warning)
 
     # ── create_subagent_worktree ───────────────────────────────────────
 
@@ -402,6 +467,49 @@ class DelegationConfigGateTests(unittest.TestCase):
             return_value={"worktree_isolation": True},
         ):
             self.assertTrue(delegate_tool._get_worktree_isolation())
+
+    def test_worktree_repo_root_reads_explicit_config(self):
+        from tools import delegate_tool
+
+        with mock.patch.object(
+            delegate_tool,
+            "_load_config",
+            return_value={"worktree_repo_root": "/srv/hermes-agent"},
+        ):
+            self.assertEqual(
+                delegate_tool._get_worktree_repo_root(), "/srv/hermes-agent"
+            )
+
+    def test_worktree_repo_root_ignores_non_string_config(self):
+        from tools import delegate_tool
+
+        with mock.patch.object(
+            delegate_tool, "_load_config", return_value={"worktree_repo_root": True}
+        ):
+            self.assertIsNone(delegate_tool._get_worktree_repo_root())
+
+    def test_workspace_candidates_preserve_later_repo_after_stale_terminal_cwd(self):
+        from tools import delegate_tool
+
+        with tempfile.TemporaryDirectory(prefix="hermes-sw-hints-") as temp:
+            root = Path(temp)
+            stale = root / "owner-home"
+            stale.mkdir()
+            repo = _make_repo(root / "agent")
+            parent = SimpleNamespace(
+                _subdirectory_hints=None,
+                terminal_cwd=None,
+                cwd=str(repo),
+            )
+
+            with mock.patch.dict(os.environ, {"TERMINAL_CWD": str(stale)}):
+                candidates = delegate_tool._workspace_hint_candidates(parent)
+                resolved, warning = sw.resolve_worktree_anchor(
+                    None, str(stale), candidates
+                )
+
+            self.assertEqual(Path(resolved).resolve(), repo.resolve())
+            self.assertIsNone(warning)
 
 
 if __name__ == "__main__":

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -898,6 +898,15 @@ def _get_worktree_isolation() -> bool:
     return bool(cfg.get("worktree_isolation", False))
 
 
+def _get_worktree_repo_root() -> Optional[str]:
+    """Return the optional explicit repository anchor for child worktrees."""
+    value = _load_config().get("worktree_repo_root")
+    if not isinstance(value, str):
+        return None
+    value = value.strip()
+    return value or None
+
+
 _LEGACY_MAX_ASYNC_WARNED = False
 
 
@@ -1276,14 +1285,9 @@ def _build_child_system_prompt(
     return "\n".join(parts)
 
 
-def _resolve_workspace_hint(parent_agent) -> Optional[str]:
-    """Best-effort local workspace hint for child prompts.
-
-    We only inject a path when we have a concrete absolute directory. This avoids
-    teaching subagents a fake container path while still helping them avoid
-    guessing `/workspace/...` for local repo tasks.
-    """
-    candidates = [
+def _workspace_hint_candidates(parent_agent) -> List[str]:
+    """Return concrete local workspace candidates in precedence order."""
+    raw_candidates = [
         os.getenv("TERMINAL_CWD"),
         getattr(
             getattr(parent_agent, "_subdirectory_hints", None), "working_dir", None
@@ -1291,16 +1295,31 @@ def _resolve_workspace_hint(parent_agent) -> Optional[str]:
         getattr(parent_agent, "terminal_cwd", None),
         getattr(parent_agent, "cwd", None),
     ]
-    for candidate in candidates:
+    candidates: List[str] = []
+    seen = set()
+    for candidate in raw_candidates:
         if not candidate:
             continue
         try:
             text = os.path.abspath(os.path.expanduser(str(candidate)))
         except Exception:
             continue
-        if os.path.isabs(text) and os.path.isdir(text):
-            return text
-    return None
+        identity = os.path.normcase(text)
+        if os.path.isabs(text) and os.path.isdir(text) and identity not in seen:
+            candidates.append(text)
+            seen.add(identity)
+    return candidates
+
+
+def _resolve_workspace_hint(parent_agent) -> Optional[str]:
+    """Best-effort first local workspace hint for child prompts.
+
+    We only inject a path when we have a concrete absolute directory. This avoids
+    teaching subagents a fake container path while still helping them avoid
+    guessing `/workspace/...` for local repo tasks.
+    """
+    candidates = _workspace_hint_candidates(parent_agent)
+    return candidates[0] if candidates else None
 
 
 def _strip_blocked_tools(toolsets: List[str]) -> List[str]:
@@ -2653,9 +2672,12 @@ def _run_single_child(
     # Worktree-isolation state: populated inside the try once the child's
     # task id is known; the default no-op keeps every early error path safe.
     _worktree_info: Optional[Dict[str, str]] = None
+    _worktree_warning: Optional[str] = None
 
     def _attach_worktree(entry_dict: Dict[str, Any]) -> None:
         """Inspect + prune the child worktree, reporting into the entry."""
+        if _worktree_warning:
+            entry_dict["worktree_warning"] = _worktree_warning
         if _worktree_info is None:
             return
         try:
@@ -2736,8 +2758,8 @@ def _run_single_child(
         # Opt-in worktree isolation (delegation.worktree_isolation, inspired
         # by Muse Code's --subagent-worktree-isolation): give this child its
         # own git worktree branched from the parent repo's HEAD, and start its
-        # terminal there. Git-only and local-backend-only; any failure
-        # degrades silently to the shared-workspace behavior above.
+        # terminal there. Git-only and local-backend-only; any degradation is
+        # reported to the child, the parent result, and the application log.
         if _get_worktree_isolation():
             try:
                 from tools import subagent_worktree
@@ -2750,16 +2772,41 @@ def _run_single_child(
                         _parent_cwd = _gsc(parent_task_id)
                     except Exception:
                         pass
-                    _worktree_info = subagent_worktree.create_subagent_worktree(
-                        _parent_cwd or _resolve_workspace_hint(parent_agent),
-                        subagent_id=_subagent_id,
+                    _repo_anchor, _worktree_warning = (
+                        subagent_worktree.resolve_worktree_anchor(
+                            _get_worktree_repo_root(),
+                            _parent_cwd,
+                            _workspace_hint_candidates(parent_agent),
+                        )
                     )
+                    if _repo_anchor:
+                        _worktree_info = subagent_worktree.create_subagent_worktree(
+                            _repo_anchor, subagent_id=_subagent_id
+                        )
+                        if _worktree_info is None:
+                            _worktree_warning = (
+                                "worktree isolation was requested and repository "
+                                f"anchor {_repo_anchor} resolved, but git worktree "
+                                "creation failed; the child is using the shared "
+                                "workspace. See the Hermes logs for the git error."
+                            )
                 else:
-                    logger.debug(
-                        "worktree isolation skipped: non-local terminal backend"
+                    _worktree_warning = (
+                        "worktree isolation was requested but the terminal backend "
+                        "is not local; the child is using the shared workspace."
                     )
             except Exception as e:
-                logger.debug("worktree isolation setup failed: %s", e)
+                _worktree_warning = (
+                    "worktree isolation setup failed; the child is using the "
+                    f"shared workspace: {e}"
+                )
+            if _worktree_warning:
+                logger.warning("%s", _worktree_warning)
+                goal = (
+                    goal
+                    + "\n\n[WORKTREE ISOLATION WARNING] "
+                    + _worktree_warning
+                )
             if _worktree_info is not None:
                 try:
                     from tools.terminal_tool import record_session_cwd as _rsc

--- a/tools/subagent_worktree.py
+++ b/tools/subagent_worktree.py
@@ -42,7 +42,7 @@ import os
 import subprocess
 import uuid
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Iterable, Optional, Tuple, Union
 
 logger = logging.getLogger(__name__)
 
@@ -96,6 +96,70 @@ def resolve_repo_root(path: Optional[str]) -> Optional[str]:
         return None
     root = result.stdout.strip()
     return root or None
+
+
+def resolve_worktree_anchor(
+    configured_root: Optional[str],
+    recorded_cwd: Optional[str],
+    workspace_hints: Union[Optional[str], Iterable[str]],
+) -> Tuple[Optional[str], Optional[str]]:
+    """Resolve the first usable repo anchor and explain any degradation.
+
+    An explicit ``delegation.worktree_repo_root`` wins. A stale session cwd
+    must not mask a valid workspace hint, which is the failure mode persistent
+    owner sessions hit. Invalid explicit configuration is visible even when a
+    lower-priority candidate succeeds.
+    """
+    if isinstance(workspace_hints, str) or workspace_hints is None:
+        workspace_values = [workspace_hints] if workspace_hints else []
+    else:
+        workspace_values = list(workspace_hints)
+    candidates = [
+        ("delegation.worktree_repo_root", configured_root),
+        ("recorded parent cwd", recorded_cwd),
+        *[("parent workspace", value) for value in workspace_values],
+    ]
+    configured_failed = False
+    seen = set()
+    for label, candidate in candidates:
+        if not candidate:
+            continue
+        text = str(candidate)
+        if label == "delegation.worktree_repo_root" and not os.path.isabs(
+            os.path.expanduser(text)
+        ):
+            configured_failed = True
+            continue
+        try:
+            identity = os.path.normcase(
+                os.path.abspath(os.path.expanduser(text))
+            )
+        except Exception:
+            identity = text
+        if identity in seen:
+            continue
+        seen.add(identity)
+        root = resolve_repo_root(text)
+        if root:
+            warning = None
+            if configured_failed:
+                warning = (
+                    "delegation.worktree_repo_root "
+                    f"({configured_root}) is not a usable git repository; "
+                    f"using {label} ({root}) instead."
+                )
+            return root, warning
+        if label == "delegation.worktree_repo_root":
+            configured_failed = True
+
+    tried = ", ".join(
+        f"{label}={value}" for label, value in candidates if value
+    ) or "no candidate paths"
+    return None, (
+        "worktree isolation was requested but no usable git repository anchor "
+        f"resolved ({tried}); the child is using the shared workspace. Set "
+        "delegation.worktree_repo_root to an absolute checkout path."
+    )
 
 
 def _ensure_gitignore_entry(repo_root: str) -> None:

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2496,6 +2496,7 @@ delegation:
   # api_mode: ""                            # Wire protocol for base_url: "chat_completions", "codex_responses", or "anthropic_messages". Empty = auto-detect from URL (e.g. /anthropic suffix → anthropic_messages). Set explicitly for non-standard endpoints the heuristic can't detect.
   max_concurrent_children: 3                # Parallel children per batch (floor 1, no ceiling). Also via DELEGATION_MAX_CONCURRENT_CHILDREN env var.
   worktree_isolation: false                 # Give each child its own git worktree branched from HEAD (local backend + git repos only; inspired by Muse Code). See Subagent Delegation → Worktree Isolation.
+  # worktree_repo_root: "/srv/hermes-agent" # Optional absolute checkout anchor when the parent session cwd is stale/non-git.
   max_spawn_depth: 1                        # Delegation tree depth cap (1-3, clamped). 1 = flat (default): parent spawns leaves that cannot delegate. 2 = orchestrator children can spawn leaf grandchildren. 3 = three levels.
   orchestrator_enabled: true                # Global kill switch. When false, role="orchestrator" is ignored and every child is forced to leaf regardless of max_spawn_depth.
 ```

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -453,6 +453,7 @@ worktree, branched from the repo's current `HEAD` (inspired by Muse Code's
 ```yaml
 delegation:
   worktree_isolation: true   # default: false
+  # worktree_repo_root: /srv/hermes-agent  # optional absolute repo anchor
 ```
 
 With isolation on:
@@ -473,10 +474,15 @@ With isolation on:
   defaults, not measurements, so inspect the worktree rather than assuming
   the child produced nothing.
 
+Hermes resolves the repository from `worktree_repo_root` first, then the
+parent session's recorded cwd, then every available local workspace hint. The
+explicit anchor is useful for persistent owner sessions whose recorded cwd may
+be a home directory or stale. It must be an absolute path to a git checkout.
+
 Scope: opt-in, git-only, and local-terminal-backend-only. In a non-git
 directory, on docker/ssh/modal backends, or if worktree creation fails, the
-setting degrades silently to today's shared-workspace behavior — never an
-error.
+child still uses today's shared-workspace behavior, but Hermes emits a warning
+in the child context, application log, and delegation result.
 
 ## Delegation vs execute_code
 
@@ -500,6 +506,7 @@ delegation:
   max_iterations: 50                        # Max turns per child (default: 50)
   # max_concurrent_children: 3              # Parallel children per batch (default: 3)
   # worktree_isolation: false               # Give each child its own git worktree (see Worktree Isolation above)
+  # worktree_repo_root: /srv/hermes-agent    # Optional absolute checkout anchor for persistent sessions
   # max_spawn_depth: 1                      # Tree depth (floor 1, no ceiling, default 1 = flat). Raise to 2 to allow orchestrator children to spawn leaves; 3+ for deeper trees.
   # orchestrator_enabled: true              # Disable to force all children to leaf role.
   model: "google/gemini-3-flash-preview"             # Optional provider/model override


### PR DESCRIPTION
## Summary

- add `delegation.worktree_repo_root` as an explicit absolute repository anchor for persistent sessions
- resolve every available workspace candidate when the recorded session cwd is stale or outside a repository
- surface worktree isolation degradation in the child context, application logs, and the parent delegation result
- document anchor precedence and cover it with real git repositories plus delegation-result behavior tests

## Testing

- `scripts/run_tests.sh tests/tools/test_subagent_worktree.py -q`
- `scripts/run_tests.sh tests/tools/test_delegate.py -k worktree_degradation_is_visible_to_child_and_parent -q`

Closes #97209
