### PR TITLE
feat(gateway): add bounded Telegram profile-turn routing

### DIFF
--- a/agent/secret_scope.py
+++ b/agent/secret_scope.py
@@ -56,6 +56,13 @@ def is_multiplex_active() -> bool:
 _SECRET_SCOPE: ContextVar[Optional[Mapping[str, str]]] = ContextVar(
     "_SECRET_SCOPE", default=None
 )
+# A profile turn on an otherwise single-profile gateway needs the same
+# credential isolation as a multiplexed turn, without changing the process
+# deployment mode. This remains task-local so ordinary gateway work keeps its
+# legacy environment fallback.
+_SECRET_SCOPE_STRICT: ContextVar[bool] = ContextVar(
+    "_SECRET_SCOPE_STRICT", default=False
+)
 
 
 class UnscopedSecretError(RuntimeError):
@@ -80,6 +87,16 @@ def set_secret_scope(secrets: Optional[Mapping[str, str]]) -> Token:
 def reset_secret_scope(token: Token) -> None:
     """Restore the previous secret scope."""
     _SECRET_SCOPE.reset(token)
+
+
+def set_secret_scope_strict(strict: bool) -> Token:
+    """Require scoped credential misses to fail closed for this context only."""
+    return _SECRET_SCOPE_STRICT.set(bool(strict))
+
+
+def reset_secret_scope_strict(token: Token) -> None:
+    """Restore the previous context-local strict-scope setting."""
+    _SECRET_SCOPE_STRICT.reset(token)
 
 
 def current_secret_scope() -> Optional[Mapping[str, str]]:
@@ -178,7 +195,7 @@ def get_secret(name: str, default: Optional[str] = None) -> Optional[str]:
         val = scope.get(name)
         if val is not None:
             return val
-        if _MULTIPLEX_ACTIVE:
+        if _MULTIPLEX_ACTIVE or _SECRET_SCOPE_STRICT.get():
             return default
         # Multiplex off: the scope is an overlay over the process environment,
         # not an isolation boundary — there is no other profile to leak from.

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -88,6 +88,61 @@ def _normalize_multiplex_profile_allowlist(value: Any) -> Optional[List[str]]:
     return normalized
 
 
+def _normalize_profile_turn_allowlist(value: Any) -> List[str]:
+    """Normalize the opt-in set of profiles eligible for one routed turn.
+
+    Unlike ``multiplex_profile_allowlist``, this mode has no serve-all form:
+    an absent or malformed value is an empty list, so no inbound source can
+    enter a named profile runtime accidentally.
+    """
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        logger.warning(
+            "Invalid gateway.profile_turn_allowlist (expected a list, got %s); "
+            "disabling profile-turn routing",
+            type(value).__name__,
+        )
+        return []
+
+    from hermes_cli.profiles import normalize_profile_name, validate_profile_name
+
+    normalized: List[str] = []
+    seen = set()
+    for entry in value:
+        if not isinstance(entry, str):
+            logger.warning(
+                "Skipping invalid gateway.profile_turn_allowlist entry %r "
+                "(expected a profile name)",
+                entry,
+            )
+            continue
+        try:
+            name = normalize_profile_name(entry)
+            validate_profile_name(name)
+        except ValueError:
+            logger.warning(
+                "Skipping invalid gateway.profile_turn_allowlist entry %r",
+                entry,
+            )
+            continue
+        # ``default`` maps to the legacy ``agent:main`` namespace. Allowing it
+        # here would instead manufacture ``agent:default`` for a route that
+        # does not need a named runtime at all.
+        if name == "default":
+            logger.warning(
+                "Skipping gateway.profile_turn_allowlist entry %r: "
+                "the default profile is not a named profile turn",
+                entry,
+            )
+            continue
+        if name in seen:
+            continue
+        seen.add(name)
+        normalized.append(name)
+    return normalized
+
+
 # Recognized truthy / falsy tokens for the GATEWAY_MULTIPLEX_PROFILES operator
 # override. Anything not in either set — and a blank/whitespace value — is
 # treated as "unset" so it falls through to config.yaml rather than silently
@@ -982,6 +1037,12 @@ class GatewayConfig:
     # historical serve-all behavior; [] serves only the default profile.
     multiplex_profile_allowlist: Optional[List[str]] = None
 
+    # Explicit profile targets permitted for a single inbound profile turn.
+    # Empty by default: unlike multiplexing, this does not create adapters,
+    # listeners, API prefixes, or schedulers; it only authorizes a stamped
+    # source to enter that profile's runtime scope for one message turn.
+    profile_turn_allowlist: List[str] = field(default_factory=list)
+
     # Opt-in systemd event-loop watchdog. Zero preserves Type=simple and
     # disables sd_notify at runtime.
     systemd_watchdog_seconds: int = 0
@@ -1032,6 +1093,9 @@ class GatewayConfig:
     def __post_init__(self) -> None:
         self.multiplex_profile_allowlist = _normalize_multiplex_profile_allowlist(
             self.multiplex_profile_allowlist
+        )
+        self.profile_turn_allowlist = _normalize_profile_turn_allowlist(
+            self.profile_turn_allowlist
         )
         self.systemd_watchdog_seconds = coerce_systemd_watchdog_seconds(
             self.systemd_watchdog_seconds
@@ -1148,6 +1212,7 @@ class GatewayConfig:
             "max_concurrent_sessions": self.max_concurrent_sessions,
             "multiplex_profiles": self.multiplex_profiles,
             "multiplex_profile_allowlist": self.multiplex_profile_allowlist,
+            "profile_turn_allowlist": self.profile_turn_allowlist,
             "systemd_watchdog_seconds": self.systemd_watchdog_seconds,
             "loop_watchdog": self.loop_watchdog,
             "loop_watchdog_probe_interval_s": self.loop_watchdog_probe_interval_s,
@@ -1222,6 +1287,10 @@ class GatewayConfig:
             multiplex_profile_allowlist = nested_gateway.get(
                 "multiplex_profile_allowlist"
             )
+        if "profile_turn_allowlist" in data:
+            profile_turn_allowlist = data.get("profile_turn_allowlist")
+        else:
+            profile_turn_allowlist = nested_gateway.get("profile_turn_allowlist")
         if "systemd_watchdog_seconds" in data:
             systemd_watchdog_raw = data.get("systemd_watchdog_seconds")
             systemd_watchdog_key = "systemd_watchdog_seconds"
@@ -1328,6 +1397,7 @@ class GatewayConfig:
             thread_sessions_per_user=_coerce_bool(thread_sessions_per_user, False),
             multiplex_profiles=_coerce_bool(multiplex_profiles, False),
             multiplex_profile_allowlist=multiplex_profile_allowlist,
+            profile_turn_allowlist=profile_turn_allowlist,
             systemd_watchdog_seconds=systemd_watchdog_seconds,
             loop_watchdog=loop_watchdog,
             loop_watchdog_probe_interval_s=loop_watchdog_probe_interval_s,
@@ -1484,6 +1554,18 @@ def load_gateway_config() -> GatewayConfig:
             ):
                 gw_data["multiplex_profile_allowlist"] = gateway_section[
                     "multiplex_profile_allowlist"
+                ]
+
+            if "profile_turn_allowlist" in yaml_cfg:
+                gw_data["profile_turn_allowlist"] = yaml_cfg[
+                    "profile_turn_allowlist"
+                ]
+            elif (
+                isinstance(gateway_section, dict)
+                and "profile_turn_allowlist" in gateway_section
+            ):
+                gw_data["profile_turn_allowlist"] = gateway_section[
+                    "profile_turn_allowlist"
                 ]
 
             # Profile-based routing rules: accept either top-level

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2283,7 +2283,7 @@ async def _reclaim_stale(runner: object) -> None:
 
 
 @_contextmanager
-def _profile_runtime_scope(profile_home: "Path"):
+def _profile_runtime_scope(profile_home: "Path", *, strict_secrets: bool = False):
     """Scope config/skills/memory AND credentials to a profile for one turn.
 
     Combines the two seams the multiplexer needs:
@@ -2295,9 +2295,11 @@ def _profile_runtime_scope(profile_home: "Path"):
          keys and never the process-global ``os.environ`` (which in a
          multiplexer may hold another profile's values).
 
-    Only used on the multiplexed inbound path. Single-profile gateways never
-    enter this scope, so their behavior is unchanged. Loading the profile's
-    ``.env`` here does NOT mutate ``os.environ`` — ``build_profile_secret_scope``
+    Multiplexed inbound paths always use this scope. The bounded
+    profile-turn path may also request ``strict_secrets``: that is a
+    task-local fail-closed credential scope and deliberately does not change
+    the process-wide multiplex deployment mode. Loading the profile's ``.env``
+    here does NOT mutate ``os.environ`` — ``build_profile_secret_scope``
     returns an isolated dict — which is what keeps subprocesses (MCP, kanban)
     from inheriting cross-profile secrets.
     """
@@ -2306,15 +2308,19 @@ def _profile_runtime_scope(profile_home: "Path"):
         build_profile_secret_scope,
         set_secret_scope,
         reset_secret_scope,
+        set_secret_scope_strict,
+        reset_secret_scope_strict,
     )
     from hermes_cli.env_loader import hydrate_profile_secret_sources
 
     home_token = set_hermes_home_override(str(profile_home))
     hydrate_profile_secret_sources(Path(profile_home))
     secret_token = set_secret_scope(build_profile_secret_scope(Path(profile_home)))
+    strict_secret_token = set_secret_scope_strict(strict_secrets)
     try:
         yield
     finally:
+        reset_secret_scope_strict(strict_secret_token)
         reset_secret_scope(secret_token)
         reset_hermes_home_override(home_token)
 
@@ -8008,7 +8014,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         config = getattr(self, "config", None)
         # Mirror SessionStore._resolve_profile_for_key so this fallback path
         # produces the same namespace as the primary path: None (legacy
-        # agent:main) unless multiplexing is on, then the active profile.
+        # agent:main) unless multiplexing or a trusted profile turn selects a
+        # named profile.
         _profile = None
         if getattr(config, "multiplex_profiles", False):
             if source.profile:
@@ -8019,6 +8026,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _profile = get_active_profile_name() or "default"
                 except Exception:
                     _profile = None
+        elif getattr(source, "profile_turn_routed", False) is True:
+            _profile = self._profile_turn_profile_for_source(source)
         return build_session_key(
             source,
             group_sessions_per_user=getattr(config, "group_sessions_per_user", True),
@@ -16560,10 +16569,34 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         return _handler
 
+    def _make_profile_turn_message_handler(self):
+        """Scope only adapter-stamped profile turns on the primary transport.
+
+        Unlike the multiplex handler, this neither creates secondary adapters
+        nor routes ordinary inbound messages. It preserves the primary
+        transport's authorization home while a valid, allowlisted Telegram
+        group text turn reads the target profile's state.
+        """
+        default_home = Path(get_hermes_home())
+
+        async def _handler(event):
+            source = getattr(event, "source", None)
+            if source is not None:
+                source._authorization_profile_home = default_home
+            profile_home = self._profile_turn_home_for_event(event)
+            if profile_home is None:
+                return await self._handle_message(event)
+            with _profile_runtime_scope(profile_home, strict_secrets=True):
+                return await self._handle_message(event)
+
+        return _handler
+
     def _primary_message_handler(self):
         """Return the correctly scoped handler for a primary adapter."""
         if getattr(self.config, "multiplex_profiles", False):
             return self._make_default_profile_message_handler()
+        if getattr(self.config, "profile_turn_allowlist", None):
+            return self._make_profile_turn_message_handler()
         return self._handle_message
 
     async def _handle_gateway_platform_event(self, event: dict, source) -> None:
@@ -17451,6 +17484,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 source.profile = self._profile_name_for_source(source)
             except ProfileRouteRejected:
                 source.profile_route_rejected = True
+        elif (
+            not getattr(getattr(self, "config", None), "multiplex_profiles", False)
+            and getattr(source, "profile", None)
+            and getattr(source, "profile_route_rejected", False) is not True
+        ):
+            # A non-multiplex gateway must never treat an arbitrary
+            # ``source.profile`` as a scope selector. Only the primary
+            # Telegram adapter's internal profile-turn stamp can authorize it.
+            self._profile_turn_home_for_event(event)
 
         # SessionSource owns a strict boolean marker. Require the literal value
         # so duck-typed test/internal sources with dynamic attributes are not
@@ -28904,6 +28946,118 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 persist_user_display_kind=persist_user_display_kind,
                 message_type=message_type,
             )
+
+    def _profile_turn_target_homes(self) -> Dict[str, Path]:
+        """Return on-disk profiles explicitly eligible for a routed turn.
+
+        This is intentionally independent of ``_multiplex_profile_homes``:
+        profile-turn routing neither serves secondary adapters nor changes any
+        gateway process topology.
+        """
+        config = getattr(self, "config", None)
+        allowlist = getattr(config, "profile_turn_allowlist", None)
+        if not isinstance(allowlist, list) or not allowlist:
+            return {}
+
+        from hermes_cli.profiles import (
+            get_profile_dir,
+            normalize_profile_name,
+            profile_exists,
+            validate_profile_name,
+        )
+
+        targets: Dict[str, Path] = {}
+        for raw_name in allowlist:
+            if not isinstance(raw_name, str):
+                continue
+            try:
+                name = normalize_profile_name(raw_name)
+                validate_profile_name(name)
+                if name != "default" and profile_exists(name):
+                    targets[name] = get_profile_dir(name)
+            except (OSError, TypeError, ValueError):
+                continue
+        return targets
+
+    def _profile_turn_profile_for_source(
+        self, source: SessionSource
+    ) -> Optional[str]:
+        """Return a trusted profile-turn namespace for an already-checked source."""
+        config = getattr(self, "config", None)
+        if getattr(config, "multiplex_profiles", False):
+            return None
+        if getattr(source, "profile_turn_routed", False) is not True:
+            return None
+        if getattr(source, "profile_route_rejected", False) is True:
+            return None
+        profile = getattr(source, "profile", None)
+        if not isinstance(profile, str):
+            return None
+        try:
+            from hermes_cli.profiles import normalize_profile_name, validate_profile_name
+
+            profile = normalize_profile_name(profile)
+            validate_profile_name(profile)
+        except (TypeError, ValueError):
+            return None
+        if profile == "default":
+            return None
+        return profile if profile in self._profile_turn_target_homes() else None
+
+    @staticmethod
+    def _reject_profile_turn_source(source: SessionSource) -> None:
+        """Mark an untrusted profile-turn source for the shared ingress drop."""
+        try:
+            source.profile_route_rejected = True
+        except Exception:
+            pass
+
+    def _profile_turn_home_for_event(self, event: MessageEvent) -> Optional[Path]:
+        """Return the scoped home for one trusted primary Telegram text event.
+
+        The adapter's ``profile_turn_routed`` stamp is internal-only and is
+        required in addition to the allowlist/existence check. This prevents a
+        connector, plugin, or test-created ``source.profile`` from turning a
+        non-multiplex gateway into an arbitrary profile runtime.
+        """
+        config = getattr(self, "config", None)
+        if getattr(config, "multiplex_profiles", False):
+            return None
+        source = getattr(event, "source", None)
+        profile = getattr(source, "profile", None)
+        if not profile:
+            return None
+        try:
+            from hermes_constants import get_default_hermes_root, get_process_hermes_home
+
+            is_default_process = (
+                get_process_hermes_home().resolve()
+                == get_default_hermes_root().resolve()
+            )
+        except Exception:
+            is_default_process = False
+        if not is_default_process:
+            self._reject_profile_turn_source(source)
+            return None
+        if (
+            getattr(source, "profile_turn_routed", False) is not True
+            or getattr(source, "platform", None) is not Platform.TELEGRAM
+            or getattr(source, "chat_type", None) not in {"group", "forum", "supergroup"}
+            or getattr(event, "message_type", None) != MessageType.TEXT
+        ):
+            self._reject_profile_turn_source(source)
+            return None
+
+        target = self._profile_turn_profile_for_source(source)
+        if target is None:
+            self._reject_profile_turn_source(source)
+            return None
+        try:
+            source.profile = target
+        except Exception:
+            self._reject_profile_turn_source(source)
+            return None
+        return self._profile_turn_target_homes().get(target)
 
     def _profile_name_for_source(self, source: SessionSource) -> Optional[str]:
         """Resolve the profile name for an inbound source via configured routes.

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -185,6 +185,10 @@ class SessionSource:
     # Transport-local fail-closed signal for an explicit profile route whose
     # target is not served. Excluded from repr/equality and wire serialization.
     profile_route_rejected: bool = field(default=False, repr=False, compare=False)
+    # Internal, wire-invisible proof that a primary Telegram adapter performed
+    # the bounded profile-turn route after its own auth and trigger gates. A
+    # plain ``source.profile`` must not activate this non-multiplex path.
+    profile_turn_routed: bool = field(default=False, repr=False, compare=False)
 
     # Discord auto-thread metadata.  Newly auto-created Discord threads start
     # with a fast placeholder title from the raw message, then the gateway can
@@ -1958,15 +1962,36 @@ class SessionStore:
         to (``source.profile`` — set by the /p/<profile>/ URL prefix or
         per-credential adapter), falling back to the active profile name.
         """
-        if not getattr(self.config, "multiplex_profiles", False):
+        if getattr(self.config, "multiplex_profiles", False):
+            if source is not None and source.profile:
+                return source.profile
+            try:
+                from hermes_cli.profiles import get_active_profile_name
+
+                return get_active_profile_name() or "default"
+            except Exception:
+                return None
+
+        # Profile-turn routing is deliberately narrower than multiplexing:
+        # only the adapter's non-serializable stamp may use the configured
+        # allowlist to select a named session namespace. Ordinary sources stay
+        # byte-identical in agent:main, even while the feature is configured.
+        if source is None or getattr(source, "profile_turn_routed", False) is not True:
             return None
-        if source is not None and source.profile:
-            return source.profile
+        profile = getattr(source, "profile", None)
+        allowed = getattr(self.config, "profile_turn_allowlist", None)
+        if not isinstance(profile, str) or not isinstance(allowed, list):
+            return None
         try:
-            from hermes_cli.profiles import get_active_profile_name
-            return get_active_profile_name() or "default"
-        except Exception:
+            from hermes_cli.profiles import normalize_profile_name, validate_profile_name
+
+            profile = normalize_profile_name(profile)
+            validate_profile_name(profile)
+        except (TypeError, ValueError):
             return None
+        if profile == "default":
+            return None
+        return profile if profile in allowed else None
 
     @staticmethod
     def _profile_from_session_key(session_key: Optional[str]) -> Optional[str]:

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -23,6 +23,126 @@ from typing import Any, Awaitable, Callable, Dict, List, Optional, Set
 
 logger = logging.getLogger(__name__)
 
+
+_PROFILE_MENTION_HANDLE_RE = re.compile(
+    r"^\s*@([A-Za-z][A-Za-z0-9_]{0,31})(?![A-Za-z0-9_])"
+)
+_PROFILE_MENTION_HANDLE_ANY_RE = re.compile(
+    r"(?<![A-Za-z0-9_.])@([A-Za-z][A-Za-z0-9_]{0,31})(?![A-Za-z0-9_])"
+)
+_PROFILE_MENTION_HANDLE_NAME_RE = re.compile(r"[A-Za-z][A-Za-z0-9_]{0,31}\Z")
+_PROFILE_MENTION_LEADING_GUIDANCE = (
+    "Use a leading profile handle, for example: @glm your request."
+)
+_PROFILE_MENTION_TEXT_ONLY_GUIDANCE = (
+    "Profile routing is text-only. Send @glm followed by your request as text."
+)
+_PROFILE_MENTION_UNAVAILABLE_GUIDANCE = "That profile route is unavailable right now."
+
+
+def _normalize_profile_mention_handle(value: object) -> Optional[str]:
+    """Return a canonical configured Telegram handle, or ``None`` if invalid."""
+    if not isinstance(value, str):
+        return None
+    handle = value.strip()
+    if handle.startswith("@"):
+        handle = handle[1:]
+    if not _PROFILE_MENTION_HANDLE_NAME_RE.fullmatch(handle):
+        return None
+    return handle.casefold()
+
+
+def find_profile_mention_alias(
+    text: object,
+    routes: object,
+) -> tuple[Optional[str], bool]:
+    """Return a configured ``@handle`` and whether it is leading.
+
+    This recognizes only valid configured handles, normalizing the optional
+    ``@`` in config keys and casing.  A non-leading match is deliberately
+    surfaced to the adapter so it can fail closed instead of letting a broad
+    legacy wake regex dispatch the text to the default profile.
+    """
+    if not isinstance(text, str) or not isinstance(routes, dict) or not routes:
+        return None, False
+
+    configured = {
+        normalized
+        for raw_handle in routes
+        if (normalized := _normalize_profile_mention_handle(raw_handle)) is not None
+    }
+    if not configured:
+        return None, False
+
+    leading = _PROFILE_MENTION_HANDLE_RE.match(text)
+    if leading is not None:
+        alias = leading.group(1).casefold()
+        if alias in configured:
+            return alias, True
+
+    for match in _PROFILE_MENTION_HANDLE_ANY_RE.finditer(text):
+        alias = match.group(1).casefold()
+        if alias in configured:
+            return alias, False
+    return None, False
+
+
+def resolve_profile_mention_route(
+    text: object,
+    routes: object,
+    eligible_profiles: object,
+) -> tuple[Optional[str], bool]:
+    """Resolve a leading Telegram handle to an eligible profile-turn target.
+
+    Returns ``(target, matched)``. ``matched`` with a ``None`` target is an
+    explicit invalid, unserved, or ambiguous route and must be rejected by the
+    caller rather than falling through to the default profile.
+    """
+    if not isinstance(text, str) or not isinstance(routes, dict) or not routes:
+        return None, False
+
+    match = _PROFILE_MENTION_HANDLE_RE.match(text)
+    if match is None:
+        return None, False
+    requested_handle = match.group(1).casefold()
+    matching_targets = [
+        target
+        for raw_handle, target in routes.items()
+        if _normalize_profile_mention_handle(raw_handle) == requested_handle
+    ]
+    if not matching_targets:
+        return None, False
+    if len(matching_targets) != 1:
+        return None, True
+
+    try:
+        from hermes_cli.profiles import normalize_profile_name, validate_profile_name
+
+        target = matching_targets[0]
+        if not isinstance(target, str):
+            return None, True
+        target = normalize_profile_name(target)
+        validate_profile_name(target)
+        if target == "default":
+            return None, True
+
+        served = set()
+        for candidate in eligible_profiles:
+            if not isinstance(candidate, str):
+                continue
+            candidate = normalize_profile_name(candidate)
+            validate_profile_name(candidate)
+            if candidate == "default":
+                continue
+            served.add(candidate)
+    except (TypeError, ValueError):
+        return None, True
+
+    if target not in served:
+        return None, True
+    return target, True
+
+
 from agent.deadline import run_bounded_async
 
 
@@ -8689,6 +8809,217 @@ class TelegramAdapter(BasePlatformAdapter):
             return bool(configured)
         return os.getenv("TELEGRAM_EXCLUSIVE_BOT_MENTIONS", "true").lower() in {"true", "1", "yes", "on"}
 
+    def _profile_mention_routes_for_primary_group(
+        self, message: Message
+    ) -> Optional[dict]:
+        """Return configured aliases only on the default primary group adapter."""
+        extra = getattr(getattr(self, "config", None), "extra", None)
+        routes = extra.get("profile_mention_routes") if isinstance(extra, dict) else None
+        if not isinstance(routes, dict) or not routes or not self._is_group_chat(message):
+            return None
+
+        owner_profile = getattr(self, "_owner_profile", None)
+        if (
+            isinstance(owner_profile, str)
+            and owner_profile.strip()
+            and owner_profile.strip().casefold() != "default"
+        ):
+            return None
+
+        # A named profile's own gateway is a separate primary process, not the
+        # default transport that owns this opt-in turn router. Leave its group
+        # messages on its historical path (the live fleet may run both).
+        try:
+            from hermes_constants import get_default_hermes_root, get_process_hermes_home
+
+            if get_process_hermes_home().resolve() != get_default_hermes_root().resolve():
+                return None
+        except Exception:
+            # Failure to establish default-profile ownership must not create a
+            # new route on an otherwise independent gateway.
+            return None
+        return routes
+
+    def _profile_mention_alias_reference(
+        self, message: Message, text: object
+    ) -> tuple[Optional[str], bool]:
+        """Return a configured primary-adapter alias and whether it is leading."""
+        routes = self._profile_mention_routes_for_primary_group(message)
+        if routes is None:
+            return None, False
+        return find_profile_mention_alias(text, routes)
+
+    def _profile_mention_refusal_is_permitted(self, message: Message) -> bool:
+        """Apply the pre-dispatch gates before emitting an alias refusal.
+
+        Alias misuse must never acquire a chat/topic/guest bypass merely because
+        it receives a short adapter-level reply instead of an agent turn.
+        """
+        if (
+            self._profile_mention_routes_for_primary_group(message) is None
+            or self._is_own_message(message)
+        ):
+            return False
+
+        thread_id = self._effective_message_thread_id(message)
+        allowed_topics = self._telegram_allowed_topics()
+        if allowed_topics:
+            topic_id = (
+                str(thread_id)
+                if thread_id is not None
+                else self._GENERAL_TOPIC_THREAD_ID
+            )
+            if topic_id not in allowed_topics:
+                return False
+
+        if thread_id is not None:
+            try:
+                if int(thread_id) in self._telegram_ignored_threads():
+                    return False
+            except (TypeError, ValueError):
+                return False
+
+        if (
+            self._telegram_exclusive_bot_mentions()
+            and self._explicit_bot_mentions_exclude_self(message)
+        ):
+            return False
+
+        allowed_chats = self._telegram_allowed_chats()
+        chat_id = str(getattr(getattr(message, "chat", None), "id", ""))
+        return (
+            not allowed_chats
+            or chat_id in allowed_chats
+            or self._is_guest_mention(message)
+        )
+
+    def _profile_mention_correlation(self, message: Message) -> tuple[object, object, object]:
+        chat = getattr(message, "chat", None)
+        return (
+            getattr(chat, "id", "unknown"),
+            getattr(message, "message_id", "unknown"),
+            self._effective_message_thread_id(message),
+        )
+
+    async def _send_profile_mention_refusal(
+        self,
+        message: Message,
+        *,
+        alias: str,
+        reason: str,
+        text: str,
+    ) -> None:
+        """Reply in the same chat/topic without ever exposing the raw prompt."""
+        chat_id, message_id, thread_id = self._profile_mention_correlation(message)
+        logger.warning(
+            "[%s] Rejected Telegram profile mention route: alias=@%s reason=%s "
+            "chat=%s message=%s thread=%s",
+            getattr(self, "name", "telegram"),
+            alias,
+            reason,
+            chat_id,
+            message_id,
+            thread_id,
+        )
+        reply_kwargs = {}
+        effective_thread_id = self._effective_message_thread_id(message)
+        if effective_thread_id is not None:
+            try:
+                reply_kwargs["message_thread_id"] = int(effective_thread_id)
+            except (TypeError, ValueError):
+                pass
+        try:
+            await message.reply_text(text, **reply_kwargs)
+        except Exception:
+            logger.warning(
+                "[%s] Failed to send Telegram profile mention refusal: "
+                "alias=@%s reason=%s chat=%s message=%s thread=%s",
+                getattr(self, "name", "telegram"),
+                alias,
+                reason,
+                chat_id,
+                message_id,
+                thread_id,
+                exc_info=True,
+            )
+
+    def _apply_profile_mention_route(
+        self,
+        message: Message,
+        event: MessageEvent,
+    ) -> bool:
+        """Stamp a valid leading handle route on a primary Telegram text event.
+
+        Static profile routing has already run while ``event`` was built, so a
+        pre-stamped source (or its fail-closed rejection marker) always wins.
+        This adapter-only route is intentionally after normal Telegram auth and
+        trigger gating, but before batching derives its session key.
+        """
+        source = getattr(event, "source", None)
+        if source is None:
+            return True
+        if getattr(source, "profile_route_rejected", False) is True:
+            return False
+        if getattr(source, "profile", None):
+            return True
+
+        routes = self._profile_mention_routes_for_primary_group(message)
+        if routes is None:
+            return True
+
+        alias, _ = find_profile_mention_alias(event.text, routes)
+        runner = getattr(self, "gateway_runner", None)
+        config = getattr(runner, "config", None)
+        allowlist = getattr(config, "profile_turn_allowlist", None)
+        eligible_profiles = ()
+        resolution_failed = False
+        resolve_targets = getattr(runner, "_profile_turn_target_homes", None)
+        if (
+            isinstance(allowlist, list)
+            and allowlist
+            and not getattr(config, "multiplex_profiles", False)
+            and callable(resolve_targets)
+        ):
+            try:
+                eligible_profiles = resolve_targets()
+            except Exception:
+                resolution_failed = True
+
+        target, matched = resolve_profile_mention_route(
+            event.text,
+            routes,
+            eligible_profiles,
+        )
+        if not matched:
+            return True
+        chat_id, message_id, thread_id = self._profile_mention_correlation(message)
+        if target is None:
+            source.profile_route_rejected = True
+            logger.warning(
+                "[%s] Rejected Telegram profile mention route: alias=@%s reason=%s "
+                "chat=%s message=%s thread=%s",
+                getattr(self, "name", "telegram"),
+                alias or "unknown",
+                "target-resolution-error" if resolution_failed else "unavailable",
+                chat_id,
+                message_id,
+                thread_id,
+            )
+            return False
+        source.profile = target
+        source.profile_turn_routed = True
+        logger.info(
+            "[%s] Accepted Telegram profile mention route: alias=@%s target=%s "
+            "chat=%s message=%s thread=%s",
+            getattr(self, "name", "telegram"),
+            alias or "unknown",
+            target,
+            chat_id,
+            message_id,
+            thread_id,
+        )
+        return True
+
     def _telegram_free_response_chats(self) -> set[str]:
         raw = self.config.extra.get("free_response_chats")
         if raw is None:
@@ -9549,6 +9880,7 @@ class TelegramAdapter(BasePlatformAdapter):
         - the message replies to the bot
         - the bot is @mentioned
         - the text/caption matches a configured regex wake-word pattern
+        - a leading configured profile-mention alias is present in group text
 
         When ``allowed_chats`` is non-empty, it remains a hard gate except for
         the narrow ``guest_mode`` bypass: group/supergroup messages that
@@ -9630,7 +9962,15 @@ class TelegramAdapter(BasePlatformAdapter):
         # _message_mentions_bot above — skip the redundant second call.
         if not self._telegram_guest_mode() and self._message_mentions_bot(message):
             return True
-        return self._message_matches_mention_patterns(message)
+        if self._message_matches_mention_patterns(message):
+            return True
+        if not is_command:
+            _alias, is_leading = self._profile_mention_alias_reference(
+                message, getattr(message, "text", None)
+            )
+            if is_leading:
+                return True
+        return False
 
     async def _ensure_forum_commands(self, message) -> None:
         """Lazy-register bot commands for forum supergroups.
@@ -9688,7 +10028,24 @@ class TelegramAdapter(BasePlatformAdapter):
                 getattr(getattr(msg, "chat", None), "id", None),
             )
             return
-        if not self._should_process_message(msg):
+        should_process = self._should_process_message(msg)
+        alias, is_leading_alias = self._profile_mention_alias_reference(msg, msg.text)
+        if alias is not None:
+            if not is_leading_alias:
+                if self._profile_mention_refusal_is_permitted(msg):
+                    await self._send_profile_mention_refusal(
+                        msg,
+                        alias=alias,
+                        reason="embedded-text",
+                        text=_PROFILE_MENTION_LEADING_GUIDANCE,
+                    )
+                return
+            if not should_process:
+                # Do not turn a blocked alias into observed/default-profile
+                # context.  All normal authorization/chat/topic gates already
+                # ran in ``_should_process_message``.
+                return
+        if not should_process:
             if self._should_observe_unmentioned_group_message(msg):
                 self._observe_unmentioned_group_message(msg, MessageType.TEXT, update_id=update.update_id)
             return
@@ -9696,6 +10053,15 @@ class TelegramAdapter(BasePlatformAdapter):
 
         event = self._build_message_event(msg, MessageType.TEXT, update_id=update.update_id)
         event.text = self._clean_bot_trigger_text(event.text)
+        if not self._apply_profile_mention_route(msg, event):
+            if alias is not None and is_leading_alias:
+                await self._send_profile_mention_refusal(
+                    msg,
+                    alias=alias,
+                    reason="unavailable",
+                    text=_PROFILE_MENTION_UNAVAILABLE_GUIDANCE,
+                )
+            return
         await self._cache_replied_media(msg, event)
         event = self._apply_telegram_group_observe_attribution(event)
         self._enqueue_text_event(event)
@@ -9705,7 +10071,25 @@ class TelegramAdapter(BasePlatformAdapter):
         msg = self._effective_update_message(update)
         if not msg or not msg.text:
             return
-        if not self._should_process_message(msg, is_command=True):
+        should_process = self._should_process_message(msg, is_command=True)
+        alias, _ = self._profile_mention_alias_reference(msg, msg.text)
+        if alias is not None:
+            if not self._is_user_authorized_from_message(msg):
+                logger.warning(
+                    "[Telegram] Blocked unauthorized user %s in chat %s",
+                    getattr(getattr(msg, "from_user", None), "id", None),
+                    getattr(getattr(msg, "chat", None), "id", None),
+                )
+                return
+            if self._profile_mention_refusal_is_permitted(msg):
+                await self._send_profile_mention_refusal(
+                    msg,
+                    alias=alias,
+                    reason="command",
+                    text=_PROFILE_MENTION_TEXT_ONLY_GUIDANCE,
+                )
+            return
+        if not should_process:
             return
         if not self._is_user_authorized_from_message(msg):
             logger.warning(
@@ -9966,7 +10350,22 @@ class TelegramAdapter(BasePlatformAdapter):
                 getattr(getattr(update.message, "chat", None), "id", None),
             )
             return
-        if not self._should_process_message(update.message):
+        should_process = self._should_process_message(update.message)
+        alias, _ = self._profile_mention_alias_reference(
+            update.message, getattr(update.message, "caption", None)
+        )
+        if alias is not None:
+            if self._profile_mention_refusal_is_permitted(update.message):
+                await self._send_profile_mention_refusal(
+                    update.message,
+                    alias=alias,
+                    reason="media-caption",
+                    text=_PROFILE_MENTION_TEXT_ONLY_GUIDANCE,
+                )
+            # A configured alias in media/caption content is never an agent
+            # input: do not observe it, enqueue it, or download its payload.
+            return
+        if not should_process:
             if self._should_observe_unmentioned_group_message(update.message):
                 _m = update.message
                 _observe_type = self._media_message_type(_m)

--- a/tests/gateway/test_profile_turn_routing.py
+++ b/tests/gateway/test_profile_turn_routing.py
@@ -1,0 +1,775 @@
+"""Bounded, non-multiplex profile-turn routing regression coverage."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig, load_gateway_config
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.session import SessionSource, SessionStore
+
+
+def _source(**overrides) -> SessionSource:
+    values = {
+        "platform": Platform.TELEGRAM,
+        "chat_id": "-100-route",
+        "chat_type": "group",
+        "user_id": "user-1",
+    }
+    values.update(overrides)
+    return SessionSource(**values)
+
+
+def _store(tmp_path, config: GatewayConfig) -> SessionStore:
+    with patch("gateway.session.SessionStore._ensure_loaded"):
+        store = SessionStore(sessions_dir=tmp_path / "sessions", config=config)
+    store._db = None
+    store._loaded = True
+    return store
+
+
+def _telegram_adapter(
+    *,
+    require_mention=None,
+    mention_patterns=None,
+    profile_mention_routes=None,
+    allowed_chats=None,
+    guest_mode=None,
+    exclusive_bot_mentions=None,
+):
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    extra = {
+        "allowed_topics": [],
+        "allowed_chats": [],
+        "group_allowed_chats": [],
+    }
+    if require_mention is not None:
+        extra["require_mention"] = require_mention
+    if mention_patterns is not None:
+        extra["mention_patterns"] = mention_patterns
+    if profile_mention_routes is not None:
+        extra["profile_mention_routes"] = profile_mention_routes
+    if allowed_chats is not None:
+        extra["allowed_chats"] = allowed_chats
+    if guest_mode is not None:
+        extra["guest_mode"] = guest_mode
+    if exclusive_bot_mentions is not None:
+        extra["exclusive_bot_mentions"] = exclusive_bot_mentions
+
+    adapter = object.__new__(TelegramAdapter)
+    adapter.platform = Platform.TELEGRAM
+    adapter.config = PlatformConfig(enabled=True, token="***", extra=extra)
+    adapter._bot = SimpleNamespace(id=999, username="hermes_bot")
+    adapter._message_handler = AsyncMock()
+    adapter._pending_text_batches = {}
+    adapter._pending_text_batch_tasks = {}
+    adapter._text_batch_delay_seconds = 0.01
+    adapter._text_batch_split_delay_seconds = 0.01
+    adapter._mention_patterns = adapter._compile_mention_patterns()
+    adapter._forum_lock = asyncio.Lock()
+    adapter._forum_command_registered = set()
+    adapter._active_sessions = {}
+    adapter._pending_messages = {}
+    adapter._is_callback_user_authorized = lambda user_id, **_kw: True
+    return adapter
+
+
+def _group_message(
+    text="hello",
+    *,
+    caption=None,
+    chat_id=-100,
+    thread_id=None,
+    is_forum=False,
+    photo=None,
+):
+    return SimpleNamespace(
+        message_id=42,
+        text=text,
+        caption=caption,
+        entities=[],
+        caption_entities=[],
+        message_thread_id=thread_id,
+        is_topic_message=thread_id is not None,
+        chat=SimpleNamespace(
+            id=chat_id, type="group", title="Test Group", is_forum=is_forum
+        ),
+        from_user=SimpleNamespace(
+            id=111, full_name="Alice Example", first_name="Alice"
+        ),
+        reply_to_message=None,
+        date=None,
+        photo=photo,
+        reply_text=AsyncMock(),
+    )
+
+
+def _dm_message(text="hello"):
+    return SimpleNamespace(
+        message_id=43,
+        text=text,
+        caption=None,
+        entities=[],
+        caption_entities=[],
+        message_thread_id=None,
+        chat=SimpleNamespace(
+            id=111,
+            type="private",
+            full_name="Alice Example",
+            title=None,
+            is_forum=False,
+        ),
+        from_user=SimpleNamespace(
+            id=111, full_name="Alice Example", first_name="Alice"
+        ),
+        reply_to_message=None,
+        date=None,
+        reply_text=AsyncMock(),
+    )
+
+
+def _profile_turn_runner(*, target_profiles, static_profile=None, allowlist=None):
+    return SimpleNamespace(
+        config=SimpleNamespace(
+            multiplex_profiles=False,
+            profile_turn_allowlist=list(
+                target_profiles if allowlist is None else allowlist
+            ),
+        ),
+        _profile_name_for_source=lambda _source: static_profile,
+        _profile_turn_target_homes=lambda: {
+            profile: object() for profile in target_profiles
+        },
+    )
+
+
+def test_profile_mention_route_resolver_normalizes_handles_and_fails_closed():
+    from plugins.platforms.telegram.adapter import (
+        find_profile_mention_alias,
+        resolve_profile_mention_route,
+    )
+
+    routes = {"@GLM": "Gemini"}
+    assert resolve_profile_mention_route(
+        "@glm explain this", {}, {"default", "gemini"}
+    ) == (None, False)
+    assert resolve_profile_mention_route(
+        " \t@glm explain this", routes, {"default", "gemini"}
+    ) == ("gemini", True)
+    assert resolve_profile_mention_route(
+        "@glimmer explain this", routes, {"default", "gemini"}
+    ) == (None, False)
+    assert resolve_profile_mention_route(
+        "@glm_extra explain this", routes, {"default", "gemini"}
+    ) == (None, False)
+    assert resolve_profile_mention_route("say @glm", routes, {"default", "gemini"}) == (
+        None,
+        False,
+    )
+    assert resolve_profile_mention_route(
+        "@glm explain this",
+        {"glm": "gemini", "@GLM": "other"},
+        {"default", "gemini", "other"},
+    ) == (None, True)
+    assert resolve_profile_mention_route(
+        "@glm explain this", {"glm": "missing"}, {"default", "gemini"}
+    ) == (None, True)
+    assert resolve_profile_mention_route(
+        "@glm explain this", {"glm": "not/valid"}, {"default", "gemini"}
+    ) == (None, True)
+    assert resolve_profile_mention_route(
+        "@glm explain this", {"glm": "default"}, {"default"}
+    ) == (None, True)
+    assert find_profile_mention_alias("please use @glm now", routes) == ("glm", False)
+    assert find_profile_mention_alias("@glimmer is not glm", routes) == (None, False)
+
+
+def test_profile_mention_route_wakes_without_patterns_stamps_and_preserves_text():
+    async def _run():
+        adapter = _telegram_adapter(
+            require_mention=True,
+            profile_mention_routes={"@GLM": "Gemini"},
+        )
+        adapter.gateway_runner = _profile_turn_runner(target_profiles={"gemini"})
+        enqueued = []
+
+        def _enqueue(event):
+            enqueued.append((event, adapter._text_batch_key(event)))
+
+        adapter._enqueue_text_event = _enqueue
+        update = SimpleNamespace(
+            update_id=2001,
+            message=_group_message("@GLM keep this handle"),
+            effective_message=None,
+        )
+
+        await adapter._handle_text_message(update, SimpleNamespace())
+
+        assert len(enqueued) == 1
+        event, batch_key = enqueued[0]
+        assert event.source.profile == "gemini"
+        assert event.source.profile_turn_routed is True
+        assert event.text == "@GLM keep this handle"
+        assert batch_key.startswith("agent:gemini:telegram:")
+
+    asyncio.run(_run())
+
+
+def test_profile_mention_route_respects_auth_and_allowed_chat_gates():
+    async def _run():
+        adapter = _telegram_adapter(
+            require_mention=True,
+            profile_mention_routes={"glm": "gemini"},
+        )
+        adapter.gateway_runner = _profile_turn_runner(target_profiles={"gemini"})
+        adapter._enqueue_text_event = Mock()
+        unauthorized = _group_message("@glm blocked by auth")
+        adapter._is_callback_user_authorized = lambda *_args, **_kwargs: False
+        await adapter._handle_text_message(
+            SimpleNamespace(
+                update_id=2002, message=unauthorized, effective_message=None
+            ),
+            SimpleNamespace(),
+        )
+        adapter._enqueue_text_event.assert_not_called()
+        unauthorized.reply_text.assert_not_awaited()
+
+        allowed_adapter = _telegram_adapter(
+            require_mention=True,
+            profile_mention_routes={"glm": "gemini"},
+            allowed_chats=["-999"],
+        )
+        allowed_adapter.gateway_runner = _profile_turn_runner(
+            target_profiles={"gemini"}
+        )
+        allowed_adapter._enqueue_text_event = Mock()
+        outside_allowlist = _group_message("@glm blocked by chat")
+        update = SimpleNamespace(
+            update_id=2002,
+            message=outside_allowlist,
+            effective_message=None,
+        )
+
+        await allowed_adapter._handle_text_message(update, SimpleNamespace())
+
+        allowed_adapter._enqueue_text_event.assert_not_called()
+        outside_allowlist.reply_text.assert_not_awaited()
+
+    asyncio.run(_run())
+
+
+def test_profile_mention_route_rejects_unserved_target_before_text_enqueue():
+    async def _run():
+        adapter = _telegram_adapter(
+            require_mention=True,
+            profile_mention_routes={"glm": "missing"},
+        )
+        adapter.gateway_runner = _profile_turn_runner(
+            target_profiles=set(), allowlist={"missing"}
+        )
+        captured = {}
+        build_event = adapter._build_message_event
+
+        def _capture_event(*args, **kwargs):
+            event = build_event(*args, **kwargs)
+            captured["event"] = event
+            return event
+
+        adapter._build_message_event = _capture_event
+        adapter._enqueue_text_event = Mock()
+        message = _group_message("@glm do not fall back")
+        update = SimpleNamespace(
+            update_id=2003,
+            message=message,
+            effective_message=None,
+        )
+
+        await adapter._handle_text_message(update, SimpleNamespace())
+
+        adapter._enqueue_text_event.assert_not_called()
+        assert captured["event"].source.profile is None
+        assert captured["event"].source.profile_route_rejected is True
+        message.reply_text.assert_awaited_once_with(
+            "That profile route is unavailable right now."
+        )
+
+    asyncio.run(_run())
+
+
+def test_profile_mention_route_leaves_static_dms_and_secondary_adapters_unchanged():
+    adapter = _telegram_adapter(profile_mention_routes={"glm": "gemini"})
+    adapter.gateway_runner = _profile_turn_runner(
+        target_profiles={"gemini", "static"},
+        static_profile="static",
+    )
+    group_event = adapter._build_message_event(
+        _group_message("@glm static route wins"), MessageType.TEXT
+    )
+    assert (
+        adapter._apply_profile_mention_route(
+            _group_message("@glm static route wins"), group_event
+        )
+        is True
+    )
+    assert group_event.source.profile == "static"
+
+    adapter.gateway_runner = _profile_turn_runner(target_profiles={"gemini"})
+    dm_event = adapter._build_message_event(_dm_message("@glm dm"), MessageType.TEXT)
+    assert (
+        adapter._apply_profile_mention_route(_dm_message("@glm dm"), dm_event) is True
+    )
+    assert dm_event.source.profile is None
+
+    adapter._owner_profile = "default"
+    default_event = adapter._build_message_event(
+        _group_message("@glm default transport"), MessageType.TEXT
+    )
+    assert (
+        adapter._apply_profile_mention_route(
+            _group_message("@glm default transport"), default_event
+        )
+        is True
+    )
+    assert default_event.source.profile == "gemini"
+
+    secondary_event = adapter._build_message_event(
+        _group_message("@glm secondary"), MessageType.TEXT
+    )
+    adapter._owner_profile = "other"
+    assert (
+        adapter._apply_profile_mention_route(
+            _group_message("@glm secondary"), secondary_event
+        )
+        is True
+    )
+    assert secondary_event.source.profile is None
+
+
+def test_profile_mention_route_fails_closed_when_allowlist_is_off():
+    async def _run():
+        adapter = _telegram_adapter(
+            require_mention=True,
+            profile_mention_routes={"glm": "gemini"},
+        )
+        adapter.gateway_runner = _profile_turn_runner(
+            target_profiles={"gemini"}, allowlist=[]
+        )
+        adapter._enqueue_text_event = Mock()
+        message = _group_message("@glm must not fall back to default")
+        update = SimpleNamespace(
+            update_id=2004,
+            message=message,
+            effective_message=None,
+        )
+
+        await adapter._handle_text_message(update, SimpleNamespace())
+
+        adapter._enqueue_text_event.assert_not_called()
+        message.reply_text.assert_awaited_once_with(
+            "That profile route is unavailable right now."
+        )
+
+    asyncio.run(_run())
+
+
+def test_embedded_alias_with_broad_wake_regex_refuses_in_same_topic():
+    async def _run():
+        adapter = _telegram_adapter(
+            require_mention=True,
+            mention_patterns=[r"(?i)@glm"],
+            profile_mention_routes={"glm": "gemini"},
+        )
+        adapter.gateway_runner = _profile_turn_runner(target_profiles={"gemini"})
+        adapter._enqueue_text_event = Mock()
+        message = _group_message(
+            "please use @glm after this prefix",
+            thread_id=17,
+            is_forum=True,
+        )
+
+        await adapter._handle_text_message(
+            SimpleNamespace(update_id=2005, message=message, effective_message=None),
+            SimpleNamespace(),
+        )
+
+        adapter._enqueue_text_event.assert_not_called()
+        message.reply_text.assert_awaited_once_with(
+            "Use a leading profile handle, for example: @glm your request.",
+            message_thread_id=17,
+        )
+
+    asyncio.run(_run())
+
+
+def test_media_caption_alias_refuses_without_download_or_default_dispatch():
+    async def _run():
+        adapter = _telegram_adapter(
+            require_mention=True,
+            profile_mention_routes={"glm": "gemini"},
+        )
+        adapter.gateway_runner = _profile_turn_runner(target_profiles={"gemini"})
+        photo = SimpleNamespace(get_file=AsyncMock())
+        message = _group_message(
+            None,
+            caption="@glm inspect this photo",
+            photo=[photo],
+        )
+
+        await adapter._handle_media_message(
+            SimpleNamespace(update_id=2006, message=message), SimpleNamespace()
+        )
+
+        message.reply_text.assert_awaited_once_with(
+            "Profile routing is text-only. Send @glm followed by your request as text."
+        )
+        photo.get_file.assert_not_awaited()
+        adapter._message_handler.assert_not_awaited()
+
+    asyncio.run(_run())
+
+
+def test_command_alias_refuses_without_default_dispatch():
+    async def _run():
+        adapter = _telegram_adapter(
+            require_mention=True,
+            profile_mention_routes={"glm": "gemini"},
+        )
+        adapter.gateway_runner = _profile_turn_runner(target_profiles={"gemini"})
+        adapter.handle_message = AsyncMock()
+        message = _group_message("/help @glm")
+
+        await adapter._handle_command(
+            SimpleNamespace(update_id=2007, message=message, effective_message=None),
+            SimpleNamespace(),
+        )
+
+        message.reply_text.assert_awaited_once_with(
+            "Profile routing is text-only. Send @glm followed by your request as text."
+        )
+        adapter.handle_message.assert_not_awaited()
+
+    asyncio.run(_run())
+
+
+def test_no_route_config_preserves_broad_regex_legacy_dispatch():
+    async def _run():
+        adapter = _telegram_adapter(
+            require_mention=True,
+            mention_patterns=[r"(?i)@glm"],
+        )
+        adapter.gateway_runner = _profile_turn_runner(target_profiles=set())
+        enqueued = []
+        adapter._enqueue_text_event = enqueued.append
+        message = _group_message("legacy broad wake @glm remains unchanged")
+
+        await adapter._handle_text_message(
+            SimpleNamespace(update_id=2008, message=message, effective_message=None),
+            SimpleNamespace(),
+        )
+
+        assert len(enqueued) == 1
+        assert enqueued[0].source.profile is None
+        message.reply_text.assert_not_awaited()
+
+    asyncio.run(_run())
+
+
+def test_profile_mention_route_keeps_dm_and_secondary_handlers_inert():
+    async def _run():
+        dm_adapter = _telegram_adapter(
+            require_mention=True,
+            profile_mention_routes={"glm": "gemini"},
+        )
+        dm_adapter.gateway_runner = _profile_turn_runner(target_profiles={"gemini"})
+        dm_events = []
+        dm_adapter._enqueue_text_event = dm_events.append
+        dm_message = _dm_message("@glm dm remains legacy")
+        await dm_adapter._handle_text_message(
+            SimpleNamespace(update_id=2009, message=dm_message, effective_message=None),
+            SimpleNamespace(),
+        )
+        assert len(dm_events) == 1
+        assert dm_events[0].source.profile is None
+        dm_message.reply_text.assert_not_awaited()
+
+        secondary_adapter = _telegram_adapter(
+            require_mention=True,
+            profile_mention_routes={"glm": "gemini"},
+        )
+        secondary_adapter._owner_profile = "other"
+        secondary_adapter.gateway_runner = _profile_turn_runner(
+            target_profiles={"gemini"}
+        )
+        secondary_adapter._enqueue_text_event = Mock()
+        secondary_message = _group_message("@glm secondary remains legacy")
+        await secondary_adapter._handle_text_message(
+            SimpleNamespace(
+                update_id=2010,
+                message=secondary_message,
+                effective_message=None,
+            ),
+            SimpleNamespace(),
+        )
+        secondary_adapter._enqueue_text_event.assert_not_called()
+        secondary_message.reply_text.assert_not_awaited()
+
+    asyncio.run(_run())
+
+
+def test_profile_mention_route_is_inert_on_named_profile_gateway(monkeypatch):
+    adapter = _telegram_adapter(profile_mention_routes={"glm": "gemini"})
+    adapter.gateway_runner = _profile_turn_runner(target_profiles={"gemini"})
+    event = adapter._build_message_event(
+        _group_message("@glm named gateway stays unchanged"), MessageType.TEXT
+    )
+    monkeypatch.setattr(
+        "hermes_constants.get_default_hermes_root", lambda: Path("/tmp/default")
+    )
+    monkeypatch.setattr(
+        "hermes_constants.get_process_hermes_home",
+        lambda: Path("/tmp/default/profiles/gemini"),
+    )
+
+    assert (
+        adapter._apply_profile_mention_route(
+            _group_message("@glm named gateway stays unchanged"), event
+        )
+        is True
+    )
+    assert event.source.profile is None
+
+
+def test_profile_turn_allowlist_defaults_off_round_trips_and_loads_nested(
+    tmp_path, monkeypatch
+):
+    assert GatewayConfig().profile_turn_allowlist == []
+    assert GatewayConfig().multiplex_profiles is False
+
+    config = GatewayConfig.from_dict({
+        "gateway": {
+            "profile_turn_allowlist": [
+                " Gemini ",
+                "gemini",
+                "worker",
+                "Default",
+                "bad/name",
+                7,
+            ]
+        }
+    })
+    assert config.profile_turn_allowlist == ["gemini", "worker"]
+    assert GatewayConfig.from_dict(config.to_dict()).profile_turn_allowlist == [
+        "gemini",
+        "worker",
+    ]
+    assert (
+        GatewayConfig(profile_turn_allowlist=["default"]).profile_turn_allowlist == []
+    )
+
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        "gateway:\n  profile_turn_allowlist:\n    - Gemini\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    loaded = load_gateway_config()
+    assert loaded.profile_turn_allowlist == ["gemini"]
+    assert loaded.multiplex_profiles is False
+
+
+def test_profile_turn_session_key_is_namespaced_while_default_stays_legacy(tmp_path):
+    store = _store(tmp_path, GatewayConfig(profile_turn_allowlist=["gemini"]))
+
+    ordinary = _source()
+    routed = _source(profile="gemini", profile_turn_routed=True)
+    forged = _source(profile="gemini")
+
+    assert (
+        store._generate_session_key(ordinary)
+        == "agent:main:telegram:group:-100-route:user-1"
+    )
+    assert (
+        store._generate_session_key(routed)
+        == "agent:gemini:telegram:group:-100-route:user-1"
+    )
+    assert (
+        store._generate_session_key(forged)
+        == "agent:main:telegram:group:-100-route:user-1"
+    )
+    assert "profile_turn_routed" not in routed.to_dict()
+    serialized_forgery = SessionSource.from_dict({
+        **routed.to_dict(),
+        "profile_turn_routed": True,
+    })
+    assert serialized_forgery.profile_turn_routed is False
+
+
+def test_profile_turn_allowlist_does_not_enable_multiplex_lifecycle(monkeypatch):
+    from cron.scheduler_provider import scheduler_for_profile_mode
+    from gateway.run import GatewayRunner
+
+    config = GatewayConfig(profile_turn_allowlist=["gemini"])
+    runner = object.__new__(GatewayRunner)
+    runner.config = config
+    runner._profile_adapters = {}
+
+    with patch(
+        "gateway.run._multiplex_profile_homes",
+        side_effect=AssertionError("profile turns must not enumerate multiplex homes"),
+    ):
+        assert asyncio.run(GatewayRunner._start_secondary_profile_adapters(runner)) == 0
+
+    external_cron_provider = object()
+    assert (
+        scheduler_for_profile_mode(
+            external_cron_provider, multiplex_profiles=config.multiplex_profiles
+        )
+        is external_cron_provider
+    )
+    assert runner._profile_adapters == {}
+
+
+def test_profile_turn_handler_scopes_target_config_and_credentials_without_multiplexer(
+    tmp_path, monkeypatch
+):
+    from agent.secret_scope import get_secret, is_multiplex_active, set_multiplex_active
+    from gateway import run as run_mod
+    from gateway.run import GatewayRunner, _profile_runtime_scope
+    from hermes_cli.config import load_config
+    from hermes_constants import get_hermes_home
+
+    root = tmp_path / "home"
+    target = root / "profiles" / "gemini"
+    target.mkdir(parents=True)
+    (target / "config.yaml").write_text(
+        "model:\n  default: target-model\n  provider: target-provider\n",
+        encoding="utf-8",
+    )
+    (target / ".env").write_text("PROFILE_TURN_TOKEN=target-token\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    monkeypatch.setenv("PROFILE_TURN_TOKEN", "default-token")
+    monkeypatch.setenv("PROFILE_TURN_PROCESS_ONLY", "default-only")
+    monkeypatch.setattr(run_mod, "get_hermes_home", lambda: root)
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(profile_turn_allowlist=["gemini"])
+    seen = []
+
+    async def capture_scope(_event):
+        seen.append((
+            Path(get_hermes_home()),
+            load_config()["model"]["default"],
+            get_secret("PROFILE_TURN_TOKEN"),
+            get_secret("PROFILE_TURN_PROCESS_ONLY"),
+            is_multiplex_active(),
+        ))
+
+    runner._handle_message = capture_scope
+    source = _source(profile="Gemini", profile_turn_routed=True)
+    event = MessageEvent(text="@glm use this profile", source=source)
+
+    previous_multiplex = is_multiplex_active()
+    set_multiplex_active(False)
+    try:
+        with patch(
+            "gateway.run._multiplex_profile_homes",
+            side_effect=AssertionError(
+                "profile turns must not enumerate multiplex homes"
+            ),
+        ):
+            asyncio.run(runner._primary_message_handler()(event))
+    finally:
+        set_multiplex_active(previous_multiplex)
+
+    assert seen == [(target, "target-model", "target-token", None, False)]
+    assert source.profile == "gemini"
+    assert Path(get_hermes_home()) == root
+    assert get_secret("PROFILE_TURN_PROCESS_ONLY") == "default-only"
+
+
+def test_profile_turn_rejects_forged_nonallowlisted_and_missing_sources(
+    tmp_path, monkeypatch
+):
+    from gateway.run import GatewayRunner, _profile_runtime_scope
+
+    root = tmp_path / "home"
+    (root / "profiles" / "gemini").mkdir(parents=True)
+    (root / "profiles" / "other").mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(root))
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(profile_turn_allowlist=["gemini", "missing"])
+
+    sources = [
+        _source(profile="gemini"),
+        _source(profile="other", profile_turn_routed=True),
+        _source(profile="missing", profile_turn_routed=True),
+    ]
+    for source in sources:
+        result = asyncio.run(
+            GatewayRunner._handle_message(
+                runner,
+                MessageEvent(
+                    text="must not select a profile runtime",
+                    message_type=MessageType.TEXT,
+                    source=source,
+                ),
+            )
+        )
+        assert result is None
+        assert source.profile_route_rejected is True
+
+    named_gateway_source = _source(profile="gemini", profile_turn_routed=True)
+    monkeypatch.setattr(
+        "hermes_constants.get_process_hermes_home",
+        lambda: root / "profiles" / "named-gateway",
+    )
+    assert (
+        asyncio.run(
+            GatewayRunner._handle_message(
+                runner,
+                MessageEvent(
+                    text="named gateway must not select a profile turn",
+                    message_type=MessageType.TEXT,
+                    source=named_gateway_source,
+                ),
+            )
+        )
+        is None
+    )
+    assert named_gateway_source.profile_route_rejected is True
+
+    named_gateway_ordinary = _source()
+    assert (
+        GatewayRunner._profile_turn_home_for_event(
+            runner,
+            MessageEvent(
+                text="ordinary named gateway message",
+                message_type=MessageType.TEXT,
+                source=named_gateway_ordinary,
+            ),
+        )
+        is None
+    )
+    assert named_gateway_ordinary.profile_route_rejected is False
+
+    monkeypatch.setattr("hermes_constants.get_process_hermes_home", lambda: root)
+    scoped_source = _source(profile="gemini", profile_turn_routed=True)
+    with _profile_runtime_scope(root / "profiles" / "gemini", strict_secrets=True):
+        assert (
+            GatewayRunner._profile_turn_home_for_event(
+                runner,
+                MessageEvent(
+                    text="target scope must retain the valid route",
+                    message_type=MessageType.TEXT,
+                    source=scoped_source,
+                ),
+            )
+            == root / "profiles" / "gemini"
+        )
+    assert scoped_source.profile_route_rejected is False


### PR DESCRIPTION
## Summary
- add opt-in, per-message Telegram profile-turn routing without multiplexing or secondary adapters
- make configured aliases self-waking only for leading group text after existing auth/chat/topic/guest/ownership gates
- visibly refuse embedded aliases, captions/media, and commands instead of falling through to the default profile
- visibly reject invalid, disabled, or unserved targets
- preserve legacy behavior when no route configuration exists
- isolate target profile config, session namespace, and credentials for the routed turn

## Verification
- dedicated profile-turn module — 17 passed
- all 58 Telegram modules — 587 passed
- 9 coupled config/profile/session modules — 153 passed
- Ruff check and format check — PASS
- `git diff --check origin/main...HEAD` — PASS

## Runtime boundary
No live config, gateway process, Telegram message, or fleet topology was changed. Merge/install/restart and first-fire receipts remain separate gates.