### PR TITLE
fix(compression): per-attempt telemetry attribution under overlapping workers

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -94,6 +94,54 @@ _SUMMARY_ROUTE_CONSUMED: contextvars.ContextVar[Optional[Dict[str, Any]]] = (
     contextvars.ContextVar("hermes_summary_route_consumed", default=None)
 )
 
+# ── Per-attempt telemetry attribution ────────────────────────────────────
+# The compressor object is SHARED between overlapping compression attempts
+# (a fence-cancelled worker stays alive on the pool while the host launches
+# the next attempt), so instance slots like ``_last_compression_telemetry``
+# are last-writer-wins: an aborted attempt that emitted its payload from the
+# instance slot could carry an OVERLAPPING attempt's attempt_id/aux fields.
+# Attribution therefore lives in ContextVars: each pooled worker runs under
+# its own copied context (``propagate_context_to_thread``), and
+# ``compress_context`` opens a fresh scope at entry
+# (``begin_compression_attempt_attribution``) so executor-thread reuse
+# cannot leak the previous attempt's payload either. The instance slots
+# remain as last-attempt mirrors for external readers and tests.
+_COMPRESSION_ATTEMPT_SEED: contextvars.ContextVar[Optional[Dict[str, Any]]] = (
+    contextvars.ContextVar("hermes_compression_attempt_seed", default=None)
+)
+_COMPRESSION_ATTEMPT_TELEMETRY: contextvars.ContextVar[
+    Optional[Dict[str, Any]]
+] = contextvars.ContextVar(
+    "hermes_compression_attempt_telemetry", default=None
+)
+
+
+def begin_compression_attempt_attribution(
+    seed: Optional[Dict[str, Any]],
+) -> None:
+    """Open a fresh attribution scope for ONE compression attempt.
+
+    ``seed`` carries the attempt's identity (``attempt_id`` / ``session_id``
+    / ``trigger_source``). Resets the attempt-telemetry slot so a reused
+    executor thread cannot leak the previous attempt's payload into an
+    abort that never reached ``_begin_compression_telemetry``.
+    """
+    _COMPRESSION_ATTEMPT_SEED.set(dict(seed) if isinstance(seed, dict) else None)
+    _COMPRESSION_ATTEMPT_TELEMETRY.set(None)
+
+
+def current_compression_attempt_seed() -> Optional[Dict[str, Any]]:
+    """This attempt's identity seed (context-local), or ``None``."""
+    seed = _COMPRESSION_ATTEMPT_SEED.get()
+    return dict(seed) if isinstance(seed, dict) else None
+
+
+def current_compression_attempt_telemetry() -> Optional[Dict[str, Any]]:
+    """This attempt's live telemetry dict (context-local), or ``None``."""
+    telemetry = _COMPRESSION_ATTEMPT_TELEMETRY.get()
+    return telemetry if isinstance(telemetry, dict) else None
+
+
 # call_llm kwargs a pinned route may set. ``timeout`` lets a fallback entry
 # keep its own deadline instead of inheriting one the primary already burned
 # (same per-entry semantics the aux client applies to chain candidates).
@@ -2338,7 +2386,12 @@ class ContextCompressor(ContextEngine):
         trigger_source: str | None = None,
     ) -> Dict[str, Any]:
         """Initialize content-free per-attempt compression telemetry."""
-        seed = getattr(self, "_compression_telemetry_seed", None)
+        # Context-local seed first (set by compress_context for THIS attempt);
+        # the instance slot is a shared last-writer-wins mirror kept only for
+        # legacy callers and can name an overlapping attempt.
+        seed = _COMPRESSION_ATTEMPT_SEED.get()
+        if not isinstance(seed, dict):
+            seed = getattr(self, "_compression_telemetry_seed", None)
         if isinstance(seed, dict):
             attempt_id = attempt_id or seed.get("attempt_id")
             session_id = session_id or seed.get("session_id")
@@ -2377,9 +2430,26 @@ class ContextCompressor(ContextEngine):
             "split_status": "unknown",
             "failure_class": None,
         }
+        # Attempt-scoped slot is authoritative; the instance slots stay as
+        # last-attempt mirrors for external readers (tests, /usage-style
+        # introspection) and are the fallback for unscoped legacy callers.
+        _COMPRESSION_ATTEMPT_TELEMETRY.set(telemetry)
         self._active_compression_telemetry = telemetry
         self._last_compression_telemetry = telemetry
         return telemetry
+
+    def _current_attempt_telemetry(self) -> Optional[Dict[str, Any]]:
+        """The telemetry dict owned by THIS attempt's context, if any.
+
+        Falls back to the shared instance slot only when no context-local
+        attempt telemetry exists (legacy callers that never opened an
+        attribution scope).
+        """
+        telemetry = _COMPRESSION_ATTEMPT_TELEMETRY.get()
+        if isinstance(telemetry, dict):
+            return telemetry
+        telemetry = getattr(self, "_active_compression_telemetry", None)
+        return telemetry if isinstance(telemetry, dict) else None
 
     def _record_compression_regions(
         self,
@@ -2388,7 +2458,7 @@ class ContextCompressor(ContextEngine):
         middle_messages: List[Dict[str, Any]],
         tail_messages: List[Dict[str, Any]],
     ) -> None:
-        telemetry = getattr(self, "_active_compression_telemetry", None)
+        telemetry = self._current_attempt_telemetry()
         if not isinstance(telemetry, dict):
             return
         telemetry["protected_head_tokens"] = estimate_messages_tokens_rough(head_messages)
@@ -2406,7 +2476,7 @@ class ContextCompressor(ContextEngine):
         effective_aux_context: int | None = None,
         phase_timings: Dict[str, Any] | None = None,
     ) -> None:
-        telemetry = getattr(self, "_active_compression_telemetry", None)
+        telemetry = self._current_attempt_telemetry()
         if not isinstance(telemetry, dict):
             return
         telemetry["aux_prompt_tokens"] = estimate_messages_tokens_rough(prompt_messages)
@@ -4879,7 +4949,7 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
             _err_text = _err_text[:217].rstrip() + "..."
         self._last_aux_model_failure_error = _err_text
         self._last_aux_model_failure_model = self.summary_model
-        telemetry = getattr(self, "_active_compression_telemetry", None)
+        telemetry = self._current_attempt_telemetry()
         if isinstance(telemetry, dict):
             telemetry["fallback_used"] = True
             telemetry["failure_class"] = telemetry.get("failure_class") or "aux_model_fallback"

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1272,6 +1272,22 @@ def run_compress_context_with_progress_timeout(
         # telemetry stream as every other failed attempt, or a wedged pool
         # looks like compression simply stopped being attempted.
         if telemetry_agent is not None:
+            # No compress_context ran for this refusal, so open a minimal
+            # attribution scope of its own: without it, a host thread that
+            # previously ran a direct-path attempt would emit this line under
+            # that stale attempt's identity.
+            try:
+                from agent.context_compressor import (
+                    begin_compression_attempt_attribution,
+                )
+
+                begin_compression_attempt_attribution({
+                    "attempt_id": uuid.uuid4().hex,
+                    "session_id": getattr(telemetry_agent, "session_id", "")
+                    or "",
+                })
+            except Exception:
+                pass
             _emit_compression_attempt_telemetry(
                 telemetry_agent,
                 started_at=time.monotonic(),
@@ -1562,7 +1578,29 @@ def _emit_compression_attempt_telemetry(
 ) -> None:
     """Emit one content-free JSON log line for a compression attempt."""
     try:
-        telemetry = getattr(agent.context_compressor, "_last_compression_telemetry", None)
+        # Attribution order: this attempt's context-local telemetry, then its
+        # context-local identity seed (an abort that never began summary
+        # telemetry), then — only for legacy callers with no attribution
+        # scope — the compressor's shared last-attempt mirror. The mirror is
+        # last-writer-wins across OVERLAPPING attempts, so reading it for a
+        # scoped attempt could stamp this payload with another attempt's
+        # attempt_id/aux fields (the 2026-08-28 fence-cancel churn logs).
+        telemetry = None
+        try:
+            from agent.context_compressor import (
+                current_compression_attempt_seed,
+                current_compression_attempt_telemetry,
+            )
+
+            telemetry = current_compression_attempt_telemetry()
+            if telemetry is None:
+                telemetry = current_compression_attempt_seed()
+        except Exception:
+            telemetry = None
+        if telemetry is None:
+            telemetry = getattr(
+                agent.context_compressor, "_last_compression_telemetry", None
+            )
         if not isinstance(telemetry, dict):
             telemetry = {}
         payload = dict(telemetry)
@@ -2775,15 +2813,36 @@ def compress_context(
     _attempt_started_at = time.monotonic()
     _attempt_id = uuid.uuid4().hex
     _trigger_source = "manual" if force else "auto"
+    _attempt_seed = {
+        "attempt_id": _attempt_id,
+        "session_id": agent.session_id or "",
+        "trigger_source": _trigger_source,
+    }
     try:
         agent._compression_attempt_id = _attempt_id
-        setattr(agent.context_compressor, "_compression_telemetry_seed", {
-            "attempt_id": _attempt_id,
-            "session_id": agent.session_id or "",
-            "trigger_source": _trigger_source,
-        })
+        setattr(
+            agent.context_compressor,
+            "_compression_telemetry_seed",
+            dict(_attempt_seed),
+        )
     except Exception:
         pass
+    # Attribution scope for THIS attempt (context-local): overlapping workers
+    # share the compressor object, so the instance seed/telemetry slots above
+    # are last-writer-wins mirrors only. The context-local scope is what
+    # _begin_compression_telemetry and _emit_compression_attempt_telemetry
+    # read, keeping an aborted attempt's payload from carrying an overlapping
+    # attempt's attempt_id/aux fields.
+    try:
+        from agent.context_compressor import (
+            begin_compression_attempt_attribution,
+        )
+
+        begin_compression_attempt_attribution(_attempt_seed)
+    except Exception:
+        logger.debug(
+            "compression attempt attribution scope open failed", exc_info=True
+        )
 
     # Codex app-server sessions: the codex agent owns the real thread context;
     # Hermes' summarizer would only rewrite a local mirror without shrinking

--- a/tests/agent/test_compression_telemetry_attribution.py
+++ b/tests/agent/test_compression_telemetry_attribution.py
@@ -1,0 +1,325 @@
+"""Attempt telemetry attribution must survive overlapping workers.
+
+The compressor object is shared between overlapping compression attempts (a
+fence-cancelled worker stays alive on the pool while the host launches the
+next attempt), and the telemetry slots on it are last-writer-wins. Observed
+2026-08-28: aborted attempts emitted payloads carrying an OVERLAPPING
+attempt's ``attempt_id`` and aux fields (a qwen3-pinned attempt reporting a
+gpt-5.5 aux call, repeated attempt_ids with growing durations).
+
+Attribution is now context-local per attempt (``compress_context`` opens a
+scope; each pooled worker runs under its own copied context) with the
+instance slots kept only as last-attempt mirrors for legacy readers. These
+tests pin the attribution through abort/success interleavings.
+"""
+
+from __future__ import annotations
+
+import contextvars
+import json
+import logging
+import threading
+import time
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from agent.context_compressor import (
+    ContextCompressor,
+    begin_compression_attempt_attribution,
+    current_compression_attempt_telemetry,
+)
+from agent.conversation_compression import (
+    CompressionCommitFence,
+    _emit_compression_attempt_telemetry,
+    compress_context,
+)
+
+
+def _make_compressor():
+    with patch(
+        "agent.context_compressor.get_model_context_length", return_value=100_000
+    ):
+        return ContextCompressor(
+            model="test/main-model",
+            provider="test-provider",
+            threshold_percent=0.50,
+            quiet_mode=True,
+            config_context_length=100_000,
+        )
+
+
+def _bare_agent(compressor):
+    return SimpleNamespace(
+        context_compressor=compressor,
+        session_id="session-attr-test",
+        _compression_attempt_id="",
+    )
+
+
+def _payloads(caplog):
+    lines = [
+        record.getMessage()
+        for record in caplog.records
+        if "context compression attempt telemetry:" in record.getMessage()
+    ]
+    return [
+        json.loads(line.split("context compression attempt telemetry: ", 1)[1])
+        for line in lines
+    ]
+
+
+def _emit(agent, commit_status, failure_class=None):
+    _emit_compression_attempt_telemetry(
+        agent,
+        started_at=time.monotonic(),
+        commit_status=commit_status,
+        split_status="aborted" if commit_status == "aborted" else "not_applicable",
+        failure_class=failure_class,
+    )
+
+
+def _record_aux(compressor, provider, model, duration_ms):
+    compressor._record_aux_compression_call(
+        prompt_messages=[{"role": "user", "content": "prompt"}],
+        max_tokens=None,
+        duration_ms=duration_ms,
+        aux_provider=provider,
+        aux_model=model,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Deterministic interleaving across two attempt contexts, one compressor
+# ---------------------------------------------------------------------------
+
+
+def test_interleaved_attempts_keep_their_own_payloads(caplog):
+    compressor = _make_compressor()
+    agent = _bare_agent(compressor)
+    ctx_a = contextvars.copy_context()
+    ctx_b = contextvars.copy_context()
+
+    # A begins, then B begins (overwriting the shared instance mirrors), then
+    # BOTH record aux calls, then A aborts and B commits.
+    ctx_a.run(
+        begin_compression_attempt_attribution,
+        {"attempt_id": "attempt-a", "session_id": "s", "trigger_source": "manual"},
+    )
+    ctx_b.run(
+        begin_compression_attempt_attribution,
+        {"attempt_id": "attempt-b", "session_id": "s", "trigger_source": "auto"},
+    )
+    ctx_a.run(lambda: compressor._begin_compression_telemetry(current_tokens=100))
+    ctx_b.run(lambda: compressor._begin_compression_telemetry(current_tokens=200))
+    ctx_a.run(lambda: _record_aux(compressor, "prov-a", "model-a", 111))
+    ctx_b.run(lambda: _record_aux(compressor, "prov-b", "model-b", 222))
+
+    with caplog.at_level(logging.INFO, logger="agent.conversation_compression"):
+        ctx_a.run(
+            lambda: _emit(agent, "aborted", failure_class="commit_fence_cancelled")
+        )
+        ctx_b.run(lambda: _emit(agent, "committed"))
+
+    aborted, committed = _payloads(caplog)
+    assert aborted["attempt_id"] == "attempt-a"
+    assert aborted["trigger_source"] == "manual"
+    assert aborted["aux_provider"] == "prov-a"
+    assert aborted["aux_model"] == "model-a"
+    assert aborted["aux_call_duration_ms"] == 111
+    assert aborted["current_estimated_tokens"] == 100
+    assert aborted["failure_class"] == "commit_fence_cancelled"
+
+    assert committed["attempt_id"] == "attempt-b"
+    assert committed["trigger_source"] == "auto"
+    assert committed["aux_provider"] == "prov-b"
+    assert committed["aux_model"] == "model-b"
+    assert committed["aux_call_duration_ms"] == 222
+    assert committed["current_estimated_tokens"] == 200
+
+
+def test_pre_summary_abort_emits_its_own_seed_not_the_shared_slot(caplog):
+    """An abort that never began summary telemetry (fence refused before the
+    summary phase) must emit under its own identity, not whatever overlapping
+    attempt last wrote the shared mirror — the 'chunk_count:0 with a reused
+    attempt_id' log shape."""
+    compressor = _make_compressor()
+    compressor._last_compression_telemetry = {
+        "event": "compression_attempt",
+        "attempt_id": "other-overlapping-attempt",
+        "aux_model": "other-model",
+        "aux_provider": "other-provider",
+    }
+    agent = _bare_agent(compressor)
+    ctx = contextvars.copy_context()
+    ctx.run(
+        begin_compression_attempt_attribution,
+        {"attempt_id": "mine", "session_id": "s", "trigger_source": "auto"},
+    )
+
+    with caplog.at_level(logging.INFO, logger="agent.conversation_compression"):
+        ctx.run(lambda: _emit(agent, "aborted", failure_class="commit_fence_cancelled"))
+
+    (payload,) = _payloads(caplog)
+    assert payload["attempt_id"] == "mine"
+    assert payload.get("aux_model") != "other-model"
+    assert "other-provider" not in json.dumps(payload)
+
+
+def test_new_scope_resets_the_previous_attempts_telemetry():
+    """Executor threads are reused: opening a new attribution scope must drop
+    the previous attempt's telemetry so a pre-summary abort in the new
+    attempt cannot inherit it."""
+    compressor = _make_compressor()
+
+    def _scenario():
+        begin_compression_attempt_attribution(
+            {"attempt_id": "first", "session_id": "s", "trigger_source": "auto"}
+        )
+        compressor._begin_compression_telemetry(current_tokens=100)
+        assert current_compression_attempt_telemetry() is not None
+        begin_compression_attempt_attribution(
+            {"attempt_id": "second", "session_id": "s", "trigger_source": "auto"}
+        )
+        assert current_compression_attempt_telemetry() is None
+
+    contextvars.copy_context().run(_scenario)
+
+
+def test_unscoped_legacy_callers_still_read_the_shared_mirror(caplog):
+    compressor = _make_compressor()
+    compressor._last_compression_telemetry = {
+        "event": "compression_attempt",
+        "attempt_id": "legacy-attempt",
+    }
+    agent = _bare_agent(compressor)
+    ctx = contextvars.copy_context()
+    # Explicitly no scope (clears any residue from the test thread).
+    ctx.run(begin_compression_attempt_attribution, None)
+
+    with caplog.at_level(logging.INFO, logger="agent.conversation_compression"):
+        ctx.run(lambda: _emit(agent, "committed"))
+
+    (payload,) = _payloads(caplog)
+    assert payload["attempt_id"] == "legacy-attempt"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: two overlapping compress_context attempts, one aborts
+# ---------------------------------------------------------------------------
+
+
+class _TodoStore:
+    def format_for_injection(self):
+        return ""
+
+
+class _Agent:
+    def __init__(self, compressor):
+        self.context_compressor = compressor
+        self.session_id = "session-attr-e2e"
+        self.platform = "cli"
+        self.model = "test/main-model"
+        self.provider = "test-provider"
+        self.tools = []
+        self._compression_feasibility_checked = True
+        self.compression_in_place = False
+        self._memory_manager = None
+        self._session_db = None
+        self._todo_store = _TodoStore()
+        self._cached_system_prompt = None
+
+    def _emit_status(self, _message):
+        pass
+
+    def _emit_warning(self, _message):
+        pass
+
+    def _invalidate_system_prompt(self):
+        self._cached_system_prompt = None
+
+    def _build_system_prompt(self, system_message):
+        return system_message
+
+    def commit_memory_session(self, _messages):
+        pass
+
+
+def _long_messages():
+    msgs = [{"role": "system", "content": "system prompt"}]
+    for idx in range(10):
+        msgs.append({"role": "user", "content": f"user message {idx} " + "u" * 80})
+        msgs.append(
+            {"role": "assistant", "content": f"assistant reply {idx} " + "a" * 80}
+        )
+    return msgs
+
+
+def test_overlapping_compress_context_attempts_emit_distinct_attribution(caplog):
+    compressor = _make_compressor()
+    compressor.tail_token_budget = 10
+    agent = _Agent(compressor)
+
+    a_entered = threading.Event()
+    a_release = threading.Event()
+    call_lock = threading.Lock()
+    calls = {"n": 0}
+
+    def fake_generate(*_args, **_kwargs):
+        with call_lock:
+            calls["n"] += 1
+            n = calls["n"]
+        if n == 1:
+            a_entered.set()
+            assert a_release.wait(timeout=10)
+            return "SUMMARY A"
+        return "SUMMARY B"
+
+    fence_a = CompressionCommitFence()
+    fence_b = CompressionCommitFence()
+    result_a = {}
+
+    def run_a():
+        result_a["value"] = compress_context(
+            agent,
+            _long_messages(),
+            "system prompt",
+            approx_tokens=75_000,
+            force=True,  # trigger_source=manual marks attempt A's payload
+            commit_fence=fence_a,
+        )
+
+    with patch.object(compressor, "_generate_summary", side_effect=fake_generate):
+        with caplog.at_level(
+            logging.INFO, logger="agent.conversation_compression"
+        ):
+            thread_a = threading.Thread(target=run_a, name="attempt-a")
+            thread_a.start()
+            assert a_entered.wait(timeout=10)
+
+            # Attempt B (auto) starts and fully commits while A is still
+            # blocked in its summary phase.
+            compress_context(
+                agent,
+                _long_messages(),
+                "system prompt",
+                approx_tokens=75_000,
+                commit_fence=fence_b,
+            )
+
+            # A's host gives up; A's late commit must be refused.
+            assert fence_a.cancel_before_commit() is True
+            a_release.set()
+            thread_a.join(timeout=10)
+            assert not thread_a.is_alive()
+
+    payloads = _payloads(caplog)
+    assert len(payloads) == 2, payloads
+    aborted = [p for p in payloads if p.get("failure_class") == "commit_fence_cancelled"]
+    committed = [p for p in payloads if p.get("commit_status") == "committed"]
+    assert len(aborted) == 1 and len(committed) == 1, payloads
+
+    # The regression: pre-fix, the aborted attempt emitted the shared
+    # last-writer slot — attempt B's payload — so both attempt_ids matched.
+    assert aborted[0]["attempt_id"] != committed[0]["attempt_id"]
+    assert aborted[0]["trigger_source"] == "manual"
+    assert committed[0]["trigger_source"] == "auto"


### PR DESCRIPTION
## What does this PR do?

Fixes cross-attempt bleed in the `context compression attempt telemetry:` stream under overlapping compression attempts.

**Symptom.** The `ContextCompressor` object is shared between overlapping attempts: a fence-cancelled worker stays alive on the pool while the host launches the next attempt. `_compression_telemetry_seed` / `_active_compression_telemetry` / `_last_compression_telemetry` are instance attributes, i.e. last-writer-wins. An aborted attempt emitting from those slots can carry an *overlapping* attempt's `attempt_id` and aux fields — observed as repeated attempt_ids with monotonically growing `total_duration_ms`, and as an attempt whose summary call was pinned to the fallback route reporting the primary route's aux model in its payload. Downstream analysis of the telemetry (attempt dedup, per-route failure accounting) silently miscounts.

**Fix.** Attribution now lives in `ContextVar`s scoped to one attempt, complementing #96963's attempt-generation ownership (which protects compressor *state*; this protects telemetry *identity*):

- `begin_compression_attempt_attribution` opens a fresh scope (identity seed + cleared telemetry slot); `compress_context` calls it at entry, so executor-thread reuse cannot leak the previous attempt either. Pooled workers already run under per-attempt copied contexts (`propagate_context_to_thread`), giving isolation across overlaps.
- `_begin_compression_telemetry` seeds from the context scope and stores the attempt dict context-locally; `_record_compression_regions`, `_record_aux_compression_call`, and the aux-fallback marker write through `_current_attempt_telemetry` (context first, instance slot only for unscoped legacy callers).
- `_emit_compression_attempt_telemetry` prefers the attempt's context telemetry, then its identity seed (aborts that never reached the summary phase now emit their own `attempt_id` instead of borrowing the shared slot), and falls back to the instance mirror only when no scope exists. The pool-saturated refusal opens a minimal scope of its own.

The instance slots remain as last-attempt mirrors for external readers and tests; snapshot/restore semantics over them are unchanged, and unscoped legacy callers keep the historical behavior.

## Related Issue

Related: #96634, #96963 (overlapping-attempt lifecycle; no dedicated issue for the telemetry bleed)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/context_compressor.py` — `_COMPRESSION_ATTEMPT_SEED` / `_COMPRESSION_ATTEMPT_TELEMETRY` ContextVars, `begin_compression_attempt_attribution` / `current_compression_attempt_seed` / `current_compression_attempt_telemetry`, `_current_attempt_telemetry` resolution, context-first seeding in `_begin_compression_telemetry`, converted recorder sites
- `agent/conversation_compression.py` — `compress_context` opens the attribution scope at entry (instance seed kept as mirror); `_emit_compression_attempt_telemetry` context-first resolution; pool-saturated refusal emits under its own minimal scope
- `tests/agent/test_compression_telemetry_attribution.py` — new (aborted attempt emits its own attempt_id while an overlapping attempt owns the instance slots; recorder writes land in the owning attempt's payload; unscoped legacy callers still read the instance slots; scope reset on thread reuse)

## How to Test

1. `scripts/run_tests.sh tests/agent/test_compression_telemetry_attribution.py` — 5 tests
2. `scripts/run_tests.sh tests/agent/test_compression_attempt_telemetry.py tests/agent/test_compression_attempt_ownership.py` — existing telemetry/ownership invariants stay green
3. `scripts/run_tests.sh tests/agent/` — full agent suite
4. Repro shape without the fix: two overlapping attempts on one compressor (fence-cancel the first mid-summary, let the host start the second); the first attempt's abort telemetry line reports the second attempt's `attempt_id`/aux fields. With the fix, each line carries its own attempt's identity.

Tested on Linux x86_64 (Python 3.11). Full `tests/agent/` is green via `scripts/run_tests.sh` except `test_compression_review_76354.py::TestS3IdleChargedFromLastProgress::test_silence_cannot_approach_double_idle_timeout`, a timing-sensitive test that fails identically on pristine `main` on the same host (pre-existing, unrelated).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the test suite and all tests pass (one pre-existing timing-flaky test noted above)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux x86_64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings) — no user-facing docs affected
- [x] `cli-config.yaml.example` — N/A (no config keys added/changed)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered — ContextVars are platform-independent
- [x] Tool descriptions/schemas — N/A
