### PR TITLE
fix(desktop): add padding-right to tab to prevent close button overlap

### DIFF
--- a/apps/desktop/src/components/ui/pane-tab.tsx
+++ b/apps/desktop/src/components/ui/pane-tab.tsx
@@ -21,7 +21,7 @@ const TAB =
 
 // Full height: with the strip's rule removed there is no last-pixel row to
 // leave uncovered, so tabs fill the bar and no sliver of gutter shows through.
-const TAB_HORIZONTAL = 'h-full min-w-0 max-w-48 not-first:border-l not-first:border-l-(--ui-stroke-quaternary)'
+const TAB_HORIZONTAL = 'h-full min-w-0 max-w-48 pr-5 not-first:border-l not-first:border-l-(--ui-stroke-quaternary)'
 
 const TAB_VERTICAL =
   'w-full max-h-48 justify-center not-first:border-t not-first:border-t-(--ui-stroke-quaternary) [writing-mode:vertical-rl]'


### PR DESCRIPTION
## Summary

This PR fixes #96780 by adding padding-right to the Browser tab to prevent the close button from overlapping with the tab label text.

## Problem

The Browser tab's close button (✕) was overlapping with the tab label text because the tab had no right padding to accommodate the absolute-positioned close button overlay.

## Solution

Added `pr-5` (1.25rem) padding-right to `TAB_HORIZONTAL` constant to create space for the close button:

```typescript
// Before:
const TAB_HORIZONTAL = 'h-full min-w-0 max-w-48 not-first:border-l not-first:border-l-(--ui-stroke-quaternary)'

// After:
const TAB_HORIZONTAL = 'h-full min-w-0 max-w-48 pr-5 not-first:border-l not-first:border-l-(--ui-stroke-quaternary)'
```

## Changes

- Modified `apps/desktop/src/components/ui/pane-tab.tsx`: Added `pr-5` to TAB_HORIZONTAL

---

🤖 Generated with Codebuff
Co-Authored-By: Codebuff <noreply@codebuff.com>