### PR TITLE
fix(mcp): avoid OAuth stdin race with CLI prompt

### DIFF
--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -973,6 +973,37 @@ class TestWaitForCallbackPasteIntegration:
         err = capsys.readouterr().err
         assert "paste the redirect URL" in err
 
+    def test_paste_prompt_not_started_while_prompt_toolkit_is_active(
+        self, monkeypatch, capsys
+    ):
+        """OAuth must not compete with prompt_toolkit for the same stdin."""
+        import tools.mcp_oauth as mod
+        from prompt_toolkit.application.current import set_app
+
+        mod._oauth_port = _find_free_port()
+        monkeypatch.setattr(mod, "_is_interactive", lambda: True)
+        readline_called = mod.threading.Event()
+
+        def record_readline():
+            readline_called.set()
+            return ""
+
+        monkeypatch.setattr(
+            mod.sys, "stdin", MagicMock(readline=record_readline)
+        )
+
+        async def instant_sleep(_):
+            pass
+
+        with set_app(object()), patch.object(mod.asyncio, "sleep", instant_sleep):
+            with pytest.raises(OAuthNonInteractiveError):
+                asyncio.run(_wait_for_callback())
+
+        assert not readline_called.wait(1)
+        err = capsys.readouterr().err
+        assert "paste the redirect URL" not in err
+        assert "paste is unavailable while the Hermes prompt owns" in err
+
     def test_paste_prompt_NOT_shown_when_interactivity_suppressed(self, monkeypatch, capsys):
         """Background MCP discovery must not race the CLI/TUI stdin reader."""
         import tools.mcp_oauth as mod

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -334,6 +334,16 @@ def _is_interactive() -> bool:
         return False
 
 
+def _prompt_toolkit_owns_stdin() -> bool:
+    """Return True while an active prompt_toolkit app owns terminal input."""
+    try:
+        from prompt_toolkit.application.current import get_app_or_none
+
+        return get_app_or_none() is not None
+    except Exception:
+        return False
+
+
 def _raise_if_non_interactive(lead: str) -> None:
     """Raise ``OAuthNonInteractiveError`` unless an interactive session exists.
 
@@ -1019,7 +1029,8 @@ def _make_callback_waiter(
         # result dict. The HTTP listener and this thread race for the result;
         # whichever fills it first wins.
         paste_thread: threading.Thread | None = None
-        if _is_interactive():
+        interactive = _is_interactive()
+        if interactive and not _prompt_toolkit_owns_stdin():
             print(
                 "\n  Or paste the redirect URL here (or the ``?code=...&state=...`` "
                 "portion) and press Enter. Type ``skip`` + Enter to continue "
@@ -1031,6 +1042,14 @@ def _make_callback_waiter(
                 target=_paste_callback_reader, args=(result,), daemon=True
             )
             paste_thread.start()
+        elif interactive:
+            print(
+                "\n  OAuth redirect paste is unavailable while the Hermes prompt "
+                "owns terminal input. Complete the browser redirect, or run "
+                "`hermes mcp login <server>` in a separate terminal.",
+                file=sys.stderr,
+                flush=True,
+            )
 
         poll_interval = 0.5
         elapsed = 0.0


### PR DESCRIPTION
## What does this PR do?

Prevents MCP OAuth from starting a raw `sys.stdin.readline()` thread while the classic CLI's active `prompt_toolkit` application owns terminal input. Without this guard, both readers race for keystrokes and the CLI can appear frozen.

The browser callback remains available. When the Hermes prompt owns stdin, the CLI directs users to finish the browser redirect or run `hermes mcp login SERVER` in another terminal. Plain interactive terminals retain the redirect-paste fallback.

## Related Issue

Fixes #97268.

Related to #15216. Follow-up to #53294, which suppressed interactive OAuth during background discovery; this change covers OAuth reached while a `prompt_toolkit` application is active. Open PR #97216 touches the same files but addresses OAuth storage lifecycle rather than stdin ownership.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/mcp_oauth.py` — skip the redirect-paste reader when `prompt_toolkit` owns stdin and print an actionable fallback.
- `tests/tools/test_mcp_oauth.py` — verify that OAuth never calls `readline()` under an active `prompt_toolkit` application.

## How to Test

1. Reproduce the bug on `main`: start the classic CLI, trigger MCP OAuth while its `prompt_toolkit` prompt is active, and observe the OAuth paste reader competing for terminal input.
2. Run the focused regression suite:
   ```text
   uv run --frozen --extra dev pytest -q tests/tools/test_mcp_oauth.py -o addopts=''
   # 59 passed
   ```
3. Run the related approval regression tests and lint:
   ```text
   uv run --frozen --extra dev pytest -q tests/tools/test_approval.py -k 'FailClosedUnderPromptToolkit' -o addopts=''
   # 2 passed, 106 deselected

   uv run --frozen --extra dev ruff check tools/mcp_oauth.py tests/tools/test_mcp_oauth.py
   # All checks passed
   ```

The new regression test fails on `origin/main` at `0abecf7a93948da386d3b23adba37475cc40fe53` because the paste reader calls `readline()` while `prompt_toolkit` is active. Manual end-to-end verification of the fixed OAuth path has not been run.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.1, Python 3.11, Ghostty + tmux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no public interface changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the guard uses `prompt_toolkit` state and adds no platform-specific API
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
