### PR TITLE
fix(desktop): bound cross-gateway session list reads

### DIFF
--- a/apps/desktop/electron/profile-session-routing.test.ts
+++ b/apps/desktop/electron/profile-session-routing.test.ts
@@ -302,6 +302,38 @@ test('registry sources: shared remote hosts read the cross-profile aggregate onc
   )
 })
 
+test('registry sources page flat session endpoints at their 100-row ceiling', async () => {
+  const calls: string[] = []
+  const sessions = Array.from({ length: 150 }, (_, index) => ({ id: `session-${index}` }))
+
+  const rows = await fetchRegistrySessionRows(
+    [
+      {
+        connectionId: 'gw-ssh',
+        kind: 'ssh',
+        backends: [{ descriptor: 'ssh-desc', profileLabel: 'default' }]
+      }
+    ],
+    new URLSearchParams({ limit: '150', offset: '0', profile: 'all' }),
+    async (_descriptor, path) => {
+      calls.push(path)
+      const url = new URL(path, 'http://desktop.test')
+      const limit = Number(url.searchParams.get('limit'))
+      const offset = Number(url.searchParams.get('offset'))
+
+      assert.ok(limit <= 100)
+
+      return { sessions: sessions.slice(offset, offset + limit), total: sessions.length, limit, offset }
+    }
+  )
+
+  assert.deepEqual(calls, [
+    '/api/sessions?limit=100&offset=0',
+    '/api/sessions?limit=50&offset=100'
+  ])
+  assert.equal(rows.length, 150)
+})
+
 test('registry-pinned session responses retain their owning connection', () => {
   const sidebar = tagRegistrySessionResponse(
     '/api/profiles/sessions/sidebar?recents_profile=default',

--- a/apps/desktop/electron/profile-session-routing.test.ts
+++ b/apps/desktop/electron/profile-session-routing.test.ts
@@ -224,6 +224,112 @@ test('remote session reads keep small requests on one call', async () => {
   assert.equal(result, expected)
 })
 
+test('a later remote page failure rejects the window and recovery fetches it afresh', async () => {
+  const params = new URLSearchParams({ profile: 'remote-work', limit: '150', offset: '0' })
+  const calls: string[] = []
+  const failure = new Error('second page unavailable')
+  let failing = true
+
+  const fetchPage = async (_profile: string | null, path: string) => {
+    calls.push(path)
+    const query = new URL(path, 'http://desktop.test').searchParams
+    const offset = Number(query.get('offset'))
+    const limit = Number(query.get('limit'))
+
+    if (failing && offset === 100) {
+      throw failure
+    }
+
+    return {
+      sessions: Array.from({ length: limit }, (_, index) => ({
+        id: `${failing ? 'discarded' : 'fresh'}-${offset + index}`
+      })),
+      total: 150,
+      generation: failing ? 'discarded' : 'fresh'
+    }
+  }
+
+  await assert.rejects(fetchRemoteProfileSessions('remote-work', params, fetchPage), error => error === failure)
+  assert.equal(params.toString(), 'profile=remote-work&limit=150&offset=0')
+  failing = false
+  const recovered = await fetchRemoteProfileSessions('remote-work', params, fetchPage)
+
+  assert.deepEqual(calls, [
+    '/api/sessions?limit=100&offset=0',
+    '/api/sessions?limit=50&offset=100',
+    '/api/sessions?limit=100&offset=0',
+    '/api/sessions?limit=50&offset=100'
+  ])
+  assert.deepEqual(
+    recovered.sessions,
+    Array.from({ length: 150 }, (_, index) => ({ id: `fresh-${index}` }))
+  )
+  assert.equal(recovered.generation, 'fresh')
+  assert.equal(recovered.total, 150)
+  assert.equal(recovered.limit, 150)
+})
+
+test.each(['ssh', 'remote'])('registry %s later-page failure omits only that backend and recovers', async kind => {
+  const sources = [
+    { connectionId: 'gw-failing', kind, backends: [{ descriptor: 'failing', profileLabel: 'work' }] },
+    { connectionId: 'gw-live', kind: 'ssh', backends: [{ descriptor: 'live', profileLabel: 'default' }] }
+  ]
+
+  const params = new URLSearchParams({ limit: '150', offset: '0', profile: 'all' })
+  const discarded = Array.from({ length: 150 }, (_, index) => ({ id: `discarded-${index}` }))
+  const fresh = Array.from({ length: 150 }, (_, index) => ({ id: `fresh-${index}` }))
+  const calls: string[] = []
+  let failing = true
+
+  const getJson = async (descriptor: unknown, path: string) => {
+    if (descriptor === 'live') {
+      return { sessions: [{ id: 'live' }], total: 1 }
+    }
+
+    calls.push(path)
+
+    if (path.startsWith('/api/profiles/sessions')) {
+      throw new Error('404: No such API endpoint')
+    }
+
+    const query = new URL(path, 'http://desktop.test').searchParams
+    const offset = Number(query.get('offset'))
+    const limit = Number(query.get('limit'))
+
+    if (failing && offset === 100) {
+      throw new Error('second page unavailable')
+    }
+
+    return { sessions: (failing ? discarded : fresh).slice(offset, offset + limit), total: 150 }
+  }
+
+  const unavailable = await fetchRegistrySessionRows(sources, params, getJson)
+  assert.deepEqual(
+    unavailable.map(row => (row as { id: string }).id),
+    ['live']
+  )
+  assert.ok(discarded.every(row => !('connection_id' in row) && !('profile' in row)))
+  failing = false
+  const recovered = await fetchRegistrySessionRows(sources, params, getJson)
+  const remoteRows = recovered.filter(row => (row as { connection_id: string }).connection_id === 'gw-failing')
+
+  assert.equal(recovered.length, 151)
+  assert.deepEqual(
+    remoteRows.map(row => (row as { id: string }).id),
+    fresh.map(row => row.id)
+  )
+  assert.ok(remoteRows.every(row => (row as { profile: string }).profile === (kind === 'ssh' ? 'work' : 'default')))
+  assert.deepEqual(
+    calls.filter(path => path.startsWith('/api/sessions?')),
+    [
+      '/api/sessions?limit=100&offset=0',
+      '/api/sessions?limit=50&offset=100',
+      '/api/sessions?limit=100&offset=0',
+      '/api/sessions?limit=50&offset=100'
+    ]
+  )
+})
+
 test('registry sources: ssh backends are read natively and rows tagged with connection + profile', async () => {
   const calls: Array<{ descriptor: unknown; path: string }> = []
 
@@ -327,10 +433,7 @@ test('registry sources page flat session endpoints at their 100-row ceiling', as
     }
   )
 
-  assert.deepEqual(calls, [
-    '/api/sessions?limit=100&offset=0',
-    '/api/sessions?limit=50&offset=100'
-  ])
+  assert.deepEqual(calls, ['/api/sessions?limit=100&offset=0', '/api/sessions?limit=50&offset=100'])
   assert.equal(rows.length, 150)
 })
 

--- a/apps/desktop/electron/profile-session-routing.ts
+++ b/apps/desktop/electron/profile-session-routing.ts
@@ -241,7 +241,10 @@ export async function fetchRegistrySessionRows(
             const params = new URLSearchParams(searchParams)
             params.delete('profile')
 
-            const data = await getJson(descriptor, `/api/sessions?${params}`).catch(() => null)
+            const data = await fetchPagedSessionList(
+              params,
+              pageParams => getJson(descriptor, `/api/sessions?${pageParams}`) as Promise<SessionListResponse>
+            ).catch(() => null)
 
             if (data) {
               tag(data, source.connectionId, profileLabel || 'default')
@@ -269,7 +272,10 @@ export async function fetchRegistrySessionRows(
         // Older remote without the aggregator: its own default-profile list.
         const flat = new URLSearchParams(searchParams)
         flat.delete('profile')
-        data = await getJson(shared.descriptor, `/api/sessions?${flat}`).catch(() => null)
+        data = await fetchPagedSessionList(
+          flat,
+          pageParams => getJson(shared.descriptor, `/api/sessions?${pageParams}`) as Promise<SessionListResponse>
+        ).catch(() => null)
       }
 
       if (data) {
@@ -327,6 +333,17 @@ export async function fetchRemoteProfileSessions(
   const params = new URLSearchParams(searchParams)
   params.delete('profile') // the remote serves its own database
 
+  return fetchPagedSessionList(params, pageParams =>
+    fetchJsonForProfile(profile, `/api/sessions?${pageParams}`) as Promise<SessionListResponse>
+  )
+}
+
+async function fetchPagedSessionList(
+  searchParams: URLSearchParams,
+  fetchPage: (params: URLSearchParams) => Promise<SessionListResponse>
+): Promise<SessionListResponse> {
+  const params = new URLSearchParams(searchParams)
+
   const requestedLimit = Number(params.get('limit'))
   const requestedOffset = Number(params.get('offset') || '0')
 
@@ -337,7 +354,7 @@ export async function fetchRemoteProfileSessions(
     requestedOffset >= 0
 
   if (!needsPaging) {
-    return (await fetchJsonForProfile(profile, `/api/sessions?${params}`)) as SessionListResponse
+    return fetchPage(params)
   }
 
   const sessions: unknown[] = []
@@ -354,7 +371,7 @@ export async function fetchRemoteProfileSessions(
     pageParams.set('limit', String(pageLimit))
     pageParams.set('offset', String(pageOffset))
 
-    const page = (await fetchJsonForProfile(profile, `/api/sessions?${pageParams}`)) as SessionListResponse
+    const page = await fetchPage(pageParams)
     firstPage ??= page
 
     const total = nonNegativeNumber(page.total)

--- a/apps/desktop/electron/profile-session-routing.ts
+++ b/apps/desktop/electron/profile-session-routing.ts
@@ -333,11 +333,15 @@ export async function fetchRemoteProfileSessions(
   const params = new URLSearchParams(searchParams)
   params.delete('profile') // the remote serves its own database
 
-  return fetchPagedSessionList(params, pageParams =>
-    fetchJsonForProfile(profile, `/api/sessions?${pageParams}`) as Promise<SessionListResponse>
+  return fetchPagedSessionList(
+    params,
+    pageParams => fetchJsonForProfile(profile, `/api/sessions?${pageParams}`) as Promise<SessionListResponse>
   )
 }
 
+/** Resolve a complete backend window or reject, never an unmarked partial prefix.
+ * A failed page leaves fallback/retry policy to the caller, as a single read does.
+ * Serial pages preserve ordering and first-page metadata until pinned backfill is joined. */
 async function fetchPagedSessionList(
   searchParams: URLSearchParams,
   fetchPage: (params: URLSearchParams) => Promise<SessionListResponse>


### PR DESCRIPTION
## Keep Long Session Lists Visible

The unified Sessions view can silently lose a gateway's rows when Desktop requests more than 100 sessions. Load-more and owner lookups can exceed that window, but the flat `/api/sessions` endpoint rejects limits above 100 with `422`; the failed source then contributes no rows.

This PR reads API-safe pages and reassembles the requested window before attaching its connection and profile. The same helper covers registry sources, the legacy shared-host fallback and direct remote-profile reads. No backend or schema change is needed.

## Failure Behavior

A later-page failure rejects that backend's requested window rather than returning an unmarked partial list. Registry callers retain their existing per-backend fallback, so healthy gateways still contribute. A subsequent attempt starts from the original offset and refetches the complete window.

This does not promise that every cached row survives an outage. Explicit per-source completeness and cache retention would require a separate change; silently returning a successful prefix is not that change.

## Scope

- No change to the existing `profile=all` aggregate-profile contract, hidden sessions or Bot Chat ownership.
- No new endpoint, persisted state or automatic partial-result API.
- No full transcript hydration or sidebar virtualization changes; #95044 tracks that broader performance class.

## Related Work

- Merged #89466 introduced cross-gateway registry reads for #88880; this PR bounds their flat fallback to the existing backend limit.
- #81457 owns adjacent authority/profile selection. Both touch `profile-session-routing.ts`; whichever lands second must preserve both behaviors.

## Validation

Current `54d05bc4101` adds a contract comment and three failure/recovery cases to the existing suite. **24 routing tests pass**, covering direct remote, registry SSH and legacy fallback, with healthy-source retention and fresh recovery after second-page failure. Emitted production JavaScript is unchanged from `eb7c447dbc`. Targeted lint, formatting and diff checks pass; changed source/test owners remain below 2,000 lines. Current CI is tracked separately.

<details>
<summary>Earlier acceptance at eb7c447dbc</summary>

Recorded on post-#96726 main `7eee066c30`:

- Focused routing and REST-helper selection: 57 tests across two files passed.
- Electron selection: 1,911 passed, 6 skipped.
- Desktop renderer, Electron and E2E typechecks passed.
- Targeted lint passed; full Desktop lint had zero errors and 124 existing warnings.
- A broader Electron run reached 1,938 passed and 6 skipped, while reproducing the pre-existing macOS `/bin/true` fixture failure on exact main. That portability correction remains outside this PR.

These historical selections overlap, are not added together, and are not presented as a fresh full-suite run of the new test-only follow-up.

</details>
