### PR TITLE
fix(doctor): prevent false positives for WAL and launcher checks

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -2175,20 +2175,47 @@ def run_doctor(args):
         try:
             wal_size = wal_path.stat().st_size
             if wal_size > 50 * 1024 * 1024:  # 50 MB
-                check_warn(
-                    f"WAL file is large ({wal_size // (1024*1024)} MB)",
-                    "(may indicate missed checkpoints)"
-                )
-                if should_fix:
+                # Check if WAL is fully checkpointed before flagging as issue
+                try:
                     import sqlite3
                     conn = sqlite3.connect(str(state_db_path))
-                    conn.execute("PRAGMA wal_checkpoint(PASSIVE)")
+                    result = conn.execute("PRAGMA wal_checkpoint(PASSIVE)").fetchone()
                     conn.close()
-                    new_size = wal_path.stat().st_size if wal_path.exists() else 0
-                    check_ok(f"WAL checkpoint performed ({wal_size // 1024}K → {new_size // 1024}K)")
-                    fixed_count += 1
-                else:
-                    issues.append("Large WAL file — run 'hermes doctor --fix' to checkpoint")
+                    # result: (busy, log, checkpointed)
+                    # If all frames checkpointed (log == checkpointed), WAL is healthy
+                    if result and result[1] == result[2]:
+                        check_info(f"WAL file is {wal_size // (1024*1024)} MB (fully checkpointed, healthy)")
+                    else:
+                        check_warn(
+                            f"WAL file is large ({wal_size // (1024*1024)} MB)",
+                            "(may indicate missed checkpoints)"
+                        )
+                        if should_fix:
+                            import sqlite3
+                            conn = sqlite3.connect(str(state_db_path))
+                            conn.execute("PRAGMA wal_checkpoint(PASSIVE)")
+                            conn.close()
+                            new_size = wal_path.stat().st_size if wal_path.exists() else 0
+                            check_ok(f"WAL checkpoint performed ({wal_size // 1024}K → {new_size // 1024}K)")
+                            fixed_count += 1
+                        else:
+                            issues.append("Large WAL file — run 'hermes doctor --fix' to checkpoint")
+                except Exception:
+                    # If we can't check, assume it's an issue
+                    check_warn(
+                        f"WAL file is large ({wal_size // (1024*1024)} MB)",
+                        "(may indicate missed checkpoints)"
+                    )
+                    if should_fix:
+                        import sqlite3
+                        conn = sqlite3.connect(str(state_db_path))
+                        conn.execute("PRAGMA wal_checkpoint(PASSIVE)")
+                        conn.close()
+                        new_size = wal_path.stat().st_size if wal_path.exists() else 0
+                        check_ok(f"WAL checkpoint performed ({wal_size // 1024}K → {new_size // 1024}K)")
+                        fixed_count += 1
+                    else:
+                        issues.append("Large WAL file — run 'hermes doctor --fix' to checkpoint")
             elif wal_size > 10 * 1024 * 1024:  # 10 MB
                 check_info(f"WAL file is {wal_size // (1024*1024)} MB (normal for active sessions)")
         except Exception:
@@ -2251,10 +2278,16 @@ def run_doctor(args):
                 # It's a regular file, not a symlink — possibly a wrapper script
                 check_ok(f"{_cmd_link_display}/hermes exists (non-symlink)")
             else:
-                check_fail(
-                    f"{_cmd_link_display}/hermes not found",
-                    "(hermes command may not work outside the venv)"
-                )
+                # Check if hermes is already available on PATH from another location
+                import shutil
+                _hermes_on_path = shutil.which("hermes")
+                if _hermes_on_path:
+                    check_ok(f"hermes found on PATH ({_hermes_on_path})")
+                else:
+                    check_fail(
+                        f"{_cmd_link_display}/hermes not found",
+                        "(hermes command may not work outside the venv)"
+                    )
                 if should_fix:
                     _cmd_link_dir.mkdir(parents=True, exist_ok=True)
                     _cmd_link.symlink_to(_venv_bin)


### PR DESCRIPTION
## Summary

This PR fixes #96976 by preventing false positives in hermes doctor for WAL and launcher checks.

## Problem

Two false positives in hermes doctor:

1. **WAL check**: Large WAL file was flagged as an issue even when fully checkpointed
2. **Launcher check**: `~/.local/bin/hermes not found` was reported even when hermes is available on PATH from another location

## Solution

### 1. WAL Check
Now checks `PRAGMA wal_checkpoint(PASSIVE)` result before flagging:
- If all frames checkpointed (`log == checkpointed`), reports as healthy
- Only flags as issue if there are uncheckpointed frames

### 2. Launcher Check
Now checks `shutil.which("hermes")` before reporting missing:
- If hermes is found on PATH from any location, reports success
- Only reports missing if hermes is not on PATH at all

## Changes

- Modified `hermes_cli/doctor.py`: Added checkpoint verification and PATH check

---

🤖 Generated with Codebuff
Co-Authored-By: Codebuff <noreply@codebuff.com>