### PR TITLE
fix(codex): avoid orphaned Responses message IDs

### DIFF
--- a/agent/responses_replay_identity.py
+++ b/agent/responses_replay_identity.py
@@ -1,0 +1,77 @@
+"""Responses replay identity safety.
+
+Provider-issued assistant ``message`` IDs can depend on a preceding native
+``reasoning`` item identity. Hermes intentionally strips reasoning IDs when
+replaying stateless Responses history (``store=False``), so a dependent
+``msg_*`` ID must not survive on the outgoing request by itself.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def enforce_responses_replay_identity_closure(
+    api_kwargs: Any, *, drop_all_message_ids: bool = False,
+) -> Any:
+    """Return request kwargs with unsafe Responses ``message.id`` values removed.
+
+    The function is deliberately a final wire guard:
+
+    * after a ``reasoning`` item, typed assistant ``message`` IDs are removed
+      until a real output-group boundary is reached;
+    * a ``function_call`` does not close the group because commentary/final
+      messages may still belong to the same reasoning output group;
+    * ``function_call_output`` and ordinary role messages close the group;
+    * when reasoning replay has been disabled for the session, all typed
+      assistant message IDs are removed because their original dependency can
+      no longer be proven from the remaining history.
+
+    Only the native identity is removed. Content, status, phase, tool pairing,
+    and independent message IDs are preserved. The input object is not mutated.
+    """
+    if not isinstance(api_kwargs, dict):
+        return api_kwargs
+    raw_items = api_kwargs.get("input")
+    if not isinstance(raw_items, list):
+        return api_kwargs
+
+    pending_reasoning_identity = False
+    changed = False
+    normalized_items: list[Any] = []
+
+    for raw_item in raw_items:
+        if not isinstance(raw_item, dict):
+            normalized_items.append(raw_item)
+            continue
+
+        item_type = raw_item.get("type")
+        if item_type == "reasoning":
+            # Preflight intentionally removes reasoning.id for store=False.
+            # Any native message identity in this output group must degrade
+            # symmetrically or the server sees an orphaned msg_* item.
+            pending_reasoning_identity = True
+
+        item = raw_item
+        if item_type == "message" and (
+            pending_reasoning_identity or drop_all_message_ids
+        ) and "id" in raw_item:
+            item = dict(raw_item)
+            item.pop("id", None)
+            changed = True
+
+        normalized_items.append(item)
+
+        # Tool execution completes the reasoning/tool output group. Untyped
+        # role messages are also explicit conversation boundaries. A bare
+        # function_call is intentionally NOT a boundary.
+        if item_type == "function_call_output" or (
+            item_type is None and raw_item.get("role") in {"user", "assistant"}
+        ):
+            pending_reasoning_identity = False
+
+    if not changed:
+        return api_kwargs
+    sanitized = dict(api_kwargs)
+    sanitized["input"] = normalized_items
+    return sanitized

--- a/agent/turn_api_call.py
+++ b/agent/turn_api_call.py
@@ -15,6 +15,7 @@ import time
 from typing import Any, Dict, Optional
 
 from agent.message_metadata import append_message
+from agent.responses_replay_identity import enforce_responses_replay_identity_closure
 
 logger = logging.getLogger("agent.conversation_loop")
 
@@ -84,6 +85,17 @@ def perform_api_call(
             next_api_kwargs = agent._get_transport().preflight_kwargs(
                 next_api_kwargs, allow_stream=False, is_github_responses=agent._is_copilot_url(),
                 sanitize_harmony_tokens=agent._is_codex_backend(),
+            )
+            # Final wire guard after middleware + preflight. Stateless Responses
+            # replay strips rs_* reasoning identities; never let a dependent
+            # msg_* identity reach the provider by itself. If encrypted replay
+            # has been disabled for recovery, no historical message identity can
+            # be proven independent, so degrade all typed message IDs.
+            next_api_kwargs = enforce_responses_replay_identity_closure(
+                next_api_kwargs,
+                drop_all_message_ids=not bool(
+                    getattr(agent, "_codex_reasoning_replay_enabled", True)
+                ),
             )
         if _use_streaming:
             return agent._interruptible_streaming_api_call(

--- a/contributors/emails/saleh.fekry@gmail.com
+++ b/contributors/emails/saleh.fekry@gmail.com
@@ -1,0 +1,1 @@
+salehelsayed

--- a/tests/agent/test_responses_replay_identity.py
+++ b/tests/agent/test_responses_replay_identity.py
@@ -1,0 +1,101 @@
+from copy import deepcopy
+
+from agent.responses_replay_identity import enforce_responses_replay_identity_closure
+
+
+def _message(item_id: str = "msg_1", text: str = "answer"):
+    return {
+        "type": "message",
+        "role": "assistant",
+        "status": "completed",
+        "phase": "final_answer",
+        "id": item_id,
+        "content": [{"type": "output_text", "text": text}],
+    }
+
+
+def _reasoning():
+    return {
+        "type": "reasoning",
+        "encrypted_content": "sealed",
+        "summary": [],
+    }
+
+
+def test_drops_message_id_linked_to_reasoning():
+    request = {"input": [_reasoning(), _message()]}
+
+    sanitized = enforce_responses_replay_identity_closure(request)
+
+    assert "id" not in sanitized["input"][1]
+    assert sanitized["input"][1]["phase"] == "final_answer"
+    assert sanitized["input"][1]["content"] == [
+        {"type": "output_text", "text": "answer"}
+    ]
+
+
+def test_reasoning_dependency_stays_open_through_function_call():
+    request = {
+        "input": [
+            _reasoning(),
+            {
+                "type": "function_call",
+                "call_id": "call_1",
+                "name": "read_file",
+                "arguments": "{}",
+            },
+            _message("msg_commentary", "still working"),
+        ]
+    }
+
+    sanitized = enforce_responses_replay_identity_closure(request)
+
+    assert "id" not in sanitized["input"][2]
+
+
+def test_tool_output_closes_reasoning_dependency_group():
+    request = {
+        "input": [
+            _reasoning(),
+            {
+                "type": "function_call",
+                "call_id": "call_1",
+                "name": "read_file",
+                "arguments": "{}",
+            },
+            {"type": "function_call_output", "call_id": "call_1", "output": "ok"},
+            _message("msg_independent"),
+        ]
+    }
+
+    sanitized = enforce_responses_replay_identity_closure(request)
+
+    assert sanitized["input"][-1]["id"] == "msg_independent"
+
+
+def test_keeps_independent_message_id_without_reasoning_dependency():
+    request = {"input": [_message("msg_independent")]}
+
+    sanitized = enforce_responses_replay_identity_closure(request)
+
+    assert sanitized is request
+    assert sanitized["input"][0]["id"] == "msg_independent"
+
+
+def test_drop_all_mode_removes_message_ids_when_reasoning_replay_is_disabled():
+    request = {"input": [_message("msg_unknown_dependency")]}
+
+    sanitized = enforce_responses_replay_identity_closure(
+        request, drop_all_message_ids=True
+    )
+
+    assert "id" not in sanitized["input"][0]
+
+
+def test_does_not_mutate_original_request():
+    request = {"input": [_reasoning(), _message()]}
+    original = deepcopy(request)
+
+    enforce_responses_replay_identity_closure(request)
+
+    assert request == original


### PR DESCRIPTION
## What does this PR do?

Fixes #97442.
Related to #97427, which appears to report the same GPT-5.6 Responses replay failure.

Hermes intentionally strips replayed reasoning-item IDs when `store=false` because some Responses-compatible endpoints otherwise try to look them up server-side. A dependent native assistant `msg_*` ID can nevertheless survive, producing an invalid partial item graph such as:

```text
reasoning{encrypted_content} -> message{id: msg_*}
```

GPT-5.6 rejects that request because the message identity depends on the stripped `rs_*` reasoning identity.

This refreshed implementation is rebased onto current `main` and enforces the invariant at the final provider-call boundary, after request middleware and Responses preflight:

- if a native `reasoning` item starts an output group, dependent typed assistant `message` IDs are removed until a real group boundary;
- a `function_call` does not prematurely close the reasoning group;
- `function_call_output` and ordinary role messages close the group;
- if encrypted reasoning replay has been disabled for recovery, all typed assistant message IDs are omitted because their original dependency can no longer be proven;
- independent message IDs are preserved, so the existing cache optimization remains where it is demonstrably safe;
- message content, status, phase, and tool-call pairing are unchanged.

## Current-main refresh

The original PR head had become conflicted after substantial upstream refactoring. On 2026-09-11 the branch was rebuilt as a single focused commit on current `main` (`ad03f20dd61919ca2135d6904e787a94284aacaf`) rather than mechanically resolving the old diff.

Current changes:

- `agent/responses_replay_identity.py`
  - Adds the dependency-closure guard for Responses replay identities.
- `agent/turn_api_call.py`
  - Applies the guard at the final provider-call boundary after middleware and preflight.
- `tests/agent/test_responses_replay_identity.py`
  - Covers linked reasoning/message replay, function-call grouping, tool-output boundaries, independent message IDs, recovery mode, and non-mutation of the original request.
- `contributors/emails/saleh.fekry@gmail.com`
  - Adds the standard contributor mapping for `salehelsayed`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking)
- [x] ✅ Regression tests

## Validation

The refreshed head is conflict-free and GitHub reports it as mergeable against current `main`.

Hosted CI, Docker, and Nix workflows were triggered for the refreshed head but currently show `action_required`, so they require maintainer approval before they can execute for this external-contributor PR.

## Checklist

- [x] Based on current upstream `main`
- [x] Focused only on the Responses replay identity bug
- [x] Preserves independent `msg_*` IDs
- [x] Adds focused regression coverage
- [x] Does not change architecture, configuration, or user-facing behavior outside this fix
- [ ] Hosted CI completed on the refreshed head (awaiting maintainer workflow approval)
