### PR TITLE
fix(mcp-oauth): avoid locking across resource requests

### DIFF
--- a/tests/tools/test_mcp_oauth_bidirectional.py
+++ b/tests/tools/test_mcp_oauth_bidirectional.py
@@ -28,6 +28,8 @@ the bridge forwards responses correctly into the inner SDK generator.
 """
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 
 
@@ -204,6 +206,105 @@ async def test_hermes_provider_forwards_401_triggers_refresh(tmp_path, monkeypat
 
     # Clean up the generator — we don't need to complete the full dance.
     await flow.aclose()
+
+
+@pytest.mark.asyncio
+async def test_long_lived_resource_request_does_not_block_concurrent_post(
+    tmp_path, monkeypatch
+):
+    """A session-long MCP GET must not hold the provider state lock.
+
+    MCP SDK 2.0.0 wraps its entire auth-flow generator in one lock.  Leaving
+    the GET response pending then prevents a concurrent POST from even
+    acquiring its Bearer token.  Hermes narrows that lock around resource I/O
+    while retaining it for OAuth state transitions.
+    """
+    from tools.mcp_tool import sdk_httpx
+    httpx = sdk_httpx()
+    from mcp.shared.auth import OAuthClientInformationFull, OAuthClientMetadata, OAuthToken
+    from pydantic import AnyUrl
+
+    from tools.mcp_oauth import HermesTokenStorage
+    from tools.mcp_oauth_manager import _HERMES_PROVIDER_CLS, reset_manager_for_tests
+
+    assert _HERMES_PROVIDER_CLS is not None
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    reset_manager_for_tests()
+
+    storage = HermesTokenStorage("srv")
+    await storage.set_tokens(
+        OAuthToken(
+            access_token="access-token",
+            token_type="Bearer",
+            expires_in=3600,
+            refresh_token="refresh-token",
+        )
+    )
+    await storage.set_client_info(
+        OAuthClientInformationFull(
+            client_id="test-client",
+            redirect_uris=[AnyUrl("http://127.0.0.1:12345/callback")],
+            grant_types=["authorization_code", "refresh_token"],
+            response_types=["code"],
+            token_endpoint_auth_method="none",
+        )
+    )
+
+    provider = _HERMES_PROVIDER_CLS(
+        server_name="srv",
+        server_url="https://example.com/mcp",
+        client_metadata=OAuthClientMetadata(
+            redirect_uris=[AnyUrl("http://127.0.0.1:12345/callback")],
+            client_name="Hermes Agent",
+        ),
+        storage=storage,
+        redirect_handler=_noop_redirect,
+        callback_handler=_noop_callback,
+    )
+
+    get_request = httpx.Request("GET", "https://example.com/mcp")
+    get_flow = provider.async_auth_flow(get_request)
+    get_outbound = await get_flow.__anext__()
+
+    # Keep the GET open, as streamable HTTP does for the session lifetime.
+    # The POST must still authenticate and reach HTTPX without waiting for it.
+    post_request = httpx.Request("POST", "https://example.com/mcp")
+    post_flow = provider.async_auth_flow(post_request)
+    post_outbound = await asyncio.wait_for(post_flow.__anext__(), timeout=2.0)
+
+    assert post_outbound is post_request
+    assert post_outbound.headers["authorization"] == "Bearer access-token"
+
+    with pytest.raises(StopAsyncIteration):
+        await post_flow.asend(httpx.Response(200, request=post_outbound))
+
+    # A completed concurrent refresh must make the pending GET retry with the
+    # new token rather than start a second OAuth transition from its stale 401.
+    provider.context.current_tokens = OAuthToken(
+        access_token="new-access-token",
+        token_type="Bearer",
+        expires_in=3600,
+        refresh_token="refresh-token",
+    )
+    provider.context.update_token_expiry(provider.context.current_tokens)
+    get_retry = await get_flow.asend(
+        httpx.Response(
+            401,
+            request=get_outbound,
+            headers={
+                "www-authenticate": (
+                    'Bearer resource_metadata="https://example.com/'
+                    '.well-known/oauth-protected-resource"'
+                )
+            },
+        )
+    )
+    assert get_retry is get_request
+    assert get_retry.headers["authorization"] == "Bearer new-access-token"
+
+    with pytest.raises(StopAsyncIteration):
+        await get_flow.asend(httpx.Response(200, request=get_retry))
 
 
 async def _noop_redirect(_url: str) -> None:

--- a/tests/tools/test_mcp_oauth_manager.py
+++ b/tests/tools/test_mcp_oauth_manager.py
@@ -334,9 +334,10 @@ def test_bridge_forwards_requests_and_poisons_on_token_endpoint_400(
 
     async def fake_base_flow(self, request):
         # Mimic the SDK: yield the request, receive the response, then finish.
-        forwarded.append(("out", request))
-        response = yield request
-        forwarded.append(("in", response))
+        async with self.context.lock:
+            forwarded.append(("out", request))
+            response = yield request
+            forwarded.append(("in", response))
 
     from mcp.client.auth.oauth2 import OAuthClientProvider
     monkeypatch.setattr(OAuthClientProvider, "async_auth_flow", fake_base_flow)

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -138,6 +138,15 @@ def _make_hermes_provider_class() -> Optional[type]:
             **kwargs: Any,
         ):
             super().__init__(*args, **kwargs)
+            # mcp 2.0.0 uses a task-owned anyio.Lock and holds it across the
+            # yielded resource request.  A session-long GET therefore blocks
+            # every concurrent POST, and HTTPX may later close the auth-flow
+            # generator from a different task than the lock owner.  A binary
+            # semaphore preserves mutual exclusion without task ownership;
+            # async_auth_flow below narrows its scope around resource I/O.
+            import anyio
+
+            self.context.lock = anyio.Semaphore(1, max_value=1)
             self._hermes_server_name = server_name
             self._hermes_home = ""
             # When the client_id comes from config.yaml (pre-registered), an
@@ -531,10 +540,43 @@ def _make_hermes_provider_class() -> Optional[type]:
             # contract. Regression from PR #11383 caught by
             # tests/tools/test_mcp_oauth_bidirectional.py.
             inner = super().async_auth_flow(request)
+            resource_lock_released = False
+            sent_access_token = None
+            retry_after_concurrent_auth = False
             try:
                 outgoing = await inner.__anext__()
                 while True:
+                    # The SDK holds context.lock for its entire generator,
+                    # including while HTTPX waits on the actual MCP request.
+                    # Release it only for that request.  OAuth discovery,
+                    # refresh, registration, and token exchange remain
+                    # serialized exactly as the SDK implements them.
+                    if outgoing is request:
+                        tokens = self.context.current_tokens
+                        sent_access_token = (
+                            tokens.access_token if tokens is not None else None
+                        )
+                        self.context.lock.release()
+                        resource_lock_released = True
                     incoming = yield outgoing
+                    if resource_lock_released:
+                        await self.context.lock.acquire()
+                        resource_lock_released = False
+                    # A different request may have completed refresh or full
+                    # authorization while this resource request was in
+                    # flight.  Retry with that token instead of starting a
+                    # duplicate OAuth transition from the stale 401/403.
+                    tokens = self.context.current_tokens
+                    if (
+                        getattr(incoming, "status_code", None) in (401, 403)
+                        and self.context.is_token_valid()
+                        and tokens is not None
+                        and tokens.access_token != sent_access_token
+                    ):
+                        self._add_auth_header(request)
+                        await inner.aclose()
+                        retry_after_concurrent_auth = True
+                        break
                     # Sniff the response for a dead-client-registration signal
                     # before handing it back to the SDK (best-effort, GH#36767).
                     await self._maybe_flag_poisoned_client(incoming)
@@ -542,6 +584,22 @@ def _make_hermes_provider_class() -> Optional[type]:
             except StopAsyncIteration:
                 # Persist any metadata the SDK discovered lazily during the
                 # 401 branch so a subsequent cold-load skips discovery.
+                self._persist_oauth_metadata_if_changed()
+                return
+            finally:
+                if resource_lock_released:
+                    # Balance the SDK's surrounding ``async with`` even when
+                    # HTTPX cancels or closes the flow while the resource
+                    # request is still in flight.  Shield only this local
+                    # bookkeeping; general inner-generator teardown remains
+                    # the separate concern tracked by the cleanup PR.
+                    import anyio
+
+                    with anyio.CancelScope(shield=True):
+                        await self.context.lock.acquire()
+
+            if retry_after_concurrent_auth:
+                yield request
                 self._persist_oauth_metadata_if_changed()
                 return
 


### PR DESCRIPTION
## What does this PR do?

MCP SDK 2.0.0 holds one task-owned OAuth context lock across the entire HTTPX auth-flow generator. A session-long Streamable HTTP GET can therefore hold the lock indefinitely and prevent concurrent schema or tool POST requests from authenticating.

This keeps the SDK's existing OAuth state machine intact while replacing its task-owned lock with a binary semaphore and releasing that semaphore only while the actual MCP resource request is in flight. OAuth initialization, refresh, discovery, registration, and token exchange remain serialized. If another request refreshes the token while a resource request is pending, a stale 401 or 403 now retries with the new token instead of starting another OAuth transition.

This is the narrow lock-scope complement to the auth-flow cleanup work in #90888 and the stale-connection retry work in #91460. It follows the concurrency model proposed upstream in modelcontextprotocol/python-sdk#3243 without copying the SDK's full 401/403 implementation into Hermes.

## Related Issue

Related: modelcontextprotocol/python-sdk#1326

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Replace the pinned SDK provider's task-owned OAuth lock with a task-agnostic binary semaphore.
- Release the OAuth state lock only around the real MCP resource request, while preserving serialization for every token-changing OAuth transition.
- Retry stale 401/403 responses with a token refreshed by another request.
- Add a regression that leaves a GET open while a concurrent POST authenticates and proceeds.

## How to Test

1. Start an authenticated MCP GET auth flow and leave its response pending.
2. Start a POST auth flow through the same provider and verify it receives its Bearer token without waiting for the GET.
3. Refresh the shared token, return a stale 401 to the GET, and verify it retries with the new token rather than starting duplicate authorization.

Focused test command:

`scripts/run_tests.sh tests/tools/test_mcp_oauth_bidirectional.py tests/tools/test_mcp_oauth_manager.py -q -j 4`

Result: 17 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass. Full-suite coverage is left to GitHub CI; the focused tests above pass.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; behavior is covered by code comments and regression tests
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Not applicable. The regression is covered by the focused async OAuth tests above.
