### PR TITLE
fix(agent): stop incomplete runs from reporting success

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -7880,21 +7880,35 @@ class APIServerAdapter(BasePlatformAdapter):
                         "cancelled",
                         last_event="run.cancelled",
                     )
-                # Check for structured failure (non-retryable client errors like
-                # 401/400 return failed=True instead of raising, so the except
-                # block below never fires — issue #15561).
-                elif isinstance(result, dict) and result.get("failed"):
+                # Structured non-success results return normally instead of
+                # raising. Treat every explicit incomplete contract as failed;
+                # checking only ``failed`` turned completed=False / partial=True
+                # early exits into terminal-successful empty runs (#97278).
+                elif isinstance(result, dict) and (
+                    result.get("failed") is True
+                    or result.get("completed") is False
+                    or result.get("partial") is True
+                ):
                     error_msg = _redact_api_error_text(result.get("error") or "agent run failed")
+                    final_response = result.get("final_response", "") or ""
+                    completed = result.get("completed") is True
+                    partial = result.get("partial") is True
                     _put_event_if_active({
                         "event": "run.failed",
                         "run_id": run_id,
                         "timestamp": time.time(),
                         "error": error_msg,
+                        "output": final_response,
+                        "completed": completed,
+                        "partial": partial,
                     })
                     self._set_run_status(
                         run_id,
                         "failed",
                         error=error_msg,
+                        output=final_response,
+                        completed=completed,
+                        partial=partial,
                         last_event="run.failed",
                     )
                 else:

--- a/run_agent.py
+++ b/run_agent.py
@@ -8985,9 +8985,37 @@ class AIAgent:
                     # outer finally: a refresher firing between stop and join
                     # would otherwise set an interrupt that survives the clear.
             terminal = result if isinstance(result, dict) else {}
+            terminal_incomplete = (
+                terminal.get("failed") is True
+                or terminal.get("completed") is False
+                or terminal.get("partial") is True
+            )
+            if terminal_incomplete and not terminal.get("turn_exit_reason"):
+                # Early returns inside conversation_loop intentionally bypass
+                # finalize_turn, but that must not also erase the terminal
+                # diagnostic operators use to distinguish a clean empty answer
+                # from an aborted turn (#97278).  Stamp the shared result at the
+                # outer boundary so every present and future bypass is covered.
+                terminal["turn_exit_reason"] = "early_return"
+                _early_error = redact_sensitive_text(
+                    str(terminal.get("error") or terminal.get("failure_reason") or "")
+                )[:500]
+                logger.warning(
+                    "Turn ended: reason=early_return completed=%s failed=%s "
+                    "partial=%s interrupted=%s api_calls=%s response_len=%d "
+                    "session=%s error=%s",
+                    terminal.get("completed"),
+                    terminal.get("failed") is True,
+                    terminal.get("partial") is True,
+                    terminal.get("interrupted") is True,
+                    terminal.get("api_calls", "unknown"),
+                    len(str(terminal.get("final_response") or "")),
+                    session_id or "none",
+                    _early_error or "none",
+                )
             if terminal.get("interrupted") is True:
                 relay_outcome = "cancelled"
-            elif terminal.get("failed") is True:
+            elif terminal_incomplete:
                 relay_outcome = "failed"
             else:
                 relay_outcome = "success"

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -154,6 +154,46 @@ class TestStartRun:
                 assert status["object"] == "hermes.run"
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("final_response", "partial"),
+        [("", False), ("partial answer", True)],
+    )
+    async def test_incomplete_agent_result_reports_failed_run(
+        self, adapter, final_response, partial
+    ):
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+                mock_agent.run_conversation.return_value = {
+                    "final_response": final_response,
+                    "completed": False,
+                    "partial": partial,
+                    "error": "response truncated",
+                }
+                mock_agent.session_prompt_tokens = 10
+                mock_agent.session_completion_tokens = 5
+                mock_agent.session_total_tokens = 15
+                mock_create.return_value = mock_agent
+
+                response = await cli.post("/v1/runs", json={"input": "hello"})
+                run_id = (await response.json())["run_id"]
+
+                for _ in range(40):
+                    status_response = await cli.get(f"/v1/runs/{run_id}")
+                    status = await status_response.json()
+                    if status["status"] == "failed":
+                        break
+                    await asyncio.sleep(0.05)
+
+        assert status["status"] == "failed"
+        assert status["last_event"] == "run.failed"
+        assert status["completed"] is False
+        assert status["partial"] is partial
+        assert status["output"] == final_response
+        assert status["error"] == "response truncated"
+
+    @pytest.mark.asyncio
     async def test_start_binds_chat_id_for_delegation_wake_target(self, adapter):
         """/v1/runs must bind the raw session id as the api_server chat_id
         (like every other agent-entry route does via _run_agent): the async

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3267,6 +3267,45 @@ class TestRunConversation:
         assert result is failed_result
         assert order == ["logical", "metrics"]
 
+    def test_early_incomplete_return_logs_terminal_failure(self, agent):
+        from agent import relay_runtime
+
+        incomplete_result = {
+            "final_response": "partial answer",
+            "messages": [],
+            "api_calls": 2,
+            "completed": False,
+            "partial": True,
+            "error": "response truncated",
+        }
+
+        with (
+            patch(
+                "agent.conversation_loop.run_conversation",
+                return_value=incomplete_result,
+            ),
+            patch(
+                "hermes_cli.observability.relay_shared_metrics.start_task_run",
+            ),
+            patch(
+                "hermes_cli.observability.relay_shared_metrics.finish_task_run",
+            ),
+            patch.object(
+                relay_runtime.SESSION_COORDINATOR,
+                "finish_logical_calls",
+            ) as finish_logical_calls,
+            patch("run_agent.logger.warning") as warning,
+        ):
+            result = agent.run_conversation("private prompt")
+
+        assert result is incomplete_result
+        finish_logical_calls.assert_called_once()
+        assert finish_logical_calls.call_args.kwargs["outcome"] == "failed"
+        assert any(
+            call.args and str(call.args[0]).startswith("Turn ended:")
+            for call in warning.call_args_list
+        )
+
     def test_api_request_error_hook_skips_payload_work_without_listener(self, agent, monkeypatch):
         payload_built = False
         hook_called = False


### PR DESCRIPTION
## What does this PR do?

Incomplete conversation exits now leave a terminal diagnostic and propagate as failed `/v1/runs` records instead of terminal-successful runs with empty or partial output. The fix classifies the existing `completed`, `failed`, and `partial` result contract at the two outer boundaries, avoiding behavior changes inside the 26 early-return paths.

### Symptom

An early `run_conversation` return can bypass `finalize_turn`, so no `Turn ended` line is logged. `/v1/runs` then checks only `failed=True`; results carrying `completed=False` or `partial=True` are published as `run.completed`, including empty output.

### Impact

Polling consumers cannot distinguish a clean quiet completion from an aborted turn and can record incomplete work as successful. Partial text can also be presented as a complete run.

### Bug Cause

**Trigger:** `run_agent.py:8966` / the outer `AIAgent.run_conversation` boundary, followed by `gateway/platforms/api_server.py:7886` / `_handle_runs`.

**Causal chain:**
1. A conversation-loop recovery or exhaustion path returns a structured result with `completed=False`, often with `partial=True`, without reaching `finalize_turn`.
2. The outer wrapper treats any non-interrupted result lacking `failed=True` as a successful relay outcome and emits no replacement terminal diagnostic.
3. `/v1/runs` also checks only `failed=True`, publishes `run.completed`, and stores a terminal `completed` status.

**Why it is wrong:** `completed=False` and `partial=True` are explicit non-success signals in the result contract, but both consumers ignore them.

**Working sibling / contrast:** `/v1/chat/completions` already evaluates `completed`, `failed`, and `partial` together and returns an incomplete/error response instead of silently succeeding.

**Ruled out:** This is not iteration-budget, wall-clock, or cancellation handling. The failure reproduces deterministically by returning an incomplete result dict directly from the agent boundary.

### Fix

- Classify `failed=True`, `completed=False`, or `partial=True` as incomplete at the outer conversation boundary.
- Stamp bypass results with `turn_exit_reason=early_return`, emit one redacted `Turn ended` warning, and close relay instrumentation with a failed outcome.
- Publish `/v1/runs` incomplete results as `run.failed`, preserving redacted error text, partial output, and machine-readable completion flags.
- Add behavior tests for both empty and non-empty partial failures.

## Related Issue

Closes #97278

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `run_agent.py` - diagnose and classify early incomplete returns at the shared outer boundary.
- `gateway/platforms/api_server.py` - map every explicit incomplete result to failed run status and events.
- `tests/run_agent/test_run_agent.py` - verify the terminal log and failed relay outcome.
- `tests/gateway/test_api_server_runs.py` - verify failed status for empty and partial-output results.

## How to Test

1. Return `completed=False` from a mocked conversation and confirm the wrapper logs `Turn ended` and reports a failed relay outcome.
2. Start `/v1/runs` with empty and non-empty incomplete results and poll until the status is terminal.
3. Run:

```bash
scripts/run_tests.sh tests/run_agent/test_run_agent.py -k early_incomplete_return_logs_terminal_failure
scripts/run_tests.sh tests/gateway/test_api_server_runs.py
```

The focused wrapper test passed (1 test), and the full `/v1/runs` file passed (27 tests). A broader `tests/run_agent/test_run_agent.py` run passed 279 tests; its unrelated Anthropic interrupt test could not construct the optional provider because the local environment does not have the `anthropic` package installed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant repository test entry points and documented the results above
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation update: N/A; the behavior contract is covered by code comments and tests
- [x] Config example update: N/A; no config keys changed
- [x] Architecture/workflow docs update: N/A; no architecture or workflow changed
- [x] Cross-platform impact considered: the change is platform-independent result classification
- [x] Tool descriptions/schemas update: N/A; no tool behavior changed

## Screenshots / Logs

N/A; automated status and logging assertions cover the regression.
