### PR TITLE
fix(mcp): redact Bearer fragments from mcp test output and probe errors

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -10,7 +10,6 @@ configuration in ~/.hermes/config.yaml under the ``mcp_servers`` key.
 
 import asyncio
 import logging
-import os
 import re
 import time
 from typing import Any, Dict, List, Optional, Tuple
@@ -26,7 +25,7 @@ from hermes_cli.config import (
 from hermes_cli.colors import Colors, color
 from hermes_constants import display_hermes_home
 from hermes_cli.mcp_security import validate_mcp_server_entry
-from tools.mcp_tool import _ENV_VAR_PATTERN, _env_ref_name
+from tools.mcp_tool import _ENV_VAR_PATTERN, _sanitize_error
 
 logger = logging.getLogger(__name__)
 
@@ -394,7 +393,16 @@ def _probe_single_server(
     try:
         _run_on_mcp_loop(_probe(), timeout=connect_timeout + 10)
     except BaseException as exc:
-        raise _unwrap_exception_group(exc) from None
+        unwrapped = _unwrap_exception_group(exc)
+        # Probe errors can echo request headers (e.g. an HTTP client exception
+        # containing "Authorization: Bearer <token>"). This raise is the single
+        # seam every consumer funnels through — CLI test/add/login and the
+        # dashboard test endpoint — so scrub credential patterns here before
+        # the message reaches any display surface. (#97460)
+        sanitized = _sanitize_error(str(unwrapped))
+        if sanitized != str(unwrapped):
+            raise RuntimeError(sanitized) from None
+        raise unwrapped from None
     finally:
         _stop_mcp_loop_if_idle()
 
@@ -774,13 +782,14 @@ def cmd_mcp_test(args):
     elif headers:
         for k, v in headers.items():
             if isinstance(v, str) and ("key" in k.lower() or "auth" in k.lower()):
-                # Mask the value (accepts ${VAR} and Cursor-style ${env:VAR})
-                resolved = _ENV_VAR_PATTERN.sub(lambda m: os.getenv(_env_ref_name(m.group(1)), ""), v)
-                if len(resolved) > 8:
-                    masked = resolved[:4] + "***" + resolved[-4:]
+                # A first4/last4 preview of a resolved credential is a
+                # reusable fragment — redact fully instead. Keep the on-disk
+                # `${VAR}` template visible when present (it carries no
+                # secret); a literal value never reaches the screen. (#97460)
+                if _ENV_VAR_PATTERN.search(v):
+                    print(f"    {k}: {v}")
                 else:
-                    masked = "***"
-                print(f"    {k}: {masked}")
+                    print(f"    {k}: [REDACTED]")
     else:
         _info("Auth: none")
 

--- a/hermes_cli/web_routers/mcp.py
+++ b/hermes_cli/web_routers/mcp.py
@@ -199,9 +199,15 @@ async def test_mcp_server(name: str, profile: Optional[str] = None):
         # FastAPI event loop is never blocked.
         tools, token_present = await asyncio.to_thread(_probe_scoped)
     except Exception as exc:
+        # Defense in depth on top of the probe-seam scrub in
+        # ``_probe_single_server``: this JSON body goes straight to the
+        # browser, so anything that still looks like a credential gets
+        # redacted here too. (#97460)
+        from tools.mcp_tool import _sanitize_error
+
         return {
             "ok": False,
-            "error": str(exc),
+            "error": _sanitize_error(str(exc)),
             "tools": [],
         }
     if not token_present:

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -340,6 +340,110 @@ class TestMcpTest:
         assert captured["outer_timeout"] == 310.0
         assert captured["shutdown"] is True
 
+    def test_test_auth_display_shows_template_not_resolved_secret(self, tmp_path, capsys, monkeypatch):
+        """``hermes mcp test`` must not print any fragment of a resolved credential.
+
+        With the env var set, ``load_config`` resolves ``${VAR}`` to the raw
+        secret before ``cmd_mcp_test`` sees it — a first4/last4 preview of that
+        value is a reusable credential fragment, so it must be fully redacted.
+        (#97460)
+        """
+        monkeypatch.setenv("MCP_SYNTH_SECRET", "SYNTH_ABCDEFGHIJKL_MNOP")
+        _seed_config(tmp_path, {
+            "ink": {
+                "url": "https://mcp.ml.ink/mcp",
+                "headers": {"Authorization": "Bearer ${MCP_SYNTH_SECRET}"},
+            },
+        })
+
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server",
+            lambda name, config, **kw: [],
+        )
+        from hermes_cli.mcp_config import cmd_mcp_test
+
+        cmd_mcp_test(_make_args(name="ink"))
+        out = capsys.readouterr().out
+        assert "Authorization: [REDACTED]" in out
+        for fragment in ("SYNTH_ABCDEFGHIJKL_MNOP", "SYNTH_ABCD", "MNOP"):
+            assert fragment not in out
+
+    def test_test_auth_display_shows_template_when_env_unset(self, tmp_path, capsys, monkeypatch):
+        """With the env var unset the on-disk ``${VAR}`` template survives
+        ``load_config`` and is safe to show as-is. (#97460)"""
+        monkeypatch.delenv("MCP_SYNTH_SECRET", raising=False)
+        _seed_config(tmp_path, {
+            "ink": {
+                "url": "https://mcp.ml.ink/mcp",
+                "headers": {"Authorization": "Bearer ${MCP_SYNTH_SECRET}"},
+            },
+        })
+
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server",
+            lambda name, config, **kw: [],
+        )
+        from hermes_cli.mcp_config import cmd_mcp_test
+
+        cmd_mcp_test(_make_args(name="ink"))
+        out = capsys.readouterr().out
+        assert "Bearer ${MCP_SYNTH_SECRET}" in out
+
+    def test_test_auth_display_redacts_literal_credentials(self, tmp_path, capsys, monkeypatch):
+        """A literal (non-template) credential header is fully redacted."""
+        monkeypatch.setenv("MCP_SYNTH_LITERAL", "LITERAL_SECRET_9876XYZQ")
+        literal = os.environ["MCP_SYNTH_LITERAL"]
+        _seed_config(tmp_path, {
+            "ink": {
+                "url": "https://mcp.ml.ink/mcp",
+                "headers": {"X-Api-Key": literal},
+            },
+        })
+
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server",
+            lambda name, config, **kw: [],
+        )
+        from hermes_cli.mcp_config import cmd_mcp_test
+
+        cmd_mcp_test(_make_args(name="ink"))
+        out = capsys.readouterr().out
+        assert "X-Api-Key: [REDACTED]" in out
+        assert literal not in out
+
+    def test_probe_error_scrubs_bearer_from_exception_text(self, monkeypatch, tmp_path):
+        """Probe exceptions are scrubbed at the single raise seam.
+
+        HTTP client errors can echo ``Authorization: Bearer <token>``; every
+        consumer (CLI test/add/login, dashboard test endpoint) funnels through
+        this raise, so scrubbing here covers them all. (#97460)
+        """
+        import tools.mcp_tool as mcp_tool
+        from hermes_cli import mcp_config
+
+        _seed_config(tmp_path, {"ink": {"url": "https://mcp.ml.ink/mcp"}})
+
+        def exploding_run(coro, timeout):
+            coro.close()
+            bearer = "Bearer SYNTH_BEARER_98765XYZ"
+            raise RuntimeError(
+                f'Connect failed: request headers '
+                f'"Authorization: {bearer}" rejected (401)'
+            )
+
+        monkeypatch.setattr(mcp_tool, "_ensure_mcp_loop", lambda: None)
+        monkeypatch.setattr(mcp_tool, "_stop_mcp_loop_if_idle", lambda: None)
+        monkeypatch.setattr(mcp_tool, "_run_on_mcp_loop", exploding_run)
+
+        with pytest.raises(RuntimeError) as excinfo:
+            mcp_config._probe_single_server(
+                "ink", {"url": "https://mcp.ml.ink/mcp"}
+            )
+        text = str(excinfo.value)
+        assert "[REDACTED]" in text
+        for fragment in ("SYNTH_BEARER_98765XYZ", "SYNTH_BEARER", "XYZ"):
+            assert fragment not in text
+
 
 # ---------------------------------------------------------------------------
 # Tests: env var interpolation

--- a/tests/hermes_cli/test_mcp_dashboard_oauth.py
+++ b/tests/hermes_cli/test_mcp_dashboard_oauth.py
@@ -139,3 +139,34 @@ def test_flow_status_does_not_expose_authorization_code():
     assert body["status"] == "approved"
     assert "secret-code" not in response.text
     assert "secret-state" not in response.text
+
+
+def test_mcp_test_endpoint_redacts_bearer_from_error(monkeypatch, tmp_path):
+    """The dashboard MCP test endpoint must not return raw Bearer values.
+
+    Defense in depth on top of the probe-seam scrub: the JSON error body goes
+    straight to the browser. (#97460)
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    monkeypatch.setattr(
+        "hermes_cli.mcp_config._get_mcp_servers",
+        lambda: {"ink": {"url": "https://mcp.ml.ink/mcp"}},
+    )
+
+    def exploding_probe(name, config, **kw):
+        raise RuntimeError(
+            "Connect failed: Authorization: Bearer SYNTH_DASH_BEARER_99887766 rejected"
+        )
+
+    monkeypatch.setattr("hermes_cli.mcp_config._probe_single_server", exploding_probe)
+    monkeypatch.setattr(
+        "hermes_cli.mcp_config._oauth_tokens_present", lambda name: True
+    )
+
+    response = _client().post("/api/mcp/servers/ink/test")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["ok"] is False
+    assert "[REDACTED]" in body["error"]
+    assert "SYNTH_DASH_BEARER_99887766" not in body["error"]


### PR DESCRIPTION
## What does this PR do?

Closes a credential-fragment leak in `hermes mcp test` and the dashboard MCP test endpoint (#97460):

1. **Auth display**: `cmd_mcp_test` masked resolved header values as `first4***last4`. Those 8 characters are a reusable credential fragment. Now the display shows the surviving `${VAR}` on-disk template (safe — it carries no secret) or `[REDACTED]` for literal values; a resolved value never reaches the screen.
2. **Probe errors**: an HTTP client exception echoing `Authorization: Bearer <value>` was interpolated verbatim into CLI error output (`_error(f"... {exc}")`) and returned as-is by the dashboard endpoint (`{"error": str(exc)}`). The fix scrubs credential patterns at the **single raise seam** in `_probe_single_server` — every consumer (CLI `mcp test`/`add`/`login`, dashboard test endpoint) funnels through it — reusing the existing `tools.mcp_tool._sanitize_error` `[REDACTED]` redactor that the normal MCP runtime connect-error path already applies. The dashboard endpoint additionally scrubs at the JSON boundary as defense in depth, per the issue's suggested boundary.

## Related Issue

Fixes #97460

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix

## Changes Made

- `hermes_cli/mcp_config.py`
  - `_probe_single_server`: after unwrapping the exception group, run the message through `_sanitize_error`; re-raise as `RuntimeError(sanitized)` only when something was actually redacted (otherwise the original exception passes through untouched).
  - `cmd_mcp_test`: replace the `resolved[:4]+"***"+resolved[-4:]` preview with template-or-`[REDACTED]` display; drop the now-unused in-function env resolution (`os` / `_env_ref_name` imports removed).
- `hermes_cli/web_routers/mcp.py`
  - `test_mcp_server`: pass the error string through `_sanitize_error` before returning the JSON body (defense in depth on top of the seam scrub).

## How to Test

1. `uv run pytest tests/hermes_cli/test_mcp_config.py tests/hermes_cli/test_mcp_dashboard_oauth.py -q` — Observed result: 47 passed.
2. `uv run pytest tests/tools/test_mcp_tool.py tests/hermes_cli/test_mcp_security.py tests/hermes_cli/test_mcp_startup.py tests/hermes_cli/test_web_server_profile_unification.py -q` — Observed result: 135 passed (adjacent regressions).
3. New fail-closed tests (synthetic tokens; assert full value, unique prefix, and unique suffix are all absent):
   - resolved-secret display prints `[REDACTED]`, no fragment (env set → `load_config` resolves the template before `cmd_mcp_test` sees it)
   - template display kept when the env var is unset
   - literal credential header fully redacted
   - probe exception scrubbed at the seam (`[REDACTED]` present, token absent)
   - dashboard endpoint JSON error scrubbed

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable — behavior verified through the regression tests listed under How to Test.