### PR TITLE
fix(agent): guard Codex message IDs across providers

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1312,9 +1312,10 @@ class _CodexStreamGuard:
 class _CodexCompletionsAdapter:
     """Drop-in shim routing chat.completions.create() kwargs through Codex Responses streaming."""
 
-    def __init__(self, real_client: OpenAI, model: str):
+    def __init__(self, real_client: OpenAI, model: str, *, issuer_kind: Optional[str] = None):
         self._client = real_client
         self._model = model
+        self._issuer_kind = issuer_kind
 
     def _build_responses_kwargs(self, kwargs: Dict[str, Any]) -> Tuple[Dict[str, Any], str, Any]:
         """chat.completions kwargs → Responses API kwargs, ``(resp_kwargs, model, timeout)``; mirrors codex.py::build_kwargs."""
@@ -1328,12 +1329,18 @@ class _CodexCompletionsAdapter:
         # includes assistant tool_calls + role="tool" results). The shared converter encodes assistant tool
         # calls as `function_call` items and tool results as `function_call_output` items with a valid
         # call_id, so every Responses path normalizes tool history identically and cannot drift.
-        from agent.codex_responses_adapter import _chat_messages_to_responses_input
+        from agent.codex_responses_adapter import _chat_messages_to_responses_input, _classify_responses_issuer
         model = kwargs.get("model", self._model)
         host = str(getattr(self._client, "base_url", "") or "")
         is_xai = base_url_host_matches(host, "x.ai") or base_url_host_matches(host, "api.x.ai")
         is_copilot = base_url_host_matches(host, "githubcopilot.com")
         is_github = is_copilot or base_url_host_matches(host, "models.github.ai")
+        # Explicit provider identity survives custom proxy URLs; generic clients
+        # derive it from the endpoint, just like the main Responses transport.
+        issuer_kind = self._issuer_kind or _classify_responses_issuer(
+            is_xai_responses=is_xai, is_github_responses=is_github,
+            is_codex_backend=_is_official_codex_base_url(host), base_url=host,
+        )
         # System → ``instructions``; the rest goes through the SINGLE shared chat→Responses
         # converter (a private loop here once let role="tool" leak into input[]; the shared one
         # encodes tool history as function_call/function_call_output).
@@ -1352,7 +1359,8 @@ class _CodexCompletionsAdapter:
         # instead of agent/transports/codex.py's build_kwargs, so they need the same guard applied
         # independently. See #32716.
         input_items = _chat_messages_to_responses_input(
-            replay_messages, is_github_responses=is_copilot, native_compaction_eligible=False
+            replay_messages, is_github_responses=is_github,
+            current_issuer_kind=issuer_kind, native_compaction_eligible=False,
         )
         resp_kwargs: Dict[str, Any] = {
             # Codex only knows the base slug; strip the Hermes ``-900k`` picker suffix.
@@ -1539,9 +1547,9 @@ _AsyncAnthropicCompletionsAdapter = _AsyncCompletionsAdapter  # imported by test
 class CodexAuxiliaryClient:
     """OpenAI-client-compatible wrapper routing through the Codex Responses API (.api_key/.base_url for introspection)."""
 
-    def __init__(self, real_client: OpenAI, model: str):
+    def __init__(self, real_client: OpenAI, model: str, *, issuer_kind: Optional[str] = None):
         self._real_client = real_client
-        self.chat = _ChatShim(_CodexCompletionsAdapter(real_client, model))
+        self.chat = _ChatShim(_CodexCompletionsAdapter(real_client, model, issuer_kind=issuer_kind))
         self.api_key = real_client.api_key
         self.base_url = real_client.base_url
 
@@ -2729,7 +2737,7 @@ def _build_xai_oauth_aux_client(model: str) -> Tuple[Optional[Any], Optional[str
     real_client = _create_openai_client(
         api_key=api_key, base_url=base_url, default_headers=hermes_xai_default_headers()
     )
-    return CodexAuxiliaryClient(real_client, model), model
+    return CodexAuxiliaryClient(real_client, model, issuer_kind="xai_responses"), model
 
 
 def _build_codex_client(model: str) -> Tuple[Optional[Any], Optional[str]]:
@@ -2757,7 +2765,7 @@ def _build_codex_client(model: str) -> Tuple[Optional[Any], Optional[str]]:
         api_key=codex_token, base_url=base_url,
         default_headers=_codex_cloudflare_headers(codex_token, base_url=base_url),
     )
-    return CodexAuxiliaryClient(real_client, model), model
+    return CodexAuxiliaryClient(real_client, model, issuer_kind="codex_backend"), model
 
 
 def _try_azure_foundry(

--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -12,6 +12,8 @@ import uuid
 from types import SimpleNamespace
 from typing import Any, Callable, Dict, Iterator, List, NamedTuple, Optional, TypeGuard
 
+import httpx
+
 from agent.message_sanitization import deterministic_call_id
 from agent.prompt_builder import DEFAULT_AGENT_IDENTITY
 
@@ -22,12 +24,27 @@ def _classify_responses_issuer(
     *, is_xai_responses: bool = False, is_github_responses: bool = False, is_codex_backend: bool = False,
     base_url: Optional[str] = None,
 ) -> str:
-    """Stable identifier for the endpoint that mints ``reasoning.encrypted_content``. Blobs are sealed to their
-    issuer (HTTP 400 ``invalid_encrypted_content``), so stamping lets replay drop foreign blobs after a model switch."""
+    """Stable issuer identity for persisted reasoning blobs and assistant message ids.
+    Provider flags take precedence; custom endpoint URLs use the SDK's canonical form."""
     for flag, kind in ((is_xai_responses, "xai_responses"), (is_github_responses, "github_responses"), (is_codex_backend, "codex_backend")):
         if flag:
             return kind
-    return f"other:{base_url}" if base_url else "other"
+    if base_url:
+        # Match OpenAI's httpx.URL normalization (host case, default ports, IDNs)
+        # so configured main routes and SDK-normalized auxiliary routes agree.
+        try:
+            normalized_base_url = str(httpx.URL(str(base_url))).rstrip("/")
+        except (httpx.InvalidURL, TypeError, UnicodeError):
+            normalized_base_url = str(base_url).rstrip("/")
+        return f"other:{normalized_base_url}" if normalized_base_url else "other"
+    return "other"
+
+
+def _canonicalize_responses_issuer_kind(issuer_kind: Any) -> Any:
+    """Normalize legacy URL-backed stamps without inferring provider identity from a host."""
+    if not isinstance(issuer_kind, str) or not issuer_kind.startswith("other:"):
+        return issuer_kind
+    return _classify_responses_issuer(base_url=issuer_kind[len("other:"):])
 
 
 # Per-process throttle for the cross-issuer skip warning.
@@ -317,11 +334,25 @@ def _message_item(
     return item
 
 
-def _assistant_message_item(raw: Dict[str, Any], content: List[Dict[str, Any]], *, is_github_responses: bool) -> Dict[str, Any]:
-    """Replayable assistant ``message`` item from a stored one. ``id`` is kept only when short enough and never for
-    GitHub Copilot (ids bind to a backend connection; stale → 401); ``phase`` is preserved per OpenAI's cache guidance."""
+def _assistant_message_item(
+    raw: Dict[str, Any], content: List[Dict[str, Any]], *, is_github_responses: bool,
+    current_issuer_kind: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Withhold foreign or invalid ids without changing assistant text, status or phase.
+    GitHub connection-bound ids never replay; unstamped legacy ids remain compatible
+    except that the Codex backend requires the ``msg`` namespace."""
     item_id, phase = raw.get("id"), raw.get("phase")
-    keep_id = not is_github_responses and _nonblank(item_id) and len(item_id.strip()) <= _MAX_RESPONSES_ITEM_ID_LENGTH
+    item_issuer = raw.get("_issuer_kind")
+    issuer_matches = (
+        current_issuer_kind is None or item_issuer is None
+        or _canonicalize_responses_issuer_kind(item_issuer) == current_issuer_kind
+    )
+    keep_id = (
+        not is_github_responses and issuer_matches and _nonblank(item_id)
+        and len(item_id.strip()) <= _MAX_RESPONSES_ITEM_ID_LENGTH
+        # Deliberately "msg", not "msg_": match the backend's namespace contract.
+        and (current_issuer_kind != "codex_backend" or item_id.strip().startswith("msg"))
+    )
     return _message_item(
         content, status=_normalize_responses_message_status(raw.get("status")),
         item_id=item_id.strip() if keep_id else None, phase=phase.strip() if _nonblank(phase) else None,
@@ -345,7 +376,10 @@ def _replay_reasoning_items(
         if (item_id and item_id in seen_item_ids) or (ri.get("type") == "compaction" and not native_compaction_eligible):
             continue
         item_issuer = ri.get("_issuer_kind")
-        if current_issuer_kind is not None and item_issuer is not None and item_issuer != current_issuer_kind:
+        if (
+            current_issuer_kind is not None and item_issuer is not None
+            and _canonicalize_responses_issuer_kind(item_issuer) != current_issuer_kind
+        ):
             if not _CROSS_ISSUER_WARN_EMITTED:
                 logger.warning(
                     "Dropping reasoning item minted by %s while calling %s — encrypted_content is sealed to "
@@ -360,7 +394,9 @@ def _replay_reasoning_items(
     return replayed
 
 
-def _replay_message_items(msg: Dict[str, Any], *, is_github_responses: bool) -> List[Dict[str, Any]]:
+def _replay_message_items(
+    msg: Dict[str, Any], *, is_github_responses: bool, current_issuer_kind: Optional[str] = None,
+) -> List[Dict[str, Any]]:
     """Replay exact assistant message items (id/phase) for prefix-cache hits."""
     replayed: List[Dict[str, Any]] = []
     for raw_item in _as_list(msg.get("codex_message_items")):
@@ -372,7 +408,9 @@ def _replay_message_items(msg: Dict[str, Any], *, is_github_responses: bool) -> 
             if isinstance(part, dict) and str(part.get("type") or "").strip() in _OUTPUT_TEXT_TYPES
         ]
         if content:
-            replayed.append(_assistant_message_item(raw_item, content, is_github_responses=is_github_responses))
+            replayed.append(_assistant_message_item(
+                raw_item, content, is_github_responses=is_github_responses, current_issuer_kind=current_issuer_kind,
+            ))
     return replayed
 
 
@@ -425,7 +463,8 @@ def _chat_messages_to_responses_input(
     ``replay_encrypted_reasoning``: per-session kill switch, threaded False by
     ``AIAgent._disable_codex_reasoning_replay`` after an ``invalid_encrypted_content`` 400.
     ``is_github_responses``: drops ``id`` from replayed message items (Copilot 401s on stale ids).
-    ``current_issuer_kind``: cross-issuer guard; foreign-stamped items drop, legacy items replay.
+    ``current_issuer_kind``: foreign encrypted reasoning drops; foreign assistant ids are
+    withheld while their text remains. Legacy items replay, but Codex ids must start with ``msg``.
     ``native_compaction_eligible``: THIS request carries ``context_management``; gates both replaying ``compaction``
     checkpoints and ``prune_pre_checkpoint_items``. Checkpoints persist across model swaps / compression flips / resume,
     so without the gate one checkpoint would erase pre-checkpoint history on a model that cannot decrypt it (lossless:
@@ -463,6 +502,7 @@ def _chat_messages_to_responses_input(
     # `function_call_output` wrapper) that no longer carries it (#90976).
     item_sources: List[Optional[Dict[str, Any]]] = []
     seen_item_ids: set = set()
+    current_issuer_kind = _canonicalize_responses_issuer_kind(current_issuer_kind)
     def emit(new_items: List[Dict[str, Any]], msg: Dict[str, Any]) -> None:
         items.extend(new_items)
         item_sources.extend([msg] * len(new_items))
@@ -490,7 +530,9 @@ def _chat_messages_to_responses_input(
             native_compaction_eligible=native_compaction_eligible,
         )
         emit(reasoning_items, msg)
-        message_items = _replay_message_items(msg, is_github_responses=is_github_responses)
+        message_items = _replay_message_items(
+            msg, is_github_responses=is_github_responses, current_issuer_kind=current_issuer_kind,
+        )
         emit(message_items, msg)
         if not message_items:
             # Every reasoning item needs a following item (else missing_following_item), hence the "" fallback.
@@ -945,7 +987,7 @@ class _OutputScan:
                 self.has_incomplete_items = True
                 self.saw_streaming_or_item_incomplete = True
             if item_type == "message":
-                self._message(item, item_status)
+                self._message(item, item_status, issuer_kind)
             elif item_type in {"reasoning", "compaction"}:
                 if item_type == "reasoning":
                     self.saw_reasoning_item = True
@@ -964,7 +1006,7 @@ class _OutputScan:
             elif item_type == "custom_tool_call" or (item_type == "function_call" and item_status not in _INCOMPLETE_STATUSES):
                 self.tool_calls.append(_response_tool_call(item, item_type, len(self.tool_calls)))
 
-    def _message(self, item: Any, item_status: Optional[str]) -> None:
+    def _message(self, item: Any, item_status: Optional[str], issuer_kind: Optional[str]) -> None:
         normalized_phase = _lower_or_none(getattr(item, "phase", None))
         is_commentary_phase = normalized_phase in {"commentary", "analysis"}
         self.saw_commentary_phase = self.saw_commentary_phase or is_commentary_phase
@@ -976,15 +1018,18 @@ class _OutputScan:
         # to the reasoning channel; the exact item is still preserved for replay/cache.
         (self.reasoning_parts if is_commentary_phase else self.content_parts).append(message_text)
         item_id = getattr(item, "id", None)
-        self.message_items_raw.append(_message_item(
+        raw_message_item = _message_item(
             [{"type": "output_text", "text": message_text}], status=_normalize_responses_message_status(item_status),
             item_id=item_id if isinstance(item_id, str) else None, phase=normalized_phase,
-        ))
+        )
+        if issuer_kind:
+            raw_message_item["_issuer_kind"] = issuer_kind
+        self.message_items_raw.append(raw_message_item)
 
 
 def _normalize_codex_response(response: Any, *, issuer_kind: Optional[str] = None) -> tuple[Any, str]:
     """Normalize a Responses API object to ``(assistant_message, finish_reason)``.
-    ``issuer_kind`` is stamped onto captured reasoning items for cross-issuer replay drops."""
+    ``issuer_kind`` is stamped onto captured reasoning and message items for safe cross-issuer replay."""
     response_status = _lower_or_none(getattr(response, "status", None))
     incomplete_reason = str(_field(getattr(response, "incomplete_details", None), "reason", "") or "").strip().lower()
     response_incomplete_content_filter = response_status == "incomplete" and incomplete_reason == "content_filter"

--- a/tests/agent/test_responses_issuer_replay.py
+++ b/tests/agent/test_responses_issuer_replay.py
@@ -1,0 +1,198 @@
+"""Issuer provenance must protect provider switches without rewriting history."""
+
+from copy import deepcopy
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import json
+import threading
+from types import SimpleNamespace
+
+import httpx
+from openai import OpenAI
+import pytest
+
+from agent.codex_responses_adapter import (
+    _chat_messages_to_responses_input,
+    _classify_responses_issuer,
+    _normalize_codex_response,
+    _preflight_codex_input_items,
+)
+
+
+def _history(item_id, issuer):
+    message = {
+        "type": "message", "role": "assistant", "id": item_id,
+        "status": "completed", "phase": "final_answer",
+        "content": [{"type": "output_text", "text": "Previous answer"}],
+    }
+    reasoning = {"type": "reasoning", "id": "rs_previous", "encrypted_content": "sealed", "summary": []}
+    if issuer is not None:
+        message["_issuer_kind"] = reasoning["_issuer_kind"] = issuer
+    return [
+        {"role": "user", "content": "Question"},
+        {"role": "assistant", "content": "Previous answer", "codex_message_items": [message],
+         "codex_reasoning_items": [reasoning]},
+        {"role": "user", "content": "Follow-up"},
+    ]
+
+
+@pytest.mark.parametrize("current,stored,item_id,keep_id,keep_reasoning", [
+    ("codex_backend", None, "a7ca4fd3c0b6ffcf", False, True),
+    ("codex_backend", None, "msg_legacy", True, True),
+    ("codex_backend", "codex_backend", "msg_native", True, True),
+    ("codex_backend", "codex_backend", "msgWithoutUnderscore", True, True),
+    ("codex_backend", "codex_backend", "foreign_short_id", False, True),
+    ("codex_backend", "codex_backend", "msg" + "x" * 62, False, True),
+    ("codex_backend", "xai_responses", "msg_foreign", False, False),
+    ("xai_responses", "codex_backend", "msg_foreign", False, False),
+    ("xai_responses", "xai_responses", "native_uuid", True, True),
+    ("xai_responses", None, "legacy_uuid", True, True),
+    ("github_responses", "github_responses", "msg_connection_scoped", False, True),
+    (None, "xai_responses", "legacy_uuid", True, True),
+    ("other:https://responses.example/v1", "other:https://RESPONSES.EXAMPLE:443/v1/", "native_uuid", True, True),
+    ("other:http://responses.example/v1", "other:http://RESPONSES.EXAMPLE:80/v1/", "native_uuid", True, True),
+    ("other:https://responses.example/v1", "other:https://different.example/v1", "msg_foreign", False, False),
+    ("other:https://responses.example/v2", "other:https://responses.example/v1", "msg_foreign", False, False),
+    ("other:https://api.x.ai/v1", "other:https://API.X.AI:443/v1/", "native_uuid", True, True),
+    ("other:https://responses.example:invalid/v1", "other:https://responses.example:invalid/v1/", "native_uuid", True, True),
+])
+def test_replay_preserves_content_and_only_reuses_current_issuer_ids(current, stored, item_id, keep_id, keep_reasoning):
+    history = _history(item_id, stored)
+    before = deepcopy(history)
+    output = _chat_messages_to_responses_input(
+        history, current_issuer_kind=current, is_github_responses=current == "github_responses",
+    )
+    output = _preflight_codex_input_items(output, is_github_responses=current == "github_responses")
+    message = next(item for item in output if item.get("type") == "message")
+    assert ("id" in message) is keep_id
+    if keep_id:
+        assert message["id"] == item_id
+    assert message["content"] == before[1]["codex_message_items"][0]["content"]
+    assert message["phase"] == "final_answer"
+    assert message["status"] == "completed"
+    assert any(item.get("type") == "reasoning" for item in output) is keep_reasoning
+    assert all("_issuer_kind" not in item for item in output)
+    assert history == before
+
+    # Provider identity stays flag-based: normalizing a URL must not promote it to a named issuer.
+    if current and current.startswith("other:"):
+        configured = current[len("other:"):]
+        try:
+            httpx.URL(configured)
+        except httpx.InvalidURL:
+            assert _classify_responses_issuer(base_url=configured + "/") == current
+        else:
+            with OpenAI(api_key="test-only", base_url=configured) as client:
+                assert _classify_responses_issuer(base_url=configured) == _classify_responses_issuer(base_url=client.base_url)
+                assert _classify_responses_issuer(base_url=configured).startswith("other:")
+
+    response = SimpleNamespace(status="completed", output=[SimpleNamespace(
+        type="message", role="assistant", id=item_id, status="completed", phase="final_answer",
+        content=[SimpleNamespace(type="output_text", text="Previous answer")],
+    )])
+    normalized, _ = _normalize_codex_response(response, issuer_kind=stored)
+    assert normalized.codex_message_items[0].get("_issuer_kind") == stored
+
+
+@pytest.fixture
+def responses_endpoint():
+    received = []
+    output_item = {
+        "type": "message", "id": "msg_reply", "role": "assistant", "status": "completed",
+        "content": [{"type": "output_text", "text": "Reply", "annotations": []}],
+    }
+    response = {
+        "id": "resp_reply", "object": "response", "created_at": 0, "model": "gpt-test",
+        "status": "completed", "output": [output_item],
+    }
+
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, *_args):
+            pass
+
+        def do_POST(self):
+            payload = json.loads(self.rfile.read(int(self.headers["Content-Length"])))
+            received.append(payload)
+            if payload.get("stream"):
+                events = [
+                    {"type": "response.output_item.done", "output_index": 0, "item": output_item},
+                    {"type": "response.completed", "response": response},
+                ]
+                body = "".join(f"event: {event['type']}\ndata: {json.dumps(event)}\n\n" for event in events).encode()
+                content_type = "text/event-stream"
+            else:
+                body = json.dumps(response).encode()
+                content_type = "application/json"
+            self.send_response(200)
+            self.send_header("Content-Type", content_type)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=lambda: server.serve_forever(poll_interval=0.05), daemon=True)
+    thread.start()
+    try:
+        yield f"http://LOCALHOST:{server.server_port}/v1", received
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+@pytest.mark.parametrize("route,stored,item_id,keep_id,keep_reasoning", [
+    ("codex", None, "foreign_short_id", False, True),
+    ("codex", "codex_backend", "msg_native", True, True),
+    ("codex", "xai_responses", "msg_foreign", False, False),
+    ("xai", "xai_responses", "native_uuid", True, True),
+    ("xai", "codex_backend", "msg_foreign", False, False),
+    ("custom", "same-custom", "native_uuid", True, True),
+    ("custom", "codex_backend", "msg_foreign", False, False),
+])
+def test_auxiliary_and_main_transports_apply_same_replay_policy_on_wire(
+    route, stored, item_id, keep_id, keep_reasoning, responses_endpoint, monkeypatch,
+):
+    from agent import auxiliary_client as auxiliary
+    from agent.transports.codex import ResponsesApiTransport
+
+    configured, received = responses_endpoint
+    if stored == "same-custom":
+        stored = "other:" + configured + "/"
+    history = _history(item_id, stored)
+    before = deepcopy(history)
+    # Only the credential source is replaced; builders, client wrappers, SDK serialization,
+    # transport conversion and the HTTP/SSE exchange all run for real against a local server.
+    if route == "codex":
+        monkeypatch.setattr(auxiliary, "_select_pool_entry", lambda _provider: (False, None))
+        monkeypatch.setattr(auxiliary, "_read_codex_access_token", lambda: "test-only")
+        monkeypatch.setattr(auxiliary, "_CODEX_AUX_BASE_URL", configured)
+        client, _ = auxiliary._build_codex_client("gpt-test")
+    elif route == "xai":
+        monkeypatch.setattr(auxiliary, "_resolve_xai_oauth_for_aux", lambda: ("test-only", configured))
+        client, _ = auxiliary._build_xai_oauth_aux_client("gpt-test")
+    else:
+        client = auxiliary.CodexAuxiliaryClient(OpenAI(api_key="test-only", base_url=configured), "gpt-test")
+    try:
+        answer = client.chat.completions.create(messages=history, timeout=5)
+        assert answer.choices[0].message.content == "Reply"
+    finally:
+        client.close()
+
+    kwargs = ResponsesApiTransport().build_kwargs(
+        model="gpt-test", messages=history, tools=[], base_url=configured,
+        is_codex_backend=route == "codex", is_xai_responses=route == "xai",
+    )
+    with OpenAI(api_key="test-only", base_url=configured, timeout=5, max_retries=0) as main_client:
+        main_client.responses.create(**kwargs)
+    assert len(received) == 2
+    assert received[0]["input"] == received[1]["input"]
+    for payload in received:
+        message = next(item for item in payload["input"] if item.get("type") == "message")
+        assert ("id" in message) is keep_id
+        if keep_id:
+            assert message["id"] == item_id
+        assert message["content"] == before[1]["codex_message_items"][0]["content"]
+        assert message["phase"] == "final_answer"
+        assert message["status"] == "completed"
+        assert any(item.get("type") == "reasoning" for item in payload["input"]) is keep_reasoning
+        assert all("_issuer_kind" not in item for item in payload["input"])
+    assert history == before


### PR DESCRIPTION
## What does this PR do?

Prevents a session from becoming unusable when switching from another Responses-compatible provider to OpenAI Codex. A foreign assistant message ID can satisfy the existing length limit but still cause `HTTP 400: Expected an ID that begins with msg`.

Persisted assistant message items now carry issuer provenance. Replay withholds foreign IDs while preserving assistant text, phase and status. Unstamped legacy history remains compatible, except that Codex only receives IDs in its required `msg` namespace. Custom endpoint URLs are canonicalized consistently with the OpenAI SDK so the main and auxiliary paths agree.

## Related Issue

Fixes #92311.

Related to #92325. This PR additionally protects cross-issuer replay through persisted provenance, auxiliary/custom-proxy routes, and SDK URL normalization.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

Rebased the original commit onto `67764dc0863349a384c16425e73ee8571f3a94b7`, preserving its author and author date. Current head: `f538ae315c126e7dd07876970d7a77834bb5cd88`.

- `agent/codex_responses_adapter.py`: port the fix to the current replay helpers and `_OutputScan`; stamp persisted assistant items; apply issuer and Codex namespace checks; canonicalize legacy URL-backed message/reasoning stamps without mutating stored history or forwarding internal metadata.
- `agent/auxiliary_client.py`: carry explicit Codex/xAI issuer identity through the current auxiliary request builder, including custom proxies; apply the same shared replay policy as the main transport.
- `tests/agent/test_responses_issuer_replay.py`: consolidate regression coverage into two parameterized behavior tests, following the current contribution guidance. Covers legacy and stamped histories, cross-provider replay, ID length and namespace, content/phase/status preservation, URL equivalence and malformed-URL fallback, and real SDK HTTP/SSE exchanges through the main and auxiliary paths.

Provider classification remains flag-based. URL normalization deliberately does not promote a custom `other:` URL to a named provider category. The Codex check deliberately uses `startswith("msg")`, not `startswith("msg_")`.

## How to Test

```bash
scripts/run_tests.sh \
  tests/agent/test_responses_issuer_replay.py \
  -j 1 --file-retries 0

scripts/run_tests.sh \
  tests/agent/test_codex_responses_adapter.py \
  tests/agent/test_auxiliary_client.py \
  tests/agent/transports/test_codex_transport.py \
  tests/run_agent/test_codex_xai_oauth_recovery.py \
  tests/run_agent/test_provider_parity.py \
  tests/run_agent/test_run_agent_codex_responses.py \
  tests/run_agent/test_native_compaction*.py \
  -j 4 --file-retries 0

ruff check agent/codex_responses_adapter.py \
  agent/auxiliary_client.py \
  tests/agent/test_responses_issuer_replay.py
```

### Verification for the rebased revision

| Check | Result |
| --- | --- |
| New regression cases on unmodified upstream base | 21 failed, 4 passed, 0 collection/runtime errors |
| Same regression cases with the fix | 25 passed, 0 failed |
| Related adapter, auxiliary, transport, provider and native-compaction suites | 602 passed, 0 failed |
| Total targeted tests | **627 passed, 0 failed**, with file retries disabled |
| Ruff on changed files | Passed |
| Git whitespace/conflict checks | Passed |

[Baseline reproduction run](https://github.com/Amekn/hermes-agent/actions/runs/34493333442) · [Rebased validation run](https://github.com/Amekn/hermes-agent/actions/runs/34493831901)

The wire tests use the real OpenAI SDK and a local HTTP/SSE server, with only credential sources replaced. They do not use live provider accounts. The canonical test runner provides isolated Hermes state and strips inherited credentials.

**The full repository suite was not rerun for this revision.** The targeted results above supersede the earlier submission's focused-test count; they are not a claim that every repository test has passed.

## Checklist

### Code

- [x] Read the current Contributing Guide and applicable AGENTS.md instructions
- [x] Conventional commit message; original contribution authorship preserved
- [x] Related issue and overlapping PR identified above
- [x] Only changes related to this fix; one commit and three changed files
- [x] Regression behavior demonstrated failing on the upstream base and passing with the fix
- [x] Relevant existing suites pass using `scripts/run_tests.sh`
- [ ] Full repository test suite passes on this rebased revision: not run
- [x] Tested on a GitHub-hosted Ubuntu 24.04 runner

### Documentation & Housekeeping

- [x] Relevant docstrings updated; no user-facing configuration changes
- [x] No config example, architecture guide or tool schema updates required
- [x] Cross-platform impact considered; conversion is platform-neutral
- [x] Temporary validation workflows are not included in this PR

## Reproduction / Expected Result

Before: a foreign short assistant message ID is replayed to Codex and triggers a non-retryable HTTP 400.

After: the same history retains assistant output text, phase and status, but omits the invalid or foreign ID. Same-issuer valid IDs remain available for prefix-cache reuse, and foreign encrypted reasoning is not replayed.