### PR TITLE
fix(desktop): stop the workspace pane and pooled sockets flickering at idle

### DIFF
--- a/apps/desktop/src/app/right-sidebar/files/use-project-tree.test.ts
+++ b/apps/desktop/src/app/right-sidebar/files/use-project-tree.test.ts
@@ -462,4 +462,97 @@ describe('useProjectTree', () => {
     await waitFor(() => expect(result.current.rootError).toBe('no-bridge'))
     expect(result.current.data).toEqual([])
   })
+
+  // An unreadable root self-heals on a 3s timer, so this probe runs forever
+  // while the pane just sits there. Blanking the error first made every one of
+  // those a visible "unreadable" → blank → "unreadable" strobe.
+  it('keeps an unreadable root on screen while it re-probes', async () => {
+    readDir.mockResolvedValue({ entries: [], error: 'ENOENT' })
+
+    const { result } = renderHook(() => useProjectTree('/gone'))
+
+    await waitFor(() => expect(result.current.rootError).toBe('ENOENT'))
+
+    let releaseProbe: ((value: HermesReadDirResult) => void) | undefined
+
+    readDir.mockImplementationOnce(
+      () =>
+        new Promise<HermesReadDirResult>(resolve => {
+          releaseProbe = resolve
+        })
+    )
+
+    act(() => {
+      void result.current.refreshRoot()
+    })
+
+    expect(result.current.rootLoading).toBe(true)
+    expect(result.current.rootError).toBe('ENOENT')
+
+    await act(async () => {
+      releaseProbe?.({ entries: [], error: 'ENOENT' })
+    })
+
+    expect(result.current.rootError).toBe('ENOENT')
+  })
+
+  it('keeps loaded rows on screen while the root refreshes', async () => {
+    readDir.mockResolvedValueOnce(ok([{ name: 'src', path: '/p/src', isDirectory: true }]))
+
+    const { result } = renderHook(() => useProjectTree('/p'))
+
+    await waitFor(() => expect(result.current.data.length).toBe(1))
+
+    let releaseRefresh: ((value: HermesReadDirResult) => void) | undefined
+
+    readDir.mockImplementationOnce(
+      () =>
+        new Promise<HermesReadDirResult>(resolve => {
+          releaseRefresh = resolve
+        })
+    )
+
+    act(() => {
+      void result.current.refreshRoot()
+    })
+
+    expect(result.current.rootLoading).toBe(true)
+    expect(result.current.data.map(node => node.name)).toEqual(['src'])
+
+    await act(async () => {
+      releaseRefresh?.(ok([{ name: 'src', path: '/p/src', isDirectory: true }]))
+    })
+  })
+
+  it('clears the rows when the same path is re-read from another backend', async () => {
+    readDir.mockResolvedValueOnce(ok([{ name: 'from-a', path: '/shared/from-a', isDirectory: false }]))
+    $connection.set({ baseUrl: 'local-a', connectionId: 'connection-a', mode: 'local', profile: 'default' } as never)
+
+    const { result } = renderHook(() => useProjectTree('/shared'))
+
+    await waitFor(() => expect(result.current.data.map(node => node.name)).toEqual(['from-a']))
+
+    let releaseFromB: ((value: HermesReadDirResult) => void) | undefined
+
+    readDir.mockImplementationOnce(
+      () =>
+        new Promise<HermesReadDirResult>(resolve => {
+          releaseFromB = resolve
+        })
+    )
+
+    act(() => {
+      $connection.set({ baseUrl: 'local-b', connectionId: 'connection-b', mode: 'local', profile: 'default' } as never)
+    })
+
+    // The path is unchanged but the machine is not, so the old machine's
+    // listing must not sit there while the new one loads.
+    expect(result.current.data).toEqual([])
+
+    await act(async () => {
+      releaseFromB?.(ok([{ name: 'from-b', path: '/shared/from-b', isDirectory: false }]))
+    })
+
+    await waitFor(() => expect(result.current.data.map(node => node.name)).toEqual(['from-b']))
+  })
 })

--- a/apps/desktop/src/app/right-sidebar/files/use-project-tree.ts
+++ b/apps/desktop/src/app/right-sidebar/files/use-project-tree.ts
@@ -182,7 +182,11 @@ async function fallbackRootFor(cwd: string, sourceIsRemote: boolean): Promise<st
 
 async function loadRoot(
   cwd: string,
-  { connectionKey = desktopFsCacheKey(), force = false }: { connectionKey?: string; force?: boolean } = {}
+  {
+    connectionKey = desktopFsCacheKey(),
+    force = false,
+    reset = false
+  }: { connectionKey?: string; force?: boolean; reset?: boolean } = {}
 ) {
   if (!cwd) {
     clearProjectTree()
@@ -204,15 +208,25 @@ async function loadRoot(
     clearProjectDirCache(cwd)
   }
 
+  // Re-reading the SAME root — the error retry below, the refresh button, a
+  // workspace revalidation — must probe underneath what is on screen rather
+  // than blanking it first. Clearing here meant an unreadable root strobed
+  // "unreadable" → blank → "unreadable" every retry, forever, while the app
+  // just sat there; the header's project name flickered with it as
+  // `resolvedCwd` dropped back to the raw cwd and returned. Only a different
+  // root (or a different backend, via `reset`) may clear, where the previous
+  // project's tree would otherwise linger under the new one.
+  const keepVisible = current.cwd === cwd && !reset
+
   $projectTree.set({
     collapseNonce: current.collapseNonce,
     cwd,
-    data: [],
+    data: keepVisible ? current.data : [],
     loaded: false,
-    openState: current.cwd === cwd ? current.openState : {},
+    openState: keepVisible ? current.openState : {},
     requestId,
-    resolvedCwd: '',
-    rootError: null,
+    resolvedCwd: keepVisible ? current.resolvedCwd : '',
+    rootError: keepVisible ? current.rootError : null,
     rootLoading: true
   })
 
@@ -465,7 +479,9 @@ export function useProjectTree(cwd: string): UseProjectTreeResult {
 
     if (connectionChanged) {
       clearProjectDirCache()
-      void loadRoot(cwd, { connectionKey, force: true })
+      // Same path, different machine: what is on screen was read from the old
+      // backend, so it has to go even though the cwd string is unchanged.
+      void loadRoot(cwd, { connectionKey, force: true, reset: true })
 
       return
     }

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/session-info.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/session-info.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  $currentCwd,
+  $selectedStoredSessionId,
+  $workspaceCwdOwner,
+  releaseWorkspaceCwdOwner,
+  setCurrentCwd
+} from '@/store/session'
+
+import { handleSessionInfoEvent } from './session-info'
+import type { GatewayEventContext } from './types'
+
+// `_session_info` stamps `stored_session_id: session_key or ""`, so every
+// not-yet-persisted session on the gateway emits an UNNAMED session.info that
+// still carries a real cwd.
+function sessionInfoEvent({
+  activeSessionId,
+  cwd,
+  explicitSid = '',
+  storedSessionId = ''
+}: {
+  activeSessionId: null | string
+  cwd: string
+  explicitSid?: string
+  storedSessionId?: string
+}): GatewayEventContext {
+  const sessionId = explicitSid || activeSessionId
+
+  return {
+    deps: {
+      activeGatewayProfile: 'default',
+      activeSessionIdRef: { current: activeSessionId },
+      hydrateFromStoredSession: vi.fn(),
+      lastCwdInfoSessionRef: { current: null },
+      queryClient: { invalidateQueries: vi.fn() },
+      refreshHermesConfig: vi.fn(),
+      scheduleSessionsRefresh: vi.fn(),
+      sessionInterrupted: () => false,
+      sessionStateByRuntimeIdRef: { current: new Map() },
+      updateSessionState: vi.fn(state => state),
+      upsertToolCall: vi.fn()
+    },
+    event: { profile: 'default', session_id: explicitSid, type: 'session.info' },
+    explicitSid,
+    fromActiveSource: () => true,
+    isActiveEvent: !!sessionId && sessionId === activeSessionId,
+    occurredAt: Date.now() / 1000,
+    payload: { cwd, stored_session_id: storedSessionId },
+    scheduleConfigRefresh: vi.fn(),
+    sessionId
+  } as unknown as GatewayEventContext
+}
+
+describe('handleSessionInfoEvent workspace ownership', () => {
+  beforeEach(() => {
+    $selectedStoredSessionId.set(null)
+    $workspaceCwdOwner.set(null)
+    setCurrentCwd('')
+  })
+
+  afterEach(() => {
+    $selectedStoredSessionId.set(null)
+    $workspaceCwdOwner.set(null)
+    setCurrentCwd('')
+  })
+
+  // #55831 / the "workspace pane visible with no agent selected" report: with
+  // nothing selected an unscoped event is exactly the one that applies, and
+  // `broadcast_session_info` re-emits for EVERY live session at once. Adopting
+  // those repointed the pane at a stranger's folder and claimed it for the null
+  // selection, so the tree/coding rail painted it until the next release
+  // un-painted it — a flicker per fan-out, with no agent selected at all.
+  it('ignores an unnamed broadcast from a session the pane is not bound to', () => {
+    releaseWorkspaceCwdOwner()
+    const unowned = $workspaceCwdOwner.get()
+
+    handleSessionInfoEvent(sessionInfoEvent({ activeSessionId: null, cwd: '/repo/someone-elses-worktree' }))
+
+    expect($currentCwd.get()).toBe('')
+    expect($workspaceCwdOwner.get()).toBe(unowned)
+  })
+
+  it('does not let a fan-out of unnamed broadcasts walk the workspace path', () => {
+    const cwds = ['/repo/one', '/repo/two', '/repo/three']
+
+    for (const cwd of cwds) {
+      handleSessionInfoEvent(sessionInfoEvent({ activeSessionId: null, cwd }))
+    }
+
+    expect($currentCwd.get()).toBe('')
+  })
+
+  // The case the absent-id allowance exists for: a lazy session that has not
+  // been persisted yet is still the runtime this pane is bound to, so its cwd
+  // must be adopted and owned — otherwise the workspace reads as un-owned for
+  // the rest of the conversation.
+  it('adopts an unnamed session.info from the pane its own runtime', () => {
+    $selectedStoredSessionId.set('selected-session')
+
+    handleSessionInfoEvent(
+      sessionInfoEvent({ activeSessionId: 'runtime-1', cwd: '/repo/mine', explicitSid: 'runtime-1' })
+    )
+
+    expect($currentCwd.get()).toBe('/repo/mine')
+    expect($workspaceCwdOwner.get()).toBe('selected-session')
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/session-info.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/session-info.ts
@@ -38,16 +38,26 @@ import type { GatewayEventContext } from './types'
  *
  * Absent is not the same as different: the backend omits the id on a
  * not-yet-built (`lazy`) session, and refusing there would leave the workspace
- * marked un-owned for the rest of the conversation. Matching goes through the
- * lineage (`sessionMatchesStoredId`) so a compression-rotated tip and the root
- * a pinned-row selection may hold still read as one conversation.
+ * marked un-owned for the rest of the conversation. That only reads as the
+ * selection when the event is the pane's OWN runtime, though: an unscoped
+ * event applies precisely when no session is active, and the fan-outs
+ * (`broadcast_session_info`, the approvals loop) re-emit for every live
+ * session at once, each with its own cwd. As an unconditional wildcard those
+ * repoint `$currentCwd` and claim it for whatever is selected — nothing, in
+ * the report this comes from — until the next release drops the claim again.
+ * Hence `boundToPane`: with no binding there is no evidence, and no evidence
+ * must not become an ownership claim.
+ *
+ * Matching goes through the lineage (`sessionMatchesStoredId`) so a
+ * compression-rotated tip and the root a pinned-row selection may hold still
+ * read as one conversation.
  */
-function sessionInfoDescribesSelectedSession(storedSessionId: string | undefined): boolean {
+function sessionInfoDescribesSelectedSession(storedSessionId: string | undefined, boundToPane: boolean): boolean {
   const infoStoredSessionId = storedSessionId?.trim() || null
   const selected = $selectedStoredSessionId.get() ?? null
 
   if (!infoStoredSessionId) {
-    return true
+    return boundToPane
   }
 
   // A named session cannot describe a fresh draft. Treating a null selection as
@@ -91,7 +101,10 @@ function maybeRebindPaneToRebuiltRuntime(ctx: GatewayEventContext): boolean {
 
   const selected = $selectedStoredSessionId.get()
 
-  if (!selected || !sessionInfoDescribesSelectedSession(payload.stored_session_id)) {
+  // A rebuilt runtime announces itself for a conversation that is already
+  // persisted, so it always names one; an unnamed payload has no lineage to
+  // match and must not capture the pane's active runtime id.
+  if (!selected || !sessionInfoDescribesSelectedSession(payload.stored_session_id, false)) {
     return false
   }
 
@@ -180,7 +193,10 @@ export function handleSessionInfoEvent(ctx: GatewayEventContext): boolean {
       // Active-session model/provider still flows through the session state
       // cache via updateSessionState → syncRuntimeMetadataToView below.
 
-      if (typeof payload?.cwd === 'string' && sessionInfoDescribesSelectedSession(payload.stored_session_id)) {
+      if (
+        typeof payload?.cwd === 'string' &&
+        sessionInfoDescribesSelectedSession(payload.stored_session_id, isActiveEvent || rebound)
+      ) {
         // The active session's agent can relocate itself (new repo/worktree
         // via the terminal). When the SAME active session's cwd actually
         // moves, follow it — refresh the project tree + scope so the sidebar


### PR DESCRIPTION
Three bugs behind the flicker reports, distinct from the transcript-publication one in [#97293](https://github.com/NousResearch/hermes-agent/pull/97293). All three explain flickering **at idle** — people report it happening while the app just sits there.

## 1. The project tree strobes while it re-probes an unreadable root

`use-project-tree` self-heals an errored root every `ROOT_ERROR_RETRY_MS` (3s) for as long as the pane is mounted. But every forced reload tore the pane down before reading:

```ts
$projectTree.set({
  ...
  data: [],
  resolvedCwd: '',
  rootError: null,      // ← the error panel disappears
  rootLoading: true
})
```

With `rootError` cleared and `data` empty, `FileTreeBody` falls past its error branch into `loading && data.length === 0`. That renders the skeleton only after `useDelayedTrue`'s 180ms — and a local ENOENT resolves in about a millisecond — so the pane paints a **bare blank frame** and then snaps back to "unreadable". Every 3 seconds. Forever. `resolvedCwd` resetting flickers the header's project name along with it.

Nothing has to happen for this to fire: an unreadable root is enough, which is exactly the state you land in when the pane shows a path no selected session owns. It also hit the manual refresh button and any loaded tree, which blanked before repainting.

Re-reading the same root now probes underneath what is on screen. Only a different root — or the same path from a different backend, which is why `reset` is plumbed through the connection-change path — clears first.

## 2. An unnamed `session.info` claimed a stranger's cwd for the selection

`sessionInfoDescribesSelectedSession` treated an unnamed payload as describing whatever the pane had selected:

```ts
if (!infoStoredSessionId) {
  return true
}
```

Three facts make that a wildcard rather than the narrow lazy-session allowance it was meant to be:

- The gateway stamps `"stored_session_id": session_key or ""`, so every not-yet-persisted session emits an unnamed `session.info` carrying a real `cwd`.
- `broadcast_session_info()` and the approvals fan-out re-emit for **every live session at once**, each with its own `cwd`.
- An unscoped event applies precisely when nothing is active: `apply = explicitSid ? isActiveEvent : !activeSessionIdRef.current`.

So with no agent or profile selected, each unnamed broadcast ran `setCurrentCwdTransient(payload.cwd)` and claimed it via `setWorkspaceCwdOwner($selectedStoredSessionId.get())`. Everything gated on `workspaceCwdBelongsToSelectedSession()` — the file tree, `$repoStatus`/`$repoWorktrees` behind the coding rail, the statusbar project label — painted a folder nothing owned, until the next `releaseWorkspaceCwdOwner()` dropped the claim and they un-painted it.

The guard directly below already refused this for *named* payloads (`A named session cannot describe a fresh draft`), but the absent-id early return short-circuits before reaching it.

An absent id now only reads as the selection when the event is bound to the pane's own runtime. The case the allowance exists for — a lazy session that *is* the pane's runtime but is not persisted yet — still adopts and owns its cwd.

## 3. Every polled RPC redialled its pooled socket

From a debug report on a local desktop against a remote gateway: the gateway log carries an unbroken run of three `ws accepted` / `messages=1` / `client_disconnect(code=1005)` triples every ~5.4 seconds, and it only runs while the window is focused and visible.

Scoped RPCs go through a per-request lease that disposed the secondary the moment its refcount hit zero:

```ts
entry.activeRequests += 1
try {
  if (!isOpen(entry.gateway)) {
    await openSecondary(entry)   // ← a brand-new WebSocket
  }
  return await entry.gateway.request<T>(method, params)
} finally {
  entry.activeRequests -= 1
  if (/* refcount 0, nothing else holds it */) {
    disposeSecondary(entry)      // ← and it's gone
  }
}
```

Open a socket, send exactly one RPC, close it. So any caller firing on a timer redials from scratch on every tick — ~33 connects a minute, each paying a full handshake whose reconnect work lands on the renderer's main thread in a burst. That is the keystroke-stall shape in [#95033](https://github.com/NousResearch/hermes-agent/issues/95033).

Only remote users hit it. A local connection takes the `isPrimaryRegistryRoute` early return and reuses the primary socket; a registry-dialed remote gateway goes down the secondary path, where every scoped poll is its own dial.

This shape has been found once before: [#93594](https://github.com/NousResearch/hermes-agent/issues/93594) fixed it for the bot relay by handing that one caller an explicit retainer, whose comment describes the same churn verbatim. An unleased secondary now lingers briefly instead, so a repeat caller reuses the warm socket and no caller has to know to retain. Deliberate teardown still disposes on the spot — the live-work pruner, a connection edit or removal, a soft gateway switch, and a socket that already dropped (nothing to keep warm, and holding it would let the backoff loop redial a route nothing is waiting on).

That last point is the one behavior change worth a close read: ten existing tests across three past fixes pinned "release disposes synchronously", and they now assert the deferred close instead. Each still asserts reclamation actually happens.

## Premise, verified

Every set of tests was run against unfixed `origin/main` in a throwaway worktree. The regression tests fail there and the preserved-behavior tests pass:

```
# the strobe
AssertionError: expected null to be 'ENOENT'
AssertionError: expected [] to deeply equal [ 'src' ]

# the cwd claim
AssertionError: expected '/repo/someone-elses-worktree' to be ''
AssertionError: expected '/repo/three' to be ''

# the socket churn — six poll ticks, six sockets
AssertionError: expected 6 to be 1
```

`deliberate reclamation still disposes on the spot` passes on both, confirming that path is untouched.

## Test plan

- [x] 3 new `use-project-tree` tests, 3 new `session-info` tests, 4 new `gateway-idle-linger` tests — red on `main`, green here
- [x] 10 existing lease tests updated for the deferred close; each still asserts reclamation lands
- [x] Full desktop suite: 8083 pass. The 2 failures (`managed-ssh-update`, `remote-lifecycle`) reproduce on a clean tree without these changes
- [x] `tsc --noEmit` and `eslint` clean
