### PR TITLE
fix(mcp): fully redact Bearer values in mcp test output

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -32,6 +32,35 @@ logger = logging.getLogger(__name__)
 
 _ENV_VAR_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
+# MCP test/dashboard surfaces must not fingerprint Authorization values
+# (firstN/lastN is a reusable credential fragment). Replace the credential
+# entirely, then run the generic redactor as defense in depth.
+_AUTH_HEADER_VALUE_RE = re.compile(
+    r"((?:Proxy-)?Authorization:\s*(?:[A-Za-z][\w.+-]*\s+)?)([^\s\"']+)",
+    re.IGNORECASE,
+)
+_AUTH_SCHEME_VALUE_RE = re.compile(
+    r"\b((?:Bearer|Basic|Token|Digest)\s+)([^\s\"']+)",
+    re.IGNORECASE,
+)
+
+
+def redact_mcp_probe_text(text: object) -> str:
+    """Fully redact MCP probe/display strings before they leave the process.
+
+    Authorization/Bearer credentials become ``***`` (no prefix/suffix). The
+    generic secret redactor then runs with ``force=True`` so other credential
+    shapes in the same exception still cannot leak.
+    """
+    raw = "" if text is None else str(text)
+    if not raw:
+        return raw
+    redacted = _AUTH_HEADER_VALUE_RE.sub(lambda m: f"{m.group(1)}***", raw)
+    redacted = _AUTH_SCHEME_VALUE_RE.sub(lambda m: f"{m.group(1)}***", redacted)
+    from agent.redact import redact_sensitive_text
+
+    return redact_sensitive_text(redacted, force=True)
+
 
 _MCP_PRESETS: Dict[str, Dict[str, Any]] = {
     "codex": {
@@ -774,13 +803,12 @@ def cmd_mcp_test(args):
     elif headers:
         for k, v in headers.items():
             if isinstance(v, str) and ("key" in k.lower() or "auth" in k.lower()):
-                # Mask the value (accepts ${VAR} and Cursor-style ${env:VAR})
-                resolved = _ENV_VAR_PATTERN.sub(lambda m: os.getenv(_env_ref_name(m.group(1)), ""), v)
-                if len(resolved) > 8:
-                    masked = resolved[:4] + "***" + resolved[-4:]
+                # Keep ${ENV_VAR} templates as the display form. Never interpolate
+                # a resolved secret into the CLI — first4/last4 is still reusable.
+                if _ENV_VAR_PATTERN.search(v):
+                    print(f"    {k}: {v}")
                 else:
-                    masked = "***"
-                print(f"    {k}: {masked}")
+                    print(f"    {k}: {redact_mcp_probe_text(v)}")
     else:
         _info("Auth: none")
 
@@ -791,7 +819,7 @@ def cmd_mcp_test(args):
         elapsed_ms = (time.monotonic() - start) * 1000
     except Exception as exc:
         elapsed_ms = (time.monotonic() - start) * 1000
-        _error(f"Connection failed ({elapsed_ms:.0f}ms): {exc}")
+        _error(f"Connection failed ({elapsed_ms:.0f}ms): {redact_mcp_probe_text(exc)}")
         return
 
     _success(f"Connected ({elapsed_ms:.0f}ms)")

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -43,6 +43,10 @@ _AUTH_SCHEME_VALUE_RE = re.compile(
     r"\b((?:Bearer|Basic|Token|Digest)\s+)([^\s\"']+)",
     re.IGNORECASE,
 )
+_AUTH_SCHEME_PREFIX_RE = re.compile(
+    r"^(?:Bearer|Basic|Token|Digest)\s+",
+    re.IGNORECASE,
+)
 
 
 def redact_mcp_probe_text(text: object) -> str:
@@ -60,6 +64,46 @@ def redact_mcp_probe_text(text: object) -> str:
     from agent.redact import redact_sensitive_text
 
     return redact_sensitive_text(redacted, force=True)
+
+
+def _header_value_is_only_env_refs(value: str) -> bool:
+    """True when every non-scheme span in *value* is a ``${VAR}`` reference."""
+    leftover = _ENV_VAR_PATTERN.sub("", value)
+    leftover = _AUTH_SCHEME_PREFIX_RE.sub("", leftover)
+    return leftover.strip(" \t;,") == ""
+
+
+def redact_mcp_header_display(name: str, value: object) -> str:
+    """Fail-closed CLI display for a credential-shaped MCP header.
+
+    A value that is only ``${ENV}`` references (optionally with an auth scheme
+    word) may be shown — it carries no secret. Anything else, including opaque
+    API keys and mixed template+literal strings, is replaced with ``***``.
+    ``name`` stays paired with the value so callers cannot drop the header
+    identity before this policy runs.
+    """
+    raw = "" if value is None else str(value)
+    if raw and _header_value_is_only_env_refs(raw):
+        return raw
+    # Pair name+value for the generic redactor, then still fail closed — an
+    # opaque token with no recognized scheme must not print.
+    redact_mcp_probe_text(f"{name}: {raw}")
+    return "***"
+
+
+def _redact_probe_exception(exc: BaseException) -> Exception:
+    """Return a raise-able exception whose ``str()`` is safe to print."""
+    root = _unwrap_exception_group(exc)
+    safe = redact_mcp_probe_text(root)
+    if safe == str(root) and isinstance(root, Exception):
+        return root
+    try:
+        rebuilt = type(root)(safe)
+        if str(rebuilt) == safe and isinstance(rebuilt, Exception):
+            return rebuilt
+    except Exception:
+        pass
+    return RuntimeError(safe)
 
 
 _MCP_PRESETS: Dict[str, Dict[str, Any]] = {
@@ -423,7 +467,7 @@ def _probe_single_server(
     try:
         _run_on_mcp_loop(_probe(), timeout=connect_timeout + 10)
     except BaseException as exc:
-        raise _unwrap_exception_group(exc) from None
+        raise _redact_probe_exception(exc) from None
     finally:
         _stop_mcp_loop_if_idle()
 
@@ -594,7 +638,7 @@ def cmd_mcp_add(args):
     try:
         tools = _probe_single_server(name, server_config)
     except Exception as exc:
-        _error(f"Failed to connect: {exc}")
+        _error(f"Failed to connect: {redact_mcp_probe_text(exc)}")
         if _confirm("Save config anyway (you can test later)?", default=False):
             server_config["enabled"] = False
             if _save_mcp_server(name, server_config):
@@ -803,12 +847,9 @@ def cmd_mcp_test(args):
     elif headers:
         for k, v in headers.items():
             if isinstance(v, str) and ("key" in k.lower() or "auth" in k.lower()):
-                # Keep ${ENV_VAR} templates as the display form. Never interpolate
-                # a resolved secret into the CLI — first4/last4 is still reusable.
-                if _ENV_VAR_PATTERN.search(v):
-                    print(f"    {k}: {v}")
-                else:
-                    print(f"    {k}: {redact_mcp_probe_text(v)}")
+                # Keep header identity with the value. A ${ENV} substring is
+                # not proof the rest of the header is non-secret.
+                print(f"    {k}: {redact_mcp_header_display(k, v)}")
     else:
         _info("Auth: none")
 
@@ -931,7 +972,7 @@ def _reauth_oauth_server(name: str, server_config: dict) -> bool:
             )
         except Exception:
             humanized = None
-        _error(f"Authentication failed: {humanized or exc}")
+        _error(f"Authentication failed: {redact_mcp_probe_text(humanized or exc)}")
         return False
 
 
@@ -1037,7 +1078,7 @@ def cmd_mcp_configure(args):
     try:
         all_tools = _probe_single_server(name, cfg)
     except Exception as exc:
-        _error(f"Failed to connect: {exc}")
+        _error(f"Failed to connect: {redact_mcp_probe_text(exc)}")
         return
 
     if not all_tools:

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -47,20 +47,33 @@ _AUTH_SCHEME_PREFIX_RE = re.compile(
     r"^(?:Bearer|Basic|Token|Digest)\s+",
     re.IGNORECASE,
 )
+# Opaque API-key headers — fully replace the value (no head/tail fingerprint).
+_MCP_SECRET_HEADER_RE = re.compile(
+    r"((?:x-api-key|x-goog-api-key|api-key|apikey|x-api-token|"
+    r"x-auth-token|x-access-token)\s*:\s*)(\S+)",
+    re.IGNORECASE,
+)
+# Digest/params on Authorization: username=, response=, opaque=, …
+_AUTHZ_PARAM_RE = re.compile(
+    r"""\b(username|response|opaque|cnonce|nonce|uri)\s*=\s*(?:"[^"]*"|'[^']*'|[^\s,]+)""",
+    re.IGNORECASE,
+)
 
 
 def redact_mcp_probe_text(text: object) -> str:
     """Fully redact MCP probe/display strings before they leave the process.
 
-    Authorization/Bearer credentials become ``***`` (no prefix/suffix). The
-    generic secret redactor then runs with ``force=True`` so other credential
-    shapes in the same exception still cannot leak.
+    Authorization/Bearer credentials and opaque API-key header values become
+    ``***`` (no prefix/suffix). The generic secret redactor then runs with
+    ``force=True`` as defense in depth.
     """
     raw = "" if text is None else str(text)
     if not raw:
         return raw
     redacted = _AUTH_HEADER_VALUE_RE.sub(lambda m: f"{m.group(1)}***", raw)
     redacted = _AUTH_SCHEME_VALUE_RE.sub(lambda m: f"{m.group(1)}***", redacted)
+    redacted = _MCP_SECRET_HEADER_RE.sub(lambda m: f"{m.group(1)}***", redacted)
+    redacted = _AUTHZ_PARAM_RE.sub(lambda m: f"{m.group(1)}=***", redacted)
     from agent.redact import redact_sensitive_text
 
     return redact_sensitive_text(redacted, force=True)

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -32,48 +32,114 @@ logger = logging.getLogger(__name__)
 
 _ENV_VAR_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
-# MCP test/dashboard surfaces must not fingerprint Authorization values
-# (firstN/lastN is a reusable credential fragment). Replace the credential
-# entirely, then run the generic redactor as defense in depth.
-_AUTH_HEADER_VALUE_RE = re.compile(
-    r"((?:Proxy-)?Authorization:\s*(?:[A-Za-z][\w.+-]*\s+)?)([^\s\"']+)",
-    re.IGNORECASE,
-)
-_AUTH_SCHEME_VALUE_RE = re.compile(
-    r"\b((?:Bearer|Basic|Token|Digest)\s+)([^\s\"']+)",
-    re.IGNORECASE,
-)
+# MCP test/dashboard surfaces must not fingerprint credential header values
+# (firstN/lastN is a reusable fragment). Redact by field identity: once a
+# recognized credential header key is found, replace its complete associated
+# value regardless of scheme, quoting, parameter order, or wire/JSON/Python
+# mapping serialization. Header names come from agent.redact so the lists
+# cannot drift. The generic redactor then runs with force=True.
 _AUTH_SCHEME_PREFIX_RE = re.compile(
     r"^(?:Bearer|Basic|Token|Digest)\s+",
     re.IGNORECASE,
 )
-# Opaque API-key headers — fully replace the value (no head/tail fingerprint).
-_MCP_SECRET_HEADER_RE = re.compile(
-    r"((?:x-api-key|x-goog-api-key|api-key|apikey|x-api-token|"
-    r"x-auth-token|x-access-token)\s*:\s*)(\S+)",
-    re.IGNORECASE,
+_DIGEST_PARAM_NAMES = (
+    "username|response|opaque|cnonce|nonce|uri|realm|qop|nc|algorithm"
 )
-# Digest/params on Authorization: username=, response=, opaque=, …
-_AUTHZ_PARAM_RE = re.compile(
-    r"""\b(username|response|opaque|cnonce|nonce|uri)\s*=\s*(?:"[^"]*"|'[^']*'|[^\s,]+)""",
-    re.IGNORECASE,
+_DIGEST_PARAM = (
+    rf"(?:{_DIGEST_PARAM_NAMES})\s*=\s*(?:\"[^\"]*\"|'[^']*'|[^\s,]+)"
 )
+_DIGEST_PARAMS = rf"{_DIGEST_PARAM}(?:\s*,\s*{_DIGEST_PARAM})*"
+_PROBE_REDACTION_RES: Optional[Tuple[re.Pattern[str], ...]] = None
+
+
+def _credential_header_names() -> str:
+    from agent.redact import _SECRET_HEADER_NAMES
+
+    return rf"(?:(?:Proxy-)?Authorization|{_SECRET_HEADER_NAMES})"
+
+
+def _probe_redaction_res() -> Tuple[re.Pattern[str], ...]:
+    global _PROBE_REDACTION_RES
+    if _PROBE_REDACTION_RES is not None:
+        return _PROBE_REDACTION_RES
+    header = _credential_header_names()
+    # Quoted-key mapping/JSON: {'X-Api-Key': '…'} / {"Authorization": "…"}
+    mapping = re.compile(
+        rf"""(['\"])({header})\1(\s*:\s*)(['\"])((?:\\.|(?!\4).)*)\4""",
+        re.IGNORECASE,
+    )
+    unquoted_mapping = re.compile(
+        rf"""(['\"])({header})\1(\s*:\s*)(?!['\"])([^\s,}}\]]+)""",
+        re.IGNORECASE,
+    )
+    # Bare wire header: Authorization: Digest … / X-Api-Key: token
+    wire = re.compile(
+        rf"({header})(\s*:\s*)([^\n\r]+)",
+        re.IGNORECASE,
+    )
+    bare_scheme = re.compile(
+        rf"\b(Bearer|Basic|Token)(\s+)([^\s\"']+)"
+        rf"|\b(Digest)(\s+)({_DIGEST_PARAMS})",
+        re.IGNORECASE,
+    )
+    _PROBE_REDACTION_RES = (mapping, unquoted_mapping, wire, bare_scheme)
+    return _PROBE_REDACTION_RES
+
+
+def _mask_header_field_value(value: str) -> str:
+    """Replace a credential header's complete associated value with ``***``.
+
+    A leading auth scheme word is kept for debugging; Digest parameters are
+    part of the field value and are not tokenized.
+    """
+    scheme = _AUTH_SCHEME_PREFIX_RE.match(value)
+    if scheme:
+        return f"{scheme.group(0)}***"
+    return "***"
+
+
+def _sub_mapping_header(match: re.Match[str]) -> str:
+    return (
+        f"{match.group(1)}{match.group(2)}{match.group(1)}"
+        f"{match.group(3)}{match.group(4)}"
+        f"{_mask_header_field_value(match.group(5))}{match.group(4)}"
+    )
+
+
+def _sub_unquoted_mapping_header(match: re.Match[str]) -> str:
+    return (
+        f"{match.group(1)}{match.group(2)}{match.group(1)}"
+        f"{match.group(3)}{_mask_header_field_value(match.group(4))}"
+    )
+
+
+def _sub_wire_header(match: re.Match[str]) -> str:
+    return f"{match.group(1)}{match.group(2)}{_mask_header_field_value(match.group(3))}"
+
+
+def _sub_bare_scheme(match: re.Match[str]) -> str:
+    if match.group(1):
+        return f"{match.group(1)}{match.group(2)}***"
+    return f"{match.group(4)}{match.group(5)}***"
 
 
 def redact_mcp_probe_text(text: object) -> str:
     """Fully redact MCP probe/display strings before they leave the process.
 
-    Authorization/Bearer credentials and opaque API-key header values become
-    ``***`` (no prefix/suffix). The generic secret redactor then runs with
+    Recognized credential header fields (Authorization / Proxy-Authorization
+    and ``agent.redact._SECRET_HEADER_NAMES``) have their complete associated
+    value replaced with ``***``. Bare Bearer/Basic/Token/Digest spans are
+    covered the same way. The generic secret redactor then runs with
     ``force=True`` as defense in depth.
     """
     raw = "" if text is None else str(text)
     if not raw:
         return raw
-    redacted = _AUTH_HEADER_VALUE_RE.sub(lambda m: f"{m.group(1)}***", raw)
-    redacted = _AUTH_SCHEME_VALUE_RE.sub(lambda m: f"{m.group(1)}***", redacted)
-    redacted = _MCP_SECRET_HEADER_RE.sub(lambda m: f"{m.group(1)}***", redacted)
-    redacted = _AUTHZ_PARAM_RE.sub(lambda m: f"{m.group(1)}=***", redacted)
+    mapping, unquoted_mapping, wire, bare_scheme = _probe_redaction_res()
+    redacted = mapping.sub(_sub_mapping_header, raw)
+    redacted = unquoted_mapping.sub(_sub_unquoted_mapping_header, redacted)
+    redacted = wire.sub(_sub_wire_header, redacted)
+    redacted = bare_scheme.sub(_sub_bare_scheme, redacted)
     from agent.redact import redact_sensitive_text
 
     return redact_sensitive_text(redacted, force=True)

--- a/hermes_cli/web_routers/mcp.py
+++ b/hermes_cli/web_routers/mcp.py
@@ -199,9 +199,11 @@ async def test_mcp_server(name: str, profile: Optional[str] = None):
         # FastAPI event loop is never blocked.
         tools, token_present = await asyncio.to_thread(_probe_scoped)
     except Exception as exc:
+        from hermes_cli.mcp_config import redact_mcp_probe_text
+
         return {
             "ok": False,
-            "error": str(exc),
+            "error": redact_mcp_probe_text(exc),
             "tools": [],
         }
     if not token_present:

--- a/tests/hermes_cli/test_mcp_probe_redaction.py
+++ b/tests/hermes_cli/test_mcp_probe_redaction.py
@@ -10,12 +10,30 @@ SYNTHETIC = "SYNTHETIC_MCP_BEARER_NOT_A_SECRET_123456"
 SYNTHETIC_PREFIX = "SYNTHETIC_MCP_BEARER"
 SYNTHETIC_SUFFIX = "SECRET_123456"
 HEADER = f"Authorization: Bearer {SYNTHETIC}"
+OPAQUE_API_KEY = "opaquecredential1234567890ABCDEF"
 
 
 def _assert_fully_redacted(text: str) -> None:
     assert SYNTHETIC not in text
     assert SYNTHETIC_PREFIX not in text
     assert SYNTHETIC_SUFFIX not in text
+    assert OPAQUE_API_KEY not in text
+
+
+def _make_args(**kwargs):
+    defaults = {
+        "name": "test-server",
+        "url": None,
+        "mcp_command": None,
+        "args": None,
+        "auth": None,
+        "preset": None,
+        "env": None,
+        "mcp_action": None,
+        "connect_timeout": None,
+    }
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
 
 
 @pytest.fixture(autouse=True)
@@ -50,6 +68,41 @@ class TestRedactMcpProbeText:
         out = redact_mcp_probe_text(f"probe Bearer {SYNTHETIC} failed")
         _assert_fully_redacted(out)
         assert "Bearer ***" in out
+
+    def test_header_display_masks_opaque_api_key(self):
+        from hermes_cli.mcp_config import redact_mcp_header_display
+
+        assert redact_mcp_header_display("X-Api-Key", OPAQUE_API_KEY) == "***"
+        assert redact_mcp_header_display(
+            "Authorization", f"Bearer ${{MCP_TEST_TOKEN}}; backup={SYNTHETIC}"
+        ) == "***"
+
+    def test_header_display_keeps_pure_env_template(self):
+        from hermes_cli.mcp_config import redact_mcp_header_display
+
+        assert redact_mcp_header_display(
+            "Authorization", "Bearer ${MCP_TEST_TOKEN}"
+        ) == "Bearer ${MCP_TEST_TOKEN}"
+
+
+class TestProbeHelperRedactsBeforeRaise:
+    def test_probe_exception_leaving_helper_is_already_safe(self, monkeypatch):
+        import tools.mcp_tool as mcp_tool
+        from hermes_cli.mcp_config import _probe_single_server
+
+        monkeypatch.setattr(mcp_tool, "_ensure_mcp_loop", lambda: None)
+        monkeypatch.setattr(mcp_tool, "_stop_mcp_loop_if_idle", lambda: None)
+
+        def boom(coro, timeout):
+            coro.close()
+            raise RuntimeError(f"connect failed: {HEADER}")
+
+        monkeypatch.setattr(mcp_tool, "_run_on_mcp_loop", boom)
+
+        with pytest.raises(Exception) as caught:
+            _probe_single_server("ink", {"url": "https://mcp.example/mcp"})
+        _assert_fully_redacted(str(caught.value))
+        assert "Bearer ***" in str(caught.value)
 
 
 class TestCmdMcpTestRedaction:
@@ -90,6 +143,45 @@ class TestCmdMcpTestRedaction:
         out = capsys.readouterr().out
         _assert_fully_redacted(out)
         assert "Authorization:" in out
+
+    def test_success_display_masks_opaque_api_key_header(self, tmp_path, capsys, monkeypatch):
+        _seed_config(tmp_path, {
+            "ink": {
+                "url": "https://mcp.example/mcp",
+                "headers": {"X-Api-Key": OPAQUE_API_KEY},
+            },
+        })
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server",
+            lambda *a, **k: [("ping", "Ping")],
+        )
+        from hermes_cli.mcp_config import cmd_mcp_test
+
+        cmd_mcp_test(argparse.Namespace(name="ink"))
+        out = capsys.readouterr().out
+        _assert_fully_redacted(out)
+        assert "X-Api-Key:" in out
+        assert "***" in out
+
+    def test_success_display_masks_mixed_env_and_literal(self, tmp_path, capsys, monkeypatch):
+        _seed_config(tmp_path, {
+            "ink": {
+                "url": "https://mcp.example/mcp",
+                "headers": {
+                    "Authorization": f"Bearer ${{MCP_TEST_TOKEN}}; backup={SYNTHETIC}",
+                },
+            },
+        })
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server",
+            lambda *a, **k: [("ping", "Ping")],
+        )
+        from hermes_cli.mcp_config import cmd_mcp_test
+
+        cmd_mcp_test(argparse.Namespace(name="ink"))
+        out = capsys.readouterr().out
+        _assert_fully_redacted(out)
+        assert "***" in out
 
     def test_probe_exception_is_redacted(self, tmp_path, capsys, monkeypatch):
         _seed_config(tmp_path, {
@@ -140,3 +232,40 @@ class TestDashboardMcpTestRedaction:
         _assert_fully_redacted(body["error"])
         assert "Bearer ***" in body["error"]
         assert SYNTHETIC not in resp.text
+
+
+class TestSiblingProbeConsumersRedact:
+    def test_mcp_add_redacts_probe_exception(self, tmp_path, capsys, monkeypatch):
+        def boom(*a, **k):
+            raise RuntimeError(f"connect failed: {HEADER}")
+
+        monkeypatch.setattr("hermes_cli.mcp_config._probe_single_server", boom)
+        monkeypatch.setattr("hermes_cli.mcp_config._confirm", lambda *a, **k: False)
+        from hermes_cli.mcp_config import cmd_mcp_add
+
+        cmd_mcp_add(_make_args(name="ink", url="https://mcp.example/mcp"))
+        out = capsys.readouterr().out
+        _assert_fully_redacted(out)
+        assert "Failed to connect" in out
+        assert "Bearer ***" in out
+
+    def test_mcp_login_redacts_probe_exception(self, tmp_path, capsys, monkeypatch):
+        _seed_config(tmp_path, {
+            "ink": {"url": "https://mcp.example/mcp", "auth": "oauth"},
+        })
+
+        def boom(*a, **k):
+            raise RuntimeError(f"connect failed: {HEADER}")
+
+        monkeypatch.setattr("hermes_cli.mcp_config._probe_single_server", boom)
+        monkeypatch.setattr(
+            "tools.mcp_oauth.humanize_oauth_registration_error",
+            lambda *a, **k: None,
+        )
+        from hermes_cli.mcp_config import cmd_mcp_login
+
+        cmd_mcp_login(_make_args(name="ink"))
+        out = capsys.readouterr().out
+        _assert_fully_redacted(out)
+        assert "Authentication failed" in out
+        assert "Bearer ***" in out

--- a/tests/hermes_cli/test_mcp_probe_redaction.py
+++ b/tests/hermes_cli/test_mcp_probe_redaction.py
@@ -1,0 +1,142 @@
+"""MCP test/dashboard must not fingerprint Authorization credentials (#97460)."""
+
+import argparse
+
+import pytest
+import yaml
+
+
+SYNTHETIC = "SYNTHETIC_MCP_BEARER_NOT_A_SECRET_123456"
+SYNTHETIC_PREFIX = "SYNTHETIC_MCP_BEARER"
+SYNTHETIC_SUFFIX = "SECRET_123456"
+HEADER = f"Authorization: Bearer {SYNTHETIC}"
+
+
+def _assert_fully_redacted(text: str) -> None:
+    assert SYNTHETIC not in text
+    assert SYNTHETIC_PREFIX not in text
+    assert SYNTHETIC_SUFFIX not in text
+
+
+@pytest.fixture(autouse=True)
+def _isolate_config(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr("hermes_cli.config.get_hermes_home", lambda: tmp_path)
+    config_path = tmp_path / "config.yaml"
+    env_path = tmp_path / ".env"
+    monkeypatch.setattr("hermes_cli.config.get_config_path", lambda: config_path)
+    monkeypatch.setattr("hermes_cli.config.get_env_path", lambda: env_path)
+    return tmp_path
+
+
+def _seed_config(tmp_path, mcp_servers):
+    config_path = tmp_path / "config.yaml"
+    with open(config_path, "w") as f:
+        yaml.safe_dump({"mcp_servers": mcp_servers, "_config_version": 9}, f)
+
+
+class TestRedactMcpProbeText:
+    def test_authorization_header_is_fully_replaced(self):
+        from hermes_cli.mcp_config import redact_mcp_probe_text
+
+        out = redact_mcp_probe_text(f"401 {HEADER}")
+        _assert_fully_redacted(out)
+        assert "Authorization:" in out
+        assert "Bearer ***" in out
+
+    def test_bare_bearer_scheme_is_fully_replaced(self):
+        from hermes_cli.mcp_config import redact_mcp_probe_text
+
+        out = redact_mcp_probe_text(f"probe Bearer {SYNTHETIC} failed")
+        _assert_fully_redacted(out)
+        assert "Bearer ***" in out
+
+
+class TestCmdMcpTestRedaction:
+    def test_success_display_keeps_env_template(self, tmp_path, capsys, monkeypatch):
+        monkeypatch.setenv("MCP_TEST_TOKEN", SYNTHETIC)
+        _seed_config(tmp_path, {
+            "ink": {
+                "url": "https://mcp.example/mcp",
+                "headers": {"Authorization": "Bearer ${MCP_TEST_TOKEN}"},
+            },
+        })
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server",
+            lambda *a, **k: [("ping", "Ping")],
+        )
+        from hermes_cli.mcp_config import cmd_mcp_test
+
+        cmd_mcp_test(argparse.Namespace(name="ink"))
+        out = capsys.readouterr().out
+        _assert_fully_redacted(out)
+        assert "Connected" in out
+        assert "${MCP_TEST_TOKEN}" in (tmp_path / "config.yaml").read_text()
+
+    def test_success_display_masks_literal_header(self, tmp_path, capsys, monkeypatch):
+        _seed_config(tmp_path, {
+            "ink": {
+                "url": "https://mcp.example/mcp",
+                "headers": {"Authorization": f"Bearer {SYNTHETIC}"},
+            },
+        })
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server",
+            lambda *a, **k: [("ping", "Ping")],
+        )
+        from hermes_cli.mcp_config import cmd_mcp_test
+
+        cmd_mcp_test(argparse.Namespace(name="ink"))
+        out = capsys.readouterr().out
+        _assert_fully_redacted(out)
+        assert "Authorization:" in out
+
+    def test_probe_exception_is_redacted(self, tmp_path, capsys, monkeypatch):
+        _seed_config(tmp_path, {
+            "ink": {"url": "https://mcp.example/mcp"},
+        })
+
+        def boom(*a, **k):
+            raise RuntimeError(f"connect failed: {HEADER}")
+
+        monkeypatch.setattr("hermes_cli.mcp_config._probe_single_server", boom)
+        from hermes_cli.mcp_config import cmd_mcp_test
+
+        cmd_mcp_test(argparse.Namespace(name="ink"))
+        out = capsys.readouterr().out
+        _assert_fully_redacted(out)
+        assert "Connection failed" in out
+        assert "Bearer ***" in out
+
+
+class TestDashboardMcpTestRedaction:
+    def test_probe_error_json_is_redacted(self, tmp_path, monkeypatch):
+        try:
+            from starlette.testclient import TestClient
+        except ImportError:
+            pytest.skip("fastapi/starlette not installed")
+
+        from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+        import hermes_cli.mcp_config as mcp_config
+
+        _seed_config(tmp_path, {
+            "ink": {"url": "https://mcp.example/mcp"},
+        })
+
+        def boom(name, config, connect_timeout=30, details=None):
+            raise RuntimeError(f"connect failed: {HEADER}")
+
+        monkeypatch.setattr(mcp_config, "_probe_single_server", boom)
+        monkeypatch.setattr(mcp_config, "_get_mcp_servers", lambda: {
+            "ink": {"url": "https://mcp.example/mcp"},
+        })
+
+        client = TestClient(app)
+        client.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
+        resp = client.post("/api/mcp/servers/ink/test")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["ok"] is False
+        _assert_fully_redacted(body["error"])
+        assert "Bearer ***" in body["error"]
+        assert SYNTHETIC not in resp.text

--- a/tests/hermes_cli/test_mcp_probe_redaction.py
+++ b/tests/hermes_cli/test_mcp_probe_redaction.py
@@ -11,6 +11,8 @@ SYNTHETIC_PREFIX = "SYNTHETIC_MCP_BEARER"
 SYNTHETIC_SUFFIX = "SECRET_123456"
 HEADER = f"Authorization: Bearer {SYNTHETIC}"
 OPAQUE_API_KEY = "opaquecredential1234567890ABCDEF"
+OPAQUE_PREFIX = OPAQUE_API_KEY[:6]
+OPAQUE_SUFFIX = OPAQUE_API_KEY[-4:]
 
 
 def _assert_fully_redacted(text: str) -> None:
@@ -18,6 +20,8 @@ def _assert_fully_redacted(text: str) -> None:
     assert SYNTHETIC_PREFIX not in text
     assert SYNTHETIC_SUFFIX not in text
     assert OPAQUE_API_KEY not in text
+    assert OPAQUE_PREFIX not in text
+    assert OPAQUE_SUFFIX not in text
 
 
 def _make_args(**kwargs):
@@ -69,6 +73,22 @@ class TestRedactMcpProbeText:
         _assert_fully_redacted(out)
         assert "Bearer ***" in out
 
+    def test_opaque_api_key_header_is_fully_replaced(self):
+        from hermes_cli.mcp_config import redact_mcp_probe_text
+
+        out = redact_mcp_probe_text(f"connect failed: X-Api-Key: {OPAQUE_API_KEY}")
+        _assert_fully_redacted(out)
+        assert "X-Api-Key: ***" in out
+
+    def test_digest_authorization_params_are_fully_replaced(self):
+        from hermes_cli.mcp_config import redact_mcp_probe_text
+
+        out = redact_mcp_probe_text(
+            f'Authorization: Digest username="u", response="{OPAQUE_API_KEY}"'
+        )
+        _assert_fully_redacted(out)
+        assert "response=***" in out
+
     def test_header_display_masks_opaque_api_key(self):
         from hermes_cli.mcp_config import redact_mcp_header_display
 
@@ -103,6 +123,24 @@ class TestProbeHelperRedactsBeforeRaise:
             _probe_single_server("ink", {"url": "https://mcp.example/mcp"})
         _assert_fully_redacted(str(caught.value))
         assert "Bearer ***" in str(caught.value)
+
+    def test_probe_exception_redacts_opaque_api_key(self, monkeypatch):
+        import tools.mcp_tool as mcp_tool
+        from hermes_cli.mcp_config import _probe_single_server
+
+        monkeypatch.setattr(mcp_tool, "_ensure_mcp_loop", lambda: None)
+        monkeypatch.setattr(mcp_tool, "_stop_mcp_loop_if_idle", lambda: None)
+
+        def boom(coro, timeout):
+            coro.close()
+            raise RuntimeError(f"connect failed: X-Api-Key: {OPAQUE_API_KEY}")
+
+        monkeypatch.setattr(mcp_tool, "_run_on_mcp_loop", boom)
+
+        with pytest.raises(Exception) as caught:
+            _probe_single_server("ink", {"url": "https://mcp.example/mcp"})
+        _assert_fully_redacted(str(caught.value))
+        assert "X-Api-Key: ***" in str(caught.value)
 
 
 class TestCmdMcpTestRedaction:

--- a/tests/hermes_cli/test_mcp_probe_redaction.py
+++ b/tests/hermes_cli/test_mcp_probe_redaction.py
@@ -1,6 +1,8 @@
 """MCP test/dashboard must not fingerprint Authorization credentials (#97460)."""
 
 import argparse
+import itertools
+import json
 
 import pytest
 import yaml
@@ -87,7 +89,94 @@ class TestRedactMcpProbeText:
             f'Authorization: Digest username="u", response="{OPAQUE_API_KEY}"'
         )
         _assert_fully_redacted(out)
-        assert "response=***" in out
+        assert "Digest ***" in out
+
+    def test_digest_response_first_does_not_orphan_quoted_value(self):
+        from hermes_cli.mcp_config import redact_mcp_probe_text
+
+        out = redact_mcp_probe_text(
+            f'Authorization: Digest response="{OPAQUE_API_KEY}", username="u"'
+        )
+        _assert_fully_redacted(out)
+        assert "Digest ***" in out
+        assert "response=" not in out
+
+    def test_python_mapping_api_key_is_fully_replaced(self):
+        from hermes_cli.mcp_config import redact_mcp_probe_text
+
+        payload = {"X-Api-Key": OPAQUE_API_KEY}
+        out = redact_mcp_probe_text(f"headers={payload!r}")
+        _assert_fully_redacted(out)
+        assert "***" in out
+
+    def test_json_mapping_api_key_is_fully_replaced(self):
+        from hermes_cli.mcp_config import redact_mcp_probe_text
+
+        out = redact_mcp_probe_text(json.dumps({"X-Api-Key": OPAQUE_API_KEY}))
+        _assert_fully_redacted(out)
+        assert "***" in out
+
+    @pytest.mark.parametrize(
+        "params",
+        list(
+            itertools.permutations(
+                [
+                    ("username", "u"),
+                    ("response", OPAQUE_API_KEY),
+                    ("opaque", OPAQUE_API_KEY),
+                ]
+            )
+        ),
+    )
+    @pytest.mark.parametrize("quoted_values", [True, False])
+    def test_digest_parameter_order_and_quoting(self, params, quoted_values):
+        from hermes_cli.mcp_config import redact_mcp_probe_text
+
+        parts = []
+        for key, value in params:
+            parts.append(f'{key}="{value}"' if quoted_values else f"{key}={value}")
+        wire = "Authorization: Digest " + ", ".join(parts)
+        out = redact_mcp_probe_text(wire)
+        _assert_fully_redacted(out)
+        assert "Digest ***" in out
+
+    @pytest.mark.parametrize("key_quote,value_quote", [
+        ("'", "'"),
+        ('"', '"'),
+        ("'", '"'),
+        ('"', "'"),
+    ])
+    def test_mapping_quotes_on_api_key(self, key_quote, value_quote):
+        from hermes_cli.mcp_config import redact_mcp_probe_text
+
+        text = (
+            "headers={"
+            f"{key_quote}X-Api-Key{key_quote}: "
+            f"{value_quote}{OPAQUE_API_KEY}{value_quote}"
+            "}"
+        )
+        out = redact_mcp_probe_text(text)
+        _assert_fully_redacted(out)
+        assert "***" in out
+
+    def test_mapping_digest_authorization_is_fully_replaced(self):
+        from hermes_cli.mcp_config import redact_mcp_probe_text
+
+        value = f'Digest response="{OPAQUE_API_KEY}", username="u"'
+        out = redact_mcp_probe_text(f"headers={{'Authorization': {value!r}}}")
+        _assert_fully_redacted(out)
+        assert "Digest ***" in out
+
+    def test_shared_secret_header_vocabulary_is_fully_replaced(self):
+        from agent.redact import _SECRET_HEADER_NAMES
+        from hermes_cli.mcp_config import redact_mcp_probe_text
+
+        inner = _SECRET_HEADER_NAMES
+        if inner.startswith("(?:") and inner.endswith(")"):
+            inner = inner[3:-1]
+        for name in inner.split("|"):
+            out = redact_mcp_probe_text({name: OPAQUE_API_KEY}.__repr__())
+            _assert_fully_redacted(out)
 
     def test_header_display_masks_opaque_api_key(self):
         from hermes_cli.mcp_config import redact_mcp_header_display
@@ -141,6 +230,45 @@ class TestProbeHelperRedactsBeforeRaise:
             _probe_single_server("ink", {"url": "https://mcp.example/mcp"})
         _assert_fully_redacted(str(caught.value))
         assert "X-Api-Key: ***" in str(caught.value)
+
+    def test_probe_exception_redacts_digest_response_first(self, monkeypatch):
+        import tools.mcp_tool as mcp_tool
+        from hermes_cli.mcp_config import _probe_single_server
+
+        monkeypatch.setattr(mcp_tool, "_ensure_mcp_loop", lambda: None)
+        monkeypatch.setattr(mcp_tool, "_stop_mcp_loop_if_idle", lambda: None)
+
+        def boom(coro, timeout):
+            coro.close()
+            raise RuntimeError(
+                f'connect failed: Authorization: Digest '
+                f'response="{OPAQUE_API_KEY}", username="u"'
+            )
+
+        monkeypatch.setattr(mcp_tool, "_run_on_mcp_loop", boom)
+
+        with pytest.raises(Exception) as caught:
+            _probe_single_server("ink", {"url": "https://mcp.example/mcp"})
+        _assert_fully_redacted(str(caught.value))
+        assert "Digest ***" in str(caught.value)
+
+    def test_probe_exception_redacts_python_mapping_api_key(self, monkeypatch):
+        import tools.mcp_tool as mcp_tool
+        from hermes_cli.mcp_config import _probe_single_server
+
+        monkeypatch.setattr(mcp_tool, "_ensure_mcp_loop", lambda: None)
+        monkeypatch.setattr(mcp_tool, "_stop_mcp_loop_if_idle", lambda: None)
+
+        def boom(coro, timeout):
+            coro.close()
+            raise RuntimeError(f"headers={{'X-Api-Key': '{OPAQUE_API_KEY}'}}")
+
+        monkeypatch.setattr(mcp_tool, "_run_on_mcp_loop", boom)
+
+        with pytest.raises(Exception) as caught:
+            _probe_single_server("ink", {"url": "https://mcp.example/mcp"})
+        _assert_fully_redacted(str(caught.value))
+        assert "***" in str(caught.value)
 
 
 class TestCmdMcpTestRedaction:
@@ -270,6 +398,41 @@ class TestDashboardMcpTestRedaction:
         _assert_fully_redacted(body["error"])
         assert "Bearer ***" in body["error"]
         assert SYNTHETIC not in resp.text
+
+    def test_probe_error_json_redacts_digest_and_mapping(self, tmp_path, monkeypatch):
+        try:
+            from starlette.testclient import TestClient
+        except ImportError:
+            pytest.skip("fastapi/starlette not installed")
+
+        from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+        import hermes_cli.mcp_config as mcp_config
+
+        _seed_config(tmp_path, {
+            "ink": {"url": "https://mcp.example/mcp"},
+        })
+
+        def boom(name, config, connect_timeout=30, details=None):
+            raise RuntimeError(
+                f"headers={{'X-Api-Key': '{OPAQUE_API_KEY}'}}; "
+                f'Authorization: Digest response="{OPAQUE_API_KEY}", username="u"'
+            )
+
+        monkeypatch.setattr(mcp_config, "_probe_single_server", boom)
+        monkeypatch.setattr(mcp_config, "_get_mcp_servers", lambda: {
+            "ink": {"url": "https://mcp.example/mcp"},
+        })
+
+        client = TestClient(app)
+        client.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
+        resp = client.post("/api/mcp/servers/ink/test")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["ok"] is False
+        _assert_fully_redacted(body["error"])
+        assert "***" in body["error"]
+        assert SYNTHETIC not in resp.text
+        assert OPAQUE_API_KEY not in resp.text
 
 
 class TestSiblingProbeConsumersRedact:


### PR DESCRIPTION
## What does this PR do?

`hermes mcp test` resolved Authorization headers and printed `first4***last4`, which is still a reusable credential fragment. Probe exceptions that echoed `Authorization: Bearer <value>` were interpolated into the CLI error line and into `POST /api/mcp/servers/{name}/test` as `"error": str(exc)`.

This fully replaces Authorization/Bearer credentials with `***` (no prefix/suffix) on those surfaces, then runs `redact_sensitive_text(..., force=True)` as a second pass. `${ENV_VAR}` templates stay on disk; the probe does not need secrets inlined in config.

## Related Issue

Fixes #97460

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `hermes_cli/mcp_config.py`: `redact_mcp_probe_text`; stop fingerprint-masking MCP test auth display; redact CLI probe exceptions
- `hermes_cli/web_routers/mcp.py`: dashboard MCP test errors go through the same helper
- `tests/hermes_cli/test_mcp_probe_redaction.py`: synthetic Bearer absent from display, CLI errors, and dashboard JSON

## How to Test

```text
python -m pytest tests/hermes_cli/test_mcp_probe_redaction.py tests/hermes_cli/test_mcp_config.py::TestMcpTest -q
# 8 passed
```

Not runtime-tested against a real MCP server.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the targeted pytest files above
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A
