### PR TITLE
fix(desktop): prevent Inbox session row overlap (#88473)

### DIFF
--- a/apps/desktop/e2e/inbox-card-measurement.spec.ts
+++ b/apps/desktop/e2e/inbox-card-measurement.spec.ts
@@ -1,0 +1,261 @@
+/**
+ * Electron regression for stale virtual-row measurements when the session
+ * sidebar switches from compact rows to Inbox cards.
+ */
+
+import * as path from 'node:path'
+import { DatabaseSync } from 'node:sqlite'
+
+import type { Page } from '@playwright/test'
+
+import {
+  buildAppEnv,
+  createSandbox,
+  launchDesktop,
+  type MockBackendFixture,
+  waitForAppReady,
+  writeEnvFile,
+  writeMockProviderConfig
+} from './fixtures'
+import { startMockServer } from './mock-server'
+import { RealSessionBuilder } from './real-session-builder'
+import { expect, test } from './test'
+
+const SESSION_COUNT = 28
+const SESSION_PREFIX = 'E2E Inbox measurement row'
+const OVERLAP_TOLERANCE_PX = 0.5
+const RESIZE_GATE = '__hermesE2EDropResizeObservations'
+
+interface SessionRowRect {
+  bottom: number
+  height: number
+  index: number
+  session: boolean
+  text: string
+  top: number
+}
+
+interface LayoutSample {
+  maxOverlap: number
+  overlaps: Array<{ current: number; next: number; pixels: number }>
+  rows: SessionRowRect[]
+}
+
+async function setupSeededSidebar(): Promise<MockBackendFixture> {
+  const mock = await startMockServer()
+  const sandbox = createSandbox('inbox-card-measurement')
+
+  try {
+    writeMockProviderConfig(sandbox.hermesHome, mock.url)
+    writeEnvFile(sandbox.hermesHome)
+
+    const builder = await RealSessionBuilder.start(sandbox.hermesHome)
+    const sessions: string[] = []
+
+    try {
+      for (let index = 0; index < SESSION_COUNT; index += 1) {
+        const number = String(index + 1).padStart(2, '0')
+
+        const session = await builder.createSession({
+          title: `${SESSION_PREFIX} ${number}`,
+          turns: [`${SESSION_PREFIX} ${number} with enough preview text to render a complete Inbox card.`]
+        })
+
+        sessions.push(session.sessionId)
+      }
+    } finally {
+      await builder.close()
+    }
+
+    const nowSeconds = Date.now() / 1000
+    const stateDb = path.join(sandbox.hermesHome, 'state.db')
+
+    const database = new DatabaseSync(stateDb)
+
+    try {
+      const updateSession = database.prepare('UPDATE sessions SET started_at = ?, last_activity_at = ? WHERE id = ?')
+      const updateMessages = database.prepare('UPDATE messages SET timestamp = ? WHERE session_id = ?')
+
+      sessions.forEach((sessionId, index) => {
+        const ageSeconds = index < 2 ? index * 60 : 32 * 24 * 60 * 60 + (index - 2) * 60
+        const timestamp = nowSeconds - ageSeconds
+
+        updateSession.run(timestamp, timestamp, sessionId)
+        updateMessages.run(timestamp, sessionId)
+      })
+    } finally {
+      database.close()
+    }
+
+    const { app, page } = await launchDesktop(buildAppEnv(sandbox))
+    await page.addInitScript(gateName => {
+      const NativeResizeObserver = window.ResizeObserver
+
+      window.ResizeObserver = class extends NativeResizeObserver {
+        constructor(callback: ResizeObserverCallback) {
+          super((entries, observer) => {
+            if (!(window as unknown as Record<string, boolean>)[gateName]) {
+              callback(entries, observer)
+            }
+          })
+        }
+      }
+    }, RESIZE_GATE)
+    await page.reload()
+
+    return {
+      app,
+      page,
+      mock,
+      mockUrl: mock.url,
+      sandbox,
+      cleanup: async () => {
+        await app.close().catch(() => undefined)
+        await mock.close()
+        sandbox.cleanup()
+      }
+    }
+  } catch (error) {
+    await mock.close()
+    sandbox.cleanup()
+    throw error
+  }
+}
+
+async function readVisibleSessionLayout(page: Page): Promise<LayoutSample> {
+  const firstSession = page.locator('[data-slot="sidebar"] button').filter({ hasText: SESSION_PREFIX }).first()
+
+  await expect(firstSession).toBeAttached()
+
+  return firstSession.evaluate(
+    (button, { prefix, tolerance }) => {
+      const item = button.closest('[data-index]')
+      const spacer = item?.parentElement
+
+      if (!spacer) {
+        throw new Error('Could not resolve the virtual session-list spacer')
+      }
+
+      const rows = Array.from(spacer.children)
+        .filter(
+          (candidate): candidate is HTMLElement =>
+            candidate instanceof HTMLElement && candidate.hasAttribute('data-index')
+        )
+        .map(candidate => {
+          const rect = candidate.getBoundingClientRect()
+          const text = (candidate.textContent ?? '').trim().replace(/\s+/g, ' ').slice(0, 100)
+
+          return {
+            bottom: rect.bottom,
+            height: rect.height,
+            index: Number(candidate.dataset.index),
+            session: text.includes(prefix),
+            text,
+            top: rect.top
+          }
+        })
+        .sort((left, right) => left.top - right.top)
+
+      const overlaps: LayoutSample['overlaps'] = []
+
+      for (let index = 0; index < rows.length - 1; index += 1) {
+        const current = rows[index]
+        const next = rows[index + 1]
+        const pixels = current.bottom - next.top
+
+        if (pixels > tolerance) {
+          overlaps.push({ current: current.index, next: next.index, pixels })
+        }
+      }
+
+      return {
+        maxOverlap: Math.max(0, ...overlaps.map(overlap => overlap.pixels)),
+        overlaps,
+        rows
+      }
+    },
+    { prefix: SESSION_PREFIX, tolerance: OVERLAP_TOLERANCE_PX }
+  )
+}
+
+async function enableInboxStyle(page: Page): Promise<void> {
+  await page.getByRole('button', { name: 'Filters' }).click()
+  const option = page.getByRole('menuitemcheckbox', { name: 'Inbox style' })
+  await expect(option).toHaveAttribute('aria-checked', 'false')
+  await option.click()
+  await page.keyboard.press('Escape')
+}
+
+async function disableInboxStyle(page: Page): Promise<void> {
+  await page.getByRole('button', { name: 'Filters' }).click()
+  const option = page.getByRole('menuitemcheckbox', { name: 'Inbox style' })
+  await expect(option).toHaveAttribute('aria-checked', 'true')
+  await option.click()
+  await page.keyboard.press('Escape')
+}
+
+async function scrollSessionListToEnd(page: Page): Promise<void> {
+  const session = page.locator('[data-slot="sidebar"] button').filter({ hasText: SESSION_PREFIX }).first()
+
+  await session.evaluate(button => {
+    const scroller = button.closest('[data-index]')?.parentElement?.parentElement
+
+    if (!(scroller instanceof HTMLElement)) {
+      throw new Error('Could not resolve the virtual session-list scroller')
+    }
+
+    scroller.scrollTop = scroller.scrollHeight
+  })
+}
+
+test('Inbox cards keep virtualized sessions and date dividers separated', async () => {
+  test.setTimeout(240_000)
+  const fixture = await setupSeededSidebar()
+
+  try {
+    const { page } = fixture
+    await waitForAppReady(fixture, 120_000)
+
+    const compact = await readVisibleSessionLayout(page)
+    expect(compact.rows.length, 'the fixture must render enough rows to compare adjacent geometry').toBeGreaterThan(2)
+    expect(compact.overlaps).toEqual([])
+
+    await page.evaluate(gateName => {
+      ;(window as unknown as Record<string, boolean>)[gateName] = true
+    }, RESIZE_GATE)
+    await enableInboxStyle(page)
+    await expect
+      .poll(async () => (await readVisibleSessionLayout(page)).rows[0]?.height ?? 0, {
+        message: 'Inbox rows should paint at card height'
+      })
+      .toBeGreaterThan(50)
+    await page.waitForTimeout(250)
+
+    const inbox = await readVisibleSessionLayout(page)
+    expect(
+      inbox.rows.some(row => !row.session),
+      'the fixture must include an interleaved date divider'
+    ).toBe(true)
+    expect(inbox.overlaps, `Inbox rows overlap by up to ${inbox.maxOverlap.toFixed(2)}px`).toEqual([])
+
+    await scrollSessionListToEnd(page)
+    await expect(
+      page.locator('[data-slot="sidebar"] [data-slot="row-button"]').filter({ hasText: `${SESSION_PREFIX} 28` })
+    ).toBeVisible()
+
+    const bottom = await readVisibleSessionLayout(page)
+    expect(bottom.overlaps, `scrolled Inbox rows overlap by up to ${bottom.maxOverlap.toFixed(2)}px`).toEqual([])
+
+    await disableInboxStyle(page)
+    await expect
+      .poll(async () => (await readVisibleSessionLayout(page)).rows.find(row => row.session)?.height ?? Infinity, {
+        message: 'disabling Inbox style should restore compact row geometry'
+      })
+      .toBeLessThan(40)
+
+    const restored = await readVisibleSessionLayout(page)
+    expect(restored.overlaps, `restored compact rows overlap by up to ${restored.maxOverlap.toFixed(2)}px`).toEqual([])
+  } finally {
+    await fixture.cleanup()
+  }
+})

--- a/apps/desktop/src/app/chat/sidebar/virtual-session-list.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/virtual-session-list.test.tsx
@@ -110,4 +110,30 @@ describe('VirtualSessionList', () => {
     expect(scroller?.className).toContain('overflow-y-auto')
     expect(scroller?.className).not.toContain('overscroll-contain')
   })
+
+  it('remeasures cached rows when Inbox card mode changes', () => {
+    const props = {
+      activeSessionId: null,
+      onArchiveSession: noop,
+      onDeleteSession: noop,
+      onResumeSession: noop,
+      onTogglePin: noop,
+      onToggleUnread: noop,
+      pinned: false,
+      rows,
+      sortable: false
+    }
+
+    const { rerender } = render(<VirtualSessionList {...props} card={false} />)
+
+    virtualizer.measure.mockClear()
+    rerender(<VirtualSessionList {...props} card />)
+
+    expect(virtualizer.measure).toHaveBeenCalledOnce()
+
+    virtualizer.measure.mockClear()
+    rerender(<VirtualSessionList {...props} card={false} />)
+
+    expect(virtualizer.measure).toHaveBeenCalledOnce()
+  })
 })

--- a/apps/desktop/src/app/chat/sidebar/virtual-session-list.tsx
+++ b/apps/desktop/src/app/chat/sidebar/virtual-session-list.tsx
@@ -52,10 +52,10 @@ export interface VirtualSessionListProps {
   sortable: boolean
 }
 
-// Matches the card's typical rendered height (four lines when a preview
-// exists) so long card lists don't jump under the scroll thumb before
-// self-measurement catches up.
-const CARD_ROW_ESTIMATE_PX = 74
+// A full card is four lines (header, title + preview, footer). Estimate the
+// largest normal variant so a missed resize observation leaves whitespace,
+// never overlapping rows; self-measurement still tightens shorter cards.
+const CARD_ROW_ESTIMATE_PX = 92
 const DIVIDER_ESTIMATE_PX = 28
 const OVERSCAN_ROWS = 12
 
@@ -102,9 +102,9 @@ export const VirtualSessionList: FC<VirtualSessionListProps> = ({
     overscan: OVERSCAN_ROWS
   })
 
-  // Rows are measured after paint, so changing density must invalidate cached
+  // Rows are measured after paint, so changing row mode must invalidate cached
   // measurements from the previous mode before off-screen rows re-enter.
-  useEffect(() => virtualizer.measure(), [density, virtualizer])
+  useEffect(() => virtualizer.measure(), [card, density, virtualizer])
 
   const virtualItems = virtualizer.getVirtualItems()
   const totalSize = virtualizer.getTotalSize()


### PR DESCRIPTION
## What does this PR do?

Prevents Inbox-style cards in the virtualized flat Sessions list from painting over adjacent sessions and date dividers.

The compact-to-Inbox transition retained compact row measurements because the invalidation effect only watched density. If a resize observation was stale or missed, TanStack Virtual then fell back to a 74px card estimate for cards that render at about 92px.

The fix stays inside the existing virtualization contract:

- remeasure when `card` mode changes;
- use 92px as the full-card fallback estimate while normal `measureElement` calls still tighten shorter rows.

No row CSS, density behavior, scroll chaining, row identity, or Project-grouping path changes.

## Related issue

Addresses the **Inbox style + Updated/Status/Profile** case documented in #88473.

This is separate from #88499: that PR aligns comfortable/detailed non-card density heights; it does not change card-mode invalidation or the card estimate.

## Changes made

- Update `VirtualSessionList` to invalidate cached measurements when Inbox card mode toggles.
- Raise the card fallback from 74px to the measured four-line card height of 92px.
- Add unit coverage for both compact → Inbox and Inbox → compact invalidation.
- Add a real Electron regression with 28 durable sessions, an interleaved date divider, a missed resize delivery, off-screen scrolling, and both mode transitions.

## Verification

### Red / control / green

| Run | Result |
|---|---|
| Upstream target code | Electron test fails; rows overlap by up to **65.74px** |
| Causal control | Resuming resize delivery and forcing a card resize clears overlap to **0px** |
| `2e478893c` | Same Electron test passes with resize delivery still suppressed; **0px** overlap |

### Checks on exact head `2e478893c`

- `npx playwright test e2e/inbox-card-measurement.spec.ts --reporter=line` — 1 passed
- `npx vitest run --project ui src/app/chat/sidebar` — 24 files, 221 tests passed
- `npm run typecheck` — all three desktop TypeScript configs passed
- `npx eslint src/ electron/ e2e/inbox-card-measurement.spec.ts --quiet` — clean
- `npm run build` — clean packaged build; install stamp pinned to the exact SHA
- `git diff --check` — clean

Python tests were not run because this PR changes only the desktop TypeScript/Electron surface.

Tested on macOS 15.6 (Apple Silicon). The E2E uses Node's built-in SQLite API rather than a platform-specific CLI and will also run in the Linux desktop CI job.

## Screenshots

Both captures use the same 28-session Electron fixture and 520×1436 sidebar viewport.

| Before — upstream target code, 65.74px overlap | After — `2e478893c`, 0px overlap |
|---|---|
| <img width="520" alt="Before: Inbox session cards and date divider overlapping" src="https://github.com/user-attachments/assets/b90b049c-4b8d-4ded-850b-dd9ceb2b1249"> | <img width="520" alt="After: Inbox session cards and date divider separated" src="https://github.com/user-attachments/assets/84032677-686e-40d9-9726-8a12c08b7a2a"> |
