### PR TITLE
fix(desktop): route approval responses through the runtime event's exact owner

### DIFF
--- a/apps/desktop/src/store/session-states-runtime-map.test.ts
+++ b/apps/desktop/src/store/session-states-runtime-map.test.ts
@@ -7,8 +7,10 @@ import { isSessionOwnerResolutionError } from '@/store/session-owner-resolution'
 import {
   $sessionTiles,
   clearAllSessionStates,
+  dropSessionState,
   knownOwnerForSession,
   publishSessionState,
+  recordSessionEventScope,
   requestForOwnedSession,
   storedSessionIdForRuntimeId
 } from '@/store/session-states'
@@ -125,5 +127,45 @@ describe('knownOwnerForSession / requestForOwnedSession', () => {
       requestForOwnedSession('rt-orphan', ambient as never, 'approval.respond', { session_id: 'rt-orphan' })
     ).resolves.toEqual({ ok: true })
     expect(ambient).toHaveBeenCalledWith('approval.respond', { session_id: 'rt-orphan' })
+  })
+
+  it('routes a connection-tagged orphan runtime through the owner its inbound event recorded (#97511)', () => {
+    // Registry topology, multiple profiles, no tile/hint/row binding for the
+    // runtime — the approval.request event itself proved the exact owner.
+    $profiles.set([{ name: 'default' }, { name: 'omar' }] as never)
+    recordSessionEventScope({ connectionId: 'homelab', profile: 'omar', session_id: 'rt-unbound' })
+
+    expect(knownOwnerForSession('rt-unbound')).toEqual({ connectionId: 'homelab', profile: 'omar' })
+
+    // An event without a profile tag still records the 'default' convention
+    // every other owner source uses.
+    recordSessionEventScope({ connectionId: 'homelab', session_id: 'rt-unprofiled' })
+    expect(knownOwnerForSession('rt-unprofiled')).toEqual({ connectionId: 'homelab', profile: 'default' })
+  })
+
+  it('still prefers the durable stored owner when a stale runtime ledger entry collides with a stored id (#97511)', () => {
+    // Pathological collision: some dead runtime's id equals a live stored id.
+    // The persisted hint (durable identity) must outrank the ledger entry.
+    setSessionOwnerHint('stored-live', { connectionId: 'local', profile: 'omar' })
+    recordSessionEventScope({ connectionId: 'spark', profile: 'default', session_id: 'stored-live' })
+
+    expect(knownOwnerForSession('stored-live')).toEqual({ connectionId: 'local', profile: 'omar' })
+  })
+
+  it('keeps failing closed for untagged or unknown runtimes in multi-profile topology (#97511)', () => {
+    $profiles.set([{ name: 'default' }, { name: 'omar' }] as never)
+    // Untagged events carry no connectionId and record nothing.
+    recordSessionEventScope({ profile: 'omar', session_id: 'rt-untagged' })
+
+    expect(knownOwnerForSession('rt-untagged')).toBeUndefined()
+    expect(knownOwnerForSession('rt-never-seen')).toBeUndefined()
+  })
+
+  it('drops the recorded event owner together with the runtime state (#97511)', () => {
+    recordSessionEventScope({ connectionId: 'homelab', profile: 'omar', session_id: 'rt-dropped' })
+    expect(knownOwnerForSession('rt-dropped')).toEqual({ connectionId: 'homelab', profile: 'omar' })
+
+    dropSessionState('rt-dropped')
+    expect(knownOwnerForSession('rt-dropped')).toBeUndefined()
   })
 })

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -83,9 +83,22 @@ export const $sessionStates = atom<Record<string, ClientSessionState>>({})
 
 const sessionScopeByRuntimeId = new Map<string, string>()
 
+// Structured twin of the scope ledger: the same inbound events also carry the
+// exact (connectionId, profile) owner, which the composite scope string
+// cannot give back. Consumed as the LAST rung of knownOwnerForSession so a
+// runtime whose event source already proved its owner can still route
+// session-scoped RPCs (approval.respond) when every durable binding
+// (tile / hint / row) is absent — while durable stored identity keeps
+// outranking it (#97511).
+const sessionOwnerByRuntimeId = new Map<string, SessionOwnerRoute>()
+
 export function recordSessionEventScope(event: { connectionId?: string; profile?: string; session_id?: string }): void {
   if (event.session_id && event.connectionId) {
     sessionScopeByRuntimeId.set(event.session_id, registryBackendScopeKey(event.connectionId, event.profile))
+    sessionOwnerByRuntimeId.set(event.session_id, {
+      connectionId: event.connectionId,
+      profile: String(event.profile ?? '').trim() || 'default'
+    })
   }
 }
 
@@ -506,6 +519,7 @@ export function dropSessionState(runtimeId: string) {
   clearWatchdog(runtimeId)
   clearSessionProviderWait(runtimeId)
   sessionScopeByRuntimeId.delete(runtimeId)
+  sessionOwnerByRuntimeId.delete(runtimeId)
 
   const current = $sessionStates.get()
   setSessionStalled(current[runtimeId]?.storedSessionId, false)
@@ -532,6 +546,7 @@ export function clearAllSessionStates() {
   settledExpiry.clear()
   clearAllProviderWaits()
   sessionScopeByRuntimeId.clear()
+  sessionOwnerByRuntimeId.clear()
   $stalledSessionIds.set([])
   $sessionStates.set({})
 }
@@ -970,6 +985,13 @@ export function openTileGatewayScopes(): Set<string> {
  * `profile` stamp) was already loaded for the sidebar's cron section. The
  * hint outranks the row for the same reason as contrib/wiring's ladder: a
  * row can be stamped from the ambient profile and carries no connection.
+ * Last rung: the owner recorded from the inbound runtime event itself
+ * (sessionOwnerByRuntimeId, #97511) — an orphan runtime whose tile/hint/row
+ * binding is absent or stale still routes through the exact
+ * (connectionId, profile) its events proved, while every durable rung above
+ * keeps outranking it, so a stored-id collision never inherits a stale
+ * runtime ledger entry. Untagged events record nothing, so unknown owners in
+ * multi-profile topology still fail closed.
  * Returns undefined when no owner is known — the caller fails closed
  * (assertSessionOwnerResolved), never falls to "active".
  */
@@ -983,7 +1005,8 @@ export function knownOwnerForSession(sessionId: null | string | undefined): Sess
   return (
     sessionTileOwnerRoute(storedSessionId) ??
     getSessionOwnerHint(storedSessionId) ??
-    knownSessionOwner(ownerLookupSessionRows(), storedSessionId)
+    knownSessionOwner(ownerLookupSessionRows(), storedSessionId) ??
+    sessionOwnerByRuntimeId.get(sessionId)
   )
 }
 


### PR DESCRIPTION
## What does this PR do?

In registry topology with multiple profiles, a Desktop approval can render normally but every **Run / Allow / Reject** action fails with `SessionOwnerResolutionError`, even when the inbound `approval.request` event carried an exact `(connectionId, profile)` owner.

`recordSessionEventScope(event)` (called at event fan-in in `use-gateway-boot.ts`, before dispatch) already stores the exact registry scope per runtime id — but only as an opaque composite string, and `knownOwnerForSession()` never consults it. When an approval is keyed by a runtime id whose runtime-to-stored binding is absent or stale, the three durable rungs (tile route, owner hint, session row) all miss and `requestForOwnedSession(..., "approval.respond")` throws, even though the event source itself proved the owner.

This adds a structured owner twin of that scope ledger, written and cleared with it, and consumes it as the **last** rung of `knownOwnerForSession`:

- A connection-tagged orphan runtime now routes `approval.respond` through the exact owner its events recorded.
- Durable stored identity still outranks it, so a stored-id collision never inherits a stale runtime ledger entry.
- Untagged events (no `connectionId`) record nothing, so unknown owners in multi-profile topology keep failing closed — this is exact-owner evidence, not an ambient fallback (that sibling case is #96394).

## Related Issue

Fixes #97511

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/store/session-states.ts` — add `sessionOwnerByRuntimeId` (a `Map<string, SessionOwnerRoute>` twin of the scope ledger), written in `recordSessionEventScope`, cleared in `dropSessionState` / `clearAllSessionStates` alongside the scope ledger, and consumed as the final `??` rung of `knownOwnerForSession` (keyed on the original runtime id, after every durable rung).
- `apps/desktop/src/store/session-states-runtime-map.test.ts` — regression tests: orphan runtime routes through its recorded owner; stored-id collision still prefers the durable hint; untagged/unknown runtimes keep failing closed in multi-profile topology; the ledger entry drops with the runtime state.

## How to Test

1. `cd apps/desktop && npx vitest run src/store/session-states-runtime-map.test.ts` — 12 tests pass, including the four new `#97511` cases.
2. `cd apps/desktop && npx vitest run src/store/session-states.test.ts src/store/session-states-scopes.test.ts src/store/session-states-foreground-scopes.test.ts src/store/session-states-reconnect.test.ts src/store/session-owner-resolution.test.ts src/store/gateway-connection-scope.test.ts` — 105 tests pass (observed result: no regressions in the scope/owner consumers).
3. `cd apps/desktop && npx tsc -p . --noEmit` and `npx eslint src/store/session-states.ts src/store/session-states-runtime-map.test.ts` — both clean.

Manual scenario covered by the new unit tests (per the issue): with two profiles connected, `recordSessionEventScope({ connectionId: 'homelab', profile: 'omar', session_id: 'rt-unbound' })` then `knownOwnerForSession('rt-unbound')` now resolves to `{ connectionId: 'homelab', profile: 'omar' }` instead of `undefined` (which previously made `requestForOwnedSession` throw for `approval.respond`).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — N/A: Desktop TS change; ran the full desktop store vitest suite instead
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstring of `knownOwnerForSession` extended to document the new rung
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A: renderer-side store logic, platform-neutral
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Not applicable — unit-level change; test output in "How to Test".
