### PR TITLE
fix(mcp): treat non-positive schema-cache ttl_ms as no hint, not instant expiry

### DIFF
--- a/tools/mcp_schema_cache.py
+++ b/tools/mcp_schema_cache.py
@@ -83,7 +83,14 @@ def get_cached_entry(server_name: str, fingerprint: str) -> Optional[dict]:
         return None
     ttl_ms = entry.get("ttl_ms")
     written_at = entry.get("written_at")
-    if isinstance(ttl_ms, (int, float)) and isinstance(written_at, (int, float)):
+    # Local patch (2026-08-26, CHG-23): historical entries carry ttl_ms=0
+    # (mcp 2.x SDK default, not a real server hint), which made every lookup
+    # a MISS forever. Treat non-positive TTLs as "no hint / never expires",
+    # matching the documented pre-2026 behavior.
+    if (
+        isinstance(ttl_ms, (int, float)) and ttl_ms > 0
+        and isinstance(written_at, (int, float))
+    ):
         if (time.time() - written_at) * 1000.0 >= float(ttl_ms):
             return None
     return entry


### PR DESCRIPTION
## What does this PR do?

`tools/mcp_schema_cache.py::_entry_expired` treats any numeric `ttl_ms` as a real expiry, but the mcp 2.x SDK writes `ttl_ms=0` when the server provides no SEP-2549 cache hint. `(now - written_at) * 1000 >= 0` is always true, so every cache entry expires the moment it is written: the schema cache never hits and "lazy" tool loading re-fetches every schema on every lookup (visible as MISS on every call, plus the corresponding latency and token cost of re-describing tools).

This PR treats non-positive TTLs as "no hint / never expires", which matches the documented pre-hint behaviour. Positive TTLs behave exactly as before.

## Related Issue

Fixes # (no existing issue found — searched "schema cache ttl_ms expired")

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/mcp_schema_cache.py`: `_entry_expired` only applies a TTL when `ttl_ms > 0`.

## How to Test

1. Connect any MCP server whose tool list response carries no cache hint (most do) and call two lazy-loaded tools in a row: the second lookup is a cache HIT instead of a re-fetch.
2. Existing tests: `pytest tests/tools -q -k schema_cache`.

## Checklist

### Code
- [x] Contributing Guide read · [x] Conventional Commits · [x] Searched existing PRs · [x] Only related changes
- [x] Relevant suites pass; full suite in our env: 1856 passed
- [ ] Tests added — small enough that I'd welcome a pointer to the right fixture if a regression test is wanted
- [x] Tested on: Debian 13, Python 3.11 (running in production since 2026-08-26)

### Documentation & Housekeeping
- [x] Comment explains the SDK default — N/A otherwise
- [x] Cross-platform: N/A
