### PR TITLE
fix(kanban): deliver notify subscriptions for profiles that cannot host the platform

### DIFF
--- a/contributors/emails/david@devon.localdomain
+++ b/contributors/emails/david@devon.localdomain
@@ -1,0 +1,2 @@
+valicen-davidsaunders
+# PR #97408 (Valicen / David Saunders; commit-author email from ops host)

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -668,6 +668,17 @@ class GatewayKanbanWatchersMixin:
                         sub["chat_id"], sub.get("thread_id") or "",
                     )
                     mode = sub.get("delivery_mode") or "notify"
+                    if d.get("fallback") and mode != "notify":
+                        # A fallback delivery runs on a gateway that is NOT the
+                        # subscription owner's: waking "the agent" here would
+                        # wake this gateway's agent in the owner's name (the
+                        # root agent answered for chief-of-staff tasks on the
+                        # first live run, 2026-08-28). Deliver passively only.
+                        logger.info(
+                            "kanban notifier: fallback delivery for %s downgraded %s -> notify (owner profile %s not hosted here)",
+                            sub["task_id"], mode, sub.get("notifier_profile"),
+                        )
+                        mode = "notify"
                     wake_agent = mode in ("notify+wake", "wake")
                     send_passive = mode != "wake"
                     # Worker handoff carried into the synthetic wake turn below

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -170,6 +170,44 @@ def _release_singleton_lock(handle) -> None:
         pass
 
 
+def _profile_hosts_platform(profile: str, platform_str: str) -> bool:
+    """Does *profile* run its own adapter for *platform_str*?
+
+    Decided from configuration, not from this process's registries: in a
+    one-gateway-per-profile deployment the root gateway cannot see what other
+    gateway processes host, but it CAN read the owner profile's ``.env``. A
+    profile that has no bot token for the platform cannot deliver on it
+    anywhere, so refusing to deliver on its behalf just drops the message —
+    the "kanban_notify to telegram from a worker profile silently never
+    arrives" failure (Valicen, 2026-08-27). Unknown platforms (no token env
+    var in the canonical map) answer True: fail closed, no fallback.
+    """
+    try:
+        from gateway.config import PLATFORM_TOKEN_ENV_NAMES, Platform as _P
+        from hermes_cli.profiles import get_profile_dir
+
+        try:
+            plat = _P(platform_str)
+        except ValueError:
+            return True
+        env_name = PLATFORM_TOKEN_ENV_NAMES.get(plat)
+        if not env_name:
+            return True
+        env_file = get_profile_dir(profile or "default") / ".env"
+        if not env_file.is_file():
+            return False
+        for line in env_file.read_text(encoding="utf-8", errors="replace").splitlines():
+            line = line.strip()
+            if line.startswith("export "):
+                line = line[7:].strip()
+            key, sep, value = line.partition("=")
+            if sep and key.strip() == env_name:
+                return bool(value.strip().strip("'\""))
+        return False
+    except Exception:
+        return True
+
+
 def _wake_scope_id(adapter: Any, sub: dict) -> Optional[str]:
     """Return the tenant scope (Slack workspace) a subscription's wake keys to.
 
@@ -401,10 +439,14 @@ class GatewayKanbanWatchersMixin:
                                 board=slug,
                                 notifier_profiles=notifier_profiles,
                                 include_unowned=include_unowned,
-                            ) == 0:
+                            ) == 0 and _kb.count_notify_subs(board=slug) == 0:
+                                # Both owned AND total are zero. A non-zero
+                                # total with zero owned still needs the open:
+                                # the delivery fallback below may serve rows
+                                # whose owner profile cannot host the platform.
                                 logger.debug(
-                                    "kanban notifier: board %s has no subscriptions owned by %s; skipping open",
-                                    slug, sorted(notifier_profiles),
+                                    "kanban notifier: board %s has no subscriptions at all; skipping open",
+                                    slug,
                                 )
                                 continue
                         except Exception as exc:
@@ -509,6 +551,64 @@ class GatewayKanbanWatchersMixin:
                                         "kanban notifier: subscription for %s on board %s failed: %s",
                                         sub.get("task_id"), slug, sub_exc,
                                     )
+                            # Delivery fallback: a subscription owned by a
+                            # profile that has NO adapter for its platform
+                            # anywhere (checked from that profile's .env) can
+                            # only ever be delivered by a gateway that does
+                            # host the platform — this one. Without this the
+                            # row sits unclaimed forever with no error. The
+                            # "never fall back to the default profile's
+                            # adapter" rule stays intact for owners that run
+                            # their own bot: those are skipped as before.
+                            try:
+                                owned_names = set(notifier_profiles)
+                                orphan_candidates = [
+                                    o for o in _kb.list_notify_subs(conn)
+                                    if (o.get("notifier_profile") or "") not in owned_names
+                                    # "default" is the canonical platform host;
+                                    # its rows are never orphans. Legacy
+                                    # unstamped rows stay with the dispatcher.
+                                    and (o.get("notifier_profile") or "") not in ("", "default")
+                                    and (o.get("platform") or "").lower() in active_platforms
+                                ]
+                            except Exception:
+                                orphan_candidates = []
+                            for sub in orphan_candidates:
+                                try:
+                                    owner_profile = sub.get("notifier_profile") or ""
+                                    platform = (sub.get("platform") or "").lower()
+                                    if _profile_hosts_platform(owner_profile, platform):
+                                        continue
+                                    old_cursor, cursor, events = _kb.claim_unseen_events_for_sub(
+                                        conn,
+                                        task_id=sub["task_id"],
+                                        platform=sub["platform"],
+                                        chat_id=sub["chat_id"],
+                                        thread_id=sub.get("thread_id") or "",
+                                        kinds=TERMINAL_KINDS,
+                                    )
+                                    if not events:
+                                        continue
+                                    task = _kb.get_task(conn, sub["task_id"])
+                                    kinds_seen = [getattr(e, "kind", None) or (e.get("kind") if isinstance(e, dict) else "?") for e in events]
+                                    logger.info(
+                                        "kanban notifier: delivering %s for %s on behalf of profile %s (it hosts no %s adapter)",
+                                        kinds_seen, sub["task_id"], owner_profile, platform,
+                                    )
+                                    deliveries.append({
+                                        "sub": sub,
+                                        "old_cursor": old_cursor,
+                                        "cursor": cursor,
+                                        "events": events,
+                                        "task": task,
+                                        "board": slug,
+                                        "fallback": True,
+                                    })
+                                except Exception as sub_exc:
+                                    logger.warning(
+                                        "kanban notifier: fallback subscription for %s on board %s failed: %s",
+                                        sub.get("task_id"), slug, sub_exc,
+                                    )
                         finally:
                             conn.close()
                     return deliveries
@@ -538,7 +638,12 @@ class GatewayKanbanWatchersMixin:
                     # wrong bot (the cross-profile mis-delivery this whole change
                     # exists to fix). The helper returns None only when the profile
                     # (or default) genuinely has no adapter for the platform.
-                    adapter = self._authorization_adapter(plat, sub_profile or None)
+                    if d.get("fallback"):
+                        # Owner profile hosts no adapter for this platform
+                        # (see _collect); this gateway's own adapter delivers.
+                        adapter = (getattr(self, "adapters", None) or {}).get(plat)
+                    else:
+                        adapter = self._authorization_adapter(plat, sub_profile or None)
                     if adapter is None:
                         logger.debug(
                             "kanban notifier: adapter %s disconnected before delivery for %s; rewinding claim",

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -762,7 +762,7 @@ def test_root_gateway_delivers_for_profile_without_platform_adapter(tmp_path, mo
         tid = kb.create_task(conn, title="plumbing", assignee="ito")
         kb.add_notify_sub(
             conn, task_id=tid, platform="telegram", chat_id="david-dm",
-            notifier_profile="pmo_project_manager",
+            notifier_profile="pmo_project_manager", delivery_mode="notify+wake",
         )
         kb.complete_task(conn, tid, summary="done")
     finally:
@@ -777,6 +777,8 @@ def test_root_gateway_delivers_for_profile_without_platform_adapter(tmp_path, mo
 
     assert [d["chat_id"] for d in adapter.sent] == ["david-dm"]
     assert tid in adapter.sent[0]["text"]
+    # Fallback is passive-only: never wake this gateway's agent in the owner's name.
+    assert adapter.handled == []
 
 
 def test_no_fallback_when_owner_profile_hosts_its_own_adapter(tmp_path, monkeypatch):

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -745,3 +745,78 @@ def test_review_requested_does_not_wake_a_notify_only_subscription(
     assert adapter.handled == [], (
         "notify-only subscriptions must not be woken by a review handoff"
     )
+
+def test_root_gateway_delivers_for_profile_without_platform_adapter(tmp_path, monkeypatch):
+    """A worker-profile subscription on a platform that profile cannot host is
+    delivered by the gateway that does host it (Valicen 2026-08-27: a PM
+    profile subscribed David's Telegram DM; the PM gateway had no messaging
+    platforms, the root gateway skipped the foreign row, nothing was ever sent).
+    """
+    from gateway import kanban_watchers as kw
+
+    db_path = tmp_path / "fallback.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="plumbing", assignee="ito")
+        kb.add_notify_sub(
+            conn, task_id=tid, platform="telegram", chat_id="david-dm",
+            notifier_profile="pmo_project_manager",
+        )
+        kb.complete_task(conn, tid, summary="done")
+    finally:
+        conn.close()
+
+    monkeypatch.setattr(kw, "_profile_hosts_platform", lambda profile, platform: False)
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+    runner._active_profile_name = lambda: "default"
+
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert [d["chat_id"] for d in adapter.sent] == ["david-dm"]
+    assert tid in adapter.sent[0]["text"]
+
+
+def test_no_fallback_when_owner_profile_hosts_its_own_adapter(tmp_path, monkeypatch):
+    """Fail-closed rule preserved: an owner with its own bot is never served
+    by another gateway's adapter (that would send from the wrong bot)."""
+    from gateway import kanban_watchers as kw
+
+    db_path = tmp_path / "no-fallback.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="own bot", assignee="ito")
+        kb.add_notify_sub(
+            conn, task_id=tid, platform="telegram", chat_id="writer-dm",
+            notifier_profile="writer",
+        )
+        kb.complete_task(conn, tid, summary="done")
+    finally:
+        conn.close()
+
+    monkeypatch.setattr(kw, "_profile_hosts_platform", lambda profile, platform: True)
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+    runner._active_profile_name = lambda: "default"
+
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert adapter.sent == []
+    assert len(_unseen_terminal_events_for(tid, "writer-dm")) == 1
+
+
+def test_profile_hosts_platform_reads_env(tmp_path, monkeypatch):
+    from gateway import kanban_watchers as kw
+    from hermes_cli import profiles as _profiles
+
+    monkeypatch.setattr(_profiles, "get_profile_dir", lambda name: tmp_path / name)
+    (tmp_path / "hosts").mkdir(); (tmp_path / "hosts" / ".env").write_text("TELEGRAM_BOT_TOKEN=123:abc\n")
+    (tmp_path / "bare").mkdir(); (tmp_path / "bare" / ".env").write_text("OPENAI_API_KEY=x\n")
+    assert kw._profile_hosts_platform("hosts", "telegram") is True
+    assert kw._profile_hosts_platform("bare", "telegram") is False
+    assert kw._profile_hosts_platform("missing", "telegram") is False
+    assert kw._profile_hosts_platform("bare", "not-a-platform") is True


### PR DESCRIPTION
## What does this PR do?

Kanban notify subscriptions are stamped with the profile that created them, and delivery is strictly owner-scoped: only a gateway hosting that profile's adapters may send, with no default-profile fallback (correct — never send from the wrong bot). But in a one-gateway-per-profile deployment where worker profiles run **no** messaging platforms at all, a subscription to e.g. `telegram:<operator DM>` created by a worker profile is unclaimable forever: the owner's gateway skips every tick ("no connected adapters", DEBUG), the platform-hosting gateway skips the row as foreign-owned, and the cursor never advances. No error anywhere; the operator is promised a notification that never arrives.

This PR lets a gateway that hosts the platform deliver on the owner's behalf **only when the owner profile cannot host it anywhere** — decided from configuration (`_profile_hosts_platform()` reads the owner profile's `.env` for the platform's token via `PLATFORM_TOKEN_ENV_NAMES`). Owners that run their own bot are untouched (fail-closed as before); `default`-owned and legacy unstamped rows are never treated as orphans; the zero-subscription fast path only skips a board with no rows at all. Fallback deliveries are **passive-only** (a non-owner gateway must not wake "the agent" in the owner's name), logged at INFO.

## Related Issue

Fixes # (no existing issue found — searched "kanban notify fallback", "notifier profile no adapter")

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/kanban_watchers.py`: `_profile_hosts_platform()`; orphan-candidate collection in `_collect()` (rows owned by non-hosted profiles on platforms this gateway hosts); `fallback` deliveries use this gateway's own adapter and are downgraded to `notify`; zero-sub gate widened.
- `tests/gateway/test_kanban_notifier.py`: fallback delivers (and does not wake); owner-with-own-bot still not served; `.env` parsing.

## How to Test

1. `pytest tests/gateway/test_kanban_notifier.py tests/gateway/test_kanban_notifier_zero_sub_gate.py -q`
2. Live: from a profile with no messaging platforms, `kanban_notify` a Telegram chat the root gateway serves; complete the task → the root gateway logs `delivering ['completed'] for <task> on behalf of profile <p>` and the message arrives. (In our fleet the first tick delivered four notifications that had been stranded for days.)

## Checklist

### Code
- [x] Contributing Guide read · [x] Conventional Commits · [x] Searched existing PRs · [x] Only related changes
- [x] Relevant suites pass (`tests/gateway/test_kanban_notifier*.py`, 34 tests); full suite in our env: 1856 passed
- [x] Tests added
- [x] Tested on: Debian 13, Python 3.11, 15-gateway multi-profile deployment

### Documentation & Housekeeping
- [x] Docstrings explain the rule and its limits — N/A otherwise
- [x] Cross-platform: pure Python/`.env` parsing
