### PR TITLE
fix(desktop): mark truncated group-chat sync payloads

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/group-chat.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-chat.test.ts
@@ -415,6 +415,22 @@ describe('gateway mirror', () => {
     expect(log.length).toBeLessThanOrEqual(16)
     expect(log.at(-1)?.text).toMatch(/^99:/)
     expect(log.at(-1)?.text.length).toBeLessThanOrEqual(1200)
+    expect(log.at(-1)?.truncated).toBe(true)
+    expect(log.at(-1)?.text).toContain('[truncated]')
+    expect(log.at(-1)?.text).not.toContain(long)
+  })
+
+  it('marks truncated sync text instead of silently slicing it', async () => {
+    const { chat } = await loadRoom()
+    const long = `plan:${'x'.repeat(2000)}`
+    const compacted = chat.compactGroupChatSyncText(long)
+
+    expect(compacted.truncated).toBe(true)
+    expect(compacted.text).toContain('[truncated]')
+    expect(compacted.text.length).toBeLessThanOrEqual(1200)
+    expect(compacted.text.startsWith('plan:')).toBe(true)
+    expect(compacted.text).not.toBe(long)
+    expect(chat.compactGroupChatSyncText('short').truncated).toBeUndefined()
   })
 
   it('preserves threads and budgets escaped Unicode', async () => {

--- a/apps/desktop/src/plugins/hermes-bots/group-chat.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-chat.ts
@@ -50,6 +50,7 @@ const GROUP_CHAT_SYNC_META_KEY = 'hermes-bots-groups'
 const GROUP_CHAT_SYNC_MAX_BYTES = 48000
 const GROUP_CHAT_SYNC_MESSAGES = 16
 const GROUP_CHAT_SYNC_TEXT_CHARS = 1200
+const GROUP_CHAT_SYNC_TRUNCATION_MARK = '… [truncated]'
 const GROUP_CHAT_SYNC_IMAGE_CHARS = 24000
 let groupChatSyncTimer: ReturnType<typeof setTimeout> | null = null
 
@@ -88,6 +89,25 @@ const groupChatSyncInFlightConnections = new Set<string>()
 const groupChatSyncRetryTimers = new Map<string, ReturnType<typeof setTimeout>>()
 const groupChatSyncRetryCounts = new Map<string, number>()
 export let groupChatSyncDisposed = false
+
+/** Cut one sync-projection line to the per-message budget and mark the cut.
+ *  Receivers used to see a silent mid-sentence slice with no signal that the
+ *  body continued. Keep the mark inside the same char budget so CJK/envelope
+ *  accounting does not grow. */
+export function compactGroupChatSyncText(text: string, limit = GROUP_CHAT_SYNC_TEXT_CHARS) {
+  const raw = String(text || '')
+
+  if (raw.length <= limit) {
+    return { text: raw }
+  }
+
+  const budget = Math.max(0, limit - GROUP_CHAT_SYNC_TRUNCATION_MARK.length)
+
+  return {
+    text: `${raw.slice(0, budget)}${GROUP_CHAT_SYNC_TRUNCATION_MARK}`,
+    truncated: true as const
+  }
+}
 
 /** Conservative byte count for the gateway's ensure_ascii JSON encoding.
  *  Python also inserts separator spaces, so reserve one extra byte per JS
@@ -214,29 +234,38 @@ export function groupChatSyncSnapshot(
   }
 
   for (const [name, room] of ranked) {
-    const log: GroupMessage[] = room.log.slice(-GROUP_CHAT_SYNC_MESSAGES).map(entry => ({
-      ...(entry?.id
-        ? {
-            id: String(entry.id).slice(0, 160)
-          }
-        : {}),
-      from: {
-        kind: entry?.from?.kind === 'member' ? 'member' : 'user',
-        name: String(entry?.from?.name || (entry?.from?.kind === 'member' ? 'Bot' : 'You')).slice(0, 128),
-        ...(entry?.from?.source
+    const log: GroupMessage[] = room.log.slice(-GROUP_CHAT_SYNC_MESSAGES).map(entry => {
+      const compacted = compactGroupChatSyncText(String(entry?.text || ''))
+
+      return {
+        ...(entry?.id
           ? {
-              source: String(entry.from.source).slice(0, 128)
+              id: String(entry.id).slice(0, 160)
+            }
+          : {}),
+        from: {
+          kind: entry?.from?.kind === 'member' ? 'member' : 'user',
+          name: String(entry?.from?.name || (entry?.from?.kind === 'member' ? 'Bot' : 'You')).slice(0, 128),
+          ...(entry?.from?.source
+            ? {
+                source: String(entry.from.source).slice(0, 128)
+              }
+            : {})
+        },
+        text: compacted.text,
+        at: Number(entry?.at || 0),
+        ...(entry?.thread
+          ? {
+              thread: String(entry.thread).slice(0, 128)
+            }
+          : {}),
+        ...(compacted.truncated
+          ? {
+              truncated: true
             }
           : {})
-      },
-      text: String(entry?.text || '').slice(0, GROUP_CHAT_SYNC_TEXT_CHARS),
-      at: Number(entry?.at || 0),
-      ...(entry?.thread
-        ? {
-            thread: String(entry.thread).slice(0, 128)
-          }
-        : {})
-    }))
+      }
+    })
 
     const compact: GroupChatSyncRoom = {
       name: String(name).slice(0, 64),

--- a/apps/desktop/src/plugins/hermes-bots/types.ts
+++ b/apps/desktop/src/plugins/hermes-bots/types.ts
@@ -144,6 +144,8 @@ export interface GroupMessage {
   text: string
   /** Messages predating threading carry the sentinel thread `'legacy'`. */
   thread?: string
+  /** Set on the ui_meta projection when `text` was cut to the sync budget. */
+  truncated?: boolean
 }
 
 export interface GroupHold {


### PR DESCRIPTION
## What does this PR do?

The Desktop group-chat `ui_meta` projection sliced each message at 1200 characters with no marker, so a receiving client/bot saw a mid-sentence cut and had no way to know the body continued.

Sync text that exceeds the budget now ends with `… [truncated]` (kept inside the same 1200-char cap) and sets `truncated: true` on the projected message. The 48KB envelope bound is unchanged.

This does not raise the per-message cap or switch to incremental full-text delivery — that would be a larger sync-protocol change. Receivers at least know the payload was cut.

## Related Issue

Fixes #97373

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/plugins/hermes-bots/group-chat.ts`: `compactGroupChatSyncText` + stamp `truncated`
- `apps/desktop/src/plugins/hermes-bots/types.ts`: optional `truncated` on `GroupMessage`
- `apps/desktop/src/plugins/hermes-bots/group-chat.test.ts`: marker + flag on oversized sync lines

## How to Test

```text
cd apps/desktop
npx vitest run src/plugins/hermes-bots/group-chat.test.ts
# 41 passed
```

Not runtime-tested in a live multi-bot room.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the targeted vitest file above
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A
