### PR TITLE
fix(acp): canonicalize named custom model ids

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -738,6 +738,13 @@ class HermesACPAgent(acp.Agent):
         model = str(state.model or getattr(state.agent, "model", "") or "").strip()
         provider = getattr(state.agent, "provider", None) or detect_provider() or "openrouter"
         requested_provider = getattr(state.agent, "requested_provider", None)
+        requested_provider_id = (
+            requested_provider.strip().lower()
+            if isinstance(requested_provider, str)
+            else ""
+        )
+        if not requested_provider_id.startswith("custom:"):
+            requested_provider_id = ""
 
         try:
             from hermes_cli.inventory import build_models_payload, load_picker_context
@@ -776,6 +783,8 @@ class HermesACPAgent(acp.Agent):
                 raw = str(provider_id or "").strip().lower()
                 if raw == "ollama":
                     return "custom:ollama"
+                if raw == "custom" and requested_provider_id:
+                    return requested_provider_id
                 if raw.startswith("custom:"):
                     return raw
                 normalized = normalize_provider(raw)
@@ -787,7 +796,7 @@ class HermesACPAgent(acp.Agent):
                 return normalized
 
             current_choice_provider = canonical_choice_provider(
-                requested_provider or provider
+                requested_provider_id or provider
             )
             current_base_url = str(
                 getattr(state.agent, "base_url", "") or ""

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -737,14 +737,16 @@ class HermesACPAgent(acp.Agent):
         """
         model = str(state.model or getattr(state.agent, "model", "") or "").strip()
         provider = getattr(state.agent, "provider", None) or detect_provider() or "openrouter"
+        requested_provider = getattr(state.agent, "requested_provider", None)
 
         try:
             from hermes_cli.inventory import build_models_payload, load_picker_context
             from hermes_cli.models import (
-                _configured_custom_provider_ids,
+                CANONICAL_PROVIDERS,
                 normalize_provider,
                 provider_label,
             )
+            from hermes_cli.runtime_provider import canonical_custom_identity
 
             normalized_provider = normalize_provider(provider)
             context = load_picker_context().with_overrides(
@@ -768,11 +770,7 @@ class HermesACPAgent(acp.Agent):
 
             available_models: list[ModelInfo] = []
             seen_ids: set[str] = set()
-            configured_custom_provider_ids = {
-                provider_id.lower()
-                for provider_id in _configured_custom_provider_ids()
-                if provider_id.lower().startswith("custom:")
-            }
+            canonical_provider_ids = {entry.slug for entry in CANONICAL_PROVIDERS}
 
             def canonical_choice_provider(provider_id: str) -> str:
                 raw = str(provider_id or "").strip().lower()
@@ -780,14 +778,17 @@ class HermesACPAgent(acp.Agent):
                     return "custom:ollama"
                 if raw.startswith("custom:"):
                     return raw
-                custom_id = f"custom:{raw}"
-                if custom_id in configured_custom_provider_ids:
+                normalized = normalize_provider(raw)
+                if normalized in canonical_provider_ids:
+                    return normalized
+                custom_id = canonical_custom_identity(config_provider=raw)
+                if custom_id:
                     return custom_id
-                return normalize_provider(raw)
+                return normalized
 
-            current_choice_provider = str(provider or "").strip().lower()
-            if current_choice_provider == "ollama":
-                current_choice_provider = "custom:ollama"
+            current_choice_provider = canonical_choice_provider(
+                requested_provider or provider
+            )
             current_base_url = str(
                 getattr(state.agent, "base_url", "") or ""
             ).strip().rstrip("/").lower()
@@ -822,6 +823,7 @@ class HermesACPAgent(acp.Agent):
                 provider_name = str(row.get("name") or "").strip() or provider_label(
                     row_provider
                 )
+                encoded_provider = canonical_choice_provider(raw_row_provider)
                 row_models = row.get("models")
                 if not isinstance(row_models, (list, tuple)):
                     continue
@@ -837,7 +839,6 @@ class HermesACPAgent(acp.Agent):
                         rendered_model = str(model_entry or "").strip()
                     if not rendered_model:
                         continue
-                    encoded_provider = canonical_choice_provider(raw_row_provider)
                     choice_id = self._encode_model_choice(
                         encoded_provider, rendered_model
                     )

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -740,7 +740,11 @@ class HermesACPAgent(acp.Agent):
 
         try:
             from hermes_cli.inventory import build_models_payload, load_picker_context
-            from hermes_cli.models import normalize_provider, provider_label
+            from hermes_cli.models import (
+                _configured_custom_provider_ids,
+                normalize_provider,
+                provider_label,
+            )
 
             normalized_provider = normalize_provider(provider)
             context = load_picker_context().with_overrides(
@@ -764,6 +768,23 @@ class HermesACPAgent(acp.Agent):
 
             available_models: list[ModelInfo] = []
             seen_ids: set[str] = set()
+            configured_custom_provider_ids = {
+                provider_id.lower()
+                for provider_id in _configured_custom_provider_ids()
+                if provider_id.lower().startswith("custom:")
+            }
+
+            def canonical_choice_provider(provider_id: str) -> str:
+                raw = str(provider_id or "").strip().lower()
+                if raw == "ollama":
+                    return "custom:ollama"
+                if raw.startswith("custom:"):
+                    return raw
+                custom_id = f"custom:{raw}"
+                if custom_id in configured_custom_provider_ids:
+                    return custom_id
+                return normalize_provider(raw)
+
             current_choice_provider = str(provider or "").strip().lower()
             if current_choice_provider == "ollama":
                 current_choice_provider = "custom:ollama"
@@ -816,15 +837,7 @@ class HermesACPAgent(acp.Agent):
                         rendered_model = str(model_entry or "").strip()
                     if not rendered_model:
                         continue
-                    encoded_provider = (
-                        "custom:ollama"
-                        if raw_row_provider == "ollama"
-                        else raw_row_provider
-                        if raw_row_provider == "custom:ollama"
-                        else raw_row_provider
-                        if raw_row_provider.startswith("custom:")
-                        else row_provider
-                    )
+                    encoded_provider = canonical_choice_provider(raw_row_provider)
                     choice_id = self._encode_model_choice(
                         encoded_provider, rendered_model
                     )

--- a/tests/acp/test_named_provider_catalogs.py
+++ b/tests/acp/test_named_provider_catalogs.py
@@ -331,7 +331,31 @@ class TestModelStateIncludesNamedProviders:
         (tmp_path / "config.yaml").write_text(yaml.safe_dump(cfg), encoding="utf-8")
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
 
-        model_state = acp_agent._build_model_state(state)
+        inventory_provider = "custom" if current_provider == "custom" else "9router"
+        inventory = {
+            "providers": [
+                {
+                    "slug": inventory_provider,
+                    "name": "9Router",
+                    "api_url": "https://router.example/v1",
+                    "models": [{"id": model}],
+                },
+                {
+                    "slug": colon_provider,
+                    "name": "Local Ollama",
+                    "api_url": "http://127.0.0.1:11434/v1",
+                    "models": [{"id": colon_model}],
+                },
+            ]
+        }
+
+        # The ACP suite intentionally stubs remote-backed shared inventory.
+        # Supply its exact row shape while exercising real config loading,
+        # canonical identity recovery, named catalogs, and model parsing.
+        with patch(
+            "hermes_cli.inventory.build_models_payload", return_value=inventory
+        ):
+            model_state = acp_agent._build_model_state(state)
         canonical_id = f"custom:9router:{model}"
         provider, parsed_model = parse_model_input(canonical_id, "custom")
         colon_id = f"custom:{colon_provider}:{colon_model}"
@@ -387,3 +411,28 @@ class TestModelStateIncludesNamedProviders:
             "anthropic:claude-sonnet-4.5"
         ]
         canonical_custom_identity.assert_not_called()
+
+    def test_auto_request_keeps_resolved_runtime_provider_identity(self):
+        manager = SessionManager(
+            agent_factory=lambda: SimpleNamespace(
+                model="anthropic/claude-sonnet-4.5",
+                provider="openrouter",
+                requested_provider="auto",
+                base_url=None,
+            )
+        )
+        acp_agent = HermesACPAgent(session_manager=manager)
+        state = manager.create_session(cwd="/tmp")
+
+        with patch(
+            "acp_adapter.server._named_custom_provider_catalogs", return_value=[]
+        ):
+            model_state = acp_agent._build_model_state(state)
+
+        assert isinstance(model_state, SessionModelState)
+        assert model_state.current_model_id == (
+            "openrouter:anthropic/claude-sonnet-4.5"
+        )
+        assert [item.model_id for item in model_state.available_models] == [
+            "openrouter:anthropic/claude-sonnet-4.5"
+        ]

--- a/tests/acp/test_named_provider_catalogs.py
+++ b/tests/acp/test_named_provider_catalogs.py
@@ -278,49 +278,112 @@ class TestModelStateIncludesNamedProviders:
         assert provider == "custom:local-127.0.0.1:11434"
         assert model == "qwen3:1.7b"
 
-    def test_canonicalizes_named_provider_inventory_slug(self):
+    @pytest.mark.parametrize(
+        ("current_provider", "requested_provider"),
+        [
+            ("openai-codex", None),
+            ("9router", None),
+            ("custom", "custom:9router"),
+        ],
+    )
+    def test_canonicalizes_named_provider_inventory_slug(
+        self, monkeypatch, tmp_path, current_provider, requested_provider
+    ):
         """ACP must advertise one round-trippable id for a named endpoint."""
+        import yaml
+
         from hermes_cli.models import parse_model_input
 
+        model = "tflow/gpt-5.6-sol"
         manager = SessionManager(
             agent_factory=lambda: SimpleNamespace(
-                model="gpt-5.4", provider="openai-codex", base_url=None
+                model=model if current_provider != "openai-codex" else "gpt-5.4",
+                provider=current_provider,
+                requested_provider=requested_provider,
+                base_url="https://router.example/v1"
+                if current_provider != "openai-codex"
+                else None,
             )
         )
         acp_agent = HermesACPAgent(session_manager=manager)
         state = manager.create_session(cwd="/tmp")
-        model = "tflow/gpt-5.6-sol"
+        colon_provider = "local-127.0.0.1:11434"
+        colon_model = "qwen3:1.7b"
         cfg = {
+            "model": {"provider": "openai-codex", "default": "gpt-5.4"},
             "providers": {
                 "9router": {
                     "name": "9Router",
                     "base_url": "https://router.example/v1",
+                    "api_key": "test-key",
                     "default_model": model,
+                    "discover_models": False,
+                },
+                colon_provider: {
+                    "name": "Local Ollama",
+                    "base_url": "http://127.0.0.1:11434/v1",
+                    "api_key": "test-key",
+                    "default_model": colon_model,
+                    "discover_models": False,
                 }
             }
         }
-        inventory = {
-            "providers": [
-                {
-                    "slug": "9router",
-                    "name": "9Router",
-                    "api_url": "https://router.example/v1",
-                    "models": [{"id": model}],
-                }
-            ]
-        }
+        (tmp_path / "config.yaml").write_text(yaml.safe_dump(cfg), encoding="utf-8")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
 
-        with patch("hermes_cli.config.load_config", return_value=cfg), patch(
-            "hermes_cli.inventory.build_models_payload", return_value=inventory
-        ):
-            model_state = acp_agent._build_model_state(state)
-            canonical_id = f"custom:9router:{model}"
-            provider, parsed_model = parse_model_input(canonical_id, "custom")
+        model_state = acp_agent._build_model_state(state)
+        canonical_id = f"custom:9router:{model}"
+        provider, parsed_model = parse_model_input(canonical_id, "custom")
+        colon_id = f"custom:{colon_provider}:{colon_model}"
+        parsed_colon_provider, parsed_colon_model = parse_model_input(
+            colon_id, "custom"
+        )
 
         assert isinstance(model_state, SessionModelState)
         ids = [item.model_id for item in model_state.available_models]
         assert ids.count(canonical_id) == 1
         assert f"9router:{model}" not in ids
+        assert f"custom:{model}" not in ids
+        assert ids.count(colon_id) == 1
+        assert f"{colon_provider}:{colon_model}" not in ids
+        if current_provider != "openai-codex":
+            assert model_state.current_model_id == canonical_id
 
         assert provider == "custom:9router"
         assert parsed_model == model
+        assert parsed_colon_provider == f"custom:{colon_provider}"
+        assert parsed_colon_model == colon_model
+
+    def test_builtin_inventory_slug_is_not_rewritten_as_custom(self):
+        manager = SessionManager(
+            agent_factory=lambda: SimpleNamespace(
+                model="claude-sonnet-4.5", provider="anthropic", base_url=None
+            )
+        )
+        acp_agent = HermesACPAgent(session_manager=manager)
+        state = manager.create_session(cwd="/tmp")
+        inventory = {
+            "providers": [
+                {
+                    "slug": "anthropic",
+                    "name": "Anthropic",
+                    "models": [{"id": "claude-sonnet-4.5"}],
+                    "is_user_defined": False,
+                }
+            ]
+        }
+
+        with patch(
+            "hermes_cli.inventory.build_models_payload", return_value=inventory
+        ), patch(
+            "hermes_cli.runtime_provider.canonical_custom_identity"
+        ) as canonical_custom_identity, patch(
+            "acp_adapter.server._named_custom_provider_catalogs", return_value=[]
+        ):
+            model_state = acp_agent._build_model_state(state)
+
+        assert isinstance(model_state, SessionModelState)
+        assert [item.model_id for item in model_state.available_models] == [
+            "anthropic:claude-sonnet-4.5"
+        ]
+        canonical_custom_identity.assert_not_called()

--- a/tests/acp/test_named_provider_catalogs.py
+++ b/tests/acp/test_named_provider_catalogs.py
@@ -277,3 +277,50 @@ class TestModelStateIncludesNamedProviders:
             )
         assert provider == "custom:local-127.0.0.1:11434"
         assert model == "qwen3:1.7b"
+
+    def test_canonicalizes_named_provider_inventory_slug(self):
+        """ACP must advertise one round-trippable id for a named endpoint."""
+        from hermes_cli.models import parse_model_input
+
+        manager = SessionManager(
+            agent_factory=lambda: SimpleNamespace(
+                model="gpt-5.4", provider="openai-codex", base_url=None
+            )
+        )
+        acp_agent = HermesACPAgent(session_manager=manager)
+        state = manager.create_session(cwd="/tmp")
+        model = "tflow/gpt-5.6-sol"
+        cfg = {
+            "providers": {
+                "9router": {
+                    "name": "9Router",
+                    "base_url": "https://router.example/v1",
+                    "default_model": model,
+                }
+            }
+        }
+        inventory = {
+            "providers": [
+                {
+                    "slug": "9router",
+                    "name": "9Router",
+                    "api_url": "https://router.example/v1",
+                    "models": [{"id": model}],
+                }
+            ]
+        }
+
+        with patch("hermes_cli.config.load_config", return_value=cfg), patch(
+            "hermes_cli.inventory.build_models_payload", return_value=inventory
+        ):
+            model_state = acp_agent._build_model_state(state)
+            canonical_id = f"custom:9router:{model}"
+            provider, parsed_model = parse_model_input(canonical_id, "custom")
+
+        assert isinstance(model_state, SessionModelState)
+        ids = [item.model_id for item in model_state.available_models]
+        assert ids.count(canonical_id) == 1
+        assert f"9router:{model}" not in ids
+
+        assert provider == "custom:9router"
+        assert parsed_model == model


### PR DESCRIPTION
Fixes #97233

Related to #74628. Complements #74648, which repairs named-provider
session persistence/restoration; this PR fixes the ACP catalog identity
offered before selection.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- Canonicalize configured named custom provider slugs before ACP encodes
  `ModelInfo.model_id` values.
- Use the same canonical identity for inventory rows, semantic
  de-duplication, current-model detection, and `current_model_id`.
- Prefer `agent.requested_provider` only when it is a routable
  `custom:<name>` identity, preserving concrete runtime resolution such as
  `auto -> openrouter`.
- Map a bare runtime `custom` inventory row to the current named custom
  identity, matching the runtime shape propagated by #74648.
- Preserve canonical built-in providers and existing Ollama behavior.
- Add regression coverage for the AionUi `9router` reproduction, bare-current
  sessions, the #74648 runtime/requested pair, colon-bearing provider/model
  IDs, built-in providers, and `auto` requests.

## Verification

The regression failed on the old implementation because ACP advertised both
the ambiguous and canonical IDs:

```text
9router:tflow/gpt-5.6-sol
custom:9router:tflow/gpt-5.6-sol
```

On this branch, based on `origin/main` at `306db2776c`:

```bash
scripts/run_tests.sh tests/acp/ -m 'not asyncio' -q
# 110 passed

scripts/run_tests.sh tests/acp_adapter/ -m 'not asyncio' -q
# 12 passed

scripts/run_tests.sh \
  tests/hermes_cli/test_runtime_provider_resolution.py \
  tests/hermes_cli/test_custom_provider_identity.py \
  tests/hermes_cli/test_canonical_custom_identity.py \
  tests/hermes_cli/test_custom_provider_model_switch.py -q
# 95 passed
```

The two async tests in `test_named_provider_catalogs.py` were not run locally
because the existing Hermes virtualenv does not contain the project-declared
`pytest-asyncio` dependency. CI can run them in the complete test environment.

## Platform Impact

This is protocol-level provider-ID handling and is not OS-specific. The
reported reproduction came from AionUi on macOS, but the fix applies to every
ACP client using a named custom provider.
