### PR TITLE
fix(desktop): preserve model submenu pointer intent

### DIFF
--- a/apps/desktop/e2e/model-menu-pointer-intent.spec.ts
+++ b/apps/desktop/e2e/model-menu-pointer-intent.spec.ts
@@ -51,6 +51,53 @@ test('a deliberate diagonal path through sibling rows reaches the lowest effort 
   await expect(trigger).toContainText('Ultra')
 })
 
+test('Escape dismisses a submenu after a deliberate diagonal path', async () => {
+  const page = fixture!.page
+  const modelButton = page.getByRole('button', { name: /Model · mock:/i })
+
+  await modelButton.click()
+
+  const menu = page.locator('[data-slot="dropdown-menu-content"]:visible').last()
+  const trigger = menu.getByRole('menuitem', { name: /X Preview F Free/i })
+  const triggerBox = await trigger.boundingBox()
+
+  expect(triggerBox).not.toBeNull()
+  await page.mouse.move(triggerBox!.x - 8, triggerBox!.y + triggerBox!.height / 2)
+  await page.mouse.move(triggerBox!.x + triggerBox!.width / 2, triggerBox!.y + triggerBox!.height / 2)
+
+  const lowestEffort = page.getByRole('menuitemradio', { name: 'Ultra' })
+  await expect(lowestEffort).toBeVisible()
+
+  const from = await trigger.boundingBox()
+  const to = await lowestEffort.boundingBox()
+
+  expect(from).not.toBeNull()
+  expect(to).not.toBeNull()
+
+  for (let step = 1; step <= 30; step += 1) {
+    const progress = step / 30
+    await page.mouse.move(
+      from!.x + from!.width / 2 + (to!.x + to!.width / 2 - (from!.x + from!.width / 2)) * progress,
+      from!.y + from!.height / 2 + (to!.y + to!.height / 2 - (from!.y + from!.height / 2)) * progress,
+    )
+    await page.waitForTimeout(30)
+  }
+
+  await expect(lowestEffort).toBeVisible()
+  await page.keyboard.press('Escape')
+  await expect(lowestEffort).not.toBeVisible()
+  await expect(menu).not.toBeVisible()
+  await expect(page.getByRole('textbox', { name: 'Message' })).toBeFocused()
+
+  await modelButton.click()
+  const reopenedMenu = page.locator('[data-slot="dropdown-menu-content"]:visible').last()
+  await expect(reopenedMenu).toBeVisible()
+  await expect(lowestEffort).not.toBeVisible()
+  await page.keyboard.press('Escape')
+  await expect(reopenedMenu).not.toBeVisible()
+  await expect(page.getByRole('textbox', { name: 'Message' })).toBeFocused()
+})
+
 test('intentional vertical movement switches to the sibling submenu promptly', async () => {
   const page = fixture!.page
 

--- a/apps/desktop/e2e/model-menu-pointer-intent.spec.ts
+++ b/apps/desktop/e2e/model-menu-pointer-intent.spec.ts
@@ -1,0 +1,77 @@
+import { expect, test } from '@playwright/test'
+
+import { type MockBackendFixture, setupMockBackend, waitForAppReady } from './fixtures'
+
+let fixture: MockBackendFixture | null = null
+
+test.beforeEach(async () => {
+  fixture = await setupMockBackend()
+  await waitForAppReady(fixture, 120_000)
+})
+
+test.afterEach(async () => {
+  await fixture?.cleanup()
+  fixture = null
+})
+
+test('a deliberate diagonal path through sibling rows reaches the lowest effort option', async () => {
+  const page = fixture!.page
+  const modelButton = page.getByRole('button', { name: /Model · mock:/i })
+
+  await modelButton.click()
+
+  const menu = page.locator('[data-slot="dropdown-menu-content"]:visible').last()
+  const trigger = menu.getByRole('menuitem', { name: /X Preview F Free/i })
+  const triggerBox = await trigger.boundingBox()
+
+  expect(triggerBox).not.toBeNull()
+  await page.mouse.move(triggerBox!.x - 8, triggerBox!.y + triggerBox!.height / 2)
+  await page.mouse.move(triggerBox!.x + triggerBox!.width / 2, triggerBox!.y + triggerBox!.height / 2)
+
+  const lowestEffort = page.getByRole('menuitemradio', { name: 'Ultra' })
+  await expect(lowestEffort).toBeVisible()
+
+  const from = await trigger.boundingBox()
+  const to = await lowestEffort.boundingBox()
+
+  expect(from).not.toBeNull()
+  expect(to).not.toBeNull()
+
+  for (let step = 1; step <= 30; step += 1) {
+    const progress = step / 30
+    await page.mouse.move(
+      from!.x + from!.width / 2 + (to!.x + to!.width / 2 - (from!.x + from!.width / 2)) * progress,
+      from!.y + from!.height / 2 + (to!.y + to!.height / 2 - (from!.y + from!.height / 2)) * progress,
+    )
+    await page.waitForTimeout(30)
+  }
+
+  await expect(trigger).toHaveAttribute('data-state', 'open')
+  await lowestEffort.click()
+  await expect(trigger).toContainText('Ultra')
+})
+
+test('intentional vertical movement switches to the sibling submenu promptly', async () => {
+  const page = fixture!.page
+
+  await page.getByRole('button', { name: /Model · mock:/i }).click()
+
+  const menu = page.locator('[data-slot="dropdown-menu-content"]:visible').last()
+  const first = menu.getByRole('menuitem', { name: /X Preview F Free/i })
+  const sibling = menu.getByRole('menuitem', { name: /Hy3 Free/i })
+
+  await first.focus()
+  await first.press('ArrowRight')
+  await expect(first).toHaveAttribute('data-state', 'open')
+
+  const from = await first.boundingBox()
+  const to = await sibling.boundingBox()
+
+  expect(from).not.toBeNull()
+  expect(to).not.toBeNull()
+
+  await page.mouse.move(from!.x + from!.width / 2, from!.y + from!.height / 2)
+  await page.mouse.move(to!.x + to!.width / 2, to!.y + to!.height / 2)
+
+  await expect(sibling).toHaveAttribute('data-state', 'open', { timeout: 500 })
+})

--- a/apps/desktop/src/app/shell/model-catalog-menu.tsx
+++ b/apps/desktop/src/app/shell/model-catalog-menu.tsx
@@ -1,6 +1,15 @@
 import { useStore } from '@nanostores/react'
 import { useQuery } from '@tanstack/react-query'
-import { createContext, type ReactNode, useContext, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  createContext,
+  type PointerEvent,
+  type ReactNode,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState
+} from 'react'
 
 import { Codicon } from '@/components/ui/codicon'
 import { DisclosureCaret } from '@/components/ui/disclosure-caret'
@@ -132,6 +141,7 @@ export function ModelCatalogMenu({
   const copy = t.shell.modelMenu
   const closeMenu = useContext(ModelMenuCloseContext)
   const [search, setSearch] = useState('')
+  const [openSubKey, setOpenSubKey] = useState<string | null>(null)
   const collapsedProviders = useStoreCollapsed()
   const defaultEffort = useDefaultEffort()
   // Which models the user curated in Edit Models. Read HERE rather than taken
@@ -302,6 +312,8 @@ export function ModelCatalogMenu({
 
   // Keep the selected row in view while arrowing through the scrollable list.
   const listRef = useRef<HTMLDivElement>(null)
+  const pointerSamples = useRef<Array<{ at: number; x: number; y: number }>>([])
+  const pointerIntentActive = useRef(false)
 
   useEffect(() => {
     listRef.current?.querySelector('[data-kb-active]')?.scrollIntoView({ block: 'nearest' })
@@ -314,6 +326,44 @@ export function ModelCatalogMenu({
       className: cn(dropdownMenuRow, active && 'bg-(--ui-control-active-background) text-foreground'),
       ...(active ? { 'data-kb-active': '' } : {})
     }
+  }
+
+  const deferSiblingHover = (event: PointerEvent<HTMLElement>): boolean => {
+    if (event.pointerType !== 'mouse') {
+      return false
+    }
+
+    const samples = pointerSamples.current
+    const previous = samples.at(-2)
+    const current = samples.at(-1)
+    const hoveredTrigger = (event.target as Element).closest<HTMLElement>('[data-model-sub-trigger]')
+    const openTrigger = listRef.current?.querySelector<HTMLElement>('[data-model-sub-trigger][data-state="open"]')
+    const contentId = openTrigger?.getAttribute('aria-controls')
+    const submenu = contentId ? document.getElementById(contentId) : null
+
+    if (
+      !previous ||
+      !current ||
+      current.at - previous.at > 120 ||
+      !openTrigger ||
+      !submenu ||
+      openTrigger === hoveredTrigger
+    ) {
+      return false
+    }
+
+    const triggerRect = openTrigger.getBoundingClientRect()
+    const submenuRect = submenu.getBoundingClientRect()
+    const submenuIsLeft = submenuRect.right <= triggerRect.left
+    const triggerX = submenuIsLeft ? triggerRect.right : triggerRect.left
+    const submenuX = submenuIsLeft ? submenuRect.right : submenuRect.left
+
+    return (
+      current.x >= Math.min(triggerX, submenuX) &&
+      current.x <= Math.max(triggerX, submenuX) &&
+      current.y >= Math.min(triggerRect.top, submenuRect.top) - 8 &&
+      current.y <= Math.max(triggerRect.bottom, submenuRect.bottom) + 8
+    )
   }
 
   // Rows are hover-selectable, so they go inert with the pointer.
@@ -368,7 +418,26 @@ export function ModelCatalogMenu({
           {copy.noModels}
         </DropdownMenuItem>
       ) : (
-        <div className={cn('max-h-[max(150px,30dvh)] overflow-y-auto py-0.5', quietRows)} ref={listRef}>
+        <div
+          className={cn('max-h-[max(150px,30dvh)] overflow-y-auto py-0.5', quietRows)}
+          onPointerMoveCapture={event => {
+            if (event.pointerType !== 'mouse') {
+              return
+            }
+
+            pointerSamples.current = [
+              ...pointerSamples.current.slice(-2),
+              { at: event.timeStamp, x: event.clientX, y: event.clientY }
+            ]
+
+            pointerIntentActive.current = deferSiblingHover(event)
+
+            if (pointerIntentActive.current) {
+              event.preventDefault()
+            }
+          }}
+          ref={listRef}
+        >
           {groups.map(group => {
             const slug = group.provider.slug
 
@@ -397,6 +466,8 @@ export function ModelCatalogMenu({
                 </DropdownMenuItem>
                 {!collapsed &&
                   group.families.map(family => {
+                    const subKey = `${group.provider.slug}:${family.id}`
+
                     // The active id may be the base or its -fast sibling; either
                     // way this one family row represents both.
                     const activeId =
@@ -442,13 +513,31 @@ export function ModelCatalogMenu({
                     }
 
                     return (
-                      <DropdownMenuSub key={`${group.provider.slug}:${family.id}`}>
+                      <DropdownMenuSub
+                        key={subKey}
+                        onOpenChange={open => {
+                          if (pointerIntentActive.current && (!open || openSubKey !== subKey)) {
+                            return
+                          }
+
+                          setOpenSubKey(open ? subKey : null)
+                        }}
+                        open={openSubKey === subKey}
+                      >
                         <DropdownMenuSubTrigger
+                          data-model-sub-trigger=""
                           hideChevron
                           onClick={activate}
                           onKeyDown={event => {
+                            pointerIntentActive.current = false
+
                             if (event.key === 'Enter' || event.key === ' ') {
                               activate()
+                            }
+                          }}
+                          onPointerMove={event => {
+                            if (deferSiblingHover(event)) {
+                              event.preventDefault()
                             }
                           }}
                           {...kbRowProps(`${group.provider.slug}:${family.id}`)}

--- a/apps/desktop/src/app/shell/model-catalog-menu.tsx
+++ b/apps/desktop/src/app/shell/model-catalog-menu.tsx
@@ -313,7 +313,7 @@ export function ModelCatalogMenu({
   // Keep the selected row in view while arrowing through the scrollable list.
   const listRef = useRef<HTMLDivElement>(null)
   const pointerSamples = useRef<Array<{ at: number; x: number; y: number }>>([])
-  const pointerIntentActive = useRef(false)
+  const deferringSiblingHover = useRef(false)
 
   useEffect(() => {
     listRef.current?.querySelector('[data-kb-active]')?.scrollIntoView({ block: 'nearest' })
@@ -430,9 +430,9 @@ export function ModelCatalogMenu({
               { at: event.timeStamp, x: event.clientX, y: event.clientY }
             ]
 
-            pointerIntentActive.current = deferSiblingHover(event)
+            deferringSiblingHover.current = deferSiblingHover(event)
 
-            if (pointerIntentActive.current) {
+            if (deferringSiblingHover.current) {
               event.preventDefault()
             }
           }}
@@ -516,7 +516,7 @@ export function ModelCatalogMenu({
                       <DropdownMenuSub
                         key={subKey}
                         onOpenChange={open => {
-                          if (pointerIntentActive.current && (!open || openSubKey !== subKey)) {
+                          if (deferringSiblingHover.current && (!open || openSubKey !== subKey)) {
                             return
                           }
 
@@ -529,8 +529,6 @@ export function ModelCatalogMenu({
                           hideChevron
                           onClick={activate}
                           onKeyDown={event => {
-                            pointerIntentActive.current = false
-
                             if (event.key === 'Enter' || event.key === ' ') {
                               activate()
                             }
@@ -557,6 +555,9 @@ export function ModelCatalogMenu({
                           fastControl={fastControl}
                           isActive={isCurrent}
                           model={family.id}
+                          onPointerEnter={() => {
+                            deferringSiblingHover.current = false
+                          }}
                           onSelectModel={nextModel => controller.select(nextModel, group.provider.slug)}
                           onSetOptions={patch =>
                             controller.setOptions(patch, {

--- a/apps/desktop/src/app/shell/model-edit-submenu.tsx
+++ b/apps/desktop/src/app/shell/model-edit-submenu.tsx
@@ -84,6 +84,8 @@ interface ModelEditSubmenuProps {
   onSetOptions: (patch: { effort?: string; fast?: boolean }) => void
   /** This row's provider slug. */
   provider: string
+  /** Consume transient sibling-hover intent once the pointer reaches this portal. */
+  onPointerEnter?: () => void
   /** Whether this model supports reasoning effort. */
   reasoning: boolean
 }
@@ -95,7 +97,7 @@ export function ModelEditSubmenu(props: ModelEditSubmenuProps) {
   // the sub actually opens — eagerly running the body's hooks/JSX for every
   // row made opening the menu itself lag on large catalogs.
   return (
-    <DropdownMenuSubContent className="w-52 p-0" sideOffset={4}>
+    <DropdownMenuSubContent className="w-52 p-0" onPointerEnter={props.onPointerEnter} sideOffset={4}>
       <ModelEditSubmenuBody {...props} />
     </DropdownMenuSubContent>
   )


### PR DESCRIPTION
## Summary

Fixes #97505.

Preserves the active model-options submenu while a mouse/trackpad pointer travels diagonally through a sibling-row region toward the portaled submenu. Deliberate vertical movement still switches siblings promptly, and entering the submenu consumes the transient intent so later Escape/dismiss behavior is unaffected.

## Scope

Exactly three Desktop files:

- `apps/desktop/src/app/shell/model-catalog-menu.tsx`
- `apps/desktop/src/app/shell/model-edit-submenu.tsx`
- `apps/desktop/e2e/model-menu-pointer-intent.spec.ts`

Base: `3340bbbdad8368e7f3d9f6827d61692adbbd87d6`

Head: `3627aaa4e5438df4e1ce8a1ae4e5df529d1caeb0`

No shared DropdownMenu primitive changes, dependency changes, overlays, global listeners, or timer engine.

## TDD and runtime evidence

- RED: on unmodified main, a continuous 900 ms diagonal Electron trajectory closed the intended trigger before reaching the lowest option.
- GREEN: the same trajectory reaches and selects the lowest effort option.
- Sabotage: disabling sibling-hover deferral reproduced the original closed-trigger failure; restoring the seam returned green.
- Regression: diagonal movement followed by Escape closes the submenu/menu, restores composer focus, and reopens cleanly.
- Intentional vertical movement switches to a sibling submenu promptly.
- Focused Vitest: 3 files, 30 passed.
- Expanded related Vitest: 5 files, 44 passed.
- Desktop typecheck: passed.
- Production build: passed.
- Changed-file ESLint: passed.
- `git diff --check`: passed.
- Isolated Electron/Playwright pointer suite: 3 passed on Xvfb `DISPLAY=:98` with X11 explicitly selected and the host display unused.
- Host workspaces were unchanged: DP-1=1 and DP-2=2 before and after. The X11 socket and Xvfb process were cleaned up.

## Review closure

An initial independent review found that stale pointer intent could veto a later Escape/dismiss after entering the portaled submenu. The repair consumes that intent on submenu entry and adds the diagonal-then-Escape runtime regression. A second independent cold review approved this exact head SHA and reran the focused/expanded tests, typecheck, build, ESLint, diff check, and isolated three-trajectory Electron suite.

## Design and performance

The change integrates with Radix's existing bounded submenu grace instead of competing with it. Deferral is limited to mouse sibling-hover replacement; keyboard, touch/click, Enter/Space, Escape, outside-click, focus restoration, and screen-reader semantics keep their existing paths.

Pointer history is bounded to three samples. The hot path creates only a tiny bounded replacement array. There is no added global pointer listener or timer; React/Radix lifecycle owns cleanup, and transient intent is consumed when the pointer enters the portaled submenu.

## Non-goals

This does not address submenu affordance/keyboard discovery (#86966), dialog stacking (#80798), or scroll-position drift (#55856 / #55858).

## AI disclosure

Implemented and tested with Hermes Agent assistance under human direction. The exact patch was independently reviewed and runtime-verified before publication.

## Publication state

Draft only. This PR is not ready for merge or ready-for-review without explicit human approval.
