### PR TITLE
feat: clarify session activity status

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
@@ -598,9 +598,21 @@ const AssistantActionBar: FC<MessageActionProps & { durationS?: number }> = ({
     [react]
   )
 
+  const hasCompletedOutcome = typeof durationS === 'number' && Number.isFinite(durationS) && durationS >= 0
+
   return (
     <div className="relative flex w-full shrink-0 items-center justify-end gap-1.5">
-      {durationS !== undefined && (
+      {hasCompletedOutcome && (
+        <span
+          aria-label={t.assistant.thread.completed}
+          className="select-none px-0.5 text-[0.6875rem] leading-5 text-muted-foreground"
+          data-slot="aui_turn-outcome"
+          title={t.assistant.thread.completed}
+        >
+          {t.assistant.thread.completed}
+        </span>
+      )}
+      {hasCompletedOutcome && (
         <span
           className="mr-auto select-none px-0.5 text-[0.6875rem] leading-5 tabular-nums text-muted-foreground"
           data-slot="aui_turn-duration"

--- a/apps/desktop/src/components/assistant-ui/thread/status.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/status.test.tsx
@@ -6,7 +6,7 @@ import { I18nProvider } from '@/i18n'
 import { $providerWaitSessions, setSessionProviderWait } from '@/store/provider-wait'
 import { $activeSessionId, $turnStartedAt } from '@/store/session'
 
-import { ResponseLoadingIndicator } from './status'
+import { resolveThreadActivityPhase, ResponseLoadingIndicator } from './status'
 
 function renderIndicator() {
   return render(
@@ -84,5 +84,35 @@ describe('status line', () => {
     const { container } = renderIndicator()
 
     expect(container.querySelector('[role="status"]')?.hasAttribute('data-conversation-scaffold')).toBe(true)
+  })
+})
+
+describe('resolveThreadActivityPhase', () => {
+  const base = {
+    awaitingInput: false,
+    busy: true,
+    compacting: false,
+    providerWait: '',
+    quiet: false,
+    stalled: false
+  }
+
+  it('prioritizes user input over every other active signal', () => {
+    expect(resolveThreadActivityPhase({ ...base, awaitingInput: true, compacting: true, stalled: true })).toBe('input-required')
+  })
+
+  it('keeps provider wording instead of guessing a wait deadline', () => {
+    expect(resolveThreadActivityPhase({ ...base, providerWait: 'waiting on local-model' })).toBe('provider-wait')
+  })
+
+  it('distinguishes compaction, stalled, quiet, and ordinary running work', () => {
+    expect(resolveThreadActivityPhase({ ...base, compacting: true })).toBe('compacting')
+    expect(resolveThreadActivityPhase({ ...base, stalled: true })).toBe('stalled')
+    expect(resolveThreadActivityPhase({ ...base, quiet: true })).toBe('quiet-running')
+    expect(resolveThreadActivityPhase(base)).toBe('running')
+  })
+
+  it('does not claim a running phase for an idle session', () => {
+    expect(resolveThreadActivityPhase({ ...base, busy: false })).toBe('idle')
   })
 })

--- a/apps/desktop/src/components/assistant-ui/thread/status.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/status.test.tsx
@@ -2,9 +2,11 @@ import { act, cleanup, render, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { __resetElapsedTimerRegistryForTests } from '@/components/chat/activity-timer'
+import { clearClarifyRequest, setClarifyRequest } from '@/store/clarify'
 import { I18nProvider } from '@/i18n'
 import { $providerWaitSessions, setSessionProviderWait } from '@/store/provider-wait'
-import { $activeSessionId, $turnStartedAt } from '@/store/session'
+import { setSessionCompacting } from '@/store/compaction'
+import { $activeSessionId, $turnStartedAt, setBusy } from '@/store/session'
 
 import { resolveThreadActivityPhase, ResponseLoadingIndicator } from './status'
 
@@ -64,6 +66,7 @@ describe('ResponseLoadingIndicator timer', () => {
   it('names a prolonged provider wait in the existing response status row', () => {
     $activeSessionId.set('session-a')
     $turnStartedAt.set(Date.now())
+    setBusy(() => true)
     setSessionProviderWait('session-a', '⏳ waiting on local-model — 30s with no output yet')
 
     renderIndicator()
@@ -114,5 +117,43 @@ describe('resolveThreadActivityPhase', () => {
 
   it('does not claim a running phase for an idle session', () => {
     expect(resolveThreadActivityPhase({ ...base, busy: false })).toBe('idle')
+  })
+})
+describe('status hint', () => {
+  afterEach(() => {
+    cleanup()
+    clearClarifyRequest()
+    setSessionCompacting('session-a', false)
+    setBusy(() => false)
+    $activeSessionId.set(null)
+    $turnStartedAt.set(null)
+    $providerWaitSessions.set({})
+  })
+
+  it('uses input-required copy when input is requested during compaction', () => {
+    $activeSessionId.set('session-a')
+    $turnStartedAt.set(Date.now())
+    setBusy(() => true)
+    setSessionCompacting('session-a', true)
+    setClarifyRequest({ choices: null, multiSelect: false, question: 'q', requestId: 'req-a', sessionId: 'session-a' })
+
+    renderIndicator()
+
+    const status = screen.getByRole('status')
+    expect(status.getAttribute('aria-label')).toBe('Needs your input')
+    expect(status.getAttribute('aria-label')).not.toBe('Summarizing thread')
+    expect(status.querySelector('.shimmer')).toBeNull()
+  })
+
+  it('ignores whitespace-only provider wait in the status hint', () => {
+    $activeSessionId.set('session-a')
+    $turnStartedAt.set(Date.now())
+    setBusy(() => true)
+    setSessionProviderWait('session-a', '   ')
+
+    renderIndicator()
+
+    const status = screen.getByRole('status')
+    expect(status.getAttribute('aria-label')).toBe('Hermes is loading a response')
   })
 })

--- a/apps/desktop/src/components/assistant-ui/thread/status.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/status.test.tsx
@@ -118,6 +118,16 @@ describe('resolveThreadActivityPhase', () => {
   it('does not claim a running phase for an idle session', () => {
     expect(resolveThreadActivityPhase({ ...base, busy: false })).toBe('idle')
   })
+
+  it('masks provider wait text while compaction is in progress', () => {
+    expect(
+      resolveThreadActivityPhase({
+        ...base,
+        compacting: true,
+        providerWait: 'waiting on local-model'
+      })
+    ).toBe('compacting')
+  })
 })
 describe('status hint', () => {
   afterEach(() => {

--- a/apps/desktop/src/components/assistant-ui/thread/status.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/status.tsx
@@ -95,8 +95,8 @@ export function resolveThreadActivityPhase(evidence: ThreadActivityEvidence): Th
   return evidence.quiet ? 'quiet-running' : 'running'
 }
 
-const HintText: FC<{ children: ReactNode }> = ({ children }) => (
-  <span className={cn(SCAFFOLD_LABEL_CLASS, 'shimmer min-w-0 flex-1 truncate')}>{children}</span>
+const HintText: FC<{ children: ReactNode; shimmer?: boolean }> = ({ children, shimmer = true }) => (
+  <span className={cn(SCAFFOLD_LABEL_CLASS, shimmer && 'shimmer', 'min-w-0 flex-1 truncate')}>{children}</span>
 )
 
 /** These indicators render inside whichever transcript mounted them, so every
@@ -146,12 +146,38 @@ const DRAFTING_REVEAL_MS = 200
  * What to call the wait, if it deserves a name. Compaction outranks a draft —
  * it's rarer, slower, and explains a transcript that looks like it reset.
  */
+type StatusLabels = {
+  foregroundRunning: string
+  inputRequired: string
+  quietRunning: string
+  stalledWarning: string
+}
+
+function statusDescription(phase: ThreadActivityPhase, labels: StatusLabels): string | undefined {
+  if (phase === 'input-required') {
+    return labels.inputRequired
+  }
+
+  if (phase === 'stalled') {
+    return labels.stalledWarning
+  }
+
+  if (phase === 'quiet-running') {
+    return labels.quietRunning
+  }
+
+  if (phase === 'running' || phase === 'compacting') {
+    return labels.foregroundRunning
+  }
+
+  return undefined
+}
+
 function useStatusHint(
-  compacting: boolean,
   drafting: DraftingTool | null,
   providerWait: string,
   phase: ThreadActivityPhase,
-  labels: { inputRequired: string; quietRunning: string; stalledWarning: string }
+  labels: StatusLabels
 ): string {
   const [revealed, setRevealed] = useState(false)
   const name = drafting?.name ?? ''
@@ -168,10 +194,6 @@ function useStatusHint(
     return () => window.clearTimeout(id)
   }, [name])
 
-  if (compacting) {
-    return COMPACTION_LABEL
-  }
-
   if (phase === 'input-required') {
     return labels.inputRequired
   }
@@ -180,7 +202,11 @@ function useStatusHint(
     return labels.stalledWarning
   }
 
-  if (providerWait) {
+  if (phase === 'compacting') {
+    return COMPACTION_LABEL
+  }
+
+  if (phase === 'provider-wait' && providerWait.trim()) {
     return providerWait
   }
 
@@ -224,7 +250,8 @@ export const ResponseLoadingIndicator: FC = () => {
     stalled
   })
   const elapsed = useElapsedSeconds(true, undefined, turnStartedAt)
-  const hint = useStatusHint(compacting, drafting, providerWait, phase, {
+  const hint = useStatusHint(drafting, providerWait, phase, {
+    foregroundRunning: t.assistant.thread.foregroundRunning,
     inputRequired: t.assistant.thread.inputRequired,
     quietRunning: t.assistant.thread.quietRunning,
     stalledWarning: t.assistant.thread.stalledWarning
@@ -232,7 +259,7 @@ export const ResponseLoadingIndicator: FC = () => {
 
   return (
     <StatusRow
-      aria-description={t.assistant.thread.foregroundRunning}
+      aria-description={statusDescription(phase, { foregroundRunning: t.assistant.thread.foregroundRunning, inputRequired: t.assistant.thread.inputRequired, quietRunning: t.assistant.thread.quietRunning, stalledWarning: t.assistant.thread.stalledWarning })}
       data-slot="aui_response-loading"
       label={hint || t.assistant.thread.loadingResponse}
     >
@@ -241,7 +268,7 @@ export const ResponseLoadingIndicator: FC = () => {
         className="dither inline-block size-3 rounded-[2px] text-midground/80"
         kind="opacity"
       />
-      {hint && <HintText>{hint}</HintText>}
+      {hint && <HintText shimmer={phase !== 'input-required' && phase !== 'stalled'}>{hint}</HintText>}
       <ActivityTimerText seconds={elapsed} />
     </StatusRow>
   )
@@ -331,7 +358,8 @@ export const TurnActivityIndicator: FC = () => {
     quiet: quietSince !== undefined,
     stalled
   })
-  const hint = useStatusHint(compacting, drafting, providerWait, phase, {
+  const hint = useStatusHint(drafting, providerWait, phase, {
+    foregroundRunning: t.assistant.thread.foregroundRunning,
     inputRequired: t.assistant.thread.inputRequired,
     quietRunning: t.assistant.thread.quietRunning,
     stalledWarning: t.assistant.thread.stalledWarning
@@ -355,7 +383,7 @@ export const TurnActivityIndicator: FC = () => {
 
   return (
     <StatusRow
-      aria-description={t.assistant.thread.foregroundRunning}
+      aria-description={statusDescription(phase, { foregroundRunning: t.assistant.thread.foregroundRunning, inputRequired: t.assistant.thread.inputRequired, quietRunning: t.assistant.thread.quietRunning, stalledWarning: t.assistant.thread.stalledWarning })}
       data-slot="aui_turn-activity"
       label={hint || t.assistant.thread.loadingResponse}
     >
@@ -370,7 +398,7 @@ export const TurnActivityIndicator: FC = () => {
           kind="opacity"
         />
       )}
-      <HintText>{hint}</HintText>
+      <HintText shimmer={phase !== 'input-required' && phase !== 'stalled'}>{hint}</HintText>
       {phase !== 'input-required' && <ActivityTimerText seconds={elapsed} />}
     </StatusRow>
   )

--- a/apps/desktop/src/components/assistant-ui/thread/status.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/status.tsx
@@ -70,6 +70,9 @@ export interface ThreadActivityEvidence {
  * Reduce the already session-scoped evidence to one honest label family.
  * Provider text is intentionally not interpreted: a missing deadline stays
  * missing rather than becoming a fabricated timeout or countdown.
+ * Compaction is evaluated before provider-wait, so a compaction in progress
+ * masks coexisting provider wait text. The quiet flag is only meaningful for
+ * turn-activity surfaces; the pre-first-token spinner passes quiet: false.
  */
 export function resolveThreadActivityPhase(evidence: ThreadActivityEvidence): ThreadActivityPhase {
   if (evidence.awaitingInput) {
@@ -246,6 +249,8 @@ export const ResponseLoadingIndicator: FC = () => {
     busy,
     compacting,
     providerWait,
+    // Intentionally false: this row is the pre-first-token spinner and has no
+    // quiet state. quiet-running is owned by TurnActivityIndicator via quietSince.
     quiet: false,
     stalled
   })

--- a/apps/desktop/src/components/assistant-ui/thread/status.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/status.tsx
@@ -17,6 +17,7 @@ import { $backgroundResume } from '@/store/background-delegation'
 import { sessionCompacting } from '@/store/compaction'
 import { sessionAwaitingInput } from '@/store/prompts'
 import { sessionProviderWait } from '@/store/provider-wait'
+import { $stalledSessionIds } from '@/store/session-states'
 import { type DraftingTool, sessionDraftingTool } from '@/store/tool-drafting'
 
 // A status line is scaffolding like any other — "Editing" while the model
@@ -47,6 +48,53 @@ const StatusRow: FC<{ children: ReactNode; label: string } & React.ComponentProp
 // Fixed label while auto-compaction runs — decoupled from backend status text.
 const COMPACTION_LABEL = 'Summarizing thread'
 
+export type ThreadActivityPhase =
+  | 'compacting'
+  | 'idle'
+  | 'input-required'
+  | 'provider-wait'
+  | 'quiet-running'
+  | 'running'
+  | 'stalled'
+
+export interface ThreadActivityEvidence {
+  awaitingInput: boolean
+  busy: boolean
+  compacting: boolean
+  providerWait: string
+  quiet: boolean
+  stalled: boolean
+}
+
+/**
+ * Reduce the already session-scoped evidence to one honest label family.
+ * Provider text is intentionally not interpreted: a missing deadline stays
+ * missing rather than becoming a fabricated timeout or countdown.
+ */
+export function resolveThreadActivityPhase(evidence: ThreadActivityEvidence): ThreadActivityPhase {
+  if (evidence.awaitingInput) {
+    return 'input-required'
+  }
+
+  if (!evidence.busy) {
+    return 'idle'
+  }
+
+  if (evidence.compacting) {
+    return 'compacting'
+  }
+
+  if (evidence.providerWait.trim()) {
+    return 'provider-wait'
+  }
+
+  if (evidence.stalled) {
+    return 'stalled'
+  }
+
+  return evidence.quiet ? 'quiet-running' : 'running'
+}
+
 const HintText: FC<{ children: ReactNode }> = ({ children }) => (
   <span className={cn(SCAFFOLD_LABEL_CLASS, 'shimmer min-w-0 flex-1 truncate')}>{children}</span>
 )
@@ -57,6 +105,7 @@ const HintText: FC<{ children: ReactNode }> = ({ children }) => (
 function useThreadSessionStatus() {
   const view = useSessionView()
   const sessionId = useStore(view.$runtimeId)
+  const storedSessionId = useStore(view.$storedId)
   // The same turn-busy the composer's arc border and Stop button read. The
   // message-level `running` flag is a weaker signal: it goes false in the gaps
   // between bubbles (a sealed interim row, a settled turn the backend hasn't
@@ -71,6 +120,8 @@ function useThreadSessionStatus() {
   // user, not working — so don't resurrect the "thinking" timer while they
   // decide (matches the pet's awaitingInput pose taking priority over busy).
   const awaitingInput = useStore(useMemo(() => sessionAwaitingInput(sessionId), [sessionId]))
+  const stalledSessionIds = useStore($stalledSessionIds)
+  const stalled = Boolean(storedSessionId && stalledSessionIds.includes(storedSessionId))
 
   return {
     awaitingInput,
@@ -78,6 +129,7 @@ function useThreadSessionStatus() {
     compacting,
     drafting,
     providerWait,
+    stalled,
     // Epoch ms this surface's turn began, or undefined between turns. The
     // origin for anything measuring the WHOLE turn rather than one phase of
     // it — including the first seconds of a brand-new chat, where the value is
@@ -94,7 +146,13 @@ const DRAFTING_REVEAL_MS = 200
  * What to call the wait, if it deserves a name. Compaction outranks a draft —
  * it's rarer, slower, and explains a transcript that looks like it reset.
  */
-function useStatusHint(compacting: boolean, drafting: DraftingTool | null, providerWait: string): string {
+function useStatusHint(
+  compacting: boolean,
+  drafting: DraftingTool | null,
+  providerWait: string,
+  phase: ThreadActivityPhase,
+  labels: { inputRequired: string; quietRunning: string; stalledWarning: string }
+): string {
   const [revealed, setRevealed] = useState(false)
   const name = drafting?.name ?? ''
 
@@ -114,8 +172,20 @@ function useStatusHint(compacting: boolean, drafting: DraftingTool | null, provi
     return COMPACTION_LABEL
   }
 
+  if (phase === 'input-required') {
+    return labels.inputRequired
+  }
+
+  if (phase === 'stalled') {
+    return labels.stalledWarning
+  }
+
   if (providerWait) {
     return providerWait
+  }
+
+  if (phase === 'quiet-running') {
+    return labels.quietRunning
   }
 
   return revealed && name ? toolPresentVerb(name) : ''
@@ -144,12 +214,28 @@ export const CenteredThreadSpinner: FC = () => {
 
 export const ResponseLoadingIndicator: FC = () => {
   const { t } = useI18n()
-  const { compacting, drafting, providerWait, turnStartedAt } = useThreadSessionStatus()
+  const { awaitingInput, busy, compacting, drafting, providerWait, stalled, turnStartedAt } = useThreadSessionStatus()
+  const phase = resolveThreadActivityPhase({
+    awaitingInput,
+    busy,
+    compacting,
+    providerWait,
+    quiet: false,
+    stalled
+  })
   const elapsed = useElapsedSeconds(true, undefined, turnStartedAt)
-  const hint = useStatusHint(compacting, drafting, providerWait)
+  const hint = useStatusHint(compacting, drafting, providerWait, phase, {
+    inputRequired: t.assistant.thread.inputRequired,
+    quietRunning: t.assistant.thread.quietRunning,
+    stalledWarning: t.assistant.thread.stalledWarning
+  })
 
   return (
-    <StatusRow data-slot="aui_response-loading" label={hint || t.assistant.thread.loadingResponse}>
+    <StatusRow
+      aria-description={t.assistant.thread.foregroundRunning}
+      data-slot="aui_response-loading"
+      label={hint || t.assistant.thread.loadingResponse}
+    >
       <StatusPulse
         aria-hidden="true"
         className="dither inline-block size-3 rounded-[2px] text-midground/80"
@@ -180,6 +266,7 @@ export const BackgroundResumeNotice: FC = () => {
 
   return (
     <div
+      aria-label={`${t.assistant.thread.backgroundRunning}: ${label}`}
       aria-live="polite"
       className="flex max-w-[min(86%,44rem)] items-center gap-1.5 self-center px-2 py-0.5 text-[0.6875rem] leading-5 text-muted-foreground/55"
       data-slot="aui_background-resume"
@@ -214,8 +301,8 @@ export const TurnActivityIndicator: FC = () => {
   // timer read "quiet for 12s" rather than the age of this component, which is
   // the whole turn so far.
   const [quietSince, setQuietSince] = useState<number | undefined>(undefined)
-  const { awaitingInput, busy, compacting, drafting, providerWait, turnStartedAt } = useThreadSessionStatus()
-  const hint = useStatusHint(compacting, drafting, providerWait)
+  const { t } = useI18n()
+  const { awaitingInput, busy, compacting, drafting, providerWait, stalled, turnStartedAt } = useThreadSessionStatus()
 
   // A tool run at the tail already narrates the wait — its summary counts the
   // calls, its ticker names the current one, and it carries its own timer. A
@@ -235,19 +322,29 @@ export const TurnActivityIndicator: FC = () => {
     return () => window.clearTimeout(id)
   }, [activity])
 
-  // Every second the app claims to be working belongs to something. A named
-  // wait says what it is straight away; an unnamed gap has to go quiet for
-  // TURN_QUIET_S first, or a run of quick calls would strobe a row between
-  // each one. The two exemptions are waits already accounted for elsewhere: a
-  // question the user is answering, and a tool call carrying its own timer.
   const working = busy || messageRunning
-  const active = working && !awaitingInput && !toolNarrating && (Boolean(hint) || quietSince !== undefined)
+  const phase = resolveThreadActivityPhase({
+    awaitingInput,
+    busy: working,
+    compacting,
+    providerWait,
+    quiet: quietSince !== undefined,
+    stalled
+  })
+  const hint = useStatusHint(compacting, drafting, providerWait, phase, {
+    inputRequired: t.assistant.thread.inputRequired,
+    quietRunning: t.assistant.thread.quietRunning,
+    stalledWarning: t.assistant.thread.stalledWarning
+  })
+  const active =
+    !toolNarrating &&
+    (phase === 'input-required' || (working && (Boolean(hint) || quietSince !== undefined)))
 
   // Compaction owns the whole turn, so it keeps counting from the turn's start;
   // anything else counts from the moment the turn last produced something — the
   // gap's own mark, or the draft's, whichever named the wait first.
   const elapsed = useElapsedSeconds(
-    active,
+    active && phase !== 'input-required',
     undefined,
     compacting ? turnStartedAt : (quietSince ?? drafting?.since ?? turnStartedAt)
   )
@@ -257,14 +354,24 @@ export const TurnActivityIndicator: FC = () => {
   }
 
   return (
-    <StatusRow data-slot="aui_turn-activity" label={hint || 'Hermes is working'}>
-      <StatusPulse
-        aria-hidden="true"
-        className="dither inline-block size-3 rounded-[2px] text-midground/80"
-        kind="opacity"
-      />
-      {hint && <HintText>{hint}</HintText>}
-      <ActivityTimerText seconds={elapsed} />
+    <StatusRow
+      aria-description={t.assistant.thread.foregroundRunning}
+      data-slot="aui_turn-activity"
+      label={hint || t.assistant.thread.loadingResponse}
+    >
+      {phase === 'input-required' ? (
+        <Codicon aria-hidden="true" className="text-amber-500/80" name="question" size="0.8rem" />
+      ) : phase === 'stalled' ? (
+        <Codicon aria-hidden="true" className="text-amber-500/80" name="warning" size="0.8rem" />
+      ) : (
+        <StatusPulse
+          aria-hidden="true"
+          className="dither inline-block size-3 rounded-[2px] text-midground/80"
+          kind="opacity"
+        />
+      )}
+      <HintText>{hint}</HintText>
+      {phase !== 'input-required' && <ActivityTimerText seconds={elapsed} />}
     </StatusRow>
   )
 }

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -3176,6 +3176,12 @@ export const en: Translations = {
       loadingSession: 'Loading session',
       showEarlier: 'Show earlier messages',
       loadingResponse: 'Hermes is loading a response',
+      foregroundRunning: 'Foreground task running',
+      inputRequired: 'Needs your input',
+      quietRunning: 'Working quietly',
+      stalledWarning: 'Still working — no output recently',
+      backgroundRunning: 'Background task running',
+      completed: 'Completed',
       resumeWhenBackgroundDone: count =>
         count === 1
           ? 'Will resume when the background task finishes'

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2736,6 +2736,12 @@ export interface Translations {
       loadingSession: string
       showEarlier: string
       loadingResponse: string
+      foregroundRunning: string
+      inputRequired: string
+      quietRunning: string
+      stalledWarning: string
+      backgroundRunning: string
+      completed: string
       resumeWhenBackgroundDone: (count: number) => string
       thinking: string
       thought: string

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -3336,6 +3336,12 @@ export const zh: Translations = {
       loadingSession: '正在加载会话',
       showEarlier: '显示更早的消息',
       loadingResponse: 'Hermes 正在加载回复',
+      foregroundRunning: '前台任务运行中',
+      inputRequired: '需要你的输入',
+      quietRunning: '正在安静地工作',
+      stalledWarning: '仍在工作——最近没有输出',
+      backgroundRunning: '后台任务运行中',
+      completed: '已完成',
       resumeWhenBackgroundDone: count =>
         count === 1 ? '后台任务完成后将自动继续' : `${count} 个后台任务完成后将自动继续`,
       thinking: '思考中',


### PR DESCRIPTION
## Summary
Clarify desktop session activity status using existing per-session evidence: input-required, compaction, provider wait, stalled, quiet running, ordinary running, and idle/unknown. Visible copy, icons, and accessibility labels follow the same phase. Provider-wait text is shown only when non-empty after trim, without inventing deadlines.

## Test plan
- [x] `npx vitest run --project ui src/components/assistant-ui/thread/status.test.tsx` — 9 passed
- [x] `npm run typecheck` — passed on the prior candidate; this rebase did not change TypeScript

This does not claim renderer acknowledgement or persistence/delivery evidence.
