### PR TITLE
fix(slack): rerun prior reports without a mention

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -8051,12 +8051,15 @@ class SlackAdapter(BasePlatformAdapter):
     ) -> str:
         """Recover a nearby self-authored root report for a fresh-data request."""
         session_store = getattr(self, "_session_store", None)
-        ensure_loaded = getattr(session_store, "_ensure_loaded", None)
-        if callable(ensure_loaded):
-            ensure_loaded()
+        list_sessions = getattr(session_store, "list_sessions", None)
+        try:
+            session_entries: Any = list_sessions() if callable(list_sessions) else []
+        except Exception as exc:
+            logger.warning("[Slack] Failed to snapshot re-query sessions: %s", exc)
+            session_entries = []
         canonical_threads = {
             str(origin.thread_id)
-            for entry in getattr(session_store, "_entries", {}).values()
+            for entry in session_entries
             if (origin := getattr(entry, "origin", None))
             and origin.platform == Platform.SLACK
             and str(origin.chat_id) == str(channel_id)

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -466,11 +466,11 @@ _SLACK_REQUERY_PATTERNS = (
     ),
     re.compile(
         r"(?:다시|재조회|새로|최신).{0,16}(?:값|데이터|결과).{0,16}"
-        r"(?:가져|조회|확인|갱신|업데이트)"
+        r"(?:가져|가저|가지고\s*와|조회|확인|갱신|업데이트)"
     ),
     re.compile(
         r"(?:값|데이터|결과).{0,16}(?:다시|재조회|새로|최신).{0,16}"
-        r"(?:가져|조회|확인|갱신|업데이트)"
+        r"(?:가져|가저|가지고\s*와|조회|확인|갱신|업데이트)"
     ),
 )
 
@@ -8050,29 +8050,76 @@ class SlackAdapter(BasePlatformAdapter):
         team_id: str = "",
     ) -> str:
         """Recover a nearby self-authored root report for a fresh-data request."""
-        try:
-            result = await self._get_client(
-                channel_id, team_id=team_id
-            ).conversations_history(
-                channel=channel_id,
-                latest=current_ts,
-                inclusive=False,
-                limit=50,
+        session_store = getattr(self, "_session_store", None)
+        ensure_loaded = getattr(session_store, "_ensure_loaded", None)
+        if callable(ensure_loaded):
+            ensure_loaded()
+        canonical_threads = {
+            str(origin.thread_id)
+            for entry in getattr(session_store, "_entries", {}).values()
+            if (origin := getattr(entry, "origin", None))
+            and origin.platform == Platform.SLACK
+            and str(origin.chat_id) == str(channel_id)
+            and origin.user_id == "system:cron"
+            and origin.thread_id
+            and (
+                not team_id
+                or not getattr(origin, "scope_id", None)
+                or str(origin.scope_id) == str(team_id)
             )
+        }
+        if len(canonical_threads) > 1:
+            return (
+                "[Slack 재조회 컨텍스트] 가까운 보고서가 여러 개입니다. "
+                "어느 보고서인지 사용자에게 물어보고 원본 도구를 실행하지 마십시오.\n\n"
+            )
+
+        try:
+            client = self._get_client(channel_id, team_id=team_id)
             bot_uid = self._team_bot_user_ids.get(team_id, self._bot_user_id)
-            current = float(current_ts)
             candidates = []
-            for message in (result or {}).get("messages", []):
+            history_messages = []
+            if canonical_threads:
+                thread_ts = next(iter(canonical_threads))
+                result = await client.conversations_replies(
+                    channel=channel_id,
+                    ts=thread_ts,
+                    limit=1,
+                    inclusive=True,
+                )
+                messages = (result or {}).get("messages", [])
+                if messages:
+                    message = messages[0]
+                    if (
+                        message.get("user") == bot_uid
+                        and str(message.get("ts") or "") == thread_ts
+                    ):
+                        text = self._render_message_text(
+                            message, bot_uid=bot_uid or ""
+                        ).strip()
+                        if len(text) >= 40:
+                            candidates.append(text)
+
+            if not candidates:
+                result = await client.conversations_history(
+                    channel=channel_id,
+                    latest=current_ts,
+                    inclusive=False,
+                    limit=50,
+                )
+                history_messages = (result or {}).get("messages", [])
+            for message in history_messages:
                 message_ts = str(message.get("ts") or "")
                 thread_ts = str(message.get("thread_ts") or "")
                 if (
                     message.get("user") != bot_uid
                     or (thread_ts and thread_ts != message_ts)
                     or not message_ts
-                    or current - float(message_ts) > 900
                 ):
                     continue
-                text = self._render_message_text(message, bot_uid=bot_uid or "").strip()
+                text = self._render_message_text(
+                    message, bot_uid=bot_uid or ""
+                ).strip()
                 if len(text) >= 40:
                     candidates.append(text)
                 if len(candidates) == 3:

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -459,6 +459,29 @@ def _rewrite_known_bang_command(text: str) -> str:
     return text
 
 
+_SLACK_REQUERY_PATTERNS = (
+    re.compile(
+        r"(?:방금|이전|위|앞서).{0,24}(?:보고|데이터|결과|값).{0,24}"
+        r"(?:다시|재조회|새로|최신|갱신|업데이트)"
+    ),
+    re.compile(
+        r"(?:다시|재조회|새로|최신).{0,16}(?:값|데이터|결과).{0,16}"
+        r"(?:가져|조회|확인|갱신|업데이트)"
+    ),
+    re.compile(
+        r"(?:값|데이터|결과).{0,16}(?:다시|재조회|새로|최신).{0,16}"
+        r"(?:가져|조회|확인|갱신|업데이트)"
+    ),
+)
+
+
+def _slack_requery_intent(text: str) -> bool:
+    """Recognize only explicit Korean requests to refresh prior report data."""
+    return bool(text) and any(
+        pattern.search(text) for pattern in _SLACK_REQUERY_PATTERNS
+    )
+
+
 def _slack_permalink_path(channel_id: str | None, message_ts: str | None) -> str:
     """The workspace-independent tail of a Slack message permalink.
 
@@ -6412,6 +6435,8 @@ class SlackAdapter(BasePlatformAdapter):
             (bot_uid and f"<@{bot_uid}>" in routing_text)
             or self._slack_message_matches_mention_patterns(routing_text)
         )
+        is_requery = _slack_requery_intent(routing_text)
+        is_addressed = is_mentioned or is_requery
         event_thread_ts = event.get("thread_ts")
         is_thread_reply = bool(event_thread_ts and event_thread_ts != ts)
         # Internal routing paths (reaction triggers) are pre-authorized as
@@ -6460,7 +6485,7 @@ class SlackAdapter(BasePlatformAdapter):
             self_uids = {u for u in (bot_uid, self._bot_user_id) if u}
             if (
                 self._slack_ignore_other_user_mentions()
-                and not is_mentioned
+                and not is_addressed
                 and not self._slack_message_mentions_self(routing_text, self_uids)
                 and self._slack_message_addressed_to_other_user(routing_text, self_uids)
             ):
@@ -6488,7 +6513,7 @@ class SlackAdapter(BasePlatformAdapter):
                 if (
                     self._slack_thread_require_mention()
                     and is_thread_reply
-                    and not is_mentioned
+                    and not is_addressed
                 ):
                     logger.debug(
                         "[Slack] Ignoring thread reply without mention "
@@ -6497,12 +6522,12 @@ class SlackAdapter(BasePlatformAdapter):
                         event_thread_ts,
                     )
                     return
-            elif self._slack_strict_mention() and not is_mentioned:
+            elif self._slack_strict_mention() and not is_addressed:
                 return  # Strict mode: ignore until @-mentioned again
             elif (
                 self._slack_thread_require_mention()
                 and is_thread_reply
-                and not is_mentioned
+                and not is_addressed
             ):
                 logger.debug(
                     "[Slack] Ignoring thread reply without mention "
@@ -6511,7 +6536,7 @@ class SlackAdapter(BasePlatformAdapter):
                     event_thread_ts,
                 )
                 return
-            elif not is_mentioned:
+            elif not is_addressed:
                 if not await self._should_wake_on_unmentioned_message(
                     event_thread_ts=event_thread_ts,
                     channel_id=channel_id,
@@ -6606,6 +6631,12 @@ class SlackAdapter(BasePlatformAdapter):
         # command routing can misclassify it as conversational text.
         # ``channel_context`` is prepended only after command dispatch.
         channel_context = None
+        if is_requery and not is_thread_reply:
+            channel_context = await self._fetch_requery_context(
+                channel_id=channel_id,
+                current_ts=ts,
+                team_id=team_id,
+            )
         # Thread-root images recovered on the cold-start hydrate: when the
         # bot is mentioned mid-thread for the first time, the thread root is
         # very often the artifact the mention is about ("@bot what's in this
@@ -6656,7 +6687,7 @@ class SlackAdapter(BasePlatformAdapter):
             self._mark_thread_rehydration_checked(
                 channel_id, event_thread_ts, user_id, team_id
             )
-        elif is_thread_reply and has_active_thread_session and is_mentioned:
+        elif is_thread_reply and has_active_thread_session and is_addressed:
             # Explicit @mention on an active thread is a fresh intent signal:
             # the user expects the bot to read the CURRENT thread state, which
             # may include replies (e.g. from other bots/integrations) that
@@ -6738,6 +6769,14 @@ class SlackAdapter(BasePlatformAdapter):
                     watermark_ts=ts,
                     team_id=team_id,
                 )
+
+        if is_requery and is_thread_reply:
+            channel_context = (
+                "[Slack 재조회 지시] 스레드의 이전 수치를 반복하지 말고 연결된 "
+                "보고서의 원본 도구를 새로 실행해 그 결과만 답하십시오. 컨텍스트가 "
+                "불충분하거나 여러 보고서가 후보이면 어느 보고서인지 먼저 "
+                "물으십시오.\n\n" + (channel_context or "")
+            )
 
         # Determine message type
         msg_type = MessageType.TEXT
@@ -7117,7 +7156,9 @@ class SlackAdapter(BasePlatformAdapter):
         # MPIMs are shared surfaces: reacting to every group-DM message (even
         # when unmentioned) is visible noise to the whole group, so they must
         # be @mentioned to earn a reaction — same as any channel.
-        _should_react = (is_one_to_one_dm or is_mentioned) and self._reactions_enabled()
+        _should_react = (
+            (is_one_to_one_dm or is_mentioned) or is_requery
+        ) and self._reactions_enabled()
         if _should_react:
             self._reacting_message_ids.add(
                 self._workspace_message_marker(team_id, ts)
@@ -8001,6 +8042,67 @@ class SlackAdapter(BasePlatformAdapter):
             msg_text = (msg_text + "\n" + addendum).strip() if msg_text else addendum
 
         return msg_text
+
+    async def _fetch_requery_context(
+        self,
+        channel_id: str,
+        current_ts: str,
+        team_id: str = "",
+    ) -> str:
+        """Recover a nearby self-authored root report for a fresh-data request."""
+        try:
+            result = await self._get_client(
+                channel_id, team_id=team_id
+            ).conversations_history(
+                channel=channel_id,
+                latest=current_ts,
+                inclusive=False,
+                limit=50,
+            )
+            bot_uid = self._team_bot_user_ids.get(team_id, self._bot_user_id)
+            current = float(current_ts)
+            candidates = []
+            for message in (result or {}).get("messages", []):
+                message_ts = str(message.get("ts") or "")
+                thread_ts = str(message.get("thread_ts") or "")
+                if (
+                    message.get("user") != bot_uid
+                    or (thread_ts and thread_ts != message_ts)
+                    or not message_ts
+                    or current - float(message_ts) > 900
+                ):
+                    continue
+                text = self._render_message_text(message, bot_uid=bot_uid or "").strip()
+                if len(text) >= 40:
+                    candidates.append(text)
+                if len(candidates) == 3:
+                    break
+        except (TypeError, ValueError) as exc:
+            logger.debug("[Slack] Invalid re-query history timestamp: %s", exc)
+            candidates = []
+        except Exception as exc:
+            logger.warning("[Slack] Failed to recover re-query context: %s", exc)
+            candidates = []
+
+        if not candidates:
+            return (
+                "[Slack 재조회 컨텍스트] 연결할 최근 보고서를 찾지 못했습니다. "
+                "어느 보고서인지 사용자에게 물어보고 원본 도구를 실행하지 마십시오.\n\n"
+            )
+        if len(candidates) > 1:
+            return (
+                "[Slack 재조회 컨텍스트] 가까운 보고서가 여러 개입니다. "
+                "어느 보고서인지 사용자에게 물어보고 원본 도구를 실행하지 마십시오.\n\n"
+            )
+
+        from gateway.session import neutralize_untrusted_inline_text
+
+        prior = neutralize_untrusted_inline_text(candidates[0], max_chars=12000)
+        return (
+            "[Slack 재조회 컨텍스트] 사용자는 이전 수치의 반복이 아니라 새 수치를 "
+            "요청했습니다. 연결된 보고서의 원본 도구를 새로 실행하고 그 결과만 "
+            f"답하십시오.\n[이전 보고서] {prior}\n\n"
+        )
 
     async def _fetch_thread_context(
         self,

--- a/tests/gateway/test_slack_requery.py
+++ b/tests/gateway/test_slack_requery.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from gateway.config import PlatformConfig
+from gateway.config import Platform, PlatformConfig
 from plugins.platforms.slack.adapter import SlackAdapter, _slack_requery_intent
 
 
@@ -40,6 +40,10 @@ def routing_adapter():
 @pytest.mark.parametrize(
     "text",
     [
+        "다시 값을 가지고 와줘",
+        "값을 다시 가지고 와 주세요",
+        "다시 값 가지고와줘",
+        "다시 값을 가저와줘",
         "다시 값을 가져와줘",
         "방금 보고 데이터를 다시 조회해줘",
         "이전 결과를 최신 값으로 갱신해줘",
@@ -57,15 +61,19 @@ def test_requery_intent_rejects_unrelated_messages(text):
     assert not _slack_requery_intent(text)
 
 
-def _adapter(messages):
+def _adapter(messages, *, session_entries=None, thread_messages=None):
     adapter = object.__new__(SlackAdapter)
     adapter.config = PlatformConfig(enabled=True, extra={})
     adapter._bot_user_id = "U_BOT"
     adapter._team_bot_user_ids = {}
     client = SimpleNamespace(
-        conversations_history=AsyncMock(return_value={"messages": messages})
+        conversations_history=AsyncMock(return_value={"messages": messages}),
+        conversations_replies=AsyncMock(
+            return_value={"messages": thread_messages or []}
+        ),
     )
     adapter._get_client = lambda *_args, **_kwargs: client
+    adapter._session_store = SimpleNamespace(_entries=session_entries or {})
     return adapter, client
 
 
@@ -85,6 +93,69 @@ async def test_root_requery_recovers_single_nearest_self_report(channel_id):
     client.conversations_history.assert_awaited_once_with(
         channel=channel_id, latest="100.0", inclusive=False, limit=50
     )
+
+
+@pytest.mark.asyncio
+async def test_root_requery_history_fallback_accepts_hours_old_report():
+    adapter, _ = _adapter([
+        {"ts": "100.0", "user": "U_BOT", "text": "항공권 보고: " + "원본 값 " * 10},
+    ])
+
+    context = await adapter._fetch_requery_context("G_PRIVATE", "20000.0")
+
+    assert "항공권 보고" in context
+
+
+@pytest.mark.asyncio
+async def test_root_requery_prefers_canonical_cron_session_hours_later():
+    adapter, client = _adapter(
+        [
+            {"ts": "19999.0", "user": "U_BOT", "text": "unlinked report " * 10},
+        ],
+        session_entries={
+            "cron-report": SimpleNamespace(
+                origin=SimpleNamespace(
+                    platform=Platform.SLACK,
+                    chat_id="C1",
+                    thread_id="100.0",
+                    user_id="system:cron",
+                )
+            )
+        },
+        thread_messages=[
+            {"ts": "100.0", "user": "U_BOT", "text": "항공권 보고 " * 10},
+        ],
+    )
+
+    context = await adapter._fetch_requery_context("C1", "20000.0")
+
+    assert "항공권 보고" in context
+    client.conversations_replies.assert_awaited_once_with(
+        channel="C1", ts="100.0", limit=1, inclusive=True
+    )
+    client.conversations_history.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_root_requery_fails_closed_for_multiple_canonical_cron_sessions():
+    origins = {
+        name: SimpleNamespace(
+            origin=SimpleNamespace(
+                platform=Platform.SLACK,
+                chat_id="C1",
+                thread_id=ts,
+                user_id="system:cron",
+            )
+        )
+        for name, ts in (("first", "100.0"), ("second", "200.0"))
+    }
+    adapter, client = _adapter([], session_entries=origins)
+
+    context = await adapter._fetch_requery_context("C1", "20000.0")
+
+    assert "가까운 보고서가 여러 개" in context
+    client.conversations_replies.assert_not_awaited()
+    client.conversations_history.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_slack_requery.py
+++ b/tests/gateway/test_slack_requery.py
@@ -1,0 +1,183 @@
+"""Bounded Slack re-query intent and root-context recovery."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from plugins.platforms.slack.adapter import SlackAdapter, _slack_requery_intent
+
+
+@pytest.fixture()
+def routing_adapter():
+    adapter = SlackAdapter(PlatformConfig(enabled=True, token="redacted"))
+    adapter._bot_user_id = "U_BOT"
+    adapter._running = True
+    adapter._app = SimpleNamespace(
+        client=SimpleNamespace(
+            users_info=AsyncMock(
+                return_value={
+                    "user": {
+                        "is_bot": False,
+                        "profile": {"display_name": "Tester"},
+                    }
+                }
+            ),
+            conversations_info=AsyncMock(return_value={"channel": {"name": "reports"}}),
+        )
+    )
+    adapter.handle_message = AsyncMock()
+    adapter._fetch_requery_context = AsyncMock(return_value="fresh-query-context")
+    adapter._fetch_thread_context = AsyncMock(return_value="thread-report-context")
+    adapter._fetch_thread_parent_text = AsyncMock(return_value="")
+    adapter._collect_thread_root_images = AsyncMock(return_value=([], []))
+    adapter._has_active_session_for_thread = MagicMock(return_value=False)
+    adapter._reactions_enabled = MagicMock(return_value=False)
+    return adapter
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "다시 값을 가져와줘",
+        "방금 보고 데이터를 다시 조회해줘",
+        "이전 결과를 최신 값으로 갱신해줘",
+    ],
+)
+def test_requery_intent_accepts_bounded_korean_variants(text):
+    assert _slack_requery_intent(text)
+
+
+@pytest.mark.parametrize(
+    "text",
+    ["다시 설명해줘", "값 알려줘", "오늘 날씨 조회해줘", "hello everyone"],
+)
+def test_requery_intent_rejects_unrelated_messages(text):
+    assert not _slack_requery_intent(text)
+
+
+def _adapter(messages):
+    adapter = object.__new__(SlackAdapter)
+    adapter.config = PlatformConfig(enabled=True, extra={})
+    adapter._bot_user_id = "U_BOT"
+    adapter._team_bot_user_ids = {}
+    client = SimpleNamespace(
+        conversations_history=AsyncMock(return_value={"messages": messages})
+    )
+    adapter._get_client = lambda *_args, **_kwargs: client
+    return adapter, client
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("channel_id", ["C_PUBLIC", "G_PRIVATE", "D_DM"])
+async def test_root_requery_recovers_single_nearest_self_report(channel_id):
+    adapter, client = _adapter([
+        {"ts": "99.0", "user": "U_BOT", "text": "매출 보고: " + "신규 원본 값 " * 8},
+        {"ts": "98.0", "user": "U_HUMAN", "text": "unrelated human text"},
+    ])
+
+    context = await adapter._fetch_requery_context(channel_id, "100.0")
+
+    assert "신규 원본 값" in context
+    assert "원본 도구를 새로 실행" in context
+    assert "unrelated human text" not in context
+    client.conversations_history.assert_awaited_once_with(
+        channel=channel_id, latest="100.0", inclusive=False, limit=50
+    )
+
+
+@pytest.mark.asyncio
+async def test_root_requery_asks_when_multiple_reports_are_ambiguous():
+    adapter, _ = _adapter([
+        {"ts": "99.0", "user": "U_BOT", "text": "첫 번째 보고 " * 10},
+        {"ts": "98.0", "user": "U_BOT", "text": "두 번째 보고 " * 10},
+    ])
+
+    context = await adapter._fetch_requery_context("C1", "100.0")
+
+    assert "어느 보고서" in context
+    assert "원본 도구를 실행하지 마십시오" in context
+
+
+@pytest.mark.asyncio
+async def test_root_requery_ignores_self_reply_and_bot_duplicates():
+    adapter, _ = _adapter([
+        {
+            "ts": "99.0",
+            "thread_ts": "90.0",
+            "user": "U_BOT",
+            "text": "스레드 응답 " * 10,
+        },
+        {"ts": "98.0", "user": "U_OTHER_BOT", "text": "다른 봇 보고 " * 10},
+    ])
+
+    context = await adapter._fetch_requery_context("C1", "100.0")
+
+    assert "연결할 최근 보고서를 찾지 못했습니다" in context
+
+
+@pytest.mark.asyncio
+async def test_root_requery_bypasses_mention_gate_and_unrelated_text_does_not(
+    routing_adapter,
+):
+    base = {
+        "type": "message",
+        "channel": "C_PUBLIC",
+        "channel_type": "channel",
+        "user": "U_HUMAN",
+        "client_msg_id": "client-1",
+    }
+    await routing_adapter._handle_slack_message({
+        **base,
+        "ts": "100.0",
+        "text": "다시 값을 가져와줘",
+    })
+    await routing_adapter._handle_slack_message({
+        **base,
+        "ts": "100.0",
+        "text": "다시 값을 가져와줘",
+    })
+    await routing_adapter._handle_slack_message({
+        **base,
+        "ts": "100.5",
+        "user": "U_BOT",
+        "bot_id": "B_SELF",
+        "client_msg_id": "bot-copy",
+        "text": "다시 값을 가져와줘",
+    })
+    await routing_adapter._handle_slack_message({
+        **base,
+        "ts": "101.0",
+        "client_msg_id": "client-2",
+        "text": "다시 설명해줘",
+    })
+
+    routing_adapter.handle_message.assert_awaited_once()
+    routing_adapter._fetch_requery_context.assert_awaited_once_with(
+        channel_id="C_PUBLIC", current_ts="100.0", team_id=""
+    )
+    delivered = routing_adapter.handle_message.await_args.args[0]
+    assert delivered.source.thread_id == "100.0"
+    assert delivered.channel_context == "fresh-query-context"
+
+
+@pytest.mark.asyncio
+async def test_thread_requery_bypasses_strict_mention_and_hydrates_thread(
+    routing_adapter,
+):
+    routing_adapter.config.extra["strict_mention"] = True
+
+    await routing_adapter._handle_slack_message({
+        "type": "message",
+        "channel": "G_PRIVATE",
+        "channel_type": "group",
+        "user": "U_HUMAN",
+        "client_msg_id": "client-3",
+        "ts": "101.0",
+        "thread_ts": "100.0",
+        "text": "이전 보고 최신 값으로 갱신해줘",
+    })
+
+    routing_adapter.handle_message.assert_awaited_once()
+    routing_adapter._fetch_thread_context.assert_awaited_once()

--- a/tests/gateway/test_slack_requery.py
+++ b/tests/gateway/test_slack_requery.py
@@ -73,7 +73,9 @@ def _adapter(messages, *, session_entries=None, thread_messages=None):
         ),
     )
     adapter._get_client = lambda *_args, **_kwargs: client
-    adapter._session_store = SimpleNamespace(_entries=session_entries or {})
+    adapter._session_store = SimpleNamespace(
+        list_sessions=MagicMock(return_value=list((session_entries or {}).values()))
+    )
     return adapter, client
 
 
@@ -133,6 +135,41 @@ async def test_root_requery_prefers_canonical_cron_session_hours_later():
     client.conversations_replies.assert_awaited_once_with(
         channel="C1", ts="100.0", limit=1, inclusive=True
     )
+    client.conversations_history.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_root_requery_uses_lock_safe_session_snapshot_during_mutation():
+    cron_entry = SimpleNamespace(
+        origin=SimpleNamespace(
+            platform=Platform.SLACK,
+            chat_id="C1",
+            thread_id="100.0",
+            user_id="system:cron",
+        )
+    )
+
+    class MutatingEntries(dict):
+        def values(self):
+            values = super().values()
+            self["concurrent"] = SimpleNamespace(origin=None)
+            return values
+
+    adapter, client = _adapter(
+        [],
+        thread_messages=[
+            {"ts": "100.0", "user": "U_BOT", "text": "항공권 보고 " * 10},
+        ],
+    )
+    adapter._session_store = SimpleNamespace(
+        _entries=MutatingEntries({"cron": cron_entry}),
+        list_sessions=MagicMock(return_value=[cron_entry]),
+    )
+
+    context = await adapter._fetch_requery_context("C1", "20000.0")
+
+    assert "항공권 보고" in context
+    adapter._session_store.list_sessions.assert_called_once_with()
     client.conversations_history.assert_not_awaited()
 
 


### PR DESCRIPTION
## Summary
- recognize bounded Korean re-query phrases without an @mention
- recover canonical cron report sessions before bounded channel history
- preserve thread routing and duplicate/self-event guards

## Verification
- scripts/run_tests.sh tests/gateway/test_slack_requery.py tests/gateway/test_slack.py -q (255 passed)
- uvx ruff check plugins/platforms/slack/adapter.py tests/gateway/test_slack_requery.py

## Runtime evidence
- confirmed the reported private-channel message reached Slack history at 2026-08-28 22:01:59 KST with zero replies
- confirmed bot membership and channels/groups/DM history scopes without exposing credentials