### PR TITLE
fix(cron): stop recursive boilerplate nesting in context_from continuity injections

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -4666,8 +4666,19 @@ def _build_job_prompt(
                 if not output_files:
                     continue  # silent skip — no output yet
                 latest_output = output_files[0].read_text(encoding="utf-8").strip()
-                # Truncate to 8K characters to avoid prompt bloat
-                _MAX_CONTEXT_CHARS = 8000
+                # The archive file is a wrapper ("# Cron Job … ## Prompt …
+                # ## Response …"). Injecting the whole wrapper back into the
+                # prompt compounds recursively: each run embeds the previous
+                # run's wrapper, which embeds the one before it, and models
+                # start mimicking the header format in their own reports.
+                # Extract the "## Response" section so continuity sees only
+                # what the job actually SAID last time.
+                _m = re.search(r"^## Response\s*\n\n?(.*)$", latest_output,
+                               re.S | re.M)
+                if _m:
+                    latest_output = _m.group(1).strip()
+                # Truncate to 4K characters to avoid prompt bloat
+                _MAX_CONTEXT_CHARS = 4000
                 if len(latest_output) > _MAX_CONTEXT_CHARS:
                     latest_output = latest_output[:_MAX_CONTEXT_CHARS] + "\n\n[... output truncated ...]"
                 if latest_output:


### PR DESCRIPTION
## Problem

Cron jobs using `context_from` self-references (continuity mode) re-ingest their archived output each run. The archive is a wrapper:

```
# Cron Job: <name>
**Job ID:** ...
## Prompt
[the cron execution hint + full job prompt]
## Response
<the actual report>
```

The previous injection is *inside* that wrapper, so run N embeds run N-1's wrapper (including its "## Your previous run's output" block), which embeds run N-2's... The context block compounds recursively (we observed a 22 KB archive of which 19 KB was nested wrappers), the model sees stale header boilerplate every run, and it starts **mimicking the header format in its own reports** — delivering `# Cron Job:` / `Job ID:` / `## Prompt` slop to chat instead of a readable report.

## Fix

Extract the `## Response` section from the archive before injecting it as continuity context, and lower the cap from 8K to 4K chars (the extracted response is what matters; the wrapper was eating the budget). No behavioral change for jobs whose archives lack the wrapper (regex simply doesn't match).

## Testing

- `python3 -m pytest tests/cron -q`: **1033 passed, 1 skipped**.
- Verified against a live archive: 22,275-char wrapper → 1,947-char extracted response with the correct content.
- Field evidence: 6 recurring jobs on our install showed progressive header nesting in every continuity block before this change.
