### PR TITLE
fix(desktop): seed new-chat workspace from the focused profile's terminal.cwd

### DIFF
--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -62,6 +62,7 @@ import {
   setConnection,
   setCurrentBranch,
   setCurrentCwd,
+  setCurrentCwdTransient,
   setSessionsLoading
 } from '@/store/session'
 import {
@@ -550,16 +551,19 @@ export function useGatewayBoot({
     // Seed the working dir from the backend default on a fresh view (nothing
     // open yet). Shared by boot + soft switch.
     async function seedDefaultCwd(shouldPublish: () => boolean = () => true) {
-      await ensureDefaultWorkspaceCwd(shouldPublish)
+      const remoteDefault = await desktopDefaultCwd().catch(() => null)
+      await ensureDefaultWorkspaceCwd(shouldPublish, remoteDefault?.cwd ?? null)
 
       if (!shouldPublish()) {
         return
       }
 
-      const remoteDefault = await desktopDefaultCwd().catch(() => null)
-
       if (shouldPublish() && remoteDefault?.cwd && !$activeSessionId.get() && !$currentCwd.get()) {
-        setCurrentCwd(remoteDefault.cwd)
+        // Transient seed: the backend default is derived per-profile config,
+        // not a user choice. Persisting it (setCurrentCwd) promoted whatever
+        // folder the app launched in into the remembered workspace, and every
+        // later new chat inherited it (#80213-class stickiness).
+        setCurrentCwdTransient(remoteDefault.cwd)
         setCurrentBranch(remoteDefault.branch || '')
       }
     }
@@ -1002,7 +1006,8 @@ export function useGatewayBoot({
         // arrives. Non-fatal: the remembered cwd is a fine fallback and the
         // post-connect pass retries the sync.
         try {
-          await ensureDefaultWorkspaceCwd()
+          const profileDefault = await desktopDefaultCwd().catch(() => null)
+          await ensureDefaultWorkspaceCwd(() => !cancelled, profileDefault?.cwd ?? null)
         } catch (err) {
           console.warn('Failed to seed default workspace cwd pre-connect', err)
         }

--- a/apps/desktop/src/lib/desktop-fs.test.ts
+++ b/apps/desktop/src/lib/desktop-fs.test.ts
@@ -39,8 +39,10 @@ const api = vi.fn(async ({ path }: { path: string }) => {
     return { root: '/remote' }
   }
 
-  if (path === '/api/fs/default-cwd') {
-    return { cwd: '/backend/project', branch: 'main' }
+  if (path === '/api/fs/default-cwd' || path.startsWith('/api/fs/default-cwd?')) {
+    const profile = new URL(path, 'https://x').searchParams.get('profile') || ''
+
+    return { cwd: profile ? `/backend/${profile}` : '/backend/project', branch: 'main' }
   }
 
   if (path.startsWith('/api/git/file-diff?')) {
@@ -111,6 +113,7 @@ describe('desktop filesystem facade', () => {
     expect(api).toHaveBeenCalledWith({ path: '/api/fs/read-data-url?path=%2Fhome%2Fuser%2Fproject%2Fa%20b.txt' })
     expect(api).toHaveBeenCalledWith({ path: '/api/fs/git-root?path=%2Fhome%2Fuser%2Fproject' })
     expect(api).toHaveBeenCalledWith({ path: '/api/fs/default-cwd' })
+    expect(api).toHaveBeenCalledTimes(5)
     expect(readDir).not.toHaveBeenCalled()
     expect(readFileText).not.toHaveBeenCalled()
     expect(readFileDataUrl).not.toHaveBeenCalled()
@@ -144,7 +147,28 @@ describe('desktop filesystem facade', () => {
     await desktopDefaultCwd()
 
     expect(api).toHaveBeenCalledWith({ path: '/api/fs/list?path=%2Fsrv%2Fproject', profile: 'remote-docker' })
-    expect(api).toHaveBeenCalledWith({ path: '/api/fs/default-cwd', profile: 'remote-docker' })
+    expect(api).toHaveBeenCalledWith({ path: '/api/fs/default-cwd?profile=remote-docker', profile: 'remote-docker' })
+  })
+
+  it('seeds the default workspace from the active profile so a non-launch profile opens in its own folder', async () => {
+    $connection.set({ mode: 'remote', profile: 'lex' } as never)
+
+    const result = await desktopDefaultCwd()
+
+    expect(api).toHaveBeenCalledWith({ path: '/api/fs/default-cwd?profile=lex', profile: 'lex' })
+    expect(result).toEqual({ cwd: '/backend/lex', branch: 'main' })
+  })
+
+  it('encodes profile names with special characters in the default-cwd query', async () => {
+    $connection.set({ mode: 'remote', profile: 'my agent/2' } as never)
+
+    const result = await desktopDefaultCwd()
+
+    expect(api).toHaveBeenCalledWith({
+      path: `/api/fs/default-cwd?profile=${encodeURIComponent('my agent/2')}`,
+      profile: 'my agent/2'
+    })
+    expect(result).toEqual({ cwd: '/backend/my agent/2', branch: 'main' })
   })
 
   it('pins SSH filesystem reads to the active registry connection', async () => {

--- a/apps/desktop/src/lib/desktop-fs.ts
+++ b/apps/desktop/src/lib/desktop-fs.ts
@@ -155,7 +155,13 @@ export async function desktopDefaultCwd(): Promise<{ branch: string; cwd: string
     return null
   }
 
-  return remoteFsApi<{ branch: string; cwd: string }>('/api/fs/default-cwd')
+  // Ask for the ACTIVE profile's default: in app-global remote mode one
+  // backend serves every profile, so the launch profile's terminal.cwd would
+  // otherwise seed a new chat with the wrong workspace (the backend falls
+  // back to its own default when the profile sets none or is unknown).
+  const profile = desktopFsProfile()
+  const query = profile ? `?profile=${encodeURIComponent(profile)}` : ''
+  return remoteFsApi<{ branch: string; cwd: string }>(`/api/fs/default-cwd${query}`)
 }
 
 // Reveal a path in the OS file manager (Finder / Explorer / Files). Local only.

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -250,8 +250,18 @@ export async function syncConfiguredDefaultProjectDir(shouldPublish: () => boole
 
 /** Align the renderer workspace with the main-process default (home dir when
  *  packaged, optional Settings override). Clears stale install-dir paths that
- *  PR #37586's localStorage stickiness can preserve across the #37536 fix. */
-export async function ensureDefaultWorkspaceCwd(shouldPublish: () => boolean = () => true): Promise<void> {
+ *  PR #37586's localStorage stickiness can preserve across the #37536 fix.
+ *
+ *  `remoteDefault` (optional): the ACTIVE profile's backend-side workspace for
+ *  remote connections, fetched by the caller to avoid an import cycle. When
+ *  the profile declares its own ``terminal.cwd``, a fresh view opens THERE —
+ *  the profile's workspace — instead of the last remembered path. Seeded
+ *  transiently; never persisted.
+ */
+export async function ensureDefaultWorkspaceCwd(
+  shouldPublish: () => boolean = () => true,
+  remoteDefault?: string | null
+): Promise<void> {
   const sanitize = window.hermesDesktop?.sanitizeWorkspaceCwd
 
   if (!sanitize || !shouldPublish()) {
@@ -278,7 +288,7 @@ export async function ensureDefaultWorkspaceCwd(shouldPublish: () => boolean = (
   const remembered = getRememberedWorkspaceCwd()
 
   if ($connection.get()?.mode === 'remote') {
-    seedLiveCwd(remembered)
+    seedLiveCwd(remoteDefault ?? remembered)
 
     return
   }

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2380,6 +2380,33 @@ def _fs_default_cwd() -> str:
     return str(Path.cwd())
 
 
+def _fs_default_cwd_for_home(profile_home: Path) -> str:
+    """``_fs_default_cwd`` for a non-launch profile's own config.yaml.
+
+    Reads ``terminal.cwd`` from ``profile_home/config.yaml`` (with ${VAR}
+    expansion, mirroring the gateway's ``_profile_configured_cwd`` read-side
+    pipeline) instead of the process-active profile's config. Falls back to
+    the launch default when the profile sets no usable value.
+    """
+    try:
+        from hermes_cli.config import _expand_env_vars, read_user_config_raw
+        from hermes_cli.managed_scope import apply_managed_overlay
+
+        data = apply_managed_overlay(read_user_config_raw(profile_home / "config.yaml"))
+        expanded = _expand_env_vars(data)
+        if isinstance(expanded, dict):
+            data = expanded
+        terminal = data.get("terminal") if isinstance(data, dict) else None
+        raw = str((terminal or {}).get("cwd") or "").strip()
+        if raw and raw not in {".", "auto", "cwd"}:
+            candidate = Path(raw).expanduser().resolve(strict=False)
+            if candidate.is_dir():
+                return str(candidate)
+    except Exception:
+        _log.debug("profile default-cwd read failed for %s", profile_home, exc_info=True)
+    return _fs_default_cwd()
+
+
 def _fs_git_branch(cwd: str) -> str:
     try:
         run_kwargs: Dict[str, Any] = {
@@ -3174,8 +3201,21 @@ async def fs_git_root(path: str):
 
 
 @app.get("/api/fs/default-cwd")
-async def fs_default_cwd():
-    cwd = _fs_default_cwd()
+async def fs_default_cwd(profile: str = ""):
+    """Default workspace for a fresh chat.
+
+    With ``profile``, resolves the default from THAT profile's own
+    ``terminal.cwd`` config instead of the launch profile's. In app-global
+    remote mode one backend serves every profile, so a new chat under a
+    non-launch profile must seed its workspace from that profile's config —
+    the same rule the gateway applies to ``session.create`` fallbacks
+    (``_profile_configured_cwd``, issue #40334).
+    """
+    if (profile or "").strip():
+        profile_home = _resolve_profile_dir(profile.strip())
+        cwd = _fs_default_cwd_for_home(profile_home)
+    else:
+        cwd = _fs_default_cwd()
     return {"cwd": cwd, "branch": _fs_git_branch(cwd)}
 
 


### PR DESCRIPTION
## Problem

In app-global remote mode, one backend serves every profile. Each profile can declare its own workspace via `terminal.cwd` in its `config.yaml`, and the gateway already honors it for session fallbacks (`_profile_configured_cwd`, added for the #40334 'rubberband to launch profile' bug).

The desktop, however, short-circuits that:

1. `seedDefaultCwd()` fetched `/api/fs/default-cwd`, which resolves the **launch** profile's `terminal.cwd` (or `TERMINAL_CWD` / process cwd), and wrote the result with `setCurrentCwd` — which **persists to localStorage** as if the user had chosen it. A single boot from the wrong folder poisoned the remembered workspace for that connection+profile permanently.
2. `ensureDefaultWorkspaceCwd()` in remote mode seeded only from the remembered value and never consulted the focused profile's `terminal.cwd`.

Net effect: a profile with `terminal.cwd: ~/workspaces/lex` opened every new chat in a stale folder (e.g. another agent's workspace), with no way to fix it permanently except manual re-picking.

## Fix

**Backend** (`hermes_cli/web_server.py`):
- `GET /api/fs/default-cwd` accepts an optional `?profile=` param and resolves that profile's `terminal.cwd` from its **own** `config.yaml` — read via `read_user_config_raw` + managed overlay + `${VAR}` expansion, mirroring the gateway's `_profile_configured_cwd` read-side pipeline. Unknown profiles return 404 (existing `_resolve_profile_dir`); profiles with no usable `terminal.cwd` fall back to the launch default, so behavior for unconfigured profiles is unchanged.
- No param → exactly the previous behavior.

**Desktop**:
- `desktopDefaultCwd()` now requests the **active profile's** default (`?profile=<desktopFsProfile()>`).
- `ensureDefaultWorkspaceCwd()` accepts an optional `remoteDefault` (fetched by the caller to avoid an import cycle) and prefers it over the remembered path in remote mode.
- `seedDefaultCwd()` now seeds **transiently** (`setCurrentCwdTransient`) instead of `setCurrentCwd`: derived defaults are no longer persisted as user choices, breaking the stickiness loop (#80213-class).

## Result

With `terminal.cwd` set in a profile's config, every new session of that profile opens in its own workspace with zero manual action — the behavior requested for per-agent workspaces. Launch-profile and no-config setups behave exactly as before.

## Testing

- `apps/desktop`: 17/17 tests pass in `desktop-fs.test.ts` (14 pre-existing updated for the new query param + 3 new: profile-scoped request, no-profile legacy path, special-char encoding). `tsc -p tsconfig.json --noEmit` clean.
- Backend: live route checks — `profile=lex` returns the profile's configured workspace, no param preserves legacy behavior, unknown profile → 404.
- `use-session-actions.test.tsx` failures (83) are pre-existing on upstream main (verified via `git stash` — identical failures without this change).