### PR TITLE
fix(cron): prevent false gateway-down warnings in gateway process

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -1349,6 +1349,16 @@ def resolve_gateway_liveness(
     monkeypatch seam in the test-suite keeps working; production callers
     leave them ``None`` and get this module's implementations.
     """
+    # A model tool can execute in the gateway's own process. In that context
+    # process-table scans and the gateway's self-held runtime lock can both
+    # produce a false negative even though the caller is the gateway runtime.
+    # Treat the process identity as authoritative, but only for the active
+    # Hermes home so a multiplexed gateway cannot answer for another profile.
+    active_home = get_hermes_home().resolve()
+    requested_home = profile_dir.resolve() if profile_dir is not None else active_home
+    if requested_home == active_home and looks_like_gateway_command_line(" ".join(sys.argv)):
+        return GatewayLiveness(running=True, pid=os.getpid(), source="self")
+
     _pid_probe = pid_probe or (
         get_running_pid_cached if use_cache else get_running_pid
     )

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -78,9 +78,16 @@ def _builtin_gateway_liveness() -> Optional[bool]:
     try:
         if _active_cron_provider_name() != "builtin":
             return True  # external provider fires jobs without the gateway
-        from hermes_cli.gateway import find_gateway_pids
+        from gateway.status import resolve_gateway_liveness
+        from hermes_constants import get_hermes_home
 
-        return bool(find_gateway_pids())
+        result = resolve_gateway_liveness(profile_dir=get_hermes_home())
+        # ``False`` plus a probe error means "unknown", not "stopped". The
+        # cron warning is user-facing, so it must never turn an unreadable
+        # status source into a confident outage claim.
+        if result.probe_error and not result.running:
+            return None
+        return result.running
     except Exception:
         return None
 

--- a/tests/cron/test_87033_cronjob_gateway_liveness.py
+++ b/tests/cron/test_87033_cronjob_gateway_liveness.py
@@ -159,10 +159,11 @@ class TestListSurfacesGatewayLiveness:
 
 
 from contextlib import ExitStack
+from types import SimpleNamespace
 
 
 class _LivenessPatches:
-    """Context manager patching the provider/gateway-pid probes."""
+    """Context manager patching the provider/canonical gateway probe."""
 
     def __init__(self, *, provider, pids):
         self._provider = provider
@@ -186,8 +187,13 @@ class _LivenessPatches:
         )
         self._stack.enter_context(
             patch(
-                "hermes_cli.gateway.find_gateway_pids",
-                return_value=list(self._pids),
+                "gateway.status.resolve_gateway_liveness",
+                return_value=SimpleNamespace(
+                    running=bool(self._pids),
+                    pid=self._pids[0] if self._pids else None,
+                    source="pid" if self._pids else "none",
+                    probe_error=False,
+                ),
             )
         )
         return self

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -1349,6 +1349,22 @@ class TestResolveGatewayLiveness:
         assert result.probe_error is True
 
 
+    def test_gateway_process_is_authoritative_for_its_active_profile(self, tmp_path, monkeypatch):
+        """An in-gateway tool call cannot report its host process as down."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(sys, "argv", ["python", "-m", "hermes_cli.main", "gateway", "run"])
+
+        result = status.resolve_gateway_liveness(
+            profile_dir=tmp_path,
+            use_cache=False,
+            pid_probe=lambda *a, **k: None,
+        )
+
+        assert result.running is True
+        assert result.pid == os.getpid()
+        assert result.source == "self"
+        assert result.probe_error is False
+
     def test_profile_dir_scopes_every_read_to_that_profile(self, tmp_path):
         """Gateway identity files live in the per-profile home.
 


### PR DESCRIPTION
## Summary

The cron liveness warning could report `gateway_running: false` from a model-tool call executing inside a live gateway process. This patch makes the shared resolver recognize the gateway process itself as authoritative for the active Hermes profile, while retaining the tri-state `None` behavior for probe errors.

## Changes

- Use `resolve_gateway_liveness()` from the builtin cron adapter instead of the weaker `find_gateway_pids()` heuristic.
- Return unknown rather than a confident stopped result when the resolver reports a probe error.
- Short-circuit the canonical resolver to the current PID when its command line is `gateway run` and the requested profile is the active Hermes home.
- Update cron regression mocks and add an in-process/profile-scoping regression test.

## Validation

- `pytest -q tests/gateway/test_status.py tests/cron/test_87033_cronjob_gateway_liveness.py`
- Result: **77 passed, 2 skipped**
- `python3 -m compileall` and `git diff --check` pass.

Fixes #97291