### PR TITLE
fix(gateway): use canonical approval mode resolver in startup check

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7318,9 +7318,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         try:
             from hermes_cli.config import load_config as _load_full_config
             _appr_cfg = _load_full_config()
-            _appr_mode = str(
-                cfg_get(_appr_cfg, "approvals", "mode", default="manual") or "manual"
-            ).strip().lower()
+            from tools.approval import _normalize_approval_mode
+            _appr_mode = _normalize_approval_mode(
+                cfg_get(_appr_cfg, "approvals", "mode", default="manual")
+            )
             _tirith_on = bool(cfg_get(_appr_cfg, "security", "tirith_enabled", default=True))
             _aux_approval = cfg_get(_appr_cfg, "auxiliary", "approval", default=None)
             if _appr_mode == "manual" and not _tirith_on and not _aux_approval:


### PR DESCRIPTION
## Summary

This PR fixes #97016 by using the canonical `_normalize_approval_mode()` resolver in the gateway startup check instead of manual string conversion.

## Problem

The gateway startup approval mode check was using:
```python
_appr_mode = str(
    cfg_get(_appr_cfg, "approvals", "mode", default="manual") or "manual"
).strip().lower()
```

This misread YAML 1.1's boolean `False` (parsed from bare `off`) as `"manual"`, causing a spurious BLOCK warning for operators who explicitly turned approvals off.

## Solution

Use the canonical `_normalize_approval_mode()` resolver from `tools/approval.py`:
```python
from tools.approval import _normalize_approval_mode
_appr_mode = _normalize_approval_mode(
    cfg_get(_appr_cfg, "approvals", "mode", default="manual")
)
```

This correctly handles YAML 1.1 boolean parsing (`False` → `"off"`) and matches how the CLI, TUI, and approval gate itself resolve the mode.

## Changes

- Modified `gateway/run.py`: Replaced manual string conversion with canonical resolver

---

🤖 Generated with Codebuff
Co-Authored-By: Codebuff <noreply@codebuff.com>