### PR TITLE
Guard ConsuConstruct vault markdown writes

### DIFF
--- a/tests/tools/test_consuconstruct_vault_write_guard.py
+++ b/tests/tools/test_consuconstruct_vault_write_guard.py
@@ -1,0 +1,77 @@
+"""Hermes direct-write guard for David's ConsuConstruct vault Markdown.
+
+The Brain MCP `vault_note_write` / `obsidian_write` path is the only sanctioned
+writer for vault .md files because it enforces planning_complete, reason, canon
+frontmatter/CONTEXT, and a Postgres audit event.
+"""
+
+import json
+from pathlib import Path
+
+from tools import file_tools
+from tools.file_tools import patch_tool, write_file_tool
+
+
+def _set_fake_vault(monkeypatch, tmp_path: Path) -> Path:
+    vault = tmp_path / "My Brain" / "ConsuConstruct"
+    vault.mkdir(parents=True)
+    monkeypatch.setattr(file_tools, "_CONSUCONSTRUCT_VAULT_ROOT", vault.resolve())
+    return vault
+
+
+class TestConsuConstructVaultMarkdownWriteGuard:
+    def test_write_file_rejects_md_inside_vault(self, tmp_path: Path, monkeypatch):
+        vault = _set_fake_vault(monkeypatch, tmp_path)
+        target = vault / "00 Notes" / "audit.md"
+
+        result = json.loads(write_file_tool(str(target), "---\nstatus: active\n---\n"))
+
+        assert result.get("error")
+        assert "ConsuConstruct vault Markdown" in result["error"]
+        assert "vault_note_write" in result["error"]
+        assert not target.exists()
+
+    def test_write_file_allows_non_markdown_inside_vault(self, tmp_path: Path, monkeypatch):
+        vault = _set_fake_vault(monkeypatch, tmp_path)
+        target = vault / "00 Notes" / "asset.txt"
+
+        result = json.loads(write_file_tool(str(target), "plain text artifact"))
+
+        assert not result.get("error")
+        assert target.read_text(encoding="utf-8") == "plain text artifact"
+
+    def test_write_file_allows_markdown_outside_vault(self, tmp_path: Path, monkeypatch):
+        _set_fake_vault(monkeypatch, tmp_path)
+        target = tmp_path / "outside.md"
+
+        result = json.loads(write_file_tool(str(target), "# outside"))
+
+        assert not result.get("error")
+        assert target.read_text(encoding="utf-8") == "# outside"
+
+    def test_patch_replace_rejects_md_inside_vault(self, tmp_path: Path, monkeypatch):
+        vault = _set_fake_vault(monkeypatch, tmp_path)
+        target = vault / "00 Notes" / "existing.md"
+        target.parent.mkdir(parents=True)
+        target.write_text("old", encoding="utf-8")
+
+        result = json.loads(patch_tool(path=str(target), old_string="old", new_string="new"))
+
+        assert result.get("error")
+        assert "ConsuConstruct vault Markdown" in result["error"]
+        assert target.read_text(encoding="utf-8") == "old"
+
+    def test_v4a_patch_rejects_md_inside_vault(self, tmp_path: Path, monkeypatch):
+        vault = _set_fake_vault(monkeypatch, tmp_path)
+        target = vault / "00 Notes" / "v4a.md"
+        patch = f"""*** Begin Patch
+*** Add File: {target}
++# v4a
+*** End Patch
+"""
+
+        result = json.loads(patch_tool(mode="patch", patch=patch))
+
+        assert result.get("error")
+        assert "ConsuConstruct vault Markdown" in result["error"]
+        assert not target.exists()

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -2174,6 +2174,38 @@ def _mark_verification_stale(
         logger.debug("verification stale marker failed", exc_info=True)
 
 
+_CONSUCONSTRUCT_VAULT_ROOT = Path(r"D:\OneDrive\Desktop\My Brain\ConsuConstruct").resolve()
+
+
+def _check_consuconstruct_vault_markdown_write(filepath: str, task_id: str = "default") -> str | None:
+    """Reject Hermes direct writes to David's canonical Obsidian vault Markdown.
+
+    Brain MCP `vault_note_write` / `obsidian_write` is the only sanctioned write
+    path for `.md` in this vault because it enforces planning_complete, reason,
+    canon frontmatter/CONTEXT, and an audit event in Postgres.
+    """
+    try:
+        resolved = Path(_resolve_path_for_task(filepath, task_id)).resolve()
+    except Exception:
+        try:
+            resolved = Path(_expand_tilde(filepath)).resolve()
+        except Exception:
+            return None
+    if resolved.suffix.lower() not in {".md", ".markdown"}:
+        return None
+    try:
+        resolved.relative_to(_CONSUCONSTRUCT_VAULT_ROOT)
+    except ValueError:
+        return None
+    return (
+        "Refusing direct Hermes write to ConsuConstruct vault Markdown. "
+        "Rules 49/52 require Brain MCP `vault_note_write`/`obsidian_write` so "
+        "the note is written only after investigation/planning is complete and "
+        "leaves an audit record (planning_complete=True, reason, sha256). "
+        f"Rejected path: {resolved}"
+    )
+
+
 def _check_binary_document_write(filepath: str, task_id: str = "default") -> str | None:
     """Reject text-tool writes that would corrupt a binary document.
 
@@ -2239,6 +2271,9 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
     protected_err = _check_protected_instruction_write([path], task_id)
     if protected_err:
         return tool_error(protected_err)
+    vault_md_err = _check_consuconstruct_vault_markdown_write(path, task_id)
+    if vault_md_err:
+        return tool_error(vault_md_err)
     approval_err = _check_approval_required_write([path], task_id)
     if approval_err:
         return tool_error(approval_err)
@@ -2385,6 +2420,9 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
         binary_doc_err = _check_binary_document_write(_p, task_id)
         if binary_doc_err:
             return tool_error(binary_doc_err)
+        vault_md_err = _check_consuconstruct_vault_markdown_write(_p, task_id)
+        if vault_md_err:
+            return tool_error(vault_md_err)
     # One approval prompt for the whole patch: a single protected file gates
     # the ENTIRE patch (deny applies nothing — see the helper's docstring).
     protected_err = _check_protected_instruction_write(_paths_to_check, task_id)


### PR DESCRIPTION
## Summary
- Blocks direct Hermes write_file/patch writes to ConsuConstruct vault Markdown files.
- Directs vault Markdown writes through Brain MCP vault_note_write/obsidian_write so planning_complete, reason, sha256, and audit records are enforced.
- Adds regression coverage for write_file and patch guard behavior.

## Test Plan
- uv run pytest tests/tools/test_consuconstruct_vault_write_guard.py tests/tools/test_binary_document_write_guard.py tests/tools/test_write_deny.py -q
- D:/LLM/python/python.exe -m pytest tests/test_obsidian_write_gate.py tests/test_mcp_catalog.py tests/test_mcp_directed_gate.py -q (brain-agentic companion verification)
