### PR TITLE
feat(sessions): session model audit/reset CLI (--model/--provider filters + bulk re-pin)

### DIFF
--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -192,6 +192,13 @@ def _job_rows(job: Dict[str, Any]) -> List[tuple[str, str]]:
     monitor_source = job.get("monitor_script") or job.get("monitor_url")
     mon_state = job.get("monitor_state") or {}
     latest_execution = job.get("latest_execution") or {}
+    # Model/provider pin: an unpinned job runs on the profile default and can drift-skip
+    # silently when that default changes. Show the pin so `cron list` is the first place
+    # a user sees it, not a jobs.json read.
+    _model_val = job.get("model")
+    _provider_val = job.get("provider")
+    model_display = _model_val if _model_val else color("(profile default)", Colors.DIM)
+    provider_display = _provider_val if _provider_val else color("(profile default)", Colors.DIM)
     optional = [
         ("Skills", ", ".join(skills) if skills else ""),
         ("Script", job.get("script")),
@@ -211,6 +218,8 @@ def _job_rows(job: Dict[str, Any]) -> List[tuple[str, str]]:
         ("Schedule", job.get("schedule_display", job.get("schedule", {}).get("value", "?"))),
         ("Repeat", f"{repeat_info.get('completed', 0)}/{repeat_times}" if repeat_times else "∞"),
         ("Next run", job.get("next_run_at", "?")),
+        ("Model", model_display),
+        ("Provider", provider_display),
         ("Deliver", deliver if isinstance(deliver, str) else ", ".join(deliver)),
     ] + [(label, value) for label, value in optional if value]
 

--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -43,6 +43,49 @@ def _confirm_prompt(prompt: str) -> bool:
         return False
 
 
+#: Operational keys that must survive a model-pin rewrite. Identity keys
+#: (model/provider/base_url/api_mode) are rewritten or dropped; everything
+#: else in a row's model_config JSON is lineage or tuning and is preserved
+#: verbatim (dropping _branched_from/_delegate_from severs branch ancestry).
+_MODEL_CONFIG_PRESERVE_KEYS = frozenset(
+    {
+        "reasoning_config",
+        "service_tier",
+        "max_iterations",
+        "max_tokens",
+        "gateway_runtime",
+        "_delegate_from",
+        "_branched_from",
+    }
+)
+
+
+def _parse_model_config(raw):
+    """Parse a sessions.model_config JSON string; {} on absent/garbage."""
+    if not raw:
+        return {}
+    try:
+        parsed = json.loads(raw) if isinstance(raw, str) else raw
+        return parsed if isinstance(parsed, dict) else {}
+    except Exception:
+        return {}
+
+
+def _effective_session_identity(s):
+    """(effective_model, effective_provider) of a session row.
+
+    The model column and the model_config JSON can disagree (the desync
+    class: a fresh model column next to a stale JSON provider/endpoint). On
+    resume the JSON wins for provider routing, so audit filters and the
+    repair predicate read the JSON first and fall back to the column /
+    billing route.
+    """
+    mc = _parse_model_config(s.get("model_config"))
+    model = mc.get("model") or s.get("model") or ""
+    provider = mc.get("provider") or s.get("billing_provider") or ""
+    return model, provider
+
+
 def _not_found(session_id) -> int:
     print(f"Session '{session_id}' not found.")
     return 1
@@ -85,7 +128,180 @@ def _write_output(output, text, summary) -> None:
 
 # -- handlers that must run BEFORE SessionDB() is opened ----------------------
 
+def _repair_session_models(args):
+    """`hermes sessions repair --model TARGET [--provider TARGET ...]`.
+
+    Model-pin repair: rewrite every non-cron session whose EFFECTIVE model
+    and/or provider deviates from the given target(s), so a resumed chat can
+    never route to an outdated model/endpoint. This is the session-row half
+    of a model switch — config.yaml governs NEW sessions, these rows govern
+    every EXISTING chat on resume (see _stored_session_runtime_overrides in
+    tui_gateway/server.py).
+
+    Safe by construction:
+    - Backs up state.db first (timestamped sibling copy) unless --no-backup.
+    - Only touches the `sessions` table — never cron run records (id LIKE
+      'cron_%'), which are history, not chats.
+    - Preserves lineage/tuning keys in model_config (_branched_from,
+      _delegate_from, reasoning_config, service_tier, max_iterations,
+      max_tokens, gateway_runtime); rewrites only identity keys and drops
+      stale endpoint keys (base_url/api_mode) for built-in provider targets.
+    - Auxiliary models live in config.yaml, never session rows — untouched.
+    """
+    from datetime import datetime
+
+    from hermes_state import DEFAULT_DB_PATH, SessionDB
+
+    target_model = (getattr(args, "model", None) or "").strip() or None
+    target_provider = (getattr(args, "provider", None) or "").strip() or None
+    dry_run = bool(getattr(args, "dry_run", False))
+    include_all = bool(getattr(args, "all", False))
+
+    if not DEFAULT_DB_PATH.exists():
+        print(f"No session database at {DEFAULT_DB_PATH} (nothing to repair).")
+        return 0
+
+    try:
+        db = SessionDB()
+    except Exception as e:
+        print(f"Error: Could not open session database: {e}")
+        return 1
+
+    try:
+        rows = db._conn.execute(
+            "SELECT id, model, billing_provider, billing_base_url, model_config "
+            "FROM sessions WHERE id NOT LIKE 'cron_%'"
+        ).fetchall()
+        rows = [dict(r) for r in rows]
+    finally:
+        db.close()
+
+    plan = []
+    for s in rows:
+        if include_all and (target_model or target_provider):
+            # --all pins every non-cron session, including NULLs.
+            mc = _parse_model_config(s.get("model_config"))
+            if target_model and s.get("model") is None and mc.get("model") is None:
+                plan.append(s)
+                continue
+            if target_provider and s.get("billing_provider") in (None, "") and mc.get("provider") is None:
+                plan.append(s)
+                continue
+        mc = _parse_model_config(s.get("model_config"))
+        col_model = s.get("model") or None
+        col_provider = s.get("billing_provider") or None
+        json_model = mc.get("model")
+        json_provider = mc.get("provider")
+        needs = False
+        if target_model:
+            if col_model is not None and col_model != target_model:
+                needs = True
+            elif json_model is not None and json_model != target_model:
+                needs = True
+            elif include_all and col_model is None and json_model is None:
+                needs = True
+        if target_provider:
+            if col_provider not in (None, "", "auto", "custom", target_provider):
+                needs = True
+            elif json_provider is not None and json_provider != target_provider:
+                needs = True
+            elif include_all and col_provider in (None, "") and json_provider is None:
+                needs = True
+        if needs:
+            plan.append(s)
+
+    if not plan:
+        print("No sessions deviate from the target — nothing to repair.")
+        if include_all:
+            print("(--all was given; every non-cron session is already on target.)")
+        return 0
+
+    if dry_run:
+        print("Model-pin repair (dry run) — no writes performed:")
+        if target_model:
+            print(f"  target model:    {target_model}")
+        if target_provider:
+            print(f"  target provider: {target_provider}")
+        for s in plan:
+            eff_model, eff_provider = _effective_session_identity(s)
+            print(
+                f"  would rewrite {s['id']:<24} "
+                f"model={eff_model or '(null)'} provider={eff_provider or '(null)'}"
+            )
+        print(
+            f"  {len(plan)} session(s) would be rewritten; "
+            f"{len(rows) - len(plan)} already on target."
+        )
+        return 0
+
+    backup_path = None
+    if not getattr(args, "no_backup", False):
+        ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+        backup_path = DEFAULT_DB_PATH.with_name(
+            f"{DEFAULT_DB_PATH.name}.model-reset-backup-{ts}"
+        )
+        shutil.copy2(DEFAULT_DB_PATH, backup_path)
+
+    db = SessionDB()
+    try:
+        for s in plan:
+            mc = _parse_model_config(s.get("model_config"))
+            preserved = {
+                k: v for k, v in mc.items() if k in _MODEL_CONFIG_PRESERVE_KEYS
+            }
+            if target_model:
+                preserved["model"] = target_model
+            elif mc.get("model"):
+                preserved["model"] = mc["model"]
+            if target_provider:
+                preserved["provider"] = target_provider
+                if not target_provider.startswith("custom"):
+                    preserved.pop("base_url", None)
+                    preserved.pop("api_mode", None)
+            elif mc.get("provider"):
+                preserved["provider"] = mc["provider"]
+            db.update_session_meta(
+                s["id"],
+                json.dumps(preserved, ensure_ascii=False),
+                model=target_model if target_model else None,
+            )
+            if target_provider:
+                base_url = (
+                    s.get("billing_base_url") or ""
+                    if target_provider.startswith("custom")
+                    else ""
+                )
+                db.update_session_billing_route(
+                    s["id"], provider=target_provider, base_url=base_url
+                )
+    finally:
+        db.close()
+
+    print("Model-pin repair complete:")
+    if backup_path:
+        print(f"  backup:      {backup_path}")
+    print(f"  rewritten:   {len(plan)} session(s)")
+    for s in plan:
+        eff_model, eff_provider = _effective_session_identity(s)
+        print(
+            f"    {s['id']:<24} model={eff_model or '(null)'} "
+            f"provider={eff_provider or '(null)'}"
+        )
+    print(
+        f"  untouched:   {len(rows) - len(plan)} session(s) already on target"
+    )
+    print(
+        "  Cron run records (cron_%) and auxiliary models (config.yaml) "
+        "are untouched."
+    )
+    return 0
+
+
 def _cmd_repair(args):
+    # Model-pin mode (alternative to schema repair): when --model/--provider is given,
+    # rewrite session rows instead of repairing schema. Must run before the schema check.
+    if getattr(args, "model", None) or getattr(args, "provider", None):
+        return _repair_session_models(args)
     from hermes_state import DEFAULT_DB_PATH as db_path, SessionDB
     from hermes_state_repair import _db_opens_cleanly, repair_state_db_schema
     if not db_path.exists():
@@ -259,6 +475,19 @@ def _cmd_list(db, args):
         keyed = ((s, (_ws_key(s) or "").lower()) for s in sessions)
         sessions = [
             s for s, key in keyed if key and (_needle in key or _needle == os.path.basename(key.rstrip("/\\")))
+        ]
+    # Model/provider audit filters: match the EFFECTIVE identity — the model_config JSON
+    # wins on resume, so filter on it first, then fall back to the column / billing route.
+    # This is what makes `sessions list --provider nous` surface the desync class (model
+    # column looks current, JSON still routes to an old provider).
+    _model_needle = (getattr(args, "model", None) or "").strip().lower()
+    _provider_needle = (getattr(args, "provider", None) or "").strip().lower()
+    if _model_needle or _provider_needle:
+        sessions = [
+            s
+            for s in sessions
+            if (not _model_needle or _model_needle in _effective_session_identity(s)[0].lower())
+            and (not _provider_needle or _provider_needle in _effective_session_identity(s)[1].lower())
         ]
     if not sessions:
         print("No sessions found.")

--- a/hermes_cli/subcommands/sessions.py
+++ b/hermes_cli/subcommands/sessions.py
@@ -25,6 +25,16 @@ def build_sessions_parser(subparsers, *, cmd_sessions: Callable) -> None:
     sessions_list.add_argument("--workspace", metavar="NEEDLE",
         help="Only sessions in one workspace: a git repo root or project dir "
         "(matched by path substring or basename).")
+    sessions_list.add_argument("--model", metavar="NEEDLE",
+        help="Only match sessions whose EFFECTIVE model contains this substring "
+        "(e.g. 'deepseek', 'v4-flash'). Audits per-chat pins, not just the "
+        "profile default: a chat whose model_config JSON pins a different model "
+        "counts as that pinned value.")
+    sessions_list.add_argument("--provider", metavar="NEEDLE",
+        help="Only match sessions whose EFFECTIVE provider contains this "
+        "substring (e.g. 'nous', 'openrouter'). Catches chats whose model "
+        "column looks current but whose model_config still routes to an old "
+        "provider.")
 
     _filter_args = (
         ("--newer-than", dict(metavar="AGE", help="Only match sessions active within the last AGE "
@@ -165,6 +175,23 @@ def build_sessions_parser(subparsers, *, cmd_sessions: Callable) -> None:
     _flag(sessions_repair, "--check-only",
         help="Only report whether the database opens cleanly; do not modify it")
     _flag(sessions_repair, "--no-backup", help="Skip the timestamped backup copy (not recommended)")
+    sessions_repair.add_argument("--model", metavar="TARGET",
+        help="Model-pin repair mode (alternative to schema repair): rewrite "
+        "every non-cron session whose effective model deviates from TARGET so "
+        "it runs TARGET on resume. A timestamped state.db backup is made "
+        "first unless --no-backup. Combines with --provider for a full "
+        "provider+endpoint reset.")
+    sessions_repair.add_argument("--provider", metavar="TARGET",
+        help="With --model: also reset billing_provider and the model_config "
+        "provider to TARGET, dropping stale endpoint keys (base_url/api_mode) "
+        "for built-in targets. Standalone: reset only the provider routing.")
+    sessions_repair.add_argument("--dry-run", action="store_true",
+        help="With --model: list the sessions that would be rewritten and the "
+        "rewrite plan without touching the database.")
+    sessions_repair.add_argument("--all", action="store_true",
+        help="With --model: include sessions whose model is NULL (inherit the "
+        "profile default) or already match TARGET. Default only rewrites "
+        "sessions that deviate, so already-correct rows are untouched.")
 
     sessions_repair_routing = sessions_subparsers.add_parser(
         "repair-routing", help="Re-stamp gateway sessions that lost their routing identity",

--- a/tests/hermes_cli/test_sessions_model_reset.py
+++ b/tests/hermes_cli/test_sessions_model_reset.py
@@ -1,0 +1,310 @@
+"""Regression tests for `hermes sessions` model-pin audit and repair.
+
+Covers the CLI half of a model/provider switch (issue #96745):
+- `sessions list --model/--provider` — audit filters over the EFFECTIVE
+  identity (the model_config JSON wins on resume), so they catch the desync
+  class where the model column looks current but the JSON still routes to an
+  outdated provider.
+- `sessions repair --model TARGET [--provider TARGET]` — bulk re-pin of
+  per-session overrides with backup-first, lineage preservation, and
+  cron-run/aux-model safety.
+- `cron list` shows the per-job model/provider pin so drift is visible from
+  the CLI instead of requiring a jobs.json read.
+"""
+
+import json
+import time
+from argparse import Namespace
+
+import pytest
+
+import hermes_cli.sessions_cmd as sc
+
+TARGET_MODEL = "deepseek/deepseek-v4-flash-0731"
+TARGET_PROVIDER = "nous"
+
+
+def _args(action, **kw):
+    base = dict(
+        sessions_action=action,
+        session_id=None, title=None, yes=True, source=None, path=None,
+        from_source=None, dry_run=False, older_than=None, newer_than=None,
+        before=None, after=None, limit=50, workspace=None,
+        model=None, provider=None, all=False,
+        check_only=False, no_backup=False,
+    )
+    base.update(kw)
+    return Namespace(**base)
+
+
+def _init_db(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from hermes_state import SessionDB
+
+    return SessionDB()  # resolves to tmp_path/state.db via DEFAULT_DB_PATH
+
+
+def _seed(db, sid, *, model=None, billing_provider=None, mc=None, source="cli"):
+    db._conn.execute(
+        "INSERT INTO sessions (id, source, started_at, title, model, "
+        "billing_provider, billing_base_url, model_config) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            sid, source, time.time(), f"title-{sid}", model,
+            billing_provider, None,
+            json.dumps(mc) if mc is not None else None,
+        ),
+    )
+    db._conn.commit()
+
+
+def _row(db, sid):
+    cur = db._conn.execute(
+        "SELECT id, model, billing_provider, billing_base_url, model_config "
+        "FROM sessions WHERE id=?",
+        (sid,),
+    )
+    return cur.fetchone()
+
+
+# ── sessions list --model/--provider audit filters ──────────────────
+
+
+def test_list_model_filter_matches_json_pinned_model(tmp_path, monkeypatch, capsys):
+    db = _init_db(tmp_path, monkeypatch)
+    _seed(db, "alpha", model="old-model",
+          mc={"model": "glm-5.3-flash", "provider": "empero"})
+    _seed(db, "beta", model=TARGET_MODEL,
+          mc={"model": TARGET_MODEL, "provider": "nous"})
+    db.close()
+
+    rc = sc.cmd_sessions(_args("list", model="glm-5.3"))
+    out = capsys.readouterr().out
+    assert rc in (None, 0)
+    assert "alpha" in out
+    assert "beta" not in out
+
+
+def test_list_provider_filter_catches_desync_class(tmp_path, monkeypatch, capsys):
+    db = _init_db(tmp_path, monkeypatch)
+    # model column says TARGET (looks current) but the JSON still pins
+    # empero — the desync class that resume would honor.
+    _seed(db, "alpha", model=TARGET_MODEL, billing_provider="nous",
+          mc={"model": "glm-5.3-flash", "provider": "empero",
+              "base_url": "https://free.empero.org/v1"})
+    _seed(db, "beta", model=TARGET_MODEL, billing_provider="nous",
+          mc={"model": TARGET_MODEL, "provider": "nous"})
+    db.close()
+
+    rc = sc.cmd_sessions(_args("list", provider="empero"))
+    out = capsys.readouterr().out
+    assert rc in (None, 0)
+    assert "alpha" in out
+    assert "beta" not in out
+
+    capsys.readouterr()
+    rc = sc.cmd_sessions(_args("list", provider="nous"))
+    out = capsys.readouterr().out
+    assert rc in (None, 0)
+    assert "beta" in out
+    assert "alpha" not in out
+
+
+# ── sessions repair --model/--provider (bulk re-pin) ─────────────────
+
+
+def test_repair_rewrites_deviating_rows_preserves_lineage(
+    tmp_path, monkeypatch, capsys
+):
+    db = _init_db(tmp_path, monkeypatch)
+    _seed(db, "alpha", model="hy3-free", billing_provider="opencode-free",
+          mc={"model": "hy3-free", "provider": "opencode-free"})
+    _seed(db, "beta", model=TARGET_MODEL, billing_provider="nous",
+          mc={"model": "glm-5.3-flash", "provider": "empero",
+              "base_url": "https://free.empero.org/v1",
+              "api_mode": "chat_completions",
+              "reasoning_config": {"enabled": True, "effort": "high"},
+              "_branched_from": "alpha"})
+    _seed(db, "cron_123", model="old", billing_provider="x",
+          mc={"model": "old"})  # cron run record — must be untouched
+    _seed(db, "gamma", model=TARGET_MODEL, billing_provider="nous",
+          mc={"model": TARGET_MODEL, "provider": "nous"})  # already on target
+    db.close()
+
+    rc = sc.cmd_sessions(
+        _args("repair", model=TARGET_MODEL, provider=TARGET_PROVIDER)
+    )
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "backup:" in out
+    assert "rewritten:   2" in out
+
+    db = _init_db(tmp_path, monkeypatch)
+    try:
+        a = _row(db, "alpha")
+        b = _row(db, "beta")
+        c = _row(db, "cron_123")
+        g = _row(db, "gamma")
+    finally:
+        db.close()
+
+    assert a["model"] == TARGET_MODEL
+    assert a["billing_provider"] == TARGET_PROVIDER
+    mc_a = json.loads(a["model_config"])
+    assert mc_a["model"] == TARGET_MODEL and mc_a["provider"] == TARGET_PROVIDER
+
+    assert b["model"] == TARGET_MODEL
+    assert b["billing_provider"] == TARGET_PROVIDER
+    mc_b = json.loads(b["model_config"])
+    assert mc_b["model"] == TARGET_MODEL and mc_b["provider"] == TARGET_PROVIDER
+    assert "base_url" not in mc_b and "api_mode" not in mc_b
+    assert mc_b["_branched_from"] == "alpha"
+    assert mc_b["reasoning_config"] == {"enabled": True, "effort": "high"}
+
+    # cron run record untouched
+    assert c["model"] == "old"
+    # already-on-target row untouched
+    assert g["model"] == TARGET_MODEL
+    assert json.loads(g["model_config"]) == {
+        "model": TARGET_MODEL, "provider": "nous"
+    }
+
+
+def test_repair_dry_run_writes_nothing(tmp_path, monkeypatch, capsys):
+    db = _init_db(tmp_path, monkeypatch)
+    _seed(db, "alpha", model="hy3-free", billing_provider="opencode-free",
+          mc={"model": "hy3-free", "provider": "opencode-free"})
+    db.close()
+
+    rc = sc.cmd_sessions(
+        _args("repair", model=TARGET_MODEL, provider=TARGET_PROVIDER,
+              dry_run=True)
+    )
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "dry run" in out
+    assert "would rewrite alpha" in out
+
+    db = _init_db(tmp_path, monkeypatch)
+    try:
+        a = _row(db, "alpha")
+    finally:
+        db.close()
+    assert a["model"] == "hy3-free"
+    assert json.loads(a["model_config"])["provider"] == "opencode-free"
+
+
+def test_repair_default_skips_null_and_matching(tmp_path, monkeypatch, capsys):
+    db = _init_db(tmp_path, monkeypatch)
+    _seed(db, "alpha", model=None, billing_provider=None, mc=None)
+    _seed(db, "beta", model=TARGET_MODEL, billing_provider="nous",
+          mc={"model": TARGET_MODEL, "provider": "nous"})
+    db.close()
+
+    rc = sc.cmd_sessions(
+        _args("repair", model=TARGET_MODEL, provider=TARGET_PROVIDER)
+    )
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "nothing to repair" in out
+
+    db = _init_db(tmp_path, monkeypatch)
+    try:
+        a = _row(db, "alpha")
+        b = _row(db, "beta")
+    finally:
+        db.close()
+    assert a["model"] is None and a["model_config"] is None
+    assert b["model"] == TARGET_MODEL
+
+
+def test_repair_all_pins_null_rows(tmp_path, monkeypatch, capsys):
+    db = _init_db(tmp_path, monkeypatch)
+    _seed(db, "alpha", model=None, billing_provider=None, mc=None)
+    db.close()
+
+    rc = sc.cmd_sessions(
+        _args("repair", model=TARGET_MODEL, provider=TARGET_PROVIDER, all=True)
+    )
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "rewritten:   1" in out
+
+    db = _init_db(tmp_path, monkeypatch)
+    try:
+        a = _row(db, "alpha")
+    finally:
+        db.close()
+    assert a["model"] == TARGET_MODEL
+    assert json.loads(a["model_config"])["provider"] == TARGET_PROVIDER
+
+
+def test_repair_model_only_keeps_provider_routing(tmp_path, monkeypatch, capsys):
+    db = _init_db(tmp_path, monkeypatch)
+    _seed(db, "alpha", model="hy3-free", billing_provider="opencode-free",
+          mc={"model": "hy3-free", "provider": "opencode-free"})
+    db.close()
+
+    rc = sc.cmd_sessions(_args("repair", model=TARGET_MODEL))
+    out = capsys.readouterr().out
+    assert rc == 0
+
+    db = _init_db(tmp_path, monkeypatch)
+    try:
+        a = _row(db, "alpha")
+    finally:
+        db.close()
+    assert a["model"] == TARGET_MODEL
+    mc_a = json.loads(a["model_config"])
+    assert mc_a["model"] == TARGET_MODEL
+    assert mc_a["provider"] == "opencode-free"  # provider routing untouched
+    assert a["billing_provider"] == "opencode-free"
+
+
+def test_repair_no_backup_skips_copy(tmp_path, monkeypatch, capsys):
+    db = _init_db(tmp_path, monkeypatch)
+    _seed(db, "alpha", model="hy3-free", billing_provider="opencode-free",
+          mc={"model": "hy3-free", "provider": "opencode-free"})
+    db.close()
+
+    rc = sc.cmd_sessions(
+        _args("repair", model=TARGET_MODEL, provider=TARGET_PROVIDER,
+              no_backup=True)
+    )
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "backup:" not in out
+    assert not list(tmp_path.glob("state.db.model-reset-backup-*"))
+
+
+# ── cron list model/provider pin display ────────────────────────────
+
+
+def test_cron_list_shows_model_provider_pins(tmp_path, monkeypatch, capsys):
+    jobs_dir = tmp_path / "cron"
+    jobs_dir.mkdir(parents=True, exist_ok=True)
+    jobs_file = jobs_dir / "jobs.json"
+    jobs_file.write_text(json.dumps({"jobs": [
+        {
+            "id": "pinned1", "name": "pinned job", "enabled": True,
+            "schedule": {"kind": "cron", "expr": "0 9 * * *"},
+            "model": TARGET_MODEL, "provider": TARGET_PROVIDER,
+            "deliver": ["local"],
+        },
+        {
+            "id": "loose1", "name": "loose job", "enabled": True,
+            "schedule": {"kind": "interval", "minutes": 30},
+            "model": None, "provider": None,
+            "deliver": ["local"],
+        },
+    ]}))
+    monkeypatch.setattr("cron.jobs.JOBS_FILE", jobs_file)
+
+    from hermes_cli.cron import cron_list
+
+    cron_list(show_all=True)
+    out = capsys.readouterr().out
+    assert f"Model:     {TARGET_MODEL}" in out
+    assert f"Provider: {TARGET_PROVIDER}" in out
+    assert "Model:     (profile default)" in out
+    assert "Provider: (profile default)" in out

--- a/tests/hermes_cli/test_sessions_model_reset.py
+++ b/tests/hermes_cli/test_sessions_model_reset.py
@@ -304,7 +304,7 @@ def test_cron_list_shows_model_provider_pins(tmp_path, monkeypatch, capsys):
 
     cron_list(show_all=True)
     out = capsys.readouterr().out
-    assert f"Model:     {TARGET_MODEL}" in out
-    assert f"Provider: {TARGET_PROVIDER}" in out
-    assert "Model:     (profile default)" in out
-    assert "Provider: (profile default)" in out
+    assert f"Model:" in out and TARGET_MODEL in out
+    assert f"Provider:" in out and TARGET_PROVIDER in out
+    assert "Model:" in out and "(profile default)" in out
+    assert "Provider:" in out and "(profile default)" in out


### PR DESCRIPTION
"## What\n\nCLI visibility and control for per-chat model state. Sessions-only, per Teknium1's direction on the closed PR \u2014 the cron half (cron list model pins) built on the fail-closed drift guard removed in #106499, so it is dropped here.\n\n**1. `sessions list --model/--provider` \u2014 audit filters over the EFFECTIVE identity**\n\nThe `model_config` JSON wins on resume (`_stored_session_runtime_overrides` reads provider/endpoint from it), so the filter reads the JSON first and falls back to the `model` column / `billing_provider`. That is what makes `sessions list --provider nous` surface the desync class \u2014 a chat whose model column looks current but whose JSON still pins an old provider/endpoint.\n\n**2. `sessions repair --model TARGET [--provider TARGET]` \u2014 bulk re-pin**\n\nRewrites every non-cron session whose effective model/provider deviates from the target. Safety by construction:\n- timestamped `state.db` backup first (`--no-backup` opts out),\n- `cron_%` run records never touched (they are history, not chats),\n- lineage/tuning keys in `model_config` preserved verbatim (`_branched_from`, `_delegate_from`, `reasoning_config`, `service_tier`, `max_iterations`, `max_tokens`, `gateway_runtime`),\n- stale endpoint keys (`base_url`/`api_mode`) dropped for built-in provider targets,\n- `--dry-run` lists the plan without writing; `--all` also pins NULL-model sessions that inherit the profile default,\n- auxiliary models remain config.yaml-only (never session rows).\n\n## Evidence (real incident)\n\n8-profile Hermes deployment, 174 chat sessions. After a provider rotation, `config.yaml` was correct on all 8 profiles yet some chats still routed to the old endpoint on resume. Root cause: per-session overrides in `state.db` \u2014 the `model` column said the new model while the `model_config` JSON still pinned the old provider, or the column itself was stale:\n\n```\n20260828_055654_642a85|deepseek/deepseek-v4-flash-0731|nous|{\"model\": \"glm-5.3-flash\", \"provider\": \"empero\", \"base_url\": \"https://free.empero.org/v1\", ...}\n```\n\nThe only way to audit or fix these was raw SQL on `state.db` \u2014 no CLI existed.\n\n## Reproduction\n\n```bash\n# Audit: which chats deviate from the profile default?\nhermes sessions list --provider nous --limit 50        # desync rows show up here\n\n# Bulk re-pin after a provider switch (dry-run first, then real)\nhermes sessions repair --model deepseek/deepseek-v4-flash-0731 --provider nous --dry-run\nhermes sessions repair --model deepseek/deepseek-v4-flash-0731 --provider nous\n```\n\n## Tests\n\n`tests/hermes_cli/test_sessions_model_reset.py` (8 tests, real-DB E2E against a temp `HERMES_HOME`):\n\n- list `--model` filter matches the JSON-pinned model, not just the column;\n- list `--provider` filter catches the desync class (correct column, stale JSON provider);\n- repair rewrites deviating rows, preserves `_branched_from`/`reasoning_config`, drops stale `base_url`/`api_mode`, leaves cron records and already-correct rows untouched;\n- repair `--dry-run` writes nothing;\n- repair default skips NULL-model and already-matching rows; `--all` pins NULL rows;\n- `--model`-only keeps provider routing untouched;\n- `--no-backup` skips the copy.\n\nSuite results (via `scripts/run_tests.sh`): the 8 new tests pass; adjacent session CLI files (listing, pin, error-exit-codes, delete, filters) 38 passed, 0 failed.\n\n## Existing affected rows\n\nUsers with desynced rows do NOT need manual action for the bug itself \u2014 the writer-side fix (#96748) self-heals rows on the next live persist. This PR is the CLI to find and reset them on demand (e.g. immediately after a rotation, or to force-clear stale endpoint keys with `--all`).\n\nRelated: https://github.com/NousResearch/hermes-agent/issues/96745\n"