### PR TITLE
fix(kanban): `kanban block` requires a reason like `kanban_block`

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -907,6 +907,23 @@ def _commented(conn, reason: Optional[str], author, prefix: str, op):
 
 def _cmd_block(args: argparse.Namespace) -> int:
     reason = _joined_words(args.reason)
+    # A blocked task is a request for a human decision, and a request with no
+    # sentence is one nobody can act on: the next reader has to reconstruct the
+    # cause from run logs, or unblock blind and watch it re-block.
+    # ``kanban_block`` (tools/kanban_tools.py) has always refused an empty reason
+    # with "reason is required — explain what input you need". The same operation
+    # through the CLI accepted one, so the requirement depended on which surface
+    # you happened to use. Measured on one install: 126 of 141 block events
+    # carried a reason and 13 of the 15 that did not came from outside a run —
+    # this path.
+    if not reason:
+        print(
+            "kanban block: a reason is required — say what input or decision "
+            "the task is waiting for (the same rule kanban_block enforces for "
+            "workers)",
+            file=sys.stderr,
+        )
+        return 2
     kind = getattr(args, "kind", None)
     author = _profile_author()
     ids = _bulk_ids(args)

--- a/hermes_cli/kanban_parser.py
+++ b/hermes_cli/kanban_parser.py
@@ -292,7 +292,9 @@ _SPECS = [
     ], help="Edit recovery fields on an already-completed task"),
     _cmd("block", [
         _TASK_ID,
-        _arg("reason", nargs="*", help="Reason (also appended as a comment)"),
+        _arg("reason", nargs="*",
+             help="Required. Why it is blocked / what it waits for (also appended "
+                  "as a comment)"),
         _bulk_ids("block"),
         _arg("--kind", choices=sorted(kb.VALID_BLOCK_KINDS),
              help="Typed block reason. 'dependency' waits in todo (auto-promoted when "

--- a/tests/hermes_cli/test_kanban_block_requires_reason.py
+++ b/tests/hermes_cli/test_kanban_block_requires_reason.py
@@ -1,0 +1,103 @@
+"""`kanban block` requires a reason, like `kanban_block` always has.
+
+A blocked task is a request for a human decision, and a request with no sentence
+is one nobody can act on. The worker tool (tools/kanban_tools.py `_handle_block`)
+has always refused an empty reason with "reason is required — explain what input
+you need"; the CLI accepted one, so the requirement depended on which surface you
+used.
+
+Measured on one install: 126 of 141 `blocked` events carried a reason, and 13 of
+the 15 that did not came from outside any run — this path.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import pytest
+
+from hermes_cli import kanban as kanban_cmd
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_db_connect as kbc
+
+
+@pytest.fixture(autouse=True)
+def _isolate(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(kb, "_HERMES_HOME_OVERRIDE", str(tmp_path), raising=False)
+    yield
+
+
+def _task():
+    conn = kbc.connect()
+    try:
+        return kb.create_task(conn, title="Wire the thing")
+    finally:
+        conn.close()
+
+
+def _block(task_id, reason_words):
+    args = argparse.Namespace(task_id=task_id, reason=reason_words, ids=[],
+                              kind=None)
+    return kanban_cmd._cmd_block(args)
+
+
+def _status(task_id):
+    conn = kbc.connect()
+    try:
+        return kb.get_task(conn, task_id).status
+    finally:
+        conn.close()
+
+
+def test_block_without_a_reason_is_refused_and_changes_nothing():
+    tid = _task()
+    before = _status(tid)
+
+    assert _block(tid, []) == 2, "exit 2: a usage error, not a silent success"
+    # The refusal has to be total. A task left blocked with no reason is exactly
+    # the state this check exists to prevent.
+    assert _status(tid) == before
+
+
+@pytest.mark.parametrize("words", [[], [""], ["   "], ["", "  "]])
+def test_whitespace_is_not_a_reason(words):
+    tid = _task()
+    assert _block(tid, words) == 2
+    assert _status(tid) != "blocked"
+
+
+def test_a_real_reason_blocks_and_is_recorded_where_a_human_will_read_it():
+    tid = _task()
+    assert _block(tid, ["waiting", "on", "the", "vendor", "key"]) == 0
+    assert _status(tid) == "blocked"
+
+    conn = kbc.connect()
+    try:
+        # Two places, on purpose: the event payload is what a report reads, the
+        # comment is what a person reads on the card.
+        eventos = conn.execute(
+            "SELECT payload FROM task_events WHERE task_id=? AND kind='blocked'",
+            (tid,),
+        ).fetchall()
+        assert eventos and "waiting on the vendor key" in (eventos[-1][0] or "")
+        comentarios = conn.execute(
+            "SELECT body FROM task_comments WHERE task_id=?", (tid,)
+        ).fetchall()
+        assert any("BLOCKED: waiting on the vendor key" in (c[0] or "")
+                   for c in comentarios)
+    finally:
+        conn.close()
+
+
+def test_the_cli_and_the_worker_tool_now_agree():
+    """The point of the change: one rule, whichever surface you use."""
+    import inspect
+
+    from tools import kanban_tools
+
+    fonte = inspect.getsource(kanban_tools._handle_block)
+    assert "reason is required" in fonte, (
+        "the worker tool's requirement is the precedent this mirrors; if it "
+        "moved, this test should be the one that notices"
+    )


### PR DESCRIPTION
fix(kanban): `kanban block` requires a reason, like `kanban_block` always has

A blocked task is a request for a human decision, and a request with no sentence
is one nobody can act on: the next reader reconstructs the cause from run logs, or
unblocks blind and watches it re-block.

`kanban_block` — the tool workers call — has refused an empty reason from the
start: "reason is required — explain what input you need" (tools/kanban_tools.py,
`_handle_block`). The CLI accepted one, so whether the requirement applied
depended on which surface you happened to use for the same operation.

MEASURED on one install, over 141 `blocked` events: 126 carried a reason, 15 did
not, and 13 of those 15 came from outside any run — this path. So the worker-side
rule is working and this is the remaining hole, not the main one. The argument for
closing it is consistency rather than volume: two surfaces onto one operation
should not disagree about what the operation needs.

The refusal is total — exit 2 and the task is untouched. A task left blocked with
no reason is exactly the state the check exists to prevent, so half-applying it
would be worse than not checking.

Whitespace is not a reason: `kanban block t_x "   "` is refused too. The reason is
already stored twice on purpose and both keep working — the event payload, which a
report reads, and a `BLOCKED: <reason>` comment, which a person reads on the card.

Tests: seven, in tests/hermes_cli/test_kanban_block_requires_reason.py, including
the parametrised whitespace cases and one that asserts the worker tool's own
requirement is still the precedent this mirrors — if that message moves, this test
is the one that should notice. Removing the refusal fails five of the seven.

Pre-existing failures unchanged: `pytest tests/hermes_cli/ -k kanban` reports 15
failures on a clean upstream/main worktree and the same 15 with this change
applied (294 passed there, 301 here — the difference is this file's seven).
