### PR TITLE
fix(desktop): apply app color scheme to inline previews

### DIFF
--- a/apps/desktop/src/components/assistant-ui/inline-preview-directive.test.ts
+++ b/apps/desktop/src/components/assistant-ui/inline-preview-directive.test.ts
@@ -24,7 +24,7 @@ describe('directiveFrameHeight', () => {
 })
 
 describe('withInlineChrome', () => {
-  const prelude = themePrelude({ '--foreground': '#eee' }, 'Inter')
+  const prelude = themePrelude({ '--foreground': '#eee' }, 'Inter', 'dark')
 
   it('puts the theme prelude FIRST so page styles override it', () => {
     const doc = '<html><head><style>body{color:red}</style></head><body><h1>hi</h1></body></html>'
@@ -52,8 +52,16 @@ describe('withInlineChrome', () => {
 })
 
 describe('themePrelude', () => {
+  it.each(['light', 'dark'] as const)('sets the iframe document color scheme to %s', colorScheme => {
+    expect(themePrelude({}, '', colorScheme)).toContain(`color-scheme:${colorScheme}`)
+  })
+
   it('carries resolved tokens, transparent background, and the app font', () => {
-    const prelude = themePrelude({ '--foreground': 'oklch(0.9 0 0)', '--accent': '#7aa2f7' }, 'Inter, sans-serif')
+    const prelude = themePrelude(
+      { '--foreground': 'oklch(0.9 0 0)', '--accent': '#7aa2f7' },
+      'Inter, sans-serif',
+      'dark'
+    )
 
     expect(prelude).toContain('--foreground:oklch(0.9 0 0)')
     expect(prelude).toContain('--accent:#7aa2f7')
@@ -62,7 +70,7 @@ describe('themePrelude', () => {
   })
 
   it('omits the font rule when no font resolved', () => {
-    expect(themePrelude({}, '')).not.toContain('font-family')
+    expect(themePrelude({}, '', 'light')).not.toContain('font-family')
   })
 })
 

--- a/apps/desktop/src/components/assistant-ui/inline-preview-directive.tsx
+++ b/apps/desktop/src/components/assistant-ui/inline-preview-directive.tsx
@@ -28,10 +28,10 @@ import { isRemoteGateway } from '@/lib/media'
  *
  * NATIVE BY DEFAULT. A theme prelude injects first: the app's resolved
  * theme tokens under friendly names (--foreground, --muted-foreground,
- * --accent, --border, --card), the app font, zero body margin/padding, and
- * a transparent background — so widget-shaped content reads as part of the
- * app. The page's own styles override all of it, so a full page keeps its
- * own design.
+ * --accent, --border, --card), the app font and color scheme, zero body
+ * margin/padding, and a transparent background — so widget-shaped content
+ * reads as part of the app. The page's own styles override all of it, so a
+ * full page keeps its own design.
  *
  * WIDGETS TALK BACK OFF-SCREEN. `window.hermes.send(prompt)` (or declarative
  * `data-hermes-send` on any clickable element) routes the prompt through the
@@ -155,7 +155,7 @@ export function collectThemeBridge(): { vars: Record<string, string>; font: stri
  * Injected FIRST, so the page's own styles override every default here — a
  * full page that wants its own look keeps it.
  */
-export function themePrelude(vars: Record<string, string>, font: string): string {
+export function themePrelude(vars: Record<string, string>, font: string, colorScheme: 'light' | 'dark'): string {
   const tokens = Object.entries(vars)
     .map(([name, value]) => `${name}:${value}`)
     .join(';')
@@ -163,7 +163,7 @@ export function themePrelude(vars: Record<string, string>, font: string): string
   const fontRule = font ? `font-family:${font};` : ''
 
   return (
-    `<style>:root{${tokens}}` +
+    `<style>:root{color-scheme:${colorScheme};${tokens}}` +
     `html,body{margin:0;padding:0;background:transparent;color:var(--foreground,inherit);${fontRule}}</style>`
   )
 }
@@ -274,6 +274,7 @@ function InlineHtmlFrame({
 }) {
   const cwd = useStore(useSessionView().$cwd)
   const isDark = useIsDark()
+  const colorScheme = isDark ? 'dark' : 'light'
   const [doc, setDoc] = useState<string | null>(null)
   const [failed, setFailed] = useState(false)
   const [measured, setMeasured] = useState<number | null>(null)
@@ -367,7 +368,8 @@ function InlineHtmlFrame({
     return () => window.removeEventListener('message', onMessage)
   }, [initialHeight, token])
 
-  // Resolved once per mount; theme switches remount the transcript anyway.
+  // Rebuild the srcdoc when the color scheme changes so its native controls and
+  // transparent canvas stay aligned with the app.
   const framedDoc = useMemo(() => {
     if (doc === null) {
       return null
@@ -375,8 +377,8 @@ function InlineHtmlFrame({
 
     const { vars, font } = collectThemeBridge()
 
-    return withInlineChrome(doc, token, themePrelude(vars, font))
-  }, [doc, token])
+    return withInlineChrome(doc, token, themePrelude(vars, font, colorScheme))
+  }, [colorScheme, doc, token])
 
   if (!path || failed) {
     return <PreviewAttachment source="explicit-link" target={file} />
@@ -405,7 +407,7 @@ function InlineHtmlFrame({
             loading="lazy"
             sandbox="allow-scripts"
             srcDoc={framedDoc}
-            style={{ colorScheme: isDark ? 'dark' : 'light' }}
+            style={{ colorScheme }}
             title={file}
           />
         </span>


### PR DESCRIPTION
## Related Issue

Fixes #95814

## What does this PR do?

Inline `::preview` HTML runs inside a sandboxed iframe. The iframe element already followed the Desktop theme, but the HTML document inside it did not declare a `color-scheme`. In dark mode, browser-drawn controls, scrollbars, and the transparent canvas could therefore stay light.

This change passes the app's resolved light or dark mode into the existing theme prelude that is injected into the preview document. The preview's own CSS still comes later, so a page that chooses its own color scheme keeps that choice.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add the resolved `light` or `dark` `color-scheme` to the inline preview document's existing `:root` theme prelude.
- Rebuild the preview document when the resolved color scheme changes, and reuse the same value on the iframe element.
- Add regression coverage for both light and dark preview documents.

## How to Test

The new regression failed on current `main` because the generated preview document contained no `color-scheme` declaration.

1. `npx vitest run --project ui src/components/assistant-ui/inline-preview-directive.test.ts` — 16 passed.
2. `npm run test:ui` — 679 test files passed, 6707 tests passed.
3. `npm run typecheck` — all three Desktop TypeScript checks passed.
4. `npm run lint` — completed with 0 errors (124 warnings outside the changed files).
5. `npx prettier --check src/components/assistant-ui/inline-preview-directive.tsx src/components/assistant-ui/inline-preview-directive.test.ts` and `git diff --check` — passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A for this Desktop-only TypeScript change; the full Desktop renderer suite is listed above
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.5.1 arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A, no user-facing workflow or setting changed
- [x] I've updated `cli-config.yaml.example` — N/A, no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A, no architecture or workflow changed
- [x] I've considered cross-platform impact — this uses the existing browser CSS and React theme path without platform-specific APIs
- [x] I've updated tool descriptions/schemas — N/A, no model-facing tool or schema changed

## Screenshots / Logs

N/A — this changes the generated iframe document theme and does not alter layout. The light and dark outputs are covered by the regression test above.
