### PR TITLE
docs(browser): document native Camofox setup and clean-stop persistence

### DIFF
--- a/contributors/emails/islamimad66@gmail.com
+++ b/contributors/emails/islamimad66@gmail.com
@@ -1,0 +1,2 @@
+Elshayib
+# PR #97391

--- a/website/docs/user-guide/features/browser.md
+++ b/website/docs/user-guide/features/browser.md
@@ -223,6 +223,21 @@ to fully quit the browser — it won't loop or kill again on its own.
 
 [Camofox](https://github.com/jo-inc/camofox-browser) is a self-hosted Node.js server wrapping Camoufox (a Firefox fork with C++ fingerprint spoofing). It provides local anti-detection browsing without cloud dependencies.
 
+Camofox's own quick start is native Node — no Docker. That path works on Windows, including with Hermes-managed Node (no system Node required):
+
+```bash
+git clone https://github.com/jo-inc/camofox-browser
+cd camofox-browser
+npm install && npm start
+# -> http://localhost:9377
+```
+
+First run downloads the Camoufox binary (~300MB). `GET http://localhost:9377/health` should report `ok: true`. Shorthand: `npx @askjo/camofox-browser`.
+
+**Headed vs headless (native installs).** Docker's headed path is VNC (`ENABLE_VNC=1`). On a native install the lever is `interactive.mode` in `camofox.config.json` (or the `CAMOFOX_INTERACTIVE` env var): `off` (default, headless), `desktop` (visible Camoufox window for manual logins), `novnc`, or `auto`. Restart the Camofox server after changing it.
+
+#### Docker
+
 ```bash
 # Clone the Camofox browser server first
 git clone https://github.com/jo-inc/camofox-browser
@@ -343,7 +358,11 @@ If the flag is placed at the wrong path, Hermes silently falls back to a random 
 
 1. Start Hermes and your Camofox server.
 2. Open Google (or any login site) in a browser task and sign in manually.
-3. End the browser task normally.
+3. End the browser task normally. Camofox checkpoints storage on session close and process shutdown — do not kill the Node process (a hard kill skips the shutdown hook and drops uncheckpointed logins). If you set `CAMOFOX_ADMIN_KEY`, you can also stop the engine without killing Node:
+   ```bash
+   curl -X POST http://localhost:9377/stop -H "x-admin-key: $CAMOFOX_ADMIN_KEY"
+   ```
+   `POST /stop` requires that admin key; without it, end the Hermes task and let the Node process exit cleanly.
 4. Start a new browser task.
 5. Open the same site again — you should still be signed in.
 

--- a/website/docs/user-guide/features/browser.md
+++ b/website/docs/user-guide/features/browser.md
@@ -223,7 +223,7 @@ to fully quit the browser — it won't loop or kill again on its own.
 
 [Camofox](https://github.com/jo-inc/camofox-browser) is a self-hosted Node.js server wrapping Camoufox (a Firefox fork with C++ fingerprint spoofing). It provides local anti-detection browsing without cloud dependencies.
 
-Camofox's own quick start is native Node — no Docker. That path works on Windows, including with Hermes-managed Node (no system Node required):
+Camofox's own quick start is native Node — no Docker. That path works on Windows:
 
 ```bash
 git clone https://github.com/jo-inc/camofox-browser
@@ -232,9 +232,20 @@ npm install && npm start
 # -> http://localhost:9377
 ```
 
-First run downloads the Camoufox binary (~300MB). `GET http://localhost:9377/health` should report `ok: true`. Shorthand: `npx @askjo/camofox-browser`.
+First run downloads Camoufox (hundreds of MB). `GET http://localhost:9377/health` should report `ok: true`. Shorthand: `npx @askjo/camofox-browser`.
+
+To use Hermes-managed Node instead of a system install, put `~/.hermes/node` on `PATH` (Windows default profile: `%LOCALAPPDATA%\hermes\node`).
 
 **Headed vs headless (native installs).** Docker's headed path is VNC (`ENABLE_VNC=1`). On a native install the lever is `interactive.mode` in `camofox.config.json` (or the `CAMOFOX_INTERACTIVE` env var): `off` (default, headless), `desktop` (visible Camoufox window for manual logins), `novnc`, or `auto`. Restart the Camofox server after changing it.
+
+Point Hermes at the server and pick the backend:
+
+```bash
+# ~/.hermes/.env
+CAMOFOX_URL=http://localhost:9377
+```
+
+Pick **Camofox** in `hermes tools` → Browser Automation, which writes `browser.cloud_provider: camofox` to `config.yaml`. `CAMOFOX_URL` is only the server address — setting it no longer selects the backend by itself once a browser selection exists (never-configured setups still autodetect it).
 
 #### Docker
 
@@ -293,12 +304,6 @@ make down
 # then run the custom docker run command above
 ```
 
-Then set in `~/.hermes/.env`:
-
-```bash
-CAMOFOX_URL=http://localhost:9377
-```
-
 If Camofox is running in Docker and you want it to open web apps served from the host machine, enable loopback rewriting. `CAMOFOX_URL` should still point at the host-published control API, but page URLs such as `http://127.0.0.1:3000` must be opened from inside the container as `http://host.docker.internal:3000`:
 
 ```yaml
@@ -317,10 +322,6 @@ CAMOFOX_LOOPBACK_HOST_ALIAS=host.docker.internal
 ```
 
 The rewrite only applies to page navigation URLs with loopback hosts (`localhost`, `127.0.0.1`, `::1`). It does not change `CAMOFOX_URL`. Leave it disabled for non-Docker Camofox installs, where the browser already runs on the host and loopback URLs are correct.
-
-Or configure via `hermes tools` → Browser Automation → Camofox.
-
-Camofox is selected like any other browser backend: pick **Camofox** in `hermes tools` → Browser Automation, which writes `browser.cloud_provider: camofox` to `config.yaml`. `CAMOFOX_URL` is only the server address — setting it no longer selects the backend by itself once a browser selection exists (never-configured setups still autodetect it).
 
 #### Persistent browser sessions
 
@@ -356,14 +357,20 @@ If the flag is placed at the wrong path, Hermes silently falls back to a random 
 
 ##### Verify it's working
 
-1. Start Hermes and your Camofox server.
-2. Open Google (or any login site) in a browser task and sign in manually.
-3. End the browser task normally. Camofox checkpoints storage on session close and process shutdown — do not kill the Node process (a hard kill skips the shutdown hook and drops uncheckpointed logins). If you set `CAMOFOX_ADMIN_KEY`, you can also stop the engine without killing Node:
+Ending a Hermes browser task does **not** close the Camofox session. With `managed_persistence: true`, Hermes only drops its local tracking entry and leaves the Camofox/Playwright context running. Live cookies stay in that still-open context; they are not written to disk yet.
+
+Disk persist needs a Camofox checkpoint: `POST /stop` (requires `CAMOFOX_ADMIN_KEY` sent as `x-admin-key`) or a graceful Node shutdown (`SIGINT` / `SIGTERM`). Killing Node (`taskkill /F`, Task Manager) skips the shutdown hook and drops uncheckpointed logins.
+
+Headed login → headless reuse:
+
+1. Start Camofox with `interactive.mode` (or `CAMOFOX_INTERACTIVE`) set to `desktop`.
+2. Start Hermes, open a login site in a browser task, and sign in in the visible window.
+3. Checkpoint without killing Node:
    ```bash
    curl -X POST http://localhost:9377/stop -H "x-admin-key: $CAMOFOX_ADMIN_KEY"
    ```
-   `POST /stop` requires that admin key; without it, end the Hermes task and let the Node process exit cleanly.
-4. Start a new browser task.
+   State lands under `~/.camofox/profiles/<sha256(userId)>/`. `POST /stop` returns 403 if `CAMOFOX_ADMIN_KEY` is unset — use a graceful Node shutdown instead, then start Camofox again before the next step.
+4. Set `interactive.mode` to `off`, restart Camofox, and start a new Hermes browser task.
 5. Open the same site again — you should still be signed in.
 
 If step 5 logs you out, the Camofox server isn't honoring the stable `userId`. Double-check your config path, confirm you fully restarted Hermes after editing `config.yaml`, and verify your Camofox server version supports persistent per-user profiles.


### PR DESCRIPTION
## What does this PR do?

The Camofox section of the browser docs jumped from `git clone` straight into `make up` / `docker run`. Camofox's own README starts with native Node (`npm install && npm start`), which is the path that works on Windows without Docker.

This adds that native path first, documents the native headed/headless lever, and notes that persistence checkpoints on session close / shutdown so a hard kill of Node drops uncheckpointed logins.

## Related Issue

Fixes #97185

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [x] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `website/docs/user-guide/features/browser.md`
  - Native Camofox quick start (`npm install && npm start` / `npx @askjo/camofox-browser`) before the existing Docker path
  - Native headed vs headless: `interactive.mode` / `CAMOFOX_INTERACTIVE` (`off` | `desktop` | `novnc` | `auto`)
  - Persistence verify step: checkpoint on session close and shutdown; `POST /stop` with `x-admin-key` when `CAMOFOX_ADMIN_KEY` is set

## How to Test

1. Open `website/docs/user-guide/features/browser.md` (Camofox local mode).
2. Confirm the native Node path is first and the Docker/`make up` block is still present under a Docker heading.
3. Confirm headed-mode values match camofox-browser `lib/config.js` `normalizeInteractiveMode`.
4. Confirm the persistence verify step mentions `POST /stop` + `x-admin-key` and does not claim `/stop` works without `CAMOFOX_ADMIN_KEY`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A, docs-only
- [ ] I've added tests for my changes — N/A, docs-only
- [x] I've tested on my platform: Windows 11 (source-checked against camofox-browser; did not run Camofox)

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — native path is the Windows-without-Docker case
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Verified

- Current `main` Camofox section after clone was Docker-only (`make up` / `docker run`).
- jo-inc/camofox-browser README canonical start is `npm install && npm start` (port 9377).
- `camofox.config.json` has `"interactive": { "mode": "off" }`; `lib/config.js` `normalizeInteractiveMode` accepts `off|desktop|novnc|auto`.
- Persistence plugin checkpoints on session close and `server:shutdown`.
- `POST /stop` reads `x-admin-key` and compares to `CAMOFOX_ADMIN_KEY`; reason passed to close is `admin_stop`.

## NOT verified

- Did not run `npm start`, Docker, or a live Camofox login cycle on this machine.
- Did not build the docs site.
- Did not update `website/i18n/zh-Hans/.../browser.md`.
- `scripts/run_tests.sh` is POSIX-only; no test files changed.

## Screenshots / Logs

N/A