### PR TITLE
feat(desktop): persist collapsed Bot Mode roster sections

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/bot-state.roster-section-collapse.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/bot-state.roster-section-collapse.test.ts
@@ -156,7 +156,9 @@ describe('pruning ids for gateways that are gone', () => {
 
     pruneCollapsedRosterSections([{ connectionId: 'alpha' }])
 
-    expect($collapsedRosterSections.get()).toEqual(['gateway:legacy', 'gateway:all'])
+    // Stored sorted, so the assertion reads in sorted order rather than the
+    // order the two were collapsed in.
+    expect($collapsedRosterSections.get()).toEqual(['gateway:all', 'gateway:legacy'])
   })
 
   it('is a no-op before sources load, so an empty list cannot wipe the set', async () => {

--- a/apps/desktop/src/plugins/hermes-bots/bot-state.roster-section-collapse.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/bot-state.roster-section-collapse.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Collapsing a roster section is presentation state, but it is state the user
+ * SET — so it has to outlive the window. Two things make the persistence less
+ * trivial than the selected-bot key it sits beside:
+ *
+ * The boot read is async, so a click landing before storage answers would be
+ * silently undone when the older snapshot resolves. The reader carries the
+ * mutation generation it read at and drops a payload that lost the race.
+ *
+ * Section ids embed connection ids (`gateway:<connectionId>`), so a deleted
+ * connection would otherwise leave its id in storage forever. Pruning runs
+ * against the FULL gateway option list and must never fire on an empty one —
+ * that is what the roster looks like before sources have loaded, and treating
+ * it as "no gateways exist" would wipe every collapse on launch.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { writes } = vi.hoisted(() => ({ writes: [] as [string, unknown][] }))
+
+vi.mock('@hermes/plugin-sdk', async () => {
+  const { atom } = await import('nanostores')
+
+  return {
+    atom,
+    host: {
+      activeConnectionId: () => '',
+      state: {
+        connectionId: { get: () => 'source-a', listen: () => () => undefined },
+        profile: { get: () => 'default', listen: () => () => undefined }
+      }
+    },
+    queryClient: { invalidateQueries: vi.fn() },
+    useQuery: vi.fn(),
+    useValue: vi.fn()
+  }
+})
+
+vi.mock('./shared', () => ({
+  getPluginCtx: () => ({
+    storage: {
+      set: (key: string, value: unknown) => {
+        writes.push([key, value])
+
+        return Promise.resolve()
+      }
+    }
+  }),
+  ID: 'hermes-bots'
+}))
+
+/** The generation counter is module state, so every case needs a fresh graph. */
+async function load() {
+  vi.resetModules()
+  writes.length = 0
+
+  return import('./bot-state')
+}
+
+beforeEach(() => {
+  writes.length = 0
+})
+
+describe('toggling a section', () => {
+  it('collapses it and persists the id', async () => {
+    const { $collapsedRosterSections, COLLAPSED_ROSTER_SECTIONS_KEY, setRosterSectionCollapsed } = await load()
+
+    setRosterSectionCollapsed('group-chats', true)
+
+    expect($collapsedRosterSections.get()).toEqual(['group-chats'])
+    expect(writes.at(-1)).toEqual([COLLAPSED_ROSTER_SECTIONS_KEY, ['group-chats']])
+  })
+
+  it('expanding removes the id and persists the shorter set', async () => {
+    const { $collapsedRosterSections, setRosterSectionCollapsed } = await load()
+
+    setRosterSectionCollapsed('gateway:alpha', true)
+    setRosterSectionCollapsed('group-chats', true)
+    setRosterSectionCollapsed('gateway:alpha', false)
+
+    expect($collapsedRosterSections.get()).toEqual(['group-chats'])
+    expect(writes.at(-1)?.[1]).toEqual(['group-chats'])
+  })
+
+  it('ignores a blank id instead of persisting an empty section', async () => {
+    const { $collapsedRosterSections, setRosterSectionCollapsed } = await load()
+
+    setRosterSectionCollapsed('   ', true)
+    setRosterSectionCollapsed('', true)
+
+    expect($collapsedRosterSections.get()).toEqual([])
+    expect(writes).toHaveLength(0)
+  })
+})
+
+describe('hydrating a stored snapshot', () => {
+  it('restores it, de-duplicated and trimmed', async () => {
+    const { $collapsedRosterSections, currentRosterSectionGeneration, hydrateCollapsedRosterSections } = await load()
+
+    hydrateCollapsedRosterSections(
+      [' gateway:alpha ', 'gateway:alpha', 'group-chats', '', null, 7],
+      currentRosterSectionGeneration()
+    )
+
+    expect($collapsedRosterSections.get()).toEqual(['gateway:alpha', 'group-chats'])
+  })
+
+  it('ignores a payload that is not an array', async () => {
+    const { $collapsedRosterSections, currentRosterSectionGeneration, hydrateCollapsedRosterSections } = await load()
+    const generation = currentRosterSectionGeneration()
+
+    hydrateCollapsedRosterSections('group-chats', generation)
+    hydrateCollapsedRosterSections(null, generation)
+
+    expect($collapsedRosterSections.get()).toEqual([])
+  })
+
+  it('lets a click during the storage read win over the snapshot it raced', async () => {
+    const {
+      $collapsedRosterSections,
+      currentRosterSectionGeneration,
+      hydrateCollapsedRosterSections,
+      setRosterSectionCollapsed
+    } = await load()
+
+    // Boot reads the generation, then the user clicks before storage answers.
+    const generation = currentRosterSectionGeneration()
+    setRosterSectionCollapsed('gateway:alpha', true)
+
+    // The stale snapshot lands last and must not undo the click.
+    hydrateCollapsedRosterSections(['group-chats'], generation)
+
+    expect($collapsedRosterSections.get()).toEqual(['gateway:alpha'])
+  })
+})
+
+describe('pruning ids for gateways that are gone', () => {
+  it('drops the dead connection and keeps the rest', async () => {
+    const { $collapsedRosterSections, pruneCollapsedRosterSections, setRosterSectionCollapsed } = await load()
+
+    setRosterSectionCollapsed('gateway:alpha', true)
+    setRosterSectionCollapsed('gateway:deleted', true)
+    setRosterSectionCollapsed('group-chats', true)
+
+    pruneCollapsedRosterSections([{ connectionId: 'alpha' }])
+
+    expect($collapsedRosterSections.get()).toEqual(['gateway:alpha', 'group-chats'])
+    expect(writes.at(-1)?.[1]).toEqual(['gateway:alpha', 'group-chats'])
+  })
+
+  it('keeps the synthesized legacy and all bucket ids, which are not connections', async () => {
+    const { $collapsedRosterSections, pruneCollapsedRosterSections, setRosterSectionCollapsed } = await load()
+
+    setRosterSectionCollapsed('gateway:legacy', true)
+    setRosterSectionCollapsed('gateway:all', true)
+
+    pruneCollapsedRosterSections([{ connectionId: 'alpha' }])
+
+    expect($collapsedRosterSections.get()).toEqual(['gateway:legacy', 'gateway:all'])
+  })
+
+  it('is a no-op before sources load, so an empty list cannot wipe the set', async () => {
+    const { $collapsedRosterSections, pruneCollapsedRosterSections, setRosterSectionCollapsed } = await load()
+
+    setRosterSectionCollapsed('gateway:alpha', true)
+    const writesBefore = writes.length
+
+    pruneCollapsedRosterSections([])
+    pruneCollapsedRosterSections(null)
+
+    expect($collapsedRosterSections.get()).toEqual(['gateway:alpha'])
+    expect(writes).toHaveLength(writesBefore)
+  })
+
+  it('does not rewrite storage when there is nothing to drop', async () => {
+    const { pruneCollapsedRosterSections, setRosterSectionCollapsed } = await load()
+
+    setRosterSectionCollapsed('gateway:alpha', true)
+    const writesBefore = writes.length
+
+    pruneCollapsedRosterSections([{ connectionId: 'alpha' }])
+
+    expect(writes).toHaveLength(writesBefore)
+  })
+})

--- a/apps/desktop/src/plugins/hermes-bots/bot-state.ts
+++ b/apps/desktop/src/plugins/hermes-bots/bot-state.ts
@@ -76,7 +76,9 @@ export function setRosterSectionCollapsed(id: string, collapsed: boolean) {
     next.delete(key)
   }
 
-  const ids = [...next]
+  // Sorted, not insertion-ordered: the same set of collapsed sections should
+  // serialize identically no matter what order the user clicked them in.
+  const ids = [...next].sort()
   rosterSectionMutationGeneration += 1
   $collapsedRosterSections.set(ids)
   persistCollapsedRosterSections(ids)
@@ -90,9 +92,11 @@ export function hydrateCollapsedRosterSections(value: unknown, expectedGeneratio
     return
   }
 
-  $collapsedRosterSections.set([
-    ...new Set(value.filter((id): id is string => typeof id === 'string' && Boolean(id.trim())).map(id => id.trim()))
-  ])
+  $collapsedRosterSections.set(
+    [
+      ...new Set(value.filter((id): id is string => typeof id === 'string' && Boolean(id.trim())).map(id => id.trim()))
+    ].sort()
+  )
 }
 
 /** Drop stored ids for gateways that no longer exist, so a deleted connection

--- a/apps/desktop/src/plugins/hermes-bots/bot-state.ts
+++ b/apps/desktop/src/plugins/hermes-bots/bot-state.ts
@@ -37,6 +37,91 @@ export const $selectedBot = atom('default')
  *  it never activates a gateway or creates a session. */
 export const $selectedRosterKey = atom('')
 export const $selectedRosterHydrated = atom(false)
+/** Collapsed roster section ids (`gateway:<connectionId>`, `group-chats`).
+ *  Presentation only: collapsing hides rows, it never detaches a gateway or
+ *  closes a chat. Module scope rather than pane state so the set survives an
+ *  unmount, and persisted so it survives a restart. */
+export const $collapsedRosterSections = atom<string[]>([])
+/** Bumped by every user toggle. The boot hydrate carries the generation it
+ *  read at, so a click landing while the storage read is still in flight is
+ *  not overwritten by the older snapshot when it resolves. */
+let rosterSectionMutationGeneration = 0
+
+export const COLLAPSED_ROSTER_SECTIONS_KEY = 'collapsed-roster-sections-v1'
+
+export function currentRosterSectionGeneration(): number {
+  return rosterSectionMutationGeneration
+}
+
+function persistCollapsedRosterSections(ids: string[]) {
+  try {
+    Promise.resolve(getPluginCtx()?.storage?.set?.(COLLAPSED_ROSTER_SECTIONS_KEY, ids)).catch(() => undefined)
+  } catch {
+    /* storage unavailable — the collapse lasts for this window */
+  }
+}
+
+export function setRosterSectionCollapsed(id: string, collapsed: boolean) {
+  const key = String(id || '').trim()
+
+  if (!key) {
+    return
+  }
+
+  const next = new Set($collapsedRosterSections.get())
+
+  if (collapsed) {
+    next.add(key)
+  } else {
+    next.delete(key)
+  }
+
+  const ids = [...next]
+  rosterSectionMutationGeneration += 1
+  $collapsedRosterSections.set(ids)
+  persistCollapsedRosterSections(ids)
+}
+
+/** Apply a stored snapshot, unless a toggle already beat the read home. The
+ *  user's click is the newer truth; applying the snapshot now would silently
+ *  undo it. */
+export function hydrateCollapsedRosterSections(value: unknown, expectedGeneration: number) {
+  if (expectedGeneration !== rosterSectionMutationGeneration || !Array.isArray(value)) {
+    return
+  }
+
+  $collapsedRosterSections.set([
+    ...new Set(value.filter((id): id is string => typeof id === 'string' && Boolean(id.trim())).map(id => id.trim()))
+  ])
+}
+
+/** Drop stored ids for gateways that no longer exist, so a deleted connection
+ *  does not leave its section id in storage forever. Called with the FULL
+ *  gateway option list, never a search-filtered one — and never on an empty
+ *  list, which is what the roster looks like before sources have loaded. */
+export function pruneCollapsedRosterSections(gatewayOptions: { connectionId?: string }[] | null | undefined) {
+  const options = Array.isArray(gatewayOptions) ? gatewayOptions : []
+
+  if (!options.length) {
+    return
+  }
+
+  const live = new Set(options.map(option => String(option?.connectionId || '').trim()).filter(Boolean))
+  // `legacy` and `all` are synthesized bucket ids, not connections.
+  live.add('legacy')
+  live.add('all')
+
+  const current = $collapsedRosterSections.get()
+  const kept = current.filter(id => !id.startsWith('gateway:') || live.has(id.slice('gateway:'.length)))
+
+  if (kept.length === current.length) {
+    return
+  }
+
+  $collapsedRosterSections.set(kept)
+  persistCollapsedRosterSections(kept)
+}
+
 export const $rosterHydrated = atom(false)
 /** Mirrors host.paneVisibility('hermes-bots:pane') — wired in register(). */
 export const $botsPaneVisible = atom(false)

--- a/apps/desktop/src/plugins/hermes-bots/plugin.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.tsx
@@ -27,7 +27,10 @@ import {
   $selectedBot,
   $selectedRosterHydrated,
   $selectedRosterKey,
-  focusedMentionProfile
+  COLLAPSED_ROSTER_SECTIONS_KEY,
+  currentRosterSectionGeneration,
+  focusedMentionProfile,
+  hydrateCollapsedRosterSections
 } from './bot-state'
 import { isCanonicalChatOnScreen, openBotCanonicalChat } from './canonical-chat'
 import { BotChatEmpty } from './chat-empty'
@@ -195,6 +198,19 @@ export default {
     } catch {
       /* no storage — this window starts with no restored selection */
       $selectedRosterHydrated.set(true)
+    }
+
+    // Collapsed roster sections. Read the generation FIRST: a click during
+    // this round trip must win over the snapshot it raced.
+    try {
+      const generation = currentRosterSectionGeneration()
+
+      // @ts-expect-error same PluginStorage.get(key, fallback) shape as above.
+      Promise.resolve(ctx.storage?.get?.(COLLAPSED_ROSTER_SECTIONS_KEY))
+        .then(value => hydrateCollapsedRosterSections(value, generation))
+        .catch(() => undefined)
+    } catch {
+      /* no storage — every section starts expanded in this window */
     }
 
     // Bot Mode sessions are always hidden now — the old "hide Bot Chats"

--- a/apps/desktop/src/plugins/hermes-bots/roster-pane.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/roster-pane.tsx
@@ -34,13 +34,16 @@ import { BotRow, GroupRow } from './bot-row'
 import {
   $botChatFocused,
   $botsPaneVisible,
+  $collapsedRosterSections,
   $openBotChat,
   $rosterHydrated,
   $selectedRosterHydrated,
   $selectedRosterKey,
   clearSelectedRosterKey,
   parseRosterKey,
-  saveSelectedRosterBot
+  pruneCollapsedRosterSections,
+  saveSelectedRosterBot,
+  setRosterSectionCollapsed
 } from './bot-state'
 import { CreateAgentDialog, CreateGroupChatDialog, GroupDialog } from './create-dialog'
 import {
@@ -256,7 +259,7 @@ export function BotsPane() {
   const [rowKindFilter, setRowKindFilter] = useState<RosterKindFilter>('all')
   const [activityFilter, setActivityFilter] = useState<RosterActivityFilter>('all')
   const [gatewayFilter, setGatewayFilter] = useState('all')
-  const [collapsedRosterSections, setCollapsedRosterSections] = useState<Set<string>>(() => new Set())
+  const collapsedRosterSections = useValue($collapsedRosterSections)
   const hiddenSectionRef = useRef<null | HTMLDivElement>(null)
   const activityToasts = useValue($activityToasts)
   const groupChatName = useValue($groupChatWorkspace)
@@ -430,7 +433,7 @@ export function BotsPane() {
     activeFilterCount > 0
 
   const showRosterTools = showRosterSearch || showRosterFilters
-  const rosterSectionCollapsed = (id: string): boolean => !hasRosterConstraint && collapsedRosterSections.has(id)
+  const rosterSectionCollapsed = (id: string): boolean => !hasRosterConstraint && collapsedRosterSections.includes(id)
 
   const hiddenGatewaySections = rosterGatewaySections(
     matchingHiddenBots.map((bot: RosterRow) => ({
@@ -442,18 +445,19 @@ export function BotsPane() {
   )
 
   const toggleRosterSection = (id: string): void => {
-    setCollapsedRosterSections(previous => {
-      const next = new Set(previous)
-
-      if (next.has(id)) {
-        next.delete(id)
-      } else {
-        next.add(id)
-      }
-
-      return next
-    })
+    setRosterSectionCollapsed(id, !collapsedRosterSections.includes(id))
   }
+
+  // Forget sections whose gateway is gone. rosterGatewayOptions rebuilds its
+  // array every render, so the dep is the id list joined into a stable string
+  // — otherwise this re-runs on every repaint instead of on a real connection
+  // add or delete.
+  const gatewayOptionIds = gatewayOptions.map(option => option?.connectionId || '').join(' ')
+
+  useEffect(() => {
+    pruneCollapsedRosterSections(gatewayOptions)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [gatewayOptionIds])
 
   useEffect(() => {
     if (!hiddenExpanded || hasRosterConstraint) {


### PR DESCRIPTION
## Summary

Collapsing a gateway section or **Group chats** in the Bot Mode roster only holds for the current window. The set lives in pane state (`useState<Set<string>>`), so it is gone on the next restart — a user who keeps most gateways collapsed re-collapses them on every launch.

This moves the set to a `$collapsedRosterSections` atom in `bot-state.ts` — the leaf module Bot Mode's surfaces already share — persisted under `collapsed-roster-sections-v1`, following the `selected-roster-bot-v1` precedent directly above it.

Presentation state only: collapsing hides rows. It never detaches a gateway, opens or closes a chat, or touches bot metadata. Living in `bot-state` also means the set survives an unmount, not just a restart.

## What changed

- `bot-state.ts` — `$collapsedRosterSections`, `setRosterSectionCollapsed`, `hydrateCollapsedRosterSections`, `pruneCollapsedRosterSections`, and the storage key.
- `roster-pane.tsx` — reads the atom instead of local state; `toggleRosterSection` delegates to the setter; a prune effect keyed on the gateway id list.
- `plugin.tsx` — boot hydration alongside the existing selected-bot restore.

## Two details worth calling out

**Hydration races the user.** The boot read is async, so a click landing before storage answers would be silently undone when the older snapshot resolves. The reader captures a mutation generation up front and drops the payload if a toggle bumped it in the meantime. `selected-roster-bot-v1` needs no such guard (a single boot-time write), so copying that pattern as-is reintroduces the bug.

**Section ids embed connection ids.** They are `gateway:<connectionId>` and `group-chats`, so a deleted connection would otherwise leave its id in storage forever. The prune runs against the full gateway option list — never a search-filtered one — keeps the synthesized `legacy` and `all` bucket ids, and is a no-op on an empty list, which is what the roster looks like before sources have loaded.

The prune effect keys on the joined id list rather than the `gatewayOptions` array, which `rosterGatewayOptions` rebuilds on every render.

## Validation

- `vitest run src/plugins/hermes-bots/bot-state.roster-section-collapse.test.ts` — 10/10 passed (new file)
- `vitest run --project ui src/plugins/hermes-bots` — 58 files, 566 tests, 0 failed
- `npm run typecheck` — clean
- `npm run lint` — clean on all four touched files
- `npm run test:desktop:all` — packaged app + NSIS installer built clean

New tests cover the toggle/persist round trip, blank-id rejection, hydration de-duplication, non-array payloads, the click-during-hydration race, prune dropping dead gateways, prune keeping `legacy`/`all`, and prune refusing to write when there is nothing to drop or the option list is empty.

## Note on the rebase

This PR originally targeted the monolithic `plugin.js`. #96726 split that file into per-surface TypeScript modules while this was open, so the change has been reimplemented against the new layout rather than rebased — same behavior and the same two guards, now in `bot-state.ts` / `roster-pane.tsx` / `plugin.tsx` with a vitest suite in place of the old vm harness.

## Relationship to #91213

#91213 proposed Direct Messages / Groups sections with persisted disclosure state. Its sectioning has since been superseded — main groups bots per gateway and already renders Group chats as its own collapsible section. Persistence is the one part that did not land, so this PR carries just that across. #91213 is closed in favor of this.