### PR TITLE
fix(cli,tui): Shift+key types the character under Ghostty modifyOtherKeys

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -82,6 +82,7 @@ try:
         install_ctrl_enter_alias,
         install_ignored_terminal_sequences,
         install_modify_other_keys_aliases,
+        install_plain_char_data_fix,
         install_shift_enter_alias,
     )
     install_shift_enter_alias()
@@ -89,7 +90,8 @@ try:
     install_cmd_backspace_alias()
     install_modify_other_keys_aliases()
     install_ignored_terminal_sequences()
-    del install_shift_enter_alias, install_ctrl_enter_alias, install_cmd_backspace_alias, install_modify_other_keys_aliases, install_ignored_terminal_sequences
+    install_plain_char_data_fix()
+    del install_shift_enter_alias, install_ctrl_enter_alias, install_cmd_backspace_alias, install_modify_other_keys_aliases, install_ignored_terminal_sequences, install_plain_char_data_fix
 except Exception:
     pass
 import threading

--- a/hermes_cli/pt_input_extras.py
+++ b/hermes_cli/pt_input_extras.py
@@ -331,6 +331,15 @@ def install_modify_other_keys_aliases() -> int:
         upper_char = chr(ch - 32)  # 'A'..'Z'
         shift_map[ch] = upper_char
         shift_map[ch - 32] = upper_char
+    # Shift+symbol: emitters that report the ALREADY-SHIFTED codepoint (the
+    # xterm modifyOtherKeys behaviour — Ghostty sends ESC[27;2;126~ for
+    # Shift+`) need no layout knowledge at all: the codepoint IS the
+    # character to insert.  Map every remaining printable ASCII codepoint to
+    # itself so '~', '!', '@', '{' etc. stop leaking (#95550).  Unshifted
+    # codepoints are deliberately still NOT guessed at, since the shifted
+    # result of a digit/punctuation key is layout-specific.
+    for cp in range(33, 127):
+        shift_map.setdefault(cp, chr(cp))
     _install_paired(2, shift_map)
 
     # -- Multi-modifier letters: Shift+Alt (4), Ctrl+Shift (6),
@@ -493,6 +502,51 @@ def install_modify_other_keys_aliases() -> int:
         _clear_vt100_prefix_cache()
 
     return changed
+
+
+def install_plain_char_data_fix() -> int:
+    """Make single-character key aliases insert the CHARACTER, not the raw
+    escape sequence that produced them.
+
+    ``ANSI_SEQUENCES`` values may be a plain one-character string (e.g. the
+    Shift+letter and Shift+symbol entries installed by
+    ``install_modify_other_keys_aliases``, and stock entries like Shift+Space
+    → ``" "``).  prompt_toolkit's parser builds ``KeyPress(key, data)`` where
+    ``data`` is the *matched byte sequence*, and the default ``Keys.Any``
+    binding inserts ``event.data`` — so a correctly-resolved Shift+T still
+    types the literal text ``\\x1b[27;2;84~`` into the buffer (#95550).
+
+    Wrap ``Vt100Parser._call_handler`` so that when the resolved key is a
+    single printable character, the data payload becomes that character.
+    Idempotent: a sentinel attribute prevents double-wrapping.
+
+    Returns 1 if the wrapper was installed, 0 if already present or
+    unavailable.
+    """
+    try:
+        from prompt_toolkit.input.vt100_parser import Vt100Parser
+    except Exception:
+        return 0
+
+    if getattr(Vt100Parser, "_hermes_plain_char_data_fix", False):
+        return 0
+
+    original = Vt100Parser._call_handler
+
+    def _call_handler(self, key, insert_text):
+        if (
+            isinstance(key, str)
+            and len(key) == 1
+            and insert_text
+            and insert_text != key
+            and insert_text.startswith("\x1b")
+        ):
+            insert_text = key
+        return original(self, key, insert_text)
+
+    Vt100Parser._call_handler = _call_handler
+    Vt100Parser._hermes_plain_char_data_fix = True
+    return 1
 
 
 def install_ignored_terminal_sequences() -> int:

--- a/tests/cli/test_shift_modify_other_keys.py
+++ b/tests/cli/test_shift_modify_other_keys.py
@@ -1,0 +1,94 @@
+"""Shift+key under xterm modifyOtherKeys level 2 must type the character.
+
+Ghostty is pushed modifyOtherKeys=2 (CSI >4;2m) by the classic CLI, so it
+re-encodes every Shift combo as ESC[27;2;<codepoint>~.  Two defects made those
+keypresses leak the raw escape text into the prompt:
+
+  1. ANSI_SEQUENCES resolved the key to 'T' correctly, but prompt_toolkit
+     builds KeyPress(key, data) with data = the matched byte sequence, and the
+     default Keys.Any binding inserts event.data.
+  2. shift_map covered letters only, so shifted symbols had no mapping at all.
+"""
+
+import pytest
+
+from hermes_cli.pt_input_extras import (
+    install_ctrl_enter_alias,
+    install_modify_other_keys_aliases,
+    install_plain_char_data_fix,
+    install_shift_enter_alias,
+)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _installed():
+    install_shift_enter_alias()
+    install_ctrl_enter_alias()
+    install_modify_other_keys_aliases()
+    install_plain_char_data_fix()
+
+
+def _parse(sequence):
+    from prompt_toolkit.input.vt100_parser import Vt100Parser
+
+    presses = []
+    parser = Vt100Parser(presses.append)
+    for char in sequence:
+        parser.feed(char)
+    parser.flush()
+    return [(kp.key, kp.data) for kp in presses]
+
+
+@pytest.mark.parametrize(
+    "sequence,char",
+    [
+        ("\x1b[27;2;84~", "T"),
+        ("\x1b[27;2;72~", "H"),
+        ("\x1b[27;2;73~", "I"),
+        ("\x1b[84;2u", "T"),
+    ],
+)
+def test_shift_letter_inserts_the_capital(sequence, char):
+    assert _parse(sequence) == [(char, char)]
+
+
+@pytest.mark.parametrize(
+    "sequence,char",
+    [
+        ("\x1b[27;2;126~", "~"),
+        ("\x1b[27;2;33~", "!"),
+        ("\x1b[27;2;64~", "@"),
+        ("\x1b[27;2;123~", "{"),
+    ],
+)
+def test_shift_symbol_inserts_the_symbol(sequence, char):
+    """The already-shifted codepoint IS the character — no layout guessing."""
+    assert _parse(sequence) == [(char, char)]
+
+
+def test_no_shift_sequence_leaks_escape_text():
+    for codepoint in range(33, 127):
+        for key, data in _parse(f"\x1b[27;2;{codepoint}~"):
+            assert "\x1b" not in data, (codepoint, key, data)
+            assert "[27;" not in data, (codepoint, key, data)
+
+
+def test_control_keys_keep_their_raw_data():
+    """Only single-character keys are rewritten; Keys.* payloads are untouched."""
+    from prompt_toolkit.keys import Keys
+
+    assert _parse("\x1b[27;5;99~") == [(Keys.ControlC, "\x1b[27;5;99~")]
+    assert _parse("\x1b[A") == [(Keys.Up, "\x1b[A")]
+    assert _parse("\x1b[27;2;13~") == [
+        (Keys.Escape, "\x1b[27;2;13~"),
+        (Keys.ControlM, ""),
+    ]
+
+
+def test_plain_characters_are_unaffected():
+    assert _parse("a") == [("a", "a")]
+    assert _parse("Z") == [("Z", "Z")]
+
+
+def test_install_is_idempotent():
+    assert install_plain_char_data_fix() == 0

--- a/ui-tui/packages/hermes-ink/src/ink/events/input-event.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/events/input-event.ts
@@ -144,6 +144,28 @@ function parseKey(keypress: ParsedKey): [Key, string] {
     processedAsSpecialSequence = true
   }
 
+  // Restore the shifted case for letters that came through a special
+  // sequence. keycodeToName() lowercases every printable codepoint (so
+  // key-binding lookups can compare against a stable name), which means
+  // Shift+T under Kitty CSI u / xterm modifyOtherKeys reaches text input as
+  // "t" — typing under Ghostty's modifyOtherKeys push produces no capitals
+  // at all. Only plain Shift is uppercased: with ctrl/meta/super set the
+  // input string is a binding discriminator, not text, and consumers match
+  // it lowercase.
+  if (
+    processedAsSpecialSequence &&
+    keypress.shift &&
+    !keypress.ctrl &&
+    !keypress.meta &&
+    !keypress.super &&
+    !keypress.option &&
+    input.length === 1 &&
+    input >= 'a' &&
+    input <= 'z'
+  ) {
+    input = input.toUpperCase()
+  }
+
   // Clear input for non-alphanumeric keys (arrows, function keys, etc.)
   // Skip this for CSI u and application keypad mode sequences since
   // those were already converted to their proper input characters.

--- a/ui-tui/packages/hermes-ink/src/ink/events/shifted-letters.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/events/shifted-letters.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+
+import { InputEvent } from './input-event.js'
+import { INITIAL_STATE, parseMultipleKeypresses, type ParsedKey } from '../parse-keypress.js'
+
+/**
+ * Under Ghostty the TUI pushes xterm modifyOtherKeys level 2, so every Shift
+ * combo arrives as ESC[27;2;<codepoint>~ (and as ESC[<codepoint>;2u under the
+ * Kitty protocol). parse-keypress's keycodeToName() lowercases printable
+ * codepoints for stable binding lookups, which used to mean Shift+T reached
+ * text input as "t" — no capital letters at all while the mode was active.
+ */
+function inputFor(sequence: string): { input: string; shift: boolean; ctrl: boolean } {
+  const [items] = parseMultipleKeypresses(INITIAL_STATE, sequence)
+  expect(items).toHaveLength(1)
+  const event = new InputEvent(items[0] as ParsedKey)
+
+  return { input: event.input, shift: event.key.shift, ctrl: event.key.ctrl }
+}
+
+describe('shifted letters under modifyOtherKeys / CSI u', () => {
+  it('uppercases Shift+letter from modifyOtherKeys', () => {
+    expect(inputFor('\x1b[27;2;84~')).toEqual({ input: 'T', shift: true, ctrl: false })
+    expect(inputFor('\x1b[27;2;72~')).toEqual({ input: 'H', shift: true, ctrl: false })
+  })
+
+  it('uppercases Shift+letter from Kitty CSI u', () => {
+    expect(inputFor('\x1b[84;2u')).toEqual({ input: 'T', shift: true, ctrl: false })
+  })
+
+  it('passes shifted symbols through unchanged', () => {
+    expect(inputFor('\x1b[27;2;126~').input).toBe('~')
+    expect(inputFor('\x1b[27;2;33~').input).toBe('!')
+  })
+
+  it('leaves Ctrl combos lowercase so bindings still match', () => {
+    expect(inputFor('\x1b[27;5;99~')).toEqual({ input: 'c', shift: false, ctrl: true })
+  })
+
+  it('does not uppercase Ctrl+Shift combos', () => {
+    expect(inputFor('\x1b[27;6;99~').input).toBe('c')
+  })
+
+  it('leaves Shift+Enter with empty input', () => {
+    expect(inputFor('\x1b[27;2;13~').input).toBe('')
+  })
+
+  it('never leaks the raw escape sequence as text', () => {
+    for (const seq of ['\x1b[27;2;84~', '\x1b[27;2;126~', '\x1b[84;2u']) {
+      expect(inputFor(seq).input).not.toContain('[27;')
+      expect(inputFor(seq).input).not.toContain('\x1b')
+    }
+  })
+})


### PR DESCRIPTION
### Environment

- Terminal: Ghostty 1.3.1 (macOS), `TERM=xterm-ghostty`, `TERM_PROGRAM=ghostty`
- Hermes Agent v0.20.6 (2026.8.27)
- Affects both the classic CLI and the Ink TUI

### Summary

Both surfaces push xterm `modifyOtherKeys` level 2 (`CSI >4;2m`) for Ghostty, so the terminal re-encodes every Shift combo as `ESC[27;<mod>;<codepoint>~`. Three separate defects made those keypresses produce the wrong text. Typing a capital letter in the classic CLI inserted `^[[27;2;84~`; in the Ink TUI it inserted a lowercase `t`.

### Root cause

**1. Classic CLI — wrong data payload (the divergence #95550 flagged as needing a closer look).**

`install_modify_other_keys_aliases()` resolves the sequence correctly:

```python
ANSI_SEQUENCES['\x1b[27;2;84~']  # -> 'T'
```

But `Vt100Parser._call_handler` builds `KeyPress(key, data)` where `data` is the *matched byte sequence*, and prompt_toolkit's default `Keys.Any` binding inserts `event.data` (`key_binding/bindings/basic.py`). So the parser found the right key and typed the raw escape:

```
KeyPress(key='T', data='\x1b[27;2;84~')
```

This is exactly why the standalone `Vt100Parser` simulation in #95550 reported `key='A'` and looked correct while the live CLI still leaked. The alias table was never the problem; the payload was.

`install_plain_char_data_fix()` wraps `_call_handler` so a single-character key whose data is an escape sequence carries the character as its data. `Keys.*` payloads are left alone, so `Ctrl+C`, arrows, and the `(Escape, ControlM)` Shift+Enter tuple keep their raw data.

**2. Classic CLI — shifted symbols had no mapping at all.**

`shift_map` covered letters only, with an explicit comment that shifted digits are layout-specific (US `!` vs AZERTY `¹`). That reasoning holds for the *unshifted* codepoint, but modifyOtherKeys emitters report the **already-shifted** codepoint — Ghostty sends `ESC[27;2;126~` for Shift+`` ` ``. The codepoint *is* the character, so no layout knowledge is required. Printable ASCII 33–126 now maps to itself via `setdefault`, leaving the letter entries and any earlier registration to win.

**3. Ink TUI — shifted letters arrived lowercase (not previously reported).**

No escape leak here: `input-event.ts` already extracts `[27;…~` sequences. The bug is that `keycodeToName()` calls `.toLowerCase()` on every printable codepoint so binding lookups have a stable name, and `parseKey()` hands that lowercased name straight to text input:

```
Shift+T -> input="t" shift=true
```

Under Ghostty's modifyOtherKeys push the TUI produced **no capital letters at all**. `parseKey()` now re-uppercases a single a–z character when the keypress came through a special sequence with plain Shift and no ctrl/meta/super/option. The modifier guard matters: with those set, `input` is a binding discriminator that consumers match lowercase, so `Ctrl+C` and `Ctrl+Shift+C` stay `c`.

### Verification

Verified end to end in both live applications, not only in a parser simulation — given how #95550 played out, that distinction seemed worth insisting on. tmux, `TERM=xterm-ghostty`, feeding the raw bytes for Shift+T, H, I, S, `~` and `!`:

```bash
tmux new-session -d -s t -x 120 -y 40 "TERM=xterm-ghostty TERM_PROGRAM=ghostty ./venv/bin/hermes"
tmux send-keys -t t -l $'\x1b[27;2;84~\x1b[27;2;72~\x1b[27;2;73~\x1b[27;2;83~\x1b[27;2;126~\x1b[27;2;33~'
tmux capture-pane -t t -p | tail -1
```

| Surface | Before | After |
|---|---|---|
| Classic CLI | `^[[27;2;84~` | `Ψ THIS~!` |
| Ink TUI | `this` | `Ψ THIS~!` |

### Tests

- `tests/cli/test_shift_modify_other_keys.py` — both encodings (`ESC[27;2;CP~` and `ESC[CP;2u`), shifted symbols, untouched control keys, idempotent install, and a loop over codepoints 33–126 asserting no `ESC` or `[27;` reaches the buffer.
- `ui-tui/packages/hermes-ink/src/ink/events/shifted-letters.test.ts` — the TUI equivalent, including a Ctrl+Shift case that pins the lowercase discriminator so the guard can't be dropped later.

Suites: Python CLI key handling `243 passed, 2 skipped`; full ui-tui suite `160 files, 1720 passed, 3 skipped, 0 failed`.

### Relationship to existing work

Refs #95550. Overlaps PR #95562, which addresses the CLI plain-char case only — it does not cover the shifted-symbol gap (#2) or the TUI casing bug (#3). Happy to rebase onto that PR if maintainers prefer to land it first; the shifted-symbol and TUI changes are independent of the mechanism chosen for #1.

### One design question for reviewers

Fix #1 monkeypatches a prompt_toolkit internal (`Vt100Parser._call_handler`). It is guarded and idempotent, but a prompt_toolkit major bump could move that method. The alternative is fixing the `Keys.Any` binding to prefer `event.key` for single-character keys, which is arguably where the bug lives but has a wider blast radius across every key path. I went with the narrower change; happy to switch if you'd rather own it at the binding layer.
