### PR TITLE
fix(telegram): preserve durable ingress across reconnects

### DIFF
--- a/gateway/run_busy.py
+++ b/gateway/run_busy.py
@@ -622,6 +622,12 @@ class GatewayBusySessionMixin:
         adapter = self._adapter_for_source(event.source)
         if not adapter:
             return False  # let default path handle it
+        if (
+            isinstance(getattr(event, "metadata", None), dict)
+            and event.metadata.get("telegram_inbound_claimed")
+        ):
+            self._queue_or_replace_pending_event(session_key, event)
+            return True
         # Internal synthetic events (delegation / background completions) must never interrupt or
         # steer; they surface as a NEW turn when idle. Plugin events carry untrusted payload text, so
         # queue them through the FIFO (security metadata kept apart).

--- a/gateway/run_busy.py
+++ b/gateway/run_busy.py
@@ -308,6 +308,7 @@ class GatewayBusySessionMixin:
                 adapter._pending_messages, session_key, event,
                 merge_text=event.message_type == MessageType.TEXT,
             )
+            setattr(event, "_gateway_busy_fifo_admitted", True)
             return
 
         if self._queue_depth(session_key, adapter=adapter) >= self._BUSY_QUEUE_MAX_PENDING:
@@ -318,6 +319,7 @@ class GatewayBusySessionMixin:
             return
 
         self._enqueue_fifo(session_key, event, adapter)
+        setattr(event, "_gateway_busy_fifo_admitted", True)
 
     async def _prepare_busy_steer_text(self, event: MessageEvent) -> str:
         """Steerable text for a busy follow-up, transcribing voice-message media first.

--- a/gateway/run_busy.py
+++ b/gateway/run_busy.py
@@ -463,6 +463,8 @@ class GatewayBusySessionMixin:
             )
             if steer_text and (plain_text or _steer_all_voice) and agent_live and hasattr(running_agent, "steer"):
                 steered = self._try_agent_verb(running_agent, "steer", steer_text, session_key)
+            if steered:
+                setattr(event, "_gateway_busy_steer_admitted", True)
             if not steered:
                 effective_mode = "queue"
         elif (
@@ -624,12 +626,6 @@ class GatewayBusySessionMixin:
         adapter = self._adapter_for_source(event.source)
         if not adapter:
             return False  # let default path handle it
-        if (
-            isinstance(getattr(event, "metadata", None), dict)
-            and event.metadata.get("telegram_inbound_claimed")
-        ):
-            self._queue_or_replace_pending_event(session_key, event)
-            return True
         # Internal synthetic events (delegation / background completions) must never interrupt or
         # steer; they surface as a NEW turn when idle. Plugin events carry untrusted payload text, so
         # queue them through the FIFO (security metadata kept apart).

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -2,13 +2,16 @@
 
 import asyncio
 import contextlib
+import copy
 import dataclasses
+import functools
 import inspect
 import json
 import logging
 import os
 import html as _html
 import re
+import threading
 import time
 from contextvars import ContextVar
 from datetime import datetime, timezone
@@ -16,6 +19,15 @@ from typing import Any, Awaitable, Callable, Dict, Iterator, List, Optional, Set
 from hermes_cli import setup_platforms
 
 logger = logging.getLogger(__name__)
+
+_TELEGRAM_DEDUP_INIT_LOCK = threading.Lock()
+_DURABLE_UPDATE_IDS_KEY = "telegram_durable_update_ids"
+_DURABLE_EVENT_DEFERRED_KEY = "telegram_inbound_dispatch_deferred"
+_DURABLE_DISPATCH_DEFERRED = object()
+_DURABLE_DISPATCH_FAILED = object()
+_DURABLE_DISPATCH_ASYNC = object()
+_DURABLE_BUSY_RETRY_DELAY_SECONDS = 1.0
+_DURABLE_WRAPPER_MARKER = "_hermes_telegram_durable_wrapper"
 
 from agent.deadline import run_bounded_async
 
@@ -146,6 +158,13 @@ from gateway.platforms.base import (
     cache_image_from_bytes_async, cache_audio_from_bytes_async, cache_video_from_bytes_async, resolve_proxy_url, SUPPORTED_VIDEO_TYPES,
     SUPPORTED_DOCUMENT_TYPES, SUPPORTED_IMAGE_DOCUMENT_TYPES, _TEXT_INJECT_EXTENSIONS, utf16_len)
 from plugins.platforms.telegram.telegram_ids import normalize_telegram_chat_id
+from plugins.platforms.telegram.inbound_store import (
+    CaptureDecision,
+    DurableTelegramUpdateQueue,
+    TelegramInboundStore,
+    TelegramQueueLifecycleRegistry,
+    bot_account_id_from_token,
+)
 from plugins.platforms.telegram.telegram_network import (
     SEED_FALLBACK_IPS, TelegramFallbackTransport, discover_fallback_ips, parse_fallback_ip_env, tcp_keepalive_socket_options)
 from utils import env_float, env_int
@@ -365,6 +384,31 @@ class _PollingLifecycleAbort(RuntimeError):
     """Internal control flow for polling startup fenced by teardown."""
 
 
+class _TelegramPluginApplicationProxy:
+    """Expose PTB registration while fencing plugin callbacks durably."""
+
+    def __init__(self, application, adapter: "TelegramAdapter") -> None:
+        self._application = application
+        self._adapter = adapter
+
+    def __getattr__(self, name):
+        return getattr(self._application, name)
+
+    def add_handler(self, handler, group=0) -> None:
+        self._application.add_handler(
+            self._adapter._wrap_plugin_handler(handler), group=group
+        )
+
+    def add_handlers(self, handlers) -> None:
+        if isinstance(handlers, dict):
+            for group, group_handlers in handlers.items():
+                for handler in group_handlers:
+                    self.add_handler(handler, group=group)
+            return
+        for handler in handlers:
+            self.add_handler(handler)
+
+
 class TelegramAdapter(BasePlatformAdapter):
     """Telegram bot adapter: users/groups, MarkdownV2 replies, forum topics, media."""
 
@@ -427,6 +471,25 @@ class TelegramAdapter(BasePlatformAdapter):
         extra = self.config.extra
         self._app: Optional[Application] = None
         self._bot: Optional[Bot] = None
+        # Handler deduplication is adapter-scoped.  The account is included in
+        # the key as an explicit guard because a process may host more than one
+        # Telegram bot and update ids are only unique within one bot account.
+        self._seen_update_ids: Dict[tuple[str, int], None] = {}
+        self._seen_platform_update_ids: Dict[tuple[str, int], None] = {}
+        self._seen_update_ids_lock = threading.RLock()
+        self._seen_update_ids_max = 4096
+        self._inbound_store: Optional[TelegramInboundStore] = None
+        self._inbound_queue: Optional[DurableTelegramUpdateQueue] = None
+        # A same-instance reconnect replaces a queue that clean disconnect
+        # terminally closed. Keep the predecessor alive until registry recovery
+        # transfers any durable ownership to the fresh queue.
+        self._retired_inbound_queue: Optional[DurableTelegramUpdateQueue] = None
+        self._bot_account_id: Optional[str] = None
+        self._durable_queue_bound = False
+        self._deferred_inbound_update_ids: set[int] = set()
+        # Serialize adapter ingress per session so the durable busy-cap check
+        # and the inherited FIFO reservation share one admission boundary.
+        self._durable_admission_locks: Dict[str, asyncio.Lock] = {}
         self._webhook_mode: bool = False
         self._mention_patterns = self._compile_mention_patterns()
         self._reply_to_mode: str = getattr(config, 'reply_to_mode', 'first') or 'first'
@@ -599,9 +662,51 @@ class TelegramAdapter(BasePlatformAdapter):
         Callers must NOT destroy the event (PTB already advanced the offset) — hold and redispatch."""
         return bool(getattr(self, "_drop_delayed_deliveries", False))
 
+    def _inbound_queue_handoff_target(self) -> Optional[DurableTelegramUpdateQueue]:
+        """Return the replacement queue after this adapter has been retired."""
+        queue = getattr(self, "_inbound_queue", None)
+        if not getattr(queue, "_lifecycle_retired", False):
+            return None
+        target = getattr(queue, "_handoff_target", None)
+        return target if isinstance(target, DurableTelegramUpdateQueue) else None
+
+    def _on_inbound_queue_handoff(
+        self, replacement_queue: DurableTelegramUpdateQueue
+    ) -> None:
+        """Retire held projections after their durable claims are handed off."""
+        pending_task = getattr(self, "_held_inbound_redispatch_task", None)
+        try:
+            current_task = asyncio.current_task()
+        except RuntimeError:
+            current_task = None
+        if (
+            pending_task is not None
+            and not pending_task.done()
+            and pending_task is not current_task
+        ):
+            pending_task.cancel()
+
+        held = getattr(self, "_held_inbound_events", None)
+        if not held:
+            return
+        events = list(held)
+        held.clear()
+        receiver = replacement_queue._handoff_receiver()
+        if receiver is None or receiver is self:
+            return
+        for event in events:
+            # Durable held events were made replayable in SQLite by handoff;
+            # retaining their old MessageEvent would bypass the replacement
+            # queue and could deliver it a second time.
+            if self._durable_update_ids(event):
+                continue
+            receiver._hold_inbound_event(event, where="queue-handoff", schedule=False)
+
     def _schedule_held_inbound_redispatch(self) -> None:
         """Ensure a tracked drain runs when held events exist and delivery is live (no-op while
         down or after permanent fatal; an in-flight drain schedules its own follow-up)."""
+        if self._inbound_queue_handoff_target() is not None:
+            return
         if self._is_permanent_fatal() or self._should_drop_delayed_delivery():
             return
         if not getattr(self, "_held_inbound_events", None):
@@ -631,6 +736,28 @@ class TelegramAdapter(BasePlatformAdapter):
             logger.warning(
                 "[Telegram] Discarding inbound under non-retryable fatal (%s, %d chars)", where, len(getattr(event, "text", None) or ""))
             return
+        handoff_target = self._inbound_queue_handoff_target()
+        if handoff_target is not None:
+            update_ids = self._durable_update_ids(event)
+            receiver = handoff_target._handoff_receiver()
+            if not update_ids:
+                if receiver is not None and receiver is not self:
+                    receiver._hold_inbound_event(event, where="queue-handoff", schedule=False)
+                return
+            target_claimed = any(
+                handoff_target.claim_for_update(update_id) is not None
+                for update_id in update_ids
+            )
+            if (
+                target_claimed
+                and not getattr(event, "_telegram_processing_started", False)
+                and receiver is not None
+                and receiver is not self
+            ):
+                receiver._hold_inbound_event(event, where="queue-handoff", schedule=False)
+            return
+        self._defer_durable_event(event)
+        self._mark_durable_event_buffered(event)
         held = getattr(self, "_held_inbound_events", None)
         if held is None:
             self._held_inbound_events = held = []
@@ -638,7 +765,23 @@ class TelegramAdapter(BasePlatformAdapter):
             return
         max_n = int(getattr(self, "HELD_INBOUND_MAX", 64) or 64)
         while len(held) >= max_n:
-            dropped = held.pop(0)
+            dropped = held[0]
+            durable_update_ids = self._durable_update_ids(dropped)
+            if durable_update_ids:
+                if not self._schedule_durable_requeue(dropped):
+                    logger.error(
+                        "[Telegram] Cannot release durable held event during overflow; retaining it"
+                    )
+                else:
+                    logger.warning(
+                        "[Telegram] Deferring durable held-event overflow eviction (%d ids)",
+                        len(durable_update_ids),
+                    )
+                # Do not trade a bounded-memory preference for a stranded
+                # durable claim. Retain the old event until every durable
+                # requeue transition has been confirmed.
+                break
+            held.pop(0)
             logger.warning(
                 "[Telegram] Held-inbound queue full (%d); dropping oldest (%d chars)", max_n, len(getattr(dropped, "text", None) or ""))
         held.append(event)
@@ -661,6 +804,8 @@ class TelegramAdapter(BasePlatformAdapter):
             prior.cancel()
             with contextlib.suppress(asyncio.CancelledError):
                 await prior
+        if self._inbound_queue_handoff_target() is not None:
+            return
         held = getattr(self, "_held_inbound_events", None)
         if self._is_permanent_fatal():
             if held:
@@ -681,7 +826,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     self._rehold_from(events, idx, "redispatch-interrupted")
                     return
                 try:
-                    await self.handle_message(event)
+                    await self._dispatch_and_complete_durable_event(event)
                 except asyncio.CancelledError:
                     self._rehold_from(events, idx, "redispatch-cancelled")
                     raise
@@ -2056,6 +2201,11 @@ class TelegramAdapter(BasePlatformAdapter):
                 if self._looks_like_network_error(probe_err):
                     self._schedule_polling_recovery(probe_err, reason="heartbeat probe")
 
+    def _durable_ingress_paused(self) -> bool:
+        """Return whether local durable admission intentionally holds PTB."""
+        queue = getattr(self, "_inbound_queue", None)
+        return bool(queue is not None and getattr(queue, "ingress_paused", False))
+
     async def _probe_pending_updates(self, bot, probe_timeout: float) -> None:
         """Detect a wedged or stopped getUpdates consumer via pending_update_count.
 
@@ -2101,6 +2251,13 @@ class TelegramAdapter(BasePlatformAdapter):
                     "Telegram updater stopped while in polling mode")
             return
         self._polling_not_running_count = 0
+        if self._durable_ingress_paused():
+            # PTB deliberately has not acknowledged the fetched update yet.
+            # Restarting the network consumer cannot repair a local SQLite
+            # backpressure condition and used to reset the recovery counter in
+            # a loop while leaving the same update server-side.
+            self._polling_pending_stuck_count = 0
+            return
         get_webhook_info = getattr(bot, "get_webhook_info", None)
         if not callable(get_webhook_info):
             return
@@ -2137,6 +2294,11 @@ class TelegramAdapter(BasePlatformAdapter):
         See #92991.
         """
         if self._webhook_mode or self._teardown_started or self.has_fatal_error or self._recovery_in_flight():
+            return
+        if self._durable_ingress_paused():
+            # The HTTP getUpdates request completed, but durable admission is
+            # intentionally holding its PTB queue acknowledgment. The queue
+            # owns retry and emits payload-free pause/recovery diagnostics.
             return
         now = time.monotonic()
         last_progress = getattr(self, "_polling_last_progress_monotonic", None)
@@ -2679,20 +2841,1112 @@ class TelegramAdapter(BasePlatformAdapter):
                 "text": text[:8192] if text is not None else None, "edited_at": edited_at},
         }
 
+    def _dedup_account_key(self) -> str:
+        """Return the account identity used by adapter-local deduplication."""
+        account = getattr(self, "_bot_account_id", None)
+        if account:
+            return str(account)
+        bot_id = getattr(getattr(self, "_bot", None), "id", None)
+        if bot_id is not None and not isinstance(bot_id, bool):
+            return str(bot_id)
+        return "unknown"
+
+    def _dedup_cache(self, *, platform: bool = False):
+        """Return the process-local dedup cache and its shared lock.
+
+        Some tests and recovery paths construct an adapter without running its
+        normal initializer.  Lazy initialization keeps those paths safe while
+        the lock makes the check-and-set operation one atomic boundary across
+        PTB handler threads.
+        """
+        with _TELEGRAM_DEDUP_INIT_LOCK:
+            lock = getattr(self, "_seen_update_ids_lock", None)
+            if lock is None:
+                lock = threading.RLock()
+                self._seen_update_ids_lock = lock
+            attr = "_seen_platform_update_ids" if platform else "_seen_update_ids"
+            cache = getattr(self, attr, None)
+            if not isinstance(cache, dict):
+                cache = {}
+                setattr(self, attr, cache)
+            if not hasattr(self, "_seen_update_ids_max"):
+                self._seen_update_ids_max = 4096
+        return lock, cache
+
+    def _remember_update_id(
+        self,
+        update: Any,
+        cache: Optional[Dict[tuple[str, int], None]] = None,
+        *,
+        platform: bool = False,
+    ) -> bool:
+        """Return True after the same account/update id has been seen."""
+        update_id = getattr(update, "update_id", None)
+        if isinstance(update_id, bool) or not isinstance(update_id, int):
+            return False
+        key = (self._dedup_account_key(), update_id)
+        lock, owned_cache = self._dedup_cache(platform=platform)
+        # Preserve the old optional-cache signature for callers outside this
+        # module, but always protect the operation with the adapter lock.
+        target = cache if cache is not None else owned_cache
+        with lock:
+            if key in target:
+                return True
+            target[key] = None
+            maximum = max(1, int(getattr(self, "_seen_update_ids_max", 4096)))
+            while len(target) > maximum:
+                target.pop(next(iter(target)))
+            return False
+
+    def _is_duplicate_update(self, update: Any) -> bool:
+        """Return whether a core Telegram handler already entered this update."""
+        return self._remember_update_id(update)
+
+    def _is_duplicate_platform_update(self, update: Any) -> bool:
+        """Return whether the catch-all observer already saw this update."""
+        return self._remember_update_id(update, platform=True)
+
+    def _forget_update_id(
+        self,
+        update: Any,
+        cache: Optional[Dict[tuple[str, int], None]] = None,
+        *,
+        platform: bool = False,
+    ) -> None:
+        """Allow a failed handler invocation to be retried."""
+        update_id = getattr(update, "update_id", None)
+        if isinstance(update_id, bool) or not isinstance(update_id, int):
+            return
+        lock, owned_cache = self._dedup_cache(platform=platform)
+        target = cache if cache is not None else owned_cache
+        with lock:
+            target.pop((self._dedup_account_key(), update_id), None)
+
+    def _forget_durable_update_ids(
+        self, update_ids: tuple[int, ...] | list[int] | set[int]
+    ) -> None:
+        """Allow requeued durable updates through the local dedup cache."""
+        lock, cache = self._dedup_cache()
+        account = self._dedup_account_key()
+        with lock:
+            for update_id in update_ids:
+                cache.pop((account, update_id), None)
+
+    def _gateway_runner(self) -> Any:
+        """Find the owning GatewayRunner behind direct or scoped handlers."""
+        candidates = (
+            getattr(self, "_message_handler", None),
+            getattr(self, "_busy_session_handler", None),
+        )
+        for handler in candidates:
+            owner = getattr(handler, "__self__", None)
+            if owner is not None and callable(getattr(owner, "_queue_depth", None)):
+                return owner
+            try:
+                nonlocals = inspect.getclosurevars(handler).nonlocals.values()
+            except (TypeError, ValueError):
+                nonlocals = ()
+            for value in nonlocals:
+                if callable(getattr(value, "_queue_depth", None)):
+                    return value
+                value_owner = getattr(value, "__self__", None)
+                if value_owner is not None and callable(
+                    getattr(value_owner, "_queue_depth", None)
+                ):
+                    return value_owner
+        return None
+
+    def _inbound_session_key(self, event: Any) -> str:
+        """Resolve the adapter session key used by the gateway busy path."""
+        metadata = getattr(event, "metadata", None) or {}
+        session_key = str(metadata.get("gateway_session_key") or "")
+        runner = self._gateway_runner()
+        if not session_key and runner is not None:
+            resolver = getattr(runner, "_session_key_for_source", None)
+            if callable(resolver):
+                try:
+                    session_key = str(resolver(event.source) or "")
+                except Exception:
+                    session_key = ""
+        if not session_key:
+            try:
+                from gateway.session import build_session_key
+
+                extra = getattr(getattr(self, "config", None), "extra", {}) or {}
+                session_key = build_session_key(
+                    event.source,
+                    group_sessions_per_user=extra.get("group_sessions_per_user", True),
+                    thread_sessions_per_user=extra.get("thread_sessions_per_user", False),
+                    profile=self._session_key_profile(event.source),
+                )
+            except Exception:
+                session_key = ""
+        return session_key
+
+    def _durable_admission_lock(self, session_key: str) -> asyncio.Lock:
+        """Return the per-session lock guarding durable busy admission."""
+        locks = getattr(self, "_durable_admission_locks", None)
+        if not isinstance(locks, dict):
+            locks = {}
+            self._durable_admission_locks = locks
+        lock_key = session_key or "<unknown-session>"
+        lock = locks.get(lock_key)
+        if lock is None:
+            lock = asyncio.Lock()
+            locks[lock_key] = lock
+        return lock
+
+    def _durable_busy_cap_reached(self, event: Any, session_key: str) -> bool:
+        """Return whether this durable event must wait for ordinary queue room."""
+        if not self._durable_update_ids(event) or not session_key:
+            return False
+        active_sessions = getattr(self, "_active_sessions", None)
+        if not isinstance(active_sessions, dict) or session_key not in active_sessions:
+            return False
+
+        runner = self._gateway_runner()
+        if runner is None:
+            return False
+        try:
+            if event.get_command():
+                # Active-session commands have their own direct/bypass path;
+                # they are not ordinary FIFO follow-ups.
+                return False
+        except Exception:
+            pass
+
+        modes = []
+        for name in ("_effective_busy_text_mode", "_effective_busy_input_mode"):
+            resolver = getattr(runner, name, None)
+            if callable(resolver):
+                try:
+                    modes.append(resolver(event.source))
+                except Exception:
+                    continue
+        if "queue" not in modes:
+            return False
+
+        queue_depth = getattr(runner, "_queue_depth", None)
+        if not callable(queue_depth):
+            # An active queue-mode durable event cannot be safely admitted when
+            # the inherited depth boundary is unavailable.
+            return True
+        try:
+            cap = int(getattr(runner, "_BUSY_QUEUE_MAX_PENDING", 32))
+            return queue_depth(session_key, adapter=self) >= cap
+        except Exception:
+            logger.warning(
+                "Deferring durable Telegram event because busy queue depth "
+                "could not be verified for %s",
+                session_key,
+            )
+            return True
+
+    async def handle_message(self, event: MessageEvent) -> None:
+        """Serialize Telegram ingress around durable busy-cap admission."""
+        session_key = self._inbound_session_key(event)
+        durable_ids = self._durable_update_ids(event)
+        lock = self._durable_admission_lock(session_key)
+        if durable_ids:
+            setattr(event, "_telegram_durable_dispatch_result", None)
+        async with lock:
+            if durable_ids and self._durable_busy_cap_reached(event, session_key):
+                # The inherited runner's FIFO helper intentionally returns no
+                # value when its ordinary cap is full. Defer before entering
+                # that path so the durable claim cannot be marked successful.
+                self._defer_durable_event(event)
+                setattr(event, "_telegram_durable_dispatch_result", _DURABLE_DISPATCH_DEFERRED)
+                return
+            await super().handle_message(event)
+
+    @staticmethod
+    def _durable_update_ids(event: Any) -> tuple[int, ...]:
+        """Return validated durable update ids carried by a MessageEvent."""
+        metadata = getattr(event, "metadata", None)
+        raw_ids = metadata.get(_DURABLE_UPDATE_IDS_KEY) if isinstance(metadata, dict) else None
+        if not isinstance(raw_ids, (list, tuple, set)):
+            return ()
+        result: list[int] = []
+        for value in raw_ids:
+            if isinstance(value, bool):
+                continue
+            if isinstance(value, int):
+                update_id = value
+            elif isinstance(value, str) and value.strip().lstrip("+-").isdigit():
+                update_id = int(value.strip(), 10)
+            else:
+                continue
+            if update_id not in result:
+                result.append(update_id)
+        return tuple(result)
+
+    def _mark_durable_event(self, event: Any, update_id: Optional[int]) -> Any:
+        """Attach the durable claim identity to a freshly built event."""
+        if update_id is None:
+            return event
+        queue = getattr(self, "_inbound_queue", None)
+        claim_for_update = getattr(queue, "claim_for_update", None)
+        if not callable(claim_for_update) or claim_for_update(update_id) is None:
+            return event
+        metadata = dict(getattr(event, "metadata", None) or {})
+        ids = list(self._durable_update_ids(event))
+        if update_id not in ids:
+            ids.append(update_id)
+        metadata[_DURABLE_UPDATE_IDS_KEY] = ids
+        metadata["telegram_inbound_claimed"] = True
+        event.metadata = metadata
+        return event
+
+    def _defer_durable_event(self, event: Any) -> None:
+        """Mark a buffered event so its claim stays live until flush dispatch."""
+        ids = self._durable_update_ids(event)
+        if not ids:
+            return
+        deferred = getattr(self, "_deferred_inbound_update_ids", None)
+        if deferred is None:
+            deferred = set()
+            self._deferred_inbound_update_ids = deferred
+        deferred.update(ids)
+        metadata = dict(getattr(event, "metadata", None) or {})
+        metadata[_DURABLE_UPDATE_IDS_KEY] = list(ids)
+        metadata[_DURABLE_EVENT_DEFERRED_KEY] = True
+        event.metadata = metadata
+
+    def _mark_durable_event_buffered(self, event: Any) -> None:
+        """Tell the queue that this event waits outside active processing."""
+        queue = getattr(self, "_inbound_queue", None)
+        mark_buffered = getattr(queue, "mark_event_buffered", None)
+        if callable(mark_buffered):
+            # A cancellation can retain an event after gateway processing has
+            # started. It is no longer live while held, so handoff must requeue
+            # its claim rather than transfer a lease with no local driver.
+            mark_buffered(self._durable_update_ids(event))
+
+    def _mark_durable_event_active(self, event: Any) -> bool:
+        """Tell the queue that a held event has entered actual dispatch."""
+        queue = getattr(self, "_inbound_queue", None)
+        mark_active = getattr(queue, "mark_event_active", None)
+        if not callable(mark_active):
+            return False
+        return bool(mark_active(self._durable_update_ids(event)))
+
+    def _remove_held_inbound_event(self, event: Any) -> None:
+        """Remove one held projection by identity after durable release."""
+        held = getattr(self, "_held_inbound_events", None)
+        if not isinstance(held, list):
+            return
+        for index, existing in enumerate(held):
+            if existing is event:
+                held.pop(index)
+                return
+
+    def _schedule_durable_requeue(self, event: Any) -> bool:
+        """Schedule safe release for a durable event displaced by overflow."""
+        update_ids = self._durable_update_ids(event)
+        if not update_ids:
+            return True
+        queue = getattr(self, "_inbound_queue", None)
+        complete = getattr(queue, "complete_update", None)
+        register = getattr(queue, "register_lifecycle_task", None)
+        if not callable(complete) or not callable(register):
+            return False
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return False
+
+        pending = getattr(self, "_durable_overflow_cleanup_events", None)
+        if pending is None:
+            pending = set()
+            self._durable_overflow_cleanup_events = pending
+        event_identity = id(event)
+        if event_identity in pending:
+            return True
+        pending.add(event_identity)
+
+        async def requeue() -> bool:
+            return await self._complete_durable_event(
+                event,
+                success=False,
+                delay=0.0,
+                defer=True,
+            )
+
+        task = loop.create_task(requeue())
+        register(task)
+
+        def observe(completed: asyncio.Task[Any]) -> None:
+            pending.discard(event_identity)
+            try:
+                transitioned = bool(completed.result())
+            except asyncio.CancelledError:
+                logger.error(
+                    "[Telegram] Durable held-event overflow cleanup was cancelled"
+                )
+                return
+            except Exception:
+                logger.exception(
+                    "[Telegram] Durable held-event overflow cleanup failed"
+                )
+                return
+            if not transitioned:
+                logger.error(
+                    "[Telegram] Durable held-event overflow cleanup was not confirmed"
+                )
+                return
+            self._remove_held_inbound_event(event)
+
+        task.add_done_callback(observe)
+        return True
+
+    def _merge_durable_event_metadata(self, target: Any, source: Any) -> None:
+        """Merge durable claim ids when two batched events become one."""
+        source_ids = self._durable_update_ids(source)
+        target_ids = list(self._durable_update_ids(target))
+        for update_id in source_ids:
+            if update_id not in target_ids:
+                target_ids.append(update_id)
+        if not target_ids:
+            return
+        source_metadata = getattr(source, "metadata", None) or {}
+        target_metadata = dict(getattr(target, "metadata", None) or {})
+        target_metadata[_DURABLE_UPDATE_IDS_KEY] = target_ids
+        if (
+            bool(source_metadata.get(_DURABLE_EVENT_DEFERRED_KEY))
+            or bool(target_metadata.get(_DURABLE_EVENT_DEFERRED_KEY))
+            or any(update_id in getattr(self, "_deferred_inbound_update_ids", set()) for update_id in target_ids)
+        ):
+            target_metadata[_DURABLE_EVENT_DEFERRED_KEY] = True
+            deferred = getattr(self, "_deferred_inbound_update_ids", None)
+            if deferred is None:
+                deferred = set()
+                self._deferred_inbound_update_ids = deferred
+            deferred.update(target_ids)
+        target.metadata = target_metadata
+
+    def _update_durable_event_after_completion(
+        self,
+        event: Any,
+        update_ids: tuple[int, ...],
+        transitioned_ids: list[int],
+    ) -> None:
+        """Retain only durable IDs whose completion was not confirmed."""
+        transitioned = set(transitioned_ids)
+        unresolved = [update_id for update_id in update_ids if update_id not in transitioned]
+        metadata = dict(getattr(event, "metadata", None) or {})
+        deferred = getattr(self, "_deferred_inbound_update_ids", None)
+        was_deferred = bool(metadata.get(_DURABLE_EVENT_DEFERRED_KEY))
+        if deferred is not None:
+            was_deferred = was_deferred or bool(set(update_ids).intersection(deferred))
+        if was_deferred:
+            if deferred is None:
+                deferred = set()
+                self._deferred_inbound_update_ids = deferred
+            for update_id in transitioned:
+                deferred.discard(update_id)
+            deferred.update(unresolved)
+
+        if unresolved:
+            metadata[_DURABLE_UPDATE_IDS_KEY] = unresolved
+            if was_deferred:
+                metadata[_DURABLE_EVENT_DEFERRED_KEY] = True
+            else:
+                metadata.pop(_DURABLE_EVENT_DEFERRED_KEY, None)
+        else:
+            metadata.pop(_DURABLE_UPDATE_IDS_KEY, None)
+            metadata.pop(_DURABLE_EVENT_DEFERRED_KEY, None)
+        event.metadata = metadata
+
+    async def _complete_durable_update_ids(
+        self,
+        update_ids: tuple[int, ...] | list[int] | set[int],
+        *,
+        success: bool,
+        delay: float = 0.0,
+        defer: bool = False,
+        _transitioned_ids: Optional[list[int]] = None,
+    ) -> bool:
+        """Complete each durable claim only after dispatch accepts the event."""
+        unique_update_ids = tuple(dict.fromkeys(update_ids))
+        if not unique_update_ids:
+            return True
+        queue = getattr(self, "_inbound_queue", None)
+        complete = getattr(queue, "complete_update", None)
+        if not callable(complete):
+            return False
+        transitioned_ids: list[int] = []
+        for update_id in unique_update_ids:
+            if not success and (delay > 0 or defer):
+                result = complete(
+                    update_id,
+                    success=False,
+                    delay=delay,
+                    defer=defer,
+                )
+            else:
+                result = complete(update_id, success=success)
+            if inspect.isawaitable(result):
+                result = await asyncio.shield(result)
+            if bool(result):
+                transitioned_ids.append(update_id)
+        if not success and transitioned_ids:
+            deferred = getattr(self, "_deferred_inbound_update_ids", None)
+            if deferred is not None:
+                for update_id in transitioned_ids:
+                    deferred.discard(update_id)
+            self._forget_durable_update_ids(transitioned_ids)
+        if _transitioned_ids is not None:
+            _transitioned_ids.extend(transitioned_ids)
+        return len(transitioned_ids) == len(unique_update_ids)
+
+    async def _complete_durable_event(
+        self,
+        event: Any,
+        *,
+        success: bool,
+        delay: float = 0.0,
+        defer: bool = False,
+    ) -> bool:
+        """Complete all claims represented by a batched MessageEvent."""
+        update_ids = self._durable_update_ids(event)
+        transitioned_ids: list[int] = []
+        transitioned = await self._complete_durable_update_ids(
+            update_ids,
+            success=success,
+            delay=delay,
+            defer=defer,
+            _transitioned_ids=transitioned_ids,
+        )
+        self._update_durable_event_after_completion(
+            event,
+            update_ids,
+            transitioned_ids,
+        )
+        return transitioned
+
+    def _schedule_durable_processing_completion(
+        self, event: MessageEvent, outcome: ProcessingOutcome
+    ) -> None:
+        """Commit a durable result after the detached gateway owner finishes."""
+        if not getattr(event, "_telegram_durable_completion_pending", False):
+            return
+        setattr(event, "_telegram_durable_completion_pending", False)
+        existing = getattr(event, "_telegram_durable_completion_task", None)
+        if existing is not None and not existing.done():
+            return
+
+        async def complete() -> None:
+            success = outcome == ProcessingOutcome.SUCCESS
+            try:
+                transitioned = await self._complete_durable_event(event, success=success)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("[Telegram] Durable processing completion failed")
+                return
+            if not transitioned:
+                logger.warning("[Telegram] Durable processing completion was not confirmed")
+
+        task = asyncio.create_task(complete())
+        setattr(event, "_telegram_durable_completion_task", task)
+        queue = getattr(self, "_inbound_queue", None)
+        register = getattr(queue, "register_lifecycle_task", None)
+        if callable(register):
+            register(task)
+
+    @staticmethod
+    def _durable_processing_complete_event(event: Any) -> asyncio.Event:
+        """Return the per-event signal raised by the processing hook."""
+        signal = getattr(event, "_telegram_processing_complete", None)
+        if not isinstance(signal, asyncio.Event):
+            signal = asyncio.Event()
+            setattr(event, "_telegram_processing_complete", signal)
+        return signal
+
+    def _gateway_fifo_events(self, session_key: str) -> tuple[Any, ...]:
+        """Return events staged in the inherited GatewayRunner busy FIFO."""
+        if not session_key:
+            return ()
+        events: list[Any] = []
+        pending = getattr(self, "_pending_messages", None)
+        if isinstance(pending, dict):
+            pending_event = pending.get(session_key)
+            if pending_event is not None:
+                events.append(pending_event)
+
+        runner = self._gateway_runner()
+        if runner is None:
+            return tuple(events)
+        state = None
+        resolver = getattr(runner, "_peek_session_state", None)
+        if callable(resolver):
+            try:
+                state = resolver(session_key)
+            except Exception:
+                state = None
+        conversation = getattr(state, "conversation", None)
+        overflow = getattr(conversation, "queued_events", None)
+        if isinstance(overflow, (list, tuple)):
+            events.extend(overflow)
+        return tuple(events)
+
+    def _durable_event_in_gateway_fifo(self, event: Any, session_key: str) -> bool:
+        """Return whether a durable event is awaiting the volatile busy FIFO."""
+        durable_ids = set(self._durable_update_ids(event))
+        for candidate in self._gateway_fifo_events(session_key):
+            if candidate is event:
+                return True
+            if durable_ids.intersection(self._durable_update_ids(candidate)):
+                setattr(
+                    candidate,
+                    "_telegram_processing_complete",
+                    self._durable_processing_complete_event(event),
+                )
+                return True
+        return False
+
+    def _remove_durable_event_from_gateway_fifo(
+        self, event: Any, session_key: str
+    ) -> bool:
+        """Remove an externally-cancelled event before placing it on hold."""
+        removed = False
+        pending = getattr(self, "_pending_messages", None)
+        if isinstance(pending, dict) and pending.get(session_key) is event:
+            pending.pop(session_key, None)
+            removed = True
+
+        runner = self._gateway_runner()
+        resolver = getattr(runner, "_peek_session_state", None) if runner else None
+        state = None
+        if callable(resolver):
+            try:
+                state = resolver(session_key)
+            except Exception:
+                state = None
+        conversation = getattr(state, "conversation", None)
+        overflow = getattr(conversation, "queued_events", None)
+        if isinstance(overflow, list):
+            for index, candidate in enumerate(overflow):
+                if candidate is event:
+                    del overflow[index]
+                    removed = True
+                    break
+        return removed
+
+    async def _await_durable_processing(self, session_key: str) -> None:
+        """Wait for the background task chain that owns a durable session."""
+        observed_task_ids: set[int] = set()
+        while True:
+            task = getattr(self, "_session_tasks", {}).get(session_key)
+            if task is None or task is asyncio.current_task():
+                return
+            task_id = id(task)
+            if task_id in observed_task_ids:
+                return
+            observed_task_ids.add(task_id)
+            if not inspect.isawaitable(task):
+                return
+            await asyncio.shield(task)
+            if getattr(self, "_session_tasks", {}).get(session_key) is task:
+                return
+
+    async def _await_durable_event_processing(
+        self, event: Any, session_key: str
+    ) -> object:
+        """Wait for this event, not merely the preceding session owner."""
+        signal = self._durable_processing_complete_event(event)
+        await self._await_durable_processing(session_key)
+        if signal.is_set() or not self._durable_event_in_gateway_fifo(event, session_key):
+            return event
+
+        wait_task = asyncio.create_task(signal.wait())
+        try:
+            while True:
+                if wait_task.done():
+                    await asyncio.shield(wait_task)
+                    return event
+                if not self._durable_event_in_gateway_fifo(event, session_key):
+                    if getattr(event, "_telegram_processing_started", False):
+                        await asyncio.shield(wait_task)
+                        return event
+                    self._defer_durable_event(event)
+                    return _DURABLE_DISPATCH_DEFERRED
+                done, _ = await asyncio.wait({wait_task}, timeout=0.1)
+                if done:
+                    return event
+        finally:
+            if not wait_task.done():
+                wait_task.cancel()
+                try:
+                    await wait_task
+                except asyncio.CancelledError:
+                    pass
+
+    async def _dispatch_inbound_event(self, event: MessageEvent) -> object:
+        """Dispatch durable work only after its actual processing boundary."""
+        durable_ids = self._durable_update_ids(event)
+        session_key = self._inbound_session_key(event)
+        if durable_ids:
+            self._durable_processing_complete_event(event)
+            # PTB's default processor is sequential. Completion must follow
+            # the gateway owner task, not keep this handler awaiting that task.
+            setattr(event, "_telegram_durable_completion_pending", True)
+        await self.handle_message(event)
+        if (
+            durable_ids
+            and getattr(event, "_telegram_durable_dispatch_result", None)
+            is _DURABLE_DISPATCH_DEFERRED
+        ):
+            setattr(event, "_telegram_durable_completion_pending", False)
+            return _DURABLE_DISPATCH_DEFERRED
+        if durable_ids:
+            if session_key in getattr(self, "_session_tasks", {}):
+                return _DURABLE_DISPATCH_ASYNC
+            if callable(getattr(self, "_message_handler", None)):
+                # BasePlatformAdapter should create a task for a new durable
+                # session. A missing task means the event was not admitted.
+                setattr(event, "_telegram_durable_completion_pending", False)
+                self._defer_durable_event(event)
+                return _DURABLE_DISPATCH_DEFERRED
+            # Small integration adapters can dispatch synchronously without a
+            # BasePlatformAdapter owner. They still need a direct completion.
+            setattr(event, "_telegram_durable_completion_pending", False)
+        return event
+
+    def _start_batched_durable_dispatch(
+        self, event: MessageEvent
+    ) -> asyncio.Task[Any]:
+        """Detach post-window dispatch from the cancellable batching timer."""
+        tasks = getattr(self, "_durable_batch_dispatch_tasks", None)
+        if tasks is None:
+            tasks = set()
+            self._durable_batch_dispatch_tasks = tasks
+        task = asyncio.create_task(self._dispatch_and_complete_durable_event(event))
+        tasks.add(task)
+
+        def observe(completed: asyncio.Task[Any]) -> None:
+            tasks.discard(completed)
+            try:
+                completed.exception()
+            except asyncio.CancelledError:
+                return
+            except Exception:
+                logger.exception("[Telegram] Detached durable batch dispatch failed")
+
+        task.add_done_callback(observe)
+        return task
+
+    async def _dispatch_and_complete_durable_event(self, event: MessageEvent) -> None:
+        """Dispatch a buffered event and commit its durable outcome."""
+        durable_ids = self._durable_update_ids(event)
+        handoff_target = self._inbound_queue_handoff_target()
+        if (
+            handoff_target is not None
+            and not getattr(event, "_telegram_processing_started", False)
+        ):
+            self._hold_inbound_event(event, where="durable-dispatch-handoff")
+            return
+        claim_active = self._mark_durable_event_active(event)
+        if (
+            self._inbound_queue_handoff_target() is not None
+            and durable_ids
+            and not getattr(event, "_telegram_processing_started", False)
+            and not claim_active
+        ):
+            self._hold_inbound_event(event, where="durable-dispatch-handoff")
+            return
+        try:
+            dispatch_result = await self._dispatch_inbound_event(event)
+        except asyncio.CancelledError:
+            durable_ids = self._durable_update_ids(event)
+            processing_outcome = getattr(event, "_telegram_processing_outcome", None)
+            if durable_ids and processing_outcome == ProcessingOutcome.CANCELLED:
+                # The owner task ran its cancellation lifecycle and reported
+                # that outcome. Its claim is safe to requeue; do not also hold
+                # the same event for a second dispatch attempt.
+                await self._complete_durable_event(event, success=False)
+                return
+            self._remove_durable_event_from_gateway_fifo(
+                event, self._inbound_session_key(event)
+            )
+            self._hold_inbound_event(event, where="durable-dispatch-cancelled")
+            raise
+        except BaseException:
+            await self._complete_durable_event(event, success=False)
+            raise
+        if dispatch_result is _DURABLE_DISPATCH_ASYNC:
+            return
+        if dispatch_result is _DURABLE_DISPATCH_FAILED:
+            await self._complete_durable_event(event, success=False)
+            return
+        if dispatch_result is _DURABLE_DISPATCH_DEFERRED:
+            await self._complete_durable_event(
+                event,
+                success=False,
+                delay=_DURABLE_BUSY_RETRY_DELAY_SECONDS,
+                defer=True,
+            )
+            return
+        await self._complete_durable_event(event, success=True)
+
+    def _wrap_inbound_handler(
+        self, callback: Callable[..., Awaitable[Any]]
+    ) -> Callable[..., Awaitable[Any]]:
+        """Deduplicate a registered handler before downloads or dispatch."""
+        if getattr(callback, _DURABLE_WRAPPER_MARKER, False):
+            return callback
+
+        @functools.wraps(callback)
+        async def wrapped(update, context):
+            queue = getattr(self, "_inbound_queue", None)
+            if queue is not None and self._inbound_queue_handoff_target() is not None:
+                # A retired adapter must never execute replacement work through
+                # its stale handler graph. Recovery projects the durable row on
+                # the replacement queue instead.
+                logger.debug(
+                    "[Telegram] Ignoring Telegram update %s after adapter handoff",
+                    getattr(update, "update_id", None),
+                )
+                return None
+            update_id = getattr(update, "update_id", None)
+            duplicate = self._is_duplicate_update(update)
+            handler_claimed = getattr(queue, "handler_claimed", None)
+            if not duplicate and callable(handler_claimed):
+                duplicate = bool(handler_claimed(update_id))
+            if duplicate:
+                logger.debug(
+                    "[Telegram] Ignoring duplicate Telegram update %s",
+                    getattr(update, "update_id", None),
+                )
+                return None
+            claim = queue.mark_handler_claim(update_id) if queue is not None else None
+            if claim is None and queue is not None:
+                handler_claim_fenced = getattr(queue, "handler_claim_fenced", None)
+                if callable(handler_claim_fenced) and handler_claim_fenced(update_id):
+                    logger.debug(
+                        "[Telegram] Ignoring Telegram update %s after queue handoff",
+                        update_id,
+                    )
+                    return None
+            try:
+                if claim is not None and getattr(claim, "update_kind", None) == "callback_query":
+                    mark_control_started = getattr(queue, "mark_control_started", None)
+                    if callable(mark_control_started):
+                        started = mark_control_started(update_id)
+                        if inspect.isawaitable(started):
+                            started = await asyncio.shield(started)
+                        if not started:
+                            await self._complete_durable_update_ids((update_id,), success=False)
+                            self._forget_update_id(update)
+                            return None
+                result = await callback(update, context)
+            except BaseException:
+                try:
+                    if claim is not None:
+                        await self._complete_durable_update_ids((update_id,), success=False)
+                finally:
+                    self._forget_update_id(update)
+                raise
+            if result is _DURABLE_DISPATCH_FAILED:
+                if claim is not None and update_id is not None:
+                    await self._complete_durable_update_ids((update_id,), success=False)
+                self._forget_update_id(update)
+                return result
+            if result is _DURABLE_DISPATCH_DEFERRED:
+                if claim is not None and update_id is not None:
+                    await self._complete_durable_update_ids(
+                        (update_id,),
+                        success=False,
+                        delay=_DURABLE_BUSY_RETRY_DELAY_SECONDS,
+                        defer=True,
+                    )
+                self._forget_update_id(update)
+                return result
+            if result is _DURABLE_DISPATCH_ASYNC:
+                return result
+            if (
+                claim is not None
+                and update_id is not None
+                and update_id not in getattr(
+                    self, "_deferred_inbound_update_ids", set()
+                )
+            ):
+                await self._complete_durable_update_ids((update_id,), success=True)
+            return result
+
+        wrapped._hermes_telegram_durable_wrapper = True
+        return wrapped
+
+    def _wrap_platform_event_handler(
+        self, callback: Callable[..., Awaitable[Any]]
+    ) -> Callable[..., Awaitable[Any]]:
+        """Deduplicate the observer independently of core handler groups."""
+
+        @functools.wraps(callback)
+        async def wrapped(update, context):
+            if self._is_duplicate_platform_update(update):
+                logger.debug(
+                    "[Telegram] Ignoring duplicate Telegram platform update %s",
+                    getattr(update, "update_id", None),
+                )
+                return None
+            return await callback(update, context)
+
+        return wrapped
+
+    @staticmethod
+    def _update_payload(update: Any) -> Optional[dict[str, Any]]:
+        if isinstance(update, dict):
+            return update
+        converter = getattr(update, "to_dict", None)
+        if not callable(converter):
+            return None
+        try:
+            payload = converter()
+        except Exception:
+            logger.debug("[Telegram] Could not serialize update for durable ingress", exc_info=True)
+            return None
+        return payload if isinstance(payload, dict) else None
+
+    def _deserialize_update(self, payload: Any) -> Any:
+        """Rebuild a PTB Update from the durable JSON projection."""
+        if not isinstance(payload, dict) or not TELEGRAM_AVAILABLE:
+            return payload
+        try:
+            return Update.de_json(payload, self._bot)
+        except Exception:
+            logger.warning("[%s] Durable Telegram update could not be decoded", self.name, exc_info=True)
+            return None
+
+    def _classify_inbound_update(self, update: Any) -> CaptureDecision:
+        """Classify an update without downloading media or dispatching work."""
+        payload = self._update_payload(update)
+        message = self._effective_update_message(update)
+        update_kind = "message"
+        callback = getattr(update, "callback_query", None)
+        if callback is not None:
+            query_message = getattr(callback, "message", None)
+            query_user = getattr(callback, "from_user", None)
+            query_chat = getattr(query_message, "chat", None)
+            user_id = getattr(query_user, "id", None)
+            chat_id = getattr(query_chat, "id", None)
+            authorized = False
+            if user_id is not None:
+                try:
+                    authorized = bool(
+                        self._is_callback_user_authorized(
+                            str(user_id),
+                            chat_id=str(chat_id) if chat_id is not None else None,
+                            chat_type=getattr(query_chat, "type", None),
+                        )
+                    )
+                except Exception:
+                    logger.debug("[%s] Callback admission authorization failed", self.name, exc_info=True)
+            return CaptureDecision(
+                actionable=authorized and bool(getattr(callback, "data", None)),
+                update_kind="callback_query",
+                chat_id=str(chat_id) if chat_id is not None else None,
+                callback_query_id=(
+                    str(getattr(callback, "id", "")) or None
+                ),
+                payload=payload,
+                account_id=self._dedup_account_key(),
+                receipt_required=True,
+            )
+
+        if message is None:
+            return CaptureDecision(actionable=False, payload=payload)
+        try:
+            authorized = bool(self._is_user_authorized_from_message(message))
+        except Exception:
+            authorized = False
+        if not authorized or self._is_own_message(message):
+            return CaptureDecision(actionable=False, payload=payload)
+
+        text = getattr(message, "text", None) or getattr(message, "caption", None) or ""
+        is_command = bool(str(text).lstrip().startswith("/"))
+        has_location = getattr(message, "location", None) is not None or getattr(message, "venue", None) is not None
+        has_media = any(
+            getattr(message, attr, None) is not None
+            for attr in ("photo", "video", "audio", "voice", "document", "sticker")
+        )
+        if not (text or has_location or has_media):
+            return CaptureDecision(actionable=False, payload=payload)
+        try:
+            should_process = bool(
+                self._should_process_message(message, is_command=is_command)
+                if is_command
+                else self._should_process_message(message)
+            )
+            should_observe = (
+                False
+                if is_command or should_process
+                else bool(self._should_observe_unmentioned_group_message(message))
+            )
+        except Exception:
+            should_process = False
+            should_observe = False
+        kind = "command" if is_command else (
+            "location" if has_location and not text else "media" if has_media and not text else "message"
+        )
+        return CaptureDecision(
+            actionable=bool(should_process or should_observe),
+            update_kind=kind,
+            chat_id=(str(getattr(getattr(message, "chat", None), "id", "")) or None),
+            message_id=(str(getattr(message, "message_id", "")) or None),
+            payload=payload,
+            account_id=self._dedup_account_key(),
+            receipt_required=True,
+        )
+
+    def _ensure_inbound_queue(self) -> DurableTelegramUpdateQueue:
+        """Create the account-scoped durable PTB queue once per adapter."""
+        token = getattr(self.config, "token", None)
+        try:
+            account = bot_account_id_from_token(token)
+        except (TypeError, ValueError):
+            # A few lifecycle tests use a redacted token placeholder while
+            # replacing the whole PTB builder.  Keep those non-network test
+            # doubles usable without ever persisting the placeholder; real
+            # Telegram tokens always carry a numeric account prefix.
+            account = "0"
+        current = getattr(self, "_inbound_queue", None)
+        store = getattr(self, "_inbound_store", None)
+        if current is not None and self._bot_account_id == account:
+            if store is None or current.store.path == store.path:
+                # A queue retired by a completed handoff stays bound to its old
+                # adapter.  Late recovery on that stale adapter must remain a
+                # registry no-op; creating a third queue here would reverse the
+                # handoff and steal ownership from the active replacement.
+                if (
+                    getattr(current, "_lifecycle_retired", False)
+                    and getattr(current, "_handoff_target", None) is not None
+                ):
+                    return current
+                if not (
+                    getattr(current, "_ingress_closed", False)
+                    or getattr(current, "_store_executor_shutdown", False)
+                ):
+                    return current
+                self._retired_inbound_queue = current
+        store = store or TelegramInboundStore()
+        queue = DurableTelegramUpdateQueue(
+            store=store,
+            bot_account_id=account,
+            classifier=self._classify_inbound_update,
+            lease_owner=f"telegram:{account}:{os.getpid()}:{id(self)}",
+            active_limit=32,
+            item_factory=self._deserialize_update,
+        )
+        queue.attach_handoff_receiver(self)
+        self._inbound_store = store
+        self._inbound_queue = queue
+        self._bot_account_id = account
+        TelegramQueueLifecycleRegistry.observe(queue)
+        return queue
+
+    async def _recover_inbound_queue(self) -> None:
+        if not getattr(self, "_durable_queue_bound", False):
+            return
+        queue = self._ensure_inbound_queue()
+        # A reconnect may replay a leased row on this same adapter instance.
+        # The durable inbox, not these bounded process-local caches, decides
+        # whether the update is still eligible for delivery.
+        getattr(self, "_seen_update_ids", {}).clear()
+        getattr(self, "_seen_platform_update_ids", {}).clear()
+        # The registry serializes same-store/account lifecycle transitions and
+        # hands off any prior in-process queue before projecting recovery rows.
+        await TelegramQueueLifecycleRegistry.recover(queue)
+        # Clear only after a successful registry transition. On failure the
+        # strong reference preserves the predecessor for the next retry.
+        self._retired_inbound_queue = None
+
+    def _attach_inbound_queue(self, builder):
+        """Bind durable admission to PTB's polling/webhook queue boundary."""
+        setter = getattr(builder, "update_queue", None)
+        if not callable(setter):
+            self._durable_queue_bound = False
+            return builder
+        self._durable_queue_bound = True
+        configured_builder = setter(self._ensure_inbound_queue())
+        # PTB's fluent setter returns the builder itself.  Some legacy test
+        # doubles expose a callable ``update_queue`` but return a child mock;
+        # retain the canonical builder in that case so ``build()`` and the
+        # remaining chain still target the configured object.
+        return configured_builder if configured_builder is builder else builder
+
     def _register_handlers(self, app) -> None:
-        """Register every PTB handler on ``app`` (initial connect and the transient-init rebuild)."""
-        app.add_handler(TelegramMessageHandler(filters.TEXT & ~filters.COMMAND, self._handle_text_message))
-        app.add_handler(TelegramMessageHandler(filters.COMMAND, self._handle_command))
+        """Register every PTB handler with the durable claim fence."""
         app.add_handler(TelegramMessageHandler(
-            filters.LOCATION | getattr(filters, "VENUE", filters.LOCATION), self._handle_location_message))
+            filters.TEXT & ~filters.COMMAND,
+            self._wrap_inbound_handler(self._handle_text_message),
+        ))
+        app.add_handler(TelegramMessageHandler(
+            filters.COMMAND,
+            self._wrap_inbound_handler(self._handle_command),
+        ))
+        app.add_handler(TelegramMessageHandler(
+            filters.LOCATION | getattr(filters, "VENUE", filters.LOCATION),
+            self._wrap_inbound_handler(self._handle_location_message),
+        ))
         app.add_handler(TelegramMessageHandler(
             filters.PHOTO | filters.VIDEO | filters.AUDIO | filters.VOICE | filters.Document.ALL | filters.Sticker.ALL,
-            self._handle_media_message))
-        app.add_handler(CallbackQueryHandler(self._handle_callback_query))
-        # Inline command picker; inert until the owner enables inline mode via BotFather /setinline.
-        app.add_handler(InlineQueryHandler(self._handle_inline_query))
-        # gateway_platform_event observer: group 99 observes alongside, never displaces, core handlers.
-        app.add_handler(TypeHandler(Update, self._on_platform_update), group=99)
+            self._wrap_inbound_handler(self._handle_media_message),
+        ))
+        app.add_handler(CallbackQueryHandler(
+            self._wrap_inbound_handler(self._handle_callback_query),
+        ))
+        app.add_handler(InlineQueryHandler(
+            self._wrap_inbound_handler(self._handle_inline_query),
+        ))
+        app.add_handler(TypeHandler(
+            Update,
+            self._wrap_platform_event_handler(self._on_platform_update),
+        ), group=99)
+
+    def _telegram_plugin_application_proxy(self, app):
+        return _TelegramPluginApplicationProxy(app, self)
+
+    def _wrap_plugin_handler(self, handler):
+        """Clone a plugin handler and durably wrap every callback."""
+        if not TELEGRAM_AVAILABLE:
+            raise TypeError("python-telegram-bot is not installed")
+        from telegram.ext._handlers.basehandler import BaseHandler
+        from telegram.ext._handlers.conversationhandler import ConversationHandler
+
+        if not isinstance(handler, BaseHandler):
+            raise TypeError("plugin Telegram handler must be a python-telegram-bot BaseHandler")
+        if isinstance(handler, ConversationHandler):
+            try:
+                wrapped = copy.copy(handler)
+                wrapped._entry_points = [self._wrap_plugin_handler(child) for child in handler.entry_points]
+                wrapped._states = {
+                    state: [self._wrap_plugin_handler(child) for child in state_handlers]
+                    for state, state_handlers in handler.states.items()
+                }
+                wrapped._fallbacks = [self._wrap_plugin_handler(child) for child in handler.fallbacks]
+                wrapped._child_conversations = {
+                    child for child in (
+                        wrapped._entry_points + wrapped._fallbacks
+                        + [nested for handlers in wrapped._states.values() for nested in handlers]
+                    ) if isinstance(child, ConversationHandler)
+                }
+                return wrapped
+            except Exception as exc:
+                raise TypeError(
+                    f"cannot durably wrap plugin ConversationHandler: {type(handler).__name__}"
+                ) from exc
+        callback = getattr(handler, "callback", None)
+        if not callable(callback):
+            raise TypeError(f"cannot durably wrap plugin Telegram handler: {type(handler).__name__}")
+        if getattr(callback, _DURABLE_WRAPPER_MARKER, False):
+            return handler
+        try:
+            wrapped = copy.copy(handler)
+            wrapped.callback = self._wrap_inbound_handler(callback)
+            return wrapped
+        except Exception as exc:
+            raise TypeError(f"cannot durably wrap plugin Telegram handler: {type(handler).__name__}") from exc
 
     async def _build_ptb_requests(self) -> tuple:
         """Build the (general, getUpdates) HTTPXRequest pair: fallback-IP transport, explicit proxy, or
@@ -2841,6 +4095,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     old_app = self._app
                     self._app = builder.build()
                     self._bot = self._app.bot
+                    self._wire_plugin_handlers(self._telegram_plugin_application_proxy(self._app))
                     self._register_handlers(self._app)  # keep core and observer handlers in lockstep
                     with contextlib.suppress(Exception):
                         await _shutdown_abandoned_app(old_app)
@@ -2940,11 +4195,18 @@ class TelegramAdapter(BasePlatformAdapter):
                 logger.info("[%s] Using Telegram local_mode (read files from disk)", self.name)
             request, get_updates_request = await self._build_ptb_requests()
             builder = builder.request(request).get_updates_request(get_updates_request)
+            # PTB advances its polling offset immediately after
+            # ``update_queue.put`` returns (and the webhook handler responds
+            # after the same await).  Put the durable queue at that boundary so
+            # actionable updates cannot be acknowledged before SQLite has a
+            # replayable copy.
+            builder = self._attach_inbound_queue(builder)
             self._app = builder.build()
             self._bot = self._app.bot
             # Plugin PTB handlers go BEFORE core: PTB dispatches the first matching handler per group.
-            self._wire_plugin_handlers(self._app)
+            self._wire_plugin_handlers(self._telegram_plugin_application_proxy(self._app))
             self._register_handlers(self._app)
+            await self._recover_inbound_queue()
             await self._initialize_app_with_retries(builder)
             await self._app.start()
             webhook_url = os.getenv("TELEGRAM_WEBHOOK_URL", "").strip()
@@ -3034,6 +4296,7 @@ class TelegramAdapter(BasePlatformAdapter):
         pending_tasks = self._collect_live_tasks(
             [
                 *self._media_group_tasks.values(), *self._pending_photo_batch_tasks.values(), *self._pending_text_batch_tasks.values(),
+                *list(getattr(self, "_durable_batch_dispatch_tasks", ()) or ()),
                 getattr(self, "_polling_error_task", None), getattr(self, "_polling_progress_verifier_task", None),
                 # Hold-queue redispatch must be cancellable+awaitable on teardown too.
                 getattr(self, "_held_inbound_redispatch_task", None),
@@ -3047,6 +4310,11 @@ class TelegramAdapter(BasePlatformAdapter):
             task.cancel()
         if awaitable_tasks:
             await asyncio.gather(*awaitable_tasks, return_exceptions=True)
+        durable_dispatch_tasks = getattr(self, "_durable_batch_dispatch_tasks", None)
+        if durable_dispatch_tasks is not None:
+            durable_dispatch_tasks.difference_update(
+                task for task in tuple(durable_dispatch_tasks) if task.done()
+            )
         # Salvage buffered inbound events before clearing maps — unless permanent fatal, where no
         # reconnect can drain and hold would re-orphan them.
         if self._is_permanent_fatal():
@@ -3166,6 +4434,10 @@ class TelegramAdapter(BasePlatformAdapter):
                 await self._await_disconnect_step(self._app.shutdown(), _DISCONNECT_STEP_TIMEOUT, "app.shutdown()")
             except Exception as e:
                 logger.warning("[%s] Error during Telegram disconnect: %s", self.name, _redact_telegram_error_text(e))
+        inbound_queue = getattr(self, "_inbound_queue", None)
+        if inbound_queue is not None:
+            await self._await_disconnect_step(
+                inbound_queue.close(), _DISCONNECT_STEP_TIMEOUT, "durable queue close")
         self._app = None
         self._bot = None
         logger.info("[%s] Disconnected from Telegram", self.name)
@@ -5677,7 +6949,7 @@ class TelegramAdapter(BasePlatformAdapter):
         await self._ensure_forum_commands(update.message)
         self._enqueue_text_event(await self._build_triggered_event(msg, update, MessageType.TEXT))
 
-    async def _handle_command(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    async def _handle_command(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> Any:
         """Handle incoming command messages."""
         msg = self._effective_update_message(update)
         if not msg or not msg.text:
@@ -5694,9 +6966,9 @@ class TelegramAdapter(BasePlatformAdapter):
         if len(event.text or "") >= self._SPLIT_THRESHOLD:
             self._enqueue_text_event(event)
             return
-        await self.handle_message(event)
+        return await self._dispatch_inbound_event(event)
 
-    async def _handle_location_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    async def _handle_location_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> Any:
         """Handle incoming location/venue pin messages."""
         msg = self._effective_update_message(update)
         if not msg:
@@ -5727,7 +6999,9 @@ class TelegramAdapter(BasePlatformAdapter):
             "Ask what they'd like to find nearby (restaurants, cafes, etc.) and any preferences."]
         event = self._build_message_event(msg, MessageType.LOCATION, update_id=update.update_id)
         event.text = "\n".join(parts)
-        await self.handle_message(self._apply_telegram_group_observe_attribution(event))
+        return await self._dispatch_inbound_event(
+            self._apply_telegram_group_observe_attribution(event)
+        )
 
     # -- Text message aggregation (handles Telegram client-side splits) --
 
@@ -5738,10 +7012,16 @@ class TelegramAdapter(BasePlatformAdapter):
 
     def _enqueue_text_event(self, event: MessageEvent) -> None:
         """Buffer a text chunk, or hold it while delayed delivery must be dropped."""
+        self._defer_durable_event(event)
         if self._should_drop_delayed_delivery():
             self._hold_inbound_event(event, where="text-enqueue")
             return
+        key = self._text_batch_key(event)
+        existing = self._pending_text_batches.get(key)
         super()._enqueue_text_event(event)
+        if existing is not None:
+            self._merge_durable_event_metadata(existing, event)
+        self._mark_durable_event_buffered(event)
 
     async def _flush_buffered(self, pending: dict, tasks: dict, key: str, delay: float, where: str, log_fn=None) -> None:
         """Shared delayed-flush body: sleep, pop, hold if teardown started, else dispatch. A cancel after
@@ -5759,8 +7039,14 @@ class TelegramAdapter(BasePlatformAdapter):
                 return
             if log_fn is not None:
                 log_fn(event)
-            await self.handle_message(event)
+            durable = bool(self._durable_update_ids(event))
+            dispatch_task = self._start_batched_durable_dispatch(event)
             event = None
+            if not durable:
+                # Preserve the legacy cancellation boundary for ordinary
+                # in-memory events. Durable events own their claim lifecycle
+                # in the detached task and must outlive a replaced batch timer.
+                await dispatch_task
         except asyncio.CancelledError:
             if event is not None:
                 self._hold_inbound_event(event, where=f"{where}-flush-cancelled")
@@ -5819,6 +7105,7 @@ class TelegramAdapter(BasePlatformAdapter):
 
     def _enqueue_photo_event(self, batch_key: str, event: MessageEvent) -> None:
         """Merge photo events into a pending batch and schedule flush."""
+        self._defer_durable_event(event)
         if self._should_drop_delayed_delivery():
             self._hold_inbound_event(event, where="photo-enqueue")
             return
@@ -5966,9 +7253,9 @@ class TelegramAdapter(BasePlatformAdapter):
             await self._surface_media_cache_failure(msg, event, "attachment", e, display_name=getattr(doc, "file_name", None) or None)
         return False
 
-    async def _handle_media_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    async def _handle_media_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> Any:
         """Handle incoming media messages, downloading images to local cache."""
-        msg = update.message
+        msg = self._effective_update_message(update)
         if not msg:
             return
         if not self._is_user_authorized_from_message(msg):
@@ -5988,8 +7275,9 @@ class TelegramAdapter(BasePlatformAdapter):
         # Stickers: _handle_sticker overwrites event.text with its vision description, so observe attribution must run after it.
         if msg.sticker:
             await self._handle_sticker(msg, event)
-            await self.handle_message(self._apply_telegram_group_observe_attribution(event))
-            return
+            return await self._dispatch_inbound_event(
+                self._apply_telegram_group_observe_attribution(event)
+            )
         event = self._apply_telegram_group_observe_attribution(event)
         # Cache photo locally: Telegram's file URLs expire (~1 hour) before vision may run.
         if msg.photo:
@@ -6021,7 +7309,7 @@ class TelegramAdapter(BasePlatformAdapter):
         if media_group_id:
             await self._queue_media_group_event(str(media_group_id), event)
             return
-        await self.handle_message(event)
+        return await self._dispatch_inbound_event(event)
 
     async def _queue_media_group_event(self, media_group_id: str, event: MessageEvent) -> None:
         """Debounce album items (shared media_group_id) into one MessageEvent so the second image isn't
@@ -6297,10 +7585,11 @@ class TelegramAdapter(BasePlatformAdapter):
 
     async def _set_reaction(self, chat_id: str, message_id: str, emoji: Optional[str]) -> bool:
         """Set a single emoji reaction (``None`` clears all bot-set reactions, the documented Bot API way)."""
-        if not self._bot:
+        bot = getattr(self, "_bot", None)
+        if not bot:
             return False
         try:
-            await self._bot.set_message_reaction(chat_id=normalize_telegram_chat_id(chat_id), message_id=int(message_id), reaction=emoji)
+            await bot.set_message_reaction(chat_id=normalize_telegram_chat_id(chat_id), message_id=int(message_id), reaction=emoji)
             return True
         except Exception as e:
             if emoji is None:
@@ -6315,6 +7604,7 @@ class TelegramAdapter(BasePlatformAdapter):
 
     async def on_processing_start(self, event: MessageEvent) -> None:
         """Add an in-progress reaction when message processing begins."""
+        setattr(event, "_telegram_processing_started", True)
         if not self._reactions_enabled():
             return
         chat_id = getattr(event.source, "chat_id", None)
@@ -6325,6 +7615,14 @@ class TelegramAdapter(BasePlatformAdapter):
     async def on_processing_complete(self, event: MessageEvent, outcome: ProcessingOutcome) -> None:
         """Swap the in-progress reaction for a final success/failure reaction (set_message_reaction
         replaces, not adds); CANCELLED explicitly clears the 👀."""
+        setattr(event, "_telegram_processing_outcome", outcome)
+        owner_task = asyncio.current_task()
+        if owner_task is not None:
+            setattr(owner_task, "_telegram_processing_outcome", outcome)
+        signal = getattr(event, "_telegram_processing_complete", None)
+        if isinstance(signal, asyncio.Event):
+            signal.set()
+        self._schedule_durable_processing_completion(event, outcome)
         if not self._reactions_enabled():
             return
         chat_id = getattr(event.source, "chat_id", None)

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -3541,7 +3541,10 @@ class TelegramAdapter(BasePlatformAdapter):
             fifo_admitted = bool(
                 getattr(event, "_gateway_busy_fifo_admitted", False)
             )
-            if fifo_admitted or self._durable_event_in_gateway_fifo(
+            steer_admitted = bool(
+                getattr(event, "_gateway_busy_steer_admitted", False)
+            )
+            if fifo_admitted or steer_admitted or self._durable_event_in_gateway_fifo(
                 event, session_key
             ):
                 self._schedule_durable_fifo_completion(event, session_key)

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -3433,54 +3433,92 @@ class TelegramAdapter(BasePlatformAdapter):
                     break
         return removed
 
-    async def _await_durable_processing(self, session_key: str) -> None:
-        """Wait for the background task chain that owns a durable session."""
+    async def _await_durable_processing(
+        self, session_key: str
+    ) -> ProcessingOutcome | None:
+        """Wait for a durable session owner and return its final outcome."""
         observed_task_ids: set[int] = set()
+        outcome = None
         while True:
             task = getattr(self, "_session_tasks", {}).get(session_key)
             if task is None or task is asyncio.current_task():
-                return
+                return outcome
             task_id = id(task)
             if task_id in observed_task_ids:
-                return
+                return outcome
             observed_task_ids.add(task_id)
             if not inspect.isawaitable(task):
-                return
-            await asyncio.shield(task)
+                return outcome
+            try:
+                await asyncio.shield(task)
+            except asyncio.CancelledError:
+                current_task = asyncio.current_task()
+                if current_task is not None and current_task.cancelling():
+                    raise
+                outcome = getattr(task, "_telegram_processing_outcome", None)
+            except Exception:
+                outcome = None
+            else:
+                outcome = getattr(task, "_telegram_processing_outcome", None)
             if getattr(self, "_session_tasks", {}).get(session_key) is task:
-                return
+                return outcome
 
     async def _await_durable_event_processing(
         self, event: Any, session_key: str
     ) -> object:
         """Wait for this event, not merely the preceding session owner."""
         signal = self._durable_processing_complete_event(event)
-        await self._await_durable_processing(session_key)
-        if signal.is_set() or not self._durable_event_in_gateway_fifo(event, session_key):
+        owner_outcome = await self._await_durable_processing(session_key)
+        if signal.is_set():
             return event
+        if (
+            owner_outcome == ProcessingOutcome.SUCCESS
+            and not self._durable_event_in_gateway_fifo(event, session_key)
+        ):
+            return event
+        self._remove_durable_event_from_gateway_fifo(event, session_key)
+        self._defer_durable_event(event)
+        return _DURABLE_DISPATCH_DEFERRED
 
-        wait_task = asyncio.create_task(signal.wait())
-        try:
-            while True:
-                if wait_task.done():
-                    await asyncio.shield(wait_task)
-                    return event
-                if not self._durable_event_in_gateway_fifo(event, session_key):
-                    if getattr(event, "_telegram_processing_started", False):
-                        await asyncio.shield(wait_task)
-                        return event
-                    self._defer_durable_event(event)
-                    return _DURABLE_DISPATCH_DEFERRED
-                done, _ = await asyncio.wait({wait_task}, timeout=0.1)
-                if done:
-                    return event
-        finally:
-            if not wait_task.done():
-                wait_task.cancel()
-                try:
-                    await wait_task
-                except asyncio.CancelledError:
-                    pass
+    def _schedule_durable_fifo_completion(
+        self, event: MessageEvent, session_key: str
+    ) -> None:
+        """Finalize a durable event drained inside an existing session owner."""
+        existing = getattr(event, "_telegram_durable_fifo_completion_task", None)
+        if existing is not None and not existing.done():
+            return
+
+        async def complete() -> None:
+            try:
+                result = await self._await_durable_event_processing(event, session_key)
+                if self._durable_processing_complete_event(event).is_set():
+                    return
+                setattr(event, "_telegram_durable_completion_pending", False)
+                if result is _DURABLE_DISPATCH_DEFERRED:
+                    transitioned = await self._complete_durable_event(
+                        event,
+                        success=False,
+                        delay=_DURABLE_BUSY_RETRY_DELAY_SECONDS,
+                        defer=True,
+                    )
+                else:
+                    transitioned = await self._complete_durable_event(
+                        event, success=True
+                    )
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("[Telegram] Durable FIFO completion failed")
+                return
+            if not transitioned:
+                logger.warning("[Telegram] Durable FIFO completion was not confirmed")
+
+        task = asyncio.create_task(complete())
+        setattr(event, "_telegram_durable_fifo_completion_task", task)
+        queue = getattr(self, "_inbound_queue", None)
+        register = getattr(queue, "register_lifecycle_task", None)
+        if callable(register):
+            register(task)
 
     async def _dispatch_inbound_event(self, event: MessageEvent) -> object:
         """Dispatch durable work only after its actual processing boundary."""
@@ -3500,6 +3538,14 @@ class TelegramAdapter(BasePlatformAdapter):
             setattr(event, "_telegram_durable_completion_pending", False)
             return _DURABLE_DISPATCH_DEFERRED
         if durable_ids:
+            fifo_admitted = bool(
+                getattr(event, "_gateway_busy_fifo_admitted", False)
+            )
+            if fifo_admitted or self._durable_event_in_gateway_fifo(
+                event, session_key
+            ):
+                self._schedule_durable_fifo_completion(event, session_key)
+                return _DURABLE_DISPATCH_ASYNC
             if session_key in getattr(self, "_session_tasks", {}):
                 return _DURABLE_DISPATCH_ASYNC
             if callable(getattr(self, "_message_handler", None)):

--- a/plugins/platforms/telegram/inbound_store.py
+++ b/plugins/platforms/telegram/inbound_store.py
@@ -1,0 +1,3002 @@
+"""Durable Telegram ingress and dispatch primitives.
+
+The Telegram updater advances its polling offset immediately after
+``Application.update_queue.put`` returns.  This module supplies the queue used
+by the adapter so actionable updates are persisted before that boundary.  The
+SQLite schema deliberately stores both bot and update identifiers as TEXT:
+Telegram identity is not allowed to narrow through SQLite's signed INTEGER
+range.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+import os
+import re
+import sqlite3
+import stat
+import threading
+import time
+import uuid
+import weakref
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from functools import partial
+from pathlib import Path
+from typing import Any, Awaitable, Callable, Optional
+
+from hermes_cli.config import get_hermes_home
+
+
+logger = logging.getLogger(__name__)
+
+SCHEMA_VERSION = 1
+MAX_ATTEMPTS = 3
+_INGRESS_RETRY_INITIAL_SECONDS = 0.05
+_INGRESS_RETRY_MAX_SECONDS = 2.0
+_INGRESS_STALL_LOG_SECONDS = 30.0
+_DECIMAL_INTEGER = re.compile(r"^[+-]?[0-9]+$")
+_TERMINAL_STATES = frozenset({"consumed", "rejected", "dead_letter"})
+_STORE_EXECUTOR_LOCK = threading.Lock()
+_STORE_EXECUTORS: dict[str, tuple[ThreadPoolExecutor, int]] = {}
+
+
+def _canonical_store_path(path: os.PathLike[str] | str) -> str:
+    """Resolve aliases to one stable process-local SQLite identity."""
+    return os.path.realpath(os.path.abspath(os.fspath(path)))
+
+
+def _acquire_store_executor(key: str, bot_account_id: int) -> ThreadPoolExecutor:
+    """Share one SQLite worker across queue epochs for one durable inbox."""
+    with _STORE_EXECUTOR_LOCK:
+        current = _STORE_EXECUTORS.get(key)
+        if current is None:
+            executor = ThreadPoolExecutor(
+                max_workers=1,
+                thread_name_prefix=f"telegram-inbound-{bot_account_id}",
+            )
+            _STORE_EXECUTORS[key] = (executor, 1)
+            return executor
+        executor, references = current
+        _STORE_EXECUTORS[key] = (executor, references + 1)
+        return executor
+
+
+def _release_store_executor(key: str, executor: ThreadPoolExecutor) -> None:
+    """Release one queue epoch without interrupting a replacement's writes."""
+    should_shutdown = False
+    with _STORE_EXECUTOR_LOCK:
+        current = _STORE_EXECUTORS.get(key)
+        if current is None or current[0] is not executor:
+            return
+        references = current[1] - 1
+        if references > 0:
+            _STORE_EXECUTORS[key] = (executor, references)
+        else:
+            _STORE_EXECUTORS.pop(key, None)
+            should_shutdown = True
+    if should_shutdown:
+        executor.shutdown(wait=False, cancel_futures=False)
+
+
+def _canonical_decimal(value: Any, name: str) -> str:
+    """Return a decimal integer in canonical text form."""
+    if isinstance(value, bool):
+        raise TypeError(f"{name} must be an integer, not bool")
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, str) and _DECIMAL_INTEGER.fullmatch(value.strip()):
+        return str(int(value.strip(), 10))
+    raise TypeError(f"{name} must be a decimal integer")
+
+
+def canonical_bot_account_id(value: Any) -> str:
+    """Canonicalize a Telegram bot account id without SQLite narrowing."""
+    return _canonical_decimal(value, "bot_account_id")
+
+
+def bot_account_key(value: Any) -> str:
+    """Return the stable key used by account-scoped Telegram state."""
+    return f"telegram-account:{canonical_bot_account_id(value)}"
+
+
+def bot_account_id_from_token(token: Any) -> str:
+    """Extract the numeric Telegram bot id from a Bot API token.
+
+    Only the token prefix is used; the secret portion is never persisted or
+    included in an exception raised by this function.
+    """
+    raw = str(token or "")
+    prefix = raw.split(":", 1)[0]
+    return canonical_bot_account_id(prefix)
+
+
+@dataclass
+class CaptureDecision:
+    """Side-effect-free classification of one incoming Telegram update."""
+
+    actionable: bool
+    profile: str = "default"
+    account_id: str = "telegram"
+    update_kind: str = "message"
+    chat_id: Optional[str] = None
+    message_id: Optional[str] = None
+    callback_query_id: Optional[str] = None
+    session_key: str = ""
+    priority: int = 100
+    payload: Optional[dict[str, Any]] = None
+    receipt_required: bool = False
+
+
+@dataclass
+class InboundEvent:
+    """Durable representation of one accepted Telegram update."""
+
+    event_id: str
+    bot_account_id: int
+    update_id: int
+    profile: str
+    account_id: str
+    update_kind: str
+    chat_id: Optional[str]
+    message_id: Optional[str]
+    callback_query_id: Optional[str]
+    session_key: str
+    priority: int
+    payload: Optional[dict[str, Any]]
+    work_state: str
+    dispatch_state: str
+    received_at: float
+    persisted_at: float
+    queued_at: Optional[float]
+    lease_owner: Optional[str] = None
+    lease_epoch: int = 0
+    lease_expires_at: Optional[float] = None
+    leased_at: Optional[float] = None
+    attempt_count: int = 0
+    replay_count: int = 0
+    last_replay_at: Optional[float] = None
+    last_error_class: Optional[str] = None
+    duplicate_count: int = 0
+    identity_conflict_count: int = 0
+    last_duplicate_at: Optional[float] = None
+    consumed_at: Optional[float] = None
+    terminal_at: Optional[float] = None
+    terminal_reason: Optional[str] = None
+    payload_sha256: Optional[str] = None
+    replayed: bool = False
+
+
+@dataclass
+class PersistResult:
+    event_id: str
+    duplicate: bool
+    identity_conflict: bool
+    row: InboundEvent
+
+
+class TelegramInboundStore:
+    """SQLite inbox with transactional, account-scoped ownership changes."""
+
+    def __init__(self, path: Optional[Path] = None, *, busy_timeout_ms: int = 250):
+        self.path = Path(path or (get_hermes_home() / "telegram_inbound.db"))
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.busy_timeout_ms = max(1, int(busy_timeout_ms))
+        self._schema_lock = threading.Lock()
+        self._schema_ready = False
+        try:
+            fd = os.open(self.path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+        except FileExistsError:
+            pass
+        else:
+            os.close(fd)
+        self._secure_store_files()
+        self.lifecycle_path = _canonical_store_path(self.path)
+        self._ensure_schema()
+
+    def _secure_store_files(self) -> None:
+        """Keep the SQLite database and journaling sidecars owner-readable."""
+        for candidate in (
+            self.path,
+            self.path.with_name(self.path.name + "-wal"),
+            self.path.with_name(self.path.name + "-shm"),
+        ):
+            try:
+                file_stat = os.lstat(candidate)
+            except FileNotFoundError:
+                continue
+            if stat.S_ISLNK(file_stat.st_mode):
+                raise RuntimeError(
+                    f"Telegram inbound SQLite path must not be a symlink: {candidate}"
+                )
+            if not stat.S_ISREG(file_stat.st_mode):
+                raise RuntimeError(
+                    f"Telegram inbound SQLite path must be a regular file: {candidate}"
+                )
+            try:
+                os.chmod(candidate, 0o600)
+            except FileNotFoundError:
+                continue
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(
+            self.path,
+            timeout=self.busy_timeout_ms / 1000.0,
+            check_same_thread=False,
+        )
+        self._secure_store_files()
+        conn.row_factory = sqlite3.Row
+        conn.execute(f"PRAGMA busy_timeout={self.busy_timeout_ms}")
+        conn.execute("PRAGMA foreign_keys=ON")
+        return conn
+
+    def _ensure_schema(self) -> None:
+        if self._schema_ready:
+            return
+        with self._schema_lock:
+            if self._schema_ready:
+                return
+            with self._connect() as conn:
+                conn.execute("PRAGMA journal_mode=WAL")
+                existing_tables = {
+                    str(row[0])
+                    for row in conn.execute(
+                        "SELECT name FROM sqlite_master WHERE type='table' "
+                        "AND name IN ('telegram_inbound_event', 'telegram_inbound_alias')"
+                    ).fetchall()
+                }
+                if existing_tables == {
+                    "telegram_inbound_event",
+                    "telegram_inbound_alias",
+                }:
+                    existing_event_types = {
+                        str(row[1]): str(row[2]).upper()
+                        for row in conn.execute(
+                            "PRAGMA table_info(telegram_inbound_event)"
+                        ).fetchall()
+                    }
+                    existing_alias_types = {
+                        str(row[1]): str(row[2]).upper()
+                        for row in conn.execute(
+                            "PRAGMA table_info(telegram_inbound_alias)"
+                        ).fetchall()
+                    }
+                    if (
+                        existing_event_types.get("bot_account_id") != "TEXT"
+                        or existing_event_types.get("update_id") != "TEXT"
+                        or existing_alias_types.get("bot_account_id") != "TEXT"
+                    ):
+                        self._validate_identifier_migration_preflight(conn)
+                conn.executescript(
+                    """
+                    CREATE TABLE IF NOT EXISTS telegram_inbound_event (
+                        seq INTEGER PRIMARY KEY AUTOINCREMENT,
+                        event_id TEXT NOT NULL UNIQUE,
+                        bot_account_id TEXT NOT NULL,
+                        update_id TEXT NOT NULL,
+                        profile TEXT NOT NULL,
+                        account_id TEXT NOT NULL,
+                        update_kind TEXT NOT NULL,
+                        chat_id TEXT,
+                        message_id TEXT,
+                        callback_query_id TEXT,
+                        session_key TEXT NOT NULL,
+                        priority INTEGER NOT NULL DEFAULT 100,
+                        payload_json TEXT,
+                        payload_sha256 TEXT,
+                        work_state TEXT NOT NULL DEFAULT 'queued',
+                        receipt_state TEXT NOT NULL DEFAULT 'not_required',
+                        dispatch_state TEXT NOT NULL DEFAULT 'pending',
+                        next_attempt_at REAL,
+                        received_at REAL NOT NULL,
+                        persisted_at REAL NOT NULL,
+                        queued_at REAL,
+                        lease_owner TEXT,
+                        lease_epoch INTEGER NOT NULL DEFAULT 0,
+                        lease_expires_at REAL,
+                        leased_at REAL,
+                        context_committed_at REAL,
+                        attempt_count INTEGER NOT NULL DEFAULT 0,
+                        replay_count INTEGER NOT NULL DEFAULT 0,
+                        last_replay_at REAL,
+                        last_error_class TEXT,
+                        duplicate_count INTEGER NOT NULL DEFAULT 0,
+                        identity_conflict_count INTEGER NOT NULL DEFAULT 0,
+                        last_duplicate_at REAL,
+                        consumed_at REAL,
+                        terminal_at REAL,
+                        receipt_attempted_at REAL,
+                        receipt_confirmed_at REAL,
+                        terminal_reason TEXT
+                    );
+                    CREATE UNIQUE INDEX IF NOT EXISTS
+                        telegram_inbound_event_account_update
+                        ON telegram_inbound_event(bot_account_id, update_id);
+                    CREATE INDEX IF NOT EXISTS telegram_inbound_event_ready
+                        ON telegram_inbound_event(bot_account_id, work_state,
+                                                  dispatch_state, priority, seq);
+                    CREATE TABLE IF NOT EXISTS telegram_inbound_alias (
+                        bot_account_id TEXT NOT NULL,
+                        alias_kind TEXT NOT NULL,
+                        scope TEXT NOT NULL,
+                        alias_value TEXT NOT NULL,
+                        event_id TEXT NOT NULL,
+                        PRIMARY KEY (bot_account_id, alias_kind, scope, alias_value),
+                        FOREIGN KEY (event_id) REFERENCES telegram_inbound_event(event_id)
+                    );
+                    CREATE INDEX IF NOT EXISTS telegram_inbound_alias_event
+                        ON telegram_inbound_alias(event_id);
+                    """
+                )
+                columns = {
+                    str(row[1])
+                    for row in conn.execute(
+                        "PRAGMA table_info(telegram_inbound_event)"
+                    ).fetchall()
+                }
+                if "next_attempt_at" not in columns:
+                    conn.execute(
+                        "ALTER TABLE telegram_inbound_event ADD COLUMN next_attempt_at REAL"
+                    )
+                if "receipt_state" not in columns:
+                    conn.execute(
+                        "ALTER TABLE telegram_inbound_event "
+                        "ADD COLUMN receipt_state TEXT NOT NULL DEFAULT 'not_required'"
+                    )
+                conn.commit()
+                event_types = {
+                    str(row[1]): str(row[2]).upper()
+                    for row in conn.execute(
+                        "PRAGMA table_info(telegram_inbound_event)"
+                    ).fetchall()
+                }
+                alias_types = {
+                    str(row[1]): str(row[2]).upper()
+                    for row in conn.execute(
+                        "PRAGMA table_info(telegram_inbound_alias)"
+                    ).fetchall()
+                }
+                if (
+                    event_types.get("bot_account_id") != "TEXT"
+                    or event_types.get("update_id") != "TEXT"
+                    or alias_types.get("bot_account_id") != "TEXT"
+                ):
+                    self._migrate_identifier_affinity(conn)
+                self._secure_store_files()
+            self._schema_ready = True
+
+    @staticmethod
+    def _quoted_identifier(value: str) -> str:
+        return '"' + value.replace('"', '""') + '"'
+
+    def _validate_identifier_migration_preflight(
+        self, conn: sqlite3.Connection
+    ) -> None:
+        """Reject lossy identifiers and canonical-name collisions before DDL."""
+        real_identifiers = conn.execute(
+            "SELECT "
+            "(SELECT COUNT(*) FROM telegram_inbound_event "
+            " WHERE typeof(bot_account_id)='real' OR typeof(update_id)='real') + "
+            "(SELECT COUNT(*) FROM telegram_inbound_alias "
+            " WHERE typeof(bot_account_id)='real')"
+        ).fetchone()[0]
+        if real_identifiers:
+            raise RuntimeError(
+                "Telegram inbound migration found lossy REAL identifiers; "
+                "restore or repair the database before startup"
+            )
+
+        canonical_indexes = {
+            "telegram_inbound_event_account_update": (
+                "telegram_inbound_event",
+                True,
+                ("bot_account_id", "update_id"),
+            ),
+            "telegram_inbound_event_ready": (
+                "telegram_inbound_event",
+                False,
+                ("bot_account_id", "work_state", "dispatch_state", "priority", "seq"),
+            ),
+            "telegram_inbound_alias_event": (
+                "telegram_inbound_alias",
+                False,
+                ("event_id",),
+            ),
+        }
+        for name, (expected_table, expected_unique, expected_columns) in (
+            canonical_indexes.items()
+        ):
+            row = conn.execute(
+                "SELECT tbl_name FROM sqlite_master WHERE type='index' AND name=?",
+                (name,),
+            ).fetchone()
+            if row is None:
+                continue
+            table = str(row[0])
+            index_entry = next(
+                (
+                    item
+                    for item in conn.execute(
+                        f"PRAGMA index_list({self._quoted_identifier(table)})"
+                    ).fetchall()
+                    if str(item[1]) == name
+                ),
+                None,
+            )
+            columns = tuple(
+                str(item[2])
+                for item in conn.execute(
+                    f"PRAGMA index_info({self._quoted_identifier(name)})"
+                ).fetchall()
+            )
+            if (
+                table != expected_table
+                or index_entry is None
+                or bool(index_entry[2]) != expected_unique
+                or bool(index_entry[4])
+                or columns != expected_columns
+            ):
+                raise RuntimeError(
+                    "Telegram inbound migration found conflicting canonical index "
+                    f"{name}"
+                )
+
+    def _migrate_identifier_affinity(self, conn: sqlite3.Connection) -> None:
+        """Rebuild legacy INTEGER-affinity identity columns as lossless TEXT."""
+        conn.execute("PRAGMA foreign_keys=OFF")
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            self._validate_identifier_migration_preflight(conn)
+            sequence_row = conn.execute(
+                "SELECT seq FROM sqlite_sequence "
+                "WHERE name='telegram_inbound_event'"
+            ).fetchone()
+            legacy_sequence = int(sequence_row[0]) if sequence_row is not None else 0
+            index_rows = conn.execute(
+                "SELECT name, tbl_name, sql FROM sqlite_master WHERE type='index' "
+                "AND tbl_name IN ('telegram_inbound_event', 'telegram_inbound_alias') "
+                "AND sql IS NOT NULL"
+            ).fetchall()
+            canonical_index_names = {
+                "telegram_inbound_event_account_update",
+                "telegram_inbound_event_ready",
+                "telegram_inbound_alias_event",
+            }
+            preserved_indexes: list[tuple[str, str]] = []
+            for raw_name, _raw_table, raw_sql in index_rows:
+                name = str(raw_name)
+                sql = str(raw_sql)
+                if name not in canonical_index_names:
+                    preserved_indexes.append((name, sql))
+            for raw_name, _raw_table, _raw_sql in index_rows:
+                name = str(raw_name)
+                conn.execute(f"DROP INDEX {self._quoted_identifier(name)}")
+
+            conn.execute(
+                "ALTER TABLE telegram_inbound_alias "
+                "RENAME TO telegram_inbound_alias_legacy"
+            )
+            conn.execute(
+                "ALTER TABLE telegram_inbound_event "
+                "RENAME TO telegram_inbound_event_legacy"
+            )
+            conn.execute(
+                """CREATE TABLE telegram_inbound_event (
+                    seq INTEGER PRIMARY KEY AUTOINCREMENT,
+                    event_id TEXT NOT NULL UNIQUE,
+                    bot_account_id TEXT NOT NULL,
+                    update_id TEXT NOT NULL,
+                    profile TEXT NOT NULL,
+                    account_id TEXT NOT NULL,
+                    update_kind TEXT NOT NULL,
+                    chat_id TEXT,
+                    message_id TEXT,
+                    callback_query_id TEXT,
+                    session_key TEXT NOT NULL,
+                    priority INTEGER NOT NULL DEFAULT 100,
+                    payload_json TEXT,
+                    payload_sha256 TEXT,
+                    work_state TEXT NOT NULL DEFAULT 'queued',
+                    receipt_state TEXT NOT NULL DEFAULT 'not_required',
+                    dispatch_state TEXT NOT NULL DEFAULT 'pending',
+                    next_attempt_at REAL,
+                    received_at REAL NOT NULL,
+                    persisted_at REAL NOT NULL,
+                    queued_at REAL,
+                    lease_owner TEXT,
+                    lease_epoch INTEGER NOT NULL DEFAULT 0,
+                    lease_expires_at REAL,
+                    leased_at REAL,
+                    context_committed_at REAL,
+                    attempt_count INTEGER NOT NULL DEFAULT 0,
+                    replay_count INTEGER NOT NULL DEFAULT 0,
+                    last_replay_at REAL,
+                    last_error_class TEXT,
+                    duplicate_count INTEGER NOT NULL DEFAULT 0,
+                    identity_conflict_count INTEGER NOT NULL DEFAULT 0,
+                    last_duplicate_at REAL,
+                    consumed_at REAL,
+                    terminal_at REAL,
+                    receipt_attempted_at REAL,
+                    receipt_confirmed_at REAL,
+                    terminal_reason TEXT
+                )"""
+            )
+            conn.execute(
+                """CREATE TABLE telegram_inbound_alias (
+                    bot_account_id TEXT NOT NULL,
+                    alias_kind TEXT NOT NULL,
+                    scope TEXT NOT NULL,
+                    alias_value TEXT NOT NULL,
+                    event_id TEXT NOT NULL,
+                    PRIMARY KEY (bot_account_id, alias_kind, scope, alias_value),
+                    FOREIGN KEY (event_id) REFERENCES telegram_inbound_event(event_id)
+                )"""
+            )
+
+            old_event_columns = {
+                str(row[1])
+                for row in conn.execute(
+                    "PRAGMA table_info(telegram_inbound_event_legacy)"
+                ).fetchall()
+            }
+            new_event_columns = [
+                str(row[1])
+                for row in conn.execute(
+                    "PRAGMA table_info(telegram_inbound_event)"
+                ).fetchall()
+                if str(row[1]) in old_event_columns
+            ]
+            event_targets = ", ".join(
+                self._quoted_identifier(column) for column in new_event_columns
+            )
+            event_sources = ", ".join(
+                f"CAST({self._quoted_identifier(column)} AS TEXT)"
+                if column in {"bot_account_id", "update_id"}
+                else self._quoted_identifier(column)
+                for column in new_event_columns
+            )
+            conn.execute(
+                f"INSERT INTO telegram_inbound_event ({event_targets}) "
+                f"SELECT {event_sources} FROM telegram_inbound_event_legacy"
+            )
+
+            old_alias_columns = {
+                str(row[1])
+                for row in conn.execute(
+                    "PRAGMA table_info(telegram_inbound_alias_legacy)"
+                ).fetchall()
+            }
+            new_alias_columns = [
+                str(row[1])
+                for row in conn.execute(
+                    "PRAGMA table_info(telegram_inbound_alias)"
+                ).fetchall()
+                if str(row[1]) in old_alias_columns
+            ]
+            alias_targets = ", ".join(
+                self._quoted_identifier(column) for column in new_alias_columns
+            )
+            alias_sources = ", ".join(
+                f"CAST({self._quoted_identifier(column)} AS TEXT)"
+                if column == "bot_account_id"
+                else self._quoted_identifier(column)
+                for column in new_alias_columns
+            )
+            conn.execute(
+                f"INSERT INTO telegram_inbound_alias ({alias_targets}) "
+                f"SELECT {alias_sources} FROM telegram_inbound_alias_legacy"
+            )
+            conn.execute("DROP TABLE telegram_inbound_alias_legacy")
+            conn.execute("DROP TABLE telegram_inbound_event_legacy")
+            copied_sequence = int(
+                conn.execute(
+                    "SELECT COALESCE(MAX(seq), 0) FROM telegram_inbound_event"
+                ).fetchone()[0]
+            )
+            target_sequence = max(legacy_sequence, copied_sequence)
+            conn.execute(
+                "DELETE FROM sqlite_sequence WHERE name='telegram_inbound_event'"
+            )
+            if target_sequence:
+                conn.execute(
+                    "INSERT INTO sqlite_sequence(name, seq) VALUES (?, ?)",
+                    ("telegram_inbound_event", target_sequence),
+                )
+            for _name, sql in preserved_indexes:
+                conn.execute(sql)
+            conn.execute(
+                "CREATE UNIQUE INDEX "
+                "telegram_inbound_event_account_update "
+                "ON telegram_inbound_event(bot_account_id, update_id)"
+            )
+            conn.execute(
+                "CREATE INDEX telegram_inbound_event_ready "
+                "ON telegram_inbound_event(bot_account_id, work_state, "
+                "dispatch_state, priority, seq)"
+            )
+            conn.execute(
+                "CREATE INDEX telegram_inbound_alias_event "
+                "ON telegram_inbound_alias(event_id)"
+            )
+            foreign_key_errors = conn.execute("PRAGMA foreign_key_check").fetchall()
+            if foreign_key_errors:
+                raise RuntimeError(
+                    "Telegram inbound identifier migration violated foreign keys"
+                )
+            conn.commit()
+        except BaseException:
+            if conn.in_transaction:
+                conn.rollback()
+            raise
+        finally:
+            conn.execute("PRAGMA foreign_keys=ON")
+
+    @staticmethod
+    def _payload_bytes(payload: dict[str, Any]) -> bytes:
+        return json.dumps(
+            payload,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        ).encode("utf-8")
+
+    @staticmethod
+    def _event_id(account: str, update_id: str) -> str:
+        return f"telegram:{account}:{update_id}"
+
+
+    @staticmethod
+    def _row(row: Optional[sqlite3.Row], *, replayed: bool = False) -> Optional[InboundEvent]:
+        if row is None:
+            return None
+        payload = None
+        if row["payload_json"] is not None:
+            try:
+                value = json.loads(row["payload_json"])
+                if isinstance(value, dict):
+                    payload = value
+            except (TypeError, ValueError, json.JSONDecodeError):
+                payload = None
+        return InboundEvent(
+            event_id=str(row["event_id"]),
+            bot_account_id=int(row["bot_account_id"]),
+            update_id=int(row["update_id"]),
+            profile=str(row["profile"]),
+            account_id=str(row["account_id"]),
+            update_kind=str(row["update_kind"]),
+            chat_id=row["chat_id"],
+            message_id=row["message_id"],
+            callback_query_id=row["callback_query_id"],
+            session_key=str(row["session_key"]),
+            priority=int(row["priority"]),
+            payload=payload,
+            work_state=str(row["work_state"]),
+            dispatch_state=str(row["dispatch_state"]),
+            received_at=float(row["received_at"]),
+            persisted_at=float(row["persisted_at"]),
+            queued_at=(float(row["queued_at"]) if row["queued_at"] is not None else None),
+            lease_owner=row["lease_owner"],
+            lease_epoch=int(row["lease_epoch"]),
+            lease_expires_at=(
+                float(row["lease_expires_at"])
+                if row["lease_expires_at"] is not None
+                else None
+            ),
+            leased_at=(float(row["leased_at"]) if row["leased_at"] is not None else None),
+            attempt_count=int(row["attempt_count"]),
+            replay_count=int(row["replay_count"]),
+            last_replay_at=(
+                float(row["last_replay_at"])
+                if row["last_replay_at"] is not None
+                else None
+            ),
+            last_error_class=row["last_error_class"],
+            duplicate_count=int(row["duplicate_count"]),
+            identity_conflict_count=int(row["identity_conflict_count"]),
+            last_duplicate_at=(
+                float(row["last_duplicate_at"])
+                if row["last_duplicate_at"] is not None
+                else None
+            ),
+            consumed_at=(float(row["consumed_at"]) if row["consumed_at"] is not None else None),
+            terminal_at=(float(row["terminal_at"]) if row["terminal_at"] is not None else None),
+            terminal_reason=row["terminal_reason"],
+            payload_sha256=row["payload_sha256"],
+            replayed=replayed,
+        )
+
+    def persist(
+        self,
+        *,
+        bot_account_id: Any,
+        update_id: Any,
+        decision: CaptureDecision,
+        now: Optional[float] = None,
+    ) -> PersistResult:
+        """Persist one actionable update before the caller acknowledges it."""
+        if not decision.actionable:
+            raise ValueError("non-actionable updates are not durable work")
+        account = canonical_bot_account_id(bot_account_id)
+        update = _canonical_decimal(update_id, "update_id")
+        when = time.time() if now is None else float(now)
+        payload = decision.payload
+        if not isinstance(payload, dict):
+            raise ValueError("actionable Telegram updates require a dictionary payload")
+        payload_bytes = self._payload_bytes(payload)
+        payload_json = payload_bytes.decode("utf-8")
+        payload_hash = hashlib.sha256(payload_bytes).hexdigest()
+        event_id = self._event_id(account, update)
+
+        with self._connect() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            existing = conn.execute(
+                "SELECT * FROM telegram_inbound_event "
+                "WHERE bot_account_id=? AND update_id=?",
+                (account, update),
+            ).fetchone()
+            if existing is not None:
+                same_update = str(existing["update_id"]) == update
+                conflict = bool(same_update and existing["payload_sha256"] != payload_hash)
+                conn.execute(
+                    "UPDATE telegram_inbound_event SET duplicate_count=duplicate_count+1, "
+                    "identity_conflict_count=identity_conflict_count+?, "
+                    "last_duplicate_at=? WHERE event_id=?",
+                    (1 if conflict else 0, when, existing["event_id"]),
+                )
+                refreshed = conn.execute(
+                    "SELECT * FROM telegram_inbound_event WHERE event_id=?",
+                    (existing["event_id"],),
+                ).fetchone()
+                return PersistResult(
+                    event_id=str(refreshed["event_id"]),
+                    duplicate=True,
+                    identity_conflict=conflict,
+                    row=self._row(refreshed),
+                )
+
+            conn.execute(
+                """INSERT INTO telegram_inbound_event(
+                    event_id, bot_account_id, update_id, profile, account_id,
+                    update_kind, chat_id, message_id, callback_query_id, session_key,
+                    priority, payload_json, payload_sha256, work_state, receipt_state,
+                    dispatch_state, received_at, persisted_at, queued_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'queued',
+                          'not_required', 'pending', ?, ?, ?)""",
+                (
+                    event_id,
+                    account,
+                    update,
+                    str(decision.profile),
+                    str(decision.account_id),
+                    str(decision.update_kind),
+                    None if decision.chat_id is None else str(decision.chat_id),
+                    None if decision.message_id is None else str(decision.message_id),
+                    None
+                    if decision.callback_query_id is None
+                    else str(decision.callback_query_id),
+                    str(decision.session_key),
+                    int(decision.priority),
+                    payload_json,
+                    payload_hash,
+                    when,
+                    when,
+                    when,
+                ),
+            )
+            inserted = conn.execute(
+                "SELECT * FROM telegram_inbound_event WHERE event_id=?", (event_id,)
+            ).fetchone()
+            return PersistResult(
+                event_id=event_id,
+                duplicate=False,
+                identity_conflict=False,
+                row=self._row(inserted),
+            )
+
+    def get(self, event_id: str) -> Optional[InboundEvent]:
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT * FROM telegram_inbound_event WHERE event_id=?", (event_id,)
+            ).fetchone()
+        return self._row(row)
+
+    def event_id_for_update(self, bot_account_id: Any, update_id: Any) -> Optional[str]:
+        account = canonical_bot_account_id(bot_account_id)
+        update = _canonical_decimal(update_id, "update_id")
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT event_id FROM telegram_inbound_event "
+                "WHERE bot_account_id=? AND update_id=?",
+                (account, update),
+            ).fetchone()
+        return str(row[0]) if row is not None else None
+
+    def _account_filter(self, bot_account_id: Optional[Any]) -> tuple[str, tuple[Any, ...]]:
+        if bot_account_id is None:
+            return "", ()
+        return " AND bot_account_id=?", (canonical_bot_account_id(bot_account_id),)
+
+    def reclaim_process_leases(
+        self,
+        *,
+        bot_account_id: Any,
+        current_owner: str,
+        now: Optional[float] = None,
+        exclude_event_ids: tuple[str, ...] = (),
+    ) -> int:
+        """Requeue abandoned leases while preserving known active local work."""
+        account = canonical_bot_account_id(bot_account_id)
+        when = time.time() if now is None else float(now)
+        excluded = tuple(str(event_id) for event_id in exclude_event_ids)
+        exclusion = (
+            " AND event_id NOT IN (" + ",".join("?" for _ in excluded) + ")"
+            if excluded
+            else ""
+        )
+        with self._connect() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            return int(
+                conn.execute(
+                    """UPDATE telegram_inbound_event SET
+                        work_state=CASE
+                            WHEN terminal_reason='control_effect_started'
+                                 OR attempt_count>=? THEN 'dead_letter'
+                            ELSE 'queued'
+                        END,
+                        lease_owner=NULL, lease_expires_at=NULL,
+                        next_attempt_at=CASE
+                            WHEN terminal_reason='control_effect_started'
+                                 OR attempt_count>=? THEN NULL
+                            ELSE ?
+                        END,
+                        dispatch_state='pending',
+                        replay_count=replay_count+1, last_replay_at=?,
+                        terminal_at=CASE
+                            WHEN terminal_reason='control_effect_started'
+                                 OR attempt_count>=? THEN COALESCE(terminal_at, ?)
+                            ELSE terminal_at
+                        END,
+                        terminal_reason=CASE
+                            WHEN terminal_reason='control_effect_started'
+                                THEN 'control_effect_failed'
+                            WHEN attempt_count>=? THEN 'retry_budget_exhausted'
+                            ELSE terminal_reason
+                        END
+                       WHERE bot_account_id=? AND work_state='leased'
+                         AND (lease_owner<>? OR lease_expires_at<=?)"""
+                    + exclusion,
+                    (
+                        MAX_ATTEMPTS,
+                        MAX_ATTEMPTS,
+                        when,
+                        when,
+                        MAX_ATTEMPTS,
+                        when,
+                        MAX_ATTEMPTS,
+                        account,
+                        str(current_owner),
+                        when,
+                        *excluded,
+                    ),
+                ).rowcount
+            )
+
+    def recover_admitted_dispatches(
+        self, *, bot_account_id: Any, now: Optional[float] = None
+    ) -> int:
+        """Make pre-acknowledged projections eligible for replay for one bot."""
+        account = canonical_bot_account_id(bot_account_id)
+        when = time.time() if now is None else float(now)
+        with self._connect() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            return int(
+                conn.execute(
+                    """UPDATE telegram_inbound_event SET dispatch_state='pending',
+                        replay_count=replay_count+1, last_replay_at=?
+                       WHERE bot_account_id=? AND work_state='queued'
+                         AND dispatch_state='admitted'""",
+                    (when, account),
+                ).rowcount
+            )
+
+    def handoff_owner_leases(
+        self,
+        *,
+        bot_account_id: Any,
+        old_owner: str,
+        new_owner: str,
+        live_event_ids: set[str],
+        now: Optional[float] = None,
+    ) -> dict[str, int]:
+        """Transfer live handler claims and recover abandoned claims."""
+        account = canonical_bot_account_id(bot_account_id)
+        old = str(old_owner)
+        new = str(new_owner)
+        when = time.time() if now is None else float(now)
+        counts = {"requeued": 0, "transferred": 0, "quarantined": 0}
+        with self._connect() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            rows = conn.execute(
+                """SELECT event_id, terminal_reason, attempt_count
+                   FROM telegram_inbound_event
+                   WHERE bot_account_id=? AND work_state='leased' AND lease_owner=?""",
+                (account, old),
+            ).fetchall()
+            for row in rows:
+                event_id = str(row["event_id"])
+                # A one-shot control effect is ambiguous once its external
+                # action may have started.  Quarantine it even if its handler
+                # is still live; transferring it could repeat the side effect.
+                if row["terminal_reason"] == "control_effect_started":
+                    changed = conn.execute(
+                        """UPDATE telegram_inbound_event SET work_state='dead_letter',
+                              lease_owner=NULL, lease_expires_at=NULL,
+                              next_attempt_at=NULL, terminal_at=?, terminal_reason=?,
+                              last_error_class=?
+                           WHERE event_id=? AND bot_account_id=?
+                             AND work_state='leased' AND lease_owner=?""",
+                        (
+                            when,
+                            "ambiguous_reconnect_after_control_start",
+                            "reconnect_after_control_start",
+                            event_id,
+                            account,
+                            old,
+                        ),
+                    ).rowcount
+                    if changed == 1:
+                        counts["quarantined"] += 1
+                    continue
+                if event_id in live_event_ids:
+                    changed = conn.execute(
+                        """UPDATE telegram_inbound_event SET lease_owner=?
+                           WHERE event_id=? AND bot_account_id=?
+                             AND work_state='leased' AND lease_owner=?""",
+                        (new, event_id, account, old),
+                    ).rowcount
+                    if changed == 1:
+                        counts["transferred"] += 1
+                    continue
+                if int(row["attempt_count"]) >= MAX_ATTEMPTS:
+                    changed = conn.execute(
+                        """UPDATE telegram_inbound_event SET work_state='dead_letter',
+                              lease_owner=NULL, lease_expires_at=NULL,
+                              next_attempt_at=NULL, terminal_at=?,
+                              terminal_reason=?, last_error_class=?
+                           WHERE event_id=? AND bot_account_id=?
+                             AND work_state='leased' AND lease_owner=?""",
+                        (
+                            when,
+                            "retry_budget_exhausted",
+                            "retry_budget_exhausted",
+                            event_id,
+                            account,
+                            old,
+                        ),
+                    ).rowcount
+                    if changed == 1:
+                        counts["quarantined"] += 1
+                    continue
+                changed = conn.execute(
+                    """UPDATE telegram_inbound_event SET work_state='queued',
+                          lease_owner=NULL, lease_expires_at=NULL,
+                          dispatch_state='pending', replay_count=replay_count+1,
+                          last_replay_at=?
+                       WHERE event_id=? AND bot_account_id=?
+                         AND work_state='leased' AND lease_owner=?""",
+                    (when, event_id, account, old),
+                ).rowcount
+                if changed == 1:
+                    counts["requeued"] += 1
+        return counts
+
+    def _ready_where(self, *, include_expired_lease: bool = True) -> str:
+        if include_expired_lease:
+            return "((work_state='queued' AND " \
+                "(next_attempt_at IS NULL OR next_attempt_at<=?)) OR " \
+                "(work_state='leased' AND lease_expires_at<=?))"
+        return "work_state='queued' AND (next_attempt_at IS NULL OR next_attempt_at<=?)"
+
+    def eligible(
+        self,
+        *,
+        bot_account_id: Optional[Any] = None,
+        now: Optional[float] = None,
+        limit: int = 32,
+    ) -> list[InboundEvent]:
+        when = time.time() if now is None else float(now)
+        bounded = max(1, int(limit))
+        clause, params = self._account_filter(bot_account_id)
+        with self._connect() as conn:
+            rows = conn.execute(
+                "SELECT * FROM telegram_inbound_event WHERE "
+                + self._ready_where()
+                + clause
+                + " ORDER BY priority,seq LIMIT ?",
+                (when, when, *params, bounded),
+            ).fetchall()
+        return [self._row(row, replayed=row["work_state"] == "leased") for row in rows]
+
+    def pending_dispatch(
+        self,
+        *,
+        bot_account_id: Optional[Any] = None,
+        now: Optional[float] = None,
+        limit: int = 32,
+    ) -> list[InboundEvent]:
+        when = time.time() if now is None else float(now)
+        bounded = max(1, int(limit))
+        clause, params = self._account_filter(bot_account_id)
+        with self._connect() as conn:
+            rows = conn.execute(
+                """SELECT * FROM telegram_inbound_event
+                   WHERE dispatch_state='pending' AND work_state='queued'
+                     AND (next_attempt_at IS NULL OR next_attempt_at<=?)"""
+                + clause
+                + " ORDER BY priority,seq LIMIT ?",
+                (when, *params, bounded),
+            ).fetchall()
+        return [self._row(row) for row in rows]
+
+    def next_pending_dispatch_at(
+        self, *, bot_account_id: Optional[Any] = None
+    ) -> Optional[float]:
+        """Return the earliest delayed pending row for an account."""
+        clause, params = self._account_filter(bot_account_id)
+        with self._connect() as conn:
+            row = conn.execute(
+                """SELECT MIN(next_attempt_at) FROM telegram_inbound_event
+                   WHERE dispatch_state='pending' AND work_state='queued'
+                     AND next_attempt_at IS NOT NULL"""
+                + clause,
+                params,
+            ).fetchone()
+        return float(row[0]) if row is not None and row[0] is not None else None
+
+    def lease_next(
+        self,
+        *,
+        owner: str,
+        bot_account_id: Optional[Any] = None,
+        now: Optional[float] = None,
+        lease_seconds: float = 30.0,
+    ) -> Optional[InboundEvent]:
+        when = time.time() if now is None else float(now)
+        clause, params = self._account_filter(bot_account_id)
+        with self._connect() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            row = conn.execute(
+                "SELECT * FROM telegram_inbound_event WHERE "
+                + self._ready_where()
+                + clause
+                + " ORDER BY priority,seq LIMIT 1",
+                (when, when, *params),
+            ).fetchone()
+            if row is None:
+                return None
+            replayed = row["work_state"] == "leased"
+            old_epoch = int(row["lease_epoch"])
+            epoch = old_epoch + 1
+            changed = conn.execute(
+                """UPDATE telegram_inbound_event SET work_state='leased',
+                    lease_owner=?, lease_epoch=?, lease_expires_at=?, leased_at=?,
+                    attempt_count=attempt_count+1, replay_count=replay_count+?,
+                    last_replay_at=CASE WHEN ? THEN ? ELSE last_replay_at END
+                   WHERE event_id=? AND lease_epoch=? AND
+                         (work_state='queued' OR
+                          (work_state='leased' AND lease_expires_at<=?))""",
+                (
+                    str(owner),
+                    epoch,
+                    when + float(lease_seconds),
+                    when,
+                    1 if replayed else 0,
+                    replayed,
+                    when,
+                    row["event_id"],
+                    old_epoch,
+                    when,
+                ),
+            ).rowcount
+            if changed != 1:
+                return None
+            leased = conn.execute(
+                "SELECT * FROM telegram_inbound_event WHERE event_id=?",
+                (row["event_id"],),
+            ).fetchone()
+        return self._row(leased, replayed=replayed)
+
+    def lease_event(
+        self,
+        event_id: str,
+        *,
+        owner: str,
+        now: Optional[float] = None,
+        lease_seconds: float = 86400.0,
+    ) -> Optional[InboundEvent]:
+        """Lease one row with an epoch-fenced compare-and-set."""
+        when = time.time() if now is None else float(now)
+        with self._connect() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            row = conn.execute(
+                "SELECT * FROM telegram_inbound_event WHERE event_id=?", (event_id,)
+            ).fetchone()
+            if row is None or row["work_state"] in _TERMINAL_STATES:
+                return None
+            if row["work_state"] == "leased" and row["lease_expires_at"] > when:
+                if row["lease_owner"] == str(owner):
+                    return self._row(row)
+                return None
+            replayed = row["work_state"] == "leased"
+            old_epoch = int(row["lease_epoch"])
+            changed = conn.execute(
+                """UPDATE telegram_inbound_event SET work_state='leased',
+                    lease_owner=?, lease_epoch=?, lease_expires_at=?, leased_at=?,
+                    attempt_count=attempt_count+1, replay_count=replay_count+?,
+                    last_replay_at=CASE WHEN ? THEN ? ELSE last_replay_at END
+                   WHERE event_id=? AND lease_epoch=? AND
+                         (work_state='queued' OR
+                          (work_state='leased' AND lease_expires_at<=?))""",
+                (
+                    str(owner),
+                    old_epoch + 1,
+                    when + float(lease_seconds),
+                    when,
+                    1 if replayed else 0,
+                    replayed,
+                    when,
+                    event_id,
+                    old_epoch,
+                    when,
+                ),
+            ).rowcount
+            if changed != 1:
+                return None
+            leased = conn.execute(
+                "SELECT * FROM telegram_inbound_event WHERE event_id=?", (event_id,)
+            ).fetchone()
+        return self._row(leased, replayed=replayed)
+
+    def mark_consumed(
+        self,
+        event_id: str,
+        *,
+        owner: str,
+        lease_epoch: int,
+        now: Optional[float] = None,
+    ) -> bool:
+        when = time.time() if now is None else float(now)
+        with self._connect() as conn:
+            return (
+                conn.execute(
+                    """UPDATE telegram_inbound_event SET work_state='consumed',
+                        lease_owner=NULL, lease_expires_at=NULL, consumed_at=?,
+                        terminal_at=?
+                       WHERE event_id=? AND work_state='leased' AND lease_owner=?
+                         AND lease_epoch=?""",
+                    (when, when, event_id, str(owner), int(lease_epoch)),
+                ).rowcount
+                == 1
+            )
+
+    def requeue(
+        self,
+        event_id: str,
+        *,
+        owner: str,
+        lease_epoch: int,
+        now: Optional[float] = None,
+        error_class: str = "retry",
+        delay: float = 0.0,
+        preserve_retry_budget: bool = False,
+    ) -> bool:
+        when = time.time() if now is None else float(now)
+        with self._connect() as conn:
+            if preserve_retry_budget:
+                # A defer means the handler did not enter owned processing.
+                # Undo this lease's attempt and any provisional control marker
+                # instead of treating backpressure as a failed side effect.
+                return (
+                    conn.execute(
+                        """UPDATE telegram_inbound_event SET
+                            attempt_count=CASE
+                                WHEN attempt_count>0 THEN attempt_count-1
+                                ELSE 0
+                            END,
+                            work_state='queued',
+                            lease_owner=NULL, lease_expires_at=NULL,
+                            dispatch_state='pending', next_attempt_at=?,
+                            last_error_class=?,
+                            terminal_at=CASE
+                                WHEN terminal_reason='control_effect_started' THEN NULL
+                                ELSE terminal_at
+                            END,
+                            terminal_reason=CASE
+                                WHEN terminal_reason='control_effect_started' THEN NULL
+                                ELSE terminal_reason
+                            END
+                           WHERE event_id=? AND work_state='leased' AND lease_owner=?
+                             AND lease_epoch=?""",
+                        (
+                            when + max(0.0, float(delay)),
+                            str(error_class)[:80],
+                            event_id,
+                            str(owner),
+                            int(lease_epoch),
+                        ),
+                    ).rowcount
+                    == 1
+                )
+
+            retry_enabled = 1
+            return (
+                conn.execute(
+                    """UPDATE telegram_inbound_event SET
+                        attempt_count=CASE
+                            WHEN terminal_reason='control_effect_started' THEN attempt_count
+                            WHEN ?=0 AND attempt_count>0 THEN attempt_count-1
+                            ELSE attempt_count
+                        END,
+                        work_state=CASE
+                            WHEN terminal_reason='control_effect_started'
+                                 OR (attempt_count>=? AND ?=1) THEN 'dead_letter'
+                            ELSE 'queued'
+                        END,
+                        lease_owner=NULL, lease_expires_at=NULL,
+                        dispatch_state='pending',
+                        next_attempt_at=CASE
+                            WHEN terminal_reason='control_effect_started'
+                                 OR (attempt_count>=? AND ?=1) THEN NULL
+                            ELSE ?
+                        END,
+                        last_error_class=?,
+                        terminal_at=CASE
+                            WHEN terminal_reason='control_effect_started'
+                                 OR (attempt_count>=? AND ?=1) THEN COALESCE(terminal_at, ?)
+                            ELSE terminal_at
+                        END,
+                        terminal_reason=CASE
+                            WHEN terminal_reason='control_effect_started'
+                                THEN 'control_effect_failed'
+                            WHEN attempt_count>=? AND ?=1 THEN 'retry_budget_exhausted'
+                            ELSE terminal_reason
+                        END
+                       WHERE event_id=? AND work_state='leased' AND lease_owner=?
+                         AND lease_epoch=?""",
+                    (
+                        retry_enabled,
+                        MAX_ATTEMPTS,
+                        retry_enabled,
+                        MAX_ATTEMPTS,
+                        retry_enabled,
+                        when + max(0.0, float(delay)),
+                        str(error_class)[:80],
+                        MAX_ATTEMPTS,
+                        retry_enabled,
+                        when,
+                        MAX_ATTEMPTS,
+                        retry_enabled,
+                        event_id,
+                        str(owner),
+                        int(lease_epoch),
+                    ),
+                ).rowcount
+                == 1
+            )
+
+    def mark_control_started(
+        self, event_id: str, *, owner: str, lease_epoch: int
+    ) -> bool:
+        with self._connect() as conn:
+            return (
+                conn.execute(
+                    """UPDATE telegram_inbound_event SET terminal_reason='control_effect_started'
+                       WHERE event_id=? AND update_kind='callback_query'
+                         AND work_state='leased' AND lease_owner=? AND lease_epoch=?""",
+                    (event_id, str(owner), int(lease_epoch)),
+                ).rowcount
+                == 1
+            )
+
+    def mark_dispatch_admitted(self, event_id: str) -> bool:
+        with self._connect() as conn:
+            return (
+                conn.execute(
+                    """UPDATE telegram_inbound_event SET dispatch_state='admitted'
+                       WHERE event_id=? AND dispatch_state='pending'
+                         AND work_state IN ('queued','leased')""",
+                    (event_id,),
+                ).rowcount
+                == 1
+            )
+
+    def reset_dispatch_pending(self, event_id: str) -> bool:
+        with self._connect() as conn:
+            return (
+                conn.execute(
+                    """UPDATE telegram_inbound_event SET dispatch_state='pending'
+                       WHERE event_id=? AND dispatch_state='admitted'
+                         AND work_state IN ('queued','leased')""",
+                    (event_id,),
+                ).rowcount
+                == 1
+            )
+
+    def reconcile_consumed(
+        self,
+        *,
+        bot_account_id: Any,
+        committed_event_ids: set[str],
+        now: Optional[float] = None,
+    ) -> int:
+        """Consume only supplied event ids belonging to the supplied bot."""
+        if not committed_event_ids:
+            return 0
+        account = canonical_bot_account_id(bot_account_id)
+        when = time.time() if now is None else float(now)
+        event_ids = tuple(sorted(str(value) for value in committed_event_ids))
+        placeholders = ",".join("?" for _ in event_ids)
+        with self._connect() as conn:
+            return int(
+                conn.execute(
+                    """UPDATE telegram_inbound_event SET work_state='consumed',
+                        lease_owner=NULL, lease_expires_at=NULL, consumed_at=?,
+                        terminal_at=?
+                       WHERE bot_account_id=? AND work_state IN ('queued','leased')
+                         AND event_id IN ("""
+                    + placeholders
+                    + ")",
+                    (when, when, account, *event_ids),
+                ).rowcount
+            )
+
+    def health_snapshot(
+        self, *, now: Optional[float] = None, stale_after: float = 60.0
+    ) -> dict[str, Any]:
+        when = time.time() if now is None else float(now)
+        with self._connect() as conn:
+            counts = {
+                str(row[0]): int(row[1])
+                for row in conn.execute(
+                    "SELECT work_state, COUNT(*) FROM telegram_inbound_event GROUP BY work_state"
+                )
+            }
+            aggregate = conn.execute(
+                """SELECT COALESCE(SUM(duplicate_count),0),
+                          COALESCE(SUM(identity_conflict_count),0),
+                          COALESCE(SUM(replay_count),0),
+                          MIN(CASE WHEN work_state='queued' THEN queued_at END),
+                          MAX(persisted_at), MAX(consumed_at)
+                     FROM telegram_inbound_event"""
+            ).fetchone()
+        oldest = max(0.0, when - float(aggregate[3])) if aggregate[3] is not None else 0.0
+        reasons: list[str] = []
+        if aggregate[1]:
+            reasons.append("identity_conflict")
+        if oldest > float(stale_after):
+            reasons.append("stale_user_work")
+        return {
+            "status": "degraded" if reasons else "ready",
+            "schema_version": SCHEMA_VERSION,
+            "queued": counts.get("queued", 0),
+            "leased": counts.get("leased", 0),
+            "consumed": counts.get("consumed", 0),
+            "dead_letter": counts.get("dead_letter", 0),
+            "duplicates": int(aggregate[0]),
+            "identity_conflicts": int(aggregate[1]),
+            "replayed": int(aggregate[2]),
+            "oldest_queued_age_seconds": oldest,
+            "last_persisted_at": aggregate[4],
+            "last_consumed_at": aggregate[5],
+            "reasons": reasons,
+        }
+
+    @classmethod
+    def health_snapshot_readonly(
+        cls, path: Path, *, now: Optional[float] = None, stale_after: float = 60.0
+    ) -> dict[str, Any]:
+        """Read an existing store without creating or mutating it."""
+        store_path = Path(path)
+        if not store_path.exists():
+            return {"status": "unknown", "reasons": ["missing_store"]}
+        when = time.time() if now is None else float(now)
+        conn = sqlite3.connect(f"file:{store_path.as_posix()}?mode=ro", uri=True)
+        try:
+            conn.row_factory = sqlite3.Row
+            counts = {
+                str(row[0]): int(row[1])
+                for row in conn.execute(
+                    "SELECT work_state, COUNT(*) FROM telegram_inbound_event GROUP BY work_state"
+                )
+            }
+            aggregate = conn.execute(
+                """SELECT COALESCE(SUM(duplicate_count),0),
+                          COALESCE(SUM(identity_conflict_count),0),
+                          COALESCE(SUM(replay_count),0),
+                          MIN(CASE WHEN work_state='queued' THEN queued_at END),
+                          MAX(persisted_at), MAX(consumed_at)
+                     FROM telegram_inbound_event"""
+            ).fetchone()
+        except sqlite3.Error:
+            return {"status": "unknown", "reasons": ["invalid_store"]}
+        finally:
+            conn.close()
+        oldest = max(0.0, when - float(aggregate[3])) if aggregate[3] is not None else 0.0
+        reasons = ["identity_conflict"] if aggregate[1] else []
+        if oldest > float(stale_after):
+            reasons.append("stale_user_work")
+        return {
+            "status": "degraded" if reasons else "ready",
+            "schema_version": SCHEMA_VERSION,
+            "queued": counts.get("queued", 0),
+            "leased": counts.get("leased", 0),
+            "consumed": counts.get("consumed", 0),
+            "dead_letter": counts.get("dead_letter", 0),
+            "duplicates": int(aggregate[0]),
+            "identity_conflicts": int(aggregate[1]),
+            "replayed": int(aggregate[2]),
+            "oldest_queued_age_seconds": oldest,
+            "last_persisted_at": aggregate[4],
+            "last_consumed_at": aggregate[5],
+            "reasons": reasons,
+        }
+
+
+class DurableTelegramUpdateQueue(asyncio.Queue):
+    """Queue that durably captures actionable PTB updates before returning."""
+
+    def __init__(
+        self,
+        *,
+        store: TelegramInboundStore,
+        bot_account_id: Any,
+        classifier: Callable[[Any], CaptureDecision],
+        after_commit: Optional[
+            Callable[[Any, PersistResult], Awaitable[None] | None]
+        ] = None,
+        lease_owner: Optional[str] = None,
+        active_limit: int = 32,
+        item_factory: Optional[Callable[[Any], Any]] = None,
+        maxsize: Optional[int] = None,
+    ):
+        if maxsize is not None and int(maxsize) > 0:
+            active_limit = int(maxsize)
+        self.active_limit = max(1, int(active_limit))
+        # The physical PTB queue must remain unbounded: rejected updates and
+        # shutdown sentinels retain ordinary asyncio.Queue semantics even when
+        # the durable projection window is full. ``active_limit`` below bounds
+        # only durable rows projected into this queue.
+        super().__init__(maxsize=0)
+        self.store = store
+        self.bot_account_id = int(canonical_bot_account_id(bot_account_id))
+        self.classifier = classifier
+        self.after_commit = after_commit
+        self.item_factory = item_factory or (lambda payload: payload)
+        self.lease_owner = lease_owner or f"telegram:{os.getpid()}:{uuid.uuid4().hex}"
+        self._admission_lock = asyncio.Lock()
+        # Durable admission must not share asyncio's process-wide default
+        # executor. A saturated unrelated worker pool otherwise blocks PTB's
+        # update_queue.put() acknowledgment boundary before SQLite is reached.
+        self._store_executor_key = (
+            f"{self.store.lifecycle_path}:{canonical_bot_account_id(self.bot_account_id)}"
+        )
+        self._store_executor = _acquire_store_executor(
+            self._store_executor_key, self.bot_account_id
+        )
+        self._persist_retry_initial_seconds = _INGRESS_RETRY_INITIAL_SECONDS
+        self._persist_retry_max_seconds = _INGRESS_RETRY_MAX_SECONDS
+        self._persist_stall_log_seconds = _INGRESS_STALL_LOG_SECONDS
+        self._ingress_pause_lock = threading.Lock()
+        self._ingress_paused_at: Optional[float] = None
+        self._ingress_pause_stage: Optional[str] = None
+        self._ingress_pause_error_class: Optional[str] = None
+        self._ingress_pause_attempt = 0
+        self._ingress_pause_last_log_at: Optional[float] = None
+        self._ingress_tasks: set[asyncio.Task[Any]] = set()
+        # ``put`` is PTB's acknowledgement boundary.  A handoff must close
+        # admission before it retires the predecessor executor, then wait for
+        # every already-admitted put (including cancellation recovery) to stop
+        # submitting SQLite work.
+        self._ingress_handoff_lock = asyncio.Lock()
+        self._ingress_owner_tasks: set[asyncio.Task[Any]] = set()
+        self._ingress_closed = False
+        self._projection_retry_task: Optional[asyncio.Task[Any]] = None
+        self._projection_suspended = False
+        self._store_executor_shutdown = False
+        self._claim_handoff_lock = threading.RLock()
+        self._queued_event_ids: set[str] = set()
+        self._claiming_event_ids: set[str] = set()
+        self._claiming_done: dict[str, asyncio.Event] = {}
+        self._event_id_by_update_id: dict[int, str] = {}
+        self._handed_off_update_ids: set[int] = set()
+        self._claim_by_update_id: dict[int, InboundEvent] = {}
+        # A deferred cleanup can fail after the SQLite operation starts. Keep
+        # only an exact still-leased claim available for a later cleanup retry;
+        # it is intentionally not exposed as a handler claim or transferred
+        # during queue handoff.
+        self._retryable_claim_by_update_id: dict[int, InboundEvent] = {}
+        self._claim_transition_tasks: dict[int, asyncio.Task[Any]] = {}
+        self._handler_event_ids: set[str] = set()
+        # Durable events buffered by an adapter (text/media batching or the
+        # disconnect hold queue) are not active handler work.  Keep that state
+        # separate so a fresh adapter can requeue them instead of transferring
+        # a lease whose in-memory MessageEvent is stranded on the old adapter.
+        self._buffered_event_ids: set[str] = set()
+        # A handoff removes claims from this queue.  A handler can still enter
+        # the wrapper after that removal, so retain a one-shot fence for each
+        # published claim until the late wrapper observes it.
+        self._fenced_handler_update_ids: set[int] = set()
+        self._handoff_target: Optional[DurableTelegramUpdateQueue] = None
+        self._lifecycle_retired = False
+        self._handoff_in_progress = False
+        self._handoff_complete = asyncio.Event()
+        self._handoff_complete.set()
+        self._lifecycle_tasks: set[asyncio.Task[Any]] = set()
+        self._handoff_receiver_ref: Optional[weakref.ReferenceType[Any]] = None
+        try:
+            self._scheduler_loop: Optional[asyncio.AbstractEventLoop] = asyncio.get_running_loop()
+        except RuntimeError:
+            self._scheduler_loop = None
+        self._due_wakeup_handle: Optional[asyncio.TimerHandle] = None
+        self._due_wakeup_at: Optional[float] = None
+        self._due_wakeup_task: Optional[asyncio.Task[Any]] = None
+        self._prehandler_lease_seconds = 30.0
+        self._pending_dispatch_resets: set[str] = set()
+
+    @property
+    def ingress_paused(self) -> bool:
+        """Return whether a pre-commit ingress operation is backpressured."""
+        with self._ingress_pause_lock:
+            return self._ingress_paused_at is not None
+
+    def ingress_pause_snapshot(self) -> dict[str, Any]:
+        """Return payload-free state for watchdog and operator diagnostics."""
+        now = time.monotonic()
+        with self._ingress_pause_lock:
+            paused_at = self._ingress_paused_at
+            return {
+                "paused": paused_at is not None,
+                "stage": self._ingress_pause_stage,
+                "error_class": self._ingress_pause_error_class,
+                "attempt": self._ingress_pause_attempt,
+                "paused_for_seconds": (
+                    max(0.0, now - paused_at) if paused_at is not None else 0.0
+                ),
+            }
+
+    def _note_ingress_pause(
+        self, stage: str, error: BaseException, attempt: int
+    ) -> None:
+        now = time.monotonic()
+        error_class = type(error).__name__
+        with self._ingress_pause_lock:
+            if self._ingress_paused_at is None:
+                self._ingress_paused_at = now
+            self._ingress_pause_stage = stage
+            self._ingress_pause_error_class = error_class
+            self._ingress_pause_attempt = attempt
+            last_log = self._ingress_pause_last_log_at
+            should_log = (
+                last_log is None
+                or now - last_log >= max(0.01, self._persist_stall_log_seconds)
+            )
+            if should_log:
+                self._ingress_pause_last_log_at = now
+        if should_log:
+            logger.warning(
+                "Telegram durable ingress paused before polling acknowledgment: "
+                "bot_account_id=%s stage=%s attempt=%d error=%s",
+                self.bot_account_id,
+                stage,
+                attempt,
+                error_class,
+            )
+
+    def _clear_ingress_pause(self) -> None:
+        now = time.monotonic()
+        with self._ingress_pause_lock:
+            paused_at = self._ingress_paused_at
+            if paused_at is None:
+                return
+            duration = max(0.0, now - paused_at)
+            attempts = self._ingress_pause_attempt
+            self._ingress_paused_at = None
+            self._ingress_pause_stage = None
+            self._ingress_pause_error_class = None
+            self._ingress_pause_attempt = 0
+            self._ingress_pause_last_log_at = None
+        logger.info(
+            "Telegram durable ingress resumed: bot_account_id=%s "
+            "paused_for=%.3fs attempts=%d",
+            self.bot_account_id,
+            duration,
+            attempts,
+        )
+
+    async def _run_store(self, function: Callable[..., Any], /, *args, **kwargs) -> Any:
+        """Run one SQLite operation outside the process-wide executor."""
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            self._store_executor, partial(function, *args, **kwargs)
+        )
+
+    def _discard_ingress_task(self, task: asyncio.Task[Any]) -> None:
+        self._ingress_tasks.discard(task)
+        try:
+            task.exception()
+        except BaseException:
+            pass
+
+    def _track_ingress_task(self, task: asyncio.Task[Any]) -> None:
+        self._ingress_tasks.add(task)
+        task.add_done_callback(self._discard_ingress_task)
+
+    async def _enter_ingress(self) -> Optional["DurableTelegramUpdateQueue"]:
+        """Either reserve this queue's ingress epoch or return its successor."""
+        task = asyncio.current_task()
+        if task is None:
+            raise RuntimeError("Telegram ingress requires an asyncio task")
+        while True:
+            async with self._ingress_handoff_lock:
+                target = self._handoff_target
+                if target is None:
+                    if self._ingress_closed:
+                        raise RuntimeError("Telegram durable ingress queue is closed")
+                    self._ingress_owner_tasks.add(task)
+                    return None
+            if target is not None:
+                return target
+            await self._wait_for_claim_event(self._handoff_complete)
+
+    def _leave_ingress(self) -> None:
+        task = asyncio.current_task()
+        if task is not None:
+            self._ingress_owner_tasks.discard(task)
+
+    async def _wait_for_ingress_tasks(self) -> None:
+        """Drain predecessor puts before its dedicated executor is retired."""
+        while True:
+            tasks = tuple(
+                task
+                for task in self._ingress_owner_tasks | self._ingress_tasks
+                if task is not asyncio.current_task() and not task.done()
+            )
+            if not tasks:
+                return
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+    async def _classify_with_retry(self, item: Any, raw: Any) -> CaptureDecision:
+        delay = max(0.0, float(self._persist_retry_initial_seconds))
+        attempt = 0
+        while True:
+            attempt += 1
+            try:
+                decision = self.classifier(item)
+                if not isinstance(decision, CaptureDecision):
+                    raise TypeError("Telegram classifier must return CaptureDecision")
+                if decision.actionable and decision.payload is None:
+                    if not isinstance(raw, dict):
+                        raise ValueError(
+                            "actionable Telegram updates require serializable payload"
+                        )
+                    decision.payload = raw
+            except Exception as exc:
+                self._note_ingress_pause("classify", exc, attempt)
+                await asyncio.sleep(delay)
+                delay = min(
+                    max(delay * 2.0, self._persist_retry_initial_seconds),
+                    self._persist_retry_max_seconds,
+                )
+                continue
+            if not decision.actionable:
+                self._clear_ingress_pause()
+            return decision
+
+    async def _persist_with_retry(
+        self, *, update_id: int, decision: CaptureDecision
+    ) -> PersistResult:
+        delay = max(0.0, float(self._persist_retry_initial_seconds))
+        stall_log_seconds = max(0.01, float(self._persist_stall_log_seconds))
+        attempt = 0
+        while True:
+            attempt += 1
+            operation = asyncio.create_task(
+                self._run_store(
+                    self.store.persist,
+                    bot_account_id=self.bot_account_id,
+                    update_id=update_id,
+                    decision=decision,
+                )
+            )
+            try:
+                while True:
+                    try:
+                        result = await asyncio.wait_for(
+                            asyncio.shield(operation), timeout=stall_log_seconds
+                        )
+                        break
+                    except asyncio.TimeoutError as exc:
+                        # Do not submit a second write while the first thread may
+                        # still commit. Keep the PTB offset fail-closed and expose
+                        # the intentional pause to the polling watchdog instead.
+                        self._note_ingress_pause("persist_wait", exc, attempt)
+            except asyncio.CancelledError:
+                operation.cancel()
+                raise
+            except Exception as exc:
+                self._note_ingress_pause("persist", exc, attempt)
+                await asyncio.sleep(delay)
+                delay = min(
+                    max(delay * 2.0, self._persist_retry_initial_seconds),
+                    self._persist_retry_max_seconds,
+                )
+                continue
+            self._clear_ingress_pause()
+            return result
+
+    def _schedule_projection_retry(self) -> None:
+        if self._projection_suspended or self._lifecycle_retired:
+            return
+        current = self._projection_retry_task
+        if current is not None and not current.done():
+            return
+
+        async def retry() -> None:
+            delay = max(0.0, float(self._persist_retry_initial_seconds))
+            while True:
+                try:
+                    await self.wake_scheduler()
+                except asyncio.CancelledError:
+                    raise
+                except Exception as exc:
+                    logger.warning(
+                        "Telegram durable projection retry: bot_account_id=%s "
+                        "error=%s",
+                        self.bot_account_id,
+                        type(exc).__name__,
+                    )
+                else:
+                    if not self._pending_dispatch_resets:
+                        return
+                await asyncio.sleep(delay)
+                delay = min(
+                    max(delay * 2.0, self._persist_retry_initial_seconds),
+                    self._persist_retry_max_seconds,
+                )
+
+        self._projection_retry_task = asyncio.create_task(retry())
+        self._track_ingress_task(self._projection_retry_task)
+
+    @staticmethod
+    def _raw_payload(item: Any) -> Any:
+        if isinstance(item, dict):
+            return item
+        converter = getattr(item, "to_dict", None)
+        if callable(converter):
+            payload = converter()
+            if isinstance(payload, dict):
+                return payload
+        return None
+
+    @classmethod
+    def _update_id(cls, item: Any, raw: Any = None) -> Optional[int]:
+        if raw is None:
+            raw = cls._raw_payload(item)
+        value = raw.get("update_id") if isinstance(raw, dict) else getattr(item, "update_id", None)
+        if isinstance(value, bool) or not isinstance(value, (int, str)):
+            return None
+        try:
+            return int(_canonical_decimal(value, "update_id"))
+        except (TypeError, ValueError):
+            return None
+
+    @classmethod
+    def _is_update(cls, item: Any, raw: Any = None) -> bool:
+        return cls._update_id(item, raw) is not None
+
+    def claim_for_update(self, update_id: Optional[int]) -> Optional[InboundEvent]:
+        if update_id is None:
+            return None
+        with self._claim_handoff_lock:
+            return self._claim_by_update_id.get(int(update_id))
+
+    def handler_claimed(self, update_id: Optional[int]) -> bool:
+        if update_id is None:
+            return False
+        with self._claim_handoff_lock:
+            claim = self._claim_by_update_id.get(int(update_id))
+            return claim is not None and claim.event_id in self._handler_event_ids
+
+    def mark_handler_claim(self, update_id: Optional[int]) -> Optional[InboundEvent]:
+        with self._claim_handoff_lock:
+            claim = self._claim_by_update_id.get(int(update_id)) if update_id is not None else None
+            if claim is not None:
+                self._handler_event_ids.add(claim.event_id)
+            return claim
+
+    def mark_event_buffered(
+        self, update_ids: tuple[int, ...] | list[int] | set[int]
+    ) -> None:
+        """Mark durable claims whose MessageEvents await delayed dispatch."""
+        with self._claim_handoff_lock:
+            for update_id in update_ids:
+                normalized_update_id = int(update_id)
+                claim = self._claim_by_update_id.get(normalized_update_id)
+                if claim is None:
+                    claim = self._retryable_claim_by_update_id.get(normalized_update_id)
+                if claim is not None:
+                    self._buffered_event_ids.add(claim.event_id)
+
+    def mark_event_active(
+        self, update_ids: tuple[int, ...] | list[int] | set[int]
+    ) -> bool:
+        """Mark durable claims that have entered actual dispatch."""
+        activated = False
+        with self._claim_handoff_lock:
+            for update_id in update_ids:
+                normalized_update_id = int(update_id)
+                claim = self._claim_by_update_id.get(normalized_update_id)
+                if claim is None:
+                    claim = self._retryable_claim_by_update_id.pop(
+                        normalized_update_id, None
+                    )
+                    if claim is not None:
+                        self._claim_by_update_id[normalized_update_id] = claim
+                if claim is not None:
+                    self._buffered_event_ids.discard(claim.event_id)
+                    self._handler_event_ids.add(claim.event_id)
+                    activated = True
+        return activated
+
+    def handler_claim_fenced(self, update_id: Optional[int]) -> bool:
+        """Consume the fence for a handler that lost queue ownership."""
+        if update_id is None:
+            return False
+        with self._claim_handoff_lock:
+            normalized_update_id = int(update_id)
+            if normalized_update_id not in self._fenced_handler_update_ids:
+                return False
+            self._fenced_handler_update_ids.remove(normalized_update_id)
+            return True
+
+    def clear_handler_claim(self, event_id: str) -> None:
+        with self._claim_handoff_lock:
+            self._handler_event_ids.discard(event_id)
+
+    def run_claim_operation(
+        self, claim: InboundEvent, operation: Callable[[InboundEvent], Any]
+    ) -> Any:
+        with self._claim_handoff_lock:
+            return operation(claim)
+
+    def _begin_claiming_locked(self, event_id: str) -> Optional[asyncio.Event]:
+        """Register one SQLite claim operation under the handoff lock."""
+        if event_id in self._claiming_event_ids:
+            return None
+        done = asyncio.Event()
+        self._claiming_event_ids.add(event_id)
+        self._claiming_done[event_id] = done
+        return done
+
+    def _finish_claiming(self, event_id: str) -> None:
+        with self._claim_handoff_lock:
+            self._claiming_event_ids.discard(event_id)
+            done = self._claiming_done.pop(event_id, None)
+            if done is not None:
+                done.set()
+
+    def _discard_claiming_projection(self, event_id: str) -> None:
+        """Release both the claim fence and physical queue task debt."""
+        try:
+            self._finish_claiming(event_id)
+        finally:
+            super().task_done()
+
+    def _discard_lifecycle_task(self, task: asyncio.Task[Any]) -> None:
+        with self._claim_handoff_lock:
+            self._lifecycle_tasks.discard(task)
+        # A task can finish between the handoff barrier's snapshots. Retrieve
+        # its exception here so an exceptional cleanup cannot become an
+        # unobserved task warning; the adapter's callback records the failure.
+        try:
+            task.exception()
+        except BaseException:
+            pass
+
+    def register_lifecycle_task(self, task: asyncio.Task[Any]) -> None:
+        """Track asynchronous cleanup that must finish before queue handoff."""
+        with self._claim_handoff_lock:
+            self._lifecycle_tasks.add(task)
+        task.add_done_callback(self._discard_lifecycle_task)
+
+    async def _wait_for_lifecycle_tasks(self) -> None:
+        """Wait for registered cleanup before publishing a new owner."""
+        while True:
+            with self._claim_handoff_lock:
+                tasks = tuple(self._lifecycle_tasks)
+            if not tasks:
+                return
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+    def attach_handoff_receiver(self, receiver: Any) -> None:
+        """Attach the adapter that owns this queue's local projections."""
+        with self._claim_handoff_lock:
+            self._handoff_receiver_ref = weakref.ref(receiver)
+
+    def _handoff_receiver(self) -> Any:
+        with self._claim_handoff_lock:
+            reference = self._handoff_receiver_ref
+        return reference() if reference is not None else None
+
+    def _notify_handoff(self, replacement: "DurableTelegramUpdateQueue") -> None:
+        """Retire or transfer predecessor-only adapter projections."""
+        receiver = self._handoff_receiver()
+        callback = getattr(receiver, "_on_inbound_queue_handoff", None)
+        if callable(callback):
+            callback(replacement)
+
+    async def _wait_for_claim_event(self, event: asyncio.Event) -> None:
+        """Wait in the event loop without consuming a default-executor worker."""
+        await event.wait()
+
+    async def _acquire_claim_operation(
+        self, update_id: Optional[int]
+    ) -> tuple[Optional[InboundEvent], Optional["DurableTelegramUpdateQueue"]]:
+        """Reserve a claim operation, waiting for handoff or another operation."""
+        if update_id is None:
+            return None, None
+        normalized_update_id = int(update_id)
+        while True:
+            wait_event = None
+            with self._claim_handoff_lock:
+                if self._handoff_in_progress:
+                    wait_event = self._handoff_complete
+                    claim = None
+                    target = None
+                else:
+                    claim = self._claim_by_update_id.get(normalized_update_id)
+                    if claim is None:
+                        claim = self._retryable_claim_by_update_id.pop(
+                            normalized_update_id, None
+                        )
+                        if claim is not None:
+                            self._claim_by_update_id[normalized_update_id] = claim
+                    target = self._handoff_target if claim is None else None
+                    if claim is not None:
+                        wait_event = self._begin_claiming_locked(claim.event_id)
+            if claim is not None and wait_event is not None:
+                return claim, None
+            if claim is None and target is not None:
+                return None, target
+            if claim is None and target is None and wait_event is None:
+                return None, None
+            if wait_event is None:
+                # Another operation owns the claim. Its completion event is
+                # published while holding the same lock, so it cannot vanish.
+                with self._claim_handoff_lock:
+                    claim = self._claim_by_update_id.get(normalized_update_id)
+                    wait_event = (
+                        self._claiming_done.get(claim.event_id)
+                        if claim is not None
+                        else self._handoff_complete
+                    )
+                if wait_event is None:
+                    continue
+            await self._wait_for_claim_event(wait_event)
+
+    async def mark_control_started(self, update_id: Optional[int]) -> bool:
+        claim, target = await self._acquire_claim_operation(update_id)
+        if claim is None:
+            if target is not None:
+                return await target.mark_control_started(update_id)
+            return False
+        operation = asyncio.create_task(
+            self._run_store(
+                self.run_claim_operation,
+                claim,
+                lambda current: self.store.mark_control_started(
+                    current.event_id,
+                    owner=current.lease_owner or self.lease_owner,
+                    lease_epoch=current.lease_epoch,
+                ),
+            )
+        )
+        try:
+            return bool(await asyncio.shield(operation))
+        except asyncio.CancelledError:
+            await asyncio.shield(operation)
+            raise
+        finally:
+            self._finish_claiming(claim.event_id)
+
+    async def complete_update(
+        self,
+        update_id: Optional[int],
+        *,
+        success: bool,
+        delay: float = 0.0,
+        defer: bool = False,
+        _retrying: bool = False,
+    ) -> bool:
+        """Fence a completion transition until SQLite confirms its outcome."""
+        claim, target = await self._acquire_claim_operation(update_id)
+        if claim is None:
+            if target is not None:
+                return await target.complete_update(
+                    update_id,
+                    success=success,
+                    delay=delay,
+                    defer=defer,
+                    _retrying=_retrying,
+                )
+            return False
+
+        def transition(current: InboundEvent) -> bool:
+            owner = current.lease_owner or self.lease_owner
+            if success:
+                return self.store.mark_consumed(
+                    current.event_id,
+                    owner=owner,
+                    lease_epoch=current.lease_epoch,
+                )
+            if defer:
+                return self.store.requeue(
+                    current.event_id,
+                    owner=owner,
+                    lease_epoch=current.lease_epoch,
+                    error_class="busy_cap",
+                    delay=delay,
+                    preserve_retry_budget=True,
+                )
+            return self.store.requeue(
+                current.event_id,
+                owner=owner,
+                lease_epoch=current.lease_epoch,
+                error_class="handler_failed",
+                delay=delay,
+            )
+
+        operation = asyncio.create_task(
+            self._run_store(self.run_claim_operation, claim, transition)
+        )
+        changed = False
+        transition_error: Optional[Exception] = None
+        cancelled = False
+        try:
+            changed = bool(await asyncio.shield(operation))
+        except asyncio.CancelledError:
+            cancelled = True
+            try:
+                changed = bool(await asyncio.shield(operation))
+            except Exception as exc:
+                transition_error = exc
+        except Exception as exc:
+            transition_error = exc
+
+        retained = False
+        if not changed:
+            retained = await self._claim_still_owned(claim)
+            if transition_error is not None:
+                logger.warning(
+                    "Telegram durable completion retry: bot_account_id=%s "
+                    "event_id=%s error=%s",
+                    self.bot_account_id,
+                    claim.event_id,
+                    type(transition_error).__name__,
+                )
+        with self._claim_handoff_lock:
+            normalized_update_id = int(claim.update_id)
+            if changed or not retained:
+                self._buffered_event_ids.discard(claim.event_id)
+                if self._claim_by_update_id.get(normalized_update_id) is claim:
+                    self._claim_by_update_id.pop(normalized_update_id, None)
+                    self._handler_event_ids.discard(claim.event_id)
+                self._retryable_claim_by_update_id.pop(normalized_update_id, None)
+            else:
+                # Do not release local capacity or handler ownership until an
+                # idempotent terminal/requeue transition is confirmed.
+                self._claim_by_update_id[normalized_update_id] = claim
+        self._finish_claiming(claim.event_id)
+        if changed:
+            self._request_wakeup()
+        elif retained and not _retrying:
+            self._schedule_claim_transition_retry(
+                int(claim.update_id), success=success, delay=delay, defer=defer
+            )
+        if cancelled:
+            raise asyncio.CancelledError
+        return changed
+
+    async def _claim_still_owned(self, claim: InboundEvent) -> bool:
+        """Return whether an unconfirmed transition still owns this exact lease."""
+        try:
+            current = await self._run_store(self.store.get, claim.event_id)
+        except Exception:
+            # A second SQLite fault is not proof that the handler's completion
+            # lost ownership. Retain the capacity and retry conservatively.
+            return True
+        return bool(
+            current is not None
+            and current.work_state == "leased"
+            and current.lease_owner == claim.lease_owner
+            and current.lease_epoch == claim.lease_epoch
+        )
+
+    def _schedule_claim_transition_retry(
+        self, update_id: int, *, success: bool, delay: float, defer: bool
+    ) -> None:
+        """Retry only the SQLite completion, never the already-run handler."""
+        existing = self._claim_transition_tasks.get(update_id)
+        if existing is not None and not existing.done():
+            return
+
+        async def retry() -> None:
+            retry_delay = max(0.0, float(self._persist_retry_initial_seconds))
+            while True:
+                await asyncio.sleep(retry_delay)
+                try:
+                    changed = await self.complete_update(
+                        update_id,
+                        success=success,
+                        delay=delay,
+                        defer=defer,
+                        _retrying=True,
+                    )
+                except asyncio.CancelledError:
+                    raise
+                except Exception as exc:
+                    logger.warning(
+                        "Telegram durable completion retry failed: "
+                        "bot_account_id=%s update_id=%s error=%s",
+                        self.bot_account_id,
+                        update_id,
+                        type(exc).__name__,
+                    )
+                    changed = False
+                with self._claim_handoff_lock:
+                    still_owned = update_id in self._claim_by_update_id
+                if changed or not still_owned:
+                    return
+                retry_delay = min(
+                    max(retry_delay * 2.0, self._persist_retry_initial_seconds),
+                    self._persist_retry_max_seconds,
+                )
+
+        task = asyncio.create_task(retry())
+        self._claim_transition_tasks[update_id] = task
+
+        def discard(completed: asyncio.Task[Any]) -> None:
+            if self._claim_transition_tasks.get(update_id) is completed:
+                self._claim_transition_tasks.pop(update_id, None)
+            try:
+                completed.exception()
+            except BaseException:
+                pass
+
+        task.add_done_callback(discard)
+
+    def _cancel_due_wakeup(self) -> None:
+        handle = self._due_wakeup_handle
+        if handle is not None:
+            handle.cancel()
+        self._due_wakeup_handle = None
+        self._due_wakeup_at = None
+        task = self._due_wakeup_task
+        if (
+            task is not None
+            and not task.done()
+            and task is not asyncio.current_task()
+        ):
+            task.cancel()
+            self._due_wakeup_task = None
+
+    def _due_wakeup_fired(self) -> None:
+        self._due_wakeup_handle = None
+        self._due_wakeup_at = None
+        if self._projection_suspended or self._lifecycle_retired:
+            return
+        loop = self._scheduler_loop
+        if loop is None or loop.is_closed():
+            return
+
+        async def wake() -> None:
+            try:
+                await self.wake_scheduler()
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.warning(
+                    "Telegram durable due wake failed: bot_account_id=%s error=%s",
+                    self.bot_account_id,
+                    type(exc).__name__,
+                )
+                self._schedule_projection_retry()
+
+        task = loop.create_task(wake())
+        self._due_wakeup_task = task
+        self._track_ingress_task(task)
+
+        def clear_due_wakeup(completed: asyncio.Task[Any]) -> None:
+            if self._due_wakeup_task is completed:
+                self._due_wakeup_task = None
+
+        task.add_done_callback(clear_due_wakeup)
+
+    def _arm_due_wakeup(self, due_at: Optional[float]) -> None:
+        loop = self._scheduler_loop
+        if (
+            self._projection_suspended
+            or self._lifecycle_retired
+            or loop is None
+            or loop.is_closed()
+            or due_at is None
+        ):
+            self._cancel_due_wakeup()
+            return
+        due = float(due_at)
+        current_handle = self._due_wakeup_handle
+        current_due = self._due_wakeup_at
+        if (
+            current_handle is not None
+            and not current_handle.cancelled()
+            and current_due is not None
+            and current_due <= due
+        ):
+            return
+        self._cancel_due_wakeup()
+        self._due_wakeup_at = due
+        self._due_wakeup_handle = loop.call_later(
+            max(0.0, due - time.time()), self._due_wakeup_fired
+        )
+
+    async def _refresh_due_wakeup(self, *, capacity_available: bool) -> None:
+        with self._claim_handoff_lock:
+            protected_event_ids = self._handler_event_ids | self._buffered_event_ids
+            lease_deadlines = tuple(
+                claim.lease_expires_at
+                for claim in self._claim_by_update_id.values()
+                if (
+                    claim.event_id not in protected_event_ids
+                    and claim.lease_expires_at is not None
+                )
+            )
+        due_at = min(lease_deadlines) if lease_deadlines else None
+        if capacity_available:
+            try:
+                pending_due_at = await self._run_store(
+                    self.store.next_pending_dispatch_at,
+                    bot_account_id=self.bot_account_id,
+                )
+            except Exception:
+                pending_due_at = None
+            if pending_due_at is not None:
+                due_at = (
+                    pending_due_at
+                    if due_at is None
+                    else min(due_at, pending_due_at)
+                )
+        self._arm_due_wakeup(due_at)
+
+    async def wake_scheduler(self) -> int:
+        """Project a bounded, account-scoped durable backlog into PTB."""
+        self._scheduler_loop = asyncio.get_running_loop()
+        with self._claim_handoff_lock:
+            target = self._handoff_target
+        if target is not None:
+            self._cancel_due_wakeup()
+            return await target.wake_scheduler()
+        if self._projection_suspended:
+            self._cancel_due_wakeup()
+            return 0
+
+        projected = 0
+        capacity_available = False
+        try:
+            async with self._admission_lock:
+                # A handler may never be reached (e.g. an invalid projection
+                # or a PTB group that does not match it). Reclaim this owner's
+                # expired finite pre-handler leases before calculating capacity,
+                # but never expire a handler or deliberate batch that still has
+                # an in-memory completion driver.
+                with self._claim_handoff_lock:
+                    protected_event_ids = tuple(
+                        self._handler_event_ids | self._buffered_event_ids
+                    )
+                await self._run_store(
+                    self.store.reclaim_process_leases,
+                    bot_account_id=self.bot_account_id,
+                    current_owner=self.lease_owner,
+                    exclude_event_ids=protected_event_ids,
+                )
+                now = time.time()
+                with self._claim_handoff_lock:
+                    for update_id, claim in tuple(self._claim_by_update_id.items()):
+                        if (
+                            claim.event_id not in protected_event_ids
+                            and claim.lease_expires_at is not None
+                            and claim.lease_expires_at <= now
+                        ):
+                            self._claim_by_update_id.pop(update_id, None)
+                            self._retryable_claim_by_update_id.pop(update_id, None)
+                            self._handler_event_ids.discard(claim.event_id)
+                            self._buffered_event_ids.discard(claim.event_id)
+                pending_resets = tuple(self._pending_dispatch_resets)
+                for event_id in pending_resets:
+                    try:
+                        await self._run_store(
+                            self.store.reset_dispatch_pending, event_id
+                        )
+                    except Exception:
+                        self._schedule_projection_retry()
+                        return 0
+                    self._pending_dispatch_resets.discard(event_id)
+                with self._claim_handoff_lock:
+                    if self._handoff_in_progress:
+                        capacity = 0
+                    else:
+                        active = (
+                            len(self._queued_event_ids)
+                            + len(self._claiming_event_ids)
+                            + len(self._claim_by_update_id)
+                            + len(self._retryable_claim_by_update_id)
+                        )
+                        capacity = self.active_limit - active
+                capacity_available = capacity > 0
+                if capacity <= 0:
+                    return 0
+                rows = await self._run_store(
+                    self.store.pending_dispatch,
+                    bot_account_id=self.bot_account_id,
+                    limit=capacity,
+                )
+                for row in rows:
+                    with self._claim_handoff_lock:
+                        if self._handoff_in_progress:
+                            break
+                        already_queued = row.event_id in self._queued_event_ids
+                    if row.payload is None or already_queued:
+                        continue
+                    admitted = await self._run_store(
+                        self.store.mark_dispatch_admitted, row.event_id
+                    )
+                    if not admitted:
+                        continue
+                    update_id = self._update_id(row.payload, row.payload)
+                    try:
+                        if update_id is None:
+                            raise ValueError("durable payload has no integer update_id")
+                        item = self.item_factory(row.payload)
+                        if not self._is_update(item):
+                            raise ValueError(
+                                "durable item factory did not return a Telegram update"
+                            )
+                        with self._claim_handoff_lock:
+                            if self._handoff_in_progress:
+                                raise RuntimeError(
+                                    "Telegram queue handoff started during admission"
+                                )
+                            self._queued_event_ids.add(row.event_id)
+                            self._event_id_by_update_id[update_id] = row.event_id
+                            self.put_nowait(item)
+                    except Exception as exc:
+                        logger.warning(
+                            "Telegram durable projection rejected: bot_account_id=%s "
+                            "event_id=%s error=%s",
+                            self.bot_account_id,
+                            row.event_id,
+                            type(exc).__name__,
+                        )
+                        with self._claim_handoff_lock:
+                            self._queued_event_ids.discard(row.event_id)
+                            if update_id is not None:
+                                self._event_id_by_update_id.pop(update_id, None)
+                        try:
+                            await self._run_store(
+                                self.store.reset_dispatch_pending, row.event_id
+                            )
+                        except Exception:
+                            self._pending_dispatch_resets.add(row.event_id)
+                            self._schedule_projection_retry()
+                        # A factory/configuration fault cannot be made healthy
+                        # by immediately reprojecting the same row in a timer
+                        # loop. Keep it replayable for explicit recovery.
+                        capacity_available = False
+                        break
+                    projected += 1
+        finally:
+            await self._refresh_due_wakeup(
+                capacity_available=capacity_available
+            )
+        return projected
+
+    async def recover(self, *, now: Optional[float] = None) -> int:
+        """Recover this queue's account and project the replayable backlog."""
+        self._projection_suspended = False
+        await self._run_store(
+            self.store.reclaim_process_leases,
+            bot_account_id=self.bot_account_id,
+            current_owner=self.lease_owner,
+            now=now,
+        )
+        await self._run_store(
+            self.store.recover_admitted_dispatches,
+            bot_account_id=self.bot_account_id,
+            now=now,
+        )
+        return await self.wake_scheduler()
+
+    def _request_wakeup(self) -> None:
+        if self._projection_suspended or self._lifecycle_retired:
+            return
+        loop = self._scheduler_loop
+        if loop is None or loop.is_closed():
+            return
+
+        loop.call_soon_threadsafe(self._schedule_projection_retry)
+
+    async def suspend_projection(self) -> None:
+        """Stop queue-owned projection tasks until lifecycle recovery resumes."""
+        self._projection_suspended = True
+        due_wakeup_task = self._due_wakeup_task
+        self._cancel_due_wakeup()
+        if (
+            due_wakeup_task is not None
+            and not due_wakeup_task.done()
+            and due_wakeup_task is not asyncio.current_task()
+        ):
+            await asyncio.gather(due_wakeup_task, return_exceptions=True)
+        # Flush any call_soon_threadsafe callback queued by complete_update().
+        # It observes the suspension flag and exits without creating a task.
+        await asyncio.sleep(0)
+        task = self._projection_retry_task
+        if task is not None and not task.done() and task is not asyncio.current_task():
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+        if task is None or task.done():
+            self._projection_retry_task = None
+
+    def _shutdown_store_executor(self) -> None:
+        """Retire this queue's worker without abandoning submitted writes."""
+        if self._store_executor_shutdown:
+            return
+        self._store_executor_shutdown = True
+        _release_store_executor(self._store_executor_key, self._store_executor)
+
+    async def _retire_after_handoff(self) -> None:
+        """Release queue-local workers after durable ownership transfers."""
+        await self.suspend_projection()
+        self._shutdown_store_executor()
+
+    async def close(self) -> None:
+        """Release queue-owned timers, retries, and its shared SQLite reference."""
+        async with self._ingress_handoff_lock:
+            self._ingress_closed = True
+            self._lifecycle_retired = True
+            self._handoff_complete.set()
+        try:
+            await self.suspend_projection()
+            await self._wait_for_ingress_tasks()
+            for task in tuple(self._claim_transition_tasks.values()):
+                if task is not asyncio.current_task() and not task.done():
+                    task.cancel()
+            if self._claim_transition_tasks:
+                await asyncio.gather(
+                    *tuple(self._claim_transition_tasks.values()), return_exceptions=True
+                )
+            self._claim_transition_tasks.clear()
+        finally:
+            self._shutdown_store_executor()
+
+    def forget_claims(self, event_ids: set[str]) -> None:
+        if not event_ids:
+            return
+        released = False
+        with self._claim_handoff_lock:
+            for update_id, claim in tuple(self._claim_by_update_id.items()):
+                if claim.event_id in event_ids:
+                    self._claim_by_update_id.pop(update_id, None)
+                    self._handler_event_ids.discard(claim.event_id)
+                    self._buffered_event_ids.discard(claim.event_id)
+                    released = True
+            for update_id, claim in tuple(self._retryable_claim_by_update_id.items()):
+                if claim.event_id in event_ids:
+                    self._retryable_claim_by_update_id.pop(update_id, None)
+                    self._buffered_event_ids.discard(claim.event_id)
+                    released = True
+        if released:
+            self._request_wakeup()
+
+    async def put(self, item: Any) -> None:
+        target = await self._enter_ingress()
+        if target is not None:
+            await target.put(item)
+            return
+        try:
+            raw = self._raw_payload(item)
+            if not self._is_update(item, raw):
+                # PTB uses a private object sentinel during shutdown. It is not
+                # user work and must retain ordinary asyncio.Queue semantics.
+                await super().put(item)
+                return
+            decision = await self._classify_with_retry(item, raw)
+            if not decision.actionable:
+                await super().put(item)
+                return
+            update_id = self._update_id(item, raw)
+            assert update_id is not None
+            persist_task = asyncio.create_task(
+                self._persist_with_retry(update_id=update_id, decision=decision)
+            )
+            try:
+                result = await asyncio.shield(persist_task)
+            except asyncio.CancelledError:
+                # A reconnect must not wait forever for a worker thread that cannot
+                # be cancelled. PTB has not advanced its offset, while a late commit
+                # remains idempotent and is projected by this background recovery.
+                recovery = asyncio.create_task(
+                    self._recover_committed_put(item, persist_task)
+                )
+                self._track_ingress_task(recovery)
+                raise
+            await self._admit_result(item, result)
+        finally:
+            self._leave_ingress()
+
+    async def _recover_committed_put(
+        self, item: Any, task: asyncio.Task[PersistResult]
+    ) -> None:
+        try:
+            result = await task
+        except asyncio.CancelledError:
+            return
+        except Exception as exc:
+            logger.error(
+                "Telegram durable ingress background recovery failed: "
+                "bot_account_id=%s error=%s",
+                self.bot_account_id,
+                type(exc).__name__,
+            )
+            return
+        await self._admit_result(item, result)
+
+    async def _admit_result(self, item: Any, result: PersistResult) -> None:
+        with self._claim_handoff_lock:
+            target = self._handoff_target
+        if target is not None:
+            # This put began in the predecessor epoch but committed after the
+            # replacement published. The row is already durable; projection is
+            # now solely the replacement's responsibility.
+            try:
+                await target.wake_scheduler()
+            except asyncio.CancelledError:
+                # The committed row still needs a projection attempt after PTB
+                # stops awaiting this ingress put.
+                target._schedule_projection_retry()
+                raise
+            return
+        try:
+            await self.wake_scheduler()
+        except asyncio.CancelledError:
+            # Persist succeeded before this cancellation. Retain an owned
+            # projection retry so that a canceled PTB put cannot strand the
+            # durable row until an unrelated reconnect happens.
+            self._schedule_projection_retry()
+            raise
+        except Exception as exc:
+            # The Bot API update is already durable. Do not let projection or
+            # callback failures kill PTB's polling task; the durable row remains
+            # replayable and the background scheduler retries projection.
+            logger.warning(
+                "Telegram durable ingress committed but projection was deferred: "
+                "bot_account_id=%s event_id=%s error=%s",
+                self.bot_account_id,
+                result.event_id,
+                type(exc).__name__,
+            )
+            self._schedule_projection_retry()
+            return
+        if result.duplicate or self.after_commit is None:
+            return
+        try:
+            callback_result = self.after_commit(item, result)
+            if callback_result is not None:
+                await callback_result
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.warning(
+                "Telegram durable ingress post-commit callback failed: "
+                "bot_account_id=%s event_id=%s error=%s",
+                self.bot_account_id,
+                result.event_id,
+                type(exc).__name__,
+            )
+
+    async def put_replay(self, item: Any, event_id: str) -> None:
+        del item, event_id
+        await self.wake_scheduler()
+
+    async def get(self) -> Any:
+        while True:
+            item = await super().get()
+            raw = self._raw_payload(item)
+            update_id = self._update_id(item, raw)
+            if update_id is None:
+                return item
+
+            event_id = None
+            wait_event = None
+            handoff_target = None
+            with self._claim_handoff_lock:
+                if self._handoff_in_progress:
+                    # A durable projection keeps its mapping until the
+                    # handoff publishes the replacement claim. Ordinary
+                    # updates must retain their normal queue semantics.
+                    event_id = self._event_id_by_update_id.get(update_id)
+                    if event_id is not None:
+                        wait_event = self._handoff_complete
+                elif update_id in self._handed_off_update_ids:
+                    self._handed_off_update_ids.discard(update_id)
+                    handoff_target = self._handoff_target
+                else:
+                    event_id = self._event_id_by_update_id.pop(update_id, None)
+                    if event_id is not None:
+                        self._queued_event_ids.discard(event_id)
+
+            if wait_event is not None:
+                try:
+                    await self._wait_for_claim_event(wait_event)
+                except asyncio.CancelledError:
+                    super().task_done()
+                    raise
+                # The predecessor's physical projection belongs to the retired
+                # consumer.  Discard it rather than returning replacement work
+                # through an old adapter whose wrapper no longer owns the claim.
+                super().task_done()
+                continue
+
+            if handoff_target is not None:
+                super().task_done()
+                continue
+
+            if event_id is None:
+                return item
+
+            with self._claim_handoff_lock:
+                claim_done = self._begin_claiming_locked(event_id)
+            if claim_done is None:
+                with self._claim_handoff_lock:
+                    claim_done = self._claiming_done.get(event_id)
+                if claim_done is not None:
+                    await self._wait_for_claim_event(claim_done)
+                super().task_done()
+                continue
+
+            lease_task = asyncio.create_task(
+                self._run_store(
+                    self.store.lease_event,
+                    event_id,
+                    owner=self.lease_owner,
+                    lease_seconds=self._prehandler_lease_seconds,
+                )
+            )
+            leased = None
+            try:
+                leased = await asyncio.shield(lease_task)
+            except asyncio.CancelledError:
+                # Shield prevents cancellation from killing the worker thread,
+                # but the SQLite lease may already have committed. Wait for
+                # its result, then explicitly undo that lease before exposing
+                # the cancellation to the caller.
+                try:
+                    try:
+                        leased = await asyncio.shield(lease_task)
+                    except BaseException:
+                        leased = None
+                    if leased is not None:
+                        reverted = await self._run_store(
+                            self.store.requeue,
+                            event_id,
+                            owner=self.lease_owner,
+                            lease_epoch=leased.lease_epoch,
+                            error_class="claim_cancelled",
+                        )
+                        if not reverted:
+                            await self._run_store(
+                                self.store.reset_dispatch_pending, event_id
+                            )
+                    else:
+                        await self._run_store(
+                            self.store.reset_dispatch_pending, event_id
+                        )
+                except BaseException:
+                    # Preserve cancellation even when SQLite remains busy. A
+                    # later lifecycle recovery owns authoritative cleanup.
+                    pass
+                finally:
+                    self._discard_claiming_projection(event_id)
+                try:
+                    await self.wake_scheduler()
+                except BaseException:
+                    pass
+                raise
+            except Exception as exc:
+                # PTB's update fetcher awaits queue.get() outside its recovery
+                # loop. A transient SQLite fault must therefore release this
+                # projection and retry locally rather than terminate fetching.
+                logger.warning(
+                    "Telegram durable lease retry: bot_account_id=%s event_id=%s error=%s",
+                    self.bot_account_id,
+                    event_id,
+                    type(exc).__name__,
+                )
+                self._pending_dispatch_resets.add(event_id)
+                try:
+                    current = await self._run_store(self.store.get, event_id)
+                    if (
+                        current is not None
+                        and current.work_state == "leased"
+                        and current.lease_owner == self.lease_owner
+                    ):
+                        reverted = await self._run_store(
+                            self.store.requeue,
+                            event_id,
+                            owner=self.lease_owner,
+                            lease_epoch=current.lease_epoch,
+                            error_class="claim_failed",
+                        )
+                        if reverted:
+                            self._pending_dispatch_resets.discard(event_id)
+                    else:
+                        await self._run_store(
+                            self.store.reset_dispatch_pending, event_id
+                        )
+                        self._pending_dispatch_resets.discard(event_id)
+                except Exception:
+                    # The next bounded projection wake/recovery remains the
+                    # authority if the cleanup read is also transiently busy.
+                    logger.warning(
+                        "Telegram durable lease cleanup deferred: bot_account_id=%s event_id=%s",
+                        self.bot_account_id,
+                        event_id,
+                    )
+                finally:
+                    self._discard_claiming_projection(event_id)
+                try:
+                    await self.wake_scheduler()
+                except Exception:
+                    self._schedule_projection_retry()
+                await asyncio.sleep(
+                    max(0.0, float(self._persist_retry_initial_seconds))
+                )
+                continue
+
+            if leased is None:
+                try:
+                    await self._run_store(
+                        self.store.reset_dispatch_pending, event_id
+                    )
+                finally:
+                    self._discard_claiming_projection(event_id)
+                await self.wake_scheduler()
+                continue
+
+            # Publish the claim while the operation fence is still held. A
+            # handoff that started concurrently therefore observes either this
+            # complete claim or the cleanup path above, never an invisible
+            # SQLite lease.
+            with self._claim_handoff_lock:
+                self._claim_by_update_id[update_id] = leased
+            self._finish_claiming(event_id)
+            # No handler has claimed this row yet. Arm a finite recovery wake so
+            # an unmatched PTB update cannot permanently occupy active_limit.
+            await self._refresh_due_wakeup(capacity_available=False)
+            return item
+
+    async def handoff_from(self, previous: "DurableTelegramUpdateQueue") -> dict[str, int]:
+        """Transfer live claims and make abandoned projections replayable."""
+        if previous.store.lifecycle_path != self.store.lifecycle_path:
+            raise ValueError("Telegram queue handoff requires the same store")
+        if previous.bot_account_id != self.bot_account_id:
+            raise ValueError("Telegram queue handoff requires the same bot account")
+        self._claim_handoff_lock = previous._claim_handoff_lock
+
+        # Close admission before claiming predecessor state. New old-queue puts
+        # wait for publication and then forward to this queue; already-admitted
+        # puts keep their shared executor and redirect their post-commit wake
+        # below. Handoff therefore remains bounded during a transient outage.
+        async with previous._ingress_handoff_lock:
+            with previous._claim_handoff_lock:
+                if previous._handoff_in_progress:
+                    raise RuntimeError("Telegram queue handoff already in progress")
+                previous._ingress_closed = True
+                previous._handoff_complete.clear()
+
+        async with previous._admission_lock:
+            # Held-event overflow cleanup is scheduled from a synchronous
+            # adapter path. Finish it before classifying claims as live, or the
+            # replacement could transfer a lease that the old adapter is about
+            # to release.
+            await previous._wait_for_lifecycle_tasks()
+            with previous._claim_handoff_lock:
+                previous._handoff_in_progress = True
+                # Claims already inside get() when handoff began are live even
+                # if the handler has not received the returned item yet.
+                # Previously completed, unhandled claims remain replayable.
+                handoff_live_event_ids = set(previous._handler_event_ids)
+                handoff_live_event_ids.update(previous._claiming_event_ids)
+                handoff_live_event_ids.difference_update(
+                    previous._buffered_event_ids
+                )
+                claim_wait_events = tuple(previous._claiming_done.values())
+
+            try:
+                for claim_wait_event in claim_wait_events:
+                    await previous._wait_for_claim_event(claim_wait_event)
+                while True:
+                    with previous._claim_handoff_lock:
+                        remaining = tuple(previous._claiming_done.values())
+                    if not remaining:
+                        break
+                    for claim_wait_event in remaining:
+                        await previous._wait_for_claim_event(claim_wait_event)
+
+                def handoff_and_publish() -> dict[str, int]:
+                    with previous._claim_handoff_lock:
+                        handoff_live_event_ids.update(previous._handler_event_ids)
+                        handoff_live_event_ids.difference_update(
+                            previous._buffered_event_ids
+                        )
+                        claims = tuple(previous._claim_by_update_id.items())
+                        counts = self.store.handoff_owner_leases(
+                            bot_account_id=self.bot_account_id,
+                            old_owner=previous.lease_owner,
+                            new_owner=self.lease_owner,
+                            live_event_ids=handoff_live_event_ids,
+                        )
+                        previous._fenced_handler_update_ids.update(
+                            update_id for update_id, _claim in claims
+                        )
+                        for event_id in tuple(previous._queued_event_ids):
+                            self.store.reset_dispatch_pending(event_id)
+                        for update_id, claim in claims:
+                            if claim.event_id not in handoff_live_event_ids:
+                                continue
+                            current = self.store.get(claim.event_id)
+                            if (
+                                current is not None
+                                and current.work_state == "leased"
+                                and current.lease_owner == self.lease_owner
+                                and current.lease_epoch == claim.lease_epoch
+                            ):
+                                claim.lease_owner = current.lease_owner
+                                self._claim_by_update_id[update_id] = claim
+                                self._handler_event_ids.add(claim.event_id)
+                        previous._claim_by_update_id.clear()
+                        previous._retryable_claim_by_update_id.clear()
+                        previous._handler_event_ids.clear()
+                        previous._buffered_event_ids.clear()
+                        previous._handed_off_update_ids.update(
+                            previous._event_id_by_update_id
+                        )
+                        previous._event_id_by_update_id.clear()
+                        previous._queued_event_ids.clear()
+                        previous._handoff_target = self
+                        previous._lifecycle_retired = True
+                        previous._handoff_in_progress = False
+                        previous._handoff_complete.set()
+                        return counts
+
+                counts = await self._run_store(handoff_and_publish)
+            finally:
+                with previous._claim_handoff_lock:
+                    if previous._handoff_in_progress:
+                        previous._handoff_in_progress = False
+                        previous._ingress_closed = False
+                        previous._handoff_complete.set()
+
+        # A hold can be created while the threaded handoff is running. Such a
+        # cleanup redirects to this queue after publication; wait for it before
+        # the replacement's final projection wake.
+        await previous._wait_for_lifecycle_tasks()
+        await previous._retire_after_handoff()
+        previous._notify_handoff(self)
+        await self.wake_scheduler()
+        return counts
+
+
+    async def _requeue_unclaimed_projection_ids(
+        self, previous: "DurableTelegramUpdateQueue"
+    ) -> int:
+        del previous
+        return 0
+
+
+class TelegramQueueLifecycleRegistry:
+    """Serialize durable queue recovery for each store and bot account."""
+
+    _registry_lock = threading.RLock()
+    _active: dict[tuple[str, str], weakref.ReferenceType] = {}
+    _transition_locks: dict[tuple[str, str], threading.Lock] = {}
+
+    @classmethod
+    def key_for(
+        cls, store_path: os.PathLike[str] | str, bot_account_id: Any
+    ) -> tuple[str, str]:
+        """Return one process-local key for each physical SQLite path."""
+        return (
+            _canonical_store_path(store_path),
+            canonical_bot_account_id(bot_account_id),
+        )
+
+    @classmethod
+    def key_for_queue(
+        cls, queue: DurableTelegramUpdateQueue
+    ) -> tuple[str, str]:
+        return cls.key_for(queue.store.lifecycle_path, queue.bot_account_id)
+
+    @classmethod
+    def _active_queue_locked(
+        cls, key: tuple[str, str]
+    ) -> Optional[DurableTelegramUpdateQueue]:
+        reference = cls._active.get(key)
+        if reference is None:
+            return None
+        queue = reference()
+        if queue is None:
+            cls._active.pop(key, None)
+        return queue
+
+    @classmethod
+    def observe(cls, queue: DurableTelegramUpdateQueue) -> None:
+        """Register a queue without replacing an already active queue."""
+        key = cls.key_for_queue(queue)
+        with cls._registry_lock:
+            if cls._active_queue_locked(key) is None:
+                cls._active[key] = weakref.ref(queue)
+
+    @classmethod
+    def _transition_lock_for(cls, key: tuple[str, str]) -> threading.Lock:
+        with cls._registry_lock:
+            return cls._transition_locks.setdefault(key, threading.Lock())
+
+    @staticmethod
+    async def _acquire_transition_lock(lock: threading.Lock) -> None:
+        """Acquire without parking an executor thread that cancellation leaks."""
+        while not lock.acquire(blocking=False):
+            await asyncio.sleep(0.001)
+
+    @classmethod
+    async def recover(
+        cls, queue: DurableTelegramUpdateQueue, *, now: Optional[float] = None
+    ) -> int:
+        """Handoff a replaced queue before recovering the replacement."""
+        key = cls.key_for_queue(queue)
+        transition_lock = cls._transition_lock_for(key)
+        await cls._acquire_transition_lock(transition_lock)
+        try:
+            with cls._registry_lock:
+                active = cls._active_queue_locked(key)
+                if getattr(queue, "_lifecycle_retired", False):
+                    return 0
+                if active is None:
+                    cls._active[key] = weakref.ref(queue)
+                    active = queue
+
+            if active is not queue:
+                handoff_already_complete = (
+                    getattr(active, "_lifecycle_retired", False)
+                    and getattr(active, "_handoff_target", None) is queue
+                )
+                if not handoff_already_complete:
+                    await queue.handoff_from(active)
+                with cls._registry_lock:
+                    cls._active[key] = weakref.ref(queue)
+
+            return await queue.recover(now=now)
+        finally:
+            transition_lock.release()

--- a/tests/gateway/test_queue_consumption.py
+++ b/tests/gateway/test_queue_consumption.py
@@ -6,16 +6,24 @@ after the agent finishes its current task — not silently dropped.
 """
 
 import asyncio
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import pytest
 
 from gateway.run import _dequeue_pending_event
 from gateway.platforms.base import (
     BasePlatformAdapter,
     MessageEvent,
     MessageType,
+    ProcessingOutcome,
     PlatformConfig,
     Platform,
+)
+from plugins.platforms.telegram.inbound_store import (
+    CaptureDecision,
+    DurableTelegramUpdateQueue,
+    TelegramInboundStore,
 )
 
 
@@ -220,3 +228,673 @@ class TestBusyInputModeQueueFifo:
         assert runner._queue_depth(session_key, adapter=adapter) == len(texts)
 
 
+def test_ordinary_busy_queue_rejects_work_after_the_32_item_cap():
+    """Durable Telegram admission must not remove the ordinary busy cap."""
+    from gateway.run import GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._queued_events = {}
+    adapter = _StubAdapter()
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    session_key = "telegram:user:ordinary-cap"
+    source = MagicMock(chat_id="ordinary-cap", platform=Platform.TELEGRAM, profile=None)
+
+    assert runner._BUSY_QUEUE_MAX_PENDING == 32
+    for index in range(runner._BUSY_QUEUE_MAX_PENDING + 1):
+        runner._queue_or_replace_pending_event(
+            session_key,
+            MessageEvent(
+                text=f"ordinary-{index}",
+                message_type=MessageType.TEXT,
+                source=source,
+                message_id=f"ordinary-{index}",
+            ),
+        )
+
+    assert runner._queue_depth(session_key, adapter=adapter) == 32
+    assert adapter._pending_messages[session_key].text == "ordinary-0"
+    assert runner._queued_events[session_key][-1].text == "ordinary-31"
+
+
+@pytest.mark.asyncio
+async def test_claimed_durable_telegram_event_does_not_consume_ordinary_busy_cap(tmp_path):
+    """A claimed durable event is requeued, not marked done at the busy cap."""
+    from gateway.run import GatewayRunner
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    dispatch_calls = []
+
+    class ProbeRunner(GatewayRunner):
+        async def _handle_message(self, event):
+            dispatch_calls.append(event)
+
+    ordinary_runner = ProbeRunner.__new__(ProbeRunner)
+    ordinary_runner._queued_events = {}
+    adapter = object.__new__(TelegramAdapter)
+    adapter._pending_messages = {}
+    adapter._active_sessions = {"telegram:user:ordinary-cap-with-durable": asyncio.Event()}
+    adapter._inbound_store = TelegramInboundStore(tmp_path / "telegram_inbound.db")
+    adapter._inbound_queue = None
+    adapter._bot_account_id = None
+    adapter.config = PlatformConfig(enabled=True, token="111:test-token", extra={})
+    ordinary_runner.adapters = {Platform.TELEGRAM: adapter}
+    ordinary_key = "telegram:user:ordinary-cap-with-durable"
+    ordinary_source = MagicMock(
+        chat_id=ordinary_key,
+        platform=Platform.TELEGRAM,
+        profile=None,
+    )
+
+    def durable_payload(update_id):
+        return {
+            "update_id": update_id,
+            "message": {"message_id": update_id, "chat": {"id": 7}},
+        }
+
+    def classify(item):
+        return CaptureDecision(
+            actionable=True,
+            update_kind="message",
+            chat_id="7",
+            message_id=str(item["update_id"]),
+            session_key=ordinary_key,
+            payload=item,
+        )
+
+    queue = DurableTelegramUpdateQueue(
+        store=adapter._inbound_store,
+        bot_account_id=111,
+        classifier=classify,
+        lease_owner="gateway:durable-cap-test",
+        active_limit=1,
+    )
+    adapter._inbound_queue = queue
+    ordinary_runner._effective_busy_text_mode = lambda source: "queue"
+    adapter._message_handler = ordinary_runner._handle_message
+
+    durable_payload = durable_payload(9001)
+    await queue.put(durable_payload)
+    claimed_item = await queue.get()
+    claim = queue.claim_for_update(9001)
+    assert claim is not None
+    assert claimed_item["update_id"] == 9001
+    assert claimed_item["message"]["message_id"] == 9001
+    queue.task_done()
+
+    durable_source = MagicMock(
+        chat_id=ordinary_key,
+        platform=Platform.TELEGRAM,
+        profile=None,
+    )
+    claimed_durable_event = MessageEvent(
+        text="durable",
+        message_type=MessageType.TEXT,
+        source=durable_source,
+        raw_message=claim,
+        message_id="77",
+        platform_update_id=9001,
+        metadata={
+            "telegram_inbound_claimed": True,
+            "telegram_durable_update_ids": [9001],
+            "gateway_session_key": ordinary_key,
+        },
+    )
+
+    for index in range(ordinary_runner._BUSY_QUEUE_MAX_PENDING + 1):
+        ordinary_runner._queue_or_replace_pending_event(
+            ordinary_key,
+            MessageEvent(
+                text=f"ordinary-{index}",
+                message_type=MessageType.TEXT,
+                source=ordinary_source,
+                message_id=f"ordinary-{index}",
+            ),
+        )
+
+    await adapter._dispatch_and_complete_durable_event(claimed_durable_event)
+
+    row = adapter._inbound_store.get("telegram:111:9001")
+    assert row is not None
+    assert row.work_state == "queued"
+    assert row.dispatch_state == "pending"
+    assert queue.claim_for_update(9001) is None
+    assert ordinary_runner._BUSY_QUEUE_MAX_PENDING == 32
+    assert ordinary_runner._queue_depth(ordinary_key, adapter=adapter) == 32
+    assert adapter._pending_messages[ordinary_key].text == "ordinary-0"
+    assert ordinary_runner._queued_events[ordinary_key][-1].text == "ordinary-31"
+    assert dispatch_calls == []
+
+
+@pytest.mark.asyncio
+async def test_durable_busy_fifo_waits_for_its_own_processing_completion(tmp_path, monkeypatch):
+    """A volatile FIFO append is not a durable completion boundary."""
+    from gateway.run import GatewayRunner
+    from gateway.session import SessionSource
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    monkeypatch.setenv("HERMES_GATEWAY_BUSY_ACK_ENABLED", "false")
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._queued_events = {}
+    runner._draining = False
+    adapter = object.__new__(TelegramAdapter)
+    BasePlatformAdapter.__init__(
+        adapter,
+        PlatformConfig(enabled=True, token="111:test-token", extra={}),
+        Platform.TELEGRAM,
+    )
+
+    session_key = "agent:main:telegram:dm:durable-fifo-fence"
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="durable-fifo-fence",
+        chat_type="dm",
+        user_id="7",
+        user_name="tester",
+    )
+    state = SimpleNamespace(
+        conversation=SimpleNamespace(queued_events=[]),
+        turn=SimpleNamespace(agent=None, busy_ack_ts=0, started_ts=0),
+    )
+    owner_release = asyncio.Event()
+    owner_task = asyncio.create_task(owner_release.wait())
+    adapter._active_sessions = {session_key: asyncio.Event()}
+    adapter._session_tasks = {session_key: owner_task}
+
+    store = TelegramInboundStore(tmp_path / "telegram_inbound.db")
+    adapter._inbound_store = store
+    queue = DurableTelegramUpdateQueue(
+        store=store,
+        bot_account_id=111,
+        classifier=lambda item: CaptureDecision(
+            actionable=True,
+            update_kind="message",
+            chat_id="7",
+            message_id=str(item["update_id"]),
+            session_key=session_key,
+            payload=item,
+        ),
+        lease_owner="gateway:durable-fifo-fence",
+        active_limit=1,
+    )
+    adapter._inbound_queue = queue
+
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._adapter_for_source = lambda _source: adapter
+    runner._peek_session_state = lambda _session_key: state
+    runner._session_state = lambda _session_key: state
+    runner._is_user_authorized = lambda _source: True
+    runner._effective_busy_input_mode = lambda _source: "queue"
+    runner._effective_busy_text_mode = lambda _source: "queue"
+    runner._agent_has_active_subagents = lambda _agent: False
+
+    async def no_compression(_session_key):
+        return False
+
+    runner._session_has_compression_in_flight = no_compression
+    busy_finished = asyncio.Event()
+    actual_busy_handler = runner._handle_active_session_busy_message
+
+    async def busy_handler(event, key):
+        result = await actual_busy_handler(event, key)
+        busy_finished.set()
+        return result
+
+    adapter._message_handler = runner._handle_message
+    adapter._busy_session_handler = busy_handler
+
+    update_id = 9003
+    payload_data = {
+        "update_id": update_id,
+        "message": {"message_id": update_id, "chat": {"id": 7}},
+    }
+    await queue.put(payload_data)
+    await queue.get()
+    claim = queue.claim_for_update(update_id)
+    assert claim is not None
+    queue.task_done()
+
+    event = MessageEvent(
+        text="durable",
+        message_type=MessageType.DOCUMENT,
+        source=source,
+        raw_message=claim,
+        message_id="79",
+        platform_update_id=update_id,
+        metadata={
+            "telegram_inbound_claimed": True,
+            "telegram_durable_update_ids": [update_id],
+            "gateway_session_key": session_key,
+        },
+        allow_gateway_control=False,
+    )
+
+    dispatch_task = asyncio.create_task(
+        adapter._dispatch_and_complete_durable_event(event)
+    )
+    try:
+        await asyncio.wait_for(busy_finished.wait(), timeout=1.0)
+        assert runner._queue_depth(session_key, adapter=adapter) == 1
+        await asyncio.wait_for(dispatch_task, timeout=1.0)
+        row = store.get(claim.event_id)
+        assert row is not None
+        assert row.work_state == "leased"
+        assert row.consumed_at is None
+
+        owner_release.set()
+        await asyncio.wait_for(owner_task, timeout=1.0)
+        await asyncio.sleep(0.05)
+
+        # The owner finishing only proves that the preceding turn ended. The
+        # durable event remains in the inherited FIFO until its own lifecycle
+        # hook runs, so its SQLite claim must still be leased here.
+        assert dispatch_task.done()
+        row = store.get(claim.event_id)
+        assert row is not None
+        assert row.work_state == "leased"
+        assert row.consumed_at is None
+
+        await adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
+        completion = getattr(event, "_telegram_durable_completion_task", None)
+        assert completion is not None
+        await asyncio.wait_for(asyncio.shield(completion), timeout=1.0)
+    finally:
+        if not owner_task.done():
+            owner_release.set()
+            await owner_task
+        if not dispatch_task.done():
+            dispatch_task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await dispatch_task
+
+    row = store.get(claim.event_id)
+    assert row is not None
+    assert row.work_state == "consumed"
+    assert row.consumed_at is not None
+
+
+@pytest.mark.asyncio
+async def test_durable_busy_steer_is_queued_until_it_has_its_own_processing_lifecycle(
+    monkeypatch,
+):
+    """A durable event must not be detached by an unreceipted steer accept."""
+    from gateway.run import GatewayRunner
+    from gateway.session import SessionSource
+
+    monkeypatch.setenv("HERMES_GATEWAY_BUSY_ACK_ENABLED", "false")
+
+    class AcceptOnlyAgent:
+        def __init__(self):
+            self.steer_calls = []
+
+        def steer(self, text):
+            self.steer_calls.append(text)
+            return True
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._queued_events = {}
+    runner._draining = False
+    adapter = _StubAdapter()
+    runner.adapters = {Platform.TELEGRAM: adapter}
+
+    session_key = "agent:main:telegram:dm:durable-steer-fence"
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="durable-steer-fence",
+        chat_type="dm",
+        user_id="7",
+        user_name="tester",
+    )
+    agent = AcceptOnlyAgent()
+    state = SimpleNamespace(
+        conversation=SimpleNamespace(queued_events=[]),
+        turn=SimpleNamespace(agent=agent, busy_ack_ts=0, started_ts=0),
+    )
+    adapter._active_sessions = {session_key: asyncio.Event()}
+
+    runner._adapter_for_source = lambda _source: adapter
+    runner._peek_session_state = lambda _session_key: state
+    runner._session_state = lambda _session_key: state
+    runner._is_user_authorized = lambda _source: True
+    runner._effective_busy_input_mode = lambda _source: "steer"
+    runner._effective_busy_text_mode = lambda _source: "steer"
+    runner._agent_has_active_subagents = lambda _agent: False
+
+    async def no_compression(_session_key):
+        return False
+
+    runner._session_has_compression_in_flight = no_compression
+
+    event = MessageEvent(
+        text="durable correction",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="80",
+        platform_update_id=9004,
+        metadata={
+            "telegram_inbound_claimed": True,
+            "telegram_durable_update_ids": [9004],
+            "gateway_session_key": session_key,
+        },
+    )
+
+    handled = await runner._handle_active_session_busy_message(event, session_key)
+
+    assert handled is True
+    assert agent.steer_calls == []
+    assert runner._queue_depth(session_key, adapter=adapter) == 1
+    assert adapter._pending_messages[session_key] is event
+
+
+@pytest.mark.asyncio
+async def test_durable_busy_cap_claim_survives_process_loss_and_replays(tmp_path):
+    """A busy-cap decision must leave a leased durable row recoverable."""
+    from gateway.run import GatewayRunner
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    dispatch_calls = []
+
+    class ProbeRunner(GatewayRunner):
+        async def _handle_message(self, event):
+            dispatch_calls.append(event)
+
+    ordinary_runner = ProbeRunner.__new__(ProbeRunner)
+    ordinary_runner._queued_events = {}
+    adapter = object.__new__(TelegramAdapter)
+    adapter._pending_messages = {}
+    ordinary_key = "telegram:user:ordinary-cap-crash"
+    adapter._active_sessions = {ordinary_key: asyncio.Event()}
+    store = TelegramInboundStore(tmp_path / "telegram_inbound.db")
+    adapter._inbound_store = store
+    adapter._inbound_queue = None
+    adapter._bot_account_id = None
+    adapter.config = PlatformConfig(enabled=True, token="111:test-token", extra={})
+    ordinary_runner.adapters = {Platform.TELEGRAM: adapter}
+    ordinary_source = MagicMock(
+        chat_id=ordinary_key,
+        platform=Platform.TELEGRAM,
+        profile=None,
+    )
+
+    def durable_payload(update_id):
+        return {
+            "update_id": update_id,
+            "message": {"message_id": update_id, "chat": {"id": 7}},
+        }
+
+    def classify(item):
+        return CaptureDecision(
+            actionable=True,
+            update_kind="message",
+            chat_id="7",
+            message_id=str(item["update_id"]),
+            session_key=ordinary_key,
+            payload=item,
+        )
+
+    queue = DurableTelegramUpdateQueue(
+        store=store,
+        bot_account_id=111,
+        classifier=classify,
+        lease_owner="gateway:durable-cap-crash-old",
+        active_limit=1,
+    )
+    adapter._inbound_queue = queue
+    ordinary_runner._effective_busy_text_mode = lambda source: "queue"
+    adapter._message_handler = ordinary_runner._handle_message
+
+    update_id = 9002
+    await queue.put(durable_payload(update_id))
+    claimed_item = await queue.get()
+    claim = queue.claim_for_update(update_id)
+    assert claim is not None
+    assert claimed_item["update_id"] == update_id
+    queue.task_done()
+
+    claimed_event = MessageEvent(
+        text="durable",
+        message_type=MessageType.TEXT,
+        source=ordinary_source,
+        raw_message=claim,
+        message_id="78",
+        platform_update_id=update_id,
+        metadata={
+            "telegram_inbound_claimed": True,
+            "telegram_durable_update_ids": [update_id],
+            "gateway_session_key": ordinary_key,
+        },
+    )
+    for index in range(ordinary_runner._BUSY_QUEUE_MAX_PENDING + 1):
+        ordinary_runner._queue_or_replace_pending_event(
+            ordinary_key,
+            MessageEvent(
+                text=f"ordinary-{index}",
+                message_type=MessageType.TEXT,
+                source=ordinary_source,
+                message_id=f"ordinary-{index}",
+            ),
+        )
+
+    await adapter._dispatch_inbound_event(claimed_event)
+
+    row = store.get("telegram:111:9002")
+    assert row is not None
+    assert row.work_state == "leased"
+    assert row.lease_owner == "gateway:durable-cap-crash-old"
+    assert queue.claim_for_update(update_id) is claim
+    assert dispatch_calls == []
+    assert ordinary_runner._queue_depth(ordinary_key, adapter=adapter) == 32
+
+    # Process loss discards only the old queue's in-memory claim map. The
+    # replacement queue must recover the still-leased SQLite row itself.
+    queue._scheduler_loop = None
+    queue.forget_claims({claim.event_id})
+    assert queue.claim_for_update(update_id) is None
+    replacement_queue = DurableTelegramUpdateQueue(
+        store=store,
+        bot_account_id=111,
+        classifier=classify,
+        lease_owner="gateway:durable-cap-crash-new",
+        active_limit=1,
+    )
+    assert await replacement_queue.recover(now=0.0) == 1
+    replayed_item = await replacement_queue.get()
+    replayed_claim = replacement_queue.claim_for_update(update_id)
+    assert replayed_item["update_id"] == update_id
+    assert replayed_claim is not None
+    replacement_queue.task_done()
+    assert await replacement_queue.complete_update(update_id, success=True)
+
+    row = store.get("telegram:111:9002")
+    assert row is not None
+    assert row.work_state == "consumed"
+    assert row.consumed_at is not None
+
+
+@pytest.mark.asyncio
+async def test_concurrent_durable_busy_cap_admission_is_replayable(tmp_path, monkeypatch):
+    """A raced durable admission cannot turn an inherited cap drop into success."""
+    from gateway.run import GatewayRunner
+    from gateway.session import SessionSource
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    monkeypatch.setenv("HERMES_GATEWAY_BUSY_ACK_ENABLED", "false")
+
+    class ProbeRunner(GatewayRunner):
+        async def _handle_message(self, event):
+            return None
+
+    runner = ProbeRunner.__new__(ProbeRunner)
+    runner._queued_events = {}
+    runner._draining = False
+    adapter = object.__new__(TelegramAdapter)
+    BasePlatformAdapter.__init__(
+        adapter,
+        PlatformConfig(enabled=True, token="111:test-token", extra={}),
+        Platform.TELEGRAM,
+    )
+
+    ordinary_key = "agent:main:telegram:dm:durable-cap-race"
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="durable-cap-race",
+        chat_type="dm",
+        user_id="7",
+        user_name="tester",
+    )
+    state = SimpleNamespace(
+        conversation=SimpleNamespace(queued_events=[]),
+        turn=SimpleNamespace(agent=None, busy_ack_ts=0, started_ts=0),
+    )
+    owner_release = asyncio.Event()
+    owner_task = asyncio.create_task(owner_release.wait())
+
+    adapter._active_sessions = {ordinary_key: asyncio.Event()}
+    adapter._session_tasks = {ordinary_key: owner_task}
+    store = TelegramInboundStore(tmp_path / "telegram_inbound.db")
+    adapter._inbound_store = store
+    queue = DurableTelegramUpdateQueue(
+        store=store,
+        bot_account_id=111,
+        classifier=lambda item: CaptureDecision(
+            actionable=True,
+            update_kind="message",
+            chat_id="7",
+            message_id=str(item["update_id"]),
+            session_key=ordinary_key,
+            payload=item,
+        ),
+        lease_owner="gateway:durable-cap-race",
+        active_limit=2,
+    )
+    adapter._inbound_queue = queue
+
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._adapter_for_source = lambda event_source: adapter
+    runner._peek_session_state = lambda session_key: state
+    runner._session_state = lambda session_key: state
+    runner._is_user_authorized = lambda event_source: True
+    runner._effective_busy_input_mode = lambda event_source: "queue"
+    runner._effective_busy_text_mode = lambda event_source: "queue"
+    runner._agent_has_active_subagents = lambda agent: False
+
+    async def no_compression(session_key):
+        return False
+
+    runner._session_has_compression_in_flight = no_compression
+    actual_busy_handler = runner._handle_active_session_busy_message
+    first_busy_finished = asyncio.Event()
+
+    async def synchronized_busy_handler(event, session_key):
+        # Force both callers to reach the real GatewayRunner cap check before
+        # either one can reserve a FIFO slot. The adapter fix must serialize
+        # this boundary without changing the inherited cap.
+        await asyncio.sleep(0)
+        result = await actual_busy_handler(event, session_key)
+        if event.platform_update_id == 9301:
+            first_busy_finished.set()
+        return result
+
+    adapter._message_handler = runner._handle_message
+    adapter._busy_session_handler = synchronized_busy_handler
+
+    update_ids = (9301, 9302)
+    claims = []
+    for update_id in update_ids:
+        await queue.put(
+            {
+                "update_id": update_id,
+                "message": {"message_id": update_id, "chat": {"id": 7}},
+            }
+        )
+        item = await queue.get()
+        claim = queue.claim_for_update(update_id)
+        assert claim is not None
+        assert item["update_id"] == update_id
+        queue.task_done()
+        claims.append(claim)
+
+    # One pending head plus thirty overflow events establishes the ordinary
+    # inherited depth-31 boundary. The next accepted event would be item 32.
+    for index in range(31):
+        runner._queue_or_replace_pending_event(
+            ordinary_key,
+            MessageEvent(
+                text=f"ordinary-{index}",
+                message_type=MessageType.DOCUMENT,
+                source=source,
+                message_id=f"ordinary-{index}",
+                allow_gateway_control=False,
+            ),
+        )
+    assert runner._queue_depth(ordinary_key, adapter=adapter) == 31
+    assert not owner_task.done()
+
+    def durable_event(update_id, claim):
+        return MessageEvent(
+            text=f"durable-{update_id}",
+            message_type=MessageType.DOCUMENT,
+            source=source,
+            raw_message=claim,
+            message_id=f"message-{update_id}",
+            platform_update_id=update_id,
+            metadata={
+                "telegram_inbound_claimed": True,
+                "telegram_durable_update_ids": [update_id],
+                "gateway_session_key": ordinary_key,
+            },
+            allow_gateway_control=False,
+        )
+
+    events = [durable_event(update_id, claim) for update_id, claim in zip(update_ids, claims)]
+    dispatch_tasks = [
+        asyncio.create_task(adapter._dispatch_and_complete_durable_event(event))
+        for event in events
+    ]
+    await asyncio.wait_for(first_busy_finished.wait(), timeout=1.0)
+    # The first caller is now waiting at the inherited background owner. Give
+    # the serialized second caller one scheduling turn to observe the full cap.
+    await asyncio.sleep(0)
+    owner_release.set()
+    await asyncio.wait_for(owner_task, timeout=1.0)
+    await asyncio.sleep(0.05)
+
+    # The first durable event was admitted below the ordinary cap and is now
+    # staged in the inherited FIFO. It cannot be consumed until its own
+    # processing lifecycle reports success.
+    first_row = store.get("telegram:111:9301")
+    assert first_row is not None
+    assert first_row.work_state == "leased"
+    assert first_row.consumed_at is None
+    await adapter.on_processing_complete(events[0], ProcessingOutcome.SUCCESS)
+    await asyncio.gather(*dispatch_tasks)
+    completion = getattr(events[0], "_telegram_durable_completion_task", None)
+    assert completion is not None
+    await asyncio.wait_for(asyncio.shield(completion), timeout=1.0)
+
+    rows = [store.get(f"telegram:111:{update_id}") for update_id in update_ids]
+    assert all(row is not None for row in rows)
+    assert sorted(row.work_state for row in rows) == ["consumed", "queued"]
+    replayable_id = next(update_id for update_id, row in zip(update_ids, rows) if row.work_state == "queued")
+    replayable_row = store.get(f"telegram:111:{replayable_id}")
+    assert replayable_row.dispatch_state == "pending"
+    assert replayable_row.consumed_at is None
+    assert queue.claim_for_update(replayable_id) is None
+
+    queued_events = list(state.conversation.queued_events)
+    pending = adapter._pending_messages.get(ordinary_key)
+    volatile_events = ([pending] if pending is not None else []) + queued_events
+    volatile_ids = {
+        update_id
+        for queued_event in volatile_events
+        for update_id in getattr(queued_event, "metadata", {}).get(
+            "telegram_durable_update_ids", []
+        )
+    }
+    assert replayable_id not in volatile_ids
+    assert runner._queue_depth(ordinary_key, adapter=adapter) == 32
+
+    if not owner_task.done():
+        owner_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await owner_task

--- a/tests/gateway/test_queue_consumption.py
+++ b/tests/gateway/test_queue_consumption.py
@@ -366,8 +366,8 @@ async def test_claimed_durable_telegram_event_does_not_consume_ordinary_busy_cap
 
 
 @pytest.mark.asyncio
-async def test_durable_busy_fifo_waits_for_its_own_processing_completion(tmp_path, monkeypatch):
-    """A volatile FIFO append is not a durable completion boundary."""
+async def test_durable_busy_fifo_consumes_each_in_band_event(tmp_path, monkeypatch):
+    """One owner draining a busy FIFO finalizes every durable event."""
     from gateway.run import GatewayRunner
     from gateway.session import SessionSource
     from plugins.platforms.telegram.adapter import TelegramAdapter
@@ -397,7 +397,28 @@ async def test_durable_busy_fifo_waits_for_its_own_processing_completion(tmp_pat
         turn=SimpleNamespace(agent=None, busy_ack_ts=0, started_ts=0),
     )
     owner_release = asyncio.Event()
-    owner_task = asyncio.create_task(owner_release.wait())
+    drained_events = []
+
+    async def drain_owner():
+        await owner_release.wait()
+        while runner._queue_depth(session_key, adapter=adapter):
+            queued_event = _dequeue_pending_event(adapter, session_key)
+            queued_event = runner._promote_queued_event(
+                session_key, adapter, queued_event
+            )
+            if queued_event is None:
+                break
+            drained_events.append(queued_event)
+            await asyncio.sleep(0)
+        current_task = asyncio.current_task()
+        assert current_task is not None
+        setattr(
+            current_task,
+            "_telegram_processing_outcome",
+            ProcessingOutcome.SUCCESS,
+        )
+
+    owner_task = asyncio.create_task(drain_owner())
     adapter._active_sessions = {session_key: asyncio.Event()}
     adapter._session_tasks = {session_key: owner_task}
 
@@ -410,12 +431,12 @@ async def test_durable_busy_fifo_waits_for_its_own_processing_completion(tmp_pat
             actionable=True,
             update_kind="message",
             chat_id="7",
-            message_id=str(item["update_id"]),
+            message_id=str(item["message"]["message_id"]),
             session_key=session_key,
             payload=item,
         ),
         lease_owner="gateway:durable-fifo-fence",
-        active_limit=1,
+        active_limit=4,
     )
     adapter._inbound_queue = queue
 
@@ -424,93 +445,78 @@ async def test_durable_busy_fifo_waits_for_its_own_processing_completion(tmp_pat
     runner._peek_session_state = lambda _session_key: state
     runner._session_state = lambda _session_key: state
     runner._is_user_authorized = lambda _source: True
-    runner._effective_busy_input_mode = lambda _source: "queue"
-    runner._effective_busy_text_mode = lambda _source: "queue"
+    runner._effective_busy_input_mode = lambda source: "steer"
+    runner._effective_busy_text_mode = lambda source: "steer"
     runner._agent_has_active_subagents = lambda _agent: False
 
     async def no_compression(_session_key):
         return False
 
     runner._session_has_compression_in_flight = no_compression
-    busy_finished = asyncio.Event()
-    actual_busy_handler = runner._handle_active_session_busy_message
-
-    async def busy_handler(event, key):
-        result = await actual_busy_handler(event, key)
-        busy_finished.set()
-        return result
-
     adapter._message_handler = runner._handle_message
-    adapter._busy_session_handler = busy_handler
+    adapter._busy_session_handler = runner._handle_active_session_busy_message
 
-    update_id = 9003
-    payload_data = {
-        "update_id": update_id,
-        "message": {"message_id": update_id, "chat": {"id": 7}},
-    }
-    await queue.put(payload_data)
-    await queue.get()
-    claim = queue.claim_for_update(update_id)
-    assert claim is not None
-    queue.task_done()
+    update_ids = [9101, 9102, 9103, 9104]
+    message_ids = [8101, 8102, 8103, 8104]
+    texts = ["first", "identical", "identical", "fourth"]
+    events = []
+    claims = []
+    for update_id, message_id, text in zip(update_ids, message_ids, texts):
+        payload_data = {
+            "update_id": update_id,
+            "message": {"message_id": message_id, "chat": {"id": 7}},
+        }
+        await queue.put(payload_data)
+        await queue.get()
+        claim = queue.claim_for_update(update_id)
+        assert claim is not None
+        queue.task_done()
+        claims.append(claim)
+        events.append(
+            MessageEvent(
+                text=text,
+                message_type=MessageType.TEXT,
+                source=source,
+                raw_message=claim,
+                message_id=str(message_id),
+                platform_update_id=update_id,
+                metadata={
+                    "telegram_inbound_claimed": True,
+                    "telegram_durable_update_ids": [update_id],
+                    "gateway_session_key": session_key,
+                },
+                allow_gateway_control=False,
+            )
+        )
 
-    event = MessageEvent(
-        text="durable",
-        message_type=MessageType.DOCUMENT,
-        source=source,
-        raw_message=claim,
-        message_id="79",
-        platform_update_id=update_id,
-        metadata={
-            "telegram_inbound_claimed": True,
-            "telegram_durable_update_ids": [update_id],
-            "gateway_session_key": session_key,
-        },
-        allow_gateway_control=False,
-    )
-
-    dispatch_task = asyncio.create_task(
-        adapter._dispatch_and_complete_durable_event(event)
-    )
     try:
-        await asyncio.wait_for(busy_finished.wait(), timeout=1.0)
-        assert runner._queue_depth(session_key, adapter=adapter) == 1
-        await asyncio.wait_for(dispatch_task, timeout=1.0)
-        row = store.get(claim.event_id)
-        assert row is not None
-        assert row.work_state == "leased"
-        assert row.consumed_at is None
+        for event in events:
+            await adapter._dispatch_and_complete_durable_event(event)
+        assert runner._queue_depth(session_key, adapter=adapter) == 4
+        for claim in claims:
+            row = store.get(claim.event_id)
+            assert row is not None
+            assert row.work_state == "leased"
+            assert row.consumed_at is None
 
         owner_release.set()
         await asyncio.wait_for(owner_task, timeout=1.0)
-        await asyncio.sleep(0.05)
-
-        # The owner finishing only proves that the preceding turn ended. The
-        # durable event remains in the inherited FIFO until its own lifecycle
-        # hook runs, so its SQLite claim must still be leased here.
-        assert dispatch_task.done()
-        row = store.get(claim.event_id)
-        assert row is not None
-        assert row.work_state == "leased"
-        assert row.consumed_at is None
-
-        await adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
-        completion = getattr(event, "_telegram_durable_completion_task", None)
-        assert completion is not None
-        await asyncio.wait_for(asyncio.shield(completion), timeout=1.0)
+        await asyncio.wait_for(queue._wait_for_lifecycle_tasks(), timeout=1.0)
     finally:
         if not owner_task.done():
             owner_release.set()
             await owner_task
-        if not dispatch_task.done():
-            dispatch_task.cancel()
-            with pytest.raises(asyncio.CancelledError):
-                await dispatch_task
 
-    row = store.get(claim.event_id)
-    assert row is not None
-    assert row.work_state == "consumed"
-    assert row.consumed_at is not None
+    assert [event.platform_update_id for event in drained_events] == update_ids
+    assert [event.message_id for event in drained_events] == [
+        str(message_id) for message_id in message_ids
+    ]
+    assert drained_events[1].text == drained_events[2].text == "identical"
+    for claim in claims:
+        row = store.get(claim.event_id)
+        assert row is not None
+        assert row.work_state == "consumed"
+        assert row.consumed_at is not None
 
 
 @pytest.mark.asyncio
@@ -747,7 +753,24 @@ async def test_concurrent_durable_busy_cap_admission_is_replayable(tmp_path, mon
         turn=SimpleNamespace(agent=None, busy_ack_ts=0, started_ts=0),
     )
     owner_release = asyncio.Event()
-    owner_task = asyncio.create_task(owner_release.wait())
+    event_to_cancel = []
+
+    async def cancel_after_draining_event():
+        await owner_release.wait()
+        assert len(event_to_cancel) == 1
+        assert adapter._remove_durable_event_from_gateway_fifo(
+            event_to_cancel[0], ordinary_key
+        )
+        current_task = asyncio.current_task()
+        assert current_task is not None
+        setattr(
+            current_task,
+            "_telegram_processing_outcome",
+            ProcessingOutcome.CANCELLED,
+        )
+        raise asyncio.CancelledError
+
+    owner_task = asyncio.create_task(cancel_after_draining_event())
 
     adapter._active_sessions = {ordinary_key: asyncio.Event()}
     adapter._session_tasks = {ordinary_key: owner_task}
@@ -847,6 +870,7 @@ async def test_concurrent_durable_busy_cap_admission_is_replayable(tmp_path, mon
         )
 
     events = [durable_event(update_id, claim) for update_id, claim in zip(update_ids, claims)]
+    event_to_cancel.append(events[0])
     dispatch_tasks = [
         asyncio.create_task(adapter._dispatch_and_complete_durable_event(event))
         for event in events
@@ -856,30 +880,19 @@ async def test_concurrent_durable_busy_cap_admission_is_replayable(tmp_path, mon
     # the serialized second caller one scheduling turn to observe the full cap.
     await asyncio.sleep(0)
     owner_release.set()
-    await asyncio.wait_for(owner_task, timeout=1.0)
-    await asyncio.sleep(0.05)
-
-    # The first durable event was admitted below the ordinary cap and is now
-    # staged in the inherited FIFO. It cannot be consumed until its own
-    # processing lifecycle reports success.
-    first_row = store.get("telegram:111:9301")
-    assert first_row is not None
-    assert first_row.work_state == "leased"
-    assert first_row.consumed_at is None
-    await adapter.on_processing_complete(events[0], ProcessingOutcome.SUCCESS)
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(owner_task, timeout=1.0)
     await asyncio.gather(*dispatch_tasks)
-    completion = getattr(events[0], "_telegram_durable_completion_task", None)
-    assert completion is not None
-    await asyncio.wait_for(asyncio.shield(completion), timeout=1.0)
+    await asyncio.wait_for(queue._wait_for_lifecycle_tasks(), timeout=1.0)
 
+    # The admitted durable event left the FIFO under an owner that reported
+    # cancellation. It and the concurrent cap rejection must both be replayable.
     rows = [store.get(f"telegram:111:{update_id}") for update_id in update_ids]
     assert all(row is not None for row in rows)
-    assert sorted(row.work_state for row in rows) == ["consumed", "queued"]
-    replayable_id = next(update_id for update_id, row in zip(update_ids, rows) if row.work_state == "queued")
-    replayable_row = store.get(f"telegram:111:{replayable_id}")
-    assert replayable_row.dispatch_state == "pending"
-    assert replayable_row.consumed_at is None
-    assert queue.claim_for_update(replayable_id) is None
+    assert [row.work_state for row in rows] == ["queued", "queued"]
+    assert all(row.dispatch_state == "pending" for row in rows)
+    assert all(row.consumed_at is None for row in rows)
+    assert all(queue.claim_for_update(update_id) is None for update_id in update_ids)
 
     queued_events = list(state.conversation.queued_events)
     pending = adapter._pending_messages.get(ordinary_key)
@@ -891,8 +904,8 @@ async def test_concurrent_durable_busy_cap_admission_is_replayable(tmp_path, mon
             "telegram_durable_update_ids", []
         )
     }
-    assert replayable_id not in volatile_ids
-    assert runner._queue_depth(ordinary_key, adapter=adapter) == 32
+    assert not volatile_ids.intersection(update_ids)
+    assert runner._queue_depth(ordinary_key, adapter=adapter) == 31
 
     if not owner_task.done():
         owner_task.cancel()

--- a/tests/gateway/test_queue_consumption.py
+++ b/tests/gateway/test_queue_consumption.py
@@ -520,12 +520,14 @@ async def test_durable_busy_fifo_consumes_each_in_band_event(tmp_path, monkeypat
 
 
 @pytest.mark.asyncio
-async def test_durable_busy_steer_is_queued_until_it_has_its_own_processing_lifecycle(
+async def test_durable_busy_steer_is_retained_until_active_turn_completes(
+    tmp_path,
     monkeypatch,
 ):
-    """A durable event must not be detached by an unreceipted steer accept."""
+    """A durable plain-text follow-up steers and stays leased until turn success."""
     from gateway.run import GatewayRunner
     from gateway.session import SessionSource
+    from plugins.platforms.telegram.adapter import TelegramAdapter
 
     monkeypatch.setenv("HERMES_GATEWAY_BUSY_ACK_ENABLED", "false")
 
@@ -540,13 +542,18 @@ async def test_durable_busy_steer_is_queued_until_it_has_its_own_processing_life
     runner = GatewayRunner.__new__(GatewayRunner)
     runner._queued_events = {}
     runner._draining = False
-    adapter = _StubAdapter()
+    adapter = object.__new__(TelegramAdapter)
+    BasePlatformAdapter.__init__(
+        adapter,
+        PlatformConfig(enabled=True, token="111:test-token", extra={}),
+        Platform.TELEGRAM,
+    )
     runner.adapters = {Platform.TELEGRAM: adapter}
 
-    session_key = "agent:main:telegram:dm:durable-steer-fence"
+    session_key = "agent:main:telegram:dm:durable-steer"
     source = SessionSource(
         platform=Platform.TELEGRAM,
-        chat_id="durable-steer-fence",
+        chat_id="durable-steer",
         chat_type="dm",
         user_id="7",
         user_name="tester",
@@ -556,7 +563,35 @@ async def test_durable_busy_steer_is_queued_until_it_has_its_own_processing_life
         conversation=SimpleNamespace(queued_events=[]),
         turn=SimpleNamespace(agent=agent, busy_ack_ts=0, started_ts=0),
     )
+    owner_release = asyncio.Event()
+
+    async def active_turn_owner():
+        await owner_release.wait()
+        owner = asyncio.current_task()
+        assert owner is not None
+        setattr(owner, "_telegram_processing_outcome", ProcessingOutcome.SUCCESS)
+
+    owner_task = asyncio.create_task(active_turn_owner())
     adapter._active_sessions = {session_key: asyncio.Event()}
+    adapter._session_tasks = {session_key: owner_task}
+
+    store = TelegramInboundStore(tmp_path / "telegram_inbound.db")
+    queue = DurableTelegramUpdateQueue(
+        store=store,
+        bot_account_id=111,
+        classifier=lambda item: CaptureDecision(
+            actionable=True,
+            update_kind="message",
+            chat_id="7",
+            message_id=str(item["update_id"]),
+            session_key=session_key,
+            payload=item,
+        ),
+        lease_owner="gateway:durable-steer",
+        active_limit=1,
+    )
+    adapter._inbound_store = store
+    adapter._inbound_queue = queue
 
     runner._adapter_for_source = lambda _source: adapter
     runner._peek_session_state = lambda _session_key: state
@@ -570,26 +605,57 @@ async def test_durable_busy_steer_is_queued_until_it_has_its_own_processing_life
         return False
 
     runner._session_has_compression_in_flight = no_compression
+    adapter._message_handler = runner._handle_message
+    adapter._busy_session_handler = runner._handle_active_session_busy_message
+
+    update_id = 9004
+    payload = {
+        "update_id": update_id,
+        "message": {"message_id": update_id, "chat": {"id": 7}},
+    }
+    await queue.put(payload)
+    await queue.get()
+    claim = queue.claim_for_update(update_id)
+    assert claim is not None
+    queue.task_done()
 
     event = MessageEvent(
         text="durable correction",
         message_type=MessageType.TEXT,
         source=source,
+        raw_message=claim,
         message_id="80",
-        platform_update_id=9004,
+        platform_update_id=update_id,
         metadata={
             "telegram_inbound_claimed": True,
-            "telegram_durable_update_ids": [9004],
+            "telegram_durable_update_ids": [update_id],
             "gateway_session_key": session_key,
         },
     )
 
-    handled = await runner._handle_active_session_busy_message(event, session_key)
+    try:
+        await adapter._dispatch_and_complete_durable_event(event)
 
-    assert handled is True
-    assert agent.steer_calls == []
-    assert runner._queue_depth(session_key, adapter=adapter) == 1
-    assert adapter._pending_messages[session_key] is event
+        assert agent.steer_calls == ["durable correction"]
+        assert runner._queue_depth(session_key, adapter=adapter) == 0
+        row = store.get(claim.event_id)
+        assert row is not None
+        assert row.work_state == "leased"
+        assert row.consumed_at is None
+
+        owner_release.set()
+        await asyncio.wait_for(owner_task, timeout=1.0)
+        await asyncio.wait_for(queue._wait_for_lifecycle_tasks(), timeout=1.0)
+    finally:
+        if not owner_task.done():
+            owner_release.set()
+            await owner_task
+        await queue.close()
+
+    row = store.get(claim.event_id)
+    assert row is not None
+    assert row.work_state == "consumed"
+    assert row.consumed_at is not None
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_telegram_handler_dedup.py
+++ b/tests/gateway/test_telegram_handler_dedup.py
@@ -1,0 +1,1447 @@
+"""Behavioral duplicate-delivery tests for registered Telegram handlers."""
+
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    ProcessingOutcome,
+)
+from plugins.platforms.telegram import adapter as telegram_module
+from plugins.platforms.telegram.adapter import TelegramAdapter
+
+
+class _RecordingApp:
+    def __init__(self):
+        self.handlers = []
+
+    def add_handler(self, handler, group=0):
+        self.handlers.append((handler, group))
+
+
+class _RegisteredHandler:
+    """Small PTB handler stand-in that retains the registered callback."""
+
+    def __init__(self, *args):
+        self.callback = args[-1]
+
+
+def _message(*, message_id=10, text=None, location=None, photo=None, chat_type="private"):
+    chat = SimpleNamespace(id=123, type=chat_type, is_forum=False)
+    sender = SimpleNamespace(id=456, is_bot=False, username="sender", first_name="Sender")
+    return SimpleNamespace(
+        message_id=message_id,
+        text=text,
+        caption=None,
+        chat=chat,
+        from_user=sender,
+        sender_chat=None,
+        date=None,
+        edit_date=None,
+        message_thread_id=None,
+        is_topic_message=False,
+        location=location,
+        venue=None,
+        photo=photo,
+        video=None,
+        audio=None,
+        voice=None,
+        document=None,
+        sticker=None,
+        media_group_id=None,
+        entities=None,
+        caption_entities=None,
+        reply_to_message=None,
+        quote=None,
+        reply_markup=None,
+    )
+
+
+def _update(update_id, message, *, effective_message=None, channel_post=None, edited_channel_post=None):
+    if effective_message is None:
+        effective_message = message
+    return SimpleNamespace(
+        update_id=update_id,
+        message=message,
+        effective_message=effective_message,
+        callback_query=None,
+        channel_post=channel_post,
+        edited_channel_post=edited_channel_post,
+    )
+
+
+def _event_for(message, message_type, update_id=None):
+    return SimpleNamespace(
+        text=message.text or message.caption or "",
+        message_type=message_type,
+        source=SimpleNamespace(
+            platform=Platform.TELEGRAM,
+            chat_id=str(message.chat.id),
+            user_id=str(message.from_user.id),
+            chat_type="dm",
+            profile=None,
+            thread_id=None,
+            scope_id=None,
+            user_id_alt=None,
+            prospective_thread_id=None,
+        ),
+        message_id=str(message.message_id),
+        media_urls=[],
+        media_types=[],
+        platform_update_id=update_id,
+        metadata={"telegram_durable_update_ids": [update_id]},
+    )
+
+
+@pytest.fixture
+def registered_handler_fixture(monkeypatch):
+    if not telegram_module.TELEGRAM_AVAILABLE:
+        pytest.skip("python-telegram-bot is not installed")
+
+    adapter = object.__new__(TelegramAdapter)
+    adapter.config = PlatformConfig(enabled=True, token="test", extra={})
+    adapter._seen_update_ids = {}
+    adapter._seen_update_ids_max = 4096
+    adapter._seen_platform_update_ids = {}
+    adapter._mention_patterns = []
+    adapter._forum_lock = __import__("asyncio").Lock()
+    adapter._forum_command_registered = set()
+    adapter._pending_text_batches = {}
+    adapter._pending_text_batch_tasks = {}
+    adapter._pending_photo_batches = {}
+    adapter._pending_photo_batch_tasks = {}
+    adapter._active_sessions = {}
+    adapter._pending_messages = {}
+    adapter._drop_delayed_deliveries = False
+
+    enqueue_text = []
+    enqueue_photo = []
+    observed = []
+    dispatched = []
+    adapter._is_user_authorized_from_message = lambda _message: True
+    adapter._should_process_message = lambda *_args, **_kwargs: True
+    adapter._should_observe_unmentioned_group_message = lambda _message: True
+    adapter._observe_unmentioned_group_message = lambda *args, **kwargs: observed.append((args, kwargs))
+    adapter._ensure_forum_commands = AsyncMock()
+    adapter._build_message_event = _event_for
+    adapter._clean_bot_trigger_text = lambda text: text
+    adapter._cache_replied_media = AsyncMock()
+    adapter._apply_telegram_group_observe_attribution = lambda event: event
+    adapter._enqueue_text_event = enqueue_text.append
+    adapter._enqueue_photo_event = lambda key, event: enqueue_photo.append((key, event))
+    adapter._photo_batch_key = lambda event, message: "telegram:photos"
+    adapter._should_drop_delayed_delivery = lambda: False
+    adapter._media_message_type = lambda _message: MessageType.PHOTO
+    adapter._cache_observed_media = AsyncMock()
+    adapter._surface_media_cache_failure = AsyncMock()
+    adapter._handle_sticker = AsyncMock()
+
+    monkeypatch.setattr(telegram_module, "TelegramMessageHandler", _RegisteredHandler)
+    monkeypatch.setattr(telegram_module, "CallbackQueryHandler", _RegisteredHandler)
+    monkeypatch.setattr(telegram_module, "TypeHandler", _RegisteredHandler)
+
+    async def dispatch(event):
+        dispatched.append(event)
+
+    adapter.handle_message = dispatch
+
+    app = _RecordingApp()
+    adapter._register_handlers(app)
+    callbacks = {
+        handler.callback.__name__: handler.callback
+        for handler, _group in app.handlers
+        if getattr(handler, "callback", None) is not None
+        and hasattr(handler.callback, "__name__")
+    }
+    return SimpleNamespace(
+        adapter=adapter,
+        callbacks=callbacks,
+        enqueue_text=enqueue_text,
+        enqueue_photo=enqueue_photo,
+        observed=observed,
+        dispatched=dispatched,
+    )
+
+
+async def _make_durable_dispatch_harness(
+    tmp_path, update_id, process, *, update_kind="message"
+):
+    from plugins.platforms.telegram.inbound_store import (
+        CaptureDecision,
+        DurableTelegramUpdateQueue,
+        TelegramInboundStore,
+    )
+
+    session_key = "agent:main:telegram:dm:123"
+    payload = {
+        "update_id": update_id,
+        "message": {
+            "message_id": update_id,
+            "date": 1,
+            "chat": {"id": 123, "type": "private"},
+            "from": {"id": 456, "is_bot": False, "first_name": "Sender"},
+            "text": "durable test",
+        },
+    }
+    store = TelegramInboundStore(tmp_path / "telegram_inbound.db")
+
+    def classify(item):
+        return CaptureDecision(
+            actionable=True,
+            account_id="telegram",
+            update_kind=update_kind,
+            chat_id="123",
+            message_id=str(item["message"]["message_id"]),
+            session_key=session_key,
+            payload=item,
+        )
+
+    queue = DurableTelegramUpdateQueue(
+        store=store,
+        bot_account_id=111,
+        classifier=classify,
+        lease_owner=f"gateway:durable-test-{update_id}",
+        active_limit=1,
+    )
+    await queue.put(payload)
+    queued = await queue.get()
+    assert queued["update_id"] == update_id
+    claim = queue.claim_for_update(update_id)
+    assert claim is not None
+    queue.task_done()
+
+    adapter = TelegramAdapter.__new__(TelegramAdapter)
+    BasePlatformAdapter.__init__(
+        adapter,
+        PlatformConfig(enabled=True, token="111:test-token", extra={}),
+        Platform.TELEGRAM,
+    )
+    adapter.config.typing_indicator = False
+    adapter._bot = SimpleNamespace(id=111)
+    adapter._inbound_queue = queue
+    adapter._message_handler = process
+    adapter.send = AsyncMock()
+    source = SimpleNamespace(
+        platform=Platform.TELEGRAM,
+        chat_id="123",
+        user_id="456",
+        chat_type="dm",
+        profile=None,
+        thread_id=None,
+        scope_id=None,
+        user_id_alt=None,
+        prospective_thread_id=None,
+    )
+    event = MessageEvent(
+        text="durable test",
+        message_type=MessageType.TEXT,
+        source=source,
+        raw_message=claim,
+        message_id=str(update_id),
+        platform_update_id=update_id,
+        metadata={
+            "telegram_durable_update_ids": [update_id],
+            "gateway_session_key": session_key,
+        },
+    )
+    return adapter, queue, store, event
+
+
+@pytest.mark.asyncio
+async def test_registered_text_handler_deduplicates_before_enqueue_or_observe(
+    registered_handler_fixture,
+):
+    fixture = registered_handler_fixture
+    callback = fixture.callbacks["_handle_text_message"]
+    update = _update(1001, _message(text="hello"))
+
+    await callback(update, None)
+    await callback(update, None)
+
+    assert len(fixture.enqueue_text) == 1
+    assert fixture.observed == []
+    assert fixture.dispatched == []
+
+
+@pytest.mark.asyncio
+async def test_registered_command_handler_deduplicates_immediate_dispatch(
+    registered_handler_fixture,
+):
+    fixture = registered_handler_fixture
+    callback = fixture.callbacks["_handle_command"]
+    update = _update(1002, _message(text="/stop"))
+
+    await callback(update, None)
+    await callback(update, None)
+
+    assert len(fixture.dispatched) == 1
+    assert fixture.enqueue_text == []
+    assert fixture.observed == []
+
+
+@pytest.mark.asyncio
+async def test_registered_location_handler_deduplicates_dispatch(
+    registered_handler_fixture,
+):
+    fixture = registered_handler_fixture
+    callback = fixture.callbacks["_handle_location_message"]
+    location = SimpleNamespace(latitude=34.7, longitude=-86.6)
+    update = _update(1003, _message(location=location))
+
+    await callback(update, None)
+    await callback(update, None)
+
+    assert len(fixture.dispatched) == 1
+    assert fixture.enqueue_text == []
+    assert fixture.observed == []
+
+
+@pytest.mark.asyncio
+async def test_registered_media_handler_deduplicates_before_download_and_enqueue(
+    registered_handler_fixture, monkeypatch
+):
+    fixture = registered_handler_fixture
+    callback = fixture.callbacks["_handle_media_message"]
+    calls = {"get_file": 0, "download": 0, "cache": 0}
+
+    class FakeFile:
+        file_path = "photo.jpg"
+
+        async def download_as_bytearray(self):
+            calls["download"] += 1
+            return bytearray(b"image")
+
+    class FakePhoto:
+        async def get_file(self):
+            calls["get_file"] += 1
+            return FakeFile()
+
+    async def cache_image(data, *, ext):
+        calls["cache"] += 1
+        assert data == b"image"
+        assert ext == ".jpg"
+        return "/tmp/telegram-test.jpg"
+
+    monkeypatch.setattr(telegram_module, "cache_image_from_bytes_async", cache_image)
+    update = _update(1004, _message(photo=[FakePhoto()]))
+
+    await callback(update, None)
+    await callback(update, None)
+
+    assert calls == {"get_file": 1, "download": 1, "cache": 1}
+    assert len(fixture.enqueue_photo) == 1
+    assert fixture.observed == []
+    assert fixture.dispatched == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("update_field", ["channel_post", "edited_channel_post"])
+async def test_registered_media_handler_uses_effective_channel_message(
+    registered_handler_fixture, monkeypatch, update_field
+):
+    fixture = registered_handler_fixture
+    callback = fixture.callbacks["_handle_media_message"]
+    calls = {"get_file": 0, "download": 0, "cache": 0}
+
+    class FakeFile:
+        file_path = "photo.jpg"
+
+        async def download_as_bytearray(self):
+            calls["download"] += 1
+            return bytearray(b"image")
+
+    class FakePhoto:
+        async def get_file(self):
+            calls["get_file"] += 1
+            return FakeFile()
+
+    async def cache_image(data, *, ext):
+        calls["cache"] += 1
+        assert data == b"image"
+        assert ext == ".jpg"
+        return "/tmp/telegram-effective-media.jpg"
+
+    monkeypatch.setattr(telegram_module, "cache_image_from_bytes_async", cache_image)
+    message = _message(message_id=1010, photo=[FakePhoto()])
+    update = _update(1010, None, effective_message=message, **{update_field: message})
+
+    await callback(update, None)
+
+    assert calls == {"get_file": 1, "download": 1, "cache": 1}
+    assert len(fixture.enqueue_photo) == 1
+    assert fixture.dispatched == []
+
+
+@pytest.mark.asyncio
+async def test_observation_path_evaluates_should_process_false_without_forced_processing(
+    registered_handler_fixture,
+):
+    fixture = registered_handler_fixture
+    fixture.adapter._should_process_message = lambda *_args, **_kwargs: False
+    callback = fixture.callbacks["_handle_text_message"]
+
+    await callback(_update(1011, _message(text="unmentioned", chat_type="group")), None)
+
+    assert len(fixture.observed) == 1
+    assert fixture.enqueue_text == []
+    assert fixture.dispatched == []
+
+
+@pytest.mark.asyncio
+async def test_registered_text_handler_keeps_equal_text_with_distinct_update_ids(
+    registered_handler_fixture,
+):
+    fixture = registered_handler_fixture
+    callback = fixture.callbacks["_handle_text_message"]
+
+    await callback(_update(1005, _message(text="same")), None)
+    await callback(_update(1006, _message(text="same")), None)
+
+    assert len(fixture.enqueue_text) == 2
+    assert fixture.observed == []
+    assert fixture.dispatched == []
+
+
+@pytest.mark.asyncio
+async def test_registered_handler_failure_allows_durable_replay_after_requeue(
+    registered_handler_fixture,
+):
+    fixture = registered_handler_fixture
+    callback = fixture.callbacks["_handle_text_message"]
+    update = _update(1007, _message(text="retry"))
+
+    def fail_once(_event):
+        raise RuntimeError("transient handler failure")
+
+    fixture.adapter._enqueue_text_event = fail_once
+    with pytest.raises(RuntimeError, match="transient handler failure"):
+        await callback(update, None)
+
+    fixture.adapter._enqueue_text_event = fixture.enqueue_text.append
+    await callback(update, None)
+
+    assert len(fixture.enqueue_text) == 1
+
+
+@pytest.mark.asyncio
+async def test_inflight_durable_claim_blocks_replay_after_local_cache_eviction(
+    registered_handler_fixture,
+):
+    fixture = registered_handler_fixture
+    callback = fixture.callbacks["_handle_text_message"]
+    update = _update(1008, _message(text="in flight"))
+    fixture.adapter._inbound_queue = SimpleNamespace(
+        handler_claimed=lambda _update_id: True,
+        mark_handler_claim=lambda _update_id: None,
+    )
+
+    await callback(update, None)
+
+    assert fixture.enqueue_text == []
+
+
+@pytest.mark.asyncio
+async def test_delayed_text_does_not_complete_durable_claim_before_dispatch(
+    registered_handler_fixture,
+):
+    fixture = registered_handler_fixture
+    adapter = fixture.adapter
+    callback = fixture.callbacks["_handle_text_message"]
+    completed = []
+
+    class Queue:
+        def handler_claimed(self, _update_id):
+            return False
+
+        def mark_handler_claim(self, update_id):
+            return SimpleNamespace(event_id=f"telegram:111:{update_id}", update_kind="message")
+
+        async def complete_update(self, update_id, *, success):
+            completed.append((update_id, success))
+            return True
+
+    adapter._inbound_queue = Queue()
+    adapter._enqueue_text_event = TelegramAdapter._enqueue_text_event.__get__(adapter)
+    adapter._text_batch_delay_seconds = 60.0
+    update = _update(1012, _message(text="delayed"))
+
+    await callback(update, None)
+
+    assert completed == []
+    assert 1012 in adapter._deferred_inbound_update_ids
+
+    key = next(iter(adapter._pending_text_batch_tasks))
+    pending_task = adapter._pending_text_batch_tasks.pop(key)
+    pending_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await pending_task
+    adapter._text_batch_delay_seconds = 0.0
+    await adapter._flush_text_batch(key)
+    await asyncio.gather(*tuple(adapter._durable_batch_dispatch_tasks))
+
+    assert completed == [(1012, True)]
+    assert 1012 not in adapter._deferred_inbound_update_ids
+
+
+@pytest.mark.asyncio
+async def test_durable_dispatch_returns_before_inherited_background_processing():
+    """PTB admission returns promptly; durable completion follows the task boundary."""
+    started = asyncio.Event()
+    release = asyncio.Event()
+    processed = []
+    completed = []
+
+    class Queue:
+        async def complete_update(self, update_id, *, success):
+            completed.append((update_id, success, bool(processed)))
+            return True
+
+    class InheritedDispatchAdapter(TelegramAdapter):
+        def __init__(self):
+            BasePlatformAdapter.__init__(
+                self,
+                PlatformConfig(enabled=True, token="test", extra={}),
+                Platform.TELEGRAM,
+            )
+            self.config.typing_indicator = False
+            self._bot = SimpleNamespace(id=999)
+            self._inbound_queue = Queue()
+
+            async def process(event):
+                processed.append(event)
+                started.set()
+                await release.wait()
+                return None
+
+            self._message_handler = process
+
+    adapter = InheritedDispatchAdapter()
+    source = SimpleNamespace(
+        platform=Platform.TELEGRAM,
+        chat_id="123",
+        user_id="456",
+        chat_type="dm",
+        profile=None,
+        thread_id=None,
+        scope_id=None,
+        user_id_alt=None,
+        prospective_thread_id=None,
+    )
+    event = MessageEvent(
+        text="durable background work",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="durable-1016",
+        platform_update_id=1016,
+        metadata={"telegram_durable_update_ids": [1016]},
+    )
+
+    dispatch_task = asyncio.create_task(
+        adapter._dispatch_and_complete_durable_event(event)
+    )
+    try:
+        await asyncio.wait_for(started.wait(), timeout=1.0)
+        assert processed == [event]
+        await asyncio.wait_for(asyncio.shield(dispatch_task), timeout=0.2)
+        assert completed == []
+    finally:
+        release.set()
+
+    for _ in range(50):
+        if completed:
+            break
+        await asyncio.sleep(0.01)
+
+    assert completed == [(1016, True, True)]
+
+
+@pytest.mark.asyncio
+async def test_cancelling_batch_timer_does_not_cancel_started_durable_dispatch():
+    """A new batch window must not cancel the prior event after dispatch starts."""
+    adapter = object.__new__(TelegramAdapter)
+    event = SimpleNamespace(text="one", metadata={"telegram_durable_update_ids": [1016]})
+    adapter._pending_text_batches = {"session": event}
+    adapter._pending_text_batch_tasks = {}
+    adapter._text_batch_delay_seconds = 0.0
+    adapter._text_batch_split_delay_seconds = 0.0
+    adapter._should_drop_delayed_delivery = lambda: False
+    adapter._hold_inbound_event = lambda _event, **_kwargs: None
+    started = asyncio.Event()
+    release = asyncio.Event()
+    completed = []
+
+    async def dispatch(dispatched):
+        started.set()
+        await release.wait()
+        completed.append(dispatched)
+
+    adapter._dispatch_and_complete_durable_event = dispatch
+    flush = asyncio.create_task(adapter._flush_text_batch("session"))
+    try:
+        await asyncio.wait_for(started.wait(), timeout=0.5)
+        flush.cancel()
+        await asyncio.gather(flush, return_exceptions=True)
+        release.set()
+        for _ in range(50):
+            if completed:
+                break
+            await asyncio.sleep(0.01)
+        assert completed == [event]
+    finally:
+        release.set()
+        if not flush.done():
+            flush.cancel()
+            await asyncio.gather(flush, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_teardown_cancels_and_holds_started_durable_batch_dispatch():
+    """Teardown must await detached durable dispatch before returning."""
+    adapter = object.__new__(TelegramAdapter)
+    event = SimpleNamespace(
+        text="one",
+        metadata={"telegram_durable_update_ids": [1017]},
+    )
+    adapter._inbound_queue = SimpleNamespace(_lifecycle_retired=False)
+    adapter._media_group_tasks = {}
+    adapter._media_group_events = {}
+    adapter._pending_photo_batch_tasks = {}
+    adapter._pending_photo_batches = {}
+    adapter._pending_text_batch_tasks = {}
+    adapter._pending_text_batches = {}
+    adapter._polling_error_task = None
+    adapter._polling_progress_verifier_task = None
+    adapter._held_inbound_redispatch_task = None
+    adapter._drop_delayed_deliveries = True
+    adapter._is_permanent_fatal = lambda: False
+    adapter._inbound_queue_handoff_target = lambda: None
+    adapter._mark_durable_event_active = lambda _event: True
+    adapter._inbound_session_key = lambda _event: "session"
+    adapter._remove_durable_event_from_gateway_fifo = lambda *_args: False
+    held = []
+    adapter._hold_inbound_event = lambda held_event, *, where: held.append(
+        (held_event, where)
+    )
+    started = asyncio.Event()
+
+    async def dispatch(_event):
+        started.set()
+        await asyncio.Event().wait()
+
+    adapter._dispatch_inbound_event = dispatch
+    task = adapter._start_batched_durable_dispatch(event)
+    try:
+        await asyncio.wait_for(started.wait(), timeout=0.5)
+        await asyncio.wait_for(adapter._cancel_pending_delivery_tasks(), timeout=0.5)
+
+        assert task.done()
+        assert task.cancelled()
+        assert held == [(event, "durable-dispatch-cancelled")]
+        assert adapter._durable_batch_dispatch_tasks == set()
+    finally:
+        if not task.done():
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_durable_background_failure_requeues_claim(tmp_path):
+    """A contained BasePlatformAdapter failure must leave the row replayable."""
+    started = asyncio.Event()
+
+    async def process(_event):
+        started.set()
+        raise RuntimeError("background failure")
+
+    adapter, queue, store, event = await _make_durable_dispatch_harness(
+        tmp_path, 1017, process
+    )
+
+    await asyncio.wait_for(
+        adapter._dispatch_and_complete_durable_event(event), timeout=1.0
+    )
+    completion = getattr(event, "_telegram_durable_completion_task", None)
+    assert completion is not None
+    await asyncio.wait_for(asyncio.shield(completion), timeout=1.0)
+
+    assert started.is_set()
+    row = store.get("telegram:111:1017")
+    assert row is not None
+    assert row.work_state == "queued"
+    assert row.dispatch_state == "pending"
+    assert row.lease_owner is None
+    assert row.consumed_at is None
+    assert row.last_error_class == "handler_failed"
+    assert queue.claim_for_update(1017) is None
+
+
+@pytest.mark.asyncio
+async def test_plugin_handlers_are_durable_wrapped_before_core_process_update(
+    tmp_path, monkeypatch
+):
+    """PTB plugin precedence must not bypass the durable inbound wrapper."""
+    del tmp_path, monkeypatch
+    if not telegram_module.TELEGRAM_AVAILABLE:
+        pytest.skip("python-telegram-bot is not installed")
+
+    import json
+    import os
+    import sys
+    import textwrap
+
+    probe = textwrap.dedent(
+        """
+        import asyncio
+        import json
+        import sys
+        import tempfile
+        from pathlib import Path
+        from types import ModuleType, SimpleNamespace
+
+        class _Filter:
+            def __and__(self, _other):
+                return self
+
+            def __or__(self, _other):
+                return self
+
+            def __invert__(self):
+                return self
+
+        filter_value = _Filter()
+        filters = SimpleNamespace(
+            TEXT=filter_value,
+            COMMAND=filter_value,
+            LOCATION=filter_value,
+            VENUE=filter_value,
+            PHOTO=filter_value,
+            VIDEO=filter_value,
+            AUDIO=filter_value,
+            VOICE=filter_value,
+            Document=SimpleNamespace(ALL=filter_value),
+            Sticker=SimpleNamespace(ALL=filter_value),
+        )
+
+        class BaseHandler:
+            def __init__(self, *args):
+                self.callback = args[-1]
+
+            def check_update(self, _update):
+                return True
+
+        class MessageHandler(BaseHandler):
+            pass
+
+        class CallbackQueryHandler(BaseHandler):
+            pass
+
+        class InlineQueryHandler(BaseHandler):
+            pass
+
+        class TypeHandler(BaseHandler):
+            def check_update(self, _update):
+                return False
+
+        class ConversationHandler(BaseHandler):
+            pass
+
+        class Update:
+            ALL_TYPES = []
+
+            def __init__(self, update_id):
+                self.update_id = update_id
+
+            @classmethod
+            def de_json(cls, payload, _bot):
+                return cls(payload["update_id"])
+
+        class _ApplicationBuilder:
+            def token(self, _token):
+                return self
+
+            def build(self):
+                return Application()
+
+        class Application:
+            def __init__(self):
+                self.handlers = {}
+                self.bot = SimpleNamespace(id=111)
+                self._error_handler = None
+
+            @classmethod
+            def builder(cls):
+                return _ApplicationBuilder()
+
+            def add_handler(self, handler, group=0):
+                self.handlers.setdefault(group, []).append(handler)
+
+            def add_error_handler(self, callback):
+                self._error_handler = callback
+
+            async def process_update(self, update):
+                for group in sorted(self.handlers):
+                    for handler in self.handlers[group]:
+                        if not handler.check_update(update):
+                            continue
+                        try:
+                            await handler.callback(update, None)
+                        except BaseException as exc:
+                            if self._error_handler is None:
+                                raise
+                            await self._error_handler(
+                                update, SimpleNamespace(error=exc)
+                            )
+                        break
+
+        telegram_module = ModuleType("telegram")
+        telegram_module.__path__ = []
+        telegram_module.Update = Update
+        telegram_module.Bot = object
+        telegram_module.Message = object
+        telegram_module.InlineKeyboardButton = object
+        telegram_module.InlineKeyboardMarkup = object
+        telegram_module.LinkPreviewOptions = object
+
+        ext_module = ModuleType("telegram.ext")
+        ext_module.__path__ = []
+        ext_module.Application = Application
+        ext_module.CommandHandler = MessageHandler
+        ext_module.CallbackQueryHandler = CallbackQueryHandler
+        ext_module.InlineQueryHandler = InlineQueryHandler
+        ext_module.MessageHandler = MessageHandler
+        ext_module.ContextTypes = SimpleNamespace(DEFAULT_TYPE=object)
+        ext_module.TypeHandler = TypeHandler
+        ext_module.filters = filters
+
+        constants_module = ModuleType("telegram.constants")
+        constants_module.ParseMode = SimpleNamespace()
+        constants_module.ChatType = SimpleNamespace()
+        request_module = ModuleType("telegram.request")
+        request_module.HTTPXRequest = object
+        handlers_module = ModuleType("telegram.ext._handlers")
+        handlers_module.__path__ = []
+        base_module = ModuleType("telegram.ext._handlers.basehandler")
+        base_module.BaseHandler = BaseHandler
+        conversation_module = ModuleType(
+            "telegram.ext._handlers.conversationhandler"
+        )
+        conversation_module.ConversationHandler = ConversationHandler
+        sys.modules.update(
+            {
+                "telegram": telegram_module,
+                "telegram.ext": ext_module,
+                "telegram.constants": constants_module,
+                "telegram.request": request_module,
+                "telegram.ext._handlers": handlers_module,
+                "telegram.ext._handlers.basehandler": base_module,
+                "telegram.ext._handlers.conversationhandler": conversation_module,
+            }
+        )
+
+        from telegram import Update
+        from telegram.ext import Application, MessageHandler, filters
+
+        import hermes_cli.plugins as plugins_module
+        from gateway.config import Platform, PlatformConfig
+        from gateway.platforms.base import BasePlatformAdapter
+        from plugins.platforms.telegram.adapter import TelegramAdapter
+        from plugins.platforms.telegram.inbound_store import (
+            CaptureDecision,
+            DurableTelegramUpdateQueue,
+            TelegramInboundStore,
+        )
+
+        async def main():
+            with tempfile.TemporaryDirectory() as directory:
+                store = TelegramInboundStore(Path(directory) / "telegram.db")
+                payload = {
+                    "update_id": 1040,
+                    "message": {
+                        "message_id": 1040,
+                        "date": 1,
+                        "chat": {"id": 123, "type": "private"},
+                        "from": {"id": 456, "is_bot": False, "first_name": "Sender"},
+                        "text": "plugin dispatch",
+                    },
+                }
+
+                def classify(item):
+                    return CaptureDecision(
+                        actionable=True,
+                        account_id="telegram",
+                        update_kind="message",
+                        chat_id="123",
+                        message_id="1040",
+                        session_key="agent:main:telegram:dm:123",
+                        payload=item,
+                    )
+
+                queue = DurableTelegramUpdateQueue(
+                    store=store,
+                    bot_account_id=111,
+                    classifier=classify,
+                    lease_owner="gateway:plugin-probe",
+                    active_limit=1,
+                )
+                await queue.put(payload)
+                queued = await queue.get()
+                assert queued["update_id"] == 1040
+                assert queue.claim_for_update(1040) is not None
+                queue.task_done()
+
+                adapter = TelegramAdapter.__new__(TelegramAdapter)
+                BasePlatformAdapter.__init__(
+                    adapter,
+                    PlatformConfig(enabled=True, token="111:test-token", extra={}),
+                    Platform.TELEGRAM,
+                )
+                adapter.config.typing_indicator = False
+                adapter._inbound_queue = queue
+                adapter._bot_account_id = "111"
+                adapter._message_handler = lambda _event: None
+                plugin_calls = []
+                core_calls = []
+                factory_calls = []
+                errors = []
+
+                async def plugin_callback(update, _context):
+                    plugin_calls.append(update.update_id)
+
+                async def core_callback(update, _context):
+                    core_calls.append(update.update_id)
+
+                async def error_callback(_update, context):
+                    errors.append(f"{type(context.error).__name__}: {context.error}")
+
+                adapter._handle_text_message = core_callback
+                app = Application.builder().token("111:test-token").build()
+                app.add_error_handler(error_callback)
+                adapter._bot = app.bot
+
+                def factory(native, _adapter):
+                    factory_calls.append(type(native).__name__)
+                    assert type(native).__name__ == "_TelegramPluginApplicationProxy"
+                    native.add_handler(
+                        MessageHandler(filters.TEXT & ~filters.COMMAND, plugin_callback)
+                    )
+
+                class PluginManager:
+                    def get_platform_handler_factories(self, platform_name):
+                        assert platform_name == "telegram"
+                        return [(factory, "durable-plugin-test")]
+
+                plugins_module.get_plugin_manager = lambda: PluginManager()
+                adapter._wire_plugin_handlers(
+                    adapter._telegram_plugin_application_proxy(app)
+                )
+                adapter._register_handlers(app)
+                update = Update.de_json(payload, app.bot)
+                checks = [
+                    repr(handler.check_update(update))
+                    for handler in app.handlers.get(0, [])
+                ]
+                app._initialized = True
+                await app.process_update(update)
+                await app.process_update(update)
+
+                row = store.get("telegram:111:1040")
+                plugin_handler = app.handlers[0][0]
+                print(json.dumps({
+                    "plugin_calls": plugin_calls,
+                    "core_calls": core_calls,
+                    "factory_calls": factory_calls,
+                    "handler_types": [
+                        type(handler).__name__
+                        for handler in app.handlers.get(0, [])
+                    ],
+                    "handler_markers": [
+                        bool(getattr(handler.callback, "_hermes_telegram_durable_wrapper", False))
+                        for handler in app.handlers.get(0, [])
+                        if hasattr(handler, "callback")
+                    ],
+                    "checks": checks,
+                    "errors": errors,
+                    "work_state": row.work_state if row else None,
+                    "wrapped": (
+                        getattr(plugin_handler.callback, "__wrapped__", None)
+                        is plugin_callback
+                    ),
+                    "wrapped_once": adapter._wrap_inbound_handler(
+                        plugin_handler.callback
+                    ) is plugin_handler.callback,
+                }))
+
+        asyncio.run(main())
+        """
+    )
+    read_fd, write_fd = os.pipe()
+    child_pid = os.fork()
+    if child_pid == 0:  # pragma: no cover - the child runs a fresh interpreter
+        try:
+            os.close(read_fd)
+            os.dup2(write_fd, 1)
+            os.dup2(write_fd, 2)
+            os.close(write_fd)
+            os.execve(
+                sys.executable,
+                [sys.executable, "-c", probe],
+                os.environ.copy(),
+            )
+        finally:
+            os._exit(127)
+    os.close(write_fd)
+    _, wait_status = os.waitpid(child_pid, 0)
+    output = os.read(read_fd, 1 << 20).decode("utf-8", errors="replace")
+    os.close(read_fd)
+    return_code = os.waitstatus_to_exitcode(wait_status)
+    assert return_code == 0, output
+    result = json.loads(output.strip().splitlines()[-1])
+    assert result["plugin_calls"] == [1040]
+    assert result["core_calls"] == []
+    assert result["factory_calls"] == ["_TelegramPluginApplicationProxy"]
+    assert result["handler_types"][0] == "MessageHandler"
+    assert result["handler_markers"]
+    assert all(result["handler_markers"])
+    assert result["checks"][0] == "True"
+    assert result["errors"] == []
+    assert result["work_state"] == "consumed"
+    assert result["wrapped"] is True
+    assert result["wrapped_once"] is True
+
+
+@pytest.mark.asyncio
+async def test_transient_init_rebuild_rewires_plugin_handlers_through_durable_proxy(
+    tmp_path, monkeypatch
+):
+    """A rebuilt PTB application must not restore unwrapped plugin callbacks."""
+    if not telegram_module.TELEGRAM_AVAILABLE:
+        pytest.skip("python-telegram-bot is not installed")
+
+    adapter = TelegramAdapter(
+        PlatformConfig(enabled=True, token="111:test-token", extra={})
+    )
+    first_app = MagicMock()
+    first_app.bot = MagicMock()
+    first_app.initialize = MagicMock(side_effect=OSError("transient"))
+    rebuilt_app = MagicMock()
+    rebuilt_app.bot = MagicMock()
+    rebuilt_app.initialize = MagicMock(side_effect=RuntimeError("stop after rebuild"))
+
+    builder = MagicMock()
+    builder.token.return_value = builder
+    builder.request.return_value = builder
+    builder.get_updates_request.return_value = builder
+    builder.update_queue.return_value = builder
+    builder.build.side_effect = [first_app, rebuilt_app]
+
+    async def no_sleep(_delay):
+        return None
+
+    async def no_fallback_ips():
+        return []
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        telegram_module,
+        "Application",
+        SimpleNamespace(builder=MagicMock(return_value=builder)),
+    )
+    monkeypatch.setattr(
+        telegram_module, "HTTPXRequest", lambda **_kwargs: MagicMock()
+    )
+    monkeypatch.setattr(telegram_module, "discover_fallback_ips", no_fallback_ips)
+    monkeypatch.setattr(telegram_module, "resolve_proxy_url", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(telegram_module.asyncio, "sleep", no_sleep)
+    monkeypatch.setattr(
+        telegram_module, "_shutdown_abandoned_app", AsyncMock()
+    )
+    adapter._fallback_ips = MagicMock(return_value=[])
+    adapter._instrument_polling_request = MagicMock(side_effect=lambda request: request)
+    adapter._acquire_platform_lock = MagicMock(return_value=True)
+    adapter._release_platform_lock = MagicMock()
+    adapter._ensure_inbound_queue = MagicMock(return_value=MagicMock())
+    adapter._recover_inbound_queue = AsyncMock()
+    adapter._register_handlers = MagicMock()
+    adapter._wire_plugin_handlers = MagicMock()
+    adapter._looks_like_network_error = MagicMock(return_value=False)
+
+    assert await adapter.connect() is False
+
+    proxies = [call.args[0] for call in adapter._wire_plugin_handlers.call_args_list]
+    assert [proxy._application for proxy in proxies] == [first_app, rebuilt_app]
+    assert all(
+        type(proxy).__name__ == "_TelegramPluginApplicationProxy"
+        for proxy in proxies
+    )
+    assert adapter._register_handlers.call_args_list == [
+        ((first_app,), {}),
+        ((rebuilt_app,), {}),
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("update_kind", ["command", "callback_query"])
+async def test_busy_cap_defer_requeues_control_updates_without_using_budget(
+    tmp_path, monkeypatch, update_kind
+):
+    """A not-admitted control callback must return to the due-time queue."""
+    monkeypatch.setattr(telegram_module, "_DURABLE_BUSY_RETRY_DELAY_SECONDS", 0.01)
+
+    async def deferred(_update, _context):
+        return telegram_module._DURABLE_DISPATCH_DEFERRED
+
+    update_id = 1041 if update_kind == "command" else 1042
+    adapter, queue, store, _event = await _make_durable_dispatch_harness(
+        tmp_path, update_id, lambda _event: None, update_kind=update_kind
+    )
+    wrapped = adapter._wrap_inbound_handler(deferred)
+    update = SimpleNamespace(
+        update_id=update_id,
+        message=SimpleNamespace(text="/busy" if update_kind == "command" else None),
+        effective_message=None,
+        callback_query=(SimpleNamespace() if update_kind == "callback_query" else None),
+    )
+
+    assert await wrapped(update, None) is telegram_module._DURABLE_DISPATCH_DEFERRED
+
+    row = store.get(f"telegram:111:{update_id}")
+    assert row is not None
+    assert row.work_state == "queued"
+    assert row.dispatch_state == "pending"
+    assert row.attempt_count == 0
+    assert row.terminal_reason is None
+    assert row.last_error_class == "busy_cap"
+    assert store.next_pending_dispatch_at(bot_account_id=111) is not None
+    assert queue.claim_for_update(update_id) is None
+
+    replay = await asyncio.wait_for(queue.get(), timeout=0.5)
+    assert replay["update_id"] == update_id
+    replay_claim = queue.claim_for_update(update_id)
+    assert replay_claim is not None
+    assert replay_claim.attempt_count == 1
+    queue.task_done()
+    assert await queue.complete_update(update_id, success=True)
+
+
+@pytest.mark.asyncio
+async def test_started_callback_failure_remains_quarantined(tmp_path):
+    """A callback that was admitted before failing must not be replayed."""
+
+    async def failed(_update, _context):
+        raise RuntimeError("callback effect failed")
+
+    adapter, queue, store, _event = await _make_durable_dispatch_harness(
+        tmp_path, 1043, lambda _event: None, update_kind="callback_query"
+    )
+    wrapped = adapter._wrap_inbound_handler(failed)
+    update = SimpleNamespace(
+        update_id=1043,
+        message=None,
+        effective_message=None,
+        callback_query=SimpleNamespace(),
+    )
+
+    with pytest.raises(RuntimeError, match="callback effect failed"):
+        await wrapped(update, None)
+
+    row = store.get("telegram:111:1043")
+    assert row is not None
+    assert row.work_state == "dead_letter"
+    assert row.terminal_reason == "control_effect_failed"
+    assert row.dispatch_state == "pending"
+    assert row.attempt_count == 1
+    assert queue.claim_for_update(1043) is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("callback_name", "update_kind"),
+    [
+        pytest.param("_handle_command", "command", id="command"),
+        pytest.param("_handle_location_message", "location", id="location"),
+        pytest.param("_handle_media_message", "message", id="sticker-media"),
+    ],
+)
+async def test_registered_immediate_handler_failure_does_not_ack_real_claim(
+    tmp_path, monkeypatch, callback_name, update_kind
+):
+    """Registered immediate handlers must not ACK contained owner failures."""
+    if not telegram_module.TELEGRAM_AVAILABLE:
+        pytest.skip("python-telegram-bot is not installed")
+
+    started = asyncio.Event()
+
+    async def process(_event):
+        started.set()
+        raise RuntimeError("registered immediate handler failure")
+
+    adapter, queue, store, event = await _make_durable_dispatch_harness(
+        tmp_path, 1020, process, update_kind=update_kind
+    )
+    event.message_type = {
+        "_handle_command": MessageType.COMMAND,
+        "_handle_location_message": MessageType.LOCATION,
+        "_handle_media_message": MessageType.STICKER,
+    }[callback_name]
+    adapter._is_user_authorized_from_message = lambda message: True
+    adapter._should_process_message = lambda *_args, **_kwargs: True
+    adapter._ensure_forum_commands = AsyncMock()
+    adapter._apply_telegram_group_observe_attribution = lambda event: event
+    adapter._build_message_event = lambda *_args, **_kwargs: event
+    adapter._clean_bot_trigger_text = lambda text: text
+    adapter._cache_replied_media = AsyncMock()
+    adapter._handle_sticker = AsyncMock()
+
+    if callback_name == "_handle_command":
+        message = SimpleNamespace(text="/probe")
+    elif callback_name == "_handle_location_message":
+        message = SimpleNamespace(
+            location=SimpleNamespace(latitude=34.7, longitude=-86.6),
+            venue=None,
+        )
+    else:
+        message = SimpleNamespace(sticker=SimpleNamespace(), caption=None)
+
+    monkeypatch.setattr(telegram_module, "TelegramMessageHandler", _RegisteredHandler)
+    monkeypatch.setattr(telegram_module, "CallbackQueryHandler", _RegisteredHandler)
+    monkeypatch.setattr(telegram_module, "TypeHandler", _RegisteredHandler)
+    app = _RecordingApp()
+    adapter._register_handlers(app)
+    callbacks = {
+        handler.callback.__name__: handler.callback
+        for handler, _group in app.handlers
+        if getattr(handler, "callback", None) is not None
+        and hasattr(handler.callback, "__name__")
+    }
+
+    update = SimpleNamespace(
+        update_id=1020,
+        message=message,
+        effective_message=None,
+    )
+    await callbacks[callback_name](update, None)
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+    completion = getattr(event, "_telegram_durable_completion_task", None)
+    assert completion is not None
+    await asyncio.wait_for(asyncio.shield(completion), timeout=1.0)
+
+    assert started.is_set()
+    row = store.get(event.raw_message.event_id)
+    assert row is not None
+    assert row.work_state == "queued"
+    assert row.terminal_reason is None
+    assert row.dispatch_state == "pending"
+    assert row.lease_owner is None
+    assert row.consumed_at is None
+    assert row.last_error_class == "handler_failed"
+    assert queue.claim_for_update(1020) is None
+    assert ("111", 1020) not in adapter._seen_update_ids
+    await queue.suspend_projection()
+
+
+@pytest.mark.asyncio
+async def test_expected_durable_background_cancellation_requeues_claim(tmp_path):
+    """Expected owner cancellation must requeue, without holding a duplicate."""
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def process(_event):
+        started.set()
+        await release.wait()
+
+    adapter, queue, store, event = await _make_durable_dispatch_harness(
+        tmp_path, 1018, process
+    )
+    dispatch_task = asyncio.create_task(
+        adapter._dispatch_and_complete_durable_event(event)
+    )
+
+    try:
+        await asyncio.wait_for(started.wait(), timeout=1.0)
+        owner = adapter._session_tasks.get("agent:main:telegram:dm:123")
+        assert owner is not None
+        adapter._expected_cancelled_tasks.add(owner)
+        owner.cancel()
+        await asyncio.wait_for(dispatch_task, timeout=1.0)
+        completion = getattr(event, "_telegram_durable_completion_task", None)
+        assert completion is not None
+        await asyncio.wait_for(asyncio.shield(completion), timeout=1.0)
+    finally:
+        release.set()
+        if not dispatch_task.done():
+            dispatch_task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await dispatch_task
+
+    row = store.get("telegram:111:1018")
+    assert row is not None
+    assert row.work_state == "queued"
+    assert row.dispatch_state == "pending"
+    assert row.lease_owner is None
+    assert row.consumed_at is None
+    assert row.last_error_class == "handler_failed"
+    assert row.attempt_count == 1
+    assert queue.claim_for_update(1018) is None
+    assert not getattr(adapter, "_held_inbound_events", [])
+    await queue.suspend_projection()
+
+
+@pytest.mark.asyncio
+async def test_control_fence_failure_allows_same_process_durable_retry(
+    registered_handler_fixture,
+):
+    """A stale control fence must not poison the process-local dedup cache."""
+    fixture = registered_handler_fixture
+    adapter = fixture.adapter
+    completed = []
+
+    class Queue:
+        def handler_claimed(self, _update_id):
+            return False
+
+        def mark_handler_claim(self, update_id):
+            return SimpleNamespace(
+                event_id=f"telegram:111:{update_id}",
+                update_kind="callback_query",
+            )
+
+        def mark_control_started(self, _update_id):
+            return False
+
+        async def complete_update(self, update_id, *, success):
+            completed.append((update_id, success))
+            return True
+
+    adapter._inbound_queue = Queue()
+    callback = fixture.callbacks["_handle_command"]
+    update = _update(1019, _message(text="/stop"))
+
+    await callback(update, None)
+    await callback(update, None)
+
+    assert completed == [(1019, False), (1019, False)]
+
+
+def test_deduplication_is_serialized_and_lazily_initialized(registered_handler_fixture):
+    adapter = registered_handler_fixture.adapter
+    update = _update(1013, _message(text="race"))
+
+    with ThreadPoolExecutor(max_workers=16) as executor:
+        results = list(executor.map(adapter._is_duplicate_update, [update] * 50))
+
+    assert results.count(False) == 1
+    assert results.count(True) == 49
+
+
+def test_uninitialized_adapter_dedup_state_is_safe():
+    adapter = object.__new__(TelegramAdapter)
+    adapter._bot = SimpleNamespace(id=111)
+    update = _update(1014, _message(text="lazy"))
+
+    assert adapter._is_duplicate_update(update) is False
+    assert adapter._is_duplicate_update(update) is True
+
+
+@pytest.mark.asyncio
+async def test_near_limit_command_uses_real_text_batch_flush(
+    registered_handler_fixture,
+):
+    fixture = registered_handler_fixture
+    adapter = fixture.adapter
+    callback = fixture.callbacks["_handle_command"]
+    adapter._enqueue_text_event = TelegramAdapter._enqueue_text_event.__get__(adapter)
+    adapter._text_batch_delay_seconds = 0.0
+    adapter._text_batch_split_delay_seconds = 0.0
+    text = "/queue " + ("x" * (adapter._SPLIT_THRESHOLD - len("/queue ")))
+
+    await callback(_update(1015, _message(text=text)), None)
+    tasks = list(adapter._pending_text_batch_tasks.values())
+    assert tasks
+    await asyncio.gather(*tasks)
+
+    assert len(fixture.dispatched) == 1
+    assert fixture.dispatched[0].text == text
+
+
+@pytest.mark.asyncio
+async def test_processing_hooks_tolerate_sparse_adapter_without_bot(monkeypatch):
+    """Lifecycle hooks must remain safe before the Telegram bot is attached."""
+    monkeypatch.setenv("TELEGRAM_REACTIONS", "true")
+    adapter = object.__new__(TelegramAdapter)
+    event = SimpleNamespace(
+        source=SimpleNamespace(chat_id="123"),
+        message_id="10",
+    )
+
+    await adapter.on_processing_start(event)
+    await adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
+
+    assert event._telegram_processing_started is True
+    assert event._telegram_processing_outcome is ProcessingOutcome.SUCCESS
+
+
+def test_inline_picker_is_registered_through_durable_inbound_fence(monkeypatch):
+    """Inline-query ingress must claim the durable record before dispatch."""
+    if not telegram_module.TELEGRAM_AVAILABLE:
+        pytest.skip("python-telegram-bot is not installed")
+
+    adapter = object.__new__(TelegramAdapter)
+    wrapped = []
+
+    async def handle_text(*_args, **_kwargs):
+        return None
+
+    async def handle_command(*_args, **_kwargs):
+        return None
+
+    async def handle_location(*_args, **_kwargs):
+        return None
+
+    async def handle_media(*_args, **_kwargs):
+        return None
+
+    async def handle_callback(*_args, **_kwargs):
+        return None
+
+    async def handle_inline(*_args, **_kwargs):
+        return None
+
+    async def handle_platform_event(*_args, **_kwargs):
+        return None
+
+    def wrap(callback):
+        wrapped.append(callback.__name__)
+        return callback
+
+    adapter._wrap_inbound_handler = wrap
+    adapter._wrap_platform_event_handler = lambda callback: callback
+    adapter._handle_text_message = handle_text
+    adapter._handle_command = handle_command
+    adapter._handle_location_message = handle_location
+    adapter._handle_media_message = handle_media
+    adapter._handle_callback_query = handle_callback
+    adapter._handle_inline_query = handle_inline
+    adapter._on_platform_update = handle_platform_event
+
+    monkeypatch.setattr(telegram_module, "TelegramMessageHandler", _RegisteredHandler)
+    monkeypatch.setattr(telegram_module, "CallbackQueryHandler", _RegisteredHandler)
+    monkeypatch.setattr(telegram_module, "InlineQueryHandler", _RegisteredHandler)
+    monkeypatch.setattr(telegram_module, "TypeHandler", _RegisteredHandler)
+
+    TelegramAdapter._register_handlers(adapter, _RecordingApp())
+
+    assert wrapped == [
+        "handle_text",
+        "handle_command",
+        "handle_location",
+        "handle_media",
+        "handle_callback",
+        "handle_inline",
+    ]

--- a/tests/gateway/test_telegram_inbound_store.py
+++ b/tests/gateway/test_telegram_inbound_store.py
@@ -1,0 +1,2922 @@
+"""Focused durable-inbound contract tests for Telegram."""
+
+import asyncio
+import os
+import sqlite3
+import stat
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
+
+import pytest
+
+import plugins.platforms.telegram.inbound_store as inbound_store_module
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType
+from gateway.session import SessionSource
+from plugins.platforms.telegram.inbound_store import (
+    MAX_ATTEMPTS,
+    CaptureDecision,
+    DurableTelegramUpdateQueue,
+    TelegramInboundStore,
+    TelegramQueueLifecycleRegistry,
+    bot_account_key,
+    canonical_bot_account_id,
+)
+
+
+def payload(update_id, *, chat_id="10", message_id="20", text="same"):
+    return {
+        "update_id": update_id,
+        "message": {
+            "message_id": int(message_id),
+            "date": 1,
+            "chat": {"id": int(chat_id), "type": "private"},
+            "from": {"id": 30, "is_bot": False, "first_name": "U"},
+            "text": text,
+        },
+    }
+
+
+def decision(data, *, actionable=True, profile="default", update_kind="message"):
+    message = data["message"]
+    return CaptureDecision(
+        actionable=actionable,
+        profile=profile,
+        account_id="telegram",
+        update_kind=update_kind,
+        chat_id=str(message["chat"]["id"]),
+        message_id=str(message["message_id"]),
+        session_key=f"telegram:dm:{message['chat']['id']}",
+        priority=10,
+        payload=data,
+        receipt_required=False,
+    )
+
+
+def test_existing_v1_schema_accepts_new_persist(tmp_path):
+    db_path = tmp_path / "telegram_inbound.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE telegram_inbound_event (
+                seq INTEGER PRIMARY KEY AUTOINCREMENT,
+                event_id TEXT NOT NULL UNIQUE,
+                bot_account_id INTEGER NOT NULL,
+                update_id INTEGER NOT NULL,
+                profile TEXT NOT NULL,
+                account_id TEXT NOT NULL,
+                update_kind TEXT NOT NULL,
+                chat_id TEXT,
+                message_id TEXT,
+                callback_query_id TEXT,
+                session_key TEXT NOT NULL,
+                priority INTEGER NOT NULL,
+                payload_json BLOB,
+                payload_sha256 TEXT NOT NULL,
+                work_state TEXT NOT NULL,
+                receipt_state TEXT NOT NULL,
+                attempt_count INTEGER NOT NULL DEFAULT 0,
+                lease_owner TEXT,
+                lease_epoch INTEGER NOT NULL DEFAULT 0,
+                lease_expires_at REAL,
+                next_attempt_at REAL,
+                received_at REAL NOT NULL,
+                persisted_at REAL NOT NULL,
+                queued_at REAL,
+                leased_at REAL,
+                context_committed_at REAL,
+                consumed_at REAL,
+                terminal_at REAL,
+                receipt_attempted_at REAL,
+                receipt_confirmed_at REAL,
+                duplicate_count INTEGER NOT NULL DEFAULT 0,
+                last_duplicate_at REAL,
+                replay_count INTEGER NOT NULL DEFAULT 0,
+                last_replay_at REAL,
+                identity_conflict_count INTEGER NOT NULL DEFAULT 0,
+                last_error_class TEXT,
+                terminal_reason TEXT,
+                dispatch_state TEXT NOT NULL DEFAULT 'pending',
+                UNIQUE(bot_account_id, update_id)
+            );
+            CREATE TABLE telegram_inbound_alias (
+                bot_account_id INTEGER NOT NULL,
+                alias_kind TEXT NOT NULL,
+                scope TEXT NOT NULL,
+                alias_value TEXT NOT NULL,
+                event_id TEXT NOT NULL,
+                PRIMARY KEY(bot_account_id, alias_kind, scope, alias_value)
+            );
+            """
+        )
+
+    store = TelegramInboundStore(db_path)
+    result = store.persist(
+        bot_account_id=111,
+        update_id=6,
+        decision=decision(payload(6)),
+        now=1.0,
+    )
+
+    assert result.row is not None
+    assert result.row.work_state == "queued"
+    with sqlite3.connect(db_path) as conn:
+        assert conn.execute(
+            "SELECT receipt_state FROM telegram_inbound_event WHERE event_id=?",
+            (result.event_id,),
+        ).fetchone() == ("not_required",)
+
+
+def test_existing_v1_schema_migrates_identifiers_to_lossless_text(tmp_path):
+    db_path = tmp_path / "telegram_inbound.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE telegram_inbound_event (
+                seq INTEGER PRIMARY KEY AUTOINCREMENT,
+                event_id TEXT NOT NULL UNIQUE,
+                bot_account_id INTEGER NOT NULL,
+                update_id INTEGER NOT NULL,
+                profile TEXT NOT NULL,
+                account_id TEXT NOT NULL,
+                update_kind TEXT NOT NULL,
+                chat_id TEXT,
+                message_id TEXT,
+                callback_query_id TEXT,
+                session_key TEXT NOT NULL,
+                priority INTEGER NOT NULL,
+                payload_json BLOB,
+                payload_sha256 TEXT NOT NULL,
+                work_state TEXT NOT NULL,
+                receipt_state TEXT NOT NULL,
+                attempt_count INTEGER NOT NULL DEFAULT 0,
+                lease_owner TEXT,
+                lease_epoch INTEGER NOT NULL DEFAULT 0,
+                lease_expires_at REAL,
+                next_attempt_at REAL,
+                received_at REAL NOT NULL,
+                persisted_at REAL NOT NULL,
+                queued_at REAL,
+                leased_at REAL,
+                context_committed_at REAL,
+                consumed_at REAL,
+                terminal_at REAL,
+                receipt_attempted_at REAL,
+                receipt_confirmed_at REAL,
+                duplicate_count INTEGER NOT NULL DEFAULT 0,
+                last_duplicate_at REAL,
+                replay_count INTEGER NOT NULL DEFAULT 0,
+                last_replay_at REAL,
+                identity_conflict_count INTEGER NOT NULL DEFAULT 0,
+                last_error_class TEXT,
+                terminal_reason TEXT,
+                dispatch_state TEXT NOT NULL DEFAULT 'pending',
+                UNIQUE(bot_account_id, update_id)
+            );
+            CREATE TABLE telegram_inbound_alias (
+                bot_account_id INTEGER NOT NULL,
+                alias_kind TEXT NOT NULL,
+                scope TEXT NOT NULL,
+                alias_value TEXT NOT NULL,
+                event_id TEXT NOT NULL,
+                PRIMARY KEY(bot_account_id, alias_kind, scope, alias_value),
+                FOREIGN KEY(event_id) REFERENCES telegram_inbound_event(event_id)
+            );
+            CREATE INDEX custom_alias_scope ON telegram_inbound_alias(scope);
+            INSERT INTO telegram_inbound_event (
+                event_id, bot_account_id, update_id, profile, account_id,
+                update_kind, session_key, priority, payload_json, payload_sha256,
+                work_state, receipt_state, received_at, persisted_at, dispatch_state
+            ) VALUES (
+                'telegram:111:8', 111, 8, 'default', 'telegram', 'message',
+                'telegram:dm:10', 10, '{}', 'legacy-hash', 'queued',
+                'not_required', 0.5, 0.5, 'pending'
+            );
+            INSERT INTO telegram_inbound_alias (
+                bot_account_id, alias_kind, scope, alias_value, event_id
+            ) VALUES (111, 'message', 'chat:10', '20', 'telegram:111:8');
+            UPDATE sqlite_sequence SET seq=50
+            WHERE name='telegram_inbound_event';
+            """
+        )
+
+    store = TelegramInboundStore(db_path)
+    huge = 2**63
+    update_results = [
+        store.persist(
+            bot_account_id=111,
+            update_id=huge + offset,
+            decision=decision(payload(huge + offset)),
+            now=1.0 + offset,
+        )
+        for offset in range(2)
+    ]
+    bot_results = [
+        store.persist(
+            bot_account_id=huge + offset,
+            update_id=9,
+            decision=decision(payload(9)),
+            now=3.0 + offset,
+        )
+        for offset in range(2)
+    ]
+
+    assert all(not result.duplicate for result in update_results + bot_results)
+    assert len({result.event_id for result in update_results}) == 2
+    assert len({result.event_id for result in bot_results}) == 2
+    with sqlite3.connect(db_path) as conn:
+        event_types = {
+            row[1]: row[2]
+            for row in conn.execute("PRAGMA table_info(telegram_inbound_event)")
+        }
+        alias_types = {
+            row[1]: row[2]
+            for row in conn.execute("PRAGMA table_info(telegram_inbound_alias)")
+        }
+        stored_types = conn.execute(
+            "SELECT DISTINCT typeof(bot_account_id), typeof(update_id) "
+            "FROM telegram_inbound_event"
+        ).fetchall()
+        foreign_key_errors = conn.execute("PRAGMA foreign_key_check").fetchall()
+        legacy_row = conn.execute(
+            "SELECT bot_account_id, update_id FROM telegram_inbound_event "
+            "WHERE event_id='telegram:111:8'"
+        ).fetchone()
+        legacy_alias = conn.execute(
+            "SELECT bot_account_id, event_id FROM telegram_inbound_alias "
+            "WHERE alias_value='20'"
+        ).fetchone()
+        custom_index = conn.execute(
+            "SELECT sql FROM sqlite_master WHERE type='index' "
+            "AND name='custom_alias_scope'"
+        ).fetchone()
+        first_new_seq = conn.execute(
+            "SELECT seq FROM telegram_inbound_event WHERE event_id=?",
+            (update_results[0].event_id,),
+        ).fetchone()
+    assert event_types["bot_account_id"].upper() == "TEXT"
+    assert event_types["update_id"].upper() == "TEXT"
+    assert alias_types["bot_account_id"].upper() == "TEXT"
+    assert stored_types == [("text", "text")]
+    assert foreign_key_errors == []
+    assert legacy_row == ("111", "8")
+    assert legacy_alias == ("111", "telegram:111:8")
+    assert custom_index == (
+        "CREATE INDEX custom_alias_scope ON telegram_inbound_alias(scope)",
+    )
+    assert first_new_seq == (51,)
+
+
+def test_identifier_migration_rejects_conflicting_canonical_index(tmp_path):
+    db_path = tmp_path / "telegram_inbound.db"
+    conflicting_sql = (
+        "CREATE INDEX telegram_inbound_event_account_update "
+        "ON telegram_inbound_event(session_key)"
+    )
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(
+            f"""
+            CREATE TABLE telegram_inbound_event (
+                seq INTEGER PRIMARY KEY AUTOINCREMENT,
+                event_id TEXT NOT NULL UNIQUE,
+                bot_account_id INTEGER NOT NULL,
+                update_id INTEGER NOT NULL,
+                profile TEXT NOT NULL,
+                account_id TEXT NOT NULL,
+                update_kind TEXT NOT NULL,
+                session_key TEXT NOT NULL,
+                priority INTEGER NOT NULL DEFAULT 100,
+                work_state TEXT NOT NULL DEFAULT 'queued',
+                dispatch_state TEXT NOT NULL DEFAULT 'pending',
+                received_at REAL NOT NULL,
+                persisted_at REAL NOT NULL
+            );
+            CREATE TABLE telegram_inbound_alias (
+                bot_account_id INTEGER NOT NULL,
+                alias_kind TEXT NOT NULL,
+                scope TEXT NOT NULL,
+                alias_value TEXT NOT NULL,
+                event_id TEXT NOT NULL,
+                PRIMARY KEY(bot_account_id, alias_kind, scope, alias_value),
+                FOREIGN KEY(event_id) REFERENCES telegram_inbound_event(event_id)
+            );
+            {conflicting_sql};
+            INSERT INTO telegram_inbound_event (
+                event_id, bot_account_id, update_id, profile, account_id,
+                update_kind, session_key, received_at, persisted_at
+            ) VALUES (
+                'telegram:111:8', 111, 8, 'default', 'telegram', 'message',
+                'telegram:dm:10', 0.5, 0.5
+            );
+            """
+        )
+
+    with pytest.raises(RuntimeError, match="conflicting canonical index"):
+        TelegramInboundStore(db_path)
+
+    with sqlite3.connect(db_path) as conn:
+        columns = [
+            row[1]
+            for row in conn.execute("PRAGMA table_info(telegram_inbound_event)")
+        ]
+        affinity = {
+            row[1]: row[2]
+            for row in conn.execute("PRAGMA table_info(telegram_inbound_event)")
+        }
+        index_sql = conn.execute(
+            "SELECT sql FROM sqlite_master WHERE type='index' "
+            "AND name='telegram_inbound_event_account_update'"
+        ).fetchone()
+        rows = conn.execute(
+            "SELECT event_id, bot_account_id, update_id "
+            "FROM telegram_inbound_event"
+        ).fetchall()
+    assert affinity["bot_account_id"].upper() == "INTEGER"
+    assert affinity["update_id"].upper() == "INTEGER"
+    assert "receipt_state" not in columns
+    assert "next_attempt_at" not in columns
+    assert index_sql == (conflicting_sql,)
+    assert rows == [("telegram:111:8", 111, 8)]
+
+
+def test_identifier_migration_rejects_global_canonical_index_collision(tmp_path):
+    db_path = tmp_path / "telegram_inbound.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE unrelated(value TEXT);
+            CREATE INDEX telegram_inbound_event_account_update
+                ON unrelated(value);
+            CREATE TABLE telegram_inbound_event (
+                seq INTEGER PRIMARY KEY AUTOINCREMENT,
+                event_id TEXT NOT NULL UNIQUE,
+                bot_account_id INTEGER NOT NULL,
+                update_id INTEGER NOT NULL,
+                profile TEXT NOT NULL,
+                account_id TEXT NOT NULL,
+                update_kind TEXT NOT NULL,
+                session_key TEXT NOT NULL,
+                priority INTEGER NOT NULL DEFAULT 100,
+                work_state TEXT NOT NULL DEFAULT 'queued',
+                dispatch_state TEXT NOT NULL DEFAULT 'pending',
+                received_at REAL NOT NULL,
+                persisted_at REAL NOT NULL
+            );
+            CREATE TABLE telegram_inbound_alias (
+                bot_account_id INTEGER NOT NULL,
+                alias_kind TEXT NOT NULL,
+                scope TEXT NOT NULL,
+                alias_value TEXT NOT NULL,
+                event_id TEXT NOT NULL,
+                PRIMARY KEY(bot_account_id, alias_kind, scope, alias_value),
+                FOREIGN KEY(event_id) REFERENCES telegram_inbound_event(event_id)
+            );
+            """
+        )
+
+    with pytest.raises(RuntimeError, match="conflicting canonical index"):
+        TelegramInboundStore(db_path)
+
+    with sqlite3.connect(db_path) as conn:
+        columns = [
+            row[1]
+            for row in conn.execute("PRAGMA table_info(telegram_inbound_event)")
+        ]
+        collision_owner = conn.execute(
+            "SELECT tbl_name FROM sqlite_master WHERE type='index' "
+            "AND name='telegram_inbound_event_account_update'"
+        ).fetchone()
+    assert "receipt_state" not in columns
+    assert "next_attempt_at" not in columns
+    assert collision_owner == ("unrelated",)
+
+
+def test_identifier_migration_rejects_lossy_real_alias(tmp_path):
+    db_path = tmp_path / "telegram_inbound.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE telegram_inbound_event (
+                seq INTEGER PRIMARY KEY AUTOINCREMENT,
+                event_id TEXT NOT NULL UNIQUE,
+                bot_account_id INTEGER NOT NULL,
+                update_id INTEGER NOT NULL,
+                profile TEXT NOT NULL,
+                account_id TEXT NOT NULL,
+                update_kind TEXT NOT NULL,
+                session_key TEXT NOT NULL,
+                priority INTEGER NOT NULL DEFAULT 100,
+                work_state TEXT NOT NULL DEFAULT 'queued',
+                dispatch_state TEXT NOT NULL DEFAULT 'pending',
+                received_at REAL NOT NULL,
+                persisted_at REAL NOT NULL
+            );
+            CREATE TABLE telegram_inbound_alias (
+                bot_account_id INTEGER NOT NULL,
+                alias_kind TEXT NOT NULL,
+                scope TEXT NOT NULL,
+                alias_value TEXT NOT NULL,
+                event_id TEXT NOT NULL,
+                PRIMARY KEY(bot_account_id, alias_kind, scope, alias_value),
+                FOREIGN KEY(event_id) REFERENCES telegram_inbound_event(event_id)
+            );
+            INSERT INTO telegram_inbound_event (
+                event_id, bot_account_id, update_id, profile, account_id,
+                update_kind, session_key, received_at, persisted_at
+            ) VALUES (
+                'telegram:111:8', 111, 8, 'default', 'telegram', 'message',
+                'telegram:dm:10', 0.5, 0.5
+            );
+            INSERT INTO telegram_inbound_alias (
+                bot_account_id, alias_kind, scope, alias_value, event_id
+            ) VALUES (
+                9223372036854775808, 'message', 'chat:10', '20',
+                'telegram:111:8'
+            );
+            """
+        )
+        assert conn.execute(
+            "SELECT typeof(bot_account_id) FROM telegram_inbound_alias"
+        ).fetchone() == ("real",)
+
+    with pytest.raises(RuntimeError, match="lossy REAL identifiers"):
+        TelegramInboundStore(db_path)
+
+
+@pytest.mark.asyncio
+async def test_cancelled_close_releases_shared_store_executor(tmp_path, monkeypatch):
+    store = TelegramInboundStore(tmp_path / "telegram_inbound.db")
+    queue = DurableTelegramUpdateQueue(
+        store=store,
+        bot_account_id=111,
+        classifier=lambda item: decision(item),
+        after_commit=None,
+        lease_owner="gateway:test",
+        active_limit=1,
+    )
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def blocked_wait_for_ingress_tasks():
+        entered.set()
+        await release.wait()
+
+    monkeypatch.setattr(queue, "_wait_for_ingress_tasks", blocked_wait_for_ingress_tasks)
+    close_task = asyncio.create_task(queue.close())
+    await asyncio.wait_for(entered.wait(), timeout=0.5)
+    close_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await close_task
+
+    assert queue._store_executor_shutdown
+    assert queue._store_executor_key not in inbound_store_module._STORE_EXECUTORS
+    release.set()
+
+
+def test_reclaim_process_leases_is_scoped_to_one_bot_account(tmp_path):
+    store = TelegramInboundStore(tmp_path / "telegram_inbound.db")
+    account_111 = store.persist(
+        bot_account_id=111,
+        update_id=7,
+        decision=decision(payload(7)),
+        now=1.0,
+    )
+    account_222 = store.persist(
+        bot_account_id=222,
+        update_id=7,
+        decision=decision(payload(7)),
+        now=1.0,
+    )
+    store.lease_event(account_111.event_id, owner="old-111", now=2.0, lease_seconds=100.0)
+    store.lease_event(account_222.event_id, owner="old-222", now=2.0, lease_seconds=100.0)
+
+    assert store.reclaim_process_leases(
+        bot_account_id=111, current_owner="new-111", now=3.0
+    ) == 1
+    assert store.get(account_111.event_id).work_state == "queued"
+    assert store.get(account_222.event_id).work_state == "leased"
+    assert store.get(account_222.event_id).lease_owner == "old-222"
+
+    assert store.reclaim_process_leases(
+        bot_account_id=222, current_owner="new-222", now=4.0
+    ) == 1
+    assert store.get(account_222.event_id).work_state == "queued"
+    assert store.get(account_111.event_id).work_state == "queued"
+
+
+def test_recover_admitted_dispatches_is_scoped_to_one_bot_account(tmp_path):
+    store = TelegramInboundStore(tmp_path / "telegram_inbound.db")
+    account_111 = store.persist(
+        bot_account_id=111,
+        update_id=8,
+        decision=decision(payload(8)),
+        now=1.0,
+    )
+    account_222 = store.persist(
+        bot_account_id=222,
+        update_id=8,
+        decision=decision(payload(8)),
+        now=1.0,
+    )
+    assert store.mark_dispatch_admitted(account_111.event_id)
+    assert store.mark_dispatch_admitted(account_222.event_id)
+
+    assert store.recover_admitted_dispatches(bot_account_id=111, now=3.0) == 1
+    assert store.get(account_111.event_id).dispatch_state == "pending"
+    assert store.get(account_222.event_id).dispatch_state == "admitted"
+
+    assert store.recover_admitted_dispatches(bot_account_id=222, now=4.0) == 1
+    assert store.get(account_222.event_id).dispatch_state == "pending"
+    assert store.get(account_111.event_id).dispatch_state == "pending"
+
+
+def test_large_bot_account_id_round_trips_and_uses_text_safe_key(tmp_path):
+    account_id = 2**63
+    adjacent_id = account_id + 1
+    store = TelegramInboundStore(tmp_path / "telegram_inbound.db")
+    result = store.persist(
+        bot_account_id=account_id,
+        update_id=9,
+        decision=decision(payload(9)),
+        now=1.0,
+    )
+    adjacent = store.persist(
+        bot_account_id=adjacent_id,
+        update_id=9,
+        decision=decision(payload(9)),
+        now=1.0,
+    )
+
+    assert canonical_bot_account_id(account_id) == "9223372036854775808"
+    assert bot_account_key(account_id) == "telegram-account:9223372036854775808"
+    assert result.event_id == "telegram:9223372036854775808:9"
+    assert adjacent.event_id == "telegram:9223372036854775809:9"
+    assert result.event_id != adjacent.event_id
+    row = store.get(result.event_id)
+    assert row is not None
+    assert row.bot_account_id == account_id
+    assert store.event_id_for_update(account_id, 9) == result.event_id
+    assert store.event_id_for_update(adjacent_id, 9) == adjacent.event_id
+
+
+def test_update_identity_is_account_scoped_and_text_is_not_identity(tmp_path):
+    store = TelegramInboundStore(tmp_path / "telegram_inbound.db")
+    first = store.persist(
+        bot_account_id=111,
+        update_id=10,
+        decision=decision(payload(10, message_id="30", text="same")),
+        now=1.0,
+    )
+    other_account = store.persist(
+        bot_account_id=222,
+        update_id=10,
+        decision=decision(payload(10, message_id="30", text="same")),
+        now=2.0,
+    )
+    second_update = store.persist(
+        bot_account_id=111,
+        update_id=11,
+        decision=decision(payload(11, message_id="31", text="same")),
+        now=3.0,
+    )
+
+    assert not first.duplicate
+    assert not other_account.duplicate
+    assert not second_update.duplicate
+    assert len({first.event_id, other_account.event_id, second_update.event_id}) == 3
+    assert [row.update_id for row in store.eligible(bot_account_id=111)] == [10, 11]
+    assert [row.update_id for row in store.eligible(bot_account_id=222)] == [10]
+
+
+def test_distinct_update_ids_do_not_collapse_when_message_shape_repeats(tmp_path):
+    store = TelegramInboundStore(tmp_path / "telegram_inbound.db")
+    first = store.persist(
+        bot_account_id=111,
+        update_id=12,
+        decision=decision(payload(12, message_id="30", text="same")),
+        now=1.0,
+    )
+    second = store.persist(
+        bot_account_id=111,
+        update_id=13,
+        decision=decision(payload(13, message_id="30", text="same")),
+        now=2.0,
+    )
+
+    assert not first.duplicate
+    assert not second.duplicate
+    assert first.event_id == "telegram:111:12"
+    assert second.event_id == "telegram:111:13"
+    assert [row.update_id for row in store.eligible(bot_account_id=111)] == [12, 13]
+
+
+@pytest.mark.asyncio
+async def test_durable_admission_precedes_commit_callback_and_preserves_sentinels(tmp_path):
+    store = TelegramInboundStore(tmp_path / "telegram_inbound.db")
+    callback_observations = []
+
+    def classify(item):
+        return decision(item, actionable=item["update_id"] != 2)
+
+    async def after_commit(item, result):
+        row = store.get(result.event_id)
+        callback_observations.append(
+            (item["update_id"], row is not None, row.dispatch_state if row else None)
+        )
+
+    queue = DurableTelegramUpdateQueue(
+        store=store,
+        bot_account_id=111,
+        classifier=classify,
+        after_commit=after_commit,
+        lease_owner="gateway:test",
+        active_limit=4,
+    )
+
+    await queue.put(payload(1))
+    assert callback_observations == [(1, True, "admitted")]
+    item = await asyncio.wait_for(queue.get(), timeout=0.5)
+    assert item["update_id"] == 1
+    claim = queue.claim_for_update(1)
+    assert claim is not None
+    assert store.mark_consumed(
+        claim.event_id,
+        owner=claim.lease_owner,
+        lease_epoch=claim.lease_epoch,
+    )
+    queue.task_done()
+    queue.forget_claims({claim.event_id})
+
+    sentinel = object()
+    await queue.put(sentinel)
+    assert await asyncio.wait_for(queue.get(), timeout=0.5) is sentinel
+    queue.task_done()
+
+    rejected = payload(2)
+    await queue.put(rejected)
+    assert store.get("telegram:111:2") is None
+    assert await asyncio.wait_for(queue.get(), timeout=0.5) == rejected
+    queue.task_done()
+    assert callback_observations == [(1, True, "admitted")]
+
+
+@pytest.mark.asyncio
+async def test_durable_queue_recovery_pages_only_its_account(tmp_path):
+    store = TelegramInboundStore(tmp_path / "telegram_inbound.db")
+    first = store.persist(
+        bot_account_id=111,
+        update_id=20,
+        decision=decision(payload(20)),
+        now=1.0,
+    )
+    second = store.persist(
+        bot_account_id=222,
+        update_id=20,
+        decision=decision(payload(20)),
+        now=1.0,
+    )
+    assert store.mark_dispatch_admitted(first.event_id)
+    assert store.mark_dispatch_admitted(second.event_id)
+    assert store.recover_admitted_dispatches(bot_account_id=222, now=2.0) == 1
+
+    queue = DurableTelegramUpdateQueue(
+        store=store,
+        bot_account_id=222,
+        classifier=lambda item: decision(item),
+        lease_owner="gateway:222",
+    )
+    assert await queue.wake_scheduler() == 1
+    item = await queue.get()
+    assert item["update_id"] == 20
+    claim = queue.claim_for_update(20)
+    assert claim is not None
+    assert claim.event_id == second.event_id
+    assert store.get(first.event_id).dispatch_state == "admitted"
+    queue.task_done()
+
+
+@pytest.mark.asyncio
+async def test_projection_suspend_cancels_queued_wake_without_reprojection(tmp_path):
+    store = TelegramInboundStore(tmp_path / "telegram_inbound.db")
+    queue = DurableTelegramUpdateQueue(
+        store=store,
+        bot_account_id=111,
+        classifier=lambda item: decision(item),
+        lease_owner="gateway:projection-suspend",
+        active_limit=1,
+    )
+
+    await queue.put(payload(29))
+    assert (await queue.get())["update_id"] == 29
+    assert queue.claim_for_update(29) is not None
+    queue.task_done()
+    assert await queue.complete_update(29, success=False)
+    row = store.get("telegram:111:29")
+    assert row is not None
+    assert row.dispatch_state == "pending"
+
+    await queue.suspend_projection()
+    await asyncio.sleep(0)
+    row = store.get("telegram:111:29")
+    assert row is not None
+    assert row.dispatch_state == "pending"
+    task = queue._projection_retry_task
+    assert task is None or task.done()
+
+
+@pytest.mark.asyncio
+async def test_restart_handoff_requeues_abandoned_and_transfers_live_handler_claim(
+    tmp_path,
+):
+    store = TelegramInboundStore(tmp_path / "telegram_inbound.db")
+    abandoned = store.persist(
+        bot_account_id=111,
+        update_id=30,
+        decision=decision(payload(30, message_id="40")),
+        now=1.0,
+    )
+    live = store.persist(
+        bot_account_id=111,
+        update_id=31,
+        decision=decision(payload(31, message_id="41")),
+        now=1.0,
+    )
+
+    old_queue = DurableTelegramUpdateQueue(
+        store=store,
+        bot_account_id=111,
+        classifier=lambda item: decision(item),
+        lease_owner="gateway:old",
+        active_limit=2,
+    )
+    assert await old_queue.wake_scheduler() == 2
+    assert (await old_queue.get())["update_id"] == 30
+    assert (await old_queue.get())["update_id"] == 31
+    old_queue.mark_handler_claim(31)
+
+    replacement = DurableTelegramUpdateQueue(
+        store=store,
+        bot_account_id=111,
+        classifier=lambda item: decision(item),
+        lease_owner="gateway:new",
+        active_limit=2,
+    )
+    result = await replacement.handoff_from(old_queue)
+
+    assert result == {"requeued": 1, "transferred": 1, "quarantined": 0}
+    assert old_queue._store_executor_shutdown
+    assert old_queue._store_executor is replacement._store_executor
+    assert store.get(abandoned.event_id).work_state == "queued"
+    assert store.get(live.event_id).lease_owner == "gateway:new"
+    transferred = replacement.claim_for_update(31)
+    assert transferred is not None
+    assert transferred.event_id == live.event_id
+    assert transferred.lease_owner == "gateway:new"
+
+    assert await replacement.wake_scheduler() == 0
+    replay = await replacement.get()
+    assert replay["update_id"] == 30
+    replacement.task_done()
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_registry_unifies_symlink_parent_aliases(tmp_path):
+    real_parent = tmp_path / "real"
+    real_parent.mkdir()
+    alias_parent = tmp_path / "alias"
+    alias_parent.symlink_to(real_parent, target_is_directory=True)
+    real_path = real_parent / "telegram_inbound.db"
+    alias_path = alias_parent / "telegram_inbound.db"
+
+    old_store = TelegramInboundStore(real_path)
+    replacement_store = TelegramInboundStore(alias_path)
+    assert os.path.samefile(real_path, alias_path)
+
+    old_queue = DurableTelegramUpdateQueue(
+        store=old_store,
+        bot_account_id=111,
+        classifier=lambda item: decision(item),
+        lease_owner="gateway:real-parent",
+        active_limit=1,
+    )
+    replacement = DurableTelegramUpdateQueue(
+        store=replacement_store,
+        bot_account_id=111,
+        classifier=lambda item: decision(item),
+        lease_owner="gateway:alias-parent",
+        active_limit=1,
+    )
+
+    await old_queue.put(payload(310, message_id="410"))
+    assert (await old_queue.get())["update_id"] == 310
+    old_queue.mark_handler_claim(310)
+    old_queue.task_done()
+    persisted = old_store.get("telegram:111:310")
+    assert persisted is not None
+
+    TelegramQueueLifecycleRegistry.observe(old_queue)
+    assert TelegramQueueLifecycleRegistry.key_for_queue(
+        old_queue
+    ) == TelegramQueueLifecycleRegistry.key_for_queue(replacement)
+    assert await asyncio.wait_for(
+        TelegramQueueLifecycleRegistry.recover(replacement), timeout=0.5
+    ) == 0
+
+    assert old_queue.handler_claim_fenced(310)
+    transferred = replacement.claim_for_update(310)
+    assert transferred is not None
+    assert transferred.event_id == persisted.event_id
+    assert transferred.lease_owner == "gateway:alias-parent"
+    assert await replacement.complete_update(310, success=True)
+    assert not await old_queue.complete_update(310, success=True)
+    consumed = replacement_store.get(persisted.event_id)
+    assert consumed is not None
+    assert consumed.work_state == "consumed"
+
+
+@pytest.mark.asyncio
+async def test_handoff_discards_stale_old_projection_without_redirecting_to_replacement(tmp_path):
+    """A retired queue must never lend replacement work to its old adapter."""
+    store = TelegramInboundStore(tmp_path / "telegram_inbound.db")
+    persisted = store.persist(
+        bot_account_id=111,
+        update_id=32,
+        decision=decision(payload(32)),
+        now=1.0,
+    )
+    old_queue = DurableTelegramUpdateQueue(
+        store=store,
+        bot_account_id=111,
+        classifier=lambda item: decision(item),
+        lease_owner="gateway:old-stale-projection",
+        active_limit=1,
+    )
+    assert await old_queue.wake_scheduler() == 1
+
+    replacement = DurableTelegramUpdateQueue(
+        store=store,
+        bot_account_id=111,
+        classifier=lambda item: decision(item),
+        lease_owner="gateway:new-stale-projection",
+        active_limit=1,
+    )
+    assert await replacement.handoff_from(old_queue) == {
+        "requeued": 0,
+        "transferred": 0,
+        "quarantined": 0,
+    }
+
+    sentinel = object()
+    old_queue.put_nowait(sentinel)
+    assert await asyncio.wait_for(old_queue.get(), timeout=0.5) is sentinel
+    old_queue.task_done()
+
+    replay = await asyncio.wait_for(replacement.get(), timeout=0.5)
+    assert replay["update_id"] == 32
+    claim = replacement.claim_for_update(32)
+    assert claim is not None
+    assert claim.event_id == persisted.event_id
+    replacement.task_done()
+    assert await replacement.complete_update(32, success=True)
+
+
+@pytest.mark.asyncio
+async def test_handoff_waits_for_inflight_get_before_transferring_claim(tmp_path, monkeypatch):
+    store = TelegramInboundStore(tmp_path / "telegram_inbound.db")
+    persisted = store.persist(
+        bot_account_id=111,
+        update_id=33,
+        decision=decision(payload(33)),
+        now=1.0,
+    )
+    old_queue = DurableTelegramUpdateQueue(
+        store=store,
+        bot_account_id=111,
+        classifier=lambda item: decision(item),
+        lease_owner="gateway:old-inflight",
+        active_limit=1,
+    )
+    assert await old_queue.wake_scheduler() == 1
+
+    lease_returned = threading.Event()
+    release_lease = threading.Event()
+    original_lease = store.lease_event
+
+    def delayed_lease(*args, **kwargs):
+        row = original_lease(*args, **kwargs)
+        lease_returned.set()
+        assert release_lease.wait(timeout=2.0)
+        return row
+
+    monkeypatch.setattr(store, "lease_event", delayed_lease)
+    get_task = asyncio.create_task(old_queue.get())
+    await asyncio.to_thread(lease_returned.wait, 1.0)
+
+    replacement = DurableTelegramUpdateQueue(
+        store=store,
+        bot_account_id=111,
+        classifier=lambda item: decision(item),
+        lease_owner="gateway:new-inflight",
+        active_limit=1,
+    )
+    handoff_task = asyncio.create_task(replacement.handoff_from(old_queue))
+    await asyncio.sleep(0.02)
+    assert not handoff_task.done()
+
+    release_lease.set()
+    item = await asyncio.wait_for(get_task, timeout=1.0)
+    result = await asyncio.wait_for(handoff_task, timeout=1.0)
+
+    assert item["update_id"] == 33
+    assert result["transferred"] == 1
+    assert result["requeued"] == 0
+    transferred = replacement.claim_for_update(33)
+    assert transferred is not None
+    assert transferred.event_id == persisted.event_id
+    assert store.get(persisted.event_id).lease_owner == "gateway:new-inflight"
+
+
+@pytest.mark.asyncio
+async def test_cancelled_get_requeues_after_sqlite_lease_commit(tmp_path, monkeypatch):
+    store = TelegramInboundStore(tmp_path / "telegram_inbound.db")
+    persisted = store.persist(
+        bot_account_id=111,
+        update_id=34,
+        decision=decision(payload(34)),
+        now=1.0,
+    )
+    queue = DurableTelegramUpdateQueue(
+        store=store,
+        bot_account_id=111,
+        classifier=lambda item: decision(item),
+        lease_owner="gateway:cancelled-get",
+        active_limit=1,
+    )
+    assert await queue.wake_scheduler() == 1
+
+    lease_returned = threading.Event()
+    release_lease = threading.Event()
+    original_lease = store.lease_event
+
+    def delayed_lease(*args, **kwargs):
+        row = original_lease(*args, **kwargs)
+        lease_returned.set()
+        assert release_lease.wait(timeout=2.0)
+        return row
+
+    monkeypatch.setattr(store, "lease_event", delayed_lease)
+    get_task = asyncio.create_task(queue.get())
+    await asyncio.to_thread(lease_returned.wait, 1.0)
+    get_task.cancel()
+    release_lease.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await get_task
+
+    row = store.get(persisted.event_id)
+    assert row is not None
+    assert row.work_state == "queued"
+    assert row.lease_owner is None
+    assert queue.claim_for_update(34) is None
+
+
+@pytest.mark.asyncio
+async def test_cancelled_put_after_durable_commit_recovers_admission(tmp_path, monkeypatch):
+    """Cancellation during admission must not strand a committed update."""
+    store = TelegramInboundStore(tmp_path / "telegram_inbound.db")
+    queue = DurableTelegramUpdateQueue(
+        store=store,
+        bot_account_id=111,
+        classifier=lambda item: decision(item),
+        lease_owner="gateway:cancelled-put-admission",
+        active_limit=1,
+    )
+    admission_started = asyncio.Event()
+    release_admission = asyncio.Event()
+    original_wake_scheduler = queue.wake_scheduler
+    wake_calls = 0
+
+    async def block_first_admission():
+        nonlocal wake_calls
+        wake_calls += 1
+        if wake_calls == 1:
+            admission_started.set()
+            await release_admission.wait()
+        return await original_wake_scheduler()
+
+    monkeypatch.setattr(queue, "wake_scheduler", block_first_admission)
+    put_task = asyncio.create_task(queue.put(payload(35)))
+    try:
+        await asyncio.wait_for(admission_started.wait(), timeout=0.5)
+        row = store.get("telegram:111:35")
+        assert row is not None
+        assert row.dispatch_state == "pending"
+
+        put_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await put_task
+
+        release_admission.set()
+        replay = await asyncio.wait_for(queue.get(), timeout=0.5)
+        assert replay["update_id"] == 35
+        queue.task_done()
+        assert await queue.complete_update(35, success=True)
+    finally:
+        release_admission.set()
+        if not put_task.done():
+            put_task.cancel()
+            await asyncio.gather(put_task, return_exceptions=True)
+        await queue.close()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_handoff_put_recovers_successor_admission(tmp_path, monkeypatch):
+    """A committed predecessor put must retry projection through its successor."""
+    store = TelegramInboundStore(tmp_path / "telegram_inbound.db")
+    predecessor = DurableTelegramUpdateQueue(
+        store=store,
+        bot_account_id=111,
+        classifier=lambda item: decision(item),
+        lease_owner="gateway:cancelled-handoff-predecessor",
+        active_limit=1,
+    )
+    successor = DurableTelegramUpdateQueue(
+        store=store,
+        bot_account_id=111,
+        classifier=lambda item: decision(item),
+        lease_owner="gateway:cancelled-handoff-successor",
+        active_limit=1,
+    )
+    original_persist = predecessor._persist_with_retry
+
+    async def persist_then_publish_successor(*, update_id, decision):
+        result = await original_persist(update_id=update_id, decision=decision)
+        with predecessor._claim_handoff_lock:
+            predecessor._handoff_target = successor
+        return result
+
+    monkeypatch.setattr(predecessor, "_persist_with_retry", persist_then_publish_successor)
+    admission_started = asyncio.Event()
+    release_admission = asyncio.Event()
+    original_wake_scheduler = successor.wake_scheduler
+    wake_calls = 0
+
+    async def block_first_successor_admission():
+        nonlocal wake_calls
+        wake_calls += 1
+        if wake_calls == 1:
+            admission_started.set()
+            await release_admission.wait()
+        return await original_wake_scheduler()
+
+    monkeypatch.setattr(successor, "wake_scheduler", block_first_successor_admission)
+    put_task = asyncio.create_task(predecessor.put(payload(36)))
+    try:
+        await asyncio.wait_for(admission_started.wait(), timeout=0.5)
+        row = store.get("telegram:111:36")
+        assert row is not None
+        assert row.dispatch_state == "pending"
+
+        put_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await put_task
+
+        release_admission.set()
+        replay = await asyncio.wait_for(successor.get(), timeout=0.5)
+        assert replay["update_id"] == 36
+        successor.task_done()
+        assert await successor.complete_update(36, success=True)
+    finally:
+        release_admission.set()
+        if not put_task.done():
+            put_task.cancel()
+            await asyncio.gather(put_task, return_exceptions=True)
+        await predecessor.close()
+        await successor.close()
+
+
+@pytest.mark.asyncio
+async def test_transient_lease_failure_does_not_escape_queue_get(tmp_path, monkeypatch):
+    """A local lease fault must be retried inside the PTB queue boundary."""
+    store = TelegramInboundStore(tmp_path / "telegram_inbound.db")
+    queue = DurableTelegramUpdateQueue(
+        store=store,
+        bot_account_id=111,
+        classifier=lambda item: decision(item),
+        lease_owner="gateway:locked-old",
+        active_limit=1,
+    )
+    await queue.put(payload(8001, message_id="9001"))
+    original_lease = store.lease_event
+    lease_calls = 0
+
+    def transient_lease(*args, **kwargs):
+        nonlocal lease_calls
+        lease_calls += 1
+        if lease_calls == 1:
+            raise sqlite3.OperationalError("database is locked")
+        return original_lease(*args, **kwargs)
+
+    monkeypatch.setattr(store, "lease_event", transient_lease)
+    queue._persist_retry_initial_seconds = 0.01
+    try:
+        replay = await asyncio.wait_for(queue.get(), timeout=0.5)
+        assert replay["update_id"] == 8001
+        assert lease_calls == 2
+        queue.task_done()
+        assert await queue.complete_update(8001, success=True)
+    finally:
+        await queue.suspend_projection()
+
+
+def test_sqlite_inbox_and_wal_sidecars_are_private_under_permissive_umask(tmp_path):
+    path = tmp_path / "telegram_inbound.db"
+    previous_umask = os.umask(0o022)
+    try:
+        store = TelegramInboundStore(path)
+        store.persist(
+            bot_account_id=111,
+            update_id=35,
+            decision=decision(payload(35)),
+            now=1.0,
+        )
+    finally:
+        os.umask(previous_umask)
+
+    candidates = [path, path.with_name(path.name + "-wal"), path.with_name(path.name + "-shm")]
+    existing = [candidate for candidate in candidates if candidate.exists()]
+    assert existing
+    assert all(stat.S_IMODE(candidate.stat().st_mode) == 0o600 for candidate in existing)
+
+
+def test_control_started_failure_is_terminal_and_retry_budget_is_bounded(tmp_path):
+    store = TelegramInboundStore(tmp_path / "telegram_inbound.db")
+    control = store.persist(
+        bot_account_id=111,
+        update_id=36,
+        decision=decision(payload(36), update_kind="callback_query"),
+        now=1.0,
+    )
+    leased = store.lease_event(control.event_id, owner="gateway:control", now=2.0)
+    assert leased is not None
+    assert store.mark_control_started(
+        control.event_id,
+        owner="gateway:control",
+        lease_epoch=leased.lease_epoch,
+    )
+    assert store.requeue(
+        control.event_id,
+        owner="gateway:control",
+        lease_epoch=leased.lease_epoch,
+        now=3.0,
+        error_class="handler_failed",
+    )
+    control_row = store.get(control.event_id)
+    assert control_row.work_state == "dead_letter"
+    assert control_row.terminal_reason == "control_effect_failed"
+
+    retry = store.persist(
+        bot_account_id=111,
+        update_id=37,
+        decision=decision(payload(37)),
+        now=1.0,
+    )
+    for attempt in range(1, 4):
+        leased = store.lease_event(retry.event_id, owner="gateway:retry", now=10.0 * attempt)
+        assert leased is not None
+        assert store.requeue(
+            retry.event_id,
+            owner="gateway:retry",
+            lease_epoch=leased.lease_epoch,
+            now=10.0 * attempt,
+            error_class="handler_failed",
+        )
+    retry_row = store.get(retry.event_id)
+    assert retry_row.work_state == "dead_letter"
+    assert retry_row.terminal_reason == "retry_budget_exhausted"
+
+
+@pytest.mark.asyncio
+async def test_deferred_completion_requeues_without_consuming_retry_budget(tmp_path):
+    store = TelegramInboundStore(tmp_path / "telegram_inbound.db")
+    persisted = store.persist(
+        bot_account_id=111,
+        update_id=38,
+        decision=decision(payload(38)),
+        now=1.0,
+    )
+    queue = DurableTelegramUpdateQueue(
+        store=store,
+        bot_account_id=111,
+        classifier=lambda item: decision(item),
+        lease_owner="gateway:deferred-cap",
+        active_limit=1,
+    )
+
+    assert await queue.wake_scheduler() == 1
+    for defer_round in range(MAX_ATTEMPTS + 1):
+        if defer_round:
+            await queue.wake_scheduler()
+        item = await asyncio.wait_for(queue.get(), timeout=0.5)
+        assert item["update_id"] == 38
+        claim = queue.claim_for_update(38)
+        assert claim is not None
+        queue.task_done()
+
+        assert await queue.complete_update(
+            38,
+            success=False,
+            delay=0.0,
+            defer=True,
+        )
+        row = store.get(persisted.event_id)
+        assert row is not None
+        assert row.work_state == "queued"
+        assert row.dispatch_state == "pending"
+        assert row.last_error_class == "busy_cap"
+        assert row.attempt_count == 0
+        assert store.pending_dispatch(now=time.time(), limit=10) == [row]
+
+    # A real owner failure after repeated deferred projections consumes one
+    # retry and remains replayable instead of inheriting the deferral count.
+    await queue.wake_scheduler()
+    replay = await asyncio.wait_for(queue.get(), timeout=0.5)
+    assert replay["update_id"] == 38
+    replay_claim = queue.claim_for_update(38)
+    assert replay_claim is not None
+    queue.task_done()
+    assert await queue.complete_update(38, success=False)
+
+    row = store.get(persisted.event_id)
+    assert row is not None
+    assert row.work_state == "queued"
+    assert row.dispatch_state == "pending"
+    assert row.last_error_class == "handler_failed"
+    assert row.attempt_count == 1
+    assert row.terminal_reason is None
+
+
+@pytest.mark.asyncio
+async def test_deferred_completion_wakes_projection_when_retry_becomes_due(tmp_path):
+    """A busy-cap retry must re-enter PTB without an unrelated wake event."""
+    store = TelegramInboundStore(tmp_path / "telegram_inbound.db")
+    queue = DurableTelegramUpdateQueue(
+        store=store,
+        bot_account_id=111,
+        classifier=lambda item: decision(item),
+        lease_owner="gateway:deferred-due-wake",
+        active_limit=1,
+    )
+
+    await queue.put(payload(39))
+    item = await queue.get()
+    assert item["update_id"] == 39
+    claim = queue.claim_for_update(39)
+    assert claim is not None
+    queue.task_done()
+
+    assert await queue.complete_update(
+        39,
+        success=False,
+        delay=0.05,
+        defer=True,
+    )
+    await asyncio.sleep(0.08)
+
+    replay = await asyncio.wait_for(queue.get(), timeout=0.3)
+    assert replay["update_id"] == 39
+    replay_claim = queue.claim_for_update(39)
+    assert replay_claim is not None
+    queue.task_done()
+    assert await queue.complete_update(39, success=True)
+
+
+def test_reconcile_consumed_is_scoped_to_the_bot_account(tmp_path):
+    store = TelegramInboundStore(tmp_path / "telegram_inbound.db")
+    account_111 = store.persist(
+        bot_account_id=111,
+        update_id=32,
+        decision=decision(payload(32, message_id="42")),
+        now=1.0,
+    )
+    account_222 = store.persist(
+        bot_account_id=222,
+        update_id=32,
+        decision=decision(payload(32, message_id="42")),
+        now=1.0,
+    )
+
+    assert store.reconcile_consumed(
+        bot_account_id=111,
+        committed_event_ids={account_111.event_id, account_222.event_id},
+        now=2.0,
+    ) == 1
+    assert store.get(account_111.event_id).work_state == "consumed"
+    assert store.get(account_222.event_id).work_state == "queued"
+
+    assert store.reconcile_consumed(
+        bot_account_id=222,
+        committed_event_ids={account_111.event_id, account_222.event_id},
+        now=3.0,
+    ) == 1
+    assert store.get(account_222.event_id).work_state == "consumed"
+
+
+def test_adapter_attaches_durable_queue_at_ptb_update_queue_boundary(tmp_path):
+    from gateway.config import PlatformConfig
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    adapter = object.__new__(TelegramAdapter)
+    adapter.config = PlatformConfig(
+        enabled=True, token="9223372036854775808:test-token", extra={}
+    )
+    adapter._inbound_store = TelegramInboundStore(tmp_path / "telegram_inbound.db")
+    adapter._inbound_queue = None
+    adapter._bot_account_id = None
+
+    class Builder:
+        def update_queue(self, queue):
+            self.queue = queue
+            return self
+
+    builder = Builder()
+    assert adapter._attach_inbound_queue(builder) is builder
+    assert builder.queue.bot_account_id == 9223372036854775808
+    assert builder.queue.store is adapter._inbound_store
+
+
+@pytest.mark.asyncio
+async def test_real_ptb_polling_survives_local_ingress_failure_and_executor_starvation(
+    tmp_path, monkeypatch
+):
+    import importlib
+    import sys
+
+    mocked_telegram_modules = {
+        name: module
+        for name, module in tuple(sys.modules.items())
+        if name == "telegram" or name.startswith("telegram.")
+    }
+    for name in mocked_telegram_modules:
+        sys.modules.pop(name, None)
+    importlib.invalidate_caches()
+    try:
+        importlib.import_module("telegram")
+    except ImportError:
+        sys.modules.update(mocked_telegram_modules)
+        pytest.skip("python-telegram-bot not installed")
+
+    from telegram.ext import Application
+    from telegram.request import BaseRequest
+
+    class GeneralRequest(BaseRequest):
+        @property
+        def read_timeout(self):
+            return 10
+
+        async def initialize(self):
+            return None
+
+        async def shutdown(self):
+            return None
+
+        async def do_request(self, url, method, request_data=None, **_kwargs):
+            if url.endswith("/getMe"):
+                return (
+                    200,
+                    b'{"ok":true,"result":{"id":111,"is_bot":true,'
+                    b'"first_name":"Test","username":"test_bot"}}',
+                )
+            return 200, b'{"ok":true,"result":true}'
+
+    class PollingRequest(BaseRequest):
+        def __init__(self):
+            self.offsets = []
+            self.replayed_offset_seen = asyncio.Event()
+
+        @property
+        def read_timeout(self):
+            return 10
+
+        async def initialize(self):
+            return None
+
+        async def shutdown(self):
+            return None
+
+        async def do_request(self, url, method, request_data=None, **_kwargs):
+            parameters = request_data.parameters if request_data is not None else {}
+            timeout = parameters.get("timeout")
+            timeout_seconds = (
+                timeout.total_seconds()
+                if hasattr(timeout, "total_seconds")
+                else timeout
+            )
+            if timeout_seconds == 0:
+                return 200, b'{"ok":true,"result":[]}'
+            offset = parameters.get("offset")
+            self.offsets.append(offset)
+            if offset is not None and int(offset) > 77:
+                self.replayed_offset_seen.set()
+                await asyncio.sleep(0.01)
+                return 200, b'{"ok":true,"result":[]}'
+            return (
+                200,
+                b'{"ok":true,"result":[{"update_id":77,"message":'
+                b'{"message_id":20,"date":1,"chat":{"id":10,"type":"private"},'
+                b'"from":{"id":30,"is_bot":false,"first_name":"U"},'
+                b'"text":"same"}}]}',
+            )
+
+    store = TelegramInboundStore(tmp_path / "telegram_inbound.db")
+    original_persist = store.persist
+    persist_calls = 0
+
+    def transient_persist(*args, **kwargs):
+        nonlocal persist_calls
+        persist_calls += 1
+        if persist_calls == 1:
+            raise sqlite3.OperationalError("database is locked")
+        return original_persist(*args, **kwargs)
+
+    monkeypatch.setattr(store, "persist", transient_persist)
+    queue = DurableTelegramUpdateQueue(
+        store=store,
+        bot_account_id=111,
+        classifier=lambda item: decision(item.to_dict()),
+        lease_owner="gateway:ptb-boundary",
+        active_limit=1,
+    )
+    queue._persist_retry_initial_seconds = 0.01
+    queue._persist_stall_log_seconds = 0.05
+    polling_request = PollingRequest()
+    app = (
+        Application.builder()
+        .token("111:test-token")
+        .request(GeneralRequest())
+        .get_updates_request(polling_request)
+        .update_queue(queue)
+        .build()
+    )
+    errors = []
+    initialized = False
+    release_default_executor = threading.Event()
+    default_executor_entered = threading.Event()
+    blocked_executor = ThreadPoolExecutor(
+        max_workers=1, thread_name_prefix="blocked-default-executor"
+    )
+    blocker = None
+    loop = asyncio.get_running_loop()
+    await asyncio.to_thread(lambda: None)
+    previous_executor = getattr(loop, "_default_executor")
+
+    def occupy_default_executor():
+        default_executor_entered.set()
+        release_default_executor.wait(timeout=3.0)
+
+    try:
+        await app.initialize()
+        initialized = True
+        loop.set_default_executor(blocked_executor)
+        blocker = blocked_executor.submit(occupy_default_executor)
+        assert default_executor_entered.wait(timeout=1.0)
+        await app.updater.start_polling(
+            poll_interval=0,
+            timeout=1,
+            bootstrap_retries=0,
+            drop_pending_updates=False,
+            error_callback=errors.append,
+        )
+
+        async def committed_and_acknowledged():
+            for _ in range(100):
+                row = store.get("telegram:111:77")
+                if row is not None and app.updater._last_update_id == 78:
+                    return row
+                await asyncio.sleep(0.01)
+            raise AssertionError(
+                "PTB did not durably commit and acknowledge update 77 while the "
+                "global executor was unavailable"
+            )
+
+        row = await committed_and_acknowledged()
+        assert row.update_id == 77
+        assert persist_calls == 2
+        assert errors == []
+        assert polling_request.offsets[0] == 0
+        await asyncio.wait_for(polling_request.replayed_offset_seen.wait(), timeout=1.0)
+        assert 78 in polling_request.offsets[1:]
+    finally:
+        release_default_executor.set()
+        loop.set_default_executor(previous_executor)
+        if blocker is not None:
+            blocker.result(timeout=1.0)
+        blocked_executor.shutdown(wait=True)
+        if app.updater.running:
+            await asyncio.wait_for(app.updater.stop(), timeout=2.0)
+        if initialized:
+            await app.shutdown()
+        for name in tuple(sys.modules):
+            if name == "telegram" or name.startswith("telegram."):
+                sys.modules.pop(name, None)
+        sys.modules.update(mocked_telegram_modules)
+
+
+@pytest.mark.asyncio
+async def test_real_ptb_application_fetcher_survives_transient_lease_failure(
+    tmp_path, monkeypatch
+):
+    """PTB 22.8's running fetcher must survive a local queue lease fault."""
+    import importlib
+    import sys
+
+    mocked_telegram_modules = {
+        name: module
+        for name, module in tuple(sys.modules.items())
+        if name == "telegram" or name.startswith("telegram.")
+    }
+    for name in mocked_telegram_modules:
+        sys.modules.pop(name, None)
+    importlib.invalidate_caches()
+    try:
+        telegram = importlib.import_module("telegram")
+    except ImportError:
+        sys.modules.update(mocked_telegram_modules)
+        pytest.skip("python-telegram-bot not installed")
+    from telegram.ext import Application, TypeHandler
+    from telegram.request import BaseRequest
+
+    class Request(BaseRequest):
+        @property
+        def read_timeout(self):
+            return 10
+
+        async def initialize(self):
+            return None
+
+        async def shutdown(self):
+            return None
+
+        async def do_request(self, url, method, request_data=None, **_kwargs):
+            del method, request_data
+            if url.endswith("/getMe"):
+                return (
+                    200,
+                    b'{"ok":true,"result":{"id":111,"is_bot":true,'
+                    b'"first_name":"Test","username":"test_bot"}}',
+                )
+            return 200, b'{"ok":true,"result":true}'
+
+    store = TelegramInboundStore(tmp_path / "telegram_inbound.db")
+    queue = DurableTelegramUpdateQueue(
+        store=store,
+        bot_account_id=111,
+        classifier=lambda item: decision(item.to_dict()),
+        lease_owner="gateway:ptb-fetcher",
+        active_limit=1,
+    )
+    queue._persist_retry_initial_seconds = 0.01
+    original_lease = store.lease_event
+    lease_calls = 0
+
+    def transient_lease(*args, **kwargs):
+        nonlocal lease_calls
+        lease_calls += 1
+        if lease_calls == 1:
+            raise sqlite3.OperationalError("database is locked")
+        return original_lease(*args, **kwargs)
+
+    monkeypatch.setattr(store, "lease_event", transient_lease)
+    app = (
+        Application.builder()
+        .token("111:test-token")
+        .request(Request())
+        .get_updates_request(Request())
+        .update_queue(queue)
+        .build()
+    )
+    handled = asyncio.Event()
+
+    async def record(update, _context):
+        assert update.update_id == 8201
+        handled.set()
+
+    app.add_handler(TypeHandler(telegram.Update, record))
+    initialized = False
+    started = False
+    try:
+        await app.initialize()
+        initialized = True
+        # A durable projection is rebuilt from SQLite payload, just as the
+        # adapter supplies its ``_deserialize_update`` factory in production.
+        queue.item_factory = lambda stored: telegram.Update.de_json(stored, app.bot)
+        await app.start()
+        started = True
+        await queue.put(telegram.Update.de_json(payload(8201), app.bot))
+        await asyncio.wait_for(handled.wait(), timeout=1.0)
+        fetcher = getattr(app, "_Application__update_fetcher_task")
+        assert not fetcher.done()
+        assert lease_calls == 2
+    finally:
+        if started and app.running:
+            await asyncio.wait_for(app.stop(), timeout=2.0)
+        if initialized:
+            await asyncio.wait_for(app.shutdown(), timeout=2.0)
+        await queue.close()
+        for name in tuple(sys.modules):
+            if name == "telegram" or name.startswith("telegram."):
+                sys.modules.pop(name, None)
+        sys.modules.update(mocked_telegram_modules)
+
+
+@pytest.mark.asyncio
+async def test_durable_pause_suppresses_network_recovery_and_resumes(
+    tmp_path, monkeypatch
+):
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    store = TelegramInboundStore(tmp_path / "telegram_inbound.db")
+    entered = threading.Event()
+    release = threading.Event()
+    original_persist = store.persist
+
+    def blocked_persist(*args, **kwargs):
+        entered.set()
+        assert release.wait(timeout=2.0)
+        return original_persist(*args, **kwargs)
+
+    monkeypatch.setattr(store, "persist", blocked_persist)
+    queue = DurableTelegramUpdateQueue(
+        store=store,
+        bot_account_id=111,
+        classifier=lambda item: decision(item),
+        lease_owner="gateway:pause-watchdog",
+        active_limit=1,
+    )
+    queue._persist_stall_log_seconds = 0.02
+    put_task = asyncio.create_task(queue.put(payload(79)))
+    for _ in range(50):
+        if entered.is_set():
+            break
+        await asyncio.sleep(0.01)
+    assert entered.is_set()
+    for _ in range(50):
+        if queue.ingress_paused:
+            break
+        await asyncio.sleep(0.01)
+    snapshot = queue.ingress_pause_snapshot()
+    assert snapshot["paused"] is True
+    assert snapshot["stage"] == "persist_wait"
+    assert snapshot["error_class"] == "TimeoutError"
+
+    webhook_info_calls = 0
+
+    async def get_webhook_info():
+        nonlocal webhook_info_calls
+        webhook_info_calls += 1
+        return SimpleNamespace(pending_update_count=1)
+
+    adapter = TelegramAdapter(
+        PlatformConfig(enabled=True, token="111:test-token", extra={})
+    )
+    adapter._webhook_mode = False
+    adapter._app = SimpleNamespace(updater=SimpleNamespace(running=True))
+    adapter._inbound_queue = queue
+    adapter._polling_error_task = None
+    adapter._polling_pending_stuck_count = 1
+    adapter._polling_generation = 2
+    adapter._polling_generation_started_monotonic = time.monotonic() - 500
+    adapter._polling_last_progress_monotonic = time.monotonic() - 400
+    bot = SimpleNamespace(get_webhook_info=get_webhook_info)
+
+    await adapter._probe_pending_updates(bot, 0.1)
+    await adapter._check_polling_stall()
+    assert webhook_info_calls == 0
+    assert adapter._polling_pending_stuck_count == 0
+    assert adapter._polling_error_task is None
+
+    release.set()
+    await asyncio.wait_for(put_task, timeout=1.0)
+    assert queue.ingress_paused is False
+    assert store.get("telegram:111:79") is not None
+
+
+@pytest.mark.asyncio
+async def test_post_commit_callback_failure_does_not_escape_ptb_boundary(tmp_path):
+    store = TelegramInboundStore(tmp_path / "telegram_inbound.db")
+
+    async def failing_callback(_item, _result):
+        raise RuntimeError("post-commit failure")
+
+    queue = DurableTelegramUpdateQueue(
+        store=store,
+        bot_account_id=111,
+        classifier=lambda item: decision(item),
+        after_commit=failing_callback,
+        lease_owner="gateway:post-commit",
+        active_limit=1,
+    )
+
+    await queue.put(payload(80))
+
+    assert store.get("telegram:111:80") is not None
+    assert (await asyncio.wait_for(queue.get(), timeout=0.5))["update_id"] == 80
+    queue.task_done()
+
+
+@pytest.mark.asyncio
+async def test_adapter_recovery_clears_stale_in_memory_dedup_keys(tmp_path):
+    from gateway.config import PlatformConfig
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    adapter = object.__new__(TelegramAdapter)
+    adapter.config = PlatformConfig(enabled=True, token="111:test-token", extra={})
+    adapter._inbound_store = TelegramInboundStore(tmp_path / "telegram_inbound.db")
+    adapter._inbound_queue = None
+    adapter._bot_account_id = None
+    adapter._durable_queue_bound = True
+    adapter._seen_update_ids = {("111", 44): None}
+    adapter._seen_platform_update_ids = {("111", 44): None}
+
+    queue = adapter._ensure_inbound_queue()
+    try:
+        await adapter._recover_inbound_queue()
+
+        assert adapter._seen_update_ids == {}
+        assert adapter._seen_platform_update_ids == {}
+    finally:
+        await queue.close()
+
+
+@pytest.mark.asyncio
+async def test_durable_backlog_above_ordinary_cap_remains_admitted(tmp_path):
+    store = TelegramInboundStore(tmp_path / "telegram_inbound.db")
+    queue = DurableTelegramUpdateQueue(
+        store=store,
+        bot_account_id=111,
+        classifier=lambda item: decision(item),
+        lease_owner="gateway:durable-cap-boundary",
+        active_limit=32,
+    )
+
+    for update_id in range(33):
+        await queue.put(payload(update_id, message_id=str(update_id)))
+
+    rows = [store.get(f"telegram:111:{update_id}") for update_id in range(33)]
+    assert all(row is not None for row in rows)
+    assert queue.qsize() == 32
+    assert rows[-1].dispatch_state == "pending"
+    assert rows[-1].work_state == "queued"
+
+
+@pytest.mark.asyncio
+async def test_non_actionable_ingress_does_not_share_durable_projection_limit(tmp_path):
+    store = TelegramInboundStore(tmp_path / "telegram_inbound.db")
+
+    def classify(item):
+        return decision(item, actionable=item["update_id"] == 1)
+
+    queue = DurableTelegramUpdateQueue(
+        store=store,
+        bot_account_id=111,
+        classifier=classify,
+        lease_owner="gateway:ordinary-ingress-boundary",
+        active_limit=1,
+    )
+
+    await queue.put(payload(1))
+    rejected = payload(2)
+    await asyncio.wait_for(queue.put(rejected), timeout=0.5)
+
+    assert queue.qsize() == 2
+    assert store.get("telegram:111:2") is None
+
+
+@pytest.mark.asyncio
+async def test_adapter_classifier_durably_admits_authorized_update_before_put_returns(
+    tmp_path,
+):
+    from gateway.config import PlatformConfig
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    adapter = object.__new__(TelegramAdapter)
+    adapter.config = PlatformConfig(enabled=True, token="111:test-token", extra={})
+    adapter._inbound_store = TelegramInboundStore(tmp_path / "telegram_inbound.db")
+    adapter._inbound_queue = None
+    adapter._bot_account_id = None
+    adapter._bot = SimpleNamespace(id=999)
+    adapter._is_user_authorized_from_message = lambda _message: True
+    adapter._is_own_message = lambda _message: False
+    adapter._should_process_message = lambda *_args, **_kwargs: True
+
+    message = SimpleNamespace(
+        message_id=41,
+        text="hello",
+        caption=None,
+        chat=SimpleNamespace(id=7, type="private"),
+        from_user=SimpleNamespace(id=8),
+        location=None,
+        venue=None,
+        photo=None,
+        video=None,
+        audio=None,
+        voice=None,
+        document=None,
+        sticker=None,
+    )
+    update = SimpleNamespace(
+        update_id=41,
+        message=message,
+        effective_message=message,
+        callback_query=None,
+        to_dict=lambda: {"update_id": 41, "message": {"message_id": 41}},
+    )
+    adapter._deserialize_update = lambda _payload: update
+    queue = adapter._ensure_inbound_queue()
+    assert adapter._classify_inbound_update(update).actionable is True
+
+    await queue.put(update)
+    row = queue.store.get("telegram:111:41")
+    assert row is not None
+    assert row.dispatch_state == "admitted"
+    assert (await queue.get()).update_id == 41
+    queue.task_done()
+
+
+@pytest.mark.asyncio
+async def test_adapter_classifier_keeps_rejected_update_out_of_durable_store(tmp_path):
+    from gateway.config import PlatformConfig
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    adapter = object.__new__(TelegramAdapter)
+    adapter.config = PlatformConfig(enabled=True, token="111:test-token", extra={})
+    adapter._inbound_store = TelegramInboundStore(tmp_path / "telegram_inbound.db")
+    adapter._inbound_queue = None
+    adapter._bot_account_id = None
+    adapter._bot = SimpleNamespace(id=999)
+    adapter._is_user_authorized_from_message = lambda _message: False
+    adapter._is_own_message = lambda _message: False
+
+    message = SimpleNamespace(
+        message_id=42,
+        text="blocked",
+        caption=None,
+        chat=SimpleNamespace(id=7, type="private"),
+        from_user=SimpleNamespace(id=8),
+        location=None,
+        venue=None,
+        photo=None,
+        video=None,
+        audio=None,
+        voice=None,
+        document=None,
+        sticker=None,
+    )
+    update = SimpleNamespace(
+        update_id=42,
+        message=message,
+        effective_message=message,
+        callback_query=None,
+        to_dict=lambda: {"update_id": 42, "message": {"message_id": 42}},
+    )
+    queue = adapter._ensure_inbound_queue()
+    assert adapter._classify_inbound_update(update).actionable is False
+
+    await queue.put(update)
+    assert queue.store.get("telegram:111:42") is None
+    assert (await queue.get()).update_id == 42
+    queue.task_done()
+
+
+@pytest.mark.asyncio
+async def test_reconnect_handoff_fences_old_handler_before_claim_publication(tmp_path):
+    """A handler that starts after handoff must not run the old callback."""
+    from gateway.config import Platform, PlatformConfig
+    from gateway.platforms.base import BasePlatformAdapter
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    update_id = 9223372036854776030
+    update_payload = payload(update_id, message_id=str(update_id))
+
+    class FakeUpdate:
+        def __init__(self, data):
+            self.update_id = data["update_id"]
+            self._data = data
+
+        def to_dict(self):
+            return self._data
+
+    store = TelegramInboundStore(tmp_path / "telegram_inbound.db")
+
+    def classify(item):
+        return decision(item)
+
+    def make_queue(owner):
+        return DurableTelegramUpdateQueue(
+            store=store,
+            bot_account_id=111,
+            classifier=classify,
+            lease_owner=owner,
+            active_limit=1,
+            item_factory=FakeUpdate,
+        )
+
+    old_queue = make_queue("gateway:old-handler-fence")
+    replacement_queue = make_queue("gateway:new-handler-fence")
+    await old_queue.put(update_payload)
+    old_update = await old_queue.get()
+    assert old_update.update_id == update_id
+    assert old_queue.claim_for_update(update_id) is not None
+    assert not old_queue.handler_claimed(update_id)
+
+    # This is the exact get-to-wrapper interval: the old queue has returned its
+    # item, but its registered wrapper has not published the handler claim.
+    assert await replacement_queue.handoff_from(old_queue) == {
+        "requeued": 1,
+        "transferred": 0,
+        "quarantined": 0,
+    }
+
+    def make_adapter(queue):
+        adapter = object.__new__(TelegramAdapter)
+        BasePlatformAdapter.__init__(
+            adapter,
+            PlatformConfig(enabled=True, token="111:test-token", extra={}),
+            Platform.TELEGRAM,
+        )
+        adapter._inbound_queue = queue
+        adapter._deferred_inbound_update_ids = set()
+        return adapter
+
+    old_calls = []
+    replacement_calls = []
+
+    async def old_callback(update, context):
+        del context
+        old_calls.append(update.update_id)
+
+    async def replacement_callback(update, context):
+        del context
+        replacement_calls.append(update.update_id)
+
+    old_adapter = make_adapter(old_queue)
+    replacement_adapter = make_adapter(replacement_queue)
+
+    # The old wrapper is deliberately invoked only after handoff. A missing
+    # claim here is ownership loss, not permission to run volatile work.
+    await old_adapter._wrap_inbound_handler(old_callback)(old_update, None)
+    old_queue.task_done()
+
+    replacement_update = await replacement_queue.get()
+    await replacement_adapter._wrap_inbound_handler(replacement_callback)(
+        replacement_update, None
+    )
+    replacement_queue.task_done()
+
+    assert old_calls == []
+    assert replacement_calls == [update_id]
+    row = store.get(f"telegram:111:{update_id}")
+    assert row is not None
+    assert row.work_state == "consumed"
+
+
+@pytest.mark.asyncio
+async def test_fresh_adapter_recovery_handoffs_delayed_old_handler(tmp_path):
+    """Production adapter recovery must fence a stale handler callback."""
+    from gateway.config import Platform, PlatformConfig
+    from gateway.platforms.base import BasePlatformAdapter
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    update_id = 9223372036854776031
+    update_payload = payload(update_id, message_id=str(update_id))
+
+    class FakeUpdate:
+        def __init__(self, data):
+            self.update_id = data["update_id"]
+            self._data = data
+
+        def to_dict(self):
+            return self._data
+
+    store = TelegramInboundStore(tmp_path / "telegram_inbound.db")
+
+    def make_adapter():
+        adapter = object.__new__(TelegramAdapter)
+        BasePlatformAdapter.__init__(
+            adapter,
+            PlatformConfig(enabled=True, token="111:test-token", extra={}),
+            Platform.TELEGRAM,
+        )
+        adapter._inbound_store = store
+        adapter._inbound_queue = None
+        adapter._bot_account_id = None
+        adapter._durable_queue_bound = True
+        adapter._classify_inbound_update = lambda update: decision(update)
+        adapter._deserialize_update = lambda payload: FakeUpdate(payload)
+        return adapter
+
+    old_adapter = make_adapter()
+    old_queue = old_adapter._ensure_inbound_queue()
+    await old_queue.put(update_payload)
+    old_update = await old_queue.get()
+    assert old_queue.claim_for_update(update_id) is not None
+
+    replacement_adapter = make_adapter()
+    replacement_queue = replacement_adapter._ensure_inbound_queue()
+    assert replacement_queue is not old_queue
+
+    # The real fresh-adapter recovery entry point must perform the handoff
+    # before it projects the replayable row into the replacement queue.
+    await replacement_adapter._recover_inbound_queue()
+    # Repeated replacement recovery is idempotent, and a late stale-adapter
+    # recovery must not reclaim or reverse the completed handoff.
+    await replacement_adapter._recover_inbound_queue()
+    await old_adapter._recover_inbound_queue()
+    assert replacement_queue.qsize() == 1
+
+    old_calls = []
+    replacement_calls = []
+
+    async def old_callback(update, context):
+        del context
+        old_calls.append(update.update_id)
+
+    async def replacement_callback(update, context):
+        del context
+        replacement_calls.append(update.update_id)
+
+    # Simulate the old registered handler being delayed after queue claim and
+    # entering its wrapper only after the replacement has recovered.
+    await old_adapter._wrap_inbound_handler(old_callback)(old_update, None)
+    old_queue.task_done()
+
+    replacement_update = await asyncio.wait_for(replacement_queue.get(), timeout=0.5)
+    await replacement_adapter._wrap_inbound_handler(replacement_callback)(
+        replacement_update, None
+    )
+    replacement_queue.task_done()
+
+    assert old_calls == []
+    assert replacement_calls == [update_id]
+    row = store.get(f"telegram:111:{update_id}")
+    assert row is not None
+    assert row.work_state == "consumed"
+
+
+@pytest.mark.asyncio
+async def test_held_durable_overflow_requeues_before_fresh_adapter_handoff(tmp_path):
+    """Overflowing a hold queue must not strand its durable claim."""
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    class FakeUpdate:
+        def __init__(self, data):
+            self.update_id = data["update_id"]
+            self._data = data
+
+        def to_dict(self):
+            return self._data
+
+    store = TelegramInboundStore(tmp_path / "telegram_inbound.db")
+
+    def make_adapter():
+        adapter = object.__new__(TelegramAdapter)
+        BasePlatformAdapter.__init__(
+            adapter,
+            PlatformConfig(enabled=True, token="111:test-token", extra={}),
+            Platform.TELEGRAM,
+        )
+        adapter._inbound_store = store
+        adapter._inbound_queue = None
+        adapter._bot_account_id = None
+        adapter._durable_queue_bound = True
+        adapter._classify_inbound_update = lambda update: decision(update)
+        adapter._deserialize_update = lambda payload: FakeUpdate(payload)
+        adapter._drop_delayed_deliveries = True
+        adapter._held_inbound_events = []
+        adapter.HELD_INBOUND_MAX = 1
+        return adapter
+
+    def held_event(update_id, *, durable=True):
+        metadata = (
+            {"telegram_durable_update_ids": [update_id]} if durable else {}
+        )
+        return MessageEvent(
+            text=f"held-{update_id}",
+            message_type=MessageType.TEXT,
+            source=SessionSource(
+                platform=Platform.TELEGRAM,
+                chat_id="10",
+                user_id="30",
+                chat_type="dm",
+            ),
+            message_id=str(update_id),
+            platform_update_id=update_id if durable else None,
+            metadata=metadata,
+        )
+
+    old_adapter = make_adapter()
+    old_queue = old_adapter._ensure_inbound_queue()
+    update_id = 7001
+    await old_queue.put(payload(update_id))
+    old_update = await old_queue.get()
+    old_queue.task_done()
+    assert old_update.update_id == update_id
+    assert old_queue.mark_handler_claim(update_id) is not None
+    old_event = held_event(update_id)
+    old_adapter._hold_inbound_event(old_event, where="overflow-seed", schedule=False)
+    row = store.get(f"telegram:111:{update_id}")
+    assert row is not None
+    assert row.work_state == "leased"
+
+    # A non-durable held event forces the durable event out of the bounded
+    # process-local hold list without introducing a second durable row.
+    replacement_event = held_event(7002, durable=False)
+    old_adapter._hold_inbound_event(
+        replacement_event, where="overflow-trigger", schedule=False
+    )
+    # The durable projection stays in the hold list until its asynchronous
+    # store transition is confirmed. The ordinary event is retained beside it
+    # while that bounded overflow cleanup is in flight.
+    assert old_adapter._held_inbound_events == [old_event, replacement_event]
+    await old_queue._wait_for_lifecycle_tasks()
+    assert old_adapter._held_inbound_events == [replacement_event]
+
+    replacement_adapter = make_adapter()
+    replacement_queue = replacement_adapter._ensure_inbound_queue()
+    await replacement_adapter._recover_inbound_queue()
+
+    row = store.get(f"telegram:111:{update_id}")
+    assert row is not None
+    assert row.work_state == "queued"
+    replacement_update = await asyncio.wait_for(replacement_queue.get(), timeout=0.5)
+    assert replacement_update.update_id == update_id
+    replacement_queue.task_done()
+    assert await replacement_queue.complete_update(update_id, success=True)
+    row = store.get(f"telegram:111:{update_id}")
+    assert row is not None
+    assert row.work_state == "consumed"
+
+
+@pytest.mark.asyncio
+async def test_started_held_durable_event_replays_after_handoff(tmp_path):
+    """A started event retained on hold must be requeued, never transferred alone."""
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    class FakeUpdate:
+        def __init__(self, data):
+            self.update_id = data["update_id"]
+            self._data = data
+
+        def to_dict(self):
+            return self._data
+
+    store = TelegramInboundStore(tmp_path / "telegram_inbound.db")
+
+    def make_adapter():
+        adapter = object.__new__(TelegramAdapter)
+        BasePlatformAdapter.__init__(
+            adapter,
+            PlatformConfig(enabled=True, token="111:test-token", extra={}),
+            Platform.TELEGRAM,
+        )
+        adapter._inbound_store = store
+        adapter._inbound_queue = None
+        adapter._bot_account_id = None
+        adapter._durable_queue_bound = True
+        adapter._classify_inbound_update = lambda update: decision(update)
+        adapter._deserialize_update = lambda data: FakeUpdate(data)
+        adapter._drop_delayed_deliveries = True
+        adapter._held_inbound_events = []
+        return adapter
+
+    update_id = 7003
+    old_adapter = make_adapter()
+    old_queue = old_adapter._ensure_inbound_queue()
+    await old_queue.put(payload(update_id))
+    claimed_update = await old_queue.get()
+    assert claimed_update.update_id == update_id
+    old_queue.task_done()
+    assert old_queue.mark_handler_claim(update_id) is not None
+    held = MessageEvent(
+        text="started-held",
+        message_type=MessageType.TEXT,
+        source=SessionSource(
+            platform=Platform.TELEGRAM, chat_id="10", user_id="30", chat_type="dm"
+        ),
+        message_id=str(update_id),
+        platform_update_id=update_id,
+        metadata={"telegram_durable_update_ids": [update_id]},
+    )
+    held._telegram_processing_started = True
+    old_adapter._hold_inbound_event(held, where="started-held", schedule=False)
+
+    replacement_adapter = make_adapter()
+    replacement_queue = replacement_adapter._ensure_inbound_queue()
+    await replacement_adapter._recover_inbound_queue()
+
+    replay = await asyncio.wait_for(replacement_queue.get(), timeout=0.5)
+    assert replay.update_id == update_id
+    replacement_queue.task_done()
+    assert await replacement_queue.complete_update(update_id, success=True)
+
+
+@pytest.mark.asyncio
+async def test_fresh_adapter_handoff_replays_held_text_batch(tmp_path):
+    """A held text batch must become a replayable replacement projection."""
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    class FakeUpdate:
+        def __init__(self, data):
+            self.update_id = data["update_id"]
+            message_data = data["message"]
+            self.message = SimpleNamespace(
+                message_id=message_data["message_id"],
+                text=message_data["text"],
+                caption=None,
+                chat=SimpleNamespace(
+                    id=message_data["chat"]["id"],
+                    type="private",
+                    is_forum=False,
+                ),
+                from_user=SimpleNamespace(id=30, is_bot=False),
+                sender_chat=None,
+            )
+            self.effective_message = self.message
+            self.callback_query = None
+
+    store = TelegramInboundStore(tmp_path / "telegram_inbound.db")
+
+    async def no_op(*_args, **_kwargs):
+        return None
+
+    def make_adapter():
+        adapter = object.__new__(TelegramAdapter)
+        BasePlatformAdapter.__init__(
+            adapter,
+            PlatformConfig(enabled=True, token="111:test-token", extra={}),
+            Platform.TELEGRAM,
+        )
+        adapter._inbound_store = store
+        adapter._inbound_queue = None
+        adapter._bot_account_id = None
+        adapter._durable_queue_bound = True
+        adapter._classify_inbound_update = lambda update: decision(update)
+        adapter._deserialize_update = lambda payload: FakeUpdate(payload)
+        adapter._is_user_authorized_from_message = lambda _message: True
+        adapter._should_process_message = lambda *_args, **_kwargs: True
+        adapter._ensure_forum_commands = no_op
+        adapter._build_message_event = lambda message, message_type, update_id=None: MessageEvent(
+            text=message.text,
+            message_type=message_type,
+            source=SessionSource(
+                platform=Platform.TELEGRAM,
+                chat_id=str(message.chat.id),
+                user_id="30",
+                chat_type="dm",
+            ),
+            message_id=str(message.message_id),
+            platform_update_id=update_id,
+            metadata={"telegram_durable_update_ids": [update_id]},
+        )
+        adapter._clean_bot_trigger_text = lambda text: text
+        adapter._cache_replied_media = no_op
+        adapter._apply_telegram_group_observe_attribution = lambda event: event
+        adapter._text_batch_key = lambda _event: "telegram:dm:10"
+        adapter._text_batch_delay_seconds = 60.0
+        adapter._seen_update_ids = {}
+        adapter._seen_platform_update_ids = {}
+        adapter._seen_update_ids_max = 4096
+        adapter._pending_text_batches = {}
+        adapter._pending_text_batch_tasks = {}
+        adapter._pending_photo_batches = {}
+        adapter._pending_photo_batch_tasks = {}
+        adapter._media_group_events = {}
+        adapter._media_group_tasks = {}
+        adapter._drop_delayed_deliveries = False
+        adapter._held_inbound_events = []
+        adapter._held_inbound_redispatch_task = None
+        return adapter
+
+    update_id = 7101
+    old_adapter = make_adapter()
+    old_queue = old_adapter._ensure_inbound_queue()
+    await old_queue.put(payload(update_id))
+    old_update = await old_queue.get()
+    old_queue.task_done()
+
+    old_handler = old_adapter._wrap_inbound_handler(old_adapter._handle_text_message)
+    await old_handler(old_update, None)
+    assert old_adapter._pending_text_batches
+    assert old_queue.handler_claimed(update_id)
+
+    old_adapter._mark_disconnected()
+    await old_adapter._cancel_pending_delivery_tasks()
+    assert len(old_adapter._held_inbound_events) == 1
+
+    replacement_adapter = make_adapter()
+    replacement_queue = replacement_adapter._ensure_inbound_queue()
+    await replacement_adapter._recover_inbound_queue()
+
+    assert old_adapter._held_inbound_events == []
+    replacement_update = await asyncio.wait_for(replacement_queue.get(), timeout=0.5)
+    assert replacement_update.update_id == update_id
+    replacement_queue.task_done()
+    assert await replacement_queue.complete_update(update_id, success=True)
+
+    row = store.get(f"telegram:111:{update_id}")
+    assert row is not None
+    assert row.work_state == "consumed"
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(replacement_queue.get(), timeout=0.05)
+
+
+@pytest.mark.asyncio
+async def test_partial_batched_durable_cleanup_converges(tmp_path):
+    """A partial durable requeue retains only IDs still needing cleanup."""
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    class Queue:
+        def __init__(self):
+            self.calls = []
+            self.outcomes = {1: [True], 2: [False, True]}
+
+        async def complete_update(self, update_id, **kwargs):
+            self.calls.append((update_id, kwargs))
+            values = self.outcomes[update_id]
+            return values.pop(0) if values else False
+
+    adapter = object.__new__(TelegramAdapter)
+    BasePlatformAdapter.__init__(
+        adapter,
+        PlatformConfig(enabled=True, token="111:test-token", extra={}),
+        Platform.TELEGRAM,
+    )
+    queue = Queue()
+    adapter._inbound_queue = queue
+    adapter._deferred_inbound_update_ids = {1, 2}
+    event = SimpleNamespace(
+        metadata={
+            "telegram_durable_update_ids": [1, 2],
+            "telegram_inbound_dispatch_deferred": True,
+        }
+    )
+
+    first = await adapter._complete_durable_event(
+        event,
+        success=False,
+        defer=True,
+    )
+    assert first is False
+    assert event.metadata["telegram_durable_update_ids"] == [2]
+    assert event.metadata["telegram_inbound_dispatch_deferred"] is True
+    assert adapter._deferred_inbound_update_ids == {2}
+
+    second = await adapter._complete_durable_event(
+        event,
+        success=False,
+        defer=True,
+    )
+    assert second is True
+    assert "telegram_durable_update_ids" not in event.metadata
+    assert "telegram_inbound_dispatch_deferred" not in event.metadata
+    assert adapter._deferred_inbound_update_ids == set()
+    assert [update_id for update_id, _kwargs in queue.calls] == [1, 2, 2]
+
+
+@pytest.mark.asyncio
+async def test_partial_batched_cleanup_retries_unresolved_real_queue_claim(
+    tmp_path, monkeypatch
+):
+    """A transient false transition must not strand the unresolved ID."""
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    store = TelegramInboundStore(tmp_path / "telegram_inbound.db")
+    for update_id in (1, 2):
+        store.persist(
+            bot_account_id=111,
+            update_id=update_id,
+            decision=decision(payload(update_id)),
+        )
+    queue = DurableTelegramUpdateQueue(
+        store=store,
+        bot_account_id=111,
+        classifier=lambda item: decision(item),
+        lease_owner="gateway:partial-cleanup",
+        active_limit=2,
+    )
+    assert await queue.wake_scheduler() == 2
+    assert (await queue.get())["update_id"] == 1
+    queue.task_done()
+    assert (await queue.get())["update_id"] == 2
+    queue.task_done()
+    # Keep this deterministic: completion wakes are not part of this probe.
+    queue._scheduler_loop = None
+
+    original_requeue = store.requeue
+    outcomes = {1: [True], 2: [False, True]}
+    calls = []
+
+    def transient_requeue(event_id, **kwargs):
+        update_id = int(event_id.rsplit(":", 1)[-1])
+        calls.append(update_id)
+        if not outcomes[update_id].pop(0):
+            return False
+        return original_requeue(event_id, **kwargs)
+
+    monkeypatch.setattr(store, "requeue", transient_requeue)
+    adapter = object.__new__(TelegramAdapter)
+    BasePlatformAdapter.__init__(
+        adapter,
+        PlatformConfig(enabled=True, token="111:test-token", extra={}),
+        Platform.TELEGRAM,
+    )
+    adapter._inbound_queue = queue
+    adapter._bot_account_id = "111"
+    adapter._deferred_inbound_update_ids = {1, 2}
+    event = MessageEvent(
+        text="batched",
+        message_type=MessageType.TEXT,
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="10",
+            user_id="30",
+            chat_type="dm",
+        ),
+        message_id="1",
+        metadata={
+            "telegram_durable_update_ids": [1, 2],
+            "telegram_inbound_dispatch_deferred": True,
+        },
+    )
+
+    assert await adapter._complete_durable_event(event, success=False, defer=True) is False
+    assert event.metadata["telegram_durable_update_ids"] == [2]
+    assert adapter._deferred_inbound_update_ids == {2}
+    assert store.get("telegram:111:1").work_state == "queued"
+    assert store.get("telegram:111:2").work_state == "leased"
+
+    assert await adapter._complete_durable_event(event, success=False, defer=True) is True
+    assert "telegram_durable_update_ids" not in event.metadata
+    assert "telegram_inbound_dispatch_deferred" not in event.metadata
+    assert adapter._deferred_inbound_update_ids == set()
+    assert store.get("telegram:111:2").work_state == "queued"
+    assert calls == [1, 2, 2]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure_mode", ("false", "cancelled", "exception"))
+async def test_failed_held_overflow_cleanup_remains_recoverable(
+    tmp_path, monkeypatch, failure_mode
+):
+    """Failed overflow cleanup must retain its durable projection."""
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    class FakeUpdate:
+        def __init__(self, data):
+            self.update_id = data["update_id"]
+            self._data = data
+
+        def to_dict(self):
+            return self._data
+
+    store = TelegramInboundStore(tmp_path / "telegram_inbound.db")
+
+    def make_adapter():
+        adapter = object.__new__(TelegramAdapter)
+        BasePlatformAdapter.__init__(
+            adapter,
+            PlatformConfig(enabled=True, token="111:test-token", extra={}),
+            Platform.TELEGRAM,
+        )
+        adapter._inbound_store = store
+        adapter._inbound_queue = None
+        adapter._bot_account_id = None
+        adapter._durable_queue_bound = True
+        adapter._classify_inbound_update = lambda update: decision(update)
+        adapter._deserialize_update = lambda payload: FakeUpdate(payload)
+        adapter._drop_delayed_deliveries = True
+        adapter._held_inbound_events = []
+        adapter.HELD_INBOUND_MAX = 1
+        return adapter
+
+    def held_event(update_id, *, durable=True):
+        metadata = (
+            {"telegram_durable_update_ids": [update_id]} if durable else {}
+        )
+        return MessageEvent(
+            text=f"held-{update_id}",
+            message_type=MessageType.TEXT,
+            source=SessionSource(
+                platform=Platform.TELEGRAM,
+                chat_id="10",
+                user_id="30",
+                chat_type="dm",
+            ),
+            message_id=str(update_id),
+            platform_update_id=update_id if durable else None,
+            metadata=metadata,
+        )
+
+    old_adapter = make_adapter()
+    old_queue = old_adapter._ensure_inbound_queue()
+    update_id = 7003
+    await old_queue.put(payload(update_id))
+    old_update = await old_queue.get()
+    old_queue.task_done()
+    assert old_update.update_id == update_id
+    assert old_queue.mark_handler_claim(update_id) is not None
+    old_event = held_event(update_id)
+    old_adapter._hold_inbound_event(old_event, where="overflow-seed", schedule=False)
+
+    completion_started = None
+    completion_finished = None
+    requeue_started = None
+    release_requeue = None
+    if failure_mode == "false":
+
+        def false_requeue(*args, **kwargs):
+            del args, kwargs
+            return False
+
+        monkeypatch.setattr(store, "requeue", false_requeue)
+    elif failure_mode == "cancelled":
+        completion_started = asyncio.Event()
+        completion_finished = asyncio.Event()
+        requeue_started = threading.Event()
+        release_requeue = threading.Event()
+        original_complete = old_queue.complete_update
+
+        async def tracked_complete(*args, **kwargs):
+            completion_started.set()
+            try:
+                return await original_complete(*args, **kwargs)
+            finally:
+                completion_finished.set()
+
+        def blocked_requeue(*args, **kwargs):
+            del args, kwargs
+            requeue_started.set()
+            if not release_requeue.wait(timeout=1.0):
+                raise RuntimeError("timed out waiting for cancellation probe")
+            return False
+
+        monkeypatch.setattr(old_queue, "complete_update", tracked_complete)
+        monkeypatch.setattr(store, "requeue", blocked_requeue)
+    elif failure_mode == "exception":
+
+        def failed_requeue(*args, **kwargs):
+            del args, kwargs
+            raise RuntimeError("forced overflow cleanup failure")
+
+        monkeypatch.setattr(store, "requeue", failed_requeue)
+
+    old_adapter._hold_inbound_event(
+        held_event(7004, durable=False),
+        where="overflow-trigger",
+        schedule=False,
+    )
+    cleanup_tasks = tuple(old_queue._lifecycle_tasks)
+    assert len(cleanup_tasks) == 1
+    if failure_mode == "cancelled":
+        assert completion_started is not None
+        assert requeue_started is not None
+        assert release_requeue is not None
+        assert completion_finished is not None
+        await asyncio.wait_for(completion_started.wait(), timeout=0.5)
+        assert requeue_started.wait(timeout=0.5)
+        cleanup_tasks[0].cancel()
+        release_requeue.set()
+        await asyncio.wait_for(completion_finished.wait(), timeout=0.5)
+    await old_queue._wait_for_lifecycle_tasks()
+
+    assert old_event in old_adapter._held_inbound_events
+    assert update_id in old_adapter._deferred_inbound_update_ids
+    # An unconfirmed requeue must retain the claim until handoff can safely
+    # requeue the buffered event instead of silently releasing its capacity.
+    assert old_queue.claim_for_update(update_id) is not None
+    row = store.get(f"telegram:111:{update_id}")
+    assert row is not None
+    assert row.work_state == "leased"
+
+    replacement_adapter = make_adapter()
+    replacement_queue = replacement_adapter._ensure_inbound_queue()
+    await replacement_adapter._recover_inbound_queue()
+    row = store.get(f"telegram:111:{update_id}")
+    assert row is not None
+    assert row.work_state == "queued"
+    replacement_update = await asyncio.wait_for(replacement_queue.get(), timeout=0.5)
+    assert replacement_update.update_id == update_id
+    replacement_queue.task_done()
+    assert await replacement_queue.complete_update(update_id, success=True)
+    row = store.get(f"telegram:111:{update_id}")
+    assert row is not None
+    assert row.work_state == "consumed"
+
+
+@pytest.mark.asyncio
+async def test_handoff_waits_for_transient_predecessor_ingress_before_retiring_executor(
+    tmp_path, monkeypatch
+):
+    """A pre-handoff PTB put must survive its first transient SQLite failure."""
+    store = TelegramInboundStore(tmp_path / "telegram_inbound.db")
+    original_persist = store.persist
+    first_failure = asyncio.Event()
+    persist_calls = 0
+
+    def transient_persist(*args, **kwargs):
+        nonlocal persist_calls
+        persist_calls += 1
+        if persist_calls == 1:
+            first_failure.set()
+            raise sqlite3.OperationalError("database is locked")
+        return original_persist(*args, **kwargs)
+
+    monkeypatch.setattr(store, "persist", transient_persist)
+    old_queue = DurableTelegramUpdateQueue(
+        store=store,
+        bot_account_id=111,
+        classifier=lambda item: decision(item),
+        lease_owner="gateway:handoff-ingress-old",
+        active_limit=1,
+    )
+    old_queue._persist_retry_initial_seconds = 0.01
+    replacement = DurableTelegramUpdateQueue(
+        store=store,
+        bot_account_id=111,
+        classifier=lambda item: decision(item),
+        lease_owner="gateway:handoff-ingress-new",
+        active_limit=1,
+    )
+    put_task = asyncio.create_task(old_queue.put(payload(8101)))
+    try:
+        await asyncio.wait_for(first_failure.wait(), timeout=0.5)
+        await asyncio.wait_for(replacement.handoff_from(old_queue), timeout=0.5)
+        await asyncio.wait_for(put_task, timeout=0.5)
+        row = store.get("telegram:111:8101")
+        assert row is not None
+        assert row.work_state == "queued"
+        assert persist_calls == 2
+    finally:
+        if not put_task.done():
+            put_task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await put_task
+        await old_queue.suspend_projection()
+        await replacement.suspend_projection()
+
+
+@pytest.mark.asyncio
+async def test_false_consumed_transition_retries_without_a_second_handler_call(
+    tmp_path, monkeypatch
+):
+    """A false terminal transition must retain ownership until it commits."""
+    store = TelegramInboundStore(tmp_path / "telegram_inbound.db")
+    queue = DurableTelegramUpdateQueue(
+        store=store,
+        bot_account_id=111,
+        classifier=lambda item: decision(item),
+        lease_owner="gateway:false-terminal",
+        active_limit=1,
+    )
+    original_mark_consumed = store.mark_consumed
+    attempts = 0
+
+    def false_once(*args, **kwargs):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            return False
+        return original_mark_consumed(*args, **kwargs)
+
+    monkeypatch.setattr(store, "mark_consumed", false_once)
+    await queue.put(payload(8301))
+    assert (await queue.get())["update_id"] == 8301
+    queue.task_done()
+    try:
+        assert not await queue.complete_update(8301, success=True)
+        for _ in range(50):
+            row = store.get("telegram:111:8301")
+            if (
+                row is not None
+                and row.work_state == "consumed"
+                and queue.claim_for_update(8301) is None
+            ):
+                break
+            await asyncio.sleep(0.01)
+        row = store.get("telegram:111:8301")
+        assert row is not None
+        assert row.work_state == "consumed"
+        assert attempts == 2
+        assert queue.claim_for_update(8301) is None
+    finally:
+        await queue.close()
+
+
+@pytest.mark.asyncio
+async def test_raising_deferred_requeue_retries_without_releasing_the_claim(
+    tmp_path, monkeypatch
+):
+    """A transient deferred requeue failure must resolve without reconnect."""
+    store = TelegramInboundStore(tmp_path / "telegram_inbound.db")
+    queue = DurableTelegramUpdateQueue(
+        store=store,
+        bot_account_id=111,
+        classifier=lambda item: decision(item),
+        lease_owner="gateway:raising-requeue",
+        active_limit=1,
+    )
+    original_requeue = store.requeue
+    attempts = 0
+    retry_transitioned = asyncio.Event()
+    projection_scheduled = asyncio.Event()
+    loop = asyncio.get_running_loop()
+    original_schedule_projection_retry = queue._schedule_projection_retry
+
+    def record_projection_retry():
+        original_schedule_projection_retry()
+        projection_scheduled.set()
+
+    def raise_once(*args, **kwargs):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise sqlite3.OperationalError("database is locked")
+        transitioned = original_requeue(*args, **kwargs)
+        loop.call_soon_threadsafe(retry_transitioned.set)
+        return transitioned
+
+    monkeypatch.setattr(store, "requeue", raise_once)
+    monkeypatch.setattr(queue, "_schedule_projection_retry", record_projection_retry)
+    await queue.put(payload(8302))
+    assert (await queue.get())["update_id"] == 8302
+    queue.task_done()
+    try:
+        assert not await queue.complete_update(8302, success=False, defer=True)
+        await asyncio.wait_for(retry_transitioned.wait(), timeout=0.5)
+        await asyncio.wait_for(projection_scheduled.wait(), timeout=0.5)
+        projection_task = queue._projection_retry_task
+        assert projection_task is not None
+        await asyncio.wait_for(asyncio.shield(projection_task), timeout=0.5)
+        row = store.get("telegram:111:8302")
+        assert row is not None
+        assert row.work_state == "queued"
+        # The zero delay means automatic recovery is immediately projected;
+        # awaiting that physical retry proves the row was not stranded leased.
+        assert row.dispatch_state == "admitted"
+        assert attempts == 2
+        assert queue.claim_for_update(8302) is None
+        replay = await asyncio.wait_for(queue.get(), timeout=0.5)
+        assert replay["update_id"] == 8302
+        queue.task_done()
+        assert await queue.complete_update(8302, success=True)
+    finally:
+        await queue.close()
+
+
+@pytest.mark.asyncio
+async def test_unhandled_claim_expiry_reclaims_projection_capacity(tmp_path):
+    """A PTB update that never reaches a wrapper cannot permanently fill the window."""
+    store = TelegramInboundStore(tmp_path / "telegram_inbound.db")
+    queue = DurableTelegramUpdateQueue(
+        store=store,
+        bot_account_id=111,
+        classifier=lambda item: decision(item),
+        lease_owner="gateway:unhandled-expiry",
+        active_limit=1,
+    )
+    queue._prehandler_lease_seconds = 0.02
+    await queue.put(payload(8303))
+    first = await queue.get()
+    assert first["update_id"] == 8303
+    queue.task_done()
+    try:
+        for _ in range(50):
+            row = store.get("telegram:111:8303")
+            if (
+                row is not None
+                and row.work_state == "queued"
+                and queue.claim_for_update(8303) is None
+            ):
+                break
+            await asyncio.sleep(0.01)
+        row = store.get("telegram:111:8303")
+        assert row is not None
+        assert row.work_state == "queued"
+        assert queue.claim_for_update(8303) is None
+        replay = await asyncio.wait_for(queue.get(), timeout=0.5)
+        assert replay["update_id"] == 8303
+        assert queue.mark_handler_claim(8303) is not None
+        queue.task_done()
+        assert await queue.complete_update(8303, success=True)
+    finally:
+        await queue.close()
+
+
+@pytest.mark.asyncio
+async def test_invalid_projection_factory_output_is_requeued_not_delivered(tmp_path):
+    """A projection that cannot be a Telegram update must not consume a lease."""
+    store = TelegramInboundStore(tmp_path / "telegram_inbound.db")
+    queue = DurableTelegramUpdateQueue(
+        store=store,
+        bot_account_id=111,
+        classifier=lambda item: decision(item),
+        item_factory=lambda _payload: object(),
+        lease_owner="gateway:invalid-factory",
+        active_limit=1,
+    )
+    try:
+        await queue.put(payload(8304))
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(queue.get(), timeout=0.05)
+        row = store.get("telegram:111:8304")
+        assert row is not None
+        assert row.work_state == "queued"
+        assert row.dispatch_state == "pending"
+        assert queue.claim_for_update(8304) is None
+    finally:
+        await queue.close()
+
+
+@pytest.mark.asyncio
+async def test_late_put_after_close_fails_without_waiting_on_handoff(tmp_path):
+    """A terminally closed queue must reject ingress instead of busy-spinning."""
+    store = TelegramInboundStore(tmp_path / "telegram_inbound.db")
+    queue = DurableTelegramUpdateQueue(
+        store=store,
+        bot_account_id=111,
+        classifier=lambda item: decision(item),
+        lease_owner="gateway:closed-ingress",
+        active_limit=1,
+    )
+    await queue.close()
+    waited = False
+
+    async def unexpected_wait(_event):
+        nonlocal waited
+        waited = True
+        raise AssertionError("closed ingress attempted to wait for handoff")
+
+    queue._wait_for_claim_event = unexpected_wait
+    with pytest.raises(RuntimeError, match="closed"):
+        await queue.put(payload(8305))
+    assert not waited
+
+
+@pytest.mark.asyncio
+async def test_disconnect_closes_executor_and_reconnects_with_fresh_queue(tmp_path):
+    """Clean disconnect must retire SQLite work without breaking same-adapter reconnect."""
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    store = TelegramInboundStore(tmp_path / "telegram_inbound.db")
+    adapter = TelegramAdapter(
+        PlatformConfig(enabled=True, token="111:test-token", extra={})
+    )
+    adapter._inbound_store = store
+    adapter._durable_queue_bound = True
+    first = adapter._ensure_inbound_queue()
+    replacement = None
+
+    class FakeUpdate:
+        def __init__(self, data):
+            self.update_id = data["update_id"]
+            self._data = data
+
+        def to_dict(self):
+            return self._data
+
+    try:
+        worker_name = await asyncio.wait_for(
+            first._run_store(lambda: threading.current_thread().name), timeout=1.0
+        )
+        assert worker_name.startswith("telegram-inbound-111")
+        first_executor = first._store_executor
+
+        await asyncio.wait_for(adapter.disconnect(), timeout=2.0)
+
+        assert first._store_executor_shutdown
+        replacement = adapter._ensure_inbound_queue()
+        assert replacement is not first
+        assert replacement._store_executor is not first_executor
+        assert adapter._retired_inbound_queue is first
+
+        await asyncio.wait_for(adapter._recover_inbound_queue(), timeout=2.0)
+
+        assert adapter._retired_inbound_queue is None
+        assert first._handoff_target is replacement
+        replacement.classifier = lambda item: decision(item)
+        replacement.item_factory = FakeUpdate
+        await asyncio.wait_for(replacement.put(payload(8307)), timeout=1.0)
+        assert (
+            await asyncio.wait_for(replacement.get(), timeout=1.0)
+        ).update_id == 8307
+        replacement.task_done()
+        assert await asyncio.wait_for(
+            replacement.complete_update(8307, success=True), timeout=1.0
+        )
+    finally:
+        if replacement is not None:
+            await replacement.close()
+        if not first._store_executor_shutdown:
+            await first.close()


### PR DESCRIPTION
## What does this PR do?

Telegram polling could acknowledge authorized actionable updates before the gateway had durable ownership. A process loss, reconnect, cancellation, busy deferral, or plugin-handler rebuild could therefore lose work, replay stale work, or strand a claim.

This change persists authorized actionable updates in a bot-account-scoped SQLite inbox before PTB dispatch or polling progress. It adds fenced leases, ordered replay, cancellation recovery, same-process reconnect handoff, callback quarantine, and compatibility checks for the existing SQLite schema. Plugin-installed handlers use the same durable boundary.

No configuration keys are added. The candidate changes six files: `gateway/run.py`, the Telegram adapter and inbound store, and three focused test files.

## Related Issue

No direct issue identified.

## Type of Change

- ☑ 🐛 Bug fix (non-breaking change that fixes an issue)
- ☐ ✨ New feature (non-breaking change that adds functionality)
- ☐ 🔒 Security fix
- ☐ 📝 Documentation update
- ☐ ✅ Tests only
- ☐ ♻️ Refactor (no behavior change)
- ☐ 🎯 New skill (bundled or hub)

## Changes Made

- Persist authorized actionable Telegram updates before PTB dispatch or polling progress.
- Use account-scoped SQLite ownership, fenced leases, ordered replay, retry state, quarantine, and migration preflight checks.
- Recover in-flight persistence and lease transitions across cancellation, failure, and same-process reconnect handoff.
- Route plugin-installed handlers through the durable boundary, including PTB application rebuilds.
- Add focused regressions for durable ownership, cancellation, reconnect and handoff, migration compatibility, replay, and non-Telegram queue behavior.

## How to Test

1. Run the focused suite:

   ```bash
   scripts/run_tests.sh -q tests/gateway/test_queue_consumption.py tests/gateway/test_telegram_handler_dedup.py tests/gateway/test_telegram_inbound_store.py tests/gateway/test_config.py
   ```

2. Run Ruff on the requested scope:

   ```bash
   ruff check gateway/config.py gateway/run.py plugins/platforms/telegram/adapter.py plugins/platforms/telegram/inbound_store.py tests/gateway/test_config.py tests/gateway/test_queue_consumption.py tests/gateway/test_telegram_handler_dedup.py tests/gateway/test_telegram_inbound_store.py
   ```

3. Check the diff:

   ```bash
   git diff --check origin/main...HEAD
   ```

## Checklist

### Code

- ☑ I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- ☑ My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- ☑ This PR contains only changes related to this fix
- ☐ Full repository tests were not run; the exact focused suite below passed
- ☑ Focused regression tests cover the changed behavior
- ☑ Tested on Linux

### Documentation & Housekeeping

- ☑ Relevant documentation: N/A; no user-facing workflow changed
- ☑ `cli-config.yaml.example`: N/A; no configuration keys changed
- ☑ `CONTRIBUTING.md` / `AGENTS.md`: N/A; no contributor workflow changed
- ☐ Windows was not run locally; CI remains authoritative
- ☑ Tool descriptions/schemas: N/A; no tool contract changed

## Screenshots / Logs

| Validation gate | Result |
| --- | ---: |
| Exact-head focused suite | 156 passed, 0 failed |
| Ruff on the requested eight paths | Passed |
| `git diff --check origin/main...HEAD` | Passed |
| Scope against current `origin/main` | 6 files, 9,551 insertions, 64 deletions; no unexpected paths |

### Live Telegram restart/replay validation

Validated on 2026-08-30 against exact public/runtime commit `94f01bff2cf9fed450b4284eabdab6912cd60bce` (tree `f07dae1931263a6aea319a0a368626ac01ac52b8`) while the PR remained draft.

- Captured four real Telegram updates as distinct durable events: sequences `91`–`94`, update IDs `118018790`–`118018793`, and message IDs `24828`, `24829`, `24832`, and `24833`.
- Restarted the gateway while sequence `91` owned a foreground task and sequences `92`–`94` were admitted behind it.
- A local one-minute self-healing watchdog, separate from Hermes Agent, overlapped the controlled restart. It observed the gateway PID file during the brief window before the service recreated it and invoked its configured repair restart. This unintentionally exercised two consecutive restarts; logs showed no unexplained gateway crash.
- After recovery, sequences `92`–`94` each replayed once (`attempt_count=2`, `lease_epoch=2`, `replay_count=1`). All four rows reached `work_state=consumed` with no lease owner or stuck row.
- User-visible output contained the expected ACK for sequence `92` and two identical ACK lines for sequences `93` and `94`, proving identical message text did not collapse distinct Telegram updates.
- The active foreground task was interrupted by shutdown as expected. The Telegram session restored without retrying that command.
- Exact-head GitHub CI completed with `All required checks pass`.

## Infographic

![Telegram durable ingress: commit before dispatch, fenced handoff, and ordered replay](https://v3b.fal.media/files/b/0aa8319d/ym3uv9huT70SkQAbO2-Fg_P3dXmliH.png)
