### PR TITLE
fix(kanban): coerce foreign timestamp values when reading task/run/event rows

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -86,6 +86,7 @@ import logging
 import time
 from contextvars import ContextVar, Token
 from dataclasses import dataclass, field
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Iterable, Mapping, Optional
 
@@ -481,6 +482,45 @@ _CTX_MAX_COMMENTS       = 30      # most recent N comments shown in full
 _CTX_MAX_FIELD_BYTES    = 4 * 1024   # 4 KB per summary/error/metadata/result
 _CTX_MAX_BODY_BYTES     = 8 * 1024   # 8 KB per task.body (opening post)
 _CTX_MAX_COMMENT_BYTES  = 2 * 1024   # 2 KB per comment
+
+
+def _coerce_epoch(value: Any) -> Optional[int]:
+    """Coerce a timestamp-column value to a unix-epoch int, tolerating strays.
+
+    The timestamp columns of ``tasks`` / ``task_runs`` / ``task_events`` are
+    declared INTEGER, but SQLite's type affinity lets an ISO-8601 string (or
+    an epoch-as-str) land there silently when a row is written outside the
+    mutators — e.g. a worker shell running raw SQL (#97455). Every mutator in
+    this module writes ``int(time.time())``, so readers only need to tolerate
+    foreign rows: numeric values pass through, timezone-aware ISO-8601
+    strings are converted to epoch seconds, and anything else degrades to
+    ``None`` instead of crashing every later read of the card. Naive ISO
+    strings are NOT guessed at a timezone — an unparseable clock reading is
+    dropped rather than rendered as a wrong time.
+    """
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return int(value)
+    if isinstance(value, str):
+        s = value.strip()
+        if not s:
+            return None
+        try:
+            return int(s)
+        except ValueError:
+            pass
+        try:
+            iso = s[:-1] + "+00:00" if s.endswith("Z") else s
+            dt = datetime.fromisoformat(iso)
+        except ValueError:
+            return None
+        if dt.tzinfo is None:
+            return None
+        return int(dt.timestamp())
+    return None
 
 
 def _relative_age(ts: Optional[int], now: Optional[int] = None) -> str:
@@ -1162,15 +1202,15 @@ class Task:
             status=row["status"],
             priority=row["priority"],
             created_by=row["created_by"],
-            created_at=row["created_at"],
-            started_at=row["started_at"],
-            completed_at=row["completed_at"],
+            created_at=(_coerce_epoch(row["created_at"]) or 0),
+            started_at=_coerce_epoch(row["started_at"]),
+            completed_at=_coerce_epoch(row["completed_at"]),
             workspace_kind=row["workspace_kind"],
             workspace_path=row["workspace_path"],
             branch_name=row["branch_name"] if "branch_name" in keys else None,
             project_id=row["project_id"] if "project_id" in keys else None,
             claim_lock=row["claim_lock"],
-            claim_expires=row["claim_expires"],
+            claim_expires=_coerce_epoch(row["claim_expires"]),
             tenant=row["tenant"] if "tenant" in keys else None,
             result=row["result"] if "result" in keys else None,
             idempotency_key=row["idempotency_key"] if "idempotency_key" in keys else None,
@@ -1192,7 +1232,9 @@ class Task:
                 row["max_runtime_seconds"] if "max_runtime_seconds" in keys else None
             ),
             last_heartbeat_at=(
-                row["last_heartbeat_at"] if "last_heartbeat_at" in keys else None
+                _coerce_epoch(row["last_heartbeat_at"])
+                if "last_heartbeat_at" in keys
+                else None
             ),
             current_run_id=(
                 row["current_run_id"] if "current_run_id" in keys else None
@@ -1279,12 +1321,12 @@ class Run:
             step_key=row["step_key"],
             status=row["status"],
             claim_lock=row["claim_lock"],
-            claim_expires=row["claim_expires"],
+            claim_expires=_coerce_epoch(row["claim_expires"]),
             worker_pid=row["worker_pid"],
             max_runtime_seconds=row["max_runtime_seconds"],
-            last_heartbeat_at=row["last_heartbeat_at"],
-            started_at=int(row["started_at"]),
-            ended_at=(int(row["ended_at"]) if row["ended_at"] is not None else None),
+            last_heartbeat_at=_coerce_epoch(row["last_heartbeat_at"]),
+            started_at=(_coerce_epoch(row["started_at"]) or 0),
+            ended_at=_coerce_epoch(row["ended_at"]),
             outcome=row["outcome"],
             summary=row["summary"],
             metadata=meta,
@@ -4301,7 +4343,7 @@ def list_events(conn: sqlite3.Connection, task_id: str) -> list[Event]:
                 task_id=r["task_id"],
                 kind=r["kind"],
                 payload=payload,
-                created_at=r["created_at"],
+                created_at=(_coerce_epoch(r["created_at"]) or 0),
                 run_id=(int(r["run_id"]) if "run_id" in r.keys() and r["run_id"] is not None else None),
             )
         )
@@ -9490,8 +9532,8 @@ def check_respawn_guard(
             # blocker_auth regex so the stamped rate-limit text doesn't
             # re-trap the task.
             return None
-        ended_at = latest_run["ended_at"]
-        if ended_at is not None and (now - int(ended_at)) < rl_cooldown:
+        ended_at = _coerce_epoch(latest_run["ended_at"])
+        if ended_at is not None and (now - ended_at) < rl_cooldown:
             return "rate_limit_cooldown"
         # Cooldown elapsed — allow the respawn. Return early so the
         # blocker_auth check below doesn't catch the rate-limit text we
@@ -9525,7 +9567,7 @@ def check_respawn_guard(
         (task_id, cutoff),
     ).fetchone()
     if recent_completed:
-        completed_at = int(recent_completed["ended_at"] or 0)
+        completed_at = _coerce_epoch(recent_completed["ended_at"]) or 0
         requeued_after = conn.execute(
             "SELECT 1 FROM task_events "
             "WHERE task_id = ? AND created_at >= ? "
@@ -11215,10 +11257,12 @@ def build_worker_context(conn: sqlite3.Connection, task_id: str) -> str:
         if role_rows:
             lines.append(f"## Recent work by @{task.assignee}")
             for row in role_rows:
-                ts = time.strftime(
-                    "%Y-%m-%d %H:%M", time.localtime(int(row["ended_at"]))
+                ended = _coerce_epoch(row["ended_at"])
+                ts = (
+                    time.strftime("%Y-%m-%d %H:%M", time.localtime(ended))
+                    if ended is not None else "?"
                 )
-                age = _relative_age(row["ended_at"], _now)
+                age = _relative_age(ended, _now)
                 ts_disp = f"{ts}, {age}" if age else ts
                 s = (row["summary"] or "").strip().splitlines()
                 first = s[0][:200] if s else "(no summary)"
@@ -11767,7 +11811,7 @@ def unseen_events_for_sub(
             payload = None
         out.append(Event(
             id=r["id"], task_id=r["task_id"], kind=r["kind"],
-            payload=payload, created_at=r["created_at"],
+            payload=payload, created_at=(_coerce_epoch(r["created_at"]) or 0),
             run_id=(int(r["run_id"]) if "run_id" in r.keys() and r["run_id"] is not None else None),
         ))
         max_id = max(max_id, int(r["id"]))

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -70,6 +70,45 @@ def test_kanban_show_text_renders_graph_with_open_connection(kanban_home):
     assert "Cannot operate on a closed database" not in output
 
 
+def test_show_survives_iso_strings_in_integer_timestamp_columns(kanban_home):
+    """`kanban show` must not crash on ISO-8601 strings written into the
+    INTEGER timestamp columns by raw SQL outside the mutators (#97455).
+
+    SQLite's type affinity accepts those writes silently; both output modes
+    must keep the card readable, with the stray values coerced back to
+    epoch ints instead of raising ``invalid literal for int()``.
+    """
+    iso_utc = "2026-08-28T14:35:22+00:00"
+    iso_z = "2026-08-28T16:58:56.613Z"
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(conn, title="corrupted card", assignee="alice")
+        assert kb.claim_task(conn, task_id)
+        assert kb.complete_task(conn, task_id, summary="done")
+        conn.execute(
+            "UPDATE task_runs SET ended_at = ? WHERE task_id = ?",
+            (iso_utc, task_id),
+        )
+        conn.execute(
+            "UPDATE tasks SET completed_at = ? WHERE id = ?",
+            (iso_z, task_id),
+        )
+        conn.execute(
+            "UPDATE task_events SET created_at = ? WHERE task_id = ?",
+            (iso_z, task_id),
+        )
+        conn.commit()
+
+    output = kc.run_slash(f"show {task_id}")
+    assert f"Task {task_id}: corrupted card" in output
+    assert "invalid literal" not in output
+
+    payload = json.loads(kc.run_slash(f"show {task_id} --json"))
+    assert payload["task"]["id"] == task_id
+    assert isinstance(payload["task"]["completed_at"], int)
+    assert all(isinstance(r["ended_at"], int) for r in payload["runs"])
+    assert all(isinstance(e["created_at"], int) for e in payload["events"])
+
+
 def test_board_override_is_isolated_per_concurrent_call(kanban_home, monkeypatch):
     kb.create_board("alpha")
     kb.create_board("beta")

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -10,6 +10,7 @@ import sys
 import time
 import types
 import unittest.mock
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
@@ -483,6 +484,68 @@ def test_delete_task_removes_task_and_cascades(kanban_home):
         assert len(kb.list_comments(conn, t)) == 0
         assert len(kb.list_events(conn, t)) == 0
         assert len(kb.list_runs(conn, t)) == 0
+
+
+def test_coerce_epoch_matrix():
+    """_coerce_epoch tolerates foreign timestamp values (#97455)."""
+    assert kb._coerce_epoch(1785902715) == 1785902715
+    assert kb._coerce_epoch(1785902715.25) == 1785902715
+    assert kb._coerce_epoch("1785902715") == 1785902715
+    # Timezone-aware ISO-8601 — both spellings observed in the wild —
+    # convert to epoch seconds.
+    assert kb._coerce_epoch("2026-08-28T14:35:22+00:00") == int(
+        datetime(2026, 8, 28, 14, 35, 22, tzinfo=timezone.utc).timestamp()
+    )
+    assert kb._coerce_epoch("2026-08-28T16:58:56.613Z") == int(
+        datetime(2026, 8, 28, 16, 58, 56, 613000, tzinfo=timezone.utc).timestamp()
+    )
+    # A naive ISO string has no timezone to trust — dropped, not guessed.
+    assert kb._coerce_epoch("2026-08-04T21:05:15.679975") is None
+    assert kb._coerce_epoch("not a timestamp") is None
+    assert kb._coerce_epoch("") is None
+    assert kb._coerce_epoch(None) is None
+    assert kb._coerce_epoch(True) is None
+
+
+def test_readers_coerce_iso_strings_in_integer_timestamp_columns(kanban_home):
+    """Rows written outside the mutators must not make a card unreadable.
+
+    SQLite's type affinity lets raw SQL store ISO-8601 strings into the
+    INTEGER timestamp columns (#97455); the row mappers must coerce them
+    back to epoch ints instead of raising ``invalid literal for int()``.
+    """
+    iso_utc = "2026-08-28T14:35:22+00:00"
+    iso_z = "2026-08-28T16:58:56.613Z"
+    expected = int(
+        datetime(2026, 8, 28, 14, 35, 22, tzinfo=timezone.utc).timestamp()
+    )
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="corrupted card", assignee="alice")
+        assert kb.claim_task(conn, t)
+        assert kb.complete_task(conn, t, summary="done")
+        conn.execute(
+            "UPDATE task_runs SET ended_at = ? WHERE task_id = ?", (iso_utc, t)
+        )
+        conn.execute(
+            "UPDATE tasks SET completed_at = ? WHERE id = ?", (iso_z, t)
+        )
+        conn.execute(
+            "UPDATE task_events SET created_at = ? WHERE task_id = ?", (iso_z, t)
+        )
+        conn.commit()
+
+        runs = kb.list_runs(conn, t)
+        assert len(runs) == 1
+        assert runs[0].ended_at == expected
+        assert isinstance(runs[0].started_at, int)
+
+        task = kb.get_task(conn, t)
+        assert task is not None
+        assert isinstance(task.completed_at, int)
+
+        events = kb.list_events(conn, t)
+        assert events and all(isinstance(e.created_at, int) for e in events)
+
 
 
 


### PR DESCRIPTION
## What does this PR do?

`kanban show` (text and JSON), the `kanban_show` worker context, and the dashboard's run history all crash with `invalid literal for int() with base 10: '2026-08-28T14:35:22+00:00'` once a timestamp column in `tasks` / `task_runs` / `task_events` holds an ISO-8601 string, making the affected card unreadable (#97455).

SQLite's type affinity accepts those writes silently, and every mutator in `kanban_db` already writes `int(time.time())` — the stray strings come from rows written outside the mutators (e.g. a worker shell running raw SQL). Since the writer can't be pinned down, the fix is on the reader side: a new `_coerce_epoch` helper passes numeric values through, converts timezone-aware ISO-8601 strings (both `+00:00` and `Z` spellings observed in the wild) to epoch seconds, and degrades anything untrustworthy (naive ISO, garbage) to `None` so the card stays readable. Naive ISO strings are deliberately dropped rather than guessed at a timezone, so a malformed value is never rendered as a wrong time.

Applied at the row mappers (`Task.from_row`, `Run.from_row`, both `Event` constructors), which covers every consumer of those objects, plus the two raw-SQL reader spots in the dispatcher (respawn guard, rate-limit cooldown) and the worker-context "recent work" renderer that called `int()` directly.

## Related Issue

Fixes #97455

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/kanban_db.py`: added `_coerce_epoch()` — epoch/float/epoch-as-str pass through, timezone-aware ISO-8601 converts to epoch seconds, naive ISO and garbage degrade to `None`
- `hermes_cli/kanban_db.py`: `Task.from_row` / `Run.from_row` / both `Event` constructions now coerce `created_at` / `started_at` / `completed_at` / `ended_at` / `claim_expires` / `last_heartbeat_at` instead of passing strays through or calling bare `int()`
- `hermes_cli/kanban_db.py`: `check_respawn_guard` (rate-limit cooldown + recent-completion window) and the `build_worker_context` "recent work" renderer coerce raw `ended_at` values instead of `int()`
- `tests/hermes_cli/test_kanban_db.py`: `_coerce_epoch` matrix test + row-mapper regression that seeds the exact corruption from the issue
- `tests/hermes_cli/test_kanban_cli.py`: end-to-end `kanban show` regression (text + JSON) reproducing the issue's `UPDATE` scenario

## How to Test

1. `uv run --extra dev python -m pytest tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_cli.py tests/tools/test_kanban_tools.py -q` — Observed result: `70 passed, 1 skipped` (the skip is a pre-existing environment-conditional test, unrelated)
2. `uv run --extra dev python -m pytest tests/hermes_cli/test_kanban_db.py::test_readers_coerce_iso_strings_in_integer_timestamp_columns tests/hermes_cli/test_kanban_cli.py::test_show_survives_iso_strings_in_integer_timestamp_columns -q` — Observed result: `2 passed`; the tests store `'2026-08-28T14:35:22+00:00'` into `task_runs.ended_at` and `'2026-08-28T16:58:56.613Z'` into `tasks.completed_at` / `task_events.created_at` exactly as in the issue, then assert `show` renders and the JSON payload carries epoch ints
3. On the issue's repro (`UPDATE task_runs SET ended_at = '2026-08-28T14:35:22+00:00' ...` then `hermes kanban show <task_id>`): should pass — the card renders and `runs[].ended_at` is the coerced epoch int `1756384522` instead of raising `invalid literal for int()`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (#86584 tolerates string timestamps only in the CLI `_fmt_ts` renderer — this crash happens earlier, at the `Run.from_row` data layer, which #86584 does not touch)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (behavior rationale documented in the `_coerce_epoch` docstring)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pure-Python datetime parsing, no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
