### PR TITLE
fix(install): persist macOS Bash launcher path

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2033,8 +2033,21 @@ EOF
                 fi
                 ;;
             bash)
-                [ -f "$HOME/.bashrc" ] && SHELL_CONFIGS+=("$HOME/.bashrc")
-                [ -f "$HOME/.bash_profile" ] && SHELL_CONFIGS+=("$HOME/.bash_profile")
+                # Terminal.app starts bash as a login shell, so macOS reads
+                # ~/.bash_profile rather than ~/.bashrc. Prefer that file on
+                # macOS and create it whenever it is absent.
+                # Linux terminals normally start non-login bash and read
+                # ~/.bashrc, so retain that platform's existing preference.
+                if [ "$OS" = "macos" ]; then
+                    # A standalone ~/.bashrc is not enough for Terminal.app's
+                    # login Bash. Always give the login shell its own file.
+                    [ -f "$HOME/.bash_profile" ] || touch "$HOME/.bash_profile"
+                    SHELL_CONFIGS+=("$HOME/.bash_profile")
+                    [ -f "$HOME/.bashrc" ] && SHELL_CONFIGS+=("$HOME/.bashrc")
+                else
+                    [ -f "$HOME/.bashrc" ] && SHELL_CONFIGS+=("$HOME/.bashrc")
+                    [ -f "$HOME/.bash_profile" ] && SHELL_CONFIGS+=("$HOME/.bash_profile")
+                fi
                 ;;
             fish)
                 # fish uses ~/.config/fish/config.fish and fish_add_path — not export PATH=
@@ -2936,7 +2949,15 @@ print_success() {
         if [ "$LOGIN_SHELL" = "zsh" ]; then
             echo "   source ~/.zshrc"
         elif [ "$LOGIN_SHELL" = "bash" ]; then
-            echo "   source ~/.bashrc"
+            if [ "$OS" = "macos" ] && [ -f "$HOME/.bash_profile" ]; then
+                echo "   source ~/.bash_profile"
+            elif [ -f "$HOME/.bashrc" ]; then
+                echo "   source ~/.bashrc"
+            elif [ -f "$HOME/.bash_profile" ]; then
+                echo "   source ~/.bash_profile"
+            else
+                echo "   Open a new terminal"
+            fi
         elif [ "$LOGIN_SHELL" = "fish" ]; then
             echo "   source ~/.config/fish/config.fish"
         else

--- a/tests/test_install_sh_bash_path_macos.py
+++ b/tests/test_install_sh_bash_path_macos.py
@@ -1,0 +1,83 @@
+"""Behavioral coverage for Bash PATH setup on macOS."""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+
+
+def _make_executable(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+@pytest.mark.macos_only
+@pytest.mark.parametrize("existing_bashrc", [False, True])
+def test_path_stage_creates_login_bash_profile(
+    tmp_path: Path, existing_bashrc: bool
+) -> None:
+    """A macOS Bash login must find Hermes with or without an existing bashrc."""
+    home = tmp_path / "home"
+    install_dir = tmp_path / "hermes-agent"
+    venv_bin = install_dir / "venv" / "bin"
+    home.mkdir()
+    venv_bin.mkdir(parents=True)
+    if existing_bashrc:
+        (home / ".bashrc").write_text("# existing config\n", encoding="utf-8")
+
+    _make_executable(venv_bin / "python", "#!/bin/sh\nexit 0\n")
+    (install_dir / "hermes").write_text("# launcher target\n", encoding="utf-8")
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "HOME": str(home),
+            "HERMES_HOME": str(home / ".hermes"),
+            "HERMES_INSTALL_DIR": str(install_dir),
+            "SHELL": "/bin/bash",
+        }
+    )
+    local_bin = str(home / ".local" / "bin")
+    env["PATH"] = os.pathsep.join(
+        entry for entry in env.get("PATH", "").split(os.pathsep) if entry != local_bin
+    )
+
+    completed = subprocess.run(
+        [
+            "/bin/bash",
+            str(INSTALL_SH),
+            "--stage",
+            "path",
+            "--non-interactive",
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    bash_profile = home / ".bash_profile"
+    assert bash_profile.exists()
+    assert 'export PATH="$HOME/.local/bin:$PATH"' in bash_profile.read_text(
+        encoding="utf-8"
+    )
+
+    resolved = subprocess.run(
+        ["/bin/bash", "-lc", "command -v hermes"],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert resolved.returncode == 0, resolved.stderr
+    assert resolved.stdout.strip() == str(home / ".local" / "bin" / "hermes")


### PR DESCRIPTION
## What does this PR do?

On macOS, Terminal.app starts Bash as a login shell and reads `~/.bash_profile`, not `~/.bashrc`. The installer previously created the Hermes launcher under `~/.local/bin`, but if a Bash user had no startup files it persisted no PATH entry, still reported the command ready, and later told the user to source a nonexistent `~/.bashrc`.

This change ensures macOS Bash always has a `~/.bash_profile` containing the Hermes PATH entry. It also makes the completion message name the Bash startup file that actually exists. Existing Linux Bash selection remains unchanged.

## Related Issue

Reported through support; no public issue exists.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Make `scripts/install.sh` create and update `~/.bash_profile` for macOS Bash, including homes that only have `~/.bashrc`.
- Print the applicable Bash reload command instead of always naming `~/.bashrc`.
- Add a macOS-only behavioral regression that runs the real installer `path` stage against an isolated home and verifies a fresh login Bash resolves `hermes`.

## How to Test

1. On macOS, run `scripts/run_tests.sh tests/test_install_sh_bash_path_macos.py -q -j 4`.
2. Verify both parametrized cases create `~/.bash_profile` with `~/.local/bin` on PATH.
3. Verify `/bin/bash -lc 'command -v hermes'` resolves the generated launcher.

Local checks completed on Windows:

- `bash -n scripts/install.sh`
- `scripts/check-windows-footguns.py`
- `git diff --check`

The macOS-only behavioral test was not run on this Windows host and is left to the macOS CI lane.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: macOS CI pending

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A