### PR TITLE
fix(update): only require fleet verification for gateway runtimes

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -10103,7 +10103,14 @@ def _fleet_probe_expected_runtimes(
         return True
     try:
         if pre_update_plan is not None and pre_update_plan.runtimes:
-            return True
+            # Only gateway runtimes require fleet verification;
+            # dashboard/serve-only plans don't need gateway rows.
+            has_gateway = any(
+                getattr(r, 'kind', '') == 'gateway'
+                for r in pre_update_plan.runtimes
+            )
+            if has_gateway:
+                return True
     except Exception:
         pass
     return False


### PR DESCRIPTION
## Summary

This PR fixes #97332 by only requiring fleet verification for gateway runtimes, not dashboard/serve runtimes.

## Problem

The updater was treating any runtime (dashboard, serve) as evidence that gateway fleet verification was needed. This caused `hermes update` to exit 1 even when only a dashboard was running and the update succeeded.

## Solution

Filter `pre_update_plan.runtimes` to only count gateway runtimes as evidence requiring fleet verification:

```python
has_gateway = any(
    getattr(r, 'kind', '') == 'gateway'
    for r in pre_update_plan.runtimes
)
if has_gateway:
    return True
```

Dashboard/serve-only plans no longer trigger the gateway fleet check.

## Changes

- Modified `hermes_cli/update_cmd.py`: Added gateway-specific filtering in `_fleet_probe_expected_runtimes`

---

🤖 Generated with Codebuff
Co-Authored-By: Codebuff <noreply@codebuff.com>