### PR TITLE
fix(web_server): restore stdout hijacked by tui_gateway import before READY announcement

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -19797,6 +19797,26 @@ def start_server(
     except Exception as exc:
         _log.debug("exit-flush signal handlers not installed: %s", exc)
 
+    # ── v0.20.5 stdout-hijack regression guard ────────────────────────────
+    # tui_gateway/server.py performs a module-level ``sys.stdout = sys.stderr``
+    # to reserve real stdout for its stdio JSON-RPC protocol. This backend is
+    # an HTTP+WS server (`serve`/`dashboard`) that never speaks that protocol;
+    # importing tui_gateway (for the signal handlers / WS routing above) would
+    # silently divert the ``HERMES_*_READY`` port announcement to stderr. The
+    # desktop only watches child.stdout, so that would hang boot for 90s and
+    # loop. Restore real stdout once the tui_gateway import has settled.
+    if sys.stdout is sys.stderr:
+        restored_stdout = getattr(sys, "__stdout__", None)
+        if restored_stdout is None:
+            try:
+                from tui_gateway import server as _tui_gateway_server_mod
+
+                restored_stdout = getattr(_tui_gateway_server_mod, "_real_stdout", None)
+            except Exception:
+                restored_stdout = None
+        if restored_stdout is not None:
+            sys.stdout = restored_stdout
+
     # ── #93608: machine-readable port-conflict detection ──────────────
     # uvicorn's own bind_socket() would catch the EADDRINUSE and exit 1
     # with a bare ERROR line — indistinguishable from "backend broken".


### PR DESCRIPTION
## Summary

`hermes_cli/web_server.py`'s `start_server()` imports `tui_gateway.server`
(before printing the `HERMES_*_READY` port announcement, for the
`install_exit_flush_signal_handlers` hook). That import has a **global side
effect**: `tui_gateway/server.py` at module scope does

```python
_real_stdout = sys.stdout
sys.stdout = sys.stderr
```

to reserve real stdout for the stdio JSON-RPC protocol. After the import, the
`HERMES_BACKEND_READY` / `HERMES_DASHBOARD_READY` print lands on **stderr** —
but Electron's `waitForDashboardPort()` only reads `child.stdout`. So the
desktop never sees the sentinel, hangs ~90 s, the renderer resets, the backend
is SIGKILL'd (exit 1), and the whole boot loops forever.

The JSON-RPC writer itself reads `_real_stdout` directly
(`StdioTransport(lambda: _real_stdout, …)`), so it is **unaffected** by
restoring `sys.stdout` here. The fix restores real stdout only inside the
HTTP/WS backend (serve/dashboard), once the tui_gateway import has settled.

## Root cause

Introduced by `hermes update` to **v0.20.5**, commit `a588685fb`
(2026-08-26), which added the module-level `sys.stdout = sys.stderr` in
`tui_gateway/server.py`. Still present in current `main` (verified against
`306db2776`).

## Reproduction

```bash
cd "$HERMES_HOME/hermes-agent"
HERMES_HOME="$HOME/.hermes" HERMES_DESKTOP=1 timeout 20 \
  ./venv/Scripts/python.exe -m hermes_cli.main serve --host 127.0.0.1 --port 0 \
  >/tmp/o 2>/tmp/e
grep READY /tmp/o /tmp/e
```

- Bug present: `HERMES_BACKEND_READY` only in `/tmp/e` (stderr).
- Fixed: `HERMES_BACKEND_READY` appears in `/tmp/o` (stdout).

Symptom signature on Windows desktop: `desktop.log` shows the backend printing
`HERMES_BACKEND_READY port=NNNN` followed ~70 s later by
`Desktop boot failed: Timed out waiting for Hermes backend port announcement
(90000ms)` plus `reset requested by renderer`; `gui.log` stops showing
`tui_gateway.ws: ws accepted peer=127.0.0.1:...`.

## Fix

Scoped restoration in `start_server()`, immediately after the
`from tui_gateway.server import install_exit_flush_signal_handlers` block and
before the port-conflict probe:

```python
if sys.stdout is sys.stderr:
    restored_stdout = getattr(sys, "__stdout__", None)
    if restored_stdout is None:
        try:
            from tui_gateway import server as _tui_gateway_server_mod
            restored_stdout = getattr(_tui_gateway_server_mod, "_real_stdout", None)
        except Exception:
            restored_stdout = None
    if restored_stdout is not None:
        sys.stdout = restored_stdout
```

- `sys.__stdout__` preferred, `_real_stdout` fallback (both safe on PyPy / restricted interpreters).
- `if sys.stdout is sys.stderr:` guard → no-op if upstream ever removes the redirect (forward-safe).
- Only runs inside `start_server()` (serve + dashboard), never inside the TUI / gateway stdio JSON-RPC process.

## Test plan

- [ ] `HERMES_*_READY` lands on stdout (not stderr) when launching `serve`/`dashboard` headless.
- [ ] Fresh desktop boot shows `[boot] Hermes backend is ready. Finalizing desktop startup` (previously missing) and the renderer's `tui_gateway.ws: ws accepted` reconnects.
- [ ] TUI / gateway stdio JSON-RPC process unaffected (its writer reads `_real_stdout` directly).
- [ ] `git status` of this branch touches only `hermes_cli/web_server.py`.

## Risk / exclusions

- Does **not** remove the `sys.stdout = sys.stderr` line in `tui_gateway/server.py`: the comment documents a (broad) intent and the TUI test suite monkey-patches `_real_stdout` on that assumption. Deleting it globally risks TUI regressions.
- No new dependencies, no config changes, no migration.
