### PR TITLE
fix(agent): add escalation policy for sanitiser healing loops

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3822,14 +3822,44 @@ def repair_empty_non_final_messages(
             repaired.append(msg)
 
     if healed:
-        _ra().logger.warning(
-            "Pre-call sanitizer: healed %d empty non-final message(s) by "
-            "substituting placeholder content — an empty-content turn was in "
-            "the transcript and would 400 the request ('messages must have "
-            "non-empty content' / INVALID_REQUEST_BODY). Self-recovering the "
-            "poisoned transcript in memory; no restart needed.",
-            healed,
-        )
+        # Per-session sanitiser repair counter for escalation policy
+        session_id = getattr(_ra().AIAgent, "session_id", None) or "unknown"
+        if not hasattr(repair_empty_non_final_messages, "_session_repair_counts"):
+            repair_empty_non_final_messages._session_repair_counts = {}
+        counts = repair_empty_non_final_messages._session_repair_counts
+        counts[session_id] = counts.get(session_id, 0) + 1
+        repair_count = counts[session_id]
+        
+        # Threshold-based escalation: after 5 repairs in a session, escalate to ERROR
+        # and mark session for user notification
+        _ESCALATION_THRESHOLD = 5
+        if repair_count >= _ESCALATION_THRESHOLD:
+            _ra().logger.error(
+                "Pre-call sanitizer: HEALING LOOP DETECTED — session %s has been "
+                "repaired %d times. The underlying stream-death cause is likely "
+                "persistent. Consider /clear to drop affected history or /resume "
+                "to start fresh. Healed %d empty non-final message(s) this call.",
+                session_id,
+                repair_count,
+                healed,
+            )
+            # Mark session for user notification on next gateway turn
+            if hasattr(_ra().AIAgent, "_sanitiser_escalated"):
+                _ra().AIAgent._sanitiser_escalated = True
+                _ra().AIAgent._sanitiser_repair_count = repair_count
+        else:
+            _ra().logger.warning(
+                "Pre-call sanitizer: healed %d empty non-final message(s) by "
+                "substituting placeholder content — an empty-content turn was in "
+                "the transcript and would 400 the request ('messages must have "
+                "non-empty content' / INVALID_REQUEST_BODY). Self-recovering the "
+                "poisoned transcript in memory; no restart needed. "
+                "(Session %s repair count: %d/%d threshold)",
+                healed,
+                session_id,
+                repair_count,
+                _ESCALATION_THRESHOLD,
+            )
         return repaired
     return messages
 


### PR DESCRIPTION
## Summary

This PR fixes #96870 by adding an escalation policy for the sanitiser healing loops that were silently running without any user-visible signal.

## Problem

The `repair_empty_non_final_messages` function was healing empty turns on every send, but:
1. **No per-session counter** - couldn't track how often repairs happened
2. **No escalation** - stayed at WARNING level even after 70+ repairs
3. **No session metadata** - couldn't mark sessions for debugging
4. **Warning floods** - 652 WARNING entries in logs with no human on the hook

One session recorded **70 sanitiser-warning events across 2h47m**, totalling **208 individual messages healed** with no user-visible signal.

## Solution

### 1. Per-Session Repair Counter
Added a module-level dictionary `_session_repair_counts` to track repairs per session ID. This allows us to detect healing loops.

### 2. Threshold-Based Escalation
After **5 repairs** in a session, the log level escalates from WARNING to ERROR with a clear message:
```
HEALING LOOP DETECTED — session X has been repaired N times. 
The underlying stream-death cause is likely persistent. 
Consider /clear to drop affected history or /resume to start fresh.
```

### 3. Session Metadata Marking
After threshold, marks the session with `_sanitiser_escalated = True` and `_sanitiser_repair_count = N` for gateway/CLI to surface in the UI.

### 4. Improved Warning Messages
Even before threshold, warnings now include repair count context:
```
(Session X repair count: 3/5 threshold)
```

## Changes

- Modified `agent/agent_runtime_helpers.py`: Added escalation logic to `repair_empty_non_final_messages`

## Testing

- ✅ Basic import test passes
- ✅ Empty messages handling works
- ✅ Valid messages handling works
- ⚠️ Full test suite timed out (complex project, needs more time)

## Design Decisions

1. **Threshold = 5**: Conservative default based on issue observation (70+ events in 2h47m). Can be made configurable later.
2. **Module-level counter**: Simple, no database changes needed. Resets on process restart (acceptable for healing loops).
3. **Graceful degradation**: If `_ra().AIAgent` doesn't have `session_id`, falls back to "unknown".

---

🤖 Generated with Codebuff
Co-Authored-By: Codebuff <noreply@codebuff.com>