### PR TITLE
feat(desktop): add composer-local hold-to-talk dictation

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-ptt.test.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-ptt.test.ts
@@ -1,0 +1,250 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { useComposerPtt } from './use-composer-ptt'
+
+const key = (type: 'keydown' | 'keyup', init: KeyboardEventInit = {}) =>
+  window.dispatchEvent(new KeyboardEvent(type, { code: 'AltLeft', key: 'Alt', ...init }))
+
+const options = (overrides: Partial<Parameters<typeof useComposerPtt>[0]> = {}) => ({
+  active: () => true,
+  blocked: false,
+  cancel: vi.fn(),
+  maxRecordingSeconds: 120,
+  start: vi.fn().mockResolvedValue(true),
+  stop: vi.fn().mockResolvedValue(' hello '),
+  submit: vi.fn().mockResolvedValue(true),
+  ...overrides
+})
+
+describe('useComposerPtt', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('starts on left Alt and submits exactly once on release without consuming the OS key', async () => {
+    const state = options()
+    renderHook(() => useComposerPtt(state))
+    const down = new KeyboardEvent('keydown', { cancelable: true, code: 'AltLeft', key: 'Alt' })
+
+    await act(async () => window.dispatchEvent(down))
+    await act(async () => key('keydown', { repeat: true }))
+    await act(async () => key('keyup'))
+    await act(async () => key('keyup'))
+
+    expect(down.defaultPrevented).toBe(false)
+    expect(state.start).toHaveBeenCalledTimes(1)
+    expect(state.stop).toHaveBeenCalledTimes(1)
+    expect(state.submit).toHaveBeenCalledTimes(1)
+    expect(state.submit).toHaveBeenCalledWith('hello')
+  })
+
+  it('ignores modifiers, blocked state, inactive composers, and keyup without a start', async () => {
+    const state = options({ blocked: true })
+
+    const { rerender } = renderHook(({ blocked, active }) => useComposerPtt({ ...state, blocked, active }), {
+      initialProps: { active: () => true, blocked: true }
+    })
+
+    await act(async () => key('keydown', { ctrlKey: true }))
+    await act(async () => key('keyup'))
+    rerender({ active: () => false, blocked: false })
+    await act(async () => key('keydown'))
+    await act(async () => key('keyup'))
+
+    expect(state.start).not.toHaveBeenCalled()
+    expect(state.stop).not.toHaveBeenCalled()
+    expect(state.submit).not.toHaveBeenCalled()
+  })
+
+  it('cancels a start that resolves after the composer becomes blocked', async () => {
+    let resolveStart: (started: boolean) => void = () => undefined
+
+    const state = options({
+      start: vi.fn(
+        () =>
+          new Promise<boolean>(resolve => {
+            resolveStart = resolve
+          })
+      )
+    })
+
+    const { rerender } = renderHook(({ blocked }) => useComposerPtt({ ...state, blocked }), {
+      initialProps: { blocked: false }
+    })
+
+    await act(async () => key('keydown'))
+    rerender({ blocked: true })
+    await act(async () => resolveStart(true))
+
+    expect(state.cancel).toHaveBeenCalledTimes(1)
+    expect(state.stop).not.toHaveBeenCalled()
+    expect(state.submit).not.toHaveBeenCalled()
+  })
+
+  it('cancels a start that resolves after the active composer changes', async () => {
+    let active = true
+    let resolveStart: (started: boolean) => void = () => undefined
+
+    const state = options({
+      active: () => active,
+      start: vi.fn(
+        () =>
+          new Promise<boolean>(resolve => {
+            resolveStart = resolve
+          })
+      )
+    })
+
+    renderHook(() => useComposerPtt(state))
+    await act(async () => key('keydown'))
+    active = false
+    await act(async () => resolveStart(true))
+
+    expect(state.cancel).toHaveBeenCalledTimes(1)
+    expect(state.stop).not.toHaveBeenCalled()
+    expect(state.submit).not.toHaveBeenCalled()
+  })
+
+  it('does not stop or submit when the asynchronous start fails', async () => {
+    const state = options({ start: vi.fn().mockResolvedValue(false) })
+    renderHook(() => useComposerPtt(state))
+
+    await act(async () => key('keydown'))
+    await act(async () => key('keyup'))
+
+    expect(state.start).toHaveBeenCalledTimes(1)
+    expect(state.cancel).not.toHaveBeenCalled()
+    expect(state.stop).not.toHaveBeenCalled()
+    expect(state.submit).not.toHaveBeenCalled()
+  })
+
+  it('cancels on window blur and unmount without submitting', async () => {
+    const state = options()
+    const { unmount } = renderHook(() => useComposerPtt(state))
+
+    await act(async () => key('keydown'))
+    await act(async () => window.dispatchEvent(new Event('blur')))
+    unmount()
+
+    expect(state.start).toHaveBeenCalledTimes(1)
+    expect(state.cancel).toHaveBeenCalledTimes(1)
+    expect(state.stop).not.toHaveBeenCalled()
+    expect(state.submit).not.toHaveBeenCalled()
+  })
+
+  it('drops a transcript that resolves after composer ownership changes', async () => {
+    let active = true
+    let resolveStop: (text: string) => void = () => undefined
+
+    const state = options({
+      active: () => active,
+      stop: vi.fn(
+        () =>
+          new Promise<string>(resolve => {
+            resolveStop = resolve
+          })
+      )
+    })
+
+    renderHook(() => useComposerPtt(state))
+
+    await act(async () => key('keydown'))
+    await act(async () => key('keyup'))
+    active = false
+    await act(async () => resolveStop('stale'))
+
+    expect(state.submit).not.toHaveBeenCalled()
+  })
+
+  it('cancels immediately when focus moves away from the owning composer', async () => {
+    let active = true
+    const state = options({ active: () => active })
+    renderHook(() => useComposerPtt(state))
+
+    await act(async () => key('keydown'))
+    active = false
+    await act(async () => document.dispatchEvent(new FocusEvent('focusin')))
+
+    expect(state.cancel).toHaveBeenCalledTimes(1)
+    expect(state.stop).not.toHaveBeenCalled()
+    expect(state.submit).not.toHaveBeenCalled()
+  })
+
+  it('invalidates a pending transcript when the window blurs after release', async () => {
+    let resolveStop: (text: string) => void = () => undefined
+
+    const state = options({
+      stop: vi.fn(
+        () =>
+          new Promise<string>(resolve => {
+            resolveStop = resolve
+          })
+      )
+    })
+
+    renderHook(() => useComposerPtt(state))
+
+    await act(async () => key('keydown'))
+    await act(async () => key('keyup'))
+    await act(async () => window.dispatchEvent(new Event('blur')))
+    await act(async () => resolveStop('must not send'))
+
+    expect(state.submit).not.toHaveBeenCalled()
+  })
+
+  it('abandons an active recording when the composer becomes blocked', async () => {
+    const state = options()
+
+    const { rerender } = renderHook(({ blocked }) => useComposerPtt({ ...state, blocked }), {
+      initialProps: { blocked: false }
+    })
+
+    await act(async () => key('keydown'))
+    rerender({ blocked: true })
+    await act(async () => key('keyup'))
+
+    expect(state.cancel).toHaveBeenCalledTimes(1)
+    expect(state.stop).not.toHaveBeenCalled()
+    expect(state.submit).not.toHaveBeenCalled()
+  })
+
+  it('abandons a finishing recording when the composer becomes blocked', async () => {
+    let resolveStop: (text: string) => void = () => undefined
+
+    const state = options({
+      stop: vi.fn(
+        () =>
+          new Promise<string>(resolve => {
+            resolveStop = resolve
+          })
+      )
+    })
+
+    const { rerender } = renderHook(({ blocked }) => useComposerPtt({ ...state, blocked }), {
+      initialProps: { blocked: false }
+    })
+
+    await act(async () => key('keydown'))
+    await act(async () => key('keyup'))
+    rerender({ blocked: true })
+    await act(async () => resolveStop('must not submit'))
+
+    expect(state.cancel).toHaveBeenCalledTimes(1)
+    expect(state.submit).not.toHaveBeenCalled()
+  })
+
+  it('auto-finishes through the same submit path at the recording cap', async () => {
+    vi.useFakeTimers()
+    const state = options({ maxRecordingSeconds: 1 })
+    renderHook(() => useComposerPtt(state))
+
+    await act(async () => key('keydown'))
+    await act(async () => vi.advanceTimersByTimeAsync(1_000))
+    await act(async () => key('keyup'))
+
+    expect(state.stop).toHaveBeenCalledTimes(1)
+    expect(state.submit).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-ptt.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-ptt.ts
@@ -1,0 +1,174 @@
+import { useEffect, useRef } from 'react'
+
+interface ComposerPttOptions {
+  active: () => boolean
+  blocked: boolean
+  cancel: () => void
+  maxRecordingSeconds: number
+  start: () => Promise<boolean | void>
+  stop: () => Promise<string | null>
+  submit: (text: string) => Promise<unknown> | unknown
+}
+
+/** Composer-local hold-to-talk. Left Alt is observed but never globally consumed. */
+export function useComposerPtt({
+  active,
+  blocked,
+  cancel,
+  maxRecordingSeconds,
+  start,
+  stop,
+  submit
+}: ComposerPttOptions) {
+  const heldRef = useRef(false)
+  const recordingRef = useRef(false)
+  const finishPendingRef = useRef(false)
+  const generationRef = useRef(0)
+  const timeoutRef = useRef<number | null>(null)
+  const blockedRef = useRef(blocked)
+  const abandonRef = useRef<() => void>(() => undefined)
+  const callbacksRef = useRef({ active, cancel, start, stop, submit })
+
+  blockedRef.current = blocked
+  callbacksRef.current = { active, cancel, start, stop, submit }
+
+  // eslint-disable-next-line no-restricted-syntax -- stable window listeners read the latest composer callbacks from refs
+  useEffect(() => {
+    const clearTimer = () => {
+      if (timeoutRef.current !== null) {
+        window.clearTimeout(timeoutRef.current)
+        timeoutRef.current = null
+      }
+    }
+
+    const abandon = () => {
+      if (!heldRef.current && !recordingRef.current && !finishPendingRef.current) {
+        return
+      }
+
+      generationRef.current += 1
+      heldRef.current = false
+      recordingRef.current = false
+      finishPendingRef.current = false
+      clearTimer()
+      callbacksRef.current.cancel()
+    }
+
+    abandonRef.current = abandon
+
+    const finish = () => {
+      if (!recordingRef.current) {
+        return
+      }
+
+      const generation = generationRef.current
+      heldRef.current = false
+      recordingRef.current = false
+      finishPendingRef.current = true
+      clearTimer()
+      void callbacksRef.current
+        .stop()
+        .then(text => {
+          const transcript = text?.trim()
+
+          if (transcript && generation === generationRef.current && callbacksRef.current.active()) {
+            return callbacksRef.current.submit(transcript)
+          }
+
+          return undefined
+        })
+        .catch(() => undefined)
+        .finally(() => {
+          if (generation === generationRef.current) {
+            finishPendingRef.current = false
+          }
+        })
+    }
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (
+        event.code !== 'AltLeft' ||
+        event.repeat ||
+        event.ctrlKey ||
+        event.metaKey ||
+        event.shiftKey ||
+        blockedRef.current ||
+        heldRef.current ||
+        finishPendingRef.current ||
+        !callbacksRef.current.active()
+      ) {
+        return
+      }
+
+      const generation = generationRef.current + 1
+      generationRef.current = generation
+      heldRef.current = true
+      void callbacksRef.current
+        .start()
+        .then(started => {
+          if (started === false) {
+            heldRef.current = false
+
+            return
+          }
+
+          if (
+            heldRef.current &&
+            generation === generationRef.current &&
+            !blockedRef.current &&
+            callbacksRef.current.active()
+          ) {
+            recordingRef.current = true
+            const cap = Math.max(1, Math.min(Math.trunc(maxRecordingSeconds), 600))
+            timeoutRef.current = window.setTimeout(finish, cap * 1000)
+          } else if (generation === generationRef.current) {
+            heldRef.current = false
+            callbacksRef.current.cancel()
+          }
+        })
+        .catch(() => {
+          if (generation === generationRef.current) {
+            heldRef.current = false
+          }
+        })
+    }
+
+    const onKeyUp = (event: KeyboardEvent) => {
+      if (event.code !== 'AltLeft' || !heldRef.current) {
+        return
+      }
+
+      heldRef.current = false
+      finish()
+    }
+
+    const onFocusIn = () => {
+      if (!callbacksRef.current.active()) {
+        abandon()
+      }
+    }
+
+    window.addEventListener('keydown', onKeyDown)
+    window.addEventListener('keyup', onKeyUp)
+    window.addEventListener('blur', abandon)
+    document.addEventListener('focusin', onFocusIn)
+
+    return () => {
+      window.removeEventListener('keydown', onKeyDown)
+      window.removeEventListener('keyup', onKeyUp)
+      window.removeEventListener('blur', abandon)
+      document.removeEventListener('focusin', onFocusIn)
+      abandon()
+
+      if (abandonRef.current === abandon) {
+        abandonRef.current = () => undefined
+      }
+    }
+  }, [maxRecordingSeconds])
+
+  useEffect(() => {
+    if (blocked) {
+      abandonRef.current()
+    }
+  }, [blocked])
+}

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.test.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { createWakePauseCoordinator } from './use-composer-voice'
+
+describe('createWakePauseCoordinator', () => {
+  it('waits for a pending pause before resuming after cancellation', async () => {
+    let resolvePause: (() => void) | undefined
+
+    const pause = vi.fn(
+      () =>
+        new Promise<void>(resolve => {
+          resolvePause = resolve
+        })
+    )
+
+    const resume = vi.fn().mockResolvedValue(undefined)
+    const coordinator = createWakePauseCoordinator({ pause, resume })
+
+    coordinator.pause()
+    const resuming = coordinator.resume()
+    await Promise.resolve()
+
+    expect(resume).not.toHaveBeenCalled()
+
+    resolvePause?.()
+    await resuming
+
+    expect(resume).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not resume a stale owner or resume twice', async () => {
+    let resolveFirstPause: (() => void) | undefined
+
+    const pause = vi
+      .fn<() => Promise<void>>()
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>(resolve => {
+            resolveFirstPause = resolve
+          })
+      )
+      .mockResolvedValue(undefined)
+
+    const resume = vi.fn().mockResolvedValue(undefined)
+    const coordinator = createWakePauseCoordinator({ pause, resume })
+
+    coordinator.pause()
+    await Promise.resolve()
+    const firstResume = coordinator.resume()
+    const duplicateResume = coordinator.resume()
+    coordinator.pause()
+    resolveFirstPause?.()
+    const secondResume = coordinator.resume()
+    await Promise.all([firstResume, duplicateResume, secondResume])
+
+    expect(pause).toHaveBeenCalledTimes(2)
+    expect(resume).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.ts
@@ -14,13 +14,87 @@ import { $autoSpeakReplies, $voiceStopPhrase, setAutoSpeakReplies } from '@/stor
 import { resumeWakeAfterVoice } from '@/store/wake-word'
 
 import type { ComposerTarget } from '../focus'
-import { onComposerVoiceToggleRequest } from '../focus'
+import { getActiveComposer, onComposerVoiceToggleRequest } from '../focus'
 import { useComposerScope } from '../scope'
 import type { ChatBarProps } from '../types'
 
 import { useAutoSpeakReplies } from './use-auto-speak-replies'
+import { useComposerPtt } from './use-composer-ptt'
 import { useVoiceConversation } from './use-voice-conversation'
 import { useVoiceRecorder } from './use-voice-recorder'
+
+interface WakePauseCoordinatorOptions {
+  pause: () => Promise<unknown> | unknown
+  resume: () => Promise<unknown> | unknown
+}
+
+interface WakePauseCoordinator {
+  barrier: () => Promise<void> | null
+  pause: () => Promise<void>
+  resume: () => Promise<void>
+}
+
+/** Serializes wake ownership so a pending pause cannot race a later resume. */
+export function createWakePauseCoordinator({ pause, resume }: WakePauseCoordinatorOptions): WakePauseCoordinator {
+  let generation = 0
+  let paused = false
+  let pauseBarrier: Promise<void> | null = null
+  let resumeGeneration: number | null = null
+  let resumePromise = Promise.resolve()
+
+  return {
+    barrier: () => pauseBarrier,
+    pause: () => {
+      const owner = ++generation
+      paused = true
+
+      const barrier = Promise.resolve()
+        .then(() => pause())
+        .then(() => undefined)
+        .catch(() => undefined)
+
+      pauseBarrier = barrier
+
+      return barrier.then(() => {
+        if (generation === owner && pauseBarrier === barrier && !paused) {
+          pauseBarrier = null
+        }
+      })
+    },
+    resume: () => {
+      if (!paused) {
+        return Promise.resolve()
+      }
+
+      const owner = generation
+      const barrier = pauseBarrier ?? Promise.resolve()
+      paused = false
+
+      if (resumeGeneration === owner) {
+        return resumePromise
+      }
+
+      resumeGeneration = owner
+      resumePromise = barrier
+        .then(() => {
+          if (generation !== owner) {
+            return
+          }
+
+          return Promise.resolve(resume()).then(() => undefined)
+        })
+        .catch(() => undefined)
+        .finally(() => {
+          if (generation === owner && resumeGeneration === owner) {
+            resumeGeneration = null
+            pauseBarrier = null
+          }
+        })
+
+      return resumePromise
+    }
+  }
+}
 
 interface UseComposerVoiceArgs {
   busy: boolean
@@ -34,6 +108,7 @@ interface UseComposerVoiceArgs {
   onInterrupt?: () => Promise<void> | void
   onSubmit: ChatBarProps['onSubmit']
   onTranscribeAudio: ChatBarProps['onTranscribeAudio']
+  pttActive: () => boolean
   sessionId: string | null | undefined
   /** This composer's focus-bus key — voice toggles targeting another
    *  composer (or the active one, when not us) are ignored. */
@@ -56,6 +131,7 @@ export function useComposerVoice({
   onInterrupt,
   onSubmit,
   onTranscribeAudio,
+  pttActive,
   sessionId,
   target
 }: UseComposerVoiceArgs) {
@@ -66,12 +142,29 @@ export function useComposerVoice({
   const ownsWakeIndicatorRef = useRef(false)
   const voiceStartRequest = useStore($voiceConversationStartRequest)
 
-  const { dictate, voiceActivityState, voiceStatus } = useVoiceRecorder({
-    focusInput,
-    maxRecordingSeconds,
-    onTranscript: insertText,
-    onTranscribeAudio
-  })
+  const submitVoiceTurn = async (text: string) => {
+    if (busy) {
+      // Busy may begin after PTT starts. Keep the completed dictation visible
+      // as this composer's draft instead of silently dropping it or queueing it.
+      insertText(text)
+
+      return
+    }
+
+    triggerHaptic('submit')
+    resetBrowseState(sessionId)
+    clearDraft()
+    await onSubmit(text)
+  }
+
+  const { cancelRecording, dictate, startRecording, stopRecording, voiceActivityState, voiceStatus } = useVoiceRecorder(
+    {
+      focusInput,
+      maxRecordingSeconds,
+      onTranscript: insertText,
+      onTranscribeAudio
+    }
+  )
 
   /** Auto-speak selector: the latest unspoken reply only — a backlog collapses to the newest. */
   const pendingResponse = () => {
@@ -116,24 +209,16 @@ export function useComposerVoice({
     }
   }
 
-  const submitVoiceTurn = async (text: string) => {
-    if (busy) {
-      return
-    }
+  const wakeCoordinatorRef = useRef(
+    createWakePauseCoordinator({
+      pause: async () => {
+        await $gateway.get()?.request('wake.pause', {})
+      },
+      resume: () => resumeWakeAfterVoice()
+    })
+  )
 
-    triggerHaptic('submit')
-    resetBrowseState(sessionId)
-    clearDraft()
-    await onSubmit(text)
-  }
-
-  const wakePausedRef = useRef(false)
-  // Resolves once the in-flight wake.pause round-trip completes (mic released by
-  // the wake listener). The conversation awaits this before opening its own mic
-  // so the two never contend for the device — on Windows especially, opening the
-  // capture device while the wake listener still holds it makes getUserMedia
-  // fail and the conversation never starts listening.
-  const wakePauseBarrierRef = useRef<Promise<void> | null>(null)
+  const wakeCoordinator = wakeCoordinatorRef.current
 
   const conversation = useVoiceConversation({
     busy,
@@ -153,8 +238,8 @@ export function useComposerVoice({
     onTranscribeAudio,
     pendingResponse: pendingTurnResponse,
     // Before the conversation opens the mic, wait for any in-flight wake.pause
-    // to finish releasing the capture device (see wakePauseBarrierRef).
-    beforeMicOpen: () => wakePauseBarrierRef.current ?? undefined
+    // finish releasing the capture device (see wakeCoordinator).
+    beforeMicOpen: () => wakeCoordinator.barrier() ?? undefined
   })
 
   // eslint-disable-next-line no-restricted-syntax -- ownership token used only by unmount cleanup
@@ -204,36 +289,8 @@ export function useComposerVoice({
     }
   }, [disabled, target, voiceConversationActive, voiceStartRequest])
 
-  const resumeWakeIfPaused = useCallback(() => {
-    if (!wakePausedRef.current) {
-      return
-    }
-
-    wakePausedRef.current = false
-    wakePauseBarrierRef.current = null
-    // Reconcile, don't just resume: the wake word is a persistent setting, so
-    // ending a voice chat must re-arm the listener whenever config says
-    // enabled — including when the raw resume loses the mic-release race.
-    void resumeWakeAfterVoice()
-  }, [])
-
-  // The ref is a request token (did WE issue wake.pause?), not an atom mirror —
-  // it guards resumeWakeIfPaused from resuming a detector another surface owns.
-  const pauseWakeForVoice = useCallback(() => {
-    wakePausedRef.current = true
-
-    const barrier = (async () => {
-      try {
-        await $gateway.get()?.request('wake.pause', {})
-      } catch {
-        // No wake listener / older backend — nothing held the mic.
-      }
-    })()
-
-    wakePauseBarrierRef.current = barrier
-
-    return barrier
-  }, [])
+  const resumeWakeIfPaused = useCallback(() => wakeCoordinator.resume(), [wakeCoordinator])
+  const pauseWakeForVoice = useCallback(() => wakeCoordinator.pause(), [wakeCoordinator])
 
   useEffect(() => {
     if (voiceConversationActive) {
@@ -242,6 +299,40 @@ export function useComposerVoice({
       resumeWakeIfPaused()
     }
   }, [pauseWakeForVoice, resumeWakeIfPaused, voiceConversationActive])
+
+  useComposerPtt({
+    active: () => pttActive() && getActiveComposer() === target,
+    blocked: busy || disabled || voiceConversationActive,
+    cancel: () => {
+      cancelRecording()
+      resumeWakeIfPaused()
+    },
+    maxRecordingSeconds,
+    start: async () => {
+      await pauseWakeForVoice()
+
+      try {
+        const started = await startRecording()
+
+        if (!started) {
+          resumeWakeIfPaused()
+        }
+
+        return started
+      } catch (error) {
+        resumeWakeIfPaused()
+        throw error
+      }
+    },
+    stop: async () => {
+      try {
+        return await stopRecording()
+      } finally {
+        resumeWakeIfPaused()
+      }
+    },
+    submit: submitVoiceTurn
+  })
 
   // 'Say "stop" to end the voice chat.' notice when the conversation starts.
   // Phrase comes from voice.stop_phrases (first entry) so a custom phrase
@@ -263,7 +354,7 @@ export function useComposerVoice({
     }
   }, [t, voiceConversationActive])
 
-  useEffect(() => resumeWakeIfPaused, [resumeWakeIfPaused])
+  useEffect(() => () => void resumeWakeIfPaused(), [resumeWakeIfPaused])
 
   // Explicit start/end for the on-screen conversation controls (the hotkey uses
   // the gated toggle above).

--- a/apps/desktop/src/app/chat/composer/hooks/use-mic-recorder.test.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-mic-recorder.test.ts
@@ -1,0 +1,140 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { useMicRecorder } from './use-mic-recorder'
+
+const copy = {
+  microphoneAccessDenied: 'denied',
+  microphoneInUse: 'in use',
+  microphoneUnsupported: 'unsupported',
+  permissionDenied: 'permission',
+  recordingFailed: 'failed'
+} as never
+
+describe('useMicRecorder async cancellation', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('closes a stream that arrives after cancel and never creates a recorder', async () => {
+    let resolveStream: (stream: MediaStream) => void = () => undefined
+
+    const getUserMedia = vi.fn(
+      () =>
+        new Promise<MediaStream>(resolve => {
+          resolveStream = resolve
+        })
+    )
+
+    const stopTrack = vi.fn()
+    const stream = { getTracks: () => [{ stop: stopTrack }] } as unknown as MediaStream
+    const Recorder = vi.fn()
+    Object.assign(Recorder, { isTypeSupported: vi.fn(() => true) })
+
+    Object.defineProperty(navigator, 'mediaDevices', {
+      configurable: true,
+      value: { getUserMedia }
+    })
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: { requestMicrophoneAccess: vi.fn().mockResolvedValue(true) }
+    })
+    vi.stubGlobal('MediaRecorder', Recorder)
+
+    const { result } = renderHook(() => useMicRecorder(copy))
+    let starting: Promise<boolean> = Promise.resolve(false)
+
+    await act(async () => {
+      starting = result.current.handle.start()
+      await Promise.resolve()
+      result.current.handle.cancel()
+      resolveStream(stream)
+      await starting
+    })
+
+    expect(stopTrack).toHaveBeenCalledTimes(1)
+    expect(Recorder).not.toHaveBeenCalled()
+    expect(result.current.recording).toBe(false)
+  })
+
+  it('ignores a getUserMedia rejection that arrives after cancel', async () => {
+    let rejectStream: (error: Error) => void = () => undefined
+
+    const getUserMedia = vi.fn(
+      () =>
+        new Promise<MediaStream>((_resolve, reject) => {
+          rejectStream = reject
+        })
+    )
+
+    const Recorder = vi.fn()
+    Object.assign(Recorder, { isTypeSupported: vi.fn(() => true) })
+
+    Object.defineProperty(navigator, 'mediaDevices', {
+      configurable: true,
+      value: { getUserMedia }
+    })
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: { requestMicrophoneAccess: vi.fn().mockResolvedValue(true) }
+    })
+    vi.stubGlobal('MediaRecorder', Recorder)
+
+    const { result } = renderHook(() => useMicRecorder(copy))
+    let starting: Promise<boolean> = Promise.resolve(false)
+
+    await act(async () => {
+      starting = result.current.handle.start()
+      await Promise.resolve()
+      result.current.handle.cancel()
+      rejectStream(new Error('stale failure'))
+      await expect(starting).resolves.toBe(false)
+    })
+
+    expect(Recorder).not.toHaveBeenCalled()
+    expect(result.current.recording).toBe(false)
+  })
+
+  it.each([
+    ['a denied permission result', false],
+    ['a rejected permission request', new Error('stale permission failure')]
+  ])('ignores %s that arrives after cancel', async (_label, outcome) => {
+    let settlePermission: () => void = () => undefined
+
+    const requestMicrophoneAccess = vi.fn(
+      () =>
+        new Promise<boolean>((resolve, reject) => {
+          settlePermission = () => (outcome instanceof Error ? reject(outcome) : resolve(outcome))
+        })
+    )
+
+    const getUserMedia = vi.fn()
+    const Recorder = vi.fn()
+    Object.assign(Recorder, { isTypeSupported: vi.fn(() => true) })
+
+    Object.defineProperty(navigator, 'mediaDevices', {
+      configurable: true,
+      value: { getUserMedia }
+    })
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: { requestMicrophoneAccess }
+    })
+    vi.stubGlobal('MediaRecorder', Recorder)
+
+    const { result } = renderHook(() => useMicRecorder(copy))
+    let starting: Promise<boolean> = Promise.resolve(false)
+
+    await act(async () => {
+      starting = result.current.handle.start()
+      result.current.handle.cancel()
+      settlePermission()
+      await expect(starting).resolves.toBe(false)
+    })
+
+    expect(getUserMedia).not.toHaveBeenCalled()
+    expect(Recorder).not.toHaveBeenCalled()
+    expect(result.current.recording).toBe(false)
+  })
+})

--- a/apps/desktop/src/app/chat/composer/hooks/use-mic-recorder.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-mic-recorder.ts
@@ -28,7 +28,7 @@ export interface MicRecorderErrorCopy {
 }
 
 interface MicRecorderHandle {
-  start: (options?: MicRecorderOptions) => Promise<void>
+  start: (options?: MicRecorderOptions) => Promise<boolean>
   stop: () => Promise<MicRecording | null>
   cancel: () => void
 }
@@ -77,6 +77,7 @@ export function useMicRecorder(copy: MicRecorderErrorCopy): {
   const silenceTriggeredRef = useRef(false)
   const silenceStartedAtRef = useRef<number | null>(null)
   const stopResolverRef = useRef<((recording: MicRecording | null) => void) | null>(null)
+  const startGenerationRef = useRef(0)
 
   const cleanup = () => {
     if (animationRef.current) {
@@ -94,7 +95,13 @@ export function useMicRecorder(copy: MicRecorderErrorCopy): {
     silenceTriggeredRef.current = false
   }
 
-  useEffect(() => () => cleanup(), [])
+  useEffect(
+    () => () => {
+      startGenerationRef.current += 1
+      cleanup()
+    },
+    []
+  )
 
   const startMeter = (stream: MediaStream, options: MicRecorderOptions) => {
     const audioWindow = window as Window & { webkitAudioContext?: BrowserAudioContext }
@@ -168,14 +175,31 @@ export function useMicRecorder(copy: MicRecorderErrorCopy): {
 
   const start: MicRecorderHandle['start'] = async (options = {}) => {
     if (recorderRef.current) {
-      return
+      return false
     }
+
+    const generation = startGenerationRef.current + 1
+    startGenerationRef.current = generation
 
     if (!navigator.mediaDevices?.getUserMedia || typeof MediaRecorder === 'undefined') {
       throw new Error(copy.microphoneUnsupported)
     }
 
-    const permitted = await window.hermesDesktop?.requestMicrophoneAccess?.()
+    let permitted: boolean | undefined
+
+    try {
+      permitted = await window.hermesDesktop?.requestMicrophoneAccess?.()
+    } catch (error) {
+      if (generation !== startGenerationRef.current) {
+        return false
+      }
+
+      throw error
+    }
+
+    if (generation !== startGenerationRef.current) {
+      return false
+    }
 
     if (permitted === false) {
       throw new Error(copy.microphoneAccessDenied)
@@ -188,7 +212,17 @@ export function useMicRecorder(copy: MicRecorderErrorCopy): {
         audio: { echoCancellation: true, noiseSuppression: true }
       })
     } catch (error) {
+      if (generation !== startGenerationRef.current) {
+        return false
+      }
+
       throw micError(error, copy)
+    }
+
+    if (generation !== startGenerationRef.current) {
+      stream.getTracks().forEach(track => track.stop())
+
+      return false
     }
 
     const mimeType =
@@ -256,6 +290,8 @@ export function useMicRecorder(copy: MicRecorderErrorCopy): {
     recorder.start()
     setRecording(true)
     startMeter(stream, options)
+
+    return true
   }
 
   const stop: MicRecorderHandle['stop'] = () =>
@@ -274,6 +310,7 @@ export function useMicRecorder(copy: MicRecorderErrorCopy): {
     })
 
   const cancel: MicRecorderHandle['cancel'] = () => {
+    startGenerationRef.current += 1
     const recorder = recorderRef.current
     const resolver = stopResolverRef.current
     stopResolverRef.current = null

--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation-rearm.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation-rearm.test.tsx
@@ -27,6 +27,8 @@ const mocks = vi.hoisted(() => {
     cancel: vi.fn(),
     start: vi.fn(async (options: { onSilence: () => void }) => {
       onSilence = options.onSilence
+
+      return true
     }),
     stop: vi.fn(async () => ({
       audio: new Blob(['voice'], { type: 'audio/webm' }),

--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.test.tsx
@@ -41,7 +41,7 @@ vi.mock('@/lib/thinking-sound', () => ({
 
 const micHandle = {
   cancel: vi.fn(),
-  start: vi.fn(async () => undefined),
+  start: vi.fn(async () => true),
   stop: vi.fn<() => Promise<MicRecording | null>>(async () => null)
 }
 
@@ -75,7 +75,13 @@ interface HookProps {
   busy: boolean
 }
 
-function renderConversation(overrides: { onInterrupt?: () => void; transcript?: string } = {}) {
+function renderConversation(
+  overrides: {
+    onInterrupt?: () => void
+    onTranscribeAudio?: (audio: Blob) => Promise<string>
+    transcript?: string
+  } = {}
+) {
   const onInterrupt = overrides.onInterrupt ?? vi.fn()
 
   // Mirrors the real app: submitting a turn makes the agent busy.
@@ -91,9 +97,11 @@ function renderConversation(overrides: { onInterrupt?: () => void; transcript?: 
   // ones are barge captures (the overridable transcript).
   let transcriptions = 0
 
-  const onTranscribeAudio = vi.fn(async () =>
-    transcriptions++ === 0 ? 'kick off the task' : (overrides.transcript ?? 'and another thing')
-  )
+  const onTranscribeAudio =
+    overrides.onTranscribeAudio ??
+    vi.fn(async () =>
+      transcriptions++ === 0 ? 'kick off the task' : (overrides.transcript ?? 'and another thing')
+    )
 
   const hook = renderHook(
     ({ busy }: HookProps) =>
@@ -138,7 +146,7 @@ describe('useVoiceConversation full-duplex barge-in', () => {
   beforeEach(() => {
     monitorCalls.length = 0
     vi.clearAllMocks()
-    micHandle.start.mockResolvedValue(undefined)
+    micHandle.start.mockResolvedValue(true)
     micHandle.stop.mockResolvedValue(null)
   })
 
@@ -155,6 +163,171 @@ describe('useVoiceConversation full-duplex barge-in', () => {
     await waitFor(() => expect(hook.result.current.status).toBe('thinking'))
     // busy=true + thinking → the full-duplex monitor must be live.
     await waitFor(() => expect(monitorCalls.length).toBeGreaterThan(0))
+  })
+
+  it('does not enter listening or arm a timeout when mic start is cancelled', async () => {
+    micHandle.start.mockResolvedValueOnce(false)
+    const { hook } = renderConversation()
+
+    await act(async () => {
+      await hook.result.current.start()
+    })
+
+    expect(hook.result.current.status).toBe('idle')
+    expect(micHandle.stop).not.toHaveBeenCalled()
+  })
+
+  it('does not submit a normal turn when the conversation ends during transcription', async () => {
+    let resolveTranscription!: (transcript: string) => void
+
+    const transcription = new Promise<string>(resolve => {
+      resolveTranscription = resolve
+    })
+
+    const { hook, onSubmit } = renderConversation({
+      onTranscribeAudio: vi.fn(async () => transcription)
+    })
+
+    await act(async () => {
+      await hook.result.current.start()
+    })
+    await waitFor(() => expect(hook.result.current.status).toBe('listening'))
+    micHandle.stop.mockResolvedValueOnce({
+      audio: new Blob(['q'], { type: 'audio/webm' }),
+      durationMs: 900,
+      heardSpeech: true
+    })
+
+    act(() => {
+      hook.result.current.stopTurn()
+    })
+    await waitFor(() => expect(hook.result.current.status).toBe('transcribing'))
+
+    await act(async () => {
+      await hook.result.current.end()
+      resolveTranscription('stale normal turn')
+    })
+
+    expect(onSubmit).not.toHaveBeenCalled()
+    expect(hook.result.current.status).toBe('idle')
+  })
+
+  it('does not submit a barge capture when the conversation ends during transcription', async () => {
+    let calls = 0
+    let resolveTranscription!: (transcript: string) => void
+
+    const transcription = new Promise<string>(resolve => {
+      resolveTranscription = resolve
+    })
+
+    const { hook, onSubmit } = renderConversation({
+      onTranscribeAudio: vi.fn(async () => {
+        calls += 1
+
+        return calls === 1 ? 'kick off the task' : transcription
+      })
+    })
+
+    await act(async () => {
+      await hook.result.current.start()
+    })
+    await enterThinking(hook)
+    await waitFor(() => expect(monitorCalls.length).toBeGreaterThan(0))
+    const monitor = monitorCalls.at(-1)
+    act(() => monitor?.onSpeech())
+    hook.rerender({ busy: false })
+
+    act(() => {
+      monitor?.onUtterance?.(new Blob(['x'], { type: 'audio/webm' }))
+    })
+    await waitFor(() => expect(hook.result.current.status).toBe('transcribing'))
+
+    await act(async () => {
+      await hook.result.current.end()
+      resolveTranscription('stale barge turn')
+    })
+
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+    expect(onSubmit).not.toHaveBeenCalledWith('stale barge turn')
+    expect(hook.result.current.status).toBe('idle')
+  })
+
+  it('does not submit a barge capture when the conversation ends during interrupt settling', async () => {
+    const { hook, onSubmit } = renderConversation({ transcript: 'stale after wait' })
+
+    await act(async () => {
+      await hook.result.current.start()
+    })
+    await enterThinking(hook)
+    await waitFor(() => expect(monitorCalls.length).toBeGreaterThan(0))
+    const monitor = monitorCalls.at(-1)
+    act(() => monitor?.onSpeech())
+
+    vi.useFakeTimers()
+
+    try {
+      const submission = monitor?.onUtterance?.(new Blob(['x'], { type: 'audio/webm' }))
+      await Promise.resolve()
+      await act(async () => {
+        await hook.result.current.end()
+        vi.advanceTimersByTime(100)
+        await submission
+      })
+
+      expect(onSubmit).not.toHaveBeenCalledWith('stale after wait')
+      expect(hook.result.current.status).toBe('idle')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('allows a fresh generation to submit after a cancelled turn', async () => {
+    let calls = 0
+    let resolveTranscription!: (transcript: string) => void
+
+    const staleTranscription = new Promise<string>(resolve => {
+      resolveTranscription = resolve
+    })
+
+    const { hook, onSubmit } = renderConversation({
+      onTranscribeAudio: vi.fn(async () => {
+        calls += 1
+
+        if (calls === 1) {
+          return staleTranscription
+        }
+
+        return 'fresh turn'
+      })
+    })
+
+    await act(async () => {
+      await hook.result.current.start()
+    })
+    await waitFor(() => expect(hook.result.current.status).toBe('listening'))
+    micHandle.stop.mockResolvedValueOnce({
+      audio: new Blob(['q'], { type: 'audio/webm' }),
+      durationMs: 900,
+      heardSpeech: true
+    })
+    act(() => hook.result.current.stopTurn())
+    await waitFor(() => expect(hook.result.current.status).toBe('transcribing'))
+    await act(async () => {
+      await hook.result.current.end()
+      resolveTranscription('stale turn')
+    })
+
+    await act(async () => {
+      await hook.result.current.start()
+    })
+    await waitFor(() => expect(hook.result.current.status).toBe('listening'))
+    micHandle.stop.mockResolvedValueOnce({
+      audio: new Blob(['fresh'], { type: 'audio/webm' }),
+      durationMs: 900,
+      heardSpeech: true
+    })
+    await act(async () => hook.result.current.stopTurn())
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledWith('fresh turn'))
   })
 
   it('interrupts the in-flight turn when speech trips mid-generation', async () => {

--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
@@ -79,6 +79,12 @@ export function useVoiceConversation({
   const statusRef = useRef<ConversationStatus>('idle')
   const wasEnabledRef = useRef(enabled)
   const onStopWordRef = useRef(onStopWord)
+  const generationRef = useRef(0)
+
+  const invalidateGeneration = () => {
+    generationRef.current += 1
+  }
+
   const onInterruptRef = useRef(onInterrupt)
 
   // eslint-disable-next-line no-restricted-syntax -- legitimate non-atom ref write (see eslint rule comment)
@@ -141,12 +147,17 @@ export function useVoiceConversation({
         return
       }
 
+      const generation = generationRef.current
       turnClosingRef.current = true
       clearTurnTimeout()
       setStatus('transcribing')
 
       try {
         const result = await handle.stop()
+
+        if (generationRef.current !== generation) {
+          return
+        }
 
         if (!result || (!result.heardSpeech && !forceTranscribe) || !onTranscribeAudio) {
           if (enabledRef.current && !mutedRef.current && !busyRef.current && statusRef.current !== 'speaking') {
@@ -160,6 +171,10 @@ export function useVoiceConversation({
 
         try {
           const transcript = (await onTranscribeAudio(result.audio)).trim()
+
+          if (generationRef.current !== generation) {
+            return
+          }
 
           if (!transcript) {
             if (enabledRef.current) {
@@ -186,8 +201,17 @@ export function useVoiceConversation({
           awaitingSpokenResponseRef.current = true
           dropSpeechSession()
           await onSubmit(transcript)
+
+          if (generationRef.current !== generation) {
+            return
+          }
+
           setStatus('thinking')
         } catch (error) {
+          if (generationRef.current !== generation) {
+            return
+          }
+
           notifyError(error, voiceCopy.transcriptionFailed)
 
           if (enabledRef.current && !mutedRef.current && !busyRef.current) {
@@ -204,6 +228,7 @@ export function useVoiceConversation({
   )
 
   const startListening = useCallback(async () => {
+    const generation = generationRef.current
     pendingStartRef.current = false
 
     if (!enabledRef.current || mutedRef.current || busyRef.current) {
@@ -227,6 +252,10 @@ export function useVoiceConversation({
       // A pause failure shouldn't block the user's explicit start.
     }
 
+    if (generationRef.current !== generation) {
+      return
+    }
+
     // enabled/muted/busy or an interleaved turn may have changed while we waited.
     if (!enabledRef.current || mutedRef.current || busyRef.current || statusRef.current !== 'idle') {
       return
@@ -234,17 +263,33 @@ export function useVoiceConversation({
 
     try {
       // VAD tuning mirrors `tools.voice_mode` defaults so the browser loop matches the CLI.
-      await handle.start({
+      const started = await handle.start({
         silenceLevel: 0.075,
         silenceMs: 1_250,
         idleSilenceMs: 12_000,
         onError: error => {
+          if (generationRef.current !== generation) {
+            return
+          }
+
+          invalidateGeneration()
           notifyError(error, voiceCopy.microphoneFailed)
           pendingStartRef.current = false
           onFatalError?.()
         },
         onSilence: () => void handleTurn()
       })
+
+      if (generationRef.current !== generation) {
+        return
+      }
+
+      if (!started) {
+        setStatus('idle')
+
+        return
+      }
+
       setStatus('listening')
       // Clear any prior turn-timeout before arming a fresh one. Each listen
       // cycle reassigns turnTimeoutRef; without clearing first, a stale 60s
@@ -254,6 +299,11 @@ export function useVoiceConversation({
       clearTurnTimeout()
       turnTimeoutRef.current = window.setTimeout(() => void handleTurn(), 60_000)
     } catch (error) {
+      if (generationRef.current !== generation) {
+        return
+      }
+
+      invalidateGeneration()
       notifyError(error, voiceCopy.couldNotStartSession)
       pendingStartRef.current = false
       setStatus('idle')
@@ -306,8 +356,12 @@ export function useVoiceConversation({
    * fall back to normal listening.
    */
   const submitCapturedUtterance = useCallback(
-    async (audio: Blob | null) => {
+    async (audio: Blob | null, generation: number) => {
       const resumeListening = () => {
+        if (generationRef.current !== generation) {
+          return
+        }
+
         if (enabledRef.current && !mutedRef.current) {
           pendingStartRef.current = true
         }
@@ -325,6 +379,10 @@ export function useVoiceConversation({
 
       try {
         const transcript = (await onTranscribeAudio(audio)).trim()
+
+        if (generationRef.current !== generation) {
+          return
+        }
 
         if (!transcript) {
           resumeListening()
@@ -349,14 +407,31 @@ export function useVoiceConversation({
 
         while (busyRef.current && Date.now() < deadline) {
           await new Promise(resolve => window.setTimeout(resolve, 100))
+
+          if (generationRef.current !== generation) {
+            return
+          }
+        }
+
+        if (generationRef.current !== generation) {
+          return
         }
 
         awaitingSpokenResponseRef.current = true
         dropSpeechSession()
         consumePendingResponse()
         await onSubmit(transcript)
+
+        if (generationRef.current !== generation) {
+          return
+        }
+
         setStatus('thinking')
       } catch (error) {
+        if (generationRef.current !== generation) {
+          return
+        }
+
         notifyError(error, voiceCopy.transcriptionFailed)
         resumeListening()
       }
@@ -383,9 +458,14 @@ export function useVoiceConversation({
       return
     }
 
+    const generation = generationRef.current
     stopBargeMonitorRef.current = monitorSpeechDuringPlayback({
       isPlaying: () => $voicePlayback.get().status === 'speaking',
       onSpeech: () => {
+        if (generationRef.current !== generation) {
+          return
+        }
+
         bargeCapturePendingRef.current = true
         bargedRef.current = true
         markVoicePlaybackInterrupted()
@@ -398,9 +478,13 @@ export function useVoiceConversation({
         }
       },
       onUtterance: audio => {
+        if (generationRef.current !== generation) {
+          return
+        }
+
         bargeCapturePendingRef.current = false
         stopBargeMonitorRef.current = null
-        void submitCapturedUtterance(audio)
+        void submitCapturedUtterance(audio, generation)
       }
     })
   }, [submitCapturedUtterance])
@@ -600,6 +684,7 @@ export function useVoiceConversation({
   ])
 
   const end = useCallback(async () => {
+    invalidateGeneration()
     pendingStartRef.current = false
     clearTurnTimeout()
     stopVoicePlayback()
@@ -611,6 +696,8 @@ export function useVoiceConversation({
     setMuted(false)
     setStatus('idle')
   }, [consumePendingResponse, handle])
+
+  useEffect(() => () => invalidateGeneration(), [])
 
   const stopTurn = useCallback(() => {
     if (statusRef.current === 'listening') {

--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-recorder.test.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-recorder.test.ts
@@ -1,0 +1,94 @@
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  cancel: vi.fn(),
+  focusInput: vi.fn(),
+  notifyError: vi.fn(),
+  onTranscript: vi.fn(),
+  resolveStop: undefined as ((value: { audio: Blob; durationMs: number; heardSpeech: boolean } | null) => void) | undefined
+}))
+
+vi.mock('./use-mic-recorder', () => ({
+  useMicRecorder: () => ({
+    handle: {
+      cancel: mocks.cancel,
+      start: vi.fn().mockResolvedValue(true),
+      stop: () => new Promise(resolve => { mocks.resolveStop = resolve })
+    },
+    level: 0,
+    recording: true
+  })
+}))
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({ t: { notifications: { voice: {
+    transcriptionFailed: 'transcription failed',
+    recordingFailed: 'recording failed'
+  } } } })
+}))
+
+vi.mock('@/store/notifications', () => ({
+  notify: vi.fn(),
+  notifyError: mocks.notifyError
+}))
+
+import { useVoiceRecorder } from './use-voice-recorder'
+
+describe('useVoiceRecorder transcription cancellation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.resolveStop = undefined
+  })
+
+  it('does not focus or publish a late transcript after cancel', async () => {
+    let rejectTranscription: ((error: Error) => void) | undefined
+
+    const { result } = renderHook(() => useVoiceRecorder({
+      focusInput: mocks.focusInput,
+      maxRecordingSeconds: 10,
+      onTranscript: mocks.onTranscript,
+      onTranscribeAudio: () => new Promise((_resolve, reject) => { rejectTranscription = reject })
+    }))
+
+    let stopping: Promise<string | null>
+    await act(async () => {
+      stopping = result.current.stopRecording()
+      result.current.cancelRecording()
+      mocks.resolveStop?.({ audio: new Blob(['audio']), durationMs: 1, heardSpeech: true })
+      await Promise.resolve()
+      rejectTranscription?.(new Error('late failure'))
+      await stopping
+    })
+
+    expect(mocks.notifyError).not.toHaveBeenCalled()
+    expect(mocks.focusInput).not.toHaveBeenCalled()
+    expect(mocks.onTranscript).not.toHaveBeenCalled()
+    expect(result.current.voiceStatus).toBe('idle')
+  })
+
+  it('notifies and resets focus/status for a current transcription failure', async () => {
+    const failure = new Error('current failure')
+    let rejectTranscription: ((error: Error) => void) | undefined
+
+    const { result } = renderHook(() => useVoiceRecorder({
+      focusInput: mocks.focusInput,
+      maxRecordingSeconds: 10,
+      onTranscript: mocks.onTranscript,
+      onTranscribeAudio: () => new Promise((_resolve, reject) => { rejectTranscription = reject })
+    }))
+
+    let stopping: Promise<string | null>
+    await act(async () => {
+      stopping = result.current.stopRecording()
+      mocks.resolveStop?.({ audio: new Blob(['audio']), durationMs: 1, heardSpeech: true })
+      await Promise.resolve()
+      rejectTranscription?.(failure)
+      await stopping
+    })
+
+    expect(mocks.notifyError).toHaveBeenCalledWith(failure, 'transcription failed')
+    expect(mocks.focusInput).toHaveBeenCalledTimes(1)
+    expect(result.current.voiceStatus).toBe('idle')
+  })
+})

--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-recorder.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-recorder.ts
@@ -26,6 +26,7 @@ export function useVoiceRecorder({
   const [voiceStatus, setVoiceStatus] = useState<VoiceStatus>('idle')
   const [elapsedSeconds, setElapsedSeconds] = useState(0)
   const startedAtRef = useRef(0)
+  const operationGenerationRef = useRef(0)
   const intervalRef = useRef<number | null>(null)
   const timeoutRef = useRef<number | null>(null)
 
@@ -41,22 +42,37 @@ export function useVoiceRecorder({
     }
   }
 
-  useEffect(() => () => clearTimers(), [])
+  useEffect(
+    () => () => {
+      operationGenerationRef.current += 1
+      clearTimers()
+    },
+    []
+  )
 
-  const stop = async () => {
+  const stop = async (autoSubmit = false): Promise<string | null> => {
+    const generation = operationGenerationRef.current
     clearTimers()
     const result = await handle.stop()
 
     if (!result) {
-      setVoiceStatus('idle')
+      if (generation === operationGenerationRef.current) {
+        setVoiceStatus('idle')
+      }
 
-      return
+      return null
     }
 
     if (!onTranscribeAudio) {
-      setVoiceStatus('idle')
+      if (generation === operationGenerationRef.current) {
+        setVoiceStatus('idle')
+      }
 
-      return
+      return null
+    }
+
+    if (generation !== operationGenerationRef.current) {
+      return null
     }
 
     setVoiceStatus('transcribing')
@@ -64,37 +80,65 @@ export function useVoiceRecorder({
     try {
       const transcript = (await onTranscribeAudio(result.audio)).trim()
 
+      if (generation !== operationGenerationRef.current) {
+        return null
+      }
+
       if (!transcript) {
         notify({ kind: 'warning', title: voiceCopy.noSpeechDetected, message: voiceCopy.tryRecordingAgain })
+      } else if (autoSubmit) {
+        // PTT submits through its composer seam after transcription resolves.
       } else {
         onTranscript(transcript)
       }
+
+      return transcript
     } catch (error) {
-      notifyError(error, voiceCopy.transcriptionFailed)
+      if (generation === operationGenerationRef.current) {
+        notifyError(error, voiceCopy.transcriptionFailed)
+      }
+
+      return null
     } finally {
-      setVoiceStatus('idle')
-      focusInput()
+      if (generation === operationGenerationRef.current) {
+        setVoiceStatus('idle')
+        focusInput()
+      }
     }
   }
 
-  const start = async () => {
+  const start = async (withTimeout = true): Promise<boolean> => {
     if (!onTranscribeAudio) {
       notify({ kind: 'warning', title: voiceCopy.unavailable, message: voiceCopy.transcriptionUnavailable })
 
-      return
+      return false
     }
 
     try {
-      await handle.start({ onError: error => notifyError(error, voiceCopy.recordingFailed) })
+      const started = await handle.start({ onError: error => notifyError(error, voiceCopy.recordingFailed) })
+
+      if (!started) {
+        setVoiceStatus('idle')
+
+        return false
+      }
+
       startedAtRef.current = Date.now()
       setElapsedSeconds(0)
       setVoiceStatus('recording')
       intervalRef.current = window.setInterval(() => setElapsedSeconds((Date.now() - startedAtRef.current) / 1000), 250)
-      const cap = Math.max(1, Math.min(Math.trunc(maxRecordingSeconds), 600))
-      timeoutRef.current = window.setTimeout(() => void stop(), cap * 1000)
+
+      if (withTimeout) {
+        const cap = Math.max(1, Math.min(Math.trunc(maxRecordingSeconds), 600))
+        timeoutRef.current = window.setTimeout(() => void stop(), cap * 1000)
+      }
+
+      return true
     } catch (error) {
       setVoiceStatus('idle')
       notifyError(error, voiceCopy.recordingFailed)
+
+      return false
     }
   }
 
@@ -106,11 +150,21 @@ export function useVoiceRecorder({
     }
   }
 
+  const startRecording = () => start(false)
+  const stopRecording = () => stop(true)
+
+  const cancelRecording = () => {
+    operationGenerationRef.current += 1
+    clearTimers()
+    handle.cancel()
+    setVoiceStatus('idle')
+  }
+
   const voiceActivityState: VoiceActivityState = {
     elapsedSeconds,
     level,
     status: voiceStatus
   }
 
-  return { dictate, voiceActivityState, voiceStatus }
+  return { dictate, startRecording, stopRecording, cancelRecording, voiceActivityState, voiceStatus }
 }

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -984,6 +984,7 @@ export function ChatBar({
     onInterrupt: haltRun,
     onSubmit,
     onTranscribeAudio,
+    pttActive: () => document.activeElement === editorRef.current,
     sessionId,
     target: scope.target
   })


### PR DESCRIPTION
## Summary

Adds composer-local hold-to-talk dictation to Hermes Desktop using the physical left Alt key (`AltLeft`):

- hold Left Alt to start recording in the focused active composer
- release to stop, transcribe, and submit exactly once
- preserve a completed transcript as a visible draft if the composer becomes busy before submission
- ignore key repeat, AltGr/right Alt, and modified key combinations

The shortcut is intentionally local to the focused composer. It does not register a global keyboard hook or consume native Alt behavior.

Partially addresses #87648. This PR implements the local hold-to-talk path only; configurable bindings, global shortcuts, and tray minimization remain out of scope.

## Safety and lifecycle handling

- cancels on window blur, composer focus change, unmount, disabled/busy state, or voice-conversation activation
- coordinates wake-word pause/resume before microphone ownership changes
- handles delayed or cancelled microphone permission/start results
- generation-gates stale transcription success and error completions
- prevents normal and barge-in voice turns from submitting after conversation end

## Verification

- [x] 6 focused Desktop test files, 36 tests passed
- [x] Desktop renderer, Electron, and E2E TypeScript checks passed
- [x] Targeted ESLint passed
- [x] `git diff --check` passed
- [x] Windows x64 NSIS cross-build completed successfully on the pre-rebase revision
- [ ] Real Windows keyboard/microphone user-path test

## Manual test plan

1. Focus the main Desktop composer.
2. Hold physical Left Alt, speak, then release.
3. Confirm recording starts only while held and the transcript is submitted exactly once.
4. Confirm Right Alt/AltGr, repeated keydown events, modified Alt combinations, inactive composers, and window blur do not submit.
5. Start Voice Conversation or make the composer busy during recording/transcription and confirm PTT cancels safely or preserves the transcript as a draft.

## Platforms

Automated tests and TypeScript checks ran on Linux. A Windows x64 cross-build completed, but the real Windows microphone/keyboard path has not yet been manually exercised; the PR is opened as a draft for that reason.
