### PR TITLE
fix(cron): add self-check to prevent false gateway liveness negatives

### DIFF
--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -78,6 +78,18 @@ def _builtin_gateway_liveness() -> Optional[bool]:
     try:
         if _active_cron_provider_name() != "builtin":
             return True  # external provider fires jobs without the gateway
+        
+        # Self-check: if we're inside the gateway process, we're alive.
+        # This prevents false negatives when the cron tool runs in-process.
+        try:
+            import os
+            from gateway.status import get_running_pid
+            running_pid = get_running_pid()
+            if running_pid is not None and running_pid == os.getpid():
+                return True
+        except Exception:
+            pass
+        
         # The gateway runtime lock is held for exactly the gateway's lifetime, so it
         # is a more reliable "is the ticker's process alive" signal than PID scanning
         # — and inside the gateway process it short-circuits to True, so the in-gateway


### PR DESCRIPTION
## Summary

This PR fixes #97291 by adding a PID self-check to prevent false gateway liveness negatives when the cron tool runs inside the gateway process.

## Problem

The cronjob tool was reporting `gateway_running: false` when called from inside a live gateway process. The existing `is_gateway_runtime_lock_active` check wasn't catching all cases.

## Solution

Added a PID self-check that compares `os.getpid()` with the running gateway PID:

```python
# Self-check: if we're inside the gateway process, we're alive.
# This prevents false negatives when the cron tool runs in-process.
try:
    import os
    from gateway.status import get_running_pid
    running_pid = get_running_pid()
    if running_pid is not None and running_pid == os.getpid():
        return True
except Exception:
    pass
```

When the cron tool runs in-process, this short-circuits to `True` before the scan paths, preventing false negatives.

## Changes

- Modified `hermes_cli/cron.py`: Added PID self-check in `_builtin_gateway_liveness`

---

🤖 Generated with Codebuff
Co-Authored-By: Codebuff <noreply@codebuff.com>