### PR TITLE
fix(gateway): code-skew guard fingerprints the checked-out tree, not the commit

### DIFF
--- a/contributors/emails/david@devon.localdomain
+++ b/contributors/emails/david@devon.localdomain
@@ -1,0 +1,2 @@
+valicen-davidsaunders
+# PR #97407 (Valicen / David Saunders; commit-author email from ops host)

--- a/gateway/code_skew.py
+++ b/gateway/code_skew.py
@@ -23,13 +23,44 @@ _PROJECT_ROOT = Path(__file__).resolve().parent.parent
 _boot_fingerprint: str | None = None
 
 
+def _tree_fingerprint() -> str | None:
+    """Fingerprint of the checked-out TREE (``HEAD^{tree}``), not the commit.
+
+    Two commits with identical content (a branch flip, a rebase that changes
+    nothing, a merge that only rewrites history) must not read as "stale
+    code": the modules on disk are byte-for-byte what the process loaded, so a
+    restart would change nothing. Comparing commit SHAs produced exactly that
+    false positive on 2026-08-27 — a branch switch with an identical tree
+    503'd the dashboard model picker for hours. Spawning ``git`` here is fine:
+    this runs once at boot and then only on demand (model switch / picker
+    load), never on a hot path. Returns ``None`` when git is unavailable so
+    the caller falls back to the ref/SHA reader.
+    """
+    try:
+        import subprocess
+
+        out = subprocess.run(
+            ["git", "-C", str(_PROJECT_ROOT), "rev-parse", "HEAD^{tree}"],
+            capture_output=True, text=True, timeout=5, check=False,
+        )
+        tree = out.stdout.strip() if out.returncode == 0 else ""
+        if tree and len(tree) >= 7 and all(c in "0123456789abcdef" for c in tree):
+            return f"tree:HEAD:{tree}"
+    except Exception:
+        pass
+    return None
+
+
 def _fingerprint() -> str | None:
-    """Current checkout fingerprint, reusing the CLI's git-rev reader.
+    """Current checkout fingerprint: tree hash first, ref/SHA reader as fallback.
 
     ``hermes_cli.main`` is always already imported in a gateway process (it's
-    the entry point), so this import is free and avoids duplicating the
-    worktree-aware ref resolution.
+    the entry point), so the fallback import is free and avoids duplicating
+    the worktree-aware ref resolution.
     """
+    tree = _tree_fingerprint()
+    if tree:
+        return tree
     try:
         from hermes_cli.main import _read_git_revision_fingerprint
 

--- a/tests/test_code_skew.py
+++ b/tests/test_code_skew.py
@@ -144,3 +144,36 @@ class TestModelOptionsSkewGuard:
 
         assert result == expected
         assert payload_calls == [1]
+
+
+class TestTreeFingerprint:
+    """Skew is about CONTENT: identical trees under different commits are not skew."""
+
+    def _git(self, repo, *args):
+        import subprocess
+        return subprocess.run(["git", "-C", str(repo), *args], capture_output=True, text=True, check=True).stdout.strip()
+
+    def test_identical_tree_across_commits_is_not_skew(self, tmp_path, monkeypatch):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        self._git(repo, "init", "-q", "-b", "main")
+        self._git(repo, "config", "user.email", "t@example.invalid")
+        self._git(repo, "config", "user.name", "t")
+        (repo / "a.py").write_text("x = 1\n")
+        self._git(repo, "add", "a.py")
+        self._git(repo, "commit", "-q", "-m", "one")
+        monkeypatch.setattr(code_skew, "_PROJECT_ROOT", repo)
+        code_skew.record_boot_fingerprint()
+        assert code_skew._boot_fingerprint.startswith("tree:")
+        # A second commit with the SAME tree (branch flip / empty commit).
+        self._git(repo, "commit", "-q", "--allow-empty", "-m", "two")
+        assert code_skew.detect_code_skew() is None
+        # A real content change IS skew.
+        (repo / "a.py").write_text("x = 2\n")
+        self._git(repo, "commit", "-q", "-am", "three")
+        skew = code_skew.detect_code_skew()
+        assert skew is not None and skew[0] != skew[1]
+
+    def test_tree_fingerprint_none_outside_git(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(code_skew, "_PROJECT_ROOT", tmp_path)
+        assert code_skew._tree_fingerprint() is None


### PR DESCRIPTION
## What does this PR do?

`gateway/code_skew.py` decides "this process is running stale code" by comparing the checkout's **commit SHA** at boot with the one on disk now. Two commits with an identical tree (a branch switch, an `--allow-empty` commit, a history rewrite) therefore read as skew even though every module on disk is byte-for-byte what the process loaded — and a restart would change nothing. In our deployment a branch flip with an identical tree made the dashboard's `/api/model/options` guard return 503 ("Restart required") for hours.

This PR fingerprints the checked-out **tree** (`git rev-parse HEAD^{tree}`) instead, falling back to the existing ref/SHA reader when git is unavailable. It runs only at boot and on demand (model switch / picker load), never on a hot path.

## Related Issue

Fixes # (no existing issue found — searched PRs/issues for "code skew", "stale code restart required")

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/code_skew.py`: new `_tree_fingerprint()` (subprocess `git rev-parse HEAD^{tree}`, 5s timeout, hex-validated); `_fingerprint()` prefers it, falls back to `_read_git_revision_fingerprint`.
- `tests/test_code_skew.py`: `TestTreeFingerprint` — identical tree across commits is NOT skew; a real content change IS; non-git root returns `None`. Existing tests unchanged (they monkeypatch `_fingerprint`).

## How to Test

1. `pytest tests/test_code_skew.py -q` (13 pass).
2. In a gateway/dashboard checkout: `git commit --allow-empty -m x` → `/model` switch and `/api/model/options` no longer demand a restart.
3. Change a file and commit → the guard still fires.

## Checklist

### Code
- [x] I've read the Contributing Guide
- [x] Conventional Commits
- [x] Searched existing PRs
- [x] Only related changes
- [x] `pytest tests/ -q` — relevant suites pass (full-suite run in our env: 1856 passed, 1 pre-existing env-specific failure unrelated to this change)
- [x] Tests added
- [x] Tested on: Debian 13 (Linux 6.12), Python 3.11

### Documentation & Housekeeping
- [x] Docstrings updated — N/A otherwise
- [x] Cross-platform: `git` invocation is the same on all platforms; failure falls back to the existing reader
