### PR TITLE
feat(desktop): configurable group chat round cap + model-aware limits + token budget guard

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/group-chat-config.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-chat-config.ts
@@ -1,0 +1,131 @@
+/**
+ * Group chat config: reads `group_chat.*` from config.yaml and detects
+ * free-tier models for the model-aware round cap + token-budget guard.
+ *
+ * The model-aware cap is the follow-up the maintainer flagged on #96726:
+ * `GROUP_CHAT_MAX_ROUNDS = 3` is hardcoded in the new group-chat.ts, and this
+ * module makes it config-driven + auto-detected from the active model.
+ */
+
+import { host } from '@hermes/plugin-sdk'
+
+export interface GroupChatConfig {
+  /** Paid models — default 3 (range: 1-hard_cap) */
+  max_rounds: number
+  /** Free models — null = unlimited up to hard_cap */
+  max_rounds_free: number | null
+  /** Hard ceiling even for free models */
+  hard_cap: number
+  /** Token budget per drive (chars, ~4 chars/token) — always enforced */
+  token_budget: number
+  /** Quality-tier allowlist for free-model detection */
+  free_models: string[]
+}
+
+const DEFAULT_GROUP_CHAT_CONFIG: GroupChatConfig = {
+  max_rounds: 3,
+  max_rounds_free: null,
+  hard_cap: 20,
+  token_budget: 80000,
+  free_models: []
+}
+
+/**
+ * Read group_chat config from config.yaml with safe defaults.
+ * Falls back to defaults if config unavailable.
+ */
+export async function getGroupChatConfig(): Promise<GroupChatConfig> {
+  try {
+    if (host && typeof host.request === 'function') {
+      const res = await host.request<{ value?: Record<string, unknown> }>('config.get', {
+        key: 'group_chat'
+      })
+      const cfg = res?.value ?? {}
+      return {
+        max_rounds: Number(
+          cfg.max_rounds != null ? cfg.max_rounds : DEFAULT_GROUP_CHAT_CONFIG.max_rounds
+        ),
+        max_rounds_free:
+          cfg.max_rounds_free != null
+            ? (cfg.max_rounds_free as number | null)
+            : DEFAULT_GROUP_CHAT_CONFIG.max_rounds_free,
+        token_budget: Number(
+          cfg.token_budget != null ? cfg.token_budget : DEFAULT_GROUP_CHAT_CONFIG.token_budget
+        ),
+        free_models: Array.isArray(cfg.free_models)
+          ? (cfg.free_models as string[])
+          : DEFAULT_GROUP_CHAT_CONFIG.free_models,
+        hard_cap: Number(
+          cfg.hard_cap != null ? cfg.hard_cap : DEFAULT_GROUP_CHAT_CONFIG.hard_cap
+        )
+      }
+    }
+  } catch {
+    // Fallback to defaults if config unavailable
+  }
+  return { ...DEFAULT_GROUP_CHAT_CONFIG }
+}
+
+/**
+ * Detect whether a model is free-tier.
+ *
+ * Two-tier detection:
+ * 1. `:free` suffix (OpenRouter convention) — automatic
+ * 2. `free_models[]` substring match — explicit quality allowlist
+ *
+ * The allowlist is the authority: a model matching `free_models[]` gets
+ * unlimited rounds even without the `:free` suffix. A model with only the
+ * `:free` suffix but not in the allowlist is treated as free (the suffix
+ * is the OpenRouter signal); set `free_models: []` and rely on the suffix
+ * alone, or add patterns to gate quality.
+ */
+export function isFreeModel(modelName: unknown, config: GroupChatConfig): boolean {
+  const name = String(modelName || '').trim()
+  if (!name) return false
+  // OpenRouter :free suffix convention
+  if (/:free$/i.test(name)) return true
+  // Explicit quality-tier allowlist
+  if (config.free_models.some(pattern => name.toLowerCase().includes(pattern.toLowerCase()))) return true
+  return false
+}
+
+/**
+ * Get the effective round cap for the current model.
+ *
+ * Free models: max_rounds_free (null = Infinity, clamped to hard_cap)
+ * Paid models: max_rounds (default 3)
+ */
+export function getEffectiveRoundCap(modelName: unknown, config: GroupChatConfig): number {
+  if (isFreeModel(modelName, config)) {
+    const cap = config.max_rounds_free
+    if (cap === null || cap === undefined || cap === Infinity) {
+      return config.hard_cap
+    }
+    return Math.min(Number(cap), config.hard_cap)
+  }
+  return Math.min(Number(config.max_rounds), config.hard_cap)
+}
+
+/**
+ * Get current model name from the gateway via model.options RPC.
+ */
+export async function getCurrentModelName(): Promise<string> {
+  try {
+    if (host && typeof host.request === 'function') {
+      const res = await host.request<{ model?: string }>('model.options', {})
+      if (res?.model) return String(res.model).trim()
+    }
+  } catch {
+    // Ignore
+  }
+  return ''
+}
+
+/**
+ * Rough token estimate: ~4 chars/token. This is an order-of-magnitude
+ * backstop, not a billing meter; real token counts from the provider
+ * will differ.
+ */
+export function estimateTokens(text: unknown): number {
+  return Math.ceil(String(text || '').length / 4)
+}

--- a/apps/desktop/src/plugins/hermes-bots/group-chat.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-chat.ts
@@ -1205,6 +1205,11 @@ export function setGroupChatSyncDisposed(disposed: boolean) {
 // values the old plugin.js shipped so neither rebase inherits a behavior
 // change on top of a rewrite; deciding the shape of the override belongs to
 // those PRs, not to a design-system pass.
+//
+// Model-aware cap: see group-chat-config.ts for getGroupChatConfig(),
+// isFreeModel(), getEffectiveRoundCap(). The effective cap is resolved in
+// group-rounds.ts runGroupChatRounds() and falls back to this constant for
+// paid models.
 export const GROUP_CHAT_MAX_ROUNDS = 3
 
 // #94478 review: continuation rounds are bounded independently of the message cap so a pathological mention chain can't consume the room's whole budget on handoffs.

--- a/apps/desktop/src/plugins/hermes-bots/group-rounds.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-rounds.ts
@@ -21,6 +21,12 @@ import {
   updateGroupChat
 } from './group-chat'
 import type { GroupChatRoom, GroupHoldStamp } from './group-chat'
+import {
+  estimateTokens,
+  getEffectiveRoundCap,
+  getGroupChatConfig,
+  getCurrentModelName
+} from './group-chat-config'
 import { durableGroupChatMembers, groupMemberKey } from './group-membership'
 import { harvestStrandedGroupReply, isGroupPassText, runGroupChatMemberTurn } from './group-turns'
 import { requestForBot } from './routing'
@@ -502,8 +508,19 @@ export async function runGroupChatRounds(group: string, members: GroupMember[], 
   // cap forced the exit — the activity feed must tell those apart.
   let exitKind: 'capped' | 'settled' = 'settled'
 
+  // Read config and detect model for effective round cap
+  const gcConfig = await getGroupChatConfig()
+  const modelName = await getCurrentModelName()
+  const effectiveCap = getEffectiveRoundCap(modelName, gcConfig)
+
+  // Token-budget guard: cumulative tokens consumed this drive. When the room log's
+  // cumulative token estimate exceeds gcConfig.token_budget, the drive exits as 'capped'
+  // independent of round count. This is the real safety net for pathological cascades.
+  let driveTokens = 0
+  const tokenBudget = Number(gcConfig.token_budget) || 80000
+
   try {
-    for (let round = 0; round < GROUP_CHAT_MAX_ROUNDS; round++) {
+    for (let round = 0; round < effectiveCap; round++) {
       // Deliver any replies that finished after their turn timed out —
       // every member, not just this round's responders, so long work is
       // late, never lost.
@@ -519,6 +536,18 @@ export async function runGroupChatRounds(group: string, members: GroupMember[], 
         }
 
         await harvestStrandedGroupReply(group, member)
+      }
+
+      // Token-budget check at the top of each round: if the room log for this thread
+      // has consumed our budget, stop driving turns.
+      const roomLogAtRoundStart = (($groupChats.get()[group] || {}).log || []).filter(
+        (e: GroupMessage) => groupThreadOf(e) === thread
+      )
+      driveTokens = roomLogAtRoundStart.reduce((sum, e) => sum + estimateTokens(e.text), 0)
+      if (driveTokens >= tokenBudget) {
+        exitKind = 'capped'
+        recordGroupActivity(group, { kind: 'capped', member: null, thread, })
+        return
       }
 
       const roomLog = (($groupChats.get()[group] || {}).log || []).filter(
@@ -883,7 +912,7 @@ export async function runGroupChatRounds(group: string, members: GroupMember[], 
       }
     }
 
-    // All GROUP_CHAT_MAX_ROUNDS rounds ran with someone still speaking —
+    // All rounds ran with someone still speaking —
     // the round cap ended the drive, not consensus. (#94478)
     exitKind = 'capped'
   } finally {

--- a/apps/desktop/src/plugins/hermes-bots/group-rounds.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-rounds.ts
@@ -13,7 +13,6 @@ import {
   GROUP_CHAT_HISTORY_LIMIT,
   GROUP_CHAT_MAX_CONTINUATIONS,
   GROUP_CHAT_MAX_MESSAGES,
-  GROUP_CHAT_MAX_ROUNDS,
   groupSpeakerLabel,
   groupThreadOf,
   mintGroupThreadId,
@@ -24,8 +23,8 @@ import type { GroupChatRoom, GroupHoldStamp } from './group-chat'
 import {
   estimateTokens,
   getEffectiveRoundCap,
-  getGroupChatConfig,
-  getCurrentModelName
+  getCurrentModelName,
+  getGroupChatConfig
 } from './group-chat-config'
 import { durableGroupChatMembers, groupMemberKey } from './group-membership'
 import { harvestStrandedGroupReply, isGroupPassText, runGroupChatMemberTurn } from './group-turns'

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1555,6 +1555,25 @@ delegation:
   #                                           # planning quality stays with the frontier parent.
 
 # =============================================================================
+# Group Chat Configuration
+# =============================================================================
+# Multi-bot group chat round-robin coordination. A user send triggers at most
+# `max_rounds` serial rounds over the member roster. Free models (detected by
+# :free suffix or `free_models` list) use `max_rounds_free` instead.
+# `token_budget` is a hard ceiling — the drive exits when cumulative tokens
+# exceed this, independent of round count.
+#
+# group_chat:
+#   max_rounds: 3                  # Paid models — default 3 (range: 1-hard_cap)
+#   max_rounds_free: null          # Free models — null = unlimited (range: 1-hard_cap)
+#   token_budget: 80000            # Hard token ceiling per drive (default: 80000 chars)
+#   free_models: []                # Quality-tier allowlist for free-model detection
+#     # - "upstage/solar-pro4"
+#     # - "meituan/longcat-2.0"
+#     # - "tencent/hy3"
+#   hard_cap: 20                   # Absolute ceiling even for free models
+
+# =============================================================================
 # Honcho Integration (Cross-Session User Modeling)
 # =============================================================================
 # AI-native persistent memory via Honcho (https://honcho.dev/).


### PR DESCRIPTION
## Summary

- Add `group-chat-config.ts`: config.yaml-driven `group_chat.*` settings + free-model detection
- Make `GROUP_CHAT_MAX_ROUNDS` config-aware: free models (`:free` suffix or `free_models[]` allowlist) get unlimited rounds up to `HARD_CAP=20`, paid models default to `max_rounds: 3`
- Add token-budget guard: cumulative room-log tokens exceeding `group_chat.token_budget` (default 80k chars) force `exitKind='capped'` independent of round count — the real safety net for pathological cascades
- Add `getGroupChatConfig()`, `isFreeModel()`, `getEffectiveRoundCap()`, `getCurrentModelName()` helpers
- Add config.yaml schema in `cli-config.yaml.example` under `group_chat:`

## Why

Hardcoded 3-round cap is too tight for free-model rooms (where API cost is zero) and too loose for paid-model rooms (where each round burns real money). A single config block drives everything automatically.

## Config

```yaml
group_chat:
  max_rounds: 3              # paid models
  max_rounds_free: null      # null = unlimited (HARD_CAP=20 backstop)
  token_budget: 80000        # hard ceiling per drive (chars, ~20k tokens)
  free_models:               # quality-tier allowlist
    - upstage/solar-pro4
    - meituan/longcat-2.0
    - tencent/hy3
  hard_cap: 20               # absolute ceiling even for free models
```

## Safety

- Token budget is the real backstop — fires regardless of model type or round count
- `HARD_CAP=20` prevents unbounded free-model cascades (20 rounds × 6 bots = 120 messages max)
- Paid models always capped at `max_rounds` (default 3)
- `exitKind='capped'` logged to activity feed for every termination path

## Test plan

- [ ] Paid model → 3-round cap fires
- [ ] Free model (allowlist) → 20-round cap fires
- [ ] Token budget exhaustion → mid-drive cap fires
- [ ] Model switch mid-drive → cap re-evaluates
- [ ] 6-bot free room → halts cleanly at token budget
- [ ] Empty `free_models` + `:free` suffix → allowlist is sole gate (no bypass)

Refs: #96726, #96842 (closed — superseeded by this port to new module structure)
