### PR TITLE
fix(models): refresh OpenCode Free catalog from the live relay

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -564,8 +564,10 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "nemotron-3.5-lightning-free",
         "muse-spark-1.2-contributor-free",
     ],
-    # OpenCode free tier — keyless (no OpenCode account needed). Synced
-    # against live GET /zen/v1/models + anonymous probes (2026-08-21);
+    # OpenCode free tier — keyless (no OpenCode account needed). Offline floor
+    # for provider_model_ids("opencode-free"), which refreshes the rotating
+    # catalog from live GET /zen/v1/models and caches it. Last probe-sync:
+    # 2026-08-21;
     # deepseek-v4-flash-free delisted (promo ended, now 401s).
     # big-pickle + mimo-v2.5-free delisted (UA-gated: the relay 429s
     # FreeUsageLimitError for every client except User-Agent
@@ -4098,11 +4100,44 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
         except Exception:
             pass
 
-    # OpenCode Free: curated keyless list only. models.dev's cost.input==0
-    # filter lags reality (deepseek-v4-flash-free stayed "free" there after
-    # its promo ended and the relay began 401ing keyless requests), so the
-    # curated list — synced against anonymous live probes — is authoritative.
+    # OpenCode Free: discover the relay's current keyless catalog directly.
+    # models.dev's cost.input==0 filter lags reality, while an in-repo snapshot
+    # cannot remove a delisted promotion until the next Hermes release. The
+    # outer cached_provider_model_ids() layer gives this the same TTL +
+    # stale-while-revalidate behavior as other provider catalogs. Keep the
+    # curated list only as the offline floor.
     if normalized == "opencode-free":
+        try:
+            live = fetch_api_models(
+                None,
+                _OPENCODE_ZEN_FREE_BASE_URL,
+                headers=opencode_zen_free_headers(),
+            )
+        except Exception:
+            live = None
+        if live is not None:
+            curated_extras = {
+                model.lower()
+                for model in _PROVIDER_MODELS.get(normalized, [])
+                if model.lower() in _OPENCODE_KEYLESS_EXTRA_SLUGS
+            }
+            free_models: list[str] = []
+            seen: set[str] = set()
+            for model in live:
+                bare = normalize_opencode_model_id(normalized, model).strip()
+                key = bare.lower()
+                # A live Zen listing proves availability, but not that an
+                # unsuffixed model accepts anonymous requests. Only suffix
+                # markers plus separately probe-verified curated extras are
+                # safe to expose through this keyless provider.
+                if not key or (
+                    not key.endswith("-free") and key not in curated_extras
+                ):
+                    continue
+                if key not in seen:
+                    seen.add(key)
+                    free_models.append(bare)
+            return free_models
         return list(_PROVIDER_MODELS.get(normalized, []))
 
     # ── Profile-based generic live fetch (all simple api-key providers) ──
@@ -5490,7 +5525,7 @@ def opencode_zen_free_runtime(provider_id: Optional[str], model_id: Optional[str
     - ``provider_id`` is ``opencode-free`` (the dedicated keyless provider —
       EVERY model on it routes anonymously; that is the provider's contract), or
     - ``provider_id`` is any other OpenCode-family provider and ``model_id``
-      is in the VERIFIED keyless catalog (``_PROVIDER_MODELS["opencode-free"]``)
+      is in the last live (or offline curated) keyless catalog
       — heals a free-model selection made under opencode-zen/opencode-go,
       whose keys the free tier rejects.
 
@@ -5504,7 +5539,7 @@ def opencode_zen_free_runtime(provider_id: Optional[str], model_id: Optional[str
         return None
     if family != "opencode-free":
         bare = normalize_opencode_model_id(provider_id, model_id).strip().lower()
-        if bare not in {m.lower() for m in _PROVIDER_MODELS.get("opencode-free", [])}:
+        if bare not in _known_opencode_free_model_ids():
             return None
     normalized = normalize_opencode_model_id(provider_id, model_id)
     api_mode = opencode_model_api_mode("opencode-zen", normalized)
@@ -5519,6 +5554,35 @@ def opencode_zen_free_runtime(provider_id: Optional[str], model_id: Optional[str
         "default_headers": opencode_zen_free_headers(),
         "source": "opencode-zen-free-keyless",
     }
+
+
+def _known_opencode_free_model_ids() -> set[str]:
+    """Return the cache-only keyless catalog used by runtime routing.
+
+    Runtime resolution must not block on a catalog HTTP call. Prefer the
+    same-fingerprint disk cache populated by ``cached_provider_model_ids`` and
+    fall back to the release snapshot when the cache is absent or corrupt.
+    """
+    fallback = {
+        str(model).strip().lower()
+        for model in _PROVIDER_MODELS.get("opencode-free", [])
+        if str(model).strip()
+    }
+    try:
+        entry = _load_provider_models_cache().get("opencode-free")
+        fingerprint = _credential_fingerprint("opencode-free")
+        if (
+            _cache_entry_valid(entry, fingerprint)
+            and time.time() - entry["at"] < _PROVIDER_MODELS_STALE_SERVE_MAX
+        ):
+            return {
+                str(model).strip().lower()
+                for model in entry["models"]
+                if str(model).strip()
+            }
+    except Exception:
+        pass
+    return fallback
 
 
 def opencode_model_api_mode(provider_id: Optional[str], model_id: Optional[str]) -> str:

--- a/tests/hermes_cli/test_models.py
+++ b/tests/hermes_cli/test_models.py
@@ -883,7 +883,10 @@ class TestLocalOllamaModelDiscovery:
 
         row = next(row for row in rows if row["slug"] == "local-llm")
         assert row["models"] == ["qwen3:1.7b"]
-        fetch_api.assert_not_called()
+        assert not any(
+            "127.0.0.1:11434" in str(call)
+            for call in fetch_api.call_args_list
+        )
 
     def test_picker_bare_custom_model_config_discovers_ollama_api_tags(self):
         """The documented model.provider=custom shape should use native tags."""
@@ -1082,7 +1085,10 @@ class TestLocalOllamaModelDiscovery:
 
         row = next(row for row in rows if row["name"] == "Local Ollama")
         assert row["models"] == ["qwen3:1.7b"]
-        fetch_api.assert_not_called()
+        assert not any(
+            "127.0.0.1:11434" in str(call)
+            for call in fetch_api.call_args_list
+        )
 
     def test_model_validation_uses_ollama_api_tags_for_ollama_provider(self):
         """`/model` validation for provider=ollama should not probe `/models`."""

--- a/tests/hermes_cli/test_opencode_free_live_catalog.py
+++ b/tests/hermes_cli/test_opencode_free_live_catalog.py
@@ -1,0 +1,96 @@
+"""Live-catalog regression coverage for the keyless OpenCode Free provider."""
+
+from unittest.mock import patch
+
+
+def test_provider_model_ids_filters_live_catalog_to_keyless_models():
+    from hermes_cli import models
+
+    live = [
+        "paid-model",
+        "laguna-s-2.1-free",
+        "opencode-free/nemotron-3-ultra-free",
+        "laguna-s-2.1-free",
+        "big-pickle",  # live-listed is not enough: this is not probe-verified
+    ]
+    with patch.object(models, "fetch_api_models", return_value=live) as fetch:
+        result = models.provider_model_ids("opencode-free", force_refresh=True)
+
+    assert result == ["laguna-s-2.1-free", "nemotron-3-ultra-free"]
+    fetch.assert_called_once_with(
+        None,
+        models._OPENCODE_ZEN_FREE_BASE_URL,
+        headers=models.opencode_zen_free_headers(),
+    )
+
+
+def test_provider_model_ids_treats_reachable_empty_free_catalog_as_authoritative():
+    from hermes_cli import models
+
+    with patch.object(models, "fetch_api_models", return_value=["paid-model"]):
+        assert models.provider_model_ids("opencode-free") == []
+
+
+def test_provider_model_ids_uses_curated_floor_when_live_fetch_fails():
+    from hermes_cli import models
+
+    with patch.object(models, "fetch_api_models", return_value=None):
+        assert models.provider_model_ids("opencode-free") == list(
+            models._PROVIDER_MODELS["opencode-free"]
+        )
+
+
+def test_cached_provider_catalog_avoids_reprobing_within_ttl(tmp_path, monkeypatch):
+    from hermes_cli import models
+
+    monkeypatch.setattr(models, "_provider_models_cache_path", lambda: tmp_path / "models.json")
+    monkeypatch.setattr(models, "_credential_fingerprint", lambda provider: "keyless-fp")
+    with patch.object(
+        models, "fetch_api_models", return_value=["fresh-model-free"]
+    ) as fetch:
+        assert models.cached_provider_model_ids(
+            "opencode-free", force_refresh=True
+        ) == ["fresh-model-free"]
+        assert models.cached_provider_model_ids("opencode-free") == [
+            "fresh-model-free"
+        ]
+
+    fetch.assert_called_once()
+
+
+def test_runtime_routing_uses_cached_live_catalog(tmp_path, monkeypatch):
+    from hermes_cli import models
+
+    monkeypatch.setattr(models, "_provider_models_cache_path", lambda: tmp_path / "models.json")
+    monkeypatch.setattr(models, "_credential_fingerprint", lambda provider: "keyless-fp")
+    models._save_provider_models_cache(
+        {
+            "opencode-free": {
+                "fp": "keyless-fp",
+                "at": models.time.time(),
+                "models": ["new-rotating-model-free"],
+            }
+        }
+    )
+
+    assert models.opencode_zen_free_runtime(
+        "opencode-zen", "new-rotating-model-free"
+    ) is not None
+    assert models.opencode_zen_free_runtime(
+        "opencode-zen", "x-preview-f-free"
+    ) is None
+
+
+def test_runtime_routing_falls_back_to_curated_catalog_on_corrupt_cache(
+    tmp_path, monkeypatch
+):
+    from hermes_cli import models
+
+    monkeypatch.setattr(models, "_provider_models_cache_path", lambda: tmp_path / "models.json")
+    monkeypatch.setattr(models, "_credential_fingerprint", lambda provider: "keyless-fp")
+    models._save_provider_models_cache(
+        {"opencode-free": {"fp": "wrong", "at": "bad", "models": []}}
+    )
+
+    curated = models._PROVIDER_MODELS["opencode-free"][0]
+    assert models.opencode_zen_free_runtime("opencode-zen", curated) is not None

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -41,7 +41,7 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 | **OpenCode Zen** | `OPENCODE_ZEN_API_KEY` in `~/.hermes/.env` (provider: `opencode-zen`) |
 | **CommandCode** | `COMMANDCODE_API_KEY` in `~/.hermes/.env` (provider: `commandcode`, alias: `commandcode-chat`; Claude models via `commandcode-anthropic`, alias: `commandcode-claude`). Works with GOAT/Pro/Max/Provider plans (not the $1 Go plan — no API access). |
 | **OpenCode Go** | `OPENCODE_GO_API_KEY` in `~/.hermes/.env` (provider: `opencode-go`) |
-| **OpenCode Free** | Keyless — no API key or account needed (provider: `opencode-free`, aliases: `free`, `opencode_free`). Select via `hermes model` or `/model free`; requests are sent anonymously |
+| **OpenCode Free** | Keyless — no API key or account needed (provider: `opencode-free`, aliases: `free`, `opencode_free`). Select via `hermes model` or `/model free`; requests are sent anonymously and the free-model catalog is refreshed from the live relay with an offline curated fallback |
 | **DeepSeek** | `DEEPSEEK_API_KEY` in `~/.hermes/.env` (provider: `deepseek`) |
 | **Hugging Face** | `HF_TOKEN` in `~/.hermes/.env` (provider: `huggingface`, aliases: `hf`) |
 | **Google / Gemini** | `GOOGLE_API_KEY` (or `GEMINI_API_KEY`) in `~/.hermes/.env` (provider: `gemini`) |


### PR DESCRIPTION
## What does this PR do?

Refreshes the keyless `opencode-free` model catalog from OpenCode's live Zen `/models` endpoint instead of treating the release-time snapshot as authoritative.

When OpenCode rotates a promotion, delisted models currently remain selectable until the next Hermes release and then fail at runtime with `401 Model ... is not supported`. Newly added free models are hidden for the same reason.

The live response is normalized, deduplicated, and restricted to `-free` model slugs plus separately probe-verified curated unsuffixed exceptions. The existing TTL/SWR disk cache is reused, and the curated list remains an offline fallback.

## Related Issue

Closes #95914.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Refresh `opencode-free` from the live anonymous Zen catalog.
- Filter paid models, normalize provider-prefixed IDs, and deduplicate results.
- Treat a reachable empty live catalog as authoritative instead of reviving stale models.
- Fall back to the curated release snapshot only when discovery is unavailable.
- Route OpenCode-family healing through the cached live catalog without adding runtime network I/O.
- Add regression coverage for live refresh, offline fallback, TTL reuse, corrupt cache, and stale-model removal.
- Document the live-refresh/offline-fallback behavior.

## Safety and Failure Behavior

- No API key, OAuth token, account credential, or browser/session file is read or transmitted.
- Runtime provider resolution reads cache only and never blocks on catalog HTTP.
- Paid catalog entries are never exposed by the keyless provider.
- A network failure degrades to the existing curated snapshot.

## How to Test

1. Run:
   ```bash
   python -m pytest tests/hermes_cli/test_opencode_free_live_catalog.py tests/hermes_cli/test_opencode_zen_free_keyless.py tests/hermes_cli/test_model_cache_swr.py tests/hermes_cli/test_models.py tests/agent/test_opencode_free_provider.py tests/hermes_cli/test_runtime_provider_resolution.py -q
   ```
2. Verify all 194 focused tests pass.
3. Run `python -m ruff check hermes_cli/models.py tests/hermes_cli/test_opencode_free_live_catalog.py tests/hermes_cli/test_models.py`.
4. Optionally force a read-only refresh with:
   ```bash
   python -c "from hermes_cli.models import provider_model_ids; print(provider_model_ids('opencode-free', force_refresh=True))"
   ```

Local validation returned the current eight free models and excluded the delisted `x-preview-f-free`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11, Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A, no architecture or workflow changes
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — network/cache paths use existing cross-platform helpers
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A, no tool schema changed

## Duplicate Check

I searched open and closed issues and PRs for `opencode-free`, live catalog, keyless cache, free fallback, and model refresh. Issue #95914 has no competing implementation.