### PR TITLE
fix(whatsapp): keep the bridge alive through listener-less media stream errors

### DIFF
--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -37,6 +37,7 @@ import {
   buildPollPayload,
   createReconnectScheduler,
   createVersionResolver,
+  installProcessGuards,
   buildLocationPayload,
   buildTextSendPayload,
   createBoundedMessageStore,
@@ -266,6 +267,12 @@ function buildLidMap() {
 let lidToPhone = buildLidMap();
 
 const logger = pino({ level: 'warn' });
+
+// Install before anything can throw at the event-loop level: a listener-less
+// 'error' from a Baileys media stream must not kill the bridge and lose the
+// in-memory inbound queue (#97108). Route guard output through pino so it
+// lands in the adapter-captured bridge log (#58936).
+installProcessGuards({ log: (line) => logger.warn(line) });
 
 // Message queue for polling
 const messageQueue = [];

--- a/scripts/whatsapp-bridge/bridge.process_guard.test.mjs
+++ b/scripts/whatsapp-bridge/bridge.process_guard.test.mjs
@@ -1,0 +1,138 @@
+/**
+ * Unit + end-to-end tests for the last-resort process guards (#97108).
+ *
+ * Regression family: saveMedia()'s try/catch (the #59261 guard) contains the
+ * awaited-rejection half of inbound media download failures, but a Baileys
+ * media stream under undici/HTTP2 can emit 'error' with no listener outside
+ * the awaited promise chain. Without an uncaughtException handler that throw
+ * kills the bridge process and loses the in-memory inbound queue — WhatsApp
+ * does not redeliver. These tests pin both halves: the guard's logging
+ * behavior, and — via a real child process reproducing the issue's
+ * deterministic simulation — that a listener-less stream 'error' no longer
+ * kills the process once the guards are installed.
+ *
+ * These tests avoid importing bridge.js (it starts an HTTP server and a
+ * Baileys socket at module load, same reason as bridge.reconnect.test.mjs);
+ * the guards live in bridge_helpers.js for exactly that reason.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+import { installProcessGuards } from './bridge_helpers.js';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+test('installProcessGuards logs uncaught exceptions and keeps the target alive', () => {
+  const target = new EventEmitter();
+  const lines = [];
+  installProcessGuards({ log: (l) => lines.push(l), target });
+
+  const boom = new Error('HTTP/2 stream reset');
+  target.emit('uncaughtException', boom);
+
+  assert.equal(lines.length, 1);
+  assert.match(lines[0], /uncaught exception contained — bridge kept alive/);
+  assert.match(lines[0], /HTTP\/2 stream reset/);
+  assert.ok(lines[0].includes(boom.stack), 'full stack lands in the log');
+});
+
+test('installProcessGuards logs unhandled rejections too', () => {
+  const target = new EventEmitter();
+  const lines = [];
+  installProcessGuards({ log: (l) => lines.push(l), target });
+
+  target.emit('unhandledRejection', new Error('socket hang up'));
+
+  assert.equal(lines.length, 1);
+  assert.match(lines[0], /unhandled rejection contained — bridge kept alive/);
+});
+
+test('non-Error rejection reasons are stringified, not dereferenced', () => {
+  const target = new EventEmitter();
+  const lines = [];
+  installProcessGuards({ log: (l) => lines.push(l), target });
+
+  target.emit('unhandledRejection', 'plain string reason');
+
+  assert.equal(lines.length, 1);
+  assert.match(lines[0], /plain string reason/);
+});
+
+test('a broken log sink never turns the guard into the killer', () => {
+  const target = new EventEmitter();
+  installProcessGuards({
+    log: () => {
+      throw new Error('log pipeline is broken');
+    },
+    target,
+  });
+
+  // The guard must swallow its own logging failure instead of rethrowing.
+  target.emit('uncaughtException', new Error('original failure'));
+});
+
+// Real-process end-to-end anchors. The child script reproduces the issue's
+// deterministic simulation: resolve the awaited download, then on a later
+// tick emit 'error' on a listener-less Readable — the exact escape hatch the
+// saveMedia() try/catch cannot reach.
+
+const guardedChild = `
+import { Readable } from 'node:stream';
+import { installProcessGuards } from './bridge_helpers.js';
+const lines = [];
+installProcessGuards({ log: (l) => lines.push(l), target: process });
+process.on('exit', (code) => {
+  if (code !== 0) return;
+  if (lines.length < 1 || !lines[0].includes('kept alive')) process.exitCode = 2;
+});
+process.nextTick(() => {
+  // Listener-less 'error' outside any awaited promise chain (#97108 repro).
+  new Readable({ read() {} }).emit('error', new Error('HTTP/2 stream reset'));
+});
+setTimeout(() => {
+  // Reaching this timer at all proves the process survived the throw.
+  console.log('ALIVE_AFTER_UNHANDLED_STREAM_ERROR');
+}, 200);
+`;
+
+const bareChild = `
+import { Readable } from 'node:stream';
+process.nextTick(() => {
+  new Readable({ read() {} }).emit('error', new Error('HTTP/2 stream reset'));
+});
+setTimeout(() => {
+  console.log('SHOULD_NOT_GET_HERE');
+}, 200);
+`;
+
+test('end-to-end: guards keep the bridge process alive through a listener-less stream error', () => {
+  const out = execFileSync(
+    process.execPath,
+    ['--input-type=module', '-e', guardedChild],
+    { cwd: here, encoding: 'utf8', timeout: 15000 },
+  );
+  assert.match(out, /ALIVE_AFTER_UNHANDLED_STREAM_ERROR/);
+});
+
+test('negative control: without the guards the same error kills the process', () => {
+  let sawDeath = false;
+  try {
+    execFileSync(
+      process.execPath,
+      ['--input-type=module', '-e', bareChild],
+      { cwd: here, encoding: 'utf8', timeout: 15000 },
+    );
+  } catch (err) {
+    // Node exits non-zero on the unhandled 'error' event — that is the bug.
+    sawDeath = err.status !== 0;
+    assert.ok(sawDeath, 'child should die non-zero without the guards');
+    assert.doesNotMatch(String(err.stdout || ''), /SHOULD_NOT_GET_HERE/);
+    return;
+  }
+  assert.fail('child unexpectedly survived without the guards installed');
+});

--- a/scripts/whatsapp-bridge/bridge_helpers.js
+++ b/scripts/whatsapp-bridge/bridge_helpers.js
@@ -624,3 +624,37 @@ export function createVersionResolver(fetchVersionFn, {
     return cachedVersion;
   };
 }
+
+/**
+ * Last-resort process guards (#97108).
+ *
+ * The awaited-rejection half of inbound media download failures is already
+ * contained in saveMedia(), but downloadMediaMessage() consumes an HTTP
+ * stream internally: under undici/HTTP2 the underlying Readable can emit
+ * 'error' *outside* the awaited promise chain (e.g. the socket resets after
+ * the buffering consumer detached). An 'error' event with no listener throws
+ * at the event-loop level, and with no uncaughtException / unhandledRejection
+ * handler the bridge process dies — taking the in-memory inbound queue
+ * (bridge.js messageQueue) with it, and WhatsApp does not redeliver.
+ *
+ * Log the failure and keep the process alive: the emitter is already gone
+ * and the rest of the bridge is unaffected. The log line also gives
+ * operators the post-mortem trail #58936 asked for.
+ */
+export function installProcessGuards({
+  log = console.error,
+  target = process,
+} = {}) {
+  const report = (kind, value) => {
+    try {
+      const detail = value?.stack ? `${value.stack}` : String(value);
+      log(`⚠️  ${kind} contained — bridge kept alive: ${detail}`);
+    } catch {
+      // The guard itself must never become the thing that kills the process.
+    }
+  };
+  target.on('uncaughtException', (err) => report('uncaught exception', err));
+  target.on('unhandledRejection', (reason) =>
+    report('unhandled rejection', reason)
+  );
+}


### PR DESCRIPTION
## What does this PR do?

Contains the second failure mode of inbound WhatsApp media downloads: a Baileys media stream under undici/HTTP2 can emit `'error'` on a listener-less `Readable` **outside the awaited promise chain**, so the `saveMedia()` try/catch from #59261 never sees it. With no `uncaughtException` handler the throw killed the bridge process, and the in-memory inbound queue (`bridge.js` `messageQueue`) was lost with no redelivery.

The fix installs last-resort process guards (`uncaughtException` + `unhandledRejection`) that log through pino and keep the process alive. Keeping the process alive is deliberate and scoped: the failed emitter is already gone, the rest of the bridge is unaffected (the issue reports this exact guard shape running in production since August 2026 with no side effects), and the alternative — losing every queued inbound message — is unrecoverable because WhatsApp does not redeliver. Routing the guard output through pino also lands these failures in the adapter-captured `bridge.log`, closing the "bridge dies silently with an empty log" post-mortem gap from #58936.

The guards live in `bridge_helpers.js` (pure, injectable `log`/`target`) and are wired in `bridge.js` right after the logger exists — the same placement pattern the reconnect/version guards already use.

**Why a consumption-site listener cannot fix this** (evidence from the issue author, see [their comment](https://github.com/NousResearch/hermes-agent/pull/97255#issuecomment-5529095377)): in the pinned Baileys 7.0.0-rc13, `getHttpStream()` returns the undici body as a `Readable` (`lib/Utils/messages-media.js:297`) and `downloadEncryptedContent()` does `return fetched.pipe(output)` (`:515`) without ever exposing `fetched` — and `pipe()` does not forward `'error'` from the source. The source stream is listener-less **by construction**: there is no consumption-site handle the bridge could attach a listener to. A process-level guard is therefore the only fix available from the bridge side; the alternative would have to land upstream in Baileys.

## Related Issue

Fixes #97108

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `scripts/whatsapp-bridge/bridge_helpers.js` — new `installProcessGuards({ log, target })`: registers `uncaughtException`/`unhandledRejection` handlers that log the full stack with a kept-alive marker; the log call itself is guarded so a broken log sink can never turn the guard into the killer.
- `scripts/whatsapp-bridge/bridge.js` — import + one wiring line: `installProcessGuards({ log: (line) => logger.warn(line) })` installed right after the pino logger is created, before anything can throw at the event-loop level.
- `scripts/whatsapp-bridge/bridge.process_guard.test.mjs` — new tests (details below).

## How to Test

1. `cd scripts/whatsapp-bridge && node --test bridge.process_guard.test.mjs` — Observed result: `6 passed`. This includes:
   - unit tests: both handler kinds log the full stack with the kept-alive marker; non-Error reasons are stringified; a throwing log sink cannot crash the guard;
   - **end-to-end**: a real child process reproduces the issue's deterministic simulation (`nextTick` a listener-less `Readable.emit('error', ...)` after the awaited download resolves) and prints `ALIVE_AFTER_UNHANDLED_STREAM_ERROR` — the process survives;
   - **negative control**: the identical child script *without* the guards exits non-zero (Node's unhandled `'error'` event behavior) — proving the test pins the real bug mechanism, not a tautology.
2. `node --test bridge.reconnect.test.mjs allowlist.test.mjs outbound_ids.test.mjs owner_message_gate.test.mjs bridge.sendqueue.test.mjs` — Observed result: `21 passed` (no regressions in the sibling suites).
   (`bridge.native.test.mjs` fails identically on a clean checkout of `main` in this sandbox — `ERR_MODULE_NOT_FOUND` because `node_modules` isn't installed here — so it is environmental, not caused by this diff.)
3. Ran `node --check` on both modified production files — both pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — N/A for this change (Node-side bridge only; the repo's Python suite doesn't cover `scripts/whatsapp-bridge/`)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5 (Node v22)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (behavior-preserving guard; the function docstring documents the failure mode and rationale)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (Node `process` events are cross-platform)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## For New Skills

N/A — not a skill.

## Screenshots / Logs

```
$ node --test bridge.process_guard.test.mjs
# pass 6
# fail 0

# guarded child (end-to-end) stdout:
ALIVE_AFTER_UNHANDLED_STREAM_ERROR

# negative control (no guards): child exits non-zero on
# "Unhandled 'error' event" — the pre-fix behavior.
```

