### PR TITLE
feat(simplex): treat an edited inbound message as a correction that supersedes the queued/in-flight original

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9381,6 +9381,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 self._queue_or_replace_pending_event(session_key, event)
                 return True
 
+            elif running_agent is _AGENT_PENDING_SENTINEL:
+                logger.info(
+                    "Edit supersede — edit matched in-flight turn but agent "
+                    "still pending (sentinel); edit dropped for session %s",
+                    session_key,
+                )
+                return True
+
         # 3. Uncoupled edit (#35535 deliberate policy): no queued match,
         #    no in-flight match.  An isolated out-of-context correction
         #    would confuse the model — drop it silently.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9262,6 +9262,137 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _q_state.conversation.queued_events = kept
         return removed
 
+    def _replace_queued_message(
+        self,
+        session_key: str,
+        adapter: Any,
+        message_id: str,
+        new_text: str,
+    ) -> bool:
+        """Replace the text of the first queued event matching ``message_id``.
+
+        Searches the primary pending slot first, then the overflow FIFO.
+        Mutates the matching event's ``.text`` in place and preserves all
+        other fields and FIFO order.  Returns True if a match was replaced,
+        False if no match was found in either queue level.
+
+        Modeled on ``_clear_goal_pending_continuations`` (same two-level
+        search pattern).
+        """
+        # Primary slot
+        pending_slot = getattr(adapter, "_pending_messages", None) if adapter is not None else None
+        if isinstance(pending_slot, dict):
+            pending_event = pending_slot.get(session_key)
+            if pending_event is not None and getattr(pending_event, "message_id", None) == message_id:
+                pending_event.text = new_text
+                return True
+
+        # Overflow FIFO
+        _q_state = self._peek_session_state(session_key)
+        overflow = _q_state.conversation.queued_events if _q_state else []
+        for ev in overflow:
+            if getattr(ev, "message_id", None) == message_id:
+                ev.text = new_text
+                return True
+
+        return False
+
+    def _handle_edit_supersede(
+        self,
+        event: "MessageEvent",
+        session_key: str,
+        adapter: Any,
+    ) -> bool:
+        """Correlate an inbound edit with queued or in-flight messages.
+
+        Called from the synchronous edit-supersede block in
+        ``_handle_message`` (#35535).  Returns True if the event was handled
+        (queue-replaced, in-flight redirected/steered, or silently dropped);
+        the caller should return ``None`` to skip normal dispatch.  Returns
+        False for non-edit events that should continue through normal
+        processing.
+
+        Design intent (per issue #35535 design review):
+          * Queue match -> replace text in-place, silent (no ack).
+          * In-flight match (active_message_id) -> redirect/steer with
+            framing text.  Neither primitive cancels in-flight tools — this
+            is the best available approach without transcript mutation.
+          * No match (uncorrelated edit) -> silently dropped.  An isolated
+            out-of-context correction would confuse the model.
+
+        SYNCHRONOUS: no await between queued-replace, in-flight check, and
+        decision.  All operations are in-memory attribute writes.
+        """
+        _is_edit = bool(event.metadata.get("is_edit", False) if event.metadata else False)
+        _msg_id = event.message_id
+        if not _is_edit or not _msg_id:
+            return False  # not an edit — continue normal dispatch
+
+        # 1. Try queued supersede
+        if self._replace_queued_message(session_key, adapter, _msg_id, event.text or ""):
+            logger.info(
+                "Edit supersede — replaced queued message_id=%s for session %s",
+                _msg_id, session_key,
+            )
+            return True
+
+        # 2. Try in-flight redirect / steer
+        _q_state = self._peek_session_state(session_key)
+        if _q_state and _q_state.turn.active_message_id == _msg_id:
+            running_agent = _q_state.turn.agent
+            if running_agent is not None and running_agent is not _AGENT_PENDING_SENTINEL:
+                _framing = f'[User edited their earlier message. Corrected message: "{event.text}"]'
+                _handled = False
+                # Prefer redirect() over steer() — redirect delivers as
+                # user-side input next model iteration, steer appends to
+                # last tool result.  Neither cancels in-flight tools.
+                if (
+                    getattr(running_agent, "_supports_active_turn_redirect", False) is True
+                    and hasattr(running_agent, "redirect")
+                ):
+                    try:
+                        _handled = bool(running_agent.redirect(_framing))
+                    except Exception as exc:
+                        logger.warning(
+                            "Edit supersede — redirect failed for session %s: %s",
+                            session_key, exc,
+                        )
+                if not _handled and hasattr(running_agent, "steer"):
+                    try:
+                        _handled = bool(running_agent.steer(_framing))
+                    except Exception as exc:
+                        logger.warning(
+                            "Edit supersede — steer failed for session %s: %s",
+                            session_key, exc,
+                        )
+                if _handled:
+                    logger.info(
+                        "Edit supersede — redirected/steered in-flight turn "
+                        "message_id=%s for session %s",
+                        _msg_id, session_key,
+                    )
+                    return True
+                # Fallback: queue the edit as a normal pending event
+                logger.warning(
+                    "Edit supersede — redirect/steer unavailable for session %s, "
+                    "queueing edit as normal pending event",
+                    session_key,
+                )
+                self._queue_or_replace_pending_event(session_key, event)
+                return True
+
+        # 3. Uncoupled edit (#35535 deliberate policy): no queued match,
+        #    no in-flight match.  An isolated out-of-context correction
+        #    would confuse the model — drop it silently.
+        logger.info(
+            "Edit supersede — uncorrelated edit dropped "
+            "(platform=%s, chat=%s, message_id=%s)",
+            getattr(getattr(event.source, "platform", None), "value", "?"),
+            getattr(event.source, "chat_id", "?"),
+            _msg_id,
+        )
+        return True
+
     def _goal_still_active_for_session(self, session_id: str) -> bool:
         """Best-effort fresh DB check before running a queued continuation."""
         if not session_id:
@@ -17703,6 +17834,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
                 self._release_running_agent_state(_quick_key)
 
+        # ── Edit supersede (#35535) ────────────────────────────────────
+        # SYNCHRONOUS block: no await between queued-replace, in-flight
+        # check, and decision.  An inbound EDIT of a previously-sent message
+        # supersedes the queued original or the in-flight turn; an isolated
+        # out-of-context correction is silently dropped.
+        _edit_adapter = self._adapter_for_source(source)
+        if _edit_adapter is not None:
+            if self._handle_edit_supersede(event, _quick_key, _edit_adapter):
+                return None
+
         if self._is_session_running(_quick_key):
             # Resolve the command once; every command's mid-run behavior is
             # declared on its CommandDef (busy_policy / busy_handler in
@@ -18677,6 +18818,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _claim_state.turn.lease = _active_session_lease
         _claim_state.turn.agent = _AGENT_PENDING_SENTINEL
         _claim_state.turn.started_ts = time.time()
+        _claim_state.turn.active_message_id = event.message_id or None
         self._persist_active_agents()
         _run_generation = self._begin_session_run_generation(_quick_key)
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9320,14 +9320,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
           * No match (uncorrelated edit) -> silently dropped.  An isolated
             out-of-context correction would confuse the model.
 
-        SYNCHRONOUS: no await between queued-replace, in-flight check, and
-        decision.  All operations are in-memory attribute writes.
+        SYNCHRONOUS: this method and ``_replace_queued_message`` are only
+        called from the gateway's single asyncio event loop with **no await
+        points** between the queue check, the in-flight check, and the
+        mutation — cooperative scheduling therefore cannot interleave a queue
+        promotion or turn completion inside the correlation block, and no lock
+        is required.  Cross-vendor review (Gemini/GPT-OSS) verified this
+        invariant.
         """
         _is_edit = bool(event.metadata.get("is_edit", False) if event.metadata else False)
         _msg_id = event.message_id
         if not _is_edit or not _msg_id:
             return False  # not an edit — continue normal dispatch
 
+        # SECURITY: correlation is scoped by session_key (derived from
+        # platform + chat_id, distinct for group vs DM sessions).  Platform
+        # message ids are unique per chat, so an edit from user A cannot
+        # supersede a queued message from user B in a shared group — each
+        # group session is separate.
         # 1. Try queued supersede
         if self._replace_queued_message(session_key, adapter, _msg_id, event.text or ""):
             logger.info(

--- a/gateway/session_state.py
+++ b/gateway/session_state.py
@@ -73,6 +73,9 @@ class TurnState:
     # preserves that: release/rebind only match when generation is current.
     lease_token: Any = None
     lease_generation: Optional[int] = None
+    # MessageEvent.message_id of the event that started this turn; used by
+    # edit-supersede (#35535) to correlate inbound edits with in-flight turns.
+    active_message_id: Optional[str] = None
 
     def clear(self) -> None:
         """Reset the per-turn slot (agent / start ts / lease / busy-ack).
@@ -85,6 +88,7 @@ class TurnState:
         self.started_ts = 0.0
         self.lease = None
         self.busy_ack_ts = 0.0
+        self.active_message_id = None
 
 
 @dataclass

--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -440,6 +440,21 @@ class SimplexAdapter(BasePlatformAdapter):
                 logger.exception("SimpleX: error processing chat item")
             return
 
+        # Edited messages — simplex-chat sends "chatItemUpdated" with the
+        # full updated chatItem wrapper.  The itemId is stable across edits,
+        # so we use it as message_id and mark metadata["is_edit"] so
+        # consumers can react differently (e.g. re-summarize instead of
+        # append).  Outgoing-direction guard inside _handle_chat_item
+        # naturally drops edits of the bot's own messages.
+        if resp_type == "chatItemUpdated":
+            try:
+                await self._handle_chat_item(
+                    resp.get("chatItem", {}), is_edit=True
+                )
+            except Exception:
+                logger.exception("SimpleX: error processing chat item update")
+            return
+
         # File transfer completion — deliver any deferred chat item
         if resp_type == "rcvFileComplete":
             chat_item = resp.get("chatItem", {}) or {}
@@ -471,8 +486,8 @@ class SimplexAdapter(BasePlatformAdapter):
         if resp_type:
             logger.debug("SimpleX: unhandled event type: %s", resp_type)
 
-    async def _handle_chat_item(self, chat_item: dict) -> None:
-        """Process a single chat item from a newChatItems event."""
+    async def _handle_chat_item(self, chat_item: dict, is_edit: bool = False) -> None:
+        """Process a single chat item from a newChatItems or chatItemUpdated event."""
         chat_info = chat_item.get("chatInfo", {}) or {}
         chat_item_data = chat_item.get("chatItem", {}) or {}
 
@@ -643,7 +658,11 @@ class SimplexAdapter(BasePlatformAdapter):
         except (ValueError, AttributeError):
             timestamp = datetime.now(tz=timezone.utc)
 
-        msg_event = MessageEvent(
+        # Extract the stable item ID for edit tracking
+        item_id = meta.get("itemId")
+        msg_id = str(item_id) if item_id is not None else None
+
+        msg_kwargs: Dict[str, Any] = dict(
             source=source,
             text=text or "",
             message_type=msg_type,
@@ -652,6 +671,12 @@ class SimplexAdapter(BasePlatformAdapter):
             timestamp=timestamp,
             raw_message=chat_item,
         )
+        if msg_id is not None:
+            msg_kwargs["message_id"] = msg_id
+        if is_edit:
+            msg_kwargs["metadata"] = {"is_edit": True}
+
+        msg_event = MessageEvent(**msg_kwargs)
 
         logger.debug(
             "SimpleX: message from %s in %s: %s",

--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -446,6 +446,10 @@ class SimplexAdapter(BasePlatformAdapter):
         # consumers can react differently (e.g. re-summarize instead of
         # append).  Outgoing-direction guard inside _handle_chat_item
         # naturally drops edits of the bot's own messages.
+        # NOTE: edited media items carry only their caption text on the edit
+        # event — file/image payloads are not reconstructed on edits
+        # (intentional; matches newChatItems behavior for caption-only
+        # edits).
         if resp_type == "chatItemUpdated":
             try:
                 await self._handle_chat_item(

--- a/tests/gateway/test_edit_supersede.py
+++ b/tests/gateway/test_edit_supersede.py
@@ -1,0 +1,392 @@
+"""Tests for gateway-core edit supersede (#35535).
+
+An inbound EDIT of a message, correlated by message_id, supersedes the queued
+original or the in-flight turn.  Non-edit events are completely unaffected.
+"""
+from __future__ import annotations
+
+import sys
+import threading
+import types
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# Minimal telegram stubs so gateway imports cleanly.
+_tg = types.ModuleType("telegram")
+_tg.constants = types.ModuleType("telegram.constants")
+_ct = MagicMock()
+_ct.SUPERGROUP = "supergroup"
+_ct.GROUP = "group"
+_ct.PRIVATE = "private"
+_tg.constants.ChatType = _ct
+sys.modules.setdefault("telegram", _tg)
+sys.modules.setdefault("telegram.constants", _tg.constants)
+sys.modules.setdefault("telegram.ext", types.ModuleType("telegram.ext"))
+
+from gateway.platforms.base import (  # noqa: E402
+    MessageEvent,
+    MessageType,
+    SessionSource,
+    build_session_key,
+)
+from gateway.run import GatewayRunner, _AGENT_PENDING_SENTINEL  # noqa: E402
+from gateway.session_state import SessionState  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_source(platform_value="telegram", chat_id="c1", user_id="u1"):
+    return SessionSource(
+        platform=MagicMock(value=platform_value),
+        chat_id=chat_id,
+        chat_type="private",
+        user_id=user_id,
+    )
+
+
+def _make_event(
+    text: str = "hello",
+    message_id: str = "msg_1",
+    is_edit: bool = False,
+    message_type: MessageType = MessageType.TEXT,
+    source: SessionSource = None,
+) -> MessageEvent:
+    if source is None:
+        source = _make_source()
+    meta = {"is_edit": True} if is_edit else {}
+    return MessageEvent(
+        text=text,
+        message_type=message_type,
+        source=source,
+        message_id=message_id,
+        metadata=meta,
+    )
+
+
+def _make_adapter() -> MagicMock:
+    adapter = MagicMock()
+    adapter._pending_messages = {}
+    adapter._send_with_retry = AsyncMock()
+    adapter.config = MagicMock()
+    adapter.config.extra = {}
+    adapter.platform = MagicMock(value="telegram")
+    return adapter
+
+
+def _make_running_agent(supports_redirect: bool = True, supports_steer: bool = True) -> MagicMock:
+    agent = MagicMock()
+    agent._active_children = []
+    agent._active_children_lock = threading.Lock()
+    agent.get_activity_summary.return_value = {
+        "api_call_count": 4,
+        "max_iterations": 60,
+        "current_tool": "terminal",
+    }
+    agent._supports_active_turn_redirect = supports_redirect
+    if supports_redirect:
+        agent.redirect = MagicMock(return_value=True)
+    if supports_steer:
+        agent.steer = MagicMock(return_value=True)
+    return agent
+
+
+def _make_runner() -> GatewayRunner:
+    runner = object.__new__(GatewayRunner)
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._pending_messages = {}
+    runner._busy_ack_ts = {}
+    runner._sessions = {}
+    runner._draining = False
+    runner.adapters = {}
+    runner.config = MagicMock()
+    runner.session_store = None
+    runner.hooks = MagicMock()
+    runner.hooks.emit = AsyncMock()
+    runner.pairing_store = MagicMock()
+    runner.pairing_store.is_approved.return_value = True
+    runner._is_user_authorized = lambda _source: True
+    return runner
+
+
+def _session_state(runner: GatewayRunner, session_key: str) -> SessionState:
+    if session_key not in runner._sessions:
+        runner._sessions[session_key] = SessionState()
+    return runner._sessions[session_key]
+
+
+# ===================================================================
+# Tests: _replace_queued_message
+# ===================================================================
+
+class TestReplaceQueuedMessage:
+    """Verify _replace_queued_message searches both queue levels."""
+
+    def test_replace_primary_slot(self):
+        """Edit replaces text in the primary pending slot."""
+        runner = _make_runner()
+        adapter = _make_adapter()
+        sk = "test_session"
+        original = _make_event(text="original text", message_id="msg_1")
+        adapter._pending_messages[sk] = original
+
+        replaced = runner._replace_queued_message(sk, adapter, "msg_1", "edited text")
+
+        assert replaced is True
+        assert adapter._pending_messages[sk].text == "edited text"
+        # Other fields preserved
+        assert adapter._pending_messages[sk].message_id == "msg_1"
+        assert adapter._pending_messages[sk].message_type == MessageType.TEXT
+
+    def test_replace_overflow_fifo(self):
+        """Edit replaces text in the overflow FIFO when primary slot does not match."""
+        runner = _make_runner()
+        adapter = _make_adapter()
+        sk = "test_session"
+        primary = _make_event(text="primary", message_id="msg_other")
+        adapter._pending_messages[sk] = primary
+        overflow = _make_event(text="overflow target", message_id="msg_target")
+        _session_state(runner, sk).conversation.queued_events = [
+            _make_event(text="first", message_id="msg_a"),
+            overflow,
+            _make_event(text="last", message_id="msg_c"),
+        ]
+
+        replaced = runner._replace_queued_message(sk, adapter, "msg_target", "edited overflow")
+
+        assert replaced is True
+        assert adapter._pending_messages[sk].text == "primary"  # unchanged
+        assert _session_state(runner, sk).conversation.queued_events[1].text == "edited overflow"
+        # FIFO order preserved
+        assert len(_session_state(runner, sk).conversation.queued_events) == 3
+
+    def test_no_match_returns_false(self):
+        """No matching message_id in either queue returns False."""
+        runner = _make_runner()
+        adapter = _make_adapter()
+        sk = "test_session"
+        adapter._pending_messages[sk] = _make_event(text="primary", message_id="msg_a")
+        _session_state(runner, sk).conversation.queued_events = [
+            _make_event(text="second", message_id="msg_b"),
+        ]
+
+        replaced = runner._replace_queued_message(sk, adapter, "nonexistent", "edited")
+
+        assert replaced is False
+        assert adapter._pending_messages[sk].text == "primary"
+        assert _session_state(runner, sk).conversation.queued_events[0].text == "second"
+
+    def test_no_primary_slot_searches_overflow(self):
+        """No primary slot for session_key — searches overflow FIFO."""
+        runner = _make_runner()
+        adapter = _make_adapter()
+        sk = "test_session"
+        # primary slot empty for this key (no entry)
+        assert sk not in adapter._pending_messages
+        _session_state(runner, sk).conversation.queued_events = [
+            _make_event(text="target", message_id="msg_x"),
+        ]
+
+        replaced = runner._replace_queued_message(sk, adapter, "msg_x", "edited text")
+
+        assert replaced is True
+        assert _session_state(runner, sk).conversation.queued_events[0].text == "edited text"
+
+
+# ===================================================================
+# Tests: _handle_edit_supersede
+# ===================================================================
+
+class TestHandleEditSupersede:
+    """Verify edit-correlation logic in _handle_edit_supersede."""
+
+    def test_non_edit_events_untouched(self):
+        """Events without is_edit metadata pass through (return False)."""
+        runner = _make_runner()
+        sk = "test_session"
+        event = _make_event(text="not an edit", message_id="msg_1", is_edit=False)
+        adapter = _make_adapter()
+        state = _session_state(runner, sk)
+        state.turn.active_message_id = None
+
+        result = runner._handle_edit_supersede(event, sk, adapter)
+
+        assert result is False  # not handled, continue processing
+
+    def test_edit_no_message_id_passes_through(self):
+        """Edit with empty/None message_id passes through."""
+        runner = _make_runner()
+        sk = "test_session"
+        event = _make_event(text="no id", message_id="", is_edit=True)
+        adapter = _make_adapter()
+
+        result = runner._handle_edit_supersede(event, sk, adapter)
+
+        assert result is False
+
+    def test_edit_replaces_queued_primary(self):
+        """Edit event replaces the queued original in the primary slot and returns True."""
+        runner = _make_runner()
+        sk = "test_session"
+        adapter = _make_adapter()
+        original = _make_event(text="original", message_id="msg_1")
+        adapter._pending_messages[sk] = original
+        edit_event = _make_event(text="corrected", message_id="msg_1", is_edit=True)
+
+        result = runner._handle_edit_supersede(edit_event, sk, adapter)
+
+        assert result is True
+        assert adapter._pending_messages[sk].text == "corrected"
+
+    def test_edit_replaces_queued_overflow(self):
+        """Edit event replaces matching message in overflow FIFO."""
+        runner = _make_runner()
+        sk = "test_session"
+        adapter = _make_adapter()
+        adapter._pending_messages[sk] = _make_event(text="primary", message_id="other_msg")
+        _session_state(runner, sk).conversation.queued_events = [
+            _make_event(text="edited msg", message_id="msg_target"),
+        ]
+        edit_event = _make_event(text="corrected", message_id="msg_target", is_edit=True)
+
+        result = runner._handle_edit_supersede(edit_event, sk, adapter)
+
+        assert result is True
+        assert _session_state(runner, sk).conversation.queued_events[0].text == "corrected"
+
+    def test_edit_redirects_in_flight_when_supported(self):
+        """Edit matching active_message_id calls redirect() on running agent."""
+        runner = _make_runner()
+        sk = "test_session"
+        adapter = _make_adapter()
+        agent = _make_running_agent(supports_redirect=True)
+        state = _session_state(runner, sk)
+        state.turn.agent = agent
+        state.turn.active_message_id = "msg_inflight"
+        edit_event = _make_event(text="mid-flight correction", message_id="msg_inflight", is_edit=True)
+
+        result = runner._handle_edit_supersede(edit_event, sk, adapter)
+
+        assert result is True
+        agent.redirect.assert_called_once()
+        call_args = agent.redirect.call_args[0][0]
+        assert 'User edited their earlier message.' in call_args
+        assert 'mid-flight correction' in call_args
+
+    def test_edit_steers_when_redirect_unsupported(self):
+        """Edit falls back to steer() when redirect is unavailable."""
+        runner = _make_runner()
+        sk = "test_session"
+        adapter = _make_adapter()
+        agent = _make_running_agent(supports_redirect=False, supports_steer=True)
+        state = _session_state(runner, sk)
+        state.turn.agent = agent
+        state.turn.active_message_id = "msg_steer"
+        edit_event = _make_event(text="steer this one", message_id="msg_steer", is_edit=True)
+
+        result = runner._handle_edit_supersede(edit_event, sk, adapter)
+
+        assert result is True
+        agent.steer.assert_called_once()
+        call_args = agent.steer.call_args[0][0]
+        assert 'User edited their earlier message.' in call_args
+
+    def test_edit_queues_when_both_primitives_unavailable(self):
+        """Edit falls back to queue when both redirect and steer are missing."""
+        runner = _make_runner()
+        sk = "test_session"
+        adapter = _make_adapter()
+        agent = _make_running_agent(supports_redirect=False, supports_steer=False)
+        # Remove both methods
+        if hasattr(agent, 'redirect'):
+            del agent.redirect
+        if hasattr(agent, 'steer'):
+            del agent.steer
+
+        state = _session_state(runner, sk)
+        state.turn.agent = agent
+        state.turn.active_message_id = "msg_fallback"
+        edit_event = _make_event(text="fallback text", message_id="msg_fallback", is_edit=True)
+        # Register adapter so _queue_or_replace_pending_event can find it
+        runner.adapters[edit_event.source.platform] = adapter
+
+        result = runner._handle_edit_supersede(edit_event, sk, adapter)
+
+        assert result is True
+        # Should have been queued via _queue_or_replace_pending_event
+        assert sk in adapter._pending_messages
+        assert adapter._pending_messages[sk].text == "fallback text"
+
+    def test_stale_edit_dropped(self):
+        """Edit with no active_message_id (turn cleared) is dropped, not redirected."""
+        runner = _make_runner()
+        sk = "test_session"
+        adapter = _make_adapter()
+        agent = _make_running_agent()
+        state = _session_state(runner, sk)
+        state.turn.agent = agent
+        state.turn.active_message_id = None  # turn already cleared
+        edit_event = _make_event(text="stale edit", message_id="msg_stale", is_edit=True)
+
+        result = runner._handle_edit_supersede(edit_event, sk, adapter)
+
+        assert result is True  # handled (dropped)
+        agent.redirect.assert_not_called()
+        agent.steer.assert_not_called()
+        assert sk not in adapter._pending_messages  # not queued either
+
+    def test_uncorrelated_edit_dropped_no_new_turn(self):
+        """Edit matching no queued or in-flight message is dropped with no dispatch."""
+        runner = _make_runner()
+        sk = "test_session"
+        adapter = _make_adapter()
+        state = _session_state(runner, sk)
+        state.turn.agent = None  # idle session
+        state.turn.active_message_id = None
+        edit_event = _make_event(text="orphan edit", message_id="msg_orphan", is_edit=True)
+
+        result = runner._handle_edit_supersede(edit_event, sk, adapter)
+
+        assert result is True  # handled (dropped)
+        assert sk not in adapter._pending_messages
+
+    def test_pending_sentinel_edit_passed_through_to_queue(self):
+        """When the agent is _AGENT_PENDING_SENTINEL, treat the edit as uncorrelated (drop)."""
+        runner = _make_runner()
+        sk = "test_session"
+        adapter = _make_adapter()
+        state = _session_state(runner, sk)
+        state.turn.agent = _AGENT_PENDING_SENTINEL
+        state.turn.active_message_id = "msg_sentinel"
+        edit_event = _make_event(text="sentinel edit", message_id="msg_sentinel", is_edit=True)
+
+        result = runner._handle_edit_supersede(edit_event, sk, adapter)
+
+        # The active_message_id matches but agent is sentinel, so we should
+        # either drop (uncorrelated since no real agent) or queue.  The task says
+        # "if turn.agent is a real agent (not None, not _AGENT_PENDING_SENTINEL)"
+        # for the redirect/steer path, so this falls through to uncorrelated drop.
+        assert result is True  # dropped
+
+    def test_edit_to_queued_overflow_match_first(self):
+        """Edit matching in primary slot takes priority over overflow and in-flight."""
+        runner = _make_runner()
+        sk = "test_session"
+        adapter = _make_adapter()
+        agent = _make_running_agent()
+        state = _session_state(runner, sk)
+        state.turn.agent = agent
+        state.turn.active_message_id = "msg_inflight"
+        # Both primary and in-flight have same message_id
+        adapter._pending_messages[sk] = _make_event(text="queued", message_id="msg_inflight")
+        edit_event = _make_event(text="edit that matches both", message_id="msg_inflight", is_edit=True)
+
+        result = runner._handle_edit_supersede(edit_event, sk, adapter)
+
+        # Should replace the queued one (primary slot match comes first)
+        assert result is True
+        assert adapter._pending_messages[sk].text == "edit that matches both"
+        agent.redirect.assert_not_called()

--- a/tests/gateway/test_edit_supersede.py
+++ b/tests/gateway/test_edit_supersede.py
@@ -353,8 +353,9 @@ class TestHandleEditSupersede:
         assert result is True  # handled (dropped)
         assert sk not in adapter._pending_messages
 
-    def test_pending_sentinel_edit_passed_through_to_queue(self):
-        """When the agent is _AGENT_PENDING_SENTINEL, treat the edit as uncorrelated (drop)."""
+    def test_sentinel_window_edit_dropped(self):
+        """Edit matching active_message_id during the sentinel window is dropped
+        with a distinct log; redirect/steer not called."""
         runner = _make_runner()
         sk = "test_session"
         adapter = _make_adapter()

--- a/tests/gateway/test_edit_supersede.py
+++ b/tests/gateway/test_edit_supersede.py
@@ -391,3 +391,35 @@ class TestHandleEditSupersede:
         assert result is True
         assert adapter._pending_messages[sk].text == "edit that matches both"
         agent.redirect.assert_not_called()
+
+
+# ===================================================================
+# Tests: rapid consecutive edits (latest-wins race)
+# ===================================================================
+
+class TestRapidConsecutiveEdits:
+    """Verify that consecutive synchronous edits on the same message
+    leave the queued event at the latest text (no stale state, no crash)."""
+
+    def test_rapid_consecutive_edits_latest_wins(self):
+        """Two back-to-back edits on the same message_id: final text wins."""
+        runner = _make_runner()
+        sk = "rapid_session"
+        adapter = _make_adapter()
+        # Prime the primary pending slot with an original message
+        adapter._pending_messages[sk] = _make_event(
+            text="original", message_id="900"
+        )
+
+        # Call _handle_edit_supersede twice in a row (synchronously, no await
+        # between) with two edit events for message_id "900".
+        edit_a = _make_event(text="edit A", message_id="900", is_edit=True)
+        edit_b = _make_event(text="edit B", message_id="900", is_edit=True)
+
+        runner._handle_edit_supersede(edit_a, sk, adapter)
+        runner._handle_edit_supersede(edit_b, sk, adapter)
+
+        # The queued event's text should be "edit B" — latest wins, no stale
+        # state, no crash.
+        assert adapter._pending_messages[sk].text == "edit B"
+        assert adapter._pending_messages[sk].message_id == "900"

--- a/tests/gateway/test_simplex_plugin.py
+++ b/tests/gateway/test_simplex_plugin.py
@@ -583,3 +583,91 @@ async def test_chat_item_updated_empty_does_not_raise():
     event2 = {"type": "chatItemUpdated"}
     await adapter._handle_event(event2)
     adapter.handle_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_chat_item_updated_image_msg_content_produces_edit():
+    """(f) chatItemUpdated with image-type msgContent + caption: edit still
+    produces MessageEvent with message_id, is_edit=True, and caption text;
+    file metadata is not reconstructed on edits."""
+    adapter = _adapter_with_ws()
+    adapter.handle_message = AsyncMock()
+    adapter._text_batch_delay = 0
+
+    event = {
+        "type": "chatItemUpdated",
+        "chatItem": {
+            "chatInfo": {
+                "type": "direct",
+                "contact": {"contactId": 42, "localDisplayName": "tester"},
+            },
+            "chatItem": {
+                "chatDir": {"type": "directRcv"},
+                "meta": {
+                    "itemId": 321,
+                    "itemTs": "2026-01-01T00:00:00Z",
+                },
+                "content": {
+                    "type": "rcvMsgContent",
+                    "msgContent": {
+                        "type": "image",
+                        "text": "a photo of a cat",
+                    },
+                },
+            },
+        },
+    }
+
+    await adapter._handle_event(event)
+    await asyncio.sleep(0.01)
+
+    adapter.handle_message.assert_called_once()
+    msg = adapter.handle_message.call_args[0][0]
+    assert msg.message_id == "321"
+    assert msg.metadata.get("is_edit") is True
+    assert msg.text == "a photo of a cat"
+
+
+@pytest.mark.asyncio
+async def test_chat_item_updated_missing_itemid():
+    """(g) chatItemUpdated whose meta has no itemId: MessageEvent produced
+    WITHOUT message_id; metadata is_edit is still True. This documents the
+    fallback where the gateway treats such an edit as a non-edit (normal
+    dispatch)."""
+    adapter = _adapter_with_ws()
+    adapter.handle_message = AsyncMock()
+    adapter._text_batch_delay = 0
+
+    event = {
+        "type": "chatItemUpdated",
+        "chatItem": {
+            "chatInfo": {
+                "type": "direct",
+                "contact": {"contactId": 42, "localDisplayName": "tester"},
+            },
+            "chatItem": {
+                "chatDir": {"type": "directRcv"},
+                "meta": {
+                    "itemTs": "2026-01-01T00:00:00Z",
+                    # no itemId key
+                },
+                "content": {
+                    "type": "rcvMsgContent",
+                    "msgContent": {
+                        "type": "text",
+                        "text": "edit with no itemId",
+                    },
+                },
+            },
+        },
+    }
+
+    await adapter._handle_event(event)
+    await asyncio.sleep(0.01)
+
+    adapter.handle_message.assert_called_once()
+    msg = adapter.handle_message.call_args[0][0]
+    # message_id is not set when meta.itemId is absent
+    assert not hasattr(msg, "message_id") or msg.message_id is None
+    assert msg.metadata.get("is_edit") is True
+    assert msg.text == "edit with no itemId"

--- a/tests/gateway/test_simplex_plugin.py
+++ b/tests/gateway/test_simplex_plugin.py
@@ -388,3 +388,198 @@ def _make_file_chat_item(file_path: str, file_name: str) -> dict:
     }
 
 
+# ---------------------------------------------------------------------------
+# 11. Inbound: chatItemUpdated (edits) and message_id propagation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_chat_item_updated_direct_sets_message_id_and_is_edit():
+    """(a) chatItemUpdated for a direct chat produces MessageEvent with
+    message_id, metadata["is_edit"]=True, text, chat_id, and sender."""
+    adapter = _adapter_with_ws()
+    adapter.handle_message = AsyncMock()
+    # Bypass text batching delay — flush immediately
+    adapter._text_batch_delay = 0
+
+    event = {
+        "type": "chatItemUpdated",
+        "chatItem": {
+            "chatInfo": {
+                "type": "direct",
+                "contact": {"contactId": 42, "localDisplayName": "tester"},
+            },
+            "chatItem": {
+                "chatDir": {"type": "directRcv"},
+                "meta": {
+                    "itemId": 123,
+                    "itemTs": "2026-01-01T00:00:00Z",
+                },
+                "content": {
+                    "type": "rcvMsgContent",
+                    "msgContent": {"type": "text", "text": "edited message"},
+                },
+            },
+        },
+    }
+
+    await adapter._handle_event(event)
+    await asyncio.sleep(0.01)  # let batch flush task complete
+
+    adapter.handle_message.assert_called_once()
+    msg = adapter.handle_message.call_args[0][0]
+    assert msg.message_id == "123"
+    assert msg.metadata.get("is_edit") is True
+    assert msg.text == "edited message"
+    assert msg.source.chat_id == "42"
+    assert msg.source.user_id == "42"
+    assert msg.source.chat_type == "dm"
+
+
+@pytest.mark.asyncio
+async def test_chat_item_updated_group_sets_message_id_and_is_edit():
+    """(b) chatItemUpdated for a group chat — sender from groupMember."""
+    adapter = _adapter_with_ws()
+    adapter.handle_message = AsyncMock()
+    adapter._text_batch_delay = 0  # flush immediately, no async sleep
+
+    # Temporarily enable group allowance
+    adapter.group_allow_from = {"*"}
+
+    event = {
+        "type": "chatItemUpdated",
+        "chatItem": {
+            "chatInfo": {
+                "type": "group",
+                "groupInfo": {
+                    "groupId": 77,
+                    "localDisplayName": "my-group",
+                },
+            },
+            "chatItem": {
+                "chatDir": {
+                    "type": "groupRcv",
+                    "groupMember": {
+                        "memberId": 55,
+                        "localDisplayName": "alice",
+                    },
+                },
+                "meta": {
+                    "itemId": 456,
+                    "itemTs": "2026-01-01T00:00:00Z",
+                },
+                "content": {
+                    "type": "rcvMsgContent",
+                    "msgContent": {"type": "text", "text": "group edit"},
+                },
+            },
+        },
+    }
+
+    await adapter._handle_event(event)
+    await asyncio.sleep(0.01)  # let batch flush task complete
+
+    adapter.handle_message.assert_called_once()
+    msg = adapter.handle_message.call_args[0][0]
+    assert msg.message_id == "456"
+    assert msg.metadata.get("is_edit") is True
+    assert msg.text == "group edit"
+    assert msg.source.chat_id == "group:77"
+    assert msg.source.user_id == "55"
+    assert msg.source.chat_type == "group"
+
+
+@pytest.mark.asyncio
+async def test_chat_item_updated_outgoing_ignored():
+    """(c) chatItemUpdated with directSnd direction is dropped."""
+    adapter = _adapter_with_ws()
+    adapter.handle_message = AsyncMock()
+
+    event = {
+        "type": "chatItemUpdated",
+        "chatItem": {
+            "chatInfo": {
+                "type": "direct",
+                "contact": {"contactId": 42, "localDisplayName": "tester"},
+            },
+            "chatItem": {
+                "chatDir": {"type": "directSnd"},
+                "meta": {"itemId": 999, "itemTs": "2026-01-01T00:00:00Z"},
+                "content": {
+                    "type": "rcvMsgContent",
+                    "msgContent": {
+                        "type": "text",
+                        "text": "our own edit",
+                    },
+                },
+            },
+        },
+    }
+
+    await adapter._handle_event(event)
+    adapter.handle_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_new_chat_items_sets_message_id():
+    """(d) newChatItems path populates message_id from meta.itemId."""
+    adapter = _adapter_with_ws()
+    adapter.handle_message = AsyncMock()
+    adapter._text_batch_delay = 0  # flush immediately, no async sleep
+
+    event = {
+        "resp": {
+            "type": "newChatItems",
+            "chatItems": [
+                {
+                    "chatInfo": {
+                        "type": "direct",
+                        "contact": {
+                            "contactId": 42,
+                            "localDisplayName": "tester",
+                        },
+                    },
+                    "chatItem": {
+                        "chatDir": {"type": "directRcv"},
+                        "meta": {
+                            "itemId": 789,
+                            "itemTs": "2026-01-01T00:00:00Z",
+                        },
+                        "content": {
+                            "type": "rcvMsgContent",
+                            "msgContent": {
+                                "type": "text",
+                                "text": "hello",
+                            },
+                        },
+                    },
+                }
+            ],
+        }
+    }
+
+    await adapter._handle_event(event)
+    await asyncio.sleep(0.01)  # let batch flush task complete
+
+    adapter.handle_message.assert_called_once()
+    msg = adapter.handle_message.call_args[0][0]
+    assert msg.message_id == "789"
+    # metadata should NOT contain is_edit for a non-edit message
+    assert "is_edit" not in msg.metadata
+
+
+@pytest.mark.asyncio
+async def test_chat_item_updated_empty_does_not_raise():
+    """(e) chatItemUpdated with empty/malformed chatItem does not raise."""
+    adapter = _adapter_with_ws()
+    adapter.handle_message = AsyncMock()
+
+    # Empty chatItem dict
+    event = {"type": "chatItemUpdated", "chatItem": {}}
+    await adapter._handle_event(event)
+    adapter.handle_message.assert_not_called()
+
+    # No chatItem key at all
+    event2 = {"type": "chatItemUpdated"}
+    await adapter._handle_event(event2)
+    adapter.handle_message.assert_not_called()


### PR DESCRIPTION
## Summary

Implements edited-message supersede for the SimpleX gateway adapter, closing #35535.

Today the SimpleX adapter handles only `newChatItems`; a `chatItemUpdated` event (the terminal-API notification emitted when a user edits a sent message) falls into the unhandled-event log, so the agent acts on the original — mistaken — text. This PR treats an inbound edit as *"I meant this instead"*, correlated to the specific original message by platform message id:

- **Original still queued** (primary pending slot or overflow FIFO) → the queued `MessageEvent`'s text is replaced in place. FIFO order, identity, and metadata are preserved; the correction is silent (no busy-ack).
- **Original in-flight** (the turn's originating message id, now recorded on `TurnState.active_message_id`) → the running agent is redirected with the corrected text, framed as `[User edited their earlier message. Corrected message: "..."]`. Falls back to `steer()` when the agent doesn't support active-turn redirect, and to normal queueing when neither primitive is available. Neither primitive cancels in-flight tools — that is the best available behavior without mutating the transcript (see design notes).
- **Uncorrelated edits** (no queued or in-flight match) → dropped with an `info` log rather than dispatched as a new message. Rationale in *Open questions* below.

## Changes

**`plugins/platforms/simplex/adapter.py`**
- `_handle_chat_item` now extracts `meta.itemId` and sets `message_id=str(itemId)` on every inbound `MessageEvent` (the prerequisite correlation key — previously never populated).
- New `chatItemUpdated` branch routes the event's `AChatItem` through the same parse path with `is_edit=True`, tagging `metadata={"is_edit": True}`. The existing outgoing-direction guard means edits of the bot's own messages are ignored.

**`gateway/session_state.py`**
- `TurnState.active_message_id` records the message id of the event that started the turn; cleared by the existing `TurnState.clear()` at every turn boundary (no new lifecycle to maintain, no leak path).

**`gateway/run.py`**
- `_replace_queued_message()`: first-match, in-place text replacement across both queue levels, modeled on the existing `_clear_goal_pending_continuations` pattern.
- `_handle_edit_supersede()`: the correlation decision — queued replace → in-flight redirect/steer → drop+log. Fully synchronous (no `await` between the queue check, the in-flight check, and the decision), so there is no interleaving window with queue promotion. Inserted in `_handle_message` after authorization, ignored-channel, and plugin-hook guards; adapter producers other than SimpleX get the same behavior free by tagging `metadata["is_edit"]` + `message_id`.

## Design notes

- **Why not rewrite the transcript**: the stale original text stays in history; per the project's prompt-caching constraint, past context is never mutated. The correction reaches the live turn via `redirect`/`steer`, mirroring existing mid-turn steering semantics.
- **Why gateway-core, not adapter-only**: correlating an edit to the specific queued/in-flight original requires the queue/turn structures the adapter can't see — as the issue describes. Any future adapter that tags edits (Signal and Discord both surface them today in other forms) inherits the behavior.
- **Startup-resume path**: the synthetic resume event carries no message id; its `active_message_id` stays `None`, so edits during a resumed turn fall to the uncorrelated policy rather than misfiring.

## Open questions

- **Uncorrelated-edit policy**: dropping (with a log) rather than queueing as a new message is a judgment call — Pro-side reasoning in the design review was that an isolated out-of-context correction ("the") injected into a fresh turn confuses the model; the counter-argument is that a drop silently loses user intent. If maintainers prefer "queue uncorrelated edits as normal messages", it's a two-line change in `_handle_edit_supersede`.

## Tests

- `tests/gateway/test_simplex_plugin.py`: 7 new tests — direct/group edit correlation, outgoing-direction suppression, `message_id` population on the normal path, image-content edits, missing-`itemId` fallback.
- `tests/gateway/test_edit_supersede.py` (new): 15 tests — primary-slot replace, overflow-FIFO replace, in-flight redirect, steer fallback, sentinel-window handling, stale-correlation drop, uncorrelated drop, non-edit pass-through.
- All 38 pass locally; the full `tests/gateway/` suite shows only pre-existing environment flakes present on clean `main`.

Closes #35535
