### PR TITLE
fix(cron): stop Desktop ticks leaking profile sessions across state stores

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -6368,7 +6368,14 @@ def run_job(
 
             if _session_db_timeout > 0:
                 _session_db_pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
-                _session_db_future = _session_db_pool.submit(SessionDB)
+                # ThreadPoolExecutor does not copy ContextVars. Preserve the
+                # multiplex ticker's per-profile HERMES_HOME override so the
+                # bounded worker opens the job owner's state.db, not the
+                # dashboard/gateway process profile's store (#97489).
+                _session_db_context = contextvars.copy_context()
+                _session_db_future = _session_db_pool.submit(
+                    _session_db_context.run, SessionDB
+                )
                 try:
                     _session_db = _session_db_future.result(timeout=_session_db_timeout)
                 except concurrent.futures.TimeoutError:

--- a/tests/cron/test_sessiondb_init_hang.py
+++ b/tests/cron/test_sessiondb_init_hang.py
@@ -75,6 +75,53 @@ def _session_db_executor(timeouts: list, *, instant_timeout: bool = True):
 
 
 class TestSessionDbInitTimeout:
+    def test_bounded_init_preserves_profile_home_scope(self, tmp_path, monkeypatch):
+        """The timeout worker must open the owning profile's state store."""
+        from hermes_constants import (
+            get_hermes_home,
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+
+        root_home = tmp_path / "dashboard"
+        profile_home = tmp_path / "profiles" / "north-caribbean"
+        root_home.mkdir()
+        profile_home.mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(root_home))
+        monkeypatch.setenv("HERMES_CRON_SESSION_DB_TIMEOUT", "10")
+        opened_homes = []
+        fake_db = MagicMock()
+
+        def _scoped_session_db():
+            opened_homes.append(get_hermes_home())
+            return fake_db
+
+        job = {"id": "profile-scoped-db", "name": "test", "prompt": "hello"}
+        with patch("cron.scheduler._hermes_home", profile_home), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("hermes_cli.env_loader.load_hermes_dotenv"), \
+             patch("hermes_cli.env_loader.reset_secret_source_cache"), \
+             patch("hermes_state.SessionDB", side_effect=_scoped_session_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value=_RUNTIME,
+             ), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+
+            token = set_hermes_home_override(profile_home)
+            try:
+                success, _output, final_response, _error = run_job(job)
+            finally:
+                reset_hermes_home_override(token)
+
+        assert success is True
+        assert final_response == "ok"
+        assert opened_homes == [profile_home]
+        assert mock_agent_cls.call_args.kwargs["session_db"] is fake_db
+
     def test_run_job_does_not_hang_when_sessiondb_init_wedges(self, tmp_path, monkeypatch):
         """run_job proceeds without a session store when SessionDB init times out."""
         monkeypatch.setenv("HERMES_CRON_SESSION_DB_TIMEOUT", "0.2")


### PR DESCRIPTION
## What does this PR do?

Desktop and multiplex gateway cron ticks now persist a job's session in the owning profile's `state.db`. Without this fix, the bounded SessionDB initialization worker loses the active profile ContextVar and silently writes prompts, messages, tool calls, and execution-linked session data into the ticker process profile's store.

### Symptom

When a Desktop backend or multiplex gateway fires a due job for profile A while running under profile B, the job executes with A's configuration but its cron session appears in B's session history. Profile A has no session record of its own run.

### Impact

This breaks the owning profile's audit trail and mixes potentially sensitive session content across profile storage boundaries.

### Bug Cause

**Trigger:** `cron/scheduler.py:6369` in `run_job`, when `cron.session_db_timeout_seconds` is positive (the default).

**Causal chain:**
1. The multiplex scheduler installs profile A's `HERMES_HOME` ContextVar override and dispatches the due job with a copied context.
2. `run_job` opens `SessionDB` in a nested `ThreadPoolExecutor` to bound initialization time, but that executor does not copy ContextVars.
3. `SessionDB()` resolves its default path from process profile B, and the agent persists profile A's complete cron session through that wrong handle.

**Why it is wrong:** The timeout worker crosses a thread boundary without carrying the profile identity that owns every persistence decision for the job.

**Working sibling / contrast:** The unlimited SessionDB initialization path runs inline and follows the active override. The outer cron dispatch and agent inactivity worker already use `contextvars.copy_context()` before crossing executor boundaries.

**Ruled out:** The cron store and outer job executor are already scoped correctly; the regression test observes the correct profile before the nested bounded init and the process profile only inside that worker.

### Fix

Copy the active context immediately before submitting bounded SessionDB initialization and enter it inside the worker. The existing timeout, late-result cleanup, and inline unlimited behavior remain unchanged. A regression test uses distinct process and job-owner homes and proves the constructed session handle follows the owner.

## Related Issue

Closes #97489

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Security fix

## Changes Made

- `cron/scheduler.py` - preserve the active profile context in the bounded SessionDB initialization worker.
- `tests/cron/test_sessiondb_init_hang.py` - reproduce distinct process/profile homes and assert the agent receives a profile-owned session store.

## How to Test

1. Run the focused cross-profile regression; it fails on current `main` by observing the dashboard home and passes with this patch by observing the job-owner home.
2. Run the related scheduler provider and SessionDB timeout suites:

```bash
scripts/run_tests.sh tests/cron/test_sessiondb_init_hang.py tests/cron/test_scheduler_provider.py -q
```

Result: 42 passed.

3. `uv run ruff check cron/scheduler.py tests/cron/test_sessiondb_init_hang.py`

Result: clean.

The broader `tests/cron/` run passed 983 tests and exposed 15 unrelated existing Windows/platform or timing failures in `test_file_permissions.py`, `test_cleanup_timeout.py`, `test_cron_workdir.py`, `test_media_delivery_parity.py`, `test_script_claim_heartbeat.py`, and `test_monitor_kind.py`. The cleanup timeout failure passed on isolated rerun; the focused changed suites remained green.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant suites and all focused tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation is N/A; the code comment records the executor context contract
- [x] `cli-config.yaml.example` is N/A; no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A; no architecture or workflow changed
- [x] Cross-platform impact considered; this uses Python ContextVars and executor APIs uniformly
- [x] Tool descriptions and schemas are N/A; no tool surface changed

## Screenshots / Logs

N/A; the regression asserts the persistence target directly.
