### PR TITLE
fix(code-execution): preserve remote kernel output contract

### DIFF
--- a/tests/tools/test_code_kernel_remote.py
+++ b/tests/tools/test_code_kernel_remote.py
@@ -10,7 +10,9 @@ state_lost/state_reset reporting, fail-open, and owner isolation.
 """
 import json
 import os
+import subprocess
 import sys
+import tempfile
 import unittest
 from unittest.mock import patch
 
@@ -18,6 +20,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
 
 from tools.code_kernel_remote import (
     _REMOTE_KERNELS,
+    REMOTE_KERNEL_RUNNER_SOURCE,
     RemoteKernel,
     execute_in_remote_kernel,
     shutdown_all_remote_kernels,
@@ -117,6 +120,7 @@ class TestSpawnAndReuse(RemoteKernelBase):
         self.assertEqual(
             sum(1 for c in env.commands if "nohup" in c), 1,
         )
+        self.assertEqual(first["exit_code"], 0)
 
     def test_spawn_failure_fails_open(self):
         env = ScriptedEnv([
@@ -208,7 +212,7 @@ class TestDispatchIntegration(unittest.TestCase):
 
         fake = {
             "status": "success", "stdout": "kernel says hi\n", "stderr": "",
-            "traceback": "", "tool_calls_made": 0,
+            "traceback": "", "tool_calls_made": 0, "exit_code": 0,
             "kernel": {"reused": True, "remote": True, "execution_count": 3},
         }
         env = ScriptedEnv([
@@ -222,8 +226,39 @@ class TestDispatchIntegration(unittest.TestCase):
                    return_value=fake):
             result = json.loads(_execute_remote("print()", "t", ["read_file"]))
         self.assertEqual(result["status"], "success")
+        self.assertEqual(result["exit_code"], 0)
         self.assertIn("kernel says hi", result["output"])
         self.assertEqual(result["kernel"]["execution_count"], 3)
+
+    def test_execute_remote_preserves_runner_clipping_metadata(self):
+        from tools.code_execution_tool import _execute_remote
+
+        fake = {
+            "status": "success", "stdout": "x" * 50_000, "stderr": "",
+            "traceback": "", "tool_calls_made": 0, "exit_code": 0,
+            "stdout_clipped": True, "stdout_bytes_total": 80_000,
+            "stdout_spill_path": "/tmp/kernel/cell_000001_stdout.txt",
+            "kernel": {"reused": False, "remote": True, "execution_count": 1},
+        }
+        env = ScriptedEnv([
+            ("command -v python3", lambda c: {"output": "OK\n", "returncode": 0}),
+        ])
+        with patch("tools.code_execution_tool._load_config",
+                   return_value={"timeout": 30, "max_tool_calls": 5}), \
+             patch("tools.code_execution_tool._get_or_create_env",
+                   return_value=(env, "ssh")), \
+             patch("tools.code_kernel_remote.execute_in_remote_kernel",
+                   return_value=fake):
+            result = json.loads(_execute_remote("print()", "t", ["read_file"]))
+        self.assertEqual(result["exit_code"], 0)
+        self.assertTrue(result["stdout_truncated"])
+        self.assertEqual(result["stdout_bytes_total"], 80_000)
+        self.assertGreater(result["stdout_bytes_omitted"], 0)
+        self.assertEqual(
+            result["stdout_spill_path"],
+            "/tmp/kernel/cell_000001_stdout.txt",
+        )
+        self.assertIn("read_file", result["warning"])
 
     def test_execute_remote_falls_open_to_per_call(self):
         from tools.code_execution_tool import _execute_remote
@@ -247,6 +282,36 @@ class TestDispatchIntegration(unittest.TestCase):
         self.assertEqual(result["status"], "success")
         self.assertIn("per-call ran", result["output"])
 
+
+class TestRemoteRunnerSpill(unittest.TestCase):
+    def test_clipped_stdout_is_spilled_before_runner_exit(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            cells = os.path.join(tmp, "cells")
+            os.makedirs(cells)
+            runner = os.path.join(tmp, "kernel_runner.py")
+            source = REMOTE_KERNEL_RUNNER_SOURCE.format(
+                capture_limit=100, spill_cap=1_000, idle_exit=2,
+            )
+            with open(runner, "w", encoding="utf-8") as f:
+                f.write(source)
+            request_path = os.path.join(cells, "cell_req_000001.json")
+            with open(request_path, "w", encoding="utf-8") as f:
+                json.dump({
+                    "id": "000001",
+                    "code": "print('x' * 250)\nraise SystemExit(0)",
+                }, f)
+            env = dict(os.environ, HERMES_KERNEL_DIR=tmp)
+            subprocess.run(
+                [sys.executable, runner], env=env, check=True, timeout=10,
+            )
+            response_path = os.path.join(cells, "cell_res_000001.json")
+            with open(response_path, encoding="utf-8") as f:
+                result = json.load(f)
+            self.assertTrue(result["stdout_clipped"])
+            self.assertGreater(result["stdout_bytes_total"], 100)
+            self.assertTrue(os.path.isfile(result["stdout_spill_path"]))
+            with open(result["stdout_spill_path"], encoding="utf-8") as f:
+                self.assertIn("x" * 250, f.read())
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -1168,6 +1168,12 @@ def _finish_remote_kernel_result(kernel_result: Dict[str, Any], *,
     from agent.redact import redact_sensitive_text
 
     stdout_text = kernel_result.get("stdout", "") or ""
+    runner_stdout_bytes = len(stdout_text.encode("utf-8", errors="replace"))
+    runner_stdout_clipped = bool(kernel_result.get("stdout_clipped"))
+    try:
+        runner_stdout_total = int(kernel_result.get("stdout_bytes_total") or 0)
+    except (TypeError, ValueError):
+        runner_stdout_total = 0
     stderr_text = kernel_result.get("stderr", "") or ""
     traceback_text = kernel_result.get("traceback", "") or ""
     if stderr_text or traceback_text:
@@ -1186,11 +1192,42 @@ def _finish_remote_kernel_result(kernel_result: Dict[str, Any], *,
     result: Dict[str, Any] = {
         "status": kernel_result.get("status", "error"),
         "output": stdout_text,
+        "exit_code": kernel_result.get("exit_code", -1),
         "tool_calls_made": kernel_result.get("tool_calls_made", 0),
         "duration_seconds": duration,
         "kernel": kernel_result.get("kernel", {"remote": True}),
     }
     result.update(stdout_metadata)
+
+    if runner_stdout_clipped:
+        captured = min(
+            int(result.get("stdout_bytes_captured") or 0),
+            runner_stdout_bytes,
+        )
+        total = max(runner_stdout_total, runner_stdout_bytes)
+        result.update({
+            "stdout_truncated": True,
+            "stdout_bytes_captured": captured,
+            "stdout_bytes_total": total,
+            "stdout_bytes_omitted": max(0, total - captured),
+        })
+        spill_path = str(kernel_result.get("stdout_spill_path") or "")
+        if spill_path:
+            result["stdout_spill_path"] = spill_path
+            result["warning"] = (
+                "Cell stdout exceeded the inline cap; head shown. FULL "
+                f"output saved to {spill_path} — page it with "
+                f'read_file(path="{spill_path}", offset=...) instead of '
+                "re-running."
+            )
+        else:
+            # A host-side spill, if any, contains only the runner's already
+            # clipped payload and must not be advertised as the full output.
+            result.pop("stdout_spill_path", None)
+            result["warning"] = (
+                "Cell stdout exceeded the remote kernel's inline cap; the "
+                "returned output is truncated."
+            )
 
     if result["status"] == "timeout":
         timeout_msg = (

--- a/tools/code_kernel_remote.py
+++ b/tools/code_kernel_remote.py
@@ -69,15 +69,29 @@ import traceback
 KDIR = os.environ["HERMES_KERNEL_DIR"]
 CELLS = os.path.join(KDIR, "cells")
 CAPTURE_LIMIT = {capture_limit}
+SPILL_CAP = {spill_cap}
 IDLE_EXIT_SECONDS = {idle_exit}
 
 GLOBALS = {{"__name__": "__main__", "__builtins__": __builtins__}}
 
 
-def _bounded(text):
-    if len(text) <= CAPTURE_LIMIT:
-        return text, False
-    return text[:CAPTURE_LIMIT], True
+def _bounded(text, spill_name=""):
+    encoded = text.encode("utf-8", errors="replace")
+    total_bytes = len(encoded)
+    if total_bytes <= CAPTURE_LIMIT:
+        return text, False, "", total_bytes
+    spill_path = ""
+    if spill_name:
+        try:
+            spill_path = os.path.join(KDIR, spill_name)
+            with open(spill_path, "w", encoding="utf-8", errors="replace") as f:
+                f.write(encoded[:SPILL_CAP].decode("utf-8", errors="replace"))
+                if total_bytes > SPILL_CAP:
+                    f.write("\\n\\n[... spill capped ...]")
+        except Exception:
+            spill_path = ""
+    clipped = encoded[:CAPTURE_LIMIT].decode("utf-8", errors="replace")
+    return clipped, True, spill_path, total_bytes
 
 
 def main():
@@ -116,8 +130,10 @@ def main():
             except BaseException:
                 status = "error"
                 trace = traceback.format_exc()
-            stdout_text, stdout_clipped = _bounded(out.getvalue())
-            stderr_text, stderr_clipped = _bounded(err.getvalue())
+            stdout_text, stdout_clipped, stdout_spill, stdout_total = _bounded(
+                out.getvalue(), "cell_%06d_stdout.txt" % execution_count
+            )
+            stderr_text, stderr_clipped, _, _ = _bounded(err.getvalue())
             payload = {{
                 "id": request.get("id", ""),
                 "status": status,
@@ -125,6 +141,8 @@ def main():
                 "stderr": stderr_text,
                 "stdout_clipped": stdout_clipped,
                 "stderr_clipped": stderr_clipped,
+                "stdout_spill_path": stdout_spill,
+                "stdout_bytes_total": stdout_total,
                 "traceback": trace,
                 "execution_count": execution_count,
             }}
@@ -227,6 +245,7 @@ def _spawn_remote_kernel(env, env_type: str, owner: str, task_env_id: str,
                          idle_exit: int) -> Optional[RemoteKernel]:
     """Start a detached kernel runner on the remote. None on failure."""
     from tools.code_execution_tool import (
+        MAX_SPILLED_STDOUT_BYTES,
         MAX_STDOUT_BYTES,
         _ship_file_to_remote,
         _env_temp_dir,
@@ -242,6 +261,7 @@ def _spawn_remote_kernel(env, env_type: str, owner: str, task_env_id: str,
         rpc_token = _secrets.token_urlsafe(32)
         runner_src = REMOTE_KERNEL_RUNNER_SOURCE.format(
             capture_limit=MAX_STDOUT_BYTES,
+            spill_cap=MAX_SPILLED_STDOUT_BYTES,
             idle_exit=idle_exit,
         )
         _ship_file_to_remote(env, f"{kernel_dir}/kernel_runner.py", runner_src)
@@ -443,6 +463,7 @@ def execute_in_remote_kernel(
         _kill(kernel)
         return {
             "status": "timeout" if cell_status == "timeout" else "error",
+            "exit_code": -1,
             "stdout": "",
             "stderr": "",
             "traceback": "",
@@ -470,11 +491,14 @@ def execute_in_remote_kernel(
 
     result: Dict[str, Any] = {
         "status": "success" if cell_status in ("ok", "exit") else "error",
+        "exit_code": 0 if cell_status in ("ok", "exit") else 1,
         "stdout": cell_payload.get("stdout", ""),
         "stderr": cell_payload.get("stderr", ""),
         "traceback": cell_payload.get("traceback", ""),
         "stdout_clipped": bool(cell_payload.get("stdout_clipped")),
         "stderr_clipped": bool(cell_payload.get("stderr_clipped")),
+        "stdout_spill_path": cell_payload.get("stdout_spill_path", ""),
+        "stdout_bytes_total": cell_payload.get("stdout_bytes_total", 0),
         "tool_calls_made": tool_call_counter[0],
         "kernel": {
             "reused": reused,


### PR DESCRIPTION
## Summary

- preserve `exit_code` on persistent remote-kernel results
- report runner-side clipping with faithful truncation byte metadata
- spill complete remote cell stdout before clipping and return the remote path with `read_file` recovery guidance
- add a real subprocess/file-protocol regression test for runner spillover

Fixes #97256

## Testing

- `python -m pytest -p no:cacheprovider tests/tools/test_code_kernel_remote.py tests/tools/test_code_kernel.py -q`
- `python -m pytest -p no:cacheprovider tests/tools/test_code_execution.py -q -k 'not missing_token_rejected'`
- `python -m ruff check tools/code_kernel_remote.py tools/code_execution_tool.py tests/tools/test_code_kernel_remote.py`

The deselected test requires `socket.AF_UNIX`, which is unavailable in the native Windows test environment.