### PR TITLE
feat(skill_manage): operations[] is the call — each op names its skill; atomic with cross-skill rollback

### DIFF
--- a/tests/tools/test_skill_manage_batch.py
+++ b/tests/tools/test_skill_manage_batch.py
@@ -36,7 +36,11 @@ class TestSkillManageBatch(unittest.TestCase):
         shutil.rmtree(self.home, ignore_errors=True)
 
     def _call(self, name, ops):
-        return json.loads(self.smt.skill_manage(action="", name=name, operations=ops))
+        # Inject the per-op name (tests were written per-skill; the
+        # interface is name-per-op, maintainer-directed).
+        for op in ops:
+            op.setdefault("name", name)
+        return json.loads(self.smt.skill_manage(action="", name="", operations=ops))
 
     def test_create_plus_files_atomic(self):
         r = self._call("probe", [
@@ -130,6 +134,25 @@ class TestSkillManageBatch(unittest.TestCase):
             {"action": "patch", "old_string": "H.", "new_string": "I."},
         ])
         self.assertTrue(r["success"], r)
+
+    def test_cross_skill_batch_and_rollback(self):
+        """Ops may target DIFFERENT skills; a late failure rolls back
+        every touched skill, including removing a batch-created one."""
+        self._call("alpha", [{"action": "create", "content": SK.format(n="alpha")}])
+        r = json.loads(self.smt.skill_manage(action="", name="", operations=[
+            {"name": "alpha", "action": "patch",
+             "old_string": "Step 1.", "new_string": "Step A."},
+            {"name": "beta", "action": "create", "content": SK.format(n="beta")},
+            {"name": "beta", "action": "write_file",
+             "file_path": "bad/nope.md", "file_content": "x"},
+        ]))
+        self.assertFalse(r["success"])
+        self.assertEqual(r["failed_index"], 2)
+        # alpha's patch undone; beta (batch-created) removed entirely.
+        content = open(os.path.join(self.home, "skills", "alpha", "SKILL.md")).read()
+        self.assertIn("Step 1.", content)
+        self.assertNotIn("Step A.", content)
+        self.assertFalse(os.path.exists(os.path.join(self.home, "skills", "beta")))
 
     def test_single_op_path_unchanged(self):
         self._call("probe", [{"action": "create", "content": SK.format(n="probe")}])

--- a/tests/tools/test_skill_manage_batch.py
+++ b/tests/tools/test_skill_manage_batch.py
@@ -71,10 +71,19 @@ class TestSkillManageBatch(unittest.TestCase):
         self.assertFalse(os.path.exists(os.path.join(self.home, "skills", "fresh")))
 
     def test_validation_rules(self):
-        # delete not batchable
+        # delete as SOLE op routes to the real delete (works)
+        self._call("probe", [{"action": "create", "content": SK.format(n="probe")}])
         r = self._call("probe", [{"action": "delete"}])
+        self.assertTrue(r["success"], r)
+        self.assertFalse(os.path.exists(os.path.join(self.home, "skills", "probe")))
+        # delete mixed with other ops rejected
+        self._call("probe", [{"action": "create", "content": SK.format(n="probe")}])
+        r = self._call("probe", [
+            {"action": "patch", "old_string": "Step 1.", "new_string": "X."},
+            {"action": "delete"},
+        ])
         self.assertFalse(r["success"])
-        self.assertIn("standalone", r["error"])
+        self.assertIn("SOLE", r["error"])
         # create must be first
         r = self._call("x", [
             {"action": "write_file", "file_path": "references/a.md", "file_content": "a"},

--- a/tests/tools/test_skill_manage_batch.py
+++ b/tests/tools/test_skill_manage_batch.py
@@ -97,6 +97,40 @@ class TestSkillManageBatch(unittest.TestCase):
         self.assertFalse(r["success"])
         self.assertIn("capped", r["error"])
 
+    def test_intra_batch_conflict_guard(self):
+        """Same-file double writes and post-edit full rewrites are always
+        a confused plan under last-wins sequencing — rejected BEFORE any
+        side effect. Patch chains and rewrite-first stay legal."""
+        self._call("probe", [{"action": "create", "content": SK.format(n="probe")}])
+        # double write, write+remove: rejected
+        for ops in (
+            [{"action": "write_file", "file_path": "references/a.md", "file_content": "1"},
+             {"action": "write_file", "file_path": "references/a.md", "file_content": "2"}],
+            [{"action": "write_file", "file_path": "references/b.md", "file_content": "x"},
+             {"action": "remove_file", "file_path": "references/b.md"}],
+        ):
+            r = self._call("probe", ops)
+            self.assertFalse(r["success"], ops)
+            self.assertIn("clobber", r["error"])
+        # patch then full rewrite: rejected; rewrite-first: allowed
+        r = self._call("probe", [
+            {"action": "patch", "old_string": "Step 1.", "new_string": "P."},
+            {"action": "patch", "content": SK.format(n="probe")},
+        ])
+        self.assertFalse(r["success"])
+        self.assertIn("rewrite", r["error"])
+        r = self._call("probe", [
+            {"action": "patch", "content": SK.format(n="probe").replace("Step 1.", "F.")},
+            {"action": "patch", "old_string": "F.", "new_string": "G."},
+        ])
+        self.assertTrue(r["success"], r)
+        # patch chains stay legal
+        r = self._call("probe", [
+            {"action": "patch", "old_string": "G.", "new_string": "H."},
+            {"action": "patch", "old_string": "H.", "new_string": "I."},
+        ])
+        self.assertTrue(r["success"], r)
+
     def test_single_op_path_unchanged(self):
         self._call("probe", [{"action": "create", "content": SK.format(n="probe")}])
         raw = self.smt.skill_manage(

--- a/tests/tools/test_skill_manage_batch.py
+++ b/tests/tools/test_skill_manage_batch.py
@@ -106,16 +106,38 @@ class TestSkillManageBatch(unittest.TestCase):
         a confused plan under last-wins sequencing — rejected BEFORE any
         side effect. Patch chains and rewrite-first stay legal."""
         self._call("probe", [{"action": "create", "content": SK.format(n="probe")}])
-        # double write, write+remove: rejected
+        # destructive op on an already-touched file: rejected — double
+        # write, write+remove, patch-then-write, patch-then-remove, and a
+        # path-spelling variant of the same file.
+        self._call("probe", [{"action": "write_file",
+                              "file_path": "references/c.md", "file_content": "seed"}])
         for ops in (
             [{"action": "write_file", "file_path": "references/a.md", "file_content": "1"},
              {"action": "write_file", "file_path": "references/a.md", "file_content": "2"}],
             [{"action": "write_file", "file_path": "references/b.md", "file_content": "x"},
              {"action": "remove_file", "file_path": "references/b.md"}],
+            [{"action": "patch", "file_path": "references/c.md",
+              "old_string": "seed", "new_string": "edited"},
+             {"action": "write_file", "file_path": "references/c.md", "file_content": "CLOB"}],
+            [{"action": "patch", "file_path": "references/c.md",
+              "old_string": "seed", "new_string": "edited"},
+             {"action": "remove_file", "file_path": "references/c.md"}],
+            [{"action": "write_file", "file_path": "references/d.md", "file_content": "1"},
+             {"action": "write_file", "file_path": "./references//d.md", "file_content": "2"}],
         ):
             r = self._call("probe", ops)
             self.assertFalse(r["success"], ops)
-            self.assertIn("clobber", r["error"])
+            self.assertIn("discard", r["error"])
+        # ...and rejected pre-effect: c.md still holds its seed text.
+        c_md = os.path.join(self.home, "skills", "probe", "references", "c.md")
+        self.assertEqual(open(c_md).read(), "seed")
+        # write-then-patch on one supporting file stays legal (additive).
+        r = self._call("probe", [
+            {"action": "write_file", "file_path": "references/e.md", "file_content": "base"},
+            {"action": "patch", "file_path": "references/e.md",
+             "old_string": "base", "new_string": "base+"},
+        ])
+        self.assertTrue(r["success"], r)
         # patch then full rewrite: rejected; rewrite-first: allowed
         r = self._call("probe", [
             {"action": "patch", "old_string": "Step 1.", "new_string": "P."},

--- a/tests/tools/test_skill_manage_batch.py
+++ b/tests/tools/test_skill_manage_batch.py
@@ -1,0 +1,135 @@
+"""skill_manage operations[] batch (#95681 arc, maintainer-approved).
+
+Memory-tool pattern: several ops on ONE skill, atomically — create + N
+supporting files, or SKILL.md + the script it references, in one call.
+Any failure rolls the skill directory back to its pre-batch state.
+"""
+import json
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+SK = (
+    "---\nname: {n}\ndescription: Use when probing batch ops. Behavior.\n---\n"
+    "# Probe\nStep 1.\n"
+)
+
+
+class TestSkillManageBatch(unittest.TestCase):
+    def setUp(self):
+        self.home = tempfile.mkdtemp(prefix="skmbatch_t_")
+        os.environ["HERMES_HOME"] = self.home
+        os.environ["HERMES_YOLO_MODE"] = "1"
+        os.makedirs(os.path.join(self.home, "skills"), exist_ok=True)
+        # Re-import against the temp home (module caches SKILLS_DIR).
+        import importlib
+
+        import tools.skill_manager_tool as smt
+        importlib.reload(smt)
+        self.smt = smt
+
+    def tearDown(self):
+        shutil.rmtree(self.home, ignore_errors=True)
+
+    def _call(self, name, ops):
+        return json.loads(self.smt.skill_manage(action="", name=name, operations=ops))
+
+    def test_create_plus_files_atomic(self):
+        r = self._call("probe", [
+            {"action": "create", "content": SK.format(n="probe")},
+            {"action": "write_file", "file_path": "references/a.md", "file_content": "a"},
+            {"action": "write_file", "file_path": "scripts/r.py", "file_content": "pass"},
+        ])
+        self.assertTrue(r["success"], r)
+        self.assertEqual(r["operations_applied"], 3)
+        base = os.path.join(self.home, "skills", "probe")
+        for rel in ("SKILL.md", "references/a.md", "scripts/r.py"):
+            self.assertTrue(os.path.exists(os.path.join(base, rel)), rel)
+
+    def test_midbatch_failure_rolls_back_existing_skill(self):
+        self._call("probe", [{"action": "create", "content": SK.format(n="probe")}])
+        r = self._call("probe", [
+            {"action": "patch", "old_string": "Step 1.", "new_string": "Step ONE."},
+            {"action": "write_file", "file_path": "bad/nope.md", "file_content": "x"},
+        ])
+        self.assertFalse(r["success"])
+        self.assertEqual(r["failed_index"], 1)
+        content = open(os.path.join(self.home, "skills", "probe", "SKILL.md")).read()
+        self.assertIn("Step 1.", content)       # patch undone
+        self.assertNotIn("Step ONE.", content)
+
+    def test_failed_create_batch_removes_partial_skill(self):
+        r = self._call("fresh", [
+            {"action": "create", "content": SK.format(n="fresh")},
+            {"action": "write_file", "file_path": "../escape.md", "file_content": "x"},
+        ])
+        self.assertFalse(r["success"])
+        self.assertFalse(os.path.exists(os.path.join(self.home, "skills", "fresh")))
+
+    def test_validation_rules(self):
+        # delete not batchable
+        r = self._call("probe", [{"action": "delete"}])
+        self.assertFalse(r["success"])
+        self.assertIn("standalone", r["error"])
+        # create must be first
+        r = self._call("x", [
+            {"action": "write_file", "file_path": "references/a.md", "file_content": "a"},
+            {"action": "create", "content": SK.format(n="x")},
+        ])
+        self.assertFalse(r["success"])
+        # empty / capped
+        r = self._call("x", [])
+        self.assertFalse(r["success"])
+        r = self._call("x", [{"action": "patch"}] * 21)
+        self.assertFalse(r["success"])
+        self.assertIn("capped", r["error"])
+
+    def test_single_op_path_unchanged(self):
+        self._call("probe", [{"action": "create", "content": SK.format(n="probe")}])
+        raw = self.smt.skill_manage(
+            action="patch", name="probe",
+            old_string="Step 1.", new_string="Step 1 (single).",
+        )
+        self.assertTrue(json.loads(raw)["success"])
+
+    def test_batch_stages_as_one_pending_write_when_gated(self):
+        """Approval gate: the whole batch stages as ONE pending record, and
+        apply_skill_pending replays it (operations key round-trips)."""
+        from unittest.mock import patch as _patch
+
+        class _Decision:
+            allow = False
+            blocked = False
+            message = "staged for review"
+
+        staged = {}
+
+        def fake_stage_write(area, payload, summary=None, origin=None):
+            staged.update(payload=payload, summary=summary)
+            return {"id": "pend_1"}
+
+        import tools.write_approval as wa
+
+        with _patch.object(wa, "evaluate_gate", return_value=_Decision()), \
+             _patch.object(wa, "stage_write", side_effect=fake_stage_write):
+            r = self._call("probe", [
+                {"action": "create", "content": SK.format(n="probe")},
+                {"action": "write_file", "file_path": "references/a.md",
+                 "file_content": "a"},
+            ])
+        self.assertTrue(r.get("staged"), r)
+        self.assertEqual(staged["payload"]["action"], "batch")
+        self.assertEqual(len(staged["payload"]["operations"]), 2)
+        self.assertIn("2 ops", staged["summary"])
+        # Replay applies the batch (gate bypassed inside).
+        out = json.loads(self.smt.apply_skill_pending(staged["payload"]))
+        self.assertTrue(out["success"], out)
+        self.assertEqual(out["operations_applied"], 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tools/test_skill_manage_schema_diet.py
+++ b/tests/tools/test_skill_manage_schema_diet.py
@@ -15,8 +15,19 @@ from tools.skill_manager_tool import SKILL_MANAGE_SCHEMA
 
 
 class TestSkillManageSchemaDiet(unittest.TestCase):
-    def test_patch_args_defer_to_patch_tool(self):
+    def _op_props(self):
+        return SKILL_MANAGE_SCHEMA["parameters"]["properties"]["operations"]["items"]["properties"]
+
+    def test_single_call_shape(self):
+        """Maintainer-directed: operations[] IS the interface — a single
+        edit is a list of one. Flat fields are handler-only compat."""
         props = SKILL_MANAGE_SCHEMA["parameters"]["properties"]
+        self.assertEqual(sorted(props), ["name", "operations"])
+        self.assertEqual(SKILL_MANAGE_SCHEMA["parameters"]["required"], ["name", "operations"])
+        self.assertIn("delete", self._op_props()["action"]["enum"])
+
+    def test_patch_args_defer_to_patch_tool(self):
+        props = self._op_props()
         self.assertIn("patch tool", props["old_string"]["description"])
         # The uniqueness/context curriculum lives in the patch tool's schema,
         # not here.
@@ -24,7 +35,7 @@ class TestSkillManageSchemaDiet(unittest.TestCase):
         self.assertNotIn("surrounding context", props["old_string"]["description"])
 
     def test_file_path_states_relative_shape(self):
-        desc = SKILL_MANAGE_SCHEMA["parameters"]["properties"]["file_path"]["description"]
+        desc = self._op_props()["file_path"]["description"]
         self.assertIn("RELATIVE", desc)
         self.assertIn("references/api.md", desc)
         self.assertIn("never absolute", desc)
@@ -47,8 +58,9 @@ class TestSkillManageSchemaDiet(unittest.TestCase):
     def test_content_keeps_pre_irreversibility_warning(self):
         """The REPLACES-whole-file warning is pre-irreversibility guidance:
         an error can't teach after a successful full rewrite, so it must
-        stay schema-side (maintainer call)."""
-        desc = SKILL_MANAGE_SCHEMA["parameters"]["properties"]["content"]["description"]
+        stay schema-side (maintainer call). Lives in the description now
+        (op fields stay terse)."""
+        desc = SKILL_MANAGE_SCHEMA["description"]
         self.assertIn("REPLACES", desc)
         self.assertIn("skill_view()", desc)
 

--- a/tests/tools/test_skill_manage_schema_diet.py
+++ b/tests/tools/test_skill_manage_schema_diet.py
@@ -19,11 +19,14 @@ class TestSkillManageSchemaDiet(unittest.TestCase):
         return SKILL_MANAGE_SCHEMA["parameters"]["properties"]["operations"]["items"]["properties"]
 
     def test_single_call_shape(self):
-        """Maintainer-directed: operations[] IS the interface — a single
-        edit is a list of one. Flat fields are handler-only compat."""
+        """Maintainer-directed: operations[] IS the interface — each op
+        names its skill; a single edit is a list of one. Flat fields are
+        handler-only compat."""
         props = SKILL_MANAGE_SCHEMA["parameters"]["properties"]
-        self.assertEqual(sorted(props), ["name", "operations"])
-        self.assertEqual(SKILL_MANAGE_SCHEMA["parameters"]["required"], ["name", "operations"])
+        self.assertEqual(sorted(props), ["operations"])
+        self.assertEqual(SKILL_MANAGE_SCHEMA["parameters"]["required"], ["operations"])
+        items = SKILL_MANAGE_SCHEMA["parameters"]["properties"]["operations"]["items"]
+        self.assertEqual(items["required"], ["name", "action"])
         self.assertIn("delete", self._op_props()["action"]["enum"])
 
     def test_patch_args_defer_to_patch_tool(self):
@@ -53,7 +56,7 @@ class TestSkillManageSchemaDiet(unittest.TestCase):
         self.assertIn("skill_view()", desc)
         self.assertNotIn("numbered steps", desc)
         # Stale action vocabulary must not return.
-        self.assertNotIn("edit", SKILL_MANAGE_SCHEMA["parameters"]["properties"]["name"]["description"])
+        self.assertNotIn("edit", self._op_props()["name"]["description"])
 
     def test_content_keeps_pre_irreversibility_warning(self):
         """The REPLACES-whole-file warning is pre-irreversibility guidance:

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -1607,33 +1607,40 @@ def _skill_manage_batch(
 
     # --- intra-batch conflict guard: sequential last-wins semantics make
     # these SILENTLY succeed while discarding earlier ops' work — always a
-    # confused plan, never intentional. Patch CHAINS on one file (each op
-    # building on the previous text) stay legal. ---
-    seen_writes = set()
-    touched_skill_md = set()
+    # confused plan, never intentional. Rule: a DESTRUCTIVE op (write_file,
+    # remove_file, full SKILL.md rewrite) on a file some earlier op in the
+    # batch already touched is rejected; ADDITIVE patches are always legal,
+    # so patch CHAINS (each op building on the previous text) and
+    # write-then-patch both stay allowed. Paths are normalized so spelling
+    # variants ('./references/x.md', 'references//x.md') can't slip past. ---
+    import posixpath
+
+    def _norm_target(op) -> str:
+        fp = (op.get("file_path") or "").strip()
+        if not fp:
+            return "SKILL.md"
+        return posixpath.normpath(fp.lstrip("/"))
+
+    touched_files = set()  # (skill, normalized path) touched by ANY earlier op
     for i, op in enumerate(operations):
         act = op["action"]
         nm = names[i]
-        if act in ("write_file", "remove_file"):
-            key = (nm, (op.get("file_path") or "").strip())
-            if key in seen_writes:
-                return tool_error(
-                    f"operations[{i}]: '{key[1]}' on skill '{nm}' already "
-                    "written/removed earlier in this batch — the later op "
-                    "would silently clobber it. One write per file per batch.",
-                    success=False,
-                )
-            seen_writes.add(key)
-        if act in ("create", "patch") and not op.get("file_path"):
-            if act == "patch" and op.get("content") and nm in touched_skill_md:
-                return tool_error(
-                    f"operations[{i}]: full SKILL.md rewrite (content) for "
-                    f"'{nm}' after an earlier op already modified its "
-                    "SKILL.md — the rewrite would silently discard that "
-                    "edit. Put the rewrite first, or fold the change in.",
-                    success=False,
-                )
-            touched_skill_md.add(nm)
+        # create and full-rewrite patch (content) always hit SKILL.md —
+        # _edit_skill ignores file_path on the rewrite shape.
+        full_rewrite = act == "patch" and bool(op.get("content"))
+        target = "SKILL.md" if (act == "create" or full_rewrite) else _norm_target(op)
+        key = (nm, target)
+        destructive = act in ("create", "write_file", "remove_file") or full_rewrite
+        if destructive and key in touched_files:
+            return tool_error(
+                f"operations[{i}]: {act} on '{target}' of skill '{nm}' — an "
+                "earlier op in this batch already touched that file, and this "
+                "op would silently discard its work. One destructive op "
+                "(write_file/remove_file/full rewrite) per file per batch; "
+                "put it first, or fold the change in. Patch chains are fine.",
+                success=False,
+            )
+        touched_files.add(key)
 
     # --- approval gate: stage the WHOLE batch as one pending write ---
     if not _skill_gate_bypass.get():

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -1518,9 +1518,166 @@ def apply_skill_pending(payload: Dict[str, Any]) -> str:
             new_string=payload.get("new_string"),
             replace_all=payload.get("replace_all", False),
             absorbed_into=payload.get("absorbed_into"),
+            operations=payload.get("operations"),
         )
     finally:
         _skill_gate_bypass.reset(token)
+
+
+_BATCH_OP_ACTIONS = {"create", "patch", "write_file", "remove_file"}
+_BATCH_MAX_OPS = 20
+
+
+def _skill_manage_batch(
+    name: str,
+    operations,
+    task_id: str = None,
+    session_id: str = None,
+) -> str:
+    """Apply a sequence of operations to ONE skill atomically.
+
+    The memory-tool pattern (#95681 arc): create + N supporting files, or
+    a SKILL.md fix plus the script it references, land in one call — all
+    or nothing. On any op failure the skill directory is restored to its
+    pre-batch state (including full removal when the batch created it).
+
+    Scope rules:
+    - all ops target the top-level ``name`` (one skill per batch);
+    - ``delete`` is not batchable (it's a standalone decision, and its
+      recoverable-archive path doesn't compose with rollback);
+    - ``create`` only as the FIRST op.
+    """
+    import shutil
+    import tempfile
+
+    # --- validate shape up front (no side effects before this passes) ---
+    if not isinstance(operations, list) or not operations:
+        return tool_error("operations must be a non-empty array.", success=False)
+    if len(operations) > _BATCH_MAX_OPS:
+        return tool_error(f"operations is capped at {_BATCH_MAX_OPS} ops per call.", success=False)
+    for i, op in enumerate(operations):
+        if not isinstance(op, dict) or not op.get("action"):
+            return tool_error(f"operations[{i}] needs an 'action'.", success=False)
+        act = op["action"]
+        if act == "delete":
+            return tool_error(
+                "delete is not batchable — call it as a standalone action.",
+                success=False,
+            )
+        if act not in _BATCH_OP_ACTIONS:
+            return tool_error(
+                f"operations[{i}]: unknown action '{act}'. "
+                f"Batchable: {', '.join(sorted(_BATCH_OP_ACTIONS))}.",
+                success=False,
+            )
+        if act == "create" and i != 0:
+            return tool_error("create must be the first op in a batch.", success=False)
+        preflight = _background_review_preflight(act, name)
+        if preflight is not None:
+            return json.dumps(preflight, ensure_ascii=False)
+
+    # --- approval gate: stage the WHOLE batch as one pending write ---
+    if not _skill_gate_bypass.get():
+        try:
+            from tools import write_approval as wa
+        except Exception:
+            wa = None  # fail open, matching _apply_skill_write_gate
+        if wa is not None:
+            decision = wa.evaluate_gate(wa.SKILLS)
+            if decision.blocked:
+                return tool_error(decision.message, success=False)
+            if not decision.allow:
+                payload = {"action": "batch", "name": name, "operations": operations}
+                acts = ", ".join(op["action"] for op in operations)
+                gist = f"batch({len(operations)} ops: {acts}) on skill '{name}'"
+                record = wa.stage_write(
+                    wa.SKILLS, payload, summary=gist, origin=wa.current_origin()
+                )
+                return json.dumps(
+                    {"success": True, "staged": True, "pending_id": record["id"],
+                     "gist": gist, "message": decision.message},
+                    ensure_ascii=False,
+                )
+
+    # --- snapshot for rollback ---
+    pre = _find_skill(name)
+    pre_dir = Path(pre["path"]) if pre else None
+    snapshot = None
+    if pre_dir is not None and pre_dir.is_dir():
+        snapshot = Path(tempfile.mkdtemp(prefix="skill_batch_")) / pre_dir.name
+        try:
+            shutil.copytree(pre_dir, snapshot)
+        except Exception as exc:  # noqa: BLE001 — no snapshot, no atomicity
+            return tool_error(f"Could not snapshot skill for atomic batch: {exc}", success=False)
+
+    def _rollback() -> str:
+        try:
+            post = _find_skill(name)
+            post_dir = Path(post["path"]) if post else None
+            if snapshot is not None:
+                if post_dir is not None and post_dir.is_dir():
+                    shutil.rmtree(post_dir)
+                shutil.copytree(snapshot, pre_dir)
+                return "rolled back to pre-batch state"
+            # Batch created the skill: remove what the partial batch made.
+            if post_dir is not None and post_dir.is_dir():
+                shutil.rmtree(post_dir)
+            return "partially-created skill removed"
+        except Exception as exc:  # noqa: BLE001
+            return f"ROLLBACK FAILED ({exc}) — inspect the skill manually"
+
+    # --- execute ops through the normal single-op path (gate bypassed:
+    #     the batch already cleared/staged it above; ledger + telemetry
+    #     fire per-op, which is the audit granularity we want) ---
+    results = []
+    token = _skill_gate_bypass.set(True)
+    try:
+        for i, op in enumerate(operations):
+            raw = skill_manage(
+                action=op["action"],
+                name=name,
+                content=op.get("content"),
+                category=op.get("category"),
+                file_path=op.get("file_path"),
+                file_content=op.get("file_content"),
+                old_string=op.get("old_string"),
+                new_string=op.get("new_string"),
+                replace_all=op.get("replace_all", False),
+                task_id=task_id,
+                session_id=session_id,
+            )
+            try:
+                parsed = json.loads(raw)
+            except Exception:  # noqa: BLE001
+                parsed = {"success": False, "error": "unparseable op result"}
+            if not parsed.get("success"):
+                note = _rollback()
+                return json.dumps(
+                    {"success": False,
+                     "error": (
+                         f"operations[{i}] ({op['action']}) failed: "
+                         f"{parsed.get('error', 'unknown error')} — batch aborted, {note}."
+                     ),
+                     "failed_index": i,
+                     "completed_before_failure": i},
+                    ensure_ascii=False,
+                )
+            results.append({"action": op["action"],
+                            "file_path": op.get("file_path"),
+                            "success": True})
+    finally:
+        _skill_gate_bypass.reset(token)
+        if snapshot is not None:
+            try:
+                shutil.rmtree(snapshot.parent)
+            except Exception:  # noqa: BLE001
+                pass
+
+    return json.dumps(
+        {"success": True, "skill": name, "operations_applied": len(results),
+         "results": results},
+        ensure_ascii=False,
+    )
 
 
 # Debounce state for the sync push hook. A burst of skill_manage writes
@@ -1586,12 +1743,21 @@ def skill_manage(
     absorbed_into: str = None,
     task_id: str = None,
     session_id: str = None,
+    operations=None,
 ) -> str:
     """
     Manage user-created skills. Dispatches to the appropriate action handler.
 
+    ``operations``: batch shape — a list of {action, ...} dicts applied to
+    ONE skill atomically (see _skill_manage_batch). When set, the flat
+    single-op fields are ignored and ``action`` may be omitted/'batch'.
+
     Returns JSON string with results.
     """
+    if operations is not None:
+        return _skill_manage_batch(
+            name, operations, task_id=task_id, session_id=session_id
+        )
     preflight = _background_review_preflight(action, name)
     if preflight is not None:
         return json.dumps(preflight, ensure_ascii=False)
@@ -1775,7 +1941,34 @@ SKILL_MANAGE_SCHEMA = {
             "action": {
                 "type": "string",
                 "enum": ["create", "patch", "delete", "write_file", "remove_file"],
-                "description": "The action to perform."
+                "description": "The action to perform. Omit when using 'operations'."
+            },
+            "operations": {
+                "type": "array",
+                "description": (
+                    "Batch shape: several operations on THIS skill, atomic "
+                    "(any failure rolls the whole skill back). Items carry "
+                    "an action plus that action's fields; create only "
+                    "first, delete not batchable. E.g. create + its "
+                    "reference files in one call."
+                ),
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "action": {
+                            "type": "string",
+                            "enum": ["create", "patch", "write_file", "remove_file"]
+                        },
+                        "content": {"type": "string"},
+                        "category": {"type": "string"},
+                        "file_path": {"type": "string"},
+                        "file_content": {"type": "string"},
+                        "old_string": {"type": "string"},
+                        "new_string": {"type": "string"},
+                        "replace_all": {"type": "boolean"}
+                    },
+                    "required": ["action"]
+                }
             },
             "name": {
                 "type": "string",
@@ -1844,7 +2037,7 @@ SKILL_MANAGE_SCHEMA = {
             # (_curator_consolidation_delete_guard). Keeping it out saves
             # ~100 tokens on every call of every other session.
         },
-        "required": ["action", "name"],
+        "required": ["name"],  # action for single ops; operations for batch
     },
 }
 
@@ -1867,6 +2060,7 @@ registry.register(
         new_string=args.get("new_string"),
         replace_all=args.get("replace_all", False),
         absorbed_into=args.get("absorbed_into"),
+        operations=args.get("operations"),
         task_id=kw.get("task_id"),
         session_id=kw.get("session_id")),
     emoji="📝",

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -1543,8 +1543,9 @@ def _skill_manage_batch(
 
     Scope rules:
     - all ops target the top-level ``name`` (one skill per batch);
-    - ``delete`` is not batchable (it's a standalone decision, and its
-      recoverable-archive path doesn't compose with rollback);
+    - ``delete`` only as the SOLE op (its recoverable-archive path doesn't
+      compose with rollback) — routed straight to the single-op handler,
+      preserving absorbed_into/archive semantics;
     - ``create`` only as the FIRST op.
     """
     import shutil
@@ -1555,19 +1556,32 @@ def _skill_manage_batch(
         return tool_error("operations must be a non-empty array.", success=False)
     if len(operations) > _BATCH_MAX_OPS:
         return tool_error(f"operations is capped at {_BATCH_MAX_OPS} ops per call.", success=False)
+    # delete: sole-op only; route through the normal single-op path so the
+    # gate, archive, ledger, and curator absorbed_into semantics all apply.
+    if any(isinstance(op, dict) and op.get("action") == "delete" for op in operations):
+        if len(operations) != 1:
+            return tool_error(
+                "delete must be the SOLE op in its call — it doesn't "
+                "compose with other ops' rollback.",
+                success=False,
+            )
+        op = operations[0]
+        return skill_manage(
+            action="delete",
+            name=name,
+            absorbed_into=op.get("absorbed_into"),
+            task_id=task_id,
+            session_id=session_id,
+        )
     for i, op in enumerate(operations):
         if not isinstance(op, dict) or not op.get("action"):
             return tool_error(f"operations[{i}] needs an 'action'.", success=False)
         act = op["action"]
-        if act == "delete":
-            return tool_error(
-                "delete is not batchable — call it as a standalone action.",
-                success=False,
-            )
         if act not in _BATCH_OP_ACTIONS:
             return tool_error(
                 f"operations[{i}]: unknown action '{act}'. "
-                f"Batchable: {', '.join(sorted(_BATCH_OP_ACTIONS))}.",
+                f"Batchable: {', '.join(sorted(_BATCH_OP_ACTIONS))}; "
+                "delete must be sole.",
                 success=False,
             )
         if act == "create" and i != 0:
@@ -1926,118 +1940,100 @@ def skill_manage(
 
 SKILL_MANAGE_SCHEMA = {
     "name": "skill_manage",
+    # ONE call shape (memory-tool pattern, maintainer-directed): every call
+    # is an operations array on one skill — a single edit is a list of one.
+    # The legacy flat fields (action/content/old_string/...) are still
+    # ACCEPTED by the handler for old transcripts and staged-write replay,
+    # but no longer advertised. absorbed_into: see NOTE below.
     "description": (
         "Create, update, or delete skills — your procedural memory for "
-        f"recurring task types. Actions: create (lands in {display_hermes_home()}/skills/), "
-        "patch (targeted old_string/new_string fix — preferred), delete, "
-        "write_file/remove_file (supporting files). Existing skills are "
-        "modified wherever they live. Keep the description's first 57 chars "
-        "a self-contained trigger: 'Use when <trigger>. <one-line "
-        "behavior>.' — skill_view() shows full format conventions."
+        "recurring task types. Every call applies an operations array to "
+        "ONE skill, atomically (a single edit is a list of one; a failure "
+        "rolls the skill back). Ops: create (full SKILL.md; lands in "
+        f"{display_hermes_home()}/skills/), patch (targeted "
+        "old_string/new_string fix — preferred; content alone REPLACES the "
+        "whole file, read it via skill_view() first), write_file/"
+        "remove_file (supporting files), delete (sole op only). Existing "
+        "skills are modified wherever they live. Keep the description's "
+        "first 57 chars a self-contained trigger: 'Use when <trigger>. "
+        "<one-line behavior>.' — skill_view() shows format conventions."
     ),
     "parameters": {
         "type": "object",
         "properties": {
-            "action": {
+            "name": {
                 "type": "string",
-                "enum": ["create", "patch", "delete", "write_file", "remove_file"],
-                "description": "The action to perform. Omit when using 'operations'."
+                "description": (
+                    "Skill name (lowercase, hyphens/underscores, max 64 "
+                    "chars); an existing skill's name unless creating."
+                )
             },
             "operations": {
                 "type": "array",
                 "description": (
-                    "Batch shape: several operations on THIS skill, atomic "
-                    "(any failure rolls the whole skill back). Items carry "
-                    "an action plus that action's fields; create only "
-                    "first, delete not batchable. E.g. create + its "
-                    "reference files in one call."
+                    "Ordered ops for this skill. create first-only; "
+                    "delete alone-only."
                 ),
                 "items": {
                     "type": "object",
                     "properties": {
                         "action": {
                             "type": "string",
-                            "enum": ["create", "patch", "write_file", "remove_file"]
+                            "enum": ["create", "patch", "delete", "write_file", "remove_file"]
                         },
-                        "content": {"type": "string"},
-                        "category": {"type": "string"},
-                        "file_path": {"type": "string"},
-                        "file_content": {"type": "string"},
-                        "old_string": {"type": "string"},
-                        "new_string": {"type": "string"},
-                        "replace_all": {"type": "boolean"}
+                        "content": {
+                            "type": "string",
+                            "description": (
+                                "Full SKILL.md text (YAML frontmatter + "
+                                "markdown body) for create, or a full "
+                                "rewrite on patch."
+                            )
+                        },
+                        "category": {
+                            "type": "string",
+                            "description": "Optional category subdir for create (e.g. 'devops')."
+                        },
+                        # patch args: same fuzzy-matching semantics as the
+                        # `patch` tool — teach only skill-specific facts here.
+                        "old_string": {
+                            "type": "string",
+                            "description": "Text to find (patch; same matching semantics as the patch tool)."
+                        },
+                        "new_string": {
+                            "type": "string",
+                            "description": "Replacement (patch); empty string deletes the match."
+                        },
+                        "replace_all": {
+                            "type": "boolean",
+                            "description": "patch: replace all occurrences (default false)."
+                        },
+                        "file_path": {
+                            "type": "string",
+                            "description": (
+                                "Path RELATIVE to the skill's own directory, "
+                                "e.g. 'references/api.md' — no leading slash, "
+                                "never absolute. write_file/remove_file: "
+                                "required; first segment references/, "
+                                "templates/, scripts/, or assets/. patch: "
+                                "optional (default SKILL.md)."
+                            )
+                        },
+                        "file_content": {
+                            "type": "string",
+                            "description": "Content for write_file."
+                        }
                     },
                     "required": ["action"]
                 }
             },
-            "name": {
-                "type": "string",
-                "description": (
-                    "Skill name (lowercase, hyphens/underscores, max 64 "
-                    "chars); an existing skill's name for every action "
-                    "except create."
-                )
-            },
-            "content": {
-                "type": "string",
-                "description": (
-                    "Full SKILL.md content (YAML frontmatter + markdown "
-                    "body). Required for 'create'. On 'patch' (without "
-                    "old_string) it REPLACES the whole file — read it via "
-                    "skill_view() first."
-                )
-            },
-            # patch args: same fuzzy-matching semantics as the `patch` tool
-            # (uniqueness unless replace_all, context-for-uniqueness advice
-            # lives there) — teach only the skill-specific facts here.
-            "old_string": {
-                "type": "string",
-                "description": (
-                    "Text to find (for 'patch'; same matching semantics as "
-                    "the patch tool)."
-                )
-            },
-            "new_string": {
-                "type": "string",
-                "description": (
-                    "Replacement text (for 'patch'); empty string deletes "
-                    "the match."
-                )
-            },
-            "replace_all": {
-                "type": "boolean",
-                "description": "For 'patch': replace all occurrences (default: false)."
-            },
-            "category": {
-                "type": "string",
-                "description": (
-                    "Optional category subdirectory for 'create' (e.g. "
-                    "'devops', 'mlops')."
-                )
-            },
-            "file_path": {
-                "type": "string",
-                "description": (
-                    "Path RELATIVE to the skill's own directory, e.g. "
-                    "'references/api.md' — no leading slash, never absolute. "
-                    "write_file/remove_file: required; first segment must be "
-                    "references/, templates/, scripts/, or assets/. patch: "
-                    "optional (default SKILL.md)."
-                )
-            },
-            "file_content": {
-                "type": "string",
-                "description": "Content for write_file."
-            },
-            # NOTE: the handler also accepts `absorbed_into` on delete — the
-            # curator's consolidation pass declares merge-vs-prune intent with
-            # it. Deliberately NOT advertised in this schema: only curator
-            # sessions need it, the curator's own prompt documents it, and the
-            # curator-context delete guard's error re-teaches it on omission
-            # (_curator_consolidation_delete_guard). Keeping it out saves
-            # ~100 tokens on every call of every other session.
+            # NOTE: the handler also accepts the legacy flat single-op shape
+            # (action/content/old_string/new_string/replace_all/category/
+            # file_path/file_content) — old transcripts and staged-write
+            # replay depend on it — plus `absorbed_into` on delete ops
+            # (curator-only vocabulary; the curator's prompt documents it and
+            # the delete guard's error re-teaches it). None are advertised.
         },
-        "required": ["name"],  # action for single ops; operations for batch
+        "required": ["name", "operations"],
     },
 }
 

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -1590,6 +1590,35 @@ def _skill_manage_batch(
         if preflight is not None:
             return json.dumps(preflight, ensure_ascii=False)
 
+    # --- intra-batch conflict guard: sequential last-wins semantics make
+    # these SILENTLY succeed while discarding earlier ops' work — always a
+    # confused plan, never intentional. Patch CHAINS on one file (each op
+    # building on the previous text) stay legal. ---
+    seen_writes: set = set()
+    touched_skill_md = False
+    for i, op in enumerate(operations):
+        act = op["action"]
+        if act in ("write_file", "remove_file"):
+            key = (op.get("file_path") or "").strip()
+            if key in seen_writes:
+                return tool_error(
+                    f"operations[{i}]: '{key}' already written/removed "
+                    "earlier in this batch — the later op would silently "
+                    "clobber it. One write per file per batch.",
+                    success=False,
+                )
+            seen_writes.add(key)
+        if act in ("create", "patch") and not op.get("file_path"):
+            if act == "patch" and op.get("content") and touched_skill_md:
+                return tool_error(
+                    f"operations[{i}]: full SKILL.md rewrite (content) after "
+                    "an earlier op already modified SKILL.md — the rewrite "
+                    "would silently discard that edit. Put the rewrite "
+                    "first, or fold the change into it.",
+                    success=False,
+                )
+            touched_skill_md = True
+
     # --- approval gate: stage the WHOLE batch as one pending write ---
     if not _skill_gate_bypass.get():
         try:

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -1529,24 +1529,27 @@ _BATCH_MAX_OPS = 20
 
 
 def _skill_manage_batch(
-    name: str,
     operations,
+    default_name: str = None,
     task_id: str = None,
     session_id: str = None,
 ) -> str:
-    """Apply a sequence of operations to ONE skill atomically.
+    """Apply a sequence of operations atomically (memory-tool pattern).
 
-    The memory-tool pattern (#95681 arc): create + N supporting files, or
-    a SKILL.md fix plus the script it references, land in one call — all
-    or nothing. On any op failure the skill directory is restored to its
-    pre-batch state (including full removal when the batch created it).
+    Each op carries its own ``name`` (skill) and ``action``; a single edit
+    is a list of one. Every skill the batch touches is snapshotted before
+    any op runs; any failure rolls ALL touched skills back to their
+    pre-batch state (skills the batch created are removed).
 
-    Scope rules:
-    - all ops target the top-level ``name`` (one skill per batch);
-    - ``delete`` only as the SOLE op (its recoverable-archive path doesn't
-      compose with rollback) — routed straight to the single-op handler,
-      preserving absorbed_into/archive semantics;
-    - ``create`` only as the FIRST op.
+    Rules:
+    - ``delete`` only as the SOLE op of the call (its recoverable-archive
+      path doesn't compose with rollback) — routed to the single-op
+      handler, preserving absorbed_into/archive semantics;
+    - ``create`` for a skill must precede that skill's other ops;
+    - same-file clobber guard (below) rejects silently-lost work.
+
+    ``default_name``: legacy top-level ``name`` fallback for ops that omit
+    their own (staged-replay / back-compat path).
     """
     import shutil
     import tempfile
@@ -1566,13 +1569,17 @@ def _skill_manage_batch(
                 success=False,
             )
         op = operations[0]
+        nm = op.get("name") or default_name
+        if not nm:
+            return tool_error("operations[0] (delete) needs a 'name'.", success=False)
         return skill_manage(
             action="delete",
-            name=name,
+            name=nm,
             absorbed_into=op.get("absorbed_into"),
             task_id=task_id,
             session_id=session_id,
         )
+    names = []
     for i, op in enumerate(operations):
         if not isinstance(op, dict) or not op.get("action"):
             return tool_error(f"operations[{i}] needs an 'action'.", success=False)
@@ -1584,9 +1591,17 @@ def _skill_manage_batch(
                 "delete must be sole.",
                 success=False,
             )
-        if act == "create" and i != 0:
-            return tool_error("create must be the first op in a batch.", success=False)
-        preflight = _background_review_preflight(act, name)
+        nm = op.get("name") or default_name
+        if not nm:
+            return tool_error(f"operations[{i}] needs a 'name' (the skill it targets).", success=False)
+        names.append(nm)
+        if act == "create" and nm in names[:-1]:
+            return tool_error(
+                f"operations[{i}]: create for '{nm}' must precede that "
+                "skill's other ops.",
+                success=False,
+            )
+        preflight = _background_review_preflight(act, nm)
         if preflight is not None:
             return json.dumps(preflight, ensure_ascii=False)
 
@@ -1594,30 +1609,31 @@ def _skill_manage_batch(
     # these SILENTLY succeed while discarding earlier ops' work — always a
     # confused plan, never intentional. Patch CHAINS on one file (each op
     # building on the previous text) stay legal. ---
-    seen_writes: set = set()
-    touched_skill_md = False
+    seen_writes = set()
+    touched_skill_md = set()
     for i, op in enumerate(operations):
         act = op["action"]
+        nm = names[i]
         if act in ("write_file", "remove_file"):
-            key = (op.get("file_path") or "").strip()
+            key = (nm, (op.get("file_path") or "").strip())
             if key in seen_writes:
                 return tool_error(
-                    f"operations[{i}]: '{key}' already written/removed "
-                    "earlier in this batch — the later op would silently "
-                    "clobber it. One write per file per batch.",
+                    f"operations[{i}]: '{key[1]}' on skill '{nm}' already "
+                    "written/removed earlier in this batch — the later op "
+                    "would silently clobber it. One write per file per batch.",
                     success=False,
                 )
             seen_writes.add(key)
         if act in ("create", "patch") and not op.get("file_path"):
-            if act == "patch" and op.get("content") and touched_skill_md:
+            if act == "patch" and op.get("content") and nm in touched_skill_md:
                 return tool_error(
-                    f"operations[{i}]: full SKILL.md rewrite (content) after "
-                    "an earlier op already modified SKILL.md — the rewrite "
-                    "would silently discard that edit. Put the rewrite "
-                    "first, or fold the change into it.",
+                    f"operations[{i}]: full SKILL.md rewrite (content) for "
+                    f"'{nm}' after an earlier op already modified its "
+                    "SKILL.md — the rewrite would silently discard that "
+                    "edit. Put the rewrite first, or fold the change in.",
                     success=False,
                 )
-            touched_skill_md = True
+            touched_skill_md.add(nm)
 
     # --- approval gate: stage the WHOLE batch as one pending write ---
     if not _skill_gate_bypass.get():
@@ -1630,9 +1646,10 @@ def _skill_manage_batch(
             if decision.blocked:
                 return tool_error(decision.message, success=False)
             if not decision.allow:
-                payload = {"action": "batch", "name": name, "operations": operations}
+                payload = {"action": "batch", "operations": operations}
                 acts = ", ".join(op["action"] for op in operations)
-                gist = f"batch({len(operations)} ops: {acts}) on skill '{name}'"
+                skills = ", ".join(sorted(set(names)))
+                gist = f"batch({len(operations)} ops: {acts}) on {skills}"
                 record = wa.stage_write(
                     wa.SKILLS, payload, summary=gist, origin=wa.current_origin()
                 )
@@ -1642,32 +1659,38 @@ def _skill_manage_batch(
                     ensure_ascii=False,
                 )
 
-    # --- snapshot for rollback ---
-    pre = _find_skill(name)
-    pre_dir = Path(pre["path"]) if pre else None
-    snapshot = None
-    if pre_dir is not None and pre_dir.is_dir():
-        snapshot = Path(tempfile.mkdtemp(prefix="skill_batch_")) / pre_dir.name
-        try:
-            shutil.copytree(pre_dir, snapshot)
-        except Exception as exc:  # noqa: BLE001 — no snapshot, no atomicity
-            return tool_error(f"Could not snapshot skill for atomic batch: {exc}", success=False)
+    # --- snapshot every touched skill for rollback ---
+    snap_root = Path(tempfile.mkdtemp(prefix="skill_batch_"))
+    snapshots = {}  # skill name -> (pre_dir or None, snapshot_dir or None)
+    for nm in dict.fromkeys(names):  # ordered unique
+        pre = _find_skill(nm)
+        pre_dir = Path(pre["path"]) if pre else None
+        snap = None
+        if pre_dir is not None and pre_dir.is_dir():
+            snap = snap_root / nm
+            try:
+                shutil.copytree(pre_dir, snap)
+            except Exception as exc:  # noqa: BLE001 — no snapshot, no atomicity
+                shutil.rmtree(snap_root, ignore_errors=True)
+                return tool_error(f"Could not snapshot '{nm}' for atomic batch: {exc}", success=False)
+        snapshots[nm] = (pre_dir, snap)
 
     def _rollback() -> str:
-        try:
-            post = _find_skill(name)
-            post_dir = Path(post["path"]) if post else None
-            if snapshot is not None:
-                if post_dir is not None and post_dir.is_dir():
+        notes = []
+        for nm, (pre_dir, snap) in snapshots.items():
+            try:
+                post = _find_skill(nm)
+                post_dir = Path(post["path"]) if post else None
+                if snap is not None:
+                    if post_dir is not None and post_dir.is_dir():
+                        shutil.rmtree(post_dir)
+                    shutil.copytree(snap, pre_dir)
+                elif post_dir is not None and post_dir.is_dir():
+                    # Batch created this skill: remove the partial result.
                     shutil.rmtree(post_dir)
-                shutil.copytree(snapshot, pre_dir)
-                return "rolled back to pre-batch state"
-            # Batch created the skill: remove what the partial batch made.
-            if post_dir is not None and post_dir.is_dir():
-                shutil.rmtree(post_dir)
-            return "partially-created skill removed"
-        except Exception as exc:  # noqa: BLE001
-            return f"ROLLBACK FAILED ({exc}) — inspect the skill manually"
+            except Exception as exc:  # noqa: BLE001
+                notes.append(f"ROLLBACK FAILED for '{nm}' ({exc})")
+        return "; ".join(notes) if notes else "all touched skills rolled back"
 
     # --- execute ops through the normal single-op path (gate bypassed:
     #     the batch already cleared/staged it above; ledger + telemetry
@@ -1678,7 +1701,7 @@ def _skill_manage_batch(
         for i, op in enumerate(operations):
             raw = skill_manage(
                 action=op["action"],
-                name=name,
+                name=names[i],
                 content=op.get("content"),
                 category=op.get("category"),
                 file_path=op.get("file_path"),
@@ -1698,26 +1721,22 @@ def _skill_manage_batch(
                 return json.dumps(
                     {"success": False,
                      "error": (
-                         f"operations[{i}] ({op['action']}) failed: "
+                         f"operations[{i}] ({op['action']} on '{names[i]}') failed: "
                          f"{parsed.get('error', 'unknown error')} — batch aborted, {note}."
                      ),
                      "failed_index": i,
                      "completed_before_failure": i},
                     ensure_ascii=False,
                 )
-            results.append({"action": op["action"],
+            results.append({"name": names[i], "action": op["action"],
                             "file_path": op.get("file_path"),
                             "success": True})
     finally:
         _skill_gate_bypass.reset(token)
-        if snapshot is not None:
-            try:
-                shutil.rmtree(snapshot.parent)
-            except Exception:  # noqa: BLE001
-                pass
+        shutil.rmtree(snap_root, ignore_errors=True)
 
     return json.dumps(
-        {"success": True, "skill": name, "operations_applied": len(results),
+        {"success": True, "operations_applied": len(results),
          "results": results},
         ensure_ascii=False,
     )
@@ -1799,7 +1818,8 @@ def skill_manage(
     """
     if operations is not None:
         return _skill_manage_batch(
-            name, operations, task_id=task_id, session_id=session_id
+            operations, default_name=name or None,
+            task_id=task_id, session_id=session_id,
         )
     preflight = _background_review_preflight(action, name)
     if preflight is not None:
@@ -1969,43 +1989,42 @@ def skill_manage(
 
 SKILL_MANAGE_SCHEMA = {
     "name": "skill_manage",
-    # ONE call shape (memory-tool pattern, maintainer-directed): every call
-    # is an operations array on one skill — a single edit is a list of one.
-    # The legacy flat fields (action/content/old_string/...) are still
-    # ACCEPTED by the handler for old transcripts and staged-write replay,
-    # but no longer advertised. absorbed_into: see NOTE below.
+    # ONE call shape (memory-tool pattern, maintainer-directed): the call
+    # IS an operations array — each op names its skill and action; a
+    # single edit is a list of one. The legacy flat shape (top-level
+    # action/name/content/...) is still ACCEPTED by the handler for old
+    # transcripts and staged-write replay, but no longer advertised.
     "description": (
         "Create, update, or delete skills — your procedural memory for "
-        "recurring task types. Every call applies an operations array to "
-        "ONE skill, atomically (a single edit is a list of one; a failure "
-        "rolls the skill back). Ops: create (full SKILL.md; lands in "
-        f"{display_hermes_home()}/skills/), patch (targeted "
-        "old_string/new_string fix — preferred; content alone REPLACES the "
-        "whole file, read it via skill_view() first), write_file/"
-        "remove_file (supporting files), delete (sole op only). Existing "
-        "skills are modified wherever they live. Keep the description's "
-        "first 57 chars a self-contained trigger: 'Use when <trigger>. "
-        "<one-line behavior>.' — skill_view() shows format conventions."
+        "recurring task types. The call is an operations array (a single "
+        "edit is a list of one); it applies atomically — any failure rolls "
+        "every touched skill back. Ops: create (full SKILL.md; lands in "
+        f"{display_hermes_home()}/skills/; must precede that skill's other "
+        "ops), patch (targeted old_string/new_string fix — preferred; "
+        "content alone REPLACES the whole file, read it via skill_view() "
+        "first), write_file/remove_file (supporting files), delete (sole "
+        "op only). Existing skills are modified wherever they live. Keep "
+        "the description's first 57 chars a self-contained trigger: 'Use "
+        "when <trigger>. <one-line behavior>.' — skill_view() shows "
+        "format conventions."
     ),
     "parameters": {
         "type": "object",
         "properties": {
-            "name": {
-                "type": "string",
-                "description": (
-                    "Skill name (lowercase, hyphens/underscores, max 64 "
-                    "chars); an existing skill's name unless creating."
-                )
-            },
             "operations": {
                 "type": "array",
-                "description": (
-                    "Ordered ops for this skill. create first-only; "
-                    "delete alone-only."
-                ),
+                "description": "Ordered ops; each names its target skill.",
                 "items": {
                     "type": "object",
                     "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": (
+                                "Skill name (lowercase, hyphens/underscores, "
+                                "max 64 chars); an existing skill's name "
+                                "unless creating."
+                            )
+                        },
                         "action": {
                             "type": "string",
                             "enum": ["create", "patch", "delete", "write_file", "remove_file"]
@@ -2052,17 +2071,18 @@ SKILL_MANAGE_SCHEMA = {
                             "description": "Content for write_file."
                         }
                     },
-                    "required": ["action"]
+                    "required": ["name", "action"]
                 }
             },
             # NOTE: the handler also accepts the legacy flat single-op shape
-            # (action/content/old_string/new_string/replace_all/category/
-            # file_path/file_content) — old transcripts and staged-write
-            # replay depend on it — plus `absorbed_into` on delete ops
-            # (curator-only vocabulary; the curator's prompt documents it and
-            # the delete guard's error re-teaches it). None are advertised.
+            # (top-level action/name/content/old_string/new_string/
+            # replace_all/category/file_path/file_content) — old transcripts
+            # and staged-write replay depend on it — plus `absorbed_into` on
+            # delete ops (curator-only vocabulary; the curator's prompt
+            # documents it and the delete guard's error re-teaches it).
+            # None are advertised.
         },
-        "required": ["name", "operations"],
+        "required": ["operations"],
     },
 }
 


### PR DESCRIPTION
Maintainer-approved follow-up to #97152, with TWO interface corrections during review (final shape is the maintainer's):

**`skill_manage(operations=[{name, action, ...}, ...])`** — the call IS the operations array. Each op names its target skill; a single edit is a list of one; a batch is a list of several, and ops may span DIFFERENT skills.

## Semantics
- **Atomic across everything touched**: every skill named in the batch is snapshotted before any op runs; any failure rolls ALL touched skills back (batch-created skills are removed). `failed_index` + the failing op's own teaching error return.
- **Ops**: create (must precede that skill's other ops), patch (old_string/new_string; content = full rewrite), write_file/remove_file, delete (sole op of its call — routes to the real delete handler; absorbed_into/recoverable-archive semantics untouched).
- **Same-file clobber guard** (maintainer concern, live-repro'd first): under last-wins sequencing, a double write to one path, write-then-remove, or a full rewrite after an earlier SKILL.md edit SILENTLY discards work — all rejected up front with teaching errors, before any side effect. Patch chains on one file (each op building on the last) stay legal, per-skill scoped.
- **Approval gate composes**: gated batches stage as ONE pending record (gist names ops + skills); `apply_skill_pending` replays the whole batch.
- Ops execute through the single-op path — ledger, telemetry, prompt-cache invalidation, sync-push fire per-op as today. Legacy flat shape still handler-accepted (old transcripts, staged replay), unadvertised.

## Schema cost (#95681 accounting)
Diet base 427 → **482 (+55/call)** for batch + cross-skill + rollback. (Review history: flat+optional-batch draft measured 577; the maintainer's single-shape correction bought back ~95.)

## Verification
Live E2E of the exact maintainer shape: single-as-list ✅ · multi-op one skill ✅ · cross-skill batch in one call ✅ · sole-op delete ✅ · cross-skill failure → alpha's patch undone AND batch-created beta removed ✅ · clobber guards fire pre-effect, chains legal ✅ · legacy flat accepted ✅ · gate stages one record, replay applies ✅. 58 passed; 1 pre-existing symlink failure (Windows env class, clean-main verified).