### PR TITLE
feat(kanban): a retry after a no-verdict exit is told what the last run left behind

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -307,6 +307,14 @@ def _resolve_rate_limit_cooldown_seconds() -> int:
 # build_worker_context() caps, sized for a ~100k-char prompt with headroom.
 _CTX_MAX_PRIOR_ATTEMPTS = 10      # most recent N prior runs shown in full
 _CTX_MAX_COMMENTS       = 30      # most recent N comments shown in full
+# A clean-exit protocol violation means the run did its work and skipped the
+# paperwork — the guidance already tells the retry to "verify it and report the
+# result via kanban_complete". Verifying it started with REDISCOVERING it: nothing
+# handed the retry what the previous run had changed, so each attempt re-derived
+# the same state. Measured on one install: 117 such runs across 49 tasks, 5.0 runs
+# per task, and 4 tasks that never recovered at all.
+_CTX_EVIDENCE_MAX_COMMITS = 5
+_CTX_EVIDENCE_TIMEOUT_S = 10
 _CTX_MAX_FIELD_BYTES    = 4 * 1024   # per summary/error/metadata/result
 _CTX_MAX_BODY_BYTES     = 8 * 1024   # per task.body (opening post)
 _CTX_MAX_COMMENT_BYTES  = 2 * 1024   # per comment
@@ -3669,6 +3677,77 @@ def _ctx_attachments(lines: list[str], attachments: list[Attachment]) -> None:
     lines.append("")
 
 
+def _run_was_protocol_violation(run) -> bool:
+    """True when this closed run ended as a clean-exit-without-verdict.
+
+    Two readings because the two sources age differently: the durable marker
+    ``detect_crashed_workers`` copies into the run metadata, and the error text
+    for runs recorded before that marker existed.
+    """
+    meta = getattr(run, "metadata", None)
+    if isinstance(meta, dict) and meta.get("protocol_violation"):
+        return True
+    return "protocol violation" in (getattr(run, "error", "") or "")
+
+
+def _protocol_violation_evidence(task, run) -> list[str]:
+    """What the previous run left behind in the workspace, named for the retry.
+
+    Read-only, time-bounded, and silent on ANY failure: a worker prompt that
+    cannot be built is worse than one without this section, and this is a
+    convenience on top of guidance that already works.
+
+    ``--since`` filters on COMMITTER date, which is what "landed during that run"
+    means here — a commit authored earlier and committed by that run still counts,
+    and that is the case worth catching (an agent that stages for a while and
+    commits at the end).
+    """
+    path = (getattr(task, "workspace_path", None) or "").strip()
+    kind = getattr(task, "workspace_kind", None)
+    started = getattr(run, "started_at", None)
+    if not path or kind not in {"dir", "worktree"} or not started:
+        return []
+    try:
+        import subprocess
+
+        since = time.strftime("%Y-%m-%dT%H:%M:%S", time.localtime(int(started)))
+
+        def _git(*args: str) -> str:
+            out = subprocess.run(
+                ("git", "-C", path) + args,
+                capture_output=True, text=True,
+                timeout=_CTX_EVIDENCE_TIMEOUT_S,
+            )
+            return out.stdout.strip() if out.returncode == 0 else ""
+
+        if not _git("rev-parse", "--is-inside-work-tree"):
+            return []
+        commits = _git("log", f"--since={since}", "--oneline",
+                       f"-n{_CTX_EVIDENCE_MAX_COMMITS}")
+        dirty = [ln for ln in _git("status", "--porcelain").splitlines() if ln.strip()]
+    except Exception:
+        return []
+
+    if not commits and not dirty:
+        # Nothing landed. Saying so is the useful half: it tells the retry the
+        # work is still to do, instead of leaving it to hunt for work that was
+        # never there.
+        return ["_The previous run left no commit and no uncommitted change in "
+                f"`{path}` — treat the work as still to do._"]
+
+    out = ["**What the previous run left behind** (it exited without reporting, "
+           "so this is unverified — confirm before claiming it):"]
+    if commits:
+        out.append(f"Commits in `{path}` since that run started:")
+        out.extend(f"- `{ln}`" for ln in commits.splitlines())
+    if dirty:
+        shown = dirty[:_CTX_EVIDENCE_MAX_COMMITS]
+        out.append(f"Uncommitted in `{path}`: {len(dirty)} file(s)"
+                   + (" (first few)" if len(dirty) > len(shown) else ""))
+        out.extend(f"- `{ln}`" for ln in shown)
+    return out
+
+
 def _ctx_prior_attempts(lines: list[str], conn: sqlite3.Connection, task_id: str, now: int) -> None:
     """Closed runs on this task (the active run is this worker), newest
     ``_CTX_MAX_PRIOR_ATTEMPTS`` in full, older ones as a one-line marker."""
@@ -3694,6 +3773,14 @@ def _ctx_prior_attempts(lines: list[str], conn: sqlite3.Connection, task_id: str
         if meta_line:
             lines.append(meta_line)
         lines.append("")
+    # The most recent closed attempt ended clean-but-verdictless: name what it
+    # left in the workspace instead of asking the retry to go and find it.
+    if shown and _run_was_protocol_violation(shown[-1]):
+        evidence = _protocol_violation_evidence(get_task(conn, task_id), shown[-1])
+        if evidence:
+            lines.append("")
+            lines.extend(evidence)
+            lines.append("")
 
 
 def _ctx_parent_results(lines: list[str], conn: sqlite3.Connection, task_id: str, now: int) -> None:

--- a/tests/hermes_cli/test_kanban_no_verdict_evidence.py
+++ b/tests/hermes_cli/test_kanban_no_verdict_evidence.py
@@ -1,0 +1,199 @@
+"""A retry after a no-verdict exit is told what the previous run left behind.
+
+`detect_crashed_workers` records a clean-exit-without-verdict as a protocol
+violation and surfaces the corrective sentence to the retry worker: "if the prior
+run already did the work, verify it and report the result via kanban_complete".
+Verifying it began with REDISCOVERING it — nothing handed the retry what the last
+run had changed, so every attempt re-derived the same state.
+
+Measured on one install: 117 such runs across 49 tasks, 5.0 runs per task, and 4
+tasks that never recovered.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import time
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_db_connect as kbc
+
+
+@pytest.fixture(autouse=True)
+def _isolate(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(kb, "_HERMES_HOME_OVERRIDE", str(tmp_path), raising=False)
+    yield
+
+
+@pytest.fixture
+def conn():
+    c = kbc.connect()
+    try:
+        yield c
+    finally:
+        c.close()
+
+
+def _git(path, *args, env=None):
+    return subprocess.run(("git", "-C", str(path)) + args, check=True,
+                          capture_output=True, env=env)
+
+
+def _repo(tmp_path, name="repo"):
+    """A repo whose seed commit is genuinely OLD.
+
+    The seed has to predate the run window, or it shows up as "what the previous
+    run left behind" — which is what the first version of this fixture did, and
+    the empty-workspace tests caught it. Dating it a day back is the difference
+    between a window that means something and one that swallows the fixture.
+    """
+    path = tmp_path / name
+    path.mkdir()
+    _git(path, "init", "-q")
+    _git(path, "config", "user.email", "t@example.com")
+    _git(path, "config", "user.name", "T")
+    (path / "seed.txt").write_text("seed\n", encoding="utf-8")
+    _git(path, "add", "-A")
+    old = dict(os.environ,
+               GIT_AUTHOR_DATE="2026-08-01T10:00:00",
+               GIT_COMMITTER_DATE="2026-08-01T10:00:00")
+    _git(path, "commit", "-q", "-m", "seed", env=old)
+    return path
+
+
+VIOLATION_ERROR = ("worker exited cleanly (rc=0) without calling "
+                   "kanban_complete or kanban_block — protocol violation.")
+
+
+def _closed_run(conn, tid, *, error, metadata=None, started_ago=600):
+    """A closed run whose window really precedes whatever came after it.
+
+    ``_synthesize_ended_run`` stamps ``started_at == ended_at == now``, so a
+    commit made a second earlier would fall outside the ``--since`` window this
+    feature reads. Backdating the start is what makes the window mean anything in
+    a test that finishes in under a second.
+    """
+    with kb.write_txn(conn):
+        rid = kb._synthesize_ended_run(conn, tid, outcome="crashed",
+                                       error=error, metadata=metadata)
+        conn.execute("UPDATE task_runs SET started_at = ? WHERE id = ?",
+                     (int(time.time()) - started_ago, rid))
+    return rid
+
+
+def _task_with_violation(conn, repo, *, commit=None, dirty=False):
+    tid = kb.create_task(conn, title="Wire it", workspace_kind="dir",
+                         workspace_path=str(repo))
+    if commit:
+        (repo / commit).write_text("work\n", encoding="utf-8")
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "-q", "-m", "feat: the work the run did not report")
+    if dirty:
+        (repo / "left-behind.txt").write_text("half done\n", encoding="utf-8")
+    _closed_run(conn, tid, error=VIOLATION_ERROR,
+                metadata={"protocol_violation": True})
+    return tid
+
+
+def test_the_commit_the_previous_run_did_not_report_is_named(conn, tmp_path):
+    repo = _repo(tmp_path)
+    tid = _task_with_violation(conn, repo, commit="feature.txt")
+
+    ctx = kb.build_worker_context(conn, tid)
+
+    assert "What the previous run left behind" in ctx
+    assert "feat: the work the run did not report" in ctx
+    # Named as UNVERIFIED: the previous run never reported it, so the retry has
+    # to confirm rather than inherit the claim.
+    assert "unverified" in ctx
+
+
+def test_uncommitted_work_left_behind_is_counted(conn, tmp_path):
+    repo = _repo(tmp_path, "repo2")
+    tid = _task_with_violation(conn, repo, dirty=True)
+
+    ctx = kb.build_worker_context(conn, tid)
+
+    assert "Uncommitted in" in ctx
+    assert "left-behind.txt" in ctx
+
+
+def test_an_empty_workspace_says_so_instead_of_staying_silent(conn, tmp_path):
+    """The useful half of "nothing landed": it tells the retry the work is still
+    to do, instead of leaving it to hunt for work that was never there."""
+    repo = _repo(tmp_path, "repo3")
+    tid = _task_with_violation(conn, repo)
+
+    ctx = kb.build_worker_context(conn, tid)
+
+    assert "left no commit and no uncommitted change" in ctx
+    assert "still to do" in ctx
+
+
+def test_a_normal_failure_gets_no_evidence_block(conn, tmp_path):
+    """Only the no-verdict case. A run that reported its own failure already said
+    what happened, and a workspace dump would be noise on top of it."""
+    repo = _repo(tmp_path, "repo4")
+    tid = kb.create_task(conn, title="Wire it", workspace_kind="dir",
+                         workspace_path=str(repo))
+    _closed_run(conn, tid, error="pid 4242 killed by signal 9")
+
+    ctx = kb.build_worker_context(conn, tid)
+    assert "What the previous run left behind" not in ctx
+    assert "left no commit" not in ctx
+
+
+def test_a_scratch_workspace_is_never_probed(conn, tmp_path):
+    """`scratch` is not a repo checkout; running git there would be a guess.
+
+    The path is a REAL repo on purpose. The first version of this test used a
+    scratch task with no path at all, so it passed on the empty-path check and
+    said nothing about the kind — removing the kind guard left it green. Pointing
+    a scratch task at a live repo is what makes the kind the only thing standing
+    between this feature and a workspace it has no claim to read.
+    """
+    repo = _repo(tmp_path, "scratch-repo")
+    (repo / "later.txt").write_text("after\n", encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "feat: something in a scratch path")
+    tid = kb.create_task(conn, title="Research something",
+                         workspace_kind="scratch", workspace_path=str(repo))
+    assert kb.get_task(conn, tid).workspace_kind == "scratch"
+    assert kb.get_task(conn, tid).workspace_path == str(repo)
+    _closed_run(conn, tid, error=VIOLATION_ERROR,
+                metadata={"protocol_violation": True})
+
+    ctx = kb.build_worker_context(conn, tid)
+    assert "What the previous run left behind" not in ctx
+    assert "something in a scratch path" not in ctx
+    assert "left no commit" not in ctx
+
+
+def test_a_workspace_that_is_not_a_repo_is_silent_not_a_crash(conn, tmp_path):
+    plain = tmp_path / "not-a-repo"
+    plain.mkdir()
+    tid = kb.create_task(conn, title="Wire it", workspace_kind="dir",
+                         workspace_path=str(plain))
+    _closed_run(conn, tid, error=VIOLATION_ERROR,
+                metadata={"protocol_violation": True})
+
+    # The prompt still builds. That is the contract: a prompt that cannot be
+    # built is worse than a prompt without this section.
+    ctx = kb.build_worker_context(conn, tid)
+    assert "Wire it" in ctx
+    assert "What the previous run left behind" not in ctx
+
+
+def test_the_older_error_text_still_counts_as_a_violation(conn, tmp_path):
+    """Runs recorded before the durable marker existed carry only the sentence."""
+    repo = _repo(tmp_path, "repo5")
+    tid = kb.create_task(conn, title="Wire it", workspace_kind="dir",
+                         workspace_path=str(repo))
+    _closed_run(conn, tid, error=VIOLATION_ERROR)
+
+    ctx = kb.build_worker_context(conn, tid)
+    assert "left no commit and no uncommitted change" in ctx


### PR DESCRIPTION
feat(kanban): a retry after a no-verdict exit is told what the last run left behind

`detect_crashed_workers` (now in `hermes_cli/kanban_db_dispatch.py`) already handles
the clean-exit-without-verdict case well: it records a protocol violation, and its
corrective sentence reaches the retry worker through `build_worker_context` — "if the
prior run already did the work, verify it and report the result via kanban_complete".

Verifying it began with REDISCOVERING it. Nothing handed the retry what the
previous run had changed, so every attempt re-derived the same state from scratch
before it could act on the guidance.

MEASURED on one install: 117 runs ended this way across 49 tasks — 5.0 runs per
task — and 91% of those tasks did eventually complete, which is the point. The
guidance works; the cost is the rediscovery. Four tasks never recovered at all,
one of them sitting blocked for five weeks with its work already committed.

WHAT THIS ADDS. When the most recent closed attempt was a no-verdict exit and the
task has a `dir` or `worktree` workspace that is a git repo, the worker prompt now
names what is there: commits whose committer date falls inside that run's window,
and a count of uncommitted files. Committer date rather than author date on
purpose — a commit authored earlier but committed by that run still landed during
it, and that is the case worth catching.

The section is emitted from `_ctx_prior_attempts` in `hermes_cli/kanban_db.py`,
right after the shown-run tail, so it sits beside the attempt whose evidence it is.
The violation is recognised the same way `_protocol_violation_streak` recognises it
(the durable `protocol_violation` run-metadata marker, with the error text as
fallback for runs recorded before the marker existed).

"NOTHING LANDED" IS ALSO AN ANSWER, and it is why the empty case is not silent:
telling the retry the workspace is untouched saves it from hunting for work that
was never there.

BOUNDARIES, each with a test:

* Only the no-verdict case. A run that reported its own failure already said what
  happened; a workspace dump on top of that is noise.
* Only `dir` / `worktree`. A `scratch` task is not a repo checkout, and probing a
  path it happens to carry would be a guess about someone else's tree.
* A workspace that is not a repo, or a git call that fails or times out, produces
  nothing at all. A prompt that cannot be built is worse than a prompt without
  this section, and the guidance it sits beside already works without it.
* Read-only, capped at five commits, ten-second timeout.

Everything it reports is labelled unverified, because the run that produced it
never reported it. The retry has to confirm before claiming it — inheriting an
unreported claim is the failure this whole path exists to catch.

Tests: seven, in tests/hermes_cli/test_kanban_no_verdict_evidence.py. Three
mutations were run against them: not calling the evidence at all, dropping the
`--since` window, and dropping the workspace-kind guard.

The third one SURVIVED the first time, and the reason is worth recording: the
scratch test used a task with no workspace path, so it passed on the empty-path
check and said nothing about the kind. It now points a scratch task at a real repo
with a real commit, which makes the kind guard the only thing standing between this
feature and a tree it has no claim to read — and then the mutation fails.

The repo fixture backdates its seed commit for the same class of reason: with the
seed at "now" it fell inside the run window and the empty-workspace assertions were
passing on the fixture's own noise.

Rebased onto current main. The test opens its connection through
`hermes_cli.kanban_db_connect.connect` (the `kanban_db.connect` alias is a
plugin-compat pointer that `scripts/check_compat_pointers.py` rejects for in-tree
code). Locally green: the seven new tests, `test_kanban_db.py`,
`test_kanban_core_functionality.py`, `test_kanban_blocked_sticky.py`,
`tests/plugins/test_kanban_attachments.py`, ruff, and the compat-pointer check.
