### PR TITLE
fix(honcho): oauth persistence never rewrites honcho.json from an empty read; adopt a sibling's rotation after a 401

### DIFF
--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -155,15 +155,13 @@ class HonchoMemoryProvider(DialecticMixin, MemoryProvider):
             return False
 
     def save_config(self, values, hermes_home):
-        """Merge ``values`` into $HERMES_HOME/honcho.json (Honcho SDK native format)."""
+        """Merge ``values`` into $HERMES_HOME/honcho.json (Honcho SDK native format).
+        A file that exists but does not parse raises instead of being replaced by ``values`` alone."""
         from pathlib import Path
         from utils import atomic_json_write
-        from plugins.memory.honcho.client import _read_config
+        from plugins.memory.honcho.oauth import _read_config_strict
         config_path = Path(hermes_home) / "honcho.json"
-        try:
-            existing = _read_config(config_path)
-        except Exception:
-            existing = {}
+        existing = _read_config_strict(config_path)
         atomic_json_write(config_path, {**existing, **values}, mode=0o600)
 
     def get_config_schema(self):

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -155,8 +155,7 @@ class HonchoMemoryProvider(DialecticMixin, MemoryProvider):
             return False
 
     def save_config(self, values, hermes_home):
-        """Merge ``values`` into $HERMES_HOME/honcho.json (Honcho SDK native format).
-        A file that exists but does not parse raises instead of being replaced by ``values`` alone."""
+        """Merge ``values`` into $HERMES_HOME/honcho.json (Honcho SDK native format); a file that does not parse raises."""
         from pathlib import Path
         from utils import atomic_json_write
         from plugins.memory.honcho.oauth import _read_config_strict

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -155,13 +155,15 @@ class HonchoMemoryProvider(DialecticMixin, MemoryProvider):
             return False
 
     def save_config(self, values, hermes_home):
-        """Merge ``values`` into $HERMES_HOME/honcho.json (Honcho SDK native format); a file that does not parse raises."""
+        """Merge ``values`` into $HERMES_HOME/honcho.json (Honcho SDK native format); a file that does not parse raises.
+        Holds the token refresh locks so a rotation cannot land between the read and the write."""
         from pathlib import Path
         from utils import atomic_json_write
-        from plugins.memory.honcho.oauth import _read_config_strict
+        from plugins.memory.honcho.oauth import _config_refresh_lock, _read_config_strict, _refresh_lock
         config_path = Path(hermes_home) / "honcho.json"
-        existing = _read_config_strict(config_path)
-        atomic_json_write(config_path, {**existing, **values}, mode=0o600)
+        with _refresh_lock, _config_refresh_lock(config_path):
+            existing = _read_config_strict(config_path)
+            atomic_json_write(config_path, {**existing, **values}, mode=0o600)
 
     def get_config_schema(self):
         return [

--- a/plugins/memory/honcho/cli.py
+++ b/plugins/memory/honcho/cli.py
@@ -614,7 +614,7 @@ def _setup_browser_login(hermes_host: dict, write_path: Path) -> bool:
 def _setup_cloud_auth(cfg: dict, hermes_host: dict, write_path: Path) -> bool:
     """Cloud auth: OAuth (browser), device code, or API key. Returns False on abort."""
     cfg.pop("baseUrl", None)  # cloud uses SDK default
-    from plugins.memory.honcho.oauth import OAuthCredential
+    from plugins.memory.honcho.oauth import OAuthCredential, is_oauth_access_token
     existing_oauth = OAuthCredential.from_host_block(hermes_host)
     device_available = _device_login_available()
     is_remote, can_browse = _headless()
@@ -639,14 +639,20 @@ def _setup_cloud_auth(cfg: dict, hermes_host: dict, write_path: Path) -> bool:
         return _setup_device_login(hermes_host, write_path, open_browser=can_browse and not is_remote)
     if method in {"oauth", "o"}:
         return _setup_browser_login(hermes_host, write_path)
-    print(f"\n  Current API key: {_mask(cfg.get('apiKey', ''))}")
+    # A grant left on the host block shadows the key (#97990): its access token is not "current".
+    stale_grant = existing_oauth is not None or is_oauth_access_token(hermes_host.get("apiKey"))
+    current = ("" if stale_grant else hermes_host.get("apiKey", "")) or cfg.get("apiKey", "")
+    print(f"\n  Current API key: {_mask(current)}")
     if new_key := _prompt("Honcho API key (leave blank to keep current)", secret=True):
         cfg["apiKey"] = new_key
-    if cfg.get("apiKey"):
-        return True
-    print("\n  No API key configured. Get yours at https://app.honcho.dev\n"
-          "  Run 'hermes honcho setup' again once you have a key.\n")
-    return False
+    key = new_key or current
+    if not key:
+        print("\n  No API key configured. Get yours at https://app.honcho.dev\n"
+              "  Run 'hermes honcho setup' again once you have a key.\n")
+        return False
+    hermes_host.pop("oauth", None)
+    hermes_host["apiKey"] = key
+    return True
 
 
 def _menu(header: str, *lines: str) -> None:

--- a/plugins/memory/honcho/cli.py
+++ b/plugins/memory/honcho/cli.py
@@ -71,8 +71,24 @@ def _read_config() -> dict:
         return {}
 
 
+class ConfigWriteRefused(Exception):
+    """honcho.json exists on disk but does not parse, so no command may overwrite it."""
+
+
+def _refuse_unparseable(path: Path) -> None:
+    """Raise ``ConfigWriteRefused`` when ``path`` exists but cannot be read or parsed. ``_read_config``
+    returns ``{}`` for such a file, and writing that back would drop every other host and root key."""
+    from plugins.memory.honcho.oauth import _read_config_strict
+    try:
+        _read_config_strict(path)
+    except (OSError, ValueError) as e:
+        raise ConfigWriteRefused(f"{path} exists but could not be read as JSON ({e}). Nothing was written. "
+                                 "Fix or move the file, then re-run.") from e
+
+
 def _write_config(cfg: dict, path: Path | None = None) -> None:
     path = path or _local_config_path()
+    _refuse_unparseable(path)
     path.parent.mkdir(parents=True, exist_ok=True)
     from utils import atomic_json_write
     atomic_json_write(path, cfg, mode=0o600)
@@ -241,7 +257,11 @@ def _sync_profiles(verbose: bool) -> int:
 
     created = skipped = 0
     for p in (p for p in profiles if p.name != "default"):
-        if clone_honcho_for_profile(p.name):
+        try:
+            cloned = clone_honcho_for_profile(p.name)
+        except ConfigWriteRefused as e:
+            return say(f"  {e}\n") or created
+        if cloned:
             say(f"  + {p.name} -> {profile_host_key(p.name)}")
             created += 1
         else:
@@ -699,8 +719,16 @@ def _setup_tuning(cfg: dict, hermes_host: dict) -> None:
 
 def cmd_setup(args) -> None:
     """Interactive Honcho setup wizard."""
+    try:
+        _setup_wizard(args)
+    except ConfigWriteRefused as e:
+        print(f"  {e}\n")
+
+
+def _setup_wizard(args) -> None:
     cfg = _read_config()
     write_path, read_path = _local_config_path(), _config_path()
+    _refuse_unparseable(write_path)  # before the questions, not after them
     print(f"\nHoncho memory setup\n{RULE}\n  Honcho gives Hermes persistent cross-session memory.\n  Config: {write_path}")
     if read_path != write_path and read_path.exists():
         print(f"  (seeding from existing config at {read_path})")
@@ -1338,7 +1366,10 @@ def honcho_command(args) -> None:
     if handler is None:
         return print(f"  Unknown honcho command: {sub}\n"
                      "  Available: status, sessions, map, peer, mode, strategy, tokens, identity, migrate, enable, disable, sync\n")
-    handler(args)
+    try:
+        handler(args)
+    except ConfigWriteRefused as e:
+        print(f"  {e}\n")
 
 
 def register_cli(subparser) -> None:

--- a/plugins/memory/honcho/cli.py
+++ b/plugins/memory/honcho/cli.py
@@ -175,15 +175,17 @@ def _default_block_and_key(cfg: dict) -> tuple[dict, bool]:
     return cfg_get(cfg, "hosts", HOST, default={}), bool(cfg.get("apiKey") or os.environ.get("HONCHO_API_KEY"))
 
 
-def _resolve_api_key(cfg: dict, block: dict | None = None) -> str:
+def _resolve_api_key(cfg: dict, block: dict | None = None, *, env: bool = True) -> str:
     """API key for ``block`` (default: the active host's block), host -> root -> env. A self-hosted
-    http(s) or host:port ``baseUrl`` without a key yields "local" so credential guards accept it."""
+    http(s) or host:port ``baseUrl`` without a key yields "local" so credential guards accept it.
+    ``env=False`` counts only what is on disk: a write that enables a block must not rely on a variable
+    that can vanish from the next process."""
     block = _host_block(cfg, _host_key()) if block is None else block
-    key = block.get("apiKey") or cfg.get("apiKey", "") or os.environ.get("HONCHO_API_KEY", "")
+    key = (block.get("apiKey") or cfg.get("apiKey", "") or (os.environ.get("HONCHO_API_KEY", "") if env else ""))
     if key:
         return key
     base_url = (block.get("baseUrl") or block.get("base_url") or cfg.get("baseUrl") or cfg.get("base_url")
-                or os.environ.get("HONCHO_BASE_URL", "") or "").strip()
+                or (os.environ.get("HONCHO_BASE_URL", "") if env else "") or "").strip()
     if not base_url:
         return key
     from urllib.parse import urlparse
@@ -281,7 +283,7 @@ def clone_honcho_for_profile(profile_name: str) -> bool:
     # workspace is shared so all profiles see the same context.
     new_block.update(aiPeer=profile_name, workspace=_pref(default_block, cfg, "workspace") or HOST)
     # The default host's apiKey is not inherited; the block stays unenabled until this profile signs in.
-    if _resolve_api_key(cfg, new_block):
+    if _resolve_api_key(cfg, new_block, env=False):
         new_block["enabled"] = default_block.get("enabled", True)
     cfg.setdefault("hosts", {})[new_host] = new_block
     _write_config(cfg)
@@ -345,7 +347,7 @@ def cmd_enable(args) -> None:
     host = _host_key()
     label = _label(host)
     block = cfg.setdefault("hosts", {}).setdefault(host, {})
-    if not _resolve_api_key(cfg, block):
+    if not _resolve_api_key(cfg, block, env=False):
         return print(f"  {label}{_no_credential_hint(host)}\n")
     if block.get("enabled") is True:
         return print(f"  {label}Honcho is already enabled.\n")

--- a/plugins/memory/honcho/cli.py
+++ b/plugins/memory/honcho/cli.py
@@ -64,11 +64,24 @@ def _local_config_path() -> Path:
     return get_hermes_home() / "honcho.json"
 
 
+class _ReadConfig(dict):
+    """The config a command works on, carrying what disk held when it was read (``snapshot``) and where
+    (``path``), so _write_config() can apply only the command's edits onto a fresh read."""
+
+    snapshot: dict
+    path: Path
+
+
 def _read_config() -> dict:
+    import copy
+    path = _config_path()
     try:
-        return json.loads(_config_path().read_text(encoding="utf-8"))
+        raw = json.loads(path.read_text(encoding="utf-8"))
     except Exception:
-        return {}
+        raw = {}
+    cfg = _ReadConfig(raw)
+    cfg.snapshot, cfg.path = copy.deepcopy(raw), path
+    return cfg
 
 
 class ConfigWriteRefused(Exception):
@@ -86,12 +99,46 @@ def _refuse_unparseable(path: Path) -> None:
                                  "Fix or move the file, then re-run.") from e
 
 
+def _apply_edits(base: dict, edited: dict, current: dict) -> dict:
+    """Return ``current`` with every root key and ``hosts.<h>.<k>`` the command changed between ``base``
+    and ``edited`` applied. Keys the command left alone keep their on-disk value, so a token rotation
+    that landed while the command ran survives; a key the command set deliberately wins."""
+    import copy
+    out = copy.deepcopy(current)
+    for key in (set(base) | set(edited)) - {"hosts"}:
+        if key in edited and edited[key] != base.get(key):
+            out[key] = copy.deepcopy(edited[key])
+        elif key not in edited and key in base:
+            out.pop(key, None)
+    base_hosts, edited_hosts = base.get("hosts") or {}, edited.get("hosts") or {}
+    out_hosts = out.setdefault("hosts", {}) if (base_hosts or edited_hosts or "hosts" in current) else None
+    for host in set(base_hosts) | set(edited_hosts):
+        if host not in edited_hosts:
+            out_hosts.pop(host, None)
+            continue
+        b, e = base_hosts.get(host) or {}, edited_hosts[host]
+        block = out_hosts.setdefault(host, {})
+        for key in set(b) | set(e):
+            if key in e and e[key] != b.get(key):
+                block[key] = copy.deepcopy(e[key])
+            elif key not in e and key in b:
+                block.pop(key, None)
+    return out
+
+
 def _write_config(cfg: dict, path: Path | None = None) -> None:
-    path = path or _local_config_path()
-    _refuse_unparseable(path)
-    path.parent.mkdir(parents=True, exist_ok=True)
+    """Persist ``cfg`` under the same cross-process lock the token refresh holds. When ``cfg`` is the
+    object _read_config() returned for this path, only the command's edits are applied onto a fresh read
+    of disk; a plain dict is written whole."""
+    from plugins.memory.honcho.oauth import _config_refresh_lock, _read_config_strict
     from utils import atomic_json_write
-    atomic_json_write(path, cfg, mode=0o600)
+    path = path or _local_config_path()
+    with _config_refresh_lock(path):
+        _refuse_unparseable(path)
+        if getattr(cfg, "path", None) == path:
+            cfg = _apply_edits(cfg.snapshot, cfg, _read_config_strict(path))
+        path.parent.mkdir(parents=True, exist_ok=True)
+        atomic_json_write(path, cfg, mode=0o600)
 
 
 def _label(host: str) -> str:

--- a/plugins/memory/honcho/cli.py
+++ b/plugins/memory/honcho/cli.py
@@ -76,8 +76,8 @@ class ConfigWriteRefused(Exception):
 
 
 def _refuse_unparseable(path: Path) -> None:
-    """Raise ``ConfigWriteRefused`` when ``path`` exists but cannot be read or parsed. ``_read_config``
-    returns ``{}`` for such a file, and writing that back would drop every other host and root key."""
+    """Raise ConfigWriteRefused when ``path`` exists but cannot be parsed: writing back the ``{}`` a
+    tolerant read returns would drop every other host."""
     from plugins.memory.honcho.oauth import _read_config_strict
     try:
         _read_config_strict(path)
@@ -129,10 +129,8 @@ def _default_block_and_key(cfg: dict) -> tuple[dict, bool]:
 
 
 def _resolve_api_key(cfg: dict, block: dict | None = None) -> str:
-    """API key for ``block`` (default: the active host's block) with host -> root -> env fallback.
-    A self-hosted ``baseUrl`` without a key yields ``"local"`` so credential guards accept it: the
-    URL must be http/https (so ``baseUrl: true`` can't pass) or a schemeless host:port (legacy
-    ``localhost:8000``; the SDK rejects those itself)."""
+    """API key for ``block`` (default: the active host's block), host -> root -> env. A self-hosted
+    http(s) or host:port ``baseUrl`` without a key yields "local" so credential guards accept it."""
     block = _host_block(cfg, _host_key()) if block is None else block
     key = block.get("apiKey") or cfg.get("apiKey", "") or os.environ.get("HONCHO_API_KEY", "")
     if key:
@@ -235,8 +233,7 @@ def clone_honcho_for_profile(profile_name: str) -> bool:
     # AI peer is profile-specific (bare profile name: Honcho peer IDs allow no dots);
     # workspace is shared so all profiles see the same context.
     new_block.update(aiPeer=profile_name, workspace=_pref(default_block, cfg, "workspace") or HOST)
-    # The default host's apiKey is not inherited (#66125): without a credential of its own the block
-    # stays unenabled until 'hermes honcho setup --target-profile' signs the profile in.
+    # The default host's apiKey is not inherited; the block stays unenabled until this profile signs in.
     if _resolve_api_key(cfg, new_block):
         new_block["enabled"] = default_block.get("enabled", True)
     cfg.setdefault("hosts", {})[new_host] = new_block
@@ -296,8 +293,7 @@ def _no_credential_hint(host: str) -> str:
 
 
 def cmd_enable(args) -> None:
-    """Enable Honcho for the active profile. Refuses to write ``enabled: true`` for a block that
-    cannot authenticate, so an enabled block always has a credential behind it."""
+    """Enable Honcho for the active profile; refuses a block that cannot authenticate."""
     cfg = _read_config()
     host = _host_key()
     label = _label(host)
@@ -654,7 +650,7 @@ def _setup_cloud_auth(cfg: dict, hermes_host: dict, write_path: Path) -> bool:
         return _setup_device_login(hermes_host, write_path, open_browser=can_browse and not is_remote)
     if method in {"oauth", "o"}:
         return _setup_browser_login(hermes_host, write_path)
-    # A grant left on the host block shadows the key (#97990): its access token is not "current".
+    # A leftover grant on the host block would shadow the pasted key.
     stale_grant = existing_oauth is not None or is_oauth_access_token(hermes_host.get("apiKey"))
     current = ("" if stale_grant else hermes_host.get("apiKey", "")) or cfg.get("apiKey", "")
     print(f"\n  Current API key: {_mask(current)}")

--- a/plugins/memory/honcho/cli.py
+++ b/plugins/memory/honcho/cli.py
@@ -128,15 +128,17 @@ def _default_block_and_key(cfg: dict) -> tuple[dict, bool]:
     return cfg_get(cfg, "hosts", HOST, default={}), bool(cfg.get("apiKey") or os.environ.get("HONCHO_API_KEY"))
 
 
-def _resolve_api_key(cfg: dict) -> str:
-    """API key with host -> root -> env fallback. A self-hosted ``baseUrl`` without a key
-    yields ``"local"`` so credential guards accept it: the URL must be http/https (so
-    ``baseUrl: true`` can't pass) or a schemeless host:port (legacy ``localhost:8000``;
-    the SDK rejects those itself)."""
-    key = _host_block(cfg, _host_key()).get("apiKey") or cfg.get("apiKey", "") or os.environ.get("HONCHO_API_KEY", "")
+def _resolve_api_key(cfg: dict, block: dict | None = None) -> str:
+    """API key for ``block`` (default: the active host's block) with host -> root -> env fallback.
+    A self-hosted ``baseUrl`` without a key yields ``"local"`` so credential guards accept it: the
+    URL must be http/https (so ``baseUrl: true`` can't pass) or a schemeless host:port (legacy
+    ``localhost:8000``; the SDK rejects those itself)."""
+    block = _host_block(cfg, _host_key()) if block is None else block
+    key = block.get("apiKey") or cfg.get("apiKey", "") or os.environ.get("HONCHO_API_KEY", "")
     if key:
         return key
-    base_url = (cfg.get("baseUrl") or cfg.get("base_url") or os.environ.get("HONCHO_BASE_URL", "") or "").strip()
+    base_url = (block.get("baseUrl") or block.get("base_url") or cfg.get("baseUrl") or cfg.get("base_url")
+                or os.environ.get("HONCHO_BASE_URL", "") or "").strip()
     if not base_url:
         return key
     from urllib.parse import urlparse
@@ -232,8 +234,11 @@ def clone_honcho_for_profile(profile_name: str) -> bool:
         new_block["pinUserPeer"] = default_block["pinPeerName"]
     # AI peer is profile-specific (bare profile name: Honcho peer IDs allow no dots);
     # workspace is shared so all profiles see the same context.
-    new_block.update(aiPeer=profile_name, workspace=_pref(default_block, cfg, "workspace") or HOST,
-                     enabled=default_block.get("enabled", True))
+    new_block.update(aiPeer=profile_name, workspace=_pref(default_block, cfg, "workspace") or HOST)
+    # The default host's apiKey is not inherited (#66125): without a credential of its own the block
+    # stays unenabled until 'hermes honcho setup --target-profile' signs the profile in.
+    if _resolve_api_key(cfg, new_block):
+        new_block["enabled"] = default_block.get("enabled", True)
     cfg.setdefault("hosts", {})[new_host] = new_block
     _write_config(cfg)
     _ensure_peer_exists(new_host)  # eager so the peer exists before first message
@@ -283,12 +288,22 @@ def sync_honcho_profiles_quiet() -> int:
     return _sync_profiles(verbose=False)
 
 
+def _no_credential_hint(host: str) -> str:
+    profile = _active_profile_name()
+    setup = "hermes honcho setup" + (f" --target-profile {profile}" if profile != "default" else "")
+    return (f"Honcho stays disabled: no API key or base URL is configured for this profile, and the default "
+            f"profile's key is not shared.\n  Run '{setup}' to sign in, or set apiKey on hosts.{host} in {_config_path()}.")
+
+
 def cmd_enable(args) -> None:
-    """Enable Honcho for the active profile."""
+    """Enable Honcho for the active profile. Refuses to write ``enabled: true`` for a block that
+    cannot authenticate, so an enabled block always has a credential behind it."""
     cfg = _read_config()
     host = _host_key()
     label = _label(host)
     block = cfg.setdefault("hosts", {}).setdefault(host, {})
+    if not _resolve_api_key(cfg, block):
+        return print(f"  {label}{_no_credential_hint(host)}\n")
     if block.get("enabled") is True:
         return print(f"  {label}Honcho is already enabled.\n")
     block["enabled"] = True

--- a/plugins/memory/honcho/cli.py
+++ b/plugins/memory/honcho/cli.py
@@ -574,10 +574,13 @@ def _headless() -> tuple[bool, bool]:
         return False, True
 
 
-def _apply_grant_to_host(hermes_host: dict, cred) -> None:
-    """Store an OAuth grant on the host block; the wizard's final save persists it."""
+def _apply_grant_to_host(cfg: dict, hermes_host: dict, cred) -> None:
+    """Store an OAuth grant on the host block and in ``cfg``'s snapshot. install_grant already wrote it to disk,
+    so the final save must not copy it over a rotation that lands during the later prompts."""
     hermes_host["apiKey"] = cred.access_token
     hermes_host["oauth"] = cred.oauth_block()
+    if (snapshot := getattr(cfg, "snapshot", None)) is not None:
+        snapshot.setdefault("hosts", {}).setdefault(_host_key(), {}).update(apiKey=cred.access_token, oauth=cred.oauth_block())
     if cred.consent_peer_name:  # default the peer prompt to the consent name
         hermes_host["peerName"] = cred.consent_peer_name
     print("  Authorized — token saved. Let's finish configuring.\n")
@@ -605,7 +608,7 @@ def _setup_local_auth(cfg: dict, hermes_host: dict) -> None:
         print("\n  No local JWT set. Local no-auth ready.")
 
 
-def _setup_device_login(hermes_host: dict, write_path: Path, *, open_browser: bool) -> bool:
+def _setup_device_login(cfg: dict, hermes_host: dict, write_path: Path, *, open_browser: bool) -> bool:
     """RFC 8628 device-code sign-in. Returns False if setup must abort."""
     from plugins.memory.honcho.oauth_flow import (
         AccessDenied, AuthorizationTimeout, DeviceCode, DeviceCodeExpired, DeviceFlowError, authorize_via_device_code,
@@ -635,12 +638,12 @@ def _setup_device_login(hermes_host: dict, write_path: Path, *, open_browser: bo
               if isinstance(e, DeviceFlowError) and e.error == "http_429" else f"\n  Device sign-in failed: {e}\n" + _RETRY_HINT)
     else:
         print(" approved")
-        _apply_grant_to_host(hermes_host, cred)
+        _apply_grant_to_host(cfg, hermes_host, cred)
         return True
     return False
 
 
-def _setup_browser_login(hermes_host: dict, write_path: Path) -> bool:
+def _setup_browser_login(cfg: dict, hermes_host: dict, write_path: Path) -> bool:
     """Loopback OAuth sign-in. Tokens merge into the in-memory cfg so the wizard's final save
     keeps them; settings stay wizard-owned (apply_config=False). Returns False on abort."""
     from plugins.memory.honcho.oauth_flow import authorize_via_loopback
@@ -656,7 +659,7 @@ def _setup_browser_login(hermes_host: dict, write_path: Path) -> bool:
     except Exception as e:
         print(f"  OAuth sign-in failed: {e}\n" + _RETRY_HINT)
         return False
-    _apply_grant_to_host(hermes_host, cred)
+    _apply_grant_to_host(cfg, hermes_host, cred)
     return True
 
 
@@ -685,9 +688,9 @@ def _setup_cloud_auth(cfg: dict, hermes_host: dict, write_path: Path) -> bool:
                      default=default_method).strip().lower()
 
     if device_available and method in {"device", "d"}:
-        return _setup_device_login(hermes_host, write_path, open_browser=can_browse and not is_remote)
+        return _setup_device_login(cfg, hermes_host, write_path, open_browser=can_browse and not is_remote)
     if method in {"oauth", "o"}:
-        return _setup_browser_login(hermes_host, write_path)
+        return _setup_browser_login(cfg, hermes_host, write_path)
     # A leftover grant on the host block would shadow the pasted key.
     stale_grant = existing_oauth is not None or is_oauth_access_token(hermes_host.get("apiKey"))
     current = ("" if stale_grant else hermes_host.get("apiKey", "")) or cfg.get("apiKey", "")

--- a/plugins/memory/honcho/cli.py
+++ b/plugins/memory/honcho/cli.py
@@ -142,12 +142,15 @@ def _write_config(cfg: dict, path: Path | None = None) -> None:
     path = path or _local_config_path()
     with _config_refresh_lock(path):
         _refuse_unparseable(path)
+        out = cfg
         if getattr(cfg, "path", None) == path:
-            cfg = _apply_edits(cfg.snapshot, cfg, _read_config_strict(path))
+            out = _apply_edits(cfg.snapshot, cfg, _read_config_strict(path))
         elif isinstance(cfg, _ReadConfig) and path.exists():
-            cfg = _apply_edits(cfg.snapshot, cfg, _overlay_local(cfg.snapshot, _read_config_strict(path)))
+            out = _apply_edits(cfg.snapshot, cfg, _overlay_local(cfg.snapshot, _read_config_strict(path)))
         path.parent.mkdir(parents=True, exist_ok=True)
-        atomic_json_write(path, cfg, mode=0o600)
+        atomic_json_write(path, out, mode=0o600)
+        if isinstance(cfg, _ReadConfig):  # a later write on the same object applies only edits made after this one
+            cfg.snapshot, cfg.path = copy.deepcopy(dict(cfg)), path
 
 
 def _label(host: str) -> str:

--- a/plugins/memory/honcho/cli.py
+++ b/plugins/memory/honcho/cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 import json
 import os
 import sys
@@ -65,23 +66,20 @@ def _local_config_path() -> Path:
 
 
 class _ReadConfig(dict):
-    """The config a command works on, carrying what disk held when it was read (``snapshot``) and where
-    (``path``), so _write_config() can apply only the command's edits onto a fresh read."""
+    """A command's config, with the ``snapshot`` and ``path`` _write_config() needs to apply only its edits."""
 
-    snapshot: dict
-    path: Path
+    def __init__(self, raw: dict, path: Path):
+        super().__init__(raw)
+        self.snapshot, self.path = copy.deepcopy(raw), path
 
 
 def _read_config() -> dict:
-    import copy
     path = _config_path()
     try:
         raw = json.loads(path.read_text(encoding="utf-8"))
     except Exception:
         raw = {}
-    cfg = _ReadConfig(raw)
-    cfg.snapshot, cfg.path = copy.deepcopy(raw), path
-    return cfg
+    return _ReadConfig(raw, path)
 
 
 class ConfigWriteRefused(Exception):
@@ -89,8 +87,7 @@ class ConfigWriteRefused(Exception):
 
 
 def _refuse_unparseable(path: Path) -> None:
-    """Raise ConfigWriteRefused when ``path`` exists but cannot be parsed: writing back the ``{}`` a
-    tolerant read returns would drop every other host."""
+    """Raise ConfigWriteRefused when ``path`` exists but cannot be parsed; writing back ``{}`` would drop every host."""
     from plugins.memory.honcho.oauth import _read_config_strict
     try:
         _read_config_strict(path)
@@ -100,10 +97,8 @@ def _refuse_unparseable(path: Path) -> None:
 
 
 def _apply_edits(base: dict, edited: dict, current: dict) -> dict:
-    """Return ``current`` with every root key and ``hosts.<h>.<k>`` the command changed between ``base``
-    and ``edited`` applied. Keys the command left alone keep their on-disk value, so a token rotation
-    that landed while the command ran survives; a key the command set deliberately wins."""
-    import copy
+    """Return ``current`` with the root keys and ``hosts.<h>.<k>`` the command changed (``base`` to ``edited``)
+    applied. An untouched key keeps its on-disk value, so a rotation that landed while the command ran survives."""
     out = copy.deepcopy(current)
     for key in (set(base) | set(edited)) - {"hosts"}:
         if key in edited and edited[key] != base.get(key):
@@ -127,9 +122,8 @@ def _apply_edits(base: dict, edited: dict, current: dict) -> dict:
 
 
 def _write_config(cfg: dict, path: Path | None = None) -> None:
-    """Persist ``cfg`` under the same cross-process lock the token refresh holds. When ``cfg`` is the
-    object _read_config() returned for this path, only the command's edits are applied onto a fresh read
-    of disk; a plain dict is written whole."""
+    """Persist ``cfg`` under the token refresh's cross-process lock. The object _read_config() returned
+    for this path has only its edits applied onto a fresh read of disk; a plain dict is written whole."""
     from plugins.memory.honcho.oauth import _config_refresh_lock, _read_config_strict
     from utils import atomic_json_write
     path = path or _local_config_path()
@@ -178,8 +172,7 @@ def _default_block_and_key(cfg: dict) -> tuple[dict, bool]:
 def _resolve_api_key(cfg: dict, block: dict | None = None, *, env: bool = True) -> str:
     """API key for ``block`` (default: the active host's block), host -> root -> env. A self-hosted
     http(s) or host:port ``baseUrl`` without a key yields "local" so credential guards accept it.
-    ``env=False`` counts only what is on disk: a write that enables a block must not rely on a variable
-    that can vanish from the next process."""
+    ``env=False`` counts only what is on disk: a variable can vanish from the next process."""
     block = _host_block(cfg, _host_key()) if block is None else block
     key = (block.get("apiKey") or cfg.get("apiKey", "") or (os.environ.get("HONCHO_API_KEY", "") if env else ""))
     if key:
@@ -334,13 +327,6 @@ def sync_honcho_profiles_quiet() -> int:
     return _sync_profiles(verbose=False)
 
 
-def _no_credential_hint(host: str) -> str:
-    profile = _active_profile_name()
-    setup = "hermes honcho setup" + (f" --target-profile {profile}" if profile != "default" else "")
-    return (f"Honcho stays disabled: no API key or base URL is configured for this profile, and the default "
-            f"profile's key is not shared.\n  Run '{setup}' to sign in, or set apiKey on hosts.{host} in {_config_path()}.")
-
-
 def cmd_enable(args) -> None:
     """Enable Honcho for the active profile; refuses a block that cannot authenticate."""
     cfg = _read_config()
@@ -348,7 +334,10 @@ def cmd_enable(args) -> None:
     label = _label(host)
     block = cfg.setdefault("hosts", {}).setdefault(host, {})
     if not _resolve_api_key(cfg, block, env=False):
-        return print(f"  {label}{_no_credential_hint(host)}\n")
+        profile = _active_profile_name()
+        setup = "hermes honcho setup" + (f" --target-profile {profile}" if profile != "default" else "")
+        return print(f"  {label}Honcho stays disabled: no API key or base URL is configured for this profile, and the default "
+                     f"profile's key is not shared.\n  Run '{setup}' to sign in, or set apiKey on hosts.{host} in {_config_path()}.\n")
     if block.get("enabled") is True:
         return print(f"  {label}Honcho is already enabled.\n")
     block["enabled"] = True

--- a/plugins/memory/honcho/cli.py
+++ b/plugins/memory/honcho/cli.py
@@ -121,9 +121,22 @@ def _apply_edits(base: dict, edited: dict, current: dict) -> dict:
     return out
 
 
+def _overlay_local(seed: dict, local: dict) -> dict:
+    """Return ``seed`` with ``local``'s root keys and ``hosts.<h>.<k>`` keys on top. The local file wins,
+    so a grant or rotation it already holds is what the command's edits land on."""
+    out = copy.deepcopy(seed)
+    for key, value in local.items():
+        if key != "hosts":
+            out[key] = copy.deepcopy(value)
+    for host, block in (local.get("hosts") or {}).items():
+        out.setdefault("hosts", {}).setdefault(host, {}).update(copy.deepcopy(block))
+    return out
+
+
 def _write_config(cfg: dict, path: Path | None = None) -> None:
     """Persist ``cfg`` under the token refresh's cross-process lock. The object _read_config() returned
-    for this path has only its edits applied onto a fresh read of disk; a plain dict is written whole."""
+    has only its edits applied onto a fresh read of disk; a plain dict is written whole. A read that
+    resolved to a seed file (~/.honcho or a profile) is written whole only while ``path`` does not exist."""
     from plugins.memory.honcho.oauth import _config_refresh_lock, _read_config_strict
     from utils import atomic_json_write
     path = path or _local_config_path()
@@ -131,6 +144,8 @@ def _write_config(cfg: dict, path: Path | None = None) -> None:
         _refuse_unparseable(path)
         if getattr(cfg, "path", None) == path:
             cfg = _apply_edits(cfg.snapshot, cfg, _read_config_strict(path))
+        elif isinstance(cfg, _ReadConfig) and path.exists():
+            cfg = _apply_edits(cfg.snapshot, cfg, _overlay_local(cfg.snapshot, _read_config_strict(path)))
         path.parent.mkdir(parents=True, exist_ok=True)
         atomic_json_write(path, cfg, mode=0o600)
 

--- a/plugins/memory/honcho/oauth.py
+++ b/plugins/memory/honcho/oauth.py
@@ -108,17 +108,16 @@ def _mark_grant_dead(key: tuple[str, str], cred: OAuthCredential) -> None:
     _reauth_check_cache.pop(key, None)  # verdict changed without a config rewrite
 
 def _read_config(path: Path) -> dict[str, Any]:
-    """Tolerant reader for the fail-open READ paths only: an unreadable or unparseable store reads as
-    "no credential". Never feed this into a full-file write; writers go through ``_read_config_strict``."""
+    """Tolerant reader for the read paths: an unreadable store reads as no credential. Writers use
+    ``_read_config_strict``."""
     try:
         return json.loads(path.read_text(encoding="utf-8-sig"))
     except (OSError, json.JSONDecodeError):
         return {}
 
 def _read_config_strict(path: Path) -> dict[str, Any]:
-    """Reader for the WRITE paths. A missing file reads as ``{}``. A file that exists but cannot be read
-    or parsed raises so the caller leaves it alone: ``atomic_json_write`` replaces the whole file, and a
-    write seeded from ``{}`` would erase every other host's credentials and the root keys."""
+    """Reader for the write paths: a missing file is ``{}``, an unreadable one raises. A write seeded
+    from ``{}`` would replace every other host's credentials."""
     try:
         return json.loads(path.read_text(encoding="utf-8-sig"))
     except FileNotFoundError:
@@ -310,9 +309,8 @@ def _deep_merge(base: dict[str, Any], overlay: dict[str, Any]) -> dict[str, Any]
     return base
 
 def _persist_credential(path: Path, host: str, cred: OAuthCredential, raw: dict[str, Any] | None = None) -> None:
-    """Write ``cred`` into ``host``'s block (apiKey + oauth) of ``raw`` (default: a strict read of the
-    file), leaving the rest intact; marks the grant live. "Leaving the rest intact" is only true when the
-    existing store was actually read, so an unreadable file raises instead of becoming a single-host file."""
+    """Write ``cred`` into ``host``'s block of ``raw`` (default: a strict read of the file) and mark
+    the grant live."""
     from utils import atomic_json_write
 
     raw = _read_config_strict(path) if raw is None else raw
@@ -403,7 +401,7 @@ def install_grant(
     now = time.time() if now is None else now
     cred = OAuthCredential.from_token_response(grant, now=now, client_id=client_id, token_endpoint=token_endpoint)
     with _refresh_lock, _config_refresh_lock(path):
-        # Strict: a fresh login must not seed its root-merge from a store that exists but could not be read.
+        # Strict read: a login must not seed its root merge from a store it could not read.
         raw = _read_config_strict(path)
         granted_config = grant.get("config")
         if isinstance(granted_config, dict):

--- a/plugins/memory/honcho/oauth.py
+++ b/plugins/memory/honcho/oauth.py
@@ -262,6 +262,15 @@ def _rotate_and_persist(
         rotated = _exchange_with_retry(cred, now=now)
     except Exception as exc:
         if isinstance(exc, OAuthRefreshError) and exc.permanent:
+            # The file lock is best-effort: a sibling may have rotated first, making our
+            # refresh token a replay. If disk moved on, adopt that grant instead of killing it.
+            disk = _load_cred(path, host)
+            if disk is not None and disk.refresh_token != cred.refresh_token:
+                _dead_grants.pop(key, None)
+                _expiry_cache[key] = (disk.expires_at, disk.access_token)
+                logger.info("Honcho OAuth %s for host %s lost a rotation race; "
+                            "adopted the newer on-disk grant", op_label, host)
+                return disk
             _mark_grant_dead(key, cred)
             logger.error("Honcho OAuth grant for host %s is no longer valid (%s); "
                          "run 'hermes honcho setup' to re-authenticate", host, exc)
@@ -329,9 +338,14 @@ def ensure_fresh_token(
             logger.info("Honcho OAuth token refreshed for host %s", host)
         return (rotated.access_token, True) if rotated is not None else (current.access_token, False)
 
-def force_refresh_token(path: Path, host: str) -> str | None:
+def force_refresh_token(
+    path: Path, host: str, *, failed_access_token: str | None = None
+) -> str | None:
     """Rotate ``host``'s token now, ignoring local expiry (recovers a 401 on a
-    token the local clock still thinks is valid)."""
+    token the local clock still thinks is valid). ``failed_access_token`` is the
+    bearer the server rejected: when disk already holds a different one, a sibling
+    rotated the single-use refresh token first, so adopt its grant instead of
+    re-exchanging (a replay can revoke the whole grant)."""
     now = time.time()
     key = (str(path), host)
     with _refresh_lock, _config_refresh_lock(path):
@@ -342,6 +356,11 @@ def force_refresh_token(path: Path, host: str) -> str | None:
         # Dead grant, or an exchange just failed transiently: callers fail open.
         if _grant_is_dead(key, cred) or _in_failure_cooldown(key):
             return None
+        # Disk moving off the rejected bearer is the authoritative signal: the expiry cache is
+        # empty in sibling processes and already equals disk after this process's first waiter.
+        if failed_access_token and cred.access_token != failed_access_token and not cred.is_expired(now=now):
+            _expiry_cache[key] = (cred.expires_at, cred.access_token)
+            return cred.access_token
         cached = _expiry_cache.get(key)
         # Another thread or process already rotated: adopt the newer on-disk token.
         if cached is not None and cred.access_token != cached[1] and not cred.is_expired(now=now):

--- a/plugins/memory/honcho/oauth.py
+++ b/plugins/memory/honcho/oauth.py
@@ -108,9 +108,41 @@ def _mark_grant_dead(key: tuple[str, str], cred: OAuthCredential) -> None:
     _reauth_check_cache.pop(key, None)  # verdict changed without a config rewrite
 
 def _read_config(path: Path) -> dict[str, Any]:
+    """Tolerant reader for the fail-open READ paths only: an unreadable or unparseable store reads as
+    "no credential". Never feed this into a full-file write; writers go through ``_read_config_strict``."""
     try:
-        return json.loads(path.read_text(encoding="utf-8"))
+        return json.loads(path.read_text(encoding="utf-8-sig"))
     except (OSError, json.JSONDecodeError):
+        return {}
+
+def _read_config_strict(path: Path) -> dict[str, Any]:
+    """Reader for the WRITE paths: never lets a failed read become an empty store.
+
+    A missing file is the bootstrap case and reads as ``{}``. A file that EXISTS but cannot be read
+    (EACCES after a root-owned write, EIO, a stalled mount) raises instead: ``atomic_json_write`` replaces
+    the whole file and ``os.replace`` needs only a writable parent, so degrading here would let the next
+    persist erase every other host's credentials. Genuine corruption still degrades, but only after
+    preserving a ``.corrupt`` copy: a truncated store usually holds the other hosts' tokens verbatim.
+    """
+    try:
+        return json.loads(path.read_text(encoding="utf-8-sig"))
+    except FileNotFoundError:
+        return {}
+    except OSError:
+        logger.warning("Honcho config at %s could not be read; refusing to treat it as empty "
+                       "(a persist would erase every other host's credentials)", path, exc_info=True)
+        raise
+    except json.JSONDecodeError as exc:
+        corrupt = path.with_name(path.name + ".corrupt")
+        preserved = False
+        try:
+            import shutil
+            shutil.copy2(path, corrupt)
+            preserved = True
+        except Exception:
+            logger.debug("could not preserve a copy at %s", corrupt, exc_info=True)
+        logger.warning("Honcho config at %s is corrupt (%s); starting from an empty store. %s", path, exc,
+                       f"Original preserved at {corrupt}" if preserved else f"A copy could NOT be preserved at {corrupt}")
         return {}
 
 def _load_cred(path: Path, host: str, raw: dict[str, Any] | None = None) -> OAuthCredential | None:
@@ -259,6 +291,12 @@ def _rotate_and_persist(
     """Exchange ``cred`` and persist the rotation; ``None`` on failure (logged). A permanent OAuth error
     marks the grant dead so later calls skip the endpoint until a new login rotates the refresh token."""
     try:
+        # Read before spending the single-use refresh token: an exchange that cannot be persisted loses the grant.
+        raw = _read_config_strict(path)
+    except OSError:
+        _refresh_failure_at[key] = time.monotonic()
+        return None
+    try:
         rotated = _exchange_with_retry(cred, now=now)
     except Exception as exc:
         if isinstance(exc, OAuthRefreshError) and exc.permanent:
@@ -278,7 +316,7 @@ def _rotate_and_persist(
         _refresh_failure_at[key] = time.monotonic()
         logger.warning("Honcho OAuth %s failed for host %s: %s", op_label, host, redact_tokens(str(exc)))
         return None
-    _persist_credential(path, host, rotated)
+    _persist_credential(path, host, rotated, raw=raw)
     return rotated
 
 def _deep_merge(base: dict[str, Any], overlay: dict[str, Any]) -> dict[str, Any]:
@@ -290,11 +328,12 @@ def _deep_merge(base: dict[str, Any], overlay: dict[str, Any]) -> dict[str, Any]
     return base
 
 def _persist_credential(path: Path, host: str, cred: OAuthCredential, raw: dict[str, Any] | None = None) -> None:
-    """Write ``cred`` into ``host``'s block (apiKey + oauth) of ``raw`` (default:
-    the file's current content), leaving the rest intact; marks the grant live."""
+    """Write ``cred`` into ``host``'s block (apiKey + oauth) of ``raw`` (default: a strict read of the
+    file), leaving the rest intact; marks the grant live. "Leaving the rest intact" is only true when the
+    existing store was actually read, so an unreadable file raises instead of becoming a single-host file."""
     from utils import atomic_json_write
 
-    raw = _read_config(path) if raw is None else raw
+    raw = _read_config_strict(path) if raw is None else raw
     block = raw.setdefault("hosts", {}).setdefault(host, {})
     block["apiKey"], block["oauth"] = cred.access_token, cred.oauth_block()
     atomic_json_write(path, raw, mode=0o600)
@@ -380,7 +419,8 @@ def install_grant(
     ``apiKey`` and ``oauth`` block. ``apply_config=False`` stores tokens only."""
     now = time.time() if now is None else now
     cred = OAuthCredential.from_token_response(grant, now=now, client_id=client_id, token_endpoint=token_endpoint)
-    raw = _read_config(path)
+    # Strict: a fresh login must not seed its root-merge from a store that exists but could not be read.
+    raw = _read_config_strict(path)
     granted_config = grant.get("config")
     if isinstance(granted_config, dict):
         cred.consent_peer_name = granted_config.get("peerName")

--- a/plugins/memory/honcho/oauth.py
+++ b/plugins/memory/honcho/oauth.py
@@ -398,17 +398,19 @@ def install_grant(
 ) -> OAuthCredential:
     """Apply a fresh OAuth grant (an OAuthTokenResponse dict) to ``path`` for ``host``: deep-merge the
     grant's ``config`` into the file root (preserving other hosts and root keys), then write the host's
-    ``apiKey`` and ``oauth`` block. ``apply_config=False`` stores tokens only."""
+    ``apiKey`` and ``oauth`` block. ``apply_config=False`` stores tokens only. Runs under the same locks
+    as a refresh so a login cannot interleave with a sibling's read-modify-write of the file."""
     now = time.time() if now is None else now
     cred = OAuthCredential.from_token_response(grant, now=now, client_id=client_id, token_endpoint=token_endpoint)
-    # Strict: a fresh login must not seed its root-merge from a store that exists but could not be read.
-    raw = _read_config_strict(path)
-    granted_config = grant.get("config")
-    if isinstance(granted_config, dict):
-        cred.consent_peer_name = granted_config.get("peerName")
-        if apply_config:
-            _deep_merge(raw, granted_config)
-    _persist_credential(path, host, cred, raw)
+    with _refresh_lock, _config_refresh_lock(path):
+        # Strict: a fresh login must not seed its root-merge from a store that exists but could not be read.
+        raw = _read_config_strict(path)
+        granted_config = grant.get("config")
+        if isinstance(granted_config, dict):
+            cred.consent_peer_name = granted_config.get("peerName")
+            if apply_config:
+                _deep_merge(raw, granted_config)
+        _persist_credential(path, host, cred, raw)
     return cred
 
 def apply_token_to_client(client: Any, token: str) -> bool:

--- a/plugins/memory/honcho/oauth.py
+++ b/plugins/memory/honcho/oauth.py
@@ -116,34 +116,16 @@ def _read_config(path: Path) -> dict[str, Any]:
         return {}
 
 def _read_config_strict(path: Path) -> dict[str, Any]:
-    """Reader for the WRITE paths: never lets a failed read become an empty store.
-
-    A missing file is the bootstrap case and reads as ``{}``. A file that EXISTS but cannot be read
-    (EACCES after a root-owned write, EIO, a stalled mount) raises instead: ``atomic_json_write`` replaces
-    the whole file and ``os.replace`` needs only a writable parent, so degrading here would let the next
-    persist erase every other host's credentials. Genuine corruption still degrades, but only after
-    preserving a ``.corrupt`` copy: a truncated store usually holds the other hosts' tokens verbatim.
-    """
+    """Reader for the WRITE paths. A missing file reads as ``{}``. A file that exists but cannot be read
+    or parsed raises so the caller leaves it alone: ``atomic_json_write`` replaces the whole file, and a
+    write seeded from ``{}`` would erase every other host's credentials and the root keys."""
     try:
         return json.loads(path.read_text(encoding="utf-8-sig"))
     except FileNotFoundError:
         return {}
-    except OSError:
-        logger.warning("Honcho config at %s could not be read; refusing to treat it as empty "
-                       "(a persist would erase every other host's credentials)", path, exc_info=True)
+    except (OSError, ValueError) as exc:
+        logger.warning("Honcho config at %s exists but could not be read (%s); refusing to overwrite it.", path, exc)
         raise
-    except json.JSONDecodeError as exc:
-        corrupt = path.with_name(path.name + ".corrupt")
-        preserved = False
-        try:
-            import shutil
-            shutil.copy2(path, corrupt)
-            preserved = True
-        except Exception:
-            logger.debug("could not preserve a copy at %s", corrupt, exc_info=True)
-        logger.warning("Honcho config at %s is corrupt (%s); starting from an empty store. %s", path, exc,
-                       f"Original preserved at {corrupt}" if preserved else f"A copy could NOT be preserved at {corrupt}")
-        return {}
 
 def _load_cred(path: Path, host: str, raw: dict[str, Any] | None = None) -> OAuthCredential | None:
     """Credential from ``host``'s block in ``raw`` (or the file at ``path``)."""
@@ -293,7 +275,7 @@ def _rotate_and_persist(
     try:
         # Read before spending the single-use refresh token: an exchange that cannot be persisted loses the grant.
         raw = _read_config_strict(path)
-    except OSError:
+    except (OSError, ValueError):
         _refresh_failure_at[key] = time.monotonic()
         return None
     try:

--- a/plugins/memory/honcho/oauth.py
+++ b/plugins/memory/honcho/oauth.py
@@ -281,8 +281,7 @@ def _rotate_and_persist(
         rotated = _exchange_with_retry(cred, now=now)
     except Exception as exc:
         if isinstance(exc, OAuthRefreshError) and exc.permanent:
-            # The file lock is best-effort: a sibling may have rotated first, making our
-            # refresh token a replay. If disk moved on, adopt that grant instead of killing it.
+            # The file lock is best-effort: a sibling may have rotated first, so adopt what it wrote instead.
             disk = _load_cred(path, host)
             if disk is not None and disk.refresh_token != cred.refresh_token:
                 _dead_grants.pop(key, None)
@@ -357,14 +356,10 @@ def ensure_fresh_token(
             logger.info("Honcho OAuth token refreshed for host %s", host)
         return (rotated.access_token, True) if rotated is not None else (current.access_token, False)
 
-def force_refresh_token(
-    path: Path, host: str, *, failed_access_token: str | None = None
-) -> str | None:
-    """Rotate ``host``'s token now, ignoring local expiry (recovers a 401 on a
-    token the local clock still thinks is valid). ``failed_access_token`` is the
-    bearer the server rejected: when disk already holds a different one, a sibling
-    rotated the single-use refresh token first, so adopt its grant instead of
-    re-exchanging (a replay can revoke the whole grant)."""
+def force_refresh_token(path: Path, host: str, *, failed_access_token: str | None = None) -> str | None:
+    """Rotate ``host``'s token now, ignoring local expiry (recovers a 401 on a token the local clock
+    still thinks is valid). When disk no longer holds ``failed_access_token`` a sibling rotated first:
+    adopt its grant, since replaying the single-use refresh token can revoke the whole grant."""
     now = time.time()
     key = (str(path), host)
     with _refresh_lock, _config_refresh_lock(path):
@@ -375,8 +370,7 @@ def force_refresh_token(
         # Dead grant, or an exchange just failed transiently: callers fail open.
         if _grant_is_dead(key, cred) or _in_failure_cooldown(key):
             return None
-        # Disk moving off the rejected bearer is the authoritative signal: the expiry cache is
-        # empty in sibling processes and already equals disk after this process's first waiter.
+        # Disk, not the expiry cache, is the signal: the cache is empty in sibling processes.
         if failed_access_token and cred.access_token != failed_access_token and not cred.is_expired(now=now):
             _expiry_cache[key] = (cred.expires_at, cred.access_token)
             return cred.access_token
@@ -396,12 +390,11 @@ def install_grant(
 ) -> OAuthCredential:
     """Apply a fresh OAuth grant (an OAuthTokenResponse dict) to ``path`` for ``host``: deep-merge the
     grant's ``config`` into the file root (preserving other hosts and root keys), then write the host's
-    ``apiKey`` and ``oauth`` block. ``apply_config=False`` stores tokens only. Runs under the same locks
-    as a refresh so a login cannot interleave with a sibling's read-modify-write of the file."""
+    ``apiKey`` and ``oauth`` block. ``apply_config=False`` stores tokens only. Holds the refresh locks so a
+    login cannot interleave with a sibling's read-modify-write."""
     now = time.time() if now is None else now
     cred = OAuthCredential.from_token_response(grant, now=now, client_id=client_id, token_endpoint=token_endpoint)
     with _refresh_lock, _config_refresh_lock(path):
-        # Strict read: a login must not seed its root merge from a store it could not read.
         raw = _read_config_strict(path)
         granted_config = grant.get("config")
         if isinstance(granted_config, dict):

--- a/plugins/memory/honcho/session_auth.py
+++ b/plugins/memory/honcho/session_auth.py
@@ -104,7 +104,12 @@ class SessionAuthMixin:
             host = getattr(self._config, "host", "") or ""
             if not host:
                 return False
-            token = oauth.force_refresh_token(self._bound_config_path(), host)
+            # Tell the refresher which bearer 401'd so a sibling's rotation is adopted, not replayed.
+            try:
+                failed = getattr(getattr(self.honcho, "_http", None), "api_key", None)
+            except Exception:
+                failed = None
+            token = oauth.force_refresh_token(self._bound_config_path(), host, failed_access_token=failed)
             if not token:
                 return False
             if not oauth.apply_token_to_client(self.honcho, token):

--- a/plugins/memory/honcho/session_auth.py
+++ b/plugins/memory/honcho/session_auth.py
@@ -94,9 +94,11 @@ class SessionAuthMixin:
         except Exception:
             return False
 
-    def _force_reauth(self) -> bool:
+    def _force_reauth(self, failed_access_token: str | None = None) -> bool:
         """Rotate the token after a 401 and rebind the client. False for a static API key, a dead
-        grant, or a failed exchange."""
+        grant, or a failed exchange. ``failed_access_token`` is the bearer the failing operation
+        sent, snapshotted by ``_authed_call`` before it ran: the live client's ``api_key`` is
+        rotated in place by sibling waiters, so reading it here would defeat the adopt check."""
         try:
             from plugins.memory.honcho import oauth
             from plugins.memory.honcho.client import reset_honcho_client
@@ -104,12 +106,9 @@ class SessionAuthMixin:
             host = getattr(self._config, "host", "") or ""
             if not host:
                 return False
-            # Tell the refresher which bearer 401'd so a sibling's rotation is adopted, not replayed.
-            try:
-                failed = getattr(getattr(self.honcho, "_http", None), "api_key", None)
-            except Exception:
-                failed = None
-            token = oauth.force_refresh_token(self._bound_config_path(), host, failed_access_token=failed)
+            token = oauth.force_refresh_token(
+                self._bound_config_path(), host, failed_access_token=failed_access_token
+            )
             if not token:
                 return False
             if not oauth.apply_token_to_client(self.honcho, token):
@@ -132,6 +131,11 @@ class SessionAuthMixin:
             exc = HonchoAuthError(_REAUTH_REQUIRED_MESSAGE)
             self._record_auth_failure(exc)
             raise exc
+        # Snapshot the bearer first: after a 401 the client's api_key may already hold a sibling's rotation.
+        try:
+            failed_token = getattr(getattr(self.honcho, "_http", None), "api_key", None)
+        except Exception:
+            failed_token = None
         try:
             result = operation()
         except HonchoAuthError:
@@ -141,7 +145,7 @@ class SessionAuthMixin:
                 raise
             logger.warning("Honcho %s hit an auth error; forcing token refresh and retrying once: %s",
                            op_name, _redact_tokens(str(e)))
-            if not self._force_reauth():
+            if not self._force_reauth(failed_access_token=failed_token):
                 self._record_auth_failure(e)
                 raise HonchoAuthError(_auth_error_message(e)) from e
             try:

--- a/plugins/memory/honcho/session_auth.py
+++ b/plugins/memory/honcho/session_auth.py
@@ -96,9 +96,8 @@ class SessionAuthMixin:
 
     def _force_reauth(self, failed_access_token: str | None = None) -> bool:
         """Rotate the token after a 401 and rebind the client. False for a static API key, a dead
-        grant, or a failed exchange. ``failed_access_token`` is the bearer the failing operation
-        sent, snapshotted by ``_authed_call`` before it ran: the live client's ``api_key`` is
-        rotated in place by sibling waiters, so reading it here would defeat the adopt check."""
+        grant, or a failed exchange. ``failed_access_token`` is the bearer the operation sent; sibling
+        waiters rotate the live client's ``api_key`` in place, so it cannot be read back here."""
         try:
             from plugins.memory.honcho import oauth
             from plugins.memory.honcho.client import reset_honcho_client
@@ -106,9 +105,7 @@ class SessionAuthMixin:
             host = getattr(self._config, "host", "") or ""
             if not host:
                 return False
-            token = oauth.force_refresh_token(
-                self._bound_config_path(), host, failed_access_token=failed_access_token
-            )
+            token = oauth.force_refresh_token(self._bound_config_path(), host, failed_access_token=failed_access_token)
             if not token:
                 return False
             if not oauth.apply_token_to_client(self.honcho, token):

--- a/tests/honcho_plugin/test_auth_recovery.py
+++ b/tests/honcho_plugin/test_auth_recovery.py
@@ -383,7 +383,7 @@ def _make_manager(peer, *, reauth_ok=True):
     )
     mgr._cache["k"] = session
     mgr._get_or_create_peer = lambda peer_id: peer
-    mgr._force_reauth = lambda: reauth_ok
+    mgr._force_reauth = lambda **kw: reauth_ok
     return mgr
 
 
@@ -424,7 +424,7 @@ class TestDialecticAuthRetry:
         assert mgr._auth_failure is not None
 
         peer.failures = 0
-        mgr._force_reauth = lambda: True
+        mgr._force_reauth = lambda **kw: True
         assert mgr.dialectic_query("k", "q") == "synthesized answer"
         assert mgr._auth_failure is None
         assert mgr.pop_auth_notice() is None
@@ -460,6 +460,45 @@ class TestForceReauth:
         mgr = HonchoSessionManager(config=HonchoClientConfig(host="hermes"))
         assert mgr._force_reauth() is False
 
+    def test_passes_pre_call_bearer_not_the_mutated_one(self, tmp_path, monkeypatch):
+        """_authed_call snapshots the bearer BEFORE the operation runs. A
+        sibling waiter's apply_token_to_client mutates the shared client's
+        api_key in place mid-operation; if the post-mutation token were
+        passed, disk would match it and force_refresh_token would exchange
+        again — the exact burst this fix removes."""
+        from plugins.memory.honcho import client as client_mod
+        from plugins.memory.honcho import session as session_mod
+
+        http = SimpleNamespace(api_key="hch-at-old")
+        shared_client = SimpleNamespace(_http=http)
+        monkeypatch.setattr(session_mod, "get_honcho_client", lambda *a, **k: shared_client)
+        monkeypatch.setattr(client_mod, "resolve_config_path", lambda: tmp_path / "honcho.json")
+
+        seen = {}
+
+        def fake_force_refresh(p, h, *, failed_access_token=None):
+            seen["failed"] = failed_access_token
+            return "hch-at-new1"
+
+        monkeypatch.setattr(oauth, "force_refresh_token", fake_force_refresh)
+        monkeypatch.setattr(oauth, "apply_token_to_client", lambda c, t: True)
+
+        mgr = HonchoSessionManager(config=HonchoClientConfig(host="hermes", enabled=True))
+
+        calls = {"n": 0}
+
+        def operation():
+            calls["n"] += 1
+            if calls["n"] == 1:
+                # Sibling waiter rotates the shared client's bearer in place
+                # while our request is failing with the OLD token.
+                http.api_key = "hch-at-new1"
+                raise Exception("Invalid or expired access token")
+            return "ok"
+
+        assert mgr._authed_call("test op", operation) == "ok"
+        assert seen["failed"] == "hch-at-old"
+
 
 # ---------------------------------------------------------------------------
 # session: message sync 401 recovery
@@ -486,7 +525,7 @@ def _make_sync_manager(flaky_session, *, reauth_ok=True):
     peer.message.side_effect = lambda content: content
     mgr._get_or_create_peer = lambda peer_id: peer
     mgr._sessions_cache["s"] = flaky_session
-    mgr._force_reauth = lambda: reauth_ok
+    mgr._force_reauth = lambda **kw: reauth_ok
     session = HonchoSession(
         key="k", user_peer_id="u", assistant_peer_id="a", honcho_session_id="s"
     )
@@ -524,7 +563,7 @@ class TestSyncAuthRetry:
         assert mgr._flush_session(session) is False
         assert mgr._auth_failure is not None
 
-        mgr._force_reauth = lambda: True
+        mgr._force_reauth = lambda **kw: True
         assert mgr._flush_session(session) is True
         assert all(m["_synced"] for m in session.messages)
         assert mgr._auth_failure is None
@@ -782,7 +821,7 @@ class TestNonAuthFailuresNotRetried:
         _TimeoutPeer.calls = 0
         mgr = _make_manager(_TimeoutPeer())
         reauths = []
-        mgr._force_reauth = lambda: reauths.append(1) or True
+        mgr._force_reauth = lambda **kw: reauths.append(1) or True
 
         ctx = mgr.get_session_context("k")
         assert ctx == {"representation": "", "card": []}
@@ -805,7 +844,7 @@ class TestNonAuthFailuresNotRetried:
         monkeypatch.setattr(session_mod, "get_honcho_client", lambda *a, **k: client)
         mgr = _make_manager(_TimeoutSearchPeer())
         reauths = []
-        mgr._force_reauth = lambda: reauths.append(1) or True
+        mgr._force_reauth = lambda **kw: reauths.append(1) or True
 
         assert mgr.search_context("k", "q") == ""
         assert client.search.call_count == 1

--- a/tests/honcho_plugin/test_auth_recovery.py
+++ b/tests/honcho_plugin/test_auth_recovery.py
@@ -193,6 +193,101 @@ class TestForceRefreshToken:
         )
         assert oauth.force_refresh_token(path, "hermes") == "hch-at-2"
 
+    def test_serial_force_refresh_adopts_first_waiters_rotation(self, tmp_path, monkeypatch):
+        """Waiter 2 force-refreshes with the token that 401'd while disk (and
+        the expiry cache) already hold waiter 1's rotation: it must adopt
+        without a second exchange — a replayed refresh token can revoke the
+        grant."""
+        path = tmp_path / "honcho.json"
+        far = time.time() + 7200
+        _write(path, {"hosts": {"hermes": _host_block(expires_at=far)}})
+        calls = []
+
+        def exchange_once(url, data, timeout):
+            calls.append(data["refresh_token"])
+            body = _rotated_body()
+            body["expires_in"] = 7200
+            return 200, body
+
+        monkeypatch.setattr(oauth, "_http_post_form_status", exchange_once)
+        # Waiter 1: rotates for real (cache and disk now both hold new1).
+        assert (
+            oauth.force_refresh_token(path, "hermes", failed_access_token="hch-at-old")
+            == "hch-at-new1"
+        )
+        assert calls == ["hch-rt-old"]
+        # Waiter 2: was queued on the lock with the same failing token; disk
+        # has moved — must adopt, not exchange.
+        monkeypatch.setattr(
+            oauth, "_http_post_form_status",
+            lambda *a, **k: pytest.fail("second waiter must adopt, not exchange"),
+        )
+        assert (
+            oauth.force_refresh_token(path, "hermes", failed_access_token="hch-at-old")
+            == "hch-at-new1"
+        )
+
+    def test_cross_process_401_adopts_disk_with_empty_cache(self, tmp_path, monkeypatch):
+        """A sibling process rotated on disk; this process's expiry cache is
+        empty. The failing token disagreeing with disk must be enough to
+        adopt with zero HTTP."""
+        path = tmp_path / "honcho.json"
+        far = time.time() + 7200
+        rotated = _host_block(refresh="hch-rt-2", expires_at=far)
+        rotated["apiKey"] = "hch-at-2"
+        _write(path, {"hosts": {"hermes": rotated}})
+        oauth._expiry_cache.clear()
+        monkeypatch.setattr(
+            oauth, "_http_post_form_status",
+            lambda *a, **k: pytest.fail("must adopt the sibling's on-disk grant, not exchange"),
+        )
+        assert (
+            oauth.force_refresh_token(path, "hermes", failed_access_token="hch-at-old")
+            == "hch-at-2"
+        )
+        assert oauth._expiry_cache[(str(path), "hermes")][1] == "hch-at-2"
+
+    def test_invalid_grant_adopts_disk_rotated_during_exchange(self, tmp_path, monkeypatch):
+        """The exchange loses the race (endpoint says invalid_grant because a
+        sibling used the refresh token first) and the sibling persists before
+        we give up: adopt its grant, do not mark the grant dead."""
+        path = tmp_path / "honcho.json"
+        far = time.time() + 7200
+        _write(path, {"hosts": {"hermes": _host_block(expires_at=far)}})
+        monkeypatch.setattr(oauth, "_REFRESH_RETRY_DELAY_SECONDS", 0)
+
+        def lost_race(url, data, timeout):
+            # Sibling process persisted its rotation while our POST was in flight.
+            sibling = _host_block(refresh="hch-rt-sibling", expires_at=far)
+            sibling["apiKey"] = "hch-at-sibling"
+            _write(path, {"hosts": {"hermes": sibling}})
+            return 400, {"error": "invalid_grant", "error_description": "reuse detected"}
+
+        monkeypatch.setattr(oauth, "_http_post_form_status", lost_race)
+        assert (
+            oauth.force_refresh_token(path, "hermes", failed_access_token="hch-at-old")
+            == "hch-at-sibling"
+        )
+        assert oauth.reauth_required(path, "hermes") is False
+        # And the adopted grant keeps working on later calls.
+        token, _ = oauth.ensure_fresh_token(path, "hermes", now=time.time())
+        assert token == "hch-at-sibling"
+
+    def test_invalid_grant_with_unchanged_disk_still_marks_dead(self, tmp_path, monkeypatch):
+        path = tmp_path / "honcho.json"
+        far = time.time() + 7200
+        _write(path, {"hosts": {"hermes": _host_block(expires_at=far)}})
+        monkeypatch.setattr(oauth, "_REFRESH_RETRY_DELAY_SECONDS", 0)
+        monkeypatch.setattr(
+            oauth, "_http_post_form_status",
+            lambda *a, **k: (400, {"error": "invalid_grant"}),
+        )
+        assert (
+            oauth.force_refresh_token(path, "hermes", failed_access_token="hch-at-old")
+            is None
+        )
+        assert oauth.reauth_required(path, "hermes") is True
+
     def test_transient_failure_returns_none(self, tmp_path, monkeypatch):
         path = tmp_path / "honcho.json"
         _write(path, {"hosts": {"hermes": _host_block(expires_at=time.time() + 3600)}})
@@ -344,7 +439,7 @@ class TestForceReauth:
         applied = {}
         monkeypatch.setattr(session_mod, "get_honcho_client", lambda *a, **k: fake_client)
         monkeypatch.setattr(client_mod, "resolve_config_path", lambda: tmp_path / "honcho.json")
-        monkeypatch.setattr(oauth, "force_refresh_token", lambda p, h: "hch-at-new")
+        monkeypatch.setattr(oauth, "force_refresh_token", lambda p, h, **kw: "hch-at-new")
 
         def apply(client, token):
             applied["client"] = client
@@ -361,7 +456,7 @@ class TestForceReauth:
         from plugins.memory.honcho import client as client_mod
 
         monkeypatch.setattr(client_mod, "resolve_config_path", lambda: tmp_path / "honcho.json")
-        monkeypatch.setattr(oauth, "force_refresh_token", lambda p, h: None)
+        monkeypatch.setattr(oauth, "force_refresh_token", lambda p, h, **kw: None)
         mgr = HonchoSessionManager(config=HonchoClientConfig(host="hermes"))
         assert mgr._force_reauth() is False
 
@@ -731,7 +826,7 @@ def _wire_rebuild(tmp_path, monkeypatch, fresh_client):
     clients = {"current": MagicMock()}
     monkeypatch.setattr(session_mod, "get_honcho_client", lambda *a, **k: clients["current"])
     monkeypatch.setattr(client_mod, "resolve_config_path", lambda: tmp_path / "honcho.json")
-    monkeypatch.setattr(oauth, "force_refresh_token", lambda p, h: "hch-at-rotated")
+    monkeypatch.setattr(oauth, "force_refresh_token", lambda p, h, **kw: "hch-at-rotated")
     monkeypatch.setattr(oauth, "apply_token_to_client", lambda c, t: False)
     monkeypatch.setattr(
         client_mod, "reset_honcho_client",
@@ -871,7 +966,7 @@ def _wire_init(tmp_path, monkeypatch, client, *, recall_mode="hybrid", dead_refr
     monkeypatch.setattr(client_mod, "get_honcho_client", lambda *a, **k: client)
     monkeypatch.setattr(session_mod, "get_honcho_client", lambda *a, **k: client)
     if dead_refresh:
-        monkeypatch.setattr(oauth, "force_refresh_token", lambda p, h: None)
+        monkeypatch.setattr(oauth, "force_refresh_token", lambda p, h, **kw: None)
     cfg = HonchoClientConfig(
         host="hermes", api_key="hch-at-old", enabled=True, recall_mode=recall_mode,
         timeout=0.5, session_strategy="per-session",
@@ -980,7 +1075,7 @@ class TestInitAuthFailureNotice:
         client.peer.side_effect = TimeoutError("request timed out")
         _wire_init(tmp_path, monkeypatch, client, dead_refresh=False)
         reauths = []
-        monkeypatch.setattr(oauth, "force_refresh_token", lambda p, h: reauths.append(1))
+        monkeypatch.setattr(oauth, "force_refresh_token", lambda p, h, **kw: reauths.append(1))
         provider = _initialized_provider()
 
         assert provider._manager is None

--- a/tests/honcho_plugin/test_auth_recovery.py
+++ b/tests/honcho_plugin/test_auth_recovery.py
@@ -193,100 +193,43 @@ class TestForceRefreshToken:
         )
         assert oauth.force_refresh_token(path, "hermes") == "hch-at-2"
 
-    def test_serial_force_refresh_adopts_first_waiters_rotation(self, tmp_path, monkeypatch):
-        """Waiter 2 force-refreshes with the token that 401'd while disk (and
-        the expiry cache) already hold waiter 1's rotation: it must adopt
-        without a second exchange — a replayed refresh token can revoke the
-        grant."""
+    @pytest.mark.parametrize("rotated_by", ["first waiter", "sibling process"])
+    def test_401_on_a_bearer_disk_has_moved_off_adopts_without_exchange(self, tmp_path, monkeypatch, rotated_by):
+        """The failing bearer disagreeing with disk is enough to adopt: a replayed refresh token can
+        revoke the grant, and the expiry cache is empty in a sibling process."""
         path = tmp_path / "honcho.json"
         far = time.time() + 7200
         _write(path, {"hosts": {"hermes": _host_block(expires_at=far)}})
-        calls = []
+        if rotated_by == "first waiter":
+            monkeypatch.setattr(oauth, "_http_post_form_status", lambda *a, **k: (200, {**_rotated_body(2), "expires_in": 7200}))
+            assert oauth.force_refresh_token(path, "hermes", failed_access_token="hch-at-old") == "hch-at-new2"
+        else:
+            _write(path, {"hosts": {"hermes": {**_host_block(refresh="hch-rt-new2", expires_at=far), "apiKey": "hch-at-new2"}}})
+            oauth._expiry_cache.clear()
+        monkeypatch.setattr(oauth, "_http_post_form_status", lambda *a, **k: pytest.fail("must adopt the on-disk grant, not exchange"))
+        assert oauth.force_refresh_token(path, "hermes", failed_access_token="hch-at-old") == "hch-at-new2"
+        assert oauth._expiry_cache[(str(path), "hermes")][1] == "hch-at-new2"
 
-        def exchange_once(url, data, timeout):
-            calls.append(data["refresh_token"])
-            body = _rotated_body()
-            body["expires_in"] = 7200
-            return 200, body
-
-        monkeypatch.setattr(oauth, "_http_post_form_status", exchange_once)
-        # Waiter 1: rotates for real (cache and disk now both hold new1).
-        assert (
-            oauth.force_refresh_token(path, "hermes", failed_access_token="hch-at-old")
-            == "hch-at-new1"
-        )
-        assert calls == ["hch-rt-old"]
-        # Waiter 2: was queued on the lock with the same failing token; disk
-        # has moved — must adopt, not exchange.
-        monkeypatch.setattr(
-            oauth, "_http_post_form_status",
-            lambda *a, **k: pytest.fail("second waiter must adopt, not exchange"),
-        )
-        assert (
-            oauth.force_refresh_token(path, "hermes", failed_access_token="hch-at-old")
-            == "hch-at-new1"
-        )
-
-    def test_cross_process_401_adopts_disk_with_empty_cache(self, tmp_path, monkeypatch):
-        """A sibling process rotated on disk; this process's expiry cache is
-        empty. The failing token disagreeing with disk must be enough to
-        adopt with zero HTTP."""
-        path = tmp_path / "honcho.json"
-        far = time.time() + 7200
-        rotated = _host_block(refresh="hch-rt-2", expires_at=far)
-        rotated["apiKey"] = "hch-at-2"
-        _write(path, {"hosts": {"hermes": rotated}})
-        oauth._expiry_cache.clear()
-        monkeypatch.setattr(
-            oauth, "_http_post_form_status",
-            lambda *a, **k: pytest.fail("must adopt the sibling's on-disk grant, not exchange"),
-        )
-        assert (
-            oauth.force_refresh_token(path, "hermes", failed_access_token="hch-at-old")
-            == "hch-at-2"
-        )
-        assert oauth._expiry_cache[(str(path), "hermes")][1] == "hch-at-2"
-
-    def test_invalid_grant_adopts_disk_rotated_during_exchange(self, tmp_path, monkeypatch):
-        """The exchange loses the race (endpoint says invalid_grant because a
-        sibling used the refresh token first) and the sibling persists before
-        we give up: adopt its grant, do not mark the grant dead."""
+    @pytest.mark.parametrize("sibling_persists", [True, False], ids=["disk rotated during exchange", "disk unchanged"])
+    def test_invalid_grant_adopts_a_rotation_that_landed_during_the_exchange(self, tmp_path, monkeypatch, sibling_persists):
+        """The endpoint says invalid_grant because a sibling used the refresh token first. Its rotation
+        on disk is adopted; only an unchanged disk marks the grant dead."""
         path = tmp_path / "honcho.json"
         far = time.time() + 7200
         _write(path, {"hosts": {"hermes": _host_block(expires_at=far)}})
         monkeypatch.setattr(oauth, "_REFRESH_RETRY_DELAY_SECONDS", 0)
 
-        def lost_race(url, data, timeout):
-            # Sibling process persisted its rotation while our POST was in flight.
-            sibling = _host_block(refresh="hch-rt-sibling", expires_at=far)
-            sibling["apiKey"] = "hch-at-sibling"
-            _write(path, {"hosts": {"hermes": sibling}})
+        def exchange(url, data, timeout):
+            if sibling_persists:
+                _write(path, {"hosts": {"hermes": {**_host_block(refresh="hch-rt-sibling", expires_at=far), "apiKey": "hch-at-sibling"}}})
             return 400, {"error": "invalid_grant", "error_description": "reuse detected"}
 
-        monkeypatch.setattr(oauth, "_http_post_form_status", lost_race)
-        assert (
-            oauth.force_refresh_token(path, "hermes", failed_access_token="hch-at-old")
-            == "hch-at-sibling"
-        )
-        assert oauth.reauth_required(path, "hermes") is False
-        # And the adopted grant keeps working on later calls.
-        token, _ = oauth.ensure_fresh_token(path, "hermes", now=time.time())
-        assert token == "hch-at-sibling"
-
-    def test_invalid_grant_with_unchanged_disk_still_marks_dead(self, tmp_path, monkeypatch):
-        path = tmp_path / "honcho.json"
-        far = time.time() + 7200
-        _write(path, {"hosts": {"hermes": _host_block(expires_at=far)}})
-        monkeypatch.setattr(oauth, "_REFRESH_RETRY_DELAY_SECONDS", 0)
-        monkeypatch.setattr(
-            oauth, "_http_post_form_status",
-            lambda *a, **k: (400, {"error": "invalid_grant"}),
-        )
-        assert (
-            oauth.force_refresh_token(path, "hermes", failed_access_token="hch-at-old")
-            is None
-        )
-        assert oauth.reauth_required(path, "hermes") is True
+        monkeypatch.setattr(oauth, "_http_post_form_status", exchange)
+        token = oauth.force_refresh_token(path, "hermes", failed_access_token="hch-at-old")
+        assert token == ("hch-at-sibling" if sibling_persists else None)
+        assert oauth.reauth_required(path, "hermes") is (not sibling_persists)
+        if sibling_persists:
+            assert oauth.ensure_fresh_token(path, "hermes", now=time.time())[0] == "hch-at-sibling"
 
     def test_transient_failure_returns_none(self, tmp_path, monkeypatch):
         path = tmp_path / "honcho.json"
@@ -460,12 +403,9 @@ class TestForceReauth:
         mgr = HonchoSessionManager(config=HonchoClientConfig(host="hermes"))
         assert mgr._force_reauth() is False
 
-    def test_passes_pre_call_bearer_not_the_mutated_one(self, tmp_path, monkeypatch):
-        """_authed_call snapshots the bearer BEFORE the operation runs. A
-        sibling waiter's apply_token_to_client mutates the shared client's
-        api_key in place mid-operation; if the post-mutation token were
-        passed, disk would match it and force_refresh_token would exchange
-        again — the exact burst this fix removes."""
+    def test_passes_the_bearer_the_operation_sent_not_the_rotated_one(self, tmp_path, monkeypatch):
+        """A sibling waiter rotates the shared client's api_key in place while the operation fails with
+        the old bearer; passing the rotated one would match disk and exchange again."""
         from plugins.memory.honcho import client as client_mod
         from plugins.memory.honcho import session as session_mod
 
@@ -473,31 +413,19 @@ class TestForceReauth:
         shared_client = SimpleNamespace(_http=http)
         monkeypatch.setattr(session_mod, "get_honcho_client", lambda *a, **k: shared_client)
         monkeypatch.setattr(client_mod, "resolve_config_path", lambda: tmp_path / "honcho.json")
-
         seen = {}
-
-        def fake_force_refresh(p, h, *, failed_access_token=None):
-            seen["failed"] = failed_access_token
-            return "hch-at-new1"
-
-        monkeypatch.setattr(oauth, "force_refresh_token", fake_force_refresh)
+        monkeypatch.setattr(oauth, "force_refresh_token", lambda p, h, **kw: seen.update(kw) or "hch-at-new1")
         monkeypatch.setattr(oauth, "apply_token_to_client", lambda c, t: True)
-
         mgr = HonchoSessionManager(config=HonchoClientConfig(host="hermes", enabled=True))
 
-        calls = {"n": 0}
-
         def operation():
-            calls["n"] += 1
-            if calls["n"] == 1:
-                # Sibling waiter rotates the shared client's bearer in place
-                # while our request is failing with the OLD token.
+            if http.api_key == "hch-at-old":
                 http.api_key = "hch-at-new1"
                 raise Exception("Invalid or expired access token")
             return "ok"
 
         assert mgr._authed_call("test op", operation) == "ok"
-        assert seen["failed"] == "hch-at-old"
+        assert seen == {"failed_access_token": "hch-at-old"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/honcho_plugin/test_cli.py
+++ b/tests/honcho_plugin/test_cli.py
@@ -897,11 +897,22 @@ class TestEnabledRequiresACredential:
         assert honcho_cli.clone_honcho_for_profile("dreamer") is True
         assert written["cfg"]["hosts"]["hermes_dreamer"]["enabled"] is True
 
-    def test_clone_with_env_key_is_enabled(self, monkeypatch, tmp_path):
-        honcho_cli, written = self._env(monkeypatch, tmp_path, self._oauth_default())
-        monkeypatch.setenv("HONCHO_API_KEY", "hch-v3-env")
+    def test_env_key_alone_does_not_enable_a_clone(self, monkeypatch, tmp_path):
+        """A variable can vanish from the next process; only what is on disk counts at write time."""
+        cfg = {"hosts": {"hermes": {"workspace": "hermes"}}}
+        honcho_cli, written = self._env(monkeypatch, tmp_path, cfg)
+        monkeypatch.setenv("HONCHO_API_KEY", "hch-v3-from-env")
         assert honcho_cli.clone_honcho_for_profile("dreamer") is True
-        assert written["cfg"]["hosts"]["hermes_dreamer"]["enabled"] is True
+        assert "enabled" not in written["cfg"]["hosts"]["hermes_dreamer"]
+
+    def test_enable_refuses_with_only_an_env_key(self, monkeypatch, tmp_path, capsys):
+        from types import SimpleNamespace
+        cfg = {"hosts": {"hermes_dreamer": {"workspace": "hermes"}}}
+        honcho_cli, written = self._env(monkeypatch, tmp_path, cfg)
+        monkeypatch.setenv("HONCHO_API_KEY", "hch-v3-from-env")
+        honcho_cli.cmd_enable(SimpleNamespace())
+        assert written == {}
+        assert "setup" in capsys.readouterr().out
 
 
     def test_clone_with_self_hosted_url_is_enabled(self, monkeypatch, tmp_path):

--- a/tests/honcho_plugin/test_cli.py
+++ b/tests/honcho_plugin/test_cli.py
@@ -774,12 +774,11 @@ class TestWriteRefusesUnparseableStore:
         honcho_cli._write_config({"apiKey": "k"})
         assert json.loads(cfg_path.read_text(encoding="utf-8")) == {"apiKey": "k"}
 
-    def test_enable_prints_one_sentence_and_writes_nothing(self, monkeypatch, tmp_path, capsys):
+    def test_command_prints_one_sentence_and_writes_nothing(self, monkeypatch, tmp_path, capsys):
         cfg_path = tmp_path / "honcho.json"
         cfg_path.write_text("{not json", encoding="utf-8")
         honcho_cli = self._point_at(monkeypatch, cfg_path)
-        monkeypatch.setenv("HONCHO_API_KEY", "env-key")
-        honcho_cli.honcho_command(SimpleNamespace(honcho_command="enable", target_profile=None))
+        honcho_cli.honcho_command(SimpleNamespace(honcho_command="mode", mode="tools", target_profile=None))
         out = capsys.readouterr().out
         assert "could not be read as JSON" in out
         assert "Nothing was written" in out
@@ -904,6 +903,7 @@ class TestEnabledRequiresACredential:
         assert honcho_cli.clone_honcho_for_profile("dreamer") is True
         assert written["cfg"]["hosts"]["hermes_dreamer"]["enabled"] is True
 
+
     def test_clone_with_self_hosted_url_is_enabled(self, monkeypatch, tmp_path):
         cfg = {"baseUrl": "http://localhost:8000", "hosts": {"hermes": {"workspace": "hermes"}}}
         honcho_cli, written = self._env(monkeypatch, tmp_path, cfg)
@@ -942,3 +942,82 @@ class TestEnabledRequiresACredential:
         out = capsys.readouterr().out
         assert "Run 'hermes honcho setup' to sign in" in out
         assert written == {}
+
+
+class TestWriteConfigMergesOntoDisk:
+    """A command reads honcho.json, works, then writes. A refresh in another process may have rotated
+    the token in between; the write must keep that rotation and apply only the command's own edits."""
+
+    def _paths(self, monkeypatch, tmp_path, disk):
+        import plugins.memory.honcho.cli as honcho_cli
+        cfg_path = tmp_path / "honcho.json"
+        cfg_path.write_text(json.dumps(disk))
+        monkeypatch.setattr(honcho_cli, "_config_path", lambda: cfg_path)
+        monkeypatch.setattr(honcho_cli, "_local_config_path", lambda: cfg_path)
+        return honcho_cli, cfg_path
+
+    def _rotated(self, cfg_path, disk):
+        disk["hosts"]["hermes"]["apiKey"] = "hch-at-new"
+        disk["hosts"]["hermes"]["oauth"] = {"refreshToken": "hch-rt-new"}
+        cfg_path.write_text(json.dumps(disk))
+
+    def test_rotation_between_read_and_write_survives(self, monkeypatch, tmp_path):
+        disk = {"apiKey": "root", "hosts": {"hermes": {"apiKey": "hch-at-old", "oauth": {"refreshToken": "hch-rt-old"},
+                                                     "recallMode": "hybrid"}}}
+        honcho_cli, cfg_path = self._paths(monkeypatch, tmp_path, disk)
+        cfg = honcho_cli._read_config()
+        self._rotated(cfg_path, json.loads(cfg_path.read_text()))
+        cfg["hosts"]["hermes"]["recallMode"] = "tools"
+        cfg["dialecticCadence"] = 3
+        honcho_cli._write_config(cfg)
+        out = json.loads(cfg_path.read_text())
+        assert out["hosts"]["hermes"]["apiKey"] == "hch-at-new"
+        assert out["hosts"]["hermes"]["oauth"] == {"refreshToken": "hch-rt-new"}
+        assert out["hosts"]["hermes"]["recallMode"] == "tools" and out["dialecticCadence"] == 3
+
+    def test_a_credential_the_command_set_wins(self, monkeypatch, tmp_path):
+        disk = {"hosts": {"hermes": {"apiKey": "hch-at-old", "oauth": {"refreshToken": "hch-rt-old"}}}}
+        honcho_cli, cfg_path = self._paths(monkeypatch, tmp_path, disk)
+        cfg = honcho_cli._read_config()
+        self._rotated(cfg_path, json.loads(cfg_path.read_text()))
+        cfg["hosts"]["hermes"]["apiKey"] = "hch-v3-pasted"
+        cfg["hosts"]["hermes"].pop("oauth")
+        honcho_cli._write_config(cfg)
+        out = json.loads(cfg_path.read_text())
+        assert out["hosts"]["hermes"]["apiKey"] == "hch-v3-pasted" and "oauth" not in out["hosts"]["hermes"]
+
+    def test_a_key_the_command_removed_is_removed(self, monkeypatch, tmp_path):
+        disk = {"hosts": {"hermes": {"apiKey": "k", "runtimePeerPrefix": "tg_"}}}
+        honcho_cli, cfg_path = self._paths(monkeypatch, tmp_path, disk)
+        cfg = honcho_cli._read_config()
+        cfg["hosts"]["hermes"].pop("runtimePeerPrefix")
+        honcho_cli._write_config(cfg)
+        assert "runtimePeerPrefix" not in json.loads(cfg_path.read_text())["hosts"]["hermes"]
+
+    def test_write_without_a_prior_read_writes_the_whole_config(self, monkeypatch, tmp_path):
+        honcho_cli, cfg_path = self._paths(monkeypatch, tmp_path, {"hosts": {"hermes": {"apiKey": "k"}}})
+        honcho_cli._write_config({"hosts": {"other": {"apiKey": "o"}}})
+        assert json.loads(cfg_path.read_text()) == {"hosts": {"other": {"apiKey": "o"}}}
+
+    def test_a_rebuilt_plain_dict_is_written_whole(self, monkeypatch, tmp_path):
+        disk = {"hosts": {"hermes": {"apiKey": "hch-at-old", "recallMode": "hybrid"}}}
+        honcho_cli, cfg_path = self._paths(monkeypatch, tmp_path, disk)
+        cfg = dict(honcho_cli._read_config())
+        self._rotated(cfg_path, json.loads(cfg_path.read_text()))
+        honcho_cli._write_config(cfg)
+        assert json.loads(cfg_path.read_text())["hosts"]["hermes"]["apiKey"] == "hch-at-old"
+
+    def test_write_holds_the_refresh_file_lock(self, monkeypatch, tmp_path):
+        import contextlib
+        import plugins.memory.honcho.oauth as oauth
+        honcho_cli, cfg_path = self._paths(monkeypatch, tmp_path, {})
+        locked = []
+
+        @contextlib.contextmanager
+        def _lock(path):
+            locked.append(path)
+            yield
+
+        monkeypatch.setattr(oauth, "_config_refresh_lock", _lock)
+        honcho_cli._write_config({"apiKey": "k"})
+        assert locked == [cfg_path]

--- a/tests/honcho_plugin/test_cli.py
+++ b/tests/honcho_plugin/test_cli.py
@@ -848,3 +848,97 @@ class TestSetupApiKeyReplacesStaleGrant:
         assert ok is True
         assert host["apiKey"] == "hch-v3-hostkey"
         assert "apiKey" not in cfg
+
+
+class TestEnabledRequiresACredential:
+    """A host block must not be written with enabled: true unless it can authenticate. The default
+    host's apiKey is not inherited by named profiles (#66125), so a clone of an OAuth-authenticated
+    default block, or an enable on an empty block, has nothing to sign requests with."""
+
+    def _env(self, monkeypatch, tmp_path, cfg, *, host="hermes_dreamer", profile="dreamer"):
+        import plugins.memory.honcho.cli as honcho_cli
+        cfg_path = tmp_path / "honcho.json"
+        cfg_path.write_text("{}")
+        monkeypatch.delenv("HONCHO_API_KEY", raising=False)
+        monkeypatch.delenv("HONCHO_BASE_URL", raising=False)
+        monkeypatch.setattr(honcho_cli, "_read_config", lambda: cfg)
+        monkeypatch.setattr(honcho_cli, "_config_path", lambda: cfg_path)
+        monkeypatch.setattr(honcho_cli, "_local_config_path", lambda: cfg_path)
+        monkeypatch.setattr(honcho_cli, "_host_key", lambda: host)
+        monkeypatch.setattr(honcho_cli, "_active_profile_name", lambda: profile)
+        monkeypatch.setattr(honcho_cli, "_ensure_peer_exists", lambda host_key=None: True)
+        written = {}
+        monkeypatch.setattr(honcho_cli, "_write_config", lambda c, path=None: written.setdefault("cfg", c))
+        return honcho_cli, written
+
+    def _oauth_default(self):
+        return {"peerName": "eri", "hosts": {"hermes": {
+            "enabled": True, "apiKey": "hch-at-live", "workspace": "hermes", "peerName": "eri",
+            "oauth": {"refreshToken": "hch-rt-live", "expiresAt": 9e9, "clientId": "hermes-agent",
+                      "tokenEndpoint": "https://api.honcho.dev/oauth/token"},
+        }}}
+
+    def test_clone_from_oauth_default_is_written_without_enabled(self, monkeypatch, tmp_path):
+        honcho_cli, written = self._env(monkeypatch, tmp_path, self._oauth_default())
+        assert honcho_cli.clone_honcho_for_profile("dreamer") is True
+        block = written["cfg"]["hosts"]["hermes_dreamer"]
+        assert "enabled" not in block
+        assert "apiKey" not in block and "oauth" not in block
+        assert block["aiPeer"] == "dreamer" and block["workspace"] == "hermes"
+
+    def test_clone_from_host_only_static_key_is_written_without_enabled(self, monkeypatch, tmp_path):
+        cfg = {"hosts": {"hermes": {"enabled": True, "apiKey": "hch-v3-hostonly", "workspace": "hermes"}}}
+        honcho_cli, written = self._env(monkeypatch, tmp_path, cfg)
+        assert honcho_cli.clone_honcho_for_profile("dreamer") is True
+        assert "enabled" not in written["cfg"]["hosts"]["hermes_dreamer"]
+
+    def test_clone_with_root_key_is_enabled(self, monkeypatch, tmp_path):
+        cfg = {"apiKey": "hch-v3-root", "hosts": {"hermes": {"workspace": "hermes"}}}
+        honcho_cli, written = self._env(monkeypatch, tmp_path, cfg)
+        assert honcho_cli.clone_honcho_for_profile("dreamer") is True
+        assert written["cfg"]["hosts"]["hermes_dreamer"]["enabled"] is True
+
+    def test_clone_with_env_key_is_enabled(self, monkeypatch, tmp_path):
+        honcho_cli, written = self._env(monkeypatch, tmp_path, self._oauth_default())
+        monkeypatch.setenv("HONCHO_API_KEY", "hch-v3-env")
+        assert honcho_cli.clone_honcho_for_profile("dreamer") is True
+        assert written["cfg"]["hosts"]["hermes_dreamer"]["enabled"] is True
+
+    def test_clone_with_self_hosted_url_is_enabled(self, monkeypatch, tmp_path):
+        cfg = {"baseUrl": "http://localhost:8000", "hosts": {"hermes": {"workspace": "hermes"}}}
+        honcho_cli, written = self._env(monkeypatch, tmp_path, cfg)
+        assert honcho_cli.clone_honcho_for_profile("dreamer") is True
+        assert written["cfg"]["hosts"]["hermes_dreamer"]["enabled"] is True
+
+    def test_enable_on_empty_block_refuses_and_writes_nothing(self, monkeypatch, tmp_path, capsys):
+        honcho_cli, written = self._env(monkeypatch, tmp_path, self._oauth_default())
+        honcho_cli.cmd_enable(SimpleNamespace())
+        out = capsys.readouterr().out
+        assert "stays disabled" in out
+        assert "hermes honcho setup --target-profile dreamer" in out
+        assert "hosts.hermes_dreamer" in out
+        assert written == {}
+
+    def test_enable_on_legacy_enabled_keyless_block_explains_instead_of_already_enabled(self, monkeypatch, tmp_path, capsys):
+        cfg = self._oauth_default()
+        cfg["hosts"]["hermes_dreamer"] = {"enabled": True, "aiPeer": "dreamer", "workspace": "hermes", "peerName": "eri"}
+        honcho_cli, written = self._env(monkeypatch, tmp_path, cfg)
+        honcho_cli.cmd_enable(SimpleNamespace())
+        out = capsys.readouterr().out
+        assert "stays disabled" in out
+        assert "already enabled" not in out
+        assert written == {}
+
+    def test_enable_with_root_key_still_enables(self, monkeypatch, tmp_path, capsys):
+        cfg = {"apiKey": "hch-v3-root", "hosts": {"hermes": {"workspace": "hermes"}}}
+        honcho_cli, written = self._env(monkeypatch, tmp_path, cfg)
+        honcho_cli.cmd_enable(SimpleNamespace())
+        assert "Honcho enabled" in capsys.readouterr().out
+        assert written["cfg"]["hosts"]["hermes_dreamer"]["enabled"] is True
+
+    def test_enable_on_default_profile_hint_omits_target_profile(self, monkeypatch, tmp_path, capsys):
+        honcho_cli, written = self._env(monkeypatch, tmp_path, {"hosts": {}}, host="hermes", profile="default")
+        honcho_cli.cmd_enable(SimpleNamespace())
+        out = capsys.readouterr().out
+        assert "Run 'hermes honcho setup' to sign in" in out
+        assert written == {}

--- a/tests/honcho_plugin/test_cli.py
+++ b/tests/honcho_plugin/test_cli.py
@@ -3,6 +3,8 @@
 from types import SimpleNamespace
 import json
 
+import pytest
+
 
 class TestResolveApiKey:
     """Test _resolve_api_key with various config shapes."""
@@ -744,3 +746,50 @@ class TestCmdSetupDeviceFlow:
         assert len(calls) == 1
         assert "apiKey" not in cfg.get("hosts", {}).get("hermes", {})
 
+
+
+class TestWriteRefusesUnparseableStore:
+    """A honcho.json that exists but does not parse reads as {} on the tolerant path. Writing that
+    back would replace every host and root key with the current command's block, so writes refuse."""
+
+    def _point_at(self, monkeypatch, cfg_path):
+        import plugins.memory.honcho.cli as honcho_cli
+        monkeypatch.setattr(honcho_cli, "_config_path", lambda: cfg_path)
+        monkeypatch.setattr(honcho_cli, "_local_config_path", lambda: cfg_path)
+        monkeypatch.setattr(honcho_cli, "_host_key", lambda: "hermes_coder")
+        monkeypatch.setattr(honcho_cli, "_ensure_peer_exists", lambda host_key=None: False)
+        return honcho_cli
+
+    def test_write_config_refuses_and_leaves_file_alone(self, monkeypatch, tmp_path):
+        cfg_path = tmp_path / "honcho.json"
+        cfg_path.write_text('{"hosts": {"hermes": {"apiKey": "k"', encoding="utf-8")
+        honcho_cli = self._point_at(monkeypatch, cfg_path)
+        with pytest.raises(honcho_cli.ConfigWriteRefused):
+            honcho_cli._write_config({"hosts": {"hermes_coder": {"enabled": True}}})
+        assert cfg_path.read_text(encoding="utf-8") == '{"hosts": {"hermes": {"apiKey": "k"'
+
+    def test_write_config_still_bootstraps_a_missing_file(self, monkeypatch, tmp_path):
+        cfg_path = tmp_path / "honcho.json"
+        honcho_cli = self._point_at(monkeypatch, cfg_path)
+        honcho_cli._write_config({"apiKey": "k"})
+        assert json.loads(cfg_path.read_text(encoding="utf-8")) == {"apiKey": "k"}
+
+    def test_enable_prints_one_sentence_and_writes_nothing(self, monkeypatch, tmp_path, capsys):
+        cfg_path = tmp_path / "honcho.json"
+        cfg_path.write_text("{not json", encoding="utf-8")
+        honcho_cli = self._point_at(monkeypatch, cfg_path)
+        monkeypatch.setenv("HONCHO_API_KEY", "env-key")
+        honcho_cli.honcho_command(SimpleNamespace(honcho_command="enable", target_profile=None))
+        out = capsys.readouterr().out
+        assert "could not be read as JSON" in out
+        assert "Nothing was written" in out
+        assert cfg_path.read_text(encoding="utf-8") == "{not json"
+
+    def test_setup_refuses_before_asking_anything(self, monkeypatch, tmp_path, capsys):
+        cfg_path = tmp_path / "honcho.json"
+        cfg_path.write_text("{not json", encoding="utf-8")
+        honcho_cli = self._point_at(monkeypatch, cfg_path)
+        monkeypatch.setattr(honcho_cli, "_prompt", lambda *a, **k: pytest.fail("wizard asked a question"))
+        honcho_cli.cmd_setup(SimpleNamespace())
+        assert "Nothing was written" in capsys.readouterr().out
+        assert cfg_path.read_text(encoding="utf-8") == "{not json"

--- a/tests/honcho_plugin/test_cli.py
+++ b/tests/honcho_plugin/test_cli.py
@@ -793,3 +793,58 @@ class TestWriteRefusesUnparseableStore:
         honcho_cli.cmd_setup(SimpleNamespace())
         assert "Nothing was written" in capsys.readouterr().out
         assert cfg_path.read_text(encoding="utf-8") == "{not json"
+
+
+class TestSetupApiKeyReplacesStaleGrant:
+    """#97990: choosing apikey after a revoked grant left hosts.<name>.oauth in place, so the dead
+    grant kept shadowing the fresh key across every later setup run."""
+
+    def _cfg_with_grant(self):
+        return {"hosts": {"hermes": {
+            "apiKey": "hch-at-dead",
+            "oauth": {"refreshToken": "hch-rt-dead", "expiresAt": 1, "clientId": "hermes-agent",
+                      "tokenEndpoint": "https://api.honcho.dev/oauth/token"},
+        }}}
+
+    def _cloud_auth(self, monkeypatch, tmp_path, cfg, *, key_answer):
+        import plugins.memory.honcho.cli as honcho_cli
+        monkeypatch.setattr(honcho_cli, "_device_login_available", lambda: False)
+        monkeypatch.setattr(honcho_cli, "_headless", lambda: (False, True))
+        shown = []
+
+        def _prompt(label, default=None, secret=False):
+            shown.append(label)
+            return "apikey" if "OAuth" in label else key_answer
+        monkeypatch.setattr(honcho_cli, "_prompt", _prompt)
+        ok = honcho_cli._setup_cloud_auth(cfg, cfg["hosts"]["hermes"], tmp_path / "honcho.json")
+        return ok, cfg["hosts"]["hermes"]
+
+    def test_new_key_clears_oauth_and_lands_on_the_host_block(self, monkeypatch, tmp_path):
+        cfg = self._cfg_with_grant()
+        ok, host = self._cloud_auth(monkeypatch, tmp_path, cfg, key_answer="hch-v3-fresh")
+        assert ok is True
+        assert "oauth" not in host
+        assert host["apiKey"] == "hch-v3-fresh"
+        assert cfg["apiKey"] == "hch-v3-fresh"
+
+    def test_kept_root_key_still_clears_oauth(self, monkeypatch, tmp_path, capsys):
+        cfg = self._cfg_with_grant()
+        cfg["apiKey"] = "hch-v3-rootkey"
+        ok, host = self._cloud_auth(monkeypatch, tmp_path, cfg, key_answer="")
+        assert ok is True
+        assert "oauth" not in host
+        assert host["apiKey"] == "hch-v3-rootkey"
+        assert "...-rootkey" in capsys.readouterr().out
+
+    def test_dead_access_token_is_not_offered_as_current(self, monkeypatch, tmp_path, capsys):
+        cfg = self._cfg_with_grant()
+        ok, host = self._cloud_auth(monkeypatch, tmp_path, cfg, key_answer="")
+        assert ok is False
+        assert "Current API key: not set" in capsys.readouterr().out
+
+    def test_static_host_key_without_grant_is_kept(self, monkeypatch, tmp_path):
+        cfg = {"hosts": {"hermes": {"apiKey": "hch-v3-hostkey"}}}
+        ok, host = self._cloud_auth(monkeypatch, tmp_path, cfg, key_answer="")
+        assert ok is True
+        assert host["apiKey"] == "hch-v3-hostkey"
+        assert "apiKey" not in cfg

--- a/tests/honcho_plugin/test_cli.py
+++ b/tests/honcho_plugin/test_cli.py
@@ -892,6 +892,18 @@ class TestWriteConfigMergesOntoDisk:
         honcho_cli._write_config(cfg)
         assert json.loads(cfg_path.read_text())["hosts"]["hermes"] == {"apiKey": "hch-v3-pasted"}
 
+    def test_a_second_write_on_the_same_read_applies_only_the_edits_made_since_the_first(self, monkeypatch, tmp_path):
+        disk = {"hosts": {"hermes": {"apiKey": "hch-at-old", "oauth": {"refreshToken": "hch-rt-old"}, "workspace": "A"}}}
+        honcho_cli, cfg_path = self._paths(monkeypatch, tmp_path, disk)
+        cfg = honcho_cli._read_config()
+        cfg["hosts"]["hermes"]["workspace"] = "B"
+        honcho_cli._write_config(cfg)
+        self._rotate_on_disk(cfg_path)
+        cfg["hosts"]["hermes"]["workspace"] = "A"
+        honcho_cli._write_config(cfg)
+        out = json.loads(cfg_path.read_text())["hosts"]["hermes"]
+        assert out == {"apiKey": "hch-at-new", "oauth": {"refreshToken": "hch-rt-new"}, "workspace": "A"}
+
     def test_a_grant_the_login_installed_yields_to_a_later_rotation(self, monkeypatch, tmp_path):
         import plugins.memory.honcho.oauth as oauth
         honcho_cli, cfg_path = self._paths(monkeypatch, tmp_path, {"hosts": {"hermes": {"peerName": "alice"}}})

--- a/tests/honcho_plugin/test_cli.py
+++ b/tests/honcho_plugin/test_cli.py
@@ -747,288 +747,165 @@ class TestCmdSetupDeviceFlow:
         assert "apiKey" not in cfg.get("hosts", {}).get("hermes", {})
 
 
+def _point_cli_at(monkeypatch, cfg_path, **attrs):
+    """Route the honcho CLI's config reads and writes at ``cfg_path``; ``attrs`` replace other module names."""
+    import plugins.memory.honcho.cli as honcho_cli
+    for name, value in {"_config_path": lambda: cfg_path, "_local_config_path": lambda: cfg_path, **attrs}.items():
+        monkeypatch.setattr(honcho_cli, name, value)
+    return honcho_cli
+
 
 class TestWriteRefusesUnparseableStore:
-    """A honcho.json that exists but does not parse reads as {} on the tolerant path. Writing that
-    back would replace every host and root key with the current command's block, so writes refuse."""
+    """An unparseable honcho.json reads as {} on the tolerant path; writing that back would drop every other host."""
 
-    def _point_at(self, monkeypatch, cfg_path):
-        import plugins.memory.honcho.cli as honcho_cli
-        monkeypatch.setattr(honcho_cli, "_config_path", lambda: cfg_path)
-        monkeypatch.setattr(honcho_cli, "_local_config_path", lambda: cfg_path)
-        monkeypatch.setattr(honcho_cli, "_host_key", lambda: "hermes_coder")
-        monkeypatch.setattr(honcho_cli, "_ensure_peer_exists", lambda host_key=None: False)
-        return honcho_cli
-
-    def test_write_config_refuses_and_leaves_file_alone(self, monkeypatch, tmp_path):
-        cfg_path = tmp_path / "honcho.json"
-        cfg_path.write_text('{"hosts": {"hermes": {"apiKey": "k"', encoding="utf-8")
-        honcho_cli = self._point_at(monkeypatch, cfg_path)
-        with pytest.raises(honcho_cli.ConfigWriteRefused):
-            honcho_cli._write_config({"hosts": {"hermes_coder": {"enabled": True}}})
-        assert cfg_path.read_text(encoding="utf-8") == '{"hosts": {"hermes": {"apiKey": "k"'
-
-    def test_write_config_still_bootstraps_a_missing_file(self, monkeypatch, tmp_path):
-        cfg_path = tmp_path / "honcho.json"
-        honcho_cli = self._point_at(monkeypatch, cfg_path)
-        honcho_cli._write_config({"apiKey": "k"})
-        assert json.loads(cfg_path.read_text(encoding="utf-8")) == {"apiKey": "k"}
-
-    def test_command_prints_one_sentence_and_writes_nothing(self, monkeypatch, tmp_path, capsys):
+    @pytest.mark.parametrize("run", [
+        lambda cli: cli.honcho_command(SimpleNamespace(honcho_command="mode", mode="tools", target_profile=None)),
+        lambda cli: cli.cmd_setup(SimpleNamespace()),
+    ], ids=["command", "setup"])
+    def test_command_prints_one_sentence_asks_nothing_and_writes_nothing(self, monkeypatch, tmp_path, capsys, run):
         cfg_path = tmp_path / "honcho.json"
         cfg_path.write_text("{not json", encoding="utf-8")
-        honcho_cli = self._point_at(monkeypatch, cfg_path)
-        honcho_cli.honcho_command(SimpleNamespace(honcho_command="mode", mode="tools", target_profile=None))
+        honcho_cli = _point_cli_at(monkeypatch, cfg_path, _host_key=lambda: "hermes_coder",
+                                   _prompt=lambda *a, **k: pytest.fail("asked a question"))
+        run(honcho_cli)
         out = capsys.readouterr().out
-        assert "could not be read as JSON" in out
-        assert "Nothing was written" in out
-        assert cfg_path.read_text(encoding="utf-8") == "{not json"
-
-    def test_setup_refuses_before_asking_anything(self, monkeypatch, tmp_path, capsys):
-        cfg_path = tmp_path / "honcho.json"
-        cfg_path.write_text("{not json", encoding="utf-8")
-        honcho_cli = self._point_at(monkeypatch, cfg_path)
-        monkeypatch.setattr(honcho_cli, "_prompt", lambda *a, **k: pytest.fail("wizard asked a question"))
-        honcho_cli.cmd_setup(SimpleNamespace())
-        assert "Nothing was written" in capsys.readouterr().out
+        assert "could not be read as JSON" in out and "Nothing was written" in out
         assert cfg_path.read_text(encoding="utf-8") == "{not json"
 
 
 class TestSetupApiKeyReplacesStaleGrant:
-    """#97990: choosing apikey after a revoked grant left hosts.<name>.oauth in place, so the dead
-    grant kept shadowing the fresh key across every later setup run."""
+    """Choosing apikey after a revoked grant left hosts.<name>.oauth in place, shadowing the fresh key."""
 
-    def _cfg_with_grant(self):
-        return {"hosts": {"hermes": {
-            "apiKey": "hch-at-dead",
-            "oauth": {"refreshToken": "hch-rt-dead", "expiresAt": 1, "clientId": "hermes-agent",
-                      "tokenEndpoint": "https://api.honcho.dev/oauth/token"},
-        }}}
+    @pytest.mark.parametrize("grant, root_key, answer, ok, host_key, root_after, shown", [
+        (True, None, "hch-v3-fresh", True, "hch-v3-fresh", "hch-v3-fresh", ""),
+        (True, "hch-v3-rootkey", "", True, "hch-v3-rootkey", "hch-v3-rootkey", "...-rootkey"),
+        (True, None, "", False, "hch-at-dead", None, "Current API key: not set"),
+        (False, None, "", True, "hch-v3-hostkey", None, ""),
+    ], ids=["new key clears oauth", "kept root key clears oauth", "dead access token not offered", "static host key kept"])
+    def test_apikey_answer(self, monkeypatch, tmp_path, capsys, grant, root_key, answer, ok, host_key, root_after, shown):
+        host = {"apiKey": "hch-v3-hostkey"}
+        if grant:
+            host = {"apiKey": "hch-at-dead", "oauth": {"refreshToken": "hch-rt-dead", "expiresAt": 1,
+                                                       "clientId": "hermes-agent", "tokenEndpoint": "https://api.honcho.dev/oauth/token"}}
+        cfg = {"hosts": {"hermes": host}, **({"apiKey": root_key} if root_key else {})}
+        honcho_cli = _point_cli_at(monkeypatch, tmp_path / "honcho.json", _device_login_available=lambda: False,
+                                   _headless=lambda: (False, True),
+                                   _prompt=lambda label, default=None, secret=False: "apikey" if "OAuth" in label else answer)
+        assert honcho_cli._setup_cloud_auth(cfg, host, tmp_path / "honcho.json") is ok
+        assert host["apiKey"] == host_key and cfg.get("apiKey") == root_after
+        assert ("oauth" in host) is (grant and not ok)
+        assert shown in capsys.readouterr().out
 
-    def _cloud_auth(self, monkeypatch, tmp_path, cfg, *, key_answer):
-        import plugins.memory.honcho.cli as honcho_cli
-        monkeypatch.setattr(honcho_cli, "_device_login_available", lambda: False)
-        monkeypatch.setattr(honcho_cli, "_headless", lambda: (False, True))
-        shown = []
 
-        def _prompt(label, default=None, secret=False):
-            shown.append(label)
-            return "apikey" if "OAuth" in label else key_answer
-        monkeypatch.setattr(honcho_cli, "_prompt", _prompt)
-        ok = honcho_cli._setup_cloud_auth(cfg, cfg["hosts"]["hermes"], tmp_path / "honcho.json")
-        return ok, cfg["hosts"]["hermes"]
-
-    def test_new_key_clears_oauth_and_lands_on_the_host_block(self, monkeypatch, tmp_path):
-        cfg = self._cfg_with_grant()
-        ok, host = self._cloud_auth(monkeypatch, tmp_path, cfg, key_answer="hch-v3-fresh")
-        assert ok is True
-        assert "oauth" not in host
-        assert host["apiKey"] == "hch-v3-fresh"
-        assert cfg["apiKey"] == "hch-v3-fresh"
-
-    def test_kept_root_key_still_clears_oauth(self, monkeypatch, tmp_path, capsys):
-        cfg = self._cfg_with_grant()
-        cfg["apiKey"] = "hch-v3-rootkey"
-        ok, host = self._cloud_auth(monkeypatch, tmp_path, cfg, key_answer="")
-        assert ok is True
-        assert "oauth" not in host
-        assert host["apiKey"] == "hch-v3-rootkey"
-        assert "...-rootkey" in capsys.readouterr().out
-
-    def test_dead_access_token_is_not_offered_as_current(self, monkeypatch, tmp_path, capsys):
-        cfg = self._cfg_with_grant()
-        ok, host = self._cloud_auth(monkeypatch, tmp_path, cfg, key_answer="")
-        assert ok is False
-        assert "Current API key: not set" in capsys.readouterr().out
-
-    def test_static_host_key_without_grant_is_kept(self, monkeypatch, tmp_path):
-        cfg = {"hosts": {"hermes": {"apiKey": "hch-v3-hostkey"}}}
-        ok, host = self._cloud_auth(monkeypatch, tmp_path, cfg, key_answer="")
-        assert ok is True
-        assert host["apiKey"] == "hch-v3-hostkey"
-        assert "apiKey" not in cfg
+_OAUTH_DEFAULT = {"peerName": "eri", "hosts": {"hermes": {
+    "enabled": True, "apiKey": "hch-at-live", "workspace": "hermes", "peerName": "eri", "oauth": {"refreshToken": "hch-rt-live"},
+}}}
+_KEYLESS_DEFAULT = {"hosts": {"hermes": {"workspace": "hermes"}}}
 
 
 class TestEnabledRequiresACredential:
-    """A host block must not be written with enabled: true unless it can authenticate. The default
-    host's apiKey is not inherited by named profiles (#66125), so a clone of an OAuth-authenticated
-    default block, or an enable on an empty block, has nothing to sign requests with."""
+    """A host block is written with enabled: true only when it can authenticate. Named profiles do not
+    inherit the default host's apiKey, so a clone of an OAuth default block has nothing to sign with."""
 
-    def _env(self, monkeypatch, tmp_path, cfg, *, host="hermes_dreamer", profile="dreamer"):
-        import plugins.memory.honcho.cli as honcho_cli
+    def _env(self, monkeypatch, tmp_path, cfg, *, env_key=None, host="hermes_dreamer", profile="dreamer"):
+        import copy
+        cfg, written = copy.deepcopy(cfg), {}
         cfg_path = tmp_path / "honcho.json"
         cfg_path.write_text("{}")
         monkeypatch.delenv("HONCHO_API_KEY", raising=False)
         monkeypatch.delenv("HONCHO_BASE_URL", raising=False)
-        monkeypatch.setattr(honcho_cli, "_read_config", lambda: cfg)
-        monkeypatch.setattr(honcho_cli, "_config_path", lambda: cfg_path)
-        monkeypatch.setattr(honcho_cli, "_local_config_path", lambda: cfg_path)
-        monkeypatch.setattr(honcho_cli, "_host_key", lambda: host)
-        monkeypatch.setattr(honcho_cli, "_active_profile_name", lambda: profile)
-        monkeypatch.setattr(honcho_cli, "_ensure_peer_exists", lambda host_key=None: True)
-        written = {}
-        monkeypatch.setattr(honcho_cli, "_write_config", lambda c, path=None: written.setdefault("cfg", c))
+        if env_key:
+            monkeypatch.setenv("HONCHO_API_KEY", env_key)
+        honcho_cli = _point_cli_at(
+            monkeypatch, cfg_path, _read_config=lambda: cfg, _host_key=lambda: host, _active_profile_name=lambda: profile,
+            _ensure_peer_exists=lambda host_key=None: True, _write_config=lambda c, path=None: written.setdefault("cfg", c))
         return honcho_cli, written
 
-    def _oauth_default(self):
-        return {"peerName": "eri", "hosts": {"hermes": {
-            "enabled": True, "apiKey": "hch-at-live", "workspace": "hermes", "peerName": "eri",
-            "oauth": {"refreshToken": "hch-rt-live", "expiresAt": 9e9, "clientId": "hermes-agent",
-                      "tokenEndpoint": "https://api.honcho.dev/oauth/token"},
-        }}}
-
-    def test_clone_from_oauth_default_is_written_without_enabled(self, monkeypatch, tmp_path):
-        honcho_cli, written = self._env(monkeypatch, tmp_path, self._oauth_default())
+    @pytest.mark.parametrize("cfg, env_key, enabled", [
+        (_OAUTH_DEFAULT, None, False),
+        ({"hosts": {"hermes": {"enabled": True, "apiKey": "hch-v3-hostonly", "workspace": "hermes"}}}, None, False),
+        ({"apiKey": "hch-v3-root", **_KEYLESS_DEFAULT}, None, True),
+        (_KEYLESS_DEFAULT, "hch-v3-from-env", False),
+        ({"baseUrl": "http://localhost:8000", **_KEYLESS_DEFAULT}, None, True),
+    ], ids=["oauth default", "host-only static key", "root key", "env key only", "self-hosted url"])
+    def test_clone_is_enabled_only_by_an_on_disk_credential(self, monkeypatch, tmp_path, cfg, env_key, enabled):
+        honcho_cli, written = self._env(monkeypatch, tmp_path, cfg, env_key=env_key)
         assert honcho_cli.clone_honcho_for_profile("dreamer") is True
         block = written["cfg"]["hosts"]["hermes_dreamer"]
-        assert "enabled" not in block
+        assert block.get("enabled") is (True if enabled else None)
         assert "apiKey" not in block and "oauth" not in block
         assert block["aiPeer"] == "dreamer" and block["workspace"] == "hermes"
 
-    def test_clone_from_host_only_static_key_is_written_without_enabled(self, monkeypatch, tmp_path):
-        cfg = {"hosts": {"hermes": {"enabled": True, "apiKey": "hch-v3-hostonly", "workspace": "hermes"}}}
-        honcho_cli, written = self._env(monkeypatch, tmp_path, cfg)
-        assert honcho_cli.clone_honcho_for_profile("dreamer") is True
-        assert "enabled" not in written["cfg"]["hosts"]["hermes_dreamer"]
-
-    def test_clone_with_root_key_is_enabled(self, monkeypatch, tmp_path):
-        cfg = {"apiKey": "hch-v3-root", "hosts": {"hermes": {"workspace": "hermes"}}}
-        honcho_cli, written = self._env(monkeypatch, tmp_path, cfg)
-        assert honcho_cli.clone_honcho_for_profile("dreamer") is True
-        assert written["cfg"]["hosts"]["hermes_dreamer"]["enabled"] is True
-
-    def test_env_key_alone_does_not_enable_a_clone(self, monkeypatch, tmp_path):
-        """A variable can vanish from the next process; only what is on disk counts at write time."""
-        cfg = {"hosts": {"hermes": {"workspace": "hermes"}}}
-        honcho_cli, written = self._env(monkeypatch, tmp_path, cfg)
-        monkeypatch.setenv("HONCHO_API_KEY", "hch-v3-from-env")
-        assert honcho_cli.clone_honcho_for_profile("dreamer") is True
-        assert "enabled" not in written["cfg"]["hosts"]["hermes_dreamer"]
-
-    def test_enable_refuses_with_only_an_env_key(self, monkeypatch, tmp_path, capsys):
-        from types import SimpleNamespace
-        cfg = {"hosts": {"hermes_dreamer": {"workspace": "hermes"}}}
-        honcho_cli, written = self._env(monkeypatch, tmp_path, cfg)
-        monkeypatch.setenv("HONCHO_API_KEY", "hch-v3-from-env")
-        honcho_cli.cmd_enable(SimpleNamespace())
-        assert written == {}
-        assert "setup" in capsys.readouterr().out
-
-
-    def test_clone_with_self_hosted_url_is_enabled(self, monkeypatch, tmp_path):
-        cfg = {"baseUrl": "http://localhost:8000", "hosts": {"hermes": {"workspace": "hermes"}}}
-        honcho_cli, written = self._env(monkeypatch, tmp_path, cfg)
-        assert honcho_cli.clone_honcho_for_profile("dreamer") is True
-        assert written["cfg"]["hosts"]["hermes_dreamer"]["enabled"] is True
-
-    def test_enable_on_empty_block_refuses_and_writes_nothing(self, monkeypatch, tmp_path, capsys):
-        honcho_cli, written = self._env(monkeypatch, tmp_path, self._oauth_default())
+    @pytest.mark.parametrize("cfg, env_key, profile, expect, enabled", [
+        ({"hosts": {"hermes_dreamer": {"workspace": "hermes"}}}, "hch-v3-from-env", "dreamer", ["setup"], False),
+        (_OAUTH_DEFAULT, None, "dreamer",
+         ["stays disabled", "hermes honcho setup --target-profile dreamer", "hosts.hermes_dreamer"], False),
+        ({"hosts": {"hermes_dreamer": {"enabled": True, "aiPeer": "dreamer", "workspace": "hermes"}}}, None, "dreamer",
+         ["stays disabled"], False),
+        ({"hosts": {}}, None, "default", ["Run 'hermes honcho setup' to sign in"], False),
+        ({"apiKey": "hch-v3-root", **_KEYLESS_DEFAULT}, None, "dreamer", ["Honcho enabled"], True),
+    ], ids=["env key only", "empty block", "legacy enabled keyless block", "default profile hint", "root key"])
+    def test_enable_writes_enabled_only_for_an_on_disk_credential(self, monkeypatch, tmp_path, capsys,
+                                                                   cfg, env_key, profile, expect, enabled):
+        host = "hermes" if profile == "default" else "hermes_dreamer"
+        honcho_cli, written = self._env(monkeypatch, tmp_path, cfg, env_key=env_key, host=host, profile=profile)
         honcho_cli.cmd_enable(SimpleNamespace())
         out = capsys.readouterr().out
-        assert "stays disabled" in out
-        assert "hermes honcho setup --target-profile dreamer" in out
-        assert "hosts.hermes_dreamer" in out
-        assert written == {}
-
-    def test_enable_on_legacy_enabled_keyless_block_explains_instead_of_already_enabled(self, monkeypatch, tmp_path, capsys):
-        cfg = self._oauth_default()
-        cfg["hosts"]["hermes_dreamer"] = {"enabled": True, "aiPeer": "dreamer", "workspace": "hermes", "peerName": "eri"}
-        honcho_cli, written = self._env(monkeypatch, tmp_path, cfg)
-        honcho_cli.cmd_enable(SimpleNamespace())
-        out = capsys.readouterr().out
-        assert "stays disabled" in out
-        assert "already enabled" not in out
-        assert written == {}
-
-    def test_enable_with_root_key_still_enables(self, monkeypatch, tmp_path, capsys):
-        cfg = {"apiKey": "hch-v3-root", "hosts": {"hermes": {"workspace": "hermes"}}}
-        honcho_cli, written = self._env(monkeypatch, tmp_path, cfg)
-        honcho_cli.cmd_enable(SimpleNamespace())
-        assert "Honcho enabled" in capsys.readouterr().out
-        assert written["cfg"]["hosts"]["hermes_dreamer"]["enabled"] is True
-
-    def test_enable_on_default_profile_hint_omits_target_profile(self, monkeypatch, tmp_path, capsys):
-        honcho_cli, written = self._env(monkeypatch, tmp_path, {"hosts": {}}, host="hermes", profile="default")
-        honcho_cli.cmd_enable(SimpleNamespace())
-        out = capsys.readouterr().out
-        assert "Run 'hermes honcho setup' to sign in" in out
-        assert written == {}
+        assert all(s in out for s in expect) and "already enabled" not in out
+        assert written["cfg"]["hosts"][host]["enabled"] is True if enabled else written == {}
 
 
 class TestWriteConfigMergesOntoDisk:
-    """A command reads honcho.json, works, then writes. A refresh in another process may have rotated
-    the token in between; the write must keep that rotation and apply only the command's own edits."""
+    """A refresh in another process may rotate the token while a command runs; the write must keep it."""
 
     def _paths(self, monkeypatch, tmp_path, disk):
-        import plugins.memory.honcho.cli as honcho_cli
         cfg_path = tmp_path / "honcho.json"
         cfg_path.write_text(json.dumps(disk))
-        monkeypatch.setattr(honcho_cli, "_config_path", lambda: cfg_path)
-        monkeypatch.setattr(honcho_cli, "_local_config_path", lambda: cfg_path)
-        return honcho_cli, cfg_path
+        return _point_cli_at(monkeypatch, cfg_path), cfg_path
 
-    def _rotated(self, cfg_path, disk):
-        disk["hosts"]["hermes"]["apiKey"] = "hch-at-new"
-        disk["hosts"]["hermes"]["oauth"] = {"refreshToken": "hch-rt-new"}
+    def _rotate_on_disk(self, cfg_path):
+        disk = json.loads(cfg_path.read_text())
+        disk["hosts"]["hermes"].update(apiKey="hch-at-new", oauth={"refreshToken": "hch-rt-new"})
         cfg_path.write_text(json.dumps(disk))
 
-    def test_rotation_between_read_and_write_survives(self, monkeypatch, tmp_path):
+    def test_untouched_keys_take_disk_and_the_commands_edits_apply(self, monkeypatch, tmp_path):
         disk = {"apiKey": "root", "hosts": {"hermes": {"apiKey": "hch-at-old", "oauth": {"refreshToken": "hch-rt-old"},
-                                                     "recallMode": "hybrid"}}}
+                                                     "recallMode": "hybrid", "runtimePeerPrefix": "tg_"}}}
         honcho_cli, cfg_path = self._paths(monkeypatch, tmp_path, disk)
         cfg = honcho_cli._read_config()
-        self._rotated(cfg_path, json.loads(cfg_path.read_text()))
+        self._rotate_on_disk(cfg_path)
         cfg["hosts"]["hermes"]["recallMode"] = "tools"
+        cfg["hosts"]["hermes"].pop("runtimePeerPrefix")
         cfg["dialecticCadence"] = 3
         honcho_cli._write_config(cfg)
         out = json.loads(cfg_path.read_text())
-        assert out["hosts"]["hermes"]["apiKey"] == "hch-at-new"
-        assert out["hosts"]["hermes"]["oauth"] == {"refreshToken": "hch-rt-new"}
-        assert out["hosts"]["hermes"]["recallMode"] == "tools" and out["dialecticCadence"] == 3
+        assert out["hosts"]["hermes"] == {"apiKey": "hch-at-new", "oauth": {"refreshToken": "hch-rt-new"}, "recallMode": "tools"}
+        assert out["apiKey"] == "root" and out["dialecticCadence"] == 3
 
     def test_a_credential_the_command_set_wins(self, monkeypatch, tmp_path):
         disk = {"hosts": {"hermes": {"apiKey": "hch-at-old", "oauth": {"refreshToken": "hch-rt-old"}}}}
         honcho_cli, cfg_path = self._paths(monkeypatch, tmp_path, disk)
         cfg = honcho_cli._read_config()
-        self._rotated(cfg_path, json.loads(cfg_path.read_text()))
+        self._rotate_on_disk(cfg_path)
         cfg["hosts"]["hermes"]["apiKey"] = "hch-v3-pasted"
         cfg["hosts"]["hermes"].pop("oauth")
         honcho_cli._write_config(cfg)
-        out = json.loads(cfg_path.read_text())
-        assert out["hosts"]["hermes"]["apiKey"] == "hch-v3-pasted" and "oauth" not in out["hosts"]["hermes"]
+        assert json.loads(cfg_path.read_text())["hosts"]["hermes"] == {"apiKey": "hch-v3-pasted"}
 
-    def test_a_key_the_command_removed_is_removed(self, monkeypatch, tmp_path):
-        disk = {"hosts": {"hermes": {"apiKey": "k", "runtimePeerPrefix": "tg_"}}}
-        honcho_cli, cfg_path = self._paths(monkeypatch, tmp_path, disk)
-        cfg = honcho_cli._read_config()
-        cfg["hosts"]["hermes"].pop("runtimePeerPrefix")
+    @pytest.mark.parametrize("build", [lambda cli: {"hosts": {"other": {"apiKey": "o"}}}, lambda cli: dict(cli._read_config())],
+                             ids=["never read", "rebuilt from the read"])
+    def test_a_plain_dict_is_written_whole(self, monkeypatch, tmp_path, build):
+        honcho_cli, cfg_path = self._paths(monkeypatch, tmp_path, {"hosts": {"hermes": {"apiKey": "hch-at-old"}}})
+        cfg = build(honcho_cli)
+        self._rotate_on_disk(cfg_path)
         honcho_cli._write_config(cfg)
-        assert "runtimePeerPrefix" not in json.loads(cfg_path.read_text())["hosts"]["hermes"]
+        assert json.loads(cfg_path.read_text()) == cfg
 
-    def test_write_without_a_prior_read_writes_the_whole_config(self, monkeypatch, tmp_path):
-        honcho_cli, cfg_path = self._paths(monkeypatch, tmp_path, {"hosts": {"hermes": {"apiKey": "k"}}})
-        honcho_cli._write_config({"hosts": {"other": {"apiKey": "o"}}})
-        assert json.loads(cfg_path.read_text()) == {"hosts": {"other": {"apiKey": "o"}}}
-
-    def test_a_rebuilt_plain_dict_is_written_whole(self, monkeypatch, tmp_path):
-        disk = {"hosts": {"hermes": {"apiKey": "hch-at-old", "recallMode": "hybrid"}}}
-        honcho_cli, cfg_path = self._paths(monkeypatch, tmp_path, disk)
-        cfg = dict(honcho_cli._read_config())
-        self._rotated(cfg_path, json.loads(cfg_path.read_text()))
-        honcho_cli._write_config(cfg)
-        assert json.loads(cfg_path.read_text())["hosts"]["hermes"]["apiKey"] == "hch-at-old"
-
-    def test_write_holds_the_refresh_file_lock(self, monkeypatch, tmp_path):
+    def test_write_holds_the_refresh_file_lock_and_bootstraps_a_missing_file(self, monkeypatch, tmp_path):
         import contextlib
         import plugins.memory.honcho.oauth as oauth
-        honcho_cli, cfg_path = self._paths(monkeypatch, tmp_path, {})
-        locked = []
-
-        @contextlib.contextmanager
-        def _lock(path):
-            locked.append(path)
-            yield
-
-        monkeypatch.setattr(oauth, "_config_refresh_lock", _lock)
+        cfg_path = tmp_path / "honcho.json"
+        honcho_cli, locked = _point_cli_at(monkeypatch, cfg_path), []
+        monkeypatch.setattr(oauth, "_config_refresh_lock", lambda path: locked.append(path) or contextlib.nullcontext())
         honcho_cli._write_config({"apiKey": "k"})
-        assert locked == [cfg_path]
+        assert locked == [cfg_path] and json.loads(cfg_path.read_text(encoding="utf-8")) == {"apiKey": "k"}

--- a/tests/honcho_plugin/test_cli.py
+++ b/tests/honcho_plugin/test_cli.py
@@ -907,6 +907,39 @@ class TestWriteConfigMergesOntoDisk:
         assert out["apiKey"] == "hch-at-new" and out["oauth"] == {"refreshToken": "hch-rt-new"}
         assert out["peerName"] == "alice" and out["recallMode"] == "tools"
 
+    _SEED = {"dialecticCadence": 3, "hosts": {"hermes": {"peerName": "alice"}}}
+
+    def _seeded(self, monkeypatch, tmp_path):
+        seed, local = tmp_path / "seed.json", tmp_path / "honcho.json"
+        seed.write_text(json.dumps(self._SEED))
+        return _point_cli_at(monkeypatch, local, _config_path=lambda: seed, _host_key=lambda: "hermes"), local
+
+    def test_a_read_seeded_from_another_file_applies_only_its_edits_onto_the_local_file(self, monkeypatch, tmp_path):
+        import plugins.memory.honcho.oauth as oauth
+        honcho_cli, local = self._seeded(monkeypatch, tmp_path)
+        cfg = honcho_cli._read_config()
+        grant = {"access_token": "hch-at-login", "refresh_token": "hch-rt-login", "expires_in": 3600}
+        cred = oauth.install_grant(local, "hermes", grant, client_id="c", token_endpoint="e", apply_config=False)
+        honcho_cli._apply_grant_to_host(cfg, cfg["hosts"]["hermes"], cred)
+        rotated = oauth.OAuthCredential.from_token_response(
+            {"access_token": "hch-at-new", "refresh_token": "hch-rt-new", "expires_in": 3600},
+            now=0.0, client_id="c", token_endpoint="e")
+        oauth._persist_credential(local, "hermes", rotated)
+        cfg["hosts"]["hermes"]["recallMode"] = "tools"
+        honcho_cli._write_config(cfg)
+        out = json.loads(local.read_text())
+        assert out["hosts"]["hermes"]["apiKey"] == "hch-at-new"
+        assert out["hosts"]["hermes"]["oauth"]["refreshToken"] == "hch-rt-new"
+        assert out["hosts"]["hermes"]["recallMode"] == "tools" and out["hosts"]["hermes"]["peerName"] == "alice"
+        assert out["dialecticCadence"] == 3
+
+    def test_a_read_seeded_from_another_file_is_written_whole_while_no_local_file_exists(self, monkeypatch, tmp_path):
+        honcho_cli, local = self._seeded(monkeypatch, tmp_path)
+        cfg = honcho_cli._read_config()
+        cfg["hosts"]["hermes"]["recallMode"] = "tools"
+        honcho_cli._write_config(cfg)
+        assert json.loads(local.read_text()) == {"dialecticCadence": 3, "hosts": {"hermes": {"peerName": "alice", "recallMode": "tools"}}}
+
     @pytest.mark.parametrize("build", [lambda cli: {"hosts": {"other": {"apiKey": "o"}}}, lambda cli: dict(cli._read_config())],
                              ids=["never read", "rebuilt from the read"])
     def test_a_plain_dict_is_written_whole(self, monkeypatch, tmp_path, build):

--- a/tests/honcho_plugin/test_cli.py
+++ b/tests/honcho_plugin/test_cli.py
@@ -892,6 +892,21 @@ class TestWriteConfigMergesOntoDisk:
         honcho_cli._write_config(cfg)
         assert json.loads(cfg_path.read_text())["hosts"]["hermes"] == {"apiKey": "hch-v3-pasted"}
 
+    def test_a_grant_the_login_installed_yields_to_a_later_rotation(self, monkeypatch, tmp_path):
+        import plugins.memory.honcho.oauth as oauth
+        honcho_cli, cfg_path = self._paths(monkeypatch, tmp_path, {"hosts": {"hermes": {"peerName": "alice"}}})
+        monkeypatch.setattr(honcho_cli, "_host_key", lambda: "hermes")
+        cfg = honcho_cli._read_config()
+        grant = {"access_token": "hch-at-login", "refresh_token": "hch-rt-login", "expires_in": 3600}
+        cred = oauth.install_grant(cfg_path, "hermes", grant, client_id="c", token_endpoint="e", apply_config=False)
+        honcho_cli._apply_grant_to_host(cfg, cfg["hosts"]["hermes"], cred)
+        self._rotate_on_disk(cfg_path)
+        cfg["hosts"]["hermes"]["recallMode"] = "tools"
+        honcho_cli._write_config(cfg)
+        out = json.loads(cfg_path.read_text())["hosts"]["hermes"]
+        assert out["apiKey"] == "hch-at-new" and out["oauth"] == {"refreshToken": "hch-rt-new"}
+        assert out["peerName"] == "alice" and out["recallMode"] == "tools"
+
     @pytest.mark.parametrize("build", [lambda cli: {"hosts": {"other": {"apiKey": "o"}}}, lambda cli: dict(cli._read_config())],
                              ids=["never read", "rebuilt from the read"])
     def test_a_plain_dict_is_written_whole(self, monkeypatch, tmp_path, build):

--- a/tests/honcho_plugin/test_oauth.py
+++ b/tests/honcho_plugin/test_oauth.py
@@ -199,3 +199,119 @@ class TestApplyTokenToClient:
 
     def test_returns_false_when_shape_unknown(self):
         assert oauth.apply_token_to_client(object(), "hch-at-new") is False
+
+
+class TestPersistReadFailure:
+    """One unreadable honcho.json must never become a single-host store.
+
+    ``_persist_credential`` promises "leaving all else intact", but it seeded
+    the write from a reader that returned ``{}`` on ANY read failure, and
+    ``_atomic_write_config`` replaces the whole file via ``os.replace`` —
+    which needs only a writable parent, so a present-but-unreadable store did
+    not stop the overwrite. Same class as the auth-store fix in #75206.
+    """
+
+    @staticmethod
+    def _seed_two_hosts(path: Path) -> bytes:
+        _write(path, {
+            "hosts": {
+                "keep.example": _host_block(refresh="hch-rt-keep"),
+                "rotate.example": _host_block(refresh="hch-rt-rot"),
+            },
+            "defaults": {"workspace": "w1"},
+        })
+        return path.read_bytes()
+
+    def _unreadable(self, monkeypatch, target: Path):
+        real = Path.read_text
+
+        def boom(self, *a, **kw):
+            if self.name == target.name:
+                raise PermissionError(13, "Permission denied")
+            return real(self, *a, **kw)
+
+        monkeypatch.setattr(Path, "read_text", boom)
+
+    def test_persist_raises_and_preserves_store_when_unreadable(
+        self, tmp_path, monkeypatch
+    ):
+        path = tmp_path / "honcho.json"
+        before = self._seed_two_hosts(path)
+        cred = OAuthCredential.from_host_block(_host_block(refresh="hch-rt-new"))
+
+        with monkeypatch.context() as m:
+            self._unreadable(m, path)
+            with pytest.raises(OSError):
+                oauth._persist_credential(path, "rotate.example", cred)
+
+        assert path.read_bytes() == before
+
+    def test_rotate_refuses_before_spending_the_refresh_token(
+        self, tmp_path, monkeypatch
+    ):
+        # Rotation is single-use: an exchange whose result cannot be persisted
+        # loses the grant, so an unreadable store must fail the refresh BEFORE
+        # the exchange, not after.
+        path = tmp_path / "honcho.json"
+        before = self._seed_two_hosts(path)
+        cred = OAuthCredential.from_host_block(_host_block(refresh="hch-rt-rot"))
+        key = (str(path), "rotate.example")
+        oauth._refresh_failure_at.pop(key, None)
+
+        def no_exchange(*a, **kw):  # pragma: no cover - must not run
+            raise AssertionError("exchange ran against an unreadable store")
+
+        with monkeypatch.context() as m:
+            m.setattr(oauth, "_exchange_with_retry", no_exchange)
+            self._unreadable(m, path)
+            assert oauth._rotate_and_persist(
+                path, "rotate.example", key, cred, now=1.0
+            ) is None
+
+        assert key in oauth._refresh_failure_at
+        oauth._refresh_failure_at.pop(key, None)
+        assert path.read_bytes() == before
+
+    def test_corrupt_store_degrades_but_preserves_a_copy(self, tmp_path):
+        path = tmp_path / "honcho.json"
+        truncated = json.dumps(
+            {"hosts": {"keep.example": _host_block(refresh="hch-rt-keep")}}
+        )[:-5]
+        path.write_text(truncated, encoding="utf-8")
+
+        assert oauth._read_config_strict(path) == {}
+        corrupt = path.with_name(path.name + ".corrupt")
+        assert corrupt.exists()
+        assert corrupt.read_text(encoding="utf-8") == truncated
+
+    def test_missing_store_still_bootstraps_empty(self, tmp_path):
+        assert oauth._read_config_strict(tmp_path / "honcho.json") == {}
+
+    def test_bom_prefixed_store_is_not_corruption(self, tmp_path):
+        path = tmp_path / "honcho.json"
+        path.write_text(
+            json.dumps({"hosts": {"keep.example": _host_block()}}),
+            encoding="utf-8-sig",
+        )
+        assert "keep.example" in oauth._read_config(path).get("hosts", {})
+        assert "keep.example" in oauth._read_config_strict(path).get("hosts", {})
+        assert not path.with_name(path.name + ".corrupt").exists()
+
+    def test_install_grant_raises_and_preserves_store_when_unreadable(
+        self, tmp_path, monkeypatch
+    ):
+        path = tmp_path / "honcho.json"
+        before = self._seed_two_hosts(path)
+
+        with monkeypatch.context() as m:
+            self._unreadable(m, path)
+            with pytest.raises(OSError):
+                oauth.install_grant(
+                    path, "new.example",
+                    {"access_token": "hch-at-new", "refresh_token": "hch-rt-new",
+                     "expires_in": 3600},
+                    client_id="hermes-desktop",
+                    token_endpoint="http://localhost:8000/oauth/token",
+                )
+
+        assert path.read_bytes() == before

--- a/tests/honcho_plugin/test_oauth.py
+++ b/tests/honcho_plugin/test_oauth.py
@@ -272,17 +272,42 @@ class TestPersistReadFailure:
         oauth._refresh_failure_at.pop(key, None)
         assert path.read_bytes() == before
 
-    def test_corrupt_store_degrades_but_preserves_a_copy(self, tmp_path):
+    def test_corrupt_store_refuses_to_persist(self, tmp_path):
         path = tmp_path / "honcho.json"
         truncated = json.dumps(
             {"hosts": {"keep.example": _host_block(refresh="hch-rt-keep")}}
         )[:-5]
         path.write_text(truncated, encoding="utf-8")
+        cred = OAuthCredential.from_host_block(_host_block(refresh="hch-rt-new"))
 
-        assert oauth._read_config_strict(path) == {}
-        corrupt = path.with_name(path.name + ".corrupt")
-        assert corrupt.exists()
-        assert corrupt.read_text(encoding="utf-8") == truncated
+        with pytest.raises(ValueError):
+            oauth._read_config_strict(path)
+        with pytest.raises(ValueError):
+            oauth._persist_credential(path, "keep.example", cred)
+        with pytest.raises(ValueError):
+            oauth.install_grant(
+                path, "new.example",
+                {"access_token": "hch-at-new", "refresh_token": "hch-rt-new", "expires_in": 3600},
+                client_id="hermes-desktop", token_endpoint="http://localhost:8000/oauth/token",
+            )
+        assert path.read_text(encoding="utf-8") == truncated
+        assert not path.with_name(path.name + ".corrupt").exists()
+
+    def test_corrupt_store_fails_the_refresh_before_the_exchange(self, tmp_path, monkeypatch):
+        path = tmp_path / "honcho.json"
+        path.write_text("{not json", encoding="utf-8")
+        cred = OAuthCredential.from_host_block(_host_block(refresh="hch-rt-rot"))
+        key = (str(path), "rotate.example")
+        oauth._refresh_failure_at.pop(key, None)
+
+        def no_exchange(*a, **kw):  # pragma: no cover - must not run
+            raise AssertionError("exchange ran against a corrupt store")
+
+        monkeypatch.setattr(oauth, "_exchange_with_retry", no_exchange)
+        assert oauth._rotate_and_persist(path, "rotate.example", key, cred, now=1.0) is None
+        assert key in oauth._refresh_failure_at
+        oauth._refresh_failure_at.pop(key, None)
+        assert path.read_text(encoding="utf-8") == "{not json"
 
     def test_missing_store_still_bootstraps_empty(self, tmp_path):
         assert oauth._read_config_strict(tmp_path / "honcho.json") == {}
@@ -295,7 +320,6 @@ class TestPersistReadFailure:
         )
         assert "keep.example" in oauth._read_config(path).get("hosts", {})
         assert "keep.example" in oauth._read_config_strict(path).get("hosts", {})
-        assert not path.with_name(path.name + ".corrupt").exists()
 
     def test_install_grant_raises_and_preserves_store_when_unreadable(
         self, tmp_path, monkeypatch

--- a/tests/honcho_plugin/test_oauth.py
+++ b/tests/honcho_plugin/test_oauth.py
@@ -184,6 +184,38 @@ class TestInstallGrant:
                 client_id="c", token_endpoint="e",
             )
 
+    def test_reads_and_writes_under_the_refresh_locks(self, tmp_path, monkeypatch):
+        path = tmp_path / "honcho.json"
+        _write(path, {"hosts": {"other": _host_block()}})
+        seen = {}
+        real_read, real_persist = oauth._read_config_strict, oauth._persist_credential
+        locked_paths = []
+
+        @oauth.contextmanager
+        def spy_file_lock(p):
+            locked_paths.append(p)
+            yield
+
+        def spy_read(p):
+            seen["read_locked"] = oauth._refresh_lock.locked()
+            return real_read(p)
+
+        def spy_persist(p, host, cred, raw=None):
+            seen["persist_locked"] = oauth._refresh_lock.locked()
+            return real_persist(p, host, cred, raw)
+
+        monkeypatch.setattr(oauth, "_config_refresh_lock", spy_file_lock)
+        monkeypatch.setattr(oauth, "_read_config_strict", spy_read)
+        monkeypatch.setattr(oauth, "_persist_credential", spy_persist)
+        oauth.install_grant(
+            path, "hermes", {"access_token": "hch-at-new", "refresh_token": "hch-rt-new", "expires_in": 60},
+            client_id="c", token_endpoint="e",
+        )
+        assert seen == {"read_locked": True, "persist_locked": True}
+        assert locked_paths == [path]
+        assert not oauth._refresh_lock.locked()
+        assert "other" in json.loads(path.read_text())["hosts"]
+
 
 class TestApplyTokenToClient:
     def test_mutates_live_bearer(self):

--- a/tests/honcho_plugin/test_oauth.py
+++ b/tests/honcho_plugin/test_oauth.py
@@ -1,6 +1,7 @@
 """Tests for plugins/memory/honcho/oauth.py — OAuth grant storage + refresh."""
 
 import json
+from contextlib import nullcontext
 from pathlib import Path
 
 import pytest
@@ -187,31 +188,22 @@ class TestInstallGrant:
     def test_reads_and_writes_under_the_refresh_locks(self, tmp_path, monkeypatch):
         path = tmp_path / "honcho.json"
         _write(path, {"hosts": {"other": _host_block()}})
-        seen = {}
-        real_read, real_persist = oauth._read_config_strict, oauth._persist_credential
-        locked_paths = []
+        seen, locked_paths = {}, []
 
-        @oauth.contextmanager
-        def spy_file_lock(p):
-            locked_paths.append(p)
-            yield
+        def spy(name, real):
+            def wrapped(*a, **k):
+                seen[name] = oauth._refresh_lock.locked()
+                return real(*a, **k)
+            return wrapped
 
-        def spy_read(p):
-            seen["read_locked"] = oauth._refresh_lock.locked()
-            return real_read(p)
-
-        def spy_persist(p, host, cred, raw=None):
-            seen["persist_locked"] = oauth._refresh_lock.locked()
-            return real_persist(p, host, cred, raw)
-
-        monkeypatch.setattr(oauth, "_config_refresh_lock", spy_file_lock)
-        monkeypatch.setattr(oauth, "_read_config_strict", spy_read)
-        monkeypatch.setattr(oauth, "_persist_credential", spy_persist)
+        monkeypatch.setattr(oauth, "_config_refresh_lock", lambda p: locked_paths.append(p) or nullcontext())
+        monkeypatch.setattr(oauth, "_read_config_strict", spy("read", oauth._read_config_strict))
+        monkeypatch.setattr(oauth, "_persist_credential", spy("persist", oauth._persist_credential))
         oauth.install_grant(
             path, "hermes", {"access_token": "hch-at-new", "refresh_token": "hch-rt-new", "expires_in": 60},
             client_id="c", token_endpoint="e",
         )
-        assert seen == {"read_locked": True, "persist_locked": True}
+        assert seen == {"read": True, "persist": True}
         assert locked_paths == [path]
         assert not oauth._refresh_lock.locked()
         assert "other" in json.loads(path.read_text())["hosts"]

--- a/tests/test_honcho_client_config.py
+++ b/tests/test_honcho_client_config.py
@@ -204,3 +204,26 @@ class TestProfileKeyIsolationWarning:
                 host='hermes', config_path=config_path,
             )
         assert not any('NOT inherited' in r.message for r in caplog.records)
+
+
+def test_save_config_refuses_to_replace_a_file_that_does_not_parse(tmp_path, monkeypatch):
+    """A corrupt honcho.json must not be rewritten from the new values alone."""
+    import pytest
+    from plugins.memory.honcho import HonchoMemoryProvider
+
+    config_path = tmp_path / "honcho.json"
+    config_path.write_text("{ not json")
+    provider = HonchoMemoryProvider()
+    with pytest.raises(ValueError):
+        provider.save_config({"api_key": "hc-test-key"}, str(tmp_path))
+    assert config_path.read_text() == "{ not json"
+
+
+def test_save_config_merges_into_a_parseable_file(tmp_path):
+    from plugins.memory.honcho import HonchoMemoryProvider
+
+    config_path = tmp_path / "honcho.json"
+    config_path.write_text(json.dumps({"hosts": {"other": {"apiKey": "keep-me"}}}))
+    HonchoMemoryProvider().save_config({"api_key": "hc-test-key"}, str(tmp_path))
+    data = json.loads(config_path.read_text())
+    assert data["hosts"]["other"]["apiKey"] == "keep-me" and data["api_key"] == "hc-test-key"

--- a/tests/test_honcho_client_config.py
+++ b/tests/test_honcho_client_config.py
@@ -206,22 +206,16 @@ class TestProfileKeyIsolationWarning:
         assert not any('NOT inherited' in r.message for r in caplog.records)
 
 
-def test_save_config_refuses_to_replace_a_file_that_does_not_parse(tmp_path, monkeypatch):
+def test_save_config_refuses_to_replace_a_file_that_does_not_parse(tmp_path):
     """A corrupt honcho.json must not be rewritten from the new values alone."""
-    import pytest
-    from plugins.memory.honcho import HonchoMemoryProvider
-
     config_path = tmp_path / "honcho.json"
     config_path.write_text("{ not json")
-    provider = HonchoMemoryProvider()
     with pytest.raises(ValueError):
-        provider.save_config({"api_key": "hc-test-key"}, str(tmp_path))
+        HonchoMemoryProvider().save_config({"api_key": "hc-test-key"}, str(tmp_path))
     assert config_path.read_text() == "{ not json"
 
 
 def test_save_config_merges_into_a_parseable_file(tmp_path):
-    from plugins.memory.honcho import HonchoMemoryProvider
-
     config_path = tmp_path / "honcho.json"
     config_path.write_text(json.dumps({"hosts": {"other": {"apiKey": "keep-me"}}}))
     HonchoMemoryProvider().save_config({"api_key": "hc-test-key"}, str(tmp_path))

--- a/tests/test_honcho_client_config.py
+++ b/tests/test_honcho_client_config.py
@@ -221,3 +221,36 @@ def test_save_config_merges_into_a_parseable_file(tmp_path):
     HonchoMemoryProvider().save_config({"api_key": "hc-test-key"}, str(tmp_path))
     data = json.loads(config_path.read_text())
     assert data["hosts"]["other"]["apiKey"] == "keep-me" and data["api_key"] == "hc-test-key"
+
+
+def test_save_config_holds_the_refresh_locks_so_a_rotation_survives(tmp_path, monkeypatch):
+    """A refresh thread that wants the locks while save_config reads must land after its write, not under it."""
+    import threading
+    from plugins.memory.honcho import oauth
+    config_path = tmp_path / "honcho.json"
+    config_path.write_text(json.dumps({"hosts": {"hermes": {"apiKey": "hch-at-old", "oauth": {"refreshToken": "hch-rt-old"}}}}))
+    rotated = oauth.OAuthCredential("hch-at-new", "hch-rt-new", 10_000, "hermes-desktop", "http://localhost:8000/oauth/token")
+    save_read, rotation_done = threading.Event(), threading.Event()
+    real_read = oauth._read_config_strict
+
+    def read_then_wait(path):
+        raw = real_read(path)
+        if not save_read.is_set():
+            save_read.set()
+            rotation_done.wait(0.5)  # the refresh gets this window; only a held lock keeps it out
+        return raw
+
+    def rotate():
+        save_read.wait(2)
+        with oauth._refresh_lock, oauth._config_refresh_lock(config_path):
+            oauth._persist_credential(config_path, "hermes", rotated)
+        rotation_done.set()
+
+    monkeypatch.setattr(oauth, "_read_config_strict", read_then_wait)
+    thread = threading.Thread(target=rotate)
+    thread.start()
+    HonchoMemoryProvider().save_config({"logging": True}, str(tmp_path))
+    thread.join(2)
+    assert rotation_done.is_set()
+    data = json.loads(config_path.read_text())
+    assert data["hosts"]["hermes"]["apiKey"] == "hch-at-new" and data["logging"] is True


### PR DESCRIPTION
## summary

two failure classes in how the honcho plugin writes `~/.hermes/honcho.json`: the 401 recovery path re-exchanged a refresh token a sibling process had already rotated, and every write path could replace the whole file from an empty read or overwrite a rotation that landed mid-command. this pr fixes both, locks the login and cli paths, lets the setup wizard's apikey answer replace a dead grant, and stops writing `enabled: true` for a host block that cannot authenticate.

## 401 recovery

desktop spawns several `serve` processes that share one rotating refresh token. honcho refresh tokens are single-use with reuse detection, so replaying a stale one can revoke the whole grant. `force_refresh_token` treated every 401 as "rotate now"; its only adopt-a-sibling check compared disk to the in-process `_expiry_cache`, which is empty in every sibling process. observed as bursts of `force-refreshed` lines after a 401 fan-out and intermittent "automatic token refresh failed" pauses that needed `hermes honcho setup`.

`_authed_call` now snapshots the bearer before the operation runs and hands the token that actually 401'd to `force_refresh_token`. after the locked disk re-read, if disk has moved off that token, the on-disk grant is adopted with no http. on a permanent `invalid_grant`, `_rotate_and_persist` re-reads honcho.json before marking the grant dead and adopts a sibling's newer refresh token if one landed mid-exchange. disk unchanged still marks the grant dead.

## config writes

`_read_config` returns `{}` for a file that exists but cannot be read or parsed. every write seeded from that (`_persist_credential`, `install_grant`, the cli's `_write_config`, the provider's `save_config`) replaced honcho.json with the current host block alone. `_read_config_strict` now raises for such a file and logs one sentence; refreshes back off without spending the refresh token and every command prints the sentence and writes nothing. read paths keep the `{}` fallback.

cli commands also wrote the whole dict back unlocked, so a refresh that landed between a command's read and its write was overwritten with the old tokens. `_write_config` now holds the same cross-process file lock the refresh path holds and applies only the keys the command changed onto a fresh read of disk.

## install_grant

a login ran its read-modify-write unlocked next to a refresh. it now holds `_refresh_lock` and the file lock the way `force_refresh_token` does.

## setup wizard, apikey

choosing apikey after a revoked grant wrote the root apiKey only, so `hosts.<name>.oauth` kept shadowing the new key (#97990). the branch now drops the host's oauth block and writes the key on the host block too.

## enabled without a credential

a profile cloned from an oauth-authenticated default got `enabled: true` with no apiKey and no oauth; the default host's key is not inherited. `clone_honcho_for_profile` and `cmd_enable` now write `enabled: true` only when honcho.json itself resolves a credential; an environment variable does not count at write time because it can be absent from the next process. `enable` names the command that signs the profile in. legacy blocks already on disk are left alone and explained by `enable`.

## tests

`test_auth_recovery.py`: waiter 2 adopts waiter 1's rotation with no second exchange; cross-process adopt with an empty `_expiry_cache`; `invalid_grant` with disk rotated mid-exchange adopts; disk unchanged still marks dead. `test_oauth.py`, `test_cli.py`, `test_honcho_client_config.py`: refusal on a corrupt file at every write path, locks held around `install_grant`, `_write_config` and `save_config`, a rotation between a command's read and write survives, a rotation that lands while the setup wizard is still asking questions survives (including when the read was seeded from another file), apikey replaces the oauth block, clone/enable credential cohorts including env-only.

honcho suite: 376 passed. ruff and `git diff --check` clean. rebased onto main after #102117 with every commit re-applied into the split plugin layout.

thanks @FestoneX for the strict reader in #95860.

supersedes #95860. closes #97990. related: #66125 (isolation kept).

## seeded reads

when `$HERMES_HOME/honcho.json` does not exist yet, the wizard reads `~/.honcho/config.json` or the default profile's file and `install_grant` then creates the local file. `_write_config` used to write the whole seeded dict over that new file, dropping a rotation that landed during the wizard's later prompts. it now overlays the local file's contents onto the seed and applies only the keys the command edited, so the inherited settings, the rotation and the edits all survive. with no local file at write time the seeding write is unchanged.
