### PR TITLE
fix(tools): resolve peek_nous_access_token through the profile credential chain

### DIFF
--- a/tests/tools/test_managed_tool_gateway.py
+++ b/tests/tools/test_managed_tool_gateway.py
@@ -410,3 +410,105 @@ def test_is_managed_tool_gateway_ready_skips_refresh_for_expired_cached_token(tm
         assert is_managed_tool_gateway_ready("modal") is True
 
     assert refresh_calls == []
+
+
+def _fixture_token(label: str) -> str:
+    """Build a clearly-fake marker token for a test fixture."""
+    return f"fixture-nous-token-{label}"
+
+
+def _write_auth_store(path, payload):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload))
+
+
+def test_peek_nous_access_token_falls_back_to_global_root_store(tmp_path, monkeypatch):
+    # Profile with an empty providers map; the Nous login lives at the
+    # global root. peek must resolve it the same way read/status do (#97490).
+    monkeypatch.delenv("TOOL_GATEWAY_USER_TOKEN", raising=False)
+    profile_home = tmp_path / "profiles" / "alice"
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+    _write_auth_store(profile_home / "auth.json", {"version": 1, "providers": {}})
+    _write_auth_store(tmp_path / "auth.json", {
+        "version": 1,
+        "providers": {"nous": {"access_token": _fixture_token("global-root")}},
+    })
+
+    assert managed_tool_gateway.peek_nous_access_token() == _fixture_token("global-root")
+
+
+def test_peek_nous_access_token_falls_back_to_credential_pool(tmp_path, monkeypatch):
+    # Device-code logins can leave the token only in credential_pool.nous
+    # with an empty providers map — the status snapshot already falls back
+    # to the pool; peek must too.
+    monkeypatch.delenv("TOOL_GATEWAY_USER_TOKEN", raising=False)
+    profile_home = tmp_path / "profiles" / "alice"
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+    _write_auth_store(profile_home / "auth.json", {
+        "version": 1,
+        "providers": {},
+        "credential_pool": {
+            "nous": [{"source": "device_code", "access_token": _fixture_token("pool")}]
+        },
+    })
+
+    assert managed_tool_gateway.peek_nous_access_token() == _fixture_token("pool")
+
+
+def test_peek_nous_access_token_prefers_active_provider_state_over_fallbacks(tmp_path, monkeypatch):
+    # Shadowing order must not flip: an active-store token wins over both
+    # the global-root state and a pooled entry.
+    monkeypatch.delenv("TOOL_GATEWAY_USER_TOKEN", raising=False)
+    profile_home = tmp_path / "profiles" / "alice"
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+    _write_auth_store(profile_home / "auth.json", {
+        "version": 1,
+        "providers": {"nous": {"access_token": _fixture_token("profile")}},
+        "credential_pool": {
+            "nous": [{"source": "device_code", "access_token": _fixture_token("pool")}]
+        },
+    })
+    _write_auth_store(tmp_path / "auth.json", {
+        "version": 1,
+        "providers": {"nous": {"access_token": _fixture_token("global-root")}},
+    })
+
+    assert managed_tool_gateway.peek_nous_access_token() == _fixture_token("profile")
+
+
+def test_peek_nous_access_token_falls_back_to_global_pool_entries(tmp_path, monkeypatch):
+    # read_credential_pool's per-provider shadowing also covers Nous entries
+    # that only exist at the global root.
+    monkeypatch.delenv("TOOL_GATEWAY_USER_TOKEN", raising=False)
+    profile_home = tmp_path / "profiles" / "alice"
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+    _write_auth_store(profile_home / "auth.json", {"version": 1, "providers": {}})
+    _write_auth_store(tmp_path / "auth.json", {
+        "version": 1,
+        "providers": {},
+        "credential_pool": {
+            "nous": [{"source": "device_code", "access_token": _fixture_token("global-pool")}]
+        },
+    })
+
+    assert managed_tool_gateway.peek_nous_access_token() == _fixture_token("global-pool")
+
+
+def test_is_managed_tool_gateway_ready_reports_ready_from_fallback_token(tmp_path, monkeypatch):
+    # End-to-end shape of #97490: every managed tool showed unavailable in a
+    # profile while the credentials worked when invoked.
+    monkeypatch.delenv("TOOL_GATEWAY_USER_TOKEN", raising=False)
+    profile_home = tmp_path / "profiles" / "alice"
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+    _write_auth_store(profile_home / "auth.json", {"version": 1, "providers": {}})
+    _write_auth_store(tmp_path / "auth.json", {
+        "version": 1,
+        "providers": {"nous": {"access_token": _fixture_token("global-root")}},
+    })
+
+    with patch.dict(
+        os.environ,
+        {"TOOL_GATEWAY_DOMAIN": "nousresearch.com"},
+        clear=False,
+    ), patch.object(managed_tool_gateway, "managed_nous_tools_enabled", return_value=True):
+        assert managed_tool_gateway.is_managed_tool_gateway_ready("firecrawl") is True

--- a/tools/managed_tool_gateway.py
+++ b/tools/managed_tool_gateway.py
@@ -95,6 +95,46 @@ def _read_user_token_override() -> Optional[str]:
     return None
 
 
+def _read_nous_fallback_token() -> Optional[str]:
+    """Resolve a cached Nous token through the same chain as the status panel.
+
+    ``read_nous_access_token()`` and ``get_nous_auth_status()`` both resolve
+    credentials beyond the active store: provider state falls back to the
+    global-root auth.json in profile mode (#18594 shadowing), and when no
+    provider state exists the status snapshot falls back to the credential
+    pool. Mirroring that chain here keeps availability scans truthful in a
+    profile whose Nous login lives in the global store or in
+    ``credential_pool.nous`` — otherwise every managed tool reports
+    unavailable while working when invoked (#97490). Read-only: file reads
+    only, no locks, no network, so the cheap-probe contract of
+    :func:`peek_nous_access_token` is preserved.
+    """
+    try:
+        from hermes_cli.auth import (
+            _load_auth_store,
+            _load_provider_state_with_source,
+            read_credential_pool,
+        )
+
+        state, _source_path = _load_provider_state_with_source(
+            _load_auth_store(), "nous",
+        )
+        if isinstance(state, dict):
+            token = state.get("access_token")
+            if isinstance(token, str) and token.strip():
+                return token.strip()
+
+        for entry in read_credential_pool("nous"):
+            if not isinstance(entry, dict):
+                continue
+            token = entry.get("access_token")
+            if isinstance(token, str) and token.strip():
+                return token.strip()
+    except Exception:
+        logger.debug("Nous peek fallback resolution failed", exc_info=True)
+    return None
+
+
 def peek_nous_access_token() -> Optional[str]:
     """Cheap probe for a Nous gateway token without triggering refresh.
 
@@ -102,8 +142,11 @@ def peek_nous_access_token() -> Optional[str]:
     `is_available()` checks) must stay off the synchronous OAuth refresh path.
     This helper therefore only inspects the explicit env override and the
     cached auth-store token, without checking expiry and without making any
-    network calls. Truthful refresh handling stays in request/session paths
-    that call :func:`read_nous_access_token`.
+    network calls. Resolution mirrors the status panel: the active store's
+    ``providers.nous`` first, then the global-root fallback and the
+    credential pool (see :func:`_read_nous_fallback_token`). Truthful refresh
+    handling stays in request/session paths that call
+    :func:`read_nous_access_token`.
     """
     explicit = _read_user_token_override()
     if explicit:
@@ -113,7 +156,7 @@ def peek_nous_access_token() -> Optional[str]:
     access_token = nous_provider.get("access_token")
     if isinstance(access_token, str) and access_token.strip():
         return access_token.strip()
-    return None
+    return _read_nous_fallback_token()
 
 
 def read_nous_access_token() -> Optional[str]:


### PR DESCRIPTION
## What does this PR do?

`peek_nous_access_token()` only read `providers.nous` from the active auth store, while the refresh-aware `read_nous_access_token()` and the status snapshot `get_nous_auth_status()` both resolve credentials further:

- provider state falls back to the global-root `auth.json` in profile mode (`_load_provider_state_with_source`, the #18594 shadowing), and
- when no provider state exists at all, the status snapshot falls back to the credential pool (`_snapshot_nous_pool_status`).

Because availability scans (`hermes status`, `hermes tools`, provider `is_available()`/`check_fn`) run on the `peek` path, a profile whose Nous login lives in the global store or in `credential_pool.nous` reported **every** Nous-managed tool as "included by subscription, not currently selected" — while the tools actually worked when invoked. This PR makes `peek` mirror the status-panel resolution chain, reusing the same `hermes_cli.auth` helpers instead of duplicating the logic. The probe stays read-only (file reads only, no locks, no network, no refresh), preserving the documented cheap-probe contract.

## Related Issue

Fixes #97490

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/managed_tool_gateway.py`: added `_read_nous_fallback_token()`, which resolves a cached Nous token through `_load_provider_state_with_source()` (global-root fallback) and then `read_credential_pool("nous")` (device-code pool entries, with the same per-provider global shadowing), all inside a fail-soft try/except; `peek_nous_access_token()` now consults it after the active store misses.
- `tests/tools/test_managed_tool_gateway.py`: regression tests for the global-root fallback, the credential-pool fallback, the global pool fallback, the active-state-wins shadowing order, and the end-to-end `is_managed_tool_gateway_ready()` shape from the issue.

## How to Test

1. `python -m pytest tests/tools/test_managed_tool_gateway.py -q` — Observed result: 34 passed (29 pre-existing + 5 new).
2. `python -m pytest tests/tools/test_web_tools_config.py tests/hermes_cli/test_nous_subscription.py -q` — Observed result: 65 passed; the 2 `TestParallelClientConfig` failures also fail on a clean `upstream/main` checkout locally (environment-dependent, unrelated to this diff).
3. Manual shape from the issue (profile with empty `providers` + Nous login at the global root): `HERMES_HOME=<home>/profiles/<name> python3 -c "from tools.managed_tool_gateway import peek_nous_access_token; print(bool(peek_nous_access_token()))"` should pass and print `True` after this change, matching `read_nous_access_token()`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
$ python -m pytest tests/tools/test_managed_tool_gateway.py -q
34 passed, 6 warnings in 2.12s
```
