### PR TITLE
fix(desktop): stop baking the venv's base interpreter into the Linux Exec= line

### DIFF
--- a/hermes_cli/linux_desktop_entry.py
+++ b/hermes_cli/linux_desktop_entry.py
@@ -78,11 +78,11 @@ def resolve_exec_command() -> str:
             # third-party import (#90292) — silently, since Terminal=false.
             # sys.executable is the interpreter actually running Hermes (the
             # venv one), so prefix it explicitly.
-            argv = [str(Path(sys.executable).resolve()), str(resolved), "desktop"]
+            argv = [sys.executable, str(resolved), "desktop"]
         else:
             argv = [str(resolved), "desktop"]
     else:
-        argv = [str(Path(sys.executable).resolve()), "-m", "hermes_cli.main", "desktop"]
+        argv = [sys.executable, "-m", "hermes_cli.main", "desktop"]
     return " ".join(_quote_exec_arg(a) for a in argv)
 
 
@@ -106,7 +106,12 @@ def _needs_interpreter(bin_path: Path) -> bool:
     # A python shebang pointing INSIDE the running interpreter's environment
     # already resolves correctly; anything else (``/usr/bin/env python3``,
     # a system path) would escape the venv when spawned by the DE.
-    exe_dir = str(Path(sys.executable).resolve().parent)
+    # Compare against the UNRESOLVED sys.executable. In a venv,
+    # ``venv/bin/python3`` is a symlink to the base interpreter, so
+    # resolving it yields a directory no venv console-script shebang can
+    # ever contain — the test inverts, and the venv-less base interpreter
+    # gets baked into ``Exec=``, reintroducing #90292 by another route.
+    exe_dir = str(Path(sys.executable).parent)
     return exe_dir not in shebang
 
 

--- a/tests/hermes_cli/test_linux_desktop_entry.py
+++ b/tests/hermes_cli/test_linux_desktop_entry.py
@@ -107,8 +107,9 @@ def test_exec_prefixes_interpreter_for_env_shebang_python_script(tmp_path, xdg_h
     entry = lde.install_desktop_entry(root)
     exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
 
-    interpreter = str(Path(sys.executable).resolve())
-    assert exec_line.split(" ")[0].strip('"') == interpreter
+    # The venv interpreter, NOT its resolved base: resolving would strip the
+    # venv's site-packages back off.
+    assert exec_line.split(" ")[0].strip('"') == sys.executable
     assert str(hermes_bin) in exec_line
     assert exec_line.endswith("desktop")
 
@@ -135,8 +136,7 @@ def test_exec_leaves_venv_shebang_scripts_alone(tmp_path, xdg_home, monkeypatch)
     root = _make_project(tmp_path)
     hermes_bin = tmp_path / "bin" / "hermes"
     hermes_bin.parent.mkdir()
-    interpreter = str(Path(sys.executable).resolve())
-    hermes_bin.write_text(f"#!{interpreter}\nimport hermes_cli\n", encoding="utf-8")
+    hermes_bin.write_text(f"#!{sys.executable}\nimport hermes_cli\n", encoding="utf-8")
     hermes_bin.chmod(0o755)
     monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: str(hermes_bin))
     monkeypatch.setattr(lde, "refresh_desktop_databases", lambda _dir: [])
@@ -147,6 +147,41 @@ def test_exec_leaves_venv_shebang_scripts_alone(tmp_path, xdg_home, monkeypatch)
     # Console-script with the venv's own interpreter in the shebang: correct
     # as-is, prefixing would only add noise.
     assert exec_line == f"{hermes_bin} desktop"
+
+
+# Regression: `venv/bin/python3` is a symlink to the base interpreter under uv,
+# virtualenv and `python -m venv --symlinks`. Resolving sys.executable to
+# compare it against the shebang can never match a venv console script, so the
+# check inverted and `Exec=` got the base interpreter — which has none of the
+# venv's site-packages. The entry then died on `import hermes_cli`, silently,
+# because Terminal=false.
+def test_exec_leaves_symlinked_venv_python_shebang_alone(tmp_path, xdg_home, monkeypatch):
+    root = _make_project(tmp_path)
+
+    base_bin = tmp_path / "base" / "bin"
+    base_bin.mkdir(parents=True)
+    base_python = base_bin / "python3.11"
+    base_python.write_text("", encoding="utf-8")
+    base_python.chmod(0o755)
+
+    venv_bin = tmp_path / "venv" / "bin"
+    venv_bin.mkdir(parents=True)
+    venv_python = venv_bin / "python3"
+    venv_python.symlink_to(base_python)
+
+    hermes_bin = venv_bin / "hermes"
+    hermes_bin.write_text(f"#!{venv_python}\nimport hermes_cli\n", encoding="utf-8")
+    hermes_bin.chmod(0o755)
+
+    monkeypatch.setattr(lde.sys, "executable", str(venv_python))
+    monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: str(hermes_bin))
+    monkeypatch.setattr(lde, "refresh_desktop_databases", lambda _dir: [])
+
+    entry = lde.install_desktop_entry(root)
+    exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
+
+    assert exec_line == f"{Path(hermes_bin).resolve()} desktop"
+    assert str(base_python) not in exec_line
 
 
 def test_install_is_idempotent_and_skips_cache_refresh(tmp_path, xdg_home, monkeypatch):


### PR DESCRIPTION
## Symptom

On Linux, the Hermes launcher icon does nothing. `hermes desktop` from a terminal works fine. The journal shows:

```
hermes.desktop[26049]: Traceback (most recent call last):
hermes.desktop[26049]:   File "~/.hermes/hermes-agent/venv/bin/hermes", line 4, in <module>
hermes.desktop[26049]:     from hermes_cli.main import main
hermes.desktop[26049]: ModuleNotFoundError: No module named 'hermes_cli'
```

Nothing is visible to the user because the entry sets `Terminal=false`.

## Root cause

`_needs_interpreter()` decided whether a launcher's shebang escapes the venv by comparing it against `Path(sys.executable).resolve().parent`.

In every symlinked venv — `uv`, `virtualenv`, `python -m venv --symlinks` — `venv/bin/python3` is a symlink to the base interpreter, so `.resolve()` yields the *base* interpreter's directory, which no venv console-script shebang can ever contain. The test inverted: a correct venv shebang was classified as escaping the venv, and `Exec=` was rewritten to run the venv's own entry-point script under the base interpreter.

Observed on an affected machine (Ubuntu 26.04, uv-managed CPython 3.11):

```
Exec=~/.local/share/uv/python/cpython-3.11.15-linux-x86_64-gnu/bin/python3.11 ~/.hermes/hermes-agent/venv/bin/hermes desktop
```

That interpreter has none of the venv's `site-packages`, including the editable install's `.pth` that provides `hermes_cli` — hence the import error.

`install_desktop_entry()` runs on every `hermes desktop` launch and keys off `argv[0]`, so the breakage is sticky rather than transient: once any launch resolves `argv[0]` to the venv console script, the entry stays broken.

The same `.resolve()` also weakened the two branches that *legitimately* prefix an interpreter (the `/usr/bin/env python3` case from #90292, and the `-m hermes_cli.main` fallback). Both baked in the base interpreter, which sees none of the venv's third-party dependencies — so the original #90292 fix was itself degraded on any symlinked venv.

## Fix

Drop `.resolve()` in all three places. `sys.executable` is already absolute, and it is the venv interpreter we actually want.

## Tests

`test_exec_leaves_venv_shebang_scripts_alone` wrote its fixture shebang from `Path(sys.executable).resolve()` — the one shape the buggy check happened to get right — which is why this was never caught. It now uses the real shape.

Added `test_exec_leaves_symlinked_venv_python_shebang_alone`, which builds a venv with a symlinked python and asserts the base interpreter never reaches `Exec=`. Reverting the source change makes it fail with exactly the broken line seen in the wild:

```
- .../venv/bin/hermes desktop
+ .../base/bin/python3.11 .../venv/bin/hermes desktop
```

`tests/hermes_cli/test_linux_desktop_entry.py`: 16 passed, 2 skipped.
`tests/hermes_cli/test_gui_command.py`, `test_gui_uninstall.py`: 47 passed, 9 skipped.
