### PR TITLE
fix(kanban): require explicit specialist routing

### DIFF
--- a/hermes_cli/kanban_decompose.py
+++ b/hermes_cli/kanban_decompose.py
@@ -58,7 +58,6 @@ matching profile from the available roster.
 You will be given:
   - The original task title and body
   - The list of available profiles (each with name + description)
-  - The fallback "default_assignee" used when no profile fits
 
 Output a single JSON object with this exact shape:
 
@@ -69,7 +68,7 @@ Output a single JSON object with this exact shape:
       {
         "title": "<concrete task title, imperative voice, <= 80 chars>",
         "body":  "<detailed spec for the worker on this child task>",
-        "assignee": "<profile name from the roster, or null for default>",
+        "assignee": "<EXACT profile name from the roster>",
         "parents": [<int>, ...]
       },
       ...
@@ -85,8 +84,19 @@ Rules:
   - Use 2-6 tasks for normal work. Don't create 20 tiny tasks. Don't
     cram everything into 1 task.
   - Pick assignees from the roster by matching the task to the profile's
-    DESCRIPTION (not just the name). When nothing matches well, use null
-    and the system will route to the default_assignee.
+    DESCRIPTION (not just the name).
+  - Every child MUST have a non-null assignee equal to an EXACT profile name
+    from the roster. Null, blank, generic "default", or invented names are
+    invalid output.
+  - Route each child to the single best matching named profile based on its
+    main deliverable. For example: code implementation/debugging -> backend;
+    test/runtime/soak execution -> tester; independent audit/acceptance ->
+    reviewer; plan/specification only -> planner.
+  - A task being complex, cross-cutting, uncertain, or dependent on another
+    task is not a reason to avoid specialist routing.
+  - Before returning JSON, verify that implementation, testing, review, and
+    planning tasks use their matching specialist profiles and are not all
+    assigned to one catch-all profile.
   - Each child task body is what a fresh worker will read with no other
     context — be specific about goal, approach, and acceptance criteria.
 
@@ -98,12 +108,12 @@ return:
     "rationale": "<one sentence>",
     "title": "<tightened title>",
     "body":  "<concrete spec for a single worker>",
-    "assignee": "<profile name from the roster, or null for default>"
+    "assignee": "<EXACT profile name from the roster>"
   }
 
 In that case the task stays as one work item, just with a tightened spec and
-a concrete assignee. If no profile fits, use null and the system will route to
-the default_assignee.
+a concrete assignee. Pick the single best matching exact profile name from the
+roster.
 
 No preamble, no closing remarks, no code fences. Output only the JSON object.
 """
@@ -114,10 +124,8 @@ Title: {title}
 Body:
 {body}
 
-Available profiles (assignees you may pick from):
+Available profiles (assignees you must pick from):
 {roster}
-
-Default assignee (used when no profile fits a task): {default_assignee}
 """
 
 
@@ -308,7 +316,6 @@ def decompose_task(
         title=_truncate(task.title or "", 400),
         body=_truncate(task.body or "(no body)", 4000),
         roster=_format_roster(roster),
-        default_assignee=default_assignee,
     )
 
     try:

--- a/tests/hermes_cli/test_kanban_decompose.py
+++ b/tests/hermes_cli/test_kanban_decompose.py
@@ -145,6 +145,15 @@ def test_decompose_fanout_false_invalid_llm_assignee_uses_default(kanban_home):
     assert task.assignee == "fallback"
 
 
+def test_decomposer_prompt_requires_named_specialist_before_null_fallback():
+    prompt = " ".join(decomp._SYSTEM_PROMPT.split())
+    assert "Every child MUST have a non-null assignee" in prompt
+    assert "EXACT profile name from the roster" in prompt
+    assert "implementation, testing, review, and planning tasks use their matching specialist profiles" in prompt
+    assert "or null for default" not in prompt
+    assert "default_assignee" not in decomp._USER_TEMPLATE
+
+
 def test_decompose_returns_false_when_task_not_triage(kanban_home):
     with kb.connect() as conn:
         tid = kb.create_task(conn, title="x")  # ready, not triage


### PR DESCRIPTION
## Problem

The auto-decomposer prompt presents `null` as the normal fallback for every child assignee. The runtime then normalizes null/blank/unknown assignees to `kanban.default_assignee`.

That collapses specialist routing into the fallback profile. In a live board, implementation, runtime-test, and independent-review leaves all returned `null`; after normalization they were assigned to the same default profile.

## Root cause

`hermes_cli/kanban_decompose.py` asks the LLM for:

```json
"assignee": "<profile name from the roster, or null for default>"
```

and repeatedly tells it to use null when no profile fits. `_normalize_assignee_choice()` correctly prevents unassigned work, but therefore maps that output to the default assignee.

## Fix

Keep runtime fallback behavior for malformed model output, but remove null/default as a suggested normal routing option. Require an exact roster profile name and state the intended specialist ownership examples:

- implementation/debugging -> backend
- test/runtime/soak -> tester
- independent audit/acceptance -> reviewer
- plan/specification only -> planner

## Tests

```text
python3 -m pytest tests/hermes_cli/test_kanban_decompose.py -o 'addopts=' -q
4 passed
```

The added regression test checks that the prompt requires a non-null exact roster assignee and no longer exposes `default_assignee` to the decomposer user message.

## Scope

No dispatcher, DB, or fallback-normalization behavior changed. This narrows only the decomposer instruction that caused valid fallback behavior to be used for ordinary specialist work.
