### PR TITLE
fix(desktop): repair all-profile project actions

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -1900,7 +1900,9 @@ export function ChatSidebar({
           </div>
         )}
 
-        {!showSessionSections && <SidebarBlankState onNewProject={openProjectCreate} />}
+        {!showSessionSections && (
+          <SidebarBlankState onNewProject={showAllProfiles ? undefined : openProjectCreate} />
+        )}
 
         <div className="shrink-0 px-0.5 pb-1 pt-0.5">
           <ProfileRail />

--- a/apps/desktop/src/app/chat/sidebar/projects/project-menu.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/project-menu.test.tsx
@@ -115,4 +115,27 @@ describe('ProjectMenu', () => {
     // chain rather than getting silently dropped on an intermediate wrapper.
     expect(await screen.findByRole('button', { name: 'No color' })).toBeTruthy()
   }, 15000)
+
+  it('hides unroutable per-profile writes on a merged all-profiles project', async () => {
+    render(
+      <ProjectMenu
+        isActive={false}
+        project={{
+          ...project,
+          profileProjects: [
+            { id: 'p1', isAuto: false, profile: 'default' },
+            { id: 'p2', isAuto: false, profile: 'worker' }
+          ]
+        }}
+      />
+    )
+
+    openTriggerMenu(screen.getByRole('button', { name: 'Actions' }))
+
+    expect(await screen.findByRole('menuitem', { name: 'Delete…' })).toBeTruthy()
+    expect(screen.queryByRole('menuitem', { name: 'Rename' })).toBeNull()
+    expect(screen.queryByRole('menuitem', { name: 'Add folder' })).toBeNull()
+    expect(screen.queryByRole('menuitem', { name: 'Set active' })).toBeNull()
+    expect(screen.queryByRole('menuitem', { name: 'Appearance' })).toBeNull()
+  })
 })

--- a/apps/desktop/src/app/chat/sidebar/projects/project-menu.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/project-menu.tsx
@@ -66,34 +66,36 @@ function useProjectActions({
   }
 
   const confirmDelete = async () => {
-    await deleteProject(project.id)
+    await deleteProject(project)
 
     if (scoped) {
       onExitScope?.()
     }
   }
 
-  // Rename / add folder / set active — explicit projects only (auto ones lack a
-  // materialized record). Appearance is handled per-surface (popover vs submenu)
-  // by the caller since its picker chrome differs.
-  const identityItems: ActionItemSpec[] = project.isAuto
-    ? []
-    : [
-        { icon: 'edit', key: 'rename', label: p.menuRename, onSelect: () => openProjectRename(target) },
-        {
-          icon: 'new-folder',
-          key: 'add-folder',
-          label: p.menuAddFolder,
-          onSelect: () => openProjectAddFolder(target)
-        },
-        {
-          disabled: isActive,
-          icon: 'target',
-          key: 'set-active',
-          label: p.menuSetActive,
-          onSelect: () => void setActiveProject(project.id)
-        }
-      ]
+  // Rename / add folder / set active — focused explicit projects only. Auto
+  // projects lack a materialized record, while an all-profiles header can merge
+  // several records and deliberately has no single owner for those mutations.
+  // Appearance is handled per-surface (popover vs submenu) by the caller.
+  const identityItems: ActionItemSpec[] =
+    project.isAuto || project.profileProjects
+      ? []
+      : [
+          { icon: 'edit', key: 'rename', label: p.menuRename, onSelect: () => openProjectRename(target) },
+          {
+            icon: 'new-folder',
+            key: 'add-folder',
+            label: p.menuAddFolder,
+            onSelect: () => openProjectAddFolder(target)
+          },
+          {
+            disabled: isActive,
+            icon: 'target',
+            key: 'set-active',
+            label: p.menuSetActive,
+            onSelect: () => void setActiveProject(project.id)
+          }
+        ]
 
   const pathItems: ActionItemSpec[] = [
     {
@@ -165,6 +167,7 @@ export function ProjectMenu({
   // Open toward the content area: right when the sidebar is on the left, left
   // when the panes are flipped (sidebar on the right).
   const panesFlipped = useStore($panesFlipped)
+  const canTheme = project.profileProjects === undefined && (!project.isAuto || Boolean(project.path))
 
   const { confirmDialog, dangerItem, identityItems, pathItems } = useProjectActions({
     isActive,
@@ -230,24 +233,24 @@ export function ProjectMenu({
           onCloseAutoFocus={event => event.preventDefault()}
           sideOffset={6}
         >
-          {project.isAuto ? (
-            // Inherited (auto) repos can still be themed — the change adopts the
-            // repo as a real project. Rename / add-folder / set-active stay out
-            // until then (they need the materialized record).
-            project.path && (
+          {canTheme ? (
+            project.isAuto ? (
+              // Inherited (auto) repos can still be themed — the change adopts the
+              // repo as a real project. Rename / add-folder / set-active stay out
+              // until then (they need the materialized record).
               <>
                 {appearanceItem}
                 <DropdownMenuSeparator />
               </>
+            ) : (
+              <>
+                {identityItems.slice(0, 1).map(item => renderActionItem(DROPDOWN_KIT, item))}
+                {appearanceItem}
+                {identityItems.slice(1).map(item => renderActionItem(DROPDOWN_KIT, item))}
+                <DropdownMenuSeparator />
+              </>
             )
-          ) : (
-            <>
-              {identityItems.slice(0, 1).map(item => renderActionItem(DROPDOWN_KIT, item))}
-              {appearanceItem}
-              {identityItems.slice(1).map(item => renderActionItem(DROPDOWN_KIT, item))}
-              <DropdownMenuSeparator />
-            </>
-          )}
+          ) : null}
           {pathItems.map(item => renderActionItem(DROPDOWN_KIT, item))}
           <DropdownMenuSeparator />
           {renderActionItem(DROPDOWN_KIT, dangerItem)}
@@ -301,7 +304,7 @@ export function ProjectContextMenu({
     scoped
   })
 
-  const canTheme = !project.isAuto || Boolean(project.path)
+  const canTheme = project.profileProjects === undefined && (!project.isAuto || Boolean(project.path))
 
   const applyAppearance = (patch: { color?: null | string; icon?: null | string }) => {
     void setProjectAppearance(project, patch)

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
@@ -41,6 +41,13 @@ export interface SidebarWorkspaceTree {
   sessionCount: number
 }
 
+/** The concrete per-profile projects.db row contributing to a merged project. */
+export interface SidebarProjectProfileRef {
+  id: string
+  profile: string
+  isAuto: boolean
+}
+
 /** A project node: human-named (or repo-derived), holds its repo subtree. */
 export interface SidebarProjectTree {
   id: string
@@ -66,6 +73,9 @@ export interface SidebarProjectTree {
   lastActive?: number
   // Up to N most-recent sessions for the overview preview (set by `projects.tree`).
   previewSessions?: SessionInfo[]
+  // Present on the all-profiles REST tree. A shared folder is one visible row,
+  // but mutations still need the exact projects.db id(s) and owning profile(s).
+  profileProjects?: SidebarProjectProfileRef[]
 }
 
 /** Path split into segments, ignoring trailing slashes and mixed separators. */

--- a/apps/desktop/src/app/chat/sidebar/section-states.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/section-states.test.tsx
@@ -1,0 +1,34 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { SidebarBlankState } from './section-states'
+
+afterEach(cleanup)
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      sidebar: {
+        noSessions: 'No sessions yet',
+        projects: { newButton: 'New project' }
+      }
+    }
+  })
+}))
+
+describe('SidebarBlankState', () => {
+  it('offers project creation when the current profile can own it', () => {
+    const onNewProject = vi.fn()
+
+    render(<SidebarBlankState onNewProject={onNewProject} />)
+    fireEvent.click(screen.getByRole('button', { name: 'New project' }))
+
+    expect(onNewProject).toHaveBeenCalledOnce()
+  })
+
+  it('does not offer an unroutable project write in the all-profiles view', () => {
+    render(<SidebarBlankState />)
+
+    expect(screen.queryByRole('button', { name: 'New project' })).toBeNull()
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/section-states.tsx
+++ b/apps/desktop/src/app/chat/sidebar/section-states.tsx
@@ -23,7 +23,7 @@ export function SidebarSessionSkeletons() {
   )
 }
 
-export function SidebarBlankState({ onNewProject }: { onNewProject: () => void }) {
+export function SidebarBlankState({ onNewProject }: { onNewProject?: () => void }) {
   const { t } = useI18n()
   const s = t.sidebar
 
@@ -32,10 +32,12 @@ export function SidebarBlankState({ onNewProject }: { onNewProject: () => void }
       <div className="flex flex-col items-center gap-2">
         <Codicon className="text-(--ui-text-quaternary)" name="root-folder" size="1.25rem" />
         <p className="text-xs text-(--ui-text-tertiary)">{s.noSessions}</p>
-        <Button className="mt-0.5 text-(--ui-text-secondary)" onClick={onNewProject} size="sm" variant="ghost">
-          <Codicon name="add" size="0.75rem" />
-          {s.projects.newButton}
-        </Button>
+        {onNewProject && (
+          <Button className="mt-0.5 text-(--ui-text-secondary)" onClick={onNewProject} size="sm" variant="ghost">
+            <Codicon name="add" size="0.75rem" />
+            {s.projects.newButton}
+          </Button>
+        )}
       </div>
     </div>
   )

--- a/apps/desktop/src/store/projects.test.ts
+++ b/apps/desktop/src/store/projects.test.ts
@@ -18,6 +18,7 @@ import {
   ALL_PROJECTS,
   beginSessionMutation,
   createProject,
+  deleteProject,
   endSessionMutation,
   enterProject,
   exitProjectScope,
@@ -83,6 +84,7 @@ const desktopGit = vi.mocked(git.desktopGit)
 
 const hermes = await import('@/hermes')
 const getHermesConfig = vi.mocked(hermes.getHermesConfig)
+const hermesApi = vi.mocked(hermes.hermesApi)
 const notifications = await import('@/store/notifications')
 const notify = vi.mocked(notifications.notify)
 
@@ -170,6 +172,36 @@ describe('projects RPC profile forwarding', () => {
     await fetchProjectSessions('p_123')
 
     expect(request).not.toHaveBeenCalled()
+    setShowAllProfiles(false)
+  })
+
+  it('deletes a merged all-profiles project from every concrete owning profile', async () => {
+    const request = vi.fn(async () => ({ active_id: null, projects: [] }))
+    const gateway = { connectionState: 'open', request }
+    activeGateway.mockReturnValue(gateway as never)
+    gatewayAtom.set(gateway as never)
+    hermesApi.mockResolvedValue({ active_id: null, projects: [], scoped_session_ids: [] })
+    setShowAllProfiles(true)
+
+    const project = {
+      id: 'p_default',
+      label: 'Shared',
+      path: '/repos/shared',
+      profileProjects: [
+        { id: 'p_default', isAuto: false, profile: 'default' },
+        { id: 'p_worker', isAuto: false, profile: 'worker' }
+      ],
+      repos: [],
+      sessionCount: 0
+    } satisfies SidebarProjectTree
+
+    $projectTree.set([project])
+
+    await deleteProject(project)
+
+    expect(request).toHaveBeenCalledWith('projects.delete', { id: 'p_default', profile: 'default' })
+    expect(request).toHaveBeenCalledWith('projects.delete', { id: 'p_worker', profile: 'worker' })
+    expect($projectTree.get()).toEqual([])
     setShowAllProfiles(false)
   })
 })

--- a/apps/desktop/src/store/projects.ts
+++ b/apps/desktop/src/store/projects.ts
@@ -1118,16 +1118,47 @@ function openSessionBelongsToProject(projectId: string, projects: ProjectInfo[])
 // Optimistic: drop the project from the cached tree + list the instant it's
 // clicked (the entered-scope effect exits if you deleted the project you were
 // inside), reconciling from the server payload. A failed delete restores both.
-export async function deleteProject(id: string): Promise<void> {
+export async function deleteProject(
+  project: string | Pick<SidebarProjectTree, 'id' | 'profileProjects'>
+): Promise<void> {
+  const id = typeof project === 'string' ? project : project.id
+
+  const profileRefs =
+    typeof project === 'string'
+      ? []
+      : (project.profileProjects ?? []).filter(ref => !ref.isAuto && ref.id.trim() && ref.profile.trim())
+
+  const uniqueRefs = [...new Map(profileRefs.map(ref => [`${ref.profile}\u0000${ref.id}`, ref])).values()]
+
+  // Focused-profile trees predate/omit profileProjects because their owner is
+  // already the active scope. The all-profiles tree must provide refs: its
+  // visible id can belong to any contributing profile and is not routable by
+  // itself. A cached focused-list hit is a compatibility rung for an older
+  // backend serving the all-profiles REST shape without refs.
+  if (!uniqueRefs.length) {
+    const focusedProfile = projectProfile()
+    const cachedOnActiveProfile = $projects.get().some(candidate => candidate.id === id)
+
+    const fallbackProfile =
+      focusedProfile ?? (cachedOnActiveProfile ? normalizeProfileKey($activeGatewayProfile.get()) : null)
+
+    if (!fallbackProfile) {
+      throw new Error('This project does not identify the profile that owns it. Refresh Projects and try again.')
+    }
+
+    uniqueRefs.push({ id, isAuto: false, profile: fallbackProfile })
+  }
+
   const snap = snapshotProjects()
+  const deletedIds = new Set([id, ...uniqueRefs.map(ref => ref.id)])
   // Capture membership BEFORE removal — the project's folders (which determine
   // ownership) are gone once it's dropped from the cache.
-  const kickToIntro = openSessionBelongsToProject(id, snap.projects)
+  const kickToIntro = [...deletedIds].some(projectId => openSessionBelongsToProject(projectId, snap.projects))
 
-  $projects.set(snap.projects.filter(project => project.id !== id))
-  $projectTree.set(snap.tree.filter(node => node.id !== id))
+  $projects.set(snap.projects.filter(candidate => !deletedIds.has(candidate.id)))
+  $projectTree.set(snap.tree.filter(node => !deletedIds.has(node.id)))
 
-  if (snap.active === id) {
+  if (snap.active && deletedIds.has(snap.active)) {
     $activeProjectId.set(null)
   }
 
@@ -1137,10 +1168,37 @@ export async function deleteProject(id: string): Promise<void> {
     requestFreshSession()
   }
 
-  await persistOrRollback(snap, async () => {
-    applyPayload(await gatewayRequest<ProjectsPayload>('projects.delete', projectParams({ id })))
-  })
-  void refreshProjectTree()
+  try {
+    const results = await Promise.allSettled(
+      uniqueRefs.map(ref =>
+        gatewayRequest<ProjectsPayload>('projects.delete', projectParams({ id: ref.id }, ref.profile))
+      )
+    )
+
+    const failure = results.find((result): result is PromiseRejectedResult => result.status === 'rejected')
+
+    if (failure) {
+      throw failure.reason
+    }
+
+    const payloads = results.flatMap(result => (result.status === 'fulfilled' ? [result.value] : []))
+
+    // A focused tree has one authoritative projects.list payload. In the
+    // all-profiles view each response is only one slice, so applying one would
+    // clobber the merged cache; the cross-profile tree refresh below owns it.
+    if ($profileScope.get() !== ALL_PROFILES && payloads[0]) {
+      applyPayload(payloads[0])
+    }
+  } catch (error) {
+    restoreProjects(snap)
+    // Multiple profile deletes cannot be transactional across separate DBs.
+    // If one slice failed after another succeeded, replace the optimistic
+    // rollback with backend truth before surfacing the error.
+    await refreshProjectTree()
+    throw error
+  }
+
+  await refreshProjectTree()
 }
 
 export async function setActiveProject(id: null | string): Promise<void> {

--- a/hermes_cli/web_routers/profiles.py
+++ b/hermes_cli/web_routers/profiles.py
@@ -581,11 +581,18 @@ def _merge_profile_tree(
     which every profile has and which would otherwise put a "Home" on screen per
     profile. Keying on the path rather than the id also folds a profile's
     declared project (``p_<hash>``) together with the auto entry another profile
-    grows for the same folder. Sessions carry the owning profile instead, which
-    is what the row badge and the profile filter read; a group header never
-    claims a single owner.
+    grows for the same folder. Sessions carry the owning profile for row badges;
+    ``profileProjects`` preserves every concrete source record so an action on
+    the merged header can still route to the right profile database(s).
     """
     for project in projects:
+        project["profileProjects"] = [
+            {
+                "id": project["id"],
+                "profile": profile,
+                "isAuto": bool(project.get("isAuto")),
+            }
+        ]
         for lane in (repo for r in project.get("repos") or [] for repo in r.get("groups") or []):
             for session in lane.get("sessions") or []:
                 session["profile"] = profile
@@ -616,6 +623,15 @@ def _merge_profile_tree(
         previews = (existing.get("previewSessions") or []) + (project.get("previewSessions") or [])
         previews.sort(key=lambda s: s.get("last_active") or s.get("started_at") or 0, reverse=True)
         existing["previewSessions"] = previews[:preview_limit]
+        refs = {
+            (ref["profile"], ref["id"]): ref
+            for ref in existing.get("profileProjects") or []
+        }
+        refs.update({
+            (ref["profile"], ref["id"]): ref
+            for ref in project.get("profileProjects") or []
+        })
+        existing["profileProjects"] = list(refs.values())
 
 
 @sessions_router.get("/api/profiles/projects/tree")
@@ -629,9 +645,10 @@ def get_profiles_projects_tree(preview_limit: int = 3, session_limit: int = 2000
     the repo-scan policy, the HERMES_HOME junk filters — through the
     context-local home override the profile-scoped writers already use.
 
-    Projects merge by id across profiles, so a group stands for a checkout
-    rather than a checkout-and-owner, and the profile shows up per row where
-    the filter can act on it.
+    Projects merge by folder across profiles, so a group stands for a checkout
+    rather than a checkout-and-owner. Session rows carry their profile for
+    filtering, while the header carries exact per-profile project references
+    for mutations such as Delete.
 
     Discovery is off. A repo with zero sessions is the same repo in every
     profile, so folding the disk scan in would multiply empty lanes by the

--- a/tests/hermes_cli/test_profiles_sidebar_scope.py
+++ b/tests/hermes_cli/test_profiles_sidebar_scope.py
@@ -150,6 +150,10 @@ class TestCrossProfileProjectTree:
         declared = [project for project in payload["projects"] if not project["isNoProject"]]
         assert [project["path"] for project in declared] == [str(shared)]
         assert declared[0]["sessionCount"] == 2
+        assert {
+            (ref["profile"], ref["isAuto"])
+            for ref in declared[0]["profileProjects"]
+        } == {("default", False), ("worker", False)}
 
     def test_group_totals_add_up_the_sessions_the_group_counts(self, client, profiles_on_disk, tmp_path):
         # A header total is only meaningful if it covers exactly what the header


### PR DESCRIPTION
## Summary

- preserve the concrete project id and profile behind each merged all-profiles project row
- route Delete to every explicit source record and reconcile the merged tree safely
- hide owner-specific writes and the blank-state New project action when browsing All profiles

## Root cause

The cross-profile tree intentionally merges projects by folder, but discarded the source project identity. The renderer then tried to mutate the merged row through the All profiles sentinel, which the project RPC guard correctly rejects because it is not a writable profile.

## Validation

- 46 focused desktop UI tests
- 8 cross-profile backend tests
- desktop TypeScript typecheck
- targeted ESLint and Ruff checks
- manual packaged-app verification: deleting a saved project removed its Hermes record while leaving its folder and repository untouched