### PR TITLE
fix(bedrock): keep cachePoint out of toolConfig.tools for Nova models

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -645,6 +645,21 @@ def _model_supports_prompt_cache(model_id: str) -> bool:
     return any(pattern in model_lower for pattern in _CACHE_POINT_PATTERNS)
 
 
+# Nova accepts cachePoint blocks in the system list and the messages array
+# but rejects them inside toolConfig.tools — Bedrock fails the whole request
+# with "extraneous key [cachePoint] is not permitted" (#97281), so tool-level
+# cache markers stay Anthropic-only.
+_CACHE_POINT_TOOL_PATTERNS = [
+    "anthropic.claude",
+]
+
+
+def _model_supports_tool_cache_point(model_id: str) -> bool:
+    """Return True if the model accepts a cachePoint block in toolConfig.tools."""
+    model_lower = model_id.lower()
+    return any(pattern in model_lower for pattern in _CACHE_POINT_TOOL_PATTERNS)
+
+
 def is_anthropic_bedrock_model(model_id: str) -> bool:
     """Return True if the model is an Anthropic Claude model on Bedrock.
 
@@ -1263,7 +1278,7 @@ def build_converse_kwargs(
             # Strip tools for known non-tool-calling models and warn the user.
             # Ref: PR #7920 feedback from @ptlally, pattern from PR #4346.
             if _model_supports_tool_use(model):
-                if cache_enabled:
+                if _model_supports_tool_cache_point(model):
                     converse_tools = converse_tools + [{"cachePoint": {"type": "default"}}]
                 kwargs["toolConfig"] = {"tools": converse_tools}
             else:

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -504,8 +504,8 @@ class TestBuildConverseKwargs:
 
 
     def test_cache_point_added_for_supported_model(self):
-        """Claude and Nova on the Converse path get cachePoint markers on
-        system, tools, and the message before the newest turn."""
+        """Claude on the Converse path gets cachePoint markers on system, tools,
+        and the message before the newest turn."""
         from agent.bedrock_adapter import build_converse_kwargs
         tools = [{"type": "function", "function": {
             "name": "test", "description": "Test", "parameters": {},
@@ -528,6 +528,33 @@ class TestBuildConverseKwargs:
         marked = kwargs["messages"][-2]["content"]
         assert marked[-1] == {"cachePoint": {"type": "default"}}
         assert kwargs["messages"][-1]["content"][-1] != {"cachePoint": {"type": "default"}}
+
+    def test_nova_gets_system_and_message_cache_point_but_not_tools(self):
+        """Nova rejects cachePoint inside toolConfig.tools ("extraneous key
+        [cachePoint] is not permitted" ValidationException, #97281) while still
+        accepting it in the system list and the messages array, so those two
+        markers must survive the tool-marker restriction."""
+        from agent.bedrock_adapter import build_converse_kwargs
+        tools = [{"type": "function", "function": {
+            "name": "test", "description": "Test", "parameters": {},
+        }}]
+        messages = [
+            {"role": "system", "content": "Be helpful."},
+            {"role": "user", "content": "First"},
+            {"role": "assistant", "content": "Reply"},
+            {"role": "user", "content": "Second"},
+        ]
+        kwargs = build_converse_kwargs(
+            model="us.amazon.nova-pro-v1:0",
+            messages=messages,
+            tools=tools,
+        )
+        assert kwargs["system"][-1] == {"cachePoint": {"type": "default"}}
+        assert all(
+            t != {"cachePoint": {"type": "default"}} for t in kwargs["toolConfig"]["tools"]
+        )
+        marked = kwargs["messages"][-2]["content"]
+        assert marked[-1] == {"cachePoint": {"type": "default"}}
 
     def test_no_cache_point_for_unsupported_model(self):
         from agent.bedrock_adapter import build_converse_kwargs


### PR DESCRIPTION
## What does this PR do?

Amazon Nova models on the Bedrock Converse API path reject any request where a `cachePoint` block appears inside `toolConfig.tools` — Bedrock fails the whole call with `ValidationException: #/toolConfig/tools/18: extraneous key [cachePoint] is not permitted`. Because `_CACHE_POINT_PATTERNS` treats `anthropic.claude` and `amazon.nova` identically, `build_converse_kwargs` appended the tool-level cache marker for Nova too, so any Nova model with tools enabled failed 100% of requests (#97281).

Nova does accept `cachePoint` in the system list and the messages array, so this PR splits capability detection by placement: a new `_model_supports_tool_cache_point()` (Anthropic-only allowlist) gates the `toolConfig.tools` marker, while `_model_supports_prompt_cache()` continues to gate the system and message markers. Claude behavior is unchanged; only the previously-broken Nova + tools combination changes.

## Related Issue

Fixes #97281

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/bedrock_adapter.py`: added `_CACHE_POINT_TOOL_PATTERNS` + `_model_supports_tool_cache_point()`; the tool-level cachePoint append in `build_converse_kwargs` now uses this Anthropic-only gate instead of the shared `cache_enabled` flag.
- `tests/agent/test_bedrock_adapter.py`: added `test_nova_gets_system_and_message_cache_point_but_not_tools` (Nova keeps system + message markers, tools stay clean); updated the existing cachePoint test docstring, which previously claimed Nova also received the tools marker.

## How to Test

1. `uv run --extra dev python -m pytest tests/agent/test_bedrock_adapter.py -q`
   - Observed result: 67 passed (includes the new Nova regression test).
2. Fail-closed check for the new test: reverting the one-line gate back to `if cache_enabled:` makes `test_nova_gets_system_and_message_cache_point_but_not_tools` fail (tools list picks up the forbidden marker), confirming the test pins the bug.
3. Full bedrock surface: `uv run --extra dev python -m pytest tests/agent/test_bedrock_integration.py tests/agent/test_bedrock_empty_text_blocks.py tests/agent/test_bedrock_1m_context.py tests/hermes_cli/test_bedrock_model_picker.py tests/hermes_cli/test_bedrock_mantle_key_env.py tests/hermes_cli/test_bedrock_region_scoped_picker.py -q`
   - Observed result: 57 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64), Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A — not a skill.

## Screenshots / Logs

N/A — wire-format change verified by unit tests; the exact server-side error message is quoted in #97281.
