### PR TITLE
perf(state): bound compacted display tail reads

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -12014,7 +12014,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         else:
             active_clause = " AND active = 1"
         needs_display_dedupe = include_compacted
-        if include_compacted:
+        if include_compacted and not include_inactive:
             # Desktop always opts into compacted display history, including
             # for sessions that have never compacted. Avoid turning those
             # ordinary bounded reads into a full transcript materialization:
@@ -12030,7 +12030,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     ).fetchone()
                     is not None
                 )
-            if not needs_display_dedupe and not include_inactive:
+            if not needs_display_dedupe:
                 # Keep the fast query active-only even if a concurrent
                 # compaction commits after the probe. That request may see the
                 # new compacted tail on its next refresh, but it cannot mix
@@ -12055,24 +12055,44 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             # transferred to and decoded by Python. Composite user carriers
             # are the one exception: their persisted wrapper differs from the
             # original turn even though their display projection is identical.
-            # Only rows sharing that turn's timestamp/tool identity can be such
-            # a pair, so normalize those collision groups in Python and exclude
-            # their losing SQL winners before paging.
+            # Only summary carriers can change content during display
+            # projection. Normalize those rows in Python, then look up only
+            # the exact raw rows matching their projected dedupe keys. This
+            # keeps legacy imports with coarse timestamps bounded too.
+            from agent.context_compressor import (
+                _MERGED_SUMMARY_DELIMITER,
+                split_user_originated_turn,
+            )
+
+            # The full end marker contains a Unicode em dash, which structured
+            # content stores as a JSON escape. Its stable ASCII core matches
+            # both scalar and sentinel-encoded multimodal carrier content.
+            summary_end_probe = "END OF CONTEXT SUMMARY"
+            carrier_predicate = (
+                "(instr(CAST(content AS TEXT), ?) > 0"
+                " OR instr(CAST(content AS TEXT), ?) > 0)"
+            )
             ranked_display_rows = (
                 "WITH ranked_display_rows AS ("
                 " SELECT id, ROW_NUMBER() OVER ("
-                "  PARTITION BY role, content, timestamp, tool_call_id, tool_calls, tool_name"
+                "  PARTITION BY role, content,"
+                f" CASE WHEN role = 'user' AND {carrier_predicate}"
+                " THEN display_kind END,"
+                " timestamp, tool_call_id, tool_calls, tool_name"
                 "  ORDER BY active DESC, id DESC"
                 " ) AS duplicate_rank"
                 " FROM messages WHERE session_id = ?" + active_clause
                 + ")"
             )
+            ranked_params = [
+                summary_end_probe,
+                _MERGED_SUMMARY_DELIMITER,
+                session_id,
+            ]
 
             def _display_dedupe_key(row):
                 dedupe_content = row["content"]
                 if row["role"] == "user":
-                    from agent.context_compressor import split_user_originated_turn
-
                     candidate = {
                         "role": "user",
                         "content": self._decode_content(row["content"]),
@@ -12110,36 +12130,84 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     conn.execute("BEGIN")
                 try:
                     collision_sql_started = time.perf_counter()
-                    collision_rows = conn.execute(
+                    carrier_rows = conn.execute(
                         ranked_display_rows
-                        + ", exact_user_rows AS ("
-                        " SELECT m.* FROM messages AS m"
+                        + " SELECT m.* FROM messages AS m"
                         " JOIN ranked_display_rows AS ranked ON ranked.id = m.id"
                         " WHERE ranked.duplicate_rank = 1 AND m.role = 'user'"
-                        "), collision_groups AS ("
-                        " SELECT timestamp, tool_call_id, tool_calls, tool_name"
-                        " FROM exact_user_rows"
-                        " GROUP BY timestamp, tool_call_id, tool_calls, tool_name"
-                        " HAVING COUNT(*) > 1"
-                        ")"
-                        " SELECT candidate.* FROM exact_user_rows AS candidate"
-                        " JOIN collision_groups AS collision"
-                        " ON candidate.timestamp IS collision.timestamp"
-                        " AND candidate.tool_call_id IS collision.tool_call_id"
-                        " AND candidate.tool_calls IS collision.tool_calls"
-                        " AND candidate.tool_name IS collision.tool_name"
-                        " ORDER BY candidate.id ASC",
-                        [session_id],
+                        " AND (instr(CAST(m.content AS TEXT), ?) > 0"
+                        " OR instr(CAST(m.content AS TEXT), ?) > 0)"
+                        " ORDER BY m.id ASC",
+                        [
+                            *ranked_params,
+                            summary_end_probe,
+                            _MERGED_SUMMARY_DELIMITER,
+                        ],
                     ).fetchall()
                     collision_sql_seconds = (
                         time.perf_counter() - collision_sql_started
                     )
 
                     normalize_started = time.perf_counter()
+                    collision_rows_by_id = {row["id"]: row for row in carrier_rows}
+                    collision_keys = {
+                        row["id"]: _display_dedupe_key(row) for row in carrier_rows
+                    }
+                    projected_keys = {
+                        key
+                        for row in carrier_rows
+                        for key in [collision_keys[row["id"]]]
+                        if key[1] != row["content"]
+                    }
+                    normalize_seconds = time.perf_counter() - normalize_started
+
+                    # A carrier projection can collide only with another
+                    # carrier or with a raw user row whose content and tool
+                    # identity exactly match the projected key. Rank that
+                    # narrow subset with the same rule as the main CTE.
+                    projected_match_sql = (
+                        "SELECT * FROM ("
+                        " SELECT m.*, ROW_NUMBER() OVER ("
+                        "  PARTITION BY CASE WHEN "
+                        "  (instr(CAST(m.content AS TEXT), ?) > 0"
+                        "   OR instr(CAST(m.content AS TEXT), ?) > 0)"
+                        "  THEN m.display_kind END"
+                        "  ORDER BY m.active DESC, m.id DESC"
+                        " ) AS projected_rank"
+                        " FROM messages AS m WHERE m.session_id = ?"
+                        + active_clause
+                        + " AND m.role IS ? AND m.content IS ?"
+                        " AND m.timestamp IS ? AND m.tool_call_id IS ?"
+                        " AND m.tool_calls IS ? AND m.tool_name IS ?"
+                        ") WHERE projected_rank = 1"
+                    )
+                    collision_lookup_started = time.perf_counter()
+                    for key in projected_keys:
+                        matched_rows = conn.execute(
+                            projected_match_sql,
+                            [
+                                summary_end_probe,
+                                _MERGED_SUMMARY_DELIMITER,
+                                session_id,
+                                *key,
+                            ],
+                        ).fetchall()
+                        for row in matched_rows:
+                            collision_rows_by_id[row["id"]] = row
+                    collision_sql_seconds += (
+                        time.perf_counter() - collision_lookup_started
+                    )
+
+                    normalize_started = time.perf_counter()
+                    collision_rows = sorted(
+                        collision_rows_by_id.values(), key=lambda row: row["id"]
+                    )
                     collision_winners: dict = {}
                     collision_members: dict = {}
                     for row in collision_rows:
-                        key = _display_dedupe_key(row)
+                        key = collision_keys.get(row["id"])
+                        if key is None:
+                            key = _display_dedupe_key(row)
                         collision_members.setdefault(key, []).append(row)
                         current = collision_winners.get(key)
                         if current is None or (row["active"], row["id"]) > (
@@ -12154,7 +12222,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                         for row in members
                         if row["id"] != collision_winners[key]["id"]
                     }
-                    normalize_seconds = time.perf_counter() - normalize_started
+                    normalize_seconds += time.perf_counter() - normalize_started
 
                     page_sql = (
                         ranked_display_rows
@@ -12163,7 +12231,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                         " WHERE ranked.duplicate_rank = 1"
                         f" ORDER BY m.id {'DESC' if latest else 'ASC'}"
                     )
-                    page_params: list = [session_id]
+                    page_params: list = list(ranked_params)
                     if limit is not None and offset >= 0:
                         # Every excluded id can remove at most one fetched row,
                         # so this overfetch is sufficient without putting a
@@ -12172,6 +12240,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                         page_params.append(offset + limit + len(excluded_ids))
                     page_sql_started = time.perf_counter()
                     rows = conn.execute(page_sql, page_params).fetchall()
+                    page_sql_rows = len(rows)
                     page_sql_seconds = time.perf_counter() - page_sql_started
                 finally:
                     if started_read_txn:
@@ -12190,7 +12259,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 "normalize_seconds": normalize_seconds,
                 "page_sql_seconds": page_sql_seconds,
                 "collision_rows": len(collision_rows),
-                "page_rows": len(rows),
+                "page_rows": page_sql_rows,
             }
         else:
             if limit is not None or offset:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -12044,24 +12044,31 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         params: list = [session_id]
         if after_id is not None:
             params.append(after_id)
+        display_perf = None
         if needs_display_dedupe:
             # Compaction epochs copy the protected tail into each new
             # generation, so the same logical message can exist as several
             # rows (identical role/content/timestamp) with different active
             # flags and ids. A display read must surface each message exactly
-            # once: prefer the live row, then the newest generation. Read the
-            # full display set (a session's rows are bounded; the UI-level
-            # 500-row cap lives in the endpoint, not here), dedupe in Python,
-            # then apply paging.
-            with self._read_ctx() as conn:
-                cursor = conn.execute(
-                    "SELECT * FROM messages WHERE session_id = ?" + active_clause
-                    + " ORDER BY id ASC",
-                    [session_id],
-                )
-                all_rows = cursor.fetchall()
-            seen: dict = {}
-            for row in all_rows:
+            # once: prefer the live row, then the newest generation. Collapse
+            # byte-identical copies in SQLite so LIMIT applies before rows are
+            # transferred to and decoded by Python. Composite user carriers
+            # are the one exception: their persisted wrapper differs from the
+            # original turn even though their display projection is identical.
+            # Only rows sharing that turn's timestamp/tool identity can be such
+            # a pair, so normalize those collision groups in Python and exclude
+            # their losing SQL winners before paging.
+            ranked_display_rows = (
+                "WITH ranked_display_rows AS ("
+                " SELECT id, ROW_NUMBER() OVER ("
+                "  PARTITION BY role, content, timestamp, tool_call_id, tool_calls, tool_name"
+                "  ORDER BY active DESC, id DESC"
+                " ) AS duplicate_rank"
+                " FROM messages WHERE session_id = ?" + active_clause
+                + ")"
+            )
+
+            def _display_dedupe_key(row):
                 dedupe_content = row["content"]
                 if row["role"] == "user":
                     from agent.context_compressor import split_user_originated_turn
@@ -12083,7 +12090,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 # them verbatim, so identical tool messages across generations
                 # still collapse, while distinct tool calls that happen to
                 # share role/content/timestamp are never merged.
-                key = (
+                return (
                     row["role"],
                     dedupe_content,
                     row["timestamp"],
@@ -12091,17 +12098,100 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     row["tool_calls"],
                     row["tool_name"],
                 )
-                cur = seen.get(key)
-                if cur is None or (row["active"], row["id"]) > (cur["active"], cur["id"]):
-                    seen[key] = row
-            rows = sorted(seen.values(), key=lambda r: r["id"])
-            if latest:
-                rows = rows[::-1]
+
+            display_started = time.perf_counter()
+            with self._read_ctx() as conn:
+                # Keep the collision probe and the page query on one SQLite
+                # snapshot. Without this, a compaction commit between them can
+                # introduce a new carrier generation after the losing ids were
+                # computed and briefly surface a duplicate in the UI.
+                started_read_txn = not conn.in_transaction
+                if started_read_txn:
+                    conn.execute("BEGIN")
+                try:
+                    collision_sql_started = time.perf_counter()
+                    collision_rows = conn.execute(
+                        ranked_display_rows
+                        + ", exact_user_rows AS ("
+                        " SELECT m.* FROM messages AS m"
+                        " JOIN ranked_display_rows AS ranked ON ranked.id = m.id"
+                        " WHERE ranked.duplicate_rank = 1 AND m.role = 'user'"
+                        "), collision_groups AS ("
+                        " SELECT timestamp, tool_call_id, tool_calls, tool_name"
+                        " FROM exact_user_rows"
+                        " GROUP BY timestamp, tool_call_id, tool_calls, tool_name"
+                        " HAVING COUNT(*) > 1"
+                        ")"
+                        " SELECT candidate.* FROM exact_user_rows AS candidate"
+                        " JOIN collision_groups AS collision"
+                        " ON candidate.timestamp IS collision.timestamp"
+                        " AND candidate.tool_call_id IS collision.tool_call_id"
+                        " AND candidate.tool_calls IS collision.tool_calls"
+                        " AND candidate.tool_name IS collision.tool_name"
+                        " ORDER BY candidate.id ASC",
+                        [session_id],
+                    ).fetchall()
+                    collision_sql_seconds = (
+                        time.perf_counter() - collision_sql_started
+                    )
+
+                    normalize_started = time.perf_counter()
+                    collision_winners: dict = {}
+                    collision_members: dict = {}
+                    for row in collision_rows:
+                        key = _display_dedupe_key(row)
+                        collision_members.setdefault(key, []).append(row)
+                        current = collision_winners.get(key)
+                        if current is None or (row["active"], row["id"]) > (
+                            current["active"],
+                            current["id"],
+                        ):
+                            collision_winners[key] = row
+                    excluded_ids = {
+                        row["id"]
+                        for key, members in collision_members.items()
+                        if len(members) > 1
+                        for row in members
+                        if row["id"] != collision_winners[key]["id"]
+                    }
+                    normalize_seconds = time.perf_counter() - normalize_started
+
+                    page_sql = (
+                        ranked_display_rows
+                        + " SELECT m.* FROM messages AS m"
+                        " JOIN ranked_display_rows AS ranked ON ranked.id = m.id"
+                        " WHERE ranked.duplicate_rank = 1"
+                        f" ORDER BY m.id {'DESC' if latest else 'ASC'}"
+                    )
+                    page_params: list = [session_id]
+                    if limit is not None and offset >= 0:
+                        # Every excluded id can remove at most one fetched row,
+                        # so this overfetch is sufficient without putting a
+                        # potentially-large NOT IN list into SQLite.
+                        page_sql += " LIMIT ?"
+                        page_params.append(offset + limit + len(excluded_ids))
+                    page_sql_started = time.perf_counter()
+                    rows = conn.execute(page_sql, page_params).fetchall()
+                    page_sql_seconds = time.perf_counter() - page_sql_started
+                finally:
+                    if started_read_txn:
+                        conn.execute("ROLLBACK")
+
+            if excluded_ids:
+                rows = [row for row in rows if row["id"] not in excluded_ids]
             rows = rows[offset:]
             if limit is not None:
                 rows = rows[:limit]
             if latest:
                 rows = rows[::-1]
+            display_perf = {
+                "started": display_started,
+                "collision_sql_seconds": collision_sql_seconds,
+                "normalize_seconds": normalize_seconds,
+                "page_sql_seconds": page_sql_seconds,
+                "collision_rows": len(collision_rows),
+                "page_rows": len(rows),
+            }
         else:
             if limit is not None or offset:
                 # SQLite's OFFSET requires LIMIT; -1 means "no limit".
@@ -12112,6 +12202,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 rows = cursor.fetchall()
             if latest:
                 rows.reverse()
+        decode_started = time.perf_counter()
         result = []
         for row in rows:
             msg = dict(row)
@@ -12128,6 +12219,28 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             if msg.get("display_metadata") is not None:
                 msg["display_metadata"] = self._decode_display_metadata(msg["display_metadata"])
             result.append(msg)
+        if display_perf is not None:
+            decode_seconds = time.perf_counter() - decode_started
+            total_seconds = time.perf_counter() - display_perf["started"]
+            if total_seconds >= 0.25:
+                logger.warning(
+                    "Slow compacted session display read: session=%s total_ms=%.1f "
+                    "collision_sql_ms=%.1f normalize_ms=%.1f page_sql_ms=%.1f "
+                    "decode_ms=%.1f collision_rows=%d page_rows=%d returned=%d "
+                    "limit=%s offset=%d latest=%s",
+                    session_id,
+                    total_seconds * 1000,
+                    display_perf["collision_sql_seconds"] * 1000,
+                    display_perf["normalize_seconds"] * 1000,
+                    display_perf["page_sql_seconds"] * 1000,
+                    decode_seconds * 1000,
+                    display_perf["collision_rows"],
+                    display_perf["page_rows"],
+                    len(result),
+                    limit,
+                    offset,
+                    latest,
+                )
         return result
 
     def find_pr_url_messages(self, session_ids: List[str]) -> List[Dict[str, Any]]:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -12013,6 +12013,29 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             active_clause = " AND (active = 1 OR compacted = 1)"
         else:
             active_clause = " AND active = 1"
+        needs_display_dedupe = include_compacted
+        if include_compacted:
+            # Desktop always opts into compacted display history, including
+            # for sessions that have never compacted. Avoid turning those
+            # ordinary bounded reads into a full transcript materialization:
+            # without archived rows there cannot be cross-generation copies
+            # to dedupe, so SQL pagination is already exact.
+            with self._read_ctx() as conn:
+                needs_display_dedupe = (
+                    conn.execute(
+                        "SELECT 1 FROM messages "
+                        "WHERE session_id = ? AND active = 0 AND compacted = 1 "
+                        "LIMIT 1",
+                        [session_id],
+                    ).fetchone()
+                    is not None
+                )
+            if not needs_display_dedupe and not include_inactive:
+                # Keep the fast query active-only even if a concurrent
+                # compaction commits after the probe. That request may see the
+                # new compacted tail on its next refresh, but it cannot mix
+                # duplicate generations in one non-deduped page.
+                active_clause = " AND active = 1"
         keyset_clause = " AND id > ?" if after_id is not None else ""
         sql = (
             "SELECT * FROM messages WHERE session_id = ?"
@@ -12021,7 +12044,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         params: list = [session_id]
         if after_id is not None:
             params.append(after_id)
-        if include_compacted:
+        if needs_display_dedupe:
             # Compaction epochs copy the protected tail into each new
             # generation, so the same logical message can exist as several
             # rows (identical role/content/timestamp) with different active

--- a/tests/hermes_state/test_get_messages_include_compacted.py
+++ b/tests/hermes_state/test_get_messages_include_compacted.py
@@ -111,6 +111,37 @@ class TestIncludeCompacted:
         all_ids = _row_ids(db, sid, include_compacted=True)
         assert [m["id"] for m in page] == all_ids[2:5]
 
+    def test_uncompacted_latest_page_decodes_only_requested_rows(self, db, monkeypatch):
+        """The Desktop tail read stays bounded before any compaction exists."""
+        sid = "uncompacted-long-session"
+        db.create_session(sid, source="desktop")
+        db.append_messages_batch(
+            sid,
+            [{"role": "user", "content": f"message {index}"} for index in range(3_000)],
+        )
+
+        original_decode = db._decode_content
+        decoded = 0
+
+        def _counted_decode(content):
+            nonlocal decoded
+            decoded += 1
+            return original_decode(content)
+
+        monkeypatch.setattr(db, "_decode_content", _counted_decode)
+
+        page = db.get_messages(
+            sid,
+            include_compacted=True,
+            latest=True,
+            limit=120,
+        )
+
+        assert [message["content"] for message in page] == [
+            f"message {index}" for index in range(2_880, 3_000)
+        ]
+        assert decoded == 120
+
 
 class TestDisplayDedupe:
     """Compaction epochs copy the protected tail into each new generation, so

--- a/tests/hermes_state/test_get_messages_include_compacted.py
+++ b/tests/hermes_state/test_get_messages_include_compacted.py
@@ -90,6 +90,26 @@ class TestIncludeCompacted:
         msgs = db.get_messages(sid, include_inactive=True)
         assert len(msgs) == 7  # 4 archived + 1 live + 2 rewound
 
+    def test_combined_inactive_and_compacted_flags_still_dedupe(self, db):
+        """The combined audit/display mode keeps its historical dedupe."""
+        sid = "combined-uncompacted-flags"
+        db.create_session(sid, source="cli")
+        inactive_id = db.append_message(sid, "user", "duplicate", timestamp=1.0)
+        db._execute_write(
+            lambda conn: conn.execute(
+                "UPDATE messages SET active = 0 WHERE id = ?",
+                [inactive_id],
+            )
+        )
+        active_id = db.append_message(sid, "user", "duplicate", timestamp=1.0)
+
+        assert _row_ids(
+            db,
+            sid,
+            include_inactive=True,
+            include_compacted=True,
+        ) == [active_id]
+
     def test_latest_page_with_compacted_rows(self, db):
         """latest=True pages back from the newest message, still in order."""
         sid = "s1"
@@ -184,6 +204,53 @@ class TestIncludeCompacted:
 
         assert [message["content"] for message in page] == [
             f"live message {index}" for index in range(80, 200)
+        ]
+        assert decoded == 120
+
+    def test_coarse_import_timestamps_do_not_expand_collision_decode(
+        self, db, monkeypatch
+    ):
+        """Legacy imports can give thousands of distinct rows one timestamp."""
+        sid = "coarse-import-timestamps"
+        db.create_session(sid, source="desktop")
+        archived_id = db.append_message(sid, "assistant", "archived marker")
+        db._execute_write(
+            lambda conn: conn.execute(
+                "UPDATE messages SET active = 0, compacted = 1 WHERE id = ?",
+                [archived_id],
+            )
+        )
+        db.append_messages_batch(
+            sid,
+            [
+                {
+                    "role": "user",
+                    "content": f"imported message {index}",
+                    "timestamp": 1.0,
+                }
+                for index in range(3_000)
+            ],
+        )
+
+        original_decode = db._decode_content
+        decoded = 0
+
+        def _counted_decode(content):
+            nonlocal decoded
+            decoded += 1
+            return original_decode(content)
+
+        monkeypatch.setattr(db, "_decode_content", _counted_decode)
+
+        page = db.get_messages(
+            sid,
+            include_compacted=True,
+            latest=True,
+            limit=120,
+        )
+
+        assert [message["content"] for message in page] == [
+            f"imported message {index}" for index in range(2_880, 3_000)
         ]
         assert decoded == 120
 
@@ -324,6 +391,47 @@ class TestDisplayDedupe:
 
         assert _row_ids(db, sid, include_compacted=True) == [carrier_id, answer_id]
         assert [message["id"] for message in page] == [carrier_id]
+
+    def test_composite_carriers_with_distinct_display_kinds_are_not_merged(self, db):
+        """Display kind can change whether an identical carrier is projected."""
+        from agent.context_compressor import (
+            HISTORICAL_TASK_HEADING,
+            SUMMARY_PREFIX,
+            _SUMMARY_END_MARKER,
+        )
+
+        sid = "composite-carrier-display-kind"
+        timestamp = 1_700_000_000.0
+        carrier = (
+            f"{SUMMARY_PREFIX}\n{HISTORICAL_TASK_HEADING}\nold task\n\n"
+            f"{_SUMMARY_END_MARKER}\n\nREAL ASK"
+        )
+        db.create_session(sid, source="desktop")
+        hidden_id = db.append_message(
+            sid,
+            "user",
+            carrier,
+            timestamp=timestamp,
+            display_kind="hidden",
+        )
+        db._execute_write(
+            lambda conn: conn.execute(
+                "UPDATE messages SET active = 0, compacted = 1 WHERE id = ?",
+                [hidden_id],
+            )
+        )
+        notification_id = db.append_message(
+            sid,
+            "user",
+            carrier,
+            timestamp=timestamp,
+            display_kind="internal_notification",
+        )
+
+        assert _row_ids(db, sid, include_compacted=True) == [
+            hidden_id,
+            notification_id,
+        ]
 
     def test_distinct_tool_calls_with_same_content_are_not_merged(self, db):
         """Two real tool messages that happen to share role/content/timestamp

--- a/tests/hermes_state/test_get_messages_include_compacted.py
+++ b/tests/hermes_state/test_get_messages_include_compacted.py
@@ -142,6 +142,51 @@ class TestIncludeCompacted:
         ]
         assert decoded == 120
 
+    def test_compacted_latest_page_decodes_only_requested_rows(self, db, monkeypatch):
+        """The Desktop tail read stays bounded after in-place compaction."""
+        sid = "compacted-long-session"
+        db.create_session(sid, source="desktop")
+        db.append_messages_batch(
+            sid,
+            [
+                {"role": "user", "content": f"archived message {index}"}
+                for index in range(3_000)
+            ],
+        )
+        db.archive_and_compact(
+            sid,
+            [{"role": "assistant", "content": "summary of archived turns"}],
+        )
+        db.append_messages_batch(
+            sid,
+            [
+                {"role": "user", "content": f"live message {index}"}
+                for index in range(200)
+            ],
+        )
+
+        original_decode = db._decode_content
+        decoded = 0
+
+        def _counted_decode(content):
+            nonlocal decoded
+            decoded += 1
+            return original_decode(content)
+
+        monkeypatch.setattr(db, "_decode_content", _counted_decode)
+
+        page = db.get_messages(
+            sid,
+            include_compacted=True,
+            latest=True,
+            limit=120,
+        )
+
+        assert [message["content"] for message in page] == [
+            f"live message {index}" for index in range(80, 200)
+        ]
+        assert decoded == 120
+
 
 class TestDisplayDedupe:
     """Compaction epochs copy the protected tail into each new generation, so
@@ -236,6 +281,49 @@ class TestDisplayDedupe:
         page = db.get_messages(sid, include_compacted=True, limit=2, offset=2)
         assert [m["id"] for m in page] == all_ids[2:]
         assert len(page) == 2
+
+    def test_composite_carrier_dedupe_still_applies_before_latest_paging(self, db):
+        """SQL paging must retain the live projection of a wrapped user turn."""
+        from agent.context_compressor import (
+            HISTORICAL_TASK_HEADING,
+            SUMMARY_PREFIX,
+            _SUMMARY_END_MARKER,
+        )
+
+        sid = "composite-carrier-page"
+        timestamp = 1_700_000_000.0
+        db.create_session(sid, source="desktop")
+        original_id = db.append_message(
+            sid,
+            "user",
+            "REAL ASK",
+            timestamp=timestamp,
+        )
+        db._execute_write(
+            lambda conn: conn.execute(
+                "UPDATE messages SET active = 0, compacted = 1 WHERE id = ?",
+                [original_id],
+            )
+        )
+        carrier_id = db.append_message(
+            sid,
+            "user",
+            f"{SUMMARY_PREFIX}\n{HISTORICAL_TASK_HEADING}\nold task\n\n"
+            f"{_SUMMARY_END_MARKER}\n\nREAL ASK",
+            timestamp=timestamp,
+        )
+        answer_id = db.append_message(sid, "assistant", "answer")
+
+        page = db.get_messages(
+            sid,
+            include_compacted=True,
+            latest=True,
+            limit=1,
+            offset=1,
+        )
+
+        assert _row_ids(db, sid, include_compacted=True) == [carrier_id, answer_id]
+        assert [message["id"] for message in page] == [carrier_id]
 
     def test_distinct_tool_calls_with_same_content_are_not_merged(self, db):
         """Two real tool messages that happen to share role/content/timestamp


### PR DESCRIPTION
## What does this PR do?

Desktop requests session messages with `include_compacted=true`. Before this
change, a genuinely compacted session forced `SessionDB.get_messages()` to
fetch, decode, and Python-deduplicate the complete display history before
applying `LIMIT`. In production that turned a 120-message tail request into a
14.7-second stall.

This PR keeps both uncompacted and compacted display reads bounded:

- uncompacted sessions stay on the existing SQL `LIMIT` / `OFFSET` path;
- compacted sessions collapse exact generation copies with SQLite
  `ROW_NUMBER()` before transferring rows to Python;
- only potential composite user carriers are projected in Python, and only
  exact raw rows matching their projected keys are looked up;
- collision detection and page selection share one SQLite read snapshot;
- slow compacted reads log separate collision SQL, normalization, page SQL,
  and decode timings without logging message content.

The existing display-dedupe semantics remain intact for live vs archived
generations, composite carriers, typed display events, tool identities,
`include_inactive`, and pagination.

## Related Issue

Related to #70445, #69640, and #80680.

## Type of Change

- [x] Bug fix
- [x] Performance improvement
- [x] Tests

## How to Test

```bash
scripts/run_tests.sh tests/hermes_state/test_get_messages_include_compacted.py -q
scripts/run_tests.sh tests/hermes_cli/test_web_server.py -k get_session_messages -q
```

Observed locally on macOS / Apple Silicon:

- compacted 3,000-row regression: `3,320 -> 120` content decodes;
- legacy import with 3,000 distinct rows sharing one coarse timestamp:
  `3,120 -> 120` content decodes;
- 30,000 archived rows plus 200 live rows, latest 120 requested: `61.9 ms`
  using SQLite DELETE journal mode.

Verification:

- 17 targeted state tests passed;
- 8 messages-endpoint tests passed;
- 205 Hermes state tests passed; one unrelated live-DB ancestry test fails in
  the restricted local sandbox;
- `ruff check` and `git diff --check` passed;
- an independent review compared 144 combinations of carriers, normal rows,
  pagination, and inactive flags against the previous Python-dedupe behavior.

The complete optional-dependency suite was also attempted in the restricted
desktop sandbox: 38,582 tests passed, while 529 unrelated tests requiring
missing extras, socket binding, process control, or external services failed.

## Checklist

- [x] Conventional commits
- [x] Targeted regression tests
- [x] macOS / Apple Silicon verification
- [x] No message contents added to diagnostics
- [ ] Complete all-extras suite green in upstream CI
