### PR TITLE
fix(update): preserve gateway progress logging

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10633,7 +10633,9 @@ def _install_hangup_protection(gateway_mode: bool = False):
     signals the user or OS sent on purpose.
 
     In gateway mode (``hermes update --gateway``) the update is already
-    spawned detached from a terminal, so this function is a no-op.
+    spawned detached from a terminal, so SIGHUP protection is unnecessary.
+    Output is still mirrored to ``update.log`` because the Windows Desktop
+    hand-off watchdog uses growth of that file as its progress signal.
 
     Returns a dict that ``cmd_update`` can pass to
     ``_finalize_update_output`` on exit.  Returning a dict rather than a
@@ -10646,19 +10648,17 @@ def _install_hangup_protection(gateway_mode: bool = False):
         "installed": False,
     }
 
-    if gateway_mode:
-        return state
+    if not gateway_mode:
+        import signal as _signal
 
-    import signal as _signal
-
-    # (1) Ignore SIGHUP for the remainder of this process.
-    if hasattr(_signal, "SIGHUP"):
-        try:
-            _signal.signal(_signal.SIGHUP, _signal.SIG_IGN)
-        except (ValueError, OSError):
-            # Called from a non-main thread — not fatal.  The update still
-            # runs, just without hangup protection.
-            pass
+        # (1) Ignore SIGHUP for the remainder of this process.
+        if hasattr(_signal, "SIGHUP"):
+            try:
+                _signal.signal(_signal.SIGHUP, _signal.SIG_IGN)
+            except (ValueError, OSError):
+                # Called from a non-main thread — not fatal.  The update still
+                # runs, just without hangup protection.
+                pass
 
     # (2) Mirror output to update.log and wrap stdio for broken-pipe
     # tolerance.  Any failure here is non-fatal; we just skip the wrap.
@@ -10799,9 +10799,8 @@ def cmd_update(args):
 
     gateway_mode = getattr(args, "gateway", False)
 
-    # Protect against mid-update terminal disconnects (SIGHUP) and tolerate
-    # writes to a closed stdout.  No-op in gateway mode.  See
-    # _install_hangup_protection for rationale.
+    # Protect terminal updates against SIGHUP and mirror both terminal and
+    # gateway update output to update.log. See _install_hangup_protection.
     _update_io_state = _install_hangup_protection(gateway_mode=gateway_mode)
     # Cross-process mutual exclusion. The dashboard's Update button spawns
     # this same command detached, and the desktop hands off to the Tauri

--- a/tests/hermes_cli/test_update_hangup_protection.py
+++ b/tests/hermes_cli/test_update_hangup_protection.py
@@ -137,6 +137,31 @@ class TestInstallHangupProtection:
             assert sys.stdout is prev_out
             assert sys.stderr is prev_err
 
+    def test_gateway_mode_keeps_update_log_progress(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        prev_out, prev_err = sys.stdout, sys.stderr
+
+        state = _install_hangup_protection(gateway_mode=True)
+
+        try:
+            assert state["installed"] is True
+            assert isinstance(sys.stdout, _UpdateOutputStream)
+            assert isinstance(sys.stderr, _UpdateOutputStream)
+
+            sys.stdout.write("gateway progress\n")
+            _log_only_write("desktop build progress\n")
+            sys.stdout.flush()
+
+            contents = (tmp_path / "logs" / "update.log").read_text(
+                encoding="utf-8"
+            )
+            assert "gateway progress" in contents
+            assert "desktop build progress" in contents
+        finally:
+            _finalize_update_output(state)
+            assert sys.stdout is prev_out
+            assert sys.stderr is prev_err
+
 
     def test_non_fatal_if_log_setup_fails(self, monkeypatch):
         """If get_hermes_home() raises, stdio must be left untouched but SIGHUP still handled."""


### PR DESCRIPTION
## Summary

- keep `logs/update.log` mirroring active for `hermes update --gateway`
- retain SIGHUP handling only for terminal-driven updates
- cover gateway progress and log-only desktop build output with a regression test

## Root cause

`_install_hangup_protection()` returned before installing the output mirror in gateway mode. Windows Desktop's update hand-off watches `logs/update.log` growth during stdout-silent build steps, so the structurally missing log made a healthy long-running build appear stalled and allowed the watchdog to terminate it with exit 124. The same early return also left `_log_only_write()` without a log target, discarding captured desktop build output.

## Verification

- `scripts/run_tests.sh tests/hermes_cli/test_update_hangup_protection.py tests/hermes_cli/test_update_handoff_exit.py -q` (17 passed)
- `scripts/run_tests.sh tests/test_desktop_update_windows_pipe_drain.py tests/test_desktop_update_windows_python_handoff.py -q` (10 passed)

Closes #97394
