### PR TITLE
fix(mcp): don't respawn a live stdio server on keepalive ping failure

### DIFF
--- a/contributors/emails/salch-cred@users.noreply.github.com
+++ b/contributors/emails/salch-cred@users.noreply.github.com
@@ -1,0 +1,1 @@
+salch-cred

--- a/tests/tools/test_mcp_reconnect_signal.py
+++ b/tests/tools/test_mcp_reconnect_signal.py
@@ -7,6 +7,7 @@ reconnect with fresh credentials. This file exercises the signal plumbing
 in isolation from the full stdio/http transport machinery.
 """
 import asyncio
+from unittest.mock import patch
 
 import pytest
 
@@ -31,3 +32,36 @@ async def test_wait_for_lifecycle_event_shutdown_wins_when_both_set():
     task._reconnect_event.set()
     reason = await task._wait_for_lifecycle_event()
     assert reason == "shutdown"
+
+
+@pytest.mark.asyncio
+async def test_keepalive_failure_with_live_stdio_child_keeps_session(monkeypatch):
+    """A keepalive failure on a healthy stdio subprocess (ping non-response)
+    must NOT trigger a reconnect/respawn loop. Only when the stdio child has
+    actually exited should a keepalive failure tear the session down.
+    Regression for #97245."""
+    from tools.mcp_tool import MCPServerTask
+
+    def task_with(pids):
+        t = MCPServerTask("srv")
+        t._stdio_child_pids = set(pids)
+        t._is_http = lambda: False
+        return t
+
+    with patch("psutil.pid_exists") as pexists:
+        # Live child pid → _stdio_children_dead() False → keep session.
+        pexists.side_effect = [True]
+        assert task_with({111})._keepalive_failure_should_reconnect() is False
+
+        # Child exited → _stdio_children_dead() True → reconnect.
+        pexists.side_effect = [False]
+        assert task_with({111})._keepalive_failure_should_reconnect() is True
+
+    # HTTP/remote transport → always reconnect (no stdio child to probe).
+    http = MCPServerTask("srv")
+    http._stdio_child_pids = {111}
+    http._is_http = lambda: True
+    assert http._keepalive_failure_should_reconnect() is True
+
+    # No tracked child (unknown) → historical behavior, reconnect.
+    assert task_with(set())._keepalive_failure_should_reconnect() is True

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -3020,6 +3020,27 @@ class MCPServerTask:
                 return
             await asyncio.sleep(0.25)
 
+    def _keepalive_failure_should_reconnect(self) -> bool:
+        """Whether a keepalive failure warrants tearing down the session.
+
+        A keepalive failure means the MCP session went stale — but for a STDIO
+        transport, a ping timeout on a healthy subprocess (one that answers
+        tools but treats the optional ``ping`` as a no-op that never replies)
+        is "alive but unresponsive", not "process died". Respawn in that case
+        would loop forever against the same healthy process (#97245). So:
+        reconnect only when the transport is HTTP/remote (no stdio child to
+        probe) or when a tracked stdio child has actually exited. A live stdio
+        child means the server is still up — keep the session.
+        """
+        if self._is_http():
+            return True
+        if not getattr(self, "_stdio_child_pids", None):
+            # Unknown / no tracked child — default to the historical behavior
+            # (a keepalive failure still means reconnect).
+            return True
+        # A tracked child is present and alive → keep the session, don't loop.
+        return self._stdio_children_dead()
+
     async def _wait_for_lifecycle_event(self) -> str:
         """Block until either _shutdown_event or _reconnect_event fires.
 
@@ -3105,16 +3126,24 @@ class MCPServerTask:
                         await _probe_under_lock()
                     except Exception as exc:
                         root = _unwrap_exception_group(exc)
+                        if self._keepalive_failure_should_reconnect():
+                            logger.warning(
+                                "MCP server '%s' keepalive failed, triggering "
+                                "reconnect (state: connected → degraded): %s: %s",
+                                self.name, type(root).__name__, root,
+                            )
+                            self.mark_suspect(
+                                f"keepalive failed: {type(root).__name__}: {root}"
+                            )
+                            self._reconnect_event.set()
+                            break
                         logger.warning(
-                            "MCP server '%s' keepalive failed, triggering "
-                            "reconnect (state: connected → degraded): %s: %s",
+                            "MCP server '%s' keepalive failed but its stdio "
+                            "subprocess is still alive — treating as a ping "
+                            "non-response, not a dead server; keeping the "
+                            "session instead of respawning (#97245): %s: %s",
                             self.name, type(root).__name__, root,
                         )
-                        self.mark_suspect(
-                            f"keepalive failed: {type(root).__name__}: {root}"
-                        )
-                        self._reconnect_event.set()
-                        break
                     # Keepalive succeeded — the session survived a full
                     # keepalive interval, which is real proof of health.
                     # Clear the rapid-drop budget (#62212).


### PR DESCRIPTION
Fixes #97245 — an MCP stdio server that's healthy but doesn't answer `ping` gets respawned in an endless keepalive loop.

## Root cause

In `MCPServerTask._wait_for_lifecycle_event`, a keepalive failure (any exception from `_keepalive_probe` — including a 30s `send_ping` timeout) unconditionally marks the server suspect and sets `_reconnect_event`, tearing down the session and respawning the stdio subprocess. But a ping timeout on a *healthy* stdio subprocess (one that answers tools but treats the optional MCP `ping` as a no-op that never replies) is "alive but unresponsive", not "process died". Since nothing about the server's actual state changed, the fresh session repeats the same timeout and respawns indefinitely.

The subprocess-liveness signal the keepalive path needed already exists — `_stdio_children_dead()` — but it was only wired into the *tool-call* fast-fail path, not the keepalive loop.

## Fix

Added `_keepalive_failure_should_reconnect()` and used it in the keepalive-failure handler:

- **HTTP/remote** transport, or **no tracked stdio child** (unknown): reconnect as before (unchanged).
- **A tracked stdio child is still alive**: keep the session — the ping non-response is not a dead process, so don't tear down and respawn (breaks the loop).

This mirrors the existing stdio-liveness decision already used at the tool-call boundary.

## Validation

- New regression `test_keepalive_failure_with_live_stdio_child_keeps_session`: a live child pid → keep session (no reconnect); a dead child → reconnect; HTTP and unknown → reconnect (historical behavior preserved).
- Verified the helper output directly against current `main` semantics.
