### PR TITLE
fix(process): report recovered supervision loss honestly

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3897,6 +3897,7 @@ def _format_concise_process_notification(
     exit_code,
     output: str,
     duration_seconds=None,
+    completion_reason: str = "exited",
 ) -> str:
     """One-line "pretty" completion message for the ``concise`` display mode.
 
@@ -3904,9 +3905,14 @@ def _format_concise_process_notification(
     the user can see what went wrong without the full raw dump. The full
     output always remains available to the agent via process(log/wait).
     """
-    ok = exit_code in {0, None}
-    icon = "✅" if ok else "❌"
-    verb = "finished" if ok else f"failed (exit {exit_code})"
+    lost = completion_reason == "lost"
+    ok = not lost and exit_code == 0
+    icon = "⚠️" if lost else ("✅" if ok else "❌")
+    verb = (
+        "supervision lost"
+        if lost
+        else ("finished" if ok else f"failed (exit {exit_code})")
+    )
     parts = [f"{icon} Background task {verb}"]
     short_cmd = _shorten_command_for_display(command)
     if short_cmd:
@@ -26686,7 +26692,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     break
                 # Decide whether to notify based on mode
                 should_notify = (
-                    notify_mode in {"concise", "all", "result"}
+                    getattr(session, "completion_reason", "exited") == "lost"
+                    or notify_mode in {"concise", "all", "result"}
                     or (notify_mode == "error" and session.exit_code not in {0, None})
                 )
                 if should_notify:
@@ -26715,12 +26722,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             session.exit_code,
                             new_output,
                             duration_seconds=_dur,
+                            completion_reason=getattr(
+                                session, "completion_reason", "exited"
+                            ),
                         )
                     else:
-                        message_text = (
-                            f"[Background process {session_id} finished with exit code {session.exit_code}~ "
-                            f"Here's the final output:\n{new_output}]"
-                        )
+                        if getattr(session, "completion_reason", "exited") == "lost":
+                            message_text = (
+                                f"[Background process {session_id} supervision was lost; "
+                                "no exit status was collected. Verify OS liveness before "
+                                f"restarting it. Last captured output:\n{new_output}]"
+                            )
+                        else:
+                            message_text = (
+                                f"[Background process {session_id} finished with exit code {session.exit_code}~ "
+                                f"Here's the final output:\n{new_output}]"
+                            )
                     adapter = None
                     for p, a in self.adapters.items():
                         if p.value == platform_name:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -26204,8 +26204,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 lines.append(output)
         omitted = len(entries) - len(shown)
         if omitted:
+            omitted_description = (
+                "status update" if has_supervision_loss else "completion"
+            )
             lines.append(
-                f"\n- … and {omitted} more completion(s); inspect them with "
+                f"\n- … and {omitted} more {omitted_description}(s); inspect them with "
                 "the process tool if they affect the conclusion."
             )
         lines.append(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -26156,9 +26156,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     @staticmethod
     def _format_coalesced_process_completions(entries: list[tuple[str, dict, asyncio.Future]]) -> str:
         """Build one bounded synthetic event from several redacted completions."""
+        has_supervision_loss = any(
+            evt.get("completion_reason") == "lost" for _text, evt, _future in entries
+        )
+        if has_supervision_loss:
+            header = (
+                f"[IMPORTANT: {len(entries)} background process status updates "
+                "for this session."
+            )
+            batch_description = "status-update"
+        else:
+            header = (
+                f"[IMPORTANT: {len(entries)} background processes completed "
+                "for this session."
+            )
+            batch_description = "completion"
         lines = [
-            f"[IMPORTANT: {len(entries)} background processes completed for this session.",
-            "Treat these results as one completion batch and send at most one "
+            header,
+            f"Treat these results as one {batch_description} batch and send at most one "
             "consolidated user-facing response.",
         ]
         shown = entries[:10]
@@ -26177,9 +26192,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             ).strip()
             if len(output) > 800:
                 output = f"[… truncated …]\n{output[-800:]}"
-            lines.append(
-                f"\n- {session_id}: exit_code={exit_code}, reason={reason}"
-            )
+            if reason == "lost":
+                lines.append(
+                    f"\n- {session_id}: supervision lost; no exit status was collected"
+                )
+            else:
+                lines.append(
+                    f"\n- {session_id}: exit_code={exit_code}, reason={reason}"
+                )
             if output:
                 lines.append(output)
         omitted = len(entries) - len(shown)

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -1124,7 +1124,7 @@ def _render_background_block(background_processes: Optional[List[Dict[str, Any]]
     """Render the live background-process list for the judge prompt.
 
     Each entry is a ``process_registry.list_sessions()`` dict. Only RUNNING
-    processes are worth showing (an exited one is nothing to wait on). Returns
+    processes are worth showing (a terminal one is nothing to wait on). Returns
     an empty string when there's nothing running, so the judge prompt is
     byte-identical to the no-background case (no behavior change for the
     common path).
@@ -1135,7 +1135,7 @@ def _render_background_block(background_processes: Optional[List[Dict[str, Any]]
     for p in background_processes:
         if not isinstance(p, dict):
             continue
-        if p.get("status") == "exited":
+        if p.get("status") != "running":
             continue
         pid = p.get("pid")
         if not pid:
@@ -1306,7 +1306,7 @@ def gather_background_processes(task_id: Optional[str] = None) -> List[Dict[str,
     """Return the live background-process snapshot for the goal judge.
 
     Thin, fail-safe wrapper over ``process_registry.list_sessions(task_id)``.
-    Returns only RUNNING processes (an exited one is nothing to wait on) and
+    Returns only RUNNING processes (a terminal one is nothing to wait on) and
     never raises — any import/registry failure yields ``[]`` so the goal loop
     degrades to its pre-wait-barrier behavior (judge just won't see processes).
     The drivers (CLI + gateway) call this and pass the result into
@@ -1319,7 +1319,7 @@ def gather_background_processes(task_id: Optional[str] = None) -> List[Dict[str,
     except Exception as exc:
         logger.debug("gather_background_processes failed: %s", exc)
         return []
-    return [s for s in sessions if isinstance(s, dict) and s.get("status") != "exited"]
+    return [s for s in sessions if isinstance(s, dict) and s.get("status") == "running"]
 
 
 def draft_contract(objective: str, *, timeout: Optional[float] = None) -> Optional[GoalContract]:

--- a/tests/gateway/test_background_process_notifications.py
+++ b/tests/gateway/test_background_process_notifications.py
@@ -408,6 +408,19 @@ class TestConciseFormatter:
         assert "…" in text
         assert len(text) < 200
 
+    def test_lost_supervision_is_not_reported_as_finished(self):
+        from gateway.run import _format_concise_process_notification
+        text = _format_concise_process_notification(
+            "proc_abc",
+            "python worker.py",
+            None,
+            "",
+            completion_reason="lost",
+        )
+        assert text.startswith("⚠️ Background task supervision lost")
+        assert "finished" not in text
+        assert "exit" not in text
+
 
 @pytest.mark.asyncio
 async def test_concise_mode_sends_pretty_message_not_raw_dump(monkeypatch, tmp_path):
@@ -438,6 +451,41 @@ async def test_concise_mode_sends_pretty_message_not_raw_dump(monkeypatch, tmp_p
     assert sent_text.startswith("✅ Background task finished")
     assert "Here's the final output" not in sent_text
     assert "5000" not in sent_text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["concise", "error"])
+async def test_lost_supervision_warns_instead_of_sending_completion(
+    monkeypatch, tmp_path, mode
+):
+    import tools.process_registry as pr_module
+
+    lost = SimpleNamespace(
+        output_buffer="last captured line\n",
+        exited=True,
+        exit_code=None,
+        completion_reason="lost",
+        command="python worker.py",
+        started_at=None,
+    )
+    monkeypatch.setattr(
+        pr_module, "process_registry", _FakeRegistry([lost], consumed=False)
+    )
+
+    async def _instant_sleep(*_a, **_kw):
+        pass
+
+    monkeypatch.setattr(asyncio, "sleep", _instant_sleep)
+    runner = _build_runner(monkeypatch, tmp_path, mode)
+    adapter = runner.adapters[Platform.TELEGRAM]
+
+    await runner._run_process_watcher(_watcher_dict())
+
+    adapter.send.assert_awaited_once()
+    sent_text = adapter.send.await_args.args[1]
+    assert "supervision" in sent_text
+    assert "finished" not in sent_text
+    assert "exit code None" not in sent_text
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_completion_delivery.py
+++ b/tests/gateway/test_completion_delivery.py
@@ -524,6 +524,25 @@ def test_coalesced_format_bounds_details_and_reports_omitted_count():
     assert "and 2 more completion(s)" in text
 
 
+def test_coalesced_format_calls_omitted_lost_events_status_updates():
+    async def _format():
+        loop = asyncio.get_running_loop()
+        entries = []
+        for index in range(11):
+            event = _completion_event(
+                started_at=float(index), session_id=f"proc_lost_{index}"
+            )
+            event["exit_code"] = None
+            event["completion_reason"] = "lost"
+            entries.append((f"event-{index}", event, loop.create_future()))
+        return GatewayRunner._format_coalesced_process_completions(entries)
+
+    text = asyncio.run(_format())
+
+    assert "and 1 more status update(s)" in text
+    assert "completion(s)" not in text
+
+
 def test_coalesced_format_force_redacts_output_when_redaction_disabled(monkeypatch):
     """A user setting cannot disable the gateway's outbound secret floor."""
     import agent.redact as redact_module

--- a/tests/gateway/test_completion_delivery.py
+++ b/tests/gateway/test_completion_delivery.py
@@ -366,6 +366,36 @@ def test_concurrent_process_watchers_coalesce_one_session_completion_turn(monkey
         assert f"proc_batch_{index}" in delivered.text
 
 
+def test_lost_process_watchers_coalesce_without_claiming_completion():
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner = _runner(adapter)
+    events = [
+        _completion_event(started_at=float(index), session_id=f"proc_lost_{index}")
+        for index in range(2)
+    ]
+    for event in events:
+        event["exit_code"] = None
+        event["completion_reason"] = "lost"
+        event["output"] = "last captured output\n"
+
+    async def _exercise():
+        return await asyncio.gather(*(
+            runner._enqueue_process_completion_notification(
+                "supervision lost", event
+            )
+            for event in events
+        ))
+
+    assert asyncio.run(_exercise()) == [True, True]
+    adapter.handle_message.assert_awaited_once()
+    delivered = adapter.handle_message.await_args.args[0]
+    assert "background process status updates" in delivered.text
+    assert "supervision lost; no exit status was collected" in delivered.text
+    assert "last captured output" in delivered.text
+    assert "processes completed" not in delivered.text
+    assert "exit_code=None" not in delivered.text
+
+
 def test_completion_arriving_during_batch_delivery_schedules_next_flush():
     """A new event cannot be stranded behind an in-flight batch for its route."""
     first_delivery_entered = asyncio.Event()

--- a/tests/hermes_cli/test_goals.py
+++ b/tests/hermes_cli/test_goals.py
@@ -798,3 +798,34 @@ class TestContractAndBackgroundCompose:
         assert verdict == "wait"
         assert wait_directive and wait_directive.get("pid") == 4242
 
+
+def test_lost_background_process_is_not_exposed_to_goal_judge():
+    from hermes_cli import goals
+    from tools.process_registry import process_registry
+
+    sessions = [
+        {
+            "session_id": "lost-build",
+            "pid": 4101,
+            "status": "lost",
+            "command": "build.sh",
+            "uptime_seconds": 9,
+        },
+        {
+            "session_id": "live-build",
+            "pid": 4102,
+            "status": "running",
+            "command": "test.sh",
+            "uptime_seconds": 3,
+        },
+    ]
+
+    with patch.object(process_registry, "list_sessions", return_value=sessions):
+        gathered = goals.gather_background_processes(task_id="goal-task")
+
+    assert [item["session_id"] for item in gathered] == ["live-build"]
+
+    rendered = goals._render_background_block(sessions)
+    assert "live-build" in rendered
+    assert "lost-build" not in rendered
+

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -961,6 +961,39 @@ class TestCheckpoint:
             recovered = registry.recover_from_checkpoint()
             assert recovered == 0
 
+    def test_recovered_process_disappearance_is_lost_not_exited(
+        self, registry, tmp_path, monkeypatch
+    ):
+        checkpoint = tmp_path / "procs.json"
+        checkpoint.write_text(json.dumps([{
+            "session_id": "proc_recovered",
+            "command": "long-running-agent",
+            "pid": 424242,
+            "pid_scope": "host",
+            "host_start_time": 123.0,
+            "notify_on_complete": True,
+        }]))
+        alive = True
+        monkeypatch.setattr(
+            registry,
+            "_host_pid_is_ours",
+            lambda *_args: alive,
+        )
+
+        with patch("tools.process_registry.CHECKPOINT_PATH", checkpoint):
+            assert registry.recover_from_checkpoint() == 1
+            alive = False
+            result = registry.poll("proc_recovered")
+
+        assert result["status"] == "lost"
+        assert result["completion_reason"] == "lost"
+        assert result["termination_source"] == "backend_lost"
+        assert result["exit_code"] is None
+
+        event = registry.completion_queue.get_nowait()
+        assert event["completion_reason"] == "lost"
+        assert event["termination_source"] == "backend_lost"
+
     def test_recover_dead_wrapper_retries_unreaped_systemd_scope(
         self, registry, tmp_path, monkeypatch
     ):

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -850,10 +850,22 @@ class ProcessRegistry:
             session.exited = True
             # Recovered sessions no longer have a waitable handle, so the real
             # exit code is unavailable once the original process object is gone.
+            # This is a supervision loss, not a collected process exit.
             session.exit_code = None
+            session.completion_reason = "lost"
+            session.termination_source = "backend_lost"
 
         self._move_to_finished(session)
         return session
+
+    @staticmethod
+    def _session_status(session: ProcessSession) -> str:
+        """Return an honest public status for a tracked session."""
+        if not session.exited:
+            return "running"
+        if session.completion_reason == "lost":
+            return "lost"
+        return "exited"
 
     @staticmethod
     def _proc_alive(proc) -> bool:
@@ -2119,7 +2131,7 @@ class ProcessRegistry:
         result = {
             "session_id": session.id,
             "command": session.command,
-            "status": "exited" if session.exited else "running",
+            "status": self._session_status(session),
             "pid": session.pid,
             "uptime_seconds": int(time.time() - session.started_at),
             "output_preview": output_preview,
@@ -2177,13 +2189,17 @@ class ProcessRegistry:
         result = {
             "session_id": session.id,
             "command": session.command,
-            "status": "exited" if session.exited else "running",
+            "status": self._session_status(session),
             "output": "\n".join(selected),
             "total_lines": total_lines,
             "showing": f"{len(selected)} lines",
         }
         if session.exited and observed_completion_output:
             self._completion_consumed.add(session_id)
+        if session.exited:
+            result["exit_code"] = session.exit_code
+            result["completion_reason"] = session.completion_reason
+            result["termination_source"] = session.termination_source
         return result
 
     def wait(self, session_id: str, timeout: int = None) -> dict:
@@ -2246,7 +2262,7 @@ class ProcessRegistry:
             if session.exited:
                 self._completion_consumed.add(session_id)
                 result = {
-                    "status": "exited",
+                    "status": self._session_status(session),
                     "command": session.command,
                     "exit_code": session.exit_code,
                     "completion_reason": session.completion_reason,
@@ -2586,7 +2602,7 @@ class ProcessRegistry:
                 "pid": s.pid,
                 "started_at": time.strftime("%Y-%m-%dT%H:%M:%S", time.localtime(s.started_at)),
                 "uptime_seconds": int(time.time() - s.started_at),
-                "status": "exited" if s.exited else "running",
+                "status": self._session_status(s),
                 "output_preview": s.output_buffer[-200:] if s.output_buffer else "",
             }
             # Flag processes surfaced only because they share the gateway
@@ -2604,6 +2620,8 @@ class ProcessRegistry:
                 entry["notify_on_complete"] = True
             if s.exited:
                 entry["exit_code"] = s.exit_code
+                entry["completion_reason"] = s.completion_reason
+                entry["termination_source"] = s.termination_source
             if s.detached:
                 entry["detached"] = True
             result.append(entry)
@@ -3214,10 +3232,16 @@ def format_process_notification(evt: dict) -> "str | None":
         _status = "completed normally"
     else:
         _status = "exited"
-    text = (
-        f"[IMPORTANT: Background process {_sid} {_status} "
-        f"(exit code {_exit}{_signal}).\n"
-    )
+    if _reason == "lost":
+        text = (
+            f"[IMPORTANT: Background process {_sid} {_status}; "
+            "no exit status was collected.\n"
+        )
+    else:
+        text = (
+            f"[IMPORTANT: Background process {_sid} {_status} "
+            f"(exit code {_exit}{_signal}).\n"
+        )
     if _attribution:
         text += f"{_attribution}\n"
         # A subagent-owned process's full output belongs in the child's


### PR DESCRIPTION
## Summary

- classify recovered process handles whose verified PID disappears as supervision loss rather than a collected exit
- return `status: "lost"` consistently from process poll/log/wait/list surfaces
- warn gateway users that supervision was lost without presenting `exit_code: null` as a successful completion

## Root cause

Checkpoint recovery correctly re-adopts a live host PID using its recorded start time, but when that detached PID later disappeared `_refresh_detached_session()` only set `exited = True` and left the default completion reason as `exited`. Query paths then derived `status: "exited"` from that boolean, while concise gateway notifications treated a missing exit code as success. No waitable process handle existed to justify either claim.

## Testing

- `scripts/run_tests.sh tests/tools/test_process_registry.py -k 'TestCheckpoint or TestGetAndPoll or TestListSessions' -q` (10 passed)
- `scripts/run_tests.sh tests/gateway/test_background_process_notifications.py -q` (24 passed)
- red-to-green regression: recovered PID disappearance previously returned `status: "exited"`; it now returns `status: "lost"` with `completion_reason: "lost"`

Closes #97285
