### PR TITLE
fix(cli): deliver literal-char key mappings with the char as KeyPress.data

### DIFF
--- a/hermes_cli/pt_input_extras.py
+++ b/hermes_cli/pt_input_extras.py
@@ -48,6 +48,53 @@ def _clear_vt100_prefix_cache() -> None:
         pass
 
 
+def _install_literal_char_data_patch() -> bool:
+    """Deliver literal-char table entries with the char itself as ``KeyPress.data``.
+
+    ``ANSI_SEQUENCES`` entries installed for Shift+letter (→ uppercase char,
+    e.g. ``\\x1b[27;2;83~`` → ``'S'``), Shift+Space (→ ``' '``) and kitty
+    keypad digits map an escape sequence to a *bare character*. prompt_toolkit
+    then emits ``KeyPress(key=<char>, data=<raw escape sequence>)`` because
+    the parser passes the matched prefix as ``data`` — and the stock
+    ``Keys.Any`` binding inserts ``event.data``, so the raw sequence leaks
+    into the prompt buffer as literal text (#97413: Ghostty under
+    modifyOtherKeys=2 re-encodes every Shift+letter this way).
+
+    Stock prompt_toolkit never maps escape sequences to bare characters, so
+    wrapping ``Vt100Parser._call_handler`` to substitute the char as ``data``
+    only affects Hermes-installed literal entries: plain typed characters
+    (``key == data``), ``Keys`` enum targets and tuple expansions
+    (``data=''`` after the first element) all fall outside the condition.
+    Idempotent via a module sentinel.
+    """
+    try:
+        import prompt_toolkit.input.vt100_parser as _vt100_mod
+        from prompt_toolkit.keys import Keys
+    except Exception:
+        return False
+
+    if getattr(_vt100_mod, "_hermes_literal_char_patched", False):
+        return True
+
+    _orig_call_handler = _vt100_mod.Vt100Parser._call_handler
+
+    def _patched_call_handler(self_parser, key, insert_text):
+        if (
+            isinstance(key, str)
+            and not isinstance(key, Keys)
+            and len(key) == 1
+            and isinstance(insert_text, str)
+            and insert_text.startswith("\x1b")
+            and insert_text != key
+        ):
+            insert_text = key
+        return _orig_call_handler(self_parser, key, insert_text)
+
+    _vt100_mod.Vt100Parser._call_handler = _patched_call_handler
+    _vt100_mod._hermes_literal_char_patched = True
+    return True
+
+
 def install_shift_enter_alias() -> int:
     """Map Shift+Enter byte sequences to the (Escape, ControlM) key tuple
     that Alt+Enter produces, so the existing Alt+Enter newline handler
@@ -491,6 +538,11 @@ def install_modify_other_keys_aliases() -> int:
     # created before this install (or in earlier tests) can't misparse.
     if changed:
         _clear_vt100_prefix_cache()
+
+    # Literal-char entries installed above (Shift+letter, Shift+Space, kitty
+    # keypad digits) must carry the char as KeyPress.data, or the raw escape
+    # sequence leaks into the prompt buffer via the Keys.Any insert (#97413).
+    _install_literal_char_data_patch()
 
     return changed
 

--- a/tests/cli/test_modify_other_keys_aliases.py
+++ b/tests/cli/test_modify_other_keys_aliases.py
@@ -560,3 +560,59 @@ def test_lock_bits_on_cmd_backspace_alias():
     assert _parse("\x1b[127;137u") == [Keys.ControlU]  # Cmd+Backspace + NumLock
     assert _parse("\x1b[127;73u") == [Keys.ControlU]   # Cmd+Backspace + Caps
     assert _parse("\x1b[3;137~") == [Keys.ControlK]    # Cmd+FwdDel + NumLock
+
+
+# ---------------------------------------------------------------------------
+# Literal-char entries: KeyPress.data must be the char, not the raw sequence
+# (#97413) — the stock Keys.Any binding inserts event.data into the buffer.
+# ---------------------------------------------------------------------------
+
+def _parse_presses(byte_seq: str):
+    """Feed bytes through the VT100 parser, returning full KeyPress objects."""
+    from prompt_toolkit.key_binding.key_processor import KeyPress
+    out: list[KeyPress] = []
+    parser = Vt100Parser(out.append)
+    for ch in byte_seq:
+        parser.feed(ch)
+    parser.flush()
+    return out
+
+
+@pytest.mark.parametrize("letter", [chr(c) for c in range(ord('a'), ord('z') + 1)])
+def test_shift_letter_data_is_the_uppercase_char(letter):
+    """Shift+<letter> under either protocol must carry the uppercase char as
+    ``KeyPress.data`` — the raw sequence leaks into the prompt buffer
+    otherwise (Ghostty modifyOtherKeys=2, #97413)."""
+    for seq in (f"\x1b[27;2;{ord(letter)}~", f"\x1b[{ord(letter)};2u"):
+        presses = _parse_presses(seq)
+        assert [(kp.key, kp.data) for kp in presses] == [(letter.upper(), letter.upper())], (
+            f"{seq!r} must produce KeyPress(key={letter.upper()!r}, "
+            f"data={letter.upper()!r}), got {[(kp.key, kp.data) for kp in presses]}"
+        )
+
+
+def test_shift_space_data_is_a_space():
+    """Shift+Space must insert a space via data, not the raw sequence."""
+    for seq in ("\x1b[27;2;32~", "\x1b[32;2u"):
+        presses = _parse_presses(seq)
+        assert [(kp.key, kp.data) for kp in presses] == [(" ", " ")], seq
+
+
+def test_kitty_keypad_digit_data_is_the_digit():
+    """Kitty keypad digits (PUA codepoints) must carry the digit as data."""
+    presses = _parse_presses("\x1b[57399u")  # KP_0
+    assert [(kp.key, kp.data) for kp in presses] == [("0", "0")]
+
+
+def test_plain_typed_char_data_unchanged():
+    """Ordinary typed characters keep key == data (patch must not touch them)."""
+    assert [(kp.key, kp.data) for kp in _parse_presses("sx")] == [("s", "s"), ("x", "x")]
+
+
+def test_ctrl_combo_data_keeps_raw_sequence():
+    """Keys-enum targets (Ctrl combos) keep the stock data semantics — only
+    literal-char entries get the data substitution."""
+    presses = _parse_presses("\x1b[27;5;97~")  # Ctrl+a (codepoint of 'a')
+    assert len(presses) == 1
+    assert presses[0].key == Keys.ControlA
+    assert presses[0].data == "\x1b[27;5;97~"


### PR DESCRIPTION
## What does this PR do?

Fixes the Ghostty regression where pressing Shift+<letter> in the interactive chat CLI inserted the raw escape sequence (`^[[27;2;83~`) instead of the uppercase character (#97413).

Root cause is one layer deeper than the alias table: `install_modify_other_keys_aliases()` maps `ESC[27;2;<cp>~` to a **bare uppercase string** in `ANSI_SEQUENCES`. prompt_toolkit's `Vt100Parser._call_handler(match, prefix)` then emits `KeyPress(key='S', data='\x1b[27;2;83~')` — the matched prefix is always the raw sequence — and the stock `Keys.Any` binding inserts `event.data` into the buffer. So the table lookup succeeds (the key *is* 'S', which is why the existing key-only tests pass) while the visible insert is the 8-byte raw sequence. Stock prompt_toolkit never maps escape sequences to bare characters, so nothing upstream corrects the data.

Ghostty is the terminal that actually triggers this: the Ghostty exception path pushes only modifyOtherKeys level 2 (no Kitty CSI-u), and modifyOtherKeys=2 re-encodes every Shift+letter as `ESC[27;2;<cp>~`. Kitty-protocol terminals keep sending the plain byte for printable Shift+letter, which is why the CSI-u side of the same mapping never leaked.

The fix wraps `Vt100Parser._call_handler` (idempotent, module sentinel — same pattern as the existing bracketed-paste patch) and substitutes the character as `data` for Hermes-installed literal-char entries: single non-`Keys` character keys whose `data` is a different escape sequence. This also repairs the sibling literal mappings in one pass: Shift+Space (`ESC[27;2;32~` → `" "`) and kitty keypad digits (`ESC[57399u` → `"0"`). Plain typed characters (`key == data`), `Keys`-enum targets (Ctrl combos keep the stock data semantics), and tuple expansions (`(Escape, x)` — data is `''` after the first element) all fall outside the condition and are untouched.

## Related Issue

Fixes #97413

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/pt_input_extras.py`: added `_install_literal_char_data_patch()` — wraps `Vt100Parser._call_handler` so literal-char table entries carry the char as `KeyPress.data`; called at the end of `install_modify_other_keys_aliases()` next to the existing prefix-cache clear.
- `tests/cli/test_modify_other_keys_aliases.py`: new regression tests asserting the **data** layer (the existing suite only asserted `kp.key`): Shift+letter (both modifyOtherKeys and CSI-u forms, all 26 letters), Shift+Space, kitty keypad digit, plus two guards — plain typed chars keep `key == data`, and Ctrl combos keep the raw sequence as data.

## How to Test

1. `pytest tests/cli/test_modify_other_keys_aliases.py tests/cli/test_cli_shift_enter_newline.py tests/cli/test_cli_cmd_backspace.py tests/cli/test_cli_terminal_shortcuts.py tests/hermes_cli/test_curses_arrow_keys.py -q` — 285 passed. Full `pytest tests/cli/ -q`: 1340 passed; the single `test_resume_quiet_stderr` failure is a pre-existing order-coupled flake reproduced identically on clean upstream/main (passes when run alone, with or without this diff).
2. End-to-end repro on macOS via pty (`TERM_PROGRAM=ghostty TERM=xterm-ghostty hermes --yolo`): before the fix, writing `\x1b[27;2;83~` to the pty rendered `^[[27;2;83~` (ESC shown as the blue control-char form) in the composer; after the fix the same write inserts a clean `S` (observed result: composer renders `S`; `\x1b[27;2;32~` inserts a space).
3. A `sitecustomize` probe on the unpatched build confirmed the failure chain directly: `_call_handler` received `key='S'` with the raw sequence as data, i.e. the parser layer was correct and only the data payload was wrong.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64), pty-driven Ghostty emulation

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (the new function is fully documented in its docstring)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (parser-level patch applies identically on all platforms; no Windows-specific input path touches these sequences)
