### PR TITLE
fix(desktop): fall back to --no-sandbox when launcher runs non-interactively

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8090,6 +8090,14 @@ def _desktop_linux_needs_no_sandbox() -> bool:
         return False
     if hasattr(os, "geteuid") and os.geteuid() == 0:
         return False
+
+    # Non-interactive launch (e.g. a systemd user service or cron): there is no
+    # TTY to prompt for the sudo password that configuring the setuid
+    # chrome-sandbox helper requires, so fall back to --no-sandbox rather than
+    # hard-failing into a restart crash-loop.
+    if sys.stdin is not None and not sys.stdin.isatty():
+        return True
+
     try:
         with open("/proc/sys/kernel/apparmor_restrict_unprivileged_userns", encoding="utf-8") as f:
             return f.read().strip() == "1"
@@ -8538,7 +8546,7 @@ def cmd_gui(args: argparse.Namespace):
     launch_command = [str(packaged_executable)]
     if not _desktop_linux_sandbox_fixup(packaged_executable):
         if _desktop_linux_needs_no_sandbox() and _desktop_linux_sandbox_helper_is_regular_file(packaged_executable):
-            print("⚠ Falling back to --no-sandbox because this Linux host restricts unprivileged user namespaces and the Electron sandbox helper could not be configured.")
+            print("⚠ Falling back to --no-sandbox because Electron's Linux setuid sandbox helper could not be configured (non-interactive launch, or this host restricts unprivileged user namespaces).")
             launch_command.append("--no-sandbox")
         else:
             sys.exit(1)

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -994,6 +995,57 @@ def test_gui_skips_desktop_entry_off_linux(tmp_path, monkeypatch):
         cli_main.cmd_gui(_ns())
 
     assert exc.value.code == 0
+
+
+def test_desktop_linux_needs_no_sandbox_when_stdin_not_a_tty(monkeypatch):
+    """A non-interactive launch (systemd user service / cron) cannot prompt for
+    the sudo password that configuring Electron's setuid ``chrome-sandbox``
+    helper requires, so ``hermes desktop`` must fall back to ``--no-sandbox``
+    rather than hard-failing into a restart crash-loop."""
+    monkeypatch.delenv("ELECTRON_DISABLE_SANDBOX", raising=False)
+    if hasattr(os, "geteuid"):
+        # Root users are deliberately excluded by the euid guard; pin a
+        # non-root uid so this test exercises the non-interactive branch.
+        monkeypatch.setattr(cli_main.os, "geteuid", lambda: 1000)
+    monkeypatch.setattr(
+        sys, "stdin", type("_Stdin", (), {"isatty": lambda self: False})()
+    )
+    if sys.platform in ("darwin", "win32"):
+        assert cli_main._desktop_linux_needs_no_sandbox() is False
+    else:
+        assert cli_main._desktop_linux_needs_no_sandbox() is True
+
+
+@pytest.mark.linux_only
+def test_gui_falls_back_to_no_sandbox_when_helper_cannot_be_configured(
+    tmp_path, monkeypatch, capsys
+):
+    """When Electron's setuid sandbox helper exists as a regular file but can't
+    be configured (e.g. a headless systemd service that can't ``sudo``), the
+    launcher appends ``--no-sandbox`` to the launch command instead of
+    ``sys.exit(1)``-ing into a restart crash-loop."""
+    root = _make_desktop_tree(tmp_path)
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    packaged_exe = _make_packaged_executable(root, monkeypatch)
+    # _make_packaged_executable lays down chrome-sandbox as a regular file on
+    # Linux, satisfying _desktop_linux_sandbox_helper_is_regular_file().
+    assert (packaged_exe.parent / "chrome-sandbox").is_file()
+
+    launch_ok = subprocess.CompletedProcess([str(packaged_exe)], 0)
+
+    with patch("hermes_cli.main._desktop_build_needed", return_value=False), \
+         patch("hermes_cli.main._resolve_node_runtime_npm", return_value="/usr/bin/npm"), \
+         patch("hermes_cli.main._desktop_linux_sandbox_fixup", return_value=False), \
+         patch("hermes_cli.main._desktop_linux_needs_no_sandbox", return_value=True), \
+         patch("hermes_cli.linux_desktop_entry.is_supported", return_value=False), \
+         patch("hermes_cli.main.subprocess.run", return_value=launch_ok) as mock_run, \
+         pytest.raises(SystemExit) as exc:
+        cli_main.cmd_gui(_ns())
+
+    assert exc.value.code == 0
+    assert mock_run.call_args.args[0] == [str(packaged_exe), "--no-sandbox"]
+    out = capsys.readouterr().out
+    assert "--no-sandbox" in out
 
 @pytest.mark.parametrize(
     "raw,expected",


### PR DESCRIPTION
## Bug

`hermes desktop` hard-fails (`sys.exit(1)`) in non-interactive/headless contexts such as a systemd user service or cron because it cannot `sudo chown root:root` + `sudo chmod 4755` Electron's Linux `chrome-sandbox` setuid helper — there is no TTY to prompt for the sudo password, so the subprocess dies and the service crash-loops with `status=1/FAILURE`.

The launcher already has a graceful `--no-sandbox` fallback, but it was gated behind `_desktop_linux_needs_no_sandbox()`, which only returned `True` when `ELECTRON_DISABLE_SANDBOX=1` was set **or** the host had `/proc/sys/kernel/apparmor_restrict_unprivileged_userns == "1"`. On a plain Linux host with neither, the fallback never fired and the launcher exited 1.

## Fix

Extend `_desktop_linux_needs_no_sandbox()` to also return `True` when the process is running non-interactively (`sys.stdin` is not a TTY), because in that context there is no way to prompt for the sudo password to configure the setuid sandbox helper — so the caller falls back to `--no-sandbox` rather than hard-failing into a crash loop.

- New check is placed **after** the `sys.platform != "linux"` guard and the `euid == 0` guard (root/non-Linux behavior unchanged), and **independent of** the AppArmor file check.
- The existing `sys.exit(1)` hard-fail branch is preserved for genuinely broken cases (helper missing / not a regular file) and for interactive contexts where the user could fix it.
- Fallback warning message generalized to cover both non-interactive launches and AppArmor-restricted hosts.

## Tests

- Unit test `test_desktop_linux_needs_no_sandbox_when_stdin_not_a_tty`: monkeypatches `sys.stdin` to a non-TTY object, clears `ELECTRON_DISABLE_SANDBOX`, and asserts `_desktop_linux_needs_no_sandbox()` is `True` on Linux (`False` on darwin/win32).
- `cmd_gui`-level test `test_gui_falls_back_to_no_sandbox_when_helper_cannot_be_configured`: patches `_desktop_linux_sandbox_fixup` to return `False`, keeps a regular `chrome-sandbox` file in the packaged tree, and asserts the launch subprocess is invoked with `--no-sandbox` and does **not** `sys.exit(1)` before launching.

`pytest tests/hermes_cli/test_gui_command.py` → `43 passed, 9 skipped` (one pre-existing ozone-hint test is host-env-dependent and fails only when `ELECTRON_OZONE_PLATFORM_HINT` is exported; it fails identically on `main`).