### PR TITLE
fix(desktop): preserve two-space Markdown hard breaks in preprocessing

### DIFF
--- a/apps/desktop/src/lib/markdown-preprocess.ts
+++ b/apps/desktop/src/lib/markdown-preprocess.ts
@@ -664,7 +664,7 @@ export function preprocessMarkdown(text: string): string {
       return leading + transformed + trailing
     })
     .join('')
-    .replace(/[ \t]+\n/g, '\n')
+    .replace(/(?<![ \t])[ \t]\n/g, '\n')
 }
 
 /**


### PR DESCRIPTION
## Summary

This PR fixes #97117 by preserving two-space Markdown hard line breaks in the Desktop markdown preprocessor.

## Problem

The `preprocessMarkdown()` function was removing all trailing whitespace before newlines with regex `/[ \t]+\n/g`, which broke Markdown hard line breaks (two spaces before newline).

**Example:**
```
Input: "First line  \nSecond line"  (two spaces = hard break)
Output: "First line\nSecond line"   (spaces removed)
Result: Lines render as one paragraph instead of two lines
```

## Solution

Changed the regex from `/[ \t]+\n/g` to `/(?<![ \t])[ \t]\n/g`:

- **Before**: Removes ALL trailing whitespace before newlines
- **After**: Only removes single trailing space/tab, preserving two+ spaces that indicate hard breaks

This follows CommonMark semantics:
- Two or more spaces before newline = hard line break (preserve)
- Single space before newline = insignificant whitespace (remove)

## Changes

- Modified `apps/desktop/src/lib/markdown-preprocess.ts`: Changed regex to preserve hard breaks

## Before/After

**Before:**
```
"First line  \nSecond line" → "First line\nSecond line" → One paragraph
```

**After:**
```
"First line  \nSecond line" → "First line  \nSecond line" → Two lines
```

---

🤖 Generated with Codebuff
Co-Authored-By: Codebuff <noreply@codebuff.com>