### PR TITLE
fix(update): sync deps into every present venv so the .venv shim uses stays current

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -2059,17 +2059,26 @@ def _update_via_zip(args, *, had_desktop_app_before_update: bool = False) -> boo
         from hermes_cli.managed_uv import managed_python_env
 
         uv_env = managed_python_env()
-        uv_env["VIRTUAL_ENV"] = str(_m().PROJECT_ROOT / "venv")
         if _m()._is_termux_env(uv_env):
             uv_env.pop("PYTHONPATH", None)
             uv_env.pop("PYTHONHOME", None)
         try:
-            _m()._install_python_dependencies_with_optional_fallback([uv_bin, "pip"], env=uv_env)
+            # Sync deps into EVERY present project venv (venv and .venv when
+            # both exist — #97340): the CLI shim / desktop-served profiles
+            # run from .venv while gateway/webui/dashboard services run from
+            # venv. Syncing only venv leaves the launcher's env stale.
+            for venv_dir in _project_venv_dirs():
+                venv_env = dict(uv_env)
+                venv_env["VIRTUAL_ENV"] = str(venv_dir)
+                _m()._install_python_dependencies_with_optional_fallback([uv_bin, "pip"], env=venv_env)
         except _shim_quarantine_error_type() as _sqe:
             # #87331: this runs inside the ZIP-fallback error handler, so the
             # boundary except clause in cmd_update cannot catch it — refuse
             # here with the same defer-via-marker contract.
             _refuse_update_for_contended_shims(_sqe)
+        # Keep the primary (git-install) venv as the tool-dependency restore
+        # target below, matching pre-#97340 behavior.
+        uv_env["VIRTUAL_ENV"] = str(_project_venv_dirs()[0])
     else:
         # Use sys.executable to explicitly call the venv's pip module,
         # avoiding PEP 668 'externally-managed-environment' errors on Debian/Ubuntu.
@@ -4621,8 +4630,34 @@ def _wait_for_windows_update_gateway_exit(
             pass
     return survivors
 
+def _project_venv_dirs() -> list[Path]:
+    """Project venv dirs to sync/probe/holder-detect, in order ``venv`` then ``.venv``.
+
+    An install can carry BOTH ``venv`` (older git-install flow) and ``.venv``
+    (uv/bootstrap flow): the ``~/.local/bin/hermes`` shim and Desktop-spawned
+    ``hermes --profile <p> serve --isolated`` processes run from ``.venv``
+    while gateway/webui/dashboard services run from ``venv`` (#97340). A
+    dep-sync / health-probe / holder-detection that only ever looks at
+    ``venv`` leaves the shim's env stale (``ModuleNotFoundError:
+    snowballstemmer`` after an update adds a dependency). So every such site
+    must cover ALL present project venvs.
+
+    Returns every ``venv``/``.venv`` directory actually present at
+    PROJECT_ROOT. When NO project venv exists (a plain dev checkout), falls
+    back to the single ``venv`` target so callers keep the historical
+    ``--python sys.executable`` pin / healthy-no-venv behavior instead of
+    silently skipping.
+    """
+    present = [
+        d
+        for name in ("venv", ".venv")
+        if (d := _m().PROJECT_ROOT / name).is_dir()
+    ]
+    return present or [_m().PROJECT_ROOT / "venv"]
+
+
 def _venv_core_imports_healthy() -> tuple[bool, str]:
-    """Probe the project venv for the core imports the backend needs to boot.
+    """Probe the project venvs for the core imports the backend needs to boot.
 
     Runs a tiny import check inside the venv interpreter (NOT this process —
     ``hermes update`` may be driven by a different Python). Catches the
@@ -4637,7 +4672,18 @@ def _venv_core_imports_healthy() -> tuple[bool, str]:
     Returns ``(healthy, detail)``. Never raises; unknown states report
     healthy so a probe failure can't force needless reinstalls.
     """
-    venv_dir = _m().PROJECT_ROOT / "venv"
+    # Every present project venv must be healthy (venv OR .venv — #97340).
+    # A stale .venv that still lacks a dependency the release added must
+    # trip a repair even when the git-install venv is fine.
+    for venv_dir in _project_venv_dirs():
+        healthy, detail = _probe_single_venv_imports(venv_dir)
+        if not healthy:
+            return False, detail
+    return True, ""
+
+
+def _probe_single_venv_imports(venv_dir: Path) -> tuple[bool, str]:
+    """Run the core-import probe against one specific venv (see caller)."""
     venv_python = venv_python_path(venv_dir, windows=_m()._is_windows())
     if not venv_python.exists():
         # No venv interpreter at all. In a dev checkout that's normal (the
@@ -4715,11 +4761,15 @@ def _detect_venv_python_processes(
     except Exception:
         return []
 
-    venv_dir = _m().PROJECT_ROOT / "venv"
-    try:
-        venv_prefix = str(venv_dir.resolve()).lower().rstrip(os.sep) + os.sep
-    except OSError:
-        venv_prefix = str(venv_dir).lower().rstrip(os.sep) + os.sep
+    venv_dirs = _project_venv_dirs()
+    venv_prefixes: list[str] = []
+    for venv_dir in venv_dirs:
+        try:
+            venv_prefixes.append(
+                str(venv_dir.resolve()).lower().rstrip(os.sep) + os.sep
+            )
+        except OSError:
+            venv_prefixes.append(str(venv_dir).lower().rstrip(os.sep) + os.sep)
     try:
         root_prefix = str(_m().PROJECT_ROOT.resolve()).lower().rstrip(os.sep) + os.sep
     except OSError:
@@ -4775,15 +4825,17 @@ def _detect_venv_python_processes(
         cmdline_low = cmdline_raw.lower()
         cwd_low = str(info.get("cwd") or "").lower().rstrip(os.sep) + os.sep
 
-        # Primary match: the executable itself lives under this venv
-        # (venv\Scripts\python(w).exe — the desktop backend / gateway case).
-        is_holder = exe_norm.startswith(venv_prefix)
+        # Primary match: the executable itself lives under one of this
+        # install's venvs (venv\Scripts\python(w).exe — the desktop backend
+        # / gateway case, from either the `venv` or `.venv` layout).
+        is_holder = any(exe_norm.startswith(p) for p in venv_prefixes)
         # Fallback: uv/base-interpreter trampolines run a python whose exe is
         # OUTSIDE the venv but which still imports from it and holds its .pyd
         # files. Catch those by what they're running: a cmdline that references
-        # this venv's path, or a `-m hermes_cli.main ...` invocation tied to
-        # this install (install root in the cmdline or as the working dir).
-        if not is_holder and venv_prefix in cmdline_low:
+        # one of this install's venv paths, or a `-m hermes_cli.main ...`
+        # invocation tied to this install (install root in the cmdline or as
+        # the working dir).
+        if not is_holder and any(p in cmdline_low for p in venv_prefixes):
             is_holder = True
         if not is_holder and "hermes_cli.main" in cmdline_low:
             if root_prefix in cmdline_low or cwd_low.startswith(root_prefix):
@@ -5136,11 +5188,14 @@ def _venv_launcher_ancestors(pids: list[int]) -> list[int]:
     except Exception:
         return []
 
-    venv_dir = _m().PROJECT_ROOT / "venv"
-    try:
-        venv_prefix = str(venv_dir.resolve()).lower().rstrip(os.sep) + os.sep
-    except OSError:
-        venv_prefix = str(venv_dir).lower().rstrip(os.sep) + os.sep
+    venv_prefixes: list[str] = []
+    for venv_dir in _project_venv_dirs():
+        try:
+            venv_prefixes.append(
+                str(venv_dir.resolve()).lower().rstrip(os.sep) + os.sep
+            )
+        except OSError:
+            venv_prefixes.append(str(venv_dir).lower().rstrip(os.sep) + os.sep)
 
     # Never return ourselves or our own ancestry: a CLI ``hermes update``
     # runs from the venv python and would otherwise nominate itself.
@@ -5180,7 +5235,7 @@ def _venv_launcher_ancestors(pids: list[int]) -> list[int]:
             exe = (parent.exe() or "").lower()
         except Exception:
             continue
-        if exe.startswith(venv_prefix):
+        if any(exe.startswith(p) for p in venv_prefixes):
             found.append(ppid)
     return found
 
@@ -7971,41 +8026,46 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 from hermes_cli.managed_uv import ensure_uv
 
                 repair_uv = ensure_uv()
+                repair_venv_dirs = _project_venv_dirs()
                 # A managed install whose venv is gone entirely (interrupted
                 # repair after the old venv was moved aside) needs the venv
                 # recreated before dependencies can be installed into it.
-                venv_python_missing = not (
-                    venv_python_path(
-                        _m().PROJECT_ROOT / "venv", windows=_m()._is_windows()
-                    )
-                ).exists()
-                if venv_python_missing and repair_uv:
-                    print("→ Recreating virtual environment...")
-                    subprocess.run(
-                        [repair_uv, "venv", "venv"],
-                        cwd=_m().PROJECT_ROOT,
-                        check=False,
-                    )
+                # #97340: recreate EVERY present project venv (venv and .venv)
+                # so a missing .venv interpreter is healed too.
+                if repair_uv:
+                    for venv_dir in repair_venv_dirs:
+                        venv_python_missing = not venv_python_path(
+                            venv_dir, windows=_m()._is_windows()
+                        ).exists()
+                        if venv_python_missing:
+                            print("→ Recreating virtual environment...")
+                            subprocess.run(
+                                [repair_uv, "venv", venv_dir.name],
+                                cwd=_m().PROJECT_ROOT,
+                                check=False,
+                            )
                 if repair_uv:
                     # Isolated from third-party UV env vars (#83914), same as
                     # the main-path and git-path dependency syncs.
                     from hermes_cli.managed_uv import managed_python_env
 
                     repair_env = managed_python_env()
-                    repair_env["VIRTUAL_ENV"] = str(_m().PROJECT_ROOT / "venv")
-                    _m()._install_python_dependencies_with_optional_fallback(
-                        [repair_uv, "pip"], env=repair_env, group="all"
-                    )
-                    _m()._refresh_active_lazy_features(
-                        [repair_uv, "pip"],
-                        env=repair_env,
-                        features=active_lazy_features,
-                    )
-                    _m()._restore_active_tool_dependencies(
-                        active_tool_dependencies,
-                        [repair_uv, "pip"],
-                        env=repair_env,
-                    )
+                    for venv_dir in repair_venv_dirs:
+                        venv_env = dict(repair_env)
+                        venv_env["VIRTUAL_ENV"] = str(venv_dir)
+                        _m()._install_python_dependencies_with_optional_fallback(
+                            [repair_uv, "pip"], env=venv_env, group="all"
+                        )
+                        _m()._refresh_active_lazy_features(
+                            [repair_uv, "pip"],
+                            env=venv_env,
+                            features=active_lazy_features,
+                        )
+                        _m()._restore_active_tool_dependencies(
+                            active_tool_dependencies,
+                            [repair_uv, "pip"],
+                            env=venv_env,
+                        )
                 else:
                     _m()._install_python_dependencies_with_optional_fallback(
                         [sys.executable, "-m", "pip"], group="all"
@@ -8364,23 +8424,34 @@ def _cmd_update_impl(args, gateway_mode: bool):
         if uv_bin:
             # Use official managed_python_env() isolation so third-party
             # UV_PYTHON_INSTALL_DIR (e.g. WorkBuddy) cannot hijack uv; then
-            # point VIRTUAL_ENV at this install's venv.
+            # point VIRTUAL_ENV at this install's venvs, one at a time.
             from hermes_cli.managed_uv import managed_python_env
 
             uv_env = managed_python_env()
-            uv_env["VIRTUAL_ENV"] = str(_m().PROJECT_ROOT / "venv")
             if _m()._is_termux_env(uv_env):
                 uv_env.pop("PYTHONPATH", None)
                 uv_env.pop("PYTHONHOME", None)
                 install_group = "termux-all"
                 print("  → Termux detected: using uv + curated termux-all optional profile...")
             if not deps_current:
-                if _m()._is_termux_env(uv_env) and _is_android_python():
-                    print("  → Termux/Android detected: prebuilding psutil with Linux source path compatibility...")
-                    _install_psutil_android_compat([uv_bin, "pip"], env=uv_env)
-                _m()._install_python_dependencies_with_optional_fallback(
-                    [uv_bin, "pip"], env=uv_env, group=install_group
-                )
+                # Sync deps into EVERY present project venv (venv and .venv
+                # when both exist — #97340). The CLI shim / desktop-served
+                # profiles run from .venv while gateway/webui/dashboard
+                # services run from venv; syncing only venv leaves the .venv
+                # the launcher actually uses stale (ModuleNotFoundError).
+                for venv_dir in _project_venv_dirs():
+                    venv_env = dict(uv_env)
+                    venv_env["VIRTUAL_ENV"] = str(venv_dir)
+                    if _m()._is_termux_env(venv_env) and _is_android_python():
+                        print("  → Termux/Android detected: prebuilding psutil with Linux source path compatibility...")
+                        _install_psutil_android_compat([uv_bin, "pip"], env=venv_env)
+                    _m()._install_python_dependencies_with_optional_fallback(
+                        [uv_bin, "pip"], env=venv_env, group=install_group
+                    )
+            # Keep the primary (git-install) venv as the lazy-refresh /
+            # tool-dependency / verify target below, matching pre-#97340
+            # behavior (set on BOTH the deps-current and deps-changed paths).
+            uv_env["VIRTUAL_ENV"] = str(_project_venv_dirs()[0])
         else:
             # Use sys.executable to explicitly call the venv's pip module,
             # avoiding PEP 668 'externally-managed-environment' errors on Debian/Ubuntu.

--- a/tests/hermes_cli/test_update_multi_venv_sync.py
+++ b/tests/hermes_cli/test_update_multi_venv_sync.py
@@ -1,0 +1,102 @@
+"""Test: multi-venv sync for installs carrying BOTH venv/ and .venv/ (#97340).
+
+An install can have both a ``venv`` (older git-install flow) and a ``.venv``
+(uv/bootstrap flow). The ``~/.local/bin/hermes`` shim and Desktop-spawned
+``hermes --profile <p> serve --isolated`` processes run from ``.venv`` while
+gateway/webui/dashboard services run from ``venv``. ``hermes update`` used to
+sync deps / probe health / detect holders against ``venv`` ONLY, leaving the
+``.venv`` the launcher actually uses stale (``ModuleNotFoundError:
+snowballstemmer`` after a release adds a dependency).
+
+These tests prove the fixed behavior: every present project venv is enumerated
+by the shared ``_project_venv_dirs()`` helper and the health probe covers ALL
+present venvs, so a stale ``.venv`` trips a repair. They FAIL against the
+pre-fix code, which only ever looked at ``venv``.
+"""
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import hermes_cli.update_cmd as update_mod
+import hermes_cli.main as main_mod
+
+
+def _make_project_root(with_both: bool = True) -> Path:
+    """Create a temp PROJECT_ROOT with ``venv/bin/python`` and (optionally)
+    ``.venv/bin/python`` present — the minimal shape a present venv dir has."""
+    root = Path(tempfile.mkdtemp(prefix="hc-97340-"))
+    for name in (("venv", ".venv") if with_both else ("venv",)):
+        venv = root / name / "bin"
+        venv.mkdir(parents=True, exist_ok=True)
+        (venv / "python").write_text("#! /usr/bin/env python\n")
+    return root
+
+
+class MultiVenvUpdateTest(unittest.TestCase):
+    def _patch_root(self, root: Path):
+        """Point PROJECT_ROOT at *root* so ``_project_venv_dirs()`` / the probe
+        see our fake layout."""
+        return mock.patch.object(main_mod, "PROJECT_ROOT", root)
+
+    # ── _project_venv_dirs ────────────────────────────────────────────────
+    def test_project_venv_dirs_lists_both_when_present(self):
+        """The sync loop iterates _project_venv_dirs(); with both present it
+        must yield venv THEN .venv so deps land in both. Pre-fix there was no
+        such helper — code hardcoded PROJECT_ROOT/"venv" only."""
+        with self._patch_root(_make_project_root(with_both=True)):
+            dirs = update_mod._project_venv_dirs()
+        self.assertEqual([d.name for d in dirs], ["venv", ".venv"])
+
+    def test_project_venv_dirs_single_when_only_venv(self):
+        """Back-compat: a plain git-install (only venv/) still yields a single
+        target, so nothing regresses for single-venv installs."""
+        with self._patch_root(_make_project_root(with_both=False)):
+            dirs = update_mod._project_venv_dirs()
+        self.assertEqual([d.name for d in dirs], ["venv"])
+
+    # ── health probe covers .venv ─────────────────────────────────────────
+    def test_health_probe_unhealthy_when_dotvenv_missing_core_import(self):
+        """THE regression: with both venv/ and .venv/ present, a stale .venv
+        (missing a core import) must make the install report unhealthy so a
+        repair is triggered. Pre-fix code only probed venv/ and returned
+        healthy, leaving the shim's env stale forever."""
+        root = _make_project_root(with_both=True)
+        dot_venv_dir = root / ".venv"
+
+        def fake_probe(venv_dir):
+            # .venv lacks 'fastapi' -> unhealthy; venv is fine.
+            if venv_dir == dot_venv_dir:
+                return False, "fastapi: No module named 'fastapi'"
+            return True, ""
+
+        with self._patch_root(root), \
+             mock.patch.object(
+                 update_mod, "_probe_single_venv_imports", side_effect=fake_probe
+             ) as probe_mock, \
+             mock.patch.object(main_mod, "_is_windows", return_value=False):
+            healthy, detail = update_mod._venv_core_imports_healthy()
+        self.assertFalse(healthy, "stale .venv must trip an unhealthy probe")
+        self.assertIn("fastapi", detail)
+        # Both venvs were probed (the probe was invoked for venv AND .venv).
+        self.assertEqual(probe_mock.call_count, 2)
+
+    def test_health_probe_healthy_when_only_venv_probed(self):
+        """Back-compat: with only venv/ present, the probe runs once against it
+        and must not be forced to fail on a nonexistent .venv."""
+        root = _make_project_root(with_both=False)
+
+        def fake_probe(venv_dir):
+            return True, ""
+
+        with self._patch_root(root), \
+             mock.patch.object(
+                 update_mod, "_probe_single_venv_imports", side_effect=fake_probe
+             ) as probe_mock:
+            healthy, _ = update_mod._venv_core_imports_healthy()
+        self.assertTrue(healthy)
+        self.assertEqual(probe_mock.call_count, 1)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

On an install that carries **both** `venv/` and `.venv/` (older git-install flow + uv/bootstrap-installer flow), `hermes update` only synced Python dependencies into `venv/`. The `~/.local/bin/hermes` launcher shim and Desktop-app-spawned `hermes --profile <p> serve --isolated` processes run from `.venv`, so any dependency a release adds is missing there after the update — observed as `ModuleNotFoundError: snowballstemmer` after v0.20.4 → v0.20.6.

The updater hardcoded `PROJECT_ROOT / "venv"` at every dependency-sync, import-health-probe, and holder-process-detection site in `hermes_cli/update_cmd.py`.

## Changes

Introduces `_project_venv_dirs()` which enumerates **all** present project venvs (`venv` then `.venv`; falls back to a single `venv` target when neither exists, preserving dev-checkout behavior) and routes every previously hardcoded site through it:

- **Dependency sync** — the git-install path (`_cmd_update_impl`), the ZIP fallback path (`_update_via_zip`), and the repair path all install into **every** present venv.
- **Health probe** (`_venv_core_imports_healthy`) — reports unhealthy if *any* present venv is missing a core import, so a stale `.venv` triggers a repair instead of silently passing.
- **Holder detection** (`_detect_venv_python_processes`, `_venv_launcher_ancestors`) — Windows lock-holder guards now scan for processes running from any present project venv, not just `venv`.

The primary (`venv`) env is kept as the lazy-refresh / tool-dependency / verify target, matching pre-change behavior on both the deps-current and deps-changed paths.

No new env vars, no telemetry, no lockfile churn. Single-venv installs and venv-less dev checkouts behave exactly as before.

## Tests

New `tests/hermes_cli/test_update_multi_venv_sync.py` (4 tests) proves the fix:

- With both `venv/` and `.venv/` present, `_project_venv_dirs()` yields both (venv then .venv).
- **Regression:** a stale `.venv` missing a core import now trips an unhealthy probe (pre-fix code only probed `venv/` and returned healthy). Verified: the test suite **fails 4/4 against the pre-fix code** (`AttributeError: no _project_venv_dirs` + probe not covering .venv) and passes 4/4 on the fix.
- Back-compat: single-venv installs still yield a single target; probe runs once.

Existing `test_update_stale_virtualenv.py` (9) plus `test_update_self_lock.py`, `test_update_concurrent_quarantine.py`, `test_update_interrupted_recovery.py`, `test_verify_core_dependencies.py` (54) all pass — no regressions.

Closes #97340
