### PR TITLE
fix(kanban): route comment-then-clean-exit workers to review instead of retry

### DIFF
--- a/contributors/emails/david@devon.localdomain
+++ b/contributors/emails/david@devon.localdomain
@@ -1,0 +1,2 @@
+valicen-davidsaunders
+# PR #97409 (Valicen / David Saunders; commit-author email from ops host)

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -8901,6 +8901,7 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     # Worker-exit observer payloads (RFC #58548), collected inside the main
     # txn and fired only after every reclaim/accounting txn has committed.
     exited_hook_payloads: list[dict] = []
+    review_candidates: list[tuple] = []  # (task_id, comment_excerpt, run_id)
     with write_txn(conn):
         rows = conn.execute(
             "SELECT id, worker_pid, claim_lock, started_at, assignee "
@@ -8927,7 +8928,41 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
             pid = int(row["worker_pid"])
             kind, code = _classify_worker_exit(pid)
             rate_limited_exit = False
+            unconfirmed_completion = None
             if kind == "clean_exit":
+                # Valicen/Talaria: a clean exit is not a failure when the
+                # worker left its RESULT on the card — a comment by the
+                # assignee during this run. Re-running such a task burns a
+                # whole budget to redo finished work and then auto-blocks a
+                # done card ("Iteration budget exhausted", t_a5199403,
+                # 2026-08-25). Route it to review instead: the human/reviewer
+                # sees the comment and confirms with one click.
+                try:
+                    _c = conn.execute(
+                        "SELECT body FROM task_comments WHERE task_id = ? "
+                        "AND author = ? AND created_at >= ? ORDER BY id DESC LIMIT 1",
+                        (row["id"], row["assignee"], int(started_at or 0) - 1),
+                    ).fetchone()
+                    if _c is not None and str(_c["body"] or "").strip():
+                        unconfirmed_completion = str(_c["body"]).strip()
+                except Exception:
+                    unconfirmed_completion = None
+            if kind == "clean_exit" and unconfirmed_completion:
+                protocol_violation = False
+                error_text = (
+                    "worker exited cleanly (rc=0) after posting a completion "
+                    "comment but without calling kanban_complete — routed to "
+                    "review instead of retry (unconfirmed completion)."
+                )
+                event_kind = "unconfirmed_completion"
+                event_payload = {
+                    "pid": pid,
+                    "claimer": row["claim_lock"],
+                    "exit_code": code,
+                    "unconfirmed_completion": True,
+                    "comment_excerpt": unconfirmed_completion[:280],
+                }
+            elif kind == "clean_exit":
                 # Worker subprocess returned 0 but its task is still
                 # ``running`` in the DB — it exited without calling
                 # ``kanban_complete`` / ``kanban_block``. Overwhelmingly the
@@ -9001,7 +9036,11 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                 # Rate-limited requeues are a clean release, not a crash —
                 # record the run outcome as ``rate_limited`` so the board
                 # history doesn't show a phantom crash for a quota wall.
-                _run_outcome = "rate_limited" if rate_limited_exit else "crashed"
+                _run_outcome = (
+                    "rate_limited" if rate_limited_exit
+                    else "unconfirmed_completion" if unconfirmed_completion
+                    else "crashed"
+                )
                 run_id = _end_run(
                     conn, row["id"],
                     outcome=_run_outcome, status=_run_outcome,
@@ -9023,7 +9062,16 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                     "outcome": _run_outcome,
                     "retry_status": retry_status,
                 })
-                if rate_limited_exit:
+                if unconfirmed_completion:
+                    # Not a failure: the result is on the card. Hand off to
+                    # review after the txn (request_review needs its own
+                    # write_txn). Leaves consecutive_failures untouched.
+                    conn.execute(
+                        "UPDATE tasks SET last_failure_error = NULL WHERE id = ?",
+                        (row["id"],),
+                    )
+                    review_candidates.append((row["id"], unconfirmed_completion, run_id))
+                elif rate_limited_exit:
                     # Stamp the failure-error column so ``check_respawn_guard``
                     # recognizes this as a quota blocker and defers the
                     # respawn until the window clears — WITHOUT touching
@@ -9068,6 +9116,25 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     # A per-task ``max_retries`` overrides the violation bound with the same
     # top precedence it has for every other failure kind. Systemic same-error
     # crashes still trip immediately.
+    # Unconfirmed completions: the worker's own comment is the summary.
+    # request_review emits ``review_requested`` (a terminal notifier kind), so
+    # the subscriber is woken to confirm with kanban_complete or send it back.
+    for _tid, _excerpt, _run_id in review_candidates:
+        try:
+            ok = request_review(
+                conn, _tid,
+                summary="[unconfirmed completion — worker exited without kanban_complete] "
+                        + _excerpt[:1500],
+                metadata={"source": "unconfirmed_completion", "run_id": _run_id},
+                force=True,
+            )
+            if not ok:
+                _log.warning(
+                    "kanban: unconfirmed completion for %s could not enter review; left at its source phase",
+                    _tid,
+                )
+        except Exception as _exc:
+            _log.warning("kanban: unconfirmed-completion review handoff failed for %s: %s", _tid, _exc)
     auto_blocked: list[str] = []
     if crash_details:
         # Fingerprint errors to detect systemic failures.

--- a/tests/hermes_cli/test_kanban_unconfirmed_completion.py
+++ b/tests/hermes_cli/test_kanban_unconfirmed_completion.py
@@ -1,0 +1,68 @@
+"""A worker that exits cleanly AFTER posting its result as a comment is not a
+protocol violation: the work is on the card, only ``kanban_complete`` was
+skipped. Retrying burned a whole budget redoing finished work and then
+auto-blocked a done task (Valicen t_a5199403, 2026-08-25). Route to review.
+"""
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME with an empty kanban DB (mirrors test_kanban_db)."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _exited_status(code: int) -> int:
+    return code << 8
+
+
+def _dead_clean_exit_with_comment(conn, monkeypatch, *, comment: bool):
+    import hermes_cli.kanban_db as _kb
+    monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
+    monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
+    host = _kb._claimer_id().split(":", 1)[0]
+    tid = kb.create_task(conn, title="write the report", assignee="ito_it_director")
+    kb.claim_task(conn, tid, claimer=f"{host}:w1")
+    pid = 71001
+    conn.execute("UPDATE tasks SET worker_pid=? WHERE id=?", (pid, tid))
+    conn.commit()
+    if comment:
+        kb.add_comment(conn, tid, author="ito_it_director", body="## RESULTS\nReport written to /tmp/report.md; endpoint confirmed.")
+    _kb._record_worker_exit(pid, _exited_status(0))
+    return tid
+
+
+def test_clean_exit_with_completion_comment_goes_to_review(kanban_home, monkeypatch):
+    with kb.connect() as conn:
+        tid = _dead_clean_exit_with_comment(conn, monkeypatch, comment=True)
+        crashed = kb.detect_crashed_workers(conn)
+        task = kb.get_task(conn, tid)
+        assert task.status == "review", f"expected review, got {task.status}"
+        assert task.consecutive_failures == 0
+        assert not task.last_failure_error
+        kinds = [r["kind"] for r in conn.execute("SELECT kind FROM task_events WHERE task_id=? ORDER BY id", (tid,)).fetchall()]
+        assert "unconfirmed_completion" in kinds
+        assert "review_requested" in kinds
+        assert "protocol_violation" not in kinds
+        outcomes = [r["outcome"] for r in conn.execute("SELECT outcome FROM task_runs WHERE task_id=?", (tid,)).fetchall()]
+        assert "unconfirmed_completion" in outcomes and "crashed" not in outcomes
+
+
+def test_clean_exit_without_comment_is_still_a_protocol_violation(kanban_home, monkeypatch):
+    with kb.connect() as conn:
+        tid = _dead_clean_exit_with_comment(conn, monkeypatch, comment=False)
+        kb.detect_crashed_workers(conn)
+        task = kb.get_task(conn, tid)
+        assert task.status != "review"
+        kinds = [r["kind"] for r in conn.execute("SELECT kind FROM task_events WHERE task_id=? ORDER BY id", (tid,)).fetchall()]
+        assert "protocol_violation" in kinds
+        assert "unconfirmed_completion" not in kinds


### PR DESCRIPTION
## What does this PR do?

A worker that finishes its task, posts the result as a comment on the card, and then exits `rc=0` **without** calling `kanban_complete` is today treated as a protocol violation: the dispatcher retries, the retry redoes finished work, exhausts the iteration budget, and the task ends up auto-blocked with `Iteration budget exhausted` — a **done** task reported as failed (we hit this repeatedly; the card's comments were the ground truth, the failure string was wrong).

This PR makes `detect_crashed_workers` check for a comment by the assignee posted during the run. If one exists, the exit is an `unconfirmed_completion`: the run closes with that outcome, no failure is counted, `last_failure_error` is cleared, and the task is handed to the review phase via `request_review(force=True, summary=<the worker's comment>)`, which emits `review_requested` so the subscriber is woken to confirm (`kanban_complete`) or send it back. Clean exits **without** such a comment are handled exactly as before (protocol violation, bounded retry).

## Related Issue

Fixes # (no existing issue found — searched "protocol violation completion comment review")

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/kanban_db.py` (`detect_crashed_workers`): comment lookup for clean exits; `unconfirmed_completion` event + run outcome; post-txn `request_review` handoff with warnings on refusal.
- `tests/hermes_cli/test_kanban_unconfirmed_completion.py`: with comment → `review`, no failure counted, events/outcomes as expected; without comment → protocol violation unchanged.

## How to Test

1. `pytest tests/hermes_cli/test_kanban_unconfirmed_completion.py tests/hermes_cli/test_kanban_db.py -q`
2. Live: let a worker post a comment and exit without a terminal call → the task lands in `review` with the comment as summary and the origin is notified.

## Checklist

### Code
- [x] Contributing Guide read · [x] Conventional Commits · [x] Searched existing PRs · [x] Only related changes
- [x] Relevant suites pass (kanban db/review/lifecycle/notifier: 99 tests); full suite in our env: 1856 passed
- [x] Tests added
- [x] Tested on: Debian 13, Python 3.11

### Documentation & Housekeeping
- [x] Docstring/comments updated — N/A otherwise
- [x] Cross-platform: N/A (SQLite + Python only)
