### PR TITLE
fix(desktop): reload project tree after profile reset

### DIFF
--- a/apps/desktop/src/app/right-sidebar/files/use-project-tree.test.ts
+++ b/apps/desktop/src/app/right-sidebar/files/use-project-tree.test.ts
@@ -29,11 +29,16 @@ function ok(entries: { name: string; path: string; isDirectory: boolean }[]): He
 }
 
 describe('useProjectTree', () => {
-  it('starts empty when cwd is blank and skips IPC', async () => {
+  it('starts empty when cwd is blank and skips IPC across external resets', async () => {
     const { result } = renderHook(() => useProjectTree(''))
 
     await waitFor(() => expect(result.current.rootLoading).toBe(false))
 
+    act(() => {
+      resetProjectTreeState()
+    })
+
+    await waitFor(() => expect(result.current.rootLoading).toBe(false))
     expect(result.current.data).toEqual([])
     expect(result.current.rootError).toBeNull()
     expect(readDir).not.toHaveBeenCalled()
@@ -116,6 +121,35 @@ describe('useProjectTree', () => {
 
     expect(result.current.rootError).toBeNull()
     expect(result.current.data.map(node => node.name)).toEqual(['IDEA.md'])
+  })
+
+  it('reloads when project state resets after the mounted root read starts', async () => {
+    let resolveSupersededRead: ((result: HermesReadDirResult) => void) | undefined
+    readDir.mockImplementationOnce(
+      () =>
+        new Promise<HermesReadDirResult>(resolve => {
+          resolveSupersededRead = resolve
+        })
+    )
+    readDir.mockResolvedValueOnce(ok([{ name: 'recovered', path: '/p/recovered', isDirectory: true }]))
+
+    const { result } = renderHook(() => useProjectTree('/p'))
+
+    await waitFor(() => expect(readDir).toHaveBeenCalledTimes(1))
+
+    act(() => {
+      resetProjectTreeState()
+    })
+
+    await waitFor(() => expect(readDir).toHaveBeenCalledTimes(2))
+    await waitFor(() => expect(result.current.data.map(node => node.name)).toEqual(['recovered']))
+
+    await act(async () => {
+      resolveSupersededRead?.(ok([{ name: 'stale', path: '/p/stale', isDirectory: false }]))
+    })
+
+    expect(result.current.data.map(node => node.name)).toEqual(['recovered'])
+    expect(result.current.rootLoading).toBe(false)
   })
 
   it('lazy-loads children on loadChildren and replaces the placeholder', async () => {

--- a/apps/desktop/src/app/right-sidebar/files/use-project-tree.ts
+++ b/apps/desktop/src/app/right-sidebar/files/use-project-tree.ts
@@ -117,6 +117,8 @@ interface ProjectTreeState {
   loaded: boolean
   openState: Record<string, boolean>
   requestId: number
+  /** Bumped only by an external tree reset so a mounted hook re-runs its root read. */
+  resetNonce: number
   /** Directory the displayed entries were read from ('' until first load). */
   resolvedCwd: string
   rootError: string | null
@@ -130,6 +132,7 @@ const initialState: ProjectTreeState = {
   loaded: false,
   openState: {},
   requestId: 0,
+  resetNonce: 0,
   resolvedCwd: '',
   rootError: null,
   rootLoading: false
@@ -138,6 +141,7 @@ const initialState: ProjectTreeState = {
 const inflight = new Set<string>()
 const $projectTree = atom<ProjectTreeState>(initialState)
 let nextRootRequestId = 0
+let nextResetNonce = 0
 let lastConnectionKey = ''
 
 // While the root is errored (ENOENT during a session's cwd race, a folder that
@@ -152,7 +156,7 @@ function setProjectTree(updater: (current: ProjectTreeState) => ProjectTreeState
 function clearProjectTree() {
   nextRootRequestId += 1
   inflight.clear()
-  $projectTree.set({ ...initialState, requestId: nextRootRequestId })
+  $projectTree.set({ ...initialState, requestId: nextRootRequestId, resetNonce: nextResetNonce })
 }
 
 /** Sessions record their launch cwd; deleted worktrees and remote-backend
@@ -211,6 +215,7 @@ async function loadRoot(
     loaded: false,
     openState: current.cwd === cwd ? current.openState : {},
     requestId,
+    resetNonce: current.resetNonce,
     resolvedCwd: '',
     rootError: null,
     rootLoading: true
@@ -259,6 +264,7 @@ async function loadRoot(
 
 export function resetProjectTreeState() {
   lastConnectionKey = ''
+  nextResetNonce += 1
   clearProjectTree()
   clearProjectDirCache()
 }
@@ -471,7 +477,7 @@ export function useProjectTree(cwd: string): UseProjectTreeResult {
     }
 
     void loadRoot(cwd, { connectionKey })
-  }, [connectionKey, cwd])
+  }, [connectionKey, cwd, state.resetNonce])
 
   // Self-heal: an errored root re-probes every few seconds while the tree is
   // mounted. Each attempt bumps requestId, so a persistent error re-arms the


### PR DESCRIPTION
## Summary
- reload the mounted project tree when an external profile/gateway reset invalidates its in-flight root read
- preserve request-generation checks so superseded directory responses cannot overwrite the replacement tree
- cover the profile-switch race and blank-CWD reset behavior with regression tests

## Root cause
During a live profile switch, the mounted tree can begin reading the new root before the parent profile-switch effect calls `resetProjectTreeState()`. The reset advances the root request ID, so the first response is correctly discarded, but the hook previously depended only on CWD and connection key. Neither changed again, leaving the right sidebar in its loading skeleton indefinitely.

## Verification
- `npm test -- --project ui src/app/right-sidebar/files/use-project-tree.test.ts` (20 passed)
- `npm test -- --project ui src/app/right-sidebar/index.test.tsx src/app/right-sidebar/files/use-project-tree.test.ts` (23 passed)
- `npm run test:ui` (6,135 passed)
- `npm run typecheck`
- `npm run lint` (0 errors; existing warnings only)
- `npm run build`
- independent code review: passed, no security or logic findings