### PR TITLE
fix(delegate): support worktree_repo_root and warn on silent isolation degradation

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1553,6 +1553,8 @@ delegation:
   #                                           # delegation.model to an inexpensive one — children carry the
   #                                           # vast majority of tokens, so this is where spend is cut while
   #                                           # planning quality stays with the frontier parent.
+  # worktree_isolation: false                 # Enable per-child git worktree isolation (default: false).
+  # worktree_repo_root: "~/projects/hermes"   # Explicit git repo root anchor for worktrees when parent session cwd is non-git.
 
 # =============================================================================
 # Honcho Integration (Cross-Session User Modeling)

--- a/tests/tools/test_subagent_worktree.py
+++ b/tests/tools/test_subagent_worktree.py
@@ -26,7 +26,7 @@ def _git(args, cwd, check=True):
 
 def _make_repo(root: Path) -> Path:
     repo = root / "repo"
-    repo.mkdir()
+    repo.mkdir(parents=True, exist_ok=True)
     _git(["init", "-q"], repo)
     _git(["config", "user.email", "test@test"], repo)
     _git(["config", "user.name", "Test"], repo)
@@ -36,12 +36,21 @@ def _make_repo(root: Path) -> Path:
     return repo
 
 
-def _break_git_index(wt: Path) -> None:
+def _break_git_index(wt: Path | str) -> None:
     """Corrupt a worktree's index so the real git probes exit non-zero."""
-    git_dir = Path(_git(["rev-parse", "--git-dir"], wt).stdout.strip())
-    if not git_dir.is_absolute():
-        git_dir = (wt / git_dir).resolve()
-    (git_dir / "index").write_bytes(b"not-a-valid-git-index\n")
+    wt_p = Path(wt)
+    dotgit = wt_p / ".git"
+    if dotgit.is_file():
+        text = dotgit.read_text(encoding="utf-8").strip()
+        if text.startswith("gitdir:"):
+            gitdir_path = text.split(":", 1)[1].strip()
+            gitdir = Path(gitdir_path) if Path(gitdir_path).is_absolute() else (wt_p / gitdir_path).resolve()
+            (gitdir / "index").write_bytes(b"not-a-valid-git-index\n")
+            return
+    raw = _git(["rev-parse", "--git-path", "index"], cwd=str(wt)).stdout.strip()
+    p = Path(raw)
+    index_file = p if p.is_absolute() else (wt_p / p).resolve()
+    index_file.write_bytes(b"not-a-valid-git-index\n")
 
 
 class SubagentWorktreeTests(unittest.TestCase):
@@ -388,6 +397,10 @@ class WorktreePayloadSchemaTests(unittest.TestCase):
 
 
 class DelegationConfigGateTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="hermes-sw-gate-"))
+        self.addCleanup(shutil.rmtree, self.tmp, True)
+
     def test_worktree_isolation_default_off(self):
         from tools import delegate_tool
 
@@ -403,6 +416,162 @@ class DelegationConfigGateTests(unittest.TestCase):
         ):
             self.assertTrue(delegate_tool._get_worktree_isolation())
 
+    def test_worktree_repo_root_config_reading(self):
+        from tools import delegate_tool
+
+        with mock.patch.object(delegate_tool, "_load_config", return_value={}):
+            self.assertIsNone(delegate_tool._get_worktree_repo_root())
+
+        with mock.patch.object(
+            delegate_tool, "_load_config",
+            return_value={"worktree_repo_root": str(self.tmp)},
+        ):
+            self.assertEqual(
+                delegate_tool._get_worktree_repo_root(),
+                os.path.abspath(str(self.tmp)),
+            )
+
+    def test_worktree_repo_root_expands_user_and_vars(self):
+        from tools import delegate_tool
+
+        with mock.patch.dict(os.environ, {"MY_REPO_DIR": str(self.tmp)}):
+            with mock.patch.object(
+                delegate_tool, "_load_config",
+                return_value={"worktree_repo_root": "$MY_REPO_DIR"},
+            ):
+                self.assertEqual(
+                    delegate_tool._get_worktree_repo_root(),
+                    os.path.abspath(str(self.tmp)),
+                )
+
+    def test_resolve_worktree_anchor_prefers_configured_repo_root(self):
+        from tools import delegate_tool
+
+        repo1 = _make_repo(self.tmp / "r1")
+        repo2 = _make_repo(self.tmp / "r2")
+        with mock.patch.object(
+            delegate_tool, "_load_config",
+            return_value={"worktree_repo_root": str(repo2)},
+        ):
+            anchor = delegate_tool._resolve_worktree_anchor(
+                parent_cwd=str(repo1),
+                parent_agent=None,
+            )
+            self.assertEqual(
+                Path(anchor).resolve(),
+                repo2.resolve(),
+            )
+
+    def test_resolve_worktree_anchor_falls_back_to_parent_cwd_when_no_config(self):
+        from tools import delegate_tool
+
+        repo1 = _make_repo(self.tmp / "r1")
+        repo2 = _make_repo(self.tmp / "r2")
+        with mock.patch.object(
+            delegate_tool, "_load_config",
+            return_value={},
+        ), mock.patch.object(
+            delegate_tool, "_resolve_workspace_hint",
+            return_value=str(repo2),
+        ):
+            anchor = delegate_tool._resolve_worktree_anchor(
+                parent_cwd=str(repo1),
+                parent_agent=mock.MagicMock(),
+            )
+            self.assertEqual(
+                Path(anchor).resolve(),
+                repo1.resolve(),
+            )
+
+    def test_resolve_worktree_anchor_falls_back_to_workspace_hint_when_parent_cwd_non_git(self):
+        from tools import delegate_tool
+
+        plain = self.tmp / "plain"
+        plain.mkdir(parents=True, exist_ok=True)
+        repo = _make_repo(self.tmp / "hint_repo")
+
+        with mock.patch.object(
+            delegate_tool, "_load_config",
+            return_value={},
+        ), mock.patch.object(
+            delegate_tool, "_resolve_workspace_hint",
+            return_value=str(repo),
+        ):
+            anchor = delegate_tool._resolve_worktree_anchor(
+                parent_cwd=str(plain),
+                parent_agent=mock.MagicMock(),
+            )
+            self.assertEqual(
+                Path(anchor).resolve(),
+                repo.resolve(),
+            )
+
+    def test_resolve_worktree_anchor_returns_none_when_all_non_git(self):
+        from tools import delegate_tool
+
+        plain = self.tmp / "plain"
+        plain.mkdir(parents=True, exist_ok=True)
+
+        with mock.patch.object(
+            delegate_tool, "_load_config",
+            return_value={"worktree_repo_root": str(plain)},
+        ):
+            anchor = delegate_tool._resolve_worktree_anchor(
+                parent_cwd=str(plain),
+                parent_agent=None,
+            )
+            self.assertIsNone(anchor)
+
+    def test_setup_subagent_worktree_happy_path_creates_worktree(self):
+        from tools import delegate_tool
+
+        repo = _make_repo(self.tmp / "happy_repo")
+        with mock.patch.object(delegate_tool, "_get_worktree_isolation", return_value=True), \
+             mock.patch("tools.subagent_worktree.local_backend_active", return_value=True), \
+             mock.patch.object(delegate_tool, "_resolve_worktree_anchor", return_value=str(repo)):
+            info = delegate_tool._setup_subagent_worktree(
+                parent_agent=None,
+                parent_task_id=None,
+                subagent_id="sub-happy",
+            )
+            self.assertIsNotNone(info)
+            self.assertIn("path", info)
+            self.assertIn("branch", info)
+            self.assertIn("base_commit", info)
+            self.assertIn("repo_root", info)
+            self.assertTrue(os.path.isdir(info["path"]))
+
+    def test_setup_subagent_worktree_warns_when_backend_not_local(self):
+        from tools import delegate_tool
+
+        with mock.patch.object(delegate_tool, "_get_worktree_isolation", return_value=True), \
+             mock.patch("tools.subagent_worktree.local_backend_active", return_value=False), \
+             self.assertLogs("tools.delegate_tool", level="WARNING") as cm:
+            info = delegate_tool._setup_subagent_worktree(
+                parent_agent=None,
+                parent_task_id=None,
+                subagent_id="sub-1",
+            )
+            self.assertIsNone(info)
+            self.assertTrue(any("non-local terminal backend" in m for m in cm.output))
+
+    def test_setup_subagent_worktree_warns_when_anchor_resolution_fails(self):
+        from tools import delegate_tool
+
+        with mock.patch.object(delegate_tool, "_get_worktree_isolation", return_value=True), \
+             mock.patch("tools.subagent_worktree.local_backend_active", return_value=True), \
+             mock.patch.object(delegate_tool, "_resolve_worktree_anchor", return_value=None), \
+             self.assertLogs("tools.delegate_tool", level="WARNING") as cm:
+            info = delegate_tool._setup_subagent_worktree(
+                parent_agent=None,
+                parent_task_id=None,
+                subagent_id="sub-2",
+            )
+            self.assertIsNone(info)
+            self.assertTrue(any("no git repository anchor found" in m.lower() or "isolation skipped" in m.lower() for m in cm.output))
+
 
 if __name__ == "__main__":
     unittest.main()
+
+

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -898,6 +898,103 @@ def _get_worktree_isolation() -> bool:
     return bool(cfg.get("worktree_isolation", False))
 
 
+def _get_worktree_repo_root() -> Optional[str]:
+    """Read delegation.worktree_repo_root from config (optional absolute path).
+
+    Allows persistent/owner sessions (whose recorded cwd may be home or non-git)
+    to explicitly pin a git repository root for subagent worktrees (#97209).
+    """
+    cfg = _load_config()
+    val = cfg.get("worktree_repo_root")
+    if not val or not isinstance(val, str) or not val.strip():
+        return None
+    try:
+        expanded = os.path.expanduser(os.path.expandvars(val.strip()))
+        return os.path.abspath(expanded)
+    except Exception:
+        return None
+
+
+def _resolve_worktree_anchor(
+    parent_cwd: Optional[str],
+    parent_agent: Any = None,
+) -> Optional[str]:
+    """Resolve the git repository root anchor for subagent worktree creation.
+
+    Priority order (#97209):
+    1. ``_get_worktree_repo_root()`` (configured root in preference when specified).
+    2. ``parent_cwd`` if it resolves to a git repository.
+    3. ``_resolve_workspace_hint(parent_agent)`` if it resolves to a git repository.
+    """
+    from tools import subagent_worktree
+
+    candidates = [
+        _get_worktree_repo_root(),
+        parent_cwd,
+        _resolve_workspace_hint(parent_agent) if parent_agent is not None else None,
+    ]
+    for candidate in candidates:
+        if not candidate:
+            continue
+        root = subagent_worktree.resolve_repo_root(candidate)
+        if root:
+            return root
+    return None
+
+
+def _setup_subagent_worktree(
+    parent_agent: Any,
+    parent_task_id: Optional[str],
+    subagent_id: Optional[str],
+) -> Optional[Dict[str, Any]]:
+    """Set up an isolated git worktree for a child subagent if enabled.
+
+    Emits visible warnings when isolation is requested (worktree_isolation: true)
+    but skipped due to non-local backend or unresolvable git repo anchor (#97209).
+    """
+    if not _get_worktree_isolation():
+        return None
+    try:
+        from tools import subagent_worktree
+
+        if not subagent_worktree.local_backend_active():
+            logger.warning(
+                "Subagent worktree isolation skipped: non-local terminal backend is active"
+            )
+            return None
+
+        _parent_cwd = None
+        try:
+            from tools.terminal_tool import get_session_cwd as _gsc
+
+            _parent_cwd = _gsc(parent_task_id)
+        except Exception:
+            pass
+
+        anchor = _resolve_worktree_anchor(_parent_cwd, parent_agent)
+        if not anchor:
+            logger.warning(
+                "Subagent worktree isolation skipped: no git repository anchor found "
+                "(checked session cwd %r, workspace hint, and delegation.worktree_repo_root)",
+                _parent_cwd,
+            )
+            return None
+
+        worktree_info = subagent_worktree.create_subagent_worktree(
+            anchor,
+            subagent_id=subagent_id,
+        )
+        if worktree_info is None:
+            logger.warning(
+                "Subagent worktree isolation failed to create worktree in %s",
+                anchor,
+            )
+        return worktree_info
+    except Exception as exc:
+        logger.warning("Subagent worktree isolation setup failed: %s", exc)
+        return None
+
+
 _LEGACY_MAX_ASYNC_WARNED = False
 
 
@@ -2736,43 +2833,22 @@ def _run_single_child(
         # Opt-in worktree isolation (delegation.worktree_isolation, inspired
         # by Muse Code's --subagent-worktree-isolation): give this child its
         # own git worktree branched from the parent repo's HEAD, and start its
-        # terminal there. Git-only and local-backend-only; any failure
-        # degrades silently to the shared-workspace behavior above.
-        if _get_worktree_isolation():
+        # terminal there. Git-only and local-backend-only; warns if isolation
+        # cannot resolve a git anchor or backend is non-local (#97209).
+        _worktree_info = _setup_subagent_worktree(parent_agent, parent_task_id, _subagent_id)
+        if _worktree_info is not None:
             try:
-                from tools import subagent_worktree
+                from tools.terminal_tool import record_session_cwd as _rsc
 
-                if subagent_worktree.local_backend_active():
-                    _parent_cwd = None
-                    try:
-                        from tools.terminal_tool import get_session_cwd as _gsc
-
-                        _parent_cwd = _gsc(parent_task_id)
-                    except Exception:
-                        pass
-                    _worktree_info = subagent_worktree.create_subagent_worktree(
-                        _parent_cwd or _resolve_workspace_hint(parent_agent),
-                        subagent_id=_subagent_id,
-                    )
-                else:
-                    logger.debug(
-                        "worktree isolation skipped: non-local terminal backend"
-                    )
+                _rsc(child_task_id, _worktree_info["path"])
             except Exception as e:
-                logger.debug("worktree isolation setup failed: %s", e)
-            if _worktree_info is not None:
-                try:
-                    from tools.terminal_tool import record_session_cwd as _rsc
+                logger.debug("worktree cwd seed failed: %s", e)
+            # The child's context is already built; carry the isolation
+            # contract on the goal message instead (same turn, no
+            # system-prompt mutation).
+            from tools.subagent_worktree import build_worktree_context_note
 
-                    _rsc(child_task_id, _worktree_info["path"])
-                except Exception as e:
-                    logger.debug("worktree cwd seed failed: %s", e)
-                # The child's context is already built; carry the isolation
-                # contract on the goal message instead (same turn, no
-                # system-prompt mutation).
-                from tools.subagent_worktree import build_worktree_context_note
-
-                goal = goal + build_worktree_context_note(_worktree_info)
+            goal = goal + build_worktree_context_note(_worktree_info)
 
         wall_start = time.time()
         parent_reads_snapshot = (


### PR DESCRIPTION
## What does this PR do?

Resolves an issue where `delegation.worktree_isolation` silently degraded to shared-workspace execution whenever the parent session's recorded cwd did not resolve to a git repository (common in persistent/owner sessions like Telegram or gateway daemons whose starting cwd is `~`).

This PR:
1. Adds support for `delegation.worktree_repo_root` in `config.yaml` to allow persistent sessions to explicitly pin a git repository root anchor for subagent worktrees.
2. Introduces anchor resolution prioritizing explicitly configured `worktree_repo_root` in preference when set, falling back to active `parent_cwd` and `workspace_hint`.
3. Emits visible `logger.warning` diagnostics when `worktree_isolation: true` is configured but cannot be activated (due to a non-local terminal backend or missing git repository anchor), eliminating silent degradation.
4. Documents `worktree_isolation` and `worktree_repo_root` in `cli-config.yaml.example`.

## Related Issue

Fixes #97209

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/delegate_tool.py`:
  - Added `_get_worktree_repo_root()` helper reading and expanding `delegation.worktree_repo_root` from configuration.
  - Added `_resolve_worktree_anchor(parent_cwd, parent_agent)` to resolve the active repo root prioritizing configured repo root, parent session cwd, and workspace hints.
  - Added `_setup_subagent_worktree(parent_agent, parent_task_id, subagent_id)` logging explicit warnings on non-local backend or missing git anchor.
  - Replaced inline spawn setup logic with `_setup_subagent_worktree`.
- `cli-config.yaml.example`:
  - Documented `delegation.worktree_isolation` and `delegation.worktree_repo_root`.
- `tests/tools/test_subagent_worktree.py`:
  - Added unit tests for `worktree_repo_root` configuration reading and environment variable expansion.
  - Added test cases verifying anchor resolution priority, fallback behavior, happy-path worktree creation, and diagnostic warning emissions on non-local backend and missing git repo anchors.
  - Made `_break_git_index` test helper cross-platform by parsing `.git` gitdir file directly.

## How to Test

Run the unit and integration test suites:

```bash
pytest tests/tools/test_subagent_worktree.py -q --tb=short
# 31 passed

pytest tests/tools/test_delegate.py -q --tb=short
# 70 passed
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 / Linux (Python 3.11)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
