### PR TITLE
fix(dashboard-auth): treat an unrecognised token as None, not as an unreachable IDP

### DIFF
--- a/plugins/dashboard_auth/nous/__init__.py
+++ b/plugins/dashboard_auth/nous/__init__.py
@@ -436,8 +436,25 @@ class NousDashboardAuthProvider(DashboardAuthProvider):
             signing_key = self._get_jwks_client().get_signing_key_from_jwt(
                 access_token
             )
-        except jwt.PyJWKClientError as exc:
+        except jwt.exceptions.PyJWKClientConnectionError as exc:
+            # The JWKS endpoint could not be fetched: we can neither confirm
+            # nor deny this token, so the middleware must answer 503 and keep
+            # the session rather than logging a valid user out on an outage.
             raise ProviderError(f"JWKS lookup failed: {exc}") from exc
+        except jwt.InvalidTokenError as exc:
+            # Not something this provider minted. The dashboard stacks
+            # providers, so a session cookie from another one (or left over
+            # from a previous auth configuration) lands here as a string PyJWT
+            # cannot even parse. Contract: unrecognised tokens are None, which
+            # lets the middleware try the next provider and end on a clean 401.
+            # Reporting it as an outage instead strands the caller: it keeps
+            # retrying an "unreachable" gateway and never returns to /login.
+            raise InvalidCodeError(f"not a Nous Portal token: {exc}") from exc
+        except jwt.PyJWKClientError as exc:
+            # No JWK matches the token's kid, and PyJWT already refreshed the
+            # set once before raising. The endpoint answered, so this is a
+            # foreign token, not an outage.
+            raise InvalidCodeError(f"no matching signing key: {exc}") from exc
         except Exception as exc:  # pragma: no cover - defensive
             raise ProviderError(f"JWKS lookup failed: {exc!r}") from exc
 

--- a/plugins/dashboard_auth/self_hosted/__init__.py
+++ b/plugins/dashboard_auth/self_hosted/__init__.py
@@ -617,8 +617,22 @@ class SelfHostedOIDCProvider(DashboardAuthProvider):
             signing_key = self._get_jwks_client().get_signing_key_from_jwt(
                 id_token
             )
-        except jwt.PyJWKClientError as exc:
+        except jwt.exceptions.PyJWKClientConnectionError as exc:
+            # The IDP's JWKS endpoint could not be fetched: neither confirm nor
+            # deny, so the middleware answers 503 instead of logging a valid
+            # user out on a transient outage.
             raise ProviderError(f"JWKS lookup failed: {exc}") from exc
+        except jwt.InvalidTokenError as exc:
+            # Not an ID token this provider issued. Providers stack (the
+            # middleware documents exactly this: a nous session hitting the
+            # self-hosted provider and vice versa), and an unrecognised token
+            # is None per the contract, so the caller gets a clean 401 rather
+            # than a 503 it will keep retrying.
+            raise InvalidCodeError(f"not an ID token from this issuer: {exc}") from exc
+        except jwt.PyJWKClientError as exc:
+            # No JWK matches the token's kid, and PyJWT already refreshed the
+            # set once. The endpoint answered, so this is a foreign token.
+            raise InvalidCodeError(f"no matching signing key: {exc}") from exc
         except Exception as exc:  # pragma: no cover - defensive
             raise ProviderError(f"JWKS lookup failed: {exc!r}") from exc
 

--- a/tests/plugins/dashboard_auth/test_nous_provider.py
+++ b/tests/plugins/dashboard_auth/test_nous_provider.py
@@ -590,14 +590,47 @@ class TestVerifySession:
 
     def test_jwks_unreachable_raises_provider_error(self, provider, rsa_keypair):
         token = _mint_token(rsa_keypair)
-        # Replace the patched client so it raises.
+        # Replace the patched client so it raises. PyJWT raises this subclass
+        # (not the bare PyJWKClientError) when the JWKS endpoint cannot be
+        # fetched, which is the only case where we can neither confirm nor
+        # deny the token and therefore must surface a 503.
         bad_client = MagicMock()
-        bad_client.get_signing_key_from_jwt.side_effect = jwt.PyJWKClientError(
-            "fetch failed"
+        bad_client.get_signing_key_from_jwt.side_effect = (
+            jwt.exceptions.PyJWKClientConnectionError("fetch failed")
         )
         provider._jwks_client = bad_client
         with pytest.raises(ProviderError, match="JWKS"):
             provider.verify_session(access_token=token)
+
+    def test_foreign_opaque_token_returns_none(self, provider):
+        """A token this provider did not mint is "not mine", not "IDP down".
+
+        The dashboard stacks providers, and a session cookie minted by another
+        one (or left over from a previous auth configuration) is an opaque
+        string PyJWT cannot even split into segments. Raising ProviderError
+        here makes the middleware answer 503 for every request carrying that
+        cookie, so the caller never receives the 401 that would send it back
+        to the login page: a desktop client retries the "unreachable gateway"
+        forever instead of asking the user to sign in again.
+        """
+        stale_client = MagicMock()
+        stale_client.get_signing_key_from_jwt.side_effect = jwt.DecodeError(
+            "Not enough segments"
+        )
+        provider._jwks_client = stale_client
+        assert provider.verify_session(access_token="opaque-basic-session") is None
+
+    def test_unknown_signing_key_returns_none(self, provider, rsa_keypair):
+        """No JWK matches the token's kid, after PyJWT already refreshed the
+        set once. The endpoint answered, so this is a foreign token rather
+        than an outage."""
+        token = _mint_token(rsa_keypair)
+        other_issuer_client = MagicMock()
+        other_issuer_client.get_signing_key_from_jwt.side_effect = (
+            jwt.PyJWKClientError('Unable to find a signing key that matches: "kid42"')
+        )
+        provider._jwks_client = other_issuer_client
+        assert provider.verify_session(access_token=token) is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/plugins/dashboard_auth/test_self_hosted_provider.py
+++ b/tests/plugins/dashboard_auth/test_self_hosted_provider.py
@@ -564,12 +564,35 @@ class TestVerifySession:
     def test_jwks_unreachable_raises(self, provider, rsa_keypair):
         token = _mint_id_token(rsa_keypair)
         bad_client = MagicMock()
-        bad_client.get_signing_key_from_jwt.side_effect = jwt.PyJWKClientError(
-            "fetch failed"
+        # PyJWT raises this subclass when the JWKS endpoint cannot be fetched,
+        # the one case where the token can be neither confirmed nor denied.
+        bad_client.get_signing_key_from_jwt.side_effect = (
+            jwt.exceptions.PyJWKClientConnectionError("fetch failed")
         )
         provider._jwks_client = bad_client
         with pytest.raises(ProviderError, match="JWKS"):
             provider.verify_session(access_token=token)
+
+    def test_foreign_opaque_token_returns_none(self, provider):
+        """A session minted by another stacked provider is unrecognised, not
+        an outage: returning None lets the middleware reach a clean 401."""
+        stale_client = MagicMock()
+        stale_client.get_signing_key_from_jwt.side_effect = jwt.DecodeError(
+            "Not enough segments"
+        )
+        provider._jwks_client = stale_client
+        assert provider.verify_session(access_token="opaque-other-session") is None
+
+    def test_unknown_signing_key_returns_none(self, provider, rsa_keypair):
+        """No JWK matches the token's kid after PyJWT's own refresh: foreign
+        token, not an unreachable IDP."""
+        token = _mint_id_token(rsa_keypair)
+        other_client = MagicMock()
+        other_client.get_signing_key_from_jwt.side_effect = jwt.PyJWKClientError(
+            'Unable to find a signing key that matches: "kid42"'
+        )
+        provider._jwks_client = other_client
+        assert provider.verify_session(access_token=token) is None
 
     def test_jwks_client_sends_explicit_http_headers(self):
         provider = oidc_plugin.SelfHostedOIDCProvider(


### PR DESCRIPTION
## What does this PR do?

Both bundled JWT providers mapped every exception out of `get_signing_key_from_jwt` to `ProviderError`, including the purely local `DecodeError` PyJWT raises for a string it cannot parse as a JWT. The provider contract is the opposite: `None` for a token you do not recognise, `ProviderError` only when the IDP cannot be reached.

Because the middleware turns `ProviderError` into 503, a session cookie minted by another stacked provider (or left over after an operator changed the auth configuration) made every request 503 instead of 401, and the caller never received the 401 that sends it back to `/login`. Hermes Desktop retried the "unavailable gateway" forever with no way out of the UI.

Classification now follows what PyJWT actually raises:

| PyJWT exception | Meaning | Now |
|---|---|---|
| `PyJWKClientConnectionError` | JWKS endpoint could not be fetched | `ProviderError` (503), unchanged |
| `InvalidTokenError` / `DecodeError` | not a token we minted | `InvalidCodeError`, which `verify_session` maps to `None` (401) |
| other `PyJWKClientError` | no JWK matches the kid, after PyJWT's own one-shot refresh | `InvalidCodeError` (401) |

The same three lines were wrong in the self-hosted OIDC provider, which the middleware documents as stacking with the nous provider ("a self-hosted-OIDC session hits the `nous` provider first"), so both are fixed together.

## Related Issue

Fixes #97361

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/dashboard_auth/nous/__init__.py`: split the `get_signing_key_from_jwt` handler per the table above.
- `plugins/dashboard_auth/self_hosted/__init__.py`: same split.
- `tests/plugins/dashboard_auth/test_nous_provider.py`, `tests/plugins/dashboard_auth/test_self_hosted_provider.py`: 4 new tests, and 2 existing ones updated (see below).

### Note for review: two existing tests changed

`test_jwks_unreachable_raises` (both files) raised a bare `PyJWKClientError("fetch failed")` to stand in for an unreachable endpoint. PyJWT never raises that for a fetch failure: `fetch_data` raises `PyJWKClientConnectionError`. The tests encoded the very conflation this PR fixes, so they now raise the subclass PyJWT actually emits. The unreachable-IDP behaviour they guard (503, no forced logout) is unchanged and still asserted.

## How to Test

Reproduce the trap:

1. Gate a network-reachable dashboard with `dashboard.basic_auth`, sign in from a browser and from Desktop.
2. Register an OAuth client, remove the `basic_auth` block, restart. `/api/status` reports `auth_providers: ["nous"]`.
3. Reload without clearing cookies.

Before: every request returns 503 `Auth provider 'nous' unreachable`, `/login` is unreachable, `logs/dashboard-auth.log` fills with `provider_unreachable`, and Desktop loops on "Could not reach the remote Hermes gateway while refreshing its WebSocket ticket".

After: the stale cookie yields a clean 401, the browser lands on `/login`, Desktop offers Sign in.

Automated coverage:

- `test_foreign_opaque_token_returns_none` (both providers): the exact production shape, an opaque non-JWT session, must be `None`.
- `test_unknown_signing_key_returns_none` (both providers): a well-formed JWT whose kid matches no JWK is foreign, not an outage.
- `test_jwks_unreachable_raises*` (both providers): a real fetch failure still raises, so an IDP outage never logs a valid user out.

Each fix was verified as a genuine regression by reverting it independently: both new tests fail on `main` with the ProviderError the fix removes.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs and issues to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the affected suites with `scripts/run_tests.sh`: `tests/plugins/` plus the dashboard-auth files, 1849 passed against 1845 on `main` at the same commit, with the same 70 pre-existing failures either way
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.6), Python 3.11, plus the live reproduction on a Linux container running the v2026.8.27 image

### Documentation & Housekeeping

- [x] N/A: no config key, no CLI surface, no doc statement changes (the contract this restores is the one `base.py` already documents)
- [x] Cross-platform: pure Python exception handling
