### PR TITLE
fix(desktop): route composer status by session owner

### DIFF
--- a/apps/desktop/src/app/chat/composer/status-stack/goal-indicator.test.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/goal-indicator.test.tsx
@@ -1,8 +1,9 @@
-import { cleanup, render, screen } from '@testing-library/react'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { I18nProvider } from '@/i18n'
+import { $gateway } from '@/store/gateway'
 import { $goalsBySession, type SessionGoal } from '@/store/goals'
 
 import { ComposerStatusStack } from './index'
@@ -37,11 +38,13 @@ function renderStack(sessionId: null | string = SID) {
 
 describe('ComposerStatusStack goal indicator', () => {
   beforeEach(() => {
+    $gateway.set(null)
     $goalsBySession.set({})
   })
 
   afterEach(() => {
     cleanup()
+    $gateway.set(null)
     $goalsBySession.set({})
   })
 
@@ -83,5 +86,18 @@ describe('ComposerStatusStack goal indicator', () => {
     const view = renderStack()
 
     expect(view.container.firstChild).toBeNull()
+  })
+
+  it('rehydrates a stale goal when the gateway becomes available after mount', async () => {
+    const request = vi.fn().mockResolvedValue({ output: 'No active goal. Set one with /goal <text>.' })
+    $goalsBySession.set({ [SID]: goal('active') })
+
+    renderStack()
+    expect(screen.getByText('Goal active')).toBeTruthy()
+
+    $gateway.set({ request } as never)
+
+    await waitFor(() => expect(screen.queryByText('Goal active')).toBeNull())
+    expect(request).toHaveBeenCalledWith('slash.exec', { command: 'goal status', session_id: SID })
   })
 })

--- a/apps/desktop/src/app/chat/composer/status-stack/index.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/index.tsx
@@ -25,6 +25,7 @@ import {
   type StatusGroup,
   stopBackgroundProcess
 } from '@/store/composer-status'
+import { $gateway } from '@/store/gateway'
 import { refreshSessionGoal } from '@/store/goals'
 import { $previewStatusBySession, dismissPreviewArtifact } from '@/store/preview-status'
 import { $threadScrolledUp } from '@/store/thread-scroll'
@@ -89,6 +90,7 @@ interface ComposerStatusStackProps {
 export function ComposerStatusStack({ queue, sessionId }: ComposerStatusStackProps) {
   const { t } = useI18n()
   const navigate = useNavigate()
+  const gateway = useStore($gateway)
   // Subscribe to THIS session's slice only. Both maps churn on other
   // sessions' activity (subagent ticks, background polls, preview updates in
   // any tile); a whole-map `useStore` re-rendered every mounted stack — one
@@ -102,8 +104,10 @@ export function ComposerStatusStack({ queue, sessionId }: ComposerStatusStackPro
 
   const groups = useMemo(() => groupStatusItems(items), [items])
 
-  // Seed from the registry on session open; event-driven refreshes (terminal /
-  // process tool completions) live in use-message-stream.
+  // Seed from the registry on session open and again when the gateway binding
+  // becomes available or changes. The composer can mount before the socket is
+  // ready; depending only on sessionId leaves a stale goal chip forever when
+  // that first refresh returns early.
   useEffect(() => {
     if (sessionId) {
       // Opening/rebinding a session is a fresh runtime binding: clear any
@@ -113,7 +117,7 @@ export function ComposerStatusStack({ queue, sessionId }: ComposerStatusStackPro
       void refreshBackgroundProcesses(sessionId)
       void refreshSessionGoal(sessionId)
     }
-  }, [sessionId])
+  }, [gateway, sessionId])
 
   const hasRunningBackground = groups.some(g => g.type === 'background' && g.items.some(i => i.state === 'running'))
 

--- a/apps/desktop/src/store/composer-status.ts
+++ b/apps/desktop/src/store/composer-status.ts
@@ -10,7 +10,7 @@ import { $goalsBySession, type GoalStatus } from './goals'
 import { dispatchNativeNotification } from './native-notifications'
 import { notifyError } from './notifications'
 import { $sessions, lineageAliases } from './session'
-import { $sessionStates } from './session-states'
+import { $sessionStates, requestForOwnedSession } from './session-states'
 import { $subagentsBySession, type SubagentProgress } from './subagents'
 import { $todosBySession } from './todos'
 
@@ -387,6 +387,11 @@ export function reconcileBackgroundProcesses(sid: string, procs: GatewayProcessE
  *  forever: one runtime id accumulated 18,614 gateway rejections in a single day
  *  (#94219 fallout). Latch the id here and skip it until something rebinds it. */
 const goneSessions = new Set<string>()
+const refreshGenerationBySession = new Map<string, number>()
+
+function invalidateRefresh(sid: string): void {
+  refreshGenerationBySession.set(sid, (refreshGenerationBySession.get(sid) ?? 0) + 1)
+}
 
 /** Gateway JSON-RPC code for "session not found" (tui_gateway _sess_nowait). */
 const GATEWAY_SESSION_NOT_FOUND_CODE = 4001
@@ -415,26 +420,50 @@ export function isSessionGoneForBackgroundPolling(error: unknown): boolean {
 export function resetBackgroundPollingGuard(sid?: string): void {
   if (sid) {
     goneSessions.delete(sid)
+    invalidateRefresh(sid)
 
     return
   }
 
   goneSessions.clear()
+
+  for (const sessionId of refreshGenerationBySession.keys()) {
+    invalidateRefresh(sessionId)
+  }
 }
 
 /** Pull the session's live process snapshot from the gateway. */
 export async function refreshBackgroundProcesses(sid: string): Promise<void> {
+  if (!sid) {
+    return
+  }
+
+  const generation = (refreshGenerationBySession.get(sid) ?? 0) + 1
+  refreshGenerationBySession.set(sid, generation)
   const gateway = $gateway.get()
 
-  if (!sid || !gateway || goneSessions.has(sid)) {
+  if (!gateway || goneSessions.has(sid)) {
     return
   }
 
   try {
-    const result = await gateway.request<{ processes?: GatewayProcessEntry[] }>('process.list', { session_id: sid })
+    const result = await requestForOwnedSession<{ processes?: GatewayProcessEntry[] }>(
+      sid,
+      gateway.request.bind(gateway) as typeof gateway.request,
+      'process.list',
+      { session_id: sid }
+    )
+
+    if (refreshGenerationBySession.get(sid) !== generation) {
+      return
+    }
 
     reconcileBackgroundProcesses(sid, result?.processes ?? [])
   } catch (error) {
+    if (refreshGenerationBySession.get(sid) !== generation) {
+      return
+    }
+
     // A gone session never comes back under this runtime id: stop polling it,
     // or the 5s timer hammers the gateway with 4001s for the window's lifetime.
     if (isSessionGoneForBackgroundPolling(error)) {
@@ -468,8 +497,17 @@ export function dismissBackgroundProcess(sid: string, id: string) {
  *  row while the process lived on, stranding rogue tasks. On failure the row
  *  stays so the user can retry / see it didn't die. */
 export async function stopBackgroundProcess(sid: string, id: string): Promise<void> {
+  const gateway = $gateway.get()
+
+  if (!gateway) {
+    return
+  }
+
   try {
-    await $gateway.get()?.request('process.kill', { process_id: id, session_id: sid })
+    await requestForOwnedSession(sid, gateway.request.bind(gateway) as typeof gateway.request, 'process.kill', {
+      process_id: id,
+      session_id: sid
+    })
     dismissBackgroundProcess(sid, id)
   } catch (err) {
     notifyError(err, 'Could not stop the process')
@@ -497,8 +535,11 @@ export function resetSessionBackground(sid: string) {
   for (const item of list) {
     dismissed.add(item.id)
 
-    if (item.state === 'running') {
-      void gateway?.request('process.kill', { process_id: item.id, session_id: sid }).catch(() => undefined)
+    if (item.state === 'running' && gateway) {
+      void requestForOwnedSession(sid, gateway.request.bind(gateway) as typeof gateway.request, 'process.kill', {
+        process_id: item.id,
+        session_id: sid
+      }).catch(() => undefined)
     }
   }
 

--- a/apps/desktop/src/store/goals.ts
+++ b/apps/desktop/src/store/goals.ts
@@ -3,6 +3,7 @@ import { atom } from 'nanostores'
 import { keyedTimeouts } from '@/lib/keyed-timeouts'
 
 import { $gateway } from './gateway'
+import { requestForOwnedSession } from './session-states'
 
 export type GoalStatus = 'active' | 'done' | 'paused' | 'waiting'
 
@@ -17,12 +18,18 @@ export const $goalsBySession = atom<Record<string, SessionGoal>>({})
 
 const DONE_LINGER_MS = 8_000
 const clearTimers = keyedTimeouts()
+const refreshGenerationBySession = new Map<string, number>()
+
+function invalidateRefresh(sid: string): void {
+  refreshGenerationBySession.set(sid, (refreshGenerationBySession.get(sid) ?? 0) + 1)
+}
 
 export function setSessionGoal(sid: string, goal: SessionGoal) {
   if (!sid) {
     return
   }
 
+  invalidateRefresh(sid)
   clearTimers.cancel(sid)
   $goalsBySession.set({ ...$goalsBySession.get(), [sid]: goal })
 
@@ -32,6 +39,11 @@ export function setSessionGoal(sid: string, goal: SessionGoal) {
 }
 
 export function clearSessionGoal(sid: string) {
+  if (!sid) {
+    return
+  }
+
+  invalidateRefresh(sid)
   clearTimers.cancel(sid)
 
   const map = $goalsBySession.get()
@@ -161,14 +173,29 @@ export function applyGoalStatusText(sid: string, text: string, opts?: { hydrate?
 }
 
 export async function refreshSessionGoal(sid: string): Promise<void> {
+  if (!sid) {
+    return
+  }
+
+  const generation = (refreshGenerationBySession.get(sid) ?? 0) + 1
+  refreshGenerationBySession.set(sid, generation)
   const gateway = $gateway.get()
 
-  if (!sid || !gateway) {
+  if (!gateway) {
     return
   }
 
   try {
-    const result = await gateway.request<{ output?: string }>('slash.exec', { command: 'goal status', session_id: sid })
+    const result = await requestForOwnedSession<{ output?: string }>(
+      sid,
+      gateway.request.bind(gateway) as typeof gateway.request,
+      'slash.exec',
+      { command: 'goal status', session_id: sid }
+    )
+
+    if (refreshGenerationBySession.get(sid) !== generation) {
+      return
+    }
 
     applyGoalStatusText(sid, result?.output ?? '', { hydrate: true })
   } catch {

--- a/apps/desktop/src/store/status-refreshes.test.ts
+++ b/apps/desktop/src/store/status-refreshes.test.ts
@@ -1,0 +1,264 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const secondaryGateways: Array<{
+  close: ReturnType<typeof vi.fn>
+  connect: ReturnType<typeof vi.fn>
+  connectionState: string
+  request: ReturnType<typeof vi.fn>
+}> = []
+
+vi.mock('@/hermes', () => ({
+  HermesGateway: class {
+    connectionState = 'closed'
+    connect = vi.fn(async () => {
+      this.connectionState = 'open'
+    })
+    request = vi.fn(async (method: string, params: Record<string, unknown>) => {
+      if (method === 'slash.exec') {
+        return { output: '⊙ Goal (active, 1/20 turns): worker-owned goal' }
+      }
+
+      return {
+        processes: [
+          {
+            command: 'worker-owned process',
+            session_id: 'worker-process',
+            status: 'running'
+          }
+        ],
+        params
+      }
+    })
+    close = vi.fn()
+    onEvent = vi.fn(() => () => {})
+    onState = vi.fn(() => () => {})
+
+    constructor() {
+      secondaryGateways.push(this)
+    }
+  },
+  setApiRequestConnection: vi.fn(),
+  setApiRequestProfile: vi.fn()
+}))
+
+const { $gateway, closeSecondaryGateways, configureGatewayRegistry, setPrimaryGateway } = await import('./gateway')
+const { $goalsBySession, refreshSessionGoal } = await import('./goals')
+
+const {
+  $backgroundStatusBySession,
+  reconcileBackgroundProcesses,
+  refreshBackgroundProcesses,
+  resetBackgroundPollingGuard,
+  resetSessionBackground,
+  stopBackgroundProcess
+} = await import('./composer-status')
+
+const { setSessions } = await import('./session')
+
+const OWNER_SESSION_ID = 'session-owned-by-worker'
+const LOCAL_SESSION_ID = 'session-on-current-gateway'
+
+type PrimaryGateway = {
+  connectionState: string
+  request: ReturnType<typeof vi.fn>
+}
+
+function installDesktop(): void {
+  ;(window as unknown as { hermesDesktop: unknown }).hermesDesktop = {
+    getConnection: vi.fn(async (profile: null | string) => ({
+      port: profile ? 5151 : 4242,
+      profile: profile || undefined,
+      token: '[REDACTED]'
+    })),
+    touchBackend: vi.fn(async () => undefined)
+  }
+}
+
+function makePrimary(): PrimaryGateway {
+  return {
+    connectionState: 'open',
+    request: vi.fn(async (method: string) => {
+      if (method === 'slash.exec') {
+        return { output: 'No active goal. Set one with /goal <text>.' }
+      }
+
+      return { processes: [] }
+    })
+  }
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+
+  const promise = new Promise<T>(resolvePromise => {
+    resolve = resolvePromise
+  })
+
+  return { promise, resolve }
+}
+
+function resetStores(): void {
+  $gateway.set(null)
+  $goalsBySession.set({})
+  $backgroundStatusBySession.set({})
+  setSessions([])
+  resetBackgroundPollingGuard()
+  closeSecondaryGateways()
+  secondaryGateways.length = 0
+  delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
+}
+
+beforeEach(() => {
+  configureGatewayRegistry({ onEvent: vi.fn() })
+  resetStores()
+})
+
+afterEach(() => {
+  resetStores()
+  vi.clearAllMocks()
+})
+
+describe('session status refresh routing', () => {
+  it('routes goal refreshes to the session owner instead of the active gateway', async () => {
+    const primary = makePrimary()
+    setPrimaryGateway(primary as never, 'default')
+    $gateway.set(primary as never)
+    installDesktop()
+    setSessions([{ id: OWNER_SESSION_ID, profile: 'worker' } as never])
+
+    await refreshSessionGoal(OWNER_SESSION_ID)
+
+    expect(primary.request).not.toHaveBeenCalled()
+    expect(secondaryGateways).toHaveLength(1)
+    expect(secondaryGateways[0].request).toHaveBeenCalledWith('slash.exec', {
+      command: 'goal status',
+      session_id: OWNER_SESSION_ID
+    })
+    expect($goalsBySession.get()[OWNER_SESSION_ID]).toMatchObject({
+      status: 'active',
+      title: 'worker-owned goal'
+    })
+  })
+
+  it('routes background-process refreshes to the session owner instead of the active gateway', async () => {
+    const primary = makePrimary()
+    setPrimaryGateway(primary as never, 'default')
+    $gateway.set(primary as never)
+    installDesktop()
+    setSessions([{ id: OWNER_SESSION_ID, profile: 'worker' } as never])
+
+    await refreshBackgroundProcesses(OWNER_SESSION_ID)
+
+    expect(primary.request).not.toHaveBeenCalled()
+    expect(secondaryGateways).toHaveLength(1)
+    expect(secondaryGateways[0].request).toHaveBeenCalledWith('process.list', {
+      session_id: OWNER_SESSION_ID
+    })
+    expect($backgroundStatusBySession.get()[OWNER_SESSION_ID]).toMatchObject([
+      { id: 'worker-process', state: 'running', title: 'worker-owned process' }
+    ])
+  })
+
+  it('routes an interactive process kill to the session owner', async () => {
+    const primary = makePrimary()
+    setPrimaryGateway(primary as never, 'default')
+    $gateway.set(primary as never)
+    installDesktop()
+    setSessions([{ id: OWNER_SESSION_ID, profile: 'worker' } as never])
+    reconcileBackgroundProcesses(OWNER_SESSION_ID, [
+      {
+        command: 'kill worker process',
+        session_id: 'kill-worker-process',
+        status: 'running'
+      }
+    ])
+
+    await stopBackgroundProcess(OWNER_SESSION_ID, 'kill-worker-process')
+
+    expect(primary.request).not.toHaveBeenCalled()
+    expect(secondaryGateways).toHaveLength(1)
+    expect(secondaryGateways[0].request).toHaveBeenCalledWith('process.kill', {
+      process_id: 'kill-worker-process',
+      session_id: OWNER_SESSION_ID
+    })
+    expect($backgroundStatusBySession.get()[OWNER_SESSION_ID]).toBeUndefined()
+  })
+
+  it('routes rewind cleanup kills to the session owner', async () => {
+    const primary = makePrimary()
+    setPrimaryGateway(primary as never, 'default')
+    $gateway.set(primary as never)
+    installDesktop()
+    setSessions([{ id: OWNER_SESSION_ID, profile: 'worker' } as never])
+    reconcileBackgroundProcesses(OWNER_SESSION_ID, [
+      {
+        command: 'rewind worker process',
+        session_id: 'rewind-worker-process',
+        status: 'running'
+      }
+    ])
+
+    resetSessionBackground(OWNER_SESSION_ID)
+    await vi.waitFor(() => expect(secondaryGateways).toHaveLength(1))
+
+    expect(primary.request).not.toHaveBeenCalled()
+    expect(secondaryGateways[0].request).toHaveBeenCalledWith('process.kill', {
+      process_id: 'rewind-worker-process',
+      session_id: OWNER_SESSION_ID
+    })
+    expect($backgroundStatusBySession.get()[OWNER_SESSION_ID]).toBeUndefined()
+  })
+})
+
+describe('session status refresh ordering', () => {
+  it('keeps the newest goal refresh when an older response resolves later', async () => {
+    const primary = makePrimary()
+    const older = deferred<{ output: string }>()
+    const newer = deferred<{ output: string }>()
+    primary.request.mockImplementationOnce(() => older.promise).mockImplementationOnce(() => newer.promise)
+    setPrimaryGateway(primary as never, 'default')
+    $gateway.set(primary as never)
+
+    const olderRefresh = refreshSessionGoal(LOCAL_SESSION_ID)
+    const newerRefresh = refreshSessionGoal(LOCAL_SESSION_ID)
+
+    newer.resolve({ output: '⊙ Goal (active, 2/20 turns): newest goal' })
+    await newerRefresh
+    older.resolve({ output: 'No active goal. Set one with /goal <text>.' })
+    await olderRefresh
+
+    expect($goalsBySession.get()[LOCAL_SESSION_ID]).toMatchObject({
+      status: 'active',
+      title: 'newest goal'
+    })
+  })
+
+  it('keeps the newest background snapshot when an older response resolves later', async () => {
+    const primary = makePrimary()
+    const older = deferred<{ processes: Array<Record<string, unknown>> }>()
+    const newer = deferred<{ processes: Array<Record<string, unknown>> }>()
+    primary.request.mockImplementationOnce(() => older.promise).mockImplementationOnce(() => newer.promise)
+    setPrimaryGateway(primary as never, 'default')
+    $gateway.set(primary as never)
+
+    const olderRefresh = refreshBackgroundProcesses(LOCAL_SESSION_ID)
+    const newerRefresh = refreshBackgroundProcesses(LOCAL_SESSION_ID)
+
+    newer.resolve({
+      processes: [
+        {
+          command: 'newest process',
+          session_id: 'newest-process',
+          status: 'running'
+        }
+      ]
+    })
+    await newerRefresh
+    older.resolve({ processes: [] })
+    await olderRefresh
+
+    expect($backgroundStatusBySession.get()[LOCAL_SESSION_ID]).toMatchObject([
+      { id: 'newest-process', state: 'running', title: 'newest process' }
+    ])
+  })
+})


### PR DESCRIPTION
## Summary

- Route goal and background-process refreshes through the session owner gateway.
- Route interactive process kills and rewind cleanup through the same owner-aware path.
- Discard stale refresh responses with per-session generations.
- Add multi-profile routing and out-of-order response regression coverage.

## Validation

- `npm run test:ui -- src/store src/app/chat/composer/status-stack` — 115 test files, 1348 tests passed.
- `npm run check:lint` — TypeScript passed; ESLint completed with 0 errors and pre-existing warnings.
- Prettier check passed.
- `git diff --check` passed.

The branch was rebased onto the latest `origin/main` before publication.