### PR TITLE
fix(process): reconcile terminal watch notifications

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -13062,6 +13062,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 continue
             self._pending_input.put(synthetic_message)
             complete_event_delivery(event, claim)
+            process_registry.mark_notification_delivered(event)
 
     def _drain_interrupt_queue_to_pending_input(self) -> None:
         """Move stray messages from ``_interrupt_queue`` into ``_pending_input``.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3950,12 +3950,22 @@ def _format_gateway_process_notification(evt: dict) -> "str | None":
         _pat = evt.get("pattern", "?")
         _out = evt.get("output", "")
         _sup = evt.get("suppressed", 0)
-        text = (
-            f"[IMPORTANT: Background process {_sid} matched "
-            f"watch pattern \"{_pat}\".\n"
-            f"Command: {_cmd}\n"
-            f"Matched output:\n{_out}"
-        )
+        if evt.get("lifecycle_alert") == "post_cleanup_listener":
+            ports = ", ".join(str(p) for p in evt.get("cleanup_open_ports", []))
+            text = (
+                f"[IMPORTANT: Background process {_sid} was intentionally terminated, "
+                f"but its declared loopback port(s) {ports or '?'} remain open or were "
+                f"rebound; cleanup/restart state requires attention.\n"
+                f"Historical watch pattern: \"{_pat}\".\n"
+                f"Command: {_cmd}\nMatched output:\n{_out}"
+            )
+        else:
+            text = (
+                f"[IMPORTANT: Background process {_sid} matched "
+                f"watch pattern \"{_pat}\".\n"
+                f"Command: {_cmd}\n"
+                f"Matched output:\n{_out}"
+            )
         if _sup:
             text += f"\n({_sup} earlier matches were suppressed by rate limit)"
         text += "]"
@@ -3993,7 +4003,9 @@ def _drain_gateway_watch_events(completion_queue) -> "list[dict]":
             "watch_overflow_tripped",
             "watch_overflow_released",
         }:
-            watch_events.append(evt)
+            from tools.process_registry import process_registry
+            if process_registry.is_notification_actionable(evt):
+                watch_events.append(evt)
         elif evt_type == "async_delegation":
             requeue.append(evt)
         # else: process completion events are handled by the watcher task
@@ -25741,7 +25753,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if not synth_text:
                 continue
             try:
-                await self._inject_watch_notification(synth_text, evt)
+                accepted = await self._inject_watch_notification(synth_text, evt)
+                if accepted is True:
+                    from tools.process_registry import process_registry
+                    process_registry.mark_notification_delivered(evt)
             except Exception as exc:
                 logger.error("Watch notification injection error: %s", exc)
 

--- a/tests/tools/test_process_notification_lifecycle.py
+++ b/tests/tools/test_process_notification_lifecycle.py
@@ -1,0 +1,352 @@
+"""Regression coverage for durable process-notification reconciliation."""
+
+import time
+from unittest.mock import patch
+
+import pytest
+
+from tools.process_registry import ProcessRegistry, ProcessSession
+
+
+def _registry(tmp_path):
+    state_path = tmp_path / "process_notification_state.sqlite3"
+    with patch("tools.process_registry.NOTIFICATION_STATE_PATH", state_path):
+        return ProcessRegistry()
+
+
+def _session(
+    sid: str,
+    *,
+    started_at: float,
+    command: str = "python -m http.server 4312",
+    exited: bool = False,
+    termination_source: str = "",
+    completion_reason: str = "exited",
+):
+    return ProcessSession(
+        id=sid,
+        command=command,
+        task_id="evaluation",
+        session_key="desktop-session",
+        started_at=started_at,
+        exited=exited,
+        exit_code=-15 if exited else None,
+        termination_source=termination_source,
+        completion_reason=completion_reason,
+        output_buffer="Local: http://127.0.0.1:4312/\n",
+    )
+
+
+def _watch_event(session, *, sequence=1, output="Local: http://127.0.0.1:4312/"):
+    return {
+        "type": "watch_match",
+        "event_id": (
+            f"watch:{session.id}:{int(session.started_at * 1_000_000)}:{sequence}"
+        ),
+        "session_id": session.id,
+        "started_at": session.started_at,
+        "session_key": session.session_key,
+        "command": session.command,
+        "pattern": "Local:",
+        "output": output,
+    }
+
+
+def _register(registry, session):
+    target = registry._finished if session.exited else registry._running
+    target[session.id] = session
+
+
+@pytest.mark.parametrize(
+    "process_id",
+    ["proc_6ea6744be486", "proc_fb4cddce1ea3", "proc_b9a4d9c996c4"],
+)
+def test_intentional_cleanup_with_closed_port_suppresses_late_readiness(
+    tmp_path, monkeypatch, process_id
+):
+    registry = _registry(tmp_path)
+    session = _session(
+        process_id,
+        started_at=1000.0,
+        exited=True,
+        termination_source="process.kill",
+        completion_reason="killed",
+    )
+    _register(registry, session)
+    event = _watch_event(session)
+    monkeypatch.setattr(registry, "_open_loopback_ports", lambda _event, _session=None: [])
+
+    registry.observe_notification(event)
+    registry.reconcile_process_notifications(session)
+
+    assert registry.is_notification_actionable(event) is False
+
+
+def test_later_polling_pass_suppresses_same_terminal_event(tmp_path, monkeypatch):
+    registry = _registry(tmp_path)
+    session = _session(
+        "proc_poll_later",
+        started_at=1001.0,
+        exited=True,
+        termination_source="process.kill",
+        completion_reason="killed",
+    )
+    _register(registry, session)
+    event = _watch_event(session)
+    monkeypatch.setattr(registry, "_open_loopback_ports", lambda _event, _session=None: [])
+
+    registry.observe_notification(event)
+    registry.reconcile_process_notifications(session)
+
+    assert not registry.is_notification_actionable(dict(event))
+    assert not registry.is_notification_actionable(dict(event))
+
+
+def test_event_queued_before_cleanup_is_reconciled_before_delivery(tmp_path, monkeypatch):
+    registry = _registry(tmp_path)
+    session = _session("proc_delayed", started_at=1002.0)
+    _register(registry, session)
+    event = _watch_event(session)
+    registry.observe_notification(event)
+    assert registry.is_notification_actionable(event)
+
+    registry._running.pop(session.id)
+    session.exited = True
+    session.exit_code = -15
+    session.completion_reason = "killed"
+    session.termination_source = "process.kill"
+    registry._finished[session.id] = session
+    monkeypatch.setattr(registry, "_open_loopback_ports", lambda _event, _session=None: [])
+    registry.reconcile_process_notifications(session)
+
+    assert not registry.is_notification_actionable(event)
+
+
+def test_delivered_event_dedupes_across_independent_registry_instances(tmp_path):
+    registry = _registry(tmp_path)
+    session = _session("proc_repeat", started_at=1003.0)
+    _register(registry, session)
+    event = _watch_event(session)
+    registry.observe_notification(event)
+    assert registry.is_notification_actionable(event)
+    registry.mark_notification_delivered(event)
+
+    restarted = _registry(tmp_path)
+    assert not restarted.is_notification_actionable(dict(event))
+
+
+def test_unexpected_process_death_during_active_run_still_alerts(tmp_path):
+    registry = _registry(tmp_path)
+    session = _session(
+        "proc_unexpected",
+        started_at=1004.0,
+        exited=True,
+        termination_source="",
+        completion_reason="exited",
+    )
+    session.exit_code = 1
+    _register(registry, session)
+    event = _watch_event(session)
+    registry.observe_notification(event)
+
+    assert registry.is_notification_actionable(event)
+
+
+def test_intentional_kill_with_open_readiness_port_alerts_cleanup_defect(tmp_path, monkeypatch):
+    registry = _registry(tmp_path)
+    session = _session(
+        "proc_leaked_port",
+        started_at=1005.0,
+        exited=True,
+        termination_source="process.kill",
+        completion_reason="killed",
+    )
+    _register(registry, session)
+    event = _watch_event(session)
+    registry.observe_notification(event)
+    monkeypatch.setattr(registry, "_open_loopback_ports", lambda _event, _session=None: [4312])
+
+    assert registry.is_notification_actionable(event)
+    assert event["lifecycle_alert"] == "post_cleanup_listener"
+    assert event["cleanup_open_ports"] == [4312]
+
+    from tools.process_registry import format_process_notification
+
+    text = format_process_notification(event)
+    assert text is not None
+    assert "remain open or were rebound" in text
+    assert "4312" in text
+
+
+def test_new_run_of_same_application_is_independently_eligible(tmp_path, monkeypatch):
+    registry = _registry(tmp_path)
+    old = _session(
+        "proc_old_run",
+        started_at=1006.0,
+        exited=True,
+        termination_source="process.kill",
+        completion_reason="killed",
+    )
+    _register(registry, old)
+    old_event = _watch_event(old)
+    registry.observe_notification(old_event)
+    monkeypatch.setattr(registry, "_open_loopback_ports", lambda _event, _session=None: [])
+    registry.reconcile_process_notifications(old)
+    assert not registry.is_notification_actionable(old_event)
+
+    new = _session("proc_new_run", started_at=1007.0)
+    _register(registry, new)
+    new_event = _watch_event(new)
+    registry.observe_notification(new_event)
+    assert registry.is_notification_actionable(new_event)
+
+
+def test_different_applications_do_not_dedupe_each_other(tmp_path):
+    registry = _registry(tmp_path)
+    first = _session("proc_app_a", started_at=1008.0, command="app-a --port 4312")
+    second = _session("proc_app_b", started_at=1008.0, command="app-b --port 4312")
+    _register(registry, first)
+    _register(registry, second)
+    first_event = _watch_event(first)
+    second_event = _watch_event(second)
+    registry.observe_notification(first_event)
+    registry.observe_notification(second_event)
+    registry.mark_notification_delivered(first_event)
+
+    assert not registry.is_notification_actionable(first_event)
+    assert registry.is_notification_actionable(second_event)
+
+
+def test_terminal_run_state_survives_registry_reload(tmp_path, monkeypatch):
+    registry = _registry(tmp_path)
+    session = _session(
+        "proc_persisted_terminal",
+        started_at=1009.0,
+        exited=True,
+        termination_source="process.kill",
+        completion_reason="killed",
+    )
+    _register(registry, session)
+    event = _watch_event(session)
+    registry.observe_notification(event)
+    monkeypatch.setattr(registry, "_open_loopback_ports", lambda _event, _session=None: [])
+    registry.reconcile_process_notifications(session)
+
+    restarted = _registry(tmp_path)
+    assert not restarted.is_notification_actionable(dict(event))
+
+
+def test_reused_process_id_with_new_spawn_epoch_is_not_suppressed(tmp_path, monkeypatch):
+    registry = _registry(tmp_path)
+    old = _session(
+        "proc_reused",
+        started_at=1010.0,
+        exited=True,
+        termination_source="process.kill",
+        completion_reason="killed",
+    )
+    _register(registry, old)
+    old_event = _watch_event(old)
+    registry.observe_notification(old_event)
+    monkeypatch.setattr(registry, "_open_loopback_ports", lambda _event, _session=None: [])
+    registry.reconcile_process_notifications(old)
+
+    replacement = _session("proc_reused", started_at=1011.0)
+    registry._finished.pop(old.id)
+    _register(registry, replacement)
+    replacement_event = _watch_event(replacement)
+    registry.observe_notification(replacement_event)
+
+    assert registry.is_notification_actionable(replacement_event)
+
+
+def test_intentional_cleanup_does_not_suppress_requested_completion_summary(
+    tmp_path, monkeypatch
+):
+    registry = _registry(tmp_path)
+    session = _session(
+        "proc_bulk_cleanup",
+        started_at=1012.0,
+        exited=True,
+        termination_source="kill_all",
+        completion_reason="killed",
+    )
+    _register(registry, session)
+    monkeypatch.setattr(registry, "_open_loopback_ports", lambda _event, _session=None: [])
+    registry.reconcile_process_notifications(session)
+    completion = {
+        "type": "completion",
+        "session_id": session.id,
+        "started_at": session.started_at,
+        "command": session.command,
+        "exit_code": -15,
+        "completion_reason": "killed",
+        "termination_source": "kill_all",
+        "output": session.output_buffer,
+    }
+    registry.observe_notification(completion)
+
+    assert registry.is_notification_actionable(completion)
+
+
+def test_remote_namespace_cleanup_is_not_certified_by_host_port_probe(
+    tmp_path, monkeypatch
+):
+    registry = _registry(tmp_path)
+    session = _session(
+        "proc_remote_cleanup",
+        started_at=1013.0,
+        exited=True,
+        termination_source="process.kill",
+        completion_reason="killed",
+    )
+    session.pid_scope = "sandbox"
+    _register(registry, session)
+    event = _watch_event(session)
+    registry.observe_notification(event)
+    monkeypatch.setattr(registry, "_open_loopback_ports", lambda _event, _session=None: [4312])
+
+    assert registry.reconcile_process_notifications(session) is False
+    assert registry.is_notification_actionable(event)
+    assert "lifecycle_alert" not in event
+
+
+def test_terminal_run_does_not_suppress_non_readiness_watch_event(
+    tmp_path, monkeypatch
+):
+    registry = _registry(tmp_path)
+    session = _session(
+        "proc_mixed_watch_events",
+        started_at=1014.0,
+        exited=True,
+        termination_source="process.kill",
+        completion_reason="killed",
+    )
+    _register(registry, session)
+    readiness = _watch_event(session, sequence=1)
+    build_complete = _watch_event(session, sequence=2, output="BUILD COMPLETE")
+    build_complete["pattern"] = "BUILD COMPLETE"
+    registry.observe_notification(readiness)
+    registry.observe_notification(build_complete)
+    monkeypatch.setattr(registry, "_open_loopback_ports", lambda _event, _session=None: [])
+
+    assert registry.reconcile_process_notifications(session) is True
+    assert registry.is_notification_actionable(readiness) is False
+    assert registry.is_notification_actionable(build_complete) is True
+
+
+def test_loopback_endpoint_parser_supports_ipv4_localhost_and_ipv6():
+    text = " ".join(
+        [
+            "http://127.0.0.1:4312/",
+            "http://localhost:4313/",
+            "http://[::1]:4314/",
+            "https://example.com:4315/",
+        ]
+    )
+
+    assert ProcessRegistry._loopback_endpoints(text) == [
+        ("127.0.0.1", 4312),
+        ("localhost", 4313),
+        ("::1", 4314),
+    ]

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -34,8 +34,11 @@ import json
 import logging
 import os
 import platform
+import re
 import shlex
 import signal
+import socket
+import sqlite3
 import subprocess
 import threading
 import time
@@ -57,6 +60,8 @@ logger = logging.getLogger(__name__)
 
 # Checkpoint file for crash recovery (gateway only)
 CHECKPOINT_PATH = get_hermes_home() / "processes.json"
+NOTIFICATION_STATE_PATH = get_hermes_home() / "process_notification_state.sqlite3"
+NOTIFICATION_STATE_TTL_SECONDS = 7 * 24 * 60 * 60
 
 # Limits
 MAX_OUTPUT_CHARS = 200_000      # 200KB rolling output buffer
@@ -487,6 +492,14 @@ class ProcessRegistry:
         # consults this set; the gateway/tui watchers deliberately do NOT.
         self._poll_observed: set = set()
 
+        # Durable lifecycle state for process notifications.  The queue itself
+        # is intentionally in-memory, but a delayed/replayed event can outlive
+        # the process that produced it (or even this registry instance).  SQLite
+        # gives independent gateway/cron processes one atomic reconciliation
+        # source without turning processes.json into a mixed live/history file.
+        self._notification_state_path = Path(NOTIFICATION_STATE_PATH)
+        self._init_notification_state()
+
         # Global watch-match circuit breaker — across all sessions.
         # Prevents sibling processes from collectively flooding the user even
         # when each stays under its own per-session cap.
@@ -512,6 +525,285 @@ class ProcessRegistry:
         while lines and any(noise in lines[0] for noise in ProcessRegistry._SHELL_NOISE_SUBSTRINGS):
             lines.pop(0)
         return "\n".join(lines)
+
+    # ----- Durable process-notification lifecycle -----
+
+    @staticmethod
+    def _notification_run_identity(value: Any) -> str:
+        """Return the stable process-incarnation identity carried by an event/session."""
+        if isinstance(value, dict):
+            session_id = str(value.get("session_id") or "")
+            started_at = value.get("started_at")
+        else:
+            session_id = str(getattr(value, "id", "") or "")
+            started_at = getattr(value, "started_at", None)
+        if not session_id or started_at is None:
+            return ""
+        try:
+            spawn_epoch_us = int(float(started_at) * 1_000_000)
+        except (TypeError, ValueError, OverflowError):
+            return ""
+        return f"{session_id}:{spawn_epoch_us}"
+
+    @staticmethod
+    def _notification_event_identity(event: dict) -> str:
+        """Return producer-stable event identity; legacy watch events fail open."""
+        event_id = str(event.get("event_id") or "")
+        if event_id:
+            return event_id
+        if event.get("type") == "completion":
+            run_id = ProcessRegistry._notification_run_identity(event)
+            return f"completion:{run_id}" if run_id else ""
+        return ""
+
+    def _notification_db(self):
+        self._notification_state_path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(str(self._notification_state_path), timeout=5.0)
+        conn.execute("PRAGMA busy_timeout = 5000")
+        return conn
+
+    def _init_notification_state(self) -> None:
+        """Create and prune the small cross-process lifecycle ledger."""
+        try:
+            with self._notification_db() as conn:
+                conn.executescript(
+                    """
+                    CREATE TABLE IF NOT EXISTS process_notification_runs (
+                        run_id TEXT PRIMARY KEY,
+                        status TEXT NOT NULL,
+                        reason TEXT NOT NULL DEFAULT '',
+                        updated_at REAL NOT NULL
+                    );
+                    CREATE TABLE IF NOT EXISTS process_notification_events (
+                        event_id TEXT PRIMARY KEY,
+                        run_id TEXT NOT NULL,
+                        status TEXT NOT NULL,
+                        readiness INTEGER NOT NULL DEFAULT 0,
+                        reason TEXT NOT NULL DEFAULT '',
+                        updated_at REAL NOT NULL
+                    );
+                    CREATE INDEX IF NOT EXISTS idx_process_notification_events_run
+                    ON process_notification_events(run_id);
+                    """
+                )
+                event_columns = {
+                    row[1]
+                    for row in conn.execute("PRAGMA table_info(process_notification_events)")
+                }
+                if "readiness" not in event_columns:
+                    conn.execute(
+                        "ALTER TABLE process_notification_events "
+                        "ADD COLUMN readiness INTEGER NOT NULL DEFAULT 0"
+                    )
+                cutoff = time.time() - NOTIFICATION_STATE_TTL_SECONDS
+                conn.execute(
+                    "DELETE FROM process_notification_events WHERE updated_at < ?",
+                    (cutoff,),
+                )
+                conn.execute(
+                    "DELETE FROM process_notification_runs WHERE updated_at < ?",
+                    (cutoff,),
+                )
+        except Exception as exc:
+            logger.warning("Could not initialize process notification state: %s", exc)
+
+    def observe_notification(self, event: dict) -> None:
+        """Persist an observation without reviving terminal/delivered state."""
+        event_id = self._notification_event_identity(event)
+        run_id = self._notification_run_identity(event)
+        if not event_id or not run_id:
+            return
+        readiness = int(bool(self._loopback_endpoints(str(event.get("output") or ""))))
+        try:
+            with self._notification_db() as conn:
+                conn.execute(
+                    """INSERT OR IGNORE INTO process_notification_events
+                       (event_id, run_id, status, readiness, reason, updated_at)
+                       VALUES (?, ?, 'observed', ?, '', ?)""",
+                    (event_id, run_id, readiness, time.time()),
+                )
+        except Exception as exc:
+            logger.warning("Could not persist observed process notification: %s", exc)
+
+    @staticmethod
+    def _intentional_termination(session: ProcessSession) -> bool:
+        return session.completion_reason == "killed" and session.termination_source in {
+            "process.kill",
+            "kill_all",
+            "gateway_turn_timeout",
+            "gateway_turn_interrupted",
+            "session_reset",
+        }
+
+    @staticmethod
+    def _loopback_endpoints(text: str) -> List[tuple[str, int]]:
+        """Extract declared HTTP(S) loopback endpoints from readiness output."""
+        from urllib.parse import urlsplit
+
+        endpoints: List[tuple[str, int]] = []
+        for raw in re.findall(r"https?://[^\s(){}<>]+", text or "", flags=re.I):
+            try:
+                parsed = urlsplit(raw.rstrip(".,;"))
+                host = (parsed.hostname or "").lower()
+                if host not in {"localhost", "127.0.0.1", "::1"}:
+                    continue
+                port = parsed.port or (443 if parsed.scheme.lower() == "https" else 80)
+                endpoints.append((host, int(port)))
+            except (TypeError, ValueError):
+                continue
+        return list(dict.fromkeys(endpoints))
+
+    def _open_loopback_ports(
+        self, event: dict, session: Optional[ProcessSession] = None
+    ) -> List[int]:
+        """Return readiness-declared loopback ports still accepting connections."""
+        text = "\n".join(
+            str(part or "")
+            for part in (
+                event.get("output"),
+                event.get("command"),
+                getattr(session, "output_buffer", ""),
+            )
+        )
+        open_ports: List[int] = []
+        for host, port in self._loopback_endpoints(text):
+            try:
+                with socket.create_connection((host, port), timeout=0.15):
+                    open_ports.append(port)
+            except OSError:
+                pass
+        return sorted(set(open_ports))
+
+    def _readiness_endpoints(self, event: dict) -> List[tuple[str, int]]:
+        """Return endpoints declared by this watch observation, not sibling output."""
+        return self._loopback_endpoints(str(event.get("output") or ""))
+
+    def reconcile_process_notifications(self, session: ProcessSession) -> bool:
+        """Persist terminal state after verified intentional cleanup."""
+        if not session.exited or not self._intentional_termination(session):
+            return False
+        # A localhost URL emitted inside Docker/SSH/Modal/Daytona names that
+        # backend's network namespace, not the Hermes host.  A host socket probe
+        # cannot certify remote cleanup, so leave those events actionable.
+        if session.pid_scope != "host":
+            return False
+        probe = {
+            "session_id": session.id,
+            "started_at": session.started_at,
+            "command": session.command,
+            "output": session.output_buffer,
+        }
+        if not self._loopback_endpoints(
+            "\n".join((str(session.command or ""), str(session.output_buffer or "")))
+        ):
+            return False
+        if self._open_loopback_ports(probe, session):
+            return False
+        run_id = self._notification_run_identity(session)
+        if not run_id:
+            return False
+        now = time.time()
+        try:
+            with self._notification_db() as conn:
+                conn.execute(
+                    """INSERT INTO process_notification_runs
+                       (run_id, status, reason, updated_at)
+                       VALUES (?, 'terminal', 'intentional_cleanup', ?)
+                       ON CONFLICT(run_id) DO UPDATE SET
+                         status='terminal', reason='intentional_cleanup', updated_at=excluded.updated_at""",
+                    (run_id, now),
+                )
+                conn.execute(
+                    """UPDATE process_notification_events
+                       SET status='terminal', reason='intentional_cleanup', updated_at=?
+                       WHERE run_id=? AND event_id LIKE 'watch:%' AND readiness=1
+                         AND status != 'delivered'""",
+                    (now, run_id),
+                )
+            return True
+        except Exception as exc:
+            logger.warning("Could not reconcile process notification state: %s", exc)
+            return False
+
+    def is_notification_actionable(self, event: dict) -> bool:
+        """Revalidate a queued event against durable and current process state."""
+        if event.get("type") not in {"watch_match", "completion"}:
+            return True
+        event_id = self._notification_event_identity(event)
+        run_id = self._notification_run_identity(event)
+        readiness_endpoints = self._readiness_endpoints(event)
+        if event_id or run_id:
+            try:
+                with self._notification_db() as conn:
+                    if event_id:
+                        row = conn.execute(
+                            "SELECT status FROM process_notification_events WHERE event_id=?",
+                            (event_id,),
+                        ).fetchone()
+                        if row and row[0] in {"terminal", "delivered"}:
+                            return False
+                    if (
+                        run_id
+                        and event.get("type") == "watch_match"
+                        and readiness_endpoints
+                    ):
+                        row = conn.execute(
+                            "SELECT status FROM process_notification_runs WHERE run_id=?",
+                            (run_id,),
+                        ).fetchone()
+                        if row and row[0] == "terminal":
+                            return False
+            except Exception as exc:
+                logger.warning("Could not read process notification state: %s", exc)
+
+        # Intentional-cleanup reconciliation applies to historical readiness
+        # matches. Completion events retain their existing consumed/delivery
+        # contract (notably kill_all(..., consume_output=False)).
+        if event.get("type") == "completion":
+            return True
+
+        session_id = str(event.get("session_id") or "")
+        with self._lock:
+            session = self._running.get(session_id) or self._finished.get(session_id)
+        if session is None or not session.exited:
+            return True
+        if run_id and run_id != self._notification_run_identity(session):
+            return True
+        if not self._intentional_termination(session):
+            return True
+        if session.pid_scope != "host" or not readiness_endpoints:
+            return True
+        open_ports = self._open_loopback_ports(event, session)
+        if open_ports:
+            # Listener ownership cannot be proven after the original process
+            # exits: this may be a leaked descendant, an unexpected restart, or
+            # another process that rebound the port.  Report the disagreement
+            # without falsely attributing the listener to the old process.
+            event["lifecycle_alert"] = "post_cleanup_listener"
+            event["cleanup_open_ports"] = open_ports
+            return True
+        # Fail open when reconciliation cannot prove cleanup (unsupported
+        # namespace, state-store failure, or any other contradictory evidence).
+        return not self.reconcile_process_notifications(session)
+
+    def mark_notification_delivered(self, event: dict) -> None:
+        """Durably mark adapter-accepted delivery to prevent later replay."""
+        event_id = self._notification_event_identity(event)
+        run_id = self._notification_run_identity(event)
+        if not event_id or not run_id:
+            return
+        try:
+            with self._notification_db() as conn:
+                conn.execute(
+                    """INSERT INTO process_notification_events
+                       (event_id, run_id, status, reason, updated_at)
+                       VALUES (?, ?, 'delivered', 'accepted', ?)
+                       ON CONFLICT(event_id) DO UPDATE SET
+                         status='delivered', reason='accepted', updated_at=excluded.updated_at""",
+                    (event_id, run_id, time.time()),
+                )
+        except Exception as exc:
+            logger.warning("Could not persist delivered process notification: %s", exc)
 
     def _emit_output(self, session: ProcessSession, chunk: str) -> None:
         """Forward a freshly-read chunk to the live-output sink, if one is set.
@@ -658,7 +950,12 @@ class ProcessRegistry:
             return
 
         notification = {
+            "event_id": (
+                f"watch:{session.id}:{int(session.started_at * 1_000_000)}:"
+                f"{session._watch_hits}"
+            ),
             "session_id": session.id,
+            "started_at": session.started_at,
             "session_key": session.session_key,
             "task_id": session.task_id,
             "command": session.command,
@@ -674,6 +971,7 @@ class ProcessRegistry:
             "message_id": session.watcher_message_id,
         }
         _redact_process_result(notification)
+        self.observe_notification(notification)
         self.completion_queue.put(notification)
 
         if lifetime_exhausted:
@@ -1651,6 +1949,7 @@ class ProcessRegistry:
                 "started_at": session.started_at,
             }
             _redact_process_result(notification)
+            self.observe_notification(notification)
             self.completion_queue.put(notification)
 
     # ----- Query Methods -----
@@ -1946,6 +2245,8 @@ class ProcessRegistry:
             if evt.get("type") == "completion" and self._drain_should_skip(
                 _evt_sid, skip_poll_observed=skip_poll_observed
             ):
+                continue
+            if not self.is_notification_actionable(evt):
                 continue
 
             # Subagent-owned process notifications (task_id "sa-...") are
@@ -2421,6 +2722,7 @@ class ProcessRegistry:
                 session.completion_reason = "killed"
                 session.termination_source = source
             self._move_to_finished(session)
+            self.reconcile_process_notifications(session)
             self._write_checkpoint()
             return {
                 "status": "killed",
@@ -3179,10 +3481,19 @@ def format_process_notification(evt: dict) -> "str | None":
         _pat = evt.get("pattern", "?")
         _out = evt.get("output", "")
         _sup = evt.get("suppressed", 0)
-        text = (
-            f"[IMPORTANT: Background process {_sid} matched "
-            f"watch pattern \"{_pat}\".\n"
-        )
+        if evt.get("lifecycle_alert") == "post_cleanup_listener":
+            ports = ", ".join(str(p) for p in evt.get("cleanup_open_ports", []))
+            text = (
+                f"[IMPORTANT: Background process {_sid} was intentionally terminated, "
+                f"but its declared loopback port(s) {ports or '?'} remain open or were "
+                f"rebound; cleanup/restart state requires attention.\n"
+                f"Historical watch pattern: \"{_pat}\".\n"
+            )
+        else:
+            text = (
+                f"[IMPORTANT: Background process {_sid} matched "
+                f"watch pattern \"{_pat}\".\n"
+            )
         if _attribution:
             text += f"{_attribution}\n"
         text += (

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -11539,6 +11539,8 @@ def _notification_event_dedup_key(evt: dict) -> tuple:
     """
     evt_type = evt.get("type", "completion")
     evt_sid = evt.get("session_id", "")
+    if evt.get("event_id"):
+        return (evt_type, evt.get("event_id"))
     if evt_type == "watch_match":
         return (
             evt_sid,
@@ -11943,6 +11945,8 @@ def _notification_poller_loop(
         _evt_sid = evt.get("session_id", "")
         if evt.get("type") == "completion" and process_registry.is_completion_consumed(_evt_sid):
             continue
+        if not process_registry.is_notification_actionable(evt):
+            continue
 
         text = format_process_notification(evt)
         if not text:
@@ -11992,6 +11996,7 @@ def _notification_poller_loop(
             else:
                 _run_prompt_submit(rid, sid, session, text)
             complete_event_delivery(evt, _claim)
+            process_registry.mark_notification_delivered(evt)
         except Exception as exc:
             release_event_delivery(evt, _claim)
             print(
@@ -12034,6 +12039,8 @@ def _notification_poller_loop(
         _evt_sid = evt.get("session_id", "")
         if evt.get("type") == "completion" and process_registry.is_completion_consumed(_evt_sid):
             continue
+        if not process_registry.is_notification_actionable(evt):
+            continue
         text = format_process_notification(evt)
         if not text:
             continue
@@ -12070,6 +12077,7 @@ def _notification_poller_loop(
             else:
                 _run_prompt_submit(rid, sid, session, text)
             complete_event_delivery(evt, _claim)
+            process_registry.mark_notification_delivered(evt)
         except Exception as exc:
             release_event_delivery(evt, _claim)
             print(
@@ -13357,6 +13365,7 @@ def _run_prompt_submit(
                     _emit("message.start", sid)
                     _run_prompt_submit(rid, sid, session, synth)
                     complete_event_delivery(_evt, _claim)
+                    process_registry.mark_notification_delivered(_evt)
                 except Exception as _n_exc:
                     release_event_delivery(_evt, _claim)
                     print(


### PR DESCRIPTION
## What does this PR do?

Prevents historical loopback readiness matches from resurfacing as fresh actionable notifications after the originating local process was intentionally terminated and its declared readiness ports were verified closed.

The repair adds a durable SQLite lifecycle ledger keyed by Hermes process-session identity plus spawn epoch, reconciles readiness events at every CLI/gateway/TUI delivery boundary, and records delivery only after acceptance. It fails open for unexpected exits, open or rebound declared ports, new process incarnations, non-readiness watch events, and remote/sandbox runtimes that cannot be verified from the host namespace.

## Related Issue

No linked issue; reproduced from repeated completed evaluation-server teardown events.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/process_registry.py`: durable run/event lifecycle identities and storage, readiness-specific terminal reconciliation, loopback cleanup verification, and fail-open actionability.
- `cli.py`, `gateway/run.py`, `tui_gateway/server.py`: delivery-time reconciliation and post-delivery persistence across all notification consumers.
- `tests/tools/test_process_notification_lifecycle.py`: deterministic coverage for stale replay, restart persistence, open/rebound ports, new failures/runs, PID reuse, completion summaries, IPv6, remote namespaces, and non-readiness watch events.

## How to Test

1. Run `scripts/run_tests.sh tests/tools/test_process_notification_lifecycle.py -q`.
2. Run the process-registry, completion-notification, gateway, and TUI notification-focused suites.
3. Verify a real loopback readiness event is terminal after intentional cleanup and closed ports across a fresh registry/process, while an open/rebound port and a new unexpected exit remain actionable.

## Checklist

### Code

- [x] I've read the Contributing Guide / repository development guide
- [x] My commit message follows Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] Exact-head regression suites pass locally
- [x] I've added tests for the bug fix
- [x] Tested on macOS

### Documentation & Housekeeping

- [x] Relevant documentation update: N/A; behavior is internal and covered by tests
- [x] `cli-config.yaml.example`: N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A; no contributor workflow changed
- [x] Cross-platform impact considered; uses stdlib SQLite/socket behavior and preserves remote/sandbox fail-open handling
- [x] Tool descriptions/schemas: N/A; no model-tool schema changed

## Verification evidence

Exact commit reviewed: `7bb7b3b74cbf71046c3d71ba4e293036e5196b49`

- Independent semantic review: **PASS**, 92% confidence, no blocker or medium findings.
- Lifecycle suite: 16 passed in final independent review.
- Process registry suite: 85 passed, 5 skipped in final independent review.
- Gateway/CLI/TUI notification-focused suites: 39 passed, 601 deselected in final independent review.
- Earlier exact-head full local suite: 614 passed, 2 known environment-sensitive cases deselected.
- Ruff, Python compilation, `git diff --check`, Windows-footgun scan, schema migration probe, and committed-diff secret scan passed.
- Real lifecycle probe: intentional cleanup plus closed ports produced zero delayed actionable notifications across repeated drains and a separate process; a new unexpected exit remained actionable.
