### PR TITLE
fix(desktop): allow spaces in MEDIA: paths in Desktop renderer

### DIFF
--- a/apps/desktop/src/lib/chat-messages/parts.ts
+++ b/apps/desktop/src/lib/chat-messages/parts.ts
@@ -10,9 +10,9 @@ export function reasoningPart(text: string, timestamp?: number): ChatMessagePart
   return { type: 'reasoning', text, ...(timestamp !== undefined ? { timestamp } : {}) }
 }
 
-const MEDIA_LINE_RE = /(^|\n)[\t ]*[`"']?MEDIA:\s*(?<line>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|\S+)[`"']?[\t ]*(\n|$)/g
+const MEDIA_LINE_RE = /(^|\n)[\t ]*[`"']?MEDIA:\s*(?<line>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|[^\n]+?)[`"']?[\t ]*(\n|$)/g
 
-const MEDIA_TAG_RE = /[`"']?MEDIA:\s*(?<inline>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|\S+)[`"']?/g
+const MEDIA_TAG_RE = /[`"']?MEDIA:\s*(?<inline>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|[^\n]+?)[`"']?/g
 
 function unquoteMediaPath(value: string): string {
   const trimmed = value.trim()


### PR DESCRIPTION
## Summary

This PR fixes #96657 by updating the Desktop renderer's MEDIA: regex to allow spaces in paths.

## Problem

The Desktop renderer's MEDIA: regex used `\S+` which doesn't allow spaces, causing paths with spaces to be truncated at the first space:

```
MEDIA:/home/hermes/Morten - Nobly Kickoff - Opening and cue cards EN.docx
```

Was rendered as a link to `Morten` instead of the full path.

## Solution

Changed `\S+` to `[^\n]+?` (non-greedy match until end of line) in both `MEDIA_LINE_RE` and `MEDIA_TAG_RE`, allowing interior whitespace in unquoted paths.

This matches the behavior of the Python side (`gateway/platforms/base.py`) which allows interior spaces in MEDIA: paths.

## Changes

- Modified `apps/desktop/src/lib/chat-messages/parts.ts`: Updated regex to allow spaces

---

🤖 Generated with Codebuff
Co-Authored-By: Codebuff <noreply@codebuff.com>