### PR TITLE
fix(provider): consult current provider's live catalog before OpenRouter fallback in detect_provider_for_model

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -3538,6 +3538,21 @@ def detect_provider_for_model(
     if _model_in_provider_catalog(name.lower(), _provider_keys(current_provider)):
         return None
 
+    # --- Step 1.5: the CURRENT provider's live catalog is authoritative ---
+    # A model the current provider actually serves (e.g. ollama-cloud serving
+    # glm-5.3-flash, which is not in the static _PROVIDER_MODELS list) must NOT
+    # be re-routed to OpenRouter merely because its bare name also appears in
+    # the OpenRouter catalog. This fixed the silent hijack where an
+    # ollama-cloud session was rebuilt on OpenRouter (billing via
+    # openrouter.ai) because the live catalog was never consulted.
+    try:
+        live_ids = provider_model_ids(current_provider)
+        live_lower = {_strip_ollama_cloud_suffix(m.lower()) for m in live_ids}
+        if name.lower() in live_lower:
+            return None
+    except Exception:
+        pass
+
     # --- Step 2: check OpenRouter catalog ---
     # First try exact match (handles provider/model format)
     or_slug = _find_openrouter_slug(name)


### PR DESCRIPTION
## Problem

On the ACP path, a model whose bare name exists in OpenRouter's catalog can silently hijack to OpenRouter even when the **current provider** already serves it.

`acp_adapter/server.py#_resolve_model_selection` runs `parse_model_input` → `('ollama-cloud', X)`, and because provider == current it calls `detect_provider_for_model`. That function consulted **only the static `_PROVIDER_MODELS` catalog** then fell through to `_find_openrouter_slug`. `ollama-cloud` is not in the static list, so any ollama-cloud model whose bare name also exists in OpenRouter (e.g. `glm-5.3-flash` → `zai/glm-5.3-flash`) returned `('openrouter', zai/...)`. `set_session_model` treats that as `provider_changed=True` and **rebuilds the agent on OpenRouter**, silently billing OpenRouter credits for a model the current provider already serves.

Confirmed live: three sessions ran `z-ai/glm-5.3-flash` on `openrouter.ai/api/v1`, ~$0.29 estimated / $0.875 billed, while the ollama-cloud catalog *does* serve the model — it was just never consulted.

## Fix

Add a step between the static-catalog check and the OpenRouter fallback that consults the **current provider's live catalog** via `provider_model_ids()` (normalized with `_strip_ollama_cloud_suffix`). If the current provider actually serves the model, return `None` (stay put) instead of falling through to OpenRouter. Wrapped in `try/except` so a live-fetch failure degrades to the old fallback.

## Verification

- `detect_provider_for_model("glm-5.3-flash", "ollama-cloud")` → `None` before fix: `('openrouter', 'zai/glm-5.3-flash')` (the hijack)
- after fix → `None` (stays on ollama-cloud) ✓
- Genuine remaps still resolve: `gpt-4o` → `openai`, `deepseek-chat` → `deepseek` ✓

This fixes the whole class: any currently-served model can no longer be re-routed to OpenRouter merely because its bare name appears there.
