### PR TITLE
feat(desktop): support multi-path and directory pickers in the plugin OS API

### DIFF
--- a/apps/desktop/src/contrib/plugin.test.ts
+++ b/apps/desktop/src/contrib/plugin.test.ts
@@ -41,6 +41,7 @@ describe('createPluginContext.os', () => {
     // The pickers answer with a path, so their "unavailable" is null.
     await expect(ctx.os.pickSavePath()).resolves.toBeNull()
     await expect(ctx.os.pickOpenPath()).resolves.toBeNull()
+    await expect(ctx.os.pickOpenPaths()).resolves.toEqual([])
   })
 
   it('file pickers return the chosen path, and null on cancel', async () => {
@@ -70,6 +71,103 @@ describe('createPluginContext.os', () => {
     }
   })
 
+  it('pickOpenPaths returns every selected path and enables native multiple selection', async () => {
+    const bridge = {
+      selectPaths: vi.fn().mockResolvedValue(['/tmp/source-a.docx', '/tmp/source-b.pdf'])
+    }
+
+    ;(window as unknown as { hermesDesktop: unknown }).hermesDesktop = bridge
+
+    try {
+      const ctx = createPluginContext('demo')
+
+      await expect(ctx.os.pickOpenPaths({ directories: true, title: 'Choose sources' })).resolves.toEqual([
+        '/tmp/source-a.docx',
+        '/tmp/source-b.pdf'
+      ])
+      expect(bridge.selectPaths).toHaveBeenCalledWith({
+        directories: true,
+        multiple: true,
+        title: 'Choose sources'
+      })
+    } finally {
+      delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
+    }
+  })
+
+  it('pickOpenPath selects a directory when requested', async () => {
+    const bridge = {
+      selectPaths: vi.fn().mockResolvedValue(['/tmp/output'])
+    }
+
+    ;(window as unknown as { hermesDesktop: unknown }).hermesDesktop = bridge
+
+    try {
+      const ctx = createPluginContext('demo')
+
+      await expect(ctx.os.pickOpenPath({ directories: true, title: 'Choose output folder' })).resolves.toBe('/tmp/output')
+      expect(bridge.selectPaths).toHaveBeenCalledWith({
+        directories: true,
+        multiple: false,
+        title: 'Choose output folder'
+      })
+    } finally {
+      delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
+    }
+  })
+
+  it('pickOpenPaths returns an empty list when the native bridge fails', async () => {
+    const bridge = {
+      selectPaths: vi.fn().mockRejectedValue(new Error('native dialog failed'))
+    }
+
+    ;(window as unknown as { hermesDesktop: unknown }).hermesDesktop = bridge
+
+    try {
+      const ctx = createPluginContext('demo')
+
+      await expect(ctx.os.pickOpenPaths()).resolves.toEqual([])
+    } finally {
+      delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
+    }
+  })
+
+  it('pickOpenPaths returns an empty list when the user cancels', async () => {
+    const bridge = {
+      selectPaths: vi.fn().mockResolvedValue([])
+    }
+
+    ;(window as unknown as { hermesDesktop: unknown }).hermesDesktop = bridge
+
+    try {
+      const ctx = createPluginContext('demo')
+
+      await expect(ctx.os.pickOpenPaths()).resolves.toEqual([])
+    } finally {
+      delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
+    }
+  })
+
+  it('pickOpenPaths filters malformed bridge results', async () => {
+    const bridge = {
+      selectPaths: vi
+        .fn()
+        .mockResolvedValueOnce(['/tmp/source.docx', '', null, 42])
+        .mockResolvedValueOnce(null)
+    }
+
+    ;(window as unknown as { hermesDesktop: unknown }).hermesDesktop = bridge
+
+    try {
+      const ctx = createPluginContext('demo')
+
+      await expect(ctx.os.pickOpenPaths()).resolves.toEqual(['/tmp/source.docx'])
+      await expect(ctx.os.pickOpenPaths()).resolves.toEqual([])
+    } finally {
+      delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
+    }
+  })
+
   it('file pickers degrade to null on an older shell that lacks them', async () => {
     ;(window as unknown as { hermesDesktop: unknown }).hermesDesktop = {}
 
@@ -77,6 +175,7 @@ describe('createPluginContext.os', () => {
       const ctx = createPluginContext('demo')
       await expect(ctx.os.pickSavePath()).resolves.toBeNull()
       await expect(ctx.os.pickOpenPath()).resolves.toBeNull()
+      await expect(ctx.os.pickOpenPaths()).resolves.toEqual([])
     } finally {
       delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
     }

--- a/apps/desktop/src/contrib/plugin.ts
+++ b/apps/desktop/src/contrib/plugin.ts
@@ -59,9 +59,12 @@ export interface PluginOs {
    *  when unavailable. The path is on the BACKEND's filesystem, so hand it
    *  to a `rest` call rather than trying to write it from the renderer. */
   pickSavePath: (options?: PluginFileDialogOptions) => Promise<null | string>
-  /** Native open dialog, single file. Resolves the chosen path, or null on
-   *  cancel / when unavailable. */
-  pickOpenPath: (options?: PluginFileDialogOptions) => Promise<null | string>
+  /** Native open dialog, single file or directory. Resolves the chosen path,
+   *  or null on cancel / when unavailable. */
+  pickOpenPath: (options?: PluginOpenDialogOptions) => Promise<null | string>
+  /** Native open dialog, multiple files or directories. Resolves every chosen
+   *  path, or an empty list on cancel / when unavailable. */
+  pickOpenPaths: (options?: PluginOpenDialogOptions) => Promise<string[]>
   /** Write text to the system clipboard. Resolves false when unavailable. */
   writeClipboard: (text: string) => Promise<boolean>
 }
@@ -70,6 +73,11 @@ export interface PluginFileDialogOptions {
   defaultPath?: string
   filters?: Array<{ extensions: string[]; name: string }>
   title?: string
+}
+
+export interface PluginOpenDialogOptions extends PluginFileDialogOptions {
+  /** Select directories instead of files. */
+  directories?: boolean
 }
 
 export interface PluginContext {
@@ -94,8 +102,8 @@ export interface PluginContext {
    *  accelerator over your polling, never a replacement. */
   socket: (path: string, onMessage: (data: unknown) => void) => () => void
   /** The curated OS door: native notification, open-external, reveal-in-file-
-   *  manager, clipboard — attributed to this plugin, result-shaped (never
-   *  throws for a missing capability). */
+   *  manager, path pickers and clipboard — attributed to this plugin,
+   *  result-shaped (never throws for a missing capability). */
   os: PluginOs
   /** Plugin-scoped persistence. */
   storage: PluginStorage
@@ -174,6 +182,22 @@ function createPluginOs(pluginId: string): PluginOs {
     }
   }
 
+  const attemptPaths = async (run: (bridge: NonNullable<typeof window.hermesDesktop>) => Promise<unknown>) => {
+    const bridge = typeof window === 'undefined' ? undefined : window.hermesDesktop
+
+    if (!bridge) {
+      return []
+    }
+
+    try {
+      const paths = await run(bridge)
+
+      return Array.isArray(paths) ? paths.filter(path => typeof path === 'string' && path.length > 0) : []
+    } catch {
+      return []
+    }
+  }
+
   return {
     notify: input => dispatchPluginNativeNotification(pluginId, input),
     openExternal: url =>
@@ -188,6 +212,7 @@ function createPluginOs(pluginId: string): PluginOs {
 
         return picked?.[0] ?? null
       }),
+    pickOpenPaths: options => attemptPaths(async bridge => bridge.selectPaths?.({ ...options, multiple: true })),
     pickSavePath: options => attemptPath(async bridge => (await bridge.selectSavePath?.(options)) ?? null),
     revealPath: path => attempt(async bridge => (bridge.revealPath ? bridge.revealPath(path) : false)),
     writeClipboard: text => attempt(bridge => bridge.writeClipboard(text))

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -1576,8 +1576,10 @@ export type {
   HermesPlugin,
   PluginContext,
   PluginContribution,
+  PluginFileDialogOptions,
   PluginNativeNotificationInput,
   PluginNotificationAction,
+  PluginOpenDialogOptions,
   PluginOs,
   PluginRestOptions,
   PluginStorage

--- a/website/docs/developer-guide/desktop-plugin-sdk.md
+++ b/website/docs/developer-guide/desktop-plugin-sdk.md
@@ -173,7 +173,7 @@ interface PluginContext {
   rest: <T>(path: string, opts?: PluginRestOptions) => Promise<T>
   /** Live WebSocket to this plugin's own namespace. Returns a disposer. */
   socket: (path: string, onMessage: (data: unknown) => void) => () => void
-  /** The curated OS door: native notification, open-external, reveal-in-file-manager, clipboard. */
+  /** The curated OS door: native notification, path pickers, open-external, reveal-in-file-manager, clipboard. */
   os: PluginOs
   /** Plugin-scoped JSON persistence (keys live under `hermes.plugin.<id>.`). */
   storage: PluginStorage
@@ -498,6 +498,15 @@ ctx.os.notify({ title, body?, silent?, icon?, activate?, onActivate?, actions? }
 ctx.os.openExternal(url)                   // OS default handler (browser, mail, spotify:) → Promise<boolean>
 ctx.os.revealPath(path)                    // reveal in Finder / Explorer → Promise<boolean>
 ctx.os.writeClipboard(text)                // system clipboard → Promise<boolean>
+ctx.os.pickOpenPath({                       // one file or directory → Promise<string | null>
+  title?, defaultPath?, directories?, filters?
+})
+ctx.os.pickOpenPaths({                      // multiple files or directories → Promise<string[]>
+  title?, defaultPath?, directories?, filters?
+})
+ctx.os.pickSavePath({                       // save destination → Promise<string | null>
+  title?, defaultPath?, filters?
+})
 host.navigate('/route')                    // hash-route navigation
 host.openSession(id, { profile?, intent? }) // open a stored session core-style;
                                            //   profile: soft-swap to that profile's backend first
@@ -628,6 +637,11 @@ happens on user click — never from a background event alone.
 The other doors (`openExternal`, `revealPath`, `writeClipboard`) resolve
 `false` instead of throwing when the capability isn't available (older desktop
 shell, plain browser) — branch on the result rather than sniffing the bridge.
+The path pickers follow the same result-shaped convention: single-path pickers
+resolve `null`, while `pickOpenPaths` resolves `[]`, on cancellation, failure,
+or an unavailable older shell. Set `directories: true` on either open picker to
+select folders instead of files; `pickOpenPaths` always enables native multiple
+selection.
 
 ## Data layer — React Query + nanostores
 
@@ -894,7 +908,7 @@ not treat this pipeline as a trust boundary.
 | Category | Exports |
 |----------|---------|
 | Host | `host` (`.state.*`, `.notify`, `.notifyError`, `.navigate`, `.onEvent`, `.logs`, `.status`, `.restartGateway`, `.request`) |
-| Plugin contract | `HermesPlugin`, `PluginContext`, `PluginContribution`, `PluginStorage`, `PluginOs`, `PluginRestOptions`, `PluginNativeNotificationInput`, `PluginNotificationAction`, `HermesOpenTarget`, `Contribution` |
+| Plugin contract | `HermesPlugin`, `PluginContext`, `PluginContribution`, `PluginStorage`, `PluginOs`, `PluginFileDialogOptions`, `PluginOpenDialogOptions`, `PluginRestOptions`, `PluginNativeNotificationInput`, `PluginNotificationAction`, `HermesOpenTarget`, `Contribution` |
 | Area constants | `PANES_AREA`, `ROUTES_AREA`, `SIDEBAR_NAV_AREA`, `STATUSBAR_AREAS`, `TITLEBAR_AREAS`, `PALETTE_AREA`, `KEYBINDS_AREA`, `THEMES_AREA`, `COMPOSER_AREAS` |
 | Area payloads | `RouteContribution`, `SidebarNavContribution`, `StatusbarItem`, `TitlebarTool`, `PaletteContribution`, `KeybindContribution`, `ComposerMiddleware`, `ComposerAttachmentProvider` |
 | React / state | `useValue`, `atom`, `computed`, `useQuery`, `useMutation`, `useQueryClient`, `queryClient`, `Contribute` |


### PR DESCRIPTION
## Summary

- extend the existing `ctx.os.pickOpenPath(...)` options with `directories` so plugins can ask the native chooser for one folder
- add `ctx.os.pickOpenPaths(...)` for user-mediated selection of multiple files or directories
- preserve the current result-shaped picker convention: single-path pickers return `null`, while the multi-path picker returns `[]`, on cancellation, failure, or an unavailable older shell
- export the file-dialog option types through `@hermes/plugin-sdk`
- document the complete plugin path-picker surface, including the existing open and save helpers

## Motivation

The existing `pickOpenPath` and `pickSavePath` helpers cover one input file and one save destination. Desktop plugins also need the same curated OS boundary for workflows that accept several source files or a user-selected directory.

This update extends the current `PluginOs` surface rather than exposing `window.hermesDesktop` or adding a second overlapping bridge API.

## API

```ts
ctx.os.pickOpenPath({
  title?,
  defaultPath?,
  directories?,
  filters?
}) // Promise<string | null>

ctx.os.pickOpenPaths({
  title?,
  defaultPath?,
  directories?,
  filters?
}) // Promise<string[]>
```

`pickOpenPaths` always requests native multiple selection. Setting `directories: true` on either open picker selects folders instead of files.

## Security and compatibility

- plugins remain behind the curated `PluginContext` boundary and receive no raw access to `window.hermesDesktop`
- the chooser only returns paths explicitly selected by the user
- no directory scanning or arbitrary filesystem read capability is added
- older Desktop shells continue to degrade safely through result values instead of throwing

## Tests

- missing Desktop bridge returns an empty list for `pickOpenPaths`
- multiple selected paths are returned and `multiple: true` is passed to the native bridge
- `directories: true` is passed through for single-directory selection
- native bridge failure resolves to an empty list
- targeted plugin OS tests pass
- Desktop TypeScript checks pass
- Desktop ESLint passes with no errors