### PR TITLE
fix(api): stream final response when no deltas arrive

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -5567,6 +5567,11 @@ class APIServerAdapter(BasePlatformAdapter):
         try:
             last_activity = time.monotonic()
 
+            # Track real text independently from tool-progress events so a
+            # normally completed run can fall back to its final response when
+            # the provider never invoked the text-delta callback.
+            emitted_text_delta = False
+
             # Role chunk
             role_chunk = {
                 "id": completion_id, "object": "chat.completion.chunk",
@@ -5587,9 +5592,12 @@ class APIServerAdapter(BasePlatformAdapter):
                 conversation history.  See #6972 for the original event,
                 #16588 for the ``toolCallId``/``status`` lifecycle fields.
                 """
+                nonlocal emitted_text_delta
                 if isinstance(item, tuple) and len(item) == 2 and item[0] == "__tool_progress__":
                     await response.write(_sse_frame(item[1], event="hermes.tool.progress"))
                 else:
+                    if isinstance(item, str) and item:
+                        emitted_text_delta = True
                     content_chunk = {
                         "id": completion_id, "object": "chat.completion.chunk",
                         "created": created, "model": model,
@@ -5664,6 +5672,10 @@ class APIServerAdapter(BasePlatformAdapter):
                 finish_reason = "error"
             else:
                 finish_reason = "stop"
+
+            final_response = result.get("final_response") if isinstance(result, dict) else None
+            if finish_reason == "stop" and not emitted_text_delta and isinstance(final_response, str) and final_response:
+                last_activity = await _emit(final_response)
 
             # Finish chunk
             finish_chunk = {

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -5668,14 +5668,14 @@ class APIServerAdapter(BasePlatformAdapter):
             # for truncation, "error" for failure, "stop" for normal completion.
             if is_partial and err_msg and "truncat" in err_msg.lower():
                 finish_reason = "length"
-            elif agent_error is not None or is_failed or (not completed and err_msg):
+            elif agent_error is not None or is_partial or is_failed or not completed or err_msg:
                 finish_reason = "error"
             else:
                 finish_reason = "stop"
 
             final_response = result.get("final_response") if isinstance(result, dict) else None
             if finish_reason == "stop" and not emitted_text_delta and isinstance(final_response, str) and final_response:
-                last_activity = await _emit(final_response)
+                last_activity = await _emit(_resolve_media_to_data_urls(final_response))
 
             # Finish chunk
             finish_chunk = {

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -1037,6 +1037,104 @@ class TestChatCompletionsEndpoint:
         assert kwargs["requested_provider"] == "minimax"
         assert kwargs["model_options"] == model_options
 
+    @pytest.mark.asyncio
+    async def test_stream_falls_back_to_final_response_when_no_deltas(self, adapter):
+        """Streaming clients receive final text when no text callback fires."""
+        app = _create_app(adapter)
+
+        async def _mock_run_agent(**kwargs):
+            assert kwargs.get("stream_delta_callback") is not None
+            return (
+                {"final_response": "pong", "messages": [], "api_calls": 1},
+                {"input_tokens": 10, "output_tokens": 2, "total_tokens": 12},
+            )
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "ping"}],
+                        "stream": True,
+                    },
+                )
+                body = await resp.text()
+
+        assert resp.status == 200
+        chunks = [
+            json.loads(line[len("data: "):])
+            for line in body.splitlines()
+            if line.startswith("data: ") and line.strip() != "data: [DONE]"
+        ]
+        content_chunks = [
+            choice["delta"]["content"]
+            for chunk in chunks
+            for choice in chunk["choices"]
+            if choice.get("delta", {}).get("content")
+        ]
+        finish_chunks = [
+            chunk
+            for chunk in chunks
+            if chunk["choices"][0].get("finish_reason") == "stop"
+        ]
+
+        assert content_chunks == ["pong"]
+        assert len(finish_chunks) == 1
+        assert finish_chunks[0]["usage"] == {
+            "prompt_tokens": 10,
+            "completion_tokens": 2,
+            "total_tokens": 12,
+        }
+        assert body.endswith("data: [DONE]\n\n")
+
+    @pytest.mark.asyncio
+    async def test_stream_final_response_fallback_does_not_duplicate_deltas(self, adapter):
+        """A final response is not emitted again after a real text delta."""
+        app = _create_app(adapter)
+
+        async def _mock_run_agent(**kwargs):
+            kwargs["stream_delta_callback"]("Hello!")
+            return (
+                {"final_response": "Hello!", "messages": [], "api_calls": 1},
+                {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+            )
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "hi"}],
+                        "stream": True,
+                    },
+                )
+                body = await resp.text()
+
+        assert resp.status == 200
+        chunks = [
+            json.loads(line[len("data: "):])
+            for line in body.splitlines()
+            if line.startswith("data: ") and line.strip() != "data: [DONE]"
+        ]
+        content_chunks = [
+            choice["delta"]["content"]
+            for chunk in chunks
+            for choice in chunk["choices"]
+            if choice.get("delta", {}).get("content")
+        ]
+        finish_reasons = [
+            choice["finish_reason"]
+            for chunk in chunks
+            for choice in chunk["choices"]
+            if choice.get("finish_reason") is not None
+        ]
+
+        assert content_chunks == ["Hello!"]
+        assert finish_reasons == ["stop"]
+        assert body.endswith("data: [DONE]\n\n")
+
 
     @pytest.mark.asyncio
     async def test_session_chat_stream_passes_request_model_provider_options(self, adapter):

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -1135,6 +1135,200 @@ class TestChatCompletionsEndpoint:
         assert finish_reasons == ["stop"]
         assert body.endswith("data: [DONE]\n\n")
 
+    @pytest.mark.asyncio
+    async def test_stream_tool_progress_without_text_uses_final_response_fallback(self, adapter):
+        """Tool progress stays out-of-band and does not suppress final text."""
+        app = _create_app(adapter)
+        marker = "TOOL_PROGRESS_FINAL_RESPONSE"
+
+        async def _mock_run_agent(**kwargs):
+            kwargs["tool_start_callback"](
+                "call_terminal_1", "terminal", {"command": "printf ok"}
+            )
+            return (
+                {"final_response": marker, "messages": [], "api_calls": 1},
+                {"input_tokens": 2, "output_tokens": 1, "total_tokens": 3},
+            )
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "run"}],
+                        "stream": True,
+                    },
+                )
+                body = await resp.text()
+
+        chunks = [
+            json.loads(line[len("data: "):])
+            for line in body.splitlines()
+            if line.startswith("data: ") and line.strip() != "data: [DONE]"
+        ]
+        content_chunks = [
+            choice["delta"]["content"]
+            for chunk in chunks
+            for choice in chunk.get("choices", [])
+            if choice.get("delta", {}).get("content")
+        ]
+
+        assert resp.status == 200
+        assert "event: hermes.tool.progress" in body
+        assert content_chunks == [marker]
+        assert body.endswith("data: [DONE]\n\n")
+
+    @pytest.mark.parametrize(
+        ("result", "expected_finish_reason"),
+        [
+            (
+                {
+                    "final_response": "TRUNCATED_MUST_NOT_FALL_BACK",
+                    "completed": False,
+                    "partial": True,
+                    "failed": False,
+                    "error": "output truncated by provider",
+                },
+                "length",
+            ),
+            (
+                {
+                    "final_response": "PARTIAL_MUST_NOT_FALL_BACK",
+                    "completed": True,
+                    "partial": True,
+                    "failed": False,
+                    "error": "provider returned a partial result",
+                },
+                "error",
+            ),
+            (
+                {
+                    "final_response": "FAILED_MUST_NOT_FALL_BACK",
+                    "completed": False,
+                    "partial": False,
+                    "failed": True,
+                    "error": "provider failed",
+                },
+                "error",
+            ),
+            (
+                {
+                    "final_response": "ERROR_MUST_NOT_FALL_BACK",
+                    "completed": True,
+                    "partial": False,
+                    "failed": False,
+                    "error": "provider returned an error",
+                },
+                "error",
+            ),
+        ],
+        ids=("truncated", "partial", "failed", "error"),
+    )
+    @pytest.mark.asyncio
+    async def test_stream_abnormal_result_does_not_emit_final_response_fallback(
+        self, adapter, result, expected_finish_reason
+    ):
+        """Incomplete or errored runs never gain a success-looking text delta."""
+        app = _create_app(adapter)
+        result = {**result, "messages": [], "api_calls": 1}
+
+        async def _mock_run_agent(**kwargs):
+            return (
+                result,
+                {"input_tokens": 2, "output_tokens": 1, "total_tokens": 3},
+            )
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "run"}],
+                        "stream": True,
+                    },
+                )
+                body = await resp.text()
+
+        chunks = [
+            json.loads(line[len("data: "):])
+            for line in body.splitlines()
+            if line.startswith("data: ") and line.strip() != "data: [DONE]"
+        ]
+        content_chunks = [
+            choice["delta"]["content"]
+            for chunk in chunks
+            for choice in chunk["choices"]
+            if choice.get("delta", {}).get("content")
+        ]
+        finish_reasons = [
+            choice["finish_reason"]
+            for chunk in chunks
+            for choice in chunk["choices"]
+            if choice.get("finish_reason") is not None
+        ]
+
+        assert resp.status == 200
+        assert content_chunks == []
+        assert finish_reasons == [expected_finish_reason]
+        assert body.endswith("data: [DONE]\n\n")
+
+    @pytest.mark.asyncio
+    async def test_stream_final_response_fallback_resolves_media_to_data_url(
+        self, adapter, tmp_path
+    ):
+        """Remote streaming clients receive inline media, not local paths."""
+        import base64
+
+        image_bytes = b"\x89PNG\r\n\x1a\n"
+        image_path = tmp_path / "fallback.png"
+        image_path.write_bytes(image_bytes)
+        app = _create_app(adapter)
+
+        async def _mock_run_agent(**kwargs):
+            return (
+                {
+                    "final_response": f"MEDIA:{image_path}",
+                    "messages": [],
+                    "api_calls": 1,
+                },
+                {"input_tokens": 2, "output_tokens": 1, "total_tokens": 3},
+            )
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "image"}],
+                        "stream": True,
+                    },
+                )
+                body = await resp.text()
+
+        chunks = [
+            json.loads(line[len("data: "):])
+            for line in body.splitlines()
+            if line.startswith("data: ") and line.strip() != "data: [DONE]"
+        ]
+        content_chunks = [
+            choice["delta"]["content"]
+            for chunk in chunks
+            for choice in chunk["choices"]
+            if choice.get("delta", {}).get("content")
+        ]
+        expected = (
+            "![image](data:image/png;base64,"
+            f"{base64.b64encode(image_bytes).decode()})"
+        )
+
+        assert resp.status == 200
+        assert content_chunks == [expected]
+        assert str(image_path) not in body
+        assert body.endswith("data: [DONE]\n\n")
+
 
     @pytest.mark.asyncio
     async def test_session_chat_stream_passes_request_model_provider_options(self, adapter):


### PR DESCRIPTION
## What does this PR do?

Fixes an OpenAI-compatible streaming edge case where an agent run completes with a non-empty `final_response` but the provider never invokes `stream_delta_callback`.

Before this change, `/v1/chat/completions` with `stream: true` could emit the assistant role chunk, a terminal finish chunk, and `[DONE]`, but no `delta.content`. OpenAI-compatible clients such as Open WebUI therefore rendered an empty assistant response even though Hermes had produced final text.

The current writer now:

- tracks only non-empty textual callback deltas with a boolean;
- keeps `hermes.tool.progress` events out-of-band and does not count them as text;
- emits `final_response` once only after a normal `finish_reason == "stop"` completion with no prior text;
- applies `_resolve_media_to_data_urls()` before the fallback crosses the OpenAI-compatible boundary;
- does not duplicate callback-streamed content;
- keeps truncation as `length` and classifies `partial`, `failed`, incomplete, exception, and explicit-error results as `error`, so they never gain a success-looking fallback.

## Relationship to #35898

This PR is a current-`main` continuation of #35898 by @justynleung, not an independent rediscovery.

The original deduplication note in this PR was incorrect. The first commit here transplants #35898 onto the current SSE writer while preserving Justyn's authorship. The follow-up commit adds the current-main hardening requested in the review of #35898: boolean state, normal-only error/partial handling, tool-progress separation, and media resolution.

Thank you to @justynleung for the original fix and regression cases.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests
- [ ] ♻️ Refactor
- [ ] 🎯 New skill

## Changes Made

- `gateway/platforms/api_server.py`
  - track whether a non-empty text delta was emitted;
  - preserve custom tool-progress SSE events;
  - emit a media-resolved final-response fallback only for normal completion without prior text;
  - prevent partial/failed/incomplete/explicit-error results from being surfaced as successful streams.
- `tests/gateway/test_api_server.py`
  - fallback with no callback delta;
  - no duplication after callback text;
  - tool progress without text still permits fallback;
  - truncation, partial, failed, incomplete, and explicit-error results do not emit success fallback text;
  - media paths in fallback text are resolved to data URLs.

## Provenance

```text
Base: 3ca096de5f8183cb2e0ec23673f294d5978656a3
Head: 4d8ca34403ba3c4dbe9652b751e750410a1edad0

2a29e735aefd71866428e54cb8622cd89fa1fd4b
  Author: Justyn <justynleung2000@gmail.com>
  fix(api_server): fallback to final response for empty chat streams

4d8ca34403ba3c4dbe9652b751e750410a1edad0
  Author: Felippe Mercurio <fmercurio@gmail.com>
  fix(api): harden final response SSE fallback
```

## How to Test

### Focused regressions

```bash
HERMES_PYTHON="$HOME/.hermes/hermes-agent/.venv/bin/python" \
  scripts/run_tests.sh tests/gateway/test_api_server.py -q \
  -k 'test_stream_falls_back_to_final_response_when_no_deltas or test_stream_final_response_fallback_does_not_duplicate_deltas or test_stream_tool_progress_without_text_uses_final_response_fallback or test_stream_abnormal_result_does_not_emit_final_response_fallback or test_stream_final_response_fallback_resolves_media_to_data_url'
```

Result on the exact head: `8 passed, 0 failed`.

### Complete API-server test file

```bash
HERMES_PYTHON="$HOME/.hermes/hermes-agent/.venv/bin/python" \
  scripts/run_tests.sh tests/gateway/test_api_server.py -q
```

Result on the exact head: `118 passed, 0 failed`.

### Repository-wide suite

```bash
HERMES_PYTHON="$HOME/.hermes/hermes-agent/.venv/bin/python" \
  scripts/run_tests.sh -q
```

The completed repository-wide run was executed on the semantically identical pre-refresh head `170fe7e827090d55bc4ed7ca1442e6260aa40a69` over base `d4611ac83789a8ff6813f6ab8ecd1eefe1f3ba3c`, before rebasing onto four non-overlapping upstream commits. It finished with exit 1 after 672.3 seconds: `42,773 passed, 91 failed, 440 skipped` across 3,552 files. The failures were distributed across 26 files; neither changed file was among them. This is **not** reported as a green repository-wide verdict. On the current exact head, the focused regressions, complete touched file, and static gates were rerun. Upstream CI remains a merge gate.

### Static checks

```bash
python -m py_compile gateway/platforms/api_server.py tests/gateway/test_api_server.py
ruff check gateway/platforms/api_server.py tests/gateway/test_api_server.py
git diff --check 3ca096de5f8183cb2e0ec23673f294d5978656a3..4d8ca34403ba3c4dbe9652b751e750410a1edad0
```

Result: pass.

## Review

Independent source review of the exact pair `3ca096de5f8183cb2e0ec23673f294d5978656a3..4d8ca34403ba3c4dbe9652b751e750410a1edad0` returned **APPROVED**, with no findings.

The reviewer confirmed the two-file scope, normal-only fallback semantics, tool-progress separation, no-duplication guard, abnormal-result handling, media resolution, and queue/drain ordering. The reviewed patch SHA-256 is `2e9af95d5d355b59d4210e1587e65c0321fbaa246d79fd2960554074bf543467`.

Residual gates: the reviewer could not repeat pytest in its isolated interpreter due to missing/incompatible local dependencies, so the canonical Hermes-run results above remain the execution evidence; the repository-wide suite is not green and upstream CI remains mandatory. A future callback shape carrying assistant text outside plain strings would require revisiting `emitted_text_delta`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] Existing work is reconciled and credited (#35898)
- [x] The PR is limited to the two files required by the fix
- [x] Focused regressions pass on the exact head
- [x] The complete touched test file passes on the exact head
- [ ] Repository-wide suite is fully green — completed with the documented failures outside the two touched files above
- [x] Static checks pass
- [x] Tested on macOS arm64

### Runtime boundary

This refresh is source-only. It did not update or restart a canary, gateway, or shared service, and it did not touch DNS, public routes, image promotion, production, or OpenClaw.

Private loopback-only canary evidence already recorded on the PR predates this source refresh and validates the behavioral contract via a compatibility overlay; it is not exact-head deployment evidence and does not authorize merge or runtime promotion. A new exact-head canary/browser pass remains a separate explicit hard gate.

