### PR TITLE
fix(kanban): distinguish waiting owners from active assignees

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -52,6 +52,8 @@ def _fmt_ts(ts: Optional[int]) -> str:
 def _fmt_task_line(t: kb.Task) -> str:
     icon = _STATUS_ICONS.get(t.status, "?")
     assignee = t.assignee or "(unassigned)"
+    if t.pending_assignee:
+        assignee = f"(reserved → {t.pending_assignee})"
     tenant = f" [{t.tenant}]" if t.tenant else ""
     return f"{icon} {t.id}  {t.status:8s}  {assignee:20s}{tenant}  {t.title}"
 
@@ -62,6 +64,8 @@ def _task_to_dict(t: kb.Task) -> dict[str, Any]:
         "title": t.title,
         "body": t.body,
         "assignee": t.assignee,
+        "assignment_state": t.assignment_state,
+        "pending_assignee": t.pending_assignee,
         "status": t.status,
         "priority": t.priority,
         "tenant": t.tenant,
@@ -1588,10 +1592,18 @@ def _cmd_create(args: argparse.Namespace) -> int:
             initial_status=getattr(args, "initial_status", "running"),
         )
         task = kb.get_task(conn, task_id)
+    if task is None:
+        print(f"created task disappeared before readback: {task_id}", file=sys.stderr)
+        return 1
     if getattr(args, "json", False):
         print(json.dumps(_task_to_dict(task), indent=2, ensure_ascii=False))
     else:
-        print(f"Created {task_id}  ({task.status}, assignee={task.assignee or '-'})")
+        owner = (
+            f"reserved={task.pending_assignee}"
+            if task.pending_assignee
+            else f"assignee={task.assignee or '-'}"
+        )
+        print(f"Created {task_id}  ({task.status}, {owner})")
 
         # Warn when the task would sit in `ready` because no dispatcher is
         # present. Only warn on ready+assigned tasks — triage/todo are

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1142,6 +1142,18 @@ class Task:
     # ``BLOCK_RECURRENCE_LIMIT``. Reset only on successful completion.
     block_recurrences: int = 0
 
+    @property
+    def assignment_state(self) -> str:
+        """How the stored assignee relates to executable work right now."""
+        if not self.assignee:
+            return "unassigned"
+        return "active" if self.status in {"ready", "running", "review"} else "reserved"
+
+    @property
+    def pending_assignee(self) -> Optional[str]:
+        """Future route selected for a task that is not dispatchable yet."""
+        return self.assignee if self.assignment_state == "reserved" else None
+
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Task":
         keys = set(row.keys())

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -103,7 +103,7 @@
   };
   const FALLBACK_COLUMN_HELP = {
     triage: "Raw ideas — a specifier will flesh out the spec",
-    todo: "Waiting on dependencies or unassigned",
+    todo: "Not dispatchable yet. A selected profile is reserved until Ready.",
     ready: "Dependencies satisfied; assign a profile to dispatch",
     running: "Claimed by a worker — in-flight",
     blocked: "Worker asked for human input",
@@ -3126,7 +3126,11 @@
           h("div", { className: "hermes-kanban-card-title" },
             t.title || tx(i18n, "untitled", "(untitled)")),
           h("div", { className: "hermes-kanban-card-row hermes-kanban-card-meta" },
-            t.assignee
+            t.assignment_state === "reserved" && t.pending_assignee
+              ? h("span", { className: "hermes-kanban-unassigned",
+                            title: `Reserved for @${t.pending_assignee}. The worker becomes active only when this task reaches Ready.` },
+                  "reserved → @", t.pending_assignee)
+              : t.assignee
               ? h("span", { className: "hermes-kanban-assignee",
                             title: `Assigned to Hermes profile @${t.assignee}` }, "@", t.assignee)
               : h("span", { className: "hermes-kanban-unassigned",

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -162,6 +162,8 @@ def _task_dict(
     latest_summary: Optional[str] = None,
 ) -> dict[str, Any]:
     d = asdict(task)
+    d["assignment_state"] = task.assignment_state
+    d["pending_assignee"] = task.pending_assignee
     # Add derived age metrics so the UI can colour stale cards without
     # computing deltas client-side.
     try:

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -171,6 +171,80 @@ def test_connect_migrates_legacy_db_before_optional_column_indexes(tmp_path):
 # ---------------------------------------------------------------------------
 
 
+def test_task_assignment_state_tracks_dispatchability(kanban_home):
+    from hermes_cli.kanban import _fmt_task_line, _task_to_dict
+
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="parent", assignee="builder")
+        child = kb.create_task(
+            conn, title="child", assignee="verifier", parents=[parent]
+        )
+        task = kb.get_task(conn, child)
+
+    assert task is not None
+    assert task.assignment_state == "reserved"
+    assert task.pending_assignee == "verifier"
+    assert "(reserved → verifier)" in _fmt_task_line(task)
+    assert _task_to_dict(task)["assignment_state"] == "reserved"
+    assert _task_to_dict(task)["pending_assignee"] == "verifier"
+    assert "todo" in _fmt_task_line(task)
+
+    with kb.connect() as conn:
+        assert kb.complete_task(conn, parent)
+        active = kb.get_task(conn, child)
+    assert active is not None
+    assert active.status == "ready"
+    assert active.assignment_state == "active"
+    assert active.pending_assignee is None
+
+
+def test_parent_free_manual_todo_owner_is_reserved(kanban_home):
+    """Reserved means not dispatchable, not specifically dependency-blocked."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="manual hold", assignee="builder")
+        conn.execute("UPDATE tasks SET status='todo' WHERE id=?", (tid,))
+        conn.commit()
+        task = kb.get_task(conn, tid)
+
+    assert task is not None
+    assert task.assignment_state == "reserved"
+    assert task.pending_assignee == "builder"
+
+
+def test_specified_parent_free_todo_owner_is_reserved(kanban_home, monkeypatch):
+    """The state stays honest even in the brief triage→todo transition."""
+    original = kb.recompute_ready
+    monkeypatch.setattr(kb, "recompute_ready", lambda conn, failure_limit=None: 0)
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="draft", assignee="builder", triage=True)
+        assert kb.specify_triage_task(conn, tid, body="ready to route")
+        task = kb.get_task(conn, tid)
+    monkeypatch.setattr(kb, "recompute_ready", original)
+
+    assert task is not None
+    assert task.status == "todo"
+    assert task.assignment_state == "reserved"
+    assert task.pending_assignee == "builder"
+
+
+def test_cli_create_labels_todo_owner_reserved(kanban_home, capsys):
+    import argparse
+    from hermes_cli import kanban as kb_cli
+
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="parent", assignee="builder")
+
+    args = argparse.Namespace(
+        title="child", body=None, assignee="verifier", created_by="user",
+        workspace="scratch", tenant=None, priority=0, parent=[parent],
+        triage=False, idempotency_key=None, max_runtime=None, skills=None,
+        max_retries=None, model_override=None, provider_override=None,
+        goal_mode=False, goal_max_turns=None, initial_status="running",
+        project_id=None, branch=None, json=False,
+    )
+    assert kb_cli._cmd_create(args) == 0
+    assert "todo, reserved=verifier" in capsys.readouterr().out
+
 
 # ---------------------------------------------------------------------------
 # Links + dependency resolution

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -190,6 +190,47 @@ def test_dashboard_markdown_html_is_sanitized_before_render():
     assert "dangerouslySetInnerHTML: { __html: renderMarkdown(props.source || \"\") }" not in js
 
 
+def test_todo_assignee_is_exposed_as_waiting_not_active(client):
+    parent = client.post(
+        "/api/plugins/kanban/tasks", json={"title": "parent", "assignee": "builder"},
+    ).json()["task"]
+    child = client.post(
+        "/api/plugins/kanban/tasks",
+        json={
+            "title": "child",
+            "assignee": "verifier",
+            "parents": [parent["id"]],
+        },
+    ).json()["task"]
+
+    assert child["status"] == "todo"
+    assert child["assignee"] == "verifier"
+    assert child["assignment_state"] == "reserved"
+    assert child["pending_assignee"] == "verifier"
+
+    # The same stored profile becomes active as soon as dependencies clear.
+    done = client.patch(
+        f"/api/plugins/kanban/tasks/{parent['id']}", json={"status": "done"},
+    )
+    assert done.status_code == 200
+    promoted = client.get(
+        f"/api/plugins/kanban/tasks/{child['id']}"
+    ).json()["task"]
+    assert promoted["status"] == "ready"
+    assert promoted["assignee"] == "verifier"
+    assert promoted["assignment_state"] == "active"
+    assert promoted["pending_assignee"] is None
+
+
+def test_todo_card_bundle_renders_waiting_owner():
+    repo_root = Path(__file__).resolve().parents[2]
+    js = (
+        repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js"
+    ).read_text(encoding="utf-8")
+    assert 't.assignment_state === "reserved"' in js
+    assert '"reserved → @", t.pending_assignee' in js
+
+
 # ---------------------------------------------------------------------------
 # GET /tasks/:id returns body + comments + events + links
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -111,6 +111,26 @@ def test_list_filters_tasks(monkeypatch, worker_env):
     assert tenant_ids == [c]
 
 
+def test_list_exposes_todo_assignee_as_pending(monkeypatch, worker_env):
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    from hermes_cli import kanban_db as kb
+    conn = kb.connect()
+    try:
+        parent = kb.create_task(conn, title="parent", assignee="builder")
+        child = kb.create_task(
+            conn, title="child", assignee="verifier", parents=[parent]
+        )
+    finally:
+        conn.close()
+
+    from tools import kanban_tools as kt
+    d = json.loads(kt._handle_list({"status": "todo", "limit": 10}))
+    task = next(t for t in d["tasks"] if t["id"] == child)
+    assert task["assignee"] == "verifier"
+    assert task["assignment_state"] == "reserved"
+    assert task["pending_assignee"] == "verifier"
+
+
 def test_complete_happy_path(worker_env):
     from tools import kanban_tools as kt
     out = kt._handle_complete({

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -490,6 +490,8 @@ def _task_summary_dict(kb, conn, task) -> dict[str, Any]:
         "id": task.id,
         "title": task.title,
         "assignee": task.assignee,
+        "assignment_state": task.assignment_state,
+        "pending_assignee": task.pending_assignee,
         "status": task.status,
         "priority": task.priority,
         "tenant": task.tenant,
@@ -539,6 +541,8 @@ def _handle_show(args: dict, **kw) -> str:
                 return {
                     "id": t.id, "title": t.title, "body": t.body,
                     "assignee": t.assignee, "status": t.status,
+                    "assignment_state": t.assignment_state,
+                    "pending_assignee": t.pending_assignee,
                     "tenant": t.tenant, "priority": t.priority,
                     "workspace_kind": t.workspace_kind,
                     "workspace_path": t.workspace_path,


### PR DESCRIPTION
## Problem

Kanban persisted a selected profile on cards that were not dispatchable yet, but every surface rendered that profile as an active assignee. The dispatcher correctly reads only `ready` and `review`, so To-Do cards could sit idle while the UI falsely implied a worker should already be acting.

`todo` is broader than dependency waits: direct/manual moves, triage specification, and ancestor invalidation can also land there. The fix follows dispatchability, not one cause.

## Fix

Add one canonical `Task.assignment_state` derived from status:

- `active`: `ready`, `running`, or `review`
- `reserved`: a profile is selected, but the task is not dispatchable
- `unassigned`: no profile selected

Expose `assignment_state` and `pending_assignee` consistently through dashboard API, CLI JSON, and `kanban_*` tools. Render reserved ownership as `reserved → @profile` in the dashboard and `(reserved → profile)` in CLI output. `kanban create` also labels reserved ownership honestly.

No DB schema or dispatcher behavior changes.

## Verification

```text
python -m pytest tests/hermes_cli/test_kanban_db.py \
  tests/plugins/test_kanban_dashboard_plugin.py \
  tests/tools/test_kanban_tools.py -q -p no:randomly

108 passed, 1 skipped
```

Coverage includes dependency-gated To-Do, parent-free manual To-Do, the brief triage→todo state, promotion to active Ready, dashboard API/rendering, CLI text/JSON/create, and agent tools.