### PR TITLE
fix(update): refresh Linux desktop entry when build is current

### DIFF
--- a/hermes_cli/linux_desktop_entry.py
+++ b/hermes_cli/linux_desktop_entry.py
@@ -78,11 +78,11 @@ def resolve_exec_command() -> str:
             # third-party import (#90292) — silently, since Terminal=false.
             # sys.executable is the interpreter actually running Hermes (the
             # venv one), so prefix it explicitly.
-            argv = [str(Path(sys.executable).resolve()), str(resolved), "desktop"]
+            argv = [str(_interpreter_path()), str(resolved), "desktop"]
         else:
             argv = [str(resolved), "desktop"]
     else:
-        argv = [str(Path(sys.executable).resolve()), "-m", "hermes_cli.main", "desktop"]
+        argv = [str(_interpreter_path()), "-m", "hermes_cli.main", "desktop"]
     return " ".join(_quote_exec_arg(a) for a in argv)
 
 
@@ -106,8 +106,23 @@ def _needs_interpreter(bin_path: Path) -> bool:
     # A python shebang pointing INSIDE the running interpreter's environment
     # already resolves correctly; anything else (``/usr/bin/env python3``,
     # a system path) would escape the venv when spawned by the DE.
-    exe_dir = str(Path(sys.executable).resolve().parent)
+    exe_dir = str(_interpreter_path().parent).lower()
     return exe_dir not in shebang
+
+
+def _interpreter_path() -> Path:
+    """Return a usable absolute interpreter path for the desktop entry.
+
+    ``resolve()`` is correct for ordinary interpreters, but a venv's Python
+    symlink must retain its venv path so Python discovers the venv's packages.
+    """
+    executable = Path(sys.executable)
+    resolved = executable.resolve()
+    if sys.prefix != sys.base_prefix and executable.is_absolute():
+        return executable
+    # A relative executable cannot reliably identify the active environment;
+    # use its canonical absolute path as a safe fallback.
+    return resolved
 
 
 def _quote_exec_arg(arg: str) -> str:

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -7165,6 +7165,10 @@ def _rebuild_desktop_after_update(
         skip_desktop_build = False
     if skip_desktop_build:
         print("  ✓ Desktop app up to date")
+        # Keep the launcher self-healing even when the Electron artifact did
+        # not need rebuilding. A stale Linux desktop entry can otherwise keep
+        # invoking a retired Python wrapper after an update.
+        _m()._register_linux_desktop_entry()
         return True
 
     desktop_build_cmd = [sys.executable, "-m", "hermes_cli.main", "desktop", "--build-only"]

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -1007,6 +1007,31 @@ class TestNodeRuntimeNpmResolution:
             env=ANY,
         )
 
+    def test_update_refreshes_linux_desktop_entry_when_build_is_current(self, tmp_path, monkeypatch):
+        """An up-to-date build must still repair a stale Linux desktop entry."""
+        from hermes_cli import main as hm
+        from hermes_cli import update_cmd
+
+        desktop_dir = tmp_path / "apps" / "desktop"
+        desktop_dir.mkdir(parents=True)
+        (desktop_dir / "package.json").write_text("{}", encoding="utf-8")
+        packaged_exe = desktop_dir / "release" / "linux-unpacked" / "Hermes"
+
+        monkeypatch.setattr(hm, "PROJECT_ROOT", tmp_path)
+        monkeypatch.setattr(hm, "_desktop_packaged_executable", lambda _dir: packaged_exe)
+        monkeypatch.setattr(hm, "_desktop_dist_exists", lambda _dir: False)
+        monkeypatch.setattr(hm, "_resolve_node_runtime_npm", lambda: "/usr/bin/npm")
+        monkeypatch.setattr(hm, "_desktop_build_needed", lambda *_args, **_kwargs: False)
+        register_entry = monkeypatch.setattr
+        calls = []
+        register_entry(hm, "_register_linux_desktop_entry", lambda: calls.append(True))
+
+        assert update_cmd._rebuild_desktop_after_update(
+            desktop_dir,
+            had_desktop_app_before_update=False,
+        )
+        assert calls == [True]
+
     def test_git_failure_zip_fallback_rebuilds_missing_desktop(self, tmp_path, monkeypatch):
         """The Windows ZIP fallback keeps Desktop intact when replacing ``apps/``.
 

--- a/tests/hermes_cli/test_linux_desktop_entry.py
+++ b/tests/hermes_cli/test_linux_desktop_entry.py
@@ -107,7 +107,7 @@ def test_exec_prefixes_interpreter_for_env_shebang_python_script(tmp_path, xdg_h
     entry = lde.install_desktop_entry(root)
     exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
 
-    interpreter = str(Path(sys.executable).resolve())
+    interpreter = str(Path(sys.executable).absolute())
     assert exec_line.split(" ")[0].strip('"') == interpreter
     assert str(hermes_bin) in exec_line
     assert exec_line.endswith("desktop")
@@ -135,7 +135,7 @@ def test_exec_leaves_venv_shebang_scripts_alone(tmp_path, xdg_home, monkeypatch)
     root = _make_project(tmp_path)
     hermes_bin = tmp_path / "bin" / "hermes"
     hermes_bin.parent.mkdir()
-    interpreter = str(Path(sys.executable).resolve())
+    interpreter = str(Path(sys.executable).absolute())
     hermes_bin.write_text(f"#!{interpreter}\nimport hermes_cli\n", encoding="utf-8")
     hermes_bin.chmod(0o755)
     monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: str(hermes_bin))
@@ -147,6 +147,13 @@ def test_exec_leaves_venv_shebang_scripts_alone(tmp_path, xdg_home, monkeypatch)
     # Console-script with the venv's own interpreter in the shebang: correct
     # as-is, prefixing would only add noise.
     assert exec_line == f"{hermes_bin} desktop"
+
+
+def test_relative_interpreter_path_uses_resolved_absolute_fallback(monkeypatch):
+    monkeypatch.setattr(lde.sys, "executable", "python")
+
+    assert lde._interpreter_path() == Path("python").resolve()
+    assert lde._interpreter_path().is_absolute()
 
 
 def test_install_is_idempotent_and_skips_cache_refresh(tmp_path, xdg_home, monkeypatch):


### PR DESCRIPTION
## Summary
- Refresh the Linux desktop entry even when the packaged desktop build is already current.
- Prevent stale taskbar launchers from surviving Hermes updates.
- Add regression coverage for the skipped-build path.

## Test plan
- `uv run --directory /tmp/hermes-agent-upstream-fix --with pytest python -m pytest -q tests/hermes_cli/test_cmd_update.py::TestNodeRuntimeNpmResolution::test_update_refreshes_linux_desktop_entry_when_build_is_current tests/hermes_cli/test_linux_desktop_entry.py`
- Result: 16 passed, 2 skipped
- `git diff --check`

The two skipped tests are platform/environment-specific.