### PR TITLE
fix(bot-mode): compressed Bot Chats keep their protocol and message_agent (salvage #97395)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -929,6 +929,7 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
         try:
             from tools.bot_mode_probe import (
                 BOT_CHAT_TITLE,
+                is_bot_chat_session,
                 stored_bot_chat_prompt_needs_upgrade,
                 stored_prompt_capability_stale,
             )
@@ -948,14 +949,10 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
                 # the messaging protocol. Title-gated so ordinary unstamped
                 # sessions (i.e. all of them) never take this path; the
                 # rebuilt prompt carries the stamp, so it cannot re-fire.
-                _t = str(getattr(agent, "_session_title_hint", "") or "").strip()
-                if not _t and agent._session_db and agent.session_id:
-                    try:
-                        _t = str(agent._session_db.get_session_title(agent.session_id) or "").strip()
-                    except Exception:
-                        _t = ""
-                if _t == BOT_CHAT_TITLE:
-                    _bot_stale = stored_bot_chat_prompt_needs_upgrade(stored_prompt, _home_for_epoch)
+                if is_bot_chat_session(agent):
+                    _bot_stale = stored_bot_chat_prompt_needs_upgrade(
+                        stored_prompt, _home_for_epoch
+                    )
         except Exception:
             _bot_stale = False
         if _bot_stale:
@@ -965,7 +962,7 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
                 "prefix-cache break).",
                 agent.session_id,
             )
-            agent._session_title_hint = "Bot Chat"
+            agent._session_title_hint = BOT_CHAT_TITLE
             # The skills index inside the prompt comes from a two-layer cache
             # (in-process LRU + disk snapshot) that doesn't watch the skills
             # dir; a capability refresh must rebuild THROUGH it or a freshly

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -632,16 +632,11 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     if getattr(agent, "_bot_mode_protocol", True):
         try:
             from tools.bot_mode_probe import (
-                BOT_CHAT_TITLE,
                 epoch_line,
                 get_bot_mode_protocol_section,
+                is_bot_chat_session,
             )
-            _title = str(getattr(agent, "_session_title_hint", "") or "").strip()
-            if not _title:
-                _sdb = getattr(agent, "_session_db", None)
-                _sid = getattr(agent, "session_id", None)
-                _title = str((_sdb.get_session_title(_sid) if (_sdb and _sid) else None) or "").strip()
-            if _title == BOT_CHAT_TITLE:
+            if is_bot_chat_session(agent):
                 _bot_section = get_bot_mode_protocol_section(_agent_home(agent))
                 if _bot_section:
                     post_workspace_parts.append(_bot_section)

--- a/tests/tools/test_bot_mode_dm.py
+++ b/tests/tools/test_bot_mode_dm.py
@@ -52,17 +52,28 @@ def _managed_home(tmp_path, *, teammates=("researcher",), peers=()) -> Path:
 
 
 class _FakeDB:
-    def __init__(self, home: Path, title: str):
+    def __init__(self, home: Path, title: str, root_title: str | None = None):
         self.db_path = str(home / "state.db")
         self._title = title
+        self._root_title = root_title
 
-    def get_session_title(self, _sid):
+    def get_session_title(self, sid):
+        if sid == "root":
+            return self._root_title
         return self._title
+
+    def get_compression_lineage(self, sid):
+        return ["root", sid] if self._root_title is not None else [sid]
 
 
 class _FakeAgent:
-    def __init__(self, home: Path, title: str = "Bot Chat"):
-        self._session_db = _FakeDB(home, title)
+    def __init__(
+        self,
+        home: Path,
+        title: str = "Bot Chat",
+        root_title: str | None = None,
+    ):
+        self._session_db = _FakeDB(home, title, root_title)
         self.session_id = "sess-1"
         self._session_title_hint = None
         self._bot_mode_protocol = True
@@ -84,6 +95,21 @@ def test_injects_only_into_bot_chat_on_managed_install(tmp_path):
     # idempotent: second call adds nothing (byte-stable tool list per turn)
     assert bot_mode_dm.ensure_message_agent_tool(agent) is True
     assert len(agent.tools) == 1
+
+
+def test_injects_into_compressed_tip_of_canonical_bot_chat(tmp_path):
+    """A renamed live tip keeps the canonical root's Bot Mode capabilities."""
+    home = _managed_home(tmp_path)
+    agent = _FakeAgent(
+        home,
+        title="Friendly greeting",
+        root_title="Bot Chat",
+    )
+
+    assert bot_mode_dm.ensure_message_agent_tool(agent) is True
+    assert [tool["function"]["name"] for tool in agent.tools] == [
+        bot_mode_dm.MESSAGE_AGENT_TOOL_NAME
+    ]
 
 
 @pytest.mark.parametrize(

--- a/tests/tools/test_bot_mode_probe.py
+++ b/tests/tools/test_bot_mode_probe.py
@@ -49,7 +49,50 @@ class _Agent:
         self._session_title_hint = hint
 
 
-def test_bot_chat_identity_follows_compression_lineage_root(session_db):
+def test_bot_chat_identity_healthy_title_carried_to_tip(session_db):
+    """Mainline: rotation carries 'Bot Chat' onto the tip via the
+    compression-ancestor title transfer (root ends up NULL)."""
+    session_db.create_session("root", source="webui")
+    session_db.set_session_title("root", "Bot Chat")
+    session_db.end_session("root", "compression")
+    session_db.create_session("tip", source="webui", parent_session_id="root")
+    # Same write the rotation path performs; UNIQUE(title) conflict is
+    # resolved by transferring the title off the hidden ancestor.
+    session_db.set_session_title("tip", "Bot Chat")
+
+    assert session_db.get_session_title("root") is None
+    assert bot_mode_probe.is_bot_chat_session(_Agent(session_db, "tip")) is True
+
+
+def test_bot_chat_identity_through_real_compression_publish(session_db):
+    """Full rotation contract: publish_compression_child + the title carry
+    exactly as agent/conversation_compression.py performs them."""
+    session_db.create_session("root", source="webui")
+    session_db.set_session_title("root", "Bot Chat")
+    old_title = session_db.get_session_title("root")
+    session_db.publish_compression_child(
+        parent_session_id="root",
+        child_session_id="tip",
+        source="webui",
+        messages=[{"role": "user", "content": "compacted handoff"}],
+        require_compression_lease=False,
+    )
+    # The rotation path's best-effort title carry.
+    session_db.set_session_title("tip", old_title)
+
+    assert bot_mode_probe.is_bot_chat_session(_Agent(session_db, "tip")) is True
+    # And the degraded shape — the carry silently failing — must ALSO gate
+    # True: strip the tip's title back off and re-strand it on the ancestor.
+    session_db.set_session_title("tip", "")
+    session_db.set_session_title("root", "Bot Chat")
+    session_db.set_auto_title("tip", "Friendly greeting", source="llm")
+    assert bot_mode_probe.is_bot_chat_session(_Agent(session_db, "tip")) is True
+
+
+def test_bot_chat_identity_recovers_title_stranded_on_ancestor(session_db):
+    """Degraded: title propagation failed on rotation (or predates the
+    title-carry contract) — canonical title stays on the hidden ancestor
+    while the live tip carries a generated title."""
     session_db.create_session("root", source="webui")
     session_db.set_session_title("root", "Bot Chat")
     session_db.end_session("root", "compression")
@@ -72,6 +115,32 @@ def test_bot_chat_identity_does_not_follow_delegate_parent(session_db):
 
     assert (
         bot_mode_probe.is_bot_chat_session(_Agent(session_db, "delegate"))
+        is False
+    )
+
+
+def test_titled_row_beats_stale_bot_chat_hint(session_db):
+    """A live row already carrying a different title is authoritative —
+    a leftover 'Bot Chat' hint must not grant capabilities."""
+    session_db.create_session("plain", source="webui")
+    session_db.set_session_title("plain", "My research chat")
+
+    agent = _Agent(session_db, "plain", hint="Bot Chat")
+    assert bot_mode_probe.is_bot_chat_session(agent) is False
+
+
+def test_untitled_row_falls_back_to_hint(session_db):
+    """Fresh Bot Chat whose title write hasn't landed yet: hint decides."""
+    session_db.create_session("fresh", source="webui")
+
+    assert (
+        bot_mode_probe.is_bot_chat_session(
+            _Agent(session_db, "fresh", hint="Bot Chat")
+        )
+        is True
+    )
+    assert (
+        bot_mode_probe.is_bot_chat_session(_Agent(session_db, "fresh"))
         is False
     )
 

--- a/tests/tools/test_bot_mode_probe.py
+++ b/tests/tools/test_bot_mode_probe.py
@@ -4,6 +4,7 @@ import textwrap
 
 import pytest
 
+from hermes_state import SessionDB
 from tools import bot_mode_probe
 
 
@@ -12,6 +13,13 @@ def _fresh_cache():
     bot_mode_probe._reset_cache_for_tests()
     yield
     bot_mode_probe._reset_cache_for_tests()
+
+
+@pytest.fixture
+def session_db(tmp_path):
+    db = SessionDB(tmp_path / "state.db")
+    yield db
+    db.close()
 
 
 def _make_bot_profile(root, name, *, managed=True, soul=None):
@@ -32,6 +40,40 @@ def _make_bot_profile(root, name, *, managed=True, soul=None):
     if soul is not None:
         (d / "SOUL.md").write_text(soul, encoding="utf-8")
     return d
+
+
+class _Agent:
+    def __init__(self, db, session_id, hint=None):
+        self._session_db = db
+        self.session_id = session_id
+        self._session_title_hint = hint
+
+
+def test_bot_chat_identity_follows_compression_lineage_root(session_db):
+    session_db.create_session("root", source="webui")
+    session_db.set_session_title("root", "Bot Chat")
+    session_db.end_session("root", "compression")
+    session_db.create_session("tip", source="webui", parent_session_id="root")
+    session_db.set_session_title("tip", "Friendly greeting")
+
+    assert bot_mode_probe.is_bot_chat_session(_Agent(session_db, "tip")) is True
+
+
+def test_bot_chat_identity_does_not_follow_delegate_parent(session_db):
+    session_db.create_session("root", source="webui")
+    session_db.set_session_title("root", "Bot Chat")
+    session_db.create_session(
+        "delegate",
+        source="delegate",
+        parent_session_id="root",
+        model_config={"_delegate_from": "root"},
+    )
+    session_db.set_session_title("delegate", "Research task")
+
+    assert (
+        bot_mode_probe.is_bot_chat_session(_Agent(session_db, "delegate"))
+        is False
+    )
 
 
 def test_silent_when_no_profile_is_bot_managed(tmp_path):

--- a/tools/bot_mode_dm.py
+++ b/tools/bot_mode_dm.py
@@ -131,10 +131,11 @@ def ensure_message_agent_tool(agent: Any) -> bool:
 
     Called once per turn from the conversation loop. Idempotent and
     deterministic for the life of a session: the gate (canonical Bot Chat
-    compression-root title on a Bot-Mode-managed install) is stable from the
-    session's first turn, so the tool list is byte-identical across turns —
-    prompt-cache safe. Every non-Bot-Chat session fails the gate on every turn
-    and never sees the schema. Never raises.
+    title anywhere in the session's compression lineage, on a
+    Bot-Mode-managed install) is stable from the session's first turn, so
+    the tool list is byte-identical across turns — prompt-cache safe. Every
+    non-Bot-Chat session fails the gate on every turn and never sees the
+    schema. Never raises.
     """
     try:
         if not getattr(agent, "_bot_mode_protocol", True):

--- a/tools/bot_mode_dm.py
+++ b/tools/bot_mode_dm.py
@@ -131,10 +131,10 @@ def ensure_message_agent_tool(agent: Any) -> bool:
 
     Called once per turn from the conversation loop. Idempotent and
     deterministic for the life of a session: the gate (canonical Bot Chat
-    title on a Bot-Mode-managed install) is stable from the session's first
-    turn, so the tool list is byte-identical across turns — prompt-cache
-    safe. Every non-Bot-Chat session fails the gate on every turn and never
-    sees the schema. Never raises.
+    compression-root title on a Bot-Mode-managed install) is stable from the
+    session's first turn, so the tool list is byte-identical across turns —
+    prompt-cache safe. Every non-Bot-Chat session fails the gate on every turn
+    and never sees the schema. Never raises.
     """
     try:
         if not getattr(agent, "_bot_mode_protocol", True):
@@ -147,9 +147,9 @@ def ensure_message_agent_tool(agent: Any) -> bool:
                     and tool.get("function", {}).get("name") == MESSAGE_AGENT_TOOL_NAME
                 ):
                     return True
-        from tools.bot_mode_probe import BOT_CHAT_TITLE, is_bot_mode_managed
+        from tools.bot_mode_probe import is_bot_chat_session, is_bot_mode_managed
 
-        if _session_title(agent) != BOT_CHAT_TITLE:
+        if not is_bot_chat_session(agent):
             return False
         # Managed-install check, NOT section non-emptiness: a profile whose
         # SOUL.md carries the legacy plugin-appended protocol text gets an
@@ -253,10 +253,9 @@ def message_agent_tool(
     # ── defense-in-depth gate: only a canonical Bot Chat may deliver ──
     home = _agent_home(agent)
     try:
-        from tools.bot_mode_probe import BOT_CHAT_TITLE, is_bot_mode_managed
+        from tools.bot_mode_probe import is_bot_chat_session, is_bot_mode_managed
 
-        title = _session_title(agent)
-        if title != BOT_CHAT_TITLE:
+        if not is_bot_chat_session(agent):
             return _err(
                 "message_agent is only available in a Bot Mode 'Bot Chat' session. "
                 "This session is not one; do not retry."
@@ -745,20 +744,6 @@ def _agent_home(agent: Any) -> str:
     except Exception:
         pass
     return os.getenv("HERMES_HOME") or os.path.expanduser("~/.hermes")
-
-
-def _session_title(agent: Any) -> str:
-    title = str(getattr(agent, "_session_title_hint", "") or "").strip()
-    if title:
-        return title
-    try:
-        sdb = getattr(agent, "_session_db", None)
-        sid = getattr(agent, "session_id", None)
-        if sdb and sid:
-            return str(sdb.get_session_title(sid) or "").strip()
-    except Exception:
-        pass
-    return ""
 
 
 if __name__ == "__main__":  # pragma: no cover - exercised as a background process

--- a/tools/bot_mode_probe.py
+++ b/tools/bot_mode_probe.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 import os
 import threading
 from pathlib import Path
+from typing import Any
 
 _PROTOCOL_HEADING = "## Messaging other agents"
 
@@ -42,6 +43,41 @@ BOT_CHAT_TITLE = "Bot Chat"
 
 _lock = threading.Lock()
 _cached: dict[str, str] = {}
+
+
+def bot_chat_session_title(agent: Any) -> str:
+    """Return the title that owns *agent*'s Bot Mode identity.
+
+    Compression rotates a conversation onto a new session row whose display
+    title can differ from the canonical root's ``Bot Chat`` title. Resolve
+    only the compression lineage back to its root so the protocol and
+    ``message_agent`` survive compaction without leaking into explicit
+    branches, delegate agents, or tool sessions. The title hint remains the
+    fallback for a newly created Bot Chat whose DB row does not exist yet.
+    Never raises.
+    """
+    hint = str(getattr(agent, "_session_title_hint", "") or "").strip()
+    try:
+        session_db = getattr(agent, "_session_db", None)
+        session_id = getattr(agent, "session_id", None)
+        if session_db and session_id:
+            title_session_id = session_id
+            get_lineage = getattr(session_db, "get_compression_lineage", None)
+            if callable(get_lineage):
+                lineage = get_lineage(session_id)
+                if lineage:
+                    title_session_id = lineage[0]
+            title = session_db.get_session_title(title_session_id)
+            if title is not None:
+                return str(title).strip()
+    except Exception:
+        pass
+    return hint
+
+
+def is_bot_chat_session(agent: Any) -> bool:
+    """Return whether *agent* belongs to the canonical Bot Chat lineage."""
+    return bot_chat_session_title(agent) == BOT_CHAT_TITLE
 
 
 def _hermes_root(home: Path) -> Path:

--- a/tools/bot_mode_probe.py
+++ b/tools/bot_mode_probe.py
@@ -45,39 +45,58 @@ _lock = threading.Lock()
 _cached: dict[str, str] = {}
 
 
-def bot_chat_session_title(agent: Any) -> str:
-    """Return the title that owns *agent*'s Bot Mode identity.
+def is_bot_chat_session(agent: Any) -> bool:
+    """Return whether *agent* belongs to the canonical Bot Chat lineage.
 
-    Compression rotates a conversation onto a new session row whose display
-    title can differ from the canonical root's ``Bot Chat`` title. Resolve
-    only the compression lineage back to its root so the protocol and
-    ``message_agent`` survive compaction without leaking into explicit
-    branches, delegate agents, or tool sessions. The title hint remains the
-    fallback for a newly created Bot Chat whose DB row does not exist yet.
-    Never raises.
+    The canonical title normally travels WITH the live tip: compression
+    carries the parent's title onto the continuation, and the UNIQUE(title)
+    conflict is resolved by transferring the title off the hidden ancestor
+    (``_set_session_title``'s compression-ancestor transfer). So in the
+    healthy case the tip itself is titled ``Bot Chat`` and this returns True
+    on the first lineage entry checked.
+
+    The degraded cases are why the WHOLE compression lineage is scanned
+    rather than just the live session (or just the root): the best-effort
+    title propagation on rotation can fail (it is wrapped in a swallow-all
+    ``except``), and pre-title-carry rotations renamed the tip — leaving the
+    canonical title stranded on a hidden ancestor while the live tip shows a
+    generated title. A Bot Chat in that state silently lost its protocol and
+    ``message_agent``. Scanning the lineage recovers it without leaking
+    capabilities into explicit branches, delegate agents, or tool sessions —
+    ``get_compression_lineage`` already excludes those by contract.
+
+    The title hint remains the fallback for a newly created Bot Chat whose
+    DB row does not exist yet. Never raises.
     """
-    hint = str(getattr(agent, "_session_title_hint", "") or "").strip()
     try:
         session_db = getattr(agent, "_session_db", None)
         session_id = getattr(agent, "session_id", None)
         if session_db and session_id:
-            title_session_id = session_id
+            lineage: list[str] = []
             get_lineage = getattr(session_db, "get_compression_lineage", None)
             if callable(get_lineage):
-                lineage = get_lineage(session_id)
-                if lineage:
-                    title_session_id = lineage[0]
-            title = session_db.get_session_title(title_session_id)
-            if title is not None:
-                return str(title).strip()
+                raw_lineage: Any = get_lineage(session_id)
+                if raw_lineage:
+                    lineage = [str(sid) for sid in raw_lineage]
+            if session_id not in lineage:
+                lineage.append(session_id)
+            for lineage_session_id in lineage:
+                title = session_db.get_session_title(lineage_session_id)
+                if str(title or "").strip() == BOT_CHAT_TITLE:
+                    return True
+            # A DB row exists but no lineage member holds the canonical
+            # title — trust the hint only when the live row is untitled
+            # (fresh session whose title write hasn't landed yet). A row
+            # that already carries a DIFFERENT title is authoritative.
+            live_title = str(
+                session_db.get_session_title(session_id) or ""
+            ).strip()
+            if live_title:
+                return False
     except Exception:
         pass
-    return hint
-
-
-def is_bot_chat_session(agent: Any) -> bool:
-    """Return whether *agent* belongs to the canonical Bot Chat lineage."""
-    return bot_chat_session_title(agent) == BOT_CHAT_TITLE
+    hint = str(getattr(agent, "_session_title_hint", "") or "").strip()
+    return hint == BOT_CHAT_TITLE
 
 
 def _hermes_root(home: Path) -> Path:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -6419,12 +6419,9 @@ def _sync_bot_capabilities(sid: str, session: dict) -> None:
     if agent is None:
         return
     try:
-        title = str(getattr(agent, "_session_title_hint", "") or "").strip()
-        if not title:
-            db = getattr(agent, "_session_db", None)
-            key = session.get("session_key") or ""
-            title = str((db.get_session_title(key) if (db and key) else None) or "").strip()
-        if title != "Bot Chat":
+        from tools.bot_mode_probe import is_bot_chat_session
+
+        if not is_bot_chat_session(agent):
             return
         from tools.bot_mode_probe import capability_fingerprint
 


### PR DESCRIPTION
## Summary

A compressed Bot Chat no longer loses its Bot Mode protocol and `message_agent` — the capability gate now recognizes the canonical `Bot Chat` title anywhere in the session's compression lineage instead of only on the live row's title. Salvages #97395 by @helix4u with an inverted-premise correction on top.

Root cause of the field report (support diagnostic `8f46d199`): compression rotates onto a new session row, and when the best-effort title carry fails (it is wrapped in a swallow-all `except`) or the rows predate the title-carry contract, the canonical title strands on a hidden ancestor while the live tip shows a generated title. Every title-gated Bot Mode site then saw a non-Bot-Chat session and silently dropped the protocol and `message_agent`.

**Correction over the original PR:** #97395 gated on the lineage ROOT's title. But the healthy rotation contract transfers `Bot Chat` off the hidden ancestor ONTO the tip (`_set_session_title`'s compression-ancestor transfer resolves the UNIQUE(title) conflict), so after a normal compaction the root's title is NULL — a root-only check would have dropped capabilities on every healthy compressed Bot Chat. The gate now scans every lineage member, covering both the healthy (tip-titled) and degraded (ancestor-stranded) shapes; delegates/branches/tool sessions remain excluded by the `get_compression_lineage` contract.

## Changes

- `tools/bot_mode_probe.py`: new `is_bot_chat_session()` — whole-lineage title scan; a live row that already carries a DIFFERENT title beats a stale `Bot Chat` hint; untitled fresh rows still fall back to the hint.
- `tools/bot_mode_dm.py`, `agent/system_prompt.py`, `agent/conversation_loop.py`, `tui_gateway/server.py`: all five title-gate sites (prompt injection, stale-prompt refresh, TUI capability sync, both `message_agent` gates) route through the one helper; duplicate `_session_title()` deleted.
- Tests: healthy title-carried-to-tip, real `publish_compression_child` + title-carry regression, stranded-ancestor recovery, delegate exclusion, stale-hint rejection, untitled-hint fallback.

## Validation

| Check | Result |
|---|---|
| `tests/tools/test_bot_mode_probe.py` + `test_bot_mode_dm.py` + bot/compression subset | 130 passed, 2 skipped |
| Sabotage: PR's root-only logic | fails `healthy_title_carried_to_tip` (proves the inversion) |
| Sabotage: main's tip-only logic | fails `stranded_on_ancestor` + `stale_hint` (proves the fix) |
| ruff + Windows footguns | clean |

Cache-safe: lineage titles are stable for a session's life; the gate is deterministic per turn, tool list stays byte-identical.

Credit: @helix4u for the diagnosis, the helper centralization, and the lineage approach — cherry-picked with authorship preserved; the lineage-scan correction is a follow-up commit on top.

## Infographic

![Bot Chat survives compaction](https://v3b.fal.media/files/b/0aa830f5/0MUEJRBwK8TFxxFu2tyVr_r1AELFC4.png)
