### PR TITLE
fix(desktop): resolve session projects from owning profile

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -19873,7 +19873,9 @@ def test_fallback_session_info_reports_session_cwd_not_launch_dir(monkeypatch):
     """
     monkeypatch.setattr(server, "_default_session_cwd", lambda: "/gateway/launch/dir")
     monkeypatch.setattr(server, "_git_branch_for_cwd", lambda cwd: "bb/feature")
-    monkeypatch.setattr(server, "_project_info_for_cwd", lambda cwd: None)
+    monkeypatch.setattr(
+        server, "_project_info_for_cwd", lambda cwd, profile_home=None: None
+    )
     monkeypatch.setattr(server, "_resolve_model", lambda: "test-model")
 
     info = server._fallback_session_info({"cwd": "/projects/session-own-repo"})
@@ -19890,7 +19892,9 @@ def test_fallback_session_info_always_emits_branch(monkeypatch):
     """
     monkeypatch.setattr(server, "_default_session_cwd", lambda: "/gateway/launch/dir")
     monkeypatch.setattr(server, "_git_branch_for_cwd", lambda cwd: "")
-    monkeypatch.setattr(server, "_project_info_for_cwd", lambda cwd: None)
+    monkeypatch.setattr(
+        server, "_project_info_for_cwd", lambda cwd, profile_home=None: None
+    )
     monkeypatch.setattr(server, "_resolve_model", lambda: "test-model")
 
     info = server._fallback_session_info({"cwd": "/plain/folder"})

--- a/tests/tui_gateway/test_projects_rpc.py
+++ b/tests/tui_gateway/test_projects_rpc.py
@@ -265,6 +265,48 @@ def test_session_info_carries_project_for_owned_cwd(tmp_path):
     assert info["project"]["name"] == "Proj"
 
 
+def test_session_info_uses_owning_profiles_project_registry(monkeypatch, tmp_path):
+    """A multiplexed sfb session must not borrow default's same-named project."""
+    from hermes_cli import projects_db as pdb
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    default_home = tmp_path / "default-home"
+    sfb_home = tmp_path / "sfb-home"
+    default_db = default_home / "projects.db"
+    sfb_db = sfb_home / "projects.db"
+
+    with pdb.connect_closing(default_db) as conn:
+        default_id = pdb.create_project(
+            conn,
+            name="Default SFB",
+            folders=[str(repo)],
+            primary_path=str(repo),
+        )
+    with pdb.connect_closing(sfb_db) as conn:
+        sfb_id = pdb.create_project(
+            conn,
+            name="Profile SFB",
+            folders=[str(repo)],
+            primary_path=str(repo),
+        )
+
+    monkeypatch.setattr(pdb, "projects_db_path", lambda: default_db)
+
+    info = server._session_info(
+        None,
+        {
+            "cwd": str(repo),
+            "profile_home": str(sfb_home),
+            "session_key": "sfb-session",
+        },
+    )
+
+    assert info["project"]["id"] == sfb_id
+    assert info["project"]["id"] != default_id
+    assert info["project"]["name"] == "Profile SFB"
+
+
 def test_update_and_archive(tmp_path):
     pid = _call("projects.create", {"name": "Orig", "folders": [str(tmp_path)]})["project"]["id"]
 

--- a/tests/tui_gateway/test_projects_rpc.py
+++ b/tests/tui_gateway/test_projects_rpc.py
@@ -307,6 +307,100 @@ def test_session_info_uses_owning_profiles_project_registry(monkeypatch, tmp_pat
     assert info["project"]["name"] == "Profile SFB"
 
 
+def _conflicting_profile_projects(monkeypatch, tmp_path):
+    """Create launch/coder projects that claim the same working directory."""
+    launch_home = _profile_dir(tmp_path, "launch")
+    coder_home = _profile_dir(tmp_path, "coder")
+    shared = tmp_path / "shared-worktree"
+    shared.mkdir()
+    _bind_profiles(monkeypatch, tmp_path, {"default": launch_home, "coder": coder_home})
+    _create_project(launch_home, "Launch Project", shared, use=True)
+    _create_project(coder_home, "Coder Project", shared, use=True)
+    return launch_home, coder_home, shared
+
+
+def _register_lazy_profile_session(session_id, session_key, profile_home, cwd):
+    server._sessions[session_id] = {
+        "agent": None,
+        "cwd": str(cwd),
+        "history": [],
+        "profile_home": str(profile_home),
+        "running": False,
+        "session_key": session_key,
+    }
+
+
+def test_session_create_reports_project_from_requested_profile(monkeypatch, tmp_path):
+    """Immediate lazy metadata must not borrow the launch profile's project."""
+    launch_home, _coder_home, shared = _conflicting_profile_projects(monkeypatch, tmp_path)
+    monkeypatch.setattr(server, "_enable_gateway_prompts", lambda: None)
+    monkeypatch.setattr(server, "_schedule_agent_build", lambda *_a, **_k: None)
+    monkeypatch.setattr(server, "_schedule_session_cap_enforcement", lambda: None)
+
+    with _serving_launch_profile(launch_home):
+        created = _call(
+            "session.create",
+            {"cwd": str(shared), "profile": "coder", "source": "desktop"},
+        )
+
+    try:
+        assert created["info"]["project"]["name"] == "Coder Project"
+    finally:
+        server._sessions.pop(created["session_id"], None)
+
+
+def test_session_cwd_set_reports_project_from_session_profile(monkeypatch, tmp_path):
+    """A lazy profile session's cwd update must use its own project registry."""
+    launch_home, coder_home, shared = _conflicting_profile_projects(monkeypatch, tmp_path)
+    session_id, session_key = "cwd-profile-runtime", "cwd-profile-stored"
+    _create_session(coder_home, session_key, shared)
+    _register_lazy_profile_session(session_id, session_key, coder_home, shared)
+
+    try:
+        with _serving_launch_profile(launch_home):
+            info = _call("session.cwd.set", {"session_id": session_id, "cwd": str(shared)})
+        assert info["project"]["name"] == "Coder Project"
+    finally:
+        server._sessions.pop(session_id, None)
+
+
+def test_session_workspace_move_emits_project_from_session_profile(monkeypatch, tmp_path):
+    """A live profile session's move event must describe its owning project."""
+    launch_home, coder_home, shared = _conflicting_profile_projects(monkeypatch, tmp_path)
+    session_id, session_key = "move-profile-runtime", "move-profile-stored"
+    _create_session(coder_home, session_key, shared)
+    _register_lazy_profile_session(session_id, session_key, coder_home, shared)
+    emitted = []
+    monkeypatch.setattr(server, "_emit", lambda *args: emitted.append(args))
+
+    try:
+        with _serving_launch_profile(launch_home):
+            _call(
+                "session.workspace.move",
+                {"cwd": str(shared), "profile": "coder", "session_key": session_key},
+            )
+        info = next(args[2] for args in emitted if args[:2] == ("session.info", session_id))
+        assert info["project"]["name"] == "Coder Project"
+    finally:
+        server._sessions.pop(session_id, None)
+
+
+def test_session_status_reports_project_from_session_profile(monkeypatch, tmp_path):
+    """Status output must not name a same-path project from the launch profile."""
+    launch_home, coder_home, shared = _conflicting_profile_projects(monkeypatch, tmp_path)
+    session_id, session_key = "status-profile-runtime", "status-profile-stored"
+    _create_session(coder_home, session_key, shared)
+    _register_lazy_profile_session(session_id, session_key, coder_home, shared)
+
+    try:
+        with _serving_launch_profile(launch_home):
+            status = _call("session.status", {"session_id": session_id})
+        assert "Project: Coder Project" in status["output"]
+        assert "Project: Launch Project" not in status["output"]
+    finally:
+        server._sessions.pop(session_id, None)
+
+
 def test_update_and_archive(tmp_path):
     pid = _call("projects.create", {"name": "Orig", "folders": [str(tmp_path)]})["project"]["id"]
 

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -153,7 +153,9 @@ def _(rid, params: dict) -> dict:
                 "skills": {},
                 "cwd": _sessions[sid]["cwd"],
                 "branch": _git_branch_for_cwd(_sessions[sid]["cwd"]),
-                "project": _project_info_for_cwd(_sessions[sid]["cwd"]),
+                "project": _project_info_for_cwd(
+                    _sessions[sid]["cwd"], profile_home
+                ),
                 "lazy": True,
                 "desktop_contract": DESKTOP_BACKEND_CONTRACT,
                 "profile_name": _response_profile_name(profile),
@@ -1098,7 +1100,7 @@ def _(rid, params: dict) -> dict:
     info = _session_info(agent, session) if agent is not None else {
         "cwd": cwd,
         "branch": _git_branch_for_cwd(cwd),
-        "project": _project_info_for_cwd(cwd),
+        "project": _project_info_for_cwd(cwd, session.get("profile_home")),
         "lazy": True,
     }
     _emit("session.info", params.get("session_id", ""), info)
@@ -1172,7 +1174,9 @@ def _(rid, params: dict) -> dict:
         info = _session_info(agent, live) if agent is not None else {
             "cwd": resolved,
             "branch": branch,
-            "project": _project_info_for_cwd(resolved),
+            "project": _project_info_for_cwd(
+                resolved, live.get("profile_home")
+            ),
             "lazy": True,
         }
         _emit("session.info", live_sid, info)
@@ -2751,7 +2755,9 @@ def _(rid, params: dict) -> dict:
     usage = _session_usage_snapshot(session)
     provider = getattr(agent, "provider", None) or mirror.get("provider") or "unknown"
     model = getattr(agent, "model", None) or mirror.get("model") or "(unknown)"
-    project = _project_info_for_cwd(_display_session_cwd(session))
+    project = _project_info_for_cwd(
+        _display_session_cwd(session), session.get("profile_home")
+    )
     lines = [
         "Hermes TUI Status",
         "",

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -7259,7 +7259,10 @@ def _session_usage_snapshot(session: dict | None) -> dict:
     return dict(mirror_usage) if isinstance(mirror_usage, dict) else {}
 
 
-def _project_info_for_cwd(cwd: str) -> dict | None:
+def _project_info_for_cwd(
+    cwd: str,
+    profile_home: str | os.PathLike[str] | None = None,
+) -> dict | None:
     """Return the first-class Project owning ``cwd`` for UI status surfaces.
 
     Backed by the per-profile projects.db (the same store the desktop's project
@@ -7273,7 +7276,12 @@ def _project_info_for_cwd(cwd: str) -> dict | None:
     try:
         from hermes_cli import projects_db as pdb
 
-        with pdb.connect_closing() as conn:
+        # A multiplexed desktop backend serves sessions from several profile
+        # homes in one process. get_hermes_home() still names the launch
+        # profile outside a profile-scoped RPC, so ambient lookup can assign a
+        # secondary-profile session to a same-named default-profile project.
+        db_path = Path(profile_home) / "projects.db" if profile_home else None
+        with pdb.connect_closing(db_path=db_path) as conn:
             project = pdb.project_for_path(conn, cwd)
         if project is None:
             return None
@@ -7362,7 +7370,7 @@ def _session_info(agent, session: dict | None = None) -> dict:
         "skills": dict(mirror.get("skills") or {}) if isinstance(mirror.get("skills"), dict) else {},
         "cwd": cwd,
         "branch": _git_branch_for_cwd(cwd),
-        "project": _project_info_for_cwd(cwd),
+        "project": _project_info_for_cwd(cwd, (session or {}).get("profile_home")),
         "terminal_backend": _effective_terminal_backend(),
         "personality": str(personality or ""),
         "running": bool((session or {}).get("running")),
@@ -8095,7 +8103,7 @@ def _apply_project_workspace(task_id: str, path: str, _name: str = "") -> None:
             else {
                 "cwd": resolved,
                 "branch": _git_branch_for_cwd(resolved),
-                "project": _project_info_for_cwd(resolved),
+                "project": _project_info_for_cwd(resolved, session.get("profile_home")),
                 "lazy": True,
             }
         )
@@ -10217,7 +10225,7 @@ def _lazy_resume_info(
     info = {
         "cwd": cwd,
         "branch": _git_branch_for_cwd(cwd),
-        "project": _project_info_for_cwd(cwd),
+        "project": _project_info_for_cwd(cwd, _profile_home(profile)),
         "model": model or _resolve_model(),
         "tools": {},
         "skills": {},
@@ -10552,7 +10560,7 @@ def _fallback_session_info(session: dict) -> dict:
     return {
         "cwd": cwd,
         "branch": _git_branch_for_cwd(cwd),
-        "project": _project_info_for_cwd(cwd),
+        "project": _project_info_for_cwd(cwd, session.get("profile_home")),
         "lazy": True,
         "model": _resolve_model(),
         "skills": {},


### PR DESCRIPTION
## Summary

Resolve Desktop session project metadata from the session's owning profile rather than the backend process's launch profile.

A multiplexed Desktop backend can serve sessions from several profile homes, each with its own `projects.db`. Outside a profile-scoped RPC, ambient project lookup still points at the launch profile. That allowed a secondary-profile session to inherit a same-path project from the wrong profile.

## Root cause

`_project_info_for_cwd()` always opened the ambient `projects.db`, even when the session already carried its owning `profile_home`.

## Fix

- Let `_project_info_for_cwd()` accept an optional profile home.
- Open `<profile_home>/projects.db` when ownership is known.
- Thread session ownership through live, lazy-resume, fallback, workspace-update, immediate-create, cwd-set, workspace-move, and status metadata paths.
- Preserve existing ambient behavior for profile-less/single-profile callers.

## Regression coverage

The tests create conflicting default-profile and secondary-profile project registries for the same working directory, then verify the owning project through:

- `session.info`
- immediate `session.create` metadata
- lazy `session.cwd.set`
- live `session.workspace.move` event metadata
- `session.status` output

## Verification

- `scripts/run_tests.sh tests/tui_gateway/test_projects_rpc.py tests/tui_gateway/test_session_profile_db.py -q` — **44 passed**
- Existing fallback project-info compatibility tests — **2 passed**
- Ruff, diff check, and added-line security scan — passed
- `git diff --check origin/main...HEAD` — passed
- Initial independent review caught four modular handler call sites omitted from the first patch; all four were reproduced RED through public RPCs and are GREEN in follow-up `2018a760e`
- A filesystem-aware re-review confirmed all eight live call sites, then caught two stale one-argument test stubs; compatibility is restored in `92c90c5bc`
- Independent filesystem-aware final-head review of `92c90c5bc` — **PASS, no blockers**

## Scope

This changes display/project metadata lookup only. It does not mutate conversation history, toolsets, prompts, or profile configuration.
