### PR TITLE
fix: make delegation retries idempotent and isolate MCP breaker

### DIFF
--- a/agent/subagent_lifecycle.py
+++ b/agent/subagent_lifecycle.py
@@ -145,6 +145,7 @@ class _Record:
     started_at: Optional[float] = None
     completed_at: Optional[float] = None
     result: Optional[SubagentResult] = None
+    request_fingerprint: Optional[str] = None
 
 
 class _Registry:
@@ -152,6 +153,7 @@ class _Registry:
 
     def __init__(self) -> None:
         self.lock = threading.RLock()
+        self.launch_lock = threading.RLock()
         self.records: dict[str, _Record] = {}
         self.correlations: dict[tuple[Optional[str], str], str] = {}
 
@@ -208,55 +210,109 @@ class SubagentLifecycleService:
                 "parent_session_id does not match the active session."
             )
         correlation_key = (parent_session_id, request.correlation_id or "")
-        with _REGISTRY.lock:
-            self._cleanup_locked()
-            if request.correlation_id and correlation_key in _REGISTRY.correlations:
-                raise SubagentLifecycleError(
-                    "Duplicate correlation_id for this parent session."
+        request_fingerprint = self._request_fingerprint(request)
+
+        # Child construction is already serialized by delegate_tool so it
+        # cannot leak the child's resolved toolset into its parent. Keep the
+        # correlation check and record insertion in that same logical launch
+        # window: two overlapping retries must not both pass the check and
+        # construct separate children. The registry lock itself stays narrow,
+        # so status/cancel/result calls remain available during construction.
+        with _REGISTRY.launch_lock:
+            with _REGISTRY.lock:
+                self._cleanup_locked()
+                existing_id = (
+                    _REGISTRY.correlations.get(correlation_key)
+                    if request.correlation_id
+                    else None
                 )
+                existing = (
+                    _REGISTRY.records.get(existing_id) if existing_id else None
+                )
+                if existing is not None:
+                    if existing.request_fingerprint != request_fingerprint:
+                        raise SubagentLifecycleError(
+                            "correlation_id was already used for a different request."
+                        )
+                    return existing.handle
+                if existing_id:
+                    # Defensive repair for an impossible/dangling index entry.
+                    _REGISTRY.correlations.pop(correlation_key, None)
 
-        # Delegate construction remains internal so plugin code never imports
-        # private delegation helpers or manipulates the active-child registry.
-        from tools.delegate_tool import (
-            _build_child_preserving_parent_tools,
-            DEFAULT_MAX_ITERATIONS,
-        )
+            # Delegate construction remains internal so plugin code never
+            # imports private delegation helpers or manipulates the
+            # active-child registry.
+            from tools.delegate_tool import (
+                _build_child_preserving_parent_tools,
+                DEFAULT_MAX_ITERATIONS,
+            )
 
-        child = _build_child_preserving_parent_tools(
-            task_index=0,
-            goal=request.goal,
-            context=request.context,
-            toolsets=list(request.allowed_toolsets)
-            if request.allowed_toolsets
-            else None,
-            model=request.model,
-            max_iterations=DEFAULT_MAX_ITERATIONS,
-            task_count=1,
-            parent_agent=parent,
-            role=request.role,
-        )
-        subagent_id = str(getattr(child, "_subagent_id", "") or "")
-        if not subagent_id:
-            raise SubagentLifecycleError("Hermes failed to assign a child identity.")
-        created = time.time()
-        handle = SubagentHandle(
-            PUBLIC_CONTRACT_VERSION,
-            subagent_id,
-            parent_session_id,
-            request.correlation_id,
-            created,
-            getattr(child, "provider", None),
-            getattr(child, "model", None),
-            getattr(child, "_delegate_role", request.role),
-            int(getattr(child, "_delegate_depth", 1) or 1),
-            self._capability(subagent_id, parent_session_id, created),
-        )
-        record = _Record(handle, SubagentState.PENDING, created, agent=child)
+            child = _build_child_preserving_parent_tools(
+                task_index=0,
+                goal=request.goal,
+                context=request.context,
+                toolsets=list(request.allowed_toolsets)
+                if request.allowed_toolsets
+                else None,
+                model=request.model,
+                max_iterations=DEFAULT_MAX_ITERATIONS,
+                task_count=1,
+                parent_agent=parent,
+                role=request.role,
+            )
+            subagent_id = str(getattr(child, "_subagent_id", "") or "")
+            if not subagent_id:
+                self._discard_unstarted_child(child, parent)
+                raise SubagentLifecycleError(
+                    "Hermes failed to assign a child identity."
+                )
+            created = time.time()
+            handle = SubagentHandle(
+                PUBLIC_CONTRACT_VERSION,
+                subagent_id,
+                parent_session_id,
+                request.correlation_id,
+                created,
+                getattr(child, "provider", None),
+                getattr(child, "model", None),
+                getattr(child, "_delegate_role", request.role),
+                int(getattr(child, "_delegate_depth", 1) or 1),
+                self._capability(subagent_id, parent_session_id, created),
+            )
+            record = _Record(
+                handle,
+                SubagentState.PENDING,
+                created,
+                agent=child,
+                request_fingerprint=request_fingerprint,
+            )
+            with _REGISTRY.lock:
+                _REGISTRY.records[subagent_id] = record
+                if request.correlation_id:
+                    _REGISTRY.correlations[correlation_key] = subagent_id
+
+        # Publish the identity before submitting. If the acknowledgement from
+        # submit is delayed after acceptance, an exact correlation-id retry
+        # can recover this handle immediately while the original child keeps
+        # running. A definite submit failure is rolled back so a later retry
+        # can perform a fresh launch instead of recovering a ghost record.
+        try:
+            future = _EXECUTOR.submit(self._run, record, request.goal, parent)
+        except Exception as exc:
+            with _REGISTRY.lock:
+                if _REGISTRY.records.get(subagent_id) is record:
+                    _REGISTRY.records.pop(subagent_id, None)
+                if (
+                    request.correlation_id
+                    and _REGISTRY.correlations.get(correlation_key) == subagent_id
+                ):
+                    _REGISTRY.correlations.pop(correlation_key, None)
+            self._discard_unstarted_child(child, parent)
+            raise SubagentLifecycleError(
+                f"Failed to schedule subagent launch: {exc}"
+            ) from exc
         with _REGISTRY.lock:
-            _REGISTRY.records[subagent_id] = record
-            if request.correlation_id:
-                _REGISTRY.correlations[correlation_key] = subagent_id
-        record.future = _EXECUTOR.submit(self._run, record, request.goal, parent)
+            record.future = future
         return handle
 
     def status(self, handle: SubagentHandle) -> SubagentStatus:
@@ -406,6 +462,37 @@ class SubagentLifecycleService:
                     (record.handle.parent_session_id, record.handle.correlation_id),
                     None,
                 )
+
+    @staticmethod
+    def _discard_unstarted_child(child: Any, parent: Any) -> None:
+        """Release a constructed child that never reached its worker."""
+        children = getattr(parent, "_active_children", None)
+        if isinstance(children, list):
+            lock = getattr(parent, "_active_children_lock", None)
+            try:
+                if lock is not None:
+                    with lock:
+                        children.remove(child)
+                else:
+                    children.remove(child)
+            except Exception:
+                pass
+        try:
+            close = getattr(child, "close", None)
+            if callable(close):
+                close()
+        except Exception:
+            pass
+
+    @staticmethod
+    def _request_fingerprint(request: SubagentLaunchRequest) -> str:
+        payload = json.dumps(
+            dataclasses.asdict(request),
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode()
+        return hashlib.sha256(payload).hexdigest()
 
     def _run(self, record: _Record, goal: str, parent: Any) -> None:
         with _REGISTRY.lock:

--- a/tests/agent/test_subagent_lifecycle.py
+++ b/tests/agent/test_subagent_lifecycle.py
@@ -1,6 +1,8 @@
 """Contract tests for the public plugin subagent lifecycle API."""
 
+import threading
 import time
+from concurrent.futures import Future
 from types import SimpleNamespace
 from unittest.mock import Mock
 
@@ -27,6 +29,7 @@ class FakeChild:
         self.interrupt_kind = None
         self.interrupt_message = None
         self.tool_reason = None
+        self.closed = False
 
     def interrupt(self, _reason):
         self.interrupted = True
@@ -37,6 +40,9 @@ class FakeChild:
         self.interrupt_kind = "hard"
         self.interrupt_message = reason
         self.tool_reason = tool_reason
+
+    def close(self):
+        self.closed = True
 
 
 @pytest.fixture
@@ -97,6 +103,327 @@ def test_cancel_uses_explicit_hard_interrupt(lifecycle):
     assert "explicit user cancel" in record.agent.interrupt_message
     assert record.agent.tool_reason == "subagent cancellation requested"
     lifecycle.wait(handle, timeout_seconds=1)
+
+
+def test_retry_recovers_visible_child_while_first_launch_response_waits(
+    lifecycle, monkeypatch
+):
+    """A lost launch acknowledgement must not strand or duplicate the child.
+
+    ``Executor.submit`` may have accepted and started the worker before its
+    caller receives the returned Future.  Model that exact boundary by
+    starting the child and then withholding the submit response.  The first
+    caller consequently times out waiting for its response even though the
+    child is live and globally listable; a correlation-id retry must recover
+    that child's handle immediately.
+    """
+    from agent import subagent_lifecycle as lifecycle_module
+    from tools import delegate_tool
+
+    child_started = threading.Event()
+    child_release = threading.Event()
+    submit_response_release = threading.Event()
+    build_calls = []
+
+    def build_child(**_kwargs):
+        child = FakeChild(f"sa-{len(build_calls)}")
+        build_calls.append(child)
+        return child
+
+    def run_visible_child(_index, goal, child, parent):
+        subagent_id = child._subagent_id
+        delegate_tool._register_subagent(
+            {
+                "subagent_id": subagent_id,
+                "parent_id": None,
+                "depth": 0,
+                "goal": goal,
+                "model": child.model,
+                "started_at": time.time(),
+                "status": "running",
+                "tool_count": 0,
+                "agent": child,
+                "owner_agent_session_id": parent.session_id,
+            }
+        )
+        child_started.set()
+        try:
+            assert child_release.wait(timeout=5), "test did not release child"
+            return {
+                "status": "completed",
+                "summary": "safe summary",
+                "api_calls": 1,
+                "duration_seconds": 0.01,
+            }
+        finally:
+            delegate_tool._unregister_subagent(subagent_id, agent=child)
+
+    class SubmitResponseGate:
+        def submit(self, callback, *args):
+            future = Future()
+
+            def run():
+                try:
+                    future.set_result(callback(*args))
+                except BaseException as exc:  # mirror Future worker capture
+                    future.set_exception(exc)
+
+            threading.Thread(target=run, daemon=True).start()
+            assert submit_response_release.wait(timeout=5), (
+                "test did not release the simulated submit response"
+            )
+            return future
+
+    monkeypatch.setattr(
+        delegate_tool, "_build_child_preserving_parent_tools", build_child
+    )
+    monkeypatch.setattr(delegate_tool, "_run_child_lifecycle", run_visible_child)
+    monkeypatch.setattr(lifecycle_module, "_EXECUTOR", SubmitResponseGate())
+
+    request = SubagentLaunchRequest(
+        goal="recover a lost launch response",
+        correlation_id="lost-launch-ack",
+    )
+    first_outcome = {}
+    first_returned = threading.Event()
+
+    def first_launch():
+        try:
+            first_outcome["handle"] = lifecycle.launch(request)
+        except BaseException as exc:
+            first_outcome["error"] = exc
+        finally:
+            first_returned.set()
+
+    first_thread = threading.Thread(target=first_launch, daemon=True)
+    first_thread.start()
+    try:
+        assert child_started.wait(timeout=2), "child was not started"
+        assert not first_returned.is_set(), (
+            "first launch unexpectedly received its submit response"
+        )
+        listed_ids = {
+            item["subagent_id"] for item in delegate_tool.list_active_subagents()
+        }
+        assert "sa-0" in listed_ids
+
+        retry_handle = lifecycle.launch(request)
+
+        assert retry_handle.subagent_id == "sa-0"
+        assert not first_returned.is_set()
+        assert len(build_calls) == 1
+
+        submit_response_release.set()
+        assert first_returned.wait(timeout=2)
+        assert first_outcome == {"handle": retry_handle}
+        assert lifecycle.status(retry_handle).state is SubagentState.RUNNING
+        assert "sa-0" in {
+            item["subagent_id"] for item in delegate_tool.list_active_subagents()
+        }
+
+        child_release.set()
+        assert lifecycle.wait(retry_handle, timeout_seconds=2).state is (
+            SubagentState.SUCCEEDED
+        )
+    finally:
+        submit_response_release.set()
+        child_release.set()
+        first_thread.join(timeout=2)
+
+    assert not first_thread.is_alive()
+    assert len(build_calls) == 1
+
+
+def test_launch_returns_handle_while_child_continues_in_background(
+    lifecycle, monkeypatch
+):
+    from tools import delegate_tool
+
+    child_started = threading.Event()
+    child_release = threading.Event()
+
+    def gated_run(_index, _goal, _child, _parent):
+        child_started.set()
+        assert child_release.wait(timeout=5), "test did not release child"
+        return {
+            "status": "completed",
+            "summary": "finished later",
+            "api_calls": 1,
+            "duration_seconds": 0.01,
+        }
+
+    monkeypatch.setattr(delegate_tool, "_run_child_lifecycle", gated_run)
+    handle = lifecycle.launch(
+        SubagentLaunchRequest(goal="continue later", correlation_id="background-id")
+    )
+    try:
+        assert handle.subagent_id == "sa-0"
+        assert child_started.wait(timeout=2)
+        assert lifecycle.status(handle).state is SubagentState.RUNNING
+        assert not lifecycle.result(handle).ready
+    finally:
+        child_release.set()
+
+    assert lifecycle.wait(handle, timeout_seconds=2).state is SubagentState.SUCCEEDED
+    assert lifecycle.result(handle).summary == "finished later"
+
+
+def test_same_correlation_is_idempotent_but_payload_change_is_rejected(lifecycle):
+    request = SubagentLaunchRequest(goal="same work", correlation_id="retry-key")
+
+    first = lifecycle.launch(request)
+    retry = lifecycle.launch(request)
+
+    assert retry == first
+    with pytest.raises(SubagentLifecycleError, match="different request"):
+        lifecycle.launch(
+            SubagentLaunchRequest(
+                goal="different work",
+                correlation_id="retry-key",
+            )
+        )
+
+
+def test_overlapping_same_correlation_builds_and_runs_only_one_child(monkeypatch):
+    from tools import delegate_tool
+
+    parent = SimpleNamespace(session_id="parent-overlap", enabled_toolsets=["file"])
+    retry_resolved_parent = threading.Event()
+    first_build_started = threading.Event()
+    duplicate_build_started = threading.Event()
+    build_calls = []
+    run_calls = []
+
+    def resolve_parent():
+        if threading.current_thread().name == "lifecycle-retry":
+            retry_resolved_parent.set()
+        return parent
+
+    def build_child(**_kwargs):
+        index = len(build_calls)
+        build_calls.append(index)
+        if index == 0:
+            first_build_started.set()
+            assert retry_resolved_parent.wait(timeout=2), "retry never entered launch"
+            # A broken check-then-build implementation lets the retry reach a
+            # second build here. The idempotent admission lock keeps it parked
+            # until this first build publishes its record instead.
+            duplicate_build_started.wait(timeout=2)
+        else:
+            duplicate_build_started.set()
+        return FakeChild(f"sa-overlap-{index}")
+
+    def run_child(_index, _goal, _child, _parent):
+        run_calls.append(True)
+        return {
+            "status": "completed",
+            "summary": "ran once",
+            "api_calls": 1,
+            "duration_seconds": 0.01,
+        }
+
+    monkeypatch.setattr(
+        delegate_tool, "_build_child_preserving_parent_tools", build_child
+    )
+    monkeypatch.setattr(delegate_tool, "_run_child_lifecycle", run_child)
+    service = SubagentLifecycleService(resolve_parent)
+    request = SubagentLaunchRequest(
+        goal="one logical launch",
+        correlation_id="overlapping-retry-key",
+    )
+    outcomes = []
+
+    def launch():
+        try:
+            outcomes.append(service.launch(request))
+        except BaseException as exc:
+            outcomes.append(exc)
+
+    first = threading.Thread(target=launch, daemon=True, name="lifecycle-first")
+    retry = threading.Thread(target=launch, daemon=True, name="lifecycle-retry")
+    first.start()
+    assert first_build_started.wait(timeout=2), "first launch never reached build"
+    retry.start()
+    first.join(timeout=2)
+    retry.join(timeout=2)
+
+    assert not first.is_alive() and not retry.is_alive()
+    assert not duplicate_build_started.is_set()
+    assert build_calls == [0]
+    assert len(outcomes) == 2
+    assert all(not isinstance(outcome, BaseException) for outcome in outcomes)
+    assert outcomes[0] == outcomes[1]
+    assert service.wait(outcomes[0], timeout_seconds=2).state is (
+        SubagentState.SUCCEEDED
+    )
+    assert run_calls == [True]
+
+
+def test_failed_submit_rolls_back_correlation_and_allows_retry(monkeypatch):
+    from agent import subagent_lifecycle as lifecycle_module
+    from tools import delegate_tool
+
+    parent = SimpleNamespace(
+        session_id="parent-submit-failure",
+        enabled_toolsets=["file"],
+        _active_children=[],
+        _active_children_lock=None,
+    )
+    service = SubagentLifecycleService(lambda: parent)
+    built_children = []
+
+    def build_child(**_kwargs):
+        child = FakeChild(f"sa-submit-{len(built_children)}")
+        built_children.append(child)
+        parent._active_children.append(child)
+        return child
+
+    def run_child(_index, _goal, child, _parent):
+        try:
+            return {
+                "status": "completed",
+                "summary": "retry ran",
+                "api_calls": 1,
+                "duration_seconds": 0.01,
+            }
+        finally:
+            parent._active_children.remove(child)
+            child.close()
+
+    real_executor = lifecycle_module._EXECUTOR
+
+    class RejectOnceExecutor:
+        def __init__(self):
+            self.calls = 0
+
+        def submit(self, callback, *args):
+            self.calls += 1
+            if self.calls == 1:
+                raise RuntimeError("executor rejected launch")
+            return real_executor.submit(callback, *args)
+
+    executor = RejectOnceExecutor()
+    monkeypatch.setattr(
+        delegate_tool, "_build_child_preserving_parent_tools", build_child
+    )
+    monkeypatch.setattr(delegate_tool, "_run_child_lifecycle", run_child)
+    monkeypatch.setattr(lifecycle_module, "_EXECUTOR", executor)
+    request = SubagentLaunchRequest(
+        goal="retry after definite failure",
+        correlation_id="submit-retry-key",
+    )
+
+    with pytest.raises(SubagentLifecycleError, match="Failed to schedule"):
+        service.launch(request)
+
+    assert built_children[0].closed
+    assert built_children[0] not in parent._active_children
+
+    handle = service.launch(request)
+    assert handle.subagent_id == "sa-submit-1"
+    assert service.wait(handle, timeout_seconds=2).state is SubagentState.SUCCEEDED
+    assert len(built_children) == 2
+    assert executor.calls == 2
 
 
 

--- a/tests/tools/test_mcp_circuit_breaker.py
+++ b/tests/tools/test_mcp_circuit_breaker.py
@@ -12,6 +12,7 @@ half-open / cooldown / reconnect-resets-breaker behavior that fixes
 that.
 """
 import json
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -99,6 +100,89 @@ def _cleanup(mcp_tool_module, name: str) -> None:
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
+
+
+def test_rendered_tool_errors_do_not_open_healthy_transport_circuit(
+    monkeypatch, tmp_path,
+):
+    """Application/input errors are responses from a reachable backend.
+
+    Three invalid calls must not prevent a fourth, valid call from using the
+    same healthy MCP session. The rendered ``{"error": ...}`` shape is a tool
+    result contract, not evidence that the transport is unreachable.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools import mcp_tool
+    from tools.mcp_tool import _make_tool_handler
+
+    calls = []
+
+    async def _call_tool(_name, arguments):
+        calls.append(arguments)
+        if arguments.get("expression") != "1 + 1":
+            return SimpleNamespace(
+                is_error=True,
+                content=[SimpleNamespace(text="invalid expression")],
+            )
+        return SimpleNamespace(
+            is_error=False,
+            content=[SimpleNamespace(text="2")],
+        )
+
+    _install_stub_server(mcp_tool, "renderer", _call_tool)
+    mcp_tool._ensure_mcp_loop()
+
+    try:
+        handler = _make_tool_handler("renderer", "evaluate", 10.0)
+
+        for _ in range(mcp_tool._CIRCUIT_BREAKER_THRESHOLD):
+            parsed = json.loads(handler({"expression": "invalid"}))
+            assert parsed == {"error": "invalid expression"}
+            assert mcp_tool._server_error_counts.get("renderer", 0) == 0
+
+        parsed = json.loads(handler({"expression": "1 + 1"}))
+        assert parsed == {"result": "2"}
+        assert len(calls) == mcp_tool._CIRCUIT_BREAKER_THRESHOLD + 1
+    finally:
+        _cleanup(mcp_tool, "renderer")
+
+
+@pytest.mark.parametrize(
+    "failure_type",
+    [EOFError, TimeoutError, ConnectionError],
+)
+def test_transport_failures_still_open_backend_circuit(
+    monkeypatch, tmp_path, failure_type,
+):
+    """Raised EOF/timeout/connectivity failures remain breaker strikes."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools import mcp_tool
+    from tools.mcp_tool import _make_tool_handler
+
+    calls = {"n": 0}
+
+    async def _call_tool(*_args, **_kwargs):
+        calls["n"] += 1
+        raise failure_type("backend transport failed")
+
+    _install_stub_server(mcp_tool, "offline", _call_tool)
+    mcp_tool._ensure_mcp_loop()
+
+    try:
+        handler = _make_tool_handler("offline", "evaluate", 10.0)
+
+        for expected_count in range(1, mcp_tool._CIRCUIT_BREAKER_THRESHOLD + 1):
+            parsed = json.loads(handler({}))
+            assert "error" in parsed
+            assert mcp_tool._server_error_counts["offline"] == expected_count
+
+        parsed = json.loads(handler({}))
+        assert "unreachable" in parsed["error"].lower()
+        assert calls["n"] == mcp_tool._CIRCUIT_BREAKER_THRESHOLD
+    finally:
+        _cleanup(mcp_tool, "offline")
 
 
 def test_circuit_breaker_half_opens_after_cooldown(monkeypatch, tmp_path):

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -5028,10 +5028,11 @@ def _handle_auth_error_and_retry(
                 parsed = json.loads(result)
                 if "error" not in parsed:
                     _reset_server_error(server_name)
-                    return result
             except (json.JSONDecodeError, TypeError):
                 _reset_server_error(server_name)
-                return result
+            # A returned payload is a completed retry. Surface rendered tool
+            # errors as-is; their JSON shape says nothing about reachability.
+            return result
         except Exception as retry_exc:
             logger.warning(
                 "MCP %s/%s retry after auth recovery failed: %s",
@@ -5222,10 +5223,11 @@ def _handle_session_expired_and_retry(
             parsed = json.loads(result)
             if "error" not in parsed:
                 _reset_server_error(server_name)
-                return result
         except (json.JSONDecodeError, TypeError):
             _reset_server_error(server_name)
-            return result
+        # A returned payload is a completed retry. Surface rendered tool
+        # errors as-is; their JSON shape says nothing about reachability.
+        return result
     except Exception as retry_exc:
         logger.warning(
             "MCP %s/%s retry after session reconnect failed: %s",
@@ -6075,6 +6077,8 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
     """
 
     def _handler(args: dict, **kwargs) -> str:
+        rpc_round_trip_completed = False
+
         # Trust-tier gate (security boundary): write-capable tools on
         # servers configured ``trust: untrusted`` must be approved by the
         # user before ANY transport work happens — including the lazy
@@ -6143,6 +6147,7 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                 return tool_error(f"MCP server '{server_name}' is not connected")
 
         async def _call():
+            nonlocal rpc_round_trip_completed
             _mark_server_call_started(server)
             async with server._rpc_lock, _track_inflight_rpc(
                 server, server_name, f"tools/call {tool_name}"
@@ -6168,9 +6173,9 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                         # Dead children but stale server.session, so the
                         # transport-down path above never fired — signal the
                         # server task to respawn and return a clean
-                        # reconnecting error. No explicit _bump_server_error:
-                        # the error return flows through the handler's JSON
-                        # parse, which already bumps once.
+                        # reconnecting error. This is a known transport
+                        # failure; leaving rpc_round_trip_completed false
+                        # charges the reachability breaker in _call_once.
                         if _signal_reconnect(server):
                             return tool_error(
                                 f"MCP server '{server_name}' stdio subprocess is "
@@ -6235,6 +6240,7 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                             await asyncio.gather(
                                 rpc_task, watch_task, return_exceptions=True
                             )
+                    rpc_round_trip_completed = True
                 finally:
                     server._pending_call_context = None
             # The RPC round-trip completed — the session is demonstrably
@@ -6368,20 +6374,22 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
             return json.dumps({"result": text_result}, ensure_ascii=False)
 
         def _call_once():
-            return _run_on_mcp_loop(_call, timeout=tool_timeout)
+            nonlocal rpc_round_trip_completed
+            rpc_round_trip_completed = False
+            result = _run_on_mcp_loop(_call, timeout=tool_timeout)
+            # Reachability follows transport facts, not the rendered JSON
+            # payload. A completed CallTool RPC proves the backend is live,
+            # including when the tool reports an application/input error.
+            if rpc_round_trip_completed:
+                _reset_server_error(server_name)
+            else:
+                # The only non-raising result without an RPC round trip is
+                # the known-dead stdio fast-fail above.
+                _bump_server_error(server_name)
+            return result
 
         try:
-            result = _call_once()
-            # Check if the MCP tool itself returned an error
-            try:
-                parsed = json.loads(result)
-                if "error" in parsed:
-                    _bump_server_error(server_name)
-                else:
-                    _reset_server_error(server_name)  # success — reset
-            except (json.JSONDecodeError, TypeError):
-                _reset_server_error(server_name)  # non-JSON = success
-            return result
+            return _call_once()
         except InterruptedError:
             return _interrupted_call_result()
         except Exception as exc:

--- a/website/docs/developer-guide/subagent-lifecycle-api.md
+++ b/website/docs/developer-guide/subagent-lifecycle-api.md
@@ -33,6 +33,9 @@ def launch_review(ctx):
 `SubagentHandle` is serializable and carries a versioned, opaque capability.
 Pass it back to `status`, `wait`, `cancel`, `result`, or `reconnect`; malformed
 or forged handles return `UNKNOWN`/`UNKNOWN_HANDLE` and cannot access a child.
+`correlation_id` is an idempotency key scoped to the parent session: retrying
+the same request returns the original handle without launching a duplicate,
+while reusing the key for a different request is rejected.
 
 The stable states are `PENDING`, `STARTING`, `RUNNING`, `SUCCEEDED`, `FAILED`,
 `INTERRUPTED`, `CANCEL_REQUESTED`, `CANCELLED`, and `UNKNOWN`.


### PR DESCRIPTION
## Summary
- recover the original child handle when a launch acknowledgement is lost and the same correlation ID is retried
- serialize overlapping admission, reject changed requests, and clean up failed submissions
- classify MCP reachability from transport/RPC completion rather than rendered tool/application errors
- preserve breaker charging for EOF, timeout, connectivity, dead-stdio, disconnected-session, and backend exceptions

## Verification
- delegation baseline: 5 passed, 4 failed; fixed: 9 passed
- delegation relevant regression suite: 136 passed
- MCP breaker RED: rendered error incremented 0→1
- MCP breaker focused: 29 passed
- MCP tools suite: 599 passed
- Ruff and git diff --check passed