### PR TITLE
fix(desktop): route project session branches by owner

### DIFF
--- a/apps/desktop/e2e/session-branch.spec.ts
+++ b/apps/desktop/e2e/session-branch.spec.ts
@@ -1,0 +1,75 @@
+import {
+  buildAppEnv,
+  createSandbox,
+  launchDesktop,
+  type MockBackendFixture,
+  waitForAppReady,
+  writeEnvFile,
+  writeMockProviderConfig
+} from './fixtures'
+import { startMockServer } from './mock-server'
+import { RealSessionBuilder } from './real-session-builder'
+import { expect, test } from './test'
+
+const SESSION_LABEL = 'E2E persisted conversation branch parent'
+
+async function setupSeededBackend(): Promise<MockBackendFixture> {
+  const mock = await startMockServer()
+  const sandbox = createSandbox('session-branch')
+
+  writeMockProviderConfig(sandbox.hermesHome, mock.url)
+  writeEnvFile(sandbox.hermesHome)
+
+  const builder = await RealSessionBuilder.start(sandbox.hermesHome)
+
+  try {
+    await builder.createSession({ title: SESSION_LABEL, turns: [SESSION_LABEL] })
+  } finally {
+    await builder.close()
+  }
+
+  const { app, page } = await launchDesktop(buildAppEnv(sandbox))
+
+  return {
+    app,
+    page,
+    mock,
+    mockUrl: mock.url,
+    sandbox,
+    cleanup: async () => {
+      await app.close()
+      await mock.close()
+      sandbox.cleanup()
+    }
+  }
+}
+
+test.describe('persisted session branching', () => {
+  let fixture: MockBackendFixture
+
+  test.beforeAll(async () => {
+    fixture = await setupSeededBackend()
+    await waitForAppReady(fixture, 120_000)
+  })
+
+  test.afterAll(async () => {
+    await fixture?.cleanup()
+  })
+
+  test('branches from the visible session-row action and renders the nested child', async () => {
+    const parentLabel = fixture.page.getByText(SESSION_LABEL, { exact: true }).first()
+
+    await expect(parentLabel).toBeVisible({ timeout: 30_000 })
+
+    const parentRow = parentLabel.locator('xpath=ancestor::div[contains(@class, "row-hover")]').first()
+
+    await parentRow.hover()
+    await parentRow.getByRole('button', { name: 'Session actions' }).click()
+    await fixture.page.getByRole('menuitem', { name: 'Branch', exact: true }).click()
+
+    const childLabel = fixture.page.getByText(/draft: branch #\d+/i).first()
+
+    await expect(childLabel).toBeVisible({ timeout: 30_000 })
+    await expect(parentLabel).toBeVisible()
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -299,7 +299,7 @@ interface ChatSidebarProps extends React.ComponentProps<typeof Sidebar> {
   onResumeSession: (sessionId: string, session?: SessionInfo) => void
   onDeleteSession: (sessionId: string) => void
   onArchiveSession: (sessionId: string) => void
-  onBranchSession: (sessionId: string) => void
+  onBranchSession: (sessionId: string, profile?: string) => void
   onNewSessionInWorkspace: (path: null | string) => void
   /** Create a brand-new session and open it as a tile on `dir`. */
   onNewSessionSplit: (dir: SplitDir) => void

--- a/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.test.ts
@@ -42,6 +42,7 @@ const row = (over: Partial<SessionInfo>): SessionInfo =>
 function renderTile(
   requestGateway: ReturnType<typeof vi.fn>,
   refs?: {
+    branchStoredSession?: (storedSessionId: string, sessionProfile?: null | string) => Promise<unknown>
     runtimeIdByStoredSessionIdRef?: { current: Map<string, string> }
     sessionStateByRuntimeIdRef?: { current: Map<string, unknown> }
     updateSessionState?: ReturnType<typeof vi.fn>
@@ -50,7 +51,7 @@ function renderTile(
   renderHook(() =>
     useSessionTileDelegate({
       archiveSession: vi.fn(async () => undefined),
-      branchStoredSession: vi.fn(async () => undefined),
+      branchStoredSession: refs?.branchStoredSession ?? vi.fn(async () => undefined),
       executeSlashCommand: vi.fn(async () => undefined) as never,
       removeSession: vi.fn(async () => undefined),
       requestGateway: requestGateway as never,
@@ -69,6 +70,16 @@ describe('useSessionTileDelegate resumeTile', () => {
 
   afterEach(() => {
     setSessions([])
+  })
+
+  it('carries the owning profile into a session-tile branch', async () => {
+    setSessions([row({ id: 'stored-branch', profile: 'sfb' })])
+    const branchStoredSession = vi.fn(async () => true)
+
+    renderTile(vi.fn(async () => ({}) as never), { branchStoredSession })
+    await sessionTileDelegate()!.branchSession('stored-branch')
+
+    expect(branchStoredSession).toHaveBeenCalledWith('stored-branch', 'sfb')
   })
 
   it('carries the owning profile into a cold tile resume so it cannot fork profiles', async () => {

--- a/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.ts
@@ -50,7 +50,7 @@ function mergeTileTranscript(
 
 interface SessionTileDelegateParams {
   archiveSession: (storedSessionId: string) => Promise<unknown>
-  branchStoredSession: (storedSessionId: string) => Promise<unknown>
+  branchStoredSession: (storedSessionId: string, sessionProfile?: null | string) => Promise<unknown>
   executeSlashCommand: ReturnType<typeof usePromptActions>['executeSlashCommand']
   removeSession: (storedSessionId: string) => Promise<unknown>
   requestGateway: GatewayRequester
@@ -134,7 +134,10 @@ export function useSessionTileDelegate({
         await archiveSession(storedSessionId)
       },
       branchSession: async storedSessionId => {
-        await branchStoredSession(storedSessionId)
+        const owner = await ownerForStoredSession(storedSessionId)
+        const profile = typeof owner === 'string' ? owner : owner?.profile
+
+        await branchStoredSession(storedSessionId, profile)
       },
       deleteSession: async storedSessionId => {
         await removeSession(storedSessionId)

--- a/apps/desktop/src/app/contrib/wiring-routing.test.ts
+++ b/apps/desktop/src/app/contrib/wiring-routing.test.ts
@@ -1,6 +1,21 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
-import { findStoredIdForRuntimeId, resolveRoutingSessionId, resolveSessionRpcOwner } from './wiring-routing'
+import {
+  branchSessionForOwner,
+  findStoredIdForRuntimeId,
+  resolveRoutingSessionId,
+  resolveSessionRpcOwner
+} from './wiring-routing'
+
+describe('branchSessionForOwner', () => {
+  it('forwards the project-tree row profile to the stored-session branch action', async () => {
+    const branchStoredSession = vi.fn(async () => true)
+
+    await expect(branchSessionForOwner(branchStoredSession, 'stored-sfb', 'sfb')).resolves.toBe(true)
+
+    expect(branchStoredSession).toHaveBeenCalledWith('stored-sfb', 'sfb')
+  })
+})
 
 describe('findStoredIdForRuntimeId', () => {
   it('reverse-resolves a runtime id to its stored id', () => {

--- a/apps/desktop/src/app/contrib/wiring-routing.ts
+++ b/apps/desktop/src/app/contrib/wiring-routing.ts
@@ -7,6 +7,14 @@
 
 import type { SessionOwnerRoute } from '@/store/session-request-router'
 
+export function branchSessionForOwner(
+  branchStoredSession: (storedSessionId: string, sessionProfile?: null | string) => Promise<boolean>,
+  storedSessionId: string,
+  sessionProfile?: null | string
+): Promise<boolean> {
+  return branchStoredSession(storedSessionId, sessionProfile)
+}
+
 /**
  * Resolve a runtime session id back to its stored id by reverse-scanning the
  * stored->runtime binding map — the same ladder use-session-tile-delegate's

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -152,6 +152,7 @@ import { $restartPreviewServer, useTitlebarToolContributions } from './panes'
 import { createSessionRpcDispatcher } from './session-rpc-dispatcher'
 import { ChatRoutesSurface, SidebarSurface, StatusbarSurface, TerminalSurface } from './surfaces'
 import type { WiringActions, WiringApi } from './types'
+import { branchSessionForOwner } from './wiring-routing'
 
 // Overlay views the controller mounts over the shell — lazy, load on demand.
 // The workspace-route full-page views (skills/messaging/artifacts) are the
@@ -964,7 +965,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     onAttachImageBlob: composer.attachImageBlob,
     onAttachPrCommentUrl: composer.attachPrCommentUrl,
     onBranchInNewChat: messageId => void branchInNewChat(messageId),
-    onBranchSession: sessionId => void branchStoredSession(sessionId),
+    onBranchSession: (sessionId, profile) => void branchSessionForOwner(branchStoredSession, sessionId, profile),
     onCancel: cancelRun,
     onDeleteSelectedSession: () => {
       const id = $selectedStoredSessionId.get()

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -1557,6 +1557,7 @@ describe('branchStoredSession desktop source tagging', () => {
   afterEach(() => {
     cleanup()
     setSessions([])
+    $projectTree.set([])
     $sessionTiles.set([])
     setSelectedStoredSessionId(null)
     vi.restoreAllMocks()
@@ -1901,6 +1902,141 @@ describe('branchStoredSession desktop source tagging', () => {
 
     expect(ensureGatewayProfile).toHaveBeenCalledWith('work')
     expect(createParams).toMatchObject({ profile: 'work' })
+  })
+
+  it('resolves the parent workspace when its profile was forwarded but the row is not cached', async () => {
+    setSessions([])
+    vi.mocked(getSession).mockResolvedValue(
+      storedSession({ cwd: '/repo/worktree', id: 'stored-parent', message_count: 1, profile: 'work' })
+    )
+    vi.mocked(getAllSessionMessages).mockResolvedValue({
+      messages: [{ content: 'branch me', role: 'user', timestamp: 1 }],
+      session_id: 'stored-parent'
+    } as never)
+
+    let createParams: Record<string, unknown> | undefined
+
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      if (method === 'session.create') {
+        createParams = params
+
+        return { session_id: 'branch-runtime', stored_session_id: 'branch-stored' } as never
+      }
+
+      return {} as never
+    })
+
+    let branchStoredSession: ((storedSessionId: string, profile?: string) => Promise<boolean>) | null = null
+
+    render(<BranchHarness onReady={branch => (branchStoredSession = branch)} requestGateway={requestGateway} />)
+    await waitFor(() => expect(branchStoredSession).not.toBeNull())
+
+    await expect(branchStoredSession!('stored-parent', 'work')).resolves.toBe(true)
+
+    expect(getSession).toHaveBeenCalled()
+    expect(createParams).toMatchObject({
+      cwd: '/repo/worktree',
+      parent_session_id: 'stored-parent',
+      profile: 'work'
+    })
+  })
+
+  it('creates a branch on the owning profile when the parent exists only in the project tree', async () => {
+    setSessions([])
+    $projectTree.set([
+      {
+        id: 'p_work',
+        label: 'Work',
+        path: '/repo/work',
+        repos: [
+          {
+            groups: [
+              {
+                id: '/repo/work::branch::main',
+                label: 'main',
+                path: '/repo/work',
+                sessionCount: 1,
+                sessions: [storedSession({ id: 'stored-parent', message_count: 1, profile: 'work' })]
+              }
+            ],
+            id: '/repo/work',
+            label: 'work',
+            path: '/repo/work',
+            sessionCount: 1
+          }
+        ],
+        sessionCount: 1
+      } as never
+    ])
+    vi.mocked(getSession).mockRejectedValue(new Error('the project-tree row is the only owner source'))
+    vi.mocked(getAllSessionMessages).mockResolvedValue({
+      messages: [{ content: 'branch me', role: 'user', timestamp: 1 }],
+      session_id: 'stored-parent'
+    } as never)
+
+    let createParams: Record<string, unknown> | undefined
+
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      if (method === 'session.create') {
+        createParams = params
+
+        return { session_id: 'branch-runtime', stored_session_id: 'branch-stored' } as never
+      }
+
+      return {} as never
+    })
+
+    let branchStoredSession: ((storedSessionId: string) => Promise<boolean>) | null = null
+
+    render(<BranchHarness onReady={branch => (branchStoredSession = branch)} requestGateway={requestGateway} />)
+    await waitFor(() => expect(branchStoredSession).not.toBeNull())
+
+    await expect(branchStoredSession!('stored-parent')).resolves.toBe(true)
+
+    expect(ensureGatewayProfile).toHaveBeenCalledWith('work')
+    expect(getAllSessionMessages).toHaveBeenCalledWith('stored-parent', 'work')
+    expect(createParams).toMatchObject({ parent_session_id: 'stored-parent', profile: 'work' })
+  })
+
+  it('prefers an owned project-tree row over an ownerless duplicate in recents', async () => {
+    setSessions([storedSession({ id: 'stored-parent', message_count: 1, profile: undefined })])
+    $projectTree.set([
+      {
+        id: 'p_work',
+        label: 'Work',
+        path: '/repo/work',
+        previewSessions: [storedSession({ id: 'stored-parent', message_count: 1, profile: 'work' })],
+        repos: [],
+        sessionCount: 1
+      } as never
+    ])
+    vi.mocked(getAllSessionMessages).mockResolvedValue({
+      messages: [{ content: 'branch me', role: 'user', timestamp: 1 }],
+      session_id: 'stored-parent'
+    } as never)
+
+    let createParams: Record<string, unknown> | undefined
+
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      if (method === 'session.create') {
+        createParams = params
+
+        return { session_id: 'branch-runtime', stored_session_id: 'branch-stored' } as never
+      }
+
+      return {} as never
+    })
+
+    let branchStoredSession: ((storedSessionId: string) => Promise<boolean>) | null = null
+
+    render(<BranchHarness onReady={branch => (branchStoredSession = branch)} requestGateway={requestGateway} />)
+    await waitFor(() => expect(branchStoredSession).not.toBeNull())
+
+    await expect(branchStoredSession!('stored-parent')).resolves.toBe(true)
+
+    expect(ensureGatewayProfile).toHaveBeenCalledWith('work')
+    expect(getAllSessionMessages).toHaveBeenCalledWith('stored-parent', 'work')
+    expect(createParams).toMatchObject({ parent_session_id: 'stored-parent', profile: 'work' })
   })
 
   it('omits profile for a profile-less parent so single-profile users are unchanged', async () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -2039,6 +2039,64 @@ describe('branchStoredSession desktop source tagging', () => {
     expect(createParams).toMatchObject({ parent_session_id: 'stored-parent', profile: 'work' })
   })
 
+  it('uses metadata from the explicitly forwarded owner when two profiles share a session id', async () => {
+    setSessions([
+      storedSession({
+        cwd: '/repo/default-worktree',
+        id: 'stored-parent',
+        message_count: 1,
+        profile: 'default'
+      })
+    ])
+    $projectTree.set([
+      {
+        id: 'p_work',
+        label: 'Work',
+        path: '/repo/work-worktree',
+        previewSessions: [
+          storedSession({
+            cwd: '/repo/work-worktree',
+            id: 'stored-parent',
+            message_count: 1,
+            profile: 'work'
+          })
+        ],
+        repos: [],
+        sessionCount: 1
+      } as never
+    ])
+    vi.mocked(getAllSessionMessages).mockResolvedValue({
+      messages: [{ content: 'branch me', role: 'user', timestamp: 1 }],
+      session_id: 'stored-parent'
+    } as never)
+
+    let createParams: Record<string, unknown> | undefined
+
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      if (method === 'session.create') {
+        createParams = params
+
+        return { session_id: 'branch-runtime', stored_session_id: 'branch-stored' } as never
+      }
+
+      return {} as never
+    })
+
+    let branchStoredSession: ((storedSessionId: string, profile?: string) => Promise<boolean>) | null = null
+
+    render(<BranchHarness onReady={branch => (branchStoredSession = branch)} requestGateway={requestGateway} />)
+    await waitFor(() => expect(branchStoredSession).not.toBeNull())
+
+    await expect(branchStoredSession!('stored-parent', 'work')).resolves.toBe(true)
+
+    expect(getAllSessionMessages).toHaveBeenCalledWith('stored-parent', 'work')
+    expect(createParams).toMatchObject({
+      cwd: '/repo/work-worktree',
+      parent_session_id: 'stored-parent',
+      profile: 'work'
+    })
+  })
+
   it('omits profile for a profile-less parent so single-profile users are unchanged', async () => {
     setSessions([storedSession({ id: 'stored-parent', message_count: 1 })])
     vi.mocked(getAllSessionMessages).mockResolvedValue({

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -2097,6 +2097,45 @@ describe('branchStoredSession desktop source tagging', () => {
     })
   })
 
+  it('keeps cached parent metadata when the explicit profile is the launch profile', async () => {
+    // Launch/default rows are stamped `profile="default"` by the fix's
+    // stamp_profile, so an ownerless cached copy must not lose cwd/parent when
+    // the explicit profile IS the launch profile and the by-id getSession miss
+    // (this is the fail-closed path: explicit != active would keep undefined,
+    // but "default" is the very profile we are already on).
+    setSessions([storedSession({ cwd: '/repo/default-worktree', id: 'stored-parent', message_count: 1 })])
+    vi.mocked(getSession).mockRejectedValueOnce(new Error('404: Session not found'))
+    vi.mocked(getAllSessionMessages).mockResolvedValue({
+      messages: [{ content: 'branch me', role: 'user', timestamp: 1 }],
+      session_id: 'stored-parent'
+    } as never)
+
+    let createParams: Record<string, unknown> | undefined
+
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      if (method === 'session.create') {
+        createParams = params
+
+        return { session_id: 'branch-runtime', stored_session_id: 'branch-stored' } as never
+      }
+
+      return {} as never
+    })
+
+    let branchStoredSession: ((storedSessionId: string, profile?: string) => Promise<boolean>) | null = null
+
+    render(<BranchHarness onReady={branch => (branchStoredSession = branch)} requestGateway={requestGateway} />)
+    await waitFor(() => expect(branchStoredSession).not.toBeNull())
+
+    await expect(branchStoredSession!('stored-parent', 'default')).resolves.toBe(true)
+
+    expect(createParams).toMatchObject({
+      cwd: '/repo/default-worktree',
+      parent_session_id: 'stored-parent',
+      profile: 'default'
+    })
+  })
+
   it('omits profile for a profile-less parent so single-profile users are unchanged', async () => {
     setSessions([storedSession({ id: 'stored-parent', message_count: 1 })])
     vi.mocked(getAllSessionMessages).mockResolvedValue({

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -2147,9 +2147,10 @@ export function useSessionActions({
       // Right-clicking a session outside the paginated sidebar window is a cache
       // miss: resolve it (cache → active backend → cross-profile) so the branch
       // is created on the parent's OWNING profile, not whichever is live (#67603).
+      const cached = $sessions.get().find(session => sessionMatchesStoredId(session, storedSessionId))
+
       const stored =
-        $sessions.get().find(session => sessionMatchesStoredId(session, storedSessionId)) ??
-        (sessionProfile ? undefined : await resolveStoredSession(storedSessionId))
+        cached?.profile?.trim() ? cached : ((await resolveStoredSession(storedSessionId)) ?? cached)
 
       const profile = sessionProfile ?? stored?.profile
 

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -2148,11 +2148,16 @@ export function useSessionActions({
       // miss: resolve it (cache → active backend → cross-profile) so the branch
       // is created on the parent's OWNING profile, not whichever is live (#67603).
       const cached = $sessions.get().find(session => sessionMatchesStoredId(session, storedSessionId))
+      const explicitProfile = sessionProfile?.trim() || undefined
 
       const stored =
-        cached?.profile?.trim() ? cached : ((await resolveStoredSession(storedSessionId)) ?? cached)
+        explicitProfile !== undefined
+          ? await resolveStoredSession(storedSessionId, explicitProfile)
+          : cached?.profile?.trim()
+            ? cached
+            : ((await resolveStoredSession(storedSessionId)) ?? cached)
 
-      const profile = sessionProfile ?? stored?.profile
+      const profile = explicitProfile ?? stored?.profile
 
       try {
         await ensureGatewayProfile(profile)

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -2152,7 +2152,14 @@ export function useSessionActions({
 
       const stored =
         explicitProfile !== undefined
-          ? await resolveStoredSession(storedSessionId, explicitProfile)
+          ? (await resolveStoredSession(storedSessionId, explicitProfile)) ??
+            // An explicit profile equal to the ACTIVE gateway profile is not a
+            // cross-profile claim — a miss there must not discard the cached
+            // row (launch/default rows are now stamped, so a by-id miss would
+            // otherwise drop the branch's cwd/parent; #67603 follow-up).
+            (normalizeProfileKey(explicitProfile) === normalizeProfileKey($activeGatewayProfile.get())
+              ? cached
+              : undefined)
           : cached?.profile?.trim()
             ? cached
             : ((await resolveStoredSession(storedSessionId)) ?? cached)

--- a/apps/desktop/src/app/session/hooks/use-session-actions/resolve-stored-session.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/resolve-stored-session.test.ts
@@ -91,6 +91,17 @@ describe('resolveStoredSession profile ownership', () => {
     expect(mockGetSession).not.toHaveBeenCalledWith('s1', 'default')
   })
 
+  it('fails closed when an explicit profile misses instead of returning a foreign same-id cache row', async () => {
+    $sessions.set([session({ cwd: '/repo/default', id: 's1', profile: 'default' })])
+    mockGetSession.mockRejectedValueOnce(new Error('404: Session not found'))
+
+    const resolved = await resolveStoredSession('s1', 'work')
+
+    expect(resolved).toBeUndefined()
+    expect(mockGetSession).toHaveBeenCalledWith('s1', 'work')
+    expect($sessions.get()).toEqual([session({ cwd: '/repo/default', id: 's1', profile: 'default' })])
+  })
+
   it('accepts a profile-less cache hit for single-profile users', async () => {
     $profiles.set(profiles('default'))
     $sessions.set([session({ id: 's1' })])

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -1390,7 +1390,7 @@ function upsertResolvedSession(session: SessionInfo, storedSessionId: string) {
 
 export async function resolveStoredSession(
   storedSessionId: string,
-  ownerRoute?: SessionProfileRoute
+  ownerScope?: SessionOwnerScope
 ): Promise<SessionInfo | undefined> {
   const projectSessions = $projectTree
     .get()
@@ -1411,16 +1411,40 @@ export async function resolveStoredSession(
 
   const cached = cachedCandidates.find(session => session.profile?.trim()) ?? cachedCandidates[0]
 
-  if (ownerRoute) {
+  if (typeof ownerScope === 'string') {
+    const profile = normalizeProfileKey(ownerScope)
+
+    const ownedCached = cachedCandidates.find(
+      session => session.profile && normalizeProfileKey(session.profile) === profile
+    )
+
+    if (ownedCached) {
+      return ownedCached
+    }
+
+    try {
+      const session = await getSession(storedSessionId, profile)
+      session.profile = profile
+      upsertResolvedSession(session, storedSessionId)
+
+      return session
+    } catch {
+      // An explicit profile is fail-closed. Returning metadata from another
+      // profile would preserve routing but leak that session's cwd/parent id.
+      return undefined
+    }
+  }
+
+  if (ownerScope) {
     const scope = {
-      connectionId: ownerRoute.connectionId,
-      profile: ownerRoute.targetProfile || ownerRoute.profile
+      connectionId: ownerScope.connectionId,
+      profile: ownerScope.targetProfile || ownerScope.profile
     }
 
     const cachedOwnerMatches =
       cached &&
-      cached.connection_id === ownerRoute.connectionId &&
-      (!cached.profile || normalizeProfileKey(cached.profile) === normalizeProfileKey(ownerRoute.profile))
+      cached.connection_id === ownerScope.connectionId &&
+      (!cached.profile || normalizeProfileKey(cached.profile) === normalizeProfileKey(ownerScope.profile))
 
     if (cached && cachedOwnerMatches) {
       return cached
@@ -1428,8 +1452,8 @@ export async function resolveStoredSession(
 
     try {
       const session = await getSession(storedSessionId, scope)
-      session.profile = normalizeProfileKey(ownerRoute.profile)
-      session.connection_id = ownerRoute.connectionId
+      session.profile = normalizeProfileKey(ownerScope.profile)
+      session.connection_id = ownerScope.connectionId
       upsertResolvedSession(session, storedSessionId)
 
       return session

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -8,6 +8,7 @@ import { isMessagingSource, normalizeSessionSource } from '@/lib/session-source'
 import { reconcileApprovalModeForProfile } from '@/store/approval-mode'
 import { requestDesktopOnboardingForCredentialWarning } from '@/store/onboarding'
 import { $activeGatewayProfile, $profiles, normalizeProfileKey } from '@/store/profile'
+import { $projectTree } from '@/store/projects'
 import {
   $cronSessions,
   $currentCwd,
@@ -1391,9 +1392,24 @@ export async function resolveStoredSession(
   storedSessionId: string,
   ownerRoute?: SessionProfileRoute
 ): Promise<SessionInfo | undefined> {
-  const cached = [...$sessions.get(), ...$cronSessions.get(), ...$messagingSessions.get()].find(session =>
-    sessionMatchesStoredId(session, storedSessionId)
-  )
+  const projectSessions = $projectTree
+    .get()
+    .flatMap(project => [
+      ...(project.previewSessions ?? []),
+      ...project.repos.flatMap(repo => repo.groups.flatMap(group => group.sessions))
+    ])
+
+  const cachedCandidates = [
+    ...$sessions.get(),
+    ...$cronSessions.get(),
+    ...$messagingSessions.get(),
+    ...projectSessions
+  ].filter(session => sessionMatchesStoredId(session, storedSessionId))
+  // The same conversation can appear in flat Recents and a profile-scoped
+  // project tree. Prefer the self-describing row: an ownerless legacy Recents
+  // copy must not mask the tree row that can route the session safely.
+
+  const cached = cachedCandidates.find(session => session.profile?.trim()) ?? cachedCandidates[0]
 
   if (ownerRoute) {
     const scope = {

--- a/tests/tui_gateway/test_projects_rpc.py
+++ b/tests/tui_gateway/test_projects_rpc.py
@@ -702,11 +702,13 @@ def test_projects_reads_are_scoped_to_the_requested_profile(monkeypatch, tmp_pat
     assert coder_tree["projects"][0]["sessionCount"] == 1
     assert launch_tree["scoped_session_ids"] == ["launch-session"]
     assert coder_tree["scoped_session_ids"] == ["coder-session"]
+    assert [s["profile"] for s in coder_tree["projects"][0]["previewSessions"]] == ["coder"]
 
     assert coder_sessions["project"]["id"] == coder_project["id"]
     assert coder_sessions["project"]["sessionCount"] == 1
     lane = coder_sessions["project"]["repos"][0]["groups"][0]
     assert [s["id"] for s in lane["sessions"]] == ["coder-session"]
+    assert [s["profile"] for s in lane["sessions"]] == ["coder"]
 
 
 def test_projects_tree_is_scoped_to_the_requested_profile(monkeypatch, tmp_path):

--- a/tui_gateway/methods_config.py
+++ b/tui_gateway/methods_config.py
@@ -123,6 +123,9 @@ def _(rid, params: dict) -> dict:
     Lanes carry no session rows here; drill-in uses ``projects.project_sessions``.
     """
     try:
+        from tui_gateway.project_tree import stamp_profile
+        from tui_gateway.server import _response_profile_name
+
         with _profile_db(params) as db:
             if db is None:
                 return _ok(
@@ -135,6 +138,9 @@ def _(rid, params: dict) -> dict:
                 hydrate=False,
                 session_limit=int(params.get("session_limit") or 2000),
                 include_discovered=True,
+            )
+            stamp_profile(
+                tree["projects"], _response_profile_name(params.get("profile"))
             )
             return _ok(
                 rid,
@@ -155,6 +161,9 @@ def _(rid, params: dict) -> dict:
     built from the same authoritative grouping as ``projects.tree`` so ids and
     membership match exactly. Used when the user enters a project."""
     try:
+        from tui_gateway.project_tree import stamp_profile
+        from tui_gateway.server import _response_profile_name
+
         project_id = str(params.get("project_id") or "")
         if not project_id:
             return _err(rid, 5063, "project_id required")
@@ -171,6 +180,9 @@ def _(rid, params: dict) -> dict:
                 hydrate=True,
                 session_limit=int(params.get("session_limit") or 5000),
                 include_discovered=False,
+            )
+            stamp_profile(
+                tree["projects"], _response_profile_name(params.get("profile"))
             )
             proj = next((p for p in tree["projects"] if p["id"] == project_id), None)
             return _ok(rid, {"project": proj})

--- a/tui_gateway/project_tree.py
+++ b/tui_gateway/project_tree.py
@@ -63,6 +63,21 @@ NO_PROJECT_LABEL = "Home"
 _MAX_SIBLING_PROBES = 4
 
 
+def stamp_profile(projects: list[dict], profile: str) -> None:
+    """Make every session row self-describing for cross-profile routing.
+
+    A scoped project tree is built from one profile's state.db, so the request
+    scope is authoritative even for legacy rows whose ``profile_name`` is NULL.
+    """
+    for project in projects:
+        for session in project.get("previewSessions") or []:
+            session["profile"] = profile
+        for repo in project.get("repos") or []:
+            for group in repo.get("groups") or []:
+                for session in group.get("sessions") or []:
+                    session["profile"] = profile
+
+
 def _branch_lane_id(repo_root: str, branch: str = "") -> str:
     """The one definition of a main-checkout lane id (must match the desktop)."""
     return f"{repo_root}::branch::{(branch or '').strip()}"


### PR DESCRIPTION
## Summary

Create a Desktop conversation branch through the parent session's owning profile when that parent comes from a profile-scoped Project tree.

This fixes the observed case where a session owned by a non-default profile was visible under a Project, but **Branch** could not resolve/read it or created the child through the active/default profile.

## Root cause

Profile ownership was lost across three boundaries:

1. Profile-scoped `projects.tree` / `projects.project_sessions` rows were not self-describing.
2. Sidebar and tile branch callbacks forwarded only the session ID.
3. `branchStoredSession()` could let an ownerless Recents duplicate mask the authoritative Project-tree row, and an explicitly forwarded profile skipped or mis-scoped parent metadata resolution (losing the worktree `cwd` or borrowing it from a same-ID session in another profile).

## Fix

- Stamp the authoritative requested profile onto project-tree preview and nested session rows after scoped DB construction.
- Include project-tree sessions in stored-session owner resolution.
- Prefer a profile-bearing row over an ownerless duplicate for the same stored ID.
- Forward optional owner profile through sidebar and tile branch actions.
- Route parent message reads and `session.create` through that profile.
- Resolve parent metadata inside the explicitly forwarded profile, preserving the correct worktree `cwd` and failing closed rather than borrowing another profile's metadata.
- Preserve profile-less/single-profile behavior by omitting profile routing when no owner exists.

## Regression coverage

- Parent exists only in a non-default profile Project tree.
- Ownerless Recents duplicate cannot mask an owned Project-tree row.
- Explicit owner profile plus uncached parent still resolves worktree `cwd`.
- Same stored ID in two profiles cannot route to one profile while inheriting the other's `cwd`.
- Genuinely profile-less parent remains unscoped.
- Sidebar wiring and session-tile delegation carry ownership.
- Profile-scoped project overview and drill-in rows carry the requested profile.
- Native Electron E2E: visible persisted parent row → Session actions → Branch → nested child.

## Verification on current `main`

- Desktop targeted Vitest: **123 passed**
- Python profile/project suites: **39 passed**
- Desktop typecheck: passed
- Touched-file ESLint: passed
- Production Desktop build + `assert-dist-built`: passed
- Added-line security scan: no hardcoded-secret, shell-injection, eval/exec, or pickle findings
- Initial independent review caught same-ID cross-profile metadata leakage; the exact default-vs-work CWD case was reproduced RED and is GREEN in follow-up `2fc2408fc`
- Independent filesystem-aware runtime-head review of `2fc2408fc` — **PASS, no blockers**
- Test-only tip `b5f9c2619` additionally pins explicit-profile fetch failure against a foreign same-ID cache row
- Native macOS E2E on exact runtime head `2fc2408fc`: arm64 production build, then visible persisted parent → Session actions → Branch → nested child — **1/1 passed in 11.1s**

## Relationship to open PRs

- **#89736** fixes profile badge metadata by projecting persisted `profile_name` (defaulting missing values). This PR fixes branch routing and stamps the *requested scoped profile*, which remains authoritative for legacy rows whose persisted `profile_name` is null. The behavioral scope is additive, though the response field may conflict mechanically if #89736 merges first.
- **#95992** fixes URL navigation after a child is already created. This PR fixes owner routing for parent lookup/read/create before that point. The fixes are complementary.
- **#95179** is a much broader multi-gateway Project ownership feature; this PR is the narrow existing-session bug fix.

## Cache/profile safety

No prompt, message history, memory, or toolset state is mutated. Ownership is carried as request/display metadata and used only to select the existing profile-scoped session APIs.
