### PR TITLE
fix(gateway): scope systemd service PIDs to current profile in gateway status

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -137,8 +137,17 @@ def _get_service_pids(all_profiles: bool = False) -> set:
     pids: set = set()
 
     # --- systemd (Linux): user and system scopes ---
-    # systemd always lists every hermes-gateway* unit regardless of scope.
+    # When all_profiles=False, only include PIDs belonging to the current profile.
     if supports_systemd_services():
+        # Determine the current profile's service name pattern
+        current_profile = None
+        if not all_profiles:
+            try:
+                from hermes_cli.profiles import get_active_profile_name
+                current_profile = get_active_profile_name()
+            except Exception:
+                pass
+        
         for scope_args in [["systemctl", "--user"], ["systemctl"]]:
             try:
                 result = subprocess.run(
@@ -159,6 +168,21 @@ def _get_service_pids(all_profiles: bool = False) -> set:
                     if not parts or not parts[0].endswith(".service"):
                         continue
                     svc = parts[0]
+                    
+                    # When not all_profiles, skip services that don't match current profile
+                    if current_profile and not all_profiles:
+                        # Service name format: hermes-gateway-<profile>.service or hermes-gateway.service (default)
+                        expected_suffix = f"-{current_profile}.service"
+                        is_default_profile = current_profile == "default"
+                        if is_default_profile:
+                            # Default profile: only accept hermes-gateway.service (no suffix)
+                            if svc != "hermes-gateway.service":
+                                continue
+                        else:
+                            # Named profile: only accept hermes-gateway-<profile>.service
+                            if not svc.endswith(expected_suffix):
+                                continue
+                    
                     try:
                         show = subprocess.run(
                             scope_args + ["show", svc, "--property=MainPID", "--value"],


### PR DESCRIPTION
## Summary

This PR fixes #97360 by properly scoping systemd service PIDs to the current profile in `gateway status`.

## Problem

`hermes -p <profile> gateway status` was reporting other profiles' PIDs and claiming the named profile's gateway was running, even when it had no gateway.

**Example:**
```
$ hermes -p it-ops gateway status
✓ Gateway is running (PID: 2081267, 2061253)
```

But PIDs 2081267 and 2061253 belong to `default` and `fte-manager` profiles, not `it-ops`.

## Root Cause

The `_get_service_pids` function's systemd branch was always returning PIDs from **ALL** `hermes-gateway*` units, even when `all_profiles=False`. The comment said "systemd always lists every hermes-gateway* unit regardless of scope" — this was the bug.

## Solution

Filter systemd services by the current profile when `all_profiles=False`:

- **Default profile**: Only accept `hermes-gateway.service` (no suffix)
- **Named profiles**: Only accept `hermes-gateway-<profile>.service`

This matches the behavior of the launchd branch (macOS) which already filters by profile.

## Changes

- Modified `hermes_cli/gateway.py`: Added profile filtering to systemd branch in `_get_service_pids`

## Behavior After Fix

**Before:**
```
$ hermes -p it-ops gateway status
✓ Gateway is running (PID: 2081267, 2061253)  # Wrong! These are other profiles
```

**After:**
```
$ hermes -p it-ops gateway status
✗ Gateway is not running  # Correct!
```

## Testing

- ✅ Default profile: only accepts `hermes-gateway.service`
- ✅ Named profiles: only accepts `hermes-gateway-<profile>.service`
- ✅ `all_profiles=True`: still returns all PIDs (for `hermes update`)

---

🤖 Generated with Codebuff
Co-Authored-By: Codebuff <noreply@codebuff.com>