### PR TITLE
fix(gateway): gate /steer on a live turn in command.dispatch

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -11139,6 +11139,76 @@ def test_snapshot_restore_is_blocked_from_tui_worker():
     )
 
 
+def test_command_dispatch_steer_falls_back_to_send_when_session_idle(monkeypatch):
+    """An idle session must not accept a /steer (#97371).
+
+    AIAgent.steer() parks the text in _pending_steer regardless of whether a
+    turn is live; with no running turn no drain hook ever fires, so the
+    message was silently discarded right after the UI reported "Steer
+    queued". The dispatcher must gate on session["running"] and return the
+    send fallback instead — the same next-turn semantics as /queue.
+    """
+    monkeypatch.setattr(server, "_load_cfg", lambda: {})
+    calls = {}
+
+    class _Agent:
+        def steer(self, text):
+            calls["steer_text"] = text
+            return True
+
+    server._sessions["sid"] = _session(agent=_Agent())  # running=False
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "command.dispatch",
+                "params": {
+                    "name": "steer",
+                    "arg": "do not change the config yet",
+                    "session_id": "sid",
+                },
+            }
+        )
+    finally:
+        server._sessions.pop("sid", None)
+
+    assert "result" in resp, resp
+    assert resp["result"]["type"] == "send"
+    assert resp["result"]["message"] == "do not change the config yet"
+    assert "steer_text" not in calls  # idle session must not stash a steer
+
+
+def test_command_dispatch_steer_injects_when_turn_running(monkeypatch):
+    monkeypatch.setattr(server, "_load_cfg", lambda: {})
+    calls = {}
+
+    class _Agent:
+        def steer(self, text):
+            calls["steer_text"] = text
+            return True
+
+    server._sessions["sid"] = _session(agent=_Agent(), running=True)
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "command.dispatch",
+                "params": {
+                    "name": "steer",
+                    "arg": "also check auth.log",
+                    "session_id": "sid",
+                },
+            }
+        )
+    finally:
+        server._sessions.pop("sid", None)
+
+    assert "result" in resp, resp
+    assert resp["result"]["type"] == "exec"
+    assert "Steer queued" in resp["result"]["output"]
+    assert calls["steer_text"] == "also check auth.log"
+
+
 def test_command_dispatch_exec_nonzero_surfaces_error(monkeypatch):
     monkeypatch.setattr(
         server,

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -798,7 +798,20 @@ def _(rid, params: dict) -> dict:
         if not arg:
             return _err(rid, 4004, "usage: /steer <prompt>")
         agent = session.get("agent") if session else None
-        if agent and hasattr(agent, "steer"):
+        # AIAgent.steer() has no notion of a live turn: it stashes the text
+        # in _pending_steer and returns True unconditionally. On an idle
+        # session no drain hook ever fires (there is no next tool call), so
+        # the message is silently discarded right after the UI reported
+        # "Steer queued" (#97371). Gate on session["running"] — the same
+        # guard the CLI applies via _agent_running and the TUI via its busy
+        # check — so an idle session falls through to the send fallback
+        # below (identical to /queue semantics).
+        if session is not None:
+            with session["history_lock"]:
+                _steer_live = bool(session.get("running"))
+        else:
+            _steer_live = False
+        if _steer_live and agent and hasattr(agent, "steer"):
             try:
                 accepted = agent.steer(arg)
                 if accepted:


### PR DESCRIPTION
## What does this PR do?

`/steer` sent after a turn had already finished was silently discarded on the Desktop path. Root cause: Desktop routes `/steer` through `slash.exec` → `command.dispatch`, and the dispatch branch called `agent.steer(arg)` whenever an agent object existed — without checking `session["running"]`. `AIAgent.steer()` has no notion of a live turn: it stashes the text in `_pending_steer` and returns `True` unconditionally. On an idle session no drain hook ever fires (there is no next tool call), so the message sat unread while the UI had just reported "⏩ Steer queued". The turn-end leftover requeue (`result["pending_steer"]` in `_run_prompt_submit`'s tail) only captures steers that arrived *while* the turn was live, so it cannot cover this window.

Every other entry point already gates on liveness — the classic CLI checks `self._agent_running` (cli.py), the Ink TUI checks `ctx.ui.busy` before calling `session.steer`, and `_busy_submit` reads `session["running"]` under `history_lock` before steering. This PR adds the same gate to `command.dispatch`: read `session["running"]` under `history_lock` (mirroring the `/retry` branch in the same handler) and only steer a live session. An idle session falls through to the existing send fallback — `{"type": "send", "message": arg}` — which is exactly what `/queue` returns from the same handler, so the message is submitted as the next prompt instead of being lost.

The residual race (session observed running, turn settles milliseconds later) is the same window the other entry points accept, and it is covered by the turn-end leftover requeue.

## Related Issue

Fixes #97371

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/methods_tools.py` — `command.dispatch` `/steer` branch: read `session["running"]` under `history_lock` before calling `agent.steer()`; an idle session (or a steer-less agent, as before) falls through to the `send` fallback.
- `tests/test_tui_gateway_server.py` — two regression tests: an idle session with a steer-capable agent must return `{"type": "send"}` and must NOT stash a steer; a running session still steers and reports "Steer queued".

## How to Test

1. `uv run --extra dev python -m pytest tests/test_tui_gateway_server.py -k command_dispatch_steer -q`
   - Observed result: 2 passed — idle session returns `type=send` with the payload and `agent.steer()` is never called; running session steers.
2. `uv run --extra dev python -m pytest tests/test_tui_gateway_server.py tests/test_tui_gateway_queue_on_busy.py -q`
   - Observed result: 649 passed (full tui_gateway suites, no regressions).
3. Manual (Desktop, pre-fix behavior from the issue): let a turn finish, then send `/steer <text>` — the message vanished. With the fix, the same command submits the text as the next prompt, identical to `/queue <text>`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
