### PR TITLE
fix(credential-pool): treat rotate-to-self after mark as no-recovery

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -2273,6 +2273,25 @@ class CredentialPool:
                 )
             self._current_id = None
             next_entry, _pending = self._select_unlocked(refresh=False)
+            if next_entry is not None and next_entry.id == entry.id:
+                # No-recovery guard (#97315): the selection handed back the
+                # very entry that was just marked exhausted — e.g. the codex
+                # auth-store sync adopted fresher tokens from auth.json and
+                # cleared the bench mid-selection, so the sole credential
+                # re-entered rotation within milliseconds of being marked.
+                # Returning it reports a successful recovery without changing
+                # the credential, so the caller retries the same 429 forever
+                # (~2 req/s for hours against an already-throttled account).
+                # Mirror the single-entry guard on the unmatched-identity
+                # branch above: hand back None so the failure surfaces and
+                # fallback/error propagation proceeds.
+                logger.warning(
+                    "credential pool: rotation returned the just-marked entry "
+                    "%s — treating as no-recovery so the failure surfaces",
+                    _label,
+                )
+                self._current_id = None
+                return None
             if next_entry:
                 _next_label = next_entry.label or next_entry.id[:8]
                 logger.info("credential pool: rotated to %s", _next_label)

--- a/tests/agent/test_credential_pool_sole_rotate_recovery.py
+++ b/tests/agent/test_credential_pool_sole_rotate_recovery.py
@@ -1,0 +1,139 @@
+"""#97315: a rotation that can only hand back the entry that was just marked
+exhausted is no recovery — it must return None so the turn fails.
+
+A sole-credential ``openai-codex`` pool hitting a 429 ``usage_limit_reached``
+writes a correct bench (``last_error_reset_at`` days into the future), yet the
+selection path can re-admit the just-marked entry within milliseconds:
+``_available_entries`` runs the auth-store sync for every exhausted codex
+``device_code`` entry, and when auth.json holds a token pair that differs from
+the pool entry's — e.g. the request path's own resolve refreshed the
+single-use tokens — the sync adopts them and clears the bench mid-selection.
+``_select_unlocked`` then returns the sole entry, ``mark_exhausted_and_rotate``
+reports a successful rotation, and the caller retries the same throttled
+credential forever (~2 req/s for hours; 11k+ requests against an
+already-exhausted account, gateway wedged until killed by hand).
+
+The fix mirrors the single-entry guard on the unmatched-identity branch of the
+same function: if the post-mark selection returns the very entry that was just
+marked, treat it as no-recovery (None) so the failure surfaces and fallback /
+error propagation proceeds. A genuine re-auth still recovers on the next
+selection; multi-entry pools keep rotating to a healthy sibling.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import replace
+
+
+def _entry(idx: int, *, token: str, refresh: str) -> dict:
+    return {
+        "id": f"codex-{idx}",
+        "label": f"codex-login-{idx}",
+        "auth_type": "oauth",
+        "priority": idx,
+        "source": "device_code",
+        "access_token": token,
+        "refresh_token": refresh,
+    }
+
+
+def _load(tmp_path, monkeypatch, entries: list[dict]):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    (hermes_home / "auth.json").write_text(
+        json.dumps(
+            {"version": 1, "credential_pool": {"openai-codex": entries}}
+        )
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    from agent.credential_pool import load_pool
+
+    return load_pool("openai-codex")
+
+
+def _revive_entry(pool, entry):
+    """Simulate the auth-store sync adopting fresher tokens from auth.json:
+    the bench (last_status / reset_at) is cleared mid-selection, exactly as
+    ``_sync_codex_entry_from_auth_store`` does for a changed token pair."""
+    updated = replace(
+        entry,
+        access_token=entry.access_token + "-adopted",
+        refresh_token=(entry.refresh_token or "") + "-adopted",
+        last_status=None,
+        last_status_at=None,
+        last_error_code=None,
+        last_error_reason=None,
+        last_error_message=None,
+        last_error_reset_at=None,
+    )
+    pool._replace_entry(entry, updated)
+    return updated
+
+
+def test_revived_sole_entry_is_no_recovery(tmp_path, monkeypatch):
+    """The auth-store sync revives the just-marked sole entry mid-selection —
+    returning it reports recovery without changing the credential, so the
+    caller would retry the same 429 forever. Must return None instead."""
+    pool = _load(tmp_path, monkeypatch, [_entry(1, token="tok-a", refresh="rf-a")])
+    pool._sync_codex_entry_from_auth_store = lambda entry: _revive_entry(pool, entry)
+
+    nxt = pool.mark_exhausted_and_rotate(
+        status_code=429,
+        error_context={
+            "reason": "usage_limit_reached",
+            "reset_at": time.time() + 95.5 * 3600,
+        },
+        credential_id="codex-1",
+    )
+    assert nxt is None
+    # The failure must stay surfaced: no cursor pointing at the dead entry.
+    assert pool._current_id is None
+
+
+def test_benched_sole_entry_without_revival_stays_benched(tmp_path, monkeypatch):
+    """Without a mid-selection revival the bench holds: the 429 reset_at keeps
+    the sole entry out of rotation and rotation returns None (pre-existing
+    semantics — pinned so the new guard cannot mask a broken bench)."""
+    pool = _load(tmp_path, monkeypatch, [_entry(1, token="tok-a", refresh="rf-a")])
+    # Tokens already in sync with auth.json: the sync path adopts nothing.
+    pool._sync_codex_entry_from_auth_store = lambda entry: entry
+
+    nxt = pool.mark_exhausted_and_rotate(
+        status_code=429,
+        error_context={
+            "reason": "usage_limit_reached",
+            "reset_at": time.time() + 95.5 * 3600,
+        },
+        credential_id="codex-1",
+    )
+    assert nxt is None
+    assert pool._entries[0].last_status == "exhausted"
+    assert pool._entries[0].last_error_reset_at is not None
+
+
+def test_multi_entry_pool_still_rotates_to_sibling(tmp_path, monkeypatch):
+    """Regression guard: with a healthy sibling available, the post-mark
+    rotation must still return it — the no-recovery guard only fires when the
+    selection hands back the just-marked entry itself."""
+    pool = _load(
+        tmp_path,
+        monkeypatch,
+        [
+            _entry(1, token="tok-a", refresh="rf-a"),
+            _entry(2, token="tok-b", refresh="rf-b"),
+        ],
+    )
+    pool._sync_codex_entry_from_auth_store = lambda entry: entry
+
+    nxt = pool.mark_exhausted_and_rotate(
+        status_code=429,
+        error_context={
+            "reason": "usage_limit_reached",
+            "reset_at": time.time() + 95.5 * 3600,
+        },
+        credential_id="codex-1",
+    )
+    assert nxt is not None
+    assert nxt.id == "codex-2"


### PR DESCRIPTION
## What does this PR do?

Stops the unbounded `mark → rotate-to-self → retry` spin loop in `CredentialPool.mark_exhausted_and_rotate()` when a sole-credential `openai-codex` pool hits a `429 usage_limit_reached` (#97315).

Root cause chain: after `_mark_exhausted()` writes a correct bench (the reporter's on-disk `last_error_reset_at` was +95.5 h), the post-mark `_select_unlocked(refresh=False)` call runs `_available_entries()`, which invokes `_sync_codex_entry_from_auth_store()` for every exhausted codex `device_code` entry. When auth.json holds a token pair that differs from the pool entry's, that sync *adopts* the store tokens and clears `last_status`/`last_error_reset_at` mid-selection — so the sole entry re-enters rotation within milliseconds of being benched. The rotation hands the just-failed entry back, the failover caller treats it as recovery, and the turn retries the same throttled credential forever (~1.4–2 req/s for hours, 11k+ requests, no backoff, no attempt cap; observed gateway wedge ~11 h).

The fix mirrors the single-entry guard that already exists on the unmatched-identity branch of the same function (the `len(avail) == 1` guard at the top of `mark_exhausted_and_rotate`): when the post-mark selection returns the very entry that was just marked exhausted, that is no recovery — return `None` so the failure surfaces and fallback/error propagation proceeds. This bounds the loop regardless of *which* mechanism re-admitted the entry (token adopt, probe, future sync variants).

Scope deliberately kept minimal: no TTL policy change (the `usage_limit_reached` bench itself is already stored correctly), no retry-cap changes in the caller, no probe changes (see #96414 for the probe-false-positive variant of this loop — complementary, different mechanism).

## Related Issue

Fixes #97315

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/credential_pool.py` — in `mark_exhausted_and_rotate()`, after `_mark_exhausted()` and `_select_unlocked(refresh=False)`, if the selection returned the entry that was just marked (same id), log a warning, clear `_current_id`, and return `None` (no-recovery) instead of reporting a successful rotation
- `tests/agent/test_credential_pool_sole_rotate_recovery.py` — new: (1) revived-sole-entry rotation returns `None` (red on main, green with the fix), (2) benched sole entry without revival stays benched and returns `None` (pins pre-existing correct semantics), (3) multi-entry pool still rotates to a healthy sibling (no false positives from the guard)

## How to Test

1. `uv run pytest tests/agent/test_credential_pool_sole_rotate_recovery.py -v` — 3 passed
2. Red/green check: stash the `agent/credential_pool.py` change and rerun — `test_revived_sole_entry_is_no_recovery` fails on main (the revived sole entry is returned as "recovery", reproducing the #97315 spin preconditions); restore the fix and it passes
3. Regression sweep: `uv run pytest tests/agent/ -k "credential_pool" -q` — 122 passed, 1 skipped; `uv run pytest tests/run_agent/test_codex_xai_oauth_recovery.py tests/run_agent/test_fallback_credential_isolation.py tests/run_agent/test_credential_pool_interrupt.py tests/agent/test_custom_pool_mismatch_guard.py tests/agent/test_billing_unverified_carrythrough.py -q` — 40 passed. Observed result: all green.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
