### PR TITLE
fix(desktop): use native PKCE for password gateways

### DIFF
--- a/apps/desktop/e2e/native-password-auth-reload.spec.ts
+++ b/apps/desktop/e2e/native-password-auth-reload.spec.ts
@@ -1,0 +1,347 @@
+/**
+ * E2E regression for password-backed remote gateways using native PKCE.
+ *
+ * The old desktop flow opened password providers in an embedded cookie jar.
+ * A renderer reload then exposed the real failure: authenticated REST/WS
+ * traffic had no reusable credential and failed with `401 no_cookie`.
+ *
+ * This test drives the public preload API through a real Electron process.
+ * Only the system-browser boundary is replaced: the fake browser follows the
+ * gateway redirect into the real loopback listener. The gateway then accepts
+ * only the native bearer for its protected WS-ticket route, so the old
+ * embedded-cookie implementation fails with the reported error while native
+ * PKCE survives both a renderer reload and a full app relaunch.
+ */
+
+import { createHash } from 'node:crypto'
+import * as http from 'node:http'
+import type { AddressInfo } from 'node:net'
+import type { Socket } from 'node:net'
+
+import { buildAppEnv, createSandbox, launchDesktop, type Sandbox } from './fixtures'
+import { allowErrorBanners, type ElectronApplication, expect, type Page, test } from './test'
+
+const ACCESS_TOKEN = 'e2e-native-password-access-token'
+const REFRESH_TOKEN = 'e2e-native-password-refresh-token'
+const APP_NAME = 'HermesE2ENativePasswordAuth'
+
+interface FakePasswordGateway {
+  url: string
+  bearerTicketMints: number
+  embeddedLogins: number
+  nativeProviders: string[]
+  noCookieRejects: number
+  close: () => Promise<void>
+}
+
+function sendJson(res: http.ServerResponse, status: number, body: unknown): void {
+  res.writeHead(status, { 'content-type': 'application/json' })
+  res.end(JSON.stringify(body))
+}
+
+async function readJson(req: http.IncomingMessage): Promise<Record<string, unknown>> {
+  const chunks: Buffer[] = []
+
+  for await (const chunk of req) {
+    chunks.push(Buffer.from(chunk))
+  }
+
+  return JSON.parse(Buffer.concat(chunks).toString('utf8'))
+}
+
+async function startFakePasswordGateway(): Promise<FakePasswordGateway> {
+  const sockets = new Set<Socket>()
+  const state = {
+    bearerTicketMints: 0,
+    embeddedLogins: 0,
+    nativeProviders: [] as string[],
+    noCookieRejects: 0
+  }
+
+  const server = http.createServer(async (req, res) => {
+    try {
+      const url = new URL(req.url ?? '/', 'http://127.0.0.1')
+
+      if (url.pathname === '/api/status') {
+        sendJson(res, 200, {
+          auth_flows: ['cookie', 'native_pkce'],
+          auth_required: true,
+          version: '0.0.0-e2e-password-gateway'
+        })
+
+        return
+      }
+
+      if (url.pathname === '/api/auth/providers') {
+        sendJson(res, 200, {
+          providers: [
+            {
+              display_name: 'Username & Password',
+              name: 'basic',
+              supports_password: true
+            }
+          ]
+        })
+
+        return
+      }
+
+      if (url.pathname === '/login') {
+        state.embeddedLogins += 1
+        // This makes the legacy embedded window look locally signed in. The
+        // protected gateway route below still rejects cookie-only traffic,
+        // reproducing the reported post-refresh `no_cookie` failure.
+        res.writeHead(200, {
+          'content-type': 'text/html; charset=utf-8',
+          'set-cookie': 'hermes_session_at=embedded-only; Path=/; HttpOnly; SameSite=Lax'
+        })
+        res.end('<!doctype html><title>Signed in</title>Signed in')
+
+        return
+      }
+
+      if (url.pathname === '/auth/native/authorize') {
+        const provider = url.searchParams.get('provider') ?? ''
+        const redirectUri = url.searchParams.get('redirect_uri')
+        const oauthState = url.searchParams.get('state')
+
+        state.nativeProviders.push(provider)
+
+        if (provider !== 'basic' || !redirectUri || !oauthState) {
+          sendJson(res, 400, { detail: 'invalid native authorization request' })
+
+          return
+        }
+
+        const callback = new URL(redirectUri)
+        callback.searchParams.set('code', 'e2e-native-code')
+        callback.searchParams.set('state', oauthState)
+        res.writeHead(302, { location: callback.toString() })
+        res.end()
+
+        return
+      }
+
+      if (url.pathname === '/auth/native/token' && req.method === 'POST') {
+        const body = await readJson(req)
+
+        if (body.code !== 'e2e-native-code' || typeof body.code_verifier !== 'string') {
+          sendJson(res, 400, { detail: 'invalid native token exchange' })
+
+          return
+        }
+
+        sendJson(res, 200, {
+          access_token: ACCESS_TOKEN,
+          expires_at: Math.floor(Date.now() / 1000) + 3_600,
+          provider: 'basic',
+          refresh_token: REFRESH_TOKEN,
+          token_type: 'Bearer',
+          user_id: 'e2e-user'
+        })
+
+        return
+      }
+
+      if (url.pathname === '/api/auth/ws-ticket' && req.method === 'POST') {
+        if (req.headers.authorization !== `Bearer ${ACCESS_TOKEN}`) {
+          state.noCookieRejects += 1
+          sendJson(res, 401, {
+            detail: 'Unauthorized',
+            error: 'unauthenticated',
+            login_url: '/login',
+            reason: 'no_cookie'
+          })
+
+          return
+        }
+
+        state.bearerTicketMints += 1
+        sendJson(res, 200, { ticket: 'e2e-ws-ticket' })
+
+        return
+      }
+
+      sendJson(res, 404, { detail: 'not found' })
+    } catch (error) {
+      sendJson(res, 500, { detail: error instanceof Error ? error.message : String(error) })
+    }
+  })
+
+  server.on('connection', socket => {
+    sockets.add(socket)
+    socket.on('close', () => sockets.delete(socket))
+  })
+
+  server.on('upgrade', (req, socket) => {
+    const url = new URL(req.url ?? '/', 'http://127.0.0.1')
+    const key = req.headers['sec-websocket-key']
+
+    if (url.pathname !== '/api/ws' || url.searchParams.get('ticket') !== 'e2e-ws-ticket' || !key) {
+      socket.destroy()
+
+      return
+    }
+
+    const accept = createHash('sha1').update(`${key}258EAFA5-E914-47DA-95CA-C5AB0DC85B11`).digest('base64')
+
+    socket.write(
+      'HTTP/1.1 101 Switching Protocols\r\n' +
+        'Upgrade: websocket\r\n' +
+        'Connection: Upgrade\r\n' +
+        `Sec-WebSocket-Accept: ${accept}\r\n\r\n`
+    )
+    // One unmasked server text frame is enough for the real WS probe to prove
+    // the authenticated transport leg is usable.
+    socket.write(Buffer.from([0x81, 0x02, 0x6f, 0x6b]))
+  })
+
+  await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve))
+
+  const { port } = server.address() as AddressInfo
+
+  return {
+    close: () =>
+      new Promise<void>(resolve => {
+        for (const socket of sockets) {
+          socket.destroy()
+        }
+
+        server.closeAllConnections?.()
+        server.close(() => resolve())
+      }),
+    get bearerTicketMints() {
+      return state.bearerTicketMints
+    },
+    get embeddedLogins() {
+      return state.embeddedLogins
+    },
+    get nativeProviders() {
+      return state.nativeProviders
+    },
+    get noCookieRejects() {
+      return state.noCookieRejects
+    },
+    url: `http://127.0.0.1:${port}`
+  }
+}
+
+async function launchAgainst(sandbox: Sandbox): Promise<{ app: ElectronApplication; page: Page }> {
+  const launched = await launchDesktop(
+    buildAppEnv(sandbox, {
+      HERMES_DESKTOP_APP_NAME: APP_NAME,
+      HERMES_DESKTOP_BOOT_FAKE_ERROR: 'E2E native password auth: local backend intentionally not started'
+    })
+  )
+
+  await launched.page.waitForFunction(
+    () =>
+      Boolean(
+        (window as unknown as { hermesDesktop?: Record<string, unknown> }).hermesDesktop?.oauthLoginConnectionConfig
+      ),
+    undefined,
+    { timeout: 60_000 }
+  )
+
+  return launched
+}
+
+async function driveSystemBrowser(app: ElectronApplication): Promise<void> {
+  await app.evaluate(({ shell }) => {
+    shell.openExternal = async (url: string) => {
+      const authorize = await fetch(url, { redirect: 'manual' })
+      const location = authorize.headers.get('location')
+
+      if (!location) {
+        throw new Error(`Native authorize did not redirect (status ${authorize.status}).`)
+      }
+
+      const callback = await fetch(new URL(location, url))
+
+      if (!callback.ok) {
+        throw new Error(`Native loopback callback failed (status ${callback.status}).`)
+      }
+    }
+  })
+}
+
+async function waitForDesktopBridge(page: Page): Promise<void> {
+  await page.waitForFunction(
+    () =>
+      Boolean((window as unknown as { hermesDesktop?: Record<string, unknown> }).hermesDesktop?.testConnectionConfig),
+    undefined,
+    { timeout: 60_000 }
+  )
+}
+
+async function testRemoteGateway(page: Page, remoteUrl: string): Promise<{ error: string | null; ok: boolean }> {
+  return page.evaluate(async url => {
+    const desktop = (window as unknown as { hermesDesktop: any }).hermesDesktop
+
+    try {
+      const result = await desktop.testConnectionConfig({
+        mode: 'remote',
+        remoteAuthMode: 'oauth',
+        remoteUrl: url
+      })
+
+      return { error: null, ok: result.ok === true }
+    } catch (error) {
+      return { error: error instanceof Error ? error.message : String(error), ok: false }
+    }
+  }, remoteUrl)
+}
+
+test('password-gateway login survives Cmd+R and a full app restart', async () => {
+  test.setTimeout(180_000)
+  allowErrorBanners()
+
+  const gateway = await startFakePasswordGateway()
+  const sandbox = createSandbox('native-password-auth')
+  let app: ElectronApplication | null = null
+
+  try {
+    const first = await launchAgainst(sandbox)
+    app = first.app
+    await driveSystemBrowser(app)
+
+    const login = await first.page.evaluate(async url => {
+      const desktop = (window as unknown as { hermesDesktop: any }).hermesDesktop
+
+      return desktop.oauthLoginConnectionConfig(url)
+    }, gateway.url)
+
+    expect(login.connected, 'the app must hold a reusable credential after login').toBe(true)
+
+    // Cmd+R: a cold renderer has no component/store state from the login.
+    await first.page.reload()
+    await waitForDesktopBridge(first.page)
+
+    const afterReload = await testRemoteGateway(first.page, gateway.url)
+
+    expect(
+      { error: afterReload.error, noCookieRejects: gateway.noCookieRejects, ok: afterReload.ok },
+      'Cmd+R must not fall back to the cookie-only `401 no_cookie` path'
+    ).toEqual({ error: null, noCookieRejects: 0, ok: true })
+
+    // Full relaunch: only userData survives, proving the token came off disk.
+    await app.close()
+    app = null
+
+    const second = await launchAgainst(sandbox)
+    app = second.app
+
+    const afterRestart = await testRemoteGateway(second.page, gateway.url)
+
+    expect(afterRestart.error, 'the persisted native token must authenticate after relaunch').toBeNull()
+    expect(afterRestart.ok).toBe(true)
+    expect(gateway.nativeProviders).toEqual(['basic'])
+    expect(gateway.embeddedLogins).toBe(0)
+    expect(gateway.noCookieRejects).toBe(0)
+    expect(gateway.bearerTicketMints).toBe(2)
+  } finally {
+    await app?.close().catch(() => undefined)
+    await gateway.close()
+    sandbox.cleanup()
+  }
+})

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -259,6 +259,7 @@ import {
   type NativeTokenSet,
   parseTokenResponse,
   resolveLoginStrategy,
+  resolveNativeLoginProvider,
   tokenNeedsRefresh
 } from './native-oauth'
 import { runNativeLogin } from './native-oauth-login'
@@ -6100,11 +6101,10 @@ function watchDirectory(rawDir) {
   return { id, path: watchDir }
 }
 
-// Best-effort read of a gateway's advertised auth providers, cached per base
-// URL for the life of the process. Used by the oauth pre-flight guard to tell
-// a password-provider gateway (which cannot satisfy the bearer/cookie checks
-// by design) from a real OAuth one. Any failure returns [] so callers keep the
-// strict guard — backends predating /api/auth/providers are unaffected.
+// Best-effort read of a gateway's interactive auth providers, cached per base
+// URL for the life of the process. Startup uses it to calibrate the pre-flight
+// guard; login uses it to avoid a native request when provider selection is
+// ambiguous. Any failure returns [] so older gateways keep their fallback.
 const gatewayAuthProvidersCache = new Map<string, any[]>()
 
 async function gatewayAuthProviders(baseUrl, headers = {}) {
@@ -15302,16 +15302,12 @@ async function fetchJsonForBackend(
 ipcMain.handle('hermes:connection-config:probe', async (_event, rawUrl) => probeRemoteAuthMode(rawUrl))
 ipcMain.handle('hermes:connection-config:oauth-login', async (_event, rawUrl) => {
   // Capability-gated login (RFC 8252). Probe the gateway's public /api/status
-  // for supported auth_flows and /api/auth/providers for provider capabilities:
-  //   - all providers support password → always use the embedded login window
-  //     (password providers require the dashboard login form; native PKCE
-  //     can never complete for that provider shape)
-  //   - advertises "native_pkce" AND at least one non-password provider →
-  //     run the system-browser + loopback + PKCE flow
-  //   - older gateway with no provider metadata → fall back to the auth_flows
-  //     check (existing compatibility)
-  //   - a failed native login reports the error rather than auto-falling back
-  //     to the embedded flow — one sign-in action opens at most one window.
+  // and /api/auth/providers:
+  //   - "native_pkce" + one unambiguous provider → system browser + PKCE
+  //   - multiple eligible providers → embedded login with its provider chooser
+  //   - older gateway without native_pkce → embedded login
+  //   - a failed native login reports the error rather than silently switching
+  //     to a cookie-only session
   const baseUrl = normalizeRemoteBaseUrl(rawUrl)
 
   let statusBody: any = null
@@ -15330,11 +15326,15 @@ ipcMain.handle('hermes:connection-config:oauth-login', async (_event, rawUrl) =>
 
   if (strategy === 'native') {
     try {
-      const tokens = await runNativeLogin(baseUrl, {
-        openExternal: url => shell.openExternal(url),
-        postJson: (url, body, opts) => postJsonNoAuth(url, body, opts),
-        rememberLog
-      })
+      const tokens = await runNativeLogin(
+        baseUrl,
+        {
+          openExternal: url => shell.openExternal(url),
+          postJson: (url, body, opts) => postJsonNoAuth(url, body, opts),
+          rememberLog
+        },
+        { provider: resolveNativeLoginProvider(providers) }
+      )
 
       _storeNativeTokens(baseUrl, tokens)
       // Confirmed sign-in — release the reauth latch so the next

--- a/apps/desktop/electron/native-oauth.test.ts
+++ b/apps/desktop/electron/native-oauth.test.ts
@@ -23,6 +23,7 @@ import {
   parseStoredTokenSet,
   parseTokenResponse,
   resolveLoginStrategy,
+  resolveNativeLoginProvider,
   statusSupportsNativeFlow,
   tokenNeedsRefresh
 } from './native-oauth'
@@ -87,39 +88,39 @@ test('resolveLoginStrategy picks native only when advertised and not forced', ()
 
 // --- provider-aware strategy ---
 
-test('resolveLoginStrategy returns embedded when every provider supports password', () => {
+test('resolveLoginStrategy uses native login for one password provider', () => {
   const statusBody = { auth_required: true, auth_flows: ['cookie', 'native_pkce'] }
   const providers = [{ name: 'basic', supportsPassword: true }]
 
-  assert.equal(resolveLoginStrategy(statusBody, { providers }), 'embedded')
+  assert.equal(resolveLoginStrategy(statusBody, { providers }), 'native')
 })
 
-test('resolveLoginStrategy returns embedded for all-password even without native_pkce in auth_flows', () => {
+test('resolveLoginStrategy keeps embedded login without native_pkce', () => {
   const statusBody = { auth_required: true, auth_flows: ['cookie'] }
   const providers = [{ name: 'basic', supportsPassword: true }]
 
   assert.equal(resolveLoginStrategy(statusBody, { providers }), 'embedded')
 })
 
-test('resolveLoginStrategy returns native for native_pkce gateway with non-password provider', () => {
+test('resolveLoginStrategy uses native login for one OAuth provider', () => {
   const statusBody = { auth_required: true, auth_flows: ['cookie', 'native_pkce'] }
-  const providers = [{ name: 'nous', displayName: 'Nous Research', supportsPassword: false }]
+  const providers = [{ name: 'github', displayName: 'GitHub', supportsPassword: false }]
 
   assert.equal(resolveLoginStrategy(statusBody, { providers }), 'native')
 })
 
-test('resolveLoginStrategy returns native for a mixed provider deployment', () => {
+test('resolveLoginStrategy uses native login for one OAuth provider with a password fallback', () => {
   const statusBody = { auth_required: true, auth_flows: ['cookie', 'native_pkce'] }
 
   const providers = [
     { name: 'basic', supportsPassword: true },
-    { name: 'nous', supportsPassword: false }
+    { name: 'github', supportsPassword: false }
   ]
 
   assert.equal(resolveLoginStrategy(statusBody, { providers }), 'native')
 })
 
-test('resolveLoginStrategy preserves existing behavior when providers are empty or missing', () => {
+test('resolveLoginStrategy preserves auth_flows behavior when providers are empty or missing', () => {
   const gated = { auth_required: true, auth_flows: ['cookie', 'native_pkce'] }
   const legacy = { auth_required: true, auth_flows: ['cookie'] }
 
@@ -133,8 +134,58 @@ test('resolveLoginStrategy ignores providers with no name', () => {
   const statusBody = { auth_required: true, auth_flows: ['cookie', 'native_pkce'] }
   const providers = [{ supportsPassword: true }]
 
-  // The unnamed provider is filtered out — still falls through to auth_flows.
   assert.equal(resolveLoginStrategy(statusBody, { providers }), 'native')
+})
+
+test('resolveLoginStrategy uses embedded login when multiple password providers need a chooser', () => {
+  const statusBody = { auth_required: true, auth_flows: ['cookie', 'native_pkce'] }
+
+  const options = {
+    providers: [
+      { name: 'basic-work', supportsPassword: true },
+      { name: 'basic-personal', supportsPassword: true }
+    ]
+  }
+
+  assert.equal(resolveLoginStrategy(statusBody, options), 'embedded')
+})
+
+test('resolveLoginStrategy uses embedded login when multiple OAuth providers need a chooser', () => {
+  const statusBody = { auth_required: true, auth_flows: ['cookie', 'native_pkce'] }
+
+  const options = {
+    providers: [
+      { name: 'github', supportsPassword: false },
+      { name: 'google', supportsPassword: false }
+    ]
+  }
+
+  assert.equal(resolveLoginStrategy(statusBody, options), 'embedded')
+})
+
+test('resolveNativeLoginProvider mirrors the server auto-selection rules', () => {
+  const cases = [
+    { providers: [{ name: 'basic', supportsPassword: true }], expected: 'basic' },
+    {
+      providers: [
+        { name: 'basic', supportsPassword: true },
+        { name: 'github', supportsPassword: false }
+      ],
+      expected: 'github'
+    },
+    {
+      providers: [
+        { name: 'github', supportsPassword: false },
+        { name: 'google', supportsPassword: false }
+      ],
+      expected: undefined
+    },
+    { providers: [], expected: undefined }
+  ]
+
+  for (const { providers, expected } of cases) {
+    assert.equal(resolveNativeLoginProvider(providers), expected)
+  }
 })
 
 // --- URL building ---

--- a/apps/desktop/electron/native-oauth.ts
+++ b/apps/desktop/electron/native-oauth.ts
@@ -20,15 +20,15 @@
  * it stores itself.
  *
  * Capability detection: the gateway advertises supported flows on the public
- * /api/status `auth_flows` array. `native_pkce` present ⇒ use this flow;
- * absent (older gateway) ⇒ the caller falls back to the embedded-webview
- * cookie flow. This is the "observable ladder / compatibility fallback tied to
- * an identified older runtime" the desktop guide requires.
+ * /api/status `auth_flows` array. `native_pkce` present ⇒ this flow is
+ * available; absent (older gateway) ⇒ the caller falls back to the
+ * embedded-webview cookie flow. This is the "observable ladder / compatibility
+ * fallback tied to an identified older runtime" the desktop guide requires.
  */
 
 import { createHash, randomBytes } from 'node:crypto'
 
-import { type AdvertisedAuthProvider, oauthGuardMayHardFail } from './native-auth-decisions'
+import { type AdvertisedAuthProvider, normalizeAdvertisedAuthProviders } from './native-auth-decisions'
 
 // The gateway status field that lists supported auth flows. See
 // hermes_cli/web_server.py status handler.
@@ -79,17 +79,31 @@ export function statusSupportsNativeFlow(statusBody: any): boolean {
   return Array.isArray(flows) && flows.includes(NATIVE_FLOW_ID)
 }
 
+function selectNativeLoginProvider(providers: AdvertisedAuthProvider[]): string | undefined {
+  const oauthProviders = providers.filter(provider => !provider.supportsPassword)
+
+  if (oauthProviders.length === 1) {
+    return oauthProviders[0].name
+  }
+
+  if (oauthProviders.length === 0 && providers.length === 1) {
+    return providers[0].name
+  }
+
+  return undefined
+}
+
+/** Pick the provider the server would auto-select; undefined leaves selection to the caller or server. */
+export function resolveNativeLoginProvider(providers: unknown): string | undefined {
+  return selectNativeLoginProvider(normalizeAdvertisedAuthProviders(providers))
+}
+
 /**
- * Decide the login strategy for a gated gateway from its status body and
- * advertised provider capabilities.
- *
- * Returns 'native' when the gateway advertises native_pkce AND at least one
- * non-password provider is available; 'embedded' when all providers are
- * password-only, the gateway lacks native_pkce, or forceEmbedded is set.
- *
- * Provider metadata is discovered from /api/auth/providers (separate from
- * /api/status). When absent (older gateway), the decision falls through to
- * the auth_flows check — existing compatibility is preserved.
+ * Decide the login strategy from the gateway's advertised auth flows.
+ * Password providers also support native PKCE: the gateway sends the system
+ * browser through its login form before returning to the desktop callback.
+ * An ambiguous provider list uses the embedded chooser; missing metadata
+ * trusts `auth_flows` so older gateways keep their existing behavior.
  *
  * `forceEmbedded` lets a user/setting or an env override pin the legacy flow
  * (e.g. a corporate proxy that blocks loopback). Precedence written down here,
@@ -97,17 +111,23 @@ export function statusSupportsNativeFlow(statusBody: any): boolean {
  */
 export function resolveLoginStrategy(
   statusBody: any,
-  opts: { forceEmbedded?: boolean; providers?: AdvertisedAuthProvider[] } = {}
+  opts: { forceEmbedded?: boolean; providers?: unknown } = {}
 ): 'native' | 'embedded' {
   if (opts.forceEmbedded) {
     return 'embedded'
   }
 
-  if (!oauthGuardMayHardFail(opts.providers)) {
+  if (!statusSupportsNativeFlow(statusBody)) {
     return 'embedded'
   }
 
-  return statusSupportsNativeFlow(statusBody) ? 'native' : 'embedded'
+  const providers = normalizeAdvertisedAuthProviders(opts.providers)
+
+  if (providers.length === 0) {
+    return 'native'
+  }
+
+  return selectNativeLoginProvider(providers) ? 'native' : 'embedded'
 }
 
 /**

--- a/website/docs/guides/desktop-native-signin.md
+++ b/website/docs/guides/desktop-native-signin.md
@@ -77,13 +77,16 @@ an `auth_flows` array:
 
 | `auth_flows` value | Meaning |
 |--------------------|---------|
-| `["cookie", "native_pkce"]` | Gateway supports native sign-in → the app uses it |
+| `["cookie", "native_pkce"]` | Gateway supports native sign-in → the app uses it when provider selection is unambiguous |
 | `["cookie"]` | Gateway supports only the legacy flow → the app uses the embedded webview |
 | *(field absent)* | Older gateway → the app uses the embedded webview |
 
 If native sign-in is advertised but fails for a local reason — e.g. a security
 tool blocks the loopback listener, or you close the browser tab — the app
-**falls back to the embedded flow automatically** so you can still sign in.
+reports the failure so you can retry; it does not silently switch to a
+cookie-only session.
+When several providers require the user to choose one, the app opens that
+embedded provider chooser directly.
 
 ## Token lifecycle
 


### PR DESCRIPTION
## What does this PR do?

Remote password-gateway sign-in now uses the gateway's advertised native PKCE flow when the Desktop can select one provider unambiguously. The resulting bearer tokens use the existing encrypted native token store, so authentication survives both Cmd+R and a full app relaunch.

Since #75808, password gateways can broker their login form through native PKCE and advertise `native_pkce`. Desktop still classified password providers as embedded-cookie-only, so sign-in could look successful while a cold renderer's REST/WebSocket-ticket traffic failed with `401 no_cookie`.

This keeps the existing compatibility ladder: older gateways and ambiguous multi-provider gateways use the embedded chooser, while native-login failures remain visible and do not silently downgrade to cookie auth.

## Related Issue

N/A — reproduced from a user report. This is a focused follow-up to #75808. It is adjacent to #95609 / #95677, which cover native-to-embedded downgrade visibility; this PR preserves current `main` behavior there and changes only password-provider selection.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/electron/native-oauth.ts`: select native PKCE for one password provider while retaining the embedded chooser for ambiguous provider sets.
- `apps/desktop/electron/main.ts`: pass the selected provider into the existing native-login path without changing native-failure behavior.
- `apps/desktop/electron/native-oauth.test.ts`: cover password, OAuth, mixed, missing, malformed, legacy, and multi-provider decisions.
- `apps/desktop/e2e/native-password-auth-reload.spec.ts`: exercise real Electron login, Cmd+R, authenticated REST/WebSocket-ticket traffic, and full relaunch.
- `website/docs/guides/desktop-native-signin.md`: document provider selection and the no-silent-downgrade contract.

## Security

This reuses the existing loopback-only, PKCE-S256 native flow and existing OS-backed token storage. It adds no credential store or authentication mechanism. Ambiguous provider sets stay on the embedded chooser, and native failures are still reported instead of silently substituting cookie auth.

## How to Test

1. Build current `main` (`306db2776`) with the new E2E test and run `npx playwright test e2e/native-password-auth-reload.spec.ts --reporter=list`; it fails immediately after `page.reload()` with `noCookieRejects: 1`.
2. Build this exact head (`19e7c815e`) and run the same command; Cmd+R and full relaunch both pass.
3. Run `npx vitest run --project electron electron/native-oauth.test.ts electron/native-oauth-login.test.ts electron/native-token-store.test.ts` (57 passed).
4. Run `npm run typecheck`, targeted ESLint/Prettier, and `npm run build` from `apps/desktop`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A: Desktop TypeScript/Electron-only change; no Python files changed
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.6 arm64, Node.js 24.15.0

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — updated Desktop native sign-in guide
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — no new platform APIs; provider selection is platform-neutral
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

No visual change.

| Revision | Electron E2E result |
|---|---|
| `main` `306db2776` | Fails after Cmd+R: WebSocket-ticket mint returns `401 no_cookie` (`noCookieRejects: 1`) |
| PR head `19e7c815e` | Passes Cmd+R and full relaunch (`1 passed`, no cookie rejects) |

Additional exact-head checks: 57 focused auth tests passed, full Desktop typecheck passed, targeted ESLint/Prettier passed, and the production build completed successfully.
