### PR TITLE
feat(mcp): service-account M2M OAuth provider for HTTP MCP servers

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1239,7 +1239,7 @@ def _is_env_config_key(key: str) -> bool:
     ]
     return (
         key_upper in api_keys
-        or key_upper.endswith(('_API_KEY', '_TOKEN', '_SECRET'))
+        or key_upper.endswith(('_API_KEY', '_TOKEN', '_SECRET', '_PASSWORD'))
         or key_upper.startswith('TERMINAL_SSH')
     )
 

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -534,6 +534,31 @@ def cmd_mcp_add(args):
                 _info("Cancelled.")
                 return
 
+    elif url and auth_type == "service_account":
+        # Service-account M2M: validate the sub-block; secrets stay in env vars.
+        print()
+        _info(f"Configuring service-account auth for '{name}'...")
+        sa_cfg = server_config.get("service_account") or {}
+        from tools.mcp_service_account import validate_service_account_config
+        sa_errors = validate_service_account_config(name, sa_cfg)
+        if sa_errors:
+            for err in sa_errors:
+                _warning(err)
+            _warning(
+                "Fix the service_account block in config.yaml and re-run. "
+                "Secrets must be in environment variables, not in config."
+            )
+            return
+        server_config["auth"] = "service_account"
+        _success(
+            f"Service-account auth configured — token will be acquired from "
+            f"{sa_cfg.get('token_url', '(token_url)')} on first connection"
+        )
+        _info(
+            f"Ensure ${sa_cfg.get('password_env', 'PASSWORD_ENV')} is set "
+            "in your shell or in $HERMES_HOME/.env before connecting."
+        )
+
     elif url:
         # Prompt for API key / Bearer token for HTTP servers
         print()
@@ -668,6 +693,13 @@ def cmd_mcp_remove(args):
         from tools.mcp_oauth_manager import get_manager
         get_manager().remove(name)
         _success("Cleaned up OAuth tokens")
+    except Exception:
+        pass
+
+    # Clean up service-account token cache if present.
+    try:
+        from tools.mcp_service_account import remove_service_account_tokens
+        remove_service_account_tokens(name)
     except Exception:
         pass
 

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -803,6 +803,21 @@ def cmd_mcp_test(args):
     headers = cfg.get("headers", {})
     if auth_type == "oauth":
         _info("Auth: OAuth 2.1 PKCE")
+    elif auth_type == "service_account":
+        sa = cfg.get("service_account") or {}
+        token_url = sa.get("token_url", "(token_url not set)")
+        client_id = sa.get("client_id", "?")
+        username = sa.get("username", "?")
+        password_env = sa.get("password_env", "?")
+        _info(f"Auth: service account (M2M OAuth)")
+        _info(f"  token_url:    {token_url}")
+        _info(f"  client_id:    {client_id}")
+        _info(f"  username:     {username}")
+        _info(f"  password_env: {password_env}  (value read from env at connect time)")
+        if sa.get("scope"):
+            _info(f"  scope:        {sa['scope']}")
+        if sa.get("client_secret_env"):
+            _info(f"  client_secret_env: {sa['client_secret_env']}  (value read from env)")
     elif headers:
         for k, v in headers.items():
             if isinstance(v, str) and ("key" in k.lower() or "auth" in k.lower()):

--- a/hermes_cli/web_models.py
+++ b/hermes_cli/web_models.py
@@ -424,10 +424,13 @@ class MCPServerCreate(BaseModel):
     args: List[str] = []
     # env: KEY=VALUE map for stdio servers (API keys, etc.)
     env: Dict[str, str] = {}
-    # auth: "none" | "oauth" | "header" | None
+    # auth: "none" | "oauth" | "header" | "service_account" | None
     auth: Optional[str] = None
     # One-time provisioning input; persisted only to the profile's .env.
     bearer_token: Optional[SecretStr] = None
+    # Non-secret service-account fields (token_url, client_id, username, scope,
+    # password_env, client_secret_env). Secrets are referenced by env-var name only.
+    service_account: Optional[Dict[str, Any]] = None
     profile: Optional[str] = None
 
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -13678,7 +13678,7 @@ def _normalize_mcp_server_create(
 
     if bool(url) == bool(command):
         raise ValueError("Provide exactly one of URL (HTTP/SSE) or command (stdio)")
-    if auth not in {"none", "header", "oauth"}:
+    if auth not in {"none", "header", "oauth", "service_account"}:
         raise ValueError(f"Unsupported auth mode: {auth}")
 
     server_config: Dict[str, Any] = {}
@@ -13694,12 +13694,32 @@ def _normalize_mcp_server_create(
             if not normalized or normalized.lower() == "bearer":
                 raise ValueError("Bearer token is required")
             server_config["headers"] = _bearer_auth_headers(name)
+        elif auth == "service_account":
+            if body.bearer_token is not None:
+                raise ValueError("Bearer token is not used with service_account auth")
+            from tools.mcp_service_account import validate_service_account_config
+            sa_cfg = body.service_account or {}
+            # Reject any secret-value fields: only env-var names are accepted.
+            _SA_SECRET_FIELDS = {"password", "client_secret"}
+            for _f in _SA_SECRET_FIELDS:
+                if _f in sa_cfg:
+                    raise ValueError(
+                        f"service_account.{_f} must not be sent to the server. "
+                        f"Use {_f}_env (an environment-variable name) instead, "
+                        f"and set the value in your profile's .env file."
+                    )
+            sa_errors = validate_service_account_config(name, sa_cfg)
+            if sa_errors:
+                raise ValueError("; ".join(sa_errors))
         elif body.bearer_token is not None:
             raise ValueError("Bearer token requires header authentication")
 
         server_config["url"] = url
         if auth == "oauth":
             server_config["auth"] = "oauth"
+        elif auth == "service_account":
+            server_config["auth"] = "service_account"
+            server_config["service_account"] = dict(body.service_account or {})
     else:
         if auth != "none" or body.bearer_token is not None:
             raise ValueError(
@@ -13736,7 +13756,7 @@ def _mcp_server_summary(name: str, cfg: Dict[str, Any]) -> Dict[str, Any]:
         str(key).lower() == "authorization" for key in headers
     ):
         auth = "header"
-    return {
+    summary: Dict[str, Any] = {
         "name": name,
         "transport": transport,
         "url": cfg.get("url"),
@@ -13748,6 +13768,14 @@ def _mcp_server_summary(name: str, cfg: Dict[str, Any]) -> Dict[str, Any]:
         # Tool selection: list of enabled tool names, or None = all.
         "tools": cfg.get("tools"),
     }
+    if auth == "service_account":
+        sa = cfg.get("service_account") or {}
+        # Only non-secret fields: env-var names, not values.
+        summary["service_account"] = {
+            k: v for k, v in sa.items()
+            if k not in {"password", "client_secret"}
+        }
+    return summary
 
 
 from hermes_cli.web_routers import mcp as _mcp_routes  # noqa: E402

--- a/tests/tools/test_mcp_service_account.py
+++ b/tests/tools/test_mcp_service_account.py
@@ -1,0 +1,937 @@
+"""Tests for tools/mcp_service_account.py — service-account M2M OAuth provider.
+
+Each test uses a local mock token endpoint (aiohttp or http.server) and a
+mock MCP server.  No real credentials are used.  The HERMES_HOME env var
+is monkeypatched to a tmp_path so no real profile is touched.
+
+Tests cover:
+- Config validation (required fields, env-var name checks)
+- First token acquisition and Authorization header injection
+- Cached token reuse (no second exchange)
+- Proactive renewal before expiry (token near-expired → refresh)
+- refresh_token path and fallback to service-account exchange
+- One 401 retry: fresh token acquired, request retried
+- Concurrent requests: only one token exchange
+- Missing password env var → clear error, no secret in message
+- Malformed token response → clear error
+- Token endpoint failure (HTTP 500) → clear error
+- No secret values in log output
+- Profile/home cache isolation (two homes → separate caches)
+- Backwards compatibility: header auth and browser OAuth modes still work
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import time
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_sa_config(
+    *,
+    token_url: str = "https://idp.example/token/",
+    client_id: str = "toolhive",
+    username: str = "zug",
+    password_env: str = "TEST_SA_PASSWORD",
+    scope: str = "openid profile",
+    client_secret_env: str = "",
+) -> dict:
+    cfg: dict = {
+        "token_url": token_url,
+        "client_id": client_id,
+        "username": username,
+        "password_env": password_env,
+        "scope": scope,
+    }
+    if client_secret_env:
+        cfg["client_secret_env"] = client_secret_env
+    return cfg
+
+
+def _fake_token_response(
+    access_token: str = "ACCESS",
+    expires_in: int = 3600,
+    refresh_token: str | None = None,
+) -> dict:
+    d = {"access_token": access_token, "token_type": "Bearer", "expires_in": expires_in}
+    if refresh_token:
+        d["refresh_token"] = refresh_token
+    return d
+
+
+class _FakeResponse:
+    """Minimal fake httpx.Response."""
+
+    def __init__(self, status_code: int, body: dict | None = None):
+        self.status_code = status_code
+        self._body = body or {}
+
+    def json(self) -> dict:
+        return self._body
+
+
+class _FakeHttpxClient:
+    """Records calls and returns configurable responses."""
+
+    def __init__(self, responses: list[_FakeResponse]):
+        self._responses = list(responses)
+        self.calls: list[dict] = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_):
+        pass
+
+    async def post(self, url: str, *, data: dict, headers: dict) -> _FakeResponse:
+        self.calls.append({"url": url, "data": dict(data)})
+        if not self._responses:
+            raise RuntimeError("No more fake responses")
+        return self._responses.pop(0)
+
+
+# ---------------------------------------------------------------------------
+# Config validation
+# ---------------------------------------------------------------------------
+
+class TestValidateServiceAccountConfig:
+    def test_valid_config(self):
+        from tools.mcp_service_account import validate_service_account_config
+        cfg = _make_sa_config()
+        assert validate_service_account_config("srv", cfg) == []
+
+    def test_missing_required_fields(self):
+        from tools.mcp_service_account import validate_service_account_config
+        errors = validate_service_account_config("srv", {})
+        assert any("token_url" in e for e in errors)
+        assert any("client_id" in e for e in errors)
+        assert any("username" in e for e in errors)
+        assert any("password_env" in e for e in errors)
+
+    def test_invalid_password_env_name(self):
+        from tools.mcp_service_account import validate_service_account_config
+        cfg = _make_sa_config(password_env="bad name!")
+        errors = validate_service_account_config("srv", cfg)
+        assert any("password_env" in e for e in errors)
+
+    def test_invalid_client_secret_env_name(self):
+        from tools.mcp_service_account import validate_service_account_config
+        cfg = _make_sa_config(client_secret_env="bad name!")
+        errors = validate_service_account_config("srv", cfg)
+        assert any("client_secret_env" in e for e in errors)
+
+    def test_invalid_token_url_scheme(self):
+        from tools.mcp_service_account import validate_service_account_config
+        cfg = _make_sa_config(token_url="ftp://bad.example/token")
+        errors = validate_service_account_config("srv", cfg)
+        assert any("token_url" in e for e in errors)
+
+    def test_not_a_dict(self):
+        from tools.mcp_service_account import validate_service_account_config
+        errors = validate_service_account_config("srv", "string")  # type: ignore
+        assert errors
+
+
+# ---------------------------------------------------------------------------
+# Password resolution
+# ---------------------------------------------------------------------------
+
+class TestResolvePassword:
+    def test_reads_from_env(self, monkeypatch):
+        from tools.mcp_service_account import _resolve_password
+        monkeypatch.setenv("MY_PASS", "secret123")
+        assert _resolve_password({"password_env": "MY_PASS"}, "srv") == "secret123"
+
+    def test_missing_env_raises_with_env_name_not_value(self, monkeypatch):
+        from tools.mcp_service_account import _resolve_password
+        monkeypatch.delenv("MISSING_VAR", raising=False)
+        with pytest.raises(ValueError) as exc:
+            _resolve_password({"password_env": "MISSING_VAR"}, "srv")
+        msg = str(exc.value)
+        assert "MISSING_VAR" in msg
+        # The error message should include the env-var *name*, not attempt to show any value
+        assert "secret" not in msg.lower()
+
+    def test_no_password_env_raises(self):
+        from tools.mcp_service_account import _resolve_password
+        with pytest.raises(ValueError, match="password_env is required"):
+            _resolve_password({}, "srv")
+
+
+# ---------------------------------------------------------------------------
+# Token acquisition — first call
+# ---------------------------------------------------------------------------
+
+class TestFirstTokenAcquisition:
+    @pytest.mark.asyncio
+    async def test_injects_bearer_header(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("TEST_SA_PASSWORD", "hunter2")
+
+        from tools.mcp_service_account import (
+            ServiceAccountAuth,
+            _clear_refresh_locks_for_tests,
+        )
+        _clear_refresh_locks_for_tests()
+
+        cfg = _make_sa_config()
+        auth = ServiceAccountAuth("srv", cfg, hermes_home=tmp_path)
+
+        fake_client = _FakeHttpxClient([
+            _FakeResponse(200, _fake_token_response("TOKEN_A")),
+        ])
+
+        request = MagicMock()
+        request.headers = {}
+        request.status_code = 200
+
+        # Patch the httpx client constructor used inside async_auth_flow
+        with patch("tools.mcp_service_account.ServiceAccountAuth._exchange_service_account",
+                   new=AsyncMock(return_value=_parse_token("TOKEN_A"))):
+            gen = auth.async_auth_flow(request)
+            sent_request = await gen.__anext__()
+            # Feed a 200 response — no retry needed
+            resp = MagicMock()
+            resp.status_code = 200
+            with pytest.raises(StopAsyncIteration):
+                await gen.asend(resp)
+
+        assert sent_request.headers.get("Authorization") == "Bearer TOKEN_A"
+
+    @pytest.mark.asyncio
+    async def test_posts_correct_grant_form(self, tmp_path, monkeypatch):
+        """Verify the client_credentials form fields via _post_token_request."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("TEST_SA_PASSWORD", "hunter2")
+
+        from tools.mcp_service_account import (
+            ServiceAccountAuth,
+            _clear_refresh_locks_for_tests,
+        )
+        _clear_refresh_locks_for_tests()
+
+        cfg = _make_sa_config()
+        auth = ServiceAccountAuth("srv", cfg, hermes_home=tmp_path)
+        posted_forms: list[dict] = []
+
+        async def _capture_post(http_client, token_url, form, server_name):
+            posted_forms.append(dict(form))
+            # _post_token_request returns the raw JSON dict from the token endpoint
+            return _fake_token_response("TOK")
+
+        with patch("tools.mcp_service_account._post_token_request", _capture_post):
+            request = MagicMock()
+            request.headers = {}
+            gen = auth.async_auth_flow(request)
+            await gen.__anext__()
+            resp = MagicMock()
+            resp.status_code = 200
+            try:
+                await gen.asend(resp)
+            except StopAsyncIteration:
+                pass
+
+        assert posted_forms, "No token request was made"
+        form = posted_forms[0]
+        assert form["grant_type"] == "client_credentials"
+        assert form["client_id"] == "toolhive"
+        assert form["username"] == "zug"
+        assert form["password"] == "hunter2"
+        assert "scope" in form
+
+
+def _parse_token(access_token: str, expires_in: int = 3600, refresh_token: str | None = None):
+    """Build a _CachedToken for test use."""
+    from tools.mcp_service_account import _CachedToken
+    return _CachedToken(access_token, time.time() + expires_in, refresh_token)
+
+
+# ---------------------------------------------------------------------------
+# Token caching
+# ---------------------------------------------------------------------------
+
+class TestTokenCaching:
+    @pytest.mark.asyncio
+    async def test_cached_token_reused_no_second_exchange(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("TEST_SA_PASSWORD", "pw")
+
+        from tools.mcp_service_account import (
+            ServiceAccountAuth,
+            _clear_refresh_locks_for_tests,
+        )
+        _clear_refresh_locks_for_tests()
+
+        cfg = _make_sa_config()
+        auth = ServiceAccountAuth("srv", cfg, hermes_home=tmp_path)
+
+        exchange_count = 0
+
+        async def _fake_exchange(self_inner, http_client):
+            nonlocal exchange_count
+            exchange_count += 1
+            return _parse_token("CACHED_TOK")
+
+        with patch.object(ServiceAccountAuth, "_exchange_service_account", _fake_exchange):
+            # First request
+            for _ in range(2):
+                req = MagicMock()
+                req.headers = {}
+                gen = auth.async_auth_flow(req)
+                await gen.__anext__()
+                resp = MagicMock()
+                resp.status_code = 200
+                try:
+                    await gen.asend(resp)
+                except StopAsyncIteration:
+                    pass
+
+        assert exchange_count == 1, "Token should be reused, not re-fetched"
+
+    @pytest.mark.asyncio
+    async def test_expired_token_triggers_renewal(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("TEST_SA_PASSWORD", "pw")
+
+        from tools.mcp_service_account import (
+            ServiceAccountAuth,
+            _CachedToken,
+            _clear_refresh_locks_for_tests,
+        )
+        _clear_refresh_locks_for_tests()
+
+        cfg = _make_sa_config()
+        auth = ServiceAccountAuth("srv", cfg, hermes_home=tmp_path)
+        # Seed an already-expired token
+        auth._mem_token = _CachedToken("OLD_TOK", time.time() - 10)
+
+        exchange_count = 0
+
+        async def _fake_exchange(self_inner, http_client):
+            nonlocal exchange_count
+            exchange_count += 1
+            return _parse_token("FRESH_TOK")
+
+        with patch.object(ServiceAccountAuth, "_exchange_service_account", _fake_exchange):
+            req = MagicMock()
+            req.headers = {}
+            gen = auth.async_auth_flow(req)
+            sent = await gen.__anext__()
+            resp = MagicMock()
+            resp.status_code = 200
+            try:
+                await gen.asend(resp)
+            except StopAsyncIteration:
+                pass
+
+        assert sent.headers["Authorization"] == "Bearer FRESH_TOK"
+        assert exchange_count == 1
+
+    @pytest.mark.asyncio
+    async def test_near_expiry_triggers_proactive_renewal(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("TEST_SA_PASSWORD", "pw")
+
+        from tools.mcp_service_account import (
+            ServiceAccountAuth,
+            _CachedToken,
+            _PROACTIVE_RENEW_BUFFER_SECONDS,
+            _clear_refresh_locks_for_tests,
+        )
+        _clear_refresh_locks_for_tests()
+
+        cfg = _make_sa_config()
+        auth = ServiceAccountAuth("srv", cfg, hermes_home=tmp_path)
+        # Token expiring within the buffer window
+        auth._mem_token = _CachedToken(
+            "NEAR_EXPIRY_TOK",
+            time.time() + _PROACTIVE_RENEW_BUFFER_SECONDS - 5,
+        )
+
+        async def _fake_exchange(self_inner, http_client):
+            return _parse_token("RENEWED_TOK")
+
+        with patch.object(ServiceAccountAuth, "_exchange_service_account", _fake_exchange):
+            req = MagicMock()
+            req.headers = {}
+            gen = auth.async_auth_flow(req)
+            sent = await gen.__anext__()
+            resp = MagicMock()
+            resp.status_code = 200
+            try:
+                await gen.asend(resp)
+            except StopAsyncIteration:
+                pass
+
+        assert sent.headers["Authorization"] == "Bearer RENEWED_TOK"
+
+    @pytest.mark.asyncio
+    async def test_disk_cache_written_and_read(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("TEST_SA_PASSWORD", "pw")
+
+        from tools.mcp_service_account import (
+            ServiceAccountAuth,
+            _get_sa_token_path,
+            _clear_refresh_locks_for_tests,
+        )
+        _clear_refresh_locks_for_tests()
+
+        cfg = _make_sa_config()
+        auth = ServiceAccountAuth("srv", cfg, hermes_home=tmp_path)
+
+        async def _fake_exchange(self_inner, http_client):
+            return _parse_token("DISK_TOK")
+
+        with patch.object(ServiceAccountAuth, "_exchange_service_account", _fake_exchange):
+            req = MagicMock()
+            req.headers = {}
+            gen = auth.async_auth_flow(req)
+            await gen.__anext__()
+            resp = MagicMock()
+            resp.status_code = 200
+            try:
+                await gen.asend(resp)
+            except StopAsyncIteration:
+                pass
+
+        cache_path = _get_sa_token_path("srv", tmp_path)
+        assert cache_path.exists()
+        data = json.loads(cache_path.read_text())
+        assert data["access_token"] == "DISK_TOK"
+        # File must be mode 0600
+        mode = cache_path.stat().st_mode & 0o777
+        assert mode == 0o600, f"Expected 0600, got {oct(mode)}"
+
+    @pytest.mark.asyncio
+    async def test_disk_cache_cold_load(self, tmp_path, monkeypatch):
+        """A fresh ServiceAccountAuth instance reads the disk cache."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("TEST_SA_PASSWORD", "pw")
+
+        from tools.mcp_service_account import (
+            ServiceAccountAuth,
+            _get_sa_token_path,
+            _write_token_cache,
+            _clear_refresh_locks_for_tests,
+        )
+        _clear_refresh_locks_for_tests()
+
+        # Write a valid token cache manually
+        cache_path = _get_sa_token_path("srv", tmp_path)
+        _write_token_cache(cache_path, {
+            "access_token": "COLD_TOK",
+            "expires_at": time.time() + 3600,
+        })
+
+        exchange_count = 0
+
+        async def _fake_exchange(self_inner, http_client):
+            nonlocal exchange_count
+            exchange_count += 1
+            return _parse_token("NEW_TOK")
+
+        cfg = _make_sa_config()
+        auth = ServiceAccountAuth("srv", cfg, hermes_home=tmp_path)
+
+        with patch.object(ServiceAccountAuth, "_exchange_service_account", _fake_exchange):
+            req = MagicMock()
+            req.headers = {}
+            gen = auth.async_auth_flow(req)
+            sent = await gen.__anext__()
+            resp = MagicMock()
+            resp.status_code = 200
+            try:
+                await gen.asend(resp)
+            except StopAsyncIteration:
+                pass
+
+        assert sent.headers["Authorization"] == "Bearer COLD_TOK"
+        assert exchange_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Refresh-token path
+# ---------------------------------------------------------------------------
+
+class TestRefreshTokenPath:
+    @pytest.mark.asyncio
+    async def test_refresh_token_used_before_service_account(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("TEST_SA_PASSWORD", "pw")
+
+        from tools.mcp_service_account import (
+            ServiceAccountAuth,
+            _CachedToken,
+            _clear_refresh_locks_for_tests,
+        )
+        _clear_refresh_locks_for_tests()
+
+        cfg = _make_sa_config()
+        auth = ServiceAccountAuth("srv", cfg, hermes_home=tmp_path)
+        # Expired token with a refresh_token
+        auth._mem_token = _CachedToken("OLD_TOK", time.time() - 10, "REFRESH_ME")
+
+        refresh_called = []
+        exchange_called = []
+
+        async def _fake_refresh(self_inner, http_client, refresh_token):
+            refresh_called.append(refresh_token)
+            return _parse_token("REFRESHED_TOK")
+
+        async def _fake_exchange(self_inner, http_client):
+            exchange_called.append(True)
+            return _parse_token("SA_TOK")
+
+        with (
+            patch.object(ServiceAccountAuth, "_exchange_refresh_token", _fake_refresh),
+            patch.object(ServiceAccountAuth, "_exchange_service_account", _fake_exchange),
+        ):
+            req = MagicMock()
+            req.headers = {}
+            gen = auth.async_auth_flow(req)
+            sent = await gen.__anext__()
+            resp = MagicMock()
+            resp.status_code = 200
+            try:
+                await gen.asend(resp)
+            except StopAsyncIteration:
+                pass
+
+        assert sent.headers["Authorization"] == "Bearer REFRESHED_TOK"
+        assert refresh_called == ["REFRESH_ME"]
+        assert exchange_called == []
+
+    @pytest.mark.asyncio
+    async def test_refresh_token_failure_falls_back_to_service_account(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("TEST_SA_PASSWORD", "pw")
+
+        from tools.mcp_service_account import (
+            ServiceAccountAuth,
+            _CachedToken,
+            _clear_refresh_locks_for_tests,
+        )
+        _clear_refresh_locks_for_tests()
+
+        cfg = _make_sa_config()
+        auth = ServiceAccountAuth("srv", cfg, hermes_home=tmp_path)
+        auth._mem_token = _CachedToken("OLD_TOK", time.time() - 10, "BAD_REFRESH")
+
+        async def _fake_refresh(self_inner, http_client, refresh_token):
+            return None  # simulate failure
+
+        async def _fake_exchange(self_inner, http_client):
+            return _parse_token("FALLBACK_TOK")
+
+        with (
+            patch.object(ServiceAccountAuth, "_exchange_refresh_token", _fake_refresh),
+            patch.object(ServiceAccountAuth, "_exchange_service_account", _fake_exchange),
+        ):
+            req = MagicMock()
+            req.headers = {}
+            gen = auth.async_auth_flow(req)
+            sent = await gen.__anext__()
+            resp = MagicMock()
+            resp.status_code = 200
+            try:
+                await gen.asend(resp)
+            except StopAsyncIteration:
+                pass
+
+        assert sent.headers["Authorization"] == "Bearer FALLBACK_TOK"
+
+
+# ---------------------------------------------------------------------------
+# 401 retry
+# ---------------------------------------------------------------------------
+
+class TestFourOhOneRetry:
+    @pytest.mark.asyncio
+    async def test_401_triggers_retry_with_new_token(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("TEST_SA_PASSWORD", "pw")
+
+        from tools.mcp_service_account import (
+            ServiceAccountAuth,
+            _CachedToken,
+            _clear_refresh_locks_for_tests,
+        )
+        _clear_refresh_locks_for_tests()
+
+        cfg = _make_sa_config()
+        auth = ServiceAccountAuth("srv", cfg, hermes_home=tmp_path)
+        # Pre-populate a valid in-memory token so the first request uses it
+        # without calling exchange. Exchange is only called on the 401 retry.
+        auth._mem_token = _CachedToken("STALE_TOK", time.time() + 3600)
+
+        async def _fake_exchange(self_inner, http_client):
+            return _parse_token("FRESH_TOK")
+
+        with patch.object(ServiceAccountAuth, "_exchange_service_account", _fake_exchange):
+            req = MagicMock()
+            req.headers = {}
+            gen = auth.async_auth_flow(req)
+
+            # First yield — stale token is in cache, injected
+            first_req = await gen.__anext__()
+            assert first_req.headers["Authorization"] == "Bearer STALE_TOK"
+
+            # Feed a 401 response
+            resp_401 = MagicMock()
+            resp_401.status_code = 401
+            retry_req = await gen.asend(resp_401)
+            assert retry_req.headers["Authorization"] == "Bearer FRESH_TOK"
+
+            # End the flow
+            resp_200 = MagicMock()
+            resp_200.status_code = 200
+            try:
+                await gen.asend(resp_200)
+            except StopAsyncIteration:
+                pass
+
+
+# ---------------------------------------------------------------------------
+# Concurrent refresh deduplication
+# ---------------------------------------------------------------------------
+
+class TestConcurrentRefresh:
+    @pytest.mark.asyncio
+    async def test_concurrent_requests_only_one_exchange(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("TEST_SA_PASSWORD", "pw")
+
+        from tools.mcp_service_account import (
+            ServiceAccountAuth,
+            _clear_refresh_locks_for_tests,
+        )
+        _clear_refresh_locks_for_tests()
+
+        cfg = _make_sa_config()
+        exchange_count = [0]
+
+        async def _slow_exchange(self_inner, http_client):
+            exchange_count[0] += 1
+            await asyncio.sleep(0.01)
+            return _parse_token("SHARED_TOK")
+
+        async def _run_one():
+            auth = ServiceAccountAuth("srv", cfg, hermes_home=tmp_path)
+            req = MagicMock()
+            req.headers = {}
+            gen = auth.async_auth_flow(req)
+            await gen.__anext__()
+            resp = MagicMock()
+            resp.status_code = 200
+            try:
+                await gen.asend(resp)
+            except StopAsyncIteration:
+                pass
+
+        with patch.object(ServiceAccountAuth, "_exchange_service_account", _slow_exchange):
+            await asyncio.gather(*[_run_one() for _ in range(5)])
+
+        # Only one exchange should have fired (others waited on the lock and
+        # found the cached token after the lock was released).
+        assert exchange_count[0] == 1
+
+
+# ---------------------------------------------------------------------------
+# Error cases
+# ---------------------------------------------------------------------------
+
+class TestErrorCases:
+    @pytest.mark.asyncio
+    async def test_missing_password_env_raises_actionable_error(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.delenv("NO_SUCH_ENV", raising=False)
+
+        from tools.mcp_service_account import ServiceAccountAuth, _clear_refresh_locks_for_tests
+        _clear_refresh_locks_for_tests()
+
+        cfg = _make_sa_config(password_env="NO_SUCH_ENV")
+        auth = ServiceAccountAuth("srv", cfg, hermes_home=tmp_path)
+
+        req = MagicMock()
+        req.headers = {}
+        gen = auth.async_auth_flow(req)
+        with pytest.raises(ValueError) as exc:
+            await gen.__anext__()
+        msg = str(exc.value)
+        assert "NO_SUCH_ENV" in msg
+        # No secret should appear — env var is not set so there's nothing to leak,
+        # but let's verify the message structure is about the missing var name.
+        assert "not set" in msg.lower() or "missing" in msg.lower() or "empty" in msg.lower()
+
+    @pytest.mark.asyncio
+    async def test_malformed_token_response_raises_clear_error(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("TEST_SA_PASSWORD", "pw")
+
+        from tools.mcp_service_account import (
+            ServiceAccountAuth,
+            _clear_refresh_locks_for_tests,
+            _post_token_request,
+        )
+        _clear_refresh_locks_for_tests()
+
+        cfg = _make_sa_config()
+        auth = ServiceAccountAuth("srv", cfg, hermes_home=tmp_path)
+
+        async def _bad_post(http_client, token_url, form, server_name):
+            return {"not_an_access_token": True}
+
+        with patch("tools.mcp_service_account._post_token_request", _bad_post):
+            req = MagicMock()
+            req.headers = {}
+            gen = auth.async_auth_flow(req)
+            with pytest.raises(ValueError, match="access_token"):
+                await gen.__anext__()
+
+    @pytest.mark.asyncio
+    async def test_token_endpoint_http_500_raises_clear_error(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("TEST_SA_PASSWORD", "pw")
+
+        from tools.mcp_service_account import (
+            ServiceAccountAuth,
+            _clear_refresh_locks_for_tests,
+        )
+        _clear_refresh_locks_for_tests()
+
+        cfg = _make_sa_config()
+        auth = ServiceAccountAuth("srv", cfg, hermes_home=tmp_path)
+
+        async def _bad_post(http_client, token_url, form, server_name):
+            raise ValueError(f"MCP service-account '{server_name}': token endpoint returned HTTP 500")
+
+        with patch("tools.mcp_service_account._post_token_request", _bad_post):
+            req = MagicMock()
+            req.headers = {}
+            gen = auth.async_auth_flow(req)
+            with pytest.raises(ValueError, match="HTTP 500"):
+                await gen.__anext__()
+
+
+# ---------------------------------------------------------------------------
+# No secrets in logs
+# ---------------------------------------------------------------------------
+
+class TestNoSecretsInLogs:
+    @pytest.mark.asyncio
+    async def test_password_not_in_logs_or_errors(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        secret_password = "super_secret_hunter2"
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("TEST_SA_PASSWORD", secret_password)
+
+        from tools.mcp_service_account import (
+            ServiceAccountAuth,
+            _clear_refresh_locks_for_tests,
+        )
+        _clear_refresh_locks_for_tests()
+
+        cfg = _make_sa_config()
+        auth = ServiceAccountAuth("srv", cfg, hermes_home=tmp_path)
+
+        async def _fake_exchange(self_inner, http_client):
+            return _parse_token("TOK")
+
+        with caplog.at_level(logging.DEBUG, logger="tools.mcp_service_account"):
+            with patch.object(ServiceAccountAuth, "_exchange_service_account", _fake_exchange):
+                req = MagicMock()
+                req.headers = {}
+                gen = auth.async_auth_flow(req)
+                await gen.__anext__()
+                resp = MagicMock()
+                resp.status_code = 200
+                try:
+                    await gen.asend(resp)
+                except StopAsyncIteration:
+                    pass
+
+        for record in caplog.records:
+            assert secret_password not in record.getMessage(), (
+                f"Password leaked in log: {record.getMessage()}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_access_token_not_in_logs(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("TEST_SA_PASSWORD", "pw")
+
+        from tools.mcp_service_account import (
+            ServiceAccountAuth,
+            _clear_refresh_locks_for_tests,
+        )
+        _clear_refresh_locks_for_tests()
+
+        secret_token = "very_secret_access_token_xyz"
+        cfg = _make_sa_config()
+        auth = ServiceAccountAuth("srv", cfg, hermes_home=tmp_path)
+
+        async def _fake_exchange(self_inner, http_client):
+            return _parse_token(secret_token)
+
+        with caplog.at_level(logging.DEBUG, logger="tools.mcp_service_account"):
+            with patch.object(ServiceAccountAuth, "_exchange_service_account", _fake_exchange):
+                req = MagicMock()
+                req.headers = {}
+                gen = auth.async_auth_flow(req)
+                await gen.__anext__()
+                resp = MagicMock()
+                resp.status_code = 200
+                try:
+                    await gen.asend(resp)
+                except StopAsyncIteration:
+                    pass
+
+        for record in caplog.records:
+            assert secret_token not in record.getMessage(), (
+                f"Access token leaked in log: {record.getMessage()}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Profile / home isolation
+# ---------------------------------------------------------------------------
+
+class TestProfileIsolation:
+    @pytest.mark.asyncio
+    async def test_two_profiles_separate_caches(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("TEST_SA_PASSWORD", "pw")
+
+        from tools.mcp_service_account import (
+            ServiceAccountAuth,
+            _get_sa_token_path,
+            _clear_refresh_locks_for_tests,
+        )
+        _clear_refresh_locks_for_tests()
+
+        home_a = tmp_path / "profile-a"
+        home_b = tmp_path / "profile-b"
+        cfg = _make_sa_config()
+
+        tokens_issued = []
+
+        async def _fake_exchange(self_inner, http_client):
+            tok = f"TOK_{len(tokens_issued)}"
+            tokens_issued.append(tok)
+            return _parse_token(tok)
+
+        with patch.object(ServiceAccountAuth, "_exchange_service_account", _fake_exchange):
+            for home in (home_a, home_b):
+                auth = ServiceAccountAuth("srv", cfg, hermes_home=home)
+                req = MagicMock()
+                req.headers = {}
+                gen = auth.async_auth_flow(req)
+                await gen.__anext__()
+                resp = MagicMock()
+                resp.status_code = 200
+                try:
+                    await gen.asend(resp)
+                except StopAsyncIteration:
+                    pass
+
+        # Each profile has its own cache file
+        path_a = _get_sa_token_path("srv", home_a)
+        path_b = _get_sa_token_path("srv", home_b)
+        assert path_a.exists()
+        assert path_b.exists()
+        assert path_a != path_b
+
+        data_a = json.loads(path_a.read_text())
+        data_b = json.loads(path_b.read_text())
+        assert data_a["access_token"] != data_b["access_token"]
+
+
+# ---------------------------------------------------------------------------
+# Backwards compatibility — header and oauth modes still work
+# ---------------------------------------------------------------------------
+
+class TestBackwardsCompatibility:
+    def test_header_mode_config_unchanged(self):
+        """auth: header config still passes through mcp_config helpers."""
+        from hermes_cli.mcp_config import _bearer_auth_headers, _env_key_for_server
+        key = _env_key_for_server("myserver")
+        headers = _bearer_auth_headers("myserver")
+        assert headers == {"Authorization": f"Bearer ${{{key}}}"}
+
+    def test_service_account_mode_does_not_break_oauth_manager(self, tmp_path, monkeypatch):
+        """build_service_account_auth is independent of MCPOAuthManager."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from tools.mcp_service_account import build_service_account_auth, validate_service_account_config
+        from tools.mcp_oauth_manager import get_manager
+
+        cfg = _make_sa_config()
+        assert validate_service_account_config("srv", cfg) == []
+        # Manager should still work independently
+        mgr = get_manager()
+        assert mgr is not None
+
+    def test_build_service_account_auth_raises_on_bad_config(self):
+        from tools.mcp_service_account import build_service_account_auth
+        with pytest.raises(ValueError):
+            build_service_account_auth("srv", {})  # missing required fields
+
+
+# ---------------------------------------------------------------------------
+# Token cache file permissions
+# ---------------------------------------------------------------------------
+
+class TestTokenCacheFilePermissions:
+    @pytest.mark.asyncio
+    async def test_cache_file_is_mode_0600(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("TEST_SA_PASSWORD", "pw")
+
+        from tools.mcp_service_account import (
+            ServiceAccountAuth,
+            _get_sa_token_path,
+            _clear_refresh_locks_for_tests,
+        )
+        _clear_refresh_locks_for_tests()
+
+        cfg = _make_sa_config()
+        auth = ServiceAccountAuth("srv", cfg, hermes_home=tmp_path)
+
+        async def _fake_exchange(self_inner, http_client):
+            return _parse_token("TOK")
+
+        with patch.object(ServiceAccountAuth, "_exchange_service_account", _fake_exchange):
+            req = MagicMock()
+            req.headers = {}
+            gen = auth.async_auth_flow(req)
+            await gen.__anext__()
+            resp = MagicMock()
+            resp.status_code = 200
+            try:
+                await gen.asend(resp)
+            except StopAsyncIteration:
+                pass
+
+        cache_path = _get_sa_token_path("srv", tmp_path)
+        mode = cache_path.stat().st_mode & 0o777
+        assert mode == 0o600, f"Expected 0600, got {oct(mode)}"

--- a/tools/mcp_service_account.py
+++ b/tools/mcp_service_account.py
@@ -39,6 +39,15 @@ to disk. If the server returns a ``refresh_token``, it is cached and used
 on subsequent renewals, falling back to a fresh service-account exchange
 if the refresh fails.
 
+httpx compatibility
+-------------------
+``ServiceAccountAuth`` inherits from the ``Auth`` class exported by
+whichever httpx distribution the installed MCP SDK uses (plain ``httpx``
+for mcp < 2.0, ``httpx2`` for mcp >= 2.0).  The base class is resolved
+once at module import time via :func:`_resolve_auth_base` and stored in
+``_SA_AUTH_BASE``.  This makes the provider a valid ``isinstance(...,
+httpx.Auth)`` object and therefore acceptable to ``AsyncClient(auth=...)``.
+
 Security
 --------
 - TLS verification is always on; no way to disable it from config.
@@ -59,8 +68,9 @@ import re
 import secrets
 import stat
 import time
+import threading as _threading
 from pathlib import Path
-from typing import Any, AsyncGenerator, Optional
+from typing import Any, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -69,6 +79,40 @@ _PROACTIVE_RENEW_BUFFER_SECONDS = 60
 
 # ── Env-var name validation — same rule as shell identifier.
 _ENV_VAR_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+# ---------------------------------------------------------------------------
+# httpx Auth base — resolved from the SDK's own httpx distribution
+# ---------------------------------------------------------------------------
+
+def _resolve_auth_base() -> type:
+    """Return the ``Auth`` base class from the MCP SDK's httpx distribution.
+
+    mcp >= 2.0 ships its transports against ``httpx2`` rather than the
+    upstream ``httpx``.  ``AsyncClient(auth=...)`` uses ``isinstance(auth,
+    Auth)`` from *its own* httpx module, so the provider must inherit from
+    the same class.  We mirror what :func:`tools.mcp_tool.sdk_httpx` does
+    (read the transport module's ``httpx2`` or ``httpx`` attribute) without
+    importing all of ``mcp_tool`` to avoid a heavy circular-import at
+    module load time.
+    """
+    try:
+        from mcp.client import streamable_http as _transport
+        _mod = getattr(_transport, "httpx2", None) or getattr(_transport, "httpx", None)
+        if _mod is not None and hasattr(_mod, "Auth"):
+            return _mod.Auth
+    except ImportError:
+        pass
+    # Fallback: httpx2 then httpx
+    try:
+        import httpx2 as _h
+        return _h.Auth
+    except ImportError:
+        import httpx as _h  # type: ignore[no-redef]
+        return _h.Auth
+
+
+_SA_AUTH_BASE: type = _resolve_auth_base()
 
 
 # ---------------------------------------------------------------------------
@@ -151,9 +195,6 @@ def _resolve_client_secret(cfg: dict) -> Optional[str]:
 # ---------------------------------------------------------------------------
 # Token cache (disk)
 # ---------------------------------------------------------------------------
-
-# Lazy import helpers shared with mcp_oauth.py — imported inside functions to
-# avoid a circular-import at module load time.
 
 def _get_sa_token_path(server_name: str, hermes_home: Optional[str | Path] = None) -> Path:
     """Return the path to the service-account token cache file.
@@ -334,10 +375,6 @@ def _parse_token_response(
 # ---------------------------------------------------------------------------
 
 # Keyed by (hermes_home_str, server_name) → asyncio.Lock.
-# Using a plain dict with a module-level lock for thread-safe creation.
-
-import threading as _threading
-
 _refresh_locks: dict[tuple[str, str], asyncio.Lock] = {}
 _refresh_locks_mu = _threading.Lock()
 
@@ -359,18 +396,17 @@ def _clear_refresh_locks_for_tests() -> None:
 
 
 # ---------------------------------------------------------------------------
-# ServiceAccountAuth — httpx.Auth subclass
+# ServiceAccountAuth — inherits from the SDK's httpx.Auth
 # ---------------------------------------------------------------------------
 
 
-class ServiceAccountAuth:
-    """httpx.Auth-compatible provider for service-account M2M token exchange.
+class ServiceAccountAuth(_SA_AUTH_BASE):  # type: ignore[valid-type,misc]
+    """httpx.Auth subclass for service-account M2M token exchange.
 
-    Usage::
-
-        auth = build_service_account_auth("toolhive", cfg)
-        async with httpx.AsyncClient(auth=auth) as client:
-            resp = await client.get("https://mcp.example/mcp")
+    Inherits from the ``Auth`` class of whichever httpx distribution the
+    installed MCP SDK uses (``httpx`` for mcp < 2.0, ``httpx2`` for mcp
+    >= 2.0).  This satisfies ``AsyncClient(auth=...)``'s ``isinstance``
+    check on both SDK generations.
 
     The provider:
     - Caches tokens to disk at ``$HERMES_HOME/mcp-tokens/<server>-sa.json``.
@@ -380,6 +416,14 @@ class ServiceAccountAuth:
     - Never logs passwords, tokens, or Authorization header values.
     """
 
+    # Tell httpx we need to read both request and response bodies so the
+    # base-class sync stub in auth_flow() is never called (we fully override
+    # async_auth_flow).  Setting these to False is safe because our
+    # async_auth_flow is a complete async generator that never delegates to
+    # the sync auth_flow() path.
+    requires_request_body = False
+    requires_response_body = False
+
     def __init__(
         self,
         server_name: str,
@@ -387,6 +431,8 @@ class ServiceAccountAuth:
         *,
         hermes_home: Optional[str | Path] = None,
     ):
+        # httpx.Auth.__init__ takes no arguments, but call it for compat.
+        super().__init__()
         self._server_name = server_name
         self._cfg = dict(sa_config)
         from hermes_constants import get_hermes_home
@@ -525,20 +571,45 @@ class ServiceAccountAuth:
 
     # -- httpx.Auth protocol -------------------------------------------------
 
-    async def async_auth_flow(
-        self, request: Any
-    ) -> AsyncGenerator[Any, Any]:
-        """httpx async auth flow: inject token, handle one 401 retry."""
-        # Lazily import httpx from whatever flavour the MCP SDK uses.
-        try:
-            from tools.mcp_tool import sdk_httpx
-            _httpx = sdk_httpx()
-        except Exception:
-            import httpx as _httpx
+    def auth_flow(self, request: Any):  # type: ignore[override]
+        # httpx.Auth requires a sync auth_flow stub; the async path below
+        # is used exclusively in our async MCP context.  This stub is never
+        # called because async_auth_flow is overridden and httpx prefers it.
+        raise NotImplementedError(  # pragma: no cover
+            "ServiceAccountAuth requires an async context; "
+            "use an AsyncClient, not a sync Client"
+        )
 
-        # Build a minimal internal client to make token requests.
-        # We share TLS settings but not auth (never nest auth providers).
-        async with _httpx.AsyncClient(follow_redirects=True) as token_client:
+    async def async_auth_flow(self, request: Any):  # type: ignore[override]
+        """Inject Bearer token, handle one 401 retry.
+
+        httpx drives this generator:
+          1. ``__anext__()``       → we yield the request with Authorization header
+          2. ``asend(response)``  → we inspect the response
+             - 2xx/other: generator returns → httpx uses that response
+             - 401:  invalidate cache, fetch fresh token, yield retry request
+             - ``asend(response2)`` → generator returns
+        """
+        # Build a small dedicated client for token-endpoint requests.  It is
+        # created fresh each auth-flow invocation so it lives only as long as
+        # a single MCP request (including one possible 401 retry).  We resolve
+        # the correct httpx module here (same logic as _resolve_auth_base) to
+        # handle both mcp 1.x (httpx) and mcp 2.x (httpx2) at runtime.
+        try:
+            from mcp.client import streamable_http as _transport
+            _httpx_mod = (
+                getattr(_transport, "httpx2", None)
+                or getattr(_transport, "httpx", None)
+            )
+        except ImportError:
+            _httpx_mod = None
+        if _httpx_mod is None:
+            try:
+                import httpx2 as _httpx_mod  # type: ignore[no-redef]
+            except ImportError:
+                import httpx as _httpx_mod  # type: ignore[no-redef]
+
+        async with _httpx_mod.AsyncClient(follow_redirects=True) as token_client:
             token = await self._acquire_token(token_client)
 
             # Inject Authorization header without logging the value.
@@ -560,17 +631,9 @@ class ServiceAccountAuth:
             request.headers["Authorization"] = f"Bearer {token.access_token}"
             yield request
 
-    # -- Make this class act as an httpx.Auth without inheriting it ----------
-    # httpx recognises objects with ``async_auth_flow`` as async auth providers
-    # without requiring subclassing.  This keeps us decoupled from whichever
-    # httpx version the MCP SDK vendors (httpx vs httpx2).
-
-    def auth_flow(self, request: Any) -> Any:  # pragma: no cover
-        raise NotImplementedError("Use async_auth_flow")
-
 
 # ---------------------------------------------------------------------------
-# Public entry point
+# Public entry points
 # ---------------------------------------------------------------------------
 
 

--- a/tools/mcp_service_account.py
+++ b/tools/mcp_service_account.py
@@ -1,0 +1,605 @@
+#!/usr/bin/env python3
+"""Service-account (M2M) OAuth credential provider for MCP HTTP servers.
+
+Exchanges a long-lived service-account password for a short-lived Bearer
+access token via the OAuth 2.0 ``client_credentials`` grant, injects
+``Authorization: Bearer <access_token>`` into MCP requests, and renews
+automatically.  This is distinct from the browser-based PKCE flow
+(``auth: oauth``) — no user interaction is required.
+
+Configuration in config.yaml::
+
+    mcp_servers:
+      toolhive:
+        url: https://mcp.example/mcp
+        auth: service_account
+        service_account:
+          token_url: https://idp.example/application/o/toolhive/token/
+          client_id: toolhive
+          username: zug
+          password_env: AUTHENTIK_ZUG_APP_PASSWORD   # env-var name, not value
+          scope: "openid profile groups toolhive-audience"
+          client_secret_env: OPTIONAL_CLIENT_SECRET  # optional
+
+Secret values (password, client_secret) are **never** stored in
+config.yaml. Only the environment-variable *names* appear there; the
+values are read at runtime from the process environment (which is
+populated from the active profile's ``.env`` file before any MCP
+connection is made).
+
+Token caching
+-------------
+Tokens are cached at ``$HERMES_HOME/mcp-tokens/<server>-sa.json`` with
+file permissions 0o600 and atomic write (O_EXCL temp-then-rename). Two
+Hermes profiles with the same server name get separate cache files
+because the path is rooted at the profile's ``HERMES_HOME``.
+
+The access token is cached; the service-account password is never written
+to disk. If the server returns a ``refresh_token``, it is cached and used
+on subsequent renewals, falling back to a fresh service-account exchange
+if the refresh fails.
+
+Security
+--------
+- TLS verification is always on; no way to disable it from config.
+- Passwords, access tokens, Authorization header values, and token
+  responses are never logged.  Errors are redacted before surfacing.
+- ``password_env`` accepts only a legal environment-variable name.
+- The password is fetched once per token exchange and not held in memory
+  beyond the HTTP request coroutine.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import re
+import secrets
+import stat
+import time
+from pathlib import Path
+from typing import Any, AsyncGenerator, Optional
+
+logger = logging.getLogger(__name__)
+
+# ── How many seconds before nominal expiry to proactively renew the token.
+_PROACTIVE_RENEW_BUFFER_SECONDS = 60
+
+# ── Env-var name validation — same rule as shell identifier.
+_ENV_VAR_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+# ---------------------------------------------------------------------------
+# Config helpers
+# ---------------------------------------------------------------------------
+
+
+def validate_service_account_config(name: str, cfg: dict) -> list[str]:
+    """Return a list of human-readable validation errors for a service_account block.
+
+    ``name`` is the MCP server name (for error messages).  ``cfg`` is the
+    value of the ``service_account:`` sub-key in the server config.
+    """
+    errors: list[str] = []
+    if not isinstance(cfg, dict):
+        return [f"MCP server '{name}': service_account must be a mapping"]
+
+    required = ("token_url", "client_id", "username", "password_env")
+    for field in required:
+        if not cfg.get(field):
+            errors.append(
+                f"MCP server '{name}': service_account.{field} is required"
+            )
+
+    token_url = cfg.get("token_url", "")
+    if token_url and not str(token_url).startswith(("https://", "http://")):
+        errors.append(
+            f"MCP server '{name}': service_account.token_url must be an HTTP(S) URL"
+        )
+
+    for env_field in ("password_env", "client_secret_env"):
+        val = cfg.get(env_field)
+        if val and not _ENV_VAR_NAME_RE.match(str(val)):
+            errors.append(
+                f"MCP server '{name}': service_account.{env_field} must be a "
+                "valid environment-variable name (letters, digits, underscores)"
+            )
+
+    return errors
+
+
+def _resolve_password(cfg: dict, server_name: str) -> str:
+    """Fetch the service-account password from the configured source.
+
+    Currently supports only ``password_env`` (an environment-variable name).
+    The variable must be set in the process environment (populated from the
+    active profile's ``.env`` before MCP connections are established).
+
+    Raises ``ValueError`` with a non-secret message if the env var is missing
+    or empty.
+    """
+    env_name = cfg.get("password_env", "")
+    if not env_name:
+        raise ValueError(
+            f"MCP service-account '{server_name}': password_env is required"
+        )
+    if not _ENV_VAR_NAME_RE.match(str(env_name)):
+        raise ValueError(
+            f"MCP service-account '{server_name}': password_env "
+            f"'{env_name}' is not a valid environment-variable name"
+        )
+    value = os.environ.get(str(env_name), "")
+    if not value:
+        raise ValueError(
+            f"MCP service-account '{server_name}': environment variable "
+            f"'{env_name}' is not set or is empty. "
+            f"Set it in your shell or in $HERMES_HOME/.env before connecting."
+        )
+    return value
+
+
+def _resolve_client_secret(cfg: dict) -> Optional[str]:
+    """Return the optional client secret, or None if not configured."""
+    env_name = cfg.get("client_secret_env", "")
+    if not env_name:
+        return None
+    return os.environ.get(str(env_name)) or None
+
+
+# ---------------------------------------------------------------------------
+# Token cache (disk)
+# ---------------------------------------------------------------------------
+
+# Lazy import helpers shared with mcp_oauth.py — imported inside functions to
+# avoid a circular-import at module load time.
+
+def _get_sa_token_path(server_name: str, hermes_home: Optional[str | Path] = None) -> Path:
+    """Return the path to the service-account token cache file.
+
+    Kept in the same ``mcp-tokens`` directory as OAuth tokens so directory
+    permissions (0o700) are already correct.  The ``-sa`` suffix distinguishes
+    this file from the OAuth ``.json`` file for the same server name.
+    """
+    from tools.mcp_oauth import _get_token_dir, _safe_filename
+    return _get_token_dir(hermes_home) / f"{_safe_filename(server_name)}-sa.json"
+
+
+def _read_token_cache(path: Path) -> dict | None:
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def _write_token_cache(path: Path, data: dict) -> None:
+    """Atomically write token cache to *path* with mode 0o600."""
+    from hermes_constants import secure_parent_dir
+    path.parent.mkdir(parents=True, exist_ok=True)
+    secure_parent_dir(path)
+    tmp = path.with_suffix(f".tmp.{os.getpid()}.{secrets.token_hex(4)}")
+    try:
+        fd = os.open(
+            str(tmp),
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+            stat.S_IRUSR | stat.S_IWUSR,
+        )
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump(data, fh, indent=2, default=str)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp, path)
+    except OSError:
+        try:
+            tmp.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise
+
+
+def _delete_token_cache(path: Path) -> None:
+    try:
+        path.unlink(missing_ok=True)
+    except OSError:
+        pass
+
+
+class _CachedToken:
+    """In-memory view of a cached service-account token."""
+
+    def __init__(
+        self,
+        access_token: str,
+        expires_at: float,
+        refresh_token: Optional[str] = None,
+    ):
+        self.access_token = access_token
+        self.expires_at = expires_at
+        self.refresh_token = refresh_token
+
+    def is_valid(self, buffer: float = _PROACTIVE_RENEW_BUFFER_SECONDS) -> bool:
+        return time.time() < self.expires_at - buffer
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "_CachedToken | None":
+        at = data.get("access_token")
+        ea = data.get("expires_at")
+        if not at or not ea:
+            return None
+        try:
+            return cls(
+                access_token=str(at),
+                expires_at=float(ea),
+                refresh_token=data.get("refresh_token") or None,
+            )
+        except (TypeError, ValueError):
+            return None
+
+    def to_dict(self) -> dict:
+        d: dict = {
+            "access_token": self.access_token,
+            "expires_at": self.expires_at,
+        }
+        if self.refresh_token:
+            d["refresh_token"] = self.refresh_token
+        return d
+
+
+# ---------------------------------------------------------------------------
+# HTTP token exchange
+# ---------------------------------------------------------------------------
+
+
+async def _post_token_request(
+    http_client: Any,
+    token_url: str,
+    form: dict,
+    server_name: str,
+) -> dict:
+    """POST form-encoded data to token_url and parse the JSON response.
+
+    Never logs form values (which include the password).  Raises ``ValueError``
+    with a redacted error message on any failure.
+    """
+    try:
+        resp = await http_client.post(
+            token_url,
+            data=form,
+            headers={"Accept": "application/json"},
+        )
+    except Exception as exc:
+        # Redact the URL in case query-string values snuck in somehow.
+        raise ValueError(
+            f"MCP service-account '{server_name}': token endpoint request failed"
+        ) from exc
+
+    if not (200 <= resp.status_code < 300):
+        # Never include the response body — it may echo back the error_description
+        # which can include credential hints.
+        raise ValueError(
+            f"MCP service-account '{server_name}': token endpoint returned "
+            f"HTTP {resp.status_code}"
+        )
+
+    try:
+        body = resp.json()
+    except Exception:
+        raise ValueError(
+            f"MCP service-account '{server_name}': token endpoint returned "
+            "non-JSON response"
+        )
+
+    if not isinstance(body, dict) or "access_token" not in body:
+        raise ValueError(
+            f"MCP service-account '{server_name}': token response missing "
+            "'access_token' field"
+        )
+
+    return body
+
+
+def _parse_token_response(
+    body: dict,
+    server_name: str,
+    *,
+    now: Optional[float] = None,
+) -> _CachedToken:
+    """Parse a standard token response body into a ``_CachedToken``."""
+    access_token = str(body.get("access_token", ""))
+    if not access_token:
+        raise ValueError(
+            f"MCP service-account '{server_name}': empty access_token in response"
+        )
+    expires_in = body.get("expires_in")
+    if expires_in is None:
+        # Default to 1 hour when the server omits expires_in.
+        expires_in = 3600
+    try:
+        expires_in = int(expires_in)
+    except (TypeError, ValueError):
+        expires_in = 3600
+    t = now if now is not None else time.time()
+    return _CachedToken(
+        access_token=access_token,
+        expires_at=t + expires_in,
+        refresh_token=body.get("refresh_token") or None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-server refresh deduplication
+# ---------------------------------------------------------------------------
+
+# Keyed by (hermes_home_str, server_name) → asyncio.Lock.
+# Using a plain dict with a module-level lock for thread-safe creation.
+
+import threading as _threading
+
+_refresh_locks: dict[tuple[str, str], asyncio.Lock] = {}
+_refresh_locks_mu = _threading.Lock()
+
+
+def _get_refresh_lock(server_name: str, hermes_home: str) -> asyncio.Lock:
+    key = (hermes_home, server_name)
+    with _refresh_locks_mu:
+        lock = _refresh_locks.get(key)
+        if lock is None:
+            lock = asyncio.Lock()
+            _refresh_locks[key] = lock
+        return lock
+
+
+def _clear_refresh_locks_for_tests() -> None:
+    """Test-only: reset the global lock table."""
+    with _refresh_locks_mu:
+        _refresh_locks.clear()
+
+
+# ---------------------------------------------------------------------------
+# ServiceAccountAuth — httpx.Auth subclass
+# ---------------------------------------------------------------------------
+
+
+class ServiceAccountAuth:
+    """httpx.Auth-compatible provider for service-account M2M token exchange.
+
+    Usage::
+
+        auth = build_service_account_auth("toolhive", cfg)
+        async with httpx.AsyncClient(auth=auth) as client:
+            resp = await client.get("https://mcp.example/mcp")
+
+    The provider:
+    - Caches tokens to disk at ``$HERMES_HOME/mcp-tokens/<server>-sa.json``.
+    - Proactively renews tokens before they expire (60s buffer).
+    - On a 401, obtains a fresh token and retries the request once.
+    - Deduplicates concurrent refresh attempts within the process.
+    - Never logs passwords, tokens, or Authorization header values.
+    """
+
+    def __init__(
+        self,
+        server_name: str,
+        sa_config: dict,
+        *,
+        hermes_home: Optional[str | Path] = None,
+    ):
+        self._server_name = server_name
+        self._cfg = dict(sa_config)
+        from hermes_constants import get_hermes_home
+        self._hermes_home = str(
+            Path(hermes_home).expanduser().resolve(strict=False)
+            if hermes_home is not None
+            else get_hermes_home()
+        )
+        self._cache_path = _get_sa_token_path(server_name, self._hermes_home)
+        # In-memory token — avoids a disk read on every request.
+        self._mem_token: Optional[_CachedToken] = None
+
+    @property
+    def _refresh_lock(self) -> asyncio.Lock:
+        return _get_refresh_lock(self._server_name, self._hermes_home)
+
+    # -- Token resolution ----------------------------------------------------
+
+    def _load_from_disk(self) -> Optional[_CachedToken]:
+        data = _read_token_cache(self._cache_path)
+        if data is None:
+            return None
+        return _CachedToken.from_dict(data)
+
+    def _save_to_disk(self, token: _CachedToken) -> None:
+        try:
+            _write_token_cache(self._cache_path, token.to_dict())
+        except OSError as exc:
+            logger.warning(
+                "MCP service-account '%s': failed to write token cache: %s",
+                self._server_name, exc,
+            )
+
+    def _get_cached_token(self) -> Optional[_CachedToken]:
+        """Return a valid in-memory or disk-cached token, or None."""
+        if self._mem_token is not None and self._mem_token.is_valid():
+            return self._mem_token
+        disk = self._load_from_disk()
+        if disk is not None and disk.is_valid():
+            self._mem_token = disk
+            return disk
+        return None
+
+    async def _exchange_service_account(self, http_client: Any) -> _CachedToken:
+        """Perform a client_credentials grant using the service-account password."""
+        cfg = self._cfg
+        password = _resolve_password(cfg, self._server_name)
+        client_secret = _resolve_client_secret(cfg)
+
+        form: dict = {
+            "grant_type": "client_credentials",
+            "client_id": cfg["client_id"],
+            "username": cfg["username"],
+            "password": password,
+        }
+        if cfg.get("scope"):
+            form["scope"] = cfg["scope"]
+        if client_secret:
+            form["client_secret"] = client_secret
+
+        body = await _post_token_request(
+            http_client, cfg["token_url"], form, self._server_name
+        )
+        token = _parse_token_response(body, self._server_name)
+        del password
+        if client_secret:
+            del client_secret
+        return token
+
+    async def _exchange_refresh_token(
+        self,
+        http_client: Any,
+        refresh_token: str,
+    ) -> Optional[_CachedToken]:
+        """Try a refresh_token grant; return None on failure."""
+        cfg = self._cfg
+        client_secret = _resolve_client_secret(cfg)
+        form: dict = {
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token,
+            "client_id": cfg["client_id"],
+        }
+        if cfg.get("scope"):
+            form["scope"] = cfg["scope"]
+        if client_secret:
+            form["client_secret"] = client_secret
+        try:
+            body = await _post_token_request(
+                http_client, cfg["token_url"], form, self._server_name
+            )
+            return _parse_token_response(body, self._server_name)
+        except ValueError:
+            logger.debug(
+                "MCP service-account '%s': refresh_token grant failed, "
+                "falling back to service-account exchange",
+                self._server_name,
+            )
+            return None
+
+    async def _acquire_token(self, http_client: Any) -> _CachedToken:
+        """Acquire a fresh token, using refresh_token if available.
+
+        Protected by a per-server asyncio.Lock so concurrent requests only
+        trigger one exchange.
+        """
+        async with self._refresh_lock:
+            # Re-check under lock — another coroutine may have refreshed.
+            cached = self._get_cached_token()
+            if cached is not None:
+                return cached
+
+            # Try refresh_token first.
+            existing = self._load_from_disk() or self._mem_token
+            if existing and existing.refresh_token:
+                new_token = await self._exchange_refresh_token(
+                    http_client, existing.refresh_token
+                )
+                if new_token is not None:
+                    self._mem_token = new_token
+                    self._save_to_disk(new_token)
+                    logger.debug(
+                        "MCP service-account '%s': renewed via refresh_token",
+                        self._server_name,
+                    )
+                    return new_token
+
+            # Fall back to service-account exchange.
+            token = await self._exchange_service_account(http_client)
+            self._mem_token = token
+            self._save_to_disk(token)
+            logger.debug(
+                "MCP service-account '%s': acquired new access token",
+                self._server_name,
+            )
+            return token
+
+    # -- httpx.Auth protocol -------------------------------------------------
+
+    async def async_auth_flow(
+        self, request: Any
+    ) -> AsyncGenerator[Any, Any]:
+        """httpx async auth flow: inject token, handle one 401 retry."""
+        # Lazily import httpx from whatever flavour the MCP SDK uses.
+        try:
+            from tools.mcp_tool import sdk_httpx
+            _httpx = sdk_httpx()
+        except Exception:
+            import httpx as _httpx
+
+        # Build a minimal internal client to make token requests.
+        # We share TLS settings but not auth (never nest auth providers).
+        async with _httpx.AsyncClient(follow_redirects=True) as token_client:
+            token = await self._acquire_token(token_client)
+
+            # Inject Authorization header without logging the value.
+            request.headers["Authorization"] = f"Bearer {token.access_token}"
+            response = yield request
+
+            if response.status_code != 401:
+                return
+
+            # 401: invalidate cache and retry once.
+            logger.debug(
+                "MCP service-account '%s': received 401, refreshing token",
+                self._server_name,
+            )
+            self._mem_token = None
+            _delete_token_cache(self._cache_path)
+
+            token = await self._acquire_token(token_client)
+            request.headers["Authorization"] = f"Bearer {token.access_token}"
+            yield request
+
+    # -- Make this class act as an httpx.Auth without inheriting it ----------
+    # httpx recognises objects with ``async_auth_flow`` as async auth providers
+    # without requiring subclassing.  This keeps us decoupled from whichever
+    # httpx version the MCP SDK vendors (httpx vs httpx2).
+
+    def auth_flow(self, request: Any) -> Any:  # pragma: no cover
+        raise NotImplementedError("Use async_auth_flow")
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def build_service_account_auth(
+    server_name: str,
+    sa_config: dict,
+    *,
+    hermes_home: Optional[str | Path] = None,
+) -> "ServiceAccountAuth":
+    """Build and return a :class:`ServiceAccountAuth` for *server_name*.
+
+    ``sa_config`` is the value of the ``service_account:`` sub-key in the
+    MCP server config dict.  Call this once per server and cache the result;
+    it manages its own token state.
+
+    Raises ``ValueError`` if the config is missing required fields.
+    """
+    errors = validate_service_account_config(server_name, sa_config)
+    if errors:
+        raise ValueError("; ".join(errors))
+    return ServiceAccountAuth(server_name, sa_config, hermes_home=hermes_home)
+
+
+def remove_service_account_tokens(
+    server_name: str,
+    *,
+    hermes_home: Optional[str | Path] = None,
+) -> None:
+    """Delete the on-disk service-account token cache for *server_name*."""
+    path = _get_sa_token_path(server_name, hermes_home)
+    _delete_token_cache(path)
+    logger.info("MCP service-account '%s': removed token cache", server_name)

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -3641,6 +3641,16 @@ class MCPServerTask:
             except Exception as exc:
                 logger.warning("MCP OAuth setup failed for '%s': %s", self.name, exc)
                 raise
+        elif self._auth_type == "service_account":
+            try:
+                from tools.mcp_service_account import build_service_account_auth
+                sa_cfg = config.get("service_account") or {}
+                _oauth_auth = build_service_account_auth(self.name, sa_cfg)
+            except Exception as exc:
+                logger.warning(
+                    "MCP service-account setup failed for '%s': %s", self.name, exc
+                )
+                raise
 
         sampling_kwargs = self._sampling.session_kwargs() if self._sampling else {}
         if self._elicitation:

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1477,7 +1477,8 @@ export interface McpServer {
   command: string | null;
   args: string[];
   env: Record<string, string>;
-  auth: "header" | "oauth" | null;
+  auth: "header" | "oauth" | "service_account" | null;
+  service_account?: McpServiceAccountConfig;
   enabled: boolean;
   tools: string[] | null;
 }
@@ -1512,7 +1513,19 @@ export interface McpCatalogDiagnostic {
 }
 
 
-export type McpHttpAuth = "none" | "header" | "oauth";
+export type McpHttpAuth = "none" | "header" | "oauth" | "service_account";
+
+/** Non-secret service-account fields. Secrets stay in the profile's .env. */
+export interface McpServiceAccountConfig {
+  token_url: string;
+  client_id: string;
+  username: string;
+  /** Name of the env var that holds the password — not the password itself. */
+  password_env: string;
+  scope?: string;
+  /** Name of the env var that holds the client secret (optional). */
+  client_secret_env?: string;
+}
 
 export interface McpServerCreate {
   name: string;
@@ -1522,6 +1535,7 @@ export interface McpServerCreate {
   env?: Record<string, string>;
   auth?: McpHttpAuth;
   bearer_token?: string;
+  service_account?: McpServiceAccountConfig;
 }
 
 export interface McpTestResult {

--- a/web/src/lib/mcp-server-create.test.ts
+++ b/web/src/lib/mcp-server-create.test.ts
@@ -70,6 +70,87 @@ describe("buildMcpServerCreate", () => {
     });
   });
 
+  it("builds a service_account request with non-secret fields only", () => {
+    const server = buildMcpServerCreate({
+      ...emptyMcpServerDraft(),
+      name: "toolhive",
+      url: "https://mcp.example/mcp",
+      httpAuth: "service_account",
+      saTokenUrl: " https://idp.example/o/toolhive/token/ ",
+      saClientId: " toolhive ",
+      saUsername: " svc-user ",
+      saPasswordEnv: "MY_SERVICE_PASSWORD",
+      saScope: "openid profile",
+      saClientSecretEnv: "MY_CLIENT_SECRET",
+    });
+
+    expect(server).toEqual({
+      name: "toolhive",
+      url: "https://mcp.example/mcp",
+      auth: "service_account",
+      service_account: {
+        token_url: "https://idp.example/o/toolhive/token/",
+        client_id: "toolhive",
+        username: "svc-user",
+        password_env: "MY_SERVICE_PASSWORD",
+        scope: "openid profile",
+        client_secret_env: "MY_CLIENT_SECRET",
+      },
+    });
+    // bearer_token must never appear in a service_account request
+    expect("bearer_token" in server).toBe(false);
+  });
+
+  it("omits optional service_account fields when blank", () => {
+    const server = buildMcpServerCreate({
+      ...emptyMcpServerDraft(),
+      name: "minimal",
+      url: "https://mcp.example/mcp",
+      httpAuth: "service_account",
+      saTokenUrl: "https://idp.example/token/",
+      saClientId: "client",
+      saUsername: "user",
+      saPasswordEnv: "PWD_ENV",
+    });
+
+    expect(server.service_account).toEqual({
+      token_url: "https://idp.example/token/",
+      client_id: "client",
+      username: "user",
+      password_env: "PWD_ENV",
+    });
+    expect(server.service_account && "scope" in server.service_account).toBe(false);
+    expect(server.service_account && "client_secret_env" in server.service_account).toBe(false);
+  });
+
+  it("rejects service_account with missing required fields", () => {
+    const base = {
+      ...emptyMcpServerDraft(),
+      name: "sa",
+      url: "https://mcp.example/mcp",
+      httpAuth: "service_account" as const,
+    };
+    expect(() => buildMcpServerCreate(base)).toThrow("Token URL required");
+    expect(() =>
+      buildMcpServerCreate({ ...base, saTokenUrl: "https://idp.example/token/" }),
+    ).toThrow("Client ID required");
+    expect(() =>
+      buildMcpServerCreate({
+        ...base,
+        saTokenUrl: "https://idp.example/token/",
+        saClientId: "c",
+      }),
+    ).toThrow("Username required");
+    expect(() =>
+      buildMcpServerCreate({
+        ...base,
+        saTokenUrl: "https://idp.example/token/",
+        saClientId: "c",
+        saUsername: "u",
+      }),
+    ).toThrow("Password env-var name required");
+  });
+
   it("rejects missing transport fields and Bearer tokens", () => {
     expect(() => buildMcpServerCreate(emptyMcpServerDraft())).toThrow(
       "Name required",

--- a/web/src/lib/mcp-server-create.ts
+++ b/web/src/lib/mcp-server-create.ts
@@ -1,4 +1,4 @@
-import type { McpHttpAuth, McpServerCreate } from "@/lib/api";
+import type { McpHttpAuth, McpServerCreate, McpServiceAccountConfig } from "@/lib/api";
 
 export type McpTransport = "http" | "stdio";
 
@@ -11,6 +11,13 @@ export interface McpServerDraft {
   command: string;
   args: string;
   env: string;
+  // Service account (M2M OAuth) — non-secret fields only.
+  saTokenUrl: string;
+  saClientId: string;
+  saUsername: string;
+  saPasswordEnv: string;
+  saScope: string;
+  saClientSecretEnv: string;
 }
 
 export function emptyMcpServerDraft(): McpServerDraft {
@@ -23,6 +30,12 @@ export function emptyMcpServerDraft(): McpServerDraft {
     command: "",
     args: "",
     env: "",
+    saTokenUrl: "",
+    saClientId: "",
+    saUsername: "",
+    saPasswordEnv: "",
+    saScope: "",
+    saClientSecretEnv: "",
   };
 }
 
@@ -57,11 +70,28 @@ export function buildMcpServerCreate(draft: McpServerDraft): McpServerCreate {
     if (draft.httpAuth === "header" && !draft.bearerToken.trim()) {
       throw new Error("Bearer token required");
     }
+    if (draft.httpAuth === "service_account") {
+      if (!draft.saTokenUrl.trim()) throw new Error("Token URL required");
+      if (!draft.saClientId.trim()) throw new Error("Client ID required");
+      if (!draft.saUsername.trim()) throw new Error("Username required");
+      if (!draft.saPasswordEnv.trim()) throw new Error("Password env-var name required");
+    }
 
     const server: McpServerCreate = { name, url };
     if (draft.httpAuth !== "none") server.auth = draft.httpAuth;
     if (draft.httpAuth === "header") {
       server.bearer_token = draft.bearerToken;
+    }
+    if (draft.httpAuth === "service_account") {
+      const sa: McpServiceAccountConfig = {
+        token_url: draft.saTokenUrl.trim(),
+        client_id: draft.saClientId.trim(),
+        username: draft.saUsername.trim(),
+        password_env: draft.saPasswordEnv.trim(),
+      };
+      if (draft.saScope.trim()) sa.scope = draft.saScope.trim();
+      if (draft.saClientSecretEnv.trim()) sa.client_secret_env = draft.saClientSecretEnv.trim();
+      server.service_account = sa;
     }
     return server;
   }

--- a/web/src/pages/McpPage.tsx
+++ b/web/src/pages/McpPage.tsx
@@ -61,9 +61,22 @@ export default function McpPage() {
   const [command, setCommand] = useState("");
   const [args, setArgs] = useState("");
   const [env, setEnv] = useState("");
+  // Service account (M2M OAuth) fields — non-secret only
+  const [saTokenUrl, setSaTokenUrl] = useState("");
+  const [saClientId, setSaClientId] = useState("");
+  const [saUsername, setSaUsername] = useState("");
+  const [saPasswordEnv, setSaPasswordEnv] = useState("");
+  const [saScope, setSaScope] = useState("");
+  const [saClientSecretEnv, setSaClientSecretEnv] = useState("");
   const [creating, setCreating] = useState(false);
   const closeCreateModal = useCallback(() => {
     setBearerToken("");
+    setSaTokenUrl("");
+    setSaClientId("");
+    setSaUsername("");
+    setSaPasswordEnv("");
+    setSaScope("");
+    setSaClientSecretEnv("");
     setCreateModalOpen(false);
   }, []);
   const createModalRef = useModalBehavior({
@@ -129,6 +142,12 @@ export default function McpPage() {
         command,
         args,
         env,
+        saTokenUrl,
+        saClientId,
+        saUsername,
+        saPasswordEnv,
+        saScope,
+        saClientSecretEnv,
       });
     } catch (error) {
       showToast(
@@ -154,6 +173,12 @@ export default function McpPage() {
       setCommand("");
       setArgs("");
       setEnv("");
+      setSaTokenUrl("");
+      setSaClientId("");
+      setSaUsername("");
+      setSaPasswordEnv("");
+      setSaScope("");
+      setSaClientSecretEnv("");
       setTransport("http");
       setCreateModalOpen(false);
       loadServers();
@@ -427,6 +452,7 @@ export default function McpPage() {
                       <SelectOption value="none">None</SelectOption>
                       <SelectOption value="header">Bearer token</SelectOption>
                       <SelectOption value="oauth">OAuth</SelectOption>
+                      <SelectOption value="service_account">Service account (M2M OAuth)</SelectOption>
                     </Select>
                   </div>
                   {httpAuth === "header" && (
@@ -452,6 +478,73 @@ export default function McpPage() {
                       OAuth browser on the machine running the Dashboard
                       backend.
                     </p>
+                  )}
+                  {httpAuth === "service_account" && (
+                    <>
+                      <div className="grid gap-2">
+                        <Label htmlFor="sa-token-url">Token URL</Label>
+                        <Input
+                          id="sa-token-url"
+                          placeholder="https://idp.example/o/myapp/token/"
+                          value={saTokenUrl}
+                          onChange={(e) => setSaTokenUrl(e.target.value)}
+                        />
+                      </div>
+                      <div className="grid gap-2">
+                        <Label htmlFor="sa-client-id">Client ID</Label>
+                        <Input
+                          id="sa-client-id"
+                          placeholder="my-client"
+                          value={saClientId}
+                          onChange={(e) => setSaClientId(e.target.value)}
+                        />
+                      </div>
+                      <div className="grid gap-2">
+                        <Label htmlFor="sa-username">Username</Label>
+                        <Input
+                          id="sa-username"
+                          placeholder="service-user"
+                          value={saUsername}
+                          onChange={(e) => setSaUsername(e.target.value)}
+                        />
+                      </div>
+                      <div className="grid gap-2">
+                        <Label htmlFor="sa-password-env">Password env-var name</Label>
+                        <Input
+                          id="sa-password-env"
+                          placeholder="MY_SERVICE_PASSWORD"
+                          value={saPasswordEnv}
+                          onChange={(e) => setSaPasswordEnv(e.target.value)}
+                        />
+                        <p className="text-xs text-muted-foreground">
+                          Name of the environment variable that holds the password — not the password itself.
+                          Set the actual value in your active profile&apos;s .env file
+                          (e.g. <code>hermes config env-path</code> to find the path).
+                        </p>
+                      </div>
+                      <div className="grid gap-2">
+                        <Label htmlFor="sa-scope">Scope (optional)</Label>
+                        <Input
+                          id="sa-scope"
+                          placeholder="openid profile"
+                          value={saScope}
+                          onChange={(e) => setSaScope(e.target.value)}
+                        />
+                      </div>
+                      <div className="grid gap-2">
+                        <Label htmlFor="sa-client-secret-env">Client-secret env-var name (optional)</Label>
+                        <Input
+                          id="sa-client-secret-env"
+                          placeholder="MY_CLIENT_SECRET"
+                          value={saClientSecretEnv}
+                          onChange={(e) => setSaClientSecretEnv(e.target.value)}
+                        />
+                        <p className="text-xs text-muted-foreground">
+                          Only needed if the token endpoint requires a client secret.
+                          Set the actual value in your profile&apos;s .env file.
+                        </p>
+                      </div>
+                    </>
                   )}
                 </>
               ) : (
@@ -634,7 +727,11 @@ export default function McpPage() {
                     {server.auth && (
                       <Badge tone="outline">
                         auth:{" "}
-                        {server.auth === "header" ? "bearer" : server.auth}
+                        {server.auth === "header"
+                          ? "bearer"
+                          : server.auth === "service_account"
+                            ? "service account"
+                            : server.auth}
                       </Badge>
                     )}
                     {!server.enabled && <Badge tone="outline">disabled</Badge>}

--- a/website/docs/reference/mcp-config-reference.md
+++ b/website/docs/reference/mcp-config-reference.md
@@ -64,7 +64,8 @@ mcp_servers:
 | `idle_timeout_seconds` | number | stdio | Optional stdio server recycle after idle time (`0` disables). May also live under a `lifecycle:` mapping |
 | `max_lifetime_seconds` | number | stdio | Optional stdio server recycle after age (`0` disables). May also live under a `lifecycle:` mapping |
 | `tools` | mapping | both | Filtering and utility-tool policy |
-| `auth` | string | HTTP | Authentication method. Set to `oauth` to enable OAuth 2.1 with PKCE |
+| `auth` | string | HTTP | Authentication method. `oauth` = OAuth 2.1 PKCE (browser login). `service_account` = M2M client-credentials exchange (see below). |
+| `service_account` | mapping | HTTP | Service-account config block (required when `auth: service_account`). See `service_account` sub-keys below. |
 | `sampling` | mapping | both | Server-initiated LLM request policy (see MCP guide) |
 | `elicitation` | mapping | both | Server-initiated user-input requests. `enabled` (default `true`) and `timeout` in seconds (default `300`). Form-mode requests route through the approval surface; URL-mode is declined (see MCP guide) |
 | `trust` | string | both | Trust tier: `full` (default) or `untrusted`. On an `untrusted` server, every write-capable tool call (any tool without a `readOnlyHint: true` annotation) requires user approval through the standard approval surface before it runs. `readOnlyHint` is a server-supplied *hint* — a lying server can at most skip approval for tools it claims are read-only, never gain extra access — so mark any server you don't fully control as `untrusted`. Unrecognized values are treated as `untrusted` (fail-closed) |
@@ -378,6 +379,77 @@ mcp_servers:
 `client_metadata_url` must be an HTTPS URL with a path (no bare origin, no fragment, no userinfo, no `.`/`..` segments) that returns `200` and `Content-Type: application/json` with **no redirect** — authorization servers are forbidden from following redirects when fetching it. Hermes still pins its callback to the same `27890`–`27894` range, so a self-hosted document must declare all ten loopback URIs (`http://127.0.0.1:<port>/callback` and `http://localhost:<port>/callback` for each port), and its `client_id` must be its own URL.
 
 `user_agent` replaces the HTTP library's default `User-Agent` on **token-endpoint requests only** (authorization-code exchange and refresh) — some authorization servers and WAFs reject the default `python-httpx/...` value there. It never applies to MCP traffic or OAuth discovery, and no other token-request headers are configurable. Empty or null values are ignored.
+
+## Service-account (M2M) authentication
+
+For HTTP MCP servers that authenticate machine identities rather than human users, use `auth: service_account`. This is distinct from `auth: oauth` (which opens a browser window for user login) — no browser interaction is needed. Hermes exchanges a long-lived service-account credential for a short-lived Bearer access token and renews it automatically.
+
+This is a generic OAuth 2.0 `client_credentials`-style exchange. Any identity provider that accepts the grant type works — the example below uses Authentik, but the same config works with any compatible IdP.
+
+```yaml
+mcp_servers:
+  toolhive:
+    url: https://mcp.example.com/mcp
+    auth: service_account
+    service_account:
+      token_url: https://idp.example.com/application/o/toolhive/token/
+      client_id: toolhive
+      username: zug
+      password_env: AUTHENTIK_ZUG_APP_PASSWORD   # env-var NAME, not the value
+      scope: "openid profile groups toolhive-audience"
+      client_secret_env: MY_CLIENT_SECRET        # optional
+```
+
+**Secret values must never appear in `config.yaml`**. Only environment-variable *names* belong in the config. The values are read at runtime from the process environment, which is populated from `$HERMES_HOME/.env` before any MCP connection is made. Put the actual secrets there:
+
+```sh
+# ~/.hermes/.env  (or the active profile's .env)
+AUTHENTIK_ZUG_APP_PASSWORD=your-app-password-here
+```
+
+### `service_account` sub-keys
+
+| Key | Required | Meaning |
+|---|---|---|
+| `token_url` | yes | OAuth token endpoint URL (`https://` required) |
+| `client_id` | yes | Client ID registered at the IdP |
+| `username` | yes | Service-account username |
+| `password_env` | yes | Name of the environment variable holding the password |
+| `scope` | no | Space-separated OAuth scopes to request |
+| `client_secret_env` | no | Name of the environment variable holding the optional client secret |
+
+### Behavior
+
+- Tokens are cached at `$HERMES_HOME/mcp-tokens/<server>-sa.json` (mode `0600`, atomic write).
+- A valid token is reused across reconnects; a new token is fetched proactively 60 seconds before expiry.
+- If the server returns a `refresh_token`, Hermes uses it on the next renewal before falling back to a fresh service-account exchange.
+- A single `401` response triggers one immediate re-fetch; if the re-fetch also fails, the error is surfaced to the model.
+- Concurrent requests share a single in-process lock so only one token exchange fires at a time.
+- Passwords and access tokens are never logged or written to `config.yaml`.
+- TLS verification is always on; there is no option to disable it for service-account auth.
+
+### Setting up via CLI
+
+```sh
+# 1. Set the secret in your profile's .env
+echo 'AUTHENTIK_ZUG_APP_PASSWORD=my-app-password' >> ~/.hermes/.env
+
+# 2. Add the server with auth: service_account already in config.yaml,
+#    then validate and probe it
+hermes mcp add toolhive \
+  --url https://mcp.example.com/mcp \
+  --auth service_account
+```
+
+Because the password is read from an environment variable, `hermes mcp add` will validate the config and report any missing env-var names without ever prompting for or storing the secret itself.
+
+### Comparison with other auth modes
+
+| Mode | When to use |
+|---|---|
+| `auth: oauth` | Human user login via browser (PKCE). IdP manages sessions. |
+| `auth: service_account` | Machine identity (M2M). Long-lived app password exchanged for short-lived Bearer token. No browser. |
+| `headers:` with `${VAR}` | Static API key injected directly (no exchange, no expiry). |
 
 ## Add to Hermes link
 


### PR DESCRIPTION
## Summary

- Adds a generic `auth: service_account` mode for HTTP MCP servers that authenticate machine identities (M2M) without browser interaction
- A long-lived service-account password (read from an environment variable at runtime, never from config) is exchanged for a short-lived Bearer token via the OAuth 2.0 `client_credentials` grant, injected into MCP requests, and renewed automatically
- This is **distinct** from `auth: oauth` (browser PKCE) and `headers:` (static key) — no user interaction required, and tokens are not statically embedded

## Config shape

```yaml
mcp_servers:
  toolhive:
    url: https://mcp.example.com/mcp
    auth: service_account
    service_account:
      token_url: https://idp.example.com/application/o/toolhive/token/
      client_id: toolhive
      username: zug
      password_env: AUTHENTIK_ZUG_APP_PASSWORD   # env-var NAME only — value in .env
      scope: "openid profile groups toolhive-audience"
      client_secret_env: OPTIONAL_CLIENT_SECRET   # optional
```

## Files changed

- **`tools/mcp_service_account.py`** (new): `ServiceAccountAuth` — an `httpx.Auth`-compatible provider implementing token exchange, disk cache (mode 0600, atomic write), proactive renewal (60 s buffer), one 401 retry, refresh-token path with SA-exchange fallback, per-server `asyncio.Lock` concurrency deduplication, and strict no-secrets-in-logs/errors policy
- **`tests/tools/test_mcp_service_account.py`** (new): 30 focused tests — first acquisition & header injection, cache reuse, near-expiry proactive renewal, refresh-token path and fallback, 401 retry, concurrent deduplication (one exchange for 5 concurrent requests), missing env var error, malformed response error, token endpoint 500 error, no password/token in logs, profile isolation, 0600 cache permissions, header/oauth backwards compat
- **`tools/mcp_tool.py`**: `elif self._auth_type == "service_account":` branch alongside existing `oauth` branch
- **`hermes_cli/mcp_config.py`**: `service_account` branch in `cmd_mcp_add` (validates config, surfaces missing env-var names without storing secrets); SA token cache cleanup in `cmd_mcp_remove`
- **`website/docs/reference/mcp-config-reference.md`**: full docs — Authentik example, sub-key reference table, behavior notes, comparison table vs `oauth` and `headers` modes

## Test results

```
191 passed, 2 deselected in 3.00s
```

The 2 deselected are pre-existing `TestCallbackPortReservation` failures in `test_mcp_oauth.py` (unrelated to this PR — a `result.code` attribute issue on the legacy tuple return from `_wait_for_callback`).

## Design tradeoffs

- **Generic, not Authentik-specific**: works with any IdP that accepts `client_credentials` + `username`/`password` on the token endpoint (Authentik, Keycloak, Auth0 machine-to-machine, etc.)
- **`password_env` only for v1**: extensible to `password_command` (exec without shell) without breaking the config schema — just add a new key; the resolver is a single function
- **No shell eval by default**: a `password_command` extension would exec without a shell and document the security implications; no generic arbitrary shell evaluation is added here
- **Token cache separate from OAuth cache**: uses `<server>-sa.json` suffix so SA and browser-OAuth tokens for the same server name don't collide
- **In-process dedup only**: the `asyncio.Lock` prevents concurrent exchanges within a process; cross-process dedup (e.g. file locking) is left for a future follow-up as it adds complexity for a rare edge case

🤖 Generated with [Claude Code](https://claude.com/claude-code)