### PR TITLE
fix(kanban): reject phantom worker reviewers

### DIFF
--- a/hermes_cli/kanban_diagnostics.py
+++ b/hermes_cli/kanban_diagnostics.py
@@ -1003,9 +1003,10 @@ def _rule_stranded_in_ready(task, events, runs, now, cfg) -> list[Diagnostic]:
     # Find the most recent event that put this task into ready.
     # ``created`` covers tasks born ready; ``promoted`` covers parent-
     # done auto-promotion; ``reclaimed`` covers TTL/crash recovery;
-    # ``unblocked`` covers human-driven resumes.
+    # ``unblocked`` covers human-driven resumes; ``review_reopened`` covers
+    # review self-heal reopening a card for a fresh dispatch attempt.
     READY_TRANSITION_KINDS = {
-        "created", "promoted", "reclaimed", "unblocked",
+        "created", "promoted", "reclaimed", "unblocked", "review_reopened",
     }
     last_ready_ts = 0
     for ev in events:

--- a/tests/hermes_cli/test_kanban_diagnostics.py
+++ b/tests/hermes_cli/test_kanban_diagnostics.py
@@ -198,6 +198,26 @@ def test_stranded_in_ready_fires_when_age_exceeds_threshold():
     assert stranded[0].data["assignee"] == "demo"
 
 
+def test_stranded_in_ready_uses_review_reopened_as_fresh_ready_transition():
+    now = 100_000
+    threshold = 30 * 60
+    task = _task(status="ready", assignee="builder", claim_lock=None)
+    events = [
+        _event("created", ts=now - 9 * 60 * 60),
+        _event("review_reopened", ts=now - 1),
+    ]
+
+    fresh = kd.compute_task_diagnostics(task, events, [], now=now)
+    assert not [d for d in fresh if d.kind == "stranded_in_ready"]
+
+    stale = kd.compute_task_diagnostics(
+        task, events, [], now=now + threshold + 1
+    )
+    stranded = [d for d in stale if d.kind == "stranded_in_ready"]
+    assert len(stranded) == 1
+    assert stranded[0].data["age_seconds"] == threshold + 2
+
+
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_review_lifecycle_complete.py
+++ b/tests/hermes_cli/test_kanban_review_lifecycle_complete.py
@@ -68,6 +68,24 @@ def _claimed_review(
     return task_id, review
 
 
+def test_direct_request_review_allows_external_human_lane(conn):
+    task_id = kb.create_task(conn, title="External review", assignee="builder")
+    implementation = kb.claim_task(conn, task_id, claimer="builder:external")
+    assert implementation is not None
+
+    assert kb.request_review(
+        conn,
+        task_id,
+        reviewer="external-human-lane",
+        summary="Ready for external review.",
+        expected_run_id=implementation.current_run_id,
+    )
+    task = kb.get_task(conn, task_id)
+    assert task is not None
+    assert task.status == "review"
+    assert task.assignee == "external-human-lane"
+
+
 def test_same_card_review_supports_changes_and_approval_without_block_loop(conn):
     task_id = kb.create_task(conn, title="Implement guarded export", assignee="builder")
     implementation = kb.claim_task(conn, task_id, claimer="builder:1")

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -160,6 +160,77 @@ def test_complete_retry_with_empty_created_cards_succeeds(worker_env):
         conn.close()
 
 
+def test_request_review_rejects_missing_profile_without_mutation(
+    monkeypatch, worker_env, tmp_path
+):
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    profiles_root = tmp_path / ".hermes" / "profiles"
+    (profiles_root / "verifier").mkdir(parents=True)
+    before_conn = kb.connect()
+    try:
+        before_task = kb.get_task(before_conn, worker_env)
+        assert before_task is not None
+        before_runs = kb.list_runs(before_conn, worker_env)
+        before_events = kb.list_events(before_conn, worker_env)
+    finally:
+        before_conn.close()
+    monkeypatch.setenv(
+        "HERMES_KANBAN_RUN_ID", str(before_task.current_run_id)
+    )
+
+    out = json.loads(kt._handle_request_review({
+        "summary": "Ready for review.",
+        "reviewer": "reviewer",
+    }))
+
+    assert "error" in out
+    assert "reviewer" in out["error"]
+    assert "verifier" in out["error"]
+    after_conn = kb.connect()
+    try:
+        after_task = kb.get_task(after_conn, worker_env)
+        assert after_task is not None
+        assert after_task.status == before_task.status == "running"
+        assert after_task.assignee == before_task.assignee == "test-worker"
+        assert after_task.current_run_id == before_task.current_run_id
+        assert kb.list_runs(after_conn, worker_env) == before_runs
+        assert kb.list_events(after_conn, worker_env) == before_events
+    finally:
+        after_conn.close()
+
+
+def test_request_review_accepts_installed_profile(monkeypatch, worker_env, tmp_path):
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    profiles_root = tmp_path / ".hermes" / "profiles"
+    (profiles_root / "verifier").mkdir(parents=True)
+    conn = kb.connect()
+    try:
+        running = kb.get_task(conn, worker_env)
+        assert running is not None
+    finally:
+        conn.close()
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(running.current_run_id))
+
+    out = json.loads(kt._handle_request_review({
+        "summary": "Ready for review.",
+        "reviewer": "verifier",
+    }))
+
+    assert out["ok"] is True
+    conn = kb.connect()
+    try:
+        task = kb.get_task(conn, worker_env)
+        assert task is not None
+        assert task.status == "review"
+        assert task.assignee == "verifier"
+    finally:
+        conn.close()
+
+
 def test_complete_goal_mode_rejected_by_judge(monkeypatch, tmp_path):
     """Goal-mode tasks must pass the auxiliary judge before completion.
     Regression for #38367: workers bypassing the judge via early kanban_complete."""

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -932,6 +932,14 @@ def _handle_request_review(args: dict, **kw) -> str:
         # Model-supplied free text stored durably on the event payload —
         # redact like summary / kanban_block's reason.
         reviewer = redact_sensitive_text(str(reviewer), force=True)
+        from hermes_cli.profiles import list_profile_names, profile_exists
+
+        if not profile_exists(reviewer):
+            alternatives = ", ".join(list_profile_names()) or "none"
+            return tool_error(
+                f"reviewer profile {reviewer!r} is not installed. "
+                f"Installed profiles: {alternatives}"
+            )
     board = args.get("board")
     try:
         kb, conn = _connect(board=board)


### PR DESCRIPTION
## What

- Reject explicit `kanban_request_review(reviewer=...)` values that are not installed Hermes profiles.
- Preserve permissive lower-level `request_review()` behavior for deliberate external or human lanes.
- Treat `review_reopened` as a fresh ready transition for stranded-ready diagnostics.

## Why

A worker can currently park a card on a nonexistent reviewer indefinitely. When self-heal reopens that card, the ready-age diagnostic anchors to task creation and immediately reports a false hours-old critical.

## Regression proof

Before the fix:

- `test_request_review_rejects_missing_profile_without_mutation` fails because the tool moves the card to review.
- `test_stranded_in_ready_uses_review_reopened_as_fresh_ready_transition` fails because the diagnostic reports nine hours ready immediately after reopen.

After the fix, both pass. The suite also proves an installed `verifier` profile works and direct `request_review(... reviewer="external-human-lane")` remains allowed.

## Verification

- `scripts/run_tests.sh tests/tools/test_kanban_tools.py tests/hermes_cli/test_kanban_diagnostics.py tests/hermes_cli/test_kanban_review_lifecycle_complete.py -q -p no:randomly` -> 63 passed
- Ruff on all five changed files -> passed
- `git diff --check` -> passed

Related: #92349 fixes implicit reviewer selection only; this PR covers explicit worker-tool validation and reopen diagnostics.