### PR TITLE
fix(tests): restore sys.modules and sys.path after tests mutate them (15 order-dependent failures)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,7 @@ test runner at ``scripts/run_tests.sh``.
 
 import asyncio
 import atexit
+import contextlib
 import importlib
 import os
 import shutil
@@ -654,6 +655,50 @@ def _neutralize_macos_keychain_creds(request, monkeypatch):
 # allow-list because test-level fixtures legitimately move HERMES_HOME to
 # sibling directories — an allow-list captured at setup time would see the
 # stale autouse-set value and falsely reject hermetic tests (#69385 review).
+
+
+_REIMPORT_PREFIXES = ("hermes_cli", "hermes_state")
+_REIMPORT_EXACT = frozenset({"hermes_constants"})
+
+
+def _is_reimport_target(name: str) -> bool:
+    return name.startswith(_REIMPORT_PREFIXES) or name in _REIMPORT_EXACT
+
+
+@contextlib.contextmanager
+def fresh_hermes_modules():
+    """Drop the Hermes modules from ``sys.modules``, then put the ORIGINALS back.
+
+    A few kanban tests need a fresh ``HERMES_HOME`` to be read at *import*
+    time, which means re-importing ``hermes_cli``. Dropping the entries and
+    walking away leaves TWO copies of the same code alive for the rest of the
+    session: the one every already-imported test module is holding, and the one
+    ``sys.modules`` hands to the next importer.
+
+    That is not a tidiness problem. ``_kanban_write_guard`` below patches
+    ``connect`` on the copy it finds in ``sys.modules``, so a test module whose
+    global still points at the other copy calls an UNGUARDED ``connect`` -- the
+    deny-list that keeps the suite off the operator's real ``~/.hermes``
+    (#69283) stops working, and says nothing about it. The same split lets a
+    test observe a module-level registry (hooks, caches) on one copy while the
+    code under test mutates the other, which is what made a dozen hook and
+    lifecycle tests fail in a full run and pass one file at a time.
+
+    Restoring the originals keeps the re-import local to the test that asked
+    for it. Yield INSIDE the block: the fresh modules are only in place while
+    it is open.
+    """
+    saved = {n: m for n, m in sys.modules.items() if _is_reimport_target(n)}
+    for name in saved:
+        del sys.modules[name]
+    try:
+        yield
+    finally:
+        # Drop whatever the re-import created, then restore identity -- so the
+        # next importer gets the same object every earlier module is holding.
+        for name in [n for n in sys.modules if _is_reimport_target(n)]:
+            del sys.modules[name]
+        sys.modules.update(saved)
 
 
 def _capture_real_kanban_root() -> Path:

--- a/tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py
+++ b/tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py
@@ -9,12 +9,13 @@ from __future__ import annotations
 
 import argparse
 import os
-import sys
 import tempfile
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
+
+from tests.conftest import fresh_hermes_modules
 
 
 @pytest.fixture()
@@ -23,10 +24,8 @@ def isolated_kanban_home(monkeypatch):
     test_home = tempfile.mkdtemp(prefix="kanban_cli_passthrough_")
     os.makedirs(os.path.join(test_home, "profiles", "default"), exist_ok=True)
     monkeypatch.setenv("HERMES_HOME", test_home)
-    for mod in list(sys.modules.keys()):
-        if mod.startswith("hermes_cli") or mod.startswith("hermes_state") or mod == "hermes_constants":
-            del sys.modules[mod]
-    yield test_home
+    with fresh_hermes_modules():
+        yield test_home
 
 
 def test_cli_dispatch_passes_max_in_progress_from_config(isolated_kanban_home, monkeypatch):

--- a/tests/hermes_cli/test_kanban_default_assignee.py
+++ b/tests/hermes_cli/test_kanban_default_assignee.py
@@ -8,10 +8,11 @@ from __future__ import annotations
 
 import json
 import os
-import sys
 import tempfile
 
 import pytest
+
+from tests.conftest import fresh_hermes_modules
 
 
 @pytest.fixture()
@@ -20,11 +21,10 @@ def isolated_kanban_home(monkeypatch):
     test_home = tempfile.mkdtemp(prefix="kanban_default_assignee_test_")
     monkeypatch.setenv("HERMES_HOME", test_home)
     # Force-reimport so the fresh HERMES_HOME is picked up.
-    for mod in list(sys.modules.keys()):
-        if mod.startswith("hermes_cli") or mod.startswith("hermes_state") or mod == "hermes_constants":
-            del sys.modules[mod]
-    from hermes_cli import kanban_db
-    yield kanban_db, test_home
+    with fresh_hermes_modules():
+        from hermes_cli import kanban_db
+
+        yield kanban_db, test_home
     # Cleanup is best-effort; tempfile dir survives but pytest isolation
     # gives each test its own monkeypatched HERMES_HOME so no cross-test
     # contamination.

--- a/tests/hermes_cli/test_kanban_module_reimport_isolation.py
+++ b/tests/hermes_cli/test_kanban_module_reimport_isolation.py
@@ -1,0 +1,87 @@
+"""Re-importing the Hermes modules must not outlive the test that asked for it.
+
+A handful of kanban tests need a fresh ``HERMES_HOME`` to be read at *import*
+time, so they drop ``hermes_cli`` from ``sys.modules`` and import it again.
+Dropping the entries and walking away leaves two copies of the same code alive
+for the rest of the session: the one every already-imported test module holds,
+and the one ``sys.modules`` hands to the next importer.
+
+That split has teeth. ``_kanban_write_guard`` in ``tests/conftest.py`` patches
+``connect`` on the ``hermes_cli.kanban_db_connect`` copy it finds in
+``sys.modules``, so a test module whose global still points at the other copy
+calls an UNGUARDED ``connect``: the
+deny-list that keeps the suite off the operator's real ``~/.hermes`` (#69283)
+stops working, and says nothing about it. It also lets a test observe a
+module-level registry on one copy while the code under test mutates the other,
+which is what made a dozen hook and lifecycle tests fail in a full run and pass
+one file at a time.
+
+These tests pin the restore that ``fresh_hermes_modules`` performs.
+"""
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from hermes_cli import kanban_db, kanban_db_connect
+from tests.conftest import fresh_hermes_modules
+
+
+def test_the_original_module_object_is_back_afterwards() -> None:
+    before = sys.modules["hermes_cli.kanban_db"]
+    assert before is kanban_db
+
+    with fresh_hermes_modules():
+        from hermes_cli import kanban_db as inner
+
+        # The point of the block: a genuinely fresh module, so import-time
+        # reads of HERMES_HOME happen again.
+        assert inner is not before
+
+    assert sys.modules["hermes_cli.kanban_db"] is before
+
+
+def test_the_write_guard_still_covers_the_module_everyone_holds() -> None:
+    """The consequence, stated directly.
+
+    The autouse guard patched ``connect`` on the module object this file
+    imported. A re-import that left the fresh copy in ``sys.modules`` would
+    hand the next importer an unguarded ``connect`` -- so the invariant worth
+    asserting is that the entry, after the block, is still the guarded one.
+    """
+    guarded = sys.modules["hermes_cli.kanban_db_connect"].connect
+    assert guarded is kanban_db_connect.connect
+    assert guarded.__qualname__.startswith("_kanban_write_guard"), (
+        "the autouse guard did not patch connect -- this test cannot say "
+        "anything about the restore"
+    )
+
+    with fresh_hermes_modules():
+        from hermes_cli import kanban_db_connect as inner
+
+        # The hazard, named: the fresh copy is NOT guarded.
+        assert inner.connect is not guarded
+
+    assert sys.modules["hermes_cli.kanban_db_connect"].connect is guarded
+
+
+def test_the_guard_refuses_the_real_root_after_a_reimport() -> None:
+    """End to end: the deny-list still fires for this module's own reference."""
+    import tests.conftest as _conftest
+
+    with fresh_hermes_modules():
+        from hermes_cli import kanban_db_connect as inner  # noqa: F401
+
+    with pytest.raises(RuntimeError, match="kanban_write_guard"):
+        kanban_db_connect.connect(_conftest._REAL_KANBAN_ROOT / "kanban.db")
+
+
+def test_the_block_restores_even_when_the_body_raises() -> None:
+    before = sys.modules["hermes_cli.kanban_db"]
+    with pytest.raises(ZeroDivisionError):
+        with fresh_hermes_modules():
+            import hermes_cli.kanban_db  # noqa: F401
+
+            1 / 0
+    assert sys.modules["hermes_cli.kanban_db"] is before

--- a/tests/hermes_cli/test_kanban_per_profile_cap.py
+++ b/tests/hermes_cli/test_kanban_per_profile_cap.py
@@ -8,10 +8,11 @@ model / API quota / browser pool from being overwhelmed by a fan-out.
 from __future__ import annotations
 
 import os
-import sys
 import tempfile
 
 import pytest
+
+from tests.conftest import fresh_hermes_modules
 
 
 @pytest.fixture()
@@ -21,11 +22,10 @@ def isolated_kanban_home_with_profiles(monkeypatch):
     for prof in ("alpha", "beta", "default"):
         os.makedirs(os.path.join(test_home, "profiles", prof), exist_ok=True)
     monkeypatch.setenv("HERMES_HOME", test_home)
-    for mod in list(sys.modules.keys()):
-        if mod.startswith("hermes_cli") or mod.startswith("hermes_state") or mod == "hermes_constants":
-            del sys.modules[mod]
-    from hermes_cli import kanban_db
-    yield kanban_db
+    with fresh_hermes_modules():
+        from hermes_cli import kanban_db
+
+        yield kanban_db
 
 
 def _fake_spawn(*args, **kwargs):

--- a/tests/hermes_cli/test_plan_reconciliation_windows_live.py
+++ b/tests/hermes_cli/test_plan_reconciliation_windows_live.py
@@ -12,10 +12,6 @@ reconciliation. No mocks on the components under test.
  4. Machine-id contract holds on Windows (no display strings leak in).
 """
 import io, contextlib, json, os, subprocess, sys, tempfile, time
-from pathlib import Path
-
-WORKTREE = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(WORKTREE))
 
 import pytest
 

--- a/tests/hermes_cli/test_web_server_host_header.py
+++ b/tests/hermes_cli/test_web_server_host_header.py
@@ -9,14 +9,7 @@ the Host header at the application layer rejects the attack.
 
 from __future__ import annotations
 
-import sys
-from pathlib import Path
-
 import pytest
-
-_repo = str(Path(__file__).resolve().parents[1])
-if _repo not in sys.path:
-    sys.path.insert(0, _repo)
 
 
 class TestHostHeaderValidator:

--- a/tests/test_tests_dir_not_on_sys_path.py
+++ b/tests/test_tests_dir_not_on_sys_path.py
@@ -1,0 +1,45 @@
+"""The tests root must never be importable as a package directory.
+
+``tests/`` holds a subdirectory per area, and several of those names are taken:
+``acp`` is a third-party dependency, and ``cron``, ``plugins``, ``providers``
+and ``tools`` are first-party packages of this repository. Putting ``tests/`` on
+``sys.path`` makes those directories SHADOW the real modules for the rest of the
+session -- ``from acp.schema import ToolKind`` starts raising
+``ModuleNotFoundError`` against a stub with no ``schema`` submodule, in a test
+that passes when run on its own.
+
+The insert that caused it was an off-by-one (``parents[1]`` from a file in
+``tests/hermes_cli/`` is ``tests/``, not the repo root) at MODULE level in a
+file whose every test is skipped off Windows: collection alone was enough to
+poison the run. This gate is cheap and catches the whole class -- collection
+happens before any test runs, so a module-level insert anywhere is already
+visible here.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+TESTS_ROOT = Path(__file__).resolve().parent
+REPO_ROOT = TESTS_ROOT.parent
+
+
+def test_the_tests_root_is_not_on_sys_path() -> None:
+    on_path = [entry for entry in sys.path if Path(entry).resolve() == TESTS_ROOT]
+    assert not on_path, (
+        f"{TESTS_ROOT} is on sys.path, so every directory under it shadows a "
+        f"top-level module of the same name. Insert the REPO root ({REPO_ROOT}) "
+        f"if a test needs it -- pytest already prepends it."
+    )
+
+
+def test_the_shadowing_names_are_real_so_the_gate_above_matters() -> None:
+    """A floor: the gate would be theatre if no name under tests/ collided."""
+    collisions = sorted(
+        entry.name
+        for entry in TESTS_ROOT.iterdir()
+        if entry.is_dir() and (REPO_ROOT / entry.name).is_dir()
+    )
+    # `acp` is not in this list -- it lives in site-packages, not the repo --
+    # and it is the one that actually broke, so the floor stays a floor.
+    assert collisions, f"nothing under {TESTS_ROOT} shares a name with a repo package"


### PR DESCRIPTION
`pytest tests/hermes_cli/ -k kanban` fails 15 tests on a clean tree. Every one of them passes when its own file runs alone. Two globals are behind all 15: a test mutated interpreter-wide state and never changed it back.

## `sys.modules`, and why this is not tidiness

Three kanban fixtures need a fresh `HERMES_HOME` to be read at *import* time, so they dropped `hermes_cli` / `hermes_state` / `hermes_constants` from `sys.modules` and imported again. Dropping the entries and walking away leaves **two copies of the same code** alive for the rest of the session: the one every already-imported test module holds in its globals, and the one `sys.modules` hands to the next importer.

`_kanban_write_guard` — the autouse deny-list from #69283 that keeps the suite off the operator's real `~/.hermes` — patches `connect` on the copy it finds in `sys.modules`. A test module whose global points at the *other* copy therefore calls an **unguarded** `connect`, for the rest of the run, silently. That is precisely how `test_kanban_write_guard.py` was failing: the guard was installed, on the wrong object. The same split let the hook and lifecycle tests observe a module-level registry on one copy while the code under test mutated the other.

`fresh_hermes_modules()` (tests/conftest.py) does the drop, yields, and puts the **originals** back, so the re-import is local to the test that asked for it.

## `sys.path`, and a dependency that stopped existing

`tests/acp/` is the test package for the ACP adapter, and `acp` is also a real third-party dependency. Two files put the **tests** root on `sys.path` at module level — both an off-by-one (`parents[1]` from a file in `tests/hermes_cli/` is `tests/`, not the repo root, which pytest already prepends), both naming the variable `_repo` / `WORKTREE`. From then on `tests/acp/` **shadowed** the dependency and `from acp.schema import ToolKind` raised `ModuleNotFoundError: No module named 'acp.schema'` against a stub with no `schema` submodule.

One of the two files is skipped in its entirety off Windows — collection alone was enough. It is also why `pytest tests/hermes_cli/ tests/acp/` cannot even collect on `main`: 7 collection errors, run interrupted. `cron`, `plugins`, `providers` and `tools` are first-party packages with a same-named directory under `tests/`, so the same insert could have shadowed any of them.

## Verification

| | before | after |
|---|---|---|
| `tests/hermes_cli/ -k kanban` | 15 failed, 294 passed, 1 skipped | **0 failed, 313 passed, 1 skipped** |
| `tests/hermes_cli/ tests/acp/` | 7 collection errors, interrupted | collects |

313 = the same 309 tests, all passing, plus the 4 new ones. The `sys.path` gate is
outside that selection: `tests/test_tests_dir_not_on_sys_path.py` is 2 more, both passing.

Mutation-verified: deleting the restore from `fresh_hermes_modules` brings back 14 of the original failures plus all four new ones — 18 failed.

The `sys.path` gate is not hypothetical either. It **failed on the first run of this branch** and found the second polluter, which is how `test_web_server_host_header.py` came to be in this PR. It ships with a floor test, because a gate guarding a collision that does not exist is theatre: it asserts some directory under `tests/` really does share a name with a repo package.

Not verified: the full `tests/hermes_cli/` suite end to end. On the box available to me it is OOM-killed partway through — a standing memory constraint there, unrelated to these changes (nothing here spawns a process).
