### PR TITLE
fix(tts): route streaming OpenAI audio through the managed gateway

### DIFF
--- a/tests/tools/test_tts_streaming.py
+++ b/tests/tools/test_tts_streaming.py
@@ -105,19 +105,23 @@ def test_elevenlabs_available_reflects_key(monkeypatch):
     assert ts.ElevenLabsStreamer.available() is False
 
 
-def test_openai_available_reflects_audio_key_resolution(monkeypatch):
-    monkeypatch.setattr(ts, "_openai_config_api_key", lambda: "")
-    monkeypatch.setattr(ts, "resolve_openai_audio_api_key", lambda: "voice-key")
+def test_openai_available_reflects_audio_backend(monkeypatch):
+    monkeypatch.setattr(ts, "_has_openai_audio_backend", lambda: True)
     assert ts.OpenAIStreamer.available() is True
-    monkeypatch.setattr(ts, "resolve_openai_audio_api_key", lambda: "")
+    monkeypatch.setattr(ts, "_has_openai_audio_backend", lambda: False)
     assert ts.OpenAIStreamer.available() is False
-    # tts.openai.api_key from config.yaml counts too
-    monkeypatch.setattr(ts, "_openai_config_api_key", lambda: "cfg-key")
-    assert ts.OpenAIStreamer.available() is True
 
 
-def test_openai_streamer_prefers_configured_api_key(monkeypatch):
-    captured = {}
+def _patch_openai_stream(monkeypatch):
+    """Patch openai.OpenAI and the resolver so stream() can be exercised.
+
+    ``_has_openai_audio_backend`` is stubbed True so ``resolve_streaming_provider``
+    constructs the streamer; ``_resolve_openai_audio_client_config`` is stubbed by
+    each test to shape the credential route. Both client kwargs and create()
+    kwargs are recorded in the returned dict.
+    """
+    captured = {"client": None, "requests": []}
+    monkeypatch.setattr(ts, "_has_openai_audio_backend", lambda: True)
 
     class _Response:
         def __enter__(self):
@@ -132,6 +136,7 @@ def test_openai_streamer_prefers_configured_api_key(monkeypatch):
     class _StreamingCreate:
         @staticmethod
         def create(**kwargs):
+            captured["requests"].append(kwargs)
             return _Response()
 
     class _OpenAI:
@@ -140,19 +145,76 @@ def test_openai_streamer_prefers_configured_api_key(monkeypatch):
             self.audio = MagicMock()
             self.audio.speech.with_streaming_response = _StreamingCreate()
 
-    monkeypatch.setattr(ts, "resolve_openai_audio_api_key", lambda: "env-key")
-    monkeypatch.setattr(ts, "get_env_value", lambda key, *args: None)
     monkeypatch.setattr("openai.OpenAI", _OpenAI)
+    return captured
+
+
+def test_openai_stream_uses_resolver_for_direct_credentials(monkeypatch):
+    captured = _patch_openai_stream(monkeypatch)
+
+    def _fake_resolve():
+        return "direct-key", "https://api.openai.com/v1", False
+
+    monkeypatch.setattr(ts, "_resolve_openai_audio_client_config", _fake_resolve)
+
+    streamer = ts.resolve_streaming_provider({"provider": "openai", "openai": {}})
+
+    assert streamer is not None
+    assert list(streamer.stream("Streaming test.")) == [b"\x01\x00"]
+    assert captured["client"]["api_key"] == "direct-key"
+    assert captured["client"]["base_url"] == "https://api.openai.com/v1"
+
+
+def test_openai_stream_coerces_unsupported_model_on_managed_gateway(monkeypatch):
+    """Regression: the managed gateway proxies only gpt-4o-mini-tts.
+
+    A model set for direct OpenAI (e.g. tts-1-hd) 400s on the gateway, so the
+    streaming path must coerce it to the default like the sync path does.
+    """
+    captured = _patch_openai_stream(monkeypatch)
+
+    def _fake_resolve():
+        return "gateway-token", "https://gateway.example/v1", True
+
+    monkeypatch.setattr(ts, "_resolve_openai_audio_client_config", _fake_resolve)
+
+    streamer = ts.resolve_streaming_provider(
+        {"provider": "openai", "openai": {"model": "tts-1-hd"}}
+    )
+
+    assert streamer is not None
+    assert list(streamer.stream("Streaming test.")) == [b"\x01\x00"]
+    assert captured["requests"][0]["model"] == ts.DEFAULT_OPENAI_MODEL
+    assert captured["client"]["api_key"] == "gateway-token"
+    assert captured["client"]["base_url"] == "https://gateway.example/v1"
+
+
+def test_openai_stream_honors_config_base_url_on_managed_gateway(monkeypatch):
+    """Regression: an explicit tts.openai.base_url bypasses gateway coercion.
+
+    When the user redirects base_url to their own endpoint, the model must be
+    respected as-is rather than coerced to the gateway default.
+    """
+    captured = _patch_openai_stream(monkeypatch)
+
+    def _fake_resolve():
+        return "gateway-token", "https://gateway.example/v1", True
+
+    monkeypatch.setattr(ts, "_resolve_openai_audio_client_config", _fake_resolve)
 
     config = {
         "provider": "openai",
-        "openai": {"api_key": "cfg-key", "base_url": "http://local-tts.example/v1"},
+        "openai": {
+            "model": "tts-1-hd",
+            "base_url": "http://self-hosted.example/v1",
+        },
     }
     streamer = ts.resolve_streaming_provider(config)
 
     assert streamer is not None
     assert list(streamer.stream("Streaming test.")) == [b"\x01\x00"]
-    assert captured["client"]["api_key"] == "cfg-key"
+    assert captured["requests"][0]["model"] == "tts-1-hd"  # not coerced
+    assert captured["client"]["base_url"] == "http://self-hosted.example/v1"
 
 
 # ── Dispatch: chunked streamer path ──────────────────────────────────────

--- a/tools/tts_streaming.py
+++ b/tools/tts_streaming.py
@@ -27,8 +27,16 @@ import time
 from abc import ABC, abstractmethod
 from typing import Callable, Dict, Iterator, List, Optional
 
-from tools.tool_backend_helpers import resolve_openai_audio_api_key
-from tools.tts_tool import _get_provider, _load_tts_config, get_env_value
+from tools.tts_tool import (
+    DEFAULT_OPENAI_BASE_URL,
+    DEFAULT_OPENAI_MODEL,
+    DEFAULT_OPENAI_VOICE,
+    MANAGED_OPENAI_TTS_MODELS,
+    _get_provider,
+    _has_openai_audio_backend,
+    _resolve_openai_audio_client_config,
+    get_env_value,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -252,15 +260,6 @@ class ElevenLabsStreamer(StreamingTTSProvider):
         )
 
 
-def _openai_config_api_key() -> str:
-    """Return ``tts.openai.api_key`` from config.yaml, or empty string."""
-    try:
-        openai_cfg = (_load_tts_config().get("openai") or {})
-    except Exception:
-        return ""
-    return openai_cfg.get("api_key") or ""
-
-
 @register("openai")
 class OpenAIStreamer(StreamingTTSProvider):
     """OpenAI speech with ``response_format=pcm`` (24 kHz mono int16)."""
@@ -269,21 +268,35 @@ class OpenAIStreamer(StreamingTTSProvider):
 
     @staticmethod
     def available() -> bool:
-        return bool(_openai_config_api_key() or resolve_openai_audio_api_key())
+        return _has_openai_audio_backend()
 
     def stream(self, text: str) -> Iterator[bytes]:
         from openai import OpenAI
 
-        client = OpenAI(
-            api_key=(self.section.get("api_key") or resolve_openai_audio_api_key()),
-            base_url=(
-                self.section.get("base_url")
-                or get_env_value("OPENAI_BASE_URL")
-                or None
-            ),
-        )
-        model = self.section.get("model", "gpt-4o-mini-tts")
-        voice = self.section.get("voice", "alloy")
+        api_key, fallback_base, is_managed = _resolve_openai_audio_client_config()
+        config_base_url = self.section.get("base_url")
+        base_url = config_base_url or fallback_base or DEFAULT_OPENAI_BASE_URL
+
+        model = self.section.get("model", DEFAULT_OPENAI_MODEL)
+        voice = self.section.get("voice", DEFAULT_OPENAI_VOICE)
+
+        # The managed OpenAI audio gateway only proxies MANAGED_OPENAI_TTS_MODELS.
+        # A model set for direct OpenAI (e.g. "tts-1-hd") 400s there, so coerce
+        # it unless the user redirected base_url to their own endpoint.
+        if (
+            is_managed
+            and not config_base_url
+            and model not in MANAGED_OPENAI_TTS_MODELS
+        ):
+            logger.warning(
+                "TTS: managed OpenAI audio gateway does not support model %r; "
+                "falling back to %s. Set VOICE_TOOLS_OPENAI_KEY or OPENAI_API_KEY "
+                "to use %r directly.",
+                model, DEFAULT_OPENAI_MODEL, model,
+            )
+            model = DEFAULT_OPENAI_MODEL
+
+        client = OpenAI(api_key=api_key, base_url=base_url)
         with client.audio.speech.with_streaming_response.create(
             model=model,
             voice=voice,


### PR DESCRIPTION
## Problem

The sync TTS path (tools/tts_tool.py) was refactored to switch on the stored tts provider selection via `_resolve_openai_audio_client_config()`: a user on the Nous managed audio gateway is routed through it, a stored vendor uses direct credentials, and a never-configured section keeps the legacy ladder.

The streaming path (tools/tts_streaming.py) was not updated in that refactor. `OpenAIStreamer.available()` still checked only direct credentials (`_openai_config_api_key() or resolve_openai_audio_api_key()`), so a managed-gateway user got `available() == False` and the streaming path silently fell back to whole-file MP3 synthesis instead of low-latency sentence playback.

## Solution

- `available()` now delegates to `_has_openai_audio_backend()`, which wraps `_resolve_openai_audio_client_config()` and reports True for both direct keys and the managed gateway.
- `stream()` resolves `(api_key, base_url, is_managed)` through the same resolver and coerces the model on the managed gateway (which only proxies `MANAGED_OPENAI_TTS_MODELS`), mirroring the sync path. An explicit `tts.openai.base_url` still bypasses coercion.
- Drops the `OPENAI_BASE_URL` env-var fallback in favor of the resolver's config-driven `base_url`, matching the sync path and the repo's rule that non-secret settings live in config.yaml.

## Regression tests

- `test_openai_available_reflects_audio_backend` — availability follows the resolver.
- `test_openai_stream_uses_resolver_for_direct_credentials` — direct-key routing.
- `test_openai_stream_coerces_unsupported_model_on_managed_gateway` — managed-gateway model coercion.
- `test_openai_stream_honors_config_base_url_on_managed_gateway` — config base_url bypasses coercion.