### PR TITLE
fix(desktop): render the three missing canonical auxiliary slots in settings

### DIFF
--- a/apps/desktop/src/app/settings/model-settings.test.tsx
+++ b/apps/desktop/src/app/settings/model-settings.test.tsx
@@ -323,6 +323,10 @@ describe('ModelSettings', () => {
     await renderModelSettings()
 
     expect(await screen.findByText('Vision')).toBeTruthy()
+    // #97297 — the three canonical slots the backend serves must have rows too.
+    expect(screen.getByText('Triage specifier')).toBeTruthy()
+    expect(screen.getByText('Kanban decomposer')).toBeTruthy()
+    expect(screen.getByText('Profile describer')).toBeTruthy()
     expect(screen.getAllByText('auto · use main model').length).toBeGreaterThan(0)
   })
 

--- a/apps/desktop/src/app/settings/model-settings.tsx
+++ b/apps/desktop/src/app/settings/model-settings.tsx
@@ -115,6 +115,11 @@ const AUX_TASKS: readonly AuxTaskMeta[] = [
   { key: 'mcp' },
   { key: 'title_generation' },
   { key: 'review' },
+  // Same three canonical slots the backend serves but the list below used to
+  // omit (#97297): triage_specifier, kanban_decomposer, profile_describer.
+  { key: 'triage_specifier' },
+  { key: 'kanban_decomposer' },
+  { key: 'profile_describer' },
   { key: 'curator' }
 ]
 

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -900,6 +900,18 @@ export const ar = defineLocale({
           label: 'المراجعة',
           hint: 'وكيل المراجعة الفرعي /review'
         },
+        triage_specifier: {
+          label: 'محدد الفرز',
+          hint: 'توضيح مواصفات كانبان'
+        },
+        kanban_decomposer: {
+          label: 'مفكك كانبان',
+          hint: 'تفكيك المهام'
+        },
+        profile_describer: {
+          label: 'واصف الملف الشخصي',
+          hint: 'أوصاف ملفات شخصية تلقائية'
+        },
         curator: {
           label: 'المنسّق',
           hint: 'مراجعة استخدام المهارات'

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1108,6 +1108,9 @@ export const en: Translations = {
         mcp: { label: 'MCP', hint: 'MCP tool routing' },
         title_generation: { label: 'Title gen', hint: 'Session titles' },
         review: { label: 'Review', hint: '/review reviewer subagent' },
+        triage_specifier: { label: 'Triage specifier', hint: 'Kanban spec fleshing' },
+        kanban_decomposer: { label: 'Kanban decomposer', hint: 'Task decomposition' },
+        profile_describer: { label: 'Profile describer', hint: 'Auto profile descriptions' },
         curator: { label: 'Curator', hint: 'Skill-usage review' }
       }
     },

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1012,6 +1012,9 @@ export const ja = defineLocale({
         mcp: { label: 'MCP', hint: 'MCP ツールルーティング' },
         title_generation: { label: 'タイトル生成', hint: 'セッションタイトル' },
         review: { label: 'レビュー', hint: '/review レビューサブエージェント' },
+        triage_specifier: { label: 'トリアージ指定', hint: 'カンバン仕様の具体化' },
+        kanban_decomposer: { label: 'カンバン分解', hint: 'タスク分解' },
+        profile_describer: { label: 'プロファイル記述', hint: 'プロファイル概要の自動生成' },
         curator: { label: 'キュレーター', hint: 'スキル使用レビュー' }
       }
     },

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -977,6 +977,9 @@ export const zhHant = defineLocale({
         mcp: { label: 'MCP', hint: 'MCP 工具路由' },
         title_generation: { label: '標題生成', hint: '工作階段標題' },
         review: { label: '評審', hint: '/review 評審子代理' },
+        triage_specifier: { label: '分類指定', hint: '看板任務規格補全' },
+        kanban_decomposer: { label: '看板分解', hint: '任務拆解' },
+        profile_describer: { label: '設定檔描述', hint: '自動生成設定檔描述' },
         curator: { label: '策展器', hint: '技能使用審查' }
       }
     },

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1302,6 +1302,9 @@ export const zh: Translations = {
         mcp: { label: 'MCP', hint: 'MCP 工具路由' },
         title_generation: { label: '标题生成', hint: '会话标题' },
         review: { label: '评审', hint: '/review 评审子智能体' },
+        triage_specifier: { label: '分类指定', hint: '看板任务规格补全' },
+        kanban_decomposer: { label: '看板分解', hint: '任务拆解' },
+        profile_describer: { label: '配置描述', hint: '自动生成配置描述' },
         curator: { label: '维护器', hint: '技能使用审查' }
       }
     },


### PR DESCRIPTION
## What does this PR do?

Renders the three canonical auxiliary task slots that the Desktop `AUX_TASKS` registry had drifted into omitting: `triage_specifier`, `kanban_decomposer`, and `profile_describer`. The backend (`_AUX_TASK_SLOTS` in `hermes_cli/web_server.py`) serves all 11 slots and the stale-aux warning banner names them, but Settings → Models → Auxiliary models had no row for these three, so the only way to change them in that UI was the broad "Reset all to main". The comment above `AUX_TASKS` already claims it mirrors `_AUX_TASK_SLOTS`; this restores that invariant by adding the missing entries (in backend order, between `review` and `curator`), with localized labels/hints in all five locales (en/ar/ja/zh/zh-hant) mirroring the wording the CLI picker (`_AUX_TASKS` in `hermes_cli/main.py`) already uses for these slots.

This is scoped to the three slots named in the issue — it does not touch `background_review`, which is a separate slot served by a different, in-flight change (#84649).

## Related Issue

Fixes #97297

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/settings/model-settings.tsx` — add `{ key: 'triage_specifier' }`, `{ key: 'kanban_decomposer' }`, `{ key: 'profile_describer' }` to `AUX_TASKS` (backend tuple order), with a comment tying the registry back to `_AUX_TASK_SLOTS`
- `apps/desktop/src/i18n/en.ts` / `ja.ts` / `zh.ts` / `zh-hant.ts` / `ar.ts` — add `label`/`hint` for the three keys in the `settings.models.tasks` map (English wording mirrors the CLI `_AUX_TASKS` display names/descriptions)
- `apps/desktop/src/app/settings/model-settings.test.tsx` — pin the rendered set: the auxiliary-rows test now asserts all three labels are present

## How to Test

1. `cd apps/desktop && npx vitest run --project ui src/app/settings/ src/i18n/`
   - Observed result: 35 test files, 330 tests passed, including the extended `renders the auxiliary task rows` case asserting the `Triage specifier`, `Kanban decomposer`, and `Profile describer` rows render.
2. `cd apps/desktop && npx tsc -p . --noEmit`
   - Observed result: exits 0.
3. Manually: open Desktop → Settings → Models → Auxiliary models — rows for Triage specifier / Kanban decomposer / Profile describer should appear with Change + Set to main actions, and a slot pinned off-main becomes individually reassignable (matches the stale-aux banner that already names `profile_describer`).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — N/A (renderer-only change; ran the desktop suite instead, see How to Test)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
