### PR TITLE
fix(dashboard-auth): unparseable foreign tokens are 401s, not 503s

### DIFF
--- a/plugins/dashboard_auth/nous/__init__.py
+++ b/plugins/dashboard_auth/nous/__init__.py
@@ -436,6 +436,13 @@ class NousDashboardAuthProvider(DashboardAuthProvider):
             signing_key = self._get_jwks_client().get_signing_key_from_jwt(
                 access_token
             )
+        except jwt.InvalidTokenError as exc:
+            # A token PyJWT cannot even parse (e.g. an opaque session blob
+            # minted by another stacked provider) fails locally, before any
+            # JWKS fetch — that is "not our token", not an unreachable IDP.
+            # The verify_session contract maps it to None (→ 401/next
+            # provider), never ProviderError (→ 503).
+            raise InvalidCodeError(f"token not parseable as a JWT: {exc}") from exc
         except jwt.PyJWKClientError as exc:
             raise ProviderError(f"JWKS lookup failed: {exc}") from exc
         except Exception as exc:  # pragma: no cover - defensive

--- a/plugins/dashboard_auth/self_hosted/__init__.py
+++ b/plugins/dashboard_auth/self_hosted/__init__.py
@@ -617,6 +617,13 @@ class SelfHostedOIDCProvider(DashboardAuthProvider):
             signing_key = self._get_jwks_client().get_signing_key_from_jwt(
                 id_token
             )
+        except jwt.InvalidTokenError as exc:
+            # A token PyJWT cannot even parse (e.g. an opaque session blob
+            # minted by another stacked provider) fails locally, before any
+            # JWKS fetch — that is "not our token", not an unreachable IDP.
+            # The verify_session contract maps it to None (→ 401/next
+            # provider), never ProviderError (→ 503).
+            raise InvalidCodeError(f"token not parseable as a JWT: {exc}") from exc
         except jwt.PyJWKClientError as exc:
             raise ProviderError(f"JWKS lookup failed: {exc}") from exc
         except Exception as exc:  # pragma: no cover - defensive

--- a/tests/plugins/dashboard_auth/test_nous_provider.py
+++ b/tests/plugins/dashboard_auth/test_nous_provider.py
@@ -599,6 +599,22 @@ class TestVerifySession:
         with pytest.raises(ProviderError, match="JWKS"):
             provider.verify_session(access_token=token)
 
+    def test_unparseable_foreign_token_returns_none_not_503(
+        self, provider, rsa_keypair
+    ):
+        """#97361 — an opaque token minted by another stacked provider (e.g.
+        the basic provider's HMAC blob left in the cookie jar) fails PyJWT's
+        header parse locally, before any JWKS fetch. The provider contract
+        says "not our token" → None (middleware: next provider / 401), not
+        ProviderError (middleware: 503 "IDP unreachable")."""
+        bad_client = MagicMock()
+        bad_client.get_signing_key_from_jwt.side_effect = jwt.DecodeError(
+            "Not enough segments"
+        )
+        provider._jwks_client = bad_client
+        foreign_cookie_value = "opaque-hmac-blob"
+        assert provider.verify_session(access_token=foreign_cookie_value) is None
+
 
 # ---------------------------------------------------------------------------
 # refresh_session + revoke_session

--- a/tests/plugins/dashboard_auth/test_self_hosted_provider.py
+++ b/tests/plugins/dashboard_auth/test_self_hosted_provider.py
@@ -571,6 +571,22 @@ class TestVerifySession:
         with pytest.raises(ProviderError, match="JWKS"):
             provider.verify_session(access_token=token)
 
+    def test_unparseable_foreign_token_returns_none_not_503(
+        self, provider, rsa_keypair
+    ):
+        """#97361 — an opaque token minted by another stacked provider (e.g.
+        the basic provider's HMAC blob left in the cookie jar) fails PyJWT's
+        header parse locally, before any JWKS fetch. The provider contract
+        says "not our token" → None (middleware: next provider / 401), not
+        ProviderError (middleware: 503 "IDP unreachable")."""
+        bad_client = MagicMock()
+        bad_client.get_signing_key_from_jwt.side_effect = jwt.DecodeError(
+            "Not enough segments"
+        )
+        provider._jwks_client = bad_client
+        foreign_cookie_value = "opaque-hmac-blob"
+        assert provider.verify_session(access_token=foreign_cookie_value) is None
+
     def test_jwks_client_sends_explicit_http_headers(self):
         provider = oidc_plugin.SelfHostedOIDCProvider(
             issuer=_ISSUER, client_id=_CLIENT_ID


### PR DESCRIPTION
## What does this PR do?

Fixes a 401/503 misclassification in both bundled JWT dashboard-auth providers (`nous`, `self_hosted`). Every exception out of `get_signing_key_from_jwt` — including a local `DecodeError` raised **before any network call** — was mapped to `ProviderError`, which the gate translates to HTTP 503 "provider unreachable". So a session cookie minted by another stacked provider (or left over after an operator changed the auth configuration) made every request 503: the login page itself 503'd before rendering, Hermes Desktop read the 503 as "gateway unavailable" and retried forever with no re-auth path, and the only escape was clearing the app's cookie store.

The `DashboardAuthProvider` contract (`hermes_cli/dashboard_auth/base.py`) is explicit: `verify_session` returns `None` for a token the provider does not recognise; `ProviderError` (→503) is reserved for an IDP that genuinely could not be fetched. PyJWT already distinguishes these — an unparseable token raises `InvalidTokenError`/`DecodeError` locally; a JWKS fetch failure raises `PyJWKClientConnectionError` ⊂ `PyJWKClientError`. This PR adds `jwt.InvalidTokenError` → `InvalidCodeError` ahead of the existing `PyJWKClientError` branch in both providers, so `verify_session` returns `None` and the middleware lands on a clean 401 (or tries the next stacked provider). A genuine JWKS outage still raises `ProviderError` and still 503s — unchanged.

## Related Issue

Fixes #97361

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/dashboard_auth/nous/__init__.py` — `_verify_jwt`: catch `jwt.InvalidTokenError` (superset of `DecodeError`) before the `PyJWKClientError` branch and raise `InvalidCodeError` instead of `ProviderError`; the existing `verify_session` consumer already maps `InvalidCodeError` → `None`.
- `plugins/dashboard_auth/self_hosted/__init__.py` — `_verify_id_token`: identical mirror of the same misclassification.
- `tests/plugins/dashboard_auth/test_nous_provider.py` — regression: a `DecodeError("Not enough segments")` out of the JWKS client makes `verify_session` return `None`, not raise.
- `tests/plugins/dashboard_auth/test_self_hosted_provider.py` — same regression for the self_hosted provider.

## How to Test

1. `pytest tests/plugins/dashboard_auth/ tests/hermes_cli/test_dashboard_auth_401_reauth.py -q` → 125 passed (including the two new regressions).
2. Negative control: with the two provider hunks reverted (tests kept), both new tests fail with `ProviderError: JWKS lookup failed: DecodeError('Not enough segments')` — proving they pin the classification, not just the happy path.
3. Scenario from the issue: configure `basic_auth`, sign in, switch the deployment to the `nous` provider without clearing cookies — previously every request 503'd; now the foreign opaque cookie verifies to `None` → next provider / clean 401 → browser returns to `/login`.

Observed result: new tests pass on the patched tree, fail on the pre-fix tree; the pre-existing `PyJWKClientError → ProviderError` tests still pass (real IDP outages still surface as 503).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass *(targeted suites: tests/plugins/dashboard_auth/ + tests/hermes_cli/test_dashboard_auth_401_reauth.py, 125 passed)*
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64), Python 3.11

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A *(inline comments at both changed branches cite the contract and #97361)*
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A *(pure exception-classification change, no platform surface)*
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
