### PR TITLE
fix(auth): return None for unrecognized tokens instead of 503 ProviderError

### DIFF
--- a/plugins/dashboard_auth/nous/__init__.py
+++ b/plugins/dashboard_auth/nous/__init__.py
@@ -436,6 +436,14 @@ class NousDashboardAuthProvider(DashboardAuthProvider):
             signing_key = self._get_jwks_client().get_signing_key_from_jwt(
                 access_token
             )
+        except jwt.DecodeError:
+            # Not a JWT at all (e.g. opaque session token from another provider).
+            # Return None so the middleware tries the next provider instead of
+            # reporting this one as unreachable (503).
+            return None
+        except jwt.InvalidTokenError:
+            # Malformed JWT header / unknown kid — also not this provider's token.
+            return None
         except jwt.PyJWKClientError as exc:
             raise ProviderError(f"JWKS lookup failed: {exc}") from exc
         except Exception as exc:  # pragma: no cover - defensive

--- a/plugins/dashboard_auth/self_hosted/__init__.py
+++ b/plugins/dashboard_auth/self_hosted/__init__.py
@@ -617,6 +617,14 @@ class SelfHostedOIDCProvider(DashboardAuthProvider):
             signing_key = self._get_jwks_client().get_signing_key_from_jwt(
                 id_token
             )
+        except jwt.DecodeError:
+            # Not a JWT at all (e.g. opaque session token from another provider).
+            # Return None so the middleware tries the next provider instead of
+            # reporting this one as unreachable (503).
+            return None
+        except jwt.InvalidTokenError:
+            # Malformed JWT header / unknown kid — also not this provider's token.
+            return None
         except jwt.PyJWKClientError as exc:
             raise ProviderError(f"JWKS lookup failed: {exc}") from exc
         except Exception as exc:  # pragma: no cover - defensive


### PR DESCRIPTION
## Summary

This PR fixes #97361 by properly handling unrecognized tokens in JWT dashboard-auth providers, returning 401 instead of 503 for stale/foreign session tokens.

## Problem

Both bundled JWT dashboard-auth providers (nous, self_hosted) were catching all exceptions from `get_signing_key_from_jwt` and raising `ProviderError`, including `DecodeError` for non-JWT tokens.

This caused stale/foreign session tokens to be reported as "IDP unreachable" (503) instead of "unrecognized token" (401), preventing client recovery.

**Example scenario:**
1. User signs in with basic_auth (gets opaque session token)
2. Operator switches to Nous Portal auth
3. User reloads without clearing cookies
4. Every request returns 503 "Auth provider 'nous' unreachable"
5. Login page is unreachable, Desktop retries forever

## Solution

Added specific exception handlers for `jwt.DecodeError` and `jwt.InvalidTokenError` that return `None` (unrecognized token) before the generic `Exception` handler that raises `ProviderError`.

This follows the provider contract in `base.py`:
- **Return `None`** for tokens this provider does NOT recognize
- **Raise `ProviderError`** ONLY for genuine backing-store outages

## Changes

- Modified `plugins/dashboard_auth/nous/__init__.py`: Added DecodeError/InvalidTokenError handlers
- Modified `plugins/dashboard_auth/self_hosted/__init__.py`: Added DecodeError/InvalidTokenError handlers

## Behavior After Fix

When a user has a stale session token from another provider:
1. The current provider returns `None` (not this provider's token)
2. The middleware tries the next provider
3. If no provider accepts, returns **401** (not 503)
4. The client redirects to `/login`

## Testing

- ✅ Non-JWT tokens now return None instead of raising ProviderError
- ✅ Genuine JWKS failures still raise ProviderError (503)
- ✅ Follows the documented provider contract in base.py

---

🤖 Generated with Codebuff
Co-Authored-By: Codebuff <noreply@codebuff.com>