### PR TITLE
fix(auth): allow profiles to share credential stores

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from functools import wraps
 import logging
 import os
 import random
@@ -43,6 +44,15 @@ from hermes_cli.auth import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _pin_pool_auth_authority(operation):
+    """Run a pool method against the authority captured when it was loaded."""
+    @wraps(operation)
+    def pinned(self, *args, **kwargs):
+        with auth_mod._use_auth_authority(self._auth_authority_binding):
+            return operation(self, *args, **kwargs)
+    return pinned
 
 
 def _load_config_safe() -> Optional[dict]:
@@ -712,6 +722,7 @@ def _write_through_provider_state_to_global_root(
 
 class CredentialPool:
     def __init__(self, provider: str, entries: List[PooledCredential]):
+        self._auth_authority_binding = auth_mod._capture_auth_authority()
         self.provider = provider
         self._entries = sorted(entries, key=lambda entry: entry.priority)
         self._current_id: Optional[str] = None
@@ -838,14 +849,17 @@ class CredentialPool:
                     return
 
     def _persist(self, *, removed_ids: Optional[List[str]] = None) -> None:
-        # Self-locking (RLock): snapshotting self._entries must not race a
-        # concurrent rotation when called from the deferred refresh path.
-        with self._lock:
-            write_credential_pool(
-                self.provider,
-                [entry.to_dict() for entry in self._entries],
-                removed_ids=removed_ids,
-            )
+        # Pool objects remain bound to the credential authority from load time;
+        # later config changes must not redirect an existing object's writes.
+        with auth_mod._use_auth_authority(self._auth_authority_binding):
+            # Self-locking (RLock): snapshotting self._entries must not race a
+            # concurrent rotation when called from the deferred refresh path.
+            with self._lock:
+                write_credential_pool(
+                    self.provider,
+                    [entry.to_dict() for entry in self._entries],
+                    removed_ids=removed_ids,
+                )
 
     def _is_terminal_auth_failure(
         self,
@@ -967,6 +981,7 @@ class CredentialPool:
             logger.debug("Failed to sync from credentials file: %s", exc)
         return entry
 
+    @_pin_pool_auth_authority
     def _sync_codex_entry_from_auth_store(self, entry: PooledCredential) -> PooledCredential:
         """Sync a Codex device_code pool entry from auth.json if tokens differ.
 
@@ -1055,6 +1070,7 @@ class CredentialPool:
             logger.debug("Failed to sync Codex entry from auth.json: %s", exc)
         return entry
 
+    @_pin_pool_auth_authority
     def _sync_xai_oauth_entry_from_auth_store(self, entry: PooledCredential) -> PooledCredential:
         """Sync an xAI OAuth pool entry from auth.json if tokens differ.
 
@@ -1152,6 +1168,7 @@ class CredentialPool:
             logger.debug("Failed to sync xAI OAuth entry from credential pool: %s", exc)
         return entry
 
+    @_pin_pool_auth_authority
     def _sync_nous_entry_from_auth_store(self, entry: PooledCredential) -> PooledCredential:
         """Sync a Nous pool entry from auth.json if tokens differ.
 
@@ -1367,6 +1384,7 @@ class CredentialPool:
         except Exception as exc:
             logger.debug("Failed to sync %s pool entry back to auth store: %s", self.provider, exc)
 
+    @_pin_pool_auth_authority
     def _refresh_entry(self, entry: PooledCredential, *, force: bool) -> Optional[PooledCredential]:
         if entry.auth_type != AUTH_TYPE_OAUTH or not entry.refresh_token:
             if force:
@@ -2425,11 +2443,7 @@ class CredentialPool:
                 replace(entry, priority=new_priority)
                 for new_priority, entry in enumerate(self._entries)
             ]
-            write_credential_pool(
-                self.provider,
-                [entry.to_dict() for entry in self._entries],
-                removed_ids=[removed.id],
-            )
+            self._persist(removed_ids=[removed.id])
             if self._current_id == removed.id:
                 self._current_id = None
             return removed
@@ -3192,6 +3206,7 @@ def _seed_custom_pool(pool_key: str, entries: List[PooledCredential]) -> Tuple[b
     return changed, active_sources
 
 
+@auth_mod._pin_auth_authority
 def load_pool(provider: str) -> CredentialPool:
     provider = (provider or "").strip().lower()
     raw_entries = read_credential_pool(provider)

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -28,6 +28,7 @@ import stat
 import sys
 import base64
 import hashlib
+import inspect
 import subprocess
 import threading
 import time
@@ -76,6 +77,7 @@ else:
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
+from functools import wraps
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 from typing import Any, Callable, Dict, FrozenSet, Iterable, List, Optional, Tuple
@@ -85,6 +87,7 @@ from hermes_cli.config import (
     get_hermes_home,
     get_config_path,
     read_raw_config,
+    read_user_config_raw,
     require_readable_config_before_write,
 )
 from hermes_constants import OPENROUTER_BASE_URL, secure_parent_dir
@@ -92,6 +95,23 @@ from agent.credential_persistence import sanitize_borrowed_credential_payload
 from utils import atomic_replace, atomic_yaml_write, env_float, is_truthy_value
 
 logger = logging.getLogger(__name__)
+
+
+def _pin_auth_authority(operation: Callable[..., Any]) -> Callable[..., Any]:
+    """Run a complete sync or async auth operation against one authority."""
+    if inspect.iscoroutinefunction(operation):
+        @wraps(operation)
+        async def pinned_async(*args: Any, **kwargs: Any) -> Any:
+            with _auth_authority_context():
+                return await operation(*args, **kwargs)
+        return pinned_async
+
+    @wraps(operation)
+    def pinned(*args: Any, **kwargs: Any) -> Any:
+        with _auth_authority_context():
+            return operation(*args, **kwargs)
+    return pinned
+
 
 try:
     import fcntl
@@ -896,6 +916,7 @@ def detect_zai_endpoint(api_key: str, timeout: float = 8.0) -> Optional[Dict[str
         pool.shutdown(wait=False)
 
 
+@_pin_auth_authority
 def _resolve_zai_base_url(api_key: str, default_url: str, env_override: str) -> str:
     """Return the correct Z.AI base URL by probing endpoints.
 
@@ -1112,20 +1133,159 @@ def _oauth_trace(event: str, *, sequence_id: Optional[str] = None, **fields: Any
 # Auth Store — persistence layer for ~/.hermes/auth.json
 # =============================================================================
 
+def _configured_auth_source_path() -> Optional[Path]:
+    """Resolve an explicit named-profile credential store.
+
+    API-only profiles can remain policy-isolated while sharing the credential
+    pool owned by another named profile. Reads, refreshes, status writes, and
+    locking must all target the same store; copying or read-only fallback would
+    split rotating OAuth state across profiles.
+    """
+    try:
+        raw_config = read_user_config_raw()
+    except Exception as error:
+        raise RuntimeError(
+            "Cannot safely resolve auth.source_profile because the active profile config is unreadable"
+        ) from error
+    auth_config = raw_config.get("auth") if isinstance(raw_config, dict) else None
+    source_profile = auth_config.get("source_profile") if isinstance(auth_config, dict) else None
+    if source_profile is None or not str(source_profile).strip():
+        return None
+    source_profile = str(source_profile).strip()
+    if not source_profile.replace("-", "").replace("_", "").isalnum():
+        raise RuntimeError("auth.source_profile must be a simple named profile")
+    from hermes_constants import get_default_hermes_root
+
+    profiles_root = (get_default_hermes_root() / "profiles").resolve(strict=True)
+    source_link = profiles_root / source_profile
+    try:
+        source_home = source_link.resolve(strict=True)
+        source_home.relative_to(profiles_root)
+    except (FileNotFoundError, OSError, ValueError) as error:
+        raise RuntimeError(f"Configured auth source profile does not exist or escapes profiles root: {source_profile}") from error
+    if source_link.is_symlink() or source_home.parent != profiles_root:
+        raise RuntimeError(f"Configured auth source profile escapes profiles root: {source_profile}")
+    active_home = get_hermes_home().resolve(strict=False)
+    if _same_path(source_home, active_home):
+        raise RuntimeError("auth.source_profile must not reference the active profile")
+    if not source_home.is_dir():
+        raise RuntimeError(f"Configured auth source profile does not exist: {source_profile}")
+    auth_path = source_home / "auth.json"
+    if auth_path.is_symlink():
+        raise RuntimeError(f"Configured auth source store must not be a symlink: {source_profile}")
+    if auth_path.exists() and not auth_path.is_file():
+        raise RuntimeError(f"Configured auth source store is not a regular file: {source_profile}")
+    try:
+        auth_path.resolve(strict=False).relative_to(source_home)
+    except ValueError as error:
+        raise RuntimeError(f"Configured auth source store escapes profile directory: {source_profile}") from error
+    return auth_path
+
+
+_AUTH_AUTHORITY_LOCAL = threading.local()
+
+
+def _resolve_auth_authority() -> Tuple[Path, Optional[Path]]:
+    """Resolve active and legacy-fallback auth paths exactly once."""
+    configured = _configured_auth_source_path()
+    active_path = configured or (get_hermes_home() / "auth.json")
+    if configured is not None:
+        return active_path, None
+    try:
+        from hermes_constants import get_default_hermes_root
+        global_root = get_default_hermes_root()
+    except Exception:
+        return active_path, None
+    profile_home = get_hermes_home()
+    try:
+        same_home = profile_home.resolve(strict=False) == global_root.resolve(strict=False)
+    except Exception:
+        same_home = profile_home == global_root
+    return active_path, None if same_home else global_root / "auth.json"
+
+
+@contextmanager
+def _auth_authority_context():
+    """Pin auth-store authority for one complete operation in one profile."""
+    previous = getattr(_AUTH_AUTHORITY_LOCAL, "value", None)
+    previous_home = getattr(_AUTH_AUTHORITY_LOCAL, "home", None)
+    current_home = get_hermes_home().resolve(strict=False)
+    replaced = previous is None or previous_home != current_home
+    if replaced:
+        _AUTH_AUTHORITY_LOCAL.value = _resolve_auth_authority()
+        _AUTH_AUTHORITY_LOCAL.home = current_home
+    try:
+        yield _AUTH_AUTHORITY_LOCAL.value
+    finally:
+        if replaced:
+            if previous is None:
+                for attribute in ("value", "home"):
+                    try:
+                        delattr(_AUTH_AUTHORITY_LOCAL, attribute)
+                    except AttributeError:
+                        pass
+            else:
+                _AUTH_AUTHORITY_LOCAL.value = previous
+                _AUTH_AUTHORITY_LOCAL.home = previous_home
+
+
+def _capture_auth_authority() -> Tuple[Tuple[Path, Optional[Path]], Path]:
+    """Capture the current profile's immutable auth authority for later use."""
+    with _auth_authority_context() as authority:
+        home = getattr(
+            _AUTH_AUTHORITY_LOCAL,
+            "home",
+            get_hermes_home().resolve(strict=False),
+        )
+        return authority, home
+
+
+@contextmanager
+def _use_auth_authority(
+    binding: Tuple[Tuple[Path, Optional[Path]], Path],
+):
+    """Temporarily restore a previously captured auth authority binding."""
+    previous = getattr(_AUTH_AUTHORITY_LOCAL, "value", None)
+    previous_home = getattr(_AUTH_AUTHORITY_LOCAL, "home", None)
+    authority, home = binding
+    _AUTH_AUTHORITY_LOCAL.value = authority
+    _AUTH_AUTHORITY_LOCAL.home = home
+    try:
+        yield authority
+    finally:
+        if previous is None:
+            for attribute in ("value", "home"):
+                try:
+                    delattr(_AUTH_AUTHORITY_LOCAL, attribute)
+                except AttributeError:
+                    pass
+        else:
+            _AUTH_AUTHORITY_LOCAL.value = previous
+            _AUTH_AUTHORITY_LOCAL.home = previous_home
+
+
 def _auth_file_path() -> Path:
-    path = get_hermes_home() / "auth.json"
+    authority = getattr(_AUTH_AUTHORITY_LOCAL, "value", None)
+    path = authority[0] if authority is not None else _resolve_auth_authority()[0]
     # Seat belt: if pytest is running and HERMES_HOME resolves to the real
     # user's auth store, refuse rather than silently corrupt it. This catches
     # tests that forgot to monkeypatch HERMES_HOME, tests invoked without the
     # hermetic conftest, or sandbox escapes via threads/subprocesses. In
     # production (no PYTEST_CURRENT_TEST) this is a single dict lookup.
     if os.environ.get("PYTEST_CURRENT_TEST"):
-        real_home_auth = (Path.home() / ".hermes" / "auth.json").resolve(strict=False)
+        declared_home = Path(os.environ.get("HOME", str(Path.home())))
+        real_hermes_root = (declared_home / ".hermes").resolve(strict=False)
         try:
             resolved = path.resolve(strict=False)
         except Exception:
             resolved = path
-        if resolved == real_home_auth:
+        real_root_auth = real_hermes_root / "auth.json"
+        try:
+            relative = resolved.relative_to(real_hermes_root / "profiles")
+            real_profile_auth = len(relative.parts) == 2 and relative.parts[-1] == "auth.json"
+        except ValueError:
+            real_profile_auth = False
+        if resolved == real_root_auth or real_profile_auth:
             raise RuntimeError(
                 f"Refusing to touch real user auth store during test run: {path}. "
                 "Set HERMES_HOME to a tmp_path in your test fixture, or run "
@@ -1137,6 +1297,10 @@ def _auth_file_path() -> Path:
 def _global_auth_file_path() -> Optional[Path]:
     """Return the global-root auth.json when the process is in profile mode.
 
+    An explicit ``auth.source_profile`` is exclusive: falling through to the
+    default/root store would silently reintroduce the very profile ambiguity
+    the setting is meant to eliminate.
+
     Returns ``None`` when the profile and global root resolve to the same
     directory (classic mode, or custom HERMES_HOME that is not a profile).
     Used by read-only fallback paths so providers authed at the root are
@@ -1144,25 +1308,8 @@ def _global_auth_file_path() -> Optional[Path]:
 
     See issue #18594 follow-up (credential_pool shadowing).
     """
-    try:
-        from hermes_constants import get_default_hermes_root
-        global_root = get_default_hermes_root()
-    except Exception:
-        return None
-    profile_home = get_hermes_home()
-    try:
-        if profile_home.resolve(strict=False) == global_root.resolve(strict=False):
-            return None
-    except Exception:
-        if profile_home == global_root:
-            return None
-    # No pytest seat belt here: this is a pure read-only path, and
-    # ``_load_global_auth_store()`` wraps the read in a try/except so an
-    # unreadable global file can never break the profile process.  The
-    # write-side seat belt still lives on ``_auth_file_path()`` where it
-    # belongs (that's what protects the real user's auth store from being
-    # corrupted by a mis-configured test).
-    return global_root / "auth.json"
+    authority = getattr(_AUTH_AUTHORITY_LOCAL, "value", None)
+    return authority[1] if authority is not None else _resolve_auth_authority()[1]
 
 
 def _load_global_auth_store() -> Dict[str, Any]:
@@ -1334,15 +1481,16 @@ def _auth_store_lock(
     refresh paths follow this order; violating it risks deadlock
     against a concurrent import on the shared store.
     """
-    auth_path = target_path if target_path is not None else _auth_file_path()
-    lock_path = auth_path.with_suffix(".lock") if target_path is not None else _auth_lock_path()
-    with _file_lock(
-        lock_path,
-        _auth_lock_holder_for(auth_path),
-        timeout_seconds,
-        "Timed out waiting for auth store lock",
-    ):
-        yield
+    with _auth_authority_context():
+        auth_path = target_path if target_path is not None else _auth_file_path()
+        lock_path = auth_path.with_suffix(".lock") if target_path is not None else _auth_lock_path()
+        with _file_lock(
+            lock_path,
+            _auth_lock_holder_for(auth_path),
+            timeout_seconds,
+            "Timed out waiting for auth store lock",
+        ):
+            yield
 
 
 def _load_auth_store(auth_file: Optional[Path] = None) -> Dict[str, Any]:
@@ -1667,7 +1815,7 @@ def is_runtime_provider_routable(provider_id: str) -> bool:
     return True
 
 
-def read_credential_pool(provider_id: Optional[str] = None) -> Dict[str, Any]:
+def _read_credential_pool_pinned(provider_id: Optional[str] = None) -> Dict[str, Any]:
     """Return the persisted credential pool, or one provider slice.
 
     In profile mode, the profile's credential pool is authoritative. If a
@@ -1712,6 +1860,12 @@ def read_credential_pool(provider_id: Optional[str] = None) -> Dict[str, Any]:
     # Profile has no entries for this provider — fall back to global.
     global_entries = global_pool.get(provider_id)
     return list(global_entries) if isinstance(global_entries, list) else []
+
+
+def read_credential_pool(provider_id: Optional[str] = None) -> Dict[str, Any]:
+    """Read one credential-pool snapshot under a single pinned authority."""
+    with _auth_authority_context():
+        return _read_credential_pool_pinned(provider_id)
 
 
 _POOL_STATUS_FIELDS = (
@@ -1929,8 +2083,9 @@ def get_provider_auth_state(provider_id: str) -> Optional[Dict[str, Any]]:
     global-scope provider state (e.g. a globally-authenticated Anthropic
     OAuth or Nous device-code session). See issue #18594 follow-up.
     """
-    auth_store = _load_auth_store()
-    return _load_provider_state(auth_store, provider_id)
+    with _auth_authority_context():
+        auth_store = _load_auth_store()
+        return _load_provider_state(auth_store, provider_id)
 
 
 def get_active_provider() -> Optional[str]:
@@ -1939,6 +2094,7 @@ def get_active_provider() -> Optional[str]:
     return auth_store.get("active_provider")
 
 
+@_pin_auth_authority
 def is_provider_explicitly_configured(provider_id: str) -> bool:
     """Return True only if the user has explicitly configured this provider.
 
@@ -2186,6 +2342,7 @@ def _get_config_hint_for_unknown_provider(provider_name: str) -> str:
         return ""
 
 
+@_pin_auth_authority
 def resolve_provider(
     requested: Optional[str] = None,
     *,
@@ -3530,6 +3687,7 @@ def _spotify_interactive_setup(redirect_uri_hint: str) -> str:
     return raw
 
 
+@_pin_auth_authority
 def login_spotify_command(args) -> None:
     existing_state = get_provider_auth_state("spotify") or {}
 
@@ -3800,6 +3958,7 @@ def _print_loopback_ssh_hint(redirect_uri: str, *, docs_url: str | None = None) 
 # where one app's refresh invalidates the other's session.
 # =============================================================================
 
+@_pin_auth_authority
 def _read_codex_tokens(*, _lock: bool = True) -> Dict[str, Any]:
     """Read Codex OAuth tokens from Hermes auth store (~/.hermes/auth.json).
     
@@ -4206,6 +4365,7 @@ def _import_codex_cli_tokens() -> Optional[Dict[str, str]]:
         return None
 
 
+@_pin_auth_authority
 def resolve_codex_runtime_credentials(
     *,
     force_refresh: bool = False,
@@ -4700,6 +4860,7 @@ def _xai_oauth_state_has_usable_tokens(state: Optional[Dict[str, Any]]) -> bool:
     )
 
 
+@_pin_auth_authority
 def _read_xai_oauth_tokens(*, _lock: bool = True) -> Dict[str, Any]:
     if _lock:
         with _auth_store_lock():
@@ -5163,6 +5324,7 @@ def refresh_xai_oauth_pure(
     return updated
 
 
+@_pin_auth_authority
 def _refresh_xai_oauth_tokens(
     tokens: Dict[str, Any],
     *,
@@ -5206,6 +5368,7 @@ def _refresh_xai_oauth_tokens(
     return updated_tokens
 
 
+@_pin_auth_authority
 def resolve_xai_oauth_runtime_credentials(
     *,
     force_refresh: bool = False,
@@ -6362,6 +6525,7 @@ def refresh_nous_oauth_from_state(
     )
 
 
+@_pin_auth_authority
 def persist_nous_credentials(
     creds: Dict[str, Any],
     *,
@@ -6431,6 +6595,7 @@ def _sync_nous_pool_from_auth_store() -> None:
         logger.debug("Failed to sync Nous credential pool from auth store: %s", exc)
 
 
+@_pin_auth_authority
 def resolve_nous_runtime_credentials(
     *,
     timeout_seconds: float = 15.0,
@@ -6877,6 +7042,7 @@ def invalidate_nous_auth_status_cache() -> None:
     _nous_auth_status_cache = None
 
 
+@_pin_auth_authority
 def get_nous_auth_status() -> Dict[str, Any]:
     """Status snapshot for Nous auth.
 
@@ -6910,6 +7076,7 @@ def get_nous_auth_status() -> Dict[str, Any]:
     return status
 
 
+@_pin_auth_authority
 def _compute_nous_auth_status() -> Dict[str, Any]:
     """Uncached implementation of get_nous_auth_status(). See that function."""
     state = get_provider_auth_state("nous")
@@ -6962,6 +7129,7 @@ def _compute_nous_auth_status() -> Dict[str, Any]:
     return _snapshot_nous_pool_status()
 
 
+@_pin_auth_authority
 def get_nous_auth_status_local() -> Dict[str, Any]:
     """Refresh-free Nous auth snapshot for read-only display surfaces.
 
@@ -7091,6 +7259,7 @@ def get_nous_session_validity() -> str:
     return NOUS_SESSION_UNKNOWN
 
 
+@_pin_auth_authority
 def get_codex_auth_status() -> Dict[str, Any]:
     """Status snapshot for Codex auth.
     
@@ -7156,6 +7325,7 @@ def get_codex_auth_status() -> Dict[str, Any]:
         }
 
 
+@_pin_auth_authority
 def get_xai_oauth_auth_status() -> Dict[str, Any]:
     try:
         from agent.credential_pool import load_pool
@@ -7290,6 +7460,7 @@ def get_external_process_provider_status(provider_id: str) -> Dict[str, Any]:
     }
 
 
+@_pin_auth_authority
 def get_auth_status(provider_id: Optional[str] = None) -> Dict[str, Any]:
     """Generic auth status dispatcher."""
     target = (provider_id or get_active_provider() or "").strip().lower()
@@ -7402,6 +7573,7 @@ def _get_azure_foundry_auth_status() -> Dict[str, Any]:
     return info
 
 
+@_pin_auth_authority
 def resolve_api_key_provider_credentials(provider_id: str) -> Dict[str, Any]:
     """Resolve API key and base URL for an API-key provider.
 
@@ -8025,6 +8197,7 @@ def login_command(args) -> None:
     raise SystemExit(0)
 
 
+@_pin_auth_authority
 def _login_openai_codex(
     args,
     pconfig: ProviderConfig,
@@ -8099,6 +8272,7 @@ def _login_openai_codex(
     print(f"  Config updated: {config_path} (model.provider=openai-codex)")
 
 
+@_pin_auth_authority
 def _login_xai_oauth(
     args,
     pconfig: ProviderConfig,
@@ -8962,6 +9136,7 @@ def build_minimax_oauth_token_provider() -> Callable[[], str]:
     process (CLI, gateway, cron) is immediately visible to every other
     process sharing the same ``auth.json``.
     """
+    @_pin_auth_authority
     def _provide() -> str:
         state = get_provider_auth_state("minimax-oauth")
         if not state or not state.get("access_token"):
@@ -8986,6 +9161,7 @@ def build_minimax_oauth_token_provider() -> Callable[[], str]:
     return _provide
 
 
+@_pin_auth_authority
 def resolve_minimax_oauth_runtime_credentials(
     *, min_token_ttl_seconds: int = MINIMAX_OAUTH_REFRESH_SKEW_SECONDS,
     as_token_provider: bool = False,
@@ -9217,6 +9393,7 @@ def nous_token_has_billing_scope() -> bool:
     return NOUS_BILLING_MANAGE_SCOPE in scope.split()
 
 
+@_pin_auth_authority
 def step_up_nous_billing_scope(
     *,
     open_browser: bool = True,
@@ -9284,6 +9461,7 @@ def step_up_nous_billing_scope(
     return isinstance(granted, str) and NOUS_BILLING_MANAGE_SCOPE in granted.split()
 
 
+@_pin_auth_authority
 def _login_nous(args, pconfig: ProviderConfig) -> None:
     """Nous Portal device authorization flow."""
     timeout_seconds = getattr(args, "timeout", None) or 15.0
@@ -9488,6 +9666,7 @@ def _login_nous(args, pconfig: ProviderConfig) -> None:
         raise SystemExit(1)
 
 
+@_pin_auth_authority
 def logout_command(args) -> None:
     """Clear auth state for a provider."""
     provider_id = getattr(args, "provider", None)

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -245,6 +245,7 @@ def _format_exhausted_status(entry) -> str:
     return f" {label}{reason_text}{code} ({wait} left)"
 
 
+@auth_mod._pin_auth_authority
 def auth_add_command(args) -> None:
     provider = _normalize_provider(getattr(args, "provider", ""))
     configured_provider = _configured_provider_entry(provider)
@@ -559,6 +560,7 @@ def auth_list_command(args) -> None:
         print()
 
 
+@auth_mod._pin_auth_authority
 def auth_remove_command(args) -> None:
     provider = _normalize_provider(getattr(args, "provider", ""))
     target = getattr(args, "target", None)
@@ -597,6 +599,7 @@ def auth_remove_command(args) -> None:
         print(line)
 
 
+@auth_mod._pin_auth_authority
 def auth_reset_command(args) -> None:
     provider = _normalize_provider(getattr(args, "provider", ""))
     pool = load_pool(provider)

--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 from hermes_cli.cli_output import line_input
 
 import argparse
+from functools import wraps
 import os
 import subprocess
 import urllib.parse
@@ -39,6 +40,16 @@ from hermes_cli.providers import custom_provider_slug
 BEDROCK_GEO_PREFIXES = (
     "us.", "eu.", "ap.", "apac.", "jp.", "ca.", "sa.", "me.", "af.",
 )
+
+
+def _pin_model_auth_authority(operation):
+    """Keep one credential-store authority across a complete model flow."""
+    @wraps(operation)
+    def pinned(*args, **kwargs):
+        from hermes_cli.auth import _auth_authority_context
+        with _auth_authority_context():
+            return operation(*args, **kwargs)
+    return pinned
 
 
 def bedrock_region_geo_prefix(region_name: str) -> str:
@@ -85,6 +96,7 @@ def _existing_api_key_for_model_flow(provider_id: str, pconfig) -> tuple[str, st
     return _resolve_api_key_provider_secret(provider_id, pconfig)
 
 
+@_pin_model_auth_authority
 def _prune_replaced_custom_model_config_credentials(
     base_url: str,
     *,

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -59,6 +59,7 @@ if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
 from hermes_cli import __version__, __release_date__
+import hermes_cli.auth as auth_mod
 from hermes_cli.config import (
     build_cron_model_impact,
     cfg_get,
@@ -14279,6 +14280,7 @@ async def list_credential_pool():
 
 
 @app.post("/api/credentials/pool")
+@auth_mod._pin_auth_authority
 async def add_credential_pool_entry(body: CredentialPoolAdd):
     import uuid as _uuid
     from agent.credential_pool import (
@@ -14331,6 +14333,7 @@ async def add_credential_pool_entry(body: CredentialPoolAdd):
 
 
 @app.delete("/api/credentials/pool/{provider}/{index}")
+@auth_mod._pin_auth_authority
 async def remove_credential_pool_entry(provider: str, index: int):
     """Remove a pool entry.  ``index`` is 1-based (matches the list response).
 

--- a/tests/hermes_cli/test_auth_profile_fallback.py
+++ b/tests/hermes_cli/test_auth_profile_fallback.py
@@ -53,6 +53,747 @@ def _write(path: Path, payload: dict) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Explicit named-profile auth source
+# ---------------------------------------------------------------------------
+
+
+def test_explicit_auth_source_profile_shares_reads_writes_and_lock(profile_env):
+    from hermes_cli import auth
+
+    source_profile = profile_env["global"] / "profiles" / "work"
+    source_profile.mkdir(parents=True)
+    _write(source_profile / "auth.json", _make_auth_store(
+        pool={
+            "openai-codex": [{
+                "id": "shared-1",
+                "label": "shared",
+                "auth_type": "oauth",
+                "priority": 0,
+                "source": "manual:device_code",
+                "access_token": "shared-token",
+            }],
+        },
+        providers={"nous": {"access_token": "source-provider"}},
+    ))
+    (profile_env["profile"] / "config.yaml").write_text(
+        "auth:\n  source_profile: work\n"
+    )
+    _write(profile_env["global"] / "auth.json", _make_auth_store(
+        pool={"anthropic": [{"id": "must-not-fallback"}]},
+        providers={"nous": {"access_token": "must-not-fallback"}},
+    ))
+    _write(profile_env["profile"] / "auth.json", _make_auth_store(pool={
+        "openai-codex": [{"id": "stale-local"}],
+    }))
+
+    assert auth._auth_file_path() == source_profile / "auth.json"
+    assert auth._auth_lock_path() == source_profile / "auth.lock"
+    assert auth._global_auth_file_path() is None
+    assert auth.read_credential_pool("openai-codex")[0]["id"] == "shared-1"
+    assert auth.read_credential_pool("anthropic") == []
+    assert auth.get_provider_auth_state("nous") == {"access_token": "source-provider"}
+    provider_state, provider_source = auth._load_provider_state_with_source(
+        auth._load_auth_store(), "nous"
+    )
+    assert provider_state == {"access_token": "source-provider"}
+    assert provider_source == source_profile / "auth.json"
+
+    auth.write_credential_pool("openai-codex", [{
+        "id": "shared-1",
+        "label": "shared",
+        "auth_type": "oauth",
+        "priority": 0,
+        "source": "manual:device_code",
+        "access_token": "refreshed-token",
+    }])
+
+    source_data = json.loads((source_profile / "auth.json").read_text())
+    local_data = json.loads((profile_env["profile"] / "auth.json").read_text())
+    assert source_data["credential_pool"]["openai-codex"][0]["access_token"] == "refreshed-token"
+    assert local_data["credential_pool"]["openai-codex"][0]["id"] == "stale-local"
+
+
+def test_explicit_auth_source_profile_rejects_path_traversal(profile_env):
+    from hermes_cli import auth
+
+    (profile_env["profile"] / "config.yaml").write_text(
+        "auth:\n  source_profile: ../work\n"
+    )
+    with pytest.raises(RuntimeError, match="simple named profile"):
+        auth._auth_file_path()
+
+
+def test_explicit_auth_source_profile_rejects_symlink_escape(profile_env, tmp_path):
+    from hermes_cli import auth
+
+    outside = tmp_path / "outside-auth"
+    outside.mkdir()
+    (profile_env["global"] / "profiles" / "escaped").symlink_to(
+        outside, target_is_directory=True
+    )
+    (profile_env["profile"] / "config.yaml").write_text(
+        "auth:\n  source_profile: escaped\n"
+    )
+
+    with pytest.raises(RuntimeError, match="escapes profiles root"):
+        auth._auth_file_path()
+
+
+def test_explicit_auth_source_profile_rejects_self_reference(profile_env):
+    from hermes_cli import auth
+
+    (profile_env["profile"] / "config.yaml").write_text(
+        "auth:\n  source_profile: coder\n"
+    )
+
+    with pytest.raises(RuntimeError, match="must not reference the active profile"):
+        auth._auth_file_path()
+
+
+def test_explicit_auth_source_profile_rejects_auth_file_symlink(profile_env, tmp_path):
+    from hermes_cli import auth
+
+    source_profile = profile_env["global"] / "profiles" / "work"
+    source_profile.mkdir()
+    outside_auth = tmp_path / "outside-auth.json"
+    _write(outside_auth, _make_auth_store(pool={"openai-codex": [{"id": "outside"}]}))
+    (source_profile / "auth.json").symlink_to(outside_auth)
+    (profile_env["profile"] / "config.yaml").write_text(
+        "auth:\n  source_profile: work\n"
+    )
+
+    with pytest.raises(RuntimeError, match="source store must not be a symlink"):
+        auth._auth_file_path()
+    assert json.loads(outside_auth.read_text())["credential_pool"]["openai-codex"][0]["id"] == "outside"
+
+
+def test_explicit_auth_source_profile_rejects_real_profile_during_pytest(
+    profile_env, tmp_path, monkeypatch
+):
+    from hermes_cli import auth
+
+    declared_home = tmp_path / "declared-real-home"
+    real_profile_auth = declared_home / ".hermes" / "profiles" / "work" / "auth.json"
+    real_profile_auth.parent.mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(declared_home))
+    monkeypatch.setattr(auth, "_configured_auth_source_path", lambda: real_profile_auth)
+
+    with pytest.raises(RuntimeError, match="Refusing to touch real user auth store"):
+        auth._auth_file_path()
+
+
+def test_explicit_auth_source_profile_fails_closed_on_malformed_config(profile_env):
+    from hermes_cli import auth
+
+    _write(profile_env["global"] / "auth.json", _make_auth_store(
+        pool={"anthropic": [{"id": "forbidden-global"}]},
+        providers={"nous": {"access_token": "forbidden-global"}},
+    ))
+    (profile_env["profile"] / "config.yaml").write_text("auth: [")
+
+    with pytest.raises(RuntimeError, match="active profile config is unreadable"):
+        auth._auth_file_path()
+    with pytest.raises(RuntimeError, match="active profile config is unreadable"):
+        auth._global_auth_file_path()
+
+
+def test_explicit_auth_source_profile_fails_closed_on_unreadable_config(
+    profile_env, monkeypatch
+):
+    from hermes_cli import auth
+
+    _write(profile_env["global"] / "auth.json", _make_auth_store(
+        pool={"anthropic": [{"id": "forbidden-global"}]},
+        providers={"nous": {"access_token": "forbidden-global"}},
+    ))
+    monkeypatch.setattr(
+        auth,
+        "read_user_config_raw",
+        lambda: (_ for _ in ()).throw(OSError("permission denied")),
+    )
+
+    with pytest.raises(RuntimeError, match="active profile config is unreadable"):
+        auth._auth_file_path()
+    with pytest.raises(RuntimeError, match="active profile config is unreadable"):
+        auth._global_auth_file_path()
+
+
+def test_auth_authority_is_pinned_across_credential_pool_read(profile_env, monkeypatch):
+    from hermes_cli import auth
+
+    source = profile_env["global"] / "profiles" / "source"
+    source.mkdir()
+    _write(source / "auth.json", _make_auth_store(
+        pool={"openai-codex": [{"id": "SOURCE"}]},
+    ))
+    _write(profile_env["global"] / "auth.json", _make_auth_store(
+        pool={"anthropic": [{"id": "ROOT-FORBIDDEN"}]},
+    ))
+    resolutions = iter([source / "auth.json", None])
+    calls = []
+
+    def changing_source():
+        calls.append(True)
+        return next(resolutions)
+
+    monkeypatch.setattr(auth, "_configured_auth_source_path", changing_source)
+    pool = auth.read_credential_pool()
+
+    assert pool == {"openai-codex": [{"id": "SOURCE"}]}
+    assert len(calls) == 1
+
+
+def test_auth_authority_is_pinned_across_credential_pool_write(profile_env, monkeypatch):
+    from hermes_cli import auth
+
+    stores = []
+    for name in ("b", "c", "d"):
+        profile = profile_env["global"] / "profiles" / name
+        profile.mkdir()
+        path = profile / "auth.json"
+        _write(path, _make_auth_store(pool={"openai-codex": [{"id": name.upper()}]}))
+        stores.append(path)
+    resolutions = iter(stores)
+    calls = []
+
+    def changing_source():
+        calls.append(True)
+        return next(resolutions)
+
+    monkeypatch.setattr(auth, "_configured_auth_source_path", changing_source)
+    auth.write_credential_pool("openai-codex", [{"id": "NEW", "source": "manual"}])
+
+    assert len(calls) == 1
+    assert json.loads(stores[0].read_text())["credential_pool"]["openai-codex"][0]["id"] == "NEW"
+    assert json.loads(stores[1].read_text())["credential_pool"]["openai-codex"][0]["id"] == "C"
+    assert json.loads(stores[2].read_text())["credential_pool"]["openai-codex"][0]["id"] == "D"
+    assert stores[0].with_suffix(".lock").exists()
+    assert not stores[1].with_suffix(".lock").exists()
+    assert not stores[2].with_suffix(".lock").exists()
+
+
+def test_load_pool_pins_authority_across_read_normalize_and_write(
+    profile_env, monkeypatch
+):
+    from agent import credential_pool
+    from hermes_cli import auth
+
+    stores = []
+    for name in ("b", "c"):
+        profile = profile_env["global"] / "profiles" / name
+        profile.mkdir()
+        path = profile / "auth.json"
+        _write(path, _make_auth_store(pool={
+            "zai": [{
+                "id": name.upper(), "label": name.upper(), "source": "manual",
+                "auth_type": "api_key", "access_token": f"{name}-token", "priority": 0,
+            }],
+        }))
+        stores.append(path)
+    original_c = stores[1].read_bytes()
+    resolutions = iter(stores)
+    calls = []
+
+    def changing_source():
+        calls.append(True)
+        return next(resolutions)
+
+    monkeypatch.setattr(auth, "_configured_auth_source_path", changing_source)
+    monkeypatch.setattr(credential_pool, "_seed_from_singletons", lambda *_: (False, set()))
+    monkeypatch.setattr(credential_pool, "_seed_from_env", lambda *_: (False, set()))
+    monkeypatch.setattr(credential_pool, "_normalize_pool_priorities", lambda *_: True)
+
+    pool = credential_pool.load_pool("zai")
+
+    assert pool._entries[0].id == "B"
+    assert len(calls) == 1
+    assert json.loads(stores[0].read_text())["credential_pool"]["zai"][0]["id"] == "B"
+    assert stores[1].read_bytes() == original_c
+    assert stores[0].with_suffix(".lock").exists()
+    assert not stores[1].with_suffix(".lock").exists()
+
+
+def test_codex_read_pins_source_and_never_reopens_root(profile_env, monkeypatch):
+    from hermes_cli import auth
+
+    source = profile_env["global"] / "profiles" / "codex-source"
+    source.mkdir()
+    _write(source / "auth.json", _make_auth_store())
+    _write(profile_env["global"] / "auth.json", _make_auth_store(providers={
+        "openai-codex": {"tokens": {
+            "access_token": "ROOT-FORBIDDEN-ACCESS",
+            "refresh_token": "ROOT-FORBIDDEN-REFRESH",
+        }},
+    }))
+    resolutions = iter([source / "auth.json", None])
+    calls = []
+
+    def changing_source():
+        calls.append(True)
+        return next(resolutions)
+
+    monkeypatch.setattr(auth, "_configured_auth_source_path", changing_source)
+    with pytest.raises(auth.AuthError, match="No Codex credentials stored"):
+        auth._read_codex_tokens()
+    assert len(calls) == 1
+
+
+def test_zai_endpoint_cache_pins_read_probe_and_write(profile_env, monkeypatch):
+    from hermes_cli import auth
+
+    stores = []
+    for name in ("b", "c"):
+        profile = profile_env["global"] / "profiles" / name
+        profile.mkdir()
+        path = profile / "auth.json"
+        _write(path, _make_auth_store(providers={"zai": {"marker": name.upper()}}))
+        stores.append(path)
+    original_c = stores[1].read_bytes()
+    resolutions = iter(stores)
+    calls = []
+
+    def changing_source():
+        calls.append(True)
+        return next(resolutions)
+
+    monkeypatch.setattr(auth, "_configured_auth_source_path", changing_source)
+    monkeypatch.setattr(auth, "detect_zai_endpoint", lambda *_: {
+        "base_url": "https://detected.example/v1", "id": "test", "label": "test", "model": "glm",
+    })
+    result = auth._resolve_zai_base_url("test-key", "https://default.example/v1", "")
+
+    assert result == "https://detected.example/v1"
+    assert len(calls) == 1
+    assert json.loads(stores[0].read_text())["providers"]["zai"]["marker"] == "B"
+    assert json.loads(stores[0].read_text())["providers"]["zai"]["detected_endpoint"]["base_url"] == result
+    assert stores[1].read_bytes() == original_c
+    assert stores[0].with_suffix(".lock").exists()
+    assert not stores[1].with_suffix(".lock").exists()
+
+
+def test_persist_nous_pins_singleton_and_pool_sync(profile_env, monkeypatch):
+    from hermes_cli import auth
+
+    stores = []
+    for name in ("b", "c"):
+        profile = profile_env["global"] / "profiles" / name
+        profile.mkdir()
+        path = profile / "auth.json"
+        _write(path, _make_auth_store())
+        stores.append(path)
+    original_c = stores[1].read_bytes()
+    resolutions = iter(stores)
+    calls = []
+
+    def changing_source():
+        calls.append(True)
+        return next(resolutions)
+
+    monkeypatch.setattr(auth, "_configured_auth_source_path", changing_source)
+    monkeypatch.setattr(auth, "_write_shared_nous_state", lambda *_: None)
+    auth.persist_nous_credentials({
+        "access_token": "B-NEW-ACCESS", "refresh_token": "B-NEW-REFRESH",
+        "portal_base_url": "https://portal.example", "inference_base_url": "https://inference.example/v1",
+    })
+
+    stored_b = json.loads(stores[0].read_text())
+    assert stored_b["providers"]["nous"]["access_token"] == "B-NEW-ACCESS"
+    assert stored_b["credential_pool"]["nous"]
+    assert stores[1].read_bytes() == original_c
+    assert len(calls) == 1
+    assert stores[0].with_suffix(".lock").exists()
+    assert not stores[1].with_suffix(".lock").exists()
+
+
+def test_logout_pins_active_provider_selection_and_clear(profile_env, monkeypatch):
+    from argparse import Namespace
+    from hermes_cli import auth
+
+    stores = []
+    for name, active in (("b", "nous"), ("c", "spotify")):
+        profile = profile_env["global"] / "profiles" / name
+        profile.mkdir()
+        path = profile / "auth.json"
+        store = _make_auth_store(providers={
+            "nous": {"access_token": f"{name}-nous"},
+            "spotify": {"access_token": f"{name}-spotify"},
+        })
+        store["active_provider"] = active
+        _write(path, store)
+        stores.append(path)
+    original_c = stores[1].read_bytes()
+    resolutions = iter(stores)
+    calls = []
+
+    def changing_source():
+        calls.append(True)
+        return next(resolutions)
+
+    monkeypatch.setattr(auth, "_configured_auth_source_path", changing_source)
+    auth.logout_command(Namespace(provider=None))
+
+    stored_b = json.loads(stores[0].read_text())
+    assert "nous" not in stored_b["providers"]
+    assert "spotify" in stored_b["providers"]
+    assert stores[1].read_bytes() == original_c
+    assert len(calls) == 1
+
+
+def test_api_key_runtime_resolution_pins_pool_and_zai_cache(profile_env, monkeypatch):
+    from hermes_cli import auth
+
+    stores = []
+    for name in ("b", "c"):
+        profile = profile_env["global"] / "profiles" / name
+        profile.mkdir()
+        path = profile / "auth.json"
+        pool = {"zai": [{
+            "id": name.upper(), "label": name.upper(), "source": "manual",
+            "auth_type": "api_key", "access_token": f"{name}-key", "priority": 0,
+        }]}
+        _write(path, _make_auth_store(pool=pool))
+        stores.append(path)
+    original_c = stores[1].read_bytes()
+    resolutions = iter(stores)
+    calls = []
+
+    def changing_source():
+        calls.append(True)
+        return next(resolutions)
+
+    monkeypatch.setattr(auth, "_configured_auth_source_path", changing_source)
+    monkeypatch.setattr(auth, "detect_zai_endpoint", lambda *_: {
+        "base_url": "https://zai.example/v1", "id": "test", "label": "test", "model": "glm",
+    })
+    result = auth.resolve_api_key_provider_credentials("zai")
+
+    assert result["api_key"] == "b-key"
+    stored_b = json.loads(stores[0].read_text())
+    assert stored_b["providers"]["zai"]["detected_endpoint"]["base_url"] == "https://zai.example/v1"
+    assert stores[1].read_bytes() == original_c
+    assert len(calls) == 1
+
+
+def test_minimax_runtime_refresh_pins_read_and_persistence(profile_env, monkeypatch):
+    from hermes_cli import auth
+
+    stores = []
+    for name in ("b", "c"):
+        profile = profile_env["global"] / "profiles" / name
+        profile.mkdir()
+        path = profile / "auth.json"
+        _write(path, _make_auth_store(providers={"minimax-oauth": {
+            "access_token": f"{name}-old", "refresh_token": f"{name}-refresh",
+            "portal_base_url": "https://portal.example", "inference_base_url": "https://api.example/v1",
+        }}))
+        stores.append(path)
+    original_c = stores[1].read_bytes()
+    resolutions = iter(stores)
+    calls = []
+
+    def changing_source():
+        calls.append(True)
+        return next(resolutions)
+
+    def fake_refresh(state, **_kwargs):
+        updated = dict(state, access_token="B-ROTATED")
+        auth._minimax_save_auth_state(updated)
+        return updated
+
+    monkeypatch.setattr(auth, "_configured_auth_source_path", changing_source)
+    monkeypatch.setattr(auth, "_refresh_minimax_oauth_state", fake_refresh)
+    result = auth.resolve_minimax_oauth_runtime_credentials()
+
+    assert result["api_key"] == "B-ROTATED"
+    assert json.loads(stores[0].read_text())["providers"]["minimax-oauth"]["access_token"] == "B-ROTATED"
+    assert stores[1].read_bytes() == original_c
+    assert len(calls) == 1
+
+
+def test_custom_model_prune_pins_pool_read_and_write(profile_env, monkeypatch):
+    from agent import credential_pool
+    from hermes_cli import auth
+    from hermes_cli.model_setup_flows import _prune_replaced_custom_model_config_credentials
+
+    stores = []
+    for name in ("b", "c"):
+        profile = profile_env["global"] / "profiles" / name
+        profile.mkdir()
+        path = profile / "auth.json"
+        _write(path, _make_auth_store(pool={
+            "custom:old": [
+                {"id": f"{name}-model", "source": "model_config", "access_token": f"{name}-old"},
+                {"id": f"{name}-manual", "source": "manual", "access_token": f"{name}-keep"},
+            ],
+        }))
+        stores.append(path)
+    original_c = stores[1].read_bytes()
+    resolutions = iter(stores)
+    calls = []
+
+    def changing_source():
+        calls.append(True)
+        return next(resolutions)
+
+    monkeypatch.setattr(auth, "_configured_auth_source_path", changing_source)
+    monkeypatch.setattr(credential_pool, "get_custom_provider_pool_key", lambda *_args, **_kwargs: "custom:new")
+    _prune_replaced_custom_model_config_credentials("https://new.example/v1")
+
+    entries_b = json.loads(stores[0].read_text())["credential_pool"]["custom:old"]
+    assert [entry["id"] for entry in entries_b] == ["b-manual"]
+    assert stores[1].read_bytes() == original_c
+    assert len(calls) == 1
+
+
+@pytest.mark.parametrize(
+    "provider,method",
+    [
+        ("openai-codex", "_sync_codex_entry_from_auth_store"),
+        ("xai-oauth", "_sync_xai_oauth_entry_from_auth_store"),
+    ],
+)
+def test_oauth_pool_sync_pins_auth_read_and_pool_persist(
+    profile_env, monkeypatch, provider, method
+):
+    from agent.credential_pool import CredentialPool, PooledCredential
+    from hermes_cli import auth
+
+    stores = []
+    for name in ("b", "c"):
+        profile = profile_env["global"] / "profiles" / name
+        profile.mkdir()
+        path = profile / "auth.json"
+        _write(path, _make_auth_store(
+            providers={provider: {"tokens": {
+                "access_token": f"{name}-new", "refresh_token": f"{name}-new-r",
+            }, "last_refresh": f"{name}-time"}},
+            pool={provider: [{
+                "id": "row", "label": "row", "auth_type": "oauth", "priority": 0,
+                "source": "device_code", "access_token": f"{name}-old",
+                "refresh_token": f"{name}-old-r", "last_status": "exhausted",
+            }]},
+        ))
+        stores.append(path)
+    original_c = stores[1].read_bytes()
+    resolutions = iter(stores)
+    calls = []
+
+    def changing_source():
+        calls.append(True)
+        return next(resolutions)
+
+    monkeypatch.setattr(auth, "_configured_auth_source_path", changing_source)
+    entry = PooledCredential(
+        provider=provider, id="row", label="row", auth_type="oauth", priority=0,
+        source="device_code", access_token="b-old", refresh_token="b-old-r",
+        last_status="exhausted",
+    )
+    pool = CredentialPool(provider, [entry])
+    updated = getattr(pool, method)(entry)
+
+    assert updated.access_token == "b-new"
+    assert json.loads(stores[0].read_text())["credential_pool"][provider][0]["access_token"] == "b-new"
+    assert stores[1].read_bytes() == original_c
+    assert len(calls) == 1
+
+
+def test_loaded_pool_remains_bound_for_later_mutation(profile_env, monkeypatch):
+    from agent import credential_pool
+    from hermes_cli import auth
+
+    stores = []
+    for name in ("b", "c"):
+        profile = profile_env["global"] / "profiles" / name
+        profile.mkdir()
+        path = profile / "auth.json"
+        _write(path, _make_auth_store(pool={"zai": [{
+            "id": name.upper(), "label": name.upper(), "source": "manual",
+            "auth_type": "api_key", "access_token": f"{name}-key", "priority": 0,
+        }]}))
+        stores.append(path)
+    original_c = stores[1].read_bytes()
+    resolutions = iter(stores)
+    calls = []
+
+    def changing_source():
+        calls.append(True)
+        return next(resolutions)
+
+    monkeypatch.setattr(auth, "_configured_auth_source_path", changing_source)
+    monkeypatch.setattr(credential_pool, "_seed_from_singletons", lambda *_: (False, set()))
+    monkeypatch.setattr(credential_pool, "_seed_from_env", lambda *_: (False, set()))
+    pool = credential_pool.load_pool("zai")
+    removed = pool.remove_index(1)
+
+    assert removed.id == "B"
+    assert json.loads(stores[0].read_text())["credential_pool"]["zai"] == []
+    assert stores[1].read_bytes() == original_c
+    assert len(calls) == 1
+
+
+def test_oauth_refresh_uses_loaded_pool_authority_for_singleton_and_pool(
+    profile_env, monkeypatch
+):
+    from dataclasses import replace
+    from agent import credential_pool
+    from hermes_cli import auth
+
+    provider = "openai-codex"
+    stores = []
+    for name in ("b", "c"):
+        profile = profile_env["global"] / "profiles" / name
+        profile.mkdir()
+        path = profile / "auth.json"
+        _write(path, _make_auth_store(
+            providers={provider: {"tokens": {
+                "access_token": f"{name}-old", "refresh_token": f"{name}-refresh",
+            }}},
+            pool={provider: [{
+                "id": "row", "label": name, "source": "device_code",
+                "auth_type": "oauth", "access_token": f"{name}-old",
+                "refresh_token": f"{name}-refresh", "priority": 0,
+            }]},
+        ))
+        stores.append(path)
+    original_c = stores[1].read_bytes()
+    resolutions = iter(stores)
+    calls = []
+
+    def changing_source():
+        calls.append(True)
+        return next(resolutions)
+
+    monkeypatch.setattr(auth, "_configured_auth_source_path", changing_source)
+    monkeypatch.setattr(credential_pool, "_seed_from_singletons", lambda *_: (False, set()))
+    monkeypatch.setattr(credential_pool, "_seed_from_env", lambda *_: (False, set()))
+    pool = credential_pool.load_pool(provider)
+
+    def fake_refresh_impl(self, entry, *, force):
+        updated = replace(entry, access_token="ROTATED", refresh_token="ROTATED-r")
+        self._replace_entry(entry, updated)
+        self._sync_device_code_entry_to_auth_store(updated)
+        self._persist()
+        return updated
+
+    monkeypatch.setattr(credential_pool.CredentialPool, "_refresh_entry_impl", fake_refresh_impl)
+    refreshed = pool.try_refresh_matching(credential_id="row")
+
+    assert refreshed.access_token == "ROTATED"
+    b_store = json.loads(stores[0].read_text())
+    assert b_store["providers"][provider]["tokens"]["access_token"] == "ROTATED"
+    assert b_store["credential_pool"][provider][0]["access_token"] == "ROTATED"
+    assert stores[1].read_bytes() == original_c
+    assert len(calls) == 1
+
+
+def test_auth_remove_pins_pool_cleanup_and_suppression(profile_env, monkeypatch):
+    from types import SimpleNamespace
+    from agent import credential_pool
+    from hermes_cli import auth
+    from hermes_cli.auth_commands import auth_remove_command
+
+    provider = "openai-codex"
+    stores = []
+    for name in ("b", "c"):
+        profile = profile_env["global"] / "profiles" / name
+        profile.mkdir()
+        path = profile / "auth.json"
+        _write(path, _make_auth_store(
+            providers={provider: {"tokens": {
+                "access_token": f"{name}-access", "refresh_token": f"{name}-refresh",
+            }}},
+            pool={provider: [{
+                "id": "row", "label": name, "source": "device_code",
+                "auth_type": "oauth", "access_token": f"{name}-access",
+                "refresh_token": f"{name}-refresh", "priority": 0,
+            }]},
+        ))
+        stores.append(path)
+    original_c = stores[1].read_bytes()
+    resolutions = iter(stores)
+    calls = []
+
+    def changing_source():
+        calls.append(True)
+        return next(resolutions)
+
+    monkeypatch.setattr(auth, "_configured_auth_source_path", changing_source)
+    monkeypatch.setattr(credential_pool, "_seed_from_singletons", lambda *_: (False, set()))
+    monkeypatch.setattr(credential_pool, "_seed_from_env", lambda *_: (False, set()))
+    auth_remove_command(SimpleNamespace(provider=provider, target="1"))
+
+    b_store = json.loads(stores[0].read_text())
+    assert b_store["credential_pool"][provider] == []
+    assert provider not in b_store.get("providers", {})
+    assert "device_code" in b_store["suppressed_sources"][provider]
+    assert stores[1].read_bytes() == original_c
+    assert len(calls) == 1
+
+
+def test_xai_oauth_read_pins_source_and_never_reopens_root(profile_env, monkeypatch):
+    from hermes_cli import auth
+
+    source = profile_env["global"] / "profiles" / "xai-source"
+    source.mkdir()
+    _write(source / "auth.json", _make_auth_store(providers={
+        "xai-oauth": {"tokens": {"access_token": "SOURCE-ACCESS", "refresh_token": "SOURCE-REFRESH"}},
+    }))
+    _write(profile_env["global"] / "auth.json", _make_auth_store(providers={
+        "xai-oauth": {"tokens": {"access_token": "ROOT-ACCESS", "refresh_token": "ROOT-REFRESH"}},
+    }))
+    resolutions = iter([source / "auth.json", None])
+    calls = []
+
+    def changing_source():
+        calls.append(True)
+        return next(resolutions)
+
+    monkeypatch.setattr(auth, "_configured_auth_source_path", changing_source)
+    result = auth._read_xai_oauth_tokens()
+
+    assert result["tokens"]["access_token"] == "SOURCE-ACCESS"
+    assert result["tokens"]["refresh_token"] == "SOURCE-REFRESH"
+    assert len(calls) == 1
+
+
+def test_nous_status_pins_authority_across_initial_and_refreshed_reads(
+    profile_env, monkeypatch
+):
+    from hermes_cli import auth
+
+    stores = []
+    for name in ("b", "c"):
+        profile = profile_env["global"] / "profiles" / name
+        profile.mkdir()
+        path = profile / "auth.json"
+        _write(path, _make_auth_store(providers={
+            "nous": {
+                "access_token": f"{name.upper()}-ACCESS",
+                "refresh_token": f"{name.upper()}-REFRESH",
+                "portal_base_url": f"https://{name}.example",
+                "inference_base_url": f"https://{name}.example/v1",
+            },
+        }))
+        stores.append(path)
+    resolutions = iter(stores)
+    calls = []
+
+    def changing_source():
+        calls.append(True)
+        return next(resolutions)
+
+    monkeypatch.setattr(auth, "_configured_auth_source_path", changing_source)
+    monkeypatch.setattr(auth, "resolve_nous_runtime_credentials", lambda: {
+        "base_url": "https://runtime.example/v1", "source": "test", "key_id": "test-key",
+    })
+    result = auth._compute_nous_auth_status()
+
+    assert result["portal_base_url"] == "https://b.example"
+    assert result["access_token"] == "B-ACCESS"
+    assert len(calls) == 1
+
+
+# ---------------------------------------------------------------------------
 # read_credential_pool — provider-slice reads
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- add strict `auth.source_profile` routing so an execution profile can use one exclusive local credential store
- pin one immutable auth authority across complete sync/async login, logout, status, runtime refresh, cache, pool mutation, cleanup, suppression, and dashboard operations
- reject malformed/self-referential/traversal/symlink/non-regular source paths and fail closed without root fallback
- bind loaded credential-pool objects to their original authority for later mutations and OAuth refresh/quarantine

## Verification
- 114 focused auth/OAuth/credential-pool tests passed on the exact candidate
- independent repository-wide review: GO, 192 tests passed, no medium+ correctness findings
- compileall and `git diff --check` passed
- hostile B→C fixtures cover reads, locks, writes, refresh, status, normalization, cleanup, suppression, CLI, and async dashboard handlers

No credential values are copied between profiles and no default/global profile is changed.