### PR TITLE
fix(video): require image input for i2v-only models

### DIFF
--- a/tests/tools/test_video_generate_schema.py
+++ b/tests/tools/test_video_generate_schema.py
@@ -229,7 +229,19 @@ class TestDynamicParamGating(unittest.TestCase):
             model_meta={"modalities": ["image"]},
         )
         self.assertIn("image_url", schema["parameters"]["properties"])
+        self.assertEqual(
+            schema["parameters"]["required"], ["prompt", "image_url"]
+        )
         self.assertIn("image-to-video only", schema["description"])
+
+    def test_dual_modality_model_keeps_image_url_optional(self):
+        schema = self._schema_with({
+            "modalities": ["text", "image"], "max_reference_images": 0,
+            "supports_audio": False, "supports_negative_prompt": False,
+            "supports_seed": False, "supports_upscale": False,
+        })
+        self.assertIn("image_url", schema["parameters"]["properties"])
+        self.assertEqual(schema["parameters"]["required"], ["prompt"])
 
     def test_no_provider_serves_prompt_only(self):
         with patch.object(vt, "_resolve_active_provider", return_value=None):

--- a/tools/video_generation_tool.py
+++ b/tools/video_generation_tool.py
@@ -586,12 +586,16 @@ def _build_dynamic_video_schema() -> Dict[str, Any]:
 
     properties["model"] = static_props["model"]
 
+    required = ["prompt"]
+    if can_i2v and not t2v:
+        required.append("image_url")
+
     return {
         "description": "\n".join(parts),
         "parameters": {
             "type": "object",
             "properties": properties,
-            "required": ["prompt"],
+            "required": required,
         },
     }
 


### PR DESCRIPTION
## Summary

- require `image_url` in the generated `video_generate` schema when the resolved model supports image input but not text-to-video
- keep `image_url` optional for dual-modality models
- add regression coverage for both schema contracts

Fixes #97252

## Testing

- `python -m pytest -p no:cacheprovider tests/tools/test_video_generate_schema.py tests/tools/test_video_generation_dynamic_schema.py tests/tools/test_video_generation_dispatch.py -q`
- `python -m ruff check tools/video_generation_tool.py tests/tools/test_video_generate_schema.py`