### PR TITLE
fix(vision): re-encode webp to PNG on the auxiliary vision path (stb_image has no webp decoder)

### DIFF
--- a/tests/tools/test_vision_tools.py
+++ b/tests/tools/test_vision_tools.py
@@ -16,6 +16,9 @@ from tools.vision_tools import (
     _handle_vision_analyze,
     _determine_mime_type,
     _image_to_base64_data_url,
+    _normalize_to_supported_image,
+    _ANTHROPIC_SUPPORTED_MEDIA_TYPES,
+    _LOCAL_BACKEND_SUPPORTED_MEDIA_TYPES,
     _resize_image_for_vision,
     _image_exceeds_dimension,
     _EMBED_MAX_DIMENSION,
@@ -1121,3 +1124,77 @@ class TestVisionCpuBurstCap:
             f"analyses were serialized to the cap (peak={calls_peak}); only the "
             "encode burst should be bounded, not the whole call"
         )
+
+
+# ---------------------------------------------------------------------------
+# _normalize_to_supported_image — webp handling differs by backend
+# ---------------------------------------------------------------------------
+
+
+class TestWebpNormalization:
+    """webp decodes on cloud providers but NOT on llama.cpp / stb_image, which
+    has no webp decoder — ``stbi_load_from_memory`` returns NULL and llama-server
+    silently drops the image (HTTP 200, text-only, model says "no image").
+
+    So the native/cloud path keeps webp as-is (re-encoding a photo to PNG there
+    would inflate every turn's baked-in history), and only the auxiliary call —
+    one-shot, backend often local — normalizes webp to PNG.
+    """
+
+    def test_cloud_set_keeps_webp_local_set_drops_it(self):
+        assert "image/webp" in _ANTHROPIC_SUPPORTED_MEDIA_TYPES
+        assert "image/webp" not in _LOCAL_BACKEND_SUPPORTED_MEDIA_TYPES
+        # formats stb_image can decode stay in both
+        for m in ("image/jpeg", "image/png", "image/gif"):
+            assert m in _ANTHROPIC_SUPPORTED_MEDIA_TYPES
+            assert m in _LOCAL_BACKEND_SUPPORTED_MEDIA_TYPES
+
+    def test_webp_passes_through_on_default_cloud_set(self, tmp_path):
+        try:
+            from PIL import Image
+        except ImportError:
+            pytest.skip("Pillow not installed")
+        src = tmp_path / "photo.webp"
+        Image.new("RGB", (32, 24), (10, 120, 220)).save(src, "WEBP")
+
+        out_path, out_mime, err = _normalize_to_supported_image(src, "image/webp")
+
+        assert err is None
+        assert out_path == src
+        assert out_mime == "image/webp"
+
+    def test_webp_reencoded_to_png_for_local_backend(self, tmp_path):
+        try:
+            from PIL import Image
+        except ImportError:
+            pytest.skip("Pillow not installed")
+        src = tmp_path / "photo.webp"
+        Image.new("RGB", (32, 24), (10, 120, 220)).save(src, "WEBP")
+
+        out_path, out_mime, err = _normalize_to_supported_image(
+            src, "image/webp", _LOCAL_BACKEND_SUPPORTED_MEDIA_TYPES,
+        )
+
+        assert err is None
+        assert out_mime == "image/png"
+        assert out_path is not None and out_path != src
+        with Image.open(out_path) as reopened:
+            assert reopened.format == "PNG"
+            assert reopened.size == (32, 24)
+
+    def test_png_passes_through_untouched_on_both_sets(self, tmp_path):
+        try:
+            from PIL import Image
+        except ImportError:
+            pytest.skip("Pillow not installed")
+        src = tmp_path / "photo.png"
+        Image.new("RGB", (8, 8), (0, 0, 0)).save(src, "PNG")
+
+        for supported in (_ANTHROPIC_SUPPORTED_MEDIA_TYPES,
+                          _LOCAL_BACKEND_SUPPORTED_MEDIA_TYPES):
+            out_path, out_mime, err = _normalize_to_supported_image(
+                src, "image/png", supported,
+            )
+            assert err is None
+            assert out_path == src
+            assert out_mime == "image/png"

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -279,15 +279,27 @@ def _detect_image_mime_type_from_bytes(data: bytes) -> Optional[str]:
     return None
 
 
-# Media types the major vision providers (Anthropic in particular) accept for
-# inline base64 images.  Anything outside this set — SVG, BMP, TIFF, etc. — is
-# rejected with a non-retryable 400.  Because a vision tool-result is baked into
-# immutable conversation history and re-sent every turn, embedding an
-# unsupported media_type permanently wedges the session (retries re-send the
-# same bad bytes).  We MUST normalize to one of these before embedding.
+# Media types the major cloud vision providers (Anthropic in particular, plus
+# OpenAI / Gemini / Bedrock) accept as-is for inline base64 images.  Anything
+# outside this set — SVG, BMP, TIFF, HEIC — is rejected with a non-retryable
+# 400.  Because a vision tool-result is baked into immutable conversation
+# history and re-sent every turn, embedding an unsupported media_type
+# permanently wedges the session (retries re-send the same bad bytes).  We MUST
+# normalize to one of these before embedding on the native path.
 _ANTHROPIC_SUPPORTED_MEDIA_TYPES = frozenset(
     {"image/jpeg", "image/png", "image/gif", "image/webp"}
 )
+
+# Subset that a local llama.cpp / stb_image vision backend can actually decode.
+# stb_image has NO webp decoder: `stbi_load_from_memory` returns NULL for webp
+# and llama-server then silently drops the image part (HTTP 200, text-only
+# prompt, no image tokens, model says "there is no image" or hallucinates).
+# The auxiliary vision call — a one-shot request whose backend is often a local
+# model, and which is NOT baked into conversation history — normalizes against
+# this set instead, so webp gets re-encoded to PNG first.  The re-encode cost is
+# a single request; if the auxiliary backend is actually a cloud provider it's a
+# harmless no-op (PNG is universally accepted).
+_LOCAL_BACKEND_SUPPORTED_MEDIA_TYPES = _ANTHROPIC_SUPPORTED_MEDIA_TYPES - {"image/webp"}
 
 
 def _rasterize_svg_to_png(svg_path: Path, out_path: Path) -> bool:
@@ -338,9 +350,15 @@ def _rasterize_svg_to_png(svg_path: Path, out_path: Path) -> bool:
 
 
 def _normalize_to_supported_image(
-    image_path: Path, detected_mime: str
+    image_path: Path, detected_mime: str,
+    supported: frozenset = _ANTHROPIC_SUPPORTED_MEDIA_TYPES,
 ) -> tuple[Optional[Path], Optional[str], Optional[str]]:
-    """Ensure an image is in a vision-provider-supported format.
+    """Ensure an image is in a format the target vision backend can read.
+
+    ``supported`` is the set of media types that need no conversion — defaults
+    to what the cloud providers accept; the auxiliary vision call passes
+    ``_LOCAL_BACKEND_SUPPORTED_MEDIA_TYPES`` so webp is re-encoded for a local
+    stb_image backend that can't decode it.
 
     Returns a 3-tuple ``(path, mime, error)``:
       - If ``detected_mime`` is already supported: ``(image_path, detected_mime, None)``.
@@ -349,11 +367,11 @@ def _normalize_to_supported_image(
       - If conversion is impossible: ``(None, None, <error message>)``.
 
     SVG is rasterized to PNG (best-effort, soft deps).  Other raster formats
-    Pillow can read (BMP, TIFF, etc.) are re-encoded to PNG.  This runs BEFORE
-    the image is base64-embedded into conversation history, so an unsupported
-    media_type can never reach the provider and wedge the session.
+    Pillow can read (BMP, TIFF, webp, etc.) are re-encoded to PNG.  This runs
+    BEFORE the image is base64-embedded, so an undecodable media_type can never
+    reach the backend and wedge the session.
     """
-    if detected_mime in _ANTHROPIC_SUPPORTED_MEDIA_TYPES:
+    if detected_mime in supported:
         return image_path, detected_mime, None
 
     out_dir = get_hermes_dir("cache/vision", "temp_vision_images")
@@ -1485,11 +1503,13 @@ async def vision_analyze_tool(
         image_size_bytes = len(resolved.data)
         image_size_kb = image_size_bytes / 1024
         logger.info("Image ready (%.1f KB)", image_size_kb)
-        # Normalize unsupported formats (SVG, BMP, ...) to PNG. Vision providers
-        # reject these media types; convert before encoding. Offloaded — the
-        # rasterizers/Pillow are blocking.
+        # Normalize unsupported formats (SVG, BMP, webp, ...) to PNG. This is the
+        # auxiliary vision call — the backend is often a local llama.cpp / ollama
+        # model, so normalize against what stb_image can decode (no webp), not
+        # just what the cloud providers accept. Offloaded — Pillow is blocking.
         normalized_path, detected_mime_type, _norm_err = await asyncio.to_thread(
             _normalize_to_supported_image, temp_image_path, detected_mime_type,
+            _LOCAL_BACKEND_SUPPORTED_MEDIA_TYPES,
         )
         if _norm_err or normalized_path is None:
             raise ValueError(_norm_err or "Image normalization failed.")


### PR DESCRIPTION
## What does this PR do?

Fixes `vision_analyze` silently losing the image on any **`.webp`** input when `auxiliary.vision` points at a local llama.cpp-served VLM.

llama.cpp decodes images with **`stb_image`**, which has no webp decoder. `mtmd_helper_bitmap_init_from_buf` → `stbi_load_from_memory(...)` returns `NULL` for webp bytes, and llama-server then **silently drops the image part**: HTTP 200, prompt tokens with no image tokens, and the model answers from the text prompt alone ("there is no image in your message", or a confident hallucination). Nothing errors, so it reads like a model or model-alias problem.

`_normalize_to_supported_image()` checked `detected_mime in _ANTHROPIC_SUPPORTED_MEDIA_TYPES` (which includes `image/webp`) and passed webp straight through.

### Why not just drop webp from the set

That set is also used by the **native** embed path (`_vision_analyze_native`), where the image is baked into conversation history and re-sent every turn. Cloud providers accept webp natively, and re-encoding a webp photo to PNG there would inflate every subsequent turn's payload — `agent/image_routing.py` deliberately keeps webp in its twin allowlist for exactly this reason.

### The fix

- Keep `_ANTHROPIC_SUPPORTED_MEDIA_TYPES` unchanged — the native/cloud path still embeds webp as-is.
- Add `_LOCAL_BACKEND_SUPPORTED_MEDIA_TYPES` (same set minus webp) and give `_normalize_to_supported_image` an optional `supported=` parameter.
- The **auxiliary** call — one-shot, not baked into history, backend often local — normalizes against the local set, so webp routes through the existing Pillow re-encode → PNG branch (the path already used for BMP/TIFF/SVG). If the auxiliary backend is actually a cloud provider, it's a harmless no-op (PNG is universally accepted).

Same rationale as #64549 (flatten alpha for stb_image) and #67848 (decode HEIC): the loader-compatibility gap is real for local backends, but the fix is scoped so it doesn't cost the cloud path anything.

## Related Issue

No existing issue — full root cause above. Happy to open one if preferred.

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/vision_tools.py`
  - `_LOCAL_BACKEND_SUPPORTED_MEDIA_TYPES` = cloud set − `image/webp`, with a comment on the stb_image constraint.
  - `_normalize_to_supported_image(image_path, detected_mime, supported=_ANTHROPIC_SUPPORTED_MEDIA_TYPES)` — new optional param.
  - Auxiliary call site passes `_LOCAL_BACKEND_SUPPORTED_MEDIA_TYPES`; native call site unchanged.
- `tests/tools/test_vision_tools.py` — `TestWebpNormalization`: cloud set keeps webp / local set drops it; webp passes through on the default set; webp re-encodes to a valid PNG on the local set; png untouched on both.

## How to Test

With `auxiliary.vision` pointed at a llama.cpp-served VL model (e.g. Qwen3-VL):

1. **Before:** `vision_analyze` any `.webp` → model responds as if no image were attached. Convert the same file to PNG → correct description.
2. Direct check against llama-server: POST a `data:image/webp;base64,…` image to `/v1/chat/completions` → HTTP 200, `usage.prompt_tokens` shows **no image tokens**, model says there's no image.
3. **After:** step 1 returns a correct description; the webp is re-encoded to PNG before the auxiliary call. Native-path (cloud) behavior is unchanged — webp still embeds as-is.

```
pytest tests/tools/test_vision_tools.py -q
41 passed
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] Conventional Commits (`fix(vision):`)
- [x] I searched for existing PRs — not a duplicate
- [x] Only changes related to this fix
- [x] `pytest tests/tools/test_vision_tools.py -q` passes
- [x] Tests added
- [x] Tested on: macOS 15 (client) + Linux llama.cpp vision backend

### Documentation & Housekeeping

- [x] Docs / config keys / CONTRIBUTING / cross-platform / schemas — N/A (Pillow reads webp on all platforms; falls back to original bytes if Pillow is absent, same as today)

## Notes for reviewers

- `agent/image_routing.py:689` `_UNIVERSALLY_SUPPORTED_MIMES` has the same webp entry for the chat-attachment embed path. That path targets the main model's provider — usually cloud, so webp is fine — but a local main model would hit the same silent drop. Left alone here since I could only reproduce the `vision_analyze` path; may warrant a follow-up.
