### PR TITLE
fix(desktop): exempt 'main' alias from stale-aux banner check

### DIFF
--- a/apps/desktop/src/app/settings/model-settings.tsx
+++ b/apps/desktop/src/app/settings/model-settings.tsx
@@ -501,7 +501,7 @@ export function ModelSettings({ onMainModelChanged, scopeProfile }: ModelSetting
       .filter(entry => {
         const p = (entry.provider ?? '').toLowerCase()
 
-        return p && p !== 'auto' && p !== mainProvider
+        return p && p !== 'auto' && p !== 'main' && p !== mainProvider
       })
       .map(entry => ({ task: entry.task, provider: entry.provider, model: entry.model }))
   }, [auxiliary, mainModel])


### PR DESCRIPTION
## Summary

This PR fixes #97310 by exempting the 'main' alias from the stale auxiliary task banner check.

## Problem

The stale auxiliary task banner was showing a false warning when the auxiliary provider was set to `'main'`:

```
⚠ 1 auxiliary task (vision) still run on main, not your main model.
```

The `'main'` alias is a valid configuration meaning "follow the current main provider" (e.g., Moonshot's official guide uses `provider: main`). The filter exempted `''` and `'auto'` but not `'main'`, causing a correct configuration to trigger a warning.

## Solution

Added `p !== 'main'` to the filter condition:

```typescript
// Before:
return p && p !== 'auto' && p !== mainProvider

// After:
return p && p !== 'auto' && p !== 'main' && p !== mainProvider
```

Now `'main'` is treated the same as `'auto'` — both mean the task follows the main provider and should not be flagged as stale.

## Changes

- Modified `apps/desktop/src/app/settings/model-settings.tsx`: Added `'main'` to stale-aux exemptions

---

🤖 Generated with Codebuff
Co-Authored-By: Codebuff <noreply@codebuff.com>