### PR TITLE
fix(zai): glm-5.3 rejects medium and the thinking off switch (1210)

### DIFF
--- a/agent/reasoning_effort.py
+++ b/agent/reasoning_effort.py
@@ -117,11 +117,20 @@ KIMI_K3_OVERRIDES: dict[str, str] = {"medium": "high", "xhigh": "max"}
 GLM52_EFFORTS: tuple[str, ...] = ("high", "max")
 GLM52_OVERRIDES: dict[str, str] = {"xhigh": "max"}
 
-#: GLM-5.3 widens the knob to a graded low/medium/high/max scale — verified
-#: live on api.z.ai/api/coding/paas/v4 (issue #91789, 2026-08-21): every
-#: level accepted with monotonic reasoning-token scaling (low=4, medium=11,
-#: high=98, max=125 on the probe prompt). ``xhigh`` requests the top tier.
-GLM53_EFFORTS: tuple[str, ...] = ("low", "medium", "high", "max")
+#: GLM-5.3 widens GLM-5.2's knob downward to low, but the vocabulary is
+#: exactly ``low|high|max`` — the server enumerates it in its own rejection:
+#: ``1210: This model always engages in thinking and cannot be disabled;
+#: please use low, high, or max``. Probed live 2026-08-29 against
+#: api.z.ai/api/paas/v4 (the base_url the zai profile ships) on
+#: glm-5.3-flash: low/high/max pass validation, ``medium`` is rejected 1210
+#: alongside ``minimal``/``xhigh``/``none``. #91789 measured a graded
+#: low/medium/high/max scale on api.z.ai/api/**coding**/paas/v4, which is
+#: the more permissive route and does accept ``medium`` — but declaring
+#: ``medium`` here turned every request at that effort into a hard 1210 on
+#: the default route. The strict route's vocabulary is the safe one to
+#: declare: ``medium`` then clamps to ``low`` (nearest weaker) for coding-
+#: route users instead of failing outright for everyone else.
+GLM53_EFFORTS: tuple[str, ...] = ("low", "high", "max")
 GLM53_OVERRIDES: dict[str, str] = {"xhigh": "max"}
 
 #: DeepSeek V4 OpenAI-compat endpoint: low/medium/high/max; ``xhigh``

--- a/plugins/model-providers/zai/__init__.py
+++ b/plugins/model-providers/zai/__init__.py
@@ -22,6 +22,13 @@ two enabled levels — ``high`` and ``max`` — on the OpenAI-compatible endpoin
 (per Z.AI / BigModel docs).  Hermes' richer effort scale is collapsed onto
 those two so the user's effort preference actually reaches the model instead
 of being silently dropped.
+
+GLM-5.3 reaches one level lower (``low``/``high``/``max``) but drops the
+``thinking`` toggle: it always thinks, and rejects both a disable marker and
+any effort word outside that set with ``1210``.  So on 5.3 the toggle is
+never sent and an explicit disable resolves to the cheapest level rather
+than to nothing — omitting the field would leave the server default, which
+is the *most* expensive tier.
 """
 
 from __future__ import annotations
@@ -68,9 +75,11 @@ def _is_glm_5_2(model: str | None) -> bool:
 def _is_glm_5_3(model: str | None) -> bool:
     """Detect GLM-5.3 specifically — it has a wider effort vocabulary.
 
-    5.2 accepts only ``high``/``max``; 5.3 accepts a graded
-    ``low``/``medium``/``high``/``max`` scale (verified live, issue #91789),
-    so effort mapping must pick the vocabulary per model.
+    5.2 accepts only ``high``/``max``; 5.3 reaches one level lower with
+    ``low``/``high``/``max`` (the server enumerates that set in its own 1210
+    rejection), so effort mapping must pick the vocabulary per model. 5.3
+    also refuses to turn thinking off at all — see
+    :func:`_glm_5_2_reasoning_effort` and :meth:`ZaiProfile.build_api_kwargs_extras`.
     """
     m = (model or "").strip().lower()
     if not m:
@@ -93,7 +102,12 @@ def _glm_5_2_reasoning_effort(
     if not isinstance(reasoning_config, dict):
         return None
     if reasoning_config.get("enabled") is False:
-        return None
+        # GLM-5.3 has no off switch: the wire rejects a disable with
+        # ``1210 ... cannot be disabled``, and omitting the field leaves the
+        # server default (max — the most expensive tier), so "off" would cost
+        # *more* than any level the user could have asked for. The cheapest
+        # supported level is as close as the wire gets. 5.2 has no such trap.
+        return "low" if _is_glm_5_3(model) else None
 
     effort = (reasoning_config.get("effort") or "").strip().lower()
     if not effort or effort == "none":
@@ -132,10 +146,14 @@ class ZaiProfile(ProviderProfile):
             return extra_body, top_level
 
         # Only emit when the user expressed a preference; omitting the field
-        # keeps the server default (enabled) exactly as before.
+        # keeps the server default (enabled) exactly as before. The disable
+        # marker is skipped for GLM-5.3, which rejects it with 1210 and would
+        # fail every request from a user who turned thinking off; that
+        # preference is carried by ``reasoning_effort: low`` instead.
         if isinstance(reasoning_config, dict):
             enabled = reasoning_config.get("enabled") is not False
-            extra_body["thinking"] = {"type": "enabled" if enabled else "disabled"}
+            if enabled or not _is_glm_5_3(model):
+                extra_body["thinking"] = {"type": "enabled" if enabled else "disabled"}
 
         if _is_glm_5_2(model):
             effort = _glm_5_2_reasoning_effort(reasoning_config, model=model)

--- a/tests/plugins/model_providers/test_zai_profile.py
+++ b/tests/plugins/model_providers/test_zai_profile.py
@@ -136,18 +136,22 @@ class TestZaiGLM52ReasoningEffort:
 
 
 class TestZaiGLM53ReasoningEffort:
-    """GLM-5.3's graded low/medium/high/max effort scale (issue #91789).
+    """GLM-5.3's low/high/max effort scale, and its missing off switch.
 
-    Verified live on api.z.ai/api/coding/paas/v4: all four levels accepted
-    with monotonic reasoning-token scaling. Unlike 5.2, low and medium must
-    reach the wire instead of clamping up to high.
+    Unlike 5.2, ``low`` must reach the wire instead of clamping up to high.
+    Unlike every other GLM, thinking cannot be turned off at all: the
+    default ``/api/paas/v4`` route answers a disable — or any effort word
+    outside ``low|high|max`` — with ``1210: This model always engages in
+    thinking and cannot be disabled; please use low, high, or max``
+    (probed live 2026-08-29 on glm-5.3-flash).
     """
 
     @pytest.mark.parametrize(
         ("effort", "expected"),
         [
             ("low", "low"),
-            ("medium", "medium"),
+            # 1210 on the wire: nearest weaker supported level instead.
+            ("medium", "low"),
             ("high", "high"),
             ("max", "max"),
             ("xhigh", "max"),
@@ -180,6 +184,21 @@ class TestZaiGLM53ReasoningEffort:
             model="glm-5.2",
         )
         assert top_level == {"reasoning_effort": "high"}
+
+    def test_disable_becomes_cheapest_level_not_a_disable_marker(self, zai_profile):
+        """``reasoning_effort: none`` on 5.3 must not send the off switch.
+
+        ``parse_reasoning_effort("none")`` yields ``{"enabled": False}``, and
+        sending ``thinking.type=disabled`` for that on 5.3 fails the whole
+        request with 1210. Dropping the field instead would silently leave
+        the server default — ``max``, the most expensive tier — so the
+        disable resolves to the cheapest level the wire accepts.
+        """
+        extra_body, top_level = zai_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": False}, model="glm-5.3-flash",
+        )
+        assert extra_body == {}
+        assert top_level == {"reasoning_effort": "low"}
 
 
 class TestZaiModelGating:


### PR DESCRIPTION
## What does this PR do?

Two request shapes the `zai` profile sends today are rejected outright by `https://api.z.ai/api/paas/v4` — the `base_url` this profile ships — on `glm-5.3-flash`:

```
1210: This model always engages in thinking and cannot be disabled; please use low, high, or max
```

**1. `reasoning_effort: medium` fails every turn.** #91789 declared `GLM53_EFFORTS = ("low", "medium", "high", "max")` from probes against `api.z.ai/api/**coding**/paas/v4`. That route really does accept `medium` (re-confirmed below), but the standard route does not — so since #91789 landed, anyone on `glm-5.3*` with the most common effort level gets a hard API error on every request.

**2. The thinking off switch fails every turn.** `parse_reasoning_effort("none")` (also `false`/`off`/`disabled`, and the desktop toggle) yields `{"enabled": False}`, and `build_api_kwargs_extras` turns that into `thinking: {"type": "disabled"}`. GLM-5.3 has no off switch and rejects the marker. Simply dropping it isn't right either: omitting the field leaves the server default, which is `max` — the *most* expensive tier — so "off" would cost more than any level the user could have asked for.

## Related Issue

No upstream issue. Observed on a production deployment running `glm-5.3-flash` through this profile, then isolated with the live probes below.

## Type of Change
- 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`agent/reasoning_effort.py`** — `GLM53_EFFORTS = ("low", "high", "max")`. Pure data change, per the module's own rule 3 ("when a provider rejects a level, fix its declared supported set"). `clamp_effort` then resolves `medium` to `low` (nearest weaker) with no call-site logic. The comment records both routes and why the strict one is the safe vocabulary to declare.
- **`plugins/model-providers/zai/__init__.py`**
  - `_glm_5_2_reasoning_effort`: an explicit disable resolves to `"low"` on GLM-5.3 — the cheapest level the wire accepts — instead of `None`. GLM-5.2 keeps returning `None` (it has a real off switch).
  - `build_api_kwargs_extras`: the `thinking` disable marker is not emitted for GLM-5.3. `thinking: {"type": "enabled"}` is still sent and still accepted.
  - Module and `_is_glm_5_3` docstrings updated.
- **`tests/plugins/model_providers/test_zai_profile.py`** — extends the existing `TestZaiGLM53ReasoningEffort`: the `medium` row of the parametrized mapping now expects `low`, plus one new test for the disable path.

GLM-5.2 and GLM-4.5 are untouched — 5.2 still clamps `low → high` and still sends a genuine disable marker (`TestZaiGLM52ReasoningEffort` unchanged and green).

### Trade-off

Users pointed at the coding route lose `medium` and get `low` instead — one notch of reasoning depth, on the side of the module's stated "never silently escalate cost above what was asked" rule. Users on the shipped default route stop getting a hard 1210 on every request. If per-route vocabularies are wanted later, that needs a `base_url`-aware selector; this PR does not add one.

## How to Test

1. `pytest tests/plugins/model_providers/test_zai_profile.py tests/agent/test_reasoning_effort_module.py -q` → 70 passed.
2. Red-first: revert the two production files and re-run — `test_graded_efforts_pass_through[medium-low]` and `test_disable_becomes_cheapest_level_not_a_disable_marker` both fail.
3. Live probes (2026-08-29, `glm-5.3-flash`). `1113` = insufficient balance, i.e. **the parameter passed validation**; `1210` = rejected:

   ```
   api.z.ai/api/paas/v4        low 1113 | medium 1210 | high 1113 | max 1113
                               xhigh 1210 | minimal 1210 | none 1210
                               thinking:{"type":"disabled"} 1210
                               thinking:{"type":"enabled"}  1113

   api.z.ai/api/coding/paas/v4 medium 200 | thinking:{"type":"disabled"} 200
   ```

   Reproduce one line with:

   ```bash
   curl -s https://api.z.ai/api/paas/v4/chat/completions \
     -H "Authorization: Bearer $GLM_API_KEY" -H "Content-Type: application/json" \
     -d '{"model":"glm-5.3-flash","messages":[{"role":"user","content":"say ok"}],"max_tokens":8,"reasoning_effort":"medium"}'
   ```

## Checklist — Code
- [x] I've read the Contributing Guide
- [x] Conventional Commits — `fix(zai): …`
- [x] Searched for existing PRs — none open on GLM-5.3 effort
- [x] Only changes related to this fix (3 files, +63/-17)
- [x] `ruff check .` passes; no new ruff diagnostics on the touched files
- [x] Repo-wide `pytest` failure set is byte-identical to pristine `main` (15 pre-existing failures in `video_gen`/`hindsight`/`a2a`, unrelated)
- [x] Tests added, and proven to fail without the production change
- [x] Tested on: macOS 15 (Python 3.12)

## Checklist — Documentation & Housekeeping
- [x] Docstrings updated (zai module, `_is_glm_5_3`, `GLM53_EFFORTS`)
- [x] `cli-config.yaml.example` — N/A (no config keys; the vocabulary is data in `agent/reasoning_effort.py`)
- [x] CONTRIBUTING / AGENTS — N/A
- [x] Cross-platform — N/A (pure request-mapping logic)
- [x] Tool descriptions — N/A
