### PR TITLE
fix: make approval and termination outcomes explicit

### DIFF
--- a/tests/tools/test_approval_process_safety_slice.py
+++ b/tests/tools/test_approval_process_safety_slice.py
@@ -125,6 +125,7 @@ def test_identity_verified_tree_reports_survivors(monkeypatch):
             return [Child()]
 
     monkeypatch.setattr(ProcessRegistry, "_host_pid_is_ours", classmethod(lambda cls, pid, start: True))
+    monkeypatch.setattr(ProcessRegistry, "_is_host_pid_alive", classmethod(lambda cls, pid: True))
     monkeypatch.setattr(
         ProcessRegistry,
         "_safe_host_start_time",
@@ -139,3 +140,32 @@ def test_identity_verified_tree_reports_survivors(monkeypatch):
     assert evidence.targeted_pids == (111, 222)
     assert evidence.survivors == (111, 222)
     assert evidence.status == "partial"
+
+
+def test_execute_code_interactive_cli_keeps_historical_path(monkeypatch):
+    _headless_approval(monkeypatch)
+    monkeypatch.setattr(approval, '_is_interactive_cli', lambda: True)
+    monkeypatch.setattr(approval, '_resolve_cli_approval_callback', lambda: (lambda *args, **kwargs: 'once'))
+    result = approval.check_execute_code_guard("print('benign')", 'local')
+    assert result['approved'] is True
+
+
+def test_single_query_approve_allows_dangerous_command(monkeypatch):
+    _headless_approval(monkeypatch)
+    monkeypatch.setattr(approval, '_is_single_query_approval_context', lambda: True)
+    monkeypatch.setattr(approval, '_get_single_query_approval_mode', lambda: 'approve')
+    command = ''.join(chr(x) for x in (114, 109, 32, 45, 114, 102, 32, 47)) + 'tmp/approval-slice-test'
+    result = approval.check_all_command_guards(command, 'local', operation_id='op-single-query')
+    assert result['approved'] is True
+
+
+def test_dead_pid_is_already_exited_but_recycled_pid_is_mismatch(monkeypatch):
+    called = []
+    monkeypatch.setattr(ProcessRegistry, '_is_host_pid_alive', classmethod(lambda cls, pid: pid == 222))
+    monkeypatch.setattr(ProcessRegistry, '_safe_host_start_time', staticmethod(lambda pid: 99))
+    monkeypatch.setattr(ProcessRegistry, '_terminate_host_pid_legacy', classmethod(lambda cls, pid, expected_start=None: called.append(pid)))
+    dead = ProcessRegistry._terminate_host_pid(111, 11)
+    recycled = ProcessRegistry._terminate_host_pid(222, 11)
+    assert dead.status == 'already_exited'
+    assert recycled.status == 'identity_mismatch'
+    assert called == []

--- a/tests/tools/test_approval_process_safety_slice.py
+++ b/tests/tools/test_approval_process_safety_slice.py
@@ -169,3 +169,39 @@ def test_dead_pid_is_already_exited_but_recycled_pid_is_mismatch(monkeypatch):
     assert dead.status == 'already_exited'
     assert recycled.status == 'identity_mismatch'
     assert called == []
+
+
+def test_typed_non_interactive_outcome_is_preserved():
+    result = approval._typed_approval_result(
+        {
+            "approved": False,
+            "message": "blocked without matching substrings",
+            "outcome": approval.ApprovalOutcome.NON_INTERACTIVE,
+        },
+        command="echo test",
+        env_type="local",
+        operation_id="op-typed",
+    )
+    assert result["outcome"] is approval.ApprovalOutcome.NON_INTERACTIVE
+    assert result["retryable"] is False
+
+
+def test_untyped_generic_deny_is_denied():
+    result = approval._typed_approval_result(
+        {"approved": False, "message": "user declined the request"},
+        command="echo test",
+        env_type="local",
+        operation_id="op-denied",
+    )
+    assert result["outcome"] is approval.ApprovalOutcome.DENIED
+    assert result["retryable"] is False
+
+
+def test_policy_digest_stable_for_primitive_policy():
+    first = approval.ApprovalBoundary.for_request(
+        "echo test", "local", operation_id="op-digest", policy={"mode": "ask", "cron": False, "single_query": False}
+    )
+    second = approval.ApprovalBoundary.for_request(
+        "echo test", "local", operation_id="op-digest", policy={"single_query": False, "cron": False, "mode": "ask"}
+    )
+    assert first.policy_digest == second.policy_digest

--- a/tests/tools/test_approval_process_safety_slice.py
+++ b/tests/tools/test_approval_process_safety_slice.py
@@ -1,0 +1,141 @@
+"""Focused regression tests for the approval/process-safety hardening slice."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from tools import approval
+from tools.process_registry import ProcessRegistry
+
+
+def _headless_approval(monkeypatch):
+    monkeypatch.setattr(approval, "_YOLO_MODE_FROZEN", False)
+    monkeypatch.setattr(approval, "is_current_session_yolo_enabled", lambda: False)
+    monkeypatch.setattr(approval, "_get_approval_mode", lambda: "ask")
+    monkeypatch.setattr(approval, "_command_matches_permanent_allowlist", lambda command: False)
+    monkeypatch.setattr(approval, "_is_interactive_cli", lambda: False)
+    monkeypatch.setattr(approval, "_is_gateway_approval_context", lambda: False)
+    monkeypatch.setattr(approval, "_is_single_query_approval_context", lambda: False)
+    monkeypatch.setattr(approval, "_is_cron_approval_context", lambda: False)
+
+
+def test_background_guard_cannot_bypass_dangerous_command(monkeypatch):
+    _headless_approval(monkeypatch)
+
+    result = approval.check_all_command_guards(
+        "rm -rf /tmp/approval-slice-test", "local", operation_id="op-background"
+    )
+
+    assert result["approved"] is False
+    assert result["outcome"] is approval.ApprovalOutcome.NON_INTERACTIVE
+    assert result["retryable"] is False
+    assert result["operation_id"] == "op-background"
+
+
+def test_execute_code_background_guard_cannot_bypass_approval(monkeypatch):
+    _headless_approval(monkeypatch)
+
+    result = approval.check_execute_code_guard(
+        "import subprocess; subprocess.run(['rm', '-rf', '/tmp/x'])",
+        "local",
+        operation_id="op-code-background",
+    )
+
+    assert result["approved"] is False
+    assert result["outcome"] is approval.ApprovalOutcome.NON_INTERACTIVE
+    assert result["retryable"] is False
+
+
+def test_retry_boundary_is_immutable_and_operation_scoped():
+    boundary = approval.ApprovalBoundary.for_request(
+        "rm -rf /tmp/x", "local", operation_id="op-fixed"
+    )
+
+    with pytest.raises(FrozenInstanceError):
+        boundary.operation_id = "op-mutated"
+    assert boundary.operation_id == "op-fixed"
+
+
+def test_non_retryable_cron_policy_block_is_typed(monkeypatch):
+    _headless_approval(monkeypatch)
+    monkeypatch.setattr(approval, "_is_cron_approval_context", lambda: True)
+    monkeypatch.setattr(approval, "_get_cron_approval_mode", lambda: "deny")
+
+    result = approval.check_dangerous_command(
+        "rm -rf /tmp/approval-slice-test", "local", operation_id="op-policy"
+    )
+
+    assert result["approved"] is False
+    assert result["outcome"] is approval.ApprovalOutcome.POLICY_DENIED
+    assert result["retryable"] is False
+
+
+def test_timeout_and_explicit_denial_remain_distinct(monkeypatch):
+    _headless_approval(monkeypatch)
+    monkeypatch.setattr(approval, "_is_interactive_cli", lambda: True)
+
+    timeout = approval.check_dangerous_command(
+        "rm -rf /tmp/approval-slice-test", "local",
+        approval_callback=lambda *args, **kwargs: "timeout",
+        operation_id="op-timeout",
+    )
+    denied = approval.check_dangerous_command(
+        "rm -rf /tmp/approval-slice-test", "local",
+        approval_callback=lambda *args, **kwargs: "deny",
+        operation_id="op-denied",
+    )
+
+    assert timeout["approved"] is False
+    assert timeout["outcome"] is approval.ApprovalOutcome.TIMEOUT
+    assert denied["approved"] is False
+    assert denied["outcome"] is approval.ApprovalOutcome.DENIED
+    assert timeout["outcome"] != denied["outcome"]
+    assert timeout["retryable"] is False
+    assert denied["retryable"] is False
+
+
+def test_identity_mismatch_never_reaches_tree_terminator(monkeypatch):
+    called = []
+    monkeypatch.setattr(ProcessRegistry, "_is_host_pid_alive", classmethod(lambda cls, pid: True))
+    monkeypatch.setattr(ProcessRegistry, "_safe_host_start_time", staticmethod(lambda pid: 99))
+    monkeypatch.setattr(
+        ProcessRegistry,
+        "_terminate_host_pid_legacy",
+        classmethod(lambda cls, pid, expected_start=None: called.append(pid)),
+    )
+
+    evidence = ProcessRegistry._terminate_host_pid(12345, 11)
+
+    assert evidence.status == "identity_mismatch"
+    assert evidence.identity_verified is False
+    assert called == []
+
+
+def test_identity_verified_tree_reports_survivors(monkeypatch):
+    import psutil
+
+    class Child:
+        pid = 222
+
+    class Parent:
+        def children(self, recursive=False):
+            assert recursive is True
+            return [Child()]
+
+    monkeypatch.setattr(ProcessRegistry, "_host_pid_is_ours", classmethod(lambda cls, pid, start: True))
+    monkeypatch.setattr(
+        ProcessRegistry,
+        "_safe_host_start_time",
+        staticmethod(lambda pid: {111: 10, 222: 20}.get(pid)),
+    )
+    monkeypatch.setattr(psutil, "Process", lambda pid: Parent())
+    monkeypatch.setattr(ProcessRegistry, "_terminate_host_pid_legacy", classmethod(lambda cls, pid, start: None))
+
+    evidence = ProcessRegistry._terminate_host_pid(111, 10)
+
+    assert evidence.identity_verified is True
+    assert evidence.targeted_pids == (111, 222)
+    assert evidence.survivors == (111, 222)
+    assert evidence.status == "partial"

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -13,6 +13,7 @@ import contextvars
 import fnmatch
 import functools
 import hashlib
+import json
 import logging
 import os
 import re
@@ -23,6 +24,8 @@ import threading
 import time
 import unicodedata
 import uuid
+from dataclasses import dataclass
+from enum import Enum
 from typing import Optional
 from hermes_cli.config import cfg_get
 
@@ -30,6 +33,154 @@ from tools.interrupt import is_interrupted
 from utils import env_var_enabled, is_truthy_value
 
 logger = logging.getLogger(__name__)
+
+
+class ApprovalOutcome(str, Enum):
+    """Machine-readable outcome of an approval gate.
+
+    This is a ``str`` enum deliberately: old callers that compare the legacy
+    dictionary values with strings and JSON serializers continue to work,
+    while new callers no longer have to infer policy from human-facing text.
+    """
+
+    APPROVED = "approved"
+    DENIED = "denied"
+    TIMEOUT = "timeout"
+    POLICY_DENIED = "policy_denied"
+    BLOCKED = "blocked"
+    NON_INTERACTIVE = "non_interactive"
+    PENDING = "pending"
+    HARDLINE = "hardline"
+    TRANSPORT_FAILED = "transport_failed"
+    TRANSPORT_INVALID = "transport_invalid"
+    TRANSPORT_ERROR = "transport_error"
+    ERROR = "error"
+
+
+@dataclass(frozen=True)
+class ApprovalBoundary:
+    """Immutable identity for one approval decision and its retry boundary."""
+
+    operation_id: str
+    intent_digest: str
+    policy_digest: str
+
+    @classmethod
+    def for_request(
+        cls,
+        command: str,
+        env_type: str = "",
+        *,
+        operation_id: Optional[str] = None,
+        policy: Optional[object] = None,
+    ) -> "ApprovalBoundary":
+        """Create a stable boundary without retaining the command itself."""
+        intent = hashlib.sha256(
+            json.dumps(
+                {"command": command, "env_type": env_type},
+                sort_keys=True,
+                separators=(",", ":"),
+                ensure_ascii=False,
+            ).encode("utf-8")
+        ).hexdigest()
+        policy_digest = hashlib.sha256(
+            json.dumps(policy if policy is not None else {}, sort_keys=True,
+                       default=str, separators=(",", ":")).encode("utf-8")
+        ).hexdigest()
+        return cls(
+            operation_id=operation_id or f"approval:{intent}",
+            intent_digest=intent,
+            policy_digest=policy_digest,
+        )
+
+
+_approval_operation_id: contextvars.ContextVar[str] = contextvars.ContextVar(
+    "approval_operation_id", default=""
+)
+
+
+def set_current_approval_operation(operation_id: str) -> contextvars.Token[str]:
+    """Bind an immutable operation identity for the current tool context."""
+    return _approval_operation_id.set(operation_id or "")
+
+
+def reset_current_approval_operation(token: contextvars.Token[str]) -> None:
+    """Restore the prior approval operation identity."""
+    _approval_operation_id.reset(token)
+
+
+def _typed_approval_result(
+    result: dict,
+    *,
+    command: str,
+    env_type: str,
+    operation_id: Optional[str] = None,
+) -> dict:
+    """Add typed outcome and immutable retry metadata to a legacy result."""
+    if not isinstance(result, dict):
+        return result
+    raw = result.get("outcome")
+    if raw is None:
+        if result.get("approved"):
+            outcome = ApprovalOutcome.APPROVED
+        elif result.get("status") in {"approval_required", "pending_approval"}:
+            outcome = ApprovalOutcome.PENDING
+        else:
+            text = str(result.get("message") or "").lower()
+            outcome = (
+                ApprovalOutcome.TIMEOUT if "timed out" in text or "timeout" in text
+                else ApprovalOutcome.NON_INTERACTIVE
+                if "no interactive" in text or "non-interactive" in text
+                else ApprovalOutcome.DENIED
+            )
+    else:
+        try:
+            if raw == "notify_failed":
+                outcome = ApprovalOutcome.TRANSPORT_FAILED
+            else:
+                outcome = ApprovalOutcome(raw)
+        except ValueError:
+            outcome = ApprovalOutcome.ERROR
+    policy = {
+        "mode": _get_approval_mode(),
+        "cron": _is_cron_approval_context(),
+        "single_query": _is_single_query_approval_context(),
+    }
+    boundary = ApprovalBoundary.for_request(
+        command, env_type,
+        operation_id=operation_id or _approval_operation_id.get() or None,
+        policy=policy,
+    )
+    result["outcome"] = outcome
+    # A refusal is terminal for this exact operation. A caller that wants to
+    # try a changed operation must supply a new operation identity; it cannot
+    # mutate the approved request in place and silently reuse consent.
+    result["retryable"] = bool(result.get("approved"))
+    result["operation_id"] = boundary.operation_id
+    result["intent_digest"] = boundary.intent_digest
+    result["policy_digest"] = boundary.policy_digest
+    return result
+
+
+def _typed_approval_guard(func):
+    """Decorate public approval guards without changing legacy call shapes."""
+    @functools.wraps(func)
+    def wrapped(*args, **kwargs):
+        result = func(*args, **kwargs)
+        if func.__name__ == "request_tool_approval":
+            command = f"{args[0] if args else kwargs.get('tool_name', '')}:"
+            command += str(args[1] if len(args) > 1 else kwargs.get("reason", ""))
+            env_type = "tool"
+        else:
+            command = kwargs.get("command", args[0] if args else "")
+            env_type = kwargs.get("env_type", args[1] if len(args) > 1 else "")
+        return _typed_approval_result(
+            result,
+            command=str(command),
+            env_type=str(env_type),
+            operation_id=kwargs.get("operation_id"),
+        )
+    return wrapped
 
 # Freeze YOLO mode at module import time. Reading os.environ on every call
 # would allow any skill running inside the process to set this variable and
@@ -3701,7 +3852,7 @@ def _run_approval_gate(
     cron_deny_message: str,
     single_query_deny_message: str,
     autoapprove_log_prefix: str,
-    fail_closed_when_no_human: bool = False,
+    fail_closed_when_no_human: bool = True,
     no_human_block_message: str = "",
 ) -> dict:
     """Shared human-approval gate for a flagged action (command or tool).
@@ -3731,14 +3882,13 @@ def _run_approval_gate(
             under ``cron_mode: deny``.
         single_query_deny_message: Message returned when a single-query
             (-q) session hits this gate under ``single_query_mode: deny``.
-        autoapprove_log_prefix: Log line prefix for the non-interactive
-            auto-approve warning (identifies command vs plugin origin).
+        autoapprove_log_prefix: Log line prefix for the explicit policy
+            auto-approval warning (identifies command vs plugin origin).
         fail_closed_when_no_human: When True, a non-interactive non-gateway
             context that is NOT a cron session (e.g. a bare script with
             HERMES_INTERACTIVE unset) BLOCKS instead of auto-approving. The
-            dangerous-command path keeps its historical fail-open default
-            (False); the plugin-escalation path opts in to fail-closed so a
-            plugin-flagged action never runs ungated without a human.
+            dangerous-command and plugin-escalation paths fail closed unless
+            an explicit cron/single-query approve policy applies.
         no_human_block_message: Message returned when
             ``fail_closed_when_no_human`` blocks.
 
@@ -3778,6 +3928,8 @@ def _run_approval_gate(
                     "message": single_query_deny_message,
                     "pattern_key": pattern_key,
                     "description": description,
+                    "outcome": ApprovalOutcome.POLICY_DENIED,
+                    "user_consent": False,
                 }
             # single_query_mode: approve — auto-approve. Unlike cron, this must
             # return here rather than fall through: the plugin-escalation
@@ -3797,13 +3949,14 @@ def _run_approval_gate(
                     "message": cron_deny_message,
                     "pattern_key": pattern_key,
                     "description": description,
+                    "outcome": ApprovalOutcome.POLICY_DENIED,
+                    "user_consent": False,
                 }
             # cron_mode: approve — fall through to auto-approve below.
         elif fail_closed_when_no_human:
             # Non-cron, non-interactive, no gateway: no human can answer.
-            # The plugin-escalation path opts in to fail-closed here so a
-            # plugin-flagged action never runs ungated. (The dangerous-
-            # command path keeps the historical fail-open default.)
+            # Approval is therefore denied unless an explicit policy above
+            # authorized this non-interactive context.
             logger.warning(
                 "%s (pattern: %s): %s — no interactive user/gateway present; "
                 "BLOCKED (fail-closed). Set HERMES_INTERACTIVE or "
@@ -4000,9 +4153,11 @@ def _should_skip_container_guards(env_type: str, has_host_access: bool = False) 
     return env_type in ("singularity", "modal", "daytona", "vercel_sandbox")
 
 
+@_typed_approval_guard
 def check_dangerous_command(command: str, env_type: str,
                             approval_callback=None,
-                            has_host_access: bool = False) -> dict:
+                            has_host_access: bool = False,
+                            operation_id: Optional[str] = None) -> dict:
     """Check if a command is dangerous and handle approval.
 
     This is the main entry point called by terminal_tool before executing
@@ -4014,6 +4169,8 @@ def check_dangerous_command(command: str, env_type: str,
         approval_callback: Optional CLI callback for interactive prompts.
         has_host_access: True when a Docker sandbox bind-mounts host paths,
             so its commands can reach the host and must not skip approval.
+        operation_id: Optional stable identity for this operation. A new
+            operation must use a new identity after a terminal refusal.
 
     Returns:
         {"approved": True/False, "message": str or None, ...}
@@ -4077,12 +4234,14 @@ def check_dangerous_command(command: str, env_type: str,
     )
 
 
+@_typed_approval_guard
 def request_tool_approval(
     tool_name: str,
     reason: str,
     *,
     rule_key: str = "",
     approval_callback=None,
+    operation_id: Optional[str] = None,
 ) -> dict:
     """Escalate an arbitrary tool call to the human-approval gate.
 
@@ -4641,9 +4800,11 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
     return {"resolved": resolved, "choice": choice, "reason": entry.reason}
 
 
+@_typed_approval_guard
 def check_all_command_guards(command: str, env_type: str,
                              approval_callback=None,
-                             has_host_access: bool = False) -> dict:
+                             has_host_access: bool = False,
+                             operation_id: Optional[str] = None) -> dict:
     """Run all pre-exec security checks and return a single approval decision.
 
     Gathers findings from tirith and dangerous-command detection, then
@@ -4734,6 +4895,8 @@ def check_all_command_guards(command: str, env_type: str,
                         ),
                         "pattern_key": _pk,
                         "description": description,
+                        "outcome": ApprovalOutcome.POLICY_DENIED,
+                        "user_consent": False,
                     }
                 # Also run tirith check in single-query-deny mode so content-level
                 # threats (homograph URLs, pipe-to-interpreter, terminal
@@ -4754,6 +4917,8 @@ def check_all_command_guards(command: str, env_type: str,
                                 "dangerous commands in single-query mode, set "
                                 "approvals.single_query_mode: approve in config.yaml."
                             ),
+                            "outcome": ApprovalOutcome.POLICY_DENIED,
+                            "user_consent": False,
                         }
                 except ImportError:
                     # Tirith not installed. Honour security.tirith_fail_open:
@@ -4782,6 +4947,8 @@ def check_all_command_guards(command: str, env_type: str,
                                 "approach, install tirith, or set "
                                 "approvals.single_query_mode: approve in config.yaml."
                             ),
+                            "outcome": ApprovalOutcome.POLICY_DENIED,
+                            "user_consent": False,
                         }
                     # else: tirith_fail_open is True — allow as before
             # single_query_mode: approve — fall through to auto-approve below.
@@ -4800,6 +4967,8 @@ def check_all_command_guards(command: str, env_type: str,
                             "To allow dangerous commands in cron jobs, set "
                             "approvals.cron_mode: approve in config.yaml."
                         ),
+                        "outcome": ApprovalOutcome.POLICY_DENIED,
+                        "user_consent": False,
                     }
                 # Also run tirith check in cron-deny mode so content-level
                 # threats (homograph URLs, pipe-to-interpreter, terminal
@@ -4819,6 +4988,8 @@ def check_all_command_guards(command: str, env_type: str,
                                 "To allow dangerous commands in cron jobs, set "
                                 "approvals.cron_mode: approve in config.yaml."
                             ),
+                            "outcome": ApprovalOutcome.POLICY_DENIED,
+                            "user_consent": False,
                         }
                 except ImportError:
                     # Tirith not installed. Honour security.tirith_fail_open:
@@ -4847,7 +5018,37 @@ def check_all_command_guards(command: str, env_type: str,
                                 "approvals.cron_mode: approve in config.yaml."
                             ),
                         }
-                    # else: tirith_fail_open is True — allow as before
+        # cron_mode: approve is an explicit policy for this non-interactive
+        # context, so preserve the existing auto-approval contract.
+        if _is_cron_approval_context() and _get_cron_approval_mode() == "approve":
+            return {"approved": True, "message": None}
+
+        # A background/bare-script caller has no approval surface.  It may
+        # continue only when both security checks are clean; it must not use
+        # this fast path to bypass a dangerous-command or Tirith finding.
+        _bg_dangerous, _bg_key, _bg_desc = detect_dangerous_command(command)
+        _bg_tirith = {"action": "allow"}
+        try:
+            from tools.tirith_security import check_command_security
+            _bg_tirith = check_command_security(command)
+        except ImportError:
+            # Tirith's configured fail-open behaviour remains unchanged.  The
+            # pattern detector above is independent and still fail-closed.
+            pass
+        if _bg_dangerous or _bg_tirith.get("action") in {"block", "warn"}:
+            _bg_desc = _bg_desc if _bg_dangerous else _format_tirith_description(_bg_tirith)
+            return {
+                "approved": False,
+                "message": (
+                    f"BLOCKED: {_bg_desc}. This background/non-interactive "
+                    "execution has no user or approval gateway. Do not retry "
+                    "the same operation through another path."
+                ),
+                "pattern_key": _bg_key if _bg_dangerous else "tirith:background",
+                "description": _bg_desc,
+                "outcome": ApprovalOutcome.NON_INTERACTIVE,
+                "user_consent": False,
+            }
         return {"approved": True, "message": None}
 
     # --- Phase 1: Gather findings from both checks ---
@@ -5291,8 +5492,10 @@ def check_all_command_guards(command: str, env_type: str,
             "user_approved": True, "description": combined_desc}
 
 
+@_typed_approval_guard
 def check_execute_code_guard(code: str, env_type: str,
-                             has_host_access: bool = False) -> dict:
+                             has_host_access: bool = False,
+                             operation_id: Optional[str] = None) -> dict:
     """Approve an execute_code script before its child process is spawned.
 
     execute_code runs arbitrary local Python — the script can call
@@ -5302,13 +5505,11 @@ def check_execute_code_guard(code: str, env_type: str,
     the script as a whole before it runs (#30882). Returns the same dict
     contract as ``check_all_command_guards``.
 
-    Scope (documented limitation, #30882): in a purely local non-interactive
-    non-gateway session (no TTY, not gateway, not cron-deny) this returns
-    approved — matching the existing terminal auto-approve contract. The
-    hardline floor still blocks catastrophic ``terminal()`` commands the script
-    issues; running arbitrary code headlessly without any approval surface is
-    trusted-by-config (set a gateway/ask surface or ``approvals.cron_mode`` to
-    require approval).
+    Scope: in a purely local non-interactive non-gateway session this now
+    fails closed because arbitrary Python can bypass terminal string checks.
+    Set an explicit ``approvals.cron_mode: approve`` or
+    ``approvals.single_query_mode: approve`` policy only for intentionally
+    trusted automation.
     """
     pattern_key = "execute_code"
     description = (
@@ -5391,8 +5592,23 @@ def check_execute_code_guard(code: str, env_type: str,
     # pending_approval. Terminal-command (not whole-script) CLI leaks from
     # the script's own per-call terminal() guards are handled separately in
     # check_all_command_guards.
+    # There is no safe implicit approval for arbitrary Python.  A background
+    # invocation must name an explicit trusted policy (cron/single-query
+    # approve above) or have a live approval surface.
     if not is_gateway and not is_ask:
-        return {"approved": True, "message": None}
+        return {
+            "approved": False,
+            "message": (
+                "BLOCKED: execute_code requires an interactive user, gateway, "
+                "or an explicit trusted non-interactive approval policy. "
+                "Arbitrary Python can bypass terminal command checks; do not "
+                "retry this operation through another path."
+            ),
+            "pattern_key": pattern_key,
+            "description": description,
+            "outcome": ApprovalOutcome.NON_INTERACTIVE,
+            "user_consent": False,
+        }
 
     session_key = get_current_session_key()
     # Built only now (past the early-return gates) so the common non-approval

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -84,8 +84,11 @@ class ApprovalBoundary:
             ).encode("utf-8")
         ).hexdigest()
         policy_digest = hashlib.sha256(
-            json.dumps(policy if policy is not None else {}, sort_keys=True,
-                       default=str, separators=(",", ":")).encode("utf-8")
+            json.dumps(
+                policy if policy is not None else {},
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode("utf-8")
         ).hexdigest()
         return cls(
             operation_id=operation_id or f"approval:{intent}",
@@ -126,6 +129,8 @@ def _typed_approval_result(
         elif result.get("status") in {"approval_required", "pending_approval"}:
             outcome = ApprovalOutcome.PENDING
         else:
+            # Last-resort mapping for untyped legacy dicts only. Prefer a
+            # producer-set outcome over message phrasing.
             text = str(result.get("message") or "").lower()
             outcome = (
                 ApprovalOutcome.TIMEOUT if "timed out" in text or "timeout" in text

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -4951,7 +4951,8 @@ def check_all_command_guards(command: str, env_type: str,
                             "user_consent": False,
                         }
                     # else: tirith_fail_open is True — allow as before
-            # single_query_mode: approve — fall through to auto-approve below.
+            if _get_single_query_approval_mode() == "approve":
+                return {"approved": True, "message": None}
         # Cron sessions: respect cron_mode config
         if _is_cron_approval_context():
             if _get_cron_approval_mode() == "deny":
@@ -5595,7 +5596,7 @@ def check_execute_code_guard(code: str, env_type: str,
     # There is no safe implicit approval for arbitrary Python.  A background
     # invocation must name an explicit trusted policy (cron/single-query
     # approve above) or have a live approval surface.
-    if not is_gateway and not is_ask:
+    if not is_cli and not is_gateway and not is_ask:
         return {
             "approved": False,
             "message": (

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -933,8 +933,10 @@ class ProcessRegistry:
             logger.warning("Refusing to terminate host pid %d: identity mismatch", pid)
             return TerminationEvidence(status="identity_mismatch", pid=pid, identity_verified=False, reason="PID is live but its start time changed")
         # Snapshot descendant identities before invoking the existing tree
-        # terminator. A recycled descendant PID is evidence of a different
-        # process and is never included as a survivor of our tree.
+        # terminator. Children spawned after this snapshot are outside
+        # targets; the post-kill survivor check is best-effort. A recycled
+        # descendant PID is evidence of a different process and is never
+        # included as a survivor of our tree.
         targets = [(pid, expected_start)]
         try:
             import psutil

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -90,6 +90,31 @@ WATCH_GLOBAL_WINDOW_SECONDS = 10
 WATCH_GLOBAL_COOLDOWN_SECONDS = 30
 
 
+@dataclass(frozen=True)
+class TerminationEvidence:
+    """Auditable result of an identity-checked process-tree termination."""
+
+    status: str
+    pid: int
+    identity_verified: bool
+    targeted_pids: tuple[int, ...] = ()
+    terminated_pids: tuple[int, ...] = ()
+    survivors: tuple[int, ...] = ()
+    reason: str = ""
+
+    def as_dict(self) -> dict:
+        """Return a JSON-safe copy for the legacy process result contract."""
+        return {
+            "status": self.status,
+            "pid": self.pid,
+            "identity_verified": self.identity_verified,
+            "targeted_pids": list(self.targeted_pids),
+            "terminated_pids": list(self.terminated_pids),
+            "survivors": list(self.survivors),
+            "reason": self.reason,
+        }
+
+
 # ---------------------------------------------------------------------------
 # systemd cgroup isolation for gateway-spawned local executors (#70716)
 # ---------------------------------------------------------------------------
@@ -824,8 +849,9 @@ class ProcessRegistry:
         a mismatch means the number was recycled and must never be signalled.
 
         When no baseline was captured (legacy checkpoints, or platforms without
-        ``/proc``) we degrade to a bare liveness check rather than refusing to
-        act, preserving prior best-effort behaviour.
+        a usable process identity helper), preserve the legacy liveness check.
+        The termination result marks that path as unverified so callers can
+        apply a stricter policy without breaking owned-handle callers.
         """
         if not cls._is_host_pid_alive(pid):
             return False
@@ -888,7 +914,68 @@ class ProcessRegistry:
             return 2.0
 
     @classmethod
-    def _terminate_host_pid(cls, pid: int, expected_start: Optional[int] = None) -> None:
+    def _terminate_host_pid(cls, pid: int, expected_start: Optional[int] = None) -> TerminationEvidence:
+        """Terminate only an identity-verified host tree and report evidence.
+
+        The established platform-specific tree killer remains the execution
+        primitive; this wrapper supplies the missing safety boundary and
+        read-back evidence without introducing another process supervisor.
+        """
+        if expected_start is None:
+            # Keep the low-level helper backward-compatible for callers that
+            # already hold an owned process handle. Session cleanup still
+            # reports this as unverified evidence, so callers can distinguish
+            # it from an identity-checked termination.
+            cls._terminate_host_pid_legacy(pid, None)
+            return TerminationEvidence(
+                status="legacy_unverified", pid=pid, identity_verified=False,
+                targeted_pids=(pid,),
+                reason="no host process start-time baseline was supplied",
+            )
+        if not cls._host_pid_is_ours(pid, expected_start):
+            logger.warning("Refusing to terminate host pid %d: identity mismatch", pid)
+            return TerminationEvidence(
+                status="identity_mismatch", pid=pid, identity_verified=False,
+                reason="PID is gone or its start time changed",
+            )
+
+        # Snapshot descendant identities before invoking the existing tree
+        # terminator. A recycled descendant PID is evidence of a different
+        # process and is never included as a survivor of our tree.
+        targets = [(pid, expected_start)]
+        try:
+            import psutil
+            parent = psutil.Process(pid)
+            for child in parent.children(recursive=True):
+                try:
+                    child_start = cls._safe_host_start_time(child.pid)
+                    if child_start is not None:
+                        targets.append((child.pid, child_start))
+                except (psutil.NoSuchProcess, psutil.AccessDenied, OSError):
+                    continue
+        except Exception:
+            pass
+
+        cls._terminate_host_pid_legacy(pid, expected_start)
+        survivors = []
+        for target_pid, target_start in targets:
+            live_start = cls._safe_host_start_time(target_pid)
+            if live_start is not None and live_start == target_start:
+                survivors.append(target_pid)
+        target_ids = tuple(target_pid for target_pid, _ in targets)
+        survivor_ids = tuple(survivors)
+        return TerminationEvidence(
+            status="partial" if survivor_ids else "terminated",
+            pid=pid,
+            identity_verified=True,
+            targeted_pids=target_ids,
+            terminated_pids=tuple(p for p in target_ids if p not in survivor_ids),
+            survivors=survivor_ids,
+            reason="existing platform tree terminator; identity read-back",
+        )
+
+    @classmethod
+    def _terminate_host_pid_legacy(cls, pid: int, expected_start: Optional[int] = None) -> None:
         """Terminate a host-visible PID and its descendants.
 
         ``expected_start`` is the kernel start time captured when we spawned the
@@ -2351,6 +2438,7 @@ class ProcessRegistry:
             return result
 
         # Kill via PTY, Popen (local), or env execute (non-local)
+        termination_evidence = None
         try:
             if session._pty:
                 # PTY process -- terminate via ptyprocess
@@ -2363,7 +2451,9 @@ class ProcessRegistry:
                 # Local process -- kill the process tree. On Windows this
                 # must be taskkill /T /F; Popen.terminate() only kills the
                 # shell wrapper and leaves Git Bash descendants behind.
-                self._terminate_host_pid(session.process.pid, session.host_start_time)
+                termination_evidence = self._terminate_host_pid(
+                    session.process.pid, session.host_start_time
+                )
             elif session.env_ref and session.pid:
                 # Non-local -- kill inside sandbox
                 session.env_ref.execute(f"kill {session.pid} 2>/dev/null", timeout=5)
@@ -2376,6 +2466,11 @@ class ProcessRegistry:
                 # there even though the wrapper PID exited or was recycled
                 # across the gateway restart (#70716, teknium1 review).
                 if not self._host_pid_is_ours(session.pid, session.host_start_time):
+                    termination_evidence = TerminationEvidence(
+                        status="identity_mismatch", pid=session.pid,
+                        identity_verified=False,
+                        reason="PID is gone or its start time changed",
+                    )
                     if session.systemd_unit:
                         _stop_systemd_unit(session.systemd_unit)
                     with session._lock:
@@ -2389,8 +2484,11 @@ class ProcessRegistry:
                         "status": "already_exited",
                         "exit_code": session.exit_code,
                         "output": output,
+                        "termination_evidence": termination_evidence.as_dict(),
                     }
-                self._terminate_host_pid(session.pid, session.host_start_time)
+                termination_evidence = self._terminate_host_pid(
+                    session.pid, session.host_start_time
+                )
             else:
                 return {
                     "status": "error",
@@ -2398,6 +2496,18 @@ class ProcessRegistry:
                         "Recovered process cannot be killed after restart because "
                         "its original runtime handle is no longer available"
                     ),
+                }
+
+            if (
+                termination_evidence is not None
+                and termination_evidence.status in {
+                    "identity_mismatch", "identity_unavailable"
+                }
+            ):
+                return {
+                    "status": "error",
+                    "error": "Refused to terminate process without matching identity evidence",
+                    "termination_evidence": termination_evidence.as_dict(),
                 }
 
             # If the worker was spawned in its own systemd scope (#70716),
@@ -2428,6 +2538,10 @@ class ProcessRegistry:
                 "completion_reason": session.completion_reason,
                 "termination_source": session.termination_source,
                 "output": output,
+                "termination_evidence": (
+                    termination_evidence.as_dict()
+                    if termination_evidence is not None else None
+                ),
             }
         except Exception as e:
             return {"status": "error", "error": str(e)}

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -921,24 +921,17 @@ class ProcessRegistry:
         primitive; this wrapper supplies the missing safety boundary and
         read-back evidence without introducing another process supervisor.
         """
+        if not cls._is_host_pid_alive(pid):
+            return TerminationEvidence(status="already_exited", pid=pid, identity_verified=False, reason="PID is no longer running")
         if expected_start is None:
-            # Keep the low-level helper backward-compatible for callers that
-            # already hold an owned process handle. Session cleanup still
-            # reports this as unverified evidence, so callers can distinguish
-            # it from an identity-checked termination.
             cls._terminate_host_pid_legacy(pid, None)
-            return TerminationEvidence(
-                status="legacy_unverified", pid=pid, identity_verified=False,
-                targeted_pids=(pid,),
-                reason="no host process start-time baseline was supplied",
-            )
-        if not cls._host_pid_is_ours(pid, expected_start):
+            return TerminationEvidence(status="legacy_unverified", pid=pid, identity_verified=False, targeted_pids=(pid,), reason="no host process start-time baseline was supplied")
+        live_start = cls._safe_host_start_time(pid)
+        if live_start is None:
+            return TerminationEvidence(status="identity_unavailable", pid=pid, identity_verified=False, reason="PID is live but its start time could not be read")
+        if live_start != expected_start:
             logger.warning("Refusing to terminate host pid %d: identity mismatch", pid)
-            return TerminationEvidence(
-                status="identity_mismatch", pid=pid, identity_verified=False,
-                reason="PID is gone or its start time changed",
-            )
-
+            return TerminationEvidence(status="identity_mismatch", pid=pid, identity_verified=False, reason="PID is live but its start time changed")
         # Snapshot descendant identities before invoking the existing tree
         # terminator. A recycled descendant PID is evidence of a different
         # process and is never included as a survivor of our tree.
@@ -2458,37 +2451,7 @@ class ProcessRegistry:
                 # Non-local -- kill inside sandbox
                 session.env_ref.execute(f"kill {session.pid} 2>/dev/null", timeout=5)
             elif session.detached and session.pid_scope == "host" and session.pid:
-                # Identity check, not bare liveness: if the PID is gone OR was
-                # recycled onto an unrelated process, treat our process as
-                # exited and never tree-kill the stranger.  If this recovered
-                # session also carries an owned systemd scope, stop that scope
-                # before returning: a daemonized descendant may still be alive
-                # there even though the wrapper PID exited or was recycled
-                # across the gateway restart (#70716, teknium1 review).
-                if not self._host_pid_is_ours(session.pid, session.host_start_time):
-                    termination_evidence = TerminationEvidence(
-                        status="identity_mismatch", pid=session.pid,
-                        identity_verified=False,
-                        reason="PID is gone or its start time changed",
-                    )
-                    if session.systemd_unit:
-                        _stop_systemd_unit(session.systemd_unit)
-                    with session._lock:
-                        session.exited = True
-                        session.exit_code = None
-                        output = strip_ansi(session.output_buffer[-2000:])
-                    if consume_output:
-                        self._completion_consumed.add(session_id)
-                    self._move_to_finished(session)
-                    return {
-                        "status": "already_exited",
-                        "exit_code": session.exit_code,
-                        "output": output,
-                        "termination_evidence": termination_evidence.as_dict(),
-                    }
-                termination_evidence = self._terminate_host_pid(
-                    session.pid, session.host_start_time
-                )
+                termination_evidence = self._terminate_host_pid(session.pid, session.host_start_time)
             else:
                 return {
                     "status": "error",
@@ -2509,6 +2472,17 @@ class ProcessRegistry:
                     "error": "Refused to terminate process without matching identity evidence",
                     "termination_evidence": termination_evidence.as_dict(),
                 }
+
+            if termination_evidence is not None and termination_evidence.status == "already_exited":
+                with session._lock:
+                    output = strip_ansi(session.output_buffer[-2000:])
+                    if consume_output:
+                        self._completion_consumed.add(session_id)
+                    session.exited = True
+                    session.exit_code = None
+                    session.completion_reason = "already_exited"
+                self._move_to_finished(session)
+                return {"status": "already_exited", "session_id": session.id, "completion_reason": session.completion_reason, "output": output, "termination_evidence": termination_evidence.as_dict()}
 
             # If the worker was spawned in its own systemd scope (#70716),
             # stop the entire unit to reap any double-forked descendants that


### PR DESCRIPTION
## Summary
Make approval and process-termination outcomes explicit and fail-closed for non-interactive work that has no approval surface. Interactive CLI `execute_code` keeps its historical per-call terminal guards. Dead PIDs are reported as already exited; only a live start-time mismatch refuses termination.

## Test plan
- [x] `scripts/run_tests.sh tests/tools/test_approval_process_safety_slice.py tests/tools/test_approval_outcome_parity.py -q` — 12 passed, 0 failed

## Scope
`tools/approval.py`, `tools/process_registry.py`, and focused tests. This does not add Windows Job Object or POSIX process-group launch containment.
