### PR TITLE
fix(curator): prevent overlapping review passes

### DIFF
--- a/agent/curator.py
+++ b/agent/curator.py
@@ -21,6 +21,7 @@ Strict invariants:
 
 from __future__ import annotations
 
+import errno
 import json
 import logging
 import os
@@ -35,6 +36,16 @@ from tools import skill_usage
 from utils import atomic_json_write
 
 logger = logging.getLogger(__name__)
+
+try:  # pragma: no cover - platform-dependent import
+    import fcntl
+except ImportError:  # pragma: no cover - Windows
+    fcntl = None  # type: ignore[assignment]
+
+try:  # pragma: no cover - platform-dependent import
+    import msvcrt
+except ImportError:  # pragma: no cover - POSIX
+    msvcrt = None  # type: ignore[assignment]
 
 
 def _strip_aux_credential(value: Any) -> Optional[str]:
@@ -76,6 +87,83 @@ DEFAULT_ARCHIVE_AFTER_DAYS = 90
 # whenever the curator is enabled; only the opinionated, aux-model-cost
 # consolidation pass is opt-in.
 DEFAULT_CONSOLIDATE = False
+
+
+class _CuratorRunLock:
+    """Owned cross-process lock for one complete curator pass."""
+
+    def __init__(self, handle: Any) -> None:
+        self._handle = handle
+
+    def release(self) -> None:
+        """Release once; safe to call again during exception unwinding."""
+        handle = self._handle
+        if handle is None:
+            return
+        self._handle = None
+        try:
+            if fcntl is not None:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+            elif msvcrt is not None:
+                handle.seek(0)
+                msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+        except OSError as e:
+            logger.debug("Failed to release curator run lock: %s", e)
+        finally:
+            try:
+                handle.close()
+            except OSError:
+                pass
+
+
+def _curator_run_lock_path() -> Path:
+    """Profile-scoped lock path outside the rollback-managed skills tree."""
+    return get_hermes_home() / ".curator-run.lock"
+
+
+def _is_run_lock_contention(error: OSError) -> bool:
+    if error.errno is None:
+        return False
+    if fcntl is not None:
+        return error.errno in (errno.EACCES, errno.EAGAIN, errno.EWOULDBLOCK)
+    if msvcrt is not None:
+        return error.errno in (errno.EACCES, errno.EAGAIN, errno.EDEADLK)
+    return False
+
+
+def _try_acquire_curator_run_lock() -> Optional[_CuratorRunLock]:
+    """Acquire the curator run lock without waiting.
+
+    ``None`` means another process owns the pass. Other open/lock failures are
+    raised so callers do not misreport a broken lock as ordinary contention.
+    """
+    if fcntl is None and msvcrt is None:
+        raise RuntimeError("no supported file-lock backend for curator")
+
+    path = _curator_run_lock_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    handle = open(path, "a+b")
+    try:
+        # msvcrt locks a byte range at the current file position. Ensure byte
+        # zero exists and seek to it before every lock/unlock operation.
+        if msvcrt is not None:
+            handle.seek(0, os.SEEK_END)
+            if handle.tell() == 0:
+                handle.write(b" ")
+                handle.flush()
+            handle.seek(0)
+            msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+        else:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError as e:
+        try:
+            handle.close()
+        except OSError:
+            pass
+        if _is_run_lock_contention(e):
+            return None
+        raise
+    return _CuratorRunLock(handle)
 
 
 # ---------------------------------------------------------------------------
@@ -1548,7 +1636,37 @@ def run_curator_review(
     can read what the curator WOULD have done. A dry-run also honors
     *consolidate*: when consolidation is off, the preview only reports the
     deterministic prune candidates.
+
+    Only one process may own a pass for a profile at a time. The lock spans
+    the complete background review, not just its scheduling preamble.
     """
+    run_lock = _try_acquire_curator_run_lock()
+    if run_lock is None:
+        logger.debug("Curator pass skipped - another process holds the run lock")
+        return {"started": False, "reason": "already_running"}
+
+    try:
+        return _run_curator_review_locked(
+            on_summary=on_summary,
+            synchronous=synchronous,
+            dry_run=dry_run,
+            consolidate=consolidate,
+            run_lock=run_lock,
+        )
+    except BaseException:
+        run_lock.release()
+        raise
+
+
+def _run_curator_review_locked(
+    *,
+    on_summary: Optional[Callable[[str], None]],
+    synchronous: bool,
+    dry_run: bool,
+    consolidate: Optional[bool],
+    run_lock: _CuratorRunLock,
+) -> Dict[str, Any]:
+    """Execute a pass while transferring lock ownership to its worker."""
     if consolidate is None:
         consolidate = get_consolidate()
     start = datetime.now(timezone.utc)
@@ -1766,13 +1884,24 @@ def run_curator_review(
             except Exception:
                 pass
 
+    def _llm_pass_and_release() -> None:
+        try:
+            _llm_pass()
+        finally:
+            run_lock.release()
+
     if synchronous:
-        _llm_pass()
+        _llm_pass_and_release()
     else:
-        t = threading.Thread(target=_llm_pass, daemon=True, name="curator-review")
+        t = threading.Thread(
+            target=_llm_pass_and_release,
+            daemon=True,
+            name="curator-review",
+        )
         t.start()
 
     return {
+        "started": True,
         "started_at": start.isoformat(),
         "auto_transitions": counts,
         "summary_so_far": auto_summary,
@@ -2035,7 +2164,8 @@ def maybe_run_curator(
             min_idle_s = get_min_idle_hours() * 3600.0
             if idle_for_seconds < min_idle_s:
                 return None
-        return run_curator_review(on_summary=on_summary)
+        result = run_curator_review(on_summary=on_summary)
+        return result if result.get("started") is not False else None
     except Exception as e:
         logger.debug("maybe_run_curator failed: %s", e, exc_info=True)
         return None

--- a/hermes_cli/curator.py
+++ b/hermes_cli/curator.py
@@ -243,6 +243,9 @@ def _cmd_run(args) -> int:
         dry_run=dry,
         consolidate=consolidate,
     )
+    if result.get("started") is False:
+        print("curator: another review pass is already running")
+        return 1
     auto = result.get("auto_transitions", {})
     if auto:
         if dry:

--- a/tests/agent/test_curator.py
+++ b/tests/agent/test_curator.py
@@ -391,11 +391,57 @@ def test_run_review_records_state(curator_env):
     u.mark_agent_created("a")
 
     result = c.run_curator_review(synchronous=True)
+    assert result["started"] is True
     assert "started_at" in result
     state = c.load_state()
     assert state["last_run_at"] is not None
     assert state["run_count"] >= 1
     assert state["last_run_summary"] is not None
+
+
+def test_run_review_skips_when_run_lock_is_held(curator_env):
+    c = curator_env["curator"]
+    lock = c._try_acquire_curator_run_lock()
+    assert lock is not None
+    try:
+        result = c.run_curator_review(
+            synchronous=True,
+            dry_run=True,
+            consolidate=True,
+        )
+    finally:
+        lock.release()
+
+    assert result == {"started": False, "reason": "already_running"}
+
+
+def test_run_lock_released_when_setup_raises(curator_env, monkeypatch):
+    c = curator_env["curator"]
+
+    def _fail(**_kwargs):
+        raise RuntimeError("setup failed")
+
+    monkeypatch.setattr(c, "_run_curator_review_locked", _fail)
+    with pytest.raises(RuntimeError, match="setup failed"):
+        c.run_curator_review(synchronous=True)
+
+    lock = c._try_acquire_curator_run_lock()
+    assert lock is not None
+    lock.release()
+
+
+def test_maybe_run_preserves_none_contract_when_lock_is_held(
+    curator_env,
+    monkeypatch,
+):
+    c = curator_env["curator"]
+    monkeypatch.setattr(c, "should_run_now", lambda: True)
+    lock = c._try_acquire_curator_run_lock()
+    assert lock is not None
+    try:
+        assert c.maybe_run_curator(idle_for_seconds=float("inf")) is None
+    finally:
+        lock.release()
 
 
 

--- a/tests/e2e/test_curator_single_flight.py
+++ b/tests/e2e/test_curator_single_flight.py
@@ -1,0 +1,185 @@
+"""Cross-process proof for curator run single-flight."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+_CHILD = r"""
+import json
+import sys
+import threading
+import time
+from pathlib import Path
+
+import agent.curator as curator
+
+ready = Path(sys.argv[1])
+release = Path(sys.argv[2])
+entered = Path(sys.argv[3])
+mode = sys.argv[4]
+
+curator._load_config = lambda: {}
+
+def render_candidates():
+    entered.write_text("entered", encoding="utf-8")
+    return "candidate: cross-process-lock-proof"
+
+def review(_prompt):
+    ready.write_text("ready", encoding="utf-8")
+    if mode == "hold":
+        deadline = time.monotonic() + 20
+        while not release.exists():
+            if time.monotonic() >= deadline:
+                raise TimeoutError("parent did not release holder")
+            time.sleep(0.01)
+    return {
+        "final": "ok",
+        "summary": "ok",
+        "model": "stub",
+        "provider": "stub",
+        "tool_calls": [],
+        "error": None,
+    }
+
+curator._render_candidate_list = render_candidates
+curator._run_llm_review = review
+
+result = curator.run_curator_review(
+    synchronous=mode != "hold",
+    dry_run=True,
+    consolidate=True,
+)
+print(json.dumps(result), flush=True)
+
+if mode == "hold":
+    deadline = time.monotonic() + 20
+    while any(
+        thread.name == "curator-review" and thread.is_alive()
+        for thread in threading.enumerate()
+    ):
+        if time.monotonic() >= deadline:
+            raise TimeoutError("curator background thread did not finish")
+        time.sleep(0.01)
+"""
+
+
+def _wait_for(path: Path, process: subprocess.Popen[str], timeout: float = 15) -> None:
+    deadline = time.monotonic() + timeout
+    while not path.exists():
+        if process.poll() is not None:
+            stdout, stderr = process.communicate()
+            raise AssertionError(
+                f"holder exited before {path.name}: rc={process.returncode}\n"
+                f"stdout={stdout}\nstderr={stderr}"
+            )
+        if time.monotonic() >= deadline:
+            process.kill()
+            stdout, stderr = process.communicate()
+            raise AssertionError(
+                f"timed out waiting for {path.name}\nstdout={stdout}\nstderr={stderr}"
+            )
+        time.sleep(0.02)
+
+
+def _result(stdout: str) -> dict:
+    lines = [line for line in stdout.splitlines() if line.strip()]
+    assert lines, "child produced no result"
+    return json.loads(lines[0])
+
+
+def test_curator_pass_is_single_flight_across_processes(tmp_path):
+    repo_root = Path(__file__).resolve().parents[2]
+    home = tmp_path / ".hermes"
+    (home / "skills").mkdir(parents=True)
+    env = os.environ.copy()
+    env["HERMES_HOME"] = str(home)
+    env["HERMES_TESTING"] = "1"
+    env["PYTHONUTF8"] = "1"
+
+    ready = tmp_path / "holder-ready"
+    release = tmp_path / "release-holder"
+    holder_entered = tmp_path / "holder-entered"
+    holder = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            _CHILD,
+            str(ready),
+            str(release),
+            str(holder_entered),
+            "hold",
+        ],
+        cwd=repo_root,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    try:
+        _wait_for(ready, holder)
+        assert holder_entered.exists()
+
+        contender_entered = tmp_path / "contender-entered"
+        contender = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                _CHILD,
+                str(tmp_path / "contender-ready"),
+                str(release),
+                str(contender_entered),
+                "quick",
+            ],
+            cwd=repo_root,
+            env=env,
+            text=True,
+            capture_output=True,
+            timeout=15,
+            check=True,
+        )
+        assert _result(contender.stdout) == {
+            "started": False,
+            "reason": "already_running",
+        }
+        assert not contender_entered.exists()
+
+        release.write_text("release", encoding="utf-8")
+        holder_stdout, holder_stderr = holder.communicate(timeout=15)
+        assert holder.returncode == 0, holder_stderr
+        assert _result(holder_stdout)["started"] is True
+
+        successor_entered = tmp_path / "successor-entered"
+        successor = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                _CHILD,
+                str(tmp_path / "successor-ready"),
+                str(release),
+                str(successor_entered),
+                "quick",
+            ],
+            cwd=repo_root,
+            env=env,
+            text=True,
+            capture_output=True,
+            timeout=15,
+            check=True,
+        )
+        assert _result(successor.stdout)["started"] is True
+        assert successor_entered.exists()
+    finally:
+        if holder.poll() is None:
+            release.write_text("release", encoding="utf-8")
+            try:
+                holder.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                holder.kill()
+                holder.wait(timeout=5)

--- a/tests/hermes_cli/test_curator_run.py
+++ b/tests/hermes_cli/test_curator_run.py
@@ -50,3 +50,21 @@ def test_dry_run_default_reports_synchronous_wording(monkeypatch, capsys):
     out = capsys.readouterr().out
     assert "When the report lands" not in out
     assert "Read the report with `hermes curator status`" in out
+
+
+def test_run_reports_existing_curator_pass(monkeypatch, capsys):
+    import agent.curator as curator_state
+    import hermes_cli.curator as curator_cli
+
+    monkeypatch.setattr(curator_state, "is_enabled", lambda: True)
+    monkeypatch.setattr(
+        curator_state,
+        "run_curator_review",
+        lambda **_kwargs: {"started": False, "reason": "already_running"},
+    )
+
+    assert curator_cli._cmd_run(_args()) == 1
+
+    out = capsys.readouterr().out
+    assert "another review pass is already running" in out
+    assert "llm pass running in background" not in out


### PR DESCRIPTION
## What does this PR do?

Prevents multiple curator review passes from running concurrently for the same Hermes profile.

Scheduled and manual curator runs could overlap before curator state was updated, causing duplicate LLM work and concurrent skill mutations. This change adds a profile-scoped, non-blocking file lock that remains held for the entire review pass, including background execution.

A concurrent invocation now exits cleanly without entering the review.

## Type of Change

- [x] Bug fix

## Changes Made

- Add cross-process curator locking using `fcntl` on POSIX and `msvcrt` on Windows
- Hold the lock until the background review thread finishes
- Release the lock on both successful and exceptional exits
- Report concurrent manual runs clearly in the CLI
- Add unit, CLI, and real two-process E2E coverage

No dependencies, configuration keys, or environment variables were added.

## How to Test

```bash
python -m pytest tests/agent/test_curator.py tests/agent/test_curator_backup.py tests/hermes_cli/test_curator_run.py tests/e2e/test_curator_single_flight.py -q
```