### PR TITLE
fix(stream): ignore malformed content and reasoning deltas

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -4192,7 +4192,11 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 model_name = chunk.model
 
             # Accumulate reasoning content
-            reasoning_text = getattr(delta, "reasoning_content", None) or getattr(delta, "reasoning", None)
+            reasoning_text = getattr(delta, "reasoning_content", None)
+            if not isinstance(reasoning_text, str) or not reasoning_text:
+                reasoning_text = getattr(delta, "reasoning", None)
+            if not isinstance(reasoning_text, str):
+                reasoning_text = None
             if reasoning_text:
                 # Summary-part models (gpt-5.x and other Responses relays) send
                 # one complete markdown block per delta with no separator, so

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -4209,8 +4209,14 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             # Accumulate text content — fire callback only when no tool calls.
             # Some OpenAI-compatible providers emit a text delta as a list of
             # content blocks.  Convert it once so callbacks and the synthetic
-            # completion message always receive plain text.
-            delta_content = flatten_message_text(getattr(delta, "content", None), sep="")
+            # completion message always receive plain text. Ignore scalar
+            # non-text values rather than exposing malformed token IDs.
+            raw_delta_content = getattr(delta, "content", None)
+            delta_content = (
+                flatten_message_text(raw_delta_content, sep="")
+                if isinstance(raw_delta_content, (str, list))
+                else None
+            )
             if delta_content:
                 content_parts.append(delta_content)
                 if not tool_calls_acc:

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -15,14 +15,14 @@ import pytest
 
 def _make_stream_chunk(
     content=None, tool_calls=None, finish_reason=None,
-    model=None, reasoning_content=None, usage=None,
+    model=None, reasoning_content=None, reasoning=None, usage=None,
 ):
     """Build a mock streaming chunk matching OpenAI's ChatCompletionChunk shape."""
     delta = SimpleNamespace(
         content=content,
         tool_calls=tool_calls,
         reasoning_content=reasoning_content,
-        reasoning=None,
+        reasoning=reasoning,
     )
     choice = SimpleNamespace(
         index=0,
@@ -677,6 +677,45 @@ class TestReasoningStreaming:
         assert text_deltas == ["The answer is 42"]
         assert response.choices[0].message.reasoning_content == "Let me think about this"
         assert response.choices[0].message.content == "The answer is 42"
+
+    @pytest.mark.parametrize("reasoning_field", ["reasoning_content", "reasoning"])
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_ignores_non_string_reasoning_delta(
+        self, mock_close, mock_create, reasoning_field
+    ):
+        """Malformed reasoning cannot abort later reasoning or text deltas."""
+        from run_agent import AIAgent
+
+        chunks = [
+            _make_stream_chunk(**{reasoning_field: 42}),
+            _make_stream_chunk(reasoning_content="still thinking"),
+            _make_stream_chunk(content="still delivered", finish_reason="stop"),
+        ]
+        reasoning_deltas = []
+        text_deltas = []
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = iter(chunks)
+        mock_create.return_value = mock_client
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            stream_delta_callback=text_deltas.append,
+            reasoning_callback=reasoning_deltas.append,
+        )
+        agent.api_mode = "chat_completions"
+        agent._interrupt_requested = False
+
+        response = agent._interruptible_streaming_api_call({})
+
+        assert response.choices[0].message.reasoning_content == "still thinking"
+        assert response.choices[0].message.content == "still delivered"
+        assert reasoning_deltas == ["still thinking"]
+        assert text_deltas == ["still delivered"]
 
 
 # ── Test: _has_stream_consumers ──────────────────────────────────────────

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -98,6 +98,37 @@ class TestStreamingAccumulator:
 
     @patch("run_agent.AIAgent._create_request_openai_client")
     @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_ignores_non_string_content_delta(self, mock_close, mock_create):
+        """Malformed provider content cannot abort a later text delta."""
+        from run_agent import AIAgent
+
+        chunks = [
+            _make_stream_chunk(content=42),
+            _make_stream_chunk(content="still delivered", finish_reason="stop"),
+        ]
+        deltas = []
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = iter(chunks)
+        mock_create.return_value = mock_client
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            stream_delta_callback=deltas.append,
+        )
+        agent.api_mode = "chat_completions"
+        agent._interrupt_requested = False
+
+        response = agent._interruptible_streaming_api_call({})
+
+        assert response.choices[0].message.content == "still delivered"
+        assert deltas == ["still delivered"]
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
     def test_sparse_delta_allows_missing_optional_fields(self, mock_close, mock_create):
         """Managed stream deltas may omit both content and tool_calls."""
         from run_agent import AIAgent


### PR DESCRIPTION
## What does this PR do?

Fixes streaming corruption when an OpenAI-compatible provider sends a scalar non-string `delta.content`, `delta.reasoning_content`, or compatibility `delta.reasoning` value.

The shared chat-completions streaming boundary now rejects scalar non-text values before they enter text buffers, callbacks, or final joins. It deliberately does not stringify malformed integer token IDs into visible output. The current upstream list-content normalization is retained, so valid list-shaped text blocks continue to reach callbacks and the synthetic completion message.

## Related Issue

Fixes #97382

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `agent/chat_completion_helpers.py`: preserve current-main list-content flattening while rejecting scalar non-text content, and validate both structured reasoning carriers at intake.
- `tests/run_agent/test_streaming.py`: cover malformed integer content plus both reasoning carriers followed by valid reasoning and text.

## How to Test

1. On current base `4209d371aa1bb8840ce8447555bdd863a1a96c38`, the real stream accumulator returns `42still delivered` for an integer content delta followed by a valid text delta: upstream normalization would otherwise stringify the malformed token ID.
2. On current head `1e6eca864ecdb6ee1d533cbceef73f837c72d806`, the same real path returns only `still delivered`; valid list-shaped content remains handled by the current-main regression.
3. Run `uv run --extra dev --extra anthropic --locked python -m pytest -q tests/run_agent/test_streaming.py` (38 passed, 4 skipped).
4. Run `uv run --extra dev --extra anthropic --locked ruff check agent/chat_completion_helpers.py tests/run_agent/test_streaming.py` and `uv run --extra dev --extra anthropic --locked python -m compileall -q agent/chat_completion_helpers.py tests/run_agent/test_streaming.py`.
5. Run `git diff origin/main...HEAD --check` and `trufflehog filesystem --no-update --only-verified agent/chat_completion_helpers.py tests/run_agent/test_streaming.py` (0 verified secrets).

## Checklist

### Code

- [x] I have read the Contributing Guide.
- [x] My commit messages follow Conventional Commits.
- [x] I searched existing open and merged PRs for the issue, exception text, owner, and stream-content terms.
- [x] This PR contains only the streaming-boundary fix and its regressions.
- [ ] I have run `pytest tests/ -q` and all tests pass. The focused streaming suite passed; the full repository suite was not run.
- [x] I have added regression tests.
- [x] I tested on macOS with Python 3.11.
- [x] Rebased on current `main` to resolve the current-head conflict without discarding the newly merged list-content behavior.

### Documentation and Housekeeping

- [x] Documentation update is N/A; the defensive behavior is internal.
- [x] `cli-config.yaml.example` update is N/A; no config changed.
- [x] `CONTRIBUTING.md` and `AGENTS.md` update is N/A; architecture and workflow did not change.
- [x] Cross-platform impact considered; the guard is pure Python wire-data validation.
- [x] Tool descriptions and schemas are N/A; tool behavior did not change.

## Screenshots / Logs

N/A. The exact base/candidate stream accumulator proof above shows malformed scalar values are no longer exposed while following valid content is delivered.