### PR TITLE
fix(compression): stall-fallback and fence-cancel waste — dup-primary skip, slow is not stalled, post-cancel digest stop, 1800s cooldown rung

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -3037,7 +3037,11 @@ class ContextCompressor(ContextEngine):
         ``run_compress_context_with_progress_timeout``. Avoids re-implementing
         the ladder at each call site (#62452).
         """
-        _TIMEOUT_COOLDOWN_LADDER = (60, 300, 900)
+        # Top rung 1800: a session whose summary phase structurally cannot
+        # finish inside the host ceiling (very large compaction regions)
+        # otherwise re-burns a doomed multi-minute attempt every ~15 minutes
+        # forever. Any successful summary still resets the streak.
+        _TIMEOUT_COOLDOWN_LADDER = (60, 300, 900, 1800)
         self._consecutive_timeout_failures = (
             getattr(self, "_consecutive_timeout_failures", 0) + 1
         )
@@ -4754,11 +4758,44 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
         if n_chunks > _LEAN_DIGEST_MAX_CHUNKS:
             chunk_size = (len(text) + _LEAN_DIGEST_MAX_CHUNKS - 1) // _LEAN_DIGEST_MAX_CHUNKS
             n_chunks = _LEAN_DIGEST_MAX_CHUNKS
+
+        # Host-cancellation probe (installed by compress_context for fenced
+        # attempts). On a large region this loop is the dominant cost of a
+        # compression attempt — up to _LEAN_DIGEST_MAX_CHUNKS sequential LLM
+        # calls AFTER the main summary call — and it used to run to completion
+        # even when the host's progress-aware timeout had already
+        # fence-cancelled the attempt, burning tens of minutes of doomed
+        # provider calls whose commit was guaranteed to be refused. Check the
+        # probe before every chunk call and stop as soon as cancellation won.
+        cancelled_check = getattr(self, "_compression_cancelled_check", None)
+
+        def _host_cancelled() -> bool:
+            if not callable(cancelled_check):
+                return False
+            try:
+                return bool(cancelled_check())
+            except Exception:
+                return False
+
         digests: list[str] = []
         for ci in range(n_chunks):
             segment = text[ci * chunk_size:(ci + 1) * chunk_size]
             if not segment.strip():
                 continue
+            if _host_cancelled():
+                logger.warning(
+                    "lean chunk digests stopped before segment %d/%d: the "
+                    "host cancelled this compression attempt — skipping the "
+                    "remaining digest calls",
+                    ci + 1, n_chunks,
+                )
+                digests.append(
+                    f"### Segment {ci + 1}/{n_chunks}\n"
+                    f"[digests unavailable for segments {ci + 1}-{n_chunks}: "
+                    "compression attempt cancelled — recover via "
+                    "session_search]"
+                )
+                break
             try:
                 from agent.auxiliary_client import call_llm
 
@@ -5472,8 +5509,9 @@ This compaction should PRIORITISE preserving all information related to the focu
             # summary route can produce within its deadline will fail the
             # same way every time, and re-burning the full timeout every
             # 60s turns each subsequent turn into a multi-minute stall
-            # (#62452). 60s → 300s → 900s (capped); any successful summary
-            # resets the streak via _clear_compression_failure_cooldown().
+            # (#62452). 60s → 300s → 900s → 1800s (capped); any successful
+            # summary resets the streak via
+            # _clear_compression_failure_cooldown().
             # Timeout takes precedence over the streaming-closed short rung:
             # a "timed out" error also matches _is_connection_error, but a
             # deadline exhaustion is the structural repeat-offender class,
@@ -5482,7 +5520,7 @@ This compaction should PRIORITISE preserving all information related to the focu
                 self._consecutive_timeout_failures = (
                     getattr(self, "_consecutive_timeout_failures", 0) + 1
                 )
-                _TIMEOUT_COOLDOWN_LADDER = (60, 300, 900)
+                _TIMEOUT_COOLDOWN_LADDER = (60, 300, 900, 1800)
                 _transient_cooldown = _TIMEOUT_COOLDOWN_LADDER[
                     min(self._consecutive_timeout_failures,
                         len(_TIMEOUT_COOLDOWN_LADDER)) - 1

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -455,6 +455,7 @@ def _restore_compressor_attempt_state(
     durable_cooldown_authoritative: Optional[bool] = None,
     durable_cooldown_state: Optional[dict[str, Any]] = None,
     attempt_generation: Optional[int] = None,
+    preserve_newer_cooldown: bool = False,
 ) -> None:
     """Restore the safe per-attempt snapshot after a pre-commit hard cancel.
 
@@ -464,6 +465,17 @@ def _restore_compressor_attempt_state(
     primary and hands the compressor to a fallback attempt, and the late
     primary's unwind must not roll fallback-owned state back to the
     primary's pre-attempt snapshot (#96634 post-merge review, claim 1).
+
+    ``preserve_newer_cooldown``: a fence-refused worker can return tens of
+    minutes AFTER its host already timed out and recorded a fresh timeout
+    cooldown (``record_timeout_failure``). Restoring the attempt-start
+    snapshot wholesale would roll that newer cooldown (deadline, error, and
+    the consecutive-failure ladder counter) back to pre-attempt values —
+    in-memory AND durable — so the next auto-compress re-fires almost
+    immediately and the 60/300/900 ladder never climbs (the #78981 fence-
+    cancel churn shape). When the flag is set and the live cooldown deadline
+    is newer than the snapshot's, the cooldown fields are kept as-is and the
+    durable cooldown rollback is skipped.
     """
     if attempt_generation is not None and not _compressor_attempt_is_current(
         compressor, attempt_generation
@@ -476,6 +488,33 @@ def _restore_compressor_attempt_state(
             getattr(compressor, "_compression_attempt_generation", None),
         )
         return
+    if preserve_newer_cooldown:
+        try:
+            _live_deadline = float(
+                getattr(compressor, "_summary_failure_cooldown_until", 0.0)
+                or 0.0
+            )
+        except (TypeError, ValueError):
+            _live_deadline = 0.0
+        try:
+            _snap_deadline = float(
+                snapshot.get("_summary_failure_cooldown_until") or 0.0
+            )
+        except (TypeError, ValueError):
+            _snap_deadline = 0.0
+        if _live_deadline > _snap_deadline:
+            _preserved = _COMPRESSOR_COOLDOWN_STATE_FIELDS + (
+                "_consecutive_timeout_failures",
+            )
+            snapshot = {
+                name: value
+                for name, value in snapshot.items()
+                if name not in _preserved
+            }
+            # The host's newer cooldown row is authoritative now; never
+            # overwrite it with the attempt-start durable state.
+            durable_cooldown_authoritative = False
+            durable_cooldown_state = None
     # A successful summary clears the durable cooldown before the outer commit
     # boundary. Recreate (or clear) that row before restoring exact in-memory
     # values, otherwise the next refresh would overwrite this rollback. Unknown
@@ -1001,6 +1040,30 @@ def resolve_context_compression_timeouts(
     return idle, ceiling
 
 
+def _normalized_route_identity(
+    provider: Any, model: Any, base_url: Any
+) -> Tuple[str, str, str]:
+    """Normalized ``(provider, model, base_url)`` identity for route equality.
+
+    Providers compare through the auxiliary client's own alias table
+    (``_normalize_aux_provider``: ``codex`` → ``openai-codex``, ``google`` →
+    ``gemini``, case-insensitive, …) so an aliased spelling of the same
+    backend cannot masquerade as a different route. Models compare
+    case-insensitively; base URLs case-insensitively with trailing slashes
+    stripped (clients themselves append/strip them freely).
+    """
+    provider_text = str(provider or "").strip()
+    try:
+        from agent.auxiliary_client import _normalize_aux_provider
+
+        provider_text = _normalize_aux_provider(provider_text)
+    except Exception:
+        provider_text = provider_text.lower()
+    model_text = str(model or "").strip().lower()
+    base_text = str(base_url or "").strip().lower().rstrip("/")
+    return provider_text, model_text, base_text
+
+
 def resolve_compression_fallback_route() -> Optional[dict]:
     """Return the first usable ``auxiliary.compression.fallback_chain`` entry.
 
@@ -1011,11 +1074,18 @@ def resolve_compression_fallback_route() -> Optional[dict]:
     resolves the same config into explicit ``call_llm`` route arguments the
     stall path can pin onto one retry.
 
-    Only the first structurally complete entry is returned: one extra bounded
-    attempt is the budget for a stall, and if that entry cannot build a client
-    (or errors) the auxiliary client's own exception path still walks the rest
-    of the chain from there. Returns ``None`` when no entry is usable, which
-    keeps the historical continue-without-compression behaviour.
+    An entry that names the ACTIVE PRIMARY compression route (same normalized
+    provider/model/base_url — see ``_normalized_route_identity``) is skipped:
+    "retrying" a stalled route on itself burns a whole second timeout budget
+    for a retry that cannot behave differently (the observed misconfig shape:
+    the chain's first entry duplicating ``auxiliary.compression`` itself).
+    Scanning continues to the next entry.
+
+    Beyond that, only the first structurally complete entry is returned: one
+    extra bounded attempt is the budget for a stall, and if that entry cannot
+    build a client (or errors) the auxiliary client's own exception path still
+    walks the rest of the chain from there. Returns ``None`` when no entry is
+    usable, which keeps the historical continue-without-compression behaviour.
     """
     try:
         from agent.auxiliary_client import (
@@ -1023,12 +1093,30 @@ def resolve_compression_fallback_route() -> Optional[dict]:
             _get_auxiliary_task_config,
         )
 
-        chain = _get_auxiliary_task_config("compression").get("fallback_chain")
+        task_config = _get_auxiliary_task_config("compression")
+        chain = task_config.get("fallback_chain")
     except Exception:
         logger.debug("compression fallback_chain lookup failed", exc_info=True)
         return None
     if not isinstance(chain, list):
         return None
+
+    # Identity of the active primary compression route. Comparable only when
+    # the config names both provider and model; otherwise (auto-resolved
+    # routes) no candidate is skipped — a wrong skip would silently disable
+    # the user's declared fallback.
+    primary_identity: Optional[Tuple[str, str, str]] = None
+    try:
+        primary_provider = str(task_config.get("provider") or "").strip()
+        primary_model = str(task_config.get("model") or "").strip()
+        if primary_provider and primary_model:
+            primary_identity = _normalized_route_identity(
+                primary_provider,
+                primary_model,
+                task_config.get("base_url"),
+            )
+    except Exception:
+        primary_identity = None
 
     for index, entry in enumerate(chain):
         if not isinstance(entry, dict):
@@ -1038,6 +1126,21 @@ def resolve_compression_fallback_route() -> Optional[dict]:
         # Both are required to name a route. _resolve_fallback_entry applies
         # the same rule when the aux client walks this chain itself.
         if not provider or not model:
+            continue
+        if primary_identity is not None and (
+            _normalized_route_identity(
+                provider, model, entry.get("base_url")
+            )
+            == primary_identity
+        ):
+            logger.warning(
+                "compression fallback_chain[%d] (%s/%s) is the active "
+                "primary compression route — skipping it as a stall-fallback "
+                "candidate",
+                index,
+                provider,
+                model,
+            )
             continue
         try:
             api_key = _fallback_entry_api_key(entry)
@@ -1311,11 +1414,18 @@ def run_compress_context_with_progress_timeout(
     # settle admission themselves (worker result returned, or fence cancel
     # won); everything else revokes in the ``finally``.
     handled_exit = False
+    # How the pre-commit wait ended: True = the worker went silent for a full
+    # idle window (a genuinely stalled route — #78981's shape); False = the
+    # total ceiling elapsed while progress was still fresh (a slow-but-alive
+    # summary phase). Only the former is a route-health signal that justifies
+    # the stall-fallback retry.
+    idle_stalled = False
     try:
         while True:
             waited = time.monotonic() - wait_started
             remaining_ceiling = ceiling - waited
             if remaining_ceiling <= 0:
+                idle_stalled = fence.seconds_since_progress() >= idle
                 break
             # #76354 S3 analogue for this wait: charge the idle budget from
             # the LAST PROGRESS event, not from the start of this wait slice.
@@ -1342,6 +1452,7 @@ def run_compress_context_with_progress_timeout(
                         ceiling,
                     )
                     continue
+                idle_stalled = since_progress >= idle
                 break
 
         # F6: a not-yet-started future must not linger as a stale queued job.
@@ -1438,7 +1549,23 @@ def run_compress_context_with_progress_timeout(
         # acquire it immediately. Run it BEFORE on_timeout: that callback
         # records the summary-failure cooldown, which would make the retry's
         # own summary call a no-op.
-        if stall_fallback:
+        #
+        # Only a genuine idle stall consults the fallback chain. When the
+        # ceiling elapsed while tokens were still streaming, the route is
+        # slow, not unhealthy — most often an oversized session whose summary
+        # phase simply cannot finish inside the ceiling. A fallback re-run of
+        # that same attempt is bound by the same ceiling, so it burns a
+        # second full ceiling on a retry that is structurally just as doomed.
+        if stall_fallback and not idle_stalled:
+            logger.warning(
+                "Context compression hit the total ceiling (%.0fs) while the "
+                "summary route was still streaming (last progress %.1fs ago) "
+                "— the route is slow, not stalled; skipping the "
+                "stall-fallback retry and continuing without compression",
+                ceiling,
+                since_progress,
+            )
+        if stall_fallback and idle_stalled:
             recovered = _retry_compression_on_fallback_chain(
                 worker=worker,
                 messages=messages,
@@ -2812,8 +2939,10 @@ def compress_context(
             )
             if not _codex_fence_entered:
                 _restore_compressor_attempt_state(
-                    agent.context_compressor, _compressor_attempt_snapshot,
+                    agent.context_compressor,
+                    _compressor_attempt_snapshot,
                     attempt_generation=_attempt_generation,
+                    preserve_newer_cooldown=True,
                 )
                 existing_prompt = getattr(agent, "_cached_system_prompt", None)
                 if not existing_prompt:
@@ -3758,12 +3887,17 @@ def compress_context(
         if commit_fence is not None:
             _commit_fence_entered = commit_fence.begin_commit(_hard_cancel_event)
             if not _commit_fence_entered:
+                # A refused commit usually means the host timed out long ago
+                # and has since recorded a fresh timeout cooldown; this late
+                # rollback must not clobber that newer cooldown (see
+                # _restore_compressor_attempt_state).
                 _restore_compressor_attempt_state(
                     agent.context_compressor,
                     _compressor_attempt_snapshot,
                     durable_cooldown_authoritative=_durable_cooldown_authoritative,
                     durable_cooldown_state=_durable_cooldown_state,
                     attempt_generation=_attempt_generation,
+                    preserve_newer_cooldown=True,
                 )
                 if (
                     messages_before_compression is not None

--- a/tests/agent/test_compression_fence_cancel_waste.py
+++ b/tests/agent/test_compression_fence_cancel_waste.py
@@ -1,0 +1,268 @@
+"""A fence-cancelled compression attempt must stop wasting work.
+
+Observed shape (2026-08-28, session 20260828_034232_fc3e4e): a ~600K-token
+session's compression attempts each ran 32-35 minutes while the host's
+progress-aware wait gave up at the 600s ceiling. Three compounding leaks:
+
+* lean-mode ``_build_chunk_digests`` runs up to 28 sequential summary-LLM
+  calls AFTER the main summary call and never consulted the host-cancellation
+  probe, so a fence-cancelled worker kept burning provider calls whose commit
+  was guaranteed to be refused;
+* the begin_commit-refusal rollback (``_restore_compressor_attempt_state``)
+  ran tens of minutes late and clobbered the newer timeout cooldown the host
+  had recorded meanwhile — in memory and in the durable row — so the next
+  auto-compress re-fired almost immediately and the cooldown ladder never
+  climbed;
+* the ladder topped out at 900s, re-burning a structurally doomed multi-minute
+  attempt every ~15 minutes forever.
+
+These tests pin the fixes for all three.
+"""
+
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import agent.context_compressor as cc_module
+from agent.context_compressor import ContextCompressor
+from agent.conversation_compression import (
+    _restore_compressor_attempt_state,
+)
+
+
+# ---------------------------------------------------------------------------
+# Chunk digests stop as soon as host cancellation wins
+# ---------------------------------------------------------------------------
+
+
+def _make_compressor():
+    with patch(
+        "agent.context_compressor.get_model_context_length", return_value=100000
+    ):
+        return ContextCompressor(model="main-model", quiet_mode=True)
+
+
+def _digest_turns():
+    # Enough serialized text for several chunks once the chunk size is
+    # patched small below.
+    return [
+        {"role": "user", "content": f"question {i} " + "q" * 120}
+        if i % 2 == 0
+        else {"role": "assistant", "content": f"answer {i} " + "a" * 120}
+        for i in range(10)
+    ]
+
+
+def _digest_response(text="segment digest body"):
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=text))]
+    )
+
+
+def test_chunk_digests_stop_after_host_cancellation():
+    compressor = _make_compressor()
+    state = {"cancelled": False}
+    compressor._compression_cancelled_check = lambda: state["cancelled"]
+    calls = []
+
+    def _fake_call_llm(**kwargs):
+        calls.append(kwargs)
+        # Host cancellation wins while the first digest call is in flight.
+        state["cancelled"] = True
+        return _digest_response()
+
+    with patch.object(cc_module, "_LEAN_DIGEST_CHUNK_CHARS", 300), patch(
+        "agent.auxiliary_client.call_llm", side_effect=_fake_call_llm
+    ):
+        result = compressor._build_chunk_digests(_digest_turns())
+
+    assert len(calls) == 1, (
+        "after cancellation, no further digest LLM calls may be issued"
+    )
+    assert "compression attempt cancelled" in result
+    assert "segment digest body" in result, (
+        "digests completed before cancellation are kept"
+    )
+
+
+def test_chunk_digests_pre_cancelled_make_no_llm_calls():
+    compressor = _make_compressor()
+    compressor._compression_cancelled_check = lambda: True
+    calls = []
+
+    def _fake_call_llm(**kwargs):
+        calls.append(kwargs)
+        return _digest_response()
+
+    with patch.object(cc_module, "_LEAN_DIGEST_CHUNK_CHARS", 300), patch(
+        "agent.auxiliary_client.call_llm", side_effect=_fake_call_llm
+    ):
+        result = compressor._build_chunk_digests(_digest_turns())
+
+    assert calls == []
+    assert "compression attempt cancelled" in result
+
+
+def test_chunk_digests_without_probe_run_every_chunk():
+    """No installed probe (unfenced callers) keeps the historical behavior."""
+    compressor = _make_compressor()
+    calls = []
+
+    def _fake_call_llm(**kwargs):
+        calls.append(kwargs)
+        return _digest_response()
+
+    with patch.object(cc_module, "_LEAN_DIGEST_CHUNK_CHARS", 300), patch(
+        "agent.auxiliary_client.call_llm", side_effect=_fake_call_llm
+    ):
+        result = compressor._build_chunk_digests(_digest_turns())
+
+    assert len(calls) > 1, "small chunk size must produce several chunks"
+    assert "compression attempt cancelled" not in result
+
+
+def test_chunk_digests_probe_errors_fail_open():
+    """A broken probe must not kill the digest pass."""
+    compressor = _make_compressor()
+
+    def _boom():
+        raise RuntimeError("probe exploded")
+
+    compressor._compression_cancelled_check = _boom
+    calls = []
+
+    def _fake_call_llm(**kwargs):
+        calls.append(kwargs)
+        return _digest_response()
+
+    with patch.object(cc_module, "_LEAN_DIGEST_CHUNK_CHARS", 300), patch(
+        "agent.auxiliary_client.call_llm", side_effect=_fake_call_llm
+    ):
+        result = compressor._build_chunk_digests(_digest_turns())
+
+    assert len(calls) > 1
+    assert "compression attempt cancelled" not in result
+
+
+# ---------------------------------------------------------------------------
+# The late begin_commit-refusal rollback must not clobber a newer cooldown
+# ---------------------------------------------------------------------------
+
+
+class _FakeSessionDB:
+    def __init__(self):
+        self.calls = []
+
+    def restore_compression_failure_cooldown_row(self, session_id, state):
+        self.calls.append(("restore", session_id, state))
+
+    def record_compression_failure_cooldown(self, session_id, deadline, error):
+        self.calls.append(("record", session_id, deadline, error))
+
+    def clear_compression_failure_cooldown(self, session_id):
+        self.calls.append(("clear", session_id))
+
+
+def _live_compressor(cooldown_until, *, streak=3, db=None):
+    comp = SimpleNamespace()
+    comp._summary_failure_cooldown_until = cooldown_until
+    comp._last_summary_error = "host compress_context timeout (no summary progress)"
+    comp._cooldown_persist_failed = False
+    comp._consecutive_timeout_failures = streak
+    comp._previous_summary = "live-summary"
+    if db is not None:
+        comp._session_db = db
+        comp._session_id = "sess-1"
+    return comp
+
+
+def _older_snapshot():
+    return {
+        "_summary_failure_cooldown_until": 0.0,
+        "_last_summary_error": None,
+        "_cooldown_persist_failed": False,
+        "_consecutive_timeout_failures": 0,
+        "_previous_summary": "snapshot-summary",
+    }
+
+
+def test_preserve_newer_cooldown_keeps_host_recorded_state():
+    newer_deadline = time.monotonic() + 900.0
+    db = _FakeSessionDB()
+    comp = _live_compressor(newer_deadline, db=db)
+    snapshot = _older_snapshot()
+
+    _restore_compressor_attempt_state(
+        comp,
+        snapshot,
+        durable_cooldown_authoritative=True,
+        durable_cooldown_state={"cooldown_until": None},
+        preserve_newer_cooldown=True,
+    )
+
+    # The host's newer cooldown survives — deadline, error, and the ladder
+    # counter — while non-cooldown attempt state is still rolled back.
+    assert comp._summary_failure_cooldown_until == newer_deadline
+    assert comp._consecutive_timeout_failures == 3
+    assert comp._last_summary_error and "host compress_context" in comp._last_summary_error
+    assert comp._previous_summary == "snapshot-summary"
+    # The durable cooldown row is left alone too.
+    assert db.calls == []
+    # The caller's snapshot dict is not mutated.
+    assert "_summary_failure_cooldown_until" in snapshot
+
+
+def test_legacy_restore_without_flag_still_rolls_back():
+    newer_deadline = time.monotonic() + 900.0
+    comp = _live_compressor(newer_deadline)
+    snapshot = _older_snapshot()
+
+    _restore_compressor_attempt_state(comp, snapshot)
+
+    assert comp._summary_failure_cooldown_until == 0.0
+    assert comp._consecutive_timeout_failures == 0
+    assert comp._previous_summary == "snapshot-summary"
+
+
+def test_preserve_flag_with_older_live_cooldown_restores_snapshot():
+    """The flag only protects NEWER live state; when the snapshot carries the
+    newer (or equal) deadline the normal rollback still applies."""
+    comp = _live_compressor(0.0, streak=0)
+    future_deadline = time.monotonic() + 300.0
+    snapshot = dict(
+        _older_snapshot(),
+        _summary_failure_cooldown_until=future_deadline,
+        _consecutive_timeout_failures=2,
+    )
+
+    _restore_compressor_attempt_state(
+        comp, snapshot, preserve_newer_cooldown=True
+    )
+
+    assert comp._summary_failure_cooldown_until == future_deadline
+    assert comp._consecutive_timeout_failures == 2
+
+
+# ---------------------------------------------------------------------------
+# The timeout cooldown ladder gains a half-hour top rung
+# ---------------------------------------------------------------------------
+
+
+def test_timeout_cooldown_ladder_climbs_to_half_hour_and_saturates():
+    comp = MagicMock()
+    comp._consecutive_timeout_failures = 0
+    comp.record_timeout_failure = ContextCompressor.record_timeout_failure.__get__(
+        comp, MagicMock
+    )
+    comp._record_compression_failure_cooldown = MagicMock()
+
+    for _ in range(5):
+        comp.record_timeout_failure("host compress_context timeout")
+
+    rungs = [
+        call.args[0]
+        for call in comp._record_compression_failure_cooldown.call_args_list
+    ]
+    assert rungs == [60.0, 300.0, 900.0, 1800.0, 1800.0]

--- a/tests/agent/test_compression_stall_fallback_78981.py
+++ b/tests/agent/test_compression_stall_fallback_78981.py
@@ -358,3 +358,187 @@ def test_unpinned_summary_call_keeps_task_routing():
     assert summary
     assert calls and "provider" not in calls[0]
     assert calls[0]["model"] == "aux-summarizer"
+
+
+# ---------------------------------------------------------------------------
+# Primary-route hardening: a chain entry that IS the primary is never a
+# fallback candidate (the observed misconfig: fallback_chain[0] duplicating
+# auxiliary.compression itself, so the "fallback" re-ran the stalled route).
+# ---------------------------------------------------------------------------
+
+PRIMARY_CONFIG = {
+    "provider": "openai-codex",
+    "model": "gpt-5.5",
+    "base_url": "https://chatgpt.com/backend-api/codex",
+}
+
+
+def _patch_task_config(config):
+    return patch(
+        "agent.auxiliary_client._get_auxiliary_task_config",
+        return_value=config,
+    )
+
+
+def test_primary_identical_first_entry_is_skipped_for_the_next_entry():
+    chain = [
+        {
+            "provider": "openai-codex",
+            "model": "gpt-5.5",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+        },
+        CHAIN_ENTRY,
+    ]
+    with _patch_task_config(dict(PRIMARY_CONFIG, fallback_chain=chain)):
+        route = resolve_compression_fallback_route()
+
+    assert route is not None
+    assert route["model"] == "backup-summarizer"
+    assert route["label"] == "fallback_chain[1](custom)"
+
+
+def test_normalized_primary_duplicates_cannot_evade_the_skip():
+    """Trailing slash, case difference, and provider alias all still name the
+    same backend as the primary and must not survive as fallback candidates."""
+    chain = [
+        {  # trailing slash on base_url
+            "provider": "openai-codex",
+            "model": "gpt-5.5",
+            "base_url": "https://chatgpt.com/backend-api/codex/",
+        },
+        {  # case differences in every field
+            "provider": "OpenAI-Codex",
+            "model": "GPT-5.5",
+            "base_url": "HTTPS://chatgpt.com/backend-api/CODEX",
+        },
+        {  # provider alias ("codex" normalizes to "openai-codex")
+            "provider": "codex",
+            "model": "gpt-5.5",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+        },
+        CHAIN_ENTRY,
+    ]
+    with _patch_task_config(dict(PRIMARY_CONFIG, fallback_chain=chain)):
+        route = resolve_compression_fallback_route()
+
+    assert route is not None
+    assert route["model"] == "backup-summarizer"
+    assert route["label"] == "fallback_chain[3](custom)"
+
+
+def test_chain_of_only_primary_duplicates_resolves_to_no_route():
+    chain = [
+        {
+            "provider": "codex",
+            "model": "GPT-5.5",
+            "base_url": "https://chatgpt.com/backend-api/codex/",
+        },
+    ]
+    with _patch_task_config(dict(PRIMARY_CONFIG, fallback_chain=chain)):
+        assert resolve_compression_fallback_route() is None
+
+
+def test_same_model_on_a_different_base_url_is_a_real_fallback():
+    """Identity is (provider, model, base_url): the same model served from a
+    different endpoint is a genuinely distinct route and must be kept."""
+    chain = [
+        {
+            "provider": "openai-codex",
+            "model": "gpt-5.5",
+            "base_url": "https://other-endpoint.invalid/v1",
+        },
+    ]
+    with _patch_task_config(dict(PRIMARY_CONFIG, fallback_chain=chain)):
+        route = resolve_compression_fallback_route()
+
+    assert route is not None
+    assert route["base_url"] == "https://other-endpoint.invalid/v1"
+
+
+def test_unknown_primary_identity_skips_nothing():
+    """Without an explicit primary provider+model in config (auto-resolved
+    routes) no candidate can be proven identical — the declared chain wins."""
+    chain = [
+        {
+            "provider": "openai-codex",
+            "model": "gpt-5.5",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+        },
+    ]
+    with _patch_task_config({"fallback_chain": chain}):
+        route = resolve_compression_fallback_route()
+
+    assert route is not None
+    assert route["model"] == "gpt-5.5"
+
+
+# ---------------------------------------------------------------------------
+# Stall classification: only an idle-stalled route consults the chain. A
+# summary phase that is still streaming when the total ceiling elapses is
+# slow (or the region is simply too large for the ceiling), not stalled — a
+# fallback re-run of the identical attempt burns a second full ceiling on a
+# retry that cannot finish either.
+# ---------------------------------------------------------------------------
+
+
+def test_ceiling_with_fresh_progress_skips_the_fallback_retry():
+    original = [{"role": "user", "content": "keep-me"}]
+    worker_calls = []
+    release = threading.Event()
+
+    def streaming_worker(fence: CompressionCommitFence):
+        worker_calls.append(fence)
+        # Stream continuously: progress stays fresher than the idle budget
+        # for well past the total ceiling.
+        for _ in range(200):
+            if release.is_set():
+                break
+            fence.touch_progress()
+            threading.Event().wait(0.01)
+        if not fence.begin_commit():
+            return (original, "late")
+        try:
+            return ([{"role": "assistant", "content": "late"}], "late")
+        finally:
+            fence.finish_commit()
+
+    timeouts = []
+    try:
+        with _patch_chain([CHAIN_ENTRY]):
+            msgs, prompt = run_compress_context_with_progress_timeout(
+                worker=streaming_worker,
+                messages=original,
+                system_prompt_fallback="degraded-prompt",
+                idle_timeout_seconds=0.3,
+                total_ceiling_seconds=0.6,
+                on_timeout=lambda *args: timeouts.append(args),
+            )
+    finally:
+        release.set()
+
+    assert len(worker_calls) == 1, (
+        "a streaming-but-slow attempt must not be retried on the fallback "
+        "chain — the retry is bound by the same ceiling and equally doomed"
+    )
+    assert msgs is original
+    assert prompt == "degraded-prompt"
+    assert len(timeouts) == 1, "the degrade must still be reported"
+
+
+def test_idle_stall_still_consults_the_fallback_chain():
+    """The classification must not break #78981's core contract: a silent
+    stall (no progress for a full idle window) still gets its one retry."""
+    original = [{"role": "user", "content": "keep-me"}]
+    compressed = [{"role": "user", "content": "summary"}]
+    worker = _StalledSummaryWorker(compressed)
+
+    try:
+        msgs, prompt = _run(
+            worker, chain=[CHAIN_ENTRY], timeouts=[], messages=original
+        )
+    finally:
+        worker.release.set()
+
+    assert worker.attempts == 2
+    assert msgs == compressed
+    assert prompt == "summarized-prompt"


### PR DESCRIPTION
## What does this PR do?

Follow-up hardening for the stall-fallback retry (#96634, issue #78981) and the commit fence, targeting a waste/churn shape observed on very large sessions: compression attempts that burn the full total ceiling (30+ minutes wall clock including post-cancel work), get fence-cancelled, and then re-arm almost immediately — repeating indefinitely.

Four root causes, four fixes (two commits):

**Commit 1 — `fix(compression): harden stall-fallback routing and late fence-refusal rollback`**

- **`resolve_compression_fallback_route` can hand back the primary route.** A `fallback_chain` whose first entry duplicates `auxiliary.compression` itself (an easy misconfig) made the one bounded stall retry re-dial the exact route that just stalled. Entries whose normalized `(provider, model, base_url)` identity matches the active primary are now skipped (aliases via `_normalize_aux_provider`, case-insensitive, trailing-slash-insensitive), continuing to the next entry. Auto-resolved primaries (no explicit provider+model in config) skip nothing, so a declared fallback can never be silently disabled by a wrong match.
- **Slow is not stalled.** The pre-commit wait now records *how* it ended. Only a genuine idle stall (silence for a full idle window) consults the fallback chain. When the total ceiling elapses while the summary is still streaming, the route is slow — typically an oversized session whose summary phase structurally cannot finish inside the ceiling — and the fallback re-run of the identical attempt (bound by the same ceiling) is skipped instead of burning a second full ceiling.
- **Late fence-refusal rollback re-armed doomed attempts.** `_restore_compressor_attempt_state` gains `preserve_newer_cooldown`: a `begin_commit`-refused worker can unwind tens of minutes after its host already timed out and recorded a fresh timeout cooldown. The rollback no longer rolls that newer cooldown (deadline, error, ladder counter, durable row) back to attempt-start values — which had been re-firing auto-compress within a minute of every refusal, so the cooldown ladder never climbed. This composes with #96963's `attempt_generation` guard rather than duplicating it: the generation no-op only protects state once a *newer attempt* has claimed the compressor; the case here has no newer attempt yet — just a newer cooldown recorded by the departed host.

**Commit 2 — `fix(compression): stop chunk-digest calls after fence cancellation; extend cooldown ladder`**

- **Post-cancel digest waste.** In lean mode, `_build_chunk_digests` issues up to `_LEAN_DIGEST_MAX_CHUNKS` (28) sequential summary-LLM calls *after* the main summary call. Each call streams and ticks the progress hook, so the host wait never sees an idle stall, exhausts its full ceiling, fence-cancels, and departs — while the worker keeps burning digest calls for many more minutes on a commit that is guaranteed to be refused (`commit_status=aborted`, `failure_class=commit_fence_cancelled`). The digest loop now consults the host-cancellation probe (`_compression_cancelled_check`, installed by `compress_context` for fenced attempts) before every chunk call and stops as soon as cancellation won, keeping already-produced digests and noting the omission in the digest text. A broken probe fails open.
- **Cooldown ladder tops out at 1800s.** Both `record_timeout_failure` and the inline summary-LLM timeout handler extend `(60, 300, 900)` with an 1800s top rung, so a session whose summary phase structurally cannot finish inside the host ceiling re-attempts half-hourly instead of every ~15 minutes. Any successful summary still resets the streak.

## Related Issue

Related: #78981, #96634, #96963 (no dedicated issue; hardening follow-up to those threads)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/conversation_compression.py` — primary-route skip in `resolve_compression_fallback_route` (+ `_normalized_route_identity` helper), `idle_stalled` discrimination in `run_compress_context_with_progress_timeout`, `preserve_newer_cooldown` on `_restore_compressor_attempt_state` (passed at both fence-refusal rollback sites alongside `attempt_generation`)
- `agent/context_compressor.py` — host-cancellation probe consult in `_build_chunk_digests`; 1800s cooldown rung in both ladder sites
- `tests/agent/test_compression_stall_fallback_78981.py` — extended (dup-primary skip incl. alias/slash normalization + auto-resolved-primary no-skip; slow-vs-stalled gating; preserved-newer-cooldown rollback)
- `tests/agent/test_compression_fence_cancel_waste.py` — new (digest loop stops on cancellation, keeps produced digests, fails open on broken probe; ladder reaches and holds 1800s, resets on success)

## How to Test

1. `scripts/run_tests.sh tests/agent/test_compression_stall_fallback_78981.py tests/agent/test_compression_fence_cancel_waste.py` — 18 + 8 tests
2. `scripts/run_tests.sh tests/agent/` — full agent suite
3. Repro shape without the fix: a lean-mode session large enough that the summary phase cannot finish inside `compression.total_ceiling_seconds`, with a `fallback_chain` whose first entry duplicates the primary route — observe double-ceiling burns, post-cancel digest calls in the aux logs, and sub-minute re-arms after every fence refusal; with the fix, one bounded attempt, digest calls stop at cancellation, and re-attempts back off to 1800s.

Tested on Linux x86_64 (Python 3.11). Full `tests/agent/` is green via `scripts/run_tests.sh` except `test_compression_review_76354.py::TestS3IdleChargedFromLastProgress::test_silence_cannot_approach_double_idle_timeout`, a timing-sensitive test that fails identically on pristine `main` on the same host (pre-existing, unrelated).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the test suite and all tests pass (one pre-existing timing-flaky test noted above)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux x86_64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings) — no user-facing docs affected
- [x] `cli-config.yaml.example` — N/A (no config keys added/changed)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered — pure-Python control flow, no platform-specific I/O
- [x] Tool descriptions/schemas — N/A
