### PR TITLE
fix(tools): relay the message_agent reply, not the turn's trailing narration

### DIFF
--- a/tests/tools/test_bot_mode_dm.py
+++ b/tests/tools/test_bot_mode_dm.py
@@ -638,3 +638,116 @@ def test_dm_dir_rejects_precreated_symlink(tmp_path, monkeypatch):
 
     with pytest.raises(PermissionError, match="not a directory"):
         bot_mode_dm._dm_dir()
+
+
+# ── reply read-back: relay the message_agent payload, not trailing narration ──
+# Regression for the Bot-Mode "Track B" bug: _run_delivery captured the target
+# turn's final stdout (often a user-facing wrap-up) instead of the peer-addressed
+# message_agent reply the target actually composed. _peer_reply_after reads that
+# reply back from the target's own state.db so the right text is relayed.
+
+import sqlite3
+
+
+def _seed_target_db(path: Path, rows: list[dict]) -> None:
+    """Minimal `messages` table with the columns _peer_reply_after reads."""
+    conn = sqlite3.connect(str(path))
+    conn.execute(
+        "CREATE TABLE messages (id INTEGER PRIMARY KEY, session_id TEXT, "
+        "role TEXT, content TEXT, tool_calls TEXT, tool_name TEXT, timestamp REAL)"
+    )
+    for i, r in enumerate(rows, start=1):
+        conn.execute(
+            "INSERT INTO messages (id, session_id, role, content, tool_calls, "
+            "tool_name, timestamp) VALUES (?,?,?,?,?,?,?)",
+            (i, "sess-1", r["role"], r.get("content"), r.get("tool_calls"),
+             r.get("tool_name"), float(i)),
+        )
+    conn.commit()
+    conn.close()
+
+
+def _ma_call(target: str, message: str) -> str:
+    return json.dumps(
+        [{"function": {"name": "message_agent",
+                       "arguments": json.dumps({"target": target, "message": message})}}]
+    )
+
+
+def test_peer_reply_after_prefers_message_agent_over_trailing_narration(tmp_path):
+    db = tmp_path / "state.db"
+    reply = "Got you loud and clear, Sonny. Acknowledged, no action needed."
+    _seed_target_db(db, [
+        {"role": "user", "content": "Message from 🤖 sonny (@sonny): ping"},
+        {"role": "assistant", "content": "", "tool_calls": _ma_call("sonny", reply)},
+        {"role": "tool", "content": '{"status":"sent"}', "tool_name": "message_agent"},
+        # the trailing user-facing wrap-up the old code wrongly relayed
+        {"role": "assistant", "content": "Done — I relayed it to you. All good, Josh."},
+    ])
+    assert bot_mode_dm._peer_reply_after(db, 0, "sonny") == reply
+
+
+def test_peer_reply_after_falls_back_to_none_on_plain_text_reply(tmp_path):
+    db = tmp_path / "state.db"
+    _seed_target_db(db, [
+        {"role": "user", "content": "Message from 🤖 sonny (@sonny): ping"},
+        {"role": "assistant", "content": "Thanks, noted!"},  # no message_agent call
+    ])
+    # None => caller keeps the existing stdout-capture behaviour
+    assert bot_mode_dm._peer_reply_after(db, 0, "sonny") is None
+
+
+def test_peer_reply_after_matches_default_via_hermes_handle(tmp_path):
+    db = tmp_path / "state.db"
+    reply = "Round two ack — all clean on my end."
+    # target composed by handle "hermes"; sender profile is the default ("hermes")
+    _seed_target_db(db, [
+        {"role": "assistant", "content": "", "tool_calls": _ma_call("hermes", reply)},
+    ])
+    assert bot_mode_dm._peer_reply_after(db, 0, "hermes") == reply
+    assert bot_mode_dm._peer_reply_after(db, 0, "default") == reply
+
+
+def test_peer_reply_after_ignores_replies_to_other_agents(tmp_path):
+    db = tmp_path / "state.db"
+    _seed_target_db(db, [
+        {"role": "assistant", "content": "", "tool_calls": _ma_call("someone_else", "not for sonny")},
+    ])
+    assert bot_mode_dm._peer_reply_after(db, 0, "sonny") is None
+
+
+def test_peer_reply_after_respects_since_id_window(tmp_path):
+    db = tmp_path / "state.db"
+    _seed_target_db(db, [
+        {"role": "assistant", "content": "", "tool_calls": _ma_call("sonny", "old reply")},
+        {"role": "assistant", "content": "", "tool_calls": _ma_call("sonny", "new reply")},
+    ])
+    # only rows after id 1 are this turn's — must pick the new reply
+    assert bot_mode_dm._peer_reply_after(db, 1, "sonny") == "new reply"
+
+
+def test_db_high_water_and_missing_db(tmp_path):
+    db = tmp_path / "state.db"
+    assert bot_mode_dm._db_high_water(None) == -1
+    assert bot_mode_dm._db_high_water(tmp_path / "nope.db") == -1
+    _seed_target_db(db, [{"role": "user", "content": "hi"}])
+    assert bot_mode_dm._db_high_water(db) == 1
+
+
+def test_target_db_path_resolves_default_and_named(tmp_path, monkeypatch):
+    root = tmp_path / ".hermes"
+    (root / "profiles" / "sonny").mkdir(parents=True)
+    (root / "state.db").write_text("", encoding="utf-8")
+    (root / "profiles" / "sonny" / "state.db").write_text("", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    assert bot_mode_dm._target_db_path(["hermes", "-p", "default", "chat"]) == root / "state.db"
+    assert bot_mode_dm._target_db_path(["hermes", "-p", "sonny", "chat"]) == root / "profiles" / "sonny" / "state.db"
+    assert bot_mode_dm._target_db_path(["hermes", "chat"]) is None  # no -p
+
+
+def test_sender_handle_from_dm(tmp_path):
+    f = tmp_path / "dm.txt"
+    f.write_text("Message from 🤖 sonny (@sonny): hello there", encoding="utf-8")
+    assert bot_mode_dm._sender_handle_from_dm(str(f)) == "sonny"
+    f.write_text("no prefix here", encoding="utf-8")
+    assert bot_mode_dm._sender_handle_from_dm(str(f)) is None

--- a/tools/bot_mode_dm.py
+++ b/tools/bot_mode_dm.py
@@ -547,6 +547,106 @@ def _delivery_lock(argv: list[str], *, stdin_file: bool):
     return acquire_turn_lock(_hermes_root(home), argv[2])
 
 
+def _target_db_path(argv: list[str]) -> Optional[Path]:
+    """state.db of the ``-p <profile>`` target in a query-file delivery.
+
+    Named profiles live under ``profiles/<name>/state.db``; the default
+    profile uses the root ``state.db``. Returns None if the profile can't be
+    resolved or its DB doesn't exist yet.
+    """
+    profile = None
+    for i, tok in enumerate(argv):
+        if tok == "-p" and i + 1 < len(argv):
+            profile = argv[i + 1]
+            break
+    if not profile:
+        return None
+    root = _hermes_root(
+        Path(os.getenv("HERMES_HOME") or os.path.expanduser("~/.hermes"))
+    )
+    db = root / "state.db" if profile == "default" else root / "profiles" / profile / "state.db"
+    return db if db.exists() else None
+
+
+def _sender_handle_from_dm(dm_file: str) -> Optional[str]:
+    """The '@<handle>' the inbound DM is attributed to, parsed from its
+    ``Message from 🤖 <name> (@<handle>):`` prefix — used to match the
+    target's reply back to the original sender."""
+    try:
+        head = Path(dm_file).read_text(encoding="utf-8", errors="replace")[:400]
+    except OSError:
+        return None
+    m = re.search(r"\(@([^)]+)\)\s*:", head)
+    return m.group(1).strip().lower() if m else None
+
+
+def _db_high_water(db_path: Optional[Path]) -> int:
+    """Max message id in the target DB before the turn runs (-1 if none)."""
+    if not db_path:
+        return -1
+    try:
+        import sqlite3
+
+        with sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=5) as conn:
+            row = conn.execute("SELECT MAX(id) FROM messages").fetchone()
+        return int(row[0]) if row and row[0] is not None else -1
+    except Exception:
+        return -1
+
+
+def _peer_reply_after(
+    db_path: Optional[Path], since_id: int, sender_handle: Optional[str]
+) -> Optional[str]:
+    """The target's own ``message_agent`` reply addressed back to the sender.
+
+    Scans assistant rows created after ``since_id`` (this turn's rows, since
+    the per-profile turn lock serialises deliveries) for a ``message_agent``
+    call targeting ``sender_handle`` and returns its ``message`` — the text
+    that SHOULD be relayed, not the turn's trailing (often user-facing)
+    narration that stdout captures. Returns None when the target replied in
+    plain text (no such call), so the caller falls back to stdout.
+    """
+    if not db_path or not sender_handle:
+        return None
+
+    def _norm(h: str) -> str:
+        h = h.strip().lstrip("@").lower()
+        return "hermes" if h in ("hermes", "default") else h
+
+    want = _norm(sender_handle)
+    try:
+        import sqlite3
+
+        with sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=5) as conn:
+            rows = conn.execute(
+                "SELECT tool_calls FROM messages "
+                "WHERE id > ? AND role = 'assistant' AND tool_calls IS NOT NULL "
+                "ORDER BY id DESC",
+                (since_id,),
+            ).fetchall()
+    except Exception:
+        return None
+    for (raw,) in rows:
+        try:
+            calls = json.loads(raw) if isinstance(raw, str) else raw
+        except (ValueError, TypeError):
+            continue
+        for call in calls if isinstance(calls, list) else []:
+            fn = (call or {}).get("function") or {}
+            if fn.get("name") != "message_agent":
+                continue
+            args = fn.get("arguments")
+            try:
+                parsed = json.loads(args) if isinstance(args, str) else (args or {})
+            except (ValueError, TypeError):
+                continue
+            if _norm(str(parsed.get("target") or "")) == want:
+                msg = str(parsed.get("message") or "").strip()
+                if msg:
+                    return msg
+    return None
+
+
 def _run_delivery(argv: list[str], dm_file: str, *, stdin_file: bool) -> int:
     """Run one DM transport and remove its plaintext file after consumption.
 
@@ -569,6 +669,13 @@ def _run_delivery(argv: list[str], dm_file: str, *, stdin_file: bool) -> int:
                 # after subprocess.run returns, not merely after stdin reaches EOF.
                 with open(dm_file, "r", encoding="utf-8") as stream:
                     return subprocess.run(argv, stdin=stream, check=False).returncode
+            # Capture the target DB high-water + sender handle BEFORE the turn
+            # so we can read back the target's own message_agent reply (the
+            # peer-addressed text) instead of relaying its trailing, often
+            # user-facing, narration.
+            db_path = _target_db_path(argv)
+            sender_handle = _sender_handle_from_dm(dm_file)
+            pre_id = _db_high_water(db_path) if (db_path and sender_handle) else -1
             proc = subprocess.run(
                 [*argv, "--query-file", dm_file],
                 check=False,
@@ -590,9 +697,20 @@ def _run_delivery(argv: list[str], dm_file: str, *, stdin_file: bool) -> int:
                         capture_output=True,
                         text=True,
                     )
-            # Re-emit the transport's streams: stdout is the reply text the
-            # completion notification carries back to the sending agent.
-            if proc.stdout:
+            # Prefer the target's own message_agent reply (addressed back to the
+            # sender) over the turn's trailing stdout, which is frequently a
+            # user-facing wrap-up rather than the peer reply. Fall back to
+            # stdout when the target replied in plain text (no message_agent
+            # call) or on any read-back error — never worse than before.
+            reply = (
+                _peer_reply_after(db_path, pre_id, sender_handle)
+                if proc.returncode == 0
+                else None
+            )
+            if reply is not None:
+                sys.stdout.write(reply)
+                sys.stdout.flush()
+            elif proc.stdout:
                 sys.stdout.write(proc.stdout)
                 sys.stdout.flush()
             if proc.stderr:

--- a/tools/bot_mode_probe.py
+++ b/tools/bot_mode_probe.py
@@ -274,7 +274,10 @@ def _build_section(home: Path) -> str:
         "explicitly asked.\n"
         f'When YOU receive a "Message from 🤖 <name> (@<handle>):" message, a '
         "teammate agent is talking to you (not the user): address them, reply "
-        "concisely via message_agent to their handle, and if it is a pure FYI "
+        "concisely via message_agent to their handle. That message_agent call "
+        "IS your reply — do NOT add a further remark addressed to the user "
+        "after it in the same turn (no \"I'll relay it to you\" / \"all good\" "
+        "wrap-up); end the turn on the tool call. If it is a pure FYI "
         "with nothing to add, staying silent is fine — never ping-pong "
         "acknowledgements.\n"
         f"You are `@{handle}`. Your teammates (live roster; roles from their "


### PR DESCRIPTION
## What does this PR do?

Fixes a Bot Mode agent-to-agent messaging bug: the reply relayed back to the
**sending** agent is not the text the receiving agent actually composed, but a
second, unrelated closing remark written afterward in the receiver's own
"talking to the user" voice.

Root cause is in `tools/bot_mode_dm.py::_run_delivery`. The completion
notification returned to the sender captures **whatever the target turn's final
stdout was** (`-Q` one-shot mode prints the turn's final assistant text). When
the receiving agent does the normal tool-calling thing — call `message_agent`
to reply, *then* add a short wrap-up after the tool result — that trailing
wrap-up (often addressed to the human, e.g. "…I'll relay it to you", "All good,
Josh") is what gets captured and relayed. The real, correctly-addressed reply —
the `message_agent` argument — is ded.

This approach reads the receiver's ack from its
per-profile `state.db` and relays *ack to the existing
stdout capture only when the receivno `message_agent`
call). The already-correct direct-ilain-text replies
are untouched.

## Related Issue

No separate issue filed — full reprate.db` evidence,
and root-cause analysis are includebody.

## Type of Change

- [x] 🐛 Bug fix (non-breaking chan

## Changes Made

- `tools/bot_mode_dm.py` — after th the target's own
  `message_agent` reply addressed b per-profile
  `state.db` and relay that insteaddout. Falls back to
  stdout on plain-text replies or aworse than before).
  Helpers: `_target_db_path`, `_senhigh_water`,
  `_peer_reply_after`.
- `tools/bot_mode_probe.py` — tightrotocol so a reply
  IS the `message_agent` call, withended after it in
  the same turn.

## How to Test

1. From a Bot Chat, `message_agent(age="ping 1")`.
2. Wait for the completion notifica
3. Query the target's Bot Chat sess
   ```sql
   SELECT id, role, content, tool_c
   WHERE session_id = '<target Bot  id DESC LIMIT 6;
4. Confirm the notification text noent of the
target's own message_agent tool calt text in
that turn.

Automated: 8 new cases in tests/toolay prefers the
message_agent payload over trailing narration; plain-text fallback; handle
normalization; since-id window). teest_bot_mode_probe.py (14) pass.

Checklist

Code

- [x] I've read the Contributing Gu
- [x] My commit messages follow Conls): …)
- [x] I searched for existing PRs tuplicate
- [x] My PR contains only changes r
- [x] I've run the affected suites:assed) + test_bot_mode_probe.py (14
passed)
- [x] I've added tests for my changools/test_bot_mode_dm.py)
- [x] I've tested on my platform: milicon)

Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings) — or N/A
- [x] I've updated cli-config.yaml. config keys — N/A (no config keys)
- [x] I've updated CONTRIBUTING.md/hitecture — N/A
- [x] I've considered cross-platforre sqlite3/pathlib; no
platform-specific primitives