### PR TITLE
fix(scripts): --all skipped tui_gateway and every package outside its 8 hardcoded roots

### DIFF
--- a/apps/desktop/scripts/perf/gateway_attach_bench.py
+++ b/apps/desktop/scripts/perf/gateway_attach_bench.py
@@ -114,7 +114,7 @@ def main() -> int:
     content_b64 = base64.b64encode(png_bytes(args.kb)).decode("ascii")
 
     scratch = home / "scratch.txt"
-    scratch.write_text("hello from the bench\n")
+    scratch.write_text("hello from the bench\n", encoding="utf-8")
 
     image_on_disk = home / "on-disk.png"
     image_on_disk.write_bytes(png_bytes(args.kb))

--- a/evals/readtool/report.py
+++ b/evals/readtool/report.py
@@ -28,7 +28,7 @@ def load_label(label: str, model_filter: str | None) -> dict:
         if model_filter and model_dir.name != model_filter:
             continue
         for rep_file in sorted(model_dir.glob("rep*.json")):
-            data = json.loads(rep_file.read_text())
+            data = json.loads(rep_file.read_text(encoding="utf-8"))
             for rec in data["records"]:
                 if rec.get("error"):
                     # count errored task-runs as score 0 but keep them in the

--- a/evals/session_search_schema/runner.py
+++ b/evals/session_search_schema/runner.py
@@ -50,7 +50,7 @@ def _load_api_key() -> str:
         return key
     env_path = Path.home() / ".hermes" / ".env"
     if env_path.exists():
-        for line in env_path.read_text().splitlines():
+        for line in env_path.read_text(encoding="utf-8").splitlines():
             if line.startswith("OPENROUTER_API_KEY="):
                 return line.split("=", 1)[1].strip().strip('"').strip("'")
     raise SystemExit("OPENROUTER_API_KEY not found (env or ~/.hermes/.env)")
@@ -65,7 +65,7 @@ def extract_arm(ref: str, workdir: Path, name: str) -> Path:
     if out.returncode != 0:
         raise SystemExit(f"git show {ref}: {out.stderr.strip()}")
     path = workdir / f"ss_arm_{name}.py"
-    path.write_text(out.stdout)
+    path.write_text(out.stdout, encoding="utf-8")
     return path
 
 
@@ -237,7 +237,7 @@ def main():
         outpath = outdir / (re.sub(r"[^\w.-]", "_", args.model) + ".jsonl")
         done = set()
         if outpath.exists():
-            for line in outpath.read_text().splitlines():
+            for line in outpath.read_text(encoding="utf-8").splitlines():
                 try:
                     r = json.loads(line)
                     done.add((r["task"], r["arm"], r["rep"]))

--- a/scripts/check-windows-footguns.py
+++ b/scripts/check-windows-footguns.py
@@ -113,6 +113,17 @@ EXCLUDED_FILES = {
     "CONTRIBUTING.md",
 }
 
+# Directories --all walks past. Unlike EXCLUDED_DIRS these are still scanned
+# when named explicitly or reached through --diff / staged mode, so a footgun
+# introduced in a test is still caught at review time. `tests/` is skipped by
+# the full sweep only because it is overwhelmingly the larger half of the repo
+# and currently carries ~2.3k matches (nearly all bare read_text()); letting
+# them into the blocking CI sweep would bury the handful of production hits
+# this check exists to surface. Cleaning them up is its own campaign.
+FULL_SCAN_SKIP_DIRS = {
+    "tests",
+}
+
 
 @dataclass
 class Footgun:
@@ -456,6 +467,24 @@ def should_scan_file(path: Path) -> bool:
     return False
 
 
+def full_scan_roots() -> list[Path]:
+    """Top-level entries --all sweeps: the whole repo minus the skip lists.
+
+    Returns repo-root children rather than REPO_ROOT itself so the top-level
+    skip decision is explicit and testable; ``iter_files`` still applies
+    EXCLUDED_DIRS / EXCLUDED_SUFFIXES / EXCLUDED_FILES underneath each one.
+    Top-level *files* (cli.py, conftest.py, ...) are included — they were
+    invisible to the old package list.
+    """
+    return sorted(
+        child
+        for child in REPO_ROOT.iterdir()
+        if not child.name.startswith(".")
+        and child.name not in EXCLUDED_DIRS
+        and child.name not in FULL_SCAN_SKIP_DIRS
+    )
+
+
 def iter_files(paths: Iterable[Path]) -> Iterable[Path]:
     for p in paths:
         if p.is_file():
@@ -709,7 +738,10 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     p.add_argument(
         "--all",
         action="store_true",
-        help="Scan the full repository (hermes_cli/, gateway/, tools/, cron/, etc.).",
+        help=(
+            "Scan the full repository (everything except "
+            f"{'/, '.join(sorted(FULL_SCAN_SKIP_DIRS))}/ and the always-excluded dirs)."
+        ),
     )
     p.add_argument(
         "--diff",
@@ -749,18 +781,14 @@ def main(argv: list[str]) -> int:
         return 0
 
     if args.all:
-        # Scan main Python packages + scripts
-        roots = [
-            REPO_ROOT / "hermes_cli",
-            REPO_ROOT / "gateway",
-            REPO_ROOT / "tools",
-            REPO_ROOT / "cron",
-            REPO_ROOT / "agent",
-            REPO_ROOT / "plugins",
-            REPO_ROOT / "scripts",
-            REPO_ROOT / "acp_adapter",
-        ]
-        roots = [r for r in roots if r.exists()]
+        # Walk the repository rather than a hand-maintained package list. The
+        # old list named eight directories and silently skipped everything
+        # else — tui_gateway/, evals/, providers/, skills/ and the top-level
+        # modules like cli.py — so the blocking CI sweep reported "no footguns
+        # found" for code it had never opened. Anything new at the repo root
+        # is now covered the day it lands instead of the day someone
+        # remembers to extend this list.
+        roots = full_scan_roots()
     elif args.diff:
         roots = get_diff_files(args.diff)
     elif args.paths:

--- a/tests/scripts/test_windows_footguns_full_repo_scan.py
+++ b/tests/scripts/test_windows_footguns_full_repo_scan.py
@@ -16,12 +16,30 @@ the stdin guard already closes its equivalent one.
 
 from __future__ import annotations
 
+import importlib.util
 import subprocess
 import sys
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = REPO_ROOT / "scripts" / "check-windows-footguns.py"
+
+
+def _load_checker():
+    """Import the hyphenated script as a module.
+
+    Registered in sys.modules before exec_module because @dataclass resolves
+    its class's __module__ through sys.modules while the class body runs.
+    """
+    spec = importlib.util.spec_from_file_location("_windows_footgun_checker", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    try:
+        spec.loader.exec_module(module)
+    except Exception:
+        sys.modules.pop(spec.name, None)
+        raise
+    return module
 
 
 def test_full_repo_scan_has_no_unsuppressed_windows_footguns():
@@ -39,3 +57,61 @@ def test_full_repo_scan_has_no_unsuppressed_windows_footguns():
     assert result.returncode == 0, (
         f"Windows footgun check failed:\n{result.stdout}\n{result.stderr}"
     )
+
+
+def test_full_scan_reaches_packages_outside_the_old_hardcoded_list():
+    """--all must walk the repo, not a hand-maintained package list.
+
+    Until this was fixed, --all scanned eight named directories
+    (hermes_cli, gateway, tools, cron, agent, plugins, scripts,
+    acp_adapter). Everything else — tui_gateway/ among them — was invisible,
+    so the blocking CI job above reported a clean tree for code it had never
+    opened, and a live os.kill(pid, 0) sat in tui_gateway/host_supervisor.py
+    (#97019) while this very test passed. Assert the walk reaches packages
+    the old list omitted so the coverage gap cannot silently return.
+    """
+    checker = _load_checker()
+    roots = {p.name for p in checker.full_scan_roots()}
+
+    for package in (
+        "tui_gateway",
+        "evals",
+        "providers",
+        "skills",
+        "hermes_cli",
+        "gateway",
+    ):
+        if (REPO_ROOT / package).is_dir():
+            assert package in roots, f"--all no longer reaches {package}/"
+
+    # Top-level modules were invisible to the old directory-only list too.
+    if (REPO_ROOT / "cli.py").is_file():
+        assert "cli.py" in roots
+
+
+def test_full_scan_skips_only_the_documented_directories():
+    """Skips stay narrow and declared — no silent additions."""
+    checker = _load_checker()
+    roots = {p.name for p in checker.full_scan_roots()}
+
+    assert checker.FULL_SCAN_SKIP_DIRS == {"tests"}
+    assert "tests" not in roots, (
+        "tests/ is skipped by the sweep, per FULL_SCAN_SKIP_DIRS"
+    )
+    assert ".git" not in roots
+    for excluded in checker.EXCLUDED_DIRS:
+        assert excluded not in roots
+
+
+def test_named_paths_still_scan_skipped_directories():
+    """--all skipping tests/ must not make the checker blind to it.
+
+    Staged/diff/explicit-path runs still cover tests, so a footgun added to a
+    test is caught at review time even though the sweep walks past it.
+    """
+    checker = _load_checker()
+    tests_dir = REPO_ROOT / "tests"
+    if not tests_dir.is_dir():
+        return
+    scanned = any(True for _ in checker.iter_files([tests_dir]))
+    assert scanned, "explicitly naming tests/ must still scan it"

--- a/tui_gateway/host_supervisor.py
+++ b/tui_gateway/host_supervisor.py
@@ -88,13 +88,18 @@ def _default_registry_path() -> Path:
 def _pid_alive(pid: int) -> bool:
     if pid <= 0:
         return False
+    # NOT os.kill(pid, 0): on Windows CPython maps sig=0 onto CTRL_C_EVENT and
+    # routes it through GenerateConsoleCtrlEvent(0, pid), Ctrl+C-ing the whole
+    # console process group containing the target (bpo-14484). This function is
+    # a read-only probe — reconcile_startup_orphan calls it before deciding
+    # whether to touch anything — so on Windows it was killing the process it
+    # was only meant to ask about, plus unrelated siblings sharing its console.
+    # _pid_exists is the repo's cross-platform answer (psutil, ctypes
+    # OpenProcess fallback); it raises nothing we need to translate.
+    from gateway.status import _pid_exists
+
     try:
-        os.kill(pid, 0)
-        return True
-    except ProcessLookupError:
-        return False
-    except PermissionError:
-        return True
+        return bool(_pid_exists(pid))
     except Exception:
         return False
 
@@ -544,7 +549,12 @@ class HostSupervisor:
                 return
             time.sleep(0.05)
         try:
-            os.kill(pid, signal.SIGKILL)
+            # signal.SIGKILL is POSIX-only — referencing it on Windows raises
+            # AttributeError, which the except below swallowed at debug level,
+            # so the escalation silently never happened. SIGTERM reaches
+            # TerminateProcess through os.kill on Windows, which is the
+            # force-kill this branch wants.
+            os.kill(pid, getattr(signal, "SIGKILL", signal.SIGTERM))
         except ProcessLookupError:
             return
         except Exception:


### PR DESCRIPTION
## What does this PR do?

`scripts/check-windows-footguns.py --all` advertises a full-repository scan, and it is what the blocking **"Windows footguns (blocking)"** lint job runs (`.github/workflows/lint.yml:180`). It actually walked a hand-maintained list of eight directories — `hermes_cli`, `gateway`, `tools`, `cron`, `agent`, `plugins`, `scripts`, `acp_adapter` — and silently ignored everything else in the repo.

So the sweep reported a clean tree for code it had never opened:

```console
$ python scripts/check-windows-footguns.py --all
✓ No Windows footguns found (1021 file(s) scanned).

$ python scripts/check-windows-footguns.py tui_gateway/host_supervisor.py
✗ 2 Windows footgun(s) found across 1 file(s) scanned.
tui_gateway/host_supervisor.py:92: [os.kill(pid, 0)]
tui_gateway/host_supervisor.py:547: [bare signal.SIGKILL]
```

`tests/scripts/test_windows_footguns_full_repo_scan.py` exists precisely to stop a bare `os.killpg`/`signal.SIGKILL` regression reaching main, and its docstring records that one already had. It passed throughout — it shells out to `--all`, so it inherited the same blind spot.

`--all` now walks the repository. Coverage goes **1021 → 1168 files**, picking up `tui_gateway/`, `evals/`, `providers/`, `skills/` and the top-level modules (`cli.py`) that a directory-only list could never see.

`tests/` is skipped by the sweep alone. It is the larger half of the repo and currently carries ~2.3k matches, nearly all bare `read_text()`, which would bury the production hits this job exists to surface. Explicit paths, `--diff` and staged mode still scan it, so a footgun added to a test is still caught at review time; that backlog is its own campaign.

### Why this approach

Walking the repo and subtracting a small declared skip list means anything added at the repo root is covered the day it lands, rather than the day someone remembers to extend a list. The skip set is a named constant with a comment, and a test asserts it stays narrow.

## Related Issue

Fixes #97019

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

**The coverage gap**

- `scripts/check-windows-footguns.py` — added `full_scan_roots()`; `--all` uses it instead of eight hardcoded paths. Added `FULL_SCAN_SKIP_DIRS = {"tests"}` (sweep-only, documented). Updated `--all` help text, which claimed a full-repo scan.

**The seven findings that surfaced** — fixed here so the blocking job stays green:

- `tui_gateway/host_supervisor.py:92` — `_pid_alive` used `os.kill(pid, 0)`. On Windows CPython maps `sig=0` onto `CTRL_C_EVENT` and routes it through `GenerateConsoleCtrlEvent(0, pid)`, Ctrl+C-ing the entire console process group containing the target ([bpo-14484](https://bugs.python.org/issue14484)) — the case `CONTRIBUTING.md`'s first critical rule forbids. `reconcile_startup_orphan` calls it as a **read-only probe** before deciding whether to touch anything, so on Windows the probe was killing the process it was only meant to ask about, plus unrelated siblings sharing its console. Now delegates to `gateway.status._pid_exists`, matching `cli.py`, `cron/executions.py`, `gateway/delivery_ledger.py` and `gateway/lifecycle_ledger.py`.
- `tui_gateway/host_supervisor.py:547` — `_terminate_pid`'s escalation referenced `signal.SIGKILL`, which does not exist on Windows. The `AttributeError` was swallowed by the surrounding `except` and logged at debug, so **the force-kill silently never ran**. Now `getattr(signal, "SIGKILL", signal.SIGTERM)`; on Windows `os.kill` reaches `TerminateProcess`, which is the force-kill this branch wants. (Not reported in #97019 — it surfaced from the same scan.)
- `evals/readtool/report.py`, `evals/session_search_schema/runner.py`, `apps/desktop/scripts/perf/gateway_attach_bench.py` — five bare `read_text()`/`write_text()` calls now pass `encoding="utf-8"`.

**Tests**

- `tests/scripts/test_windows_footguns_full_repo_scan.py` — three tests: the walk reaches packages the old list omitted; the skip list stays narrow and declared; naming `tests/` explicitly still scans it.

## How to Test

1. Confirm the gap on `main`:
   ```console
   $ python scripts/check-windows-footguns.py --all
   ✓ No Windows footguns found (1021 file(s) scanned).
   $ python scripts/check-windows-footguns.py tui_gateway/host_supervisor.py
   ✗ 2 Windows footgun(s) found across 1 file(s) scanned.
   ```
2. On this branch, the sweep sees them and is clean after the fixes:
   ```console
   $ python scripts/check-windows-footguns.py --all
   ✓ No Windows footguns found (1168 file(s) scanned).
   ```
3. `pytest tests/scripts/test_windows_footguns_full_repo_scan.py tests/scripts/test_footgun_subprocess_encoding.py -q` → 13 passed.
4. `ruff check .` → passes.
5. `_pid_alive` behaviour, verified on Windows 11: `True` for the current process and a live child, `False` after that child is killed, `False` for `0`, a negative pid and an unused high pid.

I deliberately did **not** script a live reproduction of the `os.kill(pid, 0)` kill on my own machine — `GenerateConsoleCtrlEvent` would have signalled unrelated processes in my session. The mechanism is documented in `gateway/status._pid_exists`'s own docstring and in bpo-14484.

### Note on unrelated test failures

`tests/tui_gateway/test_compute_host.py::test_compute_host_line_json_seed_turn_interrupt` and `tests/tui_gateway/test_compute_host_phase1.py::test_append_log_record_single_write_lines` fail for me on Windows on **clean `origin/main`** as well as on this branch. They are pre-existing and unrelated to this change — I have not touched them.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the relevant tests and they pass (see note on two pre-existing unrelated failures above)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`--all` help text and in-code comments) — no user-facing docs reference this script
- [x] N/A — no config keys added or changed
- [x] N/A — no architecture or workflow change
- [x] Cross-platform impact considered: this is a Windows correctness fix; `_pid_exists` and `getattr(signal, ...)` are no-ops behaviourally on POSIX
