### PR TITLE
fix(metadata): normalize version separators in catalog substring match

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -2227,7 +2227,7 @@ def _stale_pre_catalog_cache_entry(model: str, cached: int) -> bool:
     matches = [
         (key, value)
         for key, value in DEFAULT_CONTEXT_LENGTHS.items()
-        if key in model_lower
+        if _catalog_key_matches(key, model_lower)
     ]
     if not matches:
         return False
@@ -2439,6 +2439,18 @@ def _normalize_model_version(model: str) -> str:
     Normalize both to dashes for comparison.
     """
     return model.replace(".", "-")
+
+
+def _catalog_key_matches(catalog_key: str, model_lower: str) -> bool:
+    """Check if a *catalog_key* is a substring of *model_lower*, normalizing
+    version separators first.
+
+    Catalog keys may use dots (e.g. ``"glm-5.3"``) while provider slugs use
+    hyphens (e.g. ``"z-ai-glm-5-3"``).  Without normalization the substring
+    check ``"glm-5.3" in "z-ai-glm-5-3"`` is ``False`` and the model silently
+    falls back to a shorter catch-all entry (e.g. ``"glm"`` → 202 752).
+    """
+    return _normalize_model_version(catalog_key) in _normalize_model_version(model_lower)
 
 
 def _query_anthropic_context_length(model: str, base_url: str, api_key: str) -> Optional[int]:
@@ -3263,7 +3275,7 @@ def get_model_context_length(
                 key=lambda x: len(x[0]),
                 reverse=True,
             ):
-                if default_model in model_lower:
+                if _catalog_key_matches(default_model, model_lower):
                     logger.info(
                         "Using hardcoded context length %s for model %r "
                         "(custom endpoint, catalog match on %r)",
@@ -3443,7 +3455,7 @@ def get_model_context_length(
     for default_model, length in sorted(
         DEFAULT_CONTEXT_LENGTHS.items(), key=lambda x: len(x[0]), reverse=True
     ):
-        if default_model in model_lower:
+        if _catalog_key_matches(default_model, model_lower):
             return length
 
     # 9. Default fallback — warn (deduped per model+endpoint) so


### PR DESCRIPTION
## Summary

Fixes bug #1 from issue #97398: the `DEFAULT_CONTEXT_LENGTHS` catalog substring match fails when a catalog key uses a dot version separator (e.g. `"glm-5.3"`) but the runtime model slug uses hyphens (e.g. `"z-ai-glm-5-3"`).

The plain substring check `"glm-5.3" in "z-ai-glm-5-3"` is `False`, so the model silently falls back to the shorter catch-all entry `"glm"` (202,752 tokens) instead of the correct 1,048,576.

### Fix

Added a `_catalog_key_matches()` helper that normalizes version separators on both sides via the existing `_normalize_model_version()` function (which replaces `.` with `-`) before performing the substring check. Applied at all three `DEFAULT_CONTEXT_LENGTHS` lookup sites:

1. `_stale_pre_catalog_cache_entry()` — stale-cache detection
2. `get_model_context_length()` step 3b — custom endpoint catalog fallback
3. `get_model_context_length()` step 8 — generic hardcoded defaults

This also benefits any other dotted catalog key vs hyphenated slug mismatch (not just GLM).

### Verification

```python
>>> _catalog_key_matches("glm-5.3", "z-ai-glm-5-3")
True        # was False before fix
>>> _catalog_key_matches("glm-5.2", "z-ai-glm-5-2")
True        # existing behavior preserved
>>> _catalog_key_matches("claude-opus-4.8", "claude-opus-4-8")
True        # existing behavior preserved
>>> _catalog_key_matches("claude-opus-4-8", "glm-5-3")
False       # non-matches still correct
```

### Note

This addresses bug #1 (substring catalog match) from #97398. Bug #2 (custom_providers context_length override not threaded to the compressor) is tracked separately in PR #83324.

Closes #97398 (partially — bug #1 only).