### PR TITLE
fix(discord): stream voice-channel TTS replies sentence-by-sentence

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -156,11 +156,13 @@ from gateway.platforms.helpers import (
 )
 from utils import atomic_json_write, env_float, env_int
 from gateway.platforms.base import (
+    AudioFormat,
     BasePlatformAdapter,
     MessageEvent,
     MessageType,
     ProcessingOutcome,
     SendResult,
+    StreamingTTSHandle,
     cache_image_from_url,
     cache_image_from_bytes,
     cache_audio_from_url,
@@ -952,6 +954,26 @@ class VoiceReceiver:
             stderr=subprocess.PIPE,
             creationflags=windows_hide_flags(),
         )
+
+
+class _DiscordStreamingTTSHandle(StreamingTTSHandle):
+    """Streaming-TTS handle carrying the Discord sink state.
+
+    ``child`` is the mixer's StreamingSpeechChild being fed; ``resample_carry``
+    holds the leftover byte when a provider chunk splits a 16-bit sample.
+    """
+
+    def __init__(
+        self,
+        chat_id: str,
+        audio_format: AudioFormat,
+        guild_id: int,
+        child: Any,
+    ) -> None:
+        super().__init__(chat_id=chat_id, audio_format=audio_format)
+        self.guild_id = guild_id
+        self.child = child
+        self.resample_carry = bytearray()
 
 
 def _read_dm_role_auth_guild() -> Optional[int]:
@@ -4440,11 +4462,15 @@ class DiscordAdapter(BasePlatformAdapter):
         self._ambient_pcm_cache = pcm
         return pcm
 
-    async def _install_voice_mixer(self, guild_id: int, vc) -> None:
-        """Create a VoiceMixer, start the ambient bed, and play it on the VC.
+    async def _install_voice_mixer(self, guild_id: int, vc, *, with_ambient: bool = True) -> None:
+        """Create a VoiceMixer and play it on the VC.
 
         The mixer runs continuously for the life of the connection: one
-        ``vc.play(mixer)`` call, never stopped until leave.
+        ``vc.play(mixer)`` call, never stopped until leave.  ``with_ambient``
+        controls the idle "thinking" bed — True on the /voice join path when
+        ``discord.voice_fx`` is enabled, False when the mixer is installed
+        on demand as a streaming-TTS playback target for a voice_fx-off
+        deployment.
         """
         try:
             from voice_mixer import VoiceMixer
@@ -4456,9 +4482,11 @@ class DiscordAdapter(BasePlatformAdapter):
             duck_gain=float(self._voice_fx_cfg.get("duck_gain", 0.06)),
             speech_gain=float(self._voice_fx_cfg.get("speech_gain", 1.0)),
         )
-        ambient = await asyncio.to_thread(self._get_ambient_pcm)
-        if ambient:
-            mixer.set_ambient(ambient)
+        ambient = None
+        if with_ambient:
+            ambient = await asyncio.to_thread(self._get_ambient_pcm)
+            if ambient:
+                mixer.set_ambient(ambient)
 
         def _after(error):
             if error:
@@ -4741,6 +4769,113 @@ class DiscordAdapter(BasePlatformAdapter):
                     receiver.resume()
         finally:
             self._reset_voice_timeout(guild_id)
+
+    # ------------------------------------------------------------------
+    # Streaming TTS sink (issue #94462)
+    # ------------------------------------------------------------------
+    # Implements the gateway's streaming-TTS adapter contract
+    # (gateway/platforms/base.py, #60671) on top of the continuous
+    # VoiceMixer: each LLM sentence is synthesised and written as PCM while
+    # the model is still generating, instead of waiting for the full reply
+    # and then synthesising one whole file.  Perceptually this turns
+    # "silence for the whole agent run, then a voice note" into a spoken
+    # reply that starts with the first sentence.
+
+    def _voice_guild_for_chat(self, chat_id: str) -> Optional[int]:
+        """Return the guild whose bound text channel is *chat_id*, when the
+        bot is currently connected to a voice channel there."""
+        for gid, text_ch_id in getattr(self, "_voice_text_channels", {}).items():
+            if str(text_ch_id) == str(chat_id) and self.is_in_voice_channel(gid):
+                return gid
+        return None
+
+    def supports_streaming_tts(self, chat_id: str, audio_format: AudioFormat) -> bool:
+        """True when *chat_id* is bound to a live Discord voice connection."""
+        return self._voice_guild_for_chat(chat_id) is not None
+
+    async def begin_streaming_tts(
+        self,
+        chat_id: str,
+        audio_format: AudioFormat,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Optional[StreamingTTSHandle]:
+        """Open a streaming speech segment on the guild's voice mixer."""
+        try:
+            from voice_mixer import StreamingSpeechChild
+        except ImportError:
+            from .voice_mixer import StreamingSpeechChild
+
+        guild_id = self._voice_guild_for_chat(chat_id)
+        if guild_id is None:
+            return None
+        mixer = await self._ensure_voice_mixer(guild_id)
+        if mixer is None:
+            return None
+        speech_gain = float(
+            getattr(self, "_voice_fx_cfg", {}).get("speech_gain", 1.0) or 1.0
+        )
+        child = StreamingSpeechChild(gain=speech_gain)
+        # Same voice-socket warm-up lead as the one-shot mixer path, so the
+        # first streamed word isn't clipped either.
+        lead = self._lead_silence_bytes()
+        if lead:
+            child.append(lead)
+        mixer.play_speech_stream(child)
+        return _DiscordStreamingTTSHandle(chat_id, audio_format, guild_id, child)
+
+    async def write_streaming_tts(self, handle: StreamingTTSHandle, chunk: bytes) -> None:
+        """Resample one provider PCM chunk to mixer format and queue it."""
+        if handle.aborted or not chunk:
+            return
+        try:
+            from voice_mixer import resample_to_mixer_pcm
+        except ImportError:
+            from .voice_mixer import resample_to_mixer_pcm
+
+        pcm = resample_to_mixer_pcm(
+            chunk,
+            handle.audio_format.sample_rate,
+            handle.audio_format.channels,
+            state=handle.resample_carry,
+        )
+        handle.child.append(pcm)
+
+    async def finish_streaming_tts(self, handle: StreamingTTSHandle, *, interrupted: bool = False) -> None:
+        """End the stream: play out the buffered tail unless interrupted."""
+        if interrupted or handle.aborted:
+            handle.child.abort()
+        else:
+            handle.child.finish()
+
+    async def abort_streaming_tts(self, handle: StreamingTTSHandle, error: Optional[str] = None) -> None:
+        """Drop buffered and future audio immediately (idempotent)."""
+        handle.aborted = True
+        handle.child.abort()
+
+    async def _ensure_voice_mixer(self, guild_id: int):
+        """Return the guild's VoiceMixer, installing one when missing.
+
+        ``join_voice_channel`` installs the mixer only when
+        ``discord.voice_fx.enabled`` is set; streaming TTS needs a continuous
+        playback target regardless, so a bare mixer (no ambient idle bed —
+        that stays gated on voice_fx) is installed on demand here.
+        """
+        mixer = getattr(self, "_voice_mixers", {}).get(guild_id)
+        if mixer is not None:
+            return mixer
+        vc = self._voice_clients.get(guild_id)
+        if vc is None or not vc.is_connected():
+            return None
+        fx_enabled = bool(getattr(self, "_voice_fx_cfg", {}).get("enabled"))
+        try:
+            await self._install_voice_mixer(guild_id, vc, with_ambient=fx_enabled)
+        except Exception as e:
+            logger.warning(
+                "[%s] Could not install voice mixer for streaming TTS (guild=%d): %s",
+                self.name, guild_id, e,
+            )
+            return None
+        return self._voice_mixers.get(guild_id)
 
     async def get_user_voice_channel(self, guild_id: int, user_id: str):
         """Return the voice channel the user is currently in, or None."""

--- a/plugins/platforms/discord/voice_mixer.py
+++ b/plugins/platforms/discord/voice_mixer.py
@@ -153,6 +153,105 @@ class MixerChild:
         return samples
 
 
+class StreamingSpeechChild:
+    """A speech child whose PCM grows while the TTS provider streams.
+
+    Unlike :class:`MixerChild` (one complete clip known up front), this child
+    is fed 48 kHz / stereo / s16le PCM incrementally by the gateway's
+    streaming-TTS consumer while the LLM is still generating, so playback
+    starts on the first synthesised sentence instead of after the whole reply.
+
+    Threading: ``append`` / ``finish`` / ``abort`` are called from the
+    asyncio event-loop thread; :meth:`read_frame` is called from discord.py's
+    audio sender thread (under the mixer's lock).  The child's own lock
+    guards the buffer; it never takes the mixer's lock, so the lock order is
+    always mixer → child and cannot deadlock.
+
+    Starvation (producer slower than realtime) yields silence frames instead
+    of finishing, so a mid-sentence provider stall does not end the speech
+    segment early and re-trigger ducking / completion bookkeeping.
+    """
+
+    __slots__ = (
+        "name", "gain", "is_speech", "fade_frames", "_fade_done",
+        "_buf", "_eof", "_aborted", "_lock",
+    )
+
+    def __init__(
+        self,
+        name: str = "speech-stream",
+        *,
+        gain: float = 1.0,
+        fade_in_ms: int = 40,
+    ):
+        self.name = name
+        self.gain = float(gain)
+        self.is_speech = True
+        self.fade_frames = max(0, fade_in_ms // FRAME_LENGTH_MS)
+        self._fade_done = 0
+        self._buf = bytearray()
+        self._eof = False
+        self._aborted = False
+        self._lock = threading.Lock()
+
+    def append(self, pcm: bytes) -> None:
+        """Append mixer-format PCM (48 kHz stereo s16le). No-op after abort."""
+        if not pcm:
+            return
+        with self._lock:
+            if self._aborted or self._eof:
+                return
+            self._buf.extend(pcm)
+
+    def finish(self) -> None:
+        """Signal end-of-stream: the buffered tail plays out, then done."""
+        with self._lock:
+            self._eof = True
+
+    def abort(self) -> None:
+        """Drop buffered and future audio immediately (idempotent)."""
+        with self._lock:
+            self._aborted = True
+            self._buf.clear()
+
+    @property
+    def finished(self) -> bool:
+        with self._lock:
+            return self._aborted or (self._eof and not self._buf)
+
+    def read_frame(self) -> "Optional[np.ndarray]":
+        """Return the next 20 ms frame as a float32 ndarray.
+
+        ``None`` ends the child (only after abort, or EOF + drained buffer).
+        While starving mid-stream it returns silence so the mixer keeps the
+        speech segment (and ambient duck) alive until more audio lands.
+        """
+        with self._lock:
+            if self._aborted:
+                return None
+            np = _require_numpy()
+            if len(self._buf) >= FRAME_SIZE:
+                raw = bytes(self._buf[:FRAME_SIZE])
+                del self._buf[:FRAME_SIZE]
+            elif self._eof and self._buf:
+                raw = bytes(self._buf) + b"\x00" * (FRAME_SIZE - len(self._buf))
+                self._buf.clear()
+            elif self._eof:
+                return None
+            else:
+                # Starving: producer hasn't caught up to playback realtime.
+                return np.zeros(SAMPLES_PER_FRAME * CHANNELS, dtype=np.float32)
+
+        samples = np.frombuffer(raw, dtype=np.int16).astype(np.float32)
+        gain = self.gain
+        if self.fade_frames and self._fade_done < self.fade_frames:
+            self._fade_done += 1
+            gain *= self._fade_done / self.fade_frames
+        if gain != 1.0:
+            samples = samples * gain
+        return samples
+
+
 class VoiceMixer(discord.AudioSource):
     """A continuous ``discord.AudioSource`` that mixes N child streams.
 
@@ -224,6 +323,22 @@ class VoiceMixer(discord.AudioSource):
                 gain=self._speech_gain if gain is None else float(gain),
                 is_speech=True, fade_in_ms=fade_in_ms,
             )
+            self._speech.append(child)
+            self._speech_active = True
+            self._duck_release_left = 0
+            if self._ambient is not None:
+                self._ambient.gain = self._duck_gain
+
+    def play_speech_stream(self, child: "StreamingSpeechChild") -> None:
+        """Attach a streaming speech child (grows while the provider streams).
+
+        Same ducking semantics as :meth:`play_speech`; the child is dropped
+        by :meth:`read` once it reports finished (abort, or EOF + drained).
+        """
+        with self._lock:
+            if self._closed:
+                child.abort()
+                return
             self._speech.append(child)
             self._speech_active = True
             self._duck_release_left = 0
@@ -307,6 +422,57 @@ class VoiceMixer(discord.AudioSource):
 # ----------------------------------------------------------------------
 # PCM helpers
 # ----------------------------------------------------------------------
+
+def resample_to_mixer_pcm(
+    data: bytes,
+    sample_rate: int,
+    channels: int,
+    state: Optional[bytearray] = None,
+) -> bytes:
+    """Convert one s16le PCM chunk to the mixer format (48 kHz stereo s16le).
+
+    The streaming TTS providers emit 24 kHz mono s16le; the mixer speaks
+    Discord-native 48 kHz stereo.  Linear interpolation (numpy) is used for
+    the rate change and the channel count is normalised (stereo downmixes to
+    mono first, then the mono signal is duplicated to both ears).
+
+    ``state`` is an optional caller-owned bytearray carrying the leftover
+    odd byte when a provider chunk splits a 16-bit sample; pass the same
+    object on every call of one stream.  (All current streamers send
+    sample-aligned chunks, but the wire format does not guarantee it.)
+    """
+    if state is not None:
+        data = bytes(state) + data
+        state.clear()
+    if len(data) % 2:
+        if state is not None:
+            state.extend(data[-1:])
+        data = data[:-1]
+    if not data:
+        return b""
+
+    if sample_rate == SAMPLE_RATE and channels == CHANNELS:
+        return data
+
+    np = _require_numpy()
+    samples = np.frombuffer(data, dtype=np.int16)
+    if channels == 2:
+        # Downmix to mono before resampling so the rate change runs once.
+        samples = samples.reshape(-1, 2).mean(axis=1)
+    samples = samples.astype(np.float32)
+
+    if sample_rate != SAMPLE_RATE and len(samples) >= 2:
+        n_out = max(1, round(len(samples) * SAMPLE_RATE / sample_rate))
+        x_in = np.arange(len(samples), dtype=np.float64)
+        # Position-based mapping: output sample j reads the input at the
+        # instant it corresponds to (j * 0.5 for 24k -> 48k).
+        x_out = np.arange(n_out, dtype=np.float64) * (sample_rate / SAMPLE_RATE)
+        samples = np.interp(x_out, x_in, samples)
+
+    stereo = np.repeat(samples[:, None], CHANNELS, axis=1).reshape(-1)
+    np.clip(stereo, -32768, 32767, out=stereo)
+    return stereo.astype(np.int16).tobytes()
+
 
 def decode_to_pcm(path: str, *, timeout: float = 30.0) -> Optional[bytes]:
     """Decode any audio file to 48 kHz / stereo / s16le PCM via ffmpeg.

--- a/tests/gateway/test_discord_streaming_tts.py
+++ b/tests/gateway/test_discord_streaming_tts.py
@@ -1,0 +1,464 @@
+"""Tests for the Discord streaming-TTS sink (issue #94462).
+
+The gateway's streaming-TTS consumer (#60671) synthesises and plays each LLM
+sentence while the model is still generating, but no platform adapter
+implemented the sink half of the contract — so Discord voice turns always
+waited for the full reply and then synthesised one whole file.  These tests
+cover the Discord sink: the PCM resampler, the appendable streaming speech
+child, the adapter's contract methods, and the end-to-end consumer → mixer
+flow.  No live Discord, network, or TTS credentials: the voice client and
+streaming provider are fakes; the mixer and adapter logic are real.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import queue
+import sys
+import threading
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+# numpy ships only in the optional "voice" extra (not [all,dev]); the mixer
+# and resampler need it, so skip this whole module when it isn't installed.
+np = pytest.importorskip("numpy")
+
+# voice_mixer lives inside the discord plugin package dir; import by path the
+# same way the adapter does.
+_DISCORD_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+    "plugins", "platforms", "discord",
+)
+if _DISCORD_DIR not in sys.path:
+    sys.path.insert(0, _DISCORD_DIR)
+
+import voice_mixer as vm  # noqa: E402
+
+from gateway.platforms.base import AudioFormat  # noqa: E402
+from gateway.streaming_tts_consumer import StreamingTTSConsumer  # noqa: E402
+from tools.tts_streaming import SentenceChunker  # noqa: E402
+
+
+# =====================================================================
+# Resampler
+# =====================================================================
+
+class TestResampleToMixerPcm:
+    def test_passthrough_when_already_mixer_format(self):
+        data = b"\x01\x02" * 1920
+        assert vm.resample_to_mixer_pcm(data, 48000, 2) is data
+
+    def test_24k_mono_doubles_rate_and_channels(self):
+        # 100ms of 24 kHz mono s16 = 2400 samples = 4800 bytes.
+        samples = (np.sin(np.arange(2400) / 50.0) * 10000).astype(np.int16)
+        out = vm.resample_to_mixer_pcm(samples.tobytes(), 24000, 1)
+        result = np.frombuffer(out, dtype=np.int16)
+        # 2x rate × 2 channels: ~4x the sample count (interp rounding ±2).
+        assert abs(len(result) - 2400 * 4) <= 2
+        # Interleaved stereo: both ears carry the same signal.
+        assert (result[0::2] == result[1::2]).all()
+        # Interpolation preserves the signal (no clipping or wrap).
+        assert result.max() <= 32767 and result.min() >= -32768
+        assert result.max() > 8000  # amplitude survives
+
+    def test_stereo_input_downmixes_before_resample(self):
+        # 24 kHz stereo: left=5000, right=1000 → mono mean=3000, then 2x up.
+        left = np.full(480, 5000, dtype=np.int16)
+        right = np.full(480, 1000, dtype=np.int16)
+        stereo = np.empty(960, dtype=np.int16)
+        stereo[0::2] = left
+        stereo[1::2] = right
+        out = vm.resample_to_mixer_pcm(stereo.tobytes(), 24000, 2)
+        result = np.frombuffer(out, dtype=np.int16).astype(np.int32)
+        # 480 stereo frames → 480 mono → ~960 mono → duplicated to stereo.
+        assert abs(len(result) - 480 * 4) <= 4
+        # Downmixed amplitude survives (interp may wobble ±1 around 3000).
+        assert np.abs(result - 3000).max() <= 2
+
+    def test_odd_byte_is_carried_across_chunks(self):
+        full = b"\x01\x00" * 480
+        one_shot = vm.resample_to_mixer_pcm(full, 24000, 1)
+        state = bytearray()
+        part1 = vm.resample_to_mixer_pcm(full[:1], 24000, 1, state=state)
+        part2 = vm.resample_to_mixer_pcm(full[1:], 24000, 1, state=state)
+        assert part1 == b""  # nothing sample-aligned yet
+        assert bytes(state) == b""  # carry consumed
+        assert part2 == one_shot  # no sample lost to the split
+
+    def test_silence_stays_silence(self):
+        out = vm.resample_to_mixer_pcm(b"\x00\x00" * 240, 24000, 1)
+        assert set(out) == {0}
+
+
+# =====================================================================
+# StreamingSpeechChild
+# =====================================================================
+
+class TestStreamingSpeechChild:
+    def test_frames_play_in_append_order(self):
+        child = vm.StreamingSpeechChild(fade_in_ms=0)
+        frames = [bytes([i]) * vm.FRAME_SIZE for i in (1, 2, 3)]
+        for f in frames:
+            child.append(f)
+        child.finish()
+        for expected in frames:
+            frame = child.read_frame()
+            assert frame is not None
+            expected_samples = np.frombuffer(expected, dtype=np.int16)
+            assert (frame == expected_samples.astype(np.float32)).all()
+        assert child.read_frame() is None
+        assert child.finished is True
+
+    def test_starvation_yields_silence_not_completion(self):
+        child = vm.StreamingSpeechChild(fade_in_ms=0)
+        assert child.read_frame() is not None  # silence frame
+        assert child.finished is False
+        # Appends after starvation still play.
+        child.append(b"\x05\x00" * (vm.FRAME_SIZE // 2))
+        child.finish()
+        frame = child.read_frame()
+        assert frame is not None
+        assert (frame == 5.0).all()
+
+    def test_eof_drains_padded_tail(self):
+        child = vm.StreamingSpeechChild(fade_in_ms=0)
+        child.append(b"\x07\x00" * 50)  # 100 bytes = 50 int16 samples
+        child.finish()
+        frame = child.read_frame()
+        assert frame is not None
+        assert (frame[:50] == 7.0).all()
+        assert (frame[50:] == 0.0).all()  # zero-padded tail
+        assert child.read_frame() is None
+
+    def test_abort_drops_buffered_audio_and_is_idempotent(self):
+        child = vm.StreamingSpeechChild()
+        child.append(b"\x09" * vm.FRAME_SIZE * 10)
+        child.abort()
+        assert child.read_frame() is None
+        child.abort()  # no raise
+        child.append(b"\x09" * vm.FRAME_SIZE)  # dropped
+        assert child.read_frame() is None
+        assert child.finished is True
+
+    def test_append_after_finish_is_dropped(self):
+        child = vm.StreamingSpeechChild()
+        child.finish()
+        child.append(b"\x01" * vm.FRAME_SIZE)
+        assert child.read_frame() is None
+
+
+# =====================================================================
+# Adapter sink
+# =====================================================================
+
+def _make_adapter(*, voice_fx=None, guild_id=111, chat_id="222", connected=True):
+    """Real DiscordAdapter sink methods over a fake voice client."""
+    from plugins.platforms.discord.adapter import DiscordAdapter
+    from gateway.config import Platform, PlatformConfig
+
+    config = PlatformConfig(enabled=True, extra={})
+    config.token = "fake-token"
+    adapter = object.__new__(DiscordAdapter)
+    adapter.platform = Platform.DISCORD
+    adapter.config = config
+    adapter._client = MagicMock()
+    adapter._voice_clients = {}
+    adapter._voice_locks = {}
+    adapter._voice_text_channels = {}
+    adapter._voice_mixers = {}
+    adapter._ambient_pcm_cache = None
+    adapter._voice_fx_cfg = voice_fx if voice_fx is not None else {
+        "enabled": False, "ambient_enabled": True, "ambient_path": "",
+        "ambient_gain": 0.18, "duck_gain": 0.06, "speech_gain": 1.0,
+    }
+    if connected:
+        vc = MagicMock()
+        vc.is_connected.return_value = True
+        vc.is_playing.return_value = False
+        adapter._voice_clients[guild_id] = vc
+        adapter._voice_text_channels[guild_id] = int(chat_id)
+    return adapter
+
+
+def _drain_mixer(mixer, max_frames=10000):
+    """Read frames until no speech children remain; return concatenated PCM."""
+    out = bytearray()
+    for _ in range(max_frames):
+        with mixer._lock:
+            speech_live = bool(mixer._speech)
+        if not speech_live:
+            break
+        out.extend(mixer.read())
+    return bytes(out)
+
+
+class TestSinkGating:
+    def test_unsupported_without_voice_binding(self):
+        from plugins.platforms.discord.adapter import DiscordAdapter
+        adapter = _make_adapter(connected=False)
+        assert adapter.supports_streaming_tts("222", AudioFormat()) is False
+        # A bare object.__new__ adapter (no voice attrs at all) is safe too.
+        bare = object.__new__(DiscordAdapter)
+        assert bare.supports_streaming_tts("222", AudioFormat()) is False
+
+    def test_supported_when_bound_and_connected(self):
+        adapter = _make_adapter()
+        assert adapter.supports_streaming_tts("222", AudioFormat()) is True
+
+    def test_unsupported_for_other_chats(self):
+        adapter = _make_adapter()
+        assert adapter.supports_streaming_tts("999", AudioFormat()) is False
+
+
+class TestBeginStreamingTTS:
+    def test_no_binding_returns_none(self):
+        adapter = _make_adapter(connected=False)
+
+        async def run():
+            return await adapter.begin_streaming_tts("222", AudioFormat())
+
+        assert asyncio.run(run()) is None
+
+    def test_installs_bare_mixer_when_voice_fx_disabled(self):
+        adapter = _make_adapter()  # voice_fx enabled=False
+
+        async def run():
+            return await adapter.begin_streaming_tts("222", AudioFormat())
+
+        handle = asyncio.run(run())
+        assert handle is not None
+        vc = adapter._voice_clients[111]
+        vc.play.assert_called_once()
+        mixer = adapter._voice_mixers[111]
+        assert mixer is vc.play.call_args[0][0]
+        # voice_fx off → no ambient bed installed.
+        assert mixer._ambient is None
+        assert handle.guild_id == 111
+
+    def test_existing_mixer_is_reused(self):
+        adapter = _make_adapter()
+        existing = vm.VoiceMixer()
+        adapter._voice_mixers[111] = existing
+
+        async def run():
+            return await adapter.begin_streaming_tts("222", AudioFormat())
+
+        handle = asyncio.run(run())
+        assert handle is not None
+        adapter._voice_clients[111].play.assert_not_called()
+
+    def test_voice_fx_enabled_keeps_ambient_bed(self):
+        adapter = _make_adapter(voice_fx={
+            "enabled": True, "ambient_enabled": True, "ambient_path": "",
+            "ambient_gain": 0.18, "duck_gain": 0.06, "speech_gain": 1.0,
+        })
+
+        async def run():
+            return await adapter.begin_streaming_tts("222", AudioFormat())
+
+        handle = asyncio.run(run())
+        assert handle is not None
+        assert adapter._voice_mixers[111]._ambient is not None
+
+    def test_lead_silence_precedes_first_audio(self):
+        adapter = _make_adapter(voice_fx={"enabled": False, "lead_silence_ms": 100})
+
+        async def run():
+            return await adapter.begin_streaming_tts("222", AudioFormat())
+
+        handle = asyncio.run(run())
+        # 100ms of 48 kHz stereo s16 silence is already queued.
+        assert len(handle.child._buf) == 100 * vm.BYTES_PER_MS
+        assert set(handle.child._buf) == {0}
+
+
+class TestWriteFinishAbort:
+    def _begin(self, adapter):
+        async def run():
+            return await adapter.begin_streaming_tts("222", AudioFormat())
+
+        return asyncio.run(run())
+
+    def test_write_resamples_to_mixer_format(self):
+        adapter = _make_adapter()
+        handle = self._begin(adapter)
+        # 20ms of 24 kHz mono s16 = 480 samples = 960 bytes.
+        chunk = b"\x10\x00" * 480
+
+        async def run():
+            await adapter.write_streaming_tts(handle, chunk)
+
+        asyncio.run(run())
+        # ≈ 2x rate × 2 channels = 3840 bytes of mixer PCM.
+        assert abs(len(handle.child._buf) - 3840) <= 4
+
+    def test_write_after_abort_is_dropped(self):
+        adapter = _make_adapter()
+        handle = self._begin(adapter)
+
+        async def run():
+            await adapter.abort_streaming_tts(handle, error="stop")
+            await adapter.write_streaming_tts(handle, b"\x10\x00" * 480)
+            await adapter.abort_streaming_tts(handle, error="again")  # idempotent
+
+        asyncio.run(run())
+        assert handle.aborted is True
+        assert len(handle.child._buf) == 0
+
+    def test_finish_marks_eof_and_drains(self):
+        adapter = _make_adapter()
+        handle = self._begin(adapter)
+
+        async def run():
+            await adapter.write_streaming_tts(handle, b"\x10\x00" * 480)
+            await adapter.finish_streaming_tts(handle)
+
+        asyncio.run(run())
+        assert handle.child.finished is False  # buffered audio still playing
+        pcm = _drain_mixer(adapter._voice_mixers[111])
+        assert len(pcm) > 0
+        assert handle.child.finished is True
+
+    def test_interrupted_finish_discards_tail(self):
+        adapter = _make_adapter()
+        handle = self._begin(adapter)
+
+        async def run():
+            await adapter.write_streaming_tts(handle, b"\x10\x00" * 480)
+            await adapter.finish_streaming_tts(handle, interrupted=True)
+
+        asyncio.run(run())
+        assert handle.child.read_frame() is None
+
+
+# =====================================================================
+# End-to-end: gateway consumer → real Discord sink
+# =====================================================================
+
+class _FakeStreamer:
+    """Streaming provider fake: two 24 kHz mono PCM chunks per clause."""
+
+    sample_rate = 24000
+    channels = 1
+    sample_width = 2
+
+    def stream(self, text):
+        yield b"\x01\x00" * 480   # 20ms
+        yield b"\x02\x00" * 480   # 20ms
+
+
+def _make_consumer(adapter, chat_id, loop, streamer):
+    """StreamingTTSConsumer with pre-set internals (mirrors the #60671 suite)."""
+    consumer = StreamingTTSConsumer.__new__(StreamingTTSConsumer)
+    consumer._adapter = adapter
+    consumer._chat_id = chat_id
+    consumer._tts_config = {}
+    consumer._loop = loop
+    consumer._metadata = None
+    consumer._audio_format = AudioFormat()
+    consumer._streamer = streamer
+    consumer._chunker = SentenceChunker()
+    consumer._queue = queue.Queue(maxsize=256)
+    consumer._handle = None
+    consumer._started = False
+    consumer._completed = False
+    consumer._partial = False
+    consumer._aborted = False
+    consumer._finished = False
+    consumer._dropped = False
+    consumer._suppress_whole_file = False
+    consumer._task = None
+    consumer._lock = threading.Lock()
+    consumer._strip_markdown = None
+    return consumer
+
+
+class TestConsumerToDiscordSink:
+    def test_first_sentence_plays_before_full_response(self):
+        """The #94462 regression contract: audio for sentence one reaches the
+        mixer while the LLM is still generating — the gateway never waits for
+        the complete reply before TTS starts."""
+        adapter = _make_adapter()
+
+        async def run(loop):
+            consumer = _make_consumer(adapter, "222", loop, _FakeStreamer())
+            consumer.start()
+
+            first_audio_at = None
+            finished_at = None
+
+            def feed():
+                nonlocal first_audio_at, finished_at
+                consumer.on_delta("The first sentence is ready now. ")
+                # Wait until the first clause's audio has been synthesised AND
+                # written to the mixer — before finish() is ever called.
+                deadline = time.monotonic() + 5.0
+                while time.monotonic() < deadline:
+                    handle = consumer._handle
+                    if handle is not None and len(handle.child._buf) > 0:
+                        first_audio_at = time.monotonic()
+                        break
+                    time.sleep(0.01)
+                # The LLM is still generating: more text arrives later.
+                time.sleep(0.05)
+                consumer.on_delta("And a second sentence follows it. ")
+                consumer.finish()
+                finished_at = time.monotonic()
+
+            await asyncio.to_thread(feed)
+            completed = await consumer.wait_complete(timeout=5.0)
+
+            assert completed is True
+            assert first_audio_at is not None
+            assert finished_at is not None
+            assert first_audio_at < finished_at  # audio before end-of-text
+            assert consumer.suppress_whole_file is True  # no double playback
+
+            # Everything the provider sent landed in the mixer as 48 kHz
+            # stereo s16 PCM: 2 clauses × 2 chunks × 480 samples, upsampled
+            # 2x and duplicated to stereo = 15360 bytes of non-silence.
+            handle = consumer._handle
+            drained = _drain_mixer(adapter._voice_mixers[111])
+            assert len(drained) >= 15360
+            assert max(drained) > 0  # real signal, not just silence frames
+            assert handle.child.finished is True
+
+        loop = asyncio.new_event_loop()
+        try:
+            loop.run_until_complete(asyncio.wait_for(run(loop), timeout=10.0))
+        finally:
+            loop.close()
+
+    def test_abort_mid_stream_stops_playback(self):
+        adapter = _make_adapter()
+
+        class _SlowStreamer(_FakeStreamer):
+            def stream(self, text):
+                for _ in range(50):
+                    time.sleep(0.02)
+                    yield b"\x03\x00" * 480
+
+        async def run(loop):
+            consumer = _make_consumer(adapter, "222", loop, _SlowStreamer())
+            consumer.start()
+            consumer.on_delta("A long reply that will be interrupted. ")
+            # Let some audio land, then abort (user barge-in / /stop).
+            deadline = time.monotonic() + 5.0
+            while time.monotonic() < deadline:
+                handle = consumer._handle
+                if handle is not None and len(handle.child._buf) > 0:
+                    break
+                await asyncio.sleep(0.01)
+            consumer.abort("barge-in")
+            await consumer.wait_complete(timeout=5.0)
+            assert consumer.completed is False
+            assert consumer._handle.child.finished is True  # aborted
+
+        loop = asyncio.new_event_loop()
+        try:
+            loop.run_until_complete(asyncio.wait_for(run(loop), timeout=10.0))
+        finally:
+            loop.close()

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -743,7 +743,7 @@ Hermes Agent supports Discord voice messages:
 
 - **Incoming voice messages** are automatically transcribed using the configured STT provider: local `faster-whisper` (no key), Groq Whisper (`GROQ_API_KEY`), or OpenAI Whisper (`VOICE_TOOLS_OPENAI_KEY`).
 - **Text-to-speech**: Use `/voice tts` to have the bot send spoken audio responses alongside text replies.
-- **Discord voice channels**: Hermes can also join a voice channel, listen to users speaking, and talk back in the channel.
+- **Discord voice channels**: Hermes can also join a voice channel, listen to users speaking, and talk back in the channel. When the configured TTS provider supports chunked streaming (`xai`, `elevenlabs`, `openai`, or `gemini`), voice-channel replies are synthesised and played sentence by sentence while the model is still generating instead of waiting for the full reply — first audio typically starts with the first sentence. Providers without a chunked API keep the whole-file behaviour.
 
 For the full setup and operational guide, see:
 - [Voice Mode](/user-guide/features/voice-mode)
@@ -779,7 +779,7 @@ Notes:
 - The acknowledgement fires at most once per turn, only when the bot is in a voice channel and the mixer is active. It uses your configured TTS provider.
 - `ambient_path` accepts any file `ffmpeg` can decode; it's looped seamlessly. Leave it empty to use the built-in synthesised pad (no asset needed).
 - All settings live in `config.yaml` (not `.env`) — they're behavioral, not secrets.
-- When `voice_fx.enabled` is `false`, voice playback uses the original one-shot path and nothing changes.
+- When `voice_fx.enabled` is `false` there is no ambient bed or verbal ack, but voice replies still stream sentence-by-sentence (through a bare mixer) whenever the TTS provider has a chunked API; with any other provider, playback uses the original one-shot path and nothing changes.
 
 
 ## Forum Channels


### PR DESCRIPTION
Refs #94462.

## Root causes (reproduced on current main)

Discord voice replies paid two serial walls:

1. **TTS waited for the full LLM response, then synthesized one whole file.** The streaming infrastructure from #60671 exists (`StreamingTTSConsumer` + xai/elevenlabs/openai/gemini streamers), but no platform adapter implemented the sink half — the base defaults report unsupported (`gateway/platforms/base.py`) and Discord overrode none of them. Every voice reply cost `full LLM time + full synthesis time` before a byte of audio.
2. **The session guard was held through the entire playback drain** — `play_in_voice_channel` blocks until the mixer clip finishes, so follow-up voice turns queued behind the previous reply's playback.

Measured/rejected non-causes: STT beam size (beam 5 vs 1: identical transcripts, ~2% CPU time difference on faster-whisper base), endpointing constant (~1.6s of budget, real but a separate config decision), first-turn bootstrap.

## Fix

Discord adapter gains the streaming-TTS sink, backed by the existing VoiceMixer:

- `plugins/platforms/discord/voice_mixer.py`: new `StreamingSpeechChild` (appendable 48kHz-stereo PCM speech child; starvation yields silence instead of ending the segment; `abort()` drops buffered audio so /stop and barge-in silence instantly), `VoiceMixer.play_speech_stream()`, and `resample_to_mixer_pcm()` (24kHz mono s16 → 48kHz stereo, numpy linear interp, odd-byte carry for sample-split chunks).
- `plugins/platforms/discord/adapter.py`: the `supports_streaming_tts` / `begin_` / `write_` / `finish_` / `abort_` sink surface plus mixer wiring.
- Fallbacks unchanged: non-streaming providers (edge, the default) and non-VC replies keep the whole-file path; consumer failure pre-audio re-enables whole-file (existing #60671 semantics).

**One disclosed behavior choice:** when `discord.voice_fx.enabled` is false (the default), the sink installs a bare mixer (no ambient bed) on demand so default deployments get streaming too — otherwise the fix would only reach the opt-in voice_fx minority, including not the issue reporter. Join path and ambient gating untouched; happy to gate behind voice_fx instead if reviewers prefer (3-line change).

## Measured proof (synthetic harness, real consumer + mixer + adapter sink, fake streamer/VC)

4-sentence reply, 1.2s-to-first-sentence LLM pacing, 600ms-TTFB streamer:

| | time to first audio | turn releases session |
|---|---|---|
| Before (whole-file) | 4.30s | after synthesis + full playback drain |
| After (streaming sink) | **2.06s** | **at synthesis end, ~2s of audio still playing** |

Projected against the issue's real numbers (4.8s warm LLM + 2.2s whole-file TTS): first audio ~1.8–2.6s instead of ~7s, and the queued-followup window shrinks by the playback-drain duration.

## Tests

- New `tests/gateway/test_discord_streaming_tts.py` — 24 tests: resampler geometry/carry/clipping, child lifecycle (ordering, starvation, EOF tail, abort idempotency), sink gating, mixer auto-install, plus the regression contract: **the first sentence's audio reaches the mixer before `finish()` is called**.
- CI-parity via `scripts/run_tests.sh`: 156 passed / 0 failed across the touched area sweep. `ruff check` clean; `scripts/check-windows-footguns.py` clean.
- Pre-existing Windows-host failures in `test_tts_media_routing.py`/`test_platform_base.py` reproduce identically on clean upstream/main (stash-verified) — unrelated.

## Not in scope (deliberate)

Endpointing constant (UX/config decision), the session-serialization model itself (intentional per AGENTS.md; this shrinks the hold window instead), first-turn bootstrap, and anything in the realtime-voice lane — that's the interface discussion on #77111, not this bug.