### PR TITLE
feat(lsp): add fsautocomplete F# language server

### DIFF
--- a/agent/lsp/install.py
+++ b/agent/lsp/install.py
@@ -60,6 +60,10 @@ INSTALL_RECIPES: Dict[str, Dict[str, Any]] = {
     # PowerShellEditorServices is a release-zip bundle driven by pwsh; we probe
     # the host so `hermes lsp status` reports its presence.
     "powershell": _manual("pwsh"),
+    # F# — fsautocomplete is a .NET global tool. Auto-install via
+    # ``dotnet tool install --tool-path``. Also probed in ``~/.dotnet/tools``
+    # because ``dotnet tool install -g`` often leaves that dir off PATH.
+    "fsautocomplete": _recipe("dotnet", "fsautocomplete", "fsautocomplete"),
 }
 
 _install_locks: Dict[str, threading.Lock] = {}
@@ -79,6 +83,24 @@ def hermes_lsp_bin_dir() -> Path:
     p = get_hermes_home() / "lsp" / "bin"
     p.mkdir(parents=True, exist_ok=True)
     return p
+
+
+def _dotnet_tools_dir() -> Optional[Path]:
+    """Return the .NET global-tools directory if it exists.
+
+    ``dotnet tool install --global`` installs here, but the installer only
+    prints a PATH hint — it does not always mutate the user's shell rc.
+    Probing the directory directly lets Hermes find fsautocomplete (and
+    future ``dotnet tool`` language servers) even when ``~/.dotnet/tools``
+    is missing from PATH.
+
+    Honours ``DOTNET_CLI_HOME`` the same way the dotnet CLI does: when set,
+    tools live in ``$DOTNET_CLI_HOME/tools`` and the default
+    ``~/.dotnet/tools`` is ignored.
+    """
+    cli_home = os.environ.get("DOTNET_CLI_HOME")
+    candidate = Path(cli_home) / "tools" if cli_home else Path.home() / ".dotnet" / "tools"
+    return candidate if candidate.is_dir() else None
 
 
 def _native_binary_candidates(base: Path) -> list[Path]:
@@ -102,7 +124,17 @@ def _existing_binary(name: str) -> Optional[str]:
         if staged.exists() and os.access(staged, os.X_OK):
             return str(staged)
     suffixes = ("", *_WINDOWS_WRAPPER_SUFFIXES) if _is_windows() else ("",)
-    return next((p for s in suffixes if (p := shutil.which(f"{name}{s}"))), None)
+    on_path = next((p for s in suffixes if (p := shutil.which(f"{name}{s}"))), None)
+    if on_path:
+        return on_path
+    # ``dotnet tool install -g`` lands in ~/.dotnet/tools (or
+    # $DOTNET_CLI_HOME/tools) without always putting that directory on PATH.
+    tools_dir = _dotnet_tools_dir()
+    if tools_dir is not None:
+        found = _first_existing(tools_dir / name)
+        if found is not None and os.access(found, os.X_OK):
+            return str(found)
+    return None
 
 
 def try_install(pkg: str, strategy: str = "auto") -> Optional[str]:
@@ -231,11 +263,30 @@ def _install_pip(pkg: str, bin_name: str) -> Optional[str]:
     return _link_into_bin(found) if found is not None else None
 
 
+def _install_dotnet(pkg: str, bin_name: str) -> Optional[str]:
+    """``dotnet tool install --tool-path <staging>`` into ``lsp/bin/``."""
+    dotnet = shutil.which("dotnet")
+    if dotnet is None:
+        logger.info("[install] cannot install %s: dotnet not on PATH", pkg)
+        return None
+    staging = hermes_lsp_bin_dir()
+    logger.info("[install] dotnet tool install --tool-path %s %s", staging, pkg)
+    cmd = [dotnet, "tool", "install", "--tool-path", str(staging), pkg]
+    if not _run_installer("dotnet", pkg, cmd, timeout=600):
+        return None
+    found = _first_existing(staging / bin_name)
+    if found is not None and os.access(found, os.X_OK):
+        return str(found)
+    logger.warning("[install] dotnet tool install for %s succeeded but bin %s not found", pkg, bin_name)
+    return None
+
+
 # strategy → installer(recipe, bin_name).  ``manual`` is handled before dispatch.
 _INSTALLERS: Dict[str, Callable[[Dict[str, Any], str], Optional[str]]] = {
     "npm": lambda r, b: _install_npm(r["pkg"], b, extra_pkgs=r.get("extra_pkgs") or []),
     "go": lambda r, b: _install_go(r["pkg"], b),
     "pip": lambda r, b: _install_pip(r["pkg"], b),
+    "dotnet": lambda r, b: _install_dotnet(r["pkg"], b),
 }
 
 

--- a/agent/lsp/servers.py
+++ b/agent/lsp/servers.py
@@ -8,6 +8,7 @@ that language is actually edited.
 """
 from __future__ import annotations
 
+import hashlib
 import logging
 import os
 import shutil
@@ -247,6 +248,50 @@ def _spawn_powershell_es(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
     )
 
 
+def _spawn_fsautocomplete(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
+    """Spawn Ionide's fsautocomplete F# language server.
+
+    fsautocomplete is a ``dotnet tool``.  Resolution order: config override,
+    PATH, then :func:`agent.lsp.install.try_install` (Hermes staging dir,
+    PATH, ``~/.dotnet/tools`` / ``$DOTNET_CLI_HOME/tools``, then
+    ``dotnet tool install --tool-path``).  A user-installed global tool
+    already on PATH therefore wins over a staged copy; ``try_install`` only
+    reaches ``~/.dotnet/tools`` when PATH and staging are both empty
+    (``dotnet tool install -g`` often leaves that directory off PATH).
+
+    ``AutomaticWorkspaceInit`` is required: without it the server waits for
+    custom ``fsharp/workspacePeek`` + ``fsharp/workspaceLoad`` requests that
+    Hermes never sends, so diagnostics would stay empty.
+    ``--state-directory`` keeps FSAC's workspace cache out of the user's
+    repo and under ``<HERMES_HOME>/lsp/``.
+    """
+    bin_path = _find_binary(ctx, "fsautocomplete", ("fsautocomplete",), "fsautocomplete")
+    if bin_path is None:
+        return None
+    from hermes_constants import get_hermes_home
+
+    # normcase so Windows paths that differ only by case share one cache dir.
+    digest = hashlib.sha256(
+        os.path.normcase(os.path.abspath(root)).encode("utf-8")
+    ).hexdigest()[:16]
+    state_dir = os.path.join(str(get_hermes_home()), "lsp", "fsautocomplete", digest)
+    os.makedirs(state_dir, exist_ok=True)
+    init: Dict[str, Any] = {"AutomaticWorkspaceInit": True}
+    init.update(ctx.init_overrides.get("fsautocomplete", {}))
+    env = dict(ctx.env_overrides.get("fsautocomplete", {}))
+    if "DOTNET_ROOT" not in env:
+        dotnet = _which("dotnet")
+        if dotnet:
+            try:
+                env["DOTNET_ROOT"] = os.path.dirname(os.path.realpath(dotnet))
+            except OSError:
+                pass
+    return SpawnSpec(
+        [bin_path, "--state-directory", state_dir],
+        root, root, env=env, initialization_options=init,
+    )
+
+
 def hermes_lsp_session_dir() -> str:
     """Return (and create) the dir for PSES session/log scratch files."""
     from hermes_constants import get_hermes_home
@@ -275,6 +320,85 @@ def _server(server_id: str, extensions: Tuple[str, ...], description: str, *,
         build_spawn or _simple_spawn(server_id, which or (server_id,), args, install_pkg, base_init, seed),
         seed_first_push=seed, description=description, multi_root=multi_root,
     )
+
+
+# Strong F# / .NET SDK signals. ``Directory.Build.props`` and
+# ``Directory.Packages.props`` are MSBuild files that also appear in
+# C#-only trees, so they are a best-effort fallback only.
+_FSHARP_STRONG_MARKERS = (
+    "paket.dependencies",
+    "global.json",
+)
+_FSHARP_WEAK_MARKERS = (
+    "Directory.Build.props",
+    "Directory.Packages.props",
+)
+
+
+def _fsharp_dir_markers(directory: str) -> Tuple[bool, bool, bool]:
+    """Return ``(has_sln, has_strong, has_weak)`` for one directory."""
+    has_sln = False
+    has_strong = False
+    has_weak = False
+    try:
+        names = os.listdir(directory)
+    except OSError:
+        return False, False, False
+    for name in names:
+        lowered = name.lower()
+        if lowered.endswith(".sln") or lowered.endswith(".slnx"):
+            has_sln = True
+        elif lowered.endswith(".fsproj") or name in _FSHARP_STRONG_MARKERS:
+            has_strong = True
+        elif name in _FSHARP_WEAK_MARKERS:
+            has_weak = True
+        if has_sln and has_strong and has_weak:
+            break
+    return has_sln, has_strong, has_weak
+
+
+def _root_fsharp(file_path: str, workspace: Optional[str]) -> Optional[str]:
+    """Resolve the F# project root for fsautocomplete.
+
+    ``nearest_root`` only matches exact filenames, so ``*.sln`` /
+    ``*.fsproj`` can't go through it. Walk up from the file preferring
+    a solution, then a strong project marker (``.fsproj`` /
+    ``paket.dependencies`` / ``global.json``), then a best-effort
+    MSBuild ``Directory.*.props`` file, then the git workspace.
+    fsautocomplete's AutomaticWorkspaceInit peeks inside whatever root
+    we hand it, so a solution directory is the best starting point.
+
+    The up-walk is always bounded by ``workspace``. If ``workspace`` is
+    empty, return immediately rather than walking toward the filesystem
+    root — a stray ``.sln`` above the file would otherwise become the
+    project root.
+    """
+    if not workspace:
+        return None
+    start = os.path.abspath(file_path)
+    if not os.path.isdir(start):
+        start = os.path.dirname(start)
+    workspace_abs = os.path.abspath(workspace)
+    found_strong: Optional[str] = None
+    found_weak: Optional[str] = None
+    cur = start
+    for _ in range(64):
+        has_sln, has_strong, has_weak = _fsharp_dir_markers(cur)
+        if has_sln:
+            return cur
+        if has_strong and found_strong is None:
+            found_strong = cur
+        if has_weak and found_weak is None:
+            found_weak = cur
+        # Don't walk out of the git workspace — AutomaticWorkspaceInit
+        # peeks downward from whatever root we return.
+        if cur == workspace_abs:
+            break
+        parent = os.path.dirname(cur)
+        if parent == cur:
+            break
+        cur = parent
+    return found_strong or found_weak or workspace
 
 
 SERVERS: List[ServerDef] = [
@@ -334,6 +458,8 @@ SERVERS: List[ServerDef] = [
     # No universal PowerShell root marker; nearest_root is exact-name only (no globs).
     _server("powershell", (".ps1", ".psm1", ".psd1"), "PowerShell — PowerShellEditorServices (manual bundle)",
             markers=["PSScriptAnalyzerSettings.psd1"], build_spawn=_spawn_powershell_es),
+    _server("fsautocomplete", (".fs", ".fsi", ".fsx"), "F# — fsautocomplete (Ionide)",
+            resolve_root=_root_fsharp, build_spawn=_spawn_fsautocomplete),
 ]
 
 

--- a/tests/agent/lsp/test_fsautocomplete_server.py
+++ b/tests/agent/lsp/test_fsautocomplete_server.py
@@ -1,0 +1,254 @@
+"""Tests for the fsautocomplete (F# / Ionide) server registration.
+
+fsautocomplete is a ``dotnet tool``. These tests cover registry wiring,
+project-root resolution (``*.sln`` / ``*.fsproj`` are globs, so they
+can't go through ``nearest_root``), spawn flags, and discovery of the
+binary in the .NET global-tools directory when it is not on PATH.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import agent.lsp.install as install_mod
+import agent.lsp.servers as srv
+from agent.lsp.install import INSTALL_RECIPES, detect_status
+from agent.lsp.servers import (
+    ServerContext,
+    find_server_for_file,
+    language_id_for,
+)
+
+
+def test_fsharp_extensions_route_to_fsautocomplete():
+    for name in ("App.fs", "App.fsi", "Script.fsx"):
+        s = find_server_for_file(name)
+        assert s is not None, name
+        assert s.server_id == "fsautocomplete"
+
+
+def test_fsharp_language_id():
+    assert language_id_for("src/App.fs") == "fsharp"
+    assert language_id_for("src/App.fsi") == "fsharp"
+    assert language_id_for("scratch.fsx") == "fsharp"
+
+
+def test_recipe_is_dotnet_tool():
+    recipe = INSTALL_RECIPES["fsautocomplete"]
+    assert recipe["strategy"] == "dotnet"
+    assert recipe["bin"] == "fsautocomplete"
+    assert recipe["pkg"] == "fsautocomplete"
+
+
+def _make_dotnet_tool(home: Path, name: str = "fsautocomplete") -> Path:
+    tools = home / "tools"
+    tools.mkdir(parents=True)
+    binary = tools / name
+    binary.write_text("#!/bin/sh\n")
+    binary.chmod(0o755)
+    return binary
+
+
+def test_existing_binary_finds_dotnet_global_tool(tmp_path, monkeypatch):
+    """``dotnet tool install -g`` lands in $DOTNET_CLI_HOME/tools, often off PATH."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_home"))
+    monkeypatch.setenv("DOTNET_CLI_HOME", str(tmp_path / "dotnet_home"))
+    binary = _make_dotnet_tool(tmp_path / "dotnet_home")
+    monkeypatch.setattr(install_mod.shutil, "which", lambda name, **k: None)
+
+    assert install_mod._existing_binary("fsautocomplete") == str(binary)
+
+
+def test_existing_binary_dotnet_cli_home_hides_default_home(tmp_path, monkeypatch):
+    """When DOTNET_CLI_HOME is set, ~/.dotnet/tools is not consulted."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_home"))
+    monkeypatch.setenv("DOTNET_CLI_HOME", str(tmp_path / "cli_home"))
+    (tmp_path / "cli_home" / "tools").mkdir(parents=True)
+    monkeypatch.setattr(install_mod.shutil, "which", lambda name, **k: None)
+
+    assert install_mod._existing_binary("fsautocomplete") is None
+
+
+def test_detect_status_installed_from_dotnet_tools(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_home"))
+    monkeypatch.setenv("DOTNET_CLI_HOME", str(tmp_path / "dotnet_home"))
+    _make_dotnet_tool(tmp_path / "dotnet_home")
+    monkeypatch.setattr(install_mod.shutil, "which", lambda name, **k: None)
+
+    assert detect_status("fsautocomplete") == "installed"
+
+
+def test_spawn_builds_command_from_path(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_home"))
+    monkeypatch.setattr(srv, "_which", lambda *names: "/usr/bin/fsautocomplete" if "fsautocomplete" in names else None)
+
+    ctx = ServerContext(workspace_root=str(tmp_path), install_strategy="manual")
+    spec = srv._spawn_fsautocomplete(str(tmp_path), ctx)
+    assert spec is not None
+    assert spec.command[0] == "/usr/bin/fsautocomplete"
+    assert "--state-directory" in spec.command
+    state_dir = spec.command[spec.command.index("--state-directory") + 1]
+    assert str(tmp_path / "hermes_home") in state_dir
+    assert spec.initialization_options.get("AutomaticWorkspaceInit") is True
+    assert spec.cwd == str(tmp_path)
+    assert spec.workspace_root == str(tmp_path)
+
+
+def test_spawn_finds_dotnet_global_tool_when_not_on_path(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_home"))
+    monkeypatch.setenv("DOTNET_CLI_HOME", str(tmp_path / "dotnet_home"))
+    binary = _make_dotnet_tool(tmp_path / "dotnet_home")
+    monkeypatch.setattr(srv, "_which", lambda *names: None)
+    monkeypatch.setattr(install_mod.shutil, "which", lambda name, **k: None)
+    monkeypatch.setattr(install_mod, "_install_results", {})
+
+    ctx = ServerContext(workspace_root=str(tmp_path), install_strategy="manual")
+    spec = srv._spawn_fsautocomplete(str(tmp_path), ctx)
+    assert spec is not None
+    assert spec.command[0] == str(binary)
+
+
+def test_spawn_returns_none_when_missing(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_home"))
+    monkeypatch.setenv("DOTNET_CLI_HOME", str(tmp_path / "empty_dotnet"))
+    (tmp_path / "empty_dotnet" / "tools").mkdir(parents=True)
+    monkeypatch.setattr(srv, "_which", lambda *names: None)
+    monkeypatch.setattr(install_mod.shutil, "which", lambda name, **k: None)
+    monkeypatch.setattr(install_mod, "_install_results", {})
+
+    ctx = ServerContext(workspace_root=str(tmp_path), install_strategy="manual")
+    assert srv._spawn_fsautocomplete(str(tmp_path), ctx) is None
+
+
+def test_spawn_init_overrides_can_disable_automatic_workspace_init(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_home"))
+    monkeypatch.setattr(srv, "_which", lambda *names: "/usr/bin/fsautocomplete")
+
+    ctx = ServerContext(
+        workspace_root=str(tmp_path),
+        install_strategy="manual",
+        init_overrides={"fsautocomplete": {"AutomaticWorkspaceInit": False, "foo": 1}},
+    )
+    spec = srv._spawn_fsautocomplete(str(tmp_path), ctx)
+    assert spec is not None
+    assert spec.initialization_options["AutomaticWorkspaceInit"] is False
+    assert spec.initialization_options["foo"] == 1
+
+
+def test_spawn_sets_dotnet_root_from_dotnet_binary(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_home"))
+    sdk = tmp_path / "sdk"
+    sdk.mkdir()
+    dotnet = sdk / "dotnet"
+    dotnet.write_text("")
+    dotnet.chmod(0o755)
+
+    def which(*names):
+        if "fsautocomplete" in names:
+            return "/usr/bin/fsautocomplete"
+        if "dotnet" in names:
+            return str(dotnet)
+        return None
+
+    monkeypatch.setattr(srv, "_which", which)
+    ctx = ServerContext(workspace_root=str(tmp_path), install_strategy="manual")
+    spec = srv._spawn_fsautocomplete(str(tmp_path), ctx)
+    assert spec is not None
+    assert spec.env.get("DOTNET_ROOT") == str(sdk)
+
+
+def test_spawn_does_not_clobber_user_dotnet_root(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_home"))
+    monkeypatch.setattr(srv, "_which", lambda *names: "/usr/bin/fsautocomplete")
+    ctx = ServerContext(
+        workspace_root=str(tmp_path),
+        install_strategy="manual",
+        env_overrides={"fsautocomplete": {"DOTNET_ROOT": "/custom/dotnet"}},
+    )
+    spec = srv._spawn_fsautocomplete(str(tmp_path), ctx)
+    assert spec is not None
+    assert spec.env["DOTNET_ROOT"] == "/custom/dotnet"
+
+
+def test_root_prefers_nearest_sln(tmp_path: Path):
+    repo = tmp_path / "repo"
+    src = repo / "src" / "App"
+    src.mkdir(parents=True)
+    (src / "App.fsproj").write_text("")
+    (repo / "App.sln").write_text("")
+    found = srv._root_fsharp(str(src / "App.fs"), str(repo))
+    assert found == str(repo)
+
+
+def test_root_uses_fsproj_when_no_sln(tmp_path: Path):
+    repo = tmp_path / "repo"
+    src = repo / "src" / "App"
+    src.mkdir(parents=True)
+    (src / "App.fsproj").write_text("")
+    found = srv._root_fsharp(str(src / "App.fs"), str(repo))
+    assert found == str(src)
+
+
+def test_root_accepts_slnx(tmp_path: Path):
+    repo = tmp_path / "repo"
+    src = repo / "src"
+    src.mkdir(parents=True)
+    (repo / "App.slnx").write_text("")
+    found = srv._root_fsharp(str(src / "App.fs"), str(repo))
+    assert found == str(repo)
+
+
+def test_root_falls_back_to_workspace(tmp_path: Path):
+    repo = tmp_path / "repo"
+    src = repo / "src"
+    src.mkdir(parents=True)
+    found = srv._root_fsharp(str(src / "Scratch.fsx"), str(repo))
+    assert found == str(repo)
+
+
+def test_root_does_not_walk_above_workspace(tmp_path: Path):
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "Other.sln").write_text("")
+    repo = tmp_path / "repo"
+    src = repo / "src"
+    src.mkdir(parents=True)
+    found = srv._root_fsharp(str(src / "App.fs"), str(repo))
+    assert found == str(repo)
+
+
+def test_root_uses_global_json(tmp_path: Path):
+    repo = tmp_path / "repo"
+    nested = repo / "src"
+    nested.mkdir(parents=True)
+    (nested / "global.json").write_text("{}")
+    found = srv._root_fsharp(str(nested / "App.fs"), str(repo))
+    assert found == str(nested)
+
+
+def test_install_dotnet_command(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        staging = install_mod.hermes_lsp_bin_dir()
+        binary = staging / "fsautocomplete"
+        binary.write_text("#!/bin/sh\n")
+        binary.chmod(0o755)
+        from unittest.mock import MagicMock
+        return MagicMock(returncode=0, stderr="")
+
+    monkeypatch.setattr(install_mod.subprocess, "run", fake_run)
+    monkeypatch.setattr(install_mod.shutil, "which", lambda name, **k: "/usr/bin/dotnet" if name == "dotnet" else None)
+
+    resolved = install_mod._install_dotnet("fsautocomplete", "fsautocomplete")
+    assert resolved is not None
+    assert resolved.endswith("fsautocomplete")
+    assert captured["cmd"][:4] == ["/usr/bin/dotnet", "tool", "install", "--tool-path"]
+    assert captured["cmd"][-1] == "fsautocomplete"
+
+
+def test_install_dotnet_missing_sdk(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(install_mod.shutil, "which", lambda name, **k: None)
+    assert install_mod._install_dotnet("fsautocomplete", "fsautocomplete") is None

--- a/tests/agent/lsp/test_fsautocomplete_server.py
+++ b/tests/agent/lsp/test_fsautocomplete_server.py
@@ -156,6 +156,20 @@ def test_spawn_sets_dotnet_root_from_dotnet_binary(monkeypatch, tmp_path):
     assert spec.env.get("DOTNET_ROOT") == str(sdk)
 
 
+def test_spawn_state_dir_is_stable_under_normcase(monkeypatch, tmp_path):
+    """Windows case-folded paths must share one FSAC state directory."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_home"))
+    monkeypatch.setattr(srv, "_which", lambda *names: "/usr/bin/fsautocomplete")
+    monkeypatch.setattr(srv.os.path, "normcase", lambda p: p.lower())
+    ctx = ServerContext(workspace_root=str(tmp_path), install_strategy="manual")
+    spec_a = srv._spawn_fsautocomplete(str(tmp_path / "Repo"), ctx)
+    spec_b = srv._spawn_fsautocomplete(str(tmp_path / "repo"), ctx)
+    assert spec_a is not None and spec_b is not None
+    state_a = spec_a.command[spec_a.command.index("--state-directory") + 1]
+    state_b = spec_b.command[spec_b.command.index("--state-directory") + 1]
+    assert state_a == state_b
+
+
 def test_spawn_does_not_clobber_user_dotnet_root(monkeypatch, tmp_path):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_home"))
     monkeypatch.setattr(srv, "_which", lambda *names: "/usr/bin/fsautocomplete")
@@ -214,6 +228,35 @@ def test_root_does_not_walk_above_workspace(tmp_path: Path):
     src.mkdir(parents=True)
     found = srv._root_fsharp(str(src / "App.fs"), str(repo))
     assert found == str(repo)
+
+
+def test_root_empty_workspace_does_not_walk(tmp_path: Path):
+    """An empty workspace must not walk toward a stray .sln above the file."""
+    (tmp_path / "Other.sln").write_text("")
+    nested = tmp_path / "a" / "b" / "c"
+    nested.mkdir(parents=True)
+    (nested / "App.fs").write_text("")
+    assert srv._root_fsharp(str(nested / "App.fs"), "") is None
+    assert srv._root_fsharp(str(nested / "App.fs"), None) is None
+
+
+def test_root_prefers_strong_marker_over_inner_directory_build_props(tmp_path: Path):
+    repo = tmp_path / "repo"
+    nested = repo / "src"
+    nested.mkdir(parents=True)
+    (nested / "Directory.Build.props").write_text("")
+    (repo / "paket.dependencies").write_text("")
+    found = srv._root_fsharp(str(nested / "App.fs"), str(repo))
+    assert found == str(repo)
+
+
+def test_root_uses_directory_build_props_as_fallback(tmp_path: Path):
+    repo = tmp_path / "repo"
+    nested = repo / "src"
+    nested.mkdir(parents=True)
+    (nested / "Directory.Build.props").write_text("")
+    found = srv._root_fsharp(str(nested / "App.fs"), str(repo))
+    assert found == str(nested)
 
 
 def test_root_uses_global_json(tmp_path: Path):

--- a/website/docs/user-guide/features/lsp.md
+++ b/website/docs/user-guide/features/lsp.md
@@ -119,11 +119,11 @@ download link.
 ### F#
 
 FsAutoComplete is a .NET global tool. Hermes looks for the
-`fsautocomplete` binary on PATH, in `<HERMES_HOME>/lsp/bin/`, and in
-the .NET global tools directory (`~/.dotnet/tools`, or
-`$DOTNET_CLI_HOME/tools` when that env var is set) — the last of
-those matters because `dotnet tool install -g` often leaves the
-tools directory off PATH.
+`fsautocomplete` binary on PATH first (so a user-installed global
+tool wins), then in `<HERMES_HOME>/lsp/bin/`, then in the .NET
+global tools directory (`~/.dotnet/tools`, or `$DOTNET_CLI_HOME/tools`
+when that env var is set) — the last of those matters because
+`dotnet tool install -g` often leaves the tools directory off PATH.
 
 Install it yourself with:
 

--- a/website/docs/user-guide/features/lsp.md
+++ b/website/docs/user-guide/features/lsp.md
@@ -87,6 +87,7 @@ agent sees a syntax-clean file with semantic problems as
 | Kotlin | `kotlin-language-server` | manual |
 | Java | `jdtls` | manual |
 | PowerShell | `PowerShellEditorServices` (`pwsh` host) | manual (release zip) |
+| F# | `fsautocomplete` | `dotnet tool` |
 
 For "manual" entries, install the server through whatever toolchain
 manager makes sense for that language (rustup, ghcup, opam, brew,
@@ -114,6 +115,32 @@ host. Setup:
 `hermes lsp status` reports `installed` once `pwsh` is found; if the
 bundle is missing you'll see a one-time warning in the logs with the
 download link.
+
+### F#
+
+FsAutoComplete is a .NET global tool. Hermes looks for the
+`fsautocomplete` binary on PATH, in `<HERMES_HOME>/lsp/bin/`, and in
+the .NET global tools directory (`~/.dotnet/tools`, or
+`$DOTNET_CLI_HOME/tools` when that env var is set) — the last of
+those matters because `dotnet tool install -g` often leaves the
+tools directory off PATH.
+
+Install it yourself with:
+
+```
+dotnet tool install --global fsautocomplete
+```
+
+or let Hermes stage a copy:
+
+```
+hermes lsp install fsautocomplete
+```
+
+which runs `dotnet tool install --tool-path <HERMES_HOME>/lsp/bin fsautocomplete`
+(requires `dotnet` on PATH). Hermes starts the
+server with `AutomaticWorkspaceInit` so it loads `.sln` / `.fsproj`
+files without the custom Ionide workspace RPCs.
 
 A few servers are installed alongside a peer dependency that npm
 won't auto-pull. The current case is `typescript-language-server`,
@@ -202,7 +229,8 @@ When `install_strategy: auto`, Hermes installs binaries into
 `<HERMES_HOME>/lsp/bin/`. NPM packages land in
 `<HERMES_HOME>/lsp/node_modules/` with bin symlinks one level up.
 Go binaries come from `go install` with `GOBIN` pointed at the
-staging dir.
+staging dir. .NET global tools (fsautocomplete) come from
+`dotnet tool install --tool-path` pointed at the same staging dir.
 
 Nothing is ever installed to `/usr/local/`, `~/.local/`, or any other
 shared location — the staging dir is fully Hermes-owned and is


### PR DESCRIPTION
Registers Ionide's fsautocomplete for .fs/.fsi/.fsx, discovers the dotnet global tool in ~/.dotnet/tools when it isn't on PATH, and auto-installs via `dotnet tool install --tool-path`.

## What does this PR do?

Currently, Hermes does not include support for F#'s LSP provided by the Ionide project (https://ionide.io/). This PR addresses this shortcoming.

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made. 

Added `fsautocomplete` support for reducing the number of turns required for a model to fix or address issues before building the application.


## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate - https://github.com/NousResearch/hermes-agent/pull/41056 stalled/abandoned PR
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Fedora Linux 44

### Documentation & Housekeeping

- [x] I've updated relevant documentation: `lsp.md`
- [N/A] I've updated `cli-config.yaml.example` if I added/changed config keys 
- [N/A] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows 
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) 
- [N/A] I've updated tool descriptions/schemas if I changed tool behavior
