### PR TITLE
fix(desktop): resolve v2 registry SSH terminals from the bootstrap pool key

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -391,7 +391,11 @@ import {
 import { fetchMarketplaceThemes, searchMarketplaceThemes } from './vscode-marketplace'
 import { createWakeIndicatorWindowController } from './wake-indicator-window'
 import { enumerateWindowsFrontToBack, enumerationFailed, readWindowBelow } from './window-below'
-import { registrySshScopeForWindowRoute, WindowConnectionRouteRegistry } from './window-connection-route'
+import {
+  registrySshPoolScopeByConnectionId,
+  registrySshScopeForWindowRoute,
+  WindowConnectionRouteRegistry
+} from './window-connection-route'
 import { installWindowRendererLifecycle } from './window-renderer-lifecycle'
 import { createWindowRevealController } from './window-reveal'
 import {
@@ -9927,7 +9931,18 @@ function activeSshTerminalTarget(webContentsId?: number) {
 
     const state = sshConnections.get(scope)
 
-    return state && state.ssh ? { ssh: state.ssh, scope } : 'pending'
+    if (state && state.ssh) {
+      return { ssh: state.ssh, scope }
+    }
+
+    // The pool's single writer publishes under the per-profile bootstrap key
+    // while stamping the entry with its registry connection id (#97345), so a
+    // composite-key miss must still resolve the live tunnel by that identity
+    // instead of reporting 'pending' forever.
+    const pooledScope = registrySshPoolScopeByConnectionId(sshConnections, windowRoute.connectionId)
+    const pooledState = pooledScope === null ? null : sshConnections.get(pooledScope)
+
+    return pooledState && pooledState.ssh ? { ssh: pooledState.ssh, scope: pooledScope } : 'pending'
   }
 
   const profile = windowRoute?.profile ?? primaryProfileKey()

--- a/apps/desktop/electron/window-connection-route.test.ts
+++ b/apps/desktop/electron/window-connection-route.test.ts
@@ -4,6 +4,7 @@ import { test } from 'vitest'
 
 import {
   normalizeWindowConnectionRoute,
+  registrySshPoolScopeByConnectionId,
   registrySshScopeForWindowRoute,
   WindowConnectionRouteRegistry
 } from './window-connection-route'
@@ -119,4 +120,21 @@ test('uses the canonical default profile scope when a registry SSH route has no 
     ),
     'conn:source-b::default'
   )
+})
+
+test('recovers the bootstrap pool key a registry SSH tunnel was published under', () => {
+  const pool = new Map<string, any>([['', { registryConnectionId: 'source-b', ssh: { alive: true } }]])
+
+  assert.equal(registrySshPoolScopeByConnectionId(pool, 'source-b'), '')
+})
+
+test('does not match another connection, an unlabelled entry, or a torn-down tunnel', () => {
+  const pool = new Map<string, any>([
+    ['research', { registryConnectionId: 'source-a', ssh: { alive: true } }],
+    ['', { registryConnectionId: '', ssh: { alive: true } }],
+    ['worker', { registryConnectionId: 'source-b' }]
+  ])
+
+  assert.equal(registrySshPoolScopeByConnectionId(pool, 'source-b'), null)
+  assert.equal(registrySshPoolScopeByConnectionId(pool, 'source-c'), null)
 })

--- a/apps/desktop/electron/window-connection-route.ts
+++ b/apps/desktop/electron/window-connection-route.ts
@@ -40,6 +40,30 @@ export function registrySshScopeForWindowRoute(
   return backendScopeKey(route.connectionId, route.profile)
 }
 
+export interface RegistrySshPoolEntry {
+  registryConnectionId?: null | string
+  ssh?: unknown
+}
+
+// The sshConnections pool has a single writer that publishes every tunnel under
+// its per-profile bootstrap key while stamping the entry with the registry
+// connection that owns it. A registry-scoped lookup under the composite
+// backendScopeKey can therefore miss a live tunnel; this recovers the writer's
+// actual key from the stamped identity, the same match managedSshScopeRole
+// applies to pool entries.
+export function registrySshPoolScopeByConnectionId(
+  entries: Iterable<readonly [string, RegistrySshPoolEntry | undefined]>,
+  connectionId: string
+): null | string {
+  for (const [scope, entry] of entries) {
+    if (entry?.ssh && entry.registryConnectionId === connectionId) {
+      return scope
+    }
+  }
+
+  return null
+}
+
 export class WindowConnectionRouteRegistry {
   private readonly routes = new Map<number, WindowConnectionRoute>()
 


### PR DESCRIPTION
## What does this PR do?

After #95081, a v2 registry SSH connection's terminal pane fails instantly with `Remote connection is not ready yet. Try again in a moment.` on every tab and relaunch (#97345).

Root cause: `activeSshTerminalTarget()`'s registry-scoped branch looks the tunnel up under `backendScopeKey(connectionId, profile)`, but the pool's single writer (`bootstrapSshConnectionInner`) publishes every tunnel under its per-profile bootstrap key (`sshScopeKey(profile)`), stamping the entry with `registryConnectionId` instead. The composite lookup can never hit, so the pane is permanently `'pending'`.

This PR makes the registry-scoped branch fall back to the entry the writer stamped with the window's connection id, returning the writer's actual scope. It is the same identity match `managedSshScopeRole` already applies to pool entries (`state.registryConnectionId === connectionId`), and it mirrors the reader-aligns-with-writer direction PR #95473 takes for the v1 branch — the two branches are disjoint (the registry-scoped branch returns before the v1 path is reached), so this does not overlap with #95473.

Deliberately not done here: the structural writer-side option from the issue (publishing registry tunnels under the composite key, which is what would make #95081's multi-connection goal fully hold). That changes the key every per-profile reader, teardown path, and the managed-update drain would see, so it needs a broader consumer audit than this reader-side fix. The fallback below fixes the single-primary-connection regression (#97345's reported setup) without touching pool semantics: with multiple registry connections under one profile the pool still holds one entry, and a mismatched id still reports `'pending'` rather than borrowing another connection's tunnel.

## Related Issue

Fixes #97345

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/electron/window-connection-route.ts`: new `registrySshPoolScopeByConnectionId()` — scans pool entries for the one stamped with the given registry connection id and carrying a live `ssh`, returning the writer's actual scope key.
- `apps/desktop/electron/main.ts`: `activeSshTerminalTarget()`'s registry-scoped branch keeps the composite-key lookup first; on a miss it resolves via `registrySshPoolScopeByConnectionId()` and returns the bootstrap scope so downstream `getSshConnectionState(sshTarget.scope)`, preview-reach scoping, and `sshScope` teardown bookkeeping all hit the real entry.
- `apps/desktop/electron/window-connection-route.test.ts`: tests for the recovery (bootstrap key recovered for a stamped entry) and the negatives (other connection id, unlabelled legacy entry, torn-down entry without `ssh` all stay unmatched).

## How to Test

1. `cd apps/desktop && ../../node_modules/.bin/vitest run electron/window-connection-route.test.ts` — Observed result: 9/9 pass, including the two new tests.
2. `../../node_modules/.bin/tsc -p tsconfig.electron.json --noEmit` — Observed result: passes.
3. `../../node_modules/.bin/vitest run electron/desktop-remote-route.test.ts` — Observed result: 21/21 pass (adjacent #95473 domain unaffected).
4. On a v2 registry `connections.json` (`version: 2`, primary ssh connection, `launchMode: "primary"`) desktop build, opening the terminal pane should start a remote PTY instead of failing with "Remote connection is not ready yet" (per #97345's repro steps). I could not run the full Windows-client → Linux-remote setup locally, so the behavior change is pinned by the unit tests on the scope-resolution logic.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(desktop): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (#95473 fixes the v1 branch only; its description explicitly leaves the registry-scoped branch unchanged)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — N/A for this Electron/desktop-only change; ran `vitest run` on the touched project plus `tsc -p tsconfig.electron.json --noEmit` instead (both pass)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64); the reported setup is Windows 11 → Linux SSH — the scope-resolution logic is platform-independent and covered by unit tests

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure key-resolution logic in the Electron main process, no platform APIs touched
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
