### PR TITLE
fix(gateway): skip paused/non-running SCM services instead of aborting update

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1086,9 +1086,17 @@ def find_windows_gateway_services(
             if service_status == "stopped":
                 continue
             if service_status != "running":
-                raise RuntimeError(
-                    f"SCM service {service_name} has indeterminate status: {service_status}"
+                # Non-running, non-stopped statuses (paused, pause_pending,
+                # continue_pending, start_pending, stop_pending) are not active
+                # SCM hosts for a gateway — skip them instead of aborting the
+                # entire enumeration.  A single paused third-party service
+                # (e.g. Siemens SmartServer) must not block updates. (#96860)
+                logger.debug(
+                    "Skipping SCM service %s with non-running status: %s",
+                    service_name,
+                    service_status,
                 )
+                continue
             if service_pid <= 0:
                 raise RuntimeError(
                     f"Running SCM service {service_name} has no valid process ID"

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -1126,6 +1126,27 @@ def test_find_windows_gateway_services_fails_closed_on_service_access_error(
         )
 
 
+def test_find_windows_gateway_services_skips_paused_service(monkeypatch):
+    """A paused third-party service must not abort the SCM enumeration (#96860)."""
+    monkeypatch.setattr(gateway.sys, "platform", "win32")
+    profile = SimpleNamespace(profile="default", pid=300, create_time=300.0)
+
+    class PausedService:
+        def as_dict(self):
+            return {"name": "cortsmartserver", "pid": 0, "status": "paused"}
+
+    fake_psutil = SimpleNamespace(
+        win_service_iter=lambda: [PausedService()],
+    )
+
+    # Must not raise — paused services are skipped, not fatal.
+    result = gateway.find_windows_gateway_services(
+        psutil_module=fake_psutil,
+        profile_processes=[profile],
+    )
+    assert result == []
+
+
 def test_find_windows_gateway_services_fails_closed_when_scm_scan_is_indeterminate(
     monkeypatch,
 ):


### PR DESCRIPTION
## Summary

`find_windows_gateway_services()` aborts the entire SCM service enumeration when it encounters any service whose status is not `running` or `stopped`. A single paused third-party service (e.g. Siemens SmartServer `cortsmartserver`) raises `RuntimeError: SCM service {name} has indeterminate status: paused`, which wraps as `SCM service enumeration failed` and blocks `hermes update` entirely — even though the code update itself would succeed.

## Root Cause

`hermes_cli/gateway.py:find_windows_gateway_services()` treats any service status that isn't `running` or `stopped` as a fatal error. Windows SCM services can have statuses like `paused`, `pause_pending`, `continue_pending`, `start_pending`, `stop_pending` — none of which indicate an active gateway host.

## Fix

Skip non-running, non-stopped services with a `logger.debug` call instead of raising `RuntimeError`. This allows the enumeration to continue past paused third-party services.

## Test

Added `test_find_windows_gateway_services_skips_paused_service` which verifies a paused service is skipped without aborting the enumeration.

## Rebase Note

Rebased onto current `main` (was 119 commits behind). Clean rebase, no conflicts. Supersedes #96862 which had the same fix but was stale.

Closes #96860