### PR TITLE
feat(desktop): add AI-isolated secure credential entry

### DIFF
--- a/apps/desktop/e2e/secure-credential.spec.ts
+++ b/apps/desktop/e2e/secure-credential.spec.ts
@@ -1,0 +1,58 @@
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+
+import { type NoProviderFixture, setupNoProvider } from './fixtures'
+import { expect, test } from './test'
+
+let fixture: NoProviderFixture | null = null
+
+test.beforeAll(async () => {
+  fixture = await setupNoProvider()
+})
+
+test.afterAll(async () => {
+  await fixture?.cleanup()
+  fixture = null
+})
+
+test('native credential window saves outside the chat renderer', async () => {
+  const app = fixture!.app
+  const page = fixture!.page
+  const credentialWindow = app.waitForEvent('window')
+
+  const result = page.evaluate(() =>
+    (window as unknown as {
+      hermesDesktop: {
+        secureCredential: {
+          capture: (request: {
+            envVar: string
+            locale: string
+            profile: string
+            prompt: string
+            requestId: string
+          }) => Promise<{ status: 'busy' | 'cancelled' | 'saved' }>
+        }
+      }
+    }).hermesDesktop.secureCredential.capture({
+      envVar: 'HERMES_SECURE_CREDENTIAL_CANARY',
+      locale: 'en',
+      profile: 'default',
+      prompt: 'Harmless end-to-end credential canary',
+      requestId: 'e2e-credential-canary'
+    })
+  )
+
+  const credentialPage = await credentialWindow
+
+  await credentialPage.getByLabel('HERMES_SECURE_CREDENTIAL_CANARY').fill('  harmless-canary  ')
+  await credentialPage.getByRole('button', { name: 'Save securely' }).click()
+
+  await expect(result).resolves.toEqual({ status: 'saved' })
+
+  const envText = fs.readFileSync(path.join(fixture!.sandbox.hermesHome, '.env'), 'utf8')
+  const canaryLine = envText
+    .split(/\r?\n/)
+    .find(line => line.startsWith('HERMES_SECURE_CREDENTIAL_CANARY='))
+
+  expect(canaryLine).toContain('  harmless-canary  ')
+})

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -13740,6 +13740,7 @@ type CredentialCaptureResult = { status: 'busy' | 'cancelled' | 'saved' }
 
 type PendingCredentialCapture = {
   envVar: string
+  locale: string
   profile: null | string
   prompt: string
   promise: Promise<CredentialCaptureResult>
@@ -13781,8 +13782,14 @@ ipcMain.handle('hermes:credential:capture', (event, rawRequest) => {
   const envVar = typeof rawRequest?.envVar === 'string' ? rawRequest.envVar.trim() : ''
   const prompt = typeof rawRequest?.prompt === 'string' ? rawRequest.prompt.trim().slice(0, 500) : ''
   const profile = typeof rawRequest?.profile === 'string' ? rawRequest.profile.trim() || null : null
+  const locale = typeof rawRequest?.locale === 'string' ? rawRequest.locale.trim().slice(0, 16) : 'en'
 
-  if (!requestId || !/^[A-Z][A-Z0-9_]{1,127}$/.test(envVar)) {
+  if (
+    !BrowserWindow.fromWebContents(event.sender) ||
+    !requestId ||
+    !/^[A-Z][A-Z0-9_]{0,127}$/.test(envVar) ||
+    (profile !== null && profile !== 'default' && !PROFILE_NAME_RE.test(profile))
+  ) {
     throw new Error('Invalid secure credential request.')
   }
 
@@ -13837,6 +13844,7 @@ ipcMain.handle('hermes:credential:capture', (event, rawRequest) => {
 
   const pending: PendingCredentialCapture = {
     envVar,
+    locale,
     profile,
     prompt,
     promise,
@@ -13869,7 +13877,7 @@ ipcMain.handle('hermes:credential:request:get', event => {
     throw new Error('Credential request is no longer available.')
   }
 
-  return { envVar: pending.envVar, prompt: pending.prompt }
+  return { envVar: pending.envVar, locale: pending.locale, prompt: pending.prompt }
 })
 
 ipcMain.handle('hermes:credential:submit', async (event, payload) => {
@@ -13879,7 +13887,7 @@ ipcMain.handle('hermes:credential:submit', async (event, payload) => {
     return { error: 'Credential request is no longer available.', ok: false }
   }
 
-  const value = typeof payload?.value === 'string' ? payload.value.trim() : ''
+  const value = typeof payload?.value === 'string' ? payload.value : ''
 
   if (!value || value.length > 65_536) {
     return { error: 'Enter a credential before saving.', ok: false }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -13727,6 +13727,189 @@ function closeHudWindow() {
 // the shortcut on a cold launch without the renderer ever visiting Settings),
 // same authority split as keep-awake. Registration failure is surfaced, never
 // swallowed: a chord another app already owns comes back as `error: 'taken'`.
+// ---------------------------------------------------------------------------
+// Secure credential entry.
+//
+// The agent-facing renderer receives request metadata and a final status only.
+// The secret is typed in a separate sandboxed window, crosses its narrow IPC
+// bridge once, and is written through the existing profile-aware /api/env
+// endpoint by Electron main. It never returns to chat or a gateway tool result.
+// ---------------------------------------------------------------------------
+
+type CredentialCaptureResult = { status: 'busy' | 'cancelled' | 'saved' }
+
+type PendingCredentialCapture = {
+  envVar: string
+  profile: null | string
+  prompt: string
+  promise: Promise<CredentialCaptureResult>
+  requestId: string
+  resolve: (result: CredentialCaptureResult) => void
+  settled: boolean
+  window: BrowserWindow
+}
+
+let pendingCredentialCapture: PendingCredentialCapture | null = null
+
+function credentialEntryUrl() {
+  if (DEV_SERVER) {
+    return `${DEV_SERVER.endsWith('/') ? DEV_SERVER.slice(0, -1) : DEV_SERVER}/?win=credential#/`
+  }
+
+  return `${pathToFileURL(resolveRendererIndex()).toString()}?win=credential#/`
+}
+
+function finishCredentialCapture(pending: PendingCredentialCapture, result: CredentialCaptureResult) {
+  if (pending.settled) {
+    return
+  }
+
+  pending.settled = true
+  pending.resolve(result)
+
+  if (pendingCredentialCapture === pending) {
+    pendingCredentialCapture = null
+  }
+
+  if (!pending.window.isDestroyed()) {
+    pending.window.close()
+  }
+}
+
+ipcMain.handle('hermes:credential:capture', (event, rawRequest) => {
+  const requestId = typeof rawRequest?.requestId === 'string' ? rawRequest.requestId.trim() : ''
+  const envVar = typeof rawRequest?.envVar === 'string' ? rawRequest.envVar.trim() : ''
+  const prompt = typeof rawRequest?.prompt === 'string' ? rawRequest.prompt.trim().slice(0, 500) : ''
+  const profile = typeof rawRequest?.profile === 'string' ? rawRequest.profile.trim() || null : null
+
+  if (!requestId || !/^[A-Z][A-Z0-9_]{1,127}$/.test(envVar)) {
+    throw new Error('Invalid secure credential request.')
+  }
+
+  if (pendingCredentialCapture) {
+    if (pendingCredentialCapture.requestId === requestId) {
+      pendingCredentialCapture.window.show()
+      pendingCredentialCapture.window.focus()
+
+      return pendingCredentialCapture.promise
+    }
+
+    return { status: 'busy' } satisfies CredentialCaptureResult
+  }
+
+  const parent = BrowserWindow.fromWebContents(event.sender) ?? mainWindow ?? undefined
+
+  const win = new BrowserWindow({
+    width: 520,
+    height: 430,
+    parent: parent || undefined,
+    modal: Boolean(parent),
+    show: false,
+    resizable: false,
+    minimizable: false,
+    maximizable: false,
+    fullscreenable: false,
+    autoHideMenuBar: true,
+    backgroundColor: '#111318',
+    webPreferences: {
+      preload: PRELOAD_PATH,
+      contextIsolation: true,
+      sandbox: true,
+      nodeIntegration: false,
+      devTools: false
+    }
+  })
+
+  // Best-effort OS screen-capture protection. On Windows this uses
+  // SetWindowDisplayAffinity; it is defence in depth, not a DRM guarantee.
+  win.setContentProtection(true)
+  win.setMenuBarVisibility(false)
+
+  // Credential entry owns a fixed-size layout like Quick Entry, so it opts out
+  // of the main app's persisted UI zoom.
+  wireCommonWindowHandlers(win, zoomWiringForWindowKind('quickEntry'))
+
+  let resolveCapture!: (result: CredentialCaptureResult) => void
+
+  const promise = new Promise<CredentialCaptureResult>(resolve => {
+    resolveCapture = resolve
+  })
+
+  const pending: PendingCredentialCapture = {
+    envVar,
+    profile,
+    prompt,
+    promise,
+    requestId,
+    resolve: resolveCapture,
+    settled: false,
+    window: win
+  }
+
+  pendingCredentialCapture = pending
+
+  win.once('ready-to-show', () => {
+    if (!win.isDestroyed()) {
+      win.show()
+      win.focus()
+    }
+  })
+  win.once('closed', () => finishCredentialCapture(pending, { status: 'cancelled' }))
+  win.webContents.setWindowOpenHandler(() => ({ action: 'deny' }))
+  win.webContents.on('will-navigate', navigationEvent => navigationEvent.preventDefault())
+  void win.loadURL(credentialEntryUrl()).catch(() => finishCredentialCapture(pending, { status: 'cancelled' }))
+
+  return promise
+})
+
+ipcMain.handle('hermes:credential:request:get', event => {
+  const pending = pendingCredentialCapture
+
+  if (!pending || pending.window.webContents.id !== event.sender.id) {
+    throw new Error('Credential request is no longer available.')
+  }
+
+  return { envVar: pending.envVar, prompt: pending.prompt }
+})
+
+ipcMain.handle('hermes:credential:submit', async (event, payload) => {
+  const pending = pendingCredentialCapture
+
+  if (!pending || pending.window.webContents.id !== event.sender.id) {
+    return { error: 'Credential request is no longer available.', ok: false }
+  }
+
+  const value = typeof payload?.value === 'string' ? payload.value.trim() : ''
+
+  if (!value || value.length > 65_536) {
+    return { error: 'Enter a credential before saving.', ok: false }
+  }
+
+  try {
+    await handleHermesApiRequest({
+      body: { key: pending.envVar, value },
+      method: 'PUT',
+      path: '/api/env',
+      profile: pending.profile
+    })
+    finishCredentialCapture(pending, { status: 'saved' })
+
+    return { ok: true }
+  } catch (error) {
+    return { error: error instanceof Error ? error.message : 'Hermes could not save this credential.', ok: false }
+  }
+})
+
+ipcMain.handle('hermes:credential:cancel', event => {
+  const pending = pendingCredentialCapture
+
+  if (pending && pending.window.webContents.id === event.sender.id) {
+    finishCredentialCapture(pending, { status: 'cancelled' })
+  }
+
+  return { ok: true }
+})
+
 const QUICK_ENTRY_CONFIG_PATH = path.join(app.getPath('userData'), 'quick-entry.json')
 
 let quickEntryWindow = null

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -1,5 +1,18 @@
 import { contextBridge, ipcRenderer, webFrame, webUtils } from 'electron'
 
+const isCredentialWindow = new URLSearchParams(globalThis.location.search).get('win') === 'credential'
+
+if (isCredentialWindow) {
+  // Deliberately expose ONLY the credential-window bridge. The secret entry
+  // renderer cannot reach chat, gateway sockets, files, clipboard, plugins,
+  // or the general Desktop API surface.
+  contextBridge.exposeInMainWorld('hermesCredential', {
+    getRequest: () => ipcRenderer.invoke('hermes:credential:request:get'),
+    submit: value => ipcRenderer.invoke('hermes:credential:submit', { value }),
+    cancel: () => ipcRenderer.invoke('hermes:credential:cancel')
+  })
+} else {
+
 // Which translucency the OS can back. Asked synchronously because the renderer
 // needs it before its first paint, and answered by main because deciding it
 // needs `os.release()` — a sandboxed preload may only require electron, events,
@@ -37,6 +50,9 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
     return () => ipcRenderer.removeListener('hermes:browser-popout:closed', listener)
   },
   claimAmbientCue: key => ipcRenderer.invoke('hermes:ambient:claim', key),
+  secureCredential: {
+    capture: request => ipcRenderer.invoke('hermes:credential:capture', request)
+  },
   wakeIndicator: {
     getState: () => ipcRenderer.invoke('hermes:wake-indicator:get'),
     setState: state => ipcRenderer.send('hermes:wake-indicator:set', state),
@@ -529,3 +545,4 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
     return () => ipcRenderer.removeListener('hermes:open-find-bar', listener)
   }
 })
+}

--- a/apps/desktop/src/app/secure-credential/secure-credential-root.tsx
+++ b/apps/desktop/src/app/secure-credential/secure-credential-root.tsx
@@ -1,0 +1,101 @@
+import { type FormEvent, StrictMode, useEffect, useState } from 'react'
+import { createRoot } from 'react-dom/client'
+
+function SecureCredentialEntry() {
+  const bridge = window.hermesCredential
+  const [request, setRequest] = useState<{ envVar: string; prompt: string } | null>(null)
+  const [value, setValue] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    void bridge?.getRequest().then(setRequest).catch(() => setError('Credential request is no longer available.'))
+  }, [bridge])
+
+  async function submit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+
+    if (!bridge || !value) {
+      return
+    }
+
+    setBusy(true)
+    setError('')
+
+    try {
+      const result = await bridge.submit(value)
+
+      if (!result.ok) {
+        setError(result.error || 'Hermes could not save this credential.')
+        setBusy(false)
+      }
+    } catch {
+      setError('Hermes could not save this credential.')
+      setBusy(false)
+    }
+  }
+
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-background p-5 text-foreground">
+      <section className="w-full max-w-md rounded-xl border border-border bg-card p-5 shadow-2xl">
+        <div className="mb-4 flex items-start gap-3">
+          <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-primary/10 text-xl">🔐</div>
+          <div>
+            <h1 className="text-base font-semibold">Secure credential entry</h1>
+            <p className="mt-1 text-sm text-muted-foreground">
+              This value is saved directly by Hermes Desktop. It is not added to chat or shown to the AI.
+            </p>
+          </div>
+        </div>
+
+        <div className="mb-4 rounded-lg bg-muted/60 p-3">
+          <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Saving as</div>
+          <div className="mt-1 break-all font-mono text-sm">{request?.envVar || 'Loading…'}</div>
+          {request?.prompt ? <p className="mt-2 text-sm text-muted-foreground">{request.prompt}</p> : null}
+        </div>
+
+        <form className="grid gap-3" onSubmit={submit}>
+          <input
+            aria-label={request?.envVar || 'Credential'}
+            autoComplete="off"
+            autoFocus
+            className="h-10 rounded-md border border-input bg-background px-3 text-sm outline-none focus:ring-2 focus:ring-ring"
+            disabled={busy || !request}
+            onChange={event => setValue(event.target.value)}
+            placeholder="Paste token or password"
+            spellCheck={false}
+            type="password"
+            value={value}
+          />
+          {error ? <p className="text-sm text-destructive">{error}</p> : null}
+          <div className="flex justify-end gap-2 pt-1">
+            <button
+              className="h-9 rounded-md px-3 text-sm hover:bg-muted"
+              disabled={busy}
+              onClick={() => void bridge?.cancel()}
+              type="button"
+            >
+              Cancel
+            </button>
+            <button
+              className="h-9 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground disabled:opacity-50"
+              disabled={busy || !request || !value}
+              type="submit"
+            >
+              {busy ? 'Saving…' : 'Save securely'}
+            </button>
+          </div>
+        </form>
+      </section>
+    </main>
+  )
+}
+
+export function mountSecureCredential(): void {
+  document.title = 'Secure Credential Entry — Hermes Desktop'
+  createRoot(document.getElementById('root')!).render(
+    <StrictMode>
+      <SecureCredentialEntry />
+    </StrictMode>
+  )
+}

--- a/apps/desktop/src/app/secure-credential/secure-credential-root.tsx
+++ b/apps/desktop/src/app/secure-credential/secure-credential-root.tsx
@@ -1,15 +1,46 @@
-import { type FormEvent, StrictMode, useEffect, useState } from 'react'
+import { type FormEvent, StrictMode, useEffect, useMemo, useState } from 'react'
 import { createRoot } from 'react-dom/client'
+
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Loader } from '@/components/ui/loader'
+import { TRANSLATIONS } from '@/i18n'
+import { normalizeLocale } from '@/i18n/languages'
+import { Lock } from '@/lib/icons'
+
+interface CredentialRequest {
+  envVar: string
+  locale: string
+  prompt: string
+}
 
 function SecureCredentialEntry() {
   const bridge = window.hermesCredential
-  const [request, setRequest] = useState<{ envVar: string; prompt: string } | null>(null)
+  const [request, setRequest] = useState<CredentialRequest | null>(null)
   const [value, setValue] = useState('')
   const [busy, setBusy] = useState(false)
-  const [error, setError] = useState('')
+  const [loadFailed, setLoadFailed] = useState(false)
+  const [saveError, setSaveError] = useState('')
+  const locale = normalizeLocale(request?.locale)
+  const copy = useMemo(() => TRANSLATIONS[locale].prompts.secureCredential, [locale])
 
   useEffect(() => {
-    void bridge?.getRequest().then(setRequest).catch(() => setError('Credential request is no longer available.'))
+    document.documentElement.lang = locale
+    document.documentElement.dir = locale === 'ar' ? 'rtl' : 'ltr'
+    document.title = copy.title
+  }, [copy.title, locale])
+
+  useEffect(() => {
+    if (!bridge) {
+      setLoadFailed(true)
+
+      return
+    }
+
+    void bridge
+      .getRequest()
+      .then(setRequest)
+      .catch(() => setLoadFailed(true))
   }, [bridge])
 
   async function submit(event: FormEvent<HTMLFormElement>) {
@@ -20,79 +51,82 @@ function SecureCredentialEntry() {
     }
 
     setBusy(true)
-    setError('')
+    setSaveError('')
 
     try {
       const result = await bridge.submit(value)
 
       if (!result.ok) {
-        setError(result.error || 'Hermes could not save this credential.')
+        setSaveError(result.error || copy.saveFailed)
         setBusy(false)
       }
     } catch {
-      setError('Hermes could not save this credential.')
+      setSaveError(copy.saveFailed)
       setBusy(false)
     }
   }
 
   return (
     <main className="flex min-h-screen items-center justify-center bg-background p-5 text-foreground">
-      <section className="w-full max-w-md rounded-xl border border-border bg-card p-5 shadow-2xl">
-        <div className="mb-4 flex items-start gap-3">
-          <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-primary/10 text-xl">🔐</div>
+      <section className="w-full max-w-md border border-(--stroke-nous) bg-background p-5 shadow-nous">
+        <header className="mb-5 flex items-start gap-3">
+          <Lock aria-hidden="true" className="mt-0.5 shrink-0 text-primary" />
           <div>
-            <h1 className="text-base font-semibold">Secure credential entry</h1>
-            <p className="mt-1 text-sm text-muted-foreground">
-              This value is saved directly by Hermes Desktop. It is not added to chat or shown to the AI.
-            </p>
+            <h1 className="text-base font-semibold">{copy.title}</h1>
+            <p className="mt-1 text-sm text-(--ui-text-secondary)">{copy.description}</p>
           </div>
-        </div>
+        </header>
 
-        <div className="mb-4 rounded-lg bg-muted/60 p-3">
-          <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Saving as</div>
-          <div className="mt-1 break-all font-mono text-sm">{request?.envVar || 'Loading…'}</div>
-          {request?.prompt ? <p className="mt-2 text-sm text-muted-foreground">{request.prompt}</p> : null}
-        </div>
-
-        <form className="grid gap-3" onSubmit={submit}>
-          <input
-            aria-label={request?.envVar || 'Credential'}
-            autoComplete="off"
-            autoFocus
-            className="h-10 rounded-md border border-input bg-background px-3 text-sm outline-none focus:ring-2 focus:ring-ring"
-            disabled={busy || !request}
-            onChange={event => setValue(event.target.value)}
-            placeholder="Paste token or password"
-            spellCheck={false}
-            type="password"
-            value={value}
-          />
-          {error ? <p className="text-sm text-destructive">{error}</p> : null}
-          <div className="flex justify-end gap-2 pt-1">
-            <button
-              className="h-9 rounded-md px-3 text-sm hover:bg-muted"
-              disabled={busy}
-              onClick={() => void bridge?.cancel()}
-              type="button"
-            >
-              Cancel
-            </button>
-            <button
-              className="h-9 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground disabled:opacity-50"
-              disabled={busy || !request || !value}
-              type="submit"
-            >
-              {busy ? 'Saving…' : 'Save securely'}
-            </button>
+        {loadFailed ? (
+          <p className="text-sm text-destructive" role="alert">
+            {copy.unavailable}
+          </p>
+        ) : !request ? (
+          <div className="flex justify-center py-5">
+            <Loader label={copy.loading} type="lemniscate-bloom" />
           </div>
-        </form>
+        ) : (
+          <>
+            <div className="mb-4 border-t border-(--ui-stroke-tertiary) pt-4">
+              <div className="text-xs font-medium uppercase tracking-wide text-(--ui-text-tertiary)">
+                {copy.savingAs}
+              </div>
+              <div className="mt-1 break-all font-mono text-sm">{request.envVar}</div>
+              {request.prompt ? <p className="mt-2 text-sm text-(--ui-text-secondary)">{request.prompt}</p> : null}
+            </div>
+
+            <form className="grid gap-3" onSubmit={submit}>
+              <Input
+                aria-label={request.envVar}
+                autoFocus
+                disabled={busy}
+                onChange={event => setValue(event.target.value)}
+                placeholder={copy.placeholder}
+                type="password"
+                value={value}
+              />
+              {saveError ? (
+                <p className="text-sm text-destructive" role="alert">
+                  {saveError}
+                </p>
+              ) : null}
+              <div className="flex justify-end gap-2 pt-1">
+                <Button disabled={busy} onClick={() => void bridge?.cancel()} type="button" variant="text">
+                  {copy.cancel}
+                </Button>
+                <Button disabled={busy || !value} type="submit">
+                  {busy ? copy.saving : copy.save}
+                </Button>
+              </div>
+            </form>
+          </>
+        )}
       </section>
     </main>
   )
 }
 
 export function mountSecureCredential(): void {
-  document.title = 'Secure Credential Entry — Hermes Desktop'
   createRoot(document.getElementById('root')!).render(
     <StrictMode>
       <SecureCredentialEntry />

--- a/apps/desktop/src/components/prompt-overlays.test.tsx
+++ b/apps/desktop/src/components/prompt-overlays.test.tsx
@@ -69,6 +69,7 @@ describe('PromptOverlays', () => {
     await waitFor(() => expect($secretRequest.get()).toBeNull())
     expect(capture).toHaveBeenCalledWith({
       envVar: 'TEST_SECRET',
+      locale: 'en',
       profile: 'default',
       prompt: 'Paste a secret',
       requestId: 'secret-1'

--- a/apps/desktop/src/components/prompt-overlays.test.tsx
+++ b/apps/desktop/src/components/prompt-overlays.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { I18nProvider } from '@/i18n'
 import { $gateway } from '@/store/gateway'
@@ -20,11 +20,19 @@ function renderPrompts(sessionId: string | null = 's1') {
   )
 }
 
+beforeEach(() => {
+  Object.defineProperty(window, 'hermesDesktop', {
+    configurable: true,
+    value: {}
+  })
+})
+
 afterEach(() => {
   cleanup()
   clearAllPrompts()
   $activeSessionId.set(null)
   $gateway.set(null)
+  delete window.hermesDesktop.secureCredential
   vi.clearAllMocks()
 })
 
@@ -47,21 +55,45 @@ describe('PromptOverlays', () => {
     expect(notifyError).not.toHaveBeenCalled()
   })
 
-  it('dismisses a stale secret dialog when the gateway no longer has the value request', async () => {
-    const request = vi.fn().mockRejectedValue(new Error('no pending value request'))
+  it('opens native credential capture and sends only a stored receipt to the gateway', async () => {
+    const request = vi.fn().mockResolvedValue({ status: 'ok' })
+    const capture = vi.fn().mockResolvedValue({ status: 'saved' })
 
     $activeSessionId.set('s1')
     $gateway.set({ request } as never)
+    window.hermesDesktop.secureCredential = { capture }
     setSecretRequest({ envVar: 'TEST_SECRET', prompt: 'Paste a secret', requestId: 'secret-1', sessionId: 's1' })
 
     renderPrompts()
 
-    expect(screen.getByText('TEST_SECRET')).toBeTruthy()
+    await waitFor(() => expect($secretRequest.get()).toBeNull())
+    expect(capture).toHaveBeenCalledWith({
+      envVar: 'TEST_SECRET',
+      profile: 'default',
+      prompt: 'Paste a secret',
+      requestId: 'secret-1'
+    })
+    expect(request).toHaveBeenCalledWith('secret.respond', {
+      request_id: 'secret-1',
+      value: { stored: true }
+    })
+    expect(screen.queryByLabelText('TEST_SECRET')).toBeNull()
+    expect(notifyError).not.toHaveBeenCalled()
+  })
 
-    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+  it('maps cancellation in the native credential window to an empty response', async () => {
+    const request = vi.fn().mockResolvedValue({ status: 'ok' })
+    const capture = vi.fn().mockResolvedValue({ status: 'cancelled' })
+
+    $activeSessionId.set('s1')
+    $gateway.set({ request } as never)
+    window.hermesDesktop.secureCredential = { capture }
+    setSecretRequest({ envVar: 'TEST_SECRET', prompt: 'Paste a secret', requestId: 'secret-2', sessionId: 's1' })
+
+    renderPrompts()
 
     await waitFor(() => expect($secretRequest.get()).toBeNull())
-    expect(request).toHaveBeenCalledWith('secret.respond', { request_id: 'secret-1', value: '' })
+    expect(request).toHaveBeenCalledWith('secret.respond', { request_id: 'secret-2', value: '' })
     expect(notifyError).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/components/prompt-overlays.tsx
+++ b/apps/desktop/src/components/prompt-overlays.tsx
@@ -142,7 +142,7 @@ function SudoDialog({ sessionId }: { sessionId: string | null }) {
 const activeCredentialCaptures = new Map<string, Promise<void>>()
 
 function SecretDialog({ sessionId }: { sessionId: string | null }) {
-  const { t } = useI18n()
+  const { locale, t } = useI18n()
   const copy = t.prompts
   const $request = useMemo(() => sessionSecretRequest(sessionId), [sessionId])
   const request = useStore($request)
@@ -166,6 +166,7 @@ function SecretDialog({ sessionId }: { sessionId: string | null }) {
       try {
         const result = await capture({
           envVar: request.envVar,
+          locale,
           profile,
           prompt: request.prompt,
           requestId: request.requestId
@@ -197,7 +198,7 @@ function SecretDialog({ sessionId }: { sessionId: string | null }) {
     })()
 
     activeCredentialCaptures.set(request.requestId, task)
-  }, [copy.gatewayDisconnected, copy.secretSendFailed, gateway, profile, request])
+  }, [copy.gatewayDisconnected, copy.secretSendFailed, gateway, locale, profile, request])
 
   // The actual input lives in the dedicated native window. Rendering no form
   // here ensures password managers, DOM inspection, and chat capture cannot

--- a/apps/desktop/src/components/prompt-overlays.tsx
+++ b/apps/desktop/src/components/prompt-overlays.tsx
@@ -17,9 +17,10 @@ import { Input } from '@/components/ui/input'
 import { useI18n } from '@/i18n'
 import { isMissingPendingPromptRequest } from '@/lib/gateway-rpc'
 import { triggerHaptic } from '@/lib/haptics'
-import { KeyRound, Loader2, Lock } from '@/lib/icons'
+import { Loader2, Lock } from '@/lib/icons'
 import { $gateway } from '@/store/gateway'
 import { notifyError } from '@/store/notifications'
+import { $activeProfile } from '@/store/profile'
 import { clearSecretRequest, clearSudoRequest, sessionSecretRequest, sessionSudoRequest } from '@/store/prompts'
 
 // Renders the modal mid-turn prompts the gateway raises and waits on: sudo
@@ -138,40 +139,49 @@ function SudoDialog({ sessionId }: { sessionId: string | null }) {
   )
 }
 
+const activeCredentialCaptures = new Map<string, Promise<void>>()
+
 function SecretDialog({ sessionId }: { sessionId: string | null }) {
   const { t } = useI18n()
   const copy = t.prompts
   const $request = useMemo(() => sessionSecretRequest(sessionId), [sessionId])
   const request = useStore($request)
   const gateway = useStore($gateway)
-  const [value, setValue] = useState('')
-  const [submitting, setSubmitting] = useState(false)
+  const profile = useStore($activeProfile)
 
   useEffect(() => {
-    setValue('')
-    setSubmitting(false)
-  }, [request?.requestId])
+    if (!request || activeCredentialCaptures.has(request.requestId)) {
+      return
+    }
 
-  const send = useCallback(
-    async (secret: string) => {
-      if (!request) {
-        return
-      }
+    const capture = window.hermesDesktop.secureCredential?.capture
 
-      if (!gateway) {
-        notifyError(new Error(copy.gatewayDisconnected), copy.secretSendFailed)
+    if (!gateway || !capture) {
+      notifyError(new Error(copy.gatewayDisconnected), copy.secretSendFailed)
 
-        return
-      }
+      return
+    }
 
-      setSubmitting(true)
-
+    const task = (async () => {
       try {
+        const result = await capture({
+          envVar: request.envVar,
+          profile,
+          prompt: request.prompt,
+          requestId: request.requestId
+        })
+
+        // The gateway receives only a storage receipt. The credential value was
+        // already written by Electron main and never entered this renderer.
         await gateway.request<{ status?: string }>('secret.respond', {
           request_id: request.requestId,
-          value: secret
+          value: result.status === 'saved' ? { stored: true } : ''
         })
-        triggerHaptic('submit')
+
+        if (result.status === 'saved') {
+          triggerHaptic('submit')
+        }
+
         clearSecretRequest(request.sessionId, request.requestId)
       } catch (error) {
         if (isMissingPendingPromptRequest(error, 'value')) {
@@ -181,62 +191,18 @@ function SecretDialog({ sessionId }: { sessionId: string | null }) {
         }
 
         notifyError(error, copy.secretSendFailed)
-        setSubmitting(false)
+      } finally {
+        activeCredentialCaptures.delete(request.requestId)
       }
-    },
-    [copy.gatewayDisconnected, copy.secretSendFailed, gateway, request]
-  )
+    })()
 
-  const onOpenChange = useCallback(
-    (open: boolean) => {
-      if (!open && !submitting && request) {
-        void send('')
-      }
-    },
-    [request, send, submitting]
-  )
+    activeCredentialCaptures.set(request.requestId, task)
+  }, [copy.gatewayDisconnected, copy.secretSendFailed, gateway, profile, request])
 
-  const onSubmit = useCallback(
-    (event: FormEvent<HTMLFormElement>) => {
-      event.preventDefault()
-      void send(value)
-    },
-    [send, value]
-  )
-
-  if (!request) {
-    return null
-  }
-
-  return (
-    <Dialog onOpenChange={onOpenChange} open>
-      <DialogContent showCloseButton={false}>
-        <DialogHeader>
-          <DialogTitle icon={KeyRound}>{request.envVar || copy.secretTitle}</DialogTitle>
-          <DialogDescription>{request.prompt || copy.secretDesc}</DialogDescription>
-        </DialogHeader>
-
-        <form className="grid gap-3" onSubmit={onSubmit}>
-          <Input
-            autoFocus
-            disabled={submitting}
-            onChange={event => setValue(event.target.value)}
-            placeholder={request.envVar || copy.secretPlaceholder}
-            type="password"
-            value={value}
-          />
-          <DialogFooter>
-            <Button disabled={submitting} onClick={() => void send('')} type="button" variant="ghost">
-              {t.common.cancel}
-            </Button>
-            <Button disabled={submitting || !value} type="submit">
-              {submitting ? <Loader2 className="size-3.5 animate-spin" /> : t.common.send}
-            </Button>
-          </DialogFooter>
-        </form>
-      </DialogContent>
-    </Dialog>
-  )
+  // The actual input lives in the dedicated native window. Rendering no form
+  // here ensures password managers, DOM inspection, and chat capture cannot
+  // observe a credential field in the agent-facing renderer.
+  return null
 }
 
 /** Mid-turn prompt surfaces for ONE session. Mounted by both the primary chat

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -15,7 +15,7 @@ export {}
 declare global {
   interface Window {
     hermesCredential?: {
-      getRequest: () => Promise<{ envVar: string; prompt: string }>
+      getRequest: () => Promise<{ envVar: string; locale: string; prompt: string }>
       submit: (value: string) => Promise<{ ok: boolean; error?: string }>
       cancel: () => Promise<{ ok: boolean }>
     }
@@ -80,6 +80,7 @@ declare global {
       secureCredential?: {
         capture: (request: {
           envVar: string
+          locale?: string
           profile?: null | string
           prompt?: string
           requestId: string

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -14,6 +14,11 @@ export {}
 
 declare global {
   interface Window {
+    hermesCredential?: {
+      getRequest: () => Promise<{ envVar: string; prompt: string }>
+      submit: (value: string) => Promise<{ ok: boolean; error?: string }>
+      cancel: () => Promise<{ ok: boolean }>
+    }
     hermesDesktop: {
       // Resolve a backend connection. Omit `profile` (or pass the primary) for
       // the window's backend; pass a named profile to lazily spawn/reuse that
@@ -72,6 +77,14 @@ declare global {
       // reply). Resolves true for the first window to claim a key, false for
       // peers — so N open windows don't all fire the same cue.
       claimAmbientCue: (key: string) => Promise<boolean>
+      secureCredential?: {
+        capture: (request: {
+          envVar: string
+          profile?: null | string
+          prompt?: string
+          requestId: string
+        }) => Promise<{ status: 'busy' | 'cancelled' | 'saved' }>
+      }
       wakeIndicator?: {
         getState: () => Promise<WakeIndicatorState>
         setState: (state: WakeIndicatorState) => void

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -2758,7 +2758,19 @@ export const ar = defineLocale({
     sudoPlaceholder: 'كلمة المرور',
     secretTitle: 'مطلوب سر',
     secretDesc: 'أدخل القيمة المطلوبة لمتابعة المهمة.',
-    secretPlaceholder: 'القيمة السرية'
+    secretPlaceholder: 'القيمة السرية',
+    secureCredential: {
+      title: 'إدخال آمن لبيانات الاعتماد',
+      description: 'يحفظ Hermes Desktop هذه القيمة مباشرة. لا تُضاف إلى الدردشة ولا تظهر للذكاء الاصطناعي.',
+      savingAs: 'الحفظ باسم',
+      unavailable: 'لم يعد طلب بيانات الاعتماد متاحا.',
+      saveFailed: 'تعذر على Hermes حفظ بيانات الاعتماد.',
+      placeholder: 'ألصق الرمز أو كلمة المرور',
+      cancel: 'إلغاء',
+      save: 'حفظ بأمان',
+      saving: 'جار الحفظ',
+      loading: 'جار تحميل طلب بيانات الاعتماد'
+    }
   },
   desktop: {
     audioReadFailed: 'فشلت قراءة الصوت',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -3395,7 +3395,19 @@ export const en: Translations = {
     sudoPlaceholder: 'sudo password',
     secretTitle: 'Secret required',
     secretDesc: 'Hermes needs a credential to continue.',
-    secretPlaceholder: 'secret value'
+    secretPlaceholder: 'secret value',
+    secureCredential: {
+      title: 'Secure credential entry',
+      description: 'Hermes Desktop saves this value directly. It is not added to chat or shown to the AI.',
+      savingAs: 'Saving as',
+      unavailable: 'Credential request is no longer available.',
+      saveFailed: 'Hermes could not save this credential.',
+      placeholder: 'Paste token or password',
+      cancel: 'Cancel',
+      save: 'Save securely',
+      saving: 'Saving',
+      loading: 'Loading credential request'
+    }
   },
 
   desktop: {

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -3017,7 +3017,19 @@ export const ja = defineLocale({
     sudoPlaceholder: 'sudo パスワード',
     secretTitle: 'シークレットが必要です',
     secretDesc: 'Hermes は続行するための認証情報が必要です。',
-    secretPlaceholder: 'シークレット値'
+    secretPlaceholder: 'シークレット値',
+    secureCredential: {
+      title: '認証情報を安全に入力',
+      description: 'Hermes Desktop がこの値を直接保存します。チャットに追加されたり、AI に表示されたりしません。',
+      savingAs: '保存先',
+      unavailable: '認証情報のリクエストは利用できなくなりました。',
+      saveFailed: 'Hermes はこの認証情報を保存できませんでした。',
+      placeholder: 'トークンまたはパスワードを貼り付け',
+      cancel: 'キャンセル',
+      save: '安全に保存',
+      saving: '保存中',
+      loading: '認証情報のリクエストを読み込み中'
+    }
   },
 
   desktop: {

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2919,6 +2919,18 @@ export interface Translations {
     secretTitle: string
     secretDesc: string
     secretPlaceholder: string
+    secureCredential: {
+      title: string
+      description: string
+      savingAs: string
+      unavailable: string
+      saveFailed: string
+      placeholder: string
+      cancel: string
+      save: string
+      saving: string
+      loading: string
+    }
   }
 
   desktop: {

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2892,7 +2892,19 @@ export const zhHant = defineLocale({
     sudoPlaceholder: 'sudo 密碼',
     secretTitle: '需要密鑰',
     secretDesc: 'Hermes 需要一個憑證才能繼續。',
-    secretPlaceholder: '密鑰值'
+    secretPlaceholder: '密鑰值',
+    secureCredential: {
+      title: '安全輸入憑證',
+      description: 'Hermes Desktop 會直接儲存此值。它不會加入聊天，也不會顯示給 AI。',
+      savingAs: '儲存為',
+      unavailable: '憑證要求已無法使用。',
+      saveFailed: 'Hermes 無法儲存此憑證。',
+      placeholder: '貼上權杖或密碼',
+      cancel: '取消',
+      save: '安全儲存',
+      saving: '正在儲存',
+      loading: '正在載入憑證要求'
+    }
   },
 
   desktop: {

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -3540,7 +3540,19 @@ export const zh: Translations = {
     sudoPlaceholder: 'sudo 密码',
     secretTitle: '需要密钥',
     secretDesc: 'Hermes 需要一个凭据才能继续。',
-    secretPlaceholder: '密钥值'
+    secretPlaceholder: '密钥值',
+    secureCredential: {
+      title: '安全输入凭据',
+      description: 'Hermes Desktop 会直接保存此值。它不会添加到聊天中，也不会向 AI 显示。',
+      savingAs: '保存为',
+      unavailable: '凭据请求已不可用。',
+      saveFailed: 'Hermes 无法保存此凭据。',
+      placeholder: '粘贴令牌或密码',
+      cancel: '取消',
+      save: '安全保存',
+      saving: '正在保存',
+      loading: '正在加载凭据请求'
+    }
   },
 
   desktop: {

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -51,6 +51,10 @@ if (winParam === 'hud') {
 
 if (winParam === 'overlay') {
   void import('./app/pet-overlay/overlay-root').then(({ mountPetOverlay }) => mountPetOverlay())
+} else if (winParam === 'credential') {
+  void import('./app/secure-credential/secure-credential-root').then(({ mountSecureCredential }) =>
+    mountSecureCredential()
+  )
 } else if (winParam === 'quick') {
   void import('./app/quick-entry/quick-entry-root').then(({ mountQuickEntry }) => mountQuickEntry())
 } else if (winParam === 'wake') {

--- a/tests/tui_gateway/test_secure_credential_receipt.py
+++ b/tests/tui_gateway/test_secure_credential_receipt.py
@@ -1,0 +1,59 @@
+"""Desktop secure-credential receipts must never be mistaken for secret text."""
+
+from __future__ import annotations
+
+
+def _install_secret_callback(monkeypatch, block_result):
+    from tools import project_tools, skills_tool, terminal_tool
+    from tui_gateway import server
+
+    captured = {}
+    monkeypatch.setattr(terminal_tool, "set_sudo_password_callback", lambda _callback: None)
+    monkeypatch.setattr(project_tools, "set_project_workspace_callback", lambda _callback: None)
+    monkeypatch.setattr(
+        skills_tool,
+        "set_secret_capture_callback",
+        lambda callback: captured.setdefault("callback", callback),
+    )
+    monkeypatch.setattr(server, "_block", lambda *_args, **_kwargs: block_result)
+
+    server._wire_callbacks("session-1")
+    return captured["callback"]
+
+
+def test_stored_receipt_returns_success_without_resaving(monkeypatch):
+    from hermes_cli import config
+
+    def forbidden(*_args, **_kwargs):
+        raise AssertionError("the non-secret receipt was passed to secret storage")
+
+    monkeypatch.setattr(config, "save_env_value_secure", forbidden)
+    callback = _install_secret_callback(monkeypatch, {"stored": True})
+
+    result = callback("A", "Enter a credential")
+
+    assert result == {
+        "success": True,
+        "stored_as": "A",
+        "validated": False,
+        "skipped": False,
+        "message": "ok",
+    }
+
+
+def test_legacy_string_response_still_uses_secure_storage(monkeypatch):
+    from hermes_cli import config
+
+    saved = []
+
+    def save(key, value):
+        saved.append((key, value))
+        return {"success": True, "stored_as": key, "validated": True}
+
+    monkeypatch.setattr(config, "save_env_value_secure", save)
+    callback = _install_secret_callback(monkeypatch, "  secret with spaces  ")
+
+    result = callback("API_KEY", "Enter a credential")
+
+    assert saved == [("API_KEY", "  secret with spaces  ")]
+    assert result["skipped"] is False

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -8412,6 +8412,17 @@ def _wire_callbacks(sid: str):
         if metadata:
             pl["metadata"] = metadata
         val = _block("secret.request", sid, pl)
+        if isinstance(val, dict) and val.get("stored") is True:
+            # Hermes Desktop's separate credential window already persisted the
+            # value through the profile-aware /api/env endpoint. Only this
+            # non-secret receipt crosses the agent-facing gateway connection.
+            return {
+                "success": True,
+                "stored_as": env_var,
+                "validated": False,
+                "skipped": False,
+                "message": "ok",
+            }
         if not val:
             return {
                 "success": True,


### PR DESCRIPTION
## What this adds

Adds a separate Hermes Desktop credential window for API keys, passwords, and tokens requested by skills.

The credential is:

- Entered outside the chat interface
- Captured in an isolated Electron window
- Persisted through the profile-aware local environment endpoint
- Replaced with a non-secret `{ stored: true }` receipt before the gateway resumes the agent
- Never inserted into the chat transcript or model-facing response

## Why

Non-technical users should not need to edit `.env` files manually or paste credentials into an AI conversation. This provides a human-controlled credential boundary while allowing the paused skill workflow to continue.

## Security boundary

This change keeps credential values outside the chat/model path. It does not introduce an encrypted vault: environment values retain Hermes' existing local `.env` storage behavior.

## Verification

- Focused prompt-overlay UI tests: 3/3 passed
- Full desktop TypeScript typecheck passed
- Full desktop lint passed with 0 errors (pre-existing warnings remain)
- Packaged Windows build launched successfully
- Required-variable detection opened the separate secure-entry window
- Local fallback secret scan found no high-confidence findings
- Final manual save-and-resume canary verification is pending

## Follow-up

A future storage-provider abstraction could support Windows Credential Manager, DPAPI, or 1Password instead of plaintext `.env` persistence.