### PR TITLE
fix(projects): bind-board writes the project link, not only the workdir mirror

### DIFF
--- a/hermes_cli/projects_cmd.py
+++ b/hermes_cli/projects_cmd.py
@@ -305,31 +305,82 @@ def _cmd_restore(args, conn, proj) -> int:
 
 @_with_project
 def _cmd_bind_board(args, conn, proj) -> int:
+    previous = (proj.board_slug or "").strip()
     pdb.update_project(conn, proj.id, board_slug=args.board)
     if args.board.strip():
         print(f"Bound {proj.slug} -> board {args.board}")
-        _sync_board_default_workdir(proj, args.board)
+        _sync_board_binding(proj, args.board)
     else:
         print(f"Unbound board from {proj.slug}")
+        # The board keeps a `project_id` of its own; leaving it set after an
+        # unbind is how a board goes on inheriting a project it is no longer
+        # bound to.
+        _clear_board_binding(previous)
     return 0
 
 
-def _sync_board_default_workdir(proj, board_slug: str) -> None:
-    """Best-effort: point the bound board's default_workdir at the primary repo.
+def _board_slug_or_none(board_slug: str):
+    """The normalized slug of an EXISTING board, or None. Shared by both writers."""
+    from hermes_cli import kanban_db as kb
 
-    Keeps kanban task worktrees anchored to the project's repo. Failures here
-    are non-fatal — the binding itself already succeeded.
+    slug = kb._normalize_board_slug(board_slug)
+    if not slug:
+        return None, kb
+    if slug != kb.DEFAULT_BOARD and not kb.board_exists(slug):
+        return None, kb
+    return slug, kb
+
+
+def _sync_board_binding(proj, board_slug: str) -> None:
+    """Best-effort: write the project LINK onto the board, and mirror its repo.
+
+    TWO jobs, and the previous version silently did only the second one.
+    ``project_id`` is the field the board's own inheritance path reads —
+    ``kanban_db.write_board_metadata`` documents it as "Optional first-class
+    Project this board is scoped to. When set, new tasks inherit it
+    (deterministic worktree + branch under the project's primary repo)" — so a
+    board bound without it keeps minting tasks on a shared ``dir`` workspace,
+    which is what ``--project`` exists to avoid. The bind reported success and
+    the effect never arrived.
+
+    Measured on one install before this fix: 11 of 11 boards had
+    ``project_id: null`` while their projects named them, and 249 tasks had piled
+    onto shared working trees — including two that blocked each other with
+    "concurrent edits in shared dir".
+
+    The order also matters: the primary-path check may not gate the link. A
+    project with no folder yet still has an identity to bind, and the old early
+    return threw both jobs away for want of the second one's input.
+
+    Failures stay non-fatal, as before: the binding in the projects DB has
+    already succeeded, and this mirror is a convenience on top of it.
     """
-    if not proj.primary_path:
-        return
     try:
-        from hermes_cli import kanban_db as kb
-
-        slug = kb._normalize_board_slug(board_slug)
+        slug, kb = _board_slug_or_none(board_slug)
         if not slug:
             return
-        if slug != kb.DEFAULT_BOARD and not kb.board_exists(slug):
+        fields = {"project_id": proj.id}
+        if proj.primary_path:
+            fields["default_workdir"] = proj.primary_path
+        kb.write_board_metadata(slug, **fields)
+    except Exception:
+        pass
+
+
+def _clear_board_binding(board_slug: str) -> None:
+    """Best-effort: drop the project scope from a board that was just unbound.
+
+    ``write_board_metadata`` takes the empty string as "clear" and ``None`` as
+    "leave unchanged", so the clear has to be explicit. ``default_workdir`` is
+    deliberately left alone: an operator may have set it by hand, and it is not
+    the project link.
+    """
+    if not board_slug:
+        return
+    try:
+        slug, kb = _board_slug_or_none(board_slug)
+        if not slug:
             return
-        kb.write_board_metadata(slug, default_workdir=proj.primary_path)
+        kb.write_board_metadata(slug, project_id="")
     except Exception:
         pass

--- a/tests/hermes_cli/test_project_bind_board.py
+++ b/tests/hermes_cli/test_project_bind_board.py
@@ -1,0 +1,132 @@
+"""`project bind-board` must write the LINK, not only mirror the workdir.
+
+The board's own metadata carries `project_id`, and `kanban_db.write_board_metadata`
+documents what it is for: "Optional first-class Project this board is scoped to.
+When set, new tasks inherit it (deterministic worktree + branch under the project's
+primary repo)". `bind-board` set the project's `board_slug` and mirrored
+`default_workdir`, and never wrote that field — so the bind printed success while
+the effect it exists for never arrived.
+
+Measured on one install before this fix: 11 of 11 boards had `project_id: null`
+while their projects named them, and 249 tasks had piled onto shared working trees,
+two of them blocking each other with "concurrent edits in shared dir".
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import projects_cmd
+from hermes_cli import projects_db as pdb
+
+
+@pytest.fixture(autouse=True)
+def _isolate(tmp_path, monkeypatch):
+    """Boards and the projects DB in tmp_path — never the operator's real ones."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(kb, "_HERMES_HOME_OVERRIDE", str(tmp_path), raising=False)
+    yield
+
+
+def _project(name="Web App", folders=("/tmp/webapp",)):
+    with pdb.connect_closing() as pc:
+        pid = pdb.create_project(pc, name=name, folders=list(folders))
+        return pdb.get_project(pc, pid)
+
+
+def _bind(proj, board):
+    # Through the decorated entry point, which is what the CLI calls: the
+    # @_with_project wrapper opens the DB and resolves the project itself.
+    args = argparse.Namespace(board=board, project=proj.slug)
+    return projects_cmd._cmd_bind_board(args)
+
+
+def test_bind_board_writes_the_project_link_onto_the_board():
+    proj = _project()
+    kb.create_board("web")
+
+    assert _bind(proj, "web") == 0
+
+    meta = kb.read_board_metadata("web")
+    # The field the inheritance path reads. This is the assertion the old code
+    # failed: everything else about the bind already worked.
+    assert meta["project_id"] == proj.id
+    # And the convenience mirror it already did.
+    assert meta["default_workdir"] == proj.primary_path
+
+
+def test_a_project_with_no_folder_still_binds():
+    """The workdir mirror may not gate the link.
+
+    The old code returned early when `primary_path` was empty, throwing away the
+    link for want of the mirror's input. A project with no folder yet still has an
+    identity, and binding it is exactly how a board starts inheriting one.
+    """
+    proj = _project(name="Empty", folders=())
+    assert not proj.primary_path
+    kb.create_board("empty-board")
+
+    assert _bind(proj, "empty-board") == 0
+
+    meta = kb.read_board_metadata("empty-board")
+    assert meta["project_id"] == proj.id
+    # Nothing to mirror, so nothing is invented.
+    assert not meta.get("default_workdir")
+
+
+def test_a_bound_board_makes_new_tasks_inherit_the_worktree(tmp_path):
+    """The point of the whole thing, asserted through task creation.
+
+    A task created on a bound board with no workspace flags must land on a
+    deterministic worktree under the project's repo — not on the shared `dir`
+    workspace that 249 tasks ended up sharing.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    proj = _project(name="Router", folders=(str(repo),))
+    kb.create_board("router")
+    _bind(proj, "router")
+
+    conn = kb.connect(board="router")
+    try:
+        #  explicitly: create_task resolves the project from the board it
+        # is TOLD about, falling back to the ambient current board — not from the
+        # connection. Passing it is what the CLI does, and leaving it out here
+        # tested the active board instead of this one.
+        tid = kb.create_task(conn, title="Add login", board="router")
+        task = kb.get_task(conn, tid)
+    finally:
+        conn.close()
+
+    assert task.project_id == proj.id, "the board's link must reach the task"
+    assert task.workspace_kind == "worktree"
+    assert task.workspace_path.startswith(str(repo))
+    assert task.branch_name and not task.branch_name.startswith("wt/")
+
+
+def test_unbinding_clears_the_scope_it_set():
+    """Otherwise a board goes on inheriting a project it is no longer bound to.
+
+    `write_board_metadata` takes `None` as "leave unchanged" and the empty string
+    as "clear", so the clear has to be deliberate.
+    """
+    proj = _project()
+    kb.create_board("web")
+    _bind(proj, "web")
+    assert kb.read_board_metadata("web")["project_id"] == proj.id
+
+    with pdb.connect_closing() as pc:
+        proj = pdb.get_project(pc, proj.id)   # reload: board_slug is set now
+    assert _bind(proj, "") == 0
+
+    assert not kb.read_board_metadata("web")["project_id"]
+
+
+def test_binding_a_board_that_does_not_exist_is_a_no_op_not_a_crash():
+    """The mirror was always best-effort and stays that way: the projects DB is
+    the authority on the binding, and this side is a convenience on top of it."""
+    proj = _project()
+    assert _bind(proj, "no-such-board") == 0


### PR DESCRIPTION
fix(projects): bind-board writes the project link, not only the workdir mirror

`project bind-board` had two jobs and silently did one. It set the project's
`board_slug` and mirrored `default_workdir` onto the board, and never wrote the
board's own `project_id` — the field the inheritance path actually reads.

`kanban_db.write_board_metadata` documents what that field is for:

    ``project_id``: Optional first-class Project this board is scoped to. When
    set, new tasks inherit it (deterministic worktree + branch under the
    project's primary repo) and ``default_workdir`` mirrors the project's
    primary path.

and `create_task` implements exactly that. So the bind printed `Bound X -> board
Y` and the effect it exists for never arrived: every task kept landing on a
shared `dir` workspace, which is what `--project` exists to avoid.

MEASURED on one install before this fix: 11 of 11 boards had `project_id: null`
while their projects named them, and 249 tasks had piled onto shared working
trees — 119 of them on a single repo path. Two blocked each other with
"Paused to avoid concurrent edits in shared dir". The one board with worktree
tasks got them by passing `--workspace worktree` on every single create.

THE PRIMARY-PATH CHECK MAY NOT GATE THE LINK, which is the second half of the
same defect. The old code returned early when `primary_path` was empty, throwing
away the binding for want of the mirror's input. A project with no folder yet
still has an identity, and binding it is how a board starts inheriting one.

UNBIND NOW CLEARS WHAT BIND SET. Leaving `project_id` behind is how a board goes
on inheriting a project it is no longer bound to. `write_board_metadata` takes
`None` as "leave unchanged" and the empty string as "clear", so the clear has to
be deliberate.

Failures stay non-fatal, as before: the projects DB is the authority on the
binding and this mirror is a convenience on top of it.

Tests: five, in tests/hermes_cli/test_project_bind_board.py. The load-bearing one
goes through task creation — a task created on a bound board with no workspace
flags must land on a deterministic worktree under the project's repo — because
asserting the metadata alone would not have told us whether anything reads it.
Dropping `project_id` from the write fails four of the five.

One observation left for a separate change, not fixed here: `create_task`
resolves the board for that inheritance from its `board` argument, falling back
to the ambient current board — not from the connection it was handed. Creating a
task with a connection for board X while the active board is Y therefore inherits
Y's project. The `default_workdir` fallback a few lines below reads the board the
same way. Both are consistent with each other and predate this change.
