### PR TITLE
fix(tui_gateway): reject deleted profile homes

### DIFF
--- a/tests/tui_gateway/test_compute_host.py
+++ b/tests/tui_gateway/test_compute_host.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import pytest
 
+from hermes_constants import mark_named_profile_deleted
 from tui_gateway.compute_host import ComputeHost, HostSession
 from tui_gateway.server import (
     _open_profile_session_db,
@@ -171,6 +172,53 @@ def test_compute_host_rejects_deleted_profile_home_before_agent_build(
         host.close()
 
     assert not profile_home.exists()
+
+
+@pytest.mark.parametrize("cached", [False, True])
+def test_compute_host_rejects_tombstoned_profile_before_agent_build(
+    tmp_path, cached
+):
+    profile_home = tmp_path / ".hermes" / "profiles" / "deleted"
+    profile_home.mkdir(parents=True)
+    mark_named_profile_deleted(profile_home)
+    sid = "stale-profile"
+
+    class _Server:
+        _sessions = (
+            {
+                sid: {
+                    "session_key": sid,
+                    "profile_home": str(profile_home),
+                }
+            }
+            if cached
+            else {}
+        )
+        _require_existing_profile_home = staticmethod(_require_existing_profile_home)
+
+        @staticmethod
+        def _open_profile_session_db(*_args, **_kwargs):
+            raise AssertionError("SessionDB construction must not run")
+
+        @staticmethod
+        def _make_agent(*_args, **_kwargs):
+            raise AssertionError("agent construction must not run")
+
+    host = ComputeHost(heartbeat_secs=0)
+    try:
+        with pytest.raises(RuntimeError, match="profile home no longer exists"):
+            host._ensure_server_session(
+                _Server,
+                {
+                    "sid": sid,
+                    "session_key": sid,
+                    "profile_home": str(profile_home),
+                },
+            )
+    finally:
+        host.close()
+
+    assert list(profile_home.iterdir()) == []
 
 
 def test_profile_home_guard_accepts_existing_directory(tmp_path):

--- a/tests/tui_gateway/test_compute_host.py
+++ b/tests/tui_gateway/test_compute_host.py
@@ -9,6 +9,10 @@ from pathlib import Path
 import pytest
 
 from tui_gateway.compute_host import ComputeHost, HostSession
+from tui_gateway.server import (
+    _open_profile_session_db,
+    _require_existing_profile_home,
+)
 
 
 def _stdout_queue(proc: subprocess.Popen) -> queue.Queue[dict]:
@@ -126,3 +130,66 @@ def test_compute_host_interrupt_uses_explicit_stop_compatibility(kind):
 
     assert calls == ["hard" if kind == "hard-only" else "legacy"]
     assert emitted[-1]["applied"] is True
+
+
+@pytest.mark.parametrize("cached", [False, True])
+def test_compute_host_rejects_deleted_profile_home_before_agent_build(
+    tmp_path, cached
+):
+    profile_home = tmp_path / "profiles" / "deleted"
+    sid = "stale-profile"
+
+    class _Server:
+        _sessions = (
+            {
+                sid: {
+                    "session_key": sid,
+                    "profile_home": str(profile_home),
+                }
+            }
+            if cached
+            else {}
+        )
+        _require_existing_profile_home = staticmethod(_require_existing_profile_home)
+
+        @staticmethod
+        def _make_agent(*_args, **_kwargs):
+            raise AssertionError("agent construction must not run")
+
+    host = ComputeHost(heartbeat_secs=0)
+    try:
+        with pytest.raises(RuntimeError, match="profile home no longer exists"):
+            host._ensure_server_session(
+                _Server,
+                {
+                    "sid": sid,
+                    "session_key": sid,
+                    "profile_home": str(profile_home),
+                },
+            )
+    finally:
+        host.close()
+
+    assert not profile_home.exists()
+
+
+def test_profile_home_guard_accepts_existing_directory(tmp_path):
+    profile_home = tmp_path / "profiles" / "live"
+    profile_home.mkdir(parents=True)
+
+    assert _require_existing_profile_home(profile_home) == profile_home
+
+
+def test_profile_db_open_does_not_create_missing_profile_home(
+    tmp_path, monkeypatch
+):
+    profile_home = tmp_path / "profiles" / "deleted"
+    monkeypatch.setattr(
+        "hermes_state.SessionDB",
+        lambda **_kwargs: pytest.fail("SessionDB construction must not run"),
+    )
+
+    with pytest.raises(RuntimeError, match="profile home no longer exists"):
+        _open_profile_session_db(profile_home)
+
+    assert not profile_home.exists()

--- a/tui_gateway/compute_host.py
+++ b/tui_gateway/compute_host.py
@@ -532,6 +532,13 @@ class ComputeHost:
         sid = str(frame.get("sid") or "")
         key = str(frame.get("session_key") or sid)
         session = server._sessions.get(sid)
+        profile_home = str(
+            frame.get("profile_home")
+            or ((session or {}).get("profile_home"))
+            or ""
+        )
+        if profile_home:
+            server._require_existing_profile_home(profile_home)
         if session is not None:
             session["transport"] = self._transport
             if frame.get("cols") is not None:
@@ -545,7 +552,6 @@ class ComputeHost:
             return session
 
         history = frame.get("history") if isinstance(frame.get("history"), list) else []
-        profile_home = str(frame.get("profile_home") or "")
         session_db = None
         owns_db = False
         home_token = None
@@ -554,7 +560,6 @@ class ComputeHost:
             if profile_home:
                 from hermes_constants import set_hermes_home_override
                 from agent.secret_scope import build_profile_secret_scope, set_secret_scope
-                from hermes_state import SessionDB
 
                 home_token = set_hermes_home_override(profile_home)
                 secret_token = set_secret_scope(build_profile_secret_scope(Path(profile_home)))
@@ -563,7 +568,7 @@ class ComputeHost:
                 # server._sessions[sid] (via _init_session, or the fallback dict
                 # in the except below), so the agent is the right owner; a
                 # _make_agent that RAISES is the one path where nothing takes it.
-                session_db = SessionDB(db_path=Path(profile_home) / "state.db")
+                session_db = server._open_profile_session_db(profile_home)
                 owns_db = True
             agent = server._make_agent(
                 sid,

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -26,6 +26,7 @@ from agent.secret_scope import (
 from hermes_constants import (
     DEFAULT_INDICATOR_STYLE,
     INDICATOR_STYLES,
+    assert_named_profile_home_live,
     get_hermes_home,
     get_hermes_home_override,
     reset_hermes_home_override,
@@ -2290,6 +2291,10 @@ def _transfer_db_to_agent(agent, db) -> bool:
 def _require_existing_profile_home(profile_home: str | Path) -> Path:
     """Resolve a live profile home without recreating a deleted profile."""
     path = Path(profile_home)
+    try:
+        assert_named_profile_home_live(path)
+    except FileNotFoundError:
+        raise RuntimeError(f"profile home no longer exists: {path}") from None
     if not path.is_dir():
         raise RuntimeError(f"profile home no longer exists: {path}")
     return path

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2287,6 +2287,14 @@ def _transfer_db_to_agent(agent, db) -> bool:
         return False
 
 
+def _require_existing_profile_home(profile_home: str | Path) -> Path:
+    """Resolve a live profile home without recreating a deleted profile."""
+    path = Path(profile_home)
+    if not path.is_dir():
+        raise RuntimeError(f"profile home no longer exists: {path}")
+    return path
+
+
 def _open_profile_session_db(profile_home):
     """Open a DEDICATED handle on ``profile_home``'s ``state.db`` — FAIL CLOSED.
 
@@ -2301,7 +2309,7 @@ def _open_profile_session_db(profile_home):
     """
     from hermes_state import SessionDB
 
-    db_path = Path(profile_home) / "state.db"
+    db_path = _require_existing_profile_home(profile_home) / "state.db"
     try:
         return SessionDB(db_path=db_path)
     except Exception as exc:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -26,7 +26,6 @@ from agent.secret_scope import (
 from hermes_constants import (
     DEFAULT_INDICATOR_STYLE,
     INDICATOR_STYLES,
-    assert_named_profile_home_live,
     get_hermes_home,
     get_hermes_home_override,
     reset_hermes_home_override,
@@ -2290,6 +2289,8 @@ def _transfer_db_to_agent(agent, db) -> bool:
 
 def _require_existing_profile_home(profile_home: str | Path) -> Path:
     """Resolve a live profile home without recreating a deleted profile."""
+    from hermes_constants import assert_named_profile_home_live
+
     path = Path(profile_home)
     try:
         assert_named_profile_home_live(path)


### PR DESCRIPTION
## Summary

- reject stale compute-host frames when their profile directory has been deleted
- validate cached profile homes before reusing a live TUI session
- make dedicated profile database opens fail closed instead of recreating the directory

## Testing

- `scripts/run_tests.sh tests/tui_gateway/test_compute_host.py -k 'profile' -q`
- `scripts/run_tests.sh tests/tui_gateway/test_session_db_ownership_teardown.py -q`

## Related Issue

Closes #97347