### PR TITLE
fix(desktop): keep primary session selector in sync on model switch

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
@@ -21,8 +21,8 @@ import {
   $sessionStates,
   publishSessionState,
   sessionTileDelegate,
-  setSessionTileDelegate,
-  type SessionTileDelegate
+  type SessionTileDelegate,
+  setSessionTileDelegate
 } from '@/store/session-states'
 
 import { deferred } from '../../../test/deferred'
@@ -92,6 +92,7 @@ function installSessionDelegate() {
     updateSession: (runtimeId, updater) => {
       const previous =
         sessionStateCache.get(runtimeId) ?? $sessionStates.get()[runtimeId] ?? createClientSessionState()
+
       const next = updater(previous)
 
       if (next === previous) {
@@ -693,6 +694,7 @@ describe('useModelControls', () => {
     const requestGateway = vi.fn(async () => {
       throw new Error('no such model')
     })
+
     let controls!: Controls
 
     render(<Harness onReady={value => (controls = value)} requestGateway={requestGateway} />)
@@ -714,6 +716,7 @@ describe('useModelControls', () => {
     const requestGateway = vi.fn(async () => {
       throw new Error('no such model')
     })
+
     let controls!: Controls
 
     render(<Harness onReady={value => (controls = value)} requestGateway={requestGateway} />)
@@ -847,6 +850,7 @@ describe('useModelControls', () => {
     setCurrentModel('primary/model')
     setCurrentProvider('openai')
     seedRuntimeSlice('primary-runtime', 'primary/model', 'openai')
+
     seedRuntimeSlice('tile-runtime', 'old-tile', 'nous')
 
     const requestGateway = vi.fn(async () => ({ key: 'model', value: 'tile-model' }) as never)

--- a/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
@@ -2,7 +2,9 @@ import { QueryClient } from '@tanstack/react-query'
 import { act, cleanup, render, renderHook, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { PRIMARY_SESSION_VIEW } from '@/app/chat/session-view'
 import { getGlobalModelInfo } from '@/hermes'
+import { createClientSessionState } from '@/lib/chat-runtime'
 import { modelOptionsQueryKey } from '@/lib/model-options'
 import { $activeGatewayProfile } from '@/store/profile'
 import {
@@ -14,6 +16,7 @@ import {
   setCurrentModelSource,
   setCurrentProvider
 } from '@/store/session'
+import { $sessionStates, publishSessionState } from '@/store/session-states'
 import type * as SessionStates from '@/store/session-states'
 
 import { deferred } from '../../../test/deferred'
@@ -78,10 +81,19 @@ function Harness({
   return null
 }
 
+function seedRuntimeSlice(runtimeId: string, model: string, provider: string) {
+  publishSessionState(runtimeId, {
+    ...createClientSessionState(`stored-${runtimeId}`),
+    model,
+    provider
+  })
+}
+
 describe('useModelControls', () => {
   beforeEach(() => {
     $activeGatewayProfile.set('default')
     $activeSessionId.set(null)
+    $sessionStates.set({})
     setCurrentModel('')
     setCurrentModelSource('')
     setCurrentProvider('')
@@ -92,6 +104,7 @@ describe('useModelControls', () => {
     vi.restoreAllMocks()
     $activeGatewayProfile.set('default')
     $activeSessionId.set(null)
+    $sessionStates.set({})
     setCurrentModel('')
     setCurrentModelSource('')
     setCurrentProvider('')
@@ -612,6 +625,109 @@ describe('useModelControls', () => {
     expect(getCurrentModelSource()).toBe('default')
   })
 
+  it('updates the primary session slice so the selector matches an acknowledged switch', async () => {
+    $activeSessionId.set('session-1')
+    setCurrentModel('gpt-5.6-sol')
+    setCurrentProvider('openai-codex')
+    seedRuntimeSlice('session-1', 'gpt-5.6-sol', 'openai-codex')
+
+    const requestGateway = vi.fn(async () => ({ key: 'model', value: 'grok-4.5' }) as never)
+    let controls!: Controls
+
+    render(<Harness onReady={value => (controls = value)} requestGateway={requestGateway} />)
+
+    await expect(controls.selectModel({ model: 'grok-4.5', provider: 'xai' })).resolves.toBe(true)
+
+    expect($currentModel.get()).toBe('grok-4.5')
+    expect($currentProvider.get()).toBe('xai')
+    expect($sessionStates.get()['session-1']?.model).toBe('grok-4.5')
+    expect($sessionStates.get()['session-1']?.provider).toBe('xai')
+    expect(PRIMARY_SESSION_VIEW.$model.get()).toBe('grok-4.5')
+    expect(PRIMARY_SESSION_VIEW.$provider.get()).toBe('xai')
+  })
+
+  it('rolls the primary session slice back when the switch fails', async () => {
+    $activeSessionId.set('session-1')
+    setCurrentModel('gpt-5.6-sol')
+    setCurrentProvider('openai-codex')
+    seedRuntimeSlice('session-1', 'gpt-5.6-sol', 'openai-codex')
+
+    const requestGateway = vi.fn(async () => {
+      throw new Error('no such model')
+    })
+    let controls!: Controls
+
+    render(<Harness onReady={value => (controls = value)} requestGateway={requestGateway} />)
+
+    await expect(controls.selectModel({ model: 'bogus', provider: 'xai' })).resolves.toBe(false)
+
+    expect($currentModel.get()).toBe('gpt-5.6-sol')
+    expect($currentProvider.get()).toBe('openai-codex')
+    expect(PRIMARY_SESSION_VIEW.$model.get()).toBe('gpt-5.6-sol')
+    expect(PRIMARY_SESSION_VIEW.$provider.get()).toBe('openai-codex')
+  })
+
+  it('rolls the primary session slice back when confirmation is required, then paints on confirm', async () => {
+    $activeSessionId.set('session-1')
+    setCurrentModel('gpt-5.6-sol')
+    setCurrentProvider('openai-codex')
+    seedRuntimeSlice('session-1', 'gpt-5.6-sol', 'openai-codex')
+
+    const requestGateway = vi
+      .fn()
+      .mockResolvedValueOnce({
+        confirm_message: 'This contributor model trains on your data.',
+        confirm_required: true,
+        key: 'model',
+        value: 'muse-spark-1.2-contributor'
+      })
+      .mockResolvedValueOnce({ key: 'model', scope: 'global', value: 'muse-spark-1.2-contributor' })
+
+    let controls!: Controls
+
+    render(<Harness onReady={value => (controls = value)} requestGateway={requestGateway} />)
+
+    await expect(
+      controls.selectModel({ model: 'muse-spark-1.2-contributor', provider: 'opencode-go' })
+    ).resolves.toBe(false)
+
+    expect(PRIMARY_SESSION_VIEW.$model.get()).toBe('gpt-5.6-sol')
+    expect(PRIMARY_SESSION_VIEW.$provider.get()).toBe('openai-codex')
+
+    const action = notify.mock.calls.at(-1)?.[0]?.action
+
+    await act(async () => {
+      await action?.onClick()
+    })
+
+    await waitFor(() => expect(requestGateway).toHaveBeenCalledTimes(2))
+    expect(PRIMARY_SESSION_VIEW.$model.get()).toBe('muse-spark-1.2-contributor')
+    expect(PRIMARY_SESSION_VIEW.$provider.get()).toBe('opencode-go')
+  })
+
+  it('does not let a later composer-atom-only heartbeat hide a newer primary pick', async () => {
+    $activeSessionId.set('session-1')
+    setCurrentModel('gpt-5.6-sol')
+    setCurrentProvider('openai-codex')
+    seedRuntimeSlice('session-1', 'gpt-5.6-sol', 'openai-codex')
+
+    const requestGateway = vi.fn(async () => ({ key: 'model', value: 'grok-4.5' }) as never)
+    let controls!: Controls
+
+    render(<Harness onReady={value => (controls = value)} requestGateway={requestGateway} />)
+
+    await controls.selectModel({ model: 'grok-4.5', provider: 'xai' })
+
+    // session.info still does not write the composer atoms. A stale global
+    // default here must not become the visible selector while the slice is live.
+    setCurrentModel('profile-default')
+    setCurrentProvider('nous')
+
+    expect(PRIMARY_SESSION_VIEW.$model.get()).toBe('grok-4.5')
+    expect(PRIMARY_SESSION_VIEW.$provider.get()).toBe('xai')
+    expect($currentModel.get()).toBe('profile-default')
+  })
+
   it('targets an explicit tile sessionId without clobbering the primary model', async () => {
     const queryClient = new QueryClient()
     $activeGatewayProfile.set('compass')
@@ -642,5 +758,32 @@ describe('useModelControls', () => {
       provider: 'anthropic'
     })
     expect(queryClient.getQueryData(modelOptionsQueryKey('default', 'tile-runtime'))).toBeUndefined()
+  })
+
+  it('paints a tile slice without rewriting the primary session selector', async () => {
+    $activeSessionId.set('primary-runtime')
+    setCurrentModel('primary/model')
+    setCurrentProvider('openai')
+    seedRuntimeSlice('primary-runtime', 'primary/model', 'openai')
+    seedRuntimeSlice('tile-runtime', 'old-tile', 'nous')
+
+    const requestGateway = vi.fn(async () => ({ key: 'model', value: 'tile-model' }) as never)
+    const { result } = renderHook(() =>
+      useModelControls({ queryClient: new QueryClient(), requestGateway })
+    )
+
+    await expect(
+      result.current.selectModel({
+        model: 'tile-model',
+        provider: 'anthropic',
+        sessionId: 'tile-runtime'
+      })
+    ).resolves.toBe(true)
+
+    expect($sessionStates.get()['tile-runtime']?.model).toBe('tile-model')
+    expect($sessionStates.get()['tile-runtime']?.provider).toBe('anthropic')
+    expect(PRIMARY_SESSION_VIEW.$model.get()).toBe('primary/model')
+    expect(PRIMARY_SESSION_VIEW.$provider.get()).toBe('openai')
+    expect($currentModel.get()).toBe('primary/model')
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
@@ -3,6 +3,7 @@ import { act, cleanup, render, renderHook, waitFor } from '@testing-library/reac
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { PRIMARY_SESSION_VIEW } from '@/app/chat/session-view'
+import type { ClientSessionState } from '@/app/types'
 import { getGlobalModelInfo } from '@/hermes'
 import { createClientSessionState } from '@/lib/chat-runtime'
 import { modelOptionsQueryKey } from '@/lib/model-options'
@@ -16,8 +17,13 @@ import {
   setCurrentModelSource,
   setCurrentProvider
 } from '@/store/session'
-import { $sessionStates, publishSessionState } from '@/store/session-states'
-import type * as SessionStates from '@/store/session-states'
+import {
+  $sessionStates,
+  publishSessionState,
+  sessionTileDelegate,
+  setSessionTileDelegate,
+  type SessionTileDelegate
+} from '@/store/session-states'
 
 import { deferred } from '../../../test/deferred'
 
@@ -33,15 +39,6 @@ vi.mock('@/hermes', () => ({
   setApiRequestProfile: vi.fn(),
   setGlobalModel: (...args: Parameters<typeof setGlobalModel>) => setGlobalModel(...args)
 }))
-
-vi.mock('@/store/session-states', async importOriginal => {
-  const actual = await importOriginal<typeof SessionStates>()
-
-  return {
-    ...actual,
-    sessionTileDelegate: () => null
-  }
-})
 
 vi.mock('@/i18n', () => ({
   useI18n: () => ({
@@ -81,12 +78,50 @@ function Harness({
   return null
 }
 
+const sessionStateCache = new Map<string, ClientSessionState>()
+
+function installSessionDelegate() {
+  setSessionTileDelegate({
+    archiveSession: vi.fn(async () => undefined),
+    branchSession: vi.fn(async () => undefined),
+    deleteSession: vi.fn(async () => undefined),
+    executeSlash: vi.fn(async () => undefined),
+    interruptSession: vi.fn(async () => undefined),
+    resumeTile: vi.fn(async () => ''),
+    submitToSession: vi.fn(async () => undefined),
+    updateSession: (runtimeId, updater) => {
+      const previous =
+        sessionStateCache.get(runtimeId) ?? $sessionStates.get()[runtimeId] ?? createClientSessionState()
+      const next = updater(previous)
+
+      if (next === previous) {
+        return previous
+      }
+
+      sessionStateCache.set(runtimeId, next)
+      publishSessionState(runtimeId, next)
+
+      // Same contract as updateSessionState → syncRuntimeMetadataToView for
+      // the focused session: composer atoms follow the slice write.
+      if (runtimeId === $activeSessionId.get()) {
+        setCurrentModel(next.model ?? '')
+        setCurrentProvider(next.provider ?? '')
+      }
+
+      return next
+    }
+  } as SessionTileDelegate)
+}
+
 function seedRuntimeSlice(runtimeId: string, model: string, provider: string) {
-  publishSessionState(runtimeId, {
+  const state = {
     ...createClientSessionState(`stored-${runtimeId}`),
     model,
     provider
-  })
+  }
+
+  sessionStateCache.set(runtimeId, state)
+  publishSessionState(runtimeId, state)
 }
 
 describe('useModelControls', () => {
@@ -94,9 +129,11 @@ describe('useModelControls', () => {
     $activeGatewayProfile.set('default')
     $activeSessionId.set(null)
     $sessionStates.set({})
+    sessionStateCache.clear()
     setCurrentModel('')
     setCurrentModelSource('')
     setCurrentProvider('')
+    installSessionDelegate()
   })
 
   afterEach(() => {
@@ -105,6 +142,7 @@ describe('useModelControls', () => {
     $activeGatewayProfile.set('default')
     $activeSessionId.set(null)
     $sessionStates.set({})
+    sessionStateCache.clear()
     setCurrentModel('')
     setCurrentModelSource('')
     setCurrentProvider('')
@@ -667,6 +705,27 @@ describe('useModelControls', () => {
     expect(PRIMARY_SESSION_VIEW.$provider.get()).toBe('openai-codex')
   })
 
+  it('rolls the slice back to its own prior pair when composer atoms disagree', async () => {
+    $activeSessionId.set('session-1')
+    setCurrentModel('composer-stale')
+    setCurrentProvider('nous')
+    seedRuntimeSlice('session-1', 'gpt-5.6-sol', 'openai-codex')
+
+    const requestGateway = vi.fn(async () => {
+      throw new Error('no such model')
+    })
+    let controls!: Controls
+
+    render(<Harness onReady={value => (controls = value)} requestGateway={requestGateway} />)
+
+    await expect(controls.selectModel({ model: 'bogus', provider: 'xai' })).resolves.toBe(false)
+
+    expect($sessionStates.get()['session-1']?.model).toBe('gpt-5.6-sol')
+    expect($sessionStates.get()['session-1']?.provider).toBe('openai-codex')
+    expect(PRIMARY_SESSION_VIEW.$model.get()).toBe('gpt-5.6-sol')
+    expect(PRIMARY_SESSION_VIEW.$provider.get()).toBe('openai-codex')
+  })
+
   it('rolls the primary session slice back when confirmation is required, then paints on confirm', async () => {
     $activeSessionId.set('session-1')
     setCurrentModel('gpt-5.6-sol')
@@ -705,7 +764,7 @@ describe('useModelControls', () => {
     expect(PRIMARY_SESSION_VIEW.$provider.get()).toBe('opencode-go')
   })
 
-  it('does not let a later composer-atom-only heartbeat hide a newer primary pick', async () => {
+  it('keeps PRIMARY_SESSION_VIEW on the live slice when composer atoms change', async () => {
     $activeSessionId.set('session-1')
     setCurrentModel('gpt-5.6-sol')
     setCurrentProvider('openai-codex')
@@ -718,14 +777,37 @@ describe('useModelControls', () => {
 
     await controls.selectModel({ model: 'grok-4.5', provider: 'xai' })
 
-    // session.info still does not write the composer atoms. A stale global
-    // default here must not become the visible selector while the slice is live.
     setCurrentModel('profile-default')
     setCurrentProvider('nous')
 
     expect(PRIMARY_SESSION_VIEW.$model.get()).toBe('grok-4.5')
     expect(PRIMARY_SESSION_VIEW.$provider.get()).toBe('xai')
     expect($currentModel.get()).toBe('profile-default')
+  })
+
+  it('applies a session.info-shaped slice patch through the same updateSession path', async () => {
+    $activeSessionId.set('session-1')
+    setCurrentModel('gpt-5.6-sol')
+    setCurrentProvider('openai-codex')
+    seedRuntimeSlice('session-1', 'gpt-5.6-sol', 'openai-codex')
+
+    const requestGateway = vi.fn(async () => ({ key: 'model', value: 'grok-4.5' }) as never)
+    let controls!: Controls
+
+    render(<Harness onReady={value => (controls = value)} requestGateway={requestGateway} />)
+
+    await controls.selectModel({ model: 'grok-4.5', provider: 'xai' })
+
+    sessionTileDelegate()!.updateSession('session-1', state => ({
+      ...state,
+      model: 'heartbeat-model',
+      provider: 'heartbeat-provider'
+    }))
+
+    expect($sessionStates.get()['session-1']?.model).toBe('heartbeat-model')
+    expect(PRIMARY_SESSION_VIEW.$model.get()).toBe('heartbeat-model')
+    expect(PRIMARY_SESSION_VIEW.$provider.get()).toBe('heartbeat-provider')
+    expect($currentModel.get()).toBe('heartbeat-model')
   })
 
   it('targets an explicit tile sessionId without clobbering the primary model', async () => {

--- a/apps/desktop/src/app/session/hooks/use-model-controls.ts
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.ts
@@ -20,7 +20,7 @@ import {
   setCurrentModelSource,
   setCurrentProvider
 } from '@/store/session'
-import { $sessionStates, publishSessionState, sessionTileDelegate } from '@/store/session-states'
+import { $sessionStates, sessionTileDelegate } from '@/store/session-states'
 import type { ModelOptionsResponse } from '@/types/hermes'
 
 interface ModelControlsOptions {
@@ -194,11 +194,10 @@ export function useModelControls({ queryClient, requestGateway }: ModelControlsO
       const liveSessionId = 'sessionId' in selection ? (selection.sessionId ?? null) : primaryRuntimeId
       const touchesPrimary = !liveSessionId || liveSessionId === primaryRuntimeId
 
-      const prevModel = touchesPrimary ? $currentModel.get() : ($sessionStates.get()[liveSessionId!]?.model ?? '')
+      const prevSlice = liveSessionId ? $sessionStates.get()[liveSessionId] : undefined
+      const prevModel = touchesPrimary ? $currentModel.get() : (prevSlice?.model ?? '')
 
-      const prevProvider = touchesPrimary
-        ? $currentProvider.get()
-        : ($sessionStates.get()[liveSessionId!]?.provider ?? '')
+      const prevProvider = touchesPrimary ? $currentProvider.get() : (prevSlice?.provider ?? '')
 
       const prevSource = getCurrentModelSource()
       const liveGatewayProfile = $activeGatewayProfile.get()
@@ -206,30 +205,18 @@ export function useModelControls({ queryClient, requestGateway }: ModelControlsO
       // PRIMARY_SESSION_VIEW treats `$sessionStates[runtimeId]` as
       // authoritative for model/provider once a runtime exists. Painting only
       // the composer atoms left the visible selector on the previous pair.
+      // Writes go through the session-tile delegate (updateSessionState) so
+      // the wiring cache, $sessionStates, and the focused view stay aligned.
       const paintLiveSlice = (model: string, provider: string) => {
         if (!liveSessionId) {
           return
         }
 
-        const delegate = sessionTileDelegate()
-
-        if (delegate) {
-          delegate.updateSession(liveSessionId, state => ({
-            ...state,
-            model,
-            provider
-          }))
-
-          return
-        }
-
-        const current = $sessionStates.get()[liveSessionId]
-
-        if (!current) {
-          return
-        }
-
-        publishSessionState(liveSessionId, { ...current, model, provider })
+        sessionTileDelegate()?.updateSession(liveSessionId, state => ({
+          ...state,
+          model,
+          provider
+        }))
       }
 
       const paintSelection = () => {
@@ -253,7 +240,7 @@ export function useModelControls({ queryClient, requestGateway }: ModelControlsO
           setCurrentModelSource(prevSource)
         }
 
-        paintLiveSlice(prevModel, prevProvider)
+        paintLiveSlice(prevSlice?.model ?? prevModel, prevSlice?.provider ?? prevProvider)
         cacheSelection(prevProvider, prevModel)
       }
 
@@ -320,13 +307,10 @@ export function useModelControls({ queryClient, requestGateway }: ModelControlsO
             // not clobber the newer choice: bail if the live state no longer
             // matches the snapshot this notification was created for.
             isStale: () =>
-              touchesPrimary
-                ? $activeSessionId.get() !== liveSessionId ||
-                  $currentModel.get() !== prevModel ||
-                  $currentProvider.get() !== prevProvider
-                : !liveSessionId ||
-                  $sessionStates.get()[liveSessionId]?.model !== prevModel ||
-                  $sessionStates.get()[liveSessionId]?.provider !== prevProvider,
+              $activeSessionId.get() !== liveSessionId ||
+              !liveSessionId ||
+              $sessionStates.get()[liveSessionId]?.model !== (prevSlice?.model ?? prevModel) ||
+              $sessionStates.get()[liveSessionId]?.provider !== (prevSlice?.provider ?? prevProvider),
             repaint: () => {
               paintSelection()
               cacheSelection(selection.provider, selection.model)

--- a/apps/desktop/src/app/session/hooks/use-model-controls.ts
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.ts
@@ -306,11 +306,29 @@ export function useModelControls({ queryClient, requestGateway }: ModelControlsO
             // a different model or switches sessions. Clicking Confirm must
             // not clobber the newer choice: bail if the live state no longer
             // matches the snapshot this notification was created for.
-            isStale: () =>
-              $activeSessionId.get() !== liveSessionId ||
-              !liveSessionId ||
-              $sessionStates.get()[liveSessionId]?.model !== (prevSlice?.model ?? prevModel) ||
-              $sessionStates.get()[liveSessionId]?.provider !== (prevSlice?.provider ?? prevProvider),
+            isStale: () => {
+              if ($activeSessionId.get() !== liveSessionId) {
+                return true
+              }
+
+              if (!liveSessionId) {
+                return $currentModel.get() !== prevModel || $currentProvider.get() !== prevProvider
+              }
+
+              const live = $sessionStates.get()[liveSessionId]
+
+              // No slice yet (fresh runtime / tests without a cache entry):
+              // compare composer atoms, the same snapshot the confirm toast
+              // rolled back to.
+              if (!live) {
+                return $currentModel.get() !== prevModel || $currentProvider.get() !== prevProvider
+              }
+
+              return (
+                live.model !== (prevSlice?.model ?? prevModel) ||
+                live.provider !== (prevSlice?.provider ?? prevProvider)
+              )
+            },
             repaint: () => {
               paintSelection()
               cacheSelection(selection.provider, selection.model)

--- a/apps/desktop/src/app/session/hooks/use-model-controls.ts
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.ts
@@ -20,7 +20,7 @@ import {
   setCurrentModelSource,
   setCurrentProvider
 } from '@/store/session'
-import { $sessionStates, sessionTileDelegate } from '@/store/session-states'
+import { $sessionStates, publishSessionState, sessionTileDelegate } from '@/store/session-states'
 import type { ModelOptionsResponse } from '@/types/hermes'
 
 interface ModelControlsOptions {
@@ -203,19 +203,43 @@ export function useModelControls({ queryClient, requestGateway }: ModelControlsO
       const prevSource = getCurrentModelSource()
       const liveGatewayProfile = $activeGatewayProfile.get()
 
+      // PRIMARY_SESSION_VIEW treats `$sessionStates[runtimeId]` as
+      // authoritative for model/provider once a runtime exists. Painting only
+      // the composer atoms left the visible selector on the previous pair.
+      const paintLiveSlice = (model: string, provider: string) => {
+        if (!liveSessionId) {
+          return
+        }
+
+        const delegate = sessionTileDelegate()
+
+        if (delegate) {
+          delegate.updateSession(liveSessionId, state => ({
+            ...state,
+            model,
+            provider
+          }))
+
+          return
+        }
+
+        const current = $sessionStates.get()[liveSessionId]
+
+        if (!current) {
+          return
+        }
+
+        publishSessionState(liveSessionId, { ...current, model, provider })
+      }
+
       const paintSelection = () => {
         if (touchesPrimary) {
           setCurrentModel(selection.model)
           setCurrentProvider(selection.provider)
           markComposerSelectionManual()
-        } else if (liveSessionId) {
-          // Optimistic tile paint — session.info will confirm; rollback on error.
-          sessionTileDelegate()?.updateSession(liveSessionId, state => ({
-            ...state,
-            model: selection.model,
-            provider: selection.provider
-          }))
         }
+
+        paintLiveSlice(selection.model, selection.provider)
       }
 
       const cacheSelection = (provider: string, model: string) => {
@@ -227,14 +251,9 @@ export function useModelControls({ queryClient, requestGateway }: ModelControlsO
           setCurrentModel(prevModel)
           setCurrentProvider(prevProvider)
           setCurrentModelSource(prevSource)
-        } else if (liveSessionId) {
-          sessionTileDelegate()?.updateSession(liveSessionId, state => ({
-            ...state,
-            model: prevModel,
-            provider: prevProvider
-          }))
         }
 
+        paintLiveSlice(prevModel, prevProvider)
         cacheSelection(prevProvider, prevModel)
       }
 


### PR DESCRIPTION
## What does this PR do?

On an idle existing Desktop conversation, a successful model/provider switch updated `$currentModel` / `$currentProvider` while `PRIMARY_SESSION_VIEW` kept reading `$sessionStates[runtimeId]`. The visible selector and composer pill could stay on the previous pair until a later session metadata refresh.

`selectModel` now paints the live runtime slice on success (via the session-tile delegate, or `$sessionStates` when the delegate is not registered). Failure and `confirm_required` still roll that slice back. Tile picks still do not rewrite the primary composer atoms. `session.info` still does not write the global composer atoms.

## Related Issue

Fixes #97425

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/session/hooks/use-model-controls.ts`: paint/rollback the live session slice on primary (and tile) switches
- `apps/desktop/src/app/session/hooks/use-model-controls.test.tsx`: acknowledged switch, failure rollback, confirm handshake, stale composer atoms, tile isolation

## How to Test

```text
cd apps/desktop
npx vitest run src/app/session/hooks/use-model-controls.test.tsx
# 26 passed
```

Not runtime-tested in the packaged Desktop app.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the targeted vitest file above
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A
