### PR TITLE
fix(desktop): stop stale app shells from blaming remote SSH hosts

### DIFF
--- a/apps/desktop/electron/bundle-skew.test.ts
+++ b/apps/desktop/electron/bundle-skew.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { detectBundleSkew, isFallbackCommit, type RunGit } from './bundle-skew'
+import { assertCurrentBundleForSsh, detectBundleSkew, isFallbackCommit, type RunGit } from './bundle-skew'
 
 const REPO = '/repo'
 const STAMP = { commit: 'a'.repeat(40), source: 'ci' }
@@ -83,5 +83,22 @@ describe('detectBundleSkew', () => {
       desktopCommitsBehind: null,
       outOfSync: false
     })
+  })
+})
+
+describe('assertCurrentBundleForSsh', () => {
+  it('surfaces local shell skew instead of blaming remote compatibility', () => {
+    expect(() => assertCurrentBundleForSsh({ desktopCommitsBehind: 3, outOfSync: true })).toThrowError(
+      expect.objectContaining({
+        kind: 'desktop-update-required',
+        sshError: 'desktop-update-required',
+        message: expect.stringMatching(/Desktop app shell is 3 desktop commits behind.*remote Hermes may already be compatible/i)
+      })
+    )
+  })
+
+  it('allows SSH probing when the shell is current or skew is unknowable', () => {
+    expect(() => assertCurrentBundleForSsh({ desktopCommitsBehind: 0, outOfSync: false })).not.toThrow()
+    expect(() => assertCurrentBundleForSsh({ desktopCommitsBehind: null, outOfSync: false })).not.toThrow()
   })
 })

--- a/apps/desktop/electron/bundle-skew.ts
+++ b/apps/desktop/electron/bundle-skew.ts
@@ -41,6 +41,12 @@ export interface BundleSkewResult {
   outOfSync: boolean
 }
 
+interface DesktopSshBundleError extends Error {
+  isSshBootstrap: true
+  kind: 'desktop-update-required'
+  sshError: 'desktop-update-required'
+}
+
 export type RunGit = (
   args: string[],
   options: { cwd: string }
@@ -81,4 +87,24 @@ export async function detectBundleSkew(
   } catch {
     return NOT_STALE
   }
+}
+
+export function assertCurrentBundleForSsh(skew: BundleSkewResult): void {
+  if (!skew.outOfSync) {
+    return
+  }
+
+  const count = skew.desktopCommitsBehind
+  const distance = count === 1 ? '1 desktop commit' : `${count ?? 'multiple'} desktop commits`
+
+  const error = new Error(
+    `The Hermes Desktop app shell is ${distance} behind the installed runtime. ` +
+      'Update or reinstall the Desktop app before checking SSH compatibility; the remote Hermes may already be compatible.'
+  ) as DesktopSshBundleError
+
+  error.kind = 'desktop-update-required'
+  error.sshError = 'desktop-update-required'
+  error.isSshBootstrap = true
+
+  throw error
 }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -86,7 +86,7 @@ import {
   BROWSER_WINDOW_WIDTH,
   buildBrowserWindowUrl
 } from './browser-windows'
-import { detectBundleSkew } from './bundle-skew'
+import { assertCurrentBundleForSsh, detectBundleSkew } from './bundle-skew'
 import { applyConnectionChange, teardownSshState } from './connection-apply'
 import {
   apiRequestRegistryConnectionId,
@@ -10155,6 +10155,8 @@ async function rollbackSshBootstrapResult(ssh, result, profile, sshConfig, bound
 }
 
 async function bootstrapSshConnectionInner(profile, sshConfig, reuseToken, source, metadata, fingerprint, lease) {
+  assertCurrentBundleForSsh(await detectRendererSkew())
+
   const scope = sshScopeKey(profile)
   const hostLabel = sshConfig.user ? `${sshConfig.user}@${sshConfig.host}` : sshConfig.host
   const existing = sshConnections.get(scope)
@@ -10657,6 +10659,8 @@ async function testDesktopConnectionConfig(input: any = {}) {
     )
 
     try {
+      assertCurrentBundleForSsh(await detectRendererSkew())
+
       // One bounded retry on TIMEOUT only: a cold Windows backend's first
       // PowerShell exec can exceed the budget (observed live), and a timeout is
       // indeterminate — unlike auth/host-key/unreachable, which are verdicts.

--- a/apps/desktop/src/app/settings/gateway-settings.tsx
+++ b/apps/desktop/src/app/settings/gateway-settings.tsx
@@ -534,6 +534,7 @@ export function GatewaySettings({ embedded = false }: { embedded?: boolean } = {
 
       const errors = {
         'auth-failed': g.sshErrAuth,
+        'desktop-update-required': g.sshErrDesktopUpdateRequired,
         'hermes-not-found': g.sshErrNotInstalled,
         'host-key-changed': g.sshErrHostKey,
         timeout: g.sshErrTimeout,
@@ -992,6 +993,7 @@ export function GatewaySettings({ embedded = false }: { embedded?: boolean } = {
       if (!result.reachable) {
         const errors = {
           'auth-failed': g.sshErrAuth,
+          'desktop-update-required': g.sshErrDesktopUpdateRequired,
           'hermes-not-found': g.sshErrNotInstalled,
           'host-key-changed': g.sshErrHostKey,
           timeout: g.sshErrTimeout,

--- a/apps/desktop/src/components/boot-failure-reauth.test.ts
+++ b/apps/desktop/src/components/boot-failure-reauth.test.ts
@@ -130,9 +130,18 @@ describe('shouldApplyPostBootProgressError', () => {
 
 describe('sshFailureMessage', () => {
   it('localizes SSH failures without changing non-SSH errors', () => {
-    const copy = { sshErrAuth: 'localized auth', sshErrUnknown: 'localized unknown' }
+    const copy = {
+      sshErrAuth: 'localized auth',
+      sshErrDesktopUpdateRequired: 'localized desktop update',
+      sshErrUnknown: 'localized unknown'
+    }
+
     const ssh = config({ mode: 'ssh', sshHost: 'box', remoteUrl: '' })
+
     expect(sshFailureMessage(ssh, 'SSH authentication failed', copy)).toBe('localized auth')
+    expect(sshFailureMessage(ssh, 'The Hermes Desktop app shell is behind; update it', copy)).toBe(
+      'localized desktop update'
+    )
     expect(sshFailureMessage(ssh, 'unexpected failure', copy)).toBe('localized unknown')
     expect(sshFailureMessage(config(), 'raw remote error', copy)).toBe('raw remote error')
   })

--- a/apps/desktop/src/components/boot-failure-reauth.ts
+++ b/apps/desktop/src/components/boot-failure-reauth.ts
@@ -82,6 +82,7 @@ export function sshFailureMessage(
   error: string | null | undefined,
   copy: {
     sshErrAuth?: string
+    sshErrDesktopUpdateRequired?: string
     sshErrHostKey?: string
     sshErrNotInstalled?: string
     sshErrPlatform?: string
@@ -98,6 +99,10 @@ export function sshFailureMessage(
   }
 
   const text = raw.toLowerCase()
+
+  if (text.includes('desktop app shell')) {
+    return copy.sshErrDesktopUpdateRequired || raw
+  }
 
   if (text.includes('host key')) {
     return copy.sshErrHostKey || raw

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -828,6 +828,7 @@ export interface DesktopConnectionTestResult {
   reachable?: boolean
   sshError?:
     | 'auth-failed'
+    | 'desktop-update-required'
     | 'hermes-not-found'
     | 'host-key-changed'
     | 'timeout'

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -969,6 +969,8 @@ export const en: Translations = {
       sshErrUnreachable: 'Could not reach that host over SSH. Check the host, port, and your network.',
       sshErrAuth:
         'SSH authentication failed. Load your key into the ssh-agent (ssh-add) or set an IdentityFile in ~/.ssh/config — Hermes runs ssh non-interactively.',
+      sshErrDesktopUpdateRequired:
+        'This Hermes Desktop app shell is older than the installed runtime. Update or reinstall the Desktop app before checking SSH compatibility; the remote Hermes may already be compatible.',
       sshErrHostKey:
         'The host key has CHANGED since you last connected. Verify this is expected, then run ssh-keygen -R <host> and reconnect.',
       sshErrNotInstalled:

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -899,6 +899,8 @@ export const ja = defineLocale({
       sshErrUnreachable: 'SSH でそのホストに到達できませんでした。ホスト、ポート、ネットワークを確認してください。',
       sshErrAuth:
         'SSH 認証に失敗しました。鍵を ssh-agent に読み込む（ssh-add）か、~/.ssh/config に IdentityFile を設定してください。Hermes は非対話的に ssh を実行します。',
+      sshErrDesktopUpdateRequired:
+        'Hermes Desktop アプリのシェルがインストール済みランタイムより古くなっています。SSH 互換性を確認する前に Desktop アプリを更新または再インストールしてください。リモートの Hermes はすでに互換性がある可能性があります。',
       sshErrHostKey:
         '前回の接続以降、ホスト鍵が変更されています。想定どおりか確認し、ssh-keygen -R <host> を実行してから再接続してください。',
       sshErrNotInstalled:

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -833,6 +833,7 @@ export interface Translations {
       sshIncompleteHost: string
       sshErrUnreachable: string
       sshErrAuth: string
+      sshErrDesktopUpdateRequired: string
       sshErrHostKey: string
       sshErrNotInstalled: string
       sshErrPlatform: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -872,6 +872,8 @@ export const zhHant = defineLocale({
       sshErrUnreachable: '無法透過 SSH 連線到該主機。請檢查主機、連接埠和網路。',
       sshErrAuth:
         'SSH 驗證失敗。請將金鑰載入 ssh-agent（ssh-add），或在 ~/.ssh/config 中設定 IdentityFile——Hermes 以非互動方式執行 ssh。',
+      sshErrDesktopUpdateRequired:
+        'Hermes Desktop 應用程式外殼早於已安裝的執行階段。請先更新或重新安裝 Desktop 應用程式，再檢查 SSH 相容性；遠端 Hermes 可能已經相容。',
       sshErrHostKey: '自上次連線以來主機金鑰已變更。請確認這是預期的，然後執行 ssh-keygen -R <host> 並重新連線。',
       sshErrNotInstalled:
         '遠端主機上未安裝 Hermes。請在遠端安裝（curl -fsSL https://hermes-agent.nousresearch.com/install.sh | sh）或設定 Hermes 路徑。',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1166,6 +1166,8 @@ export const zh: Translations = {
       sshErrUnreachable: '无法通过 SSH 连接到该主机。请检查主机、端口和网络。',
       sshErrAuth:
         'SSH 认证失败。请将密钥加载到 ssh-agent（ssh-add），或在 ~/.ssh/config 中设置 IdentityFile——Hermes 以非交互方式运行 ssh。',
+      sshErrDesktopUpdateRequired:
+        'Hermes Desktop 应用外壳早于已安装的运行时。请先更新或重新安装 Desktop 应用，再检查 SSH 兼容性；远程 Hermes 可能已经兼容。',
       sshErrHostKey: '自上次连接以来主机密钥已更改。请确认这是预期的，然后运行 ssh-keygen -R <host> 并重新连接。',
       sshErrNotInstalled:
         '远程主机上未安装 Hermes。请在远程安装（curl -fsSL https://hermes-agent.nousresearch.com/install.sh | sh）或设置 Hermes 路径。',


### PR DESCRIPTION
## What does this PR do?

A Hermes Desktop shell that is older than its installed runtime can run outdated SSH discovery code and incorrectly tell users to update a remote Hermes installation that already supports Desktop SSH. This change uses the existing build-stamp skew proof before both SSH connection tests and real SSH bootstrap, then reports that the local Desktop app needs to be updated or reinstalled instead of blaming the remote host.

### Symptom

Desktop SSH reports `Update Hermes on the remote host` even when the remote `hermes serve --help` already exposes `--ssh-session-token-file` and `--ssh-owner-nonce`.

### Impact

Users can spend time updating or debugging a compatible remote host while the actual incompatible component is the stale local Electron shell. The affected population is limited to installs where the packaged Desktop build predates later `apps/desktop/` commits in the installed source tree.

### Bug Cause

**Trigger:** `apps/desktop/electron/main.ts:bootstrapSshConnectionInner` and `testDesktopConnectionConfig` when `detectBundleSkew` proves that the packaged Desktop commit predates Desktop changes in the installed runtime.

**Causal chain:**
1. The source/runtime checkout advances while the packaged Electron shell remains at an older build stamp.
2. SSH test and bootstrap paths proceed directly to remote capability probing without consulting the existing bundle-skew result.
3. Outdated shell logic can probe the wrong remote launcher and present a remote update error, even though the remote runtime is compatible.

**Why it is wrong:** Desktop already has authoritative local evidence that its own packaged shell is stale, but SSH compatibility diagnostics ignore that evidence and assign the failure to the remote installation.

**Working sibling / contrast:** The About panel and `hermes:version` IPC already surface `detectRendererSkew()` as a local Desktop bundle problem.

**Ruled out:** Current remote launcher discovery preserves the Hermes wrapper and has regression coverage for the former Python-interpreter rewrite. The reported mismatch is therefore not evidence that the current remote runtime lacks the SSH ownership flags.

### Fix

- Add a typed `desktop-update-required` SSH failure that includes the proven Desktop commit distance and explicitly says the remote may already be compatible.
- Gate both real SSH bootstrap and Settings' SSH connection test before opening or probing the remote host.
- Map the new failure through boot recovery and localized Gateway Settings messages.
- Add behavior tests for the skew gate and the distinct local-shell message.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/electron/bundle-skew.ts` - convert proven Desktop bundle skew into a typed SSH bootstrap failure.
- `apps/desktop/electron/main.ts` - enforce the local-shell gate before SSH test and bootstrap paths.
- `apps/desktop/src/app/settings/gateway-settings.tsx` and `apps/desktop/src/components/boot-failure-reauth.ts` - surface the local Desktop update diagnosis instead of the remote update message.
- `apps/desktop/src/i18n/` - add localized copy for the distinct failure.
- Desktop unit tests - cover stale/current/unknowable bundle states and boot-message routing.

## How to Test

1. Run the focused skew and boot-message tests with a synthetic packaged commit behind the installed runtime.
2. Run Desktop TypeScript checks across renderer, Electron, and E2E projects.

```bash
cd apps/desktop
npx vitest run electron/bundle-skew.test.ts src/components/boot-failure-reauth.test.ts
npm run typecheck
```

Result: 35 tests passed; all three TypeScript projects passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant Desktop tests and typechecks and all pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation update is N/A; the change is an in-product diagnostic
- [x] Config example update is N/A; no config keys changed
- [x] Contributing or AGENTS update is N/A; no architecture or workflow changed
- [x] I've considered cross-platform impact; the gate uses the existing cross-platform build-stamp detector before platform-specific SSH probing
- [x] Tool descriptions/schemas update is N/A; no model tool behavior changed

## Screenshots / Logs

N/A; automated tests exercise the stale-shell diagnosis without requiring a live remote host.
