### PR TITLE
fix(skill_manage): batch failures keep the failing op's file_preview — models no longer recover blind

### DIFF
--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -1725,16 +1725,24 @@ def _skill_manage_batch(
                 parsed = {"success": False, "error": "unparseable op result"}
             if not parsed.get("success"):
                 note = _rollback()
-                return json.dumps(
-                    {"success": False,
-                     "error": (
-                         f"operations[{i}] ({op['action']} on '{names[i]}') failed: "
-                         f"{parsed.get('error', 'unknown error')} — batch aborted, {note}."
-                     ),
-                     "failed_index": i,
-                     "completed_before_failure": i},
-                    ensure_ascii=False,
-                )
+                fail = {
+                    "success": False,
+                    "error": (
+                        f"operations[{i}] ({op['action']} on '{names[i]}') failed: "
+                        f"{parsed.get('error', 'unknown error')} — batch aborted, {note}."
+                    ),
+                    "failed_index": i,
+                    "completed_before_failure": i,
+                }
+                # Carry the failing op's teaching payload through (e.g.
+                # patch's file_preview / fuzzy-match hints): without it the
+                # model recovers blind — live A/B showed sonnet probing a
+                # file with placeholder edits for 8 turns because the batch
+                # path dropped the preview the flat path always returned.
+                for k, v in parsed.items():
+                    if k not in ("success", "error") and v is not None:
+                        fail.setdefault(k, v)
+                return json.dumps(fail, ensure_ascii=False)
             results.append({"name": names[i], "action": op["action"],
                             "file_path": op.get("file_path"),
                             "success": True})


### PR DESCRIPTION
## Summary
Batch skill_manage failures now return the failing op's full teaching payload (`file_preview`, fuzzy-match hints) — before this, models recovered blind after any mid-batch patch miss, because the batch wrapper rebuilt the error dict and dropped every field except the message.

Found by a live A/B eval of the operations[] interface (#97295) across 3 models × 5 multi-op skill tasks × 2 arms × 3 reps (90 runs): claude-sonnet-5 on a three-targeted-edits task went 1/3 pass, ~15 calls, 50k tokens on the batch arm — the transcript showed it *probing the file by writing and reverting placeholder patches* because the flat path's `file_preview` never arrived. With this fix: 3/3 pass, 4 calls, 16k tokens.

## Changes
- `tools/skill_manager_tool.py`: on op failure, `_skill_manage_batch` merges through all non-`success`/`error` fields from the failing op's result (setdefault, so batch keys win).

## Validation
Live A/B, sonnet-5 `three_patches` batch arm (n=3):

| | without fix | with fix |
|---|---|---|
| pass | 1/3 | 3/3 |
| avg turns | 10.0 | 5.0 |
| avg tokens | 50,044 | 16,135 |

Full 90-run eval (all 3 models, final): new interface 45/45 ok, 1.58 vs 3.51 avg calls, 4.6k vs 8.0k avg tokens vs the flat schema; zero flat-shape fallbacks. `tests/tools/test_skill_manage_batch.py` 8/8 green.

## Infographic

![skill_manage batch teaching errors restored](https://v3b.fal.media/files/b/0aa83239/hD00wMAmi8MmnpzUaZtZ-_LJSpSLA3.png)
