### PR TITLE
fix(tui): show status while idle/auto compaction runs (#97239)

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -96,7 +96,8 @@ _TERMINAL_COMPRESSION_PROVENANCES = frozenset(
 # status as ``kind="compacting"`` (tui_gateway/server.py::_status_update), so
 # drivers like the desktop app can show an explicit "Summarizing…" indicator
 # instead of the transcript appearing to silently reset. Keep the marker phrase
-# intact if you reword COMPACTION_STATUS.
+# intact if you reword COMPACTION_STATUS. Idle/preflight/retry lines do not
+# contain this marker — ``is_compaction_progress_status`` covers those too.
 COMPACTION_STATUS_MARKER = "Compacting context"
 COMPACTION_STATUS = (
     f"🗜️ {COMPACTION_STATUS_MARKER} — summarizing earlier conversation so I can continue..."
@@ -204,6 +205,40 @@ ROUTINE_COMPRESSION_STATUS_SAMPLES = (
         new_ctx=120000, old_ctx=250000
     ),
 )
+
+
+def is_compaction_progress_status(text: str | None) -> bool:
+    """True for in-progress auto-compaction lifecycle lines (not the done edge).
+
+    ``tui_gateway.server._status_update`` re-tags matching ``lifecycle``
+    statuses as ``kind="compacting"`` so TUI and desktop can show a summarizing
+    indicator for the whole pause. Matching only ``COMPACTION_STATUS_MARKER``
+    left idle/preflight/retry lines looking like a hung turn (#97239).
+
+    The terminal ``COMPACTION_DONE_STATUS`` is emitted as ``kind="compacted"``
+    and must not match here.
+    """
+    if not isinstance(text, str):
+        return False
+    body = text.strip()
+    if not body:
+        return False
+    if COMPACTION_STATUS_MARKER in body:
+        return True
+    if body == COMPACTION_DONE_STATUS:
+        return False
+    lowered = body.lower()
+    if "compaction complete" in lowered:
+        return False
+    # Failure-class overflow warning mentions compression but is a blocked
+    # notice, not progress — keep it lifecycle so chat gateways stay loud.
+    if "compression is currently blocked" in lowered:
+        return False
+    return (
+        "compact" in lowered
+        or "compress" in lowered
+        or "context reduced to" in lowered
+    )
 
 
 def _builtin_memory_prompt_snapshot(agent: Any) -> Optional[Tuple[str, str]]:
@@ -5126,6 +5161,7 @@ __all__ = [
     "COMPACTION_STATUS",
     "COMPACTION_DONE_STATUS",
     "COMPACTION_STATUS_MARKER",
+    "is_compaction_progress_status",
     "check_compression_model_feasibility",
     "replay_compression_warning",
     "compress_context",

--- a/tests/tui_gateway/test_compaction_status.py
+++ b/tests/tui_gateway/test_compaction_status.py
@@ -1,9 +1,9 @@
-"""Auto-compaction status re-tagging for the desktop "Summarizing…" indicator.
+"""Auto-compaction status re-tagging for TUI/desktop summarizing indicators.
 
 Auto-compaction reaches the gateway as a generic ``lifecycle`` status. The
-gateway re-tags it as ``kind="compacting"`` so drivers (the desktop app) can
-show an explicit summarizing indicator instead of the transcript appearing to
-silently reset mid-turn.
+gateway re-tags in-progress lines as ``kind="compacting"`` so drivers can
+show an explicit summarizing indicator instead of the turn looking hung
+(#97239). The marker-only match missed idle/preflight/retry wording.
 """
 
 from __future__ import annotations
@@ -51,9 +51,55 @@ def test_compaction_lifecycle_is_retagged(server, monkeypatch):
     assert events == [{"kind": "compacting", "text": COMPACTION_STATUS}]
 
 
+def test_idle_compaction_lifecycle_is_retagged(server, monkeypatch):
+    from agent.conversation_compression import IDLE_COMPACTION_STATUS_TEMPLATE
+
+    events = _capture(server, monkeypatch)
+    text = IDLE_COMPACTION_STATUS_TEMPLATE.format(idle_seconds=747, tokens=44_579)
+    server._status_update("sid", "lifecycle", text)
+
+    assert events == [{"kind": "compacting", "text": text}]
+
+
+def test_preflight_compaction_lifecycle_is_retagged(server, monkeypatch):
+    from agent.conversation_compression import PREFLIGHT_COMPRESSION_STATUS_TEMPLATE
+
+    events = _capture(server, monkeypatch)
+    text = PREFLIGHT_COMPRESSION_STATUS_TEMPLATE.format(
+        tokens=120_000, threshold=100_000
+    )
+    server._status_update("sid", "lifecycle", text)
+
+    assert events == [{"kind": "compacting", "text": text}]
+
+
+def test_compaction_done_is_not_retagged_as_compacting(server, monkeypatch):
+    from agent.conversation_compression import COMPACTION_DONE_STATUS
+
+    events = _capture(server, monkeypatch)
+    server._status_update("sid", "lifecycle", COMPACTION_DONE_STATUS)
+    assert events[0]["kind"] == "lifecycle"
+
+    events.clear()
+    server._status_update("sid", "compacted", COMPACTION_DONE_STATUS)
+    assert events[0]["kind"] == "compacted"
+
+
 def test_other_lifecycle_status_stays_lifecycle(server, monkeypatch):
     events = _capture(server, monkeypatch)
     server._status_update("sid", "lifecycle", "❌ Rate limited after 5 retries")
+
+    assert events[0]["kind"] == "lifecycle"
+
+
+def test_overflow_blocked_warning_stays_lifecycle(server, monkeypatch):
+    from agent.conversation_compression import CONTEXT_OVERFLOW_BLOCKED_WARNING_TEMPLATE
+
+    events = _capture(server, monkeypatch)
+    text = CONTEXT_OVERFLOW_BLOCKED_WARNING_TEMPLATE.format(
+        tokens=85_000, threshold=72_000, reason="cooldown:30"
+    )
+    server._status_update("sid", "lifecycle", text)
 
     assert events[0]["kind"] == "lifecycle"
 
@@ -65,3 +111,24 @@ def test_manual_compressing_kind_is_preserved(server, monkeypatch):
     assert events[0]["kind"] == "compressing"
 
 
+def test_is_compaction_progress_status_covers_routine_in_progress_lines():
+    from agent.conversation_compression import (
+        COMPACTION_DONE_STATUS,
+        CONTEXT_OVERFLOW_BLOCKED_WARNING_TEMPLATE,
+        ROUTINE_COMPRESSION_STATUS_SAMPLES,
+        is_compaction_progress_status,
+    )
+
+    for message in ROUTINE_COMPRESSION_STATUS_SAMPLES:
+        if message == COMPACTION_DONE_STATUS:
+            assert is_compaction_progress_status(message) is False
+        else:
+            assert is_compaction_progress_status(message) is True, message
+
+    assert is_compaction_progress_status(None) is False
+    assert is_compaction_progress_status("") is False
+    assert is_compaction_progress_status("❌ Rate limited after 5 retries") is False
+    overflow = CONTEXT_OVERFLOW_BLOCKED_WARNING_TEMPLATE.format(
+        tokens=85_000, threshold=72_000, reason="ineffective"
+    )
+    assert is_compaction_progress_status(overflow) is False

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2849,12 +2849,12 @@ def _status_update(sid: str, kind: str, text: str | None = None):
         return
     out_kind = kind if text is not None else "status"
     # Auto-compaction reaches us as a generic "lifecycle" status. Re-tag it so
-    # drivers (desktop app) can show an explicit "Summarizing…" indicator —
-    # otherwise a mid-turn compaction looks like the transcript reset itself.
+    # drivers (TUI / desktop) can show an explicit summarizing indicator —
+    # otherwise idle/preflight compaction looks like a hung turn (#97239).
     if out_kind == "lifecycle":
-        from agent.conversation_compression import COMPACTION_STATUS_MARKER
+        from agent.conversation_compression import is_compaction_progress_status
 
-        if COMPACTION_STATUS_MARKER in body:
+        if is_compaction_progress_status(body):
             out_kind = "compacting"
     _emit("status.update", sid, {"kind": out_kind, "text": body})
 

--- a/ui-tui/src/__tests__/appChromeBlockedTimers.test.tsx
+++ b/ui-tui/src/__tests__/appChromeBlockedTimers.test.tsx
@@ -248,6 +248,15 @@ describe('status-chrome timers under an occluding overlay', () => {
     expect(oneSecondTimers(intervalSpy)).toBeGreaterThan(0)
   })
 
+  it('freezes the FaceTicker verb on compacting and skips verb rotation (#97239)', () => {
+    const { output } = mount({ ...busyProps, compacting: true })
+
+    expect(output()).toContain('compacting')
+    // Glyph still ticks at the kaomoji cadence; the rotating-verb timer does not.
+    expect(armedDelays(intervalSpy).filter(delay => delay === 2500)).toHaveLength(1)
+    expect(oneSecondTimers(intervalSpy)).toBeGreaterThan(0)
+  })
+
   it('arms no FaceTicker timer mid-turn while the modal widget slot is open', () => {
     patchOverlayState({ widget: { appId: 'demo', state: null } })
 

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -194,6 +194,40 @@ describe('createGatewayEventHandler', () => {
     } as any)
 
     expect(ctx.system.sys).toHaveBeenCalledWith('compressing 968 messages (~123,400 tok)…')
+    expect(getUiState().compacting).toBe(true)
+  })
+
+  it('keeps auto-compaction status visible until compaction finishes (#97239)', () => {
+    const ctx = buildCtx([])
+    const onEvent = createGatewayEventHandler(ctx)
+    const idleLine = '💤 Resumed after 747s idle — compacting ~44,579 tokens before continuing.'
+
+    vi.useFakeTimers()
+    patchUiState({ busy: true, status: 'running…' })
+
+    try {
+      onEvent({
+        payload: { kind: 'compacting', text: idleLine },
+        type: 'status.update'
+      } as any)
+
+      expect(ctx.system.sys).toHaveBeenCalledWith(idleLine)
+      expect(getUiState().compacting).toBe(true)
+      expect(getUiState().status).toBe(idleLine)
+
+      vi.advanceTimersByTime(4001)
+      expect(getUiState().status).toBe(idleLine)
+      expect(getUiState().compacting).toBe(true)
+
+      onEvent({
+        payload: { kind: 'compacted', text: '✓ Context compaction complete — continuing turn...' },
+        type: 'status.update'
+      } as any)
+
+      expect(getUiState().compacting).toBe(false)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('keeps goal verdict text in transcript but shows a brief idle status (#goal statusbar)', () => {

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -852,10 +852,16 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
 
         setStatus(p.text)
 
-        if (p.kind === 'compressing') {
+        if (p.kind === 'compressing' || p.kind === 'compacting') {
           sys(p.text)
+          turnController.clearStatusTimer()
+          patchUiState({ compacting: true })
 
           return
+        }
+
+        if (p.kind === 'compacted') {
+          patchUiState({ compacting: false })
         }
 
         if (!p.kind || p.kind === 'status') {

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -322,6 +322,9 @@ export interface UiState {
   busy: boolean
   busyInputMode: BusyInputMode
   compact: boolean
+  // Context compaction in progress (idle/preflight/auto). Distinct from
+  // `compact`, which is the /compact layout-density flag.
+  compacting: boolean
   destructiveSlashConfirm: boolean
   detailsMode: DetailsMode
   detailsModeCommandOverride: boolean

--- a/ui-tui/src/app/turnController.ts
+++ b/ui-tui/src/app/turnController.ts
@@ -293,7 +293,7 @@ class TurnController {
       tools: [],
       turnTrail: []
     })
-    patchUiState({ busy: false })
+    patchUiState({ busy: false, compacting: false })
     resetFlowOverlays()
   }
 

--- a/ui-tui/src/app/uiStore.ts
+++ b/ui-tui/src/app/uiStore.ts
@@ -14,6 +14,7 @@ const buildUiState = (): UiState => ({
   busy: false,
   busyInputMode: 'queue',
   compact: false,
+  compacting: false,
   destructiveSlashConfirm: true,
   detailsMode: 'collapsed',
   detailsModeCommandOverride: false,

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -909,7 +909,7 @@ export function useMainApp(gw: GatewayClient) {
       // dead/respawning gateway. recoverSidRef carries the session forward, and
       // resumeById restores sid once the fresh gateway is ready.
       recoveryAtRef.current = plan.attempts
-      patchUiState({ busy: false, sid: null, status: 'gateway exited' })
+      patchUiState({ busy: false, compacting: false, sid: null, status: 'gateway exited' })
 
       if (plan.recover && plan.sid) {
         recoverSidRef.current = plan.sid

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -119,7 +119,17 @@ export const busyIndicatorWidth = (style: IndicatorStyle, hasDuration: boolean):
   return indicatorFrameWidth(style) + verb + duration
 }
 
-function FaceTicker({ color, startedAt, style }: { color: string; startedAt?: null | number; style: IndicatorStyle }) {
+function FaceTicker({
+  color,
+  startedAt,
+  style,
+  verbOverride
+}: {
+  color: string
+  startedAt?: null | number
+  style: IndicatorStyle
+  verbOverride?: string
+}) {
   const [tick, setTick] = useState(() => Math.floor(Math.random() * 1000))
   const [verbTick, setVerbTick] = useState(() => Math.floor(Math.random() * VERBS.length))
   const [now, setNow] = useState(() => Date.now())
@@ -128,8 +138,11 @@ function FaceTicker({ color, startedAt, style }: { color: string; startedAt?: nu
   // Pre-compute cadence + verb-visibility for the active style so an
   // `/indicator` switch re-arms the interval (and skips the verb timer
   // for verb-less styles like `unicode`) without leaving the previous
-  // timer dangling.
+  // timer dangling. A frozen override (idle compaction) always shows the
+  // verb so "compacting…" is visible even in unicode style (#97239).
   const { intervalMs, showVerb } = renderIndicator(style, 0)
+  const freezeVerb = Boolean(verbOverride)
+  const displayVerb = freezeVerb || showVerb
 
   useEffect(() => {
     // An overlay is painted OVER the status rule (the modal widget slot, or a
@@ -147,9 +160,10 @@ function FaceTicker({ color, startedAt, style }: { color: string; startedAt?: nu
 
     const glyph = setInterval(() => setTick(n => n + 1), intervalMs)
     const clock = setInterval(() => setNow(Date.now()), 1000)
-    // Verb timer is gated on `showVerb` — `unicode` style hides the verb
-    // entirely, so cycling `verbTick` would be an avoidable re-render.
-    const verb = showVerb ? setInterval(() => setVerbTick(n => n + 1), FACE_TICK_MS) : null
+    // Verb timer is gated on `displayVerb` — `unicode` style hides the verb
+    // entirely, so cycling `verbTick` would be an avoidable re-render. A
+    // frozen override does not rotate.
+    const verb = displayVerb && !freezeVerb ? setInterval(() => setVerbTick(n => n + 1), FACE_TICK_MS) : null
 
     return () => {
       clearInterval(glyph)
@@ -159,11 +173,11 @@ function FaceTicker({ color, startedAt, style }: { color: string; startedAt?: nu
         clearInterval(verb)
       }
     }
-  }, [intervalMs, isOccluded, showVerb])
+  }, [displayVerb, freezeVerb, intervalMs, isOccluded])
 
   const { frame } = renderIndicator(style, tick)
-  const verb = VERBS[verbTick % VERBS.length] ?? ''
-  const verbSegment = showVerb ? ` ${padVerb(verb)}` : ''
+  const verb = verbOverride ?? VERBS[verbTick % VERBS.length] ?? ''
+  const verbSegment = displayVerb ? ` ${padVerb(verb)}` : ''
   // Leading space keeps a gap between the frame and the duration when the
   // verb segment is hidden (e.g. `unicode` spinner style).  When the verb
   // IS shown, its trailing padding already provides the gap, so the extra
@@ -469,6 +483,7 @@ export function StatusRule({
   cwdLabel,
   cols,
   busy,
+  compacting = false,
   status,
   statusColor,
   model,
@@ -638,7 +653,12 @@ export function StatusRule({
             </Text>
           ) : null}
           {busy ? (
-            <FaceTicker color={statusColor} startedAt={turnStartedAt} style={indicatorStyle} />
+            <FaceTicker
+              color={statusColor}
+              startedAt={turnStartedAt}
+              style={indicatorStyle}
+              verbOverride={compacting ? 'compacting' : undefined}
+            />
           ) : showNotice ? null : (
             <Text color={statusColor} wrap="truncate-end">
               {status}
@@ -862,6 +882,8 @@ interface StatusRuleProps {
   lastTurnEndedAt?: null | number
   liveSessionCount: number
   busy: boolean
+  // Context compaction in progress — FaceTicker freezes on "compacting".
+  compacting?: boolean
   cols: number
   cwdLabel: string
   model: string

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -492,6 +492,7 @@ const StatusRulePane = memo(function StatusRulePane({
         battery={ui.battery ? ui.batteryStatus : null}
         bgCount={ui.bgTasks.size}
         busy={ui.busy}
+        compacting={ui.compacting}
         cols={composer.cols}
         cwdLabel={status.cwdLabel}
         focusView={ui.focusView}


### PR DESCRIPTION
## Summary
- Idle/preflight compaction reached the TUI as a generic `lifecycle` status that did not contain `Compacting context`, so the busy bar kept rotating "cogitating"/"running…" with no hint that the turn was blocked on a minutes-long summary.
- Re-tag those in-progress compression lines as `kind="compacting"`, keep that status until `compacted` (no 4s restore), and freeze the FaceTicker verb on "compacting" so the elapsed clock is visible for the whole pause.

Fixes #97239

## Test plan
- [x] `scripts/run_tests.sh tests/tui_gateway/test_compaction_status.py`
- [x] `npx vitest run` in `ui-tui` for `createGatewayEventHandler` + `appChromeBlockedTimers` (compaction cases)
- [ ] TUI: enable `compression.idle_compact_after_seconds`, grow a large session, send a prompt, confirm the status bar shows `compacting…` with a live elapsed duration instead of a silent hang
- [ ] After compaction finishes, confirm the bar returns to the normal busy ticker and the turn proceeds
