### PR TITLE
fix(state): refuse destructive restore on incomplete holder scans

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -1092,7 +1092,7 @@ def _resolve_quick_snapshot_dir(
     snapshot_id: str,
     hermes_home: Optional[Path] = None,
 ) -> Optional[Path]:
-    """Return a contained quick-snapshot directory, or None when invalid."""
+    """Return a contained quick-snapshot directory, or None for an invalid ID or missing directory."""
     root = _quick_snapshot_root(hermes_home)
     if (
         not snapshot_id
@@ -1294,7 +1294,7 @@ def restore_quick_snapshot(snapshot_id: str, hermes_home: Optional[Path] = None)
                 # stale pages from a replaced inode (#65942).
                 if not _safe_restore_db(src, dst):
                     # Refused (live holder) or failed: destination untouched — a failure, not a restore.
-                    logger.error("Failed to restore %s: live-safe restore refused", rel)
+                    logger.error("Failed to restore %s: live-safe restore failed or was refused", rel)
                     db_restore_failed = True
                     continue
             else:

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -1088,6 +1088,27 @@ def _quick_snapshot_root(hermes_home: Optional[Path] = None) -> Path:
     return home / _QUICK_SNAPSHOTS_DIR
 
 
+def _resolve_quick_snapshot_dir(
+    snapshot_id: str,
+    hermes_home: Optional[Path] = None,
+) -> Optional[Path]:
+    """Return a contained quick-snapshot directory, or None when invalid."""
+    root = _quick_snapshot_root(hermes_home)
+    if (
+        not snapshot_id
+        or "/" in snapshot_id
+        or "\\" in snapshot_id
+        or snapshot_id in (".", "..")
+    ):
+        logger.error("Invalid snapshot_id: %s", snapshot_id)
+        return None
+    snap_dir = root / snapshot_id
+    if not _is_within(snap_dir, root.resolve()):
+        logger.error("Snapshot path traversal blocked for id: %s", snapshot_id)
+        return None
+    return snap_dir if snap_dir.is_dir() else None
+
+
 def create_quick_snapshot(
     label: Optional[str] = None, hermes_home: Optional[Path] = None, keep: Optional[int] = None,
     max_file_size: Optional[int] = None) -> Optional[str]:
@@ -1247,22 +1268,17 @@ def list_quick_snapshots(limit: int = 20, hermes_home: Optional[Path] = None) ->
 def restore_quick_snapshot(snapshot_id: str, hermes_home: Optional[Path] = None) -> bool:
     """Restore state from a quick snapshot."""
     home = hermes_home or get_hermes_home()
-    root = _quick_snapshot_root(home)
-    # Reject ids with separators or traversal so ``root / snapshot_id`` stays inside root.
-    if not snapshot_id or "/" in snapshot_id or "\\" in snapshot_id or snapshot_id in (".", ".."):
-        logger.error("Invalid snapshot_id: %s", snapshot_id)
-        return False
-    snap_dir = root / snapshot_id
-    if not _is_within(snap_dir, root.resolve()):  # handles symlinks etc.
-        logger.error("Snapshot path traversal blocked for id: %s", snapshot_id)
+    snap_dir = _resolve_quick_snapshot_dir(snapshot_id, home)
+    if snap_dir is None:
         return False
     manifest_path = snap_dir / "manifest.json"
-    if not snap_dir.is_dir() or not manifest_path.exists():
+    if not manifest_path.exists():
         return False
     with open(manifest_path, encoding="utf-8") as f:
         meta = json.load(f)
     snap_res, home_res = snap_dir.resolve(), home.resolve()
     restored = 0
+    db_restore_failed = False
     for rel in meta.get("files", {}):
         src = snap_dir / rel
         dst = home / rel
@@ -1279,14 +1295,15 @@ def restore_quick_snapshot(snapshot_id: str, hermes_home: Optional[Path] = None)
                 if not _safe_restore_db(src, dst):
                     # Refused (live holder) or failed: destination untouched — a failure, not a restore.
                     logger.error("Failed to restore %s: live-safe restore refused", rel)
-                    return False
+                    db_restore_failed = True
+                    continue
             else:
                 shutil.copy2(src, dst)
             restored += 1
         except (OSError, PermissionError) as exc:
             logger.error("Failed to restore %s: %s", rel, exc)
     logger.info("Restored %d files from snapshot %s", restored, snapshot_id)
-    return restored > 0
+    return restored > 0 and not db_restore_failed
 
 
 # Kept in sync with ``_QUICK_STATE_FILES`` and ``cron/jobs.py``'s ``JOBS_FILE``.

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -1279,7 +1279,7 @@ def restore_quick_snapshot(snapshot_id: str, hermes_home: Optional[Path] = None)
                 if not _safe_restore_db(src, dst):
                     # Refused (live holder) or failed: destination untouched — a failure, not a restore.
                     logger.error("Failed to restore %s: live-safe restore refused", rel)
-                    continue
+                    return False
             else:
                 shutil.copy2(src, dst)
             restored += 1

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -416,12 +416,15 @@ def _foreign_db_holder_pids(db_path: Path) -> Optional[List[int]]:
     def _canonical(path: str) -> str:
         return os.path.normcase(os.path.abspath(path.removesuffix(" (deleted)")))
 
-    def _holds_watched(fds: List[str], fd_dir: str) -> bool:
+    def _holds_watched(fds: List[str], fd_dir: str) -> Optional[bool]:
         for fd in fds:
             try:
                 target = os.readlink(f"{fd_dir}/{fd}")
-            except OSError:
+            except FileNotFoundError:
+                # The descriptor closed after its directory was listed.
                 continue
+            except OSError:
+                return None
             if _canonical(target) in watched:
                 return True
         return False
@@ -437,9 +440,15 @@ def _foreign_db_holder_pids(db_path: Path) -> Optional[List[int]]:
             fd_dir = f"/proc/{pid_str}/fd"
             try:
                 fds = os.listdir(fd_dir)
-            except OSError:
+            except FileNotFoundError:
+                # The process exited after the /proc PID listing.
                 continue
-            if _holds_watched(fds, fd_dir):
+            except OSError:
+                return None
+            holds_watched = _holds_watched(fds, fd_dir)
+            if holds_watched is None:
+                return None
+            if holds_watched:
                 pids.append(int(pid_str))
     except OSError:
         return None
@@ -451,7 +460,7 @@ def _safe_restore_db(src: Path, dst: Path) -> bool:
 
     Writing pages into the live file preserves its inode and WAL state, so other holders (gateway,
     dashboard, another CLI) see the restored data instead of stale pages from a replaced inode.
-    The fallback runs ONLY when no other process or in-process connection holds the file
+    The fallback runs ONLY when inspection proves that no other process or in-process connection holds the file
     (replacing the inode under a live holder is the #90950 split-brain); otherwise it fails closed
     (``False``) and the caller reports the file as skipped.
     """
@@ -482,6 +491,14 @@ def _unlink_move_restore_db(src: Path, dst: Path) -> bool:
     from hermes_cli.sqlite_safe_read import LiveConnectionError, offline_file_access
     try:
         holders = _foreign_db_holder_pids(dst)
+        if holders is None:
+            logger.error(
+                "Refusing unlink+move restore of %s: database-holder inspection "
+                "is unavailable or incomplete, so the destructive fallback "
+                "cannot be proven safe. Resolve the SQLite restore error and retry.",
+                dst,
+            )
+            return False
         if holders:
             logger.error("Refusing unlink+move restore of %s: process(es) %s still "
                          "hold the database or its WAL open. Stop them and retry.", dst, holders)

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -838,7 +838,15 @@ class CLICommandsMixin:
             _pr(f"  Restored state from: {snap_id}",
                 "  Restart recommended for gateway/dashboard processes to pick up state.db changes.")
         else:
-            print(f"  Snapshot not found: {snap_id}")
+            from hermes_constants import get_hermes_home
+            snap_dir = get_hermes_home() / "state-snapshots" / snap_id
+            if snap_dir.is_dir():
+                print(
+                    "  Restore refused: another process still holds state.db "
+                    "or its WAL. Stop the gateway or dashboard and retry."
+                )
+            else:
+                print(f"  Snapshot not found: {snap_id}")
 
     def _snapshot_prune(self, parts) -> None:
         from hermes_cli.backup import prune_quick_snapshots

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -811,7 +811,11 @@ class CLICommandsMixin:
         print(f"  Snapshot created: {snap_id}" if snap_id else "  No state files found to snapshot.")
 
     def _snapshot_restore(self, parts) -> None:
-        from hermes_cli.backup import list_quick_snapshots, restore_quick_snapshot
+        from hermes_cli.backup import (
+            _resolve_quick_snapshot_dir,
+            list_quick_snapshots,
+            restore_quick_snapshot,
+        )
         if len(parts) < 3:
             print("  Usage: /snapshot restore <snapshot-id>")
             snaps = list_quick_snapshots(limit=1)
@@ -838,12 +842,10 @@ class CLICommandsMixin:
             _pr(f"  Restored state from: {snap_id}",
                 "  Restart recommended for gateway/dashboard processes to pick up state.db changes.")
         else:
-            from hermes_constants import get_hermes_home
-            snap_dir = get_hermes_home() / "state-snapshots" / snap_id
-            if snap_dir.is_dir():
+            if _resolve_quick_snapshot_dir(snap_id) is not None:
                 print(
-                    "  Restore refused: another process still holds state.db "
-                    "or its WAL. Stop the gateway or dashboard and retry."
+                    "  Restore failed or was refused. Check the Hermes logs "
+                    "for the specific cause, then retry."
                 )
             else:
                 print(f"  Snapshot not found: {snap_id}")

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -1307,6 +1307,34 @@ class TestForeignDbHolderPids:
 
         assert backup_mod._foreign_db_holder_pids(tmp_path / "state.db") is None
 
+    @pytest.mark.parametrize("race", ("process-exit", "fd-close"))
+    def test_ignores_file_not_found_races(self, tmp_path, monkeypatch, race):
+        from hermes_cli import backup as backup_mod
+
+        if not backup_mod.sys.platform.startswith("linux"):
+            pytest.skip("Linux holder scanning uses /proc")
+
+        own_pid = backup_mod.os.getpid()
+        foreign_pid = own_pid + 100_000
+
+        def _listdir(path):
+            if path == "/proc":
+                return [str(own_pid), str(foreign_pid)]
+            if path == f"/proc/{foreign_pid}/fd":
+                if race == "process-exit":
+                    raise FileNotFoundError("process exited")
+                return ["7"]
+            raise AssertionError(f"unexpected path: {path}")
+
+        def _readlink(path):
+            assert path == f"/proc/{foreign_pid}/fd/7"
+            raise FileNotFoundError("descriptor closed")
+
+        monkeypatch.setattr(backup_mod.os, "listdir", _listdir)
+        monkeypatch.setattr(backup_mod.os, "readlink", _readlink)
+
+        assert backup_mod._foreign_db_holder_pids(tmp_path / "state.db") == []
+
 
 # ---------------------------------------------------------------------------
 # Quick state snapshot tests
@@ -1433,20 +1461,19 @@ class TestQuickSnapshot:
     def test_restore_returns_false_when_safe_restore_refuses(
         self, hermes_home, monkeypatch
     ):
-        """#95531 leftover: _safe_restore_db False must not look like success.
+        from hermes_cli import backup as backup_mod
 
-        The update helper already prints a refusal. /snapshot restore used
-        to ignore that False, increment restored, and print
-        'Restored state from:'.
-        """
-        from hermes_cli.backup import create_quick_snapshot, restore_quick_snapshot
-        import hermes_cli.backup as backup_mod
+        snap_id = backup_mod.create_quick_snapshot(hermes_home=hermes_home)
+        monkeypatch.setattr(
+            backup_mod, "_safe_restore_db", lambda _src, _dst: False
+        )
 
-        snap_id = create_quick_snapshot(hermes_home=hermes_home)
-        monkeypatch.setattr(backup_mod, "_safe_restore_db", lambda src, dst: False)
-        assert restore_quick_snapshot(snap_id, hermes_home=hermes_home) is False
+        assert (
+            backup_mod.restore_quick_snapshot(snap_id, hermes_home=hermes_home)
+            is False
+        )
 
-    def test_snapshot_restore_command_prints_refuse_not_success(
+    def test_snapshot_restore_command_reports_failure_not_missing(
         self, hermes_home, monkeypatch, capsys
     ):
         from hermes_cli.backup import create_quick_snapshot
@@ -1454,16 +1481,38 @@ class TestQuickSnapshot:
 
         snap_id = create_quick_snapshot(hermes_home=hermes_home)
         monkeypatch.setattr(
-            "hermes_cli.backup.restore_quick_snapshot", lambda *a, **k: False
+            "hermes_cli.backup.restore_quick_snapshot", lambda *_args, **_kwargs: False
         )
         monkeypatch.setattr(
-            "hermes_constants.get_hermes_home", lambda: hermes_home
+            "hermes_cli.backup.get_hermes_home", lambda: hermes_home
         )
+
         CLICommandsMixin()._handle_snapshot_command(f"/snapshot restore {snap_id}")
-        out = capsys.readouterr().out
-        assert "Restored state from" not in out
-        assert "Restore refused" in out
-        assert "Snapshot not found" not in out
+
+        output = capsys.readouterr().out
+        assert "Restored state from" not in output
+        assert "Restore failed or was refused" in output
+        assert "Snapshot not found" not in output
+
+    def test_snapshot_restore_command_rejects_invalid_snapshot_path(
+        self, hermes_home, monkeypatch, capsys
+    ):
+        from hermes_cli.cli_commands_mixin import CLICommandsMixin
+
+        (hermes_home / "state-snapshots").mkdir()
+        (hermes_home / "outside").mkdir()
+        monkeypatch.setattr(
+            "hermes_cli.backup.restore_quick_snapshot", lambda *_args, **_kwargs: False
+        )
+        monkeypatch.setattr(
+            "hermes_cli.backup.get_hermes_home", lambda: hermes_home
+        )
+
+        CLICommandsMixin()._handle_snapshot_command("/snapshot restore ../outside")
+
+        output = capsys.readouterr().out
+        assert "Restore failed or was refused" not in output
+        assert "Snapshot not found: ../outside" in output
 
     def test_restore_refuses_destructive_fallback_when_holder_scan_is_unavailable(
         self, tmp_path, monkeypatch

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -1430,6 +1430,41 @@ class TestQuickSnapshot:
             f"(expected 1); the extra row 's2' should have been reverted."
         )
 
+    def test_restore_returns_false_when_safe_restore_refuses(
+        self, hermes_home, monkeypatch
+    ):
+        """#95531 leftover: _safe_restore_db False must not look like success.
+
+        The update helper already prints a refusal. /snapshot restore used
+        to ignore that False, increment restored, and print
+        'Restored state from:'.
+        """
+        from hermes_cli.backup import create_quick_snapshot, restore_quick_snapshot
+        import hermes_cli.backup as backup_mod
+
+        snap_id = create_quick_snapshot(hermes_home=hermes_home)
+        monkeypatch.setattr(backup_mod, "_safe_restore_db", lambda src, dst: False)
+        assert restore_quick_snapshot(snap_id, hermes_home=hermes_home) is False
+
+    def test_snapshot_restore_command_prints_refuse_not_success(
+        self, hermes_home, monkeypatch, capsys
+    ):
+        from hermes_cli.backup import create_quick_snapshot
+        from hermes_cli.cli_commands_mixin import CLICommandsMixin
+
+        snap_id = create_quick_snapshot(hermes_home=hermes_home)
+        monkeypatch.setattr(
+            "hermes_cli.backup.restore_quick_snapshot", lambda *a, **k: False
+        )
+        monkeypatch.setattr(
+            "hermes_constants.get_hermes_home", lambda: hermes_home
+        )
+        CLICommandsMixin()._handle_snapshot_command(f"/snapshot restore {snap_id}")
+        out = capsys.readouterr().out
+        assert "Restored state from" not in out
+        assert "Restore refused" in out
+        assert "Snapshot not found" not in out
+
     def test_restore_refuses_destructive_fallback_when_holder_scan_is_unavailable(
         self, tmp_path, monkeypatch
     ):

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -1458,8 +1458,8 @@ class TestQuickSnapshot:
             f"(expected 1); the extra row 's2' should have been reverted."
         )
 
-    def test_restore_returns_false_when_safe_restore_refuses(
-        self, hermes_home, monkeypatch
+    def test_restore_returns_false_when_safe_restore_fails(
+        self, hermes_home, monkeypatch, caplog
     ):
         from hermes_cli import backup as backup_mod
 
@@ -1472,6 +1472,7 @@ class TestQuickSnapshot:
             backup_mod.restore_quick_snapshot(snap_id, hermes_home=hermes_home)
             is False
         )
+        assert "live-safe restore failed or was refused" in caplog.text
 
     def test_snapshot_restore_command_reports_failure_not_missing(
         self, hermes_home, monkeypatch, capsys

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -1275,6 +1275,39 @@ class TestSafeCopyDb:
         assert is_zeroed_sqlite_file(p) is True
 
 
+class TestForeignDbHolderPids:
+    @pytest.mark.parametrize("unreadable", ("fd-table", "fd-target"))
+    def test_returns_unknown_when_process_inspection_is_unreadable(
+        self, tmp_path, monkeypatch, unreadable
+    ):
+        from hermes_cli import backup as backup_mod
+
+        if not backup_mod.sys.platform.startswith("linux"):
+            pytest.skip("Linux holder scanning uses /proc")
+
+        own_pid = backup_mod.os.getpid()
+        foreign_pid = own_pid + 100_000
+
+        def _listdir(path):
+            if path == "/proc":
+                return [str(own_pid), str(foreign_pid)]
+            if path == f"/proc/{foreign_pid}/fd":
+                if unreadable == "fd-table":
+                    raise PermissionError("fd table unreadable")
+                return ["7"]
+            raise AssertionError(f"unexpected path: {path}")
+
+        def _readlink(_path):
+            if unreadable == "fd-target":
+                raise PermissionError("fd target unreadable")
+            raise AssertionError("readlink should not be reached")
+
+        monkeypatch.setattr(backup_mod.os, "listdir", _listdir)
+        monkeypatch.setattr(backup_mod.os, "readlink", _readlink)
+
+        assert backup_mod._foreign_db_holder_pids(tmp_path / "state.db") is None
+
+
 # ---------------------------------------------------------------------------
 # Quick state snapshot tests
 # ---------------------------------------------------------------------------
@@ -1396,6 +1429,47 @@ class TestQuickSnapshot:
             f"Live connection still sees {len(rows_after)} rows after restore "
             f"(expected 1); the extra row 's2' should have been reverted."
         )
+
+    def test_restore_refuses_destructive_fallback_when_holder_scan_is_unavailable(
+        self, tmp_path, monkeypatch
+    ):
+        from hermes_cli import backup as backup_mod
+
+        src = tmp_path / "snapshot.db"
+        dst = tmp_path / "state.db"
+        for path, value in (
+            (src, "snapshot-generation"),
+            (dst, "live-generation"),
+        ):
+            conn = sqlite3.connect(path)
+            try:
+                conn.execute("CREATE TABLE marker (value TEXT)")
+                conn.execute("INSERT INTO marker VALUES (?)", (value,))
+                conn.commit()
+            finally:
+                conn.close()
+
+        sidecars = {}
+        for suffix in ("-wal", "-shm", "-journal"):
+            sidecar = dst.with_name(dst.name + suffix)
+            sidecar.write_bytes(f"live{suffix}".encode())
+            sidecars[sidecar] = sidecar.read_bytes()
+
+        before_bytes = dst.read_bytes()
+        before_inode = dst.stat().st_ino
+
+        def _fail_safe_route(*_args, **_kwargs):
+            raise sqlite3.OperationalError("forced safe-restore failure")
+
+        monkeypatch.setattr(backup_mod.sqlite3, "connect", _fail_safe_route)
+        monkeypatch.setattr(
+            backup_mod, "_foreign_db_holder_pids", lambda _path: None
+        )
+
+        assert backup_mod._safe_restore_db(src, dst) is False
+        assert dst.read_bytes() == before_bytes
+        assert dst.stat().st_ino == before_inode
+        assert {path: path.read_bytes() for path in sidecars} == sidecars
 
 
 

--- a/tests/hermes_cli/test_restore_own_holder_guard.py
+++ b/tests/hermes_cli/test_restore_own_holder_guard.py
@@ -106,13 +106,15 @@ def test_update_autorestore_refuses_under_own_live_connection(
     assert _own_deleted_fds(str(dst.name)) == []
 
 
-def test_safe_restore_fallback_still_works_without_holder(tmp_path):
+def test_safe_restore_fallback_still_works_without_holder(tmp_path, monkeypatch):
     dst = tmp_path / "state.db"
     src = tmp_path / "snap.db"
     _make_db(src, "snapshot-good")
     _make_db(dst, "live-old")
     with open(dst, "r+b") as fh:
         fh.write(b"\x00" * 100)
+    # Exercise the known-clear branch independent of host /proc visibility.
+    monkeypatch.setattr(backup_mod, "_foreign_db_holder_pids", lambda _path: [])
 
     assert backup_mod._safe_restore_db(src, dst) is True
     assert _read_marker(dst) == "snapshot-good"


### PR DESCRIPTION
## What does this PR do?

Snapshot restore can fall back from SQLite's live-safe backup route to copy, unlink, and move. That fallback is safe only when holder inspection proves that no foreign process still has the database open. Per-process inspection failures could collapse into a known-empty result, and the fallback caller also treated an unknown result like an empty scan.

This change keeps holder inspection tri-state: known holders, known clear, or unknown. Unknown inspection now blocks the destructive fallback. Normal process-exit and descriptor-close races remain skippable. A refused database restore also propagates through the quick-restore caller, so the CLI no longer prints false success or misclassifies every failure as a missing snapshot.

## Related Issue

Fixes #95763

Follow-up to #95531. This branch incorporates the caller-propagation change from #95764 as a separate commit and preserves @Adolanium's original authorship.

## Type of Change

- ☑ 🐛 Bug fix (non-breaking change that fixes an issue)
- ☐ ✨ New feature (non-breaking change that adds functionality)
- ☐ 🔒 Security fix
- ☐ 📝 Documentation update
- ☐ ✅ Tests (adding or improving test coverage)
- ☐ ♻️ Refactor (no behavior change)
- ☐ 🎯 New skill (bundled or hub)

## Changes Made

- Preserve unknown when holder inspection is unavailable, incomplete, or unreadable instead of treating it as proof that no holder exists.
- Refuse destructive copy, unlink, and move unless the holder scan is known clear.
- Propagate `_safe_restore_db` refusal through `restore_quick_snapshot` rather than counting the database as restored.
- Reuse one containment-aware snapshot-directory resolver and report restore failures generically instead of guessing the cause.
- Add regression coverage for unreadable descriptor tables and targets, benign process races, unknown-scan refusal, caller failure propagation, and CLI output.

## How to Test

1. Run the targeted backup and update-restore suites with `pytest -q`; result: **73 passed**.
2. Run the candidate-specific selection on native Windows with `pytest -q`; result: **4 passed, 4 skipped** because those cases are Linux-only.
3. Run the broader native Windows comparison with `pytest -q` on the pinned base and candidate; both produced the same **3 pre-existing failures**, with **0 new candidate failures**.
4. Run `ruff check`; result: **passed**. Run `git diff --check`; result: **clean**.
5. Verify commit signatures and the outgoing-signature gate with `git verify-commit` and `git verify-outgoing`; result: **passed**.
6. Run the broader gateway and runtime regression selection with `pytest -q`; result: **700 passed**.
7. Load the exact PR versions of the changed runtime modules and run an isolated operational restore test in a temporary Hermes home; result: **passed**:
   - A live Linux holder scan produced the `unknown` state.
   - The SQLite backup route restored snapshot data while preserving the destination inode; both a connection kept open across restore and a fresh connection observed the restored data.
   - With the SQLite backup route forced to fail and holder inspection forced to `unknown`, restore returned `False` without changing the database bytes, inode, or `-wal`, `-shm`, and `-journal` sidecars.
   - The quick-restore caller and CLI propagated the refusal without false success or a false `snapshot missing` result.
   - The gateway remained healthy after the test with the same process and no automatic restart.

## Checklist

### Code

- ☑ I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- ☑ My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- ☑ I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) and incorporated the directly overlapping #95764 change with contributor credit preserved
- ☑ My PR contains only changes related to this fix
- ☐ I've run the complete `pytest tests/ -q` suite and all tests pass; targeted Linux and native Windows evidence is reported above
- ☑ I've added tests for the changed behavior
- ☑ I've tested on Linux and native Windows

### Documentation & Housekeeping

- ☑ Documentation update: N/A; no user-facing command or configuration contract changed
- ☑ Example configuration update: N/A; no configuration keys changed
- ☑ Contributor workflow update: N/A; no architecture or contributor workflow changed
- ☑ Cross-platform impact considered and tested on Linux and native Windows
- ☑ Tool description or schema update: N/A; no tool contract changed

## Screenshots / Logs

The exact publication-safe validation results are listed above. The infographic below summarizes the before-and-after safety invariant.

## Infographic

![Industrial safety-logic diagram showing an unknown holder-inspection result reaching restore and producing false success before the fix; after the fix, a closed gate blocks restore and reports failure, while a separate verified-clear path still allows fallback. The official Nous Research website icon and a 73 TESTS PASS plaque appear at lower right.](https://v3b.fal.media/files/b/0aa83507/B_9FGi-4LwH_3pxwBnGwg_c012.png)
