### PR TITLE
docs(voice): note realtime duplex voice via the hermes-talk plugin

### DIFF
--- a/website/docs/guides/use-voice-mode-with-hermes.md
+++ b/website/docs/guides/use-voice-mode-with-hermes.md
@@ -466,7 +466,7 @@ That progression keeps the debugging surface small.
 
 ## Where to read next
 
-- [Voice Mode feature reference](/user-guide/features/voice-mode)
+- [Voice Mode feature reference](/user-guide/features/voice-mode) — includes realtime duplex voice via the community hermes-talk plugin
 - [Messaging Gateway](/user-guide/messaging)
 - [Discord setup](/user-guide/messaging/discord)
 - [Telegram setup](/user-guide/messaging/telegram)

--- a/website/docs/user-guide/features/voice-mode.md
+++ b/website/docs/user-guide/features/voice-mode.md
@@ -36,6 +36,26 @@ A paid [Nous Portal](/user-guide/features/tool-gateway) subscription supplies th
 | **Auto Voice Reply** | Telegram, Discord | Agent sends spoken audio alongside text responses |
 | **Voice Channel** | Discord | Bot joins VC, listens to users speaking, speaks replies back |
 
+## Realtime duplex voice (plugin)
+
+Voice mode in core is turn-based: you speak, Hermes transcribes, thinks, then
+speaks back. If you want a live, interruptible conversation instead — the agent
+listens while it talks, you can cut it off mid-sentence, and it can call tools
+mid-conversation — that is available today through the community plugin
+[hermes-talk](https://github.com/TheSmokeDev/hermes-talk):
+
+```bash
+hermes plugins install TheSmokeDev/hermes-talk --enable
+pip install "hermes-talk[audio]"
+hermes talk
+```
+
+hermes-talk streams duplex speech-to-speech through your choice of provider —
+OpenAI Realtime (API key or an existing Codex/ChatGPT sign-in), xAI Grok Voice,
+or Gemini Live (a free AI Studio key works). Tools, memory, and approvals stay
+with Hermes; the realtime model is only the ears, mouth, and turn-taking.
+Discord voice channels work too: `/voice join`, then `/talk join`.
+
 ## Requirements
 
 ### Python Packages


### PR DESCRIPTION
## What

Adds a short **Realtime duplex voice (plugin)** section to the Voice Mode feature reference, plus a pointer line in the voice guide's "Where to read next."

## Why

The voice docs cover the built-in turn-based modes (push-to-talk CLI, voice replies, Discord VC) thoroughly, but a user looking for a live, interruptible, full-duplex conversation has no signpost — that question keeps surfacing in Discord and in issue comments (e.g. #75193). The community plugin [hermes-talk](https://github.com/TheSmokeDev/hermes-talk) fills exactly that gap today (OpenAI Realtime / xAI Grok / Gemini Live; terminal + Discord VC), and the docs already link community plugins in comparable spots.

The section is deliberately framed as a *plugin* pointer — core's turn-based docs are untouched, and the wording states plainly that tools/memory/approvals stay with Hermes.

## How to test

Docs-only change. Rendered the two pages mentally against the existing Docusaurus conventions (bash block, admonition-free section, relative link style matches the page's existing external links); no internal links were added or altered except the existing `/user-guide/features/voice-mode` anchor line in the guide, which keeps its target.

## Platforms

N/A (docs).