### PR TITLE
fix(memory): omit current_entries on batch abort

### DIFF
--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -216,11 +216,38 @@ class TestMemoryConsolidationGracefulDegrade:
         for _ in range(cap):
             r = store.apply_batch("memory", bad_batch)
             assert r["success"] is False
-            assert "current_entries" in r  # still actionable under cap
+            assert "current_entries" not in r
+            assert "No operations were applied" in r["error"]
         r = store.apply_batch("memory", bad_batch)
         assert r["success"] is False
         assert r["done"] is True
         assert "continue with your reply" in r["error"]
+        assert "current_entries" not in r
+
+    def test_apply_batch_abort_does_not_echo_store(self, store):
+        """A failed consolidation must not pay the whole MEMORY.md back (#97316)."""
+        store.add("memory", "fact A that is unique and long enough to matter")
+        store.add("memory", "fact B stays in the store after the abort")
+        result = store.apply_batch(
+            "memory",
+            [{"action": "remove", "old_text": "this substring is not in any entry"}],
+        )
+        assert result["success"] is False
+        assert "current_entries" not in result
+        payload = json.dumps(result)
+        assert "fact A that is unique" not in payload
+        assert "fact B stays in the store" not in payload
+        assert "No operations were applied" in result["error"]
+        assert store.memory_entries == [
+            "fact A that is unique and long enough to matter",
+            "fact B stays in the store after the abort",
+        ]
+
+    def test_single_replace_still_echoes_entries_on_miss(self, store):
+        store.add("memory", "fact A")
+        result = store.replace("memory", "nonexistent", "new")
+        assert result["success"] is False
+        assert result["current_entries"] == ["fact A"]
 
     def test_success_and_turn_boundary_reset_failure_budget(self, store):
         store.add("memory", "real entry")

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -594,7 +594,9 @@ class MemoryStore:
 
         Semantics: all-or-nothing. If any op is malformed, doesn't match, or
         the net result would exceed the char limit, NOTHING is written and an
-        error is returned describing the first failure plus the live state.
+        error is returned describing the first failure. Batch aborts do not
+        echo ``current_entries`` — the store did not change, and a failed
+        consolidation must not inflate the context it was meant to shrink.
         """
         if not operations:
             return {"success": False, "error": "operations list is empty."}
@@ -680,9 +682,8 @@ class MemoryStore:
                     "error": (
                         f"After applying all {len(operations)} operations, memory would be at "
                         f"{new_total:,}/{limit:,} chars -- over the limit. Remove or shorten more "
-                        f"entries in the same batch (see current_entries below), then retry."
+                        f"entries in the same batch, then retry."
                     ),
-                    "current_entries": self._entries_for(target),
                     "usage": f"{current:,}/{limit:,}",
                 })
 
@@ -693,13 +694,19 @@ class MemoryStore:
         return self._success_response(target, f"Applied {len(operations)} operation(s).")
 
     def _batch_error(self, target: str, message: str) -> Dict[str, Any]:
-        """Build a batch-abort error that reports live (uncommitted) state."""
+        """Build a batch-abort error without echoing the store.
+
+        Single replace/remove failures still return ``current_entries`` so the
+        model can retry with exact text. A batch is all-or-nothing, so the
+        caller already has the live inventory from the previous response —
+        re-sending it on abort is what made consolidation retries grow the
+        context they were invoked to shrink.
+        """
         current = self._char_count(target)
         limit = self._char_limit(target)
         return self._consolidation_failure({
             "success": False,
             "error": message + " No operations were applied (batch is all-or-nothing).",
-            "current_entries": self._entries_for(target),
             "usage": f"{current:,}/{limit:,}",
         })
 


### PR DESCRIPTION
## What does this PR do?

`memory` batch ops are all-or-nothing, but the abort path returned `current_entries` — the full store — next to the error. A consolidation batch is used precisely when the store is large, so each stale `old_text` retry paid tens of KB back into the turn.

Single `replace`/`remove` misses still echo entries (the error text tells the model to use them). Batch aborts now return the failed operation + `usage` only.

## Related Issue

Fixes #97316

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `tools/memory_tool.py`: `_batch_error` and the batch budget-overflow path omit `current_entries`
- `tests/tools/test_memory_tool.py`: batch abort does not echo store contents; single replace still does

## How to Test

```text
python -m pytest tests/tools/test_memory_tool.py -q
# 43 passed
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the targeted pytest file above
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A
