### PR TITLE
fix(code-execution): key remote kernels by tool set

### DIFF
--- a/tests/tools/test_code_kernel_remote.py
+++ b/tests/tools/test_code_kernel_remote.py
@@ -74,10 +74,11 @@ def _cell(status="ok", stdout="", execution_count=1, **kw):
     return payload
 
 
-def _run(env, code="print(1)", *, task="t1", reset=False, timeout=10):
+def _run(env, code="print(1)", *, task="t1", reset=False, timeout=10,
+         tools=frozenset({"read_file"})):
     return execute_in_remote_kernel(
         code, env=env, env_type="ssh", task_env_id=task,
-        sandbox_tools=frozenset({"read_file"}), timeout=timeout,
+        sandbox_tools=tools, timeout=timeout,
         max_tool_calls=5, reset=reset,
     )
 
@@ -176,6 +177,19 @@ class TestDeathDetection(RemoteKernelBase):
 
 
 class TestOwnershipIsolation(RemoteKernelBase):
+    def test_changed_tool_set_spawns_kernel_with_fresh_stubs(self):
+        env = ScriptedEnv(_spawn_ok_handlers([_cell(), _cell()]))
+        _run(env, tools=frozenset({"read_file"}))
+        _run(env, tools=frozenset({"web_search"}))
+
+        self.assertEqual(len(_REMOTE_KERNELS), 2)
+        self.assertEqual(sum(1 for c in env.commands if "nohup" in c), 2)
+        keyed_tool_sets = {key[-1] for key in _REMOTE_KERNELS}
+        self.assertEqual(
+            keyed_tool_sets,
+            {("read_file",), ("web_search",)},
+        )
+
     def test_delegated_children_get_their_own_remote_kernels(self):
         """Same invariant as local (#94647 review fix): the child context
         qualifier must key a DIFFERENT remote kernel."""

--- a/tools/code_kernel_remote.py
+++ b/tools/code_kernel_remote.py
@@ -158,8 +158,12 @@ class RemoteKernel:
     cell_seq: int = 0
 
 
-def _kernel_key(owner: str, env_type: str, task_env_id: str) -> Tuple:
-    return (owner, "remote", env_type, task_env_id)
+def _kernel_key(owner: str, env_type: str, task_env_id: str,
+                sandbox_tools: frozenset) -> Tuple:
+    return (
+        owner, "remote", env_type, task_env_id,
+        tuple(sorted(sandbox_tools)),
+    )
 
 
 def _is_alive(kernel: RemoteKernel) -> bool:
@@ -324,7 +328,7 @@ def execute_in_remote_kernel(
     from tools.thread_context import propagate_context_to_thread
 
     owner = _resolve_owner(task_env_id)
-    key = _kernel_key(owner, env_type, task_env_id)
+    key = _kernel_key(owner, env_type, task_env_id, sandbox_tools)
     state_lost = False
     state_reset = False
 


### PR DESCRIPTION
## Summary

- include the sorted sandbox tool set in persistent remote-kernel cache keys
- spawn a fresh kernel and regenerate `hermes_tools.py` when capabilities change
- preserve owner-based disposal while matching the local session-kernel key invariant
- add regression coverage for capability changes on the same owner/environment

Fixes #97263

## Testing

- `python -m pytest -p no:cacheprovider tests/tools/test_code_kernel_remote.py tests/tools/test_code_kernel.py -q`
- `python -m ruff check tools/code_kernel_remote.py tests/tools/test_code_kernel_remote.py`