### PR TITLE
fix(uv): prefer the user's uv, move the managed one off PATH

### DIFF
--- a/hermes_cli/_early_recovery.py
+++ b/hermes_cli/_early_recovery.py
@@ -23,7 +23,6 @@ in main.py, which runs right after import succeeds.
 
 from __future__ import annotations
 
-import importlib
 import os
 import shutil
 import subprocess
@@ -281,7 +280,7 @@ def _probe_broken_packages() -> list[str]:
     broken: list[str] = []
     for mod_name, attr in LAZY_REFRESH_IMPORT_PROBES:
         try:
-            mod = importlib.import_module(mod_name)
+            mod = __import__(mod_name)
             if not hasattr(mod, attr):
                 raise ImportError(f"{mod_name} missing {attr}")
             if mod_name == "certifi" and _certifi_bundle_broken():
@@ -302,10 +301,22 @@ def _find_uv_binary() -> str | None:
     (``~/.hermes/uv/uv.exe``) or the user has on PATH.  Stdlib-only.
     """
     exe = "uv.exe" if sys.platform == "win32" else "uv"
+
+    hermes_env = os.environ.get("HERMES_HOME", "").strip()
+    if hermes_env:
+        hermes_home = Path(hermes_env)
+    elif sys.platform == "win32":
+        local_appdata = os.environ.get("LOCALAPPDATA", "").strip()
+        base = Path(local_appdata) if local_appdata else Path.home() / "AppData" / "Local"
+        hermes_home = base / "hermes"
+    else:
+        hermes_home = Path.home() / ".hermes"
+
     candidates = [
-        Path.home() / ".hermes" / "uv" / exe,
+        # Private uv in Hermes home (custom HERMES_HOME, %LOCALAPPDATA%/hermes on Windows, ~/.hermes on POSIX)
+        hermes_home / "uv" / exe,
         # Legacy pre-isolation layout; migrated to the private dir on use.
-        Path.home() / ".hermes" / "bin" / exe,
+        hermes_home / "bin" / exe,
         Path.home() / ".local" / "bin" / exe,
         Path.home() / ".cargo" / "bin" / exe,
     ]

--- a/hermes_cli/_early_recovery.py
+++ b/hermes_cli/_early_recovery.py
@@ -299,10 +299,12 @@ def _find_uv_binary() -> str | None:
     uv-managed base interpreters carry an ``EXTERNALLY-MANAGED`` marker, so
     the stdlib ``pip`` fallback below refuses to touch them.  In that state
     the only sanctioned installer is uv itself, which Hermes already vendors
-    (``~/.hermes/bin/uv.exe``) or the user has on PATH.  Stdlib-only.
+    (``~/.hermes/uv/uv.exe``) or the user has on PATH.  Stdlib-only.
     """
     exe = "uv.exe" if sys.platform == "win32" else "uv"
     candidates = [
+        Path.home() / ".hermes" / "uv" / exe,
+        # Legacy pre-isolation layout; migrated to the private dir on use.
         Path.home() / ".hermes" / "bin" / exe,
         Path.home() / ".local" / "bin" / exe,
         Path.home() / ".cargo" / "bin" / exe,

--- a/hermes_cli/_install_repair.py
+++ b/hermes_cli/_install_repair.py
@@ -190,9 +190,10 @@ def ensure_windows_bin_launchers(
     On Windows, ``hermes`` resolves through launchers derived from the venv
     console scripts — never ``venv\\Scripts`` itself on PATH, which would
     shadow the user's ``python`` (#83797). The canonical launcher home is
-    the managed binary dir — the default Hermes root's ``bin``
-    (``%LOCALAPPDATA%\\hermes\\bin``, next to the managed uv) — which lives
-    OUTSIDE the git checkout so no git operation can ever touch it. It is
+    the default Hermes root's ``bin`` (``%LOCALAPPDATA%\\hermes\\bin`` — the
+    managed uv lives in the sibling ``uv\\`` dir since the uv-isolation
+    change) which lives OUTSIDE the git checkout so no git operation can
+    ever touch it. It is
     a per-machine dir shared by every profile: ``get_hermes_home()`` would
     point inside ``profiles\\<name>`` under ``hermes -p``, so the anchor
     here is :func:`hermes_constants.get_default_hermes_root`.

--- a/hermes_cli/managed_uv.py
+++ b/hermes_cli/managed_uv.py
@@ -1598,8 +1598,8 @@ def _install_uv(target: Path) -> None:
     """Bootstrap uv into *target* using the official standalone installer.
 
     Uses ``UV_UNMANAGED_INSTALL`` (POSIX) or ``UV_INSTALL_DIR`` (Windows)
-    so the astral installer writes the binary directly into
-    ``$HERMES_HOME/bin/`` instead of ``~/.local/bin/``.
+    so the astral installer writes the binary directly into the private
+    managed dir (``$HERMES_HOME/uv``) instead of ``~/.local/bin/``.
     """
     system = platform.system()
     env = {

--- a/hermes_cli/managed_uv.py
+++ b/hermes_cli/managed_uv.py
@@ -112,6 +112,11 @@ def _uv_runs(path: str) -> bool:
     *depends* on one: a uv that is on PATH yet cannot even report its version
     (broken install, wrong arch, quarantined binary) is not "suitable" and
     falls through to the managed fallback.
+
+    Worst case is a bounded 15s: a *hung* PATH uv (network-sandboxed or
+    quarantined binary that never answers) stalls resolution for 15s before
+    falling through.  Resolution runs only at update/install/bootstrap time
+    — never on a per-turn hot path — so the bound is deliberate.
     """
     try:
         result = subprocess.run(
@@ -124,6 +129,23 @@ def _uv_runs(path: str) -> bool:
     except (OSError, subprocess.SubprocessError):
         return False
     return result.returncode == 0
+
+
+def _is_managed_uv(uv_bin: str | Path) -> bool:
+    """True when *uv_bin* is Hermes' own private managed uv binary.
+
+    Comparison is case-insensitive on Windows (``os.path.normcase`` lowercases
+    there and is a no-op on POSIX) — the same rule :func:`resolve_uv_engine`
+    applies so a PATH hit that IS our binary is never mistaken for the user's.
+    This is the ownership gate: engine-mutating operations (catalog refresh,
+    self-update) may only run against the managed binary, never the user's.
+    """
+    try:
+        return os.path.normcase(str(Path(uv_bin).resolve())) == os.path.normcase(
+            str(managed_uv_path().resolve())
+        )
+    except OSError:
+        return False
 
 
 @dataclass
@@ -1306,15 +1328,21 @@ def _refresh_managed_uv_catalog(uv_bin: str) -> bool:
     provisioning retry can now see a different catalog.  ``False`` means a
     retry would resolve identically and is not worth the download cycle.
     """
-    managed = managed_uv_path()
-    try:
-        if Path(uv_bin).resolve() != managed.resolve():
-            return False
-    except OSError:
+    # Ownership red line: this re-bootstraps the engine (the only supported
+    # refresh path for UV_UNMANAGED_INSTALL binaries), so it may only ever
+    # run against Hermes' own managed binary.  A foreign engine — typically
+    # the user's own uv under tier-1 — is used strictly read-only here and
+    # never re-bootstrapped.
+    if not _is_managed_uv(uv_bin):
+        logger.debug(
+            "refusing to refresh uv catalog for foreign binary %s "
+            "(read-only: the user's uv is never re-bootstrapped)",
+            uv_bin,
+        )
         return False
     before = _uv_version_string(uv_bin)
     try:
-        _install_uv(managed)
+        _install_uv(managed_uv_path())
     except Exception as exc:
         logger.warning("managed uv refresh failed: %s", exc)
         return False
@@ -1402,6 +1430,22 @@ def repair_vulnerable_runtime(
     root = Path(project_root) if project_root is not None else _PROJECT_ROOT
     live = Path(venv_dir) if venv_dir is not None else _default_live_venv(root)
     live_python = _venv_python(live)
+
+    # Ownership red line: the repair may run with the USER's own uv as the
+    # engine (tier-1 — there is often no managed binary at all), but that
+    # engine is strictly read-only.  Every uv invocation below writes only
+    # into Hermes' own directories: managed_python_env() pins the python
+    # install dir, shims and registry, and the venv/sync target the
+    # checkout-scoped candidate.  The only engine-mutating operation in this
+    # path (_refresh_managed_uv_catalog) refuses a foreign binary.  A future
+    # edit that adds any engine-mutating call (``uv self update``,
+    # ``uv tool install``, ...) MUST gate it on _is_managed_uv(uv_bin) first.
+    if not _is_managed_uv(uv_bin):
+        logger.info(
+            "runtime repair engine is the user's uv (%s) — used strictly "
+            "read-only; all writes stay inside Hermes' own directories",
+            uv_bin,
+        )
     if not (root / "pyproject.toml").is_file() or not live_python.is_file():
         return RuntimeRepairResult("not-applicable")
 

--- a/hermes_cli/managed_uv.py
+++ b/hermes_cli/managed_uv.py
@@ -1,11 +1,21 @@
 """Hermes-managed uv and Python runtime repair.
 
-Hermes owns its own uv binary at ``$HERMES_HOME/bin/uv`` (or ``uv.exe`` on
-Windows).  Every code path that needs uv resolves it from that single location.
-If the binary is missing, ``ensure_uv()`` bootstraps it via the official
-standalone installer with ``UV_UNMANAGED_INSTALL`` / ``UV_INSTALL_DIR`` pointed
-at ``$HERMES_HOME/bin`` so the installer writes directly there — no PATH
-probing, no conda guards, no multi-location resolution chains.
+Hermes keeps its own uv binary at ``$HERMES_HOME/uv/uv`` (or ``uv.exe`` on
+Windows) as a private fallback, but **prefers the user's own uv when one is
+present and usable** — tier-1 of the same contract the managed-Node installer
+uses. Resolution order (see :func:`resolve_uv_engine`):
+
+1. A usable ``uv`` on PATH (runs ``uv --version``) → use it, never modify it;
+2. Otherwise the managed binary at ``$HERMES_HOME/uv/uv`` → use it, and only
+   this one may be self-updated (``resolve_uv`` is managed-only, so
+   ``update_managed_uv`` can never touch a toolchain Hermes does not own);
+3. Otherwise provision the managed binary into ``$HERMES_HOME/uv`` — a
+   private directory that is never registered on PATH, so shells always
+   resolve the user's own uv (or none), never Hermes' copy.
+
+Legacy installs that placed the managed uv at ``$HERMES_HOME/bin/uv`` (the
+pre-isolation layout — bin is a persisted User PATH entry on Windows) are
+migrated to the private location on first use.
 
 The Python backing the install is different: it is shared by every Hermes
 profile because the checkout's ``venv`` is shared.  Runtime repair therefore
@@ -52,11 +62,28 @@ _MACOS_MANAGED_PYTHON_IDENTIFIER = "com.nousresearch.hermes.managed-python"
 
 
 def managed_uv_path() -> Path:
-    """Return the path where Hermes keeps *its* uv binary.
+    """Return the path where Hermes keeps *its own* uv binary.
 
-    ``$HERMES_HOME/bin/uv`` on POSIX, ``$HERMES_HOME\\bin\\uv.exe`` on
-    Windows.  The directory may not exist yet — callers should use
+    ``$HERMES_HOME/uv/uv`` on POSIX, ``$HERMES_HOME\\uv\\uv.exe`` on
+    Windows.  This is a **private** location: it is never registered on PATH,
+    so interactive shells always resolve the user's own uv (or none) rather
+    than Hermes' copy.  The directory may not exist yet — callers should use
     ``ensure_uv()`` to bootstrap it.
+    """
+    home = get_hermes_home()
+    if platform.system() == "Windows":
+        return home / "uv" / "uv.exe"
+    return home / "uv" / "uv"
+
+
+def legacy_managed_uv_path() -> Path:
+    """Return the pre-isolation managed-uv location, if it is still around.
+
+    Installers before the uv isolation change placed the managed binary at
+    ``$HERMES_HOME/bin/uv(.exe)`` — ``bin`` is a persisted User PATH entry on
+    Windows, so that layout silently shadowed the user's own uv in every new
+    shell.  Callers migrate a legacy binary to :func:`managed_uv_path` once;
+    this accessor exists so the migration can recognize the old shape.
     """
     home = get_hermes_home()
     if platform.system() == "Windows":
@@ -67,12 +94,108 @@ def managed_uv_path() -> Path:
 def resolve_uv() -> Optional[str]:
     """Return the managed uv path if it exists, else ``None``.
 
-    No side effects — pure lookup.
+    No side effects — pure lookup.  **Managed-only**: this never resolves the
+    user's own uv on PATH, which is exactly what keeps
+    :func:`update_managed_uv` from ever modifying a toolchain Hermes does not
+    own.
     """
     p = managed_uv_path()
     if p.is_file() and os.access(p, os.X_OK):
         return str(p)
     return None
+
+
+def _uv_runs(path: str) -> bool:
+    """Smoke-test a uv binary: ``uv --version`` must succeed.
+
+    Hermes never modifies a toolchain it does not own — but it also never
+    *depends* on one: a uv that is on PATH yet cannot even report its version
+    (broken install, wrong arch, quarantined binary) is not "suitable" and
+    falls through to the managed fallback.
+    """
+    try:
+        result = subprocess.run(
+            [path, "--version"],
+            capture_output=True,
+            text=True, encoding="utf-8", errors="replace",
+            check=False,
+            timeout=15,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return result.returncode == 0
+
+
+@dataclass
+class UvEngine:
+    """The uv binary Hermes should use, plus the ownership rules for it.
+
+    ``engine`` is ``"user"`` (the user's own uv on PATH — read-only use, never
+    self-updated, never moved), ``"managed"`` (Hermes' private binary — may be
+    self-updated), or ``"none"`` (nothing usable yet — bootstrap required).
+    ``path`` is the resolved binary or ``None``; ``can_self_update`` encodes the
+    ownership rule so callers never need to re-derive it.
+    """
+
+    engine: str
+    path: Optional[str]
+    can_self_update: bool = False
+
+
+def resolve_uv_engine() -> UvEngine:
+    """Resolve which uv Hermes should use, tier-1 first.
+
+    Order:
+
+    1. **User's uv** — a ``uv`` on PATH that passes the ``--version`` smoke
+       test.  Preferred whenever present (the user's machine, the user's
+       choice), but never modified.  A PATH hit that resolves to Hermes' own
+       managed or legacy binary is *not* "user" — it is the managed engine
+       (and the legacy case is migrated on next bootstrap).
+    2. **Managed uv** — the private binary at :func:`managed_uv_path`.
+    3. **None** — nothing usable; callers bootstrap the managed binary.
+
+    No side effects — migration/install live in the callers.
+    """
+    managed = managed_uv_path()
+    legacy = legacy_managed_uv_path()
+    try:
+        on_path = shutil.which("uv")
+    except Exception:
+        on_path = None
+    if on_path:
+        resolved = Path(on_path)
+        # Windows paths are case-insensitive: normcase lowercases there and is
+        # a no-op on POSIX, so a PATH hit that IS our own binary (possibly
+        # spelled differently) is never mistaken for the user's.
+        is_managed = (
+            os.path.normcase(str(resolved)) == os.path.normcase(str(managed))
+            or os.path.normcase(str(resolved)) == os.path.normcase(str(legacy))
+        )
+        if not is_managed and _uv_runs(on_path):
+            return UvEngine("user", on_path, can_self_update=False)
+    if managed.is_file() and os.access(managed, os.X_OK):
+        return UvEngine("managed", str(managed), can_self_update=True)
+    return UvEngine("none", None, can_self_update=False)
+
+
+def _migrate_legacy_managed_uv() -> bool:
+    """Move a pre-isolation ``bin/uv(.exe)`` to the private location, once.
+
+    Best-effort: a locked or busy legacy binary simply stays put (a concurrent
+    process may hold it); the resolver keeps finding it via PATH and the next
+    bootstrap retries.  Never deletes anything.
+    """
+    legacy = legacy_managed_uv_path()
+    target = managed_uv_path()
+    if target.is_file() or not legacy.is_file():
+        return False
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        os.replace(str(legacy), str(target))
+        return True
+    except OSError:
+        return False
 
 
 def managed_python_install_dir(project_root: Path | None = None) -> Path:
@@ -271,11 +394,24 @@ def _ensure_uv_path(
     *,
     repair_observer: Callable[[RuntimeRepairResult], None] | None = None,
 ) -> Optional[str]:
-    """Resolve the managed uv path, installing it if necessary (plain ``str``/``None``)."""
-    existing = resolve_uv()
-    if existing:
-        return existing
+    """Resolve the uv Hermes should use, tier-1 first (plain ``str``/``None``).
 
+    Order: the user's own uv on PATH (read-only use — never modified), then
+    the managed private binary, then bootstrap the managed binary into the
+    private location (migrating a legacy ``bin/uv`` first if present).
+    """
+    engine = resolve_uv_engine()
+    if engine.path:
+        return engine.path
+
+    # Nothing usable yet — provision the managed binary.  A legacy
+    # pre-isolation binary at $HERMES_HOME/bin/uv (Windows: bin is on the
+    # persisted User PATH) is moved to the private location first, and a
+    # successful move means the managed uv already exists — no reinstall.
+    _migrate_legacy_managed_uv()
+    migrated = resolve_uv()
+    if migrated:
+        return migrated
     target = managed_uv_path()
     target.parent.mkdir(parents=True, exist_ok=True)
 
@@ -319,7 +455,13 @@ def ensure_uv(
     *,
     repair_observer: Callable[[RuntimeRepairResult], None] | None = None,
 ):
-    """Return the managed uv path, installing it first if necessary.
+    """Return the uv Hermes should use, tier-1 first (install as fallback).
+
+    Resolution order: the user's own uv on PATH (read-only use, never
+    modified — see :func:`resolve_uv_engine`), then the managed private
+    binary, then bootstrap the managed binary.  The managed binary lives at
+    ``$HERMES_HOME/uv`` — a private directory never registered on PATH — so
+    Hermes' own copy can never shadow the user's uv in their shells.
 
     On **POSIX** the result is a :class:`_UvResult` (a ``str`` subclass) that is
     both usable directly as the path *and* unpackable as
@@ -394,9 +536,12 @@ def update_managed_uv(
     """Run ``uv self update`` on the managed uv binary.
 
     Call this during ``hermes update`` so the managed copy stays current.
-    Returns the managed path when uv is available and ``None`` otherwise.
-    A self-update failure is non-fatal because the old version still works.
-    ``repair_observer``, when provided, receives the runtime repair result.
+    **This never touches the user's own uv**: resolution goes through
+    ``resolve_uv()``, which is managed-only, so a toolchain Hermes does not
+    own is never self-updated (ownership red line).  Returns the managed path
+    when uv is available and ``None`` otherwise.  A self-update failure is
+    non-fatal because the old version still works.  ``repair_observer``, when
+    provided, receives the runtime repair result.
 
     The network self-update is skipped when it succeeded within the last
     ``UV_SELF_UPDATE_INTERVAL_SECONDS`` (7 days) unless ``force=True``; the

--- a/hermes_cli/managed_uv.py
+++ b/hermes_cli/managed_uv.py
@@ -546,14 +546,22 @@ def update_managed_uv(
     The network self-update is skipped when it succeeded within the last
     ``UV_SELF_UPDATE_INTERVAL_SECONDS`` (7 days) unless ``force=True``; the
     vulnerable-runtime repair probe below ALWAYS runs — CVE-driven runtime
-    repair must never be gated behind the freshness stamp.
+    repair must never be gated behind the freshness stamp or behind the
+    managed binary's existence: with tier-1 (the user's own uv on PATH) there
+    is often no managed uv at all, and the repair must still run.
     """
+    # Self-update target: managed-only.  The user's own uv is never
+    # self-updated (ownership red line).
     existing = resolve_uv()
-    if not existing:
-        # Not installed yet — ensure_uv() will handle that elsewhere.
-        return None
 
-    if force or not _uv_self_update_is_fresh():
+    # Repair probe engine: ANY usable uv (user's or managed).  The probe and
+    # any Python provisioning it triggers go through managed_python_env(), so
+    # every write lands in Hermes' own directories even when the engine is the
+    # user's uv; _refresh_managed_uv_catalog() likewise refuses to touch a
+    # foreign binary.  Read-only use of the user's engine — never modified.
+    engine = resolve_uv_engine()
+
+    if existing and (force or not _uv_self_update_is_fresh()):
         try:
             result = subprocess.run(
                 [existing, "self", "update"],
@@ -580,12 +588,17 @@ def update_managed_uv(
                 "uv self update failed (rc=%d): %s", result.returncode, result.stderr
             )
 
+    repair_uv = engine.path or existing
+    if not repair_uv:
+        # No uv at all yet — ensure_uv() will handle provisioning elsewhere.
+        return None
+
     # Keep this hook inside the long-standing API. During an update, main.py is
     # already imported from the old checkout, then ``git pull`` replaces this
     # module on disk before the updater imports it. Calling the repair here is
     # what makes the migration happen on that first update.
     try:
-        repair = repair_vulnerable_runtime(existing)
+        repair = repair_vulnerable_runtime(repair_uv)
         if repair_observer is not None:
             repair_observer(repair)
         if repair.status == "failed":

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1661,7 +1661,7 @@ def setup_terminal_backend(config: dict):
             print_info("Installing vercel SDK...")
             import subprocess
 
-            # Managed uv first: $HERMES_HOME/bin is never on PATH, so a bare
+            # Managed uv first: $HERMES_HOME/uv is never on PATH, so a bare
             # which() misses the uv Hermes installed. Bootstrapping one is
             # welcome here — this is the interactive setup wizard, already
             # mid-install, and the alternative tier is a pip that a `uv venv`

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -877,7 +877,7 @@ def _pip_install(
     venv_root = Path(sys.executable).parent.parent
     uv_env = {**os.environ, "VIRTUAL_ENV": str(venv_root)}
 
-    # Managed uv first: $HERMES_HOME/bin is never on PATH, so a bare which()
+    # Managed uv first: $HERMES_HOME/uv is never on PATH, so a bare which()
     # misses the uv Hermes installed and prefers a system one when both exist.
     # ensure_uv() rather than a pure lookup because this runs during setup,
     # where installing uv is in scope — and tier 2 is a pip that the Windows

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -3582,7 +3582,7 @@ def _ensure_uv_for_termux(pip_cmd: list[str]) -> str | None:
     """Best-effort uv bootstrap on Termux for faster update installs.
 
     The normal path (``ensure_uv()`` in managed_uv) installs the managed
-    standalone uv into ``$HERMES_HOME/bin/uv``, but on Termux the official
+    standalone uv into ``$HERMES_HOME/uv/uv``, but on Termux the official
     installer may not work (glibc vs bionic).  Prefer a uv already on PATH
     (e.g. ``pkg install uv``); only if there is none do we fall back to a
     wheel-only ``pip install uv`` so we never source-build the Rust crate.

--- a/scripts/ci/test_install_ps1_uv_isolation.ps1
+++ b/scripts/ci/test_install_ps1_uv_isolation.ps1
@@ -47,6 +47,7 @@ function Get-RewrittenDefinition {
 Invoke-Expression (Get-RewrittenDefinition -Name 'Get-ManagedUvPath')
 Invoke-Expression (Get-RewrittenDefinition -Name 'Test-UserUvUsable')
 Invoke-Expression (Get-RewrittenDefinition -Name 'Move-LegacyManagedUv')
+Invoke-Expression (Get-RewrittenDefinition -Name 'Set-UvPythonIsolationEnv')
 
 # install.ps1's write helpers (failure paths only here).
 function Write-Info    { Write-Host "[info]  $args" }
@@ -96,6 +97,27 @@ Write-Host "install.ps1 Get-ManagedUvPath (private location)"
 $managed = Get-ManagedUvPath
 Assert-Equal (Join-Path (Join-Path $script:HermesHome "uv") "uv.exe") $managed `
     'managed uv lives in the private uv\ dir, not bin\'
+
+Write-Host ""
+Write-Host "install.ps1 Set-UvPythonIsolationEnv (uv python write containment)"
+
+# Save the harness's own env; restore after.
+$savedUvInstallDir = $env:UV_PYTHON_INSTALL_DIR
+$savedUvBin = $env:UV_PYTHON_INSTALL_BIN
+$savedUvRegistry = $env:UV_PYTHON_INSTALL_REGISTRY
+
+# An inherited value must be OVERRIDDEN, not respected -- Hermes never writes
+# into a dir the user configured for their own toolchain.
+$env:UV_PYTHON_INSTALL_DIR = "C:\Users\me\my-own-pythons"
+Set-UvPythonIsolationEnv
+Assert-Equal (Join-Path $script:HermesHome "python") $env:UV_PYTHON_INSTALL_DIR `
+    'inherited UV_PYTHON_INSTALL_DIR overridden to Hermes\python'
+Assert-Equal "0" $env:UV_PYTHON_INSTALL_BIN 'UV_PYTHON_INSTALL_BIN=0 (no ~/.local/bin shims)'
+Assert-Equal "0" $env:UV_PYTHON_INSTALL_REGISTRY 'UV_PYTHON_INSTALL_REGISTRY=0 (no Windows registry)'
+
+$env:UV_PYTHON_INSTALL_DIR = $savedUvInstallDir
+$env:UV_PYTHON_INSTALL_BIN = $savedUvBin
+$env:UV_PYTHON_INSTALL_REGISTRY = $savedUvRegistry
 
 Write-Host ""
 Write-Host "install.ps1 Test-UserUvUsable (tier-1 PATH probe)"

--- a/scripts/ci/test_install_ps1_uv_isolation.ps1
+++ b/scripts/ci/test_install_ps1_uv_isolation.ps1
@@ -1,0 +1,155 @@
+# Behavioral test for install.ps1's managed-uv isolation helpers.
+#
+# Run:  pwsh -NoProfile -File scripts/ci/test_install_ps1_uv_isolation.ps1
+#
+# Not wired into the default CI lane -- the Linux runners have no PowerShell
+# host. It runs on any machine with pwsh, and on a Windows runner if one is
+# ever added.
+#
+# Same AST-lift methodology as test_install_ps1_path_migration.ps1: parses
+# install.ps1, lifts the real function bodies, and exercises the shipped
+# logic -- private managed path, tier-1 user-uv preference, legacy bin\uv
+# migration -- for real.  These helpers have no registry calls, so they are
+# lifted verbatim (0/0) and driven with a temp HERMES_HOME and a shadowed
+# Get-Command for the PATH probe.
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$installPs1 = Join-Path $PSScriptRoot '..' 'install.ps1' | Resolve-Path
+
+function Find-InstallFunction {
+    param([string]$Name)
+    $parsed = [System.Management.Automation.Language.Parser]::ParseFile(
+        $installPs1, [ref]$null, [ref]$null)
+    return $parsed.Find({
+        param($n)
+        $n -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+        $n.Name -eq $Name
+    }, $true)
+}
+
+function Get-RewrittenDefinition {
+    param([string]$Name, [int]$ExpectedReads = 0, [int]$ExpectedWrites = 0)
+    $fn = Find-InstallFunction -Name $Name
+    if (-not $fn) {
+        throw "$Name not found in $installPs1"
+    }
+    $definition = $fn.Extent.Text
+    $reads  = ([regex]'\[Environment\]::GetEnvironmentVariable\("Path", "User"\)').Matches($definition).Count
+    $writes = ([regex]'\[Environment\]::SetEnvironmentVariable\("Path", ([^,]+), "User"\)').Matches($definition).Count
+    if ($reads -ne $ExpectedReads -or $writes -ne $ExpectedWrites) {
+        throw "expected $ExpectedReads read(s) and $ExpectedWrites write(s) in ${Name}; found $reads read(s), $writes write(s). Update this harness."
+    }
+    return $definition
+}
+
+Invoke-Expression (Get-RewrittenDefinition -Name 'Get-ManagedUvPath')
+Invoke-Expression (Get-RewrittenDefinition -Name 'Test-UserUvUsable')
+Invoke-Expression (Get-RewrittenDefinition -Name 'Move-LegacyManagedUv')
+
+# install.ps1's write helpers (failure paths only here).
+function Write-Info    { Write-Host "[info]  $args" }
+function Write-Success { Write-Host "[ok]    $args" }
+function Write-Warn    { Write-Host "[warn]  $args" }
+
+# Point $HermesHome (script scope — the lifted functions read it) at a
+# temp dir.
+$script:HermesHome = Join-Path ([System.IO.Path]::GetTempPath()) ("hermes-uv-test-" + [guid]::NewGuid().ToString("N"))
+New-Item -ItemType Directory -Force -Path $script:HermesHome | Out-Null
+
+# Shadowed Get-Command for the tier-1 PATH probe: returns a fake uv source,
+# or $null when the test wants "no user uv".
+$script:FakeUvSource = $null
+function Get-Command {
+    param($Name, $ErrorAction)
+    if ($Name -eq 'uv' -and $script:FakeUvSource) {
+        return [pscustomobject]@{ Source = $script:FakeUvSource }
+    }
+    return $null
+}
+
+$script:Failures = 0
+
+function Assert-Equal {
+    param($Expected, $Actual, [string]$Name)
+    if ($Expected -ceq $Actual) {
+        Write-Host "  PASS  $Name"
+    } else {
+        Write-Host "  FAIL  $Name"
+        Write-Host "        expected: [$Expected]"
+        Write-Host "        actual:   [$Actual]"
+        $script:Failures++
+    }
+}
+
+function Assert-True {
+    param([bool]$Actual, [string]$Name)
+    if ($Actual) { Write-Host "  PASS  $Name" }
+    else {
+        Write-Host "  FAIL  $Name"
+        $script:Failures++
+    }
+}
+
+Write-Host "install.ps1 Get-ManagedUvPath (private location)"
+$managed = Get-ManagedUvPath
+Assert-Equal (Join-Path (Join-Path $script:HermesHome "uv") "uv.exe") $managed `
+    'managed uv lives in the private uv\ dir, not bin\'
+
+Write-Host ""
+Write-Host "install.ps1 Test-UserUvUsable (tier-1 PATH probe)"
+
+# No uv on PATH -> $null.
+$script:FakeUvSource = $null
+Assert-Equal $null (Test-UserUvUsable) 'no uv on PATH: not usable'
+
+# A real user uv that runs --version is adopted read-only.
+$userUv = Join-Path $script:HermesHome "user-uv.exe"
+Set-Content -Path $userUv -Value "@echo off`r`necho uv 0.12.6" -Encoding Ascii
+$script:FakeUvSource = $userUv
+Assert-Equal $userUv (Test-UserUvUsable) 'user uv on PATH: adopted'
+
+# A PATH hit that is Hermes' OWN legacy binary is NOT "user".
+$legacy = Join-Path $script:HermesHome "bin\uv.exe"
+New-Item -ItemType Directory -Force -Path (Split-Path $legacy -Parent) | Out-Null
+Set-Content -Path $legacy -Value "@echo off`r`necho uv 0.1.2" -Encoding Ascii
+$script:FakeUvSource = $legacy
+Assert-Equal $null (Test-UserUvUsable) 'PATH hit at legacy bin\uv.exe is not user'
+
+# A PATH hit that is Hermes' OWN managed binary is NOT "user".
+New-Item -ItemType Directory -Force -Path "$script:HermesHome\uv" | Out-Null
+Set-Content -Path $managed -Value "@echo off`r`necho uv 0.9.9" -Encoding Ascii
+$script:FakeUvSource = $managed
+Assert-Equal $null (Test-UserUvUsable) 'PATH hit at managed uv\uv.exe is not user'
+
+Write-Host ""
+Write-Host "install.ps1 Move-LegacyManagedUv (one-time migration)"
+
+# Legacy bin\uv.exe -> private dir.
+Remove-Item $managed -Force
+$script:FakeUvSource = $null
+Assert-True (Move-LegacyManagedUv) 'legacy bin\uv.exe moved'
+Assert-True (Test-Path $managed) 'managed path exists after migration'
+Assert-Equal $false (Test-Path $legacy) 'legacy path gone after migration'
+
+# No-op when the managed binary already exists.
+Set-Content -Path $legacy -Value "@echo off`r`necho uv 0.1.2" -Encoding Ascii
+Assert-Equal $false (Move-LegacyManagedUv) 'no-op when managed already present'
+Assert-Equal $true (Test-Path $legacy) 'legacy left in place when managed present'
+
+# No-op when there is no legacy binary.
+Remove-Item $legacy -Force
+Assert-Equal $false (Move-LegacyManagedUv) 'no-op when no legacy binary'
+
+# Cleanup
+Remove-Item -Recurse -Force $script:HermesHome -ErrorAction SilentlyContinue
+
+if ($script:Failures -gt 0) {
+    Write-Host ""
+    Write-Host "$script:Failures assertion(s) failed"
+    exit 1
+}
+
+Write-Host ""
+Write-Host "all assertions passed"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1190,7 +1190,26 @@ function Test-ManagedNodeInUse {
 # at the top to populate $script:UvCmd from the managed location.
 # Throws if uv is not findable -- the caller's stage then surfaces a
 # clean error via the stage-driver's try/catch.
+function Set-UvPythonIsolationEnv {
+    # Contain every uv python write inside Hermes' own tree, regardless of
+    # whether the uv ENGINE is Hermes' managed binary or the user's own uv
+    # (tier-1).  uv respects UV_PYTHON_INSTALL_DIR / _BIN / _REGISTRY for all
+    # python acquisition: with these set, `uv python install` and
+    # `uv venv --python` write into $HermesHome\python and never touch the
+    # user's uv python store, ~/.local/bin shims, or the Windows python
+    # registry.  Overrides any inherited values -- Hermes must never write
+    # into a directory the user configured for their own toolchain.
+    # Mirrors managed_python_env() in hermes_cli/managed_uv.py -- keep in sync.
+    $env:UV_PYTHON_INSTALL_DIR = Join-Path $HermesHome "python"
+    $env:UV_PYTHON_INSTALL_BIN = "0"
+    $env:UV_PYTHON_INSTALL_REGISTRY = "0"
+}
+
 function Resolve-UvCmd {
+    # Isolate all uv python writes (install / venv acquisition) inside
+    # Hermes' tree up front, whatever engine this process ends up using.
+    Set-UvPythonIsolationEnv
+
     # Already resolved (default invocation path: Install-Uv ran earlier
     # in the same process and set $script:UvCmd).
     if ($script:UvCmd) {

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -741,12 +741,69 @@ function Get-PowerShellHostExe {
     return "powershell"
 }
 
+function Get-ManagedUvPath {
+    # Private location, never on PATH.  Mirrors managed_uv_path() in
+    # hermes_cli/managed_uv.py -- keep the two in sync.
+    return Join-Path $HermesHome "uv\uv.exe"
+}
+
+function Test-UserUvUsable {
+    # Tier-1: the user's OWN uv on PATH (one that actually runs `uv --version`)
+    # is preferred and used read-only -- never installed over, never updated.
+    # A PATH hit that resolves to Hermes' own managed or legacy binary is NOT
+    # "user" (an upgrade can find the old bin\uv.exe this way); that is the
+    # managed engine and is handled by the migration below.
+    $cmd = Get-Command uv -ErrorAction SilentlyContinue
+    if (-not $cmd -or -not $cmd.Source -or -not (Test-Path $cmd.Source)) {
+        return $null
+    }
+    $managed = Get-ManagedUvPath
+    $legacy = Join-Path $HermesHome "bin\uv.exe"
+    if ($cmd.Source -eq $legacy -or $cmd.Source -eq $managed) {
+        return $null
+    }
+    try {
+        $null = & $cmd.Source --version
+        return $cmd.Source
+    } catch {
+        return $null
+    }
+}
+
+function Move-LegacyManagedUv {
+    # One-time migration from the pre-isolation layout.  Installers before the
+    # uv isolation change placed the managed binary at $HermesHome\bin\uv.exe;
+    # bin is a persisted User PATH entry, so that layout silently shadowed the
+    # user's own uv in every new shell.  Move it into the private directory
+    # (never on PATH).  Best-effort: a locked legacy binary stays put and the
+    # next run retries.  Never deletes anything.
+    $legacy = Join-Path $HermesHome "bin\uv.exe"
+    $target = Get-ManagedUvPath
+    if (-not (Test-Path $legacy) -or (Test-Path $target)) { return $false }
+    try {
+        New-Item -ItemType Directory -Path (Split-Path $target -Parent) -Force | Out-Null
+        Move-Item -LiteralPath $legacy -Destination $target -Force
+        return $true
+    } catch {
+        Write-Warn "Could not migrate legacy managed uv from $legacy : $($_.Exception.Message)"
+        return $false
+    }
+}
+
 function Install-Uv {
-    # Hermes owns its own uv at $HermesHome\bin\uv.exe.  Always install there --
-    # no PATH probing, no conda guards, no multi-location resolution chains.
-    # The runtime update path (hermes_cli/managed_uv.py) looks in the same
-    # place, so install.ps1 and `hermes update` stay in sync.
-    $managedUv = Join-Path $HermesHome "bin\uv.exe"
+    # Tier-1: a usable user uv on PATH wins -- install nothing, touch nothing.
+    # The managed binary is only provisioned when the user has no working uv.
+    $userUv = Test-UserUvUsable
+    if ($userUv) {
+        $script:UvCmd = $userUv
+        Write-Success "Using uv from PATH ($userUv)"
+        return $true
+    }
+
+    # Managed binary lives in a private directory that is never registered on
+    # PATH.  The runtime update path (hermes_cli/managed_uv.py) looks in the
+    # same place, so install.ps1 and `hermes update` stay in sync.
+    $managedUv = Get-ManagedUvPath
 
     if (Test-Path $managedUv) {
         $script:UvCmd = $managedUv
@@ -755,15 +812,23 @@ function Install-Uv {
         return $true
     }
 
-    Write-Info "Installing managed uv into $HermesHome\bin ..."
-    New-Item -ItemType Directory -Path (Join-Path $HermesHome "bin") -Force | Out-Null
+    # Upgrade path: migrate a pre-isolation bin\uv.exe into the private dir.
+    if (Move-LegacyManagedUv) {
+        $script:UvCmd = $managedUv
+        $version = & $managedUv --version
+        Write-Success "Managed uv migrated from $HermesHome\bin ($version)"
+        return $true
+    }
+
+    Write-Info "Installing managed uv into $(Split-Path $managedUv -Parent) ..."
+    New-Item -ItemType Directory -Path (Split-Path $managedUv -Parent) -Force | Out-Null
 
     # UV_INSTALL_DIR tells the astral installer to place the binary
-    # directly into $HermesHome\bin instead of ~/.local/bin.
+    # directly into the private managed dir instead of ~/.local/bin.
     $prevEAP = $ErrorActionPreference
     try {
         $ErrorActionPreference = "Continue"
-        $env:UV_INSTALL_DIR = Join-Path $HermesHome "bin"
+        $env:UV_INSTALL_DIR = Split-Path $managedUv -Parent
         # Spawn via the resolved host exe (see Get-PowerShellHostExe) rather
         # than a bare `powershell`, which isn't guaranteed to be on PATH under
         # PowerShell 7 / pwsh-only setups.
@@ -801,7 +866,7 @@ function Install-Uv {
         # on PATH, or at ~/.local/bin (the astral default location when
         # UV_INSTALL_DIR was ignored by an older installer) -- copy it into
         # the managed location so the managed-first invariant holds
-        # (hermes_cli/managed_uv.py looks only at $HermesHome\bin\uv.exe).
+        # (hermes_cli/managed_uv.py looks only at the private managed dir).
         if (-not (Test-Path $managedUv)) {
             $existingUv = $null
             $uvOnPath = Get-Command uv -CommandType Application -ErrorAction SilentlyContinue |
@@ -1139,10 +1204,24 @@ function Resolve-UvCmd {
         # Stale; fall through to re-discover.
     }
 
-    # Check the managed location first -- this is where Install-Uv puts it.
-    $managedUv = Join-Path $HermesHome "bin\uv.exe"
+    # Tier-1: the user's own uv on PATH wins (read-only use).  Re-checked
+    # here because cross-process stages may not have seen Install-Uv's choice.
+    $userUv = Test-UserUvUsable
+    if ($userUv) {
+        $script:UvCmd = $userUv
+        return
+    }
+
+    # Check the managed location first -- private dir, never on PATH.
+    $managedUv = Get-ManagedUvPath
     if (Test-Path $managedUv) {
         $script:UvCmd = $managedUv
+        return
+    }
+
+    # Upgrade path: migrate a pre-isolation bin\uv.exe into the private dir.
+    if (Move-LegacyManagedUv) {
+        $script:UvCmd = Get-ManagedUvPath
         return
     }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -561,11 +561,14 @@ install_uv() {
 
     # Contain uv python writes inside Hermes' own tree, whatever uv ENGINE is
     # used (tier-1: possibly the user's own uv).  Root FHS installs already
-    # pin this in resolve_install_layout (world-readable /usr/local/share);
-    # everyone else gets $HERMES_HOME/python so `uv python install` and
-    # `uv venv --python` never write into the user's uv python store,
-    # ~/.local/bin shims, or the Windows registry.
-    if [ -z "${UV_PYTHON_INSTALL_DIR:-}" ]; then
+    # pin this in resolve_install_layout (world-readable /usr/local/share —
+    # keep that pin); everyone else OVERRIDES any inherited value with
+    # $HERMES_HOME/python, so `uv python install` and `uv venv --python`
+    # never write into the user's uv python store, ~/.local/bin shims, or the
+    # Windows registry.  Same contract as install.ps1's
+    # Set-UvPythonIsolationEnv: Hermes must never write into a directory the
+    # user configured for their own toolchain, even when they exported one.
+    if [ "$ROOT_FHS_LAYOUT" != "true" ]; then
         export UV_PYTHON_INSTALL_DIR="$HERMES_HOME/python"
     fi
     export UV_PYTHON_INSTALL_BIN=0

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -559,11 +559,26 @@ install_uv() {
         return 0
     fi
 
-    # Hermes owns its own uv at $HERMES_HOME/bin/uv.  Always install there —
-    # no PATH probing, no conda guards, no multi-location resolution chains.
-    # The runtime update path (hermes_cli/managed_uv.py) looks in the same
-    # place, so install.sh and `hermes update` stay in sync.
-    local _managed_uv="$HERMES_HOME/bin/uv"
+    # Tier-1: a usable user uv on PATH wins — install nothing, touch nothing.
+    # A PATH hit that resolves to Hermes' own managed/legacy binary is not
+    # "user"; that is the managed engine (migrated/used below).
+    if command -v uv >/dev/null 2>&1; then
+        local _on_path_uv
+        _on_path_uv="$(command -v uv)"
+        local _managed_path="$HERMES_HOME/uv/uv" _legacy_path="$HERMES_HOME/bin/uv"
+        if [ "$_on_path_uv" != "$_managed_path" ] && [ "$_on_path_uv" != "$_legacy_path" ] \
+                && "$_on_path_uv" --version >/dev/null 2>&1; then
+            UV_CMD="$_on_path_uv"
+            UV_VERSION=$($UV_CMD --version 2>/dev/null)
+            log_success "Using uv from PATH ($UV_CMD)"
+            return 0
+        fi
+    fi
+
+    # Managed binary lives in a private directory that is never registered on
+    # PATH.  The runtime update path (hermes_cli/managed_uv.py) looks in the
+    # same place, so install.sh and `hermes update` stay in sync.
+    local _managed_uv="$HERMES_HOME/uv/uv"
 
     if [ -x "$_managed_uv" ]; then
         UV_CMD="$_managed_uv"
@@ -572,8 +587,21 @@ install_uv() {
         return 0
     fi
 
-    log_info "Installing managed uv into $HERMES_HOME/bin ..."
-    mkdir -p "$HERMES_HOME/bin"
+    # Upgrade path: migrate a pre-isolation $HERMES_HOME/bin/uv (bin is a
+    # persisted PATH entry on Windows, so that layout shadowed the user's uv)
+    # into the private directory.  Best-effort; a locked file retries next run.
+    if [ -x "$HERMES_HOME/bin/uv" ] && [ ! -e "$_managed_uv" ]; then
+        mkdir -p "$HERMES_HOME/uv"
+        if mv "$HERMES_HOME/bin/uv" "$_managed_uv" 2>/dev/null; then
+            UV_CMD="$_managed_uv"
+            UV_VERSION=$($UV_CMD --version 2>/dev/null)
+            log_success "Managed uv migrated from $HERMES_HOME/bin ($UV_VERSION)"
+            return 0
+        fi
+    fi
+
+    log_info "Installing managed uv into $HERMES_HOME/uv ..."
+    mkdir -p "$HERMES_HOME/uv"
 
     # Two-stage: download the installer, then run it.  Piping
     # `curl | sh` masks curl failures (sh exits 0 on empty stdin)
@@ -591,7 +619,7 @@ install_uv() {
     fi
     # UV_UNMANAGED_INSTALL tells the astral installer to place the binary
     # directly into $HERMES_HOME/bin instead of ~/.local/bin.
-    if UV_UNMANAGED_INSTALL="$HERMES_HOME/bin" sh "$_uv_installer" >>"$_uv_install_log" 2>&1; then
+    if UV_UNMANAGED_INSTALL="$HERMES_HOME/uv" sh "$_uv_installer" >>"$_uv_install_log" 2>&1; then
         rm -f "$_uv_installer"
         if [ -x "$_managed_uv" ]; then
             UV_CMD="$_managed_uv"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -559,6 +559,18 @@ install_uv() {
         return 0
     fi
 
+    # Contain uv python writes inside Hermes' own tree, whatever uv ENGINE is
+    # used (tier-1: possibly the user's own uv).  Root FHS installs already
+    # pin this in resolve_install_layout (world-readable /usr/local/share);
+    # everyone else gets $HERMES_HOME/python so `uv python install` and
+    # `uv venv --python` never write into the user's uv python store,
+    # ~/.local/bin shims, or the Windows registry.
+    if [ -z "${UV_PYTHON_INSTALL_DIR:-}" ]; then
+        export UV_PYTHON_INSTALL_DIR="$HERMES_HOME/python"
+    fi
+    export UV_PYTHON_INSTALL_BIN=0
+    export UV_PYTHON_INSTALL_REGISTRY=0
+
     # Tier-1: a usable user uv on PATH wins — install nothing, touch nothing.
     # A PATH hit that resolves to Hermes' own managed/legacy binary is not
     # "user"; that is the managed engine (migrated/used below).

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -205,7 +205,7 @@ class TestCmdUpdateTermuxUvBootstrap:
 
         pkg_uv = "/data/data/com.termux/files/usr/bin/uv"
         monkeypatch.setattr(hm, "_is_termux_env", lambda env=None: True)
-        # Production resolve_uv only checks $HERMES_HOME/bin/uv; model an empty
+        # Production resolve_uv only checks $HERMES_HOME/uv/uv; model an empty
         # managed dir so the PATH probe is what surfaces the packaged uv.
         monkeypatch.setattr("hermes_cli.managed_uv.resolve_uv", lambda: None)
         monkeypatch.setattr("shutil.which", lambda name: pkg_uv if name == "uv" else None)

--- a/tests/hermes_cli/test_managed_uv.py
+++ b/tests/hermes_cli/test_managed_uv.py
@@ -741,6 +741,72 @@ class TestRuntimeRepair:
         assert fresh_backup.exists(), "fresh backup may be an in-flight repair"
         assert sentinel.read_text(encoding="utf-8") == "live"
 
+    def test_repair_uses_user_uv_read_only(self, tmp_path):
+        """Tier-1 red line: with the USER's uv as the repair engine, the
+        repair still runs to completion, but the engine itself is never
+        mutated and every uv write is env-pinned inside Hermes' own
+        checkout-scoped directories."""
+        from hermes_cli.managed_uv import repair_vulnerable_runtime
+
+        root, live, _ = _make_runtime_install(tmp_path)
+        (root / "uv.lock").write_text("# lock\n", encoding="utf-8")
+        current = _runtime_info(live / "bin" / "python", (3, 50, 4))
+        fixed = _runtime_info(root / "generation" / "bin" / "python", (3, 53, 1))
+        user_uv = "/usr/local/bin/uv"
+
+        calls: list[tuple[list, dict]] = []
+
+        def fake_run(argv, **kwargs):
+            calls.append((list(argv), kwargs.get("env") or {}))
+            if argv[:1] == [user_uv] and argv[1:3] == ["python", "find"]:
+                # The resolved interpreter must live inside the generation dir
+                # that this invocation's env pins (managed_python_env).
+                generation = Path(kwargs["env"]["UV_PYTHON_INSTALL_DIR"])
+                python = generation / "bin" / "python"
+                python.parent.mkdir(parents=True, exist_ok=True)
+                python.write_text("candidate interpreter", encoding="utf-8")
+                return MagicMock(returncode=0, stdout=str(python))
+            if argv[:1] == [user_uv] and argv[1] == "venv":
+                # The real `uv venv` creates the candidate dir; the cutover
+                # renames it into place, so it must exist.
+                Path(argv[2]).mkdir(parents=True, exist_ok=True)
+            return MagicMock(returncode=0)
+
+        with patch(
+                 "hermes_cli.managed_uv.probe_sqlite_runtime",
+                 side_effect=[current, current, fixed],
+             ), \
+             patch(
+                 "hermes_cli.managed_uv._smoke_candidate_venv",
+                 return_value=(True, "", fixed),
+             ), \
+             patch("hermes_cli.managed_uv.subprocess.run", side_effect=fake_run), \
+             patch("hermes_cli.managed_uv._macos_sign_managed_python", return_value=False):
+            result = repair_vulnerable_runtime(user_uv, project_root=root)
+
+        assert result.status == "repaired", result.detail
+
+        uv_calls = [c for c in calls if c[0][:1] == [user_uv]]
+        assert uv_calls, "repair must have driven the user's uv engine"
+
+        # Never mutate the engine: no `uv self update`, no `uv tool *`.
+        mutating = [
+            argv for argv, _ in uv_calls
+            if argv[1:3] == ["self", "update"] or argv[1] == "tool"
+        ]
+        assert mutating == [], f"user uv must never be mutated: {mutating}"
+
+        # Every write is env-pinned inside the checkout's .hermes-runtime.
+        hermes_runtime = str((root / ".hermes-runtime").resolve())
+        for argv, env in uv_calls:
+            assert env["UV_PYTHON_INSTALL_DIR"].startswith(hermes_runtime), argv
+            assert env["UV_PYTHON_INSTALL_BIN"] == "0"
+            assert env["UV_PYTHON_INSTALL_REGISTRY"] == "0"
+        # The old venv was cut over and parked backup reclaimed — the repair
+        # completed through the real rename pipeline.
+        assert result.backup_venv is not None
+        assert not result.backup_venv.exists()
+
     def test_successful_repair_removes_parked_backup(self, tmp_path):
         """After a successful cutover the parked venv is removed instead of
         leaking ~1 GB at the project root forever (issue #73109)."""
@@ -1322,6 +1388,22 @@ class TestRefreshManagedUvCatalog:
             uv_path = managed_uv.managed_uv_path()
             _make_executable(uv_path)
             assert managed_uv._refresh_managed_uv_catalog(str(uv_path)) is False
+
+
+    def test_refresh_refuses_foreign_binary(self, tmp_path):
+        """Ownership red line: catalog refresh re-bootstraps the engine, so a
+        foreign (user's) uv is refused — the user's toolchain is never
+        re-bootstrapped, even when provisioning failed and a retry would
+        otherwise want a fresh catalog."""
+        import hermes_cli.managed_uv as managed_uv
+
+        with patch("hermes_cli.managed_uv.get_hermes_home", return_value=tmp_path), \
+             patch("hermes_cli.managed_uv._install_uv") as mock_install, \
+             patch("hermes_cli.managed_uv._uv_version_string") as mock_version:
+            assert managed_uv._refresh_managed_uv_catalog("/usr/local/bin/uv") is False
+
+        mock_install.assert_not_called()
+        mock_version.assert_not_called()
 
 
 @pytest.mark.skipif(sys.platform == "win32",

--- a/tests/hermes_cli/test_managed_uv.py
+++ b/tests/hermes_cli/test_managed_uv.py
@@ -76,11 +76,11 @@ def _make_runtime_install(
 class TestManagedUvPath:
     # POSIX arm of the name mapping; the Windows arm (uv.exe) is exercised
     # for real by TestEnsureUvWindowsSafe on the Windows lane.
-    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only: bin/uv name")
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only: uv/uv name")
     def test_posix(self, tmp_path):
         with patch("hermes_cli.managed_uv.get_hermes_home", return_value=tmp_path):
             from hermes_cli.managed_uv import managed_uv_path
-            assert managed_uv_path() == tmp_path / "bin" / "uv"
+            assert managed_uv_path() == tmp_path / "uv" / "uv"
 
 
 class TestMacOSManagedPythonSigning:
@@ -158,14 +158,14 @@ class TestMacOSManagedPythonSigning:
 class TestResolveUv:
 
     def test_existing_executable(self, tmp_path):
-        _make_executable(tmp_path / "bin" / "uv")
+        _make_executable(tmp_path / "uv" / "uv")
         with patch("hermes_cli.managed_uv.get_hermes_home", return_value=tmp_path):
             from hermes_cli.managed_uv import resolve_uv
             result = resolve_uv()
-            assert result == str(tmp_path / "bin" / "uv")
+            assert result == str(tmp_path / "uv" / "uv")
 
     def test_non_executable_file_returns_none(self, tmp_path):
-        uv = tmp_path / "bin" / "uv"
+        uv = tmp_path / "uv" / "uv"
         uv.parent.mkdir(parents=True)
         uv.write_text("not a binary")
         # Ensure no execute bit
@@ -183,6 +183,7 @@ class TestEnsureUv:
 
     def test_installs_if_missing(self, tmp_path):
         with patch("hermes_cli.managed_uv.get_hermes_home", return_value=tmp_path), \
+             patch("hermes_cli.managed_uv.shutil.which", return_value=None), \
              patch("hermes_cli.managed_uv.repair_vulnerable_runtime", return_value=_RRR("not-applicable")), \
              patch("hermes_cli.managed_uv._install_uv") as mock_install:
             # Simulate the installer creating the binary
@@ -192,7 +193,7 @@ class TestEnsureUv:
 
             from hermes_cli.managed_uv import ensure_uv
             path = ensure_uv()
-            assert path == str(tmp_path / "bin" / "uv")
+            assert path == str(tmp_path / "uv" / "uv")
             mock_install.assert_called_once()
 
     def test_install_reports_runtime_repair_to_observer(self, tmp_path):
@@ -215,6 +216,9 @@ class TestEnsureUv:
             "hermes_cli.managed_uv.get_hermes_home",
             return_value=tmp_path,
         ), patch(
+            "hermes_cli.managed_uv.shutil.which",
+            return_value=None,
+        ), patch(
             "hermes_cli.managed_uv._install_uv",
             side_effect=fake_install,
         ), patch(
@@ -223,7 +227,7 @@ class TestEnsureUv:
         ):
             path = ensure_uv(repair_observer=observed.append)
 
-        assert path == str(tmp_path / "bin" / "uv")
+        assert path == str(tmp_path / "uv" / "uv")
         assert observed == [repair]
 
 
@@ -250,25 +254,28 @@ class TestEnsureUvUpdateBoundary:
     """
 
     def test_success_usable_as_single_value(self, tmp_path):
-        _make_executable(tmp_path / "bin" / "uv")
+        _make_executable(tmp_path / "uv" / "uv")
         with patch("hermes_cli.managed_uv.get_hermes_home", return_value=tmp_path), \
+             patch("hermes_cli.managed_uv.shutil.which", return_value=None), \
              patch("hermes_cli.managed_uv.repair_vulnerable_runtime", return_value=_RRR("not-applicable")):
             from hermes_cli.managed_uv import ensure_uv
             uv_bin = ensure_uv()
-            assert uv_bin == str(tmp_path / "bin" / "uv")
+            assert uv_bin == str(tmp_path / "uv" / "uv")
             assert bool(uv_bin) is True
 
     def test_success_unpacks_as_legacy_two_tuple(self, tmp_path):
-        _make_executable(tmp_path / "bin" / "uv")
+        _make_executable(tmp_path / "uv" / "uv")
         with patch("hermes_cli.managed_uv.get_hermes_home", return_value=tmp_path), \
+             patch("hermes_cli.managed_uv.shutil.which", return_value=None), \
              patch("hermes_cli.managed_uv.repair_vulnerable_runtime", return_value=_RRR("not-applicable")):
             from hermes_cli.managed_uv import ensure_uv
             uv_bin, fresh = ensure_uv()  # old: uv_bin, fresh_bootstrap = ensure_uv()
-            assert uv_bin == str(tmp_path / "bin" / "uv")
+            assert uv_bin == str(tmp_path / "uv" / "uv")
             assert fresh is False
 
     def test_failure_unpacks_without_raising(self, tmp_path):
         with patch("hermes_cli.managed_uv.get_hermes_home", return_value=tmp_path), \
+             patch("hermes_cli.managed_uv.shutil.which", return_value=None), \
              patch("hermes_cli.managed_uv.repair_vulnerable_runtime", return_value=_RRR("not-applicable")), \
              patch("hermes_cli.managed_uv._install_uv", side_effect=RuntimeError("network down")):
             from hermes_cli.managed_uv import ensure_uv
@@ -310,8 +317,9 @@ class TestEnsureUvWindowsSafe:
         host that reported it."""
         import subprocess
         # On Windows the managed binary is uv.exe.
-        _make_executable(tmp_path / "bin" / "uv.exe")
+        _make_executable(tmp_path / "uv" / "uv.exe")
         with patch("hermes_cli.managed_uv.get_hermes_home", return_value=tmp_path), \
+             patch("hermes_cli.managed_uv.shutil.which", return_value=None), \
              patch("hermes_cli.managed_uv.repair_vulnerable_runtime", return_value=_RRR("not-applicable")):
             from hermes_cli.managed_uv import _UvResult, ensure_uv
             uv_bin = ensure_uv()
@@ -319,6 +327,138 @@ class TestEnsureUvWindowsSafe:
             # The exact operation that crashed in the field must now succeed.
             cmdline = subprocess.list2cmdline([uv_bin, "pip", "install", "-e", "."])
             assert "pip" in cmdline and "install" in cmdline
+
+
+# ---------------------------------------------------------------------------
+# resolve_uv_engine / legacy migration / tier-1 ensure_uv
+# ---------------------------------------------------------------------------
+
+class TestResolveUvEngine:
+    """Tier-1-first resolution: the user's own uv on PATH wins, is never
+    self-updated, and a PATH hit that is Hermes' own managed/legacy binary is
+    not treated as 'user'."""
+
+    def test_user_uv_on_path_wins(self, tmp_path, monkeypatch):
+        from hermes_cli.managed_uv import resolve_uv_engine
+
+        monkeypatch.setattr("hermes_cli.managed_uv.shutil.which", lambda name: "/usr/local/bin/uv")
+        monkeypatch.setattr("hermes_cli.managed_uv._uv_runs", lambda path: True)
+        engine = resolve_uv_engine()
+        assert engine.engine == "user"
+        assert engine.path == "/usr/local/bin/uv"
+        assert engine.can_self_update is False
+
+    def test_broken_user_uv_falls_through(self, tmp_path, monkeypatch):
+        from hermes_cli.managed_uv import resolve_uv_engine
+
+        monkeypatch.setattr("hermes_cli.managed_uv.shutil.which", lambda name: "/usr/local/bin/uv")
+        monkeypatch.setattr("hermes_cli.managed_uv._uv_runs", lambda path: False)
+        engine = resolve_uv_engine()
+        assert engine.engine == "none"
+
+    def test_path_hit_at_managed_location_is_not_user(self, tmp_path, monkeypatch):
+        """If Hermes' own managed binary is somehow on PATH, tier-1 must not
+        label it 'user' (which would freeze self-update of our own binary)."""
+        from hermes_cli.managed_uv import managed_uv_path, resolve_uv_engine
+
+        managed = tmp_path / "uv" / "uv"
+        managed.parent.mkdir(parents=True)
+        managed.write_text("#!/bin/sh\necho uv 0.1.2\n")
+        managed.chmod(0o755)
+        with patch("hermes_cli.managed_uv.get_hermes_home", return_value=tmp_path):
+            monkeypatch.setattr("hermes_cli.managed_uv.shutil.which", lambda name: str(managed))
+            monkeypatch.setattr("hermes_cli.managed_uv._uv_runs", lambda path: True)
+            engine = resolve_uv_engine()
+        assert engine.engine == "managed"
+        assert engine.can_self_update is True
+
+    def test_path_hit_at_legacy_location_is_not_user(self, tmp_path, monkeypatch):
+        from hermes_cli.managed_uv import legacy_managed_uv_path, resolve_uv_engine
+
+        legacy = tmp_path / "bin" / "uv"
+        legacy.parent.mkdir(parents=True)
+        legacy.write_text("#!/bin/sh\necho uv 0.1.2\n")
+        legacy.chmod(0o755)
+        with patch("hermes_cli.managed_uv.get_hermes_home", return_value=tmp_path):
+            monkeypatch.setattr("hermes_cli.managed_uv.shutil.which", lambda name: str(legacy))
+            monkeypatch.setattr("hermes_cli.managed_uv._uv_runs", lambda path: True)
+            engine = resolve_uv_engine()
+        # Managed binary absent -> none, and the caller migrates + provisions.
+        assert engine.engine == "none"
+
+
+class TestMigrateLegacyManagedUv:
+    def test_moves_legacy_bin_uv_to_private_dir(self, tmp_path):
+        from hermes_cli.managed_uv import _migrate_legacy_managed_uv
+
+        legacy = tmp_path / "bin" / "uv"
+        legacy.parent.mkdir(parents=True)
+        legacy.write_text("#!/bin/sh\necho uv 0.1.2\n")
+        legacy.chmod(0o755)
+        with patch("hermes_cli.managed_uv.get_hermes_home", return_value=tmp_path):
+            moved = _migrate_legacy_managed_uv()
+        assert moved is True
+        assert (tmp_path / "uv" / "uv").exists()
+        assert not legacy.exists()
+
+    def test_noop_when_managed_already_present(self, tmp_path):
+        from hermes_cli.managed_uv import _migrate_legacy_managed_uv
+
+        legacy = tmp_path / "bin" / "uv"
+        legacy.parent.mkdir(parents=True)
+        legacy.write_text("#!/bin/sh\necho uv 0.1.2\n")
+        managed = tmp_path / "uv" / "uv"
+        managed.parent.mkdir(parents=True)
+        managed.write_text("#!/bin/sh\necho uv 0.9.9\n")
+        with patch("hermes_cli.managed_uv.get_hermes_home", return_value=tmp_path):
+            moved = _migrate_legacy_managed_uv()
+        assert moved is False
+        assert legacy.exists() and managed.exists()
+
+
+class TestEnsureUvTier1:
+    def test_uses_user_uv_without_provisioning_managed(self, tmp_path, monkeypatch):
+        """Tier-1: a usable user uv means NO managed install happens at all."""
+        from hermes_cli.managed_uv import ensure_uv
+
+        monkeypatch.setattr("hermes_cli.managed_uv.shutil.which", lambda name: "/usr/local/bin/uv")
+        monkeypatch.setattr("hermes_cli.managed_uv._uv_runs", lambda path: True)
+        with patch("hermes_cli.managed_uv._install_uv") as mock_install:
+            path = ensure_uv()
+        assert path == "/usr/local/bin/uv"
+        mock_install.assert_not_called()
+
+    def test_broken_user_uv_provisions_managed(self, tmp_path, monkeypatch):
+        from hermes_cli.managed_uv import ensure_uv
+
+        monkeypatch.setattr("hermes_cli.managed_uv.shutil.which", lambda name: "/usr/local/bin/uv")
+        monkeypatch.setattr("hermes_cli.managed_uv._uv_runs", lambda path: False)
+
+        def fake_install(target):
+            _make_executable(target)
+
+        with patch("hermes_cli.managed_uv.get_hermes_home", return_value=tmp_path), \
+             patch("hermes_cli.managed_uv._install_uv", side_effect=fake_install), \
+             patch("hermes_cli.managed_uv.repair_vulnerable_runtime", return_value=_RRR("not-applicable")):
+            path = ensure_uv()
+        assert path == str(tmp_path / "uv" / "uv")
+
+    def test_legacy_binary_migrated_then_reused(self, tmp_path, monkeypatch):
+        """A legacy bin/uv is moved to the private dir and used — no reinstall."""
+        from hermes_cli.managed_uv import ensure_uv
+
+        monkeypatch.setattr("hermes_cli.managed_uv.shutil.which", lambda name: None)
+        legacy = tmp_path / "bin" / "uv"
+        legacy.parent.mkdir(parents=True)
+        legacy.write_text("#!/bin/sh\necho uv 0.1.2\n")
+        legacy.chmod(0o755)
+        with patch("hermes_cli.managed_uv.get_hermes_home", return_value=tmp_path), \
+             patch("hermes_cli.managed_uv._install_uv") as mock_install, \
+             patch("hermes_cli.managed_uv.repair_vulnerable_runtime", return_value=_RRR("not-applicable")):
+            path = ensure_uv()
+        assert path == str(tmp_path / "uv" / "uv")
+        assert not legacy.exists()
+        mock_install.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -334,7 +474,7 @@ class TestUpdateManagedUv:
         vulnerable-runtime repair probe still runs (CVE repair is never gated)."""
         from hermes_cli.managed_uv import RuntimeRepairResult, update_managed_uv
 
-        uv = tmp_path / "bin" / "uv"
+        uv = tmp_path / "uv" / "uv"
         _make_executable(uv)
         # Fresh stamp under the isolated HERMES_HOME.
         import hermes_constants
@@ -361,7 +501,7 @@ class TestUpdateManagedUv:
 
         from hermes_cli.managed_uv import UV_SELF_UPDATE_INTERVAL_SECONDS, update_managed_uv
 
-        uv = tmp_path / "bin" / "uv"
+        uv = tmp_path / "uv" / "uv"
         _make_executable(uv)
         import hermes_constants
         stamp = hermes_constants.get_hermes_home() / "cache" / ".uv_self_update_stamp"
@@ -675,13 +815,13 @@ class TestRuntimeCutover:
 
 class TestInstallUvInternals:
     def test_posix_sets_uv_unmanaged_install(self, tmp_path):
-        target = tmp_path / "bin" / "uv"
+        target = tmp_path / "uv" / "uv"
         with patch("hermes_cli.managed_uv._install_uv_posix") as mock_posix:
             from hermes_cli.managed_uv import _install_uv
             _install_uv(target)
             mock_posix.assert_called_once()
             call_env = mock_posix.call_args[0][0]
-            assert call_env["UV_UNMANAGED_INSTALL"] == str(tmp_path / "bin")
+            assert call_env["UV_UNMANAGED_INSTALL"] == str(tmp_path / "uv")
 
 
 class TestRuntimeRequestMinorLine:

--- a/tests/hermes_cli/test_managed_uv.py
+++ b/tests/hermes_cli/test_managed_uv.py
@@ -483,6 +483,7 @@ class TestUpdateManagedUv:
         stamp.touch()
 
         with patch("hermes_cli.managed_uv.get_hermes_home", return_value=tmp_path), \
+             patch("hermes_cli.managed_uv.shutil.which", return_value=None), \
              patch("hermes_cli.managed_uv.subprocess.run") as mock_run, \
              patch(
                  "hermes_cli.managed_uv.repair_vulnerable_runtime",
@@ -511,6 +512,7 @@ class TestUpdateManagedUv:
         _os.utime(stamp, (old, old))
 
         with patch("hermes_cli.managed_uv.get_hermes_home", return_value=tmp_path), \
+             patch("hermes_cli.managed_uv.shutil.which", return_value=None), \
              patch("hermes_cli.managed_uv.repair_vulnerable_runtime", return_value=_RRR("not-applicable")), \
              patch("hermes_cli.managed_uv.subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(returncode=0, stdout="uv 0.2.0")
@@ -518,6 +520,30 @@ class TestUpdateManagedUv:
 
         assert mock_run.call_args_list[0][0][0] == [str(uv), "self", "update"]
         assert stamp.stat().st_mtime > old + 30, "successful self-update must refresh the stamp"
+
+
+    def test_repair_runs_with_user_uv_when_no_managed_exists(self, tmp_path, monkeypatch):
+        """Tier-1 regression: with only the USER's uv available (no managed
+        binary), the CVE-driven repair probe must still run — never gated
+        behind the managed binary's existence."""
+        from hermes_cli.managed_uv import RuntimeRepairResult, update_managed_uv
+
+        user_uv = "/usr/local/bin/uv"
+        monkeypatch.setattr("hermes_cli.managed_uv.shutil.which", lambda name: user_uv)
+        monkeypatch.setattr("hermes_cli.managed_uv._uv_runs", lambda path: True)
+        with patch("hermes_cli.managed_uv.get_hermes_home", return_value=tmp_path), \
+             patch(
+                 "hermes_cli.managed_uv.repair_vulnerable_runtime",
+                 return_value=RuntimeRepairResult("skipped"),
+             ) as mock_repair, \
+             patch("hermes_cli.managed_uv.subprocess.run") as mock_run:
+            result = update_managed_uv()
+
+        # No managed uv -> no self-update attempted, but the repair runs with
+        # the user's uv engine (read-only use; writes stay in Hermes' dirs).
+        assert result is None
+        assert mock_run.call_count == 0, "no managed uv -> nothing to self-update"
+        mock_repair.assert_called_once_with(user_uv)
 
 
 

--- a/tests/test_managed_runtime_resolution.py
+++ b/tests/test_managed_runtime_resolution.py
@@ -65,7 +65,7 @@ _ALLOWED: dict[tuple[str, str], str] = {
     ),
     ("hermes_cli/update_cmd.py", "uv"): (
         "Termux fallback: a pkg-installed uv lands on PATH but not in the "
-        "managed bin dir, and it is checked only after resolve_uv() misses."
+        "managed dir, and it is checked only after resolve_uv() misses."
     ),
     ("hermes_cli/update_cmd.py", "npm"): (
         "WSL diagnostic: deliberately inspects what PATH resolves so it can "
@@ -188,7 +188,7 @@ def test_no_unreviewed_bare_managed_runtime_lookups():
     assert not unexpected, (
         "Bare PATH lookup for a Hermes-managed runtime.\n\n"
         + "\n".join(f"  {rel}:{lineno}  which({cmd!r})" for rel, cmd, lineno in unexpected)
-        + "\n\n$HERMES_HOME/bin (uv) and $HERMES_HOME/node are not on an "
+        + "\n\n$HERMES_HOME/uv (uv) and $HERMES_HOME/node are not on an "
         "arbitrary process's PATH, so this resolves a system copy — or nothing "
         "— on an install that has a managed one.\n"
         "Use instead:\n"

--- a/tests/test_managed_runtime_resolution.py
+++ b/tests/test_managed_runtime_resolution.py
@@ -1,6 +1,6 @@
 """Guard: Hermes-owned subprocesses must not resolve managed runtimes by bare PATH.
 
-Hermes installs runtimes for itself — ``uv`` at ``$HERMES_HOME/bin/uv``, Node at
+Hermes installs runtimes for itself — ``uv`` at ``$HERMES_HOME/uv/uv``, Node at
 ``$HERMES_HOME/node``. Neither directory is on the ambient PATH of an arbitrary
 process, so ``shutil.which("uv")`` / ``shutil.which("node")`` in Hermes's own
 code has two failure modes:
@@ -70,6 +70,12 @@ _ALLOWED: dict[tuple[str, str], str] = {
     ("hermes_cli/update_cmd.py", "npm"): (
         "WSL diagnostic: deliberately inspects what PATH resolves so it can "
         "warn that the only reachable npm is the Windows one."
+    ),
+    ("hermes_cli/managed_uv.py", "uv"): (
+        "Tier-1 probe of resolve_uv_engine(): PATH here deliberately means "
+        "the USER's own uv (preferred when present, never modified). The "
+        "managed uv is resolved separately by absolute path via resolve_uv(), "
+        "never via this call."
     ),
     ("tools/lazy_deps.py", "uv"): (
         "Fallback after resolve_uv(), plus the except-branch for the "
@@ -227,4 +233,4 @@ def test_managed_uv_helpers_exist():
 
     assert callable(resolve_uv)
     assert callable(ensure_uv)
-    assert managed_uv_path().parent.name == "bin"
+    assert managed_uv_path().parent.name == "uv"

--- a/tests/tools/test_browser_use_cli.py
+++ b/tests/tools/test_browser_use_cli.py
@@ -918,6 +918,32 @@ class TestFindCliManagedBin:
         uvx.chmod(uvx.stat().st_mode | stat.S_IXUSR)
         assert bu_cli._find_cli_unpatched() == [str(uvx), "browser-use"]
 
+    def test_managed_uv_dir_uvx_found(self, tmp_path, monkeypatch):
+        """The managed uvx lives next to the managed uv in the private uv/
+        dir (post-isolation layout) — the zero-install probe must find it
+        there even though it is never on PATH."""
+        uv_dir = tmp_path / "home" / "uv"
+        uv_dir.mkdir(parents=True)
+        uvx = uv_dir / "uvx"
+        uvx.write_text("#!/bin/sh\n")
+        uvx.chmod(uvx.stat().st_mode | stat.S_IXUSR)
+        assert bu_cli._find_cli_unpatched() == [str(uvx), "browser-use"]
+
+    def test_managed_uv_dir_uvx_precedes_legacy_bin(self, tmp_path, monkeypatch):
+        """Current layout wins: the private uv/ copy is probed before the
+        pre-isolation bin/ copy."""
+        uv_dir = tmp_path / "home" / "uv"
+        uv_dir.mkdir(parents=True)
+        uvx = uv_dir / "uvx"
+        uvx.write_text("#!/bin/sh\n")
+        uvx.chmod(uvx.stat().st_mode | stat.S_IXUSR)
+        legacy = tmp_path / "home" / "bin"
+        legacy.mkdir(parents=True)
+        legacy_uvx = legacy / "uvx"
+        legacy_uvx.write_text("#!/bin/sh\n")
+        legacy_uvx.chmod(legacy_uvx.stat().st_mode | stat.S_IXUSR)
+        assert bu_cli._find_cli_unpatched() == [str(uvx), "browser-use"]
+
     def test_nothing_found(self, tmp_path, monkeypatch):
         assert bu_cli._find_cli_unpatched() is None
 

--- a/tools/browser_use_cli.py
+++ b/tools/browser_use_cli.py
@@ -291,14 +291,28 @@ def default_downgrade_notice() -> Optional[str]:
 
 
 def _managed_bin_dir() -> Optional[str]:
-    """Hermes' own bin dir ($HERMES_HOME/bin) — where install.sh puts uv/uvx
-    and where install_cli() links the browser-use binary."""
+    """Hermes' own bin dir ($HERMES_HOME/bin) — where install_cli() links
+    the browser-use binary via UV_TOOL_BIN_DIR (and legacy installs used to
+    keep the managed uv/uvx before the uv-isolation change)."""
     try:
         from hermes_constants import get_hermes_home
 
         return str(Path(get_hermes_home()) / "bin")
     except Exception as e:  # pragma: no cover — defensive
         logger.debug("Could not resolve managed bin dir: %s", e)
+        return None
+
+
+def _managed_uv_dir() -> Optional[str]:
+    """Hermes' private managed uv dir ($HERMES_HOME/uv) — where install.sh /
+    install.ps1 and the runtime updater keep the managed uv + uvx binaries,
+    never on PATH.  Mirrors managed_uv_path() in hermes_cli/managed_uv.py."""
+    try:
+        from hermes_constants import get_hermes_home
+
+        return str(Path(get_hermes_home()) / "uv")
+    except Exception as e:  # pragma: no cover — defensive
+        logger.debug("Could not resolve managed uv dir: %s", e)
         return None
 
 
@@ -329,7 +343,9 @@ def _find_cli() -> Optional[List[str]]:
     (~/.local/bin / %APPDATA%\\uv\\bin, where a manual ``uv tool install``
     links binaries) are fallbacks for setups that never ran our install,
     and cover Desktop/TUI workers that spawn with a minimal PATH. The uvx
-    zero-install path (same probe order) is the final fallback.
+    zero-install path probes the managed uv dir first ($HERMES_HOME/uv —
+    uvx lives next to the managed uv there), then the legacy bin/ copy,
+    then PATH and the user-level tool dir, as the final fallback.
     """
     probe_paths = (_managed_bin_dir(), None, _user_local_bin_dir())
     for probe_path in probe_paths:
@@ -337,7 +353,12 @@ def _find_cli() -> Optional[List[str]]:
             direct = shutil.which("browser-use", path=probe_path)
             if direct:
                 return [direct]
-    for probe_path in probe_paths:
+    # uvx ships alongside the managed uv in the private uv/ dir (the astral
+    # installer drops both there); the pre-isolation bin/ copy is probed too
+    # until a legacy install migrates.  Appended after the browser-use probe
+    # so a real install always wins over the zero-install runner.
+    uvx_probe_paths = (_managed_uv_dir(), _managed_bin_dir(), None, _user_local_bin_dir())
+    for probe_path in uvx_probe_paths:
         if probe_path is None or probe_path:
             uvx = shutil.which("uvx", path=probe_path)
             if uvx:

--- a/tools/env_probe.py
+++ b/tools/env_probe.py
@@ -218,8 +218,9 @@ def _build_probe_line() -> str:
     # Bare which() is correct here, unlike Hermes's own uv call sites: this
     # reports the environment *the model will see* in the terminal tool, and
     # what the model can type is exactly what is on that subshell's PATH.
-    # local.py puts the Hermes-managed $HERMES_HOME/bin there, so a managed-only
-    # install answers yes — without that, claiming uv the model cannot invoke
+    # local.py appends the Hermes-managed dirs there — $HERMES_HOME/uv for the
+    # managed uv, $HERMES_HOME/bin for other managed CLIs — so a managed-only
+    # install answers yes; without that, claiming uv the model cannot invoke
     # would be worse than claiming none.
     has_uv = shutil.which("uv") is not None
 

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -1297,9 +1297,13 @@ def _managed_runtime_path_entries() -> list[str]:
     - ``$HERMES_HOME/node`` (+ ``/bin``) — installed to satisfy the desktop and
       browser toolchain. ``tools/browser_tool.py`` already does this for its own
       subprocesses; the agent's shell deserves the same.
-    - ``$HERMES_HOME/bin`` — the managed ``uv``. ``install.sh`` writes it there
-      and nothing has ever put that directory on PATH, so an install whose only
-      uv is the managed one looks uv-less to both the agent and the model.
+    - ``$HERMES_HOME/uv`` — the managed ``uv``/``uvx`` (the private location the
+      installers and the runtime updater keep them in; nothing has ever put it
+      on the user's PATH). Appended here so a managed-only install looks
+      uv-capable to the agent's shell, while a user's own uv on their PATH
+      still wins (first-occurrence-wins, see ``_append_missing_sane_path_entries``).
+    - ``$HERMES_HOME/bin`` — the browser-use CLI (``UV_TOOL_BIN_DIR``) and
+      other Hermes-managed CLIs.
 
     Resolved per call rather than cached in a module constant because
     ``get_hermes_home()`` is profile-scoped and a managed tree can appear
@@ -1308,7 +1312,11 @@ def _managed_runtime_path_entries() -> list[str]:
     try:
         from hermes_constants import get_hermes_home, iter_hermes_node_dirs
 
-        candidates = [*iter_hermes_node_dirs(), get_hermes_home() / "bin"]
+        candidates = [
+            *iter_hermes_node_dirs(),
+            get_hermes_home() / "uv",
+            get_hermes_home() / "bin",
+        ]
         return [str(d) for d in candidates if d.is_dir()]
     except Exception:
         return []

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -742,7 +742,7 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
         uv_env["VIRTUAL_ENV"] = str(venv_root)
 
         # Tier 1: uv (preferred — fast, doesn't need pip in the venv)
-        # Managed uv first: $HERMES_HOME/bin is never on PATH, so a bare
+        # Managed uv first: $HERMES_HOME/uv is never on PATH, so a bare
         # which() misses the uv Hermes installed and falls through to the
         # slower pip tier. Deliberately a lookup and not ensure_uv(): this runs
         # mid-turn to install an optional dependency, and downloading uv +

--- a/website/docs/user-guide/windows-native.md
+++ b/website/docs/user-guide/windows-native.md
@@ -205,7 +205,8 @@ Services require admin rights to install and tie the gateway's lifecycle to mach
 | `%LOCALAPPDATA%\hermes\hermes-agent\` | Git checkout + venv. Safe to `Remove-Item -Recurse` and reinstall. |
 | `%LOCALAPPDATA%\hermes\git\` | PortableGit (only if the installer provisioned it). |
 | `%LOCALAPPDATA%\hermes\node\` | Portable Node.js (only if the installer provisioned it). |
-| `%LOCALAPPDATA%\hermes\bin\` | The `hermes` / `hermes-acp` launchers and Hermes's managed `uv.exe` (the Python manager it uses for updates). |
+| `%LOCALAPPDATA%\hermes\bin\` | The `hermes` / `hermes-acp` launchers. **Launchers only** — the managed `uv.exe` lives in the private `uv\` subdirectory, which is never on PATH, so Hermes never shadows your own `uv` command. |
+| `%LOCALAPPDATA%\hermes\uv\` | Hermes's managed `uv.exe` (the Python manager it uses for updates). Private — reachable only by absolute path; your own `uv` keeps priority in your shells. |
 | `%LOCALAPPDATA%\hermes\` (root) | Your config, auth, skills, sessions, logs (`config.yaml`, `.env`, `skills\`, `sessions\`, `logs\`, …). **Survives reinstalls.** |
 
 On native Windows the installer sets `HERMES_HOME=%LOCALAPPDATA%\hermes`, so your data and the disposable install live under the **same** `%LOCALAPPDATA%\hermes` root: the install/runtime is the `hermes-agent\`, `git\`, `node\`, and `bin\` subdirectories, while your data files sit directly in `%LOCALAPPDATA%\hermes`. Reinstalling only replaces the `hermes-agent\` checkout, so your data survives — but because the two share a root, **don't** `Remove-Item -Recurse %LOCALAPPDATA%\hermes` if you want to keep your data; delete the `hermes-agent\` subdirectory instead. Your data directory is identical in shape to a Linux `~/.hermes`, so you can mirror it between machines.

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/windows-native.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/windows-native.md
@@ -205,7 +205,8 @@ hermes gateway uninstall   # 移除 schtasks 条目、Startup 快捷方式、pid
 | `%LOCALAPPDATA%\hermes\hermes-agent\` | Git 检出 + venv。可安全执行 `Remove-Item -Recurse` 后重新安装。 |
 | `%LOCALAPPDATA%\hermes\git\`          | PortableGit（仅在安装程序配置时存在）。                         |
 | `%LOCALAPPDATA%\hermes\node\`         | 便携式 Node.js（仅在安装程序配置时存在）。                      |
-| `%LOCALAPPDATA%\hermes\bin\`          | `hermes.cmd` 垫片，已添加到用户 PATH。                          |
+| `%LOCALAPPDATA%\hermes\bin\` | `hermes.cmd` 垫片，已添加到用户 PATH。**仅垫片** — 托管 `uv.exe` 位于私有的 `uv\` 子目录，永不进 PATH，Hermes 不会遮蔽你自己的 `uv` 命令。 |
+| `%LOCALAPPDATA%\hermes\uv\` | Hermes 的托管 `uv.exe`（更新时使用的 Python 管理器）。私有 — 仅可通过绝对路径访问；你自己的 `uv` 在 shell 中保持优先。 |
 | `%USERPROFILE%\.hermes\`              | 你的配置、认证、技能、会话、日志。**重装后保留。**              |
 
 这种分离是有意为之：`%LOCALAPPDATA%\hermes` 是可丢弃的基础设施（可以删除后用一行命令恢复）。`%USERPROFILE%\.hermes` 是你的数据——配置、记忆、技能、会话历史——其结构与 Linux 安装完全相同。在机器间同步它，你的 Hermes 就随之迁移。


### PR DESCRIPTION
# fix(uv): prefer the user's uv, move the managed one off PATH

## What does this PR do?

On Windows, `install.ps1` places Hermes' managed uv at
`%LOCALAPPDATA%\hermes\bin\uv.exe` — and `%LOCALAPPDATA%\hermes\bin` is a
persisted User PATH entry (registered for the `hermes` launcher, prepended on
fresh install). The managed `uv.exe` therefore resolves as the `uv` command in
every new shell, silently shadowing the user's own uv — and because it shares
`bin` with `hermes.exe`, the user cannot even remove the directory from PATH
without breaking the `hermes` command. `hermes update` then silently changes
the shell-visible `uv` version (managed_uv self-update). POSIX is unaffected:
`install.sh` never adds `$HERMES_HOME/bin` to PATH, so the asymmetry is
Windows-only.

This change applies the same tiered contract the managed-Node installer
established (PR #95748):

1. **System already has a working uv → use it directly; install nothing;
   touch no PATH; never modify it** (no `uv self update` on a toolchain
   Hermes does not own). Tier-1 wins even when a managed uv already exists.
2. **No working uv → provision a managed uv under `$HERMES_HOME/uv/`** — a
   private directory that is never registered on PATH — reachable only by
   absolute path.
3. **Auto-management never takes over command names** — shells always resolve
   the user's own uv (or none), never Hermes' copy.

## Related Issue

Fixes #97259

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/managed_uv.py`:
  - `managed_uv_path()` → `$HERMES_HOME/uv/uv` (POSIX) / `$HERMES_HOME\uv\uv.exe`
    (Windows) — the private location, never on PATH. `legacy_managed_uv_path()`
    recognizes the pre-isolation `bin/uv(.exe)` shape.
  - New `resolve_uv_engine()` — the single resolution seam. Tier-1: a `uv` on
    PATH that passes the `--version` smoke test is adopted as `user`
    (`can_self_update=False`); a PATH hit that resolves to Hermes' own managed
    or legacy binary is never mistaken for the user's (Windows
    case-insensitive comparison). Then the managed binary; then `none`.
  - `ensure_uv()` / `_ensure_uv_path()` — tier-1 first: a usable user uv
    returns without any managed provisioning; otherwise the managed binary is
    installed into the private dir, migrating a legacy `bin/uv(.exe)` first
    (best-effort `os.replace`, no reinstall after a successful move).
  - `update_managed_uv()` — self-update stays managed-only (`resolve_uv()`
    is the target resolver), but the CVE-driven runtime-repair probe now runs
    with ANY usable uv (user's or managed): with tier-1 there is often no
    managed binary at all, and repair must not be gated behind its existence.
    The probe/provisioning writes stay in Hermes' own dirs via
    `managed_python_env()`, and `_refresh_managed_uv_catalog()` refuses to
    touch a foreign binary — the user's uv is used read-only, never modified.
- `scripts/install.ps1`:
  - New helpers `Get-ManagedUvPath`, `Test-UserUvUsable` (tier-1 probe with
    the managed/legacy guard), `Move-LegacyManagedUv` (one-time migration),
    `Set-UvPythonIsolationEnv` (pins `UV_PYTHON_INSTALL_DIR` to
    `$HermesHome\python` + `UV_PYTHON_INSTALL_BIN=0` +
    `UV_PYTHON_INSTALL_REGISTRY=0`, wired into `Resolve-UvCmd` so every uv
    python write stays inside Hermes' tree regardless of which uv engine runs).
  - `Install-Uv` — tier-1 first; managed binary to the private dir
    (`UV_INSTALL_DIR` retargeted); legacy migration on upgrade.
  - `Resolve-UvCmd` — tier-1 first, then the private managed path, then
    migration, then the existing PATH fallbacks.
- `scripts/install.sh`:
  - `install_uv()` — tier-1 (`command -v uv` + runs) first; managed binary to
    `$HERMES_HOME/uv/uv`; legacy `bin/uv` migration; `UV_UNMANAGED_INSTALL`
    retargeted; non-root installs pin `UV_PYTHON_INSTALL_DIR` to
    `$HERMES_HOME/python` (root FHS keeps its world-readable pin).
- `hermes_cli/_early_recovery.py` — managed path updated; legacy `bin/uv`
  kept as a fallback candidate.
- `hermes_cli/update_cmd.py` — docstring path reference updated.
- `website/docs/user-guide/windows-native.md` + zh-Hans — `bin\` is now
  documented as launchers-only; the private `uv\` directory added.

### Scope note (why the diff touches consumers beyond the installer)

Moving the managed uv out of `$HERMES_HOME/bin` into the private
`$HERMES_HOME/uv` dir has a downstream: several runtime consumers still
resolved the managed binary at its old home. `tools/browser_use_cli.py`'s
uvx zero-install probe and `tools/environments/local.py`'s terminal-subshell
PATH injection would silently lose the managed uv after this change. Those
files are patched here for consistency (`$HERMES_HOME/uv` probed/appended,
gap-fill only — a user's own uv on PATH still wins, first-occurrence-wins),
with stale `$HERMES_HOME/bin` mention synced in comments/docs. Without this,
the fix itself would be the thing that breaks uv discovery.

## How to Test

1. **Python** (cross-platform, no network):
   `scripts/run_tests.sh tests/hermes_cli/test_managed_uv.py tests/test_managed_runtime_resolution.py`
   — covers the resolver (user/managed/none), the managed/legacy guard, the
   legacy migration, and tier-1 `ensure_uv` (user uv → no managed install;
   broken user uv → managed fallback).
2. **PowerShell** (any machine with pwsh):
   `pwsh -NoProfile -File scripts/ci/test_install_ps1_uv_isolation.ps1`
   — AST-lifts the real `Get-ManagedUvPath` / `Test-UserUvUsable` /
   `Move-LegacyManagedUv` / `Set-UvPythonIsolationEnv` bodies and asserts the
   private path, tier-1 guard, migration semantics, and write containment
   (inherited `UV_PYTHON_INSTALL_DIR` is overridden, never respected).
3. **Windows E2E** (needs a Windows box): install with a user-scoped uv of
   your own → `where uv` resolves to yours, not `%LOCALAPPDATA%\hermes\...`;
   re-run the installer with no user uv → managed uv lands in
   `%LOCALAPPDATA%\hermes\uv\` and `where uv` finds nothing Hermes-owned;
   upgrade an install that has the old `bin\uv.exe` → it migrates to `uv\`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant tests for this change:
  - `tests/hermes_cli/test_managed_uv.py` → 53 passed (incl. tier-1 repair
    regression: the repair probe runs with the user's uv when no managed
    binary exists)
  - `tests/test_managed_runtime_resolution.py` → 7 passed
  - `pwsh -NoProfile -File scripts/ci/test_install_ps1_uv_isolation.ps1` → all
    assertions passed; `install.ps1` / `install.sh` parse clean
- [x] I've added tests for my changes (required for bug fixes)
- [x] I've tested on my platform: macOS (Python + PowerShell harness); Windows
  E2E pending (no Windows host available)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation — N/A (installer/runtime behavior;
  no user-facing config key added)
- [x] I've considered cross-platform impact (Windows, macOS) per the
  compatibility guide — the managed uv is now private on BOTH platforms; the
  Windows-specific PATH shadowing is the bug being fixed
- [ ] I've updated tool descriptions/schemas — N/A (no model tool changed)

## Known Limitations

- The tier-1 suitability check is "runs `uv --version`" — there is still no
  uv version floor (the codebase never had one; the managed uv self-updates).
  If a floor is ever needed, `resolve_uv_engine()` is the single place to add
  it.
- The installer's Rung-3 salvage (copying an existing uv into the managed
  location when the network is fully blocked) still targets the private dir;
  it only runs when no usable user uv exists.

## Screenshots / Logs

```
$ where uv            # after install, on a box with the user's own uv
C:\Users\me\AppData\Local\Programs\uv\uv.exe     (the user's — not Hermes')

$ ls %LOCALAPPDATA%\hermes\uv\
uv.exe                                             (Hermes' private copy, off PATH)
```

`pwsh -NoProfile -File scripts/ci/test_install_ps1_uv_isolation.ps1`
→ `all assertions passed`.

