### PR TITLE
feat(tools): surface display_metadata in session_search output

### DIFF
--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -22,6 +22,7 @@ from tools.session_search_tool import (
     _is_compression_ended,
     _resolve_to_parent,
     _session_link,
+    _shape_message,
     session_search,
 )
 
@@ -1143,4 +1144,77 @@ class TestNewResetLineageBrowse:
         result = json.loads(session_search(db=db, current_session_id="s_other"))
         sids = [r["session_id"] for r in result["results"]]
         assert "s_legacy_child" in sids
+
+
+# =========================================================================
+# display_metadata emit — read-path for per-message attribution
+# =========================================================================
+
+class TestDisplayMetadataEmit:
+    """`_shape_message` must surface stored per-message attribution.
+
+    The persist path (agent/turn_context.py) writes ``display_metadata`` onto
+    every user message when pre_llm_call metadata is available. Without the
+    emit below, session_search returns the words but not who/where — the
+    attribution blindness post-compaction. Complements PR #96081 (write path).
+    """
+
+    def test_emits_dict_metadata_when_present(self):
+        meta = {
+            "platform": "telegram",
+            "chat_id": "-1001234567890",
+            "chat_type": "group",
+            "user_id": "555000111",
+            "user_name": "synthetic_user",
+            "chat_name": "Synthetic Room",
+            "origin": "text",
+        }
+        shaped = _shape_message(
+            {"id": 1, "role": "user", "content": "hello", "display_metadata": meta}
+        )
+        assert shaped["display_metadata"] == meta
+        # Core shape unchanged
+        assert shaped["id"] == 1
+        assert shaped["role"] == "user"
+        assert shaped["content"] == "hello"
+
+    def test_emits_str_metadata_when_present(self):
+        # Stored form can be a JSON string (e.g. sqlite TEXT column).
+        meta = '{"platform": "discord", "chat_id": "111222", "origin": "voice"}'
+        shaped = _shape_message(
+            {"id": 2, "role": "user", "content": "hi", "display_metadata": meta}
+        )
+        assert shaped["display_metadata"] == meta
+
+    def test_omits_metadata_when_absent(self):
+        shaped = _shape_message({"id": 3, "role": "assistant", "content": "reply"})
+        assert "display_metadata" not in shaped
+
+    def test_search_round_trips_metadata_in_result(self, db):
+        db.create_session("s_meta", source="telegram")
+        meta = {
+            "platform": "telegram",
+            "chat_id": "-100999888777",
+            "chat_type": "group",
+            "user_id": "777666555",
+            "user_name": "synthetic_user",
+            "chat_name": "Synthetic Room",
+            "origin": "text",
+        }
+        db.append_message(
+            "s_meta", role="user", content="attributed needle",
+            display_metadata=meta,
+        )
+        db._conn.commit()
+        result = json.loads(session_search(query="attributed", db=db, limit=1))
+        assert result["success"] is True
+        assert result["results"]
+        hit = result["results"][0]
+        # Discovery wraps messages in bookend/messages; find the attributed one.
+        found = False
+        for m in hit.get("messages", []):
+            if m.get("content") == "attributed needle":
+                assert m.get("display_metadata") == meta
+                found = True
+        assert found, "attributed message not present in discovery output"
 

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -327,6 +327,12 @@ def _shape_message(
         "content": content,
         "timestamp": m.get("timestamp"),
     }
+    # Surface per-message attribution when present. Written by the persist path
+    # (agent/turn_context.py) for every user message; without this, session_search
+    # returns the words but not who/where — recreating the attribution blindness
+    # post-compaction. Always a dict in practice; tolerate str (stored JSON) too.
+    if m.get("display_metadata"):
+        entry["display_metadata"] = m["display_metadata"]
     if m.get("tool_name"):
         entry["tool_name"] = m.get("tool_name")
     if m.get("tool_calls"):


### PR DESCRIPTION
## Summary
`_shape_message()` in `tools/session_search_tool.py` trims every message row to `id/role/content/timestamp`, dropping the `display_metadata` column that the persist path (`agent/turn_context.py`) writes for every user message. Post-compaction, `session_search` therefore returns the **words** but not **who/where** — recreating the attribution blindness this project set out to fix.

This PR is the **read-path** counterpart to the write-path PR #96081: it emits `display_metadata` back into the tool output when present.

- Emit `display_metadata` (dict, or stored-JSON-string form from a TEXT column).
- No behavior change for rows without it; prompt-cache surface untouched (outgoing copies already strip `display_metadata`).
- 4 new test cases (`TestDisplayMetadataEmit`): dict emit, str emit, absence omission, full discovery round-trip through `SessionDB`.

## Why
Verified end-to-end locally: a real attributed row previously returned no attribution in `session_search`; after this change it returns `platform/chat_id/chat_type/user_id/user_name/chat_name/origin`. Without it, post-compaction session reconstruction finds the message but not its room — the exact gap #96081's write-path enables but does not itself close.

## Scope / lifecycle note
This is a focused fix. Our deployment currently carries the same 2-line emit as a fleet startup patcher (local band-aid); once #96081 + this PR merge, that patcher retires — same stopgap-then-upstream pattern as our other local patches. PII: no real identifiers in code or tests (synthetic fixtures only).

## Test plan
- [x] `pytest tests/tools/test_session_search.py::TestDisplayMetadataEmit` — 4 passed
- [x] Manual: `session_search` on an attributed row now includes `display_metadata`