### PR TITLE
fix(cron): suppress standalone fallback after adapter reports an ambiguous write

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3010,6 +3010,26 @@ def _confirm_adapter_delivery(send_result) -> bool:
     return bool(getattr(send_result, "success"))
 
 
+def _send_result_error_kind(send_result) -> Optional[str]:
+    """Return the platform-neutral ``error_kind`` from a send result, if any.
+
+    Accepts both shapes ``_deliver_to_platform`` can return (a
+    ``SendResult`` object or, when the silence-narration filter drops the
+    message, a plain dict) so callers never substring-match raw provider
+    text.  Unlike :func:`gateway.delivery._send_result_error_kind`, this
+    accepts non-SendResult/non-dict objects (returns ``None``) instead of
+    raising on a missing attribute — a producer that never set the field is
+    simply unclassified.
+    """
+    if send_result is None:
+        return None
+    if isinstance(send_result, dict):
+        kind = send_result.get("error_kind")
+    else:
+        kind = getattr(send_result, "error_kind", None)
+    return str(kind) if kind else None
+
+
 def _is_channel_dm_topic(
     runtime_adapter: Any,
     chat_id: Any,
@@ -3648,6 +3668,36 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                                 else:
                                     err = "no response from adapter"
                                     shape = "None"
+                                send_error_kind = _send_result_error_kind(send_result)
+                                if send_error_kind == "ambiguous":
+                                    # #97230: the adapter reports an AMBIGUOUS
+                                    # WRITE — the payload (for a multi-chunk send,
+                                    # possibly only some chunks) may already be on
+                                    # the wire, but the adapter cannot confirm the
+                                    # final outcome and has told us a replay is
+                                    # unsafe.  Re-sending the entire payload via
+                                    # the standalone path would DUPLICATE the
+                                    # chunks that already landed.  Treat this like
+                                    # the #38922 in-flight timeout: record the
+                                    # unknown outcome honestly and suppress the
+                                    # standalone fallback (and any second send
+                                    # path for this target).
+                                    msg = (
+                                        f"live adapter send to {platform_name}:{chat_id} "
+                                        f"returned ambiguous result ({shape}, "
+                                        f"error={err}) — outcome unknown, NOT "
+                                        "re-sending via standalone to avoid "
+                                        "duplicate delivery"
+                                    )
+                                    logger.warning("Job '%s': %s", job["id"], msg)
+                                    # Record the unknown outcome in the RUN
+                                    # status (not just target_errors — that
+                                    # list is folded in only on the paths
+                                    # below, which this `continue` skips): a
+                                    # possibly-unconfirmed delivery must not
+                                    # report ok/delivered.
+                                    delivery_errors.append(msg)
+                                    continue
                                 msg = (
                                     f"live adapter send to {platform_name}:{chat_id} "
                                     f"returned unconfirmed result ({shape}, error={err})"

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2592,6 +2592,13 @@ class SendResult:
 #   not_found     the target chat/thread/message no longer exists.
 #   rate_limited  the platform throttled the send (flood control).
 #   transient     a connection-level failure that is safe to retry.
+#   ambiguous     an ambiguous write: the send may have PARTIALLY or fully
+#                 succeeded on the wire but the adapter cannot confirm the
+#                 final outcome (e.g. a multi-chunk payload delivered some
+#                 chunks before the failure).  Replaying the payload is
+#                 UNSAFE (duplicates already-delivered chunks); consumers
+#                 must record the outcome and wait for human/adjudicated
+#                 reconciliation instead of re-sending.
 #   unknown       classification did not match any known shape.
 SEND_ERROR_KINDS = frozenset(
     {
@@ -2601,6 +2608,7 @@ SEND_ERROR_KINDS = frozenset(
         "not_found",
         "rate_limited",
         "transient",
+        "ambiguous",
         "unknown",
     }
 )

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1,14 +1,17 @@
 """Tests for cron/scheduler.py — origin resolution, delivery routing, and error logging."""
 
+import asyncio
 import contextlib
 import itertools
 import json
 import logging
 import os
+from concurrent.futures import Future
 from unittest.mock import AsyncMock, patch, MagicMock
 
 import pytest
 
+from gateway.config import Platform, PlatformConfig
 from cron.scheduler import (
     SILENT_MARKER,
     _build_job_prompt,
@@ -538,6 +541,157 @@ class TestDeliverResultErrorReturns:
             result = _deliver_result(job, "Output.")
         assert result is not None
         assert "not configured" in result
+
+
+class TestDeliverResultAmbiguousWrite:
+    """#97230: a live adapter's ambiguous write must suppress standalone fallback.
+
+    A live adapter that partially delivers a multi-chunk payload and then
+    returns ``SendResult(success=False, retryable=False, error_kind="ambiguous")``
+    has told the scheduler the outcome is UNKNOWN — re-sending the entire
+    payload via the standalone path would duplicate the chunks that already
+    landed. The scheduler must record the unknown outcome and stop, exactly
+    like the #38922 in-flight-timeout case. Adapters must be able to report
+    ambiguity in the platform-neutral vocabulary instead of lying with
+    ``success=True``.
+    """
+
+    def _job(self):
+        return {
+            "id": "ambiguous-job",
+            "name": "Ambiguous Job",
+            "deliver": "origin",
+            "origin": {"platform": "telegram", "chat_id": "555"},
+        }
+
+    def _run(self, send_result, *, fake_standalone):
+        """Drive _deliver_result with a live telegram adapter whose send
+        returns ``send_result``, recording any standalone fallback sends."""
+        loop = MagicMock()
+        loop.is_running.return_value = True
+
+        def fake_run_coro(coro, _loop):
+            future = Future()
+            try:
+                future.set_result(asyncio.run(coro))
+            except BaseException as e:  # noqa: BLE001
+                future.set_exception(e)
+            return future
+
+        router = MagicMock()
+
+        async def _deliver_to_platform(target, content, metadata):
+            return send_result
+
+        router._deliver_to_platform = _deliver_to_platform
+
+        config = MagicMock()
+        config.platforms = {Platform.TELEGRAM: PlatformConfig(enabled=True, token="t", extra={})}
+        adapters = {Platform.TELEGRAM: MagicMock()}
+
+        with patch("gateway.config.load_gateway_config", return_value=config), \
+             patch("cron.scheduler.load_config",
+                   return_value={"cron": {"wrap_response": False}}), \
+             patch("gateway.delivery.DeliveryRouter", return_value=router), \
+             patch("asyncio.run_coroutine_threadsafe", side_effect=fake_run_coro), \
+             patch("tools.send_message_tool._send_to_platform", fake_standalone):
+            return _deliver_result(self._job(), "Nightly report.",
+                                   adapters=adapters, loop=loop)
+
+    def _assert_no_fallback(self, err, standalone_calls):
+        assert standalone_calls == [], (
+            "an ambiguous write must NEVER be replayed via the standalone "
+            "path — already-delivered chunks would be duplicated"
+        )
+        assert err is not None
+        assert "ambiguous" in err
+        assert "555" in err
+
+    def test_ambiguous_send_result_object_suppresses_fallback(self):
+        from gateway.platforms.base import SendResult
+
+        async def fake_standalone(*_a, **_kw):
+            return {"success": True}
+
+        standalone_calls = []
+
+        def recording_fake(*a, **kw):
+            standalone_calls.append((a, kw))
+            return fake_standalone(*a, **kw)
+
+        result = SendResult(
+            success=False,
+            error="chunks 1-2 delivered; final chunk unconfirmed",
+            retryable=False,
+            error_kind="ambiguous",
+        )
+        err = self._run(result, fake_standalone=recording_fake)
+        self._assert_no_fallback(err, standalone_calls)
+
+    def test_ambiguous_dict_result_suppresses_fallback(self):
+        async def fake_standalone(*_a, **_kw):
+            return {"success": True}
+
+        standalone_calls = []
+
+        def recording_fake(*a, **kw):
+            standalone_calls.append((a, kw))
+            return fake_standalone(*a, **kw)
+
+        send_result = {
+            "success": False,
+            "retryable": False,
+            "error": "chunks 1-2 delivered; final chunk unconfirmed",
+            "error_kind": "ambiguous",
+        }
+        err = self._run(send_result, fake_standalone=recording_fake)
+        self._assert_no_fallback(err, standalone_calls)
+
+    def test_ordinary_unconfirmed_failure_still_falls_back_to_standalone(self):
+        """Regression guard: only error_kind="ambiguous" suppresses the
+        fallback — an ordinary unconfirmed failure must still reach the
+        standalone path or the message is silently dropped."""
+        from gateway.platforms.base import SendResult
+
+        async def fake_standalone(*_a, **_kw):
+            return {"success": True}
+
+        standalone_calls = []
+
+        def recording_fake(*a, **kw):
+            standalone_calls.append((a, kw))
+            return fake_standalone(*a, **kw)
+
+        result = SendResult(
+            success=False,
+            error="502 bad gateway",
+            retryable=False,
+            error_kind=None,
+        )
+        err = self._run(result, fake_standalone=recording_fake)
+        assert len(standalone_calls) == 1, (
+            "an ordinary unconfirmed failure keeps the standalone fallback"
+        )
+        assert err is None  # standalone delivered cleanly
+
+    def test_ambiguous_kind_on_success_is_ignored(self):
+        """error_kind is a failure category: a success=True result must never
+        route through the no-fallback branch."""
+        from gateway.platforms.base import SendResult
+
+        async def fake_standalone(*_a, **_kw):
+            return {"success": True}
+
+        standalone_calls = []
+
+        def recording_fake(*a, **kw):
+            standalone_calls.append((a, kw))
+            return fake_standalone(*a, **kw)
+
+        result = SendResult(success=True, message_id="42", error_kind="ambiguous")
+        err = self._run(result, fake_standalone=recording_fake)
+        assert standalone_calls == []
+        assert err is None
 
 
 class TestRunJobSessionPersistence:


### PR DESCRIPTION
## What does this PR do?

Teaches the cron scheduler to honor a producer-declared **ambiguous write** on a live-adapter `SendResult` instead of replaying the whole payload through standalone fallback.

When a live adapter partially delivers a multi-chunk payload and then returns an explicit non-retryable ambiguous-write result, `cron/scheduler.py` treated it like any ordinary unconfirmed failure and re-sent the entire payload from chunk one through the standalone path — duplicating the chunks that had already landed (issue #97230; live incident proven in calebhicks/hermes-agent#2).

## Related Issues and PRs

Closes #97230
Related: #93629 (gateway-loop timeout path — sibling trigger, both needed)
Complements (not duplicates): #75876 (confirmation *timeout* race — different trigger: `future.result()` TimeoutError, not an adapter-returned ambiguous `SendResult`); #93009 (durable transport-receipt ledger — a deliberate non-goal of #97230).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes a bug)
- [x] ✅ Tests (regression coverage added)

## Changes Made

1. **Platform-neutral vocabulary** (`gateway/platforms/base.py`): add `"ambiguous"` to `SEND_ERROR_KINDS` — the existing machine-readable failure categories on `SendResult.error_kind` — with documentation: bytes may or may not be on the wire; replay is unsafe; consumers must record-and-wait, not resend.
2. **Scheduler no-fallback handling** (`cron/scheduler.py`): in the `not send_success` branch of `_deliver_result`, when the failed result carries `error_kind == "ambiguous"` (checked on both the `SendResult` object and dict shapes via the existing shape normalization), the scheduler:
   - logs the unknown outcome at WARNING with the durable receipt preserved;
   - records it in `delivery_errors` (run status stays honest, no "delivered" lie);
   - skips the standalone fallback and any second send path for that target;
   - retryable failures and permanent pre-send refusals keep their existing behavior.
3. **Regression tests** (`tests/cron/test_scheduler.py`): new `TestDeliverResultAmbiguousWrite` covering:
   - object (`SendResult(success=False, retryable=False, error_kind="ambiguous", ...)`) → standalone fallback NOT invoked;
   - dict (`{"success": False, "retryable": False, "error_kind": "ambiguous", ...}`) → same;
   - ordinary unconfirmed failure still falls through to standalone (fallback preservation);
   - `success=True` with `error_kind="ambiguous"` is treated as delivered (error_kind is a failure category).

## How to Test

1. `scripts/run_tests.sh tests/cron/test_scheduler.py -q` — all pass, including the new regression class.
2. Revert the scheduler change (keep the tests): the ambiguous-shape tests FAIL (standalone is awaited — the duplicate), proving the tests catch the bug.

## Checklist

### Code

- [x] Conventional Commits
- [x] Searched open/closed issues and PRs; no open PR fixes this root cause
- [x] Only changes related to this fix (no lockfile churn, no scope creep)
- [x] Added regression coverage
- [x] No new config keys, no telemetry, no adapter-specific branching in cron

### Documentation and Housekeeping

- [x] Docs update N/A — behavior addition to an existing typed contract, documented at the producer/consumer sites
- [x] `cli-config.yaml.example` N/A — no config keys changed