### PR TITLE
fix(telegram): degrade unsupported markdown link targets to display text

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -503,6 +503,56 @@ def _rich_normalize_linebreaks(text: str) -> str:
     return ''.join(out)
 
 
+# Markdown link syntax shared by both Telegram delivery paths: the legacy
+# MarkdownV2 formatter's link conversion and the rich-message outbound scrub
+# below.
+_MD_LINK_RE = re.compile(r'\[([^\]]+)\]\(([^()]*(?:\([^()]*\)[^()]*)*)\)')
+
+# Bot API link targets are "HTTP or tg://" URLs (MessageEntity text_link
+# spec). Anything else — a schemeless destination like ``[Title](Title)`` or a
+# Hermes-internal ``@session:profile/id`` reference — cannot be rendered as a
+# link by Telegram and is exposed to the user as raw bracket syntax (#97497).
+_SUPPORTED_LINK_TARGET_RE = re.compile(r'(?i)^(?:https?://|tg://)\S+$')
+
+# Regions where link syntax is literal content rather than a link to degrade:
+# inline code spans, plus the fenced-code / pipe-table regions already matched
+# by _RICH_PROTECTED_REGION_RE.
+_LINK_SCRUB_PROTECT_RE = re.compile(
+    r'`[^`\n]+`|' + _RICH_PROTECTED_REGION_RE.pattern,
+    re.MULTILINE,
+)
+
+
+def _tg_link_target_supported(target: str) -> bool:
+    """True if Telegram can render *target* as a clickable link target."""
+    return bool(_SUPPORTED_LINK_TARGET_RE.match(target.strip()))
+
+
+def _degrade_unsupported_markdown_links(text: str) -> str:
+    """Degrade markdown links Telegram cannot render to their display text.
+
+    Models sometimes emit ``[Title](Title)`` or ``[Title](@session:p/id)``
+    when referencing session-search results; Telegram then shows the raw
+    bracket-and-parenthesis syntax instead of readable prose (#97497).
+    HTTP(S)/tg:// targets stay clickable; every other target degrades to the
+    label text. Code spans/blocks and table blocks are left verbatim.
+    """
+    if '[' not in text:
+        return text
+
+    def _degrade(m):
+        return m.group(0) if _tg_link_target_supported(m.group(2)) else m.group(1)
+
+    out: list[str] = []
+    pos = 0
+    for m in _LINK_SCRUB_PROTECT_RE.finditer(text):
+        out.append(_MD_LINK_RE.sub(_degrade, text[pos : m.start()]))
+        out.append(m.group(0))  # protected region kept verbatim
+        pos = m.end()
+    out.append(_MD_LINK_RE.sub(_degrade, text[pos:]))
+    return ''.join(out)
+
+
 # Watchdog bound for `await updater.stop()`. When the underlying TCP socket is
 # in CLOSE-WAIT the PTB polling task is blocked on epoll on the dead socket and
 # never wakes, so an unguarded stop() hangs indefinitely and wedges the whole
@@ -2137,8 +2187,16 @@ class TelegramAdapter(BasePlatformAdapter):
         Single newlines are normalized to Markdown hard breaks so that
         multi-line content (slash-command lists, etc.) renders correctly
         in the rich-message path.  See ``_rich_normalize_linebreaks``.
+
+        Unsupported link targets (schemeless destinations, ``@session:``
+        references) are degraded to their display text on the way out so
+        Telegram never exposes raw ``[label](target)`` syntax (#97497).
         """
-        payload: Dict[str, Any] = {"markdown": _rich_normalize_linebreaks(content)}
+        payload: Dict[str, Any] = {
+            "markdown": _degrade_unsupported_markdown_links(
+                _rich_normalize_linebreaks(content)
+            )
+        }
         if skip_entity_detection:
             payload["skip_entity_detection"] = True
         return payload
@@ -8526,13 +8584,18 @@ class TelegramAdapter(BasePlatformAdapter):
         )
 
         # 3) Convert markdown links – escape the display text; inside the URL
-        #    only ')' and '\' need escaping per the MarkdownV2 spec.
+        #    only ')' and '\' need escaping per the MarkdownV2 spec. Targets
+        #    Telegram cannot render as links (schemeless destinations,
+        #    @session: references) degrade to the escaped display text so the
+        #    raw bracket syntax is never exposed (#97497).
         def _convert_link(m):
             display = _escape_mdv2(m.group(1))
+            if not _tg_link_target_supported(m.group(2)):
+                return _ph(display)
             url = m.group(2).replace('\\', '\\\\').replace(')', '\\)')
             return _ph(f'[{display}]({url})')
 
-        text = re.sub(r'\[([^\]]+)\]\(([^()]*(?:\([^()]*\)[^()]*)*)\)', _convert_link, text)
+        text = _MD_LINK_RE.sub(_convert_link, text)
 
         # 4) Convert markdown headers (## Title) → bold *Title*
         def _convert_header(m):

--- a/tests/gateway/test_telegram_unsupported_link_targets.py
+++ b/tests/gateway/test_telegram_unsupported_link_targets.py
@@ -1,0 +1,112 @@
+"""Tests for unsupported markdown link targets on Telegram (issue #97497).
+
+Models sometimes reformat Hermes' desktop-only ``@session:<profile>/<id>``
+references as markdown links with a non-URL destination, e.g.
+``[Title](Title)`` or ``[Title](@session:profile/id)``. Telegram cannot
+render those as links and exposes the raw bracket-and-parenthesis syntax to
+the user instead of readable prose.
+
+Both delivery paths must degrade unsupported targets to their display text
+while keeping HTTP(S)/tg:// links clickable:
+
+- the legacy MarkdownV2 formatter (``format_message``), and
+- the rich-message path — ``_rich_message_payload`` is the shared payload
+  builder for rich sends, finalized edits, and drafts, so scrubbing it
+  covers all three rich call sites.
+
+Code spans/blocks and table blocks hold literal content and must be left
+verbatim.
+"""
+
+from plugins.platforms.telegram.adapter import (
+    TelegramAdapter,
+    _degrade_unsupported_markdown_links,
+)
+
+
+class TestLegacyMarkdownV2LinkDegrade:
+    """format_message must not emit raw [label](target) for bad targets."""
+
+    def _adapter(self):
+        return object.__new__(TelegramAdapter)
+
+    def test_schemeless_target_degrades_to_display_text(self):
+        """The deterministic repro from the issue.
+
+        ``format_message("Already underway in [Example Session](Example
+        Session).")`` used to preserve the schemeless destination, so the
+        Telegram client showed the raw link syntax.
+        """
+        result = self._adapter().format_message(
+            "Already underway in [Example Session](Example Session)."
+        )
+        assert "](" not in result
+        assert "Example Session" in result
+
+    def test_session_reference_degrades_to_display_text(self):
+        """``@session:`` is a Hermes-Desktop-only reference Telegram can't
+        resolve — it must degrade to the title, never ship as a link."""
+        result = self._adapter().format_message(
+            "Continuing [Research](@session:default/abc123)."
+        )
+        assert "](" not in result
+        assert "Research" in result
+        assert "@session:" not in result
+
+    def test_https_link_stays_clickable(self):
+        result = self._adapter().format_message("See [Docs](https://example.com/x).")
+        assert "[Docs](https://example.com/x)" in result
+
+    def test_tg_link_stays_clickable(self):
+        result = self._adapter().format_message("Open [settings](tg://settings).")
+        assert "[settings](tg://settings)" in result
+
+
+class TestRichMessageLinkDegrade:
+    """_rich_message_payload feeds rich sends, final edits, and drafts."""
+
+    def _payload_markdown(self, content):
+        adapter = object.__new__(TelegramAdapter)
+        return adapter._rich_message_payload(content)["markdown"]
+
+    def test_schemeless_target_degrades_to_display_text(self):
+        md = self._payload_markdown(
+            "Already underway in [Example Session](Example Session)."
+        )
+        assert md == "Already underway in Example Session."
+
+    def test_session_reference_degrades_to_display_text(self):
+        md = self._payload_markdown("Continuing [Research](@session:default/abc123).")
+        assert md == "Continuing Research."
+
+    def test_https_link_stays_clickable(self):
+        md = self._payload_markdown("See [Docs](https://example.com/x).")
+        assert "[Docs](https://example.com/x)" in md
+
+
+class TestDegradeHelper:
+    """The shared outbound scrub used by both delivery paths."""
+
+    def test_text_without_brackets_untouched(self):
+        assert _degrade_unsupported_markdown_links("plain text") == "plain text"
+
+    def test_empty_target_degrades(self):
+        assert _degrade_unsupported_markdown_links("see [x]()") == "see x"
+
+    def test_inline_code_span_untouched(self):
+        assert _degrade_unsupported_markdown_links("see `[a](b)`") == "see `[a](b)`"
+
+    def test_fenced_code_block_untouched(self):
+        text = "intro\n```\n[a](b)\n```\n"
+        assert _degrade_unsupported_markdown_links(text) == text
+
+    def test_table_block_untouched(self):
+        text = "| a | b |\n|---|---|\n| [x](y) | 2 |\n"
+        assert _degrade_unsupported_markdown_links(text) == text
+
+    def test_display_markers_survive_degrade(self):
+        """Degrading must hand the raw label back to the renderer, so
+        emphasis in the display text still renders."""
+        assert (
+            _degrade_unsupported_markdown_links("[**Bold**](not-a-url)") == "**Bold**"
+        )


### PR DESCRIPTION
## What does this PR do?

Telegram exposes raw `[label](target)` markdown syntax to the user when the target is not a URL Telegram can render. The trigger observed in #97497: models reformat Hermes' desktop-only `@session:<profile>/<id>` references as `[Long-Term Fix Research](Long-Term Fix Research)` or `[Title](@session:profile/id)`. Telegram cannot resolve these destinations, so the delivered message shows the bracket-and-parenthesis syntax instead of readable prose.

This adds a shared outbound check: a markdown link target is only kept clickable when it matches the Bot API `text_link` contract (HTTP(S)/`tg://` URLs). Every other target degrades to its display text. Wired into both delivery paths:

- `format_message` (legacy MarkdownV2): the link-conversion step now emits the escaped display text for unsupported targets instead of preserving the unrenderable destination.
- `_rich_message_payload` (rich path): the raw markdown is scrubbed on the way out. This is the shared payload builder for rich sends, finalized edits, and drafts, so all three rich call sites are covered by the single hook.

Code spans, fenced code blocks, and GFM table blocks hold literal content and are left verbatim — link syntax inside them is content, not a link. Hermes Desktop is untouched: its clickable titled `@session:` rendering lives outside the Telegram adapter.

## Related Issue

Fixes #97497

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/telegram/adapter.py` — added module-level `_MD_LINK_RE` (the link pattern both paths now share), `_SUPPORTED_LINK_TARGET_RE` (HTTP(S)/`tg://` per the Bot API text_link spec), `_tg_link_target_supported()`, and `_degrade_unsupported_markdown_links()` which protects code/table regions and degrades unsupported links in prose.
- `plugins/platforms/telegram/adapter.py` — `format_message` step 3 (`_convert_link`) degrades unsupported targets to the escaped display text.
- `plugins/platforms/telegram/adapter.py` — `_rich_message_payload` runs `_degrade_unsupported_markdown_links` after newline normalization.
- `tests/gateway/test_telegram_unsupported_link_targets.py` — new regression suite (13 tests).

## How to Test

1. Deterministic formatter-level repro from the issue (previously preserved the schemeless destination):
   ```python
   from plugins.platforms.telegram.adapter import TelegramAdapter
   adapter = object.__new__(TelegramAdapter)
   print(adapter.format_message("Already underway in [Example Session](Example Session)."))
   ```
   Observed result: `Already underway in Example Session\.` — no `](...)` syntax, readable prose only.
2. Rich path: `_rich_message_payload("See [Research](@session:default/abc123).")["markdown"]` returns `See Research.` while `[Docs](https://example.com/x)` and `[settings](tg://settings)` stay clickable links.
3. `uv run --extra dev pytest tests/gateway/test_telegram_unsupported_link_targets.py tests/gateway/test_telegram_format.py tests/gateway/test_telegram_rich_newlines.py tests/gateway/test_telegram_rich_messages.py tests/gateway/test_telegram_send_draft_format.py -q` — Observed result: 97 passed (13 new + 84 existing).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64), Python 3.11

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-impact) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
