### PR TITLE
fix(bot-mode): preserve canonical capabilities after compression

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -929,6 +929,7 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
         try:
             from tools.bot_mode_probe import (
                 BOT_CHAT_TITLE,
+                is_bot_chat_session,
                 stored_bot_chat_prompt_needs_upgrade,
                 stored_prompt_capability_stale,
             )
@@ -948,14 +949,10 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
                 # the messaging protocol. Title-gated so ordinary unstamped
                 # sessions (i.e. all of them) never take this path; the
                 # rebuilt prompt carries the stamp, so it cannot re-fire.
-                _t = str(getattr(agent, "_session_title_hint", "") or "").strip()
-                if not _t and agent._session_db and agent.session_id:
-                    try:
-                        _t = str(agent._session_db.get_session_title(agent.session_id) or "").strip()
-                    except Exception:
-                        _t = ""
-                if _t == BOT_CHAT_TITLE:
-                    _bot_stale = stored_bot_chat_prompt_needs_upgrade(stored_prompt, _home_for_epoch)
+                if is_bot_chat_session(agent):
+                    _bot_stale = stored_bot_chat_prompt_needs_upgrade(
+                        stored_prompt, _home_for_epoch
+                    )
         except Exception:
             _bot_stale = False
         if _bot_stale:
@@ -965,7 +962,7 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
                 "prefix-cache break).",
                 agent.session_id,
             )
-            agent._session_title_hint = "Bot Chat"
+            agent._session_title_hint = BOT_CHAT_TITLE
             # The skills index inside the prompt comes from a two-layer cache
             # (in-process LRU + disk snapshot) that doesn't watch the skills
             # dir; a capability refresh must rebuild THROUGH it or a freshly

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -632,16 +632,11 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     if getattr(agent, "_bot_mode_protocol", True):
         try:
             from tools.bot_mode_probe import (
-                BOT_CHAT_TITLE,
                 epoch_line,
                 get_bot_mode_protocol_section,
+                is_bot_chat_session,
             )
-            _title = str(getattr(agent, "_session_title_hint", "") or "").strip()
-            if not _title:
-                _sdb = getattr(agent, "_session_db", None)
-                _sid = getattr(agent, "session_id", None)
-                _title = str((_sdb.get_session_title(_sid) if (_sdb and _sid) else None) or "").strip()
-            if _title == BOT_CHAT_TITLE:
+            if is_bot_chat_session(agent):
                 _bot_section = get_bot_mode_protocol_section(_agent_home(agent))
                 if _bot_section:
                     post_workspace_parts.append(_bot_section)

--- a/tests/tools/test_bot_mode_dm.py
+++ b/tests/tools/test_bot_mode_dm.py
@@ -52,17 +52,28 @@ def _managed_home(tmp_path, *, teammates=("researcher",), peers=()) -> Path:
 
 
 class _FakeDB:
-    def __init__(self, home: Path, title: str):
+    def __init__(self, home: Path, title: str, root_title: str | None = None):
         self.db_path = str(home / "state.db")
         self._title = title
+        self._root_title = root_title
 
-    def get_session_title(self, _sid):
+    def get_session_title(self, sid):
+        if sid == "root":
+            return self._root_title
         return self._title
+
+    def get_compression_lineage(self, sid):
+        return ["root", sid] if self._root_title is not None else [sid]
 
 
 class _FakeAgent:
-    def __init__(self, home: Path, title: str = "Bot Chat"):
-        self._session_db = _FakeDB(home, title)
+    def __init__(
+        self,
+        home: Path,
+        title: str = "Bot Chat",
+        root_title: str | None = None,
+    ):
+        self._session_db = _FakeDB(home, title, root_title)
         self.session_id = "sess-1"
         self._session_title_hint = None
         self._bot_mode_protocol = True
@@ -84,6 +95,21 @@ def test_injects_only_into_bot_chat_on_managed_install(tmp_path):
     # idempotent: second call adds nothing (byte-stable tool list per turn)
     assert bot_mode_dm.ensure_message_agent_tool(agent) is True
     assert len(agent.tools) == 1
+
+
+def test_injects_into_compressed_tip_of_canonical_bot_chat(tmp_path):
+    """A renamed live tip keeps the canonical root's Bot Mode capabilities."""
+    home = _managed_home(tmp_path)
+    agent = _FakeAgent(
+        home,
+        title="Friendly greeting",
+        root_title="Bot Chat",
+    )
+
+    assert bot_mode_dm.ensure_message_agent_tool(agent) is True
+    assert [tool["function"]["name"] for tool in agent.tools] == [
+        bot_mode_dm.MESSAGE_AGENT_TOOL_NAME
+    ]
 
 
 @pytest.mark.parametrize(

--- a/tests/tools/test_bot_mode_probe.py
+++ b/tests/tools/test_bot_mode_probe.py
@@ -4,6 +4,7 @@ import textwrap
 
 import pytest
 
+from hermes_state import SessionDB
 from tools import bot_mode_probe
 
 
@@ -12,6 +13,13 @@ def _fresh_cache():
     bot_mode_probe._reset_cache_for_tests()
     yield
     bot_mode_probe._reset_cache_for_tests()
+
+
+@pytest.fixture
+def session_db(tmp_path):
+    db = SessionDB(tmp_path / "state.db")
+    yield db
+    db.close()
 
 
 def _make_bot_profile(root, name, *, managed=True, soul=None):
@@ -32,6 +40,40 @@ def _make_bot_profile(root, name, *, managed=True, soul=None):
     if soul is not None:
         (d / "SOUL.md").write_text(soul, encoding="utf-8")
     return d
+
+
+class _Agent:
+    def __init__(self, db, session_id, hint=None):
+        self._session_db = db
+        self.session_id = session_id
+        self._session_title_hint = hint
+
+
+def test_bot_chat_identity_follows_compression_lineage_root(session_db):
+    session_db.create_session("root", source="webui")
+    session_db.set_session_title("root", "Bot Chat")
+    session_db.end_session("root", "compression")
+    session_db.create_session("tip", source="webui", parent_session_id="root")
+    session_db.set_session_title("tip", "Friendly greeting")
+
+    assert bot_mode_probe.is_bot_chat_session(_Agent(session_db, "tip")) is True
+
+
+def test_bot_chat_identity_does_not_follow_delegate_parent(session_db):
+    session_db.create_session("root", source="webui")
+    session_db.set_session_title("root", "Bot Chat")
+    session_db.create_session(
+        "delegate",
+        source="delegate",
+        parent_session_id="root",
+        model_config={"_delegate_from": "root"},
+    )
+    session_db.set_session_title("delegate", "Research task")
+
+    assert (
+        bot_mode_probe.is_bot_chat_session(_Agent(session_db, "delegate"))
+        is False
+    )
 
 
 def test_silent_when_no_profile_is_bot_managed(tmp_path):

--- a/tools/bot_mode_dm.py
+++ b/tools/bot_mode_dm.py
@@ -131,10 +131,10 @@ def ensure_message_agent_tool(agent: Any) -> bool:
 
     Called once per turn from the conversation loop. Idempotent and
     deterministic for the life of a session: the gate (canonical Bot Chat
-    title on a Bot-Mode-managed install) is stable from the session's first
-    turn, so the tool list is byte-identical across turns — prompt-cache
-    safe. Every non-Bot-Chat session fails the gate on every turn and never
-    sees the schema. Never raises.
+    compression-root title on a Bot-Mode-managed install) is stable from the
+    session's first turn, so the tool list is byte-identical across turns —
+    prompt-cache safe. Every non-Bot-Chat session fails the gate on every turn
+    and never sees the schema. Never raises.
     """
     try:
         if not getattr(agent, "_bot_mode_protocol", True):
@@ -147,9 +147,9 @@ def ensure_message_agent_tool(agent: Any) -> bool:
                     and tool.get("function", {}).get("name") == MESSAGE_AGENT_TOOL_NAME
                 ):
                     return True
-        from tools.bot_mode_probe import BOT_CHAT_TITLE, is_bot_mode_managed
+        from tools.bot_mode_probe import is_bot_chat_session, is_bot_mode_managed
 
-        if _session_title(agent) != BOT_CHAT_TITLE:
+        if not is_bot_chat_session(agent):
             return False
         # Managed-install check, NOT section non-emptiness: a profile whose
         # SOUL.md carries the legacy plugin-appended protocol text gets an
@@ -253,10 +253,9 @@ def message_agent_tool(
     # ── defense-in-depth gate: only a canonical Bot Chat may deliver ──
     home = _agent_home(agent)
     try:
-        from tools.bot_mode_probe import BOT_CHAT_TITLE, is_bot_mode_managed
+        from tools.bot_mode_probe import is_bot_chat_session, is_bot_mode_managed
 
-        title = _session_title(agent)
-        if title != BOT_CHAT_TITLE:
+        if not is_bot_chat_session(agent):
             return _err(
                 "message_agent is only available in a Bot Mode 'Bot Chat' session. "
                 "This session is not one; do not retry."
@@ -745,20 +744,6 @@ def _agent_home(agent: Any) -> str:
     except Exception:
         pass
     return os.getenv("HERMES_HOME") or os.path.expanduser("~/.hermes")
-
-
-def _session_title(agent: Any) -> str:
-    title = str(getattr(agent, "_session_title_hint", "") or "").strip()
-    if title:
-        return title
-    try:
-        sdb = getattr(agent, "_session_db", None)
-        sid = getattr(agent, "session_id", None)
-        if sdb and sid:
-            return str(sdb.get_session_title(sid) or "").strip()
-    except Exception:
-        pass
-    return ""
 
 
 if __name__ == "__main__":  # pragma: no cover - exercised as a background process

--- a/tools/bot_mode_probe.py
+++ b/tools/bot_mode_probe.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 import os
 import threading
 from pathlib import Path
+from typing import Any
 
 _PROTOCOL_HEADING = "## Messaging other agents"
 
@@ -42,6 +43,41 @@ BOT_CHAT_TITLE = "Bot Chat"
 
 _lock = threading.Lock()
 _cached: dict[str, str] = {}
+
+
+def bot_chat_session_title(agent: Any) -> str:
+    """Return the title that owns *agent*'s Bot Mode identity.
+
+    Compression rotates a conversation onto a new session row whose display
+    title can differ from the canonical root's ``Bot Chat`` title. Resolve
+    only the compression lineage back to its root so the protocol and
+    ``message_agent`` survive compaction without leaking into explicit
+    branches, delegate agents, or tool sessions. The title hint remains the
+    fallback for a newly created Bot Chat whose DB row does not exist yet.
+    Never raises.
+    """
+    hint = str(getattr(agent, "_session_title_hint", "") or "").strip()
+    try:
+        session_db = getattr(agent, "_session_db", None)
+        session_id = getattr(agent, "session_id", None)
+        if session_db and session_id:
+            title_session_id = session_id
+            get_lineage = getattr(session_db, "get_compression_lineage", None)
+            if callable(get_lineage):
+                lineage = get_lineage(session_id)
+                if lineage:
+                    title_session_id = lineage[0]
+            title = session_db.get_session_title(title_session_id)
+            if title is not None:
+                return str(title).strip()
+    except Exception:
+        pass
+    return hint
+
+
+def is_bot_chat_session(agent: Any) -> bool:
+    """Return whether *agent* belongs to the canonical Bot Chat lineage."""
+    return bot_chat_session_title(agent) == BOT_CHAT_TITLE
 
 
 def _hermes_root(home: Path) -> Path:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -6419,12 +6419,9 @@ def _sync_bot_capabilities(sid: str, session: dict) -> None:
     if agent is None:
         return
     try:
-        title = str(getattr(agent, "_session_title_hint", "") or "").strip()
-        if not title:
-            db = getattr(agent, "_session_db", None)
-            key = session.get("session_key") or ""
-            title = str((db.get_session_title(key) if (db and key) else None) or "").strip()
-        if title != "Bot Chat":
+        from tools.bot_mode_probe import is_bot_chat_session
+
+        if not is_bot_chat_session(agent):
             return
         from tools.bot_mode_probe import capability_fingerprint
 


### PR DESCRIPTION
## What does this PR do?

Current Hermes compresses sessions in place by default, preserving the same session ID and title. Hermes also supports existing compression lineages created by the legacy rotation path or by installs configured with `compression.in_place: false`. In those lineages, the canonical `Bot Chat` is the root session while the active continuation can have a different display title.

Several Bot Mode capability gates checked only the active session's title, so a valid compression descendant of `Bot Chat` could lose the Bot Mode protocol and `message_agent` capability. The diagnostic established that the affected session belonged to such a lineage, but did not include the original compression event, so this PR does not assume how or when that lineage was created.

This centralizes the identity check and resolves compression lineage back to its canonical root. It deliberately uses the compression-only lineage contract, which excludes explicit branches, delegated agents, and tool sessions. Normal in-place compression behavior is unchanged.

## Related Issue

No public issue. Reproduced from a support diagnostic and current source.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add one lineage-aware Bot Chat identity helper in `tools/bot_mode_probe.py`.
- Use that helper for system-prompt protocol injection, capability-epoch refresh, TUI capability sync, and both `message_agent` gates.
- Add regressions proving a renamed compression descendant retains Bot Chat capabilities while a delegated child does not inherit them.

## How to Test

1. Create a canonical session titled `Bot Chat`, then model an existing compression-rotation lineage with a continuation whose display title differs.
2. Resolve Bot Mode identity and inject `message_agent` against the continuation.
3. Confirm the continuation uses the root identity, while an explicit delegate child remains outside Bot Mode.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: Windows 11 static verification only; behavioral tests are left to CI

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Static verification completed with `git diff --check` and Python bytecode compilation for every modified Python file. Focused pytest files were not run locally; GitHub CI exercised the change successfully across the required Python and OS-specific lanes.