### PR TITLE
fix(cli): make approvals suggest follow-up guidance profile-aware

### DIFF
--- a/hermes_cli/approvals_suggest.py
+++ b/hermes_cli/approvals_suggest.py
@@ -34,6 +34,7 @@ Safety posture:
 from __future__ import annotations
 
 import json
+import os
 import re
 import sqlite3
 import time
@@ -379,6 +380,43 @@ def apply_proposals(proposals: list[Proposal], indices: list[int]) -> set:
     return merged
 
 
+def _apply_command_hint() -> str:
+    """Return the follow-up apply command, preserving the active profile.
+
+    A bare ``hermes approvals suggest --apply 1,3`` always targets the
+    default profile, but the proposals scanned (and the allowlist the
+    entries would merge into) belong to the *active* profile's home.  When
+    a non-default profile is active, rendering the bare command invites
+    the operator to apply proposal numbers recomputed from a different
+    profile's history into the wrong config (#97266).
+    """
+    from hermes_cli.profiles import get_active_profile_name
+
+    profile = get_active_profile_name()
+    if profile and profile != "default" and profile != "custom":
+        return f"hermes -p {profile} approvals suggest --apply 1,3"
+    return "hermes approvals suggest --apply 1,3"
+
+
+def _config_destination() -> str:
+    """Return a display path for the config file entries merge into.
+
+    Resolved from the active Hermes home (profile-aware) and folded to
+    ``~`` when it lives under the user's home, so a named profile shows
+    ``~/.hermes/profiles/<name>/config.yaml`` instead of the default
+    profile's path (#97266).
+    """
+    from hermes_constants import get_hermes_home
+
+    home = get_hermes_home()
+    config = home / "config.yaml"
+    user_home = Path(os.path.expanduser("~"))
+    try:
+        return str(Path("~") / config.relative_to(user_home))
+    except ValueError:
+        return str(config)
+
+
 def _render_text(proposals: list[Proposal], days: int) -> None:
     window = "all history" if days <= 0 else f"last {days} days"
     if not proposals:
@@ -398,9 +436,9 @@ def _render_text(proposals: list[Proposal], days: int) -> None:
         for ex in p.examples:
             print(f"       e.g. {ex}")
     print(
-        "\nNothing has been changed. Apply selected entries with:\n"
-        "  hermes approvals suggest --apply 1,3\n"
-        "Entries are merged into command_allowlist in ~/.hermes/config.yaml."
+        f"\nNothing has been changed. Apply selected entries with:\n"
+        f"  {_apply_command_hint()}\n"
+        f"Entries are merged into command_allowlist in {_config_destination()}."
     )
 
 
@@ -438,8 +476,10 @@ def suggest_command(args) -> int:
             print("Added to command_allowlist:")
             for pattern in applied:
                 print(f"  + {pattern}")
-            print(f"\ncommand_allowlist now has {len(merged)} entries "
-                  "(~/.hermes/config.yaml).")
+            print(
+                f"\ncommand_allowlist now has {len(merged)} entries "
+                f"({_config_destination()})."
+            )
         return 0
 
     if getattr(args, "json", False):

--- a/tests/hermes_cli/test_approvals_suggest.py
+++ b/tests/hermes_cli/test_approvals_suggest.py
@@ -11,6 +11,7 @@ and the --apply merge path.
 from __future__ import annotations
 
 import json
+import os
 import sqlite3
 import time
 from argparse import Namespace
@@ -252,6 +253,85 @@ class TestJsonOutput:
         assert payload["proposals"][0]["count"] == 4
         assert payload["proposals"][0]["n"] == 1
         assert isolated_allowlist["saves"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Profile-aware rendering (#97266)
+# ---------------------------------------------------------------------------
+
+class TestProfileAwareRendering:
+    """Suggested apply command and config path must follow the active profile.
+
+    The scan and the merge target resolve through the active profile's
+    Hermes home; the printed follow-up command and config destination
+    must not silently redirect an operator to the default profile.
+    """
+
+    def _profile_env(self, monkeypatch, tmp_path, name="coder"):
+        """Point HERMES_HOME at a profile-shaped home, as -p/--profile does."""
+        root = tmp_path / ".hermes"
+        profile_home = root / "profiles" / name
+        profile_home.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setenv("HERMES_HOME", str(profile_home))
+        return root, profile_home
+
+    def test_dry_render_preserves_named_profile(
+        self, db_path, isolated_allowlist, monkeypatch, tmp_path, capsys
+    ):
+        path, con = db_path
+        for _ in range(3):
+            _add_terminal_call(con, "git push --force origin main")
+        _, profile_home = self._profile_env(monkeypatch, tmp_path)
+
+        assert suggest_command(_args(path)) == 0
+        out = capsys.readouterr().out
+        assert "hermes -p coder approvals suggest --apply 1,3" in out
+        assert str(profile_home / "config.yaml") in out
+        # Must not advertise the default profile's config.
+        assert "~/.hermes/config.yaml" not in out
+        assert "hermes approvals suggest --apply" not in out.replace(
+            "hermes -p coder approvals suggest --apply", ""
+        )
+
+    def test_apply_message_names_profile_config(
+        self, db_path, isolated_allowlist, monkeypatch, tmp_path, capsys
+    ):
+        path, con = db_path
+        for _ in range(3):
+            _add_terminal_call(con, "git push --force origin main")
+        _, profile_home = self._profile_env(monkeypatch, tmp_path)
+
+        assert suggest_command(_args(path, apply_indices="1")) == 0
+        out = capsys.readouterr().out
+        assert str(profile_home / "config.yaml") in out
+        assert "~/.hermes/config.yaml" not in out
+        assert isolated_allowlist["saves"] == 1
+
+    def test_helpers_default_profile_unchanged(self, monkeypatch, tmp_path):
+        from hermes_cli.approvals_suggest import (
+            _apply_command_hint,
+            _config_destination,
+        )
+
+        # Default home (plain root, not profile-shaped): bare command,
+        # config path resolved under that home.
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        assert _apply_command_hint() == "hermes approvals suggest --apply 1,3"
+        assert _config_destination().endswith(".hermes/config.yaml")
+
+    def test_helpers_named_profile(self, monkeypatch, tmp_path):
+        from hermes_cli.approvals_suggest import (
+            _apply_command_hint,
+            _config_destination,
+        )
+
+        _, profile_home = self._profile_env(monkeypatch, tmp_path, name="reviewer")
+        assert _apply_command_hint() == (
+            "hermes -p reviewer approvals suggest --apply 1,3"
+        )
+        assert _config_destination().endswith(
+            f".hermes{os.sep}profiles{os.sep}reviewer{os.sep}config.yaml"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Under a non-default profile (`hermes -p coder approvals suggest`), the scan and the `--apply` merge correctly resolve through the active profile's Hermes home (`default_db_path()` → `get_hermes_home()`, `load_permanent_allowlist()` → `get_config_path()`), but the human-readable follow-up guidance was hard-coded to the default profile:

- `_render_text()` printed a bare `hermes approvals suggest --apply 1,3` — copying it starts a *default-profile* invocation, whose proposal numbers are recomputed from a different profile's history, so the operator can merge unrelated allowlist entries into the wrong config.
- Both the dry-run hint and the post-`--apply` confirmation printed the literal `~/.hermes/config.yaml`, hiding the actual (profile) write destination.

Fix: render both from the resolved environment instead of literals.

- `_apply_command_hint()` uses `hermes_cli.profiles.get_active_profile_name()`; for a named profile it renders `hermes -p <profile> approvals suggest --apply 1,3`, otherwise the unchanged bare command.
- `_config_destination()` renders `get_hermes_home() / "config.yaml"`, folding to `~` when under the user's home (so `~/.hermes/profiles/coder/config.yaml` instead of the literal default path).

Why safe: pure rendering change — no scan, ranking, safety-exclusion, or merge logic touched; default-profile output is byte-identical to before; profile detection reuses the existing canonical helper, and `custom`/unrecognized homes keep the bare command with an explicit resolved path.

## Testing

Reproduced RED first on the worktree (simulated `hermes -p coder approvals suggest` via a profile-shaped `HERMES_HOME`, exactly what `_apply_profile_override()` installs):

```
Nothing has been changed. Apply selected entries with:
  hermes approvals suggest --apply 1,3
Entries are merged into command_allowlist in ~/.hermes/config.yaml.
```

After the fix, same invocation renders:

```
Nothing has been changed. Apply selected entries with:
  hermes -p coder approvals suggest --apply 1,3
Entries are merged into command_allowlist in ~/.hermes/profiles/coder/config.yaml.
command_allowlist now has 1 entries (~/.hermes/profiles/coder/config.yaml).
```

```
$ uv run --extra dev python -m pytest tests/hermes_cli/test_approvals_suggest.py tests/hermes_cli/test_approvals_test.py -q
32 passed in 0.66s
```

(12 pre-existing + 4 new regression tests in `TestProfileAwareRendering` — named-profile dry run, named-profile apply message, and helper behavior for default/named homes; sibling `test_approvals_test.py` green.)

`ruff check` clean on both touched files.

Fixes #97266