### PR TITLE
fix(cli): add UTF-8 encoding to subprocess calls in update check

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -297,7 +297,8 @@ def _check_via_local_git(repo_dir: Path) -> Optional[int]:
         # ref) so a stale ref can't fake an up-to-date report.
         ancestor = subprocess.run(
             ["git", "merge-base", "--is-ancestor", upstream_rev, "HEAD"],
-            capture_output=True, timeout=5, cwd=str(repo_dir),
+            capture_output=True, text=True, encoding="utf-8", errors="replace",
+            timeout=5, cwd=str(repo_dir),
         )
         if ancestor.returncode == 0:
             return 0
@@ -346,7 +347,8 @@ def _check_via_local_git(repo_dir: Path) -> Optional[int]:
         fetch_args.append("--quiet")
         fetch_proc = subprocess.run(
             fetch_args,
-            capture_output=True, timeout=10,
+            capture_output=True, text=True, encoding="utf-8", errors="replace",
+            timeout=10,
             cwd=str(repo_dir),
         )
         fetch_ok = fetch_proc.returncode == 0


### PR DESCRIPTION
## Summary

This PR fixes #97322 by adding UTF-8 encoding to subprocess calls in the update check that were missing encoding parameters, causing UnicodeDecodeError on Windows.

## Problem

Running `hermes --version` on Windows produced noisy tracebacks:
```
Exception in thread Thread-11 (_readerthread):
UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 74
```

The update check subprocess calls at lines 298 and 347 in `hermes_cli/banner.py` were missing `encoding="utf-8"`, so Python used the platform default (cp1252 on Windows). When git output contained UTF-8 characters (like emoji in commit subjects), the reader thread crashed.

## Solution

Added `text=True, encoding="utf-8", errors="replace"` to two subprocess.run calls:

1. **Line 298**: `git merge-base --is-ancestor` subprocess
2. **Line 347**: `git fetch` subprocess

These now match the encoding parameters already used by other subprocess calls in the same file (`_git_stdout`, `_upstream_main_sha`, etc.).

## Changes

- Modified `hermes_cli/banner.py`: Added encoding parameters to 2 subprocess calls

## Testing

- ✅ All other subprocess calls in the file already use `encoding="utf-8"`
- ✅ `errors="replace"` ensures no crashes even with malformed output

## Before/After

**Before:**
```
Exception in thread Thread-11 (_readerthread):
UnicodeDecodeError: 'charmap' codec can't decode byte 0x81...
Up to date
```

**After:**
```
Up to date
```

---

🤖 Generated with Codebuff
Co-Authored-By: Codebuff <noreply@codebuff.com>