### PR TITLE
fix(photon): explain rich-link target_not_allowed fallback and carry error class

### DIFF
--- a/plugins/platforms/photon/README.md
+++ b/plugins/platforms/photon/README.md
@@ -156,6 +156,14 @@ All env vars are documented in `plugin.yaml`. The most important:
   via spectrum-ts' `richlink()` builder so iMessage can render a native link
   preview card. `PHOTON_MARKDOWN=false` reverts to stripped plain text and
   disables rich-link routing.
+
+  Rich-link sends to a chat that has never received a successful outbound
+  message can fail with `Target not allowed for this project` on
+  shared/free-tier Spectrum projects — spectrum-ts enforces the
+  outbound-initiation check on every `richlink()` call. When this happens the
+  adapter falls back to plain text and logs a warning; the first successful
+  outbound send to a target warms it up and rich-link previews work from then
+  on (see #97305).
 - **Reactions (tapbacks) are supported** behind `PHOTON_REACTIONS` (default
   off): the adapter tapbacks 👀 while processing and swaps it for 👍/👎 on
   completion, and a user tapback on a bot-sent message is routed to the agent

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -2503,6 +2503,33 @@ class PhotonAdapter(BasePlatformAdapter):
             data = await self._sidecar_call(
                 "/send-richlink", {"spaceId": space_id, "url": url}
             )
+        except PhotonSidecarError as e:
+            if e.error_class == "target_not_allowed":
+                # Plan limitation, not a transient fault: shared/free-tier
+                # projects may not initiate rich-link conversations with a
+                # never-contacted target (#97305). The message still lands as
+                # plain text via the caller's fallback, and a successful
+                # outbound send warms the target up for future rich links.
+                logger.info(
+                    "[photon] target not warmed for rich-link previews "
+                    "(target_not_allowed) — sending as plain text; rich-link "
+                    "previews should work on future sends to this chat: %s",
+                    e.error,
+                )
+            else:
+                logger.warning(
+                    "[photon] rich-link send failed, falling back to plain text: %s",
+                    e,
+                )
+            return SendResult(
+                success=False,
+                error=str(e),
+                raw_response={
+                    "error_class": e.error_class,
+                    "retryable": e.retryable,
+                },
+                retryable=e.retryable,
+            )
         except Exception as e:
             return SendResult(success=False, error=str(e))
         self._record_sent_message(data.get("messageId"))

--- a/tests/plugins/platforms/photon/test_rich_links.py
+++ b/tests/plugins/platforms/photon/test_rich_links.py
@@ -149,6 +149,46 @@ async def test_direct_url_only_send_falls_back_to_plain_send(
 
 
 @pytest.mark.asyncio
+async def test_target_not_allowed_falls_back_and_reports_error_class(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A target_not_allowed rich-link failure degrades to plain text, and the
+    returned SendResult carries the error class so callers (and the fallback
+    path) can distinguish a plan limitation from a transient fault (#97305)."""
+    monkeypatch.delenv("PHOTON_MARKDOWN", raising=False)
+    adapter = _make_adapter(monkeypatch)
+    calls: List[Tuple[str, Dict[str, Any]]] = []
+
+    async def _fake_call(path: str, body: Dict[str, Any]) -> Dict[str, Any]:
+        calls.append((path, body))
+        if path == "/send-richlink":
+            raise photon_adapter.PhotonSidecarError(
+                path="/send-richlink",
+                status_code=500,
+                error="Target not allowed for this project",
+                error_class="target_not_allowed",
+                retryable=False,
+            )
+        return {"ok": True, "messageId": "plain-msg"}
+
+    adapter._sidecar_call = _fake_call  # type: ignore[assignment]
+
+    result = await adapter.send("+155****4567", _URL)
+
+    assert result.success is True
+    assert result.message_id == "plain-msg"
+    assert calls == [
+        ("/send-richlink", {"spaceId": "+155****4567", "url": _URL}),
+        ("/send", {"spaceId": "+155****4567", "text": _URL}),
+    ]
+    # The richlink attempt itself reported the structured error class.
+    probe = await adapter._sidecar_send_richlink("+155****4567", _URL)
+    assert probe.success is False
+    assert probe.raw_response == {"error_class": "target_not_allowed", "retryable": False}
+    assert probe.retryable is False
+
+
+@pytest.mark.asyncio
 async def test_standalone_url_only_send_routes_to_richlink_endpoint(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

Follow-up to #97305. Rich-link sends to never-contacted targets fail with
`Target not allowed for this project` on shared/free-tier Spectrum projects,
and the adapter's generic warning (`rich-link send failed, falling back to
plain text`) made the plan limitation look like a Hermes routing bug. This PR
makes the failure self-explanatory and documented.

## Changes

**`plugins/platforms/photon/adapter.py` — `_sidecar_send_richlink`**
- Distinguishes `PhotonSidecarError.error_class`:
  - `target_not_allowed` → logs an **info**-level line that says what actually
    happened ("target not warmed for rich-link previews — sending as plain
    text; rich-link previews should work on future sends to this chat")
    instead of a scary warning.
  - anything else → keeps the existing warning.
- Propagates `error_class` / `retryable` onto the returned `SendResult`
  (`raw_response` + `retryable`), mirroring what `_sidecar_send` already does
  for `PhotonSidecarError`, so callers can distinguish a plan limitation from
  a transient fault.

**`plugins/platforms/photon/README.md`**
- Documents the warm-up behavior under the rich-link bullet: never-contacted
  chats can reject `richlink()` sends, the message still lands as plain text,
  and the first successful outbound send warms the target up.

**Tests**
- New `test_target_not_allowed_falls_back_and_reports_error_class`: the
  fallback chain still delivers the URL as plain text, and the richlink
  attempt reports `{"error_class": "target_not_allowed", "retryable": False}`.

## Validation

```
pytest tests/plugins/platforms/photon/test_rich_links.py  → 8 passed
pytest tests/plugins/platforms/photon/                    → 129 passed,
  1 pre-existing failure on pristine main
  (test_spectrum_patch.py::test_sidecar_patch_failure_still_reaches_health_endpoint,
  fails identically without this change in this container)
```

Refs #97305
