### PR TITLE
fix(tests): POSIX-only imports at collection time abort the whole suite on Windows

### DIFF
--- a/tests/hermes_cli/test_doctor_journal_modes.py
+++ b/tests/hermes_cli/test_doctor_journal_modes.py
@@ -142,7 +142,13 @@ class TestReadJournalMode:
             holder.close()
 
     @pytest.mark.skipif(os.name == "nt", reason="chmod is a no-op on Windows")
-    @pytest.mark.skipif(os.geteuid() == 0, reason="root ignores file permissions")
+    @pytest.mark.skipif(
+        # os.geteuid is POSIX-only, and a skipif condition is evaluated at
+        # collection time — calling it unguarded would raise AttributeError
+        # and take the whole module down on Windows.
+        hasattr(os, "geteuid") and os.geteuid() == 0,
+        reason="root ignores file permissions",
+    )
     def test_read_only_directory_is_still_readable(self, tmp_path):
         db = tmp_path / "state.db"
         _make_db(db, journal_mode="WAL")
@@ -387,7 +393,13 @@ class TestReportDatabaseJournalModes:
         assert "state.db: rollback journal mode" in out
 
     @pytest.mark.skipif(os.name == "nt", reason="chmod is a no-op on Windows")
-    @pytest.mark.skipif(os.geteuid() == 0, reason="root ignores file permissions")
+    @pytest.mark.skipif(
+        # os.geteuid is POSIX-only, and a skipif condition is evaluated at
+        # collection time — calling it unguarded would raise AttributeError
+        # and take the whole module down on Windows.
+        hasattr(os, "geteuid") and os.geteuid() == 0,
+        reason="root ignores file permissions",
+    )
     def test_unreadable_database_does_not_crash(self, tmp_path, capsys):
         db = tmp_path / "state.db"
         _make_db(db)

--- a/tests/tools/test_bot_turn_lock.py
+++ b/tests/tools/test_bot_turn_lock.py
@@ -9,7 +9,6 @@ process, so threads exercise the true kernel-lock semantics.
 
 from __future__ import annotations
 
-import fcntl
 import json
 import os
 import re
@@ -17,6 +16,13 @@ import threading
 import time
 
 import pytest
+
+# fcntl is POSIX-only. Importing it at module scope raised
+# ModuleNotFoundError on Windows during collection, which pytest counts as
+# a collection error and which aborts the whole run — not just this file.
+# These tests exercise real flock contention, so skipping the module is the
+# honest outcome; same idiom as tests/tools/test_file_sync_back.py.
+fcntl = pytest.importorskip("fcntl")
 
 from tools import bot_mode_dm, bot_relay
 from tools.bot_relay import TurnBusyError, acquire_turn_lock, turn_lock_path


### PR DESCRIPTION
## What does this PR do?

`pytest tests/` cannot complete collection on Windows. Two modules touch POSIX-only APIs at import time, and pytest treats a collection error as fatal to the **entire run**, not to the offending file:

```console
$ python -m pytest tests --collect-only -q
ERROR tests/tools/test_bot_turn_lock.py
ERROR tests/hermes_cli/test_doctor_journal_modes.py
!!!!!!!!!!!!!!!!!! Interrupted: 13 errors during collection !!!!!!!!!!!!!!!!!!!
```

So a Windows contributor cannot run the suite at all — not a subset, not one file, nothing. That makes "please add a test with your fix" a hard ask on this platform.

Two import-time guards fix it. Both match a pattern that already exists in the tree.

## Related Issue

Related to #84437 (native Windows test-runner path for contributors). Not a full fix for it — this removes the hard blocker, it does not add a runner path.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

**`tests/tools/test_bot_turn_lock.py`**
`import fcntl` at module scope raises `ModuleNotFoundError` on Windows. These tests exercise real flock contention between separate fds, so skipping the module is the honest outcome rather than faking the lock. Now `fcntl = pytest.importorskip("fcntl")` — the idiom already used at `tests/tools/test_file_sync_back.py:13`.

**`tests/hermes_cli/test_doctor_journal_modes.py`**
Two `@pytest.mark.skipif(os.geteuid() == 0, ...)` decorators call a POSIX-only function. `skipif` conditions are evaluated at collection time, so on Windows this raises `AttributeError` and takes the module down before any test runs.

A third decorator in the same file already guards this and carries a comment naming exactly this failure mode:

```python
@pytest.mark.skipif(
    # os.geteuid is POSIX-only, and a skipif condition is evaluated at
    # collection time — calling it unguarded would raise AttributeError
    # and take the whole module down on Windows.
    hasattr(os, "geteuid") and os.geteuid() == 0,
    reason="root ignores file permissions",
)
```

The other two occurrences were missed. Both now match it.

## How to Test

On Windows, with identical flags either side:

```console
# before
40010/40062 tests collected (52 deselected), 2 errors in 51.10s
!!!! Interrupted: 2 errors during collection !!!!

# after
40046/40098 tests collected (52 deselected) in 177.23s
```

```bash
python -m pytest tests --collect-only -q --ignore=tests/acp --ignore=tests/acp_adapter
```

On POSIX nothing changes: `importorskip` imports normally, and `hasattr(os, "geteuid")` is `True` so the skip condition evaluates exactly as before.

### Two notes I'd rather flag than bury

**1. The `acp` collection errors are probably not a platform issue.** Both runs above pass `--ignore=tests/acp --ignore=tests/acp_adapter`, which fail with `ModuleNotFoundError: No module named 'acp'`. There is no `acp` package in the tree — only `acp_adapter/`, and `acp` is not in the `packages` list in `pyproject.toml`. That looks like it would fail everywhere, not just on Windows, so I have not touched it. Worth a look from someone who can confirm on Linux.

**2. Fixing collection exposes two pre-existing Windows failures** in `test_doctor_journal_modes.py` that had never been reachable on this platform:

- `test_missing_file_keeps_the_os_error_text` asserts the POSIX string `"No such file or directory"`; Windows produces `"[WinError 2] The system cannot find the file specified"`.
- `test_lists_every_managed_database` asserts `"kanban/boards/myboard/kanban.db"`; Windows produces backslash separators.

Both are assertion-level platform assumptions, a different class of problem from a collection blocker, and fixing them means choosing how strict those assertions should be. I've left them out rather than widening this PR's scope, and I'm happy to send a follow-up if you tell me which way you'd want them written.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the relevant tests and they pass (`tests/tools/test_bot_turn_lock.py` skips cleanly on Windows; `test_doctor_journal_modes.py` is 31 passed / 4 skipped / 2 pre-existing failures documented above)
- [x] N/A — this fixes test collection itself; the verification is the collection run above
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] N/A — no user-facing behavior change
- [x] N/A — no config keys
- [x] N/A — no architecture or workflow change
- [x] Cross-platform impact considered: both changes are no-ops on POSIX by construction
