### PR TITLE
fix(update): verify Windows gateway relaunch and keep a stderr trace (#48820)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1348,9 +1348,16 @@ def _spawn_gateway_restart_watcher(old_pid: int, run_argv: list[str]) -> bool:
         # been spawned inside a job object (Electron/Tauri parent), and
         # without breakaway the respawned gateway would die when that job
         # tears down. See _subprocess_compat.windows_detach_flags().
+        # Keep a stderr trace for the respawned gateway: with both streams
+        # in DEVNULL, a gateway that dies on startup leaves no evidence at
+        # all (#48820 — reproduced 4x, zero trace each time).
+        _respawn_stderr = os.path.join(
+            os.environ.get("LOCALAPPDATA") or os.path.expanduser("~"),
+            "hermes", "logs", "gateway-respawn-stderr.log",
+        )
         _popen_kwargs = {{
             "stdout": subprocess.DEVNULL,
-            "stderr": subprocess.DEVNULL,
+            "stderr": open(_respawn_stderr, "ab"),
         }}
         # Anchor the respawned gateway at the stable working dir and overlay
         # the env (VIRTUAL_ENV / PYTHONPATH / HERMES_HOME) the windowless

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -6825,6 +6825,38 @@ def _refresh_bootstrap_cache_scripts(branch: str = "main") -> None:
     except Exception as exc:
         logger.debug("Could not refresh bootstrap-cache scripts after update: %s", exc)
 
+def _verify_windows_gateway_relaunch(previous_pids, timeout_s=25):
+    """Wait for a fresh gateway pid to appear in gateway_state.json and be alive.
+
+    The relaunch helpers only verify that a watcher was spawned — not that
+    the gateway itself came up. A respawned Windows gateway has been
+    observed dying within seconds with zero trace anywhere (#48820,
+    reproduced 4x). Polling the state file for a pid that is (a) not one of
+    the pre-update pids and (b) actually present in the process table turns
+    that silent death into a visible warning instead of a misleading
+    "✓ Restarting Windows gateway profile(s)".
+    """
+    state_path = get_hermes_home() / "gateway_state.json"
+    deadline = _time.monotonic() + timeout_s
+    while _time.monotonic() < deadline:
+        try:
+            with open(state_path, "r", encoding="utf-8") as fh:
+                state = json.load(fh)
+            pid = state.get("pid")
+            if isinstance(pid, int) and pid > 0 and pid not in previous_pids:
+                try:
+                    from gateway.status import _pid_exists
+
+                    if _pid_exists(pid):
+                        return True, pid
+                except Exception:
+                    pass
+        except Exception:
+            pass
+        _time.sleep(2)
+    return False, None
+
+
 def _resume_windows_gateways_after_update(token: dict | None) -> None:
     """Restart Windows profile gateways previously paused for update."""
     if not token or not token.get("resume_needed"):
@@ -6963,6 +6995,29 @@ def _resume_windows_gateways_after_update(token: dict | None) -> None:
         print(
             f"  ✓ Restarting {unmapped_relaunched} unmapped Windows gateway process(es)"
         )
+
+    # Verify the respawn actually came up instead of trusting the spawn
+    # call. Silent-death gateways (#48820) print a misleading ✓ otherwise.
+    if relaunched or unmapped_relaunched:
+        previous_pids = set()
+        for _old_pid in profiles.values():
+            if isinstance(_old_pid, int):
+                previous_pids.add(_old_pid)
+        for _entry in unmapped:
+            _old_pid = _entry.get("pid")
+            if isinstance(_old_pid, int):
+                previous_pids.add(_old_pid)
+        _alive, _new_pid = _verify_windows_gateway_relaunch(previous_pids)
+        if _alive:
+            print(f"  ✓ Respawned gateway verified alive (pid {_new_pid})")
+        else:
+            print()
+            print(
+                "  ⚠ Respawned gateway did not come up within 25s — it may have"
+            )
+            print("    died on startup (silent-death class, see #48820).")
+            print("    Relaunch manually with:")
+            print("      wscript <hermes_home>\\gateway-service\\Hermes_Gateway.vbs")
 
 def _discard_lockfile_churn(git_cmd, repo_root):
     """Restore tracked ``package-lock.json`` files that npm dirtied locally.


### PR DESCRIPTION
## Summary

The Windows update pause/resume path trusted the spawn call: a respawned gateway could die within seconds while the update printed `✓ Restarting Windows gateway profile(s)` — and nothing anywhere recorded the death. Reproduced **4 times** on a real install (#48820): no gateway.log line, no exit-diag record, no WER, no Defender detection, because the watcher respawns with `stdout=DEVNULL, stderr=DEVNULL`.

This PR is a focused fix for the silent-death class, on current main:

1. **Verify the relaunch instead of trusting it.** `_resume_windows_gateways_after_update` now polls `gateway_state.json` for a fresh pid (not one of the pre-update pids) that is actually alive in the process table (25s budget). If nothing comes up, the update prints an explicit ⚠ warning with the manual relaunch command (`wscript <hermes_home>\gateway-service\Hermes_Gateway.vbs`) instead of a misleading ✓.

2. **Keep a stderr trace for respawned gateways.** The watcher's respawn now writes stderr to `hermes/logs/gateway-respawn-stderr.log` instead of DEVNULL, so a gateway that dies on startup leaves evidence for the next diagnosis.

## Why this instead of salvaging #48852

#48852 (open, "salvageability: medium" per the sweeper) is a larger watchdog/env/proxy rework based on June's main; its patch no longer applies to current main (files moved/rewritten: `gateway/platforms/matrix.py`, `slack.py`, `config.py`, `run.py` etc. — `git apply` fails on 8 files). This PR deliberately does not touch the watchdog architecture; it closes the worst UX gap of the reported class (silent success + silent death) with a small, reviewable change.

## Reproduction context (for the record)

2026-08-28, v0.20.5 → v0.20.6 hand-off update: old gateway (pid 41672) stalled during shutdown (weixin mid backoff-retry, bad network), was force-killed (`lifecycle_ledger`: "exited UNCLEANLY (no exit path ran — SIGKILL)"). Updater respawned pid 48452 at 08:40:06; it wrote its `gateway.start` exit-diag entry and died within seconds — zero trace. Control: same venv, same machine, gateway launched via the vbs script stays up for hours. Strong suspect is job-object teardown when the updater process exits (the watcher comment at `gateway.py` warns about exactly this: without `CREATE_BREAKAWAY_FROM_JOB` the respawned gateway dies when the parent job tears down), but no crash dump exists to prove it — which is why fix #2 (stderr trace) matters.

## Testing

- `python -m py_compile` on both modified files: OK
- Functional smoke test of `_verify_windows_gateway_relaunch` against the live machine: with `previous_pids={41672, 48452}` it correctly detected the currently-running gateway (pid 65240) as alive and returned `True`
