### PR TITLE
fix(tui): set process title in tui_gateway.entry so tmux shows 'hermes'

### DIFF
--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -10,6 +10,13 @@ import hermes_bootstrap
 
 hermes_bootstrap.harden_import_path()
 
+# Set process title so tmux/ps shows 'hermes' instead of 'python'
+try:
+    from hermes_cli.main import _set_process_title
+    _set_process_title()
+except Exception:
+    pass
+
 import json
 import logging
 import signal


### PR DESCRIPTION
## Summary

This PR fixes #97157 by calling `_set_process_title()` in `tui_gateway/entry.py` so the TUI gateway process shows as 'hermes' instead of 'python' in tmux window names and ps output.

## Problem

The TUI gateway process (`python -m tui_gateway.entry`) was showing as 'python' in:
- tmux window names
- `ps` output
- Process listings

This happened because `_set_process_title()` was only called in the main CLI entry point (`hermes_cli/main.py:13107`), not in the TUI gateway entry.

## Solution

Added `_set_process_title()` call to `tui_gateway/entry.py` after `hermes_bootstrap.harden_import_path()`:

```python
# Set process title so tmux/ps shows 'hermes' instead of 'python'
try:
    from hermes_cli.main import _set_process_title
    _set_process_title()
except Exception:
    pass
```

The call is wrapped in `try/except` to be non-fatal if:
- `setproctitle` is not installed
- Platform-specific fallback fails

## Changes

- Modified `tui_gateway/entry.py`: Added `_set_process_title()` call

## Testing

- ✅ Import and call works without errors
- ✅ Non-fatal on platforms without setproctitle

## Before/After

**Before:**
```
python .../venv/bin/python -m tui_gateway.entry  # Shows as "python"
```

**After:**
```
hermes .../venv/bin/python -m tui_gateway.entry  # Shows as "hermes"
```

---

🤖 Generated with Codebuff
Co-Authored-By: Codebuff <noreply@codebuff.com>