### PR TITLE
fix(browser): warn when Chrome purges copied cookies on copy-profile launch

### DIFF
--- a/tests/tools/test_browser_real_profile_purge.py
+++ b/tests/tools/test_browser_real_profile_purge.py
@@ -1,0 +1,254 @@
+"""Tests for the real-profile cookie-purge detection (#96993).
+
+Chrome >= 151 on Windows binds cookie encryption to the original profile, so
+the copy-browser's first launch actively purges the cookies the snapshot just
+copied in (556 -> 6, 3507 -> ~0 in the issue's measurements). The fix detects
+the drop and surfaces a notice on the first navigation instead of letting the
+agent discover site-by-site login failures.
+
+The detection is deliberately platform-independent (a before/after cookie
+count around the launch), so these tests run everywhere: they build real
+SQLite cookie DBs in tmp_path and exercise the counting helper, the purge
+predicate, and the notice -> session wiring.
+"""
+import os
+import sqlite3
+from unittest.mock import patch
+
+import pytest
+
+
+def _write_cookie_db(path: str, count: int) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    rows = [("host.example", "c", b"v10x")] * count
+    conn = sqlite3.connect(path)
+    try:
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS cookies (host_key TEXT, name TEXT, encrypted_value BLOB)"
+        )
+        conn.execute("DELETE FROM cookies")
+        conn.executemany(
+            "INSERT INTO cookies VALUES (?, ?, ?)",
+            rows,
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+@pytest.fixture(autouse=True)
+def _clean_real_profile_state():
+    import tools.browser_tool as bt
+
+    bt._real_profile_cdp_cache.pop("cdp", None)
+    bt._real_profile_purge_notice.pop("msg", None)
+    yield
+    bt._real_profile_cdp_cache.pop("cdp", None)
+    bt._real_profile_purge_notice.pop("msg", None)
+
+
+class TestCountRealProfileCookies:
+    def test_counts_network_location(self, tmp_path):
+        from tools.browser_tool import _count_real_profile_cookies
+
+        copy_dir = str(tmp_path)
+        _write_cookie_db(os.path.join(copy_dir, "Default", "Network", "Cookies"), 7)
+        assert _count_real_profile_cookies(copy_dir) == 7
+
+    def test_falls_back_to_legacy_root_location(self, tmp_path):
+        from tools.browser_tool import _count_real_profile_cookies
+
+        copy_dir = str(tmp_path)
+        _write_cookie_db(os.path.join(copy_dir, "Default", "Cookies"), 3)
+        assert _count_real_profile_cookies(copy_dir) == 3
+
+    def test_prefers_network_location_when_both_exist(self, tmp_path):
+        from tools.browser_tool import _count_real_profile_cookies
+
+        copy_dir = str(tmp_path)
+        _write_cookie_db(os.path.join(copy_dir, "Default", "Cookies"), 100)
+        _write_cookie_db(os.path.join(copy_dir, "Default", "Network", "Cookies"), 9)
+        assert _count_real_profile_cookies(copy_dir) == 9
+
+    def test_missing_db_returns_none(self, tmp_path):
+        from tools.browser_tool import _count_real_profile_cookies
+
+        assert _count_real_profile_cookies(str(tmp_path)) is None
+
+    def test_non_sqlite_file_returns_none(self, tmp_path):
+        from tools.browser_tool import _count_real_profile_cookies
+
+        db = tmp_path / "Default" / "Network" / "Cookies"
+        db.parent.mkdir(parents=True)
+        db.write_text("this is not a database")
+        assert _count_real_profile_cookies(str(tmp_path)) is None
+
+    def test_empty_jar_is_zero_not_none(self, tmp_path):
+        from tools.browser_tool import _count_real_profile_cookies
+
+        copy_dir = str(tmp_path)
+        _write_cookie_db(os.path.join(copy_dir, "Default", "Network", "Cookies"), 0)
+        assert _count_real_profile_cookies(copy_dir) == 0
+
+
+class TestCookiesPurgedAfterLaunch:
+    @pytest.mark.parametrize(
+        "before,after,expected",
+        [
+            # The reported purge shapes: 556 -> 6 and 3507 -> ~0.
+            (556, 6, True),
+            (3507, 0, True),
+            # Normal startup churn (expired-cookie sweep, visitor cookies).
+            (556, 550, False),
+            (120, 121, False),
+            # Baseline too small to be worth a warning.
+            (4, 0, False),
+            # Unknown counts (locked / missing DB) never claim a purge.
+            (None, 0, False),
+            (556, None, False),
+            (None, None, False),
+            # Exactly halving is not a purge; anything past it is.
+            (100, 50, False),
+            (100, 49, True),
+        ],
+    )
+    def test_predicate(self, before, after, expected):
+        from tools.browser_tool import _cookies_purged_after_launch
+
+        assert _cookies_purged_after_launch(before, after) is expected
+
+
+class TestPurgeNoticeWiring:
+    def test_create_local_session_carries_notice_once(self):
+        """A pending purge notice lands on the session features and is consumed."""
+        import tools.browser_tool as bt
+
+        bt._real_profile_purge_notice["msg"] = "purge notice under test"
+        with patch.object(bt, "_real_profile_cdp", return_value=("http://127.0.0.1:9222", None)), \
+             patch.object(bt, "_resolve_cdp_override", side_effect=lambda u: u):
+            first = bt._create_local_session("task-1")
+            second = bt._create_local_session("task-2")
+
+        assert first["features"]["real_profile"] is True
+        assert first["features"]["real_profile_cookies_purged"] is True
+        assert first["real_profile_purge_warning"] == "purge notice under test"
+        # One-shot: sessions created later (the copy-browser is reused, the
+        # launch — and therefore the purge — already happened) stay clean.
+        assert "real_profile_cookies_purged" not in second["features"]
+        assert "real_profile_purge_warning" not in second
+
+    def test_create_local_session_without_notice_unchanged(self):
+        import tools.browser_tool as bt
+
+        with patch.object(bt, "_real_profile_cdp", return_value=("http://127.0.0.1:9222", None)), \
+             patch.object(bt, "_resolve_cdp_override", side_effect=lambda u: u):
+            session = bt._create_local_session("task-1")
+        assert session["features"] == {"local": True, "real_profile": True}
+        assert "real_profile_purge_warning" not in session
+
+
+def _arm_real_profile_launch(monkeypatch, copy_dir, on_cdp_visible):
+    """Stub everything _real_profile_cdp needs around the (fake) launch."""
+    import tools.browser_tool as bt
+
+    monkeypatch.setattr(bt, "_use_real_profile", lambda: True)
+    monkeypatch.setattr(bt, "_using_lightpanda_engine", lambda: False)
+    monkeypatch.setattr(bt, "_find_agent_browser", lambda: "agent-browser")
+    monkeypatch.setattr(bt, "_agent_browser_argv", lambda cmd: [cmd])
+    monkeypatch.setattr(bt, "_build_browser_env", lambda: dict(os.environ))
+    monkeypatch.setattr(bt, "_get_open_command_timeout", lambda first_open=False: 30)
+    monkeypatch.setattr(bt, "_cdp_http_ready", lambda c: False)
+    monkeypatch.setattr(bt, "_cdp_on_data_dir", lambda c, d: False)
+    monkeypatch.setattr(bt, "_agent_browser_close_session", lambda s: None)
+
+    class FakeProc:
+        returncode = 0
+        stderr = ""
+        stdout = ""
+
+    monkeypatch.setattr(bt.subprocess, "run", lambda *a, **k: FakeProc())
+
+    def cdp_visible(session):
+        # First call is the pre-launch reuse probe (no copy-browser is up) —
+        # report none. The second call is the post-launch endpoint lookup,
+        # which is where the (fake) browser gets to rewrite the cookie jar.
+        if cdp_visible.seen:
+            on_cdp_visible()
+            return "http://127.0.0.1:9222"
+        cdp_visible.seen = True
+        return None
+
+    cdp_visible.seen = False
+
+    monkeypatch.setattr(bt, "_agent_browser_get_cdp", cdp_visible)
+
+    import hermes_cli.browser_connect as bc
+
+    monkeypatch.setattr(bc, "detect_default_chromium", lambda system=None: "chrome")
+    monkeypatch.setattr(bc, "real_profile_copy_dir", lambda browser: copy_dir)
+    monkeypatch.setattr(
+        bc, "snapshot_real_profile", lambda browser, src=None: (copy_dir, None)
+    )
+
+
+class TestPurgeDetectionAroundLaunch:
+    def test_detected_drop_sets_notice_and_keeps_launching(self, tmp_path, monkeypatch):
+        """End-to-end through _real_profile_cdp: snapshot counts 8, launch leaves 1.
+
+        The heavy launch path is stubbed; what is under test is the real
+        counting against real DB files and the decision that follows it —
+        the purge must produce a notice, not a launch failure.
+        """
+        import tools.browser_tool as bt
+
+        copy_dir = str(tmp_path / "browser-profile" / "chrome")
+        cookies = os.path.join(copy_dir, "Default", "Network", "Cookies")
+        _write_cookie_db(cookies, 8)
+
+        def purge_on_launch():
+            # The purge: Chrome rewrites the jar down to one survivor.
+            _write_cookie_db(cookies, 1)
+
+        _arm_real_profile_launch(monkeypatch, copy_dir, purge_on_launch)
+
+        cdp, err = bt._real_profile_cdp()
+        assert cdp == "http://127.0.0.1:9222"
+        assert err is None
+        assert "#96993" in bt._real_profile_purge_notice["msg"]
+
+    def test_surviving_jar_sets_no_notice(self, tmp_path, monkeypatch):
+        """No meaningful drop -> no notice; the launch result is untouched."""
+        import tools.browser_tool as bt
+
+        copy_dir = str(tmp_path / "browser-profile" / "chrome")
+        cookies = os.path.join(copy_dir, "Default", "Network", "Cookies")
+        _write_cookie_db(cookies, 8)
+
+        def churn_on_launch():
+            # Normal startup churn only: one cookie expired.
+            _write_cookie_db(cookies, 7)
+
+        _arm_real_profile_launch(monkeypatch, copy_dir, churn_on_launch)
+
+        cdp, err = bt._real_profile_cdp()
+        assert cdp == "http://127.0.0.1:9222"
+        assert err is None
+        assert "msg" not in bt._real_profile_purge_notice
+
+    def test_missing_post_launch_db_never_claims_purge(self, tmp_path, monkeypatch):
+        """A post-launch DB that cannot be read must not fabricate a purge notice."""
+        import tools.browser_tool as bt
+
+        copy_dir = str(tmp_path / "browser-profile" / "chrome")
+        cookies = os.path.join(copy_dir, "Default", "Network", "Cookies")
+        _write_cookie_db(cookies, 8)
+
+        def remove_db_on_launch():
+            os.unlink(cookies)
+
+        _arm_real_profile_launch(monkeypatch, copy_dir, remove_db_on_launch)
+
+        cdp, err = bt._real_profile_cdp()
+        assert cdp == "http://127.0.0.1:9222"
+        assert err is None
+        assert "msg" not in bt._real_profile_purge_notice

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -56,6 +56,7 @@ import logging
 import os
 import signal
 import re
+import sqlite3
 import subprocess
 import shutil
 import sys
@@ -1454,6 +1455,51 @@ def _use_real_profile() -> bool:
 _REAL_PROFILE_SESSION = "hermes-real-profile"
 _real_profile_cdp_lock = threading.Lock()
 _real_profile_cdp_cache: dict = {}
+# One-shot notice set when a freshly launched copy-browser is detected to have
+# purged the cookies the snapshot just copied in (Chrome ≥151 on Windows binds
+# cookie encryption to the original profile and deletes copied entries on first
+# launch, #96993). Consumed by the next real-profile session creation so the
+# first navigation can tell the agent why sites start signed out.
+_real_profile_purge_notice: dict = {}
+
+
+def _count_real_profile_cookies(copy_dir: str) -> Optional[int]:
+    """Count cookies in a real-profile copy's cookie DB, best-effort.
+
+    Reads the copy's ``Default/Network/Cookies`` (falling back to the legacy
+    ``Default/Cookies`` location) with a short-timeout read-only SQLite
+    connection. Any failure (missing DB, locked by the running copy-browser,
+    non-SQLite file) returns ``None`` — callers treat that as "cannot tell"
+    and skip the purge check rather than guess.
+    """
+    for rel in ("Network/Cookies", "Cookies"):
+        db = os.path.join(copy_dir, "Default", *rel.split("/"))
+        if not os.path.isfile(db):
+            continue
+        try:
+            conn = sqlite3.connect(f"file:{db}?mode=ro", timeout=1.0, uri=True)
+            try:
+                row = conn.execute("SELECT COUNT(*) FROM cookies").fetchone()
+            finally:
+                conn.close()
+            return int(row[0]) if row else 0
+        except (sqlite3.Error, OSError, ValueError):
+            return None
+    return None
+
+
+def _cookies_purged_after_launch(before: Optional[int], after: Optional[int]) -> bool:
+    """True when the post-launch cookie count shows an active purge.
+
+    Chrome's app-bound-encryption purge wipes essentially the whole jar (556 → 6
+    and 3507 → ~0 in the #96993 reports), so a >50% drop from a non-trivial
+    baseline is unambiguous; normal startup work (expired-cookie sweeping,
+    fresh visitor cookies) moves counts by a handful. Counts below 5 are
+    ignored — a near-empty jar has nothing worth warning about.
+    """
+    if before is None or after is None or before < 5:
+        return False
+    return after * 2 < before
 
 
 def _agent_browser_argv(browser_cmd: str) -> list:
@@ -1650,6 +1696,11 @@ def _real_profile_cdp() -> tuple:
                 )
             return None, f"browser.use_real_profile is on, but {err}"
         copy_dir = snap_dir
+        # Baseline cookie count while nothing holds the copy's DBs: after the
+        # launch below, a Chromium that purges copied cookies (Chrome ≥151 on
+        # Windows, #96993) will have rewritten the jar down to ~zero, and the
+        # drop is what we warn on — not the copy, which this just verified.
+        cookies_before_launch = _count_real_profile_cookies(copy_dir)
 
         # Launch agent-browser's packaged Chromium on the profile COPY. This is
         # the same launch path Hermes' built-in local browsing already uses,
@@ -1703,6 +1754,24 @@ def _real_profile_cdp() -> tuple:
                 "the toggle off."
             )
         _real_profile_cdp_cache["cdp"] = cdp
+        cookies_after_launch = _count_real_profile_cookies(copy_dir)
+        if _cookies_purged_after_launch(cookies_before_launch, cookies_after_launch):
+            notice = (
+                "Chrome deleted the cookies copied from your real profile on "
+                "this copy browser's first launch (current Chrome binds cookie "
+                "encryption to the original profile, so copies are purged; "
+                "#96993). Sites will start signed out even though you are "
+                "signed in locally. Logins created inside this copy browser do "
+                "persist across sessions, but sites that refuse automated "
+                "browsers (e.g. Google sign-in) may reject a login here."
+            )
+            _real_profile_purge_notice["msg"] = notice
+            logger.warning(
+                "real-profile cookie purge detected: %d cookies copied, %d "
+                "survived the copy-browser launch — sessions will start "
+                "signed out (#96993)",
+                cookies_before_launch, cookies_after_launch,
+            )
         logger.info("real-profile browser ready for %s at %s (%s)", browser, cdp, copy_dir)
         return cdp, None
 
@@ -2716,12 +2785,22 @@ def _create_local_session(task_id: str, allow_real_profile: bool = True) -> Dict
             logger.info(
                 "Created real-profile local session %s for task %s", session_name, task_id
             )
-            return {
+            features = {"local": True, "real_profile": True}
+            session = {
                 "session_name": session_name,
                 "bb_session_id": None,
                 "cdp_url": _resolve_cdp_override(cdp_url),
-                "features": {"local": True, "real_profile": True},
+                "features": features,
             }
+            # One-shot: if this launch was detected to have purged the copied
+            # cookies (#96993), carry the notice on the session so the first
+            # navigation can explain the signed-out state instead of the agent
+            # discovering it as mysterious login failures, site by site.
+            purge_notice = _real_profile_purge_notice.pop("msg", None)
+            if purge_notice:
+                features["real_profile_cookies_purged"] = True
+                session["real_profile_purge_warning"] = purge_notice
+            return session
 
     session_name = f"h_{uuid.uuid4().hex[:10]}"
     logger.info("Created local browser session %s for task %s",
@@ -4097,6 +4176,12 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
                     "Consider upgrading Browserbase plan for proxy support."
                 )
             response["stealth_features"] = active_features
+            # Set when the copy-browser's first launch purged the copied
+            # cookies (#96993): the agent needs to know up front why every
+            # site starts signed out before it burns turns probing logins.
+            purge_warning = session_info.get("real_profile_purge_warning")
+            if purge_warning:
+                response["real_profile_purge_warning"] = purge_warning
 
         # Auto-take a compact snapshot so the model can act immediately
         # without a separate browser_snapshot call.


### PR DESCRIPTION
## What does this PR do?

On Windows, Chrome ≥ 151 binds cookie encryption to the original profile, so the first launch of the real-profile **copy** browser actively purges the cookies the snapshot just copied in (#96993: 556 → 6 and 3507 → ~0 across three launch paths, including a bare `chrome.exe --user-data-dir=<copy>`). The session then silently starts signed out, and the agent discovers it as mysterious per-site login failures.

This implements the issue's suggested "detect + fail soft" direction: after launching the copy-browser, `_real_profile_cdp()` re-counts the copy's cookie jar and compares it to a baseline taken right after the snapshot (while nothing holds the DBs). A >50% drop from a baseline of ≥5 cookies is unambiguous — normal startup churn (expired-cookie sweeping, fresh visitor cookies) moves counts by a handful — so on that drop Hermes now surfaces a one-shot `real_profile_purge_warning` on the session's **first navigation**, telling the agent up front why sites are signed out and what actually persists. The launch itself still succeeds (fail-soft): the copy browser is usable, only the copied login state is gone.

The check is deliberately platform-independent (a before/after count, not a Windows check), and read failures (DB locked by the running copy-browser, torn file) return "cannot tell" and skip the warning — it can never fabricate a purge.

## Related Issue

Fixes #96993

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/browser_tool.py` — added `_count_real_profile_cookies()`: best-effort read-only SQLite count of the copy's `Default/Network/Cookies` (legacy `Default/Cookies` fallback), `None` on any read failure
- `tools/browser_tool.py` — added `_cookies_purged_after_launch()`: the drop predicate (≥5 baseline, post-launch count less than half)
- `tools/browser_tool.py` — `_real_profile_cdp()`: take the baseline after the snapshot, re-count after the CDP endpoint is up, stash a one-shot notice + `logger.warning` on a detected purge
- `tools/browser_tool.py` — `_create_local_session()` / first-navigation response: carry the notice as `real_profile_cookies_purged` feature + `real_profile_purge_warning` field, consumed once per launch
- `tests/tools/test_browser_real_profile_purge.py` — new: counting helper (locations, fallback, missing/garbage DB), predicate truth table (both reported purge shapes, normal churn, unknown counts, small baseline), notice→session one-shot wiring, and end-to-end detection through `_real_profile_cdp()` with stubbed launch (purge sets notice, churn/unreadable DB does not)

## How to Test

1. `.venv/bin/python -m pytest tests/tools/test_browser_real_profile_purge.py -q` — Observed result: **21 passed** (real SQLite cookie DBs in tmp_path; no Windows needed)
2. `.venv/bin/python -m pytest tests/tools/test_browser_real_profile.py -q` — Observed result: **73 passed** (existing real-profile suite unaffected)
3. On Windows 11 + Chrome ≥ 151 with `browser.use_real_profile: true`: first `browser_navigate` response now carries `real_profile_purge_warning` instead of a silently signed-out session (detection path is exercised end-to-end by the stubbed-launch tests above; the real Windows purge behavior is documented in #96993's measurements).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — ran the browser/tools suites: 617 passed; the 5 remaining failures reproduce identically on a clean `upstream/main` checkout with my changes stashed (camofox local-service + order-coupled selection tests, pre-existing)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (darwin arm64); the Windows-specific purge itself is covered by the platform-independent detection design + tests

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the detection is platform-independent and read-failure-safe by design
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A (no schema change; the warning rides the existing first-navigation response)
