### PR TITLE
fix(cron): profile_routes rescue for satellite-profile delivery preflight

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -5146,6 +5146,66 @@ def _preflight_check_provider_key(job: dict, cfg: dict) -> Optional[str]:
     return None
 
 
+def _delivery_platform_routed_from_primary_gateway(platform_name: str) -> bool:
+    """True when the primary gateway routes this platform to the profile the
+    scheduler is currently serving.
+
+    Under ``gateway.multiplex_profiles`` a satellite profile's cron jobs are
+    ticked by the primary gateway's in-process ticker (#69377) and delivered
+    through the primary gateway's live adapters — the satellite home never
+    holds the platform credentials itself (giving it a token of its own is a
+    ``duplicate_credential`` fatal). ``_preflight_check_delivery`` loads the
+    gateway config of the job's OWN home, where such a platform correctly
+    reads as unconnected; consulting the primary home's ``profile_routes``
+    keeps routed satellite jobs from being permanently false-blocked (#97476).
+    Reads the primary config.yaml directly (both the top-level and nested
+    ``gateway.`` forms) instead of ``load_gateway_config()`` so no primary
+    platform config leaks into this process's environment.
+    """
+    try:
+        from hermes_constants import get_default_hermes_root, get_hermes_home
+
+        primary_home = get_default_hermes_root()
+        current_home = Path(get_hermes_home())
+        if (
+            primary_home.expanduser().resolve(strict=False)
+            == current_home.expanduser().resolve(strict=False)
+        ):
+            return False  # this IS the primary home — nothing to consult
+        config_path = primary_home.expanduser() / "config.yaml"
+        if not config_path.exists():
+            return False
+
+        import yaml
+
+        with open(config_path, encoding="utf-8") as f:
+            raw = yaml.safe_load(f) or {}
+        routes_raw = raw.get("profile_routes")
+        if routes_raw is None and isinstance(raw.get("gateway"), dict):
+            routes_raw = raw["gateway"].get("profile_routes")
+        if not isinstance(routes_raw, list):
+            return False
+
+        from gateway.profile_routing import parse_profile_routes
+        from hermes_cli.profiles import profile_matches_home
+
+        platform_key = platform_name.lower()
+        for route in parse_profile_routes(routes_raw):
+            if (
+                route.enabled
+                and str(route.platform).lower() == platform_key
+                and profile_matches_home(route.profile)
+            ):
+                return True
+        return False
+    except Exception:
+        logger.debug(
+            "preflight: primary-gateway profile-route lookup unavailable",
+            exc_info=True,
+        )
+        return False
+
+
 def _preflight_check_delivery(job: dict) -> Optional[str]:
     """Check the job's delivery target(s) resolve to configured platforms.
 
@@ -5197,6 +5257,12 @@ def _preflight_check_delivery(job: dict) -> Optional[str]:
                 )
                 return None  # fail-open
         if platform_name.lower() not in connected:
+            # Multiplex escape hatch: a satellite profile whose deliveries
+            # are routed by the primary gateway's profile_routes is served
+            # by the primary's adapters, so its own unconnected reading is
+            # a false block (#97476).
+            if _delivery_platform_routed_from_primary_gateway(platform_name):
+                continue
             return (
                 f"delivery platform '{platform_name}' has no gateway "
                 "credentials configured (not connected). Configure it via "

--- a/tests/cron/test_cron_multiplex_profile_route_preflight.py
+++ b/tests/cron/test_cron_multiplex_profile_route_preflight.py
@@ -1,0 +1,146 @@
+"""Multiplex profile_routes must rescue cron preflight from false blocks.
+
+Under ``gateway.multiplex_profiles`` the primary gateway's in-process ticker
+fires satellite-profile jobs and delivers them through the PRIMARY gateway's
+live adapters (#69377) — the satellite home intentionally holds no platform
+credentials of its own (a second token is a ``duplicate_credential`` fatal).
+``_preflight_check_delivery`` loads the gateway config of the job's OWN home,
+so the routed platform reads as unconnected there and the job was permanently
+blocked before any LLM call (#97476). The guard: when the primary home's
+``profile_routes`` routes the platform to the profile being served, the
+delivery is the primary gateway's to make — pass it through.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+
+from cron.scheduler import (
+    _delivery_platform_routed_from_primary_gateway,
+    _preflight_check_delivery,
+)
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+
+PRIMARY_YAML = {
+    "gateway": {
+        "multiplex_profiles": True,
+        "profile_routes": [
+            {
+                "name": "grant-topic",
+                "platform": "telegram",
+                "chat_id": "-1004306455751",
+                "thread_id": "14",
+                "profile": "grant",
+            }
+        ],
+    }
+}
+
+
+def _gateway_config(connected_values):
+    config = MagicMock()
+    config.get_connected_platforms.return_value = [
+        MagicMock(value=v) for v in connected_values
+    ]
+    return config
+
+
+@pytest.fixture
+def multiplex_homes(tmp_path, monkeypatch):
+    """A primary root whose config routes telegram→grant, plus the grant home.
+
+    ``get_default_hermes_root`` is patched so the primary config, the profiles
+    root, and ``get_profile_dir`` all resolve inside ``tmp_path``; the home
+    override reproduces exactly what the multiplex ticker does per profile.
+    """
+    root = tmp_path / "root"
+    grant_home = root / "profiles" / "grant"
+    grant_home.mkdir(parents=True)
+    (root / "config.yaml").write_text(yaml.safe_dump(PRIMARY_YAML), encoding="utf-8")
+    monkeypatch.setattr(
+        "hermes_constants.get_default_hermes_root", lambda: root
+    )
+    token = set_hermes_home_override(str(grant_home))
+    yield root, grant_home
+    reset_hermes_home_override(token)
+
+
+class TestRoutedSatellitePreflight:
+    def test_routed_platform_passes_preflight(self, multiplex_homes):
+        """telegram→grant route: a grant-profile telegram deliver passes."""
+        with patch("gateway.config.load_gateway_config",
+                   return_value=_gateway_config(set())):
+            assert _preflight_check_delivery(
+                {"deliver": "telegram:-1004306455751:14"}) is None
+
+    def test_unrouted_platform_still_blocked(self, multiplex_homes):
+        """The route rescues telegram only — discord stays blocked."""
+        with patch("gateway.config.load_gateway_config",
+                   return_value=_gateway_config(set())):
+            reason = _preflight_check_delivery({"deliver": "discord:12345"})
+            assert reason is not None
+            assert "discord" in reason
+
+    def test_route_for_another_profile_does_not_rescue(self, tmp_path, monkeypatch):
+        """A route naming a DIFFERENT profile is not this home's lifeline."""
+        root = tmp_path / "root"
+        other_home = root / "profiles" / "other"
+        other_home.mkdir(parents=True)
+        (root / "config.yaml").write_text(yaml.safe_dump(PRIMARY_YAML),
+                                          encoding="utf-8")
+        monkeypatch.setattr(
+            "hermes_constants.get_default_hermes_root", lambda: root
+        )
+        token = set_hermes_home_override(str(other_home))
+        try:
+            assert _delivery_platform_routed_from_primary_gateway("telegram") is False
+        finally:
+            reset_hermes_home_override(token)
+
+    def test_primary_home_itself_skips_route_lookup(self, multiplex_homes):
+        """Running as the primary home: no primary/secondary split to consult."""
+        root, _ = multiplex_homes
+        token = set_hermes_home_override(str(root))
+        try:
+            assert _delivery_platform_routed_from_primary_gateway("telegram") is False
+        finally:
+            reset_hermes_home_override(token)
+
+    def test_missing_primary_config_fails_closed(self, tmp_path, monkeypatch):
+        """No primary config.yaml readable: the rescue stays off (blocked)."""
+        root = tmp_path / "root"
+        grant_home = root / "profiles" / "grant"
+        grant_home.mkdir(parents=True)
+        monkeypatch.setattr(
+            "hermes_constants.get_default_hermes_root", lambda: root
+        )
+        token = set_hermes_home_override(str(grant_home))
+        try:
+            with patch("gateway.config.load_gateway_config",
+                       return_value=_gateway_config(set())):
+                reason = _preflight_check_delivery(
+                    {"deliver": "telegram:-1004306455751:14"})
+                assert reason is not None
+                assert "telegram" in reason
+        finally:
+            reset_hermes_home_override(token)
+
+    def test_disabled_route_does_not_rescue(self, tmp_path, monkeypatch):
+        """``enabled: false`` routes are inert — the block stands."""
+        root = tmp_path / "root"
+        grant_home = root / "profiles" / "grant"
+        grant_home.mkdir(parents=True)
+        cfg = yaml.safe_load(yaml.safe_dump(PRIMARY_YAML))
+        cfg["gateway"]["profile_routes"][0]["enabled"] = False
+        (root / "config.yaml").write_text(yaml.safe_dump(cfg), encoding="utf-8")
+        monkeypatch.setattr(
+            "hermes_constants.get_default_hermes_root", lambda: root
+        )
+        token = set_hermes_home_override(str(grant_home))
+        try:
+            assert _delivery_platform_routed_from_primary_gateway("telegram") is False
+        finally:
+            reset_hermes_home_override(token)


### PR DESCRIPTION
## What does this PR do?

Under `gateway.multiplex_profiles`, a satellite profile's cron jobs are ticked by the **primary** gateway's in-process ticker (#69377) and delivered through the **primary** gateway's live adapters — the satellite home intentionally holds no platform credentials of its own (installing a second token is a `duplicate_credential` fatal). `_preflight_check_delivery` loads the gateway config of the job's **own** home, so a platform delivered via `profile_routes` correctly reads as unconnected there, and the job is permanently blocked before any LLM call with a misleading "no gateway credentials configured (not connected)" error (#97476) — even though the exact same `deliver` string would be delivered fine by the primary's adapters.

This adds a `profile_routes` rescue: when the own-home config reports a platform unconnected, the preflight consults the **primary** home's `profile_routes`; an enabled route matching the platform that points at the profile currently being served means the delivery is the primary gateway's to make, so the check passes. The primary `config.yaml` is read directly (both the top-level and nested `gateway.` forms, mirroring `load_gateway_config`'s precedence) rather than via `load_gateway_config()`, so no primary platform config is loaded into the satellite process's environment. Lookup errors, missing configs, and disabled/foreign routes fail closed — the existing block stands.

## Related Issue

Fixes #97476

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/scheduler.py` — new `_delivery_platform_routed_from_primary_gateway()` helper: resolves the primary home via `get_default_hermes_root()`, short-circuits when the current home IS the primary, parses `profile_routes` (top-level + nested form) via the existing `gateway.profile_routing.parse_profile_routes`, and matches enabled routes on platform + `profile_matches_home` (the current scheduler home, i.e. the exact mechanism the multiplex ticker scopes ticks with).
- `cron/scheduler.py` — `_preflight_check_delivery` now calls the helper in the not-connected branch before returning the block, mirroring the existing relay-fronted rescue's placement.
- `tests/cron/test_cron_multiplex_profile_route_preflight.py` — 6 regression tests: routed satellite passes, unrouted platform still blocked, route for another profile does not rescue, primary home itself skips the lookup, missing primary config fails closed, disabled route is inert.

## How to Test

1. `uv run --extra dev python -m pytest tests/cron/test_cron_multiplex_profile_route_preflight.py -q` → **Observed result: 6 passed.**
2. `uv run --extra dev python -m pytest tests/cron/test_cron_relay_delivery_guards.py tests/cron/test_cron_bot_chat_delivery.py -q` → **Observed result: 27 passed** (the existing relay/bot-chat preflight behavior is unchanged).
3. `uv run --extra dev python -m pytest tests/cron/test_scheduler.py -q` → **Observed result: 103 passed.**
4. Manual shape of the rescued path (covered by test 1): primary `config.yaml` with `gateway.profile_routes: [{platform: telegram, profile: grant, ...}]`, home override set to the `grant` profile, own-home gateway config reporting nothing connected → `_preflight_check_delivery({"deliver": "telegram:-100...:14"})` returns `None` (previously returned the "not connected" block).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no new keys; `profile_routes` already exists)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
