### PR TITLE
fix(desktop): use stored session identity for reactions

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/use-message-reactions.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/use-message-reactions.ts
@@ -2,6 +2,7 @@ import { useAuiState, useMessageRuntime } from '@assistant-ui/react'
 import { useStore } from '@nanostores/react'
 import { type MouseEvent, useCallback } from 'react'
 
+import { useSessionView } from '@/app/chat/session-view'
 import type { ChatMessage } from '@/lib/chat-messages'
 import { triggerHaptic } from '@/lib/haptics'
 import { QUICK_REACTIONS, toggleMessageReaction } from '@/store/reactions'
@@ -41,12 +42,13 @@ function commitReaction(
   role: ChatMessage['role'],
   rowId: number | undefined,
   reactions: MessageReaction[],
-  emoji: null | string
+  emoji: null | string,
+  sessionId: null | string
 ): void {
   // Flip the UI immediately — a tapback is direct manipulation and must never
   // wait on a round-trip. Persistence follows in the background.
   setLocalReaction(messageId, emoji)
-  void toggleMessageReaction({ id: messageId, role, rowId, reactions } as ChatMessage, emoji)
+  void toggleMessageReaction({ id: messageId, role, rowId, reactions } as ChatMessage, emoji, 'user', sessionId)
 }
 
 /**
@@ -81,12 +83,16 @@ export function useMessageReactions(
   const enabled = useStore($reactionsEnabled)
   const localAll = useStore($localReactions)
   const agentLive = useStore($agentReactions)
+  const sessionView = useSessionView()
+  const runtimeSessionId = useStore(sessionView.$runtimeId)
+  const storedSessionId = useStore(sessionView.$storedId)
+  const sessionId = runtimeSessionId ?? storedSessionId
 
   return {
     enabled,
     react: useCallback(
-      (emoji: null | string) => commitReaction(messageId, role, rowId, reactions, emoji),
-      [messageId, reactions, role, rowId]
+      (emoji: null | string) => commitReaction(messageId, role, rowId, reactions, emoji, sessionId),
+      [messageId, reactions, role, rowId, sessionId]
     ),
     reactions: mergeReactions(reactions, localAll[messageId], rowId === undefined ? undefined : agentLive[rowId])
   }
@@ -107,6 +113,10 @@ export function useTapbackDoubleClick(
 ): ((event: MouseEvent<HTMLElement>) => void) | undefined {
   const enabled = useStore($reactionsEnabled)
   const messageRuntime = useMessageRuntime()
+  const sessionView = useSessionView()
+  const runtimeSessionId = useStore(sessionView.$runtimeId)
+  const storedSessionId = useStore(sessionView.$storedId)
+  const sessionId = runtimeSessionId ?? storedSessionId
 
   const onDoubleClick = useCallback(
     (event: MouseEvent<HTMLElement>) => {
@@ -136,10 +146,11 @@ export function useTapbackDoubleClick(
         role,
         custom.rowId,
         reactions,
-        mine?.emoji === DOUBLE_CLICK_REACTION ? null : DOUBLE_CLICK_REACTION
+        mine?.emoji === DOUBLE_CLICK_REACTION ? null : DOUBLE_CLICK_REACTION,
+        sessionId
       )
     },
-    [messageId, messageRuntime, role]
+    [messageId, messageRuntime, role, sessionId]
   )
 
   return enabled ? onDoubleClick : undefined

--- a/apps/desktop/src/store/reactions.test.ts
+++ b/apps/desktop/src/store/reactions.test.ts
@@ -1,9 +1,58 @@
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { applyReaction, QUICK_REACTIONS } from '@/store/reactions'
 import type { MessageReaction } from '@/types/hermes'
 
+const reactionTestState = vi.hoisted(() => {
+  const store = <T>(initial: T) => {
+    let value = initial
+
+    return {
+      get: () => value,
+      set: (next: T | ((current: T) => T)) => {
+        value = typeof next === 'function' ? (next as (current: T) => T)(value) : next
+      }
+    }
+  }
+  const gateway = { request: vi.fn(async (..._args: any[]) => ({ row_id: 7, reactions: [] })) }
+
+  return {
+    activeSessionId: store<string | null>(null),
+    gateway,
+    gatewayStore: store(gateway),
+    messages: store<any[]>([]),
+    requestForOwnedSession: vi.fn(
+      async <T>(
+        _sessionId: string | null,
+        request: typeof gateway.request,
+        method: string,
+        params: Record<string, unknown>
+      ) => request(method, params) as Promise<T>
+    ),
+    selectedStoredSessionId: store<string | null>(null)
+  }
+})
+
+vi.mock('@/store/gateway', () => ({ $gateway: reactionTestState.gatewayStore }))
+vi.mock('@/store/notifications', () => ({ notifyError: vi.fn() }))
+vi.mock('@/store/session-states', () => ({ requestForOwnedSession: reactionTestState.requestForOwnedSession }))
+vi.mock('@/store/session', () => ({
+  $activeSessionId: reactionTestState.activeSessionId,
+  $messages: reactionTestState.messages,
+  $selectedStoredSessionId: reactionTestState.selectedStoredSessionId,
+  setMessages: (update: (messages: any[]) => any[]) =>
+    reactionTestState.messages.set(update(reactionTestState.messages.get()))
+}))
+
+import { applyReaction, QUICK_REACTIONS, toggleMessageReaction } from '@/store/reactions'
 const at = 1_700_000_000
+
+beforeEach(() => {
+  reactionTestState.activeSessionId.set(null)
+  reactionTestState.selectedStoredSessionId.set(null)
+  reactionTestState.messages.set([])
+  reactionTestState.gateway.request.mockClear()
+  reactionTestState.requestForOwnedSession.mockClear()
+})
 
 function reaction(emoji: string, author: MessageReaction['author']): MessageReaction {
   return { emoji, author, at }
@@ -55,5 +104,28 @@ describe('QUICK_REACTIONS', () => {
   it('is the six iOS Tapback defaults, each distinct', () => {
     expect(QUICK_REACTIONS).toHaveLength(6)
     expect(new Set(QUICK_REACTIONS).size).toBe(6)
+  })
+})
+
+describe('toggleMessageReaction session binding', () => {
+  it('uses the selected stored session while its runtime id is unset', async () => {
+    reactionTestState.selectedStoredSessionId.set('stored-session')
+
+    await toggleMessageReaction({ id: 'message-1', role: 'assistant', parts: [] }, '❤️')
+
+    expect(reactionTestState.requestForOwnedSession).toHaveBeenCalledWith(
+      'stored-session',
+      expect.any(Function),
+      'message.react',
+      expect.objectContaining({ session_id: 'stored-session', newest_role: 'assistant', emoji: '❤️' })
+    )
+    expect(reactionTestState.gateway.request).toHaveBeenCalledTimes(1)
+  })
+
+  it('still rejects a genuinely new draft with no session identity', async () => {
+    await toggleMessageReaction({ id: 'message-1', role: 'assistant', parts: [] }, '❤️')
+
+    expect(reactionTestState.requestForOwnedSession).not.toHaveBeenCalled()
+    expect(reactionTestState.gateway.request).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/store/reactions.ts
+++ b/apps/desktop/src/store/reactions.ts
@@ -1,7 +1,8 @@
 import type { ChatMessage } from '@/lib/chat-messages'
-import { activeGateway } from '@/store/gateway'
+import { $gateway } from '@/store/gateway'
 import { notifyError } from '@/store/notifications'
-import { $activeSessionId, $messages, setMessages } from '@/store/session'
+import { $activeSessionId, $messages, $selectedStoredSessionId, setMessages } from '@/store/session'
+import { requestForOwnedSession } from '@/store/session-states'
 import type { MessageReaction } from '@/types/hermes'
 
 /** The six iOS Tapback defaults, in Apple's order. */
@@ -51,15 +52,22 @@ function writeReactions(messageId: string, reactions: MessageReaction[], rowId?:
 export async function toggleMessageReaction(
   message: ChatMessage,
   emoji: null | string,
-  author: MessageReaction['author'] = 'user'
+  author: MessageReaction['author'] = 'user',
+  sessionIdOverride?: null | string
 ): Promise<void> {
   // A live message hasn't round-tripped through a resume yet, so it carries no
   // rowId. Rather than disable the affordance (which made reactions invisible
   // in any active conversation), let the backend resolve the newest row of
   // this role — which is exactly the message being reacted to.
   const rowId = message.rowId
-  const sessionId = $activeSessionId.get()
-  const gateway = activeGateway()
+  // The runtime id is unavailable while a stored conversation is being
+  // resumed (and can briefly be cleared during a profile/context switch), but
+  // the mounted transcript is still owned by the selected stored session.
+  // Use that durable identity as the routing fallback instead of treating a
+  // visible conversation as a draft. A genuinely new draft has neither id.
+  const sessionId =
+    sessionIdOverride === undefined ? ($activeSessionId.get() ?? $selectedStoredSessionId.get()) : sessionIdOverride
+  const gateway = $gateway.get()
 
   if (!sessionId || !gateway) {
     notifyError(new Error(!sessionId ? 'No active session' : 'Gateway not connected'), 'Could not react')
@@ -72,12 +80,20 @@ export async function toggleMessageReaction(
   writeReactions(message.id, applyReaction(snapshot, emoji, author))
 
   try {
-    const result = await gateway.request<MessageReactResponse>('message.react', {
-      session_id: sessionId,
-      ...(rowId === undefined ? { newest_role: message.role } : { row_id: rowId }),
-      emoji,
-      author
-    })
+    // Keep reaction writes on the session's owning backend. The selected
+    // stored-id fallback above is especially important here: owner lookup can
+    // resolve it even while the runtime binding is still being rebuilt.
+    const result = await requestForOwnedSession<MessageReactResponse>(
+      sessionId,
+      gateway.request.bind(gateway) as typeof gateway.request,
+      'message.react',
+      {
+        session_id: sessionId,
+        ...(rowId === undefined ? { newest_role: message.role } : { row_id: rowId }),
+        emoji,
+        author
+      }
+    )
 
     // Learn the row id from the response so later toggles address it directly.
     writeReactions(message.id, result?.reactions ?? [], result?.row_id)


### PR DESCRIPTION
## What does this PR do?

Fixes the renderer-side failure in #97277 where the desktop reaction path shows `Could not react — No active session` before sending any RPC when a visible stored conversation has no runtime `$activeSessionId` during resume or context re-binding.

## Related Issue

Fixes #97277

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Resolve the reaction session identity from `$activeSessionId`, falling back to `$selectedStoredSessionId` for mounted stored conversations.
- Pass the session identity from `SessionView` into picker and double-click reaction actions, including tile views.
- Route `message.react` through `requestForOwnedSession` so the write follows the session owner rather than the ambient gateway.
- Preserve the no-session guard for genuinely new drafts.
- Add focused regression coverage for stored-session fallback and draft rejection.

## How to Test

1. `npm test -- --project ui src/store/reactions.test.ts`
2. `npm run typecheck`
3. `npm run lint -- --quiet`
4. `npx prettier --check src/store/reactions.ts src/store/reactions.test.ts src/components/assistant-ui/thread/use-message-reactions.ts`

All focused tests, typecheck, lint, and formatting checks pass.

## Checklist

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide
- [x] I've updated relevant documentation — N/A
- [x] I've updated config documentation — N/A

## Screenshots / Logs

N/A — renderer state/routing fix covered by focused tests.
