### PR TITLE
fix(desktop): exempt the main alias from the stale-aux banner

### DIFF
--- a/apps/desktop/src/app/settings/model-settings.test.tsx
+++ b/apps/desktop/src/app/settings/model-settings.test.tsx
@@ -409,6 +409,27 @@ describe('ModelSettings', () => {
     // Banner present on load, no switch required.
     expect(await screen.findByText(/still run on/)).toBeTruthy()
   })
+
+  it('does not flag an aux slot pinned to the main alias as stale', async () => {
+    // `main` is a valid backend alias meaning "follow the current main
+    // provider" (e.g. Moonshot's guide configures auxiliary.vision.provider:
+    // main). It resolves to the main model, so it must not trip the stale-aux
+    // banner. #97310
+    getAuxiliaryModels.mockResolvedValueOnce({
+      main: { provider: 'nous', model: 'hermes-4' },
+      tasks: [{ task: 'vision', provider: 'main', model: 'kimi-k3', base_url: '' }]
+    })
+
+    await renderModelSettings()
+
+    // Wait for the aux data to load and the task rows to render before
+    // asserting the banner is absent — otherwise the assertion runs before
+    // the async load resolves and passes vacuously.
+    await screen.findAllByRole('button', { name: 'Set to main' })
+
+    // No banner on load — `main` correctly follows the main model.
+    expect(screen.queryByText(/still run on/)).toBeNull()
+  })
 })
 
 describe('ModelSettings MoA preset editor', () => {

--- a/apps/desktop/src/app/settings/model-settings.tsx
+++ b/apps/desktop/src/app/settings/model-settings.tsx
@@ -501,7 +501,7 @@ export function ModelSettings({ onMainModelChanged, scopeProfile }: ModelSetting
       .filter(entry => {
         const p = (entry.provider ?? '').toLowerCase()
 
-        return p && p !== 'auto' && p !== mainProvider
+        return p && p !== 'auto' && p !== 'main' && p !== mainProvider
       })
       .map(entry => ({ task: entry.task, provider: entry.provider, model: entry.model }))
   }, [auxiliary, mainModel])


### PR DESCRIPTION
## Summary

The desktop app's Settings → Model page shows a false "stale auxiliary task" warning when an auxiliary task's provider is set to the `main` alias. `main` is a valid backend alias meaning "follow the current main provider" (e.g. Moonshot's official Hermes integration guide configures `auxiliary.vision.provider: main`). The banner claimed the task "still run[s] on `main`, not your main model" even though `main` correctly follows the main model — a GUI-only false positive.

## Changes

- `apps/desktop/src/app/settings/model-settings.tsx`: exempt the `main` alias in the `persistentStaleAux` filter, alongside the existing `auto` and current-main-provider exemptions.
- `apps/desktop/src/app/settings/model-settings.test.tsx`: add a regression test asserting an aux slot pinned to `provider: 'main'` does not trip the stale-aux banner.

## Tests

- New regression test fails on the buggy code (banner renders "1 auxiliary task (Vision) still run on `main`") and passes with the fix.
- `model-settings.test.tsx`: 23/23 pass. Full settings dir: 303 tests pass, no regressions.

Closes #97310
