### PR TITLE
feat(dashboard): withhold deployment detail from anonymous /api/status callers

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1888,6 +1888,18 @@ updates:
 #   #     - "172.20.0.5"
 #   #     # - "172.20.0.0/24"  # dedicated network, if the IP is dynamic
 #
+#   # How much of /api/status an ANONYMOUS caller sees on a gated bind.
+#   # /api/status bypasses the auth gate (liveness probe + pre-login
+#   # bootstrap), so on a public host anyone reading the hostname gets this
+#   # payload. "full" (default) keeps every field public, which is what
+#   # Hermes Cloud needs: the Portal renders the profile list from an
+#   # unauthenticated read. "minimal" withholds the deployment detail
+#   # (profiles, gateway_mode, memory and disk rollups) from anonymous
+#   # callers, while a signed-in operator still gets the full payload.
+#   # Override: HERMES_DASHBOARD_PUBLIC_STATUS_DETAIL
+#   #
+#   #   public_status_detail: "minimal"
+#
 # -----------------------------------------------------------------------------
 # Self-hosted OIDC dashboard auth (generic OpenID Connect — Authentik,
 # Keycloak, Zitadel, Authelia, Auth0, Okta, Google, …). Use this INSTEAD of the

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1637,6 +1637,15 @@ DEFAULT_CONFIG = {
         # Set this to True to re-enable the surfaces with the understanding
         # that the numbers are a local lower-bound estimate, not billing.
         "show_token_analytics": False,
+        # How much of ``/api/status`` an ANONYMOUS caller sees on a gated
+        # (non-loopback) bind. "full" keeps every field public, which is what
+        # Hermes Cloud needs: the Portal renders the profile list from an
+        # unauthenticated read. "minimal" withholds the deployment detail
+        # (profile names, gateway mode, host memory / disk rollups) from
+        # anonymous callers while a signed-in operator still gets the full
+        # payload. Meant for a self-hosted dashboard published on the internet,
+        # where nothing but the operator has a reason to read it.
+        "public_status_detail": "full",
         # IP addresses or bounded CIDR networks of reverse proxies allowed to
         # supply X-Forwarded-Proto / X-Forwarded-For. Loopback remains trusted
         # automatically. Wildcards and /0 networks are rejected so arbitrary

--- a/hermes_cli/dashboard_auth/middleware.py
+++ b/hermes_cli/dashboard_auth/middleware.py
@@ -335,7 +335,20 @@ def _attach_public_path_session(request: Request) -> None:
     """
     if getattr(request.state, "session", None) is not None:
         return
+    # The desktop authenticates REST with ``Authorization: Bearer`` and holds
+    # no cookies at all (RFC 8252 native flow), so the bearer has to be read
+    # here too: otherwise a signed-in desktop reads as anonymous on every
+    # public path.
     try:
+        bearer = _extract_bearer(request)
+        if bearer:
+            try:
+                bearer_session = _verify_bearer(request, access_token=bearer)
+            except Exception:
+                bearer_session = None
+            if bearer_session is not None:
+                request.state.session = bearer_session
+                return
         access_token, _refresh_token = read_session_cookies(request)
         if not access_token:
             return

--- a/hermes_cli/dashboard_auth/middleware.py
+++ b/hermes_cli/dashboard_auth/middleware.py
@@ -320,6 +320,38 @@ def _verify_bearer(request: Request, *, access_token: str):
     return None
 
 
+def _attach_public_path_session(request: Request) -> None:
+    """Best-effort session attach for a request on a public (ungated) path.
+
+    Public paths bypass the gate by design, so a handler there cannot tell a
+    signed-in operator from an anonymous probe: both arrive with
+    ``request.state.session`` unset. ``/api/status`` needs that distinction to
+    decide how much deployment detail its payload may carry.
+
+    Nothing here may fail the request: an absent, stale, or unverifiable
+    cookie, or an unreachable IDP, all mean the same thing to the caller of
+    this helper (anonymous), and a liveness probe that 503s because a cookie
+    went stale is worse than the disclosure it was hardening against.
+    """
+    if getattr(request.state, "session", None) is not None:
+        return
+    try:
+        access_token, _refresh_token = read_session_cookies(request)
+        if not access_token:
+            return
+        provider_hint = read_session_provider(request)
+        for provider in _ordered_session_providers(provider_hint):
+            try:
+                session = provider.verify_session(access_token=access_token)
+            except Exception:
+                continue
+            if session is not None:
+                request.state.session = session
+                return
+    except Exception:
+        return
+
+
 async def gated_auth_middleware(
     request: Request,
     call_next: Callable[[Request], Awaitable[Response]],
@@ -341,6 +373,10 @@ async def gated_auth_middleware(
 
     path = request.url.path
     if _path_is_public(path):
+        # Ungated, but not necessarily anonymous: attach the session when the
+        # caller carries a valid one so a public handler can vary its payload
+        # by caller (see ``_attach_public_path_session``).
+        _attach_public_path_session(request)
         return await call_next(request)
 
     # RFC 8252 native-app bearer path (goal: no session cookies). The desktop

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3758,6 +3758,13 @@ def _public_status_detail() -> str:
             "public_status_detail", "full"
         )
     except Exception:
+        # Fail open: an unreadable config must not turn a liveness probe into
+        # an error. Logged because it silently drops an operator's hardening
+        # choice back to the public default.
+        _log.warning(
+            "Could not read dashboard.public_status_detail; "
+            "serving the full public /api/status payload"
+        )
         return "full"
     if isinstance(configured, str) and configured.strip().lower() == "minimal":
         return "minimal"

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3740,6 +3740,14 @@ def _merge_profile_gateway_platforms(
     return merged
 
 
+# One-shot guard for the unreadable-config warning below. ``/api/status`` is a
+# liveness probe: portals, uptime monitors and the desktop poll it on a timer,
+# so a per-call warning would turn one broken config into a log flood that
+# buries the very line the operator needs to see. Same discipline as the
+# malformed-public_url warnings in dashboard_auth/prefix.py.
+_warned_public_status_detail_unreadable = False
+
+
 def _public_status_detail() -> str:
     """Return ``"minimal"`` or ``"full"`` for the public ``/api/status`` payload.
 
@@ -3759,12 +3767,15 @@ def _public_status_detail() -> str:
         )
     except Exception:
         # Fail open: an unreadable config must not turn a liveness probe into
-        # an error. Logged because it silently drops an operator's hardening
-        # choice back to the public default.
-        _log.warning(
-            "Could not read dashboard.public_status_detail; "
-            "serving the full public /api/status payload"
-        )
+        # an error. Warned once because it silently drops an operator's
+        # hardening choice back to the public default.
+        global _warned_public_status_detail_unreadable
+        if not _warned_public_status_detail_unreadable:
+            _warned_public_status_detail_unreadable = True
+            _log.warning(
+                "Could not read dashboard.public_status_detail; "
+                "serving the full public /api/status payload"
+            )
         return "full"
     if isinstance(configured, str) and configured.strip().lower() == "minimal":
         return "minimal"

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3740,8 +3740,32 @@ def _merge_profile_gateway_platforms(
     return merged
 
 
+def _public_status_detail() -> str:
+    """Return ``"minimal"`` or ``"full"`` for the public ``/api/status`` payload.
+
+    ``full`` (the default) keeps the historical payload: Hermes Cloud renders
+    the profile list in the Portal from an unauthenticated read of this
+    endpoint, so trimming it by default would regress a product surface.
+    ``minimal`` is for the self-hosted case the default cannot serve: a
+    dashboard published on the open internet, where the only readers are the
+    operator (who signs in) and whoever else finds the hostname.
+    """
+    env_override = os.environ.get("HERMES_DASHBOARD_PUBLIC_STATUS_DETAIL", "").strip()
+    if env_override:
+        return "minimal" if env_override.lower() == "minimal" else "full"
+    try:
+        configured = (load_config().get("dashboard") or {}).get(
+            "public_status_detail", "full"
+        )
+    except Exception:
+        return "full"
+    if isinstance(configured, str) and configured.strip().lower() == "minimal":
+        return "minimal"
+    return "full"
+
+
 @app.get("/api/status")
-async def get_status(profile: Optional[str] = None):
+async def get_status(request: Request = None, profile: Optional[str] = None):
     status_scope = None
     requested_profile = (profile or "").strip()
     # Plain /api/status stays the machine-level public liveness probe. The
@@ -4051,6 +4075,26 @@ async def get_status(profile: Optional[str] = None):
             else "degraded"
         )
 
+        # Deployment detail vs liveness. ``/api/status`` is in
+        # ``PUBLIC_API_PATHS``, so on a gated bind an anonymous caller reaches
+        # it cold. The rollups below (host memory, host disk) and the profile
+        # topology further down describe the deployment, not whether it is
+        # alive, and an operator running ``public_status_detail: minimal``
+        # asked for them to stay off the anonymous probe. A caller carrying a
+        # valid session is not anonymous (the gate's public-path branch
+        # attaches ``request.state.session``), so the dashboard's own Status
+        # page keeps every field it renders today.
+        # ``request`` is None for the in-process callers that await this
+        # handler directly (a long-standing test seam); they are not a network
+        # caller, so they read as anonymous.
+        request_state = getattr(request, "state", None)
+        withhold_operator_detail = (
+            auth_required
+            and _public_status_detail() == "minimal"
+            and getattr(request_state, "session", None) is None
+            and not getattr(request_state, "token_authenticated", False)
+        )
+
         # Memory-pressure rollup (NS-656). Distilled from the gateway's
         # 30s loop heartbeat + lifecycle sentinel — two small file reads,
         # no gateway IPC. Coarse MB numbers/enums/booleans only: this
@@ -4060,30 +4104,32 @@ async def get_status(profile: Optional[str] = None):
         # material), not a liveness verdict, and flipping `overall` to
         # "degraded" on it would page NAS's availability sweep for a
         # condition the valve is already handling.
-        try:
-            from gateway.memory_status import collect_memory_status
+        if not withhold_operator_detail:
+            try:
+                from gateway.memory_status import collect_memory_status
 
-            status["memory"] = await run_in_threadpool(
-                collect_memory_status,
-                profile_dir if profile_dir else get_hermes_home(),
-            )
-        except Exception:
-            status["memory"] = {"pressure": "unknown"}
+                status["memory"] = await run_in_threadpool(
+                    collect_memory_status,
+                    profile_dir if profile_dir else get_hermes_home(),
+                )
+            except Exception:
+                status["memory"] = {"pressure": "unknown"}
 
         # Disk-usage rollup (NS-656, same lineage as OOF-2/OOF-107 fleet
         # disk-exhaustion incidents). One statvfs call on HERMES_HOME's
         # filesystem — coarse MB numbers + enum, same public disclosure
         # class as the memory block, and equally advisory: not folded
         # into components/overall.
-        try:
-            from gateway.disk_status import collect_disk_status
+        if not withhold_operator_detail:
+            try:
+                from gateway.disk_status import collect_disk_status
 
-            status["disk"] = await run_in_threadpool(
-                collect_disk_status,
-                profile_dir if profile_dir else get_hermes_home(),
-            )
-        except Exception:
-            status["disk"] = {"pressure": "unknown"}
+                status["disk"] = await run_in_threadpool(
+                    collect_disk_status,
+                    profile_dir if profile_dir else get_hermes_home(),
+                )
+            except Exception:
+                status["disk"] = {"pressure": "unknown"}
 
         # Deferred FTS rebuild progress (schema v23): lets the desktop /
         # dashboard render a "search index rebuilding: N%" indicator instead
@@ -4121,8 +4167,9 @@ async def get_status(profile: Optional[str] = None):
         # (``topology`` was already fetched above, before the platform rollup,
         # so the per-profile platform merge could use it — the TTL cache makes
         # the earlier fetch the only real scan either way.)
-        status["profiles"] = topology["profiles"]
-        status["gateway_mode"] = topology["gateway_mode"]
+        if not withhold_operator_detail:
+            status["profiles"] = topology["profiles"]
+            status["gateway_mode"] = topology["gateway_mode"]
 
         # Absolute host paths, the gateway PID, the internal gateway health
         # URL, and per-gateway ports are deployment recon a liveness probe never

--- a/tests/hermes_cli/test_dashboard_auth_status_endpoint.py
+++ b/tests/hermes_cli/test_dashboard_auth_status_endpoint.py
@@ -249,3 +249,22 @@ def test_status_survives_an_unreadable_config(gated_client, monkeypatch):
     r = gated_client.get("/api/status")
     assert r.status_code == 200
     assert "version" in r.json()
+
+
+def test_unreadable_config_warns_once_not_per_probe(gated_client, monkeypatch, caplog):
+    """The warning must not scale with probe traffic. /api/status is polled on a
+    timer by portals, uptime monitors and the desktop, so a per-call warning
+    turns one broken config into a log flood that buries the line the operator
+    needs."""
+    import logging
+
+    def _boom():
+        raise RuntimeError("config unreadable")
+
+    monkeypatch.setattr(web_server, "load_config", _boom)
+    monkeypatch.setattr(web_server, "_warned_public_status_detail_unreadable", False)
+    with caplog.at_level(logging.WARNING, logger="hermes_cli.web_server"):
+        for _ in range(3):
+            assert gated_client.get("/api/status").status_code == 200
+    hits = [r for r in caplog.records if "public_status_detail" in r.message]
+    assert len(hits) == 1, f"expected one warning, got {len(hits)}"

--- a/tests/hermes_cli/test_dashboard_auth_status_endpoint.py
+++ b/tests/hermes_cli/test_dashboard_auth_status_endpoint.py
@@ -172,3 +172,80 @@ def test_status_probe_survives_a_broken_session_cookie(gated_client, monkeypatch
     r = gated_client.get("/api/status")
     assert r.status_code == 200
     assert _OPERATOR_DETAIL_FIELDS.isdisjoint(r.json().keys())
+
+
+def _session_token(client) -> str:
+    """Return the access token of a logged-in client's session cookie.
+
+    The cookie name carries a ``__Host-`` prefix over HTTPS, so match on the
+    bare suffix rather than hardcoding the prefixed name.
+    """
+    for name, value in client.cookies.items():
+        if name.endswith("hermes_session_at"):
+            return value
+    raise AssertionError(f"no session cookie among {list(client.cookies.keys())}")
+
+
+def test_status_keeps_operator_detail_for_bearer_caller(gated_client, monkeypatch):
+    """The desktop authenticates REST with ``Authorization: Bearer`` and holds
+    no cookie (RFC 8252 native flow). It must not read as anonymous, or
+    ``minimal`` would blind the very cockpit that manages the gateway."""
+    monkeypatch.setattr(
+        web_server, "load_config",
+        lambda: {"dashboard": {"public_status_detail": "minimal"}},
+    )
+    _login(gated_client)
+    token = _session_token(gated_client)
+    gated_client.cookies.clear()
+    body = gated_client.get(
+        "/api/status", headers={"Authorization": f"Bearer {token}"}
+    ).json()
+    assert "profiles" in body, "bearer caller lost the profile list"
+    assert "memory" in body, "bearer caller lost the memory rollup"
+
+
+def test_status_minimal_is_a_no_op_on_a_loopback_bind(loopback_client, monkeypatch):
+    """``minimal`` describes what an anonymous NETWORK caller sees. A loopback
+    dashboard has no gate and no anonymous reader, so the payload is whole."""
+    monkeypatch.setattr(
+        web_server, "load_config",
+        lambda: {"dashboard": {"public_status_detail": "minimal"}},
+    )
+    body = loopback_client.get("/api/status").json()
+    assert "profiles" in body
+    assert "memory" in body
+
+
+def test_status_detail_env_override_wins(gated_client, monkeypatch):
+    """Hosting platforms inject settings as env, matching the precedence the
+    other dashboard keys already follow."""
+    monkeypatch.setattr(
+        web_server, "load_config",
+        lambda: {"dashboard": {"public_status_detail": "full"}},
+    )
+    monkeypatch.setenv("HERMES_DASHBOARD_PUBLIC_STATUS_DETAIL", "minimal")
+    body = gated_client.get("/api/status").json()
+    assert _OPERATOR_DETAIL_FIELDS.isdisjoint(body.keys())
+
+
+def test_status_detail_unknown_value_falls_back_to_full(gated_client, monkeypatch):
+    """An unrecognised value must not silently mean ``minimal``: the payload
+    Hermes Cloud reads stays whole unless the operator asked otherwise."""
+    monkeypatch.setattr(
+        web_server, "load_config",
+        lambda: {"dashboard": {"public_status_detail": "moderate"}},
+    )
+    body = gated_client.get("/api/status").json()
+    assert "profiles" in body
+
+
+def test_status_survives_an_unreadable_config(gated_client, monkeypatch):
+    """A config read that raises must degrade to the public default rather
+    than failing the liveness probe."""
+    def _boom():
+        raise RuntimeError("config unreadable")
+
+    monkeypatch.setattr(web_server, "load_config", _boom)
+    r = gated_client.get("/api/status")
+    assert r.status_code == 200
+    assert "version" in r.json()

--- a/tests/hermes_cli/test_dashboard_auth_status_endpoint.py
+++ b/tests/hermes_cli/test_dashboard_auth_status_endpoint.py
@@ -95,3 +95,80 @@ def test_status_withholds_host_detail_in_gated_mode(gated_client):
     assert not leaked, f"/api/status leaked host detail under the gate: {leaked}"
 
 
+
+# ---------------------------------------------------------------------------
+# dashboard.public_status_detail: operator detail on the anonymous probe
+# ---------------------------------------------------------------------------
+
+# Profile names, the gateway topology mode, and the host memory / disk
+# rollups describe the deployment, not its liveness. They are public by
+# default because Hermes Cloud renders them in the Portal from an
+# unauthenticated read. A self-hosted dashboard exposed to the internet has
+# no such reader, so ``dashboard.public_status_detail: minimal`` withholds
+# them from anonymous callers while keeping them for a signed-in operator.
+_OPERATOR_DETAIL_FIELDS = frozenset({
+    "profiles", "gateway_mode", "memory", "disk",
+})
+
+
+def _login(client):
+    """Walk the stub IDP round trip so the client holds a session cookie."""
+    to_idp = client.get("/auth/login?provider=stub", follow_redirects=False)
+    assert to_idp.status_code in (302, 307), to_idp.status_code
+    callback = to_idp.headers["location"]
+    landed = client.get(callback, follow_redirects=False)
+    assert landed.status_code in (302, 307), landed.status_code
+
+
+def test_status_publishes_operator_detail_by_default(gated_client, monkeypatch):
+    """Default stays ``full``: the Cloud Portal's profile list must not
+    regress on an install that never opts in."""
+    monkeypatch.setattr(web_server, "load_config", lambda: {})
+    body = gated_client.get("/api/status").json()
+    assert "profiles" in body
+    assert "memory" in body
+
+
+def test_status_withholds_operator_detail_when_minimal(gated_client, monkeypatch):
+    """``minimal`` + gated bind + anonymous caller: the deployment detail
+    must be absent from the public probe."""
+    monkeypatch.setattr(
+        web_server, "load_config",
+        lambda: {"dashboard": {"public_status_detail": "minimal"}},
+    )
+    r = gated_client.get("/api/status")
+    assert r.status_code == 200
+    body = r.json()
+    # Liveness + auth-gate shape stays public: the probe contract holds.
+    for key in ("version", "gateway_state", "auth_required", "auth_providers"):
+        assert key in body, f"liveness field {key!r} must stay public"
+    leaked = _OPERATOR_DETAIL_FIELDS & set(body.keys())
+    assert not leaked, f"/api/status leaked operator detail: {leaked}"
+
+
+def test_status_keeps_operator_detail_for_signed_in_caller(gated_client, monkeypatch):
+    """``minimal`` must not blind the operator's own dashboard: a request
+    carrying a valid session cookie still gets the full payload, so the
+    Status page keeps rendering profiles and the resource banners."""
+    monkeypatch.setattr(
+        web_server, "load_config",
+        lambda: {"dashboard": {"public_status_detail": "minimal"}},
+    )
+    _login(gated_client)
+    body = gated_client.get("/api/status").json()
+    assert "profiles" in body, "signed-in caller lost the profile list"
+    assert "memory" in body, "signed-in caller lost the memory rollup"
+
+
+def test_status_probe_survives_a_broken_session_cookie(gated_client, monkeypatch):
+    """The public probe must never fail because a cookie could not be
+    verified. A liveness endpoint that 500s on a stale cookie is worse
+    than the disclosure it was hardening against."""
+    monkeypatch.setattr(
+        web_server, "load_config",
+        lambda: {"dashboard": {"public_status_detail": "minimal"}},
+    )
+    gated_client.cookies.set("hermes_session_at", "not-a-valid-token")
+    r = gated_client.get("/api/status")
+    assert r.status_code == 200
+    assert _OPERATOR_DETAIL_FIELDS.isdisjoint(r.json().keys())

--- a/website/docs/user-guide/features/web-dashboard.md
+++ b/website/docs/user-guide/features/web-dashboard.md
@@ -458,6 +458,29 @@ Both collectors are fail-safe: any sampling error degrades the block to
 `{"pressure": "unknown"}` instead of failing the status endpoint. The numbers
 are coarse (whole MB, whole-percent) since `/api/status` is public.
 
+#### Limiting what anonymous callers see
+
+`/api/status` bypasses the auth gate (it is the portal's liveness probe and the
+SPA's pre-login bootstrap), so on a gated bind **anyone who can reach the host
+reads it**. By default the payload also carries deployment detail: `profiles`
+(profile names), `gateway_mode`, and the `memory` / `disk` rollups above. That
+default serves Hermes Cloud, where the portal renders the profile list from an
+unauthenticated read.
+
+A self-hosted dashboard published on the internet has no such reader. Set:
+
+```yaml
+dashboard:
+  public_status_detail: minimal   # default: "full"
+```
+
+(or `HERMES_DASHBOARD_PUBLIC_STATUS_DETAIL=minimal`) and those four fields are
+withheld from **anonymous** callers on a gated bind. Version, gateway state,
+`install_id`, session counts, and the auth-gate shape stay public, so probes
+and the desktop's pre-login discovery keep working. A caller carrying a valid
+session still receives the full payload, so the dashboard's own Status page and
+its resource banners are unaffected. On a loopback bind nothing changes.
+
 ### GET /api/sessions
 
 Returns the 20 most recent sessions with metadata (model, token counts, timestamps, preview).


### PR DESCRIPTION
## What does this PR do?

`/api/status` bypasses the auth gate by design (portal liveness probe, SPA pre-login bootstrap), so on a gated bind anyone who reaches the host reads it cold. Beyond liveness the payload carries deployment detail: `profiles`, `gateway_mode`, and the host `memory` / `disk` rollups. That is intentional for Hermes Cloud, where the Portal renders the profile list from an unauthenticated read. A self-hosted dashboard published on the internet has no such reader, and publishes its profile roster and host sizing to anyone who curls the hostname.

This adds `dashboard.public_status_detail` (default `"full"`, so nothing changes unless an operator opts in). With `"minimal"`, those four fields are withheld from **anonymous** callers on a gated bind; version, gateway state, `install_id`, session counts and the auth-gate shape stay public, so probes and the desktop's pre-login discovery keep working.

For the knob not to blind the operator's own dashboard, the gate's public-path branch now attaches `request.state.session` when the caller carries a valid one, best effort and never failing the request: a public path that 503s because a cookie went stale would be worse than the disclosure it hardens against. A signed-in caller therefore keeps the full payload, and the Status page keeps rendering its resource banners.

Side benefit: on the anonymous path the handler no longer performs the `statvfs` and heartbeat reads at all.

## Related Issue

Fixes #97302

Same endpoint, different field class from #90700 (free-text `error_message` / `gateway_exit_reason`); the two changes do not overlap.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix

## Changes Made

- `hermes_cli/web_server.py`: `_public_status_detail()` reads `dashboard.public_status_detail` with `HERMES_DASHBOARD_PUBLIC_STATUS_DETAIL` as the env override (same precedence as the other dashboard keys); `get_status` takes the `Request` and computes `withhold_operator_detail` from gate state, the knob, and whether the caller has a session or a token principal. The `request` parameter defaults to `None` so the existing in-process callers that await the handler directly keep working.
- `hermes_cli/dashboard_auth/middleware.py`: `_attach_public_path_session()`, called from the public-path branch. Tries the `Authorization: Bearer` token first (the desktop's native flow holds no cookie, and the public-path branch returns before the gate's own bearer verification), then the session cookie, through the ordered provider stack, swallowing every failure.
- `hermes_cli/config_defaults.py`: the new key, defaulting to `"full"`.
- `cli-config.yaml.example` and `website/docs/user-guide/features/web-dashboard.md`: documented.
- `tests/hermes_cli/test_dashboard_auth_status_endpoint.py`: 9 tests.

## How to Test

Reproduce the exposure, then verify the knob:

1. Run a gated dashboard: `hermes dashboard --host 0.0.0.0 --port 9119 --no-open` with an auth provider configured.
2. `curl -s http://<host>:9119/api/status | jq '.profiles, .memory, .disk'` returns the deployment detail with no credentials.
3. Set `dashboard.public_status_detail: minimal` in `config.yaml`, restart, repeat step 2: the three fields (and `gateway_mode`) are gone, while `version`, `gateway_state`, `auth_required` and `auth_providers` remain.
4. Sign in to the dashboard in a browser, then load `/api/status` in the same session: the full payload is back.

Automated coverage in `tests/hermes_cli/test_dashboard_auth_status_endpoint.py` (9 tests):

- `test_status_publishes_operator_detail_by_default` guards the Cloud default.
- `test_status_withholds_operator_detail_when_minimal` is the leak test.
- `test_status_keeps_operator_detail_for_signed_in_caller` proves the operator is not blinded.
- `test_status_keeps_operator_detail_for_bearer_caller` covers the desktop's cookieless native flow.
- `test_status_minimal_is_a_no_op_on_a_loopback_bind` pins the loopback carve-out.
- `test_status_detail_env_override_wins` and `test_status_detail_unknown_value_falls_back_to_full` cover the setting's precedence and its parsing.
- `test_status_probe_survives_a_broken_session_cookie` and `test_status_survives_an_unreadable_config` pin the never-fail contract of both new code paths.

Each behavior was verified as a genuine regression by reverting it independently: without the middleware cookie attach the signed-in test fails, without the bearer branch the desktop test fails, without the handler change the leak test fails.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature
- [x] I've run the test suite for the affected area with `scripts/run_tests.sh`: 50 dashboard / web-server test files, 605 passed. The 24 failures in that set are pre-existing on `main` at the same commit (596 passed / 24 failed before this branch).
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.6), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`website/docs/user-guide/features/web-dashboard.md`)
- [x] I've updated `cli-config.yaml.example`
- [x] N/A for `CONTRIBUTING.md` / `AGENTS.md`
- [x] Cross-platform: pure Python, no platform-specific primitives touched
