### PR TITLE
fix(update): scope fleet-probe runtime expectation to gateway-kind plan records

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -10066,7 +10066,7 @@ def _fleet_probe_expected_runtimes(
     * ``pre_restart_pids`` non-empty, or ``None`` (pre-state unreadable —
       cannot prove nothing was running; same contract as
       ``_restart_phase_failure_is_incomplete``, #78574).
-    * the pre-update plan inventoried ≥1 runtime.
+    * the pre-update plan inventoried ≥1 runtime with ``kind == "gateway"``.
 
     ``windows_resume_token`` is deliberately EXCLUDED (#93406 residual). The
     pause/resume token is bookkeeping for ``_pause_windows_gateways_for_update``
@@ -10089,6 +10089,18 @@ def _fleet_probe_expected_runtimes(
     parameter stays in the signature so the call site keeps passing the token
     (cheap, explicit, and the docstring is where the exclusion is explained).
 
+    The plan-runtime check is gateway-scoped for the same reason (#97332):
+    the plan inventory also carries ``kind="serve"`` / ``kind="dashboard"``
+    records (#95576), and ``collect_fleet_versions()`` verifies gateway
+    identities only — a serve/dashboard backend never publishes the
+    ``gateway_state.json`` row the probe would need. Counting any non-empty
+    plan therefore made a dashboard-only update (gateway never started)
+    wait out the probe for rows that cannot exist, print the
+    incomplete-verification warning, and exit 1 after a successful update.
+    Only a ``kind == "gateway"`` record is evidence that gateway rows were
+    expected; the restarted/killed/pre-restart-PID signals above still fail
+    closed unchanged.
+
     The same condition gates the 2.0s settle sleep: a freshly restarted
     gateway needs the settle window to rewrite ``gateway_state.json``.
 
@@ -10103,7 +10115,15 @@ def _fleet_probe_expected_runtimes(
         return True
     try:
         if pre_update_plan is not None and pre_update_plan.runtimes:
-            return True
+            # Gateway-scoped on purpose (#97332): serve/dashboard plan
+            # records have no collect_fleet_versions() row, so only a
+            # kind == "gateway" runtime is evidence that gateway rows were
+            # expected.
+            if any(
+                getattr(runtime, "kind", None) == "gateway"
+                for runtime in pre_update_plan.runtimes
+            ):
+                return True
     except Exception:
         pass
     return False

--- a/tests/hermes_cli/test_update_fleet_check_fail_closed.py
+++ b/tests/hermes_cli/test_update_fleet_check_fail_closed.py
@@ -12,9 +12,11 @@ which never fires on Windows: ``_pause_windows_gateways_for_update`` /
 hoists the "should the probe have produced rows?" decision into
 ``_fleet_probe_expected_runtimes`` and keys it on the ROW-CAPABLE pre-update
 liveness signals: restart-phase bookkeeping, the pre-restart PID snapshot,
-and the pre-update plan inventory.  The Windows pause/resume token is
-deliberately NOT a signal — it is bookkeeping, not a runtime inventory, and
-its entries have no corresponding ``collect_fleet_versions()`` rows (see
+and the gateway-kind records in the pre-update plan inventory (the plan's
+serve/dashboard records are row-incapable for this probe, #97332).  The
+Windows pause/resume token is deliberately NOT a signal — it is bookkeeping,
+not a runtime inventory, and its entries have no corresponding
+``collect_fleet_versions()`` rows (see
 ``test_update_fleet_probe_resume_token.py``).  The same condition gates the
 2.0s settle sleep.
 """
@@ -25,6 +27,7 @@ import inspect
 import types
 
 from hermes_cli.main import _fleet_probe_expected_runtimes
+from hermes_cli.update_inventory import RuntimeRecord
 
 
 def _plan(runtimes):
@@ -34,17 +37,68 @@ def _plan(runtimes):
 class TestEmptySnapshotFailClosed:
     """Signals under which zero fleet rows means verification failure."""
 
-    def test_incomplete_when_pre_update_plan_saw_runtimes(self):
-        # (a) The plan inventoried a live runtime pre-update but the restart
-        # phase's POSIX bookkeeping is empty (e.g. Windows, or an
+    def test_incomplete_when_pre_update_plan_saw_gateway_runtimes(self):
+        # (a) The plan inventoried a live gateway runtime pre-update but the
+        # restart phase's POSIX bookkeeping is empty (e.g. Windows, or an
         # externally-supervised gateway). Zero rows must fail closed.
         assert (
             _fleet_probe_expected_runtimes(
-                _plan([object()]),
+                _plan([RuntimeRecord(kind="gateway", profile="default")]),
                 [],  # pre_restart_pids: probe saw nothing
                 None,  # no Windows resume token
                 [],  # restarted_services
                 set(),  # killed_pids
+            )
+            is True
+        )
+
+    def test_dashboard_only_plan_does_not_expect_rows(self):
+        # #97332: the plan inventory also carries kind="dashboard" records
+        # (#95576), but collect_fleet_versions() reports gateway identities
+        # only. A dashboard-only plan (gateway never started) cannot ground
+        # a rows-expected verdict — counting it made a successful update
+        # print the incomplete-verification warning and exit 1.
+        assert (
+            _fleet_probe_expected_runtimes(
+                _plan([RuntimeRecord(kind="dashboard", profile="default")]),
+                [],
+                None,
+                [],
+                set(),
+            )
+            is False
+        )
+
+    def test_serve_only_plan_does_not_expect_rows(self):
+        # Same row-incapable reasoning as the dashboard record above: a
+        # manually launched `hermes serve` backend never publishes the
+        # gateway_state.json row the fleet probe would need.
+        assert (
+            _fleet_probe_expected_runtimes(
+                _plan([RuntimeRecord(kind="serve", profile="default")]),
+                [],
+                None,
+                [],
+                set(),
+            )
+            is False
+        )
+
+    def test_mixed_plan_keys_on_gateway_record(self):
+        # A dashboard running alongside a real gateway still expects rows:
+        # the gateway record carries the expectation.
+        assert (
+            _fleet_probe_expected_runtimes(
+                _plan(
+                    [
+                        RuntimeRecord(kind="dashboard", profile="default"),
+                        RuntimeRecord(kind="gateway", profile="work"),
+                    ]
+                ),
+                [],
+                None,
+                [],
+                set(),
             )
             is True
         )

--- a/tests/hermes_cli/test_update_fleet_probe_resume_token.py
+++ b/tests/hermes_cli/test_update_fleet_probe_resume_token.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 import types
 
 from hermes_cli.main import _fleet_probe_expected_runtimes
+from hermes_cli.update_inventory import RuntimeRecord
 
 
 def _plan(runtimes):
@@ -86,7 +87,13 @@ class TestRowCapableSignalsStillCount:
     def test_plan_inventory_still_expects_rows_alongside_token(self):
         token = {"resume_needed": False, "unmapped": [{"pid": 99, "argv": ["x"]}]}
         assert (
-            _fleet_probe_expected_runtimes(_plan([object()]), [], token, [], set())
+            _fleet_probe_expected_runtimes(
+                _plan([RuntimeRecord(kind="gateway", profile="default")]),
+                [],
+                token,
+                [],
+                set(),
+            )
             is True
         )
 


### PR DESCRIPTION
## What does this PR do?

`hermes update` exits 1 after a *successful* update when a dashboard (or `hermes serve`) is running but no gateway is. The pre-update plan inventory carries `kind="dashboard"` / `kind="serve"` records (#95576), and `_fleet_probe_expected_runtimes()` treated any non-empty `pre_update_plan.runtimes` as evidence that gateway fleet rows must exist. `collect_fleet_versions()` reports gateway identities only, so a dashboard-only plan created an impossible expectation: the probe waited for rows that cannot exist, printed the "verification incomplete" warning, recorded a partial result, and exited 1.

The fix keys the plan-derived expectation on `kind == "gateway"` records — the same row-capability rule the function already applies to the Windows resume token (#93406: "expected-runtimes must key only on signals that map to rows the probe can actually see"). A serve/dashboard backend never publishes the `gateway_state.json` row the probe would need, so it cannot ground a rows-expected verdict. All existing fail-closed signals (restart-phase bookkeeping, killed PIDs, pre-restart PID snapshot including the unreadable `None` case) are untouched, and a real gateway record in the plan still expects rows.

Not related to #78863 (Node-dependency repair at current HEAD) — that PR touches `hermes_cli/update_cmd.py` too but a different function, and does not touch the fleet probe.

## Related Issue

Fixes #97332

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/update_cmd.py` — `_fleet_probe_expected_runtimes()`: the plan check now requires ≥1 runtime with `kind == "gateway"` instead of any non-empty `runtimes`; docstring documents the gateway-scoping rationale (#97332) alongside the existing token-exclusion precedent.
- `tests/hermes_cli/test_update_fleet_check_fail_closed.py` — replace the `object()` placeholder in `test_incomplete_when_pre_update_plan_saw_runtimes` with a real `RuntimeRecord(kind="gateway", ...)` so the test pins the runtime-kind distinction; add `test_dashboard_only_plan_does_not_expect_rows`, `test_serve_only_plan_does_not_expect_rows`, and `test_mixed_plan_keys_on_gateway_record`.
- `tests/hermes_cli/test_update_fleet_probe_resume_token.py` — same `object()` → `RuntimeRecord(kind="gateway", ...)` update for the plan-signal test.

## How to Test

1. `uv run pytest tests/hermes_cli/test_update_fleet_check_fail_closed.py tests/hermes_cli/test_update_fleet_probe_resume_token.py -v` — Observed result: **20 passed** (16 pre-existing incl. the updated ones + 4 new regression cases).
2. New negative cases pin the bug: a plan of `[RuntimeRecord(kind="dashboard", ...)]` or `[RuntimeRecord(kind="serve", ...)]` with no gateway-side signals returns `False` (pre-fix the non-empty check returned `True`, which produced exit 1 on a healthy dashboard-only update).
3. Fail-closed controls still hold: `kind="gateway"` plan record → `True`; restarted services / killed PIDs / non-empty or unreadable pre-restart PID snapshot → `True` (covered by the unchanged pre-existing tests in both files).
4. Broader local run `uv run pytest tests/hermes_cli/ -k "update" -q`: 754 passed, 48 failed — all 48 reproduce on a clean `upstream/main` checkout of this branch point (or pass when run in isolation), i.e. pre-existing local-environment failures / order coupling, none in the two files this PR touches.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## For New Skills

N/A — not a skill.
