### PR TITLE
fix: inverted liveness check fast-failed healthy stdio MCP servers

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2994,9 +2994,8 @@ class MCPServerTask:
 
             if not psutil.pid_exists(pid):
                 continue  # this one is dead
-            return True  # alive (signal permission irrelevant for liveness)
-            return False  # at least one child alive
-        return True
+            return False  # at least one child alive -> not dead
+        return True  # every tracked child exited
 
     async def _watch_stdio_children(self) -> None:
         """Poll child liveness while a stdio RPC is in flight (#81995).


### PR DESCRIPTION
## Summary
- `MCPServerTask._stdio_children_dead()` documented "True when every stdio child has exited" but the alive branch returned `True`, so **every** stdio MCP tool call against a healthy server was cancelled immediately with "MCP stdio subprocess for 'X' has exited".
- Return `False` when any tracked child is alive; `True` only when every tracked PID has exited, matching the docstring.

## Reproduction
Any stdio MCP server with captured child PIDs (e.g. `uvx blender-mcp`). Every tool call fast-fails while the child process runs fine:
```
MCP stdio subprocess for 'blender' has exited
```

## Verification
- One-shot agent session end-to-end through two stdio MCP servers (blender + filesystem) after the fix: 25-tool server connects, tool calls execute, full Cycles render pipeline completed.
- Blender MCP socket log confirms tool commands now reach the server (previously zero commands arrived). The render artifact exists on disk with expected dimensions/size (1280x720 PNG, ~887KB).