### PR TITLE
fix(agent): gate the provider-agnostic /api/show probe on detected server type

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -2127,6 +2127,20 @@ def _query_ollama_api_show_uncached(model: str, base_url: str, api_key: str = ""
     if _endpoint_blackholed(server_url):
         return None
 
+    # Ollama's native /api/show only exists on actual Ollama servers. Probing
+    # every unrecognized endpoint 404s forever on OpenAI-compatible local
+    # servers (llama.cpp / Lemonade / LM Studio) because failures are
+    # deliberately never cached — every fresh process re-paid the probe.
+    # Mirror the server-type guard query_ollama_num_ctx() already uses.
+    # ollama.com (hosted Ollama) bypasses the local-type detection: it is
+    # definitively Ollama and detection adds nothing but latency there.
+    if "ollama.com" not in server_url:
+        try:
+            if detect_local_server_type(base_url, api_key=api_key) != "ollama":
+                return None
+        except Exception:
+            return None
+
     headers = _auth_headers(api_key)
 
     try:

--- a/tests/agent/test_endpoint_blackhole.py
+++ b/tests/agent/test_endpoint_blackhole.py
@@ -200,7 +200,8 @@ class TestQueryOllamaApiShowBlackhole:
         from agent.model_metadata import _endpoint_blackholed, _query_ollama_api_show_uncached
 
         client = _client_mock(httpx.ConnectTimeout("timed out"))
-        with patch("httpx.Client", return_value=client):
+        with patch("agent.model_metadata.detect_local_server_type", return_value="ollama"), \
+             patch("httpx.Client", return_value=client):
             assert _query_ollama_api_show_uncached("some-model", self.URL) is None
 
         assert client.post.call_count == 1
@@ -219,7 +220,8 @@ class TestQueryOllamaApiShowBlackhole:
         from agent.model_metadata import _endpoint_blackholed, _query_ollama_api_show_uncached
 
         client = _client_mock(httpx.ReadTimeout("slow"))
-        with patch("httpx.Client", return_value=client):
+        with patch("agent.model_metadata.detect_local_server_type", return_value="ollama"), \
+             patch("httpx.Client", return_value=client):
             assert _query_ollama_api_show_uncached("some-model", self.URL) is None
 
         assert _endpoint_blackholed(self.URL) is False

--- a/tests/test_ollama_num_ctx.py
+++ b/tests/test_ollama_num_ctx.py
@@ -130,3 +130,74 @@ class TestQueryOllamaSupportsVision:
         with patch("agent.model_metadata.detect_local_server_type", return_value="vllm"):
             result = query_ollama_supports_vision("llava", "http://localhost:8000/v1")
         assert result is None
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# _query_ollama_api_show_uncached — server-type guard (#96054)
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestQueryOllamaApiShowServerTypeGuard:
+    """The provider-agnostic /api/show probe must not spray 404s at
+    OpenAI-compatible local servers (llama.cpp / Lemonade / LM Studio).
+    Failures are deliberately never cached, so without the guard every
+    fresh process re-paid the probe against a server that can never
+    answer it."""
+
+    def test_returns_none_for_non_ollama_local_server(self):
+        from agent.model_metadata import _query_ollama_api_show_uncached
+
+        with patch(
+            "agent.model_metadata.detect_local_server_type",
+            return_value="lm-studio",
+        ), patch("httpx.Client") as client_cls:
+            result = _query_ollama_api_show_uncached(
+                "Qwen3-30B-A3B-Instruct-2507-GGUF", "http://localhost:13305/api/v1"
+            )
+        assert result is None
+        client_cls.assert_not_called()  # the POST never happens
+
+    def test_returns_none_when_detection_fails(self):
+        from agent.model_metadata import _query_ollama_api_show_uncached
+
+        with patch(
+            "agent.model_metadata.detect_local_server_type",
+            side_effect=RuntimeError("boom"),
+        ), patch("httpx.Client") as client_cls:
+            result = _query_ollama_api_show_uncached(
+                "some-model", "http://localhost:8000/v1"
+            )
+        assert result is None
+        client_cls.assert_not_called()
+
+    def test_probes_when_server_is_ollama(self):
+        from agent.model_metadata import _query_ollama_api_show_uncached
+
+        mock_ctx, mock_client = _mock_httpx_client(
+            {"model_info": {"qwen3.context_length": 40960}}
+        )
+        with patch(
+            "agent.model_metadata.detect_local_server_type",
+            return_value="ollama",
+        ), patch("httpx.Client", return_value=mock_ctx):
+            result = _query_ollama_api_show_uncached(
+                "qwen3", "http://localhost:11434/v1"
+            )
+        assert result == 40960
+        mock_client.post.assert_called_once()
+
+    def test_ollama_com_bypasses_local_detection(self):
+        from agent.model_metadata import _query_ollama_api_show_uncached
+
+        mock_ctx, mock_client = _mock_httpx_client(
+            {"model_info": {"deepseek.context_length": 163840}}
+        )
+        with patch(
+            "agent.model_metadata.detect_local_server_type",
+            side_effect=AssertionError("must not be called for ollama.com"),
+        ), patch("httpx.Client", return_value=mock_ctx):
+            result = _query_ollama_api_show_uncached(
+                "deepseek-v4", "https://ollama.com/v1", api_key="k"
+            )
+        assert result == 163840
+        mock_client.post.assert_called_once()


### PR DESCRIPTION
## What does this PR do?

Stops the `/api/show` 404 spray against OpenAI-compatible local servers.

`_query_ollama_api_show` is deliberately provider-agnostic and POSTs Ollama's native `/api/show` at **any** base_url not recognized as a known hosted provider. Against local servers that aren't Ollama (llama.cpp server, Lemonade, LM Studio) that POST can never succeed — and because probe **failures are deliberately never cached** (a down server must not pin a negative verdict), every fresh process re-pays the probe. With cron jobs and CLI invocations in the mix, a Lemonade server's log showed a steady `Error 404: POST /api/api/show` spray — 3× every ~10 minutes, around the clock.

The fix mirrors the `detect_local_server_type() == "ollama"` guard that this function's siblings (`query_ollama_num_ctx`, `query_ollama_supports_vision`, `_query_local_context_length_uncached`) already use. `ollama.com` bypasses detection: hosted Ollama is definitively Ollama, and detection there adds nothing but latency (the server-type verdict is disk-cached, so the guard adds no recurring cost for local servers either).

Verified in production against a Lemonade (llama.cpp) server: probes went from 18/hour to zero over a 30-minute active-use window, with no change to chat, tool-calling, or model discovery behavior.

## Related Issue

Addresses the `/api/show` 404-spray portion of #96054 (that issue also covers a reasoning-floor timeout and a stale-breaker problem, which this PR does not touch).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/model_metadata.py` — `_query_ollama_api_show_uncached` gains the server-type guard (after the blackhole check, before the POST), with an `ollama.com` bypass.
- `tests/test_ollama_num_ctx.py` — new `TestQueryOllamaApiShowServerTypeGuard`: non-Ollama server → no POST; detection failure → no POST; Ollama server → probes as before; `ollama.com` → bypasses detection and probes.
- `tests/agent/test_endpoint_blackhole.py` — the two blackhole tests that exercise this probe's POST path now declare `server_type="ollama"` explicitly, matching the pattern `TestQueryLocalContextLengthBlackhole` already uses.

## How to Test

1. Point a provider at any OpenAI-compatible non-Ollama local server (llama.cpp `llama-server`, Lemonade, LM Studio) and watch its access log: before this change, each fresh Hermes process POSTs `/api/show` and 404s; after, no such request is made.
2. Against a real Ollama server, behavior is unchanged: context length still resolves from `/api/show` GGUF metadata.
3. `pytest tests/test_ollama_num_ctx.py tests/agent/test_endpoint_blackhole.py tests/agent/test_model_metadata.py tests/agent/test_local_probe_disk_cache.py -q` → 151 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the four suites covering the touched module (151 passed); the full 38k-test suite wasn't runnable in my minimal env, deferring to CI
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu Linux (production Hermes install against a Lemonade server)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
