### PR TITLE
fix(desktop): keep backend gate closed through Windows update handoff

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -2135,16 +2135,20 @@ const UPDATE_WAIT_POLL_MS = 1000
 const UPDATE_HANDOFF_DWELL_MS = 2500
 
 // Gate deps shared by the primary-window boot path and the pool-backend
-// spawn path. Consulting BOTH the on-disk marker and the in-process
-// updateInFlight flag is load-bearing (#73822): applyUpdates kills its own
-// backend BEFORE the Windows venv-blocker scan but only writes the marker
-// AFTER it, so a marker-only gate lets the renderer's ~1s reconnect respawn
-// a backend inside the update's own critical section — which the scan then
-// reports as a blocker, aborting every update attempt.
+// spawn path. Consulting the on-disk marker, the in-process updateInFlight
+// flag, AND the successful detached hand-off state is load-bearing (#73822):
+// applyUpdates kills its own backend BEFORE the Windows venv-blocker scan but
+// only writes the marker AFTER it, so a marker-only gate lets the renderer's
+// ~1s reconnect respawn a backend inside the update's own critical section —
+// which the scan then reports as a blocker, aborting every update attempt.
+// The hand-off state closes the later Windows `cmd start` wrapper gap: the
+// wrapper exits 0 before the real PowerShell script claims the marker, and
+// `finally` clears updateInFlight immediately after the hand-off is accepted.
 function updateGateDeps() {
   return {
     hasLiveMarker: () => Boolean(readLiveUpdateMarker(HERMES_HOME)),
-    isUpdateInFlight: () => updateInFlight
+    isUpdateInFlight: () => updateInFlight,
+    isHandoffActive: () => isQuittingForHandoff
   }
 }
 

--- a/apps/desktop/electron/update-gate.test.ts
+++ b/apps/desktop/electron/update-gate.test.ts
@@ -7,7 +7,8 @@
  * it. A marker-only gate therefore let the renderer's reconnect spawn a
  * fresh backend inside the update's own critical section, which the scan
  * reported as a blocker — aborting every Desktop update attempt on Windows.
- * The gate must consult the in-process updateInFlight flag as well.
+ * The gate must consult the in-process updateInFlight flag and the successful
+ * detached hand-off state as well.
  */
 
 import assert from 'node:assert/strict'
@@ -16,10 +17,11 @@ import { test } from 'vitest'
 
 import { updateGateReason, waitForUpdateClearance } from './update-gate'
 
-function deps(marker: boolean, inFlight: boolean) {
+function deps(marker: boolean, inFlight: boolean, handoffActive = false) {
   return {
     hasLiveMarker: () => marker,
-    isUpdateInFlight: () => inFlight
+    isUpdateInFlight: () => inFlight,
+    isHandoffActive: () => handoffActive
   }
 }
 
@@ -41,6 +43,35 @@ test('updateInFlight alone closes the gate (#73822 — the pre-marker window)', 
 
 test('marker wins as the reported reason when both are set', () => {
   assert.equal(updateGateReason(deps(true, true)), 'marker')
+})
+
+test('handoff remains closed after the detached wrapper exits', async () => {
+  let handoffActive = true
+  let ticks = 0
+
+  const outcome = await waitForUpdateClearance(
+    {
+      hasLiveMarker: () => false,
+      isUpdateInFlight: () => false,
+      isHandoffActive: () => handoffActive
+    },
+    {
+      onWaitTick: reason => {
+        ticks += 1
+        assert.equal(reason, 'handoff')
+
+        if (ticks === 2) {
+          handoffActive = false
+        }
+      },
+      pollMs: 1,
+      sleep: async () => {},
+      timeoutMs: 10_000
+    }
+  )
+
+  assert.equal(outcome, 'finished')
+  assert.equal(ticks, 2)
 })
 
 // ---------------------------------------------------------------------------
@@ -70,7 +101,7 @@ test('parks on the in-flight flag and finishes when it clears', async () => {
   let ticks = 0
 
   const outcome = await waitForUpdateClearance(
-    { hasLiveMarker: () => false, isUpdateInFlight: () => inFlight },
+    { hasLiveMarker: () => false, isUpdateInFlight: () => inFlight, isHandoffActive: () => false },
     {
       onWaitTick: reason => {
         ticks += 1
@@ -100,7 +131,7 @@ test('parks across the flag→marker handoff without a gap', async () => {
   const reasons: string[] = []
 
   const outcome = await waitForUpdateClearance(
-    { hasLiveMarker: () => marker, isUpdateInFlight: () => inFlight },
+    { hasLiveMarker: () => marker, isUpdateInFlight: () => inFlight, isHandoffActive: () => false },
     {
       onWaitTick: reason => {
         ticks += 1

--- a/apps/desktop/electron/update-gate.ts
+++ b/apps/desktop/electron/update-gate.ts
@@ -6,12 +6,14 @@
  * Pure, dependency-injected gate that parks local backend spawns while an
  * in-app update is running (#73822, #50238).
  *
- * Two independent signals mean "an update owns the venv right now":
+ * Three independent signals mean "an update owns the venv right now":
  *
  *  - the on-disk marker (`HERMES_HOME/.hermes-update-in-progress`), written
  *    by the updater — and by the desktop itself just before hand-off — and
  *  - the in-process `updateInFlight` flag, true for the whole
- *    `applyUpdates()` critical section.
+ *    `applyUpdates()` critical section, and
+ *  - the successful detached hand-off state, which remains true while this
+ *    Desktop is waiting to quit after the wrapper has handed control away.
  *
  * The marker alone is NOT enough (#73822): `applyUpdates` kills its own
  * backend early (`releaseBackendLock`) but only writes the marker AFTER the
@@ -25,13 +27,15 @@
  * waiter could slip through mid-update.
  */
 
-export type UpdateGateReason = 'marker' | 'update-in-flight' | null
+export type UpdateGateReason = 'marker' | 'update-in-flight' | 'handoff' | null
 
 export interface UpdateGateDeps {
   /** True when a live on-disk update marker exists (see update-marker.ts). */
   hasLiveMarker: () => boolean
   /** True while this process is inside applyUpdates()' critical section. */
   isUpdateInFlight: () => boolean
+  /** True after a detached updater hand-off is viable and this Desktop will quit. */
+  isHandoffActive: () => boolean
 }
 
 /** Why the gate is closed right now, or null when it is open. */
@@ -42,6 +46,10 @@ export function updateGateReason(deps: UpdateGateDeps): UpdateGateReason {
 
   if (deps.isUpdateInFlight()) {
     return 'update-in-flight'
+  }
+
+  if (deps.isHandoffActive()) {
+    return 'handoff'
   }
 
   return null


### PR DESCRIPTION
## Bug Description

On Windows, a detached repo-update handoff can let Hermes Desktop restart local primary/pool backends after the short-lived `cmd.exe` wrapper exits but before the real `windows.ps1` process claims the update marker. In the affected v0.20.6 run, those replacement backends exited before readiness and the renderer entered a failed/connecting state.

Fixes #97287

## Root Cause

`update-gate.ts` originally considered only the live update marker and `updateInFlight`. The repo handoff marker initially names the short-lived Windows wrapper. `observeUpdaterHandoff()` correctly treats the wrapper's clean exit as successful, but the marker then becomes stale before the real PowerShell handoff claims it. `applyUpdates()` clears `updateInFlight`, creating a brief interval in which local backend startup is incorrectly allowed.

## Fix

- Add a third `handoff` state to `UpdateGateDeps` and `updateGateReason()`.
- Wire the gate to the existing `isQuittingForHandoff` state, which is set after a viable handoff and before `updateInFlight` is cleared.
- Keep both primary and pool backend starts parked through that interval.
- Add a regression test that simulates the wrapper marker disappearing while the detached handoff remains active.

## How to Verify

1. Run `npm run test:desktop:platforms -- electron/update-gate.test.ts` from `apps/desktop`.
2. Run the relevant Electron/renderer suite listed in the test results.
3. Inspect `main.ts` handoff ordering: `isQuittingForHandoff` is set before `updateInFlight` is cleared.

## Test Plan

- [x] Added regression test for the wrapper-exit/real-marker-claim interval.
- [x] Relevant Electron/renderer tests: 151 passed.
- [x] Typecheck passed.
- [x] Changed-file ESLint passed.
- [x] `git diff --check` passed.
- [ ] Full Electron project: 36 unrelated Windows/platform/environment failures remain (filesystem mode/permissions, POSIX-only SSH expectations, Electron binary setup, and platform-specific fixtures).
- [ ] Manual packaged-app update reproduction was not run.

## Risk Assessment

Low — the change is limited to the update gate contract, its main-process dependency wiring, and focused tests. It only prevents backend starts while the desktop is already committed to quitting for a successful detached handoff; failed handoffs retain the existing recovery path, and the existing bounded update wait remains unchanged.
