### PR TITLE
fix(prompt-size): report GUI and subagent surfaces accurately

### DIFF
--- a/hermes_cli/prompt_size.py
+++ b/hermes_cli/prompt_size.py
@@ -32,6 +32,11 @@ _NAMES_ONLY_LINE_RE = re.compile(r"^  .+ \[names only\]: (?P<names>.+)$")
 # Cap the human-readable "Skills by size" table; ``--json`` always has them all.
 _SKILLS_TABLE_LIMIT = 20
 
+# Bucket label for the tool_search bridge tools. They are synthesised at
+# assembly time (``tools.tool_search.assemble_tool_defs``) rather than
+# registered in a toolset, so they have no registry attribution of their own.
+_DEFERRED_BRIDGE_LABEL = "(deferred tool-search bridge)"
+
 
 def _bytes(s: str) -> int:
     return len(s.encode("utf-8"))
@@ -47,6 +52,88 @@ def _tool_name(tool: Any) -> str:
     return str(tool.get("name", ""))
 
 
+def _resolve_gui_surface_toolsets(platform: str) -> set:
+    """GUI/client-surface toolsets the tui_gateway folds in at agent creation.
+
+    ``desktop``/``tui`` sessions are not built from a ``hermes-<platform>``
+    composite — they run through ``tui_gateway.server._load_enabled_toolsets``,
+    which resolves the CLI toolsets and then adds the client-surface toolsets
+    that are deliberately off ``_HERMES_CORE_TOOLS``. Delegating to the real
+    resolver keeps this diagnostic in lockstep with runtime instead of
+    re-deriving the set here.
+    """
+    try:
+        from tui_gateway.server import _gui_surface_toolsets
+
+        return set(_gui_surface_toolsets(platform))
+    except Exception:
+        # Conservative mirror of the resolver's contract if the gateway module
+        # is unavailable (e.g. a trimmed install).
+        surfaces = {"project"}
+        if platform == "desktop":
+            surfaces.add("desktop_ui")
+        return surfaces
+
+
+def _resolve_subagent_toolsets(cfg: dict) -> Tuple[List[str], List[str]]:
+    """Enabled + extra-disabled toolsets for a default delegated subagent.
+
+    ``tools/delegate_tool.py`` never resolves a ``hermes-subagent`` composite.
+    A child *inherits the parent's* enabled toolsets (``child_toolsets =
+    _strip_blocked_tools(parent_enabled)``) and is additionally handed
+    ``_blocked_toolsets_for_role(role) + ["kanban"]`` as ``disabled_toolsets``
+    so the blocked tools are subtracted after composite expansion. Model a
+    leaf child of a CLI-configured parent — the common case — so
+    ``--platform subagent`` reports a prompt a real subagent would receive.
+
+    Returns ``(enabled, disabled_extra)``.
+    """
+    from hermes_cli.tools_config import _get_platform_tools
+
+    parent = sorted(_get_platform_tools(cfg, "cli", include_default_mcp_servers=True))
+    try:
+        from tools.delegate_tool import (
+            _blocked_toolsets_for_role,
+            _strip_blocked_tools,
+        )
+
+        enabled = _strip_blocked_tools(parent)
+        disabled_extra = list(
+            dict.fromkeys(_blocked_toolsets_for_role("leaf") + ["kanban"])
+        )
+    except Exception:
+        enabled = [ts for ts in parent if ts not in {"delegation", "kanban"}]
+        disabled_extra = ["kanban"]
+    return sorted(enabled), disabled_extra
+
+
+def _resolve_inspection_toolsets(
+    cfg: dict, platform: str
+) -> Tuple[List[str], List[str]]:
+    """Resolve enabled + extra-disabled toolsets the way *platform*'s host does.
+
+    ``_get_platform_tools`` only knows platforms that own a ``hermes-<name>``
+    composite toolset (see ``hermes_cli/platforms.py``). ``desktop``, ``tui``
+    and ``subagent`` are real ``agent.platform`` values with no such composite,
+    so a bare lookup resolved to an empty set and the diagnostic reported a
+    toolless, skill-less prompt that no session ever ships. Route those three
+    through the resolver their actual host uses.
+
+    Returns ``(enabled, disabled_extra)``; ``disabled_extra`` is empty for
+    every platform except ``subagent``, whose host imposes a role blocklist.
+    """
+    from hermes_cli.tools_config import _get_platform_tools
+
+    if platform == "subagent":
+        return _resolve_subagent_toolsets(cfg)
+    if platform in ("desktop", "tui"):
+        # tui_gateway resolves the CLI toolsets, then folds in the surfaces
+        # that only exist because of the client on the other end.
+        base = _get_platform_tools(cfg, "cli", include_default_mcp_servers=True)
+        return sorted(set(base) | _resolve_gui_surface_toolsets(platform)), []
+    return sorted(_get_platform_tools(cfg, platform)), []
+
+
 def _build_inspection_agent(platform: str) -> Any:
     """Construct an offline AIAgent for prompt inspection.
 
@@ -56,18 +143,19 @@ def _build_inspection_agent(platform: str) -> Any:
     """
     from run_agent import AIAgent
     from hermes_cli.config import load_config
-    from hermes_cli.tools_config import _get_platform_tools
 
     cfg = load_config()
     model_cfg = cfg.get("model", {}) if isinstance(cfg.get("model"), dict) else {}
     model = model_cfg.get("default") or model_cfg.get("model") or ""
 
-    # Resolve platform-specific toolsets the same way the gateway does.
-    enabled_toolsets = sorted(_get_platform_tools(cfg, platform))
+    # Resolve platform-specific toolsets the same way the platform's host does.
+    enabled_toolsets, disabled_extra = _resolve_inspection_toolsets(cfg, platform)
     agent_cfg = cfg.get("agent") or {}
     from agent.skill_utils import parse_config_string_list
 
-    disabled_toolsets = parse_config_string_list(agent_cfg.get("disabled_toolsets")) or None
+    disabled_toolsets = parse_config_string_list(agent_cfg.get("disabled_toolsets")) or []
+    # The host's own role blocklist stacks on top of the user's config.
+    disabled_toolsets = list(dict.fromkeys(list(disabled_toolsets) + disabled_extra))
 
     return AIAgent(
         model=model,
@@ -77,7 +165,7 @@ def _build_inspection_agent(platform: str) -> Any:
         save_trajectories=False,
         platform=platform,
         enabled_toolsets=enabled_toolsets,
-        disabled_toolsets=disabled_toolsets,
+        disabled_toolsets=disabled_toolsets or None,
     )
 
 
@@ -88,6 +176,13 @@ def _skill_md_paths_by_name() -> Dict[str, Path]:
     skill directory name, so either resolves. Local skills win over external
     dirs (``get_all_skills_dirs`` yields local first), matching the index's own
     precedence. Used to attribute the real on-disk read cost per skill.
+
+    Resolution is two-pass: every frontmatter ``name`` is registered first, and
+    directory names are only added as aliases for keys no frontmatter claimed.
+    A single-pass ``setdefault`` let an earlier skill's *directory* alias shadow
+    a later skill's declared ``name`` (renamed skills are exactly this shape),
+    so the breakdown attributed one file's bytes to two different skills while
+    the real skill's SKILL.md went unreported.
     """
     from agent.skill_utils import (
         get_all_skills_dirs,
@@ -95,22 +190,29 @@ def _skill_md_paths_by_name() -> Dict[str, Path]:
         parse_frontmatter,
     )
 
-    mapping: Dict[str, Path] = {}
+    by_frontmatter: Dict[str, Path] = {}
+    by_dirname: Dict[str, Path] = {}
     for skills_dir in get_all_skills_dirs():
         if not skills_dir.exists():
             continue
         for skill_file in iter_skill_index_files(skills_dir, "SKILL.md"):
-            frontmatter_name = skill_file.parent.name
+            dir_name = skill_file.parent.name
+            frontmatter_name = dir_name
             try:
                 frontmatter, _ = parse_frontmatter(
                     skill_file.read_text(encoding="utf-8")
                 )
-                frontmatter_name = str(frontmatter.get("name") or frontmatter_name)
+                frontmatter_name = str(frontmatter.get("name") or dir_name)
             except Exception:
                 pass
             # setdefault keeps the first (local) occurrence on name collisions.
-            mapping.setdefault(frontmatter_name, skill_file)
-            mapping.setdefault(skill_file.parent.name, skill_file)
+            by_frontmatter.setdefault(frontmatter_name, skill_file)
+            by_dirname.setdefault(dir_name, skill_file)
+
+    # Declared names always win; dir names only fill keys nobody declared.
+    mapping: Dict[str, Path] = dict(by_frontmatter)
+    for dir_name, skill_file in by_dirname.items():
+        mapping.setdefault(dir_name, skill_file)
     return mapping
 
 
@@ -214,14 +316,30 @@ def _compute_toolsets_breakdown(tools: List[Any]) -> List[Dict[str, Any]]:
     sum of the individual tool serializations (which is the array total from
     ``tools['json_bytes']`` minus JSON framing of ``2 * count`` bytes). Sorted
     largest-first by ``json_bytes``, tie-broken by toolset name.
+
+    ``tool_search``/``tool_describe``/``tool_call`` are synthesised by
+    ``tools.tool_search.assemble_tool_defs`` and are in no toolset, so the
+    registry map has no entry for them. Bucketing them under ``(unknown)``
+    hid the single largest lever on the shipped payload — the deferred-tool
+    bridge — behind a label that reads like a bug. They get their own
+    ``(deferred tool-search bridge)`` bucket instead, which also carries the
+    embedded catalog listing's bytes where the reader can see them.
     """
     from tools.registry import registry
+
+    try:
+        from tools.tool_search import BRIDGE_TOOL_NAMES
+    except Exception:
+        BRIDGE_TOOL_NAMES = frozenset()
 
     tool_to_toolset = registry.get_tool_to_toolset_map()
     groups: Dict[str, Dict[str, Any]] = {}
     for tool in tools:
         name = _tool_name(tool)
-        toolset = tool_to_toolset.get(name) or "(unknown)"
+        if name in BRIDGE_TOOL_NAMES:
+            toolset = _DEFERRED_BRIDGE_LABEL
+        else:
+            toolset = tool_to_toolset.get(name) or "(unknown)"
         group = groups.setdefault(
             toolset, {"toolset": toolset, "tool_count": 0, "json_bytes": 0}
         )
@@ -328,12 +446,13 @@ def render_breakdown(data: Dict[str, Any]) -> str:
     # Per-toolset schema cost — which toolset's tools cost the most to ship.
     toolsets = data.get("toolsets_breakdown") or []
     if toolsets:
+        width = max(22, *(len(ts["toolset"]) for ts in toolsets))
         lines.append("")
         lines.append("  Toolsets by size (tool-schema JSON, largest first):")
-        lines.append(f"    {'toolset':<22} {'tools':>5}  {'schema':>10}")
+        lines.append(f"    {'toolset':<{width}} {'tools':>5}  {'schema':>10}")
         for ts in toolsets:
             lines.append(
-                f"    {ts['toolset']:<22} {ts['tool_count']:>5}  "
+                f"    {ts['toolset']:<{width}} {ts['tool_count']:>5}  "
                 f"{ts['json_bytes']:>8,} B  ({_fmt_kb(ts['json_bytes'])})"
             )
 

--- a/optional-skills/software-development/hermes-diagnostic-fidelity/SKILL.md
+++ b/optional-skills/software-development/hermes-diagnostic-fidelity/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: hermes-diagnostic-fidelity
+description: Fix Hermes diagnostics that disagree with real runtime.
+version: 0.1.0
+author: Irakli (Maestro), Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [diagnostics, reporting, prompt-size, regression-tests, contributor]
+    related_skills: [hermes-agent, systematic-debugging, test-driven-development]
+---
+
+# Hermes Diagnostic Fidelity Skill
+
+Hermes ships introspection commands (`hermes prompt-size`, context breakdowns,
+toolset reports) that *model* what a live session would send. When one of them
+reports a zero, an `(unknown)` bucket, or a duplicated row, the defect is
+usually in the measuring code, not in the agent runtime. This skill is the
+discipline for proving which of the two is broken and fixing only the
+reporting layer.
+
+Scope: diagnostic and reporting code inside the hermes-agent tree. Not for
+debugging the agent's actual tool-calling behavior — use `systematic-debugging`
+for that.
+
+## When to Use
+
+- A Hermes diagnostic reports `0`, `[]`, `(unknown)`, or a duplicated row.
+- Diagnostic numbers disagree with what a live session demonstrably ships.
+- You are about to change runtime semantics because a report looked wrong.
+- Don't use for: real runtime defects, provider/model failures, config repair.
+
+## Prerequisites
+
+- A hermes-agent source checkout; run commands from the repo root.
+- The repo venv interpreter. The launcher shim names it — read the shim with
+  `read_file` rather than guessing, and prefer `./venv/bin/python` over the
+  system interpreter, which lacks the project dependencies.
+- No API key needed: the diagnostics build an offline agent.
+
+## Core Principle
+
+**The diagnostic must delegate to the runtime resolver, never re-derive it.**
+Every re-derivation is a copy that drifts silently. If a report needs the
+toolsets a surface receives, import the function that surface actually calls.
+
+## How to Run
+
+```
+terminal(command="./venv/bin/hermes prompt-size --platform cli --json", timeout=300)
+terminal(command="./scripts/run_tests.sh tests/hermes_cli/test_prompt_size.py -q", timeout=600)
+```
+
+## Quick Reference
+
+| Need | Call |
+|---|---|
+| Compare all surfaces | `hermes prompt-size --platform <p> --json` per surface |
+| Find a surface's real host | `search_files(pattern="enabled_toolsets", path="tui_gateway")` |
+| Find delegation blocklists | `search_files(pattern="_blocked_toolsets_for_role", path="tools")` |
+| Run one suite | `./scripts/run_tests.sh <path> -q` |
+| Long suite | same, with `background=True, notify_on_complete=True` |
+
+## Procedure
+
+1. **Reproduce across every variant, not just the broken one.** Loop the
+   diagnostic over all platforms/modes and tabulate the output. A healthy peer
+   column is the control that tells you what the broken one should look like.
+   Done when the table holds at least one known-good row.
+   Note: a serialized tool array of `2` bytes is literally `[]` — nothing at
+   all, not "small".
+
+2. **Locate the real host of the broken variant.** Do not assume a platform
+   lookup table covers it; surfaces such as the desktop app, the TUI, and
+   delegated subagents may own no composite entry. Use `search_files` for the
+   place that constructs a live agent for that surface.
+   Done when you can name the file and line where a real session of that
+   variant obtains its toolsets, and it differs from what the diagnostic calls.
+
+3. **Prove the runtime is healthy before editing anything.** Build the object
+   through the real path with `terminal` and print the numbers.
+   Done when the real path yields non-zero where the diagnostic yielded zero.
+   If the runtime is also zero, stop: this is a runtime defect, switch skills.
+
+4. **Trace caused-by cascades.** One zero often manufactures another — the
+   skills index is gated on the skill tools being present in the resolved tool
+   names, so zero tools silently produces a zero-byte skills index.
+   Done when every reported zero is attributed to a cause rather than listed
+   as an independent defect.
+
+5. **Fix by delegation, with a documented fallback.** Import the runtime
+   helper; keep any local mirror minimal and label it as a mirror.
+   Done when the fix adds no second copy of a runtime set.
+
+6. **Write regression tests, then prove they bite.** Copy the fixed file aside
+   with `terminal`, revert the fix in source only, keep the tests, run them,
+   then restore the copy.
+   Done when the reverted run fails with one cluster per defect and the
+   restored run is fully green. A test that passes both ways is a no-op.
+
+7. **Run the blast radius.** The targeted file, then every module you imported
+   from. Long suites go to the background.
+   Done when you have read the actual summary line — a launched run is not a
+   passed run.
+
+## Pitfalls
+
+- **Latent defects need synthetic reproduction.** A name-collision defect can
+  show zero collisions on the current machine. Build the collision under
+  pytest's `tmp_path` and monkeypatch the skills-directory lookup. Label the
+  proof as synthetic in the report.
+- **Two-key `setdefault` in a single pass is an ordering defect.** Registering
+  a declared `name` and a directory name together lets an earlier entry's
+  directory alias shadow a later entry's declared name. Use two passes:
+  declared names first, directory names only for keys nobody claimed.
+- **Synthesised tools have no registry entry.** Bridge tools built at assembly
+  time are absent from the tool-to-toolset map and fall into `(unknown)`. Give
+  them their own named bucket so the cost is visible.
+- **Fixed-width report columns truncate new labels.** Compute the column width
+  from the rows and assert the label survives rendering.
+- **A verification tool that is not the project's pinned tool is a fabricated
+  result.** `npx --yes -p pkg@5 …` silently resolves a cached major (5.9.3)
+  while the project pins 6.0.3, and it runs with whatever dependencies happen
+  to be installed — none, if nobody ran the install. The resulting errors
+  describe the harness, not the file: a missing-module diagnostic vanished
+  entirely once the real toolchain ran. Invoke the pinned binary directly
+  (`./node_modules/.bin/tsc`, `./venv/bin/python`) and confirm `--version`
+  against the lockfile before believing any output. This is the skill's own
+  Core Principle applied to your instruments.
+- **Two bad runs are not a baseline.** Comparing a patched file against a
+  baseline measured with the same broken harness reproduces the artifact on
+  both sides and looks like proof. Re-measure the baseline after every change
+  of instrument, and treat an unchanged conclusion as unproven until it comes
+  from the pinned tool.
+- **Foreground `terminal` is capped at 600s.** Use `background=True` with
+  `notify_on_complete=True`, then read the summary.
+- **Prefer `search_files` over ad-hoc shell search.** Regex escaping differs
+  between engines and some are unavailable in trimmed environments.
+
+## Verification
+
+- [ ] Every variant reports non-zero, plausible numbers; `(unknown)` is gone
+- [ ] The fix contains no re-derived copy of a runtime set
+- [ ] Revert-check produced one failure cluster per defect; restored run green
+- [ ] Blast-radius summary line read, not merely launched
+- [ ] Diff touches only diagnostic and test files
+- [ ] Every verification ran the project's pinned binary, version checked
+      against the lockfile — not an `npx` fallback
+- [ ] Any baseline comparison was re-measured with that same pinned tool
+- [ ] Latent or synthetic proofs are labeled as such in the report

--- a/tests/hermes_cli/test_prompt_size.py
+++ b/tests/hermes_cli/test_prompt_size.py
@@ -8,9 +8,13 @@ from types import SimpleNamespace
 import pytest
 
 from hermes_cli.prompt_size import (
+    _DEFERRED_BRIDGE_LABEL,
     _SKILLS_BLOCK_RE,
     _build_inspection_agent,
     _compute_skills_breakdown,
+    _compute_toolsets_breakdown,
+    _resolve_inspection_toolsets,
+    _skill_md_paths_by_name,
     compute_prompt_breakdown,
     render_breakdown,
 )
@@ -115,6 +119,198 @@ def test_skills_breakdown_attributes_demoted_category_shared_line(isolated_home)
         assert entry["index_line_total_bytes"] == shared_line_bytes
         assert entry["index_line_shared_bytes"] > 0
         assert entry["index_line_skill_count"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Composite-less platforms (desktop / tui / subagent)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("platform", ["desktop", "tui", "subagent"])
+def test_composite_less_platforms_resolve_real_toolsets(isolated_home, platform):
+    """desktop/tui/subagent own no ``hermes-<platform>`` composite toolset.
+
+    A bare ``_get_platform_tools`` lookup returns an empty set for them, which
+    made the diagnostic report a toolless, skill-less prompt no session ships.
+    The resolver must route them through their real host instead.
+    """
+    from hermes_cli.config import load_config
+
+    cfg = load_config()
+    enabled, _disabled_extra = _resolve_inspection_toolsets(cfg, platform)
+    assert enabled, f"{platform} resolved to no toolsets"
+    # The composite these platforms do NOT have must never appear.
+    assert f"hermes-{platform}" not in enabled
+
+
+def test_desktop_folds_in_gui_surface_toolsets(isolated_home):
+    """``desktop`` gets the client-surface toolsets the tui_gateway adds.
+
+    They are deliberately off ``_HERMES_CORE_TOOLS``, so only the gateway
+    resolver exposes them — mirroring it is what keeps the numbers honest.
+    """
+    from hermes_cli.config import load_config
+
+    cfg = load_config()
+    desktop, _ = _resolve_inspection_toolsets(cfg, "desktop")
+    tui, _ = _resolve_inspection_toolsets(cfg, "tui")
+    assert "desktop_ui" in desktop
+    assert "project" in desktop
+    # ``desktop_ui`` is desktop-only; ``project`` is on both GUI surfaces.
+    assert "desktop_ui" not in tui
+    assert "project" in tui
+
+
+def test_subagent_carries_delegation_role_blocklist(isolated_home):
+    """A leaf subagent inherits the parent's toolsets minus the role blocklist."""
+    from hermes_cli.config import load_config
+
+    cfg = load_config()
+    enabled, disabled_extra = _resolve_inspection_toolsets(cfg, "subagent")
+    assert enabled
+    # delegate_task/clarify/memory/cronjob are blocked for a leaf child.
+    assert "delegation" not in enabled
+    assert "kanban" in disabled_extra
+
+
+@pytest.mark.parametrize("platform", ["desktop", "tui", "subagent"])
+def test_breakdown_reports_tools_and_skills_for_composite_less_platforms(
+    isolated_home, platform
+):
+    """Regression: these three previously reported skills_index=0 and tools=0."""
+    _seed_skill(isolated_home, "probe-skill", "probe description")
+    data = compute_prompt_breakdown(platform)
+    assert data["tools"]["count"] > 0
+    # An empty tool list serialises to ``[]`` — exactly 2 bytes.
+    assert data["tools"]["json_bytes"] > 2
+    assert data["skills_index"]["bytes"] > 0
+    assert data["skills_breakdown"]
+    assert data["toolsets_breakdown"]
+
+
+# ---------------------------------------------------------------------------
+# Skill name/dir collisions
+# ---------------------------------------------------------------------------
+
+
+def _write_skill(path: Path, *, name: str, body_size: int) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: d\n---\n" + "x" * body_size,
+        encoding="utf-8",
+    )
+
+
+def test_declared_name_beats_another_skills_dir_alias(tmp_path, monkeypatch):
+    """A skill's declared ``name`` must not be shadowed by another's dir alias.
+
+    ``local/alpha/`` declares ``name: renamed`` (a renamed skill — the common
+    shape), while ``ext/other/`` genuinely declares ``name: alpha``. The old
+    single-pass ``setdefault`` registered the ``alpha`` *directory* alias first,
+    so both names resolved to the same file: one file's bytes were reported
+    twice and the real ``alpha`` skill's SKILL.md never appeared.
+    """
+    import agent.skill_utils as su
+
+    local = tmp_path / "local"
+    ext = tmp_path / "ext"
+    _write_skill(local / "alpha", name="renamed", body_size=50)
+    _write_skill(ext / "other", name="alpha", body_size=9000)
+
+    monkeypatch.setattr(su, "get_all_skills_dirs", lambda *a, **k: [local, ext])
+
+    mapping = _skill_md_paths_by_name()
+    assert mapping["alpha"] == ext / "other" / "SKILL.md"
+    assert mapping["renamed"] == local / "alpha" / "SKILL.md"
+
+    block = (
+        "<available_skills>\n  cat:\n"
+        "    - alpha: d\n"
+        "    - renamed: d\n"
+        "</available_skills>"
+    )
+    entries = {e["name"]: e for e in _compute_skills_breakdown(block)}
+    # Distinct files, distinct sizes — no double-counted winner path.
+    assert entries["alpha"]["path"] != entries["renamed"]["path"]
+    assert entries["alpha"]["skill_md_bytes"] > entries["renamed"]["skill_md_bytes"]
+    paths = [e["path"] for e in entries.values()]
+    assert len(set(paths)) == len(paths)
+
+
+def test_local_skill_still_wins_on_true_name_collision(tmp_path, monkeypatch):
+    """Two skills declaring the SAME name: local still wins (index precedence)."""
+    import agent.skill_utils as su
+
+    local = tmp_path / "local"
+    ext = tmp_path / "ext"
+    _write_skill(local / "dupe", name="dupe", body_size=10)
+    _write_skill(ext / "dupe", name="dupe", body_size=9000)
+
+    monkeypatch.setattr(su, "get_all_skills_dirs", lambda *a, **k: [local, ext])
+
+    mapping = _skill_md_paths_by_name()
+    assert mapping["dupe"] == local / "dupe" / "SKILL.md"
+
+
+# ---------------------------------------------------------------------------
+# Deferred tool-search bridge attribution
+# ---------------------------------------------------------------------------
+
+
+def _fn_tool(name: str, description: str = "d") -> dict:
+    return {
+        "type": "function",
+        "function": {"name": name, "description": description, "parameters": {}},
+    }
+
+
+def test_bridge_tools_get_their_own_bucket_not_unknown():
+    """tool_search/tool_describe/tool_call are synthesised, not registry-owned.
+
+    They previously landed in ``(unknown)``, hiding the deferred-tool bridge —
+    often the largest single lever on the shipped payload — behind a label that
+    reads like a bug.
+    """
+    from tools.tool_search import BRIDGE_TOOL_NAMES
+
+    tools = [_fn_tool(name) for name in sorted(BRIDGE_TOOL_NAMES)]
+    tools.append(_fn_tool("read_file"))
+
+    groups = {g["toolset"]: g for g in _compute_toolsets_breakdown(tools)}
+    assert _DEFERRED_BRIDGE_LABEL in groups
+    assert groups[_DEFERRED_BRIDGE_LABEL]["tool_count"] == len(BRIDGE_TOOL_NAMES)
+    assert "(unknown)" not in groups
+
+
+def test_toolsets_breakdown_bytes_are_fully_attributable():
+    """Per-toolset json_bytes sum to the array total minus JSON framing."""
+    from tools.tool_search import BRIDGE_TOOL_NAMES
+
+    tools = [_fn_tool(n) for n in sorted(BRIDGE_TOOL_NAMES)] + [_fn_tool("read_file")]
+    total = len(json.dumps(tools, ensure_ascii=False).encode("utf-8"))
+    attributed = sum(g["json_bytes"] for g in _compute_toolsets_breakdown(tools))
+    # Framing: the enclosing "[]" plus ", " between each pair of elements.
+    assert attributed == total - 2 - 2 * (len(tools) - 1)
+
+
+def test_render_does_not_truncate_the_bridge_label():
+    """The bridge label is wider than the old fixed column — must stay intact."""
+    data = {
+        "platform": "cli",
+        "model": "m",
+        "system_prompt": {"chars": 1, "bytes": 1},
+        "skills_index": {"chars": 0, "bytes": 0},
+        "memory": {"chars": 0, "bytes": 0},
+        "user_profile": {"chars": 0, "bytes": 0},
+        "tools": {"count": 3, "json_bytes": 300},
+        "sections": [],
+        "skills_breakdown": [],
+        "toolsets_breakdown": [
+            {"toolset": _DEFERRED_BRIDGE_LABEL, "tool_count": 3, "json_bytes": 300}
+        ],
+    }
+    out = render_breakdown(data)
+    assert _DEFERRED_BRIDGE_LABEL in out
 
 
 

--- a/tests/skills/test_hermes_diagnostic_fidelity_skill.py
+++ b/tests/skills/test_hermes_diagnostic_fidelity_skill.py
@@ -1,0 +1,149 @@
+"""Authoring + content contract for the hermes-diagnostic-fidelity skill.
+
+The generic sweep in ``test_authoring_standards.py`` covers the mechanical
+frontmatter rules for every skill. These tests pin the parts that are specific
+to this skill: the tier/placement decision, the shell-utility prose ban, and
+the load-bearing sections a reader relies on (the core principle, the
+revert-check step, and the completion criteria that make the procedure
+checkable rather than aspirational).
+"""
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO = Path(__file__).resolve().parents[2]
+SKILL_DIR = REPO / "optional-skills" / "software-development" / "hermes-diagnostic-fidelity"
+SKILL_MD = SKILL_DIR / "SKILL.md"
+
+
+@pytest.fixture(scope="module")
+def content() -> str:
+    return SKILL_MD.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def frontmatter(content: str) -> dict:
+    assert content.startswith("---"), "frontmatter must start at byte 0"
+    m = re.search(r"\n---\s*\n", content[3:])
+    assert m, "unclosed frontmatter"
+    fm = yaml.safe_load(content[3 : m.start() + 3])
+    assert isinstance(fm, dict)
+    return fm
+
+
+def test_skill_is_optional_tier():
+    """Contributor-facing repo-maintenance skill — not a daily driver."""
+    assert SKILL_MD.exists(), f"missing skill at {SKILL_MD.relative_to(REPO)}"
+    assert not (
+        REPO / "skills" / "software-development" / "hermes-diagnostic-fidelity"
+    ).exists(), "skill must live in optional-skills/, not bundled skills/"
+
+
+def test_description_within_index_window(frontmatter):
+    """The trigger must survive the system-prompt index truncation at 57."""
+    desc = frontmatter["description"]
+    assert len(desc) <= 60, f"{len(desc)} chars (hardline 60)"
+    assert desc.endswith(".")
+    assert "hermes-diagnostic-fidelity" not in desc, "don't repeat the skill name"
+
+
+def test_related_skills_resolve_in_repo(frontmatter):
+    """Every related skill must exist in this tree, not only user-local."""
+    names = {
+        p.parent.name
+        for p in list(REPO.glob("skills/**/SKILL.md"))
+        + list(REPO.glob("optional-skills/**/SKILL.md"))
+    }
+    dangling = [
+        rs
+        for rs in frontmatter["metadata"]["hermes"]["related_skills"]
+        if rs not in names
+    ]
+    assert not dangling, f"dangling related_skills: {dangling}"
+
+
+def test_prose_names_hermes_tools_not_raw_shell(content: str):
+    """AGENTS.md hardline #2: wrapped shell utilities must not headline prose."""
+    body = content.split("\n---\n", 1)[1]
+    for banned in (r"`grep`", r"`cat`", r"`head`", r"`tail`", r"`sed`", r"`awk`", r"`find`"):
+        assert banned not in body, f"prose names a wrapped shell utility: {banned}"
+    for expected in ("`terminal`", "`search_files`", "`read_file`"):
+        assert expected in body, f"prose should reference {expected}"
+
+
+def test_core_principle_is_stated(content: str):
+    """The delegate-don't-re-derive rule is the whole point of the skill."""
+    assert "## Core Principle" in content
+    assert "never re-derive" in content
+
+
+def test_revert_check_step_present(content: str):
+    """A regression test that passes both ways is a no-op — say so."""
+    assert "prove they bite" in content
+    assert "one cluster per defect" in content
+    assert "passes both ways is a no-op" in content
+
+
+def test_every_procedure_step_has_completion_criterion(content: str):
+    """Numbered steps must end in something checkable."""
+    procedure = content.split("## Procedure", 1)[1].split("## Pitfalls", 1)[0]
+    steps = re.findall(r"^\d+\. \*\*(.+?)\*\*", procedure, re.MULTILINE)
+    assert len(steps) >= 6, f"expected the full procedure, found {len(steps)} steps"
+    assert procedure.count("Done when") == len(steps), (
+        f"{len(steps)} steps but {procedure.count('Done when')} completion criteria"
+    )
+
+
+def test_modern_section_order(content: str):
+    """Sections appear in the AGENTS.md hardline #5 order."""
+    order = [
+        "## When to Use",
+        "## Prerequisites",
+        "## How to Run",
+        "## Quick Reference",
+        "## Procedure",
+        "## Pitfalls",
+        "## Verification",
+    ]
+    positions = [content.index(s) for s in order]
+    assert positions == sorted(positions), "sections out of the modern order"
+
+
+def test_no_machine_local_paths(content: str):
+    """A baked-in home directory breaks the skill for every other user."""
+    assert not re.search(r"/home/(?!runner\b)[a-z0-9_-]+/", content)
+    assert "/.hermes/hermes-agent/" not in content
+
+
+def test_pinned_toolchain_pitfall_is_present(content: str):
+    """Regression: verifying with an unpinned tool fabricated a diagnostic.
+
+    An `npx --yes -p pkg@5` fallback resolved a cached 5.9.3 against absent
+    dependencies while the project pinned 6.0.3, producing a missing-module
+    error that belonged to the harness. The skill must keep warning about it
+    and must pair the warning with a checkable verification item.
+    """
+    pitfalls = content.split("## Pitfalls", 1)[1].split("## Verification", 1)[0]
+    assert "pinned" in pitfalls
+    assert "npx" in pitfalls
+    assert "./node_modules/.bin/" in pitfalls
+    assert "--version" in pitfalls
+
+    verification = content.split("## Verification", 1)[1]
+    assert "pinned binary" in verification
+    assert "lockfile" in verification
+
+
+def test_baseline_must_be_remeasured_after_tool_change(content: str):
+    """Comparing against a baseline from the same broken harness is not proof."""
+    pitfalls = content.split("## Pitfalls", 1)[1].split("## Verification", 1)[0]
+    assert "Two bad runs are not a baseline" in pitfalls
+    assert "re-measured" in content.split("## Verification", 1)[1]
+
+
+def test_size_is_reviewable(content: str):
+    """Target ~200 lines for a complex skill; hard ceiling is 100k chars."""
+    assert len(content) <= 100_000
+    assert len(content.splitlines()) <= 200

--- a/website/docs/reference/optional-skills-catalog.md
+++ b/website/docs/reference/optional-skills-catalog.md
@@ -232,6 +232,7 @@ hermes skills uninstall <skill-name>
 |-------|-------------|
 | [**code-wiki**](/docs/user-guide/skills/optional/software-development/software-development-code-wiki) | Generate wiki docs + Mermaid diagrams for any codebase. |
 | [**grill-me**](/docs/user-guide/skills/optional/software-development/software-development-grill-me) | Adversarial plan interview before implementation. |
+| [**hermes-diagnostic-fidelity**](/docs/user-guide/skills/optional/software-development/software-development-hermes-diagnostic-fidelity) | Fix Hermes diagnostics that disagree with real runtime. |
 | [**rest-graphql-debug**](/docs/user-guide/skills/optional/software-development/software-development-rest-graphql-debug) | Debug REST/GraphQL APIs: status codes, auth, schemas, repro. |
 | [**subagent-driven-development**](/docs/user-guide/skills/optional/software-development/software-development-subagent-driven-development) | Execute plans via delegate_task subagents (2-stage review). |
 

--- a/website/docs/user-guide/skills/optional/software-development/software-development-hermes-diagnostic-fidelity.md
+++ b/website/docs/user-guide/skills/optional/software-development/software-development-hermes-diagnostic-fidelity.md
@@ -1,0 +1,169 @@
+---
+title: "Hermes Diagnostic Fidelity — Fix Hermes diagnostics that disagree with real runtime"
+sidebar_label: "Hermes Diagnostic Fidelity"
+description: "Fix Hermes diagnostics that disagree with real runtime"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Hermes Diagnostic Fidelity
+
+Fix Hermes diagnostics that disagree with real runtime.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Optional — install with `hermes skills install official/software-development/hermes-diagnostic-fidelity` |
+| Path | `optional-skills/software-development/hermes-diagnostic-fidelity` |
+| Version | `0.1.0` |
+| Author | Irakli (Maestro), Hermes Agent |
+| License | MIT |
+| Platforms | linux, macos, windows |
+| Tags | `diagnostics`, `reporting`, `prompt-size`, `regression-tests`, `contributor` |
+| Related skills | [`hermes-agent`](/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-hermes-agent), [`systematic-debugging`](/docs/user-guide/skills/bundled/software-development/software-development-systematic-debugging), [`test-driven-development`](/docs/user-guide/skills/bundled/software-development/software-development-test-driven-development) |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# Hermes Diagnostic Fidelity Skill
+
+Hermes ships introspection commands (`hermes prompt-size`, context breakdowns,
+toolset reports) that *model* what a live session would send. When one of them
+reports a zero, an `(unknown)` bucket, or a duplicated row, the defect is
+usually in the measuring code, not in the agent runtime. This skill is the
+discipline for proving which of the two is broken and fixing only the
+reporting layer.
+
+Scope: diagnostic and reporting code inside the hermes-agent tree. Not for
+debugging the agent's actual tool-calling behavior — use `systematic-debugging`
+for that.
+
+## When to Use
+
+- A Hermes diagnostic reports `0`, `[]`, `(unknown)`, or a duplicated row.
+- Diagnostic numbers disagree with what a live session demonstrably ships.
+- You are about to change runtime semantics because a report looked wrong.
+- Don't use for: real runtime defects, provider/model failures, config repair.
+
+## Prerequisites
+
+- A hermes-agent source checkout; run commands from the repo root.
+- The repo venv interpreter. The launcher shim names it — read the shim with
+  `read_file` rather than guessing, and prefer `./venv/bin/python` over the
+  system interpreter, which lacks the project dependencies.
+- No API key needed: the diagnostics build an offline agent.
+
+## Core Principle
+
+**The diagnostic must delegate to the runtime resolver, never re-derive it.**
+Every re-derivation is a copy that drifts silently. If a report needs the
+toolsets a surface receives, import the function that surface actually calls.
+
+## How to Run
+
+```
+terminal(command="./venv/bin/hermes prompt-size --platform cli --json", timeout=300)
+terminal(command="./scripts/run_tests.sh tests/hermes_cli/test_prompt_size.py -q", timeout=600)
+```
+
+## Quick Reference
+
+| Need | Call |
+|---|---|
+| Compare all surfaces | `hermes prompt-size --platform <p> --json` per surface |
+| Find a surface's real host | `search_files(pattern="enabled_toolsets", path="tui_gateway")` |
+| Find delegation blocklists | `search_files(pattern="_blocked_toolsets_for_role", path="tools")` |
+| Run one suite | `./scripts/run_tests.sh <path> -q` |
+| Long suite | same, with `background=True, notify_on_complete=True` |
+
+## Procedure
+
+1. **Reproduce across every variant, not just the broken one.** Loop the
+   diagnostic over all platforms/modes and tabulate the output. A healthy peer
+   column is the control that tells you what the broken one should look like.
+   Done when the table holds at least one known-good row.
+   Note: a serialized tool array of `2` bytes is literally `[]` — nothing at
+   all, not "small".
+
+2. **Locate the real host of the broken variant.** Do not assume a platform
+   lookup table covers it; surfaces such as the desktop app, the TUI, and
+   delegated subagents may own no composite entry. Use `search_files` for the
+   place that constructs a live agent for that surface.
+   Done when you can name the file and line where a real session of that
+   variant obtains its toolsets, and it differs from what the diagnostic calls.
+
+3. **Prove the runtime is healthy before editing anything.** Build the object
+   through the real path with `terminal` and print the numbers.
+   Done when the real path yields non-zero where the diagnostic yielded zero.
+   If the runtime is also zero, stop: this is a runtime defect, switch skills.
+
+4. **Trace caused-by cascades.** One zero often manufactures another — the
+   skills index is gated on the skill tools being present in the resolved tool
+   names, so zero tools silently produces a zero-byte skills index.
+   Done when every reported zero is attributed to a cause rather than listed
+   as an independent defect.
+
+5. **Fix by delegation, with a documented fallback.** Import the runtime
+   helper; keep any local mirror minimal and label it as a mirror.
+   Done when the fix adds no second copy of a runtime set.
+
+6. **Write regression tests, then prove they bite.** Copy the fixed file aside
+   with `terminal`, revert the fix in source only, keep the tests, run them,
+   then restore the copy.
+   Done when the reverted run fails with one cluster per defect and the
+   restored run is fully green. A test that passes both ways is a no-op.
+
+7. **Run the blast radius.** The targeted file, then every module you imported
+   from. Long suites go to the background.
+   Done when you have read the actual summary line — a launched run is not a
+   passed run.
+
+## Pitfalls
+
+- **Latent defects need synthetic reproduction.** A name-collision defect can
+  show zero collisions on the current machine. Build the collision under
+  pytest's `tmp_path` and monkeypatch the skills-directory lookup. Label the
+  proof as synthetic in the report.
+- **Two-key `setdefault` in a single pass is an ordering defect.** Registering
+  a declared `name` and a directory name together lets an earlier entry's
+  directory alias shadow a later entry's declared name. Use two passes:
+  declared names first, directory names only for keys nobody claimed.
+- **Synthesised tools have no registry entry.** Bridge tools built at assembly
+  time are absent from the tool-to-toolset map and fall into `(unknown)`. Give
+  them their own named bucket so the cost is visible.
+- **Fixed-width report columns truncate new labels.** Compute the column width
+  from the rows and assert the label survives rendering.
+- **A verification tool that is not the project's pinned tool is a fabricated
+  result.** `npx --yes -p pkg@5 …` silently resolves a cached major (5.9.3)
+  while the project pins 6.0.3, and it runs with whatever dependencies happen
+  to be installed — none, if nobody ran the install. The resulting errors
+  describe the harness, not the file: a missing-module diagnostic vanished
+  entirely once the real toolchain ran. Invoke the pinned binary directly
+  (`./node_modules/.bin/tsc`, `./venv/bin/python`) and confirm `--version`
+  against the lockfile before believing any output. This is the skill's own
+  Core Principle applied to your instruments.
+- **Two bad runs are not a baseline.** Comparing a patched file against a
+  baseline measured with the same broken harness reproduces the artifact on
+  both sides and looks like proof. Re-measure the baseline after every change
+  of instrument, and treat an unchanged conclusion as unproven until it comes
+  from the pinned tool.
+- **Foreground `terminal` is capped at 600s.** Use `background=True` with
+  `notify_on_complete=True`, then read the summary.
+- **Prefer `search_files` over ad-hoc shell search.** Regex escaping differs
+  between engines and some are unavailable in trimmed environments.
+
+## Verification
+
+- [ ] Every variant reports non-zero, plausible numbers; `(unknown)` is gone
+- [ ] The fix contains no re-derived copy of a runtime set
+- [ ] Revert-check produced one failure cluster per defect; restored run green
+- [ ] Blast-radius summary line read, not merely launched
+- [ ] Diff touches only diagnostic and test files
+- [ ] Every verification ran the project's pinned binary, version checked
+      against the lockfile — not an `npx` fallback
+- [ ] Any baseline comparison was re-measured with that same pinned tool
+- [ ] Latent or synthetic proofs are labeled as such in the report

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -601,6 +601,7 @@ const sidebars: SidebarsConfig = {
                   items: [
                     'user-guide/skills/optional/software-development/software-development-code-wiki',
                     'user-guide/skills/optional/software-development/software-development-grill-me',
+                    'user-guide/skills/optional/software-development/software-development-hermes-diagnostic-fidelity',
                     'user-guide/skills/optional/software-development/software-development-rest-graphql-debug',
                     'user-guide/skills/optional/software-development/software-development-subagent-driven-development',
                   ],

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -842,8 +842,8 @@ const sidebars: SidebarsConfig = {
           items: [
             'reference/tools-reference',
             'reference/toolsets-reference',
-            'reference/skills-catalog',
-            'reference/optional-skills-catalog',
+            { type: 'ref', id: 'reference/skills-catalog' },
+            { type: 'ref', id: 'reference/optional-skills-catalog' },
           ],
         },
         'reference/cli-symbols',

--- a/website/src/components/AutomationBlueprintsCatalog/index.tsx
+++ b/website/src/components/AutomationBlueprintsCatalog/index.tsx
@@ -25,7 +25,7 @@ interface Blueprint {
 
 const INDEX_URL = "/docs/api/automation-blueprints-index.json";
 
-function CopyButton({ text }: { text: string }): JSX.Element {
+function CopyButton({ text }: { text: string }): React.JSX.Element {
   const [copied, setCopied] = useState(false);
   return (
     <button
@@ -44,7 +44,7 @@ function CopyButton({ text }: { text: string }): JSX.Element {
   );
 }
 
-function BlueprintCard({ blueprint }: { blueprint: Blueprint }): JSX.Element {
+function BlueprintCard({ blueprint }: { blueprint: Blueprint }): React.JSX.Element {
   return (
     <div className={styles.card}>
       <div className={styles.cardHead}>
@@ -78,7 +78,7 @@ function BlueprintCard({ blueprint }: { blueprint: Blueprint }): JSX.Element {
   );
 }
 
-export default function AutomationBlueprintsCatalog(): JSX.Element {
+export default function AutomationBlueprintsCatalog(): React.JSX.Element {
   const [blueprints, setBlueprints] = useState<Blueprint[] | null>(null);
   const [error, setError] = useState<string | null>(null);
 

--- a/website/src/components/UserStoriesCollage/index.tsx
+++ b/website/src/components/UserStoriesCollage/index.tsx
@@ -145,7 +145,7 @@ function sourceColor(source: string): string {
   }
 }
 
-export default function UserStoriesCollage(): JSX.Element {
+export default function UserStoriesCollage(): React.JSX.Element {
   const [activeCategory, setActiveCategory] = useState<string>('all');
   const [activeSource, setActiveSource] = useState<string>('all');
 

--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -1,5 +1,11 @@
 {
   // This file is not used in compilation. It is here just for a nice editor experience.
   "extends": "@docusaurus/tsconfig",
+  "compilerOptions": {
+    "ignoreDeprecations": "6.0",
+    "resolveJsonModule": true,
+    "baseUrl": ".",
+    "paths": { "@site/*": ["./*"] }
+  },
   "exclude": [".docusaurus", "build"]
 }


### PR DESCRIPTION
## What does this PR do?

`hermes prompt-size` is the tool you reach for when a session's prompt is
bigger than expected. On two surfaces it reported a prompt that no real
session would receive, because it re-derived the toolset list instead of
asking the code that actually assembles it.

- **desktop/tui** — these sessions are not built from a `hermes-<platform>`
  composite. `tui_gateway.server._load_enabled_toolsets` resolves the CLI
  toolsets and then folds in the client-surface toolsets that are
  deliberately kept off `_HERMES_CORE_TOOLS` (`project`, `desktop_ui`).
  The diagnostic never added them.
- **subagents** — `tools/delegate_tool.py` never resolves a
  `hermes-subagent` composite either. A child inherits the parent's
  enabled toolsets and is separately handed
  `_blocked_toolsets_for_role(role) + ["kanban"]` as `disabled_toolsets`,
  so blocked tools are subtracted *after* composite expansion.
- **tool_search bridge** — those tools are synthesised at assembly time by
  `tools.tool_search.assemble_tool_defs` and carry no registry
  attribution, so their bytes were reported as unattributed.

The fix delegates to the runtime resolvers rather than re-deriving the
sets, so the diagnostic stays in lockstep when the runtime changes. A
conservative fallback keeps trimmed installs working when the gateway
module is unavailable.

The accompanying optional skill (`hermes-diagnostic-fidelity`) writes up
the general procedure, since this is a recurring shape: a diagnostic
disagrees with runtime, and the disagreement gets read as a product bug
rather than a reporting bug.

## Related Issue

No existing issue — found while auditing a live install where
`prompt-size` under-reported a desktop session.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [x] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/prompt_size.py` — `_resolve_gui_surface_toolsets()` delegates
  to `tui_gateway.server._gui_surface_toolsets`;
  `_resolve_subagent_toolsets()` models a leaf child of a CLI-configured
  parent; deferred bridge tools get their own attribution bucket.
- `tests/hermes_cli/test_prompt_size.py` — 16 tests asserting the
  diagnostic agrees with the runtime resolvers.
- `optional-skills/software-development/hermes-diagnostic-fidelity/SKILL.md`
  plus its docs page and catalog/sidebar registration.
- `tests/skills/test_hermes_diagnostic_fidelity_skill.py` — 12 tests.
- `website/` — docs typecheck was failing on `main` with TS5101
  (`baseUrl` deprecated); fixed alongside the catalog registration,
  isolated in its own commit.

## How to Test

1. `pytest tests/hermes_cli/test_prompt_size.py tests/skills/test_hermes_diagnostic_fidelity_skill.py -q`
   → 28 passed.
2. `hermes prompt-size --platform desktop` — `project` / `desktop_ui` now
   appear in the toolset breakdown; before this change they were absent.
3. `hermes prompt-size --platform subagent` — reports the prompt a real
   delegated child receives (parent's toolsets minus the blocked set),
   instead of an unresolvable composite.
4. `cd website && npx tsc --noEmit -p tsconfig.json` → exit 0 (fails on
   `main` with TS5101).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [x] I've run the relevant suites and they pass — see note below
- [x] I've added tests for my changes
- [x] I've tested on my platform: Debian 12 (aarch64), Python 3.11.15

**Note on the full suite:** `pytest tests/hermes_cli/ -q` reports
`1 failed, 1053 passed` — `test_config.py::TestSanitizeEnvLines::test_migrate_reports_normalized_line_formatting`.
That failure reproduces identically on a clean `origin/main` checkout with
this branch's changes absent, and the test passes in isolation on both —
it is a pre-existing ordering/state-leak issue, not a regression from this
PR. Happy to open a separate issue for it.

### Documentation & Housekeeping

- [x] I've updated relevant documentation — skill docs page + catalog +
      sidebar; module docstrings updated in `prompt_size.py`
- [x] N/A — no config keys added or changed
- [x] N/A — no architecture or workflow change
- [x] I've considered cross-platform impact — the GUI resolver is imported
      defensively with a conservative fallback, so trimmed or
      gateway-less installs (any OS) degrade to the documented default
      rather than raising
