### PR TITLE
fix: add type check in _provider_stream_text_may_be_sse to handle non-string input

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -357,9 +357,11 @@ def _payload_has_error_shape(payload: Any) -> bool:
     return False
 
 
-def _provider_stream_text_may_be_sse(text: str) -> bool:
+def _provider_stream_text_may_be_sse(text: Any) -> bool:
     """Return True while pending text still looks like an SSE control block."""
-    stripped = (text or "").lstrip()
+    if not isinstance(text, str):
+        return False
+    stripped = text.lstrip()
     if not stripped:
         return False
 


### PR DESCRIPTION
## Summary

This PR fixes #97382 by adding a type check in `_provider_stream_text_may_be_sse` to handle non-string input gracefully.

## Problem

When streaming from certain OpenAI-compatible providers or upstream gateways, `delta.content` can sometimes contain non-string types (e.g., integer tokens or token IDs). The function `_provider_stream_text_may_be_sse` was expecting a string and crashing with:

```
AttributeError: 'int' object has no attribute 'lstrip'
```

This caused the agent to interpret the broken stream as a token-limit length truncation, triggering 4 consecutive continuation attempts and ultimately terminating with "Response remained truncated".

## Solution

Added `isinstance(text, str)` check at the beginning of the function:
- If `text` is not a string, it cannot be an SSE control block, so return `False`
- This allows streaming to proceed normally without breaking execution

## Changes

- Modified `agent/chat_completion_helpers.py`: Added type hint `Any` and `isinstance` check

## Testing

The fix is defensive and should not break existing functionality. Non-string inputs will simply be treated as non-SSE content, which is the correct behavior.

---

🤖 Generated with Codebuff
Co-Authored-By: Codebuff <noreply@codebuff.com>