### PR TITLE
chore: add .install_method to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,6 +119,10 @@ docs/superpowers/*
 # treat it as a local edit and autostash it on every run (#38529).
 .hermes-bootstrap-complete
 
+# Install method marker — records how Hermes was installed at runtime; never a
+# code change, keep git status clean.
+.install_method
+
 # Interrupted-update breadcrumb + recovery lock written next to the shared venv
 # by `hermes update` / launch-time self-heal. Runtime state, never a code change
 # — ignore so `git status` stays clean and update's autostash skips them.


### PR DESCRIPTION
Stabilization PR — ignore runtime install-method marker so git status stays clean. The file is Hermes-managed runtime state, never a code change.