### PR TITLE
fix(kanban): terminalize dispatcher workers when context recovery exhausts after stop nudge

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1513,6 +1513,22 @@ def _compression_deferred_result(
     }
 
 
+def _record_kanban_context_recovery_exhausted(agent, messages) -> None:
+    """Best-effort terminal fallback for a Kanban stop continuation."""
+    try:
+        from agent.kanban_stop import record_context_recovery_exhausted
+
+        record_context_recovery_exhausted(
+            messages=messages,
+            attempts=getattr(agent, "_kanban_stop_nudges", 0),
+        )
+    except Exception:
+        logger.debug(
+            "kanban context-recovery terminalization failed",
+            exc_info=True,
+        )
+
+
 def _rewrite_system_content_blocks(system_message: dict, effective: str) -> bool:
     """Rewrite a cache-decorated system message in place, keeping its blocks.
 
@@ -1884,6 +1900,10 @@ def run_conversation(
     agent._last_compaction_in_place = False
     agent._last_compression_attempt_recorded = False
     agent._last_compression_attempt_in_place = None
+    # The gateway and goal loop reuse an agent across user turns.  A terminal
+    # nudge authorizes fallback only for the turn that issued it; carrying the
+    # count forward could let an unrelated later overflow block the Kanban run.
+    agent._kanban_stop_nudges = 0
 
     # Adopt any ~/.hermes/.env credential/base-url edits made since the last
     # turn — a Settings save updates .env but not this worker's client, which
@@ -5356,6 +5376,7 @@ def run_conversation(
                         f"{agent.log_prefix}Context overflow ({classified.reason.value}) with "
                         f"auto-compaction disabled — not compressing."
                     )
+                    _record_kanban_context_recovery_exhausted(agent, messages)
                     agent._persist_session(messages, conversation_history)
                     _final_response = (
                         "Context overflow and auto-compaction is disabled "
@@ -5678,6 +5699,7 @@ def run_conversation(
                         agent._vprint(f"{agent.log_prefix}❌ Max compression attempts ({max_compression_attempts}) reached for payload-too-large error.", force=True)
                         agent._vprint(f"{agent.log_prefix}   💡 Try /new to start a fresh conversation, or /compress to retry compression.", force=True)
                         logger.error("%s413 compression failed after %d attempts.", agent.log_prefix, max_compression_attempts)
+                        _record_kanban_context_recovery_exhausted(agent, messages)
                         agent._persist_session(messages, conversation_history)
                         _final_response = f"Request payload too large: max compression attempts ({max_compression_attempts}) reached."
                         return {
@@ -5774,6 +5796,7 @@ def run_conversation(
                         agent._vprint(f"{agent.log_prefix}❌ Payload too large and cannot compress further.", force=True)
                         agent._vprint(f"{agent.log_prefix}   💡 Try /new to start a fresh conversation, or /compress to retry compression.", force=True)
                         logger.error("%s413 payload too large. Cannot compress further.", agent.log_prefix)
+                        _record_kanban_context_recovery_exhausted(agent, messages)
                         agent._persist_session(messages, conversation_history)
                         _final_response = "Request payload too large (413). Cannot compress further."
                         return {
@@ -6006,6 +6029,7 @@ def run_conversation(
                         agent._vprint(f"{agent.log_prefix}❌ Max compression attempts ({max_compression_attempts}) reached.", force=True)
                         agent._vprint(f"{agent.log_prefix}   💡 Try /new to start a fresh conversation, or /compress to retry compression.", force=True)
                         logger.error("%sContext compression failed after %d attempts.", agent.log_prefix, max_compression_attempts)
+                        _record_kanban_context_recovery_exhausted(agent, messages)
                         agent._persist_session(messages, conversation_history)
                         _final_response = f"Context length exceeded: max compression attempts ({max_compression_attempts}) reached."
                         return {
@@ -6069,6 +6093,7 @@ def run_conversation(
                         agent._vprint(f"{agent.log_prefix}❌ Context length exceeded and cannot compress further.", force=True)
                         agent._vprint(f"{agent.log_prefix}   💡 The conversation has accumulated too much content. Try /new to start fresh, or /compress to manually trigger compression.", force=True)
                         logger.error("%sContext length exceeded: %s tokens. Cannot compress further.", agent.log_prefix, f"{new_tokens:,}")
+                        _record_kanban_context_recovery_exhausted(agent, messages)
                         agent._persist_session(messages, conversation_history)
                         _final_response = f"Context length exceeded ({new_tokens:,} tokens). Cannot compress further."
                         return {

--- a/agent/kanban_stop.py
+++ b/agent/kanban_stop.py
@@ -13,6 +13,7 @@ loop continues instead of exiting.
 
 from __future__ import annotations
 
+import logging
 import os
 from typing import Any, Iterable, Optional
 
@@ -20,6 +21,8 @@ from typing import Any, Iterable, Optional
 _TERMINAL_KANBAN_TOOLS = frozenset({"kanban_complete", "kanban_block"})
 
 _DEFAULT_MAX_ATTEMPTS = 2
+
+logger = logging.getLogger(__name__)
 
 
 def kanban_stop_nudge_enabled() -> bool:
@@ -101,8 +104,81 @@ def build_kanban_stop_nudge(
     )
 
 
+def record_context_recovery_exhausted(
+    *,
+    messages: Iterable[dict] | None = None,
+    attempts: int = 0,
+) -> bool:
+    """Run-fenced diagnostic block after a stop continuation exhausts context.
+
+    This fallback never infers completion from assistant prose. It only prevents
+    a dispatcher-owned worker run from disappearing as an opaque dead PID after
+    the runtime already issued a terminal-tool continuation. A valid run id is
+    mandatory so a reclaimed worker cannot mutate its successor.
+    """
+    from agent.delegation_context import is_dispatcher_owned_worker_context
+
+    if (
+        attempts <= 0
+        or not is_dispatcher_owned_worker_context()
+        or not kanban_stop_nudge_enabled()
+    ):
+        return False
+    task_id = (os.environ.get("HERMES_KANBAN_TASK") or "").strip()
+    raw_run_id = (os.environ.get("HERMES_KANBAN_RUN_ID") or "").strip()
+    if not task_id or not raw_run_id:
+        return False
+    try:
+        run_id = int(raw_run_id)
+    except ValueError:
+        logger.warning("invalid HERMES_KANBAN_RUN_ID=%r", raw_run_id)
+        return False
+
+    session_id = (os.environ.get("HERMES_SESSION_ID") or "").strip() or "unavailable"
+    workspace = (os.environ.get("HERMES_KANBAN_WORKSPACE") or "").strip() or "unavailable"
+    reason = (
+        "Runtime diagnostic: the Kanban terminal-tool continuation exhausted "
+        "context overflow recovery before an explicit kanban_complete or "
+        "kanban_block call could be committed. No completion was inferred from "
+        "assistant prose. "
+        f"Evidence handles: task={task_id}; run={run_id}; session={session_id}; "
+        f"workspace={workspace}. "
+        "Clearing gate: inspect the preserved task workspace/session evidence, "
+        "resume or re-run with enough context for the terminal turn, and commit "
+        "an explicit kanban_complete or kanban_block transition."
+    )
+
+    try:
+        from agent.redact import redact_sensitive_text
+        from hermes_cli import kanban_db as kb
+
+        conn = kb.connect()
+        try:
+            return kb.block_task(
+                conn,
+                task_id,
+                reason=redact_sensitive_text(reason, force=True),
+                # Goal-mode workers already permit needs_input as a genuine
+                # external stop. Use the same lifecycle ownership instead of
+                # creating a runtime-only escape around the completion judge.
+                kind="needs_input",
+                expected_run_id=run_id,
+            )
+        finally:
+            conn.close()
+    except Exception:
+        logger.warning(
+            "Failed to record context-recovery diagnostic block for task %s run %s",
+            task_id,
+            run_id,
+            exc_info=True,
+        )
+        return False
+
+
 __all__ = [
     "build_kanban_stop_nudge",
     "kanban_stop_nudge_enabled",
+    "record_context_recovery_exhausted",
     "session_called_kanban_terminal",
 ]

--- a/tests/agent/test_kanban_stop.py
+++ b/tests/agent/test_kanban_stop.py
@@ -7,13 +7,21 @@ import pytest
 from agent.kanban_stop import (
     build_kanban_stop_nudge,
     kanban_stop_nudge_enabled,
+    record_context_recovery_exhausted,
     session_called_kanban_terminal,
 )
 
 
 @pytest.fixture
 def clear_kanban_env(monkeypatch):
-    for var in ("HERMES_KANBAN_TASK", "HERMES_KANBAN_STOP_NUDGE"):
+    for var in (
+        "HERMES_KANBAN_DB",
+        "HERMES_KANBAN_RUN_ID",
+        "HERMES_KANBAN_STOP_NUDGE",
+        "HERMES_KANBAN_TASK",
+        "HERMES_KANBAN_WORKSPACE",
+        "HERMES_SESSION_ID",
+    ):
         monkeypatch.delenv(var, raising=False)
     return monkeypatch
 
@@ -72,6 +80,211 @@ def test_no_nudge_after_kanban_complete(clear_kanban_env):
     ]
     assert session_called_kanban_terminal(messages) is True
     assert build_kanban_stop_nudge(messages=messages) is None
+
+
+def test_recovery_fallback_is_kanban_only(clear_kanban_env):
+    assert record_context_recovery_exhausted(messages=[], attempts=1) is False
+
+
+def test_recovery_fallback_rejects_non_dispatcher_context(clear_kanban_env):
+    from agent.delegation_context import non_dispatcher_owned_context
+
+    clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_abc")
+    clear_kanban_env.setenv("HERMES_KANBAN_RUN_ID", "1")
+    with non_dispatcher_owned_context():
+        assert record_context_recovery_exhausted(
+            messages=[],
+            attempts=1,
+        ) is False
+
+
+def _claimed_task(tmp_path, *, goal_mode=False):
+    from hermes_cli import kanban_db as kb
+
+    db_path = tmp_path / "kanban.db"
+    conn = kb.connect(db_path=db_path)
+    task_id = kb.create_task(
+        conn,
+        title="terminal recovery",
+        assignee="worker",
+        goal_mode=goal_mode,
+    )
+    claimed = kb.claim_task(conn, task_id, claimer="worker:fixture")
+    assert claimed is not None
+    run_id = claimed.current_run_id
+    conn.close()
+    return kb, db_path, task_id, run_id
+
+
+@pytest.mark.parametrize("terminal_tool", ["kanban_complete", "kanban_block"])
+def test_recovery_fallback_ignores_committed_terminal_state(
+    clear_kanban_env, tmp_path, terminal_tool,
+):
+    kb, db_path, task_id, run_id = _claimed_task(tmp_path)
+    conn = kb.connect(db_path=db_path)
+    try:
+        if terminal_tool == "kanban_complete":
+            assert kb.complete_task(
+                conn,
+                task_id,
+                result="done",
+                expected_run_id=run_id,
+            )
+            expected_status = "done"
+            expected_outcome = "completed"
+        else:
+            assert kb.block_task(
+                conn,
+                task_id,
+                reason="explicit block",
+                expected_run_id=run_id,
+            )
+            expected_status = "blocked"
+            expected_outcome = "blocked"
+    finally:
+        conn.close()
+
+    clear_kanban_env.setenv("HERMES_KANBAN_DB", str(db_path))
+    clear_kanban_env.setenv("HERMES_KANBAN_TASK", task_id)
+    clear_kanban_env.setenv("HERMES_KANBAN_RUN_ID", str(run_id))
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "1",
+                    "type": "function",
+                    "function": {"name": terminal_tool, "arguments": "{}"},
+                }
+            ],
+        }
+    ]
+
+    assert record_context_recovery_exhausted(
+        messages=messages,
+        attempts=1,
+    ) is False
+
+    conn = kb.connect(db_path=db_path)
+    try:
+        assert kb.get_task(conn, task_id).status == expected_status
+        assert kb.latest_run(conn, task_id).outcome == expected_outcome
+    finally:
+        conn.close()
+
+
+def test_recovery_fallback_blocks_after_rejected_terminal_tool_call(
+    clear_kanban_env, tmp_path,
+):
+    kb, db_path, task_id, run_id = _claimed_task(tmp_path)
+    clear_kanban_env.setenv("HERMES_KANBAN_DB", str(db_path))
+    clear_kanban_env.setenv("HERMES_KANBAN_TASK", task_id)
+    clear_kanban_env.setenv("HERMES_KANBAN_RUN_ID", str(run_id))
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "1",
+                    "type": "function",
+                    "function": {"name": "kanban_complete", "arguments": "{}"},
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "name": "kanban_complete",
+            "tool_call_id": "1",
+            "content": "completion rejected; task remains in-flight",
+        },
+    ]
+
+    assert session_called_kanban_terminal(messages) is True
+    assert record_context_recovery_exhausted(
+        messages=messages,
+        attempts=1,
+    ) is True
+
+    conn = kb.connect(db_path=db_path)
+    try:
+        assert kb.get_task(conn, task_id).status == "blocked"
+        assert kb.latest_run(conn, task_id).outcome == "blocked"
+    finally:
+        conn.close()
+
+
+@pytest.mark.parametrize("goal_mode", [False, True])
+def test_recovery_fallback_records_run_fenced_diagnostic_block(
+    clear_kanban_env, tmp_path, goal_mode,
+):
+    kb, db_path, task_id, run_id = _claimed_task(
+        tmp_path,
+        goal_mode=goal_mode,
+    )
+    clear_kanban_env.setenv("HERMES_KANBAN_DB", str(db_path))
+    clear_kanban_env.setenv("HERMES_KANBAN_TASK", task_id)
+    clear_kanban_env.setenv("HERMES_KANBAN_RUN_ID", str(run_id))
+    clear_kanban_env.setenv("HERMES_SESSION_ID", "session-fixture")
+    clear_kanban_env.setenv("HERMES_KANBAN_WORKSPACE", str(tmp_path))
+
+    assert record_context_recovery_exhausted(
+        messages=[{"role": "assistant", "content": "work is done"}],
+        attempts=1,
+    ) is True
+
+    conn = kb.connect(db_path=db_path)
+    try:
+        task = kb.get_task(conn, task_id)
+        run = kb.latest_run(conn, task_id)
+        assert task.status == "blocked"
+        assert run.id == run_id
+        assert run.outcome == "blocked"
+        assert "context overflow" in (run.summary or "").lower()
+        assert "clearing gate" in (run.summary or "").lower()
+        assert not any(event.kind == "completed" for event in kb.list_events(conn, task_id))
+    finally:
+        conn.close()
+
+
+def test_recovery_fallback_cannot_mutate_successor_run(
+    clear_kanban_env, tmp_path,
+):
+    kb, db_path, task_id, stale_run_id = _claimed_task(tmp_path)
+    conn = kb.connect(db_path=db_path)
+    try:
+        assert kb.block_task(
+            conn,
+            task_id,
+            reason="first run ended",
+            expected_run_id=stale_run_id,
+        )
+        assert kb.unblock_task(conn, task_id)
+        successor = kb.claim_task(conn, task_id, claimer="worker:successor")
+        assert successor is not None
+        assert successor.current_run_id != stale_run_id
+    finally:
+        conn.close()
+
+    clear_kanban_env.setenv("HERMES_KANBAN_DB", str(db_path))
+    clear_kanban_env.setenv("HERMES_KANBAN_TASK", task_id)
+    clear_kanban_env.setenv("HERMES_KANBAN_RUN_ID", str(stale_run_id))
+
+    assert record_context_recovery_exhausted(
+        messages=[{"role": "assistant", "content": "stale run"}],
+        attempts=1,
+    ) is False
+
+    conn = kb.connect(db_path=db_path)
+    try:
+        task = kb.get_task(conn, task_id)
+        run = kb.latest_run(conn, task_id)
+        assert task.status == "running"
+        assert run.id == successor.current_run_id
+        assert run.outcome is None
+    finally:
+        conn.close()
 
 
 

--- a/tests/run_agent/test_413_compression.py
+++ b/tests/run_agent/test_413_compression.py
@@ -1170,6 +1170,266 @@ class TestToolResultPreflightCompression:
         assert result["completed"] is True
 
 
+def test_kanban_stop_nudge_context_overflow_records_diagnostic_block(
+    agent, monkeypatch, tmp_path,
+):
+    """A finished worker must not vanish when its stop continuation overflows."""
+    from hermes_cli import kanban_db as kb
+
+    db_path = tmp_path / "kanban.db"
+    conn = kb.connect(db_path=db_path)
+    try:
+        task_id = kb.create_task(
+            conn,
+            title="preserve terminal state",
+            assignee="worker",
+        )
+        claimed = kb.claim_task(conn, task_id, claimer="worker:fixture")
+        assert claimed is not None
+        run_id = claimed.current_run_id
+    finally:
+        conn.close()
+
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    monkeypatch.setenv("HERMES_KANBAN_TASK", task_id)
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(run_id))
+    monkeypatch.delenv("HERMES_KANBAN_STOP_NUDGE", raising=False)
+
+    tool_calls = [
+        {
+            "id": f"call-{index}",
+            "type": "function",
+            "function": {"name": "web_search", "arguments": "{}"},
+        }
+        for index in range(200)
+    ]
+    history = [
+        {"role": "user", "content": "do the substantive work"},
+        {"role": "assistant", "content": "", "tool_calls": tool_calls},
+        *[
+            {
+                "role": "tool",
+                "name": "web_search",
+                "tool_call_id": f"call-{index}",
+                "content": "evidence saved",
+            }
+            for index in range(200)
+        ],
+    ]
+    assert len(history) == 202
+
+    stop = _mock_response(
+        content="Review finished; durable evidence is in the task workspace.",
+        finish_reason="stop",
+    )
+    overflow = Exception("Your input exceeds the context window of this model")
+    overflow.status_code = 400
+    agent.client.chat.completions.create.side_effect = [stop, overflow, overflow]
+    agent.max_compression_attempts = 1
+    original_context_length = agent.context_compressor.context_length
+
+    def _compress_preserving_guard(messages, *_args, **_kwargs):
+        return list(messages[-6:]), "compressed prompt"
+
+    with (
+        patch.object(agent, "_compress_context", side_effect=_compress_preserving_guard),
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation(
+            "finish and terminalize the task",
+            conversation_history=history,
+        )
+
+    assert result["failed"] is True
+    assert result["compression_exhausted"] is True
+    assert agent.context_compressor.context_length == original_context_length
+
+    conn = kb.connect(db_path=db_path)
+    try:
+        task = kb.get_task(conn, task_id)
+        run = kb.latest_run(conn, task_id)
+        assert task.status == "blocked"
+        assert run.id == run_id
+        assert run.outcome == "blocked"
+        assert "context overflow" in (run.summary or "").lower()
+        assert "clearing gate" in (run.summary or "").lower()
+        assert not any(
+            event.kind == "completed" for event in kb.list_events(conn, task_id)
+        )
+    finally:
+        conn.close()
+
+
+def test_kanban_stop_nudge_overflow_with_compaction_disabled_still_blocks(
+    agent, monkeypatch, tmp_path,
+):
+    """Every terminal generic-overflow return honors the Kanban fallback."""
+    from hermes_cli import kanban_db as kb
+
+    db_path = tmp_path / "kanban.db"
+    conn = kb.connect(db_path=db_path)
+    try:
+        task_id = kb.create_task(conn, title="disabled compaction", assignee="worker")
+        claimed = kb.claim_task(conn, task_id, claimer="worker:fixture")
+        assert claimed is not None
+        run_id = claimed.current_run_id
+    finally:
+        conn.close()
+
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    monkeypatch.setenv("HERMES_KANBAN_TASK", task_id)
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(run_id))
+    agent.compression_enabled = False
+    stop = _mock_response(content="work finished", finish_reason="stop")
+    overflow = Exception("Your input exceeds the context window of this model")
+    overflow.status_code = 400
+    agent.client.chat.completions.create.side_effect = [stop, overflow]
+
+    with (
+        patch.object(agent, "_compress_context") as compress,
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("finish and terminalize")
+
+    assert result["compaction_disabled"] is True
+    compress.assert_not_called()
+    conn = kb.connect(db_path=db_path)
+    try:
+        assert kb.get_task(conn, task_id).status == "blocked"
+        assert kb.latest_run(conn, task_id).outcome == "blocked"
+    finally:
+        conn.close()
+
+
+def _claimed_kanban_task_for_overflow(monkeypatch, tmp_path):
+    from hermes_cli import kanban_db as kb
+
+    db_path = tmp_path / "kanban.db"
+    conn = kb.connect(db_path=db_path)
+    try:
+        task_id = kb.create_task(conn, title="payload recovery", assignee="worker")
+        claimed = kb.claim_task(conn, task_id, claimer="worker:fixture")
+        assert claimed is not None
+        run_id = claimed.current_run_id
+    finally:
+        conn.close()
+
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    monkeypatch.setenv("HERMES_KANBAN_TASK", task_id)
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(run_id))
+    monkeypatch.delenv("HERMES_KANBAN_STOP_NUDGE", raising=False)
+    return kb, db_path, task_id, run_id
+
+
+def test_kanban_stop_nudge_count_resets_before_unrelated_new_turn_overflow(
+    agent, monkeypatch, tmp_path,
+):
+    """A cached worker cannot reuse a prior turn's terminal-nudge authority."""
+    kb, db_path, task_id, run_id = _claimed_kanban_task_for_overflow(
+        monkeypatch, tmp_path,
+    )
+    agent._kanban_stop_nudges = 2
+    agent.compression_enabled = False
+    overflow = Exception("Your input exceeds the context window of this model")
+    overflow.status_code = 400
+    agent.client.chat.completions.create.side_effect = [overflow]
+
+    with (
+        patch.object(agent, "_compress_context") as compress,
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("new unrelated turn")
+
+    assert result["compaction_disabled"] is True
+    assert agent._kanban_stop_nudges == 0
+    compress.assert_not_called()
+    conn = kb.connect(db_path=db_path)
+    try:
+        task = kb.get_task(conn, task_id)
+        run = kb.latest_run(conn, task_id)
+        assert task.status == "running"
+        assert run.id == run_id
+        assert run.outcome is None
+    finally:
+        conn.close()
+
+
+def test_kanban_stop_nudge_413_attempt_exhaustion_records_diagnostic_block(
+    agent, monkeypatch, tmp_path,
+):
+    """A post-nudge 413 retry ceiling must terminalize the owned run."""
+    kb, db_path, task_id, run_id = _claimed_kanban_task_for_overflow(
+        monkeypatch, tmp_path,
+    )
+    stop = _mock_response(content="work finished", finish_reason="stop")
+    payload_error = _make_413_error()
+    agent.client.chat.completions.create.side_effect = [
+        stop,
+        payload_error,
+        payload_error,
+    ]
+    agent.max_compression_attempts = 1
+
+    def _reduce(messages, *_args, **_kwargs):
+        return list(messages[-2:]), "compressed prompt"
+
+    with (
+        patch.object(agent, "_compress_context", side_effect=_reduce),
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("finish and terminalize")
+
+    assert result["compression_exhausted"] is True
+    conn = kb.connect(db_path=db_path)
+    try:
+        assert kb.get_task(conn, task_id).status == "blocked"
+        run = kb.latest_run(conn, task_id)
+        assert run.id == run_id
+        assert run.outcome == "blocked"
+    finally:
+        conn.close()
+
+
+def test_kanban_stop_nudge_irreducible_413_records_diagnostic_block(
+    agent, monkeypatch, tmp_path,
+):
+    """An irreducible post-nudge 413 must not strand the owned run."""
+    kb, db_path, task_id, run_id = _claimed_kanban_task_for_overflow(
+        monkeypatch, tmp_path,
+    )
+    stop = _mock_response(content="work finished", finish_reason="stop")
+    agent.client.chat.completions.create.side_effect = [stop, _make_413_error()]
+
+    def _no_reduction(messages, *_args, **_kwargs):
+        return list(messages), "compressed prompt"
+
+    with (
+        patch.object(agent, "_compress_context", side_effect=_no_reduction),
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("finish and terminalize")
+
+    assert result["compression_exhausted"] is True
+    conn = kb.connect(db_path=db_path)
+    try:
+        assert kb.get_task(conn, task_id).status == "blocked"
+        run = kb.latest_run(conn, task_id)
+        assert run.id == run_id
+        assert run.outcome == "blocked"
+    finally:
+        conn.close()
+
+
 # ---------------------------------------------------------------------------
 # Disabled auto-compaction on overflow (port of anomalyco/opencode#30749)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

A dispatcher-owned Kanban worker can finish substantive work, receive the bounded terminal-tool stop nudge, and then exhaust context recovery on the continuation. Every recovery path returns without touching the board, so the run closes with a generic dead-PID crash and the card stays `running` — discarding the worker's real outcome and forcing manual evidence reconstruction.

This is the class tracked in #42289 (post-verdict / pre-finalization `pid not alive` state drift). Reproduced deterministically: on unmodified upstream, a 202-message / 200-tool-call session that receives the stop nudge then hits a generic context overflow exits with no terminal event and the task left `running`.

## Fix

When all of the following hold — dispatcher-owned Kanban worker context, a same-turn bounded stop nudge was issued, and context recovery is exhausted (generic overflow, disabled compaction, or either terminal 413 branch) — record a **diagnostic block** instead of letting the run die:

- Atomic run fencing: `kb.block_task(expected_run_id=run_id)` decides; a stale worker can never mutate a successor run, and already-committed terminal states are non-blockable.
- Never infers completion from prose; the durable reason says so explicitly and preserves non-secret task/run/session/workspace handles plus a clearing gate, force-redacted via `redact_sensitive_text(..., force=True)`.
- Durable DB outcome — not syntactic tool-call presence — gates eligibility: a rejected `kanban_complete`/`kanban_block` call still falls back to the diagnostic block.
- `_kanban_stop_nudges` resets in the `run_conversation` prologue so cached/gateway agents cannot inherit nudge authority for an unrelated later turn.
- Goal mode keeps the established `needs_input` block lifecycle; delegate children, cron, and normal chat are isolated via the canonical dispatcher-ownership predicate.
- The new byte-based 413 progress contract (`serialized_messages_bytes`) is untouched; the fallback hooks the existing terminal returns.

## Verification

- RED: 202-message/200-tool-call integration test fails on unmodified upstream (defect reproduced).
- GREEN with patch: focused terminalization 13 passed; new 413 regressions 2 passed; byte-413 suite 11 passed; per-turn reset regression 1 passed; lifecycle matrix 239 passed / 1 skipped (one pre-existing clean-baseline failure deselected); compileall + ruff + `git diff --check` pass.
- Independent spec-compliance review: PASS. Independent code-quality/runtime-safety review: APPROVED (no findings). Three earlier review findings (rejected-terminal-call suppression, uncovered 413 exits, cross-turn nudge authority leak) were each fixed with dedicated regressions before final approval.

## Scope

4 files: `agent/kanban_stop.py`, `agent/conversation_loop.py`, `tests/agent/test_kanban_stop.py`, `tests/run_agent/test_413_compression.py`. +575/−1. No behavior change outside the dispatcher-owned Kanban stop/overflow boundary.

Closes #42289